### PR TITLE
Handle timeout errors as api errors

### DIFF
--- a/packages/api/src/utils/client/client.ts
+++ b/packages/api/src/utils/client/client.ts
@@ -1,8 +1,9 @@
-import {mapValues} from "@lodestar/utils";
+import {TimeoutError, mapValues} from "@lodestar/utils";
 import {compileRouteUrlFormater} from "../urlFormat.js";
 import {RouteDef, ReqGeneric, ReturnTypes, TypeJson, ReqSerializer, ReqSerializers, RoutesData} from "../types.js";
 import {APIClientHandler} from "../../interfaces.js";
 import {FetchOpts, HttpError, IHttpClient} from "./httpClient.js";
+import {HttpStatusCode} from "./httpStatusCode.js";
 
 // See /packages/api/src/routes/index.ts for reasoning
 
@@ -81,6 +82,13 @@ export function generateGenericJsonClient<
           return {ok: false, error: {code: err.status, message: err.message, operationId: routeId}} as ReturnType<
             Api[keyof Api]
           >;
+        }
+
+        if (err instanceof TimeoutError) {
+          return {
+            ok: false,
+            error: {code: HttpStatusCode.INTERNAL_SERVER_ERROR, message: err.message, operationId: routeId},
+          } as ReturnType<Api[keyof Api]>;
         }
 
         throw err;


### PR DESCRIPTION
**Motivation**

Error logs due to a http timeout are hard to read as those are not handled as by `ApiError.assert` which adds more context to the error.

**Current error log**

Error message itself it not detailed, need to look into stack trace to find out where it failed

```log
Eph 0/3 0.022[]                error: Error on runEvery fn  Timeout request
Error: Timeout request
    at HttpClient.requestWithBody (file:///home/nico/projects/ethereum/lodestar/packages/api/src/utils/client/httpClient.ts:302:17)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Object.request [as produceAttestationData] (file:///home/nico/projects/ethereum/lodestar/packages/api/src/utils/client/client.ts:69:23)
    at AttestationService.produceAttestation (file:///home/nico/projects/ethereum/lodestar/packages/validator/src/services/attestation.ts:151:17)
    at AttestationService.runAttestationTasksGrouped (file:///home/nico/projects/ethereum/lodestar/packages/validator/src/services/attestation.ts:119:36)
    at AttestationService.runAttestationTasks (file:///home/nico/projects/ethereum/lodestar/packages/validator/src/services/attestation.ts:87:7)
    at Clock.runAtMostEvery (file:///home/nico/projects/ethereum/lodestar/packages/validator/src/util/clock.ts:96:7)
```

**Expected error log**

Error message includes all details, we know it was timeout and that it happened on produce attestation data request

```log
Eph 0/1 2.002[]                error: Error on runEvery fn  Error producing attestation - Timeout request
Error: Error producing attestation - Timeout request
    at Function.assert (file:///home/nico/projects/ethereum/lodestar/packages/api/src/utils/client/httpClient.ts:44:13)
    at AttestationService.produceAttestation (file:///home/nico/projects/ethereum/lodestar/packages/validator/src/services/attestation.ts:152:14)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at AttestationService.runAttestationTasksGrouped (file:///home/nico/projects/ethereum/lodestar/packages/validator/src/services/attestation.ts:119:36)
    at AttestationService.runAttestationTasks (file:///home/nico/projects/ethereum/lodestar/packages/validator/src/services/attestation.ts:87:7)
    at Clock.runAtMostEvery (file:///home/nico/projects/ethereum/lodestar/packages/validator/src/util/clock.ts:96:7)
```

**Description**

Check if error is `TimeoutError` and instead of throwing it return a API response with code `500`.
