### PR TITLE
refactor: update execution client state change logs

### DIFF
--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -428,19 +428,19 @@ export class ExecutionEngineHttp implements IExecutionEngine {
 
     switch (newState) {
       case ExecutionEngineState.ONLINE:
-        this.logger.info("ExecutionEngine became online");
+        this.logger.info("Execution client became online");
         break;
       case ExecutionEngineState.OFFLINE:
-        this.logger.error("ExecutionEngine went offline");
+        this.logger.error("Execution client went offline");
         break;
       case ExecutionEngineState.SYNCED:
-        this.logger.info("ExecutionEngine is synced");
+        this.logger.info("Execution client is synced");
         break;
       case ExecutionEngineState.SYNCING:
-        this.logger.info("ExecutionEngine is syncing");
+        this.logger.info("Execution client is syncing");
         break;
       case ExecutionEngineState.AUTH_FAILED:
-        this.logger.error("ExecutionEngine authentication failed");
+        this.logger.error("Execution client authentication failed");
         break;
     }
 

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -437,7 +437,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         this.logger.info("Execution client is synced");
         break;
       case ExecutionEngineState.SYNCING:
-        this.logger.info("Execution client is syncing");
+        this.logger.warn("Execution client is syncing");
         break;
       case ExecutionEngineState.AUTH_FAILED:
         this.logger.error("Execution client authentication failed");


### PR DESCRIPTION
**Motivation**

These logs are meant for end users as they are info/warn/error and not debug only. The term "ExecutionEngine" is quite technical in my opinion and to avoid any confusion would recommend we just stick to "Execution client" which is the term used by most users.

The second change of this PR is the update of log level to warn from info if execution client is syncing. This better aligns it with the validator log if beacon node is syncing. We have discussed in https://github.com/ChainSafe/lodestar/pull/5467 if info or warn should be used there.

**Description**

- Update execution client state change messages
- Use warn instead of info if execution client is syncing
