### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,11 +1,7 @@
-name: Bug Report
+name: Bug report
 description: Create a bug report to help us improve
 title: "[Descriptive title] "
 body:
-  - type: markdown
-    attributes:
-      value: |
-        **NOTE: General questions should go to the [Discord chat](https://discord.gg/aMxzVcr) instead of the issue tracker.**
   - type: textarea
     id: describe
     attributes:
@@ -28,10 +24,10 @@ body:
       label: Steps to reproduce
       description: List the steps to reproduce the behavior
       placeholder: |
-        1. Go to '...'
-        2. Click on '....'
-        3. Scroll down to '....'
-        4. See error    
+        1. Run command './lodestar beacon --flag'
+        2. Wait for node syncing log
+        3. Query API at 'beacon:9596/eth/v1/api'
+        4. See error
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,11 @@
 blank_issues_enabled: true
 contact_links:
+  - name: General questions
+    url: https://github.com/ChainSafe/lodestar/discussions
+    about: General questions should be directed to our Github discussions instead of an issue.
+  - name: Join our Discord community
+    url: https://discord.gg/aMxzVcr
+    about: Engage in our Lodestar community of contributors, users and supporters.
   - name: Ethereum Bug Bounty
     url: https://ethereum.org/en/bug-bounty/
     about: Earn up to $250,000 USD and a place on the leaderboard by finding protocol, client and Solidity bugs affecting the Ethereum network.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -3,10 +3,6 @@ description: Suggest an idea for this project
 title: "[Descriptive title] "
 labels: [meta-feature-request]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        **NOTE: General questions should go to the [Discord chat](https://discord.gg/aMxzVcr) instead of the issue tracker.**
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
**Motivation**

This PR is to more cleanly apply the call to actions for a user coming onto our repository looking for sources of help by clicking "New issue".

**Description**

This PR removes the markdown in the issue templates and directs users to ask questions in our "Discussions" section of the repo or to seek joining our Discord from the issue templates, rather than in the issues themselves.

This PR also updates the placeholder text in how to submit a bug report with properly defined steps based on this comment: https://github.com/ChainSafe/lodestar/pull/5539#discussion_r1209513069
