### PR TITLE
feat: improve batch validator exit UX

### DIFF
--- a/packages/cli/src/util/errors.ts
+++ b/packages/cli/src/util/errors.ts
@@ -2,3 +2,12 @@
  * Expected error that shouldn't print a stack trace
  */
 export class YargsError extends Error {}
+
+export type Result<T> = {err: null; result: T} | {err: Error};
+export async function wrapError<T>(promise: Promise<T>): Promise<Result<T>> {
+  try {
+    return {err: null, result: await promise};
+  } catch (err) {
+    return {err: err as Error};
+  }
+}


### PR DESCRIPTION
if there is an issue with one validator exit submission (most of the times already exited) other exits are not processed causing user frustration.

this PR processes all exits and console logs the status, and neatly handles the already exit scenarios of some of the validatoes which is what is what user faces most of the time

cc @barnabasbusa