### PR TITLE
chore: automatic meta-bug labels for bug report issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Create a bug report to help us improve
 title: "[Descriptive title] "
+labels: [meta-bug]
 body:
   - type: textarea
     id: describe


### PR DESCRIPTION
**Motivation**

When submitting a new bug report, you need to manually select `meta-bug` label to include with the issue

**Description**

This PR will allow the template to add the `meta-bug` label by default.