### PR TITLE
fix: fix archiver's cleanup of non checkpoint roots

### DIFF
--- a/packages/beacon-node/src/chain/archiver/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiver/archiveBlocks.ts
@@ -223,7 +223,7 @@ export function getNonCheckpointBlocks<T extends {slot: Slot}>(blocks: T[]): T[]
   // This function must return only blocks that are guaranteed to never become checkpoints.
   let epochPtrHasFirstSlot = false;
 
-  // blocks order: from child to ancestor, increasing slot
+  // blocks order: from child to ancestor, decreasing slot
   for (let i = 0; i < blocks.length; i++) {
     let isCheckpoint = false;
     const block = blocks[i];

--- a/packages/beacon-node/src/chain/archiver/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiver/archiveBlocks.ts
@@ -202,8 +202,8 @@ export function getParentRootFromSignedBlock(bytes: Uint8Array): Uint8Array {
 
 /**
  *
- * @param blocks sequence of linear blocks, from ancestor to child.
- * In ProtoArray.getAllAncestorNodes child nodes are pushed to the returned array.
+ * @param blocks sequence of linear blocks, from child to ancestor.
+ * In ProtoArray.getAllAncestorNodes child nodes are pushed first to the returned array.
  */
 export function getNonCheckpointBlocks<T extends {slot: Slot}>(blocks: T[]): T[] {
   // Iterate from lowest child to highest ancestor
@@ -223,9 +223,8 @@ export function getNonCheckpointBlocks<T extends {slot: Slot}>(blocks: T[]): T[]
   // This function must return only blocks that are guaranteed to never become checkpoints.
   let epochPtrHasFirstSlot = false;
 
-  // blocks order: from ancestor to child, increasing slot
-  // Iterate in reverse: from child to ancestor, decreasing slot
-  for (let i = blocks.length - 1; i >= 0; i--) {
+  // blocks order: from child to ancestor, increasing slot
+  for (let i = 0; i < blocks.length; i++) {
     let isCheckpoint = false;
     const block = blocks[i];
     const blockEpoch = computeEpochAtSlot(block.slot);

--- a/packages/beacon-node/test/unit/chain/archive/nonCheckpoint.test.ts
+++ b/packages/beacon-node/test/unit/chain/archive/nonCheckpoint.test.ts
@@ -32,7 +32,9 @@ describe("chain / archive / getNonCheckpointBlocks", () => {
       const checkpointBlocksSet = new Set(checkpointBlocks);
       const nonAncestorSlots = blocks.filter((slot) => !checkpointBlocksSet.has(slot));
 
-      const nonAncestorBlocks = getNonCheckpointBlocks(blocks.map(toProtoBlock));
+      // blocks are to be passed in reverse order as thats how they would be recieved in
+      // ProtoArray.getAllAncestorNodes
+      const nonAncestorBlocks = getNonCheckpointBlocks(blocks.reverse().map(toProtoBlock));
 
       expect(sort(nonAncestorBlocks.map((block) => block.slot))).to.deep.equal(sort(nonAncestorSlots));
     });


### PR DESCRIPTION
Archiver's `getNonCheckpointBlocks` assumed ancestor to child order of blocks input (`increasing slot`) and then iterated in reverse to find the non checkpoint slots from new finalized checkpoint's ancestors obtained via 
```typescript
  const finalizedCanonicalBlocks = forkChoice.getAllAncestorBlocks(finalizedCheckpoint.rootHex);
```


However `getAllAncestorBlocks` returns data in child to ancestor i.e. `decreasing slot`. This leads to incorrect calculation of the non checkpoint roots (which included actual checkpoint roots which are not perfectly aligned with epoch boundary) which lead to errors like this 

- https://github.com/ChainSafe/lodestar/issues/4183
- https://github.com/ChainSafe/lodestar/issues/5129

As checkpointed data gets incorrectly pruned out  for these non perfectly epoch boundary aligned checkpoints.

Closes #4183, Closes #5129

