### PR TITLE
fix: ignore queue aborted errors in prepareForNextSlot

### DIFF
--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -8,6 +8,7 @@ import {GENESIS_SLOT, ZERO_HASH_HEX} from "../constants/constants.js";
 import {Metrics} from "../metrics/index.js";
 import {TransitionConfigurationV1} from "../execution/engine/interface.js";
 import {ClockEvent} from "../util/clock.js";
+import {isQueueErrorAborted} from "../util/queue/index.js";
 import {prepareExecutionPayload, getPayloadAttributesForSSE} from "./produceBlock/produceBlockBody.js";
 import {IBeaconChain} from "./interface.js";
 import {RegenCaller} from "./regen/index.js";
@@ -172,7 +173,7 @@ export class PrepareNextSlotScheduler {
         }
       }
     } catch (e) {
-      if (!isErrorAborted(e)) {
+      if (!isErrorAborted(e) && !isQueueErrorAborted(e)) {
         this.metrics?.precomputeNextEpochTransition.count.inc({result: "error"}, 1);
         this.logger.error("Failed to run prepareForNextSlot", {nextEpoch, isEpochTransition, prepareSlot}, e as Error);
       }


### PR DESCRIPTION
**Motivation**

When shutting down beacon node it might happen that we get this error which is quite noisy and might scare users that something bad happened but `QUEUE_ERROR_QUEUE_ABORTED` are expected on shutdown and can be ignored.

```
Jun-11 14:44:57.539[chain]           error: Failed to run prepareForNextSlot nextEpoch=182258, isEpochTransition=false, prepareSlot=5832225 code=QUEUE_ERROR_QUEUE_ABORTED
Error: QUEUE_ERROR_QUEUE_ABORTED
    at EventTarget.JobItemQueue.abortAllJobs (file:///home/devops/goerli/lodestar/packages/beacon-node/src/util/queue/itemQueue.ts:124:27)
    at EventTarget.[nodejs.internal.kHybridDispatch] (node:internal/event_target:735:20)
    at EventTarget.dispatchEvent (node:internal/event_target:677:26)
    at abortSignal (node:internal/abort_controller:308:10)
    at AbortController.abort (node:internal/abort_controller:338:5)
    at BeaconChain.close (file:///home/devops/goerli/lodestar/packages/beacon-node/src/chain/chain.ts:297:26)
    at BeaconNode.close (file:///home/devops/goerli/lodestar/packages/beacon-node/src/node/nodejs.ts:321:24)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at EventTarget.abortController.signal.addEventListener.once (file:///home/devops/goerli/lodestar/packages/cli/src/cmds/beacon/handler.ts:136:11)
```

**Description**

Ignore queue aborted errors (`isQueueErrorAborted`) in `prepareForNextSlot`.

This error rarely happens, that's why I initially missed it in https://github.com/ChainSafe/lodestar/pull/5330.
