### PR TITLE
refactor: update distributed aggregation selection error logs

### DIFF
--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -322,9 +322,7 @@ export class AttestationService {
     this.logger.debug("Submitting partial beacon committee selection proofs", {slot, count: partialSelections.length});
 
     const res = await Promise.race([
-      this.api.validator
-        .submitBeaconCommitteeSelections(partialSelections)
-        .catch((e) => this.logger.error("Error on submitBeaconCommitteeSelections", {slot}, e)),
+      this.api.validator.submitBeaconCommitteeSelections(partialSelections),
       // Exit attestation aggregation flow if there is no response after 1/3 of slot as
       // beacon node would likely not have enough time to prepare an aggregate attestation.
       // Note that the aggregations flow is not explicitly exited but rather will be skipped
@@ -334,7 +332,7 @@ export class AttestationService {
     ]);
 
     if (!res) {
-      throw new Error("submitBeaconCommitteeSelections did not resolve after 1/3 of slot");
+      throw new Error("Failed to receive combined selection proofs before 1/3 of slot");
     }
     ApiError.assert(res, "Error receiving combined selection proofs");
 

--- a/packages/validator/src/services/syncCommittee.ts
+++ b/packages/validator/src/services/syncCommittee.ts
@@ -261,9 +261,7 @@ export class SyncCommitteeService {
     this.logger.debug("Submitting partial sync committee selection proofs", {slot, count: partialSelections.length});
 
     const res = await Promise.race([
-      this.api.validator
-        .submitSyncCommitteeSelections(partialSelections)
-        .catch((e) => this.logger.error("Error on submitSyncCommitteeSelections", {slot}, e)),
+      this.api.validator.submitSyncCommitteeSelections(partialSelections),
       // Exit sync committee contributions flow if there is no response after 2/3 of slot.
       // This is in contrast to attestations aggregations flow which is already exited at 1/3 of the slot
       // because for sync committee is not required to resubscribe to subnets as beacon node will assume
@@ -275,7 +273,7 @@ export class SyncCommitteeService {
     ]);
 
     if (!res) {
-      throw new Error("submitSyncCommitteeSelections did not resolve after 2/3 of slot");
+      throw new Error("Failed to receive combined selection proofs before 2/3 of slot");
     }
     ApiError.assert(res, "Error receiving combined selection proofs");
 


### PR DESCRIPTION
**Motivation**

The error that distributed aggregation selection failed because client did not receive combined selection proofs before certain time in slot happens quite frequently if peers are offline and threshold (3/4) is not fulfilled.

After seeing this error quite a few times I think it should be less technical (not use operation id from spec).

**Description**

- Update error logs if client failed to receive combined selection proofs before x time of slot
- Remove unnecessary catch block, there is no scenario where we would swallow an error here, i.e. an error that is thrown after x time of slot such as timeouts but those are handled as API errors now (see https://github.com/ChainSafe/lodestar/pull/5331)
