### PR TITLE
refactor!: drop MetadataController dependency on BeaconChain

### DIFF
--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -71,7 +71,7 @@ describe("AttnetsService", function () {
     });
     // load getCurrentSlot first, vscode not able to debug without this
     getCurrentSlot(config, Math.floor(Date.now() / 1000));
-    metadata = new MetadataController({}, {config, chain, logger});
+    metadata = new MetadataController(config);
     service = new AttnetsService(config, chain, gossipStub, metadata, logger, null, {
       randBetweenFn,
       shuffleFn: shuffleFn as ShuffleFn,


### PR DESCRIPTION
**Motivation**

- From https://github.com/ChainSafe/lodestar/pull/5351, remove unnecessary dependency of MetadataController that complicates its use

**Description**

Drop MetadataController dependency on BeaconChain
