### PR TITLE
test: add transfer / copy benchmark

### DIFF
--- a/packages/beacon-node/test/perf/util/transferBytes.test.ts
+++ b/packages/beacon-node/test/perf/util/transferBytes.test.ts
@@ -1,4 +1,4 @@
-import {itBench} from "@dapplion/benchmark";
+import {itBench, setBenchOpts} from "@dapplion/benchmark";
 import {expect} from "chai";
 
 describe("transfer bytes", function () {
@@ -13,6 +13,8 @@ describe("transfer bytes", function () {
     {size: 524380, name: "BlobsSidecar"},
     {size: 1_000_000, name: "Big SignedBeaconBlock"},
   ];
+
+  setBenchOpts({noThreshold: true});
 
   for (const {size, name} of sizes) {
     const array = new Uint8Array(size);

--- a/packages/beacon-node/test/perf/util/transferBytes.test.ts
+++ b/packages/beacon-node/test/perf/util/transferBytes.test.ts
@@ -1,4 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
+import {expect} from "chai";
 
 describe("transfer bytes", function () {
   const sizes = [
@@ -12,6 +13,7 @@ describe("transfer bytes", function () {
     {size: 524380, name: "BlobsSidecar"},
     {size: 1_000_000, name: "Big SignedBeaconBlock"},
   ];
+
   for (const {size, name} of sizes) {
     const array = new Uint8Array(size);
     for (let i = 0; i < array.length; i++) array[i] = Math.random() * 255;
@@ -29,4 +31,14 @@ describe("transfer bytes", function () {
       },
     });
   }
+
+  it("ArrayBuffer use after structuredClone transfer", () => {
+    const data = new Uint8Array(32);
+    data[0] = 1;
+    expect(data[0]).equals(1);
+    structuredClone(data, {transfer: [data.buffer]});
+    // After structuredClone() data is mutated in place to hold an empty ArrayBuffer
+    expect(data[0]).equals(undefined);
+    expect(data).deep.equals(new Uint8Array());
+  });
 });

--- a/packages/beacon-node/test/perf/util/transferBytes.test.ts
+++ b/packages/beacon-node/test/perf/util/transferBytes.test.ts
@@ -1,0 +1,32 @@
+import {itBench} from "@dapplion/benchmark";
+
+describe("transfer bytes", function () {
+  const sizes = [
+    {size: 84, name: "Status"},
+    {size: 112, name: "SignedVoluntaryExit"},
+    {size: 416, name: "ProposerSlashing"},
+    {size: 485, name: "Attestation"},
+    {size: 33_232, name: "AttesterSlashing"},
+    {size: 128_000, name: "Small SignedBeaconBlock"},
+    {size: 200_000, name: "Avg SignedBeaconBlock"},
+    {size: 524380, name: "BlobsSidecar"},
+    {size: 1_000_000, name: "Big SignedBeaconBlock"},
+  ];
+  for (const {size, name} of sizes) {
+    const array = new Uint8Array(size);
+    for (let i = 0; i < array.length; i++) array[i] = Math.random() * 255;
+    itBench({
+      id: `transfer serialized ${name} (${size} B)`,
+      beforeEach: () => array.slice(),
+      fn: async (a) => {
+        structuredClone(a, {transfer: [a.buffer]});
+      },
+    });
+    itBench({
+      id: `copy serialized ${name} (${size} B)`,
+      fn: async () => {
+        structuredClone(array);
+      },
+    });
+  }
+});


### PR DESCRIPTION
```
  transfer bytes
    ✔ transfer serialized Status (84 B)                                   278784.5 ops/s    3.587000 us/op        -     200446 runs   1.01 s
    ✔ copy serialized Status (84 B)                                       344708.7 ops/s    2.901000 us/op        -     307857 runs   1.01 s
    ✔ transfer serialized SignedVoluntaryExit (112 B)                     291460.2 ops/s    3.431000 us/op        -     230077 runs   1.11 s
    ✔ copy serialized SignedVoluntaryExit (112 B)                         332446.8 ops/s    3.008000 us/op        -     415151 runs   1.41 s
    ✔ transfer serialized ProposerSlashing (416 B)                        235294.1 ops/s    4.250000 us/op        -     168969 runs   1.01 s
    ✔ copy serialized ProposerSlashing (416 B)                            228990.2 ops/s    4.367000 us/op        -     212139 runs   1.01 s
    ✔ transfer serialized Attestation (485 B)                             242895.3 ops/s    4.117000 us/op        -     435085 runs   2.53 s
    ✔ copy serialized Attestation (485 B)                                 259470.7 ops/s    3.854000 us/op        -     427502 runs   1.82 s
    ✔ transfer serialized AttesterSlashing (33232 B)                      255754.5 ops/s    3.910000 us/op        -      73625 runs  0.808 s
    ✔ copy serialized AttesterSlashing (33232 B)                          116563.7 ops/s    8.579000 us/op        -      32696 runs  0.303 s
    ✔ transfer serialized Small SignedBeaconBlock (128000 B)              234192.0 ops/s    4.270000 us/op        -      28611 runs  0.707 s
    ✔ copy serialized Small SignedBeaconBlock (128000 B)                  44865.18 ops/s    22.28900 us/op        -      12291 runs  0.303 s
    ✔ transfer serialized Avg SignedBeaconBlock (200000 B)                200843.5 ops/s    4.979000 us/op        -      13545 runs  0.505 s
    ✔ copy serialized Avg SignedBeaconBlock (200000 B)                    30021.92 ops/s    33.30900 us/op        -       7960 runs  0.303 s
    ✔ transfer serialized BlobsSidecar (524380 B)                         182249.0 ops/s    5.487000 us/op        -      10534 runs  0.909 s
    ✔ copy serialized BlobsSidecar (524380 B)                             12473.03 ops/s    80.17300 us/op        -       4001 runs  0.404 s
    ✔ transfer serialized Big SignedBeaconBlock (1000000 B)               164419.6 ops/s    6.082000 us/op        -       7487 runs   1.27 s
    ✔ copy serialized Big SignedBeaconBlock (1000000 B)                   6638.784 ops/s    150.6300 us/op        -       2004 runs  0.454 s
```