### PR TITLE
Comment on PRs included in release

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -114,6 +114,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  comment:
+    name: Comment on included PRs
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    needs: [tag, npm]
+    if: needs.tag.outputs.is_stable == 'true'
+    steps:
+      - uses: nflaig/release-comment-on-pr@v1
+        with:
+          token: ${{ secrets.GH_PAGES_TOKEN }}
+
   docker:
     name: Publish to Docker Hub
     runs-on: buildjet-4vcpu-ubuntu-2204


### PR DESCRIPTION
**Motivation**

Make it easier to track in which release a PR was included.

**Description**

Comment on PRs included in stable release by adding [GitHub Action: Comment on Pull Requests included in Release](https://github.com/marketplace/actions/comment-on-pull-requests-included-in-release) to publish stable workflow.

By default the message looks like this:

🎉 This PR is included in [v1.5.0](https://github.com/ChainSafe/lodestar/releases/tag/v1.5.0) 🎉

We can customize that if needed by setting the `message`, see [inputs](https://github.com/marketplace/actions/comment-on-pull-requests-included-in-release#inputs). 
