### PR TITLE
refactor(network)!: use StatusCache in PeerManager

### DIFF
--- a/packages/beacon-node/src/network/peers/utils/assertPeerRelevance.ts
+++ b/packages/beacon-node/src/network/peers/utils/assertPeerRelevance.ts
@@ -1,8 +1,5 @@
-import {computeStartSlotAtEpoch, getBlockRootAtSlot} from "@lodestar/state-transition";
-import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
-import {Epoch, ForkDigest, Root, phase0, ssz} from "@lodestar/types";
+import {ForkDigest, Root, Slot, phase0, ssz} from "@lodestar/types";
 import {toHexString} from "@chainsafe/ssz";
-import {IBeaconChain} from "../../../chain/index.js";
 
 // TODO: Why this value? (From Lighthouse)
 const FUTURE_SLOT_TOLERANCE = 1;
@@ -22,9 +19,11 @@ type IrrelevantPeerType =
  * Process a `Status` message to determine if a peer is relevant to us. If the peer is
  * irrelevant the reason is returned.
  */
-export function assertPeerRelevance(remote: phase0.Status, chain: IBeaconChain): IrrelevantPeerType | null {
-  const local = chain.getStatus();
-
+export function assertPeerRelevance(
+  remote: phase0.Status,
+  local: phase0.Status,
+  currentSlot: Slot
+): IrrelevantPeerType | null {
   // The node is on a different network/fork
   if (!ssz.ForkDigest.equals(local.forkDigest, remote.forkDigest)) {
     return {
@@ -37,7 +36,7 @@ export function assertPeerRelevance(remote: phase0.Status, chain: IBeaconChain):
   // The remote's head is on a slot that is significantly ahead of what we consider the
   // current slot. This could be because they are using a different genesis time, or that
   // their or our system's clock is incorrect.
-  const slotDiff = remote.headSlot - Math.max(chain.clock.currentSlot, 0);
+  const slotDiff = remote.headSlot - Math.max(currentSlot, 0);
   if (slotDiff > FUTURE_SLOT_TOLERANCE) {
     return {code: IrrelevantPeerCode.DIFFERENT_CLOCKS, slotDiff};
   }
@@ -52,11 +51,7 @@ export function assertPeerRelevance(remote: phase0.Status, chain: IBeaconChain):
     !isZeroRoot(local.finalizedRoot)
   ) {
     const remoteRoot = remote.finalizedRoot;
-    const expectedRoot =
-      remote.finalizedEpoch === local.finalizedEpoch
-        ? local.finalizedRoot
-        : // This will get the latest known block at the start of the epoch.
-          getRootAtHistoricalEpoch(chain, remote.finalizedEpoch);
+    const expectedRoot = remote.finalizedEpoch === local.finalizedEpoch ? local.finalizedRoot : null;
 
     if (expectedRoot !== null && !ssz.Root.equals(remoteRoot, expectedRoot)) {
       return {
@@ -74,32 +69,6 @@ export function assertPeerRelevance(remote: phase0.Status, chain: IBeaconChain):
 export function isZeroRoot(root: Root): boolean {
   const ZERO_ROOT = ssz.Root.defaultValue();
   return ssz.Root.equals(root, ZERO_ROOT);
-}
-
-function getRootAtHistoricalEpoch(chain: IBeaconChain, epoch: Epoch): Root | null {
-  const headState = chain.getHeadState();
-  const slot = computeStartSlotAtEpoch(epoch);
-
-  if (slot < headState.slot - SLOTS_PER_HISTORICAL_ROOT) {
-    // TODO: If the slot is very old, go to the historical blocks DB and fetch the block with less or equal `slot`.
-    // Note that our db schema will have to be updated to persist the block root to prevent re-hashing.
-    // For now peers will be accepted, since it's better than throwing an error on `getBlockRootAtSlot()`
-    return null;
-  }
-
-  // This will get the latest known block at the start of the epoch.
-  // NOTE: Throws if the epoch if from a long-ago epoch
-  return getBlockRootAtSlot(headState, slot);
-
-  // NOTE: Previous code tolerated long-ago epochs
-  // ^^^^
-  // finalized checkpoint of status is from an old long-ago epoch.
-  // We need to ask the chain for most recent canonical block at the finalized checkpoint start slot.
-  // The problem is that the slot may be a skip slot.
-  // And the block root may be from multiple epochs back even.
-  // The epoch in the checkpoint is there to checkpoint the tail end of skip slots, even if there is no block.
-  // TODO: accepted for now. Need to maintain either a list of finalized block roots,
-  // or inefficiently loop from finalized slot backwards, until we find the block we need to check against.
 }
 
 export function renderIrrelevantPeerType(type: IrrelevantPeerType): string {

--- a/packages/beacon-node/src/network/statusCache.ts
+++ b/packages/beacon-node/src/network/statusCache.ts
@@ -1,0 +1,17 @@
+import {phase0} from "@lodestar/types";
+
+export interface StatusCache {
+  get(): phase0.Status;
+}
+
+export class LocalStatusCache implements StatusCache {
+  constructor(private status: phase0.Status) {}
+
+  get(): phase0.Status {
+    return this.status;
+  }
+
+  update(localStatus: phase0.Status): void {
+    this.status = localStatus;
+  }
+}

--- a/packages/beacon-node/test/unit/network/peers/utils/assertPeerRelevance.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/utils/assertPeerRelevance.test.ts
@@ -1,8 +1,6 @@
 import {expect} from "chai";
 import {phase0} from "@lodestar/types";
-import {MockBeaconChain} from "../../../../utils/mocks/chain/chain.js";
 import {assertPeerRelevance, IrrelevantPeerCode} from "../../../../../src/network/peers/utils/assertPeerRelevance.js";
-import {IClock} from "../../../../../src/util/clock.js";
 
 describe("network / peers / utils / assertPeerRelevance", () => {
   const correctForkDigest = Buffer.alloc(4, 0);
@@ -81,21 +79,15 @@ describe("network / peers / utils / assertPeerRelevance", () => {
 
   for (const {id, remote, currentSlot, irrelevantType} of testCases) {
     it(id, async () => {
-      // Partial instance with only the methods needed for the test
-      const chain = {
-        getStatus: () => ({
-          forkDigest: correctForkDigest,
-          finalizedRoot: ZERO_HASH,
-          finalizedEpoch: 0,
-          headRoot: ZERO_HASH,
-          headSlot: 0,
-        }),
-        clock: {
-          currentSlot: currentSlot ?? 0,
-        } as Partial<IClock>,
-      } as Partial<MockBeaconChain> as MockBeaconChain;
+      const local = {
+        forkDigest: correctForkDigest,
+        finalizedRoot: ZERO_HASH,
+        finalizedEpoch: 0,
+        headRoot: ZERO_HASH,
+        headSlot: 0,
+      };
 
-      expect(assertPeerRelevance(remote, chain)).to.deep.equal(irrelevantType);
+      expect(assertPeerRelevance(remote, local, currentSlot ?? 0)).to.deep.equal(irrelevantType);
     });
   }
 });


### PR DESCRIPTION
**Motivation**

- Spin-off from https://github.com/ChainSafe/lodestar/pull/5351

**Description**

Use `StatusCache` (and clock) in PeerManager instead of using the entire chain as a module dependency.
Note: this relaxes our peer relevance calculation by removing the check in the case that a peer is on an old finalized chain.