### PR TITLE
feat: skip serializing block after fetching from network

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -218,12 +218,14 @@ export function getBeaconBlockApi({
             config,
             signedBlock,
             signedBlobs.map((sblob) => sblob.message)
-          )
+          ),
+          null
         );
       } else {
         signedBlock = signedBlockOrContents;
         signedBlobs = [];
-        blockForImport = getBlockInput.preDeneb(config, signedBlock, BlockSource.api);
+        // TODO: Once API supports submitting data as SSZ, replace null with blockBytes
+        blockForImport = getBlockInput.preDeneb(config, signedBlock, BlockSource.api, null);
       }
 
       // Simple implementation of a pending block queue. Keeping the block here recycles the API logic, and keeps the

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -1,4 +1,4 @@
-import {WithOptionalBytes, allForks} from "@lodestar/types";
+import {allForks} from "@lodestar/types";
 import {toHex, isErrorAborted} from "@lodestar/utils";
 import {JobItemQueue, isQueueErrorAborted} from "../../util/queue/index.js";
 import {Metrics} from "../../metrics/metrics.js";
@@ -19,10 +19,10 @@ const QUEUE_MAX_LENGTH = 256;
  * BlockProcessor processes block jobs in a queued fashion, one after the other.
  */
 export class BlockProcessor {
-  readonly jobQueue: JobItemQueue<[WithOptionalBytes<BlockInput>[], ImportBlockOpts], void>;
+  readonly jobQueue: JobItemQueue<[BlockInput[], ImportBlockOpts], void>;
 
   constructor(chain: BeaconChain, metrics: Metrics | null, opts: BlockProcessOpts, signal: AbortSignal) {
-    this.jobQueue = new JobItemQueue<[WithOptionalBytes<BlockInput>[], ImportBlockOpts], void>(
+    this.jobQueue = new JobItemQueue<[BlockInput[], ImportBlockOpts], void>(
       (job, importOpts) => {
         return processBlocks.call(chain, job, {...opts, ...importOpts});
       },
@@ -31,7 +31,7 @@ export class BlockProcessor {
     );
   }
 
-  async processBlocksJob(job: WithOptionalBytes<BlockInput>[], opts: ImportBlockOpts = {}): Promise<void> {
+  async processBlocksJob(job: BlockInput[], opts: ImportBlockOpts = {}): Promise<void> {
     await this.jobQueue.push(job, opts);
   }
 }
@@ -48,7 +48,7 @@ export class BlockProcessor {
  */
 export async function processBlocks(
   this: BeaconChain,
-  blocks: WithOptionalBytes<BlockInput>[],
+  blocks: BlockInput[],
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<void> {
   if (blocks.length === 0) {

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -4,7 +4,7 @@ import {
   isStateValidatorsNodesPopulated,
   DataAvailableStatus,
 } from "@lodestar/state-transition";
-import {WithOptionalBytes, bellatrix} from "@lodestar/types";
+import {bellatrix} from "@lodestar/types";
 import {ForkName} from "@lodestar/params";
 import {toHexString} from "@chainsafe/ssz";
 import {ProtoBlock} from "@lodestar/fork-choice";
@@ -37,7 +37,7 @@ import {writeBlockInputToDb} from "./writeBlockInputToDb.js";
 export async function verifyBlocksInEpoch(
   this: BeaconChain,
   parentBlock: ProtoBlock,
-  blocksInput: WithOptionalBytes<BlockInput>[],
+  blocksInput: BlockInput[],
   dataAvailabilityStatuses: DataAvailableStatus[],
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<{

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSanityChecks.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSanityChecks.ts
@@ -1,7 +1,7 @@
 import {computeStartSlotAtEpoch, DataAvailableStatus} from "@lodestar/state-transition";
 import {ChainForkConfig} from "@lodestar/config";
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
-import {Slot, deneb, WithOptionalBytes} from "@lodestar/types";
+import {Slot, deneb} from "@lodestar/types";
 import {toHexString} from "@lodestar/utils";
 import {IClock} from "../../util/clock.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
@@ -22,10 +22,10 @@ import {BlockInput, BlockInputType, ImportBlockOpts} from "./types.js";
  */
 export function verifyBlocksSanityChecks(
   chain: {forkChoice: IForkChoice; clock: IClock; config: ChainForkConfig},
-  blocks: WithOptionalBytes<BlockInput>[],
+  blocks: BlockInput[],
   opts: ImportBlockOpts
 ): {
-  relevantBlocks: WithOptionalBytes<BlockInput>[];
+  relevantBlocks: BlockInput[];
   dataAvailabilityStatuses: DataAvailableStatus[];
   parentSlots: Slot[];
   parentBlock: ProtoBlock | null;
@@ -34,7 +34,7 @@ export function verifyBlocksSanityChecks(
     throw Error("Empty partiallyVerifiedBlocks");
   }
 
-  const relevantBlocks: WithOptionalBytes<BlockInput>[] = [];
+  const relevantBlocks: BlockInput[] = [];
   const dataAvailabilityStatuses: DataAvailableStatus[] = [];
   const parentSlots: Slot[] = [];
   let parentBlock: ProtoBlock | null = null;

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -23,7 +23,6 @@ import {
   ValidatorIndex,
   deneb,
   Wei,
-  WithOptionalBytes,
   bellatrix,
 } from "@lodestar/types";
 import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
@@ -558,11 +557,11 @@ export class BeaconChain implements IBeaconChain {
     return blobSidecars;
   }
 
-  async processBlock(block: WithOptionalBytes<BlockInput>, opts?: ImportBlockOpts): Promise<void> {
+  async processBlock(block: BlockInput, opts?: ImportBlockOpts): Promise<void> {
     return this.blockProcessor.processBlocksJob([block], opts);
   }
 
-  async processChainSegment(blocks: WithOptionalBytes<BlockInput>[], opts?: ImportBlockOpts): Promise<void> {
+  async processChainSegment(blocks: BlockInput[], opts?: ImportBlockOpts): Promise<void> {
     return this.blockProcessor.processBlocksJob(blocks, opts);
   }
 

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -1,16 +1,4 @@
-import {
-  allForks,
-  UintNum64,
-  Root,
-  phase0,
-  Slot,
-  RootHex,
-  Epoch,
-  ValidatorIndex,
-  deneb,
-  Wei,
-  WithOptionalBytes,
-} from "@lodestar/types";
+import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch, ValidatorIndex, deneb, Wei} from "@lodestar/types";
 import {
   BeaconStateAllForks,
   CachedBeaconStateAllForks,
@@ -152,9 +140,9 @@ export interface IBeaconChain {
   produceBlindedBlock(blockAttributes: BlockAttributes): Promise<{block: allForks.BlindedBeaconBlock; blockValue: Wei}>;
 
   /** Process a block until complete */
-  processBlock(block: WithOptionalBytes<BlockInput>, opts?: ImportBlockOpts): Promise<void>;
+  processBlock(block: BlockInput, opts?: ImportBlockOpts): Promise<void>;
   /** Process a chain of blocks until complete */
-  processChainSegment(blocks: WithOptionalBytes<BlockInput>[], opts?: ImportBlockOpts): Promise<void>;
+  processChainSegment(blocks: BlockInput[], opts?: ImportBlockOpts): Promise<void>;
 
   getStatus(): phase0.Status;
 

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -10,6 +10,8 @@ import {GossipType} from "./gossip/interface.js";
 import {PendingGossipsubMessage} from "./processor/types.js";
 import {PeerAction} from "./peers/index.js";
 
+export type WithBytes<T> = {data: T; bytes: Uint8Array};
+
 /**
  * The architecture of the network looks like so:
  * - core:
@@ -34,11 +36,11 @@ export interface INetwork extends INetworkCorePublic {
   sendBeaconBlocksByRange(
     peerId: PeerIdStr,
     request: phase0.BeaconBlocksByRangeRequest
-  ): Promise<allForks.SignedBeaconBlock[]>;
+  ): Promise<WithBytes<allForks.SignedBeaconBlock>[]>;
   sendBeaconBlocksByRoot(
     peerId: PeerIdStr,
     request: phase0.BeaconBlocksByRootRequest
-  ): Promise<allForks.SignedBeaconBlock[]>;
+  ): Promise<WithBytes<allForks.SignedBeaconBlock>[]>;
   sendBlobSidecarsByRange(peerId: PeerIdStr, request: deneb.BlobSidecarsByRangeRequest): Promise<deneb.BlobSidecar[]>;
   sendBlobSidecarsByRoot(peerId: PeerIdStr, request: deneb.BlobSidecarsByRootRequest): Promise<deneb.BlobSidecar[]>;
 

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -15,7 +15,7 @@ import {IBeaconDb} from "../db/interface.js";
 import {PeerIdStr, peerIdToString} from "../util/peerId.js";
 import {IClock} from "../util/clock.js";
 import {NetworkOptions} from "./options.js";
-import {INetwork} from "./interface.js";
+import {WithBytes, INetwork} from "./interface.js";
 import {ReqRespMethod} from "./reqresp/index.js";
 import {GossipHandlers, GossipTopicMap, GossipType, GossipTypeMap} from "./gossip/index.js";
 import {PeerAction, PeerScoreStats} from "./peers/index.js";
@@ -24,7 +24,11 @@ import {CommitteeSubscription} from "./subnets/index.js";
 import {isPublishToZeroPeersError} from "./util.js";
 import {NetworkProcessor, PendingGossipsubMessage} from "./processor/index.js";
 import {INetworkCore, NetworkCore, WorkerNetworkCore} from "./core/index.js";
-import {collectExactOneTyped, collectMaxResponseTyped} from "./reqresp/utils/collect.js";
+import {
+  collectExactOneTyped,
+  collectMaxResponseTyped,
+  collectMaxResponseTypedWithBytes,
+} from "./reqresp/utils/collect.js";
 import {GetReqRespHandlerFn, Version, requestSszTypeByMethod, responseSszTypeByMethod} from "./reqresp/types.js";
 import {collectSequentialBlocksInRange} from "./reqresp/utils/collectSequentialBlocksInRange.js";
 import {getGossipSSZType, gossipTopicIgnoreDuplicatePublishError, stringifyGossipTopic} from "./gossip/topic.js";
@@ -396,7 +400,7 @@ export class Network implements INetwork {
   async sendBeaconBlocksByRange(
     peerId: PeerIdStr,
     request: phase0.BeaconBlocksByRangeRequest
-  ): Promise<allForks.SignedBeaconBlock[]> {
+  ): Promise<WithBytes<allForks.SignedBeaconBlock>[]> {
     return collectSequentialBlocksInRange(
       this.sendReqRespRequest(
         peerId,
@@ -412,8 +416,8 @@ export class Network implements INetwork {
   async sendBeaconBlocksByRoot(
     peerId: PeerIdStr,
     request: phase0.BeaconBlocksByRootRequest
-  ): Promise<allForks.SignedBeaconBlock[]> {
-    return collectMaxResponseTyped(
+  ): Promise<WithBytes<allForks.SignedBeaconBlock>[]> {
+    return collectMaxResponseTypedWithBytes(
       this.sendReqRespRequest(
         peerId,
         ReqRespMethod.BeaconBlocksByRoot,

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1,7 +1,7 @@
 import {toHexString} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
 import {Logger, prettyBytes} from "@lodestar/utils";
-import {Root, Slot, ssz, WithBytes} from "@lodestar/types";
+import {Root, Slot, ssz} from "@lodestar/types";
 import {ForkName, ForkSeq} from "@lodestar/params";
 import {Metrics} from "../../metrics/index.js";
 import {OpSource} from "../../metrics/validatorMonitor.js";
@@ -125,11 +125,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
     }
   }
 
-  function handleValidBeaconBlock(
-    blockInput: WithBytes<BlockInput>,
-    peerIdStr: string,
-    seenTimestampSec: number
-  ): void {
+  function handleValidBeaconBlock(blockInput: BlockInput, peerIdStr: string, seenTimestampSec: number): void {
     const signedBlock = blockInput.block;
 
     // Handler - MUST NOT `await`, to allow validation result to be propagated
@@ -185,9 +181,9 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
         throw new GossipActionError(GossipAction.REJECT, {code: "POST_DENEB_BLOCK"});
       }
 
-      const blockInput = getBlockInput.preDeneb(config, signedBlock, BlockSource.gossip);
+      const blockInput = getBlockInput.preDeneb(config, signedBlock, BlockSource.gossip, serializedData);
       await validateBeaconBlock(blockInput, topic.fork, peerIdStr, seenTimestampSec);
-      handleValidBeaconBlock({...blockInput, serializedData}, peerIdStr, seenTimestampSec);
+      handleValidBeaconBlock(blockInput, peerIdStr, seenTimestampSec);
     },
 
     [GossipType.blob_sidecar]: async (_data, _topic, _peerIdStr, _seenTimestampSec) => {
@@ -203,10 +199,11 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       }
 
       // Validate block + blob. Then forward, then handle both
-      const blockInput = getBlockInput.postDeneb(config, beaconBlock, BlockSource.gossip, blobsSidecar);
+      // TODO DENEB: replace null with proper binary data for block and blobs separately
+      const blockInput = getBlockInput.postDeneb(config, beaconBlock, BlockSource.gossip, blobsSidecar, null);
       await validateBeaconBlock(blockInput, topic.fork, peerIdStr, seenTimestampSec);
       validateGossipBlobsSidecar(beaconBlock, blobsSidecar);
-      handleValidBeaconBlock({...blockInput, serializedData}, peerIdStr, seenTimestampSec);
+      handleValidBeaconBlock(blockInput, peerIdStr, seenTimestampSec);
     },
 
     [GossipType.beacon_aggregate_and_proof]: async ({serializedData}, topic, _peer, seenTimestampSec) => {

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -18,8 +18,8 @@ export async function beaconBlocksMaybeBlobsByRoot(
   const blobIdentifiers: deneb.BlobIdentifier[] = [];
 
   for (const block of allBlocks) {
-    const blockRoot = config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
-    const blobKzgCommitmentsLen = (block.message.body as deneb.BeaconBlockBody).blobKzgCommitments?.length ?? 0;
+    const blockRoot = config.getForkTypes(block.data.message.slot).BeaconBlock.hashTreeRoot(block.data.message);
+    const blobKzgCommitmentsLen = (block.data.message.body as deneb.BeaconBlockBody).blobKzgCommitments?.length ?? 0;
     for (let index = 0; index < blobKzgCommitmentsLen; index++) {
       blobIdentifiers.push({blockRoot, index});
     }

--- a/packages/beacon-node/src/network/reqresp/utils/collectSequentialBlocksInRange.ts
+++ b/packages/beacon-node/src/network/reqresp/utils/collectSequentialBlocksInRange.ts
@@ -1,6 +1,7 @@
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {allForks, phase0} from "@lodestar/types";
 import {LodestarError} from "@lodestar/utils";
+import {WithBytes} from "../../interface.js";
 import {ReqRespMethod, responseSszTypeByMethod} from "../types.js";
 import {sszDeserializeResponse} from "./collect.js";
 
@@ -11,8 +12,8 @@ import {sszDeserializeResponse} from "./collect.js";
 export async function collectSequentialBlocksInRange(
   blockStream: AsyncIterable<ResponseIncoming>,
   {count, startSlot}: Pick<phase0.BeaconBlocksByRangeRequest, "count" | "startSlot">
-): Promise<allForks.SignedBeaconBlock[]> {
-  const blocks: allForks.SignedBeaconBlock[] = [];
+): Promise<WithBytes<allForks.SignedBeaconBlock>[]> {
+  const blocks: WithBytes<allForks.SignedBeaconBlock>[] = [];
 
   for await (const chunk of blockStream) {
     const blockType = responseSszTypeByMethod[ReqRespMethod.BeaconBlocksByRange](chunk.fork, chunk.protocolVersion);
@@ -31,12 +32,12 @@ export async function collectSequentialBlocksInRange(
 
     const prevBlock = blocks.length === 0 ? null : blocks[blocks.length - 1];
     if (prevBlock) {
-      if (prevBlock.message.slot >= blockSlot) {
+      if (prevBlock.data.message.slot >= blockSlot) {
         throw new BlocksByRangeError({code: BlocksByRangeErrorCode.BAD_SEQUENCE});
       }
     }
 
-    blocks.push(block);
+    blocks.push({data: block, bytes: chunk.data});
     if (blocks.length >= count) {
       break; // Done, collected all blocks
     }

--- a/packages/beacon-node/src/sync/backfill/verify.ts
+++ b/packages/beacon-node/src/sync/backfill/verify.ts
@@ -3,6 +3,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {allForks, Root, allForks as allForkTypes, ssz, Slot} from "@lodestar/types";
 import {GENESIS_SLOT} from "@lodestar/params";
 import {IBlsVerifier} from "../../chain/bls/index.js";
+import {WithBytes} from "../../network/interface.js";
 import {BackfillSyncError, BackfillSyncErrorCode} from "./errors.js";
 
 export type BackfillBlockHeader = {
@@ -14,19 +15,19 @@ export type BackfillBlock = BackfillBlockHeader & {block: allForks.SignedBeaconB
 
 export function verifyBlockSequence(
   config: BeaconConfig,
-  blocks: allForkTypes.SignedBeaconBlock[],
+  blocks: WithBytes<allForkTypes.SignedBeaconBlock>[],
   anchorRoot: Root
 ): {
   nextAnchor: BackfillBlock | null;
-  verifiedBlocks: allForkTypes.SignedBeaconBlock[];
+  verifiedBlocks: WithBytes<allForkTypes.SignedBeaconBlock>[];
   error?: BackfillSyncErrorCode.NOT_LINEAR;
 } {
   let nextRoot: Root = anchorRoot;
   let nextAnchor: BackfillBlock | null = null;
 
-  const verifiedBlocks: allForkTypes.SignedBeaconBlock[] = [];
+  const verifiedBlocks: WithBytes<allForkTypes.SignedBeaconBlock>[] = [];
   for (const block of blocks.reverse()) {
-    const blockRoot = config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
+    const blockRoot = config.getForkTypes(block.data.message.slot).BeaconBlock.hashTreeRoot(block.data.message);
     if (!ssz.Root.equals(blockRoot, nextRoot)) {
       if (ssz.Root.equals(nextRoot, anchorRoot)) {
         throw new BackfillSyncError({code: BackfillSyncErrorCode.NOT_ANCHORED});
@@ -34,8 +35,8 @@ export function verifyBlockSequence(
       return {nextAnchor, verifiedBlocks, error: BackfillSyncErrorCode.NOT_LINEAR};
     }
     verifiedBlocks.push(block);
-    nextAnchor = {block, slot: block.message.slot, root: nextRoot};
-    nextRoot = block.message.parentRoot;
+    nextAnchor = {block: block.data, slot: block.data.message.slot, root: nextRoot};
+    nextRoot = block.data.message.parentRoot;
   }
   return {nextAnchor, verifiedBlocks};
 }
@@ -43,12 +44,12 @@ export function verifyBlockSequence(
 export async function verifyBlockProposerSignature(
   bls: IBlsVerifier,
   state: CachedBeaconStateAllForks,
-  blocks: allForkTypes.SignedBeaconBlock[]
+  blocks: WithBytes<allForkTypes.SignedBeaconBlock>[]
 ): Promise<void> {
-  if (blocks.length === 1 && blocks[0].message.slot === GENESIS_SLOT) return;
+  if (blocks.length === 1 && blocks[0].data.message.slot === GENESIS_SLOT) return;
   const signatures = blocks.reduce((sigs: ISignatureSet[], block) => {
     // genesis block doesn't have valid signature
-    if (block.message.slot !== GENESIS_SLOT) sigs.push(getBlockProposerSignatureSet(state, block));
+    if (block.data.message.slot !== GENESIS_SLOT) sigs.push(getBlockProposerSignatureSet(state, block.data));
     return sigs;
   }, []);
 

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -84,6 +84,7 @@ describe("data serialization through worker boundary", function () {
         type: BlockInputType.preDeneb,
         block: ssz.capella.SignedBeaconBlock.defaultValue(),
         source: BlockSource.gossip,
+        blockBytes: ZERO_HASH,
       },
       peer,
     },

--- a/packages/beacon-node/test/e2e/network/reqresp.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqresp.test.ts
@@ -144,7 +144,10 @@ function runTests(this: Mocha.Suite, {useWorker}: {useWorker: boolean}): void {
     expect(returnedBlocks).to.have.length(req.count, "Wrong returnedBlocks length");
 
     for (const [i, returnedBlock] of returnedBlocks.entries()) {
-      expect(ssz.phase0.SignedBeaconBlock.equals(returnedBlock, blocks[i])).to.equal(true, `Wrong returnedBlock[${i}]`);
+      expect(ssz.phase0.SignedBeaconBlock.equals(returnedBlock.data, blocks[i])).to.equal(
+        true,
+        `Wrong returnedBlock[${i}]`
+      );
     }
   });
 

--- a/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
@@ -117,7 +117,7 @@ describe("sync / unknown block sync", function () {
       );
 
       await connect(bn2.network, bn.network);
-      const headInput = getBlockInput.preDeneb(config, head, BlockSource.gossip);
+      const headInput = getBlockInput.preDeneb(config, head, BlockSource.gossip, null);
 
       switch (event) {
         case NetworkEvent.unknownBlockParent:

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -107,7 +107,7 @@ describe.skip("verify+import blocks - range sync perf test", () => {
     },
     fn: async (chain) => {
       const blocksImport = blocks.value.map((block) =>
-        getBlockInput.preDeneb(chain.config, block, BlockSource.byRange)
+        getBlockInput.preDeneb(chain.config, block, BlockSource.byRange, null)
       );
 
       await chain.processChainSegment(blocksImport, {

--- a/packages/beacon-node/test/spec/presets/fork_choice.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.ts
@@ -157,12 +157,13 @@ export const forkChoiceTest =
 
               const blockImport =
                 config.getForkSeq(slot) < ForkSeq.deneb
-                  ? getBlockInput.preDeneb(config, signedBlock, BlockSource.gossip)
+                  ? getBlockInput.preDeneb(config, signedBlock, BlockSource.gossip, null)
                   : getBlockInput.postDeneb(
                       config,
                       signedBlock,
                       BlockSource.gossip,
-                      getEmptyBlobsSidecar(config, signedBlock as deneb.SignedBeaconBlock)
+                      getEmptyBlobsSidecar(config, signedBlock as deneb.SignedBeaconBlock),
+                      null
                     );
 
               try {

--- a/packages/beacon-node/test/unit/chain/blocks/verifyBlocksSanityChecks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyBlocksSanityChecks.test.ts
@@ -127,7 +127,7 @@ function verifyBlocksSanityChecks(
 ): {relevantBlocks: allForks.SignedBeaconBlock[]; parentSlots: Slot[]; parentBlock: ProtoBlock | null} {
   const {relevantBlocks, parentSlots, parentBlock} = verifyBlocksImportSanityChecks(
     modules,
-    blocks.map((block) => getBlockInput.preDeneb(config, block, BlockSource.byRange)),
+    blocks.map((block) => getBlockInput.preDeneb(config, block, BlockSource.byRange, null)),
     opts
   );
   return {

--- a/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
@@ -4,7 +4,7 @@ import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lo
 import {BYTES_PER_FIELD_ELEMENT} from "@lodestar/params";
 
 import {beaconBlocksMaybeBlobsByRange} from "../../../src/network/reqresp/index.js";
-import {BlockInputType, BlockSource, blobSidecarsToBlobsSidecar} from "../../../src/chain/blocks/types.js";
+import {BlockInput, BlockInputType, BlockSource, blobSidecarsToBlobsSidecar} from "../../../src/chain/blocks/types.js";
 import {ckzg, initCKZG, loadEthereumTrustedSetup, FIELD_ELEMENTS_PER_BLOB_MAINNET} from "../../../src/util/kzg.js";
 import {INetwork} from "../../../src/network/interface.js";
 import {ZERO_HASH} from "../../../src/constants/constants.js";
@@ -89,7 +89,7 @@ describe("beaconBlocksMaybeBlobsByRange", () => {
         .filter((blobs) => blobs !== undefined)
         .reduce((acc, elem) => acc.concat(elem), []);
 
-      const expectedResponse = blocksWithBlobs.map(([block, blobSidecars]) => {
+      const expectedResponse: BlockInput[] = blocksWithBlobs.map(([block, blobSidecars]) => {
         const blobs = (blobSidecars !== undefined ? blobSidecars : []).map((bscar) => {
           // TODO DENEB: cleanup the following generation as its not required to generate
           // proper field elements for the aggregate proofs compute
@@ -104,11 +104,16 @@ describe("beaconBlocksMaybeBlobsByRange", () => {
           source: BlockSource.byRange,
           // TODO DENEB: Cleanup the conversion once migration complete
           blobs: blobSidecarsToBlobsSidecar(chainConfig, block, blobs),
+          blockBytes: null,
         };
       });
 
       const network = {
-        sendBeaconBlocksByRange: async () => blocks.map((data) => ({data, bytes: ZERO_HASH})),
+        sendBeaconBlocksByRange: async () =>
+          blocks.map((data) => ({
+            data,
+            bytes: ZERO_HASH,
+          })),
         sendBlobSidecarsByRange: async () => blobSidecars,
       } as Partial<INetwork> as INetwork;
 

--- a/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
@@ -7,6 +7,7 @@ import {beaconBlocksMaybeBlobsByRange} from "../../../src/network/reqresp/index.
 import {BlockInputType, BlockSource, blobSidecarsToBlobsSidecar} from "../../../src/chain/blocks/types.js";
 import {ckzg, initCKZG, loadEthereumTrustedSetup, FIELD_ELEMENTS_PER_BLOB_MAINNET} from "../../../src/util/kzg.js";
 import {INetwork} from "../../../src/network/interface.js";
+import {ZERO_HASH} from "../../../src/constants/constants.js";
 
 describe("beaconBlocksMaybeBlobsByRange", () => {
   before(async function () {
@@ -107,7 +108,7 @@ describe("beaconBlocksMaybeBlobsByRange", () => {
       });
 
       const network = {
-        sendBeaconBlocksByRange: async () => blocks,
+        sendBeaconBlocksByRange: async () => blocks.map((data) => ({data, bytes: ZERO_HASH})),
         sendBlobSidecarsByRange: async () => blobSidecars,
       } as Partial<INetwork> as INetwork;
 

--- a/packages/beacon-node/test/unit/sync/backfill/verify.test.ts
+++ b/packages/beacon-node/test/unit/sync/backfill/verify.test.ts
@@ -6,6 +6,8 @@ import {createBeaconConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
 import {phase0, ssz} from "@lodestar/types";
 import {verifyBlockSequence} from "../../../../src/sync/backfill/verify.js";
+import {WithBytes} from "../../../../src/network/interface.js";
+import {ZERO_HASH} from "../../../../src/constants/constants.js";
 import {BackfillSyncErrorCode, BackfillSyncError} from "./../../../../src/sync/backfill/errors.js";
 
 // Global variable __dirname no longer available in ES6 modules.
@@ -23,7 +25,7 @@ describe("backfill sync - verify block sequence", function () {
   it("should verify valid chain of blocks", function () {
     const blocks = getBlocks();
 
-    expect(() => verifyBlockSequence(beaconConfig, blocks.slice(0, 2), blocks[2].message.parentRoot)).to.not.throw;
+    expect(() => verifyBlockSequence(beaconConfig, blocks.slice(0, 2), blocks[2].data.message.parentRoot)).to.not.throw;
   });
 
   it("should fail with sequence not anchored", function () {
@@ -41,18 +43,18 @@ describe("backfill sync - verify block sequence", function () {
       const {error} = verifyBlockSequence(
         beaconConfig,
         // remove middle block
-        blocks.filter((b) => b.message.slot !== 2).slice(0, blocks.length - 2),
-        blocks[blocks.length - 1].message.parentRoot
+        blocks.filter((b) => b.data.message.slot !== 2).slice(0, blocks.length - 2),
+        blocks[blocks.length - 1].data.message.parentRoot
       );
       if (error) throw new BackfillSyncError({code: error});
     }).to.throw(BackfillSyncErrorCode.NOT_LINEAR);
   });
 
   //first 4 mainnet blocks
-  function getBlocks(): phase0.SignedBeaconBlock[] {
+  function getBlocks(): WithBytes<phase0.SignedBeaconBlock>[] {
     const json = JSON.parse(fs.readFileSync(path.join(__dirname, "./blocks.json"), "utf-8")) as unknown[];
     return json.map((b) => {
-      return ssz.phase0.SignedBeaconBlock.fromJson(b);
+      return {data: ssz.phase0.SignedBeaconBlock.fromJson(b), bytes: ZERO_HASH};
     });
   }
 });

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -12,7 +12,7 @@ describe("sync / range / batch", async () => {
   const startEpoch = 0;
   const peer = validPeerIdStr;
   const blocksDownloaded = [
-    getBlockInput.preDeneb(config, ssz.phase0.SignedBeaconBlock.defaultValue(), BlockSource.byRange),
+    getBlockInput.preDeneb(config, ssz.phase0.SignedBeaconBlock.defaultValue(), BlockSource.byRange, null),
   ];
 
   it("Should return correct blockByRangeRequest", () => {

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -89,7 +89,8 @@ describe("sync / range / chain", () => {
                 message: generateEmptyBlock(i),
                 signature: shouldReject ? REJECT_BLOCK : ACCEPT_BLOCK,
               },
-              BlockSource.byRange
+              BlockSource.byRange,
+              null
             )
           );
         }
@@ -134,7 +135,8 @@ describe("sync / range / chain", () => {
               message: generateEmptyBlock(i),
               signature: ACCEPT_BLOCK,
             },
-            BlockSource.byRange
+            BlockSource.byRange,
+            null
           )
         );
       }

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -20,5 +20,3 @@ export enum ProducedBlockSource {
 
 export type SlotRootHex = {slot: Slot; root: RootHex};
 export type SlotOptionalRoot = {slot: Slot; root?: RootHex};
-export type WithBytes<T extends Record<string, unknown>> = T & {serializedData: Uint8Array};
-export type WithOptionalBytes<T extends Record<string, unknown>> = T & {serializedData?: Uint8Array};


### PR DESCRIPTION
**Motivation**

When we fetch blocks from network we don't need to re-serialize them again.

**Description**

Avoid the extra work of serialization by keeping a reference to the serialized payload as the block travels through the codepaths.

Generalizes @tuyennhv 's approach to apply not only to gossip but to all syncs, by modifying the BlockInput:

https://github.com/ChainSafe/lodestar/blob/1a5a578f4d32497ddbf09601652e643ffdc2b266/packages/beacon-node/src/chain/blocks/types.ts#L20-L22

Closes https://github.com/ChainSafe/lodestar/issues/3657
