### PR TITLE
test: split sim tests to multiple jobs

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -1,0 +1,58 @@
+name: "Setup and build the repo"
+description: "A task to reuse setup steps during multiple jobs"
+inputs:
+  node:
+    description: Node version
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{inputs.node}}
+        check-latest: true
+        cache: yarn
+
+    - name: Node.js version
+      id: node
+      shell: bash
+      run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
+
+    - name: Restore build
+      uses: actions/cache/restore@v4
+      id: cache-build-restore
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+          lib/
+          packages/*/lib
+          packages/*/.git-data.json
+        key: ${{ runner.os }}-node-${{ inputs.node }}-${{ github.sha }}
+
+    - name: Install & build
+      if: steps.cache-build-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: yarn install --frozen-lockfile && yarn build
+
+    - name: Build
+      if: steps.cache-build-restore.outputs.cache-hit == 'true'
+      shell: bash
+      run: yarn build      
+
+    - name: Check Build
+      shell: bash
+      run: yarn check-build      
+
+    - name: Cache build artifacts
+      uses: actions/cache@master
+      with:
+        path: |
+          node_modules
+          packages/*/node_modules
+          lib/
+          packages/*/lib
+          packages/*/.git-data.json
+        key: ${{ runner.os }}-node-${{ inputs.node }}-${{ github.sha }}

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -40,11 +40,11 @@ runs:
     - name: Build
       if: steps.cache-build-restore.outputs.cache-hit == 'true'
       shell: bash
-      run: yarn build      
+      run: yarn build
 
     - name: Check Build
       shell: bash
-      run: yarn check-build      
+      run: yarn check-build
 
     - name: Cache build artifacts
       uses: actions/cache@master

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -35,6 +35,7 @@ jobs:
 
   sim-test-multifork:
     name: Multifork sim test
+    needs: build
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
@@ -63,6 +64,7 @@ jobs:
 
   sim-test-endpoints:
     name: Endpoint sim tests
+    needs: build
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
@@ -91,6 +93,7 @@ jobs:
 
   sim-test-deneb:
     name: Deneb sim tests
+    needs: build
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
@@ -119,6 +122,7 @@ jobs:
 
   sim-test-eth-backup-provider:
     name: Eth backup provider sim tests
+    needs: build
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
@@ -147,6 +151,7 @@ jobs:
   
   sim-test-mixed-clients:
     name: Mixed clients sim tests
+    needs: build
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sim-test-multifork-logs
-          path: packages/cli/test-logs                    
+          path: packages/cli/test-logs
 
   sim-test-endpoints:
     name: Endpoint sim tests
@@ -89,7 +89,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sim-test-endpoints-logs
-          path: packages/cli/test-logs          
+          path: packages/cli/test-logs
 
   sim-test-deneb:
     name: Deneb sim tests
@@ -118,7 +118,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sim-test-deneb-logs
-          path: packages/cli/test-logs      
+          path: packages/cli/test-logs
 
   sim-test-eth-backup-provider:
     name: Eth backup provider sim tests
@@ -148,7 +148,7 @@ jobs:
         with:
           name: sim-test-eth-backup-provider-logs
           path: packages/cli/test-logs
-  
+
   sim-test-mixed-clients:
     name: Mixed clients sim tests
     needs: build

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -17,84 +17,158 @@ on:
         required: false
         default: ""
       genesisDelaySlots:
-        description: 'Number of slots delay before genesis'
+        description: "Number of slots delay before genesis"
         required: true
         type: number
         default: 40
 
 jobs:
-  tests-sim:
-    name: Sim tests
+  build:
+    name: Build
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: "./.github/actions/setup-and-build"
         with:
-          node-version: 20
-          check-latest: true
-          cache: yarn          
-      - name: Node.js version
-        id: node
-        run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
-      - name: Restore dependencies
-        uses: actions/cache@master
-        id: cache-deps
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-          key: ${{ runner.os }}-${{ steps.node.outputs.v8CppApiVersion }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
-      - name: Install & build
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile && yarn build
-      - name: Build
-        run: yarn build
-        if: steps.cache-deps.outputs.cache-hit == 'true'
-      # </common-build>
+          node: 20
 
-      - name: Load env variables 
+  sim-test-multifork:
+    name: Multifork sim test
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    steps:
+      # <common-build> - Uses YAML anchors in the future
+      - uses: actions/checkout@v4
+      - uses: "./.github/actions/setup-and-build"
+        with:
+          node: 20
+      - name: Load env variables
         uses: ./.github/actions/dotenv
-        
       - name: Download required docker images before running tests
         run: |
           docker pull ${{env.GETH_DOCKER_IMAGE}}
           docker pull ${{env.LIGHTHOUSE_DOCKER_IMAGE}}
           docker pull ${{env.NETHERMIND_DOCKER_IMAGE}}
-
       - name: Sim tests multifork
         run: DEBUG='${{github.event.inputs.debug}}' yarn test:sim:multifork
         working-directory: packages/cli
-        env: 
+        env:
           GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
-
-      - name: Sim tests endpoints
-        run: DEBUG='${{github.event.inputs.debug}}'  yarn test:sim:endpoints
-        working-directory: packages/cli
-        env: 
-          GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}        
-
-      - name: Sim tests deneb
-        run: DEBUG='${{github.event.inputs.debug}}' yarn test:sim:deneb
-        working-directory: packages/cli
-        env: 
-          GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}        
-
-      - name: Sim tests backup eth provider
-        run: DEBUG='${{github.event.inputs.debug}}' yarn test:sim:backup_eth_provider
-        working-directory: packages/cli
-        env: 
-          GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}        
-
-      - name: Sim tests mixed client
-        run: DEBUG='${{github.event.inputs.debug}}' yarn test:sim:mixedclient
-        working-directory: packages/cli
-        env: 
-          GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}        
-
       - name: Upload debug log test files for "packages/cli"
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: debug-test-logs-cli
+          name: sim-test-multifork-logs
+          path: packages/cli/test-logs                    
+
+  sim-test-endpoints:
+    name: Endpoint sim tests
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    steps:
+      # <common-build> - Uses YAML anchors in the future
+      - uses: actions/checkout@v4
+      - uses: "./.github/actions/setup-and-build"
+        with:
+          node: 20
+      - name: Load env variables
+        uses: ./.github/actions/dotenv
+      - name: Download required docker images before running tests
+        run: |
+          docker pull ${{env.GETH_DOCKER_IMAGE}}
+          docker pull ${{env.LIGHTHOUSE_DOCKER_IMAGE}}
+          docker pull ${{env.NETHERMIND_DOCKER_IMAGE}}
+      - name: Sim tests endpoints
+        run: DEBUG='${{github.event.inputs.debug}}'  yarn test:sim:endpoints
+        working-directory: packages/cli
+        env:
+          GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
+      - name: Upload debug log test files for "packages/cli"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-test-endpoints-logs
+          path: packages/cli/test-logs          
+
+  sim-test-deneb:
+    name: Deneb sim tests
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    steps:
+      # <common-build> - Uses YAML anchors in the future
+      - uses: actions/checkout@v4
+      - uses: "./.github/actions/setup-and-build"
+        with:
+          node: 20
+      - name: Load env variables
+        uses: ./.github/actions/dotenv
+      - name: Download required docker images before running tests
+        run: |
+          docker pull ${{env.GETH_DOCKER_IMAGE}}
+          docker pull ${{env.LIGHTHOUSE_DOCKER_IMAGE}}
+          docker pull ${{env.NETHERMIND_DOCKER_IMAGE}}
+      - name: Sim tests deneb
+        run: DEBUG='${{github.event.inputs.debug}}' yarn test:sim:deneb
+        working-directory: packages/cli
+        env:
+          GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
+      - name: Upload debug log test files for "packages/cli"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-test-deneb-logs
+          path: packages/cli/test-logs      
+
+  sim-test-eth-backup-provider:
+    name: Eth backup provider sim tests
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    steps:
+      # <common-build> - Uses YAML anchors in the future
+      - uses: actions/checkout@v4
+      - uses: "./.github/actions/setup-and-build"
+        with:
+          node: 20
+      - name: Load env variables
+        uses: ./.github/actions/dotenv
+      - name: Download required docker images before running tests
+        run: |
+          docker pull ${{env.GETH_DOCKER_IMAGE}}
+          docker pull ${{env.LIGHTHOUSE_DOCKER_IMAGE}}
+          docker pull ${{env.NETHERMIND_DOCKER_IMAGE}}
+      - name: Sim tests backup eth provider
+        run: DEBUG='${{github.event.inputs.debug}}' yarn test:sim:backup_eth_provider
+        working-directory: packages/cli
+        env:
+          GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
+      - name: Upload debug log test files for "packages/cli"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-test-eth-backup-provider-logs
+          path: packages/cli/test-logs
+  
+  sim-test-mixed-clients:
+    name: Mixed clients sim tests
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    steps:
+      # <common-build> - Uses YAML anchors in the future
+      - uses: actions/checkout@v4
+      - uses: "./.github/actions/setup-and-build"
+        with:
+          node: 20
+      - name: Load env variables
+        uses: ./.github/actions/dotenv
+      - name: Download required docker images before running tests
+        run: |
+          docker pull ${{env.GETH_DOCKER_IMAGE}}
+          docker pull ${{env.LIGHTHOUSE_DOCKER_IMAGE}}
+          docker pull ${{env.NETHERMIND_DOCKER_IMAGE}}
+      - name: Sim tests mixed client
+        run: DEBUG='${{github.event.inputs.debug}}' yarn test:sim:mixedclient
+        working-directory: packages/cli
+        env:
+          GENESIS_DELAY_SLOTS: ${{github.event.inputs.genesisDelaySlots}}
+      - name: Upload debug log test files for "packages/cli"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-test-mixed-clients-logs
           path: packages/cli/test-logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,50 +23,17 @@ jobs:
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: './.github/actions/setup-and-build'
         with:
-          node-version: ${{matrix.node}}
-          check-latest: true
-          cache: yarn
-      - name: Node.js version
-        id: node
-        run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
-      - name: Restore build
-        uses: actions/cache/restore@v4
-        id: cache-build-restore
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-            lib/
-            packages/*/lib
-            packages/*/.git-data.json
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
-      - name: Install & build
-        if: steps.cache-build-restore.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile && yarn build
-      - name: Build
-        if: steps.cache-build-restore.outputs.cache-hit == 'true'
-        run: yarn build
-      - name: Check Build
-        run: yarn check-build
+          node: ${{ matrix.node }}
+
       - name: Test root binary exists
         run: ./lodestar --version
+        
       - name: Reject yarn.lock changes
         run: .github/workflows/scripts/reject_yarn_lock_changes.sh
         # Run only on forks
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-      - name: Cache build artifacts
-        uses: actions/cache@master
-        id: cache-build
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-            lib/
-            packages/*/lib
-            packages/*/.git-data.json
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
 
   lint:
     name: Lint
@@ -78,33 +45,25 @@ jobs:
         node: [20]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: './.github/actions/setup-and-build'
         with:
-          node-version: ${{ matrix.node }}
-          check-latest: true
-          cache: yarn
-      - name: Restore build cache
-        id: cache-primes-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-            lib/
-            packages/*/lib
-            packages/*/.git-data.json
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
-          fail-on-cache-miss: true
+          node: ${{ matrix.node }}
+
       - name: Assert yarn prints no warnings
         run: scripts/assert_no_yarn_warnings.sh
+
       - name: Lint yarn lockfile
         run: npx lockfile-lint --path yarn.lock --allowed-hosts npm yarn --validate-https
+
       - name: Lint Code
         run: yarn lint
+
       - name: Lint Grafana dashboards
         run: scripts/validate-grafana-dashboards.sh
+
       - name: Assert ESM module exports
         run: node scripts/assert_exports.mjs
+
       - name: Assert eslintrc rules sorted
         run: scripts/assert_eslintrc_sorted.mjs
 
@@ -118,23 +77,10 @@ jobs:
         node: [20]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+
+      - uses: './.github/actions/setup-and-build'
         with:
-          node-version: ${{ matrix.node }}
-          check-latest: true
-          cache: yarn
-      - name: Restore build cache
-        id: cache-primes-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-            lib/
-            packages/*/lib
-            packages/*/.git-data.json
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
-          fail-on-cache-miss: true
+          node: ${{ matrix.node }}
 
       - name: Check Types
         run: yarn check-types
@@ -152,27 +98,9 @@ jobs:
         node: [20]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: './.github/actions/setup-and-build'
         with:
-          node-version: ${{ matrix.node }}
-          check-latest: true
-          cache: yarn
-
-      # # Remove when finished debugging core dumps
-      # - uses: './.github/actions/setup-debug-node'
-
-      - name: Restore build cache
-        id: cache-primes-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-            lib/
-            packages/*/lib
-            packages/*/.git-data.json
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
-          fail-on-cache-miss: true
+          node: ${{ matrix.node }}
 
       # Cache validator slashing protection data tests
       - name: Restore spec tests cache
@@ -210,23 +138,10 @@ jobs:
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+
+      - uses: './.github/actions/setup-and-build'
         with:
-          node-version: ${{matrix.node}}
-          check-latest: true
-          cache: yarn
-      - name: Restore build cache
-        id: cache-primes-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-            lib/
-            packages/*/lib
-            packages/*/.git-data.json
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
-          fail-on-cache-miss: true
+          node: ${{ matrix.node }}
 
       - name: Load env variables 
         uses: ./.github/actions/dotenv
@@ -260,23 +175,9 @@ jobs:
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: './.github/actions/setup-and-build'
         with:
-          node-version: ${{matrix.node}}
-          check-latest: true
-          cache: yarn
-      - name: Restore build cache
-        id: cache-primes-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-            lib/
-            packages/*/lib
-            packages/*/.git-data.json
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
-          fail-on-cache-miss: true
+          node: ${{ matrix.node }}
       - name: Install Chrome browser
         run: npx @puppeteer/browsers install chromedriver@latest --path /tmp
       - name: Install Firefox browser
@@ -297,23 +198,9 @@ jobs:
         node: [20]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: './.github/actions/setup-and-build'
         with:
-          node-version: ${{matrix.node}}
-          check-latest: true
-          cache: yarn
-      - name: Restore build cache
-        id: cache-primes-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-            lib/
-            packages/*/lib
-            packages/*/.git-data.json
-          key: ${{ runner.os }}-node-${{ matrix.node }}-${{ github.sha }}
-          fail-on-cache-miss: true
+          node: ${{ matrix.node }}
 
       # Download spec tests with cache
       - name: Restore spec tests cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,13 +23,13 @@ jobs:
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
-      - uses: './.github/actions/setup-and-build'
+      - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}
 
       - name: Test root binary exists
         run: ./lodestar --version
-        
+
       - name: Reject yarn.lock changes
         run: .github/workflows/scripts/reject_yarn_lock_changes.sh
         # Run only on forks
@@ -45,7 +45,7 @@ jobs:
         node: [20]
     steps:
       - uses: actions/checkout@v4
-      - uses: './.github/actions/setup-and-build'
+      - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}
 
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: './.github/actions/setup-and-build'
+      - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}
 
@@ -98,7 +98,7 @@ jobs:
         node: [20]
     steps:
       - uses: actions/checkout@v4
-      - uses: './.github/actions/setup-and-build'
+      - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}
 
@@ -139,13 +139,13 @@ jobs:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
 
-      - uses: './.github/actions/setup-and-build'
+      - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}
 
-      - name: Load env variables 
+      - name: Load env variables
         uses: ./.github/actions/dotenv
-        
+
       - name: Run the e2e test environment
         run: scripts/run_e2e_env.sh start
 
@@ -175,7 +175,7 @@ jobs:
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
-      - uses: './.github/actions/setup-and-build'
+      - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}
       - name: Install Chrome browser
@@ -198,7 +198,7 @@ jobs:
         node: [20]
     steps:
       - uses: actions/checkout@v4
-      - uses: './.github/actions/setup-and-build'
+      - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}
 


### PR DESCRIPTION
**Motivation**

To make the sim tests stable. 

**Description**

- Sim tests are very long running jobs
- Often we need to debug one scenario in one specific sim test 
- Which end up running full half an hour jobs each time
- Splitting jobs will help to re-run one sim test independently when it fails 
- Splitting will also help to complete the sim tests earlier as current sim test job is taking over 30 minutes. 

**Steps to test or reproduce**

- Run all tests