### PR TITLE
feat: add metrics to AsyncIterableBridgeCaller

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -104,6 +104,13 @@ export function createLodestarMetrics(
       }),
     },
 
+    networkWorkerHandler: {
+      reqRespBridgeReqCallerPending: register.gauge({
+        name: "lodestar_network_worker_handler_reqresp_bridge_req_caller_pending_count",
+        help: "Current count of pending items in reqRespBridgeReqCaller data structure",
+      }),
+    },
+
     regenQueue: {
       length: register.gauge({
         name: "lodestar_regen_queue_length",

--- a/packages/beacon-node/src/network/core/metrics.ts
+++ b/packages/beacon-node/src/network/core/metrics.ts
@@ -304,3 +304,13 @@ export function createNetworkCoreMetrics(register: RegistryMetricCreator) {
     },
   };
 }
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function getNetworkCoreWorkerMetrics(register: RegistryMetricCreator) {
+  return {
+    reqRespBridgeRespCallerPending: register.gauge({
+      name: "lodestar_network_worker_reqresp_bridge_caller_pending_count",
+      help: "Current count of pending elements in respBridgeCaller",
+    }),
+  };
+}

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -11,6 +11,7 @@ import {BeaconConfig, chainConfigToJson} from "@lodestar/config";
 import {LoggerNode} from "@lodestar/logger/node";
 import {AsyncIterableBridgeCaller, AsyncIterableBridgeHandler} from "../../util/asyncIterableToEvents.js";
 import {wireEventsOnMainThread} from "../../util/workerEvents.js";
+import {Metrics} from "../../metrics/index.js";
 import {IncomingRequestArgs, OutgoingRequestArgs, GetReqRespHandlerFn} from "../reqresp/types.js";
 import {NetworkEventBus, NetworkEventData, networkEventDirection} from "../events.js";
 import {CommitteeSubscription} from "../subnets/interface.js";
@@ -28,7 +29,7 @@ import {
 } from "./events.js";
 
 export type WorkerNetworkCoreOpts = NetworkOptions & {
-  metrics: boolean;
+  metricsEnabled: boolean;
   peerStoreDir?: string;
   activeValidatorCount: number;
   genesisTime: number;
@@ -41,6 +42,7 @@ export type WorkerNetworkCoreInitModules = {
   logger: LoggerNode;
   peerId: PeerId;
   events: NetworkEventBus;
+  metrics: Metrics | null;
   getReqRespHandler: GetReqRespHandlerFn;
 };
 
@@ -78,11 +80,18 @@ export class WorkerNetworkCore implements INetworkCore {
       modules.worker as unknown as worker_threads.Worker,
       reqRespBridgeEventDirection
     );
+
+    const {metrics} = modules;
+    if (metrics) {
+      metrics.networkWorkerHandler.reqRespBridgeReqCallerPending.addCollect(() => {
+        metrics.networkWorkerHandler.reqRespBridgeReqCallerPending.set(this.reqRespBridgeReqCaller.pendingCount);
+      });
+    }
   }
 
   static async init(modules: WorkerNetworkCoreInitModules): Promise<WorkerNetworkCore> {
     const {opts, config, peerId} = modules;
-    const {genesisTime, peerStoreDir, activeValidatorCount, localMultiaddrs, metrics, initialStatus} = opts;
+    const {genesisTime, peerStoreDir, activeValidatorCount, localMultiaddrs, metricsEnabled, initialStatus} = opts;
 
     const workerData: NetworkWorkerData = {
       opts,
@@ -90,7 +99,7 @@ export class WorkerNetworkCore implements INetworkCore {
       genesisValidatorsRoot: config.genesisValidatorsRoot,
       peerIdProto: exportToProtobuf(peerId),
       localMultiaddrs,
-      metrics,
+      metricsEnabled,
       peerStoreDir,
       genesisTime,
       initialStatus,

--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -76,7 +76,7 @@ export type NetworkWorkerData = {
   initialStatus: phase0.Status;
   peerIdProto: Uint8Array;
   localMultiaddrs: string[];
-  metrics: boolean;
+  metricsEnabled: boolean;
   peerStoreDir?: string;
   loggerOpts: LoggerNodeOpts;
 };

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -136,7 +136,7 @@ export class Network implements INetwork {
           opts: {
             ...opts,
             peerStoreDir,
-            metrics: Boolean(metrics),
+            metricsEnabled: Boolean(metrics),
             activeValidatorCount,
             genesisTime: chain.genesisTime,
             initialStatus,
@@ -145,6 +145,7 @@ export class Network implements INetwork {
           peerId,
           logger,
           events,
+          metrics,
           getReqRespHandler,
         })
       : await NetworkCore.init({

--- a/packages/beacon-node/src/util/asyncIterableToEvents.ts
+++ b/packages/beacon-node/src/util/asyncIterableToEvents.ts
@@ -34,12 +34,15 @@ type PendingItem<T> = {
 export class AsyncIterableBridgeCaller<Args, Item> {
   private nextRequestId = 0;
 
-  // TODO: Track count of pending with metrics to ensure no leaks
   // TODO: Consider expiring the requests after no reply for long enough, t
   private readonly pending = new Map<number, PendingItem<Item>>();
 
   constructor(private readonly events: Pick<AsyncIterableEventBus<Args, Item>, "onResponse" | "emitRequest">) {
     events.onResponse(this.onResponse.bind(this));
+  }
+
+  get pendingCount(): number {
+    return this.pending.size;
   }
 
   getAsyncIterable(callArgs: Args): AsyncIterable<Item> {


### PR DESCRIPTION
**Motivation**

- Cover last pending item from https://github.com/ChainSafe/lodestar/pull/5229

> Add metrics to track async iterable bridge Maps

To ensure this data structures don't leak

**Description**

Add metrics to AsyncIterableBridgeCaller pending item count
