### PR TITLE
chore: fix dashboard panels with outdated metric queries

### DIFF
--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -1497,23 +1497,11 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "avg(\n  delta(validator_monitor_prev_epoch_on_chain_balance_total[32m])\n)",
+          "expr": "avg(\n  delta(validator_monitor_prev_epoch_on_chain_balance[32m])\n)",
           "hide": false,
           "interval": "",
           "legendFormat": "balance_delta",
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "avg(\n  delta(validator_monitor_prev_epoch_on_chain_balance[32m])\n)",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "balance_delta_new",
-          "refId": "B"
         }
       ],
       "title": "balance delta prev epoch",
@@ -2693,7 +2681,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "(time() - lodestar_genesis_time) / 12 - lodestar_clock_slot",
+              "expr": "(time() - lodestar_genesis_time) / 12 - beacon_clock_slot",
               "hide": false,
               "interval": "",
               "legendFormat": "clock drift",
@@ -2908,7 +2896,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": false,
-              "expr": "lodestar_clock_slot - beacon_head_slot",
+              "expr": "beacon_clock_slot - beacon_head_slot",
               "hide": false,
               "interval": "",
               "legendFormat": "clock drift",

--- a/dashboards/lodestar_validator_monitor.json
+++ b/dashboards/lodestar_validator_monitor.json
@@ -287,23 +287,11 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "avg(\n  delta(validator_monitor_prev_epoch_on_chain_balance_total[32m])\n)",
+          "expr": "avg(\n  delta(validator_monitor_prev_epoch_on_chain_balance[32m])\n)",
           "hide": false,
           "interval": "",
           "legendFormat": "balance_delta",
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "avg(\n  delta(validator_monitor_prev_epoch_on_chain_balance[32m])\n)",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "balance_delta_new",
-          "refId": "B"
         }
       ],
       "title": "balance delta prev epoch",
@@ -1172,7 +1160,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "sum(validator_monitor_prev_epoch_attestations_total)/sum(validator_monitor_validators)",
+          "expr": "validator_monitor_prev_epoch_attestations_count / validator_monitor_validators",
           "interval": "",
           "legendFormat": "attestations_sent",
           "refId": "A"
@@ -1183,7 +1171,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "sum(validator_monitor_prev_epoch_aggregates_total)/sum(validator_monitor_validators)",
+          "expr": "validator_monitor_prev_epoch_aggregates_count / validator_monitor_validators",
           "hide": false,
           "interval": "",
           "legendFormat": "aggregates_sent",
@@ -1584,34 +1572,10 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "avg(validator_monitor_prev_epoch_attestation_block_inclusions_total)",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "block_inclusions",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "avg(validator_monitor_prev_epoch_attestation_aggregate_inclusions_total)",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "aggregate_inclusions",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
           "expr": "validator_monitor_prev_epoch_attestation_block_inclusions_sum\n/\nvalidator_monitor_prev_epoch_attestation_block_inclusions_count",
           "hide": false,
           "interval": "",
-          "legendFormat": "block_inclusions new",
+          "legendFormat": "block_inclusions",
           "refId": "A"
         },
         {
@@ -1623,8 +1587,8 @@
           "expr": "validator_monitor_prev_epoch_attestation_aggregate_inclusions_sum\n/\nvalidator_monitor_prev_epoch_attestation_aggregate_inclusions_count",
           "hide": false,
           "interval": "",
-          "legendFormat": "aggregate_inclusions new",
-          "refId": "D"
+          "legendFormat": "aggregate_inclusions",
+          "refId": "B"
         }
       ],
       "title": "Attestation inclusions epoch per validator",

--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -1199,7 +1199,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "(time() - lodestar_genesis_time) / 12 - lodestar_clock_slot",
+              "expr": "(time() - lodestar_genesis_time) / 12 - beacon_clock_slot",
               "hide": false,
               "interval": "",
               "legendFormat": "clock drift",
@@ -1414,7 +1414,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": false,
-              "expr": "lodestar_clock_slot - beacon_head_slot",
+              "expr": "beacon_clock_slot - beacon_head_slot",
               "hide": false,
               "interval": "",
               "legendFormat": "clock drift",


### PR DESCRIPTION
**Motivation**

Looked through metrics and fixed few metric queries along the way.

**Description**

Some metrics were changed from gauge to histogram but the queries in the dashboards were not updated
- https://github.com/ChainSafe/lodestar/pull/4475

Other updates are related to panels where we have a old and a new metric queries, just removed the old one as it should no longer be relevant at this point (updated Sep 1, 2022).
