### PR TITLE
chore: log block transition steps in publishBlock api

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -131,6 +131,7 @@ export function getBeaconBlockApi({
                 verifyOnly: true,
                 skipVerifyBlockSignatures: true,
                 skipVerifyExecutionPayload: true,
+                seenTimestampSec,
               }
             );
           } catch (error) {


### PR DESCRIPTION
**Motivation**

Log block transition steps in publishBlock api

**Description**

Add `seenTimestampsSec` in order to log block transition steps, see https://github.com/ChainSafe/lodestar/blob/c044d4cdd484a7e5ac90e83169955bd6e4697063/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts#L246

cc @g11tech 