### PR TITLE
chore: move DB Bucket schema to consumer packages

### DIFF
--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -1,5 +1,5 @@
 import {routes, ServerApi} from "@lodestar/api";
-import {Bucket, Repository} from "@lodestar/db";
+import {Repository} from "@lodestar/db";
 import {toHex} from "@lodestar/utils";
 import {getLatestWeakSubjectivityCheckpointEpoch} from "@lodestar/state-transition";
 import {toHexString} from "@chainsafe/ssz";
@@ -144,14 +144,13 @@ export function getLodestarApi({
     async dumpDbBucketKeys(bucketReq) {
       for (const repo of Object.values(db) as IBeaconDb[keyof IBeaconDb][]) {
         if (repo instanceof Repository) {
-          const bucket = (repo as RepositoryAny)["bucket"];
-          if (bucket === bucket || Bucket[bucket] === bucketReq) {
+          if (String(repo["bucket"]) === bucketReq || repo["bucketId"] === bucketReq) {
             return {data: stringifyKeys(await repo.keys())};
           }
         }
       }
 
-      throw Error(`Unknown Bucket '${bucketReq}' available: ${Object.keys(Bucket).join(", ")}`);
+      throw Error(`Unknown Bucket '${bucketReq}'`);
     },
 
     async dumpDbStateIndex() {
@@ -185,9 +184,6 @@ function regenRequestToJson(config: ChainForkConfig, regenRequest: RegenRequest)
       };
   }
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type RepositoryAny = Repository<any, any>;
 
 function stringifyKeys(keys: (Uint8Array | number | string)[]): string[] {
   return keys.map((key) => {

--- a/packages/beacon-node/src/db/buckets.ts
+++ b/packages/beacon-node/src/db/buckets.ts
@@ -30,16 +30,6 @@ export enum Bucket {
   phase0_proposerSlashing = 14, // ValidatorIndex -> ProposerSlashing
   phase0_attesterSlashing = 15, // Root -> AttesterSlashing
   capella_blsToExecutionChange = 16, // ValidatorIndex -> SignedBLSToExecutionChange
-  // validator
-  // validator = 16, // DEPRECATED on v0.11.0
-  // lastProposedBlock = 17, // DEPRECATED on v0.11.0
-  // proposedAttestations = 18, // DEPRECATED on v0.11.0
-  // validator slashing protection
-  phase0_slashingProtectionBlockBySlot = 20,
-  phase0_slashingProtectionAttestationByTarget = 21,
-  phase0_slashingProtectionAttestationLowerBound = 22,
-  index_slashingProtectionMinSpanDistance = 23,
-  index_slashingProtectionMaxSpanDistance = 24,
   // allForks_pendingBlock = 25, // Root -> SignedBeaconBlock // DEPRECATED on v0.30.0
 
   index_stateArchiveRootIndex = 26, // State Root -> slot
@@ -70,8 +60,6 @@ export enum Bucket {
   // 54 was for bestPartialLightClientUpdate, allocate a fresh one
   // lightClient_bestLightClientUpdate = 55, // SyncPeriod -> LightClientUpdate // DEPRECATED on v1.5.0
   lightClient_bestLightClientUpdate = 56, // SyncPeriod -> [Slot, LightClientUpdate]
-
-  validator_metaData = 41,
 
   backfilled_ranges = 42, // Backfilled From to To, inclusive of both From, To
 }

--- a/packages/beacon-node/src/db/buckets.ts
+++ b/packages/beacon-node/src/db/buckets.ts
@@ -1,6 +1,3 @@
-import {intToBytes} from "@lodestar/utils";
-import {BUCKET_LENGTH} from "./const.js";
-
 // Buckets are separate database namespaces
 export enum Bucket {
   // beacon chain
@@ -79,37 +76,16 @@ export enum Bucket {
   backfilled_ranges = 42, // Backfilled From to To, inclusive of both From, To
 }
 
-export enum Key {
-  chainHeight = 0,
-
-  latestState = 1,
-  finalizedState = 2,
-  justifiedState = 3,
-
-  finalizedBlock = 4,
-  justifiedBlock = 5,
-}
-
-export const uintLen = 8;
-
-/**
- * Prepend a bucket to a key
- */
-export function encodeKey(bucket: Bucket, key: Uint8Array | string | number | bigint): Uint8Array {
-  let buf;
-  const prefixLength = BUCKET_LENGTH;
-  //all keys are writen with prefixLength offet
-  if (typeof key === "string") {
-    buf = Buffer.alloc(key.length + prefixLength);
-    buf.write(key, prefixLength);
-  } else if (typeof key === "number" || typeof key === "bigint") {
-    buf = Buffer.alloc(uintLen + prefixLength);
-    intToBytes(BigInt(key), uintLen, "be").copy(buf, prefixLength);
-  } else {
-    buf = Buffer.alloc(key.length + prefixLength);
-    buf.set(key, prefixLength);
+export function getBucketNameByValue<T extends Bucket>(enumValue: T): keyof typeof Bucket {
+  const keys = Object.keys(Bucket).filter((x) => {
+    if (isNaN(parseInt(x))) {
+      return Bucket[x as keyof typeof Bucket] == enumValue;
+    } else {
+      return false;
+    }
+  }) as (keyof typeof Bucket)[];
+  if (keys.length > 0) {
+    return keys[0];
   }
-  //bucket prefix on position 0
-  buf.set(intToBytes(bucket, BUCKET_LENGTH, "le"), 0);
-  return buf;
+  throw new Error("Missing bucket for value " + enumValue);
 }

--- a/packages/beacon-node/src/db/repositories/attesterSlashing.ts
+++ b/packages/beacon-node/src/db/repositories/attesterSlashing.ts
@@ -1,6 +1,7 @@
 import {phase0, ssz, ValidatorIndex} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
-import {Db, Bucket, Repository} from "@lodestar/db";
+import {Db, Repository} from "@lodestar/db";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 /**
  * AttesterSlashing indexed by root
@@ -10,7 +11,8 @@ import {Db, Bucket, Repository} from "@lodestar/db";
  */
 export class AttesterSlashingRepository extends Repository<Uint8Array, phase0.AttesterSlashing> {
   constructor(config: ChainForkConfig, db: Db) {
-    super(config, db, Bucket.phase0_attesterSlashing, ssz.phase0.AttesterSlashing);
+    const bucket = Bucket.phase0_attesterSlashing;
+    super(config, db, bucket, ssz.phase0.AttesterSlashing, getBucketNameByValue(bucket));
   }
 
   async hasAll(attesterIndices: ValidatorIndex[] = []): Promise<boolean> {

--- a/packages/beacon-node/src/db/repositories/backfilledRanges.ts
+++ b/packages/beacon-node/src/db/repositories/backfilledRanges.ts
@@ -1,7 +1,8 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {Slot, ssz} from "@lodestar/types";
-import {DatabaseController, Bucket, Repository} from "@lodestar/db";
+import {DatabaseController, Repository} from "@lodestar/db";
 import {bytesToInt} from "@lodestar/utils";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 /**
  * Slot to slot ranges that ensure that block range is fully backfilled
@@ -14,7 +15,8 @@ import {bytesToInt} from "@lodestar/utils";
  */
 export class BackfilledRanges extends Repository<Slot, Slot> {
   constructor(config: ChainForkConfig, db: DatabaseController<Uint8Array, Uint8Array>) {
-    super(config, db, Bucket.backfilled_ranges, ssz.Slot);
+    const bucket = Bucket.backfilled_ranges;
+    super(config, db, bucket, ssz.Slot, getBucketNameByValue(bucket));
   }
 
   decodeKey(data: Buffer): number {

--- a/packages/beacon-node/src/db/repositories/blobSidecars.ts
+++ b/packages/beacon-node/src/db/repositories/blobSidecars.ts
@@ -1,7 +1,8 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Bucket, Db, Repository} from "@lodestar/db";
+import {Db, Repository} from "@lodestar/db";
 import {ssz} from "@lodestar/types";
 import {ValueOf, ContainerType} from "@chainsafe/ssz";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 export const blobSidecarsWrapperSsz = new ContainerType(
   {
@@ -25,7 +26,8 @@ export const BLOBSIDECAR_FIXED_SIZE = 131256;
  */
 export class BlobSidecarsRepository extends Repository<Uint8Array, BlobSidecarsWrapper> {
   constructor(config: ChainForkConfig, db: Db) {
-    super(config, db, Bucket.allForks_blobSidecars, blobSidecarsWrapperSsz);
+    const bucket = Bucket.allForks_blobSidecars;
+    super(config, db, bucket, blobSidecarsWrapperSsz, getBucketNameByValue(bucket));
   }
 
   /**

--- a/packages/beacon-node/src/db/repositories/blobSidecarsArchive.ts
+++ b/packages/beacon-node/src/db/repositories/blobSidecarsArchive.ts
@@ -1,8 +1,8 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Bucket, Db, Repository} from "@lodestar/db";
+import {Db, Repository} from "@lodestar/db";
 import {Slot} from "@lodestar/types";
 import {bytesToInt} from "@lodestar/utils";
-
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 import {blobSidecarsWrapperSsz, BlobSidecarsWrapper} from "./blobSidecars.js";
 
 /**
@@ -12,7 +12,8 @@ import {blobSidecarsWrapperSsz, BlobSidecarsWrapper} from "./blobSidecars.js";
  */
 export class BlobSidecarsArchiveRepository extends Repository<Slot, BlobSidecarsWrapper> {
   constructor(config: ChainForkConfig, db: Db) {
-    super(config, db, Bucket.allForks_blobSidecarsArchive, blobSidecarsWrapperSsz);
+    const bucket = Bucket.allForks_blobSidecarsArchive;
+    super(config, db, bucket, blobSidecarsWrapperSsz, getBucketNameByValue(bucket));
   }
 
   // Handle key as slot

--- a/packages/beacon-node/src/db/repositories/blobsSidecar.ts
+++ b/packages/beacon-node/src/db/repositories/blobsSidecar.ts
@@ -1,6 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Bucket, Db, Repository} from "@lodestar/db";
+import {Db, Repository} from "@lodestar/db";
 import {deneb, ssz} from "@lodestar/types";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 /**
  * BlobsSidecar by block root (= hash_tree_root(SignedBeaconBlockAndBlobsSidecar.beacon_block.message))
@@ -9,7 +10,8 @@ import {deneb, ssz} from "@lodestar/types";
  */
 export class BlobsSidecarRepository extends Repository<Uint8Array, deneb.BlobsSidecar> {
   constructor(config: ChainForkConfig, db: Db) {
-    super(config, db, Bucket.allForks_blobsSidecar, ssz.deneb.BlobsSidecar);
+    const bucket = Bucket.allForks_blobsSidecar;
+    super(config, db, bucket, ssz.deneb.BlobsSidecar, getBucketNameByValue(bucket));
   }
 
   /**

--- a/packages/beacon-node/src/db/repositories/blobsSidecarArchive.ts
+++ b/packages/beacon-node/src/db/repositories/blobsSidecarArchive.ts
@@ -1,7 +1,8 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Db, Repository, KeyValue, FilterOptions, Bucket} from "@lodestar/db";
+import {Db, Repository, KeyValue, FilterOptions} from "@lodestar/db";
 import {Slot, Root, ssz, deneb} from "@lodestar/types";
 import {bytesToInt} from "@lodestar/utils";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 export interface BlockFilterOptions extends FilterOptions<Slot> {
   step?: number;
@@ -18,7 +19,8 @@ export type BlockArchiveBatchPutBinaryItem = KeyValue<Slot, Uint8Array> & {
  */
 export class BlobsSidecarArchiveRepository extends Repository<Slot, deneb.BlobsSidecar> {
   constructor(config: ChainForkConfig, db: Db) {
-    super(config, db, Bucket.allForks_blobsSidecarArchive, ssz.deneb.BlobsSidecar);
+    const bucket = Bucket.allForks_blobsSidecarArchive;
+    super(config, db, bucket, ssz.deneb.BlobsSidecar, getBucketNameByValue(bucket));
   }
 
   // Handle key as slot

--- a/packages/beacon-node/src/db/repositories/block.ts
+++ b/packages/beacon-node/src/db/repositories/block.ts
@@ -1,7 +1,8 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Bucket, Db, Repository} from "@lodestar/db";
+import {Db, Repository} from "@lodestar/db";
 import {allForks, ssz} from "@lodestar/types";
 import {getSignedBlockTypeFromBytes} from "../../util/multifork.js";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 /**
  * Blocks by root
@@ -10,8 +11,9 @@ import {getSignedBlockTypeFromBytes} from "../../util/multifork.js";
  */
 export class BlockRepository extends Repository<Uint8Array, allForks.SignedBeaconBlock> {
   constructor(config: ChainForkConfig, db: Db) {
+    const bucket = Bucket.allForks_block;
     const type = ssz.phase0.SignedBeaconBlock; // Pick some type but won't be used
-    super(config, db, Bucket.allForks_block, type);
+    super(config, db, bucket, type, getBucketNameByValue(bucket));
   }
 
   /**

--- a/packages/beacon-node/src/db/repositories/blockArchive.ts
+++ b/packages/beacon-node/src/db/repositories/blockArchive.ts
@@ -1,9 +1,10 @@
 import all from "it-all";
 import {ChainForkConfig} from "@lodestar/config";
-import {Db, Repository, KeyValue, FilterOptions, Bucket} from "@lodestar/db";
+import {Db, Repository, KeyValue, FilterOptions} from "@lodestar/db";
 import {Slot, Root, allForks, ssz} from "@lodestar/types";
 import {bytesToInt} from "@lodestar/utils";
 import {getSignedBlockTypeFromBytes} from "../../util/multifork.js";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 import {getRootIndexKey, getParentRootIndexKey} from "./blockArchiveIndex.js";
 import {deleteParentRootIndex, deleteRootIndex, storeParentRootIndex, storeRootIndex} from "./blockArchiveIndex.js";
 
@@ -22,8 +23,9 @@ export type BlockArchiveBatchPutBinaryItem = KeyValue<Slot, Uint8Array> & {
  */
 export class BlockArchiveRepository extends Repository<Slot, allForks.SignedBeaconBlock> {
   constructor(config: ChainForkConfig, db: Db) {
+    const bucket = Bucket.allForks_blockArchive;
     const type = ssz.phase0.SignedBeaconBlock; // Pick some type but won't be used
-    super(config, db, Bucket.allForks_blockArchive, type);
+    super(config, db, bucket, type, getBucketNameByValue(bucket));
   }
 
   // Overrides for multi-fork

--- a/packages/beacon-node/src/db/repositories/blockArchiveIndex.ts
+++ b/packages/beacon-node/src/db/repositories/blockArchiveIndex.ts
@@ -1,6 +1,7 @@
-import {Db, encodeKey, Bucket} from "@lodestar/db";
+import {Db, encodeKey} from "@lodestar/db";
 import {Slot, Root, allForks, ssz} from "@lodestar/types";
 import {intToBytes} from "@lodestar/utils";
+import {Bucket} from "../buckets.js";
 
 export async function storeRootIndex(db: Db, slot: Slot, blockRoot: Root): Promise<void> {
   return db.put(getRootIndexKey(blockRoot), intToBytes(slot, 8, "be"));

--- a/packages/beacon-node/src/db/repositories/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/db/repositories/blsToExecutionChange.ts
@@ -1,11 +1,13 @@
 import {ValidatorIndex} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
-import {Db, Bucket, Repository} from "@lodestar/db";
+import {Db, Repository} from "@lodestar/db";
 import {SignedBLSToExecutionChangeVersioned, signedBLSToExecutionChangeVersionedType} from "../../util/types.js";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 export class BLSToExecutionChangeRepository extends Repository<ValidatorIndex, SignedBLSToExecutionChangeVersioned> {
   constructor(config: ChainForkConfig, db: Db) {
-    super(config, db, Bucket.capella_blsToExecutionChange, signedBLSToExecutionChangeVersionedType);
+    const bucket = Bucket.capella_blsToExecutionChange;
+    super(config, db, bucket, signedBLSToExecutionChangeVersionedType, getBucketNameByValue(bucket));
   }
 
   getId(value: SignedBLSToExecutionChangeVersioned): ValidatorIndex {

--- a/packages/beacon-node/src/db/repositories/depositDataRoot.ts
+++ b/packages/beacon-node/src/db/repositories/depositDataRoot.ts
@@ -2,7 +2,8 @@ import {ByteVectorType, CompositeViewDU, ListCompositeType} from "@chainsafe/ssz
 import {Root, ssz} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
 import {bytesToInt} from "@lodestar/utils";
-import {Db, Bucket, Repository, KeyValue} from "@lodestar/db";
+import {Db, Repository, KeyValue} from "@lodestar/db";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 // TODO: Review where is best to put this type
 export type DepositTree = CompositeViewDU<ListCompositeType<ByteVectorType>>;
@@ -11,7 +12,8 @@ export class DepositDataRootRepository extends Repository<number, Root> {
   private depositRootTree?: DepositTree;
 
   constructor(config: ChainForkConfig, db: Db) {
-    super(config, db, Bucket.index_depositDataRoot, ssz.Root);
+    const bucket = Bucket.index_depositDataRoot;
+    super(config, db, bucket, ssz.Root, getBucketNameByValue(bucket));
   }
 
   decodeKey(data: Buffer): number {

--- a/packages/beacon-node/src/db/repositories/depositEvent.ts
+++ b/packages/beacon-node/src/db/repositories/depositEvent.ts
@@ -1,6 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {phase0, ssz} from "@lodestar/types";
-import {Db, Bucket, Repository} from "@lodestar/db";
+import {Db, Repository} from "@lodestar/db";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 /**
  * DepositData indexed by deposit index
@@ -8,7 +9,8 @@ import {Db, Bucket, Repository} from "@lodestar/db";
  */
 export class DepositEventRepository extends Repository<number, phase0.DepositEvent> {
   constructor(config: ChainForkConfig, db: Db) {
-    super(config, db, Bucket.phase0_depositEvent, ssz.phase0.DepositEvent);
+    const bucket = Bucket.phase0_depositEvent;
+    super(config, db, bucket, ssz.phase0.DepositEvent, getBucketNameByValue(bucket));
   }
 
   async deleteOld(depositCount: number): Promise<void> {

--- a/packages/beacon-node/src/db/repositories/eth1Data.ts
+++ b/packages/beacon-node/src/db/repositories/eth1Data.ts
@@ -1,11 +1,13 @@
 import {phase0, ssz} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
 import {bytesToInt} from "@lodestar/utils";
-import {Db, Bucket, Repository} from "@lodestar/db";
+import {Db, Repository} from "@lodestar/db";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 export class Eth1DataRepository extends Repository<number, phase0.Eth1DataOrdered> {
   constructor(config: ChainForkConfig, db: Db) {
-    super(config, db, Bucket.phase0_eth1Data, ssz.phase0.Eth1DataOrdered);
+    const bucket = Bucket.phase0_eth1Data;
+    super(config, db, bucket, ssz.phase0.Eth1DataOrdered, getBucketNameByValue(bucket));
   }
 
   decodeKey(data: Buffer): number {

--- a/packages/beacon-node/src/db/repositories/lightclientBestUpdate.ts
+++ b/packages/beacon-node/src/db/repositories/lightclientBestUpdate.ts
@@ -1,6 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Bucket, DatabaseController, Repository} from "@lodestar/db";
+import {DatabaseController, Repository} from "@lodestar/db";
 import {ssz, SyncPeriod, allForks} from "@lodestar/types";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 const SLOT_BYTE_COUNT = 8;
 
@@ -12,7 +13,8 @@ const SLOT_BYTE_COUNT = 8;
 export class BestLightClientUpdateRepository extends Repository<SyncPeriod, allForks.LightClientUpdate> {
   constructor(config: ChainForkConfig, db: DatabaseController<Uint8Array, Uint8Array>) {
     // Pick some type but won't be used
-    super(config, db, Bucket.lightClient_bestLightClientUpdate, ssz.altair.LightClientUpdate);
+    const bucket = Bucket.lightClient_bestLightClientUpdate;
+    super(config, db, bucket, ssz.altair.LightClientUpdate, getBucketNameByValue(bucket));
   }
 
   // Overrides for multi-fork

--- a/packages/beacon-node/src/db/repositories/lightclientCheckpointHeader.ts
+++ b/packages/beacon-node/src/db/repositories/lightclientCheckpointHeader.ts
@@ -1,7 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Bucket, DatabaseController, Repository} from "@lodestar/db";
+import {DatabaseController, Repository} from "@lodestar/db";
 import {ssz, allForks} from "@lodestar/types";
-
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 import {getLightClientHeaderTypeFromBytes} from "../../util/multifork.js";
 
 /**
@@ -13,7 +13,8 @@ import {getLightClientHeaderTypeFromBytes} from "../../util/multifork.js";
 export class CheckpointHeaderRepository extends Repository<Uint8Array, allForks.LightClientHeader> {
   constructor(config: ChainForkConfig, db: DatabaseController<Uint8Array, Uint8Array>) {
     // Pick some type but won't be used
-    super(config, db, Bucket.lightClient_checkpointHeader, ssz.altair.LightClientHeader);
+    const bucket = Bucket.lightClient_checkpointHeader;
+    super(config, db, bucket, ssz.altair.LightClientHeader, getBucketNameByValue(bucket));
   }
 
   // Overrides for multi-fork

--- a/packages/beacon-node/src/db/repositories/lightclientSyncCommittee.ts
+++ b/packages/beacon-node/src/db/repositories/lightclientSyncCommittee.ts
@@ -1,6 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Bucket, DatabaseController, Repository} from "@lodestar/db";
+import {DatabaseController, Repository} from "@lodestar/db";
 import {altair, ssz} from "@lodestar/types";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 /**
  * Historical sync committees by SyncCommittee hash tree root
@@ -9,6 +10,7 @@ import {altair, ssz} from "@lodestar/types";
  */
 export class SyncCommitteeRepository extends Repository<Uint8Array, altair.SyncCommittee> {
   constructor(config: ChainForkConfig, db: DatabaseController<Uint8Array, Uint8Array>) {
-    super(config, db, Bucket.lightClient_syncCommittee, ssz.altair.SyncCommittee);
+    const bucket = Bucket.lightClient_syncCommittee;
+    super(config, db, bucket, ssz.altair.SyncCommittee, getBucketNameByValue(bucket));
   }
 }

--- a/packages/beacon-node/src/db/repositories/lightclientSyncCommitteeWitness.ts
+++ b/packages/beacon-node/src/db/repositories/lightclientSyncCommitteeWitness.ts
@@ -1,8 +1,9 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Bucket, DatabaseController, Repository} from "@lodestar/db";
+import {DatabaseController, Repository} from "@lodestar/db";
 import {ssz} from "@lodestar/types";
 import {ContainerType, VectorCompositeType} from "@chainsafe/ssz";
 import {SyncCommitteeWitness} from "../../chain/lightClient/types.js";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 /**
  * Historical sync committees witness by block root
@@ -11,12 +12,13 @@ import {SyncCommitteeWitness} from "../../chain/lightClient/types.js";
  */
 export class SyncCommitteeWitnessRepository extends Repository<Uint8Array, SyncCommitteeWitness> {
   constructor(config: ChainForkConfig, db: DatabaseController<Uint8Array, Uint8Array>) {
+    const bucket = Bucket.lightClient_syncCommitteeWitness;
     const type = new ContainerType({
       witness: new VectorCompositeType(ssz.Root, 4),
       currentSyncCommitteeRoot: ssz.Root,
       nextSyncCommitteeRoot: ssz.Root,
     });
 
-    super(config, db, Bucket.lightClient_syncCommitteeWitness, type);
+    super(config, db, bucket, type, getBucketNameByValue(bucket));
   }
 }

--- a/packages/beacon-node/src/db/repositories/proposerSlashing.ts
+++ b/packages/beacon-node/src/db/repositories/proposerSlashing.ts
@@ -1,10 +1,12 @@
 import {phase0, ssz, ValidatorIndex} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
-import {Db, Bucket, Repository} from "@lodestar/db";
+import {Db, Repository} from "@lodestar/db";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 export class ProposerSlashingRepository extends Repository<ValidatorIndex, phase0.ProposerSlashing> {
   constructor(config: ChainForkConfig, db: Db) {
-    super(config, db, Bucket.phase0_proposerSlashing, ssz.phase0.ProposerSlashing);
+    const bucket = Bucket.phase0_proposerSlashing;
+    super(config, db, bucket, ssz.phase0.ProposerSlashing, getBucketNameByValue(bucket));
   }
 
   getId(value: phase0.ProposerSlashing): ValidatorIndex {

--- a/packages/beacon-node/src/db/repositories/stateArchive.ts
+++ b/packages/beacon-node/src/db/repositories/stateArchive.ts
@@ -2,8 +2,9 @@ import {BeaconStateAllForks} from "@lodestar/state-transition";
 import {Epoch, Root, RootHex, Slot, ssz} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
 import {bytesToInt, toHex} from "@lodestar/utils";
-import {Db, Bucket, Repository} from "@lodestar/db";
+import {Db, Repository} from "@lodestar/db";
 import {getStateTypeFromBytes} from "../../util/multifork.js";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 import {getRootIndexKey, storeRootIndex} from "./stateArchiveIndex.js";
 
 export class StateArchiveRepository extends Repository<Slot, BeaconStateAllForks> {
@@ -11,7 +12,8 @@ export class StateArchiveRepository extends Repository<Slot, BeaconStateAllForks
     // Pick some type but won't be used. Casted to any because no type can match `BeaconStateAllForks`
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
     const type = ssz.phase0.BeaconState as any;
-    super(config, db, Bucket.allForks_stateArchive, type);
+    const bucket = Bucket.allForks_stateArchive;
+    super(config, db, bucket, type, getBucketNameByValue(bucket));
   }
 
   // Overrides for multi-fork

--- a/packages/beacon-node/src/db/repositories/stateArchiveIndex.ts
+++ b/packages/beacon-node/src/db/repositories/stateArchiveIndex.ts
@@ -1,6 +1,7 @@
-import {Bucket, encodeKey, Db} from "@lodestar/db";
+import {encodeKey, Db} from "@lodestar/db";
 import {Root, Slot} from "@lodestar/types";
 import {intToBytes} from "@lodestar/utils";
+import {Bucket} from "../buckets.js";
 
 export function storeRootIndex(db: Db, slot: Slot, stateRoot: Root): Promise<void> {
   return db.put(getRootIndexKey(stateRoot), intToBytes(slot, 8, "be"));

--- a/packages/beacon-node/src/db/repositories/voluntaryExit.ts
+++ b/packages/beacon-node/src/db/repositories/voluntaryExit.ts
@@ -1,10 +1,12 @@
 import {phase0, ssz, ValidatorIndex} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
-import {Db, Bucket, Repository} from "@lodestar/db";
+import {Db, Repository} from "@lodestar/db";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 export class VoluntaryExitRepository extends Repository<ValidatorIndex, phase0.SignedVoluntaryExit> {
   constructor(config: ChainForkConfig, db: Db) {
-    super(config, db, Bucket.phase0_exit, ssz.phase0.SignedVoluntaryExit);
+    const bucket = Bucket.phase0_exit;
+    super(config, db, bucket, ssz.phase0.SignedVoluntaryExit, getBucketNameByValue(bucket));
   }
 
   getId(value: phase0.SignedVoluntaryExit): ValidatorIndex {

--- a/packages/beacon-node/src/db/single/preGenesisState.ts
+++ b/packages/beacon-node/src/db/single/preGenesisState.ts
@@ -1,8 +1,9 @@
 import {GENESIS_SLOT} from "@lodestar/params";
 import {allForks} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
-import {Db, Bucket} from "@lodestar/db";
+import {Db} from "@lodestar/db";
 import {BeaconStateAllForks} from "@lodestar/state-transition";
+import {Bucket} from "../buckets.js";
 
 export class PreGenesisState {
   private readonly config: ChainForkConfig;

--- a/packages/beacon-node/src/db/single/preGenesisStateLastProcessedBlock.ts
+++ b/packages/beacon-node/src/db/single/preGenesisStateLastProcessedBlock.ts
@@ -1,7 +1,8 @@
 import {UintNumberType} from "@chainsafe/ssz";
 import {ssz} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
-import {Db, Bucket} from "@lodestar/db";
+import {Db} from "@lodestar/db";
+import {Bucket} from "../buckets.js";
 
 export class PreGenesisStateLastProcessedBlock {
   private readonly bucket: Bucket;

--- a/packages/beacon-node/test/unit/db/api/repositories/blockArchive.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repositories/blockArchive.test.ts
@@ -4,10 +4,11 @@ import sinon from "sinon";
 import {ssz} from "@lodestar/types";
 import {config} from "@lodestar/config/default";
 import {intToBytes} from "@lodestar/utils";
-import {LevelDbController, Bucket, encodeKey} from "@lodestar/db";
+import {LevelDbController, encodeKey} from "@lodestar/db";
 
 import {BlockArchiveRepository} from "../../../../../src/db/repositories/index.js";
 import {testLogger} from "../../../../utils/logger.js";
+import {Bucket} from "../../../../../src/db/buckets.js";
 
 describe("block archive repository", function () {
   const testDir = "./.tmp";

--- a/packages/beacon-node/test/unit/db/api/repository.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repository.test.ts
@@ -5,7 +5,8 @@ import all from "it-all";
 import {ContainerType} from "@chainsafe/ssz";
 import {Bytes32, ssz} from "@lodestar/types";
 import {config} from "@lodestar/config/default";
-import {Db, LevelDbController, Repository, Bucket} from "@lodestar/db";
+import {Db, LevelDbController, Repository} from "@lodestar/db";
+import {Bucket} from "../../../../src/db/buckets.js";
 
 interface TestType {
   bool: boolean;
@@ -20,7 +21,7 @@ const TestSSZType = new ContainerType({
 
 class TestRepository extends Repository<string, TestType> {
   constructor(db: Db) {
-    super(config, db, Bucket.phase0_depositEvent, TestSSZType);
+    super(config, db, Bucket.phase0_depositEvent, TestSSZType, "phase0_depositEvent");
   }
 }
 

--- a/packages/cli/test/unit/db.test.ts
+++ b/packages/cli/test/unit/db.test.ts
@@ -1,0 +1,15 @@
+import {Bucket as BeaconBucket} from "../../../beacon-node/src/db/buckets.js";
+import {Bucket as ValidatorBucket} from "../../../validator/src/buckets.js";
+
+describe("no db bucket overlap", () => {
+  it("beacon and validator dn buckets do not overlap", () => {
+    const beaconBucketValues = Object.values(BeaconBucket).filter(Number.isInteger) as number[];
+    const validatorBucketValues = Object.values(ValidatorBucket).filter(Number.isInteger) as number[];
+
+    for (const bucket of beaconBucketValues) {
+      if (validatorBucketValues.includes(bucket)) {
+        throw Error(`db bucket value ${bucket} present in both beacon and validator db schemas`);
+      }
+    }
+  });
+});

--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -3,8 +3,7 @@ import {Type} from "@chainsafe/ssz";
 import {BUCKET_LENGTH} from "./const.js";
 import {FilterOptions, KeyValue} from "./controller/index.js";
 import {Db, DbReqOpts} from "./controller/interface.js";
-import {Bucket, encodeKey as _encodeKey} from "./schema.js";
-import {getBucketNameByValue} from "./util.js";
+import {encodeKey as _encodeKey} from "./util.js";
 
 export type Id = Uint8Array | string | number | bigint;
 
@@ -17,26 +16,19 @@ export type Id = Uint8Array | string | number | bigint;
  * indexed by root
  */
 export abstract class Repository<I extends Id, T> {
-  protected config: ChainForkConfig;
-
-  protected db: Db;
-
-  protected bucket: Bucket;
-  private readonly bucketId: string;
   private readonly dbReqOpts: DbReqOpts;
 
   private readonly minKey: Uint8Array;
   private readonly maxKey: Uint8Array;
 
-  protected type: Type<T>;
-
-  protected constructor(config: ChainForkConfig, db: Db, bucket: Bucket, type: Type<T>) {
-    this.config = config;
-    this.db = db;
-    this.bucket = bucket;
-    this.bucketId = getBucketNameByValue(bucket);
+  protected constructor(
+    protected config: ChainForkConfig,
+    protected db: Db,
+    protected bucket: number,
+    protected type: Type<T>,
+    private readonly bucketId: string
+  ) {
     this.dbReqOpts = {bucketId: this.bucketId};
-    this.type = type;
     this.minKey = _encodeKey(bucket, Buffer.alloc(0));
     this.maxKey = _encodeKey(bucket + 1, Buffer.alloc(0));
   }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,6 +1,5 @@
 export * from "./databaseService.js";
 export * from "./abstractRepository.js";
 export * from "./controller/index.js";
-export * from "./schema.js";
 export * from "./const.js";
 export * from "./util.js";

--- a/packages/db/src/util.ts
+++ b/packages/db/src/util.ts
@@ -1,15 +1,26 @@
-import {Bucket} from "./schema.js";
+import {intToBytes} from "@lodestar/utils";
+import {BUCKET_LENGTH} from "./const.js";
 
-export function getBucketNameByValue<T extends Bucket>(enumValue: T): keyof typeof Bucket {
-  const keys = Object.keys(Bucket).filter((x) => {
-    if (isNaN(parseInt(x))) {
-      return Bucket[x as keyof typeof Bucket] == enumValue;
-    } else {
-      return false;
-    }
-  }) as (keyof typeof Bucket)[];
-  if (keys.length > 0) {
-    return keys[0];
+export const uintLen = 8;
+
+/**
+ * Prepend a bucket to a key
+ */
+export function encodeKey(bucket: number, key: Uint8Array | string | number | bigint): Uint8Array {
+  let buf;
+  const prefixLength = BUCKET_LENGTH;
+  //all keys are writen with prefixLength offet
+  if (typeof key === "string") {
+    buf = Buffer.alloc(key.length + prefixLength);
+    buf.write(key, prefixLength);
+  } else if (typeof key === "number" || typeof key === "bigint") {
+    buf = Buffer.alloc(uintLen + prefixLength);
+    intToBytes(BigInt(key), uintLen, "be").copy(buf, prefixLength);
+  } else {
+    buf = Buffer.alloc(key.length + prefixLength);
+    buf.set(key, prefixLength);
   }
-  throw new Error("Missing bucket for value " + enumValue);
+  //bucket prefix on position 0
+  buf.set(intToBytes(bucket, BUCKET_LENGTH, "le"), 0);
+  return buf;
 }

--- a/packages/db/test/unit/schema.test.ts
+++ b/packages/db/test/unit/schema.test.ts
@@ -1,21 +1,15 @@
 import {assert} from "chai";
 import {intToBytes} from "@lodestar/utils";
-import {Bucket, encodeKey} from "../../src/schema.js";
-import {BUCKET_LENGTH} from "../../src/index.js";
+import {BUCKET_LENGTH, encodeKey} from "../../src/index.js";
 
 describe("encodeKey", () => {
+  const bucket = 1;
   const testCases = [
-    {
-      input: {bucket: Bucket.allForks_block, key: Buffer.from([0, 0, 0, 1])},
-      type: "Buffer",
-    },
-    {
-      input: {bucket: Bucket.allForks_block, key: Buffer.from([0, 1, 0, 1])},
-      type: "Buffer",
-    },
-    {input: {bucket: Bucket.allForks_block, key: 5}, type: "number"},
-    {input: {bucket: Bucket.allForks_block, key: BigInt(5)}, type: "number"},
-    {input: {bucket: Bucket.allForks_block, key: "test"}, type: "string"},
+    {input: {bucket, key: Buffer.from([0, 0, 0, 1])}, type: "Buffer"},
+    {input: {bucket, key: Buffer.from([0, 1, 0, 1])}, type: "Buffer"},
+    {input: {bucket, key: 5}, type: "number"},
+    {input: {bucket, key: BigInt(5)}, type: "number"},
+    {input: {bucket, key: "test"}, type: "string"},
   ];
   for (const {
     input: {bucket, key},

--- a/packages/validator/src/buckets.ts
+++ b/packages/validator/src/buckets.ts
@@ -1,0 +1,30 @@
+// Buckets are separate database namespaces
+export enum Bucket {
+  // validator
+  // validator = 16, // DEPRECATED on v0.11.0
+  // lastProposedBlock = 17, // DEPRECATED on v0.11.0
+  // proposedAttestations = 18, // DEPRECATED on v0.11.0
+  // validator slashing protection
+  slashingProtectionBlockBySlot = 20,
+  slashingProtectionAttestationByTarget = 21,
+  slashingProtectionAttestationLowerBound = 22,
+  slashingProtectionMinSpanDistance = 23,
+  slashingProtectionMaxSpanDistance = 24,
+  // allForks_pendingBlock = 25, // Root -> SignedBeaconBlock // DEPRECATED on v0.30.0
+
+  validator_metaData = 41,
+}
+
+export function getBucketNameByValue<T extends Bucket>(enumValue: T): keyof typeof Bucket {
+  const keys = Object.keys(Bucket).filter((x) => {
+    if (isNaN(parseInt(x))) {
+      return Bucket[x as keyof typeof Bucket] == enumValue;
+    } else {
+      return false;
+    }
+  }) as (keyof typeof Bucket)[];
+  if (keys.length > 0) {
+    return keys[0];
+  }
+  throw new Error("Missing bucket for value " + enumValue);
+}

--- a/packages/validator/src/repositories/metaDataRepository.ts
+++ b/packages/validator/src/repositories/metaDataRepository.ts
@@ -1,7 +1,8 @@
-import {Bucket, encodeKey, DatabaseApiOptions, DbReqOpts, getBucketNameByValue} from "@lodestar/db";
+import {encodeKey, DatabaseApiOptions, DbReqOpts} from "@lodestar/db";
 import {Root, UintNum64} from "@lodestar/types";
 import {ssz} from "@lodestar/types";
 import {LodestarValidatorDatabaseController} from "../types.js";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 const GENESIS_VALIDATORS_ROOT = Buffer.from("GENESIS_VALIDATORS_ROOT");
 const GENESIS_TIME = Buffer.from("GENESIS_TIME");
@@ -13,12 +14,11 @@ export class MetaDataRepository {
   protected db: LodestarValidatorDatabaseController;
   protected bucket = Bucket.validator_metaData;
 
-  private readonly bucketId: string;
-  private readonly dbReqOpts: DbReqOpts;
+  private readonly bucketId = getBucketNameByValue(this.bucket);
+  private readonly dbReqOpts: DbReqOpts = {bucketId: this.bucketId};
 
   constructor(opts: DatabaseApiOptions) {
     this.db = opts.controller;
-    this.bucketId = getBucketNameByValue(this.bucket);
     this.dbReqOpts = {bucketId: this.bucketId};
   }
 

--- a/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
+++ b/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
@@ -1,18 +1,11 @@
 import {BLSPubkey, Epoch, ssz} from "@lodestar/types";
 import {intToBytes, bytesToInt} from "@lodestar/utils";
-import {
-  Bucket,
-  DatabaseApiOptions,
-  DB_PREFIX_LENGTH,
-  DbReqOpts,
-  encodeKey,
-  uintLen,
-  getBucketNameByValue,
-} from "@lodestar/db";
+import {DatabaseApiOptions, DB_PREFIX_LENGTH, DbReqOpts, encodeKey, uintLen} from "@lodestar/db";
 import {ContainerType, Type} from "@chainsafe/ssz";
 import {LodestarValidatorDatabaseController} from "../../types.js";
 import {SlashingProtectionAttestation} from "../types.js";
 import {blsPubkeyLen, uniqueVectorArr} from "../utils.js";
+import {Bucket, getBucketNameByValue} from "../../buckets.js";
 
 /**
  * Manages validator db storage of attestations.
@@ -22,11 +15,10 @@ import {blsPubkeyLen, uniqueVectorArr} from "../utils.js";
 export class AttestationByTargetRepository {
   protected type: Type<SlashingProtectionAttestation>;
   protected db: LodestarValidatorDatabaseController;
-  protected bucket = Bucket.phase0_slashingProtectionAttestationByTarget;
+  protected bucket = Bucket.slashingProtectionAttestationByTarget;
 
-  private readonly bucketId: string;
-  private readonly dbReqOpts: DbReqOpts;
-
+  private readonly bucketId = getBucketNameByValue(this.bucket);
+  private readonly dbReqOpts: DbReqOpts = {bucketId: this.bucketId};
   private readonly minKey: Uint8Array;
   private readonly maxKey: Uint8Array;
 
@@ -37,8 +29,6 @@ export class AttestationByTargetRepository {
       targetEpoch: ssz.Epoch,
       signingRoot: ssz.Root,
     }); // casing doesn't matter
-    this.bucketId = getBucketNameByValue(this.bucket);
-    this.dbReqOpts = {bucketId: this.bucketId};
     this.minKey = encodeKey(this.bucket, Buffer.alloc(0));
     this.maxKey = encodeKey(this.bucket + 1, Buffer.alloc(0));
   }

--- a/packages/validator/src/slashingProtection/attestation/attestationLowerBoundRepository.ts
+++ b/packages/validator/src/slashingProtection/attestation/attestationLowerBoundRepository.ts
@@ -1,7 +1,8 @@
 import {BLSPubkey, Epoch, ssz} from "@lodestar/types";
-import {Bucket, encodeKey, DatabaseApiOptions, DbReqOpts, getBucketNameByValue} from "@lodestar/db";
+import {encodeKey, DatabaseApiOptions, DbReqOpts} from "@lodestar/db";
 import {ContainerType, Type} from "@chainsafe/ssz";
 import {LodestarValidatorDatabaseController} from "../../types.js";
+import {Bucket, getBucketNameByValue} from "../../buckets.js";
 
 // Only used locally here
 export interface SlashingProtectionLowerBound {
@@ -16,10 +17,10 @@ export interface SlashingProtectionLowerBound {
 export class AttestationLowerBoundRepository {
   protected type: Type<SlashingProtectionLowerBound>;
   protected db: LodestarValidatorDatabaseController;
-  protected bucket = Bucket.phase0_slashingProtectionAttestationLowerBound;
+  protected bucket = Bucket.slashingProtectionAttestationLowerBound;
 
-  private readonly bucketId: string;
-  private readonly dbReqOpts: DbReqOpts;
+  private readonly bucketId = getBucketNameByValue(this.bucket);
+  private readonly dbReqOpts: DbReqOpts = {bucketId: this.bucketId};
 
   constructor(opts: DatabaseApiOptions) {
     this.db = opts.controller;
@@ -27,7 +28,6 @@ export class AttestationLowerBoundRepository {
       minSourceEpoch: ssz.Epoch,
       minTargetEpoch: ssz.Epoch,
     }); // casing doesn't matter
-    this.bucketId = getBucketNameByValue(this.bucket);
     this.dbReqOpts = {bucketId: this.bucketId};
   }
 

--- a/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
+++ b/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
@@ -1,16 +1,9 @@
 import {BLSPubkey, Slot, ssz} from "@lodestar/types";
 import {intToBytes, bytesToInt} from "@lodestar/utils";
-import {
-  Bucket,
-  DatabaseApiOptions,
-  DB_PREFIX_LENGTH,
-  DbReqOpts,
-  encodeKey,
-  uintLen,
-  getBucketNameByValue,
-} from "@lodestar/db";
+import {DatabaseApiOptions, DB_PREFIX_LENGTH, DbReqOpts, encodeKey, uintLen} from "@lodestar/db";
 import {ContainerType, Type} from "@chainsafe/ssz";
 import {LodestarValidatorDatabaseController} from "../../types.js";
+import {Bucket, getBucketNameByValue} from "../../buckets.js";
 import {SlashingProtectionBlock} from "../types.js";
 import {blsPubkeyLen, uniqueVectorArr} from "../utils.js";
 
@@ -22,11 +15,10 @@ import {blsPubkeyLen, uniqueVectorArr} from "../utils.js";
 export class BlockBySlotRepository {
   protected type: Type<SlashingProtectionBlock>;
   protected db: LodestarValidatorDatabaseController;
-  protected bucket = Bucket.phase0_slashingProtectionBlockBySlot;
+  protected bucket = Bucket.slashingProtectionBlockBySlot;
 
-  private readonly bucketId: string;
-  private readonly dbReqOpts: DbReqOpts;
-
+  private readonly bucketId = getBucketNameByValue(this.bucket);
+  private readonly dbReqOpts: DbReqOpts = {bucketId: this.bucketId};
   private readonly minKey: Uint8Array;
   private readonly maxKey: Uint8Array;
 
@@ -36,8 +28,6 @@ export class BlockBySlotRepository {
       slot: ssz.Slot,
       signingRoot: ssz.Root,
     }); // casing doesn't matter
-    this.bucketId = getBucketNameByValue(this.bucket);
-    this.dbReqOpts = {bucketId: this.bucketId};
     this.minKey = encodeKey(this.bucket, Buffer.alloc(0));
     this.maxKey = encodeKey(this.bucket + 1, Buffer.alloc(0));
   }

--- a/packages/validator/src/slashingProtection/minMaxSurround/distanceStoreRepository.ts
+++ b/packages/validator/src/slashingProtection/minMaxSurround/distanceStoreRepository.ts
@@ -1,7 +1,8 @@
-import {Bucket, encodeKey, DatabaseApiOptions, DbReqOpts, getBucketNameByValue} from "@lodestar/db";
+import {encodeKey, DatabaseApiOptions, DbReqOpts} from "@lodestar/db";
 import {BLSPubkey, Epoch, ssz} from "@lodestar/types";
 import {intToBytes} from "@lodestar/utils";
 import {Type} from "@chainsafe/ssz";
+import {Bucket, getBucketNameByValue} from "../../buckets.js";
 import {LodestarValidatorDatabaseController} from "../../types.js";
 import {DistanceEntry, IDistanceStore} from "./interface.js";
 
@@ -13,8 +14,8 @@ export class DistanceStoreRepository implements IDistanceStore {
   maxSpan: SpanDistanceRepository;
 
   constructor(opts: DatabaseApiOptions) {
-    this.minSpan = new SpanDistanceRepository(opts, Bucket.index_slashingProtectionMinSpanDistance);
-    this.maxSpan = new SpanDistanceRepository(opts, Bucket.index_slashingProtectionMaxSpanDistance);
+    this.minSpan = new SpanDistanceRepository(opts, Bucket.slashingProtectionMinSpanDistance);
+    this.maxSpan = new SpanDistanceRepository(opts, Bucket.slashingProtectionMaxSpanDistance);
   }
 }
 
@@ -30,7 +31,7 @@ class SpanDistanceRepository {
     this.db = opts.controller;
     this.type = ssz.Epoch;
     this.bucket = bucket;
-    this.bucketId = getBucketNameByValue(this.bucket);
+    this.bucketId = getBucketNameByValue(bucket);
     this.dbReqOpts = {bucketId: this.bucketId};
   }
 


### PR DESCRIPTION
**Motivation**

DB Bucket entries are all defined in the db package. Some of these entries are used in the beacon node (lodestar package), some are used in the validator (validator package).
The db package should really only be used to define the abstract db logic, and doesn't need to know which buckets exist for all downstream db consumers.

- See https://github.com/ChainSafe/lodestar/issues/2820

**Description**

Move DB Bucket schema to consumer packages

Closes https://github.com/ChainSafe/lodestar/issues/2820
