### PR TITLE
Add reason label to Requested peers to disconnect panel

### DIFF
--- a/dashboards/lodestar_networking.json
+++ b/dashboards/lodestar_networking.json
@@ -1713,7 +1713,7 @@
           "expr": "increase(lodestar_peers_requested_total_to_disconnect[$rate_interval])",
           "hide": false,
           "interval": "",
-          "legendFormat": "to disconnect",
+          "legendFormat": "to disconnect {{reason}}",
           "refId": "B"
         }
       ],


### PR DESCRIPTION
**Motivation**

The "Requested peers to disconnect" panel has duplicate "to disconnect" legends

<img width="1274" alt="Screen Shot 2023-03-03 at 09 15 42" src="https://user-images.githubusercontent.com/10568965/222614485-31cd708e-f0cf-4b26-a106-50ea467420b8.png">


**Description**

- Add `{{reason}}` label to distinguish them

<img width="1276" alt="Screen Shot 2023-03-03 at 09 16 39" src="https://user-images.githubusercontent.com/10568965/222614603-6099c155-4ab6-4b0a-9ad2-04a02377da84.png">


part of #5198

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
