### PR TITLE
Fix attestation compatibility issue in distributed validator cluster

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -51,6 +51,7 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
 
   const {version, commit} = getVersionData();
   logger.info("Lodestar", {network, version, commit});
+  if (args.distributed) logger.info("Client is configured to run as part of a distributed validator cluster");
   logger.info("Connecting to LevelDB database", {path: validatorPaths.validatorsDbDir});
 
   const dbPath = validatorPaths.validatorsDbDir;
@@ -167,6 +168,7 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
       scAfterBlockDelaySlotFraction: args.scAfterBlockDelaySlotFraction,
       disableAttestationGrouping: args.disableAttestationGrouping,
       valProposerConfig,
+      distributed: args.distributed,
     },
     metrics
   );

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -165,6 +165,7 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
       doppelgangerProtectionEnabled,
       afterBlockDelaySlotFraction: args.afterBlockDelaySlotFraction,
       scAfterBlockDelaySlotFraction: args.scAfterBlockDelaySlotFraction,
+      disableAttestationGrouping: args.disableAttestationGrouping,
       valProposerConfig,
     },
     metrics

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -36,6 +36,7 @@ export type IValidatorCliArgs = AccountValidatorArgs &
     graffiti: string;
     afterBlockDelaySlotFraction?: number;
     scAfterBlockDelaySlotFraction?: number;
+    disableAttestationGrouping?: boolean;
     suggestedFeeRecipient?: string;
     proposerSettingsFile?: string;
     strictFeeRecipientCheck?: boolean;
@@ -187,6 +188,14 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
     description:
       "Delay before publishing SyncCommitteeSignature if block comes early, as a fraction of SECONDS_PER_SLOT (value is from 0 inclusive to 1 exclusive)",
     type: "number",
+  },
+
+  disableAttestationGrouping: {
+    hidden: true,
+    description:
+      "Disables attestation service grouping optimization, attestation tasks will be executed per committee instead of just once for all committees.",
+    default: false,
+    type: "boolean",
   },
 
   proposerSettingsFile: {

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -53,6 +53,8 @@ export type IValidatorCliArgs = AccountValidatorArgs &
     "externalSigner.pubkeys"?: string[];
     "externalSigner.fetch"?: boolean;
 
+    distributed?: boolean;
+
     interopIndexes?: string;
     fromMnemonic?: string;
     mnemonicIndexes?: string;
@@ -284,6 +286,14 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
     description: "Fetch then list of pubkeys to validate from an external signer",
     type: "boolean",
     group: "externalSignerUrl",
+  },
+
+  // Distributed validator
+
+  distributed: {
+    description: "Enables specific features required to run as part of a distributed validator cluster",
+    default: false,
+    type: "boolean",
   },
 
   // Metrics

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -196,7 +196,6 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
     hidden: true,
     description:
       "Disables attestation service grouping optimization, attestation tasks will be executed per committee instead of just once for all committees.",
-    default: false,
     type: "boolean",
   },
 
