### PR TITLE
feat: only dial subnet peers if needed

### DIFF
--- a/packages/beacon-node/src/network/core/metrics.ts
+++ b/packages/beacon-node/src/network/core/metrics.ts
@@ -120,6 +120,11 @@ export function createNetworkCoreMetrics(register: RegistryMetricCreator) {
         help: "Current peers to connect count from discoverPeers requests",
         labelNames: ["type"],
       }),
+      subnetsToConnect: register.gauge<"type">({
+        name: "lodestar_discovery_subnets_to_connect",
+        help: "Current subnets to connect count from discoverPeers requests",
+        labelNames: ["type"],
+      }),
       cachedENRsSize: register.gauge({
         name: "lodestar_discovery_cached_enrs_size",
         help: "Current size of the cachedENRs Set",

--- a/packages/beacon-node/src/network/core/metrics.ts
+++ b/packages/beacon-node/src/network/core/metrics.ts
@@ -115,6 +115,11 @@ export function createNetworkCoreMetrics(register: RegistryMetricCreator) {
         name: "lodestar_discovery_peers_to_connect",
         help: "Current peers to connect count from discoverPeers requests",
       }),
+      subnetPeersToConnect: register.gauge<"type">({
+        name: "lodestar_discovery_subnet_peers_to_connect",
+        help: "Current peers to connect count from discoverPeers requests",
+        labelNames: ["type"],
+      }),
       cachedENRsSize: register.gauge({
         name: "lodestar_discovery_cached_enrs_size",
         help: "Current size of the cachedENRs Set",


### PR DESCRIPTION
**Motivation**

- For now we always dial subnet peers as much as we can, this lead to https://github.com/ChainSafe/lodestar/issues/5741
- This is because:
  - Most of the time, we have enough subnet peers very quickly (see `Peer requests to discovery` metrics)
  - But we always got ENRs very frequently (because node wants to connect to "maxPeers" so it issue FIND_NODES request frequently) and if the retuned ENRs have the subnets we want, we still connect to it
    - In the case of sync committee subscription, we usually have up to 50 long lived subnets per peer and most of them are outbound peers
  
**Description**

- Only connect to subnet peers if needed by adding "peersToConnect" to "subnetRequests"
- Based on the current metrics, this should help us have around 10 long lived subnets per peer instead of 50 like in the case of sync committee

Closes #5741