### PR TITLE
[DNM] Network processor without emitting event

### DIFF
--- a/packages/beacon-node/src/network/events.ts
+++ b/packages/beacon-node/src/network/events.ts
@@ -1,11 +1,9 @@
 import {EventEmitter} from "events";
 import {PeerId} from "@libp2p/interface-peer-id";
 import StrictEventEmitter from "strict-event-emitter-types";
-import {TopicValidatorResult} from "@libp2p/interface-pubsub";
 import {phase0} from "@lodestar/types";
 import {BlockInput} from "../chain/blocks/types.js";
 import {RequestTypedContainer} from "./reqresp/ReqRespBeaconNode.js";
-import {PendingGossipsubMessage} from "./processor/types.js";
 
 export enum NetworkEvent {
   /** A relevant peer has connected or has been re-STATUS'd */
@@ -16,10 +14,6 @@ export enum NetworkEvent {
   gossipHeartbeat = "gossipsub.heartbeat",
   reqRespRequest = "req-resp.request",
   unknownBlockParent = "unknownBlockParent",
-
-  // Network processor events
-  pendingGossipsubMessage = "gossip.pendingGossipsubMessage",
-  gossipMessageValidationResult = "gossip.messageValidationResult",
 }
 
 export type NetworkEvents = {
@@ -27,12 +21,6 @@ export type NetworkEvents = {
   [NetworkEvent.peerDisconnected]: (peer: PeerId) => void;
   [NetworkEvent.reqRespRequest]: (request: RequestTypedContainer, peer: PeerId) => void;
   [NetworkEvent.unknownBlockParent]: (blockInput: BlockInput, peerIdStr: string) => void;
-  [NetworkEvent.pendingGossipsubMessage]: (data: PendingGossipsubMessage) => void;
-  [NetworkEvent.gossipMessageValidationResult]: (
-    msgId: string,
-    propagationSource: PeerId,
-    acceptance: TopicValidatorResult
-  ) => void;
 };
 
 export type INetworkEventBus = StrictEventEmitter<EventEmitter, NetworkEvents>;

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -230,9 +230,20 @@ export class Network implements INetwork {
     );
 
     const networkProcessor = new NetworkProcessor(
-      {attnetsService, chain, config, logger, metrics, peerRpcScores, events: networkEventBus, gossipHandlers},
+      {
+        attnetsService,
+        chain,
+        config,
+        logger,
+        metrics,
+        peerRpcScores,
+        events: networkEventBus,
+        gossipHandlers,
+        gossipsub: gossip,
+      },
       opts
     );
+    gossip.subscribePendingGossipsubMessage(networkProcessor.onPendingGossipsubMessage.bind(networkProcessor));
 
     await libp2p.start();
 

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -243,7 +243,6 @@ export class Network implements INetwork {
       },
       opts
     );
-    gossip.subscribePendingGossipsubMessage(networkProcessor.onPendingGossipsubMessage.bind(networkProcessor));
 
     await libp2p.start();
 

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -239,7 +239,7 @@ export class Network implements INetwork {
         peerRpcScores,
         events: networkEventBus,
         gossipHandlers,
-        gossipsub: gossip,
+        gossip,
       },
       opts
     );

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -15,7 +15,7 @@ export type NetworkProcessorModules = NetworkWorkerModules &
     events: NetworkEventBus;
     logger: Logger;
     metrics: Metrics | null;
-    gossipsub: Eth2Gossipsub;
+    gossip: Eth2Gossipsub;
   };
 
 export type NetworkProcessorOpts = GossipHandlerOpts & {

--- a/packages/beacon-node/src/network/processor/worker.ts
+++ b/packages/beacon-node/src/network/processor/worker.ts
@@ -10,7 +10,7 @@ import {PendingGossipsubMessage} from "./types.js";
 export type NetworkWorkerModules = ValidatorFnsModules &
   ValidatorFnModules & {
     chain: IBeaconChain;
-    gossipsub: Eth2Gossipsub;
+    gossip: Eth2Gossipsub;
     events: NetworkEventBus;
     metrics: Metrics | null;
     // Optionally pass custom GossipHandlers, for testing
@@ -20,13 +20,13 @@ export type NetworkWorkerModules = ValidatorFnsModules &
 export class NetworkWorker {
   private readonly events: NetworkEventBus;
   private readonly metrics: Metrics | null;
-  private readonly gossipsub: Eth2Gossipsub;
+  private readonly gossip: Eth2Gossipsub;
   private readonly gossipValidatorFn: GossipValidatorFn;
 
   constructor(modules: NetworkWorkerModules, opts: GossipHandlerOpts) {
     this.events = modules.events;
     this.metrics = modules.metrics;
-    this.gossipsub = modules.gossipsub;
+    this.gossip = modules.gossip;
     this.gossipValidatorFn = getGossipValidatorFn(modules.gossipHandlers ?? getGossipHandlers(modules, opts), modules);
   }
 
@@ -51,6 +51,6 @@ export class NetworkWorker {
       );
     }
 
-    this.gossipsub.reportMessageValidationResult(message.msgId, message.propagationSource, acceptance);
+    this.gossip.reportMessageValidationResult(message.msgId, message.propagationSource, acceptance);
   }
 }


### PR DESCRIPTION
**Motivation**

- We have network I/O lag issue since we introduce the new gossip queue
- I found that emitting event in gossipsub makes our event loop more busy, see https://itnext.io/high-performance-node-js-concurrency-with-events-on-hexomter-da4472ae3061

**Description**

- Use callback instead of network event to communicate between network processor and gossipsub.

part of #5247

same effort in `js-libp2p-gossipsub`: https://github.com/ChainSafe/js-libp2p-gossipsub/pull/416

**Test**
- Deployed this on feat1, this is on 16 validator node
<img width="1355" alt="Screenshot 2023-03-23 at 10 01 29" src="https://user-images.githubusercontent.com/10568965/227089723-6204d667-2339-48d7-9f15-f800e2786910.png">

- While the same node on `unstable` (confirm that they have same subnet mesh peers => same network load)
<img width="1320" alt="Screenshot 2023-03-23 at 10 02 34" src="https://user-images.githubusercontent.com/10568965/227089879-9e8055b2-0e4f-4649-9f38-a5e196b3d36a.png">

