### PR TITLE
fix: improve handling of non-integer builder boost factor values

### DIFF
--- a/docs/pages/validator-management/vc-configuration.md
+++ b/docs/pages/validator-management/vc-configuration.md
@@ -103,7 +103,7 @@ With Lodestar's `--builder.selection` validator options, you can select:
 
 #### Calculating builder boost factor with examples
 
-To calculate the builder boost factor setting, you need to know what percentage you will accept a builder block for against a local execution block using the following formula: `100*100/(100+percentage)`.
+To calculate the builder boost factor setting, you need to know what percentage you will accept a builder block for against a local execution block using the following formula: `100*100/(100+percentage)`. The value passed to `--builder.boostFactor` must be a valid number without decimals.
 
 Example 1: I will only accept a builder block with 25% more value than the local execution block.
 ```

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -227,7 +227,7 @@ function getProposerConfigFromArgs(
       selection: parseBuilderSelection(
         args["builder.selection"] ?? (args["builder"] ? defaultOptions.builderAliasSelection : undefined)
       ),
-      boostFactor: args["builder.boostFactor"] !== undefined ? BigInt(args["builder.boostFactor"]) : undefined,
+      boostFactor: parseBuilderBoostFactor(args["builder.boostFactor"]),
     },
   };
 
@@ -266,7 +266,7 @@ function parseBuilderSelection(builderSelection?: string): routes.validator.Buil
       case "executiononly":
         break;
       default:
-        throw Error("Invalid input for builder selection, check help.");
+        throw new YargsError("Invalid input for builder selection, check help");
     }
   }
   return builderSelection as routes.validator.BuilderSelection;
@@ -280,9 +280,19 @@ function parseBroadcastValidation(broadcastValidation?: string): routes.beacon.B
       case "consensus_and_equivocation":
         break;
       default:
-        throw Error("Invalid input for broadcastValidation, check help");
+        throw new YargsError("Invalid input for broadcastValidation, check help");
     }
   }
 
   return broadcastValidation as routes.beacon.BroadcastValidation;
+}
+
+function parseBuilderBoostFactor(boostFactor?: string): bigint | undefined {
+  if (boostFactor === undefined) return;
+
+  if (!/^\d+$/.test(boostFactor)) {
+    throw new YargsError("Invalid input for builder boost factor, must be a valid number without decimals");
+  }
+
+  return BigInt(boostFactor);
 }

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -45,7 +45,7 @@ export type IValidatorCliArgs = AccountValidatorArgs &
 
     builder?: boolean;
     "builder.selection"?: string;
-    "builder.boostFactor"?: bigint;
+    "builder.boostFactor"?: string;
 
     useProduceBlockV3?: boolean;
     broadcastValidation?: string;


### PR DESCRIPTION
**Motivation**

As noted in https://github.com/ChainSafe/lodestar/issues/6302, we should improve handling of non-integer builder boost factor values.

**Description**

I went with the second solution proposed in the issue
> throw friendly error and shutdown, include documentation update to highlight that


The error is much easier for a user to understand now and highlights that the number must be without decimals. 

```sh
> ./lodestar validator --builder.boostFactor 83.3
 ✖ Invalid input for builder boost factor, must be a valid number without decimals
```

Added a note in docs to highlight the same.


Closes https://github.com/ChainSafe/lodestar/issues/6302


