### PR TITLE
fix: remove extra white space in logs if context is empty

### DIFF
--- a/packages/logger/src/utils/format.ts
+++ b/packages/logger/src/utils/format.ts
@@ -1,4 +1,5 @@
 import winston from "winston";
+import {isEmptyObject} from "@lodestar/utils";
 import {LoggerOptions, TimestampFormatCode} from "../interface.js";
 import {logCtxToJson, logCtxToString, LogData} from "./json.js";
 import {formatEpochSlotTime} from "./timeFormat.js";
@@ -86,7 +87,7 @@ function humanReadableTemplateFn(_info: {[key: string]: any; level: string; mess
 
   str += `[${infoString}] ${info.level.padStart(infoPad)}: ${info.message}`;
 
-  if (info.context !== undefined) str += " " + logCtxToString(info.context);
+  if (info.context !== undefined && !isEmptyObject(info.context)) str += " " + logCtxToString(info.context);
   if (info.error !== undefined) str += " - " + logCtxToString(info.error);
 
   return str;

--- a/packages/logger/test/fixtures/loggerFormats.ts
+++ b/packages/logger/test/fixtures/loggerFormats.ts
@@ -39,10 +39,27 @@ export const formatsTestCases: (TestCase | (() => TestCase))[] = [
       id: "regular log with error",
       opts: {module: "test"},
       message: "foo bar",
+      context: {},
       error: error,
       output: {
         human: `[test]             \u001b[33mwarn\u001b[39m: foo bar - err message\n${error.stack}`,
-        json: '{"error":{"message":"err message","stack":"$STACK"},"level":"warn","message":"foo bar","module":"test"}',
+        json: '{"context":{},"error":{"message":"err message","stack":"$STACK"},"level":"warn","message":"foo bar","module":"test"}',
+      },
+    };
+  },
+
+  () => {
+    const error = new Error("err message");
+    error.stack = "$STACK";
+    return {
+      id: "regular log with error and metadata",
+      opts: {module: "test"},
+      message: "foo bar",
+      context: {meta: "data"},
+      error: error,
+      output: {
+        human: `[test]             \u001b[33mwarn\u001b[39m: foo bar meta=data - err message\n${error.stack}`,
+        json: '{"context":{"meta":"data"},"error":{"message":"err message","stack":"$STACK"},"level":"warn","message":"foo bar","module":"test"}',
       },
     };
   },

--- a/packages/utils/src/objects.ts
+++ b/packages/utils/src/objects.ts
@@ -29,11 +29,11 @@ export function toExpectedCase(
   }
 }
 
-function isObjectObject(val: unknown): boolean {
+function isObjectObject(val: unknown): val is object {
   return val != null && typeof val === "object" && Array.isArray(val) === false;
 }
 
-export function isPlainObject(o: unknown): boolean {
+export function isPlainObject(o: unknown): o is object {
   if (isObjectObject(o) === false) return false;
 
   // If has modified constructor
@@ -51,6 +51,10 @@ export function isPlainObject(o: unknown): boolean {
 
   // Most likely a plain Object
   return true;
+}
+
+export function isEmptyObject(value: unknown): boolean {
+  return isObjectObject(value) && Object.keys(value).length === 0;
 }
 
 /**


### PR DESCRIPTION
**Motivation**

Noticed that an extra white space is added to log if context is an empty object `{}`

Current
```
Oct-17 18:07:21.655[rest]            error: Req req-pt5m registerValidator error  - Execution builder not enabled
```

Expected
```
Oct-17 18:07:21.655[rest]            error: Req req-pt5m registerValidator error - Execution builder not enabled
```

**Description**

Additionally check if provided object is empty and handle it the same way as undefined values. In most places, an empty object is passed to the logger instead of undefined.

