### PR TITLE
Specify ckzg 1.0.7 for test flow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Only install c-kzg if required. See https://github.com/ChainSafe/lodestar/pull/4888
       # Install in workspace root, else there are weird type errors with NodeJS types
-      - run: yarn add --ignore-workspace-root-check c-kzg
+      - run: yarn add --ignore-workspace-root-check c-kzg@1.0.7
 
       # Cache validator slashing protection data tests
       - name: Restore spec tests cache


### PR DESCRIPTION
**Motivation**

Failed test in Release v1.5.1 PR #5253 https://github.com/ChainSafe/lodestar/actions/runs/4379547064/jobs/7666306325

```
 1) doBeaconBlocksMaybeBlobsByRange
@lodestar/beacon-node:        one block with sidecar:
@lodestar/beacon-node:      TypeError: ckzg.computeAggregateKzgProof is not a function
@lodestar/beacon-node:       at Context.<anonymous> (file:///home/runner/work/lodestar/lodestar/packages/beacon-node/test/unit/network/doBeaconBlocksMaybeBlobsByRange.test.ts:63:44)
@lodestar/beacon-node:       at processImmediate (node:internal/timers:476:21)
```

**Description**

- The test flow wants to go with ckzg v1.0.7 but v2.0.0 was released 9 days ago
- Specify v1.0.7 in test flow
