### PR TITLE
fix(slashing-protection): limit min-max surround epoch lookback to 4096

### DIFF
--- a/packages/validator/src/slashingProtection/minMaxSurround/minMaxSurround.ts
+++ b/packages/validator/src/slashingProtection/minMaxSurround/minMaxSurround.ts
@@ -5,13 +5,29 @@ import {SurroundAttestationError, SurroundAttestationErrorCode} from "./errors.j
 // surround vote checking with min-max surround
 // https://github.com/protolambda/eth2-surround#min-max-surround
 
+/**
+ * Number of epochs in the past to check for surrounding attestations.
+ *
+ * This value can be limited to a reasonable high amount as Lodestar does not solely rely on this strategy but also
+ * implements the minimal strategy which has been formally proven to be safe (https://github.com/michaelsproul/slashing-proofs).
+ *
+ * Limiting this value is required due to practical reasons as otherwise there would be a min-span DB read and write
+ * for each validator from current epoch until genesis which massively increases DB size and causes I/O lag, resulting in
+ * instability on first startup with an empty DB. See https://github.com/ChainSafe/lodestar/issues/5356 for more details.
+ *
+ * The value 4096 has been chosen as it is the default used by slashers (https://lighthouse-book.sigmaprime.io/slasher.html#history-length)
+ * and is generally higher than the weak subjectivity period. However, it would still be risky if we just relied on min-max surround
+ * for slashing protection, as slashers can be configured to collect slashable attestations over a longer period.
+ */
+const DEFAULT_MAX_EPOCH_LOOKBACK = 4096;
+
 export class MinMaxSurround implements IMinMaxSurround {
   private store: IDistanceStore;
   private maxEpochLookback: number;
 
   constructor(store: IDistanceStore, options?: {maxEpochLookback?: number}) {
     this.store = store;
-    this.maxEpochLookback = options?.maxEpochLookback ?? Infinity;
+    this.maxEpochLookback = options?.maxEpochLookback ?? DEFAULT_MAX_EPOCH_LOOKBACK;
   }
 
   async assertNoSurround(pubKey: BLSPubkey, attestation: MinMaxSurroundAttestation): Promise<void> {


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5356

**Description**

Limits number of epochs in the past to check for surrounding attestations (min-span) to **4096**.

**DB size**

Running with 2k keys, the DB size was initially **4GB** and is now reduced to **100MB**.

**Metrics**

These are the metrics when running a VC with 2k keys and an empty db.

There are still quite a lot of read/writes but it goes down very fast compared to initially and does no longer cause instability in VC.

![image](https://user-images.githubusercontent.com/38436224/235620214-42abebd7-2ab2-4715-bc4f-dc6516c02d8d.png)


Request times do not show any I/O lag, previously was running into timeouts (10 seconds).

![image](https://user-images.githubusercontent.com/38436224/235620555-8bd6bd2f-53f0-4692-a5b0-2c30a0ac2bd4.png)


For the first 1-2 minutes there is still a increased step times diff but it goes down very fast, after a few minutes instead of hours as before.

![image](https://user-images.githubusercontent.com/38436224/235620808-7f16ee0a-b589-4dc8-9c0e-ae1fb0483604.png)


Metrics look good to me now, there are no big issues and also need to keep in mind that those metrics are collected running 2k validators which is not a normal setup. This also only happens if the db is empty, meaning for most setups only on initial installation.
