### PR TITLE
chore: namespace getExpectedWithdrawals benchmark

### DIFF
--- a/packages/state-transition/test/perf/block/processWithdrawals.test.ts
+++ b/packages/state-transition/test/perf/block/processWithdrawals.test.ts
@@ -43,18 +43,18 @@ describe("getExpectedWithdrawals", () => {
 
   for (const opts of testCases) {
     const caseID = [
-      `eb ${opts.excessBalance}`,
-      `eth1 ${opts.eth1Credentials}`,
-      `we ${opts.withdrawable}`,
-      `wn ${opts.withdrawn}`,
+      `eb:${opts.excessBalance}`,
+      `eth1:${opts.eth1Credentials}`,
+      `we:${opts.withdrawable}`,
+      `wn:${opts.withdrawn}`,
       opts.cache ? null : "nocache",
-      `- smpl ${opts.sampled}`,
+      `smpl:${opts.sampled}`,
     ]
       .filter((str) => str)
-      .join(" ");
+      .join(",");
 
     itBench<CachedBeaconStateCapella, CachedBeaconStateCapella>({
-      id: `vc - ${vc} ${caseID}`,
+      id: `getExpectedWithdrawals ${vc} ${caseID}`,
       yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
       before: () => {
         const state = getExpectedWithdrawalsTestData(vc, opts);

--- a/packages/state-transition/test/unit/block/processWithdrawals.test.ts
+++ b/packages/state-transition/test/unit/block/processWithdrawals.test.ts
@@ -25,18 +25,18 @@ describe("getExpectedWithdrawals", () => {
 
   for (const opts of testCases) {
     const caseID = [
-      `eb ${opts.excessBalance}`,
-      `eth1 ${opts.eth1Credentials}`,
-      `we ${opts.withdrawable}`,
-      `wn ${opts.withdrawn}`,
+      `eb:${opts.excessBalance}`,
+      `eth1:${opts.eth1Credentials}`,
+      `we:${opts.withdrawable}`,
+      `wn:${opts.withdrawn}`,
     ]
       .filter((str) => str)
-      .join(" ");
+      .join(",");
 
     // Clone true to drop cache
     const state = beforeValue(() => getExpectedWithdrawalsTestData(vc, opts).clone(true));
 
-    it(`vc - ${vc} ${caseID}`, () => {
+    it(`getExpectedWithdrawals ${vc} ${caseID}`, () => {
       const {sampledValidators, withdrawals} = getExpectedWithdrawals(state.value);
       expect(sampledValidators).equals(opts.sampled, "Wrong sampledValidators");
       expect(withdrawals.length).equals(opts.withdrawals, "Wrong withdrawals");


### PR DESCRIPTION
**Motivation**

it blocks of benchmarks must be fully qualified. This example below does not have enough information in the name

```
    ✔ vc - 250000 eb 1 eth1 1 we 0 wn 0 - smpl 15                         20304.57 ops/s    49.25000 us/op   x6.472       1246 runs   7.16 s
    ✔ vc - 250000 eb 0.95 eth1 0.1 we 0.05 wn 0 - smpl 219                3745.837 ops/s    266.9630 us/op   x9.680       1393 runs   7.43 s
    ✔ vc - 250000 eb 0.95 eth1 0.3 we 0.05 wn 0 - smpl 42                 12449.58 ops/s    80.32400 us/op   x8.091       2167 runs   7.81 s
    ✔ vc - 250000 eb 0.95 eth1 0.7 we 0.05 wn 0 - smpl 18                 21150.14 ops/s    47.28100 us/op   x5.419       1175 runs   6.69 s
    ✔ vc - 250000 eb 0.1 eth1 0.1 we 0 wn 0 - smpl 1020                   547.5639 ops/s    1.826271 ms/op  x18.489        275 runs   5.87 s
    ✔ vc - 250000 eb 0.03 eth1 0.03 we 0 wn 0 - smpl 11777                72.51992 ops/s    13.78932 ms/op  x11.016         72 runs   5.81 s
    ✔ vc - 250000 eb 0.01 eth1 0.01 we 0 wn 0 - smpl 16384                45.21641 ops/s    22.11587 ms/op  x24.413         16 runs   5.15 s
    ✔ vc - 250000 eb 0 eth1 0 we 0 wn 0 - smpl 16384                      52.17905 ops/s    19.16478 ms/op  x13.449        125 runs   7.17 s
    ✔ vc - 250000 eb 0 eth1 0 we 0 wn 0 nocache - smpl 16384              26.93323 ops/s    37.12886 ms/op  x15.540         31 runs   5.53 s
    ✔ vc - 250000 eb 0 eth1 1 we 0 wn 0 - smpl 16384                      42.02287 ops/s    23.79657 ms/op  x12.279         48 runs   5.88 s
    ✔ vc - 250000 eb 0 eth1 1 we 0 wn 0 nocache - smpl 16384              20.92901 ops/s    47.78057 ms/op  x11.428         29 runs   6.38 s
```

**Description**


Prefix getExpectedWithdrawals benchmarks with `getExpectedWithdrawals`
