### PR TITLE
test: fix flaky e2e tests

### DIFF
--- a/packages/cli/test/utils/runUtils.ts
+++ b/packages/cli/test/utils/runUtils.ts
@@ -26,4 +26,5 @@ export function expectDeepEquals<T>(a: T, b: T, message: string): void {
 export function expectDeepEqualsUnordered<T>(a: T[], b: T[], message: string): void {
   expect(a).toEqualWithMessage(expect.arrayContaining(b), message);
   expect(b).toEqualWithMessage(expect.arrayContaining(a), message);
+  expect(a).toHaveLength(b.length);
 }

--- a/packages/cli/test/utils/runUtils.ts
+++ b/packages/cli/test/utils/runUtils.ts
@@ -17,20 +17,13 @@ export function findApiToken(dirpath: string): string {
 }
 
 export function expectDeepEquals<T>(a: T, b: T, message: string): void {
-  try {
-    expect(a).toEqual(b);
-  } catch (e) {
-    expect.fail(message);
-  }
+  expect(a).toEqualWithMessage(b, message);
 }
 
 /**
  * Similar to `expectDeepEquals` but only checks presence of all elements in array, irrespective of their order.
  */
 export function expectDeepEqualsUnordered<T>(a: T[], b: T[], message: string): void {
-  try {
-    expect(a.sort()).toEqual(b.sort());
-  } catch (e) {
-    expect.fail(message);
-  }
+  expect(a).toEqualWithMessage(expect.arrayContaining(b), message);
+  expect(b).toEqualWithMessage(expect.arrayContaining(a), message);
 }

--- a/scripts/vitest/customMatchers.ts
+++ b/scripts/vitest/customMatchers.ts
@@ -42,7 +42,7 @@ expect.extend({
   toBeWithMessage(received: unknown, expected: unknown, message: string) {
     if (Object.is(received, expected)) {
       return {
-        message: () => "Expected value is truthy",
+        message: () => "Received value is the same as expected value",
         pass: true,
       };
     }
@@ -50,25 +50,27 @@ expect.extend({
     return {
       pass: false,
       message: () => message,
+      actual: received,
+      expected,
     };
   },
   toSatisfy(received: unknown, func: (received: unknown) => boolean) {
     if (func(received)) {
       return {
-        message: () => "Expected value satisfied the condition",
+        message: () => "Received value satisfied the condition",
         pass: true,
       };
     }
 
     return {
       pass: false,
-      message: () => "Expected value did not satisfy the condition",
+      message: () => "Received value did not satisfy the condition",
     };
   },
   toEqualWithMessage(received: unknown, expected: unknown, message: string) {
     if (this.equals(received, expected)) {
       return {
-        message: () => "Expected value is truthy",
+        message: () => "Received value equals expected value",
         pass: true,
       };
     }
@@ -76,6 +78,8 @@ expect.extend({
     return {
       pass: false,
       message: () => message,
+      actual: received,
+      expected,
     };
   },
 });


### PR DESCRIPTION
**Motivation**

Fixes flaky e2e tests since we merged https://github.com/ChainSafe/lodestar/pull/6192.

As mentioned in https://github.com/ChainSafe/lodestar/pull/6192#discussion_r1431337483, the `expectDeepEqualsUnordered` function does not work as expected. Sorting an array of objects does not work like that, we would have to sort by pubkey for our specific use case but since this is supposed to be a generic function I used `expect.arrayContaining` which if called on both arrays works similar to `to.have.deep.members`.

I also noticed that the test does not print the diff on failure and just the message is not very helpful to diagnose the issue.




**Description**

- Fixes assertion to check deep equality unordered arrays of objects
- Update custom matchers to print diff on failure to make it easier to diagnose issues, see [extending-matchers](https://vitest.dev/guide/extending-matchers)


Previous error on failure

![image](https://github.com/ChainSafe/lodestar/assets/38436224/ab9b99f4-b562-403f-946e-9e2fc0884eab)


Updated error on failure

![image](https://github.com/ChainSafe/lodestar/assets/38436224/e5662417-c098-45c6-a621-1d33b484cfd8)


