### PR TITLE
docs: update instructions on how to contribute to dashboards

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -59,6 +59,7 @@ TOC
 TTD
 TypeScript
 UI
+UID
 UTF
 VM
 Vitalik

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,10 +195,10 @@ Contributors must choose the log level carefully to ensure a consistent experien
 To edit or extend an existing Grafana dashboard with minimal diff:
 
 1. Grab the `.json` dashboard file from current unstable
-2. Import file to Grafana via the web UI at `/dashboard/import`. Give it some temporal name relevant to your work (i.e. the branch name)
+2. Import the file to Grafana via the web UI at `/dashboard/import` without modifying the UID of the dashboard
 3. Visually edit the dashboard
-4. Once done make sure to leave the exact same visual aspect as before: same refresh interval, collapsed rows, etc.
-5. Save the dashboard (CTRL + S)
+4. Once done make sure to leave the exact same visual aspect as before: same refresh interval, time range, etc.
+5. Save the dashboard (CTRL+S)
 6. Run download script, see [below](#using-download-script) on how to use it
 7. Check git diff of updated dashboards, commit, push and open your PR
 


### PR DESCRIPTION
**Motivation**

After using the download script a bit more myself noted that instructions are not that precise for current workflow.

It is no longer required to import a temporal dashboard with different name but more importantly it must be ensured that the UID is not modified, else the download script will not pick up the changes.

It should be pretty clear to existing maintainers that when using our Grafana cloud instance there is no need to import the dashboard, in fact, it is not possible to import it with same UID. Point 1. and 2. are rather meant for (new) contributors that modify dashboards on their own / local Grafana instance.

**Description**

Update instructions on how to contribute to dashboards to better reflect current workflow.
