### PR TITLE
chore: update url of goerli bootnodes file and genesis ssz

### DIFF
--- a/packages/cli/src/networks/goerli.ts
+++ b/packages/cli/src/networks/goerli.ts
@@ -1,10 +1,8 @@
 export {goerliChainConfig as chainConfig} from "@lodestar/config/networks";
 
 export const depositContractDeployBlock = 4367322;
-export const genesisFileUrl =
-  "https://raw.githubusercontent.com/eth-clients/eth2-networks/master/shared/prater/genesis.ssz";
-export const bootnodesFileUrl =
-  "https://raw.githubusercontent.com/eth-clients/eth2-networks/master/shared/prater/bootstrap_nodes.txt";
+export const genesisFileUrl = "https://raw.githubusercontent.com/eth-clients/goerli/main/prater/genesis.ssz";
+export const bootnodesFileUrl = "https://raw.githubusercontent.com/eth-clients/goerli/main/prater/bootstrap_nodes.txt";
 
 export const bootEnrs = [
   "enr:-LK4QH1xnjotgXwg25IDPjrqRGFnH1ScgNHA3dv1Z8xHCp4uP3N3Jjl_aYv_WIxQRdwZvSukzbwspXZ7JjpldyeVDzMCh2F0dG5ldHOIAAAAAAAAAACEZXRoMpB53wQoAAAQIP__________gmlkgnY0gmlwhIe1te-Jc2VjcDI1NmsxoQOkcGXqbCJYbcClZ3z5f6NWhX_1YPFRYRRWQpJjwSHpVIN0Y3CCIyiDdWRwgiMo",


### PR DESCRIPTION
**Motivation**

Files have been removed from eth-clients/eth2-networks, see https://github.com/eth-clients/eth2-networks/pull/92

Running Lodestar with `--network goerli` flag causes the following error on startup
```
Error fetching latest bootnodes: HTTPError: Response code 404 (Not Found)
    at Request.<anonymous> (/home/nico/projects/ethereum/lodestar/node_modules/got/dist/source/as-promise/index.js:118:42)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

**Description**

Update url of goerli bootnodes file and genesis ssz
