### PR TITLE
Implement distributed aggregation selections

### DIFF
--- a/packages/api/test/unit/beacon/testData/validator.ts
+++ b/packages/api/test/unit/beacon/testData/validator.ts
@@ -6,6 +6,7 @@ import {GenericServerTestCases} from "../../../utils/genericServerTest.js";
 const ZERO_HASH = Buffer.alloc(32, 0);
 const ZERO_HASH_HEX = "0x" + ZERO_HASH.toString("hex");
 const randaoReveal = Buffer.alloc(96, 1);
+const selectionProof = Buffer.alloc(96, 1);
 const graffiti = "a".repeat(32);
 
 export const testData: GenericServerTestCases<Api> = {
@@ -89,6 +90,14 @@ export const testData: GenericServerTestCases<Api> = {
   prepareBeaconProposer: {
     args: [[{validatorIndex: "1", feeRecipient: "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"}]],
     res: undefined,
+  },
+  submitBeaconCommitteeSelections: {
+    args: [[]],
+    res: {data: [{validatorIndex: 1, slot: 2, selectionProof}]},
+  },
+  submitSyncCommitteeSelections: {
+    args: [[]],
+    res: {data: [{validatorIndex: 1, slot: 2, subcommitteeIndex: 3, selectionProof}]},
   },
   getLiveness: {
     args: [[0], 0],

--- a/packages/beacon-node/src/api/impl/errors.ts
+++ b/packages/beacon-node/src/api/impl/errors.ts
@@ -31,3 +31,11 @@ export class NodeIsSyncing extends ApiError {
     super(503, `Node is syncing - ${statusMsg}`);
   }
 }
+
+// Error thrown by beacon node APIs that are only supported by distributed validator middleware clients
+// For example https://github.com/ethereum/beacon-APIs/blob/f087fbf2764e657578a6c29bdf0261b36ee8db1e/apis/validator/beacon_committee_selections.yaml
+export class OnlySupportedByDVT extends ApiError {
+  constructor() {
+    super(501, "Only supported by distributed validator middleware clients");
+  }
+}

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -19,7 +19,7 @@ import {ZERO_HASH} from "../../../constants/index.js";
 import {SyncState} from "../../../sync/index.js";
 import {isOptimisticBlock} from "../../../util/forkChoice.js";
 import {toGraffitiBuffer} from "../../../util/graffiti.js";
-import {ApiError, NodeIsSyncing} from "../errors.js";
+import {ApiError, NodeIsSyncing, OnlySupportedByDVT} from "../errors.js";
 import {validateSyncCommitteeGossipContributionAndProof} from "../../../chain/validation/syncCommitteeContributionAndProof.js";
 import {CommitteeSubscription} from "../../../network/subnets/index.js";
 import {ApiModules} from "../types.js";
@@ -696,6 +696,14 @@ export function getValidatorApi({
 
     async prepareBeaconProposer(proposers) {
       await chain.updateBeaconProposerData(chain.clock.currentEpoch, proposers);
+    },
+
+    async submitBeaconCommitteeSelections() {
+      throw new OnlySupportedByDVT();
+    },
+
+    async submitSyncCommitteeSelections() {
+      throw new OnlySupportedByDVT();
     },
 
     async getLiveness(indices: ValidatorIndex[], epoch: Epoch) {

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -324,7 +324,7 @@ export class AttestationService {
       // Exit attestation aggregation flow if there is no response after 1/3 of slot as
       // beacon node would likely not have enough time to prepare an aggregate attestation.
       // Note that the aggregations flow is not explicitly exited but rather will be skipped
-      // due to the fact that calculation of `is_aggregator` in duties service is not done
+      // due to the fact that calculation of `is_aggregator` in AttestationDutiesService is not done
       // and selectionProof is set to null, meaning no validator will be considered an aggregator.
       sleep(this.clock.msToSlot(slot + 1 / 3), signal),
     ]);

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -332,7 +332,7 @@ export class AttestationService {
     if (!res) {
       throw new Error("submitBeaconCommitteeSelections did not resolve after 1/3 of slot");
     }
-    ApiError.assert(res);
+    ApiError.assert(res, "Error receiving combined selection proofs");
 
     const combinedSelections = res.response.data;
     this.logger.debug("Received combined beacon committee selection proofs", {slot, count: combinedSelections.length});

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -328,7 +328,7 @@ export class AttestationService {
     ]);
 
     if (!res) {
-      throw new Error("No response after 1/3 of slot");
+      throw new Error("submitBeaconCommitteeSelections did not resolve after 1/3 of slot");
     }
     ApiError.assert(res);
 

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -318,7 +318,9 @@ export class AttestationService {
     this.logger.debug("Submitting partial beacon committee selection proofs", {slot, count: partialSelections.length});
 
     const res = await Promise.race([
-      this.api.validator.submitBeaconCommitteeSelections(partialSelections),
+      this.api.validator
+        .submitBeaconCommitteeSelections(partialSelections)
+        .catch((e) => this.logger.error("Error on submitBeaconCommitteeSelections", {slot}, e)),
       // Exit attestation aggregation flow if there is no response after 1/3 of slot as
       // beacon node would likely not have enough time to prepare an aggregate attestation.
       // Note that the aggregations flow is not explicitly exited but rather will be skipped

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -371,15 +371,14 @@ export class AttestationService {
 
     // If there are any subscriptions with aggregators, push them out to the beacon node.
     if (beaconCommitteeSubscriptions.length > 0) {
-      try {
-        ApiError.assert(await this.api.validator.prepareBeaconCommitteeSubnet(beaconCommitteeSubscriptions));
-        this.logger.debug("Resubscribed validators as aggregators on beacon committee subnets", {
-          slot,
-          count: beaconCommitteeSubscriptions.length,
-        });
-      } catch (e) {
-        this.logger.error("Failed to resubscribe to beacon committee subnets", {slot}, e as Error);
-      }
+      ApiError.assert(
+        await this.api.validator.prepareBeaconCommitteeSubnet(beaconCommitteeSubscriptions),
+        "Failed to resubscribe to beacon committee subnets"
+      );
+      this.logger.debug("Resubscribed validators as aggregators on beacon committee subnets", {
+        slot,
+        count: beaconCommitteeSubscriptions.length,
+      });
     }
   }
 }

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -337,7 +337,7 @@ export class AttestationDutiesService {
     if (this.opts?.distributedAggregationSelection) {
       // Validator in distributed cluster only has a key share, not the full private key.
       // Passing a partial selection proof to `is_aggregator` would produce incorrect result.
-      // Attestation service will exchange partial for combined selection proofs retrieved from
+      // AttestationService will exchange partial for combined selection proofs retrieved from
       // distributed validator middleware client and determine aggregators at beginning of every slot.
       return {duty, selectionProof: null, partialSelectionProof: selectionProof};
     }

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -277,7 +277,7 @@ export class SyncCommitteeService {
     if (!res) {
       throw new Error("submitSyncCommitteeSelections did not resolve after 2/3 of slot");
     }
-    ApiError.assert(res);
+    ApiError.assert(res, "Error receiving combined selection proofs");
 
     const combinedSelections = res.response.data;
     this.logger.debug("Received combined sync committee selection proofs", {slot, count: combinedSelections.length});

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -273,7 +273,7 @@ export class SyncCommitteeService {
     ]);
 
     if (!res) {
-      throw new Error("No response after 2/3 of slot");
+      throw new Error("submitSyncCommitteeSelections did not resolve after 2/3 of slot");
     }
     ApiError.assert(res);
 

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -12,7 +12,7 @@ import {groupSyncDutiesBySubcommitteeIndex, SubcommitteeDuty} from "./utils.js";
 import {ChainHeaderTracker} from "./chainHeaderTracker.js";
 import {ValidatorEventEmitter} from "./emitter.js";
 
-type SyncCommitteeServiceOpts = {
+export type SyncCommitteeServiceOpts = {
   scAfterBlockDelaySlotFraction?: number;
   distributedAggregationSelection?: boolean;
 };

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -269,7 +269,7 @@ export class SyncCommitteeService {
       // because for sync committee is not required to resubscribe to subnets as beacon node will assume
       // validator always aggregates. This allows us to wait until we have to produce sync committee contributions.
       // Note that the sync committee contributions flow is not explicitly exited but rather will be skipped
-      // due to the fact that calculation of `is_sync_committee_aggregator` in duties service is not done
+      // due to the fact that calculation of `is_sync_committee_aggregator` in SyncCommitteeDutiesService is not done
       // and selectionProof is set to null, meaning no validator will be considered an aggregator.
       sleep(this.clock.msToSlot(slot + 2 / 3), signal),
     ]);

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -261,7 +261,9 @@ export class SyncCommitteeService {
     this.logger.debug("Submitting partial sync committee selection proofs", {slot, count: partialSelections.length});
 
     const res = await Promise.race([
-      this.api.validator.submitSyncCommitteeSelections(partialSelections),
+      this.api.validator
+        .submitSyncCommitteeSelections(partialSelections)
+        .catch((e) => this.logger.error("Error on submitSyncCommitteeSelections", {slot}, e)),
       // Exit sync committee contributions flow if there is no response after 2/3 of slot.
       // This is in contrast to attestations aggregations flow which is already exited at 1/3 of the slot
       // because for sync committee is not required to resubscribe to subnets as beacon node will assume

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -1,8 +1,8 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Slot, CommitteeIndex, altair, Root} from "@lodestar/types";
+import {Slot, CommitteeIndex, altair, Root, BLSSignature} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
-import {Api, ApiError} from "@lodestar/api";
+import {computeEpochAtSlot, isSyncCommitteeAggregator} from "@lodestar/state-transition";
+import {Api, ApiError, routes} from "@lodestar/api";
 import {IClock, LoggerVc} from "../util/index.js";
 import {PubkeyHex} from "../types.js";
 import {Metrics} from "../metrics.js";
@@ -14,6 +14,7 @@ import {ValidatorEventEmitter} from "./emitter.js";
 
 type SyncCommitteeServiceOpts = {
   scAfterBlockDelaySlotFraction?: number;
+  distributedAggregationSelection?: boolean;
 };
 
 /**
@@ -33,7 +34,9 @@ export class SyncCommitteeService {
     private readonly metrics: Metrics | null,
     private readonly opts?: SyncCommitteeServiceOpts
   ) {
-    this.dutiesService = new SyncCommitteeDutiesService(config, logger, api, clock, validatorStore, metrics);
+    this.dutiesService = new SyncCommitteeDutiesService(config, logger, api, clock, validatorStore, metrics, {
+      distributedAggregationSelection: opts?.distributedAggregationSelection,
+    });
 
     // At most every slot, check existing duties from SyncCommitteeDutiesService and run tasks
     clock.runEverySlot(this.runSyncCommitteeTasks);
@@ -54,6 +57,18 @@ export class SyncCommitteeService {
       const dutiesAtSlot = await this.dutiesService.getDutiesAtSlot(slot);
       if (dutiesAtSlot.length === 0) {
         return;
+      }
+
+      if (this.opts?.distributedAggregationSelection) {
+        // Validator in distributed cluster only has a key share, not the full private key.
+        // The partial selection proofs must be exchanged for combined selection proofs by
+        // calling submitSyncCommitteeSelections on the distributed validator middleware client.
+        // This will run in parallel to other sync committee tasks but must be finished before starting
+        // sync committee contributions as it is required to correctly determine if validator is aggregator
+        // and to produce a ContributionAndProof that can be threshold aggregated by the middleware client.
+        this.runDistributedAggregationSelectionTasks(dutiesAtSlot, slot, signal).catch((e) =>
+          this.logger.error("Error on sync committee aggregation selection", {slot}, e)
+        );
       }
 
       // unlike Attestation, SyncCommitteeSignature could be published asap
@@ -211,6 +226,84 @@ export class SyncCommitteeService {
         this.metrics?.publishedSyncCommitteeContribution.inc(signedContributions.length);
       } catch (e) {
         this.logger.error("Error publishing SyncCommitteeContribution", logCtx, e as Error);
+      }
+    }
+  }
+
+  /**
+   * Performs additional sync committee contribution tasks required if validator is part of distributed cluster
+   *
+   * 1. Exchange partial for combined selection proofs
+   * 2. Determine validators that should produce sync committee contribution
+   * 3. Mutate duty objects to set selection proofs for aggregators
+   *
+   * See https://docs.google.com/document/d/1q9jOTPcYQa-3L8luRvQJ-M0eegtba4Nmon3dpO79TMk/mobilebasic
+   */
+  private async runDistributedAggregationSelectionTasks(
+    duties: SyncDutyAndProofs[],
+    slot: number,
+    signal: AbortSignal
+  ): Promise<void> {
+    const partialSelections: routes.validator.SyncCommitteeSelection[] = [];
+
+    for (const {duty, selectionProofs} of duties) {
+      const validatorSelections: routes.validator.SyncCommitteeSelection[] = selectionProofs.map(
+        ({subcommitteeIndex, partialSelectionProof}) => ({
+          validatorIndex: duty.validatorIndex,
+          slot,
+          subcommitteeIndex,
+          selectionProof: partialSelectionProof as BLSSignature,
+        })
+      );
+      partialSelections.push(...validatorSelections);
+    }
+
+    this.logger.debug("Submitting partial sync committee selection proofs", {slot, count: partialSelections.length});
+
+    const res = await Promise.race([
+      this.api.validator.submitSyncCommitteeSelections(partialSelections),
+      // Exit sync committee contributions flow if there is no response after 2/3 of slot.
+      // This is in contrast to attestations aggregations flow which is already exited at 1/3 of the slot
+      // because for sync committee is not required to resubscribe to subnets as beacon node will assume
+      // validator always aggregates. This allows us to wait until we have to produce sync committee contributions.
+      // Note that the sync committee contributions flow is not explicitly exited but rather will be skipped
+      // due to the fact that calculation of `is_sync_committee_aggregator` in duties service is not done
+      // and selectionProof is set to null, meaning no validator will be considered an aggregator.
+      sleep(this.clock.msToSlot(slot + 2 / 3), signal),
+    ]);
+
+    if (!res) {
+      throw new Error("No response after 2/3 of slot");
+    }
+    ApiError.assert(res);
+
+    const combinedSelections = res.response.data;
+    this.logger.debug("Received combined sync committee selection proofs", {slot, count: combinedSelections.length});
+
+    for (const dutyAndProofs of duties) {
+      const {validatorIndex, subnets} = dutyAndProofs.duty;
+
+      for (const subnet of subnets) {
+        const logCtxValidator = {slot, index: subnet, validatorIndex};
+
+        const combinedSelection = combinedSelections.find(
+          (s) => s.validatorIndex === validatorIndex && s.slot === slot && s.subcommitteeIndex === subnet
+        );
+
+        if (!combinedSelection) {
+          this.logger.warn("Did not receive combined sync committee selection proof", logCtxValidator);
+          continue;
+        }
+
+        const isAggregator = isSyncCommitteeAggregator(combinedSelection.selectionProof);
+
+        if (isAggregator) {
+          const selectionProofObject = dutyAndProofs.selectionProofs.find((p) => p.subcommitteeIndex === subnet);
+          if (selectionProofObject) {
+            // Update selection proof by mutating proof objects in duty object
+            selectionProofObject.selectionProof = combinedSelection.selectionProof;
+          }
+        }
       }
     }
   }

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -295,7 +295,7 @@ export class SyncCommitteeDutiesService {
       if (this.opts?.distributedAggregationSelection) {
         // Validator in distributed cluster only has a key share, not the full private key.
         // Passing a partial selection proof to `is_sync_committee_aggregator` would produce incorrect result.
-        // Sync committee service will exchange partial for combined selection proofs retrieved from
+        // SyncCommitteeService will exchange partial for combined selection proofs retrieved from
         // distributed validator middleware client and determine aggregators at beginning of every slot.
         dutiesAndProofs.push({
           selectionProof: null,

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -42,6 +42,8 @@ export type SyncDutySubnet = {
 export type SyncSelectionProof = {
   /** This value is only set to not null if the proof indicates that the validator is an aggregator. */
   selectionProof: BLSSignature | null;
+  /** This value will only be set if validator is part of distributed cluster and only has a key share */
+  partialSelectionProof?: BLSSignature;
   subcommitteeIndex: number;
 };
 
@@ -60,6 +62,10 @@ export type SyncDutyAndProofs = {
 // To assist with readability
 type DutyAtPeriod = {duty: SyncDutySubnet};
 
+type SyncCommitteeDutiesServiceOpts = {
+  distributedAggregationSelection?: boolean;
+};
+
 /**
  * Validators are part of a static long (~27h) sync committee, and part of static subnets.
  * However, the isAggregator role changes per slot.
@@ -74,7 +80,8 @@ export class SyncCommitteeDutiesService {
     private readonly api: Api,
     clock: IClock,
     private readonly validatorStore: ValidatorStore,
-    metrics: Metrics | null
+    metrics: Metrics | null,
+    private readonly opts?: SyncCommitteeDutiesServiceOpts
   ) {
     // Running this task every epoch is safe since a re-org of many epochs is very unlikely
     // TODO: If the re-org event is reliable consider re-running then
@@ -285,11 +292,23 @@ export class SyncCommitteeDutiesService {
     const dutiesAndProofs: SyncSelectionProof[] = [];
     for (const subnet of duty.subnets) {
       const selectionProof = await this.validatorStore.signSyncCommitteeSelectionProof(duty.pubkey, slot, subnet);
-      dutiesAndProofs.push({
-        // selectionProof === null is used to check if is aggregator
-        selectionProof: isSyncCommitteeAggregator(selectionProof) ? selectionProof : null,
-        subcommitteeIndex: subnet,
-      });
+      if (this.opts?.distributedAggregationSelection) {
+        // Validator in distributed cluster only has a key share, not the full private key.
+        // Passing a partial selection proof to `is_sync_committee_aggregator` would produce incorrect result.
+        // Sync committee service will exchange partial for combined selection proofs retrieved from
+        // distributed validator middleware client and determine aggregators at beginning of every slot.
+        dutiesAndProofs.push({
+          selectionProof: null,
+          partialSelectionProof: selectionProof,
+          subcommitteeIndex: subnet,
+        });
+      } else {
+        dutiesAndProofs.push({
+          // selectionProof === null is used to check if is aggregator
+          selectionProof: isSyncCommitteeAggregator(selectionProof) ? selectionProof : null,
+          subcommitteeIndex: subnet,
+        });
+      }
     }
     return dutiesAndProofs;
   }

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -129,6 +129,7 @@ export class Validator {
       {
         afterBlockDelaySlotFraction: opts.afterBlockDelaySlotFraction,
         disableAttestationGrouping: opts.disableAttestationGrouping || opts.distributed,
+        distributedAggregationSelection: opts.distributed,
       }
     );
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -142,7 +142,10 @@ export class Validator {
       emitter,
       chainHeaderTracker,
       metrics,
-      {scAfterBlockDelaySlotFraction: opts.scAfterBlockDelaySlotFraction}
+      {
+        scAfterBlockDelaySlotFraction: opts.scAfterBlockDelaySlotFraction,
+        distributedAggregationSelection: opts.distributed,
+      }
     );
 
     this.config = config;

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -3,7 +3,7 @@ import sinon from "sinon";
 import bls from "@chainsafe/bls";
 import {toHexString} from "@chainsafe/ssz";
 import {ssz} from "@lodestar/types";
-import {HttpStatusCode} from "@lodestar/api";
+import {HttpStatusCode, routes} from "@lodestar/api";
 import {AttestationService, AttestationServiceOpts} from "../../../src/services/attestation.js";
 import {AttDutyAndProof} from "../../../src/services/attestationDuties.js";
 import {ValidatorStore} from "../../../src/services/validatorStore.js";
@@ -42,104 +42,157 @@ describe("AttestationService", function () {
     sandbox.resetHistory();
   });
 
-  context("With attestation grouping enabled", () => {
-    const opts: AttestationServiceOpts = {disableAttestationGrouping: false};
+  const testContexts: [string, AttestationServiceOpts][] = [
+    ["With default configuration", {}],
+    ["With attestation grouping disabled", {disableAttestationGrouping: true}],
+    ["With distributed aggregation selection enabled", {distributedAggregationSelection: true}],
+  ];
 
-    it("Should produce, sign, and publish an attestation + aggregate", async () => {
-      await testAttestationTasks(opts);
+  for (const [title, opts] of testContexts) {
+    context(title, () => {
+      it("Should produce, sign, and publish an attestation + aggregate", async () => {
+        const clock = new ClockMock();
+        const attestationService = new AttestationService(
+          loggerVc,
+          api,
+          clock,
+          validatorStore,
+          emitter,
+          chainHeadTracker,
+          null,
+          opts
+        );
+
+        const attestation = ssz.phase0.Attestation.defaultValue();
+        const aggregate = ssz.phase0.SignedAggregateAndProof.defaultValue();
+        const duties: AttDutyAndProof[] = [
+          {
+            duty: {
+              slot: 0,
+              committeeIndex: attestation.data.index,
+              committeeLength: 120,
+              committeesAtSlot: 120,
+              validatorCommitteeIndex: 1,
+              validatorIndex: 0,
+              pubkey: pubkeys[0],
+            },
+            selectionProof: opts.distributedAggregationSelection ? null : ZERO_HASH,
+            partialSelectionProof: opts.distributedAggregationSelection ? ZERO_HASH : undefined,
+          },
+        ];
+
+        // Return empty replies to duties service
+        api.beacon.getStateValidators.resolves({
+          response: {executionOptimistic: false, data: []},
+          ok: true,
+          status: HttpStatusCode.OK,
+        });
+        api.validator.getAttesterDuties.resolves({
+          response: {dependentRoot: ZERO_HASH_HEX, executionOptimistic: false, data: []},
+          ok: true,
+          status: HttpStatusCode.OK,
+        });
+
+        // Mock duties service to return some duties directly
+        attestationService["dutiesService"].getDutiesAtSlot = sinon.stub().returns(duties);
+
+        // Mock beacon's attestation and aggregates endpoints
+
+        api.validator.produceAttestationData.resolves({
+          response: {data: attestation.data},
+          ok: true,
+          status: HttpStatusCode.OK,
+        });
+        api.validator.getAggregatedAttestation.resolves({
+          response: {data: attestation},
+          ok: true,
+          status: HttpStatusCode.OK,
+        });
+        api.beacon.submitPoolAttestations.resolves({
+          response: undefined,
+          ok: true,
+          status: HttpStatusCode.OK,
+        });
+        api.validator.publishAggregateAndProofs.resolves({
+          response: undefined,
+          ok: true,
+          status: HttpStatusCode.OK,
+        });
+
+        if (opts.distributedAggregationSelection) {
+          // Mock distributed validator middleware client selections endpoint
+          // and return a selection proof that passes `is_aggregator` test
+          api.validator.submitBeaconCommitteeSelections.resolves({
+            response: {data: [{validatorIndex: 0, slot: 0, selectionProof: Buffer.alloc(1, 0x10)}]},
+            ok: true,
+            status: HttpStatusCode.OK,
+          });
+          // Accept all subscriptions
+          api.validator.prepareBeaconCommitteeSubnet.resolves({
+            response: undefined,
+            ok: true,
+            status: HttpStatusCode.OK,
+          });
+        }
+
+        // Mock signing service
+        validatorStore.signAttestation.resolves(attestation);
+        validatorStore.signAggregateAndProof.resolves(aggregate);
+
+        // Trigger clock onSlot for slot 0
+        await clock.tickSlotFns(0, controller.signal);
+
+        if (opts.distributedAggregationSelection) {
+          // Must submit partial beacon committee selection proof based on duty
+          const selection: routes.validator.BeaconCommitteeSelection = {
+            validatorIndex: 0,
+            slot: 0,
+            selectionProof: ZERO_HASH,
+          };
+          expect(api.validator.submitBeaconCommitteeSelections.callCount).to.equal(
+            1,
+            "submitBeaconCommitteeSelections() must be called once"
+          );
+          expect(api.validator.submitBeaconCommitteeSelections.getCall(0).args).to.deep.equal(
+            [[selection]], // 1 arg, = selection[]
+            "wrong submitBeaconCommitteeSelections() args"
+          );
+
+          // Must resubscribe validator as aggregator on beacon committee subnet
+          const subscription: routes.validator.BeaconCommitteeSubscription = {
+            validatorIndex: 0,
+            committeeIndex: 0,
+            committeesAtSlot: 120,
+            slot: 0,
+            isAggregator: true,
+          };
+          expect(api.validator.prepareBeaconCommitteeSubnet.callCount).to.equal(
+            1,
+            "prepareBeaconCommitteeSubnet() must be called once"
+          );
+          expect(api.validator.prepareBeaconCommitteeSubnet.getCall(0).args).to.deep.equal(
+            [[subscription]], // 1 arg, = subscription[]
+            "wrong prepareBeaconCommitteeSubnet() args"
+          );
+        }
+
+        // Must submit the attestation received through produceAttestationData()
+        expect(api.beacon.submitPoolAttestations.callCount).to.equal(1, "submitAttestations() must be called once");
+        expect(api.beacon.submitPoolAttestations.getCall(0).args).to.deep.equal(
+          [[attestation]], // 1 arg, = attestation[]
+          "wrong submitAttestations() args"
+        );
+
+        // Must submit the aggregate received through getAggregatedAttestation() then createAndSignAggregateAndProof()
+        expect(api.validator.publishAggregateAndProofs.callCount).to.equal(
+          1,
+          "publishAggregateAndProofs() must be called once"
+        );
+        expect(api.validator.publishAggregateAndProofs.getCall(0).args).to.deep.equal(
+          [[aggregate]], // 1 arg, = aggregate[]
+          "wrong publishAggregateAndProofs() args"
+        );
+      });
     });
-  });
-
-  context("With attestation grouping disabled", () => {
-    const opts: AttestationServiceOpts = {disableAttestationGrouping: true};
-
-    it("Should produce, sign, and publish an attestation + aggregate", async () => {
-      await testAttestationTasks(opts);
-    });
-  });
-
-  async function testAttestationTasks(opts?: AttestationServiceOpts): Promise<void> {
-    const clock = new ClockMock();
-    const attestationService = new AttestationService(
-      loggerVc,
-      api,
-      clock,
-      validatorStore,
-      emitter,
-      chainHeadTracker,
-      null,
-      opts
-    );
-
-    const attestation = ssz.phase0.Attestation.defaultValue();
-    const aggregate = ssz.phase0.SignedAggregateAndProof.defaultValue();
-    const duties: AttDutyAndProof[] = [
-      {
-        duty: {
-          slot: 0,
-          committeeIndex: attestation.data.index,
-          committeeLength: 120,
-          committeesAtSlot: 120,
-          validatorCommitteeIndex: 1,
-          validatorIndex: 0,
-          pubkey: pubkeys[0],
-        },
-        selectionProof: ZERO_HASH,
-      },
-    ];
-
-    // Return empty replies to duties service
-    api.beacon.getStateValidators.resolves({
-      response: {executionOptimistic: false, data: []},
-      ok: true,
-      status: HttpStatusCode.OK,
-    });
-    api.validator.getAttesterDuties.resolves({
-      response: {dependentRoot: ZERO_HASH_HEX, executionOptimistic: false, data: []},
-      ok: true,
-      status: HttpStatusCode.OK,
-    });
-
-    // Mock duties service to return some duties directly
-    attestationService["dutiesService"].getDutiesAtSlot = sinon.stub().returns(duties);
-
-    // Mock beacon's attestation and aggregates endpoints
-
-    api.validator.produceAttestationData.resolves({
-      response: {data: attestation.data},
-      ok: true,
-      status: HttpStatusCode.OK,
-    });
-    api.validator.getAggregatedAttestation.resolves({
-      response: {data: attestation},
-      ok: true,
-      status: HttpStatusCode.OK,
-    });
-    api.beacon.submitPoolAttestations.resolves();
-    api.validator.publishAggregateAndProofs.resolves();
-
-    // Mock signing service
-    validatorStore.signAttestation.resolves(attestation);
-    validatorStore.signAggregateAndProof.resolves(aggregate);
-
-    // Trigger clock onSlot for slot 0
-    await clock.tickSlotFns(0, controller.signal);
-
-    // Must submit the attestation received through produceAttestationData()
-    expect(api.beacon.submitPoolAttestations.callCount).to.equal(1, "submitAttestations() must be called once");
-    expect(api.beacon.submitPoolAttestations.getCall(0).args).to.deep.equal(
-      [[attestation]], // 1 arg, = attestation[]
-      "wrong submitAttestations() args"
-    );
-
-    // Must submit the aggregate received through getAggregatedAttestation() then createAndSignAggregateAndProof()
-    expect(api.validator.publishAggregateAndProofs.callCount).to.equal(
-      1,
-      "publishAggregateAndProofs() must be called once"
-    );
-    expect(api.validator.publishAggregateAndProofs.getCall(0).args).to.deep.equal(
-      [[aggregate]], // 1 arg, = aggregate[]
-      "wrong publishAggregateAndProofs() args"
-    );
   }
 });

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -85,7 +85,6 @@ describe("AttestationService", function () {
           pubkey: pubkeys[0],
         },
         selectionProof: ZERO_HASH,
-        isAggregator: true,
       },
     ];
 

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -85,6 +85,7 @@ describe("AttestationService", function () {
           pubkey: pubkeys[0],
         },
         selectionProof: ZERO_HASH,
+        isAggregator: true,
       },
     ];
 

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -3,7 +3,7 @@ import {expect} from "chai";
 import sinon from "sinon";
 import {chainConfig} from "@lodestar/config/default";
 import bls from "@chainsafe/bls";
-import {toHexString} from "@chainsafe/ssz";
+import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {HttpStatusCode, routes} from "@lodestar/api";
 import {ssz} from "@lodestar/types";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
@@ -35,6 +35,11 @@ describe("AttestationDutiesService", function () {
     status: "active",
     validator: ssz.phase0.Validator.defaultValue(),
   };
+  const signedAttSelectionProof = fromHexString(
+    "0x8d80fe4be57500d2fe4f99c7d5586d9bd65ea4f9e4def0591020dd66f7d1daad" +
+      "1cea7520beb815423e2bc8316949ac2606da80d5d00df34f352b5a946d6a4bb4" +
+      "7e402f5d1167dec97af9742e61820625c5c792ddd2b8796962243d8e8cbeadee"
+  );
 
   before(() => {
     const secretKeys = [bls.SecretKey.fromBytes(toBufferBE(BigInt(98), 32))];
@@ -96,8 +101,8 @@ describe("AttestationDutiesService", function () {
       Object.fromEntries(dutiesService["dutiesByIndexByEpoch"].get(epoch)?.dutiesByIndex || new Map())
     ).to.deep.equal(
       {
-        // Since the ZERO_HASH won't pass the isAggregator test, selectionProof is null
-        [index]: {duty, selectionProof: null},
+        // Since the ZERO_HASH won't pass the isAggregator test
+        [index]: {duty, selectionProof: signedAttSelectionProof, isAggregator: false},
       },
       "Wrong dutiesService.attesters Map at current epoch"
     );
@@ -105,14 +110,14 @@ describe("AttestationDutiesService", function () {
       Object.fromEntries(dutiesService["dutiesByIndexByEpoch"].get(epoch + 1)?.dutiesByIndex || new Map())
     ).to.deep.equal(
       {
-        // Since the ZERO_HASH won't pass the isAggregator test, selectionProof is null
-        [index]: {duty, selectionProof: null},
+        // Since the ZERO_HASH won't pass the isAggregator test
+        [index]: {duty, selectionProof: signedAttSelectionProof, isAggregator: false},
       },
       "Wrong dutiesService.attesters Map at next epoch"
     );
 
     expect(dutiesService.getDutiesAtSlot(slot)).to.deep.equal(
-      [{duty, selectionProof: null}],
+      [{duty, selectionProof: signedAttSelectionProof, isAggregator: false}],
       "Wrong getAttestersAtSlot()"
     );
 
@@ -165,13 +170,13 @@ describe("AttestationDutiesService", function () {
     // first confirm duties for this and next epoch should be persisted
     expect(Object.fromEntries(dutiesService["dutiesByIndexByEpoch"].get(0)?.dutiesByIndex || new Map())).to.deep.equal(
       {
-        4: {duty: duty, selectionProof: null},
+        4: {duty: duty, selectionProof: signedAttSelectionProof, isAggregator: false},
       },
       "Wrong dutiesService.attesters Map at current epoch"
     );
     expect(Object.fromEntries(dutiesService["dutiesByIndexByEpoch"].get(1)?.dutiesByIndex || new Map())).to.deep.equal(
       {
-        4: {duty: duty, selectionProof: null},
+        4: {duty: duty, selectionProof: signedAttSelectionProof, isAggregator: false},
       },
       "Wrong dutiesService.attesters Map at current epoch"
     );

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -3,7 +3,7 @@ import {expect} from "chai";
 import sinon from "sinon";
 import {chainConfig} from "@lodestar/config/default";
 import bls from "@chainsafe/bls";
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {toHexString} from "@chainsafe/ssz";
 import {HttpStatusCode, routes} from "@lodestar/api";
 import {ssz} from "@lodestar/types";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
@@ -35,11 +35,6 @@ describe("AttestationDutiesService", function () {
     status: "active",
     validator: ssz.phase0.Validator.defaultValue(),
   };
-  const signedAttSelectionProof = fromHexString(
-    "0x8d80fe4be57500d2fe4f99c7d5586d9bd65ea4f9e4def0591020dd66f7d1daad" +
-      "1cea7520beb815423e2bc8316949ac2606da80d5d00df34f352b5a946d6a4bb4" +
-      "7e402f5d1167dec97af9742e61820625c5c792ddd2b8796962243d8e8cbeadee"
-  );
 
   before(() => {
     const secretKeys = [bls.SecretKey.fromBytes(toBufferBE(BigInt(98), 32))];
@@ -101,8 +96,8 @@ describe("AttestationDutiesService", function () {
       Object.fromEntries(dutiesService["dutiesByIndexByEpoch"].get(epoch)?.dutiesByIndex || new Map())
     ).to.deep.equal(
       {
-        // Since the ZERO_HASH won't pass the isAggregator test
-        [index]: {duty, selectionProof: signedAttSelectionProof, isAggregator: false},
+        // Since the ZERO_HASH won't pass the isAggregator test, selectionProof is null
+        [index]: {duty, selectionProof: null},
       },
       "Wrong dutiesService.attesters Map at current epoch"
     );
@@ -110,14 +105,14 @@ describe("AttestationDutiesService", function () {
       Object.fromEntries(dutiesService["dutiesByIndexByEpoch"].get(epoch + 1)?.dutiesByIndex || new Map())
     ).to.deep.equal(
       {
-        // Since the ZERO_HASH won't pass the isAggregator test
-        [index]: {duty, selectionProof: signedAttSelectionProof, isAggregator: false},
+        // Since the ZERO_HASH won't pass the isAggregator test, selectionProof is null
+        [index]: {duty, selectionProof: null},
       },
       "Wrong dutiesService.attesters Map at next epoch"
     );
 
     expect(dutiesService.getDutiesAtSlot(slot)).to.deep.equal(
-      [{duty, selectionProof: signedAttSelectionProof, isAggregator: false}],
+      [{duty, selectionProof: null}],
       "Wrong getAttestersAtSlot()"
     );
 
@@ -170,13 +165,13 @@ describe("AttestationDutiesService", function () {
     // first confirm duties for this and next epoch should be persisted
     expect(Object.fromEntries(dutiesService["dutiesByIndexByEpoch"].get(0)?.dutiesByIndex || new Map())).to.deep.equal(
       {
-        4: {duty: duty, selectionProof: signedAttSelectionProof, isAggregator: false},
+        4: {duty: duty, selectionProof: null},
       },
       "Wrong dutiesService.attesters Map at current epoch"
     );
     expect(Object.fromEntries(dutiesService["dutiesByIndexByEpoch"].get(1)?.dutiesByIndex || new Map())).to.deep.equal(
       {
-        4: {duty: duty, selectionProof: signedAttSelectionProof, isAggregator: false},
+        4: {duty: duty, selectionProof: null},
       },
       "Wrong dutiesService.attesters Map at current epoch"
     );


### PR DESCRIPTION
**Motivation**

Implements https://github.com/ethereum/beacon-APIs/pull/224 based on [guide](https://docs.google.com/document/d/1q9jOTPcYQa-3L8luRvQJ-M0eegtba4Nmon3dpO79TMk/mobilebasic), closes https://github.com/ChainSafe/lodestar/issues/5334

**Description**

- [x] Add [beacon](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/submitBeaconCommitteeSelections) and [sync committee](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/submitSyncCommitteeSelections) selection APIs
- [x] Implement distributed attestation aggregation selection
- [x] Implement distributed sync committee aggregation selection
- [x] Update unit tests to check additional steps

**Additional context**

- [Committee Aggregations with Distributed Validators](https://blog.obol.tech/committee-aggregations-with-distributed-validators/)
- [Distributed Validator middlewares and the aggregation duty](https://ethresear.ch/t/distributed-validator-middlewares-and-the-aggregation-duty/13044)
