### PR TITLE
chore: replace lerna commands with yarn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing to Lodestar. It's people like you that 
 ## Prerequisites
 
 - :gear: [NodeJS](https://nodejs.org/) (LTS)
-- :toolbox: [Yarn](https://yarnpkg.com/)/[Lerna](https://lerna.js.org/)
+- :toolbox: [Yarn](https://yarnpkg.com/)
 
 ## Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,10 @@ Thanks for your interest in contributing to Lodestar. It's people like you that 
 
 To run tests:
 
-- :test_tube: Run `lerna run test:unit` for unit tests.
-- :test_tube: Run `lerna run test:e2e` for end-to-end tests.
-- :test_tube: Run `lerna run test:spec` for spec tests.
-- :test_tube: Run `lerna run test` to run all tests.
+- :test_tube: Run `yarn test:unit` for unit tests.
+- :test_tube: Run `yarn test:e2e` for end-to-end tests.
+- :test_tube: Run `yarn test:spec` for spec tests.
+- :test_tube: Run `yarn test` to run all tests.
 - :test_tube: Run `yarn check-types` to check TypeScript types.
 - :test_tube: Run `yarn lint` to run the linter (ESLint).
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ## Prerequisites
 
 - :gear: [NodeJS](https://nodejs.org/) (LTS)
-- :toolbox: [Yarn](https://yarnpkg.com/)/[Lerna](https://lerna.js.org/)
+- :toolbox: [Yarn](https://yarnpkg.com/)
 
 ###### Developer Quickstart:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 ###### Developer Quickstart:
 
 ```bash
-lerna bootstrap
+yarn install
 yarn build
 ./lodestar --help
 ```

--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -43,12 +43,6 @@ Build across all packages.
 yarn run build
 ```
 
-Or if you are using [Lerna](https://lerna.js.org/):
-
-```bash
-lerna bootstrap
-```
-
 ## Lodestar CLI
 
 Lodestar should now be ready for use.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check-build": "lerna run check-build",
     "check-types": "lerna run check-types --no-bail",
     "coverage": "lerna run coverage --no-bail",
+    "test": "lerna run test --no-bail --concurrency 1",
     "test:unit": "lerna run test:unit --no-bail --concurrency 1",
     "test:browsers": "lerna run test:browsers",
     "test:e2e": "lerna run test:e2e --no-bail --concurrency 1",

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -35,7 +35,7 @@ api.beacon
 
 ## Prerequisites
 
-- [Lerna](https://github.com/lerna/lerna)
+- [NodeJS](https://nodejs.org/) (LTS)
 - [Yarn](https://yarnpkg.com/)
 
 ## What you need

--- a/packages/light-client/README.md
+++ b/packages/light-client/README.md
@@ -9,7 +9,7 @@
 
 ## Prerequisites
 
-- [Lerna](https://github.com/lerna/lerna)
+- [NodeJS](https://nodejs.org/) (LTS)
 - [Yarn](https://yarnpkg.com/)
 
 ## What you need

--- a/packages/prover/README.md
+++ b/packages/prover/README.md
@@ -114,7 +114,7 @@ lodestar-prover start \
 
 ## Prerequisites
 
-- [Lerna](https://github.com/lerna/lerna)
+- [NodeJS](https://nodejs.org/) (LTS)
 - [Yarn](https://yarnpkg.com/)
 
 ## What you need

--- a/packages/reqresp/README.md
+++ b/packages/reqresp/README.md
@@ -43,7 +43,7 @@ async function getReqResp(libp2p: Libp2p, logger: Logger): Promise<void> {
 
 ## Prerequisites
 
-- [Lerna](https://github.com/lerna/lerna)
+- [NodeJS](https://nodejs.org/) (LTS)
 - [Yarn](https://yarnpkg.com/)
 
 ## What you need


### PR DESCRIPTION
**Motivation**

Referencing both lerna and yarn commands just creates confusion. Lerna is also not a prerequisite of the project as it is installed as dev dependency.

**Description**

- Removes lerna from prerequisities, instead adds nodejs if not already mentioned
- Replaces lerna commands with yarn
