### PR TITLE
feat: manually use identify protocol

### DIFF
--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -15,6 +15,7 @@ import {
 } from "@libp2p/interface";
 import type {AddressManager, ConnectionManager, Registrar, TransportManager} from "@libp2p/interface-internal";
 import type {Datastore} from "interface-datastore";
+import {Identify} from "@chainsafe/libp2p-identify";
 import {Slot, SlotRootHex, allForks, altair, capella, deneb, phase0} from "@lodestar/types";
 import {PeerIdStr} from "../util/peerId.js";
 import {INetworkEventBus} from "./events.js";
@@ -98,4 +99,4 @@ export type LodestarComponents = {
   metrics?: Metrics;
 };
 
-export type Libp2p = ILibp2p<{components: LodestarComponents}>;
+export type Libp2p = ILibp2p<{components: LodestarComponents; identify: Identify}>;

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -112,6 +112,7 @@ export async function createNodeJsLibp2p(
     services: {
       identify: identify({
         agentVersion: networkOpts.private ? "" : networkOpts.version ? `lodestar/${networkOpts.version}` : "lodestar",
+        runOnConnectionOpen: false,
       }),
       // individual components are specified because the components object is a Proxy
       // and passing it here directly causes problems downstream, not to mention is slowwww

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -3,7 +3,7 @@ import {BitArray} from "@chainsafe/ssz";
 import {SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
 import {BeaconConfig} from "@lodestar/config";
 import {allForks, altair, phase0} from "@lodestar/types";
-import {retry, withTimeout} from "@lodestar/utils";
+import {withTimeout} from "@lodestar/utils";
 import {LoggerNode} from "@lodestar/logger/node";
 import {GoodByeReasonCode, GOODBYE_KNOWN_CODES, Libp2pEvent} from "../../constants/index.js";
 import {IClock} from "../../util/clock.js";
@@ -606,22 +606,18 @@ export class PeerManager {
       void this.requestStatus(remotePeer, this.statusCache.get());
     }
 
-    // AgentVersion was set in libp2p IdentifyService, 'peer:connect' event handler
-    // since it's not possible to handle it async, we have to wait for a while to set AgentVersion
-    // See https://github.com/libp2p/js-libp2p/pull/1168
-    retry(
-      async () => {
-        const agentVersionBytes = (await this.libp2p.peerStore.get(peerData.peerId)).metadata.get("AgentVersion");
-        if (agentVersionBytes) {
-          const agentVersion = new TextDecoder().decode(agentVersionBytes) || "N/A";
+    this.libp2p.services.identify
+      .identify(evt.detail)
+      .then((result) => {
+        const agentVersion = result.agentVersion;
+        if (agentVersion) {
           peerData.agentVersion = agentVersion;
           peerData.agentClient = getKnownClientFromAgentVersion(agentVersion);
         }
-      },
-      {retries: 3, retryDelay: 1000}
-    ).catch((err) => {
-      this.logger.debug("Error setting agentVersion for the peer", {peerId: peerData.peerId.toString()}, err);
-    });
+      })
+      .catch((err) => {
+        this.logger.debug("Error setting agentVersion for the peer", {peerId: peerData.peerId.toString()}, err);
+      });
   };
 
   /**


### PR DESCRIPTION
**Description**

- Manually dial newly connected peers with the identify protocol, rather than relying on automatic dialing with identify
- Manually dialing allows us to await the result rather than poll for peerstore updates