### PR TITLE
refactor: shift usage to publishblock v2 endpoint, cleanup v1 post deneb

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -193,7 +193,7 @@ export type Api = {
 
   publishBlockV2(
     blockOrContents: allForks.SignedBeaconBlockOrContents,
-    opts: {broadcastValidation?: BroadcastValidation}
+    opts?: {broadcastValidation?: BroadcastValidation}
   ): Promise<
     ApiClientResponse<
       {
@@ -341,7 +341,7 @@ export function getReqSerializers(config: ChainForkConfig): ReqSerializers<Api, 
     getBlockRoot: blockIdOnlyReq,
     publishBlock: reqOnlyBody(AllForksSignedBlockOrContents, Schema.Object),
     publishBlockV2: {
-      writeReq: (item, {broadcastValidation}) => ({
+      writeReq: (item, {broadcastValidation} = {}) => ({
         body: AllForksSignedBlockOrContents.toJson(item),
         query: {broadcast_validation: broadcastValidation},
       }),

--- a/packages/cli/test/sim/multi_fork.test.ts
+++ b/packages/cli/test/sim/multi_fork.test.ts
@@ -218,7 +218,7 @@ await connectNewNode(unknownBlockSync, env.nodes);
 await sleep(5000);
 
 try {
-  ApiError.assert(await unknownBlockSync.beacon.api.beacon.publishBlock(headForUnknownBlockSync.response.data));
+  ApiError.assert(await unknownBlockSync.beacon.api.beacon.publishBlockV2(headForUnknownBlockSync.response.data));
 
   env.tracker.record({
     message: "Publishing unknown block should fail",

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -178,7 +178,7 @@ export class BlockProposingService {
       ApiError.assert(
         isBlindedBeaconBlock(signedBlock.message)
           ? await this.api.beacon.publishBlindedBlock(signedBlock as allForks.SignedBlindedBeaconBlock)
-          : await this.api.beacon.publishBlock(signedBlock as allForks.SignedBeaconBlock)
+          : await this.api.beacon.publishBlockV2(signedBlock as allForks.SignedBeaconBlock)
       );
     } else {
       ApiError.assert(
@@ -187,7 +187,7 @@ export class BlockProposingService {
               signedBlindedBlock: signedBlock,
               signedBlindedBlobSidecars: signedBlobSidecars,
             } as allForks.SignedBlindedBlockContents)
-          : await this.api.beacon.publishBlock({signedBlock, signedBlobSidecars} as allForks.SignedBlockContents)
+          : await this.api.beacon.publishBlockV2({signedBlock, signedBlobSidecars} as allForks.SignedBlockContents)
       );
     }
   };

--- a/packages/validator/test/unit/services/block.test.ts
+++ b/packages/validator/test/unit/services/block.test.ts
@@ -67,7 +67,7 @@ describe("BlockDutiesService", function () {
       ok: true,
       status: HttpStatusCode.OK,
     });
-    api.beacon.publishBlock.resolves();
+    api.beacon.publishBlockV2.resolves();
 
     // Trigger block production for slot 1
     const notifyBlockProductionFn = blockService["dutiesService"]["notifyBlockProductionFn"];
@@ -77,7 +77,7 @@ describe("BlockDutiesService", function () {
     await sleep(20, controller.signal);
 
     // Must have submitted the block received on signBlock()
-    expect(api.beacon.publishBlock.callCount).to.equal(1, "publishBlock() must be called once");
-    expect(api.beacon.publishBlock.getCall(0).args).to.deep.equal([signedBlock], "wrong publishBlock() args");
+    expect(api.beacon.publishBlockV2.callCount).to.equal(1, "publishBlock() must be called once");
+    expect(api.beacon.publishBlockV2.getCall(0).args).to.deep.equal([signedBlock], "wrong publishBlock() args");
   });
 });


### PR DESCRIPTION
publishblock v1 doesn't need to be supported or used - however cleanup to be done post deneb, still deprecation should be annouced along with some other endpoints (to be coordinated separately )

- added to deprecation/cleanup list https://github.com/ChainSafe/lodestar/issues/6085