### PR TITLE
fix!: match beacon APIs URL casing

### DIFF
--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -129,24 +129,24 @@ export type Api = {
  * Define javascript values for each route
  */
 export const routesData: RoutesData<Api> = {
-  writeHeapdump: {url: "/eth/v1/lodestar/writeheapdump", method: "POST"},
+  writeHeapdump: {url: "/eth/v1/lodestar/write_heapdump", method: "POST"},
   writeNetworkThreadProfile: {url: "/eth/v1/lodestar/write_network_thread_profile", method: "POST"},
   getLatestWeakSubjectivityCheckpointEpoch: {url: "/eth/v1/lodestar/ws_epoch", method: "GET"},
-  getSyncChainsDebugState: {url: "/eth/v1/lodestar/sync-chains-debug-state", method: "GET"},
-  getGossipQueueItems: {url: "/eth/v1/lodestar/gossip-queue-items/:gossipType", method: "GET"},
-  getRegenQueueItems: {url: "/eth/v1/lodestar/regen-queue-items", method: "GET"},
-  getBlockProcessorQueueItems: {url: "/eth/v1/lodestar/block-processor-queue-items", method: "GET"},
-  getStateCacheItems: {url: "/eth/v1/lodestar/state-cache-items", method: "GET"},
-  getGossipPeerScoreStats: {url: "/eth/v1/lodestar/gossip-peer-score-stats", method: "GET"},
-  getLodestarPeerScoreStats: {url: "/eth/v1/lodestar/lodestar-peer-score-stats", method: "GET"},
+  getSyncChainsDebugState: {url: "/eth/v1/lodestar/sync_chains_debug_state", method: "GET"},
+  getGossipQueueItems: {url: "/eth/v1/lodestar/gossip_queue_items/:gossipType", method: "GET"},
+  getRegenQueueItems: {url: "/eth/v1/lodestar/regen_queue_items", method: "GET"},
+  getBlockProcessorQueueItems: {url: "/eth/v1/lodestar/block_processor_queue_items", method: "GET"},
+  getStateCacheItems: {url: "/eth/v1/lodestar/state_cache_items", method: "GET"},
+  getGossipPeerScoreStats: {url: "/eth/v1/lodestar/gossip_peer_score_stats", method: "GET"},
+  getLodestarPeerScoreStats: {url: "/eth/v1/lodestar/lodestar_peer_score_stats", method: "GET"},
   runGC: {url: "/eth/v1/lodestar/gc", method: "POST"},
-  dropStateCache: {url: "/eth/v1/lodestar/drop-state-cache", method: "POST"},
+  dropStateCache: {url: "/eth/v1/lodestar/drop_state_cache", method: "POST"},
   connectPeer: {url: "/eth/v1/lodestar/connect_peer", method: "POST"},
   disconnectPeer: {url: "/eth/v1/lodestar/disconnect_peer", method: "POST"},
   getPeers: {url: "/eth/v1/lodestar/peers", method: "GET"},
-  discv5GetKadValues: {url: "/eth/v1/debug/discv5-kad-values", method: "GET"},
-  dumpDbBucketKeys: {url: "/eth/v1/debug/dump-db-bucket-keys/:bucket", method: "GET"},
-  dumpDbStateIndex: {url: "/eth/v1/debug/dump-db-state-index", method: "GET"},
+  discv5GetKadValues: {url: "/eth/v1/debug/discv5_kad_values", method: "GET"},
+  dumpDbBucketKeys: {url: "/eth/v1/debug/dump_db_bucket_keys/:bucket", method: "GET"},
+  dumpDbStateIndex: {url: "/eth/v1/debug/dump_db_state_index", method: "GET"},
 };
 
 export type ReqTypes = {


### PR DESCRIPTION
**Motivation**

lodestar API routes, should match beacon APIs URL casing

- See https://github.com/ChainSafe/lodestar/pull/5628#discussion_r1226187456

**Description**

Set all existing routes casing to snake case. This is a breaking change but I'm not aware of us explicitly guaranteeing backwards compatibility with them. Maybe it should be clear somewhere in another PR that those are dev routes
