### PR TITLE
fix: getAttestationsForBlock performance issue

### DIFF
--- a/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
@@ -1,0 +1,124 @@
+import {describe, it, afterEach} from "vitest";
+import {assert} from "chai";
+import {fromHexString} from "@chainsafe/ssz";
+import {ChainConfig} from "@lodestar/config";
+import {phase0} from "@lodestar/types";
+import {TimestampFormatCode} from "@lodestar/logger";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {routes} from "@lodestar/api";
+import {EventData, EventType} from "@lodestar/api/lib/beacon/routes/events.js";
+import {getDevBeaconNode} from "../../utils/node/beacon.js";
+import {waitForEvent} from "../../utils/events/resolver.js";
+import {getAndInitDevValidators} from "../../utils/node/validator.js";
+import {ChainEvent} from "../../../src/chain/index.js";
+import {connect, onPeerConnect} from "../../utils/network.js";
+import {testLogger, LogLevel, TestLoggerOpts} from "../../utils/logger.js";
+
+describe(
+  "sync / finalized sync",
+  function () {
+    const validatorCount = 8;
+    const testParams: Pick<ChainConfig, "SECONDS_PER_SLOT"> = {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      SECONDS_PER_SLOT: 2,
+    };
+
+    const afterEachCallbacks: (() => Promise<unknown> | void)[] = [];
+    afterEach(async () => {
+      while (afterEachCallbacks.length > 0) {
+        const callback = afterEachCallbacks.pop();
+        if (callback) await callback();
+      }
+    });
+
+    it("should do a finalized sync from another BN", async function () {
+      // single node at beginning, use main thread to verify bls
+      const genesisSlotsDelay = 4;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const genesisTime = Math.floor(Date.now() / 1000) + genesisSlotsDelay * testParams.SECONDS_PER_SLOT;
+
+      const testLoggerOpts: TestLoggerOpts = {
+        level: LogLevel.info,
+        timestampFormat: {
+          format: TimestampFormatCode.EpochSlot,
+          genesisTime,
+          slotsPerEpoch: SLOTS_PER_EPOCH,
+          secondsPerSlot: testParams.SECONDS_PER_SLOT,
+        },
+      };
+
+      const loggerNodeA = testLogger("FinalizedSync-Node-A", testLoggerOpts);
+      const loggerNodeB = testLogger("FinalizedSync-Node-B", testLoggerOpts);
+
+      const bn = await getDevBeaconNode({
+        params: testParams,
+        options: {
+          sync: {isSingleNode: true},
+          network: {allowPublishToZeroPeers: true, useWorker: false},
+          chain: {blsVerifyAllMainThread: true},
+        },
+        validatorCount,
+        genesisTime,
+        logger: loggerNodeA,
+      });
+
+      afterEachCallbacks.push(() => bn.close());
+
+      const {validators} = await getAndInitDevValidators({
+        node: bn,
+        logPrefix: "FinalizedSyncVc",
+        validatorsPerClient: validatorCount,
+        validatorClientCount: 1,
+        startIndex: 0,
+        useRestApi: false,
+        testLoggerOpts,
+      });
+
+      afterEachCallbacks.push(() => Promise.all(validators.map((validator) => validator.close())));
+
+      // stop beacon node after validators
+      afterEachCallbacks.push(() => bn.close());
+
+      await waitForEvent<phase0.Checkpoint>(bn.chain.emitter, ChainEvent.forkChoiceFinalized, 240000);
+      loggerNodeA.info("Node A emitted finalized checkpoint event");
+
+      const bn2 = await getDevBeaconNode({
+        params: testParams,
+        options: {
+          api: {rest: {enabled: false}},
+          network: {useWorker: false},
+          chain: {blsVerifyAllMainThread: true},
+        },
+        validatorCount,
+        genesisTime,
+        logger: loggerNodeB,
+      });
+      loggerNodeA.info("Node B created");
+
+      afterEachCallbacks.push(() => bn2.close());
+      afterEachCallbacks.push(() => bn2.close());
+
+      const headSummary = bn.chain.forkChoice.getHead();
+      const head = await bn.db.block.get(fromHexString(headSummary.blockRoot));
+      if (!head) throw Error("First beacon node has no head block");
+      const waitForSynced = waitForEvent<EventData[EventType.head]>(
+        bn2.chain.emitter,
+        routes.events.EventType.head,
+        100000,
+        ({block}) => block === headSummary.blockRoot
+      );
+
+      await Promise.all([connect(bn2.network, bn.network), onPeerConnect(bn2.network), onPeerConnect(bn.network)]);
+      loggerNodeA.info("Node A connected to Node B");
+
+      try {
+        await waitForSynced;
+        loggerNodeB.info("Node B synced to Node A, received head block", {slot: head.message.slot});
+      } catch (e) {
+        assert.fail("Failed to sync to other node in time");
+      }
+    });
+  },
+  // chain is finalized at slot 32, plus 4 slots for genesis delay => ~72s it should sync pretty fast
+  {timeout: 90000}
+);

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -1,13 +1,13 @@
 import {itBench} from "@dapplion/benchmark";
