### PR TITLE
chore: remove redundant eventstream error listener

### DIFF
--- a/packages/api/src/beacon/server/events.ts
+++ b/packages/api/src/beacon/server/events.ts
@@ -1,5 +1,4 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ErrorAborted} from "@lodestar/utils";
 import {Api, ReqTypes, routesData, getEventSerdes} from "../routes/events.js";
 import {ServerRoutes} from "../../utils/server/index.js";
 import {ServerApi} from "../../interfaces.js";
@@ -50,12 +49,6 @@ export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerR
             // The client may disconnect and we need to clean the subscriptions.
             req.socket.once("close", () => resolve());
             req.socket.once("end", () => resolve());
-            req.raw.once("error", (err) => {
-              if ((err as unknown as {code: string}).code === "ECONNRESET") {
-                return reject(new ErrorAborted());
-              }
-              return reject(err);
-            });
           });
 
           // api.eventstream will never stop, so no need to ever call `res.raw.end();`


### PR DESCRIPTION
**Motivation**

Noticed that after changes done in https://github.com/ChainSafe/lodestar/pull/5795 the error listener will always be called after socket close listener. This means that calling reject will not do anything as promise is already resolved.

As per my understanding, it was redundant before as well because the only error it would report is `ECONNRESET` if client disconnects  which we don't want to log on the server (see previous PR https://github.com/ChainSafe/lodestar/pull/5722).

These two PRs on node further indicate that the only error event that is emitted is due to client disconnect (`ECONNRESET`)
- https://github.com/nodejs/node/pull/33172
- https://github.com/nodejs/node/pull/28677


If there are actual error trying to write an event to the stream on the server, it would be caught by this
https://github.com/ChainSafe/lodestar/blob/7f19831f0fc7d807003e1b6a08feb42d3234e971/packages/api/src/beacon/server/events.ts#L42-L44

The server is not really concerned about anything else than writing data, if there is an error it must be detected by the client which is what we are doing already.

Invalid json data sent would be detected here
https://github.com/ChainSafe/lodestar/blob/ec0a60fce243c37406e6469e2741eba4fca9b6c2/packages/api/src/beacon/client/events.ts#L25-L28

and any other errors are caught here and reported here
https://github.com/ChainSafe/lodestar/blob/ec0a60fce243c37406e6469e2741eba4fca9b6c2/packages/api/src/beacon/client/events.ts#L34-L42


**Description**

Remove redundant eventstream error listener on the server.
