### PR TITLE
fix: correct seen attestation data count per slot metric

### DIFF
--- a/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
@@ -100,10 +100,11 @@ export class SeenAttestationDatas {
 
   private onScrapeLodestarMetrics(metrics: Metrics): void {
     metrics?.seenCache.attestationData.totalSlot.set(this.cacheEntryByAttDataBase64BySlot.size);
-    // only track current slot
-    const currentSlot = this.lowestPermissibleSlot + this.cacheSlotDistance;
+    // tracking number of attestation data at current slot may not be correct if scrape time is not at the end of slot
+    // so we track it at the previous slot
+    const previousSlot = this.lowestPermissibleSlot + this.cacheSlotDistance - 1;
     metrics?.seenCache.attestationData.countPerSlot.set(
-      this.cacheEntryByAttDataBase64BySlot.get(currentSlot)?.size ?? 0
+      this.cacheEntryByAttDataBase64BySlot.get(previousSlot)?.size ?? 0
     );
   }
 }


### PR DESCRIPTION
**Motivation**

This is on stable mainnet node, count of seen attestation data per slot is not correct because the scrape time is at random part of a slot

<img width="1288" alt="Screenshot 2023-05-18 at 11 06 19" src="https://github.com/ChainSafe/lodestar/assets/10568965/6415500a-04d2-449b-9574-e6f46cb437d3">

**Description**

Count it at the previous slot instead of the current slot