### PR TITLE
feat: blob sidecars can be filtered by indices

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -229,7 +229,7 @@ export type Api = {
    * Retrieves BlobSidecar included in requested block.
    * @param blockId Block identifier.
    * Can be one of: "head" (canonical head in node's view), "genesis", "finalized", \<slot\>, \<hex encoded blockRoot with 0x prefix\>.
-  * @param indices Array of indices for blob sidecars to request for in the specified block. Returns all blob sidecars in the block if not specified.
+   * @param indices Array of indices for blob sidecars to request for in the specified block. Returns all blob sidecars in the block if not specified.
    */
   getBlobSidecars(
     blockId: BlockId,

--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -233,7 +233,7 @@ export type Api = {
    */
   getBlobSidecars(
     blockId: BlockId,
-    indices?: string[]
+    indices?: number[]
   ): Promise<
     ApiClientResponse<{
       [HttpStatusCode.OK]: {executionOptimistic: ExecutionOptimistic; data: deneb.BlobSidecars};
@@ -274,7 +274,7 @@ export type ReqTypes = {
   publishBlockV2: {body: unknown; query: {broadcast_validation?: string}};
   publishBlindedBlock: {body: unknown};
   publishBlindedBlockV2: {body: unknown; query: {broadcast_validation?: string}};
-  getBlobSidecars: {params: {block_id: string}; query: {indices?: string[]}};
+  getBlobSidecars: {params: {block_id: string}; query: {indices?: number[]}};
 };
 
 export function getReqSerializers(config: ChainForkConfig): ReqSerializers<Api, ReqTypes> {
@@ -361,13 +361,13 @@ export function getReqSerializers(config: ChainForkConfig): ReqSerializers<Api, 
       },
     },
     getBlobSidecars: {
-      writeReq: (block_id, indices = []) => ({
+      writeReq: (block_id, indices) => ({
         params: {block_id: String(block_id)},
         query: {indices},
       }),
       parseReq: ({params, query}) => [params.block_id, query.indices],
       schema: {
-        query: {indices: Schema.StringArray},
+        query: {indices: Schema.UintArray},
       },
     },
   };

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -130,12 +130,6 @@ const ignoredProperties: Record<string, IgnoredProperty> = {
    */
   getHealth: {request: ["query.syncing_status"]},
 
-  /**
-   * https://github.com/ChainSafe/lodestar/issues/6185
-   *  - must have required property 'query'
-   */
-  getBlobSidecars: {request: ["query"]},
-
   /* 
    https://github.com/ChainSafe/lodestar/issues/4638 
    /query - must have required property 'skip_randao_verification'

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -71,7 +71,7 @@ export const testData: GenericServerTestCases<Api> = {
     res: undefined,
   },
   getBlobSidecars: {
-    args: ["head"],
+    args: ["head", ["0"]],
     res: {executionOptimistic: true, data: ssz.deneb.BlobSidecars.defaultValue()},
   },
 

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -71,7 +71,7 @@ export const testData: GenericServerTestCases<Api> = {
     res: undefined,
   },
   getBlobSidecars: {
-    args: ["head", ["0"]],
+    args: ["head", [0]],
     res: {executionOptimistic: true, data: ssz.deneb.BlobSidecars.defaultValue()},
   },
 

--- a/packages/api/test/utils/checkAgainstSpec.ts
+++ b/packages/api/test/utils/checkAgainstSpec.ts
@@ -199,7 +199,7 @@ function prettyAjvErrors(errors: ErrorObject[] | null | undefined): string {
   return errors.map((e) => `${e.instancePath ?? "."} - ${e.message}`).join("\n");
 }
 
-type StringifiedProperty = string | StringifiedProperty[] | null | undefined;
+type StringifiedProperty = string | StringifiedProperty[];
 
 function stringifyProperty(value: unknown): StringifiedProperty {
   if (typeof value === "number") {

--- a/packages/api/test/utils/checkAgainstSpec.ts
+++ b/packages/api/test/utils/checkAgainstSpec.ts
@@ -199,14 +199,24 @@ function prettyAjvErrors(errors: ErrorObject[] | null | undefined): string {
   return errors.map((e) => `${e.instancePath ?? "."} - ${e.message}`).join("\n");
 }
 
+type StringifiedProperty = string | StringifiedProperty[] | null | undefined;
+
+function stringifyProperty(value: unknown): StringifiedProperty {
+  if (value === undefined || value === null || typeof value === "string") {
+    // Handle specifically null as `typeof null === "object"`
+    return value;
+  } else if (typeof value === "number") {
+    return value.toString(10);
+  } else if (Array.isArray(value)) {
+    return value.map(stringifyProperty);
+  }
+  return String(value);
+}
+
 function stringifyProperties(obj: Record<string, unknown>): Record<string, unknown> {
   for (const key of Object.keys(obj)) {
     const value = obj[key];
-    if (typeof value === "number") {
-      obj[key] = value.toString(10);
-    } else if (Array.isArray(value)) {
-      obj[key] = value.map((value) => value.toString(10));
-    }
+    obj[key] = stringifyProperty(value);
   }
 
   return obj;

--- a/packages/api/test/utils/checkAgainstSpec.ts
+++ b/packages/api/test/utils/checkAgainstSpec.ts
@@ -204,6 +204,8 @@ function stringifyProperties(obj: Record<string, unknown>): Record<string, unkno
     const value = obj[key];
     if (typeof value === "number") {
       obj[key] = value.toString(10);
+    } else if (Array.isArray(value)) {
+      obj[key] = value.map((value) => value.toString(10));
     }
   }
 

--- a/packages/api/test/utils/checkAgainstSpec.ts
+++ b/packages/api/test/utils/checkAgainstSpec.ts
@@ -202,10 +202,7 @@ function prettyAjvErrors(errors: ErrorObject[] | null | undefined): string {
 type StringifiedProperty = string | StringifiedProperty[] | null | undefined;
 
 function stringifyProperty(value: unknown): StringifiedProperty {
-  if (value === undefined || value === null || typeof value === "string") {
-    // Handle specifically null as `typeof null === "object"`
-    return value;
-  } else if (typeof value === "number") {
+  if (typeof value === "number") {
     return value.toString(10);
   } else if (Array.isArray(value)) {
     return value.map(stringifyProperty);

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -406,7 +406,7 @@ export function getBeaconBlockApi({
       await publishBlock(signedBlockOrContents, opts);
     },
 
-    async getBlobSidecars(blockId) {
+    async getBlobSidecars(blockId, indices = []) {
       const {block, executionOptimistic} = await resolveBlockId(chain, blockId);
       const blockRoot = config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
 
@@ -418,9 +418,11 @@ export function getBeaconBlockApi({
       if (!blobSidecars) {
         throw Error(`blobSidecars not found in db for slot=${block.message.slot} root=${toHexString(blockRoot)}`);
       }
+
+      const indicesSet = new Set(indices?.map((index) => parseInt(index)));
       return {
         executionOptimistic,
-        data: blobSidecars,
+        data: blobSidecars.filter(({index}) => indicesSet.has(index)),
       };
     },
   };

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -406,7 +406,7 @@ export function getBeaconBlockApi({
       await publishBlock(signedBlockOrContents, opts);
     },
 
-    async getBlobSidecars(blockId, indices = []) {
+    async getBlobSidecars(blockId, indices) {
       const {block, executionOptimistic} = await resolveBlockId(chain, blockId);
       const blockRoot = config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
 

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -406,7 +406,7 @@ export function getBeaconBlockApi({
       await publishBlock(signedBlockOrContents, opts);
     },
 
-    async getBlobSidecars(blockId, indices) {
+    async getBlobSidecars(blockId, indices = []) {
       const {block, executionOptimistic} = await resolveBlockId(chain, blockId);
       const blockRoot = config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
 
@@ -419,11 +419,10 @@ export function getBeaconBlockApi({
         throw Error(`blobSidecars not found in db for slot=${block.message.slot} root=${toHexString(blockRoot)}`);
       }
 
-      const indicesSet = new Set(indices);
       return {
         executionOptimistic,
         // Return all sidecars if no indices are specified, only the requested ones (identified by `indices`) otherwise
-        data: indicesSet.size == 0 ? blobSidecars : blobSidecars.filter(({index}) => indicesSet.has(index)),
+        data: indices.length == 0 ? blobSidecars : blobSidecars.filter(({index}) => indices.includes(index)),
       };
     },
   };

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -422,7 +422,8 @@ export function getBeaconBlockApi({
       const indicesSet = new Set(indices?.map((index) => parseInt(index)));
       return {
         executionOptimistic,
-        data: blobSidecars.filter(({index}) => indicesSet.has(index)),
+        // Returnonly  all sidecars if no indices are specified, only the requested ones (identified by `indices`) otherwise
+        data: indicesSet.size == 0 ? blobSidecars : blobSidecars.filter(({index}) => indicesSet.has(index)),
       };
     },
   };

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -406,7 +406,7 @@ export function getBeaconBlockApi({
       await publishBlock(signedBlockOrContents, opts);
     },
 
-    async getBlobSidecars(blockId, indices = []) {
+    async getBlobSidecars(blockId, indices) {
       const {block, executionOptimistic} = await resolveBlockId(chain, blockId);
       const blockRoot = config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
 
@@ -419,10 +419,10 @@ export function getBeaconBlockApi({
         throw Error(`blobSidecars not found in db for slot=${block.message.slot} root=${toHexString(blockRoot)}`);
       }
 
-      const indicesSet = new Set(indices?.map((index) => parseInt(index)));
+      const indicesSet = new Set(indices);
       return {
         executionOptimistic,
-        // Returnonly  all sidecars if no indices are specified, only the requested ones (identified by `indices`) otherwise
+        // Return all sidecars if no indices are specified, only the requested ones (identified by `indices`) otherwise
         data: indicesSet.size == 0 ? blobSidecars : blobSidecars.filter(({index}) => indicesSet.has(index)),
       };
     },

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -421,8 +421,7 @@ export function getBeaconBlockApi({
 
       return {
         executionOptimistic,
-        // Return all sidecars if no indices are specified, only the requested ones (identified by `indices`) otherwise
-        data: indices.length == 0 ? blobSidecars : blobSidecars.filter(({index}) => indices.includes(index)),
+        data: indices ? blobSidecars.filter(({index}) => indices.includes(index)) : blobSidecars,
       };
     },
   };


### PR DESCRIPTION
**Motivation**

Make sure the `getBlobSidecars` endpoint is implemented as specified.

**Description**

`getBlobSidecars` doesn't support `indices` filtering, as specified. Add support for the missing query parameters and implement the associated logic.

Closes #6185
