### PR TITLE
feat: add forkchoice.hasBlockUnsafe()

### DIFF
--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -244,7 +244,9 @@ export class NetworkProcessor {
           this.isProcessingCurrentSlotBlock = true;
         }
         message.msgSlot = slot;
-        if (root && !this.chain.forkChoice.hasBlockHex(root)) {
+        // check if we processed a block with this root
+        // no need to check if root is a descendant of the current finalized block, it will be checked once we validate the message if needed
+        if (root && !this.chain.forkChoice.hasBlockHexUnsafe(root)) {
           this.searchUnknownSlotRoot({slot, root}, message.propagationSource.toString());
 
           if (this.unknownBlockGossipsubMessagesCount > MAX_QUEUED_UNKNOWN_BLOCK_GOSSIP_OBJECTS) {

--- a/packages/beacon-node/test/utils/mocks/chain/chain.ts
+++ b/packages/beacon-node/test/utils/mocks/chain/chain.ts
@@ -302,6 +302,8 @@ function mockForkChoice(): IForkChoice {
     getTime: () => 0,
     hasBlock: () => true,
     hasBlockHex: () => true,
+    hasBlockUnsafe: () => true,
+    hasBlockHexUnsafe: () => true,
     getSlotsPresent: () => 0,
     getBlock: () => block,
     getBlockHex: () => block,

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -585,6 +585,20 @@ export class ForkChoice implements IForkChoice {
   }
 
   /**
+   * Same to hasBlock but without checking if the block is a descendant of the finalized root.
+   */
+  hasBlockUnsafe(blockRoot: Root): boolean {
+    return this.hasBlockHexUnsafe(toHexString(blockRoot));
+  }
+
+  /**
+   * Same to hasBlockHex but without checking if the block is a descendant of the finalized root.
+   */
+  hasBlockHexUnsafe(blockRoot: RootHex): boolean {
+    return this.protoArray.hasBlock(blockRoot);
+  }
+
+  /**
    * Returns a `ProtoBlock` if the block is known **and** a descendant of the finalized root.
    */
   getBlockHex(blockRoot: RootHex): ProtoBlock | null {

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -137,6 +137,11 @@ export interface IForkChoice {
    */
   hasBlock(blockRoot: Root): boolean;
   hasBlockHex(blockRoot: RootHex): boolean;
+  /**
+   * Same to hasBlock, but without checking if the block is a descendant of the finalized root.
+   */
+  hasBlockUnsafe(blockRoot: Root): boolean;
+  hasBlockHexUnsafe(blockRoot: RootHex): boolean;
   getSlotsPresent(windowStart: number): number;
   /**
    * Returns a `ProtoBlock` if the block is known **and** a descendant of the finalized root.


### PR DESCRIPTION
**Motivation**

- hasBlockHex takes 12% of running cpu time in main thread (except for the idle time)

**Description**

- This comes from network processor where we want to quick check if block with root is processed (known by forkchoice)
- Add `hasBlockUnsafe & hasBlockHexUnsafe` to forkchoice, to be used when consumers do not need to check if root is a descendant of finalized root
- Network processor to call `forkchoice.hasBlockHexUnsafe()`, the descendant root check is still verified in gossip validation function, for example `validateGossipAttestation()`

Closes #5550
