### PR TITLE
fix: update holesky genesis time

### DIFF
--- a/packages/config/src/networks.ts
+++ b/packages/config/src/networks.ts
@@ -55,7 +55,7 @@ export const genesisData: Record<NetworkName, GenesisData> = {
     genesisValidatorsRoot: "0xd8ea171f3c94aea21ebc42a1ed61052acf3f9209c00e4efbaaddac09ed9b8078",
   },
   holesky: {
-    genesisTime: 1694786400,
+    genesisTime: 1695902400,
     genesisValidatorsRoot: "0x9143aa7c615a7f7115e2b6aac319c03529df8242ae705fba9df39b79c59fa8b1",
   },
   chiado: {


### PR DESCRIPTION
**Motivation**

Forgot to update the genesis time in previous PR 
- https://github.com/ChainSafe/lodestar/pull/5971

**Description**

Update holesky genesis time, the genesis validators root is unchanged as per https://github.com/eth-clients/holesky/pull/73#discussion_r1329315909