### PR TITLE
chore: install same vitest version across packages

### DIFF
--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -65,7 +65,7 @@
     "@lodestar/utils": "^1.14.0",
     "async-retry": "^1.3.3",
     "axios": "^1.3.4",
-    "vitest": "^1.0.2",
+    "vitest": "^1.1.0",
     "rimraf": "^4.4.1",
     "snappyjs": "^0.7.0",
     "tar": "^6.1.13"
@@ -75,6 +75,6 @@
     "@types/tar": "^6.1.4"
   },
   "peerDependencies": {
-    "vitest": "^1.0.2"
+    "vitest": "^1.1.0"
   }
 }

--- a/packages/spec-test-util/src/single.ts
+++ b/packages/spec-test-util/src/single.ts
@@ -112,7 +112,7 @@ export function describeDirectorySpecTest<TestCase extends {meta?: any}, Result>
         continue;
       }
 
-      // Use full path here, not just `testSubDirname` to allow usage of `vitest --grep`
+      // Use full path here, not just `testSubDirname` to allow usage of `vitest -t`
       const testName = `${name}/${testSubDirname}`;
       it(testName, async function (context) {
         // some tests require to load meta.yaml first in order to know respective ssz types.


### PR DESCRIPTION
**Motivation**

Noticed when running `yarn install` locally on unstable branch it produces a lock file diff. This is due to the fact that we install different vitest versions.

I reviewed https://github.com/ChainSafe/lodestar/pull/6222 and seems to be the issue as the branch was open before we upgraded vitest in https://github.com/ChainSafe/lodestar/pull/6237. 

There is a way to enforce that a branch is rebased / merged against target branch before the PR can be merged. While I don't think this is strictly necessary, we should keep in mind to rebase long lived branches before merging.

**Description**

Install same vitest version across packages
