### PR TITLE
build: add build workflow for debug nodejs

### DIFF
--- a/.github/workflows/build-debug-node.yml
+++ b/.github/workflows/build-debug-node.yml
@@ -39,16 +39,12 @@ jobs:
       - name: Create destination folder 
         run: mkdir -p ${{ github.workspace }}/nodejs-debug-build-${{ github.event.inputs.version }}
 
-      - name: Copy nodejs build
-        run: make install 
+      - name: Copy nodejs debug build
+        run: cp -r out/Debug/* ${{ github.workspace }}/nodejs-debug-build-${{ github.event.inputs.version }}
         working-directory: 'nodejs'
-        env: 
-          DESTDIR: ${{ github.workspace }}/nodejs-debug-build-${{ github.event.inputs.version }}
 
       - name: Upload build to artifacts
         uses: actions/upload-artifact@v3
         with:
           name: nodejs-debug-build-${{ github.event.inputs.version }}
           path: nodejs-debug-build-${{ github.event.inputs.version }}
-
-

--- a/.github/workflows/build-debug-node.yml
+++ b/.github/workflows/build-debug-node.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: 'nodejs'
 
       - name: Compile the nodejs
-        run: make -j4
+        run: make -j$(nproc --all)
         working-directory: 'nodejs'
 
       - name: Verify the build 

--- a/.github/workflows/build-debug-node.yml
+++ b/.github/workflows/build-debug-node.yml
@@ -1,0 +1,54 @@
+name: Build debug node 
+
+on: 
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: 'Node.js version'
+
+jobs:
+  build:
+    name: Build Debug version of Node.js
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Install dependencies 
+        run: apt-get install python3 g++ make python3-pip
+
+      - name: Download Node.js source
+        uses: actions/checkout@v4
+        with: 
+          repository: 'nodejs/node'
+          ref: 'v${{ github.event.inputs.version }}'
+          path: 'nodejs'
+
+      - name: Configure nodejs with debug flag 
+        run: ./configure --debug
+        working-directory: 'nodejs'
+
+      - name: Compile the nodejs
+        run: make -j4
+        working-directory: 'nodejs'
+
+      - name: Verify the build 
+        run: make test-only 
+        working-directory: 'nodejs'
+
+      - name: Create destination folder 
+        run: mkdir -p ${{ github.workspace }}/nodejs-debug-build-${{ github.event.inputs.version }}
+
+      - name: Copy nodejs build
+        run: make install 
+        working-directory: 'nodejs'
+        env: 
+          DESTDIR: ${{ github.workspace }}/nodejs-debug-build-${{ github.event.inputs.version }}
+
+      - name: Upload build to artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: nodejs-debug-build-${{ github.event.inputs.version }}
+          path: nodejs-debug-build-${{ github.event.inputs.version }}
+
+

--- a/.github/workflows/build-debug-node.yml
+++ b/.github/workflows/build-debug-node.yml
@@ -40,7 +40,7 @@ jobs:
         run: mkdir -p ${{ github.workspace }}/nodejs-debug-build-${{ github.event.inputs.version }}
 
       - name: Copy nodejs debug build
-        run: cp -r out/Debug/* ${{ github.workspace }}/nodejs-debug-build-${{ github.event.inputs.version }}
+        run: cp out/Debug/node ${{ github.workspace }}/nodejs-debug-build-${{ github.event.inputs.version }}
         working-directory: 'nodejs'
 
       - name: Upload build to artifacts


### PR DESCRIPTION
**Motivation**

More flexible debugging for native nodejs modules. 

**Description**

- We often need to debug exceptions which are on the native bindings 
- NodeJS debug build provide more information in case of the segfaults or related errors
- We don't have any runner available to have builtin support for debug build for nodejs 
- The Github actions `setup-node` also don't provide this support. 
- The idea is the build once a debug level nodejs binary on same runner we use for tests and upload it to some bucket
- We can then download that binary and in case we need to debug something. 


**Steps to test or reproduce**

-Run all tests. 