### PR TITLE
feat(cli): export slashing protection as interchange format v5

### DIFF
--- a/packages/cli/src/cmds/validator/slashingProtection/export.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/export.ts
@@ -104,6 +104,6 @@ export const exportCmd: CliCommand<ExportArgs, ISlashingProtectionArgs & Account
 
       logger.info("Writing slashing protection data", {file: args.file});
       writeFile600Perm(args.file, interchange);
-      logger.verbose("Export completed successfully");
+      logger.info("Export completed successfully");
     },
   };

--- a/packages/cli/src/cmds/validator/slashingProtection/export.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/export.ts
@@ -46,8 +46,7 @@ export const exportCmd: CliCommand<ExportArgs, ISlashingProtectionArgs & Account
 
       const {validatorsDbDir: dbPath} = getValidatorPaths(args, network);
 
-      // TODO: Allow format version and pubkeys to be customized with CLI args
-      const formatVersion: InterchangeFormatVersion = {version: "4", format: "complete"};
+      const formatVersion: InterchangeFormatVersion = {version: "5"};
       logger.info("Exporting the slashing protection logs", {...formatVersion, dbPath});
 
       const {slashingProtection, metadata} = getSlashingProtection(args, network, logger);

--- a/packages/cli/src/cmds/validator/slashingProtection/export.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/export.ts
@@ -35,7 +35,7 @@ export const exportCmd: CliCommand<ExportArgs, ISlashingProtectionArgs & Account
         type: "string",
       },
       pubkeys: {
-        description: "Export slashing protection data for only a given subset of pubkeys",
+        description: "Export slashing protection data only for a given subset of pubkeys",
         type: "array",
         string: true, // Ensures the pubkey string is not automatically converted to numbers
         coerce: (pubkeys: string[]): string[] =>
@@ -71,12 +71,12 @@ export const exportCmd: CliCommand<ExportArgs, ISlashingProtectionArgs & Account
       const genesisValidatorsRoot =
         (await metadata.getGenesisValidatorsRoot()) ?? (await getGenesisValidatorsRoot(args));
 
-      logger.verbose("Fetching pubkeys from slashing protection DB");
+      logger.verbose("Fetching pubkeys from slashing protection db");
       const allPubkeys = await slashingProtection.listPubkeys();
       let pubkeysToExport = allPubkeys;
 
       if (args.pubkeys) {
-        logger.verbose("Filtering by given subset of pubkeys", {count: args.pubkeys.length});
+        logger.verbose("Filtering by pubkeys from args", {count: args.pubkeys.length});
         const filteredPubkeys = [];
 
         for (const pubkeyHex of args.pubkeys) {
@@ -85,7 +85,7 @@ export const exportCmd: CliCommand<ExportArgs, ISlashingProtectionArgs & Account
           }
           const existingPubkey = allPubkeys.find((pubkey) => toHexString(pubkey) === pubkeyHex);
           if (!existingPubkey) {
-            logger.warn("Pubkey not found in slashing protection DB", {pubkey: pubkeyHex});
+            logger.warn("Pubkey not found in slashing protection db", {pubkey: pubkeyHex});
           } else {
             filteredPubkeys.push(existingPubkey);
           }

--- a/packages/cli/src/cmds/validator/slashingProtection/export.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/export.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
+import {toHexString} from "@chainsafe/ssz";
 import {InterchangeFormatVersion} from "@lodestar/validator";
-import {CliCommand, writeFile600Perm} from "../../../util/index.js";
+import {CliCommand, YargsError, ensure0xPrefix, isValidatePubkeyHex, writeFile600Perm} from "../../../util/index.js";
 import {GlobalArgs} from "../../../options/index.js";
 import {AccountValidatorArgs} from "../options.js";
 import {getCliLogger, LogArgs} from "../../../util/index.js";
@@ -11,6 +12,7 @@ import {ISlashingProtectionArgs} from "./options.js";
 
 type ExportArgs = {
   file: string;
+  pubkeys?: string[];
 };
 
 export const exportCmd: CliCommand<ExportArgs, ISlashingProtectionArgs & AccountValidatorArgs & GlobalArgs & LogArgs> =
@@ -32,6 +34,17 @@ export const exportCmd: CliCommand<ExportArgs, ISlashingProtectionArgs & Account
         demandOption: true,
         type: "string",
       },
+      pubkeys: {
+        description: "Export slashing protection data for only a given subset of pubkeys",
+        type: "array",
+        string: true, // Ensures the pubkey string is not automatically converted to numbers
+        coerce: (pubkeys: string[]): string[] =>
+          // Parse ["0x11,0x22"] to ["0x11", "0x22"]
+          pubkeys
+            .map((item) => item.split(","))
+            .flat(1)
+            .map(ensure0xPrefix),
+      },
     },
 
     handler: async (args) => {
@@ -47,7 +60,7 @@ export const exportCmd: CliCommand<ExportArgs, ISlashingProtectionArgs & Account
       const {validatorsDbDir: dbPath} = getValidatorPaths(args, network);
 
       const formatVersion: InterchangeFormatVersion = {version: "5"};
-      logger.info("Exporting the slashing protection logs", {...formatVersion, dbPath});
+      logger.info("Exporting slashing protection data", {...formatVersion, dbPath});
 
       const {slashingProtection, metadata} = getSlashingProtection(args, network, logger);
 
@@ -58,18 +71,38 @@ export const exportCmd: CliCommand<ExportArgs, ISlashingProtectionArgs & Account
       const genesisValidatorsRoot =
         (await metadata.getGenesisValidatorsRoot()) ?? (await getGenesisValidatorsRoot(args));
 
-      logger.verbose("Fetching the pubkeys from the slashingProtection db");
-      const pubkeys = await slashingProtection.listPubkeys();
+      logger.verbose("Fetching pubkeys from slashing protection DB");
+      const allPubkeys = await slashingProtection.listPubkeys();
+      let pubkeysToExport = allPubkeys;
 
-      logger.info("Starting export for pubkeys found", {pubkeys: pubkeys.length});
+      if (args.pubkeys) {
+        logger.verbose("Filtering by given subset of pubkeys", {count: args.pubkeys.length});
+        const filteredPubkeys = [];
+
+        for (const pubkeyHex of args.pubkeys) {
+          if (!isValidatePubkeyHex(pubkeyHex)) {
+            throw new YargsError(`Invalid pubkey ${pubkeyHex}`);
+          }
+          const existingPubkey = allPubkeys.find((pubkey) => toHexString(pubkey) === pubkeyHex);
+          if (!existingPubkey) {
+            logger.warn("Pubkey not found in slashing protection DB", {pubkey: pubkeyHex});
+          } else {
+            filteredPubkeys.push(existingPubkey);
+          }
+        }
+
+        pubkeysToExport = filteredPubkeys;
+      }
+
+      logger.info("Starting export for pubkeys found", {count: pubkeysToExport.length});
       const interchange = await slashingProtection.exportInterchange(
         genesisValidatorsRoot,
-        pubkeys,
+        pubkeysToExport,
         formatVersion,
         logger
       );
 
-      logger.info("Writing the slashing protection logs", {file: args.file});
+      logger.info("Writing slashing protection data", {file: args.file});
       writeFile600Perm(args.file, interchange);
       logger.verbose("Export completed successfully");
     },

