### PR TITLE
fix: ensure transferred ArrayBuffer are Transferable

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystores/worker.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystores/worker.ts
@@ -1,18 +1,21 @@
 import fs from "node:fs";
-import worker from 'node:worker_threads';
+import worker from "node:worker_threads";
 import {expose} from "@chainsafe/threads/worker";
 import {Transfer, TransferDescriptor} from "@chainsafe/threads";
 import {Keystore} from "@chainsafe/bls-keystore";
 import {DecryptKeystoreArgs, DecryptKeystoreWorkerAPI, isLocalKeystoreDefinition} from "./types.js";
 
 /**
- * @param buffer The ArrayBuffer to be returned as transferable 
+ * @param buffer The ArrayBuffer to be returned as transferable
  * @returns a buffer that can be transferred. If the provided buffer is marked as untransferable, a copy is returned
  */
-function transferableArrayBuffer(buffer: ArrayBuffer) {
-  const unknown_worker = worker as any;
-  const isMarkedAsUntransferable = unknown_worker["isMarkedAsUntransferable"];
+function transferableArrayBuffer(buffer: ArrayBuffer): ArrayBuffer {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+  const unknownWorker = worker as any;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
+  const isMarkedAsUntransferable = unknownWorker["isMarkedAsUntransferable"];
   // Can be updated to direct access once minimal version of node is 21
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   if (isMarkedAsUntransferable && isMarkedAsUntransferable(buffer)) {
     // Return a copy of the buffer so that it can be transferred
     return buffer.slice(0);


### PR DESCRIPTION
**Motivation**

`test:unit` do not pass on nodejs starting version 21 due to a change in `ArrayBuffer` transferability 

```shell
 FAIL  test/unit/validator/decryptKeystoreDefinitions.test.ts > decryptKeystoreDefinitions > with keystore cache > decrypt keystores
 FAIL  test/unit/validator/decryptKeystoreDefinitions.test.ts > decryptKeystoreDefinitions > with keystore cache > decrypt keystores if lockfiles already exist if ignoreLockFile=true
 FAIL  test/unit/validator/decryptKeystoreDefinitions.test.ts > decryptKeystoreDefinitions > without keystore cache > decrypt keystores if lockfiles already exist if ignoreLockFile=true
Error: Multiple errors importing keystores

keystore_0.json: Cannot transfer object of unsupported type.
keystore_1.json: Cannot transfer object of unsupported type.
```

**Description**

Node [version 21](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V21.md#2023-10-17-version-2100-current-rafaelgss-and-targos) introduces [changes](https://github.com/nodejs/node/pull/47604) to the way ArrayBuffer transferability are dealt with. Specifically some of current usage now is not transferable anymore and breaks usage.
To deal with this, a new API has been introduced in node 21 to detect if an object has been [marked as not transferable](https://nodejs.org/api/worker_threads.html#workerismarkedasuntransferableobject). This API is used (when available) to do a copy of the underlying buffer instead of directly transferring it. 
Performance in this case is still assumed to be better than going through full (de)/serialization.
