### PR TITLE
feat: add validator monitor metric for missed attestation reason

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -71,7 +71,7 @@ export function getBeaconPoolApi({
               metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
             }
             const sentPeers = await network.publishBeaconAttestation(attestation, subnet);
-            metrics?.submitUnaggregatedAttestation(seenTimestampSec, indexedAttestation, subnet, sentPeers);
+            metrics?.onPoolSubmitUnaggregatedAttestation(seenTimestampSec, indexedAttestation, subnet, sentPeers);
           } catch (e) {
             errors.push(e as Error);
             logger.error(

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -579,7 +579,7 @@ export function getValidatorApi({
               committeeIndices
             );
             const sentPeers = await network.publishBeaconAggregateAndProof(signedAggregateAndProof);
-            metrics?.submitAggregatedAttestation(seenTimestampSec, indexedAttestation, sentPeers);
+            metrics?.onPoolSubmitAggregatedAttestation(seenTimestampSec, indexedAttestation, sentPeers);
           } catch (e) {
             if (e instanceof AttestationError && e.type.code === AttestationErrorCode.AGGREGATOR_ALREADY_KNOWN) {
               logger.debug("Ignoring known signedAggregateAndProof");

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -112,7 +112,7 @@ export async function importBlock(
     for (const attestation of attestations) {
       try {
         const indexedAttestation = postState.epochCtx.getIndexedAttestation(attestation);
-        const {target, slot, beaconBlockRoot} = attestation.data;
+        const {target, beaconBlockRoot} = attestation.data;
 
         const attDataRoot = toHexString(ssz.phase0.AttestationData.hashTreeRoot(indexedAttestation.data));
         this.seenAggregatedAttestations.add(
@@ -137,8 +137,19 @@ export async function importBlock(
         // Note: To avoid slowing down sync, only register attestations within FORK_CHOICE_ATT_EPOCH_LIMIT
         this.seenBlockAttesters.addIndices(blockEpoch, indexedAttestation.attestingIndices);
 
-        const correctHead = ssz.Root.equals(rootCache.getBlockRootAtSlot(slot), beaconBlockRoot);
-        this.metrics?.registerAttestationInBlock(indexedAttestation, parentBlockSlot, correctHead);
+        const correctHead = ssz.Root.equals(rootCache.getBlockRootAtSlot(attestation.data.slot), beaconBlockRoot);
+        const missedSlotVote = ssz.Root.equals(
+          rootCache.getBlockRootAtSlot(attestation.data.slot - 1),
+          rootCache.getBlockRootAtSlot(attestation.data.slot)
+        );
+        this.metrics?.registerAttestationInBlock(
+          indexedAttestation,
+          parentBlockSlot,
+          correctHead,
+          missedSlotVote,
+          blockRootHex,
+          block.message.slot
+        );
 
         // don't want to log the processed attestations here as there are so many attestations and it takes too much disc space,
         // users may want to keep more log files instead of unnecessary processed attestations log

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -28,9 +28,9 @@ import {
 } from "@lodestar/types";
 import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {ProcessShutdownCallback} from "@lodestar/validator";
-import {Logger, pruneSetToMax, toHex} from "@lodestar/utils";
+import {Logger, isErrorAborted, pruneSetToMax, sleep, toHex} from "@lodestar/utils";
 import {CompositeTypeAny, fromHexString, TreeView, Type} from "@chainsafe/ssz";
-import {ForkSeq} from "@lodestar/params";
+import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants/index.js";
 import {IBeaconDb} from "../db/index.js";
@@ -809,6 +809,16 @@ export class BeaconChain implements IBeaconChain {
           }
         }
       }
+    }
+
+    const metrics = this.metrics;
+    if (metrics && (slot + 1) % SLOTS_PER_EPOCH === 0) {
+      // On the last slot of the epoch
+      sleep((1000 * this.config.SECONDS_PER_SLOT) / 2)
+        .then(() => metrics.onceEveryEndOfEpoch(this.getHeadState()))
+        .catch((e) => {
+          if (!isErrorAborted(e)) this.logger.error("error on validator monitor onceEveryEndOfEpoch", {slot}, e);
+        });
     }
   }
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -842,6 +842,11 @@ export function createLodestarMetrics(
         help: "The count of times a sync signature was seen inside an aggregate",
         buckets: [0, 1, 2, 3, 5, 10],
       }),
+      prevEpochAttestationSummary: register.gauge<"summary">({
+        name: "validator_monitor_prev_epoch_attestation_summary",
+        help: "Best guess of the node of the result of previous epoch validators attestation actions and causality",
+        labelNames: ["summary"],
+      }),
 
       // Validator Monitor Metrics (real-time)
 

--- a/packages/beacon-node/src/metrics/validatorMonitor.ts
+++ b/packages/beacon-node/src/metrics/validatorMonitor.ts
@@ -1,8 +1,18 @@
-import {computeEpochAtSlot, AttesterStatus, parseAttesterFlags} from "@lodestar/state-transition";
-import {Logger} from "@lodestar/utils";
-import {allForks, altair} from "@lodestar/types";
-import {ChainForkConfig} from "@lodestar/config";
-import {MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {
+  computeEpochAtSlot,
+  AttesterStatus,
+  parseAttesterFlags,
+  CachedBeaconStateAllForks,
+  CachedBeaconStateAltair,
+  parseParticipationFlags,
+  computeStartSlotAtEpoch,
+  getBlockRootAtSlot,
+  ParticipationFlags,
+} from "@lodestar/state-transition";
+import {Logger, MapDef, MapDefMax, toHex} from "@lodestar/utils";
+import {RootHex, allForks, altair} from "@lodestar/types";
+import {ChainConfig, ChainForkConfig} from "@lodestar/config";
+import {ForkSeq, INTERVALS_PER_SLOT, MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Epoch, Slot, ValidatorIndex} from "@lodestar/types";
 import {IndexedAttestation, SignedAggregateAndProof} from "@lodestar/types/phase0";
 import {LodestarMetrics} from "./metrics/lodestar.js";
@@ -10,7 +20,13 @@ import {LodestarMetrics} from "./metrics/lodestar.js";
 /** The validator monitor collects per-epoch data about each monitored validator.
  * Historical data will be kept around for `HISTORIC_EPOCHS` before it is pruned.
  */
-const HISTORIC_EPOCHS = 4;
+const MAX_CACHED_EPOCHS = 4;
+
+const MAX_CACHED_DISTINCT_TARGETS = 4;
+
+const INTERVALS_LATE_ATTESTATION_SUBMISSION = 1.5;
+
+const RETAIN_REGISTERED_VALIDATORS_MS = 12 * 3600 * 1000; // 12 hours
 
 type Seconds = number;
 export enum OpSource {
@@ -24,29 +40,37 @@ export type ValidatorMonitor = {
   registerValidatorStatuses(currentEpoch: Epoch, statuses: AttesterStatus[], balances?: number[]): void;
   registerBeaconBlock(src: OpSource, seenTimestampSec: Seconds, block: allForks.BeaconBlock): void;
   registerImportedBlock(block: allForks.BeaconBlock, data: {proposerBalanceDelta: number}): void;
-  submitUnaggregatedAttestation(
+  onPoolSubmitUnaggregatedAttestation(
     seenTimestampSec: number,
     indexedAttestation: IndexedAttestation,
     subnet: number,
     sentPeers: number
   ): void;
-  registerGossipUnaggregatedAttestation(seenTimestampSec: Seconds, indexedAttestation: IndexedAttestation): void;
-  submitAggregatedAttestation(
+  onPoolSubmitAggregatedAttestation(
     seenTimestampSec: number,
     indexedAttestation: IndexedAttestation,
     sentPeers: number
   ): void;
+  registerGossipUnaggregatedAttestation(seenTimestampSec: Seconds, indexedAttestation: IndexedAttestation): void;
   registerGossipAggregatedAttestation(
     seenTimestampSec: Seconds,
     signedAggregateAndProof: SignedAggregateAndProof,
     indexedAttestation: IndexedAttestation
   ): void;
-  registerAttestationInBlock(indexedAttestation: IndexedAttestation, parentSlot: Slot, correctHead: boolean): void;
+  registerAttestationInBlock(
+    indexedAttestation: IndexedAttestation,
+    parentSlot: Slot,
+    correctHead: boolean,
+    missedSlotVote: boolean,
+    inclusionBlockRoot: RootHex,
+    inclusionBlockSlot: Slot
+  ): void;
   registerGossipSyncContributionAndProof(
     syncContributionAndProof: altair.ContributionAndProof,
     syncCommitteeParticipantIndices: ValidatorIndex[]
   ): void;
   registerSyncAggregateInBlock(epoch: Epoch, syncAggregate: altair.SyncAggregate, syncCommitteeIndices: number[]): void;
+  onceEveryEndOfEpoch(state: CachedBeaconStateAllForks): void;
   scrapeMetrics(slotClock: Slot): void;
 };
 
@@ -157,7 +181,7 @@ function getEpochSummary(validator: MonitoredValidator, epoch: Epoch): EpochSumm
   }
 
   // Prune
-  const toPrune = validator.summaries.size - HISTORIC_EPOCHS;
+  const toPrune = validator.summaries.size - MAX_CACHED_EPOCHS;
   if (toPrune > 0) {
     let pruned = 0;
     for (const idx of validator.summaries.keys()) {
@@ -169,13 +193,34 @@ function getEpochSummary(validator: MonitoredValidator, epoch: Epoch): EpochSumm
   return summary;
 }
 
+// To uniquely identify an attestation:
+// `index=$validator_index target=$target_epoch:$target_root
+type AttestationSummary = {
+  poolSubmitDelayMinSec: number | null;
+  poolSubmitSentPeers: number | null;
+  aggregateInclusionDelaysSec: number[];
+  blockInclusions: AttestationBlockInclusion[];
+};
+
+type AttestationBlockInclusion = {
+  blockRoot: RootHex;
+  blockSlot: Slot;
+  votedCorrectHeadRoot: boolean;
+  votedForMissedSlot: boolean;
+  attestationSlot: Slot;
+};
+
+/** `$target_epoch:$target_root` */
+type TargetRoot = string;
+
 /// A validator that is being monitored by the `ValidatorMonitor`. */
 type MonitoredValidator = {
-  /// The validator index in the state. */
-  index: number;
   /// A history of the validator over time. */
   summaries: Map<Epoch, EpochSummary>;
   inSyncCommitteeUntilEpoch: number;
+  // Unless the validator slashes itself, there MUST be one attestation per target checkpoint
+  attestations: MapDefMax<Epoch, MapDefMax<TargetRoot, AttestationSummary>>;
+  lastRegisteredTimeMs: number;
 };
 
 export function createValidatorMonitor(
@@ -185,15 +230,30 @@ export function createValidatorMonitor(
   logger: Logger
 ): ValidatorMonitor {
   /** The validators that require additional monitoring. */
-  const validators = new Map<ValidatorIndex, MonitoredValidator>();
+  const validators = new MapDef<ValidatorIndex, MonitoredValidator>(() => ({
+    summaries: new Map<Epoch, EpochSummary>(),
+    inSyncCommitteeUntilEpoch: -1,
+    attestations: new MapDefMax(
+      () =>
+        new MapDefMax(
+          () => ({
+            poolSubmitDelayMinSec: null,
+            poolSubmitSentPeers: null,
+            aggregateInclusionDelaysSec: [],
+            blockInclusions: [],
+          }),
+          MAX_CACHED_DISTINCT_TARGETS
+        ),
+      MAX_CACHED_EPOCHS
+    ),
+    lastRegisteredTimeMs: 0,
+  }));
 
   let lastRegisteredStatusEpoch = -1;
 
   return {
     registerLocalValidator(index) {
-      if (!validators.has(index)) {
-        validators.set(index, {index, summaries: new Map<Epoch, EpochSummary>(), inSyncCommitteeUntilEpoch: -1});
-      }
+      validators.getOrDefault(index).lastRegisteredTimeMs = Date.now();
     },
 
     registerLocalValidatorInSyncCommittee(index, untilEpoch) {
@@ -211,13 +271,12 @@ export function createValidatorMonitor(
       lastRegisteredStatusEpoch = currentEpoch;
       const previousEpoch = currentEpoch - 1;
 
-      for (const monitoredValidator of validators.values()) {
+      for (const [index, monitoredValidator] of validators.entries()) {
         // We subtract two from the state of the epoch that generated these summaries.
         //
         // - One to account for it being the previous epoch.
         // - One to account for the state advancing an epoch whilst generating the validator
         //     statuses.
-        const index = monitoredValidator.index;
         const status = statuses[index];
         if (status === undefined) {
           continue;
@@ -305,7 +364,7 @@ export function createValidatorMonitor(
       }
     },
 
-    submitUnaggregatedAttestation(seenTimestampSec, indexedAttestation, subnet, sentPeers) {
+    onPoolSubmitUnaggregatedAttestation(seenTimestampSec, indexedAttestation, subnet, sentPeers) {
       const data = indexedAttestation.data;
       // Returns the duration between when the attestation `data` could be produced (1/3rd through the slot) and `seenTimestamp`.
       const delaySec = seenTimestampSec - (genesisTime + (data.slot + 1 / 3) * config.SECONDS_PER_SLOT);
@@ -315,13 +374,23 @@ export function createValidatorMonitor(
           metrics.validatorMonitor.unaggregatedAttestationSubmittedSentPeers.observe(sentPeers);
           metrics.validatorMonitor.unaggregatedAttestationDelaySeconds.observe({src: OpSource.api}, delaySec);
           logger.debug("Local validator published unaggregated attestation", {
-            validatorIndex: validator.index,
+            validatorIndex: index,
             slot: data.slot,
             committeeIndex: data.index,
             subnet,
             sentPeers,
             delaySec,
           });
+
+          const attestationSummary = validator.attestations
+            .getOrDefault(indexedAttestation.data.target.epoch)
+            .getOrDefault(toHex(indexedAttestation.data.target.root));
+          if (
+            attestationSummary.poolSubmitDelayMinSec === null ||
+            attestationSummary.poolSubmitDelayMinSec > delaySec
+          ) {
+            attestationSummary.poolSubmitDelayMinSec = delaySec;
+          }
         }
       }
     },
@@ -345,7 +414,7 @@ export function createValidatorMonitor(
       }
     },
 
-    submitAggregatedAttestation(seenTimestampSec, indexedAttestation, sentPeers) {
+    onPoolSubmitAggregatedAttestation(seenTimestampSec, indexedAttestation, sentPeers) {
       const data = indexedAttestation.data;
       // Returns the duration between when a `AggregateAndproof` with `data` could be produced (2/3rd through the slot) and `seenTimestamp`.
       const delaySec = seenTimestampSec - (genesisTime + (data.slot + 2 / 3) * config.SECONDS_PER_SLOT);
@@ -355,12 +424,17 @@ export function createValidatorMonitor(
         if (validator) {
           metrics.validatorMonitor.aggregatedAttestationDelaySeconds.observe({src: OpSource.api}, delaySec);
           logger.debug("Local validator published aggregated attestation", {
-            validatorIndex: validator.index,
+            validatorIndex: index,
             slot: data.slot,
             committeeIndex: data.index,
             sentPeers,
             delaySec,
           });
+
+          validator.attestations
+            .getOrDefault(indexedAttestation.data.target.epoch)
+            .getOrDefault(toHex(indexedAttestation.data.target.root))
+            .aggregateInclusionDelaysSec.push(delaySec);
         }
       }
     },
@@ -390,16 +464,28 @@ export function createValidatorMonitor(
           const summary = getEpochSummary(validator, epoch);
           summary.attestationAggregateIncusions += 1;
           logger.debug("Local validator attestation is included in AggregatedAndProof", {
-            validatorIndex: validator.index,
+            validatorIndex: index,
             slot: data.slot,
             committeeIndex: data.index,
           });
+
+          validator.attestations
+            .getOrDefault(indexedAttestation.data.target.epoch)
+            .getOrDefault(toHex(indexedAttestation.data.target.root))
+            .aggregateInclusionDelaysSec.push(delaySec);
         }
       }
     },
 
     // Register that the `indexed_attestation` was included in a *valid* `BeaconBlock`.
-    registerAttestationInBlock(indexedAttestation, parentSlot, correctHead): void {
+    registerAttestationInBlock(
+      indexedAttestation,
+      parentSlot,
+      correctHead,
+      missedSlotVote,
+      inclusionBlockRoot,
+      inclusionBlockSlot
+    ): void {
       const data = indexedAttestation.data;
       // optimal inclusion distance, not to count skipped slots between data.slot and blockSlot
       const inclusionDistance = Math.max(parentSlot - data.slot, 0) + 1;
@@ -425,8 +511,19 @@ export function createValidatorMonitor(
 
           summary.attestationCorrectHead = correctHead;
 
+          validator.attestations
+            .getOrDefault(indexedAttestation.data.target.epoch)
+            .getOrDefault(toHex(indexedAttestation.data.target.root))
+            .blockInclusions.push({
+              blockRoot: inclusionBlockRoot,
+              blockSlot: inclusionBlockSlot,
+              votedCorrectHeadRoot: correctHead,
+              votedForMissedSlot: missedSlotVote,
+              attestationSlot: indexedAttestation.data.slot,
+            });
+
           logger.debug("Local validator attestation is included in block", {
-            validatorIndex: validator.index,
+            validatorIndex: index,
             slot: data.slot,
             committeeIndex: data.index,
             inclusionDistance,
@@ -460,6 +557,38 @@ export function createValidatorMonitor(
           } else {
             summary.syncCommitteeMisses++;
           }
+        }
+      }
+    },
+
+    // Validator monitor tracks performance of validators in healthy network conditions.
+    // It does not attempt to track correctly duties on forking conditions deeper than 1 epoch.
+    // To guard against short re-orgs it will track the status of epoch N at the end of epoch N+1.
+    // This function **SHOULD** be called at the last slot of an epoch to have max possible information.
+    onceEveryEndOfEpoch(headState) {
+      // Prune validators not seen in a while
+      for (const [index, validator] of validators.entries()) {
+        if (Date.now() - validator.lastRegisteredTimeMs > RETAIN_REGISTERED_VALIDATORS_MS) {
+          validators.delete(index);
+        }
+      }
+
+      // Compute summaries of previous epoch attestation performance
+      const prevEpoch = Math.max(0, computeEpochAtSlot(headState.slot) - 1);
+
+      if (config.getForkSeq(headState.slot) >= ForkSeq.altair) {
+        const {previousEpochParticipation} = headState as CachedBeaconStateAltair;
+        const prevEpochStartSlot = computeStartSlotAtEpoch(prevEpoch);
+        const prevEpochTargetRoot = toHex(getBlockRootAtSlot(headState, prevEpochStartSlot));
+        const rootCache = new RootHexCache(headState);
+
+        // Check attestation performance
+        for (const [index, validator] of validators.entries()) {
+          const flags = parseParticipationFlags(previousEpochParticipation.get(index));
+          const attestationSummary = validator.attestations.get(prevEpoch)?.get(prevEpochTargetRoot);
+          metrics.validatorMonitor.prevEpochAttestationSummary.inc({
+            summary: renderAttestationSummary(config, rootCache, attestationSummary, flags),
+          });
         }
       }
     },
@@ -549,4 +678,244 @@ export function createValidatorMonitor(
       metrics.validatorMonitor.prevEpochSyncCommitteeMisses.set(prevEpochSyncCommitteeMisses);
     },
   };
+}
+
+/**
+ * Best guess to automatically debug why validators do not achieve expected rewards.
+ * Tries to answer common questions such as:
+ * - Did the validator submit the attestation to this block?
+ * - Was the attestation seen in an aggregate?
+ * - Was the attestation seen in a block?
+ */
+function renderAttestationSummary(
+  config: ChainConfig,
+  rootCache: RootHexCache,
+  summary: AttestationSummary | undefined,
+  flags: ParticipationFlags
+): string {
+  // Reference https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#get_attestation_participation_flag_indices
+  //
+  // is_matching_source = data.source == justified_checkpoint
+  // is_matching_target = is_matching_source and data.target.root == get_block_root(state, data.target.epoch)
+  // is_matching_head = is_matching_target and data.beacon_block_root == get_block_root_at_slot(state, data.slot)
+  //
+  // is_matching_source MUST be true for the attestation to be included in a block
+  //
+  // timely_source = is_matching_source and inclusion_delay <= integer_squareroot(SLOTS_PER_EPOCH):
+  // timely_target = is_matching_target and inclusion_delay <= SLOTS_PER_EPOCH:
+  // timely_head = is_matching_head and inclusion_delay == MIN_ATTESTATION_INCLUSION_DELAY:
+
+  if (flags.timelyHead) {
+    // NOTE: If timelyHead everything else MUST be true also
+    return "timely_head";
+  }
+
+  //
+  else if (flags.timelyTarget) {
+    // timelyHead == false, means at least one is true
+    // - attestation voted incorrect head
+    // - attestation was included late
+
+    // Note: the same attestation can be included in multiple blocks. For example, block with parent A at slot N can
+    // include the attestation. Then block as slot N+1 re-orgs slot N setting as parent A and includes the attestations
+    // from block at slot N.
+    //
+    // TODO: Track block inclusions, and then check which ones are cannonical
+
+    if (!summary) {
+      // In normal conditions should never happen, validator is expected to submit an attestation to the tracking node.
+      // If the validator is using multiple beacon nodes as fallback, this condition may be triggered.
+      return "unexpected_timely_target_without_summary";
+    }
+
+    const cannonicalBlockInclusion = summary.blockInclusions.find((block) => isCannonical(rootCache, block));
+    if (!cannonicalBlockInclusion) {
+      // Should never happen, because for a state to exist that registers a validator's participation this specific
+      // beacon node must have imported a block with the attestation that caused the change in participation.
+      return "unexpected_timely_target_without_cannonical_inclusion";
+    }
+
+    const {votedCorrectHeadRoot, blockSlot, attestationSlot} = cannonicalBlockInclusion;
+    const inclusionDistance = Math.max(blockSlot - attestationSlot - MIN_ATTESTATION_INCLUSION_DELAY, 0);
+
+    if (votedCorrectHeadRoot && inclusionDistance === 0) {
+      // Should never happen, in this case timelyHead must be true
+      return "unexpected_timely_head_as_timely_target";
+    }
+
+    // Why is the distance > 0?
+    // - Block that should have included the attestation was missed
+    // - Attestation was not included in any aggregate
+    // - Attestation was sent late
+
+    // Why is the head vote wrong?
+    // - We processed a block late and voted for the parent
+    // - We voted for a block that latter was missed
+    // - We voted for a block that was re-org for another chain
+
+    let out = "timely_target";
+
+    if (!votedCorrectHeadRoot) {
+      out += "_" + whyIsHeadVoteWrong(rootCache, cannonicalBlockInclusion);
+    }
+
+    if (inclusionDistance > 0) {
+      out += "_" + whyIsDistanceNotOk(rootCache, cannonicalBlockInclusion, summary);
+    }
+
+    return out;
+  }
+
+  //
+  else if (flags.timelySource) {
+    // timelyTarget == false && timelySource == true means that
+    // - attestation voted the wrong target but distance is <= integer_squareroot(SLOTS_PER_EPOCH)
+    return "wrong_target_timely_source";
+  }
+
+  //
+  else {
+    // timelySource == false, either:
+    // - attestation was not included in the block
+    // - included in block with wrong target (very unlikely)
+    // - included in block with distance > SLOTS_PER_EPOCH (very unlikely)
+
+    // Validator failed to submit an attestation for this epoch, validator client is probably offline
+    if (!summary || summary.poolSubmitDelayMinSec === null) {
+      return "no_submission";
+    }
+
+    const cannonicalBlockInclusion = summary.blockInclusions.find((block) => isCannonical(rootCache, block));
+    if (cannonicalBlockInclusion) {
+      // Cannonical block inclusion with no participation flags set means wrong target + late source
+      return "wrong_target_late_source";
+    }
+
+    const submittedLate =
+      summary.poolSubmitDelayMinSec >
+      (INTERVALS_LATE_ATTESTATION_SUBMISSION * config.SECONDS_PER_SLOT) / INTERVALS_PER_SLOT;
+
+    const aggregateInclusion = summary.aggregateInclusionDelaysSec.length > 0;
+
+    if (submittedLate && aggregateInclusion) {
+      return "late_submit";
+    } else if (submittedLate && !aggregateInclusion) {
+      return "late_submit_no_aggregate_inclusion";
+    } else if (!submittedLate && aggregateInclusion) {
+      // TODO: Why was it missed then?
+      if (summary.blockInclusions.length) {
+        return "block_inclusion_but_orphan";
+      } else {
+        return "aggregate_inclusion_but_missed";
+      }
+      // } else if (!submittedLate && !aggregateInclusion) {
+    } else {
+      // Did the node had enough peers?
+      if (summary.poolSubmitSentPeers === 0) {
+        return "sent_to_zero_peers";
+      } else {
+        return "no_aggregate_inclusion";
+      }
+    }
+  }
+}
+
+function whyIsHeadVoteWrong(rootCache: RootHexCache, cannonicalBlockInclusion: AttestationBlockInclusion): string {
+  const {votedForMissedSlot, attestationSlot} = cannonicalBlockInclusion;
+  const cannonicalAttestationSlotMissed = isMissedSlot(rootCache, attestationSlot);
+
+  // __A_______C
+  //    \_B1
+  //      ^^ attestation slot
+  //
+  // We vote for B1, but the next proposer skips our voted block.
+  // This scenario happens sometimes when blocks are published late
+
+  // __A____________E
+  //    \_B1__C__D
+  //      ^^ attestation slot
+  //
+  // We vote for B1, and due to some issue a longer reorg happens orphaning our vote.
+  // This scenario is considered in the above
+  if (!votedForMissedSlot && cannonicalAttestationSlotMissed) {
+    // TODO: Did the block arrive late?
+    return "vote_orphaned";
+  }
+
+  // __A__B1___C
+  //    \_(A)
+  //      ^^ attestation slot
+  //
+  // We vote for A assuming skip block, next proposer's view differs
+  // This scenario happens sometimes when blocks are published late
+  if (votedForMissedSlot && !cannonicalAttestationSlotMissed) {
+    // TODO: Did the block arrive late?
+    return "wrong_skip_vote";
+  }
+
+  // __A__B2___C
+  //    \_B1
+  //      ^^ attestation slot
+  //
+  // We vote for B1, but the next proposer continues the chain on a competing block
+  // This scenario is unlikely to happen in short re-orgs given no slashings, won't consider.
+  //
+  // __A____B_______C
+  //    \    \_(B)
+  //     \_(A)_(A)
+  //
+  // Vote for different heads on skipped slot
+  else {
+    return "wrong_head_vote";
+  }
+}
+
+function whyIsDistanceNotOk(
+  rootCache: RootHexCache,
+  cannonicalBlockInclusion: AttestationBlockInclusion,
+  summary: AttestationSummary
+): string {
+  // If the attestation is not included in any aggregate it's likely because it was sent late.
+  if (summary.aggregateInclusionDelaysSec.length === 0) {
+    return "no_aggregate_inclusion";
+  }
+
+  // If the next slot of an attestation is missed, distance will be > 0 even if everything else was timely
+  if (isMissedSlot(rootCache, cannonicalBlockInclusion.attestationSlot + 1)) {
+    return "next_slot_missed";
+  }
+
+  //
+  else {
+    return "late_unknown";
+  }
+}
+
+/** Returns true if the state's root record includes `block` */
+function isCannonical(rootCache: RootHexCache, block: AttestationBlockInclusion): boolean {
+  return rootCache.getBlockRootAtSlot(block.blockSlot) === block.blockRoot;
+}
+
+/** Returns true if root at slot is the same at slot - 1 == there was no new block at slot */
+function isMissedSlot(rootCache: RootHexCache, slot: Slot): boolean {
+  return slot > 0 && rootCache.getBlockRootAtSlot(slot) === rootCache.getBlockRootAtSlot(slot - 1);
+}
+
+/**
+ * Cache to prevent accessing the state tree to fetch block roots repeteadly.
+ * In normal network conditions the same root is read multiple times, specially the target.
+ */
+export class RootHexCache {
+  private readonly blockRootSlotCache = new Map<Slot, RootHex>();
+
+  constructor(private readonly state: CachedBeaconStateAllForks) {}
+
+  getBlockRootAtSlot(slot: Slot): RootHex {
+    let root = this.blockRootSlotCache.get(slot);
+    if (!root) {
+      root = toHex(getBlockRootAtSlot(this.state, slot));
+      this.blockRootSlotCache.set(slot, root);
+    }
+    return root;
+  }
 }

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -26,6 +26,7 @@ const PROPOSER_REWARD_DOMINATOR = ((WEIGHT_DENOMINATOR - PROPOSER_WEIGHT) * WEIG
 const TIMELY_SOURCE = 1 << TIMELY_SOURCE_FLAG_INDEX;
 const TIMELY_TARGET = 1 << TIMELY_TARGET_FLAG_INDEX;
 const TIMELY_HEAD = 1 << TIMELY_HEAD_FLAG_INDEX;
+const SLOTS_PER_EPOCH_SQRT = intSqrt(SLOTS_PER_EPOCH);
 
 export function processAttestationsAltair(
   state: CachedBeaconStateAltair,
@@ -150,7 +151,7 @@ export function getAttestationParticipationStatus(
     isMatchingTarget && byteArrayEquals(data.beaconBlockRoot, rootCache.getBlockRootAtSlot(data.slot));
 
   let flags = 0;
-  if (isMatchingSource && inclusionDelay <= intSqrt(SLOTS_PER_EPOCH)) flags |= TIMELY_SOURCE;
+  if (isMatchingSource && inclusionDelay <= SLOTS_PER_EPOCH_SQRT) flags |= TIMELY_SOURCE;
   if (isMatchingTarget && inclusionDelay <= SLOTS_PER_EPOCH) flags |= TIMELY_TARGET;
   if (isMatchingHead && inclusionDelay === MIN_ATTESTATION_INCLUSION_DELAY) flags |= TIMELY_HEAD;
 

--- a/packages/state-transition/src/util/attesterStatus.ts
+++ b/packages/state-transition/src/util/attesterStatus.ts
@@ -1,3 +1,5 @@
+import {TIMELY_HEAD_FLAG_INDEX, TIMELY_SOURCE_FLAG_INDEX, TIMELY_TARGET_FLAG_INDEX} from "@lodestar/params";
+
 export const FLAG_PREV_SOURCE_ATTESTER = 1 << 0;
 export const FLAG_PREV_TARGET_ATTESTER = 1 << 1;
 export const FLAG_PREV_HEAD_ATTESTER = 1 << 2;
@@ -11,6 +13,11 @@ export const FLAG_ELIGIBLE_ATTESTER = 1 << 7;
 export const FLAG_PREV_SOURCE_ATTESTER_UNSLASHED = FLAG_PREV_SOURCE_ATTESTER | FLAG_UNSLASHED;
 export const FLAG_PREV_TARGET_ATTESTER_UNSLASHED = FLAG_PREV_TARGET_ATTESTER | FLAG_UNSLASHED;
 export const FLAG_PREV_HEAD_ATTESTER_UNSLASHED = FLAG_PREV_HEAD_ATTESTER | FLAG_UNSLASHED;
+
+/** Same to https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.5/specs/altair/beacon-chain.md#has_flag */
+const TIMELY_SOURCE = 1 << TIMELY_SOURCE_FLAG_INDEX;
+const TIMELY_TARGET = 1 << TIMELY_TARGET_FLAG_INDEX;
+const TIMELY_HEAD = 1 << TIMELY_HEAD_FLAG_INDEX;
 
 /**
  * During the epoch transition, additional data is precomputed to avoid traversing any state a second
@@ -72,4 +79,18 @@ export function toAttesterFlags(flagsObj: AttesterFlags): number {
   if (flagsObj.unslashed) flag |= FLAG_UNSLASHED;
   if (flagsObj.eligibleAttester) flag |= FLAG_ELIGIBLE_ATTESTER;
   return flag;
+}
+
+export type ParticipationFlags = {
+  timelySource: boolean;
+  timelyTarget: boolean;
+  timelyHead: boolean;
+};
+
+export function parseParticipationFlags(flags: number): ParticipationFlags {
+  return {
+    timelySource: hasMarkers(flags, TIMELY_SOURCE),
+    timelyTarget: hasMarkers(flags, TIMELY_TARGET),
+    timelyHead: hasMarkers(flags, TIMELY_HEAD),
+  };
 }

--- a/packages/utils/src/map.ts
+++ b/packages/utils/src/map.ts
@@ -14,6 +14,29 @@ export class MapDef<K, V> extends Map<K, V> {
 }
 
 /**
+ * Extends MapDef but ensures that there always a max of `maxKeys` keys
+ */
+export class MapDefMax<K, V> {
+  private readonly map = new Map<K, V>();
+
+  constructor(private readonly getDefault: () => V, private readonly maxKeys: number) {}
+
+  getOrDefault(key: K): V {
+    let value = this.map.get(key);
+    if (value === undefined) {
+      value = this.getDefault();
+      this.map.set(key, value);
+      pruneSetToMax(this.map, this.maxKeys);
+    }
+    return value;
+  }
+
+  get(key: K): V | undefined {
+    return this.map.get(key);
+  }
+}
+
+/**
  * 2 dimensions Es6 Map
  */
 export class Map2d<K1, K2, V> {


### PR DESCRIPTION
**Motivation**

Beacon nodes sometimes miss attestations, either due to network conditions or internal problems. This PR extends the validator monitor with heuristics to try to guess _why_ a registered validator did not obtain the maximum attester reward possible.

- https://github.com/ChainSafe/lodestar/issues/5376

**Description**

Assumptions:
- Must handle short re-orgs of 1-5 slot depth
- Assumes somewhat healthy network conditions: no slashings, no deep re-orgs of > 32 slots

First, what's a missed attestation?
- Half way through the last slot of the epoch, the validator monitor is called with the current head state
- Iterates previous epoch participation and if some flag is set to false
- Uses tracked data from API submission and gossip inputs to guess the reason of penalty

The main function to review is this one :point_down: 

https://github.com/ChainSafe/lodestar/blob/9a5828d37c58d71f0a952d73ee2ff1f55bcbf7f1/packages/beacon-node/src/metrics/validatorMonitor.ts#L683-L695

Closes https://github.com/ChainSafe/lodestar/issues/5376
