### PR TITLE
fix: handle only downloaded blocks in unknown block sync

### DIFF
--- a/packages/beacon-node/src/sync/interface.ts
+++ b/packages/beacon-node/src/sync/interface.ts
@@ -55,28 +55,36 @@ export interface SyncModules {
   wsCheckpoint?: phase0.Checkpoint;
 }
 
+export type UnknownAndAncestorBlocks = {
+  unknowns: UnknownBlock[];
+  ancestors: DownloadedBlock[];
+};
+
 /**
  * onUnknownBlock: store 1 record with undefined parentBlockRootHex & blockInput, blockRootHex as key, status pending
  * onUnknownBlockParent:
  *   - store 1 record with known parentBlockRootHex & blockInput, blockRootHex as key, status downloaded
  *   - store 1 record with undefined parentBlockRootHex & blockInput, parentBlockRootHex as key, status pending
  */
-export type PendingBlock = {
+export type PendingBlock = UnknownBlock | DownloadedBlock;
+
+type PendingBlockCommon = {
   blockRootHex: RootHex;
   peerIdStrs: Set<string>;
   downloadAttempts: number;
-} & (
-  | {
-      status: PendingBlockStatus.pending | PendingBlockStatus.fetching;
-      parentBlockRootHex: null;
-      blockInput: null;
-    }
-  | {
-      status: PendingBlockStatus.downloaded | PendingBlockStatus.processing;
-      parentBlockRootHex: RootHex;
-      blockInput: BlockInput;
-    }
-);
+};
+
+export type UnknownBlock = PendingBlockCommon & {
+  status: PendingBlockStatus.pending | PendingBlockStatus.fetching;
+  parentBlockRootHex: null;
+  blockInput: null;
+};
+
+export type DownloadedBlock = PendingBlockCommon & {
+  status: PendingBlockStatus.downloaded | PendingBlockStatus.processing;
+  parentBlockRootHex: RootHex;
+  blockInput: BlockInput;
+};
 
 export enum PendingBlockStatus {
   pending = "pending",

--- a/packages/beacon-node/src/sync/options.ts
+++ b/packages/beacon-node/src/sync/options.ts
@@ -20,6 +20,8 @@ export type SyncOptions = {
    * allocation to backfill sync. The default of 0 would mean backfill sync will be skipped
    */
   backfillBatchSize: number;
+  /** For testing only, MAX_PENDING_BLOCKS by default */
+  maxPendingBlocks?: number;
 };
 
 export const defaultSyncOptions: SyncOptions = {

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -29,6 +29,7 @@ export class UnknownBlockSync {
   private readonly pendingBlocks = new Map<RootHex, PendingBlock>();
   private readonly knownBadBlocks = new Set<RootHex>();
   private readonly proposerBoostSecWindow: number;
+  private readonly maxPendingBlocks;
 
   constructor(
     private readonly config: ChainForkConfig,
@@ -46,6 +47,7 @@ export class UnknownBlockSync {
     } else {
       this.logger.debug("UnknownBlockSync disabled.");
     }
+    this.maxPendingBlocks = opts?.maxPendingBlocks ?? MAX_PENDING_BLOCKS;
 
     this.proposerBoostSecWindow = this.config.SECONDS_PER_SLOT / INTERVALS_PER_SLOT;
 
@@ -147,7 +149,7 @@ export class UnknownBlockSync {
     }
 
     // Limit pending blocks to prevent DOS attacks that cause OOM
-    const prunedItemCount = pruneSetToMax(this.pendingBlocks, MAX_PENDING_BLOCKS);
+    const prunedItemCount = pruneSetToMax(this.pendingBlocks, this.maxPendingBlocks);
     if (prunedItemCount > 0) {
       this.logger.warn(`Pruned ${prunedItemCount} pending blocks from UnknownBlockSync`);
     }

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -172,7 +172,7 @@ export class UnknownBlockSync {
     }
 
     const {unknowns, ancestors} = getUnknownAndAncestorBlocks(this.pendingBlocks);
-    // it's rare when there is no pending block
+    // it's rare when there is no unknown block
     // see https://github.com/ChainSafe/lodestar/issues/5649#issuecomment-1594213550
     if (unknowns.length === 0) {
       let processedBlocks = 0;

--- a/packages/beacon-node/src/sync/utils/pendingBlocksTree.ts
+++ b/packages/beacon-node/src/sync/utils/pendingBlocksTree.ts
@@ -1,6 +1,12 @@
 import {RootHex} from "@lodestar/types";
 import {MapDef} from "@lodestar/utils";
-import {PendingBlock, PendingBlockStatus} from "../interface.js";
+import {
+  DownloadedBlock,
+  PendingBlock,
+  PendingBlockStatus,
+  UnknownAndAncestorBlocks,
+  UnknownBlock,
+} from "../interface.js";
 
 export function getAllDescendantBlocks(blockRootHex: RootHex, blocks: Map<RootHex, PendingBlock>): PendingBlock[] {
   // Do one pass over all blocks to index by parent
@@ -43,14 +49,27 @@ export function getDescendantBlocks(blockRootHex: RootHex, blocks: Map<RootHex, 
   return descendantBlocks;
 }
 
-export function getUnknownBlocks(blocks: Map<RootHex, PendingBlock>): PendingBlock[] {
-  const blocksToFetch: PendingBlock[] = [];
+/**
+ * Given this chain segment unknown block n => downloaded block n + 1 => downloaded block n + 2
+ *   return `{unknowns: [n], ancestors: []}`
+ *
+ * Given this chain segment: downloaded block n => downloaded block n + 1 => downloaded block n + 2
+ *   return {unknowns: [], ancestors: [n]}
+ */
+export function getUnknownAndAncestorBlocks(blocks: Map<RootHex, PendingBlock>): UnknownAndAncestorBlocks {
+  const unknowns: UnknownBlock[] = [];
+  const ancestors: DownloadedBlock[] = [];
 
   for (const block of blocks.values()) {
-    if (block.status === PendingBlockStatus.pending && block.blockInput == null && block.parentBlockRootHex == null) {
-      blocksToFetch.push(block);
+    const parentHex = block.parentBlockRootHex;
+    if (block.status === PendingBlockStatus.pending && block.blockInput == null && parentHex == null) {
+      unknowns.push(block);
+    }
+
+    if (parentHex && !blocks.has(parentHex)) {
+      ancestors.push(block);
     }
   }
 
-  return blocksToFetch;
+  return {unknowns, ancestors};
 }

--- a/packages/beacon-node/test/unit/sync/utils/pendingBlocksTree.test.ts
+++ b/packages/beacon-node/test/unit/sync/utils/pendingBlocksTree.test.ts
@@ -1,10 +1,10 @@
 import {expect} from "chai";
 import {RootHex} from "@lodestar/types";
-import {PendingBlock, PendingBlockStatus} from "../../../../src/sync/index.js";
+import {PendingBlock, PendingBlockStatus, UnknownAndAncestorBlocks} from "../../../../src/sync/index.js";
 import {
   getAllDescendantBlocks,
   getDescendantBlocks,
-  getUnknownBlocks,
+  getUnknownAndAncestorBlocks,
 } from "../../../../src/sync/utils/pendingBlocksTree.js";
 
 describe("sync / pendingBlocksTree", () => {
@@ -13,14 +13,14 @@ describe("sync / pendingBlocksTree", () => {
     blocks: {block: string; parent: string | null}[];
     getAllDescendantBlocks: {block: string; res: string[]}[];
     getDescendantBlocks: {block: string; res: string[]}[];
-    getUnknownBlocks: string[];
+    getUnknownOrAncestorBlocks: {unknowns: string[]; ancestors: string[]};
   }[] = [
     {
       id: "empty case",
       blocks: [],
       getAllDescendantBlocks: [{block: "0A", res: []}],
       getDescendantBlocks: [{block: "0A", res: []}],
-      getUnknownBlocks: [],
+      getUnknownOrAncestorBlocks: {unknowns: [], ancestors: []},
     },
     {
       id: "two branches with multiple blocks",
@@ -44,7 +44,7 @@ describe("sync / pendingBlocksTree", () => {
         {block: "3C", res: ["4C"]},
         {block: "3B", res: []},
       ],
-      getUnknownBlocks: ["0A"],
+      getUnknownOrAncestorBlocks: {unknowns: ["0A"], ancestors: ["4C"]},
     },
   ];
 
@@ -72,7 +72,7 @@ describe("sync / pendingBlocksTree", () => {
       }
 
       it("getUnknownBlocks", () => {
-        expect(toRes(getUnknownBlocks(blocks))).to.deep.equal(testCase.getUnknownBlocks);
+        expect(toRes2(getUnknownAndAncestorBlocks(blocks))).to.deep.equal(testCase.getUnknownOrAncestorBlocks);
       });
     });
   }
@@ -80,4 +80,11 @@ describe("sync / pendingBlocksTree", () => {
 
 function toRes(blocks: PendingBlock[]): string[] {
   return blocks.map((block) => block.blockRootHex);
+}
+
+function toRes2(blocks: UnknownAndAncestorBlocks): {unknowns: string[]; ancestors: string[]} {
+  return {
+    unknowns: blocks.unknowns.map((block) => block.blockRootHex),
+    ancestors: blocks.ancestors.map((block) => block.blockRootHex),
+  };
 }


### PR DESCRIPTION
**Motivation**

- In unknown block sync, there could be unknown blocks and downloaded blocks. 
- Normally there is 1 unknown block following by some downloaded blocks, and it worked fine in all goerli nodes
- The issue happened in https://github.com/ChainSafe/lodestar/issues/5649#issuecomment-1594213550 that there are only downloaded blocks due to `pruneSetToMax()`, no block to download and the sync get stuck

**Description**

- Modify the type of `PendingBlock` to be either `UnknownBlock` or `DownloadedBlock`
- refactor `getUnknownBlocks` to be `getUnknownAndAncestorBlocks`
- when there is no unknown block, process the ancestor downloaded block. It's likely there is head sync when we have up to 100 (`MAX_PENDING_BLOCKS`) blocks at that time so that the sync is not stuck

Closes #5649