### PR TITLE
feat: allow to execute lodestar script inside docker container

### DIFF
--- a/lodestar
+++ b/lodestar
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Convenience script to run the lodestar binary from built source
 #


### PR DESCRIPTION
**Motivation**

This makes it easier to execute any lodestar command inside a running container

e.g. instead of
```sh
docker exec -it <container_id> node ./packages/cli/bin/lodestar validator voluntary-exit ...
```

it is now possible to run
```sh
docker exec -it <container_id> lodestar validator voluntary-exit ...
```

**Description**

Allow to execute lodestar script inside docker container, the script does not use any bash specific syntax and can be executed with sh which is installed on alpine by default.

**Alternative solution**

Could also install bash when building the docker image
