### PR TITLE
Process api attestations in batch

### DIFF
--- a/packages/beacon-node/src/chain/regen/interface.ts
+++ b/packages/beacon-node/src/chain/regen/interface.ts
@@ -11,6 +11,7 @@ export enum RegenCaller {
   processBlocksInEpoch = "processBlocksInEpoch",
   validateGossipAggregateAndProof = "validateGossipAggregateAndProof",
   validateGossipAttestation = "validateGossipAttestation",
+  validateApiAttestation = "validateApiAttestation",
   onForkChoiceFinalized = "onForkChoiceFinalized",
 }
 

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -1,4 +1,4 @@
-import {phase0, Epoch, Root, Slot} from "@lodestar/types";
+import {phase0, Epoch, Root, Slot, ValidatorIndex} from "@lodestar/types";
 import {ProtoBlock} from "@lodestar/fork-choice";
 import {ATTESTATION_SUBNET_COUNT, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {toHexString} from "@chainsafe/ssz";
@@ -6,18 +6,21 @@ import {
   computeEpochAtSlot,
   CachedBeaconStateAllForks,
   getIndexedAttestationSignatureSet,
+  ISignatureSet,
 } from "@lodestar/state-transition";
 import {IBeaconChain} from "..";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors/index.js";
 import {MAXIMUM_GOSSIP_CLOCK_DISPARITY_SEC} from "../../constants/index.js";
 import {RegenCaller} from "../regen/index.js";
 
+type ValidationResult = {indexedAttestation: phase0.IndexedAttestation; subnet: number};
+
 export async function validateGossipAttestation(
   chain: IBeaconChain,
   attestation: phase0.Attestation,
   /** Optional, to allow verifying attestations through API with unknown subnet */
   subnet: number | null
-): Promise<{indexedAttestation: phase0.IndexedAttestation; subnet: number}> {
+): Promise<ValidationResult> {
   // Do checks in this order:
   // - do early checks (w/o indexed attestation)
   // - > obtain indexed attestation and committes per slot
@@ -159,6 +162,161 @@ export async function validateGossipAttestation(
   chain.seenAttesters.add(targetEpoch, validatorIndex);
 
   return {indexedAttestation, subnet: expectedSubnet};
+}
+
+/**
+ * Similar to validateGossipAttestation but for attestations from Rest Api
+ * /eth/v1/beacon/pool/attestations
+ * Need to ensure attestations have the same data before calling this function
+ * Doing this in batch have some advantage:
+ *   - Validate a lot of data once
+ *   - Regen state once
+ *   - Verify signatures in the same batch
+ */
+export async function validateApiAttestations(
+  chain: IBeaconChain,
+  attestations: phase0.Attestation[]
+): Promise<ValidationResult[]> {
+  if (attestations.length <= 1) {
+    return Promise.all(attestations.map((att) => validateGossipAttestation(chain, att, null)));
+  }
+
+  // Do checks in this order:
+  // - do early checks (w/o indexed attestation)
+  // - > obtain indexed attestation and committes per slot
+  // - do middle checks w/ indexed attestation
+  // - > verify signature
+  // - do late checks w/ a valid signature
+
+  // verify_early_checks
+  // Run the checks that happen before an indexed attestation is constructed.
+  const attData = attestations[0].data;
+  const attSlot = attData.slot;
+  const attEpoch = computeEpochAtSlot(attSlot);
+  const attTarget = attData.target;
+  const targetEpoch = attTarget.epoch;
+
+  // [REJECT] The attestation's epoch matches its target -- i.e. attestation.data.target.epoch == compute_epoch_at_slot(attestation.data.slot)
+  if (targetEpoch !== attEpoch) {
+    throw new AttestationError(GossipAction.REJECT, {
+      code: AttestationErrorCode.BAD_TARGET_EPOCH,
+    });
+  }
+
+  // Attestations must be for a known block. If the block is unknown, we simply drop the
+  // attestation and do not delay consideration for later.
+  //
+  // TODO (LH): Enforce a maximum skip distance for unaggregated attestations.
+
+  // [IGNORE] The block being voted for (attestation.data.beacon_block_root) has been seen (via both gossip
+  // and non-gossip sources) (a client MAY queue attestations for processing once block is retrieved).
+  const attHeadBlock = verifyHeadBlockAndTargetRoot(chain, attData.beaconBlockRoot, attTarget.root, attEpoch);
+
+  // [REJECT] The block being voted for (attestation.data.beacon_block_root) passes validation.
+  // > Altready check in `verifyHeadBlockAndTargetRoot()`
+
+  // [IGNORE] The current finalized_checkpoint is an ancestor of the block defined by attestation.data.beacon_block_root
+  // -- i.e. get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)) == store.finalized_checkpoint.root
+  // > Altready check in `verifyHeadBlockAndTargetRoot()`
+
+  // [REJECT] The attestation's target block is an ancestor of the block named in the LMD vote
+  //  --i.e. get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(attestation.data.target.epoch)) == attestation.data.target.root
+  // > Altready check in `verifyHeadBlockAndTargetRoot()`
+
+  // Using the target checkpoint state here caused unstable memory issue
+  // See https://github.com/ChainSafe/lodestar/issues/4896
+  // TODO: https://github.com/ChainSafe/lodestar/issues/4900
+  const attHeadState = await chain.regen
+    .getState(attHeadBlock.stateRoot, RegenCaller.validateApiAttestation)
+    .catch((e: Error) => {
+      throw new AttestationError(GossipAction.REJECT, {
+        code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE,
+        error: e as Error,
+      });
+    });
+
+  // [IGNORE] attestation.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots (within a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
+  //  -- i.e. attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot
+  // (a client MAY queue future attestations for processing at the appropriate slot).
+  verifyPropagationSlotRange(chain, attSlot);
+
+  const signatureSets: ISignatureSet[] = [];
+  const validationResults: ValidationResult[] = [];
+  const validatorIndices: ValidatorIndex[] = [];
+  for (const attestation of attestations) {
+    // [REJECT] The attestation is unaggregated -- that is, it has exactly one participating validator
+    // (len([bit for bit in attestation.aggregation_bits if bit]) == 1, i.e. exactly 1 bit is set).
+    // > TODO: Do this check **before** getting the target state but don't recompute zipIndexes
+    const aggregationBits = attestation.aggregationBits;
+    const bitIndex = aggregationBits.getSingleTrueBit();
+    if (bitIndex === null) {
+      throw new AttestationError(GossipAction.REJECT, {
+        code: AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET,
+      });
+    }
+
+    // [REJECT] The committee index is within the expected range
+    // -- i.e. data.index < get_committee_count_per_slot(state, data.target.epoch)
+    const attIndex = attData.index;
+    const committeeIndices = getCommitteeIndices(attHeadState, attSlot, attIndex);
+
+    const validatorIndex = committeeIndices[bitIndex];
+    validatorIndices.push(validatorIndex);
+
+    // [REJECT] The number of aggregation bits matches the committee size
+    // -- i.e. len(attestation.aggregation_bits) == len(get_beacon_committee(state, data.slot, data.index)).
+    // > TODO: Is this necessary? Lighthouse does not do this check
+    if (aggregationBits.bitLen !== committeeIndices.length) {
+      throw new AttestationError(GossipAction.REJECT, {
+        code: AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS,
+      });
+    }
+
+    // api attestations don't have subnet so never throw AttestationErrorCode.INVALID_SUBNET_ID
+    const expectedSubnet = attHeadState.epochCtx.computeSubnetForSlot(attSlot, attIndex);
+
+    // [IGNORE] There has been no other valid attestation seen on an attestation subnet that has an
+    // identical attestation.data.target.epoch and participating validator index.
+    if (chain.seenAttesters.isKnown(targetEpoch, validatorIndex)) {
+      throw new AttestationError(GossipAction.IGNORE, {
+        code: AttestationErrorCode.ATTESTATION_ALREADY_KNOWN,
+        targetEpoch,
+        validatorIndex,
+      });
+    }
+
+    // [REJECT] The signature of attestation is valid.
+    const indexedAttestation: phase0.IndexedAttestation = {
+      attestingIndices: [validatorIndex],
+      data: attData,
+      signature: attestation.signature,
+    };
+
+    signatureSets.push(getIndexedAttestationSignatureSet(attHeadState, indexedAttestation));
+
+    // Now that the attestation has been fully verified, store that we have received a valid attestation from this validator.
+    //
+    // It's important to double check that the attestation still hasn't been observed, since
+    // there can be a race-condition if we receive two attestations at the same time and
+    // process them in different threads.
+    if (chain.seenAttesters.isKnown(targetEpoch, validatorIndex)) {
+      throw new AttestationError(GossipAction.IGNORE, {
+        code: AttestationErrorCode.ATTESTATION_ALREADY_KNOWN,
+        targetEpoch,
+        validatorIndex,
+      });
+    }
+
+    validationResults.push({indexedAttestation, subnet: expectedSubnet});
+  }
+
+  if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
+    throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.INVALID_SIGNATURE});
+  }
+
+  validatorIndices.forEach((validatorIndex) => chain.seenAttesters.add(targetEpoch, validatorIndex));
+
+  return validationResults;
 }
 
 /**

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -172,6 +172,8 @@ export async function validateGossipAttestation(
  *   - Validate a lot of data once
  *   - Regen state once
  *   - Verify signatures in the same batch
+ * Since these attestations are from API, it's more likely that they are valid.
+ * If one of them is not valid, the API will fallback to validate them one by one.
  */
 export async function validateApiAttestations(
   chain: IBeaconChain,
@@ -314,7 +316,9 @@ export async function validateApiAttestations(
     throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.INVALID_SIGNATURE});
   }
 
