### PR TITLE
chore: remove npm badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,8 @@
 # Lodestar Ethereum Consensus Implementation
 
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/chainsafe/lodestar?label=Github)](https://github.com/ChainSafe/lodestar/releases/latest)
-[![npm](https://img.shields.io/npm/v/@chainsafe/lodestar)](https://www.npmjs.com/package/@chainsafe/lodestar)
 [![Docker Image Version (latest by date)](https://img.shields.io/docker/v/chainsafe/lodestar?color=blue&label=Docker&sort=semver)](https://hub.docker.com/r/chainsafe/lodestar)
 [![Ethereum Consensus Spec v1.1.10](https://img.shields.io/badge/ETH%20consensus--spec-1.1.10-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.1.10)
-<br/>
 ![ES Version](https://img.shields.io/badge/ES-2021-yellow)
 ![Node Version](https://img.shields.io/badge/node-20.x-green)
 [![codecov](https://codecov.io/gh/ChainSafe/lodestar/graph/badge.svg)](https://codecov.io/gh/ChainSafe/lodestar)


### PR DESCRIPTION
**Motivation**

We have a big red warning in our docs to not use the CLI package
![image](https://github.com/ChainSafe/lodestar/assets/38436224/97f35397-64d7-4b23-a22f-11e0bbd6e336)

But at the same time we have a badge that links to the package on top of the README alongside docker and github (source). Until we fix the npm supply chain issue I'd suggest to remove that and not advocate for npm installation.

There is also already a reference to the CLI package in the [Architecture Overview](https://github.com/ChainSafe/lodestar?tab=readme-ov-file#architecture-overview)

**Description**

Remove npm badge from README
