### PR TITLE
fix: include slot in block error metadata

### DIFF
--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -138,10 +138,13 @@ export function renderBlockErrorType(type: BlockErrorType): Record<string, strin
       };
 
     case BlockErrorCode.INVALID_SIGNATURE:
-      return {};
+      return {
+        slot: type.state.slot,
+      };
 
     case BlockErrorCode.INVALID_STATE_ROOT:
       return {
+        slot: type.postState.slot,
         root: toHexString(type.root),
         expectedRoot: toHexString(type.expectedRoot),
       };


### PR DESCRIPTION
**Motivation**

Block errors do not show up when filtering logs by slot, e.g. [logs for slot 7876128](https://grafana-lodestar.chainsafe.io/explore?panes=%7B%222Zb%22:%7B%22datasource%22:%22mWyrm924z%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Binstance%3D%5C%22hetzner-lido-prod-bn-14%5C%22,%20container%3D%5C%22beacon%5C%22%7D%20%7C%3D%20%607876128%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22mWyrm924z%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%221701337469686%22,%22to%22:%221701337810649%22%7D%7D%7D&schemaVersion=1&orgId=1) do not show the actual error

```
2023-11-30 10:46:02.521    
Nov-30 09:46:02.521[rest]            error: Req req-f6dw publishBlockV2 error root=0xd3305606c6b84b65b726a908f70a912bec495da811f7366d1f062c0940156627, expectedRoot=0x4da0fbe9b849c839d107104267ee41641ce41f681e07b1747835d86d60e58a77
2023-11-30 10:46:02.507    
    at JobItemQueue.runJob (file:///usr/app/packages/beacon-node/src/util/queue/itemQueue.ts:101:22)
2023-11-30 10:46:02.507    
    at BeaconChain.processBlocks (file:///usr/app/packages/beacon-node/src/chain/blocks/index.ts:75:68)

2023-11-30 10:46:02.507    
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
2023-11-30 10:46:02.507    
    at BeaconChain.verifyBlocksInEpoch (file:///usr/app/packages/beacon-node/src/chain/blocks/verifyBlock.ts:95:7)
2023-11-30 10:46:02.507    
    at verifyBlocksStateTransitionOnly (file:///usr/app/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts:66:13)
2023-11-30 10:46:02.507    
Error: BLOCK_ERROR_INVALID_STATE_ROOT
```

**Description**

Include slot in block error metadata to make it easier to debug block production errors
