### PR TITLE
chore: update @chainsafe/blst dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/bls-keygen": "^0.3.0",
     "@chainsafe/bls-keystore": "^2.0.0",
-    "@chainsafe/blst": "^0.2.8",
+    "@chainsafe/blst": "^0.2.9",
     "@chainsafe/discv5": "^3.0.0",
     "@chainsafe/ssz": "^0.10.2",
     "@libp2p/peer-id-factory": "^2.0.3",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -70,7 +70,7 @@
     "buffer-xor": "^2.0.2"
   },
   "devDependencies": {
-    "@chainsafe/blst": "^0.2.8",
+    "@chainsafe/blst": "^0.2.9",
     "@types/buffer-xor": "^2.0.0",
     "@types/mockery": "^1.4.30",
     "mockery": "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -489,11 +489,12 @@
     bls-eth-wasm "^0.4.8"
     randombytes "^2.1.0"
 
-"@chainsafe/blst@^0.2.8":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.2.8.tgz#f4513b48ba26099e2ec366076cc2b5c93b223710"
-  integrity sha512-f3uXSSJcQ+go7qIh9uYZfMaWeA2+XiU8QhRUKor6aqYjVT6N2JdEip3hbVbJu7BIr/qSWOKRQEeGMVNvNfwJQQ==
+"@chainsafe/blst@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.2.9.tgz#b356b47759c3ce127677227fc24faa3ac6c72032"
+  integrity sha512-6MXBUy5Co6k6V9Bv0EC5YrHD7kwWIpzwBO4yCqurLw//Zm3cUmN6DohuYuEGcS4QMNEswa/cXqzZLf+LFBJPiw==
   dependencies:
+    "@types/tar" "^6.1.4"
     node-fetch "^2.6.1"
     node-gyp "^8.4.0"
 


### PR DESCRIPTION
0.2.9 has nodejs v20 support and is otherwise exactly the same