### PR TITLE
feat: track participants of produced aggregates

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -374,6 +374,11 @@ export function getValidatorApi({
 
       const contribution = chain.syncCommitteeMessagePool.getContribution(subcommitteeIndex, slot, beaconBlockRoot);
       if (!contribution) throw new ApiError(500, "No contribution available");
+
+      metrics?.production.producedSyncContributionParticipants.observe(
+        contribution.aggregationBits.getTrueBitIndexes().length
+      );
+
       return {data: contribution};
     },
 
@@ -537,6 +542,9 @@ export function getValidatorApi({
       notWhileSyncing();
 
       await waitForSlot(slot); // Must never request for a future slot > currentSlot
+
+      const aggregate = chain.attestationPool.getAggregate(slot, attestationDataRoot);
+      metrics?.production.producedAggregateParticipants.observe(aggregate.aggregationBits.getTrueBitIndexes().length);
 
       return {
         data: chain.attestationPool.getAggregate(slot, attestationDataRoot),

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -130,10 +130,11 @@ export async function produceBlockBody<T extends BlockType>(
   const blockEpoch = computeEpochAtSlot(blockSlot);
 
   if (blockEpoch >= this.config.ALTAIR_FORK_EPOCH) {
-    (blockBody as altair.BeaconBlockBody).syncAggregate = this.syncContributionAndProofPool.getAggregate(
-      parentSlot,
-      parentBlockRoot
+    const syncAggregate = this.syncContributionAndProofPool.getAggregate(parentSlot, parentBlockRoot);
+    this.metrics?.production.producedSyncAggregateParticipants.observe(
+      syncAggregate.syncCommitteeBits.getTrueBitIndexes().length
     );
+    (blockBody as altair.BeaconBlockBody).syncAggregate = syncAggregate;
   }
 
   const fork = currentState.config.getForkName(blockSlot);

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -221,6 +221,30 @@ export function createLodestarMetrics(
       }),
     },
 
+    production: {
+      producedAggregateParticipants: register.histogram({
+        name: "lodestar_produced_aggregate_participants",
+        help: "API impl produced aggregates histogram of participatns",
+        // We care more about tracking low quality aggregates with low participation
+        // Max committee sizes are: 0.5e6 vc: 244, 1e6 vc: 488
+        buckets: [1, 5, 20, 50, 100, 200, 400],
+      }),
+      producedSyncContributionParticipants: register.histogram({
+        name: "lodestar_produced_sync_contribution_participants",
+        help: "API impl produced sync contribution histogram of participatns",
+        // We care more about tracking low quality aggregates with low participation
+        // Max committee sizes fixed to 512/4 = 128
+        buckets: [1, 5, 20, 50, 128],
+      }),
+      producedSyncAggregateParticipants: register.histogram({
+        name: "lodestar_produced_sync_aggregate_participants",
+        help: "API impl produced sync aggregate histogram of participatns",
+        // We care more about tracking low quality aggregates with low participation
+        // Max committee sizes fixed to 512
+        buckets: [1, 5, 20, 50, 100, 200, 512],
+      }),
+    },
+
     // Beacon state transition metrics
 
     epochTransitionTime: register.histogram({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -224,21 +224,21 @@ export function createLodestarMetrics(
     production: {
       producedAggregateParticipants: register.histogram({
         name: "lodestar_produced_aggregate_participants",
-        help: "API impl produced aggregates histogram of participatns",
+        help: "API impl produced aggregates histogram of participants",
         // We care more about tracking low quality aggregates with low participation
         // Max committee sizes are: 0.5e6 vc: 244, 1e6 vc: 488
         buckets: [1, 5, 20, 50, 100, 200, 400],
       }),
       producedSyncContributionParticipants: register.histogram({
         name: "lodestar_produced_sync_contribution_participants",
-        help: "API impl produced sync contribution histogram of participatns",
+        help: "API impl produced sync contribution histogram of participants",
         // We care more about tracking low quality aggregates with low participation
         // Max committee sizes fixed to 512/4 = 128
         buckets: [1, 5, 20, 50, 128],
       }),
       producedSyncAggregateParticipants: register.histogram({
         name: "lodestar_produced_sync_aggregate_participants",
-        help: "API impl produced sync aggregate histogram of participatns",
+        help: "API impl produced sync aggregate histogram of participants",
         // We care more about tracking low quality aggregates with low participation
         // Max committee sizes fixed to 512
         buckets: [1, 5, 20, 50, 100, 200, 512],

--- a/packages/beacon-node/test/perf/util/bitArray.test.ts
+++ b/packages/beacon-node/test/perf/util/bitArray.test.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
 import {BitArray} from "@chainsafe/ssz";
 import {intersectUint8Arrays} from "../../../src/util/bitArray.js";
@@ -40,6 +41,18 @@ describe("Intersect BitArray vs Array+Set", () => {
             }
           }
         }
+      },
+    });
+  }
+});
+
+describe("BitArray.trueBitCount", () => {
+  for (const bitLen of [128, 248, 512]) {
+    itBench({
+      id: `bitArray.getTrueBitIndexes() bitLen ${bitLen}`,
+      beforeEach: () => new BitArray(crypto.randomBytes(Math.ceil(bitLen / 8)), bitLen),
+      fn: (bitArray) => {
+        bitArray.getTrueBitIndexes().length;
       },
     });
   }


### PR DESCRIPTION
**Motivation**

Know the quality of produced aggregates for any API callee

**Description**

Added metrics:

https://github.com/ChainSafe/lodestar/blob/7f24c6eacd0519a0dc47a07504039140e158dabc/packages/beacon-node/src/metrics/metrics/lodestar.ts#L226-L227

https://github.com/ChainSafe/lodestar/blob/7f24c6eacd0519a0dc47a07504039140e158dabc/packages/beacon-node/src/metrics/metrics/lodestar.ts#L233-L234

https://github.com/ChainSafe/lodestar/blob/7f24c6eacd0519a0dc47a07504039140e158dabc/packages/beacon-node/src/metrics/metrics/lodestar.ts#L240-L241

**Considerations**

This PR adds an extra step in block production hot path. 1 call per block to getTrueBitIndexes for a 512 bits SyncAggregate. I have added a benchmark and showed to it adds ~12us which is not a concern at all

```
  BitArray.trueBitCount
    ✔ bitArray.getTrueBitIndexes() bitLen 128                             298062.6 ops/s    3.355000 us/op        -      88220 runs  0.909 s
    ✔ bitArray.getTrueBitIndexes() bitLen 248                             155690.5 ops/s    6.423000 us/op        -      64211 runs  0.909 s
    ✔ bitArray.getTrueBitIndexes() bitLen 512                             82047.92 ops/s    12.18800 us/op        -      55888 runs   1.11 s
```