### PR TITLE
ci: lint yarn lockfiles to analyze and detect security issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,8 @@ jobs:
           fail-on-cache-miss: true
       - name: Assert yarn prints no warnings
         run: scripts/assert_no_yarn_warnings.sh
+      - name: Lint yarn lockfile
+        run: npx lockfile-lint --path yarn.lock --allowed-hosts npm yarn --validate-https
       - name: Lint Code
         run: yarn lint
       - name: Lint Grafana dashboards
@@ -153,12 +155,12 @@ jobs:
       matrix:
         node: [20]
     steps:
-      - uses: actions/checkout@v4      
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
-          cache: yarn 
+          cache: yarn
 
       # # Remove when finished debugging core dumps
       # - uses: './.github/actions/setup-debug-node'
@@ -188,7 +190,7 @@ jobs:
         # Rever to "yarn test:unit" when finished debugging core dumps
         # run: sudo sh -c "ulimit -c unlimited && /usr/bin/node-with-debug $(which yarn) test:unit"
         run: yarn test:unit
-      
+
       # # Remove when finished debugging core dumps
       # - uses: './.github/actions/core-dump'
       #   if: ${{ failure() && steps.unit_tests.conclusion == 'failure' }}
@@ -277,7 +279,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
           fail-on-cache-miss: true
       - name: Install Chrome browser
-        run: npx @puppeteer/browsers install chromedriver@latest --path /tmp          
+        run: npx @puppeteer/browsers install chromedriver@latest --path /tmp
       - name: Install Firefox browser
         run: npx @puppeteer/browsers install firefox@latest --path /tmp
       - name: Browser tests
@@ -331,7 +333,7 @@ jobs:
         working-directory: packages/beacon-node
       - name: Spec tests bls
         run: yarn test:spec:bls
-        working-directory: packages/beacon-node        
+        working-directory: packages/beacon-node
       - name: Spec tests minimal
         run: yarn test:spec:minimal
         working-directory: packages/beacon-node


### PR DESCRIPTION
**Motivation**

Lockfile changes are hard to review and we should make sure we don't introduce a malicious dependency either accidentally or from an external contribution. Don't trust, verify.

**Description**

Add CI job to lint yarn lockfiles to analyze and detect security issues

It only takes 4 seconds to execute the lint task

![image](https://github.com/ChainSafe/lodestar/assets/38436224/b2f6423a-a6d8-4739-9e2f-c122233b026f)

Example of detected issue

```sh
> npx lockfile-lint --path yarn.lock --allowed-hosts npm yarn --validate-https
detected invalid host(s) for package: @types/json5@^0.0.29
    expected: registry.npmjs.org,registry.yarnpkg.com
    actual: registry.evil.org

 ✖ Error: security issues detected! 
```
