### PR TITLE
Update JSON schema for multiple types to use anyOf

### DIFF
--- a/packages/api/src/utils/schema.ts
+++ b/packages/api/src/utils/schema.ts
@@ -56,9 +56,9 @@ function getJsonSchemaItem(schema: Schema): JsonSchema {
       return {type: "array", items: {type: "string"}};
 
     case Schema.UintOrStringRequired:
-      return {type: ["string", "integer"]};
+      return {anyOf: [{type: "string"}, {type: "integer"}]};
     case Schema.UintOrStringArray:
-      return {type: "array", items: {type: ["string", "integer"]}};
+      return {type: "array", items: {anyOf: [{type: "string"}, {type: "integer"}]}};
 
     case Schema.Object:
       return {type: "object"};


### PR DESCRIPTION
**Motivation**

With update to Fastify v4 in https://github.com/ChainSafe/lodestar/pull/5369, Ajv has been upgraded to v8, meaning "type" keywords with multiple types other than "null" [are now prohibited](https://ajv.js.org/strict-mode.html#strict-types).

This change gets rid of the following warning logs

```
strict mode: use allowUnionTypes to allow union type keyword at "#/properties/id/items" (strictTypes)
strict mode: use allowUnionTypes to allow union type keyword at "#/properties/id/items" (strictTypes)
```

**Description**

Updates JSON schema for multiple types to use `anyOf` as recommended in [Fastify v4 migration guide](https://github.com/fastify/fastify/blob/main/docs/Guides/Migration-Guide-V4.md#change-of-schema-for-multiple-types).
