### PR TITLE
ci: assert eslintrc rules are sorted

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,30 +18,21 @@ module.exports = {
   plugins: ["@typescript-eslint", "eslint-plugin-import", "@chainsafe/eslint-plugin-node", "prettier"],
   extends: [
     "eslint:recommended",
-    "plugin:import/errors",
-    "plugin:import/warnings",
-    "plugin:import/typescript",
     "plugin:@typescript-eslint/recommended",
+    "plugin:import/errors",
+    "plugin:import/typescript",
+    "plugin:import/warnings",
   ],
   rules: {
-    "prettier/prettier": "error",
-    //doesnt work, it reports false errors
-    "constructor-super": "off",
-    "import/order": [
-      "error",
-      {
-        groups: ["builtin", "external", "internal", "parent", "sibling", "index"],
-        pathGroups: [
-          {
-            pattern: "@lodestar/**",
-            group: "internal",
-          },
-        ],
-        pathGroupsExcludedImportTypes: ["builtin"],
-      },
-    ],
+    "@chainsafe/node/file-extension-in-import": ["error", "always", {esm: true}],
+    "@chainsafe/node/no-deprecated-api": "error",
     "@typescript-eslint/await-thenable": "error",
-    "@typescript-eslint/return-await": "error",
+    "@typescript-eslint/ban-ts-comment": "error",
+    "@typescript-eslint/explicit-function-return-type": ["error", {allowExpressions: true}],
+    "@typescript-eslint/explicit-member-accessibility": ["error", {accessibility: "no-public"}],
+    "@typescript-eslint/func-call-spacing": "error",
+    // TODO after upgrading es-lint, member-ordering is now leading to lint errors. Set to warning now and fix in another PR
+    "@typescript-eslint/member-ordering": "off",
     "@typescript-eslint/naming-convention": [
       "error",
       {selector: "default", format: ["camelCase"]},
@@ -71,80 +62,60 @@ module.exports = {
         modifiers: ["requiresQuotes"],
       },
       //ignore rules on destructured params
-      {
-        selector: "variable",
-        modifiers: ["destructured"],
-        format: null,
-      },
+      {selector: "variable", modifiers: ["destructured"], format: null},
     ],
-    "@typescript-eslint/explicit-function-return-type": [
-      "error",
-      {
-        allowExpressions: true,
-      },
-    ],
-    "@typescript-eslint/func-call-spacing": "error",
-    // TODO after upgrading es-lint, member-ordering is now leading to lint errors. Set to warning now and fix in another PR
-    "@typescript-eslint/member-ordering": "off",
     "@typescript-eslint/no-explicit-any": "error",
-    "@typescript-eslint/no-require-imports": "error",
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      {
-        varsIgnorePattern: "^_",
-        argsIgnorePattern: "^_",
-      },
-    ],
-    "@typescript-eslint/ban-ts-comment": "error",
-    "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/semi": "error",
-    "@typescript-eslint/type-annotation-spacing": "error",
     "@typescript-eslint/no-floating-promises": "error",
-    "@typescript-eslint/explicit-member-accessibility": ["error", {accessibility: "no-public"}],
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/no-require-imports": "error",
     "@typescript-eslint/no-unsafe-assignment": "error",
     "@typescript-eslint/no-unsafe-call": "error",
     "@typescript-eslint/no-unsafe-member-access": "error",
     "@typescript-eslint/no-unsafe-return": "error",
-    "@typescript-eslint/no-non-null-assertion": "error",
-    "@typescript-eslint/strict-boolean-expressions": [
-      "error",
-      {
-        allowNullableBoolean: true,
-        allowNullableString: true,
-        allowAny: true,
-      },
-    ],
+    "@typescript-eslint/no-unused-vars": ["error", {varsIgnorePattern: "^_", argsIgnorePattern: "^_"}],
+    "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/restrict-template-expressions": [
       "error",
       {allowNumber: true, allowBoolean: true, allowNullish: true, allowNever: true, allowRegExp: true},
     ],
-    "import/no-extraneous-dependencies": [
+    "@typescript-eslint/return-await": "error",
+    "@typescript-eslint/semi": "error",
+    "@typescript-eslint/strict-boolean-expressions": [
       "error",
-      {
-        devDependencies: false,
-        optionalDependencies: false,
-        peerDependencies: false,
-      },
+      {allowNullableBoolean: true, allowNullableString: true, allowAny: true},
     ],
+
+    "@typescript-eslint/type-annotation-spacing": "error",
+    "constructor-super": "off",
     "func-call-spacing": "off",
+    // Force to add names to all functions to ease CPU profiling
+    "func-names": ["error", "always"],
     //if --fix is run it messes imports like /lib/presets/minimal & /lib/presets/mainnet
     "import/no-duplicates": "off",
+    "import/no-extraneous-dependencies": [
+      "error",
+      {devDependencies: false, optionalDependencies: false, peerDependencies: false},
+    ],
     "import/no-relative-packages": "error",
-    "@chainsafe/node/no-deprecated-api": "error",
+    // TEMP Disabled while eslint-plugin-import support ESM (Typescript does support it) https://github.com/import-js/eslint-plugin-import/issues/2170
+    "import/no-unresolved": "off",
+    "import/order": [
+      "error",
+      {
+        groups: ["builtin", "external", "internal", "parent", "sibling", "index"],
+        pathGroups: [{pattern: "@lodestar/**", group: "internal"}],
+        pathGroupsExcludedImportTypes: ["builtin"],
+      },
+    ],
+    //doesnt work, it reports false errors
     "new-parens": "error",
-    "no-loss-of-precision": "error",
-    "no-caller": "error",
     "no-bitwise": "off",
+    "no-caller": "error",
     "no-cond-assign": "error",
     "no-consecutive-blank-lines": 0,
     "no-console": "error",
-    "no-var": "error",
-    "object-curly-spacing": ["error", "never"],
-    "object-literal-sort-keys": 0,
+    "no-loss-of-precision": "error",
     "no-prototype-builtins": 0,
-    "prefer-const": "error",
-    quotes: ["error", "double"],
-    semi: "off",
     "no-restricted-imports": [
       "error",
       {
@@ -167,16 +138,15 @@ module.exports = {
       },
     ],
     "no-restricted-syntax": ["error", ...restrictImportDestructuring("node:fs", "node:os", "node:path")],
-    // Force to add names to all functions to ease CPU profiling
-    "func-names": ["error", "always"],
-
-    // TEMP Disabled while eslint-plugin-import support ESM (Typescript does support it) https://github.com/import-js/eslint-plugin-import/issues/2170
-    "import/no-unresolved": "off",
-
     // superseded by @typescript-eslint/return-await, must be disabled as it can report incorrect errors
     "no-return-await": "off",
-
-    "@chainsafe/node/file-extension-in-import": ["error", "always", {esm: true}],
+    "no-var": "error",
+    "object-curly-spacing": ["error", "never"],
+    "object-literal-sort-keys": 0,
+    "prefer-const": "error",
+    "prettier/prettier": "error",
+    quotes: ["error", "double"],
+    semi: "off",
   },
   settings: {
     "import/internal-regex": "^@chainsafe/",
@@ -197,25 +167,25 @@ module.exports = {
     {
       files: ["**/*.config.js", "**/*.config.mjs", "**/*.config.cjs", "**/*.config.ts"],
       rules: {
+        "@typescript-eslint/naming-convention": "off",
+        // Allow require in CJS modules
+        "@typescript-eslint/no-require-imports": "off",
+        // Allow require in CJS modules
+        "@typescript-eslint/no-var-requires": "off",
         // Allow importing packages from dev dependencies
         "import/no-extraneous-dependencies": "off",
         // Allow importing and mixing different configurations
         "import/no-relative-packages": "off",
-        "@typescript-eslint/naming-convention": "off",
-        // Allow require in CJS modules
-        "@typescript-eslint/no-var-requires": "off",
-        // Allow require in CJS modules
-        "@typescript-eslint/no-require-imports": "off",
       },
     },
     {
       files: ["**/test/**/*.ts"],
       rules: {
+        "@typescript-eslint/no-explicit-any": "off",
+        "func-names": "off",
         "import/no-extraneous-dependencies": "off",
         // Turned off as it floods log with warnings. Underlying issue is not critical so switching off is acceptable
         "import/no-named-as-default-member": "off",
-        "@typescript-eslint/no-explicit-any": "off",
-        "func-names": "off",
       },
     },
     {
@@ -223,6 +193,13 @@ module.exports = {
       plugins: ["mocha", "chai-expect"],
       extends: ["plugin:mocha/recommended", "plugin:chai-expect/recommended"],
       rules: {
+        // We observed that having multiple top level "describe" save valuable indentation
+        // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/max-top-level-suites.md
+        "mocha/max-top-level-suites": "off",
+        // We need to disable because we disabled "mocha/no-setup-in-describe" rule
+        // TODO: Move all setup code to before/beforeEach and then disable async describe
+        // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-async-describe.md
+        "mocha/no-async-describe": "off",
         // Use of arrow functions are very common
         "mocha/no-mocha-arrows": "off",
         // It's common to call function inside describe block
@@ -231,13 +208,6 @@ module.exports = {
         // We use to split before in small isolated tasks
         // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-sibling-hooks.md
         "mocha/no-sibling-hooks": "off",
-        // We need to disable because we disabled "mocha/no-setup-in-describe" rule
-        // TODO: Move all setup code to before/beforeEach and then disable async describe
-        // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-async-describe.md
-        "mocha/no-async-describe": "off",
-        // We observed that having multiple top level "describe" save valuable indentation
-        // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/max-top-level-suites.md
-        "mocha/max-top-level-suites": "off",
       },
     },
     {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,8 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       - name: Assert ESM module exports
         run: node scripts/assert_exports.mjs
+      - name: Assert eslintrc rules sorted
+        run: scripts/assert_eslintrc_sorted.mjs
 
       - name: Check Types
         run: yarn run check-types

--- a/scripts/assert_eslintrc_sorted.mjs
+++ b/scripts/assert_eslintrc_sorted.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import assert from "node:assert";
+import eslintrc from "../.eslintrc.js";
+
+assertSorted(eslintrc.extends, ".extends");
+assertSorted(Object.keys(eslintrc.rules), ".rules");
+for (const overrides of eslintrc.overrides) {
+  assertSorted(Object.keys(overrides.rules), `.overrides ${overrides.files.join(",")}`);
+}
+
+/** @param {string[]} keys @param {string} id */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function assertSorted(keys, id) {
+  try {
+    assert.deepStrictEqual(keys, [...keys].sort());
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(`Lint error in ${id}\n\n`, e.message);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
**Motivation**

- Minimize diff for rule addition, to ease efforts like https://github.com/ChainSafe/lodestar/issues/5566

**Description**

Add CI step to ensure eslintrc rules are sorted
