### PR TITLE
Gossip queue to drop by ratio

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -248,6 +248,12 @@ export function createLodestarMetrics(
       help: "Count of total gossip validation queue length",
       labelNames: ["topic"],
     }),
+
+    gossipValidationQueueDropRatio: register.gauge<"topic">({
+      name: "lodestar_gossip_validation_queue_current_drop_ratio",
+      help: "Current drop ratio of gossip validation queue",
+      labelNames: ["topic"],
+    }),
     gossipValidationQueueDroppedJobs: register.gauge<"topic">({
       name: "lodestar_gossip_validation_queue_dropped_jobs_total",
       help: "Count of total gossip validation queue dropped jobs",

--- a/packages/beacon-node/test/unit/network/processor/gossipQueues.test.ts
+++ b/packages/beacon-node/test/unit/network/processor/gossipQueues.test.ts
@@ -1,0 +1,86 @@
+import {expect} from "chai";
+import {DropType, GossipQueue, QueueType} from "../../../../src/network/processor/gossipQueues.js";
+
+describe("GossipQueues - drop by ratio", () => {
+  const gossipQueue = new GossipQueue<number>({
+    maxLength: 10,
+    type: QueueType.LIFO,
+    dropOpts: {type: DropType.ratio, start: 0.1, step: 0.2},
+  });
+
+  beforeEach(() => {
+    gossipQueue.clear();
+    for (let i = 0; i < 9; i++) {
+      gossipQueue.add(i);
+    }
+  });
+
+  it("add and next", () => {
+    // no drop
+    expect(gossipQueue.length).to.be.equal(9);
+    expect(gossipQueue.add(9)).to.be.equal(0);
+    expect(gossipQueue.length).to.be.equal(10);
+    // LIFO, last in first out
+    expect(gossipQueue.next()).to.be.equal(9);
+  });
+
+  it("should drop by ratio", () => {
+    expect(gossipQueue.add(9)).to.be.equal(0);
+    expect(gossipQueue.length).to.be.equal(10);
+    expect(gossipQueue.dropRatio).to.be.equal(0.1);
+
+    // drop 1 item
+    expect(gossipQueue.add(100)).to.be.equal(1);
+    expect(gossipQueue.length).to.be.equal(10);
+    // work around to get through the floating point precision
+    expect(Math.floor(gossipQueue.dropRatio * 100) / 100).to.be.equal(0.3);
+
+    // drop 3 items
+    expect(gossipQueue.add(101)).to.be.equal(3);
+    expect(gossipQueue.length).to.be.equal(8);
+    expect(gossipQueue.dropRatio).to.be.equal(0.5);
+
+    gossipQueue.clear();
+    expect(gossipQueue.add(1000)).to.be.equal(0);
+    expect(gossipQueue.length).to.be.equal(1);
+    // drop ratio is reset
+    expect(gossipQueue.dropRatio).to.be.equal(0.1);
+  });
+});
+
+describe("GossipQueues - drop by count", () => {
+  const gossipQueue = new GossipQueue<number>({
+    maxLength: 10,
+    type: QueueType.LIFO,
+    dropOpts: {type: DropType.count, count: 1},
+  });
+
+  beforeEach(() => {
+    gossipQueue.clear();
+    for (let i = 0; i < 9; i++) {
+      gossipQueue.add(i);
+    }
+  });
+
+  it("add and next", () => {
+    // no drop
+    expect(gossipQueue.length).to.be.equal(9);
+    expect(gossipQueue.add(9)).to.be.equal(0);
+    expect(gossipQueue.length).to.be.equal(10);
+    // LIFO, last in first out
+    expect(gossipQueue.next()).to.be.equal(9);
+  });
+
+  it("should drop by count", () => {
+    expect(gossipQueue.add(9)).to.be.equal(0);
+    expect(gossipQueue.length).to.be.equal(10);
+
+    // drop 1 item
+    expect(gossipQueue.add(100)).to.be.equal(1);
+    expect(gossipQueue.length).to.be.equal(10);
+
+    // drop 1 items
+    expect(gossipQueue.add(101)).to.be.equal(1);
+    expect(gossipQueue.length).to.be.equal(10);
+  });
+});

--- a/packages/beacon-node/test/unit/network/processor/gossipQueues.test.ts
+++ b/packages/beacon-node/test/unit/network/processor/gossipQueues.test.ts
@@ -29,18 +29,35 @@ describe("GossipQueues - drop by ratio", () => {
     expect(gossipQueue.length).to.be.equal(10);
     expect(gossipQueue.dropRatio).to.be.equal(0.1);
 
-    // drop 1 item
+    // drop 1 item (11 * 0.1)
     expect(gossipQueue.add(100)).to.be.equal(1);
     expect(gossipQueue.length).to.be.equal(10);
     // work around to get through the floating point precision
     expect(Math.floor(gossipQueue.dropRatio * 100) / 100).to.be.equal(0.3);
 
-    // drop 3 items
+    // drop 3 items (11 * 0.3)
     expect(gossipQueue.add(101)).to.be.equal(3);
     expect(gossipQueue.length).to.be.equal(8);
     expect(gossipQueue.dropRatio).to.be.equal(0.5);
 
+    // drop 5 items (11 * 0.5)
+    expect(gossipQueue.add(102)).to.be.equal(0);
+    expect(gossipQueue.length).to.be.equal(9);
+    expect(gossipQueue.add(103)).to.be.equal(0);
+    expect(gossipQueue.length).to.be.equal(10);
+    expect(gossipQueue.add(104)).to.be.equal(5);
+    expect(gossipQueue.length).to.be.equal(6);
+    expect(gossipQueue.dropRatio).to.be.equal(0.7);
+
+    // node is recovering
     gossipQueue.clear();
+    for (let i = 0; i < 10; i++) {
+      expect(gossipQueue.add(i)).to.be.equal(0);
+      expect(gossipQueue.next()).to.be.equal(i);
+      expect(gossipQueue.dropRatio).to.be.equal(0.7);
+    }
+
+    // node is in good status
     expect(gossipQueue.add(1000)).to.be.equal(0);
     expect(gossipQueue.length).to.be.equal(1);
     // drop ratio is reset


### PR DESCRIPTION
**Motivation**

- With mainnet node, after a while node has to drop 30% - 40% attestations consistently and other lower priority queues are never processed, they are all dropped 100%
- Right now after add an item to queue, if it's >= maxLength we drop 1, this keeps the node busy, queue length = max length all the time and node is not able to recover

**Description**

The current strategy is considered "drop by count" strategy with `count=1`. This PR implements a new "drop by ratio" strategy:
- With `start / step` as its params, applied for `attestation` topic only, other topics use the same `drop by count` strategy (unchanged)
- Add a `dropRatio` initialized with `start`
- If node is overload, i.e queue hit max length, drop by `dropRatio`, and increase it with `step`, bound by `MAX_DROP_RATIO`
- If node is in good status, i.e queue has 0 item and not a recent drop, reset `dropRatio`

part of #5353

**Testing**
- The initial test shows that `dropRatio` hit `MAX_DROP_RATIO` after 10h-12h and stay that high but even with that, the total drop of attestation is only around 10% (as compared to 30% - 40%), and other lower priority queues have some chance to run (instead of having to drop 100% of them like currently)
- Need to continue monitor the latest commit