### PR TITLE
feat: only subscribe to short lived subnets 2 slots in advanced

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -603,7 +603,7 @@ export function getValidatorApi({
       metrics?.production.producedAggregateParticipants.observe(aggregate.aggregationBits.getTrueBitIndexes().length);
 
       return {
-        data: chain.attestationPool.getAggregate(slot, attestationDataRoot),
+        data: aggregate,
       };
     },
 

--- a/packages/beacon-node/test/unit/network/subnets/dllAttnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/dllAttnetsService.test.ts
@@ -124,6 +124,10 @@ describe("DLLAttnetsService", () => {
       isAggregator: true,
     };
     service.addCommitteeSubscriptions([subscription]);
+    // it does not subscribe immediately
+    expect(gossipStub.subscribeTopic.callCount).to.be.equal(SUBNETS_PER_NODE);
+    sandbox.clock.tick(config.SECONDS_PER_SLOT * (subscription.slot - 2) * 1000);
+    // then subscribe 3 slots before dutied slot
     expect(gossipStub.subscribeTopic.callCount).to.be.equal(SUBNETS_PER_NODE + 1);
     // then unsubscribe after the expiration
     sandbox.clock.tick(config.SECONDS_PER_SLOT * (subscription.slot + 1) * 1000);

--- a/packages/beacon-node/test/unit/network/subnets/dllAttnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/dllAttnetsService.test.ts
@@ -127,7 +127,7 @@ describe("DLLAttnetsService", () => {
     // it does not subscribe immediately
     expect(gossipStub.subscribeTopic.callCount).to.be.equal(SUBNETS_PER_NODE);
     sandbox.clock.tick(config.SECONDS_PER_SLOT * (subscription.slot - 2) * 1000);
-    // then subscribe 3 slots before dutied slot
+    // then subscribe 2 slots before dutied slot
     expect(gossipStub.subscribeTopic.callCount).to.be.equal(SUBNETS_PER_NODE + 1);
     // then unsubscribe after the expiration
     sandbox.clock.tick(config.SECONDS_PER_SLOT * (subscription.slot + 1) * 1000);


### PR DESCRIPTION
**Motivation**

- Right now if we have aggregator duty at epoch `n` we'll subscribe at the start of epoch `n-1` which is a waste of cpu and bandwidth

**Description**

- We still search for subnet peers at the start of epoch `n - 1`, that makes topic peers available, so it does not take time to get stable mesh peers
- Subscribe to dutied subnet 2 slots before dutied slot
- Use the current `aggregatorSlotSubnet` map, check it per clock slot to subscribe

Closes #5757

**Test**

- The produced aggregate has same number of participants on all nodes, for example `1v`

<img width="1290" alt="Screenshot 2023-07-27 at 14 48 39" src="https://github.com/ChainSafe/lodestar/assets/10568965/1c37aa8f-29c5-47d1-a3a0-419e9c1cd8d5">

- vs `unstable`

<img width="1299" alt="Screenshot 2023-07-27 at 14 49 13" src="https://github.com/ChainSafe/lodestar/assets/10568965/d90669f5-d6b8-45d1-8e90-87a7df4c95b5">

- For short lived subnets, we subscribed in very short period

<img width="1290" alt="Screenshot 2023-07-27 at 14 50 55" src="https://github.com/ChainSafe/lodestar/assets/10568965/550d1b09-71ff-4b2c-9bb4-277ccebed175">

- vs `unstable`

<img width="1316" alt="Screenshot 2023-07-27 at 14 51 20" src="https://github.com/ChainSafe/lodestar/assets/10568965/daf8f865-bbd5-47bb-bd5a-4eb3d6f22b0e">

- average number of mesh peers are good, this is on `1v` node

<img width="1301" alt="Screenshot 2023-07-27 at 14 57 54" src="https://github.com/ChainSafe/lodestar/assets/10568965/8ba5d63c-d472-4d64-b1f2-fbd04c8eee2a">

