### PR TITLE
docs: update link to erigon jwt setup

### DIFF
--- a/docs/pages/getting-started/starting-a-node.md
+++ b/docs/pages/getting-started/starting-a-node.md
@@ -47,7 +47,7 @@ Use the `--JsonRpc.JwtSecretFile /data/jwtsecret` flag to configure the secret. 
 Use the `--engine-jwt-secret=<FILE>` flag to configure the secret. Use their documentation [here](https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/#engine-jwt-secret).
 
 **For Erigon:**
-Use the `--authrpc.jwtsecret` flag to configure the secret. Use their documentation [here](https://github.com/ledgerwatch/erigon#authentication-api).
+Use the `--authrpc.jwtsecret` flag to configure the secret. Use their documentation [here](https://github.com/ledgerwatch/erigon?tab=readme-ov-file#beacon-chain-consensus-layer).
 
 ## Run a beacon node
 


### PR DESCRIPTION
**Motivation**

Fix a documentation link.

**Description**

The existing link to erigon no longer goes to the correct section. This commit updates it.

**Steps to test or reproduce**

Try using the existing link and note that it goes to the top of the main page for erigon's repo. Thew new proposed link goes to the correct section in the readme.