### PR TITLE
feat: add setHeadAfterFirstInterval metric

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -1,5 +1,5 @@
 import {capella, ssz, allForks, altair} from "@lodestar/types";
-import {ForkSeq, MAX_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkSeq, INTERVALS_PER_SLOT, MAX_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {toHexString} from "@chainsafe/ssz";
 import {
   CachedBeaconStateAltair,
@@ -235,8 +235,11 @@ export async function importBlock(
       this.metrics.headSlot.set(newHead.slot);
       // Only track "recent" blocks. Otherwise sync can distort this metrics heavily.
       // We want to track recent blocks coming from gossip, unknown block sync, and API.
-      if (delaySec < 64 * this.config.SECONDS_PER_SLOT) {
+      if (delaySec < SLOTS_PER_EPOCH * this.config.SECONDS_PER_SLOT) {
         this.metrics.importBlock.elapsedTimeTillBecomeHead.observe(delaySec);
+        if (delaySec > this.config.SECONDS_PER_SLOT / INTERVALS_PER_SLOT) {
+          this.metrics.importBlock.setHeadAfterFirstInterval.inc();
+        }
       }
     }
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -614,6 +614,10 @@ export function createLodestarMetrics(
         help: "Time elapsed between block slot time and the time block becomes head",
         buckets: [0.5, 1, 2, 4, 6, 12],
       }),
+      setHeadAfterFirstInterval: register.gauge({
+        name: "lodestar_import_block_set_head_after_first_interval_total",
+        help: "Total times an imported block is set as head after the first slot interval",
+      }),
       bySource: register.gauge<"source">({
         name: "lodestar_import_block_by_source_total",
         help: "Total number of imported blocks by source",


### PR DESCRIPTION
**Motivation**

- Part of https://github.com/ChainSafe/lodestar/issues/2468

**Description**

Add setHeadAfterFirstInterval metric, additive to histogram since it tracks exactly the amount of times blocks come more than 1/3 of the slot late. It's not guaranteed that the histogram will contain a bucket for it and it's a really important metric
