### PR TITLE
Always add gossip attestations to forkchoice

### DIFF
--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -255,15 +255,13 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       const {indexedAttestation} = validationResult;
       metrics?.registerGossipUnaggregatedAttestation(seenTimestampSec, indexedAttestation);
 
-      // Node may be subscribe to extra subnets (long-lived random subnets). For those, validate the messages
-      // but don't import them, to save CPU and RAM
-      if (!attnetsService.shouldProcess(subnet, attestation.data.slot)) {
-        return;
-      }
-
       try {
-        const insertOutcome = chain.attestationPool.add(attestation);
-        metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
+        // Node may be subscribe to extra subnets (long-lived random subnets). For those, validate the messages
+        // but don't add to attestation poolm, to save CPU and RAM
+        if (attnetsService.shouldProcess(subnet, attestation.data.slot)) {
+          const insertOutcome = chain.attestationPool.add(attestation);
+          metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
+        }
       } catch (e) {
         logger.error("Error adding unaggregated attestation to pool", {subnet}, e as Error);
       }

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -257,7 +257,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
 
       try {
         // Node may be subscribe to extra subnets (long-lived random subnets). For those, validate the messages
-        // but don't add to attestation poolm, to save CPU and RAM
+        // but don't add to attestation pool, to save CPU and RAM
         if (attnetsService.shouldProcess(subnet, attestation.data.slot)) {
           const insertOutcome = chain.attestationPool.add(attestation);
           metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});


### PR DESCRIPTION
**Motivation**

- Gossip handler: Right now we do early return if beacon node does not have any validators as aggregator on specified subnets, i.e we didn't add gossip attestations to forkchoice in that case

**Description**

- We should always add attestations to forkchoice
- The `attnetsService.shouldProcess` should only decide if we add attestation to our pool to prepare for aggregator's duty later
