### PR TITLE
fix: deduplicate notifier log

### DIFF
--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -150,10 +150,10 @@ function timeToNextHalfSlot(config: BeaconConfig, chain: IBeaconChain, isFirstTi
   const msFromGenesis = Date.now() - chain.genesisTime * 1000;
   const msToNextSlot = msPerSlot - (msFromGenesis % msPerSlot);
   if (isFirstTime) {
-    // at the 1st time we may miss the next slot
+    // at the 1st time we may miss middle of the current clock slot
     return msToNextSlot > msPerHalfSlot ? msToNextSlot - msPerHalfSlot : msToNextSlot + msPerHalfSlot;
   } else {
-    // after the 1st time always wait until half of next clock slot
+    // after the 1st time always wait until middle of next clock slot
     return msToNextSlot + msPerHalfSlot;
   }
 }


### PR DESCRIPTION
**Motivation**

Duplicate Synced log per slot, almost at the same time
```
May-23 21:36:28.999[]                 info: Synced - slot: 6504480 - head: 0xbf13…d6c8 - exec-block: valid(17324638 0x87bf…) - finalized: 0xfd48…a00d:203263 - peers: 60
May-23 21:36:29.000[]                 info: Synced - slot: 6504480 - head: 0xbf13…d6c8 - exec-block: valid(17324638 0x87bf…) - finalized: 0xfd48…a00d:203263 - peers: 60
```

**Description**

- In `timeToNextHalfSlot` function, it checks which middle slot of current or next clock slot is closer and wait until that time. It happens that it does not pass middle of the current clock slot, the `runNodeNotifier` runs so fast and it still does not pass middle of the current clock slot so it runs again
- The fix is to always wait for middle of next clock slot, except for the 1st time 

Closes #5532
