### PR TITLE
refactor: rename CLI flag to enable doppelganger protection

### DIFF
--- a/packages/beacon-node/test/e2e/doppelganger/doppelganger.test.ts
+++ b/packages/beacon-node/test/e2e/doppelganger/doppelganger.test.ts
@@ -41,7 +41,7 @@ describe.skip("doppelganger / doppelganger test", function () {
 
   type TestConfig = {
     genesisTime?: number;
-    doppelgangerProtectionEnabled?: boolean;
+    doppelgangerProtection?: boolean;
   };
 
   async function createBNAndVC(config?: TestConfig): Promise<{beaconNode: BeaconNode; validators: Validator[]}> {
@@ -69,7 +69,7 @@ describe.skip("doppelganger / doppelganger test", function () {
       startIndex: 0,
       useRestApi: false,
       testLoggerOpts,
-      doppelgangerProtectionEnabled: config?.doppelgangerProtectionEnabled,
+      doppelgangerProtection: config?.doppelgangerProtection,
     });
     afterEachCallbacks.push(() => Promise.all(validatorsWithDoppelganger.map((v) => v.close())));
 
@@ -83,7 +83,7 @@ describe.skip("doppelganger / doppelganger test", function () {
     const validatorIndex = 0;
 
     const {beaconNode: bn, validators: validatorsWithDoppelganger} = await createBNAndVC({
-      doppelgangerProtectionEnabled: true,
+      doppelgangerProtection: true,
     });
 
     const validatorUnderTest = validatorsWithDoppelganger[0];
@@ -118,7 +118,7 @@ describe.skip("doppelganger / doppelganger test", function () {
 
     const {beaconNode: bn, validators: validatorsWithDoppelganger} = await createBNAndVC({
       genesisTime,
-      doppelgangerProtectionEnabled: true,
+      doppelgangerProtection: true,
     });
 
     const {beaconNode: bn2, validators: validators} = await createBNAndVC({
@@ -148,7 +148,7 @@ describe.skip("doppelganger / doppelganger test", function () {
   it("should shut down validator if same key is active with same BN and started after genesis", async function () {
     this.timeout("10 min");
 
-    const doppelgangerProtectionEnabled = true;
+    const doppelgangerProtection = true;
     const testLoggerOpts: TestLoggerOpts = {level: LogLevel.info};
 
     // set genesis time to allow at least an epoch
@@ -156,7 +156,7 @@ describe.skip("doppelganger / doppelganger test", function () {
 
     const {beaconNode: bn, validators: validator0WithDoppelganger} = await createBNAndVC({
       genesisTime,
-      doppelgangerProtectionEnabled,
+      doppelgangerProtection,
     });
 
     const {validators: validator0WithoutDoppelganger} = await getAndInitDevValidators({
@@ -166,7 +166,7 @@ describe.skip("doppelganger / doppelganger test", function () {
       startIndex: 0,
       useRestApi: false,
       testLoggerOpts,
-      doppelgangerProtectionEnabled: false,
+      doppelgangerProtection: false,
     });
     afterEachCallbacks.push(() => Promise.all(validator0WithoutDoppelganger.map((v) => v.close())));
 
@@ -194,15 +194,15 @@ describe.skip("doppelganger / doppelganger test", function () {
   it("should not shut down validator if key is different", async function () {
     this.timeout("10 min");
 
-    const doppelgangerProtectionEnabled = true;
+    const doppelgangerProtection = true;
 
     const {beaconNode: bn, validators: validatorsWithDoppelganger} = await createBNAndVC({
-      doppelgangerProtectionEnabled,
+      doppelgangerProtection,
     });
 
     const {beaconNode: bn2, validators: validators} = await createBNAndVC({
       genesisTime: bn.chain.getHeadState().genesisTime,
-      doppelgangerProtectionEnabled: false,
+      doppelgangerProtection: false,
     });
 
     await connect(bn2.network, bn.network);
@@ -226,14 +226,14 @@ describe.skip("doppelganger / doppelganger test", function () {
   it("should not sign block if doppelganger period has not passed and not started at genesis", async function () {
     this.timeout("10 min");
 
-    const doppelgangerProtectionEnabled = true;
+    const doppelgangerProtection = true;
 
     // set genesis time to allow at least an epoch
     const genesisTime = Math.floor(Date.now() / 1000) - SLOTS_PER_EPOCH * beaconParams.SECONDS_PER_SLOT;
 
     const {beaconNode: bn, validators: validatorsWithDoppelganger} = await createBNAndVC({
       genesisTime,
-      doppelgangerProtectionEnabled,
+      doppelgangerProtection,
     });
 
     const validatorUnderTest = validatorsWithDoppelganger[0];
@@ -259,14 +259,14 @@ describe.skip("doppelganger / doppelganger test", function () {
   it("should not sign attestations if doppelganger period has not passed and started after genesis", async function () {
     this.timeout("10 min");
 
-    const doppelgangerProtectionEnabled = true;
+    const doppelgangerProtection = true;
 
     // set genesis time to allow at least an epoch
     const genesisTime = Math.floor(Date.now() / 1000) - SLOTS_PER_EPOCH * beaconParams.SECONDS_PER_SLOT;
 
     const {beaconNode: bn, validators: validatorsWithDoppelganger} = await createBNAndVC({
       genesisTime,
-      doppelgangerProtectionEnabled,
+      doppelgangerProtection,
     });
 
     const validatorUnderTest = validatorsWithDoppelganger[0];

--- a/packages/beacon-node/test/utils/node/validator.ts
+++ b/packages/beacon-node/test/utils/node/validator.ts
@@ -16,7 +16,7 @@ export async function getAndInitDevValidators({
   useRestApi,
   testLoggerOpts,
   externalSignerUrl,
-  doppelgangerProtectionEnabled = false,
+  doppelgangerProtection = false,
   valProposerConfig,
 }: {
   node: BeaconNode;
@@ -26,7 +26,7 @@ export async function getAndInitDevValidators({
   useRestApi?: boolean;
   testLoggerOpts?: TestLoggerOpts;
   externalSignerUrl?: string;
-  doppelgangerProtectionEnabled?: boolean;
+  doppelgangerProtection?: boolean;
   valProposerConfig?: ValidatorProposerConfig;
 }): Promise<{validators: Validator[]; secretKeys: SecretKey[]}> {
   const validators: Promise<Validator>[] = [];
@@ -70,7 +70,7 @@ export async function getAndInitDevValidators({
         processShutdownCallback: () => {},
         abortController,
         signers,
-        doppelgangerProtectionEnabled,
+        doppelgangerProtection,
         valProposerConfig,
       })
     );

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -36,7 +36,7 @@ import {KeymanagerRestApiServer} from "./keymanager/server.js";
 export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Promise<void> {
   const {config, network} = getBeaconConfigFromArgs(args);
 
-  const doppelgangerProtectionEnabled = args.doppelgangerProtectionEnabled;
+  const {doppelgangerProtection} = args;
 
   const validatorPaths = getValidatorPaths(args, network);
   const accountPaths = getAccountPaths(args, network);
@@ -160,7 +160,7 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
       processShutdownCallback,
       signers,
       abortController,
-      doppelgangerProtectionEnabled,
+      doppelgangerProtection,
       afterBlockDelaySlotFraction: args.afterBlockDelaySlotFraction,
       scAfterBlockDelaySlotFraction: args.scAfterBlockDelaySlotFraction,
       disableAttestationGrouping: args.disableAttestationGrouping,

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -40,7 +40,7 @@ export type IValidatorCliArgs = AccountValidatorArgs &
     suggestedFeeRecipient?: string;
     proposerSettingsFile?: string;
     strictFeeRecipientCheck?: boolean;
-    doppelgangerProtectionEnabled?: boolean;
+    doppelgangerProtection?: boolean;
     defaultGasLimit?: number;
 
     builder?: boolean;
@@ -256,7 +256,8 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
     type: "string",
   },
 
-  doppelgangerProtectionEnabled: {
+  doppelgangerProtection: {
+    alias: ["doppelgangerProtectionEnabled"],
     description: "Enables Doppelganger protection",
     default: false,
     type: "boolean",

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -34,7 +34,7 @@ export type ValidatorOptions = {
   afterBlockDelaySlotFraction?: number;
   scAfterBlockDelaySlotFraction?: number;
   disableAttestationGrouping?: boolean;
-  doppelgangerProtectionEnabled?: boolean;
+  doppelgangerProtection?: boolean;
   closed?: boolean;
   valProposerConfig?: ValidatorProposerConfig;
   distributed?: boolean;
@@ -93,7 +93,7 @@ export class Validator {
     }
 
     const indicesService = new IndicesService(logger, api, metrics);
-    const doppelgangerService = opts.doppelgangerProtectionEnabled
+    const doppelgangerService = opts.doppelgangerProtection
       ? new DoppelgangerService(logger, clock, api, indicesService, opts.processShutdownCallback, metrics)
       : null;
 


### PR DESCRIPTION
**Motivation**

As a user of Lodestar, I intuitively assumed the flag to be `--doppelgangerProtection` (without looking into docs/code) when wanting to enable the feature for the first time.

The current CLI flag (`--doppelgangerProtectionEnabled`) is not aligned with other flags such as
- `--rest`
- `--builder`
- `--keymanager`
- `--metrics`
- `--discv5`
- `--strictFeeRecipientCheck`
- ... 

Suffixing the value with `Enabled` does not provide more information, just increases verbosity and reduces consistency with other CLI flags.

**Description**

Renames CLI flag to enable doppelganger protection to `--doppelgangerProtection`, keeps previous name as alias to be backward compatible.
