### PR TITLE
chore: add peer discovery metrics to grafana

### DIFF
--- a/dashboards/lodestar_networking.json
+++ b/dashboards/lodestar_networking.json
@@ -770,6 +770,246 @@
     },
     {
       "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 608,
+      "panels": [],
+      "title": "Network Worker",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Async time to send a message across the worker/parent port",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 23,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "id": 148,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(\n  sum(rate(\n    lodestar_network_worker_wire_events_on_worker_thread_latency_sum[$rate_interval]\n  )) \n  +\n  sum(rate(\n    lodestar_network_worker_wire_events_on_main_thread_latency_sum[$rate_interval]\n  ))\n)\n/\n(\n  sum(rate(\n    lodestar_network_worker_wire_events_on_worker_thread_latency_count[$rate_interval]\n  ))\n  +\n  sum(rate(\n    lodestar_network_worker_wire_events_on_main_thread_latency_count[$rate_interval]\n  ))\n)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Average",
+          "range": true,
+          "refId": "average"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(rate(lodestar_network_worker_wire_events_on_worker_thread_latency_sum[$rate_interval])/rate(lodestar_network_worker_wire_events_on_worker_thread_latency_count[$rate_interval]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Worker to Main",
+          "range": true,
+          "refId": "by eventName"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "avg(rate(lodestar_network_worker_wire_events_on_main_thread_latency_sum[$rate_interval])/rate(lodestar_network_worker_wire_events_on_main_thread_latency_count[$rate_interval]))",
+          "hide": false,
+          "legendFormat": "Main to Worker",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Network Worker Message  Latency - Main to Worker",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Async time to send a message across the worker/parent port",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 23,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "id": 609,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.4.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "avg(rate(lodestar_network_worker_wire_events_on_main_thread_latency_sum[$rate_interval])/rate(lodestar_network_worker_wire_events_on_main_thread_latency_count[$rate_interval]))",
+          "hide": true,
+          "interval": "",
+          "legendFormat": "Average to Main",
+          "range": true,
+          "refId": "average"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(lodestar_network_worker_wire_events_on_main_thread_latency_sum[$rate_interval])/rate(lodestar_network_worker_wire_events_on_main_thread_latency_count[$rate_interval])",
+          "interval": "",
+          "legendFormat": "{{eventName}}",
+          "range": true,
+          "refId": "by eventName"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(lodestar_network_worker_wire_events_on_worker_thread_latency_sum[$rate_interval])/rate(lodestar_network_worker_wire_events_on_worker_thread_latency_count[$rate_interval])",
+          "hide": false,
+          "legendFormat": "{{eventName}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Network Worker Message  Latency - Worker to Main",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
@@ -778,7 +1018,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 37
       },
       "id": 28,
       "panels": [],
@@ -845,7 +1085,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 31
+        "y": 38
       },
       "id": 30,
       "options": {
@@ -930,7 +1170,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 31
+        "y": 38
       },
       "id": 507,
       "options": {
@@ -1018,7 +1258,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 39
+        "y": 46
       },
       "id": 32,
       "options": {
@@ -1085,7 +1325,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 46
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -1215,7 +1455,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 47
+        "y": 54
       },
       "id": 506,
       "options": {
@@ -1283,7 +1523,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 47
+        "y": 54
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -1395,7 +1635,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 55
+        "y": 62
       },
       "heatmap": {},
       "hideZeroBuckets": false,
@@ -1540,7 +1780,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 55
+        "y": 62
       },
       "id": 34,
       "options": {
@@ -1638,7 +1878,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 63
+        "y": 70
       },
       "id": 508,
       "options": {
@@ -1721,7 +1961,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 63
+        "y": 70
       },
       "id": 38,
       "options": {
@@ -1765,7 +2005,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 70
+        "y": 77
       },
       "id": 512,
       "panels": [],
@@ -1802,7 +2042,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 71
+        "y": 78
       },
       "hiddenSeries": false,
       "id": 294,
@@ -1912,7 +2152,7 @@
         "h": 7,
         "w": 6,
         "x": 12,
-        "y": 71
+        "y": 78
       },
       "hiddenSeries": false,
       "id": 296,
@@ -1957,7 +2197,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Requested subnets to query (rate / min)",
+      "title": "Peer Manager - Requested subnets to query (rate / min)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2008,7 +2248,7 @@
         "h": 7,
         "w": 6,
         "x": 18,
-        "y": 71
+        "y": 78
       },
       "hiddenSeries": false,
       "id": 297,
@@ -2053,7 +2293,7 @@
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Requested total peers in subnets (rate / min)",
+      "title": "Peer Manager - Requested total peers in subnets (rate / min)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2084,6 +2324,189 @@
       }
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 85
+      },
+      "id": 611,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "lodestar_discovery_subnet_peers_to_connect",
+          "legendFormat": "{{type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Peer Discovery - Subnet peers to connect",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "attnets"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 85
+      },
+      "id": 613,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "lodestar_discovery_subnets_to_connect",
+          "legendFormat": "{{type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Peer Discovery - Subnets to connect",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
@@ -2093,7 +2516,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 78
+        "y": 93
       },
       "id": 75,
       "panels": [],
