### PR TITLE
feat: limit incoming connections to lodestar

### DIFF
--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -75,6 +75,10 @@ export async function createNodeJsLibp2p(
     transports: [
       tcp({
         maxConnections: networkOpts.maxPeers,
+        // socket option: the maximum length of the queue of pending connections
+        // https://nodejs.org/dist/latest-v18.x/docs/api/net.html#serverlisten
+        // this is 10% of our target peers
+        backlog: 5,
         closeServerOnMaxConnections: {
           closeAbove: networkOpts.maxPeers ?? Infinity,
           listenBelow: networkOpts.maxPeers ?? Infinity,
@@ -101,6 +105,9 @@ export async function createNodeJsLibp2p(
       //maxConnections: options.maxConnections,
       // DOCS: There is no way to turn off autodial other than setting minConnections to 0
       minConnections: 0,
+      // the maximum number of pending connections libp2p will accept before it starts rejecting incoming connections.
+      // make it the same to backlog option above
+      maxIncomingPendingConnections: 5,
     },
     datastore,
     services: {

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -77,7 +77,7 @@ export async function createNodeJsLibp2p(
         maxConnections: networkOpts.maxPeers,
         // socket option: the maximum length of the queue of pending connections
         // https://nodejs.org/dist/latest-v18.x/docs/api/net.html#serverlisten
-        // this is 10% of our target peers
+        // it's not safe if we increase this number
         backlog: 5,
         closeServerOnMaxConnections: {
           closeAbove: networkOpts.maxPeers ?? Infinity,


### PR DESCRIPTION
**Motivation**

With a max peers of 55, we don't want to have too many pending connections to lodestar

**Description**

- Specify `backlog` option for `libp2p-tcp` and `maxIncomingPendingConnections` for libp2p connection manager

**TODOs**

- [x] test on a node