### PR TITLE
DOS protection based on message slot

### DIFF
--- a/packages/beacon-node/src/chain/errors/gossipValidation.ts
+++ b/packages/beacon-node/src/chain/errors/gossipValidation.ts
@@ -5,7 +5,10 @@ export enum GossipAction {
   REJECT = "REJECT",
 }
 
-export const INVALID_SERIALIZED_BYTES_ERROR_CODE = "GOSSIP_ERROR_INVALID_SERIALIZED_BYTES";
+export enum GossipErrorCode {
+  INVALID_SERIALIZED_BYTES_ERROR_CODE = "GOSSIP_ERROR_INVALID_SERIALIZED_BYTES",
+  PAST_SLOT = "GOSSIP_ERROR_PAST_SLOT",
+}
 
 export class GossipActionError<T extends {code: string}> extends LodestarError<T> {
   action: GossipAction;

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -276,11 +276,6 @@ export function createLodestarMetrics(
       help: "Current count of jobs being run on network processor for topic",
       labelNames: ["topic"],
     }),
-    gossipValidationErrorTooManySkippedSlots: register.gauge<"topic">({
-      name: "lodestar_gossip_validation_error_too_many_skipped_slots_total",
-      help: "Count of total gossip validation errors due to too many skipped slots",
-      labelNames: ["topic"],
-    }),
 
     networkProcessor: {
       executeWorkCalls: register.gauge({

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -8,11 +8,7 @@ import {
   isForkLightClient,
 } from "@lodestar/params";
 
-import {
-  GossipAction,
-  GossipActionError,
-  INVALID_SERIALIZED_BYTES_ERROR_CODE,
-} from "../../chain/errors/gossipValidation.js";
+import {GossipAction, GossipActionError, GossipErrorCode} from "../../chain/errors/gossipValidation.js";
 import {GossipEncoding, GossipTopic, GossipType, GossipTopicTypeMap, SSZTypeOfGossipTopic} from "./interface.js";
 import {DEFAULT_ENCODING} from "./constants.js";
 
@@ -123,7 +119,7 @@ export function sszDeserialize<T extends GossipTopic>(topic: T, serializedData: 
   try {
     return sszType.deserialize(serializedData) as SSZTypeOfGossipTopic<T>;
   } catch (e) {
-    throw new GossipActionError(GossipAction.REJECT, {code: INVALID_SERIALIZED_BYTES_ERROR_CODE});
+    throw new GossipActionError(GossipAction.REJECT, {code: GossipErrorCode.INVALID_SERIALIZED_BYTES_ERROR_CODE});
   }
 }
 
@@ -134,7 +130,7 @@ export function sszDeserializeAttestation(serializedData: Uint8Array): phase0.At
   try {
     return ssz.phase0.Attestation.deserialize(serializedData);
   } catch (e) {
-    throw new GossipActionError(GossipAction.REJECT, {code: INVALID_SERIALIZED_BYTES_ERROR_CODE});
+    throw new GossipActionError(GossipAction.REJECT, {code: GossipErrorCode.INVALID_SERIALIZED_BYTES_ERROR_CODE});
   }
 }
 

--- a/packages/beacon-node/src/network/processor/extractSlotRootFns.ts
+++ b/packages/beacon-node/src/network/processor/extractSlotRootFns.ts
@@ -1,9 +1,11 @@
-import {SlotRootHex} from "@lodestar/types";
+import {SlotOptionalRoot, SlotRootHex} from "@lodestar/types";
 import {
   getBlockRootFromAttestationSerialized,
   getBlockRootFromSignedAggregateAndProofSerialized,
   getSlotFromAttestationSerialized,
   getSlotFromSignedAggregateAndProofSerialized,
+  getSlotFromSignedBeaconBlockAndBlobsSidecarSerialized,
+  getSlotFromSignedBeaconBlockSerialized,
 } from "../../util/sszBytes.js";
 import {GossipType} from "../gossip/index.js";
 import {ExtractSlotRootFns} from "./types.js";
@@ -31,6 +33,22 @@ export function createExtractBlockSlotRootFns(): ExtractSlotRootFns {
         return null;
       }
       return {slot, root};
+    },
+    [GossipType.beacon_block]: (data: Uint8Array): SlotOptionalRoot | null => {
+      const slot = getSlotFromSignedBeaconBlockSerialized(data);
+
+      if (slot === null) {
+        return null;
+      }
+      return {slot};
+    },
+    [GossipType.beacon_block_and_blobs_sidecar]: (data: Uint8Array): SlotOptionalRoot | null => {
+      const slot = getSlotFromSignedBeaconBlockAndBlobsSidecarSerialized(data);
+
+      if (slot === null) {
+        return null;
+      }
+      return {slot};
     },
   };
 }

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -203,13 +203,8 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       try {
         validationResult = await validateGossipAggregateAndProof(chain, signedAggregateAndProof, false, serializedData);
       } catch (e) {
-        if (e instanceof AttestationError) {
-          if (e.action === GossipAction.REJECT) {
-            chain.persistInvalidSszValue(ssz.phase0.SignedAggregateAndProof, signedAggregateAndProof, "gossip_reject");
-          }
-          if (e.type.code === AttestationErrorCode.TOO_MANY_SKIPPED_SLOTS) {
-            metrics?.gossipValidationErrorTooManySkippedSlots.inc({topic: topic.type});
-          }
+        if (e instanceof AttestationError && e.action === GossipAction.REJECT) {
+          chain.persistInvalidSszValue(ssz.phase0.SignedAggregateAndProof, signedAggregateAndProof, "gossip_reject");
         }
         throw e;
       }
@@ -239,7 +234,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       }
     },
 
