### PR TITLE
Update default builder selection strategy to MaxProfit

### DIFF
--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -120,7 +120,7 @@ type ValidatorData = ProposerConfig & {
 export const defaultOptions = {
   suggestedFeeRecipient: "0x0000000000000000000000000000000000000000",
   defaultGasLimit: 30_000_000,
-  builderSelection: BuilderSelection.BuilderAlways,
+  builderSelection: BuilderSelection.MaxProfit,
 };
 
 /**


### PR DESCRIPTION
Shift builder vs execution default selection strategy to max profit

making this as a default UX makes more sense for a retail user who has to supply less args :+1: