### PR TITLE
fix: ensure benchmark workflow is not cancelled on stable/unstable consecutive pushes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,8 +3,8 @@ name: Benchmark
 # Actions access a common cache entry and may corrupt it.
 concurrency:
   # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
-  # if push, default to github.ref so retries of the same commit do not overwrite each other
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # if push, default to github.run_id so retries of the same commit do not overwrite each other
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
always run benchmark workflow to compleition on stable unstable push