### PR TITLE
Add note about setting default nodejs version when using nvm

### DIFF
--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -7,6 +7,7 @@ Make sure to have [Yarn installed](https://classic.yarnpkg.com/en/docs/install).
 <!-- prettier-ignore-start -->
 !!! info
     NodeJS versions older than the current LTS are not supported by Lodestar. We recommend running the latest Node LTS.
+    It is important to make sure the NodeJS version is not changed after reboot by setting a default `nvm alias default <version> && nvm use default`.
 
 !!! note
     Node Version Manager (NVM) will only install NodeJS for use with the active user. If you intend on setting up Lodestar to run under another user, we recommend using [Nodesource's source for NodeJS](https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions) so you can install NodeJS globally.


### PR DESCRIPTION
**Motivation**

nvm sets the node version to default after reboot which might break Lodestar because modules are compiled on a different node version during `yarn install`, see [discord](https://discord.com/channels/593655374469660673/743858262864167062/1093330636565131325).

**Description**

Add note to source installation page that a default version via `nvm alias default <version> && nvm use default` should bet set to ensure the node version does not change after reboot.
