### PR TITLE
Use more deterministic keystore cache path 

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/keystoreCache.ts
+++ b/packages/cli/src/cmds/validator/keymanager/keystoreCache.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import {dirname} from "node:path";
 import bls from "@chainsafe/bls";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {SignerLocal, SignerType} from "@lodestar/validator";
@@ -76,6 +77,7 @@ export async function writeKeystoreCache(
   const secretKeyConcatenatedBytes = Buffer.concat(secretKeys);
   const publicConcatenatedBytes = Buffer.concat(publicKeys);
   const keystore = await Keystore.create(password, secretKeyConcatenatedBytes, publicConcatenatedBytes, cacheFilepath);
+  if (!fs.existsSync(dirname(cacheFilepath))) fs.mkdirSync(dirname(cacheFilepath), {recursive: true});
   lockFilepath(cacheFilepath);
   fs.writeFileSync(cacheFilepath, keystore.stringify());
   unlockFilepath(cacheFilepath);

--- a/packages/cli/src/cmds/validator/paths.ts
+++ b/packages/cli/src/cmds/validator/paths.ts
@@ -7,6 +7,7 @@ export type IValidatorPaths = {
 };
 
 export type AccountPaths = {
+  cacheDir: string;
   keystoresDir: string;
   secretsDir: string;
   remoteKeysDir: string;
@@ -73,12 +74,14 @@ export function getAccountPaths(
   const globalPaths = getGlobalPaths(args, network);
 
   const dataDir = globalPaths.dataDir;
+  const cacheDir = args.cacheDir || path.join(dataDir, "cache");
   const keystoresDir = args.keystoresDir || path.join(dataDir, "keystores");
   const secretsDir = args.secretsDir || path.join(dataDir, "secrets");
   const remoteKeysDir = args.remoteKeysDir || path.join(dataDir, "remoteKeys");
   const proposerDir = args.proposerDir || path.join(dataDir, "proposerConfigs");
   return {
     ...globalPaths,
+    cacheDir,
     keystoresDir,
     secretsDir,
     remoteKeysDir,

--- a/packages/cli/src/cmds/validator/signers/index.ts
+++ b/packages/cli/src/cmds/validator/signers/index.ts
@@ -1,3 +1,4 @@
+import {join} from "node:path";
 import bls from "@chainsafe/bls";
 import {deriveEth2ValidatorKeys, deriveKeyFromMnemonic} from "@chainsafe/bls-keygen";
 import {interopSecretKey} from "@lodestar/state-transition";
@@ -94,7 +95,7 @@ export async function getSignersFromArgs(
     return decryptKeystoreDefinitions(keystoreDefinitions, {
       ...args,
       onDecrypt: needle,
-      cacheFilePath: `${args.importKeystores[0]}.cache`,
+      cacheFilePath: join(args.importKeystores[0], "keystore.cache"),
     });
   }
 
@@ -126,7 +127,7 @@ export async function getSignersFromArgs(
     const keystoreSigners = await decryptKeystoreDefinitions(keystoreDefinitions, {
       ...args,
       onDecrypt: needle,
-      cacheFilePath: `${accountPaths.keystoresDir}.cache`,
+      cacheFilePath: join(accountPaths.cacheDir, "keystores.cache"),
     });
 
     // Read local remote keys, imported via keymanager api

--- a/packages/cli/src/cmds/validator/signers/index.ts
+++ b/packages/cli/src/cmds/validator/signers/index.ts
@@ -45,6 +45,8 @@ export async function getSignersFromArgs(
   network: string,
   {logger, signal}: {logger: Pick<ILogger, "info">; signal: AbortSignal}
 ): Promise<Signer[]> {
+  const accountPaths = getAccountPaths(args, network);
+
   // ONLY USE FOR TESTNETS - Derive interop keys
   if (args.interopIndexes) {
     const indexes = parseRange(args.interopIndexes);
@@ -95,7 +97,7 @@ export async function getSignersFromArgs(
     return decryptKeystoreDefinitions(keystoreDefinitions, {
       ...args,
       onDecrypt: needle,
-      cacheFilePath: join(args.importKeystores[0], "keystore.cache"),
+      cacheFilePath: join(accountPaths.cacheDir, "imported_keystores.cache"),
     });
   }
 
@@ -106,7 +108,6 @@ export async function getSignersFromArgs(
 
   // Read keys from local account manager
   else {
-    const accountPaths = getAccountPaths(args, network);
     const persistedKeysBackend = new PersistedKeysBackend(accountPaths);
 
     // Read and decrypt local keystores, imported via keymanager api or import cmd
@@ -124,10 +125,11 @@ export async function getSignersFromArgs(
         );
       },
     });
+
     const keystoreSigners = await decryptKeystoreDefinitions(keystoreDefinitions, {
       ...args,
       onDecrypt: needle,
-      cacheFilePath: join(accountPaths.cacheDir, "keystores.cache"),
+      cacheFilePath: join(accountPaths.cacheDir, "local_keystores.cache"),
     });
 
     // Read local remote keys, imported via keymanager api


### PR DESCRIPTION
**Motivation**

Use more deterministic keystore cache. 

**Description**

Create a new cache directory and use the keystore cache stored in there. 

Closes #5141

**Steps to test or reproduce**

Ru all tests. 