### PR TITLE
feat: always --force for voluntary exit

### DIFF
--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -77,6 +77,7 @@ If no `pubkeys` are provided, it will exit all validators that have been importe
     const exitEpoch = args.exitEpoch ?? computeEpochAtSlot(getCurrentSlot(config, genesisTime));
 
     // Select signers to exit
+    args.force = true;
     const signers = await getSignersFromArgs(args, network, {logger: console, signal: new AbortController().signal});
     if (signers.length === 0) {
       throw new YargsError(`No local keystores found with current args.


### PR DESCRIPTION
**Motivation**

When Lodestar is running, the voluntary exit command should function even when the user doesn't manually specify `--force`

**Description**

Set `args.force = true` regardless of user setting, only when running the voluntary exit command

See https://discord.com/channels/694822223575384095/694822223575384099/1151039470955667476
