### PR TITLE
chore: improve type safety of CLI args

### DIFF
--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -143,7 +143,7 @@ type ENRArgs = {
   nat?: boolean;
 };
 
-const enrOptions: Record<string, CliOptionDefinition> = {
+const enrOptions: CliCommandOptions<ENRArgs> = {
   "enr.ip": {
     description: "Override ENR IP entry",
     type: "string",

--- a/packages/cli/src/util/command.ts
+++ b/packages/cli/src/util/command.ts
@@ -6,15 +6,26 @@ export interface CliExample {
   description?: string;
 }
 
-export interface CliOptionDefinition extends Options {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface CliOptionDefinition<T = any> extends Options {
   example?: Omit<CliExample, "title">;
+  // Ensure `type` property matches type of `T`
+  type: T extends string
+    ? "string"
+    : T extends number
+    ? "number"
+    : T extends boolean
+    ? "boolean"
+    : T extends Array<unknown>
+    ? "array"
+    : never;
 }
 
 export type CliCommandOptions<OwnArgs> = Required<{
   [K in keyof OwnArgs]: undefined extends OwnArgs[K]
-    ? CliOptionDefinition
+    ? CliOptionDefinition<OwnArgs[K]>
     : // If arg cannot be undefined it must specify a default value
-      CliOptionDefinition & Required<Pick<Options, "default">>;
+      CliOptionDefinition<OwnArgs[K]> & Required<Pick<Options, "default">>;
 }>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/6404

**Description**

 Ensure `type` property matches ts type of option. This guarantees that the value of the parsed CLI arg matches with the type / value we expect in the code and avoids issue such as https://github.com/ChainSafe/lodestar/pull/6403.
