### PR TITLE
chore: remove unmet peer dependencies

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -84,9 +84,6 @@
     "ajv": "^8.12.0",
     "fastify": "^4.15.0"
   },
-  "peerDependencies": {
-    "fastify": "^4.15.0"
-  },
   "keywords": [
     "ethereum",
     "eth-consensus",

--- a/packages/api/src/utils/server/types.ts
+++ b/packages/api/src/utils/server/types.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import {FastifyInstance} from "fastify";
+import type {FastifyInstance} from "fastify";
 // eslint-disable-next-line import/no-extraneous-dependencies
-import * as fastify from "fastify";
+import type * as fastify from "fastify";
 import {ReqGeneric} from "../types.js";
 
 export type ServerInstance = FastifyInstance;

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -157,9 +157,6 @@
     "varint": "^6.0.0",
     "xxhash-wasm": "1.0.2"
   },
-  "peerDependencies": {
-    "c-kzg": "^1.0.7"
-  },
   "devDependencies": {
     "@types/eventsource": "^1.1.11",
     "@types/leveldown": "^4.0.3",

--- a/packages/reqresp/package.json
+++ b/packages/reqresp/package.json
@@ -69,7 +69,7 @@
     "@lodestar/types": "^1.8.0"
   },
   "peerDependencies": {
-    "libp2p": "0.41.0"
+    "libp2p": "~0.42.2"
   },
   "keywords": [
     "ethereum",


### PR DESCRIPTION
**Motivation**

I dislike warnings

```
warning " > @lodestar/api@1.8.0" has unmet peer dependency "fastify@^4.15.0".
warning " > @lodestar/beacon-node@1.8.0" has unmet peer dependency "c-kzg@^1.0.7".
warning " > @lodestar/reqresp@1.8.0" has unmet peer dependency "libp2p@0.41.0".
```

**Description**

Removes unmet peer dependencies