### PR TITLE
feat: allow to skip gossip validation

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -39,6 +39,7 @@ export type BlockHeaderResponse = {
 };
 
 export enum BroadcastValidation {
+  none = "none",
   gossip = "gossip",
   consensus = "consensus",
   consensusAndEquivocation = "consensus_and_equivocation",

--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -39,6 +39,13 @@ export type BlockHeaderResponse = {
 };
 
 export enum BroadcastValidation {
+  /* 
+  NOTE: The value `none` is not part of the spec. 
+
+  In case a node is configured only with the unknownBlockSync, it needs to know the unknown parent blocks on the network 
+  to initiate the syncing process. Such cases can be covered only if we publish blocks and make sure no gossip validation 
+  is performed on those. But this behavior is not the default.
+  */
   none = "none",
   gossip = "gossip",
   consensus = "consensus",

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -149,6 +149,11 @@ export function getBeaconBlockApi({
         break;
       }
 
+      case routes.beacon.BroadcastValidation.none: {
+        chain.logger.debug("Skipping broadcast validation", valLogMeta);
+        break;
+      }
+
       default: {
         // error or log warning we do not support this validation
         const message = `Broadcast validation of ${broadcastValidation} type not implemented yet`;


### PR DESCRIPTION
**Motivation**

Make sure the block is published to network.

**Description**

In case a node is configured only with the `unknownBlockSync`, it needs to know the unknown parent blocks on the network to initiate the syncing process. Such cases can be covered only if we publish blocks and make sure no gossip validation is performed on those. But this behavior is not the default.


**Steps to test or reproduce**

- Run all tests