### PR TITLE
fix: update cache with newly discovered attester duties

### DIFF
--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -241,7 +241,8 @@ export class AttestationDutiesService {
 
     this.logger.debug("Downloaded attester duties", {epoch, dependentRoot, count: relevantDuties.length});
 
-    const priorDependentRoot = this.dutiesByIndexByEpoch.get(epoch)?.dependentRoot;
+    const dutiesAtEpoch = this.dutiesByIndexByEpoch.get(epoch);
+    const priorDependentRoot = dutiesAtEpoch?.dependentRoot;
     const dependentRootChanged = priorDependentRoot !== undefined && priorDependentRoot !== dependentRoot;
 
     if (!priorDependentRoot || dependentRootChanged) {
@@ -251,15 +252,34 @@ export class AttestationDutiesService {
         dutiesByIndex.set(duty.validatorIndex, dutyAndProof);
       }
       this.dutiesByIndexByEpoch.set(epoch, {dependentRoot, dutiesByIndex});
-    }
 
-    if (priorDependentRoot && dependentRootChanged) {
-      this.metrics?.attesterDutiesReorg.inc();
-      this.logger.warn("Attester duties re-org. This may happen from time to time", {
-        priorDependentRoot: priorDependentRoot,
-        dependentRoot: dependentRoot,
-        epoch,
-      });
+      if (priorDependentRoot && dependentRootChanged) {
+        this.metrics?.attesterDutiesReorg.inc();
+        this.logger.warn("Attester duties re-org. This may happen from time to time", {
+          priorDependentRoot: priorDependentRoot,
+          dependentRoot: dependentRoot,
+          epoch,
+        });
+      }
+    } else {
+      const existingDuties = dutiesAtEpoch.dutiesByIndex;
+      const existingDutiesCount = existingDuties.size;
+      const discoveredNewDuties = relevantDuties.length > existingDutiesCount;
+
+      if (discoveredNewDuties) {
+        for (const duty of relevantDuties) {
+          if (!existingDuties.has(duty.validatorIndex)) {
+            const dutyAndProof = await this.getDutyAndProof(duty);
+            existingDuties.set(duty.validatorIndex, dutyAndProof);
+          }
+        }
+
+        this.logger.debug("Discovered new attester duties", {
+          epoch,
+          dependentRoot,
+          count: relevantDuties.length - existingDutiesCount,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
**Motivation**

This is something I noticed a while ago already, our doppelganger protection consistently causes 3 missed attestation whereas in theory it should only cause 2 missed attestations. Initially, I thought it is just timing related but after working on https://github.com/ChainSafe/lodestar/pull/6012, I found an issue that we are not updating our cached duties each epoch unless there is a dependent root change due to a re-org.

**Description**

Update cache (`dutiesByIndexByEpoch`) with newly discovered attester duties.

New duties might be discovered due to
- new validators imported via keymanager
- doppelganger detection completed

Proposer and sync committee duties are **not** affected by this as those are overwritten each time.
