### PR TITLE
feat: allow builder boost factor to be configured via proposer config file

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -287,7 +287,7 @@ function parseBroadcastValidation(broadcastValidation?: string): routes.beacon.B
   return broadcastValidation as routes.beacon.BroadcastValidation;
 }
 
-function parseBuilderBoostFactor(boostFactor?: string): bigint | undefined {
+export function parseBuilderBoostFactor(boostFactor?: string): bigint | undefined {
   if (boostFactor === undefined) return;
 
   if (!/^\d+$/.test(boostFactor)) {

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -22,6 +22,7 @@ import {GlobalArgs} from "../../options/index.js";
 import {YargsError, cleanOldLogFiles, getDefaultGraffiti, mkdir, parseLoggerArgs} from "../../util/index.js";
 import {onGracefulShutdown, parseFeeRecipient, parseProposerConfig} from "../../util/index.js";
 import {getVersionData} from "../../util/version.js";
+import {parseBuilderSelection, parseBuilderBoostFactor} from "../../util/proposerConfig.js";
 import {getAccountPaths, getValidatorPaths} from "./paths.js";
 import {IValidatorCliArgs, validatorMetricsDefaultOptions, validatorMonitoringDefaultOptions} from "./options.js";
 import {getSignersFromArgs} from "./signers/index.js";
@@ -254,24 +255,6 @@ function getProposerConfigFromArgs(
   return valProposerConfig;
 }
 
-function parseBuilderSelection(builderSelection?: string): routes.validator.BuilderSelection | undefined {
-  if (builderSelection) {
-    switch (builderSelection) {
-      case "maxprofit":
-        break;
-      case "builderalways":
-        break;
-      case "builderonly":
-        break;
-      case "executiononly":
-        break;
-      default:
-        throw new YargsError("Invalid input for builder selection, check help");
-    }
-  }
-  return builderSelection as routes.validator.BuilderSelection;
-}
-
 function parseBroadcastValidation(broadcastValidation?: string): routes.beacon.BroadcastValidation | undefined {
   if (broadcastValidation) {
     switch (broadcastValidation) {
@@ -285,14 +268,4 @@ function parseBroadcastValidation(broadcastValidation?: string): routes.beacon.B
   }
 
   return broadcastValidation as routes.beacon.BroadcastValidation;
-}
-
-export function parseBuilderBoostFactor(boostFactor?: string): bigint | undefined {
-  if (boostFactor === undefined) return;
-
-  if (!/^\d+$/.test(boostFactor)) {
-    throw new YargsError("Invalid input for builder boost factor, must be a valid number without decimals");
-  }
-
-  return BigInt(boostFactor);
 }

--- a/packages/cli/src/util/proposerConfig.ts
+++ b/packages/cli/src/util/proposerConfig.ts
@@ -20,6 +20,7 @@ type ProposerConfigFileSection = {
     // for js-yaml
     gas_limit?: number;
     selection?: routes.validator.BuilderSelection;
+    boost_factor?: bigint;
   };
 };
 
@@ -57,7 +58,7 @@ function parseProposerConfigSection(
   overrideConfig?: ProposerConfig
 ): ProposerConfig {
   const {graffiti, strict_fee_recipient_check, fee_recipient, builder} = proposerFileSection;
-  const {gas_limit, selection: builderSelection} = builder || {};
+  const {gas_limit, selection: builderSelection, boost_factor} = builder || {};
 
   if (graffiti !== undefined && typeof graffiti !== "string") {
     throw Error("graffiti is not 'string");
@@ -79,6 +80,9 @@ function parseProposerConfigSection(
       throw Error("(Number.isNaN(Number(gas_limit)) 2");
     }
   }
+  if (boost_factor !== undefined && typeof boost_factor !== "string") {
+    throw Error("boost_factor is not 'string");
+  }
 
   return {
     graffiti: overrideConfig?.graffiti ?? graffiti,
@@ -89,6 +93,8 @@ function parseProposerConfigSection(
     builder: {
       gasLimit: overrideConfig?.builder?.gasLimit ?? (gas_limit !== undefined ? Number(gas_limit) : undefined),
       selection: overrideConfig?.builder?.selection ?? builderSelection,
+      boostFactor:
+        overrideConfig?.builder?.boostFactor ?? (boost_factor !== undefined ? BigInt(boost_factor) : undefined),
     },
   };
 }

--- a/packages/cli/src/util/proposerConfig.ts
+++ b/packages/cli/src/util/proposerConfig.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import {ValidatorProposerConfig} from "@lodestar/validator";
 import {routes} from "@lodestar/api";
+import {parseBuilderBoostFactor} from "../cmds/validator/handler.js";
 
 import {parseFeeRecipient} from "./feeRecipient.js";
 
@@ -93,8 +94,7 @@ function parseProposerConfigSection(
     builder: {
       gasLimit: overrideConfig?.builder?.gasLimit ?? (gas_limit !== undefined ? Number(gas_limit) : undefined),
       selection: overrideConfig?.builder?.selection ?? builderSelection,
-      boostFactor:
-        overrideConfig?.builder?.boostFactor ?? (boost_factor !== undefined ? BigInt(boost_factor) : undefined),
+      boostFactor: overrideConfig?.builder?.boostFactor ?? parseBuilderBoostFactor(boost_factor),
     },
   };
 }

--- a/packages/cli/src/util/proposerConfig.ts
+++ b/packages/cli/src/util/proposerConfig.ts
@@ -4,11 +4,11 @@ import fs from "node:fs";
 import path from "node:path";
 import {ValidatorProposerConfig} from "@lodestar/validator";
 import {routes} from "@lodestar/api";
-import {parseBuilderBoostFactor} from "../cmds/validator/handler.js";
 
 import {parseFeeRecipient} from "./feeRecipient.js";
 
 import {readFile} from "./file.js";
+import {YargsError} from "./index.js";
 
 type ProposerConfig = ValidatorProposerConfig["defaultConfig"];
 
@@ -93,7 +93,7 @@ function parseProposerConfigSection(
     feeRecipient: overrideConfig?.feeRecipient ?? (fee_recipient ? parseFeeRecipient(fee_recipient) : undefined),
     builder: {
       gasLimit: overrideConfig?.builder?.gasLimit ?? (gas_limit !== undefined ? Number(gas_limit) : undefined),
-      selection: overrideConfig?.builder?.selection ?? builderSelection,
+      selection: overrideConfig?.builder?.selection ?? parseBuilderSelection(builderSelection),
       boostFactor: overrideConfig?.builder?.boostFactor ?? parseBuilderBoostFactor(boost_factor),
     },
   };
@@ -103,4 +103,32 @@ export function readProposerConfigDir(filepath: string, filename: string): Propo
   const proposerConfigStr = fs.readFileSync(path.join(filepath, filename), "utf8");
   const proposerConfigJSON = JSON.parse(proposerConfigStr) as ProposerConfigFileSection;
   return proposerConfigJSON;
+}
+
+export function parseBuilderSelection(builderSelection?: string): routes.validator.BuilderSelection | undefined {
+  if (builderSelection) {
+    switch (builderSelection) {
+      case "maxprofit":
+        break;
+      case "builderalways":
+        break;
+      case "builderonly":
+        break;
+      case "executiononly":
+        break;
+      default:
+        throw new YargsError("Invalid input for builder selection, check help");
+    }
+  }
+  return builderSelection as routes.validator.BuilderSelection;
+}
+
+export function parseBuilderBoostFactor(boostFactor?: string): bigint | undefined {
+  if (boostFactor === undefined) return;
+
+  if (!/^\d+$/.test(boostFactor)) {
+    throw new YargsError("Invalid input for builder boost factor, must be a valid number without decimals");
+  }
+
+  return BigInt(boostFactor);
 }

--- a/packages/cli/test/unit/validator/parseProposerConfig.test.ts
+++ b/packages/cli/test/unit/validator/parseProposerConfig.test.ts
@@ -17,6 +17,7 @@ const testValue = {
       builder: {
         gasLimit: 30000000,
         selection: undefined,
+        boostFactor: undefined,
       },
     },
     "0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d": {
@@ -26,6 +27,7 @@ const testValue = {
       builder: {
         gasLimit: 35000000,
         selection: routes.validator.BuilderSelection.MaxProfit,
+        boostFactor: BigInt(18446744073709551616),
       },
     },
   },
@@ -36,6 +38,7 @@ const testValue = {
     builder: {
       gasLimit: 30000000,
       selection: routes.validator.BuilderSelection.BuilderAlways,
+      boostFactor: BigInt(100),
     },
   },
 };

--- a/packages/cli/test/unit/validator/proposerConfigs/validData.yaml
+++ b/packages/cli/test/unit/validator/proposerConfigs/validData.yaml
@@ -10,6 +10,7 @@ proposer_config:
     builder:
       gas_limit: "35000000"
       selection: "maxprofit"
+      boost_factor: "18446744073709551616"
 default_config:
   graffiti: 'default graffiti'
   strict_fee_recipient_check: "true"
@@ -17,3 +18,4 @@ default_config:
   builder:
     gas_limit: "30000000"
     selection: "builderalways"
+    boost_factor: "100"


### PR DESCRIPTION
allows per validator configuration of boost factor for builder via static proposer config file

Closes https://github.com/ChainSafe/lodestar/issues/6304