### PR TITLE
feat: track block source in BlockInput

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -4,7 +4,7 @@ import {ForkSeq, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {sleep} from "@lodestar/utils";
 import {deneb, allForks} from "@lodestar/types";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
-import {getBlockInput, ImportBlockOpts} from "../../../../chain/blocks/types.js";
+import {BlockSource, getBlockInput, ImportBlockOpts} from "../../../../chain/blocks/types.js";
 import {promiseAllMaybeAsync} from "../../../../util/promises.js";
 import {isOptimisticBlock} from "../../../../util/forkChoice.js";
 import {BlockError, BlockErrorCode} from "../../../../chain/errors/index.js";
@@ -223,9 +223,10 @@ export function getBeaconBlockApi({
           ? getBlockInput.postDeneb(
               config,
               signedBlock,
+              BlockSource.api,
               chain.getBlobsSidecar(signedBlock.message as deneb.BeaconBlock)
             )
-          : getBlockInput.preDeneb(config, signedBlock);
+          : getBlockInput.preDeneb(config, signedBlock, BlockSource.api);
 
       await promiseAllMaybeAsync([
         // Send the block, regardless of whether or not it is valid. The API

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -9,7 +9,7 @@ import {
   getCurrentSlot,
 } from "@lodestar/state-transition";
 import {GENESIS_SLOT, SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT, SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
-import {Root, Slot, ValidatorIndex, ssz, Epoch, BlockSource} from "@lodestar/types";
+import {Root, Slot, ValidatorIndex, ssz, Epoch, ProducedBlockSource} from "@lodestar/types";
 import {ExecutionStatus} from "@lodestar/fork-choice";
 import {toHex} from "@lodestar/utils";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
@@ -187,7 +187,7 @@ export function getValidatorApi({
 
   const produceBlindedBlock: ServerApi<routes.validator.Api>["produceBlindedBlock"] =
     async function produceBlindedBlock(slot, randaoReveal, graffiti) {
-      const source = BlockSource.builder;
+      const source = ProducedBlockSource.builder;
       let timer;
       metrics?.blockProductionRequests.inc({source});
       try {
@@ -232,7 +232,7 @@ export function getValidatorApi({
     randaoReveal,
     graffiti
   ) {
-    const source = BlockSource.engine;
+    const source = ProducedBlockSource.engine;
     let timer;
     metrics?.blockProductionRequests.inc({source});
     try {

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -51,7 +51,7 @@ export async function importBlock(
   opts: ImportBlockOpts
 ): Promise<void> {
   const {blockInput, postState, parentBlockSlot, executionStatus} = fullyVerifiedBlock;
-  const {block, serializedData} = blockInput;
+  const {block, serializedData, source} = blockInput;
   const blockRoot = this.config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
   const blockRootHex = toHexString(blockRoot);
   const currentEpoch = computeEpochAtSlot(this.forkChoice.getTime());
@@ -100,6 +100,7 @@ export async function importBlock(
   // Some block event handlers require state being in state cache so need to do this before emitting EventType.block
   this.stateCache.add(postState);
 
+  this.metrics?.importBlock.bySource.inc({source});
   this.logger.verbose("Added block to forkchoice and state cache", {slot: block.message.slot, root: blockRootHex});
   this.emitter.emit(routes.events.EventType.block, {
     block: toHexString(this.config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message)),

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -9,9 +9,17 @@ export enum BlockInputType {
   postDeneb = "postDeneb",
 }
 
+/** Enum to represent where blocks come from */
+export enum BlockSource {
+  gossip = "gossip",
+  api = "api",
+  byRange = "req_resp_by_range",
+  byRoot = "req_resp_by_root",
+}
+
 export type BlockInput =
-  | {type: BlockInputType.preDeneb; block: allForks.SignedBeaconBlock}
-  | {type: BlockInputType.postDeneb; block: allForks.SignedBeaconBlock; blobs: deneb.BlobsSidecar};
+  | {type: BlockInputType.preDeneb; block: allForks.SignedBeaconBlock; source: BlockSource}
+  | {type: BlockInputType.postDeneb; block: allForks.SignedBeaconBlock; source: BlockSource; blobs: deneb.BlobsSidecar};
 
 export function blockRequiresBlobs(config: ChainForkConfig, blockSlot: Slot, clockSlot: Slot): boolean {
   return (
@@ -22,23 +30,30 @@ export function blockRequiresBlobs(config: ChainForkConfig, blockSlot: Slot, clo
 }
 
 export const getBlockInput = {
-  preDeneb(config: ChainForkConfig, block: allForks.SignedBeaconBlock): BlockInput {
+  preDeneb(config: ChainForkConfig, block: allForks.SignedBeaconBlock, source: BlockSource): BlockInput {
     if (config.getForkSeq(block.message.slot) >= ForkSeq.deneb) {
       throw Error(`Post Deneb block slot ${block.message.slot}`);
     }
     return {
       type: BlockInputType.preDeneb,
       block,
+      source,
     };
   },
 
-  postDeneb(config: ChainForkConfig, block: allForks.SignedBeaconBlock, blobs: deneb.BlobsSidecar): BlockInput {
+  postDeneb(
+    config: ChainForkConfig,
+    block: allForks.SignedBeaconBlock,
+    source: BlockSource,
+    blobs: deneb.BlobsSidecar
+  ): BlockInput {
     if (config.getForkSeq(block.message.slot) < ForkSeq.deneb) {
       throw Error(`Pre Deneb block slot ${block.message.slot}`);
     }
     return {
       type: BlockInputType.postDeneb,
       block,
+      source,
       blobs,
     };
   },

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -511,6 +511,11 @@ export function createLodestarMetrics(
         help: "Time elapsed between block slot time and the time block becomes head",
         buckets: [0.5, 1, 2, 4, 6, 12],
       }),
+      bySource: register.gauge<"source">({
+        name: "lodestar_import_block_by_source_total",
+        help: "Total number of imported blocks by source",
+        labelNames: ["source"],
+      }),
     },
     engineNotifyNewPayloadResult: register.gauge<"result">({
       name: "lodestar_execution_engine_notify_new_payload_result_total",

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -36,7 +36,7 @@ import {PeerAction, PeerRpcScoreStore} from "../peers/index.js";
 import {validateLightClientFinalityUpdate} from "../../chain/validation/lightClientFinalityUpdate.js";
 import {validateLightClientOptimisticUpdate} from "../../chain/validation/lightClientOptimisticUpdate.js";
 import {validateGossipBlobsSidecar} from "../../chain/validation/blobsSidecar.js";
-import {BlockInput, getBlockInput} from "../../chain/blocks/types.js";
+import {BlockInput, BlockSource, getBlockInput} from "../../chain/blocks/types.js";
 import {AttnetsService} from "../subnets/attnetsService.js";
 import {sszDeserialize} from "../gossip/topic.js";
 
@@ -180,7 +180,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
         throw new GossipActionError(GossipAction.REJECT, {code: "POST_DENEB_BLOCK"});
       }
 
-      const blockInput = getBlockInput.preDeneb(config, signedBlock);
+      const blockInput = getBlockInput.preDeneb(config, signedBlock, BlockSource.gossip);
       await validateBeaconBlock(blockInput, topic.fork, peerIdStr, seenTimestampSec);
       handleValidBeaconBlock({...blockInput, serializedData}, peerIdStr, seenTimestampSec);
     },
@@ -194,7 +194,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       }
 
       // Validate block + blob. Then forward, then handle both
-      const blockInput = getBlockInput.postDeneb(config, beaconBlock, blobsSidecar);
+      const blockInput = getBlockInput.postDeneb(config, beaconBlock, BlockSource.gossip, blobsSidecar);
       await validateBeaconBlock(blockInput, topic.fork, peerIdStr, seenTimestampSec);
       validateGossipBlobsSidecar(beaconBlock, blobsSidecar);
       handleValidBeaconBlock({...blockInput, serializedData}, peerIdStr, seenTimestampSec);

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -4,7 +4,7 @@ import {deneb, Epoch, phase0} from "@lodestar/types";
 import {ForkSeq, MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS} from "@lodestar/params";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 
-import {BlockInput, getBlockInput} from "../../chain/blocks/types.js";
+import {BlockInput, BlockSource, getBlockInput} from "../../chain/blocks/types.js";
 import {getEmptyBlobsSidecar} from "../../util/blobs.js";
 import {IReqRespBeaconNode} from "./interface.js";
 
@@ -34,7 +34,7 @@ export async function beaconBlocksMaybeBlobsByRange(
   // Note: Assumes all blocks in the same epoch
   if (config.getForkSeq(startSlot) < ForkSeq.deneb) {
     const blocks = await reqResp.beaconBlocksByRange(peerId, request);
-    return blocks.map((block) => getBlockInput.preDeneb(config, block));
+    return blocks.map((block) => getBlockInput.preDeneb(config, block, BlockSource.byRange));
   }
 
   // Only request blobs if they are recent enough
@@ -72,7 +72,7 @@ export async function beaconBlocksMaybeBlobsByRange(
         }
         blobsSidecar = getEmptyBlobsSidecar(config, block as deneb.SignedBeaconBlock);
       }
-      blockInputs.push(getBlockInput.postDeneb(config, block, blobsSidecar));
+      blockInputs.push(getBlockInput.postDeneb(config, block, BlockSource.byRange, blobsSidecar));
     }
 
     // If there are still unconsumed blobs this means that the response was inconsistent

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -16,7 +16,7 @@ import {Eth1ForBlockProductionDisabled} from "../../../src/eth1/index.js";
 import {testLogger} from "../../utils/logger.js";
 import {linspace} from "../../../src/util/numpy.js";
 import {BeaconDb} from "../../../src/index.js";
-import {getBlockInput, AttestationImportOpt} from "../../../src/chain/blocks/types.js";
+import {getBlockInput, AttestationImportOpt, BlockSource} from "../../../src/chain/blocks/types.js";
 
 // Define this params in `packages/state-transition/test/perf/params.ts`
 // to trigger Github actions CI cache
@@ -107,7 +107,9 @@ describe.skip("verify+import blocks - range sync perf test", () => {
       return chain;
     },
     fn: async (chain) => {
-      const blocksImport = blocks.value.map((block) => getBlockInput.preDeneb(chain.config, block));
+      const blocksImport = blocks.value.map((block) =>
+        getBlockInput.preDeneb(chain.config, block, BlockSource.byRange)
+      );
 
       await chain.processChainSegment(blocksImport, {
         // Only skip importing attestations for finalized sync. For head sync attestation are valuable.

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -20,7 +20,7 @@ import {ExecutionEngineMockBackend} from "../../../src/execution/engine/mock.js"
 import {defaultChainOptions} from "../../../src/chain/options.js";
 import {getStubbedBeaconDb} from "../../utils/mocks/db.js";
 import {ClockStopped} from "../../utils/mocks/clock.js";
-import {getBlockInput, AttestationImportOpt} from "../../../src/chain/blocks/types.js";
+import {getBlockInput, AttestationImportOpt, BlockSource} from "../../../src/chain/blocks/types.js";
 import {getEmptyBlobsSidecar} from "../../../src/util/blobs.js";
 import {ZERO_HASH_HEX} from "../../../src/constants/constants.js";
 import {PowMergeBlock} from "../../../src/eth1/interface.js";
@@ -157,10 +157,11 @@ export const forkChoiceTest =
 
               const blockImport =
                 config.getForkSeq(slot) < ForkSeq.deneb
-                  ? getBlockInput.preDeneb(config, signedBlock)
+                  ? getBlockInput.preDeneb(config, signedBlock, BlockSource.gossip)
                   : getBlockInput.postDeneb(
                       config,
                       signedBlock,
+                      BlockSource.gossip,
                       getEmptyBlobsSidecar(config, signedBlock as deneb.SignedBeaconBlock)
                     );
 

--- a/packages/beacon-node/test/unit/chain/blocks/verifyBlocksSanityChecks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyBlocksSanityChecks.test.ts
@@ -12,7 +12,7 @@ import {BlockErrorCode} from "../../../../src/chain/errors/index.js";
 import {expectThrowsLodestarError} from "../../../utils/errors.js";
 import {IClock} from "../../../../src/util/clock.js";
 import {ClockStopped} from "../../../utils/mocks/clock.js";
-import {getBlockInput} from "../../../../src/chain/blocks/types.js";
+import {BlockSource, getBlockInput} from "../../../../src/chain/blocks/types.js";
 
 describe("chain / blocks / verifyBlocksSanityChecks", function () {
   let forkChoice: SinonStubbedInstance<ForkChoice>;
@@ -127,7 +127,7 @@ function verifyBlocksSanityChecks(
 ): {relevantBlocks: allForks.SignedBeaconBlock[]; parentSlots: Slot[]; parentBlock: ProtoBlock | null} {
   const {relevantBlocks, parentSlots, parentBlock} = verifyBlocksImportSanityChecks(
     modules,
-    blocks.map((block) => getBlockInput.preDeneb(config, block)),
+    blocks.map((block) => getBlockInput.preDeneb(config, block, BlockSource.byRange)),
     opts
   );
   return {

--- a/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
@@ -5,7 +5,7 @@ import {ssz, deneb} from "@lodestar/types";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 
 import {beaconBlocksMaybeBlobsByRange, ReqRespBeaconNode} from "../../../src/network/reqresp/index.js";
-import {BlockInputType} from "../../../src/chain/blocks/types.js";
+import {BlockInputType, BlockSource} from "../../../src/chain/blocks/types.js";
 import {ckzg, initCKZG, loadEthereumTrustedSetup} from "../../../src/util/kzg.js";
 
 describe("beaconBlocksMaybeBlobsByRange", () => {
@@ -75,6 +75,7 @@ describe("beaconBlocksMaybeBlobsByRange", () => {
         return {
           type: BlockInputType.postDeneb,
           block,
+          source: BlockSource.byRange,
           blobs,
         };
       });

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -6,13 +6,15 @@ import {ssz} from "@lodestar/types";
 import {expectThrowsLodestarError} from "../../../utils/errors.js";
 import {Batch, BatchStatus, BatchErrorCode, BatchError} from "../../../../src/sync/range/batch.js";
 import {EPOCHS_PER_BATCH} from "../../../../src/sync/constants.js";
-import {getBlockInput} from "../../../../src/chain/blocks/types.js";
+import {BlockSource, getBlockInput} from "../../../../src/chain/blocks/types.js";
 
 describe("sync / range / batch", async () => {
   // Common mock data
   const startEpoch = 0;
   const peer = await createSecp256k1PeerId();
-  const blocksDownloaded = [getBlockInput.preDeneb(config, ssz.phase0.SignedBeaconBlock.defaultValue())];
+  const blocksDownloaded = [
+    getBlockInput.preDeneb(config, ssz.phase0.SignedBeaconBlock.defaultValue(), BlockSource.byRange),
+  ];
 
   it("Should return correct blockByRangeRequest", () => {
     const batch = new Batch(startEpoch, config);

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -9,7 +9,7 @@ import {RangeSyncType} from "../../../../src/sync/utils/remoteSyncType.js";
 import {ZERO_HASH} from "../../../../src/constants/index.js";
 import {testLogger} from "../../../utils/logger.js";
 import {getValidPeerId} from "../../../utils/peer.js";
-import {BlockInput, getBlockInput} from "../../../../src/chain/blocks/types.js";
+import {BlockInput, BlockSource, getBlockInput} from "../../../../src/chain/blocks/types.js";
 
 describe("sync / range / chain", () => {
   const testCases: {
@@ -83,10 +83,14 @@ describe("sync / range / chain", () => {
           const shouldReject = badBlocks?.has(i);
           if (shouldReject) badBlocks?.delete(i);
           blocks.push(
-            getBlockInput.preDeneb(config, {
-              message: generateEmptyBlock(i),
-              signature: shouldReject ? REJECT_BLOCK : ACCEPT_BLOCK,
-            })
+            getBlockInput.preDeneb(
+              config,
+              {
+                message: generateEmptyBlock(i),
+                signature: shouldReject ? REJECT_BLOCK : ACCEPT_BLOCK,
+              },
+              BlockSource.byRange
+            )
           );
         }
         return blocks;
@@ -124,10 +128,14 @@ describe("sync / range / chain", () => {
       const blocks: BlockInput[] = [];
       for (let i = request.startSlot; i < request.startSlot + request.count; i += request.step) {
         blocks.push(
-          getBlockInput.preDeneb(config, {
-            message: generateEmptyBlock(i),
-            signature: ACCEPT_BLOCK,
-          })
+          getBlockInput.preDeneb(
+            config,
+            {
+              message: generateEmptyBlock(i),
+              signature: ACCEPT_BLOCK,
+            },
+            BlockSource.byRange
+          )
         );
       }
       return blocks;

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -77,7 +77,11 @@ describe("sync / UnknownBlockSync", () => {
       };
 
       new UnknownBlockSync(config, network as INetwork, chain as IBeaconChain, logger, null);
-      network.events?.emit(NetworkEvent.unknownBlockParent, getBlockInput.preDeneb(config, blockC), peerIdStr);
+      network.events?.emit(
+        NetworkEvent.unknownBlockParent,
+        getBlockInput.preDeneb(config, blockC, BlockSource.gossip),
+        peerIdStr
+      );
 
       if (reportPeer) {
         const err = await reportPeerPromise;

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -9,7 +9,7 @@ import {INetwork, NetworkEvent, NetworkEventBus, PeerAction} from "../../../src/
 import {UnknownBlockSync} from "../../../src/sync/unknownBlock.js";
 import {testLogger} from "../../utils/logger.js";
 import {getValidPeerId} from "../../utils/peer.js";
-import {getBlockInput} from "../../../src/chain/blocks/types.js";
+import {BlockSource, getBlockInput} from "../../../src/chain/blocks/types.js";
 
 describe("sync / UnknownBlockSync", () => {
   const logger = testLogger();
@@ -55,7 +55,7 @@ describe("sync / UnknownBlockSync", () => {
           Array.from(roots)
             .map((root) => blocksByRoot.get(toHexString(root)))
             .filter(notNullish)
-            .map((block) => getBlockInput.preDeneb(config, block)),
+            .map((block) => getBlockInput.preDeneb(config, block, BlockSource.byRoot)),
 
         reportPeer: async (peerId, action, actionName) => reportPeerResolveFn([peerId, action, actionName]),
       };

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -13,7 +13,7 @@ export {ts as allForks} from "./allForks/index.js";
 export type RootHex = string;
 
 /** Handy enum to represent the block production source */
-export enum BlockSource {
+export enum ProducedBlockSource {
   builder = "builder",
   engine = "engine",
 }


### PR DESCRIPTION
**Motivation**

- We want to track where block comes from after processing it
- As a preparation for #5485

**Description**

- The old `BlockSource` becomes `ProducedBlockSource` enum
- New block source enum with 4 possible values: api, gossip, `beacon_blocks_by_root` and `beacon_block_by_range`
- Add `BlockSource` to `BlockInput` and refactor all the consumers of `preDeneb, postDeneb`
- Add metric to track where blocks come from

