### PR TITLE
test: migrate params tests to vitest

### DIFF
--- a/packages/params/karma.config.cjs
+++ b/packages/params/karma.config.cjs
@@ -1,9 +1,0 @@
-const karmaConfig = require("../../karma.base.config.js");
-const webpackConfig = require("./webpack.test.config.cjs");
-
-module.exports = function karmaConfigurator(config) {
-  config.set({
-    ...karmaConfig,
-    webpack: webpackConfig,
-  });
-};

--- a/packages/params/package.json
+++ b/packages/params/package.json
@@ -52,10 +52,13 @@
     "check-types": "tsc",
     "lint": "eslint --color --ext .ts src/ test/",
     "lint:fix": "yarn run lint --fix",
-    "test": "yarn run check-types",
-    "test:unit": "mocha 'test/unit/**/*.test.ts'",
-    "test:browsers": "yarn karma start karma.config.cjs",
-    "test:e2e": "LODESTAR_PRESET=minimal mocha 'test/e2e/**/*.test.ts'",
+    "test": "yarn run check-types",    
+    "test:unit": "vitest --run --dir test/unit/ --coverage",
+    "test:browsers": "yarn test:browsers:chrome && yarn test:browsers:firefox && yarn test:browsers:electron",
+    "test:browsers:chrome": "vitest --run --browser chrome --config ./vitest.browser.config.ts --dir test/unit",
+    "test:browsers:firefox": "vitest --run --browser firefox --config ./vitest.browser.config.ts --dir test/unit",
+    "test:browsers:electron": "echo 'Electron tests will be introduced back in the future as soon vitest supports electron.'",
+    "test:e2e": "LODESTAR_PRESET=minimal vitest --run --dir test/e2e/",
     "check-readme": "typescript-docs-verifier"
   },
   "repository": {

--- a/packages/params/test/e2e/ensure-config-is-synced.test.ts
+++ b/packages/params/test/e2e/ensure-config-is-synced.test.ts
@@ -1,4 +1,4 @@
-import {expect} from "chai";
+import {describe, it, expect, vi} from "vitest";
 import axios from "axios";
 import {mainnetPreset} from "../../src/presets/mainnet.js";
 import {minimalPreset} from "../../src/presets/minimal.js";
@@ -11,7 +11,7 @@ import {loadConfigYaml} from "../yaml.js";
 const specConfigCommit = "v1.4.0-beta.2";
 
 describe("Ensure config is synced", function () {
-  this.timeout(60 * 1000);
+  vi.setConfig({testTimeout: 60 * 1000});
 
   it("mainnet", async function () {
     const remotePreset = await downloadRemoteConfig("mainnet", specConfigCommit);
@@ -27,10 +27,10 @@ describe("Ensure config is synced", function () {
 function assertCorrectPreset(localPreset: BeaconPreset, remotePreset: BeaconPreset): void {
   // Check each key for better debuggability
   for (const key of Object.keys(remotePreset) as (keyof BeaconPreset)[]) {
-    expect(localPreset[key]).to.equal(remotePreset[key], `Wrong ${key} value`);
+    expect(localPreset[key]).toBe(remotePreset[key]);
   }
 
-  expect(localPreset).to.deep.equal(remotePreset);
+  expect(localPreset).toEqual(remotePreset);
 }
 
 async function downloadRemoteConfig(preset: "mainnet" | "minimal", commit: string): Promise<BeaconPreset> {

--- a/packages/params/test/e2e/overridePreset.test.ts
+++ b/packages/params/test/e2e/overridePreset.test.ts
@@ -2,15 +2,12 @@ import path from "node:path";
 import util from "node:util";
 import child from "node:child_process";
 import {fileURLToPath} from "node:url";
-import {expect, use} from "chai";
-import chaiAsPromised from "chai-as-promised";
+import {describe, it, expect, vi} from "vitest";
 
 const scriptNames = {
   ok: "overridePresetOk.ts",
   error: "overridePresetError.ts",
 };
-
-use(chaiAsPromised);
 
 const exec = util.promisify(child.exec);
 
@@ -21,7 +18,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe("Override preset", function () {
   // Allow time for ts-node to compile Typescript source
-  this.timeout(30_000);
+  vi.setConfig({testTimeout: 30_000});
 
   it("Should correctly override preset", async () => {
     // These commands can not run with minimal preset
@@ -31,7 +28,7 @@ describe("Override preset", function () {
   });
 
   it("Should throw trying to override preset in the wrong order", async () => {
-    await expect(exec(`node --loader ts-node/esm ${path.join(__dirname, scriptNames.error)}`)).to.be.rejectedWith(
+    await expect(exec(`node --loader ts-node/esm ${path.join(__dirname, scriptNames.error)}`)).rejects.toThrow(
       "Lodestar preset is already frozen"
     );
   });

--- a/packages/params/test/e2e/setPreset.test.ts
+++ b/packages/params/test/e2e/setPreset.test.ts
@@ -2,15 +2,12 @@ import path from "node:path";
 import util from "node:util";
 import child from "node:child_process";
 import {fileURLToPath} from "node:url";
-import {expect, use} from "chai";
-import chaiAsPromised from "chai-as-promised";
+import {describe, it, expect, vi} from "vitest";
 
 const scriptNames = {
   ok: "setPresetOk.ts",
   error: "setPresetError.ts",
 };
-
-use(chaiAsPromised);
 
 const exec = util.promisify(child.exec);
 
@@ -21,7 +18,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe("setPreset", function () {
   // Allow time for ts-node to compile Typescript source
-  this.timeout(30_000);
+  vi.setConfig({testTimeout: 30_000});
 
   it("Should correctly set preset", async () => {
     // These commands can not run with minimal preset
@@ -31,7 +28,7 @@ describe("setPreset", function () {
   });
 
   it("Should throw trying to set preset in the wrong order", async () => {
-    await expect(exec(`node --loader ts-node/esm ${path.join(__dirname, scriptNames.error)}`)).to.be.rejectedWith(
+    await expect(exec(`node --loader ts-node/esm ${path.join(__dirname, scriptNames.error)}`)).rejects.toThrow(
       "Lodestar preset is already frozen"
     );
   });

--- a/packages/params/test/globalSetup.ts
+++ b/packages/params/test/globalSetup.ts
@@ -1,0 +1,2 @@
+export async function setup(): Promise<void> {}
+export async function teardown(): Promise<void> {}

--- a/packages/params/test/unit/activePreset.test.ts
+++ b/packages/params/test/unit/activePreset.test.ts
@@ -1,4 +1,4 @@
-import {expect} from "chai";
+import {describe, it, expect} from "vitest";
 import {mainnetPreset} from "../../src/presets/mainnet.js";
 import {minimalPreset} from "../../src/presets/minimal.js";
 import {gnosisPreset as gnosisParams} from "../../src/presets/gnosis.js";
@@ -16,18 +16,15 @@ describe("active preset", async () => {
 
   it("Active preset should be set to the correct value", () => {
     if (process.env.LODESTAR_PRESET) {
-      expect(ACTIVE_PRESET).to.equal(
-        process.env.LODESTAR_PRESET,
-        "process.env.LODESTAR_PRESET must equal ACTIVE_PRESET"
-      );
+      expect(ACTIVE_PRESET).toBe(process.env.LODESTAR_PRESET);
     } else {
-      expect(ACTIVE_PRESET).to.equal(PresetName.mainnet, "Default preset must be mainnet");
+      expect(ACTIVE_PRESET).toBe(PresetName.mainnet);
     }
   });
 
   it("Constants should be set to the correct value", () => {
     for (const [k, v] of Object.entries(params[ACTIVE_PRESET])) {
-      expect(exports[k]).to.deep.equal(v);
+      expect(exports[k]).toEqual(v);
     }
   });
 
@@ -37,6 +34,6 @@ describe("active preset", async () => {
       // To ensure this throws, call setActivePreset on both the src and lib file.
       setActivePreset(PresetName.minimal);
       setActivePresetLib(PresetName.minimal);
-    }).to.throw();
+    }).toThrow();
   });
 });

--- a/packages/params/test/unit/applicationDomains.test.ts
+++ b/packages/params/test/unit/applicationDomains.test.ts
@@ -8,7 +8,8 @@ describe("validate application domains", () => {
       for (let i = 0; i < DOMAIN_APPLICATION_MASK.length; i++) {
         r += DOMAIN_APPLICATION_MASK[i] & domain[i];
       }
-      expect(r).toBeGreaterThan(0);
+      // eslint-disable-next-line chai-expect/no-inner-compare
+      expect(r > 0).toBeWithMessage(true, `${name} mask application should be valid`);
     });
   });
 });

--- a/packages/params/test/unit/applicationDomains.test.ts
+++ b/packages/params/test/unit/applicationDomains.test.ts
@@ -1,4 +1,4 @@
-import {expect} from "chai";
+import {describe, it, expect} from "vitest";
 import {DOMAIN_APPLICATION_MASK, DOMAIN_APPLICATION_BUILDER} from "../../src/index.js";
 
 describe("validate application domains", () => {
@@ -8,7 +8,7 @@ describe("validate application domains", () => {
       for (let i = 0; i < DOMAIN_APPLICATION_MASK.length; i++) {
         r += DOMAIN_APPLICATION_MASK[i] & domain[i];
       }
-      expect(r).to.be.above(0, `${name} mask application should be valid`);
+      expect(r).toBeGreaterThan(0);
     });
   });
 });

--- a/packages/params/tsconfig.e2e.json
+++ b/packages/params/tsconfig.e2e.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../tsconfig.e2e.json",
-  "include": [
-    "src",
-    "test"
-  ],
-}

--- a/packages/params/vitest.browser.config.ts
+++ b/packages/params/vitest.browser.config.ts
@@ -1,0 +1,14 @@
+import {defineConfig, mergeConfig} from "vitest/config";
+import vitestConfig from "../../vitest.base.browser.config";
+
+export default mergeConfig(
+  vitestConfig,
+  defineConfig({
+    test: {
+      globalSetup: ["./test/globalSetup.ts"],
+    },
+    optimizeDeps: {
+      exclude: ["@chainsafe/blst"],
+    },
+  })
+);

--- a/packages/params/vitest.config.ts
+++ b/packages/params/vitest.config.ts
@@ -1,0 +1,11 @@
+import {defineConfig, mergeConfig} from "vitest/config";
+import vitestConfig from "../../vitest.base.config";
+
+export default mergeConfig(
+  vitestConfig,
+  defineConfig({
+    test: {
+      globalSetup: ["./test/globalSetup.ts"],
+    },
+  })
+);

--- a/packages/params/webpack.test.config.cjs
+++ b/packages/params/webpack.test.config.cjs
@@ -1,5 +1,0 @@
-const webpackConfig = require("../../webpack.test.config.js");
-
-module.exports = {
-  ...webpackConfig,
-};


### PR DESCRIPTION
**Motivation**

Consolidate the testing frameworks and migrate to vitest.

**Description**

Migrate `params` tests to vitest.


Closes #issue_number

- Run all tests 