### PR TITLE
fix: fix the validation of the forkchoice spec test

### DIFF
--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -180,7 +180,7 @@ const forkChoiceTest =
                 });
                 if (!isValid) throw Error("Expect error since this is a negative test");
               } catch (e) {
-                if (isValid) throw e;
+                if (isValid || (e as Error).message === "Expect error since this is a negative test") throw e;
               }
             }
 


### PR DESCRIPTION
for the negative forkchoice tests (testing invalid cases), the tests pass even if they don't throw error because in the final catch the `Expect error since this is a negative test` gets ignored.

this PR fixes the ignore. 

(this is needed in new version of spec tests but a separate PR is done to see if any old spec tests are being wrongly validated and need fixing)