### PR TITLE
refactor: drop observable usage in Discv5Worker for vanila events

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -188,7 +188,7 @@ export class NetworkCore implements INetworkCore {
     const attnetsService = new AttnetsService(config, clock, gossip, metadata, logger, metrics, opts);
     const syncnetsService = new SyncnetsService(config, clock, gossip, metadata, logger, metrics, opts);
 
-    const peerManager = new PeerManager(
+    const peerManager = await PeerManager.init(
       {
         libp2p,
         gossip: gossip,
@@ -218,8 +218,6 @@ export class NetworkCore implements INetworkCore {
     const forkCurrentSlot = config.getForkName(clock.currentSlot);
     // Register only ReqResp protocols relevant to clock's fork
     reqResp.registerProtocolsAtFork(forkCurrentSlot);
-
-    await peerManager.startDiscovery();
 
     // Bind discv5's ENR to local metadata
     discv5 = peerManager["discovery"]?.discv5;

--- a/packages/beacon-node/src/network/discv5/types.ts
+++ b/packages/beacon-node/src/network/discv5/types.ts
@@ -1,7 +1,7 @@
-import {Discv5, ENRData, SignableENRData} from "@chainsafe/discv5";
-import {Observable} from "@chainsafe/threads/observable";
+import {Discv5, ENR, ENRData, SignableENRData} from "@chainsafe/discv5";
 import {ChainConfig} from "@lodestar/config";
 import {LoggerNodeOpts} from "@lodestar/logger/node";
+import {EventDirection} from "../../util/workerEvents.js";
 
 // TODO export IDiscv5Config so we don't need this convoluted type
 type Discv5Config = Parameters<(typeof Discv5)["create"]>[0]["config"];
@@ -43,11 +43,23 @@ export type Discv5WorkerApi = {
   discoverKadValues(): Promise<void>;
   /** Begin a random search through the DHT, return discovered ENRs */
   findRandomNode(): Promise<ENRData[]>;
-  /** Stream of discovered ENRs */
-  discovered(): Observable<ENRData>;
 
   /** Prometheus metrics string */
   scrapeMetrics(): Promise<string>;
   /** tear down discv5 resources */
   close(): Promise<void>;
+};
+
+export const DISCV5_WORKER_EVENTID = "discv5WorkerEvent";
+
+export enum Discv5WorkerEvent {
+  discoveredENR = "discv5-worker.discoveredENR",
+}
+
+export type Discv5WorkerEventData = {
+  [Discv5WorkerEvent.discoveredENR]: ENR;
+};
+
+export const discv5WorkerEventDirection: Record<Discv5WorkerEvent, EventDirection> = {
+  [Discv5WorkerEvent.discoveredENR]: EventDirection.workerToMain,
 };

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -301,6 +301,7 @@ export class PeerDiscovery {
 
     const status = this.handleDiscoveredPeer(peerId, multiaddrTCP, attnets, syncnets);
     this.metrics?.discovery.discoveredStatus.inc({status});
+    this.logger.debug("onDiscoveredENR", {status, peerId: peerId.toString()});
   };
 
   /**


### PR DESCRIPTION
**Motivation**

After merging the network worker PR we are managing events ourselves, no need to depend on Observables if we don't use their features

**Description**

Drop observable usage in Discv5Worker for vanila events

Builds on https://github.com/ChainSafe/lodestar/pull/5618
