### PR TITLE
chore: format inputs on all dashboards to reduce diff

### DIFF
--- a/dashboards/lodestar_block_processor.json
+++ b/dashboards/lodestar_block_processor.json
@@ -1,19 +1,19 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
-      "type": "datasource",
-      "label": "Prometheus",
       "description": "",
+      "label": "Prometheus",
+      "name": "DS_PROMETHEUS",
       "pluginId": "prometheus",
-      "pluginName": "Prometheus"
+      "pluginName": "Prometheus",
+      "type": "datasource"
     },
     {
+      "description": "",
+      "label": "Beacon node job name",
       "name": "VAR_BEACON_JOB",
       "type": "constant",
-      "label": "Beacon node job name",
-      "value": "beacon",
-      "description": ""
+      "value": "beacon"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_block_production.json
+++ b/dashboards/lodestar_block_production.json
@@ -1,12 +1,12 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
-      "type": "datasource",
-      "label": "Prometheus",
       "description": "",
+      "label": "Prometheus",
+      "name": "DS_PROMETHEUS",
       "pluginId": "prometheus",
-      "pluginName": "Prometheus"
+      "pluginName": "Prometheus",
+      "type": "datasource"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_debug_gossipsub.json
+++ b/dashboards/lodestar_debug_gossipsub.json
@@ -1,12 +1,12 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
-      "type": "datasource",
-      "label": "Prometheus",
       "description": "",
+      "label": "Prometheus",
+      "name": "DS_PROMETHEUS",
       "pluginId": "prometheus",
-      "pluginName": "Prometheus"
+      "pluginName": "Prometheus",
+      "type": "datasource"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_validator_monitor.json
+++ b/dashboards/lodestar_validator_monitor.json
@@ -1,12 +1,12 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
-      "type": "datasource",
-      "label": "Prometheus",
       "description": "",
+      "label": "Prometheus",
+      "name": "DS_PROMETHEUS",
       "pluginId": "prometheus",
-      "pluginName": "Prometheus"
+      "pluginName": "Prometheus",
+      "type": "datasource"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -1,19 +1,19 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
-      "type": "datasource",
-      "label": "Prometheus",
       "description": "",
+      "label": "Prometheus",
+      "name": "DS_PROMETHEUS",
       "pluginId": "prometheus",
-      "pluginName": "Prometheus"
+      "pluginName": "Prometheus",
+      "type": "datasource"
     },
     {
+      "description": "",
+      "label": "Beacon node job name",
       "name": "VAR_BEACON_JOB",
       "type": "constant",
-      "label": "Beacon node job name",
-      "value": "beacon",
-      "description": ""
+      "value": "beacon"
     }
   ],
   "annotations": {


### PR DESCRIPTION
**Motivation**

Right now when running `node scripts/download_dashboards.mjs` it will produce a diff even if no dashboard was modified due to the fact that not all them have the same format of  `__inputs`  variables as defined in the lint script.

https://github.com/ChainSafe/lodestar/blob/487aef9445e4e83531d541054ea0b60ccf11d7e3/scripts/lint-grafana-dashboard.mjs#L99


**Description**

Format inputs on all dashboards to reduce diff when running download script.
