### PR TITLE
chore: fix yarn install warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "karma-spec-reporter": "^0.0.36",
     "karma-webpack": "^5.0.0",
     "lerna": "^6.6.1",
+    "libp2p": "0.42.2",
     "mocha": "^10.2.0",
     "node-gyp": "^9.3.1",
     "npm-run-all": "^4.1.5",
@@ -85,5 +86,8 @@
     "typescript": "^5.0.3",
     "typescript-docs-verifier": "^2.4.0",
     "webpack": "^5.77.0"
+  },
+  "resolutions": {
+    "dns-over-http-resolver": "^2.1.1"
   }
 }

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -97,6 +97,7 @@
     "@chainsafe/as-chacha20poly1305": "^0.1.0",
     "@chainsafe/as-sha256": "^0.3.1",
     "@chainsafe/bls": "7.1.1",
+    "@chainsafe/blst": "^0.2.9",
     "@chainsafe/discv5": "^3.0.0",
     "@chainsafe/libp2p-gossipsub": "^6.2.0",
     "@chainsafe/libp2p-noise": "^11.0.4",

--- a/packages/reqresp/package.json
+++ b/packages/reqresp/package.json
@@ -68,7 +68,8 @@
   },
   "devDependencies": {
     "@lodestar/logger": "^1.9.0",
-    "@lodestar/types": "^1.9.0"
+    "@lodestar/types": "^1.9.0",
+    "libp2p": "0.42.2"
   },
   "peerDependencies": {
     "libp2p": "~0.42.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5266,6 +5266,13 @@ builtins@^5.0.0:
   dependencies:
     semver "^7.0.0"
 
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
+
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
@@ -6563,14 +6570,15 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dns-over-http-resolver@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/dns-over-http-resolver/-/dns-over-http-resolver-2.1.0.tgz#e3f13182b46b60e0be2473f3fbfc4ec5bbfb9539"
-  integrity sha512-eb8RGy6k54JdD7Rjw8g65y1MyA4z3m3IIYh7uazkgZuKIdFn8gYt8dydMm3op+2UshDdk9EexrXcDluKNY/CDg==
+dns-over-http-resolver@^2.1.0, dns-over-http-resolver@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/dns-over-http-resolver/-/dns-over-http-resolver-2.1.1.tgz#a3ff3fd7614cea7a4b72594eaf12fb3c85080456"
+  integrity sha512-Lm/eXB7yAQLJ5WxlBGwYfBY7utduXPZykcSmcG6K7ozM0wrZFvxZavhT6PqI0kd/5CUTfev/RrEFQqyU4CGPew==
   dependencies:
     debug "^4.3.1"
     native-fetch "^4.0.2"
     receptacle "^1.3.2"
+    undici "^5.12.0"
 
 dns-packet@^4.0.0:
   version "4.2.0"
@@ -14134,6 +14142,11 @@ streamroller@^3.1.1:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
 strict-event-emitter-types@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz"
@@ -15034,6 +15047,13 @@ unbox-primitive@^1.0.0, unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici@^5.12.0:
+  version "5.22.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.22.1.tgz#877d512effef2ac8be65e695f3586922e1a57d7b"
+  integrity sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==
+  dependencies:
+    busboy "^1.6.0"
 
 unique-filename@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
**Motivation**

No warnings when running `yarn install`

and be able to merge
- https://github.com/ChainSafe/lodestar/pull/5565

**Description**

Fixes yarn install warnings


**Steps to reproduce**

Clean node_modules

```
yarn clean:nm
```

Reinstall

```
yarn install
```

Output

```
~/projects/ethereum/lodestar [nflaig/fix-yarn-warnings ≡]> yarn install
yarn install v1.22.19
[1/5] Validating package.json...
[2/5] Resolving packages...
[3/5] Fetching packages...
[4/5] Linking dependencies...
[5/5] Building fresh packages...
Done in 51.36s.
```
