### PR TITLE
chore: update to ssz 0.13.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@chainsafe/persistent-merkle-tree": "^0.5.0",
-    "@chainsafe/ssz": "^0.12.0",
+    "@chainsafe/ssz": "^0.13.0",
     "@lodestar/config": "^1.11.1",
     "@lodestar/params": "^1.11.1",
     "@lodestar/types": "^1.11.1",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -104,7 +104,7 @@
     "@chainsafe/libp2p-noise": "^13.0.0",
     "@chainsafe/persistent-merkle-tree": "^0.5.0",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
-    "@chainsafe/ssz": "^0.12.0",
+    "@chainsafe/ssz": "^0.13.0",
     "@chainsafe/threads": "^1.11.1",
     "@ethersproject/abi": "^5.7.0",
     "@fastify/bearer-auth": "^9.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,7 +59,7 @@
     "@chainsafe/bls-keystore": "^2.0.0",
     "@chainsafe/blst": "^0.2.9",
     "@chainsafe/discv5": "^5.1.0",
-    "@chainsafe/ssz": "^0.12.0",
+    "@chainsafe/ssz": "^0.13.0",
     "@chainsafe/threads": "^1.11.1",
     "@libp2p/crypto": "^2.0.2",
     "@libp2p/peer-id": "^3.0.1",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -64,7 +64,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/ssz": "^0.12.0",
+    "@chainsafe/ssz": "^0.13.0",
     "@lodestar/params": "^1.11.1",
     "@lodestar/types": "^1.11.1"
   }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -37,7 +37,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^0.12.0",
+    "@chainsafe/ssz": "^0.13.0",
     "@lodestar/config": "^1.11.1",
     "@lodestar/utils": "^1.11.1",
     "@types/levelup": "^4.3.3",

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -38,7 +38,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^0.12.0",
+    "@chainsafe/ssz": "^0.13.0",
     "@lodestar/config": "^1.11.1",
     "@lodestar/params": "^1.11.1",
     "@lodestar/state-transition": "^1.11.1",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/persistent-merkle-tree": "^0.5.0",
-    "@chainsafe/ssz": "^0.12.0",
+    "@chainsafe/ssz": "^0.13.0",
     "@lodestar/api": "^1.11.1",
     "@lodestar/config": "^1.11.1",
     "@lodestar/params": "^1.11.1",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -61,7 +61,7 @@
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/persistent-merkle-tree": "^0.5.0",
     "@chainsafe/persistent-ts": "^0.19.1",
-    "@chainsafe/ssz": "^0.12.0",
+    "@chainsafe/ssz": "^0.13.0",
     "@lodestar/config": "^1.11.1",
     "@lodestar/params": "^1.11.1",
     "@lodestar/types": "^1.11.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -67,7 +67,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/ssz": "^0.12.0",
+    "@chainsafe/ssz": "^0.13.0",
     "@lodestar/params": "^1.11.1"
   },
   "keywords": [

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@chainsafe/bls": "7.1.1",
-    "@chainsafe/ssz": "^0.12.0",
+    "@chainsafe/ssz": "^0.13.0",
     "@lodestar/api": "^1.11.1",
     "@lodestar/config": "^1.11.1",
     "@lodestar/db": "^1.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -644,10 +644,10 @@
     "@chainsafe/as-sha256" "^0.4.1"
     "@chainsafe/persistent-merkle-tree" "^0.6.1"
 
-"@chainsafe/ssz@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.12.0.tgz#60dbbd855d2d39d3bc032f44d18a094c364501ae"
-  integrity sha512-FZUvB7NsQBQc+/3+QSCaqHjKMAXs+M4NiFsskOcRVm1G2FN19u/Er+783YeIpX8Ld9mLplvn2qv33vQedcul0w==
+"@chainsafe/ssz@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.13.0.tgz#0bd11af6abe023d4cc24067a46889dcabbe573e5"
+  integrity sha512-73PF5bFXE9juLD1+dkmYV/CMO/5ip0TmyzgYw87vAn8Cn+CbwCOp/HyNNdYCmdl104a2bqcORFJzirCvvc+nNw==
   dependencies:
     "@chainsafe/as-sha256" "^0.4.1"
     "@chainsafe/persistent-merkle-tree" "^0.6.1"


### PR DESCRIPTION
**Motivation**

- migrate to ssz 0.13.0

**Description**

- use deserializeUint8ArrayBitListFromBytes util from @chainsafe/ssz
