### PR TITLE
feat: prioritize api signature sets

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -1,12 +1,12 @@
 import {routes, ServerApi} from "@lodestar/api";
 import {Epoch, ssz} from "@lodestar/types";
 import {SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
-import {validateGossipAttestation} from "../../../../chain/validation/index.js";
-import {validateGossipAttesterSlashing} from "../../../../chain/validation/attesterSlashing.js";
-import {validateGossipProposerSlashing} from "../../../../chain/validation/proposerSlashing.js";
-import {validateGossipVoluntaryExit} from "../../../../chain/validation/voluntaryExit.js";
-import {validateBlsToExecutionChange} from "../../../../chain/validation/blsToExecutionChange.js";
-import {validateSyncCommitteeSigOnly} from "../../../../chain/validation/syncCommittee.js";
+import {validateApiAttestation} from "../../../../chain/validation/index.js";
+import {validateApiAttesterSlashing} from "../../../../chain/validation/attesterSlashing.js";
+import {validateApiProposerSlashing} from "../../../../chain/validation/proposerSlashing.js";
+import {validateApiVoluntaryExit} from "../../../../chain/validation/voluntaryExit.js";
+import {validateApiBlsToExecutionChange} from "../../../../chain/validation/blsToExecutionChange.js";
+import {validateApiSyncCommittee} from "../../../../chain/validation/syncCommittee.js";
 import {ApiModules} from "../../types.js";
 import {AttestationError, GossipAction, SyncCommitteeError} from "../../../../chain/errors/index.js";
 import {validateGossipFnRetryUnknownRoot} from "../../../../network/processor/gossipHandlers.js";
@@ -53,7 +53,7 @@ export function getBeaconPoolApi({
         attestations.map(async (attestation, i) => {
           try {
             // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-            const validateFn = () => validateGossipAttestation(chain, {attestation, serializedData: null}, null);
+            const validateFn = () => validateApiAttestation(chain, {attestation, serializedData: null});
             const {slot, beaconBlockRoot} = attestation.data;
             // when a validator is configured with multiple beacon node urls, this attestation data may come from another beacon node
             // and the block hasn't been in our forkchoice since we haven't seen / processing that block
@@ -97,19 +97,19 @@ export function getBeaconPoolApi({
     },
 
     async submitPoolAttesterSlashings(attesterSlashing) {
-      await validateGossipAttesterSlashing(chain, attesterSlashing);
+      await validateApiAttesterSlashing(chain, attesterSlashing);
       chain.opPool.insertAttesterSlashing(attesterSlashing);
       await network.publishAttesterSlashing(attesterSlashing);
     },
 
     async submitPoolProposerSlashings(proposerSlashing) {
-      await validateGossipProposerSlashing(chain, proposerSlashing);
+      await validateApiProposerSlashing(chain, proposerSlashing);
       chain.opPool.insertProposerSlashing(proposerSlashing);
       await network.publishProposerSlashing(proposerSlashing);
     },
 
     async submitPoolVoluntaryExit(voluntaryExit) {
-      await validateGossipVoluntaryExit(chain, voluntaryExit);
+      await validateApiVoluntaryExit(chain, voluntaryExit);
       chain.opPool.insertVoluntaryExit(voluntaryExit);
       chain.emitter.emit(routes.events.EventType.voluntaryExit, voluntaryExit);
       await network.publishVoluntaryExit(voluntaryExit);
@@ -122,7 +122,7 @@ export function getBeaconPoolApi({
         blsToExecutionChanges.map(async (blsToExecutionChange, i) => {
           try {
             // Ignore even if the change exists and reprocess
-            await validateBlsToExecutionChange(chain, blsToExecutionChange, true);
+            await validateApiBlsToExecutionChange(chain, blsToExecutionChange);
             const preCapella = chain.clock.currentEpoch < chain.config.CAPELLA_FORK_EPOCH;
             chain.opPool.insertBlsToExecutionChange(blsToExecutionChange, preCapella);
 
@@ -182,7 +182,7 @@ export function getBeaconPoolApi({
 
             // Verify signature only, all other data is very likely to be correct, since the `signature` object is created by this node.
             // Worst case if `signature` is not valid, gossip peers will drop it and slightly downscore us.
-            await validateSyncCommitteeSigOnly(chain, state, signature);
+            await validateApiSyncCommittee(chain, state, signature);
 
             // The same validator can appear multiple times in the sync committee. It can appear multiple times per
             // subnet even. First compute on which subnet the signature must be broadcasted to.

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -20,7 +20,7 @@ import {Root, Slot, ValidatorIndex, ssz, Epoch, ProducedBlockSource, bellatrix, 
 import {ExecutionStatus} from "@lodestar/fork-choice";
 import {toHex} from "@lodestar/utils";
 import {AttestationError, AttestationErrorCode, GossipAction, SyncCommitteeError} from "../../../chain/errors/index.js";
-import {validateGossipAggregateAndProof} from "../../../chain/validation/index.js";
+import {validateApiAggregateAndProof} from "../../../chain/validation/index.js";
 import {ZERO_HASH} from "../../../constants/index.js";
 import {SyncState} from "../../../sync/index.js";
 import {isOptimisticBlock} from "../../../util/forkChoice.js";
@@ -554,12 +554,7 @@ export function getValidatorApi({
           try {
             // TODO: Validate in batch
             // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-            const validateFn = () =>
-              validateGossipAggregateAndProof(
-                chain,
-                signedAggregateAndProof,
-                true // skip known attesters check
-              );
+            const validateFn = () => validateApiAggregateAndProof(chain, signedAggregateAndProof);
             const {slot, beaconBlockRoot} = signedAggregateAndProof.message.aggregate.data;
             // when a validator is configured with multiple beacon node urls, this attestation may come from another beacon node
             // and the block hasn't been in our forkchoice since we haven't seen / processing that block

--- a/packages/beacon-node/src/chain/bls/interface.ts
+++ b/packages/beacon-node/src/chain/bls/interface.ts
@@ -15,6 +15,10 @@ export type VerifySignatureOpts = {
    * Ignore the batchable option if this is true.
    */
   verifyOnMainThread?: boolean;
+  /**
+   * Some signature sets are more important than others, and should be verified first.
+   */
+  priority?: boolean;
 };
 
 export interface IBlsVerifier {

--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -153,6 +153,13 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
   async verifySignatureSets(sets: ISignatureSet[], opts: VerifySignatureOpts = {}): Promise<boolean> {
     // Pubkeys are aggregated in the main thread regardless if verified in workers or in main thread
     this.metrics?.bls.aggregatedPubkeys.inc(getAggregatedPubkeysCount(sets));
+    this.metrics?.blsThreadPool.totalSigSets.inc(sets.length);
+    if (opts.priority) {
+      this.metrics?.blsThreadPool.prioritizedSigSets.inc(sets.length);
+    }
+    if (opts.batchable) {
+      this.metrics?.blsThreadPool.batchableSigSets.inc(sets.length);
+    }
 
     if (opts.verifyOnMainThread && !this.blsVerifyAllMultiThread) {
       const timer = this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.startTimer();

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -87,7 +87,7 @@ async function validateAttestation(
   attestationOrBytes: AttestationOrBytes,
   /** Optional, to allow verifying attestations through API with unknown subnet */
   subnet: number | null,
-  prioritizeBls: boolean = false
+  prioritizeBls = false
 ): Promise<AttestationValidationResult> {
   // Do checks in this order:
   // - do early checks (w/o indexed attestation)

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -29,16 +29,18 @@ export type AttestationValidationResult = {
   attDataRootHex: RootHex;
 };
 
-export type AttestationOrBytes =
-  // for api
-  | {attestation: phase0.Attestation; serializedData: null}
-  // for gossip
-  | {
-      attestation: null;
-      serializedData: Uint8Array;
-      // available in NetworkProcessor since we check for unknown block root attestations
-      attSlot: Slot;
-    };
+export type AttestationOrBytes = ApiAttestation | GossipAttestation;
+
+/** attestation from api */
+export type ApiAttestation = {attestation: phase0.Attestation; serializedData: null};
+
+/** attestation from gossip */
+export type GossipAttestation = {
+  attestation: null;
+  serializedData: Uint8Array;
+  // available in NetworkProcessor since we check for unknown block root attestations
+  attSlot: Slot;
+};
 
 /**
  * The beacon chain shufflings are designed to provide 1 epoch lookahead
@@ -47,14 +49,45 @@ export type AttestationOrBytes =
 const SHUFFLING_LOOK_AHEAD_EPOCHS = 1;
 
 /**
- * Only deserialize the attestation if needed, use the cached AttestationData instead
- * This is to avoid deserializing similar attestation multiple times which could help the gc
+ * Validate attestations from gossip
+ * - Only deserialize the attestation if needed, use the cached AttestationData instead
+ * - This is to avoid deserializing similar attestation multiple times which could help the gc
+ * - subnet is required
+ * - do not prioritize bls signature set
  */
 export async function validateGossipAttestation(
   chain: IBeaconChain,
+  attestationOrBytes: GossipAttestation,
+  /** Optional, to allow verifying attestations through API with unknown subnet */
+  subnet: number
+): Promise<AttestationValidationResult> {
+  return validateAttestation(chain, attestationOrBytes, subnet);
+}
+
+/**
+ * Validate attestations from api
+ * - no need to deserialize attestation
+ * - no subnet
+ * - prioritize bls signature set
+ */
+export async function validateApiAttestation(
+  chain: IBeaconChain,
+  attestationOrBytes: ApiAttestation
+): Promise<AttestationValidationResult> {
+  const prioritizeBls = true;
+  return validateAttestation(chain, attestationOrBytes, null, prioritizeBls);
+}
+
+/**
+ * Only deserialize the attestation if needed, use the cached AttestationData instead
+ * This is to avoid deserializing similar attestation multiple times which could help the gc
+ */
+async function validateAttestation(
+  chain: IBeaconChain,
   attestationOrBytes: AttestationOrBytes,
   /** Optional, to allow verifying attestations through API with unknown subnet */
-  subnet: number | null
+  subnet: number | null,
+  prioritizeBls: boolean = false
 ): Promise<AttestationValidationResult> {
   // Do checks in this order:
   // - do early checks (w/o indexed attestation)
@@ -268,7 +301,7 @@ export async function validateGossipAttestation(
     }
   }
 
-  if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
+  if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true, priority: prioritizeBls}))) {
     throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.INVALID_SIGNATURE});
   }
 

--- a/packages/beacon-node/src/chain/validation/syncCommittee.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommittee.ts
@@ -71,16 +71,26 @@ export async function validateGossipSyncCommittee(
   return {indexInSubcommittee};
 }
 
-/**
- * Abstracted so it can be re-used in API validation.
- */
-export async function validateSyncCommitteeSigOnly(
+export async function validateApiSyncCommittee(
   chain: IBeaconChain,
   headState: CachedBeaconStateAllForks,
   syncCommittee: altair.SyncCommitteeMessage
 ): Promise<void> {
+  const prioritizeBls = true;
+  return validateSyncCommitteeSigOnly(chain, headState, syncCommittee, prioritizeBls);
+}
+
+/**
+ * Abstracted so it can be re-used in API validation.
+ */
+async function validateSyncCommitteeSigOnly(
+  chain: IBeaconChain,
+  headState: CachedBeaconStateAllForks,
+  syncCommittee: altair.SyncCommitteeMessage,
+  prioritizeBls = false
+): Promise<void> {
   const signatureSet = getSyncCommitteeSignatureSet(headState, syncCommittee);
-  if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
+  if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true, priority: prioritizeBls}))) {
     throw new SyncCommitteeError(GossipAction.REJECT, {
       code: SyncCommitteeErrorCode.INVALID_SIGNATURE,
     });

--- a/packages/beacon-node/src/chain/validation/voluntaryExit.ts
+++ b/packages/beacon-node/src/chain/validation/voluntaryExit.ts
@@ -4,9 +4,25 @@ import {IBeaconChain} from "..";
 import {VoluntaryExitError, VoluntaryExitErrorCode, GossipAction} from "../errors/index.js";
 import {RegenCaller} from "../regen/index.js";
 
+export async function validateApiVoluntaryExit(
+  chain: IBeaconChain,
+  voluntaryExit: phase0.SignedVoluntaryExit
+): Promise<void> {
+  const prioritizeBls = true;
+  return validateVoluntaryExit(chain, voluntaryExit, prioritizeBls);
+}
+
 export async function validateGossipVoluntaryExit(
   chain: IBeaconChain,
   voluntaryExit: phase0.SignedVoluntaryExit
+): Promise<void> {
+  return validateVoluntaryExit(chain, voluntaryExit);
+}
+
+async function validateVoluntaryExit(
+  chain: IBeaconChain,
+  voluntaryExit: phase0.SignedVoluntaryExit,
+  prioritizeBls = false
 ): Promise<void> {
   // [IGNORE] The voluntary exit is the first valid voluntary exit received for the validator with index
   // signed_voluntary_exit.message.validator_index.
@@ -34,7 +50,7 @@ export async function validateGossipVoluntaryExit(
   }
 
   const signatureSet = getVoluntaryExitSignatureSet(state, voluntaryExit);
-  if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true}))) {
+  if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true, priority: prioritizeBls}))) {
     throw new VoluntaryExitError(GossipAction.REJECT, {
       code: VoluntaryExitErrorCode.INVALID_SIGNATURE,
     });

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -374,6 +374,18 @@ export function createLodestarMetrics(
         // Time per sig ~0.9ms on good machines
         buckets: [0.5e-3, 0.75e-3, 1e-3, 1.5e-3, 2e-3, 5e-3],
       }),
+      totalSigSets: register.gauge({
+        name: "lodestar_bls_thread_pool_sig_sets_total",
+        help: "Count of total signature sets",
+      }),
+      prioritizedSigSets: register.gauge({
+        name: "lodestar_bls_thread_pool_prioritized_sig_sets_total",
+        help: "Count of total prioritized signature sets",
+      }),
+      batchableSigSets: register.gauge({
+        name: "lodestar_bls_thread_pool_batchable_sig_sets_total",
+        help: "Count of total batchable signature sets",
+      }),
     },
 
     // BLS time on single thread mode

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -27,7 +27,7 @@ import {
   validateGossipSyncCommittee,
   validateSyncCommitteeGossipContributionAndProof,
   validateGossipVoluntaryExit,
-  validateBlsToExecutionChange,
+  validateGossipBlsToExecutionChange,
   AttestationValidationResult,
   AggregateAndProofValidationResult,
 } from "../../chain/validation/index.js";
@@ -194,7 +194,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
       const signedAggregateAndProof = sszDeserialize(topic, serializedData);
 
       try {
-        validationResult = await validateGossipAggregateAndProof(chain, signedAggregateAndProof, false, serializedData);
+        validationResult = await validateGossipAggregateAndProof(chain, signedAggregateAndProof, serializedData);
       } catch (e) {
         if (e instanceof AttestationError && e.action === GossipAction.REJECT) {
           chain.persistInvalidSszValue(ssz.phase0.SignedAggregateAndProof, signedAggregateAndProof, "gossip_reject");
@@ -376,7 +376,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
     // blsToExecutionChange is to be generated and validated against GENESIS_FORK_VERSION
     [GossipType.bls_to_execution_change]: async ({serializedData}, topic) => {
       const blsToExecutionChange = sszDeserialize(topic, serializedData);
-      await validateBlsToExecutionChange(chain, blsToExecutionChange);
+      await validateGossipBlsToExecutionChange(chain, blsToExecutionChange);
 
       // Handler
       try {

--- a/packages/beacon-node/src/util/array.ts
+++ b/packages/beacon-node/src/util/array.ts
@@ -100,6 +100,20 @@ export class LinkedList<T> {
     this._length = 0;
   }
 
+  [Symbol.iterator](): Iterator<T> {
+    let node = this.head;
+    return {
+      next(): IteratorResult<T> {
+        if (!node) {
+          return {done: true, value: undefined};
+        }
+        const value = node.data;
+        node = node.next;
+        return {done: false, value};
+      },
+    };
+  }
+
   toArray(): T[] {
     let node = this.head;
     if (!node) return [];

--- a/packages/beacon-node/src/util/array.ts
+++ b/packages/beacon-node/src/util/array.ts
@@ -63,6 +63,25 @@ export class LinkedList<T> {
     this._length++;
   }
 
+  unshift(data: T): void {
+    if (this._length === 0) {
+      this.tail = this.head = new Node(data);
+      this._length++;
+      return;
+    }
+
+    if (!this.head || !this.tail) {
+      // should not happen
+      throw Error("No head or tail");
+    }
+
+    const newHead = new Node(data);
+    newHead.next = this.head;
+    this.head.prev = newHead;
+    this.head = newHead;
+    this._length++;
+  }
+
   pop(): T | null {
     const oldTail = this.tail;
     if (!oldTail) return null;

--- a/packages/beacon-node/test/perf/chain/validation/aggregateAndProof.test.ts
+++ b/packages/beacon-node/test/perf/chain/validation/aggregateAndProof.test.ts
@@ -1,7 +1,7 @@
 import {itBench} from "@dapplion/benchmark";
-// eslint-disable-next-line import/no-relative-packages
 import {ssz} from "@lodestar/types";
-import {generateTestCachedBeaconStateOnlyValidators} from "@lodestar/state-transition/test/perf/util.js";
+// eslint-disable-next-line import/no-relative-packages
+import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../state-transition/test/perf/util.js";
 import {validateApiAggregateAndProof, validateGossipAggregateAndProof} from "../../../../src/chain/validation/index.js";
 import {getAggregateAndProofValidData} from "../../../utils/validationData/aggregateAndProof.js";
 

--- a/packages/beacon-node/test/perf/chain/validation/aggregateAndProof.test.ts
+++ b/packages/beacon-node/test/perf/chain/validation/aggregateAndProof.test.ts
@@ -1,7 +1,8 @@
 import {itBench} from "@dapplion/benchmark";
 // eslint-disable-next-line import/no-relative-packages
-import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../state-transition/test/perf/util.js";
-import {validateGossipAggregateAndProof} from "../../../../src/chain/validation/index.js";
+import {ssz} from "@lodestar/types";
+import {generateTestCachedBeaconStateOnlyValidators} from "@lodestar/state-transition/test/perf/util.js";
+import {validateApiAggregateAndProof, validateGossipAggregateAndProof} from "../../../../src/chain/validation/index.js";
 import {getAggregateAndProofValidData} from "../../../utils/validationData/aggregateAndProof.js";
 
 describe("validate gossip signedAggregateAndProof", () => {
@@ -16,6 +17,19 @@ describe("validate gossip signedAggregateAndProof", () => {
   const aggStruct = signedAggregateAndProof;
 
   for (const [id, agg] of Object.entries({struct: aggStruct})) {
+    const serializedData = ssz.phase0.SignedAggregateAndProof.serialize(aggStruct);
+
+    itBench({
+      id: `validate api signedAggregateAndProof - ${id}`,
+      beforeEach: () => {
+        chain.seenAggregators["validatorIndexesByEpoch"].clear();
+        chain.seenAggregatedAttestations["aggregateRootsByEpoch"].clear();
+      },
+      fn: async () => {
+        await validateApiAggregateAndProof(chain, agg);
+      },
+    });
+
     itBench({
       id: `validate gossip signedAggregateAndProof - ${id}`,
       beforeEach: () => {
@@ -23,7 +37,7 @@ describe("validate gossip signedAggregateAndProof", () => {
         chain.seenAggregatedAttestations["aggregateRootsByEpoch"].clear();
       },
       fn: async () => {
-        await validateGossipAggregateAndProof(chain, agg);
+        await validateGossipAggregateAndProof(chain, agg, serializedData);
       },
     });
   }

--- a/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
+++ b/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
@@ -1,7 +1,8 @@
 import {itBench} from "@dapplion/benchmark";
 // eslint-disable-next-line import/no-relative-packages
-import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../state-transition/test/perf/util.js";
-import {validateGossipAttestation} from "../../../../src/chain/validation/index.js";
+import {ssz} from "@lodestar/types";
+import {generateTestCachedBeaconStateOnlyValidators} from "@lodestar/state-transition/test/perf/util.js";
+import {validateApiAttestation, validateGossipAttestation} from "../../../../src/chain/validation/index.js";
 import {getAttestationValidData} from "../../../utils/validationData/attestation.js";
 
 describe("validate gossip attestation", () => {
@@ -16,11 +17,21 @@ describe("validate gossip attestation", () => {
   const attStruct = attestation;
 
   for (const [id, att] of Object.entries({struct: attStruct})) {
+    const serializedData = ssz.phase0.Attestation.serialize(att);
+    const slot = attestation.data.slot;
+    itBench({
+      id: `validate api attestation - ${id}`,
+      beforeEach: () => chain.seenAttesters["validatorIndexesByEpoch"].clear(),
+      fn: async () => {
+        await validateApiAttestation(chain, {attestation: att, serializedData: null});
+      },
+    });
+
     itBench({
       id: `validate gossip attestation - ${id}`,
       beforeEach: () => chain.seenAttesters["validatorIndexesByEpoch"].clear(),
       fn: async () => {
-        await validateGossipAttestation(chain, {attestation: att, serializedData: null}, subnet);
+        await validateGossipAttestation(chain, {attestation: null, serializedData, attSlot: slot}, subnet);
       },
     });
   }

--- a/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
+++ b/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
@@ -1,11 +1,11 @@
 import {itBench} from "@dapplion/benchmark";
-// eslint-disable-next-line import/no-relative-packages
 import {ssz} from "@lodestar/types";
-import {generateTestCachedBeaconStateOnlyValidators} from "@lodestar/state-transition/test/perf/util.js";
+// eslint-disable-next-line import/no-relative-packages
+import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../state-transition/test/perf/util.js";
 import {validateApiAttestation, validateGossipAttestation} from "../../../../src/chain/validation/index.js";
 import {getAttestationValidData} from "../../../utils/validationData/attestation.js";
 
-describe("validate gossip attestation", () => {
+describe("validate attestation", () => {
   const vc = 64;
   const stateSlot = 100;
 

--- a/packages/beacon-node/test/unit/chain/validation/aggregateAndProof.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/aggregateAndProof.test.ts
@@ -6,7 +6,7 @@ import {processSlots} from "@lodestar/state-transition";
 import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../state-transition/test/perf/util.js";
 import {IBeaconChain} from "../../../../src/chain/index.js";
 import {AttestationErrorCode} from "../../../../src/chain/errors/index.js";
-import {validateGossipAggregateAndProof} from "../../../../src/chain/validation/index.js";
+import {validateApiAggregateAndProof, validateGossipAggregateAndProof} from "../../../../src/chain/validation/index.js";
 import {expectRejectedWithLodestarError} from "../../../utils/errors.js";
 import {memoOnce} from "../../../utils/cache.js";
 import {
@@ -42,7 +42,7 @@ describe("chain / validation / aggregateAndProof", () => {
   it("Valid", async () => {
     const {chain, signedAggregateAndProof} = getValidData({});
 
-    await validateGossipAggregateAndProof(chain, signedAggregateAndProof);
+    await validateApiAggregateAndProof(chain, signedAggregateAndProof);
   });
 
   it("BAD_TARGET_EPOCH", async () => {
@@ -188,6 +188,10 @@ describe("chain / validation / aggregateAndProof", () => {
     signedAggregateAndProof: phase0.SignedAggregateAndProof,
     errorCode: AttestationErrorCode
   ): Promise<void> {
-    await expectRejectedWithLodestarError(validateGossipAggregateAndProof(chain, signedAggregateAndProof), errorCode);
+    const serializedData = ssz.phase0.SignedAggregateAndProof.serialize(signedAggregateAndProof);
+    await expectRejectedWithLodestarError(
+      validateGossipAggregateAndProof(chain, signedAggregateAndProof, serializedData),
+      errorCode
+    );
   }
 });

--- a/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
@@ -19,7 +19,7 @@ import {createBeaconConfig} from "@lodestar/config";
 import {BeaconChain} from "../../../../src/chain/index.js";
 import {StubbedChainMutable} from "../../../utils/stub/index.js";
 import {generateState} from "../../../utils/state.js";
-import {validateBlsToExecutionChange} from "../../../../src/chain/validation/blsToExecutionChange.js";
+import {validateGossipBlsToExecutionChange} from "../../../../src/chain/validation/blsToExecutionChange.js";
 import {BlsToExecutionChangeErrorCode} from "../../../../src/chain/errors/blsToExecutionChangeError.js";
 import {OpPool} from "../../../../src/chain/opPools/index.js";
 import {expectRejectedWithLodestarError} from "../../../utils/errors.js";
@@ -115,13 +115,13 @@ describe("validate bls to execution change", () => {
     opPool.hasSeenBlsToExecutionChange.returns(true);
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      validateGossipBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
       BlsToExecutionChangeErrorCode.ALREADY_EXISTS
     );
   });
 
   it("should return valid blsToExecutionChange ", async () => {
-    await validateBlsToExecutionChange(chainStub, signedBlsToExecChange);
+    await validateGossipBlsToExecutionChange(chainStub, signedBlsToExecChange);
   });
 
   it("should return invalid bls to execution Change - invalid validatorIndex", async () => {
@@ -135,7 +135,7 @@ describe("validate bls to execution change", () => {
     };
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      validateGossipBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
       BlsToExecutionChangeErrorCode.INVALID
     );
   });
@@ -150,7 +150,7 @@ describe("validate bls to execution change", () => {
     };
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      validateGossipBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
       BlsToExecutionChangeErrorCode.INVALID
     );
   });
@@ -166,7 +166,7 @@ describe("validate bls to execution change", () => {
     };
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      validateGossipBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
       BlsToExecutionChangeErrorCode.INVALID
     );
   });
@@ -182,7 +182,7 @@ describe("validate bls to execution change", () => {
     };
 
     await expectRejectedWithLodestarError(
-      validateBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
+      validateGossipBlsToExecutionChange(chainStub, signedBlsToExecChangeInvalid),
       BlsToExecutionChangeErrorCode.INVALID
     );
   });

--- a/packages/beacon-node/test/unit/util/array.test.ts
+++ b/packages/beacon-node/test/unit/util/array.test.ts
@@ -53,6 +53,57 @@ describe("LinkedList", () => {
     expect(list.length).to.be.equal(0);
   });
 
+  describe("push", () => {
+    const count = 100;
+    beforeEach(() => {
+      list = new LinkedList<number>();
+      expect(list.length).to.be.equal(0);
+      for (let i = 0; i < count; i++) list.push(i);
+      expect(list.length).to.be.equal(count);
+      expect(list.toArray()).to.be.deep.equal(Array.from({length: count}, (_, i) => i));
+    });
+
+    it("push then pop", () => {
+      for (let i = 0; i < count; i++) {
+        expect(list.pop()).to.be.equal(count - i - 1);
+      }
+      expect(list.length).to.be.equal(0);
+    });
+
+    it("push then shift", () => {
+      for (let i = 0; i < count; i++) {
+        expect(list.shift()).to.be.equal(i);
+      }
+      expect(list.length).to.be.equal(0);
+    });
+  });
+
+  describe("unshift", () => {
+    const count = 100;
+    beforeEach(() => {
+      list = new LinkedList<number>();
+      expect(list.length).to.be.equal(0);
+      for (let i = 0; i < count; i++) list.unshift(i);
+      expect(list.length).to.be.equal(count);
+      expect(list.toArray()).to.be.deep.equal(Array.from({length: count}, (_, i) => count - i - 1));
+    });
+
+    it("unshift then pop", () => {
+      for (let i = 0; i < count; i++) {
+        expect(list.pop()).to.be.equal(i);
+      }
+      expect(list.length).to.be.equal(0);
+    });
+
+    it("unshift then shift", () => {
+      for (let i = 0; i < count; i++) {
+        expect(list.shift()).to.be.equal(count - i - 1);
+      }
+
+      expect(list.length).to.be.equal(0);
+    });
+  });
+
   it("toArray", () => {
     expect(list.toArray()).to.be.deep.equal([]);
 

--- a/packages/beacon-node/test/unit/util/array.test.ts
+++ b/packages/beacon-node/test/unit/util/array.test.ts
@@ -72,4 +72,25 @@ describe("LinkedList", () => {
     expect(list.toArray()).to.be.deep.equal([]);
     expect(list.length).to.be.equal(0);
   });
+
+  describe("iterator", () => {
+    const testCases: {count: number}[] = [{count: 0}, {count: 10}, {count: 100}];
+
+    for (const {count} of testCases) {
+      it(`should iterate over ${count} items`, () => {
+        for (let i = 0; i < count; i++) {
+          list.push(i);
+        }
+
+        let i = 0;
+        for (const item of list) {
+          expect(item).to.be.equal(i);
+          i++;
+        }
+
+        // make sure the list is the same
+        expect(list.toArray()).to.be.deep.equal(Array.from({length: count}, (_, i) => i));
+      });
+    }
+  });
 });


### PR DESCRIPTION
**Motivation**

- When bls is overload, it takes a lot of time (>1s) to verify a signature
- There are so many gossip signature sets while just few api siganture sets so we should prioritize the latter

**Description**

- Enhance `LinkedList` to add `unshift()` method
- Change `jobs` queue in bls multithread to be a `LinkedList`, this makes it very cheap to do an `unshift()`
- Add `priority` flag to `verifySignatureSets` api
- Use `priority: true` from api end point to prioritize bls signatures

Closes #5739
