### PR TITLE
Add unit test to check for unused exports and remove them

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "supertest": "^6.2.4",
     "ts-loader": "^9.3.1",
     "ts-node": "^10.9.1",
+    "ts-prune": "^0.10.3",
     "typescript": "4.9.3",
     "typescript-docs-verifier": "^2.3.0",
     "webpack": "^5.74.0"

--- a/packages/check-dead-code/LICENSE
+++ b/packages/check-dead-code/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/check-dead-code/README.md
+++ b/packages/check-dead-code/README.md
@@ -1,0 +1,472 @@
+# lodestar-check-dead-code
+
+A package to test whether other lodestar packages have dead code / unused exports.
+
+## Usage
+
+```bash
+yarn test:unit
+```
+
+Example output:
+
+```
+  No dead-code
+    1) Should not be different from the list of expected unused exported values
+
+
+  0 passing (16s)
+  1 failing
+
+  1) No dead-code
+       Should not be different from the list of expected unused exported values:
+
+      AssertionError: expected { '@lodestar/api': [ …(51) ], …(46) } to equal {}
+      + expected - actual
+
+      -{
+      -  "@chainsafe/lodestar": [
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "mergeBeaconNodeOptions"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "mergeBeaconNodeOptionsWithDefaults"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "getBeaconParamsFromArgs"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "getBeaconConfig"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "parsePartialChainConfigJson"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "createFromJSON"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "PeerIdJSON"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "fetchBootnodes"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "WeakSubjectivityFetchOptions"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "IParamsArgs"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "defaultGlobalPaths"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "getEthersSigner"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "parse"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "stringify"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "writeFile"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "readFileIfExists"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "downloadOrCopyFile"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "downloadFile"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "yamlSchema"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "FileFormat"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "readAndGetGitData"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "shouldDeleteLogFile"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "LOG_FILE_DISABLE_KEYWORD"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "LOG_LEVEL_DEFAULT"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "LOG_FILE_LEVEL_DEFAULT"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "LOG_DAILY_ROTATE_DEFAULT"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "sleep"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "Lockfile"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "initLogger"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "getCheckpointFromState"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "overwriteEnrWithCliArgs"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "beaconExtraOptions"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "DebugArgs"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "debugOptions"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "BeaconPathsPartial"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "DEFAULT_BEACON_NODE_URL"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "KeymanagerArgs"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "keymanagerOptions"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "IValidatorPaths"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "AccountPaths"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "readRemoteSignerDefinition"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "writeRemoteSignerDefinition"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "ImportStatus"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "DeletionStatus"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "KeymanagerRestApiServerOpts"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "KeymanagerRestApiServerModules"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "isVotingKeystore"
+      -    }
+      -  ]
+      -  "@lodestar/api": [
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "HttpErrorCodes"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "HttpSuccessCodes"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "IHttpClient"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "HttpClientOptions"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "HttpClientModules"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "Metrics"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "ApiNamespace"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "APIClientHandler"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "ApiClientSuccessResponse"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "ApiClientSErrorResponse"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "ApiClientResponse"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "ApiClientResponseData"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "GenericRequestObject"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "GenericResponseObject"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "ClientApi"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "ImportStatus"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "DeletionStatus"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "ImportRemoteKeyStatus"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "DeleteRemoteKeyStatus"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "ResponseStatus"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "SignerDefinition"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "KeystoreStr"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "SlashingProtectionData"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "PubkeyHex"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "FeeRecipientData"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "GasLimitData"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "compileRouteUrlFormater"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "toColonNotationPath"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "getFastifySchema"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "SchemaDefinition"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "RouteGroupDefinition"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "ReqGenArg"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "KeysOfNonVoidResolveValues"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "querySerializeProofPathsArr"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "queryParseProofPathsArr"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "queryParseProofPaths"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "fromU64StrOpt"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "toU64StrOpt"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "U64"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "serializeSSEEvent"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "registerRoutes"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "RouteConfig"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "registerRoutes"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "RouteConfig"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "registerRoutes"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "RouteConfig"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "getFetchOptsSerializer"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "URLOpts"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "Gauge"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "Histogram"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "FastifyHandler"
+      -    }
+      -  ]
+      -  "@lodestar/api/beacon": [
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "serializeSSEEvent"
+      -    }
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "registerRoutes"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "RouteConfig"
+      -    }
+      -  ]
+      -  "@lodestar/api/beacon/server": [
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "serializeSSEEvent"
+      -    }
+      -  ]
+      -  "@lodestar/api/builder": [
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "registerRoutes"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      "value": "RouteConfig"
+      -    }
+      -  ]
+      -  "@lodestar/api/builder/server": [
+      -    {
+      -      "isUsedInModule": false
+      -      "value": "registerRoutes"
+      -    }
+      -    {
+      -      "isUsedInModule": true
+      -      
+      +{}
+```
+
+If the test fails:
+- for each exported values:
+  - if `isUsedInModule` is `true`, then you simply need to remove the `export` keyword
+  - if `isUsedInModule` is `false`, then this value is dead code and you need to delete it entirely
+
+## License
+
+Apache-2.0 [ChainSafe Systems](https://chainsafe.io)

--- a/packages/check-dead-code/package.json
+++ b/packages/check-dead-code/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@lodestar/check-dead-code",
+  "description": "Utility to test whether the lodestar packages export unused values",
+  "license": "Apache-2.0",
+  "author": "ChainSafe Systems",
+  "homepage": "https://github.com/ChainSafe/lodestar#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com:ChainSafe/lodestar.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ChainSafe/lodestar/issues"
+  },
+  "version": "1.5.1",
+  "type": "module",
+  "exports": "./lib/index.js",
+  "files": [
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "lib/**/*.js.map",
+    "*.d.ts",
+    "*.js"
+  ],
+  "scripts": {
+    "clean": "rm -rf lib && rm -f *.tsbuildinfo",
+    "check-types": "tsc",
+    "lint": "eslint --color --ext .ts test/",
+    "lint:fix": "yarn run lint --fix",
+    "pretest": "yarn run check-types",
+    "test:unit": "mocha --reporter-option maxDiffSize=0 'test/**/*.test.ts'",
+    "check-readme": "typescript-docs-verifier"
+  },
+  "types": "lib/index.d.ts",
+  "dependencies": {
+    "@vscode/ripgrep": "^1.15.0"
+  },
+  "devDependencies": {},
+  "keywords": [
+    "ethereum",
+    "eth-consensus",
+    "beacon",
+    "blockchain"
+  ]
+}

