### PR TITLE
fix: make the network listener more stable

### DIFF
--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -81,7 +81,11 @@ export async function createNodeJsLibp2p(
         backlog: 5,
         closeServerOnMaxConnections: {
           closeAbove: networkOpts.maxPeers ?? Infinity,
-          listenBelow: networkOpts.maxPeers ?? Infinity,
+          // To stop and start listening based on a fixed number of connections
+          // would make it brittle to the order in which connections are established.
+          // Instead, we stop listening when the number of connections is below the target peers
+          // given that target peers and max peers have a reasonable gap between them.
+          listenBelow: networkOpts.targetPeers ?? -Infinity,
         },
       }),
     ],

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -84,7 +84,8 @@ export async function createNodeJsLibp2p(
           // To stop and start listening based on a fixed number of connections
           // would make it brittle to the order in which connections are established.
           // Instead, we stop listening when the number of connections is below the target peers
-          // given that target peers and max peers have a reasonable gap between them.
+          // given that target peers and max peers have a reasonable gap between them and
+          // target peers are always less than the max peers
           listenBelow: networkOpts.targetPeers ?? -Infinity,
         },
       }),


### PR DESCRIPTION
**Motivation**

Make the network listener more stable. 

**Description**

- When network listener stops it should have a room to start again 
- With current configuration, it trigger start/stop based on one value which makes it brittle and can raise some edge cases. 

**Steps to test or reproduce**

Run all tests. 