--- a/packages/cli/src/cmds/validator/slashingProtection/import.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/import.ts
@@ -47,7 +47,7 @@ export const importCmd: CliCommand<ImportArgs, ISlashingProtectionArgs & Account
 
       const {validatorsDbDir: dbPath} = getValidatorPaths(args, network);
 
-      logger.info("Importing the slashing protection logs", {dbPath});
+      logger.info("Importing slashing protection data", {dbPath});
 
       const {slashingProtection, metadata} = getSlashingProtection(args, network, logger);
 
@@ -58,7 +58,7 @@ export const importCmd: CliCommand<ImportArgs, ISlashingProtectionArgs & Account
       const genesisValidatorsRoot =
         (await metadata.getGenesisValidatorsRoot()) ?? (await getGenesisValidatorsRoot(args));
 
-      logger.verbose("Reading the slashing protection logs", {file: args.file});
+      logger.verbose("Reading slashing protection data", {file: args.file});
       const interchangeStr = await fs.promises.readFile(args.file, "utf8");
       const interchangeJson = JSON.parse(interchangeStr) as Interchange;
 

--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -47,8 +47,7 @@ If no `pubkeys` are provided, it will exit all validators that have been importe
     },
 
     pubkeys: {
-      description:
-        "Pubkeys to exit, must be available as local signers. Multiple keys have to be provided as comma-separated values.",
+      description: "Pubkeys to exit, must be available as local signers",
       type: "array",
       string: true, // Ensures the pubkey string is not automatically converted to numbers
       coerce: (pubkeys: string[]): string[] =>

--- a/packages/validator/src/slashingProtection/index.ts
+++ b/packages/validator/src/slashingProtection/index.ts
@@ -59,7 +59,7 @@ export class SlashingProtection extends DatabaseService implements ISlashingProt
   async importInterchange(interchange: Interchange, genesisValidatorsRoot: Root, logger?: Logger): Promise<void> {
     const {data} = parseInterchange(interchange, genesisValidatorsRoot);
     for (const validator of data) {
-      logger?.info(`Importing logs for Validator ${toHexString(validator.pubkey)}`);
+      logger?.info("Importing slashing protection", {pubkey: toHexString(validator.pubkey)});
       await this.blockService.importBlocks(validator.pubkey, validator.signedBlocks);
       await this.attestationService.importAttestations(validator.pubkey, validator.signedAttestations);
     }
@@ -73,7 +73,7 @@ export class SlashingProtection extends DatabaseService implements ISlashingProt
   ): Promise<Interchange> {
     const validatorData: InterchangeLodestar["data"] = [];
     for (const pubkey of pubkeys) {
-      logger?.info(`Exporting logs for Validator ${toHexString(pubkey)}`);
+      logger?.info("Exporting slashing protection", {pubkey: toHexString(pubkey)});
       validatorData.push({
         pubkey,
         signedBlocks: await this.blockService.exportBlocks(pubkey),


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5248

**Description**

- Export slashing protection as interchange format v5
- Add flag to only export for a given subset of pubkeys

The issue also suggests to add documentation but for now seems sufficient to have [validator-slashing-protection](https://chainsafe.github.io/lodestar/reference/cli/#validator-slashing-protection).