### PR TITLE
refactor: update the execution api responses to decoupled blobs spec

### DIFF
--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -1,6 +1,6 @@
 import {ssz, allForks, bellatrix, Slot, Root, BLSPubkey} from "@lodestar/types";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
-import {ForkName, isForkExecution, isForkBlobs} from "@lodestar/params";
+import {ForkName, isForkExecution} from "@lodestar/params";
 import {ChainForkConfig} from "@lodestar/config";
 
 import {
@@ -42,14 +42,6 @@ export type Api = {
       HttpStatusCode.SERVICE_UNAVAILABLE
     >
   >;
-  submitBlindedBlockV2(
-    signedBlock: allForks.SignedBlindedBeaconBlock
-  ): Promise<
-    ApiClientResponse<
-      {[HttpStatusCode.OK]: {data: allForks.SignedBeaconBlockAndBlobsSidecar; version: ForkName}},
-      HttpStatusCode.SERVICE_UNAVAILABLE
-    >
-  >;
 };
 
 /**
@@ -60,7 +52,6 @@ export const routesData: RoutesData<Api> = {
   registerValidator: {url: "/eth/v1/builder/validators", method: "POST"},
   getHeader: {url: "/eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}", method: "GET"},
   submitBlindedBlock: {url: "/eth/v1/builder/blinded_blocks", method: "POST"},
-  submitBlindedBlockV2: {url: "/eth/v2/builder/blinded_blocks", method: "POST"},
 };
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -69,7 +60,6 @@ export type ReqTypes = {
   registerValidator: {body: unknown};
   getHeader: {params: {slot: Slot; parent_hash: string; pubkey: string}};
   submitBlindedBlock: {body: unknown};
-  submitBlindedBlockV2: {body: unknown};
 };
 
 export function getReqSerializers(config: ChainForkConfig): ReqSerializers<Api, ReqTypes> {
@@ -86,7 +76,6 @@ export function getReqSerializers(config: ChainForkConfig): ReqSerializers<Api, 
       },
     },
     submitBlindedBlock: getBeaconReqSerializers(config)["publishBlindedBlock"],
-    submitBlindedBlockV2: getBeaconReqSerializers(config)["publishBlindedBlock"],
   };
 }
 
@@ -97,11 +86,6 @@ export function getReturnTypes(): ReturnTypes<Api> {
     ),
     submitBlindedBlock: WithVersion((fork: ForkName) =>
       isForkExecution(fork) ? ssz.allForksExecution[fork].ExecutionPayload : ssz.bellatrix.ExecutionPayload
-    ),
-    submitBlindedBlockV2: WithVersion((fork: ForkName) =>
-      isForkBlobs(fork)
-        ? ssz.allForksBlobs[fork].SignedBeaconBlockAndBlobsSidecar
-        : ssz.deneb.SignedBeaconBlockAndBlobsSidecar
     ),
   };
 }

--- a/packages/api/test/unit/builder/testData.ts
+++ b/packages/api/test/unit/builder/testData.ts
@@ -26,8 +26,4 @@ export const testData: GenericServerTestCases<Api> = {
     args: [ssz.deneb.SignedBlindedBeaconBlock.defaultValue()],
     res: {version: ForkName.bellatrix, data: ssz.bellatrix.ExecutionPayload.defaultValue()},
   },
-  submitBlindedBlockV2: {
-    args: [ssz.deneb.SignedBlindedBeaconBlock.defaultValue()],
-    res: {version: ForkName.deneb, data: ssz.deneb.SignedBeaconBlockAndBlobsSidecar.defaultValue()},
-  },
 };

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -184,16 +184,7 @@ export function getBeaconBlockApi({
       if (!executionBuilder) throw Error("exeutionBuilder required to publish SignedBlindedBeaconBlock");
       let signedBlock: allForks.SignedBeaconBlock;
       if (config.getForkSeq(signedBlindedBlock.message.slot) >= ForkSeq.deneb) {
-        const {beaconBlock, blobsSidecar} = await executionBuilder.submitBlindedBlockV2(signedBlindedBlock);
-        signedBlock = beaconBlock;
-        // add this blobs to the map for access & broadcasting in publishBlock
-        const {blockHash} = signedBlindedBlock.message.body.executionPayloadHeader;
-        chain.producedBlobsSidecarCache.set(toHexString(blockHash), blobsSidecar);
-        // TODO: Do we need to prune here ? prune will anyway be called in local execution flow
-        // pruneSetToMax(
-        //   chain.producedBlobsSidecarCache,
-        //   chain.opts.maxCachedBlobsSidecar ?? DEFAULT_MAX_CACHED_BLOBS_SIDECAR
-        // );
+        throw Error("exeutionBuilder not yet implemented for deneb+ forks");
       } else {
         signedBlock = await executionBuilder.submitBlindedBlock(signedBlindedBlock);
       }

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -425,13 +425,14 @@ export class BeaconChain implements IBeaconChain {
     // blinded blobs will be fetched and added to this cache later before finally
     // publishing the blinded block's full version
     if (blobs.type === BlobsResultType.produced) {
+      const blockBlobs = blobs.blobSidecars.map((blobSidecar) => blobSidecar.blob);
       // TODO DENEB: Prune data structure for max entries
       this.producedBlobsSidecarCache.set(blobs.blockHash, {
         // TODO DENEB: Optimize, hashing the full block is not free.
         beaconBlockRoot: this.config.getForkTypes(block.slot).BeaconBlock.hashTreeRoot(block),
         beaconBlockSlot: block.slot,
-        blobs: blobs.blobs,
-        kzgAggregatedProof: ckzg.computeAggregateKzgProof(blobs.blobs),
+        blobs: blockBlobs,
+        kzgAggregatedProof: ckzg.computeAggregateKzgProof(blockBlobs),
       });
       pruneSetToMax(
         this.producedBlobsSidecarCache,

--- a/packages/beacon-node/src/chain/produceBlock/validateBlobsAndKzgCommitments.ts
+++ b/packages/beacon-node/src/chain/produceBlock/validateBlobsAndKzgCommitments.ts
@@ -10,17 +10,19 @@ import {ckzg} from "../../util/kzg.js";
  * https://github.com/ethereum/consensus-specs/blob/11a037fd9227e29ee809c9397b09f8cc3383a8c0/specs/eip4844/validator.md#blob-kzg-commitments
  */
 export function validateBlobsAndKzgCommitments(payload: allForks.ExecutionPayload, blobsBundle: BlobsBundle): void {
-  verifyKzgCommitmentsAgainstTransactions(payload.transactions, blobsBundle.kzgs);
+  verifyKzgCommitmentsAgainstTransactions(payload.transactions, blobsBundle.commitments);
 
   // Optionally sanity-check that the KZG commitments match the blobs (as produced by the execution engine)
-  if (blobsBundle.blobs.length !== blobsBundle.kzgs.length) {
-    throw Error(`Blobs bundle blobs len ${blobsBundle.blobs.length} != kzgs len ${blobsBundle.kzgs.length}`);
+  if (blobsBundle.blobs.length !== blobsBundle.commitments.length) {
+    throw Error(
+      `Blobs bundle blobs len ${blobsBundle.blobs.length} != commitments len ${blobsBundle.commitments.length}`
+    );
   }
 
   for (let i = 0; i < blobsBundle.blobs.length; i++) {
     const kzg = ckzg.blobToKzgCommitment(blobsBundle.blobs[i]) as deneb.KZGCommitment;
-    if (!byteArrayEquals(kzg, blobsBundle.kzgs[i])) {
-      throw Error(`Wrong KZG[${i}] ${toHex(blobsBundle.kzgs[i])} expected ${toHex(kzg)}`);
+    if (!byteArrayEquals(kzg, blobsBundle.commitments[i])) {
+      throw Error(`Wrong KZG[${i}] ${toHex(blobsBundle.commitments[i])} expected ${toHex(kzg)}`);
     }
   }
 }

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -5,7 +5,6 @@ import {byteArrayEquals, toHexString} from "@chainsafe/ssz";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 
 import {ApiError} from "@lodestar/api";
-import {validateBlobsAndKzgCommitments} from "../../chain/produceBlock/validateBlobsAndKzgCommitments.js";
 import {Metrics} from "../../metrics/metrics.js";
 import {IExecutionBuilder} from "./interface.js";
 
@@ -122,49 +121,5 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
       message: {...signedBlock.message, body: {...signedBlock.message.body, executionPayload}},
     };
     return fullySignedBlock;
-  }
-
-  async submitBlindedBlockV2(
-    signedBlock: allForks.SignedBlindedBeaconBlock
-  ): Promise<allForks.SignedBeaconBlockAndBlobsSidecar> {
-    const res = await this.api.submitBlindedBlockV2(signedBlock);
-    ApiError.assert(res, "execution.builder.submitBlindedBlockV2");
-    const signedBeaconBlockAndBlobsSidecar = res.response.data;
-    // Since we get the full block back, we can just just compare the hash of blinded to returned
-    const {beaconBlock, blobsSidecar} = signedBeaconBlockAndBlobsSidecar;
-
-    // Verify if the transactions and withdrawals match with their corresponding roots
-    // since we get the full signed block back, its easy to validate response consistency
-    // if the signed blinded and signed full root simply match
-    const signedBlockRoot = this.config
-      .getBlindedForkTypes(signedBlock.message.slot)
-      .SignedBeaconBlock.hashTreeRoot(signedBlock);
-    const beaconBlockRoot = this.config
-      .getForkTypes(beaconBlock.message.slot)
-      .SignedBeaconBlock.hashTreeRoot(beaconBlock);
-    if (!byteArrayEquals(signedBlockRoot, beaconBlockRoot)) {
-      throw Error(
-        `Invalid SignedBeaconBlock of the builder submitBlindedBlockV2 response, expected=${toHexString(
-          signedBlockRoot
-        )}, actual=${toHexString(beaconBlockRoot)}`
-      );
-    }
-
-    // Sanity check consistency between payload and blobs bundle still needs to be done
-    const payload = beaconBlock.message.body.executionPayload;
-    const blockHash = toHexString(payload.blockHash);
-    const blobsBlockHash = toHexString(blobsSidecar.beaconBlockRoot);
-    if (blockHash !== blobsBlockHash) {
-      throw Error(`blobsSidecar incorrect blockHash expected=${blockHash}, actual=${blobsBlockHash}`);
-    }
-    // Sanity-check that the KZG commitments match the versioned hashes in the transactions
-    const {blobKzgCommitments: kzgs} = beaconBlock.message.body as deneb.BeaconBlockBody;
-    if (kzgs === undefined) {
-      throw Error("Missing blobKzgCommitments on beaconBlock's body");
-    }
-    const {blobs} = blobsSidecar;
-    validateBlobsAndKzgCommitments(payload, {blockHash, kzgs, blobs});
-
-    return signedBeaconBlockAndBlobsSidecar;
   }
 }

