### PR TITLE
chore: downgrade cross-fetch to v3

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -75,7 +75,7 @@
     "@lodestar/params": "^1.9.2",
     "@lodestar/types": "^1.9.2",
     "@lodestar/utils": "^1.9.2",
-    "cross-fetch": "^4.0.0",
+    "cross-fetch": "^3.1.8",
     "eventsource": "^2.0.2",
     "qs": "^6.11.1"
   },

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -136,7 +136,7 @@
     "@types/datastore-level": "^3.0.0",
     "buffer-xor": "^2.0.2",
     "c-kzg": "^2.1.0",
-    "cross-fetch": "^4.0.0",
+    "cross-fetch": "^3.1.8",
     "datastore-core": "^9.1.1",
     "datastore-level": "^10.1.1",
     "deepmerge": "^4.3.1",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -73,7 +73,7 @@
     "@lodestar/state-transition": "^1.9.2",
     "@lodestar/types": "^1.9.2",
     "@lodestar/utils": "^1.9.2",
-    "cross-fetch": "^4.0.0",
+    "cross-fetch": "^3.1.8",
     "mitt": "^3.0.0",
     "strict-event-emitter-types": "^2.0.0"
   },

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -58,7 +58,7 @@
     "@lodestar/types": "^1.9.2",
     "@lodestar/utils": "^1.9.2",
     "bigint-buffer": "^1.1.5",
-    "cross-fetch": "^4.0.0",
+    "cross-fetch": "^3.1.8",
     "strict-event-emitter-types": "^2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6154,17 +6154,10 @@ create-require@^1.1.0:
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^3.1.4:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
-  dependencies:
-    node-fetch "2.6.7"
-
-cross-fetch@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
-  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
+cross-fetch@^3.1.4, cross-fetch@^3.1.8:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
   dependencies:
     node-fetch "^2.6.12"
 


### PR DESCRIPTION
**Motivation**

cross-fetch v4 causes browser issues

```
TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
```

and right now seems to be relatively low usage compared to v3, it is better to delay the update for a while.

**Description**

- Downgrade cross-fetch to 3.1.8