### PR TITLE
Update query parser options

### DIFF
--- a/packages/api/test/utils/utils.ts
+++ b/packages/api/test/utils/utils.ts
@@ -10,7 +10,7 @@ export function getTestServer(): {baseUrl: string; server: FastifyInstance} {
 
   const server = fastify({
     ajv: {customOptions: {coerceTypes: "array"}},
-    querystringParser: (str) => qs.parse(str, {comma: true}),
+    querystringParser: (str) => qs.parse(str, {comma: true, parseArrays: false}),
   });
 
   server.addHook("onError", (request, reply, error, done) => {

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -45,12 +45,12 @@ export class RestApiServer {
       ajv: {customOptions: {coerceTypes: "array"}},
       querystringParser: (str) =>
         qs.parse(str, {
-          // defaults to 20 but Beacon API spec allows max items of 30
-          arrayLimit: 30,
-          // array as comma-separated values must be supported to be OpenAPI spec compliant
+          // Array as comma-separated values must be supported to be OpenAPI spec compliant
           comma: true,
-          // default limit of 1000 seems unnecessarily high, let's reduce it a bit
-          parameterLimit: 100,
+          // Drop support for array query strings like `id[0]=1&id[1]=2&id[2]=3` as those are not required to
+          // be OpenAPI spec compliant and results are inconsistent, see https://github.com/ljharb/qs/issues/331.
+          // The schema validation will catch this and throw an error as parsed query string results in an object.
+          parseArrays: false,
         }),
       bodyLimit: opts.bodyLimit,
     });

--- a/packages/light-client/test/utils/server.ts
+++ b/packages/light-client/test/utils/server.ts
@@ -18,7 +18,7 @@ export async function startServer(
   const server = fastify({
     logger: false,
     ajv: {customOptions: {coerceTypes: "array"}},
-    querystringParser: (str) => qs.parse(str, {comma: true}),
+    querystringParser: (str) => qs.parse(str, {comma: true, parseArrays: false}),
   });
 
   registerRoutes(server, config, api, ["lightclient", "proof", "events"]);


### PR DESCRIPTION
**Motivation**

Follow up PR to https://github.com/ChainSafe/lodestar/pull/5268. Updates the parser options to make array query string parser more consistent/predictable.

**Description**

Update query parser options, drop support for array query strings like `id[0]=1&id[1]=2&id[2]=3` as those are not required to be OpenAPI spec compliant and results are inconsistent, see https://github.com/ljharb/qs/issues/331. The schema validation will catch this and throw an error as parsed query string results in an object.

**Parsing of different formats**

Here are just a few examples how array query strings will be parsed, most example query strings are from [OpenAPI Parameter Serialization](https://swagger.io/docs/specification/serialization/)

```ts
"id[0]=3&id[1]=4&id[3]=5" => {"id":{"0":"3","1":"4","3":"5"}} // results in "should be array" error
"id=3&id=4&id=5"          => {"id":["3","4","5"]} // supported format
"id=3,4,5"                => {"id":["3","4","5"]} // supported format
"id=3|4|5"                => {"id":"3|4|5"} // results in a string (not supported)
"id=3%204%205"            => {"id":"3 4 5"} // results in a string (not supported)
"id=3%2C4%2C5"            => {"id":"3,4,5"} // results in a string (not supported)
"id"                      => {"id":""} // empty string here is expected
```
