### PR TITLE
test: migrate light-client tests to vitest

### DIFF
--- a/packages/light-client/.mocharc.yaml
+++ b/packages/light-client/.mocharc.yaml
@@ -1,6 +1,0 @@
-colors: true
-timeout: 5000
-exit: true
-extension: ["ts"]
-node-option:
-  - "loader=ts-node/esm"

--- a/packages/light-client/.nycrc.json
+++ b/packages/light-client/.nycrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../.nycrc.json"
-}

--- a/packages/light-client/karma.config.cjs
+++ b/packages/light-client/karma.config.cjs
@@ -1,9 +1,0 @@
-const karmaConfig = require("../../karma.base.config.js");
-const webpackConfig = require("./webpack.test.config.cjs");
-
-module.exports = function karmaConfigurator(config) {
-  config.set({
-    ...karmaConfig,
-    webpack: webpackConfig,
-  });
-};

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -59,8 +59,11 @@
     "lint:fix": "yarn run lint --fix",
     "pretest": "yarn run check-types",
     "test": "yarn test:unit && yarn test:e2e",
-    "test:browsers": "yarn karma start karma.config.cjs",
-    "test:unit": "LODESTAR_PRESET=minimal nyc --cache-dir .nyc_output/.cache -e .ts mocha 'test/unit/**/*.test.ts'",
+    "test:unit": "vitest --run --dir test/unit/ --coverage",
+    "test:browsers": "yarn test:browsers:chrome && yarn test:browsers:firefox && yarn test:browsers:electron",
+    "test:browsers:chrome": "vitest --run --browser chrome --config ./vitest.browser.config.ts --dir test/unit",
+    "test:browsers:firefox": "vitest --run --browser firefox --config ./vitest.browser.config.ts --dir test/unit",
+    "test:browsers:electron": "echo 'Electron tests will be introduced back in the future as soon vitest supports electron.'",
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {

--- a/packages/light-client/src/spec/validateLightClientUpdate.ts
+++ b/packages/light-client/src/spec/validateLightClientUpdate.ts
@@ -1,4 +1,4 @@
-import bls from "@chainsafe/bls/switchable";
+import bls from "@chainsafe/bls";
 import type {PublicKey, Signature} from "@chainsafe/bls/types";
 import {Root, ssz, allForks} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";

--- a/packages/light-client/src/utils/utils.ts
+++ b/packages/light-client/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import bls from "@chainsafe/bls/switchable";
+import bls from "@chainsafe/bls";
 import type {PublicKey} from "@chainsafe/bls/types";
 import {BitArray} from "@chainsafe/ssz";
 import {altair, Root, ssz} from "@lodestar/types";

--- a/packages/light-client/src/validation.ts
+++ b/packages/light-client/src/validation.ts
@@ -1,4 +1,4 @@
-import bls from "@chainsafe/bls/switchable";
+import bls from "@chainsafe/bls";
 import type {PublicKey, Signature} from "@chainsafe/bls/types";
 import {altair, Root, Slot, ssz, allForks} from "@lodestar/types";
 import {

--- a/packages/light-client/test/globalSetup.ts
+++ b/packages/light-client/test/globalSetup.ts
@@ -1,0 +1,2 @@
+export async function setup(): Promise<void> {}
+export async function teardown(): Promise<void> {}

--- a/packages/light-client/test/unit/isValidLightClientHeader.test.ts
+++ b/packages/light-client/test/unit/isValidLightClientHeader.test.ts
@@ -1,4 +1,4 @@
-import {expect} from "chai";
+import {describe, it, expect} from 'vitest';
 import {fromHexString} from "@chainsafe/ssz";
 import {ssz, allForks} from "@lodestar/types";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
@@ -91,7 +91,7 @@ describe("isValidLightClientHeader", function () {
   testCases.forEach(([name, header]: [string, allForks.LightClientHeader]) => {
     it(name, function () {
       const isValid = isValidLightClientHeader(config, header);
-      expect(isValid).to.be.true;
+      expect(isValid).toBe(true);
     });
   });
 });

--- a/packages/light-client/test/unit/isValidLightClientHeader.test.ts
+++ b/packages/light-client/test/unit/isValidLightClientHeader.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect} from "vitest";
 import {fromHexString} from "@chainsafe/ssz";
 import {ssz, allForks} from "@lodestar/types";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";

--- a/packages/light-client/test/unit/sync.node.test.ts
+++ b/packages/light-client/test/unit/sync.node.test.ts
@@ -1,5 +1,4 @@
-import {expect} from "chai";
-import {init} from "@chainsafe/bls/switchable";
+import {describe, it, expect, afterEach, vi} from 'vitest';
 import {JsonPath, toHexString} from "@chainsafe/ssz";
 import {computeDescriptor, TreeOffsetProof} from "@chainsafe/persistent-merkle-tree";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@lodestar/params";
@@ -21,20 +20,14 @@ import {
   lastInMap,
 } from "../utils/utils.js";
 import {startServer, ServerOpts} from "../utils/server.js";
-import {isNode} from "../../src/utils/utils.js";
 import {computeSyncPeriodAtSlot} from "../../src/utils/clock.js";
 import {LightClientRestTransport} from "../../src/transport/rest.js";
 
 const SOME_HASH = Buffer.alloc(32, 0xff);
 
 describe("sync", () => {
+  vi.setConfig({testTimeout: 15000});
   const afterEachCbs: (() => Promise<unknown> | unknown)[] = [];
-
-  before("init bls", async () => {
-    // This process has to be done manually because of an issue in Karma runner
-    // https://github.com/karma-runner/karma/issues/3804
-    await init(isNode ? "blst-native" : "herumi");
-  });
 
   afterEach(async () => {
     await Promise.all(afterEachCbs);
@@ -168,16 +161,13 @@ describe("sync", () => {
     });
 
     // Ensure that the lightclient head is correct
-    expect(lightclient.getHead().beacon.slot).to.equal(targetSlot, "lightclient.head is not the targetSlot head");
+    expect(lightclient.getHead().beacon.slot).toBe(targetSlot);
 
     // Fetch proof of "latestExecutionPayloadHeader.stateRoot"
     const {proof, header} = await getHeadStateProof(lightclient, api, [["latestExecutionPayloadHeader", "stateRoot"]]);
 
     const recoveredState = ssz.bellatrix.BeaconState.createFromProof(proof, header.beacon.stateRoot);
-    expect(toHexString(recoveredState.latestExecutionPayloadHeader.stateRoot)).to.equal(
-      toHexString(executionStateRoot),
-      "Recovered executionStateRoot from getHeadStateProof() not correct"
-    );
+    expect(toHexString(recoveredState.latestExecutionPayloadHeader.stateRoot)).toBe(toHexString(executionStateRoot));
   });
 });
 

--- a/packages/light-client/test/unit/sync.node.test.ts
+++ b/packages/light-client/test/unit/sync.node.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, afterEach, vi} from 'vitest';
+import {describe, it, expect, afterEach, vi} from "vitest";
 import {JsonPath, toHexString} from "@chainsafe/ssz";
 import {computeDescriptor, TreeOffsetProof} from "@chainsafe/persistent-merkle-tree";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@lodestar/params";
