### PR TITLE
test: migrate config unit tests to vitest

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -50,7 +50,7 @@
     "lint": "eslint --color --ext .ts src/",
     "lint:fix": "yarn run lint --fix",
     "pretest": "yarn run check-types",
-    "test:unit": "nyc --cache-dir .nyc_output/.cache -e .ts mocha 'test/unit/**/*.test.ts'",
+    "test:unit": "yarn vitest --run --dir test/unit/ --coverage",
     "check-readme": "typescript-docs-verifier"
   },
   "repository": {

--- a/packages/config/test/globalSetup.ts
+++ b/packages/config/test/globalSetup.ts
@@ -1,0 +1,2 @@
+export async function setup(): Promise<void> {}
+export async function teardown(): Promise<void> {}

--- a/packages/config/test/unit/index.test.ts
+++ b/packages/config/test/unit/index.test.ts
@@ -1,4 +1,4 @@
-import {expect} from "chai";
+import {describe, it, expect} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
 import {ForkName} from "@lodestar/params";
 import {config, chainConfig} from "../../src/default.js";
@@ -12,30 +12,27 @@ describe("forks", () => {
       const fork2 = forks[i + 1];
 
       // Use less equal to be okay with both forks being at Infinity
-      expect(fork1.epoch).to.be.at.most(
-        fork2.epoch,
-        `Forks are not sorted ${fork1.name} ${fork1.epoch} -> ${fork2.name} ${fork2.epoch}`
-      );
+      expect(fork1.epoch).toBeLessThanOrEqual(fork2.epoch);
     }
   });
 
   it("Get phase0 fork for slot 0", () => {
     const fork = config.getForkName(0);
-    expect(fork).to.equal(ForkName.phase0);
+    expect(fork).toBe(ForkName.phase0);
   });
 
   it("correct prev data", () => {
     for (let i = 1; i < config.forksAscendingEpochOrder.length; i++) {
       const fork = config.forksAscendingEpochOrder[i];
       const prevFork = config.forksAscendingEpochOrder[i - 1];
-      expect(toHexString(fork.prevVersion)).to.equal(toHexString(prevFork.version), `Wrong prevVersion ${fork.name}`);
-      expect(fork.prevForkName).to.equal(prevFork.name, `Wrong prevName ${fork.name}`);
+      expect(toHexString(fork.prevVersion)).toBe(toHexString(prevFork.version));
+      expect(fork.prevForkName).toBe(prevFork.name);
     }
   });
 
   it("correctly handle pre-genesis", () => {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const postMergeTestnet = createForkConfig({...chainConfig, ALTAIR_FORK_EPOCH: 0, BELLATRIX_FORK_EPOCH: 0});
-    expect(postMergeTestnet.getForkName(-1)).to.equal(ForkName.bellatrix);
+    expect(postMergeTestnet.getForkName(-1)).toBe(ForkName.bellatrix);
   });
 });

--- a/packages/config/test/unit/json.test.ts
+++ b/packages/config/test/unit/json.test.ts
@@ -1,4 +1,4 @@
-import {expect} from "chai";
+import {describe, it, expect} from "vitest";
 import {chainConfigFromJson, chainConfigToJson} from "../../src/index.js";
 import {chainConfig} from "../../src/default.js";
 
@@ -7,6 +7,6 @@ describe("chainConfig JSON", () => {
     const json = chainConfigToJson(chainConfig);
     const chainConfigRes = chainConfigFromJson(json);
 
-    expect(chainConfigRes).to.deep.equal(chainConfig);
+    expect(chainConfigRes).toEqual(chainConfig);
   });
 });

--- a/packages/config/vitest.config.ts
+++ b/packages/config/vitest.config.ts
@@ -1,0 +1,11 @@
+import {defineConfig, mergeConfig} from "vitest/config";
+import vitestConfig from "../../vitest.base.config";
+
+export default mergeConfig(
+  vitestConfig,
+  defineConfig({
+    test: {
+      globalSetup: ["./test/globalSetup.ts"],
+    },
+  })
+);


### PR DESCRIPTION
**Motivation**

Consolidate the testing frameworks and migrate to vitest.

**Description**

Migrate `config` unit tests to vitest.


Closes #issue_number

- Run all tests