### PR TITLE
fix: improve forkchoice updateHead() time

### DIFF
--- a/packages/fork-choice/src/protoArray/computeDeltas.ts
+++ b/packages/fork-choice/src/protoArray/computeDeltas.ts
@@ -19,12 +19,26 @@ export function computeDeltas(
   newBalances: EffectiveBalanceIncrements,
   equivocatingIndices: Set<ValidatorIndex>
 ): number[] {
-  const deltas = Array.from({length: indices.size}, () => 0);
+  const deltas = Array<number>(indices.size).fill(0);
   const zeroHash = HEX_ZERO_HASH;
   // avoid creating new variables in the loop to potentially reduce GC pressure
   let oldBalance, newBalance: number;
   let currentRoot, nextRoot: string;
   let currentDeltaIndex, nextDeltaIndex: number | undefined;
+  // this function tends to get some very few roots from `indices` so create a small cache to improve performance
+  const cachedIndices = new Map<string, number>();
+
+  const getIndex = (root: string): number | undefined => {
+    let index = cachedIndices.get(root);
+    if (index === undefined) {
+      index = indices.get(root);
+      if (index !== undefined) {
+        cachedIndices.set(root, index);
+      }
+    }
+    return index;
+  };
+
   for (let vIndex = 0; vIndex < votes.length; vIndex++) {
     const vote = votes[vIndex];
     // There is no need to create a score change if the validator has never voted or both of their
@@ -52,7 +66,7 @@ export function computeDeltas(
     if (equivocatingIndices.size > 0 && equivocatingIndices.has(vIndex)) {
       // this function could be called multiple times but we only want to process slashing validator for 1 time
       if (currentRoot !== zeroHash) {
-        currentDeltaIndex = indices.get(currentRoot);
+        currentDeltaIndex = getIndex(currentRoot);
         if (currentDeltaIndex !== undefined) {
           if (currentDeltaIndex >= deltas.length) {
             throw new ProtoArrayError({
@@ -70,7 +84,7 @@ export function computeDeltas(
     if (currentRoot !== nextRoot || oldBalance !== newBalance) {
       // We ignore the vote if it is not known in `indices .
       // We assume that it is outside of our tree (ie: pre-finalization) and therefore not interesting
-      currentDeltaIndex = indices.get(currentRoot);
+      currentDeltaIndex = getIndex(currentRoot);
       if (currentDeltaIndex !== undefined) {
         if (currentDeltaIndex >= deltas.length) {
           throw new ProtoArrayError({
@@ -82,7 +96,7 @@ export function computeDeltas(
       }
       // We ignore the vote if it is not known in `indices .
       // We assume that it is outside of our tree (ie: pre-finalization) and therefore not interesting
-      nextDeltaIndex = indices.get(nextRoot);
+      nextDeltaIndex = getIndex(nextRoot);
       if (nextDeltaIndex !== undefined) {
         if (nextDeltaIndex >= deltas.length) {
           throw new ProtoArrayError({

--- a/packages/fork-choice/src/protoArray/computeDeltas.ts
+++ b/packages/fork-choice/src/protoArray/computeDeltas.ts
@@ -21,6 +21,10 @@ export function computeDeltas(
 ): number[] {
   const deltas = Array.from({length: indices.size}, () => 0);
   const zeroHash = HEX_ZERO_HASH;
+  // avoid creating new variables in the loop to potentially reduce GC pressure
+  let oldBalance, newBalance: number;
+  let currentRoot, nextRoot: string;
+  let currentDeltaIndex, nextDeltaIndex: number | undefined;
   for (let vIndex = 0; vIndex < votes.length; vIndex++) {
     const vote = votes[vIndex];
     // There is no need to create a score change if the validator has never voted or both of their
@@ -28,26 +32,27 @@ export function computeDeltas(
     if (vote === undefined) {
       continue;
     }
-    const {currentRoot, nextRoot} = vote;
+    currentRoot = vote.currentRoot;
+    nextRoot = vote.nextRoot;
     if (currentRoot === zeroHash && nextRoot === zeroHash) {
       continue;
     }
 
     // IF the validator was not included in the _old_ balances (i.e. it did not exist yet)
     // then say its balance was 0
-    const oldBalance = oldBalances[vIndex] ?? 0;
+    oldBalance = oldBalances[vIndex] ?? 0;
 
     // If the validator's vote is not known in the _new_ balances, then use a balance of zero.
     //
     // It is possible that there was a vote for an unknown validator if we change our justified
     // state to a new state with a higher epoch that is on a different fork because that fork may have
     // on-boarded fewer validators than the prior fork.
-    const newBalance = newBalances[vIndex] ?? 0;
+    newBalance = newBalances[vIndex] ?? 0;
 
     if (equivocatingIndices.size > 0 && equivocatingIndices.has(vIndex)) {
       // this function could be called multiple times but we only want to process slashing validator for 1 time
       if (currentRoot !== zeroHash) {
-        const currentDeltaIndex = indices.get(currentRoot);
+        currentDeltaIndex = indices.get(currentRoot);
         if (currentDeltaIndex !== undefined) {
           if (currentDeltaIndex >= deltas.length) {
             throw new ProtoArrayError({
@@ -65,7 +70,7 @@ export function computeDeltas(
     if (currentRoot !== nextRoot || oldBalance !== newBalance) {
       // We ignore the vote if it is not known in `indices .
       // We assume that it is outside of our tree (ie: pre-finalization) and therefore not interesting
-      const currentDeltaIndex = indices.get(currentRoot);
+      currentDeltaIndex = indices.get(currentRoot);
       if (currentDeltaIndex !== undefined) {
         if (currentDeltaIndex >= deltas.length) {
           throw new ProtoArrayError({
@@ -77,7 +82,7 @@ export function computeDeltas(
       }
       // We ignore the vote if it is not known in `indices .
       // We assume that it is outside of our tree (ie: pre-finalization) and therefore not interesting
-      const nextDeltaIndex = indices.get(nextRoot);
+      nextDeltaIndex = indices.get(nextRoot);
       if (nextDeltaIndex !== undefined) {
         if (nextDeltaIndex >= deltas.length) {
           throw new ProtoArrayError({

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -740,10 +740,39 @@ export class ProtoArray {
       correctJustified = node.unrealizedJustifiedEpoch >= previousEpoch && votingSourceEpoch + 2 >= currentEpoch;
     }
 
-    const finalizedSlot = computeStartSlotAtEpoch(this.finalizedEpoch);
-    const correctFinalized =
-      this.finalizedRoot === this.getAncestorOrNull(node.blockRoot, finalizedSlot) || this.finalizedEpoch === 0;
+    const correctFinalized = this.finalizedEpoch === 0 || this.isFinalizedRootOrDescendant(node);
     return correctJustified && correctFinalized;
+  }
+
+  /**
+   * Return `true` if `node` is equal to or a descendant of the finalized node.
+   */
+  isFinalizedRootOrDescendant(node: ProtoNode): boolean {
+    // The finalized and justified checkpoints represent a list of known
+    // ancestors of `node` that are likely to coincide with the store's
+    // finalized checkpoint.
+    //
+    // Run this check once, outside of the loop rather than inside the loop.
+    // If the conditions don't match for this node then they're unlikely to
+    // start matching for its ancestors.
+    if (node.finalizedEpoch === this.finalizedEpoch && node.finalizedRoot === this.finalizedRoot) {
+      return true;
+    }
+
+    if (node.justifiedEpoch === this.finalizedEpoch && node.justifiedRoot === this.finalizedRoot) {
+      return true;
+    }
+
+    if (node.unrealizedFinalizedEpoch === this.finalizedEpoch && node.unrealizedFinalizedRoot === this.finalizedRoot) {
+      return true;
+    }
+
+    if (node.unrealizedJustifiedEpoch === this.finalizedEpoch && node.unrealizedJustifiedRoot === this.finalizedRoot) {
+      return true;
+    }
+
+    const finalizedSlot = computeStartSlotAtEpoch(this.finalizedEpoch);
+    return this.finalizedEpoch === 0 || this.finalizedRoot === this.getAncestorOrNull(node.blockRoot, finalizedSlot);
   }
 
   /**

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -746,15 +746,13 @@ export class ProtoArray {
 
   /**
    * Return `true` if `node` is equal to or a descendant of the finalized node.
+   * This function helps improve performance of nodeIsViableForHead a lot by avoiding
+   * the loop inside `getAncestors`.
    */
   isFinalizedRootOrDescendant(node: ProtoNode): boolean {
     // The finalized and justified checkpoints represent a list of known
     // ancestors of `node` that are likely to coincide with the store's
     // finalized checkpoint.
-    //
-    // Run this check once, outside of the loop rather than inside the loop.
-    // If the conditions don't match for this node then they're unlikely to
-    // start matching for its ancestors.
     if (node.finalizedEpoch === this.finalizedEpoch && node.finalizedRoot === this.finalizedRoot) {
       return true;
     }

--- a/packages/fork-choice/test/perf/forkChoice/updateHead.test.ts
+++ b/packages/fork-choice/test/perf/forkChoice/updateHead.test.ts
@@ -13,8 +13,8 @@ describe("forkchoice updateHead", () => {
     10 * 32,
     // 4 hours of blocks
     (4 * 60 * 60) / 12,
-    // // 1 day of blocks
-    // (24 * 60 * 60) / 12,
+    // 1 day of blocks
+    (24 * 60 * 60) / 12,
     // // 20 days of blocks
     // (20 * 24 * 60 * 60) / 12,
   ]) {

--- a/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
+++ b/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
@@ -11,7 +11,8 @@ describe("computeDeltas", () => {
 
   const oldRoot = "0x32dec344944029ba183ac387a7aa1f2068591c00e9bfadcfb238e50fbe9ea38e";
   const newRoot = "0xb59f3a209f639dd6b5645ea9fad8d441df44c3be93bd1bbf50ef90bf124d1238";
-  for (const numValidator of [800_000, 2_100_100]) {
+  // 2 first numbers are respective to number of validators in goerli, mainnet as of Aug 2023
+  for (const numValidator of [500_000, 750_000, 1_400_000, 2_100_000]) {
     before(function () {
       this.timeout(2 * 60 * 1000);
       oldBalances = getEffectiveBalanceIncrementsZeroed(numValidator);

--- a/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
+++ b/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
@@ -1,98 +1,62 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {expect} from "chai";
-import {
-  CachedBeaconStateAltair,
-  computeStartSlotAtEpoch,
-  EffectiveBalanceIncrements,
-  getEffectiveBalanceIncrementsZeroed,
-} from "@lodestar/state-transition";
-import {TIMELY_SOURCE_FLAG_INDEX} from "@lodestar/params";
-// eslint-disable-next-line import/no-relative-packages
-import {generatePerfTestCachedStateAltair} from "../../../../state-transition/test/perf/util.js";
+import {EffectiveBalanceIncrements, getEffectiveBalanceIncrementsZeroed} from "@lodestar/state-transition";
 import {VoteTracker} from "../../../src/protoArray/interface.js";
 import {computeDeltas} from "../../../src/protoArray/computeDeltas.js";
 import {computeProposerBoostScoreFromBalances} from "../../../src/forkChoice/forkChoice.js";
 
-/** Same to https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.5/specs/altair/beacon-chain.md#has_flag */
-const TIMELY_SOURCE = 1 << TIMELY_SOURCE_FLAG_INDEX;
-function flagIsTimelySource(flag: number): boolean {
-  return (flag & TIMELY_SOURCE) === TIMELY_SOURCE;
-}
-
 describe("computeDeltas", () => {
-  let originalState: CachedBeaconStateAltair;
   const indices: Map<string, number> = new Map<string, number>();
   let oldBalances: EffectiveBalanceIncrements;
   let newBalances: EffectiveBalanceIncrements;
 
   const oldRoot = "0x32dec344944029ba183ac387a7aa1f2068591c00e9bfadcfb238e50fbe9ea38e";
   const newRoot = "0xb59f3a209f639dd6b5645ea9fad8d441df44c3be93bd1bbf50ef90bf124d1238";
+  for (const numValidator of [800_000, 2_100_100]) {
+    before(function () {
+      this.timeout(2 * 60 * 1000);
+      oldBalances = getEffectiveBalanceIncrementsZeroed(numValidator);
+      newBalances = getEffectiveBalanceIncrementsZeroed(numValidator);
 
-  before(function () {
-    this.timeout(2 * 60 * 1000); // Generating the states for the first time is very slow
+      for (let i = 0; i < numValidator; i++) {
+        oldBalances[i] = 32;
+        newBalances[i] = 32;
+      }
+      for (let i = 0; i < 10000; i++) {
+        indices.set("" + i, i);
+      }
+      indices.set(oldRoot, 1001);
+      indices.set(newRoot, 1002);
+    });
 
-    originalState = generatePerfTestCachedStateAltair({goBackOneSlot: true});
+    setBenchOpts({
+      minMs: 30 * 1000,
+      maxMs: 40 * 1000,
+    });
 
-    const previousEpochParticipationArr = originalState.previousEpochParticipation.getAll();
-    const currentEpochParticipationArr = originalState.currentEpochParticipation.getAll();
-
-    const numPreviousEpochParticipation = previousEpochParticipationArr.filter(flagIsTimelySource).length;
-    const numCurrentEpochParticipation = currentEpochParticipationArr.filter(flagIsTimelySource).length;
-
-    expect(numPreviousEpochParticipation).to.equal(250000, "Wrong numPreviousEpochParticipation");
-    expect(numCurrentEpochParticipation).to.equal(250000, "Wrong numCurrentEpochParticipation");
-
-    oldBalances = getEffectiveBalanceIncrementsZeroed(numPreviousEpochParticipation);
-    newBalances = getEffectiveBalanceIncrementsZeroed(numPreviousEpochParticipation);
-
-    for (let i = 0; i < numPreviousEpochParticipation; i++) {
-      oldBalances[i] = 32;
-      newBalances[i] = 32;
-    }
-    for (let i = 0; i < 10000; i++) {
-      indices.set("" + i, i);
-    }
-    indices.set(oldRoot, 1001);
-    indices.set(newRoot, 1001);
-  });
-
-  setBenchOpts({
-    minMs: 30 * 1000,
-    maxMs: 40 * 1000,
-  });
-
-  itBench({
-    id: "computeDeltas",
-    beforeEach: () => {
-      const votes: VoteTracker[] = [];
-      const epoch = originalState.epochCtx.currentShuffling.epoch;
-      const committee = originalState.epochCtx.getBeaconCommittee(computeStartSlotAtEpoch(epoch), 0);
-      for (let i = 0; i < 250000; i++) {
-        if (committee.includes(i)) {
+    itBench({
+      id: `computeDeltas ${numValidator} validators`,
+      beforeEach: () => {
+        const votes: VoteTracker[] = [];
+        const epoch = 100_000;
+        for (let i = 0; i < numValidator; i++) {
           votes.push({
             currentRoot: oldRoot,
             nextRoot: newRoot,
             nextEpoch: epoch,
           });
-        } else {
-          votes.push({
-            currentRoot: oldRoot,
-            nextRoot: oldRoot,
-            nextEpoch: epoch - 1,
-          });
         }
-      }
-      return votes;
-    },
-    fn: (votes) => {
-      computeDeltas(indices, votes, oldBalances, newBalances, new Set());
-    },
-  });
+        return votes;
+      },
+      fn: (votes) => {
+        computeDeltas(indices, votes, oldBalances, newBalances, new Set());
+      },
+    });
 
-  itBench({
-    id: "computeProposerBoostScoreFromBalances",
-    fn: () => {
-      computeProposerBoostScoreFromBalances(newBalances, {slotsPerEpoch: 32, proposerScoreBoost: 70});
-    },
-  });
+    itBench({
+      id: `computeProposerBoostScoreFromBalances ${numValidator} validators`,
+      fn: () => {
+        computeProposerBoostScoreFromBalances(newBalances, {slotsPerEpoch: 32, proposerScoreBoost: 70});
+      },
+    });
+  }
 });

--- a/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
+++ b/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
@@ -1,18 +1,23 @@
+import crypto from "node:crypto";
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
+import {toHexString} from "@chainsafe/ssz";
 import {EffectiveBalanceIncrements, getEffectiveBalanceIncrementsZeroed} from "@lodestar/state-transition";
 import {VoteTracker} from "../../../src/protoArray/interface.js";
 import {computeDeltas} from "../../../src/protoArray/computeDeltas.js";
 import {computeProposerBoostScoreFromBalances} from "../../../src/forkChoice/forkChoice.js";
 
 describe("computeDeltas", () => {
-  const indices: Map<string, number> = new Map<string, number>();
   let oldBalances: EffectiveBalanceIncrements;
   let newBalances: EffectiveBalanceIncrements;
 
   const oldRoot = "0x32dec344944029ba183ac387a7aa1f2068591c00e9bfadcfb238e50fbe9ea38e";
   const newRoot = "0xb59f3a209f639dd6b5645ea9fad8d441df44c3be93bd1bbf50ef90bf124d1238";
+  const oneHourProtoNodes = (60 * 60) / 12;
+  const fourHourProtoNodes = 4 * oneHourProtoNodes;
+  const oneDayProtoNodes = 24 * oneHourProtoNodes;
   // 2 first numbers are respective to number of validators in goerli, mainnet as of Aug 2023
-  for (const numValidator of [500_000, 750_000, 1_400_000, 2_100_000]) {
+  const numValidators = [500_000, 750_000, 1_400_000, 2_100_000];
+  for (const numValidator of numValidators) {
     before(function () {
       this.timeout(2 * 60 * 1000);
       oldBalances = getEffectiveBalanceIncrementsZeroed(numValidator);
@@ -22,11 +27,6 @@ describe("computeDeltas", () => {
         oldBalances[i] = 32;
         newBalances[i] = 32;
       }
-      for (let i = 0; i < 10000; i++) {
-        indices.set("" + i, i);
-      }
-      indices.set(oldRoot, 1001);
-      indices.set(newRoot, 1002);
     });
 
     setBenchOpts({
@@ -34,25 +34,35 @@ describe("computeDeltas", () => {
       maxMs: 40 * 1000,
     });
 
-    itBench({
-      id: `computeDeltas ${numValidator} validators`,
-      beforeEach: () => {
-        const votes: VoteTracker[] = [];
-        const epoch = 100_000;
-        for (let i = 0; i < numValidator; i++) {
-          votes.push({
-            currentRoot: oldRoot,
-            nextRoot: newRoot,
-            nextEpoch: epoch,
-          });
-        }
-        return votes;
-      },
-      fn: (votes) => {
-        computeDeltas(indices, votes, oldBalances, newBalances, new Set());
-      },
-    });
+    for (const numProtoNode of [oneHourProtoNodes, fourHourProtoNodes, oneDayProtoNodes]) {
+      const indices: Map<string, number> = new Map<string, number>();
+      for (let i = 0; i < numProtoNode; i++) {
+        indices.set(toHexString(crypto.randomBytes(32)), i);
+      }
+      indices.set(oldRoot, Math.floor(numProtoNode / 2));
+      indices.set(newRoot, Math.floor(numProtoNode / 2) + 1);
+      itBench({
+        id: `computeDeltas ${numValidator} validators ${numProtoNode} proto nodes`,
+        beforeEach: () => {
+          const votes: VoteTracker[] = [];
+          const epoch = 100_000;
+          for (let i = 0; i < numValidator; i++) {
+            votes.push({
+              currentRoot: oldRoot,
+              nextRoot: newRoot,
+              nextEpoch: epoch,
+            });
+          }
+          return votes;
+        },
+        fn: (votes) => {
+          computeDeltas(indices, votes, oldBalances, newBalances, new Set());
+        },
+      });
+    }
+  }
 
+  for (const numValidator of numValidators) {
     itBench({
       id: `computeProposerBoostScoreFromBalances ${numValidator} validators`,
       fn: () => {


### PR DESCRIPTION
**Motivation**

- Performance test of computeDeltas does not reflect the number we see in goerli/mainnet
- Update: was able to reproduce the big updateHead time in `forkChoice updateHead vc 600000 bc 7200 eq 0` test

**Description**

- Update performance tests to reproduce performance issue of "forkchoice.updateHead"
- Write "isFinalizedRootOrDescendant" specifically used for "nodeIsViableForHead()" function to avoid having to loop through the entire nodes a lot of time in "updateHead()"
  - This is exactly the same to https://github.com/sigp/lighthouse/blob/stable/consensus/proto_array/src/proto_array.rs#L975

part of #5852