### PR TITLE
chore: fix dashboard job name variables

### DIFF
--- a/dashboards/lodestar_block_production.json
+++ b/dashboards/lodestar_block_production.json
@@ -7,13 +7,6 @@
       "pluginId": "prometheus",
       "pluginName": "Prometheus",
       "type": "datasource"
-    },
-    {
-      "description": "",
-      "label": "Beacon node job name",
-      "name": "VAR_BEACON_JOB",
-      "type": "constant",
-      "value": "beacon"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_debug_gossipsub.json
+++ b/dashboards/lodestar_debug_gossipsub.json
@@ -7,13 +7,6 @@
       "pluginId": "prometheus",
       "pluginName": "Prometheus",
       "type": "datasource"
-    },
-    {
-      "description": "",
-      "label": "Beacon node job name",
-      "name": "VAR_BEACON_JOB",
-      "type": "constant",
-      "value": "beacon"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_discv5.json
+++ b/dashboards/lodestar_discv5.json
@@ -7,13 +7,6 @@
       "pluginId": "prometheus",
       "pluginName": "Prometheus",
       "type": "datasource"
-    },
-    {
-      "description": "",
-      "label": "Beacon node job name",
-      "name": "VAR_BEACON_JOB",
-      "type": "constant",
-      "value": "beacon"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_execution_engine.json
+++ b/dashboards/lodestar_execution_engine.json
@@ -7,13 +7,6 @@
       "pluginId": "prometheus",
       "pluginName": "Prometheus",
       "type": "datasource"
-    },
-    {
-      "description": "",
-      "label": "Beacon node job name",
-      "name": "VAR_BEACON_JOB",
-      "type": "constant",
-      "value": "beacon"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_multinode.json
+++ b/dashboards/lodestar_multinode.json
@@ -7,13 +7,6 @@
       "pluginId": "prometheus",
       "pluginName": "Prometheus",
       "type": "datasource"
-    },
-    {
-      "description": "",
-      "label": "Beacon node job name",
-      "name": "VAR_BEACON_JOB",
-      "type": "constant",
-      "value": "beacon"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_networking.json
+++ b/dashboards/lodestar_networking.json
@@ -7,13 +7,6 @@
       "pluginId": "prometheus",
       "pluginName": "Prometheus",
       "type": "datasource"
-    },
-    {
-      "description": "",
-      "label": "Beacon node job name",
-      "name": "VAR_BEACON_JOB",
-      "type": "constant",
-      "value": "beacon"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -12,14 +12,14 @@
       "name": "VAR_BEACON_JOB",
       "type": "constant",
       "label": "Beacon node job name",
-      "value": "${VAR_BEACON_JOB}",
+      "value": "beacon",
       "description": ""
     },
     {
       "name": "VAR_VALIDATOR_JOB",
       "type": "constant",
       "label": "Validator client job name",
-      "value": "${VAR_VALIDATOR_JOB}",
+      "value": "validator",
       "description": ""
     }
   ],

--- a/dashboards/lodestar_validator_client.json
+++ b/dashboards/lodestar_validator_client.json
@@ -9,11 +9,11 @@
       "type": "datasource"
     },
     {
-      "description": "",
-      "label": "Beacon node job name",
-      "name": "VAR_BEACON_JOB",
+      "name": "VAR_VALIDATOR_JOB",
       "type": "constant",
-      "value": "beacon"
+      "label": "Validator client job name",
+      "value": "validator",
+      "description": ""
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_validator_monitor.json
+++ b/dashboards/lodestar_validator_monitor.json
@@ -7,13 +7,6 @@
       "pluginId": "prometheus",
       "pluginName": "Prometheus",
       "type": "datasource"
-    },
-    {
-      "description": "",
-      "label": "Beacon node job name",
-      "name": "VAR_BEACON_JOB",
-      "type": "constant",
-      "value": "beacon"
     }
   ],
   "annotations": {

--- a/scripts/lint-grafana-dashboard.mjs
+++ b/scripts/lint-grafana-dashboard.mjs
@@ -97,13 +97,6 @@ export function lintGrafanaDashboard(json) {
         pluginName: "Prometheus",
         type: "datasource",
       },
-      {
-        description: "",
-        label: "Beacon node job name",
-        name: "VAR_BEACON_JOB",
-        type: "constant",
-        value: "beacon",
-      },
     ],
     ...json,
   };


### PR DESCRIPTION
**Motivation**

Job name variables are broken for some dashboards.

**Description**

- Remove job name variables on dashboards that do not use them
- Correctly set default values
- Update script to not set job name variable in `__inputs`

Follow up to
- https://github.com/ChainSafe/lodestar/pull/5525
- https://github.com/ChainSafe/lodestar/pull/5526
