### PR TITLE
feat: add support for `justified` block id in Beacon Node API

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/utils.ts
@@ -65,6 +65,13 @@ async function resolveBlockIdOrNull(
     };
   }
 
+  if (blockId === "justified") {
+    return {
+      block: await db.blockArchive.get(forkChoice.getJustifiedBlock().slot),
+      executionOptimistic: false,
+    };
+  }
+
   let blockSummary;
   let getBlockByBlockArchive;
 

--- a/packages/beacon-node/src/api/impl/beacon/blocks/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/utils.ts
@@ -69,7 +69,7 @@ async function resolveBlockIdOrNull(
     const justified = forkChoice.getJustifiedBlock();
     return {
       block: await db.block.get(fromHexString(justified.blockRoot)),
-      executionOptimistic: false,
+      executionOptimistic: isOptimisticBlock(justified),
     };
   }
 

--- a/packages/beacon-node/src/api/impl/beacon/blocks/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/utils.ts
@@ -66,8 +66,9 @@ async function resolveBlockIdOrNull(
   }
 
   if (blockId === "justified") {
+    const justified = forkChoice.getJustifiedBlock();
     return {
-      block: await db.blockArchive.get(forkChoice.getJustifiedBlock().slot),
+      block: await db.block.get(fromHexString(justified.blockRoot)),
       executionOptimistic: false,
     };
   }

--- a/packages/beacon-node/test/unit/api/impl/beacon/blocks/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/blocks/utils.test.ts
@@ -72,10 +72,9 @@ describe("block api utils", function () {
     });
 
     it("should resolve justified", async function () {
-      const expected = 0;
       forkChoiceStub.getJustifiedBlock.returns(expectedSummary);
       await resolveBlockId(forkChoiceStub, dbStub, "justified").catch(() => {});
-      expect(dbStub.blockArchive.get).to.be.calledOnceWithExactly(expected);
+      expect(dbStub.block.get).to.be.calledOnceWithExactly(bufferEqualsMatcher(expectedBuffer));
     });
 
     it("should resolve finalized block root", async function () {

--- a/packages/beacon-node/test/unit/api/impl/beacon/blocks/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/blocks/utils.test.ts
@@ -71,6 +71,13 @@ describe("block api utils", function () {
       expect(dbStub.blockArchive.get).to.be.calledOnceWithExactly(expected);
     });
 
+    it("should resolve justified", async function () {
+      const expected = 0;
+      forkChoiceStub.getJustifiedBlock.returns(expectedSummary);
+      await resolveBlockId(forkChoiceStub, dbStub, "justified").catch(() => {});
+      expect(dbStub.blockArchive.get).to.be.calledOnceWithExactly(expected);
+    });
+
     it("should resolve finalized block root", async function () {
       forkChoiceStub.getBlock.returns(expectedSummary);
       forkChoiceStub.getFinalizedBlock.returns(expectedSummary);


### PR DESCRIPTION
**Motivation**

This PR closes #4255.

**Description**

The [`ethereum-metrics-exporter`](https://github.com/ethpandaops/ethereum-metrics-exporter) uses `justified` as block id to retrieve block details https://ethereum.github.io/beacon-APIs/?urls.primaryName=v2.4.0#/Beacon/getBlockV2.

This PR adds support for the `justified` block id, even if it is not explicitly stated in the Beacon API.
