### PR TITLE
Skip deserializing gossip attestation messages by caching AttestationData

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -53,7 +53,7 @@ export function getBeaconPoolApi({
         attestations.map(async (attestation, i) => {
           try {
             // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-            const validateFn = () => validateGossipAttestation(chain, {attestation, bytes: null}, null);
+            const validateFn = () => validateGossipAttestation(chain, {attestation, serializedData: null}, null);
             const {slot, beaconBlockRoot} = attestation.data;
             // when a validator is configured with multiple beacon node urls, this attestation data may come from another beacon node
             // and the block hasn't been in our forkchoice since we haven't seen / processing that block

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -53,7 +53,7 @@ export function getBeaconPoolApi({
         attestations.map(async (attestation, i) => {
           try {
             // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-            const validateFn = () => validateGossipAttestation(chain, attestation, null, null);
+            const validateFn = () => validateGossipAttestation(chain, {attestation, bytes: null}, null);
             const {slot, beaconBlockRoot} = attestation.data;
             // when a validator is configured with multiple beacon node urls, this attestation data may come from another beacon node
             // and the block hasn't been in our forkchoice since we haven't seen / processing that block

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -493,6 +493,12 @@ export class BeaconChain implements IBeaconChain {
     }
   }
 
+  persistInvalidSszBytes(typeName: string, sszBytes: Uint8Array, suffix?: string): void {
+    if (this.opts.persistInvalidSszObjects) {
+      void this.persistInvalidSszObject(typeName, sszBytes, sszBytes, suffix);
+    }
+  }
+
   persistInvalidSszView(view: TreeView<CompositeTypeAny>, suffix?: string): void {
     if (this.opts.persistInvalidSszObjects) {
       void this.persistInvalidSszObject(view.type.typeName, view.serialize(), view.hashTreeRoot(), suffix);

--- a/packages/beacon-node/src/chain/errors/attestationError.ts
+++ b/packages/beacon-node/src/chain/errors/attestationError.ts
@@ -126,6 +126,10 @@ export enum AttestationErrorCode {
    * Invalid attestation indexes: not sorted or unique
    */
   INVALID_INDEXED_ATTESTATION = "ATTESTATION_ERROR_INVALID_INDEXED_ATTESTATION",
+  /**
+   * Invalid ssz bytes.
+   */
+  INVALID_SERIALIZED_BYTES = "ATTESTATION_ERROR_INVALID_SERIALIZED_BYTES",
 }
 
 export type AttestationErrorType =
@@ -158,7 +162,8 @@ export type AttestationErrorType =
   | {code: AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE; index: number}
   | {code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE; error: Error}
   | {code: AttestationErrorCode.INVALID_AGGREGATOR}
-  | {code: AttestationErrorCode.INVALID_INDEXED_ATTESTATION};
+  | {code: AttestationErrorCode.INVALID_INDEXED_ATTESTATION}
+  | {code: AttestationErrorCode.INVALID_SERIALIZED_BYTES};
 
 export class AttestationError extends GossipActionError<AttestationErrorType> {
   getMetadata(): Record<string, string | number | null> {

--- a/packages/beacon-node/src/chain/errors/gossipValidation.ts
+++ b/packages/beacon-node/src/chain/errors/gossipValidation.ts
@@ -5,6 +5,8 @@ export enum GossipAction {
   REJECT = "REJECT",
 }
 
+export const INVALID_SERIALIZED_BYTES_ERROR_CODE = "GOSSIP_ERROR_INVALID_SERIALIZED_BYTES";
+
 export class GossipActionError<T extends {code: string}> extends LodestarError<T> {
   action: GossipAction;
 

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -134,6 +134,7 @@ export interface IBeaconChain {
   updateBeaconProposerData(epoch: Epoch, proposers: ProposerPreparationData[]): Promise<void>;
 
   persistInvalidSszValue<T>(type: Type<T>, sszObject: T | Uint8Array, suffix?: string): void;
+  persistInvalidSszBytes(type: string, sszBytes: Uint8Array, suffix?: string): void;
   /** Persist bad items to persistInvalidSszObjectsDir dir, for example invalid state, attestations etc. */
   persistInvalidSszView(view: TreeView<CompositeTypeAny>, suffix?: string): void;
   updateBuilderStatus(clockSlot: Slot): void;

--- a/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
@@ -1,4 +1,4 @@
-import {RootHex, Slot} from "@lodestar/types";
+import {phase0, RootHex, Slot} from "@lodestar/types";
 import {MapDef} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {AttDataBase64} from "../../util/sszBytes.js";
@@ -9,8 +9,9 @@ export type AttestationDataCacheEntry = {
   committeeIndices: number[];
   // IndexedAttestationData signing root, 32 bytes
   signingRoot: Uint8Array;
-  // to be consumed by forkchoice
+  // to be consumed by forkchoice and oppool
   attDataRootHex: RootHex;
+  attestationData: phase0.AttestationData;
   subnet: number;
 };
 

--- a/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
@@ -11,6 +11,8 @@ export type AttestationDataCacheEntry = {
   signingRoot: Uint8Array;
   // to be consumed by forkchoice and oppool
   attDataRootHex: RootHex;
+  // caching this for 3 slots take 600 instances max, this is nothing compared to attestations processed per slot
+  // for example in a mainnet node subscribing to all subnets, attestations are processed up to 20k per slot
   attestationData: phase0.AttestationData;
   subnet: number;
 };

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -20,6 +20,7 @@ import {
   getSignatureFromAttestationSerialized,
 } from "../../util/sszBytes.js";
 import {AttestationDataCacheEntry} from "../seenCache/seenAttestationData.js";
+import {sszDeserializeAttestation} from "../../network/gossip/topic.js";
 
 export type AttestationValidationResult = {
   attestation: phase0.Attestation;
@@ -28,14 +29,14 @@ export type AttestationValidationResult = {
   attDataRootHex: RootHex;
 };
 
-type AttestationOrBytes =
+export type AttestationOrBytes =
   // for api
   | {attestation: phase0.Attestation; serializedData: null}
   // for gossip
   | {
       attestation: null;
       serializedData: Uint8Array;
-      // available in after NetworkProcessor since we check for unknown block root attestations
+      // available in NetworkProcessor since we check for unknown block root attestations
       attSlot: Slot;
     };
 
@@ -69,7 +70,7 @@ export async function validateGossipAttestation(
     const attSlot = attestationOrBytes.attSlot;
     const cachedAttData = attDataBase64 !== null ? chain.seenAttestationDatas.get(attSlot, attDataBase64) : null;
     if (cachedAttData === null) {
-      const attestation = ssz.phase0.Attestation.deserialize(attestationOrBytes.serializedData);
+      const attestation = sszDeserializeAttestation(attestationOrBytes.serializedData);
       // only deserialize on the first AttestationData that's not cached
       attestationOrCache = {attestation, cache: null};
     } else {

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -13,21 +13,40 @@ import {IBeaconChain} from "..";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors/index.js";
 import {MAXIMUM_GOSSIP_CLOCK_DISPARITY_SEC} from "../../constants/index.js";
 import {RegenCaller} from "../regen/index.js";
-import {getAttDataBase64FromAttestationSerialized} from "../../util/sszBytes.js";
+import {
+  AttDataBase64,
+  getAggregateionBitsFromAttestationSerialized,
+  getAttDataBase64FromAttestationSerialized,
+  getSignatureFromAttestationSerialized,
+  getSlotFromAttestationSerialized,
+} from "../../util/sszBytes.js";
+import {AttestationDataCacheEntry} from "../seenCache/seenAttestationData.js";
 
 export type AttestationValidationResult = {
+  attestation: phase0.Attestation;
   indexedAttestation: phase0.IndexedAttestation;
   subnet: number;
   attDataRootHex: RootHex;
 };
 
+type AttestationOrBytes =
+  // for api
+  | {attestation: phase0.Attestation; bytes: null}
+  // for gossip
+  | {
+      attestation: null;
+      bytes: Uint8Array;
+    };
+
+/**
+ * Only deserialize the attestation if needed, use the cached AttestationData instead
+ * This is to avoid deserializing similar attestation multiple times which could help the gc
+ */
 export async function validateGossipAttestation(
   chain: IBeaconChain,
-  attestation: phase0.Attestation,
+  attestationOrBytes: AttestationOrBytes,
   /** Optional, to allow verifying attestations through API with unknown subnet */
-  subnet: number | null,
-  // available for gossip attestations, null for api attestations
-  serializedData: Uint8Array | null = null
+  subnet: number | null
 ): Promise<AttestationValidationResult> {
   // Do checks in this order:
   // - do early checks (w/o indexed attestation)
@@ -38,17 +57,41 @@ export async function validateGossipAttestation(
 
   // verify_early_checks
   // Run the checks that happen before an indexed attestation is constructed.
-  const attData = attestation.data;
+
+  let attestationOrCache:
+    | {attestation: phase0.Attestation; cache: null}
+    | {attestation: null; cache: AttestationDataCacheEntry};
+  let attDataBase64: AttDataBase64 | null;
+  if (attestationOrBytes.bytes) {
+    // gossip
+    attDataBase64 = getAttDataBase64FromAttestationSerialized(attestationOrBytes.bytes);
+    // TODO any better way to get cached AttestationData without attSlot?
+    // we get it from the extractSlotRootFns already, maybe just reuse it from there
+    const attSlot = getSlotFromAttestationSerialized(attestationOrBytes.bytes);
+    const cachedAttData =
+      attSlot !== null && attDataBase64 !== null ? chain.seenAttestationDatas.get(attSlot, attDataBase64) : null;
+    if (cachedAttData === null) {
+      // only deserialize on the first AttestationData that's not cached
+      attestationOrCache = {attestation: ssz.phase0.Attestation.deserialize(attestationOrBytes.bytes), cache: null};
+    } else {
+      attestationOrCache = {attestation: null, cache: cachedAttData};
+    }
+  } else {
+    // api
+    attDataBase64 = null;
+    attestationOrCache = {attestation: attestationOrBytes.attestation, cache: null};
+  }
+
+  const attData: phase0.AttestationData = attestationOrCache.attestation
+    ? attestationOrCache.attestation.data
+    : attestationOrCache.cache.attestationData;
   const attSlot = attData.slot;
   const attIndex = attData.index;
   const attEpoch = computeEpochAtSlot(attSlot);
   const attTarget = attData.target;
   const targetEpoch = attTarget.epoch;
 
-  const attDataBase64 = serializedData ? getAttDataBase64FromAttestationSerialized(serializedData) : null;
-  const cachedAttData = attDataBase64 ? chain.seenAttestationDatas.get(attSlot, attDataBase64) : null;
-
-  if (!cachedAttData) {
+  if (!attestationOrCache.cache) {
     // [REJECT] The attestation's epoch matches its target -- i.e. attestation.data.target.epoch == compute_epoch_at_slot(attestation.data.slot)
     if (targetEpoch !== attEpoch) {
       throw new AttestationError(GossipAction.REJECT, {
@@ -59,13 +102,21 @@ export async function validateGossipAttestation(
     // [IGNORE] attestation.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots (within a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
     //  -- i.e. attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot
     // (a client MAY queue future attestations for processing at the appropriate slot).
-    verifyPropagationSlotRange(chain, attSlot);
+    verifyPropagationSlotRange(chain, attestationOrCache.attestation.data.slot);
   }
 
   // [REJECT] The attestation is unaggregated -- that is, it has exactly one participating validator
   // (len([bit for bit in attestation.aggregation_bits if bit]) == 1, i.e. exactly 1 bit is set).
   // > TODO: Do this check **before** getting the target state but don't recompute zipIndexes
-  const aggregationBits = attestation.aggregationBits;
+  const aggregationBits = attestationOrBytes.attestation
+    ? attestationOrBytes.attestation.aggregationBits
+    : getAggregateionBitsFromAttestationSerialized(attestationOrBytes.bytes);
+  if (aggregationBits === null) {
+    throw new AttestationError(GossipAction.REJECT, {
+      code: AttestationErrorCode.INVALID_SERIALIZED_BYTES,
+    });
+  }
+
   const bitIndex = aggregationBits.getSingleTrueBit();
   if (bitIndex === null) {
     throw new AttestationError(GossipAction.REJECT, {
@@ -76,10 +127,11 @@ export async function validateGossipAttestation(
   let committeeIndices: number[];
   let getSigningRoot: () => Uint8Array;
   let expectedSubnet: number;
-  if (cachedAttData) {
-    committeeIndices = cachedAttData.committeeIndices;
-    getSigningRoot = () => cachedAttData.signingRoot;
-    expectedSubnet = cachedAttData.subnet;
+  if (attestationOrCache.cache) {
+    committeeIndices = attestationOrCache.cache.committeeIndices;
+    const signingRoot = attestationOrCache.cache.signingRoot;
+    getSigningRoot = () => signingRoot;
+    expectedSubnet = attestationOrCache.cache.subnet;
   } else {
     // Attestations must be for a known block. If the block is unknown, we simply drop the
     // attestation and do not delay consideration for later.
@@ -88,7 +140,12 @@ export async function validateGossipAttestation(
 
     // [IGNORE] The block being voted for (attestation.data.beacon_block_root) has been seen (via both gossip
     // and non-gossip sources) (a client MAY queue attestations for processing once block is retrieved).
-    const attHeadBlock = verifyHeadBlockAndTargetRoot(chain, attData.beaconBlockRoot, attTarget.root, attEpoch);
+    const attHeadBlock = verifyHeadBlockAndTargetRoot(
+      chain,
+      attestationOrCache.attestation.data.beaconBlockRoot,
+      attestationOrCache.attestation.data.target.root,
+      attEpoch
+    );
 
     // [REJECT] The block being voted for (attestation.data.beacon_block_root) passes validation.
     // > Altready check in `verifyHeadBlockAndTargetRoot()`
@@ -162,19 +219,28 @@ export async function validateGossipAttestation(
   const attestingIndices = [validatorIndex];
   let signatureSet: ISignatureSet;
   let attDataRootHex: RootHex;
-  if (cachedAttData) {
+  const signature = attestationOrBytes.attestation
+    ? attestationOrBytes.attestation.signature
+    : getSignatureFromAttestationSerialized(attestationOrBytes.bytes);
+  if (signature === null) {
+    throw new AttestationError(GossipAction.REJECT, {
+      code: AttestationErrorCode.INVALID_SERIALIZED_BYTES,
+    });
+  }
+
+  if (attestationOrCache.cache) {
     // there could be up to 6% of cpu time to compute signing root if we don't clone the signature set
     signatureSet = createAggregateSignatureSetFromComponents(
       attestingIndices.map((i) => chain.index2pubkey[i]),
-      cachedAttData.signingRoot,
-      attestation.signature
+      attestationOrCache.cache.signingRoot,
+      signature
     );
-    attDataRootHex = cachedAttData.attDataRootHex;
+    attDataRootHex = attestationOrCache.cache.attDataRootHex;
   } else {
     signatureSet = createAggregateSignatureSetFromComponents(
       attestingIndices.map((i) => chain.index2pubkey[i]),
       getSigningRoot(),
-      attestation.signature
+      signature
     );
 
     // add cached attestation data before verifying signature
@@ -187,6 +253,7 @@ export async function validateGossipAttestation(
         // precompute this to be used in forkchoice
         // root of AttestationData was already cached during getIndexedAttestationSignatureSet
         attDataRootHex,
+        attestationData: attData,
       });
     }
   }
@@ -213,9 +280,17 @@ export async function validateGossipAttestation(
   const indexedAttestation: phase0.IndexedAttestation = {
     attestingIndices,
     data: attData,
-    signature: attestation.signature,
+    signature,
   };
-  return {indexedAttestation, subnet: expectedSubnet, attDataRootHex};
+
+  const attestation: phase0.Attestation = attestationOrCache.attestation
+    ? attestationOrCache.attestation
+    : {
+        aggregationBits,
+        data: attData,
+        signature,
+      };
+  return {attestation, indexedAttestation, subnet: expectedSubnet, attDataRootHex};
 }
 
 /**

--- a/packages/beacon-node/src/network/gossip/interface.ts
+++ b/packages/beacon-node/src/network/gossip/interface.ts
@@ -162,19 +162,18 @@ export type GossipJobQueues = {
 };
 
 export type GossipHandlerFn = (
-  object: GossipTypeMap[GossipType],
+  gossipSerializedData: Uint8Array,
   topic: GossipTopicMap[GossipType],
   peerIdStr: string,
-  seenTimestampSec: number,
-  gossipSerializedData: Uint8Array
+  seenTimestampSec: number
 ) => Promise<void>;
+
 export type GossipHandlers = {
   [K in GossipType]: (
-    object: GossipTypeMap[K],
+    gossipSerializedData: Uint8Array,
     topic: GossipTopicMap[K],
     peerIdStr: string,
-    seenTimestampSec: number,
-    gossipSerializedData: Uint8Array
+    seenTimestampSec: number
   ) => Promise<void>;
 };
 

--- a/packages/beacon-node/src/network/gossip/interface.ts
+++ b/packages/beacon-node/src/network/gossip/interface.ts
@@ -4,7 +4,7 @@ import {Message, TopicValidatorResult} from "@libp2p/interface-pubsub";
 import StrictEventEmitter from "strict-event-emitter-types";
 import {PeerIdStr} from "@chainsafe/libp2p-gossipsub/types";
 import {ForkName} from "@lodestar/params";
-import {allForks, altair, capella, deneb, phase0} from "@lodestar/types";
+import {allForks, altair, capella, deneb, phase0, Slot} from "@lodestar/types";
 import {BeaconConfig} from "@lodestar/config";
 import {Logger} from "@lodestar/utils";
 import {IBeaconChain} from "../../chain/index.js";
@@ -152,7 +152,8 @@ export type GossipValidatorFn = (
   topic: GossipTopic,
   msg: Message,
   propagationSource: PeerIdStr,
-  seenTimestampSec: number
+  seenTimestampSec: number,
+  msgSlot?: Slot
 ) => Promise<TopicValidatorResult>;
 
 export type ValidatorFnsByType = {[K in GossipType]: GossipValidatorFn};
@@ -161,8 +162,13 @@ export type GossipJobQueues = {
   [K in GossipType]: JobItemQueue<Parameters<GossipValidatorFn>, ResolvedType<GossipValidatorFn>>;
 };
 
+export type GossipData = {
+  serializedData: Uint8Array;
+  msgSlot?: Slot;
+};
+
 export type GossipHandlerFn = (
-  gossipSerializedData: Uint8Array,
+  gossipData: GossipData,
   topic: GossipTopicMap[GossipType],
   peerIdStr: string,
   seenTimestampSec: number
@@ -170,7 +176,7 @@ export type GossipHandlerFn = (
 
 export type GossipHandlers = {
   [K in GossipType]: (
-    gossipSerializedData: Uint8Array,
+    gossipData: GossipData,
     topic: GossipTopicMap[K],
     peerIdStr: string,
     seenTimestampSec: number

--- a/packages/beacon-node/src/network/gossip/interface.ts
+++ b/packages/beacon-node/src/network/gossip/interface.ts
@@ -65,6 +65,10 @@ export type GossipTopicMap = {
  */
 export type GossipTopic = GossipTopicMap[keyof GossipTopicMap];
 
+export type SSZTypeOfGossipTopic<T extends GossipTopic> = T extends {type: infer K extends GossipType}
+  ? GossipTypeMap[K]
+  : never;
+
 export type GossipTypeMap = {
   [GossipType.beacon_block]: allForks.SignedBeaconBlock;
   [GossipType.beacon_block_and_blobs_sidecar]: deneb.SignedBeaconBlockAndBlobsSidecar;

--- a/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
+++ b/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
@@ -28,11 +28,16 @@ export type ValidatorFnModules = {
 export function getGossipValidatorFn(gossipHandlers: GossipHandlers, modules: ValidatorFnModules): GossipValidatorFn {
   const {logger, metrics} = modules;
 
-  return async function gossipValidatorFn(topic, msg, propagationSource, seenTimestampSec) {
+  return async function gossipValidatorFn(topic, msg, propagationSource, seenTimestampSec, msgSlot) {
     const type = topic.type;
 
     try {
-      await (gossipHandlers[type] as GossipHandlerFn)(msg.data, topic, propagationSource, seenTimestampSec);
+      await (gossipHandlers[type] as GossipHandlerFn)(
+        {serializedData: msg.data, msgSlot},
+        topic,
+        propagationSource,
+        seenTimestampSec
+      );
 
       metrics?.gossipValidationAccept.inc({topic: type});
 

--- a/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
+++ b/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
@@ -60,6 +60,7 @@ export function getGossipValidatorFn(gossipHandlers: GossipHandlers, modules: Va
 
         case GossipAction.REJECT:
           metrics?.gossipValidationReject.inc({topic: type});
+          logger.debug(`Gossip validation ${type} rejected`, {}, e);
           return TopicValidatorResult.Reject;
       }
     }

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -179,6 +179,8 @@ export class NetworkProcessor {
         this.metrics?.reprocessGossipAttestations.total.inc();
         const awaitingGossipsubMessagesByRoot = this.awaitingGossipsubMessagesByRootBySlot.getOrDefault(slotRoot.slot);
         const awaitingGossipsubMessages = awaitingGossipsubMessagesByRoot.getOrDefault(slotRoot.root);
+        // msgSlot is only available for beacon_attestation and aggregate_and_proof
+        message.msgSlot = slotRoot.slot;
         awaitingGossipsubMessages.add(message);
         this.unknownBlockGossipsubMessagesCount++;
       }

--- a/packages/beacon-node/src/network/processor/types.ts
+++ b/packages/beacon-node/src/network/processor/types.ts
@@ -1,6 +1,6 @@
 import {PeerId} from "@libp2p/interface-peer-id";
 import {Message} from "@libp2p/interface-pubsub";
-import {SlotRootHex} from "@lodestar/types";
+import {Slot, SlotRootHex} from "@lodestar/types";
 import {GossipTopic, GossipType} from "../gossip/index.js";
 
 export type GossipAttestationsWork = {
@@ -10,6 +10,8 @@ export type GossipAttestationsWork = {
 export type PendingGossipsubMessage = {
   topic: GossipTopic;
   msg: Message;
+  // only available for beacon_attestation and aggregate_and_proof
+  msgSlot?: Slot;
   msgId: string;
   // TODO: Refactor into accepting string (requires gossipsub changes) for easier multi-threading
   propagationSource: PeerId;

--- a/packages/beacon-node/src/network/processor/worker.ts
+++ b/packages/beacon-node/src/network/processor/worker.ts
@@ -33,7 +33,8 @@ export class NetworkWorker {
       message.topic,
       message.msg,
       message.propagationSource.toString(),
-      message.seenTimestampSec
+      message.seenTimestampSec,
+      message.msgSlot
     );
 
     if (message.startProcessUnixSec !== null) {

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -76,7 +76,7 @@ export function getAttDataBase64FromAttestationSerialized(data: Uint8Array): Att
  * Extract aggregation bits from attestation serialized bytes.
  * Return null if data is not long enough to extract aggregation bits.
  */
-export function getAggregateionBitsFromAttestationSerialized(data: Uint8Array): BitArray | null {
+export function getAggregationBitsFromAttestationSerialized(data: Uint8Array): BitArray | null {
   if (data.length < VARIABLE_FIELD_OFFSET + ATTESTATION_DATA_SIZE + SIGNATURE_SIZE) {
     return null;
   }

--- a/packages/beacon-node/test/e2e/network/gossipsub.test.ts
+++ b/packages/beacon-node/test/e2e/network/gossipsub.test.ts
@@ -4,6 +4,7 @@ import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lo
 import {sleep} from "@lodestar/utils";
 
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {ssz} from "@lodestar/types";
 import {getReqRespHandlers, Network, NetworkInitModules} from "../../../src/network/index.js";
 import {defaultNetworkOptions, NetworkOptions} from "../../../src/network/options.js";
 import {GossipType, GossipHandlers} from "../../../src/network/gossip/index.js";
@@ -120,8 +121,8 @@ describe("gossipsub", function () {
     const onVoluntaryExitPromise = new Promise<Uint8Array>((resolve) => (onVoluntaryExit = resolve));
 
     const {netA, netB, controller} = await mockModules({
-      [GossipType.voluntary_exit]: async (sszSerializedData) => {
-        onVoluntaryExit(sszSerializedData);
+      [GossipType.voluntary_exit]: async ({serializedData}) => {
+        onVoluntaryExit(serializedData);
       },
     });
 
@@ -152,8 +153,8 @@ describe("gossipsub", function () {
     const receivedVoluntaryExits: Uint8Array[] = [];
 
     const {netA, netB, controller} = await mockModules({
-      [GossipType.voluntary_exit]: async (voluntaryExit) => {
-        receivedVoluntaryExits.push(voluntaryExit);
+      [GossipType.voluntary_exit]: async ({serializedData}) => {
+        receivedVoluntaryExits.push(serializedData);
       },
     });
 
@@ -197,8 +198,8 @@ describe("gossipsub", function () {
     const onBlsToExecutionChangePromise = new Promise<Uint8Array>((resolve) => (onBlsToExecutionChange = resolve));
 
     const {netA, netB, controller} = await mockModules({
-      [GossipType.bls_to_execution_change]: async (blsToExec) => {
-        onBlsToExecutionChange(blsToExec);
+      [GossipType.bls_to_execution_change]: async ({serializedData}) => {
+        onBlsToExecutionChange(serializedData);
       },
     });
 
@@ -232,8 +233,8 @@ describe("gossipsub", function () {
     );
 
     const {netA, netB, controller} = await mockModules({
-      [GossipType.light_client_optimistic_update]: async (lightClientOptimisticUpdate) => {
-        onLightClientOptimisticUpdate(lightClientOptimisticUpdate);
+      [GossipType.light_client_optimistic_update]: async ({serializedData}) => {
+        onLightClientOptimisticUpdate(serializedData);
       },
     });
 
@@ -268,8 +269,8 @@ describe("gossipsub", function () {
     );
 
     const {netA, netB, controller} = await mockModules({
-      [GossipType.light_client_finality_update]: async (lightClientFinalityUpdate) => {
-        onLightClientFinalityUpdate(lightClientFinalityUpdate);
+      [GossipType.light_client_finality_update]: async ({serializedData}) => {
+        onLightClientFinalityUpdate(serializedData);
       },
     });
 

--- a/packages/beacon-node/test/e2e/network/gossipsub.test.ts
+++ b/packages/beacon-node/test/e2e/network/gossipsub.test.ts
@@ -223,7 +223,7 @@ describe("gossipsub", function () {
     await netA.gossip.publishBlsToExecutionChange(blsToExec);
 
     const receivedblsToExec = await onBlsToExecutionChangePromise;
-    expect(receivedblsToExec).to.deep.equal(blsToExec);
+    expect(receivedblsToExec).to.deep.equal(ssz.capella.SignedBLSToExecutionChange.serialize(blsToExec));
   });
 
   it("Publish and receive a LightClientOptimisticUpdate", async function () {
@@ -259,7 +259,9 @@ describe("gossipsub", function () {
     await netA.gossip.publishLightClientOptimisticUpdate(lightClientOptimisticUpdate);
 
     const optimisticUpdate = await onLightClientOptimisticUpdatePromise;
-    expect(optimisticUpdate).to.deep.equal(lightClientOptimisticUpdate);
+    expect(optimisticUpdate).to.deep.equal(
+      ssz.capella.LightClientOptimisticUpdate.serialize(lightClientOptimisticUpdate)
+    );
   });
 
   it("Publish and receive a LightClientFinalityUpdate", async function () {
@@ -295,6 +297,6 @@ describe("gossipsub", function () {
     await netA.gossip.publishLightClientFinalityUpdate(lightClientFinalityUpdate);
 
     const optimisticUpdate = await onLightClientFinalityUpdatePromise;
-    expect(optimisticUpdate).to.deep.equal(lightClientFinalityUpdate);
+    expect(optimisticUpdate).to.deep.equal(ssz.capella.LightClientFinalityUpdate.serialize(lightClientFinalityUpdate));
   });
 });

--- a/packages/beacon-node/test/e2e/network/gossipsub.test.ts
+++ b/packages/beacon-node/test/e2e/network/gossipsub.test.ts
@@ -1,7 +1,6 @@
 import sinon from "sinon";
 import {expect} from "chai";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
-import {capella, phase0, ssz, allForks} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
@@ -117,12 +116,12 @@ describe("gossipsub", function () {
   }
 
   it("Publish and receive a voluntaryExit", async function () {
-    let onVoluntaryExit: (ve: phase0.SignedVoluntaryExit) => void;
-    const onVoluntaryExitPromise = new Promise<phase0.SignedVoluntaryExit>((resolve) => (onVoluntaryExit = resolve));
+    let onVoluntaryExit: (ve: Uint8Array) => void;
+    const onVoluntaryExitPromise = new Promise<Uint8Array>((resolve) => (onVoluntaryExit = resolve));
 
     const {netA, netB, controller} = await mockModules({
-      [GossipType.voluntary_exit]: async (voluntaryExit) => {
-        onVoluntaryExit(voluntaryExit);
+      [GossipType.voluntary_exit]: async (sszSerializedData) => {
+        onVoluntaryExit(sszSerializedData);
       },
     });
 
@@ -146,11 +145,11 @@ describe("gossipsub", function () {
     await netA.gossip.publishVoluntaryExit(voluntaryExit);
 
     const receivedVoluntaryExit = await onVoluntaryExitPromise;
-    expect(receivedVoluntaryExit).to.deep.equal(voluntaryExit);
+    expect(receivedVoluntaryExit).to.deep.equal(ssz.phase0.SignedVoluntaryExit.serialize(voluntaryExit));
   });
 
   it("Publish and receive 1000 voluntaryExits", async function () {
-    const receivedVoluntaryExits: phase0.SignedVoluntaryExit[] = [];
+    const receivedVoluntaryExits: Uint8Array[] = [];
 
     const {netA, netB, controller} = await mockModules({
       [GossipType.voluntary_exit]: async (voluntaryExit) => {
@@ -194,10 +193,8 @@ describe("gossipsub", function () {
   });
 
   it("Publish and receive a blsToExecutionChange", async function () {
-    let onBlsToExecutionChange: (blsToExec: capella.SignedBLSToExecutionChange) => void;
-    const onBlsToExecutionChangePromise = new Promise<capella.SignedBLSToExecutionChange>(
-      (resolve) => (onBlsToExecutionChange = resolve)
-    );
+    let onBlsToExecutionChange: (blsToExec: Uint8Array) => void;
+    const onBlsToExecutionChangePromise = new Promise<Uint8Array>((resolve) => (onBlsToExecutionChange = resolve));
 
     const {netA, netB, controller} = await mockModules({
       [GossipType.bls_to_execution_change]: async (blsToExec) => {
@@ -229,8 +226,8 @@ describe("gossipsub", function () {
   });
 
   it("Publish and receive a LightClientOptimisticUpdate", async function () {
-    let onLightClientOptimisticUpdate: (ou: allForks.LightClientOptimisticUpdate) => void;
-    const onLightClientOptimisticUpdatePromise = new Promise<allForks.LightClientOptimisticUpdate>(
+    let onLightClientOptimisticUpdate: (ou: Uint8Array) => void;
+    const onLightClientOptimisticUpdatePromise = new Promise<Uint8Array>(
       (resolve) => (onLightClientOptimisticUpdate = resolve)
     );
 
@@ -265,8 +262,8 @@ describe("gossipsub", function () {
   });
 
   it("Publish and receive a LightClientFinalityUpdate", async function () {
-    let onLightClientFinalityUpdate: (fu: allForks.LightClientFinalityUpdate) => void;
-    const onLightClientFinalityUpdatePromise = new Promise<allForks.LightClientFinalityUpdate>(
+    let onLightClientFinalityUpdate: (fu: Uint8Array) => void;
+    const onLightClientFinalityUpdatePromise = new Promise<Uint8Array>(
       (resolve) => (onLightClientFinalityUpdate = resolve)
     );
 

--- a/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
+++ b/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
@@ -19,7 +19,7 @@ describe("validate gossip attestation", () => {
       id: `validate gossip attestation - ${id}`,
       beforeEach: () => chain.seenAttesters["validatorIndexesByEpoch"].clear(),
       fn: async () => {
-        await validateGossipAttestation(chain, {attestation: att, bytes: null}, subnet);
+        await validateGossipAttestation(chain, {attestation: att, serializedData: null}, subnet);
       },
     });
   }

--- a/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
+++ b/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
@@ -19,7 +19,7 @@ describe("validate gossip attestation", () => {
       id: `validate gossip attestation - ${id}`,
       beforeEach: () => chain.seenAttesters["validatorIndexesByEpoch"].clear(),
       fn: async () => {
-        await validateGossipAttestation(chain, att, subnet);
+        await validateGossipAttestation(chain, {attestation: att, bytes: null}, subnet);
       },
     });
   }

--- a/packages/beacon-node/test/unit/chain/validation/attestation.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation.test.ts
@@ -1,10 +1,10 @@
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {phase0} from "@lodestar/types";
 import {BitArray} from "@chainsafe/ssz";
 import {processSlots} from "@lodestar/state-transition";
+import {ssz} from "@lodestar/types";
 import {IBeaconChain} from "../../../../src/chain/index.js";
-import {AttestationErrorCode} from "../../../../src/chain/errors/index.js";
-import {validateGossipAttestation} from "../../../../src/chain/validation/index.js";
+import {AttestationErrorCode, INVALID_SERIALIZED_BYTES_ERROR_CODE} from "../../../../src/chain/errors/index.js";
+import {AttestationOrBytes, validateGossipAttestation} from "../../../../src/chain/validation/index.js";
 import {expectRejectedWithLodestarError} from "../../../utils/errors.js";
 import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../state-transition/test/perf/util.js";
 import {memoOnce} from "../../../utils/cache.js";
@@ -41,27 +41,58 @@ describe("chain / validation / attestation", () => {
     await validateGossipAttestation(chain, {attestation, serializedData: null}, subnet);
   });
 
+  it("INVALID_SERIALIZED_BYTES_ERROR_CODE", async () => {
+    const {chain, subnet} = getValidData();
+    await expectError(
+      chain,
+      {attestation: null, serializedData: Buffer.alloc(0), attSlot: 0},
+      subnet,
+      INVALID_SERIALIZED_BYTES_ERROR_CODE
+    );
+  });
+
   it("BAD_TARGET_EPOCH", async () => {
     const {chain, attestation, subnet} = getValidData();
 
     // Change target epoch to it doesn't match data.slot
     attestation.data.target.epoch += 1;
+    const serializedData = ssz.phase0.Attestation.serialize(attestation);
 
-    await expectError(chain, attestation, subnet, AttestationErrorCode.BAD_TARGET_EPOCH);
+    await expectError(chain, {attestation, serializedData: null}, subnet, AttestationErrorCode.BAD_TARGET_EPOCH);
+    await expectError(
+      chain,
+      {attestation: null, serializedData, attSlot: attestation.data.slot},
+      subnet,
+      AttestationErrorCode.BAD_TARGET_EPOCH
+    );
   });
 
   it("PAST_SLOT", async () => {
     // Set attestation at a very old slot
     const {chain, attestation, subnet} = getValidData({attSlot: stateSlot - SLOTS_PER_EPOCH - 3});
+    const serializedData = ssz.phase0.Attestation.serialize(attestation);
 
-    await expectError(chain, attestation, subnet, AttestationErrorCode.PAST_SLOT);
+    await expectError(chain, {attestation, serializedData: null}, subnet, AttestationErrorCode.PAST_SLOT);
+    await expectError(
+      chain,
+      {attestation: null, serializedData, attSlot: attestation.data.slot},
+      subnet,
+      AttestationErrorCode.PAST_SLOT
+    );
   });
 
   it("FUTURE_SLOT", async () => {
     // Set attestation to a future slot
     const {chain, attestation, subnet} = getValidData({attSlot: stateSlot + 2});
+    const serializedData = ssz.phase0.Attestation.serialize(attestation);
 
-    await expectError(chain, attestation, subnet, AttestationErrorCode.FUTURE_SLOT);
+    await expectError(chain, {attestation, serializedData: null}, subnet, AttestationErrorCode.FUTURE_SLOT);
+    await expectError(
+      chain,
+      {attestation: null, serializedData, attSlot: attestation.data.slot},
+      subnet,
+      AttestationErrorCode.FUTURE_SLOT
+    );
   });
 
   it("NOT_EXACTLY_ONE_AGGREGATION_BIT_SET - 0 bits", async () => {
@@ -69,8 +100,20 @@ describe("chain / validation / attestation", () => {
     const bitIndex = 1;
     const {chain, attestation, subnet} = getValidData({bitIndex});
     attestation.aggregationBits.set(bitIndex, false);
+    const serializedData = ssz.phase0.Attestation.serialize(attestation);
 
-    await expectError(chain, attestation, subnet, AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET);
+    await expectError(
+      chain,
+      {attestation, serializedData: null},
+      subnet,
+      AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
+    );
+    await expectError(
+      chain,
+      {attestation: null, serializedData, attSlot: attestation.data.slot},
+      subnet,
+      AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
+    );
   });
 
   it("NOT_EXACTLY_ONE_AGGREGATION_BIT_SET - 2 bits", async () => {
@@ -78,24 +121,49 @@ describe("chain / validation / attestation", () => {
     const bitIndex = 1;
     const {chain, attestation, subnet} = getValidData({bitIndex});
     attestation.aggregationBits.set(bitIndex + 1, true);
+    const serializedData = ssz.phase0.Attestation.serialize(attestation);
 
-    await expectError(chain, attestation, subnet, AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET);
+    await expectError(
+      chain,
+      {attestation: null, serializedData, attSlot: attestation.data.slot},
+      subnet,
+      AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
+    );
   });
 
   it("UNKNOWN_BEACON_BLOCK_ROOT", async () => {
     const {chain, attestation, subnet} = getValidData();
     // Set beaconBlockRoot to a root not known by the fork choice
     attestation.data.beaconBlockRoot = UNKNOWN_ROOT;
+    const serializedData = ssz.phase0.Attestation.serialize(attestation);
 
-    await expectError(chain, attestation, subnet, AttestationErrorCode.UNKNOWN_OR_PREFINALIZED_BEACON_BLOCK_ROOT);
+    await expectError(
+      chain,
+      {attestation, serializedData: null},
+      subnet,
+      AttestationErrorCode.UNKNOWN_OR_PREFINALIZED_BEACON_BLOCK_ROOT
+    );
+    await expectError(
+      chain,
+      {attestation: null, serializedData, attSlot: attestation.data.slot},
+      subnet,
+      AttestationErrorCode.UNKNOWN_OR_PREFINALIZED_BEACON_BLOCK_ROOT
+    );
   });
 
   it("INVALID_TARGET_ROOT", async () => {
     const {chain, attestation, subnet} = getValidData();
     // Set target.root to an unknown root
     attestation.data.target.root = UNKNOWN_ROOT;
+    const serializedData = ssz.phase0.Attestation.serialize(attestation);
 
-    await expectError(chain, attestation, subnet, AttestationErrorCode.INVALID_TARGET_ROOT);
+    await expectError(chain, {attestation, serializedData: null}, subnet, AttestationErrorCode.INVALID_TARGET_ROOT);
+    await expectError(
+      chain,
+      {attestation: null, serializedData, attSlot: attestation.data.slot},
+      subnet,
+      AttestationErrorCode.INVALID_TARGET_ROOT
+    );
   });
 
   it("NO_COMMITTEE_FOR_SLOT_AND_INDEX", async () => {
@@ -107,8 +175,20 @@ describe("chain / validation / attestation", () => {
     (chain as {regen: IStateRegenerator}).regen = {
       getState: async () => committeeState,
     } as Partial<IStateRegenerator> as IStateRegenerator;
+    const serializedData = ssz.phase0.Attestation.serialize(attestation);
 
-    await expectError(chain, attestation, subnet, AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX);
+    await expectError(
+      chain,
+      {attestation, serializedData: null},
+      subnet,
+      AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX
+    );
+    await expectError(
+      chain,
+      {attestation: null, serializedData, attSlot: attestation.data.slot},
+      subnet,
+      AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX
+    );
   });
 
   it("WRONG_NUMBER_OF_AGGREGATION_BITS", async () => {
@@ -118,24 +198,60 @@ describe("chain / validation / attestation", () => {
       attestation.aggregationBits.uint8Array,
       attestation.aggregationBits.bitLen + 1
     );
+    const serializedData = ssz.phase0.Attestation.serialize(attestation);
 
-    await expectError(chain, attestation, subnet, AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS);
+    await expectError(
+      chain,
+      {attestation, serializedData: null},
+      subnet,
+      AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS
+    );
+    await expectError(
+      chain,
+      {attestation: null, serializedData, attSlot: attestation.data.slot},
+      subnet,
+      AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS
+    );
   });
 
   it("INVALID_SUBNET_ID", async () => {
     const {chain, attestation, subnet} = getValidData();
     // Pass a different subnet value than the correct one
     const invalidSubnet = subnet === 0 ? 1 : 0;
+    const serializedData = ssz.phase0.Attestation.serialize(attestation);
 
-    await expectError(chain, attestation, invalidSubnet, AttestationErrorCode.INVALID_SUBNET_ID);
+    await expectError(
+      chain,
+      {attestation, serializedData: null},
+      invalidSubnet,
+      AttestationErrorCode.INVALID_SUBNET_ID
+    );
+    await expectError(
+      chain,
+      {attestation: null, serializedData, attSlot: attestation.data.slot},
+      invalidSubnet,
+      AttestationErrorCode.INVALID_SUBNET_ID
+    );
   });
 
   it("ATTESTATION_ALREADY_KNOWN", async () => {
     const {chain, attestation, subnet, validatorIndex} = getValidData();
     // Register attester as already seen
     chain.seenAttesters.add(attestation.data.target.epoch, validatorIndex);
+    const serializedData = ssz.phase0.Attestation.serialize(attestation);
 
-    await expectError(chain, attestation, subnet, AttestationErrorCode.ATTESTATION_ALREADY_KNOWN);
+    await expectError(
+      chain,
+      {attestation, serializedData: null},
+      subnet,
+      AttestationErrorCode.ATTESTATION_ALREADY_KNOWN
+    );
+    await expectError(
+      chain,
+      {attestation: null, serializedData, attSlot: attestation.data.slot},
+      subnet,
+      AttestationErrorCode.ATTESTATION_ALREADY_KNOWN
+    );
   });
 
   it("INVALID_SIGNATURE", async () => {
@@ -144,20 +260,24 @@ describe("chain / validation / attestation", () => {
     // Change the bit index so the signature is validated against a different pubkey
     attestation.aggregationBits.set(bitIndex, false);
     attestation.aggregationBits.set(bitIndex + 1, true);
+    const serializedData = ssz.phase0.Attestation.serialize(attestation);
 
-    await expectError(chain, attestation, subnet, AttestationErrorCode.INVALID_SIGNATURE);
+    await expectError(chain, {attestation, serializedData: null}, subnet, AttestationErrorCode.INVALID_SIGNATURE);
+    await expectError(
+      chain,
+      {attestation: null, serializedData, attSlot: attestation.data.slot},
+      subnet,
+      AttestationErrorCode.INVALID_SIGNATURE
+    );
   });
 
   /** Alias to reduce code duplication */
   async function expectError(
     chain: IBeaconChain,
-    attestation: phase0.Attestation,
+    attestationOrBytes: AttestationOrBytes,
     subnet: number,
-    errorCode: AttestationErrorCode
+    errorCode: string
   ): Promise<void> {
-    await expectRejectedWithLodestarError(
-      validateGossipAttestation(chain, {attestation, serializedData: null}, subnet),
-      errorCode
-    );
+    await expectRejectedWithLodestarError(validateGossipAttestation(chain, attestationOrBytes, subnet), errorCode);
   }
 });

--- a/packages/beacon-node/test/unit/chain/validation/attestation.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation.test.ts
@@ -38,7 +38,7 @@ describe("chain / validation / attestation", () => {
   it("Valid", async () => {
     const {chain, attestation, subnet} = getValidData();
 
-    await validateGossipAttestation(chain, {attestation, bytes: null}, subnet);
+    await validateGossipAttestation(chain, {attestation, serializedData: null}, subnet);
   });
 
   it("BAD_TARGET_EPOCH", async () => {
@@ -156,7 +156,7 @@ describe("chain / validation / attestation", () => {
     errorCode: AttestationErrorCode
   ): Promise<void> {
     await expectRejectedWithLodestarError(
-      validateGossipAttestation(chain, {attestation, bytes: null}, subnet),
+      validateGossipAttestation(chain, {attestation, serializedData: null}, subnet),
       errorCode
     );
   }

--- a/packages/beacon-node/test/unit/chain/validation/attestation.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation.test.ts
@@ -38,7 +38,7 @@ describe("chain / validation / attestation", () => {
   it("Valid", async () => {
     const {chain, attestation, subnet} = getValidData();
 
-    await validateGossipAttestation(chain, attestation, subnet);
+    await validateGossipAttestation(chain, {attestation, bytes: null}, subnet);
   });
 
   it("BAD_TARGET_EPOCH", async () => {
@@ -155,6 +155,9 @@ describe("chain / validation / attestation", () => {
     subnet: number,
     errorCode: AttestationErrorCode
   ): Promise<void> {
-    await expectRejectedWithLodestarError(validateGossipAttestation(chain, attestation, subnet), errorCode);
+    await expectRejectedWithLodestarError(
+      validateGossipAttestation(chain, {attestation, bytes: null}, subnet),
+      errorCode
+    );
   }
 });

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -4,7 +4,7 @@ import {fromHex, toHex} from "@lodestar/utils";
 import {
   getAttDataBase64FromAttestationSerialized,
   getAttDataBase64FromSignedAggregateAndProofSerialized,
-  getAggregateionBitsFromAttestationSerialized as getAggregationBitsFromAttestationSerialized,
+  getAggregationBitsFromAttestationSerialized as getAggregationBitsFromAttestationSerialized,
   getBlockRootFromAttestationSerialized,
   getBlockRootFromSignedAggregateAndProofSerialized,
   getSlotFromAttestationSerialized,

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -4,11 +4,12 @@ import {fromHex, toHex} from "@lodestar/utils";
 import {
   getAttDataBase64FromAttestationSerialized,
   getAttDataBase64FromSignedAggregateAndProofSerialized,
-  getAggregateionBitsFromAttestationSerialized,
+  getAggregateionBitsFromAttestationSerialized as getAggregationBitsFromAttestationSerialized,
   getBlockRootFromAttestationSerialized,
   getBlockRootFromSignedAggregateAndProofSerialized,
   getSlotFromAttestationSerialized,
   getSlotFromSignedAggregateAndProofSerialized,
+  getSignatureFromAttestationSerialized,
 } from "../../../src/util/sszBytes.js";
 
 describe("attestation SSZ serialized picking", () => {
@@ -28,9 +29,10 @@ describe("attestation SSZ serialized picking", () => {
 
       expect(getSlotFromAttestationSerialized(bytes)).equals(attestation.data.slot);
       expect(getBlockRootFromAttestationSerialized(bytes)).equals(toHex(attestation.data.beaconBlockRoot));
-      expect(getAggregateionBitsFromAttestationSerialized(bytes).toBoolArray()).to.be.deep.equals(
+      expect(getAggregationBitsFromAttestationSerialized(bytes)?.toBoolArray()).to.be.deep.equals(
         attestation.aggregationBits.toBoolArray()
       );
+      expect(getSignatureFromAttestationSerialized(bytes)).to.be.deep.equals(attestation.signature);
 
       const attDataBase64 = ssz.phase0.AttestationData.serialize(attestation.data);
       expect(getAttDataBase64FromAttestationSerialized(bytes)).to.be.equal(
@@ -57,6 +59,20 @@ describe("attestation SSZ serialized picking", () => {
     const invalidAttDataBase64DataSizes = [0, 4, 100, 128, 131];
     for (const size of invalidAttDataBase64DataSizes) {
       expect(getAttDataBase64FromAttestationSerialized(Buffer.alloc(size))).to.be.null;
+    }
+  });
+
+  it("getAggregateionBitsFromAttestationSerialized - invalid data", () => {
+    const invalidAggregationBitsDataSizes = [0, 4, 100, 128, 227];
+    for (const size of invalidAggregationBitsDataSizes) {
+      expect(getAggregationBitsFromAttestationSerialized(Buffer.alloc(size))).to.be.null;
+    }
+  });
+
+  it("getSignatureFromAttestationSerialized - invalid data", () => {
+    const invalidSignatureDataSizes = [0, 4, 100, 128, 227];
+    for (const size of invalidSignatureDataSizes) {
+      expect(getSignatureFromAttestationSerialized(Buffer.alloc(size))).to.be.null;
     }
   });
 });

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -4,6 +4,7 @@ import {fromHex, toHex} from "@lodestar/utils";
 import {
   getAttDataBase64FromAttestationSerialized,
   getAttDataBase64FromSignedAggregateAndProofSerialized,
+  getAggregateionBitsFromAttestationSerialized,
   getBlockRootFromAttestationSerialized,
   getBlockRootFromSignedAggregateAndProofSerialized,
   getSlotFromAttestationSerialized,
@@ -27,6 +28,9 @@ describe("attestation SSZ serialized picking", () => {
 
       expect(getSlotFromAttestationSerialized(bytes)).equals(attestation.data.slot);
       expect(getBlockRootFromAttestationSerialized(bytes)).equals(toHex(attestation.data.beaconBlockRoot));
+      expect(getAggregateionBitsFromAttestationSerialized(bytes).toBoolArray()).to.be.deep.equals(
+        attestation.aggregationBits.toBoolArray()
+      );
 
       const attDataBase64 = ssz.phase0.AttestationData.serialize(attestation.data);
       expect(getAttDataBase64FromAttestationSerialized(bytes)).to.be.equal(

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -48,6 +48,7 @@ import {IChainOptions} from "../../../../src/chain/options.js";
 import {BlockAttributes} from "../../../../src/chain/produceBlock/produceBlockBody.js";
 import {ReqRespBlockResponse} from "../../../../src/network/index.js";
 import {SeenAttestationDatas} from "../../../../src/chain/seenCache/seenAttestationData.js";
+import {IExecutionBuilder} from "../../../../src/execution/index.js";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 
@@ -164,6 +165,7 @@ export class MockBeaconChain implements IBeaconChain {
     this.pubkey2index = new PubkeyIndexMap();
     this.index2pubkey = [];
   }
+  executionBuilder?: IExecutionBuilder | undefined;
 
   validatorSeenAtEpoch(): boolean {
     return false;
@@ -229,6 +231,10 @@ export class MockBeaconChain implements IBeaconChain {
   }
 
   persistInvalidSszObject(): void {
+    return;
+  }
+
+  persistInvalidSszBytes(): void {
     return;
   }
 

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -17,6 +17,7 @@ import {BlsSingleThreadVerifier} from "../../../src/chain/bls/index.js";
 import {signCached} from "../cache.js";
 import {ClockStatic} from "../clock.js";
 import {SeenAggregatedAttestations} from "../../../src/chain/seenCache/seenAggregateAndProof.js";
+import {SeenAttestationDatas} from "../../../src/chain/seenCache/seenAttestationData.js";
 
 export type AttestationValidDataOpts = {
   currentSlot?: Slot;
@@ -120,6 +121,7 @@ export function getAttestationValidData(opts: AttestationValidDataOpts): {
     regen,
     seenAttesters: new SeenAttesters(),
     seenAggregatedAttestations: new SeenAggregatedAttestations(null),
+    seenAttestationDatas: new SeenAttestationDatas(null, 0, 0),
     bls: new BlsSingleThreadVerifier({metrics: null}),
     waitForBlock: () => Promise.resolve(false),
     index2pubkey: state.epochCtx.index2pubkey,


### PR DESCRIPTION
**Motivation**

- Improve gossip validation flow for `beacon_attestation` topic
- We deserialize Attestation for every attestation gossip message but a lot of them have same AttestationData while:
  - `aggregationBits` can be extracted from ssz bytes
  - `signature` can also be extracted from ssz bytes
- Caching AttestationData does not take memory because according to metrics, we process up to 15k-20k attestations per slot while this cache only have 600 items max
- Fix `NetworkProcessor.onPendingGossipsubMessage()` to not push to the queue if unknown block root attestations

**Description**

- Skip deserializing gossip attestation messages most of the time
- Add `AttestationData` to seen cache, used for `beacon_attestation` topic only
- `gossipHandlerFn` now accept ssz bytes instead of ssz object. For `beacon_attestation` we don't do the deserialization and delegate to the `validateAttestation` function to do that. For all other topics we deserialize to ssz objects and pass to validation functions (unchange)
- Modify `validateAttestation`:
  - For api attestation, still accept Attestation object
  - For gossip attestation, accept ssz bytes. Only do the deserialization the 1st time AttestationData is not cached. After that reuse the cached AttestationData along with extracted `aggregationBits` and `signature` from ssz bytes.

part of #5352 #5353

**Testing in progress on feat1, feat2**


