### PR TITLE
feat: rename prover CLI start command as proxy and make it default

### DIFF
--- a/packages/prover/README.md
+++ b/packages/prover/README.md
@@ -39,7 +39,7 @@ You can also invoke the package as binary.
 ```bash
 npm -i g @lodestar/prover
 
-lodestar-prover start \
+lodestar-prover proxy \
   --network sepolia \
   --execution-rpc https://lodestar-sepoliarpc.chainsafe.io \
   --mode rest \

--- a/packages/prover/src/cli/cli.ts
+++ b/packages/prover/src/cli/cli.ts
@@ -49,7 +49,7 @@ export function getLodestarProverCli(): yargs.Argv {
   }
 
   // Register the proxy command as the default one
-  registerCommandToYargs(prover, {...proverProxyStartCommand, command: '*'});
+  registerCommandToYargs(prover, {...proverProxyStartCommand, command: "*"});
 
   // throw an error if we see an unrecognized cmd
   prover.recommendCommands().strict();

--- a/packages/prover/src/cli/cli.ts
+++ b/packages/prover/src/cli/cli.ts
@@ -3,7 +3,7 @@ import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
 import {registerCommandToYargs} from "../utils/command.js";
 import {getVersionData} from "../utils/version.js";
-import {cmds} from "./cmds/index.js";
+import {cmds, proverProxyStartCommand} from "./cmds/index.js";
 import {globalOptions} from "./options.js";
 
 const {version} = getVersionData();
@@ -47,6 +47,9 @@ export function getLodestarProverCli(): yargs.Argv {
   for (const cmd of cmds) {
     registerCommandToYargs(prover, cmd);
   }
+
+  // Register the proxy command as the default one
+  registerCommandToYargs(prover, {...proverProxyStartCommand, command: '*'});
 
   // throw an error if we see an unrecognized cmd
   prover.recommendCommands().strict();

--- a/packages/prover/src/cli/cmds/index.ts
+++ b/packages/prover/src/cli/cmds/index.ts
@@ -1,5 +1,6 @@
 import {CliCommand} from "../../utils/command.js";
 import {GlobalArgs} from "../options.js";
 import {proverProxyStartCommand} from "./start/index.js";
+export {proverProxyStartCommand} from "./start/index.js";
 
 export const cmds: Required<CliCommand<GlobalArgs, Record<never, never>>>["subcommands"] = [proverProxyStartCommand];

--- a/packages/prover/src/cli/cmds/start/index.ts
+++ b/packages/prover/src/cli/cmds/start/index.ts
@@ -4,7 +4,7 @@ import {proverProxyStartHandler} from "./handler.js";
 import {StartArgs, startOptions} from "./options.js";
 
 export const proverProxyStartCommand: CliCommand<StartArgs, GlobalArgs> = {
-  command: "start",
+  command: "proxy",
   describe: "Start proxy server",
   examples: [
     {

--- a/packages/prover/test/e2e/cli/cmds/start.test.ts
+++ b/packages/prover/test/e2e/cli/cmds/start.test.ts
@@ -11,15 +11,15 @@ import {rpcUrl, beaconUrl, proxyPort, proxyUrl, chainId, waitForCapellaFork, con
 
 const cli = getLodestarProverCli();
 
-describe("prover/start", () => {
+describe("prover/proxy", () => {
   it("should show help", async () => {
-    const output = await runCliCommand(cli, ["start", "--help"]);
+    const output = await runCliCommand(cli, ["proxy", "--help"]);
 
     expect(output).toEqual(expect.stringContaining("Show help"));
   });
 
   it("should fail when --executionRpcUrl is missing", async () => {
-    await expect(runCliCommand(cli, ["start", "--port", "8088"])).rejects.toThrow(
+    await expect(runCliCommand(cli, ["proxy", "--port", "8088"])).rejects.toThrow(
       "Missing required argument: executionRpcUrl"
     );
   });
@@ -27,7 +27,7 @@ describe("prover/start", () => {
   it("should fail when --beaconUrls and --beaconBootnodes are provided together", async () => {
     await expect(
       runCliCommand(cli, [
-        "start",
+        "proxy",
         "--beaconUrls",
         "http://localhost:4000",
         "--beaconBootnodes",
@@ -38,7 +38,7 @@ describe("prover/start", () => {
 
   it("should fail when both of --beaconUrls and --beaconBootnodes are not provided", async () => {
     await expect(
-      runCliCommand(cli, ["start", "--port", "8088", "--executionRpcUrl", "http://localhost:3000"])
+      runCliCommand(cli, ["proxy", "--port", "8088", "--executionRpcUrl", "http://localhost:3000"])
     ).rejects.toThrow("Either --beaconUrls or --beaconBootnodes must be provided");
   });
 
@@ -55,7 +55,7 @@ describe("prover/start", () => {
       proc = await spawnCliCommand(
         "packages/prover/bin/lodestar-prover.js",
         [
-          "start",
+          "proxy",
           "--port",
           String(proxyPort as number),
           "--executionRpcUrl",


### PR DESCRIPTION
**Motivation**

`prover` CLI has a single command, `start`, rename it as `proxy` and make it the default for better UX

**Description**

It's now possible to start the prover using `npx @chainsafe/prover proxy ...` or `npx @chainsafe/prover ...` (previously was `npx @chainsafe/prover start ...`).
This is a *breaking change* as the old `start` command won't work anymore.