### PR TITLE
feat(logger): remove unused trace log level

### DIFF
--- a/packages/logger/src/empty.ts
+++ b/packages/logger/src/empty.ts
@@ -17,8 +17,5 @@ export function getEmptyLogger(): Logger {
     debug: function debug(): void {
       // Do nothing
     },
-    trace: function trace(): void {
-      // Do nothing
-    },
   };
 }

--- a/packages/logger/src/winston.ts
+++ b/packages/logger/src/winston.ts
@@ -77,8 +77,8 @@ export class WinstonLogger implements Logger {
     this.createLogEntry(LogLevel.debug, message, context, error);
   }
 
-  trace(message: string, context?: LogData, error?: Error): void {
-    this.createLogEntry(LogLevel.trace, message, context, error);
+  trace(): void {
+    throw new Error("Trace it not supported by Lodestar");
   }
 
   private createLogEntry(level: LogLevel, message: string, context?: LogData, error?: Error): void {

--- a/packages/logger/src/winston.ts
+++ b/packages/logger/src/winston.ts
@@ -77,10 +77,6 @@ export class WinstonLogger implements Logger {
     this.createLogEntry(LogLevel.debug, message, context, error);
   }
 
-  trace(message: string, context?: LogData, error?: Error): void {
-    this.createLogEntry(LogLevel.trace, message, context, error);
-  }
-
   private createLogEntry(level: LogLevel, message: string, context?: LogData, error?: Error): void {
     // Note: logger does not run format.transform function unless it will actually write the log to the transport
 

--- a/packages/logger/src/winston.ts
+++ b/packages/logger/src/winston.ts
@@ -77,8 +77,8 @@ export class WinstonLogger implements Logger {
     this.createLogEntry(LogLevel.debug, message, context, error);
   }
 
-  trace(): void {
-    throw new Error("Trace it not supported by Lodestar");
+  trace(message: string, context?: LogData, error?: Error): void {
+    this.createLogEntry(LogLevel.trace, message, context, error);
   }
 
   private createLogEntry(level: LogLevel, message: string, context?: LogData, error?: Error): void {

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,7 +1,7 @@
 /**
  * Interface of a generic Lodestar logger. For implementations, see `@lodestar/logger`
  */
-export type Logger = Record<LogLevel, LogHandler>;
+export type Logger = Record<Exclude<LogLevel, LogLevel.trace>, LogHandler>;
 
 export enum LogLevel {
   error = "error",

--- a/packages/validator/src/util/logger.ts
+++ b/packages/validator/src/util/logger.ts
@@ -35,7 +35,6 @@ export function getLoggerVc(logger: Logger, clock: IClock): LoggerVc {
     info: logger.info.bind(logger),
     verbose: logger.verbose.bind(logger),
     debug: logger.debug.bind(logger),
-    trace: logger.trace.bind(logger),
 
     /**
      * Throttle "node is syncing" errors to not pollute the console too much.


### PR DESCRIPTION
**Motivation**

`trace` does not follow our logging policy and it is broken as well.  Found an error and instead of fixing we decided to remove it.  

Closes  #5809 

**Description**

- Ensured no usage of the `log.trace()` 
- Update `Logger` interface to remove `trace` method
- Kept `LogLevel.trace` so that it can be passed into the CLI without throwing an error but will be handled similar to `debug` logging level
- Remove `trace` method from `WinstonLogger`, `getLoggerVc` and `getEmptyLogger`