### PR TITLE
fix: remove invalid workflow step

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,17 +18,6 @@ jobs:
     env:
       DEPLOY_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || 'stable' }}
     steps:
-      # Validation step for workflow_dispatch ref input
-      - name: Validate Ref
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          if git rev-parse "${{ env.DEPLOY_REF }}" >/dev/null 2>&1; then
-            echo "Ref ${{ env.DEPLOY_REF }} is valid."
-          else
-            echo "Error: Ref ${{ env.DEPLOY_REF }} is not a valid branch, tag or commit." >&2
-            exit 1
-          fi
-
       # Log out the ref being deployed
       - name: Log Deployment Ref
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
**Motivation**

There was a logical bug in the workflow update.  The command was valid but the repo is not checked out yet in order to validate the branch/tag/commit. 

**Description**

Is a chicken/egg situation.  I wanted to validate the ref before checkout but need repo to validate against. Remove invalid step.  Checked in `action/checkout` source code that the ref is validated so an error still gets thrown for invalid input data and the workflow still aborts