### PR TITLE
Stablize lightclient e2e tests

### DIFF
--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -485,6 +485,7 @@ export class LightClientServer {
       this.logger.debug("sync committee below required MIN_SYNC_COMMITTEE_PARTICIPANTS", {
         syncPeriod,
         attestedPeriod,
+        syncAggregateParticipation,
       });
       this.metrics?.lightclientServer.onSyncAggregate.inc({event: "ignore_sync_committee_low"});
       return;

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -14,7 +14,7 @@ import {BeaconNode} from "../../../../../src/node/nodejs.js";
 import {waitForEvent} from "../../../../utils/events/resolver.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
-describe.only("lightclient api", function () {
+describe("lightclient api", function () {
   this.timeout("10 min");
 
   const SECONDS_PER_SLOT = 1;

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -14,7 +14,7 @@ import {BeaconNode} from "../../../../../src/node/nodejs.js";
 import {waitForEvent} from "../../../../utils/events/resolver.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
-describe("lightclient api", function () {
+describe.only("lightclient api", function () {
   this.timeout("10 min");
 
   const SECONDS_PER_SLOT = 1;
@@ -71,22 +71,31 @@ describe("lightclient api", function () {
     }
   });
 
-  it("getUpdates()", async function () {
+  const waitForBestUpdate = async (): Promise<void> => {
+    // should see this event in 5 slots
+    await waitForEvent(
+      bn.chain.emitter,
+      routes.events.EventType.lightClientOptimisticUpdate,
+      5 * SECONDS_PER_SLOT * 1000
+    );
+    // wait for 1 slot to persist the best update
     await sleep(2 * SECONDS_PER_SLOT * 1000);
+  };
+
+  it("getUpdates()", async function () {
     const client = getClient({baseUrl: `http://127.0.0.1:${restPort}`}, {config}).lightclient;
+    await waitForBestUpdate();
     const res = await client.getUpdates(0, 1);
     ApiError.assert(res);
     const updates = res.response;
-    const slot = bn.chain.clock.currentSlot;
     expect(updates.length).to.be.equal(1);
-    // at slot 2 we got attestedHeader for slot 1
-    expect(updates[0].data.attestedHeader.beacon.slot).to.be.equal(slot - 1);
+    // best update could be any slots
     // version is set
     expect(updates[0].version).to.be.equal(ForkName.altair);
   });
 
   it("getOptimisticUpdate()", async function () {
-    await sleep(2 * SECONDS_PER_SLOT * 1000);
+    await waitForBestUpdate();
     const client = getClient({baseUrl: `http://127.0.0.1:${restPort}`}, {config}).lightclient;
     const res = await client.getOptimisticUpdate();
     ApiError.assert(res);
@@ -109,8 +118,7 @@ describe("lightclient api", function () {
   });
 
   it("getCommitteeRoot() for the 1st period", async function () {
-    // call this right away causes "No partialUpdate available for period 0"
-    await sleep(2 * SECONDS_PER_SLOT * 1000);
+    await waitForBestUpdate();
 
     const lightclient = getClient({baseUrl: `http://127.0.0.1:${restPort}`}, {config}).lightclient;
     const committeeRes = await lightclient.getCommitteeRoot(0, 1);


### PR DESCRIPTION
**Motivation**

Stablize lightclient e2e tests

**Description**

Make sure there is a stored best update before calling `getUpdate` at lightclient api client side

Closes #4806
Closes #5208