--- a/packages/check-dead-code/test/setup.ts
+++ b/packages/check-dead-code/test/setup.ts
@@ -1,0 +1,6 @@
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import sinonChai from "sinon-chai";
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);

--- a/packages/check-dead-code/test/unit/assert.test.ts
+++ b/packages/check-dead-code/test/unit/assert.test.ts
@@ -1,0 +1,514 @@
+// TODO: Refactor the parsing to JSON to avoid the any escape hatch
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable no-restricted-imports */
+import "../setup.js";
+import {spawn} from "child_process";
+import {readdirSync} from "fs";
+import * as path from "path";
+import {expect} from "chai";
+import {rgPath} from "@vscode/ripgrep";
+import {testLogger} from "../utils/logger.js";
+
+interface ExportedValue {
+  value: string;
+  isUsedInModule: boolean;
+}
+
+/**
+ * relative to pkg
+ * Ex:
+ * {
+ *   "relativeName": '.'
+ *   "relativeLocation": "./lib/index.js"
+ * }
+ * */
+interface Subpackage {
+  name: string;
+  relativeName: string;
+  relativeLocation: string;
+}
+
+describe("No dead-code", () => {
+  /**
+   * Example:
+   * {
+   *   "@lodestar/api": [
+   *     "@lodestar/config",
+   *     "@lodestar/params",
+   *     "@lodestar/types",
+   *     "@lodestar/utils"
+   *   ],
+   *   "@lodestar/beacon-node": [
+   *     "@lodestar/api",
+   *     "@lodestar/config",
+   *     "@lodestar/db",
+   *     "@lodestar/fork-choice",
+   *     "@lodestar/light-client",
+   *     "@lodestar/params",
+   *     "@lodestar/reqresp",
+   *     "@lodestar/state-transition",
+   *     "@lodestar/types",
+   *     "@lodestar/utils",
+   *     "@lodestar/validator"
+   *     ],
+   *     ...etc
+   * }
+   * */
+  let dependencyTree: {[pkg: string]: string[]};
+  let isDependencyTreeLoaded = false;
+  /**
+   * Example:
+   * {'@lodestar/api': './packages/api', '@lodestar/beacon-node': './packages/beacon-node'}
+   *
+   * */
+  const directoriesPerPackages: {
+    [pkg: string]: string;
+  } = {};
+  let isDirectoriesPerPackagesLoaded = false;
+  /**
+   * Example:
+   * {
+   *   '@lodestar/api': [
+   *     {
+   *       'name': '@lodestar/api',
+   *       'relativeName': '.',
+   *       'relativeLocation': './lib/index.js',
+   *     },
+   *     {
+   *       'name': '@lodestar/api/beacon',
+   *       'relativeName': './beacon',
+   *       'relativeLocation': './lib/beacon/index.js',
+   *     },
+   *     {
+   *       'name': '@lodestar/api/builder',
+   *       'relativeName': './builder',
+   *       'relativeLocation': './lib/builder/index.js',
+   *     },
+   *     {
+   *       'name': '@lodestar/api/builder/server',
+   *       'relativeName': './builder/server',
+   *       'relativeLocation': './lib/builder/server/index.js',
+   *     },
+   *     {
+   *       'name': '@lodestar/api/keymanager',
+   *       'relativeName': './keymanager',
+   *       'relativeLocation': './lib/keymanager/index.js',
+   *     },
+   *     {
+   *       'name': '@lodestar/api/keymanager/server',
+   *       'relativeName': './keymanager/server',
+   *       'relativeLocation': './lib/keymanager/server/index.js',
+   *     }
+   *   ],
+   *   '@lodestar/beacon-node': [
+   *     {
+   *       'name': '@lodestar/beacon-node',
+   *       'relativeName': '.',
+   *       'relativeLocation': './lib/index.js',
+   *     },
+   *     {
+   *       'name': '@lodestar/beacon-node/api',
+   *       'relativeName': './api',
+   *       'relativeLocation': './lib/api/index.js',
+   *     },
+   *     ...etc
+   *   ],
+   *   ...etc
+   * }
+   *
+   * */
+  const subpackagesPerPackages: {[pkg: string]: Subpackage[]} = {};
+  let isSubpackagePerPackagesLoaded = false;
+  /**
+   * Exports that are unused within the package of the subpackage.
+   * Example:
+   * {
+   *   '@lodestar/api': [
+   *     {
+   *       'value': 'routes',
+   *       'isUsedInModule': true
+   *     }
+   *     {
+   *       'value': 'ServerApi',
+   *       'isUsedInModule': false
+   *     }
+   *     {
+   *       'value': 'ApiError',
+   *       'isUsedInModule': true
+   *     },
+   *     ...etc
+   *   ],
+   *   '@lodestar/api/lib/beacon': [
+   *     {
+   *       'value': 'getClients',
+   *       'isUsedInModule': true
+   *     }
+   *     {
+   *       'value': 'allNamespaces',
+   *       'isUsedInModule': false
+   *     },
+   *     ...etc
+   *   ],
+   *   ...etc
+   * }
+   * */
+  const unusedExportsPerSubpackages: {[subpkg: string]: ExportedValue[]} = {};
+  let isUnusedExportsPerSubpackagesLoaded = false;
+
+  /**
+   * For each subpackage, list import usage per exported values - if any
+   * Example:
+   * {
+   *   '@lodestar/api': [
+   *     'routes': {
+   *         '@chainsafe/lodestar': [/home/user/lodestar/packages/cli/test/sim/endpoints.test.ts:5', ...etc],
+   *         '@lodestar/beacon-node': [/home/user/lodestar/packages/beacon-node/src/foo/bar.ts:8', ...etc],
+   *         ...etc
+   *     }
+   *     'ServerApi': {
+   *         '@chainsafe/lodestar': [/home/user/lodestar/packages/cli/test/utils/mockBeaconApiServer.ts'', ...etc],
+   *         ...etc
+   *     }
+   *     'ApiError': {
+   *         '@chainsafe/lodestar': ['/home/user/lodestar/packages/cli/test/utils/simulation/utils/network.ts', '/home/user/lodestar/packages/cli/test/utils/simulation/assertions/nodeAssertion.ts', ...etc],
+   *         ...etc
+   *     }
+   *     ...etc
+   *   ],
+   *   '@lodestar/api/lib/beacon': [
+   *       ...etc
+   *   ],
+   *   ...etc
+   * }
+   * */
+  const importsPerSubpackages: {[subpkg: string]: {[value: string]: {[pkg: string]: string[]}}} = {};
+  let isImportsPerSubpackagesLoaded = false;
+  const logger = testLogger();
+
+  before(function (done) {
+    this.timeout(0);
+    // get the dependency tree
+    const lerna = spawn("npx", ["lerna", "list", "--graph"], {cwd: `${process.cwd()}/../../`});
+    let result = "";
+    lerna.stdout.on("data", function (data) {
+      result += data;
+    });
+    lerna.on("close", function () {
+      dependencyTree = JSON.parse(result); // this could throw an error and stop the test
+      // only keep lodestar-related dependencies
+      const lodestarPackages = Object.keys(dependencyTree);
+      for (const lodestarPackage of lodestarPackages) {
+        dependencyTree[lodestarPackage] = dependencyTree[lodestarPackage].filter((dep) =>
+          lodestarPackages.includes(dep)
+        );
+      }
+
+      isDependencyTreeLoaded = true;
+    });
+
+    // get a one-to-one mapping between a package and its local directory location
+    // get the list of subpackage per packages
+    // how?: go to each packages/ subdirectory
+    // how?: in each corresponding subdirectory, run `yarn info --graph --json --silent`, parse to JSON and get the `exports` and `name` parameter at the root
+
+    // first, get list of directories in <root>/packages except this one:
+    const packageDirectories = readdirSync(`${process.cwd()}/../../packages`, {withFileTypes: true})
+      .filter((dirent) => dirent.isDirectory() && dirent.name !== path.basename(path.resolve(process.cwd())))
+      .map((dirent) => dirent.name);
+    const areYarnDonePerDirectory: {[directoryName: string]: boolean} = packageDirectories.reduce(
+      (acc: {[directoryName: string]: boolean}, directory) => {
+        acc[directory] = false;
+        return acc;
+      },
+      {}
+    );
+    for (const directoryName of packageDirectories) {
+      areYarnDonePerDirectory[directoryName] = false;
+      const directory = path.join(process.cwd(), `../../packages/${directoryName}`);
+      const yarnInfoCommand = spawn("yarn", ["info", "--silent", "--json", "--graph"], {cwd: directory});
+      let result = "";
+      yarnInfoCommand.stdout.on("data", function (data) {
+        result += data;
+      });
+      yarnInfoCommand.on("close", function () {
+        //
+        try {
+          const packageJson: any = JSON.parse(result); // this could throw and error and stop the test
+          const pkg = packageJson.data.name;
+          directoriesPerPackages[pkg] = path.join("packages", directoryName);
+          if (typeof packageJson.data.exports === "string") {
+            const subpkg = {name: pkg, relativeName: ".", relativeLocation: packageJson.data.exports};
+            if (pkg in subpackagesPerPackages) {
+              subpackagesPerPackages[pkg].push(subpkg);
+            } else {
+              subpackagesPerPackages[pkg] = [subpkg];
+            }
+          } else {
+            for (const [relativeName, relativeLocation] of Object.entries(packageJson.data.exports)) {
+              const subpkg = {
+                name: path.join(pkg, relativeName),
+                relativeName: relativeName,
+                relativeLocation: (relativeLocation as any).import,
+              };
+              if (pkg in subpackagesPerPackages) {
+                subpackagesPerPackages[pkg].push(subpkg);
+              } else {
+                subpackagesPerPackages[pkg] = [subpkg];
+              }
+            }
+            // sorting in descending order of depth (@lodestar/api/builder/server > @lodestar/api/beacon/server > @lodestar/api/builder > @lodestar/api/beacon > @lodestar/api)
+            subpackagesPerPackages[pkg].sort(function (subpkgA, subpkgB) {
+              return subpkgB.relativeLocation.split("/").length - subpkgA.relativeLocation.split("/").length;
+            });
+          }
+          areYarnDonePerDirectory[directoryName] = true;
+          if (!Object.values(areYarnDonePerDirectory).includes(false)) {
+            isDirectoriesPerPackagesLoaded = true;
+            isSubpackagePerPackagesLoaded = true;
+          }
+        } catch (e) {
+          logger.error(
+            `Cannot run 'yarn info' in ${directoryName} - could be due to the package still being unpublished`,
+            {rawResult: result},
+            e as Error
+          );
+          areYarnDonePerDirectory[directoryName] = true;
+          if (!Object.values(areYarnDonePerDirectory).includes(false)) {
+            isDirectoriesPerPackagesLoaded = true;
+            isSubpackagePerPackagesLoaded = true;
+          }
+        }
+      });
+    }
+    //
+    //
+    const waitUntilYarnDone = setInterval(() => {
+      if (isDirectoriesPerPackagesLoaded && isSubpackagePerPackagesLoaded) {
+        stopWaitingForYarn();
+        loadUnusedExports();
+        loadImports();
+      }
+    }, 500);
+
+    function stopWaitingForYarn(): void {
+      clearInterval(waitUntilYarnDone);
+    }
+
+    function loadUnusedExports(): void {
+      // get the list of unused exported values per subpackage - only care about src/* and test/* directories (some values are exported only to be tested), ignore lib/* directories
+      // skip unused exported values from the test/* directory for now
+      // exported values that are only used in tests are considered used
+      // this list doesn't take into consideration cross-packages usage
+      const repoRootDirectory = path.join(process.cwd(), "../../");
+      const tsPruneCommand = spawn("npx", ["ts-prune", "-s", "'(.*/lib/.*)'", "-i", "'(.*/test/.*)'"], {
+        cwd: repoRootDirectory,
+        shell: true,
+      }); // 'shell: true' is necessary otherwise spawn ignores the regex!
+      let result = "";
+      tsPruneCommand.stdout.on("data", function (data) {
+        result += data;
+      });
+      tsPruneCommand.on("close", function () {
+        const lines = result.split("\n");
+        for (const line of lines) {
+          if (line === "") {
+            // for some reasons, the first line is an empty string
+            continue;
+          }
+          const pathAndValue = line.split(":");
+          const exportedValuePath = pathAndValue[0];
+          // get string after '-', remove trailing space
+          // we get: "<exportedValue> (used in module)" OR "<exportedValue"
+          const exportedValueWithInModule: string = pathAndValue[1].split("-")[1].trim();
+          // if true, it means the exported value is potentially unused but the value itself shall not be deleted, only 'export' keyword should be removed
+          // if false, the value is potentially dead code that must be deleted entirely
+          let isUsedInModule = false;
+          if (exportedValueWithInModule.includes("(used in module)")) {
+            isUsedInModule = true;
+          }
+          const exportedValue = {
+            value: exportedValueWithInModule.replace(/ .*/, ""), // take first word (ignoring potential "(used in module)")
+            isUsedInModule: isUsedInModule,
+          };
+          // const exportedValue = pathAndValue[1]
+          for (const [pkg, subpkgs] of Object.entries(subpackagesPerPackages)) {
+            const pkgLocation = directoriesPerPackages[pkg];
+            for (const subpkg of subpkgs) {
+              let subpkgLocation = path.join(pkgLocation, subpkg.relativeLocation);
+              subpkgLocation = path.dirname(subpkgLocation);
+              subpkgLocation = subpkgLocation.replace(/lib/g, "src");
+              if (exportedValuePath.includes(subpkgLocation)) {
+                if (subpkg.name in unusedExportsPerSubpackages) {
+                  unusedExportsPerSubpackages[subpkg.name].push(exportedValue);
+                } else {
+                  unusedExportsPerSubpackages[subpkg.name] = [exportedValue];
+                }
+              }
+            }
+          }
+        }
+        isUnusedExportsPerSubpackagesLoaded = true;
+      });
+    }
+
+    function loadImports(): void {
+      // for each subpackage, get the list of values imported by each package that depends on it
+      // example for @lodestar/api, run the following in the directory of each package that depends on it
+      // rg --no-heading -g *.ts  "^.*?(import)(\s+\{*\s*)([^\{\}]+)(\s*\}*\s+)(from)(\s+)(['|\"]@lodestar/api['|\"]).*?$" -r '"$3"'
+      // rg --no-heading -g *.ts  "^.*?(import)(\s+\{*\s*)([^\{\}]+)(\s*\}*\s+)(from)(\s+)(['|\"]@lodestar/api/lib/beacon['|\"]).*?$" -r '"$3"'
+      // ...etc
+      let numberOfRg = 0; // will be used to condition whether all `rg` has terminated
+      const rgIsFinished: boolean[] = [];
+      for (const [pkg, deps] of Object.entries(dependencyTree)) {
+        for (const dep of deps) {
+          for (const subpkg of subpackagesPerPackages[dep]) {
+            numberOfRg += 1;
+            // ex: lodestar/packages/check-dead-code/../../packages/cli
+            const directory = path.join(process.cwd(), `../../${directoriesPerPackages[pkg]}`);
+            // rgPath load rg in node_modules, we cd there to load the binary
+            const rgCommand = spawn(
+              "./rg",
+              [
+                "--no-heading",
+                "-g",
+                "*.ts",
+                String.raw`"^.*?(import)(\s+\{*\s*)([^\{\}]+)(\s*\}*\s+)(from)(\s+)(['|\"]${subpkg.name}['|\"]).*?$"`,
+                "-r",
+                "'$3'",
+                directory,
+              ],
+              {cwd: path.dirname(rgPath), shell: true}
+            );
+            let result = "";
+            rgCommand.stdout.on("data", function (data) {
+              result += data;
+            });
+            rgCommand.on("close", function () {
+              const lines = result.split("\n");
+              for (const line of lines) {
+                if (line === "") {
+                  // for some reasons, the first line is an empty string
+                  continue;
+                }
+                const pathAndValues = line.split(":");
+                const filename = pathAndValues[0];
+                const values = pathAndValues[1];
+                const imports = values.split(",");
+                for (let imp of imports) {
+                  imp = imp.trim();
+                  const firstWord = imp.replace(/ .*/, "");
+                  if (firstWord !== "*") {
+                    addImportedValue(importsPerSubpackages, subpkg.name, firstWord, pkg, filename);
+                  } else {
+                    const importAs = imp.split("as")[1].trim();
+                    // search in the file which parts are actually used
+                    numberOfRg += 1;
+                    const rgCommand = spawn(
+                      "./rg",
+                      ["--no-heading", String.raw`"^.*?(${importAs})(\.)(\w+).*?$"`, "-r", "'$3'", filename],
+                      {cwd: path.dirname(rgPath), shell: true}
+                    );
+                    let result = "";
+                    rgCommand.stdout.on("data", function (data) {
+                      result += data;
+                    });
+                    rgCommand.on("close", function () {
+                      if (result === "") {
+                        // may be `${importAs} as unknown` type of usage (ex with importAs === 'constants')
+                        // TODO: distinguish this case with the ones with an unused import
+                        // for now we consider the whole value has been imported & used
+                        // we use the special char '*' to say everything was imported & used
+                        addImportedValue(importsPerSubpackages, subpkg.name, "*", pkg, filename);
+                      } else {
+                        const lines = result.split("\n");
+                        for (const line of lines) {
+                          if (line === "") {
+                            // for some reasons, the first line is an empty string
+                            continue;
+                          }
+                          addImportedValue(importsPerSubpackages, subpkg.name, line, pkg, filename);
+                        }
+                      }
+                      rgIsFinished.push(true);
+                      if (rgIsFinished.filter((finished) => finished === true).length === numberOfRg) {
+                        // all commands finished executing
+                        isImportsPerSubpackagesLoaded = true;
+                      }
+                    });
+                  }
+                }
+              }
+              rgIsFinished.push(true);
+              if (rgIsFinished.filter((finished) => finished === true).length === numberOfRg) {
+                // all commands finished executing
+                isImportsPerSubpackagesLoaded = true;
+              }
+            });
+          }
+        }
+      }
+    }
+
+    function addImportedValue(
+      importsPerSubpackages: {[subpkg: string]: {[value: string]: {[pkg: string]: string[]}}},
+      subpkg: string,
+      importedValue: string,
+      pkg: string,
+      filename: string
+    ): void {
+      const location = {
+        [pkg]: [filename],
+      };
+      if (subpkg in importsPerSubpackages) {
+        if (importedValue in importsPerSubpackages[subpkg]) {
+          if (pkg in importsPerSubpackages[subpkg][importedValue]) {
+            importsPerSubpackages[subpkg][importedValue][pkg].push(filename);
+          } else {
+            importsPerSubpackages[subpkg][importedValue][pkg] = [filename];
+          }
+        } else {
+          importsPerSubpackages[subpkg][importedValue] = location;
+        }
+      } else {
+        importsPerSubpackages[subpkg] = {
+          [importedValue]: location,
+        };
+      }
+    }
+
+    const waitUntilDone = setInterval(() => {
+      if (
+        isDependencyTreeLoaded &&
+        isDirectoriesPerPackagesLoaded &&
+        isSubpackagePerPackagesLoaded &&
+        isUnusedExportsPerSubpackagesLoaded &&
+        isImportsPerSubpackagesLoaded
+      ) {
+        stopWaiting();
+        done();
+      }
+    }, 500);
+
+    function stopWaiting(): void {
+      clearInterval(waitUntilDone);
+    }
+  });
+
+  it("Should not be different from the list of expected unused exported values", () => {
+    // For each subpackages, list the exported values that are never imported
+    const actualUnusedExportedValues: {[subpkg: string]: ExportedValue[]} = {};
+    const expectedUnusedExportedValues: {[subpkg: string]: ExportedValue[]} = {};
+    for (const [subpkg, exportedValues] of Object.entries(unusedExportsPerSubpackages)) {
+      const unusedExportedValues = exportedValues.filter(
+        (exportedValue) =>
+          !(subpkg in importsPerSubpackages) ||
+          (!(exportedValue.value in importsPerSubpackages[subpkg]) && !("*" in importsPerSubpackages)) // * means every values from the subpkg are used
+      );
+      if (unusedExportedValues.length !== 0) {
+        actualUnusedExportedValues[subpkg] = unusedExportedValues;
+      }
+    }
+    expect(actualUnusedExportedValues).deep.equals(expectedUnusedExportedValues);
+  });
+});

