### PR TITLE
feat: add ThreadBoundaryError

### DIFF
--- a/packages/beacon-node/src/util/error.ts
+++ b/packages/beacon-node/src/util/error.ts
@@ -1,0 +1,54 @@
+import {REQUEST_ERROR_CLASS_NAME, RESPONSE_ERROR_CLASS_NAME, RequestError, ResponseError} from "@lodestar/reqresp";
+import {FromObjectFn, LodestarError, LodestarErrorObject} from "@lodestar/utils";
+import {ClonableLodestarError} from "@lodestar/utils";
+
+/**
+ * Error that can be passed across thread boundaries
+ */
+export type ThreadBoundaryError = {error: null; object: LodestarErrorObject} | {error: Error; object: null};
+
+/**
+ * Structured clone does not work with Error objects.
+ * For ClonableLodestarError, we want to specify the LodestarErrorObject with className so that we can deserialize later.
+ */
+export function toThreadBoundaryError(error: Error): ThreadBoundaryError {
+  if (error instanceof ClonableLodestarError) {
+    return {error: null, object: error.toObject()};
+  }
+
+  // note that non-clonable errors will be deserialized as a generic Error object
+  return {error, object: null};
+}
+
+/**
+ * Only RequestError and ResponseError pass through thread boundaries.
+ * If we pass more errors in the future through thread boundaries, we need to add them here.
+ */
+const fromObjectFnRegistry = new Map<string, FromObjectFn>([
+  [RESPONSE_ERROR_CLASS_NAME, ResponseError.fromObject],
+  [REQUEST_ERROR_CLASS_NAME, RequestError.fromObject],
+]);
+
+/**
+ * If error is ClonableLodestarError, deserialize it from the LodestarErrorObject.
+ * Else use the generic Error object.
+ */
+export function fromThreadBoundaryError(error: ThreadBoundaryError): Error {
+  if (error.error) {
+    // this is always a generic Error object
+    return error.error;
+  }
+
+  let clonedError: Error;
+  const fromObjectFn = fromObjectFnRegistry.get(error.object.className);
+  if (fromObjectFn) {
+    clonedError = fromObjectFn(error.object);
+  } else {
+    // should not happen as a ClonableLodestarError class should implement "fromObject" method and register it
+    // try our best to clone the error with the same stack trace
+    clonedError = new LodestarError({code: "UNKNOWN_ERROR_CLASS"}, `Unknown error class ${error.object.className}`);
+  }
+
+  clonedError.stack = error.object.stack;
+  return clonedError;
+}

--- a/packages/beacon-node/test/unit/util/error.test.ts
+++ b/packages/beacon-node/test/unit/util/error.test.ts
@@ -2,8 +2,6 @@ import v8 from "node:v8";
 import {expect} from "chai";
 import {RequestError, RequestErrorCode, RespStatus, ResponseError} from "@lodestar/reqresp";
 import {fromThreadBoundaryError, toThreadBoundaryError} from "../../../src/util/error.js";
-import {AttestationError, AttestationErrorCode} from "../../../src/chain/errors/attestationError.js";
-import {GossipAction} from "../../../src/chain/errors/index.js";
 
 function structuredClone<T>(value: T): T {
   return v8.deserialize(v8.serialize(value)) as T;
@@ -40,19 +38,5 @@ describe("ThreadBoundaryError", () => {
       expect.fail("clonedResponseError should be instance of ResponseError");
     }
     expect((clonedResponseError as ResponseError).toObject()).to.be.deep.equal(responseError.toObject());
-  });
-
-  it("should not able to clone AttestationError through thread boundary", () => {
-    const attestationError = new AttestationError(GossipAction.IGNORE, {code: AttestationErrorCode.BAD_TARGET_EPOCH});
-    const threadBoundaryError = toThreadBoundaryError(attestationError);
-    const clonedError = structuredClone(threadBoundaryError);
-    expect(clonedError.error).to.be.not.null;
-    if (!clonedError.error) {
-      // should not happen
-      expect.fail("clonedError.error should not be null");
-    }
-    expect(clonedError.object).to.be.null;
-    const clonedAttestationError = fromThreadBoundaryError(clonedError);
-    expect(clonedAttestationError instanceof AttestationError).to.be.false;
   });
 });

