### PR TITLE
fix: correct subscribedToNetworkEvents flag of UnknownBlockSync

### DIFF
--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -57,21 +57,23 @@ export class UnknownBlockSync {
     if (!this.opts?.disableUnknownBlockSync) {
       // cannot chain to the above if or the log will be incorrect
       if (!this.subscribedToNetworkEvents) {
-        this.logger.debug("UnknownBlockSync enabled.");
+        this.logger.verbose("UnknownBlockSync enabled.");
         this.network.events.on(NetworkEvent.unknownBlock, this.onUnknownBlock);
         this.network.events.on(NetworkEvent.unknownBlockParent, this.onUnknownParent);
         this.network.events.on(NetworkEvent.peerConnected, this.triggerUnknownBlockSearch);
         this.subscribedToNetworkEvents = true;
       }
     } else {
-      this.logger.debug("UnknownBlockSync disabled.");
+      this.logger.verbose("UnknownBlockSync disabled by disableUnknownBlockSync option.");
     }
   }
 
   unsubscribeFromNetwork(): void {
+    this.logger.verbose("UnknownBlockSync disabled.");
     this.network.events.off(NetworkEvent.unknownBlock, this.onUnknownBlock);
     this.network.events.off(NetworkEvent.unknownBlockParent, this.onUnknownParent);
     this.network.events.off(NetworkEvent.peerConnected, this.triggerUnknownBlockSearch);
+    this.subscribedToNetworkEvents = false;
   }
 
   close(): void {


### PR DESCRIPTION
**Motivation**

In the case network is subscribed/unsubscribed multiple times, UnknownBlockSync did not do the same thing

**Description**

- This flag was not set when unsubscribing network event: `subscribedToNetworkEvents`

Closes #5763