### PR TITLE
fix: prioritize voluntary_exit and bls_to_execution_change topic

### DIFF
--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -45,15 +45,15 @@ const executeGossipWorkOrderObj: Record<GossipType, WorkOpts> = {
   [GossipType.beacon_block]: {bypassQueue: true},
   [GossipType.beacon_block_and_blobs_sidecar]: {bypassQueue: true},
   [GossipType.beacon_aggregate_and_proof]: {},
-  [GossipType.beacon_attestation]: {},
   [GossipType.voluntary_exit]: {},
+  [GossipType.bls_to_execution_change]: {},
+  [GossipType.beacon_attestation]: {},
   [GossipType.proposer_slashing]: {},
   [GossipType.attester_slashing]: {},
   [GossipType.sync_committee_contribution_and_proof]: {},
   [GossipType.sync_committee]: {},
   [GossipType.light_client_finality_update]: {},
   [GossipType.light_client_optimistic_update]: {},
-  [GossipType.bls_to_execution_change]: {},
 };
 const executeGossipWorkOrder = Object.keys(executeGossipWorkOrderObj) as (keyof typeof executeGossipWorkOrderObj)[];
 


### PR DESCRIPTION
**Motivation**

With new gossip validation implementation, `voluntary_exit` and `bls_to_execution_change` may stay in queue for too long which reflect in this metric

<img width="1286" alt="Screenshot 2023-04-24 at 14 37 38" src="https://user-images.githubusercontent.com/10568965/233929998-1f47bb24-a8e1-4e50-87ba-cc388e7048ae.png">

**Description**

Post capella we should prioritize these 2 topics over `beacon_attestation`

this should close #5371 (need to verify)
