### PR TITLE
chore: disable rate limiting on local testnet node

### DIFF
--- a/scripts/dev/node1.sh
+++ b/scripts/dev/node1.sh
@@ -13,4 +13,5 @@ GENESIS_TIME=$(date +%s)
   --rest.namespace '*' \
   --metrics \
   --logLevel debug \
-  --eth1 false
+  --eth1 false \
+  --network.rateLimitMultiplier 0


### PR DESCRIPTION
**Motivation**

As mentioned in https://github.com/ChainSafe/lodestar/pull/5719#discussion_r1251764546, starting external nodes (e.g. node2) after a while such that they need to sync a sufficient number of slots (thousands) will cause rate limiting.

**Description**

Disable rate limiting on node1 by setting `--network.rateLimitMultiplier 0`
