### PR TITLE
fix: improve error logging of voluntary-exit command

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions.ts
@@ -28,6 +28,10 @@ export async function decryptKeystoreDefinitions(
   keystoreDefinitions: LocalKeystoreDefinition[],
   opts: KeystoreDecryptOptions
 ): Promise<SignerLocal[]> {
+  if (keystoreDefinitions.length === 0) {
+    return [];
+  }
+
   if (opts.cacheFilePath) {
     try {
       const signers = await loadKeystoreCache(opts.cacheFilePath, keystoreDefinitions);

--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -33,7 +33,7 @@ If no `pubkeys` are provided, it will exit all validators that have been importe
 
   examples: [
     {
-      command: "validator voluntary-exit --pubkeys 0xF00",
+      command: "validator voluntary-exit --network goerli --pubkeys 0xF00",
       description: "Perform a voluntary exit for the validator who has a public key 0xF00",
     },
   ],
@@ -78,6 +78,11 @@ If no `pubkeys` are provided, it will exit all validators that have been importe
 
     // Select signers to exit
     const signers = await getSignersFromArgs(args, network, {logger: console, signal: new AbortController().signal});
+    if (signers.length === 0) {
+      throw new YargsError(`No local keystores found with current args.
+   Ensure --dataDir and --network match values used when importing keys via validator import
+   or alternatively, import keys by providing --importKeystores arg to voluntary-exit command.`);
+    }
     const signersToExit = selectSignersToExit(args, signers);
     const validatorsToExit = await resolveValidatorIndexes(client, signersToExit);
 
@@ -153,7 +158,8 @@ async function resolveValidatorIndexes(client: Api, signersToExit: SignerLocalPu
   return signersToExit.map(({signer, pubkey}) => {
     const item = dataByPubkey.get(pubkey);
     if (!item) {
-      throw Error(`beacon node did not return status for pubkey ${pubkey}`);
+      throw new YargsError(`Validator with pubkey ${pubkey} is unknown.
+   Re-check the pubkey submitted or wait until the validator activated on the beacon chain to voluntary exit.`);
     }
 
     return {

--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -159,7 +159,7 @@ async function resolveValidatorIndexes(client: Api, signersToExit: SignerLocalPu
     const item = dataByPubkey.get(pubkey);
     if (!item) {
       throw new YargsError(`Validator with pubkey ${pubkey} is unknown.
-   Re-check the pubkey submitted or wait until the validator activated on the beacon chain to voluntary exit.`);
+   Re-check the pubkey submitted or wait until the validator is activated on the beacon chain to voluntary exit.`);
     }
 
     return {


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/4540 and addresses error logging UX issues mentioned in https://github.com/ChainSafe/lodestar/issues/4540#issuecomment-1588580003.

**Description**

- Better logging for exit-validator if key is not yet activated on beacon chain
- Throw error (exit early) with detailed message if there are no imported keys
- Stop printing out progress indicator if there are no keystores

This should address most of the confusion around why voluntary-exit does not work
- Wrong network ([user feedback](https://discord.com/channels/694822223575384095/903403272998641675/1111590812690681856))
- No imported keystores ([user feedback](https://discord.com/channels/694822223575384095/903403272998641675/1117913907546296360))
- Socket hang up due to querying `getStateValidators` without pubkeys ([user feedback](https://discord.com/channels/593655374469660673/743858262864167062/1126224445938352198))

**Error logging**

No local keystores
```sh
> ./lodestar validator voluntary-exit
 ✖ No local keystores found with current args.
   Ensure --dataDir and --network match values used when importing keys via validator import
   or alternatively, import keys by providing --importKeystores arg to voluntary-exit command.
```

Unknown pubkey (not found in local signers)
```sh
> ./lodestar validator voluntary-exit --importKeystores /path/to/validator_keys --pubkeys aa8bcc77b45f58769c29671547294ea49cd505519aa2be0be8dc46df0c14e35e07689f732ca06723b6fcd5cc03b83d9e
? Enter the keystore(s) password [hidden]
100% of keystores imported. current=1 total=1 rate=387.10keys/m
Loaded keystores via keystore cache
 ✖ Unknown pubkey 0xaa8bcc77b45f58769c29671547294ea49cd505519aa2be0be8dc46df0c14e35e07689f732ca06723b6fcd5cc03b83d9e
```

Validator with pubkey is unknown (not found in beacon state)
```sh
> ./lodestar validator voluntary-exit --importKeystores /path/to/validator_keys
? Enter the keystore(s) password [hidden]
100% of keystores imported. current=1 total=1 rate=19.07keys/m
Written keystores to keystore cache
 ✖ Validator with pubkey 0xb7387f7bb5fe95e5b976bbb877972926df099f092438aa2e2d57278b25dee66d1c3c96212540f0f4b5db7643e236cdcd is unknown.
   Re-check the pubkey submitted or wait until the validator activated on the beacon chain to voluntary exit.
```
