### PR TITLE
docs: fix formatting of examples in PR naming section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,8 +103,9 @@ Pull request titles must be:
 
 For example:
 
-> feat: add lodestar prover for execution api
-> refactor(reqresp)!: support byte based handlers
+- feat: add lodestar prover for execution api
+- fix: ignore known block in publish blinded block flow
+- refactor(reqresp)!: support byte based handlers
 
 **Pull Request Etiquette**
 


### PR DESCRIPTION
**Motivation**

Current formatting of examples
![image](https://user-images.githubusercontent.com/38436224/235118558-2e154e16-3588-416a-9bc9-bb490a8fba3e.png)

**Description**

Fix formatting, add `fix:` example

cc @philknows 