### PR TITLE
ci: update debug node action and test workflow to use on several steps

### DIFF
--- a/.github/actions/setup-debug-node/action.yml
+++ b/.github/actions/setup-debug-node/action.yml
@@ -2,12 +2,30 @@ name: "Setup node with debug support"
 description: "Setup the nodejs version with debug support"
 runs:
   using: "composite"
-  steps:
+  steps:    
+    # Determine the path of the Node executable
+    - name: Get Node Path
+      id: nodepath
+      shell: sh
+      run: echo "NODE_PATH=$(which node)" >> $GITHUB_OUTPUT
+
+    - name: Check node version
+      shell: sh
+      run: |
+        NODE_VERSION=$(${{ steps.nodepath.outputs.NODE_PATH }} --print "process.version")
+        echo "Node version found: $NODE_VERSION"
+        if [[ "$NODE_VERSION" == v20* ]]; then
+          echo "Matching node version (v20) is installed."
+        else
+          echo "Only node 20 has a debug version available"
+          exit 1
+        fi
+
     # For now we only have the Node 20 debug build
     - run: |
         sudo apt-get install unzip && curl -L "https://drive.google.com/uc?export=download&id=1hlhbbQi-NJi8_WjULvOdo-K_tfZFzN3Z&confirm=t" > nodejs.zip && unzip nodejs.zip
-        sudo cp -f node /usr/bin/node-with-debug
-        sudo chmod +x /usr/bin/node-with-debug
+        sudo cp -f node ${{ steps.nodepath.outputs.NODE_PATH }}
+        sudo chmod +x ${{ steps.nodepath.outputs.NODE_PATH }}
       shell: sh
 
     # List of naming patterns
@@ -18,6 +36,6 @@ runs:
       shell: sh
 
     - run: |
-        echo $(/usr/bin/node-with-debug --print "process.version")
-        echo $(/usr/bin/node-with-debug --print "process.features.debug")
+        echo $(${{ steps.nodepath.outputs.NODE_PATH }} --print "process.version")
+        echo $(${{ steps.nodepath.outputs.NODE_PATH }} --print "process.features.debug")
       shell: sh

--- a/.github/actions/setup-debug-node/action.yml
+++ b/.github/actions/setup-debug-node/action.yml
@@ -6,11 +6,11 @@ runs:
     # Determine the path of the Node executable
     - name: Get Node Path
       id: nodepath
-      shell: sh
+      shell: bash
       run: echo "NODE_PATH=$(which node)" >> $GITHUB_OUTPUT
 
     - name: Check node version
-      shell: sh
+      shell: bash
       run: |
         NODE_VERSION=$(${{ steps.nodepath.outputs.NODE_PATH }} --print "process.version")
         echo "Node version found: $NODE_VERSION"
@@ -26,16 +26,16 @@ runs:
         sudo apt-get install unzip && curl -L "https://drive.google.com/uc?export=download&id=1hlhbbQi-NJi8_WjULvOdo-K_tfZFzN3Z&confirm=t" > nodejs.zip && unzip nodejs.zip
         sudo cp -f node ${{ steps.nodepath.outputs.NODE_PATH }}
         sudo chmod +x ${{ steps.nodepath.outputs.NODE_PATH }}
-      shell: sh
+      shell: bash
 
     # List of naming patterns
     # https://man7.org/linux/man-pages/man5/core.5.html
     - run: |
         sudo mkdir -p /cores
         sudo sh -c "echo /cores/core-%e-%s-%u-%g-%p-%t > /proc/sys/kernel/core_pattern"
-      shell: sh
+      shell: bash
 
     - run: |
         echo $(${{ steps.nodepath.outputs.NODE_PATH }} --print "process.version")
         echo $(${{ steps.nodepath.outputs.NODE_PATH }} --print "process.features.debug")
-      shell: sh
+      shell: bash

