### PR TITLE
refactor: cleanup the block production flow logic

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/endpoints/produceBlockV3.ts
+++ b/packages/beacon-node/src/api/impl/validator/endpoints/produceBlockV3.ts
@@ -1,7 +1,7 @@
 import {ServerApi, routes} from "@lodestar/api";
 import {ForkSeq, isForkExecution} from "@lodestar/params";
 import {BLSSignature, ProducedBlockSource, Slot} from "@lodestar/types";
-import {RaceEvent, gweiToWei, racePromisesWithCutoff, toHexString} from "@lodestar/utils";
+import {toHexString, resolveOrRacePromises} from "@lodestar/utils";
 import {ApiModules} from "../../types.js";
 import {toGraffitiBuffer} from "../../../../util/graffiti.js";
 import {ValidatorEndpointDependencies} from "./types.js";
@@ -29,9 +29,10 @@ export function buildProduceBlockV3(
     // TODO deneb: skip randao verification
     _skipRandaoVerification?: boolean,
     {feeRecipient, builderSelection, strictFeeRecipientCheck}: routes.validator.ExtraProduceBlockOps = {}
-  ): Promise<routes.validator.ProduceFullOrBlindedBlockOrContentsRes> {
+  ) {
+    const {notWhileSyncing, waitForSlotWithDisparity} = deps;
     const {chain, config, logger} = modules;
-    const {notWhileSyncing, waitForSlotWithDisparity, produceBlockV2} = deps;
+
     notWhileSyncing();
     await waitForSlotWithDisparity(slot); // Must never request for a future slot > currentSlot
 
@@ -56,168 +57,39 @@ export function buildProduceBlockV3(
       isBuilderEnabled,
       strictFeeRecipientCheck,
     });
-    // Start calls for building execution and builder blocks
-    const blindedBlockPromise = isBuilderEnabled
-      ? // can't do fee recipient checks as builder bid doesn't return feeRecipient as of now
-        produceBuilderBlindedBlock(modules, deps, {
-          slot,
-          randaoReveal,
-          graffiti,
-          feeRecipient,
-          // skip checking and recomputing head in these individual produce calls
-          skipHeadChecksAndUpdate: true,
-        }).catch((e) => {
-          logger.error("produceBuilderBlindedBlock failed to produce block", {slot}, e);
-          return null;
-        })
-      : null;
 
