### PR TITLE
feat: take profiles of main thread and discv5 thread

### DIFF
--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -74,11 +74,14 @@ export type LodestarNodePeer = NodePeer & {
   agentVersion: string;
 };
 
+export type LodestarThreadType = "main" | "network" | "discv5";
+
 export type Api = {
   /** Trigger to write a heapdump to disk at `dirpath`. May take > 1min */
   writeHeapdump(dirpath?: string): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: {filepath: string}}}>>;
   /** Trigger to write 10m network thread profile to disk */
-  writeNetworkThreadProfile(
+  writeProfile(
+    thread?: LodestarThreadType,
     duration?: number,
     dirpath?: string
   ): Promise<ApiClientResponse<{[HttpStatusCode.OK]: {data: {filepath: string}}}>>;
@@ -130,7 +133,7 @@ export type Api = {
  */
 export const routesData: RoutesData<Api> = {
   writeHeapdump: {url: "/eth/v1/lodestar/write_heapdump", method: "POST"},
-  writeNetworkThreadProfile: {url: "/eth/v1/lodestar/write_network_thread_profile", method: "POST"},
+  writeProfile: {url: "/eth/v1/lodestar/write_profile", method: "POST"},
   getLatestWeakSubjectivityCheckpointEpoch: {url: "/eth/v1/lodestar/ws_epoch", method: "GET"},
   getSyncChainsDebugState: {url: "/eth/v1/lodestar/sync_chains_debug_state", method: "GET"},
   getGossipQueueItems: {url: "/eth/v1/lodestar/gossip_queue_items/:gossipType", method: "GET"},
@@ -151,7 +154,7 @@ export const routesData: RoutesData<Api> = {
 
 export type ReqTypes = {
   writeHeapdump: {query: {dirpath?: string}};
-  writeNetworkThreadProfile: {query: {duration?: number; dirpath?: string}};
+  writeProfile: {query: {thread?: LodestarThreadType; duration?: number; dirpath?: string}};
   getLatestWeakSubjectivityCheckpointEpoch: ReqEmpty;
   getSyncChainsDebugState: ReqEmpty;
   getGossipQueueItems: {params: {gossipType: string}};
@@ -177,9 +180,9 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
       parseReq: ({query}) => [query.dirpath],
       schema: {query: {dirpath: Schema.String}},
     },
-    writeNetworkThreadProfile: {
-      writeReq: (duration, dirpath) => ({query: {duration, dirpath}}),
-      parseReq: ({query}) => [query.duration, query.dirpath],
+    writeProfile: {
+      writeReq: (thread, duration, dirpath) => ({query: {thread, duration, dirpath}}),
+      parseReq: ({query}) => [query.thread, query.duration, query.dirpath],
       schema: {query: {dirpath: Schema.String}},
     },
     getLatestWeakSubjectivityCheckpointEpoch: reqEmpty,
@@ -224,7 +227,7 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 export function getReturnTypes(): ReturnTypes<Api> {
   return {
     writeHeapdump: sameType(),
-    writeNetworkThreadProfile: sameType(),
+    writeProfile: sameType(),
     getLatestWeakSubjectivityCheckpointEpoch: sameType(),
     getSyncChainsDebugState: jsonType("snake"),
     getGossipQueueItems: jsonType("snake"),

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import {toHexString} from "@chainsafe/ssz";
 import {routes, ServerApi} from "@lodestar/api";
 import {Repository} from "@lodestar/db";
@@ -5,11 +7,14 @@ import {toHex} from "@lodestar/utils";
 import {getLatestWeakSubjectivityCheckpointEpoch} from "@lodestar/state-transition";
 import {ChainForkConfig} from "@lodestar/config";
 import {ssz} from "@lodestar/types";
+import {LodestarThreadType} from "@lodestar/api/lib/beacon/routes/lodestar.js";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {BeaconChain} from "../../../chain/index.js";
 import {QueuedStateRegenerator, RegenRequest} from "../../../chain/regen/index.js";
 import {GossipType} from "../../../network/index.js";
 import {IBeaconDb} from "../../../db/interface.js";
 import {ApiModules} from "../types.js";
+import {profileNodeJS} from "../../../util/profile.js";
 
 export function getLodestarApi({
   chain,
@@ -19,7 +24,8 @@ export function getLodestarApi({
   sync,
 }: Pick<ApiModules, "chain" | "config" | "db" | "network" | "sync">): ServerApi<routes.lodestar.Api> {
   let writingHeapdump = false;
-  let writingNetworkProfile = false;
+  let writingProfile = false;
+  const defaultProfileMs = SLOTS_PER_EPOCH * config.SECONDS_PER_SLOT * 1000;
 
   return {
     async writeHeapdump(dirpath = ".") {
@@ -48,16 +54,30 @@ export function getLodestarApi({
       }
     },
 
-    async writeNetworkThreadProfile(durationMs?: number, dirpath?: string) {
-      if (writingNetworkProfile) {
+    async writeProfile(thread: LodestarThreadType = "network", durationMs = defaultProfileMs, dirpath = ".") {
+      if (writingProfile) {
         throw Error("Already writing network profile");
       }
+      writingProfile = true;
 
       try {
-        const filepath = await network.writeNetworkThreadProfile(durationMs, dirpath);
+        let filepath: string;
+        let profile: string;
+        switch (thread) {
+          case "network":
+            filepath = await network.writeNetworkThreadProfile(durationMs, dirpath);
+            break;
+          // TODO: discv5
+          default:
+            // main thread
+            profile = await profileNodeJS(durationMs);
+            filepath = path.join(dirpath, `main_thread_${new Date().toISOString()}.cpuprofile`);
+            fs.writeFileSync(filepath, profile);
+            break;
+        }
         return {data: {filepath}};
       } finally {
-        writingNetworkProfile = false;
+        writingProfile = false;
       }
     },
 

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -67,7 +67,9 @@ export function getLodestarApi({
           case "network":
             filepath = await network.writeNetworkThreadProfile(durationMs, dirpath);
             break;
-          // TODO: discv5
+          case "discv5":
+            filepath = await network.writeDiscv5Profile(durationMs, dirpath);
+            break;
           default:
             // main thread
             profile = await profileNodeJS(durationMs);

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -421,6 +421,10 @@ export class NetworkCore implements INetworkCore {
     throw new Error("Method not implemented, please configure network thread");
   }
 
+  async writeDiscv5Profile(durationMs: number, dirpath: string): Promise<string> {
+    return this.peerManager["discovery"]?.discv5.writeProfile(durationMs, dirpath) ?? "no discv5";
+  }
+
   /**
    * Handle subscriptions through fork transitions, @see FORK_EPOCH_LOOKAHEAD
    */

--- a/packages/beacon-node/src/network/core/networkCoreWorker.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorker.ts
@@ -157,6 +157,9 @@ const libp2pWorkerApi: NetworkWorkerApi = {
     fs.writeFileSync(filePath, profile);
     return filePath;
   },
+  writeDiscv5Profile: async (durationMs: number, dirpath: string) => {
+    return core.writeDiscv5Profile(durationMs, dirpath);
+  },
 };
 
 expose(libp2pWorkerApi as WorkerModule<keyof NetworkWorkerApi>);

--- a/packages/beacon-node/src/network/core/networkCoreWorker.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorker.ts
@@ -6,7 +6,6 @@ import {expose} from "@chainsafe/threads/worker";
 import type {WorkerModule} from "@chainsafe/threads/dist/types/worker.js";
 import {chainConfigFromJson, createBeaconConfig} from "@lodestar/config";
 import {getNodeLogger} from "@lodestar/logger/node";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {collectNodeJSMetrics, RegistryMetricCreator} from "../../metrics/index.js";
 import {AsyncIterableBridgeCaller, AsyncIterableBridgeHandler} from "../../util/asyncIterableToEvents.js";
 import {Clock} from "../../util/clock.js";
@@ -36,7 +35,6 @@ if (!parentPort) throw Error("parentPort must be defined");
 
 const config = createBeaconConfig(chainConfigFromJson(workerData.chainConfigJson), workerData.genesisValidatorsRoot);
 const peerId = await createFromProtobuf(workerData.peerIdProto);
-const DEFAULT_PROFILE_DURATION = SLOTS_PER_EPOCH * config.SECONDS_PER_SLOT * 1000;
 
 // TODO: Pass options from main thread for logging
 // TODO: Logging won't be visible in file loggers
@@ -153,7 +151,7 @@ const libp2pWorkerApi: NetworkWorkerApi = {
   dumpGossipPeerScoreStats: () => core.dumpGossipPeerScoreStats(),
   dumpDiscv5KadValues: () => core.dumpDiscv5KadValues(),
   dumpMeshPeers: () => core.dumpMeshPeers(),
-  writeProfile: async (durationMs = DEFAULT_PROFILE_DURATION, dirpath = ".") => {
+  writeProfile: async (durationMs: number, dirpath: string) => {
     const profile = await profileNodeJS(durationMs);
     const filePath = path.join(dirpath, `network_thread_${new Date().toISOString()}.cpuprofile`);
     fs.writeFileSync(filePath, profile);

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -213,6 +213,9 @@ export class WorkerNetworkCore implements INetworkCore {
   writeNetworkThreadProfile(durationMs: number, dirpath: string): Promise<string> {
     return this.getApi().writeProfile(durationMs, dirpath);
   }
+  writeDiscv5Profile(durationMs: number, dirpath: string): Promise<string> {
+    return this.getApi().writeDiscv5Profile(durationMs, dirpath);
+  }
 
   private getApi(): NetworkWorkerApi {
     return this.modules.workerApi;

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -210,7 +210,7 @@ export class WorkerNetworkCore implements INetworkCore {
   dumpMeshPeers(): Promise<Record<string, string[]>> {
     return this.getApi().dumpMeshPeers();
   }
-  writeNetworkThreadProfile(durationMs?: number, dirpath?: string): Promise<string> {
+  writeNetworkThreadProfile(durationMs: number, dirpath: string): Promise<string> {
     return this.getApi().writeProfile(durationMs, dirpath);
   }
 

--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -62,6 +62,7 @@ export interface INetworkCore extends INetworkCorePublic {
   close(): Promise<void>;
   scrapeMetrics(): Promise<string>;
   writeNetworkThreadProfile(durationMs: number, dirpath: string): Promise<string>;
+  writeDiscv5Profile(durationMs: number, dirpath: string): Promise<string>;
 }
 
 /**
@@ -101,6 +102,7 @@ export type NetworkWorkerApi = INetworkCorePublic & {
   close(): Promise<void>;
   scrapeMetrics(): Promise<string>;
   writeProfile(durationMs: number, dirpath: string): Promise<string>;
+  writeDiscv5Profile(durationMs: number, dirpath: string): Promise<string>;
 
   // TODO: ReqResp outgoing
   // TODO: ReqResp incoming

--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -61,7 +61,7 @@ export interface INetworkCore extends INetworkCorePublic {
 
   close(): Promise<void>;
   scrapeMetrics(): Promise<string>;
-  writeNetworkThreadProfile(durationMs?: number, dirpath?: string): Promise<string>;
+  writeNetworkThreadProfile(durationMs: number, dirpath: string): Promise<string>;
 }
 
 /**
@@ -100,7 +100,7 @@ export type NetworkWorkerApi = INetworkCorePublic & {
 
   close(): Promise<void>;
   scrapeMetrics(): Promise<string>;
-  writeProfile(durationMs?: number, dirpath?: string): Promise<string>;
+  writeProfile(durationMs: number, dirpath: string): Promise<string>;
 
   // TODO: ReqResp outgoing
   // TODO: ReqResp incoming

--- a/packages/beacon-node/src/network/discv5/index.ts
+++ b/packages/beacon-node/src/network/discv5/index.ts
@@ -103,6 +103,10 @@ export class Discv5Worker extends (EventEmitter as {new (): StrictEventEmitter<E
     return this.workerApi.scrapeMetrics();
   }
 
+  async writeProfile(durationMs: number, dirpath: string): Promise<string> {
+    return this.workerApi.writeProfile(durationMs, dirpath);
+  }
+
   private decodeEnrs(objs: ENRData[]): ENR[] {
     const enrs: ENR[] = [];
     for (const obj of objs) {

--- a/packages/beacon-node/src/network/discv5/types.ts
+++ b/packages/beacon-node/src/network/discv5/types.ts
@@ -62,6 +62,9 @@ export type Discv5WorkerApi = {
 
   /** Prometheus metrics string */
   scrapeMetrics(): Promise<string>;
+
+  /** write profile to disc */
+  writeProfile(durationMs: number, dirpath: string): Promise<string>;
   /** tear down discv5 resources */
   close(): Promise<void>;
 };

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -58,7 +58,7 @@ export interface INetwork extends INetworkCorePublic {
 
   // Debug
   dumpGossipQueue(gossipType: GossipType): Promise<PendingGossipsubMessage[]>;
-  writeNetworkThreadProfile(durationMs?: number, dirpath?: string): Promise<string>;
+  writeNetworkThreadProfile(durationMs: number, dirpath: string): Promise<string>;
 }
 
 export type LodestarComponents = Pick<

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -59,6 +59,7 @@ export interface INetwork extends INetworkCorePublic {
   // Debug
   dumpGossipQueue(gossipType: GossipType): Promise<PendingGossipsubMessage[]>;
   writeNetworkThreadProfile(durationMs: number, dirpath: string): Promise<string>;
+  writeDiscv5Profile(durationMs: number, dirpath: string): Promise<string>;
 }
 
 export type LodestarComponents = Pick<

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -537,7 +537,7 @@ export class Network implements INetwork {
     return this.networkProcessor.dumpGossipQueue(gossipType);
   }
 
-  async writeNetworkThreadProfile(durationMs?: number, dirpath?: string): Promise<string> {
+  async writeNetworkThreadProfile(durationMs: number, dirpath: string): Promise<string> {
     return this.core.writeNetworkThreadProfile(durationMs, dirpath);
   }
 

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -541,6 +541,10 @@ export class Network implements INetwork {
     return this.core.writeNetworkThreadProfile(durationMs, dirpath);
   }
 
+  async writeDiscv5Profile(durationMs: number, dirpath: string): Promise<string> {
+    return this.core.writeDiscv5Profile(durationMs, dirpath);
+  }
+
   private onLightClientFinalityUpdate = async (finalityUpdate: allForks.LightClientFinalityUpdate): Promise<void> => {
     // TODO: Review is OK to remove if (this.hasAttachedSyncCommitteeMember())
 

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -142,6 +142,7 @@ describe("data serialization through worker boundary", function () {
     close: [],
     scrapeMetrics: [],
     writeProfile: [0, ""],
+    writeDiscv5Profile: [0, ""],
   };
 
   const lodestarPeer: routes.lodestar.LodestarNodePeer = {
@@ -204,6 +205,7 @@ describe("data serialization through worker boundary", function () {
     close: null,
     scrapeMetrics: "test-metrics",
     writeProfile: "",
+    writeDiscv5Profile: "",
   };
 
   type TestCase = {id: string; data: unknown; shouldFail?: boolean};


### PR DESCRIPTION
**Motivation**

- Right now we only have api to take profile of network thread, we want to take profile of main thread and discv5 thread too
- From v1.11 I'll take these profiles for latter reference after every release, also it's a good preparation to investigate lodestar's performance in Holesky

**Description**

- Extend the current api to support main thread and network thread `/eth/v1/lodestar/write_profile`

