### PR TITLE
Refactor client monitoring

### DIFF
--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -2742,7 +2742,7 @@
                   "type": "linear"
                 },
                 "showPoints": "never",
-                "spanNulls": true,
+                "spanNulls": 3600000,
                 "stacking": {
                   "group": "A",
                   "mode": "none"
@@ -2767,7 +2767,68 @@
               },
               "unit": "s"
             },
-            "overrides": []
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "validator - error"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "validator - success"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "beacon - error"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "beacon - success"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           "gridPos": {
             "h": 8,

--- a/docs/usage/client-monitoring.md
+++ b/docs/usage/client-monitoring.md
@@ -39,11 +39,15 @@ It is also possible to print out the data sent to the remote service by enabling
 
 ### Monitoring interval
 
-It is possible to adjust the interval between sending client stats to the remote service by
-setting the `--monitoring.interval` flag. It takes an integer value in milliseconds, the default is `60000` which means data is sent once a minute.
+It is possible to adjust the interval between sending client stats to the remote service by setting the `--monitoring.interval` flag.
+It takes an integer value in milliseconds, the default is `62000` which means data is sent approximately once a minute.
+The extra 2 seconds are added to avoid rate limit errors when using *beaconcha.in* as they are currently really strict
+and minor delays in the previous request can cause the following request to fail.
+
+For example, setting an interval of `300000` would mean the data is only sent every 5 minutes.
 
 ```bash
-lodestar beacon --monitoring.interval 60000
+lodestar beacon --monitoring.interval 300000
 ```
 
 Increasing the monitoring interval can be useful if you are running into rate limit errors when posting large amounts of data for multiple nodes.

--- a/packages/beacon-node/src/monitoring/clientStats.ts
+++ b/packages/beacon-node/src/monitoring/clientStats.ts
@@ -200,13 +200,11 @@ function createSystemStats(): ClientStats {
     cpuCores: new DynamicProperty({
       jsonKey: "cpu_cores",
       provider: () => 0,
-      cacheResult: true,
       description: "Number of CPU cores available",
     }),
     cpuThreads: new DynamicProperty({
       jsonKey: "cpu_threads",
       provider: () => 0,
-      cacheResult: true,
       description: "Number of CPU threads available",
     }),
     cpuNodeSystemSecondsTotal: new DynamicProperty({
@@ -232,7 +230,6 @@ function createSystemStats(): ClientStats {
     memoryNodeBytesTotal: new DynamicProperty({
       jsonKey: "memory_node_bytes_total",
       provider: () => 0,
-      cacheResult: true,
       description: "Total amount of memory in bytes available",
     }),
     memoryNodeBytesFree: new DynamicProperty({

--- a/packages/beacon-node/src/monitoring/options.ts
+++ b/packages/beacon-node/src/monitoring/options.ts
@@ -13,7 +13,9 @@ export type MonitoringOptions = {
 
 export const defaultMonitoringOptions: Required<MonitoringOptions> = {
   endpoint: "",
-  interval: 60_000,
+  // default interval should be once a minute
+  // but need to add 2 seconds to avoid rate limit errors
+  interval: 62_000,
   initialDelay: 30_000,
   requestTimeout: 10_000,
   collectSystemStats: true,

--- a/packages/beacon-node/src/monitoring/properties.ts
+++ b/packages/beacon-node/src/monitoring/properties.ts
@@ -39,12 +39,18 @@ interface MetricPropertyDefinition<T extends RecordValue> extends PropertyDefini
   defaultValue: T;
 }
 
+/**
+ * Interface to be implemented by client stats properties
+ */
 export interface ClientStatsProperty<T extends RecordValue> {
   readonly definition: PropertyDefinition;
 
   getRecord(register: Registry): JsonRecord<T> | Promise<JsonRecord<T>>;
 }
 
+/**
+ * Static property that can be used to define hard-coded values
+ */
 export class StaticProperty<T extends RecordValue> implements ClientStatsProperty<T> {
   constructor(readonly definition: StaticPropertyDefinition<T>) {}
 
@@ -53,6 +59,9 @@ export class StaticProperty<T extends RecordValue> implements ClientStatsPropert
   }
 }
 
+/**
+ * Dynamic property that can be used to get value from a provider function
+ */
 export class DynamicProperty<T extends RecordValue> implements ClientStatsProperty<T> {
   constructor(readonly definition: DynamicPropertyDefinition<T>) {}
 
@@ -61,6 +70,9 @@ export class DynamicProperty<T extends RecordValue> implements ClientStatsProper
   }
 }
 
+/**
+ * Metric property that can be used to get value from an existing prometheus metric
+ */
 export class MetricProperty<T extends RecordValue> implements ClientStatsProperty<T> {
   private cachedValue?: T;
 

--- a/packages/beacon-node/src/monitoring/properties.ts
+++ b/packages/beacon-node/src/monitoring/properties.ts
@@ -15,9 +15,7 @@ interface StaticPropertyDefinition<T extends RecordValue> extends PropertyDefini
 
 interface DynamicPropertyDefinition<T extends RecordValue> extends PropertyDefinition {
   /** Value provider function */
-  provider: () => T | Promise<T>;
-  /** Only call provider function once and then use cached value */
-  cacheResult?: boolean;
+  provider: () => T;
 }
 
 interface MetricPropertyDefinition<T extends RecordValue> extends PropertyDefinition {
@@ -56,22 +54,10 @@ export class StaticProperty<T extends RecordValue> implements ClientStatsPropert
 }
 
 export class DynamicProperty<T extends RecordValue> implements ClientStatsProperty<T> {
-  private cachedValue?: T;
-
   constructor(readonly definition: DynamicPropertyDefinition<T>) {}
 
-  async getRecord(): Promise<JsonRecord<T>> {
-    if (this.cachedValue != null) {
-      return {key: this.definition.jsonKey, value: this.cachedValue};
-    }
-
-    const value = await this.definition.provider();
-
-    if (this.definition.cacheResult) {
-      this.cachedValue = value;
-    }
-
-    return {key: this.definition.jsonKey, value};
+  getRecord(): JsonRecord<T> {
+    return {key: this.definition.jsonKey, value: this.definition.provider()};
   }
 }
 

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -61,7 +61,7 @@ export class MonitoringService {
     this.collectDataMetric = register.histogram({
       name: "lodestar_monitoring_collect_data_seconds",
       help: "Time spent to collect monitoring data in seconds",
-      buckets: [0.001, 0.01, 0.1, 1],
+      buckets: [0.001, 0.01, 0.1, 1, 5],
     });
 
     this.sendDataMetric = register.histogram({

--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -90,6 +90,7 @@ export class MonitoringService {
     }, initialDelay);
 
     this.logger.info("Started monitoring service", {
+      // do not log full URL as it may contain secrets
       remote: this.remoteServiceHost,
       machine: this.remoteServiceUrl.searchParams.get("machine"),
       interval,

--- a/packages/beacon-node/test/unit/monitoring/clientStats.test.ts
+++ b/packages/beacon-node/test/unit/monitoring/clientStats.test.ts
@@ -1,14 +1,14 @@
 import {expect} from "chai";
 import {ClientStats} from "../../../src/monitoring/types.js";
 import {createClientStats} from "../../../src/monitoring/clientStats.js";
-import {beaconNodeStatsSchema, ClientStatsSchema, systemStatsSchema, validatorStatsSchema} from "./schemas.js";
+import {BEACON_NODE_STATS_SCHEMA, ClientStatsSchema, SYSTEM_STATS_SCHEMA, VALIDATOR_STATS_SCHEMA} from "./schemas.js";
 
 describe("monitoring / clientStats", () => {
   describe("BeaconNodeStats", () => {
     it("should contain all required keys", () => {
       const beaconNodeStats = createClientStats("beacon")[0];
 
-      expect(getJsonKeys(beaconNodeStats)).to.have.all.members(getSchemaKeys(beaconNodeStatsSchema));
+      expect(getJsonKeys(beaconNodeStats)).to.have.all.members(getSchemaKeys(BEACON_NODE_STATS_SCHEMA));
     });
   });
 
@@ -16,7 +16,7 @@ describe("monitoring / clientStats", () => {
     it("should contain all required keys", () => {
       const validatorNodeStats = createClientStats("validator")[0];
 
-      expect(getJsonKeys(validatorNodeStats)).to.have.all.members(getSchemaKeys(validatorStatsSchema));
+      expect(getJsonKeys(validatorNodeStats)).to.have.all.members(getSchemaKeys(VALIDATOR_STATS_SCHEMA));
     });
   });
 
@@ -24,7 +24,7 @@ describe("monitoring / clientStats", () => {
     it("should contain all required keys", () => {
       const systemStats = createClientStats("beacon", true)[1];
 
-      expect(getJsonKeys(systemStats)).to.have.all.members(getSchemaKeys(systemStatsSchema));
+      expect(getJsonKeys(systemStats)).to.have.all.members(getSchemaKeys(SYSTEM_STATS_SCHEMA));
     });
   });
 });

--- a/packages/beacon-node/test/unit/monitoring/properties.test.ts
+++ b/packages/beacon-node/test/unit/monitoring/properties.test.ts
@@ -20,31 +20,13 @@ describe("monitoring / properties", () => {
   });
 
   describe("DynamicProperty", () => {
-    it("should return a json record with the configured key and return value of provider", async () => {
+    it("should return a json record with the configured key and return value of provider", () => {
       const dynamicProperty = new DynamicProperty({jsonKey, provider: () => value});
 
-      const jsonRecord = await dynamicProperty.getRecord();
+      const jsonRecord = dynamicProperty.getRecord();
 
       expect(jsonRecord.key).to.equal(jsonKey);
       expect(jsonRecord.value).to.equal(value);
-    });
-
-    it("should return the same value on consecutive calls if cacheResult is set to true", async () => {
-      const initialValue = 1;
-      let updatedValue = initialValue;
-
-      const provider = (): number => {
-        const value = updatedValue;
-        updatedValue++;
-        return value;
-      };
-
-      const dynamicProperty = new DynamicProperty({jsonKey, provider, cacheResult: true});
-
-      // ensure consecutive calls still return initial provider value
-      expect((await dynamicProperty.getRecord()).value).to.equal(initialValue);
-      expect((await dynamicProperty.getRecord()).value).to.equal(initialValue);
-      expect((await dynamicProperty.getRecord()).value).to.equal(initialValue);
     });
   });
 

--- a/packages/beacon-node/test/unit/monitoring/remoteService.ts
+++ b/packages/beacon-node/test/unit/monitoring/remoteService.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import fastify from "fastify";
 import {RemoteServiceError} from "../../../src/monitoring/service.js";
 import {ProcessType} from "../../../src/monitoring/types.js";
-import {beaconNodeStatsSchema, ClientStatsSchema, systemStatsSchema, validatorStatsSchema} from "./schemas.js";
+import {BEACON_NODE_STATS_SCHEMA, ClientStatsSchema, SYSTEM_STATS_SCHEMA, VALIDATOR_STATS_SCHEMA} from "./schemas.js";
 
 /* eslint-disable no-console */
 
@@ -60,13 +60,13 @@ export async function startRemoteService(): Promise<{baseUrl: URL}> {
 function validateRequestData(data: ReceivedData): void {
   switch (data.process) {
     case ProcessType.BeaconNode:
-      validateClientStats(data, beaconNodeStatsSchema);
+      validateClientStats(data, BEACON_NODE_STATS_SCHEMA);
       break;
     case ProcessType.Validator:
-      validateClientStats(data, validatorStatsSchema);
+      validateClientStats(data, VALIDATOR_STATS_SCHEMA);
       break;
     case ProcessType.System:
-      validateClientStats(data, systemStatsSchema);
+      validateClientStats(data, SYSTEM_STATS_SCHEMA);
       break;
     default:
       throw new Error(`Invalid process type "${data.process}"`);

--- a/packages/beacon-node/test/unit/monitoring/schemas.ts
+++ b/packages/beacon-node/test/unit/monitoring/schemas.ts
@@ -2,14 +2,14 @@
 
 export type ClientStatsSchema = {key: string; type: "string" | "number" | "boolean"}[];
 
-export const commonStatsSchema: ClientStatsSchema = [
+export const COMMON_STATS_SCHEMA: ClientStatsSchema = [
   {key: "version", type: "number"},
   {key: "timestamp", type: "number"},
   {key: "process", type: "string"},
 ];
 
-export const processStatsSchema: ClientStatsSchema = [
-  ...commonStatsSchema,
+export const PROCESS_STATS_SCHEMA: ClientStatsSchema = [
+  ...COMMON_STATS_SCHEMA,
   {key: "cpu_process_seconds_total", type: "number"},
   {key: "memory_process_bytes", type: "number"},
   {key: "client_name", type: "string"},
@@ -19,8 +19,8 @@ export const processStatsSchema: ClientStatsSchema = [
   {key: "sync_eth2_fallback_connected", type: "boolean"},
 ];
 
-export const beaconNodeStatsSchema: ClientStatsSchema = [
-  ...processStatsSchema,
+export const BEACON_NODE_STATS_SCHEMA: ClientStatsSchema = [
+  ...PROCESS_STATS_SCHEMA,
   {key: "disk_beaconchain_bytes_total", type: "number"},
   {key: "network_libp2p_bytes_total_receive", type: "number"},
   {key: "network_libp2p_bytes_total_transmit", type: "number"},
@@ -33,14 +33,14 @@ export const beaconNodeStatsSchema: ClientStatsSchema = [
   {key: "slasher_active", type: "boolean"},
 ];
 
-export const validatorStatsSchema: ClientStatsSchema = [
-  ...processStatsSchema,
+export const VALIDATOR_STATS_SCHEMA: ClientStatsSchema = [
+  ...PROCESS_STATS_SCHEMA,
   {key: "validator_total", type: "number"},
   {key: "validator_active", type: "number"},
 ];
 
-export const systemStatsSchema: ClientStatsSchema = [
-  ...commonStatsSchema,
+export const SYSTEM_STATS_SCHEMA: ClientStatsSchema = [
+  ...COMMON_STATS_SCHEMA,
   {key: "cpu_cores", type: "number"},
   {key: "cpu_threads", type: "number"},
   {key: "cpu_node_system_seconds_total", type: "number"},

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -18,7 +18,7 @@ export const validatorMetricsDefaultOptions = {
 };
 
 export const validatorMonitoringDefaultOptions = {
-  interval: 60_000,
+  interval: 62_000,
   initialDelay: 30_000,
   requestTimeout: 10_000,
   collectSystemStats: false,

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -54,7 +54,7 @@ describe("options / beaconNodeOptions", () => {
       "metrics.address": "0.0.0.0",
 
       "monitoring.endpoint": "https://beaconcha.in/api/v1/client/metrics?apikey=secretKey&machine=machine1",
-      "monitoring.interval": 60000,
+      "monitoring.interval": 62000,
       "monitoring.initialDelay": 30000,
       "monitoring.requestTimeout": 10000,
       "monitoring.collectSystemStats": true,
@@ -142,7 +142,7 @@ describe("options / beaconNodeOptions", () => {
       },
       monitoring: {
         endpoint: "https://beaconcha.in/api/v1/client/metrics?apikey=secretKey&machine=machine1",
-        interval: 60000,
+        interval: 62000,
         initialDelay: 30000,
         requestTimeout: 10000,
         collectSystemStats: true,


### PR DESCRIPTION
**Motivation**

Some follow up changes/refactoring for #5037 to clean up few things and fix some minor issues.

**Description**

- Simplify dynamic client stats property
- Add 5 seconds bucket to collect data metric
- Add 2 seconds to monitoring interval to avoid rate limit errors
- Add comment on why only remote host should be logged
- Override colors in send data duration panel
- Add jsdoc to client stats properties
- Use `CONSTANT_CASE` for client stats schema fixtures


See [commits](https://github.com/ChainSafe/lodestar/pull/5183/commits) for further details.
