### PR TITLE
ci: enable mixed beacon-validator sim tests

### DIFF
--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -68,11 +68,9 @@ jobs:
         run: yarn test:sim:backup_eth_provider
         working-directory: packages/cli
 
-      # Enable these tests after fixing the following issue
-      # https://github.com/ChainSafe/lodestar/issues/5553
-      # - name: Sim tests multi client
-      #   run: DEBUG='${{github.event.inputs.debug}}' yarn test:sim:multiclient
-      #   working-directory: packages/cli
+      - name: Sim tests multi client
+        run: DEBUG='${{github.event.inputs.debug}}' yarn test:sim:multiclient
+        working-directory: packages/cli
 
       - name: Upload debug log test files for "packages/cli"
         if: ${{ always() }}

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -68,8 +68,8 @@ jobs:
         run: yarn test:sim:backup_eth_provider
         working-directory: packages/cli
 
-      - name: Sim tests multi client
-        run: DEBUG='${{github.event.inputs.debug}}' yarn test:sim:multiclient
+      - name: Sim tests mixed client
+        run: DEBUG='${{github.event.inputs.debug}}' yarn test:sim:mixedclient
         working-directory: packages/cli
 
       - name: Upload debug log test files for "packages/cli"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,7 @@
     "test:unit": "nyc --cache-dir .nyc_output/.cache -e .ts mocha 'test/unit/**/*.test.ts'",
     "test:e2e": "mocha --timeout 30000 'test/e2e/**/*.test.ts'",
     "test:sim:multifork": "LODESTAR_PRESET=minimal node --loader ts-node/esm test/sim/multi_fork.test.ts",
-    "test:sim:multiclient": "LODESTAR_PRESET=minimal node --loader ts-node/esm test/sim/multi_client.test.ts",
+    "test:sim:mixedclient": "LODESTAR_PRESET=minimal node --loader ts-node/esm test/sim/mixed_client.test.ts",
     "test:sim:endpoints": "LODESTAR_PRESET=minimal node --loader ts-node/esm test/sim/endpoints.test.ts",
     "test:sim:deneb": "LODESTAR_PRESET=minimal node --loader ts-node/esm test/sim/deneb.test.ts",
     "test:sim:backup_eth_provider": "LODESTAR_PRESET=minimal node --loader ts-node/esm test/sim/backup_eth_provider.test.ts",

--- a/packages/cli/test/sim/mixed_client.test.ts
+++ b/packages/cli/test/sim/mixed_client.test.ts
@@ -35,8 +35,8 @@ const ttd = getEstimatedTTD({
 
 const env = await SimulationEnvironment.initWithDefaults(
   {
-    id: "multi-clients",
-    logsDir: path.join(logFilesDir, "multi-clients"),
+    id: "mixed-clients",
+    logsDir: path.join(logFilesDir, "mixed-clients"),
     chainConfig: {
       ALTAIR_FORK_EPOCH: altairForkEpoch,
       BELLATRIX_FORK_EPOCH: bellatrixForkEpoch,

--- a/packages/cli/test/utils/simulation/interfaces.ts
+++ b/packages/cli/test/utils/simulation/interfaces.ts
@@ -29,12 +29,12 @@ export type SimulationOptions = {
 };
 
 export enum BeaconClient {
-  Lodestar = "beacon_loadstar",
+  Lodestar = "beacon_lodestar",
   Lighthouse = "beacon_lighthouse",
 }
 
 export enum ValidatorClient {
-  Lodestar = "validator_loadstar",
+  Lodestar = "validator_lodestar",
   Lighthouse = "validator_lighthouse",
 }
 

--- a/packages/cli/test/utils/simulation/runner/DockerRunner.ts
+++ b/packages/cli/test/utils/simulation/runner/DockerRunner.ts
@@ -55,7 +55,7 @@ export class DockerRunner implements RunnerEnv<RunnerType.Docker> {
   }
 
   create(jobOption: Omit<JobOptions<RunnerType.Docker>, "children">): Job {
-    const jobArgs = ["run", "--rm", "--name", jobOption.id];
+    const jobArgs = ["run", "--rm", "--name", jobOption.id, "--add-host", "host.docker.internal:host-gateway"];
 
     if (jobOption.options.dockerNetworkIp) {
       jobArgs.push("--network", dockerNetworkName);


### PR DESCRIPTION
**Motivation**

At the moment mixed client tests are disabled because the assumption was that those will only work once https://github.com/ChainSafe/lodestar/issues/5553 is fixed but that is not the case as the issue is not an actual problem which would prevent Lodestar BN <> Lighthouse VC combinations from producing attestations and aggregates.

**Description**

- Enable mixed client tests added in https://github.com/ChainSafe/lodestar/pull/5885
- Fix host resolution issue
- Rename from "multi client" to "mixed client"

**Further considerations**

We could update sim tests to run all containers with `--network host` flag and not create a [custom docker network](https://github.com/ChainSafe/lodestar/blob/74ee2216677f9fd26697851ae56d67165b3dee30/packages/cli/test/utils/simulation/runner/DockerRunner.ts#L29)
- [`host.docker.internal` workaround](https://github.com/ChainSafe/lodestar/blob/34ab3817af0a93263c744047b173ccac3d9dbe5c/packages/cli/test/utils/simulation/SimulationEnvironment.ts#L299) could be removed
- less isolation of running process, potential port collisions

@nazarhussain are there any other reasons / trade offs for using a custom docker network instead of host network?