### PR TITLE
Use finalized state id when no checkpoint provided in checkpoint sync

### DIFF
--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -1,12 +1,7 @@
 import {ssz} from "@lodestar/types";
 import {createBeaconConfig, BeaconConfig, ChainForkConfig} from "@lodestar/config";
 import {Logger} from "@lodestar/utils";
-import {
-  getLatestBlockRoot,
-  isWithinWeakSubjectivityPeriod,
-  BeaconStateAllForks,
-  computeCheckpointEpochAtStateSlot,
-} from "@lodestar/state-transition";
+import {isWithinWeakSubjectivityPeriod, BeaconStateAllForks} from "@lodestar/state-transition";
 import {
   IBeaconDb,
   IBeaconNodeOptions,
@@ -18,17 +13,13 @@ import {Checkpoint} from "@lodestar/types/phase0";
 
 import {downloadOrLoadFile} from "../../util/index.js";
 import {defaultNetwork, GlobalArgs} from "../../options/globalOptions.js";
-import {fetchWeakSubjectivityState, getCheckpointFromArg, getGenesisFileUrl} from "../../networks/index.js";
+import {
+  fetchWeakSubjectivityState,
+  getCheckpointFromArg,
+  getGenesisFileUrl,
+  getCheckpointFromState,
+} from "../../networks/index.js";
 import {BeaconArgs} from "./options.js";
-
-export function getCheckpointFromState(state: BeaconStateAllForks): Checkpoint {
-  return {
-    // the correct checkpoint is based on state's slot, its latestBlockHeader's slot's epoch can be
-    // behind the state
-    epoch: computeCheckpointEpochAtStateSlot(state.slot),
-    root: getLatestBlockRoot(state),
-  };
-}
 
 async function initAndVerifyWeakSubjectivityState(
   config: BeaconConfig,

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -166,7 +166,7 @@ export async function fetchWeakSubjectivityState(
       return res.response;
     });
 
-    logger.info("Download completed");
+    logger.info("Download completed", {stateId});
     const wsState = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);
 
     return {

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -1,12 +1,13 @@
 import fs from "node:fs";
 import got from "got";
-import {SLOTS_PER_EPOCH, ForkName} from "@lodestar/params";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ApiError, getClient} from "@lodestar/api";
 import {getStateTypeFromBytes} from "@lodestar/beacon-node";
 import {ChainConfig, ChainForkConfig} from "@lodestar/config";
 import {Checkpoint} from "@lodestar/types/phase0";
+import {Slot} from "@lodestar/types";
 import {fromHex, callFnWhenAwait, Logger} from "@lodestar/utils";
-import {BeaconStateAllForks} from "@lodestar/state-transition";
+import {BeaconStateAllForks, getLatestBlockRoot, computeCheckpointEpochAtStateSlot} from "@lodestar/state-transition";
 import {parseBootnodesFile} from "../util/format.js";
 import * as mainnet from "./mainnet.js";
 import * as dev from "./dev.js";
@@ -140,20 +141,21 @@ export async function fetchWeakSubjectivityState(
   {checkpointSyncUrl, wssCheckpoint}: {checkpointSyncUrl: string; wssCheckpoint?: string}
 ): Promise<{wsState: BeaconStateAllForks; wsCheckpoint: Checkpoint}> {
   try {
-    let wsCheckpoint;
+    let wsCheckpoint: Checkpoint | null;
+    let stateId: Slot | "finalized";
+
     const api = getClient({baseUrl: checkpointSyncUrl}, {config});
     if (wssCheckpoint) {
       wsCheckpoint = getCheckpointFromArg(wssCheckpoint);
+      stateId = wsCheckpoint.epoch * SLOTS_PER_EPOCH;
     } else {
-      const res = await api.beacon.getStateFinalityCheckpoints("head");
-      ApiError.assert(res, "Can not fetch finalized checkpoint");
-      wsCheckpoint = res.response.data.finalized;
+      // Fetch current finalized state and extract checkpoint from it
+      stateId = "finalized";
+      wsCheckpoint = null;
     }
-    const stateSlot = wsCheckpoint.epoch * SLOTS_PER_EPOCH;
-    const getStatePromise =
-      config.getForkName(stateSlot) === ForkName.phase0
-        ? api.debug.getState(`${stateSlot}`, "ssz")
-        : api.debug.getStateV2(`${stateSlot}`, "ssz");
+
+    // getStateV2 should be available for all forks including phase0
+    const getStatePromise = api.debug.getStateV2(stateId, "ssz");
 
     const stateBytes = await callFnWhenAwait(
       getStatePromise,
@@ -165,10 +167,11 @@ export async function fetchWeakSubjectivityState(
     });
 
     logger.info("Download completed");
+    const wsState = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);
 
     return {
-      wsState: getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes),
-      wsCheckpoint,
+      wsState,
+      wsCheckpoint: wsCheckpoint ?? getCheckpointFromState(wsState),
     };
   } catch (e) {
     throw new Error("Unable to fetch weak subjectivity state: " + (e as Error).message);
@@ -182,4 +185,13 @@ export function getCheckpointFromArg(checkpointStr: string): Checkpoint {
     throw new Error(`Could not parse checkpoint string: ${checkpointStr}`);
   }
   return {root: fromHex(match[1]), epoch: parseInt(match[2])};
+}
+
+export function getCheckpointFromState(state: BeaconStateAllForks): Checkpoint {
+  return {
+    // the correct checkpoint is based on state's slot, its latestBlockHeader's slot's epoch can be
+    // behind the state
+    epoch: computeCheckpointEpochAtStateSlot(state.slot),
+    root: getLatestBlockRoot(state),
+  };
 }


### PR DESCRIPTION
When no checkpoint was provided, we used to explicitly fetch `finalized` checkpoint which caused issues on `checkpointz` as it would not cache states for those checkpoints whose root  does not perfectly lie on epoch boundaries

This PR fixes that by just using `finalized` tag to get the state which checkpointz serves and duly updates with the last perfect checkpoint it has.

See: https://github.com/dappnode/DAppNodePackage-Lodestar-Prater/issues/58

Closes #4524