### PR TITLE
chore: cancel previous workflows on new push to the PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,9 +1,10 @@
 name: Benchmark
 
-# only one can run at a time.
 # Actions access a common cache entry and may corrupt it.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
+  # if push, default to github.ref so retries of the same commit do not overwrite each other
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,10 @@
 name: Benchmark
 
-# only one can tun at a time.
+# only one can run at a time.
 # Actions access a common cache entry and may corrupt it.
-concurrency: cd-benchmark-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,11 @@
 #
 name: "CodeQL"
 
+# only one can run at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,8 +11,8 @@
 #
 name: "CodeQL"
 
-# only one can run at a time.
 concurrency:
+  # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
@@ -27,7 +27,7 @@ on:
       - stable
       - unstable
   schedule:
-    - cron: '19 21 * * 3'
+    - cron: "19 21 * * 3"
 
 jobs:
   analyze:
@@ -41,41 +41,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]
+        language: ["javascript"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -1,4 +1,8 @@
 name: Browser tests
+# only one can run at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -1,6 +1,7 @@
 name: Browser tests
-# only one can run at a time.
+
 concurrency:
+  # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,4 +1,8 @@
 name: E2E tests
+# only one can run at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,6 +1,7 @@
 name: E2E tests
-# only one can run at a time.
+
 concurrency:
+  # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -1,4 +1,8 @@
 name: Sim merge execution/builder tests
+# only one can run at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -1,6 +1,7 @@
 name: Sim merge execution/builder tests
-# only one can run at a time.
+
 concurrency:
+  # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -1,6 +1,7 @@
 name: Sim tests
-# only one can run at a time.
+
 concurrency:
+  # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -1,4 +1,8 @@
 name: Sim tests
+# only one can run at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -1,4 +1,8 @@
 name: Spec tests
+# only one can run at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -1,6 +1,7 @@
 name: Spec tests
-# only one can run at a time.
+
 concurrency:
+  # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
@@ -63,5 +64,5 @@ jobs:
         run: yarn test:spec-minimal
         working-directory: packages/beacon-node
       - name: Spec tests mainnet
-        run:  NODE_OPTIONS='--max-old-space-size=4096' yarn test:spec-mainnet
+        run: NODE_OPTIONS='--max-old-space-size=4096' yarn test:spec-mainnet
         working-directory: packages/beacon-node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,8 @@
 name: Tests
+# only one can run at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Tests
-# only one can run at a time.
+# only one can run at a time
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Tests
 # only one can run at a time
 concurrency:
+  # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 


### PR DESCRIPTION
Cancel previous workflows on new push to the PRs

grouping strategy to cancel any previous runs:
```
  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
```

head_ref is only defined on PRs and will group the runs per PR and on stable/unstable the unique run id will cause each PR merge commit to be grouped separately resulting into  CI being run on each merged PR commit.

 