### PR TITLE
fix: log errors setting agent version as debug

### DIFF
--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -620,7 +620,10 @@ export class PeerManager {
       },
       {retries: 3, retryDelay: 1000}
     ).catch((err) => {
-      this.logger.error("Error setting agentVersion for the peer", {peerId: peerData.peerId.toString()}, err);
+      // Ignore Not Found error if peer was disconnected
+      if (err instanceof Error && !err.message.includes("NotFound")) {
+        this.logger.error("Error setting agentVersion for the peer", {peerId: peerData.peerId.toString()}, err);
+      }
     });
   };
 

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -619,13 +619,8 @@ export class PeerManager {
         }
       },
       {retries: 3, retryDelay: 1000}
-    ).catch((err: Error) => {
-      if (err.message.includes("NotFound")) {
-        return this.logger.debug("Peer not found when attempting to set agentVersion", {
-          peerId: peerData.peerId.toString(),
-        });
-      }
-      this.logger.error("Error setting agentVersion for the peer", {peerId: peerData.peerId.toString()}, err);
+    ).catch((err) => {
+      this.logger.debug("Error setting agentVersion for the peer", {peerId: peerData.peerId.toString()}, err);
     });
   };
 

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -619,11 +619,13 @@ export class PeerManager {
         }
       },
       {retries: 3, retryDelay: 1000}
-    ).catch((err) => {
-      // Ignore Not Found error if peer was disconnected
-      if (err instanceof Error && !err.message.includes("NotFound")) {
-        this.logger.error("Error setting agentVersion for the peer", {peerId: peerData.peerId.toString()}, err);
+    ).catch((err: Error) => {
+      if (err.message.includes("NotFound")) {
+        return this.logger.debug("Peer not found when attempting to set agentVersion", {
+          peerId: peerData.peerId.toString(),
+        });
       }
+      this.logger.error("Error setting agentVersion for the peer", {peerId: peerData.peerId.toString()}, err);
     });
   };
 


### PR DESCRIPTION
**Motivation**

Seeing an error when attempting to setAgent for a peer that is no longer in the peerStore

@wemeetagain @tuyennhv Do you think this error should be skipped because its just a result of peer churn and the info already being removed from the DB or do you think its worth making it a `debug` statement?

Resolves https://github.com/ChainSafe/lodestar/issues/6365

**Description**

Log errors setting agent version as debug

~~Add check for leveldb `NotFound` error and do not log as its an anticipated error.~~

~~**NOTE:** Double checking the leveldb code where this originates to see if there is a better way to filter for the error.  Will move to readyToReveiw once complete~~