### PR TITLE
feat: prune BlsToExecutionChange opPool with head state

### DIFF
--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -13,8 +13,9 @@ import {
   MAX_BLS_TO_EXECUTION_CHANGES,
   BLS_WITHDRAWAL_PREFIX,
   MAX_ATTESTER_SLASHINGS,
+  ForkSeq,
 } from "@lodestar/params";
-import {Epoch, phase0, capella, ssz, ValidatorIndex} from "@lodestar/types";
+import {Epoch, phase0, capella, ssz, ValidatorIndex, allForks} from "@lodestar/types";
 import {IBeaconDb} from "../../db/index.js";
 import {SignedBLSToExecutionChangeVersioned} from "../../util/types.js";
 import {BlockType} from "../interface.js";
@@ -300,11 +301,11 @@ export class OpPool {
   /**
    * Prune all types of transactions given the latest head state
    */
-  pruneAll(headState: CachedBeaconStateAllForks, finalizedState: CachedBeaconStateAllForks | null): void {
+  pruneAll(headBlock: allForks.SignedBeaconBlock, headState: CachedBeaconStateAllForks): void {
     this.pruneAttesterSlashings(headState);
     this.pruneProposerSlashings(headState);
     this.pruneVoluntaryExits(headState);
-    this.pruneBlsToExecutionChanges(headState, finalizedState);
+    this.pruneBlsToExecutionChanges(headBlock, headState);
   }
 
   /**
@@ -369,19 +370,29 @@ export class OpPool {
   }
 
   /**
-   * Call after finalizing
-   * Prune blsToExecutionChanges for validators which have been set with withdrawal
-   * credentials
+   * Prune BLS to execution changes that have been applied to the state more than 1 block ago.
+   * In the worse case where head block is reorged, the same BlsToExecutionChange message can be re-added
+   * to opPool once gossipsub seen cache TTL passes.
    */
   private pruneBlsToExecutionChanges(
-    headState: CachedBeaconStateAllForks,
-    finalizedState: CachedBeaconStateAllForks | null
+    headBlock: allForks.SignedBeaconBlock,
+    headState: CachedBeaconStateAllForks
   ): void {
+    const {config} = headState;
+    const recentBlsToExecutionChanges =
+      config.getForkSeq(headBlock.message.slot) >= ForkSeq.capella
+        ? (headBlock as capella.SignedBeaconBlock).message.body.blsToExecutionChanges
+        : [];
+
+    const recentBlsToExecutionChangeIndexes = new Set<ValidatorIndex>();
+    for (const blsToExecutionChange of recentBlsToExecutionChanges) {
+      recentBlsToExecutionChangeIndexes.add(blsToExecutionChange.message.validatorIndex);
+    }
+
     for (const [key, blsToExecutionChange] of this.blsToExecutionChanges.entries()) {
-      // TODO CAPELLA: We need the finalizedState to safely prune BlsToExecutionChanges. Finalized state may not be
-      // available in the cache, so it can be null. Once there's a head only prunning strategy, change
-      if (finalizedState !== null) {
-        const validator = finalizedState.validators.getReadonly(blsToExecutionChange.data.message.validatorIndex);
+      const {validatorIndex} = blsToExecutionChange.data.message;
+      if (!recentBlsToExecutionChangeIndexes.has(validatorIndex)) {
+        const validator = headState.validators.getReadonly(validatorIndex);
         if (validator.withdrawalCredentials[0] !== BLS_WITHDRAWAL_PREFIX) {
           this.blsToExecutionChanges.delete(key);
         }

--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -384,10 +384,9 @@ export class OpPool {
         ? (headBlock as capella.SignedBeaconBlock).message.body.blsToExecutionChanges
         : [];
 
-    const recentBlsToExecutionChangeIndexes = new Set<ValidatorIndex>();
-    for (const blsToExecutionChange of recentBlsToExecutionChanges) {
-      recentBlsToExecutionChangeIndexes.add(blsToExecutionChange.message.validatorIndex);
-    }
+    const recentBlsToExecutionChangeIndexes = new Set(
+      recentBlsToExecutionChanges.map((blsToExecutionChange) => blsToExecutionChange.message.validatorIndex)
+    );
 
     for (const [key, blsToExecutionChange] of this.blsToExecutionChanges.entries()) {
       const {validatorIndex} = blsToExecutionChange.data.message;


### PR DESCRIPTION
**Motivation**

- Right now we use finalized state to prune BlsToExecutionChange but it's not available anymore after n-historical state work, that's also in our `TODO` list

**Description**

- Prune BlsToExecutionChange opPool with head state except for ones recently added in the head block
- This is the same to lighthouse strategy https://github.com/sigp/lighthouse/blob/441fc1691b69f9edc4bbdc6665f3efab16265c9b/beacon_node/operation_pool/src/bls_to_execution_changes.rs#L96

this is a prerequisite for #6250