@@ -26,7 +26,7 @@ import {LightClientRestTransport} from "../../src/transport/rest.js";
 const SOME_HASH = Buffer.alloc(32, 0xff);
 
 describe("sync", () => {
-  vi.setConfig({testTimeout: 15000});
+  vi.setConfig({testTimeout: 30_000});
   const afterEachCbs: (() => Promise<unknown> | unknown)[] = [];
 
   afterEach(async () => {

--- a/packages/light-client/test/unit/syncInMemory.test.ts
+++ b/packages/light-client/test/unit/syncInMemory.test.ts
@@ -1,5 +1,5 @@
-import {expect} from "chai";
-import bls, {init} from "@chainsafe/bls/switchable";
+import {describe, it, expect, beforeAll, vi} from "vitest";
+import bls from "@chainsafe/bls";
 import {createBeaconConfig} from "@lodestar/config";
 import {chainConfig} from "@lodestar/config/default";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@lodestar/params";
@@ -25,7 +25,7 @@ function getSyncCommittee(
 
 describe("syncInMemory", function () {
   // In browser test this process is taking more time than default 2000ms
-  this.timeout(10000);
+  vi.setConfig({testTimeout: 10000});
 
   // Fixed params
   const genValiRoot = Buffer.alloc(32, 9);
@@ -35,20 +35,14 @@ describe("syncInMemory", function () {
   let updateData: {chain: IBeaconChainLc; blockWithSyncAggregate: altair.BeaconBlock};
   let update: altair.LightClientUpdate;
 
-  before("init bls", async () => {
-    // This process has to be done manually because of an issue in Karma runner
-    // https://github.com/karma-runner/karma/issues/3804
-    await init(isNode ? "blst-native" : "herumi");
-  });
-
-  before("BLS sanity check", () => {
+  beforeAll(() => {
     const sk = bls.SecretKey.fromBytes(Buffer.alloc(32, 1));
-    expect(sk.toPublicKey().toHex()).to.equal(
+    expect(sk.toPublicKey().toHex()).toBe(
       "0xaa1a1c26055a329817a5759d877a2795f9499b97d6056edde0eea39512f24e8bc874b4471f0501127abb1ea0d9f68ac1"
     );
   });
 
-  before("Generate data for prepareUpdate", () => {
+  beforeAll(() => {
     // Create a state that has as nextSyncCommittee the committee 2
     const finalizedBlockSlot = SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD + 1;
     const headerBlockSlot = finalizedBlockSlot + 1;
@@ -107,6 +101,6 @@ describe("syncInMemory", function () {
       },
     };
 
-    expect(() => processLightClientUpdate(config, store, update, currentSlot)).to.not.throw();
+    expect(() => processLightClientUpdate(config, store, update, currentSlot)).not.toThrow();
   });
 });

--- a/packages/light-client/test/unit/syncInMemory.test.ts
+++ b/packages/light-client/test/unit/syncInMemory.test.ts
@@ -9,7 +9,6 @@ import {BeaconChainLcMock} from "../mocks/BeaconChainLcMock.js";
 import {processLightClientUpdate} from "../utils/naive/update.js";
 import {IBeaconChainLc, prepareUpdateNaive} from "../utils/prepareUpdateNaive.js";
 import {getInteropSyncCommittee, getSyncAggregateSigningRoot, SyncCommitteeKeys} from "../utils/utils.js";
-import {isNode} from "../../src/utils/utils.js";
 
 function getSyncCommittee(
   syncCommitteesKeys: Map<SyncPeriod, SyncCommitteeKeys>,

--- a/packages/light-client/test/unit/utils.test.ts
+++ b/packages/light-client/test/unit/utils.test.ts
@@ -1,4 +1,4 @@
-import {expect} from "chai";
+import {describe, it, expect} from 'vitest';
 import {isValidMerkleBranch} from "../../src/utils/verifyMerkleBranch.js";
 import {computeMerkleBranch} from "../utils/utils.js";
 
@@ -9,6 +9,6 @@ describe("utils", () => {
     const index = 22;
     const {root, proof} = computeMerkleBranch(leaf, depth, index);
 
-    expect(isValidMerkleBranch(leaf, proof, depth, index, root)).to.equal(true);
+    expect(isValidMerkleBranch(leaf, proof, depth, index, root)).toBe(true);
   });
 });

--- a/packages/light-client/test/unit/utils.test.ts
+++ b/packages/light-client/test/unit/utils.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect} from "vitest";
 import {isValidMerkleBranch} from "../../src/utils/verifyMerkleBranch.js";
 import {computeMerkleBranch} from "../utils/utils.js";
 

--- a/packages/light-client/test/unit/utils/chunkify.test.ts
+++ b/packages/light-client/test/unit/utils/chunkify.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect} from 'vitest';
+import {describe, it, expect} from "vitest";
 import {chunkifyInclusiveRange} from "../../../src/utils/chunkify.js";
 
 describe("utils / chunkifyInclusiveRange", () => {

--- a/packages/light-client/test/unit/utils/chunkify.test.ts
+++ b/packages/light-client/test/unit/utils/chunkify.test.ts
@@ -1,4 +1,4 @@
-import {expect} from "chai";
+import {describe, it, expect} from 'vitest';
 import {chunkifyInclusiveRange} from "../../../src/utils/chunkify.js";
 
 describe("utils / chunkifyInclusiveRange", () => {
@@ -20,7 +20,7 @@ describe("utils / chunkifyInclusiveRange", () => {
 
   for (const {id, from, to, max, result} of testCases) {
     it(id, () => {
-      expect(chunkifyInclusiveRange(from, to, max)).to.deep.equal(result);
+      expect(chunkifyInclusiveRange(from, to, max)).toEqual(result);
     });
   }
 });

--- a/packages/light-client/test/unit/validation.test.ts
+++ b/packages/light-client/test/unit/validation.test.ts
@@ -1,5 +1,5 @@
-import {expect} from "chai";
-import bls, {init} from "@chainsafe/bls/switchable";
+import {describe, it, expect, beforeAll, vi} from 'vitest';
+import bls from "@chainsafe/bls";
 import {Tree} from "@chainsafe/persistent-merkle-tree";
 import {altair, ssz} from "@lodestar/types";
 import {chainConfig} from "@lodestar/config/default";
@@ -19,7 +19,7 @@ import {isNode} from "../../src/utils/utils.js";
 describe("validation", function () {
   // In browser test this process is taking more time than default 2000ms
   // specially on the CI
-  this.timeout(15000);
+  vi.setConfig({testTimeout: 15000});
 
   const genValiRoot = Buffer.alloc(32, 9);
   const config = createBeaconConfig(chainConfig, genValiRoot);
@@ -27,13 +27,7 @@ describe("validation", function () {
   let update: altair.LightClientUpdate;
   let snapshot: LightClientSnapshotFast;
 
-  before("prepare bls", async () => {
-    // This process has to be done manually because of an issue in Karma runner
-    // https://github.com/karma-runner/karma/issues/3804
-    await init(isNode ? "blst-native" : "herumi");
-  });
-
-  before("prepare data", function () {
+  beforeAll(function () {
     // Update slot must > snapshot slot
     // attestedHeaderSlot must == updateHeaderSlot + 1
     const snapshotHeaderSlot = 1;
@@ -106,6 +100,6 @@ describe("validation", function () {
   });
 
   it("should validate valid update", () => {
-    expect(() => assertValidLightClientUpdate(config, snapshot.nextSyncCommittee, update)).to.not.throw();
+    expect(() => assertValidLightClientUpdate(config, snapshot.nextSyncCommittee, update)).not.toThrow();
   });
 });

--- a/packages/light-client/test/unit/validation.test.ts
+++ b/packages/light-client/test/unit/validation.test.ts
@@ -1,4 +1,4 @@
-import {describe, it, expect, beforeAll, vi} from 'vitest';
+import {describe, it, expect, beforeAll, vi} from "vitest";
 import bls from "@chainsafe/bls";
 import {Tree} from "@chainsafe/persistent-merkle-tree";
 import {altair, ssz} from "@lodestar/types";
@@ -14,7 +14,6 @@ import {
 import {assertValidLightClientUpdate} from "../../src/validation.js";
 import {LightClientSnapshotFast, SyncCommitteeFast} from "../../src/types.js";
 import {defaultBeaconBlockHeader, getSyncAggregateSigningRoot, signAndAggregate} from "../utils/utils.js";
-import {isNode} from "../../src/utils/utils.js";
 
 describe("validation", function () {
   // In browser test this process is taking more time than default 2000ms

--- a/packages/light-client/test/utils/utils.ts
+++ b/packages/light-client/test/utils/utils.ts
@@ -1,4 +1,4 @@
-import bls from "@chainsafe/bls/switchable";
+import bls from "@chainsafe/bls";
 import {PointFormat, PublicKey, SecretKey} from "@chainsafe/bls/types";
 import {hasher, Tree} from "@chainsafe/persistent-merkle-tree";
 import {BitArray, fromHexString} from "@chainsafe/ssz";

--- a/packages/light-client/tsconfig.e2e.json
+++ b/packages/light-client/tsconfig.e2e.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../tsconfig.e2e.json",
-  "include": [
-    "src",
-    "test"
-  ],
-}

--- a/packages/light-client/vitest.browser.config.ts
+++ b/packages/light-client/vitest.browser.config.ts
@@ -1,0 +1,14 @@
+import {defineConfig, mergeConfig} from "vitest/config";
+import vitestConfig from "../../vitest.base.browser.config";
+
+export default mergeConfig(
+  vitestConfig,
+  defineConfig({
+    test: {
+      globalSetup: ["./test/globalSetup.ts"],
+    },
+    optimizeDeps: {
+      exclude: ["@chainsafe/blst"],
+    },
+  })
+);

--- a/packages/light-client/vitest.config.ts
+++ b/packages/light-client/vitest.config.ts
@@ -1,0 +1,11 @@
+import {defineConfig, mergeConfig} from "vitest/config";
+import vitestConfig from "../../vitest.base.config";
+
+export default mergeConfig(
+  vitestConfig,
+  defineConfig({
+    test: {
+      globalSetup: ["./test/globalSetup.ts"],
+    },
+  })
+);

--- a/packages/light-client/webpack.test.config.cjs
+++ b/packages/light-client/webpack.test.config.cjs
@@ -1,5 +1,0 @@
-const webpackConfig = require("../../webpack.test.config.js");
-
-module.exports = {
-  ...webpackConfig,
-};


### PR DESCRIPTION
**Motivation**

Consolidate the testing frameworks and migrate to vitest.

**Description**

Migrate `light-client` tests to vitest.

**Steps to test or reproduce**

- Run all tests 