### PR TITLE
Improve approximate db size instrumentation

### DIFF
--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -1,9 +1,49 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "8.5.16"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -21,8 +61,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 35,
-  "iteration": 1674481074076,
+  "id": null,
   "links": [
     {
       "asDropdown": true,
@@ -43,6 +82,10 @@
   "panels": [
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -51,16 +94,31 @@
       },
       "id": 12,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "VM Stats",
       "type": "row"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -119,7 +177,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
@@ -155,12 +214,18 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -230,7 +295,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
@@ -267,12 +333,18 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -331,7 +403,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
@@ -404,12 +477,18 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -479,7 +558,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
@@ -504,12 +584,18 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -568,7 +654,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
@@ -578,6 +665,10 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "nodejs_active_requests",
           "interval": "",
           "legendFormat": "{{type}}",
@@ -588,12 +679,18 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -665,8 +762,9 @@
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
-          "placement": "bottom"
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
         },
         "tooltip": {
           "mode": "multi",
@@ -676,6 +774,10 @@
       "pluginVersion": "8.4.0-beta1",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "rate(process_cpu_user_seconds_total[$rate_interval])",
           "interval": "",
           "legendFormat": "",
@@ -686,12 +788,18 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -725,8 +833,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -750,7 +857,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "multi",
@@ -760,6 +868,10 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "nodejs_active_handles",
           "interval": "",
           "legendFormat": "{{type}}",
@@ -770,12 +882,18 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -809,8 +927,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -849,8 +966,9 @@
         "graph": {},
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
-          "placement": "bottom"
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
         },
         "tooltip": {
           "mode": "multi",
@@ -860,6 +978,10 @@
       "pluginVersion": "7.4.5",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "expr": "nodejs_eventloop_lag_seconds",
           "interval": "",
           "legendFormat": "event loop lag",
@@ -870,12 +992,18 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -908,8 +1036,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -931,7 +1058,8 @@
         "legend": {
           "calcs": [],
           "displayMode": "list",
-          "placement": "bottom"
+          "placement": "bottom",
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -940,6 +1068,10 @@
       },
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "exemplar": false,
           "expr": "rate(lodestar_unhandled_promise_rejections_total[$rate_interval])",
           "interval": "",
@@ -952,6 +1084,10 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -961,6 +1097,10 @@
       "id": 104,
       "panels": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1016,15 +1156,16 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 1
+            "y": 9
           },
           "id": 102,
           "options": {
             "graph": {},
             "legend": {
               "calcs": [],
-              "displayMode": "hidden",
-              "placement": "bottom"
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
             },
             "tooltip": {
               "mode": "multi",
@@ -1034,6 +1175,10 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "expr": "(time() - lodestar_genesis_time) / 12 - lodestar_clock_slot",
               "hide": false,
               "interval": "",
@@ -1045,6 +1190,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1126,15 +1275,16 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 1
+            "y": 9
           },
           "id": 172,
           "options": {
             "graph": {},
             "legend": {
               "calcs": [],
-              "displayMode": "hidden",
-              "placement": "bottom"
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
             },
             "tooltip": {
               "mode": "multi",
@@ -1144,6 +1294,10 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
               "expr": "lodestar_sync_status",
               "format": "time_series",
@@ -1157,6 +1311,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1212,15 +1370,16 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 7
+            "y": 15
           },
           "id": 171,
           "options": {
             "graph": {},
             "legend": {
               "calcs": [],
-              "displayMode": "hidden",
-              "placement": "bottom"
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
             },
             "tooltip": {
               "mode": "multi",
@@ -1230,6 +1389,10 @@
           "pluginVersion": "7.4.5",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
               "expr": "lodestar_clock_slot - beacon_head_slot",
               "hide": false,
@@ -1242,11 +1405,15 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "gridPos": {
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 7
+            "y": 15
           },
           "id": 99,
           "options": {
@@ -1256,6 +1423,10 @@
           "pluginVersion": "8.4.2",
           "targets": [
             {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
               "exemplar": false,
               "expr": "lodestar_sync_status",
               "format": "time_series",
@@ -1269,11 +1440,24 @@
           "type": "text"
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Node status",
       "type": "row"
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1283,6 +1467,10 @@
       "id": 367,
       "panels": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "CPU usage by user (not system) per core",
           "fieldConfig": {
             "defaults": {
@@ -1338,14 +1526,15 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 3
+            "y": 11
           },
           "id": 353,
           "options": {
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "single",
@@ -1369,6 +1558,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1424,14 +1617,15 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 3
+            "y": 11
           },
           "id": 355,
           "options": {
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "single",
@@ -1455,6 +1649,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1509,14 +1707,15 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 11
+            "y": 19
           },
           "id": 357,
           "options": {
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "single",
@@ -1552,6 +1751,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "description": "Basic memory usage",
           "fieldConfig": {
             "defaults": {
@@ -1977,7 +2180,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 11
+            "y": 19
           },
           "id": 359,
           "links": [],
@@ -1985,7 +2188,8 @@
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "multi",
@@ -2071,6 +2275,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2125,14 +2333,15 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 27
           },
           "id": 361,
           "options": {
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "single",
@@ -2168,6 +2377,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2239,14 +2452,15 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 27
           },
           "id": 363,
           "options": {
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "multi",
@@ -2282,6 +2496,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2336,14 +2554,15 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 35
           },
           "id": 365,
           "options": {
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "single",
@@ -2379,11 +2598,24 @@
           "type": "timeseries"
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Node exporter",
       "type": "row"
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2393,6 +2625,10 @@
       "id": 46,
       "panels": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2448,7 +2684,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 35
           },
           "id": 48,
           "options": {
@@ -2456,7 +2692,8 @@
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "multi",
@@ -2494,6 +2731,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2580,7 +2821,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27
+            "y": 35
           },
           "id": 50,
           "options": {
@@ -2588,7 +2829,8 @@
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "multi",
@@ -2613,11 +2855,24 @@
           "type": "timeseries"
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Scrape stats",
       "type": "row"
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2627,12 +2882,18 @@
       "id": 527,
       "panels": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
@@ -2666,8 +2927,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2683,7 +2943,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 53
           },
           "id": 529,
           "options": {
@@ -2691,7 +2951,8 @@
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "multi",
@@ -2717,12 +2978,18 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
@@ -2756,8 +3023,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2834,7 +3100,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 53
           },
           "id": 531,
           "options": {
@@ -2842,7 +3108,8 @@
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "multi",
@@ -2868,11 +3135,24 @@
           "type": "timeseries"
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Monitoring",
       "type": "row"
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2882,6 +3162,10 @@
       "id": 86,
       "panels": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2936,14 +3220,15 @@
             "h": 11,
             "w": 12,
             "x": 0,
-            "y": 5
+            "y": 13
           },
           "id": 84,
           "options": {
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "multi",
@@ -2969,6 +3254,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3024,14 +3313,15 @@
             "h": 11,
             "w": 12,
             "x": 12,
-            "y": 5
+            "y": 13
           },
           "id": 87,
           "options": {
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "multi",
@@ -3056,6 +3346,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3110,14 +3404,15 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 16
+            "y": 24
           },
           "id": 516,
           "options": {
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "single",
@@ -3153,6 +3448,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3206,14 +3505,15 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 16
+            "y": 24
           },
           "id": 515,
           "options": {
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "single",
@@ -3237,6 +3537,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3290,14 +3594,15 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 32
           },
           "id": 513,
           "options": {
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "single",
@@ -3321,6 +3626,10 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -3374,14 +3683,15 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 32
           },
           "id": 517,
           "options": {
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "single",
@@ -3404,11 +3714,24 @@
           "type": "timeseries"
         }
       ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "REST API",
       "type": "row"
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3418,12 +3741,18 @@
       "id": 164,
       "panels": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
@@ -3474,7 +3803,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 47
           },
           "id": 160,
           "options": {
@@ -3482,7 +3811,8 @@
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "multi",
@@ -3507,12 +3837,18 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
@@ -3563,7 +3899,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 47
           },
           "id": 162,
           "options": {
@@ -3571,7 +3907,8 @@
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "multi",
@@ -3596,12 +3933,18 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
@@ -3652,7 +3995,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 37
+            "y": 56
           },
           "id": 481,
           "options": {
@@ -3660,7 +4003,8 @@
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "multi",
@@ -3685,12 +4029,18 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
@@ -3741,7 +4091,7 @@
             "h": 9,
             "w": 12,
             "x": 12,
-            "y": 37
+            "y": 56
           },
           "id": 480,
           "options": {
@@ -3749,7 +4099,8 @@
             "legend": {
               "calcs": [],
               "displayMode": "list",
-              "placement": "bottom"
+              "placement": "bottom",
+              "showLegend": true
             },
             "tooltip": {
               "mode": "multi",
@@ -3774,12 +4125,18 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
@@ -3812,8 +4169,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3854,14 +4210,15 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 65
           },
           "id": 527,
           "options": {
             "legend": {
               "calcs": [],
-              "displayMode": "hidden",
-              "placement": "bottom"
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
             },
             "tooltip": {
               "mode": "multi",
@@ -3885,12 +4242,18 @@
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
@@ -3923,8 +4286,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -3965,14 +4327,15 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 65
           },
           "id": 529,
           "options": {
             "legend": {
               "calcs": [],
-              "displayMode": "hidden",
-              "placement": "bottom"
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
             },
             "tooltip": {
               "mode": "multi",
@@ -3994,6 +4357,125 @@
           ],
           "title": "DB Size - Validator",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "opacity",
+                "hideFrom": {
+                  "graph": false,
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 73
+          },
+          "id": 533,
+          "options": {
+            "graph": {},
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "7.4.5",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "rate(lodestar_db_approximate_size_time_seconds_sum[$rate_interval])\r\n/\r\nrate(lodestar_db_approximate_size_time_seconds_count[$rate_interval])",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{job}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "rate(validator_db_approximate_size_time_seconds_sum[$rate_interval])\r\n/\r\nrate(validator_db_approximate_size_time_seconds_count[$rate_interval])",
+              "hide": false,
+              "legendFormat": "{{job}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Approximate db size duration",
+          "type": "timeseries"
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "refId": "A"
         }
       ],
       "title": "DB disk",
@@ -4001,7 +4483,8 @@
     }
   ],
   "refresh": "10s",
-  "schemaVersion": 35,
+  "revision": 1,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [
     "lodestar"
@@ -4143,6 +4626,6 @@
   "timezone": "utc",
   "title": "Lodestar - VM + host",
   "uid": "lodestar_vm_host",
-  "version": 6,
+  "version": 7,
   "weekStart": "monday"
 }

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1357,6 +1357,11 @@ export function createLodestarMetrics(
         name: "lodestar_db_size_bytes_total",
         help: "Approximate number of bytes of file system space used by db",
       }),
+      dbApproximateSizeTime: register.histogram({
+        name: "lodestar_db_approximate_size_time_seconds",
+        help: "Time to approximate db size in seconds",
+        buckets: [0.0001, 0.001, 0.01, 0.1, 1],
+      }),
     },
   };
 }

--- a/packages/beacon-node/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/beacon-node/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -43,7 +43,7 @@ describe.skip("eth1 / Eth1Provider", function () {
     // Nuke DB to make sure it's empty
     await promisify<string>(leveldown.destroy)(dbLocation);
 
-    dbController = new LevelDbController({name: dbLocation}, {});
+    dbController = new LevelDbController({name: dbLocation}, {logger});
     db = new BeaconDb({
       config,
       controller: dbController,

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -62,7 +62,7 @@ describe.skip("verify+import blocks - range sync perf test", () => {
 
   let db: BeaconDb;
   before(async () => {
-    db = new BeaconDb({config, controller: new LevelDbController({name: ".tmpdb"}, {})});
+    db = new BeaconDb({config, controller: new LevelDbController({name: ".tmpdb"}, {logger})});
     await db.start();
   });
   after(async () => {

--- a/packages/beacon-node/test/unit/db/api/repositories/blockArchive.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repositories/blockArchive.test.ts
@@ -7,6 +7,7 @@ import {intToBytes} from "@lodestar/utils";
 import {LevelDbController, Bucket, encodeKey} from "@lodestar/db";
 
 import {BlockArchiveRepository} from "../../../../../src/db/repositories/index.js";
+import {testLogger} from "../../../../utils/logger.js";
 
 describe("block archive repository", function () {
   const testDir = "./.tmp";
@@ -14,7 +15,7 @@ describe("block archive repository", function () {
   let controller: LevelDbController;
 
   beforeEach(async function () {
-    controller = new LevelDbController({name: testDir}, {});
+    controller = new LevelDbController({name: testDir}, {logger: testLogger()});
     blockArchive = new BlockArchiveRepository(config, controller);
     await controller.start();
   });

--- a/packages/beacon-node/test/utils/db.ts
+++ b/packages/beacon-node/test/utils/db.ts
@@ -2,6 +2,7 @@ import child_process from "node:child_process";
 import {FilterOptions, LevelDbController} from "@lodestar/db";
 import {ChainForkConfig} from "@lodestar/config";
 import {BeaconDb} from "../../src/index.js";
+import {testLogger} from "./logger.js";
 
 export const TEMP_DB_LOCATION = ".tmpdb";
 
@@ -11,7 +12,7 @@ export async function startTmpBeaconDb(config: ChainForkConfig): Promise<BeaconD
 
   const db = new BeaconDb({
     config,
-    controller: new LevelDbController({name: TEMP_DB_LOCATION}, {}),
+    controller: new LevelDbController({name: TEMP_DB_LOCATION}, {logger: testLogger()}),
   });
   await db.start();
 

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -39,7 +39,7 @@ export async function getDevBeaconNode(
   const config = createChainForkConfig({...minimalConfig, ...params});
   logger = logger ?? testLogger();
 
-  const db = new BeaconDb({config, controller: new LevelDbController({name: tmpDir.name}, {})});
+  const db = new BeaconDb({config, controller: new LevelDbController({name: tmpDir.name}, {logger})});
   await db.start();
 
   options = deepmerge(

--- a/packages/beacon-node/test/utils/node/validator.ts
+++ b/packages/beacon-node/test/utils/node/validator.ts
@@ -40,7 +40,7 @@ export async function getAndInitDevValidators({
     const tmpDir = tmp.dirSync({unsafeCleanup: true});
     const dbOps = {
       config: node.config,
-      controller: new LevelDbController({name: tmpDir.name}, {}),
+      controller: new LevelDbController({name: tmpDir.name}, {logger}),
     };
     const slashingProtection = new SlashingProtection(dbOps);
 

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -65,7 +65,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
   }
   const db = new BeaconDb({
     config,
-    controller: new LevelDbController(options.db, {metrics: null}),
+    controller: new LevelDbController(options.db, {metrics: null, logger}),
   });
 
   await db.start();

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -100,7 +100,7 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
 
   const dbOps = {
     config,
-    controller: new LevelDbController({name: dbPath}, {metrics: null}),
+    controller: new LevelDbController({name: dbPath}, {metrics: null, logger}),
   };
   onGracefulShutdownCbs.push(() => dbOps.controller.stop());
   await dbOps.controller.start();

--- a/packages/cli/src/cmds/validator/slashingProtection/export.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/export.ts
@@ -52,7 +52,7 @@ export const exportCmd: CliCommand<
     const formatVersion: InterchangeFormatVersion = {version: "4", format: "complete"};
     logger.info("Exporting the slashing protection logs", {...formatVersion, dbPath});
 
-    const {slashingProtection, metadata} = getSlashingProtection(args, network);
+    const {slashingProtection, metadata} = getSlashingProtection(args, network, logger);
 
     // When exporting validator DB should already have genesisValidatorsRoot persisted.
     // For legacy node and general fallback, fetch from:

--- a/packages/cli/src/cmds/validator/slashingProtection/import.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/import.ts
@@ -51,7 +51,7 @@ export const importCmd: CliCommand<
 
     logger.info("Importing the slashing protection logs", {dbPath});
 
-    const {slashingProtection, metadata} = getSlashingProtection(args, network);
+    const {slashingProtection, metadata} = getSlashingProtection(args, network, logger);
 
     // Fetch genesisValidatorsRoot from:
     // - existing cached in validator DB

--- a/packages/cli/src/cmds/validator/slashingProtection/utils.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/utils.ts
@@ -1,6 +1,6 @@
 import {Root} from "@lodestar/types";
 import {ApiError, getClient} from "@lodestar/api";
-import {fromHex} from "@lodestar/utils";
+import {fromHex, Logger} from "@lodestar/utils";
 import {genesisData, NetworkName} from "@lodestar/config/networks";
 import {SlashingProtection, MetaDataRepository} from "@lodestar/validator";
 import {DatabaseApiOptions, LevelDbController} from "@lodestar/db";
@@ -14,7 +14,8 @@ import {ISlashingProtectionArgs} from "./options.js";
  */
 export function getSlashingProtection(
   args: GlobalArgs,
-  network: string
+  network: string,
+  logger: Logger
 ): {slashingProtection: SlashingProtection; metadata: MetaDataRepository} {
   const validatorPaths = getValidatorPaths(args, network);
   const dbPath = validatorPaths.validatorsDbDir;
@@ -22,7 +23,7 @@ export function getSlashingProtection(
 
   const dbOpts: DatabaseApiOptions = {
     config,
-    controller: new LevelDbController({name: dbPath}, {}),
+    controller: new LevelDbController({name: dbPath}, {logger}),
   };
 
   return {

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -1,5 +1,6 @@
 import {Level} from "level";
 import type {ClassicLevel} from "classic-level";
+import {Logger} from "@lodestar/utils";
 import {DbReqOpts, DatabaseController, DatabaseOptions, FilterOptions, KeyValue} from "./interface.js";
 import {LevelDbControllerMetrics} from "./metrics.js";
 
@@ -15,6 +16,7 @@ export interface LevelDBOptions extends DatabaseOptions {
 }
 
 export type LevelDbControllerModules = {
+  logger: Logger;
   metrics?: LevelDbControllerMetrics | null;
 };
 
@@ -31,11 +33,13 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
   private db: Level<Uint8Array, Uint8Array>;
 
   private readonly opts: LevelDBOptions;
+  private readonly logger: Logger;
   private metrics: LevelDbControllerMetrics | null;
   private dbSizeMetricInterval?: NodeJS.Timer;
 
-  constructor(opts: LevelDBOptions, {metrics}: LevelDbControllerModules) {
+  constructor(opts: LevelDBOptions, {metrics, logger}: LevelDbControllerModules) {
     this.opts = opts;
+    this.logger = logger;
     this.metrics = metrics ?? null;
     this.db = opts.db || new Level(opts.name || "beaconchain", {keyEncoding: "binary", valueEncoding: "binary"});
   }
@@ -206,8 +210,8 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
       .then((dbSize) => {
         this.metrics?.dbSizeTotal.set(dbSize);
       })
-      .catch(() => {
-        // ignore errors
+      .catch((e) => {
+        this.logger.debug("Error approximating db size", {}, e);
       });
   }
 }

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -203,6 +203,7 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
 
   /** Capture metric for db size */
   private dbSizeMetric(): void {
+    const timer = this.metrics?.dbApproximateSizeTime.startTimer();
     const minKey = Buffer.from([0x00]);
     const maxKey = Buffer.from([0xff]);
 
@@ -212,7 +213,8 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
       })
       .catch((e) => {
         this.logger.debug("Error approximating db size", {}, e);
-      });
+      })
+      .finally(timer);
   }
 }
 

--- a/packages/db/src/controller/metrics.ts
+++ b/packages/db/src/controller/metrics.ts
@@ -4,6 +4,7 @@ export type LevelDbControllerMetrics = {
   dbWriteReq: Counter<"bucket">;
   dbWriteItems: Counter<"bucket">;
   dbSizeTotal: Gauge;
+  dbApproximateSizeTime: Histogram;
 };
 
 type Labels<T extends string> = Partial<Record<T, string | number>>;
@@ -18,4 +19,8 @@ interface Gauge<T extends string = string> {
   set(value: number): void;
   set(labels: Labels<T>, value: number): void;
   set(arg1?: Labels<T> | number, arg2?: number): void;
+}
+
+interface Histogram {
+  startTimer(): () => number;
 }

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -3,10 +3,11 @@ import {expect} from "chai";
 import leveldown from "leveldown";
 import all from "it-all";
 import {LevelDbController} from "../../../src/controller/index.js";
+import {testLogger} from "../../utils/logger.js";
 
 describe("LevelDB controller", () => {
   const dbLocation = "./.__testdb";
-  const db = new LevelDbController({name: dbLocation}, {metrics: null});
+  const db = new LevelDbController({name: dbLocation}, {metrics: null, logger: testLogger()});
 
   before(async () => {
     await db.start();

--- a/packages/db/test/utils/logger.ts
+++ b/packages/db/test/utils/logger.ts
@@ -1,0 +1,20 @@
+import {createWinstonLogger, LogLevel, Logger} from "@lodestar/utils";
+
+/**
+ * Run the test with ENVs to control log level:
+ * ```
+ * LOG_LEVEL=debug mocha .ts
+ * DEBUG=1 mocha .ts
+ * VERBOSE=1 mocha .ts
+ * ```
+ */
+export function testLogger(module?: string): Logger {
+  return createWinstonLogger({level: getLogLevel(), module});
+}
+
+function getLogLevel(): LogLevel {
+  if (process.env["LOG_LEVEL"]) return process.env["LOG_LEVEL"] as LogLevel;
+  if (process.env["DEBUG"]) return LogLevel.debug;
+  if (process.env["VERBOSE"]) return LogLevel.verbose;
+  return LogLevel.error;
+}

--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -411,6 +411,11 @@ export function getMetrics(register: MetricsRegister, gitData: LodestarGitData) 
         name: "validator_db_size_bytes_total",
         help: "Approximate number of bytes of file system space used by db",
       }),
+      dbApproximateSizeTime: register.histogram({
+        name: "validator_db_approximate_size_time_seconds",
+        help: "Time to approximate db size in seconds",
+        buckets: [0.0001, 0.001, 0.01, 0.1, 1],
+      }),
     },
 
     doppelganger: {

--- a/packages/validator/test/spec/index.test.ts
+++ b/packages/validator/test/spec/index.test.ts
@@ -9,10 +9,11 @@ import {
   InvalidBlockError,
   InvalidAttestationError,
 } from "../../src/slashingProtection/index.js";
+import {testLogger} from "../utils/logger.js";
 
 describe("slashing-protection custom tests", () => {
   const dbLocation = "./.__testdb_2";
-  const controller = new LevelDbController({name: dbLocation}, {});
+  const controller = new LevelDbController({name: dbLocation}, {logger: testLogger()});
   const pubkey = Buffer.alloc(96, 1);
 
   before(async () => {

--- a/packages/validator/test/spec/spec.test.ts
+++ b/packages/validator/test/spec/spec.test.ts
@@ -13,13 +13,14 @@ import {
   SlashingProtectionBlock,
   SlashingProtectionAttestation,
 } from "../../src/slashingProtection/index.js";
+import {testLogger} from "../utils/logger.js";
 import {loadTestCases} from "../utils/spec.js";
 import {SPEC_TEST_LOCATION} from "./params.js";
 
 describe("slashing-protection-interchange-tests", () => {
   const testCases = loadTestCases(path.join(SPEC_TEST_LOCATION, "/tests/generated"));
   const dbLocation = "./.__testdb";
-  const controller = new LevelDbController({name: dbLocation}, {});
+  const controller = new LevelDbController({name: dbLocation}, {logger: testLogger()});
 
   after(() => {
     rimraf.sync(dbLocation);


### PR DESCRIPTION
**Motivation**

As discussed in https://github.com/ChainSafe/lodestar/pull/5087 in https://github.com/ChainSafe/lodestar/pull/5087#discussion_r1111193591 we should improve approximate db size instrumentation.

**Description**

- Add debug log to capture approximate db size errors
- Add histogram to track approximate db size time (bucket sizes are chosen based on initial measurements, see https://github.com/ChainSafe/lodestar/pull/5087#discussion_r1104650506)
- Add dashboard panel to display approximate db size duration

![image](https://user-images.githubusercontent.com/38436224/220573010-78d221af-5102-462e-95d5-a41f7f193176.png)

@dapplion You also mentioned that an error counter should be added but this is really not necessary in my opinion as this should never throw an error and if it does, we will now log it to debug.