--- a/.github/actions/setup-debug-node/action.yml
+++ b/.github/actions/setup-debug-node/action.yml
@@ -26,16 +26,16 @@ runs:
         sudo apt-get install unzip && curl -L "https://drive.google.com/uc?export=download&id=1hlhbbQi-NJi8_WjULvOdo-K_tfZFzN3Z&confirm=t" > nodejs.zip && unzip nodejs.zip
         sudo cp -f node ${{ steps.nodepath.outputs.NODE_PATH }}
         sudo chmod +x ${{ steps.nodepath.outputs.NODE_PATH }}
-      shell: bash
+      shell: sh
 
     # List of naming patterns
     # https://man7.org/linux/man-pages/man5/core.5.html
     - run: |
         sudo mkdir -p /cores
         sudo sh -c "echo /cores/core-%e-%s-%u-%g-%p-%t > /proc/sys/kernel/core_pattern"
-      shell: bash
+      shell: sh
 
     - run: |
         echo $(${{ steps.nodepath.outputs.NODE_PATH }} --print "process.version")
         echo $(${{ steps.nodepath.outputs.NODE_PATH }} --print "process.features.debug")
-      shell: bash
+      shell: sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 
 env:
+  NODE_DEBUG: true
   GETH_DOCKER_IMAGE: ethereum/client-go:v1.11.6
   NETHERMIND_DOCKER_IMAGE: nethermind/nethermind:1.18.0
 
@@ -32,6 +33,9 @@ jobs:
           node-version: ${{matrix.node}}
           check-latest: true
           cache: yarn
