### PR TITLE
fix(logger): avoid creating new winston instance for each child

### DIFF
--- a/packages/logger/src/winston.ts
+++ b/packages/logger/src/winston.ts
@@ -40,19 +40,21 @@ export class WinstonLogger implements Logger {
   constructor(protected readonly winston: Winston) {}
 
   static fromOpts(options: Partial<LoggerOptions> = {}, transports?: winston.transport[]): WinstonLogger {
+    return new WinstonLogger(this.createWinstonInstance(options, transports));
+  }
+
+  static createWinstonInstance(options: Partial<LoggerOptions> = {}, transports?: winston.transport[]): Winston {
     const defaultMeta: DefaultMeta = {module: options?.module || ""};
 
-    return new WinstonLogger(
-      winston.createLogger({
-        // Do not set level at the logger level. Always control by Transport, unless for testLogger
-        level: options.level,
-        defaultMeta,
-        format: getFormat(options),
-        transports,
-        exitOnError: false,
-        levels: logLevelNum,
-      })
-    );
+    return winston.createLogger({
+      // Do not set level at the logger level. Always control by Transport, unless for testLogger
+      level: options.level,
+      defaultMeta,
+      format: getFormat(options),
+      transports,
+      exitOnError: false,
+      levels: logLevelNum,
+    });
   }
 
   error(message: string, context?: LogData, error?: Error): void {

--- a/packages/logger/test/unit/logger/winston.test.ts
+++ b/packages/logger/test/unit/logger/winston.test.ts
@@ -79,7 +79,7 @@ describe("winston logger", () => {
       for (const format of logFormats) {
         it(`${id} ${format} output`, async () => {
           const memoryTransport = new MemoryTransport();
-          const logger = new WinstonLoggerNode(
+          const logger = WinstonLoggerNode.fromOpts(
             {level: LogLevel.info, format, timestampFormat: {format: TimestampFormatCode.Hidden}},
             [memoryTransport]
           );
@@ -94,7 +94,7 @@ describe("winston logger", () => {
   describe("child logger", () => {
     it("Should parse child module", async () => {
       const memoryTransport = new MemoryTransport();
-      const loggerA = new WinstonLoggerNode(
+      const loggerA = WinstonLoggerNode.fromOpts(
         {level: LogLevel.info, timestampFormat: {format: TimestampFormatCode.Hidden}, module: "a"},
         [memoryTransport]
       );


### PR DESCRIPTION
**Motivation**

As discussed in https://github.com/ChainSafe/lodestar/pull/5490#discussion_r1209317683

Method to create child loggers was updated in
- https://github.com/ChainSafe/lodestar/pull/5490

This causes issues with no clear benefit
- https://github.com/ChainSafe/lodestar/issues/5529

**Description**

Reverts `logger.child` implementation back to original approach https://github.com/ChainSafe/lodestar/blob/375d660ed1e7ba13945dff41e63154a26c4be008/packages/utils/src/logger/winston.ts#L82

This avoids `MaxListenersExceededWarning` warnings as it no longer creates a new winston instance for each child logger.

Reverts https://github.com/ChainSafe/lodestar/pull/5537 as the workaround is no longer needed.