### PR TITLE
fix: eventstream invalid topic error

### DIFF
--- a/packages/api/src/beacon/server/events.ts
+++ b/packages/api/src/beacon/server/events.ts
@@ -1,7 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ErrorAborted} from "@lodestar/utils";
-import {Api, ReqTypes, routesData, getEventSerdes} from "../routes/events.js";
-import {ServerRoutes} from "../../utils/server/index.js";
+import {Api, ReqTypes, routesData, getEventSerdes, eventTypes} from "../routes/events.js";
+import {ApiError, ServerRoutes} from "../../utils/server/index.js";
 import {ServerApi} from "../../interfaces.js";
 
 export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerRoutes<Api, ReqTypes> {
@@ -15,6 +15,13 @@ export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerR
       id: "eventstream",
 
       handler: async (req, res) => {
+        const validTopics = new Set(Object.values(eventTypes));
+        for (const topic of req.query.topics) {
+          if (!validTopics.has(topic)) {
+            throw new ApiError(400, `Invalid topic: ${topic}`);
+          }
+        }
+
         const controller = new AbortController();
 
         try {

--- a/packages/api/src/beacon/server/index.ts
+++ b/packages/api/src/beacon/server/index.ts
@@ -1,6 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {Api} from "../routes/index.js";
-import {ServerInstance, ServerRoute, RouteConfig, registerRoute} from "../../utils/server/index.js";
+import {ApiError, ServerInstance, ServerRoute, RouteConfig, registerRoute} from "../../utils/server/index.js";
 
 import {ServerApi} from "../../interfaces.js";
 import * as beacon from "./beacon.js";
@@ -12,6 +12,9 @@ import * as lodestar from "./lodestar.js";
 import * as node from "./node.js";
 import * as proof from "./proof.js";
 import * as validator from "./validator.js";
+
+// Re-export for usage in beacon-node
+export {ApiError};
 
 // Re-export for convenience
 export {RouteConfig};

--- a/packages/api/src/utils/server/errors.ts
+++ b/packages/api/src/utils/server/errors.ts
@@ -1,0 +1,9 @@
+import {HttpErrorCodes} from "../client/httpStatusCode.js";
+
+export class ApiError extends Error {
+  statusCode: HttpErrorCodes;
+  constructor(statusCode: HttpErrorCodes, message?: string) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}

--- a/packages/api/src/utils/server/index.ts
+++ b/packages/api/src/utils/server/index.ts
@@ -1,3 +1,4 @@
 export * from "./genericJsonServer.js";
 export * from "./registerRoute.js";
+export * from "./errors.js";
 export * from "./types.js";

--- a/packages/beacon-node/src/api/impl/errors.ts
+++ b/packages/beacon-node/src/api/impl/errors.ts
@@ -1,12 +1,6 @@
-import {HttpErrorCodes} from "@lodestar/api";
+import {ApiError} from "@lodestar/api/beacon/server";
 
-export class ApiError extends Error {
-  statusCode: HttpErrorCodes;
-  constructor(statusCode: HttpErrorCodes, message?: string) {
-    super(message);
-    this.statusCode = statusCode;
-  }
-}
+export {ApiError};
 
 export class StateNotFound extends ApiError {
   constructor() {

--- a/packages/beacon-node/src/api/impl/events/index.ts
+++ b/packages/beacon-node/src/api/impl/events/index.ts
@@ -1,19 +1,12 @@
 import {routes, ServerApi} from "@lodestar/api";
 import {ApiModules} from "../types.js";
-import {ApiError} from "../errors.js";
 
 export function getEventsApi({chain}: Pick<ApiModules, "chain" | "config">): ServerApi<routes.events.Api> {
-  const validTopics = new Set(Object.values(routes.events.eventTypes));
-
   return {
     async eventstream(topics, signal, onEvent) {
       const onAbortFns: (() => void)[] = [];
 
       for (const topic of topics) {
-        if (!validTopics.has(topic)) {
-          throw new ApiError(400, `Unknown topic ${topic}`);
-        }
-
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const handler = (data: any): void => {
           // TODO: What happens if this handler throws? Does it break the other chain.emitter listeners?


### PR DESCRIPTION
**Motivation**

Eventstream API does not respond with 400 error if invalid topic is provided, it keeps connection open without sending any data.

**Description**

- move topic validation to request handler
- define api error thrown on server in @lodestar/api to make it usable in handlers
- update error message based on spec example, https://ethereum.github.io/beacon-APIs/#/Events/eventstream

Can be easily tested by sending request with invalid topic
```sh
> curl -N http://localhost:9596/eth/v1/events?topics=test
{"statusCode":400,"error":"Bad Request","message":"Invalid topic: test"}
```

We also log a warning now on server if a client sents an eventstream request with an invalid topic
```
Eph 0/1 2.989[rest]             warn: Req req-n eventstream failed reason=Invalid topic: test
```