### PR TITLE
feat: support "input" param for verifiable tx (cont.)

### DIFF
--- a/packages/prover/src/utils/evm.ts
+++ b/packages/prover/src/utils/evm.ts
@@ -56,7 +56,7 @@ export async function getVMWithState({
   const accessListTx = cleanObject({
     to,
     from,
-    data: tx.data,
+    data: tx.input ? tx.input : tx.data,
     value: tx.value,
     gas: tx.gas ? tx.gas : numberToHex(gasLimit),
     gasPrice: "0x0",


### PR DESCRIPTION
This is a continuation of https://github.com/ChainSafe/lodestar/pull/6019 There is an additional fix needed, where tx.input support is added in case input is used instead of data

