### PR TITLE
fix: parse --builder.boostFactor value as bigint instead of number

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -227,7 +227,7 @@ function getProposerConfigFromArgs(
       selection: parseBuilderSelection(
         args["builder.selection"] ?? (args["builder"] ? defaultOptions.builderAliasSelection : undefined)
       ),
-      boostFactor: args["builder.boostFactor"],
+      boostFactor: args["builder.boostFactor"] !== undefined ? BigInt(args["builder.boostFactor"]) : undefined,
     },
   };
 

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -248,7 +248,7 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
   },
 
   "builder.boostFactor": {
-    type: "number",
+    type: "string",
     description:
       "Percentage multiplier the block producing beacon node must apply to boost (>100) or dampen (<100) builder block value for selection against execution block. The multiplier is ignored if `--builder.selection` is set to anything other than `maxprofit`",
     defaultDescription: `${defaultOptions.builderBoostFactor}`,


### PR DESCRIPTION
**Motivation**

Noticed another issue related to https://github.com/ChainSafe/lodestar/pull/6275, we parse the value of `--builder.boostFactor` as a number instead of bigint. We have to use string and parse it separately for the same reason as we do in on API level as otherwise we lose precision on the value.

**Description**

Parse `--builder.boostFactor` value as bigint instead of number.