### PR TITLE
fix: prevent unhandled rejections in racePromisesWithCutoff

### DIFF
--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -80,11 +80,11 @@ export async function racePromisesWithCutoff<T>(
 ): Promise<(Error | T)[]> {
   // start the cutoff and timeout timers
   let cutoffObserved = false;
-  const cutoffPromise = new Promise((resolve) => setTimeout(resolve, cutoffMs)).then(() => {
+  const cutoffPromise = sleep(cutoffMs).then(() => {
     cutoffObserved = true;
   });
   let timeoutObserved = false;
-  const timeoutPromise = new Promise((resolve) => setTimeout(resolve, timeoutMs)).then(() => {
+  const timeoutPromise = sleep(timeoutMs).then(() => {
     timeoutObserved = true;
   });
   const startTime = Date.now();

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -80,14 +80,12 @@ export async function racePromisesWithCutoff<T>(
 ): Promise<(Error | T)[]> {
   // start the cutoff and timeout timers
   let cutoffObserved = false;
-  const cutoffPromise = new Promise((_resolve, reject) => setTimeout(reject, cutoffMs)).catch((e) => {
+  const cutoffPromise = new Promise((resolve) => setTimeout(resolve, cutoffMs)).then(() => {
     cutoffObserved = true;
-    throw e;
   });
   let timeoutObserved = false;
-  const timeoutPromise = new Promise((_resolve, reject) => setTimeout(reject, timeoutMs)).catch((e) => {
+  const timeoutPromise = new Promise((resolve) => setTimeout(resolve, timeoutMs)).then(() => {
     timeoutObserved = true;
-    throw e;
   });
   const startTime = Date.now();
 

--- a/packages/utils/test/unit/promiserace.test.ts
+++ b/packages/utils/test/unit/promiserace.test.ts
@@ -84,6 +84,20 @@ describe("racePromisesWithCutoff", () => {
     ["none resolve/reject pre timeout", [1600, -1700], ["pending", "pending"], [cutoff, timeout]],
   ];
 
+  let unhandledRejectionListener: (error: Error) => void;
+
+  before(() => {
+    unhandledRejectionListener = (error) => {
+      // eslint-disable-next-line no-console
+      console.error("unhandledRejection", error);
+    };
+    process.on("unhandledRejection", unhandledRejectionListener);
+  });
+
+  after(() => {
+    process.removeListener("unhandledRejection", unhandledRejectionListener);
+  });
+
   for (const [name, promises, results, events] of testcases) {
     it(name, async () => {
       const testPromises = promises.map((timeMs) => {

--- a/packages/utils/test/unit/promiserace.test.ts
+++ b/packages/utils/test/unit/promiserace.test.ts
@@ -84,20 +84,6 @@ describe("racePromisesWithCutoff", () => {
     ["none resolve/reject pre timeout", [1600, -1700], ["pending", "pending"], [cutoff, timeout]],
   ];
 
-  let unhandledRejectionListener: (error: Error) => void;
-
-  before(() => {
-    unhandledRejectionListener = (error) => {
-      // eslint-disable-next-line no-console
-      console.error("unhandledRejection", error);
-    };
-    process.on("unhandledRejection", unhandledRejectionListener);
-  });
-
-  after(() => {
-    process.removeListener("unhandledRejection", unhandledRejectionListener);
-  });
-
   for (const [name, promises, results, events] of testcases) {
     it(name, async () => {
       const testPromises = promises.map((timeMs) => {


### PR DESCRIPTION
**Motivation**

Prevent unhandled promise rejections in `racePromisesWithCutoff`, as reported [in discord](https://discord.com/channels/593655374469660673/743858262864167062/1117247288759304282)

```
10:52:23.013[]                error: uncaughtException: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "undefined".
UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "undefined". This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "undefined".
UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "undefined"
```

and already previously reported [in discord](https://discord.com/channels/593655374469660673/593655641445367808/1099556361471283281)

```
validator_1    | UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "undefined". This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "undefined".
validator_1    | UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "undefined".
```

**Description**

Resolves `cutoffPromise` and `timeoutPromise` promises when timeout is reached instead of rejecting and throwing an error.

This prevents unhandled rejections due to `timeoutPromise` not being handled if we return earlier
https://github.com/ChainSafe/lodestar/blob/f2458491b96a8e3177568928268d5499fa5e20fa/packages/utils/src/promise.ts#L120

we never handle the `timeoutPromise` here
https://github.com/ChainSafe/lodestar/blob/f2458491b96a8e3177568928268d5499fa5e20fa/packages/utils/src/promise.ts#L130

**Related issues**
- https://github.com/ChainSafe/lodestar/issues/5404