### PR TITLE
chore: add preHandler hook to fastify

### DIFF
--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -90,6 +90,11 @@ export class RestApiServer {
       metrics?.requests.inc({operationId});
     });
 
+    server.addHook("preHandler", async (req, _res) => {
+      const {operationId} = req.routeConfig as RouteConfig;
+      this.logger.debug(`Exec ${req.id as string} ${req.ip} ${operationId}`);
+    });
+
     // Log after response
     server.addHook("onResponse", async (req, res) => {
       const {operationId} = req.routeConfig as RouteConfig;


### PR DESCRIPTION
**Motivation**

There are some delays publishing blocks, in the example below the `publishBlockV2` comes first but get executed the last:

```
Dec-16 00:53:13.845[rest]            ^[[34mdebug^[[39m: Req req-adfi x.x.x.x publishBlockV2
Dec-16 00:53:15.025[rest]            ^[[34mdebug^[[39m: Req req-adfj x.x.x.x produceAttestationData
Dec-16 00:53:15.025[rest]            ^[[34mdebug^[[39m: Res req-adfj produceAttestationData - 200
Dec-16 00:53:15.029[rest]            ^[[34mdebug^[[39m: Req req-adfk x.x.x.x produceAttestationData
Dec-16 00:53:15.029[rest]            ^[[34mdebug^[[39m: Res req-adfk produceAttestationData - 200
Dec-16 00:53:15.040[rest]            ^[[34mdebug^[[39m: Req req-adfl x.x.x.x produceAttestationData
Dec-16 00:53:15.041[rest]            ^[[34mdebug^[[39m: Res req-adfl produceAttestationData - 200
Dec-16 00:53:15.077[rest]            ^[[34mdebug^[[39m: Req req-adfm x.x.x.x submitPoolAttestations
Dec-16 00:53:15.097[rest]            ^[[34mdebug^[[39m: Req req-adfn x.x.x.x submitPoolAttestations
Dec-16 00:53:15.115[rest]            ^[[34mdebug^[[39m: Req req-adfo x.x.x.x submitPoolAttestations
Dec-16 00:53:15.213[rest]            ^[[34mdebug^[[39m: Res req-adfo submitPoolAttestations - 200
Dec-16 00:53:15.224[rest]            ^[[34mdebug^[[39m: Res req-adfn submitPoolAttestations - 200
Dec-16 00:53:15.231[rest]            ^[[34mdebug^[[39m: Res req-adfm submitPoolAttestations - 200
Dec-16 00:53:15.394[chain]           ^[[34mdebug^[[39m: Consensus validated while publishing block broadcastValidation=consensus, blockRoot=0x85a5568c31207c70baa001f56fb5cba0e5b9ff1c29492887d798f0a8d0249b0d, bodyRoot=0xa9e3ba8bfb722730c9578a333b97e97e9a73951708262cb470febf2f617dcef0, blockLocallyProduced=true, slot=7988664
```

I suspect the delay could come from `vc` - `bn` latency posting the payload as `publishBlockV2` is the only api with big request body

this is also caught by `getResponseTime()` api of fastify

<img width="1332" alt="Screenshot 2023-12-20 at 19 54 43" src="https://github.com/ChainSafe/lodestar/assets/10568965/defd6d1b-5680-4d2d-bafd-12dac9326b49">


**Description**

- Add `preHandler` hook to fastify to make it clear the delay comes from `vc`-`bn` latency or the api handler itself (which contains deserializing the request body + api impl). This hook is called right before our api handler. Log looks like:

```
Dec-20 08:37:38.762[rest]            debug: Req req-bu 127.0.0.1 submitPoolAttestations
Dec-20 08:37:38.762[rest]            debug: Exec req-bu 127.0.0.1 submitPoolAttestations
Dec-20 08:37:38.932[rest]            debug: Res req-bu submitPoolAttestations - 200
```

this should help us separate streaming time + fastify steps from our own handler time