--- a/packages/beacon-node/test/unit/util/error.test.ts
+++ b/packages/beacon-node/test/unit/util/error.test.ts
@@ -1,0 +1,58 @@
+import v8 from "node:v8";
+import {expect} from "chai";
+import {RequestError, RequestErrorCode, RespStatus, ResponseError} from "@lodestar/reqresp";
+import {fromThreadBoundaryError, toThreadBoundaryError} from "../../../src/util/error.js";
+import {AttestationError, AttestationErrorCode} from "../../../src/chain/errors/attestationError.js";
+import {GossipAction} from "../../../src/chain/errors/index.js";
+
+function structuredClone<T>(value: T): T {
+  return v8.deserialize(v8.serialize(value)) as T;
+}
+
+describe("ThreadBoundaryError", () => {
+  it("should clone RequestError through thread boundary", () => {
+    const requestError = new RequestError({code: RequestErrorCode.TTFB_TIMEOUT});
+    const threadBoundaryError = toThreadBoundaryError(requestError);
+    const clonedError = structuredClone(threadBoundaryError);
+    expect(clonedError.error).to.be.null;
+    if (!clonedError.object) {
+      // should not happen
+      expect.fail("clonedError.object should not be null");
+    }
+    const clonedRequestError = fromThreadBoundaryError(clonedError);
+    if (!(clonedRequestError instanceof RequestError)) {
+      expect.fail("clonedRequestError should be instance of RequestError");
+    }
+    expect((clonedRequestError as RequestError).toObject()).to.be.deep.equal(requestError.toObject());
+  });
+
+  it("should clone ResponseError through thread boundary", () => {
+    const responseError = new ResponseError(RespStatus.SERVER_ERROR, "internal server error");
+    const threadBoundaryError = toThreadBoundaryError(responseError);
+    const clonedError = structuredClone(threadBoundaryError);
+    expect(clonedError.error).to.be.null;
+    if (!clonedError.object) {
+      // should not happen
+      expect.fail("clonedError.object should not be null");
+    }
+    const clonedResponseError = fromThreadBoundaryError(clonedError);
+    if (!(clonedResponseError instanceof ResponseError)) {
+      expect.fail("clonedResponseError should be instance of ResponseError");
+    }
+    expect((clonedResponseError as ResponseError).toObject()).to.be.deep.equal(responseError.toObject());
+  });
+
+  it("should not able to clone AttestationError through thread boundary", () => {
+    const attestationError = new AttestationError(GossipAction.IGNORE, {code: AttestationErrorCode.BAD_TARGET_EPOCH});
+    const threadBoundaryError = toThreadBoundaryError(attestationError);
+    const clonedError = structuredClone(threadBoundaryError);
+    expect(clonedError.error).to.be.not.null;
+    if (!clonedError.error) {
+      // should not happen
+      expect.fail("clonedError.error should not be null");
+    }
+    expect(clonedError.object).to.be.null;
+    const clonedAttestationError = fromThreadBoundaryError(clonedError);
+    expect(clonedAttestationError instanceof AttestationError).to.be.false;
+  });
+});

--- a/packages/reqresp/src/index.ts
+++ b/packages/reqresp/src/index.ts
@@ -3,6 +3,6 @@ export {getMetrics, Metrics, MetricsRegister} from "./metrics.js";
 export {Encoding as ReqRespEncoding} from "./types.js"; // Expose enums renamed
 export * from "./types.js";
 export * from "./interface.js";
