### PR TITLE
fix: do not uri-encode Basic Auth header contents

### DIFF
--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -109,7 +109,8 @@ export class HttpClient implements IHttpClient {
   private readonly urlsScore: number[];
 
   get baseUrl(): string {
-    return this.urlsOpts[0].baseUrl;
+    // Don't leak username/password to caller
+    return new URL(this.urlsOpts[0].baseUrl).origin;
   }
 
   /**

--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -292,7 +292,7 @@ export class HttpClient implements IHttpClient {
       }
       if (url.username || url.password) {
         if (headers["Authorization"] === undefined) {
-          headers["Authorization"] = `Basic ${toBase64(`${url.username}:${url.password}`)}`;
+          headers["Authorization"] = `Basic ${toBase64(decodeURIComponent(`${url.username}:${url.password}`))}`;
         }
         // Remove the username and password from the URL
         url.username = "";

--- a/packages/api/test/unit/client/httpClient.test.ts
+++ b/packages/api/test/unit/client/httpClient.test.ts
@@ -174,6 +174,16 @@ describe("httpClient json client", () => {
     await httpClient.json(testRoute);
   });
 
+  it("should not leak user credentials in baseUrl getter", () => {
+    const url = new URL("http://localhost");
+    url.username = "user";
+    url.password = "password";
+    const httpClient = new HttpClient({baseUrl: url.toString()});
+
+    expect(httpClient.baseUrl.includes(url.username)).to.be.false;
+    expect(httpClient.baseUrl.includes(url.password)).to.be.false;
+  });
+
   it("should handle aborting request with timeout", async () => {
     const {baseUrl} = await getServer({
       ...testRoute,

--- a/packages/api/test/unit/client/httpClientOptions.test.ts
+++ b/packages/api/test/unit/client/httpClientOptions.test.ts
@@ -83,4 +83,8 @@ describe("HTTPClient options", () => {
   it("Throw if invalid value in urls option", () => {
     expect(() => new HttpClient({urls: ["invalid"]})).to.throw(Error);
   });
+
+  it("Throw if invalid username/password", () => {
+    expect(() => new HttpClient({baseUrl: "http://hasa%:%can'tbedecoded@localhost"})).to.throw(Error);
+  });
 });

--- a/packages/utils/src/validation.ts
+++ b/packages/utils/src/validation.ts
@@ -9,7 +9,7 @@ export function isValidHttpUrl(urlStr: string): boolean {
     //
     // Make sure that we can successfully decode the username and password here.
     //
-    // Unfortunately this menas we don't accept every character supported by RFC-3986.
+    // Unfortunately this means we don't accept every character supported by RFC-3986.
     decodeURIComponent(url.username);
     decodeURIComponent(url.password);
   } catch (_) {

--- a/packages/utils/src/validation.ts
+++ b/packages/utils/src/validation.ts
@@ -2,6 +2,16 @@ export function isValidHttpUrl(urlStr: string): boolean {
   let url;
   try {
     url = new URL(urlStr);
+
+    // `new URL` encodes the username/password with the userinfo percent-encode set.
+    // This means the `%` character is not encoded, but others are (such as `=`).
+    // If a username/password contain a `%`, they will not be able to be decoded.
+    //
+    // Make sure that we can successfully decode the username and password here.
+    //
+    // Unfortunately this menas we don't accept every character supported by RFC-3986.
+    decodeURIComponent(url.username);
+    decodeURIComponent(url.password);
   } catch (_) {
     return false;
   }


### PR DESCRIPTION
**Motivation**

Basic Auth is supported by all clients, and only Lodestar URI-encodes certain special characters provided in the userinfo portion of the URI. These changes align Lodestar with the other clients.

Additionally, it adds some protection against leaking http uri userinfo segments into the logs, as they could be considered sensitive.

**Description**

First commit fixes the issue where `new URL()` would URI-encode the `=` character by simply calling decodeURIComponent on username/password from the parsed URL.

Re: https://github.com/ChainSafe/lodestar/issues/6154#issuecomment-1839305982

Certain characters are not allowed in URIs, even in the userinfo field. These seem to align with the `new URL()` behavior fine:
```
userinfo      = *( unreserved / pct-encoded / sub-delims / ":" )
unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
pct-encoded   = "%" HEXDIG HEXDIG
sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
                 / "*" / "+" / "," / ";" / "="
```

Specifically, `@` and `#` are in gen-delims, and should not be parts of username:password pairs provided in a URI.

Because of the way javascript handles URLs, `%` will not be encoded, and users providing URIs to lodestar with userinfo that contains a `%` character should take care to manually encode it as `%25`.

Closes #6154

**Steps to test or reproduce**

`yarn test`
