### PR TITLE
feat: add logs for builder validator registrations

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -845,6 +845,7 @@ export function getValidatorApi({
       await chain.executionBuilder.registerValidator(filteredRegistrations);
 
       logger.debug("Forwarded validator registrations to connected builder", {
+        epoch: currentEpoch,
         count: filteredRegistrations.length,
       });
     },

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -816,6 +816,10 @@ export function getValidatorApi({
     },
 
     async registerValidator(registrations) {
+      if (!chain.executionBuilder) {
+        throw Error("Execution builder not enabled");
+      }
+
       // should only send active or pending validator to builder
       // Spec: https://ethereum.github.io/builder-specs/#/Builder/registerValidator
       const headState = chain.getHeadState();
@@ -838,12 +842,11 @@ export function getValidatorApi({
         );
       });
 
-      if (chain.executionBuilder) {
-        await chain.executionBuilder.registerValidator(filteredRegistrations);
-        logger.debug("Submitted validator registrations to builder", {
-          count: filteredRegistrations.length,
-        });
-      }
+      await chain.executionBuilder.registerValidator(filteredRegistrations);
+
+      logger.debug("Submitted validator registrations to builder", {
+        count: filteredRegistrations.length,
+      });
     },
   };
 }

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -844,7 +844,7 @@ export function getValidatorApi({
 
       await chain.executionBuilder.registerValidator(filteredRegistrations);
 
-      logger.debug("Submitted validator registrations to builder", {
+      logger.debug("Forwarded validator registrations to connected builder", {
         count: filteredRegistrations.length,
       });
     },

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -838,7 +838,12 @@ export function getValidatorApi({
         );
       });
 
-      return chain.executionBuilder?.registerValidator(filteredRegistrations);
+      if (chain.executionBuilder) {
+        await chain.executionBuilder.registerValidator(filteredRegistrations);
+        logger.debug("Submitted validator registrations to builder", {
+          count: filteredRegistrations.length,
+        });
+      }
     },
   };
 }

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -84,7 +84,10 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
   }
 
   async registerValidator(registrations: bellatrix.SignedValidatorRegistrationV1[]): Promise<void> {
-    ApiError.assert(await this.api.registerValidator(registrations));
+    ApiError.assert(
+      await this.api.registerValidator(registrations),
+      "Failed to submit validator registrations to builder"
+    );
   }
 
   async getHeader(

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -86,7 +86,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
   async registerValidator(registrations: bellatrix.SignedValidatorRegistrationV1[]): Promise<void> {
     ApiError.assert(
       await this.api.registerValidator(registrations),
-      "Failed to submit validator registrations to builder"
+      "Failed to forward validator registrations to connected builder"
     );
   }
 

--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -106,9 +106,9 @@ export function pollBuilderValidatorRegistration(
             })
           );
           ApiError.assert(await api.validator.registerValidator(registrations));
-          logger.info("Published validator registrations to builder", {epoch, count: registrations.length});
+          logger.info("Published validator registrations to the builder network", {epoch, count: registrations.length});
         } catch (e) {
-          logger.error("Failed to publish validator registrations to builder", {epoch}, e as Error);
+          logger.error("Failed to publish validator registrations to the builder network", {epoch}, e as Error);
         }
       }
     }

--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -106,9 +106,9 @@ export function pollBuilderValidatorRegistration(
             })
           );
           ApiError.assert(await api.validator.registerValidator(registrations));
-          logger.info("Published validator registrations to the builder network", {epoch, count: registrations.length});
+          logger.info("Published validator registrations to builder network", {epoch, count: registrations.length});
         } catch (e) {
-          logger.error("Failed to publish validator registrations to the builder network", {epoch}, e as Error);
+          logger.error("Failed to publish validator registrations to builder network", {epoch}, e as Error);
         }
       }
     }

--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -106,8 +106,9 @@ export function pollBuilderValidatorRegistration(
             })
           );
           ApiError.assert(await api.validator.registerValidator(registrations));
+          logger.info("Published validator registrations to builder", {epoch, count: registrations.length});
         } catch (e) {
-          logger.error("Failed to register validator registrations with builder", {epoch}, e as Error);
+          logger.error("Failed to publish validator registrations to builder", {epoch}, e as Error);
         }
       }
     }


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5337

**Description**

Adds logs for builder validator registrations. Especially on the validator client this should be logged to info as it helps to detect issues like https://github.com/rocket-pool/smartnode-install/pull/105 earlier. On the beacon node side, I opted to keep it as debug for now and only log errors.

**Note:** For users that want more visibility on the beacon node, it is possible to set `--logLevelModule="api=debug"` flag. This will print out the debug log `Forwarded validator registrations ...` to stdout instead of just the log file.

**What are other clients doing?**

- Nimbus
   - vc : no log
   - bn: no log
- Lighthouse
   - vc: `INFO Published validator registrations to the builder network, count: 10, service: preparation`
   - bn: `INFO Forwarding register validator request to connected builder, count: 9`
- Teku
   - vc: `INFO  - Validator   *** 10 out of 10 validator registration(s) were successfully sent to the builder network via the Beacon Node.`
   - bn: no log
- Prysm
   - vc: `level=info msg="Submitted builder validator registration settings for custom builders" prefix=validator`
   - bn: no log





