### PR TITLE
fix: epoch cache error should be treated with care in gossips validation

### DIFF
--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -224,9 +224,7 @@ export async function validateAttestation(
         code: AttestationErrorCode.BAD_TARGET_EPOCH,
       });
     } else {
-      throw new AttestationError(GossipAction.IGNORE, {
-        code: AttestationErrorCode.INVALID_SIGNATURE,
-      });
+      throw err;
     }
   }
 }

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -8,6 +8,8 @@ import {
   getAttestationDataSigningRoot,
   createSingleSignatureSetFromComponents,
   SingleSignatureSet,
+  EpochCacheError,
+  EpochCacheErrorCode,
 } from "@lodestar/state-transition";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors/index.js";
 import {MAXIMUM_GOSSIP_CLOCK_DISPARITY_SEC} from "../../constants/index.js";
@@ -202,18 +204,30 @@ export async function validateAttestation(
   subnet: number | null,
   prioritizeBls = false
 ): Promise<AttestationValidationResult> {
-  const step0Result = await validateGossipAttestationNoSignatureCheck(fork, chain, attestationOrBytes, subnet);
-  const {attestation, signatureSet, validatorIndex} = step0Result;
-  const isValid = await chain.bls.verifySignatureSets([signatureSet], {batchable: true, priority: prioritizeBls});
+  try {
+    const step0Result = await validateGossipAttestationNoSignatureCheck(fork, chain, attestationOrBytes, subnet);
+    const {attestation, signatureSet, validatorIndex} = step0Result;
+    const isValid = await chain.bls.verifySignatureSets([signatureSet], {batchable: true, priority: prioritizeBls});
 
-  if (isValid) {
-    const targetEpoch = attestation.data.target.epoch;
-    chain.seenAttesters.add(targetEpoch, validatorIndex);
-    return step0Result;
-  } else {
-    throw new AttestationError(GossipAction.IGNORE, {
-      code: AttestationErrorCode.INVALID_SIGNATURE,
-    });
+    if (isValid) {
+      const targetEpoch = attestation.data.target.epoch;
+      chain.seenAttesters.add(targetEpoch, validatorIndex);
+      return step0Result;
+    } else {
+      throw new AttestationError(GossipAction.IGNORE, {
+        code: AttestationErrorCode.INVALID_SIGNATURE,
+      });
+    }
+  } catch (err) {
+    if (err instanceof EpochCacheError && err.type.code === EpochCacheErrorCode.COMMITTEE_INDEX_OUT_OF_RANGE) {
+      throw new AttestationError(GossipAction.IGNORE, {
+        code: AttestationErrorCode.BAD_TARGET_EPOCH,
+      });
+    } else {
+      throw new AttestationError(GossipAction.IGNORE, {
+        code: AttestationErrorCode.INVALID_SIGNATURE,
+      });
+    }
   }
 }
 

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -30,7 +30,13 @@ export {
   isStateBalancesNodesPopulated,
   isStateValidatorsNodesPopulated,
 } from "./cache/stateCache.js";
-export {EpochCache, EpochCacheImmutableData, createEmptyEpochCacheImmutableData} from "./cache/epochCache.js";
+export {
+  EpochCache,
+  EpochCacheImmutableData,
+  createEmptyEpochCacheImmutableData,
+  EpochCacheError,
+  EpochCacheErrorCode,
+} from "./cache/epochCache.js";
 export {EpochTransitionCache, beforeProcessEpoch} from "./cache/epochTransitionCache.js";
 
 // Aux data-structures


### PR DESCRIPTION
**Motivation**

Make the error logging more user friendly. 

**Description**

Some epoch cache related errors were treated aggressively and rather to be treated more naturally in the gossips with the right error codes. 

Closes #5938

**Steps to test or reproduce**

- Run all tests. 