### PR TITLE
feat: simplify bootnode enr initialization

### DIFF
--- a/packages/cli/src/cmds/bootnode/handler.ts
+++ b/packages/cli/src/cmds/bootnode/handler.ts
@@ -180,7 +180,7 @@ export async function bootnodeHandlerInit(args: BootnodeArgs & GlobalArgs) {
   );
 
   const logger = initLogger(args, beaconPaths.dataDir, config, "bootnode.log");
-  const {peerId, enr} = await initPeerIdAndEnr(args as unknown as BeaconArgs, bootnodeDir, logger);
+  const {peerId, enr} = await initPeerIdAndEnr(args as unknown as BeaconArgs, bootnodeDir, logger, true);
 
   return {discv5Args, metricsArgs, bootnodeDir, network, version, commit, peerId, enr, logger};
 }

--- a/packages/cli/test/unit/cmds/initPeerIdAndEnr.test.ts
+++ b/packages/cli/test/unit/cmds/initPeerIdAndEnr.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import tmp from "tmp";
 import {expect} from "chai";
 import {initPeerIdAndEnr} from "../../../src/cmds/beacon/initPeerIdAndEnr.js";
@@ -12,7 +13,7 @@ describe("initPeerIdAndEnr", () => {
   });
 
   afterEach(() => {
-    tmpDir.removeCallback();
+    fs.rmSync(tmpDir.name, {recursive: true});
   });
 
   it("first time should create a new enr and peer id", async () => {
@@ -25,6 +26,9 @@ describe("initPeerIdAndEnr", () => {
     expect((await enr.peerId()).toString(), "enr peer id doesn't equal the returned peer id").to.equal(
       peerId.toString()
     );
+    expect(enr.seq).to.equal(BigInt(1));
+    expect(enr.tcp).to.equal(undefined);
+    expect(enr.tcp6).to.equal(undefined);
   });
 
   it("second time should use ths existing enr and peer id", async () => {

--- a/packages/cli/test/unit/cmds/initPeerIdAndEnr.test.ts
+++ b/packages/cli/test/unit/cmds/initPeerIdAndEnr.test.ts
@@ -1,0 +1,48 @@
+import tmp from "tmp";
+import {expect} from "chai";
+import {initPeerIdAndEnr} from "../../../src/cmds/beacon/initPeerIdAndEnr.js";
+import {BeaconArgs} from "../../../src/cmds/beacon/options.js";
+import {testLogger} from "../../utils.js";
+
+describe("initPeerIdAndEnr", () => {
+  let tmpDir: tmp.DirResult;
+
+  beforeEach(() => {
+    tmpDir = tmp.dirSync();
+  });
+
+  afterEach(() => {
+    tmpDir.removeCallback();
+  });
+
+  it("first time should create a new enr and peer id", async () => {
+    const {enr, peerId} = await initPeerIdAndEnr(
+      {persistNetworkIdentity: true} as unknown as BeaconArgs,
+      tmpDir.name,
+      testLogger(),
+      true
+    );
+    expect((await enr.peerId()).toString(), "enr peer id doesn't equal the returned peer id").to.equal(
+      peerId.toString()
+    );
+  });
+
+  it("second time should use ths existing enr and peer id", async () => {
+    const run1 = await initPeerIdAndEnr(
+      {persistNetworkIdentity: true} as unknown as BeaconArgs,
+      tmpDir.name,
+      testLogger(),
+      true
+    );
+
+    const run2 = await initPeerIdAndEnr(
+      {persistNetworkIdentity: true} as unknown as BeaconArgs,
+      tmpDir.name,
+      testLogger(),
+      true
+    );
+
+    expect(run1.peerId.toString()).to.equal(run2.peerId.toString());
+    expect(run1.enr.encodeTxt()).to.equal(run2.enr.encodeTxt());
+  });
+});


### PR DESCRIPTION
**Motivation**

Especially when running a bootnode, its convenient, tho not strictly necessary, to have an ENR that changes as little as possible.

**Description**

On enr initialization, update the enr as little as possible.
On the bootnode setup, don't update the enr `tcp` or `tcp6` fields