### PR TITLE
refactor: compute validator monitor log level only once

### DIFF
--- a/packages/beacon-node/src/metrics/validatorMonitor.ts
+++ b/packages/beacon-node/src/metrics/validatorMonitor.ts
@@ -248,8 +248,8 @@ export function createValidatorMonitor(
   logger: Logger,
   opts: ValidatorMonitorOpts
 ): ValidatorMonitor {
+  const logLevel = opts.validatorMonitorLogs ? LogLevel.info : LogLevel.debug;
   const log: LogHandler = (message: string, context?: LogData) => {
-    const logLevel = opts.validatorMonitorLogs ? LogLevel.info : LogLevel.debug;
     logger[logLevel](message, context);
   };
 


### PR DESCRIPTION
**Motivation**

Minor optimization but might be worth it as validator monitor logs are done quite frequently if there are a lot of attached validators.

**Description**

Move log level computation outside of log function, there's no need to run this on every log call as the value never changes.
