### PR TITLE
fix: run sync notifier once every slot pre-genesis

### DIFF
--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -148,7 +148,12 @@ function timeToNextHalfSlot(config: BeaconConfig, chain: IBeaconChain, isFirstTi
   const msPerSlot = config.SECONDS_PER_SLOT * 1000;
   const msPerHalfSlot = msPerSlot / 2;
   const msFromGenesis = Date.now() - chain.genesisTime * 1000;
-  const msToNextSlot = msPerSlot - (msFromGenesis % msPerSlot);
+  const msToNextSlot =
+    msFromGenesis < 0
+      ? // For future genesis time, calculate time left in the slot
+        -msFromGenesis % msPerSlot
+      : // For past genesis time, calculate time until the next slot
+        msPerSlot - (msFromGenesis % msPerSlot);
   if (isFirstTime) {
     // at the 1st time we may miss middle of the current clock slot
     return msToNextSlot > msPerHalfSlot ? msToNextSlot - msPerHalfSlot : msToNextSlot + msPerHalfSlot;


### PR DESCRIPTION
**Motivation**

Sync notifier is not working as expected pre-genesis, it logs only every other slot
```
Sep-26 20:55:30.000[]                 info: Synced - slot: -12323 - head: 0xab09…f889 - finalized: 0x0000…0000:0 - peers: 30
Sep-26 20:55:54.001[]                 info: Synced - slot: -12321 - head: 0xab09…f889 - finalized: 0x0000…0000:0 - peers: 30
Sep-26 20:56:18.000[]                 info: Synced - slot: -12319 - head: 0xab09…f889 - finalized: 0x0000…0000:0 - peers: 30
Sep-26 20:56:42.001[]                 info: Synced - slot: -12317 - head: 0xab09…f889 - finalized: 0x0000…0000:0 - peers: 31
Sep-26 20:57:05.999[]                 info: Synced - slot: -12315 - head: 0xab09…f889 - finalized: 0x0000…0000:0 - peers: 31
```

**Description**

Run sync notifier once every slot pre-genesis
- For future genesis time, calculate time left in the slot
- For past genesis time, calculate time until the next slot
```
Sep-26 21:58:30.001[]                 info: Synced - slot: -12008 - head: 0xab09…f889 - finalized: 0x0000…0000:0 - peers: 1
Sep-26 21:58:42.001[]                 info: Synced - slot: -12007 - head: 0xab09…f889 - finalized: 0x0000…0000:0 - peers: 2
Sep-26 21:58:54.001[]                 info: Synced - slot: -12006 - head: 0xab09…f889 - finalized: 0x0000…0000:0 - peers: 2
Sep-26 21:59:06.000[]                 info: Synced - slot: -12005 - head: 0xab09…f889 - finalized: 0x0000…0000:0 - peers: 2
Sep-26 21:59:18.002[]                 info: Synced - slot: -12004 - head: 0xab09…f889 - finalized: 0x0000…0000:0 - peers: 2
```
