### PR TITLE
fix: fix breaking builder block production

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -329,8 +329,14 @@ export async function produceBlockBody<T extends BlockType>(
     (blockBody as capella.BeaconBlockBody).blsToExecutionChanges = blsToExecutionChanges;
     Object.assign(logMeta, {
       blsToExecutionChanges: blsToExecutionChanges.length,
-      withdrawals: (blockBody as capella.BeaconBlockBody).executionPayload.withdrawals.length,
     });
+
+    // withdrawals are only available in full body
+    if (blockType === BlockType.Full) {
+      Object.assign(logMeta, {
+        withdrawals: (blockBody as capella.BeaconBlockBody).executionPayload.withdrawals.length,
+      });
+    }
   }
 
   Object.assign(logMeta, {blockValue});


### PR DESCRIPTION
The builder block proposals are breaking because of a bug that crept in while improving the logging for better tracking of block proposals.
This PR fixes the same.