### PR TITLE
fix: ignore lockfiles when loading keys for voluntary exit

### DIFF
--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -76,6 +76,9 @@ If no `pubkeys` are provided, it will exit all validators that have been importe
     // Set exitEpoch to current epoch if unspecified
     const exitEpoch = args.exitEpoch ?? computeEpochAtSlot(getCurrentSlot(config, genesisTime));
 
+    // Ignore lockfiles to allow exiting while validator client is running
+    args.force = true;
+
     // Select signers to exit
     const signers = await getSignersFromArgs(args, network, {logger: console, signal: new AbortController().signal});
     if (signers.length === 0) {


### PR DESCRIPTION
**Motivation**

The voluntary exit command needs to load the keystore in order to sign the message. If this command is executed on the same keystore used by the currently running validator client it will fail due to existing lockfiles. There is a workaround to pass `--force` flag but this seems unnecessary as there is no reason to use lockfiles for the voluntary exit command.

**Description**

Ignore lockfiles when loading keys for voluntary exit
