### PR TITLE
feat: add response headers to produceBlockV3

### DIFF
--- a/packages/api/src/beacon/server/validator.ts
+++ b/packages/api/src/beacon/server/validator.ts
@@ -20,6 +20,10 @@ export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerR
       handler: async (req, res) => {
         const response = await api.produceBlockV3(...reqSerializers.produceBlockV3.parseReq(req));
         void res.header("Eth-Consensus-Version", response.version);
+        void res.header("Eth-Execution-Payload-Blinded", response.executionPayloadBlinded);
+        void res.header("Eth-Execution-Payload-Value", response.executionPayloadValue);
+        void res.header("Eth-Consensus-Block-Value", response.consensusBlockValue);
+
         return returnTypes.produceBlockV3.toJson(response);
       },
     },

--- a/packages/api/src/beacon/server/validator.ts
+++ b/packages/api/src/beacon/server/validator.ts
@@ -19,7 +19,7 @@ export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerR
       ...serverRoutes.produceBlockV3,
       handler: async (req, res) => {
         const response = await api.produceBlockV3(...reqSerializers.produceBlockV3.parseReq(req));
-        res.header("Eth-Consensus-Version", response.version);
+        void res.header("Eth-Consensus-Version", response.version);
         return returnTypes.produceBlockV3.toJson(response);
       },
     },

--- a/packages/api/src/beacon/server/validator.ts
+++ b/packages/api/src/beacon/server/validator.ts
@@ -21,7 +21,7 @@ export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerR
         const response = await api.produceBlockV3(...reqSerializers.produceBlockV3.parseReq(req));
         res.header("Eth-Consensus-Version", response.version);
         return returnTypes.produceBlockV3.toJson(response);
-      }
+      },
     },
   };
 }

--- a/packages/api/src/beacon/server/validator.ts
+++ b/packages/api/src/beacon/server/validator.ts
@@ -4,6 +4,24 @@ import {ServerRoutes, getGenericJsonServer} from "../../utils/server/index.js";
 import {ServerApi} from "../../interfaces.js";
 
 export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerRoutes<Api, ReqTypes> {
-  // All routes return JSON, use a server auto-generator
-  return getGenericJsonServer<ServerApi<Api>, ReqTypes>({routesData, getReturnTypes, getReqSerializers}, config, api);
+  const reqSerializers = getReqSerializers();
+  const returnTypes = getReturnTypes();
+
+  // Most of routes return JSON, use a server auto-generator
+  const serverRoutes = getGenericJsonServer<ServerApi<Api>, ReqTypes>(
+    {routesData, getReturnTypes, getReqSerializers},
+    config,
+    api
+  );
+  return {
+    ...serverRoutes,
+    produceBlockV3: {
+      ...serverRoutes.produceBlockV3,
+      handler: async (req, res) => {
+        const response = await api.produceBlockV3(...reqSerializers.produceBlockV3.parseReq(req));
+        res.header("Eth-Consensus-Version", response.version);
+        return returnTypes.produceBlockV3.toJson(response);
+      }
+    },
+  };
 }


### PR DESCRIPTION
**Motivation**

<!-- Why is this PR exists? What are the goals of the pull request? -->
Some tools (eg. [blockdreamer](https://github.com/blockprint-collective/blockdreamer)) rely on `Eth-Consenus-Version` header from `produceBlockV3` before further processing. 

**Description**

This is a temporary solution to add the 4 headers (`Eth-Consensus-Version`, `Eth-Execution-Payload-Blinded`, `Eth-Execution-Payload-Value`, `Eth-Consensus-Block-Value`) for `produceBlockV3` according to the [spec](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/produceBlockV3) before a more permanent solution of returning api response headers is introduced.
<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #6202