### PR TITLE
feat(beacon-node): deduplicate payload from persisted beacon blocks

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -186,6 +186,7 @@ export class BeaconChain implements IBeaconChain {
     this.genesisValidatorsRoot = anchorState.genesisValidatorsRoot;
     this.eth1 = eth1;
     this.executionEngine = executionEngine;
+    this.db.blockArchive.setExecutionEngine(executionEngine);
     this.executionBuilder = executionBuilder;
     // From https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#specification-3
     // > Consensus Layer client software SHOULD poll this endpoint every 60 seconds.

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -182,7 +182,7 @@ export class StateRegenerator implements IStateRegeneratorInternal {
       }
 
       try {
-        // Only advances state trusting block's signture and hashes.
+        // Only advances state trusting block's signature and hashes.
         // We are only running the state transition to get a specific state's data.
         state = stateTransition(
           state,

--- a/packages/beacon-node/src/db/repositories/block.ts
+++ b/packages/beacon-node/src/db/repositories/block.ts
@@ -28,6 +28,6 @@ export class BlockRepository extends Repository<Uint8Array, allForks.SignedBeaco
   }
 
   decodeValue(data: Buffer): allForks.SignedBeaconBlock {
-    return getSignedBlockTypeFromBytes(this.config, data).deserialize(data);
+    return getSignedBlockTypeFromBytes(this.config, data, false).deserialize(data);
   }
 }

--- a/packages/beacon-node/src/util/multifork.ts
+++ b/packages/beacon-node/src/util/multifork.ts
@@ -20,15 +20,27 @@ const SLOT_BYTE_COUNT = 8;
  */
 const SLOT_BYTES_POSITION_IN_STATE = 40;
 
+export function getSignedBlockTypeFromBytes<T extends boolean>(
+  config: ChainForkConfig,
+  bytes: Buffer | Uint8Array,
+  isBlinded: T
+): T extends true
+  ? allForks.AllForksBlindedSSZTypes["SignedBeaconBlock"]
+  : allForks.AllForksSSZTypes["SignedBeaconBlock"];
 export function getSignedBlockTypeFromBytes(
   config: ChainForkConfig,
-  bytes: Buffer | Uint8Array
-): allForks.AllForksSSZTypes["SignedBeaconBlock"] {
+  bytes: Buffer | Uint8Array,
+  isBlinded: boolean
+): allForks.AllForksBlindedSSZTypes["SignedBeaconBlock"] | allForks.AllForksSSZTypes["SignedBeaconBlock"] {
+  // slot offset is same for blinded and full blocks
   const slot = getSlotFromSignedBeaconBlockSerialized(bytes);
   if (slot === null) {
     throw Error("getSignedBlockTypeFromBytes: invalid bytes");
   }
 
+  if (isBlinded) {
+    return config.getBlindedForkTypes(slot).SignedBeaconBlock;
+  }
   return config.getForkTypes(slot).SignedBeaconBlock;
 }
 

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -5,6 +5,9 @@ import {toHex} from "@lodestar/utils";
 export type BlockRootHex = RootHex;
 export type AttDataBase64 = string;
 
+export const DATABASE_SERIALIZED_FULL_BLOCK_BIT = 0x00;
+export const DATABASE_SERIALIZED_BLINDED_BLOCK_BIT = 0xff;
+
 // class Attestation(Container):
 //   aggregation_bits: Bitlist[MAX_VALIDATORS_PER_COMMITTEE] - offset 4
 //   data: AttestationData - target data - 128

--- a/packages/reqresp/src/types.ts
+++ b/packages/reqresp/src/types.ts
@@ -71,6 +71,10 @@ export type ProtocolHandler = (req: ReqRespRequest, peerId: PeerId) => AsyncIter
  * ReqResp Protocol Deceleration
  */
 export interface ProtocolAttributes {
+  /**
+   * Messages are grouped into families identified by a shared libp2p protocol
+   * name prefix. In this case, we use /eth2/beacon_chain/req
+   */
   readonly protocolPrefix: string;
   /** Protocol name identifier `beacon_blocks_by_range` or `status` */
   readonly method: string;
@@ -79,12 +83,14 @@ export interface ProtocolAttributes {
   readonly encoding: Encoding;
 }
 
+/**
+ * `protocolPrefix` is constant and added runtime so not part of definition
+ */
 export interface ProtocolDescriptor extends Omit<ProtocolAttributes, "protocolPrefix"> {
   contextBytes: ContextBytesFactory;
   ignoreResponse?: boolean;
 }
 
-// `protocolPrefix` is added runtime so not part of definition
 /**
  * ReqResp Protocol definition for full duplex protocols
  */

--- a/packages/reqresp/src/types.ts
+++ b/packages/reqresp/src/types.ts
@@ -104,7 +104,7 @@ export interface Protocol extends ProtocolDescriptor {
 /**
  * ReqResp Protocol definition for dial only protocols
  */
-export interface DialOnlyProtocol extends Omit<Protocol, "handler" | "inboundRateLimits" | "renderRequestBody"> {
+export interface DialOnlyProtocol extends Omit<Protocol, "handler" | "inboundRateLimits"> {
   handler?: never;
   inboundRateLimits?: never;
   renderRequestBody?: never;

--- a/packages/types/src/allForks/types.ts
+++ b/packages/types/src/allForks/types.ts
@@ -63,7 +63,8 @@ export type SignedBlindedBeaconBlock =
 // Full or blinded types
 export type FullOrBlindedExecutionPayload =
   | bellatrix.FullOrBlindedExecutionPayload
-  | capella.FullOrBlindedExecutionPayload;
+  | capella.FullOrBlindedExecutionPayload
+  | deneb.FullOrBlindedExecutionPayload;
 export type FullOrBlindedBeaconBlockBody = BeaconBlockBody | BlindedBeaconBlockBody;
 export type FullOrBlindedBeaconBlock = BeaconBlock | BlindedBeaconBlock;
 export type FullOrBlindedSignedBeaconBlock = SignedBeaconBlock | SignedBlindedBeaconBlock;


### PR DESCRIPTION
## Inclusions

1) Trace references from Reqresp calls that pull blocks
- `onBeaconBlocksByRoot`
- `onBeaconBlocksByRange`


2) Trace references from all API calls that pull blocks
-- Updated functions called from `resolveBlockIdOrNull` which ultimately reference:
--- `getBlockByRoot`
--- `getCanonicalBlockAtSlot`

Both call `db.block.get` and `db.blockArchive.get`


3) Check Regen `getBlockState`
- Is the whole block needed for the blockRoot?
- `getState` looks like it only gets from fork choice in `beacon-node/src/chain/regen/regen.ts` and hot db



