### PR TITLE
fix: correct error message if produceBlindedBlock request fails

### DIFF
--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -265,7 +265,7 @@ export class BlockProposingService {
     } else {
       Object.assign(debugLogCtx, {api: "produceBlindedBlock"});
       const res = await this.api.validator.produceBlindedBlock(slot, randaoReveal, graffiti);
-      ApiError.assert(res, "Failed to produce block: validator.produceBlockV2");
+      ApiError.assert(res, "Failed to produce block: validator.produceBlindedBlock");
       const {response} = res;
       const executionPayloadSource = ProducedBlockSource.builder;
 


### PR DESCRIPTION
**Motivation**

From Obol logs:
```
2024-01-14 12:46:00 Jan-14 11:46:00.107[]                error: Error proposing block slot=330830, validator=0xaf64…356a - Failed to produce block: validator.produceBlockV2 - Internal Server Error: Internal server error - Failed to produce block
2024-01-14 12:46:00 Error: Failed to produce block: validator.produceBlockV2 - Internal Server Error: Internal server error - Failed to produce block
```
We are calling `produceBlindedBlock` but in the error it says `validator.produceBlockV2`

**Description**

Correct error message if `produceBlindedBlock` request fails