### PR TITLE
fix: handle encoded commas in URL query parameters

### DIFF
--- a/packages/api/test/utils/utils.ts
+++ b/packages/api/test/utils/utils.ts
@@ -10,7 +10,16 @@ export function getTestServer(): {baseUrl: string; server: FastifyInstance} {
 
   const server = fastify({
     ajv: {customOptions: {coerceTypes: "array"}},
-    querystringParser: (str) => qs.parse(str, {comma: true, parseArrays: false}),
+    querystringParser: (str) =>
+      qs.parse(str, {
+        decoder: (str, defaultDecoder, charset, type) => {
+          if (type === "key") {
+            return defaultDecoder(str, defaultDecoder, charset);
+          } else if (type === "value") {
+            return decodeURIComponent(str).split(",");
+          } else throw new Error(`Unexpected type: ${type}`);
+        },
+      }),
   });
 
   server.addHook("onError", (request, reply, error, done) => {

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -51,11 +51,13 @@ export class RestApiServer {
       querystringParser: (str) =>
         qs.parse(str, {
           // Array as comma-separated values must be supported to be OpenAPI spec compliant
-          comma: true,
-          // Drop support for array query strings like `id[0]=1&id[1]=2&id[2]=3` as those are not required to
-          // be OpenAPI spec compliant and results are inconsistent, see https://github.com/ljharb/qs/issues/331.
-          // The schema validation will catch this and throw an error as parsed query string results in an object.
-          parseArrays: false,
+          decoder: (str, defaultDecoder, charset, type) => {
+            if (type === "key") {
+              return defaultDecoder(str, defaultDecoder, charset);
+            } else if (type === "value") {
+              return decodeURIComponent(str).split(",");
+            } else throw new Error(`Unexpected type: ${type}`);
+          },
         }),
       bodyLimit: opts.bodyLimit,
       http: {maxHeaderSize: opts.headerLimit},


### PR DESCRIPTION
**Motivation**

The Teku validator client is unable to fetch validator statuses from a Lodestar beacon node if more than 1 validator status is requested due to the way they request the data. Lodestar should be able to serve Teku's requests.

**Description**

The issue is caused by the differing ways the validator clients encode the query parameter values.

Lodestar VC request:

`GET /eth/v1/beacon/states/head/validators?id=0x978e96b6b6b474f3f91b705a311906b14a5e2893d15e01f5a0ff210393ace5e0abc8488e844dab00f430364ba4c19b1a&id=0x99f013b0314981b0083e494bdd2989304f9fc9dfd2b0c23b40429d817b02acc78f0b4328e45e745a5c6cc48e8f0e9930 HTTP/1.1`

Teku VC request:

`GET /eth/v1/beacon/states/head/validators?id=0x978e96b6b6b474f3f91b705a311906b14a5e2893d15e01f5a0ff210393ace5e0abc8488e844dab00f430364ba4c19b1a%2C0x99f013b0314981b0083e494bdd2989304f9fc9dfd2b0c23b40429d817b02acc78f0b4328e45e745a5c6cc48e8f0e9930 HTTP/1.1`
-> the comma is URI-encoded as `%2C` . Lodestar then returns an empty array of validator statuses, resulting in Teku VC error messages (and the Teku VC therefore not starting validator duties for the affected validators):

```
19:14:03.083 WARN  - Unable to retrieve status for validator 978e96b.
19:14:03.083 WARN  - Unable to retrieve status for validator 99f013b.
```

I did not test other VC clients but it is possible others do the same.
The Beacon API Swagger seems to result in the comma unencoded in the request.

After reading some discussions on this topic, I am still unsure about which way should be considered technically correct and therefore decided to try supporting both ways on the Lodestar side.

This PR implements support for URI-encoded query parameter values, like the ones Teku VC sends. It is backwards compatible - it supports the comma encoded but also unencoded.