### PR TITLE
docs: improve prerequisites for OSX users

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -8,7 +8,6 @@ CLI
 CTRL
 Chai
 ChainSafe
-coreutils
 Customizations
 Discv
 DockerHub
@@ -78,6 +77,7 @@ config
 configs
 const
 constantish
+coreutils
 cors
 cryptographic
 dApp
@@ -107,7 +107,6 @@ namespace
 namespaced
 namespaces
 nodemodule
-OSX
 overriden
 params
 plaintext

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -8,6 +8,7 @@ CLI
 CTRL
 Chai
 ChainSafe
+coreutils
 Customizations
 Discv
 DockerHub
@@ -106,6 +107,7 @@ namespace
 namespaced
 namespaces
 nodemodule
+OSX
 overriden
 params
 plaintext

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ Thanks for your interest in contributing to Lodestar. It's people like you that 
 
 When using OSX a couple extra prerequisites are required.
 
-* python
-* coreutils (e.g. via `brew install coreutils`)
+- python
+- coreutils (e.g. via `brew install coreutils`)
 
 ## Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,9 @@ Thanks for your interest in contributing to Lodestar. It's people like you that 
 - :gear: [NodeJS](https://nodejs.org/) (LTS)
 - :toolbox: [Yarn](https://yarnpkg.com/)
 
-### OSX Specifics
+### MacOS Specifics
 
-When using OSX a couple extra prerequisites are required.
+When using MacOS a couple extra prerequisites are required.
 
 - python
 - coreutils (e.g. via `brew install coreutils`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thanks for your interest in contributing to Lodestar. It's people like you that 
 
 ### MacOS Specifics
 
-When using MacOS a couple extra prerequisites are required.
+When using MacOS, there are a couple of extra prerequisites that are required.
 
 - python
 - coreutils (e.g. via `brew install coreutils`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,13 @@ Thanks for your interest in contributing to Lodestar. It's people like you that 
 - :gear: [NodeJS](https://nodejs.org/) (LTS)
 - :toolbox: [Yarn](https://yarnpkg.com/)
 
+### OSX Specifics
+
+When using OSX a couple extra prerequisistes are required.
+
+* python
+* coreutils (e.g. via `brew install coreutils`)
+
 ## Getting Started
 
 - :gear: Run `yarn` to install dependencies.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thanks for your interest in contributing to Lodestar. It's people like you that 
 
 ### OSX Specifics
 
-When using OSX a couple extra prerequisistes are required.
+When using OSX a couple extra prerequisites are required.
 
 * python
 * coreutils (e.g. via `brew install coreutils`)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@
 
 ## Prerequisites
 
-First follow the prerequisites list [here](./CONTRIBUTING.md#prerequisites)
+- :gear: [NodeJS](https://nodejs.org/) (LTS)
+- :toolbox: [Yarn](https://yarnpkg.com/)
 
 ###### Developer Quickstart:
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@
 
 ## Prerequisites
 
-- :gear: [NodeJS](https://nodejs.org/) (LTS)
-- :toolbox: [Yarn](https://yarnpkg.com/)
+First follow the prerequisites list [here](./CONTRIBUTING.md#prerequisites)
 
 ###### Developer Quickstart:
 

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -144,6 +144,7 @@ describe("LevelDB controller", () => {
           return "gdu";
         }
       } catch {
+        /* eslint-disable no-console */
         console.error("Cannot find correct gdu command");
       }
     }

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -145,7 +145,7 @@ describe("LevelDB controller", () => {
         }
       } catch {
         /* eslint-disable no-console */
-        console.error("Cannot find correct gdu command");
+        console.error("Cannot find gdu command, falling back to du");
       }
     }
     return "du";

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -144,7 +144,7 @@ describe("LevelDB controller", () => {
           return "gdu";
         }
       } catch {
-        console.error('Cannot find correct gdu command');
+        console.error("Cannot find correct gdu command");
       }
     }
     return "du";

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -144,7 +144,7 @@ describe("LevelDB controller", () => {
           return "gdu";
         }
       } catch {
-        /* no-op */
+        console.error('Cannot find correct gdu command');
       }
     }
     return "du";


### PR DESCRIPTION
**Motivation**

Improves DX for OSX users

**Description**

Add some extra prerequisites for OSX users so that they can build/test `lodestar`.
`python` is required for mac silicon users as https://github.com/ChainSafe/blst-ts doesn't provide a prebuild for those CPUs
