### PR TITLE
docs: Remove comprehensive guide and add quickstart info

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Getting started
 
-- :gear: Follow the installation method for [source install](https://chainsafe.github.io/lodestar/install/source/), [NPM install](https://chainsafe.github.io/lodestar/install/npm/), or [Docker install](https://chainsafe.github.io/lodestar/install/docker/) to install Lodestar. Or use our [comprehensive setup guide](https://hackmd.io/@philknows/HkROkZW55).
+- :gear: Follow the installation method for [source install](https://chainsafe.github.io/lodestar/install/source/), [NPM install](https://chainsafe.github.io/lodestar/install/npm/), or [Docker install](https://chainsafe.github.io/lodestar/install/docker/) to install Lodestar. Or use our [Lodestar Quickstart scripts](https://github.com/ChainSafe/lodestar-quickstart).
 - :books: Use [Lodestar libraries](https://chainsafe.github.io/lodestar/libraries) in your next Ethereum Typescript project.
 - :globe_with_meridians: Run a beacon node on [mainnet or a public testnet](https://chainsafe.github.io/lodestar/usage/beacon-management).
 - :computer: Utilize the whole stack by [starting a local testnet](https://chainsafe.github.io/lodestar/usage/local).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 
 ### Getting started
 
-- Follow the installation method for [source install](install/source.md), [NPM install](install/npm.md), or [Docker install](install/docker.md) to install Lodestar. Or use our [comprehensive setup guide](https://hackmd.io/@philknows/rk5cDvKmK).
+- Follow the installation method for [source install](install/source.md), [NPM install](install/npm.md), or [Docker install](install/docker.md) to install Lodestar. Or use our [Lodestar Quickstart scripts](https://github.com/ChainSafe/lodestar-quickstart).
 - Use [Lodestar libraries](libraries) in your next Ethereum Typescript project.
 - Run a beacon node on [mainnet or a public testnet](usage/beacon-management.md).
 - Utilize the whole stack by [starting a local testnet](usage/local).

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -24,5 +24,5 @@ docker run chainsafe/lodestar --help
 ```
 <!-- prettier-ignore-start -->
 !!! info
-    Docker is the recommended setup for Lodestar. Use our [comprehensive setup guide](https://hackmd.io/@philknows/rk5cDvKmK) with Docker for detailed instructions.
+    Docker is the recommended setup for Lodestar. Use our [Lodestar Quickstart scripts](https://github.com/ChainSafe/lodestar-quickstart) with Docker for detailed instructions.
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
**Motivation**

Comprehensive guide is outdated. 

**Description**

Removing the comprehensive guide links in our docs and pushing users to use the Lodestar quickscripts repo with its own instructions to more easily launch Lodestar + EL client in anticipation of incentive program launch.
