### PR TITLE
ci: disable the node debug task

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,6 +160,9 @@ jobs:
           check-latest: true
           cache: yarn 
 
+      # # Remove when finished debugging core dumps
+      # - uses: './.github/actions/setup-debug-node'
+
       - name: Restore build cache
         id: cache-primes-restore
         uses: actions/cache/restore@v3
@@ -181,8 +184,15 @@ jobs:
           key: spec-test-data-${{ hashFiles('packages/validator/test/spec/params.ts') }}
 
       - name: Unit tests
+        # id: unit_tests
+        # Rever to "yarn test:unit" when finished debugging core dumps
+        # run: sudo sh -c "ulimit -c unlimited && /usr/bin/node-with-debug $(which yarn) test:unit"
         run: yarn test:unit
       
+      # # Remove when finished debugging core dumps
+      # - uses: './.github/actions/core-dump'
+      #   if: ${{ failure() && steps.unit_tests.conclusion == 'failure' }}
+
       - name: Upload coverage data
         run: yarn coverage
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,9 +160,6 @@ jobs:
           check-latest: true
           cache: yarn 
 
-      # Remove when finished debugging core dumps
-      - uses: './.github/actions/setup-debug-node'
-
       - name: Restore build cache
         id: cache-primes-restore
         uses: actions/cache/restore@v3
@@ -184,14 +181,8 @@ jobs:
           key: spec-test-data-${{ hashFiles('packages/validator/test/spec/params.ts') }}
 
       - name: Unit tests
-        id: unit_tests
-        # Rever to "yarn test:unit" when finished debugging core dumps
-        run: sudo sh -c "ulimit -c unlimited && /usr/bin/node-with-debug $(which yarn) test:unit"
+        run: yarn test:unit
       
-      # Remove when finished debugging core dumps
-      - uses: './.github/actions/core-dump'
-        if: ${{ failure() && steps.unit_tests.conclusion == 'failure' }}
-
       - name: Upload coverage data
         run: yarn coverage
 


### PR DESCRIPTION
**Motivation**

Make the CI stable. 

**Description**

Debug Node task  is failing to download the debug build. Until we figure it out comment these tasks. 


```
unzip is already the newest version (6.0-26ubuntu3.1).
0 upgraded, 0 newly installed, 0 to remove and 27 not upgraded.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  [24](https://github.com/ChainSafe/lodestar/actions/runs/7486950382/job/20378582480?pr=6270#step:4:26)41  100  2441    0     0   4[28](https://github.com/ChainSafe/lodestar/actions/runs/7486950382/job/20378582480?pr=6270#step:4:30)0      0 --:--:-- --:--:-- --:--:-- 13948
  End-of-central-directory signature not found.  Either this file is not
Archive:  nodejs.zip
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of nodejs.zip or
        nodejs.zip.zip, and cannot find nodejs.zip.ZIP, period.
```

**Steps to test or reproduce**

- Run all tests. 