### PR TITLE
fix: only transfer cache at epoch transition

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -71,6 +71,7 @@ export async function verifyBlocksInEpoch(
 
   if (!isStateValidatorsNodesPopulated(preState0)) {
     this.logger.verbose("verifyBlocksInEpoch preState0 SSZ cache stats", {
+      slot: preState0.slot,
       cache: isStateValidatorsNodesPopulated(preState0),
       clonedCount: preState0.clonedCount,
       clonedCountWithTransferCache: preState0.clonedCountWithTransferCache,

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -98,8 +98,9 @@ export class PrepareNextSlotScheduler {
       const prepareState = await this.chain.regen.getBlockSlotState(
         headRoot,
         prepareSlot,
-        // the 1st slot of next epoch will likely use this Previous Root Checkpoint state so we transfer cache here
-        {dontTransferCache: false},
+        // the slot 0 of next epoch will likely use this Previous Root Checkpoint state for state transition so we transfer cache here
+        // for other slots dontTransferCached=true because we don't run state transition on this state
+        {dontTransferCache: !isEpochTransition},
         RegenCaller.precomputeEpoch
       );
 


### PR DESCRIPTION
**Motivation**

#6068 improved state transition but it made the block transition worse

**Description**

In `prepareNextSlot`, it's supposed to transfer cache only at epoch transition

related to #6063
