### PR TITLE
test: migrate flare unit tests to vitest

### DIFF
--- a/packages/flare/.mocharc.yaml
+++ b/packages/flare/.mocharc.yaml
@@ -1,5 +1,0 @@
-exit: true
-extension: ["ts"]
-colors: true
-node-option:
-  - "loader=ts-node/esm"

--- a/packages/flare/package.json
+++ b/packages/flare/package.json
@@ -44,7 +44,7 @@
     "lint": "eslint --color --ext .ts src/",
     "lint:fix": "yarn run lint --fix",
     "pretest": "yarn run check-types",
-    "test:unit": "nyc --cache-dir .nyc_output/.cache -e .ts mocha 'test/unit/**/*.test.ts'",
+    "test:unit": "vitest --run --dir test/unit/ --coverage",
     "check-readme": "typescript-docs-verifier"
   },
   "repository": {

--- a/packages/flare/test/globalSetup.ts
+++ b/packages/flare/test/globalSetup.ts
@@ -1,0 +1,2 @@
+export async function setup(): Promise<void> {}
+export async function teardown(): Promise<void> {}

--- a/packages/flare/test/unit/utils/format.test.ts
+++ b/packages/flare/test/unit/utils/format.test.ts
@@ -1,4 +1,4 @@
-import {expect} from "chai";
+import {describe, it, expect} from "vitest";
 import {parseRange} from "../../../src/util/format.js";
 
 describe("utils / format", () => {
@@ -10,7 +10,7 @@ describe("utils / format", () => {
 
   for (const {range, indexes} of testCases) {
     it(range, () => {
-      expect(parseRange(range)).to.deep.equal(indexes);
+      expect(parseRange(range)).toEqual(indexes);
     });
   }
 });

--- a/packages/flare/vitest.config.ts
+++ b/packages/flare/vitest.config.ts
@@ -1,0 +1,11 @@
+import {defineConfig, mergeConfig} from "vitest/config";
+import vitestConfig from "../../vitest.base.config";
+
+export default mergeConfig(
+  vitestConfig,
+  defineConfig({
+    test: {
+      globalSetup: ["./test/globalSetup.ts"],
+    },
+  })
+);


### PR DESCRIPTION
**Motivation**

Consolidate the testing frameworks and migrate to vitest.

**Description**

Migrate `flare` unit tests to vitest.


**Steps to test or reproduce**

- Run all tests