### PR TITLE
ci: use stable lighthouse version in sim tests

### DIFF
--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   GETH_DOCKER_IMAGE: ethereum/client-go:v1.11.6
-  LIGHTHOUSE_DOCKER_IMAGE: sigp/lighthouse:latest-amd64-unstable-dev
+  LIGHTHOUSE_DOCKER_IMAGE: sigp/lighthouse:latest-amd64-modern-dev
   NETHERMIND_DOCKER_IMAGE: nethermind/nethermind:1.18.0
 
 jobs:


### PR DESCRIPTION
**Motivation**

Sim tests are failing due to `CodeError: protocol selection failed`, see [failed job](https://github.com/ChainSafe/lodestar/actions/runs/5748720543/job/15582161354#step:8:95).

This issue seems to be related to a PR which was merged yesterday to the Lighthouse unstable branch
- https://github.com/sigp/lighthouse/pull/4431

We should not test against their unstable branch but still want to use a unpinned image to detect incompatibilities with Lighthouse as soon as possible.

**Description**

Use stable lighthouse version in sim tests

- `latest` for the stable branch (latest release)
- `-amd64` for x86_64, e.g. Intel, AMD
- `-modern` for optimized builds (most used build on the network)
- `-dev` for a development build with minimal-spec preset enabled

See [available-docker-images](https://lighthouse-book.sigmaprime.io/docker.html#available-docker-images) for more information about different builds.