### PR TITLE
chore: ensureWithinWeakSubjectivityPeriod

### DIFF
--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -1,7 +1,11 @@
 import {ssz} from "@lodestar/types";
 import {createBeaconConfig, BeaconConfig, ChainForkConfig} from "@lodestar/config";
 import {Logger} from "@lodestar/utils";
-import {isWithinWeakSubjectivityPeriod, BeaconStateAllForks} from "@lodestar/state-transition";
+import {
+  isWithinWeakSubjectivityPeriod,
+  ensureWithinWeakSubjectivityPeriod,
+  BeaconStateAllForks,
+} from "@lodestar/state-transition";
 import {
   IBeaconDb,
   IBeaconNodeOptions,
@@ -54,9 +58,7 @@ async function initAndVerifyWeakSubjectivityState(
 
   // Instead of warning user of wss check failure, we throw because user explicity wants to use
   // the checkpoint sync
-  if (!isWithinWeakSubjectivityPeriod(config, anchorState, anchorCheckpoint)) {
-    throw new Error("Fetched weak subjectivity checkpoint not within weak subjectivity period.");
-  }
+  ensureWithinWeakSubjectivityPeriod(config, anchorState, anchorCheckpoint);
 
   anchorState = await initStateFromAnchorState(config, db, logger, anchorState, {
     isWithinWeakSubjectivityPeriod: true,

--- a/packages/state-transition/src/util/weakSubjectivity.ts
+++ b/packages/state-transition/src/util/weakSubjectivity.ts
@@ -138,7 +138,7 @@ export function ensureWithinWeakSubjectivityPeriod(
   const clockEpoch = computeEpochAtSlot(getCurrentSlot(config, wsState.genesisTime));
   if (clockEpoch > wsStateEpoch + wsPeriod) {
     throw new Error(
-      `The downloaded state with epoch ${wsStateEpoch} is not within subjectivity period of ${wsPeriod} from the current epoch ${clockEpoch}. Please please verify your checkpoint source`
+      `The downloaded state with epoch ${wsStateEpoch} is not within subjectivity period of ${wsPeriod} from the current epoch ${clockEpoch}. Please verify your checkpoint source`
     );
   }
 }

--- a/packages/state-transition/src/util/weakSubjectivity.ts
+++ b/packages/state-transition/src/util/weakSubjectivity.ts
@@ -111,6 +111,19 @@ export function isWithinWeakSubjectivityPeriod(
   wsState: BeaconStateAllForks,
   wsCheckpoint: Checkpoint
 ): boolean {
+  try {
+    ensureWithinWeakSubjectivityPeriod(config, wsState, wsCheckpoint);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+export function ensureWithinWeakSubjectivityPeriod(
+  config: BeaconConfig,
+  wsState: BeaconStateAllForks,
+  wsCheckpoint: Checkpoint
+): void {
   const wsStateEpoch = computeCheckpointEpochAtStateSlot(wsState.slot);
   const blockRoot = getLatestBlockRoot(wsState);
   if (!ssz.Root.equals(blockRoot, wsCheckpoint.root)) {
@@ -123,5 +136,9 @@ export function isWithinWeakSubjectivityPeriod(
   }
   const wsPeriod = computeWeakSubjectivityPeriod(config, wsState);
   const clockEpoch = computeEpochAtSlot(getCurrentSlot(config, wsState.genesisTime));
-  return clockEpoch <= wsStateEpoch + wsPeriod;
+  if (clockEpoch > wsStateEpoch + wsPeriod) {
+    throw new Error(
+      `The downloaded state with epoch ${wsStateEpoch} is not within subjectivity period of ${wsPeriod} from the current epoch ${clockEpoch}. Please please verify your checkpoint source`
+    );
+  }
 }


### PR DESCRIPTION
**Motivation**

- More info when the downloaded state from checkpointSyncUrl is not within weak subjectivity peirod

**Description**

- Separate `isWithinWeakSubjectivityPeriod()` function to `isWithinWeakSubjectivityPeriod()` and `ensureWithinWeakSubjectivityPeriod()`, the latter one throws more detailed error