### PR TITLE
[WIP] feat: Refactor pubkeyCache into finalized and unfinalized cache

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -1,7 +1,7 @@
 import {fromHexString} from "@chainsafe/ssz";
 import {routes} from "@lodestar/api";
 import {FAR_FUTURE_EPOCH, GENESIS_SLOT} from "@lodestar/params";
-import {BeaconStateAllForks, PubkeyIndexMap} from "@lodestar/state-transition";
+import {BeaconStateAllForks} from "@lodestar/state-transition";
 import {BLSPubkey, phase0} from "@lodestar/types";
 import {Epoch, ValidatorIndex} from "@lodestar/types";
 import {IBeaconChain, StateGetOpts} from "../../../../chain/index.js";
@@ -136,7 +136,7 @@ type StateValidatorIndexResponse = {valid: true; validatorIndex: number} | {vali
 export function getStateValidatorIndex(
   id: routes.beacon.ValidatorId | BLSPubkey,
   state: BeaconStateAllForks,
-  pubkey2indexFn: (arg: BLSPubkey) => number | undefined,
+  pubkey2indexFn: (arg: BLSPubkey) => number | undefined
 ): StateValidatorIndexResponse {
   let validatorIndex: ValidatorIndex | undefined;
   if (typeof id === "string") {

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -111,7 +111,7 @@ export function toValidatorResponse(
 export function filterStateValidatorsByStatus(
   statuses: string[],
   state: BeaconStateAllForks,
-  pubkey2index: PubkeyIndexMap,
+  pubkey2index: (arg: BLSPubkey) => number | undefined,
   currentEpoch: Epoch
 ): routes.beacon.ValidatorResponse[] {
   const responses: routes.beacon.ValidatorResponse[] = [];
@@ -136,7 +136,7 @@ type StateValidatorIndexResponse = {valid: true; validatorIndex: number} | {vali
 export function getStateValidatorIndex(
   id: routes.beacon.ValidatorId | BLSPubkey,
   state: BeaconStateAllForks,
-  pubkey2index: PubkeyIndexMap
+  pubkey2indexFn: (arg: BLSPubkey) => number | undefined,
 ): StateValidatorIndexResponse {
   let validatorIndex: ValidatorIndex | undefined;
   if (typeof id === "string") {
@@ -161,7 +161,7 @@ export function getStateValidatorIndex(
   }
 
   // typeof id === Uint8Array
-  validatorIndex = pubkey2index.get(id as BLSPubkey);
+  validatorIndex = pubkey2indexFn(id as BLSPubkey);
   if (validatorIndex === undefined) {
     return {valid: false, code: 404, reason: "Validator pubkey not found in state"};
   }

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -823,7 +823,7 @@ export function getValidatorApi({
 
       const filteredRegistrations = registrations.filter((registration) => {
         const {pubkey} = registration.message;
-        const validatorIndex = headState.epochCtx.pubkey2index.get(pubkey);
+        const validatorIndex = headState.epochCtx.getValidatorIndex(pubkey);
         if (validatorIndex === undefined) return false;
 
         const validator = headState.validators.getReadonly(validatorIndex);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -75,6 +75,7 @@ import {BlockAttributes, produceBlockBody} from "./produceBlock/produceBlockBody
 import {computeNewStateRoot} from "./produceBlock/computeNewStateRoot.js";
 import {BlockInput} from "./blocks/types.js";
 import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
+import { createEmptyCarryoverData } from "@lodestar/state-transition/src/cache/epochCache.js";
 
 /**
  * Arbitrary constants, blobs should be consumed immediately in the same slot they are produced.
@@ -224,7 +225,7 @@ export class BeaconChain implements IBeaconChain {
             config,
             pubkey2index: new PubkeyIndexMap(),
             index2pubkey: [],
-          });
+          }, createEmptyCarryoverData());
 
     // Persist single global instance of state caches
     this.pubkey2index = cachedState.epochCtx.pubkey2index;

--- a/packages/beacon-node/src/chain/genesis/genesis.ts
+++ b/packages/beacon-node/src/chain/genesis/genesis.ts
@@ -13,6 +13,7 @@ import {
   BeaconStateAllForks,
   createEmptyEpochCacheImmutableData,
   getActiveValidatorIndices,
+  createEmptyCarryoverData
 } from "@lodestar/state-transition";
 import {Logger} from "@lodestar/utils";
 import {IEth1Provider} from "../../eth1/index.js";
@@ -86,7 +87,7 @@ export class GenesisBuilder implements IGenesisBuilder {
     }
 
     // TODO - PENDING: Ensure EpochCacheImmutableData is created only once
-    this.state = createCachedBeaconState(stateView, createEmptyEpochCacheImmutableData(config, stateView));
+    this.state = createCachedBeaconState(stateView, createEmptyEpochCacheImmutableData(config, stateView), createEmptyCarryoverData());
     this.config = this.state.config;
     this.activatedValidatorCount = getActiveValidatorIndices(stateView, GENESIS_EPOCH).length;
   }

--- a/packages/beacon-node/src/chain/genesis/genesis.ts
+++ b/packages/beacon-node/src/chain/genesis/genesis.ts
@@ -13,7 +13,7 @@ import {
   BeaconStateAllForks,
   createEmptyEpochCacheImmutableData,
   getActiveValidatorIndices,
-  createEmptyCarryoverData
+  createEmptyCarryoverData,
 } from "@lodestar/state-transition";
 import {Logger} from "@lodestar/utils";
 import {IEth1Provider} from "../../eth1/index.js";
@@ -87,7 +87,11 @@ export class GenesisBuilder implements IGenesisBuilder {
     }
 
     // TODO - PENDING: Ensure EpochCacheImmutableData is created only once
-    this.state = createCachedBeaconState(stateView, createEmptyEpochCacheImmutableData(config, stateView), createEmptyCarryoverData());
+    this.state = createCachedBeaconState(
+      stateView,
+      createEmptyEpochCacheImmutableData(config, stateView),
+      createEmptyCarryoverData()
+    );
     this.config = this.state.config;
     this.activatedValidatorCount = getActiveValidatorIndices(stateView, GENESIS_EPOCH).length;
   }

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -185,7 +185,7 @@ async function validateAggregateAndProof(
   // by the validator with index aggregate_and_proof.aggregator_index.
   // [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
   // [REJECT] The signature of aggregate is valid.
-  const aggregator = attHeadState.epochCtx.index2pubkey[aggregateAndProof.aggregatorIndex];
+  const aggregator = attHeadState.epochCtx.getPubkey(aggregateAndProof.aggregatorIndex);
   let indexedAttestationSignatureSet: ISignatureSet;
   if (cachedAttData) {
     const {signingRoot} = cachedAttData;

--- a/packages/beacon-node/src/chain/validation/signatureSets/contributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/contributionAndProof.ts
@@ -20,7 +20,7 @@ export function getContributionAndProofSignatureSet(
   const signingData = signedContributionAndProof.message;
   return {
     type: SignatureSetType.single,
-    pubkey: epochCtx.index2pubkey[signedContributionAndProof.message.aggregatorIndex],
+    pubkey: epochCtx.getPubkey(signedContributionAndProof.message.aggregatorIndex),
     signingRoot: computeSigningRoot(ssz.altair.ContributionAndProof, signingData, domain),
     signature: signedContributionAndProof.signature,
   };

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommittee.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommittee.ts
@@ -15,7 +15,7 @@ export function getSyncCommitteeSignatureSet(
 
   return {
     type: SignatureSetType.single,
-    pubkey: state.epochCtx.index2pubkey[syncCommittee.validatorIndex],
+    pubkey: state.epochCtx.getPubkey(syncCommittee.validatorIndex),
     signingRoot: computeSigningRoot(ssz.Root, syncCommittee.beaconBlockRoot, domain),
     signature: syncCommittee.signature,
   };

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
@@ -20,7 +20,7 @@ export function getSyncCommitteeSelectionProofSignatureSet(
   };
   return {
     type: SignatureSetType.single,
-    pubkey: epochCtx.index2pubkey[contributionAndProof.aggregatorIndex],
+    pubkey: epochCtx.getPubkey(contributionAndProof.aggregatorIndex),
     signingRoot: computeSigningRoot(ssz.altair.SyncAggregatorSelectionData, signingData, domain),
     signature: contributionAndProof.selectionProof,
   };

--- a/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -74,7 +74,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   // > Checked in validateGossipSyncCommitteeExceptSig()
 
   const participantPubkeys = syncCommitteeParticipantIndices.map(
-    (validatorIndex) => headState.epochCtx.index2pubkey[validatorIndex]
+    (validatorIndex) => headState.epochCtx.getPubkey(validatorIndex)
   );
   const signatureSets = [
     // [REJECT] The contribution_and_proof.selection_proof is a valid signature of the SyncAggregatorSelectionData

--- a/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -73,8 +73,8 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   // i.e. state.validators[contribution_and_proof.aggregator_index].pubkey in get_sync_subcommittee_pubkeys(state, contribution.subcommittee_index).
   // > Checked in validateGossipSyncCommitteeExceptSig()
 
-  const participantPubkeys = syncCommitteeParticipantIndices.map(
-    (validatorIndex) => headState.epochCtx.getPubkey(validatorIndex)
+  const participantPubkeys = syncCommitteeParticipantIndices.map((validatorIndex) =>
+    headState.epochCtx.getPubkey(validatorIndex)
   );
   const signatureSets = [
     // [REJECT] The contribution_and_proof.selection_proof is a valid signature of the SyncAggregatorSelectionData

--- a/packages/beacon-node/test/perf/api/impl/validator/attester.test.ts
+++ b/packages/beacon-node/test/perf/api/impl/validator/attester.test.ts
@@ -35,7 +35,7 @@ describe("api / impl / validator", () => {
       noThreshold: true,
       fn: () => {
         for (let i = 0; i < reqCount; i++) {
-          const pubkey = state.epochCtx.index2pubkey[i];
+          const pubkey = state.epochCtx.getPubkey(i);
           pubkey.toBytes(PointFormat.compressed);
         }
       },

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -107,39 +107,39 @@ describe("beacon state api utils", function () {
 
   describe("getStateValidatorIndex", async function () {
     const state = generateCachedAltairState();
-    const pubkey2index = state.epochCtx.pubkey2index;
+    const pubkey2indexFn = state.epochCtx.getValidatorIndex;
 
     it("should return valid: false on invalid input", () => {
-      expect(getStateValidatorIndex("foo", state, pubkey2index).valid, "invalid validator id number").to.equal(false);
-      expect(getStateValidatorIndex("0xfoo", state, pubkey2index).valid, "invalid hex").to.equal(false);
+      expect(getStateValidatorIndex("foo", state, pubkey2indexFn).valid, "invalid validator id number").to.equal(false);
+      expect(getStateValidatorIndex("0xfoo", state, pubkey2indexFn).valid, "invalid hex").to.equal(false);
     });
 
     it("should return valid: false on validator indices / pubkeys not in the state", () => {
       expect(
-        getStateValidatorIndex(String(state.validators.length), state, pubkey2index).valid,
+        getStateValidatorIndex(String(state.validators.length), state, pubkey2indexFn).valid,
         "validator id not in state"
       ).to.equal(false);
-      expect(getStateValidatorIndex("0xabcd", state, pubkey2index).valid, "validator pubkey not in state").to.equal(
+      expect(getStateValidatorIndex("0xabcd", state, pubkey2indexFn).valid, "validator pubkey not in state").to.equal(
         false
       );
     });
 
     it("should return valid: true on validator indices / pubkeys in the state", () => {
       const index = state.validators.length - 1;
-      const resp1 = getStateValidatorIndex(String(index), state, pubkey2index);
+      const resp1 = getStateValidatorIndex(String(index), state, pubkey2indexFn);
       if (resp1.valid) {
         expect(resp1.validatorIndex).to.equal(index);
       } else {
         expect.fail("validator index should be found - validator index input");
       }
       const pubkey = state.validators.get(index).pubkey;
-      const resp2 = getStateValidatorIndex(pubkey, state, pubkey2index);
+      const resp2 = getStateValidatorIndex(pubkey, state, pubkey2indexFn);
       if (resp2.valid) {
         expect(resp2.validatorIndex).to.equal(index);
       } else {
         expect.fail("validator index should be found - Uint8Array input");
       }
-      const resp3 = getStateValidatorIndex(toHexString(pubkey), state, pubkey2index);
+      const resp3 = getStateValidatorIndex(toHexString(pubkey), state, pubkey2indexFn);
       if (resp3.valid) {
         expect(resp3.validatorIndex).to.equal(index);
       } else {

--- a/packages/beacon-node/test/utils/cachedBeaconState.ts
+++ b/packages/beacon-node/test/utils/cachedBeaconState.ts
@@ -11,5 +11,9 @@ export function createCachedBeaconStateTest<T extends BeaconStateAllForks>(
   state: T,
   chainConfig: ChainForkConfig
 ): T & BeaconStateCache {
-  return createCachedBeaconState<T>(state, createEmptyEpochCacheImmutableData(chainConfig, state), createEmptyCarryoverData());
+  return createCachedBeaconState<T>(
+    state,
+    createEmptyEpochCacheImmutableData(chainConfig, state),
+    createEmptyCarryoverData()
+  );
 }

--- a/packages/beacon-node/test/utils/cachedBeaconState.ts
+++ b/packages/beacon-node/test/utils/cachedBeaconState.ts
@@ -3,6 +3,7 @@ import {
   BeaconStateCache,
   createCachedBeaconState,
   createEmptyEpochCacheImmutableData,
+  createEmptyCarryoverData,
 } from "@lodestar/state-transition";
 import {ChainForkConfig} from "@lodestar/config";
 
@@ -10,5 +11,5 @@ export function createCachedBeaconStateTest<T extends BeaconStateAllForks>(
   state: T,
   chainConfig: ChainForkConfig
 ): T & BeaconStateCache {
-  return createCachedBeaconState<T>(state, createEmptyEpochCacheImmutableData(chainConfig, state));
+  return createCachedBeaconState<T>(state, createEmptyEpochCacheImmutableData(chainConfig, state), createEmptyCarryoverData());
 }

--- a/packages/beacon-node/test/utils/state.ts
+++ b/packages/beacon-node/test/utils/state.ts
@@ -100,12 +100,16 @@ export function generateState(
 export function generateCachedState(opts?: TestBeaconState): CachedBeaconStateAllForks {
   const config = getConfig(ForkName.phase0);
   const state = generateState(opts, config);
-  return createCachedBeaconState(state, {
-    config: createBeaconConfig(config, state.genesisValidatorsRoot),
-    // This is a performance test, there's no need to have a global shared cache of keys
-    pubkey2index: new PubkeyIndexMap(),
-    index2pubkey: [],
-  }, createEmptyCarryoverData());
+  return createCachedBeaconState(
+    state,
+    {
+      config: createBeaconConfig(config, state.genesisValidatorsRoot),
+      // This is a performance test, there's no need to have a global shared cache of keys
+      pubkey2index: new PubkeyIndexMap(),
+      index2pubkey: [],
+    },
+    createEmptyCarryoverData()
+  );
 }
 
 /**
@@ -114,12 +118,16 @@ export function generateCachedState(opts?: TestBeaconState): CachedBeaconStateAl
 export function generateCachedAltairState(opts?: TestBeaconState, altairForkEpoch = 0): CachedBeaconStateAllForks {
   const config = getConfig(ForkName.altair, altairForkEpoch);
   const state = generateState(opts, config);
-  return createCachedBeaconState(state, {
-    config: createBeaconConfig(config, state.genesisValidatorsRoot),
-    // This is a performance test, there's no need to have a global shared cache of keys
-    pubkey2index: new PubkeyIndexMap(),
-    index2pubkey: [],
-  }, createEmptyCarryoverData());
+  return createCachedBeaconState(
+    state,
+    {
+      config: createBeaconConfig(config, state.genesisValidatorsRoot),
+      // This is a performance test, there's no need to have a global shared cache of keys
+      pubkey2index: new PubkeyIndexMap(),
+      index2pubkey: [],
+    },
+    createEmptyCarryoverData()
+  );
 }
 
 /**
@@ -128,10 +136,14 @@ export function generateCachedAltairState(opts?: TestBeaconState, altairForkEpoc
 export function generateCachedBellatrixState(opts?: TestBeaconState): CachedBeaconStateBellatrix {
   const config = getConfig(ForkName.bellatrix);
   const state = generateState(opts, config);
-  return createCachedBeaconState(state as BeaconStateBellatrix, {
-    config: createBeaconConfig(config, state.genesisValidatorsRoot),
-    // This is a performance test, there's no need to have a global shared cache of keys
-    pubkey2index: new PubkeyIndexMap(),
-    index2pubkey: [],
-  }, createEmptyCarryoverData());
+  return createCachedBeaconState(
+    state as BeaconStateBellatrix,
+    {
+      config: createBeaconConfig(config, state.genesisValidatorsRoot),
+      // This is a performance test, there's no need to have a global shared cache of keys
+      pubkey2index: new PubkeyIndexMap(),
+      index2pubkey: [],
+    },
+    createEmptyCarryoverData()
+  );
 }

--- a/packages/beacon-node/test/utils/state.ts
+++ b/packages/beacon-node/test/utils/state.ts
@@ -7,6 +7,7 @@ import {
   PubkeyIndexMap,
   CachedBeaconStateBellatrix,
   BeaconStateBellatrix,
+  createEmptyCarryoverData,
 } from "@lodestar/state-transition";
 import {allForks, altair, bellatrix, ssz} from "@lodestar/types";
 import {createBeaconConfig, ChainForkConfig} from "@lodestar/config";
@@ -104,7 +105,7 @@ export function generateCachedState(opts?: TestBeaconState): CachedBeaconStateAl
     // This is a performance test, there's no need to have a global shared cache of keys
     pubkey2index: new PubkeyIndexMap(),
     index2pubkey: [],
-  });
+  }, createEmptyCarryoverData());
 }
 
 /**
@@ -118,7 +119,7 @@ export function generateCachedAltairState(opts?: TestBeaconState, altairForkEpoc
     // This is a performance test, there's no need to have a global shared cache of keys
     pubkey2index: new PubkeyIndexMap(),
     index2pubkey: [],
-  });
+  }, createEmptyCarryoverData());
 }
 
 /**
@@ -132,5 +133,5 @@ export function generateCachedBellatrixState(opts?: TestBeaconState): CachedBeac
     // This is a performance test, there's no need to have a global shared cache of keys
     pubkey2index: new PubkeyIndexMap(),
     index2pubkey: [],
-  });
+  }, createEmptyCarryoverData());
 }

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -67,7 +67,8 @@
     "@lodestar/types": "^1.10.0",
     "@lodestar/utils": "^1.10.0",
     "bigint-buffer": "^1.1.5",
-    "buffer-xor": "^2.0.2"
+    "buffer-xor": "^2.0.2",
+    "immutable": "^4.3.2"
   },
   "devDependencies": {
     "@chainsafe/blst": "^0.2.9",

--- a/packages/state-transition/src/block/processDeposit.ts
+++ b/packages/state-transition/src/block/processDeposit.ts
@@ -43,7 +43,7 @@ export function processDeposit(fork: ForkSeq, state: CachedBeaconStateAllForks, 
 
   const pubkey = deposit.data.pubkey; // Drop tree
   const amount = deposit.data.amount;
-  const cachedIndex = epochCtx.getPubkeyIndex(pubkey);
+  const cachedIndex = epochCtx.getValidatorIndex(pubkey);
   if (cachedIndex === undefined || !Number.isSafeInteger(cachedIndex) || cachedIndex >= validators.length) {
     // verify the deposit signature (proof of posession) which is not checked by the deposit contract
     const depositMessage = {

--- a/packages/state-transition/src/block/processDeposit.ts
+++ b/packages/state-transition/src/block/processDeposit.ts
@@ -89,6 +89,7 @@ export function processDeposit(fork: ForkSeq, state: CachedBeaconStateAllForks, 
     epochCtx.effectiveBalanceIncrementsSet(validatorIndex, effectiveBalance);
 
     // now that there is a new validator, update the epoch context with the new pubkey
+    // TODO: Here we should populate unfinalized cache instead
     epochCtx.addPubkey(validatorIndex, pubkey);
 
     // Only after altair:

--- a/packages/state-transition/src/block/processDeposit.ts
+++ b/packages/state-transition/src/block/processDeposit.ts
@@ -89,7 +89,6 @@ export function processDeposit(fork: ForkSeq, state: CachedBeaconStateAllForks, 
     epochCtx.effectiveBalanceIncrementsSet(validatorIndex, effectiveBalance);
 
     // now that there is a new validator, update the epoch context with the new pubkey
-    // TODO: Here we should populate unfinalized cache instead
     epochCtx.addPubkey(validatorIndex, pubkey);
 
     // Only after altair:

--- a/packages/state-transition/src/block/processDeposit.ts
+++ b/packages/state-transition/src/block/processDeposit.ts
@@ -43,7 +43,7 @@ export function processDeposit(fork: ForkSeq, state: CachedBeaconStateAllForks, 
 
   const pubkey = deposit.data.pubkey; // Drop tree
   const amount = deposit.data.amount;
-  const cachedIndex = epochCtx.pubkey2index.get(pubkey);
+  const cachedIndex = epochCtx.getPubkeyIndex(pubkey);
   if (cachedIndex === undefined || !Number.isSafeInteger(cachedIndex) || cachedIndex >= validators.length) {
     // verify the deposit signature (proof of posession) which is not checked by the deposit contract
     const depositMessage = {

--- a/packages/state-transition/src/block/processSyncCommittee.ts
+++ b/packages/state-transition/src/block/processSyncCommittee.ts
@@ -104,7 +104,7 @@ export function getSyncCommitteeSignatureSet(
 
   return {
     type: SignatureSetType.aggregate,
-    pubkeys: participantIndices.map((i) => epochCtx.index2pubkey[i]),
+    pubkeys: participantIndices.map((i) => epochCtx.getPubkey(i)),
     signingRoot: computeSigningRoot(ssz.Root, rootSigned, domain),
     signature,
   };

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -29,7 +29,7 @@ import {computeEpochShuffling, EpochShuffling} from "../util/epochShuffling.js";
 import {computeBaseRewardPerIncrement, computeSyncParticipantReward} from "../util/syncCommittee.js";
 import {sumTargetUnslashedBalanceIncrements} from "../util/targetUnslashedBalance.js";
 import {EffectiveBalanceIncrements, getEffectiveBalanceIncrementsWithLen} from "./effectiveBalanceIncrements.js";
-import {Index2PubkeyCache, PubkeyIndexMap, UnfinalizedPubkeyIndexMap, newUnfinalizedPubkeyIndexMap, syncPubkeys, toMemoryEfficientHexStr} from "./pubkeyCache.js";
+import {Index2PubkeyCache, PubkeyIndexMap, UnfinalizedPubkeyIndexMap, syncPubkeys, toMemoryEfficientHexStr, newUnfinalizedPubkeyIndexMap} from "./pubkeyCache.js";
 import {BeaconStateAllForks, BeaconStateAltair} from "./types.js";
 import {
   computeSyncCommitteeCache,

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -477,7 +477,7 @@ export class EpochCache {
   afterProcessEpoch(
     state: BeaconStateAllForks,
     epochTransitionCache: {
-      indicesEligibleForActivation: ValidatorIndex[];
+      indicesEligibleForActivationQueue: ValidatorIndex[];
       nextEpochShufflingActiveValidatorIndices: ValidatorIndex[];
       nextEpochTotalActiveBalanceByIncrement: number;
     }
@@ -494,12 +494,12 @@ export class EpochCache {
       nextEpoch
     );
 
-    // To populate finalized cache and prune unfinalized cache with validators that just became pending activated in processEpoch
-    const expectedActivationEpoch = computeActivationExitEpoch(prevEpoch);
+    // To populate finalized cache and prune unfinalized cache with validators that just entered the activation queue
+    const expectedActivationEligibilityEpoch = prevEpoch + 1;
     const validators = state.validators;
-    for (const index of epochTransitionCache.indicesEligibleForActivation) {
+    for (const index of epochTransitionCache.indicesEligibleForActivationQueue) {
       const validator = validators.getReadonly(index);
-      if (validator.activationEpoch == expectedActivationEpoch) {
+      if (validator.activationEpoch == expectedActivationEligibilityEpoch) {
         this.addFinalizedPubkey(validator.pubkey, index);
       } else {
         break;

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -29,7 +29,15 @@ import {computeEpochShuffling, EpochShuffling} from "../util/epochShuffling.js";
 import {computeBaseRewardPerIncrement, computeSyncParticipantReward} from "../util/syncCommittee.js";
 import {sumTargetUnslashedBalanceIncrements} from "../util/targetUnslashedBalance.js";
 import {EffectiveBalanceIncrements, getEffectiveBalanceIncrementsWithLen} from "./effectiveBalanceIncrements.js";
-import {Index2PubkeyCache, PubkeyIndexMap, UnfinalizedPubkeyIndexMap, syncPubkeys, toMemoryEfficientHexStr, newUnfinalizedPubkeyIndexMap, PubkeyHex} from "./pubkeyCache.js";
+import {
+  Index2PubkeyCache,
+  PubkeyIndexMap,
+  UnfinalizedPubkeyIndexMap,
+  syncPubkeys,
+  toMemoryEfficientHexStr,
+  newUnfinalizedPubkeyIndexMap,
+  PubkeyHex,
+} from "./pubkeyCache.js";
 import {BeaconStateAllForks, BeaconStateAltair} from "./types.js";
 import {
   computeSyncCommitteeCache,
@@ -49,7 +57,7 @@ export type EpochCacheImmutableData = {
 
 export type CarryoverData = {
   unfinalizedPubkey2index: UnfinalizedPubkeyIndexMap;
-}
+};
 
 export type EpochCacheOpts = {
   skipSyncCommitteeCache?: boolean;
@@ -88,7 +96,7 @@ export class EpochCache {
    *
    * TODO: this is a hack, we need a safety mechanism in case a bad eth1 majority vote is in,
    * or handle non finalized data differently, or use an immutable.js structure for cheap copies
-   * 
+   *
    * New: This would include only validators whose activation_eligibility_epoch is finalized and hence it is insert only. Validators may still be in the activation queue.
    *
    * $VALIDATOR_COUNT x 192 char String -> Number Map
@@ -98,16 +106,15 @@ export class EpochCache {
    * Unique globally shared pubkey registry. There should only exist one for the entire application.
    *
    * New: This would include only validators whose activation_eligibility_epoch is finalized and hence it is insert only. Validators may still be in the activation queue.
-   * 
+   *
    * $VALIDATOR_COUNT x BLST deserialized pubkey (Jacobian coordinates)
    */
   globalIndex2pubkey: Index2PubkeyCache;
   /**
    * Unique pubkey registry shared in the same fork. There should only exist one for the fork.
-   * 
+   *
    */
   unfinalizedPubkey2index: UnfinalizedPubkeyIndexMap;
-
 
   /**
    * Indexes of the block proposers for the current epoch.
@@ -755,22 +762,22 @@ export class EpochCache {
   }
 
   /**
-   * 
+   *
    * Add unfinalized pubkeys
-   * 
+   *
    */
   addPubkey(index: ValidatorIndex, pubkey: Uint8Array): void {
-    this.unfinalizedPubkey2index.set(toMemoryEfficientHexStr(pubkey), index); 
+    this.unfinalizedPubkey2index.set(toMemoryEfficientHexStr(pubkey), index);
   }
 
   /**
-   * 
+   *
    * Given a validator whose activation_epoch has just been set, we move its pubkey from unfinalized cache to finalized cache
-   * 
+   *
    */
   addFinalizedPubkey(pubkey: Uint8Array, index: ValidatorIndex): void {
     this.globalPubkey2index.set(pubkey, index);
-    this.globalIndex2pubkey[index] = bls.PublicKey.fromBytes(pubkey, CoordType.jacobian); 
+    this.globalIndex2pubkey[index] = bls.PublicKey.fromBytes(pubkey, CoordType.jacobian);
 
     this.unfinalizedPubkey2index.delete(toMemoryEfficientHexStr(pubkey));
   }
@@ -854,7 +861,6 @@ export class EpochCache {
 
     this.effectiveBalanceIncrements[index] = Math.floor(effectiveBalance / EFFECTIVE_BALANCE_INCREMENT);
   }
-
 }
 
 function getEffectiveBalanceIncrementsByteLen(validatorCount: number): number {
@@ -896,8 +902,8 @@ export function createEmptyEpochCacheImmutableData(
   };
 }
 
-export function createEmptyCarryoverData() {
+export function createEmptyCarryoverData(): CarryoverData {
   return {
-    unfinalizedPubkey2index: newUnfinalizedPubkeyIndexMap()
+    unfinalizedPubkey2index: newUnfinalizedPubkeyIndexMap(),
   };
 }

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -441,7 +441,7 @@ export class EpochCache {
       // Common append-only structures shared with all states, no need to clone
       pubkey2index: this.pubkey2index,
       index2pubkey: this.index2pubkey,
-      // Fork-aware cache needs to be cloned. But due to it being persistent, we don't need to do anything here
+      // Fork-aware cache needs to be cloned. But by the virtue of it being persistent, we don't need to do anything here
       unfinalizedIndex2pubkey: this.unfinalizedPubkey2Index,
       // Immutable data
       proposers: this.proposers,

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -487,6 +487,18 @@ export class EpochCache {
       nextEpoch
     );
 
+    // To populate finalized cache with validators that just became pending activated in processEpoch
+    const expectedActivationEpoch = computeActivationExitEpoch(prevEpoch);
+    const validators = state.validators;
+    for (const index of epochTransitionCache.indicesEligibleForActivation) {
+      const validator = validators.get(index);
+      if (validator.activationEpoch == expectedActivationEpoch) {
+        this.addPubkey(validator.pubkey, index);
+      } else {
+        break;
+      }
+    }
+
     // Roll current proposers into previous proposers for metrics
     this.proposersPrevEpoch = this.proposers;
 

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -47,6 +47,10 @@ export type EpochCacheImmutableData = {
   index2pubkey: Index2PubkeyCache;
 };
 
+export type CarryoverData = {
+  unfinalizedPubkey2index: UnfinalizedPubkeyIndexMap;
+}
+
 export type EpochCacheOpts = {
   skipSyncCommitteeCache?: boolean;
   skipSyncPubkeys?: boolean;
@@ -257,6 +261,7 @@ export class EpochCache {
   static createFromState(
     state: BeaconStateAllForks,
     {config, pubkey2index, index2pubkey}: EpochCacheImmutableData,
+    {unfinalizedPubkey2index}: CarryoverData,
     opts?: EpochCacheOpts
   ): EpochCache {
     // syncPubkeys here to ensure EpochCacheImmutableData is popualted before computing the rest of caches
@@ -264,8 +269,6 @@ export class EpochCache {
     if (!opts?.skipSyncPubkeys) {
       syncPubkeys(state, pubkey2index, index2pubkey);
     }
-
-    const unfinalizedIndex2pubkey = newUnfinalizedPubkeyIndexMap(); // TODO: Figure out how to populate it
 
     const currentEpoch = computeEpochAtSlot(state.slot);
     const isGenesis = currentEpoch === GENESIS_EPOCH;
@@ -890,5 +893,11 @@ export function createEmptyEpochCacheImmutableData(
     // This is a test state, there's no need to have a global shared cache of keys
     pubkey2index: new PubkeyIndexMap(),
     index2pubkey: [],
+  };
+}
+
+export function createEmptyCarryoverData() {
+  return {
+    unfinalizedPubkey2index: newUnfinalizedPubkeyIndexMap()
   };
 }

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -106,7 +106,7 @@ export class EpochCache {
    * Unique pubkey registry shared in the same fork. There should only exist one for the fork.
    * 
    */
-  unfinalizedPubkey2Index: UnfinalizedPubkeyIndexMap;
+  unfinalizedPubkey2index: UnfinalizedPubkeyIndexMap;
 
 
   /**
@@ -204,7 +204,7 @@ export class EpochCache {
     config: BeaconConfig;
     globalPubkey2index: PubkeyIndexMap;
     globalIndex2pubkey: Index2PubkeyCache;
-    unfinalizedIndex2pubkey: UnfinalizedPubkeyIndexMap;
+    unfinalizedPubkey2index: UnfinalizedPubkeyIndexMap;
     proposers: number[];
     proposersPrevEpoch: number[] | null;
     proposersNextEpoch: ProposersDeferred;
@@ -229,7 +229,7 @@ export class EpochCache {
     this.config = data.config;
     this.globalPubkey2index = data.globalPubkey2index;
     this.globalIndex2pubkey = data.globalIndex2pubkey;
-    this.unfinalizedPubkey2Index = data.unfinalizedIndex2pubkey;
+    this.unfinalizedPubkey2index = data.unfinalizedPubkey2index;
     this.proposers = data.proposers;
     this.proposersPrevEpoch = data.proposersPrevEpoch;
     this.proposersNextEpoch = data.proposersNextEpoch;
@@ -407,7 +407,7 @@ export class EpochCache {
       config,
       globalPubkey2index: pubkey2index,
       globalIndex2pubkey: index2pubkey,
-      unfinalizedIndex2pubkey,
+      unfinalizedPubkey2index,
       proposers,
       // On first epoch, set to null to prevent unnecessary work since this is only used for metrics
       proposersPrevEpoch: null,
@@ -445,7 +445,7 @@ export class EpochCache {
       globalPubkey2index: this.globalPubkey2index,
       globalIndex2pubkey: this.globalIndex2pubkey,
       // Fork-aware cache needs to be cloned. But by the virtue of it being persistent, we don't need to do anything here
-      unfinalizedIndex2pubkey: this.unfinalizedPubkey2Index,
+      unfinalizedPubkey2index: this.unfinalizedPubkey2index,
       // Immutable data
       proposers: this.proposers,
       proposersPrevEpoch: this.proposersPrevEpoch,
@@ -751,7 +751,7 @@ export class EpochCache {
   }
 
   getPubkeyIndex(pubkey: Uint8Array): ValidatorIndex | undefined {
-    return this.globalPubkey2index.get(pubkey) || this.unfinalizedPubkey2Index.get(toMemoryEfficientHexStr(pubkey));
+    return this.globalPubkey2index.get(pubkey) || this.unfinalizedPubkey2index.get(toMemoryEfficientHexStr(pubkey));
   }
 
   /**
@@ -760,7 +760,7 @@ export class EpochCache {
    * 
    */
   addPubkey(index: ValidatorIndex, pubkey: Uint8Array): void {
-    this.unfinalizedPubkey2Index.set(toMemoryEfficientHexStr(pubkey), index); 
+    this.unfinalizedPubkey2index.set(toMemoryEfficientHexStr(pubkey), index); 
   }
 
   /**
@@ -772,7 +772,7 @@ export class EpochCache {
     this.globalPubkey2index.set(pubkey, index);
     this.globalIndex2pubkey[index] = bls.PublicKey.fromBytes(pubkey, CoordType.jacobian); 
 
-    this.unfinalizedPubkey2Index.delete(toMemoryEfficientHexStr(pubkey));
+    this.unfinalizedPubkey2index.delete(toMemoryEfficientHexStr(pubkey));
   }
 
   getShufflingAtSlot(slot: Slot): EpochShuffling {

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -85,7 +85,7 @@ export class EpochCache {
    * TODO: this is a hack, we need a safety mechanism in case a bad eth1 majority vote is in,
    * or handle non finalized data differently, or use an immutable.js structure for cheap copies
    * 
-   * New: This would only validators whose deposit is finalized and hence it is insert only. Validators may still be in the activation queue.
+   * New: This would only validators whose activation_eligibility_epoch is finalized and hence it is insert only. Validators may still be in the activation queue.
    *
    * $VALIDATOR_COUNT x 192 char String -> Number Map
    */
@@ -93,7 +93,7 @@ export class EpochCache {
   /**
    * Unique globally shared pubkey registry. There should only exist one for the entire application.
    *
-   * New: This would only validators whose deposit is finalized and hence it is insert only. Validators may still be in the activation queue.
+   * New: This would only validators whose activation_eligibility_epoch is finalized and hence it is insert only. Validators may still be in the activation queue.
    * 
    * $VALIDATOR_COUNT x BLST deserialized pubkey (Jacobian coordinates)
    */

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -84,7 +84,8 @@ export class EpochCache {
    *
    * TODO: this is a hack, we need a safety mechanism in case a bad eth1 majority vote is in,
    * or handle non finalized data differently, or use an immutable.js structure for cheap copies
-   * Warning: may contain pubkeys that do not yet exist in the current state, but do in a later processed state.
+   * 
+   * New: This would only validators whose deposit is finalized and hence it is insert only. Validators may still be in the activation queue.
    *
    * $VALIDATOR_COUNT x 192 char String -> Number Map
    */
@@ -92,8 +93,8 @@ export class EpochCache {
   /**
    * Unique globally shared pubkey registry. There should only exist one for the entire application.
    *
-   * Warning: may contain indices that do not yet exist in the current state, but do in a later processed state.
-   *
+   * New: This would only validators whose deposit is finalized and hence it is insert only. Validators may still be in the activation queue.
+   * 
    * $VALIDATOR_COUNT x BLST deserialized pubkey (Jacobian coordinates)
    */
   index2pubkey: Index2PubkeyCache;

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -29,7 +29,7 @@ import {computeEpochShuffling, EpochShuffling} from "../util/epochShuffling.js";
 import {computeBaseRewardPerIncrement, computeSyncParticipantReward} from "../util/syncCommittee.js";
 import {sumTargetUnslashedBalanceIncrements} from "../util/targetUnslashedBalance.js";
 import {EffectiveBalanceIncrements, getEffectiveBalanceIncrementsWithLen} from "./effectiveBalanceIncrements.js";
-import {Index2PubkeyCache, PubkeyIndexMap, UnfinalizedPubkeyIndexMap, syncPubkeys, toMemoryEfficientHexStr, newUnfinalizedPubkeyIndexMap} from "./pubkeyCache.js";
+import {Index2PubkeyCache, PubkeyIndexMap, UnfinalizedPubkeyIndexMap, syncPubkeys, toMemoryEfficientHexStr, newUnfinalizedPubkeyIndexMap, PubkeyHex} from "./pubkeyCache.js";
 import {BeaconStateAllForks, BeaconStateAltair} from "./types.js";
 import {
   computeSyncCommitteeCache,
@@ -750,7 +750,7 @@ export class EpochCache {
     return this.globalIndex2pubkey[index];
   }
 
-  getPubkeyIndex(pubkey: Uint8Array): ValidatorIndex | undefined {
+  getValidatorIndex(pubkey: Uint8Array | PubkeyHex): ValidatorIndex | undefined {
     return this.globalPubkey2index.get(pubkey) || this.unfinalizedPubkey2index.get(toMemoryEfficientHexStr(pubkey));
   }
 

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -48,15 +48,19 @@ export class PubkeyIndexMap {
   }
 }
 
-export class UnfinalizedPubkeyIndexMap {
-  private map = immutable.Map<PubkeyHex, ValidatorIndex>();
+export class UnfinalizedIndex2PubkeyCache {
+  private list = immutable.List<PublicKey>();
 
-  get(key: Uint8Array | PubkeyHex): ValidatorIndex | undefined {
-    return this.map.get(toMemoryEfficientHexStr(key));
+  get(index: number): PublicKey | undefined {
+    return this.list.get(index);
   }
 
-  set(key: Uint8Array, value: ValidatorIndex): void {
-    this.map = this.map.set(toMemoryEfficientHexStr(key), value);
+  push(pubkey: PublicKey): void {
+    this.list = this.list.push(pubkey);
+  }
+
+  delete(index: number): void {
+    this.list = this.list.delete(index);
   }
 }
 

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -2,6 +2,7 @@ import {CoordType, PublicKey} from "@chainsafe/bls/types";
 import bls from "@chainsafe/bls";
 import {ValidatorIndex} from "@lodestar/types";
 import {BeaconStateAllForks} from "./types.js";
+import * as immutable from "immutable";
 
 export type Index2PubkeyCache = PublicKey[];
 
@@ -26,6 +27,22 @@ function toMemoryEfficientHexStr(hex: Uint8Array | string): string {
   return Buffer.from(hex).toString("hex");
 }
 
+export class UnfinanlizedIndex2PubkeyCache {
+  private list = immutable.List<PubkeyHex | null>();
+
+  get(i: number): PubkeyHex | null {
+  }
+
+  push(element: PubkeyHex): void {
+
+  }
+
+  length(): number {
+
+  }
+
+}
+
 export class PubkeyIndexMap {
   // We don't really need the full pubkey. We could just use the first 20 bytes like an Ethereum address
   readonly map = new Map<PubkeyHex, ValidatorIndex>();
@@ -43,6 +60,18 @@ export class PubkeyIndexMap {
 
   set(key: Uint8Array, value: ValidatorIndex): void {
     this.map.set(toMemoryEfficientHexStr(key), value);
+  }
+}
+
+export class UnfinalizedPubkeyIndexMap {
+  private map = immutable.Map<PubkeyHex, ValidatorIndex>();
+
+  get(key: Uint8Array | PubkeyHex): ValidatorIndex | undefined {
+    return this.map.get(toMemoryEfficientHexStr(key));
+  }
+
+  set(key: Uint8Array, value: ValidatorIndex): void {
+    this.map = this.map.set(toMemoryEfficientHexStr(key), value);
   }
 }
 

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -1,8 +1,8 @@
 import {CoordType, PublicKey} from "@chainsafe/bls/types";
 import bls from "@chainsafe/bls";
+import * as immutable from "immutable";
 import {ValidatorIndex} from "@lodestar/types";
 import {BeaconStateAllForks} from "./types.js";
-import * as immutable from "immutable";
 
 export type Index2PubkeyCache = PublicKey[];
 

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -30,7 +30,7 @@ export function toMemoryEfficientHexStr(hex: Uint8Array | string): string {
 
 /**
  * 
- * A wrapper for calling immutable.js
+ * A wrapper for calling immutable.js. To abstract the initialization of UnfinalizedPubkeyIndexMap
  * 
  */
 export function newUnfinalizedPubkeyIndexMap(): UnfinalizedPubkeyIndexMap {

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -7,7 +7,7 @@ import {BeaconStateAllForks} from "./types.js";
 export type Index2PubkeyCache = PublicKey[];
 export type UnfinalizedPubkeyIndexMap = immutable.Map<PubkeyHex, ValidatorIndex>;
 
-type PubkeyHex = string;
+export type PubkeyHex = string;
 
 /**
  * toHexString() creates hex strings via string concatenation, which are very memory inneficient.

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -27,21 +27,6 @@ function toMemoryEfficientHexStr(hex: Uint8Array | string): string {
   return Buffer.from(hex).toString("hex");
 }
 
-export class UnfinanlizedIndex2PubkeyCache {
-  private list = immutable.List<PubkeyHex | null>();
-
-  get(i: number): PubkeyHex | null {
-  }
-
-  push(element: PubkeyHex): void {
-
-  }
-
-  length(): number {
-
-  }
-
-}
 
 export class PubkeyIndexMap {
   // We don't really need the full pubkey. We could just use the first 20 bytes like an Ethereum address

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -29,14 +29,13 @@ export function toMemoryEfficientHexStr(hex: Uint8Array | string): string {
 }
 
 /**
- * 
+ *
  * A wrapper for calling immutable.js. To abstract the initialization of UnfinalizedPubkeyIndexMap
- * 
+ *
  */
 export function newUnfinalizedPubkeyIndexMap(): UnfinalizedPubkeyIndexMap {
   return immutable.Map<PubkeyHex, ValidatorIndex>();
 }
-
 
 export class PubkeyIndexMap {
   // We don't really need the full pubkey. We could just use the first 20 bytes like an Ethereum address
@@ -58,14 +57,13 @@ export class PubkeyIndexMap {
   }
 }
 
-
 /**
  * Checks the pubkey indices against a state and adds missing pubkeys
  *
  * Mutates `pubkey2index` and `index2pubkey`
  *
  * If pubkey caches are empty: SLOW CODE - 🐢
- * 
+ *
  * TODO: Deal with this
  */
 export function syncPubkeys(

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -5,6 +5,7 @@ import {ValidatorIndex} from "@lodestar/types";
 import {BeaconStateAllForks} from "./types.js";
 
 export type Index2PubkeyCache = PublicKey[];
+export type UnfinalizedPubkeyIndexMap = immutable.Map<PubkeyHex, ValidatorIndex>;
 
 type PubkeyHex = string;
 
@@ -16,7 +17,7 @@ type PubkeyHex = string;
  *
  * See https://github.com/ChainSafe/lodestar/issues/3446
  */
-function toMemoryEfficientHexStr(hex: Uint8Array | string): string {
+export function toMemoryEfficientHexStr(hex: Uint8Array | string): string {
   if (typeof hex === "string") {
     if (hex.startsWith("0x")) {
       hex = hex.slice(2);
@@ -48,22 +49,6 @@ export class PubkeyIndexMap {
   }
 }
 
-export class UnfinalizedPubkeyIndexMap {
-   private map = immutable.Map<PubkeyHex, ValidatorIndex>();
-
-   get(key: Uint8Array | PubkeyHex): ValidatorIndex | undefined {
-     return this.map.get(toMemoryEfficientHexStr(key));
-   }
-
-   set(key: Uint8Array, value: ValidatorIndex): void {
-     this.map = this.map.set(toMemoryEfficientHexStr(key), value);
-   }
-
-   delete(key: Uint8Array): void {
-    this.map = this.map.delete(toMemoryEfficientHexStr(key));
-   }
-
-}
 
 /**
  * Checks the pubkey indices against a state and adds missing pubkeys
@@ -71,6 +56,8 @@ export class UnfinalizedPubkeyIndexMap {
  * Mutates `pubkey2index` and `index2pubkey`
  *
  * If pubkey caches are empty: SLOW CODE - 🐢
+ * 
+ * TODO: Deal with this
  */
 export function syncPubkeys(
   state: BeaconStateAllForks,

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -28,6 +28,15 @@ export function toMemoryEfficientHexStr(hex: Uint8Array | string): string {
   return Buffer.from(hex).toString("hex");
 }
 
+/**
+ * 
+ * A wrapper for calling immutable.js
+ * 
+ */
+export function newUnfinalizedPubkeyIndexMap(): UnfinalizedPubkeyIndexMap {
+  return immutable.Map<PubkeyHex, ValidatorIndex>();
+}
+
 
 export class PubkeyIndexMap {
   // We don't really need the full pubkey. We could just use the first 20 bytes like an Ethereum address

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -48,20 +48,21 @@ export class PubkeyIndexMap {
   }
 }
 
-export class UnfinalizedIndex2PubkeyCache {
-  private list = immutable.List<PublicKey>();
+export class UnfinalizedPubkeyIndexMap {
+   private map = immutable.Map<PubkeyHex, ValidatorIndex>();
 
-  get(index: number): PublicKey | undefined {
-    return this.list.get(index);
-  }
+   get(key: Uint8Array | PubkeyHex): ValidatorIndex | undefined {
+     return this.map.get(toMemoryEfficientHexStr(key));
+   }
 
-  push(pubkey: PublicKey): void {
-    this.list = this.list.push(pubkey);
-  }
+   set(key: Uint8Array, value: ValidatorIndex): void {
+     this.map = this.map.set(toMemoryEfficientHexStr(key), value);
+   }
 
-  delete(index: number): void {
-    this.list = this.list.delete(index);
-  }
+   delete(key: Uint8Array): void {
+    this.map = this.map.delete(toMemoryEfficientHexStr(key));
+   }
+
 }
 
 /**

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -37,6 +37,8 @@ export function newUnfinalizedPubkeyIndexMap(): UnfinalizedPubkeyIndexMap {
   return immutable.Map<PubkeyHex, ValidatorIndex>();
 }
 
+
+
 export class PubkeyIndexMap {
   // We don't really need the full pubkey. We could just use the first 20 bytes like an Ethereum address
   readonly map = new Map<PubkeyHex, ValidatorIndex>();
@@ -55,6 +57,7 @@ export class PubkeyIndexMap {
   set(key: Uint8Array, value: ValidatorIndex): void {
     this.map.set(toMemoryEfficientHexStr(key), value);
   }
+
 }
 
 /**

--- a/packages/state-transition/src/cache/stateCache.ts
+++ b/packages/state-transition/src/cache/stateCache.ts
@@ -1,5 +1,5 @@
 import {BeaconConfig} from "@lodestar/config";
-import {EpochCache, EpochCacheImmutableData, EpochCacheOpts} from "./epochCache.js";
+import {CarryoverData, EpochCache, EpochCacheImmutableData, EpochCacheOpts} from "./epochCache.js";
 import {
   BeaconStateAllForks,
   BeaconStateExecutions,
@@ -138,11 +138,12 @@ export type CachedBeaconStateExecutions = CachedBeaconState<BeaconStateExecution
 export function createCachedBeaconState<T extends BeaconStateAllForks>(
   state: T,
   immutableData: EpochCacheImmutableData,
+  carryoverData: CarryoverData,
   opts?: EpochCacheOpts
 ): T & BeaconStateCache {
   return getCachedBeaconState(state, {
     config: immutableData.config,
-    epochCtx: EpochCache.createFromState(state, immutableData, opts),
+    epochCtx: EpochCache.createFromState(state, immutableData, carryoverData, opts),
     clonedCount: 0,
     clonedCountWithTransferCache: 0,
     createdWithTransferCache: false,

--- a/packages/state-transition/src/cache/stateCache.ts
+++ b/packages/state-transition/src/cache/stateCache.ts
@@ -9,10 +9,17 @@ import {
   BeaconStateCapella,
   BeaconStateDeneb,
 } from "./types.js";
+import {UnfinalizedPubkeyIndexMap, UnfinanlizedIndex2PubkeyCache} from "./pubkeyCache";
+import {PublicKey} from "@chainsafe/bls/types";
+import {ValidatorIndex} from "@lodestar/types";
 
 export type BeaconStateCache = {
   config: BeaconConfig;
   epochCtx: EpochCache;
+  /** Unfinalized cache for current state */
+  unfinalizedPubkeyCache: UnfinanlizedIndex2PubkeyCache;
+  unfinalizedPubkeyIndexMap: UnfinalizedPubkeyIndexMap;
+
   /** Count of clones created from this BeaconStateCache instance. readonly to prevent accidental usage downstream */
   readonly clonedCount: number;
   readonly clonedCountWithTransferCache: number;
@@ -140,6 +147,8 @@ export function createCachedBeaconState<T extends BeaconStateAllForks>(
   return getCachedBeaconState(state, {
     config: immutableData.config,
     epochCtx: EpochCache.createFromState(state, immutableData, opts),
+    unfinalizedPubkeyCache: new UnfinanlizedIndex2PubkeyCache(),
+    unfinalizedPubkeyIndexMap: new UnfinalizedPubkeyIndexMap(),
     clonedCount: 0,
     clonedCountWithTransferCache: 0,
     createdWithTransferCache: false,
@@ -177,6 +186,8 @@ export function getCachedBeaconState<T extends BeaconStateAllForks>(
     return getCachedBeaconState(viewDUCloned, {
       config: this.config,
       epochCtx: this.epochCtx.clone(),
+      unfinalizedPubkeyCache: this.unfinalizedPubkeyCache,
+      unfinalizedPubkeyIndexMap: new UnfinalizedPubkeyIndexMap(),
       clonedCount: 0,
       clonedCountWithTransferCache: 0,
       createdWithTransferCache: !dontTransferCache,
@@ -206,4 +217,14 @@ export function isStateValidatorsNodesPopulated(state: CachedBeaconStateAllForks
 
 export function isStateBalancesNodesPopulated(state: CachedBeaconStateAllForks): boolean {
   return state.balances["nodesPopulated"] === true;
+}
+
+export function getPubkeyForAggregation(state: CachedBeaconStateAllForks, index: ValidatorIndex): PublicKey {
+}
+
+export function getPubkeyIndex(state: CachedBeaconStateAllForks, pubkey: Uint8Array): ValidatorIndex | null {
+}
+
+export function addPubkey(state: CachedBeaconStateAllForks, pubkey: Uint8Array, index: ValidatorIndex): void {
+
 }

--- a/packages/state-transition/src/cache/stateCache.ts
+++ b/packages/state-transition/src/cache/stateCache.ts
@@ -9,15 +9,12 @@ import {
   BeaconStateCapella,
   BeaconStateDeneb,
 } from "./types.js";
-import {UnfinalizedPubkeyIndexMap} from "./pubkeyCache";
 import {PublicKey} from "@chainsafe/bls/types";
 import {ValidatorIndex} from "@lodestar/types";
 
 export type BeaconStateCache = {
   config: BeaconConfig;
   epochCtx: EpochCache;
-  /** Unfinalized cache for current state */
-  unfinalizedPubkeyIndexMap: UnfinalizedPubkeyIndexMap;
 
   /** Count of clones created from this BeaconStateCache instance. readonly to prevent accidental usage downstream */
   readonly clonedCount: number;
@@ -146,7 +143,6 @@ export function createCachedBeaconState<T extends BeaconStateAllForks>(
   return getCachedBeaconState(state, {
     config: immutableData.config,
     epochCtx: EpochCache.createFromState(state, immutableData, opts),
-    unfinalizedPubkeyIndexMap: new UnfinalizedPubkeyIndexMap(),
     clonedCount: 0,
     clonedCountWithTransferCache: 0,
     createdWithTransferCache: false,
@@ -184,7 +180,6 @@ export function getCachedBeaconState<T extends BeaconStateAllForks>(
     return getCachedBeaconState(viewDUCloned, {
       config: this.config,
       epochCtx: this.epochCtx.clone(),
-      unfinalizedPubkeyIndexMap: new UnfinalizedPubkeyIndexMap(),
       clonedCount: 0,
       clonedCountWithTransferCache: 0,
       createdWithTransferCache: !dontTransferCache,
@@ -214,14 +209,4 @@ export function isStateValidatorsNodesPopulated(state: CachedBeaconStateAllForks
 
 export function isStateBalancesNodesPopulated(state: CachedBeaconStateAllForks): boolean {
   return state.balances["nodesPopulated"] === true;
-}
-
-export function getPubkeyForAggregation(state: CachedBeaconStateAllForks, index: ValidatorIndex): PublicKey {
-}
-
-export function getPubkeyIndex(state: CachedBeaconStateAllForks, pubkey: Uint8Array): ValidatorIndex | null {
-}
-
-export function addPubkey(state: CachedBeaconStateAllForks, pubkey: Uint8Array, index: ValidatorIndex): void {
-
 }

--- a/packages/state-transition/src/cache/stateCache.ts
+++ b/packages/state-transition/src/cache/stateCache.ts
@@ -9,7 +9,7 @@ import {
   BeaconStateCapella,
   BeaconStateDeneb,
 } from "./types.js";
-import {UnfinalizedPubkeyIndexMap, UnfinanlizedIndex2PubkeyCache} from "./pubkeyCache";
+import {UnfinalizedPubkeyIndexMap} from "./pubkeyCache";
 import {PublicKey} from "@chainsafe/bls/types";
 import {ValidatorIndex} from "@lodestar/types";
 
@@ -17,7 +17,6 @@ export type BeaconStateCache = {
   config: BeaconConfig;
   epochCtx: EpochCache;
   /** Unfinalized cache for current state */
-  unfinalizedPubkeyCache: UnfinanlizedIndex2PubkeyCache;
   unfinalizedPubkeyIndexMap: UnfinalizedPubkeyIndexMap;
 
   /** Count of clones created from this BeaconStateCache instance. readonly to prevent accidental usage downstream */
@@ -147,7 +146,6 @@ export function createCachedBeaconState<T extends BeaconStateAllForks>(
   return getCachedBeaconState(state, {
     config: immutableData.config,
     epochCtx: EpochCache.createFromState(state, immutableData, opts),
-    unfinalizedPubkeyCache: new UnfinanlizedIndex2PubkeyCache(),
     unfinalizedPubkeyIndexMap: new UnfinalizedPubkeyIndexMap(),
     clonedCount: 0,
     clonedCountWithTransferCache: 0,
@@ -186,7 +184,6 @@ export function getCachedBeaconState<T extends BeaconStateAllForks>(
     return getCachedBeaconState(viewDUCloned, {
       config: this.config,
       epochCtx: this.epochCtx.clone(),
-      unfinalizedPubkeyCache: this.unfinalizedPubkeyCache,
       unfinalizedPubkeyIndexMap: new UnfinalizedPubkeyIndexMap(),
       clonedCount: 0,
       clonedCountWithTransferCache: 0,

--- a/packages/state-transition/src/cache/stateCache.ts
+++ b/packages/state-transition/src/cache/stateCache.ts
@@ -9,8 +9,6 @@ import {
   BeaconStateCapella,
   BeaconStateDeneb,
 } from "./types.js";
-import {PublicKey} from "@chainsafe/bls/types";
-import {ValidatorIndex} from "@lodestar/types";
 
 export type BeaconStateCache = {
   config: BeaconConfig;

--- a/packages/state-transition/src/epoch/processRegistryUpdates.ts
+++ b/packages/state-transition/src/epoch/processRegistryUpdates.ts
@@ -34,6 +34,11 @@ export function processRegistryUpdates(state: CachedBeaconStateAllForks, cache: 
   // set new activation eligibilities
   for (const index of cache.indicesEligibleForActivationQueue) {
     validators.get(index).activationEligibilityEpoch = epochCtx.epoch + 1;
+    // TODO: For all new validators that are eligible to be in the activation queue, we need to move its cache from unfinalized to finalized queue
+    // const validator = validators.get(index);
+    // const pubkey = validator.pubkey;
+    // state.epochCtx.addPubkey(index, pubkey);
+
   }
 
   const finalityEpoch = state.finalizedCheckpoint.epoch;

--- a/packages/state-transition/src/epoch/processRegistryUpdates.ts
+++ b/packages/state-transition/src/epoch/processRegistryUpdates.ts
@@ -34,11 +34,6 @@ export function processRegistryUpdates(state: CachedBeaconStateAllForks, cache: 
   // set new activation eligibilities
   for (const index of cache.indicesEligibleForActivationQueue) {
     validators.get(index).activationEligibilityEpoch = epochCtx.epoch + 1;
-    // TODO: For all new validators that are eligible to be in the activation queue, we need to move its cache from unfinalized to finalized queue
-    // const validator = validators.get(index);
-    // const pubkey = validator.pubkey;
-    // state.epochCtx.addPubkey(index, pubkey);
-
   }
 
   const finalityEpoch = state.finalizedCheckpoint.epoch;
@@ -54,5 +49,9 @@ export function processRegistryUpdates(state: CachedBeaconStateAllForks, cache: 
       break;
     }
     validator.activationEpoch = computeActivationExitEpoch(cache.currentEpoch);
+    // TODO: For all new validators that are eligible to be in the activation queue, we need to move its cache from unfinalized to finalized queue
+    // const validator = validators.get(index);
+    // const pubkey = validator.pubkey;
+    // state.epochCtx.addPubkey(index, pubkey);
   }
 }

--- a/packages/state-transition/src/epoch/processRegistryUpdates.ts
+++ b/packages/state-transition/src/epoch/processRegistryUpdates.ts
@@ -49,9 +49,5 @@ export function processRegistryUpdates(state: CachedBeaconStateAllForks, cache: 
       break;
     }
     validator.activationEpoch = computeActivationExitEpoch(cache.currentEpoch);
-    // TODO: For all new validators that are eligible to be in the activation queue, we need to move its cache from unfinalized to finalized queue
-    // const validator = validators.get(index);
-    // const pubkey = validator.pubkey;
-    // state.epochCtx.addPubkey(index, pubkey);
   }
 }

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -34,7 +34,7 @@ export {EpochCache, EpochCacheImmutableData, createEmptyEpochCacheImmutableData}
 export {EpochTransitionCache, beforeProcessEpoch} from "./cache/epochTransitionCache.js";
 
 // Aux data-structures
-export {PubkeyIndexMap, Index2PubkeyCache, UnfinalizedIndex2PubkeyCache} from "./cache/pubkeyCache.js";
+export {PubkeyIndexMap, Index2PubkeyCache, UnfinalizedPubkeyIndexMap} from "./cache/pubkeyCache.js";
 
 export {
   EffectiveBalanceIncrements,

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -34,7 +34,7 @@ export {EpochCache, EpochCacheImmutableData, createEmptyEpochCacheImmutableData}
 export {EpochTransitionCache, beforeProcessEpoch} from "./cache/epochTransitionCache.js";
 
 // Aux data-structures
-export {PubkeyIndexMap, Index2PubkeyCache} from "./cache/pubkeyCache.js";
+export {PubkeyIndexMap, Index2PubkeyCache, UnfinalizedIndex2PubkeyCache} from "./cache/pubkeyCache.js";
 
 export {
   EffectiveBalanceIncrements,

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -30,7 +30,12 @@ export {
   isStateBalancesNodesPopulated,
   isStateValidatorsNodesPopulated,
 } from "./cache/stateCache.js";
-export {EpochCache, EpochCacheImmutableData, createEmptyEpochCacheImmutableData, createEmptyCarryoverData} from "./cache/epochCache.js";
+export {
+  EpochCache,
+  EpochCacheImmutableData,
+  createEmptyEpochCacheImmutableData,
+  createEmptyCarryoverData,
+} from "./cache/epochCache.js";
 export {EpochTransitionCache, beforeProcessEpoch} from "./cache/epochTransitionCache.js";
 
 // Aux data-structures

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -30,7 +30,7 @@ export {
   isStateBalancesNodesPopulated,
   isStateValidatorsNodesPopulated,
 } from "./cache/stateCache.js";
-export {EpochCache, EpochCacheImmutableData, createEmptyEpochCacheImmutableData} from "./cache/epochCache.js";
+export {EpochCache, EpochCacheImmutableData, createEmptyEpochCacheImmutableData, createEmptyCarryoverData} from "./cache/epochCache.js";
 export {EpochTransitionCache, beforeProcessEpoch} from "./cache/epochTransitionCache.js";
 
 // Aux data-structures

--- a/packages/state-transition/src/signatureSets/attesterSlashings.ts
+++ b/packages/state-transition/src/signatureSets/attesterSlashings.ts
@@ -27,13 +27,13 @@ export function getIndexedAttestationBigintSignatureSet(
   state: CachedBeaconStateAllForks,
   indexedAttestation: phase0.IndexedAttestationBigint
 ): ISignatureSet {
-  const {index2pubkey} = state.epochCtx;
+  const index2pubkey = state.epochCtx.getPubkey;
   const slot = computeStartSlotAtEpoch(Number(indexedAttestation.data.target.epoch as bigint));
   const domain = state.config.getDomain(state.slot, DOMAIN_BEACON_ATTESTER, slot);
 
   return {
     type: SignatureSetType.aggregate,
-    pubkeys: indexedAttestation.attestingIndices.map((i) => index2pubkey[i]),
+    pubkeys: indexedAttestation.attestingIndices.map((i) => index2pubkey(i)),
     signingRoot: computeSigningRoot(ssz.phase0.AttestationDataBigint, indexedAttestation.data, domain),
     signature: indexedAttestation.signature,
   };

--- a/packages/state-transition/src/signatureSets/indexedAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedAttestation.ts
@@ -24,7 +24,7 @@ export function getAttestationWithIndicesSignatureSet(
   attestingIndices: number[]
 ): ISignatureSet {
   return createAggregateSignatureSetFromComponents(
-    attestingIndices.map((i) => state.epochCtx.index2pubkey[i]),
+    attestingIndices.map((i) => state.epochCtx.getPubkey(i)),
     getAttestationDataSigningRoot(state, attestation.data),
     attestation.signature
   );

--- a/packages/state-transition/src/signatureSets/proposer.ts
+++ b/packages/state-transition/src/signatureSets/proposer.ts
@@ -25,7 +25,7 @@ export function getBlockProposerSignatureSet(
 
   return {
     type: SignatureSetType.single,
-    pubkey: epochCtx.index2pubkey[signedBlock.message.proposerIndex],
+    pubkey: epochCtx.getPubkey(signedBlock.message.proposerIndex),
     signingRoot: computeSigningRoot(blockType, signedBlock.message, domain),
     signature: signedBlock.signature,
   };
@@ -42,7 +42,7 @@ export function getBlobProposerSignatureSet(
 
   return {
     type: SignatureSetType.single,
-    pubkey: epochCtx.index2pubkey[signedBlob.message.proposerIndex],
+    pubkey: epochCtx.getPubkey(signedBlob.message.proposerIndex),
     signingRoot: computeSigningRoot(blockType, signedBlob.message, domain),
     signature: signedBlob.signature,
   };

--- a/packages/state-transition/src/signatureSets/proposerSlashings.ts
+++ b/packages/state-transition/src/signatureSets/proposerSlashings.ts
@@ -11,7 +11,7 @@ export function getProposerSlashingSignatureSets(
   proposerSlashing: phase0.ProposerSlashing
 ): ISignatureSet[] {
   const {epochCtx} = state;
-  const pubkey = epochCtx.index2pubkey[proposerSlashing.signedHeader1.message.proposerIndex];
+  const pubkey = epochCtx.getPubkey(proposerSlashing.signedHeader1.message.proposerIndex);
 
   // In state transition, ProposerSlashing headers are only partially validated. Their slot could be higher than the
   // clock and the slashing would still be valid. Must use bigint variants to hash correctly to all possible values

--- a/packages/state-transition/src/signatureSets/randao.ts
+++ b/packages/state-transition/src/signatureSets/randao.ts
@@ -27,7 +27,7 @@ export function getRandaoRevealSignatureSet(
 
   return {
     type: SignatureSetType.single,
-    pubkey: epochCtx.index2pubkey[block.proposerIndex],
+    pubkey: epochCtx.getPubkey(block.proposerIndex),
     signingRoot: computeSigningRoot(ssz.Epoch, epoch, domain),
     signature: block.body.randaoReveal,
   };

--- a/packages/state-transition/src/signatureSets/voluntaryExits.ts
+++ b/packages/state-transition/src/signatureSets/voluntaryExits.ts
@@ -28,7 +28,7 @@ export function getVoluntaryExitSignatureSet(
 
   return {
     type: SignatureSetType.single,
-    pubkey: epochCtx.index2pubkey[signedVoluntaryExit.message.validatorIndex],
+    pubkey: epochCtx.getPubkey(signedVoluntaryExit.message.validatorIndex),
     signingRoot: computeSigningRoot(ssz.phase0.VoluntaryExit, signedVoluntaryExit.message, domain),
     signature: signedVoluntaryExit.signature,
   };

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -12,7 +12,7 @@ import {Bytes32, phase0, Root, ssz, TimeSeconds} from "@lodestar/types";
 
 import {CachedBeaconStateAllForks, BeaconStateAllForks} from "../types.js";
 import {createCachedBeaconState} from "../cache/stateCache.js";
-import {EpochCacheImmutableData} from "../cache/epochCache.js";
+import {EpochCacheImmutableData, createEmptyCarryoverData} from "../cache/epochCache.js";
 import {processDeposit} from "../block/processDeposit.js";
 import {computeEpochAtSlot} from "./epoch.js";
 import {getActiveValidatorIndices} from "./validator.js";
@@ -232,7 +232,7 @@ export function initializeBeaconStateFromEth1(
   // - 3. interop state: Only supports starting from genesis at phase0 fork
   // So it's okay to skip syncing the sync committee cache here and expect it to be
   // populated latter when the altair fork happens for cases 2, 3.
-  const state = createCachedBeaconState(stateView, immutableData, {skipSyncCommitteeCache: true});
+  const state = createCachedBeaconState(stateView, immutableData, createEmptyCarryoverData(), {skipSyncCommitteeCache: true});
 
   applyTimestamp(config, state, eth1Timestamp);
   applyEth1BlockHash(state, eth1BlockHash);

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -232,7 +232,9 @@ export function initializeBeaconStateFromEth1(
   // - 3. interop state: Only supports starting from genesis at phase0 fork
   // So it's okay to skip syncing the sync committee cache here and expect it to be
   // populated latter when the altair fork happens for cases 2, 3.
-  const state = createCachedBeaconState(stateView, immutableData, createEmptyCarryoverData(), {skipSyncCommitteeCache: true});
+  const state = createCachedBeaconState(stateView, immutableData, createEmptyCarryoverData(), {
+    skipSyncCommitteeCache: true,
+  });
 
   applyTimestamp(config, state, eth1Timestamp);
   applyEth1BlockHash(state, eth1BlockHash);

--- a/packages/state-transition/test/perf/util.ts
+++ b/packages/state-transition/test/perf/util.ts
@@ -20,6 +20,7 @@ import {
   newFilledArray,
   createCachedBeaconState,
   computeCommitteeCount,
+  createEmptyCarryoverData,
 } from "../../src/index.js";
 import {
   CachedBeaconStateAllForks,
@@ -129,7 +130,7 @@ export function generatePerfTestCachedStatePhase0(opts?: {goBackOneSlot: boolean
       config: createBeaconConfig(config, state.genesisValidatorsRoot),
       pubkey2index,
       index2pubkey,
-    });
+    }, createEmptyCarryoverData());
 
     const currentEpoch = computeEpochAtSlot(state.slot - 1);
     const previousEpoch = currentEpoch - 1;
@@ -227,7 +228,7 @@ export function generatePerfTestCachedStateAltair(opts?: {goBackOneSlot: boolean
       config: createBeaconConfig(altairConfig, state.genesisValidatorsRoot),
       pubkey2index,
       index2pubkey,
-    });
+    }, createEmptyCarryoverData());
   }
   if (!altairCachedState23638) {
     altairCachedState23638 = processSlots(
@@ -428,5 +429,5 @@ export function generateTestCachedBeaconStateOnlyValidators({
     config: createBeaconConfig(config, state.genesisValidatorsRoot),
     pubkey2index,
     index2pubkey,
-  });
+  }, createEmptyCarryoverData());
 }

--- a/packages/state-transition/test/perf/util.ts
+++ b/packages/state-transition/test/perf/util.ts
@@ -126,11 +126,15 @@ export function generatePerfTestCachedStatePhase0(opts?: {goBackOneSlot: boolean
   if (!phase0CachedState23637) {
     const state = phase0State.clone();
     state.slot -= 1;
-    phase0CachedState23637 = createCachedBeaconState(state, {
-      config: createBeaconConfig(config, state.genesisValidatorsRoot),
-      pubkey2index,
-      index2pubkey,
-    }, createEmptyCarryoverData());
+    phase0CachedState23637 = createCachedBeaconState(
+      state,
+      {
+        config: createBeaconConfig(config, state.genesisValidatorsRoot),
+        pubkey2index,
+        index2pubkey,
+      },
+      createEmptyCarryoverData()
+    );
 
     const currentEpoch = computeEpochAtSlot(state.slot - 1);
     const previousEpoch = currentEpoch - 1;
@@ -224,11 +228,15 @@ export function generatePerfTestCachedStateAltair(opts?: {goBackOneSlot: boolean
   if (!altairCachedState23637) {
     const state = origState.clone();
     state.slot -= 1;
-    altairCachedState23637 = createCachedBeaconState(state, {
-      config: createBeaconConfig(altairConfig, state.genesisValidatorsRoot),
-      pubkey2index,
-      index2pubkey,
-    }, createEmptyCarryoverData());
+    altairCachedState23637 = createCachedBeaconState(
+      state,
+      {
+        config: createBeaconConfig(altairConfig, state.genesisValidatorsRoot),
+        pubkey2index,
+        index2pubkey,
+      },
+      createEmptyCarryoverData()
+    );
   }
   if (!altairCachedState23638) {
     altairCachedState23638 = processSlots(
@@ -425,9 +433,13 @@ export function generateTestCachedBeaconStateOnlyValidators({
     throw Error(`Wrong number of validators in the state: ${state.validators.length} !== ${vc}`);
   }
 
-  return createCachedBeaconState(state, {
-    config: createBeaconConfig(config, state.genesisValidatorsRoot),
-    pubkey2index,
-    index2pubkey,
-  }, createEmptyCarryoverData());
+  return createCachedBeaconState(
+    state,
+    {
+      config: createBeaconConfig(config, state.genesisValidatorsRoot),
+      pubkey2index,
+      index2pubkey,
+    },
+    createEmptyCarryoverData()
+  );
 }

--- a/packages/state-transition/test/unit/upgradeState.test.ts
+++ b/packages/state-transition/test/unit/upgradeState.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 import {ssz} from "@lodestar/types";
 import {ForkName} from "@lodestar/params";
-import {createCachedBeaconState, PubkeyIndexMap} from "@lodestar/state-transition";
+import {createCachedBeaconState, PubkeyIndexMap, createEmptyCarryoverData} from "@lodestar/state-transition";
 import {createBeaconConfig, ChainForkConfig, createChainForkConfig} from "@lodestar/config";
 import {config as chainConfig} from "@lodestar/config/default";
 
@@ -18,6 +18,7 @@ describe("upgradeState", () => {
         pubkey2index: new PubkeyIndexMap(),
         index2pubkey: [],
       },
+      createEmptyCarryoverData(),
       {skipSyncCommitteeCache: true}
     );
     const newState = upgradeStateToDeneb(stateView);

--- a/packages/state-transition/test/unit/util/cachedBeaconState.test.ts
+++ b/packages/state-transition/test/unit/util/cachedBeaconState.test.ts
@@ -7,10 +7,14 @@ describe("CachedBeaconState", () => {
   it("Create empty CachedBeaconState", () => {
     const emptyState = ssz.phase0.BeaconState.defaultViewDU();
 
-    createCachedBeaconState(emptyState, {
-      config: createBeaconConfig(config, emptyState.genesisValidatorsRoot),
-      pubkey2index: new PubkeyIndexMap(),
-      index2pubkey: [],
-    }, createEmptyCarryoverData());
+    createCachedBeaconState(
+      emptyState,
+      {
+        config: createBeaconConfig(config, emptyState.genesisValidatorsRoot),
+        pubkey2index: new PubkeyIndexMap(),
+        index2pubkey: [],
+      },
+      createEmptyCarryoverData()
+    );
   });
 });

--- a/packages/state-transition/test/unit/util/cachedBeaconState.test.ts
+++ b/packages/state-transition/test/unit/util/cachedBeaconState.test.ts
@@ -1,7 +1,7 @@
 import {createBeaconConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
 import {ssz} from "@lodestar/types";
-import {createCachedBeaconState, PubkeyIndexMap} from "../../../src/index.js";
+import {createCachedBeaconState, PubkeyIndexMap, createEmptyCarryoverData} from "../../../src/index.js";
 
 describe("CachedBeaconState", () => {
   it("Create empty CachedBeaconState", () => {
@@ -11,6 +11,6 @@ describe("CachedBeaconState", () => {
       config: createBeaconConfig(config, emptyState.genesisValidatorsRoot),
       pubkey2index: new PubkeyIndexMap(),
       index2pubkey: [],
-    });
+    }, createEmptyCarryoverData());
   });
 });

--- a/packages/state-transition/test/utils/state.ts
+++ b/packages/state-transition/test/utils/state.ts
@@ -21,7 +21,7 @@ import {
   PubkeyIndexMap,
 } from "../../src/index.js";
 import {BeaconStateCache} from "../../src/cache/stateCache.js";
-import {EpochCacheOpts} from "../../src/cache/epochCache.js";
+import {EpochCacheOpts, createEmptyCarryoverData} from "../../src/cache/epochCache.js";
 
 /**
  * Copy of BeaconState, but all fields are marked optional to allow for swapping out variables as needed.
@@ -94,7 +94,7 @@ export function generateCachedState(
     // This is a test state, there's no need to have a global shared cache of keys
     pubkey2index: new PubkeyIndexMap(),
     index2pubkey: [],
-  });
+  }, createEmptyCarryoverData());
 }
 
 export function createCachedBeaconStateTest<T extends BeaconStateAllForks>(
@@ -110,6 +110,7 @@ export function createCachedBeaconStateTest<T extends BeaconStateAllForks>(
       pubkey2index: new PubkeyIndexMap(),
       index2pubkey: [],
     },
+    createEmptyCarryoverData(),
     opts
   );
 }

--- a/packages/state-transition/test/utils/state.ts
+++ b/packages/state-transition/test/utils/state.ts
@@ -89,12 +89,16 @@ export function generateCachedState(
   opts: TestBeaconState = {}
 ): CachedBeaconStateAllForks {
   const state = generateState(opts);
-  return createCachedBeaconState(state, {
-    config: createBeaconConfig(config, state.genesisValidatorsRoot),
-    // This is a test state, there's no need to have a global shared cache of keys
-    pubkey2index: new PubkeyIndexMap(),
-    index2pubkey: [],
-  }, createEmptyCarryoverData());
+  return createCachedBeaconState(
+    state,
+    {
+      config: createBeaconConfig(config, state.genesisValidatorsRoot),
+      // This is a test state, there's no need to have a global shared cache of keys
+      pubkey2index: new PubkeyIndexMap(),
+      index2pubkey: [],
+    },
+    createEmptyCarryoverData()
+  );
 }
 
 export function createCachedBeaconStateTest<T extends BeaconStateAllForks>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7859,6 +7859,11 @@ ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
+immutable@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.2.tgz#f89d910f8dfb6e15c03b2cae2faaf8c1f66455fe"
+  integrity sha512-oGXzbEDem9OOpDWZu88jGiYCvIsLHMvGw+8OXlpsvTFvIQplQbjg1B1cvKg8f7Hoch6+NGjpPsH1Fr+Mc2D1aA==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz"


### PR DESCRIPTION
**Motivation**

To refactor the current `pubkeyCache` by:
- Introduce unfinalized `pubkey2Index` in `EpochCache` that is fork specific and will be cloned on state.clone()
- To modify existed  `pubkey2Index` and  `index2Pubkey` in `EpochCache` such that they only contain validators that are confirmed active or in the activation queue.

This is a prerequisite to fixing #5366 .

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->
- Introduce class `UnfinalizedPubkeyIndexMap` which is an alias of immutable.Map
- Existed `pubkey2Index` and `index2Pubkey` are renamed to `globalPubkey2index` and `globalIndex2pubkey`.
- Add new field `unfinalizedPubkey2Index: UnfinalizedPubkeyIndexMap` in the `EpochCache ` and will be included during state cloning
- Populating `globalPubkey2index` and `globalIndex2pubkey` happens during `afterProcessEpoch()`. At the same time, `UnfinalizedPubkeyIndexMap` is pruned for every pubkeys that are inserted into global caches.
- Introduce interfaces to hide finalized and unfinalized caches from callers. Callers to the cache should not interact with finalized and unfinalized cache directly
- Introduce `CarryoverData` to specifically allow caller to pass unfinalized cache into `EpochCache.createFromState()` if desired
<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

