### PR TITLE
fix: eventstream listen on socket for close/end event

### DIFF
--- a/packages/api/src/beacon/server/events.ts
+++ b/packages/api/src/beacon/server/events.ts
@@ -48,8 +48,8 @@ export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerR
             // In that case the BeaconNode class will call server.close() and end this connection.
 
             // The client may disconnect and we need to clean the subscriptions.
-            req.raw.once("close", () => resolve());
-            req.raw.once("end", () => resolve());
+            req.socket.once("close", () => resolve());
+            req.socket.once("end", () => resolve());
             req.raw.once("error", (err) => {
               if ((err as unknown as {code: string}).code === "ECONNRESET") {
                 return reject(new ErrorAborted());

--- a/packages/api/src/beacon/server/events.ts
+++ b/packages/api/src/beacon/server/events.ts
@@ -18,12 +18,6 @@ export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerR
         const controller = new AbortController();
 
         try {
-          // Prevent Fastify from sending the response, this is recommended before writing to the `.raw` stream
-          // and avoids "Cannot set headers after they are sent to the client" errors during shutdown or client aborts.
-          // See https://github.com/fastify/fastify/issues/3979, https://github.com/ChainSafe/lodestar/issues/5783
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          res.hijack();
-
           // Add injected headers from other plugins. This is required for fastify-cors for example
           // From: https://github.com/NodeFactoryIo/fastify-sse-v2/blob/b1686a979fbf655fb9936c0560294a0c094734d4/src/plugin.ts
           Object.entries(res.getHeaders()).forEach(([key, value]) => {


### PR DESCRIPTION
**Motivation**

Previous PR https://github.com/ChainSafe/lodestar/pull/5784 resolved issue https://github.com/ChainSafe/lodestar/issues/5783 but "hijacking" the response (`res.hijack()`) should not be necessary and it is hard to understand all side-effects this has even though as far as I understand in our case it does not have any (https://github.com/ChainSafe/lodestar/pull/5784#issuecomment-1646575227).

I noticed, that in fastify-sse there is a note about removing event listeners (https://github.com/NodeFactoryIo/fastify-sse-v2#note) and there it adds a listener to socket, not the stream (thanks @mpetrunic for the pointers).

I looked into the timings of this and it seems like socket end event is emitted before stream is closed causing [event listeners to be aborted](https://github.com/ChainSafe/lodestar/blob/2b22d0a9ea546a7f11763725ec0b34ee321d5964/packages/api/src/beacon/server/events.ts#L63) earlier. This avoids a race condition trying to [send an event](https://github.com/ChainSafe/lodestar/blob/2b22d0a9ea546a7f11763725ec0b34ee321d5964/packages/beacon-node/src/api/impl/events/index.ts#L22) even though stream is already closed causing the header already sent error (https://github.com/ChainSafe/lodestar/issues/5783).

**Description**

- Removes previously added `res.hijack()`
- Listen on socket for close/end event instead of stream.

**Note:** It might be sufficient to just listen to socket end event but hard to test all edge cases.
