### PR TITLE
feat: add reqresp TTFB metrics

### DIFF
--- a/packages/reqresp/src/ReqResp.ts
+++ b/packages/reqresp/src/ReqResp.ts
@@ -174,7 +174,7 @@ export class ReqResp {
 
     try {
       yield* sendRequest(
-        {logger: this.logger, libp2p: this.libp2p, peerClient},
+        {logger: this.logger, libp2p: this.libp2p, metrics: this.metrics, peerClient},
         peerId,
         protocols,
         protocolIDs,
@@ -218,6 +218,7 @@ export class ReqResp {
       try {
         await handleRequest({
           logger: this.logger,
+          metrics: this.metrics,
           stream,
           peerId,
           protocol: protocol as Protocol,

--- a/packages/reqresp/src/encoders/responseEncode.ts
+++ b/packages/reqresp/src/encoders/responseEncode.ts
@@ -13,10 +13,16 @@ import {RespStatus, RpcResponseStatusError} from "../interface.js";
  * Note: `response` has zero or more chunks (denoted by `<>*`)
  */
 export function responseEncodeSuccess(
-  protocol: Protocol
+  protocol: Protocol,
+  cbs: {onChunk: (chunkIndex: number) => void}
 ): (source: AsyncIterable<ResponseOutgoing>) => AsyncIterable<Buffer> {
   return async function* responseEncodeSuccessTransform(source) {
+    let chunkIndex = 0;
+
     for await (const chunk of source) {
+      // Postfix increment, return 0 as first chunk
+      cbs.onChunk(chunkIndex++);
+
       // <result>
       yield Buffer.from([RespStatus.SUCCESS]);
 

--- a/packages/reqresp/src/metrics.ts
+++ b/packages/reqresp/src/metrics.ts
@@ -74,7 +74,8 @@ export function getMetrics(register: MetricsRegister) {
       name: "beacon_reqresp_outgoing_request_roundtrip_time_seconds",
       help: "Histogram of outgoing requests round-trip time",
       labelNames: ["method"],
-      buckets: [0.1, 0.2, 0.5, 1, 5, 15, 60],
+      // Spec sets RESP_TIMEOUT = 10 sec
+      buckets: [0.1, 0.2, 0.5, 1, 5, 10, 15, 60],
     }),
     outgoingErrors: register.gauge<"method">({
       name: "beacon_reqresp_outgoing_requests_error_total",
@@ -90,12 +91,27 @@ export function getMetrics(register: MetricsRegister) {
       name: "beacon_reqresp_incoming_request_handler_time_seconds",
       help: "Histogram of incoming requests internal handling time",
       labelNames: ["method"],
-      buckets: [0.1, 0.2, 0.5, 1, 5],
+      // Spec sets RESP_TIMEOUT = 10 sec
+      buckets: [0.1, 0.2, 0.5, 1, 5, 10],
     }),
     incomingErrors: register.gauge<"method">({
       name: "beacon_reqresp_incoming_requests_error_total",
       help: "Counts total failed responses handled per method",
       labelNames: ["method"],
+    }),
+    outgoingResponseTTFB: register.histogram<"method">({
+      name: "beacon_reqresp_outgoing_response_ttfb_seconds",
+      help: "Time to first byte (TTFB) for outgoing responses",
+      labelNames: ["method"],
+      // Spec sets TTFB_TIMEOUT = 5 sec
+      buckets: [0.1, 1, 5],
+    }),
+    incomingResponseTTFB: register.histogram<"method">({
+      name: "beacon_reqresp_incoming_response_ttfb_seconds",
+      help: "Time to first byte (TTFB) for incoming responses",
+      labelNames: ["method"],
+      // Spec sets TTFB_TIMEOUT = 5 sec
+      buckets: [0.1, 1, 5],
     }),
     dialErrors: register.gauge({
       name: "beacon_reqresp_dial_errors_total",

--- a/packages/reqresp/test/unit/request/index.test.ts
+++ b/packages/reqresp/test/unit/request/index.test.ts
@@ -72,7 +72,7 @@ describe("request / sendRequest", () => {
 
       const responses = await pipe(
         sendRequest(
-          {logger, libp2p},
+          {logger, libp2p, metrics: null},
           peerId,
           protocols,
           protocols.map((p) => p.method),
@@ -144,7 +144,7 @@ describe("request / sendRequest", () => {
         await expectRejectedWithLodestarError(
           pipe(
             sendRequest(
-              {logger, libp2p},
+              {logger, libp2p, metrics: null},
               peerId,
               [emptyProtocol],
               [testMethod],

--- a/packages/reqresp/test/unit/response/index.test.ts
+++ b/packages/reqresp/test/unit/response/index.test.ts
@@ -61,6 +61,7 @@ describe("response / handleRequest", () => {
 
       const resultPromise = handleRequest({
         logger,
+        metrics: null,
         protocol,
         protocolID: protocol.method,
         stream,

--- a/packages/reqresp/test/utils/response.ts
+++ b/packages/reqresp/test/utils/response.ts
@@ -8,7 +8,11 @@ import {arrToSource} from "../utils/index.js";
 export async function* responseEncode(responseChunks: ResponseChunk[], protocol: Protocol): AsyncIterable<Buffer> {
   for (const chunk of responseChunks) {
     if (chunk.status === RespStatus.SUCCESS) {
-      yield* pipe(arrToSource([(chunk as SuccessResponseChunk).payload]), responseEncodeSuccess(protocol));
+      yield* pipe(
+        arrToSource([(chunk as SuccessResponseChunk).payload]),
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        responseEncodeSuccess(protocol, {onChunk: () => {}})
+      );
     } else {
       yield* responseEncodeError(protocol, chunk.status, chunk.errorMessage);
     }


### PR DESCRIPTION
**Motivation**

Add visibility into our own behaviour to debug bad peer scoring we are observing after switching libp2p to a worker.

**Description**

TTFB (Time to first byte) is a speced parameter that clients expect from responders, see https://github.com/ethereum/consensus-specs/blob/v1.2.0/specs/phase0/p2p-interface.md#configuration
