### PR TITLE
refactor!: move getNetworkIdentity to network class

### DIFF
--- a/packages/beacon-node/src/api/impl/node/index.ts
+++ b/packages/beacon-node/src/api/impl/node/index.ts
@@ -9,20 +9,8 @@ export function getNodeApi(
 ): ServerApi<routes.node.Api> {
   return {
     async getNetworkIdentity() {
-      const enr = await network.getEnr();
-      const discoveryAddresses = [
-        enr?.getLocationMultiaddr("tcp")?.toString() ?? null,
-        enr?.getLocationMultiaddr("udp")?.toString() ?? null,
-      ].filter((addr): addr is string => Boolean(addr));
-
       return {
-        data: {
-          peerId: network.peerId.toString(),
-          enr: enr?.encodeTxt() || "",
-          discoveryAddresses,
-          p2pAddresses: network.localMultiaddrs.map((m) => m.toString()),
-          metadata: await network.getMetadata(),
-        },
+        data: await network.getNetworkIdentity(),
       };
     },
 

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -4,8 +4,7 @@ import {Registrar} from "@libp2p/interface-registrar";
 import {Multiaddr} from "@multiformats/multiaddr";
 import {PeerId} from "@libp2p/interface-peer-id";
 import {ConnectionManager} from "@libp2p/interface-connection-manager";
-import {SignableENR} from "@chainsafe/discv5";
-import {altair, phase0} from "@lodestar/types";
+import {phase0} from "@lodestar/types";
 import {PeerScoreStatsDump} from "@chainsafe/libp2p-gossipsub/score";
 import {routes} from "@lodestar/api";
 import {BlockInput} from "../chain/blocks/types.js";
@@ -31,10 +30,9 @@ export interface INetwork {
   attnetsService: AttnetsService;
   gossip: GossipBeaconNode;
 
-  getEnr(): Promise<SignableENR | undefined>;
-  getMetadata(): Promise<altair.Metadata>;
   getConnectedPeers(): PeerId[];
   getConnectedPeerCount(): number;
+  getNetworkIdentity(): Promise<routes.node.NetworkIdentity>;
 
   publishBeaconBlockMaybeBlobs(signedBlock: BlockInput): Promise<void>;
   beaconBlocksMaybeBlobsByRange(peerId: PeerId, request: phase0.BeaconBlocksByRangeRequest): Promise<BlockInput[]>;

--- a/packages/beacon-node/test/unit/api/impl/node/node.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/node/node.test.ts
@@ -3,8 +3,6 @@ import {PeerId} from "@libp2p/interface-peer-id";
 import {expect} from "chai";
 import {multiaddr} from "@multiformats/multiaddr";
 import {createSecp256k1PeerId} from "@libp2p/peer-id-factory";
-import {createKeypairFromPeerId, SignableENR} from "@chainsafe/discv5";
-import {BitArray} from "@chainsafe/ssz";
 import {routes} from "@lodestar/api";
 import {BeaconSync, IBeaconSync} from "../../../../../src/sync/index.js";
 import {INetwork, Network} from "../../../../../src/network/index.js";
@@ -41,36 +39,6 @@ describe("node api implementation", function () {
     peerId = await createSecp256k1PeerId();
     sinon.stub(networkStub, "peerId").get(() => peerId);
     sinon.stub(networkStub, "localMultiaddrs").get(() => [multiaddr("/ip4/127.0.0.1/tcp/36000")]);
-  });
-
-  describe("getNetworkIdentity", function () {
-    it("should get node identity", async function () {
-      const keypair = createKeypairFromPeerId(peerId);
-      const enr = SignableENR.createV4(keypair);
-      enr.setLocationMultiaddr(multiaddr("/ip4/127.0.0.1/tcp/36001"));
-      networkStub.getEnr.returns(Promise.resolve(enr));
-      networkStub.getMetadata.returns(
-        Promise.resolve({
-          attnets: BitArray.fromBoolArray([true]),
-          syncnets: BitArray.fromBitLen(0),
-          seqNumber: BigInt(1),
-        })
-      );
-      const {data: identity} = await api.getNetworkIdentity();
-      expect(identity.peerId.startsWith("16")).to.equal(true);
-      expect(identity.enr.startsWith("enr:-")).to.equal(true);
-      expect(identity.discoveryAddresses.length).to.equal(1);
-      expect(identity.discoveryAddresses[0]).to.equal("/ip4/127.0.0.1/tcp/36001");
-      expect(identity.p2pAddresses.length).to.equal(1);
-      expect(identity.p2pAddresses[0]).to.equal("/ip4/127.0.0.1/tcp/36000");
-      expect(identity.metadata).to.not.null;
-    });
-
-    it("should get node identity - no enr", async function () {
-      networkStub.getEnr.returns(Promise.resolve(undefined));
-      const {data: identity} = await api.getNetworkIdentity();
-      expect(identity.enr).equal("");
-    });
   });
 
   describe("getPeerCount", function () {

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -83,10 +83,12 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
 
     onGracefulShutdown(async () => {
       if (args.persistNetworkIdentity) {
-        const enr = await node.network.getEnr().catch((e) => logger.warn("Unable to persist enr", {}, e));
-        if (enr) {
+        try {
+          const networkIdentity = await node.network.getNetworkIdentity();
           const enrPath = path.join(beaconPaths.beaconDir, "enr");
-          writeFile600Perm(enrPath, enr.encodeTxt());
+          writeFile600Perm(enrPath, networkIdentity.enr);
+        } catch (e) {
+          logger.warn("Unable to persist enr", {}, e as Error);
         }
       }
       abortController.abort();


### PR DESCRIPTION
**Motivation**

- Spin-off from https://github.com/ChainSafe/lodestar/pull/5229

**Description**

Move getNetworkIdentity logic into network class to reduce interface surface