### PR TITLE
fix: reduce verbosity of gossip block errors

### DIFF
--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -279,7 +279,7 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
           }
         }
         metrics?.gossipBlock.processBlockErrors.inc({error: e instanceof BlockError ? e.type.code : "NOT_BLOCK_ERROR"});
-        logger.error("Error receiving block", {slot: signedBlock.message.slot, peer: peerIdStr}, e as Error);
+        logger.warn("Error receiving block", {slot: signedBlock.message.slot, peer: peerIdStr}, e as Error);
         chain.seenGossipBlockInput.prune();
       });
   }

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -278,13 +278,13 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
             case BlockErrorCode.PARENT_UNKNOWN:
             case BlockErrorCode.PRESTATE_MISSING:
             case BlockErrorCode.EXECUTION_ENGINE_ERROR:
-              // Errors might indicate an issue with our node or the connected execution client
+              // Errors might indicate an issue with our node, the connected execution client, or another client
               logLevel = LogLevel.error;
               break;
             default:
               // TODO: Should it use PeerId or string?
               core.reportPeer(peerIdStr, PeerAction.LowToleranceError, "BadGossipBlock");
-              // Misbehaving peer, user cannot be expected to do something about this
+              // Misbehaving peer, but could highlight an issue in another client
               logLevel = LogLevel.warn;
           }
         } else {

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -263,8 +263,9 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
               const forkTypes = config.getForkTypes(slot);
               const rootHex = toHexString(forkTypes.BeaconBlock.hashTreeRoot(signedBlock.message));
 
+              logger.debug("Blobs are unavailable within cutoff time", {slot, root: rootHex, peer: peerIdStr});
               events.emit(NetworkEvent.unknownBlock, {rootHex, peer: peerIdStr});
-              break;
+              return;
             }
             // ALREADY_KNOWN should not happen with ignoreIfKnown=true above
             // PARENT_UNKNOWN should not happen, we handled this in validateBeaconBlock() function above

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -263,9 +263,8 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
               const forkTypes = config.getForkTypes(slot);
               const rootHex = toHexString(forkTypes.BeaconBlock.hashTreeRoot(signedBlock.message));
 
-              logger.debug("Blobs are unavailable within cutoff time", {slot, root: rootHex, peer: peerIdStr});
               events.emit(NetworkEvent.unknownBlock, {rootHex, peer: peerIdStr});
-              return;
+              break;
             }
             // ALREADY_KNOWN should not happen with ignoreIfKnown=true above
             // PARENT_UNKNOWN should not happen, we handled this in validateBeaconBlock() function above

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -255,8 +255,8 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
         chain.seenGossipBlockInput.prune();
       })
       .catch((e) => {
-        // Any unexpected error
-        let logLevel = LogLevel.error;
+        // Adjust verbosity based on error type
+        let logLevel: LogLevel;
 
         if (e instanceof BlockError) {
           switch (e.type.code) {
@@ -287,6 +287,9 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
               // Misbehaving peer, user cannot be expected to do something about this
               logLevel = LogLevel.warn;
           }
+        } else {
+          // Any unexpected error
+          logLevel = LogLevel.error;
         }
         metrics?.gossipBlock.processBlockErrors.inc({error: e instanceof BlockError ? e.type.code : "NOT_BLOCK_ERROR"});
         logger[logLevel]("Error receiving block", {slot: signedBlock.message.slot, peer: peerIdStr}, e as Error);

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -278,7 +278,7 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
             case BlockErrorCode.PARENT_UNKNOWN:
             case BlockErrorCode.PRESTATE_MISSING:
             case BlockErrorCode.EXECUTION_ENGINE_ERROR:
-              // Errors might indicate an issue with our node, the connected execution client, or another client
+              // Errors might indicate an issue with our node or the connected EL client
               logLevel = LogLevel.error;
               break;
             default:


### PR DESCRIPTION
**Motivation**

Follow [logging-policy](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#logging-policy) and avoid user concerns by reducing verbosity of non-critical errors.

**Description**

- Adjust verbosity based on error type
- ~~Log gossip block errors as warnings~~
- ~~Only log to debug if blobs are unavailable within cutoff time~~

**TODO**
- [x] come up with a better approach to determine log verbosity (based on error type / code)

Closes https://github.com/ChainSafe/lodestar/issues/6402