### PR TITLE
feat: add option to force checkpoint sync

### DIFF
--- a/docs/usage/beacon-management.md
+++ b/docs/usage/beacon-management.md
@@ -120,6 +120,15 @@ In case you really trust `checkpointSyncUrl` then you may skip providing `wssChe
 If possible, validate your `wssCheckpoint` from multiple places (e.g. different client distributions) or from other trusted sources. This will highly reduce the risk of starting off on a malicious chain.
 <!-- prettier-ignore-end -->
 
+**Taking too long to sync?**
+
+After your node has been offline for a while, it might be the case that it takes a long time to sync even though a `checkpointSyncUrl` is specified.
+This is due to the fact that the last db state is still within the weak subjectivity period (~15 days on mainnet) which causes the node
+to sync from the db state instead of the checkpoint state.
+
+It is possible to force syncing from checkpoint state by supplying the `--forceCheckpointSync` flag. This option is only recommended if it is absolutely
+necessary for the node to be synced right away to fulfill its duties as there is an inherent risk each time the state is obtained from an external source.
+
 ### Guide to the sync logs
 
 Lodestar beacon sync log aims to provide information of utmost importance  about your node and yet be suucint at the same time. You may see the sync logs in the following format:

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -84,6 +84,9 @@ export async function initBeaconState(
   logger: Logger,
   signal: AbortSignal
 ): Promise<{anchorState: BeaconStateAllForks; wsCheckpoint?: Checkpoint}> {
+  if (args.forceCheckpointSync && !(args.checkpointState || args.checkpointSyncUrl)) {
+    throw new Error("Forced checkpoint sync without specifying a checkpointState or checkpointSyncUrl");
+  }
   // fetch the latest state stored in the db which will be used in all cases, if it exists, either
   //   i)  used directly as the anchor state
   //   ii) used during verification of a weak subjectivity state,
@@ -91,15 +94,26 @@ export async function initBeaconState(
   if (lastDbState) {
     const config = createBeaconConfig(chainForkConfig, lastDbState.genesisValidatorsRoot);
     const wssCheck = isWithinWeakSubjectivityPeriod(config, lastDbState, getCheckpointFromState(lastDbState));
-    // All cases when we want to directly use lastDbState as the anchor state:
-    //  - if no checkpoint sync args provided, or
-    //  - the lastDbState is within weak subjectivity period:
-    if ((!args.checkpointState && !args.checkpointSyncUrl) || wssCheck) {
-      const anchorState = await initStateFromAnchorState(config, db, logger, lastDbState, {
-        isWithinWeakSubjectivityPeriod: wssCheck,
-        isCheckpointState: false,
-      });
-      return {anchorState};
+
+    // Explicitly force syncing from checkpoint state
+    if (args.forceCheckpointSync) {
+      // Forcing to sync from checkpoint is only recommended if node is taking too long to sync from last db state.
+      // It is important to remind the user to remove this flag again unless it is absolutely necessary.
+      if (wssCheck) {
+        logger.warn("Forced syncing from checkpoint even though db state is within weak subjectivity period");
+        logger.warn("Please consider removing --forceCheckpointSync flag unless absolutely necessary");
+      }
+    } else {
+      // All cases when we want to directly use lastDbState as the anchor state:
+      //  - if no checkpoint sync args provided, or
+      //  - the lastDbState is within weak subjectivity period:
+      if ((!args.checkpointState && !args.checkpointSyncUrl) || wssCheck) {
+        const anchorState = await initStateFromAnchorState(config, db, logger, lastDbState, {
+          isWithinWeakSubjectivityPeriod: wssCheck,
+          isCheckpointState: false,
+        });
+        return {anchorState};
+      }
     }
   }
 

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -12,6 +12,7 @@ type BeaconExtraArgs = {
   checkpointSyncUrl?: string;
   checkpointState?: string;
   wssCheckpoint?: string;
+  forceCheckpointSync?: boolean;
   beaconDir?: string;
   dbDir?: string;
   persistInvalidSszObjectsDir?: string;
@@ -63,6 +64,13 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
     description:
       "Start beacon node off a state at the provided weak subjectivity checkpoint, to be supplied in <blockRoot>:<epoch> format. For example, 0x1234:100 will sync and start off from the weakSubjectivity state at checkpoint of epoch 100 with block root 0x1234.",
     type: "string",
+    group: "weak subjectivity",
+  },
+
+  forceCheckpointSync: {
+    description:
+      "Force syncing from checkpoint state even if db state is within weak subjectivity period. This helps to avoid long sync times after node has been offline for a while.",
+    type: "boolean",
     group: "weak subjectivity",
   },
 


### PR DESCRIPTION
**Motivation**

As [discussed on discord](https://discord.com/channels/593655374469660673/605818244036821012/1100019913734770729):

After your node has been offline for a while, it might be the case that it takes a long time to sync even though a `checkpointSyncUrl` is specified.
This is due to the fact that the last db state is still within the weak subjectivity period (~15 days on mainnet) which causes the node to sync from the db state instead of the checkpoint state.

This behavior might not always be desired as it could take quite a while  (possibly several hours) for node to be synced again and to be able to fulfill its duties.

The only option that exists right now to force syncing from a checkpoint state and avoid long sync times is to delete the existing db which is not an ideal solution for this problem, especially once Lodestar enables backfill sync (all historical blocks would have to be re-downloaded).

This PR provides a quick option to get the node synced again without having to mess with the existing db. This is quite useful during development and also for any user who's node has been offline (e.g. due to maintenance) for a while but not long enough to be outside of ws period.

**Description**

- adds new flag `--forceCheckpointSync` to force syncing from checkpoint state even if db state is within weak subjectivity period
- throw error flag is specified without providing either a `checkpointState` or `checkpointSyncUrl`
- logs warning to inform the user that forcing checkpoint sync should only be used if absolutely necessary

**Forcing checkpoint sync without providing checkpoint**
```sh
Jun-15 13:18:31.486[]                 info: Connected to LevelDB database path=/home/devops/data/chain-db
 ✖ Error: Forced checkpoint sync without specifying a checkpointState or checkpointSyncUrl
    at initBeaconState (file:///home/devops/lodestar/packages/cli/src/cmds/beacon/initBeaconState.ts:88:11)
    at Object.beaconHandler [as handler] (file:///home/devops/lodestar/packages/cli/src/cmds/beacon/handler.ts:66:47))
```

**Forcing checkpoint sync with valid db state**
```sh
Jun-15 13:23:01.404[]                 info: Connected to LevelDB database path=/home/devops/data/chain-db
Jun-15 13:23:10.844[]                 warn: Forced syncing from checkpoint even though db state is within weak subjectivity period
Jun-15 13:23:10.844[]                 warn: Please consider removing --forceCheckpointSync flag unless absolutely necessary
Jun-15 13:23:10.845[]                 info: Fetching checkpoint state checkpointSyncUrl=https://beaconstate-goerli.chainsafe.io
Jun-15 13:23:16.915[]                 info: Download completed stateId=finalized
Jun-15 13:23:23.280[]                 info: Initializing beacon from a valid checkpoint state slot=5859904, epoch=183122, stateRoot=0x71198a605a8aa0d509f50a7c7ae1cd0b6f333e8dda599f41b8f716efb442ed6f, isWithinWeakSubjectivityPeriod=true
```
