### PR TITLE
fix(logger): restore previous --logFileDailyRotate behavior

### DIFF
--- a/packages/cli/src/options/logOptions.ts
+++ b/packages/cli/src/options/logOptions.ts
@@ -36,7 +36,7 @@ export const logOptions: CliCommandOptions<LogArgs> = {
 
   logFileDailyRotate: {
     description:
-      "Daily rotate log files, set to an integer to limit the file count, set to 0(zero) to disable rotation",
+      "Daily rotate log files, set to an integer to limit the file count, set to 0 (zero) to disable rotation",
     default: 5,
     type: "number",
   },

--- a/packages/logger/src/node.ts
+++ b/packages/logger/src/node.ts
@@ -90,19 +90,16 @@ function getNodeLoggerTransports(opts: LoggerNodeOpts): winston.transport[] {
 
   const transports: TransportStream[] = [consoleTransport];
 
-  // yargs populates with undefined if just set but with no arg
-  // $ ./bin/lodestar.js beacon --logFileDailyRotate
-  // args = {
-  //   logFileDailyRotate: undefined,
-  // }
-  // `lodestar --logFileDailyRotate` -> enabled daily rotate with default value
-  // `lodestar --logFileDailyRotate 10` -> set daily rotate to custom value 10
-  // `lodestar --logFileDailyRotate 0` -> disable daily rotate and accumulate in same file
   if (opts.file) {
     const filename = opts.file.filepath;
 
+    // `lodestar --logFileDailyRotate` -> enable daily rotate with default value
+    // `lodestar --logFileDailyRotate 10` -> set daily rotate to custom value 10
+    // `lodestar --logFileDailyRotate 0` -> disable daily rotate and accumulate in same file
+    const enableDailyRotate = opts.file.dailyRotate != null && opts.file.dailyRotate > 0;
+
     transports.push(
-      opts.file.dailyRotate != null
+      enableDailyRotate
         ? new DailyRotateFile({
             level: opts.file.level,
             //insert the date pattern in filename before the file extension.

--- a/packages/logger/test/unit/loggerTransport.test.ts
+++ b/packages/logger/test/unit/loggerTransport.test.ts
@@ -127,7 +127,7 @@ describe("winston transport log to file", () => {
     const filenameRx = /^child-logger-test/;
     const filepath = path.join(tmpDir, filename);
 
-    const logger = getNodeLoggerTest({module: "a", file: {filepath, level: LogLevel.info}});
+    const logger = getNodeLoggerTest({module: "a", file: {filepath, level: LogLevel.info, dailyRotate: 5}});
 
     stdoutHook = hookProcessStdout();
 


### PR DESCRIPTION
**Motivation**

https://github.com/ChainSafe/lodestar/pull/5490#discussion_r1209337604

**Description**

Restores previous `--logFileDailyRotate` behavior

- `lodestar --logFileDailyRotate` -> enable daily rotate with default value (same as omitting the flag)
- `lodestar --logFileDailyRotate 10` -> set daily rotate to custom value 10
- `lodestar --logFileDailyRotate 0` -> disable daily rotate and accumulate in same file

This logic was previously handled by the CLI package

https://github.com/ChainSafe/lodestar/blob/a4b29cfe38de109c44992977074869a8c01cfc83/packages/cli/src/util/logger.ts#L72-L82