### PR TITLE
refactor: clean up validator import options

### DIFF
--- a/packages/cli/src/cmds/validator/import.ts
+++ b/packages/cli/src/cmds/validator/import.ts
@@ -10,7 +10,11 @@ import {PersistedKeysBackend} from "./keymanager/persistedKeys.js";
 
 /* eslint-disable no-console */
 
-export const importCmd: CliCommand<IValidatorCliArgs, GlobalArgs> = {
+type ValidatorImportArgs = Pick<IValidatorCliArgs, "importKeystores" | "importKeystoresPassword">;
+
+const {importKeystores, importKeystoresPassword} = validatorOptions;
+
+export const importCmd: CliCommand<ValidatorImportArgs, IValidatorCliArgs & GlobalArgs> = {
   command: "import",
 
   describe:
@@ -29,12 +33,11 @@ Ethereum Foundation utility.",
   // Note: re-uses `--importKeystores` and `--importKeystoresPassword` from root validator command options
 
   options: {
-    ...validatorOptions,
-
     importKeystores: {
-      ...validatorOptions.importKeystores,
+      ...importKeystores,
       requiresArg: true,
     },
+    importKeystoresPassword,
   },
 
   handler: async (args) => {


### PR DESCRIPTION
**Motivation**

The [validator import docs](https://chainsafe.github.io/lodestar/reference/cli/#validator-import) show all options that are available to validator which does not make sense as the only essential (non-hidden) options are `--importKeystores` and `importKeystoresPassword`.

**Description**

Fix validator import docs to only show relevant options. Validator options and global options are still available as parent args but do not need to be specifically documented for the sub-command.

![image](https://github.com/ChainSafe/lodestar/assets/38436224/92d94d8d-6eb9-4ae3-9823-6efc06d7d5e4)


