### PR TITLE
Reuse `stripOffNewlines` to trim keystore password from file

### DIFF
--- a/packages/cli/src/util/passphrase.ts
+++ b/packages/cli/src/util/passphrase.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import {stripOffNewlines} from "./stripOffNewlines.js";
 
 /**
  * Utility to read file as UTF8 and strip any trailing new lines.
@@ -6,8 +7,7 @@ import fs from "node:fs";
  */
 export function readPassphraseFile(passphraseFile: string): string {
   const data = fs.readFileSync(passphraseFile, "utf8");
-  // Remove trailing new lines '\n' or '\r' if any
-  const passphrase = data.replace(/[\n\r]+$/g, "");
+  const passphrase = stripOffNewlines(data);
 
   // Validate the passphraseFile contents to prevent the user to create a wallet with a password
   // that is the contents a random unintended file

--- a/packages/cli/src/util/stripOffNewlines.ts
+++ b/packages/cli/src/util/stripOffNewlines.ts
@@ -2,5 +2,5 @@
  * Remove trailing new lines '\n' or '\r' if any
  */
 export function stripOffNewlines(s: string): string {
-  return s.replace(/[\n|\r]+$/g, "");
+  return s.replace(/[\n\r]+$/g, "");
 }

--- a/packages/cli/test/unit/util/stripOffNewlines.test.ts
+++ b/packages/cli/test/unit/util/stripOffNewlines.test.ts
@@ -1,0 +1,34 @@
+import {expect} from "chai";
+import {stripOffNewlines} from "../../../src/util/index.js";
+
+describe("stripOffNewlines", () => {
+  it("should remove trailing newlines from a string", () => {
+    expect(stripOffNewlines("1231321\n")).to.equal("1231321");
+    expect(stripOffNewlines("1231321\r")).to.equal("1231321");
+    expect(stripOffNewlines("1231321\r\n")).to.equal("1231321");
+    expect(stripOffNewlines("1231321\n\n\r")).to.equal("1231321");
+    expect(stripOffNewlines("1231321\n\r\n")).to.equal("1231321");
+    expect(stripOffNewlines("\n\r\n")).to.equal("");
+  });
+
+  it("should not remove pipe character(s) at the end of a string", () => {
+    expect(stripOffNewlines("1231321|")).to.equal("1231321|");
+    expect(stripOffNewlines("1231321||")).to.equal("1231321||");
+    expect(stripOffNewlines("1231321|||")).to.equal("1231321|||");
+  });
+
+  it("should not remove newlines in the middle of a string", () => {
+    expect(stripOffNewlines("123\n1321\n\n\n")).to.equal("123\n1321");
+  });
+
+  it("should not modify the string if there are no new lines", () => {
+    expect(stripOffNewlines("1231321")).to.equal("1231321");
+    expect(stripOffNewlines("")).to.equal("");
+  });
+
+  it("should not mutate the original string", () => {
+    const originalString = "123\n1321\n\n\n";
+    stripOffNewlines(originalString);
+    expect(originalString).to.equal("123\n1321\n\n\n");
+  });
+});


### PR DESCRIPTION
**Motivation**

Follow up PR for https://github.com/ChainSafe/lodestar/pull/5282 to reuse existing `stripOffNewlines` function and add some unit tests to ensure it works

**Description**

- Fix `stripOffNewlines` to not remove pipe character
- Add unit tests to verify `stripOffNewlines` works as expected
- Reuse `stripOffNewlines` to trim keystore password from file