--- a/packages/check-dead-code/test/utils/logger.ts
+++ b/packages/check-dead-code/test/utils/logger.ts
@@ -1,0 +1,20 @@
+import {createWinstonLogger, LogLevel, Logger} from "@lodestar/utils";
+
+/**
+ * Run the test with ENVs to control log level:
+ * ```
+ * LOG_LEVEL=debug mocha .ts
+ * DEBUG=1 mocha .ts
+ * VERBOSE=1 mocha .ts
+ * ```
+ */
+export function testLogger(module?: string): Logger {
+  return createWinstonLogger({level: getLogLevel(), module});
+}
+
+function getLogLevel(): LogLevel {
+  if (process.env["LOG_LEVEL"]) return process.env["LOG_LEVEL"] as LogLevel;
+  if (process.env["DEBUG"]) return LogLevel.debug;
+  if (process.env["VERBOSE"]) return LogLevel.verbose;
+  return LogLevel.error;
+}

--- a/packages/check-dead-code/tsconfig.build.json
+++ b/packages/check-dead-code/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "./lib"
+  }
+}

--- a/packages/check-dead-code/tsconfig.e2e.json
+++ b/packages/check-dead-code/tsconfig.e2e.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.e2e.json",
+  "include": [
+    "src",
+    "test"
+  ]
+}

