### PR TITLE
docs: remove beacon node command prefix from --monitoring flags

### DIFF
--- a/docs/usage/client-monitoring.md
+++ b/docs/usage/client-monitoring.md
@@ -9,14 +9,14 @@ and in your [account settings](https://beaconcha.in/user/settings#app).
 
 ## Configuration
 
-Lodestar provides CLI options to configure monitoring on both the beacon node and validator client.
+Lodestar provides CLI options to configure monitoring on both the beacon node **and** validator client.
 
 ### Remote endpoint URL
 
 Client monitoring can be enabled by setting the `--monitoring.endpoint` flag to a remote service endpoint URL.
 
 ```bash
-lodestar beacon --monitoring.endpoint "https://beaconcha.in/api/v1/client/metrics?apikey={apikey}&machine={machineName}"
+--monitoring.endpoint "https://beaconcha.in/api/v1/client/metrics?apikey={apikey}&machine={machineName}"
 ```
 
 In case of _beaconcha.in_, the API key can be found in your [account settings](https://beaconcha.in/user/settings#api).
@@ -44,7 +44,7 @@ It takes an integer value in milliseconds, the default is `60000` which means da
 For example, setting an interval of `300000` would mean the data is only sent every 5 minutes.
 
 ```bash
-lodestar beacon --monitoring.interval 300000
+--monitoring.interval 300000
 ```
 
 Increasing the monitoring interval can be useful if you are running into rate limit errors when posting large amounts of data for multiple nodes.


### PR DESCRIPTION
**Motivation**

Make it clearer that this flag should be set on both the beacon node **and** validator client.

**Description**

Removes beacon node command prefix from `--monitoring.*` flags. 

We have several other places in docs where we omit this as well and I think it makes sense to do for flags that are applicable to both the beacon node and validator client.

It also makes it easier to copy and paste as most users already have an existing command and just they just want to add the flag to enable client monitoring.
