### PR TITLE
refactor: more explicit voluntary exit process

### DIFF
--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -91,6 +91,7 @@ If no `pubkeys` are provided, it will exit all validators that have been importe
         {
           name: "yes",
           type: "confirm",
+          default: false,
           message: `Confirm to exit pubkeys at epoch ${exitEpoch} from network ${network}?
 ${validatorsToExit.map((v) => `${v.pubkey} ${v.index} ${v.status}`).join("\n")}`,
         },

--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -87,6 +87,7 @@ If no `pubkeys` are provided, it will exit all validators that have been importe
     const validatorsToExit = await resolveValidatorIndexes(client, signersToExit);
 
     if (!args.yes) {
+      console.log("\nWARNING: THIS IS AN IRREVERSIBLE OPERATION\n");
       const confirmation = await inquirer.prompt<{yes: boolean}>([
         {
           name: "yes",


### PR DESCRIPTION
**Motivation**

As noted by @SeaMonkey82 on [discord](https://discord.com/channels/593655374469660673/593655641445367808/1136844839305084938) our voluntary exit is pretty "lax" compared to how it works on Lighthouse.
- There is no warning that this is irreversible
- And we default to "Y" in the prompt which makes it less explicit

I also think we should make the whole process a bit more explicit to make the user "think twice" before executing the command.

**Description**

- Default confirm to exit prompt to "N"
- Add warning that this operation is irreversible

```
> ./lodestar validator voluntary-exit --network goerli
? Enter the keystore(s) password [hidden]
100% of keystores imported. current=3 total=3 rate=1065.09keys/m
Loaded keystores via keystore cache

WARNING: THIS IS AN IRREVERSIBLE OPERATION

? Confirm to exit pubkeys at epoch 194408 from network goerli?
0xa21c0e0cd0166eacc3eb51d855c17edb264ea2e5432ac3de4ea4c2e16fb5fdd6070b12cc5bd029b70b4436f7e973751e 462278 active_ongoing
0xa2db29290e6d2f7cbc4665638e80c090b7e8ae226dbf548179bfe531c1a43cff018543b7bf54d9e608c73ecbd6771e9e 460986 active_ongoing
0xa40233164c674c424a877495535293e969eae0d849add2f17fa70595673a740b4a94fbffb7c377b750f523176dcaed7e 461251 active_ongoing (y/N)
```