+      - name: Use Debug Version of Node
+        uses: './.github/actions/setup-debug-node'
+        if: env.NODE_DEBUG == 'true'
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
@@ -47,11 +51,24 @@ jobs:
             packages/*/.git-data.json
           key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
       - name: Install & build
+        id: install_and_build
         if: steps.cache-build-restore.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile && yarn build
+        run: |
+          if [ "${{ env.NODE_DEBUG }}" == "true" ]; then
+            sudo sh -c "ulimit -c unlimited"
+          fi
+          yarn install --frozen-lockfile && yarn build
       - name: Build
+        id: build
         if: steps.cache-build-restore.outputs.cache-hit == 'true'
-        run: yarn build
+        run: |
+          if [ "${{ env.NODE_DEBUG }}" == "true" ]; then
+            sudo sh -c "ulimit -c unlimited"
+          fi
+          yarn build
+      - uses: './.github/actions/core-dump'
+        if: ${{ env.NODE_DEBUG == 'true' && always() && (steps.install_and_build.conclusion == 'failure' || steps.build.conclusion == 'failure') }}
+
       - name: Check Build
         run: yarn check-build
       - name: Test root binary exists
@@ -159,9 +176,8 @@ jobs:
           node-version: ${{ matrix.node }}
           check-latest: true
           cache: yarn 
-
-      # # Remove when finished debugging core dumps
-      # - uses: './.github/actions/setup-debug-node'
+      - uses: './.github/actions/setup-debug-node'
+        if: env.NODE_DEBUG == 'true'
 
       - name: Restore build cache
         id: cache-primes-restore
@@ -184,14 +200,15 @@ jobs:
           key: spec-test-data-${{ hashFiles('packages/validator/test/spec/params.ts') }}
 
       - name: Unit tests
-        # id: unit_tests
-        # Rever to "yarn test:unit" when finished debugging core dumps
-        # run: sudo sh -c "ulimit -c unlimited && /usr/bin/node-with-debug $(which yarn) test:unit"
-        run: yarn test:unit
-      
-      # # Remove when finished debugging core dumps
-      # - uses: './.github/actions/core-dump'
-      #   if: ${{ failure() && steps.unit_tests.conclusion == 'failure' }}
+        id: unit_tests
+        run: |
+          if [ "${{ env.NODE_DEBUG }}" == "true" ]; then
+            sudo sh -c "ulimit -c unlimited"
+          fi
+          yarn test:unit
+
+      - uses: './.github/actions/core-dump'
+        if: ${{ always() && env.NODE_DEBUG == 'true' && steps.unit_tests.conclusion == 'failure' }}
 
       - name: Upload coverage data
         run: yarn coverage
@@ -212,6 +229,10 @@ jobs:
           node-version: ${{matrix.node}}
           check-latest: true
           cache: yarn
+      - name: Use Debug Version of Node
+        uses: './.github/actions/setup-debug-node'
+        if: env.NODE_DEBUG == 'true'
+
       - name: Restore build cache
         id: cache-primes-restore
         uses: actions/cache/restore@v3
@@ -229,9 +250,18 @@ jobs:
         run: scripts/run_e2e_env.sh start
 
       - name: E2E tests
-        run: yarn test:e2e
+        id: e2e_tests
         env:
           GOERLI_RPC_URL: ${{ secrets.GOERLI_RPC_URL!=0 && secrets.GOERLI_RPC_URL || env.GOERLI_RPC_DEFAULT_URL }}
+        run: |
+          if [ "${{ env.NODE_DEBUG }}" == "true" ]; then
+            sudo sh -c "ulimit -c unlimited"
+          fi
+          yarn test:e2e
+
+      # Conditional core-dump action based on NODE_DEBUG and test failure
+      - uses: './.github/actions/core-dump'
+        if: ${{ env.NODE_DEBUG == 'true' && failure() && steps.e2e_tests.conclusion == 'failure' }}
 
       - name: Stop the e2e test environment
         run: scripts/run_e2e_env.sh stop
@@ -296,6 +326,9 @@ jobs:
           node-version: ${{matrix.node}}
           check-latest: true
           cache: yarn
+      - name: Use Debug Version of Node
+        uses: './.github/actions/setup-debug-node'
+        if: env.NODE_DEBUG == 'true'
       - name: Restore build cache
         id: cache-primes-restore
         uses: actions/cache/restore@v3
@@ -318,15 +351,38 @@ jobs:
       - name: Download spec tests
         run: yarn download-spec-tests
         working-directory: packages/beacon-node
+
       # Run them in different steps to quickly identifying which command failed
       # Otherwise just doing `yarn test:spec` you can't tell which specific suite failed
       # many of the suites have identical names for minimal and mainnet
+      # Spec tests with IDs
       - name: Spec tests bls-general
-        run: yarn test:spec-bls-general
+        id: spec_bls_general
         working-directory: packages/beacon-node
+        run: |
+          if [ "${{ env.NODE_DEBUG }}" == "true" ]; then
+            sudo sh -c "ulimit -c unlimited"
+          fi
+          yarn test:spec-bls-general
+
       - name: Spec tests minimal
-        run: yarn test:spec-minimal
+        id: spec_minimal
         working-directory: packages/beacon-node
+        run: |
+          if [ "${{ env.NODE_DEBUG }}" == "true" ]; then
+            sudo sh -c "ulimit -c unlimited"
+          fi
+          yarn test:spec-minimal
+
       - name: Spec tests mainnet
-        run: NODE_OPTIONS='--max-old-space-size=4096' yarn test:spec-mainnet
+        id: spec_mainnet
         working-directory: packages/beacon-node
+        run: |
+          if [ "${{ env.NODE_DEBUG }}" == "true" ]; then
+            sudo sh -c "ulimit -c unlimited"
+          fi
+          NODE_OPTIONS='--max-old-space-size=4096' yarn test:spec-mainnet
+
+      - uses: './.github/actions/core-dump'
+        if: ${{ always() && env.NODE_DEBUG == 'true' && (steps.spec_bls_general.outcome == 'failure' || steps.spec_minimal.outcome == 'failure' || steps.spec_mainnet.outcome == 'failure') }}
+  


### PR DESCRIPTION
**Motivation**

We are getting a lot of seg faults in various steps.

- Updated `.github/actions/setup-debug-node` to overwrite node with a debug version of node.
- Updated main workflow to add `NODE_DEBUG` flag that controls usage of regular or debug version throughout workflow.
- Updated several jobs/steps to accommodate NODE_DEBUG functionality

**Testing**
This workflow needs to be tested to verify that the added scripts and functionality works as expected.  Will go through a round of reviews and then may need to update if there are bugs.