### PR TITLE
Fix network processor jobsSubmitted metric

### DIFF
--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -292,6 +292,8 @@ export class NetworkProcessor {
       break;
     }
 
-    this.metrics?.networkProcessor.jobsSubmitted.observe(jobsSubmitted);
+    if (jobsSubmitted > 0) {
+      this.metrics?.networkProcessor.jobsSubmitted.observe(jobsSubmitted);
+    }
   }
 }


### PR DESCRIPTION
**Motivation**

The network processor `jobsSubmitted` metric was monitored as 1 while debug showed that it's usually 128 if there are jobs submitted

**Description**

- Only record `jobsSubmitted` if there are really jobs submitted
- a follow up of #5350