### PR TITLE
fix: improve jsonRPC error UX for eth1 + execution 

### DIFF
--- a/packages/beacon-node/src/chain/initState.ts
+++ b/packages/beacon-node/src/chain/initState.ts
@@ -87,7 +87,7 @@ export async function initStateFromEth1({
 
   const builder = new GenesisBuilder({
     config,
-    eth1Provider: new Eth1Provider(config, opts, signal),
+    eth1Provider: new Eth1Provider(config, {...opts, logger}, signal),
     logger,
     signal,
     pendingStatus:

--- a/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
@@ -164,7 +164,6 @@ export class Eth1DepositDataTracker {
 
     while (!this.signal.aborted) {
       lastRunMs = Date.now();
-      const oldState = this.eth1Provider.getState();
 
       try {
         const hasCaughtUp = await this.update();

--- a/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
@@ -176,17 +176,16 @@ export class Eth1DepositDataTracker {
           await sleep(sleepTimeMs, this.signal);
         }
       } catch (e) {
+        this.metrics?.eth1.depositTrackerUpdateErrors.inc(1);
+
         // From Infura: 429 Too Many Requests
         if (e instanceof HttpRpcError && e.status === 429) {
           this.logger.debug("Eth1 provider rate limited", {}, e);
           await sleep(RATE_LIMITED_WAIT_MS, this.signal);
           // only log error if state switched from online to some other state
         } else if (!isErrorAborted(e) && this.eth1Provider.getState() !== oldState) {
-          this.logger.error("Error updating eth1 chain cache", {}, e as Error);
           await sleep(MIN_WAIT_ON_ERROR_MS, this.signal);
         }
-
-        this.metrics?.eth1.depositTrackerUpdateErrors.inc(1);
       }
     }
   }

--- a/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
@@ -183,7 +183,7 @@ export class Eth1DepositDataTracker {
           this.logger.debug("Eth1 provider rate limited", {}, e);
           await sleep(RATE_LIMITED_WAIT_MS, this.signal);
           // only log error if state switched from online to some other state
-        } else if (!isErrorAborted(e) && this.eth1Provider.getState() !== oldState) {
+        } else if (!isErrorAborted(e)) {
           await sleep(MIN_WAIT_ON_ERROR_MS, this.signal);
         }
       }

--- a/packages/beacon-node/src/eth1/index.ts
+++ b/packages/beacon-node/src/eth1/index.ts
@@ -67,7 +67,13 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
     modules: Eth1DepositDataTrackerModules & Eth1MergeBlockTrackerModules & {eth1Provider?: IEth1Provider}
   ) {
     const eth1Provider =
-      modules.eth1Provider || new Eth1Provider(modules.config, opts, modules.signal, modules.metrics?.eth1HttpClient);
+      modules.eth1Provider ||
+      new Eth1Provider(
+        modules.config,
+        {...opts, logger: modules.logger},
+        modules.signal,
+        modules.metrics?.eth1HttpClient
+      );
 
     this.eth1DepositDataTracker = opts.disableEth1DepositDataTracker
       ? null

--- a/packages/beacon-node/src/eth1/interface.ts
+++ b/packages/beacon-node/src/eth1/interface.ts
@@ -29,6 +29,14 @@ export interface IEth1Provider {
   getBlocksByNumber(fromBlock: number, toBlock: number): Promise<EthJsonRpcBlockRaw[]>;
   getDepositEvents(fromBlock: number, toBlock: number): Promise<phase0.DepositEvent[]>;
   validateContract(): Promise<void>;
+  getState(): Eth1ProviderState;
+}
+
+export enum Eth1ProviderState {
+  ONLINE = "ONLINE",
+  OFFLINE = "OFFLINE",
+  ERROR = "ERROR",
+  AUTH_FAILED = "AUTH_FAILED",
 }
 
 export type Eth1DataAndDeposits = {

--- a/packages/beacon-node/src/eth1/provider/eth1Provider.ts
+++ b/packages/beacon-node/src/eth1/provider/eth1Provider.ts
@@ -1,7 +1,7 @@
 import {toHexString} from "@chainsafe/ssz";
 import {phase0} from "@lodestar/types";
 import {ChainConfig} from "@lodestar/config";
-import {fromHex, isErrorAborted, waitForElapsedTime} from "@lodestar/utils";
+import {fromHex, isErrorAborted, createElapsedTimeTracker} from "@lodestar/utils";
 import {Logger} from "@lodestar/logger";
 
 import {FetchError, isFetchError} from "@lodestar/api";
@@ -52,7 +52,7 @@ const getBlockByHashOpts: ReqOpts = {routeId: "getBlockByHash"};
 const getBlockNumberOpts: ReqOpts = {routeId: "getBlockNumber"};
 const getLogsOpts: ReqOpts = {routeId: "getLogs"};
 
-const isOneMinutePassed = waitForElapsedTime({minElapsedTime: 60_000});
+const isOneMinutePassed = createElapsedTimeTracker({minElapsedTime: 60_000});
 
 export class Eth1Provider implements IEth1Provider {
   readonly deployBlock: number;

--- a/packages/beacon-node/src/eth1/provider/eth1Provider.ts
+++ b/packages/beacon-node/src/eth1/provider/eth1Provider.ts
@@ -60,11 +60,11 @@ export class Eth1Provider implements IEth1Provider {
   private readonly rpc: JsonRpcHttpClient;
   // The default state is ONLINE, it will be updated to offline if we receive a http error
   private state: Eth1ProviderState = Eth1ProviderState.ONLINE;
-  private logger: Logger;
+  private logger?: Logger;
 
   constructor(
     config: Pick<ChainConfig, "DEPOSIT_CONTRACT_ADDRESS">,
-    opts: Pick<Eth1Options, "depositContractDeployBlock" | "providerUrls" | "jwtSecretHex"> & {logger: Logger},
+    opts: Pick<Eth1Options, "depositContractDeployBlock" | "providerUrls" | "jwtSecretHex"> & {logger?: Logger},
     signal?: AbortSignal,
     metrics?: JsonRpcHttpClientMetrics | null
   ) {
@@ -84,7 +84,7 @@ export class Eth1Provider implements IEth1Provider {
       this.state = Eth1ProviderState.ONLINE;
 
       if (oldState !== Eth1ProviderState.ONLINE) {
-        this.logger.info("Eth1Provider is back online", {oldState, newState: this.state});
+        this.logger?.info("Eth1Provider is back online", {oldState, newState: this.state});
       }
     });
 
@@ -101,7 +101,7 @@ export class Eth1Provider implements IEth1Provider {
 
       if (this.state !== Eth1ProviderState.ONLINE) {
         ifOneMinutePassed(({msSinceLastCall, now}) => {
-          this.logger.error(
+          this.logger?.error(
             "Eth1Provider faced error",
             {
               state: this.state,

--- a/packages/beacon-node/src/eth1/provider/eth1Provider.ts
+++ b/packages/beacon-node/src/eth1/provider/eth1Provider.ts
@@ -52,7 +52,7 @@ const getBlockByHashOpts: ReqOpts = {routeId: "getBlockByHash"};
 const getBlockNumberOpts: ReqOpts = {routeId: "getBlockNumber"};
 const getLogsOpts: ReqOpts = {routeId: "getLogs"};
 
-const ifOneMinutePassed = waitForElapsedTime({minElapsedTime: 60_000});
+const isOneMinutePassed = waitForElapsedTime({minElapsedTime: 60_000});
 
 export class Eth1Provider implements IEth1Provider {
   readonly deployBlock: number;
@@ -100,16 +100,16 @@ export class Eth1Provider implements IEth1Provider {
       }
 
       if (this.state !== Eth1ProviderState.ONLINE) {
-        ifOneMinutePassed(({msSinceLastCall, now}) => {
+        if (isOneMinutePassed()) {
           this.logger?.error(
             "Eth1Provider faced error",
             {
               state: this.state,
-              lastErrorAt: msSinceLastCall !== undefined ? new Date(now - msSinceLastCall).toLocaleTimeString() : "N/A",
+              lastErrorAt: new Date(Date.now() - isOneMinutePassed.msSinceLastCall).toLocaleTimeString(),
             },
             error
           );
-        });
+        }
       }
     });
   }

--- a/packages/beacon-node/src/eth1/provider/jsonRpcHttpClient.ts
+++ b/packages/beacon-node/src/eth1/provider/jsonRpcHttpClient.ts
@@ -6,7 +6,7 @@ import {IGauge, IHistogram} from "../../metrics/interface.js";
 import {IJson, RpcPayload} from "../interface.js";
 import {encodeJwtToken} from "./jwt.js";
 
-export const enum JsonRpcHttpClientEvent {
+export enum JsonRpcHttpClientEvent {
   /**
    * When registered this event will be emitted before the client throws an error.
    * This is useful for defining the error behavior in a common place at the time of declaration of the client.

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -5,13 +5,13 @@ import {
   ErrorJsonRpcResponse,
   HttpRpcError,
   IJsonRpcHttpClient,
+  JsonRpcHttpClientEvent,
   ReqOpts,
 } from "../../eth1/provider/jsonRpcHttpClient.js";
 import {Metrics} from "../../metrics/index.js";
 import {JobItemQueue} from "../../util/queue/index.js";
 import {EPOCHS_PER_BATCH} from "../../sync/constants.js";
 import {numToQuantity} from "../../eth1/provider/utils.js";
-import {IJson, RpcPayload} from "../../eth1/interface.js";
 import {
   ExecutionPayloadStatus,
   ExecutePayloadResponse,
@@ -110,7 +110,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   private readonly rpcFetchQueue: JobItemQueue<[EngineRequest], EngineResponse>;
 
   private jobQueueProcessor = async ({method, params, methodOpts}: EngineRequest): Promise<EngineResponse> => {
-    return this.fetchWithRetries<EngineApiRpcReturnTypes[typeof method], EngineApiRpcParamTypes[typeof method]>(
+    return this.rpc.fetchWithRetries<EngineApiRpcReturnTypes[typeof method], EngineApiRpcParamTypes[typeof method]>(
       {method, params},
       methodOpts
     );
@@ -126,22 +126,14 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       metrics?.engineHttpProcessorQueue
     );
     this.logger = logger;
-  }
 
-  protected async fetchWithRetries<R, P = IJson[]>(payload: RpcPayload<P>, opts?: ReqOpts): Promise<R> {
-    try {
-      const res = await this.rpc.fetchWithRetries<R, P>(payload, opts);
+    this.rpc.emitter.on(JsonRpcHttpClientEvent.ERROR, ({error}) => {
+      this.updateEngineState(getExecutionEngineState({payloadError: error, oldState: this.state}));
+    });
+
+    this.rpc.emitter.on(JsonRpcHttpClientEvent.RESPONSE, () => {
       this.updateEngineState(getExecutionEngineState({targetState: ExecutionEngineState.ONLINE, oldState: this.state}));
-      return res;
-    } catch (err) {
-      this.updateEngineState(getExecutionEngineState({payloadError: err, oldState: this.state}));
-
-      /*
-       * TODO: For some error cases as abort, we may not want to escalate the error to the caller
-       * But for now the higher level code handles such cases so we can just rethrow the error
-       */
-      throw err;
-    }
+    });
   }
 
   /**
@@ -370,7 +362,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         : ForkSeq[fork] >= ForkSeq.capella
         ? "engine_getPayloadV2"
         : "engine_getPayloadV1";
-    const payloadResponse = await this.fetchWithRetries<
+    const payloadResponse = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
     >(
@@ -390,7 +382,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   async getPayloadBodiesByHash(blockHashes: RootHex[]): Promise<(ExecutionPayloadBody | null)[]> {
     const method = "engine_getPayloadBodiesByHashV1";
     assertReqSizeLimit(blockHashes.length, 32);
-    const response = await this.fetchWithRetries<
+    const response = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
     >({method, params: [blockHashes]});
@@ -405,7 +397,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     assertReqSizeLimit(blockCount, 32);
     const start = numToQuantity(startBlockNumber);
     const count = numToQuantity(blockCount);
-    const response = await this.fetchWithRetries<
+    const response = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
     >({method, params: [start, count]});

--- a/packages/beacon-node/test/unit/chain/bls/bls.test.ts
+++ b/packages/beacon-node/test/unit/chain/bls/bls.test.ts
@@ -4,7 +4,7 @@ import {CoordType} from "@chainsafe/blst";
 import {PublicKey} from "@chainsafe/bls/types";
 import {ISignatureSet, SignatureSetType} from "@lodestar/state-transition";
 import {BlsSingleThreadVerifier} from "../../../../src/chain/bls/singleThread.js";
-import {BlsMultiThreadWorkerPool} from "../../../../lib/chain/bls/multithread/index.js";
+import {BlsMultiThreadWorkerPool} from "../../../../src/chain/bls/multithread/index.js";
 import {testLogger} from "../../../utils/logger.js";
 
 describe("BlsVerifier ", function () {

--- a/packages/beacon-node/test/unit/chain/genesis/genesis.test.ts
+++ b/packages/beacon-node/test/unit/chain/genesis/genesis.test.ts
@@ -10,7 +10,7 @@ import {ErrorAborted} from "@lodestar/utils";
 import {GenesisBuilder} from "../../../../src/chain/genesis/genesis.js";
 import {testLogger} from "../../../utils/logger.js";
 import {ZERO_HASH_HEX} from "../../../../src/constants/index.js";
-import {EthJsonRpcBlockRaw, IEth1Provider} from "../../../../src/eth1/interface.js";
+import {Eth1ProviderState, EthJsonRpcBlockRaw, IEth1Provider} from "../../../../src/eth1/interface.js";
 
 describe("genesis builder", function () {
   const logger = testLogger();
@@ -62,6 +62,7 @@ describe("genesis builder", function () {
       validateContract: async () => {
         return;
       },
+      getState: () => Eth1ProviderState.ONLINE,
       ...eth1Provider,
     };
   }

--- a/packages/beacon-node/test/unit/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/beacon-node/test/unit/eth1/eth1MergeBlockTracker.test.ts
@@ -5,7 +5,7 @@ import {sleep} from "@lodestar/utils";
 import {IEth1Provider} from "../../../src/index.js";
 import {ZERO_HASH} from "../../../src/constants/index.js";
 import {Eth1MergeBlockTracker, StatusCode, toPowBlock} from "../../../src/eth1/eth1MergeBlockTracker.js";
-import {EthJsonRpcBlockRaw} from "../../../src/eth1/interface.js";
+import {Eth1ProviderState, EthJsonRpcBlockRaw} from "../../../src/eth1/interface.js";
 import {testLogger} from "../../utils/logger.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -57,6 +57,7 @@ describe("eth1 / Eth1MergeBlockTracker", () => {
       validateContract: async (): Promise<any> => {
         throw Error("Not implemented");
       },
+      getState: () => Eth1ProviderState.ONLINE,
     };
 
     const eth1MergeBlockTracker = new Eth1MergeBlockTracker(
@@ -133,6 +134,7 @@ describe("eth1 / Eth1MergeBlockTracker", () => {
       validateContract: async (): Promise<any> => {
         throw Error("Not implemented");
       },
+      getState: () => Eth1ProviderState.ONLINE,
     };
 
     await runFindMergeBlockTest(eth1Provider, blocks[blocks.length - 1]);
@@ -216,6 +218,7 @@ describe("eth1 / Eth1MergeBlockTracker", () => {
       validateContract: async (): Promise<any> => {
         throw Error("Not implemented");
       },
+      getState: () => Eth1ProviderState.ONLINE,
     };
   }
 

--- a/packages/utils/src/waitFor.ts
+++ b/packages/utils/src/waitFor.ts
@@ -63,7 +63,7 @@ export interface ElapsedTimeTracker {
  * @param durationMs
  * @returns
  */
-export function waitForElapsedTime({minElapsedTime}: {minElapsedTime: number}): ElapsedTimeTracker {
+export function createElapsedTimeTracker({minElapsedTime}: {minElapsedTime: number}): ElapsedTimeTracker {
   // Initialized with undefined as the function has not been called yet
   let lastTimeCalled: number | undefined = undefined;
 

--- a/packages/utils/test/unit/waitFor.test.ts
+++ b/packages/utils/test/unit/waitFor.test.ts
@@ -1,6 +1,5 @@
 import "../setup.js";
 import {expect} from "chai";
-import sinon from "sinon";
 import {waitFor, waitForElapsedTime} from "../../src/waitFor.js";
 import {ErrorAborted, TimeoutError} from "../../src/errors.js";
 import {sleep} from "../../src/sleep.js";
@@ -39,54 +38,27 @@ describe("waitFor", () => {
 });
 
 describe("waitForElapsedTime", () => {
-  it("should call the function for the first time", () => {
+  it("should true for the first time", () => {
     const callIfTimePassed = waitForElapsedTime({minElapsedTime: 1000});
-    const fn = sinon.spy();
-    callIfTimePassed(fn);
 
-    expect(fn).to.have.been.calledOnce;
+    expect(callIfTimePassed()).to.be.true;
   });
 
-  it("should call the function after the minElapsedTime has passed", async () => {
+  it("should return true after the minElapsedTime has passed", async () => {
     const callIfTimePassed = waitForElapsedTime({minElapsedTime: 100});
-    const fn = sinon.spy();
-    callIfTimePassed(fn);
+    callIfTimePassed();
 
     await sleep(150);
-    callIfTimePassed(fn);
 
-    expect(fn).to.have.been.calledTwice;
+    expect(callIfTimePassed()).to.be.true;
   });
 
-  it("should not call the function before the minElapsedTime has passed", () => {
+  it("should return false before the minElapsedTime has passed", async () => {
     const callIfTimePassed = waitForElapsedTime({minElapsedTime: 100});
-    const fn = sinon.spy();
-    callIfTimePassed(fn);
-    callIfTimePassed(fn);
+    callIfTimePassed();
 
-    expect(fn).to.have.been.calledOnce;
-  });
+    await sleep(10);
 
-  it("should call the onError if the function is called before the minElapsedTime has passed", () => {
-    const fn = sinon.spy();
-    const err = sinon.spy();
-    const callIfTimePassed = waitForElapsedTime({minElapsedTime: 100, onError: err});
-    callIfTimePassed(fn);
-    callIfTimePassed(fn);
-
-    expect(err).to.have.been.calledOnce;
-  });
-
-  it("should not call the onError if the function is called after the minElapsedTime has passed", async () => {
-    const fn = sinon.spy();
-    const err = sinon.spy();
-    const callIfTimePassed = waitForElapsedTime({minElapsedTime: 100, onError: err});
-    callIfTimePassed(fn);
-
-    await sleep(100);
-
-    callIfTimePassed(fn);
-
-    expect(err).to.have.been.callCount(0);
+    expect(callIfTimePassed()).to.be.false;
   });
 });

--- a/packages/utils/test/unit/waitFor.test.ts
+++ b/packages/utils/test/unit/waitFor.test.ts
@@ -1,6 +1,6 @@
 import "../setup.js";
 import {expect} from "chai";
-import {waitFor, waitForElapsedTime} from "../../src/waitFor.js";
+import {waitFor, createElapsedTimeTracker} from "../../src/waitFor.js";
 import {ErrorAborted, TimeoutError} from "../../src/errors.js";
 import {sleep} from "../../src/sleep.js";
 
@@ -39,13 +39,13 @@ describe("waitFor", () => {
 
 describe("waitForElapsedTime", () => {
   it("should true for the first time", () => {
-    const callIfTimePassed = waitForElapsedTime({minElapsedTime: 1000});
+    const callIfTimePassed = createElapsedTimeTracker({minElapsedTime: 1000});
 
     expect(callIfTimePassed()).to.be.true;
   });
 
   it("should return true after the minElapsedTime has passed", async () => {
-    const callIfTimePassed = waitForElapsedTime({minElapsedTime: 100});
+    const callIfTimePassed = createElapsedTimeTracker({minElapsedTime: 100});
     callIfTimePassed();
 
     await sleep(150);
@@ -54,7 +54,7 @@ describe("waitForElapsedTime", () => {
   });
 
   it("should return false before the minElapsedTime has passed", async () => {
-    const callIfTimePassed = waitForElapsedTime({minElapsedTime: 100});
+    const callIfTimePassed = createElapsedTimeTracker({minElapsedTime: 100});
     callIfTimePassed();
 
     await sleep(10);


### PR DESCRIPTION
**Motivation**

Manage the state transition for the eth1 provider to log the errors with right context.

**Description**

- Refactor the JSONRPCClient to allow events
- Updated the Execution Engine to use the events of rpc client
- Used the same pattern for the Eth1Provider as well

Closes #4348

**Steps to test or reproduce**

- Run all tests