### PR TITLE
Log expected api errors as warning instead of error

### DIFF
--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -97,7 +97,12 @@ export class RestApiServer {
       if (err instanceof ErrorAborted || err instanceof NodeIsSyncing) return;
 
       const {operationId} = res.context.config as RouteConfig;
-      this.logger.error(`Req ${req.id} ${operationId} error`, {}, err);
+
+      if (err instanceof ApiError && err.statusCode < 500) {
+        this.logger.warn(`Req ${req.id} ${operationId} failed`, {reason: err.message});
+      } else {
+        this.logger.error(`Req ${req.id} ${operationId} error`, {}, err);
+      }
       metrics?.errors.inc({operationId});
     });
 

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -98,7 +98,7 @@ export class RestApiServer {
 
       const {operationId} = res.context.config as RouteConfig;
 
-      if (err instanceof ApiError && err.statusCode < 500) {
+      if (err instanceof ApiError) {
         this.logger.warn(`Req ${req.id} ${operationId} failed`, {reason: err.message});
       } else {
         this.logger.error(`Req ${req.id} ${operationId} error`, {}, err);


### PR DESCRIPTION
**Motivation**

Expected API errors (`ApiError`) should be logged as warnings instead of errors to not unnecessarily scare users. Printing out the stacktrace does not help here either, it just creates noise.

**Description**

Check if error is `ApiError` and just log it as `warn` and only print out the `err.message`.

Unexpected errors (non `ApiError`) will still be logged as `error` including the stacktrace.

Closes https://github.com/ChainSafe/lodestar/issues/5265, related [discussion](https://discord.com/channels/593655374469660673/743858262864167062/1084567242437558292)