### PR TITLE
fix: increase range for the random value of request id in prover 

### DIFF
--- a/packages/prover/src/utils/rpc.ts
+++ b/packages/prover/src/utils/rpc.ts
@@ -100,6 +100,6 @@ export class ELRpc {
 
   getRequestId(): string {
     // TODO: Find better way to generate random id
-    return (Math.random() * 10000).toFixed(0);
+    return (Math.random() * 100000000000000000).toFixed(0);
   }
 }


### PR DESCRIPTION
Request id is currently generated by choosing random number 0-10000. 
This range is too small, and in some scenarios causes duplicate ids in batch. 
Example:
call eth_call to multicall contract, aggregating balanceOf calls of many tokens. 
If enough tokens are queried, then many eth_getProof requests will be submitted in a batch. for a large amount of tokens there is a large chance of request id collision, failing the check in https://github.com/ChainSafe/lodestar/blob/unstable/packages/prover/src/utils/json_rpc.ts#L84
