### PR TITLE
fix: remove duties when deleting remote key via keymanager

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/impl.ts
+++ b/packages/cli/src/cmds/validator/keymanager/impl.ts
@@ -240,11 +240,11 @@ export class KeymanagerApi implements Api {
 
         // Skip unknown keys or remote signers
         const signer = this.validator.validatorStore.getSigner(pubkeyHex);
-        if (signer && signer?.type === SignerType.Local) {
+        if (signer && signer.type === SignerType.Local) {
           // Remove key from live local signer
           deletedKey[i] = this.validator.validatorStore.removeSigner(pubkeyHex);
 
-          // Remove key from blockduties
+          // Remove key from block duties
           // Remove from attestation duties
           // Remove from Sync committee duties
           // Remove from indices
@@ -367,9 +367,12 @@ export class KeymanagerApi implements Api {
 
         // Remove key from live local signer
         const deletedFromMemory =
-          signer && signer?.type === SignerType.Remote ? this.validator.validatorStore.removeSigner(pubkeyHex) : false;
+          signer && signer.type === SignerType.Remote ? this.validator.validatorStore.removeSigner(pubkeyHex) : false;
 
-        // TODO: Remove duties
+        if (deletedFromMemory) {
+          // Remove duties if key was deleted from in-memory store
+          this.validator.removeDutiesForKey(pubkeyHex);
+        }
 
         const deletedFromDisk = this.persistedKeysBackend.deleteRemoteKey(pubkeyHex);
 


### PR DESCRIPTION
**Motivation**

Duties should be removed if key was deleted from in-memory store.

This prevents errors such as in case doppelganger protection is enabled
```
error: Error signing attestation slot=7063462, index=25, head=0x45243768b4c135c1cc6d426b06ce9aaf5f93e606f828d4f1a90a30ffeb462fc3, validatorIndex=453228 - Doppelganger state for key 0xa5920d02398e0e9ade09a9e10b741dd47ffcccd1d468147978560dab20181562d84dc120126fe38aafd4a19456c6e51b is not safe
Error: Doppelganger state for key 0xa5920d02398e0e9ade09a9e10b741dd47ffcccd1d468147978560dab20181562d84dc120126fe38aafd4a19456c6e51b is not safe
    at ValidatorStore.assertDoppelgangerSafe (file:///usr/app/packages/validator/src/services/validatorStore.ts:737:13)
    at ValidatorStore.signAttestation (file:///usr/app/packages/validator/src/services/validatorStore.ts:446:10)
    at file:///usr/app/packages/validator/src/services/attestation.ts:195:61
    at Array.map (<anonymous>)
    at AttestationService.signAndPublishAttestations (file:///usr/app/packages/validator/src/services/attestation.ts:189:14)
    at AttestationService.runAttestationTasksGrouped (file:///usr/app/packages/validator/src/services/attestation.ts:141:16)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at AttestationService.runAttestationTasks (file:///usr/app/packages/validator/src/services/attestation.ts:103:9)
    at Clock.runAtMostEvery (file:///usr/app/packages/validator/src/util/clock.ts:96:7)
```

or if doppelganger protection is not enabled, it would throw an error during `getSignature` call
```
error: Error signing aggregateAndProofs slot=7063462, index=25, validatorIndex=453228 - Validator pubkey 0xa5920d02398e0e9ade09a9e10b741dd47ffcccd1d468147978560dab20181562d84dc120126fe38aafd4a19456c6e51b not known
Error: Validator pubkey 0xa5920d02398e0e9ade09a9e10b741dd47ffcccd1d468147978560dab20181562d84dc120126fe38aafd4a19456c6e51b not known
    at ValidatorStore.getSignature (file:///usr/app/packages/validator/src/services/validatorStore.ts:679:13)
    at ValidatorStore.signAggregateAndProof (file:///usr/app/packages/validator/src/services/validatorStore.ts:500:29)
    at file:///usr/app/packages/validator/src/services/attestation.ts:275:41
    at Array.map (<anonymous>)
    at AttestationService.produceAndPublishAggregates (file:///usr/app/packages/validator/src/services/attestation.ts:269:14)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 0)
    at AttestationService.runAttestationTasksGrouped (file:///usr/app/packages/validator/src/services/attestation.ts:152:5)
    at AttestationService.runAttestationTasks (file:///usr/app/packages/validator/src/services/attestation.ts:103:9)
    at Clock.runAtMostEvery (file:///usr/app/packages/validator/src/util/clock.ts:96:7)
Nov-29 14:52:36.000[]                debug: HttpClient request routeId=getProposerDuties
```


**Description**

Remove duties when deleting remote key via keymanager
