### PR TITLE
fix: metrics server listen on localhost by default

### DIFF
--- a/packages/beacon-node/src/metrics/options.ts
+++ b/packages/beacon-node/src/metrics/options.ts
@@ -18,4 +18,5 @@ export type MetricsOptions = HttpMetricsServerOpts & {
 export const defaultMetricsOptions: MetricsOptions = {
   enabled: false,
   port: 8008,
+  address: "127.0.0.1",
 };


### PR DESCRIPTION
**Motivation**

We are currently not setting the beacon node metrics server host to localhost / 127.0.0.1 by default. This causes it to listen on IPv6 network interface and makes it externally reachable by default (unless firewall is enabled), see https://github.com/ChainSafe/lodestar/issues/5768#issuecomment-1640866352 for further details.

Metric servers should only be explicitly exposed to an external network inferface by setting `--metrics.address "0.0.0.0"`.

**Description**

Set `127.0.0.1` as default beacon node metrics address.

This is already the case for validator metrics server
https://github.com/ChainSafe/lodestar/blob/0884fdfa1b2b80e3538633cba70b0ce3585f0c5c/packages/cli/src/cmds/validator/options.ts#L17

