### PR TITLE
chore: remove winston from packages other than logger

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -124,7 +124,6 @@
     "@lodestar/db": "^1.9.1",
     "@lodestar/fork-choice": "^1.9.1",
     "@lodestar/light-client": "^1.9.1",
-    "@lodestar/logger": "^1.9.1",
     "@lodestar/params": "^1.9.1",
     "@lodestar/reqresp": "^1.9.1",
     "@lodestar/state-transition": "^1.9.1",
@@ -156,6 +155,7 @@
     "xxhash-wasm": "1.0.2"
   },
   "devDependencies": {
+    "@lodestar/logger": "^1.9.1",
     "@types/eventsource": "^1.1.11",
     "@types/leveldown": "^4.0.3",
     "@types/qs": "^6.9.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,9 +88,6 @@
     "source-map-support": "^0.5.21",
     "uint8arrays": "^4.0.3",
     "uuidv4": "^6.2.13",
-    "winston": "^3.8.2",
-    "winston-daily-rotate-file": "^4.7.1",
-    "winston-transport": "^4.5.0",
     "yargs": "^17.7.1"
   },
   "devDependencies": {

--- a/packages/prover/package.json
+++ b/packages/prover/package.json
@@ -78,8 +78,6 @@
     "http-proxy": "^1.18.1",
     "js-yaml": "^4.1.0",
     "source-map-support": "^0.5.21",
-    "winston-transport": "^4.5.0",
-    "winston": "^3.8.2",
     "yargs": "^17.7.1"
   },
   "devDependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -42,8 +42,7 @@
     "bigint-buffer": "^1.1.5",
     "case": "^1.6.3",
     "chalk": "^5.2.0",
-    "js-yaml": "^4.1.0",
-    "winston": "^3.8.2"
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",


### PR DESCRIPTION
**Motivation**

Noticed when installing @lodestar/api, it also installs winston and tons of other sub deps which are not required.

**Description**

Remove winston* dependencies from all packages other than @lodestar/logger.
