### PR TITLE
chore: update flag to pass builder url

### DIFF
--- a/docs/pages/beacon-management/mev-and-builder-integration.md
+++ b/docs/pages/beacon-management/mev-and-builder-integration.md
@@ -20,7 +20,7 @@ All you have to do is:
 
 1. Provide lodestar beacon node with a Builder endpoint (which corresponds to the network you are running) via these additional flags:
    ```shell
-   --builder --builder.urls <builder/relay/boost url>
+   --builder --builder.url <builder/relay/boost url>
    ```
 2. Run lodestar validator client with these additional flags
    ```shell

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -16,7 +16,7 @@ import {IExecutionBuilder} from "./interface.js";
 
 export type ExecutionBuilderHttpOpts = {
   enabled: boolean;
-  urls: string[];
+  url: string;
   timeout?: number;
   faultInspectionWindow?: number;
   allowedFaults?: number;
@@ -29,7 +29,7 @@ export type ExecutionBuilderHttpOpts = {
 
 export const defaultExecutionBuilderHttpOpts: ExecutionBuilderHttpOpts = {
   enabled: false,
-  urls: ["http://localhost:8661"],
+  url: "http://localhost:8661",
   timeout: 12000,
 };
 
@@ -48,7 +48,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
     metrics: Metrics | null = null,
     logger?: Logger
   ) {
-    const baseUrl = opts.urls[0];
+    const baseUrl = opts.url;
     if (!baseUrl) throw Error("No Url provided for executionBuilder");
     this.api = getClient(
       {

--- a/packages/beacon-node/test/sim/mergemock.test.ts
+++ b/packages/beacon-node/test/sim/mergemock.test.ts
@@ -157,7 +157,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
         eth1: {enabled: false, providerUrls: [engineRpcUrl], jwtSecretHex},
         executionEngine: {urls: [engineRpcUrl], jwtSecretHex},
         executionBuilder: {
-          urls: [ethRpcUrl],
+          url: ethRpcUrl,
           enabled: true,
           issueLocalFcUWithFeeRecipient: feeRecipientMevBoost,
           allowedFaults: 16,

--- a/packages/cli/src/options/beaconNodeOptions/builder.ts
+++ b/packages/cli/src/options/beaconNodeOptions/builder.ts
@@ -1,5 +1,5 @@
 import {defaultExecutionBuilderHttpOpts, IBeaconNodeOptions} from "@lodestar/beacon-node";
-import {CliCommandOptions} from "../../util/index.js";
+import {CliCommandOptions, YargsError} from "../../util/index.js";
 
 export type ExecutionBuilderArgs = {
   builder: boolean;
@@ -10,6 +10,12 @@ export type ExecutionBuilderArgs = {
 };
 
 export function parseArgs(args: ExecutionBuilderArgs): IBeaconNodeOptions["executionBuilder"] {
+  if (Array.isArray(args["builder.url"]) || args["builder.url"]?.includes(",http")) {
+    throw new YargsError(
+      "Lodestar only supports a single builder URL. External tooling like mev-boost can be used to connect to multiple builder/relays"
+    );
+  }
+
   return {
     enabled: args["builder"],
     url: args["builder.url"] ?? defaultExecutionBuilderHttpOpts.url,

--- a/packages/cli/src/options/beaconNodeOptions/builder.ts
+++ b/packages/cli/src/options/beaconNodeOptions/builder.ts
@@ -3,7 +3,7 @@ import {CliCommandOptions} from "../../util/index.js";
 
 export type ExecutionBuilderArgs = {
   builder: boolean;
-  "builder.urls"?: string[];
+  "builder.url"?: string;
   "builder.timeout"?: number;
   "builder.faultInspectionWindow"?: number;
   "builder.allowedFaults"?: number;
@@ -12,7 +12,7 @@ export type ExecutionBuilderArgs = {
 export function parseArgs(args: ExecutionBuilderArgs): IBeaconNodeOptions["executionBuilder"] {
   return {
     enabled: args["builder"],
-    urls: args["builder.urls"] ?? defaultExecutionBuilderHttpOpts.urls,
+    url: args["builder.url"] ?? defaultExecutionBuilderHttpOpts.url,
     timeout: args["builder.timeout"],
     faultInspectionWindow: args["builder.faultInspectionWindow"],
     allowedFaults: args["builder.allowedFaults"],
@@ -27,14 +27,11 @@ export const options: CliCommandOptions<ExecutionBuilderArgs> = {
     group: "builder",
   },
 
-  "builder.urls": {
-    description: "Urls hosting the builder API",
-    defaultDescription: defaultExecutionBuilderHttpOpts.urls.join(","),
-    type: "array",
-    string: true,
-    coerce: (urls: string[]): string[] =>
-      // Parse ["url1,url2"] to ["url1", "url2"]
-      urls.map((item) => item.split(",")).flat(1),
+  "builder.url": {
+    alias: ["builder.urls"],
+    description: "Url hosting the builder API",
+    defaultDescription: defaultExecutionBuilderHttpOpts.url,
+    type: "string",
     group: "builder",
   },
 

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -53,7 +53,7 @@ describe("options / beaconNodeOptions", () => {
       "execution.retryAttempts": 1,
 
       builder: false,
-      "builder.urls": ["http://localhost:8661"],
+      "builder.url": "http://localhost:8661",
       "builder.timeout": 12000,
       "builder.faultInspectionWindow": 32,
       "builder.allowedFaults": 16,
@@ -157,7 +157,7 @@ describe("options / beaconNodeOptions", () => {
       },
       executionBuilder: {
         enabled: false,
-        urls: ["http://localhost:8661"],
+        url: "http://localhost:8661",
         timeout: 12000,
         faultInspectionWindow: 32,
         allowedFaults: 16,


### PR DESCRIPTION
**Motivation**

Lodestar only supports a single builder URL and silently removes fallback URLs if multiple are provided. This behavior is not transparent to the end user and we should be more explicit about it.

**Description**

Update flag to pass builder URL to `--builder.url` (previous flag is kept as alias)

Note that I explicitly removed the support for array and comma-separated values as I think it is better to throw an error on startup then to let the user have wrong assumptions that builder has a fallback configured. I don't know any setup that sets multiple builders but better to have an informative error.

Closes https://github.com/ChainSafe/lodestar/issues/6181
