### PR TITLE
fix(slashing-protection): filter by db bucket when loading pubkeys

### DIFF
--- a/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
+++ b/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
@@ -45,10 +45,10 @@ export class AttestationByTargetRepository {
 
   async getAll(pubkey: BLSPubkey, limit?: number): Promise<SlashingProtectionAttestation[]> {
     const attestations = await this.db.values({
-      ...this.dbReqOpts,
       limit,
       gte: this.encodeKey(pubkey, 0),
       lt: this.encodeKey(pubkey, Number.MAX_SAFE_INTEGER),
+      bucketId: this.bucketId,
     });
     return attestations.map((attestation) => this.type.deserialize(attestation));
   }
@@ -69,7 +69,7 @@ export class AttestationByTargetRepository {
   }
 
   async listPubkeys(): Promise<BLSPubkey[]> {
-    const keys = await this.db.keys({...this.dbReqOpts, gte: this.minKey, lt: this.maxKey});
+    const keys = await this.db.keys({gte: this.minKey, lt: this.maxKey, bucketId: this.bucketId});
     return uniqueVectorArr(keys.map((key) => this.decodeKey(key).pubkey));
   }
 

--- a/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
+++ b/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
@@ -27,6 +27,9 @@ export class AttestationByTargetRepository {
   private readonly bucketId: string;
   private readonly dbReqOpts: DbReqOpts;
 
+  private readonly minKey: Uint8Array;
+  private readonly maxKey: Uint8Array;
+
   constructor(opts: DatabaseApiOptions) {
     this.db = opts.controller;
     this.type = new ContainerType({
@@ -36,6 +39,8 @@ export class AttestationByTargetRepository {
     }); // casing doesn't matter
     this.bucketId = getBucketNameByValue(this.bucket);
     this.dbReqOpts = {bucketId: this.bucketId};
+    this.minKey = encodeKey(this.bucket, Buffer.alloc(0));
+    this.maxKey = encodeKey(this.bucket + 1, Buffer.alloc(0));
   }
 
   async getAll(pubkey: BLSPubkey, limit?: number): Promise<SlashingProtectionAttestation[]> {
@@ -64,7 +69,7 @@ export class AttestationByTargetRepository {
   }
 
   async listPubkeys(): Promise<BLSPubkey[]> {
-    const keys = await this.db.keys(this.dbReqOpts);
+    const keys = await this.db.keys({...this.dbReqOpts, gte: this.minKey, lt: this.maxKey});
     return uniqueVectorArr(keys.map((key) => this.decodeKey(key).pubkey));
   }
 

--- a/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
+++ b/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
@@ -44,10 +44,10 @@ export class BlockBySlotRepository {
 
   async getAll(pubkey: BLSPubkey, limit?: number): Promise<SlashingProtectionBlock[]> {
     const blocks = await this.db.values({
-      ...this.dbReqOpts,
       limit,
       gte: this.encodeKey(pubkey, 0),
       lt: this.encodeKey(pubkey, Number.MAX_SAFE_INTEGER),
+      bucketId: this.bucketId,
     });
     return blocks.map((block) => this.type.deserialize(block));
   }
@@ -73,7 +73,7 @@ export class BlockBySlotRepository {
   }
 
   async listPubkeys(): Promise<BLSPubkey[]> {
-    const keys = await this.db.keys({...this.dbReqOpts, gte: this.minKey, lt: this.maxKey});
+    const keys = await this.db.keys({gte: this.minKey, lt: this.maxKey, bucketId: this.bucketId});
     return uniqueVectorArr(keys.map((key) => this.decodeKey(key).pubkey));
   }
 

--- a/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
+++ b/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
@@ -27,6 +27,9 @@ export class BlockBySlotRepository {
   private readonly bucketId: string;
   private readonly dbReqOpts: DbReqOpts;
 
+  private readonly minKey: Uint8Array;
+  private readonly maxKey: Uint8Array;
+
   constructor(opts: DatabaseApiOptions) {
     this.db = opts.controller;
     this.type = new ContainerType({
@@ -35,6 +38,8 @@ export class BlockBySlotRepository {
     }); // casing doesn't matter
     this.bucketId = getBucketNameByValue(this.bucket);
     this.dbReqOpts = {bucketId: this.bucketId};
+    this.minKey = encodeKey(this.bucket, Buffer.alloc(0));
+    this.maxKey = encodeKey(this.bucket + 1, Buffer.alloc(0));
   }
 
   async getAll(pubkey: BLSPubkey, limit?: number): Promise<SlashingProtectionBlock[]> {
@@ -68,7 +73,7 @@ export class BlockBySlotRepository {
   }
 
   async listPubkeys(): Promise<BLSPubkey[]> {
-    const keys = await this.db.keys(this.dbReqOpts);
+    const keys = await this.db.keys({...this.dbReqOpts, gte: this.minKey, lt: this.maxKey});
     return uniqueVectorArr(keys.map((key) => this.decodeKey(key).pubkey));
   }
 


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/4261

**Description**

Applies min-max key filter to db query to only get pubkeys from bucket used by repository. The OOM mentioned in https://github.com/ChainSafe/lodestar/issues/4261 was caused by a combination of https://github.com/ChainSafe/lodestar/issues/5356 (causing the db state to be quite huge) and the db query not applying any filtering.

**Note:** There is currently no limit on how many attestation are stored in the db. In some extrem cases could still run into OOM issues. This is likely only relevant for big operators that run many validators but pruning strategy for attestation would be something useful to implement in the future.

https://github.com/ChainSafe/lodestar/blob/f0dec8c89957ef0653bb40e3a969750db8d0a869/packages/validator/src/slashingProtection/attestation/index.ts#L46

Other solution that can be implemented is to provide the option to just export the slashing protection for a subset of validators

https://github.com/ChainSafe/lodestar/blob/f0dec8c89957ef0653bb40e3a969750db8d0a869/packages/cli/src/cmds/validator/slashingProtection/export.ts#L49

Depends on https://github.com/ChainSafe/lodestar/pull/5436 to be merged first to avoid conflicts.