### PR TITLE
Add User-Agent to builder requests

### DIFF
--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -18,6 +18,8 @@ export type ExecutionBuilderHttpOpts = {
 
   // Only required for merge-mock runs, no need to expose it to cli
   issueLocalFcUForBlockProduction?: boolean;
+  // Add User-Agent header to all requests
+  userAgent?: string;
 };
 
 export const defaultExecutionBuilderHttpOpts: ExecutionBuilderHttpOpts = {
@@ -38,7 +40,14 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
   constructor(opts: ExecutionBuilderHttpOpts, config: ChainForkConfig, metrics: Metrics | null = null) {
     const baseUrl = opts.urls[0];
     if (!baseUrl) throw Error("No Url provided for executionBuilder");
-    this.api = getClient({baseUrl, timeoutMs: opts.timeout}, {config, metrics: metrics?.builderHttpClient});
+    this.api = getClient(
+      {
+        baseUrl,
+        timeoutMs: opts.timeout,
+        extraHeaders: opts.userAgent ? {"User-Agent": opts.userAgent} : undefined,
+      },
+      {config, metrics: metrics?.builderHttpClient}
+    );
     this.config = config;
     this.issueLocalFcUForBlockProduction = opts.issueLocalFcUForBlockProduction;
 

--- a/packages/cli/src/options/beaconNodeOptions/builder.ts
+++ b/packages/cli/src/options/beaconNodeOptions/builder.ts
@@ -1,5 +1,6 @@
 import {defaultOptions, IBeaconNodeOptions} from "@lodestar/beacon-node";
 import {CliCommandOptions} from "../../util/index.js";
+import {getVersionData} from "../../util/version.js";
 
 export type ExecutionBuilderArgs = {
   builder: boolean;
@@ -7,6 +8,7 @@ export type ExecutionBuilderArgs = {
   "builder.timeout": number;
   "builder.faultInspectionWindow": number;
   "builder.allowedFaults": number;
+  "builder.userAgent": string;
 };
 
 export function parseArgs(args: ExecutionBuilderArgs): IBeaconNodeOptions["executionBuilder"] {
@@ -16,6 +18,7 @@ export function parseArgs(args: ExecutionBuilderArgs): IBeaconNodeOptions["execu
     timeout: args["builder.timeout"],
     faultInspectionWindow: args["builder.faultInspectionWindow"],
     allowedFaults: args["builder.allowedFaults"],
+    userAgent: args["builder.userAgent"],
   };
 }
 
@@ -54,6 +57,14 @@ export const options: CliCommandOptions<ExecutionBuilderArgs> = {
   "builder.allowedFaults": {
     type: "number",
     description: "Number of missed slots allowed in the faultInspectionWindow for builder circuit",
+    group: "builder",
+  },
+
+  "builder.userAgent": {
+    type: "string",
+    description: "User-Agent header attached to all builder requests",
+    // Casting to `as string` so that if version type changes this line does not compile
+    default: `Lodestar/${getVersionData().version as string}`,
     group: "builder",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -52,6 +52,7 @@ describe("options / beaconNodeOptions", () => {
       "builder.timeout": 12000,
       "builder.faultInspectionWindow": 32,
       "builder.allowedFaults": 16,
+      "builder.userAgent": "lodestar/-",
 
       metrics: true,
       "metrics.port": 8765,
@@ -143,6 +144,7 @@ describe("options / beaconNodeOptions", () => {
         timeout: 12000,
         faultInspectionWindow: 32,
         allowedFaults: 16,
+        userAgent: "lodestar/-",
       },
       metrics: {
         enabled: true,


### PR DESCRIPTION
**Motivation**

- see https://github.com/ChainSafe/lodestar/issues/5360

**Description**

- Set on all requests by default
- Set to current agent version by default
- Allow to customize and disable via visible flag `--builder.userAgent`

```
builder
      --builder                        Enable builder interface
                                                      [boolean] [default: false]
      --builder.urls                   Urls hosting the builder API      [array]
      --builder.timeout                Timeout in milliseconds for builder API H
                                       TTP client                       [number]
      --builder.faultInspectionWindow  Window to inspect missed slots for enabli
                                       ng/disabling builder circuit breaker
                                                                        [number]
      --builder.allowedFaults          Number of missed slots allowed in the fau
                                       ltInspectionWindow for builder circuit
                                                                        [number]
      --builder.userAgent              User-Agent header attached to all builder
                                        requests
        [string] [default: "Lodestar/v1.6.0/dapplion/builder-useragent/8846e16"]
```

Closes https://github.com/ChainSafe/lodestar/issues/5360
