### PR TITLE
test: update beacon api spec version to 2.4.1

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,7 +1,7 @@
 # Lodestar Eth Consensus API
 
 [![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/aMxzVcr)
-[![ETH Beacon APIs Spec v2.1.0](https://img.shields.io/badge/ETH%20beacon--APIs-2.1.0-blue)](https://github.com/ethereum/beacon-APIs/releases/tag/v2.1.0)
+[![ETH Beacon APIs Spec v2.4.1](https://img.shields.io/badge/ETH%20beacon--APIs-2.4.1-blue)](https://github.com/ethereum/beacon-APIs/releases/tag/v2.4.1)
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
 ![Node Version](https://img.shields.io/badge/node-18.x-green)
 

--- a/packages/api/src/beacon/routes/beacon/pool.ts
+++ b/packages/api/src/beacon/routes/beacon/pool.ts
@@ -63,7 +63,7 @@ export type Api = {
    * @returns any Successful response
    * @throws ApiError
    */
-  getPoolBlsToExecutionChanges(): Promise<
+  getPoolBLSToExecutionChanges(): Promise<
     ApiClientResponse<{[HttpStatusCode.OK]: {data: capella.SignedBLSToExecutionChange[]}}>
   >;
 
@@ -123,7 +123,7 @@ export type Api = {
    * @returns any BLSToExecutionChange is stored in node and broadcasted to network
    * @throws ApiError
    */
-  submitPoolBlsToExecutionChange(
+  submitPoolBLSToExecutionChange(
     blsToExecutionChange: capella.SignedBLSToExecutionChange[]
   ): Promise<ApiClientResponse<{[HttpStatusCode.OK]: void}, HttpStatusCode.BAD_REQUEST>>;
 
@@ -143,12 +143,12 @@ export const routesData: RoutesData<Api> = {
   getPoolAttesterSlashings: {url: "/eth/v1/beacon/pool/attester_slashings", method: "GET"},
   getPoolProposerSlashings: {url: "/eth/v1/beacon/pool/proposer_slashings", method: "GET"},
   getPoolVoluntaryExits: {url: "/eth/v1/beacon/pool/voluntary_exits", method: "GET"},
-  getPoolBlsToExecutionChanges: {url: "/eth/v1/beacon/pool/bls_to_execution_changes", method: "GET"},
+  getPoolBLSToExecutionChanges: {url: "/eth/v1/beacon/pool/bls_to_execution_changes", method: "GET"},
   submitPoolAttestations: {url: "/eth/v1/beacon/pool/attestations", method: "POST"},
   submitPoolAttesterSlashings: {url: "/eth/v1/beacon/pool/attester_slashings", method: "POST"},
   submitPoolProposerSlashings: {url: "/eth/v1/beacon/pool/proposer_slashings", method: "POST"},
   submitPoolVoluntaryExit: {url: "/eth/v1/beacon/pool/voluntary_exits", method: "POST"},
-  submitPoolBlsToExecutionChange: {url: "/eth/v1/beacon/pool/bls_to_execution_changes", method: "POST"},
+  submitPoolBLSToExecutionChange: {url: "/eth/v1/beacon/pool/bls_to_execution_changes", method: "POST"},
   submitPoolSyncCommitteeSignatures: {url: "/eth/v1/beacon/pool/sync_committees", method: "POST"},
 };
 
@@ -158,12 +158,12 @@ export type ReqTypes = {
   getPoolAttesterSlashings: ReqEmpty;
   getPoolProposerSlashings: ReqEmpty;
   getPoolVoluntaryExits: ReqEmpty;
-  getPoolBlsToExecutionChanges: ReqEmpty;
+  getPoolBLSToExecutionChanges: ReqEmpty;
   submitPoolAttestations: {body: unknown};
   submitPoolAttesterSlashings: {body: unknown};
   submitPoolProposerSlashings: {body: unknown};
   submitPoolVoluntaryExit: {body: unknown};
-  submitPoolBlsToExecutionChange: {body: unknown};
+  submitPoolBLSToExecutionChange: {body: unknown};
   submitPoolSyncCommitteeSignatures: {body: unknown};
 };
 
@@ -177,12 +177,12 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
     getPoolAttesterSlashings: reqEmpty,
     getPoolProposerSlashings: reqEmpty,
     getPoolVoluntaryExits: reqEmpty,
-    getPoolBlsToExecutionChanges: reqEmpty,
+    getPoolBLSToExecutionChanges: reqEmpty,
     submitPoolAttestations: reqOnlyBody(ArrayOf(ssz.phase0.Attestation), Schema.ObjectArray),
     submitPoolAttesterSlashings: reqOnlyBody(ssz.phase0.AttesterSlashing, Schema.Object),
     submitPoolProposerSlashings: reqOnlyBody(ssz.phase0.ProposerSlashing, Schema.Object),
     submitPoolVoluntaryExit: reqOnlyBody(ssz.phase0.SignedVoluntaryExit, Schema.Object),
-    submitPoolBlsToExecutionChange: reqOnlyBody(ArrayOf(ssz.capella.SignedBLSToExecutionChange), Schema.ObjectArray),
+    submitPoolBLSToExecutionChange: reqOnlyBody(ArrayOf(ssz.capella.SignedBLSToExecutionChange), Schema.ObjectArray),
     submitPoolSyncCommitteeSignatures: reqOnlyBody(ArrayOf(ssz.altair.SyncCommitteeMessage), Schema.ObjectArray),
   };
 }
@@ -193,6 +193,6 @@ export function getReturnTypes(): ReturnTypes<Api> {
     getPoolAttesterSlashings: ContainerData(ArrayOf(ssz.phase0.AttesterSlashing)),
     getPoolProposerSlashings: ContainerData(ArrayOf(ssz.phase0.ProposerSlashing)),
     getPoolVoluntaryExits: ContainerData(ArrayOf(ssz.phase0.SignedVoluntaryExit)),
-    getPoolBlsToExecutionChanges: ContainerData(ArrayOf(ssz.capella.SignedBLSToExecutionChange)),
+    getPoolBLSToExecutionChanges: ContainerData(ArrayOf(ssz.capella.SignedBLSToExecutionChange)),
   };
 }

--- a/packages/api/src/beacon/routes/lightclient.ts
+++ b/packages/api/src/beacon/routes/lightclient.ts
@@ -24,7 +24,7 @@ export type Api = {
    * - Has most bits
    * - Oldest update
    */
-  getUpdates(
+  getLightClientUpdatesByRange(
     startPeriod: SyncPeriod,
     count: number
   ): Promise<
@@ -39,7 +39,7 @@ export type Api = {
    * Returns the latest optimistic head update available. Clients should use the SSE type `light_client_optimistic_update`
    * unless to get the very first head update after syncing, or if SSE are not supported by the server.
    */
-  getOptimisticUpdate(): Promise<
+  getLightClientOptimisticUpdate(): Promise<
     ApiClientResponse<{
       [HttpStatusCode.OK]: {
         version: ForkName;
@@ -47,7 +47,7 @@ export type Api = {
       };
     }>
   >;
-  getFinalityUpdate(): Promise<
+  getLightClientFinalityUpdate(): Promise<
     ApiClientResponse<{
       [HttpStatusCode.OK]: {
         version: ForkName;
@@ -60,7 +60,7 @@ export type Api = {
    * The trusted block root should be fetched with similar means to a weak subjectivity checkpoint.
    * Only block roots for checkpoints are guaranteed to be available.
    */
-  getBootstrap(blockRoot: string): Promise<
+  getLightClientBootstrap(blockRoot: string): Promise<
     ApiClientResponse<{
       [HttpStatusCode.OK]: {
         version: ForkName;
@@ -71,7 +71,7 @@ export type Api = {
   /**
    * Returns an array of sync committee hashes based on the provided period and count
    */
-  getCommitteeRoot(
+  getLightClientCommitteeRoot(
     startPeriod: SyncPeriod,
     count: number
   ): Promise<
@@ -87,39 +87,39 @@ export type Api = {
  * Define javascript values for each route
  */
 export const routesData: RoutesData<Api> = {
-  getUpdates: {url: "/eth/v1/beacon/light_client/updates", method: "GET"},
-  getOptimisticUpdate: {url: "/eth/v1/beacon/light_client/optimistic_update", method: "GET"},
-  getFinalityUpdate: {url: "/eth/v1/beacon/light_client/finality_update", method: "GET"},
-  getBootstrap: {url: "/eth/v1/beacon/light_client/bootstrap/{block_root}", method: "GET"},
-  getCommitteeRoot: {url: "/eth/v0/beacon/light_client/committee_root", method: "GET"},
+  getLightClientUpdatesByRange: {url: "/eth/v1/beacon/light_client/updates", method: "GET"},
+  getLightClientOptimisticUpdate: {url: "/eth/v1/beacon/light_client/optimistic_update", method: "GET"},
+  getLightClientFinalityUpdate: {url: "/eth/v1/beacon/light_client/finality_update", method: "GET"},
+  getLightClientBootstrap: {url: "/eth/v1/beacon/light_client/bootstrap/{block_root}", method: "GET"},
+  getLightClientCommitteeRoot: {url: "/eth/v0/beacon/light_client/committee_root", method: "GET"},
 };
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export type ReqTypes = {
-  getUpdates: {query: {start_period: number; count: number}};
-  getOptimisticUpdate: ReqEmpty;
-  getFinalityUpdate: ReqEmpty;
-  getBootstrap: {params: {block_root: string}};
-  getCommitteeRoot: {query: {start_period: number; count: number}};
+  getLightClientUpdatesByRange: {query: {start_period: number; count: number}};
+  getLightClientOptimisticUpdate: ReqEmpty;
+  getLightClientFinalityUpdate: ReqEmpty;
+  getLightClientBootstrap: {params: {block_root: string}};
+  getLightClientCommitteeRoot: {query: {start_period: number; count: number}};
 };
 
 export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
   return {
-    getUpdates: {
+    getLightClientUpdatesByRange: {
       writeReq: (start_period, count) => ({query: {start_period, count}}),
       parseReq: ({query}) => [query.start_period, query.count],
       schema: {query: {start_period: Schema.UintRequired, count: Schema.UintRequired}},
     },
 
-    getOptimisticUpdate: reqEmpty,
-    getFinalityUpdate: reqEmpty,
+    getLightClientOptimisticUpdate: reqEmpty,
+    getLightClientFinalityUpdate: reqEmpty,
 
-    getBootstrap: {
+    getLightClientBootstrap: {
       writeReq: (block_root) => ({params: {block_root}}),
       parseReq: ({params}) => [params.block_root],
       schema: {params: {block_root: Schema.StringRequired}},
     },
-    getCommitteeRoot: {
+    getLightClientCommitteeRoot: {
       writeReq: (start_period, count) => ({query: {start_period, count}}),
       parseReq: ({query}) => [query.start_period, query.count],
       schema: {query: {start_period: Schema.UintRequired, count: Schema.UintRequired}},
@@ -128,31 +128,31 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 }
 
 export function getReturnTypes(): ReturnTypes<Api> {
-  // Form a TypeJson convertor for getUpdates
+  // Form a TypeJson convertor for getLightClientUpdatesByRange
   const VersionedUpdate = WithVersion((fork: ForkName) =>
     isForkLightClient(fork) ? ssz.allForksLightClient[fork].LightClientUpdate : ssz.altair.LightClientUpdate
   );
-  const getUpdates = {
+  const getLightClientUpdatesByRange = {
     toJson: (updates: {version: ForkName; data: allForks.LightClientUpdate}[]) =>
       updates.map((data) => VersionedUpdate.toJson(data)),
     fromJson: (updates: unknown[]) => updates.map((data) => VersionedUpdate.fromJson(data)),
   };
 
   return {
-    getUpdates,
-    getOptimisticUpdate: WithVersion((fork: ForkName) =>
+    getLightClientUpdatesByRange,
+    getLightClientOptimisticUpdate: WithVersion((fork: ForkName) =>
       isForkLightClient(fork)
         ? ssz.allForksLightClient[fork].LightClientOptimisticUpdate
         : ssz.altair.LightClientOptimisticUpdate
     ),
-    getFinalityUpdate: WithVersion((fork: ForkName) =>
+    getLightClientFinalityUpdate: WithVersion((fork: ForkName) =>
       isForkLightClient(fork)
         ? ssz.allForksLightClient[fork].LightClientFinalityUpdate
         : ssz.altair.LightClientFinalityUpdate
     ),
-    getBootstrap: WithVersion((fork: ForkName) =>
+    getLightClientBootstrap: WithVersion((fork: ForkName) =>
       isForkLightClient(fork) ? ssz.allForksLightClient[fork].LightClientBootstrap : ssz.altair.LightClientBootstrap
     ),
-    getCommitteeRoot: ContainerData(ArrayOf(ssz.Root)),
+    getLightClientCommitteeRoot: ContainerData(ArrayOf(ssz.Root)),
   };
 }

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -23,7 +23,7 @@ import {testData as validatorTestData} from "./testData/validator.js";
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const version = "v2.3.0";
+const version = "v2.4.1";
 const openApiFile: OpenApiFile = {
   url: `https://github.com/ethereum/beacon-APIs/releases/download/${version}/beacon-node-oapi.json`,
   filepath: path.join(__dirname, "../../../oapi-schemas/beacon-node-oapi.json"),

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -79,7 +79,7 @@ export const testData: GenericServerTestCases<Api> = {
     args: [],
     res: {data: [ssz.phase0.SignedVoluntaryExit.defaultValue()]},
   },
-  getPoolBlsToExecutionChanges: {
+  getPoolBLSToExecutionChanges: {
     args: [],
     res: {data: [ssz.capella.SignedBLSToExecutionChange.defaultValue()]},
   },
@@ -99,7 +99,7 @@ export const testData: GenericServerTestCases<Api> = {
     args: [ssz.phase0.SignedVoluntaryExit.defaultValue()],
     res: undefined,
   },
-  submitPoolBlsToExecutionChange: {
+  submitPoolBLSToExecutionChange: {
     args: [[ssz.capella.SignedBLSToExecutionChange.defaultValue()]],
     res: undefined,
   },

--- a/packages/api/test/unit/beacon/testData/lightclient.ts
+++ b/packages/api/test/unit/beacon/testData/lightclient.ts
@@ -12,15 +12,15 @@ const header = ssz.altair.LightClientHeader.defaultValue();
 const signatureSlot = ssz.Slot.defaultValue();
 
 export const testData: GenericServerTestCases<Api> = {
-  getUpdates: {
+  getLightClientUpdatesByRange: {
     args: [1, 2],
     res: [{version: ForkName.bellatrix, data: lightClientUpdate}],
   },
-  getOptimisticUpdate: {
+  getLightClientOptimisticUpdate: {
     args: [],
     res: {version: ForkName.bellatrix, data: {syncAggregate, attestedHeader: header, signatureSlot}},
   },
-  getFinalityUpdate: {
+  getLightClientFinalityUpdate: {
     args: [],
     res: {
       version: ForkName.bellatrix,
@@ -33,7 +33,7 @@ export const testData: GenericServerTestCases<Api> = {
       },
     },
   },
-  getBootstrap: {
+  getLightClientBootstrap: {
     args: [toHexString(root)],
     res: {
       version: ForkName.bellatrix,
@@ -44,7 +44,7 @@ export const testData: GenericServerTestCases<Api> = {
       },
     },
   },
-  getCommitteeRoot: {
+  getLightClientCommitteeRoot: {
     args: [1, 2],
     res: {data: [Buffer.alloc(32, 0), Buffer.alloc(32, 1)]},
   },

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -5,7 +5,7 @@ import {validateGossipAttestation} from "../../../../chain/validation/index.js";
 import {validateGossipAttesterSlashing} from "../../../../chain/validation/attesterSlashing.js";
 import {validateGossipProposerSlashing} from "../../../../chain/validation/proposerSlashing.js";
 import {validateGossipVoluntaryExit} from "../../../../chain/validation/voluntaryExit.js";
-import {validateBlsToExecutionChange} from "../../../../chain/validation/blsToExecutionChange.js";
+import {validateBLSToExecutionChange} from "../../../../chain/validation/blsToExecutionChange.js";
 import {validateSyncCommitteeSigOnly} from "../../../../chain/validation/syncCommittee.js";
 import {ApiModules} from "../../types.js";
 import {AttestationError, GossipAction, SyncCommitteeError} from "../../../../chain/errors/index.js";
@@ -41,8 +41,8 @@ export function getBeaconPoolApi({
       return {data: chain.opPool.getAllVoluntaryExits()};
     },
 
-    async getPoolBlsToExecutionChanges() {
-      return {data: chain.opPool.getAllBlsToExecutionChanges().map(({data}) => data)};
+    async getPoolBLSToExecutionChanges() {
+      return {data: chain.opPool.getAllBLSToExecutionChanges().map(({data}) => data)};
     },
 
     async submitPoolAttestations(attestations) {
@@ -111,23 +111,23 @@ export function getBeaconPoolApi({
       await network.publishVoluntaryExit(voluntaryExit);
     },
 
-    async submitPoolBlsToExecutionChange(blsToExecutionChanges) {
+    async submitPoolBLSToExecutionChange(blsToExecutionChanges) {
       const errors: Error[] = [];
 
       await Promise.all(
         blsToExecutionChanges.map(async (blsToExecutionChange, i) => {
           try {
             // Ignore even if the change exists and reprocess
-            await validateBlsToExecutionChange(chain, blsToExecutionChange, true);
+            await validateBLSToExecutionChange(chain, blsToExecutionChange, true);
             const preCapella = chain.clock.currentEpoch < chain.config.CAPELLA_FORK_EPOCH;
-            chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, preCapella);
+            chain.opPool.insertBLSToExecutionChange(blsToExecutionChange, preCapella);
             if (!preCapella) {
-              await network.publishBlsToExecutionChange(blsToExecutionChange);
+              await network.publishBLSToExecutionChange(blsToExecutionChange);
             }
           } catch (e) {
             errors.push(e as Error);
             logger.error(
-              `Error on submitPoolBlsToExecutionChange [${i}]`,
+              `Error on submitPoolBLSToExecutionChange [${i}]`,
               {validatorIndex: blsToExecutionChange.message.validatorIndex},
               e as Error
             );
@@ -136,7 +136,7 @@ export function getBeaconPoolApi({
       );
 
       if (errors.length > 1) {
-        throw Error("Multiple errors on submitPoolBlsToExecutionChange\n" + errors.map((e) => e.message).join("\n"));
+        throw Error("Multiple errors on submitPoolBLSToExecutionChange\n" + errors.map((e) => e.message).join("\n"));
       } else if (errors.length === 1) {
         throw errors[0];
       }

--- a/packages/beacon-node/src/api/impl/lightclient/index.ts
+++ b/packages/beacon-node/src/api/impl/lightclient/index.ts
@@ -11,7 +11,7 @@ export function getLightclientApi({
   config,
 }: Pick<ApiModules, "chain" | "config">): ServerApi<routes.lightclient.Api> {
   return {
-    async getUpdates(startPeriod: SyncPeriod, count: number) {
+    async getLightClientUpdatesByRange(startPeriod: SyncPeriod, count: number) {
       const maxAllowedCount = Math.min(MAX_REQUEST_LIGHT_CLIENT_UPDATES, count);
       const periods = Array.from({length: maxAllowedCount}, (_ignored, i) => i + startPeriod);
       const updates = await Promise.all(periods.map((period) => chain.lightClientServer.getUpdate(period)));
@@ -21,7 +21,7 @@ export function getLightclientApi({
       }));
     },
 
-    async getOptimisticUpdate() {
+    async getLightClientOptimisticUpdate() {
       const data = chain.lightClientServer.getOptimisticUpdate();
       if (data === null) {
         throw Error("No optimistic update available");
@@ -29,7 +29,7 @@ export function getLightclientApi({
       return {version: config.getForkName(data.attestedHeader.beacon.slot), data};
     },
 
-    async getFinalityUpdate() {
+    async getLightClientFinalityUpdate() {
       const data = chain.lightClientServer.getFinalityUpdate();
       if (data === null) {
         throw Error("No finality update available");
@@ -37,12 +37,12 @@ export function getLightclientApi({
       return {version: config.getForkName(data.attestedHeader.beacon.slot), data};
     },
 
-    async getBootstrap(blockRoot) {
+    async getLightClientBootstrap(blockRoot) {
       const bootstrapProof = await chain.lightClientServer.getBootstrap(fromHexString(blockRoot));
       return {version: config.getForkName(bootstrapProof.header.beacon.slot), data: bootstrapProof};
     },
 
-    async getCommitteeRoot(startPeriod: SyncPeriod, count: number) {
+    async getLightClientCommitteeRoot(startPeriod: SyncPeriod, count: number) {
       const maxAllowedCount = Math.min(MAX_REQUEST_LIGHT_CLIENT_COMMITTEE_HASHES, count);
       const periods = Array.from({length: maxAllowedCount}, (_ignored, i) => i + startPeriod);
       const committeeHashes = await Promise.all(

--- a/packages/beacon-node/src/chain/errors/blsToExecutionChangeError.ts
+++ b/packages/beacon-node/src/chain/errors/blsToExecutionChangeError.ts
@@ -1,13 +1,13 @@
 import {GossipActionError} from "./gossipValidation.js";
 
-export enum BlsToExecutionChangeErrorCode {
+export enum BLSToExecutionChangeErrorCode {
   ALREADY_EXISTS = "BLS_TO_EXECUTION_CHANGE_ERROR_ALREADY_EXISTS",
   INVALID = "BLS_TO_EXECUTION_CHANGE_ERROR_INVALID",
   INVALID_SIGNATURE = "BLS_TO_EXECUTION_CHANGE_ERROR_INVALID_SIGNATURE",
 }
-export type BlsToExecutionChangeErrorType =
-  | {code: BlsToExecutionChangeErrorCode.ALREADY_EXISTS}
-  | {code: BlsToExecutionChangeErrorCode.INVALID}
-  | {code: BlsToExecutionChangeErrorCode.INVALID_SIGNATURE};
+export type BLSToExecutionChangeErrorType =
+  | {code: BLSToExecutionChangeErrorCode.ALREADY_EXISTS}
+  | {code: BLSToExecutionChangeErrorCode.INVALID}
+  | {code: BLSToExecutionChangeErrorCode.INVALID_SIGNATURE};
 
-export class BlsToExecutionChangeError extends GossipActionError<BlsToExecutionChangeErrorType> {}
+export class BLSToExecutionChangeError extends GossipActionError<BLSToExecutionChangeErrorType> {}

--- a/packages/beacon-node/src/chain/opPools/utils.ts
+++ b/packages/beacon-node/src/chain/opPools/utils.ts
@@ -37,7 +37,7 @@ export function signatureFromBytesNoCheck(signature: Uint8Array): Signature {
  * Ensures that a SignedBLSToExecutionChange object is _still_ valid for block inclusion. An object valid for the pool,
  * can become invalid for certain forks.
  */
-export function isValidBlsToExecutionChangeForBlockInclusion(
+export function isValidBLSToExecutionChangeForBlockInclusion(
   state: CachedBeaconStateAllForks,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
 ): boolean {

--- a/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
@@ -1,44 +1,44 @@
 import {capella} from "@lodestar/types";
 import {
-  isValidBlsToExecutionChange,
-  getBlsToExecutionChangeSignatureSet,
+  isValidBLSToExecutionChange,
+  getBLSToExecutionChangeSignatureSet,
   CachedBeaconStateCapella,
 } from "@lodestar/state-transition";
 import {IBeaconChain} from "..";
-import {BlsToExecutionChangeError, BlsToExecutionChangeErrorCode, GossipAction} from "../errors/index.js";
+import {BLSToExecutionChangeError, BLSToExecutionChangeErrorCode, GossipAction} from "../errors/index.js";
 
-export async function validateBlsToExecutionChange(
+export async function validateBLSToExecutionChange(
   chain: IBeaconChain,
   blsToExecutionChange: capella.SignedBLSToExecutionChange,
   ignoreExists = false
 ): Promise<void> {
   // [IGNORE] The blsToExecutionChange is the first valid blsToExecutionChange received for the validator with index
   // signedBLSToExecutionChange.message.validatorIndex.
-  if (!ignoreExists && chain.opPool.hasSeenBlsToExecutionChange(blsToExecutionChange.message.validatorIndex)) {
-    throw new BlsToExecutionChangeError(GossipAction.IGNORE, {
-      code: BlsToExecutionChangeErrorCode.ALREADY_EXISTS,
+  if (!ignoreExists && chain.opPool.hasSeenBLSToExecutionChange(blsToExecutionChange.message.validatorIndex)) {
+    throw new BLSToExecutionChangeError(GossipAction.IGNORE, {
+      code: BLSToExecutionChangeErrorCode.ALREADY_EXISTS,
     });
   }
 
   // validate bls to executionChange
   // NOTE: No need to advance head state since the signature's fork is handled with `broadcastedOnFork`,
-  // and chanes relevant to `isValidBlsToExecutionChange()` happen only on processBlock(), not processEpoch()
+  // and chanes relevant to `isValidBLSToExecutionChange()` happen only on processBlock(), not processEpoch()
   const state = chain.getHeadState();
   const {config} = state;
 
   // [REJECT] All of the conditions within process_bls_to_execution_change pass validation.
   // verifySignature = false, verified in batch below
-  const {valid} = isValidBlsToExecutionChange(state as CachedBeaconStateCapella, blsToExecutionChange, false);
+  const {valid} = isValidBLSToExecutionChange(state as CachedBeaconStateCapella, blsToExecutionChange, false);
   if (!valid) {
-    throw new BlsToExecutionChangeError(GossipAction.REJECT, {
-      code: BlsToExecutionChangeErrorCode.INVALID,
+    throw new BLSToExecutionChangeError(GossipAction.REJECT, {
+      code: BLSToExecutionChangeErrorCode.INVALID,
     });
   }
 
-  const signatureSet = getBlsToExecutionChangeSignatureSet(config, blsToExecutionChange);
+  const signatureSet = getBLSToExecutionChangeSignatureSet(config, blsToExecutionChange);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
-    throw new BlsToExecutionChangeError(GossipAction.REJECT, {
-      code: BlsToExecutionChangeErrorCode.INVALID_SIGNATURE,
+    throw new BLSToExecutionChangeError(GossipAction.REJECT, {
+      code: BLSToExecutionChangeErrorCode.INVALID_SIGNATURE,
     });
   }
 }

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -50,7 +50,7 @@ export interface INetwork extends INetworkCorePublic {
   publishBeaconAggregateAndProof(aggregateAndProof: phase0.SignedAggregateAndProof): Promise<number>;
   publishBeaconAttestation(attestation: phase0.Attestation, subnet: number): Promise<number>;
   publishVoluntaryExit(voluntaryExit: phase0.SignedVoluntaryExit): Promise<number>;
-  publishBlsToExecutionChange(blsToExecutionChange: capella.SignedBLSToExecutionChange): Promise<number>;
+  publishBLSToExecutionChange(blsToExecutionChange: capella.SignedBLSToExecutionChange): Promise<number>;
   publishProposerSlashing(proposerSlashing: phase0.ProposerSlashing): Promise<number>;
   publishAttesterSlashing(attesterSlashing: phase0.AttesterSlashing): Promise<number>;
   publishSyncCommitteeSignature(signature: altair.SyncCommitteeMessage, subnet: number): Promise<number>;

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -321,7 +321,7 @@ export class Network implements INetwork {
     });
   }
 
-  async publishBlsToExecutionChange(blsToExecutionChange: capella.SignedBLSToExecutionChange): Promise<number> {
+  async publishBLSToExecutionChange(blsToExecutionChange: capella.SignedBLSToExecutionChange): Promise<number> {
     return this.publishGossip<GossipType.bls_to_execution_change>(
       {type: GossipType.bls_to_execution_change, fork: ForkName.capella},
       blsToExecutionChange,

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -26,7 +26,7 @@ import {
   validateGossipSyncCommittee,
   validateSyncCommitteeGossipContributionAndProof,
   validateGossipVoluntaryExit,
-  validateBlsToExecutionChange,
+  validateBLSToExecutionChange,
   AttestationValidationResult,
   AggregateAndProofValidationResult,
 } from "../../chain/validation/index.js";
@@ -378,11 +378,11 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
     // blsToExecutionChange is to be generated and validated against GENESIS_FORK_VERSION
     [GossipType.bls_to_execution_change]: async ({serializedData}, topic) => {
       const blsToExecutionChange = sszDeserialize(topic, serializedData);
-      await validateBlsToExecutionChange(chain, blsToExecutionChange);
+      await validateBLSToExecutionChange(chain, blsToExecutionChange);
 
       // Handler
       try {
-        chain.opPool.insertBlsToExecutionChange(blsToExecutionChange);
+        chain.opPool.insertBLSToExecutionChange(blsToExecutionChange);
       } catch (e) {
         logger.error("Error adding blsToExecutionChange to pool", {}, e as Error);
       }

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -82,10 +82,10 @@ describe("lightclient api", function () {
     await sleep(2 * SECONDS_PER_SLOT * 1000);
   };
 
-  it("getUpdates()", async function () {
+  it("getLightClientUpdatesByRange()", async function () {
     const client = getClient({baseUrl: `http://127.0.0.1:${restPort}`}, {config}).lightclient;
     await waitForBestUpdate();
-    const res = await client.getUpdates(0, 1);
+    const res = await client.getLightClientUpdatesByRange(0, 1);
     ApiError.assert(res);
     const updates = res.response;
     expect(updates.length).to.be.equal(1);
@@ -94,10 +94,10 @@ describe("lightclient api", function () {
     expect(updates[0].version).to.be.equal(ForkName.altair);
   });
 
-  it("getOptimisticUpdate()", async function () {
+  it("getLightClientOptimisticUpdate()", async function () {
     await waitForBestUpdate();
     const client = getClient({baseUrl: `http://127.0.0.1:${restPort}`}, {config}).lightclient;
-    const res = await client.getOptimisticUpdate();
+    const res = await client.getLightClientOptimisticUpdate();
     ApiError.assert(res);
     const update = res.response;
     const slot = bn.chain.clock.currentSlot;
@@ -107,21 +107,21 @@ describe("lightclient api", function () {
     expect(update.version).to.be.equal(ForkName.altair);
   });
 
-  it.skip("getFinalityUpdate()", async function () {
+  it.skip("getLightClientFinalityUpdate()", async function () {
     // TODO: not sure how this causes subsequent tests failed
     await waitForEvent<phase0.Checkpoint>(bn.chain.emitter, routes.events.EventType.finalizedCheckpoint, 240000);
     await sleep(SECONDS_PER_SLOT * 1000);
     const client = getClient({baseUrl: `http://127.0.0.1:${restPort}`}, {config}).lightclient;
-    const res = await client.getFinalityUpdate();
+    const res = await client.getLightClientFinalityUpdate();
     ApiError.assert(res);
     expect(res.response).to.be.not.undefined;
   });
 
-  it("getCommitteeRoot() for the 1st period", async function () {
+  it("getLightClientCommitteeRoot() for the 1st period", async function () {
     await waitForBestUpdate();
 
     const lightclient = getClient({baseUrl: `http://127.0.0.1:${restPort}`}, {config}).lightclient;
-    const committeeRes = await lightclient.getCommitteeRoot(0, 1);
+    const committeeRes = await lightclient.getLightClientCommitteeRoot(0, 1);
     ApiError.assert(committeeRes);
     const client = getClient({baseUrl: `http://127.0.0.1:${restPort}`}, {config}).beacon;
     const validatorResponse = await client.getStateValidators("head");

--- a/packages/beacon-node/test/e2e/network/gossipsub.test.ts
+++ b/packages/beacon-node/test/e2e/network/gossipsub.test.ts
@@ -86,12 +86,12 @@ function runTests(this: Mocha.Suite, {useWorker}: {useWorker: boolean}): void {
   });
 
   it("Publish and receive a blsToExecutionChange", async function () {
-    let onBlsToExecutionChange: (blsToExec: Uint8Array) => void;
-    const onBlsToExecutionChangePromise = new Promise<Uint8Array>((resolve) => (onBlsToExecutionChange = resolve));
+    let onBLSToExecutionChange: (blsToExec: Uint8Array) => void;
+    const onBLSToExecutionChangePromise = new Promise<Uint8Array>((resolve) => (onBLSToExecutionChange = resolve));
 
     const {netA, netB} = await mockModules({
       [GossipType.bls_to_execution_change]: async ({serializedData}) => {
-        onBlsToExecutionChange(serializedData);
+        onBLSToExecutionChange(serializedData);
       },
     });
 
@@ -111,9 +111,9 @@ function runTests(this: Mocha.Suite, {useWorker}: {useWorker: boolean}): void {
     }
 
     const blsToExec = ssz.capella.SignedBLSToExecutionChange.defaultValue();
-    await netA.publishBlsToExecutionChange(blsToExec);
+    await netA.publishBLSToExecutionChange(blsToExec);
 
-    const receivedblsToExec = await onBlsToExecutionChangePromise;
+    const receivedblsToExec = await onBLSToExecutionChangePromise;
     expect(receivedblsToExec).to.deep.equal(ssz.capella.SignedBLSToExecutionChange.serialize(blsToExec));
   });
 

--- a/packages/beacon-node/test/spec/presets/operations.ts
+++ b/packages/beacon-node/test/spec/presets/operations.ts
@@ -78,7 +78,7 @@ const operationFns: Record<string, BlockProcessFn<CachedBeaconStateAllForks>> = 
   },
 
   bls_to_execution_change: (state, testCase: {address_change: capella.SignedBLSToExecutionChange}) => {
-    blockFns.processBlsToExecutionChange(state as CachedBeaconStateCapella, testCase.address_change);
+    blockFns.processBLSToExecutionChange(state as CachedBeaconStateCapella, testCase.address_change);
   },
 
   withdrawals: (state, testCase: {execution_payload: capella.ExecutionPayload}) => {

--- a/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
@@ -19,8 +19,8 @@ import {createBeaconConfig} from "@lodestar/config";
 import {BeaconChain} from "../../../../src/chain/index.js";
 import {StubbedChainMutable} from "../../../utils/stub/index.js";
 import {generateState} from "../../../utils/state.js";
-import {validateBlsToExecutionChange} from "../../../../src/chain/validation/blsToExecutionChange.js";
-import {BlsToExecutionChangeErrorCode} from "../../../../src/chain/errors/blsToExecutionChangeError.js";
+import {validateBLSToExecutionChange} from "../../../../src/chain/validation/blsToExecutionChange.js";
+import {BLSToExecutionChangeErrorCode} from "../../../../src/chain/errors/blsToExecutionChangeError.js";
 import {OpPool} from "../../../../src/chain/opPools/index.js";
 import {expectRejectedWithLodestarError} from "../../../utils/errors.js";
 import {createCachedBeaconStateTest} from "../../../utils/cachedBeaconState.js";
@@ -111,17 +111,17 @@ describe("validate bls to execution change", () => {
       signature: Buffer.alloc(96, 0),
     };
 
-    // Return BlsToExecutionChange known
-    opPool.hasSeenBlsToExecutionChange.returns(true);
+    // Return BLSToExecutionChange known
+    opPool.hasSeenBLSToExecutionChange.returns(true);
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
-      BlsToExecutionChangeErrorCode.ALREADY_EXISTS
+      validateBLSToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      BLSToExecutionChangeErrorCode.ALREADY_EXISTS
     );
   });
 
   it("should return valid blsToExecutionChange ", async () => {
-    await validateBlsToExecutionChange(chainStub, signedBlsToExecChange);
+    await validateBLSToExecutionChange(chainStub, signedBlsToExecChange);
   });
 
   it("should return invalid bls to execution Change - invalid validatorIndex", async () => {
@@ -135,8 +135,8 @@ describe("validate bls to execution change", () => {
     };
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
-      BlsToExecutionChangeErrorCode.INVALID
+      validateBLSToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      BLSToExecutionChangeErrorCode.INVALID
     );
   });
 
@@ -150,8 +150,8 @@ describe("validate bls to execution change", () => {
     };
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
-      BlsToExecutionChangeErrorCode.INVALID
+      validateBLSToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      BLSToExecutionChangeErrorCode.INVALID
     );
   });
 
@@ -166,8 +166,8 @@ describe("validate bls to execution change", () => {
     };
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
-      BlsToExecutionChangeErrorCode.INVALID
+      validateBLSToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      BLSToExecutionChangeErrorCode.INVALID
     );
   });
 
@@ -182,8 +182,8 @@ describe("validate bls to execution change", () => {
     };
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
-      BlsToExecutionChangeErrorCode.INVALID
+      validateBLSToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      BLSToExecutionChangeErrorCode.INVALID
     );
   });
 });

--- a/packages/cli/src/cmds/validator/blsToExecutionChange.ts
+++ b/packages/cli/src/cmds/validator/blsToExecutionChange.ts
@@ -14,13 +14,13 @@ import {IValidatorCliArgs} from "./options.js";
 
 /* eslint-disable no-console */
 
-type BlsToExecutionChangeArgs = {
+type BLSToExecutionChangeArgs = {
   publicKey?: string;
   fromBlsPrivkey?: string;
   toExecutionAddress?: string;
 };
 
-export const blsToExecutionChange: CliCommand<BlsToExecutionChangeArgs, IValidatorCliArgs & GlobalArgs> = {
+export const blsToExecutionChange: CliCommand<BLSToExecutionChangeArgs, IValidatorCliArgs & GlobalArgs> = {
   command: "bls-to-execution-change",
 
   describe:
@@ -94,7 +94,7 @@ like to choose for BLS To Execution Change.",
     };
 
     ApiError.assert(
-      await client.beacon.submitPoolBlsToExecutionChange([signedBLSToExecutionChange]),
+      await client.beacon.submitPoolBLSToExecutionChange([signedBLSToExecutionChange]),
       "Can not submit bls to execution change"
     );
     console.log(`Submitted bls to execution change for ${publicKey}`);

--- a/packages/cli/test/e2e/blsToExecutionchange.test.ts
+++ b/packages/cli/test/e2e/blsToExecutionchange.test.ts
@@ -68,7 +68,7 @@ describeCliTest("bLSToExecutionChange cmd", function ({spawnCli}) {
       "--toExecutionAddress 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     ]);
 
-    const pooledBlsChanges = await client.beacon.getPoolBlsToExecutionChanges();
+    const pooledBlsChanges = await client.beacon.getPoolBLSToExecutionChanges();
     ApiError.assert(pooledBlsChanges);
     const message = pooledBlsChanges.response.data[0].message;
     const {validatorIndex, toExecutionAddress, fromBlsPubkey} = message;

--- a/packages/light-client/src/transport/rest.ts
+++ b/packages/light-client/src/transport/rest.ts
@@ -30,25 +30,25 @@ export class LightClientRestTransport extends (EventEmitter as {new (): RestEven
       data: allForks.LightClientUpdate;
     }[]
   > {
-    const res = await this.api.lightclient.getUpdates(startPeriod, count);
+    const res = await this.api.lightclient.getLightClientUpdatesByRange(startPeriod, count);
     ApiError.assert(res);
     return res.response;
   }
 
   async getOptimisticUpdate(): Promise<{version: ForkName; data: allForks.LightClientOptimisticUpdate}> {
-    const res = await this.api.lightclient.getOptimisticUpdate();
+    const res = await this.api.lightclient.getLightClientOptimisticUpdate();
     ApiError.assert(res);
     return res.response;
   }
 
   async getFinalityUpdate(): Promise<{version: ForkName; data: allForks.LightClientFinalityUpdate}> {
-    const res = await this.api.lightclient.getFinalityUpdate();
+    const res = await this.api.lightclient.getLightClientFinalityUpdate();
     ApiError.assert(res);
     return res.response;
   }
 
   async getBootstrap(blockRoot: string): Promise<{version: ForkName; data: allForks.LightClientBootstrap}> {
-    const res = await this.api.lightclient.getBootstrap(blockRoot);
+    const res = await this.api.lightclient.getLightClientBootstrap(blockRoot);
     ApiError.assert(res);
     return res.response;
   }

--- a/packages/light-client/test/mocks/LightclientServerApiMock.ts
+++ b/packages/light-client/test/mocks/LightclientServerApiMock.ts
@@ -32,7 +32,7 @@ export class LightclientServerApiMock implements ServerApi<routes.lightclient.Ap
   latestHeadUpdate: altair.LightClientOptimisticUpdate | null = null;
   finalized: altair.LightClientFinalityUpdate | null = null;
 
-  async getUpdates(from: SyncPeriod, to: SyncPeriod): Promise<VersionedLightClientUpdate[]> {
+  async getLightClientUpdatesByRange(from: SyncPeriod, to: SyncPeriod): Promise<VersionedLightClientUpdate[]> {
     const updates: VersionedLightClientUpdate[] = [];
     for (let period = parseInt(String(from)); period <= parseInt(String(to)); period++) {
       const update = this.updates.get(period);
@@ -46,23 +46,23 @@ export class LightclientServerApiMock implements ServerApi<routes.lightclient.Ap
     return updates;
   }
 
-  async getOptimisticUpdate(): Promise<{version: ForkName; data: altair.LightClientOptimisticUpdate}> {
+  async getLightClientOptimisticUpdate(): Promise<{version: ForkName; data: altair.LightClientOptimisticUpdate}> {
     if (!this.latestHeadUpdate) throw Error("No latest head update");
     return {version: ForkName.bellatrix, data: this.latestHeadUpdate};
   }
 
-  async getFinalityUpdate(): Promise<{version: ForkName; data: altair.LightClientFinalityUpdate}> {
+  async getLightClientFinalityUpdate(): Promise<{version: ForkName; data: altair.LightClientFinalityUpdate}> {
     if (!this.finalized) throw Error("No finalized head update");
     return {version: ForkName.bellatrix, data: this.finalized};
   }
 
-  async getBootstrap(blockRoot: string): Promise<{version: ForkName; data: altair.LightClientBootstrap}> {
+  async getLightClientBootstrap(blockRoot: string): Promise<{version: ForkName; data: altair.LightClientBootstrap}> {
     const snapshot = this.snapshots.get(blockRoot);
     if (!snapshot) throw Error(`snapshot for blockRoot ${blockRoot} not available`);
     return {version: ForkName.bellatrix, data: snapshot};
   }
 
-  async getCommitteeRoot(startPeriod: SyncPeriod, count: number): Promise<{data: Uint8Array[]}> {
+  async getLightClientCommitteeRoot(startPeriod: SyncPeriod, count: number): Promise<{data: Uint8Array[]}> {
     const periods = Array.from({length: count}, (_ignored, i) => i + startPeriod);
     const committeeHashes = periods
       .map((period) => this.updates.get(period)?.nextSyncCommittee.pubkeys)

--- a/packages/prover/README.md
+++ b/packages/prover/README.md
@@ -1,7 +1,7 @@
 # Lodestar Eth Consensus Lightclient Prover
 
 [![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/aMxzVcr)
-[![ETH Beacon APIs Spec v2.1.0](https://img.shields.io/badge/ETH%20beacon--APIs-2.1.0-blue)](https://github.com/ethereum/beacon-APIs/releases/tag/v2.1.0)
+[![ETH Beacon APIs Spec v2.4.1](https://img.shields.io/badge/ETH%20beacon--APIs-2.4.1-blue)](https://github.com/ethereum/beacon-APIs/releases/tag/v2.4.1)
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
 ![Node Version](https://img.shields.io/badge/node-18.x-green)
 

--- a/packages/reqresp/README.md
+++ b/packages/reqresp/README.md
@@ -1,7 +1,7 @@
 # Lodestar Eth Consensus Req/Resp Protocol
 
 [![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/aMxzVcr)
-[![ETH Beacon APIs Spec v2.1.0](https://img.shields.io/badge/ETH%20beacon--APIs-2.1.0-blue)](https://github.com/ethereum/beacon-APIs/releases/tag/v2.1.0)
+[![ETH Beacon APIs Spec v2.4.1](https://img.shields.io/badge/ETH%20beacon--APIs-2.4.1-blue)](https://github.com/ethereum/beacon-APIs/releases/tag/v2.4.1)
 ![ES Version](https://img.shields.io/badge/ES-2020-yellow)
 ![Node Version](https://img.shields.io/badge/node-18.x-green)
 

--- a/packages/state-transition/src/block/processBLSToExecutionChange.ts
+++ b/packages/state-transition/src/block/processBLSToExecutionChange.ts
@@ -2,17 +2,17 @@ import {capella} from "@lodestar/types";
 import {BLS_WITHDRAWAL_PREFIX, ETH1_ADDRESS_WITHDRAWAL_PREFIX} from "@lodestar/params";
 import {toHexString, byteArrayEquals} from "@chainsafe/ssz";
 import {digest} from "@chainsafe/as-sha256";
-import {verifyBlsToExecutionChangeSignature} from "../signatureSets/index.js";
+import {verifyBLSToExecutionChangeSignature} from "../signatureSets/index.js";
 
 import {CachedBeaconStateCapella} from "../types.js";
 
-export function processBlsToExecutionChange(
+export function processBLSToExecutionChange(
   state: CachedBeaconStateCapella,
-  signedBlsToExecutionChange: capella.SignedBLSToExecutionChange
+  signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
 ): void {
-  const addressChange = signedBlsToExecutionChange.message;
+  const addressChange = signedBLSToExecutionChange.message;
 
-  const validation = isValidBlsToExecutionChange(state, signedBlsToExecutionChange, true);
+  const validation = isValidBLSToExecutionChange(state, signedBLSToExecutionChange, true);
   if (!validation.valid) {
     throw validation.error;
   }
@@ -26,7 +26,7 @@ export function processBlsToExecutionChange(
   validator.withdrawalCredentials = newWithdrawalCredentials;
 }
 
-export function isValidBlsToExecutionChange(
+export function isValidBLSToExecutionChange(
   state: CachedBeaconStateCapella,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange,
   verifySignature = true
@@ -67,7 +67,7 @@ export function isValidBlsToExecutionChange(
     };
   }
 
-  if (verifySignature && !verifyBlsToExecutionChangeSignature(state, signedBLSToExecutionChange)) {
+  if (verifySignature && !verifyBLSToExecutionChangeSignature(state, signedBLSToExecutionChange)) {
     return {
       valid: false,
       error: Error(

--- a/packages/state-transition/src/block/processOperations.ts
+++ b/packages/state-transition/src/block/processOperations.ts
@@ -7,7 +7,7 @@ import {processProposerSlashing} from "./processProposerSlashing.js";
 import {processAttesterSlashing} from "./processAttesterSlashing.js";
 import {processDeposit} from "./processDeposit.js";
 import {processVoluntaryExit} from "./processVoluntaryExit.js";
-import {processBlsToExecutionChange} from "./processBlsToExecutionChange.js";
+import {processBLSToExecutionChange} from "./processBLSToExecutionChange.js";
 import {ProcessBlockOpts} from "./types.js";
 
 export {
@@ -16,7 +16,7 @@ export {
   processAttestations,
   processDeposit,
   processVoluntaryExit,
-  processBlsToExecutionChange,
+  processBLSToExecutionChange,
 };
 
 export function processOperations(
@@ -51,7 +51,7 @@ export function processOperations(
 
   if (fork >= ForkSeq.capella) {
     for (const blsToExecutionChange of (body as capella.BeaconBlockBody).blsToExecutionChanges) {
-      processBlsToExecutionChange(state as CachedBeaconStateCapella, blsToExecutionChange);
+      processBLSToExecutionChange(state as CachedBeaconStateCapella, blsToExecutionChange);
     }
   }
 }

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -44,7 +44,7 @@ export {
 
 // BeaconChain validation
 export {isValidVoluntaryExit} from "./block/processVoluntaryExit.js";
-export {isValidBlsToExecutionChange} from "./block/processBlsToExecutionChange.js";
+export {isValidBLSToExecutionChange} from "./block/processBLSToExecutionChange.js";
 export {assertValidProposerSlashing} from "./block/processProposerSlashing.js";
 export {assertValidAttesterSlashing} from "./block/processAttesterSlashing.js";
 export {ExecutionPayloadStatus, DataAvailableStatus, BlockExternalData} from "./block/externalData.js";

--- a/packages/state-transition/src/signatureSets/blsToExecutionChange.ts
+++ b/packages/state-transition/src/signatureSets/blsToExecutionChange.ts
@@ -7,17 +7,17 @@ import {CoordType} from "@chainsafe/bls/types";
 import {computeSigningRoot, ISignatureSet, SignatureSetType, verifySignatureSet} from "../util/index.js";
 import {CachedBeaconStateAllForks} from "../types.js";
 
-export function verifyBlsToExecutionChangeSignature(
+export function verifyBLSToExecutionChangeSignature(
   state: CachedBeaconStateAllForks,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
 ): boolean {
-  return verifySignatureSet(getBlsToExecutionChangeSignatureSet(state.config, signedBLSToExecutionChange));
+  return verifySignatureSet(getBLSToExecutionChangeSignatureSet(state.config, signedBLSToExecutionChange));
 }
 
 /**
  * Extract signatures to allow validating all block signatures at once
  */
-export function getBlsToExecutionChangeSignatureSet(
+export function getBLSToExecutionChangeSignatureSet(
   config: BeaconConfig,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
 ): ISignatureSet {
@@ -35,11 +35,11 @@ export function getBlsToExecutionChangeSignatureSet(
   };
 }
 
-export function getBlsToExecutionChangeSignatureSets(
+export function getBLSToExecutionChangeSignatureSets(
   config: BeaconConfig,
   signedBlock: capella.SignedBeaconBlock
 ): ISignatureSet[] {
   return signedBlock.message.body.blsToExecutionChanges.map((blsToExecutionChange) =>
-    getBlsToExecutionChangeSignatureSet(config, blsToExecutionChange)
+    getBLSToExecutionChangeSignatureSet(config, blsToExecutionChange)
   );
 }

--- a/packages/state-transition/src/signatureSets/index.ts
+++ b/packages/state-transition/src/signatureSets/index.ts
@@ -9,7 +9,7 @@ import {getAttestationsSignatureSets} from "./indexedAttestation.js";
 import {getBlockProposerSignatureSet} from "./proposer.js";
 import {getRandaoRevealSignatureSet} from "./randao.js";
 import {getVoluntaryExitsSignatureSets} from "./voluntaryExits.js";
-import {getBlsToExecutionChangeSignatureSets} from "./blsToExecutionChange.js";
+import {getBLSToExecutionChangeSignatureSets} from "./blsToExecutionChange.js";
 
 export * from "./attesterSlashings.js";
 export * from "./indexedAttestation.js";
@@ -60,7 +60,7 @@ export function getBlockSignatureSets(
 
   // only after capella fork
   if (fork >= ForkSeq.capella) {
-    const blsToExecutionChangeSignatureSets = getBlsToExecutionChangeSignatureSets(
+    const blsToExecutionChangeSignatureSets = getBLSToExecutionChangeSignatureSets(
       state.config,
       signedBlock as capella.SignedBeaconBlock
     );

--- a/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -45,7 +45,7 @@ describe("signatureSets", () => {
         attestations: [getMockAttestations(1)],
         deposits: [] as phase0.Deposit[],
         voluntaryExits: [getMockSignedVoluntaryExit({validatorIndex: 0, signature: EMPTY_SIGNATURE})],
-        blsToExecutionChanges: [getMockSignedBlsToExecutionChange({validatorIndex: 0, signature: EMPTY_SIGNATURE})],
+        blsToExecutionChanges: [getMockSignedBLSToExecutionChange({validatorIndex: 0, signature: EMPTY_SIGNATURE})],
       },
     };
 
@@ -177,7 +177,7 @@ type SignedBLStoExecutionChange = {
   validatorIndex: ValidatorIndex;
 };
 
-function getMockSignedBlsToExecutionChange(data: SignedBLStoExecutionChange): capella.SignedBLSToExecutionChange {
+function getMockSignedBLSToExecutionChange(data: SignedBLStoExecutionChange): capella.SignedBLSToExecutionChange {
   return {
     message: {
       validatorIndex: data.validatorIndex,


### PR DESCRIPTION
**Motivation**

Compliance to latest beacon api spec ([v2.4.1](https://github.com/ethereum/beacon-APIs/releases/tag/v2.4.1))

**Description**

This branch is used to test our API against latest beacon api spec.

There are several updates required
- ensure operationIds match spec value
- https://github.com/ChainSafe/lodestar/issues/5693
- https://github.com/ChainSafe/lodestar/issues/5542
- https://github.com/ChainSafe/lodestar/issues/5694
- https://github.com/ChainSafe/lodestar/issues/5696
- https://github.com/ChainSafe/lodestar/issues/5697
- https://github.com/ChainSafe/lodestar/issues/5698
- https://github.com/ChainSafe/lodestar/issues/5699
- https://github.com/ChainSafe/lodestar/issues/5700
- https://github.com/ChainSafe/lodestar/issues/5701
- https://github.com/ChainSafe/lodestar/issues/5702
- https://github.com/ChainSafe/lodestar/issues/4638
