### PR TITLE
fix: close REST API server before closing network

### DIFF
--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -317,10 +317,10 @@ export class BeaconNode {
       this.status = BeaconNodeStatus.closing;
       this.sync.close();
       this.backfillSync?.close();
+      if (this.restApi) await this.restApi.close();
       await this.network.close();
       if (this.metricsServer) await this.metricsServer.close();
       if (this.monitoring) this.monitoring.close();
-      if (this.restApi) await this.restApi.close();
       await this.chain.persistToDisk();
       await this.chain.close();
       if (this.controller) this.controller.abort();


### PR DESCRIPTION
**Motivation**

Some APIs depend on the network to be operational, e.g. `submitPoolAttestations` and `publishAggregateAndProofs` but the network itself has no dependency to the REST API server, hence it is better if we close the REST API server first and stop accepting new requests before starting to close the network.

Errors that might happen due to current close sequence

```
Oct-24 08:56:52.194[api]             error: Error on submitPoolAttestations [22] slot=6802484, index=17 - PublishError.InsufficientPeers
Error: PublishError.InsufficientPeers
    at Eth2Gossipsub.publish (file:///home/devops/goerli/lodestar/node_modules/@chainsafe/libp2p-gossipsub/dist/src/index.js:1547:19)
    at async NetworkCore.publishGossip (file:///home/devops/goerli/lodestar/packages/beacon-node/lib/network/core/networkCore.js:290:32)
```

```
Oct-24 08:56:56.163[rest]            error: Req req-54t0 publishAggregateAndProofs error - Multiple errors on publishAggregateAndProofs
PublishError.InsufficientPeers
PublishError.InsufficientPeers
Error: Multiple errors on publishAggregateAndProofs
PublishError.InsufficientPeers
PublishError.InsufficientPeers
    at Object.publishAggregateAndProofs (file:///home/devops/goerli/lodestar/packages/beacon-node/src/api/impl/validator/index.ts:668:15)
    at Object.handler (file:///home/devops/goerli/lodestar/packages/api/src/utils/server/genericJsonServer.ts:45:23)
```

Note that these errors are really rare in normal circumstances as the time between closing the network and the REST API server is usually just a few milliseconds but due to current libp2p issue https://github.com/ChainSafe/lodestar/issues/6053 this issue becomes more apparent.


**Description**

Close REST API server before closing network

The only reason I see why we would close the network first is that some APIs are still functional if they only rely on chain data but we are already closing the connections gracefully (https://github.com/ChainSafe/lodestar/pull/5786) which gives pending requests some time to complete.
