### PR TITLE
feat: Introduce EIP-6110 epoch and version in `ChainConfig`

### DIFF
--- a/packages/config/src/chainConfig/json.ts
+++ b/packages/config/src/chainConfig/json.ts
@@ -8,8 +8,9 @@ export function chainConfigToJson(config: ChainConfig): Record<string, string> {
 
   for (const key of Object.keys(chainConfigTypes) as (keyof ChainConfig)[]) {
     const value = config[key];
-    if (value !== undefined) {
-      json[key] = serializeSpecValue(value, chainConfigTypes[key]);
+    const targetType = chainConfigTypes[key];
+    if (value !== undefined && targetType) {
+      json[key] = serializeSpecValue(value, targetType);
     }
   }
 
@@ -21,8 +22,9 @@ export function chainConfigFromJson(json: Record<string, unknown>): ChainConfig 
 
   for (const key of Object.keys(chainConfigTypes) as (keyof ChainConfig)[]) {
     const value = json[key];
-    if (value !== undefined) {
-      config[key] = deserializeSpecValue(json[key], chainConfigTypes[key], key) as never;
+    const targetType = chainConfigTypes[key];
+    if (value !== undefined && targetType) {
+      config[key] = deserializeSpecValue(json[key], targetType, key) as never;
     }
   }
 

--- a/packages/config/src/chainConfig/types.ts
+++ b/packages/config/src/chainConfig/types.ts
@@ -40,6 +40,9 @@ export type ChainConfig = {
   // DENEB
   DENEB_FORK_VERSION: Uint8Array;
   DENEB_FORK_EPOCH: number;
+  // EIP6110 - Experimental fork
+  EIP6110_FORK_VERSION?: Uint8Array,
+  EIP6110_FORK_EPOCH?: number,
 
   // Time parameters
   SECONDS_PER_SLOT: number;
@@ -92,6 +95,9 @@ export const chainConfigTypes: SpecTypes<ChainConfig> = {
   // DENEB
   DENEB_FORK_VERSION: "bytes",
   DENEB_FORK_EPOCH: "number",
+  // EIP6110
+  EIP6110_FORK_VERSION: "bytes",
+  EIP6110_FORK_EPOCH: "number",
 
   // Time parameters
   SECONDS_PER_SLOT: "number",

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -73,6 +73,7 @@ function getSpecCriticalParams(localConfig: ChainConfig): Record<keyof ConfigWit
   const bellatrixForkRelevant = localConfig.BELLATRIX_FORK_EPOCH < Infinity;
   const capellaForkRelevant = localConfig.CAPELLA_FORK_EPOCH < Infinity;
   const denebForkRelevant = localConfig.DENEB_FORK_EPOCH < Infinity;
+  const eip6110ForkRelevant = (localConfig.EIP6110_FORK_EPOCH ?? Infinity) < Infinity;
 
   return {
     // # Config
@@ -105,6 +106,9 @@ function getSpecCriticalParams(localConfig: ChainConfig): Record<keyof ConfigWit
     // Deneb
     DENEB_FORK_VERSION: denebForkRelevant,
     DENEB_FORK_EPOCH: denebForkRelevant,
+    // EIP6110
+    EIP6110_FORK_VERSION: eip6110ForkRelevant,
+    EIP6110_FORK_EPOCH: eip6110ForkRelevant,
 
     // Time parameters
     SECONDS_PER_SLOT: true,


### PR DESCRIPTION
**Motivation**

<!-- Why is this PR exists? What are the goals of the pull request? -->
This is part of the effort to implement #5366 . 
Original intention was to implement changes to pubkey cache on unstable branch, and the actual EIP-6110 implementation on a separate branch. However, there is a need to have a fork gate on pubkey cache mentioned here https://github.com/ChainSafe/lodestar/pull/5937#discussion_r1316008264 and thus, there is a need to define the EIP-6110 fork in unstable branch. 

This PR is to make as minimal change as possible to define EIP-6110 fork such that the development of fork gate on pubkey cache can continue.

**Description**

* Introduce optional fields `EIP6110_FORK_VERSION` and `EIP6110_FORK_EPOCH` in `ChainConfig`. 
* Handles optional fields during (de)serialization of `ChainConfig`.

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
