### PR TITLE
Add TOO_MANY_SKIPPED_SLOTS attestation error

### DIFF
--- a/packages/beacon-node/src/chain/errors/attestationError.ts
+++ b/packages/beacon-node/src/chain/errors/attestationError.ts
@@ -130,6 +130,8 @@ export enum AttestationErrorCode {
    * Invalid ssz bytes.
    */
   INVALID_SERIALIZED_BYTES = "ATTESTATION_ERROR_INVALID_SERIALIZED_BYTES",
+  /** Too many skipped slots. */
+  TOO_MANY_SKIPPED_SLOTS = "ATTESTATION_ERROR_TOO_MANY_SKIPPED_SLOTS",
 }
 
 export type AttestationErrorType =
@@ -163,7 +165,8 @@ export type AttestationErrorType =
   | {code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE; error: Error}
   | {code: AttestationErrorCode.INVALID_AGGREGATOR}
   | {code: AttestationErrorCode.INVALID_INDEXED_ATTESTATION}
-  | {code: AttestationErrorCode.INVALID_SERIALIZED_BYTES};
+  | {code: AttestationErrorCode.INVALID_SERIALIZED_BYTES}
+  | {code: AttestationErrorCode.TOO_MANY_SKIPPED_SLOTS; headBlockSlot: Slot; attestationSlot: Slot};
 
 export class AttestationError extends GossipActionError<AttestationErrorType> {
   getMetadata(): Record<string, string | number | null> {

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -74,4 +74,7 @@ export const defaultChainOptions: IChainOptions = {
   assertCorrectProgressiveBalances: false,
   archiveStateEpochFrequency: 1024,
   emitPayloadAttributes: false,
+  // for gossip block validation, it's unlikely we see a reorg with 32 slots
+  // for attestation validation, having this value ensures we don't have to regen states most of the time
+  maxSkipSlots: 32,
 };

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -88,7 +88,16 @@ export async function validateGossipAggregateAndProof(
 
   // [IGNORE] The block being voted for (attestation.data.beacon_block_root) has been seen (via both gossip
   // and non-gossip sources) (a client MAY queue attestations for processing once block is retrieved).
-  const attHeadBlock = verifyHeadBlockAndTargetRoot(chain, attData.beaconBlockRoot, attTarget.root, attEpoch);
+  // Lighthouse doesn't check maxSkipSlots option here but Lodestar wants to be more strict
+  // to be more DOS protection
+  const attHeadBlock = verifyHeadBlockAndTargetRoot(
+    chain,
+    attData.beaconBlockRoot,
+    attTarget.root,
+    attSlot,
+    attEpoch,
+    chain.opts.maxSkipSlots
+  );
 
   // [IGNORE] The current finalized_checkpoint is an ancestor of the block defined by aggregate.data.beacon_block_root
   // -- i.e. get_ancestor(store, aggregate.data.beacon_block_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)) == store.finalized_checkpoint.root

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -276,6 +276,11 @@ export function createLodestarMetrics(
       help: "Current count of jobs being run on network processor for topic",
       labelNames: ["topic"],
     }),
+    gossipValidationErrorTooManySkippedSlots: register.gauge<"topic">({
+      name: "lodestar_gossip_validation_error_too_many_skipped_slots_total",
+      help: "Count of total gossip validation errors due to too many skipped slots",
+      labelNames: ["topic"],
+    }),
 
     networkProcessor: {
       executeWorkCalls: register.gauge({

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -18,6 +18,7 @@ import {signCached} from "../cache.js";
 import {ClockStatic} from "../clock.js";
 import {SeenAggregatedAttestations} from "../../../src/chain/seenCache/seenAggregateAndProof.js";
 import {SeenAttestationDatas} from "../../../src/chain/seenCache/seenAttestationData.js";
+import {defaultChainOptions} from "../../../src/chain/options.js";
 
 export type AttestationValidDataOpts = {
   currentSlot?: Slot;
@@ -125,6 +126,7 @@ export function getAttestationValidData(opts: AttestationValidDataOpts): {
     bls: new BlsSingleThreadVerifier({metrics: null}),
     waitForBlock: () => Promise.resolve(false),
     index2pubkey: state.epochCtx.index2pubkey,
+    opts: defaultChainOptions,
   } as Partial<IBeaconChain> as IBeaconChain;
 
   return {chain, attestation, subnet, validatorIndex};


### PR DESCRIPTION
**Motivation**

- Regen module is overloaded, see #5384
- We want to have DOS protection to avoid having to process attestations with very old head block that can potentially cause our regen to be overloaded

**Description**

- Follow Lighthouse to add `TOO_MANY_SKIPPED_SLOTS` error
- By default, configure `maxSkipSlots` of chain to be 32:
  - for gossip block validation, it's unlikely we see a reorg with 32 slots
  - for attestation validation, having this value ensures we don't have to regen states most of the time (because attestation has to be in the last 32 slots + `maxSkipSlots` of 32 above => headBlock of attestation should be in the last 64 slots and it's likely we can get its state from the cache). Also most of Attestations (>90%) are caught by the `SeenAttestationDatas` cache, it's no problem not to import these weird attestations.
- Import block: add postState to state cache before we emit "block" event since some handlers need that
- Add metrics to track this new error

part of #5384
