### PR TITLE
`persistNetworkIdentity` cli option

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -1,9 +1,5 @@
-import fs from "node:fs";
 import path from "node:path";
-import {PeerId} from "@libp2p/interface-peer-id";
 import {Registry} from "prom-client";
-import {createSecp256k1PeerId} from "@libp2p/peer-id-factory";
-import {createKeypairFromPeerId, SignableENR} from "@chainsafe/discv5";
 import {ErrorAborted, Logger} from "@lodestar/utils";
 import {LevelDbController} from "@lodestar/db";
 import {BeaconNode, BeaconDb} from "@lodestar/beacon-node";
@@ -12,14 +8,14 @@ import {ACTIVE_PRESET, PresetName} from "@lodestar/params";
 import {ProcessShutdownCallback} from "@lodestar/validator";
 
 import {GlobalArgs, parseBeaconNodeArgs} from "../../options/index.js";
-import {BeaconNodeOptions, exportToJSON, getBeaconConfigFromArgs, readPeerId} from "../../config/index.js";
+import {BeaconNodeOptions, getBeaconConfigFromArgs} from "../../config/index.js";
 import {getNetworkBootnodes, getNetworkData, isKnownNetworkName, readBootnodes} from "../../networks/index.js";
 import {onGracefulShutdown, getCliLogger, mkdir, writeFile600Perm, cleanOldLogFiles} from "../../util/index.js";
 import {getVersionData} from "../../util/version.js";
-import {defaultP2pPort} from "../../options/beaconNodeOptions/network.js";
 import {BeaconArgs} from "./options.js";
 import {getBeaconPaths} from "./paths.js";
 import {initBeaconState} from "./initBeaconState.js";
