### PR TITLE
fix: archive state without using batchDelete

### DIFF
--- a/packages/beacon-node/src/chain/archiver/archiveStates.ts
+++ b/packages/beacon-node/src/chain/archiver/archiveStates.ts
@@ -65,7 +65,9 @@ export class StatesArchiver {
 
       const statesSlotsToDelete = computeStateSlotsToDelete(storedStateSlots, archiveStateEpochFrequency);
       if (statesSlotsToDelete.length > 0) {
-        await this.db.stateArchive.batchDelete(statesSlotsToDelete);
+        // using this.db.stateArchive.batchDelete() causes rss memory spike since v1.9.0
+        // see https://github.com/ChainSafe/lodestar/issues/5591#issuecomment-1575754902
+        await Promise.all(statesSlotsToDelete.map((slot) => this.db.stateArchive.delete(slot)));
       }
 
       // More logs to investigate the rss spike issue https://github.com/ChainSafe/lodestar/issues/5591

--- a/packages/beacon-node/src/chain/archiver/archiveStates.ts
+++ b/packages/beacon-node/src/chain/archiver/archiveStates.ts
@@ -65,9 +65,7 @@ export class StatesArchiver {
 
       const statesSlotsToDelete = computeStateSlotsToDelete(storedStateSlots, archiveStateEpochFrequency);
       if (statesSlotsToDelete.length > 0) {
-        // using this.db.stateArchive.batchDelete() causes rss memory spike since v1.9.0
-        // see https://github.com/ChainSafe/lodestar/issues/5591#issuecomment-1575754902
-        await Promise.all(statesSlotsToDelete.map((slot) => this.db.stateArchive.delete(slot)));
+        await this.db.stateArchive.batchDelete(statesSlotsToDelete);
       }
 
       // More logs to investigate the rss spike issue https://github.com/ChainSafe/lodestar/issues/5591

--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -91,6 +91,10 @@ export abstract class Repository<I extends Id, T> {
   }
 
   async batchPut(items: KeyValue<I, T>[]): Promise<void> {
+    if (items.length === 1) {
+      return this.put(items[0].key, items[0].value);
+    }
+
     await this.db.batchPut(
       Array.from({length: items.length}, (_, i) => ({
         key: this.encodeKey(items[i].key),
@@ -102,6 +106,10 @@ export abstract class Repository<I extends Id, T> {
 
   // Similar to batchPut but we support value as Uint8Array
   async batchPutBinary(items: KeyValue<I, Uint8Array>[]): Promise<void> {
+    if (items.length === 1) {
+      return this.db.put(this.encodeKey(items[0].key), items[0].value, this.dbReqOpts);
+    }
+
     await this.db.batchPut(
       Array.from({length: items.length}, (_, i) => ({
         key: this.encodeKey(items[i].key),
@@ -112,6 +120,10 @@ export abstract class Repository<I extends Id, T> {
   }
 
   async batchDelete(ids: I[]): Promise<void> {
+    if (ids.length === 1) {
+      return this.delete(ids[0]);
+    }
+
     await this.db.batchDelete(
       Array.from({length: ids.length}, (_, i) => this.encodeKey(ids[i])),
       this.dbReqOpts
@@ -119,6 +131,7 @@ export abstract class Repository<I extends Id, T> {
   }
 
   async batchAdd(values: T[]): Promise<void> {
+    // handle single value in batchPut
     await this.batchPut(
       Array.from({length: values.length}, (_, i) => ({
         key: this.getId(values[i]),
@@ -128,6 +141,7 @@ export abstract class Repository<I extends Id, T> {
   }
 
   async batchRemove(values: T[]): Promise<void> {
+    // handle single value in batchDelete
     await this.batchDelete(Array.from({length: values.length}, (ignored, i) => this.getId(values[i])));
   }
 


### PR DESCRIPTION
**Motivation**

- `batchDelete()` causes rss memory spike while most of the time we delete only 1 state
```
527859:Jun-03 15:36:48.355[chain]         verbose: Archived state completed finalizedEpoch=180463, minEpoch=179200, storedStateSlots=5734400,5767424,5773760, statesSlotsToDelete=5773760
647957:Jun-03 19:08:09.414[chain]         verbose: Archived state completed finalizedEpoch=180496, minEpoch=179200, storedStateSlots=5734400,5767424,5774816, statesSlotsToDelete=5774816
```

**Description**

- Fallback to regular operation (delete/add/put/remove) if 1 item
- Specifically for `archiveState`, it'll delete 1 or more than 1 state for the 1st time, and it'll delete exactly 1 state from the 2nd time

```
21619763:Jun-08 03:15:38.904[chain]         verbose: Archived state completed finalizedEpoch=206691, minEpoch=204800, storedStateSlots=6553600,6587104,6612448,6613056, statesSlotsToDelete=6612448,6613056 ===> this will call batchDelete, only happen at the 1st time
43719043:Jun-08 06:46:50.966[chain]         verbose: Archived state completed finalizedEpoch=206724, minEpoch=204800, storedStateSlots=6553600,6587104,6614112, statesSlotsToDelete=6614112 ===> this will call delete instead of batchDelete
```

part of #5591

**TODOs**
- [x] Monitor this branch for 12h
