### PR TITLE
fix: use proper state to verify attestations

### DIFF
--- a/packages/beacon-node/src/chain/errors/attestationError.ts
+++ b/packages/beacon-node/src/chain/errors/attestationError.ts
@@ -115,9 +115,9 @@ export enum AttestationErrorCode {
    */
   COMMITTEE_INDEX_OUT_OF_RANGE = "ATTESTATION_ERROR_COMMITTEE_INDEX_OUT_OF_RANGE",
   /**
-   * Missing attestation head state
+   * Missing state to verify attestation
    */
-  MISSING_ATTESTATION_HEAD_STATE = "ATTESTATION_ERROR_MISSING_ATTESTATION_HEAD_STATE",
+  MISSING_STATE_TO_VERIFY_ATTESTATION = "ATTESTATION_ERROR_MISSING_STATE_TO_VERIFY_ATTESTATION",
   /**
    * Invalid aggregator.
    */
@@ -162,7 +162,7 @@ export type AttestationErrorType =
   | {code: AttestationErrorCode.INVALID_TARGET_ROOT; targetRoot: RootHex; expected: string | null}
   | {code: AttestationErrorCode.TARGET_BLOCK_NOT_AN_ANCESTOR_OF_LMD_BLOCK}
   | {code: AttestationErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE; index: number}
-  | {code: AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE; error: Error}
+  | {code: AttestationErrorCode.MISSING_STATE_TO_VERIFY_ATTESTATION; error: Error}
   | {code: AttestationErrorCode.INVALID_AGGREGATOR}
   | {code: AttestationErrorCode.INVALID_INDEXED_ATTESTATION}
   | {code: AttestationErrorCode.INVALID_SERIALIZED_BYTES}
@@ -174,7 +174,7 @@ export class AttestationError extends GossipActionError<AttestationErrorType> {
     switch (type.code) {
       case AttestationErrorCode.UNKNOWN_TARGET_ROOT:
         return {code: type.code, root: toHexString(type.root)};
-      case AttestationErrorCode.MISSING_ATTESTATION_HEAD_STATE:
+      case AttestationErrorCode.MISSING_STATE_TO_VERIFY_ATTESTATION:
         // TODO: The stack trace gets lost here
         return {code: type.code, error: type.error.message};
 

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -114,9 +114,6 @@ export async function validateGossipAggregateAndProof(
   // -- i.e. get_ancestor(store, aggregate.data.beacon_block_root, compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)) == store.finalized_checkpoint.root
   // > Altready check in `chain.forkChoice.hasBlock(attestation.data.beaconBlockRoot)`
 
-  // Using the target checkpoint state here caused unstable memory issue
-  // See https://github.com/ChainSafe/lodestar/issues/4896
-  // TODO: https://github.com/ChainSafe/lodestar/issues/4900
   const attHeadState = await getStateForAttestationVerification(
     chain,
     attSlot,

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -52,6 +52,11 @@ export async function validateGossipAggregateAndProof(
   const attTarget = attData.target;
   const targetEpoch = attTarget.epoch;
 
+  chain.metrics?.gossipAttestation.attestationSlotToClockSlot.observe(
+    {caller: RegenCaller.validateGossipAggregateAndProof},
+    chain.clock.currentSlot - attSlot
+  );
+
   if (!cachedAttData) {
     // [REJECT] The attestation's epoch matches its target -- i.e. attestation.data.target.epoch == compute_epoch_at_slot(attestation.data.slot)
     if (targetEpoch !== attEpoch) {
@@ -101,6 +106,7 @@ export async function validateGossipAggregateAndProof(
     attTarget.root,
     attSlot,
     attEpoch,
+    RegenCaller.validateGossipAggregateAndProof,
     chain.opts.maxSkipSlots
   );
 

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -172,9 +172,6 @@ export async function validateGossipAttestation(
     //  --i.e. get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(attestation.data.target.epoch)) == attestation.data.target.root
     // > Altready check in `verifyHeadBlockAndTargetRoot()`
 
-    // Using the target checkpoint state here caused unstable memory issue
-    // See https://github.com/ChainSafe/lodestar/issues/4896
-    // TODO: https://github.com/ChainSafe/lodestar/issues/4900
     const attHeadState = await getStateForAttestationVerification(
       chain,
       attSlot,

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -41,6 +41,12 @@ export type AttestationOrBytes =
     };
 
 /**
+ * The beacon chain shufflings are designed to provide 1 epoch lookahead
+ * At each state, we have previous shuffling, current shuffling and next shuffling
+ */
+const SHUFFLING_LOOK_AHEAD_EPOCHS = 1;
+
+/**
  * Only deserialize the attestation if needed, use the cached AttestationData instead
  * This is to avoid deserializing similar attestation multiple times which could help the gc
  */
@@ -382,7 +388,8 @@ export async function getStateForAttestationVerification(
 ): Promise<CachedBeaconStateAllForks> {
   const isSameFork = chain.config.getForkSeq(attSlot) === chain.config.getForkSeq(attHeadBlock.slot);
   // thanks for 1 epoch look ahead of shuffling, a state at epoch n can get committee for epoch n+1
-  const headStateHasTargetEpochCommmittee = attEpoch - computeEpochAtSlot(attHeadBlock.slot) <= 1;
+  const headStateHasTargetEpochCommmittee =
+    attEpoch - computeEpochAtSlot(attHeadBlock.slot) <= SHUFFLING_LOOK_AHEAD_EPOCHS;
   try {
     if (isSameFork && headStateHasTargetEpochCommmittee) {
       // most of the time it should just use head state

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -531,6 +531,20 @@ export function createLodestarMetrics(
       }),
     },
 
+    // Gossip attestation
+    gossipAttestation: {
+      useHeadBlockState: register.gauge<"caller">({
+        name: "lodestar_gossip_attestation_use_head_block_state_count",
+        help: "Count of gossip attestation verification using head block state",
+        labelNames: ["caller"],
+      }),
+      useHeadBlockStateDialedToTargetEpoch: register.gauge<"caller">({
+        name: "lodestar_gossip_attestation_use_head_block_state_dialed_to_target_epoch_count",
+        help: "Count of gossip attestation verification using head block state and dialed to target epoch",
+        labelNames: ["caller"],
+      }),
+    },
+
     // Gossip block
     gossipBlock: {
       elapsedTimeTillReceived: register.histogram({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -543,6 +543,18 @@ export function createLodestarMetrics(
         help: "Count of gossip attestation verification using head block state and dialed to target epoch",
         labelNames: ["caller"],
       }),
+      headSlotToAttestationSlot: register.histogram<"caller">({
+        name: "lodestar_gossip_attestation_head_slot_to_attestation_slot",
+        help: "Slot distance between attestation slot and head slot",
+        labelNames: ["caller"],
+        buckets: [0, 1, 2, 4, 8, 16, 32, 64],
+      }),
+      attestationSlotToClockSlot: register.histogram<"caller">({
+        name: "lodestar_gossip_attestation_attestation_slot_to_clock_slot",
+        help: "Slot distance between clock slot and attestation slot",
+        labelNames: ["caller"],
+        buckets: [0, 1, 2, 4, 8, 16, 32, 64],
+      }),
     },
 
     // Gossip block


### PR DESCRIPTION
**Motivation**

Right now we always use head state to verify attestations

**Description**

We should only use head block state if:
- head block slot and attestation slot are in the same fork
- and head block state includes committees of target epoch

otherwise we should use head state dialed to target epoch. Notice that with `maxSkippedSlot=32` we'll always use head state unless it's at epoch boundary

Also add some metrics to monitor slot distances in attestation

Closes #5498 Closes #4831

**TODOs**
- [x] Unit test
- [x] Deploy and monitor on a test mainnet node