### PR TITLE
Collect system data for client monitoring

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -150,6 +150,7 @@
     "snappyjs": "^0.7.0",
     "stream-to-it": "^0.2.0",
     "strict-event-emitter-types": "^2.0.0",
+    "systeminformation": "^5.17.9",
     "uint8arraylist": "^2.3.2",
     "uint8arrays": "^4.0.2",
     "varint": "^6.0.0",

--- a/packages/beacon-node/src/monitoring/clientStats.ts
+++ b/packages/beacon-node/src/monitoring/clientStats.ts
@@ -1,5 +1,6 @@
 import {DynamicProperty, MetricProperty, StaticProperty} from "./properties.js";
 import {Client} from "./service.js";
+import * as system from "./system.js";
 import {ClientStats, JsonType, ProcessType} from "./types.js";
 
 // Definition of client stats based on specification
@@ -199,100 +200,97 @@ function createSystemStats(): ClientStats {
     ...createCommonStats(ProcessType.System),
     cpuCores: new DynamicProperty({
       jsonKey: "cpu_cores",
-      provider: () => 0,
-      cacheResult: true,
+      provider: system.getCpuCores,
       description: "Number of CPU cores available",
     }),
     cpuThreads: new DynamicProperty({
       jsonKey: "cpu_threads",
-      provider: () => 0,
-      cacheResult: true,
+      provider: system.getCpuThreads,
       description: "Number of CPU threads available",
     }),
     cpuNodeSystemSecondsTotal: new DynamicProperty({
       jsonKey: "cpu_node_system_seconds_total",
-      provider: () => 0,
+      provider: system.getCpuNodeSystemSecondsTotal,
       description: "CPU seconds consumed by all processes",
     }),
     cpuNodeUserSecondsTotal: new DynamicProperty({
       jsonKey: "cpu_node_user_seconds_total",
-      provider: () => 0,
+      provider: system.getCpuNodeUserSecondsTotal,
       description: "CPU seconds consumed by user processes",
     }),
     cpuNodeIOWaitSecondsTotal: new DynamicProperty({
       jsonKey: "cpu_node_iowait_seconds_total",
-      provider: () => 0,
+      provider: system.getCpuNodeIOWaitSecondsTotal,
       description: "CPU seconds spent in I/O wait state",
     }),
     cpuNodeIdleSecondsTotal: new DynamicProperty({
       jsonKey: "cpu_node_idle_seconds_total",
-      provider: () => 0,
+      provider: system.getCpuNodeIdleSecondsTotal,
       description: "CPU seconds spent in idle state",
     }),
     memoryNodeBytesTotal: new DynamicProperty({
       jsonKey: "memory_node_bytes_total",
-      provider: () => 0,
-      cacheResult: true,
+      provider: system.getMemoryNodeBytesTotal,
       description: "Total amount of memory in bytes available",
     }),
     memoryNodeBytesFree: new DynamicProperty({
       jsonKey: "memory_node_bytes_free",
-      provider: () => 0,
+      provider: system.getMemoryNodeBytesFree,
       description: "Amount of free memory in bytes",
     }),
     memoryNodeBytesCached: new DynamicProperty({
       jsonKey: "memory_node_bytes_cached",
-      provider: () => 0,
+      provider: system.getMemoryNodeBytesCached,
       description: "Amount of memory in bytes used by cache",
     }),
     memoryNodeBytesBuffers: new DynamicProperty({
       jsonKey: "memory_node_bytes_buffers",
-      provider: () => 0,
+      provider: system.getMemoryNodeBytesBuffers,
       description: "Amount of memory in bytes used by buffers",
     }),
     diskNodeBytesTotal: new DynamicProperty({
       jsonKey: "disk_node_bytes_total",
-      provider: () => 0,
+      provider: system.getDiskNodeBytesTotal,
       description: "Total amount of available disk space in bytes",
     }),
     diskNodeBytesFree: new DynamicProperty({
       jsonKey: "disk_node_bytes_free",
-      provider: () => 0,
+      provider: system.getDiskNodeBytesFree,
       description: "Amount of free disk space in bytes",
     }),
     diskNodeIOSeconds: new DynamicProperty({
       jsonKey: "disk_node_io_seconds",
-      provider: () => 0,
+      provider: system.getDiskNodeIOSeconds,
       description: "Total time spent in seconds on disk I/O operations",
     }),
     diskNodeReadsTotal: new DynamicProperty({
       jsonKey: "disk_node_reads_total",
-      provider: () => 0,
-      description: "Total amount of bytes read from disk",
+      provider: system.getDiskNodeReadsTotal,
+      description: "Total number of disk read I/O operations",
     }),
     diskNodeWritesTotal: new DynamicProperty({
       jsonKey: "disk_node_writes_total",
-      provider: () => 0,
-      description: "Total amount of bytes written to disk",
+      provider: system.getDiskNodeWritesTotal,
+      description: "Total number of disk write I/O operations",
     }),
     networkNodeBytesTotalReceive: new DynamicProperty({
       jsonKey: "network_node_bytes_total_receive",
-      provider: () => 0,
+      provider: system.getNetworkNodeBytesTotalReceive,
       description: "Total amount of bytes received over the network",
     }),
     networkNodeBytesTotalTransmit: new DynamicProperty({
       jsonKey: "network_node_bytes_total_transmit",
-      provider: () => 0,
+      provider: system.getNetworkNodeBytesTotalTransmit,
       description: "Total amount of bytes transmitted over the network",
     }),
     miscNodeBootTsSeconds: new DynamicProperty({
       jsonKey: "misc_node_boot_ts_seconds",
-      provider: () => 0,
+      provider: system.getMiscNodeBootTsSeconds,
       description: "Unix timestamp in seconds of boot time",
     }),
     miscOs: new DynamicProperty({
       jsonKey: "misc_os",
-      provider: () => "unk",
+      provider: system.getMiscOs,
       description: "Operating system, can be one of: lin, win, mac, unk for unknown",
     }),
   };

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -6,6 +6,7 @@ import {HistogramExtra} from "../metrics/utils/histogram.js";
 import {defaultMonitoringOptions, MonitoringOptions} from "./options.js";
 import {createClientStats} from "./clientStats.js";
 import {ClientStats} from "./types.js";
