### PR TITLE
refactor: rename EpochContext and EpochProcess

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -5,7 +5,7 @@ import {
   CachedBeaconStateAllForks,
   BeaconStateAllForks,
   createCachedBeaconState,
-  createEmptyEpochContextImmutableData,
+  createEmptyEpochCacheImmutableData,
   PubkeyIndexMap,
   ExecutionPayloadStatus,
   DataAvailableStatus,
@@ -237,7 +237,7 @@ async function getNearestArchivedState(
   const state = (await states[Symbol.asyncIterator]().next()).value as BeaconStateAllForks;
   // TODO - PENDING: Don't create new immutable caches here
   // see https://github.com/ChainSafe/lodestar/issues/3683
-  return createCachedBeaconState(state, createEmptyEpochContextImmutableData(config, state));
+  return createCachedBeaconState(state, createEmptyEpochCacheImmutableData(config, state));
 }
 
 async function getFinalizedState(

--- a/packages/beacon-node/src/chain/genesis/genesis.ts
+++ b/packages/beacon-node/src/chain/genesis/genesis.ts
@@ -11,7 +11,7 @@ import {
   CachedBeaconStateAllForks,
   createCachedBeaconState,
   BeaconStateAllForks,
-  createEmptyEpochContextImmutableData,
+  createEmptyEpochCacheImmutableData,
   getActiveValidatorIndices,
 } from "@lodestar/state-transition";
 import {Logger} from "@lodestar/utils";
@@ -85,8 +85,8 @@ export class GenesisBuilder implements IGenesisBuilder {
       this.fromBlock = this.eth1Provider.deployBlock;
     }
 
-    // TODO - PENDING: Ensure EpochContextImmutableData is created only once
-    this.state = createCachedBeaconState(stateView, createEmptyEpochContextImmutableData(config, stateView));
+    // TODO - PENDING: Ensure EpochCacheImmutableData is created only once
+    this.state = createCachedBeaconState(stateView, createEmptyEpochCacheImmutableData(config, stateView));
     this.config = this.state.config;
     this.activatedValidatorCount = getActiveValidatorIndices(stateView, GENESIS_EPOCH).length;
   }

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -34,7 +34,7 @@ export type BlockProcessOpts = {
    */
   safeSlotsToImportOptimistically: number;
   /**
-   * Assert progressive balances the same to EpochProcess
+   * Assert progressive balances the same to EpochTransitionCache
    */
   assertCorrectProgressiveBalances?: boolean;
   /** Used for fork_choice spec tests */

--- a/packages/beacon-node/src/node/utils/interop/state.ts
+++ b/packages/beacon-node/src/node/utils/interop/state.ts
@@ -1,7 +1,7 @@
 import {Bytes32, phase0, ssz, TimeSeconds} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
 import {BeaconStateAllForks, initializeBeaconStateFromEth1} from "@lodestar/state-transition";
-import {createEmptyEpochContextImmutableData} from "@lodestar/state-transition";
+import {createEmptyEpochCacheImmutableData} from "@lodestar/state-transition";
 import {ForkName, GENESIS_SLOT} from "@lodestar/params";
 
 import {DepositTree} from "../../../db/repositories/depositDataRoot.js";
@@ -45,7 +45,7 @@ export function getInteropState(
   latestPayloadHeader.baseFeePerGas = GENESIS_BASE_FEE_PER_GAS;
   const state = initializeBeaconStateFromEth1(
     config,
-    createEmptyEpochContextImmutableData(config, {genesisValidatorsRoot: Buffer.alloc(32, 0)}),
+    createEmptyEpochCacheImmutableData(config, {genesisValidatorsRoot: Buffer.alloc(32, 0)}),
     eth1BlockHash,
     eth1Timestamp,
     deposits,

--- a/packages/beacon-node/test/spec/presets/epoch_processing.ts
+++ b/packages/beacon-node/test/spec/presets/epoch_processing.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 import {
   CachedBeaconStateAllForks,
-  EpochProcess,
+  EpochTransitionCache,
   BeaconStateAllForks,
   beforeProcessEpoch,
 } from "@lodestar/state-transition";
@@ -13,31 +13,31 @@ import {getConfig} from "../../utils/config.js";
 import {TestRunnerFn} from "../utils/types.js";
 import {assertCorrectProgressiveBalances} from "../config.js";
 
-export type EpochProcessFn = (state: CachedBeaconStateAllForks, epochProcess: EpochProcess) => void;
+export type EpochTransitionFn = (state: CachedBeaconStateAllForks, epochTransitionCache: EpochTransitionCache) => void;
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
-const epochProcessFns: Record<string, EpochProcessFn> = {
+const epochTransitionFns: Record<string, EpochTransitionFn> = {
   effective_balance_updates: epochFns.processEffectiveBalanceUpdates,
   eth1_data_reset: epochFns.processEth1DataReset,
   historical_roots_update: epochFns.processHistoricalRootsUpdate,
-  inactivity_updates: epochFns.processInactivityUpdates as EpochProcessFn,
+  inactivity_updates: epochFns.processInactivityUpdates as EpochTransitionFn,
   justification_and_finalization: epochFns.processJustificationAndFinalization,
-  participation_flag_updates: epochFns.processParticipationFlagUpdates as EpochProcessFn,
-  participation_record_updates: epochFns.processParticipationRecordUpdates as EpochProcessFn,
+  participation_flag_updates: epochFns.processParticipationFlagUpdates as EpochTransitionFn,
+  participation_record_updates: epochFns.processParticipationRecordUpdates as EpochTransitionFn,
   randao_mixes_reset: epochFns.processRandaoMixesReset,
   registry_updates: epochFns.processRegistryUpdates,
   rewards_and_penalties: epochFns.processRewardsAndPenalties,
   slashings: epochFns.processSlashings,
   slashings_reset: epochFns.processSlashingsReset,
-  sync_committee_updates: epochFns.processSyncCommitteeUpdates as EpochProcessFn,
-  historical_summaries_update: epochFns.processHistoricalSummariesUpdate as EpochProcessFn,
+  sync_committee_updates: epochFns.processSyncCommitteeUpdates as EpochTransitionFn,
+  historical_summaries_update: epochFns.processHistoricalSummariesUpdate as EpochTransitionFn,
 };
 
 /**
  * https://github.com/ethereum/consensus-specs/blob/dev/tests/formats/epoch_processing/README.md
  */
-type EpochProcessingTestCase = {
+type EpochTransitionCacheingTestCase = {
   meta?: {bls_setting?: bigint};
   pre: BeaconStateAllForks;
   post: BeaconStateAllForks;
@@ -45,16 +45,16 @@ type EpochProcessingTestCase = {
 
 /**
  * @param fork
- * @param epochProcessFns Describe with which function to run each directory of tests
+ * @param epochTransitionFns Describe with which function to run each directory of tests
  */
 export const epochProcessing =
-  (skipTestNames?: string[]): TestRunnerFn<EpochProcessingTestCase, BeaconStateAllForks> =>
+  (skipTestNames?: string[]): TestRunnerFn<EpochTransitionCacheingTestCase, BeaconStateAllForks> =>
   (fork, testName) => {
     const config = getConfig(fork);
 
-    const epochProcessFn = epochProcessFns[testName];
-    if (epochProcessFn === undefined) {
-      throw Error(`No epochProcessFn for ${testName}`);
+    const epochTransitionFn = epochTransitionFns[testName];
+    if (epochTransitionFn === undefined) {
+      throw Error(`No epochTransitionFn for ${testName}`);
     }
 
     return {
@@ -62,14 +62,14 @@ export const epochProcessing =
         const stateTB = testcase.pre.clone();
         const state = createCachedBeaconStateTest(stateTB, config);
 
-        const epochProcess = beforeProcessEpoch(state, {assertCorrectProgressiveBalances});
+        const epochTransitionCache = beforeProcessEpoch(state, {assertCorrectProgressiveBalances});
 
         if (testcase.post === undefined) {
           // If post.ssz_snappy is not value, the sub-transition processing is aborted
           // https://github.com/ethereum/consensus-specs/blob/dev/tests/formats/epoch_processing/README.md#postssz_snappy
-          expect(() => epochProcessFn(state, epochProcess)).to.throw();
+          expect(() => epochTransitionFn(state, epochTransitionCache)).to.throw();
         } else {
-          epochProcessFn(state, epochProcess);
+          epochTransitionFn(state, epochTransitionCache);
         }
 
         state.commit();

--- a/packages/beacon-node/test/spec/presets/genesis.ts
+++ b/packages/beacon-node/test/spec/presets/genesis.ts
@@ -3,7 +3,7 @@ import {phase0, Root, ssz, TimeSeconds, allForks, deneb} from "@lodestar/types";
 import {InputType} from "@lodestar/spec-test-util";
 import {
   BeaconStateAllForks,
-  createEmptyEpochContextImmutableData,
+  createEmptyEpochCacheImmutableData,
   initializeBeaconStateFromEth1,
   isValidGenesisState,
 } from "@lodestar/state-transition";
@@ -36,7 +36,7 @@ const genesisInitialization: TestRunnerFn<GenesisInitSpecTest, BeaconStateAllFor
       }
 
       const config = getConfig(fork);
-      const immutableData = createEmptyEpochContextImmutableData(config, {
+      const immutableData = createEmptyEpochCacheImmutableData(config, {
         // TODO: Should the genesisValidatorsRoot be random here?
         genesisValidatorsRoot: Buffer.alloc(32, 0),
       });

--- a/packages/beacon-node/test/spec/presets/rewards.ts
+++ b/packages/beacon-node/test/spec/presets/rewards.ts
@@ -18,7 +18,7 @@ export const rewards: TestRunnerFn<RewardTestCase, Deltas> = (fork) => {
     testFunction: (testcase) => {
       const config = getConfig(fork);
       const wrappedState = createCachedBeaconStateTest(testcase.pre, config);
-      const epochProcess = beforeProcessEpoch(wrappedState, {assertCorrectProgressiveBalances});
+      const epochTransitionCache = beforeProcessEpoch(wrappedState, {assertCorrectProgressiveBalances});
 
       // To debug this test and get granular results you can tweak inputs to get more granular results
       //
@@ -32,7 +32,7 @@ export const rewards: TestRunnerFn<RewardTestCase, Deltas> = (fork) => {
       //   + set all inactivityScores to zero
       // - To get inactivity_penalty_deltas set TIMELY_HEAD_FLAG_INDEX | TIMELY_SOURCE_FLAG_INDEX to false
       //   + set PARTICIPATION_FLAG_WEIGHTS[TIMELY_TARGET_FLAG_INDEX] to zero
-      return getRewardsAndPenalties(wrappedState, epochProcess);
+      return getRewardsAndPenalties(wrappedState, epochTransitionCache);
     },
     options: {
       inputTypes: inputTypeSszTreeViewDU,

--- a/packages/beacon-node/test/utils/cachedBeaconState.ts
+++ b/packages/beacon-node/test/utils/cachedBeaconState.ts
@@ -2,7 +2,7 @@ import {
   BeaconStateAllForks,
   BeaconStateCache,
   createCachedBeaconState,
-  createEmptyEpochContextImmutableData,
+  createEmptyEpochCacheImmutableData,
 } from "@lodestar/state-transition";
 import {ChainForkConfig} from "@lodestar/config";
 
@@ -10,5 +10,5 @@ export function createCachedBeaconStateTest<T extends BeaconStateAllForks>(
   state: T,
   chainConfig: ChainForkConfig
 ): T & BeaconStateCache {
-  return createCachedBeaconState<T>(state, createEmptyEpochContextImmutableData(chainConfig, state));
+  return createCachedBeaconState<T>(state, createEmptyEpochCacheImmutableData(chainConfig, state));
 }

--- a/packages/beacon-node/test/utils/node/simTest.ts
+++ b/packages/beacon-node/test/utils/node/simTest.ts
@@ -44,13 +44,14 @@ export function simTestInfoTracker(bn: BeaconNode, logger: Logger): () => void {
   function logParticipation(state: CachedBeaconStateAllForks): void {
     // Compute participation (takes 5ms with 64 validators)
     // Need a CachedBeaconStateAllForks where (state.slot + 1) % SLOTS_EPOCH == 0
-    const epochProcess = beforeProcessEpoch(state);
+    const epochTransitionCache = beforeProcessEpoch(state);
     const epoch = computeEpochAtSlot(state.slot);
 
     const prevParticipation =
-      epochProcess.prevEpochUnslashedStake.targetStakeByIncrement / epochProcess.totalActiveStakeByIncrement;
+      epochTransitionCache.prevEpochUnslashedStake.targetStakeByIncrement /
+      epochTransitionCache.totalActiveStakeByIncrement;
     const currParticipation =
-      epochProcess.currEpochUnslashedTargetStakeByIncrement / epochProcess.totalActiveStakeByIncrement;
+      epochTransitionCache.currEpochUnslashedTargetStakeByIncrement / epochTransitionCache.totalActiveStakeByIncrement;
     prevParticipationPerEpoch.set(epoch - 1, prevParticipation);
     currParticipationPerEpoch.set(epoch, currParticipation);
     logger.info("> Participation", {

--- a/packages/state-transition/src/cache/stateCache.ts
+++ b/packages/state-transition/src/cache/stateCache.ts
@@ -1,5 +1,5 @@
 import {BeaconConfig} from "@lodestar/config";
-import {EpochContext, EpochContextImmutableData, EpochContextOpts} from "./epochContext.js";
+import {EpochCache, EpochCacheImmutableData, EpochCacheOpts} from "./epochCache.js";
 import {
   BeaconStateAllForks,
   BeaconStateExecutions,
@@ -12,7 +12,7 @@ import {
 
 export type BeaconStateCache = {
   config: BeaconConfig;
-  epochCtx: EpochContext;
+  epochCtx: EpochCache;
   /** Count of clones created from this BeaconStateCache instance. readonly to prevent accidental usage downstream */
   readonly clonedCount: number;
   readonly clonedCountWithTransferCache: number;
@@ -130,16 +130,16 @@ export type CachedBeaconStateDeneb = CachedBeaconState<BeaconStateDeneb>;
 export type CachedBeaconStateAllForks = CachedBeaconState<BeaconStateAllForks>;
 export type CachedBeaconStateExecutions = CachedBeaconState<BeaconStateExecutions>;
 /**
- * Create CachedBeaconState computing a new EpochContext instance
+ * Create CachedBeaconState computing a new EpochCache instance
  */
 export function createCachedBeaconState<T extends BeaconStateAllForks>(
   state: T,
-  immutableData: EpochContextImmutableData,
-  opts?: EpochContextOpts
+  immutableData: EpochCacheImmutableData,
+  opts?: EpochCacheOpts
 ): T & BeaconStateCache {
   return getCachedBeaconState(state, {
     config: immutableData.config,
-    epochCtx: EpochContext.createFromState(state, immutableData, opts),
+    epochCtx: EpochCache.createFromState(state, immutableData, opts),
     clonedCount: 0,
     clonedCountWithTransferCache: 0,
     createdWithTransferCache: false,

--- a/packages/state-transition/src/epoch/computeUnrealizedCheckpoints.ts
+++ b/packages/state-transition/src/epoch/computeUnrealizedCheckpoints.ts
@@ -1,7 +1,7 @@
 import {ForkSeq, GENESIS_EPOCH} from "@lodestar/params";
 import {phase0} from "@lodestar/types";
 import {CachedBeaconStateAllForks} from "../types.js";
-import {beforeProcessEpoch} from "../cache/epochProcess.js";
+import {beforeProcessEpoch} from "../cache/epochTransitionCache.js";
 import {
   weighJustificationAndFinalization,
   processJustificationAndFinalization,
@@ -10,7 +10,7 @@ import {
 /**
  * Compute on-the-fly justified / finalized checkpoints.
  *   - For phase0, we need to create the cache through beforeProcessEpoch
- *   - For other forks, use the progressive balances inside EpochContext
+ *   - For other forks, use the progressive balances inside EpochCache
  */
 export function computeUnrealizedCheckpoints(state: CachedBeaconStateAllForks): {
   justifiedCheckpoint: phase0.Checkpoint;
@@ -22,11 +22,11 @@ export function computeUnrealizedCheckpoints(state: CachedBeaconStateAllForks): 
   if (state.config.getForkSeq(state.slot) === ForkSeq.phase0) {
     // Clone state to mutate below         true = do not transfer cache
     stateRealizedCheckpoints = state.clone(true);
-    const epochProcess = beforeProcessEpoch(stateRealizedCheckpoints);
-    processJustificationAndFinalization(stateRealizedCheckpoints, epochProcess);
+    const epochTransitionCache = beforeProcessEpoch(stateRealizedCheckpoints);
+    processJustificationAndFinalization(stateRealizedCheckpoints, epochTransitionCache);
   }
 
-  // For other forks, use the progressive balances inside EpochContext
+  // For other forks, use the progressive balances inside EpochCache
   else {
     // same logic to processJustificationAndFinalization
     if (state.epochCtx.epoch <= GENESIS_EPOCH + 1) {

--- a/packages/state-transition/src/epoch/getRewardsAndPenalties.ts
+++ b/packages/state-transition/src/epoch/getRewardsAndPenalties.ts
@@ -9,7 +9,7 @@ import {
   WEIGHT_DENOMINATOR,
   ForkSeq,
 } from "@lodestar/params";
-import {CachedBeaconStateAltair, EpochProcess} from "../types.js";
+import {CachedBeaconStateAltair, EpochTransitionCache} from "../types.js";
 import {
   FLAG_ELIGIBLE_ATTESTER,
   FLAG_PREV_HEAD_ATTESTER_UNSLASHED,
@@ -43,11 +43,11 @@ type RewardPenaltyItem = {
  */
 export function getRewardsAndPenaltiesAltair(
   state: CachedBeaconStateAltair,
-  process: EpochProcess
+  cache: EpochTransitionCache
 ): [number[], number[]] {
   // TODO: Is there a cheaper way to measure length that going to `state.validators`?
   const validatorCount = state.validators.length;
-  const activeIncrements = process.totalActiveStakeByIncrement;
+  const activeIncrements = cache.totalActiveStakeByIncrement;
   const rewards = newZeroedArray(validatorCount);
   const penalties = newZeroedArray(validatorCount);
 
@@ -62,7 +62,7 @@ export function getRewardsAndPenaltiesAltair(
     fork === ForkSeq.altair ? INACTIVITY_PENALTY_QUOTIENT_ALTAIR : INACTIVITY_PENALTY_QUOTIENT_BELLATRIX;
   const penaltyDenominator = config.INACTIVITY_SCORE_BIAS * inactivityPenalityMultiplier;
 
-  const {statuses} = process;
+  const {statuses} = cache;
   for (let i = 0; i < statuses.length; i++) {
     const status = statuses[i];
     if (!hasMarkers(status.flags, FLAG_ELIGIBLE_ATTESTER)) {
@@ -73,13 +73,13 @@ export function getRewardsAndPenaltiesAltair(
 
     let rewardPenaltyItem = rewardPenaltyItemCache.get(effectiveBalanceIncrement);
     if (!rewardPenaltyItem) {
-      const baseReward = effectiveBalanceIncrement * process.baseRewardPerIncrement;
+      const baseReward = effectiveBalanceIncrement * cache.baseRewardPerIncrement;
       const tsWeigh = PARTICIPATION_FLAG_WEIGHTS[TIMELY_SOURCE_FLAG_INDEX];
       const ttWeigh = PARTICIPATION_FLAG_WEIGHTS[TIMELY_TARGET_FLAG_INDEX];
       const thWeigh = PARTICIPATION_FLAG_WEIGHTS[TIMELY_HEAD_FLAG_INDEX];
-      const tsUnslashedParticipatingIncrements = process.prevEpochUnslashedStake.sourceStakeByIncrement;
-      const ttUnslashedParticipatingIncrements = process.prevEpochUnslashedStake.targetStakeByIncrement;
-      const thUnslashedParticipatingIncrements = process.prevEpochUnslashedStake.headStakeByIncrement;
+      const tsUnslashedParticipatingIncrements = cache.prevEpochUnslashedStake.sourceStakeByIncrement;
+      const ttUnslashedParticipatingIncrements = cache.prevEpochUnslashedStake.targetStakeByIncrement;
+      const thUnslashedParticipatingIncrements = cache.prevEpochUnslashedStake.headStakeByIncrement;
       const tsRewardNumerator = baseReward * tsWeigh * tsUnslashedParticipatingIncrements;
       const ttRewardNumerator = baseReward * ttWeigh * ttUnslashedParticipatingIncrements;
       const thRewardNumerator = baseReward * thWeigh * thUnslashedParticipatingIncrements;

--- a/packages/state-transition/src/epoch/index.ts
+++ b/packages/state-transition/src/epoch/index.ts
@@ -4,7 +4,7 @@ import {
   CachedBeaconStateCapella,
   CachedBeaconStateAltair,
   CachedBeaconStatePhase0,
-  EpochProcess,
+  EpochTransitionCache,
 } from "../types.js";
 import {processEffectiveBalanceUpdates} from "./processEffectiveBalanceUpdates.js";
 import {processEth1DataReset} from "./processEth1DataReset.js";
@@ -42,23 +42,23 @@ export {
 
 export {computeUnrealizedCheckpoints} from "./computeUnrealizedCheckpoints.js";
 
-export function processEpoch(fork: ForkSeq, state: CachedBeaconStateAllForks, epochProcess: EpochProcess): void {
-  processJustificationAndFinalization(state, epochProcess);
+export function processEpoch(fork: ForkSeq, state: CachedBeaconStateAllForks, cache: EpochTransitionCache): void {
+  processJustificationAndFinalization(state, cache);
   if (fork >= ForkSeq.altair) {
-    processInactivityUpdates(state as CachedBeaconStateAltair, epochProcess);
+    processInactivityUpdates(state as CachedBeaconStateAltair, cache);
   }
-  processRewardsAndPenalties(state, epochProcess);
-  processRegistryUpdates(state, epochProcess);
-  processSlashings(state, epochProcess);
-  processEth1DataReset(state, epochProcess);
-  processEffectiveBalanceUpdates(state, epochProcess);
-  processSlashingsReset(state, epochProcess);
-  processRandaoMixesReset(state, epochProcess);
+  processRewardsAndPenalties(state, cache);
+  processRegistryUpdates(state, cache);
+  processSlashings(state, cache);
+  processEth1DataReset(state, cache);
+  processEffectiveBalanceUpdates(state, cache);
+  processSlashingsReset(state, cache);
+  processRandaoMixesReset(state, cache);
 
   if (fork >= ForkSeq.capella) {
-    processHistoricalSummariesUpdate(state as CachedBeaconStateCapella, epochProcess);
+    processHistoricalSummariesUpdate(state as CachedBeaconStateCapella, cache);
   } else {
-    processHistoricalRootsUpdate(state, epochProcess);
+    processHistoricalRootsUpdate(state, cache);
   }
 
   if (fork === ForkSeq.phase0) {

--- a/packages/state-transition/src/epoch/processEth1DataReset.ts
+++ b/packages/state-transition/src/epoch/processEth1DataReset.ts
@@ -1,14 +1,14 @@
 import {EPOCHS_PER_ETH1_VOTING_PERIOD} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
-import {EpochProcess, CachedBeaconStateAllForks} from "../types.js";
+import {EpochTransitionCache, CachedBeaconStateAllForks} from "../types.js";
 
 /**
  * Reset eth1DataVotes tree every `EPOCHS_PER_ETH1_VOTING_PERIOD`.
  *
  * PERF: Almost no (constant) cost
  */
-export function processEth1DataReset(state: CachedBeaconStateAllForks, epochProcess: EpochProcess): void {
-  const nextEpoch = epochProcess.currentEpoch + 1;
+export function processEth1DataReset(state: CachedBeaconStateAllForks, cache: EpochTransitionCache): void {
+  const nextEpoch = cache.currentEpoch + 1;
 
   // reset eth1 data votes
   if (nextEpoch % EPOCHS_PER_ETH1_VOTING_PERIOD === 0) {

--- a/packages/state-transition/src/epoch/processHistoricalRootsUpdate.ts
+++ b/packages/state-transition/src/epoch/processHistoricalRootsUpdate.ts
@@ -1,15 +1,15 @@
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {intDiv} from "@lodestar/utils";
-import {EpochProcess, CachedBeaconStateAllForks} from "../types.js";
+import {EpochTransitionCache, CachedBeaconStateAllForks} from "../types.js";
 
 /**
  * Persist blockRoots and stateRoots to historicalRoots.
  *
  * PERF: Very low (constant) cost. Most of the HistoricalBatch should already be hashed.
  */
-export function processHistoricalRootsUpdate(state: CachedBeaconStateAllForks, epochProcess: EpochProcess): void {
-  const nextEpoch = epochProcess.currentEpoch + 1;
+export function processHistoricalRootsUpdate(state: CachedBeaconStateAllForks, cache: EpochTransitionCache): void {
+  const nextEpoch = cache.currentEpoch + 1;
 
   // set historical root accumulator
   if (nextEpoch % intDiv(SLOTS_PER_HISTORICAL_ROOT, SLOTS_PER_EPOCH) === 0) {

--- a/packages/state-transition/src/epoch/processHistoricalSummariesUpdate.ts
+++ b/packages/state-transition/src/epoch/processHistoricalSummariesUpdate.ts
@@ -1,15 +1,15 @@
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {intDiv} from "@lodestar/utils";
-import {EpochProcess, CachedBeaconStateCapella} from "../types.js";
+import {EpochTransitionCache, CachedBeaconStateCapella} from "../types.js";
 
 /**
  * Persist blockRoots and stateRoots to historicalSummaries.
  *
  * PERF: Very low (constant) cost. Most of the HistoricalSummaries should already be hashed.
  */
-export function processHistoricalSummariesUpdate(state: CachedBeaconStateCapella, epochProcess: EpochProcess): void {
-  const nextEpoch = epochProcess.currentEpoch + 1;
+export function processHistoricalSummariesUpdate(state: CachedBeaconStateCapella, cache: EpochTransitionCache): void {
+  const nextEpoch = cache.currentEpoch + 1;
 
   // set historical root accumulator
   if (nextEpoch % intDiv(SLOTS_PER_HISTORICAL_ROOT, SLOTS_PER_EPOCH) === 0) {

--- a/packages/state-transition/src/epoch/processInactivityUpdates.ts
+++ b/packages/state-transition/src/epoch/processInactivityUpdates.ts
@@ -1,5 +1,5 @@
 import {GENESIS_EPOCH} from "@lodestar/params";
-import {CachedBeaconStateAltair, EpochProcess} from "../types.js";
+import {CachedBeaconStateAltair, EpochTransitionCache} from "../types.js";
 import * as attesterStatusUtil from "../util/attesterStatus.js";
 import {isInInactivityLeak} from "../util/index.js";
 
@@ -17,14 +17,14 @@ import {isInInactivityLeak} from "../util/index.js";
  *
  * TODO: Compute from altair testnet inactivityScores updates on average
  */
-export function processInactivityUpdates(state: CachedBeaconStateAltair, epochProcess: EpochProcess): void {
+export function processInactivityUpdates(state: CachedBeaconStateAltair, cache: EpochTransitionCache): void {
   if (state.epochCtx.epoch === GENESIS_EPOCH) {
     return;
   }
 
   const {config, inactivityScores} = state;
   const {INACTIVITY_SCORE_BIAS, INACTIVITY_SCORE_RECOVERY_RATE} = config;
-  const {statuses, eligibleValidatorIndices} = epochProcess;
+  const {statuses, eligibleValidatorIndices} = cache;
   const inActivityLeak = isInInactivityLeak(state);
 
   // this avoids importing FLAG_ELIGIBLE_ATTESTER inside the for loop, check the compiled code

--- a/packages/state-transition/src/epoch/processJustificationAndFinalization.ts
+++ b/packages/state-transition/src/epoch/processJustificationAndFinalization.ts
@@ -2,7 +2,7 @@ import {GENESIS_EPOCH} from "@lodestar/params";
 import {BitArray} from "@chainsafe/ssz";
 import {ssz} from "@lodestar/types";
 import {computeEpochAtSlot, getBlockRoot} from "../util/index.js";
-import {CachedBeaconStateAllForks, EpochProcess} from "../types.js";
+import {CachedBeaconStateAllForks, EpochTransitionCache} from "../types.js";
 
 /**
  * Update justified and finalized checkpoints depending on network participation.
@@ -11,18 +11,18 @@ import {CachedBeaconStateAllForks, EpochProcess} from "../types.js";
  */
 export function processJustificationAndFinalization(
   state: CachedBeaconStateAllForks,
-  epochProcess: EpochProcess
+  cache: EpochTransitionCache
 ): void {
   // Initial FFG checkpoint values have a `0x00` stub for `root`.
   // Skip FFG updates in the first two epochs to avoid corner cases that might result in modifying this stub.
-  if (epochProcess.currentEpoch <= GENESIS_EPOCH + 1) {
+  if (cache.currentEpoch <= GENESIS_EPOCH + 1) {
     return;
   }
   weighJustificationAndFinalization(
     state,
-    epochProcess.totalActiveStakeByIncrement,
-    epochProcess.prevEpochUnslashedStake.targetStakeByIncrement,
-    epochProcess.currEpochUnslashedTargetStakeByIncrement
+    cache.totalActiveStakeByIncrement,
+    cache.prevEpochUnslashedStake.targetStakeByIncrement,
+    cache.currEpochUnslashedTargetStakeByIncrement
   );
 }
 

--- a/packages/state-transition/src/epoch/processRandaoMixesReset.ts
+++ b/packages/state-transition/src/epoch/processRandaoMixesReset.ts
@@ -1,13 +1,13 @@
 import {EPOCHS_PER_HISTORICAL_VECTOR} from "@lodestar/params";
-import {EpochProcess, CachedBeaconStateAllForks} from "../types.js";
+import {EpochTransitionCache, CachedBeaconStateAllForks} from "../types.js";
 
 /**
  * Write next randaoMix
  *
  * PERF: Almost no (constant) cost
  */
-export function processRandaoMixesReset(state: CachedBeaconStateAllForks, epochProcess: EpochProcess): void {
-  const currentEpoch = epochProcess.currentEpoch;
+export function processRandaoMixesReset(state: CachedBeaconStateAllForks, cache: EpochTransitionCache): void {
+  const currentEpoch = cache.currentEpoch;
   const nextEpoch = currentEpoch + 1;
 
   // set randao mix

--- a/packages/state-transition/src/epoch/processRewardsAndPenalties.ts
+++ b/packages/state-transition/src/epoch/processRewardsAndPenalties.ts
@@ -1,6 +1,11 @@
 import {ForkSeq, GENESIS_EPOCH} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
-import {CachedBeaconStateAllForks, CachedBeaconStateAltair, CachedBeaconStatePhase0, EpochProcess} from "../types.js";
+import {
+  CachedBeaconStateAllForks,
+  CachedBeaconStateAltair,
+  CachedBeaconStatePhase0,
+  EpochTransitionCache,
+} from "../types.js";
 import {getAttestationDeltas} from "./getAttestationDeltas.js";
 import {getRewardsAndPenaltiesAltair} from "./getRewardsAndPenalties.js";
 
@@ -9,13 +14,13 @@ import {getRewardsAndPenaltiesAltair} from "./getRewardsAndPenalties.js";
  *
  * PERF: Cost = 'proportional' to $VALIDATOR_COUNT. Extra work is done per validator the more status flags are set
  */
-export function processRewardsAndPenalties(state: CachedBeaconStateAllForks, epochProcess: EpochProcess): void {
+export function processRewardsAndPenalties(state: CachedBeaconStateAllForks, cache: EpochTransitionCache): void {
   // No rewards are applied at the end of `GENESIS_EPOCH` because rewards are for work done in the previous epoch
-  if (epochProcess.currentEpoch === GENESIS_EPOCH) {
+  if (cache.currentEpoch === GENESIS_EPOCH) {
     return;
   }
 
-  const [rewards, penalties] = getRewardsAndPenalties(state, epochProcess);
+  const [rewards, penalties] = getRewardsAndPenalties(state, cache);
   const balances = state.balances.getAll() as number[];
 
   for (let i = 0, len = rewards.length; i < len; i++) {
@@ -28,16 +33,16 @@ export function processRewardsAndPenalties(state: CachedBeaconStateAllForks, epo
 
   // For processEffectiveBalanceUpdates() to prevent having to re-compute the balances array.
   // For validator metrics
-  epochProcess.balances = balances;
+  cache.balances = balances;
 }
 
 // Note: abstracted in separate function for easier spec tests
 export function getRewardsAndPenalties(
   state: CachedBeaconStateAllForks,
-  epochProcess: EpochProcess
+  epochTransitionCache: EpochTransitionCache
 ): [number[], number[]] {
   const fork = state.config.getForkSeq(state.slot);
   return fork === ForkSeq.phase0
-    ? getAttestationDeltas(state as CachedBeaconStatePhase0, epochProcess)
-    : getRewardsAndPenaltiesAltair(state as CachedBeaconStateAltair, epochProcess);
+    ? getAttestationDeltas(state as CachedBeaconStatePhase0, epochTransitionCache)
+    : getRewardsAndPenaltiesAltair(state as CachedBeaconStateAltair, epochTransitionCache);
 }

--- a/packages/state-transition/src/epoch/processSlashings.ts
+++ b/packages/state-transition/src/epoch/processSlashings.ts
@@ -8,7 +8,7 @@ import {
 } from "@lodestar/params";
 
 import {decreaseBalance} from "../util/index.js";
-import {CachedBeaconStateAllForks, EpochProcess} from "../types.js";
+import {CachedBeaconStateAllForks, EpochTransitionCache} from "../types.js";
 
 /**
  * Update validator registry for validators that activate + exit
@@ -19,13 +19,13 @@ import {CachedBeaconStateAllForks, EpochProcess} from "../types.js";
  *
  * - On normal mainnet conditions indicesToSlash = 0
  */
-export function processSlashings(state: CachedBeaconStateAllForks, process: EpochProcess): void {
+export function processSlashings(state: CachedBeaconStateAllForks, cache: EpochTransitionCache): void {
   // No need to compute totalSlashings if there no index to slash
-  if (process.indicesToSlash.length === 0) {
+  if (cache.indicesToSlash.length === 0) {
     return;
   }
-  // TODO: have the regular totalBalance in EpochProcess too?
-  const totalBalance = BigInt(process.totalActiveStakeByIncrement) * BigInt(EFFECTIVE_BALANCE_INCREMENT);
+  // TODO: have the regular totalBalance in EpochTransitionCache too?
+  const totalBalance = BigInt(cache.totalActiveStakeByIncrement) * BigInt(EFFECTIVE_BALANCE_INCREMENT);
 
   // TODO: Could totalSlashings be number?
   // TODO: Could totalSlashing be cached?
@@ -46,7 +46,7 @@ export function processSlashings(state: CachedBeaconStateAllForks, process: Epoc
   const {effectiveBalanceIncrements} = state.epochCtx;
   const adjustedTotalSlashingBalance = bigIntMin(totalSlashings * BigInt(proportionalSlashingMultiplier), totalBalance);
   const increment = EFFECTIVE_BALANCE_INCREMENT;
-  for (const index of process.indicesToSlash) {
+  for (const index of cache.indicesToSlash) {
     const effectiveBalanceIncrement = effectiveBalanceIncrements[index];
     const penaltyNumerator = BigInt(effectiveBalanceIncrement) * adjustedTotalSlashingBalance;
     const penalty = Number(penaltyNumerator / totalBalance) * increment;

--- a/packages/state-transition/src/epoch/processSlashingsReset.ts
+++ b/packages/state-transition/src/epoch/processSlashingsReset.ts
@@ -1,13 +1,13 @@
 import {EPOCHS_PER_SLASHINGS_VECTOR} from "@lodestar/params";
-import {EpochProcess, CachedBeaconStateAllForks} from "../types.js";
+import {EpochTransitionCache, CachedBeaconStateAllForks} from "../types.js";
 
 /**
  * Reset the next slashings balance accumulator
  *
  * PERF: Almost no (constant) cost
  */
-export function processSlashingsReset(state: CachedBeaconStateAllForks, epochProcess: EpochProcess): void {
-  const nextEpoch = epochProcess.currentEpoch + 1;
+export function processSlashingsReset(state: CachedBeaconStateAllForks, cache: EpochTransitionCache): void {
+  const nextEpoch = cache.currentEpoch + 1;
 
   // reset slashings
   state.slashings.set(nextEpoch % EPOCHS_PER_SLASHINGS_VECTOR, BigInt(0));

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -30,8 +30,8 @@ export {
   isStateBalancesNodesPopulated,
   isStateValidatorsNodesPopulated,
 } from "./cache/stateCache.js";
-export {EpochContext, EpochContextImmutableData, createEmptyEpochContextImmutableData} from "./cache/epochContext.js";
-export {EpochProcess, beforeProcessEpoch} from "./cache/epochProcess.js";
+export {EpochCache, EpochCacheImmutableData, createEmptyEpochCacheImmutableData} from "./cache/epochCache.js";
+export {EpochTransitionCache, beforeProcessEpoch} from "./cache/epochTransitionCache.js";
 
 // Aux data-structures
 export {PubkeyIndexMap, Index2PubkeyCache} from "./cache/pubkeyCache.js";

--- a/packages/state-transition/src/slot/upgradeStateToAltair.ts
+++ b/packages/state-transition/src/slot/upgradeStateToAltair.ts
@@ -94,11 +94,11 @@ export function upgradeStateToAltair(statePhase0: CachedBeaconStatePhase0): Cach
 
   // TODO: describe issue. Compute progressive target balances
   //
-  // Note: in EpochContext.afterProcessEpoch previousTargetUnslashedBalanceIncrements is overwritten,
+  // Note: in EpochCache.afterProcessEpoch previousTargetUnslashedBalanceIncrements is overwritten,
   //       currentTargetUnslashedBalanceIncrements is rotated to previousTargetUnslashedBalanceIncrements
   //
   // Here target balance is computed in full, which is slightly less performant than doing so in the loop
-  // above but gurantees consistency with EpochContext.createFromState(). Note execution order below:
+  // above but gurantees consistency with EpochCache.createFromState(). Note execution order below:
   // ```
   // processEpoch()
   // epochCtx.afterProcessEpoch()

--- a/packages/state-transition/src/types.ts
+++ b/packages/state-transition/src/types.ts
@@ -1,5 +1,5 @@
-export {EpochContext} from "./cache/epochContext.js";
-export {EpochProcess} from "./cache/epochProcess.js";
+export {EpochCache} from "./cache/epochCache.js";
+export {EpochTransitionCache} from "./cache/epochTransitionCache.js";
 
 export {
   CachedBeaconStateAllForks,

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -12,7 +12,7 @@ import {Bytes32, phase0, Root, ssz, TimeSeconds} from "@lodestar/types";
 import {CompositeViewDU, ListCompositeType} from "@chainsafe/ssz";
 import {CachedBeaconStateAllForks, BeaconStateAllForks} from "../types.js";
 import {createCachedBeaconState} from "../cache/stateCache.js";
-import {EpochContextImmutableData} from "../cache/epochContext.js";
+import {EpochCacheImmutableData} from "../cache/epochCache.js";
 import {processDeposit} from "../block/processDeposit.js";
 import {computeEpochAtSlot} from "./epoch.js";
 import {getActiveValidatorIndices} from "./validator.js";
@@ -205,7 +205,7 @@ export function applyDeposits(
  */
 export function initializeBeaconStateFromEth1(
   config: ChainForkConfig,
-  immutableData: EpochContextImmutableData,
+  immutableData: EpochCacheImmutableData,
   eth1BlockHash: Bytes32,
   eth1Timestamp: TimeSeconds,
   deposits: phase0.Deposit[],

--- a/packages/state-transition/test/perf/analyzeEpochs.ts
+++ b/packages/state-transition/test/perf/analyzeEpochs.ts
@@ -99,7 +99,7 @@ async function analyzeEpochs(network: NetworkName, fromEpoch?: number): Promise<
     const stateTB = ssz.phase0.BeaconState.toViewDU(state as phase0.BeaconState);
     const postState = createCachedBeaconStateTest(stateTB, config);
 
-    const epochProcess = beforeProcessEpoch(postState);
+    const cache = beforeProcessEpoch(postState);
     processSlots(postState, nextEpochSlot);
 
     const validatorCount = state.validators.length;
@@ -118,7 +118,7 @@ async function analyzeEpochs(network: NetworkName, fromEpoch?: number): Promise<
 
     const attesterFlagsCount = {...attesterFlagsCountZero};
     const keys = Object.keys(attesterFlagsCountZero) as (keyof typeof attesterFlagsCountZero)[];
-    for (const status of epochProcess.statuses) {
+    for (const status of cache.statuses) {
       const flags = parseAttesterFlags(status.flags);
       for (const key of keys) {
         if (flags[key]) attesterFlagsCount[key]++;
@@ -136,10 +136,10 @@ async function analyzeEpochs(network: NetworkName, fromEpoch?: number): Promise<
       ...validatorChangesCount,
       ...attesterFlagsCount,
 
-      indicesEligibleForActivation: epochProcess.indicesEligibleForActivation.length,
-      indicesEligibleForActivationQueue: epochProcess.indicesEligibleForActivationQueue.length,
-      indicesToEject: epochProcess.indicesToEject.length,
-      indicesToSlash: epochProcess.indicesToSlash.length,
+      indicesEligibleForActivation: cache.indicesEligibleForActivation.length,
+      indicesEligibleForActivationQueue: cache.indicesEligibleForActivationQueue.length,
+      indicesToEject: cache.indicesToEject.length,
+      indicesToSlash: cache.indicesToSlash.length,
 
       previousEpochAttestations: previousEpochAttestations.length,
       currentEpochAttestations: currentEpochAttestations.length,

--- a/packages/state-transition/test/perf/epoch/afterProcessEpoch.test.ts
+++ b/packages/state-transition/test/perf/epoch/afterProcessEpoch.test.ts
@@ -12,12 +12,12 @@ describe("phase0 afterProcessEpoch", () => {
     yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
     before: () => {
       const state = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
-      const epochProcess = beforeProcessEpoch(state);
-      return {state: state, epochProcess};
+      const cache = beforeProcessEpoch(state);
+      return {state: state, cache};
     },
-    beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),
-    fn: ({state, epochProcess}) => {
-      state.epochCtx.afterProcessEpoch(state, epochProcess);
+    beforeEach: ({state, cache}) => ({state: state.clone(), cache}),
+    fn: ({state, cache}) => {
+      state.epochCtx.afterProcessEpoch(state, cache);
     },
   });
 });

--- a/packages/state-transition/test/perf/epoch/epochAltair.test.ts
+++ b/packages/state-transition/test/perf/epoch/epochAltair.test.ts
@@ -43,9 +43,9 @@ describe(`altair processEpoch - ${stateId}`, () => {
     yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
     beforeEach: () => stateOg.value.clone(),
     fn: (state) => {
-      const epochProcess = beforeProcessEpoch(state);
-      processEpoch(fork, state as CachedBeaconStateAltair, epochProcess);
-      state.epochCtx.afterProcessEpoch(state, epochProcess);
+      const cache = beforeProcessEpoch(state);
+      processEpoch(fork, state as CachedBeaconStateAltair, cache);
+      state.epochCtx.afterProcessEpoch(state, cache);
       // Simulate root computation through the next block to account for changes
       // 74184 hash64 ops - 92.730 ms
       state.hashTreeRoot();
@@ -61,7 +61,7 @@ describe(`altair processEpoch - ${stateId}`, () => {
 });
 
 function benchmarkAltairEpochSteps(stateOg: LazyValue<CachedBeaconStateAllForks>, stateId: string): void {
-  const epochProcess = beforeValue(() => beforeProcessEpoch(stateOg.value));
+  const cache = beforeValue(() => beforeProcessEpoch(stateOg.value));
 
   // const getPerfState = (): CachedBeaconStateAltair => {
   //   const state = originalState.clone();
@@ -100,63 +100,63 @@ function benchmarkAltairEpochSteps(stateOg: LazyValue<CachedBeaconStateAllForks>
   itBench({
     id: `${stateId} - altair processJustificationAndFinalization`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processJustificationAndFinalization(state, epochProcess.value),
+    fn: (state) => processJustificationAndFinalization(state, cache.value),
   });
 
   itBench({
     id: `${stateId} - altair processInactivityUpdates`,
     beforeEach: () => stateOg.value.clone() as CachedBeaconStateAltair,
-    fn: (state) => processInactivityUpdates(state, epochProcess.value),
+    fn: (state) => processInactivityUpdates(state, cache.value),
   });
 
   itBench({
     id: `${stateId} - altair processRewardsAndPenalties`,
     beforeEach: () => stateOg.value.clone() as CachedBeaconStateAltair,
-    fn: (state) => processRewardsAndPenalties(state, epochProcess.value),
+    fn: (state) => processRewardsAndPenalties(state, cache.value),
   });
 
   // TODO: Needs a better state to test with, current does not include enough actions: 17.715 us/op
   itBench({
     id: `${stateId} - altair processRegistryUpdates`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processRegistryUpdates(state, epochProcess.value),
+    fn: (state) => processRegistryUpdates(state, cache.value),
   });
 
   // TODO: Needs a better state to test with, current does not include enough actions: 39.985 us/op
   itBench({
     id: `${stateId} - altair processSlashings`,
     beforeEach: () => stateOg.value.clone() as CachedBeaconStateAltair,
-    fn: (state) => processSlashings(state, epochProcess.value),
+    fn: (state) => processSlashings(state, cache.value),
   });
 
   itBench({
     id: `${stateId} - altair processEth1DataReset`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processEth1DataReset(state, epochProcess.value),
+    fn: (state) => processEth1DataReset(state, cache.value),
   });
 
   itBench({
     id: `${stateId} - altair processEffectiveBalanceUpdates`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processEffectiveBalanceUpdates(state, epochProcess.value),
+    fn: (state) => processEffectiveBalanceUpdates(state, cache.value),
   });
 
   itBench({
     id: `${stateId} - altair processSlashingsReset`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processSlashingsReset(state, epochProcess.value),
+    fn: (state) => processSlashingsReset(state, cache.value),
   });
 
   itBench({
     id: `${stateId} - altair processRandaoMixesReset`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processRandaoMixesReset(state, epochProcess.value),
+    fn: (state) => processRandaoMixesReset(state, cache.value),
   });
 
   itBench({
     id: `${stateId} - altair processHistoricalRootsUpdate`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processHistoricalRootsUpdate(state, epochProcess.value),
+    fn: (state) => processHistoricalRootsUpdate(state, cache.value),
   });
 
   itBench({
@@ -174,14 +174,14 @@ function benchmarkAltairEpochSteps(stateOg: LazyValue<CachedBeaconStateAllForks>
 
   itBench<StateEpoch, StateEpoch>({
     id: `${stateId} - altair afterProcessEpoch`,
-    // Compute a state and epochProcess after running processEpoch() since those values are mutated
+    // Compute a state and cache after running processEpoch() since those values are mutated
     before: () => {
       const state = stateOg.value.clone();
-      const epochProcessAfter = beforeProcessEpoch(state);
-      processEpoch(fork, state as CachedBeaconStateAltair, epochProcessAfter);
-      return {state, epochProcess: epochProcessAfter};
+      const cacheAfter = beforeProcessEpoch(state);
+      processEpoch(fork, state as CachedBeaconStateAltair, cacheAfter);
+      return {state, cache: cacheAfter};
     },
-    beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),
-    fn: ({state, epochProcess}) => state.epochCtx.afterProcessEpoch(state, epochProcess),
+    beforeEach: ({state, cache}) => ({state: state.clone(), cache}),
+    fn: ({state, cache}) => state.epochCtx.afterProcessEpoch(state, cache),
   });
 }

--- a/packages/state-transition/test/perf/epoch/epochPhase0.test.ts
+++ b/packages/state-transition/test/perf/epoch/epochPhase0.test.ts
@@ -40,9 +40,9 @@ describe(`phase0 processEpoch - ${stateId}`, () => {
     id: `phase0 processEpoch - ${stateId}`,
     beforeEach: () => stateOg.value.clone(),
     fn: (state) => {
-      const epochProcess = beforeProcessEpoch(state);
-      processEpoch(fork, state as CachedBeaconStatePhase0, epochProcess);
-      state.epochCtx.afterProcessEpoch(state, epochProcess);
+      const cache = beforeProcessEpoch(state);
+      processEpoch(fork, state as CachedBeaconStatePhase0, cache);
+      state.epochCtx.afterProcessEpoch(state, cache);
       // Simulate root computation through the next block to account for changes
       state.hashTreeRoot();
     },
@@ -57,7 +57,7 @@ describe(`phase0 processEpoch - ${stateId}`, () => {
 });
 
 function benchmarkPhase0EpochSteps(stateOg: LazyValue<CachedBeaconStateAllForks>, stateId: string): void {
-  const epochProcess = beforeValue(() => beforeProcessEpoch(stateOg.value));
+  const cache = beforeValue(() => beforeProcessEpoch(stateOg.value));
 
   // Functions in same order as processEpoch()
   // Rough summary as of Aug 5th 2021
@@ -87,58 +87,58 @@ function benchmarkPhase0EpochSteps(stateOg: LazyValue<CachedBeaconStateAllForks>
   itBench({
     id: `${stateId} - phase0 processJustificationAndFinalization`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processJustificationAndFinalization(state, epochProcess.value),
+    fn: (state) => processJustificationAndFinalization(state, cache.value),
   });
 
   // Very expensive 976.40 ms/op good target to optimize
   itBench({
     id: `${stateId} - phase0 processRewardsAndPenalties`,
     beforeEach: () => stateOg.value.clone() as CachedBeaconStatePhase0,
-    fn: (state) => processRewardsAndPenalties(state, epochProcess.value),
+    fn: (state) => processRewardsAndPenalties(state, cache.value),
   });
 
   // TODO: Needs a better state to test with, current does not include enough actions: 17.715 us/op
   itBench({
     id: `${stateId} - phase0 processRegistryUpdates`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processRegistryUpdates(state, epochProcess.value),
+    fn: (state) => processRegistryUpdates(state, cache.value),
   });
 
   // TODO: Needs a better state to test with, current does not include enough actions: 39.985 us/op
   itBench({
     id: `${stateId} - phase0 processSlashings`,
     beforeEach: () => stateOg.value.clone() as CachedBeaconStatePhase0,
-    fn: (state) => processSlashings(state, epochProcess.value),
+    fn: (state) => processSlashings(state, cache.value),
   });
 
   itBench({
     id: `${stateId} - phase0 processEth1DataReset`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processEth1DataReset(state, epochProcess.value),
+    fn: (state) => processEth1DataReset(state, cache.value),
   });
 
   itBench({
     id: `${stateId} - phase0 processEffectiveBalanceUpdates`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processEffectiveBalanceUpdates(state, epochProcess.value),
+    fn: (state) => processEffectiveBalanceUpdates(state, cache.value),
   });
 
   itBench({
     id: `${stateId} - phase0 processSlashingsReset`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processSlashingsReset(state, epochProcess.value),
+    fn: (state) => processSlashingsReset(state, cache.value),
   });
 
   itBench({
     id: `${stateId} - phase0 processRandaoMixesReset`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processRandaoMixesReset(state, epochProcess.value),
+    fn: (state) => processRandaoMixesReset(state, cache.value),
   });
 
   itBench({
     id: `${stateId} - phase0 processHistoricalRootsUpdate`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processHistoricalRootsUpdate(state, epochProcess.value),
+    fn: (state) => processHistoricalRootsUpdate(state, cache.value),
   });
 
   itBench({
@@ -149,14 +149,14 @@ function benchmarkPhase0EpochSteps(stateOg: LazyValue<CachedBeaconStateAllForks>
 
   itBench<StateEpoch, StateEpoch>({
     id: `${stateId} - phase0 afterProcessEpoch`,
-    // Compute a state and epochProcess after running processEpoch() since those values are mutated
+    // Compute a state and cache after running processEpoch() since those values are mutated
     before: () => {
       const state = stateOg.value.clone();
-      const epochProcessAfter = beforeProcessEpoch(state);
-      processEpoch(fork, state as CachedBeaconStatePhase0, epochProcessAfter);
-      return {state, epochProcess: epochProcessAfter};
+      const cacheAfter = beforeProcessEpoch(state);
+      processEpoch(fork, state as CachedBeaconStatePhase0, cacheAfter);
+      return {state, cache: cacheAfter};
     },
-    beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),
-    fn: ({state, epochProcess}) => state.epochCtx.afterProcessEpoch(state, epochProcess),
+    beforeEach: ({state, cache}) => ({state: state.clone(), cache}),
+    fn: ({state, cache}) => state.epochCtx.afterProcessEpoch(state, cache),
   });
 }

--- a/packages/state-transition/test/perf/epoch/processInactivityUpdates.test.ts
+++ b/packages/state-transition/test/perf/epoch/processInactivityUpdates.test.ts
@@ -3,7 +3,7 @@ import {processInactivityUpdates} from "../../../src/epoch/processInactivityUpda
 import {StateAltairEpoch} from "../types.js";
 import {generatePerfTestCachedStateAltair, numValidators} from "../util.js";
 import {mutateInactivityScores} from "./util.js";
-import {FlagFactors, generateBalanceDeltasEpochProcess} from "./utilPhase0.js";
+import {FlagFactors, generateBalanceDeltasEpochTransitionCache} from "./utilPhase0.js";
 
 // PERF: Cost = iterate over an array of size $VALIDATOR_COUNT + 'proportional' to how many validtors are inactive or
 // have been inactive in the past, i.e. that require an update to their inactivityScore. Worst case = all validators
@@ -43,12 +43,12 @@ describe("altair processInactivityUpdates", () => {
       yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
       before: () => {
         const state = generatePerfTestCachedStateAltair({goBackOneSlot: true});
-        const epochProcess = generateBalanceDeltasEpochProcess(state, isInInactivityLeak, flagFactors);
+        const cache = generateBalanceDeltasEpochTransitionCache(state, isInInactivityLeak, flagFactors);
         mutateInactivityScores(state, factorWithPositive);
-        return {state, epochProcess};
+        return {state, cache};
       },
-      beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),
-      fn: ({state, epochProcess}) => processInactivityUpdates(state, epochProcess),
+      beforeEach: ({state, cache}) => ({state: state.clone(), cache}),
+      fn: ({state, cache}) => processInactivityUpdates(state, cache),
     });
   }
 });

--- a/packages/state-transition/test/perf/epoch/processRegistryUpdates.test.ts
+++ b/packages/state-transition/test/perf/epoch/processRegistryUpdates.test.ts
@@ -1,5 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {beforeProcessEpoch, CachedBeaconStateAllForks, EpochProcess} from "../../../src/index.js";
+import {beforeProcessEpoch, CachedBeaconStateAllForks, EpochTransitionCache} from "../../../src/index.js";
 import {processRegistryUpdates} from "../../../src/epoch/processRegistryUpdates.js";
 import {generatePerfTestCachedStatePhase0, numValidators} from "../util.js";
 import {StateEpoch} from "../types.js";
@@ -48,7 +48,7 @@ describe("phase0 processRegistryUpdates", () => {
     },
   ];
 
-  // Provide flat `epochProcess.balances` + flat `epochProcess.validators`
+  // Provide flat `cache.balances` + flat `cache.validators`
   // which will it update validators tree
 
   for (const {id, notTrack, lengths} of testCases) {
@@ -61,8 +61,8 @@ describe("phase0 processRegistryUpdates", () => {
       minRuns: 5, // Worst case is very slow
       noThreshold: notTrack,
       before: () => getRegistryUpdatesTestData(vc, lengths),
-      beforeEach: async ({state, epochProcess}) => ({state: state.clone(), epochProcess}),
-      fn: ({state, epochProcess}) => processRegistryUpdates(state, epochProcess),
+      beforeEach: async ({state, cache}) => ({state: state.clone(), cache}),
+      fn: ({state, cache}) => processRegistryUpdates(state, cache),
     });
   }
 });
@@ -81,18 +81,18 @@ function getRegistryUpdatesTestData(
   lengths: IndicesLengths
 ): {
   state: CachedBeaconStateAllForks;
-  epochProcess: EpochProcess;
+  cache: EpochTransitionCache;
 } {
   const state = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
-  const epochProcess = beforeProcessEpoch(state);
+  const cache = beforeProcessEpoch(state);
 
-  epochProcess.indicesToEject = linspace(lengths.indicesToEject);
-  epochProcess.indicesEligibleForActivationQueue = linspace(lengths.indicesEligibleForActivationQueue);
-  epochProcess.indicesEligibleForActivation = linspace(lengths.indicesEligibleForActivation);
+  cache.indicesToEject = linspace(lengths.indicesToEject);
+  cache.indicesEligibleForActivationQueue = linspace(lengths.indicesEligibleForActivationQueue);
+  cache.indicesEligibleForActivation = linspace(lengths.indicesEligibleForActivation);
 
   return {
     state,
-    epochProcess,
+    cache,
   };
 }
 

--- a/packages/state-transition/test/perf/epoch/processRewardsAndPenalties.test.ts
+++ b/packages/state-transition/test/perf/epoch/processRewardsAndPenalties.test.ts
@@ -2,7 +2,7 @@ import {itBench} from "@dapplion/benchmark";
 import {processRewardsAndPenalties} from "../../../src/epoch/processRewardsAndPenalties.js";
 import {generatePerfTestCachedStateAltair, numValidators} from "../util.js";
 import {StateAltairEpoch} from "../types.js";
-import {FlagFactors, generateBalanceDeltasEpochProcess} from "./utilPhase0.js";
+import {FlagFactors, generateBalanceDeltasEpochTransitionCache} from "./utilPhase0.js";
 import {mutateInactivityScores} from "./util.js";
 
 // PERF: Cost = 'proportional' to $VALIDATOR_COUNT. Extra work is done per validator the more status flags are set
@@ -43,12 +43,12 @@ describe("altair processRewardsAndPenalties", () => {
       yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
       before: () => {
         const state = generatePerfTestCachedStateAltair({goBackOneSlot: true});
-        const epochProcess = generateBalanceDeltasEpochProcess(state, isInInactivityLeak, flagFactors);
+        const cache = generateBalanceDeltasEpochTransitionCache(state, isInInactivityLeak, flagFactors);
         mutateInactivityScores(state, factorWithPositive);
-        return {state, epochProcess};
+        return {state, cache};
       },
-      beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),
-      fn: ({state, epochProcess}) => processRewardsAndPenalties(state, epochProcess),
+      beforeEach: ({state, cache}) => ({state: state.clone(), cache}),
+      fn: ({state, cache}) => processRewardsAndPenalties(state, cache),
     });
   }
 });

--- a/packages/state-transition/test/perf/epoch/processRewardsAndPenaltiesPhase0.test.ts
+++ b/packages/state-transition/test/perf/epoch/processRewardsAndPenaltiesPhase0.test.ts
@@ -2,7 +2,7 @@ import {itBench} from "@dapplion/benchmark";
 import {getAttestationDeltas} from "../../../src/epoch/getAttestationDeltas.js";
 import {generatePerfTestCachedStatePhase0, numValidators} from "../util.js";
 import {StatePhase0Epoch} from "../types.js";
-import {FlagFactors, generateBalanceDeltasEpochProcess} from "./utilPhase0.js";
+import {FlagFactors, generateBalanceDeltasEpochTransitionCache} from "./utilPhase0.js";
 
 // - On normal mainnet conditions
 //   - prevSourceAttester: 98%
@@ -44,12 +44,12 @@ describe("phase0 getAttestationDeltas", () => {
       yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
       before: () => {
         const state = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
-        const epochProcess = generateBalanceDeltasEpochProcess(state, isInInactivityLeak, flagFactors);
-        return {state, epochProcess};
+        const cache = generateBalanceDeltasEpochTransitionCache(state, isInInactivityLeak, flagFactors);
+        return {state, cache};
       },
-      beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),
-      fn: ({state, epochProcess}) => {
-        getAttestationDeltas(state, epochProcess);
+      beforeEach: ({state, cache}) => ({state: state.clone(), cache}),
+      fn: ({state, cache}) => {
+        getAttestationDeltas(state, cache);
       },
     });
   }

--- a/packages/state-transition/test/perf/epoch/processSlashingsAllForks.test.ts
+++ b/packages/state-transition/test/perf/epoch/processSlashingsAllForks.test.ts
@@ -3,7 +3,7 @@ import {
   beforeProcessEpoch,
   CachedBeaconStatePhase0,
   CachedBeaconStateAllForks,
-  EpochProcess,
+  EpochTransitionCache,
 } from "../../../src/index.js";
 import {processSlashings} from "../../../src/epoch/processSlashings.js";
 import {generatePerfTestCachedStatePhase0, numValidators} from "../util.js";
@@ -24,7 +24,7 @@ describe("phase0 processSlashings", () => {
     {id: "worstcase", indicesToSlashLen: 8704},
   ];
 
-  // Provide flat `epochProcess.balances` + flat `epochProcess.validators`
+  // Provide flat `cache.balances` + flat `cache.validators`
   // which will it update validators tree
 
   for (const {id, indicesToSlashLen} of testCases) {
@@ -33,8 +33,8 @@ describe("phase0 processSlashings", () => {
       yieldEventLoopAfterEach: true, // So SubTree(s)'s WeakRef can be garbage collected https://github.com/nodejs/node/issues/39902
       minRuns: 5, // Worst case is very slow
       before: () => getProcessSlashingsTestData(indicesToSlashLen),
-      beforeEach: ({state, epochProcess}) => ({state: state.clone(), epochProcess}),
-      fn: ({state, epochProcess}) => processSlashings(state as CachedBeaconStatePhase0, epochProcess),
+      beforeEach: ({state, cache}) => ({state: state.clone(), cache}),
+      fn: ({state, cache}) => processSlashings(state as CachedBeaconStatePhase0, cache),
     });
   }
 });
@@ -44,16 +44,16 @@ describe("phase0 processSlashings", () => {
  */
 function getProcessSlashingsTestData(indicesToSlashLen: number): {
   state: CachedBeaconStateAllForks;
-  epochProcess: EpochProcess;
+  cache: EpochTransitionCache;
 } {
   const state = generatePerfTestCachedStatePhase0({goBackOneSlot: true});
-  const epochProcess = beforeProcessEpoch(state);
+  const cache = beforeProcessEpoch(state);
 
-  epochProcess.indicesToSlash = linspace(indicesToSlashLen);
+  cache.indicesToSlash = linspace(indicesToSlashLen);
 
   return {
     state,
-    epochProcess,
+    cache,
   };
 }
 

--- a/packages/state-transition/test/perf/epoch/utilPhase0.ts
+++ b/packages/state-transition/test/perf/epoch/utilPhase0.ts
@@ -5,18 +5,18 @@ import {
   AttesterStatus,
   toAttesterFlags,
 } from "../../../src/index.js";
-import {CachedBeaconStatePhase0, CachedBeaconStateAltair, EpochProcess} from "../../../src/types.js";
+import {CachedBeaconStatePhase0, CachedBeaconStateAltair, EpochTransitionCache} from "../../../src/types.js";
 
 /**
- * Generate an incomplete EpochProcess to simulate any network condition relevant to getAttestationDeltas
+ * Generate an incomplete EpochTransitionCache to simulate any network condition relevant to getAttestationDeltas
  * @param isInInactivityLeak true if in inactivity leak
  * @param flagFactors factor (0,1) of validators that have that flag set to true
  */
-export function generateBalanceDeltasEpochProcess(
+export function generateBalanceDeltasEpochTransitionCache(
   state: CachedBeaconStatePhase0 | CachedBeaconStateAltair,
   isInInactivityLeak: boolean,
   flagFactors: FlagFactors
-): EpochProcess {
+): EpochTransitionCache {
   const vc = state.validators.length;
 
   const statuses = generateStatuses(state.validators.length, flagFactors);
@@ -27,7 +27,7 @@ export function generateBalanceDeltasEpochProcess(
     }
   }
 
-  const epochProcess: Partial<EpochProcess> = {
+  const cache: Partial<EpochTransitionCache> = {
     statuses,
     eligibleValidatorIndices,
     totalActiveStakeByIncrement: vc,
@@ -40,7 +40,7 @@ export function generateBalanceDeltasEpochProcess(
     prevEpoch: isInInactivityLeak ? state.finalizedCheckpoint.epoch - 500 : state.finalizedCheckpoint.epoch,
   };
 
-  return epochProcess as EpochProcess;
+  return cache as EpochTransitionCache;
 }
 
 export type FlagFactors = Record<keyof AttesterFlags, number> | number;

--- a/packages/state-transition/test/perf/sanityCheck.test.ts
+++ b/packages/state-transition/test/perf/sanityCheck.test.ts
@@ -30,14 +30,13 @@ describe("Perf test sanity check", function () {
 
   it("targetStake is in the same range", () => {
     const phase0State = generatePerfTestCachedStatePhase0();
-    const epochProcess = beforeProcessEpoch(phase0State);
+    const cache = beforeProcessEpoch(phase0State);
     expect(
       // Chai does not support bigint comparisons
       // eslint-disable-next-line chai-expect/no-inner-compare
-      BigInt(epochProcess.prevEpochUnslashedStake.targetStakeByIncrement) * BigInt(EFFECTIVE_BALANCE_INCREMENT) >
-        targetStake,
+      BigInt(cache.prevEpochUnslashedStake.targetStakeByIncrement) * BigInt(EFFECTIVE_BALANCE_INCREMENT) > targetStake,
       `targetStake too low: ${
-        BigInt(epochProcess.prevEpochUnslashedStake.targetStakeByIncrement) * BigInt(EFFECTIVE_BALANCE_INCREMENT)
+        BigInt(cache.prevEpochUnslashedStake.targetStakeByIncrement) * BigInt(EFFECTIVE_BALANCE_INCREMENT)
       } > ${targetStake}`
     ).to.be.true;
   });

--- a/packages/state-transition/test/perf/types.ts
+++ b/packages/state-transition/test/perf/types.ts
@@ -1,12 +1,12 @@
 import {allForks} from "@lodestar/types";
 import {CachedBeaconStateAllForks, CachedBeaconStatePhase0, CachedBeaconStateAltair} from "../../src/index.js";
-import {EpochProcess} from "../../src/types.js";
+import {EpochTransitionCache} from "../../src/types.js";
 
 // Type aliases to typesafe itBench() calls
 
 export type State = CachedBeaconStateAllForks;
 export type StateAltair = CachedBeaconStateAltair;
 export type StateBlock = {state: CachedBeaconStateAllForks; block: allForks.SignedBeaconBlock};
-export type StateEpoch = {state: CachedBeaconStateAllForks; epochProcess: EpochProcess};
-export type StatePhase0Epoch = {state: CachedBeaconStatePhase0; epochProcess: EpochProcess};
-export type StateAltairEpoch = {state: CachedBeaconStateAltair; epochProcess: EpochProcess};
+export type StateEpoch = {state: CachedBeaconStateAllForks; cache: EpochTransitionCache};
+export type StatePhase0Epoch = {state: CachedBeaconStatePhase0; cache: EpochTransitionCache};
+export type StateAltairEpoch = {state: CachedBeaconStateAltair; cache: EpochTransitionCache};

--- a/packages/state-transition/test/utils/state.ts
+++ b/packages/state-transition/test/utils/state.ts
@@ -21,7 +21,7 @@ import {
   PubkeyIndexMap,
 } from "../../src/index.js";
 import {BeaconStateCache} from "../../src/cache/stateCache.js";
-import {EpochContextOpts} from "../../src/cache/epochContext.js";
+import {EpochCacheOpts} from "../../src/cache/epochCache.js";
 
 /**
  * Copy of BeaconState, but all fields are marked optional to allow for swapping out variables as needed.
@@ -100,7 +100,7 @@ export function generateCachedState(
 export function createCachedBeaconStateTest<T extends BeaconStateAllForks>(
   state: T,
   configCustom: ChainForkConfig = config,
-  opts?: EpochContextOpts
+  opts?: EpochCacheOpts
 ): T & BeaconStateCache {
   return createCachedBeaconState<T>(
     state,


### PR DESCRIPTION
**Motivation**

- See https://github.com/ChainSafe/lodestar/issues/2406, use simpler naming

**Description**

- Rename `EpochContext` -> `EpochCache`: persistent data associated attached to a CachedBeaconState which is associated to a longer timeframe than a single state. `EpochCache` conveys the meaning better that it's actually a cache, context is weird. Could be renamed to StateCache too.
- Rename `EpochProcess` -> `EpochTransitionCache`: ephemeral data used only during an epoch transition. `EpochProcess` is a vague name that does not convey much meaning. `EpochTransitionCache` conveys that it is a **cache** for the **epoch transition**

Closes https://github.com/ChainSafe/lodestar/issues/2406
