### PR TITLE
feat: keymanager API to create signed voluntary exit message

### DIFF
--- a/packages/api/test/unit/keymanager/testData.ts
+++ b/packages/api/test/unit/keymanager/testData.ts
@@ -1,3 +1,4 @@
+import {ssz} from "@lodestar/types";
 import {
   Api,
   DeleteRemoteKeyStatus,
@@ -79,5 +80,9 @@ export const testData: GenericServerTestCases<Api> = {
   deleteGasLimit: {
     args: [pubkeyRand],
     res: undefined,
+  },
+  signVoluntaryExit: {
+    args: [pubkeyRand, 1],
+    res: {data: ssz.phase0.SignedVoluntaryExit.defaultValue()},
   },
 };

--- a/packages/cli/src/cmds/validator/keymanager/impl.ts
+++ b/packages/cli/src/cmds/validator/keymanager/impl.ts
@@ -15,6 +15,7 @@ import {
 } from "@lodestar/api/keymanager";
 import {Interchange, SignerType, Validator} from "@lodestar/validator";
 import {ServerApi} from "@lodestar/api";
+import {Epoch} from "@lodestar/types";
 import {isValidHttpUrl} from "@lodestar/utils";
 import {getPubkeyHexFromKeystore, isValidatePubkeyHex} from "../../../util/format.js";
 import {parseFeeRecipient} from "../../../util/index.js";
@@ -362,6 +363,16 @@ export class KeymanagerApi implements Api {
     return {
       data: results,
     };
+  }
+
+  /**
+   * Create and sign a voluntary exit message for an active validator
+   */
+  async signVoluntaryExit(pubkey: PubkeyHex, epoch?: Epoch): ReturnType<Api["signVoluntaryExit"]> {
+    if (!isValidatePubkeyHex(pubkey)) {
+      throw Error(`Invalid pubkey ${pubkey}`);
+    }
+    return {data: await this.validator.signVoluntaryExit(pubkey, epoch)};
   }
 }
 

--- a/packages/cli/test/e2e/voluntaryExitFromApi.test.ts
+++ b/packages/cli/test/e2e/voluntaryExitFromApi.test.ts
@@ -49,17 +49,8 @@ describe("voluntary exit from api", function () {
       }
     });
 
-    // To cleanup the event stream connection
-    const httpClientController = new AbortController();
-
-    const beaconClient = getClient(
-      {baseUrl: `http://127.0.0.1:${beaconPort}`, getAbortSignal: () => httpClientController.signal},
-      {config}
-    ).beacon;
-    const keymanagerClient = getKeymanagerClient(
-      {baseUrl: `http://127.0.0.1:${keymanagerPort}`, getAbortSignal: () => httpClientController.signal},
-      {config}
-    );
+    const beaconClient = getClient({baseUrl: `http://127.0.0.1:${beaconPort}`}, {config}).beacon;
+    const keymanagerClient = getKeymanagerClient({baseUrl: `http://127.0.0.1:${keymanagerPort}`}, {config});
 
     // Wait for beacon node API to be available + genesis
     await retry(
@@ -102,8 +93,5 @@ describe("voluntary exit from api", function () {
       },
       {retryDelay: 1000, retries: 20}
     );
-
-    // Disconnect the event stream for the client
-    httpClientController.abort();
   });
 });

--- a/packages/cli/test/e2e/voluntaryExitFromApi.test.ts
+++ b/packages/cli/test/e2e/voluntaryExitFromApi.test.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import {expect} from "chai";
-import {rimraf} from "rimraf";
 import {ApiError, getClient} from "@lodestar/api";
 import {getClient as getKeymanagerClient} from "@lodestar/api/keymanager";
 import {config} from "@lodestar/config/default";
