### PR TITLE
fix: block value in `produceBlockV3` should be in wei

### DIFF
--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -19,7 +19,6 @@ import {
   StringType,
   SubcommitteeIndex,
   Wei,
-  Gwei,
   ProducedBlockSource,
 } from "@lodestar/types";
 import {ApiClientResponse} from "../../interfaces.js";
@@ -59,11 +58,11 @@ export type ExtraProduceBlockOps = {
   blindedLocal?: boolean;
 };
 
-export type ProduceBlockOrContentsRes = {executionPayloadValue: Wei; consensusBlockValue: Gwei} & (
+export type ProduceBlockOrContentsRes = {executionPayloadValue: Wei; consensusBlockValue: Wei} & (
   | {data: allForks.BeaconBlock; version: ForkPreBlobs}
   | {data: allForks.BlockContents; version: ForkBlobs}
 );
-export type ProduceBlindedBlockRes = {executionPayloadValue: Wei; consensusBlockValue: Gwei} & {
+export type ProduceBlindedBlockRes = {executionPayloadValue: Wei; consensusBlockValue: Wei} & {
   data: allForks.BlindedBeaconBlock;
   version: ForkExecution;
 };

--- a/packages/api/src/utils/types.ts
+++ b/packages/api/src/utils/types.ts
@@ -179,7 +179,7 @@ export function WithExecutionOptimistic<T extends {data: unknown}>(
 }
 
 /**
- * SSZ factory helper to wrap an existing type with `{executionPayloadValue: Wei, consensusBlockValue: GWei}`
+ * SSZ factory helper to wrap an existing type with `{executionPayloadValue: Wei, consensusBlockValue: Wei}`
  */
 export function WithBlockValues<T extends {data: unknown}>(
   type: TypeJson<T>

--- a/packages/api/test/unit/beacon/testData/validator.ts
+++ b/packages/api/test/unit/beacon/testData/validator.ts
@@ -78,7 +78,7 @@ export const testData: GenericServerTestCases<Api> = {
       data: ssz.altair.BeaconBlock.defaultValue(),
       version: ForkName.altair,
       executionPayloadValue: ssz.Wei.defaultValue(),
-      consensusBlockValue: ssz.Gwei.defaultValue(),
+      consensusBlockValue: ssz.Wei.defaultValue(),
     },
   },
   produceBlockV3: {
@@ -99,7 +99,7 @@ export const testData: GenericServerTestCases<Api> = {
       data: ssz.altair.BeaconBlock.defaultValue(),
       version: ForkName.altair,
       executionPayloadValue: ssz.Wei.defaultValue(),
-      consensusBlockValue: ssz.Gwei.defaultValue(),
+      consensusBlockValue: ssz.Wei.defaultValue(),
       executionPayloadBlinded: false,
       executionPayloadSource: ProducedBlockSource.engine,
     },
@@ -122,7 +122,7 @@ export const testData: GenericServerTestCases<Api> = {
       data: ssz.bellatrix.BlindedBeaconBlock.defaultValue(),
       version: ForkName.bellatrix,
       executionPayloadValue: ssz.Wei.defaultValue(),
-      consensusBlockValue: ssz.Gwei.defaultValue(),
+      consensusBlockValue: ssz.Wei.defaultValue(),
     },
   },
   produceAttestationData: {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -35,7 +35,7 @@ import {
   phase0,
 } from "@lodestar/types";
 import {ExecutionStatus} from "@lodestar/fork-choice";
-import {toHex, racePromisesWithCutoff, RaceEvent, gweiToWei} from "@lodestar/utils";
+import {toHex, racePromisesWithCutoff, RaceEvent} from "@lodestar/utils";
 import {AttestationError, AttestationErrorCode, GossipAction, SyncCommitteeError} from "../../../chain/errors/index.js";
 import {validateApiAggregateAndProof} from "../../../chain/validation/index.js";
 import {ZERO_HASH} from "../../../constants/index.js";
@@ -552,8 +552,8 @@ export function getValidatorApi({
       const consensusBlockValueBuilder = blindedBlock?.consensusBlockValue ?? BigInt(0);
       const consensusBlockValueEngine = fullBlock?.consensusBlockValue ?? BigInt(0);
 
-      const blockValueBuilder = builderPayloadValue + gweiToWei(consensusBlockValueBuilder); // Total block value is in wei
-      const blockValueEngine = enginePayloadValue + gweiToWei(consensusBlockValueEngine); // Total block value is in wei
+      const blockValueBuilder = builderPayloadValue + consensusBlockValueBuilder; // Total block value is in wei
+      const blockValueEngine = enginePayloadValue + consensusBlockValueEngine; // Total block value is in wei
 
       let executionPayloadSource: ProducedBlockSource | null = null;
       const shouldOverrideBuilder = fullBlock?.shouldOverrideBuilder ?? false;

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -27,11 +27,10 @@ import {
   Wei,
   bellatrix,
   isBlindedBeaconBlock,
-  Gwei,
 } from "@lodestar/types";
 import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {ProcessShutdownCallback} from "@lodestar/validator";
-import {Logger, isErrorAborted, pruneSetToMax, sleep, toHex} from "@lodestar/utils";
+import {Logger, gweiToWei, isErrorAborted, pruneSetToMax, sleep, toHex} from "@lodestar/utils";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants/index.js";
@@ -473,7 +472,7 @@ export class BeaconChain implements IBeaconChain {
   produceBlock(blockAttributes: BlockAttributes): Promise<{
     block: allForks.BeaconBlock;
     executionPayloadValue: Wei;
-    consensusBlockValue: Gwei;
+    consensusBlockValue: Wei;
     shouldOverrideBuilder?: boolean;
   }> {
     return this.produceBlockWrapper<BlockType.Full>(BlockType.Full, blockAttributes);
@@ -482,7 +481,7 @@ export class BeaconChain implements IBeaconChain {
   produceBlindedBlock(blockAttributes: BlockAttributes): Promise<{
     block: allForks.BlindedBeaconBlock;
     executionPayloadValue: Wei;
-    consensusBlockValue: Gwei;
+    consensusBlockValue: Wei;
   }> {
     return this.produceBlockWrapper<BlockType.Blinded>(BlockType.Blinded, blockAttributes);
   }
@@ -493,7 +492,7 @@ export class BeaconChain implements IBeaconChain {
   ): Promise<{
     block: AssembledBlockType<T>;
     executionPayloadValue: Wei;
-    consensusBlockValue: Gwei;
+    consensusBlockValue: Wei;
     shouldOverrideBuilder?: boolean;
   }> {
     const head = this.forkChoice.getHead();
@@ -572,7 +571,7 @@ export class BeaconChain implements IBeaconChain {
       this.metrics?.blockProductionCaches.producedContentsCache.set(this.producedContentsCache.size);
     }
 
-    return {block, executionPayloadValue, consensusBlockValue: proposerReward, shouldOverrideBuilder};
+    return {block, executionPayloadValue, consensusBlockValue: gweiToWei(proposerReward), shouldOverrideBuilder};
   }
 
   /**

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -1,17 +1,5 @@
 import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
-import {
-  allForks,
-  UintNum64,
-  Root,
-  phase0,
-  Slot,
-  RootHex,
-  Epoch,
-  ValidatorIndex,
-  deneb,
-  Wei,
-  Gwei,
-} from "@lodestar/types";
+import {allForks, UintNum64, Root, phase0, Slot, RootHex, Epoch, ValidatorIndex, deneb, Wei} from "@lodestar/types";
 import {
   BeaconStateAllForks,
   CachedBeaconStateAllForks,
@@ -157,13 +145,13 @@ export interface IBeaconChain {
   produceBlock(blockAttributes: BlockAttributes): Promise<{
     block: allForks.BeaconBlock;
     executionPayloadValue: Wei;
-    consensusBlockValue: Gwei;
+    consensusBlockValue: Wei;
     shouldOverrideBuilder?: boolean;
   }>;
   produceBlindedBlock(blockAttributes: BlockAttributes): Promise<{
     block: allForks.BlindedBeaconBlock;
     executionPayloadValue: Wei;
-    consensusBlockValue: Gwei;
+    consensusBlockValue: Wei;
   }>;
 
   /** Process a block until complete */

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV2.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV2.test.ts
@@ -72,7 +72,7 @@ describe("api/validator - produceBlockV2", function () {
 
     const fullBlock = ssz.bellatrix.BeaconBlock.defaultValue();
     const executionPayloadValue = ssz.Wei.defaultValue();
-    const consensusBlockValue = ssz.Gwei.defaultValue();
+    const consensusBlockValue = ssz.Wei.defaultValue();
 
     const currentSlot = 100000;
     vi.spyOn(server.chainStub.clock, "currentSlot", "get").mockReturnValue(currentSlot);

--- a/packages/state-transition/src/cache/rewardCache.ts
+++ b/packages/state-transition/src/cache/rewardCache.ts
@@ -2,6 +2,7 @@
  * A simple data structure to store rewards payable to block proposer in the memory.
  * Rewards are updated throughout the state transition
  * Should only hold info for one state transition
+ * All values are in Gwei
  */
 export type RewardCache = {
   attestations: number;

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -11,7 +11,7 @@ import {
 } from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPreBlobs, ForkBlobs, ForkSeq, ForkExecution} from "@lodestar/params";
-import {ETH_TO_GWEI, ETH_TO_WEI, extendError, gweiToWei, prettyBytes} from "@lodestar/utils";
+import {ETH_TO_WEI, extendError, gweiToWei, prettyBytes} from "@lodestar/utils";
 import {Api, ApiError, routes} from "@lodestar/api";
 import {IClock, LoggerVc} from "../util/index.js";
 import {PubkeyHex} from "../types.js";
@@ -220,7 +220,7 @@ export class BlockProposingService {
       executionPayloadBlinded: response.executionPayloadBlinded,
       // winston logger doesn't like bigint
       executionPayloadValue: `${formatBigDecimal(response.executionPayloadValue, ETH_TO_WEI, MAX_DECIMAL_FACTOR)} ETH`,
-      consensusBlockValue: `${formatBigDecimal(response.consensusBlockValue, ETH_TO_GWEI, MAX_DECIMAL_FACTOR)} ETH`,
+      consensusBlockValue: `${formatBigDecimal(response.consensusBlockValue, ETH_TO_WEI, MAX_DECIMAL_FACTOR)} ETH`,
       totalBlockValue: `${formatBigDecimal(
         response.executionPayloadValue + gweiToWei(response.consensusBlockValue),
         ETH_TO_WEI,


### PR DESCRIPTION
**Description**

Currently `consensusBlockValue` is in Gwei. To align with `executionPayloadValue`, block value is converted into Wei. 

Note that values in `RewardCache` will still be in Gwei for the purpose of rewards API, which is denominated in Gwei. 


<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

- Closes #6259 
- spec PR https://github.com/ethereum/beacon-APIs/pull/400
