### PR TITLE
fix(cli): consistently support URLs as comma-separated values

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/builder.ts
+++ b/packages/cli/src/options/beaconNodeOptions/builder.ts
@@ -31,9 +31,13 @@ export const options: CliCommandOptions<ExecutionBuilderArgs> = {
 
   "builder.urls": {
     description: "Urls hosting the builder API",
-    type: "array",
     defaultDescription:
       defaultOptions.executionBuilder.mode === "http" ? defaultOptions.executionBuilder.urls.join(" ") : "",
+    type: "array",
+    string: true,
+    coerce: (urls: string[]): string[] =>
+      // Parse ["url1,url2"] to ["url1", "url2"]
+      urls.map((item) => item.split(",")).flat(1),
     group: "builder",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/eth1.ts
+++ b/packages/cli/src/options/beaconNodeOptions/eth1.ts
@@ -49,8 +49,12 @@ export const options: CliCommandOptions<Eth1Args> = {
   "eth1.providerUrls": {
     description:
       "Urls to Eth1 node with enabled rpc. If not explicity provided and execution endpoint provided via execution.urls, it will use execution.urls. Otherwise will try connecting on the specified default(s)",
-    type: "array",
     defaultDescription: defaultOptions.eth1.providerUrls.join(" "),
+    type: "array",
+    string: true,
+    coerce: (urls: string[]): string[] =>
+      // Parse ["url1,url2"] to ["url1", "url2"]
+      urls.map((item) => item.split(",")).flat(1),
     group: "eth1",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/execution.ts
+++ b/packages/cli/src/options/beaconNodeOptions/execution.ts
@@ -37,9 +37,13 @@ export function parseArgs(args: ExecutionEngineArgs): IBeaconNodeOptions["execut
 export const options: CliCommandOptions<ExecutionEngineArgs> = {
   "execution.urls": {
     description: "Urls to execution client engine API",
-    type: "array",
     defaultDescription:
       defaultOptions.executionEngine.mode === "http" ? defaultOptions.executionEngine.urls.join(" ") : "",
+    type: "array",
+    string: true,
+    coerce: (urls: string[]): string[] =>
+      // Parse ["url1,url2"] to ["url1", "url2"]
+      urls.map((item) => item.split(",")).flat(1),
     group: "execution",
   },
 


### PR DESCRIPTION
**Motivation**

As discussed in https://github.com/ChainSafe/lodestar/pull/4576#discussion_r1232086829 we should support providing URLs as comma-separated values more consistently. This is also the most intuitive pattern to provide multiple values.

**Description**

We already support this for `--beaconNodes`
https://github.com/ChainSafe/lodestar/blob/81a6da0a7b93556d6cc62dcc9389625c08d17dcb/packages/cli/src/cmds/validator/options.ts#L165-L172

This PR just applies this pattern to CLI flag that support providing multiple URLs.

Opted to just copy-paste, extracting it into reusable function could make sense but found it to be less intuitive.