+import {collectSystemData} from "./system.js";
 
 type MonitoringData = Record<string, string | number | boolean>;
 
@@ -146,6 +147,10 @@ export class MonitoringService {
     const timer = this.collectDataMetric.startTimer();
     const data: MonitoringData[] = [];
     const recordPromises = [];
+
+    if (this.options.collectSystemStats) {
+      await collectSystemData(this.logger);
+    }
 
     for (const [i, s] of this.clientStats.entries()) {
       data[i] = {};

--- a/packages/beacon-node/src/monitoring/system.ts
+++ b/packages/beacon-node/src/monitoring/system.ts
@@ -1,0 +1,268 @@
+import os from "node:os";
+import path from "node:path";
+import system from "systeminformation";
+import {Logger} from "@lodestar/utils";
+
+type MiscOs = "lin" | "win" | "mac" | "unk";
+
+// static data only needs to be collected once
+let staticDataCollected = false;
+// disk I/O is not measurable in some environments
+let diskIOMeasurable = true;
+
+let cpuCores = 0;
+let cpuThreads = 0;
+let cpuNodeSystemSecondsTotal = 0;
+let cpuNodeUserSecondsTotal = 0;
+let cpuNodeIdleSecondsTotal = 0;
+let memoryNodeBytesTotal = 0;
+let memoryNodeBytesFree = 0;
+let memoryNodeBytesCached = 0;
+let memoryNodeBytesBuffers = 0;
+let diskNodeBytesTotal = 0;
+let diskNodeBytesFree = 0;
+let diskNodeReadsTotal = 0;
+let diskNodeWritesTotal = 0;
+let networkNodeBytesTotalReceive = 0;
+let networkNodeBytesTotalTransmit = 0;
+let miscNodeBootTsSeconds = 0;
+let miscOs: MiscOs = "unk";
+
+/**
+ * Collect system data and update cached values
+ */
+export async function collectSystemData(logger: Logger): Promise<void> {
+  const debug = (dataType: string, e: Error): void => logger.debug(`Failed to collect ${dataType} data`, {}, e);
+
+  await Promise.all([
+    collectStaticData().catch((e) => debug("static system", e)),
+    collectCpuData().catch((e) => debug("CPU", e)),
+    collectMemoryData().catch((e) => debug("memory", e)),
+    collectDiskData().catch((e) => debug("disk", e)),
+    collectNetworkData().catch((e) => debug("network", e)),
+  ]);
+
+  miscNodeBootTsSeconds = getSystemBootTime();
+}
+
+async function collectStaticData(): Promise<void> {
+  if (staticDataCollected) return;
+
+  const cpu = await system.cpu();
+  // Note: inside container this might be inaccurate as
+  // physicalCores in some cases is the count of logical CPU cores
+  cpuCores = cpu.physicalCores;
+  cpuThreads = cpu.cores;
+
+  miscOs = getNormalizedOsVersion();
+
+  staticDataCollected = true;
+}
+
+async function collectCpuData(): Promise<void> {
+  const cpuTimes: Record<string, number> = {};
+
+  os.cpus().forEach((cpu) => {
+    // sum up CPU times per mode and convert to seconds
+    for (const [mode, time] of Object.entries(cpu.times)) {
+      if (cpuTimes[mode] == null) cpuTimes[mode] = 0;
+      cpuTimes[mode] += Math.floor(time / 1000);
+    }
+  });
+
+  // Note: currently beaconcha.in expects system CPU seconds to be everything
+  cpuNodeSystemSecondsTotal = Object.values(cpuTimes).reduce((total, time) => total + time, 0);
+  cpuNodeUserSecondsTotal = cpuTimes.user;
+  cpuNodeIdleSecondsTotal = cpuTimes.idle;
+}
+
+async function collectMemoryData(): Promise<void> {
+  const memory = await system.mem();
+  memoryNodeBytesTotal = memory.total;
+  memoryNodeBytesFree = memory.free;
+  memoryNodeBytesCached = memory.cached;
+  memoryNodeBytesBuffers = memory.buffers;
+}
+
+async function collectDiskData(): Promise<void> {
+  const fileSystems = await system.fsSize();
+  // get file system root, on windows this is the name of the hard disk partition
+  const rootFs = process.platform === "win32" ? process.cwd().split(path.sep)[0] : "/";
+  // only consider root file system, if it does not exist use first entry in the list
+  const fileSystem = fileSystems.find((fs) => fs.mount === rootFs) ?? fileSystems[0];
+  diskNodeBytesTotal = fileSystem.size;
+  diskNodeBytesFree = fileSystem.available;
+
+  if (diskIOMeasurable) {
+    const disk = await system.disksIO();
+    if (disk != null && disk.rIO !== 0) {
+      // Note: rIO and wIO might not be available inside container
+      // see https://github.com/sebhildebrandt/systeminformation/issues/777
+      diskNodeReadsTotal = disk.rIO;
+      diskNodeWritesTotal = disk.wIO;
+    } else {
+      diskIOMeasurable = false;
+    }
+  }
+}
+
+async function collectNetworkData(): Promise<void> {
+  // defaults to first external network interface
+  const [network] = await system.networkStats();
+  // Note: rx_bytes and tx_bytes will be inaccurate if process
+  // runs inside container as it only captures local network traffic
+  networkNodeBytesTotalReceive = network.rx_bytes;
+  networkNodeBytesTotalTransmit = network.tx_bytes;
+}
+
+function getNormalizedOsVersion(): MiscOs {
+  switch (process.platform) {
+    case "linux":
+      return "lin";
+    case "darwin":
+      return "mac";
+    case "win32":
+      return "win";
+    default:
+      return "unk";
+  }
+}
+
+function getSystemBootTime(): number {
+  return Math.floor(Date.now() / 1000 - os.uptime());
+}
+
+/**
+ * Number of CPU cores available
+ */
+export function getCpuCores(): number {
+  return cpuCores;
+}
+
+/**
+ * Number of CPU threads available
+ */
+export function getCpuThreads(): number {
+  return cpuThreads;
+}
+
+/**
+ * CPU seconds consumed by all processes
+ */
+export function getCpuNodeSystemSecondsTotal(): number {
+  return cpuNodeSystemSecondsTotal;
+}
+
+/**
+ * CPU seconds consumed by user processes
+ */
+export function getCpuNodeUserSecondsTotal(): number {
+  return cpuNodeUserSecondsTotal;
+}
+
+/**
+ * CPU seconds spent in I/O wait state
+ */
+export function getCpuNodeIOWaitSecondsTotal(): number {
+  // Note: not measured by os.cpus()
+  return 0;
+}
+
+/**
+ * CPU seconds spent in idle state
+ */
+export function getCpuNodeIdleSecondsTotal(): number {
+  return cpuNodeIdleSecondsTotal;
+}
+
+/**
+ * Total amount of memory in bytes available
+ */
+export function getMemoryNodeBytesTotal(): number {
+  return memoryNodeBytesTotal;
+}
+
+/**
+ * Amount of free memory in bytes
+ */
+export function getMemoryNodeBytesFree(): number {
+  return memoryNodeBytesFree;
+}
+
+/**
+ * Amount of memory in bytes used by cache
+ */
+export function getMemoryNodeBytesCached(): number {
+  return memoryNodeBytesCached;
+}
+
+/**
+ * Amount of memory in bytes used by buffers
+ */
+export function getMemoryNodeBytesBuffers(): number {
+  return memoryNodeBytesBuffers;
+}
+
+/**
+ * Total amount of available disk space in bytes
+ */
+export function getDiskNodeBytesTotal(): number {
+  return diskNodeBytesTotal;
+}
+
+/**
+ * Amount of free disk space in bytes
+ */
+export function getDiskNodeBytesFree(): number {
+  return diskNodeBytesFree;
+}
+
+/**
+ * Total time spent in seconds on disk I/O operations
+ */
+export function getDiskNodeIOSeconds(): number {
+  // Note: currently unused by beaconcha.in
+  return 0;
+}
+
+/**
+ * Total number of disk read I/O operations
+ */
+export function getDiskNodeReadsTotal(): number {
+  return diskNodeReadsTotal;
+}
+
+/**
+ * Total number of disk write I/O operations
+ */
+export function getDiskNodeWritesTotal(): number {
+  return diskNodeWritesTotal;
+}
+
+/**
+ * Total amount of bytes received over the network
+ */
+export function getNetworkNodeBytesTotalReceive(): number {
+  return networkNodeBytesTotalReceive;
+}
+
+/**
+ * Total amount of bytes transmitted over the network
+ */
+export function getNetworkNodeBytesTotalTransmit(): number {
+  return networkNodeBytesTotalTransmit;
+}
+
+/**
+ * Unix timestamp in seconds of boot time
+ */
+export function getMiscNodeBootTsSeconds(): number {
+  return miscNodeBootTsSeconds;
+}
+
+/**
+ * Operating system, can be one of: lin, win, mac, unk for unknown
+ */
+export function getMiscOs(): MiscOs {
+  return miscOs;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12183,6 +12183,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+systeminformation@^5.17.9:
+  version "5.17.9"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.17.9.tgz#8a47bc84f076982734d7b7a0c71371d23bbbfd52"
+  integrity sha512-inxwRLI/4qpx4o85R54/zdhNagdBGBgs0la7Vl3qBorRVKRDk0nNsDTCGzG4lOITsw1gl7LRWeG4Zsp1pC8nfg==
+
 tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"


### PR DESCRIPTION
**Motivation**

Follow up PR for https://github.com/ChainSafe/lodestar/pull/5037 to implement collection of system data to support full feature set of beaconcha.in monitoring app.

**Description**

Replaces currently hard-coded values in system stats with proper provider functions. Most of the system data is collected using [systeminformation](https://www.npmjs.com/package/systeminformation) which is a widely used and well maintained package with [0 dependencies](https://www.npmjs.com/package/systeminformation?activeTab=dependencies). There are a few issues running in a containerized environment as some data might be inaccurate or missing but the important data is collected correctly even there. These issues might also be addressed in the future, see https://github.com/sebhildebrandt/systeminformation/issues/777, although it is really not that important.

**Performance**

Dashboards are already in place to keep track of the performance. The functions to collect system data are not executed in the main thread and a lot of the time use child processes which execute native system calls depending on OS. The performance measurements from the last few days looks really promising and I did not see any issues as of now both validator efficiency and system load seem unaffected by enabling client monitoring.

Added some screenshots of prometheus metrics, just let me now if I should provide further metrics.

<details>
<summary markdown="span">Prometheus metrics</summary>
<pre>

Takes between 0.5 - 1 second to collect system data, depending on the environment (on windows ~3 seconds).

![image](https://user-images.githubusercontent.com/38436224/220109900-fa2a77b2-0007-40e5-b34a-186503dcb295.png)

It should not cause any spikes in Lodestar CPU usage as it is executed in a different process

![image](https://user-images.githubusercontent.com/38436224/220110429-b971ac82-a018-44a5-b5f2-35d74efafd7c.png)

Overall container CPU usage looks got to me as well, it does not seem like collecting system data consumes too much CPU

![image](https://user-images.githubusercontent.com/38436224/220111667-4491e2cf-56f6-41be-9bcb-23b7de7f741f.png)

Event Loop Lag seems unaffected as well

![image](https://user-images.githubusercontent.com/38436224/220110752-c70efc88-8f80-4b1f-9ef4-3fc853443f30.png)


Process memory usage looks stable

![image](https://user-images.githubusercontent.com/38436224/220111261-3f8cf3fc-1ed9-4c84-8980-e4f124f2d97c.png)


Container memory usage as well (no rss memory leak)

![image](https://user-images.githubusercontent.com/38436224/220111500-3f230163-bb96-41fa-972c-5b5592305333.png)

</pre>

</details>


**Beaconcha.in mobile app**

We support all dashboards in the beaconcha.in mobile app and also all notifications which is the most valuable feature of the app in my opinion. A node operator gets a lot of value from the app which you normally would only get if you run prometheus + grafana and invest additional time to configure proper alerting.

<details>
<summary markdown="span">Mobile app screenshots</summary>
<pre>


![Screenshot_20230220_135448_Beaconchain](https://user-images.githubusercontent.com/38436224/220115535-8c07a0dc-f48e-4674-ad80-c2e3d06cdcf6.jpg) 
![Screenshot_20230220_141016_Beaconchain](https://user-images.githubusercontent.com/38436224/220118092-da8b632a-0c48-47c2-aa17-582adf13bf44.jpg)
![Screenshot_20230218_212040_Beaconchain](https://user-images.githubusercontent.com/38436224/220115957-22310070-09cf-4a77-9391-67dd411b279e.jpg)
![Screenshot_20230218_212106_Beaconchain](https://user-images.githubusercontent.com/38436224/220115983-be02cffc-032d-478a-a397-29e4a42aa649.jpg)
![Screenshot_20230219_232736_Beaconchain](https://user-images.githubusercontent.com/38436224/220116203-f74085ab-0005-47c3-8c04-6efb4c376b82.jpg)
![Screenshot_20230218_212159_Beaconchain](https://user-images.githubusercontent.com/38436224/220116011-c8efe9a5-9a6c-4edb-b7a1-073b6f1bdd20.jpg)
![Screenshot_20230218_212227_Beaconchain](https://user-images.githubusercontent.com/38436224/220116025-0c68a09d-5bf5-4f02-a679-6d22926778dd.jpg)
![Screenshot_20230218_212242_Beaconchain](https://user-images.githubusercontent.com/38436224/220116043-8adb4a68-4097-4dbd-b3f7-4e71924c074b.jpg)
![Screenshot_20230218_212305_Beaconchain](https://user-images.githubusercontent.com/38436224/220116057-20b4333a-f624-4d33-a632-4a61fbc9eeb6.jpg)
![Screenshot_20230218_212320_Beaconchain](https://user-images.githubusercontent.com/38436224/220116081-724aeb3c-6715-4061-b9de-8baef15f4174.jpg)
![Screenshot_20230218_212338_Beaconchain](https://user-images.githubusercontent.com/38436224/220116104-ba95bca7-d029-4e07-b26f-d5c2a0f1bda1.jpg)
![Screenshot_20230218_212403_Beaconchain](https://user-images.githubusercontent.com/38436224/220116121-41f4a0f4-5e81-402f-af7c-e048765d57ba.jpg)
![Screenshot_20230218_212417_Beaconchain](https://user-images.githubusercontent.com/38436224/220116130-67fc91fa-99f5-4acf-aea4-58fc3e71fb24.jpg)
</pre>

</details>