### PR TITLE
fix: parse --blindedLocal flag value as boolean

### DIFF
--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -268,7 +268,7 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
   },
 
   blindedLocal: {
-    type: "string",
+    type: "boolean",
     description: "Request fetching local block in blinded format for produceBlockV3",
     defaultDescription: `${defaultOptions.blindedLocal}`,
   },


### PR DESCRIPTION
**Motivation**

The CLI flag is parsed as a string value but our schema validation expects a boolean causing the http request to fail

```
consensus  | 2024-02-07T12:08:12.040208185Z Feb-07 12:08:12.039[rest]            error: Req req-jxb7 produceBlockV3 error - querystring/blinded_local must be boolean
consensus  | 2024-02-07T12:08:12.040238425Z Error: querystring/blinded_local must be boolean
consensus  | 2024-02-07T12:08:12.040243355Z     at defaultSchemaErrorFormatter (/usr/app/node_modules/fastify/lib/context.js:108:10)
consensus  | 2024-02-07T12:08:12.040247645Z     at wrapValidationError (/usr/app/node_modules/fastify/lib/validation.js:228:17)
consensus  | 2024-02-07T12:08:12.040251665Z     at validate (/usr/app/node_modules/fastify/lib/validation.js:157:16)
consensus  | 2024-02-07T12:08:12.040255685Z     at preValidationCallback (/usr/app/node_modules/fastify/lib/handleRequest.js:92:25)
consensus  | 2024-02-07T12:08:12.040259555Z     at handler (/usr/app/node_modules/fastify/lib/handleRequest.js:76:7)
consensus  | 2024-02-07T12:08:12.040263405Z     at handleRequest (/usr/app/node_modules/fastify/lib/handleRequest.js:24:5)
consensus  | 2024-02-07T12:08:12.040267315Z     at runPreParsing (/usr/app/node_modules/fastify/lib/route.js:569:5)
consensus  | 2024-02-07T12:08:12.040271175Z     at next (/usr/app/node_modules/fastify/lib/hooks.js:179:7)
consensus  | 2024-02-07T12:08:12.040274945Z     at handleResolve (/usr/app/node_modules/fastify/lib/hooks.js:196:5)
consensus  | 2024-02-07T12:08:12.040279395Z     at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

**Description**

Parse `--blindedLocal` flag value as boolean

Verified this solution works by running a local dev node but we should think about how we can have more type guarantees of CLI args to make sure if we use type `boolean` that it is actually parsed as a boolean by yargs.

```sh
./lodestar dev \
  --genesisValidators 8 \
  --startValidators 0..7 \
  --genesisTime $(date +%s) \
  --enr.ip 127.0.0.1 \
  --dataDir .lodestar/node1 \
  --reset \
  --rest \
  --rest.namespace '*' \
  --metrics \
  --logLevel info \
  --eth1 false \
  --network.rateLimitMultiplier 0 \
  --useProduceBlockV3 \
  --blindedLocal
```