### PR TITLE
chore: dynamic year on the chainsafe cli notice

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -9,7 +9,7 @@ import {getVersionData} from "./util/version.js";
 const {version} = getVersionData();
 const topBanner = `🌟 Lodestar: TypeScript Implementation of the Ethereum Consensus Beacon Chain.
   * Version: ${version}
-  * by ChainSafe Systems, 2018-2023`;
+  * by ChainSafe Systems, 2018-${new Date().getFullYear()}`;
 const bottomBanner = `📖 For more information, check the CLI reference:
   * https://chainsafe.github.io/lodestar/reference/cli
 

--- a/packages/flare/src/cli.ts
+++ b/packages/flare/src/cli.ts
@@ -10,7 +10,7 @@ Flare is a sudden brief burst of bright flame or light.
 In the wrong hands, can lead people astray.
 Use with care.
 
-  * by ChainSafe Systems, 2018-2023`;
+  * by ChainSafe Systems, 2018-${new Date().getFullYear()}`;
 const bottomBanner = `
 ✍️ Give feedback and report issues on GitHub:
   * https://github.com/ChainSafe/lodestar`;

--- a/packages/prover/src/cli/cli.ts
+++ b/packages/prover/src/cli/cli.ts
@@ -9,7 +9,7 @@ import {globalOptions} from "./options.js";
 const {version} = getVersionData();
 const topBanner = `🌟 Lodestar Prover Proxy: Ethereum RPC proxy for RPC responses, verified against the trusted block hashes.
   * Version: ${version}
-  * by ChainSafe Systems, 2018-2023`;
+  * by ChainSafe Systems, 2018-${new Date().getFullYear()}`;
 const bottomBanner = `📖 For more information, check the CLI reference:
   * https://chainsafe.github.io/lodestar/reference/cli
 


### PR DESCRIPTION
**Motivation**

As discussed in https://github.com/ChainSafe/lodestar/pull/5466 we don't really know why the year is even there but it "looks correct" so let's keep it and make sure it always up to date.

**Description**

Makes year on the chainsafe cli notice dynamic.
