### PR TITLE
refactor(network): move unclean disconnect log to debug

### DIFF
--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -628,7 +628,7 @@ export class PeerManager {
     try {
       await this.libp2p.hangUp(peer);
     } catch (e) {
-      this.logger.warn("Unclean disconnect", {peer: prettyPrintPeerId(peer)}, e as Error);
+      this.logger.debug("Unclean disconnect", {peer: prettyPrintPeerId(peer)}, e as Error);
     }
   }
 


### PR DESCRIPTION
**Motivation**

https://github.com/ChainSafe/lodestar/issues/5359#issuecomment-1519129570

**Description**

Move unclean disconnect log to from `warn` to `debug`
