### PR TITLE
ci: fail job to lint grafana dashboards on error

### DIFF
--- a/scripts/validate-grafana-dashboards.sh
+++ b/scripts/validate-grafana-dashboards.sh
@@ -3,6 +3,11 @@
 # This script will mutate the dashboards if anything needs linting
 node scripts/lint-grafana-dashboards.mjs ./dashboards
 
+if [[ $? -ne 0 ]]; then
+  echo 'linting dashboards failed'
+  exit 1
+fi
+
 if [[ $(git diff --stat ./dashboards) != '' ]]; then
   git --no-pager diff
   echo 'dashboards need fixing'


### PR DESCRIPTION
**Motivation**

As noted in https://github.com/ChainSafe/lodestar/pull/5800#discussion_r1280564857, the job to lint grafana dashboards does not fail if `scripts/lint-grafana-dashboard.mjs` throws an error. For example, the job does not fail if the dashboards has collapsed panels.

**Description**

Fail job to lint grafana dashboards on error (exit with code 1)
