### PR TITLE
chore: track block source in lodestar summary dashboard

### DIFF
--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -1,26 +1,12 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
       "description": "",
-      "type": "datasource",
+      "label": "Prometheus",
+      "name": "DS_PROMETHEUS",
       "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    },
-    {
-      "name": "VAR_BEACON_JOB",
-      "type": "constant",
-      "label": "Beacon node job name",
-      "value": "beacon",
-      "description": ""
-    },
-    {
-      "name": "VAR_VALIDATOR_JOB",
-      "type": "constant",
-      "label": "Validator client job name",
-      "value": "validator",
-      "description": ""
+      "pluginName": "Prometheus",
+      "type": "datasource"
     }
   ],
   "annotations": {
@@ -1743,7 +1729,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "percentunit"
         },
         "overrides": []
       },
@@ -1752,6 +1738,191 @@
         "w": 12,
         "x": 12,
         "y": 22
+      },
+      "id": 536,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(lodestar_gossip_block_elapsed_time_till_processed_count[$rate_interval])\n- on(instance)\nrate(lodestar_gossip_block_elapsed_time_till_processed_bucket{le=\"4\"}[$rate_interval])",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Import head late (> 4 sec) rate ",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 538,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(lodestar_import_block_by_source_total[$rate_interval]) * 12",
+          "legendFormat": "{{source}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Block Source",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
       },
       "id": 532,
       "options": {
@@ -1840,7 +2011,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 38
       },
       "id": 487,
       "panels": [],
@@ -1887,7 +2058,7 @@
         "h": 3,
         "w": 4,
         "x": 0,
-        "y": 31
+        "y": 39
       },
       "id": 493,
       "options": {
@@ -1952,7 +2123,7 @@
         "h": 3,
         "w": 4,
         "x": 4,
-        "y": 31
+        "y": 39
       },
       "id": 492,
       "options": {
@@ -2017,7 +2188,7 @@
         "h": 3,
         "w": 4,
         "x": 8,
-        "y": 31
+        "y": 39
       },
       "id": 484,
       "options": {
@@ -2082,7 +2253,7 @@
         "h": 3,
         "w": 4,
         "x": 12,
-        "y": 31
+        "y": 39
       },
       "id": 483,
       "options": {
@@ -2147,7 +2318,7 @@
         "h": 3,
         "w": 4,
         "x": 16,
-        "y": 31
+        "y": 39
       },
       "id": 485,
       "options": {
@@ -2225,7 +2396,7 @@
         "h": 3,
         "w": 4,
         "x": 20,
-        "y": 31
+        "y": 39
       },
       "id": 488,
       "options": {
@@ -2320,7 +2491,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 34
+        "y": 42
       },
       "id": 490,
       "options": {
@@ -2384,7 +2555,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 34
+        "y": 42
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -2496,7 +2667,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 42
+        "y": 50
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -2616,8 +2787,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2632,7 +2802,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 50
       },
       "id": 497,
       "options": {
@@ -2660,7 +2830,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 58
       },
       "id": 104,
       "panels": [],
@@ -2722,8 +2892,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2739,7 +2908,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 59
       },
       "id": 102,
       "options": {
@@ -2844,8 +3013,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2861,7 +3029,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 59
       },
       "id": 172,
       "options": {
@@ -2942,8 +3110,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2959,7 +3126,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 57
+        "y": 65
       },
       "id": 171,
       "options": {
@@ -3002,7 +3169,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 57
+        "y": 65
       },
       "id": 99,
       "options": {
@@ -3156,46 +3323,32 @@
         "type": "adhoc"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "${VAR_BEACON_JOB}",
+          "value": "${VAR_BEACON_JOB}"
+        },
         "description": "Job name used in Prometheus config to scrape Beacon node",
         "hide": 2,
         "label": "Beacon node job name",
         "name": "beacon_job",
         "query": "${VAR_BEACON_JOB}",
         "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_BEACON_JOB}",
-          "text": "${VAR_BEACON_JOB}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_BEACON_JOB}",
-            "text": "${VAR_BEACON_JOB}",
-            "selected": false
-          }
-        ]
+        "type": "constant"
       },
       {
+        "current": {
+          "selected": false,
+          "text": "${VAR_VALIDATOR_JOB}",
+          "value": "${VAR_VALIDATOR_JOB}"
+        },
         "description": "Job name used in Prometheus config to scrape Validator client",
         "hide": 2,
         "label": "Validator client job name",
         "name": "validator_job",
         "query": "${VAR_VALIDATOR_JOB}",
         "skipUrlSync": false,
-        "type": "constant",
-        "current": {
-          "value": "${VAR_VALIDATOR_JOB}",
-          "text": "${VAR_VALIDATOR_JOB}",
-          "selected": false
-        },
-        "options": [
-          {
-            "value": "${VAR_VALIDATOR_JOB}",
-            "text": "${VAR_VALIDATOR_JOB}",
-            "selected": false
-          }
-        ]
+        "type": "constant"
       }
     ]
   },
@@ -3219,7 +3372,7 @@
   },
   "timezone": "utc",
   "title": "Lodestar",
-  "uid": "lodestar",
+  "uid": "lodestar_summary",
   "version": 29,
   "weekStart": "monday"
 }

--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -7,6 +7,20 @@
       "pluginId": "prometheus",
       "pluginName": "Prometheus",
       "type": "datasource"
+    },
+    {
+      "name": "VAR_BEACON_JOB",
+      "type": "constant",
+      "label": "Beacon node job name",
+      "value": "beacon",
+      "description": ""
+    },
+    {
+      "name": "VAR_VALIDATOR_JOB",
+      "type": "constant",
+      "label": "Validator client job name",
+      "value": "validator",
+      "description": ""
     }
   ],
   "annotations": {


### PR DESCRIPTION
**Motivation**

- If blocks come from either range sync or unknown block sync that's an issue to our node

**Description**

- Track block source in lodestar dashboard as a new panel
- Change the `uid` of `lodestar_summary.json` to be `lodestar_summary` so it works with `download_dashboards.mjs` script (see https://github.com/ChainSafe/lodestar/blob/9a8a6f4824fdb2eb36a06fc237ce8663bad412b8/scripts/download_dashboards.mjs#L65). After this is merged we should reimport this dashboard to grafana and remove the old uid dashboard

<img width="803" alt="Screenshot 2023-06-19 at 13 33 12" src="https://github.com/ChainSafe/lodestar/assets/10568965/468168a3-3f9d-4dee-8bb6-0ba856467ac9">

