### PR TITLE
chore: update prom-client to v15.1.0

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -145,7 +145,7 @@
     "jwt-simple": "0.5.6",
     "libp2p": "0.46.12",
     "multiformats": "^11.0.1",
-    "prom-client": "^14.2.0",
+    "prom-client": "^15.1.0",
     "qs": "^6.11.1",
     "snappyjs": "^0.7.0",
     "strict-event-emitter-types": "^2.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,7 +88,7 @@
     "js-yaml": "^4.1.0",
     "lockfile": "^1.0.4",
     "lodash": "^4.17.21",
-    "prom-client": "^14.2.0",
+    "prom-client": "^15.1.0",
     "rimraf": "^4.4.1",
     "source-map-support": "^0.5.21",
     "uint8arrays": "^4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,6 +2598,11 @@
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.0-rc.0.tgz"
   integrity sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ==
 
+"@opentelemetry/api@^1.4.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.7.0.tgz#b139c81999c23e3c8d3c0a7234480e945920fc40"
+  integrity sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==
+
 "@parcel/watcher@2.0.4":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.0.4.tgz#f300fef4cc38008ff4b8c29d92588eced3ce014b"
@@ -12501,6 +12506,14 @@ prom-client@^14.2.0:
   resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
   integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
   dependencies:
+    tdigest "^0.1.1"
+
+prom-client@^15.1.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-15.1.0.tgz#816a4a2128da169d0471093baeccc6d2f17a4613"
+  integrity sha512-cCD7jLTqyPdjEPBo/Xk4Iu8jxjuZgZJ3e/oET3L+ZwOuap/7Cw3dH/TJSsZKs1TQLZ2IHpIlRAKw82ef06kmMw==
+  dependencies:
+    "@opentelemetry/api" "^1.4.0"
     tdigest "^0.1.1"
 
 promise-inflight@^1.0.1:


### PR DESCRIPTION
**Motivation**

prom-client v15 includes some promising performance improvements
- https://github.com/siimon/prom-client/pull/549
- https://github.com/siimon/prom-client/pull/594

I also want to make sure v15 types are compatible with refactoring done in https://github.com/ChainSafe/lodestar/pull/6201.

**Description**

Update prom-client to [v15.1.0](https://github.com/siimon/prom-client/releases/tag/v15.1.0)
