### PR TITLE
chore: improve browser support

### DIFF
--- a/packages/light-client/src/transport/rest.ts
+++ b/packages/light-client/src/transport/rest.ts
@@ -1,25 +1,21 @@
 import EventEmitter from "events";
-import StrictEventEmitter from "strict-event-emitter-types";
-import {allForks, SyncPeriod} from "@lodestar/types";
-import {Api, ApiError, routes} from "@lodestar/api";
-import {ForkName} from "@lodestar/params";
-import {LightClientTransport} from "./interface.js";
+import {type StrictEventEmitter} from "strict-event-emitter-types";
+import {type allForks, type SyncPeriod} from "@lodestar/types";
+import {type Api, ApiError, routes} from "@lodestar/api";
+import {type ForkName} from "@lodestar/params";
+import {type LightClientTransport} from "./interface.js";
 
 export type LightClientRestEvents = {
   [routes.events.EventType.lightClientFinalityUpdate]: allForks.LightClientFinalityUpdate;
   [routes.events.EventType.lightClientOptimisticUpdate]: allForks.LightClientOptimisticUpdate;
 };
 
-type RestEvents = StrictEventEmitter<EventEmitter, LightClientRestEvents>;
-
-export class LightClientRestTransport extends (EventEmitter as {new (): RestEvents}) implements LightClientTransport {
+export class LightClientRestTransport implements LightClientTransport {
   private controller = new AbortController();
   private readonly eventEmitter: StrictEventEmitter<EventEmitter, LightClientRestEvents> = new EventEmitter();
   private subscribedEventstream = false;
 
-  constructor(private readonly api: Api) {
-    super();
-  }
+  constructor(private readonly api: Api) {}
 
   async getUpdates(
     startPeriod: SyncPeriod,

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -28,7 +28,9 @@ presetStatus.frozen = true;
  * The active preset can be manually overridden with `setActivePreset`
  */
 export const ACTIVE_PRESET =
-  userSelectedPreset ?? PresetName[process?.env?.LODESTAR_PRESET as PresetName] ?? PresetName.mainnet;
+  userSelectedPreset ??
+  (typeof process !== "undefined" ? PresetName[process?.env?.LODESTAR_PRESET as PresetName] : undefined) ??
+  PresetName.mainnet;
 export const activePreset = {...presets[ACTIVE_PRESET], ...userOverrides};
 
 // These variables must be exported individually and explicitly

--- a/packages/state-transition/src/util/sszBytes.ts
+++ b/packages/state-transition/src/util/sszBytes.ts
@@ -37,14 +37,14 @@ export const VALIDATOR_BYTES_SIZE = 121;
  */
 const SLOT_BYTES_POSITION_IN_STATE = 40;
 
-export function getForkFromStateBytes(config: ChainForkConfig, bytes: Buffer | Uint8Array): ForkSeq {
+export function getForkFromStateBytes(config: ChainForkConfig, bytes: Uint8Array): ForkSeq {
   const slot = bytesToInt(bytes.subarray(SLOT_BYTES_POSITION_IN_STATE, SLOT_BYTES_POSITION_IN_STATE + SLOT_BYTE_COUNT));
   return config.getForkSeq(slot);
 }
 
 export function getStateTypeFromBytes(
   config: ChainForkConfig,
-  bytes: Buffer | Uint8Array
+  bytes: Uint8Array
 ): allForks.AllForksSSZTypes["BeaconState"] {
   const slot = getStateSlotFromBytes(bytes);
   return config.getForkTypes(slot).BeaconState;


### PR DESCRIPTION
**Motivation**

Make sure lodestar libs (e.g. `light-client`) can be loaded in a browser without relying on nodejs shims.
Recent bundler push for not relying on those (e.g. `esbuild` and `vite`)