### PR TITLE
chore!: set node version requirement to >=18.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "engines": {
-    "node": ">=12.9.0"
+    "node": ">=18.15.0"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
**Motivation**

After #5677, lodestar only supports node >=18.15.x

**Description**

Update the `engines` property in the root package.json