### PR TITLE
Enable metrics if monitoring endpoint is configured

### DIFF
--- a/docs/usage/client-monitoring.md
+++ b/docs/usage/client-monitoring.md
@@ -14,10 +14,9 @@ Lodestar provides CLI options to configure monitoring on both the beacon node an
 ### Remote endpoint URL
 
 Client monitoring can be enabled by setting the `--monitoring.endpoint` flag to a remote service endpoint URL.
-As monitoring relies on metrics data, it is required that metrics are also enabled by supplying the `--metrics` flag.
 
 ```bash
-lodestar beacon --monitoring.endpoint "https://beaconcha.in/api/v1/client/metrics?apikey={apikey}&machine={machineName}" --metrics
+lodestar beacon --monitoring.endpoint "https://beaconcha.in/api/v1/client/metrics?apikey={apikey}&machine={machineName}"
 ```
 
 In case of *beaconcha.in*, the API key can be found in your [account settings](https://beaconcha.in/user/settings#api).

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -164,7 +164,11 @@ export class BeaconNode {
     await db.pruneHotDb();
 
     let metrics = null;
-    if (opts.metrics.enabled) {
+    if (
+      opts.metrics.enabled ||
+      // monitoring relies on metrics data
+      opts.monitoring.endpoint
+    ) {
       metrics = createMetrics(
         opts.metrics,
         config,
@@ -179,11 +183,8 @@ export class BeaconNode {
 
     let monitoring = null;
     if (opts.monitoring.endpoint) {
-      if (metrics == null) {
-        throw new Error("Metrics must be enabled to use monitoring");
-      }
       monitoring = new MonitoringService("beacon", opts.monitoring, {
-        register: metrics.register,
+        register: (metrics as Metrics).register,
         logger: logger.child({module: LoggerModule.monitoring}),
       });
       monitoring.start();
@@ -261,9 +262,10 @@ export class BeaconNode {
       metrics,
     });
 
-    const metricsServer = metrics
+    // only start server if metrics are explicitly enabled
+    const metricsServer = opts.metrics.enabled
       ? new HttpMetricsServer(opts.metrics, {
-          register: metrics.register,
+          register: (metrics as Metrics).register,
           getOtherMetrics: async (): Promise<string> => {
             return network.metrics();
           },

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -108,10 +108,10 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
 
   const slashingProtection = new SlashingProtection(dbOps);
 
-  // Create metrics registry if metrics are enabled
+  // Create metrics registry if metrics are enabled or monitoring endpoint is configured
   // Send version and network data for static registries
 
-  const register = args["metrics"] ? new RegistryMetricCreator() : null;
+  const register = args["metrics"] || args["monitoring.endpoint"] ? new RegistryMetricCreator() : null;
   const metrics = register && getMetrics((register as unknown) as MetricsRegister, {version, commit, network});
 
   // Start metrics server if metrics are enabled.
@@ -120,19 +120,18 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
   if (metrics) {
     collectNodeJSMetrics(register);
 
-    const port = args["metrics.port"] ?? validatorMetricsDefaultOptions.port;
-    const address = args["metrics.address"] ?? validatorMetricsDefaultOptions.address;
-    const metricsServer = new HttpMetricsServer({port, address}, {register, logger});
+    // only start server if metrics are explicitly enabled
+    if (args["metrics"]) {
+      const port = args["metrics.port"] ?? validatorMetricsDefaultOptions.port;
+      const address = args["metrics.address"] ?? validatorMetricsDefaultOptions.address;
+      const metricsServer = new HttpMetricsServer({port, address}, {register, logger});
 
-    onGracefulShutdownCbs.push(() => metricsServer.stop());
-    await metricsServer.start();
+      onGracefulShutdownCbs.push(() => metricsServer.stop());
+      await metricsServer.start();
+    }
   }
 
   if (args["monitoring.endpoint"]) {
-    if (register == null) {
-      throw new Error("Metrics must be enabled to use monitoring");
-    }
-
     const {interval, initialDelay, requestTimeout, collectSystemStats} = validatorMonitoringDefaultOptions;
 
     const monitoring = new MonitoringService(
@@ -144,7 +143,7 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
         requestTimeout: args["monitoring.requestTimeout"] ?? requestTimeout,
         collectSystemStats: args["monitoring.collectSystemStats"] ?? collectSystemStats,
       },
-      {register, logger}
+      {register: register as RegistryMetricCreator, logger}
     );
 
     onGracefulShutdownCbs.push(() => monitoring.stop());

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -322,7 +322,7 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
   "monitoring.endpoint": {
     type: "string",
     description:
-      "Enables monitoring service for sending clients stats to the specified endpoint of a remote service (e.g. beaconcha.in). It is required that metrics are also enabled by supplying the --metrics flag.",
+      "Enables monitoring service for sending clients stats to the specified endpoint of a remote service (e.g. beaconcha.in)",
     group: "monitoring",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/monitoring.ts
+++ b/packages/cli/src/options/beaconNodeOptions/monitoring.ts
@@ -23,7 +23,7 @@ export const options: CliCommandOptions<MonitoringArgs> = {
   "monitoring.endpoint": {
     type: "string",
     description:
-      "Enables monitoring service for sending clients stats to the specified endpoint of a remote service (e.g. beaconcha.in). It is required that metrics are also enabled by supplying the --metrics flag.",
+      "Enables monitoring service for sending clients stats to the specified endpoint of a remote service (e.g. beaconcha.in)",
     group: "monitoring",
   },
 


### PR DESCRIPTION
**Motivation**

Improve monitoring UX by not requiring users to also supply `--metrics` flag. If users only want to use monitoring via remote service and do not have a local prometheus/grafana stack it is not required to start the metrics server.

**Description**

Monitoring relies on metrics data to work properly and as of now would throw an error if `--metrics` flag is not supplied. This change implicitly enables metrics if a monitoring endpoint is configured.

**Note:** metrics server will only be started if metrics are explicitly enabled