-import {expect} from "chai";
 import {BitArray, toHexString} from "@chainsafe/ssz";
 import {
   CachedBeaconStateAltair,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   getBlockRootAtSlot,
+  newFilledArray,
 } from "@lodestar/state-transition";
-import {HISTORICAL_ROOTS_LIMIT, SLOTS_PER_EPOCH, TIMELY_SOURCE_FLAG_INDEX} from "@lodestar/params";
+import {HISTORICAL_ROOTS_LIMIT, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ExecutionStatus, ForkChoice, IForkChoiceStore, ProtoArray} from "@lodestar/fork-choice";
 import {ssz} from "@lodestar/types";
 // eslint-disable-next-line import/no-relative-packages
@@ -15,33 +15,24 @@ import {generatePerfTestCachedStateAltair} from "../../../../../state-transition
 import {AggregatedAttestationPool} from "../../../../src/chain/opPools/aggregatedAttestationPool.js";
 import {computeAnchorCheckpoint} from "../../../../src/chain/initState.js";
 
-/** Same to https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.5/specs/altair/beacon-chain.md#has_flag */
-const TIMELY_SOURCE = 1 << TIMELY_SOURCE_FLAG_INDEX;
-function flagIsTimelySource(flag: number): boolean {
-  return (flag & TIMELY_SOURCE) === TIMELY_SOURCE;
-}
+const vc = 1_500_000;
 
-// Aug 11 2021
-// getAttestationsForBlock
-//     ✓ getAttestationsForBlock                                             4.410948 ops/s    226.7086 ms/op        -         64 runs   51.8 s
+/**
+ * Jan 2024
+ *   getAttestationsForBlock
+    ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      1.023498 ops/s    977.0415 ms/op        -         13 runs   27.2 s
+    ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       1.997617 ops/s    500.5965 ms/op        -         12 runs   15.2 s
+    ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      25.31025 ops/s    39.50969 ms/op        -         15 runs   31.3 s
+ */
 describe("getAttestationsForBlock", () => {
   let originalState: CachedBeaconStateAltair;
   let protoArray: ProtoArray;
   let forkchoice: ForkChoice;
 
   before(function () {
-    this.timeout(2 * 60 * 1000); // Generating the states for the first time is very slow
+    this.timeout(5 * 60 * 1000); // Generating the states for the first time is very slow
 
-    originalState = generatePerfTestCachedStateAltair({goBackOneSlot: true});
-
-    const previousEpochParticipationArr = originalState.previousEpochParticipation.getAll();
-    const currentEpochParticipationArr = originalState.currentEpochParticipation.getAll();
-
-    const numPreviousEpochParticipation = previousEpochParticipationArr.filter(flagIsTimelySource).length;
-    const numCurrentEpochParticipation = currentEpochParticipationArr.filter(flagIsTimelySource).length;
-
-    expect(numPreviousEpochParticipation).to.equal(250000, "Wrong numPreviousEpochParticipation");
-    expect(numCurrentEpochParticipation).to.equal(250000, "Wrong numCurrentEpochParticipation");
+    originalState = generatePerfTestCachedStateAltair({goBackOneSlot: true, vc});
 
     const {blockHeader, checkpoint} = computeAnchorCheckpoint(originalState.config, originalState);
     // TODO figure out why getBlockRootAtSlot(originalState, justifiedSlot) is not the same to justifiedCheckpoint.root
@@ -125,17 +116,71 @@ describe("getAttestationsForBlock", () => {
     forkchoice = new ForkChoice(originalState.config, fcStore, protoArray);
   });
 
-  itBench({
-    id: "getAttestationsForBlock",
-    beforeEach: () => getAggregatedAttestationPool(originalState),
-    fn: (pool) => {
-      // logger.info("Number of attestations in pool", pool.getAll().length);
-      pool.getAttestationsForBlock(forkchoice, originalState);
-    },
+  after(() => {
+    sandbox.restore();
   });
+
+  // notSeenSlots should be >=1
+  for (const [notSeenSlots, numMissedVotes, numBadVotes] of [
+    [1, 1, 10],
+    [1, 0, 4],
+    // best case scenario
+    [2, 1, 10],
+  ]) {
+    itBench({
+      id: `notSeenSlots=${notSeenSlots} numMissedVotes=${numMissedVotes} numBadVotes=${numBadVotes}`,
+      before: () => {
+        const state = originalState.clone();
+        // by default make all validators have full participation
+        const previousParticipation = newFilledArray(vc, 0b111);
+        // origState is at slot 0 of epoch so there is no currentParticipation
+        const currentParticipation = newFilledArray(vc, 0);
+        const currentEpoch = computeEpochAtSlot(state.slot);
+
+        for (let epochSlot = 0; epochSlot < SLOTS_PER_EPOCH; epochSlot++) {
+          const slot = state.slot - 1 - epochSlot;
+          const slotEpoch = computeEpochAtSlot(slot);
+          const committeeCount = state.epochCtx.getCommitteeCountPerSlot(slotEpoch);
+          for (let committeeIndex = 0; committeeIndex < committeeCount; committeeIndex++) {
+            const duties = state.epochCtx.getBeaconCommittee(slot, committeeIndex);
+            const participationArr = slotEpoch === currentEpoch ? currentParticipation : previousParticipation;
+            for (const [i, validatorIndex] of duties.entries()) {
+              // no attestation in previous slot is included yet as that's the spec
+              // for slot < previous slot, there is missed votes at every committee so the code need to keep looking for attestations because votes are not seen
+              if (slot >= state.slot - notSeenSlots || i < numMissedVotes) {
+                participationArr[validatorIndex] = 0;
+              }
+            }
+          }
+        }
+        state.previousEpochParticipation = ssz.altair.EpochParticipation.toViewDU(previousParticipation);
+        state.currentEpochParticipation = ssz.altair.EpochParticipation.toViewDU(currentParticipation);
+        state.commit();
+        return state;
+      },
+      beforeEach: (state) => {
+        const pool = getAggregatedAttestationPool(state, numMissedVotes, numBadVotes);
+        return {state, pool};
+      },
+      fn: ({state, pool}) => {
+        pool.getAttestationsForBlock(forkchoice, state);
+      },
+    });
+  }
 });
 
-function getAggregatedAttestationPool(state: CachedBeaconStateAltair): AggregatedAttestationPool {
+/**
+ * Create the pool with the following properties:
+ * - state: at slot n
+ * - all attestations at slot n - 1 are included in block but they are not enough
+ * - numMissedVotes: number of missed attestations/votes at every committee
+ * - numBadVotes: number of bad attestations/votes at every committee, they are not included in block because they are seen in the state
+ */
+function getAggregatedAttestationPool(
+  state: CachedBeaconStateAltair,
+  numMissedVotes: number,
+  numBadVotes: number
+): AggregatedAttestationPool {
   const pool = new AggregatedAttestationPool();
   for (let epochSlot = 0; epochSlot < SLOTS_PER_EPOCH; epochSlot++) {
     const slot = state.slot - 1 - epochSlot;
@@ -145,31 +190,82 @@ function getAggregatedAttestationPool(state: CachedBeaconStateAltair): Aggregate
       epoch: state.currentJustifiedCheckpoint.epoch,
       root: state.currentJustifiedCheckpoint.root,
     };
+
     for (let committeeIndex = 0; committeeIndex < committeeCount; committeeIndex++) {
-      const attestation = {
-        aggregationBits: BitArray.fromBitLen(64),
-        data: {
-          slot: slot,
-          index: committeeIndex,
-          beaconBlockRoot: getBlockRootAtSlot(state, slot),
-          source: sourceCheckpoint,
-          target: {
-            epoch,
-            root: getBlockRootAtSlot(state, computeStartSlotAtEpoch(epoch)),
-          },
+      const goodAttData = {
+        slot: slot,
+        index: committeeIndex,
+        beaconBlockRoot: getBlockRootAtSlot(state, slot),
+        source: sourceCheckpoint,
+        target: {
+          epoch,
+          root: getBlockRootAtSlot(state, computeStartSlotAtEpoch(epoch)),
         },
-        signature: Buffer.alloc(96),
       };
 
+      // for each good att data group, there are 4 versions of aggregation bits
       const committee = state.epochCtx.getBeaconCommittee(slot, committeeIndex);
-      // all attestation has full participation so getAttestationsForBlock() has to do a lot of filter
-      // aggregate_and_proof messages
-      pool.add(
-        attestation,
-        toHexString(ssz.phase0.AttestationData.hashTreeRoot(attestation.data)),
-        committee.length,
-        committee
-      );
+      const committeeSize = committee.length;
+      const goodVoteBits = BitArray.fromBoolArray(Array.from({length: committeeSize}, () => true));
+      // n first validators are totally missed
+      for (let i = 0; i < numMissedVotes; i++) {
+        goodVoteBits.set(i, false);
+      }
+      // n next validators vote for different att data
+      for (let i = 0; i < numBadVotes; i++) {
+        goodVoteBits.set(i + numMissedVotes, false);
+      }
+
+      // there are 4 different versions of the good vote
+      for (const endingBits of [0b1000, 0b0100, 0b0010, 0b0001]) {
+        const aggregationBits = goodVoteBits.clone();
+        aggregationBits.set(committeeSize - 1, Boolean(endingBits & 0b0001));
+        aggregationBits.set(committeeSize - 2, Boolean(endingBits & 0b0010));
+        aggregationBits.set(committeeSize - 3, Boolean(endingBits & 0b0100));
+        aggregationBits.set(committeeSize - 4, Boolean(endingBits & 0b1000));
+
+        const attestation = {
+          aggregationBits,
+          data: goodAttData,
+          signature: Buffer.alloc(96),
+        };
+        // all attestation has full participation so getAttestationsForBlock() has to do a lot of filter
+        // aggregate_and_proof messages
+        pool.add(
+          attestation,
+          toHexString(ssz.phase0.AttestationData.hashTreeRoot(attestation.data)),
+          committee.length,
+          committee
+        );
+      }
+
+      if (epochSlot === 0) {
+        // epochSlot === 0: attestations will be included in block but it's not enough for block
+        // epochSlot >= 1: no attestation will be included in block but the code still need to scan through them
+        continue;
+      }
+
+      const zeroAggregationBits = BitArray.fromBoolArray(Array.from({length: committeeSize}, () => false));
+
+      // n first validator votes for n different bad votes, that makes n different att data in the same slot/index
+      // these votes/attestations will NOT be included in block as they are seen in the state
+      for (let i = 0; i < numBadVotes; i++) {
+        const attData = ssz.phase0.AttestationData.clone(goodAttData);
+        attData.beaconBlockRoot = getBlockRootAtSlot(state, slot - i - 1);
+        const aggregationBits = zeroAggregationBits.clone();
+        aggregationBits.set(i + numMissedVotes, true);
+        const attestation = {
+          aggregationBits,
+          data: attData,
+          signature: Buffer.alloc(96),
+        };
+        pool.add(
+          attestation,
+          toHexString(ssz.phase0.AttestationData.hashTreeRoot(attestation.data)),
+          committee.length,
+          committee
+        );
+      }
     }
   }
   return pool;

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -19,10 +19,10 @@ const vc = 1_500_000;
 
 /**
  * Jan 2024
- *   getAttestationsForBlock
-    ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      9.152280 ops/s    109.2624 ms/op        -         48 runs   60.3 s
-    ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       9.173290 ops/s    109.0121 ms/op        -         52 runs   38.1 s
-    ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      18.10215 ops/s    55.24205 ms/op        -         18 runs   34.0 s   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      25.31025 ops/s    39.50969 ms/op        -         15 runs   31.3 s
+ *  getAttestationsForBlock vc=1500000
+ *   ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      10.48105 ops/s    95.41024 ms/op        -         12 runs   18.2 s
+ *   ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       11.44517 ops/s    87.37307 ms/op        -         13 runs   14.5 s
+ *   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      23.86144 ops/s    41.90862 ms/op        -         18 runs   34.1 s
  */
 describe(`getAttestationsForBlock vc=${vc}`, () => {
   let originalState: CachedBeaconStateAltair;
@@ -165,6 +165,9 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
   }
 });
 
+/**
+ * Fir dev purpose to find the best way to get not seen validators.
+ */
 describe.skip("getAttestationsForBlock aggregationBits intersectValues vs get", () => {
   const runsFactor = 1000;
   // As of Jan 2004

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -20,11 +20,11 @@ const vc = 1_500_000;
 /**
  * Jan 2024
  *   getAttestationsForBlock
-    ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      1.023498 ops/s    977.0415 ms/op        -         13 runs   27.2 s
-    ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       1.997617 ops/s    500.5965 ms/op        -         12 runs   15.2 s
-    ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      25.31025 ops/s    39.50969 ms/op        -         15 runs   31.3 s
+    ✔ notSeenSlots=1 numMissedVotes=1 numBadVotes=10                      9.152280 ops/s    109.2624 ms/op        -         48 runs   60.3 s
+    ✔ notSeenSlots=1 numMissedVotes=0 numBadVotes=4                       9.173290 ops/s    109.0121 ms/op        -         52 runs   38.1 s
+    ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      18.10215 ops/s    55.24205 ms/op        -         18 runs   34.0 s   ✔ notSeenSlots=2 numMissedVotes=1 numBadVotes=10                      25.31025 ops/s    39.50969 ms/op        -         15 runs   31.3 s
  */
-describe("getAttestationsForBlock", () => {
+describe(`getAttestationsForBlock vc=${vc}`, () => {
   let originalState: CachedBeaconStateAltair;
   let protoArray: ProtoArray;
   let forkchoice: ForkChoice;
@@ -116,15 +116,11 @@ describe("getAttestationsForBlock", () => {
     forkchoice = new ForkChoice(originalState.config, fcStore, protoArray);
   });
 
-  after(() => {
-    sandbox.restore();
-  });
-
   // notSeenSlots should be >=1
   for (const [notSeenSlots, numMissedVotes, numBadVotes] of [
     [1, 1, 10],
     [1, 0, 4],
-    // best case scenario
+    // notSeenSlots=2 means the previous block slot is missed
     [2, 1, 10],
   ]) {
     itBench({

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -2,11 +2,11 @@ import type {SecretKey} from "@chainsafe/bls/types";
 import bls from "@chainsafe/bls";
 import {BitArray, fromHexString, toHexString} from "@chainsafe/ssz";
 import {describe, it, expect, beforeEach, beforeAll, afterEach, vi} from "vitest";
-import {MockedForkChoice, getMockedForkChoice} from "../../../mocks/mockedBeaconChain.js";
 import {CachedBeaconStateAllForks, newFilledArray} from "@lodestar/state-transition";
 import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {ssz, phase0, ValidatorIndex} from "@lodestar/types";
+import {ssz, phase0} from "@lodestar/types";
 import {CachedBeaconStateAltair} from "@lodestar/state-transition/src/types.js";
+import {MockedForkChoice, getMockedForkChoice} from "../../../mocks/mockedBeaconChain.js";
 import {
   AggregatedAttestationPool,
   aggregateInto,

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -2,14 +2,15 @@ import type {SecretKey} from "@chainsafe/bls/types";
 import bls from "@chainsafe/bls";
 import {BitArray, fromHexString, toHexString} from "@chainsafe/ssz";
 import {describe, it, expect, beforeEach, beforeAll, afterEach, vi} from "vitest";
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {ssz, phase0} from "@lodestar/types";
 import {MockedForkChoice, getMockedForkChoice} from "../../../mocks/mockedBeaconChain.js";
+import {CachedBeaconStateAllForks, newFilledArray} from "@lodestar/state-transition";
+import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ssz, phase0, ValidatorIndex} from "@lodestar/types";
+import {CachedBeaconStateAltair} from "@lodestar/state-transition/src/types.js";
 import {
   AggregatedAttestationPool,
   aggregateInto,
-  getParticipationFn,
+  getNotSeenValidatorsFn,
   MatchingDataAttestationGroup,
 } from "../../../../src/chain/opPools/aggregatedAttestationPool.js";
 import {InsertOutcome} from "../../../../src/chain/opPools/types.js";
@@ -18,6 +19,7 @@ import {generateCachedAltairState} from "../../../utils/state.js";
 import {renderBitArray} from "../../../utils/render.js";
 import {ZERO_HASH_HEX} from "../../../../src/constants/constants.js";
 import {generateProtoBlock} from "../../../utils/typeGenerator.js";
+import {generateValidators} from "../../../utils/validator.js";
 
 /** Valid signature of random data to prevent BLS errors */
 const validSignature = fromHexString(
@@ -29,15 +31,43 @@ describe("AggregatedAttestationPool", function () {
   const altairForkEpoch = 2020;
   const currentEpoch = altairForkEpoch + 10;
   const currentSlot = SLOTS_PER_EPOCH * currentEpoch;
-  const originalState = generateCachedAltairState({slot: currentSlot + 1}, altairForkEpoch);
-  let altairState: CachedBeaconStateAllForks;
 
+  const committeeIndex = 0;
   const attestation = ssz.phase0.Attestation.defaultValue();
   attestation.data.slot = currentSlot;
+  attestation.data.index = committeeIndex;
   attestation.data.target.epoch = currentEpoch;
   const attDataRootHex = toHexString(ssz.phase0.AttestationData.hashTreeRoot(attestation.data));
 
-  const committee = [0, 1, 2, 3];
+  const validatorOpts = {
+    activationEpoch: 0,
+    effectiveBalance: MAX_EFFECTIVE_BALANCE,
+    withdrawableEpoch: FAR_FUTURE_EPOCH,
+    exitEpoch: FAR_FUTURE_EPOCH,
+  };
+  // this makes a committee length of 4
+  const vc = 64;
+  const committeeLength = 4;
+  const validators = generateValidators(vc, validatorOpts);
+  const originalState = generateCachedAltairState({slot: currentSlot + 1, validators}, altairForkEpoch);
+  const committee = originalState.epochCtx.getBeaconCommittee(currentSlot, committeeIndex);
+  expect(committee.length).toEqual(committeeLength);
+  // 0 and 1 in committee are fully participated
+  const epochParticipation = newFilledArray(vc, 0b111);
+  for (let i = 0; i < committeeLength; i++) {
+    if (i === 0 || i === 1) {
+      epochParticipation[committee[i]] = 0b111;
+    } else {
+      epochParticipation[committee[i]] = 0b000;
+    }
+  }
+  (originalState as CachedBeaconStateAltair).previousEpochParticipation =
+    ssz.altair.EpochParticipation.toViewDU(epochParticipation);
+  (originalState as CachedBeaconStateAltair).currentEpochParticipation =
+    ssz.altair.EpochParticipation.toViewDU(epochParticipation);
+  originalState.commit();
+  let altairState: CachedBeaconStateAllForks;
+
   let forkchoiceStub: MockedForkChoice;
 
   beforeEach(() => {
@@ -53,9 +83,13 @@ describe("AggregatedAttestationPool", function () {
   it("getParticipationFn", () => {
     // previousEpochParticipation and currentEpochParticipation is created inside generateCachedState
     // 0 and 1 are fully participated
-    const participationFn = getParticipationFn(altairState);
-    const participation = participationFn(currentEpoch, committee);
-    expect(participation).toEqual(new Set([0, 1]));
+    const notSeenValidatorFn = getNotSeenValidatorsFn(altairState);
+    const participation = notSeenValidatorFn(currentEpoch, committee);
+    // seen attesting indices are 0, 1 => not seen are 2, 3
+    expect(participation).toEqual({
+      validatorIndices: [null, null, committee[2], committee[3]],
+      attestingIndices: new Set([2, 3]),
+    });
   });
 
   // previousEpochParticipation and currentEpochParticipation is created inside generateCachedState
@@ -68,7 +102,7 @@ describe("AggregatedAttestationPool", function () {
 
   for (const {name, attestingBits, isReturned} of testCases) {
     it(name, function () {
-      const aggregationBits = new BitArray(new Uint8Array(attestingBits), 8);
+      const aggregationBits = new BitArray(new Uint8Array(attestingBits), committeeLength);
       pool.add(
         {...attestation, aggregationBits},
         attDataRootHex,
@@ -180,13 +214,14 @@ describe("MatchingDataAttestationGroup.add()", () => {
 describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
   const testCases: {
     id: string;
-    seenAttestingBits: number[];
+    notSeenAttestingBits: number[];
     attestationsToAdd: {bits: number[]; notSeenAttesterCount: number}[];
   }[] = [
     // Note: attestationsToAdd MUST intersect in order to not be aggregated and distort the results
     {
       id: "All have attested",
-      seenAttestingBits: [0b11111111],
+      // same to seenAttestingBits: [0b11111111],
+      notSeenAttestingBits: [0b00000000],
       attestationsToAdd: [
         {bits: [0b11111110], notSeenAttesterCount: 0},
         {bits: [0b00000011], notSeenAttesterCount: 0},
@@ -194,7 +229,8 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
     },
     {
       id: "Some have attested",
-      seenAttestingBits: [0b11110001], // equals to indexes [ 0, 4, 5, 6, 7 ]
+      // same to seenAttestingBits: [0b11110001]
+      notSeenAttestingBits: [0b00001110],
       attestationsToAdd: [
         {bits: [0b11111110], notSeenAttesterCount: 3},
         {bits: [0b00000011], notSeenAttesterCount: 1},
@@ -202,7 +238,8 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
     },
     {
       id: "Non have attested",
-      seenAttestingBits: [0b00000000],
+      // same to seenAttestingBits: [0b00000000],
+      notSeenAttestingBits: [0b11111111],
       attestationsToAdd: [
         {bits: [0b11111110], notSeenAttesterCount: 7},
         {bits: [0b00000011], notSeenAttesterCount: 2},
@@ -213,7 +250,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
   const attestationData = ssz.phase0.AttestationData.defaultValue();
   const committee = linspace(0, 7);
 
-  for (const {id, seenAttestingBits, attestationsToAdd} of testCases) {
+  for (const {id, notSeenAttestingBits, attestationsToAdd} of testCases) {
     it(id, () => {
       const attestationGroup = new MatchingDataAttestationGroup(committee, attestationData);
 
@@ -229,8 +266,19 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
         attestationGroup.add({attestation, trueBitsCount: attestation.aggregationBits.getTrueBitIndexes().length});
       }
 
-      const indices = new BitArray(new Uint8Array(seenAttestingBits), 8).intersectValues(committee);
-      const attestationsForBlock = attestationGroup.getAttestationsForBlock(new Set(indices));
+      const notSeenAggBits = new BitArray(new Uint8Array(notSeenAttestingBits), 8);
+      const notSeenValidatorIndices: (ValidatorIndex | null)[] = [];
+      const notSeenAttestingIndices = new Set<number>();
+      for (let i = 0; i < committee.length; i++) {
+        notSeenValidatorIndices.push(notSeenAggBits.get(i) ? committee[i] : null);
+        if (notSeenAggBits.get(i)) {
+          notSeenAttestingIndices.add(i);
+        }
+      }
+      const attestationsForBlock = attestationGroup.getAttestationsForBlock(
+        notSeenValidatorIndices,
+        notSeenAttestingIndices
+      );
 
       for (const [i, {notSeenAttesterCount}] of attestationsToAdd.entries()) {
         const attestation = attestationsForBlock.find((a) => a.attestation === attestations[i]);

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -86,10 +86,13 @@ describe("AggregatedAttestationPool", function () {
     const notSeenValidatorFn = getNotSeenValidatorsFn(altairState);
     const participation = notSeenValidatorFn(currentEpoch, committee);
     // seen attesting indices are 0, 1 => not seen are 2, 3
-    expect(participation).toEqual({
-      validatorIndices: [null, null, committee[2], committee[3]],
-      attestingIndices: new Set([2, 3]),
-    });
+    expect(participation).toEqual(
+      // {
+      // validatorIndices: [null, null, committee[2], committee[3]],
+      // attestingIndices: new Set([2, 3]),
+      // }
+      new Set([2, 3])
+    );
   });
 
   // previousEpochParticipation and currentEpochParticipation is created inside generateCachedState
@@ -267,16 +270,16 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       }
 
       const notSeenAggBits = new BitArray(new Uint8Array(notSeenAttestingBits), 8);
-      const notSeenValidatorIndices: (ValidatorIndex | null)[] = [];
+      // const notSeenValidatorIndices: (ValidatorIndex | null)[] = [];
       const notSeenAttestingIndices = new Set<number>();
       for (let i = 0; i < committee.length; i++) {
-        notSeenValidatorIndices.push(notSeenAggBits.get(i) ? committee[i] : null);
+        // notSeenValidatorIndices.push(notSeenAggBits.get(i) ? committee[i] : null);
         if (notSeenAggBits.get(i)) {
           notSeenAttestingIndices.add(i);
         }
       }
       const attestationsForBlock = attestationGroup.getAttestationsForBlock(
-        notSeenValidatorIndices,
+        // notSeenValidatorIndices,
         notSeenAttestingIndices
       );
 


### PR DESCRIPTION
**Motivation**

Get aggregated attestations for block production may take up to >1s, this PR improve it

**Description**

- Was able to reproduce the issue, it took ~1s in the benchmark, after all it takes ~100ms in the worse case
- Some improvements:
  - Group attestations not just by attestation data but by `slot & index` so that we can get committee once and we run the participation function way less. This is possible thanks to the attestation validation against the state
  - The participation function was changed from `seenAttestingIndices` to `notSeenAttestingIndices` which makes the logic simpler
  - The attestation validation function is cached by `beaconBlockRoot + targetEpoch`
  - Ignore attestation data if the max possible score is even less than the lowest score for included attestations

Closes #6334