@@ -292,7 +291,6 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
 
   distributed: {
     description: "Enables specific features required to run as part of a distributed validator cluster",
-    default: false,
     type: "boolean",
   },
 

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -76,7 +76,9 @@ export class AttestationService {
       const dutiesByCommitteeIndex = groupAttDutiesByCommitteeIndex(duties);
       await Promise.all(
         Array.from(dutiesByCommitteeIndex.entries()).map(([index, duties]) =>
-          this.runAttestationTasksPerCommittee(duties, slot, index, signal)
+          this.runAttestationTasksPerCommittee(duties, slot, index, signal).catch((e) => {
+            this.logger.error("Error on attestation routine", {slot, index}, e);
+          })
         )
       );
     } else {

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -12,7 +12,7 @@ import {groupAttDutiesByCommitteeIndex} from "./utils.js";
 import {ChainHeaderTracker} from "./chainHeaderTracker.js";
 import {ValidatorEventEmitter} from "./emitter.js";
 
-type AttestationServiceOpts = {
+export type AttestationServiceOpts = {
   afterBlockDelaySlotFraction?: number;
   disableAttestationGrouping?: boolean;
 };

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -14,6 +14,7 @@ import {ValidatorEventEmitter} from "./emitter.js";
 
 type AttestationServiceOpts = {
   afterBlockDelaySlotFraction?: number;
+  disableAttestationGrouping?: boolean;
 };
 
 /**
@@ -64,68 +65,69 @@ export class AttestationService {
     await Promise.race([sleep(this.clock.msToSlot(slot + 1 / 3), signal), this.emitter.waitForBlockSlot(slot)]);
     this.metrics?.attesterStepCallProduceAttestation.observe(this.clock.secFromSlot(slot + 1 / 3));
 
-    // TODO: Move to options
-    const skipAttestationGrouping = true;
-
-    if (skipAttestationGrouping) {
-      // TODO: Explain in detail with distributed validators need to not have this optimization
+    if (this.opts?.disableAttestationGrouping) {
+      // Attestation service grouping optimization must be disabled in a distributed validator cluster as
+      // middleware clients such as Charon (https://github.com/ObolNetwork/charon) expect the actual committee index
+      // to be sent to produceAttestationData endpoint. This is required because the middleware client itself
+      // calls produceAttestationData on the beacon node for each validator and there is a slight chance that
+      // the `beacon_block_root` (LMD GHOST vote) changes between calls which would cause a conflict between
+      // attestations submitted by Lodestar and other VCs in the cluster, resulting in aggregation failure.
+      // See https://github.com/ChainSafe/lodestar/issues/5103 for further details and references.
       const dutiesByCommitteeIndex = groupAttDutiesByCommitteeIndex(duties);
       await Promise.all(
         Array.from(dutiesByCommitteeIndex.entries()).map(([index, duties]) =>
-          this.produceAttestationDefault(duties, slot, index, signal)
+          this.runAttestationTasksPerCommittee(duties, slot, index, signal)
         )
       );
     } else {
       // Beacon node's endpoint produceAttestationData return data is not dependant on committeeIndex.
-      // Produce a single attestation for all committees, and clone mutate before signing
-      await this.runAttestationTaskGrouped(duties, slot, signal);
+      // Produce a single attestation for all committees and submit unaggregated attestations in one go.
+      await this.runAttestationTasksGrouped(duties, slot, signal);
     }
   };
 
-  private async produceAttestationDefault(
+  private async runAttestationTasksPerCommittee(
     dutiesSameCommittee: AttDutyAndProof[],
     slot: Slot,
     index: number,
     signal: AbortSignal
   ): Promise<void> {
+    // Produce attestation with actual committee index
     const attestation = await this.produceAttestation(index, slot);
 
-    // Step 1. Mutate, and sign `Attestation` for each validator. Then publish all `Attestations` in one go
+    // Step 1. Sign `Attestation` for each validator. Then publish all `Attestations` in one go
     await this.signAndPublishAttestations(slot, attestation, dutiesSameCommittee);
 
     // Step 2. after all attestations are submitted, make an aggregate.
-    // First, wait until the `aggregation_production_instant` (2/3rds of the way though the slot)
+    // First, wait until the `aggregation_production_instant` (2/3rds of the way through the slot)
     await sleep(this.clock.msToSlot(slot + 2 / 3), signal);
     this.metrics?.attesterStepCallProduceAggregate.observe(this.clock.secFromSlot(slot + 2 / 3));
 
     // Then download, sign and publish a `SignedAggregateAndProof` for each
-    // validator that is elected to aggregate for this `slot` and
-    // `committeeIndex`.
+    // validator that is elected to aggregate for this `slot` and `committeeIndex`.
     await this.produceAndPublishAggregates(attestation, dutiesSameCommittee);
   }
 
-  private async runAttestationTaskGrouped(
+  private async runAttestationTasksGrouped(
     dutiesAll: AttDutyAndProof[],
     slot: Slot,
     signal: AbortSignal
   ): Promise<void> {
-    // Downstream tooling may require that produceAttestation is called with a 'real' committee index
-    // So we pick the first duty's committee index - see https://github.com/ChainSafe/lodestar/issues/4687
-    const attestationNoCommittee = await this.produceAttestation(dutiesAll[0].duty.committeeIndex, slot);
+    // Produce a single attestation for all committees, and clone mutate before signing
+    const attestationNoCommittee = await this.produceAttestation(0, slot);
 
     // Step 1. Mutate, and sign `Attestation` for each validator. Then publish all `Attestations` in one go
     await this.signAndPublishAttestations(slot, attestationNoCommittee, dutiesAll);
 
     // Step 2. after all attestations are submitted, make an aggregate.
-    // First, wait until the `aggregation_production_instant` (2/3rds of the way though the slot)
+    // First, wait until the `aggregation_production_instant` (2/3rds of the way through the slot)
     await sleep(this.clock.msToSlot(slot + 2 / 3), signal);
     this.metrics?.attesterStepCallProduceAggregate.observe(this.clock.secFromSlot(slot + 2 / 3));
 
-    const dutiesByCommitteeIndex = groupAttDutiesByCommitteeIndex(this.dutiesService.getDutiesAtSlot(slot));
+    const dutiesByCommitteeIndex = groupAttDutiesByCommitteeIndex(dutiesAll);
 
     // Then download, sign and publish a `SignedAggregateAndProof` for each
-    // validator that is elected to aggregate for this `slot` and
-    // `committeeIndex`.
+    // validator that is elected to aggregate for this `slot` and `committeeIndex`.
     await Promise.all(
       Array.from(dutiesByCommitteeIndex.entries()).map(([index, dutiesSameCommittee]) => {
         const attestationData: phase0.AttestationData = {...attestationNoCommittee, index};
@@ -140,8 +142,7 @@ export class AttestationService {
    * For a validator client with many validators this allows to do a single call for all committees
    * in a slot, saving resources in both the vc and beacon node
    *
-   * A committee index is still passed in for the benefit of downstream tooling -
-   * see https://github.com/ChainSafe/lodestar/issues/4687
+   * Note: the actual committeeIndex must be passed in if attestation grouping is disabled
    */
   private async produceAttestation(committeeIndex: number, slot: Slot): Promise<phase0.AttestationData> {
     // Produce one attestation data per slot and committeeIndex

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -37,6 +37,7 @@ export type ValidatorOptions = {
   doppelgangerProtectionEnabled?: boolean;
   closed?: boolean;
   valProposerConfig?: ValidatorProposerConfig;
+  distributed?: boolean;
 };
 
 // TODO: Extend the timeout, and let it be customizable
@@ -126,7 +127,7 @@ export class Validator {
       metrics,
       {
         afterBlockDelaySlotFraction: opts.afterBlockDelaySlotFraction,
-        disableAttestationGrouping: opts.disableAttestationGrouping,
+        disableAttestationGrouping: opts.disableAttestationGrouping || opts.distributed,
       }
     );
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -33,6 +33,7 @@ export type ValidatorOptions = {
   abortController: AbortController;
   afterBlockDelaySlotFraction?: number;
   scAfterBlockDelaySlotFraction?: number;
+  disableAttestationGrouping?: boolean;
   doppelgangerProtectionEnabled?: boolean;
   closed?: boolean;
   valProposerConfig?: ValidatorProposerConfig;
@@ -123,7 +124,10 @@ export class Validator {
       emitter,
       chainHeaderTracker,
       metrics,
-      {afterBlockDelaySlotFraction: opts.afterBlockDelaySlotFraction}
+      {
+        afterBlockDelaySlotFraction: opts.afterBlockDelaySlotFraction,
+        disableAttestationGrouping: opts.disableAttestationGrouping,
+      }
     );
 
     this.syncCommitteeService = new SyncCommitteeService(


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5103 and https://github.com/ChainSafe/lodestar/issues/4687

**Description**

- allow to disable attestation service grouping optimization, attestation tasks will be executed per committee instead of just once for all committees
- add cli option to disable attestation service grouping optimization (`--disableAttestationGrouping`)
- add cli option to run as part of a distributed validator cluster (`--distributed`), this will also disable attestation grouping

**Open tasks**

- [x] add tests for  `runAttestationTasksPerCommittee`
- [x] remove TODOs