### PR TITLE
chore: remove explicit exit after beacon node closed

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -130,9 +130,6 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
         try {
           await node.close();
           logger.debug("Beacon node closed");
-          // Explicitly exit until active handles issue is resolved
-          // See https://github.com/ChainSafe/lodestar/issues/5642
-          process.exit(0);
         } catch (e) {
           logger.error("Error closing beacon node", {}, e as Error);
           // Make sure db is always closed gracefully


### PR DESCRIPTION
**Motivation**

Issue seems to be resolved
- https://github.com/ChainSafe/lodestar/issues/5642

**Description**

Remove explicit exit after beacon node closed.

Reverts temporary fix
- https://github.com/ChainSafe/lodestar/pull/5716
