### PR TITLE
fix: `hexToBuffer` bug

### DIFF
--- a/packages/prover/src/utils/conversion.ts
+++ b/packages/prover/src/utils/conversion.ts
@@ -23,7 +23,7 @@ export function bufferToHex(buffer: Buffer | Uint8Array): string {
 }
 
 export function hexToBuffer(val: string): Buffer {
-  return Buffer.from(val.replace("0x", ""), "hex");
+  return Buffer.from((val.length % 2 ? '0' : '') + val.replace("0x", ""), "hex");
 }
 
 export function padLeft<T extends Buffer | Uint8Array>(v: T, length: number): T {

--- a/packages/prover/src/utils/conversion.ts
+++ b/packages/prover/src/utils/conversion.ts
@@ -23,7 +23,7 @@ export function bufferToHex(buffer: Buffer | Uint8Array): string {
 }
 
 export function hexToBuffer(val: string): Buffer {
-  return Buffer.from((val.length % 2 ? '0' : '') + val.replace("0x", ""), "hex");
+  return Buffer.from((val.length % 2 ? "0" : "") + val.replace("0x", ""), "hex");
 }
 
 export function padLeft<T extends Buffer | Uint8Array>(v: T, length: number): T {

--- a/packages/prover/src/utils/conversion.ts
+++ b/packages/prover/src/utils/conversion.ts
@@ -23,7 +23,8 @@ export function bufferToHex(buffer: Buffer | Uint8Array): string {
 }
 
 export function hexToBuffer(val: string): Buffer {
-  return Buffer.from((val.length % 2 ? "0" : "") + val.replace("0x", ""), "hex");
+  const hexWithEvenLength = val.length % 2 ? `0${val}` : val;
+  return Buffer.from(hexWithEvenLength.replace("0x", ""), "hex");
 }
 
 export function padLeft<T extends Buffer | Uint8Array>(v: T, length: number): T {


### PR DESCRIPTION
**Description**

The current `hexToBuffer` implementation doesn't take `Buffer.from`'s "documented behavior" quirk  into consideration:
https://github.com/nodejs/node/issues/21242

This PR fixes it

**Steps to test or reproduce**

Run the following code:
```ts
function originalHexToBuffer(val: string): Buffer {
    return Buffer.from(val.replace("0x", ""), "hex");
  }
  
function fixedHexToBuffer(val: string): Buffer {
    return Buffer.from((val.length % 2 ? '0' : '') + val.replace("0x", ""), "hex");
}

for (const hex of ['0xa', '0xab', '0xabc', '0xabcd']) {
    console.log(`\noriginalHexToBuffer\t("${hex}") \t=\t`, originalHexToBuffer(hex))
    console.log(`fixedHexToBuffer\t("${hex}")      \t=\t`, fixedHexToBuffer(hex))
}
```
Which results in:
```
bun reproduce.ts

originalHexToBuffer	("0xa") 	=	 Buffer(0) [  ]
fixedHexToBuffer	("0xa")      	=	 Buffer(1) [ 10 ]

originalHexToBuffer	("0xab") 	=	 Buffer(1) [ 171 ]
fixedHexToBuffer	("0xab")      	=	 Buffer(1) [ 171 ]

originalHexToBuffer	("0xabc") 	=	 Buffer(1) [ 171 ]
fixedHexToBuffer	("0xabc")      	=	 Buffer(2) [ 10, 188 ]

originalHexToBuffer	("0xabcd") 	=	 Buffer(2) [ 171, 205 ]
fixedHexToBuffer	("0xabcd")      =	 Buffer(2) [ 171, 205 ]
```