### PR TITLE
fix: prevent low peer count warning on startup

### DIFF
--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -33,7 +33,7 @@ export async function runNodeNotifier(modules: NodeNotifierModules): Promise<voi
   const tdTimeSeries = new TimeSeries({maxPoints: 50});
 
   const SLOTS_PER_SYNC_COMMITTEE_PERIOD = SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD;
-  let hasLowPeerCount = false; // Only log once
+  let hasLowPeerCount = false;
   let isFirstTime = true;
 
   try {
@@ -41,7 +41,8 @@ export async function runNodeNotifier(modules: NodeNotifierModules): Promise<voi
       const connectedPeerCount = network.getConnectedPeerCount();
 
       if (connectedPeerCount <= WARN_PEER_COUNT) {
-        if (!hasLowPeerCount) {
+        // Only log once and prevent peer count warning on startup
+        if (!hasLowPeerCount && !isFirstTime) {
           logger.warn("Low peer count", {peers: connectedPeerCount});
           hasLowPeerCount = true;
         }


### PR DESCRIPTION
**Motivation**

Improve logs, should only print warnings if they are actually meaningful

**Description**

Prevent low peer count warning on startup
```
warn: Low peer count peers=0
```
This warning is printed out consistently on every startup but it does not add any meaningful information at this point in time. There is also an additional check to only print it once which means if there are still 0 peers on the second notifier run it will not print out a warning but at that point it would be a good warning as Lodestar likely struggles to get peers as based on my observation at this time there are usually 5-20 peers.

This change addresses both issues and reuses `isFirstTime` variable introduced in https://github.com/ChainSafe/lodestar/pull/5545