### PR TITLE
Fix decrypting keystores with password ending in pipe character

### DIFF
--- a/packages/cli/src/util/passphrase.ts
+++ b/packages/cli/src/util/passphrase.ts
@@ -7,7 +7,7 @@ import fs from "node:fs";
 export function readPassphraseFile(passphraseFile: string): string {
   const data = fs.readFileSync(passphraseFile, "utf8");
   // Remove trailing new lines '\n' or '\r' if any
-  const passphrase = data.replace(/[\n|\r]+$/g, "");
+  const passphrase = data.replace(/[\n\r]+$/g, "");
 
   // Validate the passphraseFile contents to prevent the user to create a wallet with a password
   // that is the contents a random unintended file


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5276

**Description**

Fix decrypting keystores with password ending in pipe character. This only affects users which provide their password from a file via `--importKeystoresPassword` and the password ends with a pipe character (`|`). The pipe character was trimmed off by the regex which is only supposed to remove newline characters and carriage return characters.

**Breakdown of our previous regex**

- `[...]`: Square brackets define a character set. Any character inside the brackets can be matched.
- `\n`: Represents a newline character.
- `|`: The pipe symbol acts as an OR operator, meaning either the character before or after the pipe can be matched. However, it is unnecessary to include the pipe symbol inside the square brackets, as the square brackets already create a set of characters that can be matched.
- `\r`: Represents a carriage return character.
- `+$`: The plus sign means "one or more" of the preceding element (in this case, newline or carriage return characters). The dollar sign represents the end of the string.

**Updated regex**

The new regex `/[\n\r]+$/g` will only match newline and carriage return characters at the end of the string and replace them with an empty string `""`


```node
> "1231321|".replace(/[\n\r]+$/g, "")
'1231321|'
> "1231321\n".replace(/[\n\r]+$/g, "")
'1231321'
> "1231321\r".replace(/[\n\r]+$/g, "")
'1231321'
> "1231321\n\n\r".replace(/[\n\r]+$/g, "")
'1231321'
> "1231321\n\r\n".replace(/[\n\r]+$/g, "")
'1231321'
```

