### PR TITLE
fix: use proper newlines in metrics output

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -275,7 +275,7 @@ export class NetworkCore implements INetworkCore {
       (await this.peerManager["discovery"]?.discv5.scrapeMetrics()) ?? "",
     ]
       .filter((str) => str.length > 0)
-      .join("/n/n");
+      .join("\n\n");
   }
 
   async updateStatus(status: phase0.Status): Promise<void> {


### PR DESCRIPTION
**Motivation**

#5590 introduced invalid metrics output by using incorrectly formatted newlines

**Description**

Fix the bug in #5590 
Use proper newlines