### PR TITLE
feat: enable deterministicLongLivedAttnets by default

### DIFF
--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -36,6 +36,8 @@ export const defaultNetworkOptions: NetworkOptions = {
   gossipsubDHigh: 9,
   // TODO set to false in order to release 1.9.0 in a timely manner
   useWorker: false,
+  // subscribe to 2 subnets per node
+  deterministicLongLivedAttnets: true,
   // subscribe 2 slots before aggregator dutied slot to get stable mesh peers as monitored on goerli
   slotsToSubscribeBeforeAggregatorDuty: 2,
 };


### PR DESCRIPTION
**Motivation**

Most of nodes (except for `novc` and `1v`) use significant less resource so we may want to turn this flag on by default sooner than later

**Description**

- Enable `deterministicLongLivedAttnets` flag by default which make nodes subscribe to 2 subnets instead of depending on number of connected validator

- `1k` node

<img width="1581" alt="Screenshot 2023-07-31 at 20 04 06" src="https://github.com/ChainSafe/lodestar/assets/10568965/ef282302-dfa9-4c8b-88c3-b2f6c913a6cc">

- `64 validator` node
<img width="1583" alt="Screenshot 2023-07-31 at 20 05 10" src="https://github.com/ChainSafe/lodestar/assets/10568965/441b0e5e-ba0a-400c-bf41-593c848c88e1">

- `16 validator` node
<img width="1592" alt="Screenshot 2023-07-31 at 20 06 11" src="https://github.com/ChainSafe/lodestar/assets/10568965/81bf28b2-6ae2-4b06-8a5b-c05391bb4ac2">

- `1 validator` node uses a bit more resource
<img width="1586" alt="Screenshot 2023-07-31 at 20 06 55" src="https://github.com/ChainSafe/lodestar/assets/10568965/78dcdd3d-0ab7-4697-bb01-b4e6dd7b8ce5">
