### PR TITLE
refactor: repurpose --builder flag to alias maxprofit builder.selection and turn builder off by default

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -1,7 +1,13 @@
 import path from "node:path";
 import {setMaxListeners} from "node:events";
 import {LevelDbController} from "@lodestar/db";
-import {ProcessShutdownCallback, SlashingProtection, Validator, ValidatorProposerConfig} from "@lodestar/validator";
+import {
+  ProcessShutdownCallback,
+  SlashingProtection,
+  Validator,
+  ValidatorProposerConfig,
+  defaultOptions,
+} from "@lodestar/validator";
 import {routes} from "@lodestar/api";
 import {getMetrics, MetricsRegister} from "@lodestar/validator";
 import {
@@ -216,7 +222,9 @@ function getProposerConfigFromArgs(
     feeRecipient: args.suggestedFeeRecipient ? parseFeeRecipient(args.suggestedFeeRecipient) : undefined,
     builder: {
       gasLimit: args.defaultGasLimit,
-      selection: parseBuilderSelection(args["builder.selection"]),
+      selection: parseBuilderSelection(
+        args["builder.selection"] ?? (args["builder"] ? defaultOptions.builderAliasSelection : undefined)
+      ),
     },
   };
 

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -233,7 +233,7 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
 
   builder: {
     type: "boolean",
-    description: `An alias for \`--builder.selection ${defaultOptions.builderAliasSelection}\` for the builder flow, ignored if \`--builder.selection\` explicitly provided`,
+    description: `An alias for \`--builder.selection ${defaultOptions.builderAliasSelection}\` for the builder flow, ignored if \`--builder.selection\` is explicitly provided`,
     group: "builder",
   },
 

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -233,14 +233,13 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
 
   builder: {
     type: "boolean",
-    description: "Enable execution payload production via a builder for better rewards",
+    description: `An alias for \`--builder.selection ${defaultOptions.builderAliasSelection}\` for the builder flow, ignored if \`--builder.selection\` explicitly provided`,
     group: "builder",
-    deprecated: "enabling or disabling builder flow is now solely managed by `builder.selection` flag",
   },
 
   "builder.selection": {
     type: "string",
-    description: "Default builder block selection strategy: `maxprofit`, `builderalways`, or `builderonly`",
+    description: "Builder block selection strategy `maxprofit`, `builderalways`, `builderonly` or `executiononly`",
     defaultDescription: `\`${defaultOptions.builderSelection}\``,
     group: "builder",
   },

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -122,7 +122,8 @@ type ValidatorData = ProposerConfig & {
 export const defaultOptions = {
   suggestedFeeRecipient: "0x0000000000000000000000000000000000000000",
   defaultGasLimit: 30_000_000,
-  builderSelection: routes.validator.BuilderSelection.MaxProfit,
+  builderSelection: routes.validator.BuilderSelection.ExecutionOnly,
+  builderAliasSelection: routes.validator.BuilderSelection.MaxProfit,
   // turn it off by default, turn it back on once other clients support v3 api
   useProduceBlockV3: false,
 };

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -284,6 +284,18 @@ export class Validator {
     await assertEqualGenesis(opts, genesis);
     logger.info("Verified connected beacon node and validator have the same genesisValidatorRoot");
 
+    const {useProduceBlockV3, valProposerConfig} = opts;
+    const defaultBuilderSelection =
+      valProposerConfig?.defaultConfig.builder?.selection ?? defaultOptions.builderSelection;
+    const strictFeeRecipientCheck = valProposerConfig?.defaultConfig.strictFeeRecipientCheck ?? false;
+    const suggestedFeeRecipient = valProposerConfig?.defaultConfig.feeRecipient ?? defaultOptions.suggestedFeeRecipient;
+    logger.info("Initializing validator", {
+      useProduceBlockV3,
+      defaultBuilderSelection,
+      suggestedFeeRecipient,
+      strictFeeRecipientCheck,
+    });
+
     return Validator.init(opts, genesis, metrics);
   }
 


### PR DESCRIPTION
On some discussion and feedback turning the builder off by default on validator unless `--builder.selection` is provided explicitly or via the `maxprofit` alias `--builder`

this brings us more compatible to the previous use of the builder args on the validator with the builder off if no `--builder` & `--builder.selection` is provided.

however this flag is still optional and just an alias and can be ignored if an explicit `--builder.selection` is provided