### PR TITLE
fix: bound AttesterSlashing instances when producing block

### DIFF
--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -12,6 +12,7 @@ import {
   MAX_VOLUNTARY_EXITS,
   MAX_BLS_TO_EXECUTION_CHANGES,
   BLS_WITHDRAWAL_PREFIX,
+  MAX_ATTESTER_SLASHINGS,
 } from "@lodestar/params";
 import {Epoch, phase0, capella, ssz, ValidatorIndex} from "@lodestar/types";
 import {IBeaconDb} from "../../db/index.js";
@@ -204,6 +205,9 @@ export class OpPool {
         }
         if (isSlashableAtEpoch(validator, stateEpoch)) {
           slashableIndices.add(index);
+        }
+        if (attesterSlashings.length >= MAX_ATTESTER_SLASHINGS) {
+          break attesterSlashing;
         }
       }
 


### PR DESCRIPTION
**Motivation**

Failed to setup dev network and slash a lot of validators there

**Description**

When producing blocks, include `MAX_ATTESTER_SLASHINGS` at most, or `vc` failed to deserialize it from json, see this error #6135

Closes #6135