-    const fullBlockPromise =
-      // At any point either the builder or execution or both flows should be active.
-      //
-      // Ideally such a scenario should be prevented on startup, but proposerSettingsFile or keymanager
-      // configurations could cause a validator pubkey to have builder disabled with builder selection builder only
-      // (TODO: independently make sure such an options update is not successful for a validator pubkey)
-      //
-      // So if builder is disabled ignore builder selection of builderonly if caused by user mistake
-      !isBuilderEnabled || builderSelection !== routes.validator.BuilderSelection.BuilderOnly
-        ? // TODO deneb: builderSelection needs to be figured out if to be done beacon side
-          // || builderSelection !== BuilderSelection.BuilderOnly
-          produceBlockV2(slot, randaoReveal, graffiti, {
-            feeRecipient,
-            strictFeeRecipientCheck,
-            // skip checking and recomputing head in these individual produce calls
-            skipHeadChecksAndUpdate: true,
-          }).catch((e) => {
-            logger.error("produceEngineFullBlockOrContents failed to produce block", {slot}, e);
-            return null;
-          })
-        : null;
-
-    let blindedBlock, fullBlock;
-    if (blindedBlockPromise !== null && fullBlockPromise !== null) {
-      // reference index of promises in the race
-      const promisesOrder = [ProducedBlockSource.builder, ProducedBlockSource.engine];
-      [blindedBlock, fullBlock] = await racePromisesWithCutoff<
-        routes.validator.ProduceBlockOrContentsRes | routes.validator.ProduceBlindedBlockRes | null
-      >(
-        [blindedBlockPromise, fullBlockPromise],
-        BLOCK_PRODUCTION_RACE_CUTOFF_MS,
-        BLOCK_PRODUCTION_RACE_TIMEOUT_MS,
-        // Callback to log the race events for better debugging capability
-        (event: RaceEvent, delayMs: number, index?: number) => {
-          const eventRef = index !== undefined ? {source: promisesOrder[index]} : {};
-          logger.verbose("Block production race (builder vs execution)", {
-            event,
-            ...eventRef,
-            delayMs,
-            cutoffMs: BLOCK_PRODUCTION_RACE_CUTOFF_MS,
-            timeoutMs: BLOCK_PRODUCTION_RACE_TIMEOUT_MS,
-            slot,
-          });
-        }
-      );
-      if (blindedBlock instanceof Error) {
-        // error here means race cutoff exceeded
-        logger.error("Failed to produce builder block", {slot}, blindedBlock);
-        blindedBlock = null;
-      }
-      if (fullBlock instanceof Error) {
-        logger.error("Failed to produce execution block", {slot}, fullBlock);
-        fullBlock = null;
-      }
-    } else if (blindedBlockPromise !== null && fullBlockPromise === null) {
-      blindedBlock = await blindedBlockPromise;
-      fullBlock = null;
-    } else if (blindedBlockPromise === null && fullBlockPromise !== null) {
-      blindedBlock = null;
-      fullBlock = await fullBlockPromise;
-    } else {
-      throw Error(
-        `Internal Error: Neither builder nor execution proposal flow activated isBuilderEnabled=${isBuilderEnabled} builderSelection=${builderSelection}`
-      );
+    // At any point either the builder or execution or both flows should be active.
+    //
+    // Ideally such a scenario should be prevented on startup, but proposerSettingsFile or keymanager
+    // configurations could cause a validator pubkey to have builder disabled with builder selection builder only
+    // (TODO: independently make sure such an options update is not successful for a validator pubkey)
+    if (isBuilderEnabled && builderSelection === routes.validator.BuilderSelection.BuilderOnly) {
+      return builderOnlyFlow(modules, deps, {feeRecipient, graffiti, randaoReveal, slot});
     }
 
-    const builderPayloadValue = blindedBlock?.executionPayloadValue ?? BigInt(0);
-    const enginePayloadValue = fullBlock?.executionPayloadValue ?? BigInt(0);
-    const consensusBlockValueBuilder = blindedBlock?.consensusBlockValue ?? BigInt(0);
-    const consensusBlockValueEngine = fullBlock?.consensusBlockValue ?? BigInt(0);
-
-    const blockValueBuilder = builderPayloadValue + gweiToWei(consensusBlockValueBuilder); // Total block value is in wei
-    const blockValueEngine = enginePayloadValue + gweiToWei(consensusBlockValueEngine); // Total block value is in wei
-
-    let selectedSource: ProducedBlockSource | null = null;
-
-    if (fullBlock && blindedBlock) {
-      switch (builderSelection) {
-        case routes.validator.BuilderSelection.MaxProfit: {
-          if (blockValueEngine >= blockValueBuilder) {
-            selectedSource = ProducedBlockSource.engine;
-          } else {
-            selectedSource = ProducedBlockSource.builder;
-          }
-          break;
-        }
-
-        case routes.validator.BuilderSelection.ExecutionOnly: {
-          selectedSource = ProducedBlockSource.engine;
-          break;
-        }
-
-        // For everything else just select the builder
-        default: {
-          selectedSource = ProducedBlockSource.builder;
-        }
-      }
-      logger.verbose(`Selected ${selectedSource} block`, {
-        builderSelection,
-        // winston logger doesn't like bigint
-        enginePayloadValue: `${enginePayloadValue}`,
-        builderPayloadValue: `${builderPayloadValue}`,
-        consensusBlockValueEngine: `${consensusBlockValueEngine}`,
-        consensusBlockValueBuilder: `${consensusBlockValueBuilder}`,
-        blockValueEngine: `${blockValueEngine}`,
-        blockValueBuilder: `${blockValueBuilder}`,
+    // If builder is disabled ignore builder selection of builder only if caused by user mistake
+    if (!isBuilderEnabled) {
+      return engineOnlyFlow(modules, deps, {
+        feeRecipient,
+        graffiti,
+        randaoReveal,
         slot,
-      });
-    } else if (fullBlock && !blindedBlock) {
-      selectedSource = ProducedBlockSource.engine;
-      logger.verbose("Selected engine block: no builder block produced", {
-        // winston logger doesn't like bigint
-        enginePayloadValue: `${enginePayloadValue}`,
-        consensusBlockValueEngine: `${consensusBlockValueEngine}`,
-        blockValueEngine: `${blockValueEngine}`,
-        slot,
-      });
-    } else if (blindedBlock && !fullBlock) {
-      selectedSource = ProducedBlockSource.builder;
-      logger.verbose("Selected builder block: no engine block produced", {
-        // winston logger doesn't like bigint
-        builderPayloadValue: `${builderPayloadValue}`,
-        consensusBlockValueBuilder: `${consensusBlockValueBuilder}`,
-        blockValueBuilder: `${blockValueBuilder}`,
-        slot,
+        strictFeeRecipientCheck,
       });
     }
 
-    if (selectedSource === null) {
-      throw Error(`Failed to produce engine or builder block for slot=${slot}`);
-    }
-
-    if (selectedSource === ProducedBlockSource.engine) {
-      return {...fullBlock, executionPayloadBlinded: false} as routes.validator.ProduceBlockOrContentsRes & {
-        executionPayloadBlinded: false;
-      };
-    } else {
-      return {
-        ...blindedBlock,
-        executionPayloadBlinded: true,
-      } as routes.validator.ProduceFullOrBlindedBlockOrContentsRes;
-    }
+    return builderAndExecutionFlow(modules, deps, {
+      feeRecipient,
+      graffiti,
+      randaoReveal,
+      slot,
+      strictFeeRecipientCheck,
+      builderSelection,
+    });
   };
 }
 
-async function produceBuilderBlindedBlock(
+async function produceBlindedBlockOrContents(
   {chain, config, logger, metrics}: ApiModules,
   {notWhileSyncing, waitForSlotWithDisparity}: ValidatorEndpointDependencies,
   {
@@ -285,4 +157,245 @@ async function produceBuilderBlindedBlock(
   } finally {
     if (timer) timer({source});
   }
+}
+
+export async function engineOnlyFlow(
+  {logger}: ApiModules,
+  {produceBlockV2}: ValidatorEndpointDependencies & {produceBlockV2: ServerApi<routes.validator.Api>["produceBlockV2"]},
+  {
+    feeRecipient,
+    slot,
+    randaoReveal,
+    graffiti,
+    strictFeeRecipientCheck,
+  }: routes.validator.ExtraProduceBlockOps & {
+    slot: Slot;
+    randaoReveal: BLSSignature;
+    graffiti: string;
+    strictFeeRecipientCheck?: boolean;
+  }
+): Promise<
+  routes.validator.ProduceBlockOrContentsRes & {
+    executionPayloadBlinded: false;
+  }
+> {
+  const startTime = Date.now();
+  logger.verbose("Block production via engine only starting", {
+    slot,
+  });
+
+  try {
+    const block = await produceBlockV2(slot, randaoReveal, graffiti, {
+      feeRecipient,
+      strictFeeRecipientCheck,
+      // skip checking and recomputing head in these individual produce calls
+      skipHeadChecksAndUpdate: true,
+    });
+    logger.verbose("Engine produced the block", {slot, durationMs: Date.now() - startTime});
+
+    return {...block, executionPayloadBlinded: false};
+  } catch (err) {
+    logger.error("Engine failed to produce the block", {
+      durationMs: Date.now() - startTime,
+      slot,
+    });
+    throw err;
+  }
+}
+
+export async function builderOnlyFlow(
+  modules: ApiModules,
+  deps: ValidatorEndpointDependencies,
+  {
+    feeRecipient,
+    slot,
+    randaoReveal,
+    graffiti,
+  }: routes.validator.ExtraProduceBlockOps & {
+    slot: Slot;
+    randaoReveal: BLSSignature;
+    graffiti: string;
+  }
+): Promise<
+  routes.validator.ProduceBlindedBlockRes & {
+    executionPayloadBlinded: true;
+  }
+> {
+  const {logger} = modules;
+
+  const startTime = Date.now();
+  logger.verbose("Block production via builder only starting", {
+    slot,
+  });
+
+  try {
+    const block = await produceBlindedBlockOrContents(modules, deps, {
+      slot,
+      randaoReveal,
+      graffiti,
+      feeRecipient,
+      // skip checking and recomputing head in these individual produce calls
+      skipHeadChecksAndUpdate: true,
+    });
+    logger.verbose("Builder produced the block", {slot, durationMs: Date.now() - startTime});
+
+    return {...block, executionPayloadBlinded: true};
+  } catch (err) {
+    logger.error("Builder failed to produce the block", {
+      durationMs: Date.now() - startTime,
+      slot,
+    });
+    throw err;
+  }
+}
+
+async function builderAndExecutionFlow(
+  modules: ApiModules,
+  deps: ValidatorEndpointDependencies & {produceBlockV2: ServerApi<routes.validator.Api>["produceBlockV2"]},
+  {
+    feeRecipient,
+    slot,
+    randaoReveal,
+    graffiti,
+    strictFeeRecipientCheck,
+    builderSelection,
+  }: routes.validator.ExtraProduceBlockOps & {
+    slot: Slot;
+    randaoReveal: BLSSignature;
+    graffiti: string;
+    strictFeeRecipientCheck?: boolean;
+  }
+): Promise<routes.validator.ProduceFullOrBlindedBlockOrContentsRes> {
+  const {logger} = modules;
+  const {produceBlockV2} = deps;
+
+  const startTime = Date.now();
+  logger.verbose("Block production race (builder vs execution) starting", {
+    cutoffMs: BLOCK_PRODUCTION_RACE_CUTOFF_MS,
+    timeoutMs: BLOCK_PRODUCTION_RACE_TIMEOUT_MS,
+    slot,
+  });
+
+  const [builder, engine] = await resolveOrRacePromises(
+    [
+      produceBlindedBlockOrContents(modules, deps, {
+        slot,
+        randaoReveal,
+        graffiti,
+        feeRecipient,
+        // skip checking and recomputing head in these individual produce calls
+        skipHeadChecksAndUpdate: true,
+      }),
+      produceBlockV2(slot, randaoReveal, graffiti, {
+        feeRecipient,
+        strictFeeRecipientCheck,
+        // skip checking and recomputing head in these individual produce calls
+        skipHeadChecksAndUpdate: true,
+      }),
+    ],
+    {
+      resolveTimeoutMs: BLOCK_PRODUCTION_RACE_CUTOFF_MS,
+      raceTimeoutMs: BLOCK_PRODUCTION_RACE_TIMEOUT_MS,
+    }
+  );
+
+  if (builder.status === "rejected") {
+    logger.error(
+      "Builder failed to produce the block",
+      {
+        durationMs: Date.now() - startTime,
+        slot,
+      },
+      builder.reason as Error
+    );
+  }
+
+  if (engine.status === "rejected") {
+    logger.error(
+      "Execution failed to produce the block",
+      {
+        durationMs: Date.now() - startTime,
+        slot,
+      },
+      engine.reason as Error
+    );
+  }
+
+  if (builder.status === "pending" && engine.status === "pending") {
+    throw Error(`Builder and execution both timeout to proposed the block in ${BLOCK_PRODUCTION_RACE_TIMEOUT_MS}ms`);
+  }
+
+  if (builder.status === "fulfilled" && engine.status === "fulfilled") {
+    logger.verbose("Builder and execution both produced the block", {durationMs: Date.now() - startTime, slot});
+
+    builderSelection = builderSelection ?? routes.validator.BuilderSelection.MaxProfit;
+    let selectedSource: ProducedBlockSource | null = null;
+    const builderBlock = builder.value;
+    const engineBlock = engine.value;
+
+    const enginePayloadValue = engineBlock.executionPayloadValue ?? BigInt(0);
+    const engineConsensusValue = engineBlock.consensusBlockValue ?? BigInt(0);
+    const builderPayloadValue = builderBlock.executionPayloadValue ?? BigInt(0);
+    const builderConsensusValue = builderBlock.consensusBlockValue ?? BigInt(0);
+
+    const builderBlockValue = builderPayloadValue + builderConsensusValue;
+    const engineBlockValue = enginePayloadValue + engineConsensusValue;
+
+    switch (builderSelection) {
+      case routes.validator.BuilderSelection.MaxProfit: {
+        if (engineBlockValue >= builderBlockValue) {
+          selectedSource = ProducedBlockSource.engine;
+        } else {
+          selectedSource = ProducedBlockSource.builder;
+        }
+        break;
+      }
+
+      case routes.validator.BuilderSelection.ExecutionOnly: {
+        selectedSource = ProducedBlockSource.engine;
+        break;
+      }
+
+      // For everything else just select the builder
+      default: {
+        selectedSource = ProducedBlockSource.builder;
+      }
+    }
+
+    logger.verbose(`Selected ${selectedSource} block`, {
+      builderSelection,
+      // winston logger doesn't like bigint
+      enginePayloadValue: `${enginePayloadValue}`,
+      builderPayloadValue: `${builderPayloadValue}`,
+      engineConsensusValue: `${engineConsensusValue}`,
+      builderConsensusValue: `${builderConsensusValue}`,
+      engineBlockValue: `${engineBlockValue}`,
+      builderBlock: `${builderBlockValue}`,
+      slot,
+    });
+
+    if (selectedSource === ProducedBlockSource.engine) {
+      return {...engineBlock, executionPayloadBlinded: false} as routes.validator.ProduceBlockOrContentsRes & {
+        executionPayloadBlinded: false;
+      };
+    } else {
+      return {...builderBlock, executionPayloadBlinded: true};
+    }
+  }
+
+  if (builder.status === "fulfilled") {
+    logger.verbose("Builder won the race", {durationMs: Date.now() - startTime, slot});
+
+    return {...builder.value, executionPayloadBlinded: true};
+  }
+
+  if (engine.status === "fulfilled") {
+    logger.verbose("Execution won the race", {durationMs: Date.now() - startTime, slot});
+
+    return {...engine.value, executionPayloadBlinded: false} as routes.validator.ProduceBlockOrContentsRes & {
+      executionPayloadBlinded: false;
+    };
+  }
+
+  throw new Error("Error occurred during the builder and execution block production");
 }

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -1,5 +1,6 @@
 import {TimeoutError} from "./errors.js";
 import {sleep} from "./sleep.js";
+import {ArrayToTuple, NonEmptyArray} from "./types.js";
 
 /**
  * While promise t is not finished, call function `fn` per `interval`
@@ -99,9 +100,8 @@ export class PromiseWithStatus<T> implements Promise<T> {
   }
 }
 
-type NonEmptyArray<T> = [T, ...T[]];
 type ReturnPromiseWithTuple<Tuple extends NonEmptyArray<unknown>> = {
-  [Index in keyof Tuple]: PromiseWithStatus<Awaited<Tuple[Index]>>;
+  [Index in keyof ArrayToTuple<Tuple>]: PromiseWithStatus<Awaited<Tuple[Index]>>;
 };
 
 /**

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -1,3 +1,4 @@
+import {TimeoutError} from "./errors.js";
 import {sleep} from "./sleep.js";
 
 /**
@@ -25,115 +26,137 @@ export async function callFnWhenAwait<T>(
   return t;
 }
 
-enum PromiseStatus {
-  resolved,
-  rejected,
-  pending,
-}
+export class PromiseWithStatus<T> implements Promise<T> {
+  private readonly _promise: Promise<T>;
+  private _status: "pending" | "fulfilled" | "rejected" = "pending";
+  private _value?: T;
+  private _reason: unknown;
 
-type PromiseState<T> =
-  | {status: PromiseStatus.resolved; value: T}
-  | {status: PromiseStatus.rejected; value: Error}
-  | {status: PromiseStatus.pending; value: null};
-
-function mapStatusesToResponses<T>(promisesStates: PromiseState<T>[]): (Error | T)[] {
-  return promisesStates.map((pmStatus) => {
-    switch (pmStatus.status) {
-      case PromiseStatus.resolved:
-        return pmStatus.value;
-      case PromiseStatus.rejected:
-        return pmStatus.value;
-      case PromiseStatus.pending:
-        return Error("pending");
+  constructor(...args: ConstructorParameters<typeof Promise<T>> | [Promise<T>]) {
+    if (args.length === 1 && args[0] instanceof Promise) {
+      this._promise = args[0];
+    } else {
+      this._promise = new Promise<T>(...(args as ConstructorParameters<typeof Promise<T>>));
     }
-  });
+
+    this._promise.then(
+      (value) => {
+        this._status = "fulfilled";
+        this._value = value;
+        return value;
+      },
+      (reason) => {
+        this._status = "rejected";
+        this._reason = reason;
+        throw reason;
+      }
+    );
+  }
+
+  [Symbol.toStringTag] = "Promise" as const;
+
+  get status(): "pending" | "fulfilled" | "rejected" {
+    return this._status;
+  }
+
+  get value(): T {
+    switch (this.status) {
+      case "fulfilled":
+        return this._value as T;
+      case "rejected":
+        throw this._reason;
+      case "pending":
+        throw new Error("Promise is still pending");
+    }
+  }
+
+  get reason(): unknown {
+    switch (this.status) {
+      case "fulfilled":
+        throw new Error("Promise is fulfilled");
+      case "rejected":
+        return this._reason;
+      case "pending":
+        throw new Error("Promise is still pending");
+    }
+  }
+
+  async then<TResult1 = T, TResult2 = never>(
+    onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | undefined
+  ): Promise<TResult1 | TResult2> {
+    return this._promise.then(onfulfilled, onrejected);
+  }
+
+  async catch<TResult = never>(
+    onrejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | undefined
+  ): Promise<T | TResult> {
+    return this._promise.catch(onrejected);
+  }
+
+  async finally(onfinally?: (() => void) | undefined): Promise<T> {
+    return this._promise.finally(onfinally);
+  }
 }
 
-export enum RaceEvent {
-  /** all reject/resolve before cutoff */
-  precutoff = "precutoff-return",
-  /** cutoff reached as some were pending till cutoff **/
-  cutoff = "cutoff-reached",
-  /** atleast one resolved till cutoff so no race required */
-  resolvedatcutoff = "resolved-at-cutoff",
-  /** if none reject/resolve before cutoff but one resolves or all reject before timeout */
-  pretimeout = "pretimeout-return",
-  /** timeout reached as none resolved and some were pending till timeout*/
-  timeout = "timeout-reached",
-
-  // events for the promises for better tracking
-  /** promise resolved */
-  resolved = "resolved",
-  /** promise rejected */
-  rejected = "rejected",
-}
+type NonEmptyArray<T> = [T, ...T[]];
+type ReturnPromiseWithTuple<Tuple extends NonEmptyArray<unknown>> = {
+  [Index in keyof Tuple]: PromiseWithStatus<Awaited<Tuple[Index]>>;
+};
 
 /**
- * Wait for promises to resolve till cutoff and then race them beyond the cutoff with an overall timeout
- * @return resolved values or rejections or still pending errors corresponding to input promises
+ * Resolve all promises till `resolveTimeoutMs` if not then race them till `raceTimeoutMs`
  */
-export async function racePromisesWithCutoff<T>(
-  promises: Promise<T>[],
-  cutoffMs: number,
-  timeoutMs: number,
-  eventCb: (event: RaceEvent, delayMs: number, index?: number) => void
-): Promise<(Error | T)[]> {
-  // start the cutoff and timeout timers
-  let cutoffObserved = false;
-  const cutoffPromise = sleep(cutoffMs).then(() => {
-    cutoffObserved = true;
-  });
-  let timeoutObserved = false;
-  const timeoutPromise = sleep(timeoutMs).then(() => {
-    timeoutObserved = true;
-  });
-  const startTime = Date.now();
-
-  // Track promises status and resolved values/rejected errors
-  // Even if the promises reject with the following decoration promises will not throw
-  const promisesStates = [] as PromiseState<T>[];
-  promises.forEach((promise, index) => {
-    promisesStates[index] = {status: PromiseStatus.pending, value: null};
-    promise
-      .then((value) => {
-        eventCb(RaceEvent.resolved, Date.now() - startTime, index);
-        promisesStates[index] = {status: PromiseStatus.resolved, value};
-      })
-      .catch((e: Error) => {
-        eventCb(RaceEvent.rejected, Date.now() - startTime, index);
-        promisesStates[index] = {status: PromiseStatus.rejected, value: e};
-      });
-  });
-
-  // Wait till cutoff time unless all original promises resolve/reject early
-  await Promise.allSettled(promises.map((promise) => Promise.race([promise, cutoffPromise])));
-  if (cutoffObserved) {
-    // If any is resolved, then just simply return as we are post cutoff
-    const anyResolved = promisesStates.reduce(
-      (acc, pmState) => acc || pmState.status === PromiseStatus.resolved,
-      false
-    );
-    if (anyResolved) {
-      eventCb(RaceEvent.resolvedatcutoff, Date.now() - startTime);
-      return mapStatusesToResponses(promisesStates);
-    } else {
-      eventCb(RaceEvent.cutoff, Date.now() - startTime);
-    }
-  } else {
-    eventCb(RaceEvent.precutoff, Date.now() - startTime);
-    return mapStatusesToResponses(promisesStates);
+export async function resolveOrRacePromises<T extends NonEmptyArray<Promise<unknown> | PromiseWithStatus<unknown>>>(
+  promises: T,
+  {
+    resolveTimeoutMs,
+    raceTimeoutMs,
+    signal,
+  }: {
+    resolveTimeoutMs: number;
+    raceTimeoutMs: number;
+    signal?: AbortSignal;
+  }
+): Promise<ReturnPromiseWithTuple<T>> | never {
+  if (raceTimeoutMs <= resolveTimeoutMs) {
+    throw new Error("Race time mus tbe greater than resolve time");
   }
 
-  // Post deadline resolve with any of the promise or all rejected before timeout
-  await Promise.any(promises.map((promise) => Promise.race([promise, timeoutPromise]))).catch(
-    // just ignore if all reject as we will returned mapped rejections
-    // eslint-disable-next-line  @typescript-eslint/no-empty-function
-    (_e) => {}
+  const promisesWithStatuses = promises.map((p) => (p instanceof PromiseWithStatus ? p : new PromiseWithStatus(p)));
+  const resolveTimeoutError = new TimeoutError(
+    `Given promises can't be resolved within resolveTimeoutMs=${resolveTimeoutMs}`
   );
-  if (timeoutObserved) {
-    eventCb(RaceEvent.timeout, Date.now() - startTime);
-  } else {
-    eventCb(RaceEvent.pretimeout, Date.now() - startTime);
+  const raceTimeoutError = new TimeoutError(
+    `Not a any single promise be resolved in given raceTimeoutMs=${raceTimeoutMs}`
+  );
+
+  try {
+    await Promise.race([
+      Promise.allSettled(promisesWithStatuses),
+      sleep(resolveTimeoutMs, signal).then(() => {
+        throw resolveTimeoutError;
+      }),
+    ]);
+    return promisesWithStatuses as ReturnPromiseWithTuple<T>;
+  } catch (err) {
+    if (err !== resolveTimeoutError) {
+      throw err;
+    }
   }
-  return mapStatusesToResponses(promisesStates);
+
+  try {
+    await Promise.race([
+      Promise.any(promisesWithStatuses),
+      sleep(raceTimeoutMs - resolveTimeoutMs, signal).then(() => {
+        throw raceTimeoutError;
+      }),
+    ]);
+  } catch (err) {
+    if (err !== raceTimeoutError && !(err instanceof AggregateError)) {
+      throw err;
+    }
+  }
+
+  return promisesWithStatuses as ReturnPromiseWithTuple<T>;
 }

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -49,7 +49,6 @@ export class PromiseWithStatus<T> implements Promise<T> {
       (reason) => {
         this._status = "rejected";
         this._reason = reason;
-        throw reason;
       }
     );
   }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -14,3 +14,9 @@ export type RecursivePartial<T> = {
 export function bnToNum(bn: bigint): number {
   return Number(bn);
 }
+
+export type NonEmptyArray<T> = [T, ...T[]];
+
+export type ArrayToTuple<Tuple extends NonEmptyArray<unknown>> = {
+  [Index in keyof Tuple]: Tuple[Index];
+};

--- a/packages/utils/test/unit/promiserace.test.ts
+++ b/packages/utils/test/unit/promiserace.test.ts
@@ -1,5 +1,6 @@
 import {expect, describe, it} from "vitest";
 import {resolveOrRacePromises} from "../../src/promise.js";
+import {NonEmptyArray} from "../../src/types.js";
 
 describe("resolveOrRacePromises", () => {
   const cutoffMs = 1000;
@@ -51,16 +52,16 @@ describe("resolveOrRacePromises", () => {
     ["none resolve/reject pre timeout", [1600, -1700], ["pending", "pending"]],
   ];
 
-  for (const [name, promises, results] of testCases) {
+  for (const [name, timeouts, results] of testCases) {
     it(name, async () => {
-      const testPromises = promises.map((timeMs) => {
+      const testPromises = timeouts.map((timeMs) => {
         if (timeMs > 0) {
           return resolveAfter(`${timeMs}`, timeMs);
         } else {
           return rejectAfter(`${timeMs}`, -timeMs);
         }
       });
-      const testResults = await resolveOrRacePromises(testPromises, {
+      const testResults = await resolveOrRacePromises(testPromises as NonEmptyArray<Promise<unknown>>, {
         resolveTimeoutMs: cutoffMs,
         raceTimeoutMs: timeoutMs,
       });

--- a/packages/utils/test/unit/promiserace.test.ts
+++ b/packages/utils/test/unit/promiserace.test.ts
@@ -1,5 +1,5 @@
-import {describe, it, expect} from "vitest";
-import {racePromisesWithCutoff, RaceEvent} from "../../src/promise.js";
+import {expect} from "chai";
+import {resolveOrRacePromises} from "../../src/promise.js";
 
 describe("racePromisesWithCutoff", () => {
   const cutoffMs = 1000;
@@ -14,77 +14,44 @@ describe("racePromisesWithCutoff", () => {
       setTimeout(() => reject(Error(value)), delay);
     });
 
-  // For brevity in testcases
-  const precutoff = RaceEvent.precutoff;
-  const cutoff = RaceEvent.cutoff;
-  const resolvedatcutoff = RaceEvent.resolvedatcutoff;
-  const pretimeout = RaceEvent.pretimeout;
-  const timeout = RaceEvent.timeout;
-  const resolved = RaceEvent.resolved;
-  const rejected = RaceEvent.rejected;
-
-  // Second item in testcase row i.e. array of numbers represent delay at which promise to be resolved
-  // or rejected (-ve number)
-  // Third item in testcase row is the expected value or error message in string
-  // Last item is expected events
-  const testcases: [string, number[], (string | Error)[], RaceEvent[]][] = [
-    ["all resolve pre-cutoff", [100, 200], ["100", "200"], [resolved, resolved, precutoff]],
-    ["all resolve/reject pre-cutoff", [100, -200], ["100", "-200"], [resolved, rejected, precutoff]],
-    ["all reject pre-cutoff", [-100, -200], ["-100", "-200"], [rejected, rejected, precutoff]],
-    ["all reject pre-timeout", [-1100, -1200], ["-1100", "-1200"], [cutoff, rejected, rejected, pretimeout]],
-    ["race and resolve pre-timeout", [1100, 1200], ["1100", "pending"], [cutoff, resolved, pretimeout]],
-    [
-      "race and resolve/reject pre-timeout",
-      [-1100, 1200, 1300],
-      ["-1100", "1200", "pending"],
-      [cutoff, rejected, resolved, pretimeout],
-    ],
+  const testCases: [string, number[], (string | Error)[]][] = [
+    ["all resolve pre-cutoff", [100, 200], ["100", "200"]],
+    ["all resolve/reject pre-cutoff", [100, -200], ["100", "-200"]],
+    ["all reject pre-cutoff", [-100, -200], ["-100", "-200"]],
+    ["all reject pre-timeout", [-1100, -1200], ["-1100", "-1200"]],
+    ["race and resolve pre-timeout", [1100, 1200], ["1100", "pending"]],
+    ["race and resolve/reject pre-timeout", [-1100, 1200, 1300], ["-1100", "1200", "pending"]],
     [
       "some resolve pre-cutoff with no race post cutoff",
       [100, -200, -1100, 1200],
       ["100", "-200", "pending", "pending"],
-      [resolved, rejected, resolvedatcutoff],
     ],
     [
       "some reject pre-cutoff, with race resolution pre-timeout",
       [-100, -200, -1100, 1100, 1200],
       ["-100", "-200", "-1100", "1100", "pending"],
-      [rejected, rejected, cutoff, rejected, resolved, pretimeout],
     ],
-    [
-      "some reject pre-cutoff, rest reject pre-timeout",
-      [-100, -200, -1100, -1200],
-      ["-100", "-200", "-1100", "-1200"],
-      [rejected, rejected, cutoff, rejected, rejected, pretimeout],
-    ],
+    ["some reject pre-cutoff, rest reject pre-timeout", [-100, -200, -1100, -1200], ["-100", "-200", "-1100", "-1200"]],
     [
       "some resolve/reject pre-cutoff, some resolve/reject pre-timeout but no race beyond cutoff",
       [100, -200, -1100, 1100, 1700, -1700],
       ["100", "-200", "pending", "pending", "pending", "pending"],
-      [resolved, rejected, resolvedatcutoff],
     ],
     [
       "none resolve/reject pre-cutoff with race resolution pre timeout",
       [-1100, 1200, 1700],
       ["-1100", "1200", "pending"],
-      [cutoff, rejected, resolved, pretimeout],
     ],
-    [
-      "none resolve pre-cutoff with race resolution pre timeout",
-      [1100, 1200, 1700],
-      ["1100", "pending", "pending"],
-      [cutoff, resolved, pretimeout],
-    ],
+    ["none resolve pre-cutoff with race resolution pre timeout", [1100, 1200, 1700], ["1100", "pending", "pending"]],
     [
       "some reject pre-cutoff, some reject pre-timeout, but no resolution till timeout",
       [-100, -1100, -1200, 1700, -1800],
       ["-100", "-1100", "-1200", "pending", "pending"],
-      [rejected, cutoff, rejected, rejected, timeout],
     ],
-    ["none resolve/reject pre timeout", [1600, -1700], ["pending", "pending"], [cutoff, timeout]],
+    ["none resolve/reject pre timeout", [1600, -1700], ["pending", "pending"]],
   ];
 
-  for (const [name, promises, results, events] of testcases) {
+  for (const [name, promises, results] of testCases) {
     it(name, async () => {
       const testPromises = promises.map((timeMs) => {
         if (timeMs > 0) {
@@ -93,12 +60,21 @@ describe("racePromisesWithCutoff", () => {
           return rejectAfter(`${timeMs}`, -timeMs);
         }
       });
-      const testEvents: RaceEvent[] = [];
-      const testResults = await racePromisesWithCutoff(testPromises, cutoffMs, timeoutMs, (event, _delayMs) =>
-        testEvents.push(event)
-      );
-      const testResultsCmp = testResults.map((res: string | Error) => (res instanceof Error ? res.message : res));
-      expect({results: testResultsCmp, events: testEvents}).toEqual({results, events});
+      const testResults = await resolveOrRacePromises(testPromises, {
+        resolveTimeoutMs: cutoffMs,
+        raceTimeoutMs: timeoutMs,
+      });
+      const testResultsCmp = testResults.map((r) => {
+        switch (r.status) {
+          case "fulfilled":
+            return r.value;
+          case "rejected":
+            return (r.reason as Error).message;
+          case "pending":
+            return "pending";
+        }
+      });
+      expect(testResultsCmp).toEqual(results);
     });
   }
 });

--- a/packages/utils/test/unit/promiserace.test.ts
+++ b/packages/utils/test/unit/promiserace.test.ts
@@ -1,7 +1,7 @@
-import {expect} from "chai";
+import {expect, describe, it} from "vitest";
 import {resolveOrRacePromises} from "../../src/promise.js";
 
-describe("racePromisesWithCutoff", () => {
+describe("resolveOrRacePromises", () => {
   const cutoffMs = 1000;
   const timeoutMs = 1500;
 


### PR DESCRIPTION
**Motivation**

Make the code easy to maintain and debug. 

**Description**

Make the implementation more testable. 

- Removed the usage of callbacks with promises 
- Added separate flows for the each case
- Added the clear logs for each flow
- Splited validator APIs endpoints to independent functions to refactor more easily. 

Related #6159

**Steps to test or reproduce**

- Run all tests 