### PR TITLE
feat: support "input" param for verifiable tx

### DIFF
--- a/packages/prover/src/utils/evm.ts
+++ b/packages/prover/src/utils/evm.ts
@@ -166,7 +166,7 @@ export async function executeVMCall({
   executionPayload: allForks.ExecutionPayload;
   network: NetworkName;
 }): Promise<RunTxResult["execResult"]> {
-  const {from, to, gas, gasPrice, maxPriorityFeePerGas, value, data} = tx;
+  const {from, to, gas, gasPrice, maxPriorityFeePerGas, value, data, input} = tx;
   const {result: block} = await rpc.request("eth_getBlockByHash", [bufferToHex(executionPayload.blockHash), true], {
     raiseError: true,
   });
@@ -181,7 +181,7 @@ export async function executeVMCall({
     gasLimit: hexToBigInt(gas ?? block.gasLimit),
     gasPrice: hexToBigInt(gasPrice ?? maxPriorityFeePerGas ?? "0x0"),
     value: hexToBigInt(value ?? "0x0"),
-    data: data ? hexToBuffer(data) : undefined,
+    data: input ? hexToBuffer(input) : data ? hexToBuffer(data) : undefined,
     block: {
       header: getVMBlockHeaderFromELBlock(block, executionPayload, network),
     },


### PR DESCRIPTION
Using contract calls in web3js, the transaction data can either be filled in the "data" parameter or "input" parameter, default is "input"

The current verified execution provider supports only "data" parameter, so code like this

const contract = new web3.eth.Contract(balanceOfABI, tokenContract)
 let result = await contract.methods.balanceOf(tokenHolder).call();

doesn't work

