### PR TITLE
fix: use compressed point format for bls

### DIFF
--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -128,10 +128,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
     // TODO: Allow to customize implementation
     const implementation = bls.implementation;
 
-    // Use compressed for herumi for now.
-    // THe worker is not able to deserialize from uncompressed
-    // `Error: err _wrapDeserialize`
-    this.format = implementation === "blst-native" ? PointFormat.uncompressed : PointFormat.compressed;
+    this.format = PointFormat.compressed;
     this.workers = this.createWorkers(implementation, defaultPoolSize);
 
     if (metrics) {

--- a/packages/beacon-node/test/perf/bls/bls.test.ts
+++ b/packages/beacon-node/test/perf/bls/bls.test.ts
@@ -1,6 +1,6 @@
 import {itBench} from "@dapplion/benchmark";
 import bls from "@chainsafe/bls";
-import type {PublicKey, SecretKey, Signature} from "@chainsafe/bls/types";
+import {PointFormat, PublicKey, SecretKey, Signature} from "@chainsafe/bls/types";
 import {linspace} from "../../../src/util/numpy.js";
 
 describe("BLS ops", function () {
@@ -60,6 +60,20 @@ describe("BLS ops", function () {
       fn: (pubkeys) => {
         bls.PublicKey.aggregate(pubkeys);
       },
+    });
+  }
+
+  for (const pointFormat of [PointFormat.compressed, PointFormat.uncompressed]) {
+    itBench({
+      id: `Serialize and deserialize public key, point format ${pointFormat}`,
+      beforeEach: () => getKeypair(0).publicKey,
+      fn: (publicKey) => {
+        for (let i = 0; i < 1000; i++) {
+          const bytes = publicKey.toBytes(pointFormat);
+          bls.PublicKey.fromBytes(bytes);
+        }
+      },
+      runsFactor: 1000,
     });
   }
 });


### PR DESCRIPTION
**Motivation**

We used uncompressed signature/pubkey when passing through thread boundary because of `_wrapDeserialize` in the past but now I find it's not necessary anymore

**Description**

- Using compressed form of pubkey/signature could reduce data passing through boundary as below:

```
const PUBLIC_KEY_LENGTH_COMPRESSED = 48;
const PUBLIC_KEY_LENGTH_UNCOMPRESSED = 48 * 2;
const SIGNATURE_LENGTH_COMPRESSED = 96;
const SIGNATURE_LENGTH_UNCOMPRESSED = 96 * 2;
```


**Tested on md16**

- Forwarded messages are the same, it means most of BLS signatures are valid. Also we have an e2e test to pass signature sets to worker threads
- Attestation validation job time and job wait time are a bit better

<img width="806" alt="Screenshot 2023-07-20 at 09 14 38" src="https://github.com/ChainSafe/lodestar/assets/10568965/43b2fd5a-004e-4e0b-9067-bb0e387c8074">

- vs unstable md16

<img width="868" alt="Screenshot 2023-07-20 at 09 15 28" src="https://github.com/ChainSafe/lodestar/assets/10568965/90b2f65b-a1db-4d6d-a5c2-9b13006043e9">

