### PR TITLE
fix: ignore discovered peers with no multiaddrs

### DIFF
--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -273,8 +273,9 @@ export class PeerDiscovery {
   private onDiscoveredPeer = (evt: CustomEvent<PeerInfo>): void => {
     const {id, multiaddrs} = evt.detail;
 
-    // libp2p may send us PeerInfos without multiaddrs
-    if (multiaddrs.length === 0) {
+    // libp2p may send us PeerInfos without multiaddrs https://github.com/libp2p/js-libp2p/issues/1873
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    if (!multiaddrs || multiaddrs.length === 0) {
       this.metrics?.discovery.discoveredStatus.inc({status: DiscoveredPeerStatus.no_multiaddrs});
       return;
     }


### PR DESCRIPTION
**Motivation**

- Resolves https://github.com/ChainSafe/lodestar/issues/5733
Upgrading to libp2p 0.45.9, it changed how / when it emits `"peer:discovery"` events.

**Description**

Update `onDiscoveredPeer` to handle the case where `multiaddrs: Multiaddr[]` is empty.