### PR TITLE
fix: gossipsub to yield more to the macro queue

### DIFF
--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -280,20 +280,25 @@ export class Eth2Gossipsub extends GossipSub {
     const seenTimestampSec = Date.now() / 1000;
 
     // Emit message to network processor
-    this.events.emit(NetworkEvent.pendingGossipsubMessage, {
-      topic,
-      msg,
-      msgId,
-      // Hot path, use cached .toString() version
-      propagationSource: propagationSource.toString(),
-      seenTimestampSec,
-      startProcessUnixSec: null,
-    });
+    setTimeout(() => {
+      this.events.emit(NetworkEvent.pendingGossipsubMessage, {
+        topic,
+        msg,
+        msgId,
+        // Hot path, use cached .toString() version
+        propagationSource: propagationSource.toString(),
+        seenTimestampSec,
+        startProcessUnixSec: null,
+      });
+    }, 0);
   }
 
   private onValidationResult(data: NetworkEventData[NetworkEvent.gossipMessageValidationResult]): void {
-    // TODO: reportMessageValidationResult should take PeerIdStr since it only uses string version
-    this.reportMessageValidationResult(data.msgId, peerIdFromString(data.propagationSource), data.acceptance);
+    // test sending validation results on the next event loop
+    setTimeout(() => {
+      // TODO: reportMessageValidationResult should take PeerIdStr since it only uses string version
+      this.reportMessageValidationResult(data.msgId, peerIdFromString(data.propagationSource), data.acceptance);
+    }, 0);
   }
 }
 

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -279,7 +279,9 @@ export class Eth2Gossipsub extends GossipSub {
     // Get seenTimestamp before adding the message to the queue or add async delays
     const seenTimestampSec = Date.now() / 1000;
 
-    // Emit message to network processor
+    // Use setTimeout to yield to the macro queue
+    // Without this we'll have huge event loop lag
+    // See https://github.com/ChainSafe/lodestar/issues/5604
     setTimeout(() => {
       this.events.emit(NetworkEvent.pendingGossipsubMessage, {
         topic,
@@ -294,7 +296,9 @@ export class Eth2Gossipsub extends GossipSub {
   }
 
   private onValidationResult(data: NetworkEventData[NetworkEvent.gossipMessageValidationResult]): void {
-    // test sending validation results on the next event loop
+    // Use setTimeout to yield to the macro queue
+    // Without this we'll have huge event loop lag
+    // See https://github.com/ChainSafe/lodestar/issues/5604
     setTimeout(() => {
       // TODO: reportMessageValidationResult should take PeerIdStr since it only uses string version
       this.reportMessageValidationResult(data.msgId, peerIdFromString(data.propagationSource), data.acceptance);


### PR DESCRIPTION
**Motivation**

- Network event loop is super lag, see #5604


**Description**

- Apply the same code change in v1.8.0, see https://github.com/ChainSafe/lodestar/pull/5316
- Although it does not completely resolve the below issue, it helps a lot

part of #5556
part of #5604

**Test result on mainnet node**

<img width="796" alt="Screenshot 2023-06-18 at 15 29 36" src="https://github.com/ChainSafe/lodestar/assets/10568965/dc78e46a-48c9-4ef3-b4dd-a73e5e068c6b">

the 1st event loop lag metric is not a big difference , but it's still better than unstable (from 12h)

<img width="1277" alt="Screenshot 2023-06-18 at 15 29 20" src="https://github.com/ChainSafe/lodestar/assets/10568965/2d0bc70a-a7db-495c-8b5a-cb533cc9c037">

the 2nd event loop lag is clearly better

<img width="1287" alt="Screenshot 2023-06-18 at 15 35 49" src="https://github.com/ChainSafe/lodestar/assets/10568965/0fe23612-21e5-44fa-a21c-2da227356486">


especially the incoming request handler time

<img width="1288" alt="Screenshot 2023-06-18 at 15 30 59" src="https://github.com/ChainSafe/lodestar/assets/10568965/851bcd2f-8028-443b-9841-8b9544faffaa">

also outgoing request time
<img width="1283" alt="Screenshot 2023-06-18 at 15 31 47" src="https://github.com/ChainSafe/lodestar/assets/10568965/9c7b57c7-b108-44d1-ade8-533362bf380c">

it helps our peers more stable, more peers want to stay with us
<img width="1434" alt="Screenshot 2023-06-18 at 15 33 06" src="https://github.com/ChainSafe/lodestar/assets/10568965/59ee7ab3-6eb3-445d-9613-ef78715f9080">
