### PR TITLE
fix: gracefully terminate connections when closing http server

### DIFF
--- a/packages/beacon-node/src/api/rest/activeSockets.ts
+++ b/packages/beacon-node/src/api/rest/activeSockets.ts
@@ -78,8 +78,8 @@ export class HttpActiveSocketsTracker {
         // Immediately destroy sockets without an attached HTTP request
         this.destroySocket(socket);
       } else if (serverResponse.getHeader("Content-Type") === "text/event-stream") {
-        // eventstream API will never stop and must be forcefully terminated
-        this.destroySocket(socket);
+        // eventstream API will never stop and must be forcefully closed
+        socket.end();
       } else if (!serverResponse.headersSent) {
         // Inform existing keep-alive connections that they will be closed after the current response
         serverResponse.setHeader("Connection", "close");

--- a/packages/beacon-node/src/api/rest/activeSockets.ts
+++ b/packages/beacon-node/src/api/rest/activeSockets.ts
@@ -69,12 +69,12 @@ export class HttpActiveSocketsTracker {
 
     for (const socket of this.sockets) {
       // This is the HTTP CONNECT request socket.
-      // @ts-expect-error Unclear if I am using wrong type or how else this should be handled.
+      // @ts-expect-error HTTP sockets have reference to server
       if (!(socket.server instanceof http.Server)) {
         continue;
       }
 
-      // @ts-expect-error Unclear if I am using wrong type or how else this should be handled.
+      // @ts-expect-error Internal property but only way to access response of socket
       const res = socket._httpMessage as http.ServerResponse | undefined;
 
       if (res == null) {

--- a/packages/beacon-node/src/api/rest/activeSockets.ts
+++ b/packages/beacon-node/src/api/rest/activeSockets.ts
@@ -56,6 +56,9 @@ export class HttpActiveSocketsTracker {
     if (this.terminating) return;
     this.terminating = true;
 
+    // Can speed up shutdown by a few milliseconds
+    this.server.closeIdleConnections();
+
     // Inform new incoming requests on keep-alive connections that
     // the connection will be closed after the current response
     this.server.on("request", (_req, res) => {

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -153,12 +153,14 @@ export class RestApiServer {
 
     // In NodeJS land calling close() only causes new connections to be rejected.
     // Existing connections can prevent .close() from resolving for potentially forever.
-    // In Lodestar case when the BeaconNode wants to close we will just abruptly terminate
-    // all existing connections for a fast shutdown.
+    // In Lodestar case when the BeaconNode wants to close we will attempt to gracefully
+    // close all existing connections but forcefully terminate after timeout for a fast shutdown.
     // Inspired by https://github.com/gajus/http-terminator/
-    this.activeSockets.destroyAll();
+    await this.activeSockets.terminate();
 
     await this.server.close();
+
+    this.logger.debug("REST API server closed");
   }
 
   /** For child classes to override */

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -29,11 +29,6 @@ export type RestApiServerMetrics = SocketMetrics & {
   errors: IGauge<"operationId">;
 };
 
-enum Status {
-  Listening = "listening",
-  Closed = "closed",
-}
-
 /**
  * REST API powered by `fastify` server.
  */
@@ -41,8 +36,6 @@ export class RestApiServer {
   protected readonly server: FastifyInstance;
   protected readonly logger: Logger;
   private readonly activeSockets: HttpActiveSocketsTracker;
-
-  private status = Status.Closed;
 
   constructor(
     private readonly opts: RestApiServerOpts,
@@ -106,8 +99,7 @@ export class RestApiServer {
     server.addHook("onError", async (req, _res, err) => {
       // Don't log ErrorAborted errors, they happen on node shutdown and are not useful
       // Don't log NodeISSyncing errors, they happen very frequently while syncing and the validator polls duties
-      // Don't log eventstream aborted errors if server instance is being closed on node shutdown
-      if (err instanceof ErrorAborted || err instanceof NodeIsSyncing || this.status === Status.Closed) return;
+      if (err instanceof ErrorAborted || err instanceof NodeIsSyncing) return;
 
       const {operationId} = req.routeConfig as RouteConfig;
 
@@ -127,9 +119,6 @@ export class RestApiServer {
    * Start the REST API server.
    */
   async listen(): Promise<void> {
-    if (this.status === Status.Listening) return;
-    this.status = Status.Listening;
-
     try {
       const host = this.opts.address;
       const address = await this.server.listen({port: this.opts.port, host});
@@ -139,7 +128,6 @@ export class RestApiServer {
       }
     } catch (e) {
       this.logger.error("Error starting REST api server", this.opts, e as Error);
-      this.status = Status.Closed;
       throw e;
     }
   }
@@ -148,9 +136,6 @@ export class RestApiServer {
    * Close the server instance and terminate all existing connections.
    */
   async close(): Promise<void> {
-    if (this.status === Status.Closed) return;
-    this.status = Status.Closed;
-
     // In NodeJS land calling close() only causes new connections to be rejected.
     // Existing connections can prevent .close() from resolving for potentially forever.
     // In Lodestar case when the BeaconNode wants to close we will attempt to gracefully

--- a/packages/beacon-node/src/metrics/server/http.ts
+++ b/packages/beacon-node/src/metrics/server/http.ts
@@ -90,10 +90,10 @@ export async function getHttpMetricsServer(
     async close(): Promise<void> {
       // In NodeJS land calling close() only causes new connections to be rejected.
       // Existing connections can prevent .close() from resolving for potentially forever.
-      // In Lodestar case when the BeaconNode wants to close we will just abruptly terminate
-      // all existing connections for a fast shutdown.
+      // In Lodestar case when the BeaconNode wants to close we will attempt to gracefully
+      // close all existing connections but forcefully terminate after timeout for a fast shutdown.
       // Inspired by https://github.com/gajus/http-terminator/
-      activeSockets.destroyAll();
+      await activeSockets.terminate();
 
       await new Promise<void>((resolve, reject) => {
         server.close((err) => {
@@ -101,6 +101,8 @@ export async function getHttpMetricsServer(
           else resolve();
         });
       });
+
+      logger.debug("Metrics HTTP server closed");
     },
   };
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -16,3 +16,4 @@ export * from "./timeout.js";
 export {RecursivePartial, bnToNum} from "./types.js";
 export * from "./verifyMerkleBranch.js";
 export * from "./promise.js";
+export * from "./waitFor.js";

--- a/packages/utils/src/waitFor.ts
+++ b/packages/utils/src/waitFor.ts
@@ -1,0 +1,55 @@
+import {ErrorAborted, TimeoutError} from "./errors.js";
+
+export type WaitForOpts = {
+  /** Time in milliseconds between checking condition */
+  interval?: number;
+  /** Time in milliseconds to wait before throwing TimeoutError */
+  timeout?: number;
+  /** Signal to abort waiting for condition by throwing ErrorAborted */
+  signal?: AbortSignal;
+};
+
+/**
+ * Wait for a condition to be true
+ *
+ * Simplified and abortable implementation of https://github.com/sindresorhus/p-wait-for
+ */
+export function waitFor(condition: () => boolean, opts: WaitForOpts = {}): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const {interval = 10, timeout = Infinity, signal} = opts;
+
+    if (signal && signal.aborted) {
+      return reject(new ErrorAborted());
+    }
+
+    if (condition()) {
+      return resolve();
+    }
+
+    let onDone: () => void = () => {};
+
+    const timeoutId = setTimeout(() => {
+      onDone();
+      reject(new TimeoutError());
+    }, timeout);
+
+    const intervalId = setInterval(() => {
+      if (condition()) {
+        onDone();
+        resolve();
+      }
+    }, interval);
+
+    const onAbort = (): void => {
+      onDone();
+      reject(new ErrorAborted());
+    };
+    if (signal) signal.addEventListener("abort", onAbort);
+
+    onDone = () => {
+      clearTimeout(timeoutId);
+      clearInterval(intervalId);
+      if (signal) signal.removeEventListener("abort", onAbort);
+    };
+  });
+}

--- a/packages/utils/src/waitFor.ts
+++ b/packages/utils/src/waitFor.ts
@@ -5,20 +5,18 @@ export type WaitForOpts = {
   interval?: number;
   /** Time in milliseconds to wait before throwing TimeoutError */
   timeout?: number;
-  /** Signal to abort waiting for condition by throwing ErrorAborted */
+  /** Abort signal to stop waiting for condition by throwing ErrorAborted */
   signal?: AbortSignal;
 };
 
 /**
  * Wait for a condition to be true
- *
- * Simplified and abortable implementation of https://github.com/sindresorhus/p-wait-for
  */
 export function waitFor(condition: () => boolean, opts: WaitForOpts = {}): Promise<void> {
   return new Promise((resolve, reject) => {
     const {interval = 10, timeout = Infinity, signal} = opts;
 
-    if (signal && signal.aborted) {
+    if (signal?.aborted) {
       return reject(new ErrorAborted());
     }
 

--- a/packages/utils/test/unit/waitFor.test.ts
+++ b/packages/utils/test/unit/waitFor.test.ts
@@ -1,0 +1,37 @@
+import "../setup.js";
+import {expect} from "chai";
+import {waitFor} from "../../src/waitFor.js";
+import {ErrorAborted, TimeoutError} from "../../src/errors.js";
+
+describe("waitFor", () => {
+  const interval = 10;
+  const timeout = 20;
+
+  it("Should resolve if condition is already true", async () => {
+    await expect(waitFor(() => true, {interval, timeout})).to.be.fulfilled;
+  });
+
+  it("Should resolve if condition becomes true within timeout", async () => {
+    let condition = false;
+    setTimeout(() => {
+      condition = true;
+    }, interval);
+    await waitFor(() => condition, {interval, timeout});
+  });
+
+  it("Should reject with TimeoutError if condition does not become true within timeout", async () => {
+    await expect(waitFor(() => false, {interval, timeout})).to.be.rejectedWith(TimeoutError);
+  });
+
+  it("Should reject with ErrorAborted if aborted before condition becomes true", async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), interval);
+    await expect(waitFor(() => false, {interval, timeout, signal: controller.signal})).to.be.rejectedWith(ErrorAborted);
+  });
+
+  it("Should reject with ErrorAborted if signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(waitFor(() => true, {interval, timeout, signal: controller.signal})).to.be.rejectedWith(ErrorAborted);
+  });
+});


### PR DESCRIPTION
**Motivation**

While looking into https://github.com/ChainSafe/lodestar/issues/5783 I noticed that our REST API server is not really "friendly" to clients, it abruptly terminates connections. 

We should give the beacon node some time to complete pending requests and only forcefully close connections if timeout is reached. This improves client experience and prevents potential data corruption if request is writing data.

**Description**

Gracefully close HTTP server by waiting for all connections to drain until timeout
- it immediately destroys all sockets without an attached HTTP request
- it allows graceful timeout to sockets with ongoing HTTP requests
- it informs connections using keep-alive that server is shutting down by setting a `Connection: close` header
- it forcefully terminates all connections after timeout (1 second) is reached

**Further considerations**

It might make sense to close server immediately to stop accepting new connections.

Right now, what happens is that while terminating, new connections are just force closed by destroying the socket.
https://github.com/ChainSafe/lodestar/blob/485a996a1c2244015c40ab0c8f576ad790b79f7a/packages/beacon-node/src/api/rest/activeSockets.ts#L28-L29

This causes `curl: (56) Recv failure: Connection reset by peer` error on the client.

If the server is closed immediately it will cause `curl: (7) Failed to connect to localhost port 9596 after 0 ms: Connection refused` on the client as server stops listening for connections.

The difference is likely insignificant in our case as the shutdown period is really short and the beacon node generally does not receive that many requests per second and in both cases the client will receive an error.

This has been discussed in http-terminator repository already https://github.com/gajus/http-terminator/issues/22, but since our current and now updated implementation follows that of http-terminator closely, I kept the implementation to close server after terminating sockets.