### PR TITLE
fix: set maxGossipTopicConcurrency to 512

### DIFF
--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -40,5 +40,8 @@ export const defaultNetworkOptions: NetworkOptions = {
   // TODO: this value is 12 per spec, however lodestar has performance issue if there are too many mesh peers
   // see https://github.com/ChainSafe/lodestar/issues/5420
   gossipsubDHigh: 9,
+  // TODO: with this value, lodestar drops about 35% of attestation messages on a test mainnet node subscribed to all subnets
+  // see https://github.com/ChainSafe/lodestar/issues/5441
+  maxGossipTopicConcurrency: 512,
   ...defaultGossipHandlerOpts,
 };


### PR DESCRIPTION
**Motivation**

Make "till become head" comparable to the test mainnet node in stable group so that we can release v1.8.0

**Description**

- Set maxGossipTopicConcurrency to 512
- Open https://github.com/ChainSafe/lodestar/issues/5441, will keep this issue open and work on it in the next release

12h chart after 44h

feat2

<img width="1451" alt="Screenshot 2023-05-01 at 16 47 24" src="https://user-images.githubusercontent.com/10568965/235436909-829f7076-621e-47d4-b5e0-77c6615d60d1.png">
<img width="1347" alt="Screenshot 2023-05-01 at 16 48 33" src="https://user-images.githubusercontent.com/10568965/235437008-a0c7c4fc-3aa3-42f9-90df-66b5fc9435ef.png">

stable

<img width="1466" alt="Screenshot 2023-05-01 at 16 48 00" src="https://user-images.githubusercontent.com/10568965/235436953-f6349e3d-980a-48f5-bbd1-cd27781eaaa7.png">

<img width="1309" alt="Screenshot 2023-05-01 at 16 48 48" src="https://user-images.githubusercontent.com/10568965/235437041-f56d3f75-1ada-4639-aff4-8e9540f8f7f3.png">

