### PR TITLE
feat: prune invalid SSZ objects

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -105,7 +105,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
               (args.persistInvalidSszObjectsRetentionHours ?? DEFAULT_RETENTION_SSZ_OBJECTS_HOURS) * HOURS_TO_MS
             );
           } catch (e) {
-            logger.warn("error pruning invalid SSZ objects", {persistInvalidSszObjectsDir}, e as Error);
+            logger.warn("Error pruning invalid SSZ objects", {persistInvalidSszObjectsDir}, e as Error);
           }
           // Run every ~1 hour
         }, HOURS_TO_MS)

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -11,12 +11,22 @@ import {LoggerNode, getNodeLogger} from "@lodestar/logger/node";
 import {GlobalArgs, parseBeaconNodeArgs} from "../../options/index.js";
 import {BeaconNodeOptions, getBeaconConfigFromArgs} from "../../config/index.js";
 import {getNetworkBootnodes, getNetworkData, isKnownNetworkName, readBootnodes} from "../../networks/index.js";
-import {onGracefulShutdown, mkdir, writeFile600Perm, cleanOldLogFiles, parseLoggerArgs} from "../../util/index.js";
+import {
+  onGracefulShutdown,
+  mkdir,
+  writeFile600Perm,
+  cleanOldLogFiles,
+  parseLoggerArgs,
+  pruneOldFilesInDir,
+} from "../../util/index.js";
 import {getVersionData} from "../../util/version.js";
 import {BeaconArgs} from "./options.js";
 import {getBeaconPaths} from "./paths.js";
 import {initBeaconState} from "./initBeaconState.js";
 import {initPeerIdAndEnr} from "./initPeerIdAndEnr.js";
