### PR TITLE
fix: update builder mergemock sim with builder block assertions

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -149,7 +149,7 @@ export async function produceBlockBody<T extends BlockType>(
       // This path will not be used in the production, but is here just for merge mock
       // tests because merge-mock requires an fcU to be issued prior to fetch payload
       // header.
-      if (this.executionBuilder.issueLocalFcUForBlockProduction) {
+      if (this.executionBuilder.issueLocalFcUWithFeeRecipient !== undefined) {
         await prepareExecutionPayload(
           this,
           this.logger,
@@ -157,7 +157,7 @@ export async function produceBlockBody<T extends BlockType>(
           safeBlockHash,
           finalizedBlockHash ?? ZERO_HASH_HEX,
           currentState as CachedBeaconStateBellatrix,
-          feeRecipient
+          this.executionBuilder.issueLocalFcUWithFeeRecipient
         );
       }
 

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -17,7 +17,7 @@ export type ExecutionBuilderHttpOpts = {
   allowedFaults?: number;
 
   // Only required for merge-mock runs, no need to expose it to cli
-  issueLocalFcUForBlockProduction?: boolean;
+  issueLocalFcUWithFeeRecipient?: string;
   // Add User-Agent header to all requests
   userAgent?: string;
 };
@@ -31,7 +31,7 @@ export const defaultExecutionBuilderHttpOpts: ExecutionBuilderHttpOpts = {
 export class ExecutionBuilderHttp implements IExecutionBuilder {
   readonly api: BuilderApi;
   readonly config: ChainForkConfig;
-  readonly issueLocalFcUForBlockProduction?: boolean;
+  readonly issueLocalFcUWithFeeRecipient?: string;
   // Builder needs to be explicity enabled using updateStatus
   status = false;
   faultInspectionWindow: number;
@@ -49,7 +49,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
       {config, metrics: metrics?.builderHttpClient}
     );
     this.config = config;
-    this.issueLocalFcUForBlockProduction = opts.issueLocalFcUForBlockProduction;
+    this.issueLocalFcUWithFeeRecipient = opts.issueLocalFcUWithFeeRecipient;
 
     /**
      * Beacon clients select randomized values from the following ranges when initializing

--- a/packages/beacon-node/src/execution/builder/interface.ts
+++ b/packages/beacon-node/src/execution/builder/interface.ts
@@ -6,7 +6,7 @@ export interface IExecutionBuilder {
    * an advance fcU to be issued to the engine port before payload header
    * fetch
    */
-  readonly issueLocalFcUForBlockProduction?: boolean;
+  readonly issueLocalFcUWithFeeRecipient?: string;
   status: boolean;
   /** Window to inspect missed slots for enabling/disabling builder circuit breaker */
   faultInspectionWindow: number;

--- a/packages/beacon-node/test/sim/mergemock.test.ts
+++ b/packages/beacon-node/test/sim/mergemock.test.ts
@@ -206,7 +206,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     let builderBlocks = 0;
     await new Promise<void>((resolve, _reject) => {
       bn.chain.emitter.on(routes.events.EventType.block, async (blockData) => {
-        const {data: fullOrBlindedBlock} = (await bn.api.beacon.getBlockV2(blockData.block).catch((_e) => null)) ?? {};
+        const {data: fullOrBlindedBlock} = await bn.api.beacon.getBlockV2(blockData.block);
         if (fullOrBlindedBlock !== undefined) {
           const blockFeeRecipient = toHexString(
             (fullOrBlindedBlock as bellatrix.SignedBeaconBlock).message.body.executionPayload.feeRecipient
@@ -255,13 +255,15 @@ describe("executionEngine / ExecutionEngineHttp", function () {
       );
     }
 
-    // 2. builder and engine blocks are as expected
-    if (builderBlocks < expectedBuilderBlocks || engineBlocks < expectedEngineBlocks) {
-      throw Error(
-        `Incorrect builderBlocks=${builderBlocks} (expected=${expectedBuilderBlocks}) or engineBlocks=${engineBlocks} (expected=${expectedEngineBlocks})`
-      );
+    // 2. builder blocks are as expected
+    if (builderBlocks < expectedBuilderBlocks) {
+      throw Error(`Incorrect builderBlocks=${builderBlocks} (expected=${expectedBuilderBlocks})`);
     }
-    console.log({engineBlocks, builderBlocks});
+
+    // 3. engine blocks are as expected
+    if (engineBlocks < expectedEngineBlocks) {
+      throw Error(`Incorrect engineBlocks=${engineBlocks} (expected=${expectedEngineBlocks})`);
+    }
 
     // wait for 1 slot to print current epoch stats
     await sleep(1 * bn.config.SECONDS_PER_SLOT * 1000);

--- a/packages/beacon-node/test/sim/mergemock.test.ts
+++ b/packages/beacon-node/test/sim/mergemock.test.ts
@@ -104,6 +104,12 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     const expectedBuilderBlocks = 12;
     const expectedEngineBlocks = 12;
 
+    // All assertions are tracked w.r.t. fee recipient by attaching different fee recipient to
+    // execution and builder
+    const feeRecipientLocal = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const feeRecipientEngine = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const feeRecipientMevBoost = "0xcccccccccccccccccccccccccccccccccccccccc";
+
     // delay a bit so regular sync sees it's up to date and sync is completed from the beginning
     const genesisSlotsDelay = 8;
 
@@ -145,11 +151,11 @@ describe("executionEngine / ExecutionEngineHttp", function () {
         executionBuilder: {
           urls: [ethRpcUrl],
           enabled: true,
-          issueLocalFcUWithFeeRecipient: "0xcccccccccccccccccccccccccccccccccccccccc",
+          issueLocalFcUWithFeeRecipient: feeRecipientMevBoost,
           allowedFaults: 16,
           faultInspectionWindow: 32,
         },
-        chain: {suggestedFeeRecipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+        chain: {suggestedFeeRecipient: feeRecipientLocal},
       },
       validatorCount: validatorClientCount * validatorsPerClient,
       logger: loggerNodeA,
@@ -172,7 +178,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
       defaultConfig: {
         graffiti: "default graffiti",
         strictFeeRecipientCheck: true,
-        feeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        feeRecipient: feeRecipientEngine,
         builder: {
           enabled: true,
           gasLimit: 30000000,
@@ -205,7 +211,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
           const blockFeeRecipient = toHexString(
             (fullOrBlindedBlock as bellatrix.SignedBeaconBlock).message.body.executionPayload.feeRecipient
           );
-          if (blockFeeRecipient === "0xcccccccccccccccccccccccccccccccccccccccc") {
+          if (blockFeeRecipient === feeRecipientMevBoost) {
             builderBlocks++;
           } else {
             engineBlocks++;
@@ -227,7 +233,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     await bn.close();
     await sleep(500);
 
-    if (bn.chain.beaconProposerCache.get(1) !== "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+    if (bn.chain.beaconProposerCache.get(1) !== feeRecipientEngine) {
       throw Error("Invalid feeRecipient set at BN");
     }
 


### PR DESCRIPTION
Previously builder sim was running without any validations.

Modified the mergemock builder interaction to enable differentiating by fee recipient and use that to add engine and builder block assertions