### PR TITLE
fix: correctly persist states based on archive epoch frequency

### DIFF
--- a/packages/beacon-node/src/chain/archiver/archiveStates.ts
+++ b/packages/beacon-node/src/chain/archiver/archiveStates.ts
@@ -49,7 +49,7 @@ export class StatesArchiver {
     const lastStoredEpoch = computeEpochAtSlot(lastStoredSlot ?? 0);
     const {archiveStateEpochFrequency} = this.opts;
 
-    if (finalized.epoch - lastStoredEpoch > Math.min(PERSIST_TEMP_STATE_EVERY_EPOCHS, archiveStateEpochFrequency)) {
+    if (finalized.epoch - lastStoredEpoch >= Math.min(PERSIST_TEMP_STATE_EVERY_EPOCHS, archiveStateEpochFrequency)) {
       await this.archiveState(finalized);
 
       // Only check the current and previous intervals


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5976

**Description**

Setting `--chain.archiveStateEpochFrequency 1` should persist a state every epoch and not prune any previously stored states. This allows to download finalized states (https://github.com/ChainSafe/lodestar/issues/5846) by providing the start slot of the epoch (`epoch * SLOTS_PER_EPOCH`).

```
Sep-21 16:32:00.667[chain]         verbose: Archived state completed finalizedEpoch=205203, minEpoch=205202, storedStateSlots=6566464, statesSlotsToDelete=
Sep-21 16:38:24.702[chain]         verbose: Archived state completed finalizedEpoch=205204, minEpoch=205203, storedStateSlots=6566496, statesSlotsToDelete=
Sep-21 16:44:48.615[chain]         verbose: Archived state completed finalizedEpoch=205205, minEpoch=205204, storedStateSlots=6566528, statesSlotsToDelete=
Sep-21 16:51:12.671[chain]         verbose: Archived state completed finalizedEpoch=205206, minEpoch=205205, storedStateSlots=6566560, statesSlotsToDelete=
Sep-21 16:57:36.735[chain]         verbose: Archived state completed finalizedEpoch=205207, minEpoch=205206, storedStateSlots=6566592, statesSlotsToDelete=
Sep-21 17:04:00.898[chain]         verbose: Archived state completed finalizedEpoch=205208, minEpoch=205207, storedStateSlots=6566624, statesSlotsToDelete=
Sep-21 17:10:24.685[chain]         verbose: Archived state completed finalizedEpoch=205209, minEpoch=205208, storedStateSlots=6566656, statesSlotsToDelete=
Sep-21 17:16:48.791[chain]         verbose: Archived state completed finalizedEpoch=205210, minEpoch=205209, storedStateSlots=6566688, statesSlotsToDelete=
Sep-21 17:23:12.714[chain]         verbose: Archived state completed finalizedEpoch=205211, minEpoch=205210, storedStateSlots=6566720, statesSlotsToDelete=
```
