### PR TITLE
Allow builder circuit breaker to be configured

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -17,7 +17,7 @@ import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock} from "@lode
 import {ProcessShutdownCallback} from "@lodestar/validator";
 import {Logger, pruneSetToMax, toHex} from "@lodestar/utils";
 import {CompositeTypeAny, fromHexString, TreeView, Type} from "@chainsafe/ssz";
-import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkSeq} from "@lodestar/params";
 
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants/index.js";
 import {IBeaconDb} from "../db/index.js";
@@ -130,8 +130,6 @@ export class BeaconChain implements IBeaconChain {
   private successfulExchangeTransition = false;
   private readonly exchangeTransitionConfigurationEverySlots: number;
 
-  private readonly faultInspectionWindow: number;
-  private readonly allowedFaults: number;
   private processShutdownCallback: ProcessShutdownCallback;
 
   constructor(
@@ -177,24 +175,6 @@ export class BeaconChain implements IBeaconChain {
     // > Consensus Layer client software SHOULD poll this endpoint every 60 seconds.
     // Align to a multiple of SECONDS_PER_SLOT for nicer logs
     this.exchangeTransitionConfigurationEverySlots = Math.floor(60 / this.config.SECONDS_PER_SLOT);
-
-    /**
-     * Beacon clients select randomized values from the following ranges when initializing
-     * the circuit breaker (so at boot time and once for each unique boot).
-     *
-     * ALLOWED_FAULTS: between 1 and SLOTS_PER_EPOCH // 2
-     * FAULT_INSPECTION_WINDOW: between SLOTS_PER_EPOCH and 2 * SLOTS_PER_EPOCH
-     *
-     */
-    this.faultInspectionWindow = Math.max(
-      opts.faultInspectionWindow ?? SLOTS_PER_EPOCH + Math.floor(Math.random() * SLOTS_PER_EPOCH),
-      SLOTS_PER_EPOCH
-    );
-    // allowedFaults should be < faultInspectionWindow, limiting them to faultInspectionWindow/2
-    this.allowedFaults = Math.min(
-      opts.allowedFaults ?? Math.floor(this.faultInspectionWindow / 2),
-      Math.floor(this.faultInspectionWindow / 2)
-    );
 
     const signal = this.abortController.signal;
     const emitter = new ChainEventEmitter();
@@ -755,27 +735,24 @@ export class BeaconChain implements IBeaconChain {
   updateBuilderStatus(clockSlot: Slot): void {
     const executionBuilder = this.executionBuilder;
     if (executionBuilder) {
-      const slotsPresent = this.forkChoice.getSlotsPresent(clockSlot - this.faultInspectionWindow);
+      const {faultInspectionWindow, allowedFaults} = executionBuilder;
+      const slotsPresent = this.forkChoice.getSlotsPresent(clockSlot - faultInspectionWindow);
       const previousStatus = executionBuilder.status;
-      const shouldEnable = slotsPresent >= this.faultInspectionWindow - this.allowedFaults;
+      const shouldEnable = slotsPresent >= faultInspectionWindow - allowedFaults;
 
       executionBuilder.updateStatus(shouldEnable);
       // The status changed we should log
       const status = executionBuilder.status;
+      const builderLog = {
+        status,
+        slotsPresent,
+        faultInspectionWindow,
+        allowedFaults,
+      };
       if (status !== previousStatus) {
-        this.logger.info("Execution builder status updated", {
-          status,
-          slotsPresent,
-          window: this.faultInspectionWindow,
-          allowedFaults: this.allowedFaults,
-        });
+        this.logger.info("Execution builder status updated", builderLog);
       } else {
-        this.logger.verbose("Execution builder status", {
-          status,
-          slotsPresent,
-          window: this.faultInspectionWindow,
-          allowedFaults: this.allowedFaults,
-        });
+        this.logger.verbose("Execution builder status", builderLog);
       }
     }
   }

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -15,10 +15,6 @@ export type IChainOptions = BlockProcessOpts &
     skipCreateStateCacheIfAvailable?: boolean;
     suggestedFeeRecipient: string;
     maxSkipSlots?: number;
-    /** Window to inspect missed slots for enabling/disabling builder circuit breaker */
-    faultInspectionWindow?: number;
-    /** Number of missed slots allowed in the faultInspectionWindow for builder circuit*/
-    allowedFaults?: number;
     /** Ensure blobs returned by the execution engine are valid */
     sanityCheckExecutionEngineBlobs?: boolean;
     /** Max number of produced blobs by local validators to cache */

--- a/packages/beacon-node/src/execution/builder/interface.ts
+++ b/packages/beacon-node/src/execution/builder/interface.ts
@@ -8,6 +8,11 @@ export interface IExecutionBuilder {
    */
   readonly issueLocalFcUForBlockProduction?: boolean;
   status: boolean;
+  /** Window to inspect missed slots for enabling/disabling builder circuit breaker */
+  faultInspectionWindow: number;
+  /** Number of missed slots allowed in the faultInspectionWindow for builder circuit*/
+  allowedFaults: number;
+
   updateStatus(shouldEnable: boolean): void;
   checkStatus(): Promise<void>;
   registerValidator(registrations: bellatrix.SignedValidatorRegistrationV1[]): Promise<void>;

--- a/packages/cli/src/options/beaconNodeOptions/builder.ts
+++ b/packages/cli/src/options/beaconNodeOptions/builder.ts
@@ -5,6 +5,8 @@ export type ExecutionBuilderArgs = {
   builder: boolean;
   "builder.urls": string[];
   "builder.timeout": number;
+  "builder.faultInspectionWindow": number;
+  "builder.allowedFaults": number;
 };
 
 export function parseArgs(args: ExecutionBuilderArgs): IBeaconNodeOptions["executionBuilder"] {
@@ -12,6 +14,8 @@ export function parseArgs(args: ExecutionBuilderArgs): IBeaconNodeOptions["execu
     enabled: args["builder"],
     urls: args["builder.urls"],
     timeout: args["builder.timeout"],
+    faultInspectionWindow: args["builder.faultInspectionWindow"],
+    allowedFaults: args["builder.allowedFaults"],
   };
 }
 
@@ -38,6 +42,18 @@ export const options: CliCommandOptions<ExecutionBuilderArgs> = {
     type: "number",
     defaultDescription:
       defaultOptions.executionBuilder.mode === "http" ? String(defaultOptions.executionBuilder.timeout) : "",
+    group: "builder",
+  },
+
+  "builder.faultInspectionWindow": {
+    type: "number",
+    description: "Window to inspect missed slots for enabling/disabling builder circuit breaker",
+    group: "builder",
+  },
+
+  "builder.allowedFaults": {
+    type: "number",
+    description: "Number of missed slots allowed in the faultInspectionWindow for builder circuit",
     group: "builder",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -136,6 +136,8 @@ describe("options / beaconNodeOptions", () => {
         enabled: false,
         urls: ["http://localhost:8661"],
         timeout: 12000,
+        faultInspectionWindow: 32,
+        allowedFaults: 16,
       },
       metrics: {
         enabled: true,

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -48,6 +48,8 @@ describe("options / beaconNodeOptions", () => {
       builder: false,
       "builder.urls": ["http://localhost:8661"],
       "builder.timeout": 12000,
+      "builder.faultInspectionWindow": 32,
+      "builder.allowedFaults": 16,
 
       metrics: true,
       "metrics.port": 8765,


### PR DESCRIPTION
Allow builder circuit breaker to be configured for hive tests with following beacon cli options

`--builder.faultInspectionWindow 32 --builder.allowedFaults 16`