### PR TITLE
fix: fix max responses that can be received by blobs side car by range

### DIFF
--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -8,7 +8,7 @@ import {phase0, allForks, deneb, altair, Root, capella, SlotRootHex} from "@lode
 import {routes} from "@lodestar/api";
 import {PeerScoreStatsDump} from "@chainsafe/libp2p-gossipsub/score";
 import {ResponseIncoming} from "@lodestar/reqresp";
-import {ForkName, ForkSeq} from "@lodestar/params";
+import {ForkName, ForkSeq, MAX_BLOBS_PER_BLOCK} from "@lodestar/params";
 import {Metrics, RegistryMetricCreator} from "../metrics/index.js";
 import {IBeaconChain} from "../chain/index.js";
 import {IBeaconDb} from "../db/interface.js";
@@ -468,7 +468,8 @@ export class Network implements INetwork {
   ): Promise<deneb.BlobSidecar[]> {
     return collectMaxResponseTyped(
       this.sendReqRespRequest(peerId, ReqRespMethod.BlobSidecarsByRange, [Version.V1], request),
-      request.count,
+      // request's count represent the slots, so the actual max count received could be slots * blobs per slot
+      request.count * MAX_BLOBS_PER_BLOCK,
       responseSszTypeByMethod[ReqRespMethod.BlobSidecarsByRange]
     );
   }


### PR DESCRIPTION
After quite a decent amount of debugging where lodestar would stall syncing via beacon blocks may be blobs by range on devnet6 from almost all clients on a particular epoch, it was figured out that the other clients were properly sending the response.

So it became apparent that lodestar was chunking out some of the blob data. This PR fixes the same as `count` in the blob side cars by range is `count` of `slots` for which blob data is requested.