### PR TITLE
fix: add block_id schema validation to getBlobSidecars

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -367,6 +367,7 @@ export function getReqSerializers(config: ChainForkConfig): ReqSerializers<Api, 
       }),
       parseReq: ({params, query}) => [params.block_id, query.indices],
       schema: {
+        params: {block_id: Schema.StringRequired},
         query: {indices: Schema.UintArray},
       },
     },


### PR DESCRIPTION
**Motivation**

Noticed the schema validation for `block_id` in `getBlobSidecars` API was removed in https://github.com/ChainSafe/lodestar/pull/6337.

**Description**

Adds `block_id` schema validation to `getBlobSidecars` API
