### PR TITLE
chore: add job names to __inputs if used by dashboard

### DIFF
--- a/scripts/lint-grafana-dashboard.mjs
+++ b/scripts/lint-grafana-dashboard.mjs
@@ -71,6 +71,7 @@ no-console
  *
  * @typedef {Object} TemplatingListItem
  * @property {string} name
+ * @property {string} query
  */
 
 const variableNameDatasource = "DS_PROMETHEUS";
@@ -86,18 +87,44 @@ export function lintGrafanaDashboard(json) {
   delete json.__elements;
   delete json.__requires;
 
+  // Always add Prometheus to __inputs
+  const inputs = [
+    {
+      description: "",
+      label: "Prometheus",
+      name: variableNameDatasource,
+      pluginId: "prometheus",
+      pluginName: "Prometheus",
+      type: "datasource",
+    },
+  ];
+
+  // Add job names to __inputs if used by dashboard
+  if (json.templating && json.templating.list) {
+    for (const item of json.templating.list) {
+      if (item.query === "${VAR_BEACON_JOB}") {
+        inputs.push({
+          name: "VAR_BEACON_JOB",
+          type: "constant",
+          label: "Beacon node job name",
+          value: "beacon",
+          description: "",
+        });
+      } else if (item.query === "${VAR_VALIDATOR_JOB}") {
+        inputs.push({
+          name: "VAR_VALIDATOR_JOB",
+          type: "constant",
+          label: "Validator client job name",
+          value: "validator",
+          description: "",
+        });
+      }
+    }
+  }
+
   // Ensure __inputs is first property to reduce diff
   json = {
-    __inputs: [
-      {
-        description: "",
-        label: "Prometheus",
-        name: variableNameDatasource,
-        pluginId: "prometheus",
-        pluginName: "Prometheus",
-        type: "datasource",
-      },
-    ],
+    __inputs: inputs,
     ...json,
   };
 

--- a/scripts/lint-grafana-dashboard.mjs
+++ b/scripts/lint-grafana-dashboard.mjs
@@ -90,12 +90,12 @@ export function lintGrafanaDashboard(json) {
   // Always add Prometheus to __inputs
   const inputs = [
     {
-      description: "",
-      label: "Prometheus",
       name: variableNameDatasource,
+      type: "datasource",
+      label: "Prometheus",
+      description: "",
       pluginId: "prometheus",
       pluginName: "Prometheus",
-      type: "datasource",
     },
   ];
 


### PR DESCRIPTION
**Motivation**

As noted in https://github.com/ChainSafe/lodestar/pull/5525, __inputs must be manually set. Currently, the script to lint/update dashboards only adds Prometheus to __inputs but we also need to set job names (https://github.com/ChainSafe/lodestar/pull/5211) if job variables are used by the dashboard.

**Description**

Add job names to __inputs if used by dashboard.

Lint script now checks templating list for query and if it finds match, adds job name to __inputs.

https://github.com/ChainSafe/lodestar/blob/7c54a7b188e8bb7f15a2b9d742da5e5dfc887c1d/dashboards/lodestar_summary.json#L3163

