### PR TITLE
fix: ignore already known errors in API

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -234,7 +234,7 @@ export function getBeaconPoolApi({
       );
 
       if (errors.length > 1) {
-        throw Error("Multiple errors on publishAggregateAndProofs\n" + errors.map((e) => e.message).join("\n"));
+        throw Error("Multiple errors on submitPoolSyncCommitteeSignatures\n" + errors.map((e) => e.message).join("\n"));
       } else if (errors.length === 1) {
         throw errors[0];
       }


### PR DESCRIPTION
**Motivation**

Attestations might already be published by another node as part of a fallback setup or DVT cluster
and can reach our node by gossip before the api. The error can be ignored and should not result in a 500 response.

There are also other errors related to that like known aggregates which should be ignored as well (see previous PR https://github.com/ChainSafe/lodestar/pull/2598)

**Description**

Ignore already known (`_ALREADY_KNOWN`) errors in API and return 200 response.

Closes https://github.com/ChainSafe/lodestar/issues/6021