### PR TITLE
docs: add twitter link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - :writing_hand: If you have questions [submit an issue](https://github.com/ChainSafe/lodestar/issues/new) or join us on [Discord](https://discord.gg/yjyvFRP)!
   [![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/aMxzVcr)
 - :rotating_light: Please note our [security policy](./SECURITY.md).
-- :mailbox_with_mail: Sign up to our [mailing list](https://chainsafe.typeform.com/lodestar) for announcements and any critical information about Lodestar.
+- :bird: Follow Lodestar on [Twitter](https://twitter.com/lodestar_eth) for announcements and updates! [![Twitter Follow](https://img.shields.io/twitter/follow/lodestar_eth)](https://twitter.com/lodestar_eth)
 
 ## Prerequisites
 


### PR DESCRIPTION
To remove old mailing list signup link and replace it with following us on Twitter. Replaces #6041 for consistency with our readme page.
