### PR TITLE
fix: modify minimal preset's field elements per blob to mainnet for dev runs

### DIFF
--- a/packages/beacon-node/test/setupPreset.ts
+++ b/packages/beacon-node/test/setupPreset.ts
@@ -1,4 +1,12 @@
+import {setActivePreset, PresetName} from "@lodestar/params/setPreset";
 // Set minimal
 if (process.env.LODESTAR_PRESET === undefined) {
   process.env.LODESTAR_PRESET = "minimal";
+}
+
+// Override FIELD_ELEMENTS_PER_BLOB if its a dev run, mostly to distinguish from
+// spec runs
+if (process.env.LODESTAR_PRESET === "minimal" && process.env.DEV_RUN) {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  setActivePreset(PresetName.minimal, {FIELD_ELEMENTS_PER_BLOB: 4096});
 }

--- a/packages/cli/src/applyPreset.ts
+++ b/packages/cli/src/applyPreset.ts
@@ -14,7 +14,7 @@
 // set LODESTAR_PRESET manually every time.
 
 // IMPORTANT: only import Lodestar code here which does not import any other Lodestar libraries
-import {setActivePreset, presetFromJson} from "@lodestar/params/setPreset";
+import {setActivePreset, presetFromJson, PresetName} from "@lodestar/params/setPreset";
 import {readFile} from "./util/file.js";
 
 const network = valueOfArg("network");
@@ -35,6 +35,9 @@ else if (process.env.LODESTAR_PRESET) {
 else if (network) {
   if (network === "dev") {
     process.env.LODESTAR_PRESET = "minimal";
+    // "c-kzg" has hardcoded the mainnet value, do not use presets
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    setActivePreset(PresetName.minimal, {FIELD_ELEMENTS_PER_BLOB: 4096});
   } else if (network === "gnosis" || network === "chiado") {
     process.env.LODESTAR_PRESET = "gnosis";
   }
@@ -44,6 +47,9 @@ else if (network) {
 else if (process.argv[2] === "dev") {
   process.env.LODESTAR_PRESET = "minimal";
   process.env.LODESTAR_NETWORK = "dev";
+  // "c-kzg" has hardcoded the mainnet value, do not use presets
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  setActivePreset(PresetName.minimal, {FIELD_ELEMENTS_PER_BLOB: 4096});
 }
 
 if (presetFile) {


### PR DESCRIPTION
As part of by parts integration of free the blobs PR
 - https://github.com/ChainSafe/lodestar/pull/5181

For devnets started using cli in minimal and for the merge interop/inline tests, the `FIELD_ELEMENTS_PER_BLOB` needs to be set to `4096` which is the mainnet value

because all kzg libraries and ELs process the blobs on this size and is a hardcoded value in them. We only need minimal value for spec tests which does not use the cli path or will not be providing DEV_RUN flag on test setup