### PR TITLE
[DNM] Reprocess gossip attestations

### DIFF
--- a/packages/beacon-node/src/chain/errors/gossipValidation.ts
+++ b/packages/beacon-node/src/chain/errors/gossipValidation.ts
@@ -3,6 +3,7 @@ import {LodestarError} from "@lodestar/utils";
 export enum GossipAction {
   IGNORE = "IGNORE",
   REJECT = "REJECT",
+  RETRY_UNKNOWN_BLOCK = "RETRY_UNKNOWN_BLOCK",
 }
 
 export class GossipActionError<T extends {code: string}> extends LodestarError<T> {

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -226,7 +226,8 @@ function verifyHeadBlockIsKnown(chain: IBeaconChain, beaconBlockRoot: Root): Pro
 
   const headBlock = chain.forkChoice.getBlock(beaconBlockRoot);
   if (headBlock === null) {
-    throw new AttestationError(GossipAction.IGNORE, {
+    // should retry the attestation when a block with beaconBlockRoot comes
+    throw new AttestationError(GossipAction.RETRY_UNKNOWN_BLOCK, {
       code: AttestationErrorCode.UNKNOWN_OR_PREFINALIZED_BEACON_BLOCK_ROOT,
       root: toHexString(beaconBlockRoot as typeof beaconBlockRoot),
     });

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -237,6 +237,16 @@ export function createLodestarMetrics(
       help: "Count of total gossip validation reject",
       labelNames: ["topic"],
     }),
+    gossipValidationRetry: register.gauge<"topic">({
+      name: "lodestar_gossip_validation_retry_total",
+      help: "Count of total gossip validation retry",
+      labelNames: ["topic"],
+    }),
+    gossipValidationReprocess: register.gauge<"topic">({
+      name: "lodestar_gossip_validation_reprocess_total",
+      help: "Count of total gossip validation reprocess",
+      labelNames: ["topic"],
+    }),
     gossipValidationError: register.gauge<"topic" | "error">({
       name: "lodestar_gossip_validation_error_total",
       help: "Count of total gossip validation errors detailed",
@@ -1188,8 +1198,8 @@ export function createLodestarMetrics(
       }),
     },
 
-    // reprocess attestations
-    reprocessAttestations: {
+    // reprocess api attestations
+    reprocessApiAttestations: {
       total: register.gauge({
         name: "lodestar_reprocess_attestations_total",
         help: "Total number of attestations waiting to reprocess",
@@ -1198,7 +1208,7 @@ export function createLodestarMetrics(
         name: "lodestar_reprocess_attestations_resolve_total",
         help: "Total number of attestations are reprocessed",
       }),
-      waitTimeBeforeResolve: register.gauge({
+      waitSecBeforeResolve: register.gauge({
         name: "lodestar_reprocess_attestations_wait_time_resolve_seconds",
         help: "Time to wait for unknown block in seconds",
       }),
@@ -1207,8 +1217,37 @@ export function createLodestarMetrics(
         help: "Total number of attestations are rejected to reprocess",
         labelNames: ["reason"],
       }),
-      waitTimeBeforeReject: register.gauge<"reason">({
+      waitSecBeforeReject: register.gauge<"reason">({
         name: "lodestar_reprocess_attestations_wait_time_reject_seconds",
+        help: "Time to wait for unknown block before being rejected",
+      }),
+    },
+
+    // reprocess gossip attestations
+    reprocessGossipAttestations: {
+      total: register.gauge({
+        name: "lodestar_reprocess_gossip_attestations_total",
+        help: "Total number of gossip attestations waiting to reprocess",
+      }),
+      countPerSlot: register.gauge({
+        name: "lodestar_reprocess_gossip_attestations_per_slot_total",
+        help: "Total number of gossip attestations waiting to reprocess pet slot",
+      }),
+      resolve: register.gauge({
+        name: "lodestar_reprocess_gossip_attestations_resolve_total",
+        help: "Total number of gossip attestations are reprocessed",
+      }),
+      waitSecBeforeResolve: register.gauge({
+        name: "lodestar_reprocess_gossip_attestations_wait_time_resolve_seconds",
+        help: "Time to wait for unknown block in seconds",
+      }),
+      reject: register.gauge<"reason">({
+        name: "lodestar_reprocess_gossip_attestations_reject_total",
+        help: "Total number of attestations are rejected to reprocess",
+        labelNames: ["reason"],
+      }),
+      waitSecBeforeReject: register.gauge<"reason">({
+        name: "lodestar_reprocess_gossip_attestations_wait_time_reject_seconds",
         help: "Time to wait for unknown block before being rejected",
       }),
     },

--- a/packages/beacon-node/src/network/events.ts
+++ b/packages/beacon-node/src/network/events.ts
@@ -19,7 +19,12 @@ export enum NetworkEvent {
 
   // Network processor events
   pendingGossipsubMessage = "gossip.pendingGossipsubMessage",
+  reprocessGossipsubMessage = "gossip.reprocessGossipsubMessage",
   gossipMessageValidationResult = "gossip.messageValidationResult",
+}
+
+export enum ReprocessGossipMessageType {
+  unknownBlock = "unknownBlock",
 }
 
 export type NetworkEvents = {
@@ -28,6 +33,7 @@ export type NetworkEvents = {
   [NetworkEvent.reqRespRequest]: (request: RequestTypedContainer, peer: PeerId) => void;
   [NetworkEvent.unknownBlockParent]: (blockInput: BlockInput, peerIdStr: string) => void;
   [NetworkEvent.pendingGossipsubMessage]: (data: PendingGossipsubMessage) => void;
+  [NetworkEvent.reprocessGossipsubMessage]: (data: PendingGossipsubMessage, type: ReprocessGossipMessageType) => void;
   [NetworkEvent.gossipMessageValidationResult]: (
     msgId: string,
     propagationSource: PeerId,

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -404,6 +404,7 @@ export class Eth2Gossipsub extends GossipSub implements GossipBeaconNode {
       propagationSource,
       seenTimestampSec,
       startProcessUnixSec: null,
+      gossipObject: null,
     });
   }
 

--- a/packages/beacon-node/src/network/gossip/interface.ts
+++ b/packages/beacon-node/src/network/gossip/interface.ts
@@ -4,7 +4,7 @@ import {Message, TopicValidatorResult} from "@libp2p/interface-pubsub";
 import StrictEventEmitter from "strict-event-emitter-types";
 import {PeerIdStr} from "@chainsafe/libp2p-gossipsub/types";
 import {ForkName} from "@lodestar/params";
-import {allForks, altair, capella, deneb, phase0} from "@lodestar/types";
+import {allForks, altair, capella, deneb, phase0, SlotRoot} from "@lodestar/types";
 import {BeaconConfig} from "@lodestar/config";
 import {Logger} from "@lodestar/utils";
 import {IBeaconChain} from "../../chain/index.js";
@@ -151,9 +151,12 @@ export type GossipBeaconNode = {
 export type GossipValidatorFn = (
   topic: GossipTopic,
   msg: Message,
+  object: GossipTypeMap[GossipType] | null,
   propagationSource: PeerIdStr,
   seenTimestampSec: number
-) => Promise<TopicValidatorResult>;
+) => Promise<
+  {type: "done"; result: TopicValidatorResult} | {type: "retryUnknownBlock"; gossipObject: GossipTypeMap[GossipType]}
+>;
 
 export type ValidatorFnsByType = {[K in GossipType]: GossipValidatorFn};
 
@@ -167,6 +170,7 @@ export type GossipHandlerFn = (
   peerIdStr: string,
   seenTimestampSec: number
 ) => Promise<void>;
+
 export type GossipHandlers = {
   [K in GossipType]: (
     object: GossipTypeMap[K],
@@ -175,6 +179,11 @@ export type GossipHandlers = {
     seenTimestampSec: number
   ) => Promise<void>;
 };
+
+export type UnknownBlockFns = {
+  [K in GossipType]: (object: GossipTypeMap[K]) => SlotRoot;
+};
+export type UnknownBlockFromGossipObjectFn = (object: GossipTypeMap[GossipType]) => SlotRoot;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ResolvedType<F extends (...args: any) => Promise<any>> = F extends (...args: any) => Promise<infer T>

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -194,14 +194,9 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
     [GossipType.beacon_aggregate_and_proof]: async (signedAggregateAndProof, _topic, _peer, seenTimestampSec) => {
       let validationResult: {indexedAttestation: phase0.IndexedAttestation; committeeIndices: number[]};
       try {
-        // If an attestation refers to a block root that's not known, it will wait for 1 slot max
-        // See https://github.com/ChainSafe/lodestar/pull/3564 for reasoning and results
-        // Waiting here requires minimal code and automatically affects attestation, and aggregate validation
-        // both from gossip and the API. I also prevents having to catch and re-throw in multiple places.
-        // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-        const validateFn = () => validateGossipAggregateAndProof(chain, signedAggregateAndProof);
-        const {slot, beaconBlockRoot} = signedAggregateAndProof.message.aggregate.data;
-        validationResult = await validateGossipFnRetryUnknownRoot(validateFn, chain, slot, beaconBlockRoot);
+        // validating attestations may throw UNKNOWN_BLOCK error. In that case the NetworkProcessor will have
+        // to reprocess GossipMessage when the block comes
+        validationResult = await validateGossipAggregateAndProof(chain, signedAggregateAndProof);
       } catch (e) {
         if (e instanceof AttestationError && e.action === GossipAction.REJECT) {
           chain.persistInvalidSszValue(ssz.phase0.SignedAggregateAndProof, signedAggregateAndProof, "gossip_reject");
@@ -236,14 +231,9 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
     [GossipType.beacon_attestation]: async (attestation, {subnet}, _peer, seenTimestampSec) => {
       let validationResult: {indexedAttestation: phase0.IndexedAttestation; subnet: number};
       try {
-        // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-        const validateFn = () => validateGossipAttestation(chain, attestation, subnet);
-        const {slot, beaconBlockRoot} = attestation.data;
-        // If an attestation refers to a block root that's not known, it will wait for 1 slot max
-        // See https://github.com/ChainSafe/lodestar/pull/3564 for reasoning and results
-        // Waiting here requires minimal code and automatically affects attestation, and aggregate validation
-        // both from gossip and the API. I also prevents having to catch and re-throw in multiple places.
-        validationResult = await validateGossipFnRetryUnknownRoot(validateFn, chain, slot, beaconBlockRoot);
+        // validating attestations may throw UNKNOWN_BLOCK error. In that case the NetworkProcessor will have
+        // to reprocess GossipMessage when the block comes
+        validationResult = await validateGossipAttestation(chain, attestation, subnet);
       } catch (e) {
         if (e instanceof AttestationError && e.action === GossipAction.REJECT) {
           chain.persistInvalidSszValue(ssz.phase0.Attestation, attestation, "gossip_reject");

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -1,12 +1,17 @@
-import {Logger, mapValues} from "@lodestar/utils";
+import {TopicValidatorResult} from "@libp2p/interface-pubsub";
+import {Logger, MapDef, mapValues} from "@lodestar/utils";
+import {RootHex, Slot} from "@lodestar/types";
+import {routes} from "@lodestar/api";
 import {IBeaconChain} from "../../chain/interface.js";
 import {Metrics} from "../../metrics/metrics.js";
-import {NetworkEvent, NetworkEventBus} from "../events.js";
-import {GossipType} from "../gossip/interface.js";
+import {NetworkEvent, NetworkEventBus, ReprocessGossipMessageType} from "../events.js";
+import {GossipType, UnknownBlockFromGossipObjectFn} from "../gossip/interface.js";
+import {ChainEvent} from "../../chain/emitter.js";
 import {createGossipQueues} from "./gossipQueues.js";
 import {NetworkWorker, NetworkWorkerModules} from "./worker.js";
-import {PendingGossipsubMessage} from "./types.js";
+import {PendingGossipsubMessage, WaitingGossipsubMessage} from "./types.js";
 import {ValidatorFnsModules, GossipHandlerOpts} from "./gossipHandlers.js";
+import {createUnknownBlockFromGossipObjectFns} from "./unknownBlockFromGossipObject.js";
 
 export type NetworkProcessorModules = NetworkWorkerModules &
   ValidatorFnsModules & {
@@ -39,6 +44,23 @@ const executeGossipWorkOrder = Object.keys(executeGossipWorkOrderObj) as (keyof 
 // TODO: Arbitrary constant, check metrics
 const MAX_JOBS_SUBMITTED_PER_TICK = 128;
 
+// How many attestations (aggregate + unaggregate) we keep before new ones get dropped.
+const MAXIMUM_QUEUED_UNKNOWN_BLOCK_GOSSIP_OBJECTS = 16_384;
+
+/**
+ * Reprocess reject reason for metrics
+ */
+enum ReprocessRejectReason {
+  /**
+   * There are too many attestations that have unknown block root.
+   */
+  reached_limit = "reached_limit",
+  /**
+   * The awaiting attestation is pruned per clock slot.
+   */
+  expired = "expired",
+}
+
 /**
  * Network processor handles the gossip queues and throtles processing to not overload the main thread
  * - Decides when to process work and what to process
@@ -58,23 +80,44 @@ const MAX_JOBS_SUBMITTED_PER_TICK = 128;
  *
  * The gossip queues should receive "backpressue" from the regen and BLS workers queues.
  * Such that enough work is processed to fill either one of the queue.
+ *
+ * ### WaitingGossipsubMessage beacon_attestation example
+ * 1. beacon_attestation gossip message passes through gossipQueues and executeWork()
+ * 2. During gossip validation, it throws UNKNOWN_BLOCK error
+ * 3. A WaitingGossipsubMessage instance is created which is the same to PendingGossipsubMessage with addedTimeMs
+ * 4. WaitingGossipsubMessage is then put to a temporary queue implemented as slot/root hex map (deleted per slot)
+ * 5. Once the block comes with same slot/root WaitingGossipsubMessage is then pushed back to gossipQueues again
  */
 export class NetworkProcessor {
   private readonly worker: NetworkWorker;
   private readonly chain: IBeaconChain;
+  private readonly events: NetworkEventBus;
   private readonly logger: Logger;
   private readonly metrics: Metrics | null;
   private readonly gossipQueues = createGossipQueues<PendingGossipsubMessage>();
   private readonly gossipTopicConcurrency = mapValues(this.gossipQueues, () => 0);
+  private readonly unknownBlockFns = createUnknownBlockFromGossipObjectFns();
+  // validating GossipMessage may result in UNKNOWN_BLOCK error, in that case PendingGossipsubMessage needs
+  // to be stored in this Map and reprocessed once the block comes
+  private readonly awaitingGossipsubMessagesByRootBySlot: MapDef<Slot, MapDef<RootHex, Set<WaitingGossipsubMessage>>>;
+  private unknownBlockGossipsubMessagesCount = 0;
 
   constructor(modules: NetworkProcessorModules, private readonly opts: NetworkProcessorOpts) {
     const {chain, events, logger, metrics} = modules;
     this.chain = chain;
+    this.events = events;
     this.metrics = metrics;
     this.logger = logger;
     this.worker = new NetworkWorker(modules, opts);
 
     events.on(NetworkEvent.pendingGossipsubMessage, this.onPendingGossipsubMessage.bind(this));
+    events.on(NetworkEvent.reprocessGossipsubMessage, this.onReprocessGossipsubMessage.bind(this));
+    this.chain.emitter.on(routes.events.EventType.block, this.onBlockProcessed.bind(this));
+    this.chain.emitter.on(ChainEvent.clockSlot, this.onClockSlot.bind(this));
+
+    this.awaitingGossipsubMessagesByRootBySlot = new MapDef(
+      () => new MapDef<RootHex, Set<WaitingGossipsubMessage>>(() => new Set())
+    );
 
     if (metrics) {
       metrics.gossipValidationQueueLength.addCollect(() => {
@@ -82,12 +125,20 @@ export class NetworkProcessor {
           metrics.gossipValidationQueueLength.set({topic}, this.gossipQueues[topic].length);
           metrics.gossipValidationQueueConcurrency.set({topic}, this.gossipTopicConcurrency[topic]);
         }
+        metrics.reprocessGossipAttestations.countPerSlot.set(this.unknownBlockGossipsubMessagesCount);
       });
     }
 
     // TODO: Pull new work when available
     // this.bls.onAvailable(() => this.executeWork());
     // this.regen.onAvailable(() => this.executeWork());
+  }
+
+  async stop(): Promise<void> {
+    this.events.off(NetworkEvent.pendingGossipsubMessage, this.onPendingGossipsubMessage);
+    this.events.off(NetworkEvent.reprocessGossipsubMessage, this.onReprocessGossipsubMessage);
+    this.chain.emitter.off(routes.events.EventType.block, this.onBlockProcessed);
+    this.chain.emitter.off(ChainEvent.clockSlot, this.onClockSlot);
   }
 
   dropAllJobs(): void {
@@ -114,6 +165,65 @@ export class NetworkProcessor {
 
     // Tentatively perform work
     this.executeWork();
+  }
+
+  private onReprocessGossipsubMessage(data: PendingGossipsubMessage, reprocessType: ReprocessGossipMessageType): void {
+    if (!data.gossipObject) {
+      throw Error("Should have gossip object after the 1st gossip validation");
+    }
+    if (reprocessType === ReprocessGossipMessageType.unknownBlock) {
+      if (this.unknownBlockGossipsubMessagesCount > MAXIMUM_QUEUED_UNKNOWN_BLOCK_GOSSIP_OBJECTS) {
+        this.metrics?.reprocessGossipAttestations.reject.inc({reason: ReprocessRejectReason.reached_limit});
+        return;
+      }
+
+      this.metrics?.reprocessGossipAttestations.total.inc();
+      const {slot, root} = (this.unknownBlockFns[data.topic.type] as UnknownBlockFromGossipObjectFn)(data.gossipObject);
+      const awaitingGossipsubMessagesByRoot = this.awaitingGossipsubMessagesByRootBySlot.getOrDefault(slot);
+      const awaitingGossipsubMessages = awaitingGossipsubMessagesByRoot.getOrDefault(root);
+      (data as WaitingGossipsubMessage).addedTimeMs = Date.now();
+      awaitingGossipsubMessages.add(data as WaitingGossipsubMessage);
+      this.unknownBlockGossipsubMessagesCount++;
+    }
+  }
+
+  private onBlockProcessed({slot, block: rootHex}: {slot: Slot; block: string; executionOptimistic: boolean}): void {
+    const byRootGossipsubMessages = this.awaitingGossipsubMessagesByRootBySlot.getOrDefault(slot);
+    const waitingGossipsubMessages = byRootGossipsubMessages.getOrDefault(rootHex);
+    if (waitingGossipsubMessages.size === 0) {
+      return;
+    }
+
+    this.metrics?.reprocessGossipAttestations.resolve.inc(waitingGossipsubMessages.size);
+    const now = Date.now();
+    waitingGossipsubMessages.forEach((msg) => {
+      this.metrics?.reprocessGossipAttestations.waitSecBeforeResolve.set((now - msg.addedTimeMs) / 1000);
+      this.onPendingGossipsubMessage(msg);
+    });
+
+    byRootGossipsubMessages.delete(rootHex);
+  }
+
+  private onClockSlot(clockSlot: Slot): void {
+    const now = Date.now();
+    for (const [slot, gossipMessagesByRoot] of this.awaitingGossipsubMessagesByRootBySlot.entries()) {
+      if (slot < clockSlot) {
+        for (const gossipMessages of gossipMessagesByRoot.values()) {
+          gossipMessages.forEach((message) => {
+            this.metrics?.reprocessGossipAttestations.reject.inc({reason: ReprocessRejectReason.expired});
+            this.metrics?.reprocessGossipAttestations.waitSecBeforeReject.set((now - message.addedTimeMs) / 1000);
+            this.events.emit(
+              NetworkEvent.gossipMessageValidationResult,
+              message.msgId,
+              message.propagationSource,
+              TopicValidatorResult.Ignore
+            );
+          });
+        }
+        this.awaitingGossipsubMessagesByRootBySlot.delete(slot);
+      }
+    }
+    this.unknownBlockGossipsubMessagesCount = 0;
   }
 
   private executeWork(): void {

--- a/packages/beacon-node/src/network/processor/types.ts
+++ b/packages/beacon-node/src/network/processor/types.ts
@@ -1,6 +1,6 @@
 import {PeerId} from "@libp2p/interface-peer-id";
 import {Message} from "@libp2p/interface-pubsub";
-import {GossipTopic} from "../gossip/index.js";
+import {GossipTopic, GossipType, GossipTypeMap} from "../gossip/index.js";
 
 export type GossipAttestationsWork = {
   messages: PendingGossipsubMessage[];
@@ -14,4 +14,9 @@ export type PendingGossipsubMessage = {
   propagationSource: PeerId;
   seenTimestampSec: number;
   startProcessUnixSec: number | null;
+  gossipObject: GossipTypeMap[GossipType] | null;
+};
+
+export type WaitingGossipsubMessage = PendingGossipsubMessage & {
+  addedTimeMs: number;
 };

--- a/packages/beacon-node/src/network/processor/unknownBlockFromGossipObject.ts
+++ b/packages/beacon-node/src/network/processor/unknownBlockFromGossipObject.ts
@@ -1,0 +1,34 @@
+import {toHexString} from "@chainsafe/ssz";
+import {UnknownBlockFns as UnknownBlockFromGossipObjectFns, GossipType} from "../gossip/index.js";
+
+export function createUnknownBlockFromGossipObjectFns(): UnknownBlockFromGossipObjectFns {
+  const neverReturn = (): never => {
+    throw Error("Not expect this gossip message to return an unknown block");
+  };
+  return {
+    [GossipType.beacon_attestation]: (attestation) => {
+      const {slot, beaconBlockRoot} = attestation.data;
+      return {
+        slot,
+        root: toHexString(beaconBlockRoot),
+      };
+    },
+    [GossipType.beacon_aggregate_and_proof]: (signedAggregateAndProof) => {
+      const {slot, beaconBlockRoot} = signedAggregateAndProof.message.aggregate.data;
+      return {
+        slot,
+        root: toHexString(beaconBlockRoot),
+      };
+    },
+    [GossipType.sync_committee]: neverReturn,
+    [GossipType.sync_committee_contribution_and_proof]: neverReturn,
+    [GossipType.beacon_block]: neverReturn,
+    [GossipType.beacon_block_and_blobs_sidecar]: neverReturn,
+    [GossipType.attester_slashing]: neverReturn,
+    [GossipType.proposer_slashing]: neverReturn,
+    [GossipType.voluntary_exit]: neverReturn,
+    [GossipType.bls_to_execution_change]: neverReturn,
+    [GossipType.light_client_finality_update]: neverReturn,
+    [GossipType.light_client_optimistic_update]: neverReturn,
+  };
+}

--- a/packages/beacon-node/src/network/processor/worker.ts
+++ b/packages/beacon-node/src/network/processor/worker.ts
@@ -1,6 +1,6 @@
 import {IBeaconChain} from "../../chain/interface.js";
 import {Metrics} from "../../metrics/metrics.js";
-import {NetworkEvent, NetworkEventBus} from "../events.js";
+import {NetworkEvent, NetworkEventBus, ReprocessGossipMessageType} from "../events.js";
 import {GossipHandlers, GossipValidatorFn} from "../gossip/interface.js";
 import {getGossipHandlers, GossipHandlerOpts, ValidatorFnsModules} from "./gossipHandlers.js";
 import {getGossipValidatorFn, ValidatorFnModules} from "./gossipValidatorFn.js";
@@ -32,21 +32,34 @@ export class NetworkWorker {
     const acceptance = await this.gossipValidatorFn(
       message.topic,
       message.msg,
+      // gossipObject is only available on 2nd validation
+      message.gossipObject,
       message.propagationSource.toString(),
       message.seenTimestampSec
     );
 
-    if (message.startProcessUnixSec !== null) {
-      this.metrics?.gossipValidationQueueJobWaitTime.observe(
-        {topic: message.topic.type},
-        message.startProcessUnixSec - message.seenTimestampSec
-      );
-      this.metrics?.gossipValidationQueueJobTime.observe(
-        {topic: message.topic.type},
-        Date.now() / 1000 - message.startProcessUnixSec
-      );
-    }
+    if (acceptance.type === "done") {
+      if (message.startProcessUnixSec !== null) {
+        this.metrics?.gossipValidationQueueJobWaitTime.observe(
+          {topic: message.topic.type},
+          message.startProcessUnixSec - message.seenTimestampSec
+        );
+        this.metrics?.gossipValidationQueueJobTime.observe(
+          {topic: message.topic.type},
+          Date.now() / 1000 - message.startProcessUnixSec
+        );
+      }
 
-    this.events.emit(NetworkEvent.gossipMessageValidationResult, message.msgId, message.propagationSource, acceptance);
+      this.events.emit(
+        NetworkEvent.gossipMessageValidationResult,
+        message.msgId,
+        message.propagationSource,
+        acceptance.result
+      );
+    } else if (acceptance.type === "retryUnknownBlock") {
+      // we don't have to deserialize to gossip object the next time
+      message.gossipObject = acceptance.gossipObject;
+      this.events.emit(NetworkEvent.reprocessGossipsubMessage, message, ReprocessGossipMessageType.unknownBlock);
+    }
   }
 }

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -1,3 +1,5 @@
+import {Slot} from "./primitive/types.js";
+
 export * from "./primitive/types.js";
 export {ts as phase0} from "./phase0/index.js";
 export {ts as altair} from "./altair/index.js";
@@ -9,6 +11,8 @@ export {ts as allForks} from "./allForks/index.js";
 
 /** Common non-spec type to represent roots as strings */
 export type RootHex = string;
+
+export type SlotRoot = {slot: Slot; root: RootHex};
 
 /** Handy enum to represent the block production source */
 export enum BlockSource {


### PR DESCRIPTION
**Motivation**

- There are so many unknown block root attestations passing through `executeWork` and they are reprocessed in uncontrollable way because when block come, they are processed immediately
- On a mainnet node subscribing to all subnets, there are too many of them and the pool reached limit

<img width="686" alt="Screenshot 2023-03-21 at 13 11 10" src="https://user-images.githubusercontent.com/10568965/226530547-2113b6e2-7010-4575-a02d-296b29b65579.png">

**Description**
- All attestations pass through gossip queues
- If an attestation has unknown block root, send it to a new queue in block processor (implemented as a Map of  unkown block root)
- When block comes, get from this new queue and send to the gossip queue again
- On 2nd validation, do not need to deserialize the gossip message again

part of #5247

Note: the new gossip queue will be reverted in `unstable` when we merge v1.6.0 so making this PR as Draft