### PR TITLE
feat: forkchoice to track head vote by proto index

### DIFF
--- a/packages/beacon-node/src/chain/archiver/index.ts
+++ b/packages/beacon-node/src/chain/archiver/index.ts
@@ -106,12 +106,13 @@ export class Archiver {
       this.chain.regen.pruneOnFinalized(finalizedEpoch);
 
       // tasks rely on extended fork choice
-      this.chain.forkChoice.prune(finalized.rootHex);
+      const prunedBlocks = this.chain.forkChoice.prune(finalized.rootHex);
       await this.updateBackfillRange(finalized);
 
       this.logger.verbose("Finish processing finalized checkpoint", {
         epoch: finalizedEpoch,
         rootHex: finalized.rootHex,
+        prunedBlocks: prunedBlocks.length,
       });
     } catch (e) {
       this.logger.error("Error processing finalized checkpoint", {epoch: finalized.epoch}, e as Error);

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -186,7 +186,7 @@ export class ForkChoice implements IForkChoice {
     const oldBalances = this.balances;
     const newBalances = this.fcStore.justified.balances;
     const deltas = computeDeltas(
-      this.protoArray.indices.size,
+      this.protoArray.nodes.length,
       this.votes,
       oldBalances,
       newBalances,

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -672,6 +672,11 @@ export class ForkChoice implements IForkChoice {
     const prunedNodes = this.protoArray.maybePrune(finalizedRoot);
     const prunedCount = prunedNodes.length;
     for (const vote of this.votes) {
+      // validator has never voted
+      if (vote === undefined) {
+        continue;
+      }
+
       if (vote.currentIndex !== null) {
         if (vote.currentIndex >= prunedCount) {
           vote.currentIndex -= prunedCount;
@@ -680,6 +685,7 @@ export class ForkChoice implements IForkChoice {
           vote.currentIndex = null;
         }
       }
+
       if (vote.nextIndex !== null) {
         if (vote.nextIndex >= prunedCount) {
           vote.nextIndex -= prunedCount;

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -555,7 +555,7 @@ export class ForkChoice implements IForkChoice {
     }
     return {
       epoch: vote.nextEpoch,
-      root: this.protoArray.nodes[vote.nextIndex].blockRoot,
+      root: vote.nextIndex === null ? HEX_ZERO_HASH : this.protoArray.nodes[vote.nextIndex].blockRoot,
     };
   }
 
@@ -673,9 +673,21 @@ export class ForkChoice implements IForkChoice {
     const prunedCount = prunedNodes.length;
     for (const vote of this.votes) {
       if (vote.currentIndex !== null) {
-        vote.currentIndex -= prunedCount;
+        if (vote.currentIndex >= prunedCount) {
+          vote.currentIndex -= prunedCount;
+        } else {
+          // the vote was for a pruned proto node
+          vote.currentIndex = null;
+        }
       }
-      vote.nextIndex -= prunedCount;
+      if (vote.nextIndex !== null) {
+        if (vote.nextIndex >= prunedCount) {
+          vote.nextIndex -= prunedCount;
+        } else {
+          // the vote was for a pruned proto node
+          vote.nextIndex = null;
+        }
+      }
     }
     return prunedNodes;
   }

--- a/packages/fork-choice/src/protoArray/computeDeltas.ts
+++ b/packages/fork-choice/src/protoArray/computeDeltas.ts
@@ -1,6 +1,6 @@
 import {ValidatorIndex} from "@lodestar/types";
 import {EffectiveBalanceIncrements} from "@lodestar/state-transition";
-import {VoteTracker, HEX_ZERO_HASH} from "./interface.js";
+import {VoteTracker} from "./interface.js";
 import {ProtoArrayError, ProtoArrayErrorCode} from "./errors.js";
 
 /**
@@ -13,31 +13,16 @@ import {ProtoArrayError, ProtoArrayErrorCode} from "./errors.js";
  * - If a value in `indices` is greater to or equal to `indices.length`.
  */
 export function computeDeltas(
-  indices: Map<string, number>,
+  numProtoNodes: number,
   votes: VoteTracker[],
   oldBalances: EffectiveBalanceIncrements,
   newBalances: EffectiveBalanceIncrements,
   equivocatingIndices: Set<ValidatorIndex>
 ): number[] {
-  const deltas = Array<number>(indices.size).fill(0);
-  const zeroHash = HEX_ZERO_HASH;
+  const deltas = Array<number>(numProtoNodes).fill(0);
   // avoid creating new variables in the loop to potentially reduce GC pressure
   let oldBalance, newBalance: number;
-  let currentRoot, nextRoot: string;
-  let currentDeltaIndex, nextDeltaIndex: number | undefined;
-  // this function tends to get some very few roots from `indices` so create a small cache to improve performance
-  const cachedIndices = new Map<string, number>();
-
-  const getIndex = (root: string): number | undefined => {
-    let index = cachedIndices.get(root);
-    if (index === undefined) {
-      index = indices.get(root);
-      if (index !== undefined) {
-        cachedIndices.set(root, index);
-      }
-    }
-    return index;
-  };
+  let currentIndex, nextIndex: number;
 
   for (let vIndex = 0; vIndex < votes.length; vIndex++) {
     const vote = votes[vIndex];
@@ -46,11 +31,8 @@ export function computeDeltas(
     if (vote === undefined) {
       continue;
     }
-    currentRoot = vote.currentRoot;
-    nextRoot = vote.nextRoot;
-    if (currentRoot === zeroHash && nextRoot === zeroHash) {
-      continue;
-    }
+    currentIndex = vote.currentIndex;
+    nextIndex = vote.nextIndex;
 
     // IF the validator was not included in the _old_ balances (i.e. it did not exist yet)
     // then say its balance was 0
@@ -65,49 +47,43 @@ export function computeDeltas(
 
     if (equivocatingIndices.size > 0 && equivocatingIndices.has(vIndex)) {
       // this function could be called multiple times but we only want to process slashing validator for 1 time
-      if (currentRoot !== zeroHash) {
-        currentDeltaIndex = getIndex(currentRoot);
-        if (currentDeltaIndex !== undefined) {
-          if (currentDeltaIndex >= deltas.length) {
-            throw new ProtoArrayError({
-              code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
-              index: currentDeltaIndex,
-            });
-          }
-          deltas[currentDeltaIndex] -= oldBalance;
+      if (currentIndex !== null) {
+        if (currentIndex >= numProtoNodes) {
+          throw new ProtoArrayError({
+            code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
+            index: currentIndex,
+          });
         }
+        deltas[currentIndex] -= oldBalance;
       }
-      vote.currentRoot = zeroHash;
+      vote.currentIndex = null;
       continue;
     }
 
-    if (currentRoot !== nextRoot || oldBalance !== newBalance) {
+    if (currentIndex !== nextIndex || oldBalance !== newBalance) {
       // We ignore the vote if it is not known in `indices .
       // We assume that it is outside of our tree (ie: pre-finalization) and therefore not interesting
-      currentDeltaIndex = getIndex(currentRoot);
-      if (currentDeltaIndex !== undefined) {
-        if (currentDeltaIndex >= deltas.length) {
+      if (currentIndex !== null) {
+        if (currentIndex >= numProtoNodes) {
           throw new ProtoArrayError({
             code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
-            index: currentDeltaIndex,
+            index: currentIndex,
           });
         }
-        deltas[currentDeltaIndex] -= oldBalance;
+        deltas[currentIndex] -= oldBalance;
       }
+
       // We ignore the vote if it is not known in `indices .
       // We assume that it is outside of our tree (ie: pre-finalization) and therefore not interesting
-      nextDeltaIndex = getIndex(nextRoot);
-      if (nextDeltaIndex !== undefined) {
-        if (nextDeltaIndex >= deltas.length) {
-          throw new ProtoArrayError({
-            code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
-            index: nextDeltaIndex,
-          });
-        }
-        deltas[nextDeltaIndex] += newBalance;
+      if (nextIndex >= numProtoNodes) {
+        throw new ProtoArrayError({
+          code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
+          index: nextIndex,
+        });
       }
+      deltas[nextIndex] += newBalance;
     }
-    vote.currentRoot = nextRoot;
+    vote.currentIndex = nextIndex;
   }
 
   return deltas;

--- a/packages/fork-choice/src/protoArray/computeDeltas.ts
+++ b/packages/fork-choice/src/protoArray/computeDeltas.ts
@@ -19,7 +19,11 @@ export function computeDeltas(
   newBalances: EffectiveBalanceIncrements,
   equivocatingIndices: Set<ValidatorIndex>
 ): number[] {
-  const deltas = Array<number>(numProtoNodes).fill(0);
+  const deltas = new Array<number>(numProtoNodes);
+  for (let i = 0; i < numProtoNodes; i++) {
+    deltas[i] = 0;
+  }
+
   // avoid creating new variables in the loop to potentially reduce GC pressure
   let oldBalance, newBalance: number;
   let currentIndex, nextIndex: number | null;

--- a/packages/fork-choice/src/protoArray/computeDeltas.ts
+++ b/packages/fork-choice/src/protoArray/computeDeltas.ts
@@ -22,7 +22,7 @@ export function computeDeltas(
   const deltas = Array<number>(numProtoNodes).fill(0);
   // avoid creating new variables in the loop to potentially reduce GC pressure
   let oldBalance, newBalance: number;
-  let currentIndex, nextIndex: number;
+  let currentIndex, nextIndex: number | null;
 
   for (let vIndex = 0; vIndex < votes.length; vIndex++) {
     const vote = votes[vIndex];
@@ -75,13 +75,15 @@ export function computeDeltas(
 
       // We ignore the vote if it is not known in `indices .
       // We assume that it is outside of our tree (ie: pre-finalization) and therefore not interesting
-      if (nextIndex >= numProtoNodes) {
-        throw new ProtoArrayError({
-          code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
-          index: nextIndex,
-        });
+      if (nextIndex !== null) {
+        if (nextIndex >= numProtoNodes) {
+          throw new ProtoArrayError({
+            code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
+            index: nextIndex,
+          });
+        }
+        deltas[nextIndex] += newBalance;
       }
-      deltas[nextIndex] += newBalance;
     }
     vote.currentIndex = nextIndex;
   }

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -10,7 +10,8 @@ export const HEX_ZERO_HASH = "0x000000000000000000000000000000000000000000000000
  */
 export type VoteTracker = {
   currentIndex: number | null;
-  nextIndex: number;
+  // if a vode is out of date (the voted index was in the past while proto array is pruned), it will be set to null
+  nextIndex: number | null;
   nextEpoch: Epoch;
 };
 

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -1,15 +1,17 @@
 import {Epoch, Slot, RootHex, UintNum64} from "@lodestar/types";
 
+// TODO: remove
 // RootHex is a root as a hex string
 // Used for lightweight and easy comparison
 export const HEX_ZERO_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
 /**
  * Simplified 'latest message' with previous message
+ * The index is relative to ProtoArray indices
  */
 export type VoteTracker = {
-  currentRoot: RootHex;
-  nextRoot: RootHex;
+  currentIndex: number | null;
+  nextIndex: number;
   nextEpoch: Epoch;
 };
 

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -1,6 +1,5 @@
 import {Epoch, Slot, RootHex, UintNum64} from "@lodestar/types";
 
-// TODO: remove
 // RootHex is a root as a hex string
 // Used for lightweight and easy comparison
 export const HEX_ZERO_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000";

--- a/packages/fork-choice/test/unit/protoArray/computeDeltas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/computeDeltas.test.ts
@@ -15,21 +15,21 @@ describe("computeDeltas", () => {
     for (const i of Array.from({length: validatorCount}, (_, i) => i)) {
       indices.set(i.toString(), i);
       votes.push({
-        currentRoot: "0",
-        nextRoot: "0",
+        currentIndex: 0,
+        nextIndex: 0,
         nextEpoch: 0,
       });
       oldBalances[i] = 0;
       newBalances[i] = 0;
     }
 
-    const deltas = computeDeltas(indices, votes, oldBalances, newBalances, new Set());
+    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).to.eql(validatorCount);
     expect(deltas).to.deep.equal(Array.from({length: validatorCount}, () => 0));
 
     for (const vote of votes) {
-      expect(vote.currentRoot).to.eql(vote.nextRoot);
+      expect(vote.currentIndex).to.eql(vote.nextIndex);
     }
   });
 
@@ -45,15 +45,15 @@ describe("computeDeltas", () => {
     for (const i of Array.from({length: validatorCount}, (_, i) => i)) {
       indices.set((i + 1).toString(), i);
       votes.push({
-        currentRoot: "0",
-        nextRoot: "1",
+        currentIndex: null,
+        nextIndex: 0,
         nextEpoch: 0,
       });
       oldBalances[i] = balance;
       newBalances[i] = balance;
     }
 
-    const deltas = computeDeltas(indices, votes, oldBalances, newBalances, new Set());
+    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).to.eql(validatorCount);
 
@@ -78,15 +78,15 @@ describe("computeDeltas", () => {
     for (const i of Array.from({length: validatorCount}, (_, i) => i)) {
       indices.set((i + 1).toString(), i);
       votes.push({
-        currentRoot: "0",
-        nextRoot: (i + 1).toString(),
+        currentIndex: null,
+        nextIndex: i,
         nextEpoch: 0,
       });
       oldBalances[i] = balance;
       newBalances[i] = balance;
     }
 
-    const deltas = computeDeltas(indices, votes, oldBalances, newBalances, new Set());
+    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).to.eql(validatorCount);
 
@@ -107,15 +107,15 @@ describe("computeDeltas", () => {
     for (const i of Array.from({length: validatorCount}, (_, i) => i)) {
       indices.set((i + 1).toString(), i);
       votes.push({
-        currentRoot: "1",
-        nextRoot: "2",
+        currentIndex: 0,
+        nextIndex: 1,
         nextEpoch: 0,
       });
       oldBalances[i] = balance;
       newBalances[i] = balance;
     }
 
-    const deltas = computeDeltas(indices, votes, oldBalances, newBalances, new Set());
+    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).to.eql(validatorCount);
 
@@ -132,47 +132,51 @@ describe("computeDeltas", () => {
     }
   });
 
-  it("move out of tree", () => {
-    const balance = 42;
+  /**
+   * Starting Aug 2023, this test case is not valid because when an attestation is added
+   * to forkchoice, the block should come first, i.e. nextIndex should be a number
+   */
+  // it("move out of tree", () => {
+  //   const balance = 42;
 
-    const indices = new Map();
-    // there is only one block
-    indices.set("2", 0);
+  //   const indices = new Map();
+  //   // there is only one block
+  //   indices.set("2", 0);
 
-    // There are two validators
-    const votes = [
-      // one validator moves their vote from the block to the zero hash
-      {
-        currentRoot: "2",
-        nextRoot: "0",
-        nextEpoch: 0,
-      },
-      // one validator moves their vote from the block to something outside the tree
-      {
-        currentRoot: "2",
-        nextRoot: "1337",
-        nextEpoch: 0,
-      },
-    ];
+  //   // There are two validators
+  //   const votes = [
+  //     // one validator moves their vote from the block to the zero hash
+  //     {
+  //       currentRoot: "2",
+  //       nextRoot: "0",
+  //       nextEpoch: 0,
+  //     },
+  //     // one validator moves their vote from the block to something outside the tree
+  //     {
+  //       currentRoot: "2",
+  //       nextRoot: "1337",
+  //       nextEpoch: 0,
+  //     },
+  //   ];
 
-    const oldBalances = getEffectiveBalanceIncrementsZeroed(votes.length);
-    const newBalances = getEffectiveBalanceIncrementsZeroed(votes.length);
-    for (const balances of [oldBalances, newBalances]) {
-      for (let i = 0; i < votes.length; i++) {
-        balances[i] = balance;
-      }
-    }
+  //   const oldBalances = getEffectiveBalanceIncrementsZeroed(votes.length);
+  //   const newBalances = getEffectiveBalanceIncrementsZeroed(votes.length);
+  //   for (const balances of [oldBalances, newBalances]) {
+  //     for (let i = 0; i < votes.length; i++) {
+  //       balances[i] = balance;
+  //     }
+  //   }
 
-    const deltas = computeDeltas(indices, votes, oldBalances, newBalances, new Set());
+  //   const deltas = computeDeltas(indices, votes, oldBalances, newBalances, new Set());
 
-    expect(deltas.length).to.eql(1);
+  //   expect(deltas.length).to.eql(1);
 
-    expect(deltas[0].toString()).to.eql((0 - balance * 2).toString());
+  //   expect(deltas[0].toString()).to.eql((0 - balance * 2).toString());
 
-    for (const vote of votes) {
-      expect(vote.currentRoot).to.equal(vote.nextRoot);
-    }
-  });
+  //   for (const vote of votes) {
+  //     expect(vote.currentRoot).to.equal(vote.nextRoot);
+  //   }
+  // });
 
   it("changing balances", () => {
     const oldBalance = 42;
@@ -187,15 +191,15 @@ describe("computeDeltas", () => {
     for (const i of Array.from({length: validatorCount}, (_, i) => i)) {
       indices.set((i + 1).toString(), i);
       votes.push({
-        currentRoot: "1",
-        nextRoot: "2",
+        currentIndex: 0,
+        nextIndex: 1,
         nextEpoch: 0,
       });
       oldBalances[i] = oldBalance;
       newBalances[i] = newBalance;
     }
 
-    const deltas = computeDeltas(indices, votes, oldBalances, newBalances, new Set());
+    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).to.eql(validatorCount);
 
@@ -220,8 +224,8 @@ describe("computeDeltas", () => {
 
     // Both validators move votes from block1 to block2
     const votes = Array.from({length: 2}, () => ({
-      currentRoot: "2",
-      nextRoot: "3",
+      currentIndex: 0,
+      nextIndex: 1,
       nextEpoch: 0,
     }));
 
@@ -233,7 +237,7 @@ describe("computeDeltas", () => {
     newBalances[0] = balance;
     newBalances[1] = balance;
 
-    const deltas = computeDeltas(indices, votes, oldBalances, newBalances, new Set());
+    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).to.eql(2);
 
@@ -241,7 +245,7 @@ describe("computeDeltas", () => {
     expect(deltas[1].toString()).to.eql((balance * 2).toString());
 
     for (const vote of votes) {
-      expect(vote.currentRoot).to.equal(vote.nextRoot);
+      expect(vote.currentIndex).to.equal(vote.nextIndex);
     }
   });
 
@@ -255,8 +259,8 @@ describe("computeDeltas", () => {
 
     // Both validators move votes from block1 to block2
     const votes = Array.from({length: 2}, () => ({
-      currentRoot: "2",
-      nextRoot: "3",
+      currentIndex: 0,
+      nextIndex: 1,
       nextEpoch: 0,
     }));
     // There are two validators in the old balances.
@@ -267,7 +271,7 @@ describe("computeDeltas", () => {
     const newBalances = getEffectiveBalanceIncrementsZeroed(1);
     newBalances[0] = balance;
 
-    const deltas = computeDeltas(indices, votes, oldBalances, newBalances, new Set());
+    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).to.eql(2);
 
@@ -275,7 +279,7 @@ describe("computeDeltas", () => {
     expect(deltas[1].toString()).to.eql(balance.toString());
 
     for (const vote of votes) {
-      expect(vote.currentRoot).to.equal(vote.nextRoot);
+      expect(vote.currentIndex).to.equal(vote.nextIndex);
     }
   });
 
@@ -290,21 +294,21 @@ describe("computeDeltas", () => {
 
     // Both validators move votes from block1 to block2
     const votes = Array.from({length: 2}, () => ({
-      currentRoot: "2",
-      nextRoot: "3",
+      currentIndex: 0,
+      nextIndex: 1,
       nextEpoch: 0,
     }));
 
     const balances = new Uint8Array([firstBalance, secondBalance]);
     // 1st validator is part of an attester slashing
     const equivocatingIndices = new Set([0]);
-    let deltas = computeDeltas(indices, votes, balances, balances, equivocatingIndices);
+    let deltas = computeDeltas(indices.size, votes, balances, balances, equivocatingIndices);
     expect(deltas[0]).to.be.equals(
       -1 * (firstBalance + secondBalance),
       "should disregard the 1st validator due to attester slashing"
     );
     expect(deltas[1]).to.be.equals(secondBalance, "should move 2nd balance from 1st root to 2nd root");
-    deltas = computeDeltas(indices, votes, balances, balances, equivocatingIndices);
+    deltas = computeDeltas(indices.size, votes, balances, balances, equivocatingIndices);
     expect(deltas).to.be.deep.equals([0, 0], "calling computeDeltas again should not have any affect on the weight");
   });
 });


### PR DESCRIPTION
**Motivation**

- In `computeDeltas` we have to get index from root twice for each vote so @dapplion suggested we can store vote by proto index instead

**Description**

- Tracking votes by proto index helps `computeDeltas()` 2x-3x faster as tested in my local environment
- It takes a little more time when `prune` but it happens per epoch while `computeDeltas()` happens twice per slot
- With this change it takes 1 extra index lookup per vote per epoch in `addLatestMessage()`, while the old way takes 2x2x32 = 128 lookups per vote per epoch in computeDeltas (2 lookups for 2 roots, `computeDeltas()` is called 2 per slot ) and it happens at once so it's worth the change

Closes #5852

**TODOs**

- [ ] Test this change in a group