### PR TITLE
fix: remove unused gossip block metrics from network core

### DIFF
--- a/packages/beacon-node/src/network/core/metrics.ts
+++ b/packages/beacon-node/src/network/core/metrics.ts
@@ -291,45 +291,6 @@ export function createNetworkCoreMetrics(register: RegistryMetricCreator) {
         labelNames: ["subnet"],
       }),
     },
-
-    // Gossip block
-    gossipBlock: {
-      elapsedTimeTillReceived: register.histogram({
-        name: "lodestar_gossip_block_elapsed_time_till_received",
-        help: "Time elapsed between block slot time and the time block received via gossip",
-        buckets: [0.5, 1, 2, 4, 6, 12],
-      }),
-      elapsedTimeTillProcessed: register.histogram({
-        name: "lodestar_gossip_block_elapsed_time_till_processed",
-        help: "Time elapsed between block slot time and the time block processed",
-        buckets: [0.5, 1, 2, 4, 6, 12],
-      }),
-      receivedToGossipValidate: register.histogram({
-        name: "lodestar_gossip_block_received_to_gossip_validate",
-        help: "Time elapsed between block received and block validated",
-        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
-      }),
-      receivedToStateTransition: register.histogram({
-        name: "lodestar_gossip_block_received_to_state_transition",
-        help: "Time elapsed between block received and block state transition",
-        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
-      }),
-      receivedToSignaturesVerification: register.histogram({
-        name: "lodestar_gossip_block_received_to_signatures_verification",
-        help: "Time elapsed between block received and block signatures verification",
-        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
-      }),
-      receivedToExecutionPayloadVerification: register.histogram({
-        name: "lodestar_gossip_block_received_to_execution_payload_verification",
-        help: "Time elapsed between block received and execution payload verification",
-        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
-      }),
-      receivedToBlockImport: register.histogram({
-        name: "lodestar_gossip_block_received_to_block_import",
-        help: "Time elapsed between block received and block import",
-        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
-      }),
-    },
   };
 }
 


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/6118

**Description**

Gossip block metrics are unused in network core and produce duplicate results (see https://github.com/ChainSafe/lodestar/issues/6118).

Gossip block metrics are used in
- validatorMonitor.ts
https://github.com/ChainSafe/lodestar/blob/fa30bcf10086292883ef086202474ac4df67ffe1/packages/beacon-node/src/metrics/validatorMonitor.ts#L377
- gossipHandlers.ts
https://github.com/ChainSafe/lodestar/blob/fa30bcf10086292883ef086202474ac4df67ffe1/packages/beacon-node/src/network/processor/gossipHandlers.ts#L252
- verifyBlocksStateTransitionOnly.ts
https://github.com/ChainSafe/lodestar/blob/fa30bcf10086292883ef086202474ac4df67ffe1/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts#L96
- verifyBlocksSignatures.ts
https://github.com/ChainSafe/lodestar/blob/fa30bcf10086292883ef086202474ac4df67ffe1/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts#L51
- verifyBlocksExecutionPayloads.ts
https://github.com/ChainSafe/lodestar/blob/fa30bcf10086292883ef086202474ac4df67ffe1/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts#L247
- importBlock.ts
https://github.com/ChainSafe/lodestar/blob/fa30bcf10086292883ef086202474ac4df67ffe1/packages/beacon-node/src/chain/blocks/importBlock.ts#L434