### PR TITLE
fix: explicitly exit process after beacon node closed

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -130,6 +130,9 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
         try {
           await node.close();
           logger.debug("Beacon node closed");
+          // Explicitly exit until active handles issue is resolved
+          // See https://github.com/ChainSafe/lodestar/issues/5642
+          process.exit(0);
         } catch (e) {
           logger.error("Error closing beacon node", {}, e as Error);
           // Make sure db is always closed gracefully


### PR DESCRIPTION
**Motivation**

For now, we have to explicitly call process.exit after beacon node closed to prevent process from hanging causing bad user experience. 

**Description**

Call process.exit after close sequence is completed. At this point it is safe to terminate the process.

Ideally, we should not have explicitly exit the process. This change can be reverted once issue is fixed
- https://github.com/ChainSafe/lodestar/issues/5642