### PR TITLE
Log monitoring errors as warning and reduce verbosity

### DIFF
--- a/packages/beacon-node/src/monitoring/service.ts
+++ b/packages/beacon-node/src/monitoring/service.ts
@@ -131,7 +131,7 @@ export class MonitoringService {
 
           this.logger.debug(`Sent client stats to ${this.remoteServiceHost}`, {data: JSON.stringify(data)});
         } catch (e) {
-          this.logger.error(`Failed to send client stats to ${this.remoteServiceHost}`, {}, e as Error);
+          this.logger.warn(`Failed to send client stats to ${this.remoteServiceHost}`, {reason: (e as Error).message});
         } finally {
           this.pendingRequest = undefined;
         }


### PR DESCRIPTION
**Motivation**

Similar to changes introduced in https://github.com/ChainSafe/lodestar/pull/5285, the monitoring service is just a sidecar to the main functionality/process and should be considered non-critical, meaning it should be fine here if we just log this as a warning.

**Description**

Log monitoring errors as `warn` instead of `error` and reduce verbosity (no stacktrace).

The expected errors here are

- invalid domain, cannot resolve
- timeout, remote service is unresponsive
- dns resolution issues

The error message is enough to convey the issue, the stacktrace is not needed. Based on my observations using this for several weeks the errors I usually see are becasue of timeouts which are kinda expected since we send request 24/7 every minute and the remote service might be unresponsive sometimes.
