### PR TITLE
chore: fix typos in canonical

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -62,10 +62,10 @@ export function getBeaconBlockApi({
           nonFinalizedBlocks.map(async (summary) => {
             const block = await db.block.get(fromHexString(summary.blockRoot));
             if (block) {
-              const cannonical = chain.forkChoice.getCanonicalBlockAtSlot(block.message.slot);
-              if (cannonical) {
-                result.push(toBeaconHeaderResponse(config, block, cannonical.blockRoot === summary.blockRoot));
-                if (isOptimisticBlock(cannonical)) {
+              const canonical = chain.forkChoice.getCanonicalBlockAtSlot(block.message.slot);
+              if (canonical) {
+                result.push(toBeaconHeaderResponse(config, block, canonical.blockRoot === summary.blockRoot));
+                if (isOptimisticBlock(canonical)) {
                   executionOptimistic = true;
                 }
               }

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -122,7 +122,7 @@ export interface IBeaconChain {
   getHeadStateAtCurrentEpoch(regenCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
   getHeadStateAtEpoch(epoch: Epoch, regenCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
 
-  /** Returns a local state cannonical at `slot` */
+  /** Returns a local state canonical at `slot` */
   getStateBySlot(
     slot: Slot,
     opts?: StateGetOpts

--- a/packages/beacon-node/src/metrics/validatorMonitor.ts
+++ b/packages/beacon-node/src/metrics/validatorMonitor.ts
@@ -720,7 +720,7 @@ function renderAttestationSummary(
     // include the attestation. Then block as slot N+1 re-orgs slot N setting as parent A and includes the attestations
     // from block at slot N.
     //
-    // TODO: Track block inclusions, and then check which ones are cannonical
+    // TODO: Track block inclusions, and then check which ones are canonical
 
     if (!summary) {
       // In normal conditions should never happen, validator is expected to submit an attestation to the tracking node.
@@ -728,14 +728,14 @@ function renderAttestationSummary(
       return "unexpected_timely_target_without_summary";
     }
 
-    const cannonicalBlockInclusion = summary.blockInclusions.find((block) => isCannonical(rootCache, block));
-    if (!cannonicalBlockInclusion) {
+    const canonicalBlockInclusion = summary.blockInclusions.find((block) => isCanonical(rootCache, block));
+    if (!canonicalBlockInclusion) {
       // Should never happen, because for a state to exist that registers a validator's participation this specific
       // beacon node must have imported a block with the attestation that caused the change in participation.
-      return "unexpected_timely_target_without_cannonical_inclusion";
+      return "unexpected_timely_target_without_canonical_inclusion";
     }
 
-    const {votedCorrectHeadRoot, blockSlot, attestationSlot} = cannonicalBlockInclusion;
+    const {votedCorrectHeadRoot, blockSlot, attestationSlot} = canonicalBlockInclusion;
     const inclusionDistance = Math.max(blockSlot - attestationSlot - MIN_ATTESTATION_INCLUSION_DELAY, 0);
 
     if (votedCorrectHeadRoot && inclusionDistance === 0) {
@@ -756,11 +756,11 @@ function renderAttestationSummary(
     let out = "timely_target";
 
     if (!votedCorrectHeadRoot) {
-      out += "_" + whyIsHeadVoteWrong(rootCache, cannonicalBlockInclusion);
+      out += "_" + whyIsHeadVoteWrong(rootCache, canonicalBlockInclusion);
     }
 
     if (inclusionDistance > 0) {
-      out += "_" + whyIsDistanceNotOk(rootCache, cannonicalBlockInclusion, summary);
+      out += "_" + whyIsDistanceNotOk(rootCache, canonicalBlockInclusion, summary);
     }
 
     return out;
@@ -785,9 +785,9 @@ function renderAttestationSummary(
       return "no_submission";
     }
 
-    const cannonicalBlockInclusion = summary.blockInclusions.find((block) => isCannonical(rootCache, block));
-    if (cannonicalBlockInclusion) {
-      // Cannonical block inclusion with no participation flags set means wrong target + late source
+    const canonicalBlockInclusion = summary.blockInclusions.find((block) => isCanonical(rootCache, block));
+    if (canonicalBlockInclusion) {
+      // Canonical block inclusion with no participation flags set means wrong target + late source
       return "wrong_target_late_source";
     }
 
@@ -820,9 +820,9 @@ function renderAttestationSummary(
   }
 }
 
-function whyIsHeadVoteWrong(rootCache: RootHexCache, cannonicalBlockInclusion: AttestationBlockInclusion): string {
-  const {votedForMissedSlot, attestationSlot} = cannonicalBlockInclusion;
-  const cannonicalAttestationSlotMissed = isMissedSlot(rootCache, attestationSlot);
+function whyIsHeadVoteWrong(rootCache: RootHexCache, canonicalBlockInclusion: AttestationBlockInclusion): string {
+  const {votedForMissedSlot, attestationSlot} = canonicalBlockInclusion;
+  const canonicalAttestationSlotMissed = isMissedSlot(rootCache, attestationSlot);
 
   // __A_______C
   //    \_B1
@@ -837,7 +837,7 @@ function whyIsHeadVoteWrong(rootCache: RootHexCache, cannonicalBlockInclusion: A
   //
   // We vote for B1, and due to some issue a longer reorg happens orphaning our vote.
   // This scenario is considered in the above
-  if (!votedForMissedSlot && cannonicalAttestationSlotMissed) {
+  if (!votedForMissedSlot && canonicalAttestationSlotMissed) {
     // TODO: Did the block arrive late?
     return "vote_orphaned";
   }
@@ -848,7 +848,7 @@ function whyIsHeadVoteWrong(rootCache: RootHexCache, cannonicalBlockInclusion: A
   //
   // We vote for A assuming skip block, next proposer's view differs
   // This scenario happens sometimes when blocks are published late
-  if (votedForMissedSlot && !cannonicalAttestationSlotMissed) {
+  if (votedForMissedSlot && !canonicalAttestationSlotMissed) {
     // TODO: Did the block arrive late?
     return "wrong_skip_vote";
   }
@@ -872,7 +872,7 @@ function whyIsHeadVoteWrong(rootCache: RootHexCache, cannonicalBlockInclusion: A
 
 function whyIsDistanceNotOk(
   rootCache: RootHexCache,
-  cannonicalBlockInclusion: AttestationBlockInclusion,
+  canonicalBlockInclusion: AttestationBlockInclusion,
   summary: AttestationSummary
 ): string {
   // If the attestation is not included in any aggregate it's likely because it was sent late.
@@ -881,7 +881,7 @@ function whyIsDistanceNotOk(
   }
 
   // If the next slot of an attestation is missed, distance will be > 0 even if everything else was timely
-  if (isMissedSlot(rootCache, cannonicalBlockInclusion.attestationSlot + 1)) {
+  if (isMissedSlot(rootCache, canonicalBlockInclusion.attestationSlot + 1)) {
     return "next_slot_missed";
   }
 
@@ -892,7 +892,7 @@ function whyIsDistanceNotOk(
 }
 
 /** Returns true if the state's root record includes `block` */
-function isCannonical(rootCache: RootHexCache, block: AttestationBlockInclusion): boolean {
+function isCanonical(rootCache: RootHexCache, block: AttestationBlockInclusion): boolean {
   return rootCache.getBlockRootAtSlot(block.blockSlot) === block.blockRoot;
 }
 

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -63,7 +63,7 @@ export async function* onBlocksOrBlobSidecarsByRange(
 
       // Must include only blocks in the range requested
       if (block.slot >= startSlot && block.slot < endSlot) {
-        // Note: Here the forkChoice head may change due to a re-org, so the headChain reflects the cannonical chain
+        // Note: Here the forkChoice head may change due to a re-org, so the headChain reflects the canonical chain
         // at the time of the start of the request. Spec is clear the chain of blobs must be consistent, but on
         // re-org there's no need to abort the request
         // Spec: https://github.com/ethereum/consensus-specs/blob/a1e46d1ae47dd9d097725801575b46907c12a1f8/specs/eip4844/p2p-interface.md#blobssidecarsbyrange-v1

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
@@ -39,7 +39,7 @@ export async function* onBlobSidecarsByRange(
 
       // Must include only blobs in the range requested
       if (block.slot >= startSlot && block.slot < endSlot) {
-        // Note: Here the forkChoice head may change due to a re-org, so the headChain reflects the cannonical chain
+        // Note: Here the forkChoice head may change due to a re-org, so the headChain reflects the canonical chain
         // at the time of the start of the request. Spec is clear the chain of blobs must be consistent, but on
         // re-org there's no need to abort the request
         // Spec: https://github.com/ethereum/consensus-specs/blob/a1e46d1ae47dd9d097725801575b46907c12a1f8/specs/eip4844/p2p-interface.md#blobssidecarsbyrange-v1

--- a/packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlockHeaders.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/blocks/getBlockHeaders.test.ts
@@ -72,11 +72,11 @@ describe("api - beacon - getBlockHeaders", function () {
       generateProtoBlock({slot: 2}),
       generateProtoBlock({slot: 1}),
     ]);
-    const cannonical = generateSignedBlockAtSlot(2);
+    const canonical = generateSignedBlockAtSlot(2);
     server.forkChoiceStub.getCanonicalBlockAtSlot.withArgs(1).returns(generateProtoBlock());
     server.forkChoiceStub.getCanonicalBlockAtSlot
       .withArgs(2)
-      .returns(generateProtoBlock({blockRoot: toHexString(ssz.phase0.BeaconBlock.hashTreeRoot(cannonical.message))}));
+      .returns(generateProtoBlock({blockRoot: toHexString(ssz.phase0.BeaconBlock.hashTreeRoot(canonical.message))}));
     server.dbStub.block.get.onFirstCall().resolves(generateSignedBlockAtSlot(1));
     server.dbStub.block.get.onSecondCall().resolves(generateSignedBlockAtSlot(2));
     const {data: blockHeaders} = await server.blockApi.getBlockHeaders({parentRoot});
@@ -106,11 +106,11 @@ describe("api - beacon - getBlockHeaders", function () {
       generateProtoBlock({slot: 2}),
       generateProtoBlock({slot: 1}),
     ]);
-    const cannonical = generateSignedBlockAtSlot(2);
+    const canonical = generateSignedBlockAtSlot(2);
     server.forkChoiceStub.getCanonicalBlockAtSlot.withArgs(1).returns(generateProtoBlock());
     server.forkChoiceStub.getCanonicalBlockAtSlot
       .withArgs(2)
-      .returns(generateProtoBlock({blockRoot: toHexString(ssz.phase0.BeaconBlock.hashTreeRoot(cannonical.message))}));
+      .returns(generateProtoBlock({blockRoot: toHexString(ssz.phase0.BeaconBlock.hashTreeRoot(canonical.message))}));
     server.dbStub.block.get.onFirstCall().resolves(generateSignedBlockAtSlot(1));
     server.dbStub.block.get.onSecondCall().resolves(generateSignedBlockAtSlot(2));
     const {data: blockHeaders} = await server.blockApi.getBlockHeaders({


### PR DESCRIPTION
**Motivation**

Cleaner and more readable code

**Description**

`cannonical` -> `canonical`
