### PR TITLE
fix: correct error message if produceBlockV3 request fails

### DIFF
--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -212,7 +212,7 @@ export class BlockProposingService {
       blindedLocal,
       builderBoostFactor,
     });
-    ApiError.assert(res, "Failed to produce block: validator.produceBlockV2");
+    ApiError.assert(res, "Failed to produce block: validator.produceBlockV3");
     const {response} = res;
 
     const debugLogCtx = {


### PR DESCRIPTION
**Motivation**

We are printing the wrong error on the vc side
```
Eph 0/3 0.007[]                error: Error proposing block slot=3, validator=0x9977…d373 - Failed to produce block: validator.produceBlockV2 - Bad Request: [{"instancePath":"/blinded_local","schemaPath":"#/properties/blinded_local/type","keyword":"type","params":{"type":"boolean"},"message":"must be boolean"}] - Failed to produce block
Error: Failed to produce block: validator.produceBlockV2 - Bad Request: [{"instancePath":"/blinded_local","schemaPath":"#/properties/blinded_local/type","keyword":"type","params":{"type":"boolean"},"message":"must be boolean"}] - Failed to produce block
```

should be `produceBlockV3` instead of `produceBlockV2`

**Description**

Correct error message if `produceBlockV3` request fails
