### PR TITLE
fix: use createSingleSignatureSetFromComponents when validate gossip attestation

### DIFF
--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -7,7 +7,7 @@ import {
   CachedBeaconStateAllForks,
   ISignatureSet,
   getAttestationDataSigningRoot,
-  createAggregateSignatureSetFromComponents,
+  createSingleSignatureSetFromComponents,
 } from "@lodestar/state-transition";
 import {IBeaconChain} from "..";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors/index.js";
@@ -232,15 +232,15 @@ export async function validateGossipAttestation(
 
   if (attestationOrCache.cache) {
     // there could be up to 6% of cpu time to compute signing root if we don't clone the signature set
-    signatureSet = createAggregateSignatureSetFromComponents(
-      attestingIndices.map((i) => chain.index2pubkey[i]),
+    signatureSet = createSingleSignatureSetFromComponents(
+      chain.index2pubkey[validatorIndex],
       attestationOrCache.cache.signingRoot,
       signature
     );
     attDataRootHex = attestationOrCache.cache.attDataRootHex;
   } else {
-    signatureSet = createAggregateSignatureSetFromComponents(
-      attestingIndices.map((i) => chain.index2pubkey[i]),
+    signatureSet = createSingleSignatureSetFromComponents(
+      chain.index2pubkey[validatorIndex],
       getSigningRoot(),
       signature
     );


### PR DESCRIPTION
**Motivation**

Found this along with @dapplion 

<img width="720" alt="Screenshot 2023-04-24 at 14 32 19" src="https://user-images.githubusercontent.com/10568965/233928836-06d52d1c-efe8-4e79-9311-78e366844af3.png">

we should not have to aggregate pubkeys when validating gossip attestations

**Description**

Use `createSingleSignatureSetFromComponents()` when validating gossip attestation to save 0.8% cpu time
