### PR TITLE
fix: handle uncaught exceptions when getting proposer duties

### DIFF
--- a/packages/validator/src/services/blockDuties.ts
+++ b/packages/validator/src/services/blockDuties.ts
@@ -133,7 +133,9 @@ export class BlockDutiesService {
     const isLastSlotEpoch = computeStartSlotAtEpoch(nextEpoch) === currentSlot + 1;
     if (isLastSlotEpoch) {
       // no need to await for other steps, just poll proposers for next epoch
-      void this.pollBeaconProposersNextEpoch(currentSlot, nextEpoch, signal);
+      this.pollBeaconProposersNextEpoch(currentSlot, nextEpoch, signal).catch((e) => {
+        this.logger.error("Error on pollBeaconProposersNextEpoch", {}, e);
+      });
     }
 
     // Notify the block proposal service for any proposals that we have in our cache.
@@ -163,7 +165,7 @@ export class BlockDutiesService {
   }
 
   /**
-   * This is to avoid some delay on the first slot of the opoch when validators has proposal duties.
+   * This is to avoid some delay on the first slot of the epoch when validators have proposal duties.
    * See https://github.com/ChainSafe/lodestar/issues/5792
    */
   private async pollBeaconProposersNextEpoch(currentSlot: Slot, nextEpoch: Epoch, signal: AbortSignal): Promise<void> {


### PR DESCRIPTION
**Motivation**

`pollBeaconProposersNextEpoch` might throw an error, e.g. due to node syncing or offline which is currently not handled.

```
Oct-29 21:49:10.003[]                error: uncaughtException: Error on getProposerDuties - Service Unavailable: Node is syncing - waiting for peers
Error: Error on getProposerDuties - Service Unavailable: Node is syncing - waiting for peers
    at Function.assert (file:///usr/app/packages/api/src/utils/client/httpClient.ts:44:13)
    at BlockDutiesService.pollBeaconProposers (file:///usr/app/packages/validator/src/services/blockDuties.ts:185:14)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at BlockDutiesService.pollBeaconProposersNextEpoch (file:///usr/app/packages/validator/src/services/blockDuties.ts:175:5) Error on getProposerDuties - Service Unavailable: Node is syncing - waiting for peers
```

Usually, an error like this due to node syncing should only be a one liner (without stacktrace) and logged as warn.



**Description**

Handle uncaught exceptions when getting proposer duties
