### PR TITLE
feat: schedule deneb fork on testnets

### DIFF
--- a/packages/config/src/chainConfig/networks/holesky.ts
+++ b/packages/config/src/chainConfig/networks/holesky.ts
@@ -31,6 +31,9 @@ export const holeskyChainConfig: ChainConfig = {
   // Capella
   CAPELLA_FORK_VERSION: b("0x04017000"),
   CAPELLA_FORK_EPOCH: 256,
+  // Deneb
+  DENEB_FORK_VERSION: b("0x05017000"),
+  DENEB_FORK_EPOCH: 29696,
 
   // # 28,000,000,000 Gwei to ensure quicker ejection
   EJECTION_BALANCE: 28000000000,

--- a/packages/config/src/chainConfig/networks/sepolia.ts
+++ b/packages/config/src/chainConfig/networks/sepolia.ts
@@ -30,6 +30,9 @@ export const sepoliaChainConfig: ChainConfig = {
   // Capella
   CAPELLA_FORK_VERSION: b("0x90000072"),
   CAPELLA_FORK_EPOCH: 56832,
+  // Deneb
+  DENEB_FORK_VERSION: b("0x90000073"),
+  DENEB_FORK_EPOCH: 132608,
 
   // Deposit contract
   // ---------------------------------------------------------------


### PR DESCRIPTION
UPDATE: it has been decided to first check the rollout of deneb on goerli PR (https://github.com/ChainSafe/lodestar/pull/6254) via a goerli focused release and if things go good then the schedule will be applied on a new release

deneb has been tentatively schedule for testnets (post mid jan 2024)

see: 
- https://github.com/ethereum/EIPs/pull/8051
- https://github.com/ethereum/execution-specs/pull/860

see :
 - https://github.com/eth-clients/goerli/pull/178
 - https://github.com/eth-clients/sepolia/pull/61
 - https://github.com/eth-clients/holesky/pull/94