### PR TITLE
feat: add workflow_dispatch to docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,21 +4,52 @@ on:
   push:
     branches:
       - stable
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref to deploy, defaults to `unstable`'
+        required: false
+        default: 'unstable'
+        type: string
 
 jobs:
   docs:
     runs-on: buildjet-4vcpu-ubuntu-2204
+    env:
+      DEPLOY_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || 'stable' }}
     steps:
-      # <common-build> - Uses YAML anchors in the future
+      # Validation step for workflow_dispatch ref input
+      - name: Validate Ref
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if git rev-parse "${{ env.DEPLOY_REF }}" >/dev/null 2>&1; then
+            echo "Ref ${{ env.DEPLOY_REF }} is valid."
+          else
+            echo "Error: Ref ${{ env.DEPLOY_REF }} is not a valid branch, tag or commit." >&2
+            exit 1
+          fi
+
+      # Log out the ref being deployed
+      - name: Log Deployment Ref
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "Deploying ref: $DEPLOY_REF"
+
+      # Checkout the correct ref being deployed
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.DEPLOY_REF }}
+
       - uses: actions/setup-node@v3
         with:
           node-version: 20
           check-latest: true
           cache: yarn          
+
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
+
       - name: Restore dependencies
         uses: actions/cache@master
         id: cache-deps
@@ -27,13 +58,14 @@ jobs:
             node_modules
             packages/*/node_modules
           key: ${{ runner.os }}-${{ steps.node.outputs.v8CppApiVersion }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
+
       - name: Install & build
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile && yarn build
+
       - name: Build
         run: yarn build
         if: steps.cache-deps.outputs.cache-hit == 'true'
-      # </common-build>
 
       - name: Build and collect docs
         run: yarn build:docs


### PR DESCRIPTION
**Motivation**

Adds a button to the docs workflow to manually deploy the docs website from any branch.  The workflow will still run on pushes to stable but it also can now be run to deploy a different branch of the docs.  Any `branch`, `tag`, or `commit` will work and the workflow will validate that its a validate `ref` before running the deploy process.  The default was set as `unstable` as I assumed we would want to PR the docs updates before deploying them but any branch will work.  

Note: The workflow will still run on `stable` automatically to keep the docs in sync with our releases as they are released.  We will need to be cognizant of this if there are changes to the docs that need to get merged with releases as we normally do so should not be a big hurdle but I wanted to make sure that is noted here.

Note: There is a default dropdown provided for "workflow_dispatch" events and the dropdown will specify the version of the workflow that is being run.  The second input field is the one that we want to use at deploy time.  It will select the `ref` for the docs that will be deployed. 

![Screenshot 2023-12-24 at 10 45 40 PM](https://github.com/ChainSafe/lodestar/assets/18608739/fc2740c6-309d-4396-b7a5-5a9b2ef95abb)

**Testing**

Was developed with a bit of help from chatgpt to verify that the syntax was correct but we may need to run once to triple check there are no bugs.

