### PR TITLE
Make the prover package private to avoid publishing

### DIFF
--- a/packages/prover/package.json
+++ b/packages/prover/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "@lodestar/prover",
   "description": "A Typescript implementation of the Ethereum Consensus light client",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Motivation**

Make the `@lodestar/prover` package private to avoid publishing.

**Description**

We will publish the prover package when its' get mature. 

**Reference**
https://github.com/lerna/lerna/issues/953#issuecomment-326409717
