### PR TITLE
fix: fixed chunkIntoN to chunk correctly

### DIFF
--- a/packages/prover/src/utils/conversion.ts
+++ b/packages/prover/src/utils/conversion.ts
@@ -97,12 +97,11 @@ export function cleanObject<T extends Record<string, unknown> | unknown[]>(obj: 
 }
 
 /**
- * Convert an array to array of chunks
+ * Convert an array to array of chunks of length N
  * @example
- * chunkIntoN([1,2,3,4], 2)
- * => [[1,2], [3,4]]
+ * chunkIntoN([1,2,3,4,5,6], 2)
+ * => [[1,2], [3,4], [5,6]]
  */
 export function chunkIntoN<T extends unknown[]>(arr: T, n: number): T[] {
-  const size = Math.ceil(arr.length / n);
-  return Array.from({length: n}, (v, i) => arr.slice(i * size, i * size + size)) as T[];
+  return Array.from({length: Math.ceil(arr.length / n)}, (_, i) => arr.slice(i * n, i * n + n)) as T[];
 }

--- a/packages/prover/test/unit/utils/conversion.test.ts
+++ b/packages/prover/test/unit/utils/conversion.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 import {chunkIntoN} from "../../../src/utils/conversion.js";
 
-describe("uitls/execution", () => {
+describe("utils/conversion", () => {
   describe("chunkIntoN", () => {
     it("should return true if splitting into chunks correctly", async () => {
       expect(chunkIntoN([1, 2, 3, 4, 5, 6], 2)).to.be.deep.eq([

--- a/packages/prover/test/unit/utils/conversion.test.ts
+++ b/packages/prover/test/unit/utils/conversion.test.ts
@@ -1,0 +1,14 @@
+import {expect} from "chai";
+import {chunkIntoN} from "../../../src/utils/conversion.js";
+
+describe("uitls/execution", () => {
+  describe("chunkIntoN", () => {
+    it("should return true if splitting into chunks correctly", async () => {
+      expect(chunkIntoN([1, 2, 3, 4, 5, 6], 2)).to.be.deep.eq([
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
chunkIntoN was chunking into N chunks, however it is used to chunk eth_getCode and eth_getProof responses into chunks of 2, so the desired action should be to chunk into chunks of length N https://github.com/ChainSafe/lodestar/blob/unstable/packages/prover/src/utils/evm.ts#L105

Because the current tests work on chunking array of length 4 into 2 the previous behavior was working and passing tests. When there are 6 requests the current behavior no longer works

