### PR TITLE
fix: logtrace produced cache population for blinded block assembly

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -163,6 +163,8 @@ export function getBeaconBlockApi({
       : undefined;
     const blobs = blobSidecars ? blobSidecars.map((blobSidecar) => blobSidecar.blob) : null;
 
+    chain.logger.debug("Assembling blinded block for publishing", {source, blockRoot, slot});
+
     const signedBlockOrContents =
       source === ProducedBlockSource.engine
         ? reconstructFullBlockOrContents({signedBlindedBlock, signedBlindedBlobSidecars}, {executionPayload, blobs})

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -498,16 +498,17 @@ export function getValidatorApi({
             delayMs,
             cutoffMs: BLOCK_PRODUCTION_RACE_CUTOFF_MS,
             timeoutMs: BLOCK_PRODUCTION_RACE_TIMEOUT_MS,
+            slot,
           });
         }
       );
       if (blindedBlock instanceof Error) {
         // error here means race cutoff exceeded
-        logger.error("Failed to produce builder block", {}, blindedBlock);
+        logger.error("Failed to produce builder block", {slot}, blindedBlock);
         blindedBlock = null;
       }
       if (fullBlock instanceof Error) {
-        logger.error("Failed to produce execution block", {}, fullBlock);
+        logger.error("Failed to produce execution block", {slot}, fullBlock);
         fullBlock = null;
       }
     } else if (blindedBlockPromise !== null && fullBlockPromise === null) {
@@ -561,17 +562,19 @@ export function getValidatorApi({
       logger.verbose("Selected engine block: no builder block produced", {
         // winston logger doesn't like bigint
         enginePayloadValue: `${enginePayloadValue}`,
+        slot,
       });
     } else if (blindedBlock && !fullBlock) {
       selectedSource = ProducedBlockSource.builder;
       logger.verbose("Selected builder block: no engine block produced", {
         // winston logger doesn't like bigint
         builderPayloadValue: `${builderPayloadValue}`,
+        slot,
       });
     }
 
     if (selectedSource === null) {
-      throw Error("Failed to produce engine or builder block");
+      throw Error(`Failed to produce engine or builder block for slot=${slot}`);
     }
 
     if (selectedSource === ProducedBlockSource.engine) {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -800,7 +800,6 @@ export class BeaconChain implements IBeaconChain {
     this.seenAttestationDatas.onSlot(slot);
     this.reprocessController.onSlot(slot);
 
-    this.logger.debug("Pruning produced block caches for slot", {slot});
     // Prune old cached block production artifacts, those are only useful on their slot
     pruneSetToMax(this.producedBlockRoot, this.opts.maxCachedProducedRoots ?? DEFAULT_MAX_CACHED_PRODUCED_ROOTS);
     this.metrics?.blockProductionCaches.producedBlockRoot.set(this.producedBlockRoot.size);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -801,6 +801,7 @@ export class BeaconChain implements IBeaconChain {
     this.seenAttestationDatas.onSlot(slot);
     this.reprocessController.onSlot(slot);
 
+    this.logger.debug("Pruning produced block caches for slot", {slot});
     // Prune old cached block production artifacts, those are only useful on their slot
     pruneSetToMax(this.producedBlockRoot, this.opts.maxCachedProducedRoots ?? DEFAULT_MAX_CACHED_PRODUCED_ROOTS);
     this.metrics?.blockProductionCaches.producedBlockRoot.set(this.producedBlockRoot.size);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -511,13 +511,12 @@ export class BeaconChain implements IBeaconChain {
         : this.config.getBlindedForkTypes(slot).BeaconBlock.hashTreeRoot(block as allForks.BlindedBeaconBlock);
     const blockRootHex = toHex(blockRoot);
 
+    // track the produced block for consensus broadcast validations
     if (blockType === BlockType.Full) {
-      // track the produced block for consensus broadcast validations
       this.logger.debug("Setting executionPayload cache for produced block", {blockRootHex, slot, blockType});
       this.producedBlockRoot.set(blockRootHex, (block as bellatrix.BeaconBlock).body.executionPayload ?? null);
       this.metrics?.blockProductionCaches.producedBlockRoot.set(this.producedBlockRoot.size);
     } else {
-      // track the produced block for consensus broadcast validations
       this.logger.debug("Tracking the produced blinded block", {blockRootHex, slot, blockType});
       this.producedBlindedBlockRoot.add(blockRootHex);
       this.metrics?.blockProductionCaches.producedBlindedBlockRoot.set(this.producedBlindedBlockRoot.size);


### PR DESCRIPTION
we have observed issues where a engine block produced via produceBlindedBlock race doesn't get found while assembling from local cache when subsequently published via publishBlindedBlock.

this PR add more logtrace to decipher the problem and also fixes an issue for engine block root calc and tracking which shouldn't have anyway interfered with the engine block assembly at the time of publishBlindedBlock  

plus added slot to various logs so that log search by the slot shows up all relevant logs for debugging