### PR TITLE
fix(validator): improve error handling in attestation service

### DIFF
--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -99,9 +99,11 @@ export class AttestationService {
     } else {
       // Beacon node's endpoint produceAttestationData return data is not dependant on committeeIndex.
       // Produce a single attestation for all committees and submit unaggregated attestations in one go.
-      await this.runAttestationTasksGrouped(duties, slot, signal).catch((e) => {
-        this.logger.error("Error on attestation routine", {slot}, e);
-      });
+      try {
+        await this.runAttestationTasksGrouped(duties, slot, signal);
+      } catch (e) {
+        this.logger.error("Error on attestation routine", {slot}, e as Error);
+      }
     }
   };
 

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -92,14 +92,16 @@ export class AttestationService {
       await Promise.all(
         Array.from(dutiesByCommitteeIndex.entries()).map(([index, duties]) =>
           this.runAttestationTasksPerCommittee(duties, slot, index, signal).catch((e) => {
-            this.logger.error("Error on attestation routine", {slot, index}, e);
+            this.logger.error("Error on committee attestation routine", {slot, index}, e);
           })
         )
       );
     } else {
       // Beacon node's endpoint produceAttestationData return data is not dependant on committeeIndex.
       // Produce a single attestation for all committees and submit unaggregated attestations in one go.
-      await this.runAttestationTasksGrouped(duties, slot, signal);
+      await this.runAttestationTasksGrouped(duties, slot, signal).catch((e) => {
+        this.logger.error("Error on attestation routine", {slot}, e);
+      });
     }
   };
 


### PR DESCRIPTION
**Motivation**

Errors thrown during attestation routine are not handled within `AttestationService` but instead will be will be logged by `Clock` which does not use [LoggerVC](https://github.com/ChainSafe/lodestar/blob/bc88bddd96a54c8f5fb34666d99e8f0faa329d5a/packages/validator/src/util/logger.ts#L9) due to circular dependency (LoggerVC depends on clock).

https://github.com/ChainSafe/lodestar/blob/bc88bddd96a54c8f5fb34666d99e8f0faa329d5a/packages/validator/src/validator.ts#L73-L74

When the EL is syncing the BN will throw an error during attestation routine of VC which produces an verbose error

```
error: Error on runEvery fn  Error producing attestation - Service Unavailable: Node is syncing - Block's execution payload not yet validated, executionPayloadBlockHash=0xfaf4067706a82a716245fcbd963b3ed502a8fc4a6d1c896c44e9cd7efe1ec425 number=9039112
Error: Error producing attestation - Service Unavailable: Node is syncing - Block's execution payload not yet validated, executionPayloadBlockHash=0xfaf4067706a82a716245fcbd963b3ed502a8fc4a6d1c896c44e9cd7efe1ec425 number=9039112
    at Function.assert (file:///home/devops/goerli/lodestar/packages/api/src/utils/client/httpClient.ts:44:13)
    at AttestationService.produceAttestation (file:///home/devops/goerli/lodestar/packages/validator/src/services/attestation.ts:167:14)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at AttestationService.runAttestationTasksGrouped (file:///home/devops/goerli/lodestar/packages/validator/src/services/attestation.ts:134:36)
    at AttestationService.runAttestationTasks (file:///home/devops/goerli/lodestar/packages/validator/src/services/attestation.ts:102:7)
    at Clock.runAtMostEvery (file:///home/devops/goerli/lodestar/packages/validator/src/util/clock.ts:96:7)
```

**Expected error log**

```
warn: Node is syncing - Error producing attestation - Service Unavailable: Node is syncing - Block's execution payload not yet validated, executionPayloadBlockHash=0x1c11477b79fd8d7d0c72411897fb96efa25c15781f7b78a714377af7b02bc02a number=9039134
```


**Description**

Catch errors thrown by `runAttestationTasksGrouped` to properly handle "Node is syncing" errors and improve logging UX. 
