### PR TITLE
feat: restart aware doppelganger protection

### DIFF
--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -17,3 +17,13 @@ export function prettyBytesShort(root: Uint8Array | string): string {
   const str = typeof root === "string" ? root : toHexString(root);
   return `${str.slice(0, 6)}…`;
 }
+
+/**
+ * Truncate and format bytes as `0x123456789abc`
+ * 6 bytes is sufficient to avoid collisions and it allows to easily look up
+ * values on explorers like beaconcha.in while improving readability of logs
+ */
+export function truncBytes(root: Uint8Array | string): string {
+  const str = typeof root === "string" ? root : toHexString(root);
+  return str.slice(0, 14);
+}

--- a/packages/validator/src/services/doppelgangerService.ts
+++ b/packages/validator/src/services/doppelgangerService.ts
@@ -67,21 +67,26 @@ export class DoppelgangerService {
 
     // Log here to alert that validation won't be active until remainingEpochs == 0
     if (remainingEpochs > 0) {
-      const prevEpoch = currentEpoch - 1;
+      const previousEpoch = currentEpoch - 1;
       const attestedInPreviousEpoch = await this.slashingProtection.hasAttestedInEpoch(
         fromHexString(pubkeyHex),
-        prevEpoch
+        previousEpoch
       );
 
       if (attestedInPreviousEpoch) {
         remainingEpochs = REMAINING_EPOCHS_IF_SKIPPED;
-        this.logger.info("Previous epoch attestation in slashing protection db, doppelganger detection skipped", {
-          prevEpoch,
+        this.logger.info("Doppelganger detection skipped, previous epoch attestation exists in database", {
+          previousEpoch,
           pubkeyHex,
         });
       } else {
         this.logger.info("Registered validator for doppelganger", {remainingEpochs, nextEpochToCheck, pubkeyHex});
       }
+    } else {
+      this.logger.info("Doppelganger detection skipped, validator initialized before genesis", {
+        currentEpoch,
+        pubkeyHex,
+      });
     }
 
     this.doppelgangerStateByPubkey.set(pubkeyHex, {

--- a/packages/validator/src/services/doppelgangerService.ts
+++ b/packages/validator/src/services/doppelgangerService.ts
@@ -75,22 +75,19 @@ export class DoppelgangerService {
 
       if (attestedInPreviousEpoch) {
         remainingEpochs = REMAINING_EPOCHS_IF_SKIPPED;
-        this.logger.info(
-          "Doppelganger detection skipped for validator, previous epoch attestation exists in database",
-          {
-            pubkey: prettyBytes(pubkeyHex),
-            previousEpoch,
-          }
-        );
+        this.logger.info("Doppelganger detection skipped, attestation from previous epoch exists in database", {
+          pubkey: prettyBytes(pubkeyHex),
+          previousEpoch,
+        });
       } else {
-        this.logger.info("Registered validator for doppelganger", {
+        this.logger.info("Registered validator for doppelganger detection", {
           pubkey: prettyBytes(pubkeyHex),
           remainingEpochs,
           nextEpochToCheck,
         });
       }
     } else {
-      this.logger.info("Doppelganger detection skipped for validator, initialized before genesis", {
+      this.logger.info("Doppelganger detection skipped, validator initialized before genesis", {
         pubkey: prettyBytes(pubkeyHex),
         currentEpoch,
       });

--- a/packages/validator/src/services/doppelgangerService.ts
+++ b/packages/validator/src/services/doppelgangerService.ts
@@ -27,13 +27,13 @@ export type DoppelgangerState = {
 };
 
 export enum DoppelgangerStatus {
-  // This pubkey is known to the doppelganger service and has been verified safe
+  /** This pubkey is known to the doppelganger service and has been verified safe */
   VerifiedSafe = "VerifiedSafe",
-  // This pubkey is known to the doppelganger service but has not been verified safe
+  /** This pubkey is known to the doppelganger service but has not been verified safe */
   Unverified = "Unverified",
-  // This pubkey is unknown to the doppelganger service
+  /** This pubkey is unknown to the doppelganger service */
   Unknown = "Unknown",
-  // This pubkey has been detected to be active on the network
+  /** This pubkey has been detected to be active on the network */
   DoppelgangerDetected = "DoppelgangerDetected",
 }
 

--- a/packages/validator/src/services/doppelgangerService.ts
+++ b/packages/validator/src/services/doppelgangerService.ts
@@ -77,7 +77,7 @@ export class DoppelgangerService {
         // It is safe to skip doppelganger detection
         // https://github.com/ChainSafe/lodestar/issues/5856
         remainingEpochs = REMAINING_EPOCHS_IF_SKIPPED;
-        this.logger.info("Doppelganger detection skipped, attestation from previous epoch exists in database", {
+        this.logger.info("Doppelganger detection skipped for validator because restart was detected", {
           pubkey: truncBytes(pubkeyHex),
           previousEpoch,
         });
@@ -89,7 +89,7 @@ export class DoppelgangerService {
         });
       }
     } else {
-      this.logger.info("Doppelganger detection skipped, validator initialized before genesis", {
+      this.logger.info("Doppelganger detection skipped for validator initialized before genesis", {
         pubkey: truncBytes(pubkeyHex),
         currentEpoch,
       });

--- a/packages/validator/src/services/doppelgangerService.ts
+++ b/packages/validator/src/services/doppelgangerService.ts
@@ -12,7 +12,7 @@ import {IndicesService} from "./indices.js";
 // The number of epochs that must be checked before we assume that there are
 // no other duplicate validators on the network
 const DEFAULT_REMAINING_DETECTION_EPOCHS = 1;
-const REMAINING_EPOCHS_IF_DOPPLEGANGER = Infinity;
+const REMAINING_EPOCHS_IF_DOPPELGANGER = Infinity;
 const REMAINING_EPOCHS_IF_SKIPPED = 0;
 
 /** Liveness responses for a given epoch */
@@ -198,7 +198,7 @@ export class DoppelgangerService {
         }
 
         if (state.nextEpochToCheck <= epoch) {
-          // Doppleganger detected
+          // Doppelganger detected
           violators.push(response.index);
         }
       }
@@ -207,7 +207,7 @@ export class DoppelgangerService {
     if (violators.length > 0) {
       // If a single doppelganger is detected, enable doppelganger checks on all validators forever
       for (const state of this.doppelgangerStateByPubkey.values()) {
-        state.remainingEpochs = REMAINING_EPOCHS_IF_DOPPLEGANGER;
+        state.remainingEpochs = REMAINING_EPOCHS_IF_DOPPELGANGER;
       }
 
       this.logger.error(
@@ -271,7 +271,7 @@ function getStatus(state: DoppelgangerState | undefined): DoppelgangerStatus {
     return DoppelgangerStatus.Unknown;
   } else if (state.remainingEpochs <= 0) {
     return DoppelgangerStatus.VerifiedSafe;
-  } else if (state.remainingEpochs === REMAINING_EPOCHS_IF_DOPPLEGANGER) {
+  } else if (state.remainingEpochs === REMAINING_EPOCHS_IF_DOPPELGANGER) {
     return DoppelgangerStatus.DoppelgangerDetected;
   } else {
     return DoppelgangerStatus.Unverified;

--- a/packages/validator/src/services/doppelgangerService.ts
+++ b/packages/validator/src/services/doppelgangerService.ts
@@ -1,7 +1,7 @@
 import {fromHexString} from "@chainsafe/ssz";
 import {Epoch, ValidatorIndex} from "@lodestar/types";
 import {Api, ApiError, routes} from "@lodestar/api";
-import {Logger, sleep} from "@lodestar/utils";
+import {Logger, prettyBytes, sleep} from "@lodestar/utils";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {ISlashingProtection} from "../slashingProtection/index.js";
 import {ProcessShutdownCallback, PubkeyHex} from "../types.js";
@@ -77,15 +77,19 @@ export class DoppelgangerService {
         remainingEpochs = REMAINING_EPOCHS_IF_SKIPPED;
         this.logger.info("Doppelganger detection skipped, previous epoch attestation exists in database", {
           previousEpoch,
-          pubkeyHex,
+          pubkey: prettyBytes(pubkeyHex),
         });
       } else {
-        this.logger.info("Registered validator for doppelganger", {remainingEpochs, nextEpochToCheck, pubkeyHex});
+        this.logger.info("Registered validator for doppelganger", {
+          remainingEpochs,
+          nextEpochToCheck,
+          pubkey: prettyBytes(pubkeyHex),
+        });
       }
     } else {
       this.logger.info("Doppelganger detection skipped, validator initialized before genesis", {
         currentEpoch,
-        pubkeyHex,
+        pubkey: prettyBytes(pubkeyHex),
       });
     }
 

--- a/packages/validator/src/services/doppelgangerService.ts
+++ b/packages/validator/src/services/doppelgangerService.ts
@@ -75,21 +75,24 @@ export class DoppelgangerService {
 
       if (attestedInPreviousEpoch) {
         remainingEpochs = REMAINING_EPOCHS_IF_SKIPPED;
-        this.logger.info("Doppelganger detection skipped, previous epoch attestation exists in database", {
-          previousEpoch,
-          pubkey: prettyBytes(pubkeyHex),
-        });
+        this.logger.info(
+          "Doppelganger detection skipped for validator, previous epoch attestation exists in database",
+          {
+            pubkey: prettyBytes(pubkeyHex),
+            previousEpoch,
+          }
+        );
       } else {
         this.logger.info("Registered validator for doppelganger", {
+          pubkey: prettyBytes(pubkeyHex),
           remainingEpochs,
           nextEpochToCheck,
-          pubkey: prettyBytes(pubkeyHex),
         });
       }
     } else {
-      this.logger.info("Doppelganger detection skipped, validator initialized before genesis", {
-        currentEpoch,
+      this.logger.info("Doppelganger detection skipped for validator, initialized before genesis", {
         pubkey: prettyBytes(pubkeyHex),
+        currentEpoch,
       });
     }
 
@@ -254,7 +257,7 @@ export class DoppelgangerService {
           if (remainingEpochs <= 0) {
             this.logger.info("Doppelganger detection complete", {index: response.index, epoch: currentEpoch});
           } else {
-            this.logger.info("Found no doppelganger", {remainingEpochs, nextEpochToCheck, index: response.index});
+            this.logger.info("Found no doppelganger", {index: response.index, remainingEpochs, nextEpochToCheck});
           }
         }
       }

--- a/packages/validator/src/services/doppelgangerService.ts
+++ b/packages/validator/src/services/doppelgangerService.ts
@@ -1,7 +1,7 @@
 import {fromHexString} from "@chainsafe/ssz";
 import {Epoch, ValidatorIndex} from "@lodestar/types";
 import {Api, ApiError, routes} from "@lodestar/api";
-import {Logger, prettyBytes, sleep} from "@lodestar/utils";
+import {Logger, sleep, truncBytes} from "@lodestar/utils";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {ISlashingProtection} from "../slashingProtection/index.js";
 import {ProcessShutdownCallback, PubkeyHex} from "../types.js";
@@ -76,19 +76,19 @@ export class DoppelgangerService {
       if (attestedInPreviousEpoch) {
         remainingEpochs = REMAINING_EPOCHS_IF_SKIPPED;
         this.logger.info("Doppelganger detection skipped, attestation from previous epoch exists in database", {
-          pubkey: prettyBytes(pubkeyHex),
+          pubkey: truncBytes(pubkeyHex),
           previousEpoch,
         });
       } else {
         this.logger.info("Registered validator for doppelganger detection", {
-          pubkey: prettyBytes(pubkeyHex),
+          pubkey: truncBytes(pubkeyHex),
           remainingEpochs,
           nextEpochToCheck,
         });
       }
     } else {
       this.logger.info("Doppelganger detection skipped, validator initialized before genesis", {
-        pubkey: prettyBytes(pubkeyHex),
+        pubkey: truncBytes(pubkeyHex),
         currentEpoch,
       });
     }

--- a/packages/validator/src/services/doppelgangerService.ts
+++ b/packages/validator/src/services/doppelgangerService.ts
@@ -74,6 +74,8 @@ export class DoppelgangerService {
       );
 
       if (attestedInPreviousEpoch) {
+        // It is safe to skip doppelganger detection
+        // https://github.com/ChainSafe/lodestar/issues/5856
         remainingEpochs = REMAINING_EPOCHS_IF_SKIPPED;
         this.logger.info("Doppelganger detection skipped, attestation from previous epoch exists in database", {
           pubkey: truncBytes(pubkeyHex),

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -282,18 +282,18 @@ export class ValidatorStore {
     return proposerConfig;
   }
 
-  addSigner(signer: Signer, valProposerConfig?: ValidatorProposerConfig): void {
+  async addSigner(signer: Signer, valProposerConfig?: ValidatorProposerConfig): Promise<void> {
     const pubkey = getSignerPubkeyHex(signer);
     const proposerConfig = (valProposerConfig?.proposerConfig ?? {})[pubkey];
 
     if (!this.validators.has(pubkey)) {
+      await this.doppelgangerService?.registerValidator(pubkey);
+
       this.pubkeysToDiscover.push(pubkey);
       this.validators.set(pubkey, {
         signer,
         ...proposerConfig,
       });
-
-      this.doppelgangerService?.registerValidator(pubkey);
     }
   }
 

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -310,6 +310,7 @@ export class ValidatorStore {
     const proposerConfig = (valProposerConfig?.proposerConfig ?? {})[pubkey];
 
     if (!this.validators.has(pubkey)) {
+      // Doppelganger registration must be done before adding validator to signers
       await this.doppelgangerService?.registerValidator(pubkey);
 
       this.pubkeysToDiscover.push(pubkey);

--- a/packages/validator/src/slashingProtection/attestation/index.ts
+++ b/packages/validator/src/slashingProtection/attestation/index.ts
@@ -1,4 +1,4 @@
-import {BLSPubkey} from "@lodestar/types";
+import {BLSPubkey, Epoch} from "@lodestar/types";
 import {isEqualNonZeroRoot, minEpoch} from "../utils.js";
 import {MinMaxSurround, SurroundAttestationError, SurroundAttestationErrorCode} from "../minMaxSurround/index.js";
 import {SlashingProtectionAttestation} from "../types.js";
@@ -131,6 +131,13 @@ export class SlashingProtectionAttestationService {
   async insertAttestation(pubKey: BLSPubkey, attestation: SlashingProtectionAttestation): Promise<void> {
     await this.attestationByTarget.set(pubKey, [attestation]);
     await this.minMaxSurround.insertAttestation(pubKey, attestation);
+  }
+
+  /**
+   * Retrieve an attestation from the slashing protection database for a given `pubkey` and `epoch`
+   */
+  async getAttestationForEpoch(pubkey: BLSPubkey, epoch: Epoch): Promise<SlashingProtectionAttestation | null> {
+    return this.attestationByTarget.get(pubkey, epoch);
   }
 
   /**

--- a/packages/validator/src/slashingProtection/index.ts
+++ b/packages/validator/src/slashingProtection/index.ts
@@ -1,5 +1,5 @@
 import {toHexString} from "@chainsafe/ssz";
-import {BLSPubkey, Root} from "@lodestar/types";
+import {BLSPubkey, Epoch, Root} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {LodestarValidatorDatabaseController} from "../types.js";
 import {uniqueVectorArr} from "../slashingProtection/utils.js";
@@ -54,6 +54,10 @@ export class SlashingProtection implements ISlashingProtection {
 
   async checkAndInsertAttestation(pubKey: BLSPubkey, attestation: SlashingProtectionAttestation): Promise<void> {
     await this.attestationService.checkAndInsertAttestation(pubKey, attestation);
+  }
+
+  async hasAttestedInEpoch(pubKey: BLSPubkey, epoch: Epoch): Promise<boolean> {
+    return (await this.attestationService.getAttestationForEpoch(pubKey, epoch)) !== null;
   }
 
   async importInterchange(interchange: Interchange, genesisValidatorsRoot: Root, logger?: Logger): Promise<void> {

--- a/packages/validator/src/slashingProtection/interface.ts
+++ b/packages/validator/src/slashingProtection/interface.ts
@@ -1,4 +1,4 @@
-import {BLSPubkey, Root} from "@lodestar/types";
+import {BLSPubkey, Epoch, Root} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Interchange, InterchangeFormatVersion} from "./interchange/types.js";
 import {SlashingProtectionBlock, SlashingProtectionAttestation} from "./types.js";
@@ -12,6 +12,11 @@ export interface ISlashingProtection {
    * Check an attestation for slash safety, and if it is safe, record it in the database
    */
   checkAndInsertAttestation(pubKey: BLSPubkey, attestation: SlashingProtectionAttestation): Promise<void>;
+
+  /**
+   * Check whether a validator as identified by `pubKey` has attested in the specified `epoch`
+   */
+  hasAttestedInEpoch(pubKey: BLSPubkey, epoch: Epoch): Promise<boolean>;
 
   importInterchange(interchange: Interchange, genesisValidatorsRoot: Uint8Array | Root, logger?: Logger): Promise<void>;
   exportInterchange(

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -98,7 +98,15 @@ export class Validator {
 
     const indicesService = new IndicesService(logger, api, metrics);
     const doppelgangerService = opts.doppelgangerProtection
-      ? new DoppelgangerService(logger, clock, api, indicesService, opts.processShutdownCallback, metrics)
+      ? new DoppelgangerService(
+          logger,
+          clock,
+          api,
+          indicesService,
+          slashingProtection,
+          opts.processShutdownCallback,
+          metrics
+        )
       : null;
 
     const validatorStore = new ValidatorStore(

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -22,6 +22,24 @@ import {BeaconHealth, Metrics} from "./metrics.js";
 import {MetaDataRepository} from "./repositories/metaDataRepository.js";
 import {DoppelgangerService} from "./services/doppelgangerService.js";
 
+export type ValidatorModules = {
+  opts: ValidatorOptions;
+  genesis: Genesis;
+  validatorStore: ValidatorStore;
+  slashingProtection: ISlashingProtection;
+  blockProposingService: BlockProposingService;
+  attestationService: AttestationService;
+  syncCommitteeService: SyncCommitteeService;
+  config: BeaconConfig;
+  api: Api;
+  clock: IClock;
+  chainHeaderTracker: ChainHeaderTracker;
+  logger: Logger;
+  db: LodestarValidatorDatabaseController;
+  metrics: Metrics | null;
+  controller: AbortController;
+};
+
 export type ValidatorOptions = {
   slashingProtection: ISlashingProtection;
   db: LodestarValidatorDatabaseController;
@@ -53,6 +71,7 @@ enum Status {
  * Main class for the Validator client.
  */
 export class Validator {
+  private readonly genesis: Genesis;
   readonly validatorStore: ValidatorStore;
   private readonly slashingProtection: ISlashingProtection;
   private readonly blockProposingService: BlockProposingService;
@@ -67,14 +86,69 @@ export class Validator {
   private state: Status;
   private readonly controller: AbortController;
 
-  constructor(
-    opts: ValidatorOptions,
-    readonly genesis: Genesis,
-    metrics: Metrics | null = null
-  ) {
+  constructor({
+    opts,
+    genesis,
+    validatorStore,
+    slashingProtection,
+    blockProposingService,
+    attestationService,
+    syncCommitteeService,
+    config,
+    api,
+    clock,
+    chainHeaderTracker,
+    logger,
+    db,
+    metrics,
+    controller,
+  }: ValidatorModules) {
+    this.genesis = genesis;
+    this.validatorStore = validatorStore;
+    this.slashingProtection = slashingProtection;
+    this.blockProposingService = blockProposingService;
+    this.attestationService = attestationService;
+    this.syncCommitteeService = syncCommitteeService;
+    this.config = config;
+    this.api = api;
+    this.clock = clock;
+    this.chainHeaderTracker = chainHeaderTracker;
+    this.logger = logger;
+    this.controller = controller;
+    this.db = db;
+
+    if (opts.closed) {
+      this.state = Status.closed;
+    } else {
+      // "start" the validator
+      // Instantiates block and attestation services and runs them once the chain has been started.
+      this.state = Status.running;
+      this.clock.start(this.controller.signal);
+      this.chainHeaderTracker.start(this.controller.signal);
+
+      if (metrics) {
+        this.db.setMetrics(metrics.db);
+
+        this.clock.runEverySlot(() =>
+          this.fetchBeaconHealth()
+            .then((health) => metrics.beaconHealth.set(health))
+            .catch((e) => this.logger.error("Error on fetchBeaconHealth", {}, e))
+        );
+      }
+    }
+  }
+
+  get isRunning(): boolean {
+    return this.state === Status.running;
+  }
+
+  /**
+   * Initialize and start a validator client and its varied sub-component services
+   */
+  static async init(opts: ValidatorOptions, genesis: Genesis, metrics: Metrics | null = null): Promise<Validator> {
     const {db, config: chainConfig, logger, slashingProtection, signers, valProposerConfig} = opts;
     const config = createBeaconConfig(chainConfig, genesis.genesisValidatorsRoot);
-    this.controller = opts.abortController;
+    const controller = opts.abortController;
     const clock = new Clock(config, logger, {genesisTime: Number(genesis.genesisTime)});
     const loggerVc = getLoggerVc(logger, clock);
 
@@ -88,7 +162,7 @@ export class Validator {
           // Validator would need the beacon to respond within the slot
           // See https://github.com/ChainSafe/lodestar/issues/5315 for rationale
           timeoutMs: config.SECONDS_PER_SLOT * 1000,
-          getAbortSignal: () => this.controller.signal,
+          getAbortSignal: () => controller.signal,
         },
         {config, logger, metrics: metrics?.restApiClient}
       );
@@ -97,6 +171,7 @@ export class Validator {
     }
 
     const indicesService = new IndicesService(logger, api, metrics);
+
     const doppelgangerService = opts.doppelgangerProtection
       ? new DoppelgangerService(
           logger,
@@ -109,15 +184,16 @@ export class Validator {
         )
       : null;
 
-    const validatorStore = new ValidatorStore(
-      config,
-      slashingProtection,
-      indicesService,
-      doppelgangerService,
-      metrics,
+    const validatorStore = await ValidatorStore.init(
+      {
+        config,
+        slashingProtection,
+        indicesService,
+        doppelgangerService,
+        metrics,
+      },
       signers,
-      valProposerConfig,
-      genesis.genesisValidatorsRoot
+      valProposerConfig
     );
     pollPrepareBeaconProposer(config, loggerVc, api, clock, validatorStore, metrics);
     pollBuilderValidatorRegistration(config, loggerVc, api, clock, validatorStore, metrics);
@@ -129,9 +205,9 @@ export class Validator {
 
     const chainHeaderTracker = new ChainHeaderTracker(logger, api, emitter);
 
-    this.blockProposingService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, metrics);
+    const blockProposingService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, metrics);
 
-    this.attestationService = new AttestationService(
+    const attestationService = new AttestationService(
       loggerVc,
       api,
       clock,
@@ -146,7 +222,7 @@ export class Validator {
       }
     );
 
-    this.syncCommitteeService = new SyncCommitteeService(
+    const syncCommitteeService = new SyncCommitteeService(
       config,
       loggerVc,
       api,
@@ -161,40 +237,23 @@ export class Validator {
       }
     );
 
-    this.config = config;
-    this.logger = logger;
-    this.api = api;
-    this.db = db;
-    this.clock = clock;
-    this.validatorStore = validatorStore;
-    this.chainHeaderTracker = chainHeaderTracker;
-    this.slashingProtection = slashingProtection;
-
-    if (metrics) {
-      db.setMetrics(metrics.db);
-    }
-
-    if (opts.closed) {
-      this.state = Status.closed;
-    } else {
-      // "start" the validator
-      // Instantiates block and attestation services and runs them once the chain has been started.
-      this.state = Status.running;
-      this.clock.start(this.controller.signal);
-      this.chainHeaderTracker.start(this.controller.signal);
-
-      if (metrics) {
-        this.clock.runEverySlot(() =>
-          this.fetchBeaconHealth()
-            .then((health) => metrics.beaconHealth.set(health))
-            .catch((e) => this.logger.error("Error on fetchBeaconHealth", {}, e))
-        );
-      }
-    }
-  }
-
-  get isRunning(): boolean {
-    return this.state === Status.running;
+    return new this({
+      opts,
+      genesis,
+      validatorStore,
+      slashingProtection,
+      blockProposingService,
+      attestationService,
+      syncCommitteeService,
+      config,
+      api,
+      clock,
+      chainHeaderTracker,
+      logger,
+      db,
+      metrics,
+      controller,
+    });
   }
 
   /** Waits for genesis and genesis time */
@@ -222,7 +281,7 @@ export class Validator {
     await assertEqualGenesis(opts, genesis);
     logger.info("Verified connected beacon node and validator have the same genesisValidatorRoot");
 
-    return new Validator(opts, genesis, metrics);
+    return Validator.init(opts, genesis, metrics);
   }
 
   removeDutiesForKey(pubkey: PubkeyHex): void {

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -143,7 +143,7 @@ export class Validator {
   }
 
   /**
-   * Initialize and start a validator client and its varied sub-component services
+   * Initialize and start a validator client
    */
   static async init(opts: ValidatorOptions, genesis: Genesis, metrics: Metrics | null = null): Promise<Validator> {
     const {db, config: chainConfig, logger, slashingProtection, signers, valProposerConfig} = opts;

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -36,10 +36,10 @@ describe("AttestationDutiesService", function () {
     validator: ssz.phase0.Validator.defaultValue(),
   };
 
-  before(() => {
+  before(async () => {
     const secretKeys = [bls.SecretKey.fromBytes(toBufferBE(BigInt(98), 32))];
     pubkeys = secretKeys.map((sk) => sk.toPublicKey().toBytes());
-    validatorStore = initValidatorStore(secretKeys, api, chainConfig);
+    validatorStore = await initValidatorStore(secretKeys, api, chainConfig);
   });
 
   let controller: AbortController; // To stop clock

--- a/packages/validator/test/unit/services/blockDuties.test.ts
+++ b/packages/validator/test/unit/services/blockDuties.test.ts
@@ -24,10 +24,10 @@ describe("BlockDutiesService", function () {
   let validatorStore: ValidatorStore;
   let pubkeys: Uint8Array[]; // Initialize pubkeys in before() so bls is already initialized
 
-  before(() => {
+  before(async () => {
     const secretKeys = Array.from({length: 3}, (_, i) => bls.SecretKey.fromBytes(toBufferBE(BigInt(i + 1), 32)));
     pubkeys = secretKeys.map((sk) => sk.toPublicKey().toBytes());
-    validatorStore = initValidatorStore(secretKeys, api);
+    validatorStore = await initValidatorStore(secretKeys, api);
   });
 
   let controller: AbortController; // To stop clock

--- a/packages/validator/test/unit/services/doppelganger.test.ts
+++ b/packages/validator/test/unit/services/doppelganger.test.ts
@@ -152,7 +152,7 @@ describe("doppelganger service", () => {
     const clock = new ClockMockMsToSlot(initialEpoch);
 
     const slashingProtection = new SlashingProtectionMock();
-    // Previous epoch attestation exists in slashing protection db
+    // Attestation from previous epoch exists in slashing protection db
     slashingProtection.hasAttestedInEpoch = async () => true;
 
     const doppelganger = new DoppelgangerService(

--- a/packages/validator/test/unit/services/doppelganger.test.ts
+++ b/packages/validator/test/unit/services/doppelganger.test.ts
@@ -148,12 +148,14 @@ describe("doppelganger service", () => {
     indicesService.pubkey2index.set(pubkeyHex, index);
 
     // Initial epoch must be > 0 else doppelganger detection is skipped due to pre-genesis
-    const initialEpoch = 1;
+    const initialEpoch = 10;
     const clock = new ClockMockMsToSlot(initialEpoch);
 
     const slashingProtection = new SlashingProtectionMock();
     // Attestation from previous epoch exists in slashing protection db
-    slashingProtection.hasAttestedInEpoch = async () => true;
+    slashingProtection.hasAttestedInEpoch = async (_, epoch: Epoch) => {
+      return epoch === initialEpoch - 1;
+    };
 
     const doppelganger = new DoppelgangerService(
       logger,

--- a/packages/validator/test/unit/services/doppleganger.test.ts
+++ b/packages/validator/test/unit/services/doppleganger.test.ts
@@ -7,6 +7,7 @@ import {DoppelgangerService, DoppelgangerStatus} from "../../../src/services/dop
 import {IndicesService} from "../../../src/services/indices.js";
 import {testLogger} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
+import {SlashingProtectionMock} from "../../utils/slashingProtectionMock.js";
 
 // At genesis start validating immediately
 
@@ -96,10 +97,20 @@ describe("doppelganger service", () => {
       const initialEpoch = 1;
       const clock = new ClockMockMsToSlot(initialEpoch);
 
-      const doppelganger = new DoppelgangerService(logger, clock, beaconApi, indicesService, noop, null);
+      const slashingProtection = new SlashingProtectionMock();
+
+      const doppelganger = new DoppelgangerService(
+        logger,
+        clock,
+        beaconApi,
+        indicesService,
+        slashingProtection,
+        noop,
+        null
+      );
 
       // Add validator to doppelganger
-      doppelganger.registerValidator(pubkeyHex);
+      await doppelganger.registerValidator(pubkeyHex);
 
       // Go step by step
       for (const [step, [isLivePrev, isLiveCurr, expectedStatus]] of testCase.entries()) {

--- a/packages/validator/test/unit/services/doppleganger.test.ts
+++ b/packages/validator/test/unit/services/doppleganger.test.ts
@@ -5,9 +5,9 @@ import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Api, HttpStatusCode} from "@lodestar/api";
 import {DoppelgangerService, DoppelgangerStatus} from "../../../src/services/doppelgangerService.js";
 import {IndicesService} from "../../../src/services/indices.js";
+import {SlashingProtectionMock} from "../../utils/slashingProtectionMock.js";
 import {testLogger} from "../../utils/logger.js";
 import {ClockMock} from "../../utils/clock.js";
-import {SlashingProtectionMock} from "../../utils/slashingProtectionMock.js";
 
 // At genesis start validating immediately
 

--- a/packages/validator/test/unit/services/syncCommitteDuties.test.ts
+++ b/packages/validator/test/unit/services/syncCommitteDuties.test.ts
@@ -43,13 +43,13 @@ describe("SyncCommitteeDutiesService", function () {
     validator: ssz.phase0.Validator.defaultValue(),
   };
 
-  before(() => {
+  before(async () => {
     const secretKeys = [
       bls.SecretKey.fromBytes(toBufferBE(BigInt(98), 32)),
       bls.SecretKey.fromBytes(toBufferBE(BigInt(99), 32)),
     ];
     pubkeys = secretKeys.map((sk) => sk.toPublicKey().toBytes());
-    validatorStore = initValidatorStore(secretKeys, api, altair0Config);
+    validatorStore = await initValidatorStore(secretKeys, api, altair0Config);
   });
 
   let controller: AbortController; // To stop clock

--- a/packages/validator/test/unit/validatorStore.test.ts
+++ b/packages/validator/test/unit/validatorStore.test.ts
@@ -21,7 +21,7 @@ describe("ValidatorStore", function () {
   let valProposerConfig: ValidatorProposerConfig;
   let signValidatorStub: SinonStubFn<ValidatorStore["signValidatorRegistration"]>;
 
-  before(() => {
+  before(async () => {
     valProposerConfig = {
       proposerConfig: {
         [toHexString(pubkeys[0])]: {
@@ -45,7 +45,7 @@ describe("ValidatorStore", function () {
       },
     };
 
-    validatorStore = initValidatorStore(secretKeys, api, chainConfig, valProposerConfig);
+    validatorStore = await initValidatorStore(secretKeys, api, chainConfig, valProposerConfig);
     signValidatorStub = sinon.stub(validatorStore, "signValidatorRegistration");
   });
 

--- a/packages/validator/test/utils/slashingProtectionMock.ts
+++ b/packages/validator/test/utils/slashingProtectionMock.ts
@@ -1,3 +1,4 @@
+import {BLSPubkey, Epoch} from "@lodestar/types";
 import {ISlashingProtection} from "../../src/index.js";
 
 /**
@@ -10,7 +11,7 @@ export class SlashingProtectionMock implements ISlashingProtection {
   async checkAndInsertAttestation(): Promise<void> {
     //
   }
-  async hasAttestedInEpoch(): Promise<boolean> {
+  async hasAttestedInEpoch(_p: BLSPubkey, _e: Epoch): Promise<boolean> {
     return false;
   }
   async importInterchange(): Promise<void> {

--- a/packages/validator/test/utils/slashingProtectionMock.ts
+++ b/packages/validator/test/utils/slashingProtectionMock.ts
@@ -10,6 +10,9 @@ export class SlashingProtectionMock implements ISlashingProtection {
   async checkAndInsertAttestation(): Promise<void> {
     //
   }
+  async hasAttestedInEpoch(): Promise<boolean> {
+    return false;
+  }
   async importInterchange(): Promise<void> {
     //
   }

--- a/packages/validator/test/utils/validatorStore.ts
+++ b/packages/validator/test/utils/validatorStore.ts
@@ -11,12 +11,12 @@ import {SlashingProtectionMock} from "./slashingProtectionMock.js";
 /**
  * Initializes an actual ValidatorStore without stubs
  */
-export function initValidatorStore(
+export async function initValidatorStore(
   secretKeys: SecretKey[],
   api: Api,
   customChainConfig: ChainConfig = chainConfig,
   valProposerConfig: ValidatorProposerConfig = {defaultConfig: {builder: {}}, proposerConfig: {}}
-): ValidatorStore {
+): Promise<ValidatorStore> {
   const logger = testLogger();
   const genesisValidatorsRoot = Buffer.alloc(32, 0xdd);
 
@@ -26,15 +26,16 @@ export function initValidatorStore(
   }));
 
   const metrics = null;
-  const indicesService = new IndicesService(logger, api, metrics);
-  return new ValidatorStore(
-    createBeaconConfig(customChainConfig, genesisValidatorsRoot),
-    new SlashingProtectionMock(),
-    indicesService,
-    null,
-    metrics,
+
+  return ValidatorStore.init(
+    {
+      config: createBeaconConfig(customChainConfig, genesisValidatorsRoot),
+      slashingProtection: new SlashingProtectionMock(),
+      indicesService: new IndicesService(logger, api, metrics),
+      doppelgangerService: null,
+      metrics,
+    },
     signers,
-    valProposerConfig,
-    genesisValidatorsRoot
+    valProposerConfig
   );
 }


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5856

**Description**

Skip doppelganger detection for validator if client restart is detected by checking if an attestation from previous epoch exists for this validator in the slashing protection database. This means there is now almost no downside to using doppelganger protection while still getting all security benefits. The only time doppelganger detection will run is if validator is imported for the first time or has not been active for more than one epoch due to a longer downtime / maintenance.
- see https://github.com/ChainSafe/lodestar/issues/5856 for detailed rationale
