### PR TITLE
fix: ignore forkchoice invalidations if latestValidHash not found

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -319,7 +319,7 @@ export async function verifyBlockExecutionPayload(
       const lvhResponse = {
         executionStatus,
         latestValidExecHash: execResult.latestValidHash,
-        invalidateFromBlockHash: toHexString(block.message.parentRoot),
+        invalidateFromParentBlockHash: toHexString(block.message.parentRoot),
       };
       const execError = new BlockError(block, {
         code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
@@ -416,7 +416,7 @@ function getSegmentErrorResponse(
       invalidSegmentLVH = {
         executionStatus: ExecutionStatus.Invalid,
         latestValidExecHash: lvhResponse.latestValidExecHash,
-        invalidateFromBlockHash: parentBlock.blockRoot,
+        invalidateFromParentBlockHash: parentBlock.blockRoot,
       };
     }
   }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -319,7 +319,7 @@ export async function verifyBlockExecutionPayload(
       const lvhResponse = {
         executionStatus,
         latestValidExecHash: execResult.latestValidHash,
-        invalidateFromParentBlockHash: toHexString(block.message.parentRoot),
+        invalidateFromParentBlockRoot: toHexString(block.message.parentRoot),
       };
       const execError = new BlockError(block, {
         code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
@@ -416,7 +416,7 @@ function getSegmentErrorResponse(
       invalidSegmentLVH = {
         executionStatus: ExecutionStatus.Invalid,
         latestValidExecHash: lvhResponse.latestValidExecHash,
-        invalidateFromParentBlockHash: parentBlock.blockRoot,
+        invalidateFromParentBlockRoot: parentBlock.blockRoot,
       };
     }
   }

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -29,7 +29,7 @@ export type LVHValidResponse = {
 export type LVHInvalidResponse = {
   executionStatus: ExecutionStatus.Invalid;
   latestValidExecHash: RootHex | null;
-  invalidateFromBlockHash: RootHex;
+  invalidateFromParentBlockHash: RootHex;
 };
 export type LVHExecResponse = LVHValidResponse | LVHInvalidResponse;
 

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -29,7 +29,7 @@ export type LVHValidResponse = {
 export type LVHInvalidResponse = {
   executionStatus: ExecutionStatus.Invalid;
   latestValidExecHash: RootHex | null;
-  invalidateFromParentBlockHash: RootHex;
+  invalidateFromParentBlockRoot: RootHex;
 };
 export type LVHExecResponse = LVHValidResponse | LVHInvalidResponse;
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -279,13 +279,13 @@ export class ProtoArray {
       // Mark chain ii) as Invalid if LVH is found and non null, else only invalidate invalid_payload
       // if its in fcU.
       //
-      const {invalidateFromBlockHash, latestValidExecHash} = execResponse;
-      const invalidateFromIndex = this.indices.get(invalidateFromBlockHash);
-      if (invalidateFromIndex === undefined) {
-        throw Error(`Unable to find invalidateFromBlockHash=${invalidateFromBlockHash} in forkChoice`);
+      const {invalidateFromParentBlockHash, latestValidExecHash} = execResponse;
+      const invalidateFromParentIndex = this.indices.get(invalidateFromParentBlockHash);
+      if (invalidateFromParentIndex === undefined) {
+        throw Error(`Unable to find invalidateFromParentBlockHash=${invalidateFromParentBlockHash} in forkChoice`);
       }
       const latestValidHashIndex =
-        latestValidExecHash !== null ? this.getNodeIndexFromLVH(latestValidExecHash, invalidateFromIndex) : null;
+        latestValidExecHash !== null ? this.getNodeIndexFromLVH(latestValidExecHash, invalidateFromParentIndex) : null;
       if (latestValidHashIndex === null) {
         /**
          *  If the LVH is null or not found, represented with latestValidHashIndex=undefined,
@@ -301,12 +301,12 @@ export class ProtoArray {
          *
          *   In such case for robustness, lets not process this invalidation into forkchoice
          *   as it might poision it since the invalidations can't be processed unless latestValidHashIndex
-         *   is known as invalidateFromIndex is the parent of the payload being verified which has not been
-         *   imported yet into forkchoice.
+         *   is known as invalidateFromParentIndex is the parent of the payload being verified which has not
+         *   been imported yet into forkchoice.
          */
         throw Error(`Unable to find latestValidExecHash=${latestValidExecHash} in the forkchoice`);
       } else {
-        this.propagateInValidExecutionStatusByIndex(invalidateFromIndex, latestValidHashIndex, currentSlot);
+        this.propagateInValidExecutionStatusByIndex(invalidateFromParentIndex, latestValidHashIndex, currentSlot);
       }
     }
   }
@@ -335,12 +335,12 @@ export class ProtoArray {
    */
 
   private propagateInValidExecutionStatusByIndex(
-    invalidateFromIndex: number,
+    invalidateFromParentIndex: number,
     latestValidHashIndex: number,
     currentSlot: Slot
   ): void {
-    // Pass 1: mark invalidateFromIndex and its parents invalid
-    let invalidateIndex: number | undefined = invalidateFromIndex;
+    // Pass 1: mark invalidateFromParentIndex and its parents invalid
+    let invalidateIndex: number | undefined = invalidateFromParentIndex;
     while (invalidateIndex !== undefined && invalidateIndex > latestValidHashIndex) {
       const invalidNode = this.invalidateNodeByIndex(invalidateIndex);
       invalidateIndex = invalidNode.parent;

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -299,10 +299,12 @@ export class ProtoArray {
          *     ii) lazy: that invalidation was result of simple check and the EL just
          *         responded with a bogus LVH
          *
-         *   So we will just invalidate the current payload and let future responses take care
-         *   to be as robust as possible.
+         *   In such case for robustness, lets not process this invalidation into forkchoice
+         *   as it might poision it since the invalidations can't be processed unless latestValidHashIndex
+         *   is known as invalidateFromIndex is the parent of the payload being verified which has not been
+         *   imported yet into forkchoice.
          */
-        this.invalidateNodeByIndex(invalidateFromIndex);
+        throw Error(`Unable to find latestValidExecHash=${latestValidExecHash} in the forkchoice`);
       } else {
         this.propagateInValidExecutionStatusByIndex(invalidateFromIndex, latestValidHashIndex, currentSlot);
       }

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -370,8 +370,8 @@ export class ProtoArray {
     });
   }
 
-  private getNodeIndexFromLVH(latestValidExecHash: RootHex, ancestorOfIndex: number): number | null {
-    let nodeIndex = this.nodes[ancestorOfIndex].parent;
+  private getNodeIndexFromLVH(latestValidExecHash: RootHex, ancestorFromIndex: number): number | null {
+    let nodeIndex: number | undefined = ancestorFromIndex;
     while (nodeIndex !== undefined && nodeIndex >= 0) {
       const node = this.getNodeFromIndex(nodeIndex);
       if (

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -149,7 +149,7 @@ describe("executionStatus / normal updates", () => {
     {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "2C",
-      invalidateFromBlockHash: "3C",
+      invalidateFromParentBlockHash: "3C",
     },
     3
   );
@@ -212,7 +212,7 @@ describe("executionStatus / normal updates", () => {
     {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "1A",
-      invalidateFromBlockHash: "3A",
+      invalidateFromParentBlockHash: "3A",
     },
     3
   );
@@ -259,7 +259,7 @@ describe("executionStatus / invalidate all postmerge chain", () => {
     {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-      invalidateFromBlockHash: "3B",
+      invalidateFromParentBlockHash: "3B",
     },
     3
   );
@@ -336,7 +336,7 @@ describe("executionStatus / poision forkchoice if we invalidate previous valid",
         {
           executionStatus: ExecutionStatus.Invalid,
           latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-          invalidateFromBlockHash: "3A",
+          invalidateFromParentBlockHash: "3A",
         },
         3
       )
@@ -373,7 +373,7 @@ describe("executionStatus / poision forkchoice if we validate previous invalid",
     {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-      invalidateFromBlockHash: "3B",
+      invalidateFromParentBlockHash: "3B",
     },
     3
   );

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -149,7 +149,7 @@ describe("executionStatus / normal updates", () => {
     {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "2C",
-      invalidateFromParentBlockHash: "3C",
+      invalidateFromParentBlockRoot: "3C",
     },
     3
   );
@@ -212,7 +212,7 @@ describe("executionStatus / normal updates", () => {
     {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "1A",
-      invalidateFromParentBlockHash: "3A",
+      invalidateFromParentBlockRoot: "3A",
     },
     3
   );
@@ -259,7 +259,7 @@ describe("executionStatus / invalidate all postmerge chain", () => {
     {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-      invalidateFromParentBlockHash: "3B",
+      invalidateFromParentBlockRoot: "3B",
     },
     3
   );
@@ -336,7 +336,7 @@ describe("executionStatus / poision forkchoice if we invalidate previous valid",
         {
           executionStatus: ExecutionStatus.Invalid,
           latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-          invalidateFromParentBlockHash: "3A",
+          invalidateFromParentBlockRoot: "3A",
         },
         3
       )
@@ -373,7 +373,7 @@ describe("executionStatus / poision forkchoice if we validate previous invalid",
     {
       executionStatus: ExecutionStatus.Invalid,
       latestValidExecHash: "0x0000000000000000000000000000000000000000000000000000000000000000",
-      invalidateFromParentBlockHash: "3B",
+      invalidateFromParentBlockRoot: "3B",
     },
     3
   );


### PR DESCRIPTION
Handle nullish LVH (latest valid hash), either null or not found, as if the LVH is "unknown" rather than the more strict interpretation that the LVH "doesn't exist".

In the case that the LVH "doesn't exist" it makes sense to mark the ancestor chain as invalid. This was the thinking behind our behavior befor this PR.

However, the [spec](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#payload-validation) says that the EL can return a `null` LVH if the EL "cannot determine" the LVH. In practice, a lazy (or buggy) EL may return `null` LVH, or even an LVH that doesn't exist in our fork choice.

To more robustly handle this case, as well as the case where the returned LVH cannot be found, we should simply throw and move on, rather than invalidating any ancestors.

If latest valid hash is not found (owing to odd LVH from the EL, `null` or otherwise), we shouldn't invalidate any blocks in the fork choice, since without latestValidHash, we might incorrectly be invalidating a (valid) parent block of the invalid payload being imported.

This was found based on an incident revolving around besu response:

ref:
 - https://discord.com/channels/593655374469660673/1200195786672185438/1200731583716528209
