### PR TITLE
fix: support eth_getBlockByNumber

### DIFF
--- a/packages/prover/src/proof_provider/proof_provider.ts
+++ b/packages/prover/src/proof_provider/proof_provider.ts
@@ -9,6 +9,7 @@ import {Logger} from "@lodestar/utils";
 import {LCTransport, RootProviderInitOptions} from "../interfaces.js";
 import {assertLightClient} from "../utils/assertion.js";
 import {
+  fetchBlock,
   getExecutionPayloads,
   getGenesisData,
   getSyncCheckpoint,
@@ -120,20 +121,20 @@ export class ProofProvider {
       endSlot: end,
       logger: this.logger,
     });
-    for (const payload of Object.values(payloads)) {
-      this.store.set(payload, false);
+    for (const [slot, payload] of payloads.entries()) {
+      this.store.set(payload, slot, false);
     }
 
     // Load the finalized payload from the CL
     const finalizedSlot = this.lightClient.getFinalized().beacon.slot;
     this.logger.debug("Getting finalized slot from lightclient", {finalizedSlot});
-    const finalizedPayload = await getExecutionPayloads({
-      api: this.opts.api,
-      startSlot: finalizedSlot,
-      endSlot: finalizedSlot,
-      logger: this.logger,
-    });
-    this.store.set(finalizedPayload[finalizedSlot], true);
+    const block = await fetchBlock(this.opts.api, finalizedSlot);
+    if (block) {
+      this.store.set(block.message.body.executionPayload, finalizedSlot, true);
+    } else {
+      this.logger.error("Failed to fetch finalized block", finalizedSlot);
+    }
+
     this.logger.info("Proof provider ready");
   }
 

--- a/packages/prover/src/utils/consensus.ts
+++ b/packages/prover/src/utils/consensus.ts
@@ -6,6 +6,13 @@ import {Logger} from "@lodestar/utils";
 import {MAX_PAYLOAD_HISTORY} from "../constants.js";
 import {hexToBuffer} from "./conversion.js";
 
