### PR TITLE
Only preaggregate attestations if there are connected aggregators

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -64,12 +64,13 @@ export function getBeaconPoolApi({
               slot,
               beaconBlockRoot
             );
-            const sentPeers = await network.gossip.publishBeaconAttestation(attestation, subnet);
-            metrics?.submitUnaggregatedAttestation(seenTimestampSec, indexedAttestation, subnet, sentPeers);
+
             if (network.attnetsService.shouldProcess(subnet, slot)) {
               const insertOutcome = chain.attestationPool.add(attestation);
               metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
             }
+            const sentPeers = await network.gossip.publishBeaconAttestation(attestation, subnet);
+            metrics?.submitUnaggregatedAttestation(seenTimestampSec, indexedAttestation, subnet, sentPeers);
           } catch (e) {
             errors.push(e as Error);
             logger.error(

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -64,11 +64,12 @@ export function getBeaconPoolApi({
               slot,
               beaconBlockRoot
             );
-
-            const insertOutcome = chain.attestationPool.add(attestation);
             const sentPeers = await network.gossip.publishBeaconAttestation(attestation, subnet);
             metrics?.submitUnaggregatedAttestation(seenTimestampSec, indexedAttestation, subnet, sentPeers);
-            metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
+            if (network.attnetsService.shouldProcess(subnet, slot)) {
+              const insertOutcome = chain.attestationPool.add(attestation);
+              metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
+            }
           } catch (e) {
             errors.push(e as Error);
             logger.error(

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -305,6 +305,10 @@ export function createLodestarMetrics(
         help: "Count of unsubscribe_subnets calls",
         labelNames: ["subnet", "src"],
       }),
+      aggregatorSlotSubnetCount: register.gauge({
+        name: "lodestar_attnets_service_aggregator_slot_subnet_total",
+        help: "Count of aggregator per slot and subnet",
+      }),
     },
 
     syncnetsService: {

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -13,7 +13,7 @@ import {INetworkEventBus} from "./events.js";
 import {GossipBeaconNode} from "./gossip/index.js";
 import {PeerAction, PeerScoreStats} from "./peers/index.js";
 import {IReqRespBeaconNode} from "./reqresp/ReqRespBeaconNode.js";
-import {CommitteeSubscription} from "./subnets/index.js";
+import {AttnetsService, CommitteeSubscription} from "./subnets/index.js";
 
 export type PeerSearchOptions = {
   supportsProtocols?: string[];
@@ -27,6 +27,7 @@ export interface INetwork {
 
   events: INetworkEventBus;
   reqResp: IReqRespBeaconNode;
+  attnetsService: AttnetsService;
   gossip: GossipBeaconNode;
 
   getEnr(): Promise<SignableENR | undefined>;

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -372,5 +372,10 @@ export class AttnetsService implements IAttnetsService {
     metrics.attnetsService.committeeSubnets.set(this.committeeSubnets.size);
     metrics.attnetsService.subscriptionsCommittee.set(this.subscriptionsCommittee.size);
     metrics.attnetsService.subscriptionsRandom.set(this.subscriptionsRandom.size);
+    let aggregatorCount = 0;
+    for (const subnets of this.aggregatorSlotSubnet.values()) {
+      aggregatorCount += subnets.size;
+    }
+    metrics.attnetsService.aggregatorSlotSubnetCount.set(aggregatorCount);
   }
 }

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -8,7 +8,7 @@ import {
   SLOTS_PER_EPOCH,
 } from "@lodestar/params";
 import {Epoch, Slot, ssz} from "@lodestar/types";
-import {Logger, randBetween} from "@lodestar/utils";
+import {Logger, MapDef, randBetween} from "@lodestar/utils";
 import {shuffle} from "../../util/shuffle.js";
 import {ChainEvent, IBeaconChain} from "../../chain/index.js";
 import {GossipTopic, GossipType} from "../gossip/index.js";
@@ -45,6 +45,11 @@ export class AttnetsService implements IAttnetsService {
   private subscriptionsCommittee = new SubnetMap();
   /** Same as `subscriptionsCommittee` but for long-lived subnets. May overlap with `subscriptionsCommittee` */
   private subscriptionsRandom = new SubnetMap();
+  /**
+   * Map of an aggregator at a slot and subnet
+   * Used to determine if we should process an attestation.
+   */
+  private aggregatorSlotSubnet = new MapDef<Slot, Set<number>>(() => new Set());
 
   /**
    * A collection of seen validators. These dictate how many random subnets we should be
@@ -119,6 +124,7 @@ export class AttnetsService implements IAttnetsService {
       if (isAggregator) {
         // need exact slot here
         subnetsToSubscribe.push({subnet, toSlot: slot});
+        this.aggregatorSlotSubnet.getOrDefault(slot).add(subnet);
       }
     }
 
@@ -141,7 +147,10 @@ export class AttnetsService implements IAttnetsService {
    * Check if a subscription is still active before handling a gossip object
    */
   shouldProcess(subnet: number, slot: Slot): boolean {
-    return this.subscriptionsCommittee.isActiveAtSlot(subnet, slot);
+    if (!this.aggregatorSlotSubnet.has(slot)) {
+      return false;
+    }
+    return this.aggregatorSlotSubnet.getOrDefault(slot).has(subnet);
   }
 
   /** Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork  */
@@ -184,6 +193,7 @@ export class AttnetsService implements IAttnetsService {
     try {
       const slot = computeStartSlotAtEpoch(epoch);
       this.pruneExpiredKnownValidators(slot);
+      this.pruneExpiredAggregator(slot);
     } catch (e) {
       this.logger.error("Error on AttnetsService.onEpoch", {epoch}, e as Error);
     }
@@ -244,6 +254,18 @@ export class AttnetsService implements IAttnetsService {
     }
 
     if (deletedKnownValidators) this.rebalanceRandomSubnets();
+  }
+
+  /**
+   * No need to track aggregator for past slots.
+   * @param currentSlot
+   */
+  private pruneExpiredAggregator(currentSlot: Slot): void {
+    for (const slot of this.aggregatorSlotSubnet.keys()) {
+      if (currentSlot > slot) {
+        this.aggregatorSlotSubnet.delete(slot);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
**Motivation**

- Preaggregating attestations could take up to 8% of cpu time while a lot of them are redundant, see https://github.com/ChainSafe/lodestar/issues/5247#issuecomment-1463396305. This PR is to preaggregate attestations if there are a connected aggregator at specified subnet/slot
- An effort to mitigate/fix the issue we have with new gossip queues

**Description**

- Right now we track committee subscriptions up until a slot, and we process **all** attestations up until that slot/subnet while an aggregator only has duty at a specified subnet/slot.
- Notice that `prepareBeaconCommitteeSubnet()` api is called for next epoch at `vc` side, so this causes a lot of redundancy to preaggregate attestations
- Instead of that track aggregator at slot/subnet and based on that to process attestations
- Also at `submitPoolAtestations` api, only add attestation to pool if necessary

part of #5247

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