+import {initPeerIdAndEnr} from "./initPeerIdAndEnr.js";
 
 /**
  * Runs a beacon node.
@@ -149,80 +145,6 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
   const options = beaconNodeOptions.getWithDefaults();
 
   return {config, options, beaconPaths, network, version, commit, peerId, logger};
-}
-
-export function overwriteEnrWithCliArgs(enr: SignableENR, args: BeaconArgs): void {
-  // TODO: Not sure if we should propagate port/defaultP2pPort options to the ENR
-  enr.tcp = args["enr.tcp"] ?? args.port ?? defaultP2pPort;
-  const udpPort = args["enr.udp"] ?? args.discoveryPort ?? args.port ?? defaultP2pPort;
-  if (udpPort != null) enr.udp = udpPort;
-  if (args["enr.ip"] != null) enr.ip = args["enr.ip"];
-  if (args["enr.ip6"] != null) enr.ip6 = args["enr.ip6"];
-  if (args["enr.tcp6"] != null) enr.tcp6 = args["enr.tcp6"];
-  if (args["enr.udp6"] != null) enr.udp6 = args["enr.udp6"];
-}
-
-/**
- * Create new PeerId and ENR by default, unless persistNetworkIdentity is provided
- */
-export async function initPeerIdAndEnr(
-  args: BeaconArgs,
-  beaconDir: string,
-  logger: Logger
-): Promise<{peerId: PeerId; enr: SignableENR}> {
-  const {persistNetworkIdentity} = args;
-
-  const newPeerIdAndENR = async (): Promise<{peerId: PeerId; enr: SignableENR}> => {
-    const peerId = await createSecp256k1PeerId();
-    const enr = SignableENR.createV4(createKeypairFromPeerId(peerId));
-    return {peerId, enr};
-  };
-
-  const readPersistedPeerIdAndENR = async (
-    peerIdFile: string,
-    enrFile: string
-  ): Promise<{peerId: PeerId; enr: SignableENR}> => {
-    let peerId: PeerId;
-    let enr: SignableENR;
-
-    // attempt to read stored peer id
-    try {
-      peerId = await readPeerId(peerIdFile);
-    } catch (e) {
-      logger.warn("Unable to read peerIdFile, creating a new peer id");
-      return newPeerIdAndENR();
-    }
-    // attempt to read stored enr
-    try {
-      enr = SignableENR.decodeTxt(fs.readFileSync(enrFile, "utf-8"), createKeypairFromPeerId(peerId));
-    } catch (e) {
-      logger.warn("Unable to decode stored local ENR, creating a new ENR");
-      enr = SignableENR.createV4(createKeypairFromPeerId(peerId));
-      return {peerId, enr};
-    }
-    // check stored peer id against stored enr
-    if (!peerId.equals(await enr.peerId())) {
-      logger.warn("Stored local ENR doesn't match peerIdFile, creating a new ENR");
-      enr = SignableENR.createV4(createKeypairFromPeerId(peerId));
-      return {peerId, enr};
-    }
-    return {peerId, enr};
-  };
-
-  if (persistNetworkIdentity) {
-    const enrFile = path.join(beaconDir, "enr");
-    const peerIdFile = path.join(beaconDir, "peer-id.json");
-    const {peerId, enr} = await readPersistedPeerIdAndENR(peerIdFile, enrFile);
-    overwriteEnrWithCliArgs(enr, args);
-    // Re-persist peer-id and enr
-    writeFile600Perm(peerIdFile, exportToJSON(peerId));
-    writeFile600Perm(enrFile, enr.encodeTxt());
-    return {peerId, enr};
-  } else {
-    const {peerId, enr} = await newPeerIdAndENR();
-    overwriteEnrWithCliArgs(enr, args);
-    return {peerId, enr};
-  }
 }
 
 export function initLogger(args: BeaconArgs, dataDir: string, config: ChainForkConfig): Logger {

--- a/packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts
+++ b/packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+import {PeerId} from "@libp2p/interface-peer-id";
+import {createSecp256k1PeerId} from "@libp2p/peer-id-factory";
+import {createKeypairFromPeerId, SignableENR} from "@chainsafe/discv5";
+import {Logger} from "@lodestar/utils";
+import {exportToJSON, readPeerId} from "../../config/index.js";
+import {writeFile600Perm} from "../../util/file.js";
+import {defaultP2pPort} from "../../options/beaconNodeOptions/network.js";
+import {BeaconArgs} from "./options.js";
+
+export function overwriteEnrWithCliArgs(enr: SignableENR, args: BeaconArgs): void {
+  // TODO: Not sure if we should propagate port/defaultP2pPort options to the ENR
+  enr.tcp = args["enr.tcp"] ?? args.port ?? defaultP2pPort;
+  const udpPort = args["enr.udp"] ?? args.discoveryPort ?? args.port ?? defaultP2pPort;
+  if (udpPort != null) enr.udp = udpPort;
+  if (args["enr.ip"] != null) enr.ip = args["enr.ip"];
+  if (args["enr.ip6"] != null) enr.ip6 = args["enr.ip6"];
+  if (args["enr.tcp6"] != null) enr.tcp6 = args["enr.tcp6"];
+  if (args["enr.udp6"] != null) enr.udp6 = args["enr.udp6"];
+}
+
+/**
+ * Create new PeerId and ENR by default, unless persistNetworkIdentity is provided
+ */
+export async function initPeerIdAndEnr(
+  args: BeaconArgs,
+  beaconDir: string,
+  logger: Logger
+): Promise<{peerId: PeerId; enr: SignableENR}> {
+  const {persistNetworkIdentity} = args;
+
+  const newPeerIdAndENR = async (): Promise<{peerId: PeerId; enr: SignableENR}> => {
+    const peerId = await createSecp256k1PeerId();
+    const enr = SignableENR.createV4(createKeypairFromPeerId(peerId));
+    return {peerId, enr};
+  };
+
+  const readPersistedPeerIdAndENR = async (
+    peerIdFile: string,
+    enrFile: string
+  ): Promise<{peerId: PeerId; enr: SignableENR}> => {
+    let peerId: PeerId;
+    let enr: SignableENR;
+
+    // attempt to read stored peer id
+    try {
+      peerId = await readPeerId(peerIdFile);
+    } catch (e) {
+      logger.warn("Unable to read peerIdFile, creating a new peer id");
+      return newPeerIdAndENR();
+    }
+    // attempt to read stored enr
+    try {
+      enr = SignableENR.decodeTxt(fs.readFileSync(enrFile, "utf-8"), createKeypairFromPeerId(peerId));
+    } catch (e) {
+      logger.warn("Unable to decode stored local ENR, creating a new ENR");
+      enr = SignableENR.createV4(createKeypairFromPeerId(peerId));
+      return {peerId, enr};
+    }
+    // check stored peer id against stored enr
+    if (!peerId.equals(await enr.peerId())) {
+      logger.warn("Stored local ENR doesn't match peerIdFile, creating a new ENR");
+      enr = SignableENR.createV4(createKeypairFromPeerId(peerId));
+      return {peerId, enr};
+    }
+    return {peerId, enr};
+  };
+
+  if (persistNetworkIdentity) {
+    const enrFile = path.join(beaconDir, "enr");
+    const peerIdFile = path.join(beaconDir, "peer-id.json");
+    const {peerId, enr} = await readPersistedPeerIdAndENR(peerIdFile, enrFile);
+    overwriteEnrWithCliArgs(enr, args);
+    // Re-persist peer-id and enr
+    writeFile600Perm(peerIdFile, exportToJSON(peerId));
+    writeFile600Perm(enrFile, enr.encodeTxt());
+    return {peerId, enr};
+  } else {
+    const {peerId, enr} = await newPeerIdAndENR();
+    overwriteEnrWithCliArgs(enr, args);
+    return {peerId, enr};
+  }
+}

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -16,6 +16,7 @@ type BeaconExtraArgs = {
   dbDir?: string;
   persistInvalidSszObjectsDir?: string;
   peerStoreDir?: string;
+  persistNetworkIdentity?: string;
 };
 
 export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
@@ -89,6 +90,12 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
     description: "Peer store directory",
     defaultDescription: defaultBeaconPaths.peerStoreDir,
     type: "string",
+  },
+
+  persistNetworkIdentity: {
+    hidden: true,
+    description: "Whether to reuse the same peer-id across restarts",
+    type: "boolean",
   },
 };
 

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -16,7 +16,7 @@ type BeaconExtraArgs = {
   dbDir?: string;
   persistInvalidSszObjectsDir?: string;
   peerStoreDir?: string;
-  persistNetworkIdentity?: string;
+  persistNetworkIdentity?: boolean;
 };
 
 export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -6,6 +6,7 @@ import {paramsOptions, IParamsArgs} from "./paramsOptions.js";
 type GlobalSingleArgs = {
   dataDir?: string;
   network?: NetworkName;
+  peerIdFile?: string;
   paramsFile: string;
   preset: string;
 };
