### PR TITLE
feat: track prepare next epoch time

### DIFF
--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -97,7 +97,7 @@ export class PrepareNextSlotScheduler {
         headRoot,
         isEpochTransition,
       });
-      const lodestarPrecomputeEpochTransitionTimer = isEpochTransition
+      const precomputeEpochTransitionTimer = isEpochTransition
         ? this.metrics?.precomputeNextEpochTransition.duration.startTimer()
         : null;
       // No need to wait for this or the clock drift
@@ -137,7 +137,7 @@ export class PrepareNextSlotScheduler {
           previousHits,
         });
 
-        lodestarPrecomputeEpochTransitionTimer?.();
+        precomputeEpochTransitionTimer?.();
       }
 
       if (isExecutionStateType(prepareState)) {

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -97,6 +97,9 @@ export class PrepareNextSlotScheduler {
         headRoot,
         isEpochTransition,
       });
+      const lodestarPrecomputeEpochTransitionTimer = isEpochTransition
+        ? this.metrics?.precomputeNextEpochTransition.duration.startTimer()
+        : null;
       // No need to wait for this or the clock drift
       // Pre Bellatrix: we only do precompute state transition for the last slot of epoch
       // For Bellatrix, we always do the `processSlots()` to prepare payload for the next slot
@@ -133,6 +136,8 @@ export class PrepareNextSlotScheduler {
           prepareSlot,
           previousHits,
         });
+
+        lodestarPrecomputeEpochTransitionTimer?.();
       }
 
       if (isExecutionStateType(prepareState)) {

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1300,7 +1300,7 @@ export function createLodestarMetrics(
       }),
       duration: register.histogram({
         name: "lodestar_precompute_next_epoch_transition_duration_seconds",
-        help: "Duration of precomputeNextEpochTransition at lodestar side",
+        help: "Duration of precomputeNextEpochTransition, including epoch transition and hashTreeRoot",
         buckets: [1, 2, 3, 4, 8],
       }),
     },

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1298,6 +1298,11 @@ export function createLodestarMetrics(
         name: "lodestar_precompute_next_epoch_transition_waste_total",
         help: "Total number of precomputing next epoch transition wasted",
       }),
+      duration: register.histogram({
+        name: "lodestar_precompute_next_epoch_transition_duration_seconds",
+        help: "Duration of precomputeNextEpochTransition at lodestar side",
+        buckets: [1, 2, 3, 4, 8],
+      }),
     },
 
     // reprocess attestations


### PR DESCRIPTION
**Motivation**

Track prepare next epoch time at lodestar side, the log shows that a lot of time it take >4s on holesky

**Description**

- This is to track how much time does it take at lodestar side to run epoch transition + `hashTreeRoot()` 
- There are also time to call execution engine, but I only want to focus on lodestar side  in order to improve performance