### PR TITLE
feat: implement consensus broadcastValidation and set it to default

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -52,7 +52,6 @@ export type BlockHeaderResponse = {
 };
 
 export enum BroadcastValidation {
-  none = "none",
   gossip = "gossip",
   consensus = "consensus",
   consensusAndEquivocation = "consensus_and_equivocation",

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -59,7 +59,7 @@ export const testData: GenericServerTestCases<Api> = {
     res: undefined,
   },
   publishBlockV2: {
-    args: [ssz.phase0.SignedBeaconBlock.defaultValue(), {broadcastValidation: BroadcastValidation.none}],
+    args: [ssz.phase0.SignedBeaconBlock.defaultValue(), {broadcastValidation: BroadcastValidation.consensus}],
     res: undefined,
   },
   publishBlindedBlock: {
@@ -67,7 +67,7 @@ export const testData: GenericServerTestCases<Api> = {
     res: undefined,
   },
   publishBlindedBlockV2: {
-    args: [getDefaultBlindedBlock(64), {broadcastValidation: BroadcastValidation.none}],
+    args: [getDefaultBlindedBlock(64), {broadcastValidation: BroadcastValidation.consensus}],
     res: undefined,
   },
   getBlobSidecars: {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -86,6 +86,7 @@ export function getBeaconBlockApi({
               await validateGossipBlock(config, chain, signedBlock, fork);
             } catch (error) {
               chain.logger.error("Gossip validations failed while publishing the block", valLogMeta, error as Error);
+              throw error;
             }
           }
         }

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -68,7 +68,7 @@ export function getBeaconBlockApi({
 
     // check what validations have been requested before broadcasting and publishing the block
     // TODO: add validation time to metrics
-    const broadcastValidation = opts.broadcastValidation ?? routes.beacon.BroadcastValidation.consensus;
+    const broadcastValidation = opts.broadcastValidation ?? routes.beacon.BroadcastValidation.gossip;
     // if block is locally produced, full or blinded, it already is 'consensus' validated as it went through
     // state transition to produce the stateRoot
     const slot = signedBlock.message.slot;

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -4,11 +4,11 @@ import {
   computeTimeAtSlot,
   parseSignedBlindedBlockOrContents,
   reconstructFullBlockOrContents,
+  DataAvailableStatus,
 } from "@lodestar/state-transition";
 import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {sleep, toHex} from "@lodestar/utils";
 import {allForks, deneb, isSignedBlockContents, ProducedBlockSource} from "@lodestar/types";
-import {DataAvailableStatus} from "@lodestar/state-transition/src/index.js";
 import {BlockSource, getBlockInput, ImportBlockOpts, BlockInput} from "../../../../chain/blocks/types.js";
 import {promiseAllMaybeAsync} from "../../../../util/promises.js";
 import {isOptimisticBlock} from "../../../../util/forkChoice.js";

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -136,7 +136,7 @@ export function getBeaconBlockApi({
           if (chain.opts.broadcastValidationStrictness === "error") {
             throw Error(message);
           } else {
-            chain.logger.warn(message);
+            chain.logger.warn(message, valLogMeta);
           }
         }
         break;
@@ -148,7 +148,7 @@ export function getBeaconBlockApi({
         if (chain.opts.broadcastValidationStrictness === "error") {
           throw Error(message);
         } else {
-          chain.logger.warn(message);
+          chain.logger.warn(message, valLogMeta);
         }
       }
     }

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -89,7 +89,6 @@ export function getBeaconBlockApi({
           }
         }
         chain.logger.debug("Gossip checks validated while publishing the block", valLogMeta);
-        // TODO: figure out if consensus validation is required for gossip or not
         break;
       }
 

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -100,7 +100,14 @@ export function getBeaconBlockApi({
         if (!blockLocallyProduced) {
           const parentBlock = chain.forkChoice.getBlock(signedBlock.message.parentRoot);
           if (parentBlock === null) {
-            throw Error("parentRoot not found in forkChoice");
+            network.events.emit(NetworkEvent.unknownBlockParent, {
+              blockInput: blockForImport,
+              peer: IDENTITY_PEER_ID,
+            });
+            throw new BlockError(signedBlock, {
+              code: BlockErrorCode.PARENT_UNKNOWN,
+              parentRoot: toHexString(signedBlock.message.parentRoot),
+            });
           }
 
           try {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -79,20 +79,19 @@ export function getBeaconBlockApi({
     const valLogMeta = {broadcastValidation, blockRoot, blockLocallyProduced, slot};
 
     switch (broadcastValidation) {
-      case routes.beacon.BroadcastValidation.gossip:
-        {
-          if (!blockLocallyProduced) {
-            try {
-              await validateGossipBlock(config, chain, signedBlock, fork);
-            } catch (error) {
-              chain.logger.error("Gossip validations failed while publishing the block", valLogMeta, error as Error);
-              throw error;
-            }
+      case routes.beacon.BroadcastValidation.gossip: {
+        if (!blockLocallyProduced) {
+          try {
+            await validateGossipBlock(config, chain, signedBlock, fork);
+          } catch (error) {
+            chain.logger.error("Gossip validations failed while publishing the block", valLogMeta, error as Error);
+            throw error;
           }
         }
         chain.logger.debug("Gossip checks validated while publishing the block", valLogMeta);
         // TODO: figure out if consensus validation is required for gossip or not
         break;
+      }
 
       case routes.beacon.BroadcastValidation.consensusAndEquivocation:
       case routes.beacon.BroadcastValidation.consensus: {

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -7,7 +7,7 @@ import {
 } from "@lodestar/state-transition";
 import {bellatrix} from "@lodestar/types";
 import {ForkName} from "@lodestar/params";
-import {ProtoBlock} from "@lodestar/fork-choice";
+import {ProtoBlock, ExecutionStatus} from "@lodestar/fork-choice";
 import {ChainForkConfig} from "@lodestar/config";
 import {Logger} from "@lodestar/utils";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
@@ -90,7 +90,14 @@ export async function verifyBlocksInEpoch(
     // batch all I/O operations to reduce overhead
     const [segmentExecStatus, {postStates, proposerBalanceDeltas}] = await Promise.all([
       // Execution payloads
-      verifyBlocksExecutionPayload(this, parentBlock, blocks, preState0, abortController.signal, opts),
+      opts.skipVerifyExecutionPayload !== true
+        ? verifyBlocksExecutionPayload(this, parentBlock, blocks, preState0, abortController.signal, opts)
+        : Promise.resolve({
+            execAborted: null,
+            executionStatuses: blocks.map((_blk) => ExecutionStatus.Syncing),
+            mergeBlockFound: null,
+          } as SegmentExecStatus),
+
       // Run state transition only
       // TODO: Ensure it yields to allow flushing to workers and engine API
       verifyBlocksStateTransitionOnly(
@@ -104,37 +111,43 @@ export async function verifyBlocksInEpoch(
       ),
 
       // All signatures at once
-      verifyBlocksSignatures(this.bls, this.logger, this.metrics, preState0, blocks, opts),
+      opts.skipVerifyBlockSignatures !== true
+        ? verifyBlocksSignatures(this.bls, this.logger, this.metrics, preState0, blocks, opts)
+        : Promise.resolve(),
 
       // ideally we want to only persist blocks after verifying them however the reality is there are
       // rarely invalid blocks we'll batch all I/O operation here to reduce the overhead if there's
       // an error, we'll remove blocks not in forkchoice
-      opts.eagerPersistBlock ? writeBlockInputToDb.call(this, blocksInput) : Promise.resolve(),
+      opts.verifyOnly !== true && opts.eagerPersistBlock
+        ? writeBlockInputToDb.call(this, blocksInput)
+        : Promise.resolve(),
     ]);
 
-    if (segmentExecStatus.execAborted === null && segmentExecStatus.mergeBlockFound !== null) {
-      // merge block found and is fully valid = state transition + signatures + execution payload.
-      // TODO: Will this banner be logged during syncing?
-      logOnPowBlock(this.logger, this.config, segmentExecStatus.mergeBlockFound);
-    }
+    if (opts.verifyOnly !== true) {
+      if (segmentExecStatus.execAborted === null && segmentExecStatus.mergeBlockFound !== null) {
+        // merge block found and is fully valid = state transition + signatures + execution payload.
+        // TODO: Will this banner be logged during syncing?
+        logOnPowBlock(this.logger, this.config, segmentExecStatus.mergeBlockFound);
+      }
 
-    const fromFork = this.config.getForkName(parentBlock.slot);
-    const toFork = this.config.getForkName(blocks[blocks.length - 1].message.slot);
+      const fromFork = this.config.getForkName(parentBlock.slot);
+      const toFork = this.config.getForkName(blocks[blocks.length - 1].message.slot);
 
-    // If transition through toFork, note won't happen if ${toFork}_EPOCH = 0, will log double on re-org
-    if (toFork !== fromFork) {
-      switch (toFork) {
-        case ForkName.capella:
-          this.logger.info(CAPELLA_OWL_BANNER);
-          this.logger.info("Activating withdrawals", {epoch: this.config.CAPELLA_FORK_EPOCH});
-          break;
+      // If transition through toFork, note won't happen if ${toFork}_EPOCH = 0, will log double on re-org
+      if (toFork !== fromFork) {
+        switch (toFork) {
+          case ForkName.capella:
+            this.logger.info(CAPELLA_OWL_BANNER);
+            this.logger.info("Activating withdrawals", {epoch: this.config.CAPELLA_FORK_EPOCH});
+            break;
 
-        case ForkName.deneb:
-          this.logger.info(DENEB_BLOWFISH_BANNER);
-          this.logger.info("Activating blobs", {epoch: this.config.DENEB_FORK_EPOCH});
-          break;
+          case ForkName.deneb:
+            this.logger.info(DENEB_BLOWFISH_BANNER);
+            this.logger.info("Activating blobs", {epoch: this.config.DENEB_FORK_EPOCH});
+            break;
 
-        default:
+          default:
+        }
       }
     }
 

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -19,7 +19,7 @@ import {
 } from "@lodestar/fork-choice";
 import {ChainForkConfig} from "@lodestar/config";
 import {ErrorAborted, Logger} from "@lodestar/utils";
-import {ForkSeq} from "@lodestar/params";
+import {ForkSeq, SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY} from "@lodestar/params";
 
 import {IExecutionEngine} from "../../execution/engine/interface.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
@@ -143,9 +143,10 @@ export async function verifyBlocksExecutionPayload(
   const lastBlock = blocks[blocks.length - 1];
 
   const currentSlot = chain.clock.currentSlot;
+  const safeSlotsToImportOptimistically = opts.safeSlotsToImportOptimistically ?? SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY;
   let isOptimisticallySafe =
     parentBlock.executionStatus !== ExecutionStatus.PreMerge ||
-    lastBlock.message.slot + opts.safeSlotsToImportOptimistically < currentSlot;
+    lastBlock.message.slot + safeSlotsToImportOptimistically < currentSlot;
 
   for (let blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
     const block = blocks[blockIndex];
@@ -331,7 +332,9 @@ export async function verifyBlockExecutionPayload(
       // Check if the entire segment was deemed safe or, this block specifically itself if not in
       // the safeSlotsToImportOptimistically window of current slot, then we can import else
       // we need to throw and not import his block
-      if (!isOptimisticallySafe && block.message.slot + opts.safeSlotsToImportOptimistically >= currentSlot) {
+      const safeSlotsToImportOptimistically =
+        opts.safeSlotsToImportOptimistically ?? SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY;
+      if (!isOptimisticallySafe && block.message.slot + safeSlotsToImportOptimistically >= currentSlot) {
         const execError = new BlockError(block, {
           code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
           execStatus: ExecutionPayloadStatus.UNSAFE_OPTIMISTIC_STATUS,

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -55,6 +55,8 @@ export type BlockProcessOpts = {
    */
   disableImportExecutionFcU?: boolean;
   emitPayloadAttributes?: boolean;
+
+  // Flags to use for broadcastValidation while publishing block
   verifyOnly?: boolean;
   skipVerifyExecutionPayload?: boolean;
   skipVerifyBlockSignatures?: boolean;

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -40,7 +40,7 @@ export type BlockProcessOpts = {
   /**
    * Override SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY
    */
-  safeSlotsToImportOptimistically: number;
+  safeSlotsToImportOptimistically?: number;
   /**
    * Assert progressive balances the same to EpochTransitionCache
    */
@@ -55,6 +55,9 @@ export type BlockProcessOpts = {
    */
   disableImportExecutionFcU?: boolean;
   emitPayloadAttributes?: boolean;
+  verifyOnly?: boolean;
+  skipVerifyExecutionPayload?: boolean;
+  skipVerifyBlockSignatures?: boolean;
 };
 
 export type PoolOpts = {

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -56,9 +56,15 @@ export type BlockProcessOpts = {
   disableImportExecutionFcU?: boolean;
   emitPayloadAttributes?: boolean;
 
-  // Flags to use for broadcastValidation while publishing block
+  /**
+   * Used to specify to specify to run verifications only and not
+   * to save the block or log transitions for e.g. doing
+   * broadcastValidation while publishing the block
+   */
   verifyOnly?: boolean;
+  /** Used to specify to skip execution payload validation */
   skipVerifyExecutionPayload?: boolean;
+  /** Used to specify to skip block signatures validation */
   skipVerifyBlockSignatures?: boolean;
 };
 


### PR DESCRIPTION
as a safety precaution for not broadcasting a invalid block ( see https://github.com/ChainSafe/lodestar/pull/6131), broadcastValidation consensus is imlemented and applied by default now.

In happy case of block produced by engine/builder via the beacon node, no extra work would be done while publishing as the root lookup is used to fast verify consensus validations. In case where the local root loookup fails validations are applied and will not let the invalid block to be broadcasted for e.g. because of the bug #6131 is trying to resolve.

Tested it locally as well for happy path on local by making consensus validations to always run 