--- a/packages/check-dead-code/tsconfig.json
+++ b/packages/check-dead-code/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3344,6 +3344,16 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@ts-morph/common@~0.12.3":
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.12.3.tgz#a96e250217cd30e480ab22ec6a0ebbe65fd784ff"
+  integrity sha512-4tUmeLyXJnJWvTFOKtcNJ1yh0a3SsTLi2MUoyj8iUNznFRN1ZquaNe7Oukqrnki2FzZkm0J9adCNLDZxUzvj+w==
+  dependencies:
+    fast-glob "^3.2.7"
+    minimatch "^3.0.4"
+    mkdirp "^1.0.4"
+    path-browserify "^1.0.1"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz"
@@ -4000,6 +4010,14 @@
   version "1.1.2"
   resolved "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
+
+"@vscode/ripgrep@^1.15.0":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@vscode/ripgrep/-/ripgrep-1.15.0.tgz#d6fec68d7c44d594967f21a6e6c97416cc7fb2bc"
+  integrity sha512-qbLYP3XPTfS5a80+WnGvDLhsD01LDrs03zjbbtWWnvwt8G9hP3j8mc3ckaIid7pj86MBSTyUb/ECaIWmJIGBYw==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    proxy-from-env "^1.1.0"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -5565,6 +5583,11 @@ cmd-shim@^5.0.0:
   dependencies:
     mkdirp-infer-owner "^2.0.0"
 
