### PR TITLE
chore: update funding.yml link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: https://gitcoin.co/grants/6034/lodestar-typescript-eth-consensus-client-by-chains
+custom: https://etherscan.io/address/0xb4da52336092db22fe8e036866d59c6488604f89


### PR DESCRIPTION
**Motivation**

We used to link "Sponsor this project" on our repository to Gitcoin project pages which outlined our grant. Due to the many changes in Gitcoin's grant infrastructure, the link is now broken... again.

**Description**

Instead of linking to a page that may change or get stale over time, this PR links our Etherscan address displaying our public multisig for the team. Sponsors/donors can directly donate to our multisig instead. 