+
+const DEFAULT_RETENTION_SSZ_OBJECTS_HOURS = 15 * 24;
+const HOURS_TO_MS = 3600 * 1000;
 
 /**
  * Runs a beacon node.
@@ -80,8 +90,28 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       metricsRegistries,
     });
 
-    if (args.attachToGlobalThis) (globalThis as unknown as {bn: BeaconNode}).bn = node;
+    // dev debug option to have access to the BN instance
+    if (args.attachToGlobalThis) {
+      (globalThis as unknown as {bn: BeaconNode}).bn = node;
+    }
 
+    // Prune invalid SSZ objects every interval
+    const {persistInvalidSszObjectsDir} = args;
+    const pruneInvalidSSZObjectsInterval = persistInvalidSszObjectsDir
+      ? setInterval(() => {
+          try {
+            pruneOldFilesInDir(
+              persistInvalidSszObjectsDir,
+              (args.persistInvalidSszObjectsRetentionHours ?? DEFAULT_RETENTION_SSZ_OBJECTS_HOURS) * HOURS_TO_MS
+            );
+          } catch (e) {
+            logger.warn("error pruning invalid SSZ objects", {persistInvalidSszObjectsDir}, e as Error);
+          }
+          // Run every ~1 hour
+        }, HOURS_TO_MS)
+      : null;
+
+    // Intercept SIGINT signal, to perform final ops before exiting
     onGracefulShutdown(async () => {
       if (args.persistNetworkIdentity) {
         try {
@@ -93,6 +123,10 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
         }
       }
       abortController.abort();
+
+      if (pruneInvalidSSZObjectsInterval !== null) {
+        clearInterval(pruneInvalidSSZObjectsInterval);
+      }
     }, logger.info.bind(logger));
 
     abortController.signal.addEventListener(

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -15,6 +15,7 @@ type BeaconExtraArgs = {
   beaconDir?: string;
   dbDir?: string;
   persistInvalidSszObjectsDir?: string;
+  persistInvalidSszObjectsRetentionHours?: number;
   peerStoreDir?: string;
   persistNetworkIdentity?: boolean;
 };
@@ -83,6 +84,12 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
     defaultDescription: defaultBeaconPaths.persistInvalidSszObjectsDir,
     hidden: true,
     type: "string",
+  },
+
+  persistInvalidSszObjectsRetentionHours: {
+    description: "Number of hours to keep invalid SSZ objects in local disk",
+    hidden: true,
+    type: "number",
   },
 
   peerStoreDir: {

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -87,7 +87,7 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
   },
 
   persistInvalidSszObjectsRetentionHours: {
-    description: "Number of hours to keep invalid SSZ objects in local disk",
+    description: "Number of hours to keep invalid SSZ objects on local disk",
     hidden: true,
     type: "number",
   },

--- a/packages/cli/src/util/index.ts
+++ b/packages/cli/src/util/index.ts
@@ -10,6 +10,7 @@ export * from "./logger.js";
 export * from "./object.js";
 export * from "./passphrase.js";
 export * from "./process.js";
+export * from "./pruneOldFilesInDir.js";
 export * from "./sleep.js";
 export * from "./stripOffNewlines.js";
 export * from "./types.js";

--- a/packages/cli/src/util/pruneOldFilesInDir.ts
+++ b/packages/cli/src/util/pruneOldFilesInDir.ts
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export function pruneOldFilesInDir(dirpath: string, maxAgeMs: number): void {
+  for (const entryName in fs.readdirSync(dirpath)) {
+    const entryPath = path.join(dirpath, entryName);
+
+    const stat = fs.statSync(entryPath);
+    if (stat.isDirectory()) {
+      pruneOldFilesInDir(entryPath, maxAgeMs);
+    } else if (stat.isFile()) {
+      if (Date.now() - stat.ctimeMs > maxAgeMs) {
+        fs.unlinkSync(entryPath);
+      }
+    }
+  }
+}

--- a/packages/cli/src/util/pruneOldFilesInDir.ts
+++ b/packages/cli/src/util/pruneOldFilesInDir.ts
@@ -9,7 +9,7 @@ export function pruneOldFilesInDir(dirpath: string, maxAgeMs: number): void {
     if (stat.isDirectory()) {
       pruneOldFilesInDir(entryPath, maxAgeMs);
     } else if (stat.isFile()) {
-      if (Date.now() - stat.ctimeMs > maxAgeMs) {
+      if (Date.now() - stat.mtimeMs > maxAgeMs) {
         fs.unlinkSync(entryPath);
       }
     }

--- a/packages/cli/src/util/pruneOldFilesInDir.ts
+++ b/packages/cli/src/util/pruneOldFilesInDir.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 export function pruneOldFilesInDir(dirpath: string, maxAgeMs: number): void {
-  for (const entryName in fs.readdirSync(dirpath)) {
+  for (const entryName of fs.readdirSync(dirpath)) {
     const entryPath = path.join(dirpath, entryName);
 
     const stat = fs.statSync(entryPath);

--- a/packages/cli/test/unit/util/pruneOldFilesInDir.test.ts
+++ b/packages/cli/test/unit/util/pruneOldFilesInDir.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import path from "node:path";
+import {rimraf} from "rimraf";
+import {expect} from "chai";
+import {pruneOldFilesInDir} from "../../../src/util/index.js";
+import {testFilesDir} from "../../utils.js";
+
+describe("pruneOldFilesInDir", () => {
+  const DAYS_TO_MS = 24 * 60 * 60 * 1000;
+  const dataDir = path.join(testFilesDir, "prune-old-files-test");
+  const newFile = "newFile.txt";
+  const oldFile = "oldFile.txt";
+
+  beforeEach(() => {
+    fs.mkdirSync(dataDir, {recursive: true});
+    createFileWithAge(path.join(dataDir, oldFile), 2);
+    createFileWithAge(path.join(dataDir, newFile), 0);
+  });
+
+  afterEach(() => {
+    rimraf.sync(dataDir);
+  });
+
+  it("should delete old files", () => {
+    pruneOldFilesInDir(dataDir, DAYS_TO_MS);
+
+    const files = fs.readdirSync(dataDir);
+    expect(files).to.not.include(oldFile);
+  });
+
+  it("should not delete new files", () => {
+    pruneOldFilesInDir(dataDir, DAYS_TO_MS);
+
+    const files = fs.readdirSync(dataDir);
+    expect(files).to.include(newFile);
+  });
+
+  it("should delete old files in nested directories", () => {
+    const nestedDir = path.join(dataDir, "prune-old-files-nested");
+
+    fs.mkdirSync(nestedDir);
+    createFileWithAge(path.join(nestedDir, "nestedFile.txt"), 2);
+
+    pruneOldFilesInDir(dataDir, DAYS_TO_MS);
+
+    expect(fs.readdirSync(nestedDir)).to.be.empty;
+  });
+
+  it("should handle empty directories", () => {
+    const emptyDir = path.join(dataDir, "prune-old-files-empty");
+    fs.mkdirSync(emptyDir, {recursive: true});
+
+    pruneOldFilesInDir(emptyDir, DAYS_TO_MS);
+
+    expect(fs.readdirSync(emptyDir)).to.be.empty;
+  });
+
+  function createFileWithAge(path: string, ageInDays: number): void {
+    // Create a new empty file
+    fs.closeSync(fs.openSync(path, "w"));
+
+    if (ageInDays > 0) {
+      // Alter file's access and modification dates
+      fs.utimesSync(path, Date.now() / 1000, (Date.now() - ageInDays * DAYS_TO_MS) / 1000);
+    }
+  }
+});


### PR DESCRIPTION
**Motivation**

This PR closes #4420. That is, it allows the user to prune old `invalidSszObjects` after a specified number of days.

**Description**

This PR adds a new CLI hidden option `--persistInvalidSszObjectsRetention` only applicable to `beacon` command. It works in conjunction with `--chain.persistInvalidSszObjects` and `--persistInvalidSszObjectsDir`.

When `--chain.persistInvalidSszObjects` is enabled, pruning is activated by default. However, you can disable it with `--persistInvalidSszObjectsRetention 0`

If `--persistInvalidSszObjectsRetention` is not specified, the retention period for invalid SSZ objects defaults to 7 days.

The application prunes invalid SSZ objects during start up and every hour.

**Steps to test or reproduce**

```sh
git checkout acuarica/prune-invalid-ssz-objects
lodestar beacon --persistInvalidSszObjectsRetention 14
```
