### PR TITLE
refactor!: move network core metrics to separate file

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -13,10 +13,6 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
     // From https://github.com/ethereum/beacon-metrics/blob/master/metrics.md
     // Interop-metrics
 
-    peers: register.gauge({
-      name: "libp2p_peers",
-      help: "number of connected peers",
-    }),
     headSlot: register.gauge({
       name: "beacon_head_slot",
       help: "slot of the head block of the beacon chain",
@@ -94,14 +90,6 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       help: "Histogram of distance to parent block of valid imported blocks",
       buckets: [1, 2, 3, 5, 7, 10, 20, 30, 50, 100],
     }),
-
-    reqResp: {
-      rateLimitErrors: register.gauge<"method">({
-        name: "beacon_reqresp_rate_limiter_errors_total",
-        help: "Count rate limiter errors",
-        labelNames: ["method"],
-      }),
-    },
 
     blockProductionTime: register.histogram<"source">({
       name: "beacon_block_production_seconds",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -32,252 +32,62 @@ export function createLodestarMetrics(
   }
 
   return {
-    // Peers
-
-    peersByDirection: register.gauge<"direction">({
-      name: "lodestar_peers_by_direction_count",
-      help: "number of peers, labeled by direction",
-      labelNames: ["direction"],
-    }),
-    peersByClient: register.gauge<"client">({
-      name: "lodestar_peers_by_client_count",
-      help: "number of peers, labeled by client",
-      labelNames: ["client"],
-    }),
-    peerLongLivedAttnets: register.histogram({
-      name: "lodestar_peer_long_lived_attnets_count",
-      help: "Histogram of current count of long lived attnets of connected peers",
-      buckets: [0, 4, 16, 32, 64],
-    }),
-    peerScoreByClient: register.histogram<"client">({
-      name: "lodestar_app_peer_score",
-      help: "Current peer score at lodestar app side",
-      // Min score = -100, max score = 100, disconnect = -20, ban = -50
-      buckets: [-100, -50, -20, 0, 25],
-      labelNames: ["client"],
-    }),
-    peerConnectionLength: register.histogram({
-      name: "lodestar_peer_connection_seconds",
-      help: "Current peer connection length in second",
-      // Have good resolution on shorter times. After 1 day, don't count any longer
-      //        5s 20s 1m  3m   10m  30m   1h    6h     24h
-      buckets: [5, 20, 60, 180, 600, 1200, 3600, 21600, 86400],
-    }),
-    peersSync: register.gauge({
-      name: "lodestar_peers_sync_count",
-      help: "Current count of peers useful for sync",
-    }),
-    peerConnectedEvent: register.gauge<"direction" | "status">({
-      name: "lodestar_peer_connected_total",
-      help: "Total number of peer:connected event, labeled by direction",
-      labelNames: ["direction", "status"],
-    }),
-    peerDisconnectedEvent: register.gauge<"direction">({
-      name: "lodestar_peer_disconnected_total",
-      help: "Total number of peer:disconnected event, labeled by direction",
-      labelNames: ["direction"],
-    }),
-    peerGoodbyeReceived: register.gauge<"reason">({
-      name: "lodestar_peer_goodbye_received_total",
-      help: "Total number of goodbye received, labeled by reason",
-      labelNames: ["reason"],
-    }),
-    peerLongConnectionDisconnect: register.gauge<"reason">({
-      name: "lodestar_peer_long_connection_disconnect_total",
-      help: "For peers with long connection, track disconnect reason",
-      labelNames: ["reason"],
-    }),
-    peerGoodbyeSent: register.gauge<"reason">({
-      name: "lodestar_peer_goodbye_sent_total",
-      help: "Total number of goodbye sent, labeled by reason",
-      labelNames: ["reason"],
-    }),
-    peersRequestedToConnect: register.gauge({
-      name: "lodestar_peers_requested_total_to_connect",
-      help: "Prioritization results total peers count requested to connect",
-    }),
-    peersRequestedToDisconnect: register.gauge<"reason">({
-      name: "lodestar_peers_requested_total_to_disconnect",
-      help: "Prioritization results total peers count requested to disconnect",
-      labelNames: ["reason"],
-    }),
-    peersRequestedSubnetsToQuery: register.gauge<"type">({
-      name: "lodestar_peers_requested_total_subnets_to_query",
-      help: "Prioritization results total subnets to query and discover peers in",
-      labelNames: ["type"],
-    }),
-    peersRequestedSubnetsPeerCount: register.gauge<"type">({
-      name: "lodestar_peers_requested_total_subnets_peers_count",
-      help: "Prioritization results total peers in subnets to query and discover peers in",
-      labelNames: ["type"],
-    }),
-    peersReportPeerCount: register.gauge<"reason">({
-      name: "lodestar_peers_report_peer_count",
-      help: "network.reportPeer count by reason",
-      labelNames: ["reason"],
-    }),
-    peerManager: {
-      heartbeatDuration: register.histogram({
-        name: "lodestar_peer_manager_heartbeat_duration_seconds",
-        help: "Peer manager heartbeat function duration in seconds",
-        buckets: [0.001, 0.01, 0.1, 1],
+    gossipValidationQueue: {
+      length: register.gauge<"topic">({
+        name: "lodestar_gossip_validation_queue_length",
+        help: "Count of total gossip validation queue length",
+        labelNames: ["topic"],
+      }),
+      dropRatio: register.gauge<"topic">({
+        name: "lodestar_gossip_validation_queue_current_drop_ratio",
+        help: "Current drop ratio of gossip validation queue",
+        labelNames: ["topic"],
+      }),
+      droppedJobs: register.gauge<"topic">({
+        name: "lodestar_gossip_validation_queue_dropped_jobs_total",
+        help: "Count of total gossip validation queue dropped jobs",
+        labelNames: ["topic"],
+      }),
+      jobTime: register.histogram<"topic">({
+        name: "lodestar_gossip_validation_queue_job_time_seconds",
+        help: "Time to process gossip validation queue job in seconds",
+        labelNames: ["topic"],
+        buckets: [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
+      }),
+      jobWaitTime: register.histogram<"topic">({
+        name: "lodestar_gossip_validation_queue_job_wait_time_seconds",
+        help: "Time from job added to the queue to starting the job in seconds",
+        labelNames: ["topic"],
+        buckets: [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
+      }),
+      concurrency: register.gauge<"topic">({
+        name: "lodestar_gossip_validation_queue_concurrency",
+        help: "Current count of jobs being run on network processor for topic",
+        labelNames: ["topic"],
       }),
     },
-
-    discovery: {
-      peersToConnect: register.gauge({
-        name: "lodestar_discovery_peers_to_connect",
-        help: "Current peers to connect count from discoverPeers requests",
-      }),
-      cachedENRsSize: register.gauge({
-        name: "lodestar_discovery_cached_enrs_size",
-        help: "Current size of the cachedENRs Set",
-      }),
-      findNodeQueryRequests: register.gauge<"action">({
-        name: "lodestar_discovery_find_node_query_requests_total",
-        help: "Total count of find node queries started",
-        labelNames: ["action"],
-      }),
-      findNodeQueryTime: register.histogram({
-        name: "lodestar_discovery_find_node_query_time_seconds",
-        help: "Time to complete a find node query in seconds in seconds",
-        buckets: [5, 60],
-      }),
-      findNodeQueryEnrCount: register.gauge({
-        name: "lodestar_discovery_find_node_query_enrs_total",
-        help: "Total count of found ENRs in queries",
-      }),
-      discoveredStatus: register.gauge<"status">({
-        name: "lodestar_discovery_discovered_status_total_count",
-        help: "Total count of status results of PeerDiscovery.onDiscovered() function",
-        labelNames: ["status"],
-      }),
-      dialAttempts: register.gauge({
-        name: "lodestar_discovery_total_dial_attempts",
-        help: "Total dial attempts by peer discovery",
-      }),
-      dialTime: register.histogram<"status">({
-        name: "lodestar_discovery_dial_time_seconds",
-        help: "Time to dial peers in seconds",
-        labelNames: ["status"],
-        buckets: [0.1, 5, 60],
-      }),
-    },
-
-    gossipPeer: {
-      scoreByThreshold: register.gauge<"threshold">({
-        name: "lodestar_gossip_peer_score_by_threshold_count",
-        help: "Gossip peer score by threshold",
-        labelNames: ["threshold"],
-      }),
-      meshPeersByClient: register.gauge<"client">({
-        name: "lodestar_gossip_mesh_peers_by_client_count",
-        help: "number of mesh peers, labeled by client",
-        labelNames: ["client"],
-      }),
-      scoreByClient: register.histogram<"client">({
-        name: "lodestar_gossip_score_by_client",
-        help: "Gossip peer score by client",
-        labelNames: ["client"],
-        // based on gossipScoreThresholds and negativeGossipScoreIgnoreThreshold
-        buckets: [-16000, -8000, -4000, -1000, 0, 5, 100],
-      }),
-      score: register.avgMinMax({
-        name: "lodestar_gossip_score_avg_min_max",
-        help: "Avg min max of all gossip peer scores",
-      }),
-    },
-    gossipMesh: {
-      peersByType: register.gauge<"type" | "fork">({
-        name: "lodestar_gossip_mesh_peers_by_type_count",
-        help: "Number of connected mesh peers per gossip type",
-        labelNames: ["type", "fork"],
-      }),
-      peersByBeaconAttestationSubnet: register.gauge<"subnet" | "fork">({
-        name: "lodestar_gossip_mesh_peers_by_beacon_attestation_subnet_count",
-        help: "Number of connected mesh peers per beacon attestation subnet",
-        labelNames: ["subnet", "fork"],
-      }),
-      peersBySyncCommitteeSubnet: register.gauge<"subnet" | "fork">({
-        name: "lodestar_gossip_mesh_peers_by_sync_committee_subnet_count",
-        help: "Number of connected mesh peers per sync committee subnet",
-        labelNames: ["subnet", "fork"],
-      }),
-    },
-    gossipTopic: {
-      peersByType: register.gauge<"type" | "fork">({
-        name: "lodestar_gossip_topic_peers_by_type_count",
-        help: "Number of connected topic peers per gossip type",
-        labelNames: ["type", "fork"],
-      }),
-      peersByBeaconAttestationSubnet: register.gauge<"subnet" | "fork">({
-        name: "lodestar_gossip_topic_peers_by_beacon_attestation_subnet_count",
-        help: "Number of connected topic peers per beacon attestation subnet",
-        labelNames: ["subnet", "fork"],
-      }),
-      peersBySyncCommitteeSubnet: register.gauge<"subnet" | "fork">({
-        name: "lodestar_gossip_topic_peers_by_sync_committee_subnet_count",
-        help: "Number of connected topic peers per sync committee subnet",
-        labelNames: ["subnet", "fork"],
-      }),
-    },
-
-    gossipValidationAccept: register.gauge<"topic">({
-      name: "lodestar_gossip_validation_accept_total",
-      help: "Count of total gossip validation accept",
-      labelNames: ["topic"],
-    }),
-    gossipValidationIgnore: register.gauge<"topic">({
-      name: "lodestar_gossip_validation_ignore_total",
-      help: "Count of total gossip validation ignore",
-      labelNames: ["topic"],
-    }),
-    gossipValidationReject: register.gauge<"topic">({
-      name: "lodestar_gossip_validation_reject_total",
-      help: "Count of total gossip validation reject",
-      labelNames: ["topic"],
-    }),
-    gossipValidationError: register.gauge<"topic" | "error">({
-      name: "lodestar_gossip_validation_error_total",
-      help: "Count of total gossip validation errors detailed",
-      labelNames: ["topic", "error"],
-    }),
-
-    gossipValidationQueueLength: register.gauge<"topic">({
-      name: "lodestar_gossip_validation_queue_length",
-      help: "Count of total gossip validation queue length",
-      labelNames: ["topic"],
-    }),
-
-    gossipValidationQueueDropRatio: register.gauge<"topic">({
-      name: "lodestar_gossip_validation_queue_current_drop_ratio",
-      help: "Current drop ratio of gossip validation queue",
-      labelNames: ["topic"],
-    }),
-    gossipValidationQueueDroppedJobs: register.gauge<"topic">({
-      name: "lodestar_gossip_validation_queue_dropped_jobs_total",
-      help: "Count of total gossip validation queue dropped jobs",
-      labelNames: ["topic"],
-    }),
-    gossipValidationQueueJobTime: register.histogram<"topic">({
-      name: "lodestar_gossip_validation_queue_job_time_seconds",
-      help: "Time to process gossip validation queue job in seconds",
-      labelNames: ["topic"],
-      buckets: [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
-    }),
-    gossipValidationQueueJobWaitTime: register.histogram<"topic">({
-      name: "lodestar_gossip_validation_queue_job_wait_time_seconds",
-      help: "Time from job added to the queue to starting the job in seconds",
-      labelNames: ["topic"],
-      buckets: [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10],
-    }),
-    gossipValidationQueueConcurrency: register.gauge<"topic">({
-      name: "lodestar_gossip_validation_queue_concurrency",
-      help: "Current count of jobs being run on network processor for topic",
-      labelNames: ["topic"],
-    }),
 
     networkProcessor: {
+      gossipValidationAccept: register.gauge<"topic">({
+        name: "lodestar_gossip_validation_accept_total",
+        help: "Count of total gossip validation accept",
+        labelNames: ["topic"],
+      }),
+      gossipValidationIgnore: register.gauge<"topic">({
+        name: "lodestar_gossip_validation_ignore_total",
+        help: "Count of total gossip validation ignore",
+        labelNames: ["topic"],
+      }),
+      gossipValidationReject: register.gauge<"topic">({
+        name: "lodestar_gossip_validation_reject_total",
+        help: "Count of total gossip validation reject",
+        labelNames: ["topic"],
+      }),
+      gossipValidationError: register.gauge<"topic" | "error">({
+        name: "lodestar_gossip_validation_error_total",
+        help: "Count of total gossip validation errors detailed",
+        labelNames: ["topic", "error"],
+      }),
       executeWorkCalls: register.gauge({
         name: "lodestar_network_processor_execute_work_calls_total",
         help: "Total calls to network processor execute work fn",
@@ -290,63 +100,6 @@ export function createLodestarMetrics(
       canNotAcceptWork: register.gauge({
         name: "lodestar_network_processor_can_not_accept_work_total",
         help: "Total times network processor can not accept work on executeWork",
-      }),
-    },
-
-    discv5: {
-      decodeEnrAttemptCount: register.counter({
-        name: "lodestar_discv5_decode_enr_attempt_count",
-        help: "Count of total attempts to decode enrs",
-      }),
-      decodeEnrErrorCount: register.counter({
-        name: "lodestar_discv5_decode_enr_error_count",
-        help: "Count of total errors attempting to decode enrs",
-      }),
-    },
-
-    attnetsService: {
-      committeeSubnets: register.gauge({
-        name: "lodestar_attnets_service_committee_subnets_total",
-        help: "Count of committee subnets",
-      }),
-      subscriptionsCommittee: register.gauge({
-        name: "lodestar_attnets_service_committee_subscriptions_total",
-        help: "Count of committee subscriptions",
-      }),
-      subscriptionsRandom: register.gauge({
-        name: "lodestar_attnets_service_random_subscriptions_total",
-        help: "Count of random subscriptions",
-      }),
-      subscribeSubnets: register.gauge<"subnet" | "src">({
-        name: "lodestar_attnets_service_subscribe_subnets_total",
-        help: "Count of subscribe_subnets calls",
-        labelNames: ["subnet", "src"],
-      }),
-      unsubscribeSubnets: register.gauge<"subnet" | "src">({
-        name: "lodestar_attnets_service_unsubscribe_subnets_total",
-        help: "Count of unsubscribe_subnets calls",
-        labelNames: ["subnet", "src"],
-      }),
-      aggregatorSlotSubnetCount: register.gauge({
-        name: "lodestar_attnets_service_aggregator_slot_subnet_total",
-        help: "Count of aggregator per slot and subnet",
-      }),
-    },
-
-    syncnetsService: {
-      subscriptionsCommittee: register.gauge({
-        name: "lodestar_syncnets_service_committee_subscriptions_total",
-        help: "Count of syncnet committee subscriptions",
-      }),
-      subscribeSubnets: register.gauge<"subnet">({
-        name: "lodestar_syncnets_service_subscribe_subnets_total",
-        help: "Count of syncnet subscribe_subnets calls",
-        labelNames: ["subnet"],
-      }),
-      unsubscribeSubnets: register.gauge<"subnet">({
-        name: "lodestar_syncnets_service_unsubscribe_subnets_total",
-        help: "Count of syncnet unsubscribe_subnets calls",
-        labelNames: ["subnet"],
       }),
     },
 

--- a/packages/beacon-node/src/network/core/metrics.ts
+++ b/packages/beacon-node/src/network/core/metrics.ts
@@ -1,0 +1,269 @@
+import {RegistryMetricCreator} from "../../metrics/utils/registryMetricCreator.js";
+
+export type NetworkCoreMetrics = ReturnType<typeof createNetworkCoreMetrics>;
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function createNetworkCoreMetrics(register: RegistryMetricCreator) {
+  return {
+    register,
+
+    // Peers
+
+    peers: register.gauge({
+      name: "libp2p_peers",
+      help: "number of connected peers",
+    }),
+    peersByDirection: register.gauge<"direction">({
+      name: "lodestar_peers_by_direction_count",
+      help: "number of peers, labeled by direction",
+      labelNames: ["direction"],
+    }),
+    peersByClient: register.gauge<"client">({
+      name: "lodestar_peers_by_client_count",
+      help: "number of peers, labeled by client",
+      labelNames: ["client"],
+    }),
+    peerLongLivedAttnets: register.histogram({
+      name: "lodestar_peer_long_lived_attnets_count",
+      help: "Histogram of current count of long lived attnets of connected peers",
+      buckets: [0, 4, 16, 32, 64],
+    }),
+    peerScoreByClient: register.histogram<"client">({
+      name: "lodestar_app_peer_score",
+      help: "Current peer score at lodestar app side",
+      // Min score = -100, max score = 100, disconnect = -20, ban = -50
+      buckets: [-100, -50, -20, 0, 25],
+      labelNames: ["client"],
+    }),
+    peerConnectionLength: register.histogram({
+      name: "lodestar_peer_connection_seconds",
+      help: "Current peer connection length in second",
+      // Have good resolution on shorter times. After 1 day, don't count any longer
+      //        5s 20s 1m  3m   10m  30m   1h    6h     24h
+      buckets: [5, 20, 60, 180, 600, 1200, 3600, 21600, 86400],
+    }),
+    peersSync: register.gauge({
+      name: "lodestar_peers_sync_count",
+      help: "Current count of peers useful for sync",
+    }),
+    peerConnectedEvent: register.gauge<"direction" | "status">({
+      name: "lodestar_peer_connected_total",
+      help: "Total number of peer:connected event, labeled by direction",
+      labelNames: ["direction", "status"],
+    }),
+    peerDisconnectedEvent: register.gauge<"direction">({
+      name: "lodestar_peer_disconnected_total",
+      help: "Total number of peer:disconnected event, labeled by direction",
+      labelNames: ["direction"],
+    }),
+    peerGoodbyeReceived: register.gauge<"reason">({
+      name: "lodestar_peer_goodbye_received_total",
+      help: "Total number of goodbye received, labeled by reason",
+      labelNames: ["reason"],
+    }),
+    peerLongConnectionDisconnect: register.gauge<"reason">({
+      name: "lodestar_peer_long_connection_disconnect_total",
+      help: "For peers with long connection, track disconnect reason",
+      labelNames: ["reason"],
+    }),
+    peerGoodbyeSent: register.gauge<"reason">({
+      name: "lodestar_peer_goodbye_sent_total",
+      help: "Total number of goodbye sent, labeled by reason",
+      labelNames: ["reason"],
+    }),
+    peersRequestedToConnect: register.gauge({
+      name: "lodestar_peers_requested_total_to_connect",
+      help: "Prioritization results total peers count requested to connect",
+    }),
+    peersRequestedToDisconnect: register.gauge<"reason">({
+      name: "lodestar_peers_requested_total_to_disconnect",
+      help: "Prioritization results total peers count requested to disconnect",
+      labelNames: ["reason"],
+    }),
+    peersRequestedSubnetsToQuery: register.gauge<"type">({
+      name: "lodestar_peers_requested_total_subnets_to_query",
+      help: "Prioritization results total subnets to query and discover peers in",
+      labelNames: ["type"],
+    }),
+    peersRequestedSubnetsPeerCount: register.gauge<"type">({
+      name: "lodestar_peers_requested_total_subnets_peers_count",
+      help: "Prioritization results total peers in subnets to query and discover peers in",
+      labelNames: ["type"],
+    }),
+    peersReportPeerCount: register.gauge<"reason">({
+      name: "lodestar_peers_report_peer_count",
+      help: "network.reportPeer count by reason",
+      labelNames: ["reason"],
+    }),
+    peerManager: {
+      heartbeatDuration: register.histogram({
+        name: "lodestar_peer_manager_heartbeat_duration_seconds",
+        help: "Peer manager heartbeat function duration in seconds",
+        buckets: [0.001, 0.01, 0.1, 1],
+      }),
+    },
+
+    discovery: {
+      peersToConnect: register.gauge({
+        name: "lodestar_discovery_peers_to_connect",
+        help: "Current peers to connect count from discoverPeers requests",
+      }),
+      cachedENRsSize: register.gauge({
+        name: "lodestar_discovery_cached_enrs_size",
+        help: "Current size of the cachedENRs Set",
+      }),
+      findNodeQueryRequests: register.gauge<"action">({
+        name: "lodestar_discovery_find_node_query_requests_total",
+        help: "Total count of find node queries started",
+        labelNames: ["action"],
+      }),
+      findNodeQueryTime: register.histogram({
+        name: "lodestar_discovery_find_node_query_time_seconds",
+        help: "Time to complete a find node query in seconds in seconds",
+        buckets: [5, 60],
+      }),
+      findNodeQueryEnrCount: register.gauge({
+        name: "lodestar_discovery_find_node_query_enrs_total",
+        help: "Total count of found ENRs in queries",
+      }),
+      discoveredStatus: register.gauge<"status">({
+        name: "lodestar_discovery_discovered_status_total_count",
+        help: "Total count of status results of PeerDiscovery.onDiscovered() function",
+        labelNames: ["status"],
+      }),
+      dialAttempts: register.gauge({
+        name: "lodestar_discovery_total_dial_attempts",
+        help: "Total dial attempts by peer discovery",
+      }),
+      dialTime: register.histogram<"status">({
+        name: "lodestar_discovery_dial_time_seconds",
+        help: "Time to dial peers in seconds",
+        labelNames: ["status"],
+        buckets: [0.1, 5, 60],
+      }),
+    },
+
+    gossipPeer: {
+      scoreByThreshold: register.gauge<"threshold">({
+        name: "lodestar_gossip_peer_score_by_threshold_count",
+        help: "Gossip peer score by threshold",
+        labelNames: ["threshold"],
+      }),
+      meshPeersByClient: register.gauge<"client">({
+        name: "lodestar_gossip_mesh_peers_by_client_count",
+        help: "number of mesh peers, labeled by client",
+        labelNames: ["client"],
+      }),
+      scoreByClient: register.histogram<"client">({
+        name: "lodestar_gossip_score_by_client",
+        help: "Gossip peer score by client",
+        labelNames: ["client"],
+        // based on gossipScoreThresholds and negativeGossipScoreIgnoreThreshold
+        buckets: [-16000, -8000, -4000, -1000, 0, 5, 100],
+      }),
+      score: register.avgMinMax({
+        name: "lodestar_gossip_score_avg_min_max",
+        help: "Avg min max of all gossip peer scores",
+      }),
+    },
+    gossipMesh: {
+      peersByType: register.gauge<"type" | "fork">({
+        name: "lodestar_gossip_mesh_peers_by_type_count",
+        help: "Number of connected mesh peers per gossip type",
+        labelNames: ["type", "fork"],
+      }),
+      peersByBeaconAttestationSubnet: register.gauge<"subnet" | "fork">({
+        name: "lodestar_gossip_mesh_peers_by_beacon_attestation_subnet_count",
+        help: "Number of connected mesh peers per beacon attestation subnet",
+        labelNames: ["subnet", "fork"],
+      }),
+      peersBySyncCommitteeSubnet: register.gauge<"subnet" | "fork">({
+        name: "lodestar_gossip_mesh_peers_by_sync_committee_subnet_count",
+        help: "Number of connected mesh peers per sync committee subnet",
+        labelNames: ["subnet", "fork"],
+      }),
+    },
+    gossipTopic: {
+      peersByType: register.gauge<"type" | "fork">({
+        name: "lodestar_gossip_topic_peers_by_type_count",
+        help: "Number of connected topic peers per gossip type",
+        labelNames: ["type", "fork"],
+      }),
+      peersByBeaconAttestationSubnet: register.gauge<"subnet" | "fork">({
+        name: "lodestar_gossip_topic_peers_by_beacon_attestation_subnet_count",
+        help: "Number of connected topic peers per beacon attestation subnet",
+        labelNames: ["subnet", "fork"],
+      }),
+      peersBySyncCommitteeSubnet: register.gauge<"subnet" | "fork">({
+        name: "lodestar_gossip_topic_peers_by_sync_committee_subnet_count",
+        help: "Number of connected topic peers per sync committee subnet",
+        labelNames: ["subnet", "fork"],
+      }),
+    },
+
+    discv5: {
+      decodeEnrAttemptCount: register.counter({
+        name: "lodestar_discv5_decode_enr_attempt_count",
+        help: "Count of total attempts to decode enrs",
+      }),
+      decodeEnrErrorCount: register.counter({
+        name: "lodestar_discv5_decode_enr_error_count",
+        help: "Count of total errors attempting to decode enrs",
+      }),
+    },
+
+    attnetsService: {
+      committeeSubnets: register.gauge({
+        name: "lodestar_attnets_service_committee_subnets_total",
+        help: "Count of committee subnets",
+      }),
+      subscriptionsCommittee: register.gauge({
+        name: "lodestar_attnets_service_committee_subscriptions_total",
+        help: "Count of committee subscriptions",
+      }),
+      subscriptionsRandom: register.gauge({
+        name: "lodestar_attnets_service_random_subscriptions_total",
+        help: "Count of random subscriptions",
+      }),
+      subscribeSubnets: register.gauge<"subnet" | "src">({
+        name: "lodestar_attnets_service_subscribe_subnets_total",
+        help: "Count of subscribe_subnets calls",
+        labelNames: ["subnet", "src"],
+      }),
+      unsubscribeSubnets: register.gauge<"subnet" | "src">({
+        name: "lodestar_attnets_service_unsubscribe_subnets_total",
+        help: "Count of unsubscribe_subnets calls",
+        labelNames: ["subnet", "src"],
+      }),
+      aggregatorSlotSubnetCount: register.gauge({
+        name: "lodestar_attnets_service_aggregator_slot_subnet_total",
+        help: "Count of aggregator per slot and subnet",
+      }),
+    },
+
+    syncnetsService: {
+      subscriptionsCommittee: register.gauge({
+        name: "lodestar_syncnets_service_committee_subscriptions_total",
+        help: "Count of syncnet committee subscriptions",
+      }),
+      subscribeSubnets: register.gauge<"subnet">({
+        name: "lodestar_syncnets_service_subscribe_subnets_total",
+        help: "Count of syncnet subscribe_subnets calls",
+        labelNames: ["subnet"],
+      }),
+      unsubscribeSubnets: register.gauge<"subnet">({
+        name: "lodestar_syncnets_service_unsubscribe_subnets_total",
+        help: "Count of syncnet unsubscribe_subnets calls",
+        labelNames: ["subnet"],
+      }),
+    },
+
+    reqResp: {
+      rateLimitErrors: register.gauge<"method">({
+        name: "beacon_reqresp_rate_limiter_errors_total",
+        help: "Count rate limiter errors",
+        labelNames: ["method"],
+      }),
+    },
+  };
+}

--- a/packages/beacon-node/src/network/discv5/index.ts
+++ b/packages/beacon-node/src/network/discv5/index.ts
@@ -13,7 +13,7 @@ import {
 import {spawn, Thread, Worker} from "@chainsafe/threads";
 import {chainConfigFromJson, chainConfigToJson, BeaconConfig} from "@lodestar/config";
 import {Logger} from "@lodestar/utils";
-import {Metrics} from "../../metrics/metrics.js";
+import {NetworkCoreMetrics} from "../core/metrics.js";
 import {Discv5WorkerApi, Discv5WorkerData} from "./types.js";
 
 export type Discv5Opts = {
@@ -21,7 +21,7 @@ export type Discv5Opts = {
   discv5: Omit<IDiscv5DiscoveryInputOptions, "metrics" | "searchInterval" | "enabled">;
   logger: Logger;
   config: BeaconConfig;
-  metrics?: Metrics;
+  metrics?: NetworkCoreMetrics;
 };
 
 export type Discv5Events = {

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -11,7 +11,7 @@ import {Logger, Map2d, Map2dArr} from "@lodestar/utils";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {upgradeLightClientFinalityUpdate, upgradeLightClientOptimisticUpdate} from "@lodestar/light-client";
 
-import {Metrics} from "../../metrics/index.js";
+import {NetworkCoreMetrics} from "../core/metrics.js";
 import {Eth2Context} from "../../chain/index.js";
 import {PeersData} from "../peers/peersData.js";
 import {ClientKind} from "../peers/client.js";
@@ -40,7 +40,7 @@ export type Eth2GossipsubModules = {
   config: BeaconConfig;
   libp2p: Libp2p;
   logger: Logger;
-  metrics: Metrics | null;
+  metrics: NetworkCoreMetrics | null;
   eth2Context: Eth2Context;
   peersData: PeersData;
   events: NetworkEventBus;
@@ -296,7 +296,7 @@ export class Eth2Gossipsub extends GossipSub implements GossipBeaconNode {
     return stringifyGossipTopic(this.config, topic);
   }
 
-  private onScrapeLodestarMetrics(metrics: Metrics): void {
+  private onScrapeLodestarMetrics(metrics: NetworkCoreMetrics): void {
     const mesh = this["mesh"] as Map<string, Set<string>>;
     const topics = this["topics"] as Map<string, Set<string>>;
     const peers = this["peers"] as Set<string>;

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -38,6 +38,7 @@ import {Discv5Worker} from "./discv5/index.js";
 import {createNodeJsLibp2p} from "./nodejs/util.js";
 import {NetworkProcessor} from "./processor/index.js";
 import {PendingGossipsubMessage} from "./processor/types.js";
+import {createNetworkCoreMetrics} from "./core/metrics.js";
 
 // How many changes to batch cleanup
 const CACHED_BLS_BATCH_CLEANUP_LIMIT = 10;
@@ -154,10 +155,11 @@ export class Network implements INetwork {
     gossipHandlers,
   }: NetworkInitModules): Promise<Network> {
     const clock = chain.clock;
+    const metricsCore = metrics && createNetworkCoreMetrics(metrics.register);
     const peersData = new PeersData();
     const networkEventBus = new NetworkEventBus();
     const metadata = new MetadataController({}, {config, chain, logger});
-    const peerRpcScores = new PeerRpcScoreStore(metrics);
+    const peerRpcScores = new PeerRpcScoreStore(metricsCore);
 
     const libp2p = await createNodeJsLibp2p(peerId, opts, {
       peerStoreDir: peerStoreDir,
@@ -174,7 +176,7 @@ export class Network implements INetwork {
         peerRpcScores,
         logger,
         networkEventBus,
-        metrics,
+        metrics: metricsCore,
         peersData,
       },
       opts
@@ -193,13 +195,13 @@ export class Network implements INetwork {
       },
     };
 
-    const attnetsService = new AttnetsService(config, chain, _gossip, metadata, logger, metrics, opts);
+    const attnetsService = new AttnetsService(config, chain, _gossip, metadata, logger, metricsCore, opts);
 
     gossip = new Eth2Gossipsub(opts, {
       config,
       libp2p,
       logger,
-      metrics,
+      metrics: metricsCore,
       eth2Context: {
         activeValidatorCount: chain.getHeadState().epochCtx.currentShuffling.activeIndices.length,
         currentSlot: clock.currentSlot,
@@ -209,7 +211,7 @@ export class Network implements INetwork {
       events: networkEventBus,
     });
 
-    const syncnetsService = new SyncnetsService(config, chain, gossip, metadata, logger, metrics, opts);
+    const syncnetsService = new SyncnetsService(config, chain, gossip, metadata, logger, metricsCore, opts);
 
     const peerManager = new PeerManager(
       {
@@ -219,7 +221,7 @@ export class Network implements INetwork {
         attnetsService,
         syncnetsService,
         logger,
-        metrics,
+        metrics: metricsCore,
         chain,
         config,
         peerRpcScores,

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -5,7 +5,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {Logger, pruneSetToMax, sleep} from "@lodestar/utils";
 import {ENR, IDiscv5DiscoveryInputOptions} from "@chainsafe/discv5";
 import {ATTESTATION_SUBNET_COUNT, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
-import {Metrics} from "../../metrics/index.js";
+import {NetworkCoreMetrics} from "../core/metrics.js";
 import {Libp2p} from "../interface.js";
 import {ENRKey, SubnetType} from "../metadata.js";
 import {getConnectionsMap, getDefaultDialer, prettyPrintPeerId} from "../util.js";
@@ -28,7 +28,7 @@ export type PeerDiscoveryOpts = {
 export type PeerDiscoveryModules = {
   libp2p: Libp2p;
   peerRpcScores: IPeerRpcScoreStore;
-  metrics: Metrics | null;
+  metrics: NetworkCoreMetrics | null;
   logger: Logger;
   config: BeaconConfig;
 };
@@ -74,7 +74,7 @@ export class PeerDiscovery {
   readonly discv5: Discv5Worker;
   private libp2p: Libp2p;
   private peerRpcScores: IPeerRpcScoreStore;
-  private metrics: Metrics | null;
+  private metrics: NetworkCoreMetrics | null;
   private logger: Logger;
   private config: BeaconConfig;
   private cachedENRs = new Map<PeerIdStr, CachedENR>();

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -8,7 +8,7 @@ import {allForks, altair, phase0} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {IBeaconChain} from "../../chain/index.js";
 import {GoodByeReasonCode, GOODBYE_KNOWN_CODES, Libp2pEvent} from "../../constants/index.js";
-import {Metrics} from "../../metrics/index.js";
+import {NetworkCoreMetrics} from "../core/metrics.js";
 import {NetworkEvent, INetworkEventBus} from "../events.js";
 import {Libp2p} from "../interface.js";
 import {IReqRespBeaconNode, ReqRespMethod, RequestTypedContainer} from "../reqresp/ReqRespBeaconNode.js";
@@ -83,7 +83,7 @@ export type PeerManagerOpts = {
 export type PeerManagerModules = {
   libp2p: Libp2p;
   logger: Logger;
-  metrics: Metrics | null;
+  metrics: NetworkCoreMetrics | null;
   reqResp: IReqRespBeaconNode;
   gossip: Eth2Gossipsub;
   attnetsService: SubnetsService;
@@ -114,7 +114,7 @@ enum RelevantPeerStatus {
 export class PeerManager {
   private libp2p: Libp2p;
   private logger: Logger;
-  private metrics: Metrics | null;
+  private metrics: NetworkCoreMetrics | null;
   private reqResp: IReqRespBeaconNode;
   private gossipsub: Eth2Gossipsub;
   private attnetsService: SubnetsService;
@@ -629,7 +629,7 @@ export class PeerManager {
   }
 
   /** Register peer count metrics */
-  private async runPeerCountMetrics(metrics: Metrics): Promise<void> {
+  private async runPeerCountMetrics(metrics: NetworkCoreMetrics): Promise<void> {
     let total = 0;
 
     const peersByDirection = new Map<string, number>();

--- a/packages/beacon-node/src/network/peers/score.ts
+++ b/packages/beacon-node/src/network/peers/score.ts
@@ -1,7 +1,7 @@
 import {PeerId} from "@libp2p/interface-peer-id";
 import {MapDef, pruneSetToMax} from "@lodestar/utils";
 import {gossipScoreThresholds, negativeGossipScoreIgnoreThreshold} from "../gossip/scoringParameters.js";
-import {Metrics} from "../../metrics/index.js";
+import {NetworkCoreMetrics} from "../core/metrics.js";
 
 /** The default score for new peers */
 const DEFAULT_SCORE = 0;
@@ -87,7 +87,7 @@ export interface IPeerRpcScoreStore {
 }
 
 export type PeerRpcScoreStoreModules = {
-  metrics: Metrics | null;
+  metrics: NetworkCoreMetrics | null;
 };
 
 export type PeerScoreStats = ({peerId: PeerIdStr} & PeerScoreStat)[];
@@ -107,11 +107,11 @@ export type PeerScoreStat = {
  */
 export class PeerRpcScoreStore implements IPeerRpcScoreStore {
   private readonly scores = new MapDef<PeerIdStr, PeerScore>(() => new PeerScore());
-  private readonly metrics: Metrics | null;
+  private readonly metrics: NetworkCoreMetrics | null;
 
   // TODO: Persist scores, at least BANNED status to disk
 
-  constructor(metrics: Metrics | null = null) {
+  constructor(metrics: NetworkCoreMetrics | null = null) {
     this.metrics = metrics;
   }
 

--- a/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
+++ b/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
@@ -39,7 +39,7 @@ export function getGossipValidatorFn(gossipHandlers: GossipHandlers, modules: Va
         seenTimestampSec
       );
 
-      metrics?.gossipValidationAccept.inc({topic: type});
+      metrics?.networkProcessor.gossipValidationAccept.inc({topic: type});
 
       return TopicValidatorResult.Accept;
     } catch (e) {
@@ -51,15 +51,18 @@ export function getGossipValidatorFn(gossipHandlers: GossipHandlers, modules: Va
 
       // Metrics on specific error reason
       // Note: LodestarError.code are bounded pre-declared error messages, not from arbitrary error.message
-      metrics?.gossipValidationError.inc({topic: type, error: (e as GossipActionError<{code: string}>).type.code});
+      metrics?.networkProcessor.gossipValidationError.inc({
+        topic: type,
+        error: (e as GossipActionError<{code: string}>).type.code,
+      });
 
       switch (e.action) {
         case GossipAction.IGNORE:
-          metrics?.gossipValidationIgnore.inc({topic: type});
+          metrics?.networkProcessor.gossipValidationIgnore.inc({topic: type});
           return TopicValidatorResult.Ignore;
 
         case GossipAction.REJECT:
-          metrics?.gossipValidationReject.inc({topic: type});
+          metrics?.networkProcessor.gossipValidationReject.inc({topic: type});
           logger.debug(`Gossip validation ${type} rejected`, {}, e);
           return TopicValidatorResult.Reject;
       }

--- a/packages/beacon-node/src/network/processor/worker.ts
+++ b/packages/beacon-node/src/network/processor/worker.ts
@@ -38,11 +38,11 @@ export class NetworkWorker {
     );
 
     if (message.startProcessUnixSec !== null) {
-      this.metrics?.gossipValidationQueueJobWaitTime.observe(
+      this.metrics?.gossipValidationQueue.jobWaitTime.observe(
         {topic: message.topic.type},
         message.startProcessUnixSec - message.seenTimestampSec
       );
-      this.metrics?.gossipValidationQueueJobTime.observe(
+      this.metrics?.gossipValidationQueue.jobTime.observe(
         {topic: message.topic.type},
         Date.now() / 1000 - message.startProcessUnixSec
       );

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -16,7 +16,7 @@ import {ReqRespOpts} from "@lodestar/reqresp/lib/ReqResp.js";
 import * as reqRespProtocols from "@lodestar/reqresp/protocols";
 import {allForks, altair, deneb, phase0, Root} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
-import {Metrics} from "../../metrics/metrics.js";
+import {NetworkCoreMetrics} from "../core/metrics.js";
 import {INetworkEventBus, NetworkEvent} from "../events.js";
 import {MetadataController} from "../metadata.js";
 import {PeersData} from "../peers/peersData.js";
@@ -42,7 +42,7 @@ export interface ReqRespBeaconNodeModules {
   peersData: PeersData;
   logger: Logger;
   config: BeaconConfig;
-  metrics: Metrics | null;
+  metrics: NetworkCoreMetrics | null;
   reqRespHandlers: ReqRespHandlers;
   metadata: MetadataController;
   peerRpcScores: IPeerRpcScoreStore;

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -15,7 +15,7 @@ import {GossipTopic, GossipType} from "../gossip/index.js";
 import {MetadataController} from "../metadata.js";
 import {SubnetMap, RequestedSubnet} from "../peers/utils/index.js";
 import {getActiveForks} from "../forks.js";
-import {Metrics} from "../../metrics/metrics.js";
+import {NetworkCoreMetrics} from "../core/metrics.js";
 import {IAttnetsService, CommitteeSubscription, SubnetsServiceOpts, RandBetweenFn, ShuffleFn} from "./interface.js";
 
 /**
@@ -70,7 +70,7 @@ export class AttnetsService implements IAttnetsService {
     },
     private readonly metadata: MetadataController,
     private readonly logger: Logger,
-    private readonly metrics: Metrics | null,
+    private readonly metrics: NetworkCoreMetrics | null,
     private readonly opts?: SubnetsServiceOpts
   ) {
     // if subscribeAllSubnets, we act like we have >= ATTESTATION_SUBNET_COUNT validators connecting to this node
@@ -368,7 +368,7 @@ export class AttnetsService implements IAttnetsService {
     );
   }
 
-  private onScrapeLodestarMetrics(metrics: Metrics): void {
+  private onScrapeLodestarMetrics(metrics: NetworkCoreMetrics): void {
     metrics.attnetsService.committeeSubnets.set(this.committeeSubnets.size);
     metrics.attnetsService.subscriptionsCommittee.set(this.subscriptionsCommittee.size);
     metrics.attnetsService.subscriptionsRandom.set(this.subscriptionsRandom.size);

--- a/packages/beacon-node/src/network/subnets/syncnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/syncnetsService.ts
@@ -8,7 +8,7 @@ import {getActiveForks} from "../forks.js";
 import {Eth2Gossipsub, GossipType} from "../gossip/index.js";
 import {MetadataController} from "../metadata.js";
 import {RequestedSubnet, SubnetMap} from "../peers/utils/index.js";
-import {Metrics} from "../../metrics/metrics.js";
+import {NetworkCoreMetrics} from "../core/metrics.js";
 import {CommitteeSubscription, SubnetsService, SubnetsServiceOpts} from "./interface.js";
 
 const gossipType = GossipType.sync_committee;
@@ -33,7 +33,7 @@ export class SyncnetsService implements SubnetsService {
     private readonly gossip: Eth2Gossipsub,
     private readonly metadata: MetadataController,
     private readonly logger: Logger,
-    private readonly metrics: Metrics | null,
+    private readonly metrics: NetworkCoreMetrics | null,
     private readonly opts?: SubnetsServiceOpts
   ) {
     if (metrics) {
@@ -145,7 +145,7 @@ export class SyncnetsService implements SubnetsService {
     }
   }
 
-  private onScrapeLodestarMetrics(metrics: Metrics): void {
+  private onScrapeLodestarMetrics(metrics: NetworkCoreMetrics): void {
     metrics.syncnetsService.subscriptionsCommittee.set(this.subscriptionsCommittee.size);
   }
 }

--- a/packages/beacon-node/test/unit/metrics/beacon.test.ts
+++ b/packages/beacon-node/test/unit/metrics/beacon.test.ts
@@ -12,10 +12,11 @@ describe("BeaconMetrics", () => {
     expect(metricsAsText).to.not.equal("");
 
     // check updating beacon-specific metrics
-    await expect(metrics.register.getSingleMetricAsString("libp2p_peers")).eventually.include("libp2p_peers 0");
-    metrics.peers.set(1);
-    await expect(metrics.register.getSingleMetricAsString("libp2p_peers")).eventually.include("libp2p_peers 1");
-    metrics.peers.set(20);
-    await expect(metrics.register.getSingleMetricAsString("libp2p_peers")).eventually.include("libp2p_peers 20");
+    const headSlotName = "beacon_head_slot";
+    await expect(metrics.register.getSingleMetricAsString(headSlotName)).eventually.include(`${headSlotName} 0`);
+    metrics.headSlot.set(1);
+    await expect(metrics.register.getSingleMetricAsString(headSlotName)).eventually.include(`${headSlotName} 1`);
+    metrics.headSlot.set(20);
+    await expect(metrics.register.getSingleMetricAsString(headSlotName)).eventually.include(`${headSlotName} 20`);
   });
 });

--- a/packages/beacon-node/test/unit/monitoring/properties.test.ts
+++ b/packages/beacon-node/test/unit/monitoring/properties.test.ts
@@ -38,12 +38,12 @@ describe("monitoring / properties", () => {
     });
 
     it("should return a json record with the configured key and metric value", async () => {
-      const peerCount = 50;
-      metrics.peers.set(peerCount);
+      const headSlot = 50;
+      metrics.headSlot.set(headSlot);
 
       const metricProperty = new MetricProperty({
         jsonKey,
-        metricName: "libp2p_peers",
+        metricName: "beacon_head_slot",
         jsonType: JsonType.Number,
         defaultValue: 0,
       });
@@ -51,7 +51,7 @@ describe("monitoring / properties", () => {
       const jsonRecord = await metricProperty.getRecord(metrics.register);
 
       expect(jsonRecord.key).to.equal(jsonKey);
-      expect(jsonRecord.value).to.equal(peerCount);
+      expect(jsonRecord.value).to.equal(headSlot);
     });
 
     it("should return the default value if metric with name does not exist", async () => {


### PR DESCRIPTION
**Motivation**

- Spin-off from https://github.com/ChainSafe/lodestar/pull/5351 

**Description**

Moves metrics related to components that may be placed in a separate thread into another file. The purpose of this PR is to move trivial changes out of the larger https://github.com/ChainSafe/lodestar/pull/5351
