### PR TITLE
feat: persist network thread profile

### DIFF
--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -78,7 +78,9 @@ export type Api = {
   /** Trigger to write a heapdump to disk at `dirpath`. May take > 1min */
   writeHeapdump(dirpath?: string): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: {filepath: string}}}>>;
   /** Trigger to write 10m network thread profile to disk */
-  writeNetworkThreadProfile(dirpath?: string): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: {filepath: string}}}>>;
+  writeNetworkThreadProfile(
+    dirpath?: string
+  ): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: {filepath: string}}}>>;
   /** TODO: description */
   getLatestWeakSubjectivityCheckpointEpoch(): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: Epoch}}>>;
   /** TODO: description */

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -79,6 +79,7 @@ export type Api = {
   writeHeapdump(dirpath?: string): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: {filepath: string}}}>>;
   /** Trigger to write 10m network thread profile to disk */
   writeNetworkThreadProfile(
+    duration?: number,
     dirpath?: string
   ): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: {filepath: string}}}>>;
   /** TODO: description */
@@ -129,7 +130,7 @@ export type Api = {
  */
 export const routesData: RoutesData<Api> = {
   writeHeapdump: {url: "/eth/v1/lodestar/writeheapdump", method: "POST"},
-  writeNetworkThreadProfile: {url: "/eth/v1/lodestar/writenetworkthreadprofile", method: "POST"},
+  writeNetworkThreadProfile: {url: "/eth/v1/lodestar/write_network_thread_profile", method: "POST"},
   getLatestWeakSubjectivityCheckpointEpoch: {url: "/eth/v1/lodestar/ws_epoch", method: "GET"},
   getSyncChainsDebugState: {url: "/eth/v1/lodestar/sync-chains-debug-state", method: "GET"},
   getGossipQueueItems: {url: "/eth/v1/lodestar/gossip-queue-items/:gossipType", method: "GET"},
@@ -150,7 +151,7 @@ export const routesData: RoutesData<Api> = {
 
 export type ReqTypes = {
   writeHeapdump: {query: {dirpath?: string}};
-  writeNetworkThreadProfile: {query: {dirpath?: string}};
+  writeNetworkThreadProfile: {query: {duration?: number; dirpath?: string}};
   getLatestWeakSubjectivityCheckpointEpoch: ReqEmpty;
   getSyncChainsDebugState: ReqEmpty;
   getGossipQueueItems: {params: {gossipType: string}};
@@ -177,8 +178,8 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
       schema: {query: {dirpath: Schema.String}},
     },
     writeNetworkThreadProfile: {
-      writeReq: (dirpath) => ({query: {dirpath}}),
-      parseReq: ({query}) => [query.dirpath],
+      writeReq: (duration, dirpath) => ({query: {duration, dirpath}}),
+      parseReq: ({query}) => [query.duration, query.dirpath],
       schema: {query: {dirpath: Schema.String}},
     },
     getLatestWeakSubjectivityCheckpointEpoch: reqEmpty,

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -77,6 +77,8 @@ export type LodestarNodePeer = NodePeer & {
 export type Api = {
   /** Trigger to write a heapdump to disk at `dirpath`. May take > 1min */
   writeHeapdump(dirpath?: string): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: {filepath: string}}}>>;
+  /** Trigger to write 10m profile file of network thread to disk */
+  writeNetworkThreadProfile(): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: {filepath: string}}}>>;
   /** TODO: description */
   getLatestWeakSubjectivityCheckpointEpoch(): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: Epoch}}>>;
   /** TODO: description */
