### PR TITLE
fix: do not download known block by root

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -301,6 +301,10 @@ export class BeaconChain implements IBeaconChain {
     await this.bls.close();
   }
 
+  seenBlock(blockRoot: RootHex): boolean {
+    return this.seenGossipBlockInput.hasBlock(blockRoot) || this.forkChoice.hasBlockHex(blockRoot);
+  }
+
   regenCanAcceptWork(): boolean {
     return this.regen.canAcceptWork();
   }

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -119,6 +119,8 @@ export interface IBeaconChain {
 
   /** Stop beacon chain processing */
   close(): Promise<void>;
+  /** Chain has seen the specified block root or not. The block may not be processed yet, use forkchoice.hasBlock to check it  */
+  seenBlock(blockRoot: RootHex): boolean;
   /** Populate in-memory caches with persisted data. Call at least once on startup */
   loadFromDisk(): Promise<void>;
   /** Persist in-memory data to the DB. Call at least once before stopping the process */

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -44,6 +44,10 @@ export class SeenGossipBlockInput {
     pruneSetToMax(this.blockInputCache, MAX_GOSSIPINPUT_CACHE);
   }
 
+  hasBlock(blockRoot: RootHex): boolean {
+    return this.blockInputCache.has(blockRoot);
+  }
+
   getGossipBlockInput(
     config: ChainForkConfig,
     gossipedInput: GossipedBlockInput

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -125,13 +125,14 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
 
     let blockInput;
     let blockInputMeta;
-    if (config.getForkSeq(signedBlock.message.slot) >= ForkSeq.deneb) {
-      const blockInputRes = chain.seenGossipBlockInput.getGossipBlockInput(config, {
-        type: GossipedInputType.block,
-        signedBlock,
-        blockBytes,
-      });
 
+    // always set block to seen cache for all forks so that we don't need to download it
+    const blockInputRes = chain.seenGossipBlockInput.getGossipBlockInput(config, {
+      type: GossipedInputType.block,
+      signedBlock,
+      blockBytes,
+    });
+    if (config.getForkSeq(signedBlock.message.slot) >= ForkSeq.deneb) {
       blockInput = blockInputRes.blockInput;
       blockInputMeta = blockInputRes.blockInputMeta;
 

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -231,11 +231,12 @@ export class NetworkProcessor {
   }
 
   searchUnknownSlotRoot({slot, root}: SlotRootHex, peer?: PeerIdStr): void {
-    // Search for the unknown block
-    if (!this.unknownRootsBySlot.getOrDefault(slot).has(root)) {
-      this.unknownRootsBySlot.getOrDefault(slot).add(root);
-      this.events.emit(NetworkEvent.unknownBlock, {rootHex: root, peer});
+    if (this.chain.seenBlock(root) || this.unknownRootsBySlot.getOrDefault(slot).has(root)) {
+      return;
     }
+    // Search for the unknown block
+    this.unknownRootsBySlot.getOrDefault(slot).add(root);
+    this.events.emit(NetworkEvent.unknownBlock, {rootHex: root, peer});
   }
 
   private onPendingGossipsubMessage(message: PendingGossipsubMessage): void {


### PR DESCRIPTION
**Motivation**

- There are a lot of logs like this:
```
Jan-11 00:01:13.097[network]       ^[[36mverbose^[[39m: Received gossip block slot=8175604, root=0x62df…9da8, curentSlot=8175604, peerId=16Uiu2HAmU1gDEV3eZ7ujqYLqY4KSEscWaeBRmsJr9KJKPeJNJTtH, delaySec=2.072999954223633, recvToVal=0.023999929428100586

Jan-11 00:01:13.341[sync]          ^[[36mverbose^[[39m: Downloading unknown block root=0x62dffba4e7b4eb3e07e561bc8a35377fd7edbb9d9816274a854cfb90b1bc9da8, pendingBlocks=1
```

- It said beacon node tried to download a known block root

**Description**

- Leverage the `seenGossipBlockInput` in chain to avoid it

part of #6105