### PR TITLE
feat: log agent version when client is not known

### DIFF
--- a/packages/beacon-node/src/network/peers/client.ts
+++ b/packages/beacon-node/src/network/peers/client.ts
@@ -7,7 +7,13 @@ export enum ClientKind {
   Unknown = "Unknown",
 }
 
-export function clientFromAgentVersion(agentVersion: string): ClientKind {
+/**
+ * Get known client from agent version.
+ * If client is not known, don't return ClientKind.Unknown here.
+ * For metrics it'll have fallback logic to use ClientKind.Unknown
+ * For logs, we want to print out agentVersion instead for debugging purposes.
+ */
+export function getKnownClientFromAgentVersion(agentVersion: string): ClientKind | null {
   const slashIndex = agentVersion.indexOf("/");
   const agent = slashIndex >= 0 ? agentVersion.slice(0, slashIndex) : agentVersion;
   const agentLC = agent.toLowerCase();
@@ -16,5 +22,6 @@ export function clientFromAgentVersion(agentVersion: string): ClientKind {
   if (agentLC === "prysm") return ClientKind.Prysm;
   if (agentLC === "nimbus") return ClientKind.Nimbus;
   if (agentLC === "lodestar" || agentLC === "js-libp2p") return ClientKind.Lodestar;
-  return ClientKind.Unknown;
+
+  return null;
 }

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -19,7 +19,7 @@ import {NetworkCoreMetrics} from "../core/metrics.js";
 import {LodestarDiscv5Opts} from "../discv5/types.js";
 import {PeerDiscovery, SubnetDiscvQueryMs} from "./discover.js";
 import {PeersData, PeerData} from "./peersData.js";
-import {clientFromAgentVersion, ClientKind} from "./client.js";
+import {getKnownClientFromAgentVersion, ClientKind} from "./client.js";
 import {
   getConnectedPeerIds,
   hasSomeConnectedPeer,
@@ -615,7 +615,7 @@ export class PeerManager {
         if (agentVersionBytes) {
           const agentVersion = new TextDecoder().decode(agentVersionBytes) || "N/A";
           peerData.agentVersion = agentVersion;
-          peerData.agentClient = clientFromAgentVersion(agentVersion);
+          peerData.agentClient = getKnownClientFromAgentVersion(agentVersion);
         }
       },
       {retries: 3, retryDelay: 1000}

--- a/packages/beacon-node/src/network/peers/peersData.ts
+++ b/packages/beacon-node/src/network/peers/peersData.ts
@@ -38,8 +38,8 @@ export class PeersData {
     return this.connectedPeers.get(peerIdStr)?.agentVersion ?? "NA";
   }
 
-  getPeerKind(peerIdStr: string): ClientKind {
-    return this.connectedPeers.get(peerIdStr)?.agentClient ?? ClientKind.Unknown;
+  getPeerKind(peerIdStr: string): ClientKind | null {
+    return this.connectedPeers.get(peerIdStr)?.agentClient ?? null;
   }
 
   getEncodingPreference(peerIdStr: string): Encoding | null {

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -88,7 +88,8 @@ export class ReqRespBeaconNode extends ReqResp {
           metrics?.reqResp.rateLimitErrors.inc({method});
         },
         getPeerLogMetadata(peerId) {
-          return peersData.getPeerKind(peerId);
+          // this logs the whole agent version for unknown client which is good for debugging
+          return peersData.getPeerKind(peerId) ?? peersData.getAgentVersion(peerId);
         },
       }
     );

--- a/packages/beacon-node/test/unit/network/peers/client.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/client.test.ts
@@ -2,7 +2,7 @@ import {describe, it, expect} from "vitest";
 import {getKnownClientFromAgentVersion, ClientKind} from "../../../../src/network/peers/client.js";
 
 describe("clientFromAgentVersion", () => {
-  const testCases: {name: string; agentVersion: string; client: ClientKind}[] = [
+  const testCases: {name: string; agentVersion: string; client: ClientKind | null}[] = [
     {
       name: "lighthouse",
       agentVersion: "Lighthouse/v2.0.1-fff01b2/x86_64-linux",
@@ -27,6 +27,11 @@ describe("clientFromAgentVersion", () => {
       name: "lodestar",
       agentVersion: "js-libp2p/0.32.4",
       client: ClientKind.Lodestar,
+    },
+    {
+      name: "unknown client",
+      agentVersion: "strange-client-agent-version",
+      client: null,
     },
   ];
 

--- a/packages/beacon-node/test/unit/network/peers/client.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/client.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from "vitest";
-import {clientFromAgentVersion, ClientKind} from "../../../../src/network/peers/client.js";
+import {getKnownClientFromAgentVersion, ClientKind} from "../../../../src/network/peers/client.js";
 
 describe("clientFromAgentVersion", () => {
   const testCases: {name: string; agentVersion: string; client: ClientKind}[] = [
@@ -32,7 +32,7 @@ describe("clientFromAgentVersion", () => {
 
   for (const {name, agentVersion, client} of testCases) {
     it(name, () => {
-      expect(clientFromAgentVersion(agentVersion)).toBe(client);
+      expect(getKnownClientFromAgentVersion(agentVersion)).toBe(client);
     });
   }
 });


### PR DESCRIPTION
**Motivation**

For unknown clients, the log keeps saying "Unknown" which is not beneficial for debugging purpose

```
Jan-17 07:38:21.909[network]       verbose: Req  error method=metadata, version=2, encoding=ssz_snappy, client=Unknown, peer=16...pWVhz9, requestId=403654, code=SSZ_SNAPPY_ERROR_OVER_SSZ_MAX_SIZE, maxSize=17, sszDataLength=24
Error: SSZ_SNAPPY_ERROR_OVER_SSZ_MAX_SIZE
```

**Description**
- Log: show agent version of unknown client if we have it

```
Jan-17 08:52:32.078[network]         debug: Req  sending request method=metadata, version=2, encoding=ssz_snappy, client=erigon/caplin, peer=16...UyvV1M, requestId=2180
```

- Or just show "NA" if we event don't have agent version

```
Jan-17 08:52:30.832[network]         debug: Req  received method=ping, client=NA, peer=16...T6mMb7, requestId=2163
```

- Metric: still track them as "Unknown"

<img width="915" alt="Screenshot 2024-01-17 at 15 57 16" src="https://github.com/ChainSafe/lodestar/assets/10568965/e16767ac-4ad6-4093-87d1-0ff5f77faff5">
