### PR TITLE
feat: emit eventstream events with incoming gossip

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -70,6 +70,9 @@ export function getBeaconPoolApi({
               const insertOutcome = chain.attestationPool.add(attestation, attDataRootHex);
               metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
             }
+
+            chain.emitter.emit(routes.events.EventType.attestation, attestation);
+
             const sentPeers = await network.publishBeaconAttestation(attestation, subnet);
             metrics?.onPoolSubmitUnaggregatedAttestation(seenTimestampSec, indexedAttestation, subnet, sentPeers);
           } catch (e) {
@@ -108,6 +111,7 @@ export function getBeaconPoolApi({
     async submitPoolVoluntaryExit(voluntaryExit) {
       await validateGossipVoluntaryExit(chain, voluntaryExit);
       chain.opPool.insertVoluntaryExit(voluntaryExit);
+      chain.emitter.emit(routes.events.EventType.voluntaryExit, voluntaryExit);
       await network.publishVoluntaryExit(voluntaryExit);
     },
 
@@ -121,6 +125,9 @@ export function getBeaconPoolApi({
             await validateBlsToExecutionChange(chain, blsToExecutionChange, true);
             const preCapella = chain.clock.currentEpoch < chain.config.CAPELLA_FORK_EPOCH;
             chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, preCapella);
+
+            chain.emitter.emit(routes.events.EventType.blsToExecutionChange, blsToExecutionChange);
+
             if (!preCapella) {
               await network.publishBlsToExecutionChange(blsToExecutionChange);
             }

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -26,6 +26,10 @@ import {writeBlockInputToDb} from "./writeBlockInputToDb.js";
  * Fork-choice allows to import attestations from current (0) or past (1) epoch.
  */
 const FORK_CHOICE_ATT_EPOCH_LIMIT = 1;
+/**
+ * Emit eventstream events for block contents events only for blocks that are recent enough to clock
+ */
+const EVENTSTREAM_EMIT_RECENT_BLOCK_SLOTS = 64;
 
 /**
  * Imports a fully verified block into the chain state. Produces multiple permanent side-effects.
@@ -149,11 +153,6 @@ export async function importBlock(
           blockRootHex,
           block.message.slot
         );
-
-        // don't want to log the processed attestations here as there are so many attestations and it takes too much disc space,
-        // users may want to keep more log files instead of unnecessary processed attestations log
-        // see https://github.com/ChainSafe/lodestar/pull/4032
-        this.emitter.emit(routes.events.EventType.attestation, attestation);
       } catch (e) {
         // a block has a lot of attestations and it may has same error, we don't want to log all of them
         if (e instanceof ForkChoiceError && e.type.code === ForkChoiceErrorCode.INVALID_ATTESTATION) {
@@ -370,14 +369,25 @@ export async function importBlock(
     }
   }
 
-  // Send block events
+  // Send block events, only for recent enough blocks
 
-  for (const voluntaryExit of block.message.body.voluntaryExits) {
-    this.emitter.emit(routes.events.EventType.voluntaryExit, voluntaryExit);
-  }
-
-  for (const blsToExecutionChange of (block.message.body as capella.BeaconBlockBody).blsToExecutionChanges ?? []) {
-    this.emitter.emit(routes.events.EventType.blsToExecutionChange, blsToExecutionChange);
+  if (this.clock.currentSlot - block.message.slot < EVENTSTREAM_EMIT_RECENT_BLOCK_SLOTS) {
+    // NOTE: Skip looping if there are no listeners from the API
+    if (this.emitter.listenerCount(routes.events.EventType.voluntaryExit)) {
+      for (const voluntaryExit of block.message.body.voluntaryExits) {
+        this.emitter.emit(routes.events.EventType.voluntaryExit, voluntaryExit);
+      }
+    }
+    if (this.emitter.listenerCount(routes.events.EventType.blsToExecutionChange)) {
+      for (const blsToExecutionChange of (block.message.body as capella.BeaconBlockBody).blsToExecutionChanges ?? []) {
+        this.emitter.emit(routes.events.EventType.blsToExecutionChange, blsToExecutionChange);
+      }
+    }
+    if (this.emitter.listenerCount(routes.events.EventType.attestation)) {
+      for (const attestation of block.message.body.attestations) {
+        this.emitter.emit(routes.events.EventType.attestation, attestation);
+      }
+    }
   }
 
   // Register stat metrics about the block after importing it


### PR DESCRIPTION
**Motivation**

Beacon APIs spec require to emit events for both data received on a block or p2p

Block is already emitted for all paths if valid (fully imported)

```
            block:
              description: The node has received a valid block (from P2P or API)
```

https://github.com/ethereum/beacon-APIs/blob/2a15cc71cf8473e1013713de98d0aacf8bf2ea05/apis/eventstream/index.yaml#L51

Attestation, must emit for API and P2P (added in this PR) and optional from block (already in stable)

```
            attestation:
              description: The node has received a valid attestation (from P2P or API)
```

https://github.com/ethereum/beacon-APIs/blob/2a15cc71cf8473e1013713de98d0aacf8bf2ea05/apis/eventstream/index.yaml#L55-L56

Same for rest:

```
            voluntary_exit:
              description: The node has received a valid voluntary exit (from P2P or API)
```

https://github.com/ethereum/beacon-APIs/blob/2a15cc71cf8473e1013713de98d0aacf8bf2ea05/apis/eventstream/index.yaml#L60-L61

```
            bls_to_execution_change:
              description: The node has received a BLS to execution change (from P2P or API)
```

https://github.com/ethereum/beacon-APIs/blob/2a15cc71cf8473e1013713de98d0aacf8bf2ea05/apis/eventstream/index.yaml#L65-L66

```
            contribution_and_proof:
              description: The node has received a valid sync committee SignedContributionAndProof (from P2P or API)
```

https://github.com/ethereum/beacon-APIs/blob/2a15cc71cf8473e1013713de98d0aacf8bf2ea05/apis/eventstream/index.yaml#L80-L81

**Description**

Emit attestation, voluntary_exit, bls_to_execution_change, and contribution_and_proof on gossip handler and API handler

Closes https://github.com/ChainSafe/lodestar/issues/5430