-    [GossipType.beacon_attestation]: async ({serializedData, msgSlot}, {type, subnet}, _peer, seenTimestampSec) => {
+    [GossipType.beacon_attestation]: async ({serializedData, msgSlot}, {subnet}, _peer, seenTimestampSec) => {
       if (msgSlot === undefined) {
         throw Error("msgSlot is undefined for beacon_attestation topic");
       }
@@ -252,13 +247,8 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
           subnet
         );
       } catch (e) {
-        if (e instanceof AttestationError) {
-          if (e.action === GossipAction.REJECT) {
-            chain.persistInvalidSszBytes(ssz.phase0.Attestation.typeName, serializedData, "gossip_reject");
-          }
-          if (e.type.code === AttestationErrorCode.TOO_MANY_SKIPPED_SLOTS) {
-            metrics?.gossipValidationErrorTooManySkippedSlots.inc({topic: type});
-          }
+        if (e instanceof AttestationError && e.action === GossipAction.REJECT) {
+          chain.persistInvalidSszBytes(ssz.phase0.Attestation.typeName, serializedData, "gossip_reject");
         }
         throw e;
       }

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -180,7 +180,7 @@ export class NetworkProcessor {
       // if slotRoot is null, it means the msg.data is invalid
       // in that case message will be rejected when deserializing data in later phase (gossipValidatorFn)
       if (slotRoot) {
-        // msgSlot is only available for beacon_attestation and aggregate_and_proof
+        // DOS protection: avoid processing messages that are too old
         const {slot, root} = slotRoot;
         if (slot < this.chain.clock.currentSlot - EARLIEST_PERMISSABLE_SLOT_DISTANCE) {
           // TODO: Should report the dropped job to gossip? It will be eventually pruned from the mcache
@@ -188,7 +188,7 @@ export class NetworkProcessor {
           return;
         }
         message.msgSlot = slot;
-        if (!this.chain.forkChoice.hasBlockHex(root)) {
+        if (root && !this.chain.forkChoice.hasBlockHex(root)) {
           if (this.unknownBlockGossipsubMessagesCount > MAX_QUEUED_UNKNOWN_BLOCK_GOSSIP_OBJECTS) {
             // TODO: Should report the dropped job to gossip? It will be eventually pruned from the mcache
             this.metrics?.reprocessGossipAttestations.reject.inc({reason: ReprocessRejectReason.reached_limit});

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -6,6 +6,7 @@ import {Metrics} from "../../metrics/metrics.js";
 import {NetworkEvent, NetworkEventBus} from "../events.js";
 import {GossipType} from "../gossip/interface.js";
 import {ChainEvent} from "../../chain/emitter.js";
+import {GossipErrorCode} from "../../chain/errors/gossipValidation.js";
 import {createGossipQueues} from "./gossipQueues.js";
 import {NetworkWorker, NetworkWorkerModules} from "./worker.js";
 import {PendingGossipsubMessage} from "./types.js";
@@ -23,6 +24,14 @@ export type NetworkProcessorModules = NetworkWorkerModules &
 export type NetworkProcessorOpts = GossipHandlerOpts & {
   maxGossipTopicConcurrency?: number;
 };
+
+/**
+ * This is respective to gossipsub seenTTL (which is 550 * 0.7 = 385s), also it's respective
+ * to beacon_attestation ATTESTATION_PROPAGATION_SLOT_RANGE (32 slots).
+ * If message slots are withint this window, it'll likely to be filtered by gossipsub seenCache.
+ * This is mainly for DOS protection, see https://github.com/ChainSafe/lodestar/issues/5393
+ */
+const EARLIEST_PERMISSABLE_SLOT_DISTANCE = 32;
 
 type WorkOpts = {
   bypassQueue?: boolean;
@@ -173,6 +182,11 @@ export class NetworkProcessor {
       if (slotRoot) {
         // msgSlot is only available for beacon_attestation and aggregate_and_proof
         const {slot, root} = slotRoot;
+        if (slot < this.chain.clock.currentSlot - EARLIEST_PERMISSABLE_SLOT_DISTANCE) {
+          // TODO: Should report the dropped job to gossip? It will be eventually pruned from the mcache
+          this.metrics?.gossipValidationError.inc({topic: message.topic.type, error: GossipErrorCode.PAST_SLOT});
+          return;
+        }
         message.msgSlot = slot;
         if (!this.chain.forkChoice.hasBlockHex(root)) {
           if (this.unknownBlockGossipsubMessagesCount > MAX_QUEUED_UNKNOWN_BLOCK_GOSSIP_OBJECTS) {

--- a/packages/beacon-node/src/network/processor/types.ts
+++ b/packages/beacon-node/src/network/processor/types.ts
@@ -1,6 +1,6 @@
 import {PeerId} from "@libp2p/interface-peer-id";
 import {Message} from "@libp2p/interface-pubsub";
-import {Slot, SlotRootHex} from "@lodestar/types";
+import {Slot, SlotOptionalRoot} from "@lodestar/types";
 import {GossipTopic, GossipType} from "../gossip/index.js";
 
 export type GossipAttestationsWork = {
@@ -20,5 +20,5 @@ export type PendingGossipsubMessage = {
 };
 
 export type ExtractSlotRootFns = {
-  [K in GossipType]?: (data: Uint8Array) => SlotRootHex | null;
+  [K in GossipType]?: (data: Uint8Array) => SlotOptionalRoot | null;
 };

--- a/packages/beacon-node/src/util/multifork.ts
+++ b/packages/beacon-node/src/util/multifork.ts
@@ -1,27 +1,13 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {allForks, Slot} from "@lodestar/types";
+import {allForks} from "@lodestar/types";
 import {bytesToInt} from "@lodestar/utils";
+import {getSlotFromSignedBeaconBlockSerialized} from "./sszBytes.js";
 
 /**
  * Slot	uint64
  */
 const SLOT_BYTE_COUNT = 8;
-/**
- * 4 + 96 = 100
- * ```
- * class SignedBeaconBlock(Container):
- *   message: BeaconBlock [offset - 4 bytes]
- *   signature: BLSSignature [fixed - 96 bytes]
- *
- * class BeaconBlock(Container):
- *   slot: Slot [fixed - 8 bytes]
- *   proposer_index: ValidatorIndex
- *   parent_root: Root
- *   state_root: Root
- *   body: BeaconBlockBody
- * ```
- */
-const SLOT_BYTES_POSITION_IN_BLOCK = 100;
+
 /**
  * 8 + 32 = 40
  * ```
@@ -38,12 +24,12 @@ export function getSignedBlockTypeFromBytes(
   config: ChainForkConfig,
   bytes: Buffer | Uint8Array
 ): allForks.AllForksSSZTypes["SignedBeaconBlock"] {
-  const slot = getSlotFromBytes(bytes);
-  return config.getForkTypes(slot).SignedBeaconBlock;
-}
+  const slot = getSlotFromSignedBeaconBlockSerialized(bytes);
+  if (slot === null) {
+    throw Error("getSignedBlockTypeFromBytes: invalid bytes");
+  }
 
-export function getSlotFromBytes(bytes: Buffer | Uint8Array): Slot {
-  return bytesToInt(bytes.subarray(SLOT_BYTES_POSITION_IN_BLOCK, SLOT_BYTES_POSITION_IN_BLOCK + SLOT_BYTE_COUNT));
+  return config.getForkTypes(slot).SignedBeaconBlock;
 }
 
 export function getStateTypeFromBytes(

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -16,15 +16,6 @@ export type AttDataBase64 = string;
 //   beacon_block_root: Root   - data 32
 //   source: Checkpoint        - data 40
 //   target: Checkpoint        - data 40
-//
-// class SignedAggregateAndProof(Container):
-//    message: AggregateAndProof - offset 4
-//    signature: BLSSignature    - data 96
-
-// class AggregateAndProof(Container)
-//    aggregatorIndex: ValidatorIndex - data 8
-//    aggregate: Attestation          - offset 4
-//    selectionProof: BLSSignature    - data 96
 
 const VARIABLE_FIELD_OFFSET = 4;
 const ATTESTATION_BEACON_BLOCK_ROOT_OFFSET = VARIABLE_FIELD_OFFSET + 8 + 8;
@@ -104,6 +95,16 @@ export function getSignatureFromAttestationSerialized(data: Uint8Array): BLSSign
   );
 }
 
+//
+// class SignedAggregateAndProof(Container):
+//    message: AggregateAndProof - offset 4
+//    signature: BLSSignature    - data 96
+
+// class AggregateAndProof(Container)
+//    aggregatorIndex: ValidatorIndex - data 8
+//    aggregate: Attestation          - offset 4
+//    selectionProof: BLSSignature    - data 96
+
 const AGGREGATE_AND_PROOF_OFFSET = 4 + 96;
 const AGGREGATE_OFFSET = AGGREGATE_AND_PROOF_OFFSET + 8 + 4 + 96;
 const SIGNED_AGGREGATE_AND_PROOF_SLOT_OFFSET = AGGREGATE_OFFSET + VARIABLE_FIELD_OFFSET;
@@ -151,6 +152,31 @@ export function getAttDataBase64FromSignedAggregateAndProofSerialized(data: Uint
   return Buffer.from(
     data.slice(SIGNED_AGGREGATE_AND_PROOF_SLOT_OFFSET, SIGNED_AGGREGATE_AND_PROOF_SLOT_OFFSET + ATTESTATION_DATA_SIZE)
   ).toString("base64");
+}
+
+/**
+ * 4 + 96 = 100
+ * ```
+ * class SignedBeaconBlock(Container):
+ *   message: BeaconBlock [offset - 4 bytes]
+ *   signature: BLSSignature [fixed - 96 bytes]
+ *
+ * class BeaconBlock(Container):
+ *   slot: Slot [fixed - 8 bytes]
+ *   proposer_index: ValidatorIndex
+ *   parent_root: Root
+ *   state_root: Root
+ *   body: BeaconBlockBody
+ * ```
+ */
+const SLOT_BYTES_POSITION_IN_BLOCK = VARIABLE_FIELD_OFFSET + SIGNATURE_SIZE;
+
+export function getSlotFromSignedBeaconBlockSerialized(data: Uint8Array): Slot | null {
+  if (data.length < SLOT_BYTES_POSITION_IN_BLOCK + SLOT_SIZE) {
+    return null;
+  }
+
+  return getSlotFromOffset(data, SLOT_BYTES_POSITION_IN_BLOCK);
 }
 
 function getSlotFromOffset(data: Uint8Array, offset: number): Slot {

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -169,14 +169,40 @@ export function getAttDataBase64FromSignedAggregateAndProofSerialized(data: Uint
  *   body: BeaconBlockBody
  * ```
  */
-const SLOT_BYTES_POSITION_IN_BLOCK = VARIABLE_FIELD_OFFSET + SIGNATURE_SIZE;
+const SLOT_BYTES_POSITION_IN_SIGNED_BEACON_BLOCK = VARIABLE_FIELD_OFFSET + SIGNATURE_SIZE;
 
 export function getSlotFromSignedBeaconBlockSerialized(data: Uint8Array): Slot | null {
-  if (data.length < SLOT_BYTES_POSITION_IN_BLOCK + SLOT_SIZE) {
+  if (data.length < SLOT_BYTES_POSITION_IN_SIGNED_BEACON_BLOCK + SLOT_SIZE) {
     return null;
   }
 
-  return getSlotFromOffset(data, SLOT_BYTES_POSITION_IN_BLOCK);
+  return getSlotFromOffset(data, SLOT_BYTES_POSITION_IN_SIGNED_BEACON_BLOCK);
+}
+
+/**
+ * 4 + 4 + SLOT_BYTES_POSITION_IN_SIGNED_BEACON_BLOCK = 4 + 4 + (4 + 96) = 108
+ * class SignedBeaconBlockAndBlobsSidecar(Container):
+ *  beaconBlock: SignedBeaconBlock [offset - 4 bytes]
+ *  blobsSidecar: BlobsSidecar,
+ */
+
+/**
+ * Variable size.
+ * class BlobsSidecar(Container):
+ *   beaconBlockRoot: Root,
+ *   beaconBlockSlot: Slot,
+ *   blobs: Blobs,
+ *   kzgAggregatedProof: KZGProof,
+ */
+const SLOT_BYTES_POSITION_IN_SIGNED_BEACON_BLOCK_AND_BLOBS_SIDECAR =
+  VARIABLE_FIELD_OFFSET + VARIABLE_FIELD_OFFSET + SLOT_BYTES_POSITION_IN_SIGNED_BEACON_BLOCK;
+
+export function getSlotFromSignedBeaconBlockAndBlobsSidecarSerialized(data: Uint8Array): Slot | null {
+  if (data.length < SLOT_BYTES_POSITION_IN_SIGNED_BEACON_BLOCK_AND_BLOBS_SIDECAR + SLOT_SIZE) {
+    return null;
+  }
+
+  return getSlotFromOffset(data, SLOT_BYTES_POSITION_IN_SIGNED_BEACON_BLOCK_AND_BLOBS_SIDECAR);
 }
 
 function getSlotFromOffset(data: Uint8Array, offset: number): Slot {

--- a/packages/beacon-node/test/unit/chain/validation/attestation.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation.test.ts
@@ -3,7 +3,7 @@ import {BitArray} from "@chainsafe/ssz";
 import {processSlots} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {IBeaconChain} from "../../../../src/chain/index.js";
-import {AttestationErrorCode, INVALID_SERIALIZED_BYTES_ERROR_CODE} from "../../../../src/chain/errors/index.js";
+import {AttestationErrorCode, GossipErrorCode} from "../../../../src/chain/errors/index.js";
 import {AttestationOrBytes, validateGossipAttestation} from "../../../../src/chain/validation/index.js";
 import {expectRejectedWithLodestarError} from "../../../utils/errors.js";
 import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../state-transition/test/perf/util.js";
@@ -47,7 +47,7 @@ describe("chain / validation / attestation", () => {
       chain,
       {attestation: null, serializedData: Buffer.alloc(0), attSlot: 0},
       subnet,
-      INVALID_SERIALIZED_BYTES_ERROR_CODE
+      GossipErrorCode.INVALID_SERIALIZED_BYTES_ERROR_CODE
     );
   });
 

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -10,6 +10,7 @@ import {
   getSlotFromAttestationSerialized,
   getSlotFromSignedAggregateAndProofSerialized,
   getSignatureFromAttestationSerialized,
+  getSlotFromSignedBeaconBlockSerialized,
 } from "../../../src/util/sszBytes.js";
 
 describe("attestation SSZ serialized picking", () => {
@@ -128,6 +129,24 @@ describe("aggregateAndProof SSZ serialized peaking", () => {
   });
 });
 
+describe("signedBeaconBlock SSZ serialized peaking", () => {
+  const testCases = [ssz.phase0.SignedBeaconBlock.defaultValue(), signedBeaconBlockFromValues(1_000_000)];
+
+  for (const [i, signedBeaconBlock] of testCases.entries()) {
+    const bytes = ssz.phase0.SignedBeaconBlock.serialize(signedBeaconBlock);
+    it(`signedBeaconBlock ${i}`, () => {
+      expect(getSlotFromSignedBeaconBlockSerialized(bytes)).equals(signedBeaconBlock.message.slot);
+    });
+  }
+
+  it("getSlotFromSignedBeaconBlockSerialized - invalid data", () => {
+    const invalidSlotDataSizes = [0, 50, 104];
+    for (const size of invalidSlotDataSizes) {
+      expect(getSlotFromSignedBeaconBlockSerialized(Buffer.alloc(size))).to.be.null;
+    }
+  });
+});
+
 function attestationFromValues(
   slot: Slot,
   blockRoot: RootHex,
@@ -154,4 +173,10 @@ function signedAggregateAndProofFromValues(
   signedAggregateAndProof.message.aggregate.data.target.epoch = targetEpoch;
   signedAggregateAndProof.message.aggregate.data.target.root = fromHex(targetRoot);
   return signedAggregateAndProof;
+}
+
+function signedBeaconBlockFromValues(slot: Slot): phase0.SignedBeaconBlock {
+  const signedBeaconBlock = ssz.phase0.SignedBeaconBlock.defaultValue();
+  signedBeaconBlock.message.slot = slot;
+  return signedBeaconBlock;
 }

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -19,3 +19,4 @@ export enum BlockSource {
 }
 
 export type SlotRootHex = {slot: Slot; root: RootHex};
+export type SlotOptionalRoot = {slot: Slot; root?: RootHex};


### PR DESCRIPTION
**Motivation**

- There are a lot of very old gossiped blocks sent to our node randomly on mainnet, it took our time to deserialize them before we ignore them (since they're known in forkchoice)
- This contributes to our I/O lag issue
- It happened in v1.7 as well but likely more painful in unstable

**Description**

- Check if gossiped blocks are > 32 slots from clock slot, ignore them
- Apply for `beacon_attestation` and `aggregate_and_proof` topic as well (don't apply for sync committee metrics for now since there are not a lot of them and message size is small)
  - For attestation topics, the number of 32 is respective to `ATTESTATION_PROPAGATION_SLOT_RANGE` per spec
  - For gossiped blocks, we only to want to receive gossip blocks in the last 32 slot and have gossipsub seenCache handle the duplicate, also 32 slots = gossip seenCache TTL per spec . Otherwise it'll be handled by our sync services
- Remove `gossipValidationErrorTooManySkippedSlots` metric because we have `gossipValidationError` metric already
- Refactor the api to extract slot from gossiped block serialized data

part of #5393

**Test**

Was able to caught the new `GOSSIP_ERROR_PAST_SLOT` error in the last 3h (this is on a mainnet node)

<img width="806" alt="Screenshot 2023-04-21 at 18 36 12" src="https://user-images.githubusercontent.com/10568965/233626200-f17de94e-0a34-436d-bfe4-c2396477dcc4.png">

