### PR TITLE
chore: handle native fetch timeout error

### DIFF
--- a/packages/api/src/utils/client/fetch.ts
+++ b/packages/api/src/utils/client/fetch.ts
@@ -146,9 +146,9 @@ function isNativeFetchInputError(e: unknown): e is NativeFetchInputError {
 }
 
 function isNativeFetchAbortError(e: unknown): e is NativeFetchAbortError {
-  return e instanceof DOMException && e.name === "AbortError";
+  return e instanceof DOMException && (e as NativeFetchAbortError).name === "AbortError";
 }
 
 function isNativeFetchTimeoutError(e: unknown): e is NativeFetchTimeoutError {
-  return e instanceof DOMException && e.name === "TimeoutError";
+  return e instanceof DOMException && (e as NativeFetchTimeoutError).name === "TimeoutError";
 }

--- a/packages/api/src/utils/client/fetch.ts
+++ b/packages/api/src/utils/client/fetch.ts
@@ -17,7 +17,7 @@ export function isFetchError(e: unknown): e is FetchError {
   return e instanceof FetchError;
 }
 
-export type FetchErrorType = "failed" | "input" | "aborted" | "unknown";
+export type FetchErrorType = "failed" | "input" | "aborted" | "timeout" | "unknown";
 
 type FetchErrorCause = NativeFetchFailedError["cause"] | NativeFetchInputError["cause"];
 
@@ -42,6 +42,10 @@ export class FetchError extends Error {
       super(`Request to ${url.toString()} was aborted`);
       this.type = "aborted";
       this.code = "ERR_ABORTED";
+    } else if (isNativeFetchTimeoutError(e)) {
+      super(`Request to ${url.toString()} timed out`);
+      this.type = "timeout";
+      this.code = "ERR_TIMEOUT";
     } else {
       super((e as Error).message);
       this.type = "unknown";
@@ -120,6 +124,15 @@ type NativeFetchAbortError = DOMException & {
   name: "AbortError";
 };
 
+/**
+ * ```
+ * DOMException [TimeoutError]: The operation was aborted due to timeout
+ * ```
+ */
+type NativeFetchTimeoutError = DOMException & {
+  name: "TimeoutError";
+};
+
 function isNativeFetchError(e: unknown): e is NativeFetchError {
   return e instanceof TypeError && (e as NativeFetchError).cause instanceof Error;
 }
@@ -134,4 +147,8 @@ function isNativeFetchInputError(e: unknown): e is NativeFetchInputError {
 
 function isNativeFetchAbortError(e: unknown): e is NativeFetchAbortError {
   return e instanceof DOMException && e.name === "AbortError";
+}
+
+function isNativeFetchTimeoutError(e: unknown): e is NativeFetchTimeoutError {
+  return e instanceof DOMException && e.name === "TimeoutError";
 }

--- a/packages/api/test/unit/client/fetch.test.ts
+++ b/packages/api/test/unit/client/fetch.test.ts
@@ -117,14 +117,7 @@ describe("FetchError", function () {
         );
       }
 
-      let signal: AbortSignal | undefined;
-      if (abort) {
-        const controller = new AbortController();
-        setTimeout(() => controller.abort(), 0);
-        signal = controller.signal;
-      } else if (timeout) {
-        signal = AbortSignal.timeout(10);
-      }
+      const signal = abort ? AbortSignal.abort() : timeout ? AbortSignal.timeout(1) : null;
       await expect(fetch(url, {signal})).to.be.rejected.then((error: FetchError) => {
         expect(error.type).to.be.equal(testCase.errorType);
         expect(error.code).to.be.equal(testCase.errorCode);


### PR DESCRIPTION
**Motivation**

Follow up to https://github.com/ChainSafe/lodestar/pull/5811, I noticed that native fetch has different error when using `AbortSignal.timeout(delay)` (see [example](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static#examples)). We are not using that pattern right now but error handling should consider that. Potential refactoring in other classes could be done to use this feature.

**Description**

Handle native fetch timeout error