@@ -23,6 +24,11 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
     type: "string",
     defaultDescription: defaultNetwork,
     choices: networkNames,
+  },
+
+  peerIdFile: {
+    description: "Peer id file path",
+    type: "string",
   },
 
   paramsFile: {

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -6,7 +6,6 @@ import {paramsOptions, IParamsArgs} from "./paramsOptions.js";
 type GlobalSingleArgs = {
   dataDir?: string;
   network?: NetworkName;
-  peerIdFile?: string;
   paramsFile: string;
   preset: string;
 };
@@ -24,11 +23,6 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
     type: "string",
     defaultDescription: defaultNetwork,
     choices: networkNames,
-  },
-
-  peerIdFile: {
-    description: "Peer id file path",
-    type: "string",
   },
 
   paramsFile: {

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -1,11 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import tmp from "tmp";
+import {createWinstonLogger, Logger} from "@lodestar/utils";
 
 export const networkDev = "dev";
 
 const tmpDir = tmp.dirSync({unsafeCleanup: true});
 export const testFilesDir = tmpDir.name;
+
+export const testLogger = (): Logger => createWinstonLogger();
 
 export function getTestdirPath(filepath: string): string {
   const fullpath = path.join(testFilesDir, filepath);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4737,6 +4737,13 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
+c-kzg@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/c-kzg/-/c-kzg-1.0.9.tgz#cabadd0013b28b3e75dcb3ad115d65fee37baed7"
+  integrity sha512-5shQs7k/f7cN0Ya7g1bTgCX7CO2emh/2mkPKrjxqkC7Y+tM9YN88MWkop9ftMMZXadvVMrxWfZ/RCqBR8jRQOQ==
+  dependencies:
+    node-addon-api "^5.0.0"
+
 cacache@^15.2.0:
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.3.0.tgz#dc85380fb2f556fe3dda4c719bfa0ec875a7f1eb"
@@ -9680,6 +9687,11 @@ node-addon-api@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
+node-addon-api@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
+  integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
 
 node-fetch@2.6.7, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"


### PR DESCRIPTION
**Motivation**

- To have a fixed peer id to integrate with other clients' nodes

**Description**

- Add `peerIdFile` option as global option
- Load peer id from `peerIdFile`, if it does exist it'll throw error `Error: ENOENT: no such file or directory`
- Persist enr when node is shutdown

Closes #4992