### PR TITLE
feat: add down-scoring for metadata ssz size error

### DIFF
--- a/packages/beacon-node/src/network/reqresp/score.ts
+++ b/packages/beacon-node/src/network/reqresp/score.ts
@@ -24,6 +24,7 @@ export function onOutgoingReqRespError(e: RequestError, method: ReqRespMethod): 
   switch (e.type.code) {
     case RequestErrorCode.INVALID_REQUEST:
     case RequestErrorCode.INVALID_RESPONSE_SSZ:
+    case RequestErrorCode.SSZ_OVER_MAX_SIZE:
       return PeerAction.LowToleranceError;
 
     case RequestErrorCode.SERVER_ERROR:

--- a/packages/reqresp/src/request/errors.ts
+++ b/packages/reqresp/src/request/errors.ts
@@ -31,6 +31,8 @@ export enum RequestErrorCode {
   RESP_TIMEOUT = "REQUEST_ERROR_RESP_TIMEOUT",
   /** Request rate limited */
   REQUEST_RATE_LIMITED = "REQUEST_ERROR_RATE_LIMITED",
+  /** */
+  SSZ_OVER_MAX_SIZE = "SSZ_SNAPPY_ERROR_OVER_SSZ_MAX_SIZE",
 }
 
 type RequestErrorType =
@@ -47,7 +49,8 @@ type RequestErrorType =
   | {code: RequestErrorCode.EMPTY_RESPONSE}
   | {code: RequestErrorCode.TTFB_TIMEOUT}
   | {code: RequestErrorCode.RESP_TIMEOUT}
-  | {code: RequestErrorCode.REQUEST_RATE_LIMITED};
+  | {code: RequestErrorCode.REQUEST_RATE_LIMITED}
+  | {code: RequestErrorCode.SSZ_OVER_MAX_SIZE};
 
 export const REQUEST_ERROR_CLASS_NAME = "RequestError";
 


### PR DESCRIPTION
**Motivation**

Downscore peers that send invalid metadata.  Usually comes from `Unknown` client so possibly minority client in development that has bugs.

Resolves #6315

**Description**

Add `RequestErrorCode.SSZ_OVER_MAX_SIZE`
Apply `PeerAction.LowToleranceError` to limit to 5 instances before disconnect.

