### PR TITLE
msgIdToStrFn: support Uint8Array

### DIFF
--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -2,7 +2,7 @@ import {compress, uncompress} from "snappyjs";
 import xxhashFactory from "xxhash-wasm";
 import {Message} from "@libp2p/interface-pubsub";
 import {digest} from "@chainsafe/as-sha256";
-import {intToBytes} from "@lodestar/utils";
+import {intToBytes, toHex} from "@lodestar/utils";
 import {ForkName} from "@lodestar/params";
 import {RPC} from "@chainsafe/libp2p-gossipsub/message";
 import {MESSAGE_DOMAIN_VALID_SNAPPY} from "./constants.js";
@@ -27,8 +27,7 @@ export function fastMsgIdFn(rpcMsg: RPC.IMessage): string {
 }
 
 export function msgIdToStrFn(msgId: Uint8Array): string {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-  return Buffer.prototype.toString.call(msgId, "base64");
+  return toHex(msgId);
 }
 
 /**


### PR DESCRIPTION
**Motivation**
- Nimbus sent responded `IWANT` messages, however Lodestar missed some of them
- That's due to this untracked gossipsub rpc error:

```
Mar-06 11:50:37.088[network]         ^[[34mdebug^[[39m: 2023-03-06T11:50:37.088Z libp2p:gossipsub TypeError: buf.hexSlice is not a function
    at Object.slice (node:buffer:675:37)
    at Uint8Array.toString (node:buffer:818:14)
    at Eth2Gossipsub.msgIdToStrFn (file:///usr/src/lodestar/packages/beacon-node/src/network/gossip/encoding.ts:31:36)
    at file:///usr/src/lodestar/node_modules/@chainsafe/libp2p-gossipsub/src/index.ts:1354:31
    at Array.forEach (<anonymous>)
    at file:///usr/src/lodestar/node_modules/@chainsafe/libp2p-gossipsub/src/index.ts:1353:18
    at Array.forEach (<anonymous>)
    at Eth2Gossipsub.handleIHave (file:///usr/src/lodestar/node_modules/@chainsafe/libp2p-gossipsub/src/index.ts:1346:11)
    at Eth2Gossipsub.handleControlMessage (file:///usr/src/lodestar/node_modules/@chainsafe/libp2p-gossipsub/src/index.ts:1264:43)
    at Eth2Gossipsub.handleReceivedRpc (file:///usr/src/lodestar/node_modules/@chainsafe/libp2p-gossipsub/src/index.ts:1045:18)
```
<img width="1297" alt="Screen Shot 2023-03-07 at 13 08 18" src="https://user-images.githubusercontent.com/10568965/223335146-cb52951a-12fb-481e-9ad8-1b417c0ae695.png">

**Description**

- Right now we assume message id is Buffer but sometimes it may be Uint8Array and it causes the above error
- Use our `toHex()` utility which support both Buffer and Uint8Array

part of #5074

part of https://github.com/ChainSafe/js-libp2p-gossipsub/issues/411
