### PR TITLE
Get the capella builder functional

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -392,9 +392,6 @@ async function prepareExecutionPayloadHeader(
   if (!chain.executionBuilder) {
     throw Error("executionBuilder required");
   }
-  if (ForkSeq[fork] >= ForkSeq.capella) {
-    throw Error("executionBuilder capella api not implemented");
-  }
 
   const parentHashRes = await getExecutionPayloadParentHash(chain, state);
 


### PR DESCRIPTION
Capella builder was failing because of this extra check, however it works once this check was removed,

https://zhejiang.beaconcha.in/slot/135601
proposed by the lodestar  post this fix