### PR TITLE
chore: use availableParallelism to determine thread pool size

### DIFF
--- a/packages/beacon-node/src/chain/bls/multithread/poolSize.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/poolSize.ts
@@ -4,7 +4,7 @@ try {
   if (typeof navigator !== "undefined") {
     defaultPoolSize = navigator.hardwareConcurrency ?? 4;
   } else {
-    defaultPoolSize = (await import("node:os")).cpus().length;
+    defaultPoolSize = (await import("node:os")).availableParallelism();
   }
 } catch (e) {
   defaultPoolSize = 8;

--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystores/poolSize.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystores/poolSize.ts
@@ -4,8 +4,7 @@ try {
   if (typeof navigator !== "undefined") {
     maxPoolSize = navigator.hardwareConcurrency ?? 4;
   } else {
-    // TODO change this line to use os.availableParallelism() once we upgrade to node v20
-    maxPoolSize = (await import("node:os")).cpus().length;
+    maxPoolSize = (await import("node:os")).availableParallelism();
   }
 } catch (e) {
   maxPoolSize = 8;


### PR DESCRIPTION
**Motivation**

From [node docs](https://nodejs.org/api/os.html#oscpus)

> os.cpus().length should not be used to calculate the amount of parallelism available to an application. Use os.availableParallelism() for this purpose.

**Description**

Use `os.availableParallelism()` instead of `os.cpus().length` to determine thread pool size.

This is supported from node v18.14.0, see [availableParallelism](https://nodejs.org/api/os.html#osavailableparallelism).
