### PR TITLE
refactor: revise validator log to output seen instead of exists

### DIFF
--- a/packages/validator/src/services/indices.ts
+++ b/packages/validator/src/services/indices.ts
@@ -135,7 +135,7 @@ export class IndicesService {
 
       const pubkeyHex = toHexString(validatorState.validator.pubkey);
       if (!this.pubkey2index.has(pubkeyHex)) {
-        this.logger.info("Validator exists in beacon chain", {
+        this.logger.info("Validator seen on beacon chain", {
           validatorIndex: validatorState.index,
           pubKey: pubkeyHex,
         });


### PR DESCRIPTION
**Motivation**

Referencing feedback from a user on Discord: https://discord.com/channels/593655374469660673/593655641445367808/1108123487840763977

On the `VC`, due to the frequency of this log being output: `Validator exists in beacon chain`, there is a probable chance that the word `exists` can be easily misinterpreted with the word `exits` - which should be avoided for bad UX.  

**Description**

An alternative syntax for this log output is `Validator seen on beacon chain` which will avoid any misinterpretation.
