### PR TITLE
fix: increase e2e env startup timeout

### DIFF
--- a/scripts/run_e2e_env.sh
+++ b/scripts/run_e2e_env.sh
@@ -6,7 +6,7 @@ function start_app() {
   nohup node --loader ts-node/esm packages/cli/test/scripts/e2e_test_env.ts > test-logs/e2e-test-env/simulation.out 2>&1 &
   echo $! > test-logs/e2e-test-env/simulation.pid
   echo "Wait for the node to be ready"
-  npx wait-port -t 60000 0.0.0.0:5001
+  npx wait-port -t 120000 0.0.0.0:5001
 }
 
 function stop_app() {


### PR DESCRIPTION
**Motivation**

Make the e2e tests stable.

**Description**

- When E2E job failed on CI, it's often it's just the timeout for starting the e2e nodes. 

**Steps to test or reproduce**

- Run all tests. 