### PR TITLE
feat: add option to configure REST API server header limit

### DIFF
--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -14,6 +14,7 @@ export type RestApiServerOpts = {
   cors?: string;
   address?: string;
   bearerToken?: string;
+  headerLimit?: number;
   bodyLimit?: number;
 };
 
@@ -60,6 +61,7 @@ export class RestApiServer {
           parseArrays: false,
         }),
       bodyLimit: opts.bodyLimit,
+      http: {maxHeaderSize: opts.headerLimit},
     });
 
     this.activeSockets = new HttpActiveSocketsTracker(server.server, metrics);

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -193,6 +193,7 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
         port: args["keymanager.port"],
         cors: args["keymanager.cors"],
         isAuthEnabled: args["keymanager.authEnabled"],
+        headerLimit: args["keymanager.headerLimit"],
         bodyLimit: args["keymanager.bodyLimit"],
         tokenDir: dbPath,
       },

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -76,6 +76,7 @@ export type KeymanagerArgs = {
   "keymanager.port"?: number;
   "keymanager.address"?: string;
   "keymanager.cors"?: string;
+  "keymanager.headerLimit"?: number;
   "keymanager.bodyLimit"?: number;
 };
 
@@ -109,6 +110,11 @@ export const keymanagerOptions: CliCommandOptions<KeymanagerArgs> = {
     description: "Configures the Access-Control-Allow-Origin CORS header for keymanager API",
     defaultDescription: keymanagerRestApiServerOptsDefault.cors,
     group: "keymanager",
+  },
+  "keymanager.headerLimit": {
+    hidden: true,
+    type: "number",
+    description: "Defines the maximum length of request headers, in bytes, the server is allowed to accept",
   },
   "keymanager.bodyLimit": {
     hidden: true,

--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -10,6 +10,7 @@ export type ApiArgs = {
   rest: boolean;
   "rest.address": string;
   "rest.port": number;
+  "rest.headerLimit": number;
   "rest.bodyLimit": number;
 };
 
@@ -22,6 +23,7 @@ export function parseArgs(args: ApiArgs): IBeaconNodeOptions["api"] {
       enabled: args["rest"],
       address: args["rest.address"],
       port: args["rest.port"],
+      headerLimit: args["rest.headerLimit"],
       bodyLimit: args["rest.bodyLimit"],
     },
   };
@@ -76,6 +78,11 @@ export const options: CliCommandOptions<ApiArgs> = {
     description: "Set port for HTTP API",
     defaultDescription: String(defaultOptions.api.rest.port),
     group: "api",
+  },
+  "rest.headerLimit": {
+    hidden: true,
+    type: "number",
+    description: "Defines the maximum length of request headers, in bytes, the server is allowed to accept",
   },
   "rest.bodyLimit": {
     hidden: true,

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -15,6 +15,7 @@ describe("options / beaconNodeOptions", () => {
       rest: true,
       "rest.address": "127.0.0.1",
       "rest.port": 7654,
+      "rest.headerLimit": 16384,
       "rest.bodyLimit": 30e6,
 
       "chain.blsVerifyAllMultiThread": true,
@@ -105,6 +106,7 @@ describe("options / beaconNodeOptions", () => {
           enabled: true,
           address: "127.0.0.1",
           port: 7654,
+          headerLimit: 16384,
           bodyLimit: 30e6,
         },
       },


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5554

**Description**

Adds `--rest.headerLimit` CLI flag to configure REST API server header limit (default: 16384 bytes).