@@ -14,12 +13,6 @@ describe("voluntary exit from api", function () {
   const testContext = getMochaContext(this);
   this.timeout("60s");
 
-  const dataDir = path.join(testFilesDir, "voluntary-exit-api-test");
-
-  before("Clean dataDir", () => {
-    rimraf.sync(dataDir);
-  });
-
   it("Perform a voluntary exit", async () => {
     // Start dev node with keymanager
     const keymanagerPort = 38012;
@@ -30,7 +23,7 @@ describe("voluntary exit from api", function () {
       [
         // ⏎
         "dev",
-        `--dataDir=${dataDir}`,
+        `--dataDir=${path.join(testFilesDir, "voluntary-exit-api-test")}`,
         "--genesisValidators=8",
         "--startValidators=0..7",
         "--rest",

--- a/packages/cli/test/e2e/voluntaryExitFromApi.test.ts
+++ b/packages/cli/test/e2e/voluntaryExitFromApi.test.ts
@@ -1,37 +1,31 @@
 import path from "node:path";
 import {expect} from "chai";
 import {rimraf} from "rimraf";
-import {ApiError, getClient, routes} from "@lodestar/api";
-import {Api as KeymanagerApi, getClient as getKeymanagerClient} from "@lodestar/api/keymanager";
+import {ApiError, getClient} from "@lodestar/api";
+import {getClient as getKeymanagerClient} from "@lodestar/api/keymanager";
 import {config} from "@lodestar/config/default";
 import {interopSecretKey} from "@lodestar/state-transition";
-import {gracefullyStopChildProcess, spawnCliCommand} from "@lodestar/test-utils";
-import {phase0} from "@lodestar/types";
+import {spawnCliCommand} from "@lodestar/test-utils";
+import {getMochaContext} from "@lodestar/test-utils/mocha";
 import {retry} from "@lodestar/utils";
 import {testFilesDir} from "../utils.js";
 
 describe("voluntary exit from api", function () {
+  const testContext = getMochaContext(this);
   this.timeout("60s");
 
   const dataDir = path.join(testFilesDir, "voluntary-exit-api-test");
 
-  before("clean dataDir", () => {
+  before("Clean dataDir", () => {
     rimraf.sync(dataDir);
   });
 
-  let beaconClient: routes.beacon.Api;
-  let keymanagerClient: KeymanagerApi;
-
-  // To cleanup the event stream connection
-  const httpClientController = new AbortController();
-
-  let devProc: Awaited<ReturnType<typeof spawnCliCommand>>;
-
-  before("start dev node with keymanager", async () => {
+  it("Perform a voluntary exit", async () => {
+    // Start dev node with keymanager
     const keymanagerPort = 38012;
     const beaconPort = 39012;
 
-    devProc = await spawnCliCommand(
+    const devProc = await spawnCliCommand(
       "packages/cli/bin/lodestar.js",
       [
         // ⏎
@@ -52,7 +46,7 @@ describe("voluntary exit from api", function () {
         // Disable bearer token auth to simplify testing
         "--keymanager.authEnabled=false",
       ],
-      {pipeStdioToParent: false, logPrefix: "dev"}
+      {pipeStdioToParent: false, logPrefix: "dev", testContext}
     );
 
     // Exit early if process exits
@@ -62,12 +56,14 @@ describe("voluntary exit from api", function () {
       }
     });
 
-    beaconClient = getClient(
+    // To cleanup the event stream connection
+    const httpClientController = new AbortController();
+
+    const beaconClient = getClient(
       {baseUrl: `http://127.0.0.1:${beaconPort}`, getAbortSignal: () => httpClientController.signal},
       {config}
     ).beacon;
-
-    keymanagerClient = getKeymanagerClient(
+    const keymanagerClient = getKeymanagerClient(
       {baseUrl: `http://127.0.0.1:${keymanagerPort}`, getAbortSignal: () => httpClientController.signal},
       {config}
     );
@@ -81,37 +77,25 @@ describe("voluntary exit from api", function () {
       },
       {retryDelay: 1000, retries: 20}
     );
-  });
 
-  after(async () => {
-    // Disconnect the event stream for the client
-    httpClientController.abort();
-    devProc.removeAllListeners("exit");
-    await gracefullyStopChildProcess(devProc, 3000);
-  });
+    // 1. create signed voluntary exit message from keymanager
+    const exitEpoch = 0;
+    const indexToExit = 0;
+    const pubkeyToExit = interopSecretKey(indexToExit).toPublicKey().toHex();
 
-  const exitEpoch = 0;
-  const indexToExit = 0;
-  const pubkeyToExit = interopSecretKey(indexToExit).toPublicKey().toHex();
-
-  let signedVoluntaryExit: phase0.SignedVoluntaryExit;
-
-  it("1. create signed voluntary exit message from keymanager", async () => {
     const res = await keymanagerClient.signVoluntaryExit(pubkeyToExit, exitEpoch);
     ApiError.assert(res);
-    signedVoluntaryExit = res.response.data;
+    const signedVoluntaryExit = res.response.data;
 
     expect(signedVoluntaryExit.message.epoch).to.equal(exitEpoch);
     expect(signedVoluntaryExit.message.validatorIndex).to.equal(indexToExit);
     // Signature will be verified when submitting to beacon node
     expect(signedVoluntaryExit.signature).to.not.be.undefined;
-  });
 
-  it("2. submit signed voluntary exit message to beacon node", async () => {
+    // 2. submit signed voluntary exit message to beacon node
     ApiError.assert(await beaconClient.submitPoolVoluntaryExit(signedVoluntaryExit));
-  });
 
-  it("3. confirm validator status is 'active_exiting'", async () => {
+    // 3. confirm validator status is 'active_exiting'
     await retry(
       async () => {
         const res = await beaconClient.getStateValidator("head", pubkeyToExit);
@@ -125,5 +109,8 @@ describe("voluntary exit from api", function () {
       },
       {retryDelay: 1000, retries: 20}
     );
+
+    // Disconnect the event stream for the client
+    httpClientController.abort();
   });
 });

--- a/packages/cli/test/e2e/voluntaryExitFromApi.test.ts
+++ b/packages/cli/test/e2e/voluntaryExitFromApi.test.ts
@@ -1,0 +1,129 @@
+import path from "node:path";
+import {expect} from "chai";
+import {rimraf} from "rimraf";
+import {ApiError, getClient, routes} from "@lodestar/api";
+import {Api as KeymanagerApi, getClient as getKeymanagerClient} from "@lodestar/api/keymanager";
+import {config} from "@lodestar/config/default";
+import {interopSecretKey} from "@lodestar/state-transition";
+import {gracefullyStopChildProcess, spawnCliCommand} from "@lodestar/test-utils";
+import {phase0} from "@lodestar/types";
+import {retry} from "@lodestar/utils";
+import {testFilesDir} from "../utils.js";
+
+describe("voluntary exit from api", function () {
+  this.timeout("60s");
+
+  const dataDir = path.join(testFilesDir, "voluntary-exit-api-test");
+
+  before("clean dataDir", () => {
+    rimraf.sync(dataDir);
+  });
+
+  let beaconClient: routes.beacon.Api;
+  let keymanagerClient: KeymanagerApi;
+
+  // To cleanup the event stream connection
+  const httpClientController = new AbortController();
+
+  let devProc: Awaited<ReturnType<typeof spawnCliCommand>>;
+
+  before("start dev node with keymanager", async () => {
+    const keymanagerPort = 38012;
+    const beaconPort = 39012;
+
+    devProc = await spawnCliCommand(
+      "packages/cli/bin/lodestar.js",
+      [
+        // ⏎
+        "dev",
+        `--dataDir=${dataDir}`,
+        "--genesisValidators=8",
+        "--startValidators=0..7",
+        "--rest",
+        `--rest.port=${beaconPort}`,
+        `--beaconNodes=http://127.0.0.1:${beaconPort}`,
+        // Speed up test to make genesis happen faster
+        "--params.SECONDS_PER_SLOT=2",
+        // Allow voluntary exists to be valid immediately
+        "--params.SHARD_COMMITTEE_PERIOD=0",
+        // Enable keymanager API
+        "--keymanager",
+        `--keymanager.port=${keymanagerPort}`,
+        // Disable bearer token auth to simplify testing
+        "--keymanager.authEnabled=false",
+      ],
+      {pipeStdioToParent: false, logPrefix: "dev"}
+    );
+
+    // Exit early if process exits
+    devProc.on("exit", (code) => {
+      if (code !== null && code > 0) {
+        throw new Error(`devProc process exited with code ${code}`);
+      }
+    });
+
+    beaconClient = getClient(
+      {baseUrl: `http://127.0.0.1:${beaconPort}`, getAbortSignal: () => httpClientController.signal},
+      {config}
+    ).beacon;
+
+    keymanagerClient = getKeymanagerClient(
+      {baseUrl: `http://127.0.0.1:${keymanagerPort}`, getAbortSignal: () => httpClientController.signal},
+      {config}
+    );
+
+    // Wait for beacon node API to be available + genesis
+    await retry(
+      async () => {
+        const head = await beaconClient.getBlockHeader("head");
+        ApiError.assert(head);
+        if (head.response.data.header.message.slot < 1) throw Error("pre-genesis");
+      },
+      {retryDelay: 1000, retries: 20}
+    );
+  });
+
+  after(async () => {
+    // Disconnect the event stream for the client
+    httpClientController.abort();
+    devProc.removeAllListeners("exit");
+    await gracefullyStopChildProcess(devProc, 3000);
+  });
+
+  const exitEpoch = 0;
+  const indexToExit = 0;
+  const pubkeyToExit = interopSecretKey(indexToExit).toPublicKey().toHex();
+
+  let signedVoluntaryExit: phase0.SignedVoluntaryExit;
+
+  it("1. create signed voluntary exit message from keymanager", async () => {
+    const res = await keymanagerClient.signVoluntaryExit(pubkeyToExit, exitEpoch);
+    ApiError.assert(res);
+    signedVoluntaryExit = res.response.data;
+
+    expect(signedVoluntaryExit.message.epoch).to.equal(exitEpoch);
+    expect(signedVoluntaryExit.message.validatorIndex).to.equal(indexToExit);
+    // Signature will be verified when submitting to beacon node
+    expect(signedVoluntaryExit.signature).to.not.be.undefined;
+  });
+
+  it("2. submit signed voluntary exit message to beacon node", async () => {
+    ApiError.assert(await beaconClient.submitPoolVoluntaryExit(signedVoluntaryExit));
+  });
+
+  it("3. confirm validator status is 'active_exiting'", async () => {
+    await retry(
+      async () => {
+        const res = await beaconClient.getStateValidator("head", pubkeyToExit);
+        ApiError.assert(res);
+        if (res.response.data.status !== "active_exiting") {
+          throw Error("Validator not exiting");
+        } else {
+          // eslint-disable-next-line no-console
+          console.log(`Confirmed validator ${pubkeyToExit} = ${res.response.data.status}`);
+        }
+      },
+      {retryDelay: 1000, retries: 20}
+    );
+  });
+});


### PR DESCRIPTION
**Motivation**

https://github.com/ethereum/keymanager-APIs/pull/58

**Description**

Add keymanager API to create signed voluntary exit message

Closes https://github.com/ChainSafe/lodestar/issues/5888