### PR TITLE
Add logging support to prover

### DIFF
--- a/packages/prover/package.json
+++ b/packages/prover/package.json
@@ -68,7 +68,9 @@
     "http-proxy": "^1.18.1",
     "yargs": "^16.1.0",
     "source-map-support": "^0.5.19",
-    "find-up": "^5.0.0"
+    "find-up": "^5.0.0",
+    "winston": "^3.3.3",
+    "winston-transport": "^4.5.0"
   },
   "devDependencies": {
     "@types/http-proxy": "^1.17.10",

--- a/packages/prover/src/cli/cli.ts
+++ b/packages/prover/src/cli/cli.ts
@@ -5,6 +5,7 @@ import {hideBin} from "yargs/helpers";
 import {registerCommandToYargs} from "../utils/command.js";
 import {getVersionData} from "../utils/version.js";
 import {cmds} from "./cmds/index.js";
+import {globalOptions} from "./options.js";
 
 const {version} = getVersionData();
 const topBanner = `🌟 Lodestar Prover Proxy: Ethereum RPC proxy for RPC responses, verified against the trusted block hashes.
@@ -30,6 +31,7 @@ export function getLodestarProverCli(): yargs.Argv {
       // Manually processing options is typesafe tho more verbose
       "dot-notation": false,
     })
+    .options(globalOptions)
     // blank scriptName so that help text doesn't display the cli name before each command
     .scriptName("")
     .demandCommand(1)

--- a/packages/prover/src/cli/cmds/index.ts
+++ b/packages/prover/src/cli/cmds/index.ts
@@ -1,3 +1,5 @@
+import {CliCommand} from "../../utils/command.js";
+import {GlobalArgs} from "../options.js";
 import {proverProxyStartCommand} from "./start/index.js";
 
-export const cmds = [proverProxyStartCommand];
+export const cmds: Required<CliCommand<GlobalArgs, Record<never, never>>>["subcommands"] = [proverProxyStartCommand];

--- a/packages/prover/src/cli/cmds/start/handler.ts
+++ b/packages/prover/src/cli/cmds/start/handler.ts
@@ -1,16 +1,18 @@
 import {LCTransport} from "../../../interfaces.js";
 import {createVerifiedExecutionProxy, VerifiedProxyOptions} from "../../../web3_proxy.js";
-import {stdLogger} from "../../../utils/logger.js";
+import {GlobalArgs, parseGlobalArgs} from "../../options.js";
 import {parseStartArgs, StartArgs} from "./options.js";
 
 /**
  * Runs a beacon node.
  */
-export async function proverProxyStartHandler(args: StartArgs): Promise<void> {
+export async function proverProxyStartHandler(args: StartArgs & GlobalArgs): Promise<void> {
+  const {network, logLevel} = parseGlobalArgs(args);
   const opts = parseStartArgs(args);
-  const {network, executionRpcUrl, port, wsCheckpoint} = opts;
+  const {executionRpcUrl, port, wsCheckpoint} = opts;
+
   const options: VerifiedProxyOptions = {
-    logger: stdLogger,
+    logLevel,
     network,
     executionRpcUrl,
     wsCheckpoint,

--- a/packages/prover/src/cli/cmds/start/index.ts
+++ b/packages/prover/src/cli/cmds/start/index.ts
@@ -1,8 +1,9 @@
 import {CliCommand, CliCommandOptions} from "../../../utils/command.js";
+import {GlobalArgs} from "../../options.js";
 import {proverProxyStartHandler} from "./handler.js";
 import {StartArgs, startOptions} from "./options.js";
 
-export const proverProxyStartCommand: CliCommand<StartArgs> = {
+export const proverProxyStartCommand: CliCommand<StartArgs, GlobalArgs> = {
   command: "start",
   describe: "Start proxy server",
   examples: [

--- a/packages/prover/src/cli/cmds/start/options.ts
+++ b/packages/prover/src/cli/cmds/start/options.ts
@@ -1,10 +1,8 @@
-import {NetworkName, networksChainConfig} from "@lodestar/config/networks";
 import {LCTransport} from "../../../interfaces.js";
 import {CliCommandOptions} from "../../../utils/command.js";
 
 export type StartArgs = {
   port: number;
-  network: string;
   "execution-rpc-url": string;
   transport: "rest" | "p2p";
   "beacon-urls"?: string[];
@@ -13,7 +11,6 @@ export type StartArgs = {
 };
 
 export type StartOptions = {
-  network: NetworkName;
   executionRpcUrl: string;
   port: number;
   wsCheckpoint?: string;
@@ -25,13 +22,6 @@ export const startOptions: CliCommandOptions<StartArgs> = {
     type: "number",
     default: 8080,
   },
-
-  network: {
-    description: "Specify the network to connect.",
-    type: "string",
-    choices: Object.keys(networksChainConfig),
-  },
-
   "execution-rpc-url": {
     description: "RPC url for the execution node.",
     type: "string",
@@ -68,7 +58,6 @@ export function parseStartArgs(args: StartArgs): StartOptions {
   // Remove undefined values to allow deepmerge to inject default values downstream
   return {
     port: args["port"],
-    network: args["network"] as NetworkName,
     executionRpcUrl: args["execution-rpc-url"],
     transport: args["transport"] === "p2p" ? LCTransport.P2P : LCTransport.Rest,
     urls: args["transport"] === "rest" ? args["beacon-urls"] ?? [] : [],

--- a/packages/prover/src/cli/options.ts
+++ b/packages/prover/src/cli/options.ts
@@ -1,0 +1,36 @@
+import {NetworkName, networksChainConfig} from "@lodestar/config/networks";
+import {LogLevel, LogLevels} from "@lodestar/utils";
+import {CliCommandOptions} from "../utils/command.js";
+
+export type GlobalArgs = {
+  network: string;
+  "log-level": string;
+};
+
+export type GlobalOptions = {
+  logLevel: LogLevel;
+  network: NetworkName;
+};
+
+export const globalOptions: CliCommandOptions<GlobalArgs> = {
+  network: {
+    description: "Specify the network to connect.",
+    type: "string",
+    choices: Object.keys(networksChainConfig),
+  },
+
+  "log-level": {
+    description: "Set the log level.",
+    type: "string",
+    choices: LogLevels,
+    default: "info",
+  },
+};
+
+export function parseGlobalArgs(args: GlobalArgs): GlobalOptions {
+  // Remove undefined values to allow deepmerge to inject default values downstream
+  return {
+    network: args["network"] as NetworkName,
+    logLevel: args["log-level"] as LogLevel,
+  };
+}

--- a/packages/prover/src/interfaces.ts
+++ b/packages/prover/src/interfaces.ts
@@ -1,5 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {NetworkName} from "@lodestar/config/networks";
+import {Logger, LogLevel} from "@lodestar/utils";
 import {ProofProvider} from "./proof_provider/proof_provider.js";
 import {ELRequestPayload, ELResponse} from "./types.js";
 
@@ -11,9 +12,10 @@ export enum LCTransport {
 export type RootProviderInitOptions = {
   network: NetworkName;
   signal: AbortSignal;
+  logger: Logger;
   config?: ChainForkConfig;
   wsCheckpoint?: string;
-} & ({transport: LCTransport.Rest; urls: string[]} | {transport: LCTransport.P2P; bootnodes: string[]});
+} & ConsensusNodeOptions;
 
 export type ELRequestMethod = (payload: ELRequestPayload) => Promise<ELResponse | undefined>;
 
@@ -47,5 +49,14 @@ export type Web3Provider = SendProvider | EthersProvider | SendAsyncProvider | R
 export type ELVerifiedRequestHandler<A = unknown, R = unknown> = (opts: {
   payload: ELRequestPayload<A>;
   handler: ELRequestMethod;
-  rootProvider: ProofProvider;
+  proofProvider: ProofProvider;
+  logger: Logger;
 }) => Promise<ELResponse<R>>;
+
+// Either a logger is provided by user or user specify a log level
+// If both are skipped then we don't log anything (useful for browser plugins)
+export type LogOptions = {logger?: Logger; logLevel?: never} | {logLevel?: LogLevel; logger?: never};
+
+export type ConsensusNodeOptions =
+  | {transport: LCTransport.Rest; urls: string[]}
+  | {transport: LCTransport.P2P; bootnodes: string[]};

--- a/packages/prover/src/proof_provider/proof_provider.ts
+++ b/packages/prover/src/proof_provider/proof_provider.ts
@@ -5,6 +5,7 @@ import {Lightclient, LightclientEvent, RunStatusCode} from "@lodestar/light-clie
 import {LightClientRestTransport} from "@lodestar/light-client/transport";
 import {isForkWithdrawals} from "@lodestar/params";
 import {allForks, capella} from "@lodestar/types";
+import {Logger} from "@lodestar/utils";
 import {LCTransport, RootProviderInitOptions} from "../interfaces.js";
 import {assertLightClient} from "../utils/assertion.js";
 import {
@@ -13,6 +14,7 @@ import {
   getSyncCheckpoint,
   getUnFinalizedRangeForPayloads,
 } from "../utils/consensus.js";
+import {bufferToHex} from "../utils/conversion.js";
 import {PayloadStore} from "./payload_store.js";
 
 type RootProviderOptions = Omit<RootProviderInitOptions, "transport"> & {
@@ -23,13 +25,15 @@ type RootProviderOptions = Omit<RootProviderInitOptions, "transport"> & {
 
 export class ProofProvider {
   private store: PayloadStore;
+  private logger: Logger;
 
   // Make sure readyPromise doesn't throw unhandled exceptions
   private readyPromise?: Promise<void>;
   lightClient?: Lightclient;
 
   constructor(private opts: RootProviderOptions) {
-    this.store = new PayloadStore({api: opts.api});
+    this.store = new PayloadStore({api: opts.api, logger: opts.logger});
+    this.logger = opts.logger;
   }
 
   async waitToBeReady(): Promise<void> {
@@ -40,7 +44,10 @@ export class ProofProvider {
     if (opts.transport === LCTransport.P2P) {
       throw new Error("P2P mode not supported yet");
     }
-
+    opts.logger.info("Creating ProofProvider instance with REST APIs", {
+      network: opts.network,
+      urls: opts.urls.join(","),
+    });
     const config = createChainForkConfig(networksChainConfig[opts.network]);
     const api = getClient({urls: opts.urls}, {config});
     const transport = new LightClientRestTransport(api);
@@ -66,11 +73,12 @@ export class ProofProvider {
     if (this.lightClient !== undefined) {
       throw Error("Light client already initialized and syncing.");
     }
-
+    this.logger.info("Starting sync for proof provider");
     const {api, config, transport} = this.opts;
     const checkpointRoot = await getSyncCheckpoint(api, wsCheckpoint);
     const genesisData = await getGenesisData(api);
 
+    this.logger.info("Initializing lightclient", {checkpointRoot: bufferToHex(checkpointRoot)});
     this.lightClient = await Lightclient.initializeFromCheckpointRoot({
       checkpointRoot,
       config,
@@ -88,21 +96,36 @@ export class ProofProvider {
         }
       };
       this.lightClient?.emitter.on(LightclientEvent.statusChange, lightClientStarted);
+      this.logger.info("Initiating lightclient");
       this.lightClient?.start();
     });
+    this.logger.info("Lightclient synced", this.getStatus());
     this.registerEvents();
 
     // Load the payloads from the CL
+    this.logger.info("Building EL payload history");
     const {start, end} = await getUnFinalizedRangeForPayloads(this.lightClient);
-    const payloads = await getExecutionPayloads(this.opts.api, start, end);
+    const payloads = await getExecutionPayloads({
+      api: this.opts.api,
+      startSlot: start,
+      endSlot: end,
+      logger: this.logger,
+    });
     for (const payload of Object.values(payloads)) {
       this.store.set(payload, false);
     }
 
     // Load the finalized payload from the CL
     const finalizedSlot = this.lightClient.getFinalized().beacon.slot;
-    const finalizedPayload = await getExecutionPayloads(this.opts.api, finalizedSlot, finalizedSlot);
+    this.logger.debug("Getting finalized slot from lightclient", {finalizedSlot});
+    const finalizedPayload = await getExecutionPayloads({
+      api: this.opts.api,
+      startSlot: finalizedSlot,
+      endSlot: finalizedSlot,
+      logger: this.logger,
+    });
     this.store.set(finalizedPayload[finalizedSlot], true);
+    this.logger.info("Proof provider ready");
   }
 
   getStatus(): {latest: number; finalized: number; status: RunStatusCode} {
@@ -172,17 +195,13 @@ export class ProofProvider {
 
     this.lightClient.emitter.on(LightclientEvent.lightClientFinalityHeader, async (data) => {
       await this.processLCHeader(data, true).catch((e) => {
-        // Will be replaced with logger in next PR.
-        // eslint-disable-next-line no-console
-        console.error(e);
+        this.logger.error("Error processing finality update", null, e);
       });
     });
 
     this.lightClient.emitter.on(LightclientEvent.lightClientOptimisticHeader, async (data) => {
       await this.processLCHeader(data).catch((e) => {
-        // Will be replaced with logger in next PR.
-        // eslint-disable-next-line no-console
-        console.error(e);
+        this.logger.error("Error processing optimistic update", null, e);
       });
     });
   }

--- a/packages/prover/src/utils/consensus.ts
+++ b/packages/prover/src/utils/consensus.ts
@@ -2,6 +2,7 @@ import {Api} from "@lodestar/api/beacon";
 import {allForks, Bytes32, capella} from "@lodestar/types";
 import {GenesisData, Lightclient} from "@lodestar/light-client";
 import {ApiError} from "@lodestar/api";
+import {Logger} from "@lodestar/utils";
 import {MAX_PAYLOAD_HISTORY} from "../constants.js";
 import {hexToBuffer} from "./conversion.js";
 
@@ -32,13 +33,19 @@ export async function getUnFinalizedRangeForPayloads(lightClient: Lightclient): 
   };
 }
 
-export async function getExecutionPayloads(
-  api: Api,
-  startSlot: number,
-  endSlot: number
-): Promise<Record<number, allForks.ExecutionPayload>> {
+export async function getExecutionPayloads({
+  api,
+  startSlot,
+  endSlot,
+  logger,
+}: {
+  api: Api;
+  startSlot: number;
+  endSlot: number;
+  logger: Logger;
+}): Promise<Record<number, allForks.ExecutionPayload>> {
   [startSlot, endSlot] = [Math.min(startSlot, endSlot), Math.max(startSlot, endSlot)];
-
+  logger.debug("Fetching EL payloads", {startSlot, endSlot});
   const payloads: Record<number, allForks.ExecutionPayload> = {};
 
   let slot = endSlot;

--- a/packages/prover/src/utils/logger.ts
+++ b/packages/prover/src/utils/logger.ts
@@ -35,8 +35,9 @@ class BrowserConsole extends Transport {
     const mappedMethod = this.methods[method as BrowserLogLevels];
 
     if (val <= this.levels[this.level as BrowserLogLevels]) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, no-console, @typescript-eslint/ban-ts-comment
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, no-console
       console[mappedMethod](message);
     }
   }

--- a/packages/prover/src/verified_requests/eth_getBalance.ts
+++ b/packages/prover/src/verified_requests/eth_getBalance.ts
@@ -6,12 +6,13 @@ import {generateRPCResponseForPayload, generateUnverifiedResponseForPayload} fro
 export const ethGetBalance: ELVerifiedRequestHandler<[address: string, block?: number | string], string> = async ({
   handler,
   payload,
-  rootProvider,
+  logger,
+  proofProvider,
 }) => {
   const {
     params: [address, block],
   } = payload;
-  const executionPayload = await rootProvider.getExecutionPayload(block ?? "latest");
+  const executionPayload = await proofProvider.getExecutionPayload(block ?? "latest");
   const proof = await getELProof(handler, [address, [], bufferToHex(executionPayload.blockHash)]);
 
   if (
@@ -25,5 +26,6 @@ export const ethGetBalance: ELVerifiedRequestHandler<[address: string, block?: n
     return generateRPCResponseForPayload(payload, proof.balance);
   }
 
+  logger.error("Request could not be verified.");
   return generateUnverifiedResponseForPayload(payload, "eth_getBalance request can not be verified.");
 };

--- a/packages/prover/src/web3_provider.ts
+++ b/packages/prover/src/web3_provider.ts
@@ -1,8 +1,10 @@
 import {NetworkName} from "@lodestar/config/networks";
+import {Logger} from "@lodestar/utils";
 import {
+  ConsensusNodeOptions,
   EIP1193Provider,
   EthersProvider,
-  LCTransport,
+  LogOptions,
   RequestProvider,
   SendAsyncProvider,
   SendProvider,
@@ -18,11 +20,10 @@ import {
   isSendProvider,
 } from "./utils/assertion.js";
 import {processAndVerifyRequest} from "./utils/execution.js";
+import {getLogger} from "./utils/logger.js";
 
-type ProvableProviderInitOpts = {network?: NetworkName; wsCheckpoint?: string} & (
-  | {transport: LCTransport.Rest; urls: string[]}
-  | {transport: LCTransport.P2P; bootnodes: string[]}
-);
+type ProvableProviderInitOpts = {network?: NetworkName; wsCheckpoint?: string; signal?: AbortSignal} & LogOptions &
+  ConsensusNodeOptions;
 
 const defaultNetwork = "mainnet";
 
@@ -30,37 +31,44 @@ export function createVerifiedExecutionProvider<T extends Web3Provider>(
   provider: T,
   opts: ProvableProviderInitOpts
 ): {provider: T; proofProvider: ProofProvider} {
-  const controller = new AbortController();
+  const signal = opts.signal ?? new AbortController().signal;
+  const logger = getLogger(opts);
   const proofProvider = ProofProvider.init({
     ...opts,
     network: opts.network ?? defaultNetwork,
-    signal: controller.signal,
+    signal,
+    logger,
   });
 
   if (isSendProvider(provider)) {
-    return {provider: handleSendProvider(provider, proofProvider) as T, proofProvider: proofProvider};
+    logger.debug("Creating a provider which is recognized as legacy provider with 'send' method.");
+    return {provider: handleSendProvider(provider, proofProvider, logger) as T, proofProvider};
   }
 
   if (isEthersProvider(provider)) {
-    return {provider: handleEthersProvider(provider, proofProvider) as T, proofProvider: proofProvider};
+    logger.debug("Creating a provider which is recognized as 'ethers' provider.");
+    return {provider: handleEthersProvider(provider, proofProvider, logger) as T, proofProvider};
   }
 
   if (isRequestProvider(provider)) {
-    return {provider: handleRequestProvider(provider, proofProvider) as T, proofProvider: proofProvider};
+    logger.debug("Creating a provider which is recognized as legacy provider with 'request' method.");
+    return {provider: handleRequestProvider(provider, proofProvider, logger) as T, proofProvider};
   }
 
   if (isSendAsyncProvider(provider)) {
-    return {provider: handleSendAsyncProvider(provider, proofProvider) as T, proofProvider: proofProvider};
+    logger.debug("Creating a provider which is recognized as legacy provider with 'sendAsync' method.");
+    return {provider: handleSendAsyncProvider(provider, proofProvider, logger) as T, proofProvider};
   }
 
   if (isEIP1193Provider(provider)) {
-    return {provider: handleEIP1193Provider(provider, proofProvider) as T, proofProvider: proofProvider};
+    logger.debug("Creating a provider which is recognized as 'EIP1193' provider.");
+    return {provider: handleEIP1193Provider(provider, proofProvider, logger) as T, proofProvider};
   }
 
   return {provider, proofProvider: proofProvider};
 }
 
-function handleSendProvider(provider: SendProvider, rootProvider: ProofProvider): SendProvider {
+function handleSendProvider(provider: SendProvider, proofProvider: ProofProvider, logger: Logger): SendProvider {
   const send = provider.send.bind(provider);
   const handler = (payload: ELRequestPayload): Promise<ELResponse | undefined> =>
     new Promise((resolve, reject) => {
@@ -74,7 +82,7 @@ function handleSendProvider(provider: SendProvider, rootProvider: ProofProvider)
     });
 
   function newSend(payload: ELRequestPayload, callback: (err?: Error | null, response?: ELResponse) => void): void {
-    processAndVerifyRequest({payload, handler, proofProvider: rootProvider})
+    processAndVerifyRequest({payload, handler, proofProvider, logger})
       .then((response) => callback(undefined, response))
       .catch((err) => callback(err, undefined));
   }
@@ -82,7 +90,11 @@ function handleSendProvider(provider: SendProvider, rootProvider: ProofProvider)
   return Object.assign(provider, {send: newSend});
 }
 
-function handleRequestProvider(provider: RequestProvider, rootProvider: ProofProvider): RequestProvider {
+function handleRequestProvider(
+  provider: RequestProvider,
+  proofProvider: ProofProvider,
+  logger: Logger
+): RequestProvider {
   const request = provider.request.bind(provider);
   const handler = (payload: ELRequestPayload): Promise<ELResponse | undefined> =>
     new Promise((resolve, reject) => {
@@ -96,7 +108,7 @@ function handleRequestProvider(provider: RequestProvider, rootProvider: ProofPro
     });
 
   function newRequest(payload: ELRequestPayload, callback: (err?: Error | null, response?: ELResponse) => void): void {
-    processAndVerifyRequest({payload, handler, proofProvider: rootProvider})
+    processAndVerifyRequest({payload, handler, proofProvider, logger})
       .then((response) => callback(undefined, response))
       .catch((err) => callback(err, undefined));
   }
@@ -104,29 +116,37 @@ function handleRequestProvider(provider: RequestProvider, rootProvider: ProofPro
   return Object.assign(provider, {request: newRequest});
 }
 
-function handleSendAsyncProvider(provider: SendAsyncProvider, rootProvider: ProofProvider): SendAsyncProvider {
+function handleSendAsyncProvider(
+  provider: SendAsyncProvider,
+  proofProvider: ProofProvider,
+  logger: Logger
+): SendAsyncProvider {
   const sendAsync = provider.sendAsync.bind(provider);
   const handler = (payload: ELRequestPayload): Promise<ELResponse | undefined> => sendAsync(payload);
 
   async function newSendAsync(payload: ELRequestPayload): Promise<ELResponse | undefined> {
-    return processAndVerifyRequest({payload, handler, proofProvider: rootProvider});
+    return processAndVerifyRequest({payload, handler, proofProvider, logger});
   }
 
   return Object.assign(provider, {sendAsync: newSendAsync});
 }
 
-function handleEIP1193Provider(provider: EIP1193Provider, rootProvider: ProofProvider): EIP1193Provider {
+function handleEIP1193Provider(
+  provider: EIP1193Provider,
+  proofProvider: ProofProvider,
+  logger: Logger
+): EIP1193Provider {
   const request = provider.request.bind(provider);
   const handler = (payload: ELRequestPayload): Promise<ELResponse | undefined> => request(payload);
 
   async function newRequest(payload: ELRequestPayload): Promise<ELResponse | undefined> {
-    return processAndVerifyRequest({payload, handler, proofProvider: rootProvider});
+    return processAndVerifyRequest({payload, handler, proofProvider, logger});
   }
 
   return Object.assign(provider, {request: newRequest});
 }
 
-function handleEthersProvider(provider: EthersProvider, rootProvider: ProofProvider): EthersProvider {
+function handleEthersProvider(provider: EthersProvider, proofProvider: ProofProvider, logger: Logger): EthersProvider {
   const send = provider.send.bind(provider);
   const handler = (payload: ELRequestPayload): Promise<ELResponse | undefined> => send(payload.method, payload.params);
 
@@ -134,7 +154,8 @@ function handleEthersProvider(provider: EthersProvider, rootProvider: ProofProvi
     return processAndVerifyRequest({
       payload: {jsonrpc: "2.0", id: 0, method, params},
       handler,
-      proofProvider: rootProvider,
+      proofProvider,
+      logger,
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9878,6 +9878,18 @@ logform@^2.2.0:
     ms "^2.1.1"
     triple-beam "^1.3.0"
 
+logform@^2.3.2:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.5.1.tgz#44c77c34becd71b3a42a3970c77929e52c6ed48b"
+  integrity sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    "@types/triple-beam" "^1.3.2"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    safe-stable-stringify "^2.3.1"
+    triple-beam "^1.3.0"
+
 long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
@@ -12550,6 +12562,11 @@ safe-regex2@^2.0.0:
   dependencies:
     ret "~0.2.0"
 
+safe-stable-stringify@^2.3.1:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.2.tgz#ec7b037768098bf65310d1d64370de0dc02353aa"
+  integrity sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==
+
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
@@ -14570,6 +14587,15 @@ winston-transport@^4.3.0, winston-transport@^4.4.0:
   dependencies:
     readable-stream "^2.3.7"
     triple-beam "^1.2.0"
+
+winston-transport@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.5.0.tgz#6e7b0dd04d393171ed5e4e4905db265f7ab384fa"
+  integrity sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==
+  dependencies:
+    logform "^2.3.2"
+    readable-stream "^3.6.0"
+    triple-beam "^1.3.0"
 
 winston@^3.3.3:
   version "3.3.3"


### PR DESCRIPTION
**Motivation**

Add detailed logging support to the prover. 

**Description**

Use should be able to see th logs in the browser as well in the console for the proxy. 


Partially resolves #4706

**Steps to test or reproduce**

Run all tests.