### PR TITLE
fix: only concatenate non-empty api error messages

### DIFF
--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -41,7 +41,11 @@ export class ApiError extends Error {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static assert(res: ApiClientResponse, message?: string): asserts res is ApiClientSuccessResponse<any, unknown> {
     if (!res.ok) {
-      throw new ApiError([message, res.error.message].join(" - "), res.error.code, res.error.operationId);
+      throw new ApiError(
+        [message, res.error.message].filter(Boolean).join(" - "),
+        res.error.code,
+        res.error.operationId
+      );
     }
   }
 


### PR DESCRIPTION
**Motivation**

There are a lot of places in the code where `ApiError.assert` is called without a `message`
https://github.com/ChainSafe/lodestar/blob/9618dd1a36caafd929d1e3874d1a2c8a55614290/packages/beacon-node/src/execution/builder/http.ts#L87

This results in error like this
```
Sep-23 07:57:14.074[rest]            error: Req req-3yww registerValidator error   - Bad Gateway: no successful relay response
Error:  - Bad Gateway: no successful relay response
```
```
Sep-23 08:03:39.210[]                error: Error publishing attestations slot=xxxxx  - Internal Server Error: PublishError.InsufficientPeers
Error:  - Internal Server Error: PublishError.InsufficientPeers
```

The error messages start with `  -  `

**Description**

Only concatenate non-empty api error messages by filtering out `undefined` and empty strings `""`

@nazarhussain is this intended behavior? I kinda see that it could make sense as separator if the error message itself is concatenated with another message from a log, e.g. `this.logger.error("Error publishing attestations", {}, e);` but if we wanted a separator for those messages, it should be handled by the logger.