### PR TITLE
Restrict import destructuring for some modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -146,16 +146,18 @@ module.exports = {
       {
         patterns: ["../lib/*", "@chainsafe/*/lib/*"],
         paths: [
-          {name: "child_process", message: "Please use node:child_process instead."},
-          {name: "crypto", message: "Please use node:crypto instead."},
-          {name: "fs", message: "Please use node:fs instead."},
-          {name: "http", message: "Please use node:http instead."},
-          {name: "net", message: "Please use node:net instead."},
-          {name: "os", message: "Please use node:os instead."},
-          {name: "path", message: "Please use node:path instead."},
-          {name: "stream", message: "Please use node:stream instead."},
-          {name: "util", message: "Please use node:util instead."},
-          {name: "url", message: "Please use node:url instead."},
+          ...restrictNodeModuleImports(
+            "child_process",
+            "crypto",
+            "fs",
+            "http",
+            "net",
+            "os",
+            "path",
+            "stream",
+            "util",
+            "url"
+          ),
         ],
       },
     ],
@@ -242,6 +244,10 @@ module.exports = {
     },
   ],
 };
+
+function restrictNodeModuleImports(...modules) {
+  return modules.map((module) => ({name: module, message: `Please use 'node:${module}' instead.`}));
+}
 
 function restrictImportDestructuring(...modules) {
   return modules.map((module) => ({

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -159,6 +159,7 @@ module.exports = {
         ],
       },
     ],
+    "no-restricted-syntax": ["error", ...restrictImportDestructuring("node:fs", "node:os", "node:path")],
     // Force to add names to all functions to ease CPU profiling
     "func-names": ["error", "always"],
 
@@ -241,3 +242,10 @@ module.exports = {
     },
   ],
 };
+
+function restrictImportDestructuring(...modules) {
+  return modules.map((module) => ({
+    selector: `ImportDeclaration[source.value='${module}'] ImportSpecifier`,
+    message: `Importing from '${module}' using destructuring is restricted.`,
+  }));
+}

--- a/packages/beacon-node/src/network/util.ts
+++ b/packages/beacon-node/src/network/util.ts
@@ -1,4 +1,4 @@
-import {networkInterfaces} from "node:os";
+import os from "node:os";
 import type {PeerId} from "@libp2p/interface-peer-id";
 import type {Multiaddr} from "@multiformats/multiaddr";
 import type {Connection} from "@libp2p/interface-connection";
@@ -22,7 +22,7 @@ export function isLocalMultiAddr(multiaddr: Multiaddr | undefined): boolean {
     throw new Error("Invalid udp multiaddr");
   }
 
-  const interfaces = networkInterfaces();
+  const interfaces = os.networkInterfaces();
   const tuples = multiaddr.tuples();
   const family = tuples[0][0];
   const isIPv4: boolean = family === 4;

--- a/packages/beacon-node/test/unit/sync/backfill/verify.test.ts
+++ b/packages/beacon-node/test/unit/sync/backfill/verify.test.ts
@@ -1,4 +1,4 @@
-import {readFileSync} from "node:fs";
+import fs from "node:fs";
 import path from "node:path";
 import {fileURLToPath} from "node:url";
 import {expect} from "chai";
