### PR TITLE
docs: remove instruction for ignore-optional

### DIFF
--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -29,10 +29,10 @@ cd lodestar
 
 ## Install packages
 
-Install across all packages. Lodestar follows a [monorepo](https://github.com/lerna/lerna) structure, so all commands below must be run in the project root. Use the `--ignore-optional` flag to prevent downloading the Ethereum Consensus spec tests.
+Install across all packages. Lodestar follows a [monorepo](https://github.com/lerna/lerna) structure, so all commands below must be run in the project root.
 
 ```bash
-yarn install --ignore-optional
+yarn install
 ```
 
 ## Build source code


### PR DESCRIPTION
**Motivation**

In the past spec test download was controlled via --ignore-optional. However that's no longer the case, tests are downloaded via a script **only** if spec tests are run.

However nx requires some optional dependencies to work, so let's drop the flag.

**Description**

Remove instruction for ignore-optional
