### PR TITLE
feat: allow builder only proposal flow for benefit of DVT protocols

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -254,6 +254,8 @@ function parseBuilderSelection(builderSelection?: string): BuilderSelection | un
         break;
       case "builderalways":
         break;
+      case "builderonly":
+        break;
       default:
         throw Error("Invalid input for builder selection, check help.");
     }

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -237,7 +237,7 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
 
   "builder.selection": {
     type: "string",
-    description: "Default builder block selection strategy: maxprofit or builderalways",
+    description: "Default builder block selection strategy: maxprofit or builderalways or builderonly",
     defaultDescription: `${defaultOptions.builderSelection}`,
     group: "builder",
   },

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -237,7 +237,7 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
 
   "builder.selection": {
     type: "string",
-    description: "Default builder block selection strategy: maxprofit or builderalways or builderonly",
+    description: "Default builder block selection strategy: maxprofit, builderalways, or builderonly",
     defaultDescription: `${defaultOptions.builderSelection}`,
     group: "builder",
   },

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -240,7 +240,7 @@ export class BlockProposingService {
       fullBlock = await fullBlockPromise;
     } else {
       throw Error(
-        `Neither builder not execution proposal flow activated: isBuilderEnabled=${isBuilderEnabled} builderSelection=${builderSelection}`
+        `Neither builder nor execution proposal flow activated: isBuilderEnabled=${isBuilderEnabled} builderSelection=${builderSelection}`
       );
     }
     this.logger.info("Started block production", {});

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -67,6 +67,8 @@ export type SignerRemote = {
 export enum BuilderSelection {
   BuilderAlways = "builderalways",
   MaxProfit = "maxprofit",
+  /** Only activate builder flow for DVT block proposal protocols */
+  BuilderOnly = "builderonly",
 }
 
 type DefaultProposerConfig = {


### PR DESCRIPTION
DVT protocols block proposal may depend on sourcing block for proposal only through relayer so that the distributed validators are signing off on same block for proposal.

This PR allows for the same via `--builder.selection=builderonly` option