### PR TITLE
chore: add reference to attestation summary metric explainer

### DIFF
--- a/dashboards/lodestar_networking.json
+++ b/dashboards/lodestar_networking.json
@@ -1,12 +1,12 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMETHEUS",
-      "type": "datasource",
-      "label": "Prometheus",
       "description": "",
+      "label": "Prometheus",
+      "name": "DS_PROMETHEUS",
       "pluginId": "prometheus",
-      "pluginName": "Prometheus"
+      "pluginName": "Prometheus",
+      "type": "datasource"
     }
   ],
   "annotations": {

--- a/dashboards/lodestar_validator_monitor.json
+++ b/dashboards/lodestar_validator_monitor.json
@@ -112,6 +112,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "https://hackmd.io/@dapplion/lodestar_attestation_summary",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -166,6 +167,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "https://hackmd.io/@dapplion/lodestar_attestation_summary",
       "fieldConfig": {
         "defaults": {
           "color": {


### PR DESCRIPTION
**Motivation**

The attestation summary metric labels are quite hard to understand but we have a great article that explains what each label means, just need more visibility on it so people using the dashboard are more likely to find it.

**Description**

Add reference to [attestation summary metric explainer](https://hackmd.io/@dapplion/lodestar_attestation_summary) to dashboard panel description
