### PR TITLE
feat: add builder selection executionalways

### DIFF
--- a/docs/pages/validator-management/vc-configuration.md
+++ b/docs/pages/validator-management/vc-configuration.md
@@ -97,6 +97,7 @@ With produceBlockV3 (enabled automatically after the Deneb hard fork), the `--bu
 With Lodestar's `--builder.selection` validator options, you can select:
 
 - `maxprofit`: Default setting for Lodestar set at `--builder.boostFactor=100`. This default setting will always choose the more profitable block. Using this option, you may customize your `--builder.boostFactor` to your preference. Examples of its usage are below.
+- `executionalways`: An alias of `--builder.boostFactor=0`, which will select the local execution block, unless it fails to produce due to an error or a delay in the response from the execution client.
 - `executiononly`: Beacon node will be requested to produce local execution block even if builder relays are configured. This option will always select the local execution block and will error if it couldn't produce one.
 - `builderalways`: An alias of `--builder.boostFactor=18446744073709551615` (2**64 - 1), which will select the builder block, unless the builder block fails to produce. The builder block may fail to produce if it's not available, not timely or there is an indication of censorship via `shouldOverrideBuilder` from the execution payload response.
 - `builderonly`: Generally used for distributed validators (DVs). No execution block production will be triggered. Therefore, if a builder block is not produced, the API will fail and _no block will be produced_.

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -43,6 +43,7 @@ import {ExecutionOptimistic} from "./beacon/block.js";
 
 export enum BuilderSelection {
   BuilderAlways = "builderalways",
+  ExecutionAlways = "executionalways",
   MaxProfit = "maxprofit",
   /** Only activate builder flow for DVT block proposal protocols */
   BuilderOnly = "builderonly",

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -612,6 +612,7 @@ export function getValidatorApi({
             break;
           }
 
+          case routes.validator.BuilderSelection.ExecutionAlways:
           case routes.validator.BuilderSelection.ExecutionOnly: {
             executionPayloadSource = ProducedBlockSource.engine;
             break;

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -49,6 +49,12 @@ describe("api/validator - produceBlockV3", function () {
     [routes.validator.BuilderSelection.BuilderAlways, 1, 1, 1, true, "engine"],
     [routes.validator.BuilderSelection.BuilderAlways, 1, null, 1, true, "builder"],
 
+    [routes.validator.BuilderSelection.ExecutionAlways, 2, 1, 0, false, "engine"],
+    [routes.validator.BuilderSelection.ExecutionAlways, 0, 1, 1, false, "engine"],
+    [routes.validator.BuilderSelection.ExecutionAlways, 0, null, 0, false, "builder"],
+    [routes.validator.BuilderSelection.ExecutionAlways, null, 0, 1, false, "engine"],
+    [routes.validator.BuilderSelection.ExecutionAlways, 1, 1, 1, true, "engine"],
+
     [routes.validator.BuilderSelection.BuilderOnly, 0, 2, 0, false, "builder"],
     [routes.validator.BuilderSelection.ExecutionOnly, 2, 0, 1, false, "engine"],
     [routes.validator.BuilderSelection.BuilderOnly, 1, 1, 0, true, "builder"],

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -242,7 +242,8 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
 
   "builder.selection": {
     type: "string",
-    description: "Builder block selection strategy `maxprofit`, `builderalways`, `builderonly` or `executiononly`",
+    description:
+      "Builder block selection strategy `maxprofit`, `builderalways`, `builderonly`, `executionalways`, or `executiononly`",
     defaultDescription: `${defaultOptions.builderSelection}`,
     group: "builder",
   },

--- a/packages/cli/src/util/proposerConfig.ts
+++ b/packages/cli/src/util/proposerConfig.ts
@@ -8,7 +8,6 @@ import {routes} from "@lodestar/api";
 import {parseFeeRecipient} from "./feeRecipient.js";
 
 import {readFile} from "./file.js";
-import {YargsError} from "./index.js";
 
 type ProposerConfig = ValidatorProposerConfig["defaultConfig"];
 
@@ -114,10 +113,12 @@ export function parseBuilderSelection(builderSelection?: string): routes.validat
         break;
       case "builderonly":
         break;
+      case "executionalways":
+        break;
       case "executiononly":
         break;
       default:
-        throw new YargsError("Invalid input for builder selection, check help");
+        throw Error("Invalid input for builder selection, check help");
     }
   }
   return builderSelection as routes.validator.BuilderSelection;
@@ -127,7 +128,7 @@ export function parseBuilderBoostFactor(boostFactor?: string): bigint | undefine
   if (boostFactor === undefined) return;
 
   if (!/^\d+$/.test(boostFactor)) {
-    throw new YargsError("Invalid input for builder boost factor, must be a valid number without decimals");
+    throw Error("Invalid input for builder boost factor, must be a valid number without decimals");
   }
 
   return BigInt(boostFactor);

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -277,6 +277,7 @@ export class ValidatorStore {
         boostFactor = MAX_BUILDER_BOOST_FACTOR;
         break;
 
+      case routes.validator.BuilderSelection.ExecutionAlways:
       case routes.validator.BuilderSelection.ExecutionOnly:
         boostFactor = BigInt(0);
     }


### PR DESCRIPTION
**Motivation**

- https://github.com/ChainSafe/lodestar/issues/6305

**Description**

Adds builder selection `--builder.selection=executionalways` as an alias of `--builder.boostFactor=0`

Closes https://github.com/ChainSafe/lodestar/issues/6305


