### PR TITLE
chore: add rule @typescript-eslint/restrict-template-expressions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,6 +114,10 @@ module.exports = {
         allowAny: true,
       },
     ],
+    "@typescript-eslint/restrict-template-expressions": [
+      "error",
+      {allowNumber: true, allowBoolean: true, allowNullish: true, allowNever: true, allowRegExp: true},
+    ],
     "import/no-extraneous-dependencies": [
       "error",
       {

--- a/packages/api/test/utils/utils.ts
+++ b/packages/api/test/utils/utils.ts
@@ -15,7 +15,7 @@ export function getTestServer(): {baseUrl: string; server: FastifyInstance} {
 
   server.addHook("onError", (request, reply, error, done) => {
     // eslint-disable-next-line no-console
-    console.log(`onError: ${error}`);
+    console.log(`onError: ${error.toString()}`);
     done();
   });
 

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -87,14 +87,14 @@ export class RestApiServer {
     // Note: Must be an async method so fastify can continue the release lifecycle. Otherwise we must call done() or the request stalls
     server.addHook("onRequest", async (req, _res) => {
       const {operationId} = req.routeConfig as RouteConfig;
-      this.logger.debug(`Req ${req.id} ${req.ip} ${operationId}`);
+      this.logger.debug(`Req ${req.id as string} ${req.ip} ${operationId}`);
       metrics?.requests.inc({operationId});
     });
 
     // Log after response
     server.addHook("onResponse", async (req, res) => {
       const {operationId} = req.routeConfig as RouteConfig;
-      this.logger.debug(`Res ${req.id} ${operationId} - ${res.raw.statusCode}`);
+      this.logger.debug(`Res ${req.id as string} ${operationId} - ${res.raw.statusCode}`);
       metrics?.responseTime.observe({operationId}, res.getResponseTime() / 1000);
     });
 
@@ -107,9 +107,9 @@ export class RestApiServer {
       const {operationId} = req.routeConfig as RouteConfig;
 
       if (err instanceof ApiError) {
-        this.logger.warn(`Req ${req.id} ${operationId} failed`, {reason: err.message});
+        this.logger.warn(`Req ${req.id as string} ${operationId} failed`, {reason: err.message});
       } else {
-        this.logger.error(`Req ${req.id} ${operationId} error`, {}, err);
+        this.logger.error(`Req ${req.id as string} ${operationId} error`, {}, err);
       }
       metrics?.errors.inc({operationId});
     });

--- a/packages/beacon-node/src/chain/validation/blobsSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobsSidecar.ts
@@ -1,7 +1,7 @@
 import bls from "@chainsafe/bls";
 import {CoordType} from "@chainsafe/bls/types";
 import {deneb, Root, ssz} from "@lodestar/types";
-import {bytesToBigInt} from "@lodestar/utils";
+import {bytesToBigInt, toHex} from "@lodestar/utils";
 import {BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB} from "@lodestar/params";
 import {verifyKzgCommitmentsAgainstTransactions} from "@lodestar/state-transition";
 import {BlobsSidecarError, BlobsSidecarErrorCode} from "../errors/blobsSidecarError.js";
@@ -83,7 +83,9 @@ export function validateBlobsSidecar(
   // assert beacon_block_root == blobs_sidecar.beacon_block_root
   if (!byteArrayEquals(beaconBlockRoot, blobsSidecar.beaconBlockRoot)) {
     throw new Error(
-      `beacon block root mismatch. Block root: ${beaconBlockRoot}, Blob root ${blobsSidecar.beaconBlockRoot}`
+      `beacon block root mismatch. Block root: ${toHex(beaconBlockRoot)}, Blob root ${toHex(
+        blobsSidecar.beaconBlockRoot
+      )}`
     );
   }
 

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -87,7 +87,8 @@ export async function beaconBlocksMaybeBlobsByRange(
           blobsSidecars.length
         } lastMatchedSlot=${lastMatchedSlot}, pending blobsSidecars slots=${blobsSidecars
           .slice(blobSideCarIndex)
-          .map((blb) => blb.beaconBlockSlot)}`
+          .map((blb) => blb.beaconBlockSlot)
+          .join(",")}`
       );
     }
     return blockInputs;

--- a/packages/beacon-node/test/spec/utils/sszTestCaseParser.ts
+++ b/packages/beacon-node/test/spec/utils/sszTestCaseParser.ts
@@ -47,7 +47,7 @@ export function parseSszValidTestcase(dirpath: string, metaFilename: string): Va
   const metaStr = fs.readFileSync(path.join(dirpath, metaFilename), "utf8");
   const meta = jsyaml.load(metaStr) as {root: string};
   if (typeof meta.root !== "string") {
-    throw Error(`meta.root not a string: ${meta.root}\n${fs}`);
+    throw Error(`meta.root not a string: ${meta.root}\n${metaStr}`);
   }
 
   // The serialized value is stored in serialized.ssz_snappy

--- a/packages/beacon-node/test/unit/monitoring/remoteService.ts
+++ b/packages/beacon-node/test/unit/monitoring/remoteService.ts
@@ -69,7 +69,7 @@ function validateRequestData(data: ReceivedData): void {
       validateClientStats(data, SYSTEM_STATS_SCHEMA);
       break;
     default:
-      throw new Error(`Invalid process type "${data.process}"`);
+      throw new Error(`Invalid process type "${data.process as string}"`);
   }
 }
 

--- a/packages/beacon-node/test/unit/monitoring/remoteService.ts
+++ b/packages/beacon-node/test/unit/monitoring/remoteService.ts
@@ -6,7 +6,7 @@ import {BEACON_NODE_STATS_SCHEMA, ClientStatsSchema, SYSTEM_STATS_SCHEMA, VALIDA
 
 /* eslint-disable no-console */
 
-type ReceivedData = Record<string, unknown>;
+type ReceivedData = Record<string, unknown> & {process: ProcessType};
 
 export const remoteServiceRoutes = {
   success: "/success",
@@ -69,7 +69,7 @@ function validateRequestData(data: ReceivedData): void {
       validateClientStats(data, SYSTEM_STATS_SCHEMA);
       break;
     default:
-      throw new Error(`Invalid process type "${data.process as string}"`);
+      throw new Error(`Invalid process type "${data.process}"`);
   }
 }
 

--- a/packages/beacon-node/test/unit/network/fork.test.ts
+++ b/packages/beacon-node/test/unit/network/fork.test.ts
@@ -143,7 +143,7 @@ for (const testScenario of testScenarios) {
       it(` on epoch ${epoch} should return ${JSON.stringify({
         currentFork,
         nextFork,
-      })}, getActiveForks: ${activeForks}`, () => {
+      })}, getActiveForks: ${activeForks.join(",")}`, () => {
         expect(getCurrentAndNextFork(forkConfig, epoch)).to.deep.equal({
           currentFork: forks[currentFork as ForkName],
           nextFork: (nextFork && forks[nextFork as ForkName]) ?? undefined,

--- a/packages/beacon-node/test/utils/node/validator.ts
+++ b/packages/beacon-node/test/utils/node/validator.ts
@@ -86,8 +86,8 @@ export async function getAndInitDevValidators({
 }
 
 export function getApiFromServerHandlers(api: {[K in keyof Api]: ServerApi<Api[K]>}): Api {
-  return mapValues(api, (module) =>
-    mapValues(module, (api: APIServerHandler) => {
+  return mapValues(api, (apiModule) =>
+    mapValues(apiModule, (api: APIServerHandler) => {
       return async (...args: any) => {
         let code: HttpStatusCode = HttpStatusCode.OK;
         try {
@@ -110,7 +110,7 @@ export function getApiFromServerHandlers(api: {[K in keyof Api]: ServerApi<Api[K
             error: {
               code: code ?? HttpStatusCode.INTERNAL_SERVER_ERROR,
               message: (err as Error).message,
-              operationId: `${module}.${api.name}`,
+              operationId: api.name,
             },
           };
         }

--- a/packages/cli/test/sim/deneb.test.ts
+++ b/packages/cli/test/sim/deneb.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import path from "node:path";
 import {activePreset} from "@lodestar/params";
-import {toHexString} from "@lodestar/utils";
+import {toHex, toHexString} from "@lodestar/utils";
 import {ApiError} from "@lodestar/api";
 import {nodeAssertion} from "../utils/simulation/assertions/nodeAssertion.js";
 import {CLIQUE_SEALING_PERIOD, SIM_TESTS_SECONDS_PER_SLOT} from "../utils/simulation/constants.js";
@@ -89,7 +89,7 @@ const checkpointSync = await env.createNodePair({
   id: "checkpoint-sync-node",
   cl: {
     type: CLClient.Lodestar,
-    options: {clientOptions: {wssCheckpoint: `${headForCheckpointSync.root}:${headForCheckpointSync.epoch}`}},
+    options: {clientOptions: {wssCheckpoint: `${toHex(headForCheckpointSync.root)}:${headForCheckpointSync.epoch}`}},
   },
   el: ELClient.Geth,
   keysCount: 0,

--- a/packages/cli/test/sim/multi_fork.test.ts
+++ b/packages/cli/test/sim/multi_fork.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import path from "node:path";
-import {sleep, toHexString} from "@lodestar/utils";
+import {sleep, toHex, toHexString} from "@lodestar/utils";
 import {ApiError} from "@lodestar/api";
 import {CLIQUE_SEALING_PERIOD, SIM_TESTS_SECONDS_PER_SLOT} from "../utils/simulation/constants.js";
 import {AssertionMatch, CLClient, ELClient} from "../utils/simulation/interfaces.js";
@@ -116,7 +116,7 @@ const checkpointSync = await env.createNodePair({
   id: "checkpoint-sync-node",
   cl: {
     type: CLClient.Lodestar,
-    options: {clientOptions: {wssCheckpoint: `${headForCheckpointSync.root}:${headForCheckpointSync.epoch}`}},
+    options: {clientOptions: {wssCheckpoint: `${toHex(headForCheckpointSync.root)}:${headForCheckpointSync.epoch}`}},
   },
   el: ELClient.Geth,
   keysCount: 0,

--- a/packages/cli/test/utils/simulation/TableReporter.ts
+++ b/packages/cli/test/utils/simulation/TableReporter.ts
@@ -139,7 +139,7 @@ export class TableReporter extends SimulationReporter<typeof defaultAssertions> 
         for (const error of assertionErrors) {
           console.info(
             `├──── ${error.nodeId}: ${error.message} ${Object.entries(error.data ?? {})
-              .map(([k, v]) => `${k}=${v}`)
+              .map(([k, v]) => `${k}=${v as string}`)
               .join(" ")}`
           );
         }

--- a/packages/config/src/chainConfig/json.ts
+++ b/packages/config/src/chainConfig/json.ts
@@ -52,7 +52,7 @@ export function serializeSpecValue(value: SpecValue, typeName: SpecValueTypeName
   switch (typeName) {
     case "number":
       if (typeof value !== "number") {
-        throw Error(`Invalid value ${value} expected number`);
+        throw Error(`Invalid value ${value.toString()} expected number`);
       }
       if (value === Infinity) {
         return MAX_UINT64_JSON;
@@ -61,19 +61,19 @@ export function serializeSpecValue(value: SpecValue, typeName: SpecValueTypeName
 
     case "bigint":
       if (typeof value !== "bigint") {
-        throw Error(`Invalid value ${value} expected bigint`);
+        throw Error(`Invalid value ${value.toString()} expected bigint`);
       }
       return value.toString(10);
 
     case "bytes":
       if (!(value instanceof Uint8Array)) {
-        throw Error(`Invalid value ${value} expected Uint8Array`);
+        throw Error(`Invalid value ${value.toString()} expected Uint8Array`);
       }
       return toHexString(value);
 
     case "string":
       if (typeof value !== "string") {
-        throw Error(`Invalid value ${value} expected string`);
+        throw Error(`Invalid value ${value.toString()} expected string`);
       }
       return value;
   }
@@ -81,7 +81,7 @@ export function serializeSpecValue(value: SpecValue, typeName: SpecValueTypeName
 
 export function deserializeSpecValue(valueStr: unknown, typeName: SpecValueTypeName, keyName: string): SpecValue {
   if (typeof valueStr !== "string") {
-    throw Error(`Invalid ${keyName} value ${valueStr} expected string`);
+    throw Error(`Invalid ${keyName} value ${valueStr as string} expected string`);
   }
 
   switch (typeName) {

--- a/packages/logger/test/unit/logger.test.ts
+++ b/packages/logger/test/unit/logger.test.ts
@@ -52,7 +52,9 @@ describe("shouldDeleteLogFile", function () {
   ];
 
   for (const {logFile, maxFiles, result} of tcs) {
-    it(`should ${result ? "" : "not"} delete ${logFile}, maxFiles ${maxFiles}, today ${new Date()}`, () => {
+    it(`should ${
+      result ? "" : "not"
+    } delete ${logFile}, maxFiles ${maxFiles}, today ${new Date().toUTCString()}`, () => {
       expect(shouldDeleteLogFile(prefix, extension, logFile, maxFiles)).to.be.equal(result);
     });
   }

--- a/packages/params/src/json.ts
+++ b/packages/params/src/json.ts
@@ -45,7 +45,7 @@ export function presetFromJson(json: Record<string, unknown>): Partial<BeaconPre
  */
 function deserializePresetValue(valueStr: unknown, keyName: string): number {
   if (typeof valueStr !== "string") {
-    throw Error(`Invalid ${keyName} value ${valueStr} expected string`);
+    throw Error(`Invalid ${keyName} value ${valueStr as string} expected string`);
   }
 
   const value = parseInt(valueStr, 10);

--- a/packages/prover/test/unit/verified_requests/eth_call.test.ts
+++ b/packages/prover/test/unit/verified_requests/eth_call.test.ts
@@ -36,7 +36,7 @@ describe("verified_requests / eth_call", () => {
         // Temper the responses to make them invalid
         for (const tx of testCase.dependentRequests) {
           if (tx.payload.method === "eth_getCode") {
-            tx.response.result = `${tx.response.result}12`;
+            tx.response.result = `${tx.response.result as string}12`;
           }
         }
 

--- a/packages/prover/test/unit/verified_requests/eth_estimateGas.test.ts
+++ b/packages/prover/test/unit/verified_requests/eth_estimateGas.test.ts
@@ -37,7 +37,7 @@ describe("verified_requests / eth_estimateGas", () => {
         // Temper the responses to make them invalid
         for (const tx of testCase.dependentRequests) {
           if (tx.payload.method === "eth_getCode") {
-            tx.response.result = `${tx.response.result}12`;
+            tx.response.result = `${tx.response.result as string}12`;
           }
         }
 

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -77,7 +77,7 @@ export async function downloadGenericSpecTests<TestNames extends string>(
             timeout: 30 * 60 * 1000,
           });
 
-          const totalSize = headers["content-length"];
+          const totalSize = headers["content-length"] as string;
           log(`Downloading ${url} - ${totalSize} bytes`);
 
           // extract tar into output directory

--- a/packages/spec-test-util/src/sszGeneric.ts
+++ b/packages/spec-test-util/src/sszGeneric.ts
@@ -17,7 +17,7 @@ export function parseSszValidTestcase(dirpath: string, metaFilename: string): Va
   const metaStr = fs.readFileSync(path.join(dirpath, metaFilename), "utf8");
   const meta = loadYaml(metaStr) as {root: string};
   if (typeof meta.root !== "string") {
-    throw Error(`meta.root not a string: ${meta.root}\n${fs}`);
+    throw Error(`meta.root not a string: ${meta.root}\n${metaStr}`);
   }
 
   // The serialized value is stored in serialized.ssz_snappy

--- a/packages/utils/src/assert.ts
+++ b/packages/utils/src/assert.ts
@@ -16,6 +16,7 @@ export const assert = {
    */
   equal<T>(actual: T, expected: T, message?: string): void {
     if (!(actual === expected)) {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       throw new AssertionError(`${message || "Expected values to be equal"}: ${actual} === ${expected}`);
     }
   },


### PR DESCRIPTION
**Motivation**

We have had many instances of attempting to log data in bad formats, this rule prevents such errors

- See https://github.com/ChainSafe/lodestar/issues/4650

**Description**

Closes https://github.com/ChainSafe/lodestar/issues/4650
