### PR TITLE
fix(validator): log api errors as `warn` if node is syncing

### DIFF
--- a/packages/validator/src/util/logger.ts
+++ b/packages/validator/src/util/logger.ts
@@ -1,4 +1,4 @@
-import {HttpError} from "@lodestar/api";
+import {ApiError} from "@lodestar/api";
 import {LogData, Logger, isErrorAborted} from "@lodestar/utils";
 import {IClock} from "./clock.js";
 
@@ -18,7 +18,7 @@ export function getLoggerVc(logger: Logger, clock: IClock): LoggerVc {
       if (e) {
         // Returns true if it's an network error with code 503 = Node is syncing
         // https://github.com/ethereum/beacon-APIs/blob/e68a954e1b6f6eb5421abf4532c171ce301c6b2e/types/http.yaml#L62
-        if (e instanceof HttpError && e.status === 503) {
+        if (e instanceof ApiError && e.status === 503) {
           this.isSyncing(e);
         }
         // Only log if arg `e` is not an instance of `ErrorAborted`

--- a/packages/validator/src/util/logger.ts
+++ b/packages/validator/src/util/logger.ts
@@ -44,7 +44,7 @@ export function getLoggerVc(logger: Logger, clock: IClock): LoggerVc {
       if (!hasLogged) {
         hasLogged = true;
         // Log the full error message, in case the server returns 503 for some unknown reason
-        logger.info(`Node is syncing - ${e.message}`);
+        logger.warn(`Node is syncing - ${e.message}`);
       }
     },
   };


### PR DESCRIPTION
**Motivation**

Logs mentioned in https://github.com/ChainSafe/lodestar/issues/5359#issuecomment-1529027981 should not be shown as errors on the VC if beacon node is syncing.

**Description**

`HttpError` is not thrown anymore, instead API client returns a `ApiClientResponse`

https://github.com/ChainSafe/lodestar/blob/913a51d8807d2111d1e67e50f19277e9cc953eac/packages/api/src/utils/client/client.ts#L81-L85

which will be handled by `ApiError.assert` and if not ok, will throw `ApiError`

https://github.com/ChainSafe/lodestar/blob/913a51d8807d2111d1e67e50f19277e9cc953eac/packages/api/src/utils/client/httpClient.ts#L42-L46


**Before**

```
Error: Error on getProposerDuties - Service Unavailable: Node is syncing - headSlot 5529152 currentSlot 5529417
    at Function.assert (file:///usr/app/packages/api/src/utils/client/httpClient.ts:44:13)
    at BlockDutiesService.pollBeaconProposers (file:///usr/app/packages/validator/src/services/blockDuties.ts:155:14)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at BlockDutiesService.pollBeaconProposersAndNotify (file:///usr/app/packages/validator/src/services/blockDuties.ts:129:5)
    at BlockDutiesService.runBlockDutiesTask (file:///usr/app/packages/validator/src/services/blockDuties.ts:87:9)
    at Clock.runAtMostEvery (file:///usr/app/packages/validator/src/util/clock.ts:96:7)
```

**After**

```
warn: Node is syncing - Error on getProposerDuties - Service Unavailable: Node is syncing - headSlot 5564286 currentSlot 5565452
warn: Node is syncing - Error on getProposerDuties - Service Unavailable: Node is syncing - headSlot 5564383 currentSlot 5565453
warn: Node is syncing - Error on getProposerDuties - Service Unavailable: Node is syncing - headSlot 5564479 currentSlot 5565454
```