### PR TITLE
fix: use incrementing counter for prover request ids

### DIFF
--- a/packages/prover/src/utils/rpc.ts
+++ b/packages/prover/src/utils/rpc.ts
@@ -27,6 +27,8 @@ export class ELRpc {
   private handler: ELRequestHandler;
   private logger: Logger;
 
+  private requestId = 0;
+
   constructor(handler: ELRequestHandler, logger: Logger) {
     this.handler = handler;
     this.logger = logger;
@@ -99,7 +101,6 @@ export class ELRpc {
   }
 
   getRequestId(): string {
-    // TODO: Find better way to generate random id
-    return (Math.random() * 100000000000000000).toFixed(0);
+    return (++this.requestId).toString();
   }
 }


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/6266

**Description**

Use incrementing counter for prover request ids

Based on reviewing the usage of the request id I don't see an issue with using an incrementing counter but would be good if @nazarhussain could confirm this.