### PR TITLE
refactor: increase batch size to get validator indices to 64

### DIFF
--- a/packages/validator/src/services/indices.ts
+++ b/packages/validator/src/services/indices.ts
@@ -7,9 +7,9 @@ import {Metrics} from "../metrics.js";
 
 /**
  * URLs have a limitation on size, adding an unbounded num of pubkeys will break the request.
- * For reasoning on the specific number see: https://github.com/ChainSafe/lodestar/pull/2730#issuecomment-866749083
+ * For reasoning on the specific number see: https://github.com/ethereum/beacon-APIs/pull/328
  */
-const PUBKEYS_PER_REQUEST = 10;
+const PUBKEYS_PER_REQUEST = 64;
 
 // To assist with readability
 type PubkeyHex = string;

--- a/packages/validator/src/util/batch.ts
+++ b/packages/validator/src/util/batch.ts
@@ -1,6 +1,5 @@
 /**
- * Divide pubkeys into batches, each batch contains at most 5 http requests,
- * each request can work on at most 40 pubkeys.
+ * Convert array of items into array of batched item arrays
  */
 export function batchItems<T>(items: T[], opts: {batchSize: number; maxBatches?: number}): T[][] {
   const batches: T[][] = [];


### PR DESCRIPTION
**Motivation**

The current batch size of 10 is quite conservative. The rationale behind choosing the value https://github.com/ChainSafe/lodestar/pull/2730#issuecomment-866749083 seems outdated and there has been more discussion on this https://github.com/ethereum/beacon-APIs/pull/328 in the meantime.

The value 64 is supported by all implementations and reducing the amount of queries reduces load on beacon node, especially during startup.

**Description**

- Increase batch size (`PUBKEYS_PER_REQUEST`) to get validator indices to 64
- Update tsdoc of `batchItems`, previous comment is misleading and inaccurate
