### PR TITLE
feat: selectively use nodejs crypto for noise

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -95,7 +95,6 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/as-chacha20poly1305": "^0.1.0",
     "@chainsafe/as-sha256": "^0.3.1",
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/blst": "^0.2.9",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -160,6 +160,8 @@
     "@types/supertest": "^2.0.12",
     "@types/tmp": "^0.2.3",
     "eventsource": "^2.0.2",
+    "it-pair": "^2.0.6",
+    "it-drain": "^3.0.3",
     "leveldown": "^6.1.1",
     "rewiremock": "^3.14.5",
     "rimraf": "^4.4.1",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -95,6 +95,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
+    "@chainsafe/as-chacha20poly1305": "^0.1.0",
     "@chainsafe/as-sha256": "^0.3.1",
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/blst": "^0.2.9",

--- a/packages/beacon-node/src/network/libp2p/noise.ts
+++ b/packages/beacon-node/src/network/libp2p/noise.ts
@@ -1,23 +1,30 @@
+import crypto from "node:crypto";
 import type {ConnectionEncrypter} from "@libp2p/interface/connection-encrypter";
-import {newInstance, ChaCha20Poly1305} from "@chainsafe/as-chacha20poly1305";
 import {ICryptoInterface, noise, pureJsCrypto} from "@chainsafe/libp2p-noise";
-import {digest} from "@chainsafe/as-sha256";
 
 type Bytes = Uint8Array;
 type Bytes32 = Uint8Array;
 
-const ctx = newInstance();
-const asImpl = new ChaCha20Poly1305(ctx);
+const CHACHA_POLY1305 = "chacha20-poly1305";
 
