### PR TITLE
deps: update bls-keystore to v3.0.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "@chainsafe/as-sha256": "^0.3.1",
     "@chainsafe/bls": "7.1.1",
     "@chainsafe/bls-keygen": "^0.3.0",
-    "@chainsafe/bls-keystore": "^2.0.0",
+    "@chainsafe/bls-keystore": "^3.0.0",
     "@chainsafe/blst": "^0.2.9",
     "@chainsafe/discv5": "^5.1.0",
     "@chainsafe/persistent-merkle-tree": "^0.6.1",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -62,7 +62,7 @@
   ],
   "dependencies": {
     "@chainsafe/bls": "7.1.1",
-    "@chainsafe/bls-keystore": "^2.0.0",
+    "@chainsafe/bls-keystore": "^3.0.0",
     "@lodestar/params": "^1.13.0",
     "@lodestar/utils": "^1.13.0",
     "axios": "^1.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -511,15 +511,13 @@
     "@noble/hashes" "^1.0.0"
     "@scure/bip39" "^1.0.0"
 
-"@chainsafe/bls-keystore@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/@chainsafe/bls-keystore/-/bls-keystore-2.0.0.tgz"
-  integrity sha512-XGtgGKdjYqKP09SUsfwaStsYuWuXB56/614dC1XhggG4LH8KTrFOjxb9SkS+T1BUu5doCXd9YA+gNLy01zv+Ww==
+"@chainsafe/bls-keystore@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/bls-keystore/-/bls-keystore-3.0.0.tgz#e28c979f7664417e4917fa0d4d32fa2b9416e9c6"
+  integrity sha512-vlRIIXnn555wq2emhqnSR7btno17M0sCcfdQ+Dhgr7IH6n0CMoTGw9qcrpnNYwM+9OPm3matSYeZc9mNlXf7fQ==
   dependencies:
-    ajv "^6.12.2"
-    buffer "^5.4.3"
-    ethereum-cryptography "^0.1.3"
-    uuid "^3.3.3"
+    ethereum-cryptography "^1.0.0"
+    uuid "8.3.2"
 
 "@chainsafe/bls@7.1.1":
   version "7.1.1"
@@ -3389,13 +3387,6 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
-"@types/pbkdf2@^3.0.0":
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz"
-  integrity sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/qs@^6.9.7":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
@@ -3425,13 +3416,6 @@
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.2.tgz#ed279a64fa438bb69f2480eda44937912bb7480a"
   integrity sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==
-
-"@types/secp256k1@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.2.tgz"
-  integrity sha512-QMg+9v0bbNJ2peLuHRWxzmy0HRJIG6gFZNhaRSp7S3ggSbCCxiqQB2/ybvhXyhHOCequpNkrx7OavNhrWOsW0A==
-  dependencies:
-    "@types/node" "*"
 
 "@types/semver@^7.5.0":
   version "7.5.2"
@@ -4122,16 +4106,6 @@ ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.12.2:
-  version "6.12.3"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz"
-  integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
 ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
@@ -4595,13 +4569,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-x@^3.0.2:
-  version "3.0.8"
-  resolved "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz"
-  integrity sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==
-  dependencies:
-    safe-buffer "^5.0.1"
-
 base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
@@ -4737,11 +4704,6 @@ bl@^5.0.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-blakejs@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz"
-  integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
-
 bls-eth-wasm@^0.4.8:
   version "0.4.8"
   resolved "https://registry.npmjs.org/bls-eth-wasm/-/bls-eth-wasm-0.4.8.tgz"
@@ -4846,7 +4808,7 @@ browser-stdout@1.3.1:
   resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-browserify-aes@^1.0.0, browserify-aes@^1.0.4, browserify-aes@^1.2.0:
+browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
   resolved "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz"
   integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
@@ -4916,22 +4878,6 @@ browserslist@^4.14.5:
     electron-to-chromium "^1.4.188"
     node-releases "^2.0.6"
     update-browserslist-db "^1.0.4"
-
-bs58@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz"
-  integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
-  dependencies:
-    base-x "^3.0.2"
-
-bs58check@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz"
-  integrity sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==
-  dependencies:
-    bs58 "^4.0.0"
-    create-hash "^1.1.0"
-    safe-buffer "^5.1.2"
 
 buffer-crc32@^0.2.1, buffer-crc32@^0.2.13, buffer-crc32@~0.2.3:
   version "0.2.13"
@@ -6534,7 +6480,7 @@ electron@^26.2.2:
     "@types/node" "^18.11.18"
     extract-zip "^2.0.1"
 
-elliptic@6.5.4, elliptic@^6.5.2, elliptic@^6.5.3:
+elliptic@6.5.4, elliptic@^6.5.3:
   version "6.5.4"
   resolved "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -7187,28 +7133,7 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-ethereum-cryptography@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz"
-  integrity sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==
-  dependencies:
-    "@types/pbkdf2" "^3.0.0"
-    "@types/secp256k1" "^4.0.1"
-    blakejs "^1.1.0"
-    browserify-aes "^1.2.0"
-    bs58check "^2.1.2"
-    create-hash "^1.2.0"
-    create-hmac "^1.1.7"
-    hash.js "^1.1.7"
-    keccak "^3.0.0"
-    pbkdf2 "^3.0.17"
-    randombytes "^2.1.0"
-    safe-buffer "^5.1.2"
-    scrypt-js "^3.0.0"
-    secp256k1 "^4.0.1"
-    setimmediate "^1.0.5"
-
-ethereum-cryptography@^1.2.0:
+ethereum-cryptography@^1.0.0, ethereum-cryptography@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz#5ccfa183e85fdaf9f9b299a79430c044268c9b3a"
   integrity sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==
@@ -8475,7 +8400,7 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
-hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -9949,14 +9874,6 @@ karma@^6.4.2:
     ua-parser-js "^0.7.30"
     yargs "^16.1.1"
 
-keccak@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz"
-  integrity sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==
-  dependencies:
-    node-addon-api "^2.0.0"
-    node-gyp-build "^4.2.0"
-
 keypress@0.1.x:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/keypress/-/keypress-0.1.0.tgz#4a3188d4291b66b4f65edb99f806aa9ae293592a"
@@ -11210,11 +11127,6 @@ nise@^5.1.4:
     just-extend "^4.0.2"
     path-to-regexp "^1.7.0"
 
-node-addon-api@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
-  integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
-
 node-addon-api@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
@@ -11255,11 +11167,6 @@ node-forge@^1.1.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
-
-node-gyp-build@^4.2.0:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz"
-  integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
 node-gyp-build@^4.3.0:
   version "4.5.0"
@@ -12310,7 +12217,7 @@ pathval@^1.1.1:
   resolved "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-pbkdf2@^3.0.17, pbkdf2@^3.0.3, pbkdf2@^3.0.9:
+pbkdf2@^3.0.3, pbkdf2@^3.0.9:
   version "3.1.2"
   resolved "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz"
   integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
@@ -13388,19 +13295,10 @@ schema-utils@^3.2.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-scrypt-js@3.0.1, scrypt-js@^3.0.0:
+scrypt-js@3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz"
   integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
-
-secp256k1@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz"
-  integrity sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==
-  dependencies:
-    elliptic "^6.5.2"
-    node-addon-api "^2.0.0"
-    node-gyp-build "^4.2.0"
 
 secure-json-parse@^2.5.0:
   version "2.7.0"


### PR DESCRIPTION
**Motivation**

Fixes issue with node 21 mentioned in https://github.com/ChainSafe/lodestar/pull/6251 and significantly improves performance of keystore decryption by **3x**

**Description**

Updates `@chainsafe/bls-keystore` to v3.0.0 which now uses `Uint8Array` instead of `Buffer` in all public APIs (https://github.com/ChainSafe/bls-keystore/pull/28) and updates underlying cryptography library.

This change allows to use transfer object between worker and main thread without creating a copy of the keystore. There might also be other performance improvements done in the underlying `ethereum-cryptography` package which result in a significant performance improvement.

Previous performance: **102.2 keys/m** (from https://github.com/ChainSafe/lodestar/pull/5357#issuecomment-1509845902)

```txt
Apr-15 13:51:55.473[]                 info: Lodestar network=goerli, version=v1.6.0/65a8668, commit=65a86684c54005c935e99e5eeab7497801dab1d7
Apr-15 13:51:55.476[]                 info: Connecting to LevelDB database path=/home/devops/goerli/data/validator/validator-db
Apr-15 13:52:05.507[]                 info: 100% of keystores imported. current=0 total=2000 rate=0.00keys/m
Apr-15 13:52:15.507[]                 info: 1% of keystores imported. current=24 total=2000 rate=144.00keys/m
Apr-15 13:52:25.509[]                 info: 2% of keystores imported. current=36 total=2000 rate=71.99keys/m
Apr-15 13:52:35.508[]                 info: 3% of keystores imported. current=60 total=2000 rate=144.01keys/m
Apr-15 13:52:45.509[]                 info: 4% of keystores imported. current=72 total=2000 rate=71.99keys/m
Apr-15 13:52:55.509[]                 info: 5% of keystores imported. current=91 total=2000 rate=114.01keys/m
Apr-15 13:53:05.521[]                 info: 5% of keystores imported. current=108 total=2000 rate=101.87keys/m
Apr-15 13:53:15.520[]                 info: 6% of keystores imported. current=122 total=2000 rate=84.01keys/m
Apr-15 13:53:25.521[]                 info: 7% of keystores imported. current=141 total=2000 rate=113.99keys/m
Apr-15 13:53:35.521[]                 info: 8% of keystores imported. current=167 total=2000 rate=156.00keys/m
Apr-15 13:53:45.523[]                 info: 9% of keystores imported. current=178 total=2000 rate=65.99keys/m
```

Performance after update: **315.6 keys/m** (more than **3x** faster)

```txt
Jan-05 11:48:26.963[]                 info: Lodestar network=goerli, version=v1.13.0/nflaig/update-bls-keystore/6962f72, commit=6962f72a92379bc3d947b72cabf9cf1205c43088
Jan-05 11:48:26.965[]                 info: Connecting to LevelDB database path=/home/devops/goerli/data/validator/validator-db
Jan-05 11:48:37.002[]                 info: 2% of keystores imported. current=48 total=2000 rate=287.94keys/m
Jan-05 11:48:47.004[]                 info: 5% of keystores imported. current=95 total=2000 rate=281.97keys/m
Jan-05 11:48:57.004[]                 info: 7% of keystores imported. current=148 total=2000 rate=317.97keys/m
Jan-05 11:49:07.004[]                 info: 11% of keystores imported. current=213 total=2000 rate=390.00keys/m
Jan-05 11:49:17.005[]                 info: 13% of keystores imported. current=261 total=2000 rate=287.97keys/m
Jan-05 11:49:27.005[]                 info: 16% of keystores imported. current=322 total=2000 rate=366.00keys/m
Jan-05 11:49:37.005[]                 info: 19% of keystores imported. current=381 total=2000 rate=354.00keys/m
Jan-05 11:49:47.006[]                 info: 21% of keystores imported. current=424 total=2000 rate=257.97keys/m
Jan-05 11:49:57.006[]                 info: 24% of keystores imported. current=470 total=2000 rate=276.00keys/m
Jan-05 11:50:07.006[]                 info: 26% of keystores imported. current=526 total=2000 rate=336.00keys/m
Jan-05 11:50:17.006[]                 info: 29% of keystores imported. current=582 total=2000 rate=336.00keys/m
Jan-05 11:50:27.006[]                 info: 32% of keystores imported. current=637 total=2000 rate=330.00keys/m
``` 
