### PR TITLE
Allow new release create-rc based off stable branch

### DIFF
--- a/scripts/release/create_rc.mjs
+++ b/scripts/release/create_rc.mjs
@@ -55,12 +55,16 @@ if (!semver.gt(versionMMP, currentVersion)) {
 const currentBranch = getCurrentBranch();
 if (semver.patch(versionMMP) === 0) {
   // New version release candidate
-  // This script must be run from unstable branch
-  if (currentBranch !== UNSTABLE_BRANCH) {
+  // This script must be run from unstable or stable branch
+  if (currentBranch === STABLE_BRANCH) {
+    console.warn(`Warning: Creating a new release from branch ${STABLE_BRANCH}. In most cases, a new release should be based off branch ${UNSTABLE_BRANCH} and only hotfixes should be based off branch ${STABLE_BRANCH}`);
+    assertCommitExistsInBranch(commit, STABLE_BRANCH);
+  } else if (currentBranch === UNSTABLE_BRANCH) {
+    assertCommitExistsInBranch(commit, UNSTABLE_BRANCH);
+  } else {
     throw Error(`Must be run in branch '${UNSTABLE_BRANCH}' but is in '${currentBranch}'`);
   }
 
-  assertCommitExistsInBranch(commit, UNSTABLE_BRANCH);
 } else {
   // Hot-fix release candidate
   // This script must be run from unstable branch


### PR DESCRIPTION
**Motivation**

1.5.0 will be similar to a hotfix that might otherwise be released as 1.4.4, but will include some fixes that require a breaking change. Our release scripts assume that all new releases will be based on the unstable branch.
Update the `release:create-rc` script to allow future releases to happen more easily.

**Description**
