### PR TITLE
refactor: use for...of instead of forEach

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -963,9 +963,9 @@ export class BeaconChain implements IBeaconChain {
   }
 
   async updateBeaconProposerData(epoch: Epoch, proposers: ProposerPreparationData[]): Promise<void> {
-    proposers.forEach((proposer) => {
+    for (const proposer of proposers) {
       this.beaconProposerCache.add(epoch, proposer);
-    });
+    }
   }
 
   updateBuilderStatus(clockSlot: Slot): void {

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -433,7 +433,9 @@ export class NetworkProcessor {
         ];
 
     if (Array.isArray(messageOrArray)) {
-      messageOrArray.forEach((msg) => this.trackJobTime(msg, messageOrArray.length));
+      for (const msg of messageOrArray) {
+        this.trackJobTime(msg, messageOrArray.length);
+      }
     } else {
       this.trackJobTime(messageOrArray, 1);
     }

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -547,7 +547,9 @@ export class ForkChoice implements IForkChoice {
   onAttesterSlashing(attesterSlashing: phase0.AttesterSlashing): void {
     // TODO: we already call in in state-transition, find a way not to recompute it again
     const intersectingIndices = getAttesterSlashableIndices(attesterSlashing);
-    intersectingIndices.forEach((validatorIndex) => this.fcStore.equivocatingIndices.add(validatorIndex));
+    for (const validatorIndex of intersectingIndices) {
+      this.fcStore.equivocatingIndices.add(validatorIndex);
+    }
   }
 
   getLatestMessage(validatorIndex: ValidatorIndex): LatestMessage | undefined {


### PR DESCRIPTION
**Motivation**

Code consistency, marginal performance improvements. I just watched video about node performance yesterday and it was brought up how bad forEach actually is especially if you iterate huge data sets, took this as a inspiration to give our forEach usage another review. We don't use it a lot but might as well clean up remaining forEach usage.

**Description**

Use for...of instead of forEach

**Note**: I did not update all occasions as it's either not relevant there in terms of performance or it is just a neat usage of forEach where for...of would make the code less readable.

There was plenty of previous work done by Lion related to this
- https://github.com/ChainSafe/lodestar/pull/1845
- https://github.com/ChainSafe/ssz/pull/98
- https://github.com/ChainSafe/lodestar/pull/2134