-export {ResponseErrorCode, ResponseError} from "./response/errors.js";
-export {RequestErrorCode, RequestError} from "./request/errors.js";
+export * from "./response/errors.js";
+export * from "./request/errors.js";
 export {collectExactOne, collectMaxResponse, formatProtocolID, parseProtocolID} from "./utils/index.js";

--- a/packages/reqresp/src/request/errors.ts
+++ b/packages/reqresp/src/request/errors.ts
@@ -1,4 +1,4 @@
-import {ClonableLodestarError, LodestarErrorObject, lodestarErrorObjectToMetaData} from "@lodestar/utils";
+import {LodestarError, LodestarErrorObject} from "@lodestar/utils";
 import {ResponseError} from "../response/index.js";
 import {RespStatus, RpcResponseStatusError} from "../interface.js";
 
@@ -51,9 +51,9 @@ type RequestErrorType =
 
 export const REQUEST_ERROR_CLASS_NAME = "RequestError";
 
-export class RequestError extends ClonableLodestarError<RequestErrorType> {
-  constructor(type: RequestErrorType) {
-    super(type, renderErrorMessage(type));
+export class RequestError extends LodestarError<RequestErrorType> {
+  constructor(type: RequestErrorType, message?: string, stack?: string) {
+    super(type, message ?? renderErrorMessage(type), stack);
   }
 
   static fromObject(obj: LodestarErrorObject): RequestError {
@@ -61,7 +61,7 @@ export class RequestError extends ClonableLodestarError<RequestErrorType> {
       throw new Error(`Expected className to be RequestError, but got ${obj.className}`);
     }
 
-    return new RequestError(lodestarErrorObjectToMetaData(obj) as RequestErrorType);
+    return new RequestError(obj.type as RequestErrorType, obj.message, obj.stack);
   }
 }
 

--- a/packages/reqresp/src/request/errors.ts
+++ b/packages/reqresp/src/request/errors.ts
@@ -1,4 +1,4 @@
-import {LodestarError} from "@lodestar/utils";
+import {ClonableLodestarError, LodestarErrorObject, lodestarErrorObjectToMetaData} from "@lodestar/utils";
 import {ResponseError} from "../response/index.js";
 import {RespStatus, RpcResponseStatusError} from "../interface.js";
 
@@ -49,9 +49,19 @@ type RequestErrorType =
   | {code: RequestErrorCode.RESP_TIMEOUT}
   | {code: RequestErrorCode.REQUEST_RATE_LIMITED};
 
-export class RequestError extends LodestarError<RequestErrorType> {
+export const REQUEST_ERROR_CLASS_NAME = "RequestError";
+
+export class RequestError extends ClonableLodestarError<RequestErrorType> {
   constructor(type: RequestErrorType) {
     super(type, renderErrorMessage(type));
+  }
+
+  static fromObject(obj: LodestarErrorObject): RequestError {
+    if (obj.className !== "RequestError") {
+      throw new Error(`Expected className to be RequestError, but got ${obj.className}`);
+    }
+
+    return new RequestError(lodestarErrorObjectToMetaData(obj) as RequestErrorType);
   }
 }
 

--- a/packages/reqresp/src/response/errors.ts
+++ b/packages/reqresp/src/response/errors.ts
@@ -1,4 +1,4 @@
-import {ClonableLodestarError, LodestarErrorMetaData, LodestarErrorObject} from "@lodestar/utils";
+import {LodestarError, LodestarErrorMetaData, LodestarErrorObject} from "@lodestar/utils";
 import {RespStatus, RpcResponseStatusError} from "../interface.js";
 
 type RpcResponseStatusNotSuccess = Exclude<RespStatus, RespStatus.SUCCESS>;
@@ -19,12 +19,12 @@ export const RESPONSE_ERROR_CLASS_NAME = "ResponseError";
  * Used internally only to signal a response status error. Since the error should never bubble up to the user,
  * the error code and error message does not matter much.
  */
-export class ResponseError extends ClonableLodestarError<RequestErrorType> {
+export class ResponseError extends LodestarError<RequestErrorType> {
   status: RpcResponseStatusNotSuccess;
   errorMessage: string;
-  constructor(status: RpcResponseStatusNotSuccess, errorMessage: string) {
+  constructor(status: RpcResponseStatusNotSuccess, errorMessage: string, stack?: string) {
     const type = {code: ResponseErrorCode.RESPONSE_STATUS_ERROR, status, errorMessage};
-    super(type, `RESPONSE_ERROR_${RespStatus[status]}: ${errorMessage}`);
+    super(type, `RESPONSE_ERROR_${RespStatus[status]}: ${errorMessage}`, stack);
     this.status = status;
     this.errorMessage = errorMessage;
   }
@@ -41,6 +41,10 @@ export class ResponseError extends ClonableLodestarError<RequestErrorType> {
       throw new Error(`Expected className to be ResponseError, but got ${obj.className}`);
     }
 
-    return new ResponseError(obj.status as RpcResponseStatusNotSuccess, obj.errorMessage as string);
+    return new ResponseError(
+      obj.type.status as RpcResponseStatusNotSuccess,
+      obj.type.errorMessage as string,
+      obj.stack
+    );
   }
 }

--- a/packages/reqresp/src/response/errors.ts
+++ b/packages/reqresp/src/response/errors.ts
@@ -1,4 +1,4 @@
-import {LodestarError} from "@lodestar/utils";
+import {ClonableLodestarError, LodestarErrorMetaData, LodestarErrorObject} from "@lodestar/utils";
 import {RespStatus, RpcResponseStatusError} from "../interface.js";
 
 type RpcResponseStatusNotSuccess = Exclude<RespStatus, RespStatus.SUCCESS>;
@@ -13,11 +13,13 @@ type RequestErrorType = {
   errorMessage: string;
 };
 
+export const RESPONSE_ERROR_CLASS_NAME = "ResponseError";
+
 /**
  * Used internally only to signal a response status error. Since the error should never bubble up to the user,
  * the error code and error message does not matter much.
  */
-export class ResponseError extends LodestarError<RequestErrorType> {
+export class ResponseError extends ClonableLodestarError<RequestErrorType> {
   status: RpcResponseStatusNotSuccess;
   errorMessage: string;
   constructor(status: RpcResponseStatusNotSuccess, errorMessage: string) {
@@ -25,5 +27,20 @@ export class ResponseError extends LodestarError<RequestErrorType> {
     super(type, `RESPONSE_ERROR_${RespStatus[status]}: ${errorMessage}`);
     this.status = status;
     this.errorMessage = errorMessage;
+  }
+
+  getMetadata(): LodestarErrorMetaData {
+    return {
+      status: this.status,
+      errorMessage: this.errorMessage,
+    };
+  }
+
+  static fromObject(obj: LodestarErrorObject): ResponseError {
+    if (obj.className !== RESPONSE_ERROR_CLASS_NAME) {
+      throw new Error(`Expected className to be ResponseError, but got ${obj.className}`);
+    }
+
+    return new ResponseError(obj.status as RpcResponseStatusNotSuccess, obj.errorMessage as string);
   }
 }

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -1,3 +1,7 @@
+export type LodestarErrorMetaData = Record<string, string | number | null>;
+export type LodestarErrorObject = LodestarErrorMetaData & {stack: string} & {className: string};
+export type FromObjectFn = (object: LodestarErrorObject) => Error;
+
 /**
  * Generic Lodestar error with attached metadata
  */
@@ -22,6 +26,34 @@ export class LodestarError<T extends {code: string}> extends Error {
       stack: this.stack || "",
     };
   }
+}
+
+/**
+ * Generic Lodestar error with attached metadata that can be cloned.
+ * Child classes should implement `fromObject` to deserialize the error.
+ */
+export class ClonableLodestarError<T extends {code: string}> extends LodestarError<T> {
+  constructor(type: T, message?: string) {
+    super(type, message);
+  }
+
+  /**
+   * Add className to the error object so that it can be deserialized.
+   */
+  toObject(): LodestarErrorObject {
+    return {
+      // Ignore message since it's just type.code
+      ...this.getMetadata(),
+      stack: this.stack || "",
+      className: this.constructor.name,
+    };
+  }
+}
+
+export function lodestarErrorObjectToMetaData(object: LodestarErrorObject): LodestarErrorMetaData {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const {stack, className, ...metadata} = object;
+  return metadata;
 }
 
 /**

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -1,5 +1,10 @@
 export type LodestarErrorMetaData = Record<string, string | number | null>;
-export type LodestarErrorObject = LodestarErrorMetaData & {stack: string} & {className: string};
+export type LodestarErrorObject = {
+  message: string;
+  stack: string;
+  className: string;
+  type: LodestarErrorMetaData;
+};
 export type FromObjectFn = (object: LodestarErrorObject) => Error;
 
 /**
@@ -7,53 +12,31 @@ export type FromObjectFn = (object: LodestarErrorObject) => Error;
  */
 export class LodestarError<T extends {code: string}> extends Error {
   type: T;
-  constructor(type: T, message?: string) {
+  constructor(type: T, message?: string, stack?: string) {
     super(message || type.code);
     this.type = type;
+    if (stack) this.stack = stack;
   }
 
-  getMetadata(): Record<string, string | number | null> {
+  getMetadata(): LodestarErrorMetaData {
     return this.type;
   }
 
   /**
    * Get the metadata and the stacktrace for the error.
    */
-  toObject(): Record<string, string | number | null> {
-    return {
-      // Ignore message since it's just type.code
-      ...this.getMetadata(),
-      stack: this.stack || "",
-    };
-  }
-}
-
-/**
- * Generic Lodestar error with attached metadata that can be cloned.
- * Child classes should implement `fromObject` to deserialize the error.
- */
-export class ClonableLodestarError<T extends {code: string}> extends LodestarError<T> {
-  constructor(type: T, message?: string) {
-    super(type, message);
-  }
-
-  /**
-   * Add className to the error object so that it can be deserialized.
-   */
   toObject(): LodestarErrorObject {
     return {
-      // Ignore message since it's just type.code
-      ...this.getMetadata(),
-      stack: this.stack || "",
+      type: this.getMetadata(),
+      message: this.message ?? "",
+      stack: this.stack ?? "",
       className: this.constructor.name,
     };
   }
-}
 
-export function lodestarErrorObjectToMetaData(object: LodestarErrorObject): LodestarErrorMetaData {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const {stack, className, ...metadata} = object;
-  return metadata;
+  static fromObject(obj: LodestarErrorObject): LodestarError<{code: string}> {
+    return new LodestarError(obj.type as {code: string}, obj.message, obj.stack);
+  }
 }
 
 /**


### PR DESCRIPTION
**Motivation**
- Failed reqresp e2e tests because Error objects cannot be passed through thread boundary correctly

**Description**

- Add `ThreadBoundaryError` that can be passed through thread boundaries
  - for errors that's clonnable, error is null and object is the result of `toObject()` method
  - for other errors, just pass `object` as null. They will be deserialized into the generic Error object if passing through thread boundaries

```typescript
export type ThreadBoundaryError = {error: null; object: LodestarErrorObject} | {error: Error; object: null};
```
- For errors that we want to pass through thread boundaries, they need to 
  - implement a newly created `ClonableLodestarError` class which includes class name there in `toObject` method
  - implement static `fromObject` method
  - for now I see only `RequestError` and `ResponseError` need this

- For other errors (don't see the need for now) it'll be deserialized into the generic Error object if we pass them through thread boundaries