--- a/packages/beacon-node/src/execution/builder/interface.ts
+++ b/packages/beacon-node/src/execution/builder/interface.ts
@@ -26,7 +26,4 @@ export interface IExecutionBuilder {
     blobKzgCommitments?: deneb.BlobKzgCommitments;
   }>;
   submitBlindedBlock(signedBlock: allForks.SignedBlindedBeaconBlock): Promise<allForks.SignedBeaconBlock>;
-  submitBlindedBlockV2(
-    signedBlock: allForks.SignedBlindedBeaconBlock
-  ): Promise<allForks.SignedBeaconBlockAndBlobsSidecar>;
 }

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -20,7 +20,6 @@ import {PayloadIdCache} from "./payloadIdCache.js";
 import {
   EngineApiRpcParamTypes,
   EngineApiRpcReturnTypes,
-  parseBlobsBundle,
   parseExecutionPayload,
   serializeExecutionPayload,
   serializePayloadAttributes,
@@ -293,7 +292,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   async getPayload(
     fork: ForkName,
     payloadId: PayloadId
-  ): Promise<{executionPayload: allForks.ExecutionPayload; blockValue: Wei}> {
+  ): Promise<{executionPayload: allForks.ExecutionPayload; blockValue: Wei; blobsBundle?: BlobsBundle}> {
     const method =
       ForkSeq[fork] >= ForkSeq.deneb
         ? "engine_getPayloadV3"
@@ -311,22 +310,6 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       getPayloadOpts
     );
     return parseExecutionPayload(fork, payloadResponse);
-  }
-
-  async getBlobsBundle(payloadId: PayloadId): Promise<BlobsBundle> {
-    const method = "engine_getBlobsBundleV1";
-    const blobsBundle = await this.rpc.fetchWithRetries<
-      EngineApiRpcReturnTypes[typeof method],
-      EngineApiRpcParamTypes[typeof method]
-    >(
-      {
-        method,
-        params: [payloadId],
-      },
-      getPayloadOpts
-    );
-
-    return parseBlobsBundle(blobsBundle);
   }
 
   /**

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -1,5 +1,5 @@
 import {ForkName} from "@lodestar/params";
-import {KZGCommitment, Blob} from "@lodestar/types/deneb";
+import {KZGCommitment, Blob, KZGProof} from "@lodestar/types/deneb";
 import {RootHex, allForks, capella, Wei} from "@lodestar/types";
 
 import {DATA, QUANTITY} from "../../eth1/provider/utils.js";
@@ -65,9 +65,9 @@ export type BlobsBundle = {
    * Execution payload `blockHash` for the caller to sanity-check the consistency with the `engine_getPayload` call
    * https://github.com/protolambda/execution-apis/blob/bf44a8d08ab34b861ef97fa9ef5c5e7806194547/src/engine/blob-extension.md?plain=1#L49
    */
