### PR TITLE
fix: mockExecutionEngine without checking parentHash

### DIFF
--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -168,11 +168,6 @@ export class ExecutionEngineMockBackend implements JsonRpcBackend {
     //    validation is locally available. The validation process is specified in the Payload validation section.
     //
     // > Mock only validates that parent is known
-    if (!this.validBlocks.has(parentHash)) {
-      // if requisite data for the payload's acceptance or validation is missing
-      // return {status: SYNCING, latestValidHash: null, validationError: null}
-      return {status: ExecutionPayloadStatus.SYNCING, latestValidHash: null, validationError: null};
-    }
 
     // 4. Client software MAY NOT validate the payload if the payload doesn't belong to the canonical chain.
     //
@@ -253,9 +248,6 @@ export class ExecutionEngineMockBackend implements JsonRpcBackend {
 
     // 5. Client software MUST update its forkchoice state if payloads referenced by forkchoiceState.headBlockHash and
     //    forkchoiceState.finalizedBlockHash are VALID.
-    if (!this.validBlocks.has(finalizedBlockHash)) {
-      throw Error(`Unknown finalizedBlockHash ${finalizedBlockHash}`);
-    }
     this.headBlockHash = headBlockHash;
     this.safeBlockHash = safeBlockHash;
     this.finalizedBlockHash = finalizedBlockHash;


### PR DESCRIPTION
**Motivation**

Start the beacon node in mock mode without requiring an execution node.

**Description**

https://github.com/ChainSafe/lodestar/discussions/6188


