### PR TITLE
test: allow to pass extra args everywhere

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -79,7 +79,7 @@
     "test": "yarn test:unit && yarn test:e2e",
     "test:unit:minimal": "vitest --run --segfaultRetry 3 --dir test/unit/ --coverage",
     "test:unit:mainnet": "LODESTAR_PRESET=mainnet nyc --cache-dir .nyc_output/.cache -e .ts mocha 'test/unit-mainnet/**/*.test.ts'",
-    "test:unit": "yarn test:unit:minimal && yarn test:unit:mainnet",
+    "test:unit": "wrapper() { yarn test:unit:minimal $@ && yarn test:unit:mainnet $@; }; wrapper",
     "test:e2e": "LODESTAR_PRESET=minimal vitest --run --segfaultRetry 3 --poolOptions.threads.singleThread true --dir test/e2e",
     "test:sim": "mocha 'test/sim/**/*.test.ts'",
     "test:sim:merge-interop": "mocha 'test/sim/merge-interop.test.ts'",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -63,7 +63,7 @@
     "lint:fix": "yarn run lint --fix",
     "test:constants:minimal": "LODESTAR_PRESET=minimal vitest --run --dir test/constants/ --coverage",
     "test:constants:mainnet": "LODESTAR_PRESET=mainnet vitest --run --dir test/constants/ --coverage",
-    "test:unit": "yarn test:constants:minimal && yarn test:constants:mainnet && vitest --run --dir test/unit/ --coverage",
+    "test:unit": "wrapper() { yarn test:constants:minimal $@ && yarn test:constants:mainnet $@ && vitest --run --dir test/unit/ --coverage $@; }; wrapper",
     "test:browsers": "yarn test:browsers:chrome && yarn test:browsers:firefox && yarn test:browsers:electron",
     "test:browsers:chrome": "vitest --run --browser chrome --config ./vitest.browser.config.ts --dir test/unit",
     "test:browsers:firefox": "vitest --run --browser firefox --config ./vitest.browser.config.ts --dir test/unit",


### PR DESCRIPTION
**Motivation**

Fix an issue than prevents some `test:unit` script to receive extra arguments passed via the command line.
e.g. `yarn test:unit -t someTest` will not propagate `-t someTest` 