### PR TITLE
fix: update beacon max-old-space-size to 8192

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,9 @@ FROM node:20-alpine
 WORKDIR /usr/app
 COPY --from=build_deps /usr/app .
 
-# NodeJS applications have a default memory limit of 2.5GB.
-# This limit is bit tight for a Prater node, it is recommended to raise the limit
+# NodeJS applications have a default memory limit of 4GB on most machines.
+# This limit is bit tight for a Holesky node, it is recommended to raise the limit
 # since memory may spike during certain network conditions.
-ENV NODE_OPTIONS=--max-old-space-size=4096
+ENV NODE_OPTIONS=--max-old-space-size=8192
 
 ENTRYPOINT ["node", "./packages/cli/bin/lodestar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /usr/app
 COPY --from=build_deps /usr/app .
 
 # NodeJS applications have a default memory limit of 4GB on most machines.
-# This limit is bit tight for a Holesky node, it is recommended to raise the limit
+# This limit is bit tight for a Mainnet node, it is recommended to raise the limit
 # since memory may spike during certain network conditions.
 ENV NODE_OPTIONS=--max-old-space-size=8192
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     # This limit is bit tight for a Prater node, it is recommended to raise the limit
     # since memory may spike during certain network conditions.
     environment:
-      NODE_OPTIONS: --max-old-space-size=4096
+      NODE_OPTIONS: --max-old-space-size=8192
 
   prometheus:
     build: docker/prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
       - "9000:9000" # P2P port
     #  - "9596:9596" # REST API port
     command: beacon --dataDir /data --rest --rest.address 0.0.0.0 --metrics --logFile /logs/beacon.log --logFileLevel debug --logFileDailyRotate 5
-    # NodeJS applications have a default memory limit of 2.5GB.
-    # This limit is bit tight for a Prater node, it is recommended to raise the limit
+    # NodeJS applications have a default memory limit of 4GB on most machines.
+    # This limit is bit tight for a Mainnet node, it is recommended to raise the limit
     # since memory may spike during certain network conditions.
     environment:
       NODE_OPTIONS: --max-old-space-size=8192

--- a/docs/pages/tools/flamegraphs.md
+++ b/docs/pages/tools/flamegraphs.md
@@ -18,7 +18,7 @@ Next we need to update the Lodestar service by modifying the start script. We ne
 ```sh
 node \
   --perf-basic-prof \
-  --max-old-space-size=4096 \
+  --max-old-space-size=8192 \
   /usr/src/lodestar/packages/cli/bin/lodestar \
   beacon \
   --rcConfig /home/devops/beacon/rcconfig.yml

--- a/lodestar
+++ b/lodestar
@@ -2,6 +2,6 @@
 
 # Convenience script to run the lodestar binary from built source
 #
-# ./lodestar.sh beacon --network prater
+# ./lodestar.sh beacon --network holesky
 
-node --trace-deprecation --max-old-space-size=4096 ./packages/cli/bin/lodestar.js "$@"
+node --trace-deprecation --max-old-space-size=8192 ./packages/cli/bin/lodestar.js "$@"

--- a/lodestar
+++ b/lodestar
@@ -2,6 +2,6 @@
 
 # Convenience script to run the lodestar binary from built source
 #
-# ./lodestar.sh beacon --network holesky
+# ./lodestar.sh beacon --network mainnet
 
 node --trace-deprecation --max-old-space-size=8192 ./packages/cli/bin/lodestar.js "$@"


### PR DESCRIPTION
**Motivation**

- https://github.com/ChainSafe/lodestar/issues/6137

**Description**

As discussed in the standup, we should increase our default heap memory limit. In the issue I initially proposed to use 6GB but from the call today it sounded like the consensus is rather to increase it to 8GB to prevent the node from crashing during non-finality or even potential DDoS attacks.

The downside of increasing the limit might be a slightly higher memory usage but it is not really clear how much impact this has. Increasing the limit might even be helpful to reduce GC overhead as the node should be consistently below the set limit now, even on Holesky.

This value can be revisited once https://github.com/ChainSafe/lodestar/issues/5968 is fully implemented and we are able to handle bad network conditions like non-finality without having a huge increase in memory.

**Note:** I did not update all occurrences of `--max-old-space-size` that we have in the code base as I think it is either not required or might be helpful if we get an error due to reaching the limit there.

Closes https://github.com/ChainSafe/lodestar/issues/6137
