### PR TITLE
fix(validator)!: align db metric names with other metrics

### DIFF
--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -4369,7 +4369,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": false,
-              "expr": "validator_db_size_bytes_total",
+              "expr": "vc_db_size_bytes_total",
               "interval": "",
               "legendFormat": "db size",
               "refId": "A"
@@ -4478,7 +4478,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "rate(validator_db_approximate_size_time_seconds_sum[$rate_interval])\r\n/\r\nrate(validator_db_approximate_size_time_seconds_count[$rate_interval])",
+              "expr": "rate(vc_db_approximate_size_time_seconds_sum[$rate_interval])\r\n/\r\nrate(vc_db_approximate_size_time_seconds_count[$rate_interval])",
               "hide": false,
               "legendFormat": "{{job}}",
               "range": true,

--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -396,31 +396,31 @@ export function getMetrics(register: MetricsRegister, gitData: LodestarGitData) 
 
     db: {
       dbReadReq: register.gauge<{bucket: string}>({
-        name: "validator_db_read_req_total",
+        name: "vc_db_read_req_total",
         help: "Total count of db read requests, may read 0 or more items",
         labelNames: ["bucket"],
       }),
       dbReadItems: register.gauge<{bucket: string}>({
-        name: "validator_db_read_items_total",
+        name: "vc_db_read_items_total",
         help: "Total count of db read items, item = key | value | entry",
         labelNames: ["bucket"],
       }),
       dbWriteReq: register.gauge<{bucket: string}>({
-        name: "validator_db_write_req_total",
+        name: "vc_db_write_req_total",
         help: "Total count of db write requests, may write 0 or more items",
         labelNames: ["bucket"],
       }),
       dbWriteItems: register.gauge<{bucket: string}>({
-        name: "validator_db_write_items_total",
+        name: "vc_db_write_items_total",
         help: "Total count of db write items",
         labelNames: ["bucket"],
       }),
       dbSizeTotal: register.gauge({
-        name: "validator_db_size_bytes_total",
+        name: "vc_db_size_bytes_total",
         help: "Approximate number of bytes of file system space used by db",
       }),
       dbApproximateSizeTime: register.histogram({
-        name: "validator_db_approximate_size_time_seconds",
+        name: "vc_db_approximate_size_time_seconds",
         help: "Time to approximate db size in seconds",
         buckets: [0.0001, 0.001, 0.01, 0.1, 1],
       }),


### PR DESCRIPTION
**Motivation**

Rename metric names to improve consistency.

**Description**

Renamed validator db metrics to be more inline with other validator metrics, those metrics now use `vc_` as prefix instead of `validator_`.

This is a breaking change to the metrics but I am assuming that there are no external dashboards that consume these metrics and therefore should be fine to change the name now. Still tagging as breaking change.

**Note:** Those metrics were introduced in https://github.com/ChainSafe/lodestar/pull/4121 but I don't think using `validator_` as prefix was intentional.
