### PR TITLE
Handle gossip messages asynchronously

### DIFF
--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -405,7 +405,9 @@ export class Eth2Gossipsub extends GossipSub implements GossipBeaconNode {
     // Get seenTimestamp before adding the message to the queue or add async delays
     const seenTimestampSec = Date.now() / 1000;
 
-    // Emit message to network processor
+    // Emit message to network processor, use setTimeout to yield to the macro queue
+    // This is mostly due to too many attestation messages, and a gossipsub RPC may
+    // contain multiple of them. This helps avoid the I/O lag issue.
     setTimeout(() => {
       this.events.emit(NetworkEvent.pendingGossipsubMessage, {
         topic,

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -406,14 +406,16 @@ export class Eth2Gossipsub extends GossipSub implements GossipBeaconNode {
     const seenTimestampSec = Date.now() / 1000;
 
     // Emit message to network processor
-    this.events.emit(NetworkEvent.pendingGossipsubMessage, {
-      topic,
-      msg,
-      msgId,
-      propagationSource,
-      seenTimestampSec,
-      startProcessUnixSec: null,
-    });
+    setTimeout(() => {
+      this.events.emit(NetworkEvent.pendingGossipsubMessage, {
+        topic,
+        msg,
+        msgId,
+        propagationSource,
+        seenTimestampSec,
+        startProcessUnixSec: null,
+      });
+    }, 0);
   }
 
   private onValidationResult(msgId: string, propagationSource: PeerId, acceptance: TopicValidatorResult): void {

--- a/packages/beacon-node/src/network/processor/worker.ts
+++ b/packages/beacon-node/src/network/processor/worker.ts
@@ -47,6 +47,15 @@ export class NetworkWorker {
       );
     }
 
-    this.events.emit(NetworkEvent.gossipMessageValidationResult, message.msgId, message.propagationSource, acceptance);
+    setTimeout(
+      () =>
+        this.events.emit(
+          NetworkEvent.gossipMessageValidationResult,
+          message.msgId,
+          message.propagationSource,
+          acceptance
+        ),
+      0
+    );
   }
 }

--- a/packages/beacon-node/src/network/processor/worker.ts
+++ b/packages/beacon-node/src/network/processor/worker.ts
@@ -47,6 +47,9 @@ export class NetworkWorker {
       );
     }
 
+    // Use setTimeout to yield to the macro queue
+    // This is mostly due to too many attestation messages, and a gossipsub RPC may
+    // contain multiple of them. This helps avoid the I/O lag issue.
     setTimeout(
       () =>
         this.events.emit(


### PR DESCRIPTION
**Motivation**

- There are I/O lag issue with the new gossip queue: more time to submit attestations from `vc`, more time to call `notifyNewPayload` engine api
- Lifecycle of a gossipsub message is all synchronous:
  - we call `onGossipsubMessage` synchronously
  - which call gossip validation function synchronously
  - which call the `reportMessageValidationResult` synchronously
  - this is really bad for the I/O in case `RPC` contains thousands of gossip messages
- In current implementation (`stable/unstable`) when we push gossip messages to `JobItemQueue` we always use `setTimeout()` which helps avoid the I/O lag issue, we also yield to the macro queue every 50ms there

**Description**

- Use `setTimeout` to break our gossip handler to multiple event loops which helps the I/O lag issue (which make it equivalent to the current behavior of `stable` branch)
- Metrics show that it does not effect performance at all: almost same job wait time, job process time, no dropped job

part of #5247

