### PR TITLE
fix: correct total block value in publish block log

### DIFF
--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -223,7 +223,7 @@ export class BlockProposingService {
       executionPayloadValue: `${formatBigDecimal(response.executionPayloadValue, ETH_TO_WEI, MAX_DECIMAL_FACTOR)} ETH`,
       consensusBlockValue: `${formatBigDecimal(response.consensusBlockValue, ETH_TO_WEI, MAX_DECIMAL_FACTOR)} ETH`,
       totalBlockValue: `${formatBigDecimal(
-        response.executionPayloadValue + gweiToWei(response.consensusBlockValue),
+        response.executionPayloadValue + response.consensusBlockValue,
         ETH_TO_WEI,
         MAX_DECIMAL_FACTOR
       )} ETH`,

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -11,7 +11,7 @@ import {
 } from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPreBlobs, ForkBlobs, ForkSeq, ForkExecution} from "@lodestar/params";
-import {ETH_TO_WEI, extendError, gweiToWei, prettyBytes} from "@lodestar/utils";
+import {ETH_TO_WEI, extendError, prettyBytes} from "@lodestar/utils";
 import {Api, ApiError, routes} from "@lodestar/api";
 import {IClock, LoggerVc} from "../util/index.js";
 import {PubkeyHex} from "../types.js";


### PR DESCRIPTION
**Description**

`consensusBlockValue` should be in wei and not gwei. Previous PR #6286 fixed the unit but forgot to change the unit when calculating the total block value (`totalBlockValue`) in the publish block log which this PR aims to fix.

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #6316
