### PR TITLE
fix: use bigint to calculate max builder boost factor

### DIFF
--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -134,7 +134,7 @@ export const defaultOptions = {
   blindedLocal: false,
 };
 
-export const MAX_BUILDER_BOOST_FACTOR = BigInt(2 ** 64 - 1);
+export const MAX_BUILDER_BOOST_FACTOR = 2n ** 64n - 1n;
 
 /**
  * Service that sets up and handles validator attester duties.


### PR DESCRIPTION
**Motivation**

Current value of `MAX_BUILDER_BOOST_FACTOR` is off by one due to usage of number instead of bigint in the calculation.

```node
> BigInt(2 ** 64 - 1)
18446744073709551616n
```
vs.
```node
> 2n ** 64n - 1n
18446744073709551615n
```

The correct value should be `18446744073709551615` (2**64 - 1)

**Description**

Use bigint to calculate max builder boost factor