### PR TITLE
Improve fork_choice spec test runner's time

### DIFF
--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -6,7 +6,7 @@ import {CheckpointWithHex, ForkChoice} from "@lodestar/fork-choice";
 import {phase0, allForks, bellatrix, ssz, RootHex, deneb} from "@lodestar/types";
 import {bnToNum} from "@lodestar/utils";
 import {createBeaconConfig} from "@lodestar/config";
-import {ForkSeq} from "@lodestar/params";
+import {ForkSeq, isForkBlobs} from "@lodestar/params";
 import {BeaconChain, ChainEvent} from "../../../src/chain/index.js";
 import {createCachedBeaconStateTest} from "../../utils/cachedBeaconState.js";
 import {testLogger} from "../../utils/logger.js";
@@ -42,8 +42,10 @@ export const forkChoiceTest = (opts: {onlyPredefinedResponses: boolean}): TestRu
 ) => {
   return {
     testFunction: async (testcase) => {
-      await initCKZG();
-      loadEthereumTrustedSetup();
+      if (isForkBlobs(fork)) {
+        await initCKZG();
+        loadEthereumTrustedSetup();
+      }
 
       const {steps, anchorState} = testcase;
       const currentSlot = anchorState.slot;

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -32,7 +32,7 @@ export function isForkExecution(fork: ForkName): fork is ForkExecution {
 
 export type ForkWithdrawals = Exclude<ForkExecution, ForkName.bellatrix>;
 export function isForkWithdrawals(fork: ForkName): fork is ForkWithdrawals {
-  return isForkExecution(fork) && fork !== ForkName.capella;
+  return isForkExecution(fork) && fork !== ForkName.bellatrix;
 }
 
 export type ForkBlobs = Exclude<ForkExecution, ForkName.bellatrix | ForkName.capella>;


### PR DESCRIPTION
**Motivation**

- Fork choice spec test runs really slow (20x compared to v1.5.0) due to loading ckzg for all forks

**Description**

- Only load ckzg for deneb in fork_choice spec test runner
- Fix `isForkWithdrawals` util
