### PR TITLE
feat: optimistically verify blocks even before all blobs available

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -4,7 +4,6 @@ import {
   computeTimeAtSlot,
   parseSignedBlindedBlockOrContents,
   reconstructFullBlockOrContents,
-  DataAvailableStatus,
 } from "@lodestar/state-transition";
 import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {sleep, toHex} from "@lodestar/utils";
@@ -121,19 +120,13 @@ export function getBeaconBlockApi({
           }
 
           try {
-            await verifyBlocksInEpoch.call(
-              chain as BeaconChain,
-              parentBlock,
-              [blockForImport],
-              [DataAvailableStatus.available],
-              {
-                ...opts,
-                verifyOnly: true,
-                skipVerifyBlockSignatures: true,
-                skipVerifyExecutionPayload: true,
-                seenTimestampSec,
-              }
-            );
+            await verifyBlocksInEpoch.call(chain as BeaconChain, parentBlock, [blockForImport], {
+              ...opts,
+              verifyOnly: true,
+              skipVerifyBlockSignatures: true,
+              skipVerifyExecutionPayload: true,
+              seenTimestampSec,
+            });
           } catch (error) {
             chain.logger.error("Consensus checks failed while publishing the block", valLogMeta, error as Error);
             chain.persistInvalidSszValue(

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -58,11 +58,7 @@ export async function processBlocks(
   }
 
   try {
-    const {relevantBlocks, dataAvailabilityStatuses, parentSlots, parentBlock} = verifyBlocksSanityChecks(
-      this,
-      blocks,
-      opts
-    );
+    const {relevantBlocks, parentSlots, parentBlock} = verifyBlocksSanityChecks(this, blocks, opts);
 
     // No relevant blocks, skip verifyBlocksInEpoch()
     if (relevantBlocks.length === 0 || parentBlock === null) {
@@ -72,13 +68,8 @@ export async function processBlocks(
 
     // Fully verify a block to be imported immediately after. Does not produce any side-effects besides adding intermediate
     // states in the state cache through regen.
-    const {postStates, proposerBalanceDeltas, segmentExecStatus} = await verifyBlocksInEpoch.call(
-      this,
-      parentBlock,
-      relevantBlocks,
-      dataAvailabilityStatuses,
-      opts
-    );
+    const {postStates, dataAvailabilityStatuses, proposerBalanceDeltas, segmentExecStatus} =
+      await verifyBlocksInEpoch.call(this, parentBlock, relevantBlocks, opts);
 
     // If segmentExecStatus has lvhForkchoice then, the entire segment should be invalid
     // and we need to further propagate

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -1,0 +1,126 @@
+import {computeTimeAtSlot, DataAvailableStatus} from "@lodestar/state-transition";
+import {ChainForkConfig} from "@lodestar/config";
+import {deneb, UintNum64} from "@lodestar/types";
+import {Logger} from "@lodestar/utils";
+import {BlockError, BlockErrorCode} from "../errors/index.js";
+import {validateBlobSidecars} from "../validation/blobSidecar.js";
+import {Metrics} from "../../metrics/metrics.js";
+import {BlockInput, BlockInputType, ImportBlockOpts, BlobSidecarValidation} from "./types.js";
+
+// proposer boost is not available post 3 sec so try pulling using unknown block hash
+// post 3 sec after throwing the availability error
+const BLOB_AVAILABILITY_TIMEOUT = 3_000;
+
+/**
+ * Verifies some early cheap sanity checks on the block before running the full state transition.
+ *
+ * - Parent is known to the fork-choice
+ * - Check skipped slots limit
+ * - check_block_relevancy()
+ *   - Block not in the future
+ *   - Not genesis block
+ *   - Block's slot is < Infinity
+ *   - Not finalized slot
+ *   - Not already known
+ */
+export async function verifyBlocksDataAvailability(
+  chain: {config: ChainForkConfig; genesisTime: UintNum64; logger: Logger; metrics: Metrics | null},
+  blocks: BlockInput[],
+  opts: ImportBlockOpts
+): Promise<{dataAvailabilityStatuses: DataAvailableStatus[]; availableTime: number}> {
+  if (blocks.length === 0) {
+    throw Error("Empty partiallyVerifiedBlocks");
+  }
+
+  const dataAvailabilityStatuses: DataAvailableStatus[] = [];
+  const seenTime = opts.seenTimestampSec !== undefined ? opts.seenTimestampSec * 1000 : Date.now();
+
+  for (const blockInput of blocks) {
+    // Validate status of only not yet finalized blocks, we don't need yet to propogate the status
+    // as it is not used upstream anywhere
+    const dataAvailabilityStatus = await maybeValidateBlobs(chain, blockInput, opts);
+    dataAvailabilityStatuses.push(dataAvailabilityStatus);
+  }
+
+  const availableTime = blocks[blocks.length - 1].type === BlockInputType.blobsPromise ? Date.now() : seenTime;
+  if (blocks.length === 1 && opts.seenTimestampSec !== undefined && blocks[0].type !== BlockInputType.preDeneb) {
+    const recvToAvailableTime = availableTime / 1000 - opts.seenTimestampSec;
+    const numBlobs = (blocks[0].block as deneb.SignedBeaconBlock).message.body.blobKzgCommitments.length;
+
+    chain.metrics?.gossipBlock.receivedToBlobsAvailabilityTime.observe({numBlobs}, recvToAvailableTime);
+    chain.logger.verbose("Verified blobs availability", {
+      slot: blocks[0].block.message.slot,
+      recvToAvailableTime,
+      type: blocks[0].type,
+    });
+  }
+
+  return {dataAvailabilityStatuses, availableTime};
+}
+
+async function maybeValidateBlobs(
+  chain: {config: ChainForkConfig; genesisTime: UintNum64},
+  blockInput: BlockInput,
+  opts: ImportBlockOpts
+): Promise<DataAvailableStatus> {
+  switch (blockInput.type) {
+    case BlockInputType.preDeneb:
+      return DataAvailableStatus.preDeneb;
+
+    case BlockInputType.postDeneb:
+      if (opts.validBlobSidecars === BlobSidecarValidation.Full) {
+        return DataAvailableStatus.available;
+      }
+
+    // eslint-disable-next-line no-fallthrough
+    case BlockInputType.blobsPromise: {
+      // run full validation
+      const {block} = blockInput;
+      const blockSlot = block.message.slot;
+
+      const blobsData =
+        blockInput.type === BlockInputType.postDeneb
+          ? blockInput
+          : await raceWithCutoff(chain, blockInput, blockInput.availabilityPromise);
+      const {blobs} = blobsData;
+
+      const {blobKzgCommitments} = (block as deneb.SignedBeaconBlock).message.body;
+      const beaconBlockRoot = chain.config.getForkTypes(blockSlot).BeaconBlock.hashTreeRoot(block.message);
+
+      // if the blob siddecars have been individually verified then we can skip kzg proof check
+      // but other checks to match blobs with block data still need to be performed
+      const skipProofsCheck = opts.validBlobSidecars === BlobSidecarValidation.Individual;
+      validateBlobSidecars(blockSlot, beaconBlockRoot, blobKzgCommitments, blobs, {skipProofsCheck});
+
+      return DataAvailableStatus.available;
+    }
+  }
+}
+
+/**
+ * Wait for blobs to become available with a cutoff time. If fails then throw DATA_UNAVAILABLE error
+ * which may try unknownblock/blobs fill (by root).
+ */
+async function raceWithCutoff<T>(
+  chain: {config: ChainForkConfig; genesisTime: UintNum64},
+  blockInput: BlockInput,
+  availabilityPromise: Promise<T>
+): Promise<T> {
+  const {block} = blockInput;
+  const blockSlot = block.message.slot;
+
+  const cutoffTime = Math.max(
+    computeTimeAtSlot(chain.config, blockSlot, chain.genesisTime) * 1000 + BLOB_AVAILABILITY_TIMEOUT - Date.now(),
+    0
+  );
+  const cutoffTimeout = new Promise((_resolve, reject) => setTimeout(reject, cutoffTime));
+
+  try {
+    await Promise.race([availabilityPromise, cutoffTimeout]);
+  } catch (e) {
+    // throw unavailable so that the unknownblock/blobs can be triggered to pull the block
+    throw new BlockError(block, {code: BlockErrorCode.DATA_UNAVAILABLE});
+  }
+  // we can only be here if availabilityPromise has resolved else an error will be thrown
+  return availabilityPromise;
+}

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -45,6 +45,7 @@ export type SegmentExecStatus =
   | {
       execAborted: null;
       executionStatuses: MaybeValidExecutionStatus[];
+      executionTime: number;
       mergeBlockFound: bellatrix.BeaconBlock | null;
     }
   | {execAborted: ExecAbortType; invalidSegmentLVH?: LVHInvalidResponse; mergeBlockFound: null};
@@ -243,8 +244,9 @@ export async function verifyBlocksExecutionPayload(
     }
   }
 
-  if (blocks.length === 1 && opts.seenTimestampSec !== undefined) {
-    const recvToVerifiedExecPayload = Date.now() / 1000 - opts.seenTimestampSec;
+  const executionTime = Date.now();
+  if (blocks.length === 1 && opts.seenTimestampSec !== undefined && executionStatuses[0] === ExecutionStatus.Valid) {
+    const recvToVerifiedExecPayload = executionTime / 1000 - opts.seenTimestampSec;
     chain.metrics?.gossipBlock.receivedToExecutionPayloadVerification.observe(recvToVerifiedExecPayload);
     chain.logger.verbose("Verified execution payload", {
       slot: blocks[0].message.slot,
@@ -255,6 +257,7 @@ export async function verifyBlocksExecutionPayload(
   return {
     execAborted: null,
     executionStatuses,
+    executionTime,
     mergeBlockFound,
   };
 }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -27,7 +27,7 @@ export async function verifyBlocksStateTransitionOnly(
   metrics: Metrics | null,
   signal: AbortSignal,
   opts: BlockProcessOpts & ImportBlockOpts
-): Promise<{postStates: CachedBeaconStateAllForks[]; proposerBalanceDeltas: number[]}> {
+): Promise<{postStates: CachedBeaconStateAllForks[]; proposerBalanceDeltas: number[]; verifyStateTime: number}> {
   const postStates: CachedBeaconStateAllForks[] = [];
   const proposerBalanceDeltas: number[] = [];
 
@@ -90,12 +90,13 @@ export async function verifyBlocksStateTransitionOnly(
     }
   }
 
+  const verifyStateTime = Date.now();
   if (blocks.length === 1 && opts.seenTimestampSec !== undefined) {
     const slot = blocks[0].block.message.slot;
-    const recvToTransition = Date.now() / 1000 - opts.seenTimestampSec;
+    const recvToTransition = verifyStateTime / 1000 - opts.seenTimestampSec;
     metrics?.gossipBlock.receivedToStateTransition.observe(recvToTransition);
-    logger.verbose("Transitioned gossip block", {slot, recvToTransition});
+    logger.verbose("Verified block state transition", {slot, recvToTransition});
   }
 
-  return {postStates, proposerBalanceDeltas};
+  return {postStates, proposerBalanceDeltas, verifyStateTime};
 }

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -79,6 +79,7 @@ import {BlockInput} from "./blocks/types.js";
 import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
 import {ShufflingCache} from "./shufflingCache.js";
 import {StateContextCache} from "./stateCache/stateContextCache.js";
+import {SeenGossipBlockInput} from "./seenCache/index.js";
 import {CheckpointStateCache} from "./stateCache/stateContextCheckpointsCache.js";
 
 /**
@@ -125,6 +126,7 @@ export class BeaconChain implements IBeaconChain {
   readonly seenSyncCommitteeMessages = new SeenSyncCommitteeMessages();
   readonly seenContributionAndProof: SeenContributionAndProof;
   readonly seenAttestationDatas: SeenAttestationDatas;
+  readonly seenGossipBlockInput = new SeenGossipBlockInput();
   // Seen cache for liveness checks
   readonly seenBlockAttesters = new SeenBlockAttesters();
 

--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -63,6 +63,8 @@ export enum BlockErrorCode {
   /** The attestation head block is too far behind the attestation slot, causing many skip slots.
   This is deemed a DoS risk */
   TOO_MANY_SKIPPED_SLOTS = "TOO_MANY_SKIPPED_SLOTS",
+  /** The blobs are unavailable */
+  DATA_UNAVAILABLE = "BLOCK_ERROR_DATA_UNAVAILABLE",
 }
 
 type ExecutionErrorStatus = Exclude<
@@ -103,7 +105,8 @@ export type BlockErrorType =
   | {code: BlockErrorCode.TOO_MUCH_GAS_USED; gasUsed: number; gasLimit: number}
   | {code: BlockErrorCode.SAME_PARENT_HASH; blockHash: RootHex}
   | {code: BlockErrorCode.TRANSACTIONS_TOO_BIG; size: number; max: number}
-  | {code: BlockErrorCode.EXECUTION_ENGINE_ERROR; execStatus: ExecutionErrorStatus; errorMessage: string};
+  | {code: BlockErrorCode.EXECUTION_ENGINE_ERROR; execStatus: ExecutionErrorStatus; errorMessage: string}
+  | {code: BlockErrorCode.DATA_UNAVAILABLE};
 
 export class BlockGossipError extends GossipActionError<BlockErrorType> {}
 

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -49,6 +49,7 @@ import {CheckpointBalancesCache} from "./balancesCache.js";
 import {IChainOptions} from "./options.js";
 import {AssembledBlockType, BlockAttributes, BlockType} from "./produceBlock/produceBlockBody.js";
 import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
+import {SeenGossipBlockInput} from "./seenCache/index.js";
 import {ShufflingCache} from "./shufflingCache.js";
 
 export {BlockType, type AssembledBlockType};
@@ -102,6 +103,7 @@ export interface IBeaconChain {
   readonly seenSyncCommitteeMessages: SeenSyncCommitteeMessages;
   readonly seenContributionAndProof: SeenContributionAndProof;
   readonly seenAttestationDatas: SeenAttestationDatas;
+  readonly seenGossipBlockInput: SeenGossipBlockInput;
   // Seen cache for liveness checks
   readonly seenBlockAttesters: SeenBlockAttesters;
 

--- a/packages/beacon-node/src/chain/seenCache/index.ts
+++ b/packages/beacon-node/src/chain/seenCache/index.ts
@@ -2,3 +2,4 @@ export {SeenAggregators, SeenAttesters} from "./seenAttesters.js";
 export {SeenBlockProposers} from "./seenBlockProposers.js";
 export {SeenSyncCommitteeMessages} from "./seenCommittee.js";
 export {SeenContributionAndProof} from "./seenCommitteeContribution.js";
+export {SeenGossipBlockInput} from "./seenGossipBlockInput.js";

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -1,0 +1,170 @@
+import {toHexString} from "@chainsafe/ssz";
+import {deneb, RootHex, ssz, allForks} from "@lodestar/types";
+import {ChainForkConfig} from "@lodestar/config";
+import {pruneSetToMax} from "@lodestar/utils";
+
+import {
+  BlockInput,
+  getBlockInput,
+  BlockSource,
+  BlockInputBlobs,
+  BlobsCache,
+  GossipedInputType,
+} from "../blocks/types.js";
+
+export type GossipedBlockInput =
+  | {type: GossipedInputType.block; signedBlock: allForks.SignedBeaconBlock; blockBytes: Uint8Array | null}
+  | {type: GossipedInputType.blob; signedBlob: deneb.SignedBlobSidecar; blobBytes: Uint8Array | null};
+
+export type BlockInputCacheType = {
+  block?: allForks.SignedBeaconBlock;
+  blockBytes?: Uint8Array | null;
+  blobsCache: BlobsCache;
+  // promise and its callback cached for delayed resolution
+  availabilityPromise: Promise<BlockInputBlobs>;
+  resolveAvailability: (blobs: BlockInputBlobs) => void;
+};
+
+const MAX_GOSSIPINPUT_CACHE = 5;
+// ssz.deneb.BlobSidecars.elementType.fixedSize, 131256 is size for mainnet preset;
+const BLOBSIDECAR_FIXED_SIZE = ssz.deneb.BlobSidecars.elementType.fixedSize ?? 131256;
+
+/**
+ * SeenGossipBlockInput tracks and caches the live blobs and blocks on the network to solve data availability
+ * for the blockInput. If no block has been seen yet for some already seen blobs, it responds will null, but
+ * on the first block or the consequent blobs it responds with blobs promise till all blobs become available.
+ *
+ * One can start processing block on blobs promise blockInput response and can await on the promise before
+ * fully importing the block. The blobs promise is gets resolved as soon as all blobs corresponding to that
+ * block are seen by SeenGossipBlockInput
+ */
+export class SeenGossipBlockInput {
+  private blockInputCache = new Map<RootHex, BlockInputCacheType>();
+
+  prune(): void {
+    pruneSetToMax(this.blockInputCache, MAX_GOSSIPINPUT_CACHE);
+  }
+
+  getGossipBlockInput(
+    config: ChainForkConfig,
+    gossipedInput: GossipedBlockInput
+  ):
+    | {
+        blockInput: BlockInput;
+        blockInputMeta: {pending: GossipedInputType.blob | null; haveBlobs: number; expectedBlobs: number};
+      }
+    | {blockInput: null; blockInputMeta: {pending: GossipedInputType.block; haveBlobs: number; expectedBlobs: null}} {
+    let blockHex;
+    let blockCache;
+
+    if (gossipedInput.type === GossipedInputType.block) {
+      const {signedBlock, blockBytes} = gossipedInput;
+
+      blockHex = toHexString(
+        config.getForkTypes(signedBlock.message.slot).BeaconBlock.hashTreeRoot(signedBlock.message)
+      );
+      blockCache = this.blockInputCache.get(blockHex) ?? getEmptyBlockInputCacheEntry();
+
+      blockCache.block = signedBlock;
+      blockCache.blockBytes = blockBytes;
+    } else {
+      const {signedBlob, blobBytes} = gossipedInput;
+      blockHex = toHexString(signedBlob.message.blockRoot);
+      blockCache = this.blockInputCache.get(blockHex) ?? getEmptyBlockInputCacheEntry();
+
+      // TODO: freetheblobs check if its the same blob or a duplicate and throw/take actions
+      blockCache.blobsCache.set(signedBlob.message.index, {
+        blobSidecar: signedBlob.message,
+        // easily splice out the unsigned message as blob is a fixed length type
+        blobBytes: blobBytes?.slice(0, BLOBSIDECAR_FIXED_SIZE) ?? null,
+      });
+    }
+
+    if (!this.blockInputCache.has(blockHex)) {
+      this.blockInputCache.set(blockHex, blockCache);
+    }
+    const {block: signedBlock, blockBytes, blobsCache, availabilityPromise, resolveAvailability} = blockCache;
+
+    if (signedBlock !== undefined) {
+      // block is available, check if all blobs have shown up
+      const {slot, body} = signedBlock.message;
+      const {blobKzgCommitments} = body as deneb.BeaconBlockBody;
+      const blockInfo = `blockHex=${blockHex}, slot=${slot}`;
+
+      if (blobKzgCommitments.length < blobsCache.size) {
+        throw Error(
+          `Received more blobs=${blobsCache.size} than commitments=${blobKzgCommitments.length} for ${blockInfo}`
+        );
+      }
+
+      if (blobKzgCommitments.length === blobsCache.size) {
+        const allBlobs = getBlockInputBlobs(blobsCache);
+        resolveAvailability(allBlobs);
+        const {blobs, blobsBytes} = allBlobs;
+        return {
+          blockInput: getBlockInput.postDeneb(
+            config,
+            signedBlock,
+            BlockSource.gossip,
+            blobs,
+            blockBytes ?? null,
+            blobsBytes
+          ),
+          blockInputMeta: {pending: null, haveBlobs: blobs.length, expectedBlobs: blobKzgCommitments.length},
+        };
+      } else {
+        return {
+          blockInput: getBlockInput.blobsPromise(
+            config,
+            signedBlock,
+            BlockSource.gossip,
+            blobsCache,
+            blockBytes ?? null,
+            availabilityPromise
+          ),
+          blockInputMeta: {
+            pending: GossipedInputType.blob,
+            haveBlobs: blobsCache.size,
+            expectedBlobs: blobKzgCommitments.length,
+          },
+        };
+      }
+    } else {
+      // will need to wait for the block to showup
+      return {
+        blockInput: null,
+        blockInputMeta: {pending: GossipedInputType.block, haveBlobs: blobsCache.size, expectedBlobs: null},
+      };
+    }
+  }
+}
+
+function getEmptyBlockInputCacheEntry(): BlockInputCacheType {
+  // Capture both the promise and its callbacks.
+  // It is not spec'ed but in tests in Firefox and NodeJS the promise constructor is run immediately
+  let resolveAvailability: ((blobs: BlockInputBlobs) => void) | null = null;
+  const availabilityPromise = new Promise<BlockInputBlobs>((resolveCB) => {
+    resolveAvailability = resolveCB;
+  });
+  if (resolveAvailability === null) {
+    throw Error("Promise Constructor was not executed immediately");
+  }
+  const blobsCache = new Map();
+  return {availabilityPromise, resolveAvailability, blobsCache};
+}
+
+function getBlockInputBlobs(blobsCache: BlobsCache): BlockInputBlobs {
+  const blobs = [];
+  const blobsBytes = [];
+
+  for (let index = 0; index < blobsCache.size; index++) {
+    const blobCache = blobsCache.get(index);
+    if (blobCache === undefined) {
+      throw Error(`Missing blobSidecar at index=${index}`);
+    }
+    const {blobSidecar, blobBytes} = blobCache;
+    blobs.push(blobSidecar);
+    blobsBytes.push(blobBytes);
+  }
+  return {blobs, blobsBytes};
+}

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -649,27 +649,44 @@ export function createLodestarMetrics(
       receivedToGossipValidate: register.histogram({
         name: "lodestar_gossip_block_received_to_gossip_validate",
         help: "Time elapsed between block received and block validated",
-        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
+        buckets: [0.05, 0.1, 0.3, 0.5, 0.7, 1, 1.3, 1.6, 2, 2.5, 3, 3.5, 4],
       }),
       receivedToStateTransition: register.histogram({
         name: "lodestar_gossip_block_received_to_state_transition",
         help: "Time elapsed between block received and block state transition",
-        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
+        buckets: [0.05, 0.1, 0.3, 0.5, 0.7, 1, 1.3, 1.6, 2, 2.5, 3, 3.5, 4],
       }),
       receivedToSignaturesVerification: register.histogram({
         name: "lodestar_gossip_block_received_to_signatures_verification",
         help: "Time elapsed between block received and block signatures verification",
-        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
+        buckets: [0.05, 0.1, 0.3, 0.5, 0.7, 1, 1.3, 1.6, 2, 2.5, 3, 3.5, 4],
       }),
       receivedToExecutionPayloadVerification: register.histogram({
         name: "lodestar_gossip_block_received_to_execution_payload_verification",
         help: "Time elapsed between block received and execution payload verification",
-        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
+        buckets: [0.05, 0.1, 0.3, 0.5, 0.7, 1, 1.3, 1.6, 2, 2.5, 3, 3.5, 4],
+      }),
+      receivedToBlobsAvailabilityTime: register.histogram<"numBlobs">({
+        name: "lodestar_gossip_block_received_to_blobs_availability_time",
+        help: "Time elapsed between block received and blobs became available",
+        buckets: [0.05, 0.1, 0.3, 0.5, 0.7, 1, 1.3, 1.6, 2, 2.5, 3, 3.5, 4],
+        labelNames: ["numBlobs"],
+      }),
+      receivedToFullyVerifiedTime: register.histogram({
+        name: "lodestar_gossip_block_received_to_fully_verified_time",
+        help: "Time elapsed between block received and fully verified state, signatures and payload",
+        buckets: [0.05, 0.1, 0.3, 0.5, 0.7, 1, 1.3, 1.6, 2, 2.5, 3, 3.5, 4],
+      }),
+      verifiedToBlobsAvailabiltyTime: register.histogram<"numBlobs">({
+        name: "lodestar_gossip_block_verified_to_blobs_availability_time",
+        help: "Time elapsed between block verified and blobs became available",
+        buckets: [0.05, 0.1, 0.3, 0.5, 0.7, 1, 1.3, 1.6, 2, 2.5, 3, 3.5, 4],
+        labelNames: ["numBlobs"],
       }),
       receivedToBlockImport: register.histogram({
         name: "lodestar_gossip_block_received_to_block_import",
         help: "Time elapsed between block received and block import",
-        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
+        buckets: [0.05, 0.1, 0.3, 0.5, 0.7, 1, 1.3, 1.6, 2, 2.5, 3, 3.5, 4],
       }),
       processBlockErrors: register.gauge<"error">({
         name: "lodestar_gossip_block_process_block_errors",

--- a/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
@@ -108,7 +108,7 @@ describe("SeenGossipBlockInput", () => {
             if (expectedResponseType instanceof Error) {
               expect.fail(`expected to fail with error: ${expectedResponseType.message}`);
             } else if (expectedResponseType === null) {
-              expect(blockInputRes).equal.toBeNull;
+              expect(blockInputRes).toBeNull;
             } else {
               expect(blockInputRes.blockInput?.type).to.be.equal(expectedResponseType);
             }
@@ -144,7 +144,7 @@ describe("SeenGossipBlockInput", () => {
   }
 });
 
-function parseResponseType(expectedRes: string | Error | null): BlockInputType | null | Error {
+function parseResponseType(expectedRes: string | null): BlockInputType | null | Error {
   switch (expectedRes) {
     case null:
       return null;

--- a/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
@@ -1,0 +1,158 @@
+import {describe, it, expect} from "vitest";
+import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {ssz} from "@lodestar/types";
+
+import {SeenGossipBlockInput} from "../../../../src/chain/seenCache/seenGossipBlockInput.js";
+import {BlockInputType, GossipedInputType} from "../../../../src/chain/blocks/types.js";
+
+/* eslint-disable @typescript-eslint/naming-convention */
+describe("SeenGossipBlockInput", () => {
+  const chainConfig = createChainForkConfig({
+    ...defaultChainConfig,
+    ALTAIR_FORK_EPOCH: 0,
+    BELLATRIX_FORK_EPOCH: 0,
+    DENEB_FORK_EPOCH: 0,
+  });
+  const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
+  const config = createBeaconConfig(chainConfig, genesisValidatorsRoot);
+  const seenGossipBlockInput = new SeenGossipBlockInput();
+
+  // array of numBlobs, events where events are array of
+  // [block|blob11|blob2, pd | bp | null | error string reflecting the expected result]
+  const testCases: [string, number, [string, string | null][]][] = [
+    ["no blobs", 0, [["block", "pd"]]],
+    [
+      "1 blob, block first",
+      1,
+      [
+        ["block", "bp"],
+        ["blob0", "pd"],
+      ],
+    ],
+    [
+      "1 blob, blob first",
+      1,
+      [
+        ["blob0", null],
+        ["block", "pd"],
+      ],
+    ],
+    [
+      "6 blobs, block first",
+      6,
+      [
+        ["block", "bp"],
+        ["blob1", "bp"],
+        ["blob0", "bp"],
+        ["blob5", "bp"],
+        ["blob4", "bp"],
+        ["blob2", "bp"],
+        ["blob3", "pd"],
+      ],
+    ],
+    [
+      "4 blobs, block in mid",
+      4,
+      [
+        ["blob1", null],
+        ["blob3", null],
+        ["block", "bp"],
+        ["blob0", "bp"],
+        ["blob2", "pd"],
+      ],
+    ],
+    [
+      "3 blobs, block in end",
+      3,
+      [
+        ["blob1", null],
+        ["blob0", null],
+        ["blob2", null],
+        ["block", "pd"],
+      ],
+    ],
+  ];
+  // lets start from a random slot to build cases
+  let slot = 7456;
+  for (const testCase of testCases) {
+    const [testName, numBlobs, events] = testCase;
+
+    it(`${testName}`, () => {
+      const signedBlock = ssz.deneb.SignedBeaconBlock.defaultValue();
+      // assign slot and increment for the next block so as to keep these block testcases distinguished
+      // in the cache
+      signedBlock.message.slot = slot++;
+      signedBlock.message.body.blobKzgCommitments = Array.from({length: numBlobs}, () =>
+        ssz.deneb.KZGCommitment.defaultValue()
+      );
+
+      const blockRoot = ssz.deneb.BeaconBlock.hashTreeRoot(signedBlock.message);
+      const signedBlobSidecars = Array.from({length: numBlobs}, (_val, index) => {
+        const message = {...ssz.deneb.BlobSidecar.defaultValue(), index, blockRoot, slot};
+        return {message, signature: ssz.BLSSignature.defaultValue()};
+      });
+
+      for (const testEvent of events) {
+        const [inputEvent, expectedRes] = testEvent;
+        const eventType = inputEvent.includes("block") ? GossipedInputType.block : GossipedInputType.blob;
+        const expectedResponseType = parseResponseType(expectedRes);
+
+        try {
+          if (eventType === GossipedInputType.block) {
+            const blockInputRes = seenGossipBlockInput.getGossipBlockInput(config, {
+              type: GossipedInputType.block,
+              signedBlock,
+              blockBytes: null,
+            });
+
+            if (expectedResponseType instanceof Error) {
+              expect.fail(`expected to fail with error: ${expectedResponseType.message}`);
+            } else if (expectedResponseType === null) {
+              expect(blockInputRes).equal.toBeNull;
+            } else {
+              expect(blockInputRes.blockInput?.type).to.be.equal(expectedResponseType);
+            }
+          } else {
+            const index = parseInt(inputEvent.split("blob")[1] ?? "0");
+            const signedBlob = signedBlobSidecars[index];
+            expect(signedBlob).not.equal(undefined);
+            const blockInputRes = seenGossipBlockInput.getGossipBlockInput(config, {
+              type: GossipedInputType.blob,
+              signedBlob,
+              blobBytes: null,
+            });
+
+            if (expectedResponseType instanceof Error) {
+              expect.fail(`expected to fail with error: ${expectedResponseType.message}`);
+            } else if (expectedResponseType === null) {
+              expect(blockInputRes).toBeNull;
+            } else {
+              expect(blockInputRes.blockInput?.type).to.equal(expectedResponseType);
+            }
+          }
+        } catch (e) {
+          if (!(e as Error).message.includes("expected to fail with error")) {
+            if (!(expectedResponseType instanceof Error)) {
+              expect.fail(
+                `expected not to fail with respose=${expectedResponseType} but errored: ${(e as Error).message}`
+              );
+            }
+          }
+        }
+      }
+    });
+  }
+});
+
+function parseResponseType(expectedRes: string | Error | null): BlockInputType | null | Error {
+  switch (expectedRes) {
+    case null:
+      return null;
+    case "pd":
+      return BlockInputType.postDeneb;
+    case "bp":
+      return BlockInputType.blobsPromise;
+    default:
+      return Error(expectedRes);
+  }
+}


### PR DESCRIPTION
(WIP)

while all blobs become available, block can be optimistically verified to save any delays on the import times

this PR implements blockInput with blobsPromise that need to resolve before the block can be imported in a timebound manner else the unknownblock/blob search is initiated 

TODO:
- [x] cleanup
- [x] add metrics
- [x] fix tests/types check
- [x] devnet 11
  - [x] postDeneb blobs
  - [x] blobs with promise
  - [x] promise failing with unknown block search 