### PR TITLE
chore(scripts): add clean:nm to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "clean": "rm -rf ./packages/*/lib ./packages/*/*.tsbuildinfo",
+    "clean:nm": "rm -rf ./packages/*/node_modules ./node_modules",
     "build": "lerna run build",
     "build:docs": "lerna run build:refdocs && ./scripts/prepare-docs.sh",
     "build:watch": "lerna exec --parallel -- 'yarn run build:watch'",


### PR DESCRIPTION
**Motivation**

I find that when switching branches I occasionally need to delete the node_modules folder and re-run yarn.  This is a helpful script I added and deleted a couple times.  Figured may be helpful for others.

**Description**

1-line package.json script to delete the root and package `node_modules` folders

**Steps to test or reproduce**

from root folder

```sh
git checkout mkeil/clean-nm-script
yarn clean:nm
```