### PR TITLE
Only call regen.getBlockSlotState() if necessary

### DIFF
--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -10,7 +10,7 @@ import {IExecutionEngine, IExecutionBuilder} from "../execution/index.js";
 import {Metrics} from "../metrics/metrics.js";
 import {BeaconClock} from "./clock/interface.js";
 import {ChainEventEmitter} from "./emitter.js";
-import {IStateRegenerator} from "./regen/index.js";
+import {IStateRegenerator, RegenCaller} from "./regen/index.js";
 import {StateContextCache, CheckpointStateCache} from "./stateCache/index.js";
 import {IBlsVerifier} from "./bls/index.js";
 import {
@@ -105,7 +105,8 @@ export interface IBeaconChain {
   validatorSeenAtEpoch(index: ValidatorIndex, epoch: Epoch): boolean;
 
   getHeadState(): CachedBeaconStateAllForks;
-  getHeadStateAtCurrentEpoch(): Promise<CachedBeaconStateAllForks>;
+  getHeadStateAtCurrentEpoch(regenCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
+  getHeadStateAtEpoch(epoch: Epoch, regenCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
 
   /**
    * Since we can have multiple parallel chains,

--- a/packages/beacon-node/src/chain/regen/interface.ts
+++ b/packages/beacon-node/src/chain/regen/interface.ts
@@ -11,6 +11,7 @@ export enum RegenCaller {
   processBlocksInEpoch = "processBlocksInEpoch",
   validateGossipAggregateAndProof = "validateGossipAggregateAndProof",
   validateGossipAttestation = "validateGossipAttestation",
+  validateGossipVoluntaryExit = "validateGossipVoluntaryExit",
   onForkChoiceFinalized = "onForkChoiceFinalized",
 }
 

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -124,6 +124,12 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     return this.jobQueue.push({key: "getCheckpointState", args: [cp, opts, rCaller]});
   }
 
+  /**
+   * Get state of provided `blockRoot` and dial forward to `slot`
+   * Use this api with care because we don't want the queue to be busy
+   * For the context, gossip block validation uses this api so we want it to be as fast as possible
+   * @returns
+   */
   async getBlockSlotState(
     blockRoot: RootHex,
     slot: Slot,

--- a/packages/beacon-node/src/chain/validation/voluntaryExit.ts
+++ b/packages/beacon-node/src/chain/validation/voluntaryExit.ts
@@ -2,6 +2,7 @@ import {phase0} from "@lodestar/types";
 import {isValidVoluntaryExit, getVoluntaryExitSignatureSet} from "@lodestar/state-transition";
 import {IBeaconChain} from "..";
 import {VoluntaryExitError, VoluntaryExitErrorCode, GossipAction} from "../errors/index.js";
+import {RegenCaller} from "../regen/index.js";
 
 export async function validateGossipVoluntaryExit(
   chain: IBeaconChain,
@@ -22,7 +23,7 @@ export async function validateGossipVoluntaryExit(
   // The voluntaryExit.epoch must be in the past but the validator's status may change in recent epochs.
   // We dial the head state to the current epoch to get the current status of the validator. This is
   // relevant on periods of many skipped slots.
-  const state = await chain.getHeadStateAtCurrentEpoch();
+  const state = await chain.getHeadStateAtCurrentEpoch(RegenCaller.validateGossipVoluntaryExit);
 
   // [REJECT] All of the conditions within process_voluntary_exit pass validation.
   // verifySignature = false, verified in batch below

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -165,6 +165,7 @@ export class MockBeaconChain implements IBeaconChain {
     this.pubkey2index = new PubkeyIndexMap();
     this.index2pubkey = [];
   }
+
   executionBuilder?: IExecutionBuilder | undefined;
 
   validatorSeenAtEpoch(): boolean {
@@ -178,6 +179,10 @@ export class MockBeaconChain implements IBeaconChain {
   }
 
   async getHeadStateAtCurrentEpoch(): Promise<CachedBeaconStateAllForks> {
+    return this.state;
+  }
+
+  async getHeadStateAtEpoch(): Promise<CachedBeaconStateAllForks> {
     return this.state;
   }
 


### PR DESCRIPTION
**Motivation**

- Regen Job Wait Time is sometimes high, see https://github.com/ChainSafe/lodestar/issues/5384
  - For validator_exit gossip message, sometimes it takes up to 4s due to this, see https://github.com/ChainSafe/lodestar/issues/5400 , note that we can validate up to 128 `validator_exit` messages at the same time
  - This api is used by gossip block validation too so we don't want it to be slow

**Description**

- `regen.getBlockSlotState()` always use queue implementation so we use it with care, only call it if necessary
- Modify/add `getHeadStateAtCurrentEpoch()` and `getHeadStateAtEpoch()` apis in chain so it only calls `regen` if necessary, using the `checkpointStateCache` (used inside `getHeadState()`) it'll reach the queue 1 time at most per epoch
- Add RegenCaller for voluntary_exit validation

close #5400
