### PR TITLE
feat: implement shuffling cache

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -63,6 +63,7 @@ export async function importBlock(
   const blockRootHex = toHexString(blockRoot);
   const currentEpoch = computeEpochAtSlot(this.forkChoice.getTime());
   const blockEpoch = computeEpochAtSlot(block.message.slot);
+  const parentEpoch = computeEpochAtSlot(parentBlockSlot);
   const prevFinalizedEpoch = this.forkChoice.getFinalizedCheckpoint().epoch;
   const blockDelaySec = (fullyVerifiedBlock.seenTimestampSec - postState.genesisTime) % this.config.SECONDS_PER_SLOT;
 
@@ -345,6 +346,12 @@ export async function importBlock(
 
   if (!isStateValidatorsNodesPopulated(postState)) {
     this.logger.verbose("After importBlock caching postState without SSZ cache", {slot: postState.slot});
+  }
+
+  if (parentEpoch < blockEpoch) {
+    // current epoch and previous epoch are likely cached in previous states
+    this.shufflingCache.processState(postState, postState.epochCtx.nextShuffling.epoch);
+    this.logger.verbose("Processed shuffling for next epoch", {parentEpoch, blockEpoch, slot: block.message.slot});
   }
 
   if (block.message.slot % SLOTS_PER_EPOCH === 0) {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -11,6 +11,7 @@ import {
   isCachedBeaconState,
   Index2PubkeyCache,
   PubkeyIndexMap,
+  EpochShuffling,
 } from "@lodestar/state-transition";
 import {BeaconConfig} from "@lodestar/config";
 import {
@@ -39,7 +40,6 @@ import {IExecutionEngine, IExecutionBuilder} from "../execution/index.js";
 import {Clock, ClockEvent, IClock} from "../util/clock.js";
 import {ensureDir, writeIfNotExist} from "../util/file.js";
 import {isOptimisticBlock} from "../util/forkChoice.js";
-import {CheckpointStateCache, StateContextCache} from "./stateCache/index.js";
 import {BlockProcessor, ImportBlockOpts} from "./blocks/index.js";
 import {ChainEventEmitter, ChainEvent} from "./emitter.js";
 import {IBeaconChain, ProposerPreparationData, BlockHash, StateGetOpts} from "./interface.js";
@@ -75,6 +75,9 @@ import {BlockAttributes, produceBlockBody} from "./produceBlock/produceBlockBody
 import {computeNewStateRoot} from "./produceBlock/computeNewStateRoot.js";
 import {BlockInput} from "./blocks/types.js";
 import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
+import {ShufflingCache} from "./shufflingCache.js";
+import {StateContextCache} from "./stateCache/stateContextCache.js";
+import {CheckpointStateCache} from "./stateCache/stateContextCheckpointsCache.js";
 
 /**
  * Arbitrary constants, blobs and payloads should be consumed immediately in the same slot
@@ -129,6 +132,7 @@ export class BeaconChain implements IBeaconChain {
 
   readonly beaconProposerCache: BeaconProposerCache;
   readonly checkpointBalancesCache: CheckpointBalancesCache;
+  readonly shufflingCache: ShufflingCache;
   /** Map keyed by executionPayload.blockHash of the block for those blobs */
   readonly producedBlobSidecarsCache = new Map<BlockHash, deneb.BlobSidecars>();
   readonly producedBlindedBlobSidecarsCache = new Map<BlockHash, deneb.BlindedBlobSidecars>();
@@ -209,6 +213,7 @@ export class BeaconChain implements IBeaconChain {
 
     this.beaconProposerCache = new BeaconProposerCache(opts);
     this.checkpointBalancesCache = new CheckpointBalancesCache();
+    this.shufflingCache = new ShufflingCache(metrics, this.opts);
 
     // Restore state caches
     // anchorState may already by a CachedBeaconState. If so, don't create the cache again, since deserializing all
@@ -223,6 +228,9 @@ export class BeaconChain implements IBeaconChain {
             pubkey2index: new PubkeyIndexMap(),
             index2pubkey: [],
           });
+    this.shufflingCache.processState(cachedState, cachedState.epochCtx.previousShuffling.epoch);
+    this.shufflingCache.processState(cachedState, cachedState.epochCtx.currentShuffling.epoch);
+    this.shufflingCache.processState(cachedState, cachedState.epochCtx.nextShuffling.epoch);
 
     // Persist single global instance of state caches
     this.pubkey2index = cachedState.epochCtx.pubkey2index;
@@ -638,6 +646,49 @@ export class BeaconChain implements IBeaconChain {
     if (this.opts.persistInvalidSszObjects) {
       void this.persistInvalidSszObject(view.type.typeName, view.serialize(), view.hashTreeRoot(), suffix);
     }
+  }
+
+  /**
+   * Regenerate state for attestation verification, this does not happen with default chain option of maxSkipSlots = 32 .
+   * However, need to handle just in case. Lodestar doesn't support multiple regen state requests for attestation verification
+   * at the same time, bounded inside "ShufflingCache.insertPromise()" function.
+   * Leave this function in chain instead of attestatation verification code to make sure we're aware of its performance impact.
+   */
+  async regenStateForAttestationVerification(
+    attEpoch: Epoch,
+    shufflingDependentRoot: RootHex,
+    attHeadBlock: ProtoBlock,
+    regenCaller: RegenCaller
+  ): Promise<EpochShuffling> {
+    // this is to prevent multiple calls to get shuffling for the same epoch and dependent root
+    // any subsequent calls of the same epoch and dependent root will wait for this promise to resolve
+    this.shufflingCache.insertPromise(attEpoch, shufflingDependentRoot);
+    const blockEpoch = computeEpochAtSlot(attHeadBlock.slot);
+
+    let state: CachedBeaconStateAllForks;
+    if (blockEpoch < attEpoch - 1) {
+      // thanks to one epoch look ahead, we don't need to dial up to attEpoch
+      const targetSlot = computeStartSlotAtEpoch(attEpoch - 1);
+      this.metrics?.gossipAttestation.useHeadBlockStateDialedToTargetEpoch.inc({caller: regenCaller});
+      state = await this.regen.getBlockSlotState(
+        attHeadBlock.blockRoot,
+        targetSlot,
+        {dontTransferCache: true},
+        regenCaller
+      );
+    } else if (blockEpoch > attEpoch) {
+      // should not happen, handled inside attestation verification code
+      throw Error(`Block epoch ${blockEpoch} is after attestation epoch ${attEpoch}`);
+    } else {
+      // should use either current or next shuffling of head state
+      // it's not likely to hit this since these shufflings are cached already
+      // so handle just in case
+      this.metrics?.gossipAttestation.useHeadBlockState.inc({caller: regenCaller});
+      state = await this.regen.getState(attHeadBlock.stateRoot, regenCaller);
+    }
+
+    // resolve the promise to unblock other calls of the same epoch and dependent root
+    return this.shufflingCache.processState(state, attEpoch);
   }
 
   /**

--- a/packages/beacon-node/src/chain/errors/attestationError.ts
+++ b/packages/beacon-node/src/chain/errors/attestationError.ts
@@ -1,5 +1,5 @@
 import {toHexString} from "@chainsafe/ssz";
-import {CommitteeIndex, Epoch, Slot, ValidatorIndex, RootHex} from "@lodestar/types";
+import {Epoch, Slot, ValidatorIndex, RootHex} from "@lodestar/types";
 import {GossipActionError} from "./gossipValidation.js";
 
 export enum AttestationErrorCode {
@@ -65,11 +65,6 @@ export enum AttestationErrorCode {
    * A signature on the attestation is invalid.
    */
   INVALID_SIGNATURE = "ATTESTATION_ERROR_INVALID_SIGNATURE",
-  /**
-   * There is no committee for the slot and committee index of this attestation
-   * and the attestation should not have been produced.
-   */
-  NO_COMMITTEE_FOR_SLOT_AND_INDEX = "ATTESTATION_ERROR_NO_COMMITTEE_FOR_SLOT_AND_INDEX",
   /**
    * The unaggregated attestation doesn't have only one aggregation bit set.
    */
@@ -150,7 +145,6 @@ export type AttestationErrorType =
   | {code: AttestationErrorCode.HEAD_NOT_TARGET_DESCENDANT}
   | {code: AttestationErrorCode.UNKNOWN_TARGET_ROOT; root: Uint8Array}
   | {code: AttestationErrorCode.INVALID_SIGNATURE}
-  | {code: AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX; slot: Slot; index: CommitteeIndex}
   | {code: AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET}
   | {code: AttestationErrorCode.PRIOR_ATTESTATION_KNOWN; validatorIndex: ValidatorIndex; epoch: Epoch}
   | {code: AttestationErrorCode.FUTURE_EPOCH; attestationEpoch: Epoch; currentEpoch: Epoch}

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -3,6 +3,7 @@ import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch, ValidatorIndex,
 import {
   BeaconStateAllForks,
   CachedBeaconStateAllForks,
+  EpochShuffling,
   Index2PubkeyCache,
   PubkeyIndexMap,
 } from "@lodestar/state-transition";
@@ -36,6 +37,7 @@ import {CheckpointBalancesCache} from "./balancesCache.js";
 import {IChainOptions} from "./options.js";
 import {AssembledBlockType, BlockAttributes, BlockType} from "./produceBlock/produceBlockBody.js";
 import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
+import {ShufflingCache} from "./shufflingCache.js";
 
 export {BlockType, type AssembledBlockType};
 export {type ProposerPreparationData};
@@ -96,6 +98,7 @@ export interface IBeaconChain {
   readonly producedBlobSidecarsCache: Map<BlockHash, deneb.BlobSidecars>;
   readonly producedBlockRoot: Map<RootHex, allForks.ExecutionPayload | null>;
   readonly producedBlindedBlobSidecarsCache: Map<BlockHash, deneb.BlindedBlobSidecars>;
+  readonly shufflingCache: ShufflingCache;
   readonly producedBlindedBlockRoot: Set<RootHex>;
   readonly opts: IChainOptions;
 
@@ -160,6 +163,12 @@ export interface IBeaconChain {
   persistInvalidSszBytes(type: string, sszBytes: Uint8Array, suffix?: string): void;
   /** Persist bad items to persistInvalidSszObjectsDir dir, for example invalid state, attestations etc. */
   persistInvalidSszView(view: TreeView<CompositeTypeAny>, suffix?: string): void;
+  regenStateForAttestationVerification(
+    attEpoch: Epoch,
+    shufflingDependentRoot: RootHex,
+    attHeadBlock: ProtoBlock,
+    regenCaller: RegenCaller
+  ): Promise<EpochShuffling>;
   updateBuilderStatus(clockSlot: Slot): void;
 
   regenCanAcceptWork(): boolean;

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -3,12 +3,14 @@ import {defaultOptions as defaultValidatorOptions} from "@lodestar/validator";
 import {ArchiverOpts} from "./archiver/index.js";
 import {ForkChoiceOpts} from "./forkChoice/index.js";
 import {LightClientServerOpts} from "./lightClient/index.js";
+import {ShufflingCacheOpts} from "./shufflingCache.js";
 
 export type IChainOptions = BlockProcessOpts &
   PoolOpts &
   SeenCacheOpts &
   ForkChoiceOpts &
   ArchiverOpts &
+  ShufflingCacheOpts &
   LightClientServerOpts & {
     blsVerifyAllMainThread?: boolean;
     blsVerifyAllMultiThread?: boolean;

--- a/packages/beacon-node/src/chain/shufflingCache.ts
+++ b/packages/beacon-node/src/chain/shufflingCache.ts
@@ -1,0 +1,180 @@
+import {CachedBeaconStateAllForks, EpochShuffling, getShufflingDecisionBlock} from "@lodestar/state-transition";
+import {Epoch, RootHex} from "@lodestar/types";
+import {MapDef, pruneSetToMax} from "@lodestar/utils";
+import {Metrics} from "../metrics/metrics.js";
+
+/**
+ * Same value to CheckpointBalancesCache, with the assumption that we don't have to use it for old epochs. In the worse case:
+ * - when loading state bytes from disk, we need to compute shuffling for all epochs (~1s as of Sep 2023)
+ * - don't have shuffling to verify attestations, need to do 1 epoch transition to add shuffling to this cache. This never happens
+ * with default chain option of maxSkipSlots = 32
+ **/
+const MAX_EPOCHS = 4;
+
+/**
+ * With default chain option of maxSkipSlots = 32, there should be no shuffling promise. If that happens a lot, it could blow up Lodestar,
+ * with MAX_EPOCHS = 4, only allow 2 promise at a time. Note that regen already bounds number of concurrent requests at 1 already.
+ */
+const MAX_PROMISES = 2;
+
+enum CacheItemType {
+  shuffling,
+  promise,
+}
+
+type ShufflingCacheItem = {
+  type: CacheItemType.shuffling;
+  shuffling: EpochShuffling;
+};
+
+type PromiseCacheItem = {
+  type: CacheItemType.promise;
+  promise: Promise<EpochShuffling>;
+  resolveFn: (shuffling: EpochShuffling) => void;
+};
+
+type CacheItem = ShufflingCacheItem | PromiseCacheItem;
+
+export type ShufflingCacheOpts = {
+  maxShufflingCacheEpochs?: number;
+};
+
+/**
+ * A shuffling cache to help:
+ * - get committee quickly for attestation verification
+ * - if a shuffling is not available (which does not happen with default chain option of maxSkipSlots = 32), track a promise to make sure we don't compute the same shuffling twice
+ * - skip computing shuffling when loading state bytes from disk
+ */
+export class ShufflingCache {
+  /** LRU cache implemented as an array, pruned every time we add an item */
+  private readonly itemsByDecisionRootByEpoch: MapDef<Epoch, Map<RootHex, CacheItem>> = new MapDef(
+    () => new Map<RootHex, CacheItem>()
+  );
+
+  private readonly maxEpochs: number;
+
+  constructor(
+    private readonly metrics: Metrics | null = null,
+    opts: ShufflingCacheOpts = {}
+  ) {
+    if (metrics) {
+      metrics.shufflingCache.size.addCollect(() =>
+        metrics.shufflingCache.size.set(
+          Array.from(this.itemsByDecisionRootByEpoch.values()).reduce((total, innerMap) => total + innerMap.size, 0)
+        )
+      );
+    }
+
+    this.maxEpochs = opts.maxShufflingCacheEpochs ?? MAX_EPOCHS;
+  }
+
+  /**
+   * Extract shuffling from state and add to cache
+   */
+  processState(state: CachedBeaconStateAllForks, shufflingEpoch: Epoch): EpochShuffling {
+    const decisionBlockHex = getShufflingDecisionBlock(state, shufflingEpoch);
+    let shuffling: EpochShuffling;
+    switch (shufflingEpoch) {
+      case state.epochCtx.nextShuffling.epoch:
+        shuffling = state.epochCtx.nextShuffling;
+        break;
+      case state.epochCtx.currentShuffling.epoch:
+        shuffling = state.epochCtx.currentShuffling;
+        break;
+      case state.epochCtx.previousShuffling.epoch:
+        shuffling = state.epochCtx.previousShuffling;
+        break;
+      default:
+        throw new Error(`Shuffling not found from state ${state.slot} for epoch ${shufflingEpoch}`);
+    }
+
+    let cacheItem = this.itemsByDecisionRootByEpoch.getOrDefault(shufflingEpoch).get(decisionBlockHex);
+    if (cacheItem !== undefined) {
+      // update existing promise
+      if (isPromiseCacheItem(cacheItem)) {
+        // unblock consumers of this promise
+        cacheItem.resolveFn(shuffling);
+        // then update item type to shuffling
+        cacheItem = {
+          type: CacheItemType.shuffling,
+          shuffling,
+        };
+        this.add(shufflingEpoch, decisionBlockHex, cacheItem);
+        // we updated type to CacheItemType.shuffling so the above fields are not used anyway
+        this.metrics?.shufflingCache.processStateUpdatePromise.inc();
+      } else {
+        // ShufflingCacheItem, do nothing
+        this.metrics?.shufflingCache.processStateNoOp.inc();
+      }
+    } else {
+      // not found, new shuffling
+      this.add(shufflingEpoch, decisionBlockHex, {type: CacheItemType.shuffling, shuffling});
+      this.metrics?.shufflingCache.processStateInsertNew.inc();
+    }
+
+    return shuffling;
+  }
+
+  /**
+   * Insert a promise to make sure we don't regen state for the same shuffling.
+   * Bound by MAX_SHUFFLING_PROMISE to make sure our node does not blow up.
+   */
+  insertPromise(shufflingEpoch: Epoch, decisionRootHex: RootHex): void {
+    const promiseCount = Array.from(this.itemsByDecisionRootByEpoch.values())
+      .map((innerMap) => Array.from(innerMap.values()))
+      .flat()
+      .filter((item) => isPromiseCacheItem(item)).length;
+    if (promiseCount >= MAX_PROMISES) {
+      throw new Error(
+        `Too many shuffling promises: ${promiseCount}, shufflingEpoch: ${shufflingEpoch}, decisionRootHex: ${decisionRootHex}`
+      );
+    }
+    let resolveFn: ((shuffling: EpochShuffling) => void) | null = null;
+    const promise = new Promise<EpochShuffling>((resolve) => {
+      resolveFn = resolve;
+    });
+    if (resolveFn === null) {
+      throw new Error("Promise Constructor was not executed immediately");
+    }
+
+    const cacheItem: PromiseCacheItem = {
+      type: CacheItemType.promise,
+      promise,
+      resolveFn,
+    };
+    this.add(shufflingEpoch, decisionRootHex, cacheItem);
+    this.metrics?.shufflingCache.insertPromiseCount.inc();
+  }
+
+  /**
+   * Most of the time, this should return a shuffling immediately.
+   * If there's a promise, it means we are computing the same shuffling, so we wait for the promise to resolve.
+   * Return null if we don't have a shuffling for this epoch and dependentRootHex.
+   */
+  async get(shufflingEpoch: Epoch, decisionRootHex: RootHex): Promise<EpochShuffling | null> {
+    const cacheItem = this.itemsByDecisionRootByEpoch.getOrDefault(shufflingEpoch).get(decisionRootHex);
+    if (cacheItem === undefined) {
+      return null;
+    }
+
+    if (isShufflingCacheItem(cacheItem)) {
+      return cacheItem.shuffling;
+    } else {
+      // promise
+      return cacheItem.promise;
+    }
+  }
+
+  private add(shufflingEpoch: Epoch, decisionBlock: RootHex, cacheItem: CacheItem): void {
+    this.itemsByDecisionRootByEpoch.getOrDefault(shufflingEpoch).set(decisionBlock, cacheItem);
+    pruneSetToMax(this.itemsByDecisionRootByEpoch, this.maxEpochs);
+  }
+}
+
+function isShufflingCacheItem(item: CacheItem): item is ShufflingCacheItem {
+  return item.type === CacheItemType.shuffling;
+}
+
+function isPromiseCacheItem(item: CacheItem): item is PromiseCacheItem {
+  return item.type === CacheItemType.promise;
+}

--- a/packages/beacon-node/src/chain/shufflingCache.ts
+++ b/packages/beacon-node/src/chain/shufflingCache.ts
@@ -49,7 +49,7 @@ export type ShufflingCacheOpts = {
  * - skip computing shuffling when loading state bytes from disk
  */
 export class ShufflingCache {
-  /** LRU cache implemented as an array, pruned every time we add an item */
+  /** LRU cache implemented as a map, pruned every time we add an item */
   private readonly itemsByDecisionRootByEpoch: MapDef<Epoch, Map<RootHex, CacheItem>> = new MapDef(
     () => new Map<RootHex, CacheItem>()
   );
@@ -124,8 +124,7 @@ export class ShufflingCache {
    */
   insertPromise(shufflingEpoch: Epoch, decisionRootHex: RootHex): void {
     const promiseCount = Array.from(this.itemsByDecisionRootByEpoch.values())
-      .map((innerMap) => Array.from(innerMap.values()))
-      .flat()
+      .flatMap((innerMap) => Array.from(innerMap.values()))
       .filter((item) => isPromiseCacheItem(item)).length;
     if (promiseCount >= MAX_PROMISES) {
       throw new Error(

--- a/packages/beacon-node/src/chain/validation/signatureSets/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/aggregateAndProof.ts
@@ -3,32 +3,36 @@ import {DOMAIN_AGGREGATE_AND_PROOF} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {Epoch, phase0} from "@lodestar/types";
 import {
-  CachedBeaconStateAllForks,
   computeSigningRoot,
   computeStartSlotAtEpoch,
   createSingleSignatureSetFromComponents,
   ISignatureSet,
 } from "@lodestar/state-transition";
+import {BeaconConfig} from "@lodestar/config";
 
 export function getAggregateAndProofSigningRoot(
-  state: CachedBeaconStateAllForks,
+  config: BeaconConfig,
   epoch: Epoch,
   aggregateAndProof: phase0.SignedAggregateAndProof
 ): Uint8Array {
+  // previously, we call `const aggregatorDomain = state.config.getDomain(state.slot, DOMAIN_AGGREGATE_AND_PROOF, slot);`
+  // at fork boundary, it's required to dial to target epoch https://github.com/ChainSafe/lodestar/blob/v1.11.3/packages/beacon-node/src/chain/validation/attestation.ts#L573
+  // instead of that, just use the fork of slot in the attestation data
   const slot = computeStartSlotAtEpoch(epoch);
-  const aggregatorDomain = state.config.getDomain(state.slot, DOMAIN_AGGREGATE_AND_PROOF, slot);
+  const fork = config.getForkName(slot);
+  const aggregatorDomain = config.getDomainAtFork(fork, DOMAIN_AGGREGATE_AND_PROOF);
   return computeSigningRoot(ssz.phase0.AggregateAndProof, aggregateAndProof.message, aggregatorDomain);
 }
 
 export function getAggregateAndProofSignatureSet(
-  state: CachedBeaconStateAllForks,
+  config: BeaconConfig,
   epoch: Epoch,
   aggregator: PublicKey,
   aggregateAndProof: phase0.SignedAggregateAndProof
 ): ISignatureSet {
   return createSingleSignatureSetFromComponents(
     aggregator,
-    getAggregateAndProofSigningRoot(state, epoch, aggregateAndProof),
+    getAggregateAndProofSigningRoot(config, epoch, aggregateAndProof),
     aggregateAndProof.signature
   );
 }

--- a/packages/beacon-node/src/chain/validation/signatureSets/selectionProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/selectionProof.ts
@@ -1,27 +1,27 @@
 import type {PublicKey} from "@chainsafe/bls/types";
 import {DOMAIN_SELECTION_PROOF} from "@lodestar/params";
 import {phase0, Slot, ssz} from "@lodestar/types";
-import {
-  CachedBeaconStateAllForks,
-  computeSigningRoot,
-  createSingleSignatureSetFromComponents,
-  ISignatureSet,
-} from "@lodestar/state-transition";
+import {computeSigningRoot, createSingleSignatureSetFromComponents, ISignatureSet} from "@lodestar/state-transition";
+import {BeaconConfig} from "@lodestar/config";
 
-export function getSelectionProofSigningRoot(state: CachedBeaconStateAllForks, slot: Slot): Uint8Array {
-  const selectionProofDomain = state.config.getDomain(state.slot, DOMAIN_SELECTION_PROOF, slot);
+export function getSelectionProofSigningRoot(config: BeaconConfig, slot: Slot): Uint8Array {
+  // previously, we call `const selectionProofDomain = config.getDomain(state.slot, DOMAIN_SELECTION_PROOF, slot)`
+  // at fork boundary, it's required to dial to target epoch https://github.com/ChainSafe/lodestar/blob/v1.11.3/packages/beacon-node/src/chain/validation/attestation.ts#L573
+  // instead of that, just use the fork of slot in the attestation data
+  const fork = config.getForkName(slot);
+  const selectionProofDomain = config.getDomainAtFork(fork, DOMAIN_SELECTION_PROOF);
   return computeSigningRoot(ssz.Slot, slot, selectionProofDomain);
 }
 
 export function getSelectionProofSignatureSet(
-  state: CachedBeaconStateAllForks,
+  config: BeaconConfig,
   slot: Slot,
   aggregator: PublicKey,
   aggregateAndProof: phase0.SignedAggregateAndProof
 ): ISignatureSet {
   return createSingleSignatureSetFromComponents(
     aggregator,
-    getSelectionProofSigningRoot(state, slot),
+    getSelectionProofSigningRoot(config, slot),
     aggregateAndProof.message.selectionProof
   );
 }

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -590,6 +590,26 @@ export function createLodestarMetrics(
         labelNames: ["caller"],
         buckets: [0, 1, 2, 4, 8, 16, 32, 64],
       }),
+      shufflingCacheHit: register.gauge<"caller">({
+        name: "lodestar_gossip_attestation_shuffling_cache_hit_count",
+        help: "Count of gossip attestation verification shuffling cache hit",
+        labelNames: ["caller"],
+      }),
+      shufflingCacheMiss: register.gauge<"caller">({
+        name: "lodestar_gossip_attestation_shuffling_cache_miss_count",
+        help: "Count of gossip attestation verification shuffling cache miss",
+        labelNames: ["caller"],
+      }),
+      shufflingCacheRegenHit: register.gauge<"caller">({
+        name: "lodestar_gossip_attestation_shuffling_cache_regen_hit_count",
+        help: "Count of gossip attestation verification shuffling cache regen hit",
+        labelNames: ["caller"],
+      }),
+      shufflingCacheRegenMiss: register.gauge<"caller">({
+        name: "lodestar_gossip_attestation_shuffling_cache_regen_miss_count",
+        help: "Count of gossip attestation verification shuffling cache regen miss",
+        labelNames: ["caller"],
+      }),
       attestationSlotToClockSlot: register.histogram<"caller">({
         name: "lodestar_gossip_attestation_attestation_slot_to_clock_slot",
         help: "Slot distance between clock slot and attestation slot",
@@ -1069,6 +1089,29 @@ export function createLodestarMetrics(
         name: "lodestar_balances_cache_closest_state_result_total",
         help: "Total number of stateIds returned as closest justified balances state by id",
         labelNames: ["stateId"],
+      }),
+    },
+
+    shufflingCache: {
+      size: register.gauge({
+        name: "lodestar_shuffling_cache_size",
+        help: "Shuffling cache size",
+      }),
+      processStateInsertNew: register.gauge({
+        name: "lodestar_shuffling_cache_process_state_insert_new_total",
+        help: "Total number of times processState is called resulting a new shuffling",
+      }),
+      processStateUpdatePromise: register.gauge({
+        name: "lodestar_shuffling_cache_process_state_update_promise_total",
+        help: "Total number of times processState is called resulting a promise being updated with shuffling",
+      }),
+      processStateNoOp: register.gauge({
+        name: "lodestar_shuffling_cache_process_state_no_op_total",
+        help: "Total number of times processState is called resulting no changes",
+      }),
+      insertPromiseCount: register.gauge({
+        name: "lodestar_shuffling_cache_insert_promise_count",
+        help: "Total number of times insertPromise is called",
       }),
     },
 

--- a/packages/beacon-node/src/util/dependentRoot.ts
+++ b/packages/beacon-node/src/util/dependentRoot.ts
@@ -1,0 +1,47 @@
+import {EpochDifference, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
+import {Epoch, RootHex} from "@lodestar/types";
+
+/**
+ * Get dependent root of a shuffling given attestation epoch and head block.
+ */
+export function getShufflingDependentRoot(
+  forkChoice: IForkChoice,
+  attEpoch: Epoch,
+  blockEpoch: Epoch,
+  attHeadBlock: ProtoBlock
+): RootHex {
+  let shufflingDependentRoot: RootHex;
+  if (blockEpoch === attEpoch) {
+    // current shuffling, this is equivalent to `headState.currentShuffling`
+    // given blockEpoch = attEpoch = n
+    //        epoch:       (n-2)   (n-1)     n     (n+1)
+    //               |-------|-------|-------|-------|
+    // attHeadBlock     ------------------------^
+    // shufflingDependentRoot ------^
+    shufflingDependentRoot = forkChoice.getDependentRoot(attHeadBlock, EpochDifference.previous);
+  } else if (blockEpoch === attEpoch - 1) {
+    // next shuffling, this is equivalent to `headState.nextShuffling`
+    // given blockEpoch = n-1, attEpoch = n
+    //        epoch:       (n-2)   (n-1)     n     (n+1)
+    //               |-------|-------|-------|-------|
+    // attHeadBlock     -------------------^
+    // shufflingDependentRoot ------^
+    shufflingDependentRoot = forkChoice.getDependentRoot(attHeadBlock, EpochDifference.current);
+  } else if (blockEpoch < attEpoch - 1) {
+    // this never happens with default chain option of maxSkipSlots = 32, however we still need to handle it
+    // check the verifyHeadBlockAndTargetRoot() function above
+    // given blockEpoch = n-2, attEpoch = n
+    //        epoch:       (n-2)   (n-1)     n     (n+1)
+    //               |-------|-------|-------|-------|
+    // attHeadBlock     -----------^
+    // shufflingDependentRoot -----^
+    shufflingDependentRoot = attHeadBlock.blockRoot;
+    // use lodestar_gossip_attestation_head_slot_to_attestation_slot metric to track this case
+  } else {
+    // blockEpoch > attEpoch
+    // should not happen, handled in verifyAttestationTargetRoot
+    throw Error(`attestation epoch ${attEpoch} is before head block epoch ${blockEpoch}`);
+  }
+
+  return shufflingDependentRoot;
+}

--- a/packages/beacon-node/test/__mocks__/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/__mocks__/mockedBeaconChain.ts
@@ -13,6 +13,7 @@ import {BeaconProposerCache} from "../../src/chain/beaconProposerCache.js";
 import {QueuedStateRegenerator} from "../../src/chain/regen/index.js";
 import {LightClientServer} from "../../src/chain/lightClient/index.js";
 import {Clock} from "../../src/util/clock.js";
+import {ShufflingCache} from "../../src/chain/shufflingCache.js";
 import {getMockedLogger} from "./loggerMock.js";
 
 export type MockedBeaconChain = MockedObject<BeaconChain> & {
@@ -24,6 +25,7 @@ export type MockedBeaconChain = MockedObject<BeaconChain> & {
   opPool: MockedObject<OpPool>;
   aggregatedAttestationPool: MockedObject<AggregatedAttestationPool>;
   beaconProposerCache: MockedObject<BeaconProposerCache>;
+  shufflingCache: MockedObject<ShufflingCache>;
   regen: MockedObject<QueuedStateRegenerator>;
   bls: {
     verifySignatureSets: Mock<[boolean]>;
@@ -40,6 +42,7 @@ vi.mock("../../src/eth1/index.js");
 vi.mock("../../src/chain/opPools/opPool.js");
 vi.mock("../../src/chain/opPools/aggregatedAttestationPool.js");
 vi.mock("../../src/chain/beaconProposerCache.js");
+vi.mock("../../src/chain/shufflingCache.js");
 vi.mock("../../src/chain/regen/index.js");
 vi.mock("../../src/chain/lightClient/index.js");
 vi.mock("../../src/chain/index.js", async (requireActual) => {
@@ -75,6 +78,7 @@ vi.mock("../../src/chain/index.js", async (requireActual) => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       beaconProposerCache: new BeaconProposerCache(),
+      shufflingCache: new ShufflingCache(),
       produceBlock: vi.fn(),
       produceBlindedBlock: vi.fn(),
       getCanonicalBlockAtSlot: vi.fn(),
@@ -83,6 +87,7 @@ vi.mock("../../src/chain/index.js", async (requireActual) => {
       getHeadState: vi.fn(),
       updateBuilderStatus: vi.fn(),
       processBlock: vi.fn(),
+      regenStateForAttestationVerification: vi.fn(),
       close: vi.fn(),
       logger: getMockedLogger(),
       regen: new QueuedStateRegenerator({} as any),

--- a/packages/beacon-node/test/unit/chain/shufflingCache.test.ts
+++ b/packages/beacon-node/test/unit/chain/shufflingCache.test.ts
@@ -1,0 +1,54 @@
+import {describe, it, expect, beforeEach} from "vitest";
+
+import {getShufflingDecisionBlock} from "@lodestar/state-transition";
+// eslint-disable-next-line import/no-relative-packages
+import {generateTestCachedBeaconStateOnlyValidators} from "../../../../state-transition/test/perf/util.js";
+import {ShufflingCache} from "../../../src/chain/shufflingCache.js";
+
+describe("ShufflingCache", function () {
+  const vc = 64;
+  const stateSlot = 100;
+  const state = generateTestCachedBeaconStateOnlyValidators({vc, slot: stateSlot});
+  const currentEpoch = state.epochCtx.currentShuffling.epoch;
+  let shufflingCache: ShufflingCache;
+
+  beforeEach(() => {
+    shufflingCache = new ShufflingCache(null, {maxShufflingCacheEpochs: 1});
+    shufflingCache.processState(state, currentEpoch);
+  });
+
+  it("should get shuffling from cache", async function () {
+    const decisionRoot = getShufflingDecisionBlock(state, currentEpoch);
+    expect(await shufflingCache.get(currentEpoch, decisionRoot)).to.deep.equal(state.epochCtx.currentShuffling);
+  });
+
+  it("should bound by maxSize(=1)", async function () {
+    const decisionRoot = getShufflingDecisionBlock(state, currentEpoch);
+    expect(await shufflingCache.get(currentEpoch, decisionRoot)).to.deep.equal(state.epochCtx.currentShuffling);
+    // insert promises at the same epoch does not prune the cache
+    shufflingCache.insertPromise(currentEpoch, "0x00");
+    expect(await shufflingCache.get(currentEpoch, decisionRoot)).to.deep.equal(state.epochCtx.currentShuffling);
+    // insert shufflings at other epochs does prune the cache
+    shufflingCache.processState(state, currentEpoch + 1);
+    // the current shuffling is not available anymore
+    expect(await shufflingCache.get(currentEpoch, decisionRoot)).to.be.null;
+  });
+
+  it("should return shuffling from promise", async function () {
+    const nextDecisionRoot = getShufflingDecisionBlock(state, currentEpoch + 1);
+    shufflingCache.insertPromise(currentEpoch + 1, nextDecisionRoot);
+    const shufflingRequest0 = shufflingCache.get(currentEpoch + 1, nextDecisionRoot);
+    const shufflingRequest1 = shufflingCache.get(currentEpoch + 1, nextDecisionRoot);
+    shufflingCache.processState(state, currentEpoch + 1);
+    expect(await shufflingRequest0).to.deep.equal(state.epochCtx.nextShuffling);
+    expect(await shufflingRequest1).to.deep.equal(state.epochCtx.nextShuffling);
+  });
+
+  it("should support up to 2 promises at a time", async function () {
+    // insert 2 promises at the same epoch
+    shufflingCache.insertPromise(currentEpoch, "0x00");
+    shufflingCache.insertPromise(currentEpoch, "0x01");
+    // inserting other promise should throw error
+    expect(() => shufflingCache.insertPromise(currentEpoch, "0x02")).to.throw();
+  });
+});

--- a/packages/beacon-node/test/unit/chain/validation/aggregateAndProof.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/aggregateAndProof.test.ts
@@ -2,7 +2,6 @@ import {toHexString} from "@chainsafe/ssz";
 import {describe, it} from "vitest";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {phase0, ssz} from "@lodestar/types";
-import {processSlots} from "@lodestar/state-transition";
 // eslint-disable-next-line import/no-relative-packages
 import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../state-transition/test/perf/util.js";
 import {IBeaconChain} from "../../../../src/chain/index.js";
@@ -14,7 +13,6 @@ import {
   getAggregateAndProofValidData,
   AggregateAndProofValidDataOpts,
 } from "../../../utils/validationData/aggregateAndProof.js";
-import {IStateRegenerator} from "../../../../src/chain/regen/interface.js";
 
 describe("chain / validation / aggregateAndProof", () => {
   const vc = 64;
@@ -110,22 +108,6 @@ describe("chain / validation / aggregateAndProof", () => {
     signedAggregateAndProof.message.aggregate.data.target.root = UNKNOWN_ROOT;
 
     await expectError(chain, signedAggregateAndProof, AttestationErrorCode.INVALID_TARGET_ROOT);
-  });
-
-  it("NO_COMMITTEE_FOR_SLOT_AND_INDEX", async () => {
-    const {chain, signedAggregateAndProof} = getValidData();
-    // slot is out of the commitee range
-    // simulate https://github.com/ChainSafe/lodestar/issues/4396
-    // this way we cannot get committeeIndices
-    const committeeState = processSlots(
-      getState(),
-      signedAggregateAndProof.message.aggregate.data.slot + 2 * SLOTS_PER_EPOCH
-    );
-    (chain as {regen: IStateRegenerator}).regen = {
-      getState: async () => committeeState,
-    } as Partial<IStateRegenerator> as IStateRegenerator;
-
-    await expectError(chain, signedAggregateAndProof, AttestationErrorCode.NO_COMMITTEE_FOR_SLOT_AND_INDEX);
   });
 
   it("EMPTY_AGGREGATION_BITFIELD", async () => {

--- a/packages/beacon-node/test/unit/util/dependentRoot.test.ts
+++ b/packages/beacon-node/test/unit/util/dependentRoot.test.ts
@@ -1,0 +1,67 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from "vitest";
+import {EpochDifference, ProtoBlock} from "@lodestar/fork-choice";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {getShufflingDependentRoot} from "../../../src/util/dependentRoot.js";
+import {MockedBeaconChain, getMockedBeaconChain} from "../../__mocks__/mockedBeaconChain.js";
+
+describe("util / getShufflingDependentRoot", () => {
+  let forkchoiceStub: MockedBeaconChain["forkChoice"];
+
+  const headBattHeadBlock = {
+    slot: 100,
+  } as ProtoBlock;
+  const blockEpoch = computeEpochAtSlot(headBattHeadBlock.slot);
+
+  beforeEach(() => {
+    forkchoiceStub = getMockedBeaconChain().forkChoice;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return current dependent root", () => {
+    const attEpoch = blockEpoch;
+    forkchoiceStub.getDependentRoot.mockImplementation((block, epochDiff) => {
+      if (block === headBattHeadBlock && epochDiff === EpochDifference.previous) {
+        return "current";
+      } else {
+        throw new Error("should not be called");
+      }
+    });
+    expect(getShufflingDependentRoot(forkchoiceStub, attEpoch, blockEpoch, headBattHeadBlock)).to.be.equal("current");
+  });
+
+  it("should return next dependent root", () => {
+    const attEpoch = blockEpoch + 1;
+    // forkchoiceStub.getDependentRoot.withArgs(headBattHeadBlock, EpochDifference.current).returns("previous");
+    forkchoiceStub.getDependentRoot.mockImplementation((block, epochDiff) => {
+      if (block === headBattHeadBlock && epochDiff === EpochDifference.current) {
+        return "0x000";
+      } else {
+        throw new Error("should not be called");
+      }
+    });
+    expect(getShufflingDependentRoot(forkchoiceStub, attEpoch, blockEpoch, headBattHeadBlock)).to.be.equal("0x000");
+  });
+
+  it("should return head block root as dependent root", () => {
+    const attEpoch = blockEpoch + 2;
+    // forkchoiceStub.getDependentRoot.throws("should not be called");
+    forkchoiceStub.getDependentRoot.mockImplementation(() => {
+      throw Error("should not be called");
+    });
+    expect(getShufflingDependentRoot(forkchoiceStub, attEpoch, blockEpoch, headBattHeadBlock)).to.be.equal(
+      headBattHeadBlock.blockRoot
+    );
+  });
+
+  it("should throw error if attestation epoch is before head block epoch", () => {
+    const attEpoch = blockEpoch - 1;
+    // forkchoiceStub.getDependentRoot.throws("should not be called");
+    forkchoiceStub.getDependentRoot.mockImplementation(() => {
+      throw Error("should not be called");
+    });
+    expect(() => getShufflingDependentRoot(forkchoiceStub, attEpoch, blockEpoch, headBattHeadBlock)).to.throw();
+  });
+});

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -24,6 +24,7 @@ export type ChainArgs = {
   emitPayloadAttributes?: boolean;
   broadcastValidationStrictness?: string;
   "chain.minSameMessageSignatureSetsToBatch"?: number;
+  "chain.maxShufflingCacheEpochs"?: number;
 };
 
 export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
@@ -49,6 +50,7 @@ export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
     broadcastValidationStrictness: args["broadcastValidationStrictness"],
     minSameMessageSignatureSetsToBatch:
       args["chain.minSameMessageSignatureSetsToBatch"] ?? defaultOptions.chain.minSameMessageSignatureSetsToBatch,
+    maxShufflingCacheEpochs: args["chain.maxShufflingCacheEpochs"] ?? defaultOptions.chain.maxShufflingCacheEpochs,
   };
 }
 
@@ -191,6 +193,14 @@ Will double processing times. Use only for debugging purposes.",
     description: "Minimum number of same message signature sets to batch",
     type: "number",
     default: defaultOptions.chain.minSameMessageSignatureSetsToBatch,
+    group: "chain",
+  },
+
+  "chain.maxShufflingCacheEpochs": {
+    hidden: true,
+    description: "Maximum ShufflingCache epochs to keep in memory",
+    type: "number",
+    default: defaultOptions.chain.maxShufflingCacheEpochs,
     group: "chain",
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -34,6 +34,7 @@ describe("options / beaconNodeOptions", () => {
       "chain.archiveStateEpochFrequency": 1024,
       "chain.trustedSetup": "",
       "chain.minSameMessageSignatureSetsToBatch": 32,
+      "chain.maxShufflingCacheEpochs": 100,
       emitPayloadAttributes: false,
 
       eth1: true,
@@ -135,6 +136,7 @@ describe("options / beaconNodeOptions", () => {
         emitPayloadAttributes: false,
         trustedSetup: "",
         minSameMessageSignatureSetsToBatch: 32,
+        maxShufflingCacheEpochs: 100,
       },
       eth1: {
         enabled: true,


### PR DESCRIPTION
**Motivation**

- To verify attestations, we actually don't need the state but only shuffling
- In case the head state of attestation is not available, lodestar may have to do a regen, or not able to validate attestation

**Description**

- This PR started with #6008 and addressed comments from there
- Implement a ShufflingCache, add new shufflings when we pass epoch transitions
  - Every shuffling is keyed by epoch and dependent root which is the last block root of the previous 2 epochs
- Support regen state which is tracked as a promise inside ShufflingCache
  - this is not needed with the default chain option of maxSkippedSlot = 32, handle just in case
  - if there are multiple requests of the same shuffling, only do the regen once
  - also support 1 regen at a time, bound inside ShufflingCache

this is a prerequisite for #6008

Closes https://github.com/ChainSafe/lodestar/issues/2848
