### PR TITLE
chore: add eslint rule to ensure await in try-catch

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
       },
     ],
     "@typescript-eslint/await-thenable": "error",
+    "@typescript-eslint/return-await": "error",
     "@typescript-eslint/naming-convention": [
       "error",
       {selector: "default", format: ["camelCase"]},
@@ -134,7 +135,6 @@ module.exports = {
     "no-consecutive-blank-lines": 0,
     "no-console": "error",
     "no-var": "error",
-    "no-return-await": "error",
     "object-curly-spacing": ["error", "never"],
     "object-literal-sort-keys": 0,
     "no-prototype-builtins": 0,
@@ -168,6 +168,9 @@ module.exports = {
 
     // TEMP Disabled while eslint-plugin-import support ESM (Typescript does support it) https://github.com/import-js/eslint-plugin-import/issues/2170
     "import/no-unresolved": "off",
+
+    // superseded by @typescript-eslint/return-await, must be disabled as it can report incorrect errors
+    "no-return-await": "off",
 
     "@chainsafe/node/file-extension-in-import": ["error", "always", {esm: true}],
   },

--- a/packages/api/src/utils/client/client.ts
+++ b/packages/api/src/utils/client/client.ts
@@ -67,7 +67,7 @@ export function generateGenericJsonClient<
       try {
         if (returnType) {
           const res = await fetchFn.json<unknown>(fetchOptsSerializer(...args));
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/return-await
           return {ok: true, response: returnType.fromJson(res.body), status: res.status} as ReturnType<Api[keyof Api]>;
         } else {
           // We need to avoid parsing the response as the servers might just
@@ -75,6 +75,7 @@ export function generateGenericJsonClient<
           // empty json response. We return the status code.
           const res = await fetchFn.request(fetchOptsSerializer(...args));
 
+          // eslint-disable-next-line @typescript-eslint/return-await
           return {ok: true, response: undefined, status: res.status} as ReturnType<Api[keyof Api]>;
         }
       } catch (err) {

--- a/packages/api/test/unit/client/httpClient.test.ts
+++ b/packages/api/test/unit/client/httpClient.test.ts
@@ -5,6 +5,8 @@ import {ErrorAborted, TimeoutError} from "@lodestar/utils";
 import {HttpClient, HttpError} from "../../../src/utils/client/index.js";
 import {HttpStatusCode} from "../../../src/utils/client/httpStatusCode.js";
 
+/* eslint-disable @typescript-eslint/return-await */
+
 type User = {
   id?: number;
   name: string;

--- a/packages/state-transition/test/utils/testFileCache.ts
+++ b/packages/state-transition/test/utils/testFileCache.ts
@@ -113,7 +113,7 @@ async function tryEach<T>(promises: (() => Promise<T>)[]): Promise<T> {
 
   for (let i = 0; i < promises.length; i++) {
     try {
-      return promises[i]();
+      return await promises[i]();
     } catch (e) {
       errors.push(e as Error);
     }


### PR DESCRIPTION
**Motivation**

Current eslint rules do not ensure that promises are awaited within a try-catch. This can lead to unhandled promise rejections and unexpected behavior if missed.

**Description**

https://github.com/ChainSafe/lodestar/pull/5117 already added a similar rule but [no-return-await](https://eslint.org/docs/latest/rules/no-return-await) does not consider return await within try-catch. [return-await](https://typescript-eslint.io/rules/return-await/) supersedes this rule and adds support for optionally requiring return await in certain cases by default it will be required [in-try-catch](https://typescript-eslint.io/rules/return-await/#in-try-catch).

- Add eslint rule to ensure await in try-catch
- Fix missing await inside try-catch
- Disable return-await false positives

**Related**

- https://github.com/typescript-eslint/typescript-eslint/issues/994