### PR TITLE
Missing state-transition dependency in light-client package

### DIFF
--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -69,6 +69,7 @@
     "@lodestar/api": "^1.6.0",
     "@lodestar/config": "^1.6.0",
     "@lodestar/params": "^1.6.0",
+    "@lodestar/state-transition": "^1.6.0",
     "@lodestar/types": "^1.6.0",
     "@lodestar/utils": "^1.6.0",
     "cross-fetch": "^3.1.4",


### PR DESCRIPTION
**Motivation**

Fix builds on slow machines

**Description**

https://github.com/ChainSafe/lodestar/pull/5246 added a build dep on `@lodestar/state-transition` but was never added to the `package.json`. On fast build machines the `@lodestar/state-transition` package is usually built before the `@lodestar/light-client` package starts, but slower machines (github runners etc.) have concurrency issues.

The error;

```bash
#8 [build_src 5/6] RUN yarn install --non-interactive --frozen-lockfile &&   yarn build &&   yarn install --non-interactive --frozen-lockfile --production
#8 0.350 yarn install v1.22.19
#8 0.601 [1/5] Validating package.json...
#8 0.640 [2/5] Resolving packages...
#8 1.724 [3/5] Fetching packages...
#8 38.13 [4/5] Linking dependencies...
#8 38.14 warning " > @lodestar/api@1.6.0" has unmet peer dependency "fastify@3.29.4".
#8 38.14 warning " > @lodestar/beacon-node@1.6.0" has unmet peer dependency "c-kzg@^1.0.7".
#8 38.14 warning " > @lodestar/reqresp@1.6.0" has unmet peer dependency "libp2p@0.41.0".
#8 38.14 warning "workspace-aggregator-57537408-e615-4450-8f38-bc19d6bfbcf1 > @lodestar/beacon-node > @chainsafe/bls@7.1.1" has unmet peer dependency "@chainsafe/blst@^0.2.4".
#8 38.14 warning "workspace-aggregator-57537408-e615-4450-8f38-bc19d6bfbcf1 > @lodestar/beacon-node > prometheus-gc-stats@0.6.3" has incorrect peer dependency "prom-client@>= 10 <= 12".
#8 38.14 warning "workspace-aggregator-57537408-e615-4450-8f38-bc19d6bfbcf1 > @lodestar/beacon-node > @multiformats/multiaddr > dns-over-http-resolver > native-fetch@4.0.2" has unmet peer dependency "undici@*".
#8 57.47 [5/5] Building fresh packages...
#8 120.6 Done in 120.23s.
#8 120.9 yarn run v1.22.19
#8 121.0 $ lerna run build
#8 121.5 lerna notice cli v5.5.2
#8 121.6 lerna info Executing command in 16 packages: "yarn run build"
#8 122.0 @lodestar/params: $ tsc -p tsconfig.build.json
#8 122.0 @lodestar/utils: $ tsc -p tsconfig.build.json
#8 136.3 @lodestar/types: $ tsc -p tsconfig.build.json
#8 137.4 @lodestar/spec-test-util: $ tsc -p tsconfig.build.json
#8 153.8 @lodestar/config: $ tsc -p tsconfig.build.json
#8 167.8 @lodestar/db: $ tsc -p tsconfig.build.json
#8 167.8 @lodestar/api: $ tsc -p tsconfig.build.json
#8 187.5 @lodestar/reqresp: $ tsc -p tsconfig.build.json
#8 [194](https://github.com/Savid/lodestar/actions/runs/4591419949/jobs/8107563547?pr=1#step:7:198).9 @lodestar/state-transition: $ tsc -p tsconfig.build.json
#8 [207](https://github.com/Savid/lodestar/actions/runs/4591419949/jobs/8107563547?pr=1#step:7:211).9 @lodestar/light-client: $ tsc -p tsconfig.build.json
#8 [219](https://github.com/Savid/lodestar/actions/runs/4591419949/jobs/8107563547?pr=1#step:7:223).6 @lodestar/flare: $ tsc -p tsconfig.build.json
#8 229.9 @lodestar/light-client: src/spec/utils.ts:13:34 - error TS2307: Cannot find module '@lodestar/state-transition' or its corresponding type declarations.
#8 229.9 @lodestar/light-client: 13 import {computeEpochAtSlot} from "@lodestar/state-transition";
#8 229.9 @lodestar/light-client:                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 229.9 @lodestar/light-client: Found 1 error in src/spec/utils.ts:13
#8 230.0 @lodestar/light-client: error Command failed with exit code 2.
#8 230.0 @lodestar/light-client: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
#8 230.0 lerna ERR! yarn run build exited 2 in '@lodestar/light-client'
#8 230.1 lerna WARN complete Waiting for 2 child processes to exit. CTRL-C to exit immediately.
#8 230.1 error Command failed with exit code 2.
#8 230.1 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
#8 ERROR: process "/bin/sh -c yarn install --non-interactive --frozen-lockfile &&   yarn build &&   yarn install --non-interactive --frozen-lockfile --production" did not complete successfully: exit code: 2
------
 > [build_src 5/6] RUN yarn install --non-interactive --frozen-lockfile &&   yarn build &&   yarn install --non-interactive --frozen-lockfile --production:
#8 [229](https://github.com/Savid/lodestar/actions/runs/4591419949/jobs/8107563547?pr=1#step:7:233).9 @lodestar/light-client: src/spec/utils.ts:13:34 - error TS2307: Cannot find module '@lodestar/state-transition' or its corresponding type declarations.
#8 229.9 @lodestar/light-client: 13 import {computeEpochAtSlot} from "@lodestar/state-transition";
#8 229.9 @lodestar/light-client:                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#8 229.9 @lodestar/light-client: Found 1 error in src/spec/utils.ts:13
#8 230.0 @lodestar/light-client: error Command failed with exit code 2.
#8 230.0 @lodestar/light-client: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
#8 230.0 lerna ERR! yarn run build exited 2 in '@lodestar/light-client'
#8 230.1 lerna WARN complete Waiting for 2 child processes to exit. CTRL-C to exit immediately.
#8 [230](https://github.com/Savid/lodestar/actions/runs/4591419949/jobs/8107563547?pr=1#step:7:234).1 error Command failed with exit code 2.
#8 230.1 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
------
./Dockerfile:11
--------------------
  10 |     
  11 | >>> RUN yarn install --non-interactive --frozen-lockfile && \
  12 | >>>   yarn build && \
  13 | >>>   yarn install --non-interactive --frozen-lockfile --production
  14 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c yarn install --non-interactive --frozen-lockfile &&   yarn build &&   yarn install --non-interactive --frozen-lockfile --production" did not complete successfully: exit code: 2
```

**Steps to test or reproduce**

Example build workflow https://github.com/Savid/lodestar/blob/missing-dep-test/.github/workflows/build.yml

Example failed build (current unstable) https://github.com/Savid/lodestar/actions/runs/4591419949/jobs/8107563547

Example successful build (this pr) https://github.com/Savid/lodestar/actions/runs/4591451782/jobs/8107617203



