### PR TITLE
feat(beacon-node): add block error metric to gossip handlers

### DIFF
--- a/dashboards/lodestar_networking.json
+++ b/dashboards/lodestar_networking.json
@@ -4548,7 +4548,7 @@
           "refId": "A"
         }
       ],
-      "title": "Process Block Error - Unknown Parent",
+      "title": "Process Block Error",
       "type": "timeseries"
     },
     {

--- a/dashboards/lodestar_networking.json
+++ b/dashboards/lodestar_networking.json
@@ -4548,7 +4548,7 @@
           "refId": "A"
         }
       ],
-      "title": "Process Block Error",
+      "title": "Process Block Error - Unknown Parent",
       "type": "timeseries"
     },
     {

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -594,10 +594,10 @@ export function createLodestarMetrics(
         help: "Time elapsed between block received and block import",
         buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
       }),
-      processBlockErrors: register.gauge({
+      processBlockErrors: register.gauge<"error">({
         name: "lodestar_gossip_block_process_block_errors",
         help: "Count of errors, by error type, while processing blocks",
-        labelNames: ["blockErrorCode"],
+        labelNames: ["error"],
       }),
     },
     importBlock: {

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -597,7 +597,7 @@ export function createLodestarMetrics(
       processBlockErrors: register.gauge({
         name: "lodestar_gossip_block_process_block_errors",
         help: "Count of errors, by error type, while processing blocks",
-        labelNames: ["blockErrorCode", "peerIdStr", "seenTimestampSec", "slot"],
+        labelNames: ["blockErrorCode"],
       }),
     },
     importBlock: {

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -594,6 +594,11 @@ export function createLodestarMetrics(
         help: "Time elapsed between block received and block import",
         buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
       }),
+      processBlockErrors: register.gauge({
+        name: "lodestar_gossip_block_process_block_errors",
+        help: "Count of errors, by error type, while processing blocks",
+        labelNames: ["blockErrorCode", "peerIdStr", "seenTimestampSec", "slot"],
+      }),
     },
     importBlock: {
       persistBlockNoSerializedDataCount: register.gauge({

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -159,7 +159,9 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
         metrics?.gossipBlock.elapsedTimeTillProcessed.observe(delaySec);
       })
       .catch((e) => {
+        let blockErrorCode = "NOT_BLOCK_ERROR";
         if (e instanceof BlockError) {
+          blockErrorCode = e.type.code;
           switch (e.type.code) {
             case BlockErrorCode.ALREADY_KNOWN:
             case BlockErrorCode.PARENT_UNKNOWN:
@@ -171,13 +173,12 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
               core.reportPeer(peerIdStr, PeerAction.LowToleranceError, "BadGossipBlock");
           }
         }
-        metrics?.gossipBlock.processBlockErrors.inc({
-          peerIdStr,
-          slot: signedBlock.message.slot,
-          seenTimestampSec,
-          blockErrorCode: `${e.type.code}`,
-        });
-        logger.error("Error receiving block", {slot: signedBlock.message.slot, peer: peerIdStr}, e as Error);
+        metrics?.gossipBlock.processBlockErrors.inc({blockErrorCode});
+        logger.error(
+          "Error receiving block",
+          {slot: signedBlock.message.slot, peer: peerIdStr, blockErrorCode, seenTimestampSec},
+          e as Error
+        );
       });
   }
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -171,9 +171,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
               core.reportPeer(peerIdStr, PeerAction.LowToleranceError, "BadGossipBlock");
           }
         }
-        metrics?.gossipBlock.processBlockErrors.inc({
-          blockErrorCode: e instanceof BlockError ? e.type.code : "NOT_BLOCK_ERROR",
-        });
+        metrics?.gossipBlock.processBlockErrors.inc({error: e instanceof BlockError ? e.type.code : "NOT_BLOCK_ERROR"});
         logger.error("Error receiving block", {slot: signedBlock.message.slot, peer: peerIdStr}, e as Error);
       });
   }

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -159,9 +159,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
         metrics?.gossipBlock.elapsedTimeTillProcessed.observe(delaySec);
       })
       .catch((e) => {
-        let blockErrorCode = "NOT_BLOCK_ERROR";
         if (e instanceof BlockError) {
-          blockErrorCode = e.type.code;
           switch (e.type.code) {
             case BlockErrorCode.ALREADY_KNOWN:
             case BlockErrorCode.PARENT_UNKNOWN:
@@ -173,12 +171,10 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
               core.reportPeer(peerIdStr, PeerAction.LowToleranceError, "BadGossipBlock");
           }
         }
-        metrics?.gossipBlock.processBlockErrors.inc({blockErrorCode});
-        logger.error(
-          "Error receiving block",
-          {slot: signedBlock.message.slot, peer: peerIdStr, blockErrorCode, seenTimestampSec},
-          e as Error
-        );
+        metrics?.gossipBlock.processBlockErrors.inc({
+          blockErrorCode: e instanceof BlockError ? e.type.code : "NOT_BLOCK_ERROR",
+        });
+        logger.error("Error receiving block", {slot: signedBlock.message.slot, peer: peerIdStr}, e as Error);
       });
   }
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -171,6 +171,12 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
               core.reportPeer(peerIdStr, PeerAction.LowToleranceError, "BadGossipBlock");
           }
         }
+        metrics?.gossipBlock.processBlockErrors.inc({
+          peerIdStr,
+          slot: signedBlock.message.slot,
+          seenTimestampSec,
+          blockErrorCode: `${e.type.code}`,
+        });
         logger.error("Error receiving block", {slot: signedBlock.message.slot, peer: peerIdStr}, e as Error);
       });
   }


### PR DESCRIPTION
**Motivation**

This PR is related to #5481 and captures gossip block error metrics and adds them to a new dashboard.  Will help to debug poorly gossiped blocks by peers by exposing the slot, peerId, time seen and error that was raised.

**Description**

Closes #5481

