### PR TITLE
chore: downgrade docker nodejs to 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 # --platform=$BUILDPLATFORM is used build javascript source with host arch
 # Otherwise TS builds on emulated archs and can be extremely slow (+1h)
-FROM --platform=${BUILDPLATFORM:-amd64} node:20-alpine as build_src
+FROM --platform=${BUILDPLATFORM:-amd64} node:18-alpine as build_src
 ARG COMMIT
 WORKDIR /usr/app
 RUN apk update && apk add --no-cache g++ make python3 && rm -rf /var/cache/apk/*
@@ -21,7 +21,7 @@ RUN cd packages/cli && GIT_COMMIT=${COMMIT} yarn write-git-data
 
 # Copy built src + node_modules to build native packages for archs different than host.
 # Note: This step is redundant for the host arch
-FROM node:20-alpine as build_deps
+FROM node:18-alpine as build_deps
 WORKDIR /usr/app
 RUN apk update && apk add --no-cache g++ make python3 && rm -rf /var/cache/apk/*
 
@@ -35,7 +35,7 @@ RUN cd node_modules/classic-level && yarn rebuild
 
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)
-FROM node:20-alpine
+FROM node:18-alpine
 WORKDIR /usr/app
 COPY --from=build_deps /usr/app .
 


### PR DESCRIPTION
**Motivation**

We're still facing problems related to node-fetch/cross-fetch/native fetch in node 20.

**Description**

Downgrade docker nodejs version backto 18