### PR TITLE
fix: adjust decryption worker pool size based on keystore count

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/poolSize.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions/poolSize.ts
@@ -1,17 +1,17 @@
-let defaultPoolSize: number;
+let maxPoolSize: number;
 
 try {
   if (typeof navigator !== "undefined") {
-    defaultPoolSize = navigator.hardwareConcurrency ?? 4;
+    maxPoolSize = navigator.hardwareConcurrency ?? 4;
   } else {
     // TODO change this line to use os.availableParallelism() once we upgrade to node v20
-    defaultPoolSize = (await import("node:os")).cpus().length;
+    maxPoolSize = (await import("node:os")).cpus().length;
   }
 } catch (e) {
-  defaultPoolSize = 8;
+  maxPoolSize = 8;
 }
 
 /**
- * Cross-platform aprox number of logical cores
+ * Cross-platform approx number of logical cores
  */
-export {defaultPoolSize};
+export {maxPoolSize};


### PR DESCRIPTION
**Motivation**

Spawning more worker threads than the number of keystores to decrypt does not make any difference as those workers would just be idle.

Especially during testing where we call `decryptKeystoreDefinitions` multiple times, the extra overhead of spawning those additional workers is quite noticeable.

This change reduces the time of running decrypt tests by at least 50%.

This change is especially important once https://github.com/ChainSafe/lodestar/issues/5438 is implemented as spawning too many workers when handling multiple concurrent requests to `/eth/v1/keystores` (with possibly just a single keystore in each request) would blow up the validator client.

**Description**

Adjust decryption worker pool size based on keystore count.
