### PR TITLE
Use new db bucket for light client updates

### DIFF
--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -65,7 +65,8 @@ export enum Bucket {
   // TODO: May be redundant to block stores
   lightClient_checkpointHeader = 53, // BlockRoot -> phase0.BeaconBlockHeader
   // 54 was for bestPartialLightClientUpdate, allocate a fresh one
-  lightClient_bestLightClientUpdate = 55, // SyncPeriod -> LightClientUpdate
+  // lightClient_bestLightClientUpdate = 55, // SyncPeriod -> LightClientUpdate // DEPRECATED on v1.5.0
+  lightClient_bestLightClientUpdate = 56, // SyncPeriod -> [Slot, LightClientUpdate]
 
   validator_metaData = 41,
 


### PR DESCRIPTION
**Motivation**

Avoid bad UX error:
`Error: LightClientUpdate size 25360 not equal fixed size 25368`

**Description**

Use a new bucket for light client updates since https://github.com/ChainSafe/lodestar/pull/5027 changed what we store on disk.