### PR TITLE
chore: remove not yet relevant prover options

### DIFF
--- a/packages/prover/src/cli/cmds/start/handler.ts
+++ b/packages/prover/src/cli/cmds/start/handler.ts
@@ -1,5 +1,4 @@
 import {ChainConfig, chainConfigFromJson} from "@lodestar/config";
-import {LCTransport} from "../../../interfaces.js";
 import {readFile} from "../../../utils/file.js";
 import {createVerifiedExecutionProxy, VerifiedProxyOptions} from "../../../web3_proxy.js";
 import {GlobalArgs, parseGlobalArgs} from "../../options.js";
@@ -11,25 +10,18 @@ import {parseStartArgs, StartArgs} from "./options.js";
 export async function proverProxyStartHandler(args: StartArgs & GlobalArgs): Promise<void> {
   const {network, logLevel, paramsFile} = parseGlobalArgs(args);
   const opts = parseStartArgs(args);
-  const {executionRpcUrl, port, wsCheckpoint} = opts;
 
   const config: Partial<ChainConfig> = paramsFile ? chainConfigFromJson(readFile(paramsFile)) : {};
 
   const options: VerifiedProxyOptions = {
+    ...opts,
     logLevel,
-    executionRpcUrl,
-    wsCheckpoint,
-    unverifiedWhitelist: opts.unverifiedWhitelist,
-    requestTimeout: opts.requestTimeout,
     ...(network ? {network} : {config}),
-    ...(opts.transport === LCTransport.Rest
-      ? {transport: LCTransport.Rest, urls: opts.urls}
-      : {transport: LCTransport.P2P, bootnodes: opts.bootnodes}),
   };
 
   const {server, proofProvider} = createVerifiedExecutionProxy(options);
 
-  server.listen(port);
+  server.listen(opts.port);
 
   await proofProvider.waitToBeReady();
 }

--- a/packages/prover/src/cli/cmds/start/options.ts
+++ b/packages/prover/src/cli/cmds/start/options.ts
@@ -7,7 +7,6 @@ export type StartArgs = {
   port: number;
   executionRpcUrl: string;
   beaconUrls?: string[];
-  beaconBootnodes?: string[];
   wsCheckpoint?: string;
   unverifiedWhitelist?: string[];
   requestTimeout: number;
@@ -19,7 +18,7 @@ export type StartOptions = {
   wsCheckpoint?: string;
   unverifiedWhitelist?: string[];
   requestTimeout: number;
-} & ({transport: LCTransport.Rest; urls: string[]} | {transport: LCTransport.P2P; bootnodes: string[]});
+} & {transport: LCTransport.Rest; urls: string[]};
 
 export const startOptions: CliCommandOptions<StartArgs> = {
   port: {
@@ -55,16 +54,8 @@ export const startOptions: CliCommandOptions<StartArgs> = {
   beaconUrls: {
     description: "The beacon node PRC urls for 'rest' mode.",
     type: "string",
+    demandOption: true,
     array: true,
-    conflicts: ["beaconBootnodes"],
-    group: "beacon",
-  },
-
-  beaconBootnodes: {
-    description: "The beacon node PRC urls for 'p2p' mode.",
-    type: "string",
-    array: true,
-    conflicts: ["beaconUrls"],
     group: "beacon",
   },
 
@@ -78,17 +69,12 @@ export const startOptions: CliCommandOptions<StartArgs> = {
 };
 
 export function parseStartArgs(args: StartArgs): StartOptions {
-  if (!args.beaconUrls && !args.beaconBootnodes) {
-    throw new Error("Either --beaconUrls or --beaconBootnodes must be provided");
-  }
-
   // Remove undefined values to allow deepmerge to inject default values downstream
   return {
     port: args.port,
     executionRpcUrl: args.executionRpcUrl,
-    transport: args.beaconUrls ? LCTransport.Rest : LCTransport.P2P,
+    transport: LCTransport.Rest,
     urls: args.beaconUrls ?? [],
-    bootnodes: args.beaconBootnodes ?? [],
     wsCheckpoint: args.wsCheckpoint,
     unverifiedWhitelist: args.unverifiedWhitelist,
     requestTimeout: args.requestTimeout ?? DEFAULT_PROXY_REQUEST_TIMEOUT,

--- a/packages/prover/test/e2e/cli/cmds/start.test.ts
+++ b/packages/prover/test/e2e/cli/cmds/start.test.ts
@@ -18,28 +18,10 @@ describe("prover/proxy", () => {
     expect(output).toEqual(expect.stringContaining("Show help"));
   });
 
-  it("should fail when --executionRpcUrl is missing", async () => {
+  it("should fail when --executionRpcUrl and --beaconUrls are missing", async () => {
     await expect(runCliCommand(cli, ["proxy", "--port", "8088"])).rejects.toThrow(
-      "Missing required argument: executionRpcUrl"
+      "Missing required arguments: executionRpcUrl, beaconUrls"
     );
-  });
-
-  it("should fail when --beaconUrls and --beaconBootnodes are provided together", async () => {
-    await expect(
-      runCliCommand(cli, [
-        "proxy",
-        "--beaconUrls",
-        "http://localhost:4000",
-        "--beaconBootnodes",
-        "http://localhost:0000",
-      ])
-    ).rejects.toThrow("Arguments beaconBootnodes and beaconUrls are mutually exclusive");
-  });
-
-  it("should fail when both of --beaconUrls and --beaconBootnodes are not provided", async () => {
-    await expect(
-      runCliCommand(cli, ["proxy", "--port", "8088", "--executionRpcUrl", "http://localhost:3000"])
-    ).rejects.toThrow("Either --beaconUrls or --beaconBootnodes must be provided");
   });
 
   describe("when started", () => {


### PR DESCRIPTION
**Motivation**

Make sure `prover` CLI does not expose options not yet implemented.

**Description**

The `beaconBootnodes` option should not be exposed by the `prover` CLI as it's not yet implemented.