### PR TITLE
feat: always try to fetch optimistic update when starting lc

### DIFF
--- a/packages/light-client/src/index.ts
+++ b/packages/light-client/src/index.ts
@@ -244,20 +244,20 @@ export class Lightclient {
         }
       }
 
-      // Fetch latest optimistic head to prevent a potential 12 seconds lag between syncing and getting the first head,
-      // Don't retry, this is a non-critical UX improvement
-      try {
-        const update = await this.transport.getOptimisticUpdate();
-        this.processOptimisticUpdate(update.data);
-      } catch (e) {
-        this.logger.error("Error fetching getLatestHeadUpdate", {currentPeriod}, e as Error);
-      }
-
       // After successfully syncing, track head if not already
       if (this.runStatus.code !== RunStatusCode.started) {
         const controller = new AbortController();
         this.updateRunStatus({code: RunStatusCode.started, controller});
         this.logger.debug("Started tracking the head");
+
+        // Fetch latest optimistic head to prevent a potential 12 seconds lag between syncing and getting the first head,
+        // Don't retry, this is a non-critical UX improvement
+        try {
+          const update = await this.transport.getOptimisticUpdate();
+          this.processOptimisticUpdate(update.data);
+        } catch (e) {
+          this.logger.error("Error fetching getLatestHeadUpdate", {currentPeriod}, e as Error);
+        }
 
         this.transport.onOptimisticUpdate(this.processOptimisticUpdate.bind(this));
         this.transport.onFinalityUpdate(this.processFinalizedUpdate.bind(this));

--- a/packages/light-client/src/index.ts
+++ b/packages/light-client/src/index.ts
@@ -242,15 +242,15 @@ export class Lightclient {
           await new Promise((r) => setTimeout(r, ON_ERROR_RETRY_MS));
           continue;
         }
+      }
 
-        // Fetch latest optimistic head to prevent a potential 12 seconds lag between syncing and getting the first head,
-        // Don't retry, this is a non-critical UX improvement
-        try {
-          const update = await this.transport.getOptimisticUpdate();
-          this.processOptimisticUpdate(update.data);
-        } catch (e) {
-          this.logger.error("Error fetching getLatestHeadUpdate", {currentPeriod}, e as Error);
-        }
+      // Fetch latest optimistic head to prevent a potential 12 seconds lag between syncing and getting the first head,
+      // Don't retry, this is a non-critical UX improvement
+      try {
+        const update = await this.transport.getOptimisticUpdate();
+        this.processOptimisticUpdate(update.data);
+      } catch (e) {
+        this.logger.error("Error fetching getLatestHeadUpdate", {currentPeriod}, e as Error);
       }
 
       // After successfully syncing, track head if not already


### PR DESCRIPTION
**Motivation**

UX improvement

**Description**

Currently fetching an optimistic update at client start happens only if a sync is needed.  The proposed change tries to fetch an optimistic update even if no sync is needed, e.g. the client was initialized with a recent checkpoint