@@ -50,7 +50,7 @@ describe("backfill sync - verify block sequence", function () {
 
   //first 4 mainnet blocks
   function getBlocks(): phase0.SignedBeaconBlock[] {
-    const json = JSON.parse(readFileSync(path.join(__dirname, "./blocks.json"), "utf-8")) as unknown[];
+    const json = JSON.parse(fs.readFileSync(path.join(__dirname, "./blocks.json"), "utf-8")) as unknown[];
     return json.map((b) => {
       return ssz.phase0.SignedBeaconBlock.fromJson(b);
     });

--- a/packages/cli/src/cmds/validator/keymanager/keystoreCache.ts
+++ b/packages/cli/src/cmds/validator/keymanager/keystoreCache.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import {dirname} from "node:path";
+import path from "node:path";
 import bls from "@chainsafe/bls";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {SignerLocal, SignerType} from "@lodestar/validator";
@@ -77,7 +77,7 @@ export async function writeKeystoreCache(
   const secretKeyConcatenatedBytes = Buffer.concat(secretKeys);
   const publicConcatenatedBytes = Buffer.concat(publicKeys);
   const keystore = await Keystore.create(password, secretKeyConcatenatedBytes, publicConcatenatedBytes, cacheFilepath);
-  if (!fs.existsSync(dirname(cacheFilepath))) fs.mkdirSync(dirname(cacheFilepath), {recursive: true});
+  if (!fs.existsSync(path.dirname(cacheFilepath))) fs.mkdirSync(path.dirname(cacheFilepath), {recursive: true});
   lockFilepath(cacheFilepath);
   fs.writeFileSync(cacheFilepath, keystore.stringify());
   unlockFilepath(cacheFilepath);

--- a/packages/cli/src/cmds/validator/signers/index.ts
+++ b/packages/cli/src/cmds/validator/signers/index.ts
@@ -1,4 +1,4 @@
-import {join} from "node:path";
+import path from "node:path";
 import bls from "@chainsafe/bls";
 import {deriveEth2ValidatorKeys, deriveKeyFromMnemonic} from "@chainsafe/bls-keygen";
 import {interopSecretKey} from "@lodestar/state-transition";
@@ -97,7 +97,7 @@ export async function getSignersFromArgs(
     return decryptKeystoreDefinitions(keystoreDefinitions, {
       ...args,
       onDecrypt: needle,
-      cacheFilePath: join(accountPaths.cacheDir, "imported_keystores.cache"),
+      cacheFilePath: path.join(accountPaths.cacheDir, "imported_keystores.cache"),
     });
   }
 
@@ -129,7 +129,7 @@ export async function getSignersFromArgs(
     const keystoreSigners = await decryptKeystoreDefinitions(keystoreDefinitions, {
       ...args,
       onDecrypt: needle,
-      cacheFilePath: join(accountPaths.cacheDir, "local_keystores.cache"),
+      cacheFilePath: path.join(accountPaths.cacheDir, "local_keystores.cache"),
     });
 
     // Read local remote keys, imported via keymanager api

--- a/packages/cli/src/util/file.ts
+++ b/packages/cli/src/util/file.ts
@@ -1,4 +1,4 @@
-import fs, {WriteFileOptions} from "node:fs";
+import fs from "node:fs";
 import path from "node:path";
 import stream from "node:stream";
 import {promisify} from "node:util";
@@ -67,7 +67,7 @@ export function stringify(obj: unknown, fileFormat: FileFormat): string {
  *
  * Serialize either to json, yaml, or toml
  */
-export function writeFile(filepath: string, obj: unknown, options: WriteFileOptions = "utf-8"): void {
+export function writeFile(filepath: string, obj: unknown, options: fs.WriteFileOptions = "utf-8"): void {
   mkdir(path.dirname(filepath));
   const fileFormat = path.extname(filepath).substr(1);
   fs.writeFileSync(filepath, typeof obj === "string" ? obj : stringify(obj, fileFormat as FileFormat), options);
@@ -78,7 +78,7 @@ export function writeFile(filepath: string, obj: unknown, options: WriteFileOpti
  * *Note*: 600: Owner has full read and write access to the file,
  * while no other user can access the file
  */
-export function writeFile600Perm(filepath: string, obj: unknown, options?: WriteFileOptions): void {
+export function writeFile600Perm(filepath: string, obj: unknown, options?: fs.WriteFileOptions): void {
   writeFile(filepath, obj, options);
   fs.chmodSync(filepath, "0600");
 }

--- a/packages/cli/test/sim/backup_eth_provider.test.ts
+++ b/packages/cli/test/sim/backup_eth_provider.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {join} from "node:path";
+import path from "node:path";
 import {activePreset} from "@lodestar/params";
 import {nodeAssertion} from "../utils/simulation/assertions/nodeAssertion.js";
 import {CLIQUE_SEALING_PERIOD, SIM_TESTS_SECONDS_PER_SLOT} from "../utils/simulation/constants.js";
@@ -41,7 +41,7 @@ const ttd = getEstimatedTTD({
 const env = await SimulationEnvironment.initWithDefaults(
   {
     id: "backup-eth-provider",
-    logsDir: join(logFilesDir, "backup-eth-provider"),
+    logsDir: path.join(logFilesDir, "backup-eth-provider"),
     chainConfig: {
       ALTAIR_FORK_EPOCH: altairForkEpoch,
       BELLATRIX_FORK_EPOCH: bellatrixForkEpoch,

--- a/packages/cli/test/sim/deneb.test.ts
+++ b/packages/cli/test/sim/deneb.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {join} from "node:path";
+import path from "node:path";
 import {activePreset} from "@lodestar/params";
 import {toHexString} from "@lodestar/utils";
 import {ApiError} from "@lodestar/api";
@@ -38,7 +38,7 @@ const ttd = getEstimatedTTD({
 const env = await SimulationEnvironment.initWithDefaults(
   {
     id: "multi-fork",
-    logsDir: join(logFilesDir, "multi-fork"),
+    logsDir: path.join(logFilesDir, "multi-fork"),
     chainConfig: {
       ALTAIR_FORK_EPOCH: altairForkEpoch,
       BELLATRIX_FORK_EPOCH: bellatrixForkEpoch,

--- a/packages/cli/test/sim/endpoints.test.ts
+++ b/packages/cli/test/sim/endpoints.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {join} from "node:path";
+import path from "node:path";
 import {expect} from "chai";
 import {toHexString} from "@chainsafe/ssz";
 import {routes} from "@lodestar/api";
@@ -26,7 +26,7 @@ const runTimeoutMs =
 const env = await SimulationEnvironment.initWithDefaults(
   {
     id: "beacon-endpoints",
-    logsDir: join(logFilesDir, "beacon-endpoints"),
+    logsDir: path.join(logFilesDir, "beacon-endpoints"),
     chainConfig: {
       ALTAIR_FORK_EPOCH: altairForkEpoch,
       BELLATRIX_FORK_EPOCH: bellatrixForkEpoch,

--- a/packages/cli/test/sim/multi_fork.test.ts
+++ b/packages/cli/test/sim/multi_fork.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {join} from "node:path";
+import path from "node:path";
 import {activePreset} from "@lodestar/params";
 import {sleep, toHexString} from "@lodestar/utils";
 import {ApiError} from "@lodestar/api";
@@ -45,7 +45,7 @@ const ttd = getEstimatedTTD({
 const env = await SimulationEnvironment.initWithDefaults(
   {
     id: "multi-fork",
-    logsDir: join(logFilesDir, "multi-fork"),
+    logsDir: path.join(logFilesDir, "multi-fork"),
     chainConfig: {
       ALTAIR_FORK_EPOCH: altairForkEpoch,
       BELLATRIX_FORK_EPOCH: bellatrixForkEpoch,

--- a/packages/cli/test/utils/simulation/SimulationEnvironment.ts
+++ b/packages/cli/test/utils/simulation/SimulationEnvironment.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {EventEmitter} from "node:events";
 import {mkdir, writeFile} from "node:fs/promises";
-import {join} from "node:path";
-import {existsSync} from "node:fs";
+import path from "node:path";
+import fs from "node:fs";
 import tmp from "tmp";
 import {fromHexString} from "@chainsafe/ssz";
 import {nodeUtils} from "@lodestar/beacon-node";
@@ -122,7 +122,7 @@ export class SimulationEnvironment {
       id,
       genesisTime,
       controller: new AbortController(),
-      rootDir: join(tmp.dirSync({unsafeCleanup: true, tmpdir: "/tmp", template: "sim-XXXXXX"}).name, id),
+      rootDir: path.join(tmp.dirSync({unsafeCleanup: true, tmpdir: "/tmp", template: "sim-XXXXXX"}).name, id),
     });
 
     for (const client of clients) {
@@ -158,7 +158,7 @@ export class SimulationEnvironment {
 
     try {
       regsiterProcessHandler(this);
-      if (!existsSync(this.options.rootDir)) {
+      if (!fs.existsSync(this.options.rootDir)) {
         await mkdir(this.options.rootDir);
       }
 

--- a/packages/cli/test/utils/simulation/cl_clients/lighthouse.ts
+++ b/packages/cli/test/utils/simulation/cl_clients/lighthouse.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {writeFile} from "node:fs/promises";
-import {dirname, join} from "node:path";
+import path from "node:path";
 import got, {RequestError} from "got";
 import yaml from "js-yaml";
 import {HttpClient} from "@lodestar/api";
@@ -80,8 +80,8 @@ export const generateLighthouseBeaconNode: CLClientGenerator<CLClient.Lighthouse
         }
       : undefined,
     bootstrap: async () => {
-      await writeFile(join(rootDir, "config.yaml"), yaml.dump(chainConfigToJson(config)));
-      await writeFile(join(rootDir, "deploy_block.txt"), "0");
+      await writeFile(path.join(rootDir, "config.yaml"), yaml.dump(chainConfigToJson(config)));
+      await writeFile(path.join(rootDir, "deploy_block.txt"), "0");
     },
     cli: {
       command: isDocker ? "lighthouse" : (process.env.LIGHTHOUSE_BINARY_PATH as string),
@@ -118,7 +118,7 @@ export const generateLighthouseBeaconNode: CLClientGenerator<CLClient.Lighthouse
           id: `${id}-validator`,
           paths: {
             ...opts.paths,
-            logFilePath: join(dirname(logFilePath), `${id}-validator.log`),
+            logFilePath: path.join(path.dirname(logFilePath), `${id}-validator.log`),
           },
         },
         runner
@@ -193,7 +193,7 @@ export const generateLighthouseValidatorJobs = (opts: CLClientGeneratorOptions, 
       if (isDocker) {
         await updateKeystoresPath(
           validatorsDefinitionFilePath,
-          dirname(validatorsDefinitionFilePathMounted),
+          path.dirname(validatorsDefinitionFilePathMounted),
           validatorsDefinitionFilePath
         );
       }

--- a/packages/cli/test/utils/simulation/cl_clients/lodestar.ts
+++ b/packages/cli/test/utils/simulation/cl_clients/lodestar.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {writeFile} from "node:fs/promises";
-import {dirname, join} from "node:path";
+import path from "node:path";
 import got from "got";
 import {getClient} from "@lodestar/api/beacon";
 import {getClient as keyManagerGetClient} from "@lodestar/api/keymanager";
@@ -20,8 +20,8 @@ export const generateLodestarBeaconNode: CLClientGenerator<CLClient.Lodestar> = 
   } = opts;
   const ports = getNodePorts(nodeIndex);
 
-  const rcConfigPath = join(rootDir, "rc_config.json");
-  const paramsPath = join(rootDir, "params.json");
+  const rcConfigPath = path.join(rootDir, "rc_config.json");
+  const paramsPath = path.join(rootDir, "params.json");
 
   const rcConfig = ({
     network: "dev",
@@ -69,7 +69,7 @@ export const generateLodestarBeaconNode: CLClientGenerator<CLClient.Lodestar> = 
         id: `${id}-validator`,
         paths: {
           ...opts.paths,
-          logFilePath: join(dirname(logFilePath), `${id}-validator.log`),
+          logFilePath: path.join(path.dirname(logFilePath), `${id}-validator.log`),
         },
       })
     );
@@ -146,12 +146,18 @@ export const generateLodestarValidatorJobs = (opts: CLClientGeneratorOptions): J
     id,
     type: RunnerType.ChildProcess,
     bootstrap: async () => {
-      await writeFile(join(rootDir, "rc_config.json"), JSON.stringify(rcConfig, null, 2));
-      await writeFile(join(rootDir, "params.json"), JSON.stringify(chainConfigToJson(config), null, 2));
+      await writeFile(path.join(rootDir, "rc_config.json"), JSON.stringify(rcConfig, null, 2));
+      await writeFile(path.join(rootDir, "params.json"), JSON.stringify(chainConfigToJson(config), null, 2));
     },
     cli: {
       command: LODESTAR_BINARY_PATH,
-      args: ["validator", "--rcConfig", join(rootDir, "rc_config.json"), "--paramsFile", join(rootDir, "params.json")],
+      args: [
+        "validator",
+        "--rcConfig",
+        path.join(rootDir, "rc_config.json"),
+        "--paramsFile",
+        path.join(rootDir, "params.json"),
+      ],
       env: {
         DEBUG: process.env.DISABLE_DEBUG_LOGS ? "" : "*,-winston:*",
       },

--- a/packages/cli/test/utils/simulation/constants.ts
+++ b/packages/cli/test/utils/simulation/constants.ts
@@ -1,9 +1,9 @@
 // Global variable __dirname no longer available in ES6 modules.
 // Solutions: https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const __dirname = dirname(fileURLToPath(import.meta.url));
+export const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-import {dirname} from "node:path";
+import path from "node:path";
 import {fileURLToPath} from "node:url";
 
 export const FAR_FUTURE_EPOCH = 10 ** 12;

--- a/packages/cli/test/utils/simulation/el_clients/geth.ts
+++ b/packages/cli/test/utils/simulation/el_clients/geth.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {writeFile} from "node:fs/promises";
-import {join} from "node:path";
+import path from "node:path";
 import got from "got";
 import {ZERO_HASH} from "@lodestar/state-transition";
 import {SHARED_JWT_SECRET, SIM_ENV_NETWORK_ID} from "../constants.js";
@@ -33,10 +33,10 @@ export const generateGethNode: ELClientGenerator<ELClient.Geth> = (opts, runner)
   const ethRpcUrl = `http://127.0.0.1:${httpPort}`;
   const engineRpcUrl = `http://${address}:${enginePort}`;
 
-  const skPath = join(rootDir, "sk.json");
-  const skPathMounted = join(rootDirMounted, "sk.json");
-  const passwordPath = join(rootDir, "password.txt");
-  const passwordPathMounted = join(rootDirMounted, "password.txt");
+  const skPath = path.join(rootDir, "sk.json");
+  const skPathMounted = path.join(rootDirMounted, "sk.json");
+  const passwordPath = path.join(rootDir, "password.txt");
+  const passwordPathMounted = path.join(rootDirMounted, "password.txt");
 
   const initJobOptions: JobOptions = {
     id: `${id}-init`,

--- a/packages/cli/test/utils/simulation/el_clients/nethermind.ts
+++ b/packages/cli/test/utils/simulation/el_clients/nethermind.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {writeFile} from "node:fs/promises";
-import {join} from "node:path";
+import path from "node:path";
 import got from "got";
 import {ZERO_HASH} from "@lodestar/state-transition";
 import {Eth1ProviderWithAdmin} from "../Eth1ProviderWithAdmin.js";
@@ -31,8 +31,8 @@ export const generateNethermindNode: ELClientGenerator<ELClient.Nethermind> = (o
   const ethRpcUrl = `http://127.0.0.1:${httpPort}`;
   const engineRpcUrl = `http://${address}:${enginePort}`;
 
-  const chainSpecPath = join(rootDir, "chain.json");
-  const chainSpecContainerPath = join(rootDirMounted, "chain.json");
+  const chainSpecPath = path.join(rootDir, "chain.json");
+  const chainSpecContainerPath = path.join(rootDirMounted, "chain.json");
 
   const startJobOptions: JobOptions<RunnerType.Docker> = {
     id,
@@ -69,7 +69,7 @@ export const generateNethermindNode: ELClientGenerator<ELClient.Nethermind> = (o
         "--JsonRpc.EnabledModules",
         "Admin,Net,Eth,Subscribe,Web3",
         "--Init.BaseDbPath",
-        join(rootDirMounted, "db"),
+        path.join(rootDirMounted, "db"),
         "--Init.DiscoveryEnabled",
         "false",
         "--Init.PeerManagerEnabled",

--- a/packages/cli/test/utils/simulation/runner/index.ts
+++ b/packages/cli/test/utils/simulation/runner/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import {EventEmitter} from "node:events";
-import {join} from "node:path";
+import path from "node:path";
 import {IRunner, Job, JobOptions, RunnerEvent, RunnerType} from "../interfaces.js";
 import {ChildProcessRunner} from "./ChildProcessRunner.js";
 import {DockerRunner} from "./DockerRunner.js";
@@ -12,7 +12,7 @@ export class Runner implements IRunner {
   constructor({logsDir}: {logsDir: string}) {
     this.runners = {
       [RunnerType.ChildProcess]: new ChildProcessRunner(),
-      [RunnerType.Docker]: new DockerRunner(join(logsDir, "docker_runner.log")),
+      [RunnerType.Docker]: new DockerRunner(path.join(logsDir, "docker_runner.log")),
     };
   }
 

--- a/packages/cli/test/utils/simulation/utils/child_process.ts
+++ b/packages/cli/test/utils/simulation/utils/child_process.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import {ChildProcess, spawn} from "node:child_process";
-import {createWriteStream, mkdirSync} from "node:fs";
-import {dirname} from "node:path";
+import fs from "node:fs";
+import path from "node:path";
 import {JobOptions, RunnerType} from "../interfaces.js";
 
 const healthCheckIntervalMs = 1000;
@@ -31,8 +31,8 @@ export const startChildProcess = async (
         env: {...process.env, ...jobOptions.cli.env},
       });
 
-      mkdirSync(dirname(jobOptions.logs.stdoutFilePath), {recursive: true});
-      const stdoutFileStream = createWriteStream(jobOptions.logs.stdoutFilePath);
+      fs.mkdirSync(path.dirname(jobOptions.logs.stdoutFilePath), {recursive: true});
+      const stdoutFileStream = fs.createWriteStream(jobOptions.logs.stdoutFilePath);
       childProcess.stdout?.pipe(stdoutFileStream);
       childProcess.stderr?.pipe(stdoutFileStream);
 

--- a/packages/cli/test/utils/simulation/utils/keys.ts
+++ b/packages/cli/test/utils/simulation/utils/keys.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {readFile, writeFile} from "node:fs/promises";
-import {dirname, join} from "node:path";
+import path from "node:path";
 import yaml from "js-yaml";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {SHARED_VALIDATOR_PASSWORD} from "../constants.js";
@@ -25,18 +25,18 @@ export const createKeystores = async (
       const keystore = await Keystore.create(SHARED_VALIDATOR_PASSWORD, key.toBytes(), key.toPublicKey().toBytes(), "");
 
       await writeFile(
-        join(keystoresDir, `${key.toPublicKey().toHex()}.json`),
+        path.join(keystoresDir, `${key.toPublicKey().toHex()}.json`),
         JSON.stringify(keystore.toObject(), null, 2)
       );
 
-      await writeFile(join(keystoresSecretsDir, `${key.toPublicKey().toHex()}.txt`), SHARED_VALIDATOR_PASSWORD);
+      await writeFile(path.join(keystoresSecretsDir, `${key.toPublicKey().toHex()}.txt`), SHARED_VALIDATOR_PASSWORD);
 
       definition.push({
         enabled: true,
         type: "local_keystore",
         voting_public_key: key.toPublicKey().toHex(),
-        voting_keystore_path: join(keystoresDir, `${key.toPublicKey().toHex()}.json`),
-        voting_keystore_password_path: join(keystoresSecretsDir, `${key.toPublicKey().toHex()}.txt`),
+        voting_keystore_path: path.join(keystoresDir, `${key.toPublicKey().toHex()}.json`),
+        voting_keystore_password_path: path.join(keystoresSecretsDir, `${key.toPublicKey().toHex()}.txt`),
       });
     }
   }
@@ -58,7 +58,7 @@ export const updateKeystoresPath = async (
   newDefinitionFilePath: string
 ): Promise<void> => {
   const definition = [];
-  const oldValidatorDir = dirname(definitionFilePath);
+  const oldValidatorDir = path.dirname(definitionFilePath);
 
   const definitionYaml = yaml.load(await readFile(definitionFilePath, "utf8")) as KeystoreDefinition[];
 

--- a/packages/cli/test/utils/simulation/utils/paths.ts
+++ b/packages/cli/test/utils/simulation/utils/paths.ts
@@ -1,5 +1,5 @@
-import {join} from "node:path";
-import {existsSync} from "node:fs";
+import path from "node:path";
+import fs from "node:fs";
 import {mkdir} from "node:fs/promises";
 import {CLClient, CLPaths, ELClient, ELPaths, MountedPaths} from "../interfaces.js";
 
@@ -14,23 +14,23 @@ export const getCLNodePaths = ({
   client: CLClient;
   logsDir: string;
 }): CLPaths => {
-  const clRootDir = join(root, id, `cl_${client}`);
-  const dataDir = join(clRootDir, "data");
-  const genesisFilePath = join(clRootDir, "genesis.ssz");
-  const jwtsecretFilePath = join(clRootDir, "jwtsecret.txt");
-  const validatrosDir = join(clRootDir, "validators");
-  const keystoresDir = join(clRootDir, "validators", "keystores");
-  const keystoresSecretsDir = join(clRootDir, "validators", "secretts");
-  const keystoresSecretFilePath = join(clRootDir, "validators", "password.txt");
-  const validatorsDefinitionFilePath = join(clRootDir, "validators", "validator_definitions.yml");
-  const logFilePath = join(logsDir, `${id}-cl-${client}.log`);
+  const clRootDir = path.join(root, id, `cl_${client}`);
+  const dataDir = path.join(clRootDir, "data");
+  const genesisFilePath = path.join(clRootDir, "genesis.ssz");
+  const jwtsecretFilePath = path.join(clRootDir, "jwtsecret.txt");
+  const validatorsDir = path.join(clRootDir, "validators");
+  const keystoresDir = path.join(clRootDir, "validators", "keystores");
+  const keystoresSecretsDir = path.join(clRootDir, "validators", "secretts");
+  const keystoresSecretFilePath = path.join(clRootDir, "validators", "password.txt");
+  const validatorsDefinitionFilePath = path.join(clRootDir, "validators", "validator_definitions.yml");
+  const logFilePath = path.join(logsDir, `${id}-cl-${client}.log`);
 
   return {
     rootDir: clRootDir,
     dataDir,
     genesisFilePath,
     jwtsecretFilePath,
-    validatorsDir: validatrosDir,
+    validatorsDir,
     keystoresDir,
     keystoresSecretsDir,
     validatorsDefinitionFilePath,
@@ -46,7 +46,7 @@ export const getCLNodePathsForDocker = (paths: CLPaths, mountPath: string): CLPa
     genesisFilePath,
     jwtsecretFilePath,
     validatorsDefinitionFilePath,
-    validatorsDir: validatrosDir,
+    validatorsDir,
     keystoresDir,
     keystoresSecretFilePath,
     keystoresSecretsDir,
@@ -58,7 +58,7 @@ export const getCLNodePathsForDocker = (paths: CLPaths, mountPath: string): CLPa
     dataDir: dataDir.replace(rootDir, mountPath),
     genesisFilePath: genesisFilePath.replace(rootDir, mountPath),
     jwtsecretFilePath: jwtsecretFilePath.replace(rootDir, mountPath),
-    validatorsDir: validatrosDir.replace(rootDir, mountPath),
+    validatorsDir: validatorsDir.replace(rootDir, mountPath),
     keystoresDir: keystoresDir.replace(rootDir, mountPath),
     keystoresSecretsDir: keystoresSecretsDir.replace(rootDir, mountPath),
     validatorsDefinitionFilePath: validatorsDefinitionFilePath.replace(rootDir, mountPath),
@@ -70,9 +70,9 @@ export const getCLNodePathsForDocker = (paths: CLPaths, mountPath: string): CLPa
 export const createCLNodePaths = async (paths: CLPaths): Promise<CLPaths> => {
   const {dataDir, keystoresDir, keystoresSecretsDir} = paths;
 
-  if (!existsSync(dataDir)) await mkdir(dataDir, {recursive: true});
-  if (!existsSync(keystoresDir)) await mkdir(keystoresDir, {recursive: true});
-  if (!existsSync(keystoresSecretsDir)) await mkdir(keystoresSecretsDir, {recursive: true});
+  if (!fs.existsSync(dataDir)) await mkdir(dataDir, {recursive: true});
+  if (!fs.existsSync(keystoresDir)) await mkdir(keystoresDir, {recursive: true});
+  if (!fs.existsSync(keystoresSecretsDir)) await mkdir(keystoresSecretsDir, {recursive: true});
 
   return paths;
 };
@@ -88,15 +88,15 @@ export const getELNodePaths = ({
   client: ELClient;
   logsDir: string;
 }): ELPaths => {
-  const elRootDir = join(root, id, `el_${client}`);
-  const dataDir = join(elRootDir, "data");
-  const logFilePath = join(logsDir, `${id}-el=${client}.log`);
+  const elRootDir = path.join(root, id, `el_${client}`);
+  const dataDir = path.join(elRootDir, "data");
+  const logFilePath = path.join(logsDir, `${id}-el=${client}.log`);
 
   return {
     rootDir: elRootDir,
     dataDir,
-    genesisFilePath: join(elRootDir, "genesis.json"),
-    jwtsecretFilePath: join(elRootDir, "jwtsecret.txt"),
+    genesisFilePath: path.join(elRootDir, "genesis.json"),
+    jwtsecretFilePath: path.join(elRootDir, "jwtsecret.txt"),
     logFilePath,
   };
 };
@@ -118,7 +118,7 @@ export const getNodeMountedPaths = <T extends ELPaths | CLPaths>(
 export const createELNodePaths = async (paths: ELPaths): Promise<ELPaths> => {
   const {dataDir} = paths;
 
-  if (!existsSync(dataDir)) await mkdir(dataDir, {recursive: true});
+  if (!fs.existsSync(dataDir)) await mkdir(dataDir, {recursive: true});
 
   return paths;
 };

--- a/packages/spec-test-util/src/single.ts
+++ b/packages/spec-test-util/src/single.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import {basename, join, parse} from "node:path";
+import path from "node:path";
 import {expect} from "chai";
 import {uncompress} from "snappyjs";
 import {loadYaml} from "@lodestar/utils";
@@ -107,7 +107,7 @@ export function describeDirectorySpecTest<TestCase extends {meta?: any}, Result>
     }
 
     for (const testSubDirname of fs.readdirSync(testCaseDirectoryPath)) {
-      const testSubDirPath = join(testCaseDirectoryPath, testSubDirname);
+      const testSubDirPath = path.join(testCaseDirectoryPath, testSubDirname);
       if (!isDirectory(testSubDirPath)) {
         continue;
       }
@@ -116,7 +116,7 @@ export function describeDirectorySpecTest<TestCase extends {meta?: any}, Result>
       const testName = `${name}/${testSubDirname}`;
       it(testName, async function () {
         // some tests require to load meta.yaml first in order to know respective ssz types.
-        const metaFilePath = join(testSubDirPath, "meta.yaml");
+        const metaFilePath = path.join(testSubDirPath, "meta.yaml");
         const meta: TestCase["meta"] = fs.existsSync(metaFilePath)
           ? loadYaml(fs.readFileSync(metaFilePath, "utf8"))
           : undefined;
@@ -157,13 +157,13 @@ function loadInputFiles<TestCase extends {meta?: any}, Result>(
 ): TestCase {
   const testCase: any = {};
   fs.readdirSync(directory)
-    .map((name) => join(directory, name))
+    .map((name) => path.join(directory, name))
     .filter((file) => {
       if (isDirectory(file)) {
         return false;
       }
       if (!options.inputTypes) throw Error("inputTypes is not defined");
-      const name = parse(file).name as keyof NonNullable<TestCase>;
+      const name = path.parse(file).name as keyof NonNullable<TestCase>;
       const inputType = toExpandedInputType(options.inputTypes[name] ?? InputType.SSZ_SNAPPY);
       // set options.inputTypes[name] with expanded input type
       options.inputTypes[name] = inputType;
@@ -171,7 +171,7 @@ function loadInputFiles<TestCase extends {meta?: any}, Result>(
       return file.endsWith(extension);
     })
     .forEach((file) => {
-      const inputName = basename(file).replace(".ssz_snappy", "").replace(".ssz", "").replace(".yaml", "");
+      const inputName = path.basename(file).replace(".ssz_snappy", "").replace(".ssz", "").replace(".yaml", "");
       const inputType = getInputType(file);
       testCase[inputName] = deserializeInputFile(file, inputName, inputType, options, meta);
       switch (inputType) {

--- a/packages/spec-test-util/test/e2e/single/index.test.ts
+++ b/packages/spec-test-util/test/e2e/single/index.test.ts
@@ -1,5 +1,5 @@
-import {unlinkSync, writeFileSync} from "node:fs";
-import path, {join} from "node:path";
+import fs from "node:fs";
+import path from "node:path";
 import {fileURLToPath} from "node:url";
 import {ContainerType, Type} from "@chainsafe/ssz";
 import {ssz} from "@lodestar/types";
@@ -32,22 +32,22 @@ const sampleContainerType = new ContainerType({
 });
 
 before(() => {
-  yamlToSSZ(join(__dirname, "../_test_files/single/case0/input.yaml"), sampleContainerType);
-  yamlToSSZ(join(__dirname, "../_test_files/single/case0/output.yaml"), ssz.UintNum64);
-  yamlToSSZ(join(__dirname, "../_test_files/single/case1/input.yaml"), sampleContainerType);
-  yamlToSSZ(join(__dirname, "../_test_files/single/case1/output.yaml"), ssz.UintNum64);
+  yamlToSSZ(path.join(__dirname, "../_test_files/single/case0/input.yaml"), sampleContainerType);
+  yamlToSSZ(path.join(__dirname, "../_test_files/single/case0/output.yaml"), ssz.UintNum64);
+  yamlToSSZ(path.join(__dirname, "../_test_files/single/case1/input.yaml"), sampleContainerType);
+  yamlToSSZ(path.join(__dirname, "../_test_files/single/case1/output.yaml"), ssz.UintNum64);
 });
 
 after(() => {
-  unlinkSync(join(__dirname, "../_test_files/single/case0/input.ssz"));
-  unlinkSync(join(__dirname, "../_test_files/single/case0/output.ssz"));
-  unlinkSync(join(__dirname, "../_test_files/single/case1/input.ssz"));
-  unlinkSync(join(__dirname, "../_test_files/single/case1/output.ssz"));
+  fs.unlinkSync(path.join(__dirname, "../_test_files/single/case0/input.ssz"));
+  fs.unlinkSync(path.join(__dirname, "../_test_files/single/case0/output.ssz"));
+  fs.unlinkSync(path.join(__dirname, "../_test_files/single/case1/input.ssz"));
+  fs.unlinkSync(path.join(__dirname, "../_test_files/single/case1/output.ssz"));
 });
 
 describeDirectorySpecTest<SimpleCase, number>(
   "single spec test",
-  join(__dirname, "../_test_files/single"),
+  path.join(__dirname, "../_test_files/single"),
   (testCase) => {
     return testCase.input.number;
   },
@@ -67,5 +67,5 @@ describeDirectorySpecTest<SimpleCase, number>(
 
 function yamlToSSZ(file: string, sszSchema: Type<any>): void {
   const input = sszSchema.fromJson(loadYamlFile(file)) as {test: boolean; number: number};
-  writeFileSync(file.replace(".yaml", ".ssz"), sszSchema.serialize(input));
+  fs.writeFileSync(file.replace(".yaml", ".ssz"), sszSchema.serialize(input));
 }

--- a/packages/state-transition/test/utils/specTestCases.ts
+++ b/packages/state-transition/test/utils/specTestCases.ts
@@ -1,4 +1,4 @@
-import path, {join} from "node:path";
+import path from "node:path";
 import {fileURLToPath} from "node:url";
 
 // Global variable __dirname no longer available in ES6 modules.
@@ -6,4 +6,4 @@ import {fileURLToPath} from "node:url";
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export const SPEC_TEST_LOCATION = join(__dirname, "../../../../node_modules/@chainsafe/eth2-spec-tests");
+export const SPEC_TEST_LOCATION = path.join(__dirname, "../../../../node_modules/@chainsafe/eth2-spec-tests");


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5201

**Description**

Adds eslint rule to restrict import destructuring for some modules (`"node:fs", "node:os", "node:path"`). Further modules could be added but those are the ones where I saw the highest inconsistency on how the imports are done and also these use really ambiguous function names.

Also refactored the eslint rule for restricted node module imports.

cc @nazarhussain 
