### PR TITLE
fix: remove duplicate validator registration calls

### DIFF
--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -45,17 +45,14 @@ export function pollPrepareBeaconProposer(
           })
         );
         ApiError.assert(await api.validator.prepareBeaconProposer(proposers));
+        logger.debug("Registered proposers with beacon node", {epoch, count: proposers.length});
       } catch (e) {
-        logger.error("Failed to register proposers with beacon", {epoch}, e as Error);
+        logger.error("Failed to register proposers with beacon node", {epoch}, e as Error);
       }
     }
   }
 
   clock.runEveryEpoch(prepareBeaconProposer);
-  // Since the registration of the validators to the BN as well as to builder (if enabled)
-  // is scheduled every epoch, there could be some time since the first scheduled run,
-  // so fire one registration right away as well
-  void prepareBeaconProposer(clock.getCurrentEpoch());
 }
 
 /**
@@ -81,7 +78,7 @@ export function pollBuilderValidatorRegistration(
     // registerValidator is not as time sensitive as attesting.
     // Poll indices first, then call api.validator.registerValidator once
     await validatorStore.pollValidatorIndices().catch((e: Error) => {
-      logger.error("Error on pollValidatorIndices for prepareBeaconProposer", {epoch}, e);
+      logger.error("Error on pollValidatorIndices for registerValidator", {epoch}, e);
     });
     const pubkeyHexes = validatorStore
       .getAllLocalIndices()
@@ -103,17 +100,13 @@ export function pollBuilderValidatorRegistration(
             })
           );
           ApiError.assert(await api.validator.registerValidator(registrations));
-          logger.info("Published validator registrations to builder network", {epoch, count: registrations.length});
+          logger.info("Published validator registrations to builder", {epoch, count: registrations.length});
         } catch (e) {
-          logger.error("Failed to publish validator registrations to builder network", {epoch}, e as Error);
+          logger.error("Failed to publish validator registrations to builder", {epoch}, e as Error);
         }
       }
     }
   }
 
   clock.runEveryEpoch(registerValidator);
-  // Since the registration of the validators to the BN as well as to builder (if enabled)
-  // is scheduled every epoch, there could be some time since the first scheduled run,
-  // so fire one registration right away as well
-  void registerValidator(clock.getCurrentEpoch());
 }


### PR DESCRIPTION
**Motivation**

Validator registration calls with beacon node / builder should only be done once at startup.

**Description**

Removed duplicate validator registration calls. 

The function call queued up in `runEveryEpoch` runs immediately on first time, it is not required to explicitly call the function.
https://github.com/ChainSafe/lodestar/blob/f5e2c3a40c9a01a29a4283d9f17a901ede413068/packages/validator/src/util/clock.ts#L91-L98

Startup logs
```
Sep-24 11:11:03.258[]                 info: Published validator registrations to builder network epoch=205848, count=10
Sep-24 11:11:03.302[]                 info: Published validator registrations to builder network epoch=205848, count=10
```

@g11tech I noticed this was brought up in the inital PR https://github.com/ChainSafe/lodestar/pull/3969#discussion_r899155938, the comment in code does not seem to be accurate but might be worth to double check.
