### PR TITLE
fix: update voluntary exit block inclusion filter

### DIFF
--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -409,10 +409,10 @@ export class OpPool {
 function isVoluntaryExitSignatureIncludable(stateFork: ForkSeq, voluntaryExitFork: ForkSeq): boolean {
   if (stateFork >= ForkSeq.deneb) {
     // Exists are perpetually valid https://eips.ethereum.org/EIPS/eip-7044
-    return true
+    return true;
   } else {
     // Can only include exits from the current and previous fork
-    return voluntaryExitFork === stateFork || voluntaryExitFork === (stateFork - 1)
+    return voluntaryExitFork === stateFork || voluntaryExitFork === stateFork - 1;
   }
 }
 


### PR DESCRIPTION
**Motivation**

The logic to decide when to include exists currently is:

```ts
function isVoluntaryExitSignatureIncludable(stateFork: ForkSeq, voluntaryExitFork: ForkSeq): boolean {
  return stateFork === voluntaryExitFork
}
```

this is not correct:

### Voluntary exists before deneb

Due to how get domain is calculated a voluntary exit signed at a future epoch at fork version N can only be included in a state where fork version N is stored in the `previous_version` or `current_version`. Else the signature verification will fail. So a block producer can include exists with valid signatures (with full knowledge of all fork versions) in a block at the same of next fork as the voluntary_exit.epoch

```python
def process_voluntary_exit(state: BeaconState, signed_voluntary_exit: SignedVoluntaryExit) -> None:
    ...
    domain = get_domain(state, DOMAIN_VOLUNTARY_EXIT, voluntary_exit.epoch)
    signing_root = compute_signing_root(voluntary_exit, domain)
    assert bls.Verify(validator.pubkey, signing_root, signed_voluntary_exit.signature)
    ...

def get_domain(state: BeaconState, domain_type: DomainType, epoch: Epoch=None) -> Domain:
    epoch = get_current_epoch(state) if epoch is None else epoch
    fork_version = state.fork.previous_version if epoch < state.fork.epoch else state.fork.current_version
    return compute_domain(domain_type, fork_version, state.genesis_validators_root)
```

https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#voluntary-exits

### Voluntary exists post deneb

With EIP-7044: Perpetually Valid Signed Voluntary Exits https://eips.ethereum.org/EIPS/eip-7044 exists will be valid for all future forks

**Description**

Fix inclusion rules to match the description above:

```ts
function isVoluntaryExitSignatureIncludable(stateFork: ForkSeq, voluntaryExitFork: ForkSeq): boolean {
  if (stateFork >= ForkSeq.deneb) {
    // Exists are perpetually valid https://eips.ethereum.org/EIPS/eip-7044
    return true
  } else {
    // Can only include exits from the current and previous fork
    return voluntaryExitFork === stateFork || voluntaryExitFork === (stateFork - 1)
  }
}
```

Closes https://github.com/ChainSafe/lodestar/issues/6276

^ I have not tested this PR actually allows hive tests to pass
