### PR TITLE
feat: auto use produceBlockV3 deneb+ unless specified

### DIFF
--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -257,7 +257,7 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
 
   useProduceBlockV3: {
     type: "boolean",
-    description: "Enable/disable usage of produceBlockV3 that might not be supported by all beacon clients yet",
+    description: "Enable/disable usage of produceBlockV3 pre deneb that might not be supported by all beacon clients yet",
     defaultDescription: `${defaultOptions.useProduceBlockV3}`,
   },
 

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -257,7 +257,8 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
 
   useProduceBlockV3: {
     type: "boolean",
-    description: "Enable/disable usage of produceBlockV3 pre deneb that might not be supported by all beacon clients yet",
+    description:
+      "Enable/disable usage of produceBlockV3 pre deneb that might not be supported by all beacon clients yet",
     defaultDescription: `${defaultOptions.useProduceBlockV3}`,
   },
 

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -257,9 +257,7 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
 
   useProduceBlockV3: {
     type: "boolean",
-    description:
-      "Enable/disable usage of produceBlockV3 pre deneb that might not be supported by all beacon clients yet",
-    defaultDescription: `${defaultOptions.useProduceBlockV3}`,
+    description: "Enable/disable usage of produceBlockV3 for block production, is auto enabled on deneb+ blocks",
   },
 
   broadcastValidation: {

--- a/packages/cli/test/utils/simulation/validator_clients/lodestar.ts
+++ b/packages/cli/test/utils/simulation/validator_clients/lodestar.ts
@@ -39,7 +39,7 @@ export const generateLodestarValidatorNode: ValidatorNodeGenerator<ValidatorClie
     logFile: "none",
     importKeystores: keystoresDir,
     importKeystoresPassword: keystoresSecretFilePath,
-    useProduceBlockV3: useProduceBlockV3 ?? defaultOptions.useProduceBlockV3,
+    useProduceBlockV3: useProduceBlockV3 ?? false,
     "builder.selection": builderSelection ?? defaultOptions.builderSelection,
     blindedLocal: blindedLocal ?? defaultOptions.blindedLocal,
   } as unknown as IValidatorCliArgs & GlobalArgs;

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -125,6 +125,7 @@ export class BlockProposingService {
         this.validatorStore.getBuilderSelectionParams(pubkeyHex);
       const feeRecipient = this.validatorStore.getFeeRecipient(pubkeyHex);
       const blindedLocal = this.opts.blindedLocal;
+      const useProduceBlockV3 = this.config.getForkSeq(slot) >= ForkSeq.deneb || this.opts.useProduceBlockV3;
 
       this.logger.debug("Producing block", {
         ...debugLogCtx,
@@ -132,12 +133,12 @@ export class BlockProposingService {
         builderBoostFactor,
         feeRecipient,
         strictFeeRecipientCheck,
-        useProduceBlockV3: this.opts.useProduceBlockV3,
+        useProduceBlockV3,
         blindedLocal,
       });
       this.metrics?.proposerStepCallProduceBlock.observe(this.clock.secFromSlot(slot));
 
-      const produceBlockFn = this.opts.useProduceBlockV3 ? this.produceBlockWrapper : this.produceBlockV2Wrapper;
+      const produceBlockFn = useProduceBlockV3 ? this.produceBlockWrapper : this.produceBlockV2Wrapper;
       const produceOpts = {
         feeRecipient,
         strictFeeRecipientCheck,

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -55,7 +55,7 @@ type FullOrBlindedBlockWithContents =
 
 type DebugLogCtx = {debugLogCtx: Record<string, string | boolean | undefined>};
 type BlockProposalOpts = {
-  useProduceBlockV3: boolean;
+  useProduceBlockV3?: boolean;
   broadcastValidation: routes.beacon.BroadcastValidation;
   blindedLocal: boolean;
 };
@@ -125,7 +125,7 @@ export class BlockProposingService {
         this.validatorStore.getBuilderSelectionParams(pubkeyHex);
       const feeRecipient = this.validatorStore.getFeeRecipient(pubkeyHex);
       const blindedLocal = this.opts.blindedLocal;
-      const useProduceBlockV3 = this.config.getForkSeq(slot) >= ForkSeq.deneb || this.opts.useProduceBlockV3;
+      const useProduceBlockV3 = this.opts.useProduceBlockV3 ?? this.config.getForkSeq(slot) >= ForkSeq.deneb;
 
       this.logger.debug("Producing block", {
         ...debugLogCtx,

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -126,8 +126,6 @@ export const defaultOptions = {
   builderSelection: routes.validator.BuilderSelection.ExecutionOnly,
   builderAliasSelection: routes.validator.BuilderSelection.MaxProfit,
   builderBoostFactor: BigInt(100),
-  // turn it off by default, turn it back on once other clients support v3 api
-  useProduceBlockV3: false,
   // spec asks for gossip validation by default
   broadcastValidation: routes.beacon.BroadcastValidation.gossip,
   // should request fetching the locally produced block in blinded format

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -209,7 +209,7 @@ export class Validator {
     const chainHeaderTracker = new ChainHeaderTracker(logger, api, emitter);
 
     const blockProposingService = new BlockProposingService(config, loggerVc, api, clock, validatorStore, metrics, {
-      useProduceBlockV3: opts.useProduceBlockV3 ?? defaultOptions.useProduceBlockV3,
+      useProduceBlockV3: opts.useProduceBlockV3,
       broadcastValidation: opts.broadcastValidation ?? defaultOptions.broadcastValidation,
       blindedLocal: opts.blindedLocal ?? defaultOptions.blindedLocal,
     });
@@ -289,18 +289,15 @@ export class Validator {
     await assertEqualGenesis(opts, genesis);
     logger.info("Verified connected beacon node and validator have the same genesisValidatorRoot");
 
-    const {
-      useProduceBlockV3 = defaultOptions.useProduceBlockV3,
-      broadcastValidation = defaultOptions.broadcastValidation,
-      valProposerConfig,
-    } = opts;
+    const {useProduceBlockV3, broadcastValidation = defaultOptions.broadcastValidation, valProposerConfig} = opts;
     const defaultBuilderSelection =
       valProposerConfig?.defaultConfig.builder?.selection ?? defaultOptions.builderSelection;
     const strictFeeRecipientCheck = valProposerConfig?.defaultConfig.strictFeeRecipientCheck ?? false;
     const suggestedFeeRecipient = valProposerConfig?.defaultConfig.feeRecipient ?? defaultOptions.suggestedFeeRecipient;
 
     logger.info("Initializing validator", {
-      useProduceBlockV3,
+      // if no explicit option is provided, useProduceBlockV3 will be auto enabled on/post deneb
+      useProduceBlockV3: useProduceBlockV3 === undefined ? "deneb+" : useProduceBlockV3,
       broadcastValidation,
       defaultBuilderSelection,
       suggestedFeeRecipient,


### PR DESCRIPTION
produceblockv3 is what is supposed to be used post deneb desipe our prodduceblockv2 and priduceblindedblockv2 being forward compatible with the deneb . this PR puts the deneb proposals on produceblockb3