### PR TITLE
refactor: reuse utils added in block production race refactor

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -187,21 +187,21 @@ export function getValidatorApi({
 
     if (source == null) {
       return {
-        executionPayloadValue: prettyWeiToEth(executionValue, true),
-        consensusBlockValue: prettyWeiToEth(consensusValue, true),
-        blockTotalValue: prettyWeiToEth(totalValue, true),
+        executionPayloadValue: prettyWeiToEth(executionValue),
+        consensusBlockValue: prettyWeiToEth(consensusValue),
+        blockTotalValue: prettyWeiToEth(totalValue),
       };
     } else if (source === ProducedBlockSource.builder) {
       return {
-        builderExecutionPayloadValue: prettyWeiToEth(executionValue, true),
-        builderConsensusBlockValue: prettyWeiToEth(consensusValue, true),
-        builderBlockTotalValue: prettyWeiToEth(totalValue, true),
+        builderExecutionPayloadValue: prettyWeiToEth(executionValue),
+        builderConsensusBlockValue: prettyWeiToEth(consensusValue),
+        builderBlockTotalValue: prettyWeiToEth(totalValue),
       };
     } else {
       return {
-        engineExecutionPayloadValue: prettyWeiToEth(executionValue, true),
-        engineConsensusBlockValue: prettyWeiToEth(consensusValue, true),
-        engineBlockTotalValue: prettyWeiToEth(totalValue, true),
+        engineExecutionPayloadValue: prettyWeiToEth(executionValue),
+        engineConsensusBlockValue: prettyWeiToEth(consensusValue),
+        engineBlockTotalValue: prettyWeiToEth(totalValue),
       };
     }
   }

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -45,14 +45,10 @@ export function formatBigDecimal(numerator: bigint, denominator: bigint, maxDeci
 const MAX_DECIMAL_FACTOR = BigInt("100000");
 
 /**
- * Format wei as ETH, with up to 5 decimals
- *
- * if suffix is true, append ' ETH'
+ * Format wei as ETH, with up to 5 decimals and append ' ETH'
  */
-export function prettyWeiToEth(wei: bigint, suffix = false): string {
-  let eth = formatBigDecimal(wei, ETH_TO_WEI, MAX_DECIMAL_FACTOR);
-  if (suffix) eth += " ETH";
-  return eth;
+export function prettyWeiToEth(wei: bigint): string {
+  return `${formatBigDecimal(wei, ETH_TO_WEI, MAX_DECIMAL_FACTOR)} ETH`;
 }
 
 /**

--- a/packages/utils/src/metrics.ts
+++ b/packages/utils/src/metrics.ts
@@ -1,3 +1,5 @@
+import {NonEmptyArray} from "./types.js";
+
 export type NoLabels = Record<string, never>;
 export type LabelsGeneric = Record<string, string | number>;
 export type LabelKeys<Labels extends LabelsGeneric> = Extract<keyof Labels, string>;
@@ -39,7 +41,7 @@ export interface Counter<Labels extends LabelsGeneric = NoLabels> {
 export type GaugeConfig<Labels extends LabelsGeneric> = {
   name: string;
   help: string;
-} & (NoLabels extends Labels ? {labelNames?: never} : {labelNames: [LabelKeys<Labels>, ...LabelKeys<Labels>[]]});
+} & (NoLabels extends Labels ? {labelNames?: never} : {labelNames: NonEmptyArray<LabelKeys<Labels>>});
 
 export type HistogramConfig<Labels extends LabelsGeneric> = GaugeConfig<Labels> & {
   buckets?: number[];

--- a/packages/utils/src/promise.ts
+++ b/packages/utils/src/promise.ts
@@ -74,11 +74,6 @@ export function wrapPromise<T>(promise: PromiseLike<T>): PromiseResult<T> {
   return result;
 }
 
-/**
- * ArrayToTuple converts an `Array<T>` to `[T, ...T]`
- *
- * eg: `[1, 2, 3]` from type `number[]` to `[number, number, number]`
- */
 type ReturnPromiseWithTuple<Tuple extends NonEmptyArray<PromiseLike<unknown>>> = {
   [Index in keyof ArrayToTuple<Tuple>]: PromiseResult<Awaited<Tuple[Index]>>;
 };

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -17,6 +17,11 @@ export function bnToNum(bn: bigint): number {
 
 export type NonEmptyArray<T> = [T, ...T[]];
 
+/**
+ * ArrayToTuple converts an `Array<T>` to `[T, ...T]`
+ *
+ * eg: `[1, 2, 3]` from type `number[]` to `[number, number, number]`
+ */
 export type ArrayToTuple<Tuple extends NonEmptyArray<unknown>> = {
   [Index in keyof Tuple]: Tuple[Index];
 };

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -11,16 +11,13 @@ import {
 } from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPreBlobs, ForkBlobs, ForkSeq, ForkExecution} from "@lodestar/params";
-import {ETH_TO_WEI, extendError, formatBigDecimal, prettyBytes} from "@lodestar/utils";
+import {extendError, prettyBytes, prettyWeiToEth} from "@lodestar/utils";
 import {Api, ApiError, routes} from "@lodestar/api";
 import {IClock, LoggerVc} from "../util/index.js";
 import {PubkeyHex} from "../types.js";
 import {Metrics} from "../metrics.js";
 import {ValidatorStore} from "./validatorStore.js";
 import {BlockDutiesService, GENESIS_SLOT} from "./blockDuties.js";
-
-// display upto 5 decimal places
-const MAX_DECIMAL_FACTOR = BigInt("100000");
 
 // The following combination of blocks and blobs can be produced
 //  i) a full block pre deneb
@@ -218,14 +215,9 @@ export class BlockProposingService {
     const debugLogCtx = {
       executionPayloadSource: response.executionPayloadSource,
       executionPayloadBlinded: response.executionPayloadBlinded,
-      // winston logger doesn't like bigint
-      executionPayloadValue: `${formatBigDecimal(response.executionPayloadValue, ETH_TO_WEI, MAX_DECIMAL_FACTOR)} ETH`,
-      consensusBlockValue: `${formatBigDecimal(response.consensusBlockValue, ETH_TO_WEI, MAX_DECIMAL_FACTOR)} ETH`,
-      totalBlockValue: `${formatBigDecimal(
-        response.executionPayloadValue + response.consensusBlockValue,
-        ETH_TO_WEI,
-        MAX_DECIMAL_FACTOR
-      )} ETH`,
+      executionPayloadValue: prettyWeiToEth(response.executionPayloadValue),
+      consensusBlockValue: prettyWeiToEth(response.consensusBlockValue),
+      totalBlockValue: prettyWeiToEth(response.executionPayloadValue + response.consensusBlockValue),
       // TODO PR: should be used in api call instead of adding in log
       strictFeeRecipientCheck,
       builderSelection,


### PR DESCRIPTION
**Motivation**

De-duplicate some code, consistent logging across bn and vc

**Description**

https://github.com/ChainSafe/lodestar/pull/6241 added a util to format block values. This PR just reuses it on the vc side to ensure we have consistent logging.
