### PR TITLE
Fix builder http client metric prefix

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1421,32 +1421,32 @@ export function createLodestarMetrics(
 
     builderHttpClient: {
       requestTime: register.histogram<"routeId">({
-        name: "vc_builder_http_client_request_time_seconds",
+        name: "lodestar_builder_http_client_request_time_seconds",
         help: "Histogram of builder http client request time by routeId",
         labelNames: ["routeId"],
         // Expected times are ~ 50-500ms, but in an overload NodeJS they can be greater
         buckets: [0.01, 0.1, 1, 5],
       }),
       streamTime: register.histogram<"routeId">({
-        name: "vc_builder_http_client_stream_time_seconds",
+        name: "lodestar_builder_http_client_stream_time_seconds",
         help: "Builder api - streaming time by routeId",
         labelNames: ["routeId"],
         // Provide max resolution on problematic values around 1 second
         buckets: [0.1, 0.5, 1, 2, 5, 15],
       }),
       requestErrors: register.gauge<"routeId">({
-        name: "vc_builder_http_client_request_errors_total",
+        name: "lodestar_builder_http_client_request_errors_total",
         help: "Total count of errors on builder http client requests by routeId",
         labelNames: ["routeId"],
       }),
       requestToFallbacks: register.gauge<"routeId">({
-        name: "vc_builder_http_client_request_to_fallbacks_total",
+        name: "lodestar_builder_http_client_request_to_fallbacks_total",
         help: "Total count of requests to fallback URLs on builder http API by routeId",
         labelNames: ["routeId"],
       }),
 
       urlsScore: register.gauge<"urlIndex">({
-        name: "vc_builder_http_client_urls_score",
+        name: "lodestar_builder_http_client_urls_score",
         help: "Current score of builder http URLs by url index",
         labelNames: ["urlIndex"],
       }),


### PR DESCRIPTION
**Motivation**

Wrong metric prefix found in https://github.com/ChainSafe/lodestar/pull/5231#discussion_r1135789337 , thanks @nflaig 

**Description**

Change builder http client metrcis to `lodestar_` prefix
