### PR TITLE
Upgrade spec to 1.3.0-rc.4 with deneb and fork choice tests skipped to be enabled in followups

### DIFF
--- a/packages/api/test/unit/builder/builder.test.ts
+++ b/packages/api/test/unit/builder/builder.test.ts
@@ -12,7 +12,7 @@ describe("builder", () => {
       /* eslint-disable @typescript-eslint/naming-convention */
       ALTAIR_FORK_EPOCH: 0,
       BELLATRIX_FORK_EPOCH: 0,
-      EIP4844_FORK_EPOCH: 0,
+      DENEB_FORK_EPOCH: 0,
     }),
     getClient,
     getRoutes,

--- a/packages/beacon-node/src/chain/archiver/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiver/archiveBlocks.ts
@@ -41,7 +41,7 @@ export async function archiveBlocks(
   const finalizedNonCanonicalBlocks = forkChoice.getAllNonAncestorBlocks(finalizedCheckpoint.rootHex);
 
   // NOTE: The finalized block will be exactly the first block of `epoch` or previous
-  const finalizedPostDeneb = finalizedCheckpoint.epoch >= config.EIP4844_FORK_EPOCH;
+  const finalizedPostDeneb = finalizedCheckpoint.epoch >= config.DENEB_FORK_EPOCH;
 
   const finalizedCanonicalBlockRoots: BlockRootSlot[] = finalizedCanonicalBlocks.map((block) => ({
     slot: block.slot,
@@ -82,7 +82,7 @@ export async function archiveBlocks(
   // Keep only `[max(GENESIS_EPOCH, current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS), current_epoch]`
   if (finalizedPostDeneb) {
     const blobsSidecarMinEpoch = currentEpoch - config.MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS;
-    if (blobsSidecarMinEpoch >= config.EIP4844_FORK_EPOCH) {
+    if (blobsSidecarMinEpoch >= config.DENEB_FORK_EPOCH) {
       const slotsToDelete = await db.blobsSidecarArchive.keys({lt: computeStartSlotAtEpoch(blobsSidecarMinEpoch)});
       if (slotsToDelete.length > 0) {
         await db.blobsSidecarArchive.batchDelete(slotsToDelete);

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -52,7 +52,7 @@ async function beaconBlockAndBlobsSidecarByRootFallback(
   if (resBlockBlobs.err) {
     // From the spec, if the block is from before the fork, errors with 3: ResourceUnavailable
     // > Clients MUST support requesting blocks and sidecars since minimum_request_epoch, where
-    //   minimum_request_epoch = max(finalized_epoch, current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS, EIP4844_FORK_EPOCH).
+    //   minimum_request_epoch = max(finalized_epoch, current_epoch - MIN_EPOCHS_FOR_BLOBS_SIDECARS_REQUESTS, DENEB_FORK_EPOCH).
     //   If any root in the request content references a block earlier than minimum_request_epoch,
     //   peers SHOULD respond with error code 3: ResourceUnavailable.
     // Ref: https://github.com/ethereum/consensus-specs/blob/aede132f4999ed54b98d35e27aca9451042a1ee9/specs/eip4844/p2p-interface.md#beaconblockandblobssidecarbyroot-v1

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -150,7 +150,7 @@ export class BeaconNode {
     const signal = controller.signal;
 
     // TODO DENEB, where is the best place to do this?
-    if (config.EIP4844_FORK_EPOCH < Infinity) {
+    if (config.DENEB_FORK_EPOCH < Infinity) {
       // TODO DENEB: "c-kzg" is not installed by default, so if the library is not installed this will throw
       // See "Not able to build lodestar from source" https://github.com/ChainSafe/lodestar/issues/4886
       await initCKZG();

--- a/packages/beacon-node/test/e2e/api/impl/config.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/config.test.ts
@@ -11,7 +11,7 @@ const CONSTANT_NAMES_SKIP_LIST = new Set([
   "PARTICIPATION_FLAG_WEIGHTS",
   // TODO DENEB: This constant was added then removed on a spec re-write.
   // When developing DENEB branch the tracked version still doesn't have released the removal
-  "DOMAIN_BLOBS_SIDECAR",
+  "DOMAIN_BLOB_SIDECAR",
 ]);
 
 describe("api / impl / config", function () {

--- a/packages/beacon-node/test/spec/general/index.test.ts
+++ b/packages/beacon-node/test/spec/general/index.test.ts
@@ -1,21 +1,41 @@
 import path from "node:path";
 import {RunnerType} from "../utils/types.js";
-import {specTestIterator} from "../utils/specTestIterator.js";
+import {SkipOpts, specTestIterator} from "../utils/specTestIterator.js";
 import {ethereumConsensusSpecsTests} from "../specTestVersioning.js";
 import {blsTestRunner} from "./bls.js";
 import {sszGeneric} from "./ssz_generic.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
-specTestIterator(path.join(ethereumConsensusSpecsTests.outputDir, "tests", "general"), {
-  bls: {type: RunnerType.default, fn: blsTestRunner},
-  ssz_generic: {
-    type: RunnerType.custom,
-    fn: sszGeneric([
-      // NOTE: ComplexTestStruct tests are not correctly generated.
-      // where deserialized .d value is D: '0x00'. However the tests guide mark that field as D: Bytes[256].
-      // Those test won't be fixed since most implementations staticly compile types.
-      "ComplexTestStruct",
-    ]),
+// NOTE: You MUST always provide a detailed reason of why a spec test is skipped plus link
+// to an issue marking it as pending to re-enable and an aproximate timeline of when it will
+// be fixed.
+// NOTE: Comment the minimum set of test necessary to unblock PRs: For example, instead of
+// skipping all `bls_to_execution_change` tests, just skip for a fork setting:
+// ```
+// skippedPrefixes: [
+//    // Skipped since this only test that withdrawals are de-activated
+//    "eip4844/operations/bls_to_execution_change",
+// ],
+// ```
+const skipOpts: SkipOpts = {
+  // Add kzg runner, tracked here: https://github.com/ChainSafe/lodestar/issues/5279
+  skippedRunners: ["kzg"],
+};
+
+specTestIterator(
+  path.join(ethereumConsensusSpecsTests.outputDir, "tests", "general"),
+  {
+    bls: {type: RunnerType.default, fn: blsTestRunner},
+    ssz_generic: {
+      type: RunnerType.custom,
+      fn: sszGeneric([
+        // NOTE: ComplexTestStruct tests are not correctly generated.
+        // where deserialized .d value is D: '0x00'. However the tests guide mark that field as D: Bytes[256].
+        // Those test won't be fixed since most implementations staticly compile types.
+        "ComplexTestStruct",
+      ]),
+    },
   },
-});
+  skipOpts
+);

--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -33,6 +33,7 @@ const skipOpts: SkipOpts = {
   // To be enabled in decouple blobs PR: https://github.com/ChainSafe/lodestar/pull/5181
   skippedForks: ["deneb"],
   // To be enabled with the fork choice safe slots to justified removal PR
+  // https://github.com/ChainSafe/lodestar/pull/5126
   skippedRunners: ["fork_choice"],
   // TODO: capella
   // BeaconBlockBody proof in lightclient is the new addition in v1.3.0-rc.2-hotfix

--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -30,6 +30,10 @@ import {transition} from "./transition.js";
 // ],
 // ```
 const skipOpts: SkipOpts = {
+  // To be enabled in decouple blobs PR: https://github.com/ChainSafe/lodestar/pull/5181
+  skippedForks: ["deneb"],
+  // To be enabled with the fork choice safe slots to justified removal PR
+  skippedRunners: ["fork_choice"],
   // TODO: capella
   // BeaconBlockBody proof in lightclient is the new addition in v1.3.0-rc.2-hotfix
   // Skip them for now to enable subsequently

--- a/packages/beacon-node/test/spec/presets/transition.ts
+++ b/packages/beacon-node/test/spec/presets/transition.ts
@@ -98,7 +98,7 @@ function getTransitionConfig(fork: ForkName, forkEpoch: number): Partial<ChainCo
     case ForkName.capella:
       return {ALTAIR_FORK_EPOCH: 0, BELLATRIX_FORK_EPOCH: 0, CAPELLA_FORK_EPOCH: forkEpoch};
     case ForkName.deneb:
-      return {ALTAIR_FORK_EPOCH: 0, BELLATRIX_FORK_EPOCH: 0, CAPELLA_FORK_EPOCH: 0, EIP4844_FORK_EPOCH: forkEpoch};
+      return {ALTAIR_FORK_EPOCH: 0, BELLATRIX_FORK_EPOCH: 0, CAPELLA_FORK_EPOCH: 0, DENEB_FORK_EPOCH: forkEpoch};
   }
 }
 

--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -15,7 +15,7 @@ import {DownloadTestsOptions} from "@lodestar/spec-test-util";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: DownloadTestsOptions = {
-  specVersion: "v1.3.0-rc.2-hotfix",
+  specVersion: "v1.3.0-rc.4",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-spec-tests",

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -54,9 +54,7 @@ export function specTestIterator(
     if (opts?.skippedForks?.includes(forkStr)) {
       continue;
     }
-
-    // TODO eip4844: restore the following line as soon as spec tests reflect new name
-    const fork = ForkName[(forkStr === "eip4844" ? "deneb" : forkStr) as ForkName];
+    const fork = forkStr as ForkName;
 
     const forkDirpath = path.join(configDirpath, forkStr);
     for (const testRunnerName of readdirSyncSpec(forkDirpath)) {

--- a/packages/beacon-node/test/unit/chain/lightclient/upgradeLightClientHeader.test.ts
+++ b/packages/beacon-node/test/unit/chain/lightclient/upgradeLightClientHeader.test.ts
@@ -14,7 +14,7 @@ describe("UpgradeLightClientHeader", function () {
     ALTAIR_FORK_EPOCH: 1,
     BELLATRIX_FORK_EPOCH: 2,
     CAPELLA_FORK_EPOCH: 3,
-    EIP4844_FORK_EPOCH: 4,
+    DENEB_FORK_EPOCH: 4,
   });
 
   const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);

--- a/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
@@ -26,7 +26,7 @@ describe("beaconBlocksMaybeBlobsByRange", () => {
     ALTAIR_FORK_EPOCH: 0,
     BELLATRIX_FORK_EPOCH: 0,
     CAPELLA_FORK_EPOCH: 0,
-    EIP4844_FORK_EPOCH: 0,
+    DENEB_FORK_EPOCH: 0,
   });
   const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
   const config = createBeaconConfig(chainConfig, genesisValidatorsRoot);

--- a/packages/beacon-node/test/utils/config.ts
+++ b/packages/beacon-node/test/utils/config.ts
@@ -29,7 +29,7 @@ export function getConfig(fork: ForkName, forkEpoch = 0): ChainForkConfig {
         ALTAIR_FORK_EPOCH: 0,
         BELLATRIX_FORK_EPOCH: 0,
         CAPELLA_FORK_EPOCH: 0,
-        EIP4844_FORK_EPOCH: forkEpoch,
+        DENEB_FORK_EPOCH: forkEpoch,
       });
   }
 }

--- a/packages/config/src/chainConfig/networks/zhejiang.ts
+++ b/packages/config/src/chainConfig/networks/zhejiang.ts
@@ -31,7 +31,7 @@ export const zhejiangChainConfig: ChainConfig = {
   CAPELLA_FORK_VERSION: b("0x00000072"),
   CAPELLA_FORK_EPOCH: 1350,
   // Deneb
-  EIP4844_FORK_VERSION: b("0x00000073"),
+  DENEB_FORK_VERSION: b("0x00000073"),
 
   // Deposit contract
   // ---------------------------------------------------------------

--- a/packages/config/src/chainConfig/presets/mainnet.ts
+++ b/packages/config/src/chainConfig/presets/mainnet.ts
@@ -42,8 +42,8 @@ export const chainConfig: ChainConfig = {
   CAPELLA_FORK_EPOCH: 194048, // April 12 (epoch: 194048    slot: 6209536    UTC: 4/12/2023, 10:27:35 PM)
 
   // DENEB
-  EIP4844_FORK_VERSION: b("0x04000000"),
-  EIP4844_FORK_EPOCH: Infinity,
+  DENEB_FORK_VERSION: b("0x04000000"),
+  DENEB_FORK_EPOCH: Infinity,
 
   // Time parameters
   // ---------------------------------------------------------------

--- a/packages/config/src/chainConfig/presets/minimal.ts
+++ b/packages/config/src/chainConfig/presets/minimal.ts
@@ -40,8 +40,8 @@ export const chainConfig: ChainConfig = {
   CAPELLA_FORK_VERSION: b("0x03000001"),
   CAPELLA_FORK_EPOCH: Infinity,
   // Deneb
-  EIP4844_FORK_VERSION: b("0x04000001"),
-  EIP4844_FORK_EPOCH: Infinity,
+  DENEB_FORK_VERSION: b("0x04000001"),
+  DENEB_FORK_EPOCH: Infinity,
 
   // Time parameters
   // ---------------------------------------------------------------

--- a/packages/config/src/chainConfig/types.ts
+++ b/packages/config/src/chainConfig/types.ts
@@ -38,8 +38,8 @@ export type ChainConfig = {
   CAPELLA_FORK_VERSION: Uint8Array;
   CAPELLA_FORK_EPOCH: number;
   // DENEB
-  EIP4844_FORK_VERSION: Uint8Array;
-  EIP4844_FORK_EPOCH: number;
+  DENEB_FORK_VERSION: Uint8Array;
+  DENEB_FORK_EPOCH: number;
 
   // Time parameters
   SECONDS_PER_SLOT: number;
@@ -96,8 +96,8 @@ export const chainConfigTypes: SpecTypes<ChainConfig> = {
   CAPELLA_FORK_VERSION: "bytes",
   CAPELLA_FORK_EPOCH: "number",
   // DENEB
-  EIP4844_FORK_VERSION: "bytes",
-  EIP4844_FORK_EPOCH: "number",
+  DENEB_FORK_VERSION: "bytes",
+  DENEB_FORK_EPOCH: "number",
 
   // Time parameters
   SECONDS_PER_SLOT: "number",

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -50,8 +50,8 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
   const deneb: ForkInfo = {
     name: ForkName.deneb,
     seq: ForkSeq.deneb,
-    epoch: config.EIP4844_FORK_EPOCH,
-    version: config.EIP4844_FORK_VERSION,
+    epoch: config.DENEB_FORK_EPOCH,
+    version: config.DENEB_FORK_VERSION,
     prevVersion: config.CAPELLA_FORK_VERSION,
     prevForkName: ForkName.capella,
   };

--- a/packages/light-client/src/spec/utils.ts
+++ b/packages/light-client/src/spec/utils.ts
@@ -121,7 +121,7 @@ export function isValidLightClientHeader(config: ChainForkConfig, header: allFor
     );
   }
 
-  if (epoch < config.EIP4844_FORK_EPOCH) {
+  if (epoch < config.DENEB_FORK_EPOCH) {
     if (
       (header as deneb.LightClientHeader).execution.excessDataGas &&
       (header as deneb.LightClientHeader).execution.excessDataGas !== BigInt(0)

--- a/packages/light-client/test/unit/isValidLightClientHeader.test.ts
+++ b/packages/light-client/test/unit/isValidLightClientHeader.test.ts
@@ -11,7 +11,7 @@ describe("isValidLightClientHeader", function () {
     ALTAIR_FORK_EPOCH: 0,
     BELLATRIX_FORK_EPOCH: 0,
     CAPELLA_FORK_EPOCH: 1,
-    EIP4844_FORK_EPOCH: Infinity,
+    DENEB_FORK_EPOCH: Infinity,
   });
 
   const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);

--- a/packages/state-transition/src/slot/upgradeStateToDeneb.ts
+++ b/packages/state-transition/src/slot/upgradeStateToDeneb.ts
@@ -16,7 +16,7 @@ export function upgradeStateToDeneb(stateCapella: CachedBeaconStateCapella): Cac
 
   stateDeneb.fork = ssz.phase0.Fork.toViewDU({
     previousVersion: stateCapella.fork.currentVersion,
-    currentVersion: config.EIP4844_FORK_VERSION,
+    currentVersion: config.DENEB_FORK_VERSION,
     epoch: stateCapella.epochCtx.epoch,
   });
 

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -193,7 +193,7 @@ function processSlotsWithTransientCache(
       if (stateSlot === config.CAPELLA_FORK_EPOCH) {
         postState = upgradeStateToCapella(postState as CachedBeaconStateBellatrix) as CachedBeaconStateAllForks;
       }
-      if (stateSlot === config.EIP4844_FORK_EPOCH) {
+      if (stateSlot === config.DENEB_FORK_EPOCH) {
         postState = upgradeStateToDeneb(postState as CachedBeaconStateCapella) as CachedBeaconStateAllForks;
       }
     } else {

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -275,10 +275,10 @@ export function initializeBeaconStateFromEth1(
       ssz.capella.ExecutionPayloadHeader.defaultViewDU();
   }
 
-  if (GENESIS_SLOT >= config.EIP4844_FORK_EPOCH) {
+  if (GENESIS_SLOT >= config.DENEB_FORK_EPOCH) {
     const stateDeneb = state as CompositeViewDU<typeof ssz.deneb.BeaconState>;
-    stateDeneb.fork.previousVersion = config.EIP4844_FORK_VERSION;
-    stateDeneb.fork.currentVersion = config.EIP4844_FORK_VERSION;
+    stateDeneb.fork.previousVersion = config.DENEB_FORK_VERSION;
+    stateDeneb.fork.currentVersion = config.DENEB_FORK_VERSION;
     stateDeneb.latestExecutionPayloadHeader =
       (executionPayloadHeader as CompositeViewDU<typeof ssz.deneb.ExecutionPayloadHeader>) ??
       ssz.deneb.ExecutionPayloadHeader.defaultViewDU();

--- a/packages/types/src/deneb/sszTypes.ts
+++ b/packages/types/src/deneb/sszTypes.ts
@@ -13,7 +13,6 @@ import {ssz as primitiveSsz} from "../primitive/index.js";
 import {ssz as phase0Ssz} from "../phase0/index.js";
 import {ssz as altairSsz} from "../altair/index.js";
 import {ssz as capellaSsz} from "../capella/index.js";
-import {ssz as bellatrixSsz} from "../bellatrix/index.js";
 
 const {UintNum64, Slot, Root, BLSSignature, UintBn256, Bytes32, Bytes48, Bytes96, BLSPubkey} = primitiveSsz;
 

--- a/packages/types/src/deneb/sszTypes.ts
+++ b/packages/types/src/deneb/sszTypes.ts
@@ -86,23 +86,16 @@ export const BeaconBlockAndBlobsSidecarByRootRequest = new ListCompositeType(Roo
 
 export const ExecutionPayload = new ContainerType(
   {
-    ...bellatrixSsz.CommonExecutionPayloadType.fields,
+    ...capellaSsz.ExecutionPayload.fields,
     excessDataGas: UintBn256, // New in DENEB
-    // Extra payload fields
-    blockHash: Root,
-    transactions: bellatrixSsz.Transactions,
-    withdrawals: capellaSsz.Withdrawals, // New in capella
   },
   {typeName: "ExecutionPayload", jsonCase: "eth2"}
 );
 
 export const ExecutionPayloadHeader = new ContainerType(
   {
-    ...bellatrixSsz.CommonExecutionPayloadType.fields,
+    ...capellaSsz.ExecutionPayloadHeader.fields,
     excessDataGas: UintBn256, // New in DENEB
-    blockHash: Root,
-    transactionsRoot: Root,
-    withdrawalsRoot: Root,
   },
   {typeName: "ExecutionPayloadHeader", jsonCase: "eth2"}
 );

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -72,7 +72,7 @@ function getSpecCriticalParams(localConfig: ChainConfig): Record<keyof ConfigWit
   const altairForkRelevant = localConfig.ALTAIR_FORK_EPOCH < Infinity;
   const bellatrixForkRelevant = localConfig.BELLATRIX_FORK_EPOCH < Infinity;
   const capellaForkRelevant = localConfig.CAPELLA_FORK_EPOCH < Infinity;
-  const denebForkRelevant = localConfig.EIP4844_FORK_EPOCH < Infinity;
+  const denebForkRelevant = localConfig.DENEB_FORK_EPOCH < Infinity;
 
   return {
     // # Config
@@ -103,8 +103,8 @@ function getSpecCriticalParams(localConfig: ChainConfig): Record<keyof ConfigWit
     CAPELLA_FORK_VERSION: capellaForkRelevant,
     CAPELLA_FORK_EPOCH: capellaForkRelevant,
     // Deneb
-    EIP4844_FORK_VERSION: denebForkRelevant,
-    EIP4844_FORK_EPOCH: denebForkRelevant,
+    DENEB_FORK_VERSION: denebForkRelevant,
+    DENEB_FORK_EPOCH: denebForkRelevant,
 
     // Time parameters
     SECONDS_PER_SLOT: true,


### PR DESCRIPTION
Two things skipped:

1. `deneb` fork:  because of breaking changes regarding decoupled blobs to be addressed in https://github.com/ChainSafe/lodestar/pull/5181 and will be re-added
2. `fork_choice`: To be enabled with the fork choice safe slots to justified removal PR https://github.com/ChainSafe/lodestar/pull/5126

Skipped tracked here: https://github.com/ChainSafe/lodestar/issues/5279