### PR TITLE
test(db): add check for gdu vs du

### DIFF
--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -1,4 +1,5 @@
 import {execSync} from "node:child_process";
+import os from "node:os";
 import {expect} from "chai";
 import leveldown from "leveldown";
 import all from "it-all";
@@ -135,9 +136,23 @@ describe("LevelDB controller", () => {
     expect(approxSize).gt(0, "approximateSize return not > 0");
   });
 
+  function getDuCommand(): string {
+    if (os.platform() === "darwin") {
+      try {
+        const res = execSync("gdu --help", {encoding: "utf8"});
+        if (res?.startsWith("Usage: gdu ")) {
+          return "gdu";
+        }
+      } catch {
+        /* no-op */
+      }
+    }
+    return "du";
+  }
+
   function getDbSize(): number {
     // 116	./.__testdb
-    const res = execSync(`du -bs ${dbLocation}`, {encoding: "utf8"});
+    const res = execSync(`${getDuCommand()} -bs ${dbLocation}`, {encoding: "utf8"});
     const match = res.match(/^(\d+)/);
     if (!match) throw Error(`Unknown du response \n${res}`);
     return parseInt(match[1]);


### PR DESCRIPTION
**Motivation**

I reinstalled my osX and a new error popped up.  The `du` command does not have the `-b` flag in the osx version of `du`.  Required me to install `du` from the GNU `coreutils`.  `brew install du` prefixes the commands with `g` so the command name is `gdu`.

I did not have this aliased nor on my path before reinstalling.  Never ran into the error before updating/reinstalling the os so it may be something new but am not 100% certain.  Installed version `Ventura 13.4.1 (22F82)`.  

I found a stack overflow page that explained how to alias all the commands but a few other pages I found said there could be system instability from fully aliasing because existing scripts can potentially fail if expecting the osx versions.

[OSX man page for `du`](https://ss64.com/osx/du.html)
[GNU man page for `du`](https://www.man7.org/linux/man-pages/man1/du.1.html)
[SO page for issues with aliasing commands](https://apple.stackexchange.com/questions/69223/how-to-replace-mac-os-x-utilities-with-gnu-core-utilities)

**Description**

Checks for existence of `gdu` command on `darwin` platform and defaults back to `du` if `gdu` is not found.

**Steps to test or reproduce**

On mac with `coreutils` installed via `homebrew`:

```sh
cd packages/db
yarn test:unit
```