### PR TITLE
Decrypt keystores in a thread pool

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
@@ -54,7 +54,7 @@ export async function decryptKeystoreDefinitions(
       }
     }
 
-    const task = pool.queue((thread) => thread.decryptKeystoreDefinition(definition, Boolean(opts.ignoreLockFile)));
+    const task = pool.queue((thread) => thread.decryptKeystoreDefinition(definition));
     tasks.push(task);
     task
       .then((secretKeyBytes: Uint8Array) => {

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
@@ -28,8 +28,8 @@ export async function decryptKeystoreDefinitions(
     }
   }
 
-  const signers: SignerLocal[] = [];
-  const passwords: string[] = [];
+  const signers = new Array(keystoreDefinitions.length) as SignerLocal[];
+  const passwords = new Array(keystoreDefinitions.length) as string[];
   const tasks: QueuedTask<ModuleThread<DecryptKeystoreWorkerAPI>, Uint8Array>[] = [];
   const errors: Error[] = [];
   const pool = Pool(
@@ -63,8 +63,8 @@ export async function decryptKeystoreDefinitions(
           secretKey: bls.SecretKey.fromBytes(secretKeyBytes),
         };
 
-        signers.push(signer);
-        passwords.push(definition.password);
+        signers[index] = signer;
+        passwords[index] = definition.password;
 
         if (opts?.onDecrypt) {
           opts?.onDecrypt(index);

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
@@ -46,7 +46,7 @@ export async function decryptKeystoreDefinitions(
       lockFilepath(definition.keystorePath);
     } catch (e) {
       if (opts.ignoreLockFile) {
-        opts.logger.warn("Keystore forcefully loaded even though lockfile could not be acquired", {
+        opts.logger.warn("Keystore forcefully loaded even though lockfile exists", {
           path: definition.keystorePath,
         });
       } else {

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
@@ -1,0 +1,94 @@
+import {spawn, ModuleThread, Pool, QueuedTask, Worker} from "@chainsafe/threads";
+import {Signer, SignerLocal, SignerType} from "@lodestar/validator";
+import bls from "@chainsafe/bls";
+import {LocalKeystoreDefinition} from "../interface.js";
+import {clearKeystoreCache, loadKeystoreCache, writeKeystoreCache} from "../keystoreCache.js";
+import {lockFilepath, unlockFilepath} from "../../../../util/lockfile.js";
+import {defaultPoolSize} from "./poolSize.js";
+import {DecryptKeystoreWorkerAPI, KeystoreDecryptOptions} from "./types.js";
+
+/**
+ * Decrypt keystore definitions using a threadpool
+ */
+export async function decryptKeystoreDefinitions(
+  keystoreDefinitions: LocalKeystoreDefinition[],
+  opts: KeystoreDecryptOptions
+): Promise<Signer[]> {
+  if (opts.cacheFilePath) {
+    try {
+      const signers = await loadKeystoreCache(opts.cacheFilePath, keystoreDefinitions);
+      if (opts?.onDecrypt) {
+        opts?.onDecrypt(signers.length - 1);
+      }
+      return signers;
+    } catch {
+      // Some error loading the cache, ignore and invalidate cache
+      await clearKeystoreCache(opts.cacheFilePath);
+    }
+  }
+
+  const signers: SignerLocal[] = [];
+  const passwords: string[] = [];
+  const tasks: QueuedTask<ModuleThread<DecryptKeystoreWorkerAPI>, Uint8Array>[] = [];
+  const errors: Error[] = [];
+
+  const pool = Pool(() => spawn<DecryptKeystoreWorkerAPI>(new Worker("./worker.js")), defaultPoolSize);
+  for (const [index, definition] of keystoreDefinitions.entries()) {
+    try {
+      lockFilepath(definition.keystorePath);
+    } catch (e) {
+      if (opts.force) {
+        // Ignore error, maybe log?
+      } else {
+        throw e;
+      }
+    }
+
+    const task = pool.queue((thread) => thread.decryptKeystoreDefinition(definition, Boolean(opts.force)));
+    tasks.push(task);
+    task
+      .then((secretKeyBytes: Uint8Array) => {
+        const signer: SignerLocal = {
+          type: SignerType.Local,
+          secretKey: bls.SecretKey.fromBytes(secretKeyBytes),
+        };
+
+        signers.push(signer);
+        passwords.push(definition.password);
+
+        if (opts?.onDecrypt) {
+          opts?.onDecrypt(index);
+        }
+      })
+      .catch((e: Error) => {
+        // In-progress tasks can't be canceled, so there's a chance that multiple errors may be caught
+        // add to the list of errors
+        errors.push(e);
+        // cancel all pending tasks, no need to continue decrypting after we hit one error
+        for (const task of tasks) {
+          task.cancel();
+        }
+      });
+  }
+
+  try {
+    // only resolves if there are no errored tasks
+    await pool.completed();
+  } catch (e) {
+    // If an error occurs, the program isn't going to be running,
+    // so we should unlock all lockfiles we created
+    for (const {keystorePath} of keystoreDefinitions) {
+      unlockFilepath(keystorePath);
+    }
+
+    throw new AggregateError(errors);
+  } finally {
+    await pool.terminate();
+  }
+
+  if (opts.cacheFilePath) {
+    await writeKeystoreCache(opts.cacheFilePath, signers, passwords);
+  }
+
+  return signers;
+}

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
@@ -4,7 +4,7 @@ import bls from "@chainsafe/bls";
 import {LocalKeystoreDefinition} from "../interface.js";
 import {clearKeystoreCache, loadKeystoreCache, writeKeystoreCache} from "../keystoreCache.js";
 import {lockFilepath, unlockFilepath} from "../../../../util/lockfile.js";
-import {calculateThreadpoolConcurrency} from "./poolSize.js";
+import {defaultPoolSize} from "./poolSize.js";
 import {DecryptKeystoreWorkerAPI, KeystoreDecryptOptions} from "./types.js";
 
 /**
@@ -32,7 +32,6 @@ export async function decryptKeystoreDefinitions(
   const passwords = new Array(keystoreDefinitions.length) as string[];
   const tasks: QueuedTask<ModuleThread<DecryptKeystoreWorkerAPI>, Uint8Array>[] = [];
   const errors: Error[] = [];
-  const {numWorkers, jobConcurrency} = calculateThreadpoolConcurrency();
   const pool = Pool(
     () =>
       spawn<DecryptKeystoreWorkerAPI>(new Worker("./worker.js"), {
@@ -40,10 +39,7 @@ export async function decryptKeystoreDefinitions(
         // the initialization to timeout. The number below is big enough to almost disable the timeout
         timeout: 5 * 60 * 1000,
       }),
-    {
-      concurrency: jobConcurrency,
-      size: numWorkers,
-    }
+    defaultPoolSize
   );
   for (const [index, definition] of keystoreDefinitions.entries()) {
     try {

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
@@ -45,7 +45,7 @@ export async function decryptKeystoreDefinitions(
     try {
       lockFilepath(definition.keystorePath);
     } catch (e) {
-      if (opts.force) {
+      if (opts.ignoreLockFile) {
         opts.logger.warn("Keystore forcefully loaded even though lockfile could not be acquired", {
           path: definition.keystorePath,
         });
@@ -54,7 +54,7 @@ export async function decryptKeystoreDefinitions(
       }
     }
 
-    const task = pool.queue((thread) => thread.decryptKeystoreDefinition(definition, Boolean(opts.force)));
+    const task = pool.queue((thread) => thread.decryptKeystoreDefinition(definition, Boolean(opts.ignoreLockFile)));
     tasks.push(task);
     task
       .then((secretKeyBytes: Uint8Array) => {

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
@@ -20,6 +20,7 @@ export async function decryptKeystoreDefinitions(
       if (opts?.onDecrypt) {
         opts?.onDecrypt(signers.length - 1);
       }
+      opts.logger.debug("Loaded keystores via keystore cache");
       return signers;
     } catch {
       // Some error loading the cache, ignore and invalidate cache
@@ -45,7 +46,9 @@ export async function decryptKeystoreDefinitions(
       lockFilepath(definition.keystorePath);
     } catch (e) {
       if (opts.force) {
-        // Ignore error, maybe log?
+        opts.logger.warn("Keystore forcefully loaded even though lockfile could not be acquired", {
+          path: definition.keystorePath,
+        });
       } else {
         throw e;
       }
@@ -95,6 +98,7 @@ export async function decryptKeystoreDefinitions(
 
   if (opts.cacheFilePath) {
     await writeKeystoreCache(opts.cacheFilePath, signers, passwords);
+    opts.logger.debug("Written keystores to keystore cache");
   }
 
   return signers;

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.ts
@@ -35,8 +35,7 @@ export async function decryptKeystoreDefinitions(
   const pool = Pool(
     () =>
       spawn<DecryptKeystoreWorkerAPI>(new Worker("./worker.js"), {
-        // A Lodestar Node may do very expensive task at start blocking the event loop and causing
-        // the initialization to timeout. The number below is big enough to almost disable the timeout
+        // The number below is big enough to almost disable the timeout which helps during tests run on unpredictablely slow hosts
         timeout: 5 * 60 * 1000,
       }),
     defaultPoolSize

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/poolSize.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/poolSize.ts
@@ -1,0 +1,16 @@
+let defaultPoolSize: number;
+
+try {
+  if (typeof navigator !== "undefined") {
+    defaultPoolSize = navigator.hardwareConcurrency ?? 4;
+  } else {
+    defaultPoolSize = (await import("node:os")).cpus().length;
+  }
+} catch (e) {
+  defaultPoolSize = 8;
+}
+
+/**
+ * Cross-platform aprox number of logical cores
+ */
+export {defaultPoolSize};

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/poolSize.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/poolSize.ts
@@ -1,36 +1,16 @@
-import os from "node:os";
+let defaultPoolSize: number;
 
-/**
- * Amount of memory used to decrypt a single keystore
- * calculated from https://github.com/ethereum/staking-deposit-cli/blob/d7b530442d6e0921c9db84b3a1cf6b3ecd6b9d35/staking_deposit/key_handling/keystore.py#L190-L195
- */
-export const KEYSTORE_MEMORY_USAGE = 268435456;
-/**
- * Maximum amount of memory to use per thread
- * conservatively, 2GB
- */
-export const MAX_MEMORY_USAGE_PER_THREAD = 2147483648;
-
-export const MAX_CONCURRENCY_PER_THREAD = Math.floor(MAX_MEMORY_USAGE_PER_THREAD / KEYSTORE_MEMORY_USAGE);
-
-/**
- * Figure out what the best combination of workers and job concurrency is to best utilize available memory
- */
-export function calculateThreadpoolConcurrency(): {numWorkers: number; jobConcurrency: number} {
-  const defaultPoolSize = os.cpus().length;
-  // Don't eat all available memory
-  const freeMem = os.freemem() * 0.8;
-  let numWorkers = defaultPoolSize;
-  let jobConcurrency = 1;
-  for (let i = defaultPoolSize; i > 0; i--) {
-    const iConcurrency = Math.floor(freeMem / i / KEYSTORE_MEMORY_USAGE);
-    if (iConcurrency <= MAX_CONCURRENCY_PER_THREAD && iConcurrency > jobConcurrency) {
-      numWorkers = i;
-      jobConcurrency = iConcurrency;
-    }
+try {
+  if (typeof navigator !== "undefined") {
+    defaultPoolSize = navigator.hardwareConcurrency ?? 4;
+  } else {
+    defaultPoolSize = (await import("node:os")).cpus().length;
   }
-  return {
-    numWorkers,
-    jobConcurrency,
-  };
+} catch (e) {
+  defaultPoolSize = 8;
 }
+
+/**
+ * Cross-platform aprox number of logical cores
+ */
+export {defaultPoolSize};

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/poolSize.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/poolSize.ts
@@ -4,6 +4,7 @@ try {
   if (typeof navigator !== "undefined") {
     defaultPoolSize = navigator.hardwareConcurrency ?? 4;
   } else {
+    // TODO change this line to use os.availableParallelism() once we upgrade to node v20
     defaultPoolSize = (await import("node:os")).cpus().length;
   }
 } catch (e) {

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/poolSize.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/poolSize.ts
@@ -1,16 +1,36 @@
-let defaultPoolSize: number;
-
-try {
-  if (typeof navigator !== "undefined") {
-    defaultPoolSize = navigator.hardwareConcurrency ?? 4;
-  } else {
-    defaultPoolSize = (await import("node:os")).cpus().length;
-  }
-} catch (e) {
-  defaultPoolSize = 8;
-}
+import os from "node:os";
 
 /**
- * Cross-platform aprox number of logical cores
+ * Amount of memory used to decrypt a single keystore
+ * calculated from https://github.com/ethereum/staking-deposit-cli/blob/d7b530442d6e0921c9db84b3a1cf6b3ecd6b9d35/staking_deposit/key_handling/keystore.py#L190-L195
  */
-export {defaultPoolSize};
+export const KEYSTORE_MEMORY_USAGE = 268435456;
+/**
+ * Maximum amount of memory to use per thread
+ * conservatively, 2GB
+ */
+export const MAX_MEMORY_USAGE_PER_THREAD = 2147483648;
+
+export const MAX_CONCURRENCY_PER_THREAD = Math.floor(MAX_MEMORY_USAGE_PER_THREAD / KEYSTORE_MEMORY_USAGE);
+
+/**
+ * Figure out what the best combination of workers and job concurrency is to best utilize available memory
+ */
+export function calculateThreadpoolConcurrency(): {numWorkers: number; jobConcurrency: number} {
+  const defaultPoolSize = os.cpus().length;
+  // Don't eat all available memory
+  const freeMem = os.freemem() * 0.8;
+  let numWorkers = defaultPoolSize;
+  let jobConcurrency = 1;
+  for (let i = defaultPoolSize; i > 0; i--) {
+    const iConcurrency = Math.floor(freeMem / i / KEYSTORE_MEMORY_USAGE);
+    if (iConcurrency <= MAX_CONCURRENCY_PER_THREAD && iConcurrency > jobConcurrency) {
+      numWorkers = i;
+      jobConcurrency = iConcurrency;
+    }
+  }
+  return {
+    numWorkers,
+    jobConcurrency,
+  };
+}

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/types.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/types.ts
@@ -10,5 +10,5 @@ export type KeystoreDecryptOptions = {
   onDecrypt?: (index: number) => void;
   // Try to use the cache file if it exists
   cacheFilePath?: string;
-  logger: Pick<Logger, "info">;
+  logger: Pick<Logger, "info" | "warn" | "debug">;
 };

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/types.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/types.ts
@@ -2,7 +2,7 @@ import {Logger} from "@lodestar/utils";
 import {LocalKeystoreDefinition} from "../interface.js";
 
 export type DecryptKeystoreWorkerAPI = {
-  decryptKeystoreDefinition({keystorePath, password}: LocalKeystoreDefinition, force: boolean): Promise<Uint8Array>;
+  decryptKeystoreDefinition({keystorePath, password}: LocalKeystoreDefinition): Promise<Uint8Array>;
 };
 
 export type KeystoreDecryptOptions = {

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/types.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/types.ts
@@ -1,3 +1,4 @@
+import {Logger} from "@lodestar/utils";
 import {LocalKeystoreDefinition} from "../interface.js";
 
 export type DecryptKeystoreWorkerAPI = {
@@ -9,4 +10,5 @@ export type KeystoreDecryptOptions = {
   onDecrypt?: (index: number) => void;
   // Try to use the cache file if it exists
   cacheFilePath?: string;
+  logger: Pick<Logger, "info">;
 };

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/types.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/types.ts
@@ -6,7 +6,7 @@ export type DecryptKeystoreWorkerAPI = {
 };
 
 export type KeystoreDecryptOptions = {
-  force?: boolean;
+  ignoreLockFile?: boolean;
   onDecrypt?: (index: number) => void;
   // Try to use the cache file if it exists
   cacheFilePath?: string;

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/types.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/types.ts
@@ -1,0 +1,12 @@
+import {LocalKeystoreDefinition} from "../interface.js";
+
+export type DecryptKeystoreWorkerAPI = {
+  decryptKeystoreDefinition({keystorePath, password}: LocalKeystoreDefinition, force: boolean): Promise<Uint8Array>;
+};
+
+export type KeystoreDecryptOptions = {
+  force?: boolean;
+  onDecrypt?: (index: number) => void;
+  // Try to use the cache file if it exists
+  cacheFilePath?: string;
+};

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/worker.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/worker.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import {expose} from "@chainsafe/threads/worker";
+import {Transfer, TransferDescriptor} from "@chainsafe/threads";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {LocalKeystoreDefinition} from "../interface.js";
 import {DecryptKeystoreWorkerAPI} from "./types.js";
@@ -12,11 +13,14 @@ import {DecryptKeystoreWorkerAPI} from "./types.js";
 export async function decryptKeystoreDefinition({
   keystorePath,
   password,
-}: LocalKeystoreDefinition): Promise<Uint8Array> {
+}: LocalKeystoreDefinition): Promise<TransferDescriptor<Uint8Array>> {
   const keystore = Keystore.parse(fs.readFileSync(keystorePath, "utf8"));
 
   // Memory-hogging function
-  return keystore.decrypt(password);
+  const secret = await keystore.decrypt(password);
+  // Transfer the underlying ArrayBuffer back to the main thread: https://threads.js.org/usage-advanced#transferable-objects
+  // This small performance gain may help in cases where this is run for many keystores
+  return Transfer(secret, [secret.buffer]);
 }
 
-expose({decryptKeystoreDefinition} as DecryptKeystoreWorkerAPI);
+expose({decryptKeystoreDefinition} as unknown as DecryptKeystoreWorkerAPI);

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/worker.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/worker.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import {expose} from "@chainsafe/threads/worker";
+import {Keystore} from "@chainsafe/bls-keystore";
+import {LocalKeystoreDefinition} from "../interface.js";
+import {DecryptKeystoreWorkerAPI} from "./types.js";
+
+/**
+ * Decrypt a single keystore definition, returning the secret key as a Uint8Array
+ *
+ * NOTE: This is memory-intensive process, since decrypting the keystore involves running a key derivation function (either pbkdf2 or scrypt)
+ */
+export async function decryptKeystoreDefinition({
+  keystorePath,
+  password,
+}: LocalKeystoreDefinition): Promise<Uint8Array> {
+  const keystore = Keystore.parse(fs.readFileSync(keystorePath, "utf8"));
+
+  // Memory-hogging function
+  return keystore.decrypt(password);
+}
+
+expose({decryptKeystoreDefinition} as DecryptKeystoreWorkerAPI);

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/worker.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/worker.ts
@@ -8,7 +8,7 @@ import {DecryptKeystoreWorkerAPI} from "./types.js";
 /**
  * Decrypt a single keystore definition, returning the secret key as a Uint8Array
  *
- * NOTE: This is memory-intensive process, since decrypting the keystore involves running a key derivation function (either pbkdf2 or scrypt)
+ * NOTE: This is a memory (and cpu) -intensive process, since decrypting the keystore involves running a key derivation function (either pbkdf2 or scrypt)
  */
 export async function decryptKeystoreDefinition({
   keystorePath,

--- a/packages/cli/src/cmds/validator/keymanager/persistedKeys.ts
+++ b/packages/cli/src/cmds/validator/keymanager/persistedKeys.ts
@@ -1,8 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import bls from "@chainsafe/bls";
 import {Keystore} from "@chainsafe/bls-keystore";
-import {Signer, SignerType, ProposerConfig, SignerLocal} from "@lodestar/validator";
+import {ProposerConfig} from "@lodestar/validator";
 import {DeletionStatus, ImportStatus, PubkeyHex, SignerDefinition} from "@lodestar/api/keymanager";
 import {
   getPubkeyHexFromKeystore,
@@ -13,8 +12,7 @@ import {
   readProposerConfigDir,
 } from "../../../util/index.js";
 import {lockFilepath} from "../../../util/lockfile.js";
-import {IPersistedKeysBackend} from "./interface.js";
-import {clearKeystoreCache, loadKeystoreCache, writeKeystoreCache} from "./keystoreCache.js";
+import {IPersistedKeysBackend, LocalKeystoreDefinition} from "./interface.js";
 
 export {ImportStatus, DeletionStatus};
 
@@ -23,11 +21,6 @@ type PathArgs = {
   secretsDir: string;
   remoteKeysDir: string;
   proposerDir: string;
-};
-
-export type LocalKeystoreDefinition = {
-  keystorePath: string;
-  password: string;
 };
 
 /**
@@ -243,82 +236,6 @@ export class PersistedKeysBackend implements IPersistedKeysBackend {
       proposerDirPath: path.join(this.paths.proposerDir, pubkey),
     };
   }
-}
-
-type KeystoreDecryptOptions = {
-  force?: boolean;
-  onDecrypt?: (index: number, signer: Signer) => void;
-  // Try to use the cache file if it exists
-  cacheFilePath?: string;
-};
-
-export async function decryptKeystoreDefinitions(
-  keystoreDefinitions: LocalKeystoreDefinition[],
-  opts: KeystoreDecryptOptions
-): Promise<Signer[]> {
-  if (opts.cacheFilePath) {
-    try {
-      const signers = await loadKeystoreCache(opts.cacheFilePath, keystoreDefinitions);
-      if (opts?.onDecrypt) {
-        opts?.onDecrypt(signers.length - 1, signers[signers.length - 1]);
-      }
-      return signers;
-    } catch {
-      // Some error loading the cache, ignore and invalidate cache
-      await clearKeystoreCache(opts.cacheFilePath);
-    }
-  }
-
-  const signers: SignerLocal[] = [];
-  const passwords: string[] = [];
-
-  for (const [index, {keystorePath, password}] of keystoreDefinitions.entries()) {
-    try {
-      lockFilepath(keystorePath);
-    } catch (e) {
-      if (opts.force) {
-        // Ignore error, maybe log?
-      } else {
-        throw e;
-      }
-    }
-
-    const keystore = Keystore.parse(fs.readFileSync(keystorePath, "utf8"));
-
-    // PPS: OOM error issue while decripting validators in parallel
-    // https://github.com/ChainSafe/lodestar/issues/4166
-    //
-    // Below call has been serialized as a hotfix for now as even for 10 vals
-    // it causes 2.5GB memory hog, which doesn't go down even when the promise
-    // resolves and all validators have been decrypted.
-    //
-    // return await Promise.all(validators.map(async (validator) =>
-    //  validator.votingKeypair(this.secretsDir)));
-    //
-    // The new serialized decryption takes full 5 minutes to decrypt 100 validators
-    // on a 100% single core engagement! This needs to be invesigated deeply and
-    // fixed most prefered to the above `Promise.all(...)` flow
-    //
-    const secretKeyBytes = await keystore.decrypt(password);
-
-    const signer: SignerLocal = {
-      type: SignerType.Local,
-      secretKey: bls.SecretKey.fromBytes(secretKeyBytes),
-    };
-
-    signers.push(signer);
-    passwords.push(password);
-
-    if (opts?.onDecrypt) {
-      opts?.onDecrypt(index, signer);
-    }
-  }
-
-  if (opts.cacheFilePath) {
-    await writeKeystoreCache(opts.cacheFilePath, signers, passwords);
-  }
-
-  return signers;
 }
 
 /**

--- a/packages/cli/src/cmds/validator/signers/importExternalKeystores.ts
+++ b/packages/cli/src/cmds/validator/signers/importExternalKeystores.ts
@@ -1,6 +1,6 @@
 import inquirer from "inquirer";
 import {readPassphraseFile, recursiveLookup} from "../../../util/index.js";
-import {LocalKeystoreDefinition} from "../keymanager/persistedKeys.js";
+import {LocalKeystoreDefinition} from "../keymanager/interface.js";
 
 /**
  * Imports keystores from un-controlled directories provided by the user.

--- a/packages/cli/src/cmds/validator/signers/index.ts
+++ b/packages/cli/src/cmds/validator/signers/index.ts
@@ -44,7 +44,7 @@ const KEYSTORE_IMPORT_PROGRESS_MS = 10000;
 export async function getSignersFromArgs(
   args: IValidatorCliArgs & GlobalArgs,
   network: string,
-  {logger, signal}: {logger: Pick<Logger, "info">; signal: AbortSignal}
+  {logger, signal}: {logger: Pick<Logger, "info" | "warn" | "debug">; signal: AbortSignal}
 ): Promise<Signer[]> {
   const accountPaths = getAccountPaths(args, network);
 

--- a/packages/cli/src/cmds/validator/signers/index.ts
+++ b/packages/cli/src/cmds/validator/signers/index.ts
@@ -96,7 +96,7 @@ export async function getSignersFromArgs(
       },
     });
     return decryptKeystoreDefinitions(keystoreDefinitions, {
-      ...args,
+      ignoreLockFile: args.force,
       onDecrypt: needle,
       cacheFilePath: path.join(accountPaths.cacheDir, "imported_keystores.cache"),
       logger,
@@ -129,7 +129,7 @@ export async function getSignersFromArgs(
     });
 
     const keystoreSigners = await decryptKeystoreDefinitions(keystoreDefinitions, {
-      ...args,
+      ignoreLockFile: args.force,
       onDecrypt: needle,
       cacheFilePath: path.join(accountPaths.cacheDir, "local_keystores.cache"),
       logger,

--- a/packages/cli/src/cmds/validator/signers/index.ts
+++ b/packages/cli/src/cmds/validator/signers/index.ts
@@ -9,7 +9,8 @@ import {defaultNetwork, GlobalArgs} from "../../../options/index.js";
 import {assertValidPubkeysHex, isValidHttpUrl, parseRange, YargsError} from "../../../util/index.js";
 import {getAccountPaths} from "../paths.js";
 import {IValidatorCliArgs} from "../options.js";
-import {decryptKeystoreDefinitions, PersistedKeysBackend} from "../keymanager/persistedKeys.js";
+import {PersistedKeysBackend} from "../keymanager/persistedKeys.js";
+import {decryptKeystoreDefinitions} from "../keymanager/decryptKeystoreDefinitions/index.js";
 import {showProgress} from "../../../util/progress.js";
 import {importKeystoreDefinitionsFromExternalDir, readPassphraseOrPrompt} from "./importExternalKeystores.js";
 

--- a/packages/cli/src/cmds/validator/signers/index.ts
+++ b/packages/cli/src/cmds/validator/signers/index.ts
@@ -99,6 +99,7 @@ export async function getSignersFromArgs(
       ...args,
       onDecrypt: needle,
       cacheFilePath: path.join(accountPaths.cacheDir, "imported_keystores.cache"),
+      logger,
     });
   }
 
@@ -131,6 +132,7 @@ export async function getSignersFromArgs(
       ...args,
       onDecrypt: needle,
       cacheFilePath: path.join(accountPaths.cacheDir, "local_keystores.cache"),
+      logger,
     });
 
     // Read local remote keys, imported via keymanager api

--- a/packages/cli/src/util/progress.ts
+++ b/packages/cli/src/util/progress.ts
@@ -35,7 +35,7 @@ export function showProgress({
       current,
       total,
       ratePerSec: processTime === 0 ? 0 : ((current - last) / processTime) * 1000,
-      percentage: current && total ? (current / total) * 100 : 100,
+      percentage: total ? (current / total) * 100 : 100,
     });
 
     last = current;

--- a/packages/cli/test/unit/util/progress.test.ts
+++ b/packages/cli/test/unit/util/progress.test.ts
@@ -28,14 +28,16 @@ describe("progress", () => {
       const frequencyMs = 50;
       const total = 8;
       const needle = showProgress({total, signal: new AbortController().signal, frequencyMs, progress});
+      sandbox.clock.tick(frequencyMs);
       needle(1);
       sandbox.clock.tick(frequencyMs);
       needle(3);
       sandbox.clock.tick(frequencyMs);
 
-      expect(progress).to.be.calledTwice;
-      expect(progress.firstCall.args[0]).to.eql({total, current: 2, ratePerSec: 40, percentage: 25});
-      expect(progress.secondCall.args[0]).to.eql({total, current: 4, ratePerSec: 40, percentage: 50});
+      expect(progress).to.be.calledThrice;
+      expect(progress.firstCall.args[0]).to.eql({total, current: 0, ratePerSec: 0, percentage: 0});
+      expect(progress.secondCall.args[0]).to.eql({total, current: 2, ratePerSec: 40, percentage: 25});
+      expect(progress.thirdCall.args[0]).to.eql({total, current: 4, ratePerSec: 40, percentage: 50});
     });
 
     it("should call progress with correct values when reach total", () => {

--- a/packages/cli/test/unit/validator/decryptKeystoreDefinitions.test.ts
+++ b/packages/cli/test/unit/validator/decryptKeystoreDefinitions.test.ts
@@ -59,7 +59,7 @@ describe("decryptKeystoreDefinitions", function () {
     }
   });
 
-  it("decrypt keystores if lockfiles already exist if force=true", async () => {
+  it("decrypt keystores if lockfiles already exist if ignoreLockFile=true", async () => {
     await decryptKeystoreDefinitions(definitions, {logger: console});
     // lockfiles should exist after the first run
 

--- a/packages/cli/test/unit/validator/decryptKeystoreDefinitions.test.ts
+++ b/packages/cli/test/unit/validator/decryptKeystoreDefinitions.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import rimraf from "rimraf";
 import {expect} from "chai";
@@ -8,12 +7,6 @@ import {getKeystoresStr} from "../../utils/keystores.js";
 import {testFilesDir} from "../../utils.js";
 import {decryptKeystoreDefinitions} from "../../../src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.js";
 import {LocalKeystoreDefinition} from "../../../src/cmds/validator/keymanager/interface.js";
-import {
-  KEYSTORE_MEMORY_USAGE,
-  MAX_CONCURRENCY_PER_THREAD,
-  MAX_MEMORY_USAGE_PER_THREAD,
-  calculateThreadpoolConcurrency,
-} from "../../../src/cmds/validator/keymanager/decryptKeystoreDefinitions/poolSize.js";
 
 describe("decryptKeystoreDefinitions", function () {
   this.timeout(100_000);
@@ -71,13 +64,5 @@ describe("decryptKeystoreDefinitions", function () {
     // lockfiles should exist after the first run
 
     await decryptKeystoreDefinitions(definitions, {logger: console, ignoreLockFile: true});
-  });
-
-  it("calculateThreadpoolConcurrency sanity test", () => {
-    const {numWorkers, jobConcurrency} = calculateThreadpoolConcurrency();
-    const freeMem = os.freemem() * 0.8;
-    expect(jobConcurrency).to.be.lte(MAX_CONCURRENCY_PER_THREAD);
-    expect(jobConcurrency * KEYSTORE_MEMORY_USAGE).to.be.lte(MAX_MEMORY_USAGE_PER_THREAD);
-    expect(numWorkers * jobConcurrency * KEYSTORE_MEMORY_USAGE).to.be.lte(freeMem);
   });
 });

--- a/packages/cli/test/unit/validator/decryptKeystoreDefinitions.test.ts
+++ b/packages/cli/test/unit/validator/decryptKeystoreDefinitions.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import rimraf from "rimraf";
 import {expect} from "chai";
@@ -7,6 +8,12 @@ import {getKeystoresStr} from "../../utils/keystores.js";
 import {testFilesDir} from "../../utils.js";
 import {decryptKeystoreDefinitions} from "../../../src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.js";
 import {LocalKeystoreDefinition} from "../../../src/cmds/validator/keymanager/interface.js";
+import {
+  KEYSTORE_MEMORY_USAGE,
+  MAX_CONCURRENCY_PER_THREAD,
+  MAX_MEMORY_USAGE_PER_THREAD,
+  calculateThreadpoolConcurrency,
+} from "../../../src/cmds/validator/keymanager/decryptKeystoreDefinitions/poolSize.js";
 
 describe("decryptKeystoreDefinitions", function () {
   this.timeout(100_000);
@@ -64,5 +71,13 @@ describe("decryptKeystoreDefinitions", function () {
     // lockfiles should exist after the first run
 
     await decryptKeystoreDefinitions(definitions, {logger: console, ignoreLockFile: true});
+  });
+
+  it("calculateThreadpoolConcurrency sanity test", () => {
+    const {numWorkers, jobConcurrency} = calculateThreadpoolConcurrency();
+    const freeMem = os.freemem() * 0.8;
+    expect(jobConcurrency).to.be.lte(MAX_CONCURRENCY_PER_THREAD);
+    expect(jobConcurrency * KEYSTORE_MEMORY_USAGE).to.be.lte(MAX_MEMORY_USAGE_PER_THREAD);
+    expect(numWorkers * jobConcurrency * KEYSTORE_MEMORY_USAGE).to.be.lte(freeMem);
   });
 });

--- a/packages/cli/test/unit/validator/decryptKeystoreDefinitions.test.ts
+++ b/packages/cli/test/unit/validator/decryptKeystoreDefinitions.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import path from "node:path";
+import rimraf from "rimraf";
+import {expect} from "chai";
+import {cachedSeckeysHex} from "../../utils/cachedKeys.js";
+import {getKeystoresStr} from "../../utils/keystores.js";
+import {testFilesDir} from "../../utils.js";
+import {decryptKeystoreDefinitions} from "../../../src/cmds/validator/keymanager/decryptKeystoreDefinitions/index.js";
+import {LocalKeystoreDefinition} from "../../../src/cmds/validator/keymanager/interface.js";
+
+describe("decryptKeystoreDefinitions", function () {
+  this.timeout(100_000);
+
+  const dataDir = path.join(testFilesDir, "decrypt-keystores-test");
+  const importFromDir = path.join(dataDir, "eth2.0_deposit_out");
+
+  const password = "AAAAAAAA0000000000";
+  const keyCount = 2;
+  const secretKeys = cachedSeckeysHex.slice(0, keyCount);
+
+  // Produce and encrypt keystores
+  let definitions: LocalKeystoreDefinition[] = [];
+
+  beforeEach("Prepare dataDir", async () => {
+    // wipe out data dir and existing keystores
+    rimraf.sync(dataDir);
+    rimraf.sync(importFromDir);
+
+    fs.mkdirSync(importFromDir, {recursive: true});
+
+    const keystoresStr = await getKeystoresStr(password, secretKeys);
+    definitions = [];
+    // write keystores to disk
+    for (let i = 0; i < keyCount; i++) {
+      const keystorePath = path.join(importFromDir, `keystore_${i}.json`);
+      fs.writeFileSync(keystorePath, keystoresStr[i]);
+      definitions.push({keystorePath, password});
+    }
+  });
+
+  it("decrypt keystores", async () => {
+    const signers = await decryptKeystoreDefinitions(definitions, {logger: console});
+    expect(signers.length).to.equal(secretKeys.length);
+    for (const signer of signers) {
+      const hexSecret = signer.secretKey.toHex();
+      expect(secretKeys.includes(hexSecret), `secretKeys doesn't include ${hexSecret}`).to.be.true;
+    }
+  });
+
+  it("fail to decrypt keystores if lockfiles already exist", async () => {
+    await decryptKeystoreDefinitions(definitions, {logger: console});
+    // lockfiles should exist after the first run
+
+    try {
+      await decryptKeystoreDefinitions(definitions, {logger: console});
+      expect.fail("Second decrypt should fail due to failure to get lockfile");
+    } catch (e) {
+      expect((e as Error).message.startsWith("EEXIST: file already exists"), "Wrong error is thrown").to.be.true;
+    }
+  });
+
+  it("decrypt keystores if lockfiles already exist if force=true", async () => {
+    await decryptKeystoreDefinitions(definitions, {logger: console});
+    // lockfiles should exist after the first run
+
+    await decryptKeystoreDefinitions(definitions, {logger: console, force: true});
+  });
+});

--- a/packages/cli/test/unit/validator/decryptKeystoreDefinitions.test.ts
+++ b/packages/cli/test/unit/validator/decryptKeystoreDefinitions.test.ts
@@ -63,6 +63,6 @@ describe("decryptKeystoreDefinitions", function () {
     await decryptKeystoreDefinitions(definitions, {logger: console});
     // lockfiles should exist after the first run
 
-    await decryptKeystoreDefinitions(definitions, {logger: console, force: true});
+    await decryptKeystoreDefinitions(definitions, {logger: console, ignoreLockFile: true});
   });
 });

--- a/packages/cli/test/utils/keymanagerTestRunners.ts
+++ b/packages/cli/test/utils/keymanagerTestRunners.ts
@@ -1,10 +1,9 @@
-import {expect} from "chai";
 import {sleep, retry} from "@lodestar/utils";
 import {Api, getClient} from "@lodestar/api/keymanager";
 import {config} from "@lodestar/config/default";
 import {ApiError} from "@lodestar/api";
 import {getMockBeaconApiServer} from "./mockBeaconApiServer.js";
-import {AfterEachCallback, findApiToken, itDone} from "./runUtils.js";
+import {AfterEachCallback, expectDeepEquals, findApiToken, itDone} from "./runUtils.js";
 import {DescribeArgs} from "./childprocRunner.js";
 
 type TestContext = {
@@ -79,10 +78,9 @@ export function getKeymanagerTestRunner({args: {spawnCli}, afterEachCallbacks, d
 export async function expectKeys(keymanagerClient: Api, expectedPubkeys: string[], message: string): Promise<void> {
   const keys = await keymanagerClient.listKeys();
   ApiError.assert(keys);
-
-  // the order of keys isn't always deterministic so we can't use deep equal
-  expect(keys.response.data.length).equals(expectedPubkeys.length);
-  for (const key of keys.response.data) {
-    expect(expectedPubkeys.includes(key.validatingPubkey), message).to.be.true;
-  }
+  expectDeepEquals(
+    keys.response.data,
+    expectedPubkeys.map((pubkey) => ({validatingPubkey: pubkey, derivationPath: "", readonly: false})),
+    message
+  );
 }

--- a/packages/cli/test/utils/keymanagerTestRunners.ts
+++ b/packages/cli/test/utils/keymanagerTestRunners.ts
@@ -1,9 +1,10 @@
+import {expect} from "chai";
 import {sleep, retry} from "@lodestar/utils";
 import {Api, getClient} from "@lodestar/api/keymanager";
 import {config} from "@lodestar/config/default";
 import {ApiError} from "@lodestar/api";
 import {getMockBeaconApiServer} from "./mockBeaconApiServer.js";
-import {AfterEachCallback, expectDeepEquals, findApiToken, itDone} from "./runUtils.js";
+import {AfterEachCallback, findApiToken, itDone} from "./runUtils.js";
 import {DescribeArgs} from "./childprocRunner.js";
 
 type TestContext = {
@@ -78,9 +79,10 @@ export function getKeymanagerTestRunner({args: {spawnCli}, afterEachCallbacks, d
 export async function expectKeys(keymanagerClient: Api, expectedPubkeys: string[], message: string): Promise<void> {
   const keys = await keymanagerClient.listKeys();
   ApiError.assert(keys);
-  expectDeepEquals(
-    keys.response.data,
-    expectedPubkeys.map((pubkey) => ({validatingPubkey: pubkey, derivationPath: "", readonly: false})),
-    message
-  );
+
+  // the order of keys isn't always deterministic so we can't use deep equal
+  expect(keys.response.data.length).equals(expectedPubkeys.length);
+  for (const key of keys.response.data) {
+    expect(expectedPubkeys.includes(key.validatingPubkey), message).to.be.true;
+  }
 }


### PR DESCRIPTION
**Motivation**

Resolves https://github.com/ChainSafe/lodestar/issues/4179

**Description**

- Refactor the `decryptKeystoreDefinitions` function
- Use threads library worker pool implementation
- poolSize code copied from bls worker thread impl