### PR TITLE
chore: update rimraf imports to fix eslint warnings

### DIFF
--- a/packages/beacon-node/test/unit/db/api/repositories/blockArchive.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repositories/blockArchive.test.ts
@@ -1,5 +1,5 @@
 import {expect} from "chai";
-import rimraf from "rimraf";
+import {rimraf} from "rimraf";
 import sinon from "sinon";
 import {ssz} from "@lodestar/types";
 import {config} from "@lodestar/config/default";

--- a/packages/cli/test/e2e/importFromFsDirect.test.ts
+++ b/packages/cli/test/e2e/importFromFsDirect.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import rimraf from "rimraf";
+import {rimraf} from "rimraf";
 import {testFilesDir} from "../utils.js";
 import {describeCliTest} from "../utils/childprocRunner.js";
 import {getAfterEachCallbacks} from "../utils/runUtils.js";

--- a/packages/cli/test/e2e/importFromFsPreStep.test.ts
+++ b/packages/cli/test/e2e/importFromFsPreStep.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import rimraf from "rimraf";
+import {rimraf} from "rimraf";
 import {expect} from "chai";
 import {testFilesDir} from "../utils.js";
 import {describeCliTest, execCli} from "../utils/childprocRunner.js";

--- a/packages/cli/test/e2e/importKeystoresFromApi.test.ts
+++ b/packages/cli/test/e2e/importKeystoresFromApi.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import rimraf from "rimraf";
+import {rimraf} from "rimraf";
 import {expect} from "chai";
 import {DeletionStatus, getClient, ImportStatus} from "@lodestar/api/keymanager";
 import {config} from "@lodestar/config/default";

--- a/packages/cli/test/e2e/importRemoteKeysFromApi.test.ts
+++ b/packages/cli/test/e2e/importRemoteKeysFromApi.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import rimraf from "rimraf";
+import {rimraf} from "rimraf";
 import {expect} from "chai";
 import {Api, DeleteRemoteKeyStatus, getClient, ImportRemoteKeyStatus} from "@lodestar/api/keymanager";
 import {config} from "@lodestar/config/default";

--- a/packages/cli/test/e2e/propserConfigfromKeymanager.test.ts
+++ b/packages/cli/test/e2e/propserConfigfromKeymanager.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import rimraf from "rimraf";
+import {rimraf} from "rimraf";
 import {Interchange} from "@lodestar/validator";
 import {ApiError} from "@lodestar/api";
 import {testFilesDir} from "../utils.js";

--- a/packages/cli/test/unit/validator/decryptKeystoreDefinitions.test.ts
+++ b/packages/cli/test/unit/validator/decryptKeystoreDefinitions.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import rimraf from "rimraf";
+import {rimraf} from "rimraf";
 import {expect} from "chai";
 import {cachedSeckeysHex} from "../../utils/cachedKeys.js";
 import {getKeystoresStr} from "../../utils/keystores.js";

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import stream from "node:stream";
 import {promisify} from "node:util";
-import rimraf from "rimraf";
+import {rimraf} from "rimraf";
 import axios from "axios";
 import tar from "tar";
 import retry from "async-retry";


### PR DESCRIPTION
**Motivation**

Current rimraf imports are inconsistent and cause a lot of noisy eslint warnings

```
2:8  warning  Using exported name 'rimraf' as identifier for default export  import/no-named-as-default
16:3  warning  Unexpected use of Mocha `before` hook outside of a test suite  mocha/no-top-level-hooks
```

**Description**

Update rimraf imports to be consistent and fix eslint warnings