@@ -125,6 +127,7 @@ export type Api = {
  */
 export const routesData: RoutesData<Api> = {
   writeHeapdump: {url: "/eth/v1/lodestar/writeheapdump", method: "POST"},
+  writeNetworkThreadProfile: {url: "/eth/v1/lodestar/writenetworkthreadprofile", method: "POST"},
   getLatestWeakSubjectivityCheckpointEpoch: {url: "/eth/v1/lodestar/ws_epoch", method: "GET"},
   getSyncChainsDebugState: {url: "/eth/v1/lodestar/sync-chains-debug-state", method: "GET"},
   getGossipQueueItems: {url: "/eth/v1/lodestar/gossip-queue-items/:gossipType", method: "GET"},
@@ -145,6 +148,7 @@ export const routesData: RoutesData<Api> = {
 
 export type ReqTypes = {
   writeHeapdump: {query: {dirpath?: string}};
+  writeNetworkThreadProfile: ReqEmpty;
   getLatestWeakSubjectivityCheckpointEpoch: ReqEmpty;
   getSyncChainsDebugState: ReqEmpty;
   getGossipQueueItems: {params: {gossipType: string}};
@@ -170,6 +174,7 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
       parseReq: ({query}) => [query.dirpath],
       schema: {query: {dirpath: Schema.String}},
     },
+    writeNetworkThreadProfile: reqEmpty,
     getLatestWeakSubjectivityCheckpointEpoch: reqEmpty,
     getSyncChainsDebugState: reqEmpty,
     getGossipQueueItems: {
@@ -212,6 +217,7 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 export function getReturnTypes(): ReturnTypes<Api> {
   return {
     writeHeapdump: sameType(),
+    writeNetworkThreadProfile: sameType(),
     getLatestWeakSubjectivityCheckpointEpoch: sameType(),
     getSyncChainsDebugState: jsonType("snake"),
     getGossipQueueItems: jsonType("snake"),

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -77,8 +77,8 @@ export type LodestarNodePeer = NodePeer & {
 export type Api = {
   /** Trigger to write a heapdump to disk at `dirpath`. May take > 1min */
   writeHeapdump(dirpath?: string): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: {filepath: string}}}>>;
-  /** Trigger to write 10m profile file of network thread to disk */
-  writeNetworkThreadProfile(): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: {filepath: string}}}>>;
+  /** Trigger to write 10m network thread profile to disk */
+  writeNetworkThreadProfile(dirpath?: string): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: {filepath: string}}}>>;
   /** TODO: description */
   getLatestWeakSubjectivityCheckpointEpoch(): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: Epoch}}>>;
   /** TODO: description */
