### PR TITLE
chore(dashboards): fix event loop lag panels

### DIFF
--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -1301,9 +1301,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "nodejs_eventloop_lag_seconds{job=~\"$beacon_job|beacon\"}",
+          "expr": "nodejs_eventloop_lag_seconds",
           "interval": "",
-          "legendFormat": "main_thread",
+          "legendFormat": "{{job}}",
           "range": true,
           "refId": "A"
         },
@@ -1330,18 +1330,6 @@
           "legendFormat": "discv5_worker",
           "range": true,
           "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "nodejs_eventloop_lag_seconds{job=~\"$validator_job|validator\"}",
-          "interval": "",
-          "legendFormat": "main_thread",
-          "range": true,
-          "refId": "A"
         }
       ],
       "title": "Event Loop Lag",
@@ -1439,9 +1427,9 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg_over_time(nodejs_eventloop_lag_seconds{job=~\"$beacon_job|beacon\"}[$rate_interval])",
+          "expr": "avg_over_time(nodejs_eventloop_lag_seconds[$rate_interval])",
           "interval": "",
-          "legendFormat": "main_thread",
+          "legendFormat": "{{job}}",
           "range": true,
           "refId": "A"
         },
@@ -1468,18 +1456,6 @@
           "legendFormat": "discv5_worker",
           "range": true,
           "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "avg_over_time(nodejs_eventloop_lag_seconds{job=~\"$validator_job|validator\"}[$rate_interval])",
-          "interval": "",
-          "legendFormat": "main_thread",
-          "range": true,
-          "refId": "A"
         }
       ],
       "title": "Average Event Loop Lag",


### PR DESCRIPTION
**Motivation**

Event loop panels could be optimized to remove a query.  The legends were also incorrect.  Fixes that.

**Description**

Displays both beacon and validator from a single query

![Screenshot 2023-08-11 at 2 35 49 AM](https://github.com/ChainSafe/lodestar/assets/18608739/63f54d42-fbad-4d40-be40-323f01bd8df8)

![Screenshot 2023-08-11 at 2 35 41 AM](https://github.com/ChainSafe/lodestar/assets/18608739/0c7672f7-f64a-4293-a547-6bfcd831efc5)

