### PR TITLE
fix: do not warn out-of-synced status at start up

### DIFF
--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -223,8 +223,8 @@ export class BeaconSync implements IBeaconSync {
     else if (state !== SyncState.Synced) {
       const syncDiff = this.chain.clock.currentSlot - this.chain.forkChoice.getHead().slot;
       if (syncDiff > this.slotImportTolerance * 2) {
-        this.logger.warn(`Node sync has fallen behind by ${syncDiff} slots`);
         if (this.network.isSubscribedToGossipCoreTopics()) {
+          this.logger.warn(`Node sync has fallen behind by ${syncDiff} slots`);
           this.network
             .unsubscribeGossipCoreTopics()
             .then(() => {


### PR DESCRIPTION
**Motivation**

The log `"Node sync has fallen behind"` is supposed to be printed when node is synced then fall behind but due to the refactor in v1.9.0-rc.3 it was printed a lot at startup time https://github.com/ChainSafe/lodestar/pull/5654/files#diff-f81e8224c621996ff7eea63ede6fc6414724030fdde3e9d8db72eb3eadd36e58R223

**Description**

Only print the log when node is synced, similar to v1.8.0 https://github.com/ChainSafe/lodestar/blob/v1.8.0/packages/beacon-node/src/sync/sync.ts#L216

Closes #5685
