### PR TITLE
Fix client monitoring rate limit errors

### DIFF
--- a/docs/usage/client-monitoring.md
+++ b/docs/usage/client-monitoring.md
@@ -40,9 +40,7 @@ It is also possible to print out the data sent to the remote service by enabling
 ### Monitoring interval
 
 It is possible to adjust the interval between sending client stats to the remote service by setting the `--monitoring.interval` flag.
-It takes an integer value in milliseconds, the default is `62000` which means data is sent approximately once a minute.
-The extra 2 seconds are added to avoid rate limit errors when using *beaconcha.in* as they are currently really strict
-and minor delays in the previous request can cause the following request to fail.
+It takes an integer value in milliseconds, the default is `60000` which means data is sent once a minute.
 
 For example, setting an interval of `300000` would mean the data is only sent every 5 minutes.
 

--- a/packages/beacon-node/src/monitoring/options.ts
+++ b/packages/beacon-node/src/monitoring/options.ts
@@ -13,9 +13,7 @@ export type MonitoringOptions = {
 
 export const defaultMonitoringOptions: Required<MonitoringOptions> = {
   endpoint: "",
-  // default interval should be once a minute
-  // but need to add 2 seconds to avoid rate limit errors
-  interval: 62_000,
+  interval: 60_000,
   initialDelay: 30_000,
   requestTimeout: 10_000,
   collectSystemStats: true,

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -18,7 +18,7 @@ export const validatorMetricsDefaultOptions = {
 };
 
 export const validatorMonitoringDefaultOptions = {
-  interval: 62_000,
+  interval: 60_000,
   initialDelay: 30_000,
   requestTimeout: 10_000,
   collectSystemStats: false,

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -54,7 +54,7 @@ describe("options / beaconNodeOptions", () => {
       "metrics.address": "0.0.0.0",
 
       "monitoring.endpoint": "https://beaconcha.in/api/v1/client/metrics?apikey=secretKey&machine=machine1",
-      "monitoring.interval": 62000,
+      "monitoring.interval": 60000,
       "monitoring.initialDelay": 30000,
       "monitoring.requestTimeout": 10000,
       "monitoring.collectSystemStats": true,
@@ -142,7 +142,7 @@ describe("options / beaconNodeOptions", () => {
       },
       monitoring: {
         endpoint: "https://beaconcha.in/api/v1/client/metrics?apikey=secretKey&machine=machine1",
-        interval: 62000,
+        interval: 60000,
         initialDelay: 30000,
         requestTimeout: 10000,
         collectSystemStats: true,


### PR DESCRIPTION
**Motivation**

Follow up change for #5037 which fixes beaconcha.in rate limit errors. 

**Description**

The current implementation might send the next request too early if the previous one took a bit longer due to the nature of how `setInterval` works, it does not wait for async functions to finish.

This change ensure we are only starting the next interval after the previous request has finished.

Reverts changes done in [this commit](https://github.com/ChainSafe/lodestar/pull/5183/commits/286a1cf3d5075e9de84b3a119be2f2bc89e35d58) as setting interval to 62 seconds did not actually fix the issue just made it less likely to happen.

We can safely set the interval to 60 seconds now as we will only start the next interval after we the get previous response which means the sent interval might vary a bit (usually just a few milliseconds) depending on the response times of the remote service.

