### PR TITLE
Simplify INetwork Interface

### DIFF
--- a/packages/beacon-node/src/api/impl/node/index.ts
+++ b/packages/beacon-node/src/api/impl/node/index.ts
@@ -2,7 +2,6 @@ import {routes, ServerApi} from "@lodestar/api";
 import {ApiError} from "../errors.js";
 import {ApiModules} from "../types.js";
 import {ApiOptions} from "../../options.js";
-import {formatNodePeer, getRevelantConnection} from "./utils.js";
 
 export function getNodeApi(
   opts: ApiOptions,
@@ -22,28 +21,26 @@ export function getNodeApi(
           enr: enr?.encodeTxt() || "",
           discoveryAddresses,
           p2pAddresses: network.localMultiaddrs.map((m) => m.toString()),
-          metadata: network.metadata,
+          metadata: await network.getMetadata(),
         },
       };
     },
 
     async getPeer(peerIdStr) {
-      const connections = network.getConnectionsByPeer().get(peerIdStr);
-      if (!connections) {
+      const peer = await network.dumpPeer(peerIdStr);
+      if (!peer) {
         throw new ApiError(404, "Node has not seen this peer");
       }
-      return {data: formatNodePeer(peerIdStr, connections)};
+      return {data: peer};
     },
 
     async getPeers(filters) {
       const {state, direction} = filters || {};
-      const peers = Array.from(network.getConnectionsByPeer().entries())
-        .map(([peerIdStr, connections]) => formatNodePeer(peerIdStr, connections))
-        .filter(
-          (nodePeer) =>
-            (!state || state.length === 0 || state.includes(nodePeer.state)) &&
-            (!direction || direction.length === 0 || (nodePeer.direction && direction.includes(nodePeer.direction)))
-        );
+      const peers = (await network.dumpPeers()).filter(
+        (nodePeer) =>
+          (!state || state.length === 0 || state.includes(nodePeer.state)) &&
+          (!direction || direction.length === 0 || (nodePeer.direction && direction.includes(nodePeer.direction)))
+      );
 
       return {
         data: peers,
@@ -53,35 +50,19 @@ export function getNodeApi(
 
     async getPeerCount() {
       // TODO: Implement disconnect count with on-disk persistence
-      let disconnected = 0;
-      let connecting = 0;
-      let connected = 0;
-      let disconnecting = 0;
+      const data = {
+        disconnected: 0,
+        connecting: 0,
+        connected: 0,
+        disconnecting: 0,
+      };
 
-      for (const connections of network.getConnectionsByPeer().values()) {
-        const relevantConnection = getRevelantConnection(connections);
-        switch (relevantConnection?.stat.status) {
-          case "OPEN":
-            connected++;
-            break;
-          case "CLOSING":
-            disconnecting++;
-            break;
-          case "CLOSED":
-            disconnected++;
-            break;
-          default:
-            connecting++;
-        }
+      for (const peer of await network.dumpPeers()) {
+        data[peer.state]++;
       }
 
       return {
-        data: {
-          disconnected,
-          connecting,
-          connected,
-          disconnecting,
-        },
+        data,
       };
     },
 

--- a/packages/beacon-node/src/api/impl/node/utils.ts
+++ b/packages/beacon-node/src/api/impl/node/utils.ts
@@ -6,7 +6,7 @@ import {PeerStatus} from "../../../network/index.js";
  * Format a list of connections from libp2p connections manager into the API's format NodePeer
  */
 export function formatNodePeer(peerIdStr: string, connections: Connection[]): routes.node.NodePeer {
-  const conn = getRevelantConnection(connections);
+  const conn = getRelevantConnection(connections);
 
   return {
     peerId: conn ? conn.remotePeer.toString() : peerIdStr,
@@ -24,7 +24,7 @@ export function formatNodePeer(peerIdStr: string, connections: Connection[]): ro
  * - Otherwise, the first closing connection
  * - Otherwise, the first closed connection
  */
-export function getRevelantConnection(connections: Connection[]): Connection | null {
+export function getRelevantConnection(connections: Connection[]): Connection | null {
   const byStatus = new Map<PeerStatus, Connection>();
   for (const conn of connections) {
     if (conn.stat.status === "OPEN") return conn;

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -622,7 +622,7 @@ export function getValidatorApi({
     async prepareBeaconCommitteeSubnet(subscriptions) {
       notWhileSyncing();
 
-      network.prepareBeaconCommitteeSubnet(
+      await network.prepareBeaconCommitteeSubnet(
         subscriptions.map(({validatorIndex, slot, isAggregator, committeesAtSlot, committeeIndex}) => ({
           validatorIndex: validatorIndex,
           subnet: computeSubnetForCommitteesAtSlot(slot, committeesAtSlot, committeeIndex),
@@ -670,7 +670,7 @@ export function getValidatorApi({
         }
       }
 
-      network.prepareSyncCommitteeSubnets(subs);
+      await network.prepareSyncCommitteeSubnets(subs);
 
       if (metrics) {
         for (const subscription of subscriptions) {

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -22,6 +22,7 @@ import {
   GossipTypeMap,
   ValidatorFnsByType,
   GossipHandlers,
+  GossipBeaconNode,
 } from "./interface.js";
 import {getGossipSSZType, GossipTopicCache, stringifyGossipTopic, getCoreTopicsAtFork} from "./topic.js";
 import {DataTransformSnappy, fastMsgIdFn, msgIdFn, msgIdToStrFn} from "./encoding.js";
@@ -73,7 +74,7 @@ export type Eth2GossipsubOpts = {
  *
  * See https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#the-gossip-domain-gossipsub
  */
-export class Eth2Gossipsub extends GossipSub {
+export class Eth2Gossipsub extends GossipSub implements GossipBeaconNode {
   readonly jobQueues: GossipJobQueues;
   readonly scoreParams: Partial<PeerScoreParams>;
   private readonly config: BeaconConfig;

--- a/packages/beacon-node/src/network/gossip/interface.ts
+++ b/packages/beacon-node/src/network/gossip/interface.ts
@@ -122,6 +122,21 @@ export type GossipModules = {
   chain: IBeaconChain;
 };
 
+export type GossipBeaconNode = {
+  publishBeaconBlock(signedBlock: allForks.SignedBeaconBlock): Promise<void>;
+  publishSignedBeaconBlockAndBlobsSidecar(item: deneb.SignedBeaconBlockAndBlobsSidecar): Promise<void>;
+  publishBeaconAggregateAndProof(aggregateAndProof: phase0.SignedAggregateAndProof): Promise<number>;
+  publishBeaconAttestation(attestation: phase0.Attestation, subnet: number): Promise<number>;
+  publishVoluntaryExit(voluntaryExit: phase0.SignedVoluntaryExit): Promise<void>;
+  publishBlsToExecutionChange(blsToExecutionChange: capella.SignedBLSToExecutionChange): Promise<void>;
+  publishProposerSlashing(proposerSlashing: phase0.ProposerSlashing): Promise<void>;
+  publishAttesterSlashing(attesterSlashing: phase0.AttesterSlashing): Promise<void>;
+  publishSyncCommitteeSignature(signature: altair.SyncCommitteeMessage, subnet: number): Promise<void>;
+  publishContributionAndProof(contributionAndProof: altair.SignedContributionAndProof): Promise<void>;
+  publishLightClientFinalityUpdate(lightClientFinalityUpdate: allForks.LightClientFinalityUpdate): Promise<void>;
+  publishLightClientOptimisticUpdate(lightClientOptimisitcUpdate: allForks.LightClientOptimisticUpdate): Promise<void>;
+};
+
 /**
  * Contains various methods for validation of incoming gossip topic data.
  * The conditions for valid gossip topics and how they are handled are specified here:

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -5,15 +5,15 @@ import {Multiaddr} from "@multiformats/multiaddr";
 import {PeerId} from "@libp2p/interface-peer-id";
 import {ConnectionManager} from "@libp2p/interface-connection-manager";
 import {SignableENR} from "@chainsafe/discv5";
-import {phase0} from "@lodestar/types";
+import {altair, phase0} from "@lodestar/types";
+import {PeerScoreStatsDump} from "@chainsafe/libp2p-gossipsub/score";
+import {routes} from "@lodestar/api";
 import {BlockInput} from "../chain/blocks/types.js";
 import {INetworkEventBus} from "./events.js";
-import {Eth2Gossipsub} from "./gossip/index.js";
-import {MetadataController} from "./metadata.js";
-import {IPeerRpcScoreStore, PeerAction} from "./peers/index.js";
+import {GossipBeaconNode} from "./gossip/index.js";
+import {PeerAction, PeerScoreStats} from "./peers/index.js";
 import {IReqRespBeaconNode} from "./reqresp/ReqRespBeaconNode.js";
-import {IAttnetsService, SubnetsService, CommitteeSubscription} from "./subnets/index.js";
-import {Discv5Worker} from "./discv5/index.js";
+import {CommitteeSubscription} from "./subnets/index.js";
 
 export type PeerSearchOptions = {
   supportsProtocols?: string[];
@@ -21,45 +21,48 @@ export type PeerSearchOptions = {
 };
 
 export interface INetwork {
-  events: INetworkEventBus;
-  reqResp: IReqRespBeaconNode;
-  attnetsService: IAttnetsService;
-  syncnetsService: SubnetsService;
-  gossip: Eth2Gossipsub;
-  discv5(): Discv5Worker | undefined;
-  metadata: MetadataController;
-  peerRpcScores: IPeerRpcScoreStore;
   /** Our network identity */
   peerId: PeerId;
   localMultiaddrs: Multiaddr[];
+
+  events: INetworkEventBus;
+  reqResp: IReqRespBeaconNode;
+  gossip: GossipBeaconNode;
+
   getEnr(): Promise<SignableENR | undefined>;
-  getConnectionsByPeer(): Map<string, Connection[]>;
+  getMetadata(): Promise<altair.Metadata>;
   getConnectedPeers(): PeerId[];
-  hasSomeConnectedPeer(): boolean;
+  getConnectedPeerCount(): number;
 
   publishBeaconBlockMaybeBlobs(signedBlock: BlockInput): Promise<void>;
   beaconBlocksMaybeBlobsByRange(peerId: PeerId, request: phase0.BeaconBlocksByRangeRequest): Promise<BlockInput[]>;
   beaconBlocksMaybeBlobsByRoot(peerId: PeerId, request: phase0.BeaconBlocksByRootRequest): Promise<BlockInput[]>;
 
   /** Subscribe, search peers, join long-lived attnets */
-  prepareBeaconCommitteeSubnet(subscriptions: CommitteeSubscription[]): void;
+  prepareBeaconCommitteeSubnet(subscriptions: CommitteeSubscription[]): Promise<void>;
   /** Subscribe, search peers, join long-lived syncnets */
-  prepareSyncCommitteeSubnets(subscriptions: CommitteeSubscription[]): void;
-  reStatusPeers(peers: PeerId[]): void;
-  reportPeer(peer: PeerId, action: PeerAction, actionName: string): void;
+  prepareSyncCommitteeSubnets(subscriptions: CommitteeSubscription[]): Promise<void>;
+  reStatusPeers(peers: PeerId[]): Promise<void>;
+  reportPeer(peer: PeerId, action: PeerAction, actionName: string): Promise<void>;
 
   // Gossip handler
-  subscribeGossipCoreTopics(): void;
-  unsubscribeGossipCoreTopics(): void;
+  subscribeGossipCoreTopics(): Promise<void>;
+  unsubscribeGossipCoreTopics(): Promise<void>;
   isSubscribedToGossipCoreTopics(): boolean;
 
   // Service
+  metrics(): Promise<string>;
   close(): Promise<void>;
 
   // Debug
   connectToPeer(peer: PeerId, multiaddr: Multiaddr[]): Promise<void>;
   disconnectPeer(peer: PeerId): Promise<void>;
-  getAgentVersion(peerIdStr: string): string;
+  dumpPeers(): Promise<routes.lodestar.LodestarNodePeer[]>;
+  dumpPeer(peerIdStr: string): Promise<routes.lodestar.LodestarNodePeer | undefined>;
+  dumpPeerScoreStats(): Promise<PeerScoreStats>;
+  dumpGossipPeerScoreStats(): Promise<PeerScoreStatsDump>;
+  dumpGossipQueueItems(gossipType: string): Promise<routes.lodestar.GossipQueueItem[]>;
+  dumpDiscv5KadValues(): Promise<string[]>;
 }
 
 export type PeerDirection = Connection["stat"]["direction"];

--- a/packages/beacon-node/src/network/reqresp/interface.ts
+++ b/packages/beacon-node/src/network/reqresp/interface.ts
@@ -2,8 +2,6 @@ import {PeerId} from "@libp2p/interface-peer-id";
 import {allForks, altair, deneb, phase0} from "@lodestar/types";
 
 export interface IReqRespBeaconNode {
-  start(): void;
-  stop(): void;
   status(peerId: PeerId, request: phase0.Status): Promise<phase0.Status>;
   goodbye(peerId: PeerId, request: phase0.Goodbye): Promise<void>;
   ping(peerId: PeerId): Promise<phase0.Ping>;

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -265,7 +265,7 @@ export class BeaconNode {
       ? new HttpMetricsServer(opts.metrics, {
           register: metrics.register,
           getOtherMetrics: async (): Promise<string> => {
-            return (await network.discv5()?.metrics()) ?? "";
+            return network.metrics();
           },
           logger: logger.child({module: LoggerModule.metrics}),
         })

--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -37,7 +37,7 @@ export async function runNodeNotifier(modules: NodeNotifierModules): Promise<voi
 
   try {
     while (!signal.aborted) {
-      const connectedPeerCount = network.getConnectedPeers().length;
+      const connectedPeerCount = network.getConnectedPeerCount();
 
       if (connectedPeerCount <= WARN_PEER_COUNT) {
         if (!hasLowPeerCount) {

--- a/packages/beacon-node/src/sync/backfill/backfill.ts
+++ b/packages/beacon-node/src/sync/backfill/backfill.ts
@@ -474,7 +474,7 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
 
             // falls through
             case BackfillSyncErrorCode.INVALID_SIGNATURE:
-              this.network.reportPeer(peer, PeerAction.LowToleranceError, "BadSyncBlocks");
+              await this.network.reportPeer(peer, PeerAction.LowToleranceError, "BadSyncBlocks");
           }
         }
       } finally {

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -203,7 +203,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
 
   /** Convenience method for `SyncChain` */
   private reportPeer: SyncChainFns["reportPeer"] = (peer, action, actionName) => {
-    this.network.reportPeer(peer, action, actionName);
+    this.network.reportPeer(peer, action, actionName).catch((e) => this.logger.error("Error reporting peer", {}, e));
   };
 
   /** Convenience method for `SyncChain` */
@@ -275,7 +275,9 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
         });
 
         // Re-status peers from successful chain. Potentially trigger a Head sync
-        this.network.reStatusPeers(syncChain.getPeers());
+        this.network
+          .reStatusPeers(syncChain.getPeers())
+          .catch((e) => this.logger.error("Error resyncing peers", {}, e));
       }
     }
 

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -318,7 +318,9 @@ export class UnknownBlockSync {
       for (const peerIdStr of block.peerIdStrs) {
         // TODO: Refactor peerRpcScores to work with peerIdStr only
         const peer = peerIdFromString(peerIdStr);
-        this.network.reportPeer(peer, PeerAction.LowToleranceError, "BadBlockByRoot");
+        this.network.reportPeer(peer, PeerAction.LowToleranceError, "BadBlockByRoot").catch((e) => {
+          this.logger.error("Error reporting peer", {}, e);
+        });
       }
     }
 

--- a/packages/beacon-node/test/e2e/network/gossipsub.test.ts
+++ b/packages/beacon-node/test/e2e/network/gossipsub.test.ts
@@ -130,8 +130,8 @@ describe("gossipsub", function () {
     expect(Array.from(netA.getConnectionsByPeer().values()).length).to.equal(1);
     expect(Array.from(netB.getConnectionsByPeer().values()).length).to.equal(1);
 
-    netA.subscribeGossipCoreTopics();
-    netB.subscribeGossipCoreTopics();
+    await netA.subscribeGossipCoreTopics();
+    await netB.subscribeGossipCoreTopics();
 
     // Wait to have a peer connected to a topic
     while (!controller.signal.aborted) {
@@ -162,8 +162,8 @@ describe("gossipsub", function () {
     expect(Array.from(netA.getConnectionsByPeer().values()).length).to.equal(1);
     expect(Array.from(netB.getConnectionsByPeer().values()).length).to.equal(1);
 
-    netA.subscribeGossipCoreTopics();
-    netB.subscribeGossipCoreTopics();
+    await netA.subscribeGossipCoreTopics();
+    await netB.subscribeGossipCoreTopics();
 
     // Wait to have a peer connected to a topic
     while (!controller.signal.aborted) {
@@ -209,8 +209,8 @@ describe("gossipsub", function () {
     expect(Array.from(netA.getConnectionsByPeer().values()).length).to.equal(1);
     expect(Array.from(netB.getConnectionsByPeer().values()).length).to.equal(1);
 
-    netA.subscribeGossipCoreTopics();
-    netB.subscribeGossipCoreTopics();
+    await netA.subscribeGossipCoreTopics();
+    await netB.subscribeGossipCoreTopics();
 
     // Wait to have a peer connected to a topic
     while (!controller.signal.aborted) {
@@ -244,8 +244,8 @@ describe("gossipsub", function () {
     expect(Array.from(netA.getConnectionsByPeer().values()).length).to.equal(1);
     expect(Array.from(netB.getConnectionsByPeer().values()).length).to.equal(1);
 
-    netA.subscribeGossipCoreTopics();
-    netB.subscribeGossipCoreTopics();
+    await netA.subscribeGossipCoreTopics();
+    await netB.subscribeGossipCoreTopics();
 
     // Wait to have a peer connected to a topic
     while (!controller.signal.aborted) {
@@ -280,8 +280,8 @@ describe("gossipsub", function () {
     expect(Array.from(netA.getConnectionsByPeer().values()).length).to.equal(1);
     expect(Array.from(netB.getConnectionsByPeer().values()).length).to.equal(1);
 
-    netA.subscribeGossipCoreTopics();
-    netB.subscribeGossipCoreTopics();
+    await netA.subscribeGossipCoreTopics();
+    await netB.subscribeGossipCoreTopics();
 
     // Wait to have a peer connected to a topic
     while (!controller.signal.aborted) {

--- a/packages/beacon-node/test/e2e/network/network.test.ts
+++ b/packages/beacon-node/test/e2e/network/network.test.ts
@@ -158,9 +158,9 @@ describe("network", function () {
       createTestNode("B"),
     ]);
 
-    if (!netBootnode.discv5()) throw Error("discv5 in bootnode is not enabled");
-    if (!netA.discv5()) throw Error("discv5 in A is not enabled");
-    if (!netB.discv5()) throw Error("discv5 in B is not enabled");
+    if (!netBootnode.discv5) throw Error("discv5 in bootnode is not enabled");
+    if (!netA.discv5) throw Error("discv5 in A is not enabled");
+    if (!netB.discv5) throw Error("discv5 in B is not enabled");
 
     const subscription: CommitteeSubscription = {
       validatorIndex: 2000,
@@ -173,7 +173,7 @@ describe("network", function () {
     const connected = Promise.all([onPeerConnect(netA), onPeerConnect(netB)]);
 
     // Add subnets to B ENR
-    await netB.discv5()?.setEnrValue(ENRKey.attnets, ssz.phase0.AttestationSubnets.serialize(netB.metadata.attnets));
+    await netB.discv5?.setEnrValue(ENRKey.attnets, ssz.phase0.AttestationSubnets.serialize(netB.metadata.attnets));
 
     // A knows about bootnode
     // TODO discv5 worker thread no longer allows adding an ENR
@@ -192,7 +192,7 @@ describe("network", function () {
     //   return [enrB];
     // };
 
-    netA.prepareBeaconCommitteeSubnet([subscription]);
+    await netA.prepareBeaconCommitteeSubnet([subscription]);
     await connected;
 
     expect(netA.getConnectionsByPeer().has(netB.peerId.toString())).to.be.equal(
@@ -229,9 +229,9 @@ describe("network", function () {
     const {network: netA} = await createTestNode("A");
 
     expect(netA.gossip.getTopics().length).to.equal(0);
-    netA.subscribeGossipCoreTopics();
+    await netA.subscribeGossipCoreTopics();
     expect(netA.gossip.getTopics().length).to.equal(13);
-    netA.unsubscribeGossipCoreTopics();
+    await netA.unsubscribeGossipCoreTopics();
     expect(netA.gossip.getTopics().length).to.equal(0);
     await netA.close();
   });

--- a/packages/beacon-node/test/unit/api/impl/node/node.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/node/node.test.ts
@@ -1,4 +1,3 @@
-import {Connection} from "@libp2p/interface-connection";
 import sinon, {SinonStubbedInstance} from "sinon";
 import {PeerId} from "@libp2p/interface-peer-id";
 import {expect} from "chai";
@@ -6,14 +5,12 @@ import {multiaddr} from "@multiformats/multiaddr";
 import {createSecp256k1PeerId} from "@libp2p/peer-id-factory";
 import {createKeypairFromPeerId, SignableENR} from "@chainsafe/discv5";
 import {BitArray} from "@chainsafe/ssz";
-import {altair} from "@lodestar/types";
 import {routes} from "@lodestar/api";
 import {BeaconSync, IBeaconSync} from "../../../../../src/sync/index.js";
 import {INetwork, Network} from "../../../../../src/network/index.js";
-import {MetadataController} from "../../../../../src/network/metadata.js";
 import {defaultApiOptions} from "../../../../../src/api/options.js";
 import {getNodeApi} from "../../../../../src/api/impl/node/index.js";
-import {libp2pConnection} from "../../../../utils/node/p2p.js";
+import {lodestarNodePeer} from "../../../../utils/node/p2p.js";
 
 type PeerSummary = {
   direction: string | null;
@@ -52,15 +49,13 @@ describe("node api implementation", function () {
       const enr = SignableENR.createV4(keypair);
       enr.setLocationMultiaddr(multiaddr("/ip4/127.0.0.1/tcp/36001"));
       networkStub.getEnr.returns(Promise.resolve(enr));
-      networkStub.metadata = {
-        get json(): altair.Metadata {
-          return {
-            attnets: BitArray.fromBoolArray([true]),
-            syncnets: BitArray.fromBitLen(0),
-            seqNumber: BigInt(1),
-          };
-        },
-      } as MetadataController;
+      networkStub.getMetadata.returns(
+        Promise.resolve({
+          attnets: BitArray.fromBoolArray([true]),
+          syncnets: BitArray.fromBitLen(0),
+          seqNumber: BigInt(1),
+        })
+      );
       const {data: identity} = await api.getNetworkIdentity();
       expect(identity.peerId.startsWith("16")).to.equal(true);
       expect(identity.enr.startsWith("enr:-")).to.equal(true);
@@ -88,23 +83,13 @@ describe("node api implementation", function () {
     });
 
     it("it should return peer count", async function () {
-      const connectionsByPeer = new Map<string, Connection[]>([
-        [peer1.toString(), [libp2pConnection(peer1, "OPEN", "outbound")]],
-        [
-          peer2.toString(),
-          [libp2pConnection(peer2, "CLOSING", "inbound"), libp2pConnection(peer2, "CLOSING", "inbound")],
-        ],
-        [
-          peer3.toString(),
-          [
-            libp2pConnection(peer3, "CLOSED", "inbound"),
-            libp2pConnection(peer3, "CLOSED", "inbound"),
-            libp2pConnection(peer3, "CLOSED", "inbound"),
-          ],
-        ],
-      ]);
+      const peers = [
+        lodestarNodePeer(peer1, "connected", "outbound"),
+        lodestarNodePeer(peer2, "disconnecting", "inbound"),
+        lodestarNodePeer(peer3, "disconnected", "inbound"),
+      ];
 
-      networkStub.getConnectionsByPeer.returns(connectionsByPeer);
+      networkStub.dumpPeers.returns(Promise.resolve(peers));
 
       const {data: count} = await api.getPeerCount();
       expect(count).to.be.deep.equal(
@@ -128,60 +113,33 @@ describe("node api implementation", function () {
     });
 
     it("should return connected and disconnecting peers", async function () {
-      const connectionsByPeer = new Map<string, Connection[]>([
-        [peer1.toString(), [libp2pConnection(peer1, "OPEN", "outbound")]],
-        [peer2.toString(), [libp2pConnection(peer2, "CLOSING", "inbound")]],
-      ]);
-      networkStub.getConnectionsByPeer.returns(connectionsByPeer);
+      const allPeers = [
+        lodestarNodePeer(peer1, "connected", "outbound"),
+        lodestarNodePeer(peer2, "disconnecting", "inbound"),
+      ];
+      networkStub.dumpPeers.returns(Promise.resolve(allPeers));
 
       const {data: peers} = await api.getPeers();
       expect(peers.length).to.equal(2);
       expect(peers.map(toPeerSummary)).to.be.deep.equal([
-        {direction: "outbound", state: "connected", hasP2pAddress: true, hasPeerId: true},
-        {direction: "inbound", state: "disconnecting", hasPeerId: true, hasP2pAddress: true},
+        {direction: "outbound", state: "connected", hasP2pAddress: false, hasPeerId: true},
+        {direction: "inbound", state: "disconnecting", hasPeerId: true, hasP2pAddress: false},
       ]);
     });
 
     it("should return disconnected peers", async function () {
-      const connectionsByPeer = new Map<string, Connection[]>([
-        [peer1.toString(), [libp2pConnection(peer1, "CLOSED", "outbound")]],
-        [peer2.toString(), []], // peer2 has no connections in the connection manager
-      ]);
-      networkStub.getConnectionsByPeer.returns(connectionsByPeer);
+      const allPeers = [
+        lodestarNodePeer(peer1, "disconnected", "outbound"),
+        lodestarNodePeer(peer2, "disconnected", null),
+      ];
+      networkStub.dumpPeers.returns(Promise.resolve(allPeers));
 
       const {data: peers} = await api.getPeers();
       // expect(peers[0].enr).not.empty;
       expect(peers.map(toPeerSummary)).to.be.deep.equal([
-        {direction: "outbound", state: "disconnected", hasPeerId: true, hasP2pAddress: true},
+        {direction: "outbound", state: "disconnected", hasPeerId: true, hasP2pAddress: false},
         {direction: null, state: "disconnected", hasPeerId: true, hasP2pAddress: false},
       ]);
-    });
-  });
-
-  describe("getPeer", function () {
-    it("success", async function () {
-      const peer1 = await createSecp256k1PeerId();
-      const peer2 = await createSecp256k1PeerId();
-      const connectionsByPeer = new Map<string, Connection[]>([
-        [peer1.toString(), [libp2pConnection(peer1, "OPEN", "outbound")]],
-        [peer2.toString(), [libp2pConnection(peer2, "CLOSING", "inbound")]],
-      ]);
-      networkStub.getConnectionsByPeer.returns(connectionsByPeer);
-
-      const {data: peer} = await api.getPeer(peer1.toString());
-      if (peer === undefined) throw Error("getPeer returned no peer");
-      expect(peer.peerId).to.equal(peer1.toString());
-      expect(peer.lastSeenP2pAddress).not.empty;
-      expect(peer.peerId).not.empty;
-      // expect(peers[0].enr).not.empty;
-      expect(peer.direction).to.equal("outbound");
-      expect(peer.state).to.equal("connected");
-    });
-
-    it("peer not found", async function () {
-      const connectionsByPeer = new Map<string, Connection[]>();
-      networkStub.getConnectionsByPeer.returns(connectionsByPeer);
-      await expect(api.getPeer("not existent")).to.be.rejectedWith();
     });
   });
 

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -57,7 +57,7 @@ describe("sync / UnknownBlockSync", () => {
             .filter(notNullish)
             .map((block) => getBlockInput.preDeneb(config, block)),
 
-        reportPeer: (peerId, action, actionName) => reportPeerResolveFn([peerId, action, actionName]),
+        reportPeer: async (peerId, action, actionName) => reportPeerResolveFn([peerId, action, actionName]),
       };
 
       const forkChoiceKnownRoots = new Set([blockRootHex0]);

--- a/packages/beacon-node/test/utils/node/p2p.ts
+++ b/packages/beacon-node/test/utils/node/p2p.ts
@@ -1,15 +1,18 @@
-import {Connection} from "@libp2p/interface-connection";
 import {PeerId} from "@libp2p/interface-peer-id";
-import {multiaddr} from "@multiformats/multiaddr";
-import {PeerStatus, PeerDirection} from "../../../src/network/index.js";
+import {routes} from "@lodestar/api";
+import {PeerDirection} from "../../../src/network/index.js";
 
-export function libp2pConnection(peer: PeerId, status: PeerStatus, direction: PeerDirection): Connection {
+export function lodestarNodePeer(
+  peer: PeerId,
+  state: routes.node.PeerState,
+  direction: PeerDirection | null
+): routes.lodestar.LodestarNodePeer {
   return {
-    remoteAddr: multiaddr(),
-    stat: {
-      status,
-      direction,
-    },
-    remotePeer: peer,
-  } as Connection;
+    peerId: peer.toString(),
+    state,
+    direction,
+    enr: "",
+    lastSeenP2pAddress: "",
+    agentVersion: "",
+  };
 }


### PR DESCRIPTION
**Motivation**

Another step towards #4856 
The `INetwork` class should be simplified in preparation for moving it to a worker.


**Description**

- remove unnecessary methods/properties
  - many properties were internal details, unused, or factored away
- replace large interfaces with small interfaces
  - create a simplified gossipsub interface, `GossipsubBeaconNode`
- most methods become async/return promises
  - things that will be easy to retain outside the worker can stay sync
- avoid reaching into deep internals in favor of dumpXXX methods
