### PR TITLE
Process gossip block immediately

### DIFF
--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -27,7 +27,7 @@ export type NetworkProcessorOpts = GossipHandlerOpts & {
 const executeGossipWorkOrderObj: Record<GossipType, boolean> = {
   // gossip block verify signatures on main thread, hence we want to bypass the bls check
   [GossipType.beacon_block]: true,
-  [GossipType.beacon_block_and_blobs_sidecar]: false,
+  [GossipType.beacon_block_and_blobs_sidecar]: true,
   [GossipType.beacon_aggregate_and_proof]: false,
   [GossipType.beacon_attestation]: false,
   [GossipType.voluntary_exit]: false,

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -132,11 +132,11 @@ export class NetworkProcessor {
     let jobsSubmitted = 0;
 
     job_loop: while (jobsSubmitted < MAX_JOBS_SUBMITTED_PER_TICK) {
+      // Check canAcceptWork before calling queue.next() since it consumes the items
+      const canAcceptWork = this.chain.blsThreadPoolCanAcceptWork() && this.chain.regenCanAcceptWork();
       for (const topic of executeGossipWorkOrder) {
-        // Check canAcceptWork before calling queue.next() since it consumes the items
         // beacon block is guaranteed to be processed immedately
-        const bypassQueue = executeGossipWorkOrderObj[topic]?.bypassQueue ?? false;
-        if (!bypassQueue && (!this.chain.blsThreadPoolCanAcceptWork() || !this.chain.regenCanAcceptWork())) {
+        if (!canAcceptWork && !executeGossipWorkOrderObj[topic]?.bypassQueue) {
           this.metrics?.networkProcessor.canNotAcceptWork.inc();
           break job_loop;
         }


### PR DESCRIPTION
**Motivation**

- Gossip Block needs to check bls and regen module like other gossip objects before it's processed, in the worse case the delay could be > 2s like the below test mainnet node

<img width="1271" alt="Screenshot 2023-03-13 at 14 20 08" src="https://user-images.githubusercontent.com/10568965/224633341-6faf3449-7e6b-489f-896e-24f429a408d3.png">

- Gossip block's signature is verified on main thread so network processor should not check for bls thread pool before processing it

**Description**

- Ensure to process gossip block immediately by bypassing bls thread pool and regen check for `beacon_block*` topic

part of #5247