### PR TITLE
Ignore attestation messages if cannot regen head states

### DIFF
--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -100,7 +100,7 @@ export async function validateGossipAggregateAndProof(
   const attHeadState = await chain.regen
     .getState(attHeadBlock.stateRoot, RegenCaller.validateGossipAggregateAndProof)
     .catch((e: Error) => {
-      throw new AttestationError(GossipAction.REJECT, {
+      throw new AttestationError(GossipAction.IGNORE, {
         code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE,
         error: e as Error,
       });

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -164,7 +164,7 @@ export async function validateGossipAttestation(
     const attHeadState = await chain.regen
       .getState(attHeadBlock.stateRoot, RegenCaller.validateGossipAttestation)
       .catch((e: Error) => {
-        throw new AttestationError(GossipAction.REJECT, {
+        throw new AttestationError(GossipAction.IGNORE, {
           code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE,
           error: e as Error,
         });


### PR DESCRIPTION
**Motivation**

We validate gossip attestations, they have correct head and target root in forkchoice but we cannot regen head states and we rejected them. As a result we applied p4 penalties to our peers and peer score dropped, see https://github.com/ChainSafe/lodestar/issues/5373

**Description**

- In this case it's our bad that we cannot regen states, should not reject messages (and then apply p4 penalties to our peers)
- Change to `IGNORE` instead

Closes #5373
