### PR TITLE
fix: ignore "execution reverted" errors in eth_createAccessList

### DIFF
--- a/packages/prover/src/utils/evm.ts
+++ b/packages/prover/src/utils/evm.ts
@@ -63,7 +63,7 @@ export async function getVMWithState({
   }) as ELTransaction;
   const response = await rpc.request("eth_createAccessList", [accessListTx, blockHashHex], {raiseError: false});
 
-  if (!isValidResponse(response) || response.result.error) {
+  if (!isValidResponse(response) || (response.result.error && response.result.error !== "execution reverted")) {
     throw new Error(`Invalid response from RPC. method: eth_createAccessList, params: ${JSON.stringify(tx)}`);
   }
 


### PR DESCRIPTION
eth_createAccessList sometimes returns "execution reverted" errors, even if the tx is supposed to succeed.
I wasn't able to find the reason for this, maybe more investigation is needed

# Code to replicate
The following example calls balanceOf on USDC, the tx should work but eth_createAccessList returns "execution reverted"
```typescript
import Web3 from "web3";
import {createVerifiedExecutionProvider, LCTransport} from "@lodestar/prover";
import {LogLevel} from "@lodestar/logger";


const network = "mainnet";
const beaconApiUrl = "https://lodestar-mainnet.chainsafe.io"
const elRpcUrl = "https://lodestar-mainnetrpc.chainsafe.io";
const checkpoint = "0xcc8251d86c07d31c2afd7edda6df5896d7b8b721b4402557f1a8de4a5965ae09";

const {provider, proofProvider} = createVerifiedExecutionProvider(
  new Web3.providers.HttpProvider(elRpcUrl),
  {
    transport: LCTransport.Rest,
    urls: [beaconApiUrl],
    network: network,
    wsCheckpoint: checkpoint,
    logLevel: LogLevel.info
  }
);

const web3 = new Web3(provider);

const balanceOfABI = [
  {
      "constant": true,
      "inputs": [
          {
              "name": "_owner",
              "type": "address"
          }
      ],
      "name": "balanceOf",
      "outputs": [
          {
              "name": "balance",
              "type": "uint256"
          }
      ],
      "payable": false,
      "stateMutability": "view",
      "type": "function"
  },
];

const tokenContract = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" // USDC
const tokenHolder = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"

const contract = new web3.eth.Contract(balanceOfABI, tokenContract)
const result = await contract.methods.balanceOf(tokenHolder).call();
```