### PR TITLE
chore!: update prometheus-gc-stats dependency

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          check-latest: true
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          check-latest: true
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: 18
           registry-url: "https://registry.npmjs.org"
+          check-latest: true
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -52,9 +52,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Needs full depth for changelog generation
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
+          check-latest: true
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          check-latest: true
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node}}
+          check-latest: true
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node}}
+          check-latest: true
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          check-latest: true
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          check-latest: true
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          check-latest: true
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node}}
+          check-latest: true
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Eth Consensus Spec v1.1.10](https://img.shields.io/badge/ETH%20consensus--spec-1.1.10-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.1.10)
 [![codecov](https://codecov.io/gh/ChainSafe/lodestar/branch/unstable/graph/badge.svg)](https://codecov.io/gh/ChainSafe/lodestar)
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
-![Node Version](https://img.shields.io/badge/node-18.x-green)
+![Node Version](https://img.shields.io/badge/node-18.15.x-green)
 [![gitpoap badge](https://public-api.gitpoap.io/v1/repo/ChainSafe/lodestar/badge)](https://www.gitpoap.io/gh/ChainSafe/lodestar)
 
 [Lodestar](https://lodestar.chainsafe.io) is a TypeScript implementation of the [Ethereum Consensus specification](https://github.com/ethereum/consensus-specs) developed by [ChainSafe Systems](https://chainsafe.io).

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -101,6 +101,7 @@
     "@chainsafe/libp2p-gossipsub": "^6.2.0",
     "@chainsafe/libp2p-noise": "^11.0.4",
     "@chainsafe/persistent-merkle-tree": "^0.5.0",
+    "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/ssz": "^0.10.2",
     "@chainsafe/threads": "^1.11.0",
     "@ethersproject/abi": "^5.7.0",
@@ -145,7 +146,6 @@
     "jwt-simple": "0.5.6",
     "libp2p": "0.42.2",
     "prom-client": "^14.2.0",
-    "prometheus-gc-stats": "^0.6.4",
     "qs": "^6.11.1",
     "snappyjs": "^0.7.0",
     "strict-event-emitter-types": "^2.0.0",
@@ -158,7 +158,6 @@
   "devDependencies": {
     "@types/eventsource": "^1.1.11",
     "@types/leveldown": "^4.0.3",
-    "@types/prometheus-gc-stats": "^0.6.2",
     "@types/qs": "^6.9.7",
     "@types/supertest": "^2.0.12",
     "@types/tmp": "^0.2.3",

--- a/packages/beacon-node/src/metrics/metrics.ts
+++ b/packages/beacon-node/src/metrics/metrics.ts
@@ -9,7 +9,9 @@ import {RegistryMetricCreator} from "./utils/registryMetricCreator.js";
 import {createValidatorMonitor, ValidatorMonitor} from "./validatorMonitor.js";
 import {collectNodeJSMetrics} from "./nodeJsMetrics.js";
 
-export type Metrics = BeaconMetrics & LodestarMetrics & ValidatorMonitor & {register: RegistryMetricCreator};
+export type Metrics = BeaconMetrics &
+  LodestarMetrics &
+  ValidatorMonitor & {register: RegistryMetricCreator; close: () => void};
 
 export function createMetrics(
   opts: MetricsOptions,
@@ -33,7 +35,7 @@ export function createMetrics(
     lodestar.unhandledPromiseRejections.inc();
   });
 
-  collectNodeJSMetrics(register);
+  const close = collectNodeJSMetrics(register);
 
   // Merge external registries
   for (const externalRegister of externalRegistries) {
@@ -47,5 +49,6 @@ export function createMetrics(
     ...lodestar,
     ...validatorMonitor,
     register,
+    close,
   };
 }

--- a/packages/beacon-node/src/metrics/nodeJsMetrics.ts
+++ b/packages/beacon-node/src/metrics/nodeJsMetrics.ts
@@ -1,7 +1,7 @@
 import {collectDefaultMetrics, Registry} from "prom-client";
-import gcStats from "prometheus-gc-stats";
+import {gcStats} from "@chainsafe/prometheus-gc-stats";
 
-export function collectNodeJSMetrics(register: Registry, prefix?: string): void {
+export function collectNodeJSMetrics(register: Registry, prefix?: string): () => void {
   collectDefaultMetrics({
     register,
     prefix,
@@ -13,5 +13,7 @@ export function collectNodeJSMetrics(register: Registry, prefix?: string): void 
   // - nodejs_gc_runs_total: Counts the number of time GC is invoked
   // - nodejs_gc_pause_seconds_total: Time spent in GC in seconds
   // - nodejs_gc_reclaimed_bytes_total: The number of bytes GC has freed
-  gcStats(register, {prefix})();
+  // `close` must be called to stop the gc collection process from continuing
+  const close = gcStats(register, {collectionInterval: 6000, prefix});
+  return close;
 }

--- a/packages/beacon-node/src/network/core/networkCoreWorker.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorker.ts
@@ -50,7 +50,8 @@ const abortController = new AbortController();
 // Set up metrics, nodejs and discv5-specific
 const metricsRegister = workerData.metricsEnabled ? new RegistryMetricCreator() : null;
 if (metricsRegister) {
-  collectNodeJSMetrics(metricsRegister, "network_worker_");
+  const closeMetrics = collectNodeJSMetrics(metricsRegister, "network_worker_");
+  abortController.signal.addEventListener("abort", closeMetrics, {once: true});
 }
 
 // Main event bus shared across the stack

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -184,6 +184,7 @@ export class BeaconNode {
       initBeaconMetrics(metrics, anchorState);
       // Since the db is instantiated before this, metrics must be injected manually afterwards
       db.setMetrics(metrics.db);
+      signal.addEventListener("abort", metrics.close, {once: true});
     }
 
     const monitoring = opts.monitoring.endpoint

--- a/packages/beacon-node/test/unit/metrics/utils.ts
+++ b/packages/beacon-node/test/unit/metrics/utils.ts
@@ -6,5 +6,8 @@ import {testLogger} from "../../utils/logger.js";
 export function createMetricsTest(): Metrics {
   const state = ssz.phase0.BeaconState.defaultViewDU();
   const logger = testLogger();
-  return createMetrics({enabled: true, port: 0}, config, state, logger);
+  const metrics = createMetrics({enabled: true, port: 0}, config, state, logger);
+  // we don't need gc metrics running for tests
+  metrics.close();
+  return metrics;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,6 +627,11 @@
   resolved "https://registry.npmjs.org/@chainsafe/persistent-ts/-/persistent-ts-0.19.1.tgz"
   integrity sha512-fUFFFFxdcpYkMAHnjm83EYL/R/smtVmEkJr3FGSI6dwPk4ue9rXjEHf7FTd3V8AbVOcTJGriN4cYf2V+HOYkjQ==
 
+"@chainsafe/prometheus-gc-stats@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/prometheus-gc-stats/-/prometheus-gc-stats-1.0.0.tgz#9404abcf7e7a823596ecf3d71697f644568bde8c"
+  integrity sha512-l9aKCxQHBBBZIbCAl0y+7D4gded1cHUbIIRips68vN5zgpEuxjojUJSebuhLm+cgYdK1Wvf35gusA802bVfcdQ==
+
 "@chainsafe/ssz@^0.10.2":
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.10.2.tgz#c782929e1bb25fec66ba72e75934b31fd087579e"
@@ -3774,11 +3779,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/prometheus-gc-stats@^0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@types/prometheus-gc-stats/-/prometheus-gc-stats-0.6.2.tgz#b84246b13d0e7bd8bb61fa97a9ab624306b92697"
-  integrity sha512-HkT55AB8gPA7mrlkSVEoUgKQmnadWfioPZs0AakXRiggZzGKRCyLHe+WUpnvFashtWOJHUBQDjuR/siT9BKr/Q==
-
 "@types/qs@^6.9.7":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
@@ -4910,7 +4910,7 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bindings@^1.3.0, bindings@^1.3.1, bindings@^1.5.0:
+bindings@^1.3.0, bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
@@ -12049,11 +12049,6 @@ open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-optional@^0.1.3:
-  version "0.1.4"
-  resolved "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz"
-  integrity sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==
-
 optionator@^0.9.1:
   version "0.9.1"
   resolved "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz"
@@ -12735,15 +12730,6 @@ prom-client@^14.2.0:
   integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
   dependencies:
     tdigest "^0.1.1"
-
-prometheus-gc-stats@^0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/prometheus-gc-stats/-/prometheus-gc-stats-0.6.4.tgz#7326216b92ef71591a535cc31b89ee3f94150fe9"
-  integrity sha512-HtxtDYRurj7gZS9AqjcfEAldf2e053mh+XW//OjifRxr6Y/aLx8y7ETwWesnJ9DaufvAMyqUUQJUzhB9jLc6vg==
-  dependencies:
-    optional "^0.1.3"
-  optionalDependencies:
-    gc-stats "^1.4.0"
 
 promise-all-reject-late@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
**Motivation**

When updating to node v20, the `gc-stats` package was found to be out of date and incompatible with node 20. This dependency is a sub-dependency of `prometheus-gc-stats`, which we use to gather information about gc runs.

While investigating, I found that the information from `gc-stats` is now available natively from the `node:v8` package (as of node v18.15.0).

Seeing as `prometheus-gc-stats` was not well maintained, and `gc-stats` is completely abandoned, I took this opportunity to simplify the supply chain and use the native functionality from `node:v8` in a new [`@chainsafe/prometheus-gc-stats` package](https://github.com/ChainSafe/node-prometheus-gc-stats) (pull requests and a review welcome).

**Description**

- Use `@chainsafe/prometheus-gc-stats` instead of `prometheus-gc-stats`.
- Calling `gcStats(...)` now requires cleanup by calling the returned function.
- Always use the latest lts in our workflows
- Explicitly state the minimum node version (v18.15.x) in the README