### PR TITLE
Bump prom-client from 14.1.0 to 14.2.0

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -145,7 +145,7 @@
     "it-pipe": "^2.0.5",
     "jwt-simple": "0.5.6",
     "libp2p": "0.42.2",
-    "prom-client": "^14.1.0",
+    "prom-client": "^14.2.0",
     "prometheus-gc-stats": "^0.6.3",
     "snappyjs": "^0.7.0",
     "stream-to-it": "^0.2.0",

--- a/packages/beacon-node/src/monitoring/properties.ts
+++ b/packages/beacon-node/src/monitoring/properties.ts
@@ -1,5 +1,5 @@
-import {Registry} from "prom-client";
-import {JsonRecord, JsonType, MetricObject, MetricValue, MetricWithGetter, RecordValue} from "./types.js";
+import {MetricObjectWithValues, MetricValue as MetricValueObject, Registry} from "prom-client";
+import {JsonRecord, JsonType, MetricValue, RecordValue} from "./types.js";
 
 type PropertyDefinition = {
   /** Key of value to be sent to remote service */
@@ -86,7 +86,7 @@ export class MetricProperty<T extends RecordValue> implements ClientStatsPropert
     const metric = register.getSingleMetric(this.definition.metricName);
 
     if (metric) {
-      const metricObject = await (metric as MetricWithGetter).get();
+      const metricObject = await metric.get();
 
       const metricValue = this.extractMetricValue(metricObject);
 
@@ -106,7 +106,7 @@ export class MetricProperty<T extends RecordValue> implements ClientStatsPropert
     return {key: this.definition.jsonKey, value: this.definition.defaultValue};
   }
 
-  private extractMetricValue(metricObject: MetricObject): MetricValue | undefined {
+  private extractMetricValue(metricObject: MetricObjectWithValues<MetricValueObject<string>>): MetricValue | undefined {
     const {withLabel, fromLabel} = this.definition;
 
     if (withLabel) {

--- a/packages/beacon-node/src/monitoring/types.ts
+++ b/packages/beacon-node/src/monitoring/types.ts
@@ -1,15 +1,4 @@
-import {Metric} from "prom-client";
 import {ClientStatsProperty} from "./properties.js";
-
-// get methods are missing in prom-client type definitions
-// see https://github.com/siimon/prom-client/pull/531
-export type MetricWithGetter = Metric & {
-  get(): Promise<MetricObject>;
-};
-
-export type MetricObject = {
-  values: Array<{value: number; labels: Record<string, string>}>;
-};
 
 export type MetricValue = string | number;
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -83,7 +83,7 @@
     "js-yaml": "^3.14.0",
     "lockfile": "^1.0.4",
     "lodash": "^4.17.15",
-    "prom-client": "^14.1.0",
+    "prom-client": "^14.2.0",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.19",
     "uint8arrays": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10792,10 +10792,10 @@ progress@^2.0.3:
   resolved "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-prom-client@^14.1.0:
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.1.0.tgz#049609859483d900844924df740722c76ed1fdbb"
-  integrity sha512-iFWCchQmi4170omLpFXbzz62SQTmPhtBL35v0qGEVRHKcqIeiexaoYeP0vfZTujxEq3tA87iqOdRbC9svS1B9A==
+prom-client@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
+  integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
   dependencies:
     tdigest "^0.1.1"
 


### PR DESCRIPTION
**Motivation**

Update `prom-client` to latest version which allows to remove workaround types and also includes minor performance improvement.

**Description**

- Bump prom-client from 14.1.0 to 14.2.0
- Remove prom-client workaround types


**Notable prom-client updates**

- https://github.com/siimon/prom-client/pull/531 adds `get` method to type definitions of metric classes
- https://github.com/siimon/prom-client/pull/542 improved performance of `getMetricAsPrometheusString`
