### PR TITLE
fix: clone attestations for block inclusion

### DIFF
--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -166,10 +166,16 @@ export class AggregatedAttestationPool {
       }
     }
 
-    return attestationsByScore
-      .sort((a, b) => b.score - a.score)
-      .slice(0, MAX_ATTESTATIONS)
-      .map((attestation) => attestation.attestation);
+    const sortedAttestationsByScore = attestationsByScore.sort((a, b) => b.score - a.score);
+    const attestationsForBlock: phase0.Attestation[] = [];
+    for (const [i, attestationWithScore] of sortedAttestationsByScore.entries()) {
+      if (i >= MAX_ATTESTATIONS) {
+        break;
+      }
+      // attestations could be modified in this op pool, so we need to clone for block
+      attestationsForBlock.push(ssz.phase0.Attestation.clone(attestationWithScore.attestation));
+    }
+    return attestationsForBlock;
   }
 
   /**


### PR DESCRIPTION
**Motivation**

After attestations are included for block, they could be modified by gossip, see https://github.com/ChainSafe/lodestar/blob/8bd19f431f4766bbb8066a6d858cb756d68536ae/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts#L251

This lead to the produced block and the published block (the block we received in `publishBlock` api) could be different

**Description**

Clone attestations to include for block