### PR TITLE
fix: close peer manager before sending goodbye to all peers

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -256,11 +256,13 @@ export class NetworkCore implements INetworkCore {
 
     this.clock.off(ClockEvent.epoch, this.onEpoch);
 
+    // Must close peer manager before disconnecting peers to
+    // prevent registering newly discovered peers afterwards
+    await this.peerManager.close();
+    this.logger.debug("network peerManager closed");
     // Must goodbye and disconnect before stopping libp2p
     await this.peerManager.goodbyeAndDisconnectAllPeers();
     this.logger.debug("network sent goodbye to all peers");
-    await this.peerManager.close();
-    this.logger.debug("network peerManager closed");
     await this.gossip.stop();
     this.logger.debug("network gossip closed");
     await this.reqResp.stop();


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5642

**Description**

Closes peer manager before sending goodbye to all peers, see https://github.com/ChainSafe/lodestar/issues/5642#issuecomment-1630749223 for rationale.

I looked at the code and this should not cause any issues as closing peer manager only removes intervals, event listeners and closes discv5.