### PR TITLE
feat: verifySignatureSetsSameSigningRoot bls api

### DIFF
--- a/packages/beacon-node/src/chain/bls/interface.ts
+++ b/packages/beacon-node/src/chain/bls/interface.ts
@@ -41,6 +41,17 @@ export interface IBlsVerifier {
    */
   verifySignatureSets(sets: ISignatureSet[], opts?: VerifySignatureOpts): Promise<boolean>;
 
+  /**
+   * Similar to verifySignatureSets but:
+   *   - all signatures have the same signing root
+   *   - return an array of boolean, each element indicates whether the corresponding signature set is valid
+   *   - only support `verifyOnMainThread` option.
+   */
+  verifySignatureSetsSameSigningRoot(
+    sets: ISignatureSet[],
+    opts?: Pick<VerifySignatureOpts, "verifyOnMainThread">
+  ): Promise<boolean[]>;
+
   /** For multithread pool awaits terminating all workers */
   close(): Promise<void>;
 

--- a/packages/beacon-node/src/chain/bls/maybeBatch.ts
+++ b/packages/beacon-node/src/chain/bls/maybeBatch.ts
@@ -16,9 +16,11 @@ export type SignatureSetDeserialized = {
 export function verifySignatureSetsMaybeBatch(sets: SignatureSetDeserialized[], isSameMessage = false): boolean {
   if (sets.length >= MIN_SET_COUNT_TO_BATCH) {
     if (isSameMessage) {
-      // TODO: return false if not same message or throw error?
+      // Consumers need to make sure that all sets have the same message
       const aggregatedPubkey = bls.PublicKey.aggregate(sets.map((set) => set.publicKey));
       const aggregatedSignature = bls.Signature.aggregate(
+        // As of Jul 2023 we could skip the signature validation here, no attack scenario found
+        // however this does not have the same security guarantee as the regular verify
         sets.map((set) => bls.Signature.fromBytes(set.signature, CoordType.affine, false))
       );
       return aggregatedSignature.verify(aggregatedPubkey, sets[0].message);

--- a/packages/beacon-node/src/chain/bls/maybeBatch.ts
+++ b/packages/beacon-node/src/chain/bls/maybeBatch.ts
@@ -19,9 +19,8 @@ export function verifySignatureSetsMaybeBatch(sets: SignatureSetDeserialized[], 
       // Consumers need to make sure that all sets have the same message
       const aggregatedPubkey = bls.PublicKey.aggregate(sets.map((set) => set.publicKey));
       const aggregatedSignature = bls.Signature.aggregate(
-        // As of Jul 2023 we could skip the signature validation here, no attack scenario found
-        // however this does not have the same security guarantee as the regular verify
-        sets.map((set) => bls.Signature.fromBytes(set.signature, CoordType.affine, false))
+        // true = validate signature
+        sets.map((set) => bls.Signature.fromBytes(set.signature, CoordType.affine, true))
       );
       return aggregatedSignature.verify(aggregatedPubkey, sets[0].message);
     }

--- a/packages/beacon-node/src/chain/bls/multithread/types.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/types.ts
@@ -36,3 +36,28 @@ export type BlsWorkResult = {
   workerEndNs: bigint;
   results: WorkResult<boolean>[];
 };
+
+/**
+ * A job item we want to get a result for.
+ */
+export type JobItem<W = BlsWorkReq | SerializedSet, R = boolean> = {
+  resolve: (result: R | PromiseLike<R>) => void;
+  reject: (error?: Error) => void;
+  addedTimeMs: number;
+  workReq: W;
+};
+
+/**
+ * An item in the queue. Could be BlsWorkReq or SerializedSet[] of the same message.
+ */
+export type QueueItem = JobItem<BlsWorkReq> | JobItem<SerializedSet>[];
+
+export type Jobs =
+  | {
+      isSameMessageJobs: false;
+      jobs: JobItem<BlsWorkReq>[];
+    }
+  | {
+      isSameMessageJobs: true;
+      jobs: JobItem<SerializedSet>[];
+    };

--- a/packages/beacon-node/src/chain/bls/multithread/types.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/types.ts
@@ -1,5 +1,10 @@
 import {VerifySignatureOpts} from "../interface.js";
 
+export enum ApiName {
+  verifySignatureSets = "verifySignatureSets",
+  verifySignatureSetsSameSigningRoot = "verifySignatureSetsSameSigningRoot",
+}
+
 export type WorkerData = {
   implementation: "herumi" | "blst-native";
   workerId: number;

--- a/packages/beacon-node/src/chain/bls/singleThread.ts
+++ b/packages/beacon-node/src/chain/bls/singleThread.ts
@@ -3,6 +3,7 @@ import {Metrics} from "../../metrics/index.js";
 import {IBlsVerifier} from "./interface.js";
 import {verifySignatureSetsMaybeBatch} from "./maybeBatch.js";
 import {getAggregatedPubkey, getAggregatedPubkeysCount} from "./utils.js";
+import {ApiName} from "./multithread/types.js";
 
 export class BlsSingleThreadVerifier implements IBlsVerifier {
   private readonly metrics: Metrics | null;
@@ -32,7 +33,10 @@ export class BlsSingleThreadVerifier implements IBlsVerifier {
     // Don't use a try/catch, only count run without exceptions
     const endNs = process.hrtime.bigint();
     const totalSec = Number(startNs - endNs) / 1e9;
-    this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.observe(totalSec);
+    this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.observe(
+      {api: ApiName.verifySignatureSetsSameSigningRoot},
+      totalSec
+    );
 
     return result;
   }
@@ -54,7 +58,7 @@ export class BlsSingleThreadVerifier implements IBlsVerifier {
     // Don't use a try/catch, only count run without exceptions
     const endNs = process.hrtime.bigint();
     const totalSec = Number(startNs - endNs) / 1e9;
-    this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.observe(totalSec);
+    this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.observe({api: ApiName.verifySignatureSets}, totalSec);
 
     return isValid;
   }

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -308,23 +308,31 @@ export function createLodestarMetrics(
         help: "Total API calls to the BLS thread pool",
         labelNames: ["api"],
       }),
-      jobsWorkerTime: register.gauge<"workerId">({
+      jobsWorkerTimeByWorkerId: register.gauge<"workerId">({
         name: "lodestar_bls_thread_pool_time_seconds_sum",
         help: "Total time spent verifying signature sets measured on the worker",
         labelNames: ["workerId"],
       }),
-      successJobsSignatureSetsCount: register.gauge({
+      jobsWorkerTimeByApi: register.gauge<"api">({
+        name: "lodestar_bls_thread_pool_time_by_api_seconds_sum",
+        help: "Total time spent verifying signature sets measured on the worker by api",
+        labelNames: ["api"],
+      }),
+      successJobsSignatureSetsCount: register.gauge<"api">({
         name: "lodestar_bls_thread_pool_success_jobs_signature_sets_count",
         help: "Count of total verified signature sets",
+        labelNames: ["api"],
       }),
-      errorJobsSignatureSetsCount: register.gauge({
+      errorJobsSignatureSetsCount: register.gauge<"api">({
         name: "lodestar_bls_thread_pool_error_jobs_signature_sets_count",
         help: "Count of total error-ed signature sets",
+        labelNames: ["api"],
       }),
-      jobWaitTime: register.histogram({
+      jobWaitTime: register.histogram<"api">({
         name: "lodestar_bls_thread_pool_queue_job_wait_time_seconds",
         help: "Time from job added to the queue to starting the job in seconds",
         buckets: [0.01, 0.02, 0.5, 0.1, 0.3, 1],
+        labelNames: ["api"],
       }),
       queueLength: register.gauge({
         name: "lodestar_bls_thread_pool_queue_length",
@@ -347,37 +355,43 @@ export function createLodestarMetrics(
         help: "Count of total signature sets started in bls thread pool, sig sets include 1 pk, msg, sig",
       }),
       // Re-verifying a batch means doing double work. This number must be very low or it can be a waste of CPU resources
-      batchRetries: register.gauge({
+      batchRetries: register.gauge<"api">({
         name: "lodestar_bls_thread_pool_batch_retries_total",
         help: "Count of total batches that failed and had to be verified again.",
+        labelNames: ["api"],
       }),
       // To count how many sigs are being validated with the optimization of batching them
-      batchSigsSuccess: register.gauge({
+      batchSigsSuccess: register.gauge<"api">({
         name: "lodestar_bls_thread_pool_batch_sigs_success_total",
         help: "Count of total batches that failed and had to be verified again.",
+        labelNames: ["api"],
       }),
       // To measure the time cost of main thread <-> worker message passing
-      latencyToWorker: register.histogram({
+      latencyToWorker: register.histogram<"api">({
         name: "lodestar_bls_thread_pool_latency_to_worker",
         help: "Time from sending the job to the worker and the worker receiving it",
         buckets: [0.001, 0.003, 0.01, 0.03, 0.1],
+        labelNames: ["api"],
       }),
-      latencyFromWorker: register.histogram({
+      latencyFromWorker: register.histogram<"api">({
         name: "lodestar_bls_thread_pool_latency_from_worker",
         help: "Time from the worker sending the result and the main thread receiving it",
         buckets: [0.001, 0.003, 0.01, 0.03, 0.1],
+        labelNames: ["api"],
       }),
-      mainThreadDurationInThreadPool: register.histogram({
+      mainThreadDurationInThreadPool: register.histogram<"api">({
         name: "lodestar_bls_thread_pool_main_thread_time_seconds",
         help: "Time to verify signatures in main thread with thread pool mode",
         // Time can vary significantly, so just track usage ratio
         buckets: [0],
+        labelNames: ["api"],
       }),
-      timePerSigSet: register.histogram({
+      timePerSigSet: register.histogram<"api">({
         name: "lodestar_bls_worker_thread_time_per_sigset_seconds",
         help: "Time to verify each sigset with worker thread mode",
         // Time per sig ~0.9ms on good machines
         buckets: [0.5e-3, 0.75e-3, 1e-3, 1.5e-3, 2e-3, 5e-3],
+        labelNames: ["api"],
       }),
     },
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -303,6 +303,16 @@ export function createLodestarMetrics(
     },
 
     blsThreadPool: {
+      workerApiCalls: register.gauge<"api">({
+        name: "lodestar_bls_thread_pool_worker_api_calls_total",
+        help: "Total API calls to the BLS thread pool",
+        labelNames: ["api"],
+      }),
+      verifySignatureSetsSameSigningRootError: register.gauge<"error">({
+        name: "lodestar_bls_thread_pool_verify_signature_sets_same_signing_root_error_total",
+        help: "Total errors when verifying signature sets with the same signing root",
+        labelNames: ["error"],
+      }),
       jobsWorkerTime: register.gauge<"workerId">({
         name: "lodestar_bls_thread_pool_time_seconds_sum",
         help: "Total time spent verifying signature sets measured on the worker",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -308,11 +308,6 @@ export function createLodestarMetrics(
         help: "Total API calls to the BLS thread pool",
         labelNames: ["api"],
       }),
-      verifySignatureSetsSameSigningRootError: register.gauge<"error">({
-        name: "lodestar_bls_thread_pool_verify_signature_sets_same_signing_root_error_total",
-        help: "Total errors when verifying signature sets with the same signing root",
-        labelNames: ["error"],
-      }),
       jobsWorkerTime: register.gauge<"workerId">({
         name: "lodestar_bls_thread_pool_time_seconds_sum",
         help: "Total time spent verifying signature sets measured on the worker",

--- a/packages/beacon-node/test/perf/bls/bls.test.ts
+++ b/packages/beacon-node/test/perf/bls/bls.test.ts
@@ -1,20 +1,26 @@
+import crypto from "node:crypto";
 import {itBench} from "@dapplion/benchmark";
 import bls from "@chainsafe/bls";
-import type {PublicKey, SecretKey, Signature} from "@chainsafe/bls/types";
+import {CoordType, type PublicKey, type SecretKey} from "@chainsafe/bls/types";
 import {linspace} from "../../../src/util/numpy.js";
 
 describe("BLS ops", function () {
   type Keypair = {publicKey: PublicKey; secretKey: SecretKey};
-  type BlsSet = {publicKey: PublicKey; message: Uint8Array; signature: Signature};
+  // signature needs to be in Uint8Array to match real situation
+  type BlsSet = {publicKey: PublicKey; message: Uint8Array; signature: Uint8Array};
 
   // Create and cache (on demand) crypto data to benchmark
   const sets = new Map<number, BlsSet>();
+  const sameMessageSets = new Map<number, BlsSet>();
   const keypairs = new Map<number, Keypair>();
 
   function getKeypair(i: number): Keypair {
     let keypair = keypairs.get(i);
     if (!keypair) {
-      const secretKey = bls.SecretKey.fromBytes(Buffer.alloc(32, i + 1));
+      const bytes = new Uint8Array(32);
+      const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      dataView.setUint32(0, i + 1, true);
+      const secretKey = bls.SecretKey.fromBytes(bytes);
       const publicKey = secretKey.toPublicKey();
       keypair = {secretKey, publicKey};
       keypairs.set(i, keypair);
@@ -27,26 +33,66 @@ describe("BLS ops", function () {
     if (!set) {
       const {secretKey, publicKey} = getKeypair(i);
       const message = Buffer.alloc(32, i + 1);
-      set = {publicKey, message: message, signature: secretKey.sign(message)};
+      set = {publicKey, message: message, signature: secretKey.sign(message).toBytes()};
       sets.set(i, set);
+    }
+    return set;
+  }
+
+  const seedMessage = crypto.randomBytes(32);
+  function getSetSameMessage(i: number): BlsSet {
+    const message = new Uint8Array(32);
+    message.set(seedMessage);
+    let set = sameMessageSets.get(i);
+    if (!set) {
+      const {secretKey, publicKey} = getKeypair(i);
+      set = {publicKey, message, signature: secretKey.sign(message).toBytes()};
+      sameMessageSets.set(i, set);
     }
     return set;
   }
 
   // Note: getSet() caches the value, does not re-compute every time
   itBench({id: `BLS verify - ${bls.implementation}`, beforeEach: () => getSet(0)}, (set) => {
-    const isValid = set.signature.verify(set.publicKey, set.message);
+    const isValid = bls.Signature.fromBytes(set.signature).verify(set.publicKey, set.message);
     if (!isValid) throw Error("Invalid");
   });
 
   // An aggregate and proof object has 3 signatures.
   // We may want to bundle up to 32 sets in a single batch.
-  for (const count of [3, 8, 32]) {
+  for (const count of [3, 8, 32, 64, 128]) {
     itBench({
       id: `BLS verifyMultipleSignatures ${count} - ${bls.implementation}`,
       beforeEach: () => linspace(0, count - 1).map((i) => getSet(i)),
       fn: (sets) => {
-        const isValid = bls.Signature.verifyMultipleSignatures(sets);
+        const isValid = bls.Signature.verifyMultipleSignatures(
+          sets.map((set) => ({
+            publicKey: set.publicKey,
+            message: set.message,
+            // true = validate signature
+            signature: bls.Signature.fromBytes(set.signature, CoordType.affine, true),
+          }))
+        );
+        if (!isValid) throw Error("Invalid");
+      },
+    });
+  }
+
+  // An aggregate and proof object has 3 signatures.
+  // We may want to bundle up to 32 sets in a single batch.
+  // TODO: figure out why it does not work with 256 or more
+  for (const count of [3, 8, 32, 64, 128]) {
+    itBench({
+      id: `BLS verifyMultipleSignatures - same message - ${count} - ${bls.implementation}`,
+      beforeEach: () => linspace(0, count - 1).map((i) => getSetSameMessage(i)),
+      fn: (sets) => {
+        // aggregate and verify aggregated signatures
+        const aggregatedPubkey = bls.PublicKey.aggregate(sets.map((set) => set.publicKey));
+        const aggregatedSignature = bls.Signature.aggregate(
+          // true = validate signature
+          sets.map((set) => bls.Signature.fromBytes(set.signature, CoordType.affine, true))
+        );
+        const isValid = aggregatedSignature.verify(aggregatedPubkey, sets[0].message);
         if (!isValid) throw Error("Invalid");
       },
     });

--- a/packages/beacon-node/test/unit/chain/bls/multithread/index.test.ts
+++ b/packages/beacon-node/test/unit/chain/bls/multithread/index.test.ts
@@ -1,0 +1,69 @@
+import {expect} from "chai";
+import {prepareWork} from "../../../../../src/chain/bls/multithread/index.js";
+import {JobItem, QueueItem, SerializedSet} from "../../../../../src/chain/bls/multithread/types.js";
+
+function createMultiSigsQueueItem(): QueueItem {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    resolve: () => {},
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    reject: () => {},
+    addedTimeMs: Math.random() * 1e9,
+    workReq: {opts: {}, sets: [{} as SerializedSet]},
+  };
+}
+
+function createSameMessageQueueItem(n: number): QueueItem {
+  const items: JobItem<SerializedSet>[] = [];
+  for (let i = 0; i < n; i++) {
+    items.push({
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      resolve: () => {},
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      reject: () => {},
+      addedTimeMs: Math.random() * 1e9,
+      workReq: {} as SerializedSet,
+    });
+  }
+
+  return items;
+}
+
+describe("prepareWork", () => {
+  const testCases: {
+    // true for multi-sig, false for same message
+    jobs: boolean[];
+    // index in the jobs
+    expectedRemainingJobs: number[];
+    // index in the jobs, could be 1 item in the case of same message
+    expectedResult: number[] | number;
+    expectedIsSameMessage: boolean;
+  }[] = [
+    {jobs: [true, true, true], expectedRemainingJobs: [], expectedResult: [0, 1, 2], expectedIsSameMessage: false},
+    {jobs: [true, true, false], expectedRemainingJobs: [2], expectedResult: [0, 1], expectedIsSameMessage: false},
+    {jobs: [true, false, true], expectedRemainingJobs: [1, 2], expectedResult: [0], expectedIsSameMessage: false},
+    {jobs: [true, false, false], expectedRemainingJobs: [1, 2], expectedResult: [0], expectedIsSameMessage: false},
+    {jobs: [false], expectedRemainingJobs: [], expectedResult: 0, expectedIsSameMessage: true},
+    {jobs: [false, true], expectedRemainingJobs: [1], expectedResult: 0, expectedIsSameMessage: true},
+    {jobs: [false, false], expectedRemainingJobs: [1], expectedResult: 0, expectedIsSameMessage: true},
+  ];
+
+  let i = 0;
+  for (const {jobs, expectedRemainingJobs, expectedResult, expectedIsSameMessage} of testCases) {
+    it(`test case ${i++}`, () => {
+      const typedJobs = jobs.map((isMultiSig) =>
+        isMultiSig ? createMultiSigsQueueItem() : createSameMessageQueueItem(3)
+      );
+
+      const copiedJobs = [...typedJobs];
+      const result = prepareWork(copiedJobs, 3);
+      expect(copiedJobs).to.be.deep.equals(expectedRemainingJobs.map((index) => typedJobs[index]));
+      expect(result).to.be.deep.equals({
+        isSameMessageJobs: expectedIsSameMessage,
+        jobs: Array.isArray(expectedResult)
+          ? expectedResult.map((index) => typedJobs[index])
+          : typedJobs[expectedResult],
+      });
+    });
+  }
+});

--- a/packages/beacon-node/test/unit/chain/bls/multithread/index.test.ts
+++ b/packages/beacon-node/test/unit/chain/bls/multithread/index.test.ts
@@ -39,10 +39,33 @@ describe("prepareWork", () => {
     expectedResult: number[] | number;
     expectedIsSameMessage: boolean;
   }[] = [
-    {jobs: [true, true, true], expectedRemainingJobs: [], expectedResult: [0, 1, 2], expectedIsSameMessage: false},
+    {
+      jobs: [true, true, true, true],
+      expectedRemainingJobs: [3],
+      expectedResult: [0, 1, 2],
+      expectedIsSameMessage: false,
+    },
     {jobs: [true, true, false], expectedRemainingJobs: [2], expectedResult: [0, 1], expectedIsSameMessage: false},
-    {jobs: [true, false, true], expectedRemainingJobs: [1, 2], expectedResult: [0], expectedIsSameMessage: false},
+    {
+      jobs: [true, true, false, true],
+      expectedRemainingJobs: [2],
+      expectedResult: [0, 1, 3],
+      expectedIsSameMessage: false,
+    },
+    {jobs: [true, false, true], expectedRemainingJobs: [1], expectedResult: [0, 2], expectedIsSameMessage: false},
+    {
+      jobs: [true, false, true, true],
+      expectedRemainingJobs: [1],
+      expectedResult: [0, 2, 3],
+      expectedIsSameMessage: false,
+    },
     {jobs: [true, false, false], expectedRemainingJobs: [1, 2], expectedResult: [0], expectedIsSameMessage: false},
+    {
+      jobs: [true, false, false, true],
+      expectedRemainingJobs: [1, 2],
+      expectedResult: [0, 3],
+      expectedIsSameMessage: false,
+    },
     {jobs: [false], expectedRemainingJobs: [], expectedResult: 0, expectedIsSameMessage: true},
     {jobs: [false, true], expectedRemainingJobs: [1], expectedResult: 0, expectedIsSameMessage: true},
     {jobs: [false, false], expectedRemainingJobs: [1], expectedResult: 0, expectedIsSameMessage: true},

--- a/packages/beacon-node/test/unit/chain/validation/block.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/block.test.ts
@@ -44,7 +44,12 @@ describe("gossip block validation", function () {
 
     verifySignature = sinon.stub();
     verifySignature.resolves(true);
-    chain.bls = {verifySignatureSets: verifySignature, close: () => Promise.resolve(), canAcceptWork: () => true};
+    chain.bls = {
+      verifySignatureSets: verifySignature,
+      verifySignatureSetsSameSigningRoot: () => Promise.resolve([true]),
+      close: () => Promise.resolve(),
+      canAcceptWork: () => true,
+    };
 
     forkChoice.getFinalizedCheckpoint.returns({epoch: 0, root: ZERO_HASH, rootHex: ""});
 

--- a/packages/beacon-node/test/utils/mocks/bls.ts
+++ b/packages/beacon-node/test/utils/mocks/bls.ts
@@ -1,7 +1,12 @@
+import {ISignatureSet} from "@lodestar/state-transition";
 import {IBlsVerifier} from "../../../src/chain/bls/index.js";
 
 export class BlsVerifierMock implements IBlsVerifier {
   constructor(private readonly isValidResult: boolean) {}
+
+  async verifySignatureSetsSameSigningRoot(sets: ISignatureSet[]): Promise<boolean[]> {
+    return this.isValidResult ? sets.map(() => true) : sets.map(() => false);
+  }
 
   async verifySignatureSets(): Promise<boolean> {
     return this.isValidResult;


### PR DESCRIPTION
**Motivation**

- verifying signature sets of the same signing root is 6x to >10x faster than `verifyMultipleSignatures()` api
- as a preparation for #5729 where we'll validate signature sets with same signing root
- we want to leverage our worker pool to control `canAcceptWork()` (if we should process a gossip message or not) 

**Description**

- new `verifyManySignatureSetsSameMessage()` worker api
- enhance `verifySignatureSetsMaybeBatch()` to add new param `isSameMessage: boolean`
- separate `QueueItem` type (an item in "jobs" queue) and `JobItem` type (which contain a resolve/reject function of a promise)

```typescript
/**
 * A job item we want to get a result for.
 */
export type JobItem<W = BlsWorkReq | SerializedSet, R = boolean> = {
  resolve: (result: R | PromiseLike<R>) => void;
  reject: (error?: Error) => void;
  addedTimeMs: number;
  workReq: W;
};

/**
 * An item in the queue. Could be BlsWorkReq or SerializedSet[] of the same message.
 */
export type QueueItem = JobItem<BlsWorkReq> | JobItem<SerializedSet>[];
```
- an item in the queue could be a "multi sig sets" job item or an array of job item of same message signature set
- `verifySignatureSetsSameSigningRoot` has "verifyOnMainThread" to verify on main thread or not, consumer can decide it later (in #5729)

part of #5416

**Notes**
- This introduces new api, noone consume this new api atm
- cc @matthewkeil @dapplion 
