### PR TITLE
test: make results of keymanager e2e tests deterministic

### DIFF
--- a/packages/cli/test/utils/keymanagerTestRunners.ts
+++ b/packages/cli/test/utils/keymanagerTestRunners.ts
@@ -3,7 +3,7 @@ import {Api, getClient} from "@lodestar/api/keymanager";
 import {config} from "@lodestar/config/default";
 import {ApiError} from "@lodestar/api";
 import {getMockBeaconApiServer} from "./mockBeaconApiServer.js";
-import {AfterEachCallback, expectDeepEquals, findApiToken, itDone} from "./runUtils.js";
+import {AfterEachCallback, expectDeepEqualsUnordered, findApiToken, itDone} from "./runUtils.js";
 import {DescribeArgs} from "./childprocRunner.js";
 
 type TestContext = {
@@ -78,7 +78,8 @@ export function getKeymanagerTestRunner({args: {spawnCli}, afterEachCallbacks, d
 export async function expectKeys(keymanagerClient: Api, expectedPubkeys: string[], message: string): Promise<void> {
   const keys = await keymanagerClient.listKeys();
   ApiError.assert(keys);
-  expectDeepEquals(
+  // The order of keys isn't always deterministic so we can't use deep equal
+  expectDeepEqualsUnordered(
     keys.response.data,
     expectedPubkeys.map((pubkey) => ({validatingPubkey: pubkey, derivationPath: "", readonly: false})),
     message

--- a/packages/cli/test/utils/runUtils.ts
+++ b/packages/cli/test/utils/runUtils.ts
@@ -20,6 +20,13 @@ export function expectDeepEquals<T>(a: T, b: T, message: string): void {
   expect(a).deep.equals(b, message);
 }
 
+/**
+ * Similar to `expectDeepEquals` but only checks presence of all elements in array, irrespective of their order.
+ */
+export function expectDeepEqualsUnordered<T>(a: T[], b: T[], message: string): void {
+  expect(a).to.have.deep.members(b, message);
+}
+
 export type DoneCb = (err?: Error) => void;
 
 /**


### PR DESCRIPTION
**Motivation**

Keystores are decrypted in parallel now (https://github.com/ChainSafe/lodestar/pull/5624) which means the order in which they are added to the validator store  (`validatorStore.addSigner`) is no longer deterministic.
https://github.com/ChainSafe/lodestar/blob/f07d97f5ff45e64ad45a00d9c829a4f0a899f055/packages/cli/src/cmds/validator/keymanager/impl.ts#L166

This makes the result of keymanager e2e non-deterministic and causes e2e tests to fail randomly.

![image](https://github.com/ChainSafe/lodestar/assets/38436224/6be8b3de-b284-4cbb-b66f-f92097909ea7)

However, the order of signers in validator store does not matter which means the assertion can be updated to check the response in an unordered way.

**Description**

This change makes results of keymanager e2e tests deterministic, we only need to check the presence of all keys in response, irrespective of their order.