### PR TITLE
feat: trigger block search for unknown block attestations

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -60,6 +60,7 @@ export function getBeaconPoolApi({
             // see https://github.com/ChainSafe/lodestar/issues/5098
             const {indexedAttestation, subnet, attDataRootHex} = await validateGossipFnRetryUnknownRoot(
               validateFn,
+              network.events,
               chain,
               slot,
               beaconBlockRoot

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -60,7 +60,7 @@ export function getBeaconPoolApi({
             // see https://github.com/ChainSafe/lodestar/issues/5098
             const {indexedAttestation, subnet, attDataRootHex} = await validateGossipFnRetryUnknownRoot(
               validateFn,
-              network.events,
+              network,
               chain,
               slot,
               beaconBlockRoot

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -533,6 +533,7 @@ export function getValidatorApi({
             // see https://github.com/ChainSafe/lodestar/issues/5098
             const {indexedAttestation, committeeIndices, attDataRootHex} = await validateGossipFnRetryUnknownRoot(
               validateFn,
+              network.events,
               chain,
               slot,
               beaconBlockRoot

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -117,9 +117,9 @@ export async function processBlocks(
     // TODO: De-duplicate with logic above
     // ChainEvent.errorBlock
     if (!(err instanceof BlockError)) {
-      this.logger.error("Non BlockError received", {}, err);
+      this.logger.debug("Non BlockError received", {}, err);
     } else if (!opts.disableOnBlockError) {
-      this.logger.error("Block error", {slot: err.signedBlock.message.slot}, err);
+      this.logger.debug("Block error", {slot: err.signedBlock.message.slot}, err);
 
       if (err.type.code === BlockErrorCode.INVALID_SIGNATURE) {
         const {signedBlock} = err;

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -518,6 +518,11 @@ export function createLodestarMetrics(
         name: "lodestar_sync_unknown_block_removed_blocks_total",
         help: "Total number of removed bad blocks in UnknownBlockSync",
       }),
+      elapsedTimeTillReceived: register.histogram({
+        name: "lodestar_sync_unknown_block_elapsed_time_till_received",
+        help: "Time elapsed between block slot time and the time block received via unknown block sync",
+        buckets: [0.5, 1, 2, 4, 6, 12],
+      }),
     },
 
     // Gossip block

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -485,9 +485,10 @@ export function createLodestarMetrics(
     },
 
     syncUnknownBlock: {
-      requests: register.gauge({
+      requests: register.gauge<"type">({
         name: "lodestar_sync_unknown_block_requests_total",
-        help: "Total number of unknownBlockParent events or requests",
+        help: "Total number of unknown block events or requests",
+        labelNames: ["type"],
       }),
       pendingBlocks: register.gauge({
         name: "lodestar_sync_unknown_block_pending_blocks_size",

--- a/packages/beacon-node/src/network/events.ts
+++ b/packages/beacon-node/src/network/events.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from "events";
 import {PeerId} from "@libp2p/interface-peer-id";
 import {TopicValidatorResult} from "@libp2p/interface-pubsub";
-import {phase0} from "@lodestar/types";
+import {phase0, RootHex} from "@lodestar/types";
 import {BlockInput} from "../chain/blocks/types.js";
 import {StrictEventEmitterSingleArg} from "../util/strictEvents.js";
 import {PeerIdStr} from "../util/peerId.js";
@@ -17,6 +17,7 @@ export enum NetworkEvent {
   reqRespRequest = "req-resp.request",
   // TODO remove this event, this is not a network-level concern, rather a chain / sync concern
   unknownBlockParent = "unknownBlockParent",
+  unknownBlock = "unknownBlock",
 
   // Network processor events
   /** (Network -> App) A gossip message is ready for validation */
@@ -29,7 +30,8 @@ export type NetworkEventData = {
   [NetworkEvent.peerConnected]: {peer: PeerIdStr; status: phase0.Status};
   [NetworkEvent.peerDisconnected]: {peer: PeerIdStr};
   [NetworkEvent.reqRespRequest]: {request: RequestTypedContainer; peer: PeerId};
-  [NetworkEvent.unknownBlockParent]: {blockInput: BlockInput; peer: string};
+  [NetworkEvent.unknownBlockParent]: {blockInput: BlockInput; peer: PeerIdStr};
+  [NetworkEvent.unknownBlock]: {rootHex: RootHex; peer?: PeerIdStr};
   [NetworkEvent.pendingGossipsubMessage]: PendingGossipsubMessage;
   [NetworkEvent.gossipMessageValidationResult]: {
     msgId: string;
@@ -43,6 +45,7 @@ export const networkEventDirection: Record<NetworkEvent, EventDirection> = {
   [NetworkEvent.peerDisconnected]: EventDirection.workerToMain,
   [NetworkEvent.reqRespRequest]: EventDirection.none, // Only used internally in NetworkCore
   [NetworkEvent.unknownBlockParent]: EventDirection.workerToMain,
+  [NetworkEvent.unknownBlock]: EventDirection.workerToMain,
   [NetworkEvent.pendingGossipsubMessage]: EventDirection.workerToMain,
   [NetworkEvent.gossipMessageValidationResult]: EventDirection.mainToWorker,
 };

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -2,7 +2,7 @@ import {Libp2p as ILibp2p} from "libp2p";
 import {Connection} from "@libp2p/interface-connection";
 import {Registrar} from "@libp2p/interface-registrar";
 import {ConnectionManager} from "@libp2p/interface-connection-manager";
-import {Slot, allForks, altair, capella, deneb, phase0} from "@lodestar/types";
+import {Slot, SlotRootHex, allForks, altair, capella, deneb, phase0} from "@lodestar/types";
 import {BlockInput} from "../chain/blocks/types.js";
 import {PeerIdStr} from "../util/peerId.js";
 import {INetworkEventBus} from "./events.js";
@@ -29,7 +29,7 @@ export interface INetwork extends INetworkCorePublic {
   reportPeer(peer: PeerIdStr, action: PeerAction, actionName: string): void;
   shouldAggregate(subnet: number, slot: Slot): boolean;
   reStatusPeers(peers: PeerIdStr[]): Promise<void>;
-
+  searchUnknownSlotRoot(slotRoot: SlotRootHex, peer?: PeerIdStr): void;
   // ReqResp
   sendBeaconBlocksByRange(
     peerId: PeerIdStr,

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -4,7 +4,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {sleep} from "@lodestar/utils";
 import {LoggerNode} from "@lodestar/logger/node";
 import {computeStartSlotAtEpoch, computeTimeAtSlot} from "@lodestar/state-transition";
-import {phase0, allForks, deneb, altair, Root, capella} from "@lodestar/types";
+import {phase0, allForks, deneb, altair, Root, capella, SlotRootHex} from "@lodestar/types";
 import {routes} from "@lodestar/api";
 import {PeerScoreStatsDump} from "@chainsafe/libp2p-gossipsub/score";
 import {ResponseIncoming} from "@lodestar/reqresp";
@@ -222,6 +222,10 @@ export class Network implements INetwork {
    */
   async reStatusPeers(peers: PeerIdStr[]): Promise<void> {
     return this.core.reStatusPeers(peers);
+  }
+
+  searchUnknownSlotRoot(slotRoot: SlotRootHex, peer?: PeerIdStr): void {
+    this.networkProcessor.searchUnknownSlotRoot(slotRoot, peer);
   }
 
   async reportPeer(peer: PeerIdStr, action: PeerAction, actionName: string): Promise<void> {

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -38,6 +38,7 @@ import {validateGossipBlobsSidecar} from "../../chain/validation/blobsSidecar.js
 import {BlockInput, BlockSource, getBlockInput} from "../../chain/blocks/types.js";
 import {sszDeserialize} from "../gossip/topic.js";
 import {INetworkCore} from "../core/index.js";
+import {INetwork} from "../interface.js";
 import {AggregatorTracker} from "./aggregatorTracker.js";
 
 /**
@@ -399,7 +400,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
  */
 export async function validateGossipFnRetryUnknownRoot<T>(
   fn: () => Promise<T>,
-  events: NetworkEventBus,
+  network: INetwork,
   chain: IBeaconChain,
   slot: Slot,
   blockRoot: Root
@@ -417,8 +418,9 @@ export async function validateGossipFnRetryUnknownRoot<T>(
         if (unknownBlockRootRetries === 0) {
           // Trigger unknown block root search here
           const rootHex = toHexString(blockRoot);
-          events.emit(NetworkEvent.unknownBlock, {rootHex});
+          network.searchUnknownSlotRoot({slot, root: rootHex});
         }
+
         if (unknownBlockRootRetries++ < MAX_UNKNOWN_BLOCK_ROOT_RETRIES) {
           const foundBlock = await chain.waitForBlock(slot, toHexString(blockRoot));
           // Returns true if the block was found on time. In that case, try to get it from the fork-choice again.

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -229,6 +229,8 @@ export class NetworkProcessor {
         }
         message.msgSlot = slot;
         if (root && !this.chain.forkChoice.hasBlockHex(root)) {
+          // Search for the unknown block
+          this.events.emit(NetworkEvent.unknownBlock, {rootHex: root, peer: message.propagationSource.toString()});
           if (this.unknownBlockGossipsubMessagesCount > MAX_QUEUED_UNKNOWN_BLOCK_GOSSIP_OBJECTS) {
             // TODO: Should report the dropped job to gossip? It will be eventually pruned from the mcache
             this.metrics?.reprocessGossipAttestations.reject.inc({reason: ReprocessRejectReason.reached_limit});

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -149,7 +149,7 @@ export class NetworkProcessor {
   private readonly awaitingGossipsubMessagesByRootBySlot: MapDef<Slot, MapDef<RootHex, Set<PendingGossipsubMessage>>>;
   private unknownBlockGossipsubMessagesCount = 0;
   private isProcessingCurrentSlotBlock = false;
-  private unknownRootsBySlot = new MapDef<Slot, Set<RootHex>>();
+  private unknownRootsBySlot = new MapDef<Slot, Set<RootHex>>(() => new Set());
 
   constructor(modules: NetworkProcessorModules, private readonly opts: NetworkProcessorOpts) {
     const {chain, events, logger, metrics} = modules;

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -1,6 +1,7 @@
 import {Logger, MapDef, mapValues, sleep} from "@lodestar/utils";
 import {RootHex, Slot} from "@lodestar/types";
 import {routes} from "@lodestar/api";
+import {pruneSetToMax} from "@lodestar/utils";
 import {IBeaconChain} from "../../chain/interface.js";
 import {GossipErrorCode} from "../../chain/errors/gossipValidation.js";
 import {Metrics} from "../../metrics/metrics.js";
@@ -30,6 +31,11 @@ export type NetworkProcessorModules = ValidatorFnsModules &
 export type NetworkProcessorOpts = GossipHandlerOpts & {
   maxGossipTopicConcurrency?: number;
 };
+
+/**
+ * Keep up to 3 slot of unknown roots, so we don't always emit to UnknownBlock sync.
+ */
+const MAX_UNKNOWN_ROOTS_SLOT_CACHE_SIZE = 3;
 
 /**
  * This is respective to gossipsub seenTTL (which is 550 * 0.7 = 385s), also it's respective
@@ -143,6 +149,7 @@ export class NetworkProcessor {
   private readonly awaitingGossipsubMessagesByRootBySlot: MapDef<Slot, MapDef<RootHex, Set<PendingGossipsubMessage>>>;
   private unknownBlockGossipsubMessagesCount = 0;
   private isProcessingCurrentSlotBlock = false;
+  private unknownRootsBySlot = new MapDef<Slot, Set<RootHex>>();
 
   constructor(modules: NetworkProcessorModules, private readonly opts: NetworkProcessorOpts) {
     const {chain, events, logger, metrics} = modules;
@@ -230,7 +237,11 @@ export class NetworkProcessor {
         message.msgSlot = slot;
         if (root && !this.chain.forkChoice.hasBlockHex(root)) {
           // Search for the unknown block
-          this.events.emit(NetworkEvent.unknownBlock, {rootHex: root, peer: message.propagationSource.toString()});
+          if (!this.unknownRootsBySlot.getOrDefault(slot).has(root)) {
+            this.unknownRootsBySlot.getOrDefault(slot).add(root);
+            this.events.emit(NetworkEvent.unknownBlock, {rootHex: root, peer: message.propagationSource.toString()});
+          }
+
           if (this.unknownBlockGossipsubMessagesCount > MAX_QUEUED_UNKNOWN_BLOCK_GOSSIP_OBJECTS) {
             // TODO: Should report the dropped job to gossip? It will be eventually pruned from the mcache
             this.metrics?.reprocessGossipAttestations.reject.inc({reason: ReprocessRejectReason.reached_limit});
@@ -312,6 +323,7 @@ export class NetworkProcessor {
         this.awaitingGossipsubMessagesByRootBySlot.delete(slot);
       }
     }
+    pruneSetToMax(this.unknownRootsBySlot, MAX_UNKNOWN_ROOTS_SLOT_CACHE_SIZE);
     this.unknownBlockGossipsubMessagesCount = 0;
   }
 

--- a/packages/beacon-node/src/sync/interface.ts
+++ b/packages/beacon-node/src/sync/interface.ts
@@ -55,16 +55,43 @@ export interface SyncModules {
   wsCheckpoint?: phase0.Checkpoint;
 }
 
+/**
+ * onUnknownBlock: store 1 record with undefined parentBlockRootHex & blockInput, blockRootHex as key, status pending
+ * onUnknownBlockParent:
+ *   - store 1 record with known parentBlockRootHex & blockInput, blockRootHex as key, status downloaded
+ *   - store 1 record with undefined parentBlockRootHex & blockInput, parentBlockRootHex as key, status pending
+ */
 export type PendingBlock = {
   blockRootHex: RootHex;
-  parentBlockRootHex: RootHex;
-  blockInput: BlockInput;
   peerIdStrs: Set<string>;
-  status: PendingBlockStatus;
   downloadAttempts: number;
-};
+} & (
+  | {
+      status: PendingBlockStatus.pending | PendingBlockStatus.fetching;
+      parentBlockRootHex: null;
+      blockInput: null;
+    }
+  | {
+      status: PendingBlockStatus.downloaded | PendingBlockStatus.processing;
+      parentBlockRootHex: RootHex;
+      blockInput: BlockInput;
+    }
+);
+
 export enum PendingBlockStatus {
   pending = "pending",
   fetching = "fetching",
+  downloaded = "downloaded",
   processing = "processing",
+}
+
+export enum PendingBlockType {
+  /**
+   * We got a block root (from a gossip attestation, for exxample) but we don't have the block in forkchoice.
+   */
+  UNKNOWN_BLOCK = "unknown_block",
+  /**
+   * During gossip time, we may get a block but the parent root is unknown (not in forkchoice).
+   */
+  UNKNOWN_PARENT = "unknown_parent",
 }

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -2,10 +2,10 @@ import {ChainForkConfig} from "@lodestar/config";
 import {Logger, pruneSetToMax} from "@lodestar/utils";
 import {Root, RootHex} from "@lodestar/types";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
-import {INetwork, NetworkEvent, NetworkEventData, PeerAction} from "../network/index.js";
-import {PeerIdStr} from "../util/peerId.js";
 import {INTERVALS_PER_SLOT} from "@lodestar/params";
 import {sleep} from "@lodestar/utils";
+import {INetwork, NetworkEvent, NetworkEventData, PeerAction} from "../network/index.js";
+import {PeerIdStr} from "../util/peerId.js";
 import {IBeaconChain} from "../chain/index.js";
 import {BlockInput} from "../chain/blocks/types.js";
 import {Metrics} from "../metrics/index.js";
@@ -117,7 +117,7 @@ export class UnknownBlockSync {
       };
       this.pendingBlocks.set(blockRootHex, pendingBlock);
       this.logger.verbose("Added unknown block parent to pendingBlocks", {
-        block: blockRootHex,
+        root: blockRootHex,
         parent: parentBlockRootHex,
       });
     }
@@ -139,7 +139,7 @@ export class UnknownBlockSync {
         downloadAttempts: 0,
       };
       this.pendingBlocks.set(blockRootHex, pendingBlock);
-      this.logger.verbose("Added unknown block to pendingBlocks", {blockRootHex});
+      this.logger.verbose("Added unknown block to pendingBlocks", {root: blockRootHex});
     }
 
     if (peerIdStr) {
@@ -399,9 +399,7 @@ export class UnknownBlockSync {
       this.knownBadBlocks.add(block.blockRootHex);
       for (const peerIdStr of block.peerIdStrs) {
         // TODO: Refactor peerRpcScores to work with peerIdStr only
-        this.network.reportPeer(peerIdStr, PeerAction.LowToleranceError, "BadBlockByRoot").catch((e) => {
-          this.logger.debug("Error reporting peer", {}, e);
-        });
+        this.network.reportPeer(peerIdStr, PeerAction.LowToleranceError, "BadBlockByRoot");
       }
       this.logger.debug("Banning unknown block", {
         root: block.blockRootHex,

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -116,6 +116,10 @@ export class UnknownBlockSync {
         downloadAttempts: 0,
       };
       this.pendingBlocks.set(blockRootHex, pendingBlock);
+      this.logger.verbose("Added unknown block parent to pendingBlocks", {
+        block: blockRootHex,
+        parent: parentBlockRootHex,
+      });
     }
     pendingBlock.peerIdStrs.add(peerIdStr);
 
@@ -135,6 +139,7 @@ export class UnknownBlockSync {
         downloadAttempts: 0,
       };
       this.pendingBlocks.set(blockRootHex, pendingBlock);
+      this.logger.verbose("Added unknown block to pendingBlocks", {blockRootHex});
     }
 
     if (peerIdStr) {

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -367,7 +367,7 @@ export class UnknownBlockSync {
         const block = blockInput.block.message;
         const receivedBlockRoot = this.config.getForkTypes(block.slot).BeaconBlock.hashTreeRoot(block);
         if (!byteArrayEquals(receivedBlockRoot, blockRoot)) {
-          throw Error(`Wrong block received by peer, expected ${toHexString(receivedBlockRoot)} got ${blockRootHex}`);
+          throw Error(`Wrong block received by peer, got ${toHexString(receivedBlockRoot)} expected ${blockRootHex}`);
         }
 
         return {blockInput, peerIdStr: peer};

--- a/packages/beacon-node/src/sync/utils/pendingBlocksTree.ts
+++ b/packages/beacon-node/src/sync/utils/pendingBlocksTree.ts
@@ -6,7 +6,9 @@ export function getAllDescendantBlocks(blockRootHex: RootHex, blocks: Map<RootHe
   // Do one pass over all blocks to index by parent
   const byParent = new MapDef<RootHex, PendingBlock[]>(() => []);
   for (const block of blocks.values()) {
-    byParent.getOrDefault(block.parentBlockRootHex).push(block);
+    if (block.parentBlockRootHex != null) {
+      byParent.getOrDefault(block.parentBlockRootHex).push(block);
+    }
   }
 
   // Then, do a second pass recursively to get `blockRootHex` child blocks
@@ -41,11 +43,11 @@ export function getDescendantBlocks(blockRootHex: RootHex, blocks: Map<RootHex, 
   return descendantBlocks;
 }
 
-export function getLowestPendingUnknownParents(blocks: Map<RootHex, PendingBlock>): PendingBlock[] {
+export function getUnknownBlocks(blocks: Map<RootHex, PendingBlock>): PendingBlock[] {
   const blocksToFetch: PendingBlock[] = [];
 
   for (const block of blocks.values()) {
-    if (block.status === PendingBlockStatus.pending && !blocks.has(block.parentBlockRootHex)) {
+    if (block.status === PendingBlockStatus.pending && block.blockInput == null && block.parentBlockRootHex == null) {
       blocksToFetch.push(block);
     }
   }

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -87,6 +87,10 @@ describe("data serialization through worker boundary", function () {
       },
       peer,
     },
+    [NetworkEvent.unknownBlock]: {
+      rootHex: ZERO_HASH_HEX,
+      peer,
+    },
     [NetworkEvent.pendingGossipsubMessage]: {
       topic: {type: GossipType.beacon_block, fork: ForkName.altair},
       msg: {

--- a/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
@@ -1,0 +1,150 @@
+import {ChainConfig} from "@lodestar/config";
+import {phase0} from "@lodestar/types";
+import {config} from "@lodestar/config/default";
+import {fromHexString} from "@chainsafe/ssz";
+import {TimestampFormatCode} from "@lodestar/logger";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {routes} from "@lodestar/api";
+import {EventData, EventType} from "@lodestar/api/lib/beacon/routes/events.js";
+import {getDevBeaconNode} from "../../utils/node/beacon.js";
+import {waitForEvent} from "../../utils/events/resolver.js";
+import {getAndInitDevValidators} from "../../utils/node/validator.js";
+import {ChainEvent} from "../../../src/chain/index.js";
+import {NetworkEvent} from "../../../src/network/index.js";
+import {connect} from "../../utils/network.js";
+import {testLogger, LogLevel, TestLoggerOpts} from "../../utils/logger.js";
+import {BlockError, BlockErrorCode} from "../../../src/chain/errors/index.js";
+import {BlockSource, getBlockInput} from "../../../src/chain/blocks/types.js";
+
+describe("sync / unknown block sync", function () {
+  const validatorCount = 8;
+  const testParams: Pick<ChainConfig, "SECONDS_PER_SLOT"> = {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    SECONDS_PER_SLOT: 2,
+  };
+
+  const afterEachCallbacks: (() => Promise<unknown> | void)[] = [];
+  afterEach(async () => {
+    while (afterEachCallbacks.length > 0) {
+      const callback = afterEachCallbacks.pop();
+      if (callback) await callback();
+    }
+  });
+
+  const testCases: {id: string; event: NetworkEvent}[] = [
+    {
+      id: "should do an unknown block parent sync from another BN",
+      event: NetworkEvent.unknownBlockParent,
+    },
+    {
+      id: "should do an unknown block sync from another BN",
+      event: NetworkEvent.unknownBlock,
+    },
+  ];
+
+  for (const {id, event} of testCases) {
+    it(id, async function () {
+      this.timeout("10 min");
+
+      // the node needs time to transpile/initialize bls worker threads
+      const genesisSlotsDelay = 16;
+      const genesisTime = Math.floor(Date.now() / 1000) + genesisSlotsDelay * testParams.SECONDS_PER_SLOT;
+      const testLoggerOpts: TestLoggerOpts = {
+        level: LogLevel.info,
+        timestampFormat: {
+          format: TimestampFormatCode.EpochSlot,
+          genesisTime,
+          slotsPerEpoch: SLOTS_PER_EPOCH,
+          secondsPerSlot: testParams.SECONDS_PER_SLOT,
+        },
+      };
+
+      const loggerNodeA = testLogger("Node-A", testLoggerOpts);
+      const loggerNodeB = testLogger("Node-B", testLoggerOpts);
+
+      const bn = await getDevBeaconNode({
+        params: testParams,
+        options: {
+          sync: {isSingleNode: true},
+          network: {allowPublishToZeroPeers: true},
+          chain: {blsVerifyAllMainThread: true},
+        },
+        validatorCount,
+        logger: loggerNodeA,
+      });
+
+      afterEachCallbacks.push(() => bn.close());
+
+      const {validators} = await getAndInitDevValidators({
+        node: bn,
+        validatorsPerClient: validatorCount,
+        validatorClientCount: 1,
+        startIndex: 0,
+        useRestApi: false,
+        testLoggerOpts,
+      });
+
+      afterEachCallbacks.push(() => Promise.all(validators.map((v) => v.close())));
+
+      // stop bn after validators
+      afterEachCallbacks.push(() => bn.close());
+
+      await waitForEvent<phase0.Checkpoint>(bn.chain.emitter, ChainEvent.checkpoint, 240000);
+      loggerNodeA.info("Node A emitted checkpoint event");
+
+      const bn2 = await getDevBeaconNode({
+        params: testParams,
+        options: {
+          api: {rest: {enabled: false}},
+          sync: {disableRangeSync: true},
+          chain: {blsVerifyAllMainThread: true},
+        },
+        validatorCount,
+        genesisTime: bn.chain.getHeadState().genesisTime,
+        logger: loggerNodeB,
+      });
+
+      afterEachCallbacks.push(() => bn2.close());
+
+      const headSummary = bn.chain.forkChoice.getHead();
+      const head = await bn.db.block.get(fromHexString(headSummary.blockRoot));
+      if (!head) throw Error("First beacon node has no head block");
+      const waitForSynced = waitForEvent<EventData[EventType.head]>(
+        bn2.chain.emitter,
+        routes.events.EventType.head,
+        100000,
+        ({block}) => block === headSummary.blockRoot
+      );
+
+      await connect(bn2.network, bn.network);
+      const headInput = getBlockInput.preDeneb(config, head, BlockSource.gossip);
+
+      switch (event) {
+        case NetworkEvent.unknownBlockParent:
+          await bn2.chain.processBlock(headInput).catch((e) => {
+            if (e instanceof BlockError && e.type.code === BlockErrorCode.PARENT_UNKNOWN) {
+              // Expected
+              bn2.network.events.emit(NetworkEvent.unknownBlockParent, {
+                blockInput: headInput,
+                peer: bn2.network.peerId.toString(),
+              });
+            } else {
+              throw e;
+            }
+          });
+          break;
+        case NetworkEvent.unknownBlock:
+          bn2.network.events.emit(NetworkEvent.unknownBlock, {
+            rootHex: headSummary.blockRoot,
+            peer: bn2.network.peerId.toString(),
+          });
+          break;
+        default:
+          throw Error("Unknown event type");
+      }
+
+      // Wait for NODE-A head to be processed in NODE-B without range sync
+      await waitForSynced;
+    });
+  }
+});

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -13,7 +13,6 @@ import {testLogger} from "../../utils/logger.js";
 import {getRandPeerIdStr} from "../../utils/peer.js";
 import {BlockSource, getBlockInput} from "../../../src/chain/blocks/types.js";
 import {ClockStopped} from "../../utils/mocks/clock.js";
-import {IClock} from "../../../src/util/clock.js";
 import {SeenBlockProposers} from "../../../src/chain/seenCache/seenBlockProposers.js";
 
 describe("sync / UnknownBlockSync", () => {
@@ -113,9 +112,6 @@ describe("sync / UnknownBlockSync", () => {
         hasBlock: (root) => forkChoiceKnownRoots.has(toHexString(root)),
         getFinalizedBlock: () => ({slot: finalizedSlot} as ProtoBlock),
       };
-      const clock: Pick<IClock, "secFromSlot"> = {
-        secFromSlot: () => 0,
-      };
       const seenBlockProposers: Pick<SeenBlockProposers, "isKnown"> = {
         // only return seenBlock for blockC
         isKnown: (blockSlot) => (blockSlot === blockC.message.slot ? seenBlock : false),
@@ -133,7 +129,6 @@ describe("sync / UnknownBlockSync", () => {
           forkChoiceKnownRoots.add(blockRootHex);
           if (blockRootHex === blockRootHexC) blockCResolver();
         },
-        clock: clock as IClock,
         seenBlockProposers: seenBlockProposers as SeenBlockProposers,
       };
 

--- a/packages/beacon-node/test/unit/sync/utils/pendingBlocksTree.test.ts
+++ b/packages/beacon-node/test/unit/sync/utils/pendingBlocksTree.test.ts
@@ -4,28 +4,28 @@ import {PendingBlock, PendingBlockStatus} from "../../../../src/sync/index.js";
 import {
   getAllDescendantBlocks,
   getDescendantBlocks,
-  getLowestPendingUnknownParents,
+  getUnknownBlocks,
 } from "../../../../src/sync/utils/pendingBlocksTree.js";
 
 describe("sync / pendingBlocksTree", () => {
   const testCases: {
     id: string;
-    blocks: {block: string; parent: string}[];
+    blocks: {block: string; parent: string | null}[];
     getAllDescendantBlocks: {block: string; res: string[]}[];
     getDescendantBlocks: {block: string; res: string[]}[];
-    getLowestPendingUnknownParents: string[];
+    getUnknownBlocks: string[];
   }[] = [
     {
       id: "empty case",
       blocks: [],
       getAllDescendantBlocks: [{block: "0A", res: []}],
       getDescendantBlocks: [{block: "0A", res: []}],
-      getLowestPendingUnknownParents: [],
+      getUnknownBlocks: [],
     },
     {
       id: "two branches with multiple blocks",
       blocks: [
-        {block: "0A", parent: "-"},
+        {block: "0A", parent: null},
         {block: "1A", parent: "0A"},
         {block: "2A", parent: "1A"},
         {block: "3A", parent: "2A"},
@@ -44,7 +44,7 @@ describe("sync / pendingBlocksTree", () => {
         {block: "3C", res: ["4C"]},
         {block: "3B", res: []},
       ],
-      getLowestPendingUnknownParents: ["0A", "4C"],
+      getUnknownBlocks: ["0A"],
     },
   ];
 
@@ -54,7 +54,7 @@ describe("sync / pendingBlocksTree", () => {
       blocks.set(block.block, {
         blockRootHex: block.block,
         parentBlockRootHex: block.parent,
-        status: PendingBlockStatus.pending,
+        status: block.parent == null ? PendingBlockStatus.pending : PendingBlockStatus.downloaded,
       } as PendingBlock);
     }
 
@@ -71,8 +71,8 @@ describe("sync / pendingBlocksTree", () => {
         });
       }
 
-      it("getLowestPendingUnknownParents", () => {
-        expect(toRes(getLowestPendingUnknownParents(blocks))).to.deep.equal(testCase.getLowestPendingUnknownParents);
+      it("getUnknownBlocks", () => {
+        expect(toRes(getUnknownBlocks(blocks))).to.deep.equal(testCase.getUnknownBlocks);
       });
     });
   }


### PR DESCRIPTION
**Motivation**

- At gossip time, we usually get unknown block attestations because gossip block comes after attestations, and we want to actively search for that block instead of waiting for gossip block passively

**Description**
- New `NetworkEvent.unknownBlock` network event, emitted when unknown block attestations
- Refactor unknownBlock sync to handle both `unknownBlockParent` and `unknownBlock` event
- At each block there is usually a race between gossip block and rpc block. Most of the time gossip block wins.
- Prevent unbundling attack

Closes #3613
