### PR TITLE
feat: support ssz response for validators endpoint

### DIFF
--- a/packages/api/src/beacon/client/beacon.ts
+++ b/packages/api/src/beacon/client/beacon.ts
@@ -1,8 +1,18 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Api, ReqTypes, routesData, getReqSerializers, getReturnTypes, BlockId} from "../routes/beacon/index.js";
+import {
+  Api,
+  ReqTypes,
+  routesData,
+  getReqSerializers,
+  getReturnTypes,
+  BlockId,
+  StateId,
+  ValidatorFilters,
+} from "../routes/beacon/index.js";
 import {IHttpClient, generateGenericJsonClient, getFetchOptsSerializers} from "../../utils/client/index.js";
 import {ResponseFormat} from "../../interfaces.js";
 import {BlockResponse, BlockV2Response} from "../routes/beacon/block.js";
+import {ValidatorsResponse} from "../routes/beacon/state.js";
 
 /**
  * REST HTTP client for beacon routes
@@ -16,6 +26,23 @@ export function getClient(config: ChainForkConfig, httpClient: IHttpClient): Api
 
   return {
     ...client,
+    async getStateValidators<T extends ResponseFormat = "json">(
+      stateId: StateId,
+      filters?: ValidatorFilters,
+      format?: T
+    ) {
+      if (format === "ssz") {
+        const res = await httpClient.arrayBuffer({
+          ...fetchOptsSerializer.getStateValidators(stateId, filters, format),
+        });
+        return {
+          ok: true,
+          response: new Uint8Array(res.body),
+          status: res.status,
+        } as ValidatorsResponse<T>;
+      }
+      return client.getStateValidators(stateId, filters, format);
+    },
     async getBlock<T extends ResponseFormat = "json">(blockId: BlockId, format?: T) {
       if (format === "ssz") {
         const res = await httpClient.arrayBuffer({

--- a/packages/api/src/beacon/server/beacon.ts
+++ b/packages/api/src/beacon/server/beacon.ts
@@ -16,6 +16,18 @@ export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerR
   return {
     ...serverRoutes,
     // Non-JSON routes. Return JSON or binary depending on "accept" header
+    getStateValidators: {
+      ...serverRoutes.getStateValidators,
+      handler: async (req) => {
+        const response = await api.getStateValidators(...reqSerializers.getStateValidators.parseReq(req));
+        if (response instanceof Uint8Array) {
+          // Fastify 3.x.x will automatically add header `Content-Type: application/octet-stream` if Buffer
+          return Buffer.from(response);
+        } else {
+          return returnTypes.getStateValidators.toJson(response);
+        }
+      },
+    },
     getBlock: {
       ...serverRoutes.getBlock,
       handler: async (req) => {

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -143,7 +143,7 @@ export const testData: GenericServerTestCases<Api> = {
     },
   },
   getStateValidators: {
-    args: ["head", {id: [pubkeyHex, "1300"], status: ["active_ongoing"]}],
+    args: ["head", {id: [pubkeyHex, "1300"], status: ["active_ongoing"]}, "json"],
     res: {executionOptimistic: true, data: [validatorResponse]},
   },
   getStateValidator: {

--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -55,7 +55,7 @@ export function getBeaconStateApi({
       };
     },
 
-    async getStateValidators(stateId, filters) {
+    async getStateValidators(stateId, filters, format) {
       const {state, executionOptimistic} = await resolveStateId(chain, stateId);
       const currentEpoch = getCurrentEpoch(state);
       const {validators, balances} = state; // Get the validators sub tree once for all the loop
@@ -80,16 +80,21 @@ export function getBeaconStateApi({
             validatorResponses.push(validatorResponse);
           }
         }
-        return {
-          executionOptimistic,
-          data: validatorResponses,
-        };
+
+        return format === "ssz"
+          ? routes.beacon.state.ValidatorsResponseType.serialize(validatorResponses)
+          : {
+              executionOptimistic,
+              data: validatorResponses,
+            };
       } else if (filters?.status) {
         const validatorsByStatus = filterStateValidatorsByStatus(filters.status, state, pubkey2index, currentEpoch);
-        return {
-          executionOptimistic,
-          data: validatorsByStatus,
-        };
+        return format === "ssz"
+          ? routes.beacon.state.ValidatorsResponseType.serialize(validatorsByStatus)
+          : {
+              executionOptimistic,
+              data: validatorsByStatus,
+            };
       }
 
       // TODO: This loops over the entire state, it's a DOS vector
@@ -100,10 +105,12 @@ export function getBeaconStateApi({
         resp.push(toValidatorResponse(i, validatorsArr[i], balancesArr[i], currentEpoch));
       }
 
-      return {
-        executionOptimistic,
-        data: resp,
-      };
+      return format === "ssz"
+        ? routes.beacon.state.ValidatorsResponseType.serialize(resp)
+        : {
+            executionOptimistic,
+            data: resp,
+          };
     },
 
     async getStateValidator(stateId, validatorId) {

--- a/packages/cli/test/sim/endpoints.test.ts
+++ b/packages/cli/test/sim/endpoints.test.ts
@@ -95,6 +95,16 @@ await env.tracker.assert(
 );
 
 await env.tracker.assert(
+  "should return validators as SSZ response when getStateValidators is called with format 'ssz'",
+  async () => {
+    const sszRes = await node.api.beacon.getStateValidators("head", {}, "ssz");
+    ApiError.assert(sszRes);
+    const sszStateValidators = routes.beacon.state.ValidatorsResponseType.deserialize(sszRes.response);
+    expect(sszStateValidators).to.deep.equal(stateValidators);
+  }
+);
+
+await env.tracker.assert(
   "should return the validator when getStateValidator is called with the validator index",
   async () => {
     const validatorIndex = 0;


### PR DESCRIPTION
**Motivation**

- https://github.com/ethereum/beacon-APIs/issues/333

**Description**

Support SSZ response for validators endpoint. This is an initial step to systematically support returning ssz-encoded responses throughout all/most API endpoints (https://github.com/ChainSafe/lodestar/issues/5128).

This PR also gives good insights on what it required to support SSZ response for a single API, this is not acceptable and needs to be addressed if we want broader SSZ support with low maintenance cost and an easy way to add new APIs.

- Depends on https://github.com/ChainSafe/lodestar/pull/6059