### PR TITLE
feat: swap @chainsafe/bls to use napi blst implementation

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
-    "@chainsafe/bls": "7.1.3",
+    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
     "@chainsafe/blst": "^0.2.9",
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
-    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
+    "@chainsafe/bls": "ChainSafe/bls#e8bbc1a2dd803294c24a4db2ed2c9e05b714b92d",
     "@chainsafe/blst": "^0.2.9",
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
-    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
+    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
     "@chainsafe/blst": "^0.2.9",
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",

--- a/packages/beacon-node/src/chain/bls/index.ts
+++ b/packages/beacon-node/src/chain/bls/index.ts
@@ -1,4 +1,5 @@
 export type {IBlsVerifier} from "./interface.js";
 export type {BlsMultiThreadWorkerPoolModules, JobQueueItemType} from "./multithread/index.js";
+export {BlsPoolType} from "./multithread/types.js";
 export {BlsMultiThreadWorkerPool} from "./multithread/index.js";
 export {BlsSingleThreadVerifier} from "./singleThread.js";

--- a/packages/beacon-node/src/chain/bls/maybeBatch.ts
+++ b/packages/beacon-node/src/chain/bls/maybeBatch.ts
@@ -1,29 +1,18 @@
-import {CoordType, PublicKey} from "@chainsafe/bls/types";
 import bls from "@chainsafe/bls";
+import {WorkRequestSet} from "./multithread/types.js";
+import {deserializeSet} from "./multithread/utils.js";
 
 const MIN_SET_COUNT_TO_BATCH = 2;
-
-export type SignatureSetDeserialized = {
-  publicKey: PublicKey;
-  message: Uint8Array;
-  signature: Uint8Array;
-};
 
 /**
  * Verify signatures sets with batch verification or regular core verify depending on the set count.
  * Abstracted in a separate file to be consumed by the threaded pool and the main thread implementation.
  */
