### PR TITLE
chore: correct error message if state is not within ws period

### DIFF
--- a/packages/state-transition/src/util/weakSubjectivity.ts
+++ b/packages/state-transition/src/util/weakSubjectivity.ts
@@ -138,7 +138,7 @@ export function ensureWithinWeakSubjectivityPeriod(
   const clockEpoch = computeEpochAtSlot(getCurrentSlot(config, wsState.genesisTime));
   if (clockEpoch > wsStateEpoch + wsPeriod) {
     throw new Error(
-      `The downloaded state with epoch ${wsStateEpoch} is not within subjectivity period of ${wsPeriod} from the current epoch ${clockEpoch}. Please verify your checkpoint source`
+      `The downloaded state with epoch ${wsStateEpoch} is not within weak subjectivity period of ${wsPeriod} from the current epoch ${clockEpoch}. Please verify your checkpoint source`
     );
   }
 }


### PR DESCRIPTION
**Motivation**

Minor follow to https://github.com/ChainSafe/lodestar/pull/5837, to correct error message.

The term "weak / weakly" subjective is quite important here when talking about the time period as states outside this time range require (strong) subjectivity.

> Subjective: the system has stable states where different nodes come to different conclusions, and a large amount of social information (ie. reputation) is required in order to participate.

Subjectivity is pretty bad, whereas weak subjectivity is much better / acceptable.

> Weakly subjective: a new node coming onto the network with no knowledge except (i) the protocol definition, (ii) the set of all blocks and other "important" messages that have been published and (iii) a state from less than N blocks ago that is known to be valid can independently come to the exact same conclusion as the rest of the network on the current state, unless there is an attacker that permanently has more than X percent control over the consensus set.

[Proof of Stake: How I Learned to Love Weak Subjectivity](https://blog.ethereum.org/2014/11/25/proof-stake-learned-love-weak-subjectivity) in "Weak Subjectivity" section provides more details on this.

**Description**

Correct error message if downloaded state is not within weak subjectivity period.
