### PR TITLE
chore: re-add explicit exit after beacon node closed

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -130,6 +130,9 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
         try {
           await node.close();
           logger.debug("Beacon node closed");
+          // Explicitly exit until active handles issue is resolved
+          // See https://github.com/ChainSafe/lodestar/issues/5642
+          process.exit(0);
         } catch (e) {
           logger.error("Error closing beacon node", {}, e as Error);
           // Make sure db is always closed gracefully


### PR DESCRIPTION
**Motivation**

https://github.com/ChainSafe/lodestar/issues/5642 is not yet resolved, see https://github.com/ChainSafe/lodestar/issues/5642#issuecomment-1631977838

**Description**

Re-adds explicit exit after beacon node closed

This reverts commit 1de881b7776284c6dd56f146ac55ef3df040f98d.
