### PR TITLE
refactor: fix LVH typo in code

### DIFF
--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -83,8 +83,8 @@ export async function processBlocks(
     // If segmentExecStatus has lvhForkchoice then, the entire segment should be invalid
     // and we need to further propagate
     if (segmentExecStatus.execAborted !== null) {
-      if (segmentExecStatus.invalidSegmentLHV !== undefined) {
-        this.forkChoice.validateLatestHash(segmentExecStatus.invalidSegmentLHV);
+      if (segmentExecStatus.invalidSegmentLVH !== undefined) {
+        this.forkChoice.validateLatestHash(segmentExecStatus.invalidSegmentLVH);
       }
       throw segmentExecStatus.execAborted.execError;
     }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -47,7 +47,7 @@ export type SegmentExecStatus =
       executionStatuses: MaybeValidExecutionStatus[];
       mergeBlockFound: bellatrix.BeaconBlock | null;
     }
-  | {execAborted: ExecAbortType; invalidSegmentLHV?: LVHInvalidResponse; mergeBlockFound: null};
+  | {execAborted: ExecAbortType; invalidSegmentLVH?: LVHInvalidResponse; mergeBlockFound: null};
 
 type VerifyExecutionErrorResponse =
   | {executionStatus: ExecutionStatus.Invalid; lvhResponse: LVHInvalidResponse; execError: BlockError}
@@ -379,7 +379,7 @@ function getSegmentErrorResponse(
   blocks: allForks.SignedBeaconBlock[]
 ): SegmentExecStatus {
   const {executionStatus, lvhResponse, execError} = verifyResponse;
-  let invalidSegmentLHV: LVHInvalidResponse | undefined = undefined;
+  let invalidSegmentLVH: LVHInvalidResponse | undefined = undefined;
 
   if (
     executionStatus === ExecutionStatus.Invalid &&
@@ -407,7 +407,7 @@ function getSegmentErrorResponse(
       parentBlock.executionStatus !== ExecutionStatus.PreMerge &&
       parentBlock.executionPayloadBlockHash !== lvhResponse.latestValidExecHash
     ) {
-      invalidSegmentLHV = {
+      invalidSegmentLVH = {
         executionStatus: ExecutionStatus.Invalid,
         latestValidExecHash: lvhResponse.latestValidExecHash,
         invalidateFromBlockHash: parentBlock.blockRoot,
@@ -415,5 +415,5 @@ function getSegmentErrorResponse(
     }
   }
   const execAborted = {blockIndex, execError};
-  return {execAborted, invalidSegmentLHV} as SegmentExecStatus;
+  return {execAborted, invalidSegmentLVH} as SegmentExecStatus;
 }


### PR DESCRIPTION
fix the typo in `invalidSegmentLVH` where LVH corresponds to latest valid hash

Closes #5844