### PR TITLE
fix: set gossipsubDHigh as 9

### DIFF
--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -37,5 +37,8 @@ export const defaultNetworkOptions: NetworkOptions = {
   mdns: false,
   discv5: defaultDiscv5Options,
   rateLimitMultiplier: 1,
+  // TODO: this value is 12 per spec, however lodestar has performance issue if there are too many mesh peers
+  // see https://github.com/ChainSafe/lodestar/issues/5420
+  gossipsubDHigh: 9,
   ...defaultGossipHandlerOpts,
 };


### PR DESCRIPTION
**Motivation**

When there are too many mesh peers, gossip block cannot be processed timely, see https://github.com/ChainSafe/lodestar/issues/5420

**Description**

- Set `gossipsubDHigh=9` for now, should work on removing it on upcoming release and keep the issue open

part of #5420