### PR TITLE
feat: add engine fcU v3 for devnet 8

### DIFF
--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -294,7 +294,12 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   ): Promise<PayloadId | null> {
     // Once on capella, should this need to be permanently switched to v2 when payload attrs
     // not provided
-    const method = ForkSeq[fork] >= ForkSeq.capella ? "engine_forkchoiceUpdatedV2" : "engine_forkchoiceUpdatedV1";
+    const method =
+      ForkSeq[fork] >= ForkSeq.deneb
+        ? "engine_forkchoiceUpdatedV3"
+        : ForkSeq[fork] >= ForkSeq.capella
+        ? "engine_forkchoiceUpdatedV2"
+        : "engine_forkchoiceUpdatedV1";
     const payloadAttributesRpc = payloadAttributes ? serializePayloadAttributes(payloadAttributes) : undefined;
     // If we are just fcUing and not asking execution for payload, retry is not required
     // and we can move on, as the next fcU will be issued soon on the new slot

--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -90,6 +90,7 @@ export class ExecutionEngineMockBackend implements JsonRpcBackend {
       engine_newPayloadV3: this.notifyNewPayload.bind(this),
       engine_forkchoiceUpdatedV1: this.notifyForkchoiceUpdate.bind(this),
       engine_forkchoiceUpdatedV2: this.notifyForkchoiceUpdate.bind(this),
+      engine_forkchoiceUpdatedV3: this.notifyForkchoiceUpdate.bind(this),
       engine_getPayloadV1: this.getPayload.bind(this),
       engine_getPayloadV2: this.getPayload.bind(this),
       engine_getPayloadV3: this.getPayload.bind(this),

--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -41,6 +41,10 @@ export type EngineApiRpcParamTypes = {
     forkChoiceData: {headBlockHash: DATA; safeBlockHash: DATA; finalizedBlockHash: DATA},
     payloadAttributes?: PayloadAttributesRpc,
   ];
+  engine_forkchoiceUpdatedV3: [
+    forkChoiceData: {headBlockHash: DATA; safeBlockHash: DATA; finalizedBlockHash: DATA},
+    payloadAttributes?: PayloadAttributesRpc,
+  ];
   /**
    * 1. payloadId: QUANTITY, 64 Bits - Identifier of the payload building process
    */
@@ -79,6 +83,10 @@ export type EngineApiRpcReturnTypes = {
     payloadId: QUANTITY | null;
   };
   engine_forkchoiceUpdatedV2: {
+    payloadStatus: PayloadStatus;
+    payloadId: QUANTITY | null;
+  };
+  engine_forkchoiceUpdatedV3: {
     payloadStatus: PayloadStatus;
     payloadId: QUANTITY | null;
   };
@@ -123,6 +131,7 @@ export type ExecutionPayloadRpc = {
   withdrawals?: WithdrawalRpc[]; // Capella hardfork
   dataGasUsed?: QUANTITY; // DENEB
   excessDataGas?: QUANTITY; // DENEB
+  parentBeaconBlockRoot?: QUANTITY; // DENEB
 };
 
 export type WithdrawalRpc = {
@@ -142,6 +151,8 @@ export type PayloadAttributesRpc = {
   /** DATA, 20 Bytes - suggested value for the coinbase field of the new payload */
   suggestedFeeRecipient: DATA;
   withdrawals?: WithdrawalRpc[];
+  /** DATA, 32 Bytes - value for the parentBeaconBlockRoot to be used for building block */
+  parentBeaconBlockRoot?: DATA;
 };
 
 export interface BlobsBundleRpc {
@@ -266,6 +277,7 @@ export function serializePayloadAttributes(data: PayloadAttributes): PayloadAttr
     prevRandao: bytesToData(data.prevRandao),
     suggestedFeeRecipient: data.suggestedFeeRecipient,
     withdrawals: data.withdrawals?.map(serializeWithdrawal),
+    parentBeaconBlockRoot: data.parentBeaconBlockRoot ? bytesToData(data.parentBeaconBlockRoot) : undefined,
   };
 }
 
@@ -281,6 +293,7 @@ export function deserializePayloadAttributes(data: PayloadAttributesRpc): Payloa
     // avoid any conversions
     suggestedFeeRecipient: data.suggestedFeeRecipient,
     withdrawals: data.withdrawals?.map((withdrawal) => deserializeWithdrawal(withdrawal)),
+    parentBeaconBlockRoot: data.parentBeaconBlockRoot ? dataToBytes(data.parentBeaconBlockRoot, 32) : undefined,
   };
 }
 


### PR DESCRIPTION
fcU v3 is to be used deneb onwards which provdes parentBeaconBlocRoot to the executon