### PR TITLE
fix(slashing-protection): resolve `minEpoch` max call stack issue

### DIFF
--- a/packages/validator/src/slashingProtection/utils.ts
+++ b/packages/validator/src/slashingProtection/utils.ts
@@ -28,7 +28,7 @@ export function numToString(num: number): string {
 }
 
 export function minEpoch(epochs: Epoch[]): Epoch | null {
-  return epochs.length > 0 ? Math.min(...epochs) : null;
+  return epochs.length > 0 ? epochs.reduce((minEpoch, epoch) => (minEpoch < epoch ? minEpoch : epoch)) : null;
 }
 
 export function uniqueVectorArr(buffers: Uint8Array[]): Uint8Array[] {

--- a/packages/validator/test/unit/slashingProtection/utils.test.ts
+++ b/packages/validator/test/unit/slashingProtection/utils.test.ts
@@ -1,0 +1,20 @@
+import {expect} from "chai";
+import {minEpoch} from "../../../src/slashingProtection/utils.js";
+
+describe("slashingProtection / utils / minEpoch", () => {
+  it("should return the minimum epoch from an array of epochs", () => {
+    expect(minEpoch([15, 10, 20, 30, 5, 1, 50])).to.equal(1);
+  });
+
+  it("should return the only epoch if epochs array only contains one element", () => {
+    expect(minEpoch([10])).to.equal(10);
+  });
+
+  it("should return null if epochs array is empty", () => {
+    expect(minEpoch([])).to.equal(null);
+  });
+
+  it("should not throw 'RangeError: Maximum call stack size exceeded' for huge epoch arrays", () => {
+    expect(() => minEpoch(Array.from({length: 1e6}, (_, index) => index))).to.not.throw(RangeError);
+  });
+});


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5392

**Description**

Epochs array might have more than ~10^5 elements, cannot use `Math.min` as it would throw `RangeError: Maximum call stack size exceeded` if `epochs.length >= 125626`.

This change makes the solution to determine min epoch more robust and adds few unit tests.