### PR TITLE
fix: set consensus version header in state and block response

### DIFF
--- a/packages/api/src/beacon/server/beacon.ts
+++ b/packages/api/src/beacon/server/beacon.ts
@@ -1,4 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
+import {ssz} from "@lodestar/types";
 import {Api, ReqTypes, routesData, getReturnTypes, getReqSerializers} from "../routes/beacon/index.js";
 import {ServerRoutes, getGenericJsonServer} from "../../utils/server/index.js";
 import {ServerApi} from "../../interfaces.js";
@@ -30,15 +31,35 @@ export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerR
     },
     getBlockV2: {
       ...serverRoutes.getBlockV2,
-      handler: async (req) => {
+      handler: async (req, res) => {
         const response = await api.getBlockV2(...reqSerializers.getBlockV2.parseReq(req));
         if (response instanceof Uint8Array) {
+          const slot = extractSlotFromBlockBytes(response);
+          const version = config.getForkName(slot);
+          void res.header("Eth-Consensus-Version", version);
           // Fastify 3.x.x will automatically add header `Content-Type: application/octet-stream` if Buffer
           return Buffer.from(response);
         } else {
+          void res.header("Eth-Consensus-Version", response.version);
           return returnTypes.getBlockV2.toJson(response);
         }
       },
     },
   };
+}
+
+function extractSlotFromBlockBytes(block: Uint8Array): number {
+  const {signature} = ssz.phase0.SignedBeaconBlock.fields;
+  /**
+   * class SignedBeaconBlock(Container):
+   *   message: BeaconBlock                 [offset - 4 bytes]
+   *   signature: BLSSignature              [fixed - 96 bytes]
+   *
+   * class BeaconBlock(Container):
+   *   slot: Slot                           [fixed - 8 bytes]
+   *   ...
+   */
+  const offset = 4 + signature.lengthBytes;
+  const bytes = block.subarray(offset, offset + ssz.Slot.byteLength);
+  return ssz.Slot.deserialize(bytes);
 }


### PR DESCRIPTION
**Motivation**

Beacon-API spec requires to set `Eth-Consensus-Version` in [getStateV2](https://ethereum.github.io/beacon-APIs/#/Debug/getStateV2) and [getBlockV2](https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2) response.

![image](https://github.com/ChainSafe/lodestar/assets/38436224/77517ee6-4989-4cd3-a698-da7c20a20f5d)

**Description**

Set consensus version header in state and block response in both json and ssz response as per spec both require the header.

Confirmed results manually as current API client design does not allow to access header values in tests.

```
 curl -s -o /dev/null -D - http://beacon:9596/eth/v2/debug/beacon/states/head -H "Accept: application/octet-stream"
HTTP/1.1 200 OK
...
eth-consensus-version: capella
content-type: application/octet-stream
...
```

**Note:** This is not a long-term solution, all the code here will be removed in API refactoring done in https://github.com/ChainSafe/lodestar/pull/6080

Closes https://github.com/ChainSafe/lodestar/issues/6123
Closes https://github.com/ChainSafe/lodestar/issues/6124