### PR TITLE
Track fetch response streaming time

### DIFF
--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -285,9 +285,11 @@ export class HttpClient implements IHttpClient {
         throw new HttpError(`${res.statusText}: ${getErrorMessage(errBody)}`, res.status, url);
       }
 
+      const streamTimer = this.metrics?.streamTime.startTimer({routeId});
+      const body = await getBody(res);
+      streamTimer?.();
       this.logger?.debug("HttpClient response", {routeId});
-
-      return {status: res.status, body: await getBody(res)};
+      return {status: res.status, body};
     } catch (e) {
       this.metrics?.requestErrors.inc({routeId});
 

--- a/packages/api/src/utils/client/metrics.ts
+++ b/packages/api/src/utils/client/metrics.ts
@@ -1,5 +1,6 @@
 export type Metrics = {
   requestTime: Histogram<"routeId">;
+  streamTime: Histogram<"routeId">;
   requestErrors: Gauge<"routeId">;
   requestToFallbacks: Gauge<"routeId">;
   urlsScore: Gauge<"urlIndex">;

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1345,6 +1345,13 @@ export function createLodestarMetrics(
         // Provide max resolution on problematic values around 1 second
         buckets: [0.1, 0.5, 1, 2, 5, 15],
       }),
+      streamTime: register.histogram<"routeId">({
+        name: "lodestar_eth1_http_client_stream_time_seconds",
+        help: "eth1 JsonHttpClient - streaming time by routeId",
+        labelNames: ["routeId"],
+        // Provide max resolution on problematic values around 1 second
+        buckets: [0.1, 0.5, 1, 2, 5, 15],
+      }),
       requestErrors: register.gauge<"routeId">({
         name: "lodestar_eth1_http_client_request_errors_total",
         help: "eth1 JsonHttpClient - total count of request errors",
@@ -1375,6 +1382,13 @@ export function createLodestarMetrics(
       requestTime: register.histogram<"routeId">({
         name: "lodestar_execution_engine_http_client_request_time_seconds",
         help: "ExecutionEngineHttp client - histogram or roundtrip request times",
+        labelNames: ["routeId"],
+        // Provide max resolution on problematic values around 1 second
+        buckets: [0.1, 0.5, 1, 2, 5, 15],
+      }),
+      streamTime: register.histogram<"routeId">({
+        name: "lodestar_execution_engine_http_client_stream_time_seconds",
+        help: "ExecutionEngineHttp client - streaming time by routeId",
         labelNames: ["routeId"],
         // Provide max resolution on problematic values around 1 second
         buckets: [0.1, 0.5, 1, 2, 5, 15],

--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -331,7 +331,15 @@ export function getMetrics(register: MetricsRegister, gitData: LodestarGitData) 
         help: "Histogram of REST API client request time by routeId",
         labelNames: ["routeId"],
         // Expected times are ~ 50-500ms, but in an overload NodeJS they can be greater
-        buckets: [0.01, 0.1, 1, 5],
+        buckets: [0.01, 0.1, 1, 2, 5],
+      }),
+
+      streamTime: register.histogram<{routeId: string}>({
+        name: "vc_rest_api_client_stream_time_seconds",
+        help: "Histogram of REST API client streaming time by routeId",
+        labelNames: ["routeId"],
+        // Expected times are ~ 50-500ms, but in an overload NodeJS they can be greater
+        buckets: [0.01, 0.1, 1, 2, 5],
       }),
 
       requestErrors: register.gauge<{routeId: string}>({


### PR DESCRIPTION
**Motivation**

As found in #5227, sometimes it takes a lot of time to stream the block body to client, thanks @nflaig for the finding.

**Description**

- Add `streamTime` to all http client metrics

Closes #5227