@@ -148,7 +148,7 @@ export const routesData: RoutesData<Api> = {
 
 export type ReqTypes = {
   writeHeapdump: {query: {dirpath?: string}};
-  writeNetworkThreadProfile: ReqEmpty;
+  writeNetworkThreadProfile: {query: {dirpath?: string}};
   getLatestWeakSubjectivityCheckpointEpoch: ReqEmpty;
   getSyncChainsDebugState: ReqEmpty;
   getGossipQueueItems: {params: {gossipType: string}};
@@ -174,7 +174,11 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
       parseReq: ({query}) => [query.dirpath],
       schema: {query: {dirpath: Schema.String}},
     },
-    writeNetworkThreadProfile: reqEmpty,
+    writeNetworkThreadProfile: {
+      writeReq: (dirpath) => ({query: {dirpath}}),
+      parseReq: ({query}) => [query.dirpath],
+      schema: {query: {dirpath: Schema.String}},
+    },
     getLatestWeakSubjectivityCheckpointEpoch: reqEmpty,
     getSyncChainsDebugState: reqEmpty,
     getGossipQueueItems: {

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -19,6 +19,7 @@ export function getLodestarApi({
   sync,
 }: Pick<ApiModules, "chain" | "config" | "db" | "network" | "sync">): ServerApi<routes.lodestar.Api> {
   let writingHeapdump = false;
+  let writingNetworkProfile = false;
 
   return {
     async writeHeapdump(dirpath = ".") {
@@ -47,9 +48,17 @@ export function getLodestarApi({
       }
     },
 
-    async writeNetworkThreadProfile() {
-      const filepath = await network.takeProfile();
-      return {data: {filepath}};
+    async writeNetworkThreadProfile(dirpath = ".") {
+      if (writingNetworkProfile) {
+        throw Error("Already writing network profile");
+      }
+
+      try {
+        const filepath = await network.writeNetworkThreadProfile(dirpath);
+        return {data: {filepath}};
+      } finally {
+        writingNetworkProfile = false;
+      }
     },
 
     async getLatestWeakSubjectivityCheckpointEpoch() {

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -48,13 +48,13 @@ export function getLodestarApi({
       }
     },
 
-    async writeNetworkThreadProfile(dirpath = ".") {
+    async writeNetworkThreadProfile(durationMs?: number, dirpath?: string) {
       if (writingNetworkProfile) {
         throw Error("Already writing network profile");
       }
 
       try {
-        const filepath = await network.writeNetworkThreadProfile(dirpath);
+        const filepath = await network.writeNetworkThreadProfile(durationMs, dirpath);
         return {data: {filepath}};
       } finally {
         writingNetworkProfile = false;

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -47,6 +47,11 @@ export function getLodestarApi({
       }
     },
 
+    async writeNetworkThreadProfile() {
+      const filepath = await network.takeProfile();
+      return {data: {filepath}};
+    },
+
     async getLatestWeakSubjectivityCheckpointEpoch() {
       const state = chain.getHeadState();
       return {data: getLatestWeakSubjectivityCheckpointEpoch(config, state)};

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -412,7 +412,7 @@ export class NetworkCore implements INetworkCore {
     return meshPeers;
   }
 
-  async takeProfile(): Promise<string> {
+  async writeNetworkThreadProfile(): Promise<string> {
     throw new Error("Method not implemented, please configure network thread");
   }
 

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -412,6 +412,10 @@ export class NetworkCore implements INetworkCore {
     return meshPeers;
   }
 
+  async takeProfile(): Promise<string> {
+    throw new Error("Method not implemented, please configure network thread");
+  }
+
   /**
    * Handle subscriptions through fork transitions, @see FORK_EPOCH_LOOKAHEAD
    */

--- a/packages/beacon-node/src/network/core/networkCoreWorker.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorker.ts
@@ -170,6 +170,10 @@ const libp2pWorkerApi: NetworkWorkerApi = {
             } else {
               reject(err);
             }
+
+            // Detach from the inspector and close the session
+            session.post("Profiler.disable");
+            session.disconnect();
           });
         });
       });

--- a/packages/beacon-node/src/network/core/networkCoreWorker.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorker.ts
@@ -164,7 +164,7 @@ const libp2pWorkerApi: NetworkWorkerApi = {
           session.post("Profiler.stop", (err, {profile}) => {
             // Write profile to disk, upload, etc.
             if (!err) {
-              const filePath = `network_thread_${new Date().toISOString()}.profile`;
+              const filePath = `network_thread_${new Date().toISOString()}.cpuprofile`;
               fs.writeFileSync(filePath, JSON.stringify(profile));
               resolve(filePath);
             } else {

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -210,8 +210,8 @@ export class WorkerNetworkCore implements INetworkCore {
   dumpMeshPeers(): Promise<Record<string, string[]>> {
     return this.getApi().dumpMeshPeers();
   }
-  writeNetworkThreadProfile(dirpath?: string): Promise<string> {
-    return this.getApi().writeProfile(dirpath);
+  writeNetworkThreadProfile(durationMs?: number, dirpath?: string): Promise<string> {
+    return this.getApi().writeProfile(durationMs, dirpath);
   }
 
   private getApi(): NetworkWorkerApi {

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -210,8 +210,8 @@ export class WorkerNetworkCore implements INetworkCore {
   dumpMeshPeers(): Promise<Record<string, string[]>> {
     return this.getApi().dumpMeshPeers();
   }
-  takeProfile(): Promise<string> {
-    return this.getApi().takeProfile();
+  writeNetworkThreadProfile(dirpath?: string): Promise<string> {
+    return this.getApi().writeProfile(dirpath);
   }
 
   private getApi(): NetworkWorkerApi {

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -210,6 +210,9 @@ export class WorkerNetworkCore implements INetworkCore {
   dumpMeshPeers(): Promise<Record<string, string[]>> {
     return this.getApi().dumpMeshPeers();
   }
+  takeProfile(): Promise<string> {
+    return this.getApi().takeProfile();
+  }
 
   private getApi(): NetworkWorkerApi {
     return this.modules.workerApi;

--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -61,6 +61,7 @@ export interface INetworkCore extends INetworkCorePublic {
 
   close(): Promise<void>;
   scrapeMetrics(): Promise<string>;
+  takeProfile(): Promise<string>;
 }
 
 /**
@@ -99,6 +100,7 @@ export type NetworkWorkerApi = INetworkCorePublic & {
 
   close(): Promise<void>;
   scrapeMetrics(): Promise<string>;
+  takeProfile(): Promise<string>;
 
   // TODO: ReqResp outgoing
   // TODO: ReqResp incoming

--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -61,7 +61,7 @@ export interface INetworkCore extends INetworkCorePublic {
 
   close(): Promise<void>;
   scrapeMetrics(): Promise<string>;
-  takeProfile(): Promise<string>;
+  writeNetworkThreadProfile(dirpath?: string): Promise<string>;
 }
 
 /**
@@ -100,7 +100,7 @@ export type NetworkWorkerApi = INetworkCorePublic & {
 
   close(): Promise<void>;
   scrapeMetrics(): Promise<string>;
-  takeProfile(): Promise<string>;
+  writeProfile(dirpath?: string): Promise<string>;
 
   // TODO: ReqResp outgoing
   // TODO: ReqResp incoming

--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -61,7 +61,7 @@ export interface INetworkCore extends INetworkCorePublic {
 
   close(): Promise<void>;
   scrapeMetrics(): Promise<string>;
-  writeNetworkThreadProfile(dirpath?: string): Promise<string>;
+  writeNetworkThreadProfile(durationMs?: number, dirpath?: string): Promise<string>;
 }
 
 /**
@@ -100,7 +100,7 @@ export type NetworkWorkerApi = INetworkCorePublic & {
 
   close(): Promise<void>;
   scrapeMetrics(): Promise<string>;
-  writeProfile(dirpath?: string): Promise<string>;
+  writeProfile(durationMs?: number, dirpath?: string): Promise<string>;
 
   // TODO: ReqResp outgoing
   // TODO: ReqResp incoming

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -60,6 +60,7 @@ export interface INetwork extends INetworkCorePublic {
 
   // Debug
   dumpGossipQueue(gossipType: GossipType): Promise<PendingGossipsubMessage[]>;
+  takeProfile(): Promise<string>;
 }
 
 export type PeerDirection = Connection["stat"]["direction"];

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -60,7 +60,7 @@ export interface INetwork extends INetworkCorePublic {
 
   // Debug
   dumpGossipQueue(gossipType: GossipType): Promise<PendingGossipsubMessage[]>;
-  takeProfile(): Promise<string>;
+  writeNetworkThreadProfile(dirpath?: string): Promise<string>;
 }
 
 export type PeerDirection = Connection["stat"]["direction"];

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -60,7 +60,7 @@ export interface INetwork extends INetworkCorePublic {
 
   // Debug
   dumpGossipQueue(gossipType: GossipType): Promise<PendingGossipsubMessage[]>;
-  writeNetworkThreadProfile(dirpath?: string): Promise<string>;
+  writeNetworkThreadProfile(durationMs?: number, dirpath?: string): Promise<string>;
 }
 
 export type PeerDirection = Connection["stat"]["direction"];

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -544,6 +544,10 @@ export class Network implements INetwork {
     return this.networkProcessor.dumpGossipQueue(gossipType);
   }
 
+  async takeProfile(): Promise<string> {
+    return this.core.takeProfile();
+  }
+
   private onLightClientFinalityUpdate = async (finalityUpdate: allForks.LightClientFinalityUpdate): Promise<void> => {
     // TODO: Review is OK to remove if (this.hasAttachedSyncCommitteeMember())
 

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -544,8 +544,8 @@ export class Network implements INetwork {
     return this.networkProcessor.dumpGossipQueue(gossipType);
   }
 
-  async writeNetworkThreadProfile(dirpath = "."): Promise<string> {
-    return this.core.writeNetworkThreadProfile(dirpath);
+  async writeNetworkThreadProfile(durationMs?: number, dirpath?: string): Promise<string> {
+    return this.core.writeNetworkThreadProfile(durationMs, dirpath);
   }
 
   private onLightClientFinalityUpdate = async (finalityUpdate: allForks.LightClientFinalityUpdate): Promise<void> => {

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -544,8 +544,8 @@ export class Network implements INetwork {
     return this.networkProcessor.dumpGossipQueue(gossipType);
   }
 
-  async takeProfile(): Promise<string> {
-    return this.core.takeProfile();
+  async writeNetworkThreadProfile(dirpath = "."): Promise<string> {
+    return this.core.writeNetworkThreadProfile(dirpath);
   }
 
   private onLightClientFinalityUpdate = async (finalityUpdate: allForks.LightClientFinalityUpdate): Promise<void> => {

--- a/packages/beacon-node/src/util/profile.ts
+++ b/packages/beacon-node/src/util/profile.ts
@@ -1,0 +1,34 @@
+import {sleep} from "@lodestar/utils";
+
+const DEFAULT_PROFILE_DURATION = 10 * 60 * 1000;
+
+/**
+ * Take 10m profile of the current thread without promise tracking.
+ */
+export async function profileNodeJS(): Promise<string> {
+  const inspector = await import("node:inspector");
+
+  // due to some typing issues, not able to use promisify here
+  return new Promise<string>((resolve, reject) => {
+    // Start the inspector and connect to it
+    const session = new inspector.Session();
+    session.connect();
+
+    session.post("Profiler.enable", () => {
+      session.post("Profiler.start", async () => {
+        await sleep(DEFAULT_PROFILE_DURATION);
+        session.post("Profiler.stop", (err, {profile}) => {
+          if (!err) {
+            resolve(JSON.stringify(profile));
+          } else {
+            reject(err);
+          }
+
+          // Detach from the inspector and close the session
+          session.post("Profiler.disable");
+          session.disconnect();
+        });
+      });
+    });
+  });
+}

--- a/packages/beacon-node/src/util/profile.ts
+++ b/packages/beacon-node/src/util/profile.ts
@@ -1,11 +1,9 @@
 import {sleep} from "@lodestar/utils";
 
-const DEFAULT_PROFILE_DURATION = 10 * 60 * 1000;
-
 /**
  * Take 10m profile of the current thread without promise tracking.
  */
-export async function profileNodeJS(): Promise<string> {
+export async function profileNodeJS(durationMs: number): Promise<string> {
   const inspector = await import("node:inspector");
 
   // due to some typing issues, not able to use promisify here
@@ -16,7 +14,7 @@ export async function profileNodeJS(): Promise<string> {
 
     session.post("Profiler.enable", () => {
       session.post("Profiler.start", async () => {
-        await sleep(DEFAULT_PROFILE_DURATION);
+        await sleep(durationMs);
         session.post("Profiler.stop", (err, {profile}) => {
           if (!err) {
             resolve(JSON.stringify(profile));

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -140,6 +140,7 @@ describe("data serialization through worker boundary", function () {
     publishGossip: ["test-topic", bytes, {allowPublishToZeroPeers: true, ignoreDuplicatePublishError: true}],
     close: [],
     scrapeMetrics: [],
+    writeProfile: [""],
   };
 
   const lodestarPeer: routes.lodestar.LodestarNodePeer = {
@@ -201,6 +202,7 @@ describe("data serialization through worker boundary", function () {
     publishGossip: 1,
     close: null,
     scrapeMetrics: "test-metrics",
+    writeProfile: "",
   };
 
   type TestCase = {id: string; data: unknown; shouldFail?: boolean};

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -140,7 +140,7 @@ describe("data serialization through worker boundary", function () {
     publishGossip: ["test-topic", bytes, {allowPublishToZeroPeers: true, ignoreDuplicatePublishError: true}],
     close: [],
     scrapeMetrics: [],
-    writeProfile: [""],
+    writeProfile: [0, ""],
   };
 
   const lodestarPeer: routes.lodestar.LodestarNodePeer = {


### PR DESCRIPTION
**Motivation**

- We want to take profile of network thread without promise tracking

**Description**

- Use `node:inspector` module to persist network thread profile
- 
part of #5604