@@ -2159,7 +2582,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 79
+        "y": 94
       },
       "id": 77,
       "options": {
@@ -2242,7 +2665,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 79
+        "y": 94
       },
       "id": 80,
       "options": {
@@ -2325,7 +2748,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 87
+        "y": 102
       },
       "id": 79,
       "options": {
@@ -2409,7 +2832,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 87
+        "y": 102
       },
       "id": 78,
       "options": {
@@ -2491,7 +2914,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 95
+        "y": 110
       },
       "id": 88,
       "options": {
@@ -2574,7 +2997,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 96
+        "y": 111
       },
       "id": 82,
       "options": {
@@ -2658,7 +3081,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 105
+        "y": 120
       },
       "id": 333,
       "options": {
@@ -2754,7 +3177,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 106
+        "y": 121
       },
       "id": 244,
       "options": {
@@ -2815,7 +3238,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 114
+        "y": 129
       },
       "id": 524,
       "panels": [],
@@ -2895,7 +3318,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 115
+        "y": 130
       },
       "id": 514,
       "options": {
@@ -2999,7 +3422,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 115
+        "y": 130
       },
       "id": 520,
       "options": {
@@ -3080,7 +3503,7 @@
         "h": 5,
         "w": 12,
         "x": 12,
-        "y": 120
+        "y": 135
       },
       "id": 522,
       "options": {
@@ -3136,7 +3559,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 123
+        "y": 138
       },
       "id": 518,
       "options": {
@@ -3241,7 +3664,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 125
+        "y": 140
       },
       "id": 521,
       "options": {
@@ -3322,7 +3745,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 131
+        "y": 146
       },
       "id": 540,
       "options": {
@@ -3401,7 +3824,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 131
+        "y": 146
       },
       "id": 542,
       "options": {
@@ -3438,7 +3861,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 139
+        "y": 154
       },
       "id": 528,
       "panels": [],
@@ -3518,7 +3941,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 140
+        "y": 155
       },
       "id": 526,
       "options": {
@@ -3615,7 +4038,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 140
+        "y": 155
       },
       "id": 530,
       "options": {
@@ -3719,7 +4142,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 148
+        "y": 163
       },
       "id": 534,
       "options": {
@@ -3810,7 +4233,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 148
+        "y": 163
       },
       "id": 532,
       "options": {
@@ -3906,7 +4329,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 156
+        "y": 171
       },
       "id": 536,
       "options": {
@@ -4014,7 +4437,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 156
+        "y": 171
       },
       "id": 538,
       "options": {
@@ -4063,7 +4486,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 164
+        "y": 179
       },
       "id": 600,
       "panels": [],
@@ -4119,7 +4542,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 165
+        "y": 180
       },
       "id": 602,
       "options": {
@@ -4247,7 +4670,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 165
+        "y": 180
       },
       "id": 604,
       "options": {
@@ -4399,7 +4822,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 173
+        "y": 188
       },
       "id": 603,
       "options": {
@@ -4478,7 +4901,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 173
+        "y": 188
       },
       "id": 601,
       "options": {
@@ -4519,7 +4942,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 181
+        "y": 196
       },
       "id": 188,
       "panels": [],
@@ -4584,7 +5007,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 182
+        "y": 197
       },
       "id": 180,
       "options": {
@@ -4665,7 +5088,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 182
+        "y": 197
       },
       "id": 176,
       "options": {
@@ -4746,7 +5169,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 190
+        "y": 205
       },
       "id": 182,
       "options": {
@@ -4827,7 +5250,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 190
+        "y": 205
       },
       "id": 178,
       "options": {
@@ -4908,7 +5331,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 198
+        "y": 213
       },
       "id": 605,
       "options": {
@@ -4991,7 +5414,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 198
+        "y": 213
       },
       "id": 606,
       "options": {
@@ -5074,7 +5497,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 206
+        "y": 221
       },
       "id": 498,
       "options": {
@@ -5155,7 +5578,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 206
+        "y": 221
       },
       "id": 500,
       "options": {
@@ -5236,7 +5659,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 214
+        "y": 229
       },
       "id": 184,
       "options": {
@@ -5317,7 +5740,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 214
+        "y": 229
       },
       "id": 501,
       "options": {


### PR DESCRIPTION
**Motivation**

To know more about `PeerDiscovery` status

**Description**

- Add new metrics introduced in #5782 to "Peer requests to discovery" panel of networking dashboard
- Also add "Peer Manager" prefix to the other dashboards with similar name to avoid confusion, these metrics come from "PeerManager"

<img width="1594" alt="Screenshot 2023-08-01 at 14 01 35" src="https://github.com/ChainSafe/lodestar/assets/10568965/c73237b3-1a6f-4059-86d6-4888e20784a6">

