### PR TITLE
feat: track attestationInBlockParticipants

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -850,6 +850,11 @@ export function createLodestarMetrics(
         help: "The excess slots (beyond the minimum delay) between the attestation slot and the block slot",
         buckets: [0.1, 0.25, 0.5, 1, 2, 5, 10],
       }),
+      attestationInBlockParticipants: register.histogram({
+        name: "validator_monitor_attestation_in_block_participants",
+        help: "The total participants in attestations of monitored validators included in blocks",
+        buckets: [1, 5, 20, 50, 100, 200],
+      }),
       syncSignatureInAggregateTotal: register.gauge({
         name: "validator_monitor_sync_signature_in_aggregate_total",
         help: "Number of times a sync signature has been seen in an aggregate",

--- a/packages/beacon-node/src/metrics/validatorMonitor.ts
+++ b/packages/beacon-node/src/metrics/validatorMonitor.ts
@@ -529,12 +529,14 @@ export function createValidatorMonitor(
       const inclusionDistance = Math.max(parentSlot - data.slot, 0) + 1;
       const delay = inclusionDistance - MIN_ATTESTATION_INCLUSION_DELAY;
       const epoch = computeEpochAtSlot(data.slot);
+      const participants = indexedAttestation.attestingIndices.length;
 
       for (const index of indexedAttestation.attestingIndices) {
         const validator = validators.get(index);
         if (validator) {
           metrics.validatorMonitor.attestationInBlockTotal.inc();
           metrics.validatorMonitor.attestationInBlockDelaySlots.observe(delay);
+          metrics.validatorMonitor.attestationInBlockParticipants.observe(participants);
 
           const summary = getEpochSummary(validator, epoch);
           summary.attestationBlockInclusions += 1;
@@ -566,6 +568,7 @@ export function createValidatorMonitor(
             committeeIndex: data.index,
             inclusionDistance,
             correctHead,
+            participants,
           });
         }
       }


### PR DESCRIPTION
**Motivation**

It's useful to know how many participants are in block inclusion attestations. Lower values indicate issues in our end where few participants shared our view of the chain at the time.

**Description**

Add metric

https://github.com/ChainSafe/lodestar/blob/9e21d94a46236544b2cf7c525b6e894bf980b140/packages/beacon-node/src/metrics/metrics/lodestar.ts#L854-L855
