### PR TITLE
docs: update contribution.md for conventional commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,13 +96,14 @@ If you are contributing from this repo prefix the branch name with your Github u
 
 Pull request titles must be:
 
+- Adhering to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec
 - Short and descriptive summary
 - Should be capitalized and written in imperative present tense
 - Not end with a period
 
 For example:
 
-> Add Edit on Github button to all the pages
+> feat: Add Edit on Github button to all the pages
 
 **Pull Request Etiquette**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,8 @@ Pull request titles must be:
 
 For example:
 
-> feat: Add Edit on Github button to all the pages
+> feat: add lodestar prover for execution api
+> refactor(reqresp)!: support byte based handlers
 
 **Pull Request Etiquette**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Pull request titles must be:
 
 - Adhering to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec
 - Short and descriptive summary
-- Should be capitalized and written in imperative present tense
+- Written in imperative present tense
 - Not end with a period
 
 For example:


### PR DESCRIPTION
**Motivation**

As of #5342 , we now enforce conventional commits on our PR titles.

**Description**

This PR adds the requirement to `contributions.md` for future contributors.
