### PR TITLE
fix(validator): abortable sleep in prepareForNextEpoch

### DIFF
--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -108,14 +108,14 @@ export class AttestationDutiesService {
    * If a reorg dependent root comes at a slot other than last slot of epoch
    * just update this.pendingDependentRootByEpoch() and process here
    */
-  private prepareForNextEpoch = async (slot: Slot): Promise<void> => {
+  private prepareForNextEpoch = async (slot: Slot, signal: AbortSignal): Promise<void> => {
     // only interested in last slot of epoch
     if ((slot + 1) % SLOTS_PER_EPOCH !== 0) {
       return;
     }
 
     // during the 1 / 3 of epoch, last block of epoch may come
-    await sleep(this.clock.msToSlot(slot + 1 / 3));
+    await sleep(this.clock.msToSlot(slot + 1 / 3), signal);
 
     const nextEpoch = computeEpochAtSlot(slot) + 1;
     const dependentRoot = this.dutiesByIndexByEpoch.get(nextEpoch)?.dependentRoot;


### PR DESCRIPTION
**Motivation**

Should be abortable to be able to gracefully shut down vc process without having up to 1/3 slot seconds delay.

**Description**

Forward abort signal to sleep fn inside `prepareForNextEpoch` to make it abortable.
