### PR TITLE
feat: reject builder blocks if engine indicates censorship

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -566,8 +566,8 @@ export function getValidatorApi({
           enginePayloadValue: `${enginePayloadValue}`,
           consensusBlockValueEngine: `${consensusBlockValueEngine}`,
           blockValueEngine: `${blockValueEngine}`,
-          slot,
           shouldOverrideBuilder,
+          slot,
         });
       } else if (fullBlock && blindedBlock) {
         switch (builderSelection) {
@@ -605,8 +605,8 @@ export function getValidatorApi({
           consensusBlockValueBuilder: `${consensusBlockValueBuilder}`,
           blockValueEngine: `${blockValueEngine}`,
           blockValueBuilder: `${blockValueBuilder}`,
-          slot,
           shouldOverrideBuilder,
+          slot,
         });
       } else if (fullBlock && !blindedBlock) {
         executionPayloadSource = ProducedBlockSource.engine;
@@ -615,8 +615,8 @@ export function getValidatorApi({
           enginePayloadValue: `${enginePayloadValue}`,
           consensusBlockValueEngine: `${consensusBlockValueEngine}`,
           blockValueEngine: `${blockValueEngine}`,
-          slot,
           shouldOverrideBuilder,
+          slot,
         });
       } else if (blindedBlock && !fullBlock) {
         executionPayloadSource = ProducedBlockSource.builder;
@@ -625,6 +625,7 @@ export function getValidatorApi({
           builderPayloadValue: `${builderPayloadValue}`,
           consensusBlockValueBuilder: `${consensusBlockValueBuilder}`,
           blockValueBuilder: `${blockValueBuilder}`,
+          shouldOverrideBuilder,
           slot,
         });
       }

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -561,12 +561,6 @@ export function getValidatorApi({
 
       // handle the builder override case separately
       if (shouldOverrideBuilder === true) {
-        // this is just to make typescript happy as shouldOverrideBuilder can be true only will valid
-        // full block response
-        if (fullBlock === null) {
-          throw Error("Invalid null fullBlock with builder override");
-        }
-
         executionPayloadSource = ProducedBlockSource.engine;
         logger.verbose("Selected engine block as censorship suspected in builder blocks", {
           // winston logger doesn't like bigint

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -474,7 +474,7 @@ export class BeaconChain implements IBeaconChain {
     block: allForks.BeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Gwei;
-    shouldOverrideBuilder: boolean;
+    shouldOverrideBuilder?: boolean;
   }> {
     return this.produceBlockWrapper<BlockType.Full>(BlockType.Full, blockAttributes);
   }
@@ -483,7 +483,7 @@ export class BeaconChain implements IBeaconChain {
     block: allForks.BlindedBeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Gwei;
-    shouldOverrideBuilder: boolean;
+    shouldOverrideBuilder?: boolean;
   }> {
     return this.produceBlockWrapper<BlockType.Blinded>(BlockType.Blinded, blockAttributes);
   }
@@ -495,7 +495,7 @@ export class BeaconChain implements IBeaconChain {
     block: AssembledBlockType<T>;
     executionPayloadValue: Wei;
     consensusBlockValue: Gwei;
-    shouldOverrideBuilder: boolean;
+    shouldOverrideBuilder?: boolean;
   }> {
     const head = this.forkChoice.getHead();
     const state = await this.regen.getBlockSlotState(

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -483,7 +483,6 @@ export class BeaconChain implements IBeaconChain {
     block: allForks.BlindedBeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Gwei;
-    shouldOverrideBuilder?: boolean;
   }> {
     return this.produceBlockWrapper<BlockType.Blinded>(BlockType.Blinded, blockAttributes);
   }

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -470,22 +470,33 @@ export class BeaconChain implements IBeaconChain {
     return data && {block: data, executionOptimistic: false};
   }
 
-  produceBlock(
-    blockAttributes: BlockAttributes
-  ): Promise<{block: allForks.BeaconBlock; executionPayloadValue: Wei; consensusBlockValue: Gwei}> {
+  produceBlock(blockAttributes: BlockAttributes): Promise<{
+    block: allForks.BeaconBlock;
+    executionPayloadValue: Wei;
+    consensusBlockValue: Gwei;
+    shouldOverrideBuilder: boolean;
+  }> {
     return this.produceBlockWrapper<BlockType.Full>(BlockType.Full, blockAttributes);
   }
 
-  produceBlindedBlock(
-    blockAttributes: BlockAttributes
-  ): Promise<{block: allForks.BlindedBeaconBlock; executionPayloadValue: Wei; consensusBlockValue: Gwei}> {
+  produceBlindedBlock(blockAttributes: BlockAttributes): Promise<{
+    block: allForks.BlindedBeaconBlock;
+    executionPayloadValue: Wei;
+    consensusBlockValue: Gwei;
+    shouldOverrideBuilder: boolean;
+  }> {
     return this.produceBlockWrapper<BlockType.Blinded>(BlockType.Blinded, blockAttributes);
   }
 
   async produceBlockWrapper<T extends BlockType>(
     blockType: T,
     {randaoReveal, graffiti, slot, feeRecipient}: BlockAttributes
-  ): Promise<{block: AssembledBlockType<T>; executionPayloadValue: Wei; consensusBlockValue: Gwei}> {
+  ): Promise<{
+    block: AssembledBlockType<T>;
+    executionPayloadValue: Wei;
+    consensusBlockValue: Gwei;
+    shouldOverrideBuilder: boolean;
+  }> {
     const head = this.forkChoice.getHead();
     const state = await this.regen.getBlockSlotState(
       head.blockRoot,
@@ -497,16 +508,21 @@ export class BeaconChain implements IBeaconChain {
     const proposerIndex = state.epochCtx.getBeaconProposer(slot);
     const proposerPubKey = state.epochCtx.index2pubkey[proposerIndex].toBytes();
 
-    const {body, blobs, executionPayloadValue} = await produceBlockBody.call(this, blockType, state, {
-      randaoReveal,
-      graffiti,
-      slot,
-      feeRecipient,
-      parentSlot: slot - 1,
-      parentBlockRoot,
-      proposerIndex,
-      proposerPubKey,
-    });
+    const {body, blobs, executionPayloadValue, shouldOverrideBuilder} = await produceBlockBody.call(
+      this,
+      blockType,
+      state,
+      {
+        randaoReveal,
+        graffiti,
+        slot,
+        feeRecipient,
+        parentSlot: slot - 1,
+        parentBlockRoot,
+        proposerIndex,
+        proposerPubKey,
+      }
+    );
 
     // The hashtree root computed here for debug log will get cached and hence won't introduce additional delays
     const bodyRoot =
@@ -557,7 +573,7 @@ export class BeaconChain implements IBeaconChain {
       this.metrics?.blockProductionCaches.producedContentsCache.set(this.producedContentsCache.size);
     }
 
-    return {block, executionPayloadValue, consensusBlockValue: proposerReward};
+    return {block, executionPayloadValue, consensusBlockValue: proposerReward, shouldOverrideBuilder};
   }
 
   /**

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -164,7 +164,6 @@ export interface IBeaconChain {
     block: allForks.BlindedBeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Gwei;
-    shouldOverrideBuilder?: boolean;
   }>;
 
   /** Process a block until complete */

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -158,13 +158,13 @@ export interface IBeaconChain {
     block: allForks.BeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Gwei;
-    shouldOverrideBuilder: boolean;
+    shouldOverrideBuilder?: boolean;
   }>;
   produceBlindedBlock(blockAttributes: BlockAttributes): Promise<{
     block: allForks.BlindedBeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Gwei;
-    shouldOverrideBuilder: boolean;
+    shouldOverrideBuilder?: boolean;
   }>;
 
   /** Process a block until complete */

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -154,12 +154,18 @@ export interface IBeaconChain {
 
   getContents(beaconBlock: deneb.BeaconBlock): deneb.Contents;
 
-  produceBlock(
-    blockAttributes: BlockAttributes
-  ): Promise<{block: allForks.BeaconBlock; executionPayloadValue: Wei; consensusBlockValue: Gwei}>;
-  produceBlindedBlock(
-    blockAttributes: BlockAttributes
-  ): Promise<{block: allForks.BlindedBeaconBlock; executionPayloadValue: Wei; consensusBlockValue: Gwei}>;
+  produceBlock(blockAttributes: BlockAttributes): Promise<{
+    block: allForks.BeaconBlock;
+    executionPayloadValue: Wei;
+    consensusBlockValue: Gwei;
+    shouldOverrideBuilder: boolean;
+  }>;
+  produceBlindedBlock(blockAttributes: BlockAttributes): Promise<{
+    block: allForks.BlindedBeaconBlock;
+    executionPayloadValue: Wei;
+    consensusBlockValue: Gwei;
+    shouldOverrideBuilder: boolean;
+  }>;
 
   /** Process a block until complete */
   processBlock(block: BlockInput, opts?: ImportBlockOpts): Promise<void>;

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -113,7 +113,7 @@ export async function produceBlockBody<T extends BlockType>(
   body: AssembledBodyType<T>;
   blobs: BlobsResult;
   executionPayloadValue: Wei;
-  shouldOverrideBuilder: boolean;
+  shouldOverrideBuilder?: boolean;
 }> {
   // Type-safe for blobs variable. Translate 'null' value into 'preDeneb' enum
   // TODO: Not ideal, but better than just using null.
@@ -122,7 +122,7 @@ export async function produceBlockBody<T extends BlockType>(
   let executionPayloadValue: Wei;
   // even though shouldOverrideBuilder is relevant for the engine response, for simplicity of typing
   // we can also return is just as false for builder which will anyway be ignored by the caller
-  let shouldOverrideBuilder: boolean;
+  let shouldOverrideBuilder: boolean | undefined;
   const fork = currentState.config.getForkName(blockSlot);
 
   const logMeta: Record<string, string | number | bigint> = {
@@ -212,7 +212,6 @@ export async function produceBlockBody<T extends BlockType>(
 
     if (blockType === BlockType.Blinded) {
       if (!this.executionBuilder) throw Error("Execution Builder not available");
-      shouldOverrideBuilder = false;
 
       // This path will not be used in the production, but is here just for merge mock
       // tests because merge-mock requires an fcU to be issued prior to fetch payload
@@ -289,7 +288,6 @@ export async function produceBlockBody<T extends BlockType>(
             ssz.allForksExecution[fork].ExecutionPayload.defaultValue();
           blobsResult = {type: BlobsResultType.preDeneb};
           executionPayloadValue = BigInt(0);
-          shouldOverrideBuilder = false;
         } else {
           const {prepType, payloadId} = prepareRes;
           Object.assign(logMeta, {executionPayloadPrepType: prepType});
@@ -359,7 +357,6 @@ export async function produceBlockBody<T extends BlockType>(
             ssz.allForksExecution[fork].ExecutionPayload.defaultValue();
           blobsResult = {type: BlobsResultType.preDeneb};
           executionPayloadValue = BigInt(0);
-          shouldOverrideBuilder = false;
         } else {
           // since merge transition is complete, we need a valid payload even if with an
           // empty (transactions) one. defaultValue isn't gonna cut it!
@@ -370,7 +367,6 @@ export async function produceBlockBody<T extends BlockType>(
   } else {
     blobsResult = {type: BlobsResultType.preDeneb};
     executionPayloadValue = BigInt(0);
-    shouldOverrideBuilder = false;
   }
   endExecutionPayload?.({
     step: BlockProductionStep.executionPayload,

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -109,12 +109,20 @@ export async function produceBlockBody<T extends BlockType>(
     proposerIndex: ValidatorIndex;
     proposerPubKey: BLSPubkey;
   }
-): Promise<{body: AssembledBodyType<T>; blobs: BlobsResult; executionPayloadValue: Wei}> {
+): Promise<{
+  body: AssembledBodyType<T>;
+  blobs: BlobsResult;
+  executionPayloadValue: Wei;
+  shouldOverrideBuilder: boolean;
+}> {
   // Type-safe for blobs variable. Translate 'null' value into 'preDeneb' enum
   // TODO: Not ideal, but better than just using null.
   // TODO: Does not guarantee that preDeneb enum goes with a preDeneb block
   let blobsResult: BlobsResult;
   let executionPayloadValue: Wei;
+  // even though shouldOverrideBuilder is relevant for the engine response, for simplicity of typing
+  // we can also return is just as false for builder which will anyway be ignored by the caller
+  let shouldOverrideBuilder: boolean;
   const fork = currentState.config.getForkName(blockSlot);
 
   const logMeta: Record<string, string | number | bigint> = {
@@ -204,6 +212,7 @@ export async function produceBlockBody<T extends BlockType>(
 
     if (blockType === BlockType.Blinded) {
       if (!this.executionBuilder) throw Error("Execution Builder not available");
+      shouldOverrideBuilder = false;
 
       // This path will not be used in the production, but is here just for merge mock
       // tests because merge-mock requires an fcU to be issued prior to fetch payload
@@ -280,6 +289,7 @@ export async function produceBlockBody<T extends BlockType>(
             ssz.allForksExecution[fork].ExecutionPayload.defaultValue();
           blobsResult = {type: BlobsResultType.preDeneb};
           executionPayloadValue = BigInt(0);
+          shouldOverrideBuilder = false;
         } else {
           const {prepType, payloadId} = prepareRes;
           Object.assign(logMeta, {executionPayloadPrepType: prepType});
@@ -295,9 +305,11 @@ export async function produceBlockBody<T extends BlockType>(
 
           const engineRes = await this.executionEngine.getPayload(fork, payloadId);
           const {executionPayload, blobsBundle} = engineRes;
+          shouldOverrideBuilder = engineRes.shouldOverrideBuilder;
+
           (blockBody as allForks.ExecutionBlockBody).executionPayload = executionPayload;
           executionPayloadValue = engineRes.executionPayloadValue;
-          Object.assign(logMeta, {transactions: executionPayload.transactions.length});
+          Object.assign(logMeta, {transactions: executionPayload.transactions.length, shouldOverrideBuilder});
 
           const fetchedTime = Date.now() / 1000 - computeTimeAtSlot(this.config, blockSlot, this.genesisTime);
           this.metrics?.blockPayload.payloadFetchedTime.observe({prepType}, fetchedTime);
@@ -347,6 +359,7 @@ export async function produceBlockBody<T extends BlockType>(
             ssz.allForksExecution[fork].ExecutionPayload.defaultValue();
           blobsResult = {type: BlobsResultType.preDeneb};
           executionPayloadValue = BigInt(0);
+          shouldOverrideBuilder = false;
         } else {
           // since merge transition is complete, we need a valid payload even if with an
           // empty (transactions) one. defaultValue isn't gonna cut it!
@@ -357,6 +370,7 @@ export async function produceBlockBody<T extends BlockType>(
   } else {
     blobsResult = {type: BlobsResultType.preDeneb};
     executionPayloadValue = BigInt(0);
+    shouldOverrideBuilder = false;
   }
   endExecutionPayload?.({
     step: BlockProductionStep.executionPayload,
@@ -380,7 +394,7 @@ export async function produceBlockBody<T extends BlockType>(
   Object.assign(logMeta, {executionPayloadValue});
   this.logger.verbose("Produced beacon block body", logMeta);
 
-  return {body: blockBody as AssembledBodyType<T>, blobs: blobsResult, executionPayloadValue};
+  return {body: blockBody as AssembledBodyType<T>, blobs: blobsResult, executionPayloadValue, shouldOverrideBuilder};
 }
 
 /**

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -121,7 +121,7 @@ export async function produceBlockBody<T extends BlockType>(
   let blobsResult: BlobsResult;
   let executionPayloadValue: Wei;
   // even though shouldOverrideBuilder is relevant for the engine response, for simplicity of typing
-  // we just return it undefined for the builder which anyway doesn't gets consumed downstream
+  // we just return it undefined for the builder which anyway doesn't get consumed downstream
   let shouldOverrideBuilder: boolean | undefined;
   const fork = currentState.config.getForkName(blockSlot);
 

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -121,7 +121,7 @@ export async function produceBlockBody<T extends BlockType>(
   let blobsResult: BlobsResult;
   let executionPayloadValue: Wei;
   // even though shouldOverrideBuilder is relevant for the engine response, for simplicity of typing
-  // we can also return is just as false for builder which will anyway be ignored by the caller
+  // we just return it undefined for the builder which anyway doesn't gets consumed downstream
   let shouldOverrideBuilder: boolean | undefined;
   const fork = currentState.config.getForkName(blockSlot);
 

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -363,7 +363,12 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   async getPayload(
     fork: ForkName,
     payloadId: PayloadId
-  ): Promise<{executionPayload: allForks.ExecutionPayload; executionPayloadValue: Wei; blobsBundle?: BlobsBundle}> {
+  ): Promise<{
+    executionPayload: allForks.ExecutionPayload;
+    executionPayloadValue: Wei;
+    blobsBundle?: BlobsBundle;
+    shouldOverrideBuilder: boolean;
+  }> {
     const method =
       ForkSeq[fork] >= ForkSeq.deneb
         ? "engine_getPayloadV3"

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -367,7 +367,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     executionPayload: allForks.ExecutionPayload;
     executionPayloadValue: Wei;
     blobsBundle?: BlobsBundle;
-    shouldOverrideBuilder: boolean;
+    shouldOverrideBuilder?: boolean;
   }> {
     const method =
       ForkSeq[fork] >= ForkSeq.deneb

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -140,7 +140,7 @@ export interface IExecutionEngine {
     executionPayload: allForks.ExecutionPayload;
     executionPayloadValue: Wei;
     blobsBundle?: BlobsBundle;
-    shouldOverrideBuilder: boolean;
+    shouldOverrideBuilder?: boolean;
   }>;
 
   getPayloadBodiesByHash(blockHash: DATA[]): Promise<(ExecutionPayloadBody | null)[]>;

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -136,7 +136,12 @@ export interface IExecutionEngine {
   getPayload(
     fork: ForkName,
     payloadId: PayloadId
-  ): Promise<{executionPayload: allForks.ExecutionPayload; executionPayloadValue: Wei; blobsBundle?: BlobsBundle}>;
+  ): Promise<{
+    executionPayload: allForks.ExecutionPayload;
+    executionPayloadValue: Wei;
+    blobsBundle?: BlobsBundle;
+    shouldOverrideBuilder: boolean;
+  }>;
 
   getPayloadBodiesByHash(blockHash: DATA[]): Promise<(ExecutionPayloadBody | null)[]>;
 

--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -212,7 +212,7 @@ export function parseExecutionPayload(
   executionPayload: allForks.ExecutionPayload;
   executionPayloadValue: Wei;
   blobsBundle?: BlobsBundle;
-  shouldOverrideBuilder: boolean;
+  shouldOverrideBuilder?: boolean;
 } {
   let data: ExecutionPayloadRpc;
   let executionPayloadValue: Wei;

--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -107,6 +107,7 @@ type ExecutionPayloadRpcWithValue = {
   // even though CL tracks this as executionPayloadValue, EL returns this as blockValue
   blockValue: QUANTITY;
   blobsBundle?: BlobsBundleRpc;
+  shouldOverrideBuilder?: boolean;
 };
 type ExecutionPayloadResponse = ExecutionPayloadRpc | ExecutionPayloadRpcWithValue;
 
@@ -207,19 +208,28 @@ export function hasPayloadValue(response: ExecutionPayloadResponse): response is
 export function parseExecutionPayload(
   fork: ForkName,
   response: ExecutionPayloadResponse
-): {executionPayload: allForks.ExecutionPayload; executionPayloadValue: Wei; blobsBundle?: BlobsBundle} {
+): {
+  executionPayload: allForks.ExecutionPayload;
+  executionPayloadValue: Wei;
+  blobsBundle?: BlobsBundle;
+  shouldOverrideBuilder: boolean;
+} {
   let data: ExecutionPayloadRpc;
   let executionPayloadValue: Wei;
   let blobsBundle: BlobsBundle | undefined;
+  let shouldOverrideBuilder: boolean;
+
   if (hasPayloadValue(response)) {
     executionPayloadValue = quantityToBigint(response.blockValue);
     data = response.executionPayload;
     blobsBundle = response.blobsBundle ? parseBlobsBundle(response.blobsBundle) : undefined;
+    shouldOverrideBuilder = response.shouldOverrideBuilder ?? false;
   } else {
     data = response;
     // Just set it to zero as default
     executionPayloadValue = BigInt(0);
     blobsBundle = undefined;
+    shouldOverrideBuilder = false;
   }
 
   const executionPayload = {
@@ -269,7 +279,7 @@ export function parseExecutionPayload(
     (executionPayload as deneb.ExecutionPayload).excessBlobGas = quantityToBigint(excessBlobGas);
   }
 
-  return {executionPayload, executionPayloadValue, blobsBundle};
+  return {executionPayload, executionPayloadValue, blobsBundle, shouldOverrideBuilder};
 }
 
 export function serializePayloadAttributes(data: PayloadAttributes): PayloadAttributesRpc {

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV2.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV2.test.ts
@@ -89,7 +89,6 @@ describe("api/validator - produceBlockV2", function () {
       block: fullBlock,
       executionPayloadValue,
       consensusBlockValue,
-      shouldOverrideBuilder: false,
     });
 
     // check if expectedFeeRecipient is passed to produceBlock
@@ -134,7 +133,6 @@ describe("api/validator - produceBlockV2", function () {
     executionEngineStub.getPayload.mockResolvedValue({
       executionPayload: ssz.bellatrix.ExecutionPayload.defaultValue(),
       executionPayloadValue,
-      shouldOverrideBuilder: false,
     });
 
     // use fee recipient passed in produceBlockBody call for payload gen in engine notifyForkchoiceUpdate

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV2.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV2.test.ts
@@ -85,7 +85,12 @@ describe("api/validator - produceBlockV2", function () {
     const feeRecipient = "0xcccccccccccccccccccccccccccccccccccccccc";
 
     const api = getValidatorApi(modules);
-    server.chainStub.produceBlock.mockResolvedValue({block: fullBlock, executionPayloadValue, consensusBlockValue});
+    server.chainStub.produceBlock.mockResolvedValue({
+      block: fullBlock,
+      executionPayloadValue,
+      consensusBlockValue,
+      shouldOverrideBuilder: false,
+    });
 
     // check if expectedFeeRecipient is passed to produceBlock
     await api.produceBlockV2(slot, randaoReveal, graffiti, {feeRecipient});
@@ -129,6 +134,7 @@ describe("api/validator - produceBlockV2", function () {
     executionEngineStub.getPayload.mockResolvedValue({
       executionPayload: ssz.bellatrix.ExecutionPayload.defaultValue(),
       executionPayloadValue,
+      shouldOverrideBuilder: false,
     });
 
     // use fee recipient passed in produceBlockBody call for payload gen in engine notifyForkchoiceUpdate

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -41,23 +41,38 @@ describe("api/validator - produceBlockV3", function () {
     vi.clearAllMocks();
   });
 
-  const testCases: [routes.validator.BuilderSelection, number | null, number | null, number, string][] = [
-    [routes.validator.BuilderSelection.MaxProfit, 1, 0, 0, "builder"],
-    [routes.validator.BuilderSelection.MaxProfit, 1, 2, 1, "engine"],
-    [routes.validator.BuilderSelection.MaxProfit, null, 0, 0, "engine"],
-    [routes.validator.BuilderSelection.MaxProfit, 0, null, 1, "builder"],
+  const testCases: [routes.validator.BuilderSelection, number | null, number | null, number, boolean, string][] = [
+    [routes.validator.BuilderSelection.MaxProfit, 1, 0, 0, false, "builder"],
+    [routes.validator.BuilderSelection.MaxProfit, 1, 2, 1, false, "engine"],
+    [routes.validator.BuilderSelection.MaxProfit, null, 0, 0, false, "engine"],
+    [routes.validator.BuilderSelection.MaxProfit, 0, null, 1, false, "builder"],
+    [routes.validator.BuilderSelection.MaxProfit, 0, null, 1, true, "builder"],
+    [routes.validator.BuilderSelection.MaxProfit, 1, 1, 1, true, "engine"],
+    [routes.validator.BuilderSelection.MaxProfit, 2, 1, 1, true, "engine"],
 
-    [routes.validator.BuilderSelection.BuilderAlways, 1, 2, 0, "builder"],
-    [routes.validator.BuilderSelection.BuilderAlways, 1, 0, 1, "builder"],
-    [routes.validator.BuilderSelection.BuilderAlways, null, 0, 0, "engine"],
-    [routes.validator.BuilderSelection.BuilderAlways, 0, null, 1, "builder"],
+    [routes.validator.BuilderSelection.BuilderAlways, 1, 2, 0, false, "builder"],
+    [routes.validator.BuilderSelection.BuilderAlways, 1, 0, 1, false, "builder"],
+    [routes.validator.BuilderSelection.BuilderAlways, null, 0, 0, false, "engine"],
+    [routes.validator.BuilderSelection.BuilderAlways, 0, null, 1, false, "builder"],
+    [routes.validator.BuilderSelection.BuilderAlways, 0, 1, 1, true, "engine"],
+    [routes.validator.BuilderSelection.BuilderAlways, 1, 1, 1, true, "engine"],
+    [routes.validator.BuilderSelection.BuilderAlways, 1, null, 1, true, "builder"],
 
-    [routes.validator.BuilderSelection.BuilderOnly, 0, 2, 0, "builder"],
-    [routes.validator.BuilderSelection.ExecutionOnly, 2, 0, 1, "execution"],
+    [routes.validator.BuilderSelection.BuilderOnly, 0, 2, 0, false, "builder"],
+    [routes.validator.BuilderSelection.ExecutionOnly, 2, 0, 1, false, "engine"],
+    [routes.validator.BuilderSelection.BuilderOnly, 1, 1, 0, true, "builder"],
+    [routes.validator.BuilderSelection.ExecutionOnly, 1, 1, 1, true, "engine"],
   ];
 
   testCases.forEach(
-    ([builderSelection, builderPayloadValue, enginePayloadValue, consensusBlockValue, finalSelection]) => {
+    ([
+      builderSelection,
+      builderPayloadValue,
+      enginePayloadValue,
+      consensusBlockValue,
+      shouldOverrideBuilder,
+      finalSelection,
+    ]) => {
       it(`produceBlockV3  - ${finalSelection} produces block`, async () => {
         syncStub = server.syncStub;
         modules = {
@@ -89,7 +104,7 @@ describe("api/validator - produceBlockV3", function () {
             block: fullBlock,
             executionPayloadValue: BigInt(enginePayloadValue),
             consensusBlockValue: BigInt(consensusBlockValue),
-            shouldOverrideBuilder: false,
+            shouldOverrideBuilder,
           });
         } else {
           chainStub.produceBlock.mockRejectedValue(Error("not produced"));
@@ -100,7 +115,6 @@ describe("api/validator - produceBlockV3", function () {
             block: blindedBlock,
             executionPayloadValue: BigInt(builderPayloadValue),
             consensusBlockValue: BigInt(consensusBlockValue),
-            shouldOverrideBuilder: false,
           });
         } else {
           chainStub.produceBlindedBlock.mockRejectedValue(Error("not produced"));

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -89,6 +89,7 @@ describe("api/validator - produceBlockV3", function () {
             block: fullBlock,
             executionPayloadValue: BigInt(enginePayloadValue),
             consensusBlockValue: BigInt(consensusBlockValue),
+            shouldOverrideBuilder: false,
           });
         } else {
           chainStub.produceBlock.mockRejectedValue(Error("not produced"));
@@ -99,6 +100,7 @@ describe("api/validator - produceBlockV3", function () {
             block: blindedBlock,
             executionPayloadValue: BigInt(builderPayloadValue),
             consensusBlockValue: BigInt(consensusBlockValue),
+            shouldOverrideBuilder: false,
           });
         } else {
           chainStub.produceBlindedBlock.mockRejectedValue(Error("not produced"));


### PR DESCRIPTION
a mechanism was added where local engine could indicate censorship happening by builders via `shouldOverrideBuilder`
which should make beacon produce engine blocks only irrespective of the builder boost (or to be deprecated builder selection) indicated by the validator.
 
 - https://github.com/ethereum/execution-apis/pull/425


This PR handles and implements the same.