### PR TITLE
fix: update beacon max-old-space-size to 8192

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,7 @@ WORKDIR /usr/app
 COPY --from=build_deps /usr/app .
 
 # NodeJS applications have a default memory limit of 2.5GB.
-# This limit is bit tight for a Prater node, it is recommended to raise the limit
-# since memory may spike during certain network conditions.
-ENV NODE_OPTIONS=--max-old-space-size=4096
+# This limit is too low for a Holesky node, it is required to raise the limit
+ENV NODE_OPTIONS=--max-old-space-size=8192
 
 ENTRYPOINT ["node", "./packages/cli/bin/lodestar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,9 @@ services:
     #  - "9596:9596" # REST API port
     command: beacon --dataDir /data --rest --rest.address 0.0.0.0 --metrics --logFile /logs/beacon.log --logFileLevel debug --logFileDailyRotate 5
     # NodeJS applications have a default memory limit of 2.5GB.
-    # This limit is bit tight for a Prater node, it is recommended to raise the limit
-    # since memory may spike during certain network conditions.
+    # This limit is too low for a Holesky node, it is required to raise the limit
     environment:
-      NODE_OPTIONS: --max-old-space-size=4096
+      NODE_OPTIONS: --max-old-space-size=8192
 
   prometheus:
     build: docker/prometheus

--- a/docs/pages/tools/flamegraphs.md
+++ b/docs/pages/tools/flamegraphs.md
@@ -18,7 +18,7 @@ Next we need to update the Lodestar service by modifying the start script. We ne
 ```sh
 node \
   --perf-basic-prof \
-  --max-old-space-size=4096 \
+  --max-old-space-size=8192 \
   /usr/src/lodestar/packages/cli/bin/lodestar \
   beacon \
   --rcConfig /home/devops/beacon/rcconfig.yml

--- a/lodestar
+++ b/lodestar
@@ -2,6 +2,6 @@
 
 # Convenience script to run the lodestar binary from built source
 #
-# ./lodestar.sh beacon --network prater
+# ./lodestar.sh beacon --network holesky
 
-node --trace-deprecation --max-old-space-size=4096 ./packages/cli/bin/lodestar.js "$@"
+node --trace-deprecation --max-old-space-size=8192 ./packages/cli/bin/lodestar.js "$@"


### PR DESCRIPTION
**Motivation**

With deneb coming up, and lodestar reaching close to its memory limit on mainnet, preemptively bumping the memory limit can mitigate some risk in the case of a nonfinality event.

We will be working on decreasing memory requirements in future releases and hopefully reverting this PR in time.

**Description**

Bump beacon max-old-space-size to 8192