### PR TITLE
fix: move and fix execution engine state update checks for online state

### DIFF
--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -421,6 +421,14 @@ export class ExecutionEngineHttp implements IExecutionEngine {
 
     if (oldState === newState) return;
 
+    // The ONLINE is initial state and can reached from offline or auth failed error
+    if (
+      newState === ExecutionEngineState.ONLINE &&
+      !(oldState === ExecutionEngineState.OFFLINE || oldState === ExecutionEngineState.AUTH_FAILED)
+    ) {
+      return;
+    }
+
     switch (newState) {
       case ExecutionEngineState.ONLINE:
         this.logger.info("Execution client became online", {oldState, newState});

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -131,7 +131,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   protected async fetchWithRetries<R, P = IJson[]>(payload: RpcPayload<P>, opts?: ReqOpts): Promise<R> {
     try {
       const res = await this.rpc.fetchWithRetries<R, P>(payload, opts);
-      this.updateEngineState(ExecutionEngineState.ONLINE);
+      this.updateEngineState(getExecutionEngineState({targetState: ExecutionEngineState.ONLINE, oldState: this.state}));
       return res;
     } catch (err) {
       this.updateEngineState(getExecutionEngineState({payloadError: err, oldState: this.state}));
@@ -420,14 +420,6 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     const oldState = this.state;
 
     if (oldState === newState) return;
-
-    // The ONLINE is initial state and can reached from offline or auth failed error
-    if (
-      newState === ExecutionEngineState.ONLINE &&
-      !(oldState === ExecutionEngineState.OFFLINE || oldState === ExecutionEngineState.AUTH_FAILED)
-    ) {
-      return;
-    }
 
     switch (newState) {
       case ExecutionEngineState.ONLINE:

--- a/packages/beacon-node/src/execution/engine/utils.ts
+++ b/packages/beacon-node/src/execution/engine/utils.ts
@@ -94,15 +94,5 @@ export function getExecutionEngineState<S extends ExecutionPayloadStatus | undef
       ? getExecutionEngineStateForPayloadError(payloadError, oldState)
       : getExecutionEngineStateForPayloadStatus(payloadStatus);
 
-  if (newState === oldState) return oldState;
-
-  // The ONLINE is initial state and can reached from offline or auth failed error
-  if (
-    newState === ExecutionEngineState.ONLINE &&
-    !(oldState === ExecutionEngineState.OFFLINE || oldState === ExecutionEngineState.AUTH_FAILED)
-  ) {
-    return oldState;
-  }
-
   return newState;
 }

--- a/packages/beacon-node/test/unit/execution/engine/utils.test.ts
+++ b/packages/beacon-node/test/unit/execution/engine/utils.test.ts
@@ -172,6 +172,49 @@ describe("execution / engine / utils", () => {
       ],
     ];
 
+    const testCasesTargetState: Record<
+      ExecutionEngineState,
+      [oldState: ExecutionEngineState, newState: ExecutionEngineState][]
+    > = {
+      [ExecutionEngineState.ONLINE]: [
+        [ExecutionEngineState.ONLINE, ExecutionEngineState.ONLINE],
+        [ExecutionEngineState.AUTH_FAILED, ExecutionEngineState.ONLINE],
+        [ExecutionEngineState.OFFLINE, ExecutionEngineState.ONLINE],
+        // Once start syncing it should not go back to online state
+        // Online is an initial state when execution engine is created
+        [ExecutionEngineState.SYNCED, ExecutionEngineState.SYNCED],
+        [ExecutionEngineState.SYNCING, ExecutionEngineState.SYNCING],
+      ],
+      [ExecutionEngineState.AUTH_FAILED]: [
+        [ExecutionEngineState.ONLINE, ExecutionEngineState.AUTH_FAILED],
+        [ExecutionEngineState.AUTH_FAILED, ExecutionEngineState.AUTH_FAILED],
+        [ExecutionEngineState.OFFLINE, ExecutionEngineState.AUTH_FAILED],
+        [ExecutionEngineState.SYNCED, ExecutionEngineState.AUTH_FAILED],
+        [ExecutionEngineState.SYNCING, ExecutionEngineState.AUTH_FAILED],
+      ],
+      [ExecutionEngineState.OFFLINE]: [
+        [ExecutionEngineState.ONLINE, ExecutionEngineState.OFFLINE],
+        [ExecutionEngineState.AUTH_FAILED, ExecutionEngineState.OFFLINE],
+        [ExecutionEngineState.OFFLINE, ExecutionEngineState.OFFLINE],
+        [ExecutionEngineState.SYNCED, ExecutionEngineState.OFFLINE],
+        [ExecutionEngineState.SYNCING, ExecutionEngineState.OFFLINE],
+      ],
+      [ExecutionEngineState.SYNCED]: [
+        [ExecutionEngineState.ONLINE, ExecutionEngineState.SYNCED],
+        [ExecutionEngineState.AUTH_FAILED, ExecutionEngineState.SYNCED],
+        [ExecutionEngineState.OFFLINE, ExecutionEngineState.SYNCED],
+        [ExecutionEngineState.SYNCED, ExecutionEngineState.SYNCED],
+        [ExecutionEngineState.SYNCING, ExecutionEngineState.SYNCED],
+      ],
+      [ExecutionEngineState.SYNCING]: [
+        [ExecutionEngineState.ONLINE, ExecutionEngineState.SYNCING],
+        [ExecutionEngineState.AUTH_FAILED, ExecutionEngineState.SYNCING],
+        [ExecutionEngineState.OFFLINE, ExecutionEngineState.SYNCING],
+        [ExecutionEngineState.SYNCED, ExecutionEngineState.SYNCING],
+        [ExecutionEngineState.SYNCING, ExecutionEngineState.SYNCING],
+      ],
+    };
+
     for (const payloadStatus of Object.keys(testCasesPayload) as ExecutionPayloadStatus[]) {
       for (const [oldState, newState] of testCasesPayload[payloadStatus]) {
         it(`should transition from "${oldState}" to "${newState}" on payload status "${payloadStatus}"`, () => {
@@ -185,6 +228,14 @@ describe("execution / engine / utils", () => {
       for (const [oldState, newState] of errorCases) {
         it(`should transition from "${oldState}" to "${newState}" on error "${message}"`, () => {
           expect(getExecutionEngineState({payloadError, oldState})).to.equal(newState);
+        });
+      }
+    }
+
+    for (const targetState of Object.keys(testCasesTargetState) as ExecutionEngineState[]) {
+      for (const [oldState, newState] of testCasesTargetState[targetState]) {
+        it(`should transition from "${oldState}" to "${newState}" on when targeting "${targetState}"`, () => {
+          expect(getExecutionEngineState({targetState, oldState})).to.equal(newState);
         });
       }
     }


### PR DESCRIPTION
Noticed that PR -  fix: offline error message when node is shutting down #5797  was updating execution state from SYNCED to ONLINE since the checks for the same were not located at correct place which caused excessive logging: here is an example log:

```typescript
ph 0/2 0.022[Node-A/execution] info: Execution client became online oldState=SYNCED, newState=ONLINE
EL 5743: INFO [08-07|18:59:44.030] Imported new potential chain segment     number=2 hash=fd4af3..63ebe2 blocks=1 txs=0 mgas=0.000 elapsed="190.628µs" mgasps=0.000 dirty=698.00B
Eph 0/2 0.031[Node-A/execution] info: Execution client is synced oldState=ONLINE, newState=SYNCED
```

This PR fixes the same