### PR TITLE
Unschedule capella in chiado and gnosis

### DIFF
--- a/packages/config/src/chainConfig/networks/chiado.ts
+++ b/packages/config/src/chainConfig/networks/chiado.ts
@@ -38,4 +38,7 @@ export const chiadoChainConfig: ChainConfig = {
   // Bellatrix
   BELLATRIX_FORK_VERSION: b("0x0200006f"),
   BELLATRIX_FORK_EPOCH: 180,
+  // Capella
+  CAPELLA_FORK_VERSION: b("0x0300006f"),
+  CAPELLA_FORK_EPOCH: Infinity,
 };

--- a/packages/config/src/chainConfig/networks/gnosis.ts
+++ b/packages/config/src/chainConfig/networks/gnosis.ts
@@ -38,4 +38,7 @@ export const gnosisChainConfig: ChainConfig = {
   // Bellatrix
   BELLATRIX_FORK_VERSION: b("0x02000064"),
   BELLATRIX_FORK_EPOCH: 385536,
+  // Capella
+  CAPELLA_FORK_VERSION: b("0x03000064"),
+  CAPELLA_FORK_EPOCH: Infinity,
 };


### PR DESCRIPTION
Because of mainnet scheduling of Capella a bug was introduced in chiado and gnosis configs where which inherits configs from mainnet

This PR explicitly unschedules capella iin them