### PR TITLE
fix: network worker not shutting down

### DIFF
--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -87,6 +87,9 @@ export type NetworkWorkerData = {
  * API exposed by the libp2p worker
  */
 export type NetworkWorkerApi = INetworkCorePublic & {
+  // To satisfy the constraint of `ModuleThread` type
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [string: string]: (...args: any[]) => Promise<any> | any;
   // Async method through worker boundary
   reportPeer(peer: PeerIdStr, action: PeerAction, actionName: string): Promise<void>;
   reStatusPeers(peers: PeerIdStr[]): Promise<void>;


### PR DESCRIPTION
**Motivation**

Gracefully shutdown the node. 

**Description**

- It's observed that the network worker thread didn't shutdown properly 
- Semantic observation leads to fact that it take more time to cleanup event handlers 
- Added retry for exit strategy  

Closes #5775

**Steps to test or reproduce**

Run all tests. 