### PR TITLE
fix: ignore ALREADY_KNOWN gossip block error

### DIFF
--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -128,6 +128,8 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
 
     chain
       .processBlock(blockInput, {
+        // block may be downloaded and processed by UnknownBlockSync
+        ignoreIfKnown: true,
         // proposer signature already checked in validateBeaconBlock()
         validProposerSignature: true,
         // blobsSidecar already checked in validateGossipBlobsSidecar()
@@ -152,6 +154,8 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       .catch((e) => {
         if (e instanceof BlockError) {
           switch (e.type.code) {
+            // ALREADY_KNOWN should not happen with ignoreIfKnown=true above
+            // PARENT_UNKNOWN should not happen, we handled this in validateBeaconBlock() function above
             case BlockErrorCode.ALREADY_KNOWN:
             case BlockErrorCode.PARENT_UNKNOWN:
             case BlockErrorCode.PRESTATE_MISSING:


### PR DESCRIPTION
**Motivation**

- After v1.9.0, unknown block root maybe downloaded before gossip block comes:
```
Downloaded unknown block root=0xd6726e2f9ca882c728f81b4a6f7580327576c03d9bbd7051ec0a7868671743ca, pendingBlocks=1, parentInForkchoice=true
Received gossip block slot=5942197, root=0xd672…43ca, curentSlot=5942197, peerId=16Uiu2HAm2GTP413xneJPzKQa9C8M3JzTh18RUrVuKajjrQe1o468, delaySec=0.7290000915527344, recvToVal=0.02499985694885254
```
then node may show this error
```
Error receiving block slot=5942197, peer=16Uiu2HAm2GTP413xneJPzKQa9C8M3JzTh18RUrVuKajjrQe1o468 code=BLOCK_ERROR_ALREADY_KNOWN, root=0xd6726e2f9ca882c728f81b4a6f7580327576c03d9bbd7051ec0a7868671743ca
```

**Description**

- Use `ignoreIfKnown` flag when processing gossip block