### PR TITLE
fix: fix block value calculation in `produceBlockV3`

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -35,7 +35,7 @@ import {
   phase0,
 } from "@lodestar/types";
 import {ExecutionStatus} from "@lodestar/fork-choice";
-import {toHex, racePromisesWithCutoff, RaceEvent} from "@lodestar/utils";
+import {toHex, racePromisesWithCutoff, RaceEvent, gweiToWei} from "@lodestar/utils";
 import {AttestationError, AttestationErrorCode, GossipAction, SyncCommitteeError} from "../../../chain/errors/index.js";
 import {validateApiAggregateAndProof} from "../../../chain/validation/index.js";
 import {ZERO_HASH} from "../../../constants/index.js";
@@ -541,8 +541,8 @@ export function getValidatorApi({
     const consensusBlockValueBuilder = blindedBlock?.consensusBlockValue ?? BigInt(0);
     const consensusBlockValueEngine = fullBlock?.consensusBlockValue ?? BigInt(0);
 
-    const blockValueBuilder = builderPayloadValue + consensusBlockValueBuilder;
-    const blockValueEngine = enginePayloadValue + consensusBlockValueEngine;
+    const blockValueBuilder = builderPayloadValue + gweiToWei(consensusBlockValueBuilder); // Total block value is in wei
+    const blockValueEngine = enginePayloadValue + gweiToWei(consensusBlockValueEngine); // Total block value is in wei
 
     let selectedSource: ProducedBlockSource | null = null;
 

--- a/packages/utils/src/ethConversion.ts
+++ b/packages/utils/src/ethConversion.ts
@@ -1,0 +1,12 @@
+export const ETH_TO_GWEI = BigInt(10 ** 9);
+export const GWEI_TO_WEI = BigInt(10 ** 9);
+export const ETH_TO_WEI = ETH_TO_GWEI * GWEI_TO_WEI;
+
+type EthNumeric = bigint;
+
+/**
+ * Convert gwei to wei.
+ */
+export function gweiToWei(gwei: EthNumeric): EthNumeric {
+  return gwei * GWEI_TO_WEI;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -19,3 +19,4 @@ export * from "./url.js";
 export * from "./verifyMerkleBranch.js";
 export * from "./promise.js";
 export * from "./waitFor.js";
+export * from "./ethConversion.js";

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -12,7 +12,7 @@ import {
 } from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPreBlobs, ForkBlobs, ForkSeq} from "@lodestar/params";
-import {extendError, prettyBytes} from "@lodestar/utils";
+import {ETH_TO_GWEI, ETH_TO_WEI, extendError, gweiToWei, prettyBytes} from "@lodestar/utils";
 import {Api, ApiError, routes} from "@lodestar/api";
 import {IClock, LoggerVc} from "../util/index.js";
 import {PubkeyHex} from "../types.js";
@@ -21,7 +21,6 @@ import {formatBigDecimal} from "../util/format.js";
 import {ValidatorStore} from "./validatorStore.js";
 import {BlockDutiesService, GENESIS_SLOT} from "./blockDuties.js";
 
-const ETH_TO_WEI = BigInt("1000000000000000000");
 // display upto 5 decimal places
 const MAX_DECIMAL_FACTOR = BigInt("100000");
 
@@ -220,9 +219,9 @@ export class BlockProposingService {
       source: response.executionPayloadBlinded ? ProducedBlockSource.builder : ProducedBlockSource.engine,
       // winston logger doesn't like bigint
       executionPayloadValue: `${formatBigDecimal(response.executionPayloadValue, ETH_TO_WEI, MAX_DECIMAL_FACTOR)} ETH`,
-      consensusBlockValue: `${formatBigDecimal(response.consensusBlockValue, ETH_TO_WEI, MAX_DECIMAL_FACTOR)} ETH`,
+      consensusBlockValue: `${formatBigDecimal(response.consensusBlockValue, ETH_TO_GWEI, MAX_DECIMAL_FACTOR)} ETH`,
       totalBlockValue: `${formatBigDecimal(
-        response.executionPayloadValue + response.consensusBlockValue,
+        response.executionPayloadValue + gweiToWei(response.consensusBlockValue),
         ETH_TO_WEI,
         MAX_DECIMAL_FACTOR
       )} ETH`,


### PR DESCRIPTION
**Motivation**

<!-- Why is this PR exists? What are the goals of the pull request? -->
The previous PR #6136 it introduces `consensusBlockValue` and modifies the logic of determining using builder block vs execution block by comparing their values using the direct sum of `executionPayloadValue` and `consensusBlockValue`.

```
    const blockValueBuilder = builderPayloadValue + consensusBlockValueBuilder;
    const blockValueEngine = enginePayloadValue + consensusBlockValueEngine;
...
    if (blockValueEngine >= blockValueBuilder) {
      selectedSource = ProducedBlockSource.engine;
    } else {
      selectedSource = ProducedBlockSource.builder;
    }
```
This is incorrect because consensus block value is in Gwei while payload value is in Wei. Directly summing the two will result in payload value dominating the entire block value.

**Description**
- To convert consensus block value to Wei when calculating the total block value. 
- Explicitly mention total block value is in Wei
- When logging consensus block value alone, the value should be in Gwei.

**Caveat**
There is an ongoing [discussion](https://github.com/ethereum/beacon-APIs/issues/397) in beacon API spec questioning the inconsistency of having different unit (Wei vs Gwei) in payload and CL block value. Will follow up if there is any related change to the spec. 

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->


