### PR TITLE
feat: schedule deneb on mainnet

### DIFF
--- a/packages/config/src/chainConfig/configs/mainnet.ts
+++ b/packages/config/src/chainConfig/configs/mainnet.ts
@@ -47,7 +47,7 @@ export const chainConfig: ChainConfig = {
 
   // Deneb
   DENEB_FORK_VERSION: b("0x04000000"),
-  DENEB_FORK_EPOCH: Infinity,
+  DENEB_FORK_EPOCH: 269568, // March 13, 2024, 01:55:35pm UTC
 
   // Time parameters
   // ---------------------------------------------------------------


### PR DESCRIPTION
as discussed in today's Feb 8 ACD, dencun confirmed for mainnet

![image](https://github.com/ChainSafe/lodestar/assets/76567250/b33002c9-543a-4818-9c8c-260f647cd648)
 
ref: 
- https://github.com/ethereum/consensus-specs/pull/3597
- https://github.com/ethereum/EIPs/pull/8173