### PR TITLE
chore: avoid using bigint for metrics

### DIFF
--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -435,16 +435,10 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
       const [jobStartSec, jobStartNs] = process.hrtime();
       const workResult = await workerApi.verifyManySignatureSets(workReqs);
       const [jobEndSec, jobEndNs] = process.hrtime();
-      const {
-        workerId,
-        batchRetries,
-        batchSigsSuccess,
-        workerStartSec,
-        workerStartNs,
-        workerEndSec,
-        workerEndNs,
-        results,
-      } = workResult;
+      const {workerId, batchRetries, batchSigsSuccess, workerStartTime, workerEndTime, results} = workResult;
+
+      const [workerStartSec, workerStartNs] = workerStartTime;
+      const [workerEndSec, workerEndNs] = workerEndTime;
 
       let successCount = 0;
       let errorCount = 0;

--- a/packages/beacon-node/src/chain/bls/multithread/types.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/types.ts
@@ -31,9 +31,11 @@ export type BlsWorkResult = {
   batchRetries: number;
   /** Total num of sigs that have been successfully verified with batching */
   batchSigsSuccess: number;
-  /** Time worker function starts - UNIX timestamp in nanoseconds */
-  workerStartNs: bigint;
-  /** Time worker function ends - UNIX timestamp in nanoseconds */
-  workerEndNs: bigint;
+  /** Time worker function starts - UNIX timestamp in seconds and nanoseconds */
+  workerStartNs: number;
+  workerStartSec: number;
+  /** Time worker function ends - UNIX timestamp in seconds and nanoseconds */
+  workerEndSec: number;
+  workerEndNs: number;
   results: WorkResult<boolean>[];
 };

--- a/packages/beacon-node/src/chain/bls/multithread/types.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/types.ts
@@ -32,10 +32,8 @@ export type BlsWorkResult = {
   /** Total num of sigs that have been successfully verified with batching */
   batchSigsSuccess: number;
   /** Time worker function starts - UNIX timestamp in seconds and nanoseconds */
-  workerStartNs: number;
-  workerStartSec: number;
+  workerStartTime: [number, number];
   /** Time worker function ends - UNIX timestamp in seconds and nanoseconds */
-  workerEndSec: number;
-  workerEndNs: number;
+  workerEndTime: [number, number];
   results: WorkResult<boolean>[];
 };

--- a/packages/beacon-node/src/chain/bls/multithread/worker.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/worker.ts
@@ -28,7 +28,7 @@ expose({
 });
 
 function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
-  const startNs = process.hrtime.bigint();
+  const [startSec, startNs] = process.hrtime();
   const results: WorkResult<boolean>[] = [];
   let batchRetries = 0;
   let batchSigsSuccess = 0;
@@ -95,12 +95,16 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
     }
   }
 
+  const [workerEndSec, workerEndNs] = process.hrtime();
+
   return {
     workerId,
     batchRetries,
     batchSigsSuccess,
+    workerStartSec: startSec,
     workerStartNs: startNs,
-    workerEndNs: process.hrtime.bigint(),
+    workerEndSec,
+    workerEndNs,
     results,
   };
 }

--- a/packages/beacon-node/src/chain/bls/multithread/worker.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/worker.ts
@@ -101,10 +101,8 @@ function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
     workerId,
     batchRetries,
     batchSigsSuccess,
-    workerStartSec: startSec,
-    workerStartNs: startNs,
-    workerEndSec,
-    workerEndNs,
+    workerStartTime: [startSec, startNs],
+    workerEndTime: [workerEndSec, workerEndNs],
     results,
   };
 }

--- a/packages/beacon-node/src/chain/bls/singleThread.ts
+++ b/packages/beacon-node/src/chain/bls/singleThread.ts
@@ -24,14 +24,13 @@ export class BlsSingleThreadVerifier implements IBlsVerifier {
     }));
 
     // Count time after aggregating
-    const startNs = process.hrtime.bigint();
-
+    const timer = this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.startTimer();
     const isValid = verifySignatureSetsMaybeBatch(setsAggregated);
 
     // Don't use a try/catch, only count run without exceptions
-    const endNs = process.hrtime.bigint();
-    const totalSec = Number(startNs - endNs) / 1e9;
-    this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.observe(totalSec);
+    if (timer) {
+      timer();
+    }
 
     return isValid;
   }
@@ -40,7 +39,7 @@ export class BlsSingleThreadVerifier implements IBlsVerifier {
     sets: {publicKey: PublicKey; signature: Uint8Array}[],
     message: Uint8Array
   ): Promise<boolean[]> {
-    const startNs = process.hrtime.bigint();
+    const timer = this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.startTimer();
     const pubkey = bls.PublicKey.aggregate(sets.map((set) => set.publicKey));
     let isAllValid = true;
     // validate signature = true
@@ -72,9 +71,9 @@ export class BlsSingleThreadVerifier implements IBlsVerifier {
       });
     }
 
-    const endNs = process.hrtime.bigint();
-    const totalSec = Number(startNs - endNs) / 1e9;
-    this.metrics?.blsThreadPool.mainThreadDurationInThreadPool.observe(totalSec);
+    if (timer) {
+      timer();
+    }
 
     return result;
   }


### PR DESCRIPTION
**Motivation**

We don't want to use bigint if we can since it causes us memory

**Description**

- use timer api of prom-client (which then use `process.hrtime()`)
- so the result is still precise at nanoseconds level but we use number instead of bigint

part of #5892
