### PR TITLE
Fix lodestar validator to not break on cross client block production

### DIFF
--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -189,7 +189,8 @@ export function WithBlockValue<T extends {data: unknown}>(type: TypeJson<T>): Ty
     }),
     fromJson: ({block_value, ...data}: T & {block_value: string}) => ({
       ...type.fromJson(data),
-      blockValue: BigInt(block_value),
+      // For cross client usage where beacon or validator are of separate clients, blockValue could be missing
+      blockValue: BigInt(block_value ?? "0"),
     }),
   };
 }

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -193,7 +193,9 @@ export class BlockProposingService {
       let selectedBlock;
       switch (builderSelection) {
         case BuilderSelection.MaxProfit: {
-          if (engineBlockValue >= builderBlockValue) {
+          // If blockValues are zero, than choose builder as most likely beacon didn't provide blockValues
+          // and builder blocks are most likely thresholded by a min bid
+          if (engineBlockValue >= builderBlockValue && engineBlockValue !== BigInt(0)) {
             selectedSource = BlockSource.engine;
             selectedBlock = fullBlock;
           } else {


### PR DESCRIPTION
Fix cross client validator usage as propagating blockValue to validator is not standard yet

![image](https://user-images.githubusercontent.com/76567250/226936863-d3b2784e-9d86-48b2-889b-d09c0ba9c949.png)
