### PR TITLE
fix: the unknown block sync timeout

### DIFF
--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -1,4 +1,4 @@
-import {Logger, retry} from "@lodestar/utils";
+import {Logger} from "@lodestar/utils";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Slot} from "@lodestar/types";
 import {INetwork, NetworkEvent, NetworkEventData} from "../network/index.js";

--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -73,7 +73,7 @@ export class BeaconSync implements IBeaconSync {
     // Having one epoch time for the node to connect to peers and start a syncing process
     const epochCheckFotSyncSlot = syncStartSlot + SLOTS_PER_EPOCH;
     const initiateEpochCheckForSync = (): void => {
-      if (epochCheckFotSyncSlot >= this.chain.clock.currentSlot) {
+      if (this.chain.clock.currentSlot > epochCheckFotSyncSlot) {
         this.logger.info("Initiating epoch check for sync progress");
         this.chain.clock.off(ClockEvent.slot, initiateEpochCheckForSync);
         this.chain.clock.on(ClockEvent.epoch, this.onClockEpoch);

--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -71,9 +71,9 @@ export class BeaconSync implements IBeaconSync {
       // So we are adding a particular delay to ensure that the `unknownBlockSync` is enabled.
       const syncStartSlot = this.chain.clock.currentSlot;
       // Having one epoch time for the node to connect to peers and start a syncing process
-      const epochCheckFotSyncSlot = syncStartSlot + SLOTS_PER_EPOCH;
+      const epochCheckForSyncSlot = syncStartSlot + SLOTS_PER_EPOCH;
       const initiateEpochCheckForSync = (): void => {
-        if (this.chain.clock.currentSlot > epochCheckFotSyncSlot) {
+        if (this.chain.clock.currentSlot > epochCheckForSyncSlot) {
           this.logger.info("Initiating epoch check for sync progress");
           this.chain.clock.off(ClockEvent.slot, initiateEpochCheckForSync);
           this.chain.clock.on(ClockEvent.epoch, this.onClockEpoch);

--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -57,29 +57,30 @@ export class BeaconSync implements IBeaconSync {
       this.rangeSync.on(RangeSyncEvent.completedChain, this.updateSyncState);
       this.network.events.on(NetworkEvent.peerConnected, this.addPeer);
       this.network.events.on(NetworkEvent.peerDisconnected, this.removePeer);
+      this.chain.clock.on(ClockEvent.epoch, this.onClockEpoch);
     } else {
       // test code, this is needed for Unknown block sync sim test
       this.unknownBlockSync.subscribeToNetwork();
       this.logger.debug("RangeSync disabled.");
-    }
 
-    // In case node is started with `rangeSync` disabled and `unknownBlockSync` is enabled.
-    // If the epoch boundary happens right away the `onClockEpoch` will check for the `syncDiff` and if
-    // it's more than 2 epoch will disable the disabling the `unknownBlockSync` as well.
-    // This will result into node hanging on the head slot and not syncing any blocks.
-    // This was the scenario in the test case `Unknown block sync` in `packages/cli/test/sim/multi_fork.test.ts`
-    // So we are adding a particular delay to ensure that the `unknownBlockSync` is enabled.
-    const syncStartSlot = this.chain.clock.currentSlot;
-    // Having one epoch time for the node to connect to peers and start a syncing process
-    const epochCheckFotSyncSlot = syncStartSlot + SLOTS_PER_EPOCH;
-    const initiateEpochCheckForSync = (): void => {
-      if (this.chain.clock.currentSlot > epochCheckFotSyncSlot) {
-        this.logger.info("Initiating epoch check for sync progress");
-        this.chain.clock.off(ClockEvent.slot, initiateEpochCheckForSync);
-        this.chain.clock.on(ClockEvent.epoch, this.onClockEpoch);
-      }
-    };
-    this.chain.clock.on(ClockEvent.slot, initiateEpochCheckForSync);
+      // In case node is started with `rangeSync` disabled and `unknownBlockSync` is enabled.
+      // If the epoch boundary happens right away the `onClockEpoch` will check for the `syncDiff` and if
+      // it's more than 2 epoch will disable the disabling the `unknownBlockSync` as well.
+      // This will result into node hanging on the head slot and not syncing any blocks.
+      // This was the scenario in the test case `Unknown block sync` in `packages/cli/test/sim/multi_fork.test.ts`
+      // So we are adding a particular delay to ensure that the `unknownBlockSync` is enabled.
+      const syncStartSlot = this.chain.clock.currentSlot;
+      // Having one epoch time for the node to connect to peers and start a syncing process
+      const epochCheckFotSyncSlot = syncStartSlot + SLOTS_PER_EPOCH;
+      const initiateEpochCheckForSync = (): void => {
+        if (this.chain.clock.currentSlot > epochCheckFotSyncSlot) {
+          this.logger.info("Initiating epoch check for sync progress");
+          this.chain.clock.off(ClockEvent.slot, initiateEpochCheckForSync);
+          this.chain.clock.on(ClockEvent.epoch, this.onClockEpoch);
+        }
+      };
+      this.chain.clock.on(ClockEvent.slot, initiateEpochCheckForSync);
+    }
 
     if (metrics) {
       metrics.syncStatus.addCollect(() => this.scrapeMetrics(metrics));


### PR DESCRIPTION
**Motivation**

Make the sim tests stable.

**Description**

Found this edge case which was causing timeout for sim test quite often. 

If a node is started on the epoch boundary then the `unknownBlockSync` get disabled and node hang up on the head. 

**Steps to test or reproduce**

- Run all test. 