### PR TITLE
fix: write keystore cache with 600 permissions

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/keystoreCache.ts
+++ b/packages/cli/src/cmds/validator/keymanager/keystoreCache.ts
@@ -5,6 +5,7 @@ import {Keystore} from "@chainsafe/bls-keystore";
 import {SignerLocal, SignerType} from "@lodestar/validator";
 import {fromHex, toHex} from "@lodestar/utils";
 import {PointFormat} from "@chainsafe/bls/types";
+import {writeFile600Perm} from "../../../util/file.js";
 import {lockFilepath, unlockFilepath} from "../../../util/lockfile.js";
 import {LocalKeystoreDefinition} from "./interface.js";
 
@@ -79,7 +80,7 @@ export async function writeKeystoreCache(
   const keystore = await Keystore.create(password, secretKeyConcatenatedBytes, publicConcatenatedBytes, cacheFilepath);
   if (!fs.existsSync(path.dirname(cacheFilepath))) fs.mkdirSync(path.dirname(cacheFilepath), {recursive: true});
   lockFilepath(cacheFilepath);
-  fs.writeFileSync(cacheFilepath, keystore.stringify());
+  writeFile600Perm(cacheFilepath, keystore.stringify());
   unlockFilepath(cacheFilepath);
 }
 


### PR DESCRIPTION
**Motivation**

Improve cache file security
- Related https://github.com/ChainSafe/lodestar/pull/4594

**Description**

Write keystore cache with `600 (-rw-------)` permission
