### PR TITLE
chore: use regular for loop for forkchoice prune

### DIFF
--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -671,7 +671,8 @@ export class ForkChoice implements IForkChoice {
   prune(finalizedRoot: RootHex): ProtoBlock[] {
     const prunedNodes = this.protoArray.maybePrune(finalizedRoot);
     const prunedCount = prunedNodes.length;
-    for (const vote of this.votes) {
+    for (let i = 0; i < this.votes.length; i++) {
+      const vote = this.votes[i];
       // validator has never voted
       if (vote === undefined) {
         continue;


### PR DESCRIPTION
**Motivation**

From https://github.com/ChainSafe/lodestar/pull/5882#discussion_r1296481759

**Description**

Use regular for loop to improve performance a bit in forkchoice prune() function