### PR TITLE
refactor: cleanup deneb types and use max blob commitments per block for deneb containers

### DIFF
--- a/packages/types/src/allForks/sszTypes.ts
+++ b/packages/types/src/allForks/sszTypes.ts
@@ -154,7 +154,6 @@ export const allForksLightClient = {
 
 export const allForksBlobs = {
   deneb: {
-    SignedBeaconBlockAndBlobSidecars: deneb.SignedBeaconBlockAndBlobSidecars,
     BlobSidecar: deneb.BlobSidecar,
     BlindedBlobSidecar: deneb.BlindedBlobSidecar,
   },

--- a/packages/types/src/allForks/types.ts
+++ b/packages/types/src/allForks/types.ts
@@ -92,8 +92,6 @@ export type LightClientOptimisticUpdate =
   | deneb.LightClientOptimisticUpdate;
 export type LightClientStore = altair.LightClientStore | capella.LightClientStore | deneb.LightClientStore;
 
-export type SignedBeaconBlockAndBlobSidecars = deneb.SignedBeaconBlockAndBlobSidecars;
-
 export type SSEPayloadAttributes =
   | bellatrix.SSEPayloadAttributes
   | capella.SSEPayloadAttributes
@@ -113,7 +111,6 @@ export type AllForksTypes = {
   LightClientHeader: LightClientHeader;
   BuilderBid: BuilderBid;
   SignedBuilderBid: SignedBuilderBid;
-  SignedBeaconBlockAndBlobSidecars: SignedBeaconBlockAndBlobSidecars;
 };
 
 export type AllForksBlindedTypes = {
@@ -288,7 +285,6 @@ export type AllForksLightClientSSZTypes = {
 };
 
 export type AllForksBlobsSSZTypes = {
-  SignedBeaconBlockAndBlobSidecars: AllForksTypeOf<typeof denebSsz.SignedBeaconBlockAndBlobSidecars>;
   BlobSidecar: AllForksTypeOf<typeof denebSsz.BlobSidecar>;
   BlindedBlobSidecar: AllForksTypeOf<typeof denebSsz.BlindedBlobSidecar>;
 };

--- a/packages/types/src/deneb/sszTypes.ts
+++ b/packages/types/src/deneb/sszTypes.ts
@@ -178,16 +178,6 @@ export const SignedBlindedBlobSidecars = new ListCompositeType(
   MAX_BLOB_COMMITMENTS_PER_BLOCK
 );
 
-// TODO: deneb cleanup once the builder-api gets rectified for deneb
-// as the type might be used in builder getHeader responses
-export const SignedBeaconBlockAndBlobSidecars = new ContainerType(
-  {
-    beaconBlock: SignedBeaconBlock,
-    blobSidecars: BlobSidecars,
-  },
-  {typeName: "SignedBeaconBlockAndBlobSidecars", jsonCase: "eth2"}
-);
-
 export const BlindedBeaconBlockBody = new ContainerType(
   {
     ...altairSsz.BeaconBlockBody.fields,

--- a/packages/types/src/deneb/sszTypes.ts
+++ b/packages/types/src/deneb/sszTypes.ts
@@ -3,7 +3,6 @@ import {
   HISTORICAL_ROOTS_LIMIT,
   MAX_BLOB_COMMITMENTS_PER_BLOCK,
   FIELD_ELEMENTS_PER_BLOB,
-  MAX_BLOBS_PER_BLOCK,
   MAX_REQUEST_BLOB_SIDECARS,
   BYTES_PER_FIELD_ELEMENT,
   BLOCK_BODY_EXECUTION_PAYLOAD_DEPTH as EXECUTION_PAYLOAD_DEPTH,
@@ -48,43 +47,13 @@ export const KZGProof = Bytes48;
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/beacon-chain.md#custom-types
 
 export const Blob = new ByteVectorType(BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB);
-export const Blobs = new ListCompositeType(Blob, MAX_BLOBS_PER_BLOCK);
+export const Blobs = new ListCompositeType(Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK);
 export const BlindedBlob = Bytes32;
-export const BlindedBlobs = new ListCompositeType(BlindedBlob, MAX_BLOBS_PER_BLOCK);
+export const BlindedBlobs = new ListCompositeType(BlindedBlob, MAX_BLOB_COMMITMENTS_PER_BLOCK);
 
 export const VersionedHash = Bytes32;
 export const BlobKzgCommitments = new ListCompositeType(KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK);
-export const KZGProofs = new ListCompositeType(KZGProof, MAX_BLOBS_PER_BLOCK);
-
-// Constants
-
-// Validator types
-// https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/validator.md
-
-// A polynomial in evaluation form
-export const Polynomial = new ListCompositeType(BLSFieldElement, FIELD_ELEMENTS_PER_BLOB);
-
-// class BlobsAndCommitments(Container):
-//     blobs: List[Blob, MAX_BLOBS_PER_BLOCK]
-//     kzg_commitments: List[KZGCommitment, MAX_BLOBS_PER_BLOCK]
-export const BlobsAndCommitments = new ContainerType(
-  {
-    blobs: Blobs,
-    kzgCommitments: BlobKzgCommitments,
-  },
-  {typeName: "BlobsAndCommitments", jsonCase: "eth2"}
-);
-
-// class PolynomialAndCommitment(Container):
-//     polynomial: Polynomial
-//     kzg_commitment: KZGCommitment
-export const PolynomialAndCommitment = new ContainerType(
-  {
-    polynomial: Polynomial,
-    kzgCommitment: KZGCommitment,
-  },
-  {typeName: "PolynomialAndCommitment", jsonCase: "eth2"}
-);
+export const KZGProofs = new ListCompositeType(KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK);
 
 // ReqResp types
 // =============
@@ -169,7 +138,7 @@ export const BlobSidecar = new ContainerType(
   {typeName: "BlobSidecar", jsonCase: "eth2"}
 );
 
-export const BlobSidecars = new ListCompositeType(BlobSidecar, MAX_BLOBS_PER_BLOCK);
+export const BlobSidecars = new ListCompositeType(BlobSidecar, MAX_BLOB_COMMITMENTS_PER_BLOCK);
 
 export const SignedBlobSidecar = new ContainerType(
   {
@@ -178,7 +147,7 @@ export const SignedBlobSidecar = new ContainerType(
   },
   {typeName: "SignedBlobSidecar", jsonCase: "eth2"}
 );
-export const SignedBlobSidecars = new ListCompositeType(SignedBlobSidecar, MAX_BLOBS_PER_BLOCK);
+export const SignedBlobSidecars = new ListCompositeType(SignedBlobSidecar, MAX_BLOB_COMMITMENTS_PER_BLOCK);
 
 export const BlindedBlobSidecar = new ContainerType(
   {
@@ -194,7 +163,7 @@ export const BlindedBlobSidecar = new ContainerType(
   {typeName: "BlindedBlobSidecar", jsonCase: "eth2"}
 );
 
-export const BlindedBlobSidecars = new ListCompositeType(BlindedBlobSidecar, MAX_BLOBS_PER_BLOCK);
+export const BlindedBlobSidecars = new ListCompositeType(BlindedBlobSidecar, MAX_BLOB_COMMITMENTS_PER_BLOCK);
 
 export const SignedBlindedBlobSidecar = new ContainerType(
   {
@@ -204,7 +173,10 @@ export const SignedBlindedBlobSidecar = new ContainerType(
   {typeName: "SignedBlindedBlobSidecar", jsonCase: "eth2"}
 );
 
-export const SignedBlindedBlobSidecars = new ListCompositeType(SignedBlindedBlobSidecar, MAX_BLOBS_PER_BLOCK);
+export const SignedBlindedBlobSidecars = new ListCompositeType(
+  SignedBlindedBlobSidecar,
+  MAX_BLOB_COMMITMENTS_PER_BLOCK
+);
 
 // TODO: deneb cleanup once the builder-api gets rectified for deneb
 // as the type might be used in builder getHeader responses

--- a/packages/types/src/deneb/types.ts
+++ b/packages/types/src/deneb/types.ts
@@ -19,8 +19,6 @@ export type SignedBlindedBlobSidecars = ValueOf<typeof ssz.SignedBlindedBlobSide
 
 export type BlobKzgCommitments = ValueOf<typeof ssz.BlobKzgCommitments>;
 export type KZGProofs = ValueOf<typeof ssz.KZGProofs>;
-export type Polynomial = ValueOf<typeof ssz.Polynomial>;
-export type PolynomialAndCommitment = ValueOf<typeof ssz.PolynomialAndCommitment>;
 export type BLSFieldElement = ValueOf<typeof ssz.BLSFieldElement>;
 
 export type BlobIdentifier = ValueOf<typeof ssz.BlobIdentifier>;

--- a/packages/types/src/deneb/types.ts
+++ b/packages/types/src/deneb/types.ts
@@ -32,8 +32,6 @@ export type BeaconBlockBody = ValueOf<typeof ssz.BeaconBlockBody>;
 export type BeaconBlock = ValueOf<typeof ssz.BeaconBlock>;
 export type SignedBeaconBlock = ValueOf<typeof ssz.SignedBeaconBlock>;
 
-export type SignedBeaconBlockAndBlobSidecars = ValueOf<typeof ssz.SignedBeaconBlockAndBlobSidecars>;
-
 export type BeaconState = ValueOf<typeof ssz.BeaconState>;
 
 export type BlindedBeaconBlockBody = ValueOf<typeof ssz.BlindedBeaconBlockBody>;


### PR DESCRIPTION
-  cleanup deneb types
- use `MAX_BLOB_COMMITMENTS_PER_BLOCK` instead of `MAX_BLOBS_PER_BLOCK` ref: see  https://github.com/ethereum/builder-specs/pull/87 (its for builder types but also applies for all all list objects related to blobs)