### PR TITLE
fix(validator): close gc collection process on graceful shutdown

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -117,7 +117,8 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
   // Collect NodeJS metrics defined in the Lodestar repo
 
   if (metrics) {
-    collectNodeJSMetrics(register);
+    const closeMetrics = collectNodeJSMetrics(register);
+    onGracefulShutdownCbs.push(() => closeMetrics());
 
     // only start server if metrics are explicitly enabled
     if (args["metrics"]) {


### PR DESCRIPTION
**Motivation**

GC collection process must be explicitly closed
- see https://github.com/ChainSafe/lodestar/pull/5677

**Description**

Close gc collection process when shutting down validator client.