+code-block-writer@^11.0.0:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/code-block-writer/-/code-block-writer-11.0.3.tgz#9eec2993edfb79bfae845fbc093758c0a0b73b76"
+  integrity sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -5675,6 +5698,11 @@ commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 commander@~2.9.0:
   version "2.9.0"
@@ -5946,6 +5974,17 @@ cosmiconfig@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
   integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
+
+cosmiconfig@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
+  integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
   dependencies:
     "@types/parse-json" "^4.0.0"
     import-fresh "^3.2.1"
@@ -7317,6 +7356,17 @@ fast-glob@3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
   integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
+fast-glob@^3.2.7:
+  version "3.2.12"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
+  integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -9328,6 +9378,11 @@ json5@^2.1.2:
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
+
+json5@^2.1.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonc-parser@3.2.0:
   version "3.2.0"
@@ -11900,6 +11955,11 @@ proxy-addr@^2.0.7, proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 psl@^1.1.28:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
@@ -13657,6 +13717,11 @@ triple-beam@^1.2.0, triple-beam@^1.3.0:
   resolved "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz"
   integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
+"true-myth@^4.1.0":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/true-myth/-/true-myth-4.1.1.tgz#ff4ac9d5130276e34aa338757e2416ec19248ba2"
+  integrity sha512-rqy30BSpxPznbbTcAcci90oZ1YR4DqvKcNXNerG5gQBU2v4jk0cygheiul5J6ExIMrgDVuanv/MkGfqZbKrNNg==
+
 truncate-utf8-bytes@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz"
