### PR TITLE
chore: fix format of input in dashboard lint script

### DIFF
--- a/dashboards/lodestar_networking.json
+++ b/dashboards/lodestar_networking.json
@@ -1,12 +1,12 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
-      "type": "datasource",
-      "label": "Prometheus",
       "description": "",
+      "label": "Prometheus",
+      "name": "DS_PROMETHEUS",
       "pluginId": "prometheus",
-      "pluginName": "Prometheus"
+      "pluginName": "Prometheus",
+      "type": "datasource"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_rest_api.json
+++ b/dashboards/lodestar_rest_api.json
@@ -1,12 +1,12 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
       "description": "",
-      "type": "datasource",
+      "label": "Prometheus",
+      "name": "DS_PROMETHEUS",
       "pluginId": "prometheus",
-      "pluginName": "Prometheus"
+      "pluginName": "Prometheus",
+      "type": "datasource"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -9,18 +9,18 @@
       "type": "datasource"
     },
     {
+      "description": "",
+      "label": "Beacon node job name",
       "name": "VAR_BEACON_JOB",
       "type": "constant",
-      "label": "Beacon node job name",
-      "value": "beacon",
-      "description": ""
+      "value": "beacon"
     },
     {
+      "description": "",
+      "label": "Validator client job name",
       "name": "VAR_VALIDATOR_JOB",
       "type": "constant",
-      "label": "Validator client job name",
-      "value": "validator",
-      "description": ""
+      "value": "validator"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_sync.json
+++ b/dashboards/lodestar_sync.json
@@ -7,13 +7,6 @@
       "pluginId": "prometheus",
       "pluginName": "Prometheus",
       "type": "datasource"
-    },
-    {
-      "description": "",
-      "label": "Beacon node job name",
-      "name": "VAR_BEACON_JOB",
-      "type": "constant",
-      "value": "beacon"
     }
   ],
   "annotations": {

--- a/scripts/lint-grafana-dashboard.mjs
+++ b/scripts/lint-grafana-dashboard.mjs
@@ -98,12 +98,12 @@ export function lintGrafanaDashboard(json) {
   // Always add Prometheus to __inputs
   const inputs = [
     {
-      name: variableNameDatasource,
-      type: "datasource",
-      label: "Prometheus",
       description: "",
+      label: "Prometheus",
+      name: variableNameDatasource,
       pluginId: "prometheus",
       pluginName: "Prometheus",
+      type: "datasource",
     },
   ];
 
@@ -112,19 +112,19 @@ export function lintGrafanaDashboard(json) {
     for (const item of json.templating.list) {
       if (item.query === "${VAR_BEACON_JOB}") {
         inputs.push({
+          description: "",
+          label: "Beacon node job name",
           name: "VAR_BEACON_JOB",
           type: "constant",
-          label: "Beacon node job name",
           value: "beacon",
-          description: "",
         });
       } else if (item.query === "${VAR_VALIDATOR_JOB}") {
         inputs.push({
+          description: "",
+          label: "Validator client job name",
           name: "VAR_VALIDATOR_JOB",
           type: "constant",
-          label: "Validator client job name",
           value: "validator",
-          description: "",
         });
       }
     }


### PR DESCRIPTION
**Motivation**

After further looking into why we get random dashboard diffs on __inputs it looks like downloaded dashboards have __inputs fields and the format that Grafana uses it different from the format we use in the lint script.

Maybe depends on Grafana version or when dashboard was last time updated as it does not happen for all dashboards. Tested it with our grafana instance.

**Description**

- fix format of input in dashboard lint script
- fix inputs on remaining dashboards that were not updated