-  blockHash: RootHex;
-  kzgs: KZGCommitment[];
+  commitments: KZGCommitment[];
   blobs: Blob[];
+  proofs: KZGProof[];
 };
 
 /**
@@ -119,20 +119,7 @@ export interface IExecutionEngine {
   getPayload(
     fork: ForkName,
     payloadId: PayloadId
-  ): Promise<{executionPayload: allForks.ExecutionPayload; blockValue: Wei}>;
-
-  /**
-   * "After retrieving the execution payload from the execution engine as specified in Bellatrix,
-   * use the payload_id to retrieve blobs and blob_kzg_commitments
-   * via get_blobs_and_kzg_commitments(payload_id)."
-   * https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/validator.md#blob-kzg-commitments
-   *
-   * This function calls the Engine API method engine_getBlobsBundleV1, what the consensus-spec
-   * describes as `get_blobs_and_kzg_commitments(payload_id)`.
-   *
-   * The Engine API spec is in PR: https://github.com/ethereum/execution-apis/pull/197
-   */
-  getBlobsBundle(payloadId: PayloadId): Promise<BlobsBundle>;
+  ): Promise<{executionPayload: allForks.ExecutionPayload; blockValue: Wei; blobsBundle?: BlobsBundle}>;
 
   exchangeTransitionConfigurationV1(
     transitionConfiguration: TransitionConfigurationV1

--- a/packages/types/src/deneb/sszTypes.ts
+++ b/packages/types/src/deneb/sszTypes.ts
@@ -14,7 +14,19 @@ import {ssz as phase0Ssz} from "../phase0/index.js";
 import {ssz as altairSsz} from "../altair/index.js";
 import {ssz as capellaSsz} from "../capella/index.js";
 
-const {UintNum64, Slot, Root, BLSSignature, UintBn256, Bytes32, Bytes48, Bytes96, BLSPubkey} = primitiveSsz;
+const {
+  UintNum64,
+  Slot,
+  Root,
+  BLSSignature,
+  UintBn256,
+  Bytes32,
+  Bytes48,
+  Bytes96,
+  BLSPubkey,
+  BlobIndex,
+  ValidatorIndex,
+} = primitiveSsz;
 
 // Polynomial commitments
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md
@@ -126,6 +138,23 @@ export const SignedBeaconBlock = new ContainerType(
   {typeName: "SignedBeaconBlock", jsonCase: "eth2"}
 );
 
+export const BlobSidecar = new ContainerType(
+  {
+    blockRoot: Root,
+    index: BlobIndex,
+    slot: Slot,
+    blockParentRoot: Root,
+    proposerIndex: ValidatorIndex,
+    blob: Blob,
+    kzgCommitment: KZGCommitment,
+    kzgProof: KZGProof,
+  },
+  {typeName: "BlobSidecar", jsonCase: "eth2"}
+);
+
+export const BlobSidecars = new ListCompositeType(BlobSidecar, MAX_BLOBS_PER_BLOCK);
+
+// TODO: replace and cleanup previous types when other parts integrated seamlessly
 export const BlobsSidecar = new ContainerType(
   {
     beaconBlockRoot: Root,

--- a/packages/types/src/deneb/types.ts
+++ b/packages/types/src/deneb/types.ts
@@ -20,6 +20,9 @@ export type ExecutionPayloadHeader = ValueOf<typeof ssz.ExecutionPayloadHeader>;
 export type BeaconBlockBody = ValueOf<typeof ssz.BeaconBlockBody>;
 export type BeaconBlock = ValueOf<typeof ssz.BeaconBlock>;
 export type SignedBeaconBlock = ValueOf<typeof ssz.SignedBeaconBlock>;
+
+export type BlobSidecar = ValueOf<typeof ssz.BlobSidecar>;
+export type BlobSidecars = ValueOf<typeof ssz.BlobSidecars>;
 export type SignedBeaconBlockAndBlobsSidecar = ValueOf<typeof ssz.SignedBeaconBlockAndBlobsSidecar>;
 
 export type BeaconState = ValueOf<typeof ssz.BeaconState>;

--- a/packages/types/src/primitive/sszTypes.ts
+++ b/packages/types/src/primitive/sszTypes.ts
@@ -52,6 +52,7 @@ export const WithdrawalIndex = UintNum64;
 export const Gwei = UintBn64;
 export const Wei = UintBn256;
 export const Root = new ByteVectorType(32);
+export const BlobIndex = UintNum64;
 
 export const Version = Bytes4;
 export const DomainType = Bytes4;

--- a/packages/types/src/primitive/types.ts
+++ b/packages/types/src/primitive/types.ts
@@ -29,6 +29,7 @@ export type CommitteeIndex = UintNum64;
 export type SubcommitteeIndex = UintNum64;
 export type ValidatorIndex = UintNum64;
 export type WithdrawalIndex = UintNum64;
+export type BlobIndex = UintNum64;
 export type Gwei = UintBn64;
 export type Wei = UintBn256;
 export type Root = Bytes32;


### PR DESCRIPTION
As part of by parts integration of free the blobs PR
 - https://github.com/ChainSafe/lodestar/pull/5181
 
This PR update the execution responses and handling : 
1. Merged blobsBundle to getPayloadV3
2. Make blobsBundle structure changes 
3. Removes submitBlindedBlockV2 from builder as this api endpoint for deneb has been removed from builder api spec and will rather be handled in submitBlindedBlock (yet to be finalized)