### PR TITLE
fix: correct createFromState() with cached current shuffling

### DIFF
--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -309,8 +309,10 @@ export class EpochCache {
       if (cachedPreviousShuffling == null && isActiveValidator(validator, previousEpoch)) {
         previousActiveIndices.push(i);
       }
-      if (cachedCurrentShuffling == null && isActiveValidator(validator, currentEpoch)) {
-        currentActiveIndices.push(i);
+      if (isActiveValidator(validator, currentEpoch)) {
+        if (cachedCurrentShuffling == null) {
+          currentActiveIndices.push(i);
+        }
         // We track totalActiveBalanceIncrements as ETH to fit total network balance in a JS number (53 bits)
         totalActiveBalanceIncrements += effectiveBalanceIncrements[i];
       }

--- a/packages/state-transition/test/unit/cachedBeaconState.test.ts
+++ b/packages/state-transition/test/unit/cachedBeaconState.test.ts
@@ -133,7 +133,7 @@ describe("CachedBeaconState", () => {
         const newStateBytes = newCachedState.serialize();
         expect(newStateBytes).toEqual(stateBytes);
         expect(newCachedState.hashTreeRoot()).toEqual(state.hashTreeRoot());
-        const shufflingGetter = (shufflingEpoch: Epoch, dependentRoot: RootHex) => {
+        const shufflingGetter = (shufflingEpoch: Epoch, dependentRoot: RootHex): EpochShuffling | null => {
           if (
             shufflingEpoch === seedState.epochCtx.epoch - 1 &&
             dependentRoot === getShufflingDecisionBlock(seedState, shufflingEpoch)


### PR DESCRIPTION
**Motivation**

To correctly load a state with cached shuffling, this is found when testing n-historical states branch

**Description**

- When there is a cached current shuffling, `totalActiveBalanceIncrements` is not computed which causes wrong state transitions
- Enhance unit tests to make sure EpochContext is correct when loading a state from Uint8Array

A fix for #6057