### PR TITLE
Allow blsChange reprocess/republish via API submission

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -114,18 +114,18 @@ export function getBeaconPoolApi({
       await Promise.all(
         blsToExecutionChanges.map(async (blsToExecutionChange, i) => {
           try {
-            await validateBlsToExecutionChange(chain, blsToExecutionChange);
-            // TODO: Remove below condition
-            // Only used for testing in devnet-3 of withdrawals
-            chain.opPool.insertBlsToExecutionChange(
-              blsToExecutionChange,
+            await validateBlsToExecutionChange(chain, blsToExecutionChange, true);
+            const preCapella =
               // true if pre capella else false
               !(
                 chain.clock.currentEpoch >= chain.config.CAPELLA_FORK_EPOCH &&
                 // TODO: Remove this condition once testing is done
                 network.isSubscribedToGossipCoreTopics()
-              )
-            );
+              );
+            chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, preCapella);
+            if (!preCapella) {
+              await network.gossip.publishBlsToExecutionChange(blsToExecutionChange);
+            }
           } catch (e) {
             errors.push(e as Error);
             logger.error(

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -114,14 +114,13 @@ export function getBeaconPoolApi({
       await Promise.all(
         blsToExecutionChanges.map(async (blsToExecutionChange, i) => {
           try {
+            // Ignore even if the change exists and reprocess
             await validateBlsToExecutionChange(chain, blsToExecutionChange, true);
-            const preCapella =
-              // true if pre capella else false
-              !(
-                chain.clock.currentEpoch >= chain.config.CAPELLA_FORK_EPOCH &&
-                // TODO: Remove this condition once testing is done
-                network.isSubscribedToGossipCoreTopics()
-              );
+            const preCapella = !(
+              chain.clock.currentEpoch >= chain.config.CAPELLA_FORK_EPOCH &&
+              // TODO: Remove this condition once testing is done
+              network.isSubscribedToGossipCoreTopics()
+            );
             chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, preCapella);
             if (!preCapella) {
               await network.gossip.publishBlsToExecutionChange(blsToExecutionChange);

--- a/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
@@ -9,11 +9,12 @@ import {BlsToExecutionChangeError, BlsToExecutionChangeErrorCode, GossipAction} 
 
 export async function validateBlsToExecutionChange(
   chain: IBeaconChain,
-  blsToExecutionChange: capella.SignedBLSToExecutionChange
+  blsToExecutionChange: capella.SignedBLSToExecutionChange,
+  ignoreExists = false
 ): Promise<void> {
   // [IGNORE] The blsToExecutionChange is the first valid blsToExecutionChange received for the validator with index
   // signedBLSToExecutionChange.message.validatorIndex.
-  if (chain.opPool.hasSeenBlsToExecutionChange(blsToExecutionChange.message.validatorIndex)) {
+  if (!ignoreExists && chain.opPool.hasSeenBlsToExecutionChange(blsToExecutionChange.message.validatorIndex)) {
     throw new BlsToExecutionChangeError(GossipAction.IGNORE, {
       code: BlsToExecutionChangeErrorCode.ALREADY_EXISTS,
     });


### PR DESCRIPTION
Always process then publish a blsChange submitted through the API -- even if it's already in our local pool.
This helps UX of getting blsChanges not picked up by the network to be picked up.