### PR TITLE
feat: add metric for slot of next scheduled attestation duty

### DIFF
--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -207,6 +207,9 @@ export function getMetrics(register: MetricsRegister, gitData: LodestarGitData) 
     }),
 
     attesterDutiesNextSlot: register.gauge({
+      // Metric is used by Rocket Pool dashboard (18391) to determine seconds until next attestation.
+      // It works without requiring any modification to the dashboard as the metric name is the
+      // same as Lighthouse uses for this.
       name: "vc_attestation_duty_slot",
       help: "Slot of next scheduled attestation duty",
     }),

--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -206,6 +206,11 @@ export function getMetrics(register: MetricsRegister, gitData: LodestarGitData) 
       help: "Total count of instances the attester duties dependant root changed",
     }),
 
+    attesterDutiesNextSlot: register.gauge({
+      name: "vc_attestation_duty_slot",
+      help: "Slot of next scheduled attestation duty",
+    }),
+
     // BlockProposingService
 
     blocksProduced: register.gauge({

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -72,6 +72,13 @@ export class AttestationDutiesService {
           // Historical epochs can be skipped when determining next duty slot
           if (epoch < this.clock.currentEpoch) continue;
 
+          // There is no need to check every single duty at a certain amount
+          // of validators, next duty slot will almost always be the next slot
+          if (attDutiesAtEpoch.dutiesByIndex.size >= 64) {
+            nextDutySlot = currentSlot + 1;
+            continue;
+          }
+
           for (const {duty} of attDutiesAtEpoch.dutiesByIndex.values()) {
             // Set next duty slot to the closest future slot found in all duties
             if (duty.slot > currentSlot && (nextDutySlot === null || duty.slot < nextDutySlot)) {

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -66,7 +66,7 @@ export class AttestationDutiesService {
         const currentSlot = this.clock.getCurrentSlot();
         let duties = 0;
         let nextDutySlot = null;
-        for (const [epoch, attDutiesAtEpoch] of this.dutiesByIndexByEpoch.entries()) {
+        for (const [epoch, attDutiesAtEpoch] of this.dutiesByIndexByEpoch) {
           duties += attDutiesAtEpoch.dutiesByIndex.size;
 
           // Historical epochs can be skipped when determining next duty slot

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -69,8 +69,8 @@ export class AttestationDutiesService {
         for (const [epoch, attDutiesAtEpoch] of this.dutiesByIndexByEpoch) {
           duties += attDutiesAtEpoch.dutiesByIndex.size;
 
-          // Historical epochs can be skipped when determining next duty slot
-          if (epoch < this.clock.currentEpoch) continue;
+          // Epochs are sorted, stop searching once a next duty slot is found
+          if (epoch < this.clock.currentEpoch || nextDutySlot !== null) continue;
 
           for (const {duty} of attDutiesAtEpoch.dutiesByIndex.values()) {
             // Set next duty slot to the closest future slot found in all duties

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -72,13 +72,6 @@ export class AttestationDutiesService {
           // Historical epochs can be skipped when determining next duty slot
           if (epoch < this.clock.currentEpoch) continue;
 
-          // There is no need to check every single duty at a certain amount
-          // of validators, next duty slot will almost always be the next slot
-          if (attDutiesAtEpoch.dutiesByIndex.size >= 64) {
-            nextDutySlot = currentSlot + 1;
-            continue;
-          }
-
           for (const {duty} of attDutiesAtEpoch.dutiesByIndex.values()) {
             // Set next duty slot to the closest future slot found in all duties
             if (duty.slot > currentSlot && (nextDutySlot === null || duty.slot < nextDutySlot)) {


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5477

**Description**

Adds metric to track slot of next scheduled attestation duty. Works with [Rocket Pool Dashboard v1.3.0](https://grafana.com/grafana/dashboards/18391-rocket-pool-dashboard-v1-3-0/) without requiring any modification to the dashboard as the metric name is the same as Lighthouse uses for this.