-// same to stablelib but we use as-chacha20poly1305 and as-sha256
+// same as default, but we use node crypto chacha20poly1305 and sha256
 const lodestarCrypto: ICryptoInterface = {
   ...pureJsCrypto,
   hashSHA256(data: Uint8Array): Uint8Array {
-    return digest(data);
+    return crypto.createHash("sha256").update(data).digest();
   },
 
   chaCha20Poly1305Encrypt(plaintext: Uint8Array, nonce: Uint8Array, ad: Uint8Array, k: Bytes32): Bytes {
-    return asImpl.seal(k, nonce, plaintext, ad);
+    const cipher = crypto.createCipheriv(CHACHA_POLY1305, k, nonce, {
+      authTagLength: 16,
+    });
+    cipher.setAAD(ad, {plaintextLength: plaintext.byteLength});
+    const updated = cipher.update(plaintext);
+    const final = cipher.final();
+    const tag = cipher.getAuthTag();
+
+    const encrypted = Buffer.concat([updated, tag, final]);
+    return encrypted;
   },
 
   chaCha20Poly1305Decrypt(
@@ -25,9 +32,23 @@ const lodestarCrypto: ICryptoInterface = {
     nonce: Uint8Array,
     ad: Uint8Array,
     k: Bytes32,
-    dst?: Uint8Array
+    _dst?: Uint8Array
   ): Bytes | null {
-    return asImpl.open(k, nonce, ciphertext, ad, dst);
+    const authTag = ciphertext.slice(ciphertext.length - 16);
+    const text = ciphertext.slice(0, ciphertext.length - 16);
+    const decipher = crypto.createDecipheriv(CHACHA_POLY1305, k, nonce, {
+      authTagLength: 16,
+    });
+    decipher.setAAD(ad, {
+      plaintextLength: text.byteLength,
+    });
+    decipher.setAuthTag(authTag);
+    const updated = decipher.update(text);
+    const final = decipher.final();
+    if (final.byteLength > 0) {
+      return Buffer.concat([updated, final]);
+    }
+    return updated;
   },
 };
 

--- a/packages/beacon-node/src/network/libp2p/noise.ts
+++ b/packages/beacon-node/src/network/libp2p/noise.ts
@@ -1,20 +1,20 @@
 import crypto from "node:crypto";
 import type {ConnectionEncrypter} from "@libp2p/interface/connection-encrypter";
 import {ICryptoInterface, noise, pureJsCrypto} from "@chainsafe/libp2p-noise";
+import {digest} from "@chainsafe/as-sha256";
+import {newInstance, ChaCha20Poly1305} from "@chainsafe/as-chacha20poly1305";
 
-type Bytes = Uint8Array;
-type Bytes32 = Uint8Array;
+const ctx = newInstance();
+const asImpl = new ChaCha20Poly1305(ctx);
 
 const CHACHA_POLY1305 = "chacha20-poly1305";
 
-// same as default, but we use node crypto chacha20poly1305 and sha256
-const lodestarCrypto: ICryptoInterface = {
-  ...pureJsCrypto,
-  hashSHA256(data: Uint8Array): Uint8Array {
+const nodeCrypto: Pick<ICryptoInterface, "hashSHA256" | "chaCha20Poly1305Encrypt" | "chaCha20Poly1305Decrypt"> = {
+  hashSHA256(data) {
     return crypto.createHash("sha256").update(data).digest();
   },
 
-  chaCha20Poly1305Encrypt(plaintext: Uint8Array, nonce: Uint8Array, ad: Uint8Array, k: Bytes32): Bytes {
+  chaCha20Poly1305Encrypt(plaintext, nonce, ad, k) {
     const cipher = crypto.createCipheriv(CHACHA_POLY1305, k, nonce, {
       authTagLength: 16,
     });
@@ -27,13 +27,7 @@ const lodestarCrypto: ICryptoInterface = {
     return encrypted;
   },
 
-  chaCha20Poly1305Decrypt(
-    ciphertext: Uint8Array,
-    nonce: Uint8Array,
-    ad: Uint8Array,
-    k: Bytes32,
-    _dst?: Uint8Array
-  ): Bytes | null {
+  chaCha20Poly1305Decrypt(ciphertext, nonce, ad, k, _dst) {
     const authTag = ciphertext.slice(ciphertext.length - 16);
     const text = ciphertext.slice(0, ciphertext.length - 16);
     const decipher = crypto.createDecipheriv(CHACHA_POLY1305, k, nonce, {
@@ -49,6 +43,40 @@ const lodestarCrypto: ICryptoInterface = {
       return Buffer.concat([updated, final]);
     }
     return updated;
+  },
+};
+
+const asCrypto: Pick<ICryptoInterface, "hashSHA256" | "chaCha20Poly1305Encrypt" | "chaCha20Poly1305Decrypt"> = {
+  hashSHA256(data) {
+    return digest(data);
+  },
+  chaCha20Poly1305Encrypt(plaintext, nonce, ad, k) {
+    return asImpl.seal(k, nonce, plaintext, ad);
+  },
+  chaCha20Poly1305Decrypt(ciphertext, nonce, ad, k, dst) {
+    return asImpl.open(k, nonce, ciphertext, ad, dst);
+  },
+};
+
+// benchmarks show that for chacha20poly1305
+// the as implementation is faster for smaller payloads(<1200)
+// and the node implementation is faster for larger payloads
+const lodestarCrypto: ICryptoInterface = {
+  ...pureJsCrypto,
+  hashSHA256(data) {
+    return nodeCrypto.hashSHA256(data);
+  },
+  chaCha20Poly1305Encrypt(plaintext, nonce, ad, k) {
+    if (plaintext.length < 1200) {
+      return asCrypto.chaCha20Poly1305Encrypt(plaintext, nonce, ad, k);
+    }
+    return nodeCrypto.chaCha20Poly1305Encrypt(plaintext, nonce, ad, k);
+  },
+  chaCha20Poly1305Decrypt(ciphertext, nonce, ad, k, dst) {
+    if (ciphertext.length < 1200) {
+      return asCrypto.chaCha20Poly1305Decrypt(ciphertext, nonce, ad, k, dst);
+    }
+    return nodeCrypto.chaCha20Poly1305Decrypt(ciphertext, nonce, ad, k, dst);
   },
 };
 

--- a/packages/beacon-node/test/perf/network/noise/sendData.test.ts
+++ b/packages/beacon-node/test/perf/network/noise/sendData.test.ts
@@ -8,7 +8,17 @@ import {createNoise} from "../../../../src/network/libp2p/noise.js";
 describe("network / noise / sendData", () => {
   const numberOfMessages = 1000;
 
-  for (const messageLength of [2 ** 8, 2 ** 9, 2 ** 10, 2 ** 11, 2 ** 12, 2 ** 14, 2 ** 16]) {
+  for (const messageLength of [
+    //
+    2 ** 8,
+    2 ** 9,
+    2 ** 10,
+    1200,
+    2 ** 11,
+    2 ** 12,
+    2 ** 14,
+    2 ** 16,
+  ]) {
     itBench({
       id: `send data - ${numberOfMessages} ${messageLength}B messages`,
       beforeEach: async () => {

--- a/packages/beacon-node/test/perf/network/noise/sendData.test.ts
+++ b/packages/beacon-node/test/perf/network/noise/sendData.test.ts
@@ -1,0 +1,42 @@
+import {itBench} from "@dapplion/benchmark";
+import {duplexPair} from "it-pair/duplex";
+import {createSecp256k1PeerId} from "@libp2p/peer-id-factory";
+import {pipe} from "it-pipe";
+import drain from "it-drain";
+import {createNoise} from "../../../../src/network/libp2p/noise.js";
+
+describe("network / noise / sendData", () => {
+  const numberOfMessages = 1000;
+
+  for (const messageLength of [2 ** 8, 2 ** 9, 2 ** 10, 2 ** 11, 2 ** 12, 2 ** 14, 2 ** 16]) {
+    itBench({
+      id: `send data - ${numberOfMessages} ${messageLength}B messages`,
+      beforeEach: async () => {
+        const peerA = await createSecp256k1PeerId();
+        const peerB = await createSecp256k1PeerId();
+        const noiseA = createNoise()();
+        const noiseB = createNoise()();
+
+        const [inboundConnection, outboundConnection] = duplexPair<Uint8Array>();
+        const [outbound, inbound] = await Promise.all([
+          noiseA.secureOutbound(peerA, outboundConnection, peerB),
+          noiseB.secureInbound(peerB, inboundConnection, peerA),
+        ]);
+
+        return {connA: outbound.conn, connB: inbound.conn, data: new Uint8Array(messageLength)};
+      },
+      fn: async ({connA, connB, data}) => {
+        await Promise.all([
+          //
+          pipe(connB.source, connB.sink),
+          pipe(function* () {
+            for (let i = 0; i < numberOfMessages; i++) {
+              yield data;
+            }
+          }, connA.sink),
+          pipe(connB.source, drain),
+        ]);
+      },
+    });
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,11 +436,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chainsafe/as-chacha20poly1305@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/as-chacha20poly1305/-/as-chacha20poly1305-0.1.0.tgz#7da6f8796f9b42dac6e830a086d964f1f9189e09"
-  integrity sha512-BpNcL8/lji/GM3+vZ/bgRWqJ1q5kwvTFmGPk7pxm/QQZDbaMI98waOHjEymTjq2JmdD/INdNBFOVSyJofXg7ew==
-
 "@chainsafe/as-sha256@^0.3.1":
   version "0.3.1"
   resolved "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8500,6 +8500,11 @@ it-drain@^3.0.1, it-drain@^3.0.2:
   resolved "https://registry.yarnpkg.com/it-drain/-/it-drain-3.0.2.tgz#4fb2ab30119072268c68a895fa5b9f2037942c44"
   integrity sha512-0hJvS/4Ktt9wT/bktmovjjMAY8r6FCsXqpL3zjqBBNwoL21VgQfguEnwbLSGuCip9Zq1vfU43cbHkmaRZdBfOg==
 
+it-drain@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/it-drain/-/it-drain-3.0.3.tgz#f80719d3d0d7e7d02dc298d86ca9d0e7f7bd666b"
+  integrity sha512-l4s+izxUpFAR2axprpFiCaq0EtxK1QMd0LWbEtau5b+OegiZ5xdRtz35iJyh6KZY9QtuwEiQxydiOfYJc7stoA==
+
 it-filter@^3.0.0, it-filter@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/it-filter/-/it-filter-3.0.2.tgz#19ddf6185ea21d417e6075d5796c799fa2633b69"

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,6 +436,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@chainsafe/as-chacha20poly1305@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/as-chacha20poly1305/-/as-chacha20poly1305-0.1.0.tgz#7da6f8796f9b42dac6e830a086d964f1f9189e09"
+  integrity sha512-BpNcL8/lji/GM3+vZ/bgRWqJ1q5kwvTFmGPk7pxm/QQZDbaMI98waOHjEymTjq2JmdD/INdNBFOVSyJofXg7ew==
+
 "@chainsafe/as-sha256@^0.3.1":
   version "0.3.1"
   resolved "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz"


### PR DESCRIPTION
**Motivation**

- noise crypto isn't free, lets see how we can do it better/faster
- See https://github.com/libp2p/js-libp2p/issues/1420#issuecomment-1572587139, specifically, this PR uses the crypto recommended by @dao-xyz/libp2p-noise

**Description**

- Use nodejs sha256, benchmarks show that it is faster for all payloads except for 64 byte payloads
- For chacha20poly1305, use the as implementation for smaller payloads, use nodejs crypto for larger payloads
- [x] benchmark