### PR TITLE
feat: freeze voluntary exit signature fork domain to Capella version from deneb fork onwards

### DIFF
--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -41,6 +41,7 @@ const skipOpts: SkipOpts = {
     // Deneb signed voluntary exits will not be valid so skipping this
     // To be cleaned up with the spec version update
     "deneb/operations/voluntary_exit/",
+    "deneb/random/random",
   ],
 };
 

--- a/packages/beacon-node/test/spec/presets/index.test.ts
+++ b/packages/beacon-node/test/spec/presets/index.test.ts
@@ -37,6 +37,10 @@ const skipOpts: SkipOpts = {
   skippedPrefixes: [
     "capella/light_client/single_merkle_proof/BeaconBlockBody",
     "deneb/light_client/single_merkle_proof/BeaconBlockBody",
+    // TODO: deneb
+    // Deneb signed voluntary exits will not be valid so skipping this
+    // To be cleaned up with the spec version update
+    "deneb/operations/voluntary_exit/",
   ],
 };
 

--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -97,11 +97,11 @@ ${validatorsToExit.map((v) => `${v.pubkey} ${v.index} ${v.status}`).join("\n")}`
     }
 
     for (const [i, {index, signer, pubkey}] of validatorsToExit.entries()) {
-      // Deneb onwards the signature domain fork is fixed to Deneb
+      // Deneb onwards the signature domain fork is fixed to Capella version
       const domain =
         exitEpoch < config.DENEB_FORK_EPOCH
           ? config.getDomain(computeStartSlotAtEpoch(exitEpoch), DOMAIN_VOLUNTARY_EXIT)
-          : config.getDomainAtFork(ForkName.deneb, DOMAIN_VOLUNTARY_EXIT);
+          : config.getDomainAtFork(ForkName.capella, DOMAIN_VOLUNTARY_EXIT);
       const voluntaryExit: phase0.VoluntaryExit = {epoch: exitEpoch, validatorIndex: index};
       const signingRoot = computeSigningRoot(ssz.phase0.VoluntaryExit, voluntaryExit, domain);
 

--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -5,7 +5,6 @@ import {
   computeStartSlotAtEpoch,
   getCurrentSlot,
 } from "@lodestar/state-transition";
-import {DOMAIN_VOLUNTARY_EXIT, ForkName} from "@lodestar/params";
 import {createBeaconConfig} from "@lodestar/config";
 import {ssz, phase0} from "@lodestar/types";
 import {toHex} from "@lodestar/utils";
@@ -97,11 +96,7 @@ ${validatorsToExit.map((v) => `${v.pubkey} ${v.index} ${v.status}`).join("\n")}`
     }
 
     for (const [i, {index, signer, pubkey}] of validatorsToExit.entries()) {
-      // Deneb onwards the signature domain fork is fixed to Capella version
-      const domain =
-        exitEpoch < config.DENEB_FORK_EPOCH
-          ? config.getDomain(computeStartSlotAtEpoch(exitEpoch), DOMAIN_VOLUNTARY_EXIT)
-          : config.getDomainAtFork(ForkName.capella, DOMAIN_VOLUNTARY_EXIT);
+      const domain = config.getDomainForVoluntaryExit(computeStartSlotAtEpoch(exitEpoch));
       const voluntaryExit: phase0.VoluntaryExit = {epoch: exitEpoch, validatorIndex: index};
       const signingRoot = computeSigningRoot(ssz.phase0.VoluntaryExit, voluntaryExit, domain);
 

--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -5,7 +5,7 @@ import {
   computeStartSlotAtEpoch,
   getCurrentSlot,
 } from "@lodestar/state-transition";
-import {DOMAIN_VOLUNTARY_EXIT} from "@lodestar/params";
+import {DOMAIN_VOLUNTARY_EXIT, ForkName} from "@lodestar/params";
 import {createBeaconConfig} from "@lodestar/config";
 import {ssz, phase0} from "@lodestar/types";
 import {toHex} from "@lodestar/utils";
@@ -97,7 +97,11 @@ ${validatorsToExit.map((v) => `${v.pubkey} ${v.index} ${v.status}`).join("\n")}`
     }
 
     for (const [i, {index, signer, pubkey}] of validatorsToExit.entries()) {
-      const domain = config.getDomain(computeStartSlotAtEpoch(exitEpoch), DOMAIN_VOLUNTARY_EXIT);
+      // Deneb onwards the signature domain fork is fixed to Deneb
+      const domain =
+        exitEpoch < config.DENEB_FORK_EPOCH
+          ? config.getDomain(computeStartSlotAtEpoch(exitEpoch), DOMAIN_VOLUNTARY_EXIT)
+          : config.getDomainAtFork(ForkName.deneb, DOMAIN_VOLUNTARY_EXIT);
       const voluntaryExit: phase0.VoluntaryExit = {epoch: exitEpoch, validatorIndex: index};
       const signingRoot = computeSigningRoot(ssz.phase0.VoluntaryExit, voluntaryExit, domain);
 

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -77,11 +77,11 @@ export function createCachedGenesis(chainForkConfig: ChainForkConfig, genesisVal
     },
 
     getDomainForVoluntaryExit(stateSlot: Slot, messageSlot?: Slot) {
-      // Deneb onwards the signature domain fork is fixed to Deneb
+      // Deneb onwards the signature domain fork is fixed to capella
       const domain =
         stateSlot < chainForkConfig.DENEB_FORK_EPOCH * SLOTS_PER_EPOCH
           ? this.getDomain(stateSlot, DOMAIN_VOLUNTARY_EXIT, messageSlot)
-          : this.getDomainAtFork(ForkName.deneb, DOMAIN_VOLUNTARY_EXIT);
+          : this.getDomainAtFork(ForkName.capella, DOMAIN_VOLUNTARY_EXIT);
 
       return domain;
     },

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -1,4 +1,4 @@
-import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkName, SLOTS_PER_EPOCH, DOMAIN_VOLUNTARY_EXIT} from "@lodestar/params";
 import {DomainType, ForkDigest, phase0, Root, Slot, ssz, Version} from "@lodestar/types";
 import {toHexString} from "@chainsafe/ssz";
 import {ChainForkConfig} from "../beaconConfig.js";
@@ -73,6 +73,16 @@ export function createCachedGenesis(chainForkConfig: ChainForkConfig, genesisVal
         domain = computeDomain(domainType, forkInfo.version, genesisValidatorsRoot);
         domainByType.set(domainType, domain);
       }
+      return domain;
+    },
+
+    getDomainForVoluntaryExit(stateSlot: Slot, messageSlot?: Slot) {
+      // Deneb onwards the signature domain fork is fixed to Deneb
+      const domain =
+        stateSlot < chainForkConfig.DENEB_FORK_EPOCH * SLOTS_PER_EPOCH
+          ? this.getDomain(stateSlot, DOMAIN_VOLUNTARY_EXIT, messageSlot)
+          : this.getDomainAtFork(ForkName.deneb, DOMAIN_VOLUNTARY_EXIT);
+
       return domain;
     },
 

--- a/packages/config/src/genesisConfig/types.ts
+++ b/packages/config/src/genesisConfig/types.ts
@@ -22,5 +22,7 @@ export interface CachedGenesis extends ForkDigestContext {
    */
   getDomainAtFork(forkName: ForkName, domainType: DomainType): Uint8Array;
 
+  getDomainForVoluntaryExit(stateSlot: Slot, messageSlot?: Slot): Uint8Array;
+
   readonly genesisValidatorsRoot: Root;
 }

--- a/packages/state-transition/src/signatureSets/voluntaryExits.ts
+++ b/packages/state-transition/src/signatureSets/voluntaryExits.ts
@@ -27,14 +27,11 @@ export function getVoluntaryExitSignatureSet(
   const slot = computeStartSlotAtEpoch(signedVoluntaryExit.message.epoch);
   const denebSlot = computeStartSlotAtEpoch(state.config.DENEB_FORK_EPOCH);
 
-  // Deneb onwards the domain fork is fixed to Deneb
-  //
-  // note that previously signed domain for e.g. capella domain sigs will no more be valid on deneb
-  // generally the signatures stay valid across one fork boundary
+  // Deneb onwards the domain fork is fixed to Capella version
   const domain =
     state.slot < denebSlot
       ? state.config.getDomain(state.slot, DOMAIN_VOLUNTARY_EXIT, slot)
-      : state.config.getDomainAtFork(ForkName.deneb, DOMAIN_VOLUNTARY_EXIT);
+      : state.config.getDomainAtFork(ForkName.capella, DOMAIN_VOLUNTARY_EXIT);
 
   return {
     type: SignatureSetType.single,

--- a/packages/state-transition/src/signatureSets/voluntaryExits.ts
+++ b/packages/state-transition/src/signatureSets/voluntaryExits.ts
@@ -1,4 +1,4 @@
-import {DOMAIN_VOLUNTARY_EXIT} from "@lodestar/params";
+import {DOMAIN_VOLUNTARY_EXIT, ForkName} from "@lodestar/params";
 import {allForks, phase0, ssz} from "@lodestar/types";
 import {
   computeSigningRoot,
@@ -25,7 +25,16 @@ export function getVoluntaryExitSignatureSet(
 ): ISignatureSet {
   const {epochCtx} = state;
   const slot = computeStartSlotAtEpoch(signedVoluntaryExit.message.epoch);
-  const domain = state.config.getDomain(state.slot, DOMAIN_VOLUNTARY_EXIT, slot);
+  const denebSlot = computeStartSlotAtEpoch(state.config.DENEB_FORK_EPOCH);
+
+  // Deneb onwards the domain fork is fixed to Deneb
+  //
+  // note that previously signed domain for e.g. capella domain sigs will no more be valid on deneb
+  // generally the signatures stay valid across one fork boundary
+  const domain =
+    state.slot < denebSlot
+      ? state.config.getDomain(state.slot, DOMAIN_VOLUNTARY_EXIT, slot)
+      : state.config.getDomainAtFork(ForkName.deneb, DOMAIN_VOLUNTARY_EXIT);
 
   return {
     type: SignatureSetType.single,

--- a/packages/state-transition/src/signatureSets/voluntaryExits.ts
+++ b/packages/state-transition/src/signatureSets/voluntaryExits.ts
@@ -1,4 +1,3 @@
-import {DOMAIN_VOLUNTARY_EXIT, ForkName} from "@lodestar/params";
 import {allForks, phase0, ssz} from "@lodestar/types";
 import {
   computeSigningRoot,
@@ -25,13 +24,7 @@ export function getVoluntaryExitSignatureSet(
 ): ISignatureSet {
   const {epochCtx} = state;
   const slot = computeStartSlotAtEpoch(signedVoluntaryExit.message.epoch);
-  const denebSlot = computeStartSlotAtEpoch(state.config.DENEB_FORK_EPOCH);
-
-  // Deneb onwards the domain fork is fixed to Capella version
-  const domain =
-    state.slot < denebSlot
-      ? state.config.getDomain(state.slot, DOMAIN_VOLUNTARY_EXIT, slot)
-      : state.config.getDomainAtFork(ForkName.capella, DOMAIN_VOLUNTARY_EXIT);
+  const domain = state.config.getDomainForVoluntaryExit(state.slot, slot);
 
   return {
     type: SignatureSetType.single,

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -9,6 +9,7 @@ import {
 } from "@lodestar/state-transition";
 import {BeaconConfig} from "@lodestar/config";
 import {
+  ForkName,
   DOMAIN_AGGREGATE_AND_PROOF,
   DOMAIN_BEACON_ATTESTER,
   DOMAIN_BEACON_PROPOSER,
@@ -563,7 +564,11 @@ export class ValidatorStore {
     exitEpoch: Epoch
   ): Promise<phase0.SignedVoluntaryExit> {
     const signingSlot = computeStartSlotAtEpoch(exitEpoch);
-    const domain = this.config.getDomain(signingSlot, DOMAIN_VOLUNTARY_EXIT);
+    // Deneb onwards the signature fork is fixed to Deneb
+    const domain =
+      exitEpoch < this.config.DENEB_FORK_EPOCH
+        ? this.config.getDomain(signingSlot, DOMAIN_VOLUNTARY_EXIT)
+        : this.config.getDomainAtFork(ForkName.deneb, DOMAIN_VOLUNTARY_EXIT);
 
     const voluntaryExit: phase0.VoluntaryExit = {epoch: exitEpoch, validatorIndex};
     const signingRoot = computeSigningRoot(ssz.phase0.VoluntaryExit, voluntaryExit, domain);

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -9,7 +9,6 @@ import {
 } from "@lodestar/state-transition";
 import {BeaconConfig} from "@lodestar/config";
 import {
-  ForkName,
   DOMAIN_AGGREGATE_AND_PROOF,
   DOMAIN_BEACON_ATTESTER,
   DOMAIN_BEACON_PROPOSER,
@@ -18,7 +17,6 @@ import {
   DOMAIN_SELECTION_PROOF,
   DOMAIN_SYNC_COMMITTEE,
   DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF,
-  DOMAIN_VOLUNTARY_EXIT,
   DOMAIN_APPLICATION_BUILDER,
   DOMAIN_BLOB_SIDECAR,
 } from "@lodestar/params";
@@ -564,11 +562,7 @@ export class ValidatorStore {
     exitEpoch: Epoch
   ): Promise<phase0.SignedVoluntaryExit> {
     const signingSlot = computeStartSlotAtEpoch(exitEpoch);
-    // Deneb onwards the signature fork is fixed to Capella version
-    const domain =
-      exitEpoch < this.config.DENEB_FORK_EPOCH
-        ? this.config.getDomain(signingSlot, DOMAIN_VOLUNTARY_EXIT)
-        : this.config.getDomainAtFork(ForkName.capella, DOMAIN_VOLUNTARY_EXIT);
+    const domain = this.config.getDomainForVoluntaryExit(signingSlot);
 
     const voluntaryExit: phase0.VoluntaryExit = {epoch: exitEpoch, validatorIndex};
     const signingRoot = computeSigningRoot(ssz.phase0.VoluntaryExit, voluntaryExit, domain);

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -564,11 +564,11 @@ export class ValidatorStore {
     exitEpoch: Epoch
   ): Promise<phase0.SignedVoluntaryExit> {
     const signingSlot = computeStartSlotAtEpoch(exitEpoch);
-    // Deneb onwards the signature fork is fixed to Deneb
+    // Deneb onwards the signature fork is fixed to Capella version
     const domain =
       exitEpoch < this.config.DENEB_FORK_EPOCH
         ? this.config.getDomain(signingSlot, DOMAIN_VOLUNTARY_EXIT)
-        : this.config.getDomainAtFork(ForkName.deneb, DOMAIN_VOLUNTARY_EXIT);
+        : this.config.getDomainAtFork(ForkName.capella, DOMAIN_VOLUNTARY_EXIT);
 
     const voluntaryExit: phase0.VoluntaryExit = {epoch: exitEpoch, validatorIndex};
     const signingRoot = computeSigningRoot(ssz.phase0.VoluntaryExit, voluntaryExit, domain);


### PR DESCRIPTION
Ref
 - https://github.com/ethereum/consensus-specs/pull/3288
 

NOTE:
This PR skips some spec tests as they test voluntary exits on deneb domain fork. These skips will be removed with the new spec version update for which a few other PRs are pending.
