### PR TITLE
fix: log useProduceBlockV3 default value instead of undefined

### DIFF
--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -285,7 +285,7 @@ export class Validator {
     await assertEqualGenesis(opts, genesis);
     logger.info("Verified connected beacon node and validator have the same genesisValidatorRoot");
 
-    const {useProduceBlockV3, valProposerConfig} = opts;
+    const {useProduceBlockV3 = defaultOptions.useProduceBlockV3, valProposerConfig} = opts;
     const defaultBuilderSelection =
       valProposerConfig?.defaultConfig.builder?.selection ?? defaultOptions.builderSelection;
     const strictFeeRecipientCheck = valProposerConfig?.defaultConfig.strictFeeRecipientCheck ?? false;


### PR DESCRIPTION
**Motivation**

Current log prints out undefined for `useProduceBlockV3` instead of the default value.

```
info: Initializing validator useProduceBlockV3=undefined, defaultBuilderSelection=executiononly, suggestedFeeRecipient=0x0000000000000000000000000000000000000000, strictFeeRecipientCheck=false
```

**Description**

Log `useProduceBlockV3` default value instead of undefined

```
info: Initializing validator useProduceBlockV3=false, defaultBuilderSelection=executiononly, suggestedFeeRecipient=0x0000000000000000000000000000000000000000, strictFeeRecipientCheck=false
```

cc @g11tech 