-export function verifySignatureSetsMaybeBatch(sets: SignatureSetDeserialized[]): boolean {
+export function verifySignatureSetsMaybeBatch(sets: WorkRequestSet[]): boolean {
   try {
+    const deserialized = sets.map(deserializeSet);
     if (sets.length >= MIN_SET_COUNT_TO_BATCH) {
-      return bls.Signature.verifyMultipleSignatures(
-        sets.map((s) => ({
-          publicKey: s.publicKey,
-          message: s.message,
-          // true = validate signature
-          signature: bls.Signature.fromBytes(s.signature, CoordType.affine, true),
-        }))
-      );
+      return bls.Signature.verifyMultipleSignatures(deserialized);
     }
 
     // .every on an empty array returns true
@@ -32,11 +21,32 @@ export function verifySignatureSetsMaybeBatch(sets: SignatureSetDeserialized[]):
     }
 
     // If too few signature sets verify them without batching
-    return sets.every((set) => {
-      // true = validate signature
-      const sig = bls.Signature.fromBytes(set.signature, CoordType.affine, true);
-      return sig.verify(set.publicKey, set.message);
-    });
+    return deserialized.every(({message, publicKey, signature}) => signature.verify(publicKey, message));
+  } catch (_) {
+    // A signature could be malformed, in that case fromBytes throws error
+    // blst-ts `verifyMultipleSignatures` is also a fallible operation if mul_n_aggregate fails
+    // see https://github.com/ChainSafe/blst-ts/blob/b1ba6333f664b08e5c50b2b0d18c4f079203962b/src/lib.ts#L291
+    return false;
+  }
+}
+
+export async function asyncVerifySignatureSetsMaybeBatch(sets: WorkRequestSet[]): Promise<boolean> {
+  try {
+    const deserialized = sets.map(deserializeSet);
+    if (sets.length >= MIN_SET_COUNT_TO_BATCH) {
+      return await bls.asyncVerifyMultipleSignatures(deserialized);
+    }
+
+    // .every on an empty array returns true
+    if (sets.length === 0) {
+      throw Error("Empty signature sets");
+    }
+
+    const promises = await Promise.all(
+      deserialized.map(({message, publicKey, signature}) => bls.asyncVerify(message, publicKey, signature))
+    );
+    // If too few signature sets verify them without batching
+    return promises.every((isValid) => isValid);
   } catch (_) {
     // A signature could be malformed, in that case fromBytes throws error
     // blst-ts `verifyMultipleSignatures` is also a fallible operation if mul_n_aggregate fails

--- a/packages/beacon-node/src/chain/bls/multithread/types.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/types.ts
@@ -1,4 +1,10 @@
+import {PublicKey, Signature} from "@chainsafe/bls/types";
 import {VerifySignatureOpts} from "../interface.js";
+
+export enum BlsPoolType {
+  workers = "workers",
+  libuv = "libuv",
+}
 
 export type WorkerData = {
   implementation: "herumi" | "blst-native";
@@ -11,9 +17,23 @@ export type SerializedSet = {
   signature: Uint8Array;
 };
 
+export type DeserializedKeySet = {
+  publicKey: PublicKey;
+  message: Uint8Array;
+  signature: Uint8Array;
+};
+
+export type DeserializedSet = {
+  publicKey: PublicKey;
+  message: Uint8Array;
+  signature: Signature;
+};
+
+export type WorkRequestSet = SerializedSet | DeserializedKeySet | DeserializedSet;
+
 export type BlsWorkReq = {
   opts: VerifySignatureOpts;
-  sets: SerializedSet[];
+  sets: WorkRequestSet[];
 };
 
 export enum WorkResultCode {
@@ -26,7 +46,7 @@ export type WorkResult<R> = {code: WorkResultCode.success; result: R} | WorkResu
 
 export type BlsWorkResult = {
   /** Ascending integer identifying the worker for metrics */
-  workerId: number;
+  workerId?: number;
   /** Total num of batches that had to be retried */
   batchRetries: number;
   /** Total num of sigs that have been successfully verified with batching */

--- a/packages/beacon-node/src/chain/bls/multithread/utils.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/utils.ts
@@ -1,3 +1,7 @@
+import bls from "@chainsafe/bls";
+import {CoordType, SignatureSet} from "@chainsafe/bls/types";
+import {WorkRequestSet, WorkResultError} from "./types.js";
+
 /**
  * Splits an array into an array of arrays maximizing the size of the smallest chunk.
  */
@@ -16,4 +20,23 @@ export function chunkifyMaximizeChunkSize<T>(arr: T[], minPerChunk: number): T[]
   }
 
   return arrArr;
+}
+
+export function deserializeSet(set: WorkRequestSet): SignatureSet {
+  return {
+    message: set.message,
+    publicKey:
+      set.publicKey instanceof bls.PublicKey ? set.publicKey : bls.PublicKey.fromBytes(set.publicKey, CoordType.affine),
+    // true = validate signature
+    signature:
+      set.signature instanceof bls.Signature
+        ? set.signature
+        : bls.Signature.fromBytes(set.signature, CoordType.affine, true),
+  };
+}
+
+export function getJobResultError(jobResult: WorkResultError | null, i: number): Error {
+  const workerError = jobResult ? Error(jobResult.error.message) : Error(`No jobResult for index ${i}`);
+  if (jobResult?.error?.stack) workerError.stack = jobResult.error.stack;
+  return workerError;
 }

--- a/packages/beacon-node/src/chain/bls/multithread/verifyManySignatureSets.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/verifyManySignatureSets.ts
@@ -1,0 +1,177 @@
+import {verifySignatureSetsMaybeBatch, asyncVerifySignatureSetsMaybeBatch} from "../maybeBatch.js";
+import {BlsWorkReq, WorkResult, WorkResultCode, BlsWorkResult, WorkRequestSet} from "./types.js";
+import {chunkifyMaximizeChunkSize} from "./utils.js";
+
+/**
+ * Split batchable sets in chunks of minimum size 16.
+ * Batch verify 16 has an aprox cost of 16+1. For 32 it's 32+1. After ~16 the additional savings are not significant.
+ * However, if a sig is invalid the whole batch has to be re-verified. So it's important to keep this number low.
+ * In normal network conditions almost all signatures received by the node are correct.
+ * After observing metrics this number can be reviewed
+ */
+const BATCHABLE_MIN_PER_CHUNK = 16;
+
+export function verifyManySignatureSets(workerId: number, workReqArr: BlsWorkReq[]): BlsWorkResult {
+  const [startSec, startNs] = process.hrtime();
+  const results: WorkResult<boolean>[] = [];
+  let batchRetries = 0;
+  let batchSigsSuccess = 0;
+
+  // If there are multiple batchable sets attempt batch verification with them
+  const batchableSets: {idx: number; sets: WorkRequestSet[]}[] = [];
+  const nonBatchableSets: {idx: number; sets: WorkRequestSet[]}[] = [];
+
+  // Split sets between batchable and non-batchable preserving their original index in the req array
+  for (let i = 0; i < workReqArr.length; i++) {
+    const workReq = workReqArr[i];
+
+    if (workReq.opts.batchable) {
+      batchableSets.push({idx: i, sets: workReq.sets});
+    } else {
+      nonBatchableSets.push({idx: i, sets: workReq.sets});
+    }
+  }
+
+  if (batchableSets.length > 0) {
+    // Split batchable into chunks of max size ~ 32 to minimize cost if a sig is wrong
+    const batchableChunks = chunkifyMaximizeChunkSize(batchableSets, BATCHABLE_MIN_PER_CHUNK);
+
+    for (const batchableChunk of batchableChunks) {
+      const allSets: WorkRequestSet[] = [];
+      for (const {sets} of batchableChunk) {
+        for (const set of sets) {
+          allSets.push(set);
+        }
+      }
+
+      try {
+        // Attempt to verify multiple sets at once
+        const isValid = verifySignatureSetsMaybeBatch(allSets);
+
+        if (isValid) {
+          // The entire batch is valid, return success to all
+          for (const {idx, sets} of batchableChunk) {
+            batchSigsSuccess += sets.length;
+            results[idx] = {code: WorkResultCode.success, result: isValid};
+          }
+        } else {
+          batchRetries++;
+          // Re-verify all sigs
+          nonBatchableSets.push(...batchableChunk);
+        }
+      } catch (e) {
+        // TODO: Ignore this error expecting that the same error will happen when re-verifying the set individually
+        //       It's not ideal but '@chainsafe/blst' may throw errors on some conditions
+        batchRetries++;
+        // Re-verify all sigs
+        nonBatchableSets.push(...batchableChunk);
+      }
+    }
+  }
+
+  for (const {idx, sets} of nonBatchableSets) {
+    try {
+      const isValid = verifySignatureSetsMaybeBatch(sets);
+      results[idx] = {code: WorkResultCode.success, result: isValid};
+    } catch (e) {
+      results[idx] = {code: WorkResultCode.error, error: e as Error};
+    }
+  }
+
+  const [workerEndSec, workerEndNs] = process.hrtime();
+
+  return {
+    workerId,
+    batchRetries,
+    batchSigsSuccess,
+    workerStartTime: [startSec, startNs],
+    workerEndTime: [workerEndSec, workerEndNs],
+    results,
+  };
+}
+
+export async function asyncVerifyManySignatureSets(workReqArr: BlsWorkReq[]): Promise<BlsWorkResult> {
+  const [startSec, startNs] = process.hrtime();
+  const results: WorkResult<boolean>[] = [];
+  let batchRetries = 0;
+  let batchSigsSuccess = 0;
+
+  // If there are multiple batchable sets attempt batch verification with them
+  const batchableSets: {idx: number; sets: WorkRequestSet[]}[] = [];
+  const nonBatchableSets: {idx: number; sets: WorkRequestSet[]}[] = [];
+
+  // Split sets between batchable and non-batchable preserving their original index in the req array
+  for (let i = 0; i < workReqArr.length; i++) {
+    const workReq = workReqArr[i];
+    const sets = workReq.sets;
+
+    if (workReq.opts.batchable) {
+      batchableSets.push({idx: i, sets});
+    } else {
+      nonBatchableSets.push({idx: i, sets});
+    }
+  }
+
+  const batchOperations: Promise<void>[] = [];
+  if (batchableSets.length > 0) {
+    // Split batchable into chunks of max size ~ 32 to minimize cost if a sig is wrong
+    const batchableChunks = chunkifyMaximizeChunkSize(batchableSets, BATCHABLE_MIN_PER_CHUNK);
+
+    for (const batchableChunk of batchableChunks) {
+      const allSets: WorkRequestSet[] = [];
+      for (const {sets} of batchableChunk) {
+        for (const set of sets) {
+          allSets.push(set);
+        }
+      }
+
+      // Attempt to verify multiple sets at once
+      batchOperations.push(
+        asyncVerifySignatureSetsMaybeBatch(allSets)
+          .then((isValid) => {
+            if (isValid) {
+              // The entire batch is valid, return success to all
+              for (const {idx, sets} of batchableChunk) {
+                batchSigsSuccess += sets.length;
+                results[idx] = {code: WorkResultCode.success, result: isValid};
+              }
+            } else {
+              batchRetries++;
+              // Re-verify all sigs
+              nonBatchableSets.push(...batchableChunk);
+            }
+          })
+          .catch(() => {
+            // TODO: Ignore this error expecting that the same error will happen when re-verifying the set individually
+            //       It's not ideal but '@chainsafe/blst' may throw errors on some conditions
+            batchRetries++;
+            // Re-verify all sigs
+            nonBatchableSets.push(...batchableChunk);
+          })
+      );
+    }
+  }
+  await Promise.all(batchOperations);
+
+  await Promise.all(
+    nonBatchableSets.map(({idx, sets}) =>
+      asyncVerifySignatureSetsMaybeBatch(sets)
+        .then((isValid) => {
+          results[idx] = {code: WorkResultCode.success, result: isValid};
+        })
+        .catch((e) => {
+          results[idx] = {code: WorkResultCode.error, error: e as Error};
+        })
+    )
+  );
+
+  const [workerEndSec, workerEndNs] = process.hrtime();
+
+  return {
+    batchRetries,
+    batchSigsSuccess,
+    workerStartTime: [startSec, startNs],
+    workerEndTime: [workerEndSec, workerEndNs],
+    results,
+  };
+}

--- a/packages/beacon-node/src/chain/bls/multithread/worker.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/worker.ts
@@ -1,20 +1,8 @@
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import worker from "node:worker_threads";
 import {expose} from "@chainsafe/threads/worker";
-import bls from "@chainsafe/bls";
-import {CoordType} from "@chainsafe/bls/types";
-import {verifySignatureSetsMaybeBatch, SignatureSetDeserialized} from "../maybeBatch.js";
-import {WorkerData, BlsWorkReq, WorkResult, WorkResultCode, SerializedSet, BlsWorkResult} from "./types.js";
-import {chunkifyMaximizeChunkSize} from "./utils.js";
-
-/**
- * Split batchable sets in chunks of minimum size 16.
- * Batch verify 16 has an aprox cost of 16+1. For 32 it's 32+1. After ~16 the additional savings are not significant.
- * However, if a sig is invalid the whole batch has to be re-verified. So it's important to keep this number low.
- * In normal network conditions almost all signatures received by the node are correct.
- * After observing metrics this number can be reviewed
- */
-const BATCHABLE_MIN_PER_CHUNK = 16;
+import {WorkerData, BlsWorkReq, BlsWorkResult} from "./types.js";
+import {verifyManySignatureSets} from "./verifyManySignatureSets.js";
 
 // Cloned data from instatiation
 const workerData = worker.workerData as WorkerData;
@@ -23,94 +11,6 @@ const {workerId} = workerData || {};
 
 expose({
   async verifyManySignatureSets(workReqArr: BlsWorkReq[]): Promise<BlsWorkResult> {
-    return verifyManySignatureSets(workReqArr);
+    return verifyManySignatureSets(workerId, workReqArr);
   },
 });
-
-function verifyManySignatureSets(workReqArr: BlsWorkReq[]): BlsWorkResult {
-  const [startSec, startNs] = process.hrtime();
-  const results: WorkResult<boolean>[] = [];
-  let batchRetries = 0;
-  let batchSigsSuccess = 0;
-
-  // If there are multiple batchable sets attempt batch verification with them
-  const batchableSets: {idx: number; sets: SignatureSetDeserialized[]}[] = [];
-  const nonBatchableSets: {idx: number; sets: SignatureSetDeserialized[]}[] = [];
-
-  // Split sets between batchable and non-batchable preserving their original index in the req array
-  for (let i = 0; i < workReqArr.length; i++) {
-    const workReq = workReqArr[i];
-    const sets = workReq.sets.map(deserializeSet);
-
-    if (workReq.opts.batchable) {
-      batchableSets.push({idx: i, sets});
-    } else {
-      nonBatchableSets.push({idx: i, sets});
-    }
-  }
-
-  if (batchableSets.length > 0) {
-    // Split batchable into chunks of max size ~ 32 to minimize cost if a sig is wrong
-    const batchableChunks = chunkifyMaximizeChunkSize(batchableSets, BATCHABLE_MIN_PER_CHUNK);
-
-    for (const batchableChunk of batchableChunks) {
-      const allSets: SignatureSetDeserialized[] = [];
-      for (const {sets} of batchableChunk) {
-        for (const set of sets) {
-          allSets.push(set);
-        }
-      }
-
-      try {
-        // Attempt to verify multiple sets at once
-        const isValid = verifySignatureSetsMaybeBatch(allSets);
-
-        if (isValid) {
-          // The entire batch is valid, return success to all
-          for (const {idx, sets} of batchableChunk) {
-            batchSigsSuccess += sets.length;
-            results[idx] = {code: WorkResultCode.success, result: isValid};
-          }
-        } else {
-          batchRetries++;
-          // Re-verify all sigs
-          nonBatchableSets.push(...batchableChunk);
-        }
-      } catch (e) {
-        // TODO: Ignore this error expecting that the same error will happen when re-verifying the set individually
-        //       It's not ideal but '@chainsafe/blst' may throw errors on some conditions
-        batchRetries++;
-        // Re-verify all sigs
-        nonBatchableSets.push(...batchableChunk);
-      }
-    }
-  }
-
-  for (const {idx, sets} of nonBatchableSets) {
-    try {
-      const isValid = verifySignatureSetsMaybeBatch(sets);
-      results[idx] = {code: WorkResultCode.success, result: isValid};
-    } catch (e) {
-      results[idx] = {code: WorkResultCode.error, error: e as Error};
-    }
-  }
-
-  const [workerEndSec, workerEndNs] = process.hrtime();
-
-  return {
-    workerId,
-    batchRetries,
-    batchSigsSuccess,
-    workerStartTime: [startSec, startNs],
-    workerEndTime: [workerEndSec, workerEndNs],
-    results,
-  };
-}
-
-function deserializeSet(set: SerializedSet): SignatureSetDeserialized {
-  return {
-    publicKey: bls.PublicKey.fromBytes(set.publicKey, CoordType.affine),
-    message: set.message,
-    signature: set.signature,
-  };
-}

--- a/packages/beacon-node/src/chain/bls/singleThread.ts
+++ b/packages/beacon-node/src/chain/bls/singleThread.ts
@@ -1,6 +1,5 @@
-import {PublicKey, Signature} from "@chainsafe/bls/types";
+import {CoordType, PublicKey, Signature} from "@chainsafe/bls/types";
 import bls from "@chainsafe/bls";
-import {CoordType} from "@chainsafe/blst";
 import {ISignatureSet} from "@lodestar/state-transition";
 import {Metrics} from "../../metrics/index.js";
 import {IBlsVerifier} from "./interface.js";

--- a/packages/beacon-node/src/chain/bls/utils.ts
+++ b/packages/beacon-node/src/chain/bls/utils.ts
@@ -10,6 +10,7 @@ export function getAggregatedPubkey(signatureSet: ISignatureSet, metrics: Metric
 
     case SignatureSetType.aggregate: {
       const timer = metrics?.blsThreadPool.pubkeysAggregationMainThreadDuration.startTimer();
+      metrics?.bls.aggregatedPubkeys.inc(signatureSet.pubkeys.length);
       const pubkeys = bls.PublicKey.aggregate(signatureSet.pubkeys);
       timer?.();
       return pubkeys;

--- a/packages/beacon-node/src/chain/index.ts
+++ b/packages/beacon-node/src/chain/index.ts
@@ -4,3 +4,4 @@ export * from "./chain.js";
 export * from "./forkChoice/index.js";
 export * from "./initState.js";
 export * from "./stateCache/index.js";
+export {BlsPoolType} from "./bls/index.js";

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -4,6 +4,7 @@ import {ArchiverOpts} from "./archiver/index.js";
 import {ForkChoiceOpts} from "./forkChoice/index.js";
 import {LightClientServerOpts} from "./lightClient/index.js";
 import {ShufflingCacheOpts} from "./shufflingCache.js";
+import {BlsPoolType} from "./bls/index.js";
 
 export type IChainOptions = BlockProcessOpts &
   PoolOpts &
@@ -12,6 +13,7 @@ export type IChainOptions = BlockProcessOpts &
   ArchiverOpts &
   ShufflingCacheOpts &
   LightClientServerOpts & {
+    blsPoolType?: BlsPoolType;
     blsVerifyAllMainThread?: boolean;
     blsVerifyAllMultiThread?: boolean;
     persistProducedBlocks?: boolean;
@@ -85,6 +87,7 @@ export type SeenCacheOpts = {
 };
 
 export const defaultChainOptions: IChainOptions = {
+  blsPoolType: BlsPoolType.libuv,
   blsVerifyAllMainThread: false,
   blsVerifyAllMultiThread: false,
   disableBlsBatchVerify: false,

--- a/packages/beacon-node/test/unit/chain/bls/bls.test.ts
+++ b/packages/beacon-node/test/unit/chain/bls/bls.test.ts
@@ -1,6 +1,5 @@
 import bls from "@chainsafe/bls";
-import {CoordType} from "@chainsafe/blst";
-import {PublicKey} from "@chainsafe/bls/types";
+import {PublicKey, CoordType} from "@chainsafe/bls/types";
 import {describe, it, expect, beforeEach} from "vitest";
 import {ISignatureSet, SignatureSetType} from "@lodestar/state-transition";
 import {BlsSingleThreadVerifier} from "../../../../src/chain/bls/singleThread.js";

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
-    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
+    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
     "@chainsafe/bls-keygen": "^0.4.0",
     "@chainsafe/bls-keystore": "^3.0.1",
     "@chainsafe/blst": "^0.2.9",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
   ],
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
-    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
+    "@chainsafe/bls": "ChainSafe/bls#e8bbc1a2dd803294c24a4db2ed2c9e05b714b92d",
     "@chainsafe/bls-keygen": "^0.4.0",
     "@chainsafe/bls-keystore": "^3.0.1",
     "@chainsafe/blst": "^0.2.9",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,8 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "7.1.3",
+    "@chainsafe/as-sha256": "^0.4.1",
+    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
     "@chainsafe/bls-keygen": "^0.4.0",
     "@chainsafe/bls-keystore": "^3.0.1",
     "@chainsafe/blst": "^0.2.9",

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -1,9 +1,11 @@
 import * as path from "node:path";
 import {defaultOptions, IBeaconNodeOptions} from "@lodestar/beacon-node";
+import {BlsPoolType} from "@lodestar/beacon-node/chain";
 import {CliCommandOptions} from "@lodestar/utils";
 
 export type ChainArgs = {
   suggestedFeeRecipient: string;
+  "chain.blsPoolType"?: BlsPoolType;
   "chain.blsVerifyAllMultiThread"?: boolean;
   "chain.blsVerifyAllMainThread"?: boolean;
   "chain.disableBlsBatchVerify"?: boolean;
@@ -32,6 +34,7 @@ export type ChainArgs = {
 export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
   return {
     suggestedFeeRecipient: args["suggestedFeeRecipient"],
+    blsPoolType: args["chain.blsPoolType"],
     blsVerifyAllMultiThread: args["chain.blsVerifyAllMultiThread"],
     blsVerifyAllMainThread: args["chain.blsVerifyAllMainThread"],
     disableBlsBatchVerify: args["chain.disableBlsBatchVerify"],
@@ -71,6 +74,14 @@ export const options: CliCommandOptions<ChainArgs> = {
     type: "boolean",
     defaultDescription: String(defaultOptions.chain.emitPayloadAttributes),
     description: "Flag to SSE emit execution `payloadAttributes` before every slot",
+    group: "chain",
+  },
+
+  "chain.blsPoolType": {
+    hidden: true,
+    choices: Object.values(BlsPoolType),
+    type: "string",
+    description: "Selects between using a Worker pool or using the native libuv thread pool for BLS verification",
     group: "chain",
   },
 

--- a/packages/cli/src/util/format.ts
+++ b/packages/cli/src/util/format.ts
@@ -1,5 +1,5 @@
 import bls from "@chainsafe/bls";
-import {CoordType} from "@chainsafe/blst";
+import {CoordType} from "@chainsafe/bls/types";
 import {fromHexString} from "@chainsafe/ssz";
 
 /**

--- a/packages/flare/package.json
+++ b/packages/flare/package.json
@@ -58,7 +58,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
+    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
     "@chainsafe/bls-keygen": "^0.4.0",
     "@lodestar/api": "^1.16.0",
     "@lodestar/config": "^1.16.0",

--- a/packages/flare/package.json
+++ b/packages/flare/package.json
@@ -58,7 +58,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
+    "@chainsafe/bls": "ChainSafe/bls#e8bbc1a2dd803294c24a4db2ed2c9e05b714b92d",
     "@chainsafe/bls-keygen": "^0.4.0",
     "@lodestar/api": "^1.16.0",
     "@lodestar/config": "^1.16.0",

--- a/packages/flare/package.json
+++ b/packages/flare/package.json
@@ -58,7 +58,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "7.1.3",
+    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
     "@chainsafe/bls-keygen": "^0.4.0",
     "@lodestar/api": "^1.16.0",
     "@lodestar/config": "^1.16.0",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -65,7 +65,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
+    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
     "@chainsafe/persistent-merkle-tree": "^0.6.1",
     "@chainsafe/ssz": "^0.14.0",
     "@lodestar/api": "^1.16.0",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -65,7 +65,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
+    "@chainsafe/bls": "ChainSafe/bls#e8bbc1a2dd803294c24a4db2ed2c9e05b714b92d",
     "@chainsafe/persistent-merkle-tree": "^0.6.1",
     "@chainsafe/ssz": "^0.14.0",
     "@lodestar/api": "^1.16.0",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -65,7 +65,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/bls": "7.1.3",
+    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
     "@chainsafe/persistent-merkle-tree": "^0.6.1",
     "@chainsafe/ssz": "^0.14.0",
     "@lodestar/api": "^1.16.0",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -59,7 +59,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
-    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
+    "@chainsafe/bls": "ChainSafe/bls#e8bbc1a2dd803294c24a4db2ed2c9e05b714b92d",
     "@chainsafe/blst": "^0.2.9",
     "@chainsafe/persistent-merkle-tree": "^0.6.1",
     "@chainsafe/persistent-ts": "^0.19.1",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -59,7 +59,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
-    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
+    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
     "@chainsafe/blst": "^0.2.9",
     "@chainsafe/persistent-merkle-tree": "^0.6.1",
     "@chainsafe/persistent-ts": "^0.19.1",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -59,7 +59,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
-    "@chainsafe/bls": "7.1.3",
+    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
     "@chainsafe/blst": "^0.2.9",
     "@chainsafe/persistent-merkle-tree": "^0.6.1",
     "@chainsafe/persistent-ts": "^0.19.1",

--- a/packages/state-transition/test/unit/cachedBeaconState.test.ts
+++ b/packages/state-transition/test/unit/cachedBeaconState.test.ts
@@ -174,7 +174,7 @@ describe("CachedBeaconState", () => {
         // confirm loadCachedBeaconState() result
         for (let i = 0; i < newCachedState.validators.length; i++) {
           expect(newCachedState.epochCtx.pubkey2index.get(newCachedState.validators.get(i).pubkey)).toBe(i);
-          expect(newCachedState.epochCtx.index2pubkey[i].toBytes()).toEqual(pubkeys[i]);
+          expect(Uint8Array.from(newCachedState.epochCtx.index2pubkey[i].toBytes())).toEqual(pubkeys[i]);
         }
       });
     }

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -57,7 +57,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
+    "@chainsafe/bls": "ChainSafe/bls#e8bbc1a2dd803294c24a4db2ed2c9e05b714b92d",
     "@chainsafe/bls-keystore": "^3.0.1",
     "@lodestar/params": "^1.16.0",
     "@lodestar/utils": "^1.16.0",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -57,7 +57,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
+    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
     "@chainsafe/bls-keystore": "^3.0.1",
     "@lodestar/params": "^1.16.0",
     "@lodestar/utils": "^1.16.0",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -57,7 +57,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "7.1.3",
+    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
     "@chainsafe/bls-keystore": "^3.0.1",
     "@lodestar/params": "^1.16.0",
     "@lodestar/utils": "^1.16.0",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -45,7 +45,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
+    "@chainsafe/bls": "ChainSafe/bls#e8bbc1a2dd803294c24a4db2ed2c9e05b714b92d",
     "@chainsafe/ssz": "^0.14.0",
     "@lodestar/api": "^1.16.0",
     "@lodestar/config": "^1.16.0",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -45,7 +45,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "7.1.3",
+    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
     "@chainsafe/ssz": "^0.14.0",
     "@lodestar/api": "^1.16.0",
     "@lodestar/config": "^1.16.0",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -45,7 +45,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/bls": "ChainSafe/bls#mkeil\/napi-blst",
+    "@chainsafe/bls": "ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b",
     "@chainsafe/ssz": "^0.14.0",
     "@lodestar/api": "^1.16.0",
     "@lodestar/config": "^1.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,7 +295,7 @@
 
 "@chainsafe/bls@ChainSafe/bls#mkeil/napi-blst":
   version "7.1.2"
-  resolved "https://codeload.github.com/ChainSafe/bls/tar.gz/102bff530c281c5e72e898045e6783af3481c7ab"
+  resolved "https://codeload.github.com/ChainSafe/bls/tar.gz/324d3d0313b7f5dccf496487a0aa22a968199773"
   dependencies:
     "@chainsafe/bls-keygen" "^0.4.0"
     bls-eth-wasm "^0.4.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,9 +293,9 @@
     ethereum-cryptography "^2.0.0"
     uuid "^9.0.0"
 
-"@chainsafe/bls@ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b":
+"@chainsafe/bls@ChainSafe/bls#e8bbc1a2dd803294c24a4db2ed2c9e05b714b92d":
   version "7.1.2"
-  resolved "https://codeload.github.com/ChainSafe/bls/tar.gz/e1db506be29e2c8d176844eba130628f83a9d72b"
+  resolved "https://codeload.github.com/ChainSafe/bls/tar.gz/e8bbc1a2dd803294c24a4db2ed2c9e05b714b92d"
   dependencies:
     "@chainsafe/bls-keygen" "^0.4.0"
     bls-eth-wasm "^0.4.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,7 +293,7 @@
     ethereum-cryptography "^2.0.0"
     uuid "^9.0.0"
 
-"@chainsafe/bls@ChainSafe/bls#mkeil/napi-blst":
+"@chainsafe/bls@ChainSafe/bls#e1db506be29e2c8d176844eba130628f83a9d72b":
   version "7.1.2"
   resolved "https://codeload.github.com/ChainSafe/bls/tar.gz/e1db506be29e2c8d176844eba130628f83a9d72b"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,7 +295,7 @@
 
 "@chainsafe/bls@ChainSafe/bls#mkeil/napi-blst":
   version "7.1.2"
-  resolved "https://codeload.github.com/ChainSafe/bls/tar.gz/324d3d0313b7f5dccf496487a0aa22a968199773"
+  resolved "https://codeload.github.com/ChainSafe/bls/tar.gz/e1db506be29e2c8d176844eba130628f83a9d72b"
   dependencies:
     "@chainsafe/bls-keygen" "^0.4.0"
     bls-eth-wasm "^0.4.8"
@@ -8634,7 +8634,7 @@ make-fetch-happen@^10.0.3:
     socks-proxy-agent "^7.0.0"
     ssri "^9.0.0"
 
-make-fetch-happen@^11.0.0, make-fetch-happen@^11.0.1, make-fetch-happen@^11.1.1:
+make-fetch-happen@^11.0.0, make-fetch-happen@^11.0.1, make-fetch-happen@^11.0.3, make-fetch-happen@^11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-11.1.1.tgz#85ceb98079584a9523d4bf71d32996e7e208549f"
   integrity sha512-rLWS7GCSTcEujjVBs2YqG7Y4643u8ucvCJeSRqiLYhesrDuzeuFIk37xREzAsfQaqzl8b9rNCE4m6J8tvX4Q8w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,13 +293,19 @@
     ethereum-cryptography "^2.0.0"
     uuid "^9.0.0"
 
-"@chainsafe/bls@7.1.3":
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/@chainsafe/bls/-/bls-7.1.3.tgz#8d488357b187a511cfb94c96eddc7aa9f62644a9"
-  integrity sha512-d21eYdWxDSb63n7nB+viD+3U4yJW8huiKRibJyh8X7btPLoXkvtmDf7geYyHVbKfLDgbuHkc+b48pfPQkUTLxA==
+"@chainsafe/bls@ChainSafe/bls#mkeil/napi-blst":
+  version "7.1.2"
+  resolved "https://codeload.github.com/ChainSafe/bls/tar.gz/842cf377d65c1090d9618e92f4625ad3ef82298a"
   dependencies:
     "@chainsafe/bls-keygen" "^0.4.0"
     bls-eth-wasm "^0.4.8"
+
+"@chainsafe/blst-ts@file:../../../../Library/Caches/Yarn/v6/npm-@chainsafe-bls-7.1.2/node_modules/@chainsafe/bls/temp-deps/blst-ts":
+  version "1.0.0"
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^6.1.0"
+    node-gyp "^9.3.1"
 
 "@chainsafe/blst@^0.2.9":
   version "0.2.9"
@@ -9227,6 +9233,11 @@ node-addon-api@^5.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
   integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
 
+node-addon-api@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
+  integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
+
 node-domexception@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
@@ -9281,7 +9292,23 @@ node-gyp@^8.4.0:
     tar "^6.1.2"
     which "^2.0.2"
 
-node-gyp@^9.0.0, node-gyp@^9.4.0:
+node-gyp@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-9.0.0.tgz#e1da2067427f3eb5bb56820cb62bc6b1e4bd2089"
+  integrity sha512-Ma6p4s+XCTPxCuAMrOA/IJRmVy16R8Sdhtwl4PrCr7IBlj4cPawF0vg/l7nOT1jPbuNS7lIRJpBSvVsXwEZuzw==
+  dependencies:
+    env-paths "^2.2.0"
+    glob "^7.1.4"
+    graceful-fs "^4.2.6"
+    make-fetch-happen "^10.0.3"
+    nopt "^5.0.0"
+    npmlog "^6.0.0"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.2"
+    which "^2.0.2"
+
+node-gyp@^9.3.1:
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-9.4.1.tgz#8a1023e0d6766ecb52764cc3a734b36ff275e185"
   integrity sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==
@@ -9291,6 +9318,23 @@ node-gyp@^9.0.0, node-gyp@^9.4.0:
     glob "^7.1.4"
     graceful-fs "^4.2.6"
     make-fetch-happen "^10.0.3"
+    nopt "^6.0.0"
+    npmlog "^6.0.0"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.2"
+    which "^2.0.2"
+
+node-gyp@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-9.4.0.tgz#2a7a91c7cba4eccfd95e949369f27c9ba704f369"
+  integrity sha512-dMXsYP6gc9rRbejLXmTbVRYjAHw7ppswsKyMxuxJxxOHzluIO1rGp9TOQgjFJ+2MCqcOcQTOPB/8Xwhr+7s4Eg==
+  dependencies:
+    env-paths "^2.2.0"
+    exponential-backoff "^3.1.1"
+    glob "^7.1.4"
+    graceful-fs "^4.2.6"
+    make-fetch-happen "^11.0.3"
     nopt "^6.0.0"
     npmlog "^6.0.0"
     rimraf "^3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,17 +295,10 @@
 
 "@chainsafe/bls@ChainSafe/bls#mkeil/napi-blst":
   version "7.1.2"
-  resolved "https://codeload.github.com/ChainSafe/bls/tar.gz/842cf377d65c1090d9618e92f4625ad3ef82298a"
+  resolved "https://codeload.github.com/ChainSafe/bls/tar.gz/102bff530c281c5e72e898045e6783af3481c7ab"
   dependencies:
     "@chainsafe/bls-keygen" "^0.4.0"
     bls-eth-wasm "^0.4.8"
-
-"@chainsafe/blst-ts@file:../../../../Library/Caches/Yarn/v6/npm-@chainsafe-bls-7.1.2/node_modules/@chainsafe/bls/temp-deps/blst-ts":
-  version "1.0.0"
-  dependencies:
-    bindings "^1.5.0"
-    node-addon-api "^6.1.0"
-    node-gyp "^9.3.1"
 
 "@chainsafe/blst@^0.2.9":
   version "0.2.9"
@@ -9233,11 +9226,6 @@ node-addon-api@^5.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
   integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
 
-node-addon-api@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-6.1.0.tgz#ac8470034e58e67d0c6f1204a18ae6995d9c0d76"
-  integrity sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==
-
 node-domexception@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
@@ -9302,23 +9290,6 @@ node-gyp@^9.0.0:
     graceful-fs "^4.2.6"
     make-fetch-happen "^10.0.3"
     nopt "^5.0.0"
-    npmlog "^6.0.0"
-    rimraf "^3.0.2"
-    semver "^7.3.5"
-    tar "^6.1.2"
-    which "^2.0.2"
-
-node-gyp@^9.3.1:
-  version "9.4.1"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-9.4.1.tgz#8a1023e0d6766ecb52764cc3a734b36ff275e185"
-  integrity sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==
-  dependencies:
-    env-paths "^2.2.0"
-    exponential-backoff "^3.1.1"
-    glob "^7.1.4"
-    graceful-fs "^4.2.6"
-    make-fetch-happen "^10.0.3"
-    nopt "^6.0.0"
     npmlog "^6.0.0"
     rimraf "^3.0.2"
     semver "^7.3.5"


### PR DESCRIPTION
**Motivation**

DRAFT PR.  Not ready for full review.

Branch is deployed to `feat2` to collect metrics

**Description**

Updated `@chainsafe/bls` to use the Napi version of `@chainsafe/blst`.  Added async codepaths to bls processing an added flag to allow selection of `Worker`pool or libuv threadpool.