### PR TITLE
feat: set network.useWorker to false by default

### DIFF
--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -36,6 +36,6 @@ export const defaultNetworkOptions: NetworkOptions = {
   // see https://github.com/ChainSafe/lodestar/issues/5420
   gossipsubDHigh: 9,
   ...defaultGossipHandlerOpts,
-  // TEMP default to try
-  useWorker: true,
+  // TODO set to false in order to release 1.9.0 in a timely manner
+  useWorker: false,
 };


### PR DESCRIPTION
**Motivation**

Currently, using the worker thread results in good improvements, but it is not yet stable enough to cut a release.

In order to cut a release in a timely manner, we want to temporarily disable this feature by default.

**Description**

Set network.useWorker to false by default