### PR TITLE
fix: fix the blobs side cars by range response

### DIFF
--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
@@ -65,11 +65,11 @@ export function* iterateBlobBytesFromWrapper(
   blobSideCarsBytesWrapped: Uint8Array,
   blockSlot: Slot
 ): Iterable<ResponseOutgoing> {
-  const blobSideCarsBytes = blobSideCarsBytesWrapped.slice(BLOB_SIDECARS_IN_WRAPPER_INDEX);
-  const blobsLen = blobSideCarsBytes.length / BLOBSIDECAR_FIXED_SIZE;
+  const allBlobSideCarsBytes = blobSideCarsBytesWrapped.slice(BLOB_SIDECARS_IN_WRAPPER_INDEX);
+  const blobsLen = allBlobSideCarsBytes.length / BLOBSIDECAR_FIXED_SIZE;
 
   for (let index = 0; index < blobsLen; index++) {
-    const blobSideCarBytes = blobSideCarsBytes.slice(
+    const blobSideCarBytes = allBlobSideCarsBytes.slice(
       index * BLOBSIDECAR_FIXED_SIZE,
       (index + 1) * BLOBSIDECAR_FIXED_SIZE
     );
@@ -80,7 +80,7 @@ export function* iterateBlobBytesFromWrapper(
       );
     }
     yield {
-      data: blobSideCarsBytes,
+      data: blobSideCarBytes,
       fork: chain.config.getForkName(blockSlot),
     };
   }


### PR DESCRIPTION
fix a typo which was in the yielding the response for blob side car bytes which cause all blobs for the block to be passed rather than the extracted blobsidecar bytes.

PR fixes that and also renames variables a bit to avoid confusion