-  validatorIndices.forEach((validatorIndex) => chain.seenAttesters.add(targetEpoch, validatorIndex));
+  for (const validatorIndex of validatorIndices) {
+    chain.seenAttesters.add(targetEpoch, validatorIndex);
+  }
 
   return validationResults;
 }

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -13,8 +13,8 @@ import {INetworkEventBus} from "./events.js";
 import {GossipBeaconNode, GossipType} from "./gossip/index.js";
 import {PeerAction, PeerScoreStats} from "./peers/index.js";
 import {IReqRespBeaconNode} from "./reqresp/ReqRespBeaconNode.js";
-import {PendingGossipsubMessage} from "./processor/types.js";
 import {AttnetsService, CommitteeSubscription} from "./subnets/index.js";
+import {PendingGossipsubMessage} from "./processor/types.js";
 
 export type PeerSearchOptions = {
   supportsProtocols?: string[];

--- a/packages/state-transition/src/signatureSets/indexedAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedAttestation.ts
@@ -27,6 +27,24 @@ export function getIndexedAttestationSignatureSet(
   return getAttestationWithIndicesSignatureSet(state, indexedAttestation, indexedAttestation.attestingIndices);
 }
 
+/**
+ * Create signature set for indexed attestation with same attestation data as another indexed attestation.
+ * Be careful with this function, it assume `signatureSetSameAttData` is from the same attestation data.
+ */
+export function cloneIndexedAttestationSignatureSet(
+  state: CachedBeaconStateAllForks,
+  indexedAttestation: phase0.IndexedAttestation,
+  signatureSetSameAttData: ISignatureSet
+): ISignatureSet {
+  const {epochCtx} = state;
+  return {
+    type: SignatureSetType.aggregate,
+    pubkeys: indexedAttestation.attestingIndices.map((i) => epochCtx.index2pubkey[i]),
+    signingRoot: signatureSetSameAttData.signingRoot,
+    signature: indexedAttestation.signature,
+  };
+}
+
 export function getAttestationsSignatureSets(
   state: CachedBeaconStateAllForks,
   signedBlock: allForks.SignedBeaconBlock


### PR DESCRIPTION
**Motivation**

`submitPoolsAttestation` takes more time with the new gossip queues, part of the reason is we validate their signatures in different bls batch (because there are many bls signatures to validate with new gossip queues)

**Description**

- Validate all api attestations in same batch if they have same data, this will:
  - Validate a lot of common data once
  - `computeSigningRoot()` once, we can have a cheap way to get signature set, see `cloneIndexedAttestationSignatureSet()`
  - Generate state once
  - Validate signatures in one batch
- Name the new api `validateApiAttestations`
- If attestation datas are not the same, fall back to the old api `validateGossipAttestation`
