### PR TITLE
Reduce afterEach time in network e2e tests

### DIFF
--- a/packages/beacon-node/test/e2e/network/mdns.test.ts
+++ b/packages/beacon-node/test/e2e/network/mdns.test.ts
@@ -30,10 +30,8 @@ describe("mdns", function () {
 
   const afterEachCallbacks: (() => Promise<void> | void)[] = [];
   afterEach(async () => {
-    while (afterEachCallbacks.length > 0) {
-      const callback = afterEachCallbacks.pop();
-      if (callback) await callback();
-    }
+    await Promise.all(afterEachCallbacks.map((cb) => cb()));
+    afterEachCallbacks.splice(0, afterEachCallbacks.length);
   });
 
   let controller: AbortController;

--- a/packages/beacon-node/test/e2e/network/network.test.ts
+++ b/packages/beacon-node/test/e2e/network/network.test.ts
@@ -34,10 +34,8 @@ describe("network", function () {
 
   const afterEachCallbacks: (() => Promise<void> | void)[] = [];
   afterEach(async () => {
-    while (afterEachCallbacks.length > 0) {
-      const callback = afterEachCallbacks.pop();
-      if (callback) await callback();
-    }
+    await Promise.all(afterEachCallbacks.map((cb) => cb()));
+    afterEachCallbacks.splice(0, afterEachCallbacks.length);
   });
 
   let controller: AbortController;
@@ -56,12 +54,7 @@ describe("network", function () {
       bootMultiaddrs: [],
       localMultiaddrs: [],
       discv5FirstQueryDelayMs: 0,
-      discv5: {
-        enr,
-        bindAddr: bindAddrUdp,
-        bootEnrs: [],
-        enabled: true,
-      },
+      discv5: null,
     };
   }
 


### PR DESCRIPTION
**Motivation**

- Fix network e2e timeout issue

**Description**

- Execute callbacks in parallel
- Do not configure discv5

Closes #5180 #5138
