### PR TITLE
Fix missing builder streamTime metric

### DIFF
--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -4,7 +4,7 @@ import {getClient, Api as BuilderApi} from "@lodestar/api/builder";
 import {byteArrayEquals, toHexString} from "@chainsafe/ssz";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 
-import {ApiError, Metrics as ApiMetrics} from "@lodestar/api";
+import {ApiError} from "@lodestar/api";
 import {validateBlobsAndKzgCommitments} from "../../chain/produceBlock/validateBlobsAndKzgCommitments.js";
 import {Metrics} from "../../metrics/metrics.js";
 import {IExecutionBuilder} from "./interface.js";
@@ -38,10 +38,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
   constructor(opts: ExecutionBuilderHttpOpts, config: ChainForkConfig, metrics: Metrics | null = null) {
     const baseUrl = opts.urls[0];
     if (!baseUrl) throw Error("No Url provided for executionBuilder");
-    this.api = getClient(
-      {baseUrl, timeoutMs: opts.timeout},
-      {config, metrics: metrics?.builderHttpClient as ApiMetrics | undefined}
-    );
+    this.api = getClient({baseUrl, timeoutMs: opts.timeout}, {config, metrics: metrics?.builderHttpClient});
     this.config = config;
     this.issueLocalFcUForBlockProduction = opts.issueLocalFcUForBlockProduction;
 

--- a/packages/beacon-node/src/metrics/interface.ts
+++ b/packages/beacon-node/src/metrics/interface.ts
@@ -1,7 +1,9 @@
 import {Gauge, Histogram} from "prom-client";
 
+type CollectFn<T extends string> = (metric: IGauge<T>) => void;
+
 export type IGauge<T extends string = string> = Pick<Gauge<T>, "inc" | "dec" | "set"> & {
-  addCollect: (collectFn: () => void) => void;
+  addCollect: (collectFn: CollectFn<T>) => void;
 };
 
 export type IHistogram<T extends string = string> = Pick<Histogram<T>, "observe" | "startTimer">;

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1427,13 +1427,18 @@ export function createLodestarMetrics(
         // Expected times are ~ 50-500ms, but in an overload NodeJS they can be greater
         buckets: [0.01, 0.1, 1, 5],
       }),
-
+      streamTime: register.histogram<"routeId">({
+        name: "vc_builder_http_client_stream_time_seconds",
+        help: "Builder api - streaming time by routeId",
+        labelNames: ["routeId"],
+        // Provide max resolution on problematic values around 1 second
+        buckets: [0.1, 0.5, 1, 2, 5, 15],
+      }),
       requestErrors: register.gauge<"routeId">({
         name: "vc_builder_http_client_request_errors_total",
         help: "Total count of errors on builder http client requests by routeId",
         labelNames: ["routeId"],
       }),
-
       requestToFallbacks: register.gauge<"routeId">({
         name: "vc_builder_http_client_request_to_fallbacks_total",
         help: "Total count of requests to fallback URLs on builder http API by routeId",


### PR DESCRIPTION
EF devops reported a builder api bug while running 1.6.0-rc for goerli nodes

![image](https://user-images.githubusercontent.com/76567250/224344135-5f5a98f1-f288-4f73-8c67-c22fe2412e84.png)

PS: this doesn't affect 1.5.1-rc releases and hence won't also affect 1.5.1 release, so we only need to include fix for 1.6 releases