### PR TITLE
docs: add documentation contribution instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,22 +231,17 @@ node scripts/download_dashboards.mjs
 
 ## Contributing to Documentation
 
-When submitting PRs for documentation updates, build the docs locally and ensure functionality before submission. To build docs locally, ensure you have Python installed, then follow these steps:
-
-```sh
-pip install -r docs/requirements.txt
-yarn build:docs
-cd docs
-mkdocs serve --watch pages
-```
+When submitting PRs for documentation updates, build and run the docs locally to ensure functionality before submission. To build the docs locally, ensure you have Python installed, then simply execute `yarn build:docs` 
 
 Your locally served docs will then be accessible at http://localhost:8000.
 
 If you run into build issues due to circular dependencies, branch switching or other incompatibilities, try cleaning your modules and rebuild your dependencies with:
 
-```
+```sh
 yarn clean && yarn clean:nm && yarn && yarn build
 ```
+
+We also use a spelling [wordlist](https://github.com/ChainSafe/lodestar/blob/unstable/.wordlist.txt) as part of our documentation checks. If using unrecognized words or abbreviations, please extend the wordlist to pass checks. Make sure the list is sorted with `./scripts/wordlist_sort.sh`.
 
 ## Label Guide
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,6 +229,25 @@ Run script to download dashboards to `./dashboards` folder
 node scripts/download_dashboards.mjs
 ```
 
+## Contributing to Documentation
+
+When submitting PRs for documentation updates, build the docs locally and ensure functionality before submission. To build docs locally, ensure you have Python installed, then follow these steps:
+
+```sh
+pip install -r docs/requirements.txt
+yarn build:docs
+cd docs
+mkdocs serve --watch pages
+```
+
+Your locally served docs will then be accessible at http://localhost:8000.
+
+If you run into build issues due to circular dependencies, branch switching or other incompatibilities, try cleaning your modules and rebuild your dependencies with:
+
+```
+yarn clean && yarn clean:nm && yarn && yarn build
+```
+
 ## Label Guide
 
 Issues and pull requests are subject to the following labeling guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ node scripts/download_dashboards.mjs
 
 ## Contributing to Documentation
 
-When submitting PRs for documentation updates, build and run the documentation locally to ensure functionality before submission. To build the documentation locally, ensure you have Python installed, then simply execute `yarn build:docs` 
+When submitting PRs for documentation updates, build and run the documentation locally to ensure functionality before submission. For first time documentation contributors, install the python dependencies with `yarn docs:install`. Build the documentation locally with `yarn docs:build` and serve with `yarn docs:serve`
 
 Your locally served documentation will then be accessible at http://localhost:8000.
 
@@ -241,7 +241,7 @@ If you run into build issues due to circular dependencies, branch switching or o
 yarn clean && yarn clean:nm && yarn && yarn build
 ```
 
-We also use a spelling [word list](https://github.com/ChainSafe/lodestar/blob/unstable/.wordlist.txt) as part of our documentation checks. If using unrecognized words or abbreviations, please extend the wordlist to pass checks. Make sure the list is sorted with `./scripts/wordlist_sort.sh` and checked with `./scripts/wordlist_sort_check.sh` for sorting and duplicates.
+We also use a spelling [word list](https://github.com/ChainSafe/lodestar/blob/unstable/.wordlist.txt) as part of our documentation checks. If using unrecognized words or abbreviations, please extend the word list to pass checks. Make sure the list is sorted with `./scripts/wordlist_sort.sh` and checked with `./scripts/wordlist_sort_check.sh` for sorting and duplicates.
 
 ## Label Guide
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,9 +231,9 @@ node scripts/download_dashboards.mjs
 
 ## Contributing to Documentation
 
-When submitting PRs for documentation updates, build and run the docs locally to ensure functionality before submission. To build the docs locally, ensure you have Python installed, then simply execute `yarn build:docs` 
+When submitting PRs for documentation updates, build and run the documentation locally to ensure functionality before submission. To build the documentation locally, ensure you have Python installed, then simply execute `yarn build:docs` 
 
-Your locally served docs will then be accessible at http://localhost:8000.
+Your locally served documentation will then be accessible at http://localhost:8000.
 
 If you run into build issues due to circular dependencies, branch switching or other incompatibilities, try cleaning your modules and rebuild your dependencies with:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,7 +241,7 @@ If you run into build issues due to circular dependencies, branch switching or o
 yarn clean && yarn clean:nm && yarn && yarn build
 ```
 
-We also use a spelling [wordlist](https://github.com/ChainSafe/lodestar/blob/unstable/.wordlist.txt) as part of our documentation checks. If using unrecognized words or abbreviations, please extend the wordlist to pass checks. Make sure the list is sorted with `./scripts/wordlist_sort.sh`.
+We also use a spelling [wordlist](https://github.com/ChainSafe/lodestar/blob/unstable/.wordlist.txt) as part of our documentation checks. If using unrecognized words or abbreviations, please extend the wordlist to pass checks. Make sure the list is sorted with `./scripts/wordlist_sort.sh` and checked with `./scripts/wordlist_sort_check.sh` for sorting and duplicates.
 
 ## Label Guide
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,7 +241,7 @@ If you run into build issues due to circular dependencies, branch switching or o
 yarn clean && yarn clean:nm && yarn && yarn build
 ```
 
-We also use a spelling [wordlist](https://github.com/ChainSafe/lodestar/blob/unstable/.wordlist.txt) as part of our documentation checks. If using unrecognized words or abbreviations, please extend the wordlist to pass checks. Make sure the list is sorted with `./scripts/wordlist_sort.sh` and checked with `./scripts/wordlist_sort_check.sh` for sorting and duplicates.
+We also use a spelling [word list](https://github.com/ChainSafe/lodestar/blob/unstable/.wordlist.txt) as part of our documentation checks. If using unrecognized words or abbreviations, please extend the wordlist to pass checks. Make sure the list is sorted with `./scripts/wordlist_sort.sh` and checked with `./scripts/wordlist_sort_check.sh` for sorting and duplicates.
 
 ## Label Guide
 


### PR DESCRIPTION
**Motivation**

This PR is to persist the instructions for building docs locally for revision before submission.

**Description**

This PR modifies contribution.md to include the reference details for future contributors.
