### PR TITLE
fix: unknown block sync to subscribe/unsubscribe to network events

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -492,6 +492,11 @@ export function createLodestarMetrics(
     },
 
     syncUnknownBlock: {
+      switchNetworkSubscriptions: register.gauge<"action">({
+        name: "lodestar_sync_unknown_block_network_subscriptions_count",
+        help: "Switch network subscriptions on/off",
+        labelNames: ["action"],
+      }),
       requests: register.gauge<"type">({
         name: "lodestar_sync_unknown_block_requests_total",
         help: "Total number of unknown block events or requests",

--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -196,36 +196,48 @@ export class BeaconSync implements IBeaconSync {
     const state = this.state; // Don't run the getter twice
 
     // We have become synced, subscribe to all the gossip core topics
-    if (
-      state === SyncState.Synced &&
-      !this.network.isSubscribedToGossipCoreTopics() &&
-      this.chain.clock.currentEpoch >= MIN_EPOCH_TO_START_GOSSIP
-    ) {
-      this.network
-        .subscribeGossipCoreTopics()
-        .then(() => {
-          this.metrics?.syncSwitchGossipSubscriptions.inc({action: "subscribed"});
-          this.logger.info("Subscribed gossip core topics");
-        })
-        .catch((e) => {
-          this.logger.error("Error subscribing to gossip core topics", {}, e);
-        });
+    if (state === SyncState.Synced && this.chain.clock.currentEpoch >= MIN_EPOCH_TO_START_GOSSIP) {
+      if (!this.network.isSubscribedToGossipCoreTopics()) {
+        this.network
+          .subscribeGossipCoreTopics()
+          .then(() => {
+            this.metrics?.syncSwitchGossipSubscriptions.inc({action: "subscribed"});
+            this.logger.info("Subscribed gossip core topics");
+          })
+          .catch((e) => {
+            this.logger.error("Error subscribing to gossip core topics", {}, e);
+          });
+
+        // also start searching for unknown blocks
+        if (!this.unknownBlockSync.isSubscribedToNetwork()) {
+          this.unknownBlockSync.subscribeToNetwork();
+          this.metrics?.syncUnknownBlock.switchNetworkSubscriptions.inc({action: "subscribed"});
+        }
+      }
     }
 
     // If we stopped being synced and falled significantly behind, stop gossip
-    else if (state !== SyncState.Synced && this.network.isSubscribedToGossipCoreTopics()) {
+    else if (state !== SyncState.Synced) {
       const syncDiff = this.chain.clock.currentSlot - this.chain.forkChoice.getHead().slot;
       if (syncDiff > this.slotImportTolerance * 2) {
         this.logger.warn(`Node sync has fallen behind by ${syncDiff} slots`);
-        this.network
-          .unsubscribeGossipCoreTopics()
-          .then(() => {
-            this.metrics?.syncSwitchGossipSubscriptions.inc({action: "unsubscribed"});
-            this.logger.info("Un-subscribed gossip core topics");
-          })
-          .catch((e) => {
-            this.logger.error("Error unsubscribing to gossip core topics", {}, e);
-          });
+        if (this.network.isSubscribedToGossipCoreTopics()) {
+          this.network
+            .unsubscribeGossipCoreTopics()
+            .then(() => {
+              this.metrics?.syncSwitchGossipSubscriptions.inc({action: "unsubscribed"});
+              this.logger.info("Un-subscribed gossip core topics");
+            })
+            .catch((e) => {
+              this.logger.error("Error unsubscribing to gossip core topics", {}, e);
+            });
+        }
+
+        // also stop searching for unknown blocks
+        if (this.unknownBlockSync.isSubscribedToNetwork()) {
+          this.unknownBlockSync.unsubscribeFromNetwork();
+          this.metrics?.syncUnknownBlock.switchNetworkSubscriptions.inc({action: "unsubscribed"});
+        }
       }
     }
   };

--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -51,11 +51,14 @@ export class BeaconSync implements IBeaconSync {
 
     // Subscribe to RangeSync completing a SyncChain and recompute sync state
     if (!opts.disableRangeSync) {
+      // prod code
       this.logger.debug("RangeSync enabled.");
       this.rangeSync.on(RangeSyncEvent.completedChain, this.updateSyncState);
       this.network.events.on(NetworkEvent.peerConnected, this.addPeer);
       this.network.events.on(NetworkEvent.peerDisconnected, this.removePeer);
     } else {
+      // test code, this is needed for Unknown block sync sim test
+      this.unknownBlockSync.subscribeToNetwork();
       this.logger.debug("RangeSync disabled.");
     }
 

--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -210,12 +210,12 @@ export class BeaconSync implements IBeaconSync {
           .catch((e) => {
             this.logger.error("Error subscribing to gossip core topics", {}, e);
           });
+      }
 
-        // also start searching for unknown blocks
-        if (!this.unknownBlockSync.isSubscribedToNetwork()) {
-          this.unknownBlockSync.subscribeToNetwork();
-          this.metrics?.syncUnknownBlock.switchNetworkSubscriptions.inc({action: "subscribed"});
-        }
+      // also start searching for unknown blocks
+      if (!this.unknownBlockSync.isSubscribedToNetwork()) {
+        this.unknownBlockSync.subscribeToNetwork();
+        this.metrics?.syncUnknownBlock.switchNetworkSubscriptions.inc({action: "subscribed"});
       }
     }
 

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -177,6 +177,7 @@ describe("sync / UnknownBlockSync", () => {
         ...defaultSyncOptions,
         maxPendingBlocks,
       });
+      syncService.subscribeToNetwork();
       if (event === NetworkEvent.unknownBlockParent) {
         network.events?.emit(NetworkEvent.unknownBlockParent, {
           blockInput: getBlockInput.preDeneb(config, blockC, BlockSource.gossip),
@@ -220,6 +221,8 @@ describe("sync / UnknownBlockSync", () => {
           "Wrong blocks in mock ForkChoice"
         );
       }
+
+      syncService.close();
     });
   }
 });


### PR DESCRIPTION
**Motivation**

Unknown block sync received unknown block roots while the node is syncing, this lead to:
- Pending blocks may be filled up quickly
- Incorrect catch of this case https://github.com/ChainSafe/lodestar/blob/2eddf466394680cb1c6a24700b9a3a2958a3ef90/packages/beacon-node/src/sync/unknownBlock.ts#L228

**Description**

- Add subscribe/unsubscribe methods to UnknownBlock sync
- Only subscribe once the node is synced, similar to `network.subscribeGossipCoreTopics()`

Closes #5653