### PR TITLE
feat(cli): add info logs for connected services URLS

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -25,6 +25,7 @@ import {BeaconArgs} from "./options.js";
 import {getBeaconPaths} from "./paths.js";
 import {initBeaconState} from "./initBeaconState.js";
 import {initPeerIdAndEnr} from "./initPeerIdAndEnr.js";
+import {logArguments} from "./logArguments.js";
 
 const DEFAULT_RETENTION_SSZ_OBJECTS_HOURS = 15 * 24;
 const HOURS_TO_MS = 3600 * 1000;
@@ -207,6 +208,8 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
 
   // Render final options
   const options = beaconNodeOptions.getWithDefaults();
+
+  logArguments(logger, args);
 
   return {config, options, beaconPaths, network, version, commit, peerId, logger};
 }

--- a/packages/cli/src/cmds/beacon/logArguments.ts
+++ b/packages/cli/src/cmds/beacon/logArguments.ts
@@ -1,0 +1,35 @@
+import {LogLevel, Logger} from "@lodestar/utils";
+import {GlobalArgs} from "../../options/index.js";
+import {BeaconArgs} from "./options.js";
+
+/**
+ * Log urls from CLI arguments for execution.urls, eth1.providerUrls and builder.urls
+ */
+export function logArguments(logger: Pick<Logger, LogLevel.info>, args: BeaconArgs & GlobalArgs): void {
+  const executionUrls = args["execution.urls"];
+
+  if (executionUrls?.length > 0) {
+    logger.info(`Total execution urls: ${executionUrls.length}`);
+    executionUrls.forEach((url, index) => {
+      logger.info(`Execution url (${index + 1}): ${url}`);
+    });
+  }
+
+  const eth1ProviderUrls = args["eth1.providerUrls"];
+
+  if (eth1ProviderUrls && eth1ProviderUrls?.length > 0) {
+    logger.info(`Total eth1 provider urls: ${eth1ProviderUrls.length}`);
+    eth1ProviderUrls.forEach((url, index) => {
+      logger.info(`Eth1 provider url (${index + 1}): ${url}`);
+    });
+  }
+
+  const builderUrls = args["builder.urls"];
+
+  if (builderUrls && builderUrls?.length > 0) {
+    logger.info(`Total builder url(s): ${builderUrls.length}`);
+    builderUrls.forEach((url, index) => {
+      logger.info(`Builder url (${index + 1}): ${url}`);
+    });
+  }
+}

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -30,6 +30,7 @@ import {KeymanagerApi} from "./keymanager/impl.js";
 import {PersistedKeysBackend} from "./keymanager/persistedKeys.js";
 import {IPersistedKeysBackend} from "./keymanager/interface.js";
 import {KeymanagerRestApiServer} from "./keymanager/server.js";
+import {logArguments} from "./logArguments.js";
 
 /**
  * Runs a validator client.
@@ -102,6 +103,7 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
   }
 
   logSigners(logger, signers);
+  logArguments(logger, args);
 
   const db = await LevelDbController.create({name: dbPath}, {metrics: null, logger});
   onGracefulShutdownCbs.push(() => db.close());

--- a/packages/cli/src/cmds/validator/logArguments.ts
+++ b/packages/cli/src/cmds/validator/logArguments.ts
@@ -1,0 +1,17 @@
+import {LogLevel, Logger} from "@lodestar/utils";
+import {GlobalArgs} from "../../options/index.js";
+import {IValidatorCliArgs} from "./options.js";
+
+/**
+ * Log beacon node urls
+ */
+export function logArguments(logger: Pick<Logger, LogLevel.info>, args: IValidatorCliArgs & GlobalArgs): void {
+  const beaconNodes = args["beaconNodes"];
+
+  if (beaconNodes?.length > 0) {
+    logger.info(`${beaconNodes.length} beacon nodes`);
+    beaconNodes.forEach((url, index) => {
+      logger.info(`Beacon node url ${index + 1}: ${url}`);
+    });
+  }
+}


### PR DESCRIPTION
**Motivation**

Print URLS in the CLI package for connected services. 

**Description**

Prints info logs to show URLs of connected services

> Beacon node

- execution urls
- builder urls
- eth1 provider urls


> Validator client

- beacon node urls

Closes #5990
