### PR TITLE
fix: pass user credentials to events http client

### DIFF
--- a/packages/api/src/beacon/client/events.ts
+++ b/packages/api/src/beacon/client/events.ts
@@ -1,6 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {Api, BeaconEvent, routesData, getEventSerdes} from "../routes/events.js";
-import {stringifyQuery} from "../../utils/client/format.js";
+import {stringifyQuery, urlJoin} from "../../utils/client/format.js";
 import {getEventSource} from "../../utils/client/eventSource.js";
 import {HttpStatusCode} from "../../utils/client/httpStatusCode.js";
 
@@ -13,8 +13,7 @@ export function getClient(config: ChainForkConfig, baseUrl: string): Api {
   return {
     eventstream: async (topics, signal, onEvent) => {
       const query = stringifyQuery({topics});
-      // TODO: Use a proper URL formatter
-      const url = `${baseUrl}${routesData.eventstream.url}?${query}`;
+      const url = `${urlJoin(baseUrl, routesData.eventstream.url)}?${query}`;
       // eslint-disable-next-line @typescript-eslint/naming-convention
       const EventSource = await getEventSource();
       const eventSource = new EventSource(url);
@@ -58,4 +57,4 @@ export function getClient(config: ChainForkConfig, baseUrl: string): Api {
 }
 
 // https://github.com/EventSource/eventsource/blob/82e034389bd2c08d532c63172b8e858c5b185338/lib/eventsource.js#L143
-type EventSourceError = {status: number; message: string};
+type EventSourceError = {status?: number; message: string};

--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -109,8 +109,7 @@ export class HttpClient implements IHttpClient {
   private readonly urlsScore: number[];
 
   get baseUrl(): string {
-    // Don't leak username/password to caller
-    return new URL(this.urlsOpts[0].baseUrl).origin;
+    return this.urlsOpts[0].baseUrl;
   }
 
   /**

--- a/packages/api/test/unit/client/httpClient.test.ts
+++ b/packages/api/test/unit/client/httpClient.test.ts
@@ -174,16 +174,6 @@ describe("httpClient json client", () => {
     await httpClient.json(testRoute);
   });
 
-  it("should not leak user credentials in baseUrl getter", () => {
-    const url = new URL("http://localhost");
-    url.username = "user";
-    url.password = "password";
-    const httpClient = new HttpClient({baseUrl: url.toString()});
-
-    expect(httpClient.baseUrl.includes(url.username)).toBe(false);
-    expect(httpClient.baseUrl.includes(url.password)).toBe(false);
-  });
-
   it("should handle aborting request with timeout", async () => {
     const {baseUrl} = await getServer({
       ...testRoute,

--- a/packages/validator/src/services/chainHeaderTracker.ts
+++ b/packages/validator/src/services/chainHeaderTracker.ts
@@ -31,8 +31,10 @@ export class ChainHeaderTracker {
   ) {}
 
   start(signal: AbortSignal): void {
-    void this.api.events.eventstream([EventType.head], signal, this.onHeadUpdate);
-    this.logger.verbose("Subscribed to head event");
+    this.logger.verbose("Subscribing to head event");
+    this.api.events
+      .eventstream([EventType.head], signal, this.onHeadUpdate)
+      .catch((e) => this.logger.error("Failed to subscribe to head event", {}, e));
   }
 
   getCurrentChainHead(slot: Slot): Root | null {


### PR DESCRIPTION
**Motivation**

Eventstream API does not work with rescue node at the moment because user credentials are removed from URL which is passed to events client.

https://github.com/ChainSafe/lodestar/blob/959a8af1b757c46a0e57450788fb72773a372608/packages/api/src/beacon/client/index.ts#L31

**Description**

Pass user credentials to events http client. The `EventSource` node implementation will parse the credentials, remove them from the URL and set them in Authorization header. The browser implementation does not support credentials via URL and headers are generally not supported (https://github.com/whatwg/html/issues/2177). We don't expect anyone to use the rescue node from browser, but it is possible to pass authentication tokens as part of cookies.

Closes https://github.com/ChainSafe/lodestar/issues/4521, this was previously already fixed by calling `new URL(...).origin` on the URL as it removed the extra `/` but I am now calling `urlJoin` which we also use in http client to join urls/paths.