@@ -13673,6 +13738,14 @@ ts-loader@^9.3.1:
     enhanced-resolve "^5.0.0"
     micromatch "^4.0.0"
     semver "^7.3.4"
+
+ts-morph@^13.0.1:
+  version "13.0.3"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-13.0.3.tgz#c0c51d1273ae2edb46d76f65161eb9d763444c1d"
+  integrity sha512-pSOfUMx8Ld/WUreoSzvMFQG5i9uEiWIsBYjpU9+TTASOeUa89j5HykomeqVULm1oqWtBdleI3KEFRLrlA3zGIw==
+  dependencies:
+    "@ts-morph/common" "~0.12.3"
+    code-block-writer "^11.0.0"
 
 ts-node@^10.8.1, ts-node@^10.9.1:
   version "10.9.1"
@@ -13692,6 +13765,18 @@ ts-node@^10.8.1, ts-node@^10.9.1:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
+
+ts-prune@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-prune/-/ts-prune-0.10.3.tgz#b6c71a525543b38dcf947a7d3adfb7f9e8b91f38"
+  integrity sha512-iS47YTbdIcvN8Nh/1BFyziyUqmjXz7GVzWu02RaZXqb+e/3Qe1B7IQ4860krOeCGUeJmterAlaM2FRH0Ue0hjw==
+  dependencies:
+    commander "^6.2.1"
+    cosmiconfig "^7.0.1"
+    json5 "^2.1.3"
+    lodash "^4.17.21"
+    "true-myth" "^4.1.0"
+    ts-morph "^13.0.1"
 
 tsconfig-paths@^3.14.1, tsconfig-paths@^3.9.0:
   version "3.14.1"


### PR DESCRIPTION
**Motivation**

The goal is this PR is to:
1. create a reproducible unit test to check for unused exports (values used within the same module - but unused in the same package or cross-package) or dead-code (exported values that's never used, even within the same module)
1. remove detected unnecessary `export` keywords and delete detected dead code

Only 1. has been done for now.

How does it work?
1. get the dependency tree
3. get the directories per package
4. get the list of subpackages per package
5. get the list of unused exports per subpackage (using `ts-prune`). It will only look for usage within the same package the subpackage is in
6. get the list of imported values per subpackage (using `ripgrep`)
7. compare the list of exports created in 4. with the list of imports created in 5. and conclude

Why not just use `ts-prune`?
- `ts-prune` does not support monorepo & lerna. There have been PRs - [here](https://github.com/nadeesha/ts-prune/pull/213) and [there](https://github.com/nadeesha/ts-prune/issues/208) but the repo is in maintenance mode so they were closed.
- `ts-prune` only search for usages within a package
- but in our case, almost all exports are used cross-package (think `@lodestar/api`)
- it is still useful to get a first list of potential unused exports

Why `ripgrep`?
- it is fast and widely used
- I know it
- there is an npm package to use it in nodejs, used by vscode

Known limitations and possible improvements:
- the way it detects actual usage from `import * as foo from 'subpkg'` is potentially incomplete or inaccurate
- it's relatively slow - it wasn't optimized for speed, I just wanted to make it work first
- it only supports ES Module import, not CommonJS (but we don't really care)
- it would be nice if it was just an external tool that we would use as a CLI instead of creating a specific package for this test
- maybe adding monorepo support to a fork of `ts-prune` would have been better

What I need from you:
- the test seems to work as expected: it fails with the list of unused exported values. The values I manually checked do seem to be unused across packages.
- I need to know which of the unused exported values I should really act upon? (removing 'export' or deleting dead-code)

For convenience, I have put [here](https://raw.githubusercontent.com/nicobao/lodestar/unused-exports/packages/check-dead-code/result.json) the list of unused exported values that the test has found. You can log the same value by running the failing test (it will just not output a beautiful json like the one I provided).

Closes #2209 

**Steps to test or reproduce**

```sh
cd packages/check-dead-code
yarn test:unit
```