+export async function fetchBlock(api: Api, slot: number): Promise<capella.SignedBeaconBlock | undefined> {
+  const res = await api.beacon.getBlockV2(slot);
+
+  if (res.ok) return res.response.data as capella.SignedBeaconBlock;
+  return;
+}
+
 export async function fetchNearestBlock(
   api: Api,
   slot: number,
@@ -13,7 +20,7 @@ export async function fetchNearestBlock(
 ): Promise<capella.SignedBeaconBlock> {
   const res = await api.beacon.getBlockV2(slot);
 
-  if (res.ok) return res.response.data;
+  if (res.ok) return res.response.data as capella.SignedBeaconBlock;
 
   if (!res.ok && res.error.code === 404) {
     return fetchNearestBlock(api, direction === "down" ? slot - 1 : slot + 1);
@@ -43,7 +50,7 @@ export async function getExecutionPayloads({
   startSlot: number;
   endSlot: number;
   logger: Logger;
-}): Promise<Record<number, allForks.ExecutionPayload>> {
+}): Promise<Map<number, allForks.ExecutionPayload>> {
   [startSlot, endSlot] = [Math.min(startSlot, endSlot), Math.max(startSlot, endSlot)];
   if (startSlot === endSlot) {
     logger.debug("Fetching EL payload", {slot: startSlot});
@@ -51,18 +58,18 @@ export async function getExecutionPayloads({
     logger.debug("Fetching EL payloads", {startSlot, endSlot});
   }
 
-  const payloads: Record<number, allForks.ExecutionPayload> = {};
+  const payloads = new Map<number, allForks.ExecutionPayload>();
 
   let slot = endSlot;
-  let block = await fetchNearestBlock(api, slot, "down");
-  payloads[block.message.slot] = block.message.body.executionPayload;
+  let block = await fetchNearestBlock(api, slot);
+  payloads.set(block.message.slot, block.message.body.executionPayload);
   slot = block.message.slot - 1;
 
   while (slot >= startSlot) {
-    const previousBlock = await fetchNearestBlock(api, block.message.slot - 1, "down");
+    const previousBlock = await fetchNearestBlock(api, block.message.slot - 1);
 
     if (block.message.body.executionPayload.parentHash === previousBlock.message.body.executionPayload.blockHash) {
-      payloads[block.message.slot] = block.message.body.executionPayload;
+      payloads.set(block.message.slot, block.message.body.executionPayload);
     }
 
     slot = block.message.slot - 1;
@@ -76,16 +83,16 @@ export async function getExecutionPayloadForBlockNumber(
   api: Api,
   startSlot: number,
   blockNumber: number
-): Promise<Record<number, allForks.ExecutionPayload>> {
-  const payloads: Record<number, allForks.ExecutionPayload> = {};
+): Promise<Map<number, allForks.ExecutionPayload>> {
+  const payloads = new Map<number, allForks.ExecutionPayload>();
 
-  let block = await fetchNearestBlock(api, startSlot, "down");
-  payloads[block.message.slot] = block.message.body.executionPayload;
+  let block = await fetchNearestBlock(api, startSlot);
+  payloads.set(block.message.slot, block.message.body.executionPayload);
 
-  while (payloads[block.message.slot].blockNumber !== blockNumber) {
-    const previousBlock = await fetchNearestBlock(api, block.message.slot - 1, "down");
+  while (payloads.get(block.message.slot)?.blockNumber !== blockNumber) {
+    const previousBlock = await fetchNearestBlock(api, block.message.slot - 1);
     block = previousBlock;
-    payloads[block.message.slot] = block.message.body.executionPayload;
+    payloads.set(block.message.slot, block.message.body.executionPayload);
   }
 
   return payloads;

--- a/packages/prover/src/utils/evm.ts
+++ b/packages/prover/src/utils/evm.ts
@@ -167,12 +167,13 @@ export async function executeVMCall({
   network: NetworkName;
 }): Promise<RunTxResult["execResult"]> {
   const {from, to, gas, gasPrice, maxPriorityFeePerGas, value, data, input} = tx;
-  const {result: block} = await rpc.request("eth_getBlockByHash", [bufferToHex(executionPayload.blockHash), true], {
+  const blockHash = bufferToHex(executionPayload.blockHash);
+  const {result: block} = await rpc.request("eth_getBlockByHash", [blockHash, true], {
     raiseError: true,
   });
 
   if (!block) {
-    throw new Error(`Block not found: ${bufferToHex(executionPayload.blockHash)}`);
+    throw new Error(`Block not found: ${blockHash}`);
   }
 
   const {execResult} = await vm.evm.runCall({

--- a/packages/prover/src/utils/validation.ts
+++ b/packages/prover/src/utils/validation.ts
@@ -104,28 +104,27 @@ export async function isValidBlock({
   logger: Logger;
   config: ChainForkConfig;
 }): Promise<boolean> {
-  const common = getChainCommon(config.PRESET_BASE);
-  common.setHardforkByBlockNumber(executionPayload.blockNumber, undefined, executionPayload.timestamp);
-
-  const blockObject = Block.fromBlockData(blockDataFromELBlock(block), {common});
-
-  if (bufferToHex(executionPayload.blockHash) !== bufferToHex(blockObject.hash())) {
+  if (bufferToHex(executionPayload.blockHash) !== block.hash) {
     logger.error("Block hash does not match", {
-      rpcBlockHash: bufferToHex(blockObject.hash()),
+      rpcBlockHash: block.hash,
       beaconExecutionBlockHash: bufferToHex(executionPayload.blockHash),
     });
 
     return false;
   }
 
-  if (bufferToHex(executionPayload.parentHash) !== bufferToHex(blockObject.header.parentHash)) {
+  if (bufferToHex(executionPayload.parentHash) !== block.parentHash) {
     logger.error("Block parent hash does not match", {
-      rpcBlockHash: bufferToHex(blockObject.header.parentHash),
+      rpcBlockHash: block.parentHash,
       beaconExecutionBlockHash: bufferToHex(executionPayload.parentHash),
     });
 
     return false;
   }
+
+  const common = getChainCommon(config.PRESET_BASE);
+  common.setHardforkByBlockNumber(executionPayload.blockNumber, undefined, executionPayload.timestamp);
+  const blockObject = Block.fromBlockData(blockDataFromELBlock(block), {common});
 
   if (!(await blockObject.validateTransactionsTrie())) {
     logger.error("Block transactions could not be verified.", {

--- a/packages/prover/src/utils/verification.ts
+++ b/packages/prover/src/utils/verification.ts
@@ -86,8 +86,9 @@ export async function verifyBlock({
   logger: Logger;
 }): Promise<VerificationResult<ELBlock>> {
   try {
-    const executionPayload = await proofProvider.getExecutionPayload(payload.params[0]);
-    const block = await getELBlock(rpc, payload.params);
+    const blockNumber = payload.params[0];
+    const executionPayload = await proofProvider.getExecutionPayload(blockNumber);
+    const block = await getELBlock(rpc, [blockNumber, true]); // Always request hydrated blocks as we need access to `transactions` details
 
     // If response is not valid from the EL we don't need to verify it
     if (!block) return {data: block, valid: false};

--- a/packages/prover/test/unit/proof_provider/payload_store.test.ts
+++ b/packages/prover/test/unit/proof_provider/payload_store.test.ts
@@ -9,6 +9,7 @@ import {ForkName} from "@lodestar/params";
 import {PayloadStore} from "../../../src/proof_provider/payload_store.js";
 import {MAX_PAYLOAD_HISTORY} from "../../../src/constants.js";
 
+const slotNumber = 10;
 const createHash = (input: string): Uint8Array => hash(Buffer.from(input, "utf8"));
 
 const buildPayload = ({blockNumber}: {blockNumber: number}): allForks.ExecutionPayload =>
@@ -71,14 +72,14 @@ describe("proof_provider/payload_store", function () {
     });
 
     it("should return undefined if no finalized block", () => {
-      store.set(buildPayload({blockNumber: 10}), false);
+      store.set(buildPayload({blockNumber: 10}), slotNumber, false);
 
       expect(store.finalized).toBeUndefined();
     });
 
     it("should return finalized payload", () => {
       const payload = buildPayload({blockNumber: 10});
-      store.set(payload, true);
+      store.set(payload, slotNumber, true);
 
       expect(store.finalized).toEqual(payload);
     });
@@ -86,8 +87,8 @@ describe("proof_provider/payload_store", function () {
     it("should return highest finalized payload", () => {
       const payload1 = buildPayload({blockNumber: 10});
       const payload2 = buildPayload({blockNumber: 11});
-      store.set(payload1, true);
-      store.set(payload2, true);
+      store.set(payload1, slotNumber, true);
+      store.set(payload2, slotNumber, true);
 
       expect(store.finalized).toEqual(payload2);
     });
@@ -101,8 +102,8 @@ describe("proof_provider/payload_store", function () {
     it("should return latest payload if finalized", () => {
       const payload1 = buildPayload({blockNumber: 10});
       const payload2 = buildPayload({blockNumber: 11});
-      store.set(payload1, true);
-      store.set(payload2, true);
+      store.set(payload1, slotNumber, true);
+      store.set(payload2, slotNumber, true);
 
       expect(store.latest).toEqual(payload2);
     });
@@ -110,8 +111,8 @@ describe("proof_provider/payload_store", function () {
     it("should return latest payload if not finalized", () => {
       const payload1 = buildPayload({blockNumber: 10});
       const payload2 = buildPayload({blockNumber: 11});
-      store.set(payload1, false);
-      store.set(payload2, false);
+      store.set(payload1, slotNumber, false);
+      store.set(payload2, slotNumber, false);
 
       expect(store.latest).toEqual(payload2);
     });
@@ -124,14 +125,14 @@ describe("proof_provider/payload_store", function () {
 
     it("should return undefined for non existing block id", async () => {
       const payload1 = buildPayload({blockNumber: 10});
-      store.set(payload1, false);
+      store.set(payload1, slotNumber, false);
 
       await expect(store.get(11)).resolves.toBeUndefined();
     });
 
     it("should return undefined for non existing block hash", async () => {
       const payload1 = buildPayload({blockNumber: 10});
-      store.set(payload1, false);
+      store.set(payload1, slotNumber, false);
       const nonExistingBlockHash = createHash("non-existing-block-hash");
 
       await expect(store.get(toHexString(nonExistingBlockHash))).resolves.toBeUndefined();
@@ -140,7 +141,7 @@ describe("proof_provider/payload_store", function () {
     describe("block hash as blockId", () => {
       it("should return payload for a block hash", async () => {
         const payload1 = buildPayload({blockNumber: 10});
-        store.set(payload1, false);
+        store.set(payload1, slotNumber, false);
 
         await expect(store.get(toHexString(payload1.blockHash))).resolves.toEqual(payload1);
       });
@@ -149,7 +150,7 @@ describe("proof_provider/payload_store", function () {
     describe("block number as blockId", () => {
       it("should throw error to use block hash for un-finalized blocks", async () => {
         const finalizedPayload = buildPayload({blockNumber: 10});
-        store.set(finalizedPayload, true);
+        store.set(finalizedPayload, slotNumber, true);
 
         await expect(store.get(11)).rejects.toThrow(
           "Block number 11 is higher than the latest finalized block number. We recommend to use block hash for unfinalized blocks."
@@ -158,28 +159,28 @@ describe("proof_provider/payload_store", function () {
 
       it("should return undefined if payload exists but not-finalized", async () => {
         const payload1 = buildPayload({blockNumber: 10});
-        store.set(payload1, false);
+        store.set(payload1, slotNumber, false);
 
         await expect(store.get(10)).resolves.toBeUndefined();
       });
 
       it("should return payload for a block number in hex", async () => {
         const payload1 = buildPayload({blockNumber: 10});
-        store.set(payload1, true);
+        store.set(payload1, slotNumber, true);
 
         await expect(store.get(`0x${payload1.blockNumber.toString(16)}`)).resolves.toEqual(payload1);
       });
 
       it("should return payload for a block number as string", async () => {
         const payload1 = buildPayload({blockNumber: 10});
-        store.set(payload1, true);
+        store.set(payload1, slotNumber, true);
 
         await expect(store.get(payload1.blockNumber.toString())).resolves.toEqual(payload1);
       });
 
       it("should return payload for a block number as integer", async () => {
         const payload1 = buildPayload({blockNumber: 10});
-        store.set(payload1, true);
+        store.set(payload1, slotNumber, true);
 
         await expect(store.get(10)).resolves.toEqual(payload1);
       });
@@ -199,7 +200,7 @@ describe("proof_provider/payload_store", function () {
           .calledWith(unavailableBlockNumber)
           .thenResolve(buildBlockResponse({blockNumber: unavailableBlockNumber, slot: unavailableBlockNumber}));
 
-        store.set(availablePayload, true);
+        store.set(availablePayload, slotNumber, true);
 
         const result = await store.get(unavailablePayload.blockNumber);
 
@@ -214,7 +215,7 @@ describe("proof_provider/payload_store", function () {
   describe("set", () => {
     it("should set the payload for non-finalized blocks", async () => {
       const payload1 = buildPayload({blockNumber: 10});
-      store.set(payload1, false);
+      store.set(payload1, slotNumber, false);
 
       // Unfinalized blocks are not indexed by block hash
       await expect(store.get(toHexString(payload1.blockHash))).resolves.toEqual(payload1);
@@ -223,7 +224,7 @@ describe("proof_provider/payload_store", function () {
 
     it("should set the payload for finalized blocks", async () => {
       const payload1 = buildPayload({blockNumber: 10});
-      store.set(payload1, true);
+      store.set(payload1, slotNumber, true);
 
       await expect(store.get(payload1.blockNumber.toString())).resolves.toEqual(payload1);
       expect(store.finalized).toEqual(payload1);
@@ -324,7 +325,7 @@ describe("proof_provider/payload_store", function () {
       const numberOfPayloads = MAX_PAYLOAD_HISTORY + 2;
 
       for (let i = 1; i <= numberOfPayloads; i++) {
-        store.set(buildPayload({blockNumber: i}), true);
+        store.set(buildPayload({blockNumber: i}), slotNumber, true);
       }
 
       expect(store["payloads"].size).toEqual(numberOfPayloads);
@@ -338,7 +339,7 @@ describe("proof_provider/payload_store", function () {
       const numberOfPayloads = MAX_PAYLOAD_HISTORY;
 
       for (let i = 1; i <= numberOfPayloads; i++) {
-        store.set(buildPayload({blockNumber: i}), true);
+        store.set(buildPayload({blockNumber: i}), slotNumber, true);
       }
 
       expect(store["payloads"].size).toEqual(MAX_PAYLOAD_HISTORY);
@@ -352,7 +353,7 @@ describe("proof_provider/payload_store", function () {
       const numberOfPayloads = MAX_PAYLOAD_HISTORY - 1;
 
       for (let i = 1; i <= numberOfPayloads; i++) {
-        store.set(buildPayload({blockNumber: i}), true);
+        store.set(buildPayload({blockNumber: i}), slotNumber, true);
       }
 
       expect(store["payloads"].size).toEqual(numberOfPayloads);
@@ -366,7 +367,7 @@ describe("proof_provider/payload_store", function () {
       const numberOfPayloads = MAX_PAYLOAD_HISTORY + 2;
 
       for (let i = 1; i <= numberOfPayloads; i++) {
-        store.set(buildPayload({blockNumber: i}), true);
+        store.set(buildPayload({blockNumber: i}), slotNumber, true);
       }
 
       expect(store["finalizedRoots"].size).toEqual(numberOfPayloads);


### PR DESCRIPTION
**Motivation**

Make sure the web3 provider `prover` wrapper correctly handles `eth_getBlockByNumber`

**Description**

During verification, wrapped calls to `eth_getBlockByNumber` try to access EL blocks using block numbers, which is incorrect. Issue is fixed by keeping track of slots numbers when new light-client header are received.

Note that when trying to access older blocks it might get slow, as current implementation tries to find matching EL blocks by querying CL slots one by one starting from freshly finalized slots.  

Closes #6032
