### PR TITLE
Add option to override preset with custom values from file

### DIFF
--- a/packages/cli/src/applyPreset.ts
+++ b/packages/cli/src/applyPreset.ts
@@ -13,8 +13,13 @@
 // Running this file allows us to keep a static export strategy while NOT requiring users to
 // set LODESTAR_PRESET manually every time.
 
+// IMPORTANT: only import Lodestar code here which does not import any other Lodestar libraries
+import {setActivePreset, presetFromJson} from "@lodestar/params/setPreset";
+import {readFile} from "./util/file.js";
+
 const network = valueOfArg("network");
 const preset = valueOfArg("preset");
+const presetFile = valueOfArg("presetFile");
 
 // Apply preset flag if present
 if (preset) {
@@ -39,6 +44,12 @@ else if (network) {
 else if (process.argv[2] === "dev") {
   process.env.LODESTAR_PRESET = "minimal";
   process.env.LODESTAR_NETWORK = "dev";
+}
+
+if (presetFile) {
+  // Override the active preset with custom values from file
+  // Do not modify the preset to use as a base by passing null
+  setActivePreset(null, presetFromJson(readFile(presetFile) ?? {}));
 }
 
 /**

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -8,6 +8,7 @@ type GlobalSingleArgs = {
   network?: NetworkName;
   paramsFile: string;
   preset: string;
+  presetFile?: string;
 };
 
 export const defaultNetwork: NetworkName = "mainnet";
@@ -35,6 +36,12 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
     hidden: true,
     type: "string",
     default: ACTIVE_PRESET,
+  },
+
+  presetFile: {
+    hidden: true,
+    description: "Preset configuration file to override the active preset with custom values",
+    type: "string",
   },
 };
 

--- a/packages/params/README.md
+++ b/packages/params/README.md
@@ -72,6 +72,7 @@ Important Notes:
 - The `minimal` preset is NOT compatible with the `mainnet` preset.
 - using `setActivePreset` may be dangerous, and only should be run once before loading any other libraries. All downstream Lodestar libraries expect the active preset to never change.
 - Preset values can be overriden by executing `setActivePreset(presetName: PresetName, overrides?: Partial<BeaconPreset>)` and supplying values to override.
+- The Lodestar CLI exposes `setActivePreset` through `--presetFile` flag which allows to override the active preset with custom values from file.
 
 ## License
 

--- a/packages/params/src/json.ts
+++ b/packages/params/src/json.ts
@@ -21,3 +21,37 @@ export function presetToJson(preset: BeaconPreset): Record<string, string> {
 function serializePresetValue(value: number): string {
   return value.toString(10);
 }
+
+/**
+ * Parse JSON strings of BeaconPreset
+ * - Numbers: Convert quoted decimal string to number
+ *
+ * Note: extraneous keys are not filtered out and will be validated
+ */
+export function presetFromJson(json: Record<string, unknown>): Partial<BeaconPreset> {
+  const beaconPreset = {} as BeaconPreset;
+
+  for (const key of Object.keys(json) as (keyof BeaconPreset)[]) {
+    beaconPreset[key] = deserializePresetValue(json[key], key);
+  }
+
+  return beaconPreset;
+}
+
+/**
+ * Ensure that all values of parsed BeaconPreset are numbers
+ * If there are more types, expand this function with a type switch
+ */
+function deserializePresetValue(valueStr: unknown, keyName: string): number {
+  if (typeof valueStr !== "string") {
+    throw Error(`Invalid ${keyName} value ${valueStr} expected string`);
+  }
+
+  const value = parseInt(valueStr, 10);
+
+  if (isNaN(value)) {
+    throw Error(`Invalid ${keyName} value ${valueStr} expected number`);
+  }
+
+  return value;
+}

--- a/packages/params/src/setPreset.ts
+++ b/packages/params/src/setPreset.ts
@@ -1,8 +1,9 @@
 import {PresetName} from "./presetName.js";
 import {presetStatus} from "./presetStatus.js";
 import {BeaconPreset} from "./interface.js";
+import {presetFromJson} from "./json.js";
 
-export {PresetName};
+export {PresetName, presetFromJson};
 
 /**
  * The preset name currently exported by this library
@@ -26,14 +27,14 @@ export let userOverrides: Partial<BeaconPreset> | undefined = undefined;
  * @param presetName - the preset to use as a base
  * @param overrides - customized fields
  */
-export function setActivePreset(presetName: PresetName, overrides?: Partial<BeaconPreset>): void {
+export function setActivePreset(presetName: PresetName | null, overrides?: Partial<BeaconPreset>): void {
   if (presetStatus.frozen) {
     throw Error(`Lodestar preset is already frozen. You must call setActivePreset() at the top of your
 application entry point, before importing @lodestar/params, or any library that may import it.
 
 \`\`\`
 // index.ts
-import {setActivePreset, PresetName} from "@lodestar/params/preset"
+import {setActivePreset, PresetName} from "@lodestar/params/setPreset"
 setActivePreset(PresetName.minimal)
 // Now you can safely import from other paths and consume params
 import {SLOTS_PER_EPOCH} from "@lodestar/params"


### PR DESCRIPTION
**Motivation**

Follow up to https://github.com/ChainSafe/lodestar/pull/4601 to expose `setActivePreset` through the CLI and not just at the library level.

Presets are more extensive than runtime configurations, and generally only applicable during compile-time. However, to support various private networks, simulation networks  or CI/CD integration tests we require more flexibility.

The main motivation for this PR is to support running Lodestar VC in Obol Network CI/CD integration tests where they use a custom configuration that requires to override preset values such as `SLOTS_PER_EPOCH` and `EPOCHS_PER_SYNC_COMMITTEE_PERIOD`.

**Description**

Adds CLI flag `--presetFile` which invokes `setActivePreset` with custom values from file to override values of the active preset.

**Usage**

> preset.yaml

```yml
SLOTS_PER_EPOCH: 16
EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 2
```

```
lodestar beacon --presetFile "./preset.yaml"
```


