### PR TITLE
chore: bump test-utils to 1.9.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -100,6 +100,6 @@
     "@types/inquirer": "^9.0.3",
     "@types/lodash": "^4.14.192",
     "@types/yargs": "^17.0.24",
-    "@lodestar/test-utils": "^1.9.1"
+    "@lodestar/test-utils": "^1.9.2"
   }
 }

--- a/packages/prover/package.json
+++ b/packages/prover/package.json
@@ -82,7 +82,7 @@
     "yargs": "^17.7.1"
   },
   "devDependencies": {
-    "@lodestar/test-utils": "^1.9.1",
+    "@lodestar/test-utils": "^1.9.2",
     "@types/http-proxy": "^1.17.10",
     "@types/yargs": "^17.0.24",
     "axios": "^1.3.4",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lodestar/test-utils",
   "private": true,
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Test utilities reused across other packages",
   "author": "ChainSafe Systems",
   "license": "Apache-2.0",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -61,11 +61,11 @@
     "blockchain"
   ],
   "dependencies": {
-    "@lodestar/utils": "^1.9.1",
+    "@lodestar/utils": "^1.9.2",
     "axios": "^1.3.4",
     "chai": "^4.3.7",
     "mocha": "^10.2.0",
-    "sinon": "^15.0.3"    
+    "sinon": "^15.0.3"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.1",


### PR DESCRIPTION
**Motivation**

- Missed in #5772 

**Description**

- bump test-utils to 1.9.2 to match the rest of the monorepo