### PR TITLE
Update fastify.listen() method invocations

### DIFF
--- a/packages/api/test/unit/client/httpClient.test.ts
+++ b/packages/api/test/unit/client/httpClient.test.ts
@@ -32,7 +32,7 @@ describe("httpClient json client", () => {
       await server.close();
     });
 
-    return {baseUrl: await server.listen(0)};
+    return {baseUrl: await server.listen({port: 0})};
   }
 
   async function getServerWithClient(opts: RouteOptions): Promise<HttpClient> {

--- a/packages/api/test/utils/utils.ts
+++ b/packages/api/test/utils/utils.ts
@@ -21,7 +21,7 @@ export function getTestServer(): {baseUrl: string; server: FastifyInstance} {
 
   before("start server", async () => {
     await new Promise((resolve, reject) => {
-      server.listen(port, function (err, address) {
+      server.listen({port}, function (err, address) {
         if (err !== null && err != undefined) {
           reject(err);
         } else {

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -1,5 +1,5 @@
 import qs from "qs";
-import fastify, {FastifyError, FastifyInstance} from "fastify";
+import fastify, {FastifyInstance} from "fastify";
 import fastifyCors from "@fastify/cors";
 import bearerAuthPlugin from "@fastify/bearer-auth";
 import {RouteConfig} from "@lodestar/api/beacon/server";
@@ -59,8 +59,8 @@ export class RestApiServer {
 
     // To parse our ApiError -> statusCode
     server.setErrorHandler((err, req, res) => {
-      if ((err as FastifyError).validation) {
-        void res.status(400).send((err as FastifyError).validation);
+      if (err.validation) {
+        void res.status(400).send(err.validation);
       } else {
         // Convert our custom ApiError into status code
         const statusCode = err instanceof ApiError ? err.statusCode : 500;

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -116,7 +116,7 @@ export class RestApiServer {
   async listen(): Promise<void> {
     try {
       const host = this.opts.address;
-      const address = await this.server.listen(this.opts.port, host);
+      const address = await this.server.listen({port: this.opts.port, host});
       this.logger.info("Started REST API server", {address});
       if (!host || !isLocalhostIP(host)) {
         this.logger.warn("REST API server is exposed, ensure untrusted traffic cannot reach this API");

--- a/packages/beacon-node/test/unit/executionEngine/http.test.ts
+++ b/packages/beacon-node/test/unit/executionEngine/http.test.ts
@@ -38,7 +38,7 @@ describe("ExecutionEngine / http", () => {
       await server.close();
     });
 
-    const baseUrl = await server.listen(0);
+    const baseUrl = await server.listen({port: 0});
 
     executionEngine = initializeExecutionEngine(
       {

--- a/packages/beacon-node/test/unit/executionEngine/httpRetry.test.ts
+++ b/packages/beacon-node/test/unit/executionEngine/httpRetry.test.ts
@@ -43,7 +43,7 @@ describe("ExecutionEngine / http ", () => {
       await server.close();
     });
 
-    baseUrl = await server.listen(0);
+    baseUrl = await server.listen({port: 0});
 
     executionEngine = initializeExecutionEngine(
       {

--- a/packages/cli/test/utils/simulation/ExternalSignerServer.ts
+++ b/packages/cli/test/utils/simulation/ExternalSignerServer.ts
@@ -66,7 +66,7 @@ export class ExternalSignerServer {
 
   async start(): Promise<void> {
     console.log(`Starting external signer server at ${this.url}.`);
-    await this.server.listen(this.port, this.address);
+    await this.server.listen({port: this.port, host: this.address});
     console.log(`Started external signer server at ${this.url}.`);
   }
 

--- a/packages/light-client/test/utils/server.ts
+++ b/packages/light-client/test/utils/server.ts
@@ -25,6 +25,6 @@ export async function startServer(
 
   void server.register(fastifyCors, {origin: "*"});
 
-  await server.listen(opts.port, opts.host);
+  await server.listen({port: opts.port, host: opts.host});
   return server;
 }


### PR DESCRIPTION
**Motivation**

With update to Fastify v4 in https://github.com/ChainSafe/lodestar/pull/5369, the following invocations are valid as per [migration guide v4](https://github.com/fastify/fastify/blob/main/docs/Guides/Migration-Guide-V4.md#deprecation-of-variadic-listen-signature):

```
fastify.listen()
fastify.listen({ port: 8000 })
fastify.listen({ port: 8000 }, (err) => { if (err) throw err })
```

Other invocations will show a deprecation warning

```
@deprecated — Variadic listen method is deprecated. Please use .listen(optionsObject) instead. The variadic signature will be removed in fastify@5
```

and create deprecation log

```
(node:6766) [FSTDEP011] FastifyDeprecation: Variadic listen method is deprecated. Please use ".listen(optionsObject)" instead. The variadic signature will be removed in `fastify@5`.
```

See [Fastify v4 GA](https://medium.com/@fastifyjs/fastify-v4-ga-59f2103b5f0e) for further details on what changed with Fastify v4.


**Description**

Updates `fastify.listen()` method invocations, pass options object instead of multiple separate parameters.
