### PR TITLE
ci: set job status of e2e tests to passed after 15m timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,7 +217,11 @@ jobs:
         run: scripts/run_e2e_env.sh start
 
       - name: E2E tests
-        run: yarn test:e2e
+        # E2E tests are sometimes stalling until timeout is reached but we know that
+        # after ~10 minutes those should have passed already if there are no failed test cases.
+        # In this case, just set the job status to passed as there was likely no actual issue.
+        # See https://github.com/ChainSafe/lodestar/issues/5913
+        run: timeout 15m yarn test:e2e || { test $? -ne 124 && exit 1; }
         env:
           GOERLI_RPC_URL: ${{ secrets.GOERLI_RPC_URL!=0 && secrets.GOERLI_RPC_URL || env.GOERLI_RPC_DEFAULT_URL }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,7 +218,7 @@ jobs:
 
       - name: E2E tests
         # E2E tests are sometimes stalling until timeout is reached but we know that
-        # after ~10 minutes those should have passed already if there are no failed test cases.
+        # after 15 minutes those should have passed already if there are no failed test cases.
         # In this case, just set the job status to passed as there was likely no actual issue.
         # See https://github.com/ChainSafe/lodestar/issues/5913
         run: timeout 15m yarn test:e2e || { test $? -eq 124 || exit 1; }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,7 @@ jobs:
         # after ~10 minutes those should have passed already if there are no failed test cases.
         # In this case, just set the job status to passed as there was likely no actual issue.
         # See https://github.com/ChainSafe/lodestar/issues/5913
-        run: timeout 15m yarn test:e2e || { test $? -ne 124 && exit 1; }
+        run: timeout 15m yarn test:e2e || { test $? -eq 124 || exit 1; }
         env:
           GOERLI_RPC_URL: ${{ secrets.GOERLI_RPC_URL!=0 && secrets.GOERLI_RPC_URL || env.GOERLI_RPC_DEFAULT_URL }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ on:
     branches: [unstable, stable]
   pull_request:
   workflow_dispatch:
-    
+
 env:
   GETH_DOCKER_IMAGE: ethereum/client-go:v1.11.6
   NETHERMIND_DOCKER_IMAGE: nethermind/nethermind:1.18.0
-  
+
 jobs:
   build:
     name: Build
@@ -53,9 +53,9 @@ jobs:
         if: steps.cache-build-restore.outputs.cache-hit == 'true'
         run: yarn build
       - name: Check Build
-        run: yarn check-build      
+        run: yarn check-build
       - name: Test root binary exists
-        run: ./lodestar --version 
+        run: ./lodestar --version
       - name: Reject yarn.lock changes
         run: .github/workflows/scripts/reject_yarn_lock_changes.sh
         # Run only on forks
@@ -69,17 +69,17 @@ jobs:
             packages/*/node_modules
             lib/
             packages/*/lib
-            packages/*/.git-data.json            
+            packages/*/.git-data.json
           key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
 
   lint:
     name: Lint
     needs: build
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
-        node: [20]    
+        node: [20]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -96,28 +96,28 @@ jobs:
             packages/*/node_modules
             lib/
             packages/*/lib
-            packages/*/.git-data.json            
+            packages/*/.git-data.json
           key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Assert yarn prints no warnings
-        run: scripts/assert_no_yarn_warnings.sh          
+        run: scripts/assert_no_yarn_warnings.sh
       - name: Lint Code
-        run: yarn lint 
+        run: yarn lint
       - name: Lint Grafana dashboards
-        run: scripts/validate-grafana-dashboards.sh        
+        run: scripts/validate-grafana-dashboards.sh
       - name: Assert ESM module exports
         run: node scripts/assert_exports.mjs
       - name: Assert eslintrc rules sorted
         run: scripts/assert_eslintrc_sorted.mjs
 
-  type-checks: 
+  type-checks:
     name: Type Checks
     needs: build
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
-        node: [20]        
+        node: [20]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -134,16 +134,16 @@ jobs:
             packages/*/node_modules
             lib/
             packages/*/lib
-            packages/*/.git-data.json            
+            packages/*/.git-data.json
           key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
           fail-on-cache-miss: true
 
       - name: Check Types
         run: yarn check-types
-  
+
       - name: README check
         run: yarn check-readme
-          
+
   unit-tests:
     name: Unit Tests
     needs: type-checks
@@ -168,7 +168,7 @@ jobs:
             packages/*/node_modules
             lib/
             packages/*/lib
-            packages/*/.git-data.json            
+            packages/*/.git-data.json
           key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
           fail-on-cache-miss: true
 
@@ -199,7 +199,7 @@ jobs:
         with:
           node-version: ${{matrix.node}}
           check-latest: true
-          cache: yarn          
+          cache: yarn
       - name: Restore build cache
         id: cache-primes-restore
         uses: actions/cache/restore@v3
@@ -209,7 +209,7 @@ jobs:
             packages/*/node_modules
             lib/
             packages/*/lib
-            packages/*/.git-data.json            
+            packages/*/.git-data.json
           key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
           fail-on-cache-miss: true
 
@@ -230,7 +230,7 @@ jobs:
         with:
           name: debug-e2e-test-logs-node-${{matrix.node}}
           path: test-logs/e2e-test-env
-      
+
   browser-tests:
     name: Browser Tests
     runs-on: buildjet-4vcpu-ubuntu-2204
@@ -246,7 +246,7 @@ jobs:
         with:
           node-version: ${{matrix.node}}
           check-latest: true
-          cache: yarn          
+          cache: yarn
       - name: Restore build cache
         id: cache-primes-restore
         uses: actions/cache/restore@v3
@@ -256,7 +256,7 @@ jobs:
             packages/*/node_modules
             lib/
             packages/*/lib
-            packages/*/.git-data.json            
+            packages/*/.git-data.json
           key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
           fail-on-cache-miss: true
 
@@ -290,18 +290,18 @@ jobs:
             packages/*/node_modules
             lib/
             packages/*/lib
-            packages/*/.git-data.json            
+            packages/*/.git-data.json
           key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
           fail-on-cache-miss: true
-          
+
       # Download spec tests with cache
       - name: Restore spec tests cache
         uses: actions/cache@master
         with:
           path: packages/beacon-node/spec-tests
           key: spec-test-data-${{ hashFiles('packages/beacon-node/test/spec/specTestVersioning.ts') }}
-      - name: Download spec tests	
-        run: yarn download-spec-tests	
+      - name: Download spec tests
+        run: yarn download-spec-tests
         working-directory: packages/beacon-node
       # Run them in different steps to quickly identifying which command failed
       # Otherwise just doing `yarn test:spec` you can't tell which specific suite failed


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/5913

**Description**

E2E tests are sometimes stalling until timeout (6 hours) is reached but we know that after 15 minutes those should have passed already if there are no failed test cases. In this case, just set the job status to passed as there was likely no actual issue.

| Scenario         | Job status |
| --------------- |------------ |
| all tests pass early |✔️|
| after 15m timeout| ✔️|
| any test case fails |❌|

Regarding the formatting changes, there were a lot of extra white spaces for no good reason, diff comes from auto-formatting.