### PR TITLE
fix: skip useWorker mode for gossipsub e2e tests

### DIFF
--- a/packages/beacon-node/test/e2e/network/gossipsub.test.ts
+++ b/packages/beacon-node/test/e2e/network/gossipsub.test.ts
@@ -16,7 +16,12 @@ describe(
   {timeout: 3000}
 );
 
-describe(
+/**
+ * This is nice to have to investigate networking issue in local environment.
+ * Since we use vitest to run tests in parallel, including this causes the test to be unstable.
+ * See https://github.com/ChainSafe/lodestar/issues/6358
+ */
+describe.skip(
   "gossipsub / worker",
   function () {
     runTests({useWorker: true});


### PR DESCRIPTION
**Motivation**

I see a lot of failed gossipsub e2e tests since we switched to vitest, and it always happen with `useWorker=true`

**Description**

Skipping tests with `useWorker=true` in CI, while we leave that for local tests if we find any issues with it in the future
- Given vitest also runs in worker thread, it caused the test to be unstable in CI environment
- Gossipsub logic does not really depend on this `useWorker` flag

cc @wemeetagain 

part of #6358
