### PR TITLE
fix: transfer cache in prepareNextSlot epoch transition

### DIFF
--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -100,7 +100,8 @@ export class PrepareNextSlotScheduler {
       const prepareState = await this.chain.regen.getBlockSlotState(
         headRoot,
         prepareSlot,
-        {dontTransferCache: true},
+        // the 1st slot of next epoch will likely use this Previous Root Checkpoint state so we transfer cache here
+        {dontTransferCache: false},
         RegenCaller.precomputeEpoch
       );
 

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -149,14 +149,7 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     if (parentEpoch < blockEpoch) {
       const checkpointState = this.checkpointStateCache.getLatest(parentRoot, blockEpoch);
       if (checkpointState && computeEpochAtSlot(checkpointState.slot) === blockEpoch) {
-        // TODO: Miss-use of checkpointStateCache here
         return checkpointState;
-        // console.error({
-        //   "checkpointState.slot": checkpointState.slot,
-        //   "block.slot": block.slot,
-        //   blockEpoch,
-        //   blockEpochStartSlot: computeStartSlotAtEpoch(blockEpoch),
-        // });
       }
     }
 


### PR DESCRIPTION
**Motivation**

While investigating #6063 I found we only transfer cache when verifying block https://github.com/ChainSafe/lodestar/blob/421fd1a8db6b1e4e381b51e5d211b619e6cbe4da/packages/beacon-node/src/chain/blocks/verifyBlock.ts#L66 as part of transition

However at epoch boundary when `getPreState()` we get the checkpoint state instead of state of previous epoch to save us an epoch transition https://github.com/ChainSafe/lodestar/blob/421fd1a8db6b1e4e381b51e5d211b619e6cbe4da/packages/beacon-node/src/chain/regen/queued.ts#L150

**Description**

- Also transfer cache at `prepareNextSlot()` when we cache Previous Root Checkpoint State

related to #6063

**Test Result**
Epoch transition of this branch vs `unstable` group

| type of node | feature branch | unstable |
|--------------|----------------|----------|
|mainnet.        | 0.96s                | 1.1s. |
| 64                | 0.73s                   | 0.81s|
| 16.                | 3.3s                    | 4s|
|sm1v           | 2.15s               | 3.25s|
|novc             | 4.6s.                  | 1.6s |


on all types of node I see lower epoch transition time except for `novc` where `unstable` is significantly faster, not sure why it is like that but epoch transition on `novc` is inconsistent between groups so I'd not trust it