### PR TITLE
chore: consistently include code in block error metadata

### DIFF
--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -134,16 +134,19 @@ export function renderBlockErrorType(type: BlockErrorType): Record<string, strin
     case BlockErrorCode.PER_BLOCK_PROCESSING_ERROR:
     case BlockErrorCode.BEACON_CHAIN_ERROR:
       return {
+        code: type.code,
         error: type.error.message,
       };
 
     case BlockErrorCode.INVALID_SIGNATURE:
       return {
+        code: type.code,
         slot: type.state.slot,
       };
 
     case BlockErrorCode.INVALID_STATE_ROOT:
       return {
+        code: type.code,
         slot: type.postState.slot,
         root: toHexString(type.root),
         expectedRoot: toHexString(type.expectedRoot),


### PR DESCRIPTION
**Motivation**

Follow up to https://github.com/ChainSafe/lodestar/pull/6146, noticed we are omitting error code in some block errors but those add more context to the error message itself without having to look into the stack trace which does not show up when filtering logs by slot in grafana.

**Description**

Consistently include code in block error metadata

By default would render type which always include `code`
https://github.com/ChainSafe/lodestar/blob/9475b8d40224848a6cc193ded54a1d4a3ef42a20/packages/beacon-node/src/chain/errors/blockError.ts#L152-L153

This aligns the implementation with what is currently done for `AttestationError`
https://github.com/ChainSafe/lodestar/blob/9475b8d40224848a6cc193ded54a1d4a3ef42a20/packages/beacon-node/src/chain/errors/attestationError.ts#L169-L170
