### PR TITLE
chore: remove unused eslint disable directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "lerna run build",
     "build:watch": "lerna exec --parallel -- 'yarn run build:watch'",
     "build:ifchanged": "lerna exec -- ../../scripts/build_if_changed.sh",
-    "lint": "eslint --color --ext .ts packages/*/src packages/*/test",
+    "lint": "eslint --report-unused-disable-directives --color --ext .ts packages/*/src packages/*/test",
     "lint:fix": "yarn lint --fix",
     "lint-dashboards": "node scripts/lint-grafana-dashboards.mjs ./dashboards",
     "check-build": "lerna run check-build",

--- a/packages/api/src/utils/server/types.ts
+++ b/packages/api/src/utils/server/types.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import type {FastifyInstance, FastifyContextConfig} from "fastify";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import type * as fastify from "fastify";
 import {ReqGeneric} from "../types.js";
 

--- a/packages/api/test/unit/beacon/testData/events.ts
+++ b/packages/api/test/unit/beacon/testData/events.ts
@@ -5,7 +5,7 @@ import {GenericServerTestCases} from "../../../utils/genericServerTest.js";
 
 const abortController = new AbortController();
 
-/* eslint-disable @typescript-eslint/no-empty-function, @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/naming-convention */
 
 export const testData: GenericServerTestCases<Api> = {
   eventstream: {

--- a/packages/api/test/utils/utils.ts
+++ b/packages/api/test/utils/utils.ts
@@ -1,5 +1,5 @@
 import {MockedObject, vi} from "vitest";
-import qs from "qs";
+import {parse as parseQueryString} from "qs";
 import {FastifyInstance, fastify} from "fastify";
 import {mapValues} from "@lodestar/utils";
 import {ServerApi} from "../../src/interfaces.js";
@@ -7,7 +7,7 @@ import {ServerApi} from "../../src/interfaces.js";
 export function getTestServer(): {server: FastifyInstance; start: () => Promise<string>} {
   const server = fastify({
     ajv: {customOptions: {coerceTypes: "array"}},
-    querystringParser: (str) => qs.parse(str, {comma: true, parseArrays: false}),
+    querystringParser: (str) => parseQueryString(str, {comma: true, parseArrays: false}),
   });
 
   server.addHook("onError", (request, reply, error, done) => {

--- a/packages/beacon-node/src/network/core/networkCoreWorker.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorker.ts
@@ -30,7 +30,6 @@ const workerData = worker.workerData as NetworkWorkerData;
 const parentPort = worker.parentPort;
 // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 if (!workerData) throw Error("workerData must be defined");
-// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
 if (!parentPort) throw Error("parentPort must be defined");
 
 const config = createBeaconConfig(chainConfigFromJson(workerData.chainConfigJson), workerData.genesisValidatorsRoot);

--- a/packages/beacon-node/src/network/peers/score/score.ts
+++ b/packages/beacon-node/src/network/peers/score/score.ts
@@ -139,14 +139,12 @@ export class MaxScore implements IPeerScore {
     return DEFAULT_SCORE;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   add(): void {}
 
   update(): number {
     return MAX_SCORE;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   updateGossipsubScore(): void {}
 
   getStat(): PeerScoreStat {

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -212,7 +212,6 @@ export class ReqRespBeaconNode extends ReqResp {
    * Any protocol not in this list must be un-subscribed.
    */
   private getProtocolsAtFork(fork: ForkName): [ProtocolNoHandler, ProtocolHandler][] {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const protocolsAtFork: [ProtocolNoHandler, ProtocolHandler][] = [
       [protocols.Ping(this.config), this.onPing.bind(this)],
       [protocols.Status(this.config), this.onStatus.bind(this)],

--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -43,10 +43,10 @@ const G2POINT_COUNT = 65;
 const TOTAL_SIZE = 2 * POINT_COUNT_BYTES + G1POINT_BYTES * G1POINT_COUNT + G2POINT_BYTES * G2POINT_COUNT;
 
 export async function initCKZG(): Promise<void> {
-  /* eslint-disable import/no-extraneous-dependencies, @typescript-eslint/ban-ts-comment */
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
   // @ts-ignore
   ckzg = (await import("c-kzg")).default as typeof ckzg;
-  /* eslint-enable import/no-extraneous-dependencies, @typescript-eslint/ban-ts-comment */
+  /* eslint-enable @typescript-eslint/ban-ts-comment */
 }
 
 export enum TrustedFileMode {

--- a/packages/beacon-node/test/e2e/network/onWorker/workerEchoHandler.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/workerEchoHandler.ts
@@ -10,7 +10,6 @@ export async function getEchoWorker(): Promise<EchoWorker> {
   const workerThreadjs = new Worker("./workerEcho.js");
   const worker = workerThreadjs as unknown as workerThreads.Worker;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   await spawn<any>(workerThreadjs, {
     // A Lodestar Node may do very expensive task at start blocking the event loop and causing
     // the initialization to timeout. The number below is big enough to almost disable the timeout

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -58,7 +58,6 @@ describe("network / peers / PeerManager", function () {
     const reqResp = new ReqRespFake();
     const peerRpcScores = new PeerRpcScoreStore();
     const networkEventBus = new NetworkEventBus();
-    /* eslint-disable @typescript-eslint/no-empty-function */
     const mockSubnetsService: IAttnetsService = {
       getActiveSubnets: () => [],
       shouldProcess: () => true,

--- a/packages/beacon-node/test/e2e/network/reqresp.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqresp.test.ts
@@ -13,11 +13,7 @@ import {arrToSource} from "../../unit/network/reqresp/utils.js";
 import {GetReqRespHandlerFn, ReqRespMethod} from "../../../src/network/reqresp/types.js";
 import {PeerIdStr} from "../../../src/util/peerId.js";
 
-/* eslint-disable
-    require-yield,
-    @typescript-eslint/naming-convention,
-    @typescript-eslint/explicit-function-return-type
-*/
+/* eslint-disable require-yield, @typescript-eslint/naming-convention */
 
 describe(
   "network / reqresp / main thread",

--- a/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
@@ -22,7 +22,7 @@ import {testLogger} from "../../utils/logger.js";
 import {GetReqRespHandlerFn} from "../../../src/network/reqresp/types.js";
 import {LocalStatusCache} from "../../../src/network/statusCache.js";
 
-/* eslint-disable require-yield, @typescript-eslint/naming-convention */
+/* eslint-disable require-yield */
 
 describe("reqresp encoder", () => {
   let port = 60000;

--- a/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
@@ -34,7 +34,6 @@ describe(
     it("should do a finalized sync from another BN", async function () {
       // single node at beginning, use main thread to verify bls
       const genesisSlotsDelay = 4;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const genesisTime = Math.floor(Date.now() / 1000) + genesisSlotsDelay * testParams.SECONDS_PER_SLOT;
 
       const testLoggerOpts: TestLoggerOpts = {

--- a/packages/beacon-node/test/mocks/mockedBeaconDb.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconDb.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {vi, Mocked} from "vitest";
 import {config as minimalConfig} from "@lodestar/config/default";
 import {

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -41,7 +41,6 @@ describe("produceBlockBody", () => {
         config: state.config,
         db,
         logger,
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
         processShutdownCallback: () => {},
         metrics: null,
         anchorState: state,

--- a/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
+++ b/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-relative-packages
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
 import {expect} from "chai";
 import {ssz} from "@lodestar/types";

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -97,7 +97,6 @@ describe.skip("verify+import blocks - range sync perf test", () => {
           config: state.config,
           db,
           logger,
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
           processShutdownCallback: () => {},
           metrics: null,
           anchorState: state,

--- a/packages/beacon-node/test/sim/4844-interop.test.ts
+++ b/packages/beacon-node/test/sim/4844-interop.test.ts
@@ -65,7 +65,6 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     }
   });
 
-  // eslint-disable-next-line vitest/expect-expect
   it("Post-merge, run for a few blocks", async function () {
     console.log("\n\nPost-merge, run for a few blocks\n\n");
     const {elClient, tearDownCallBack} = await runEL(

--- a/packages/beacon-node/test/sim/merge-interop.test.ts
+++ b/packages/beacon-node/test/sim/merge-interop.test.ts
@@ -86,7 +86,6 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     }
   });
 
-  // eslint-disable-next-line vitest/expect-expect
   it("Send stub payloads to EL", async () => {
     const {elClient, tearDownCallBack} = await runEL(
       {...elSetupConfig, mode: ELStartMode.PostMerge},
@@ -203,7 +202,6 @@ describe("executionEngine / ExecutionEngineHttp", function () {
      */
   });
 
-  // eslint-disable-next-line vitest/expect-expect
   it("Post-merge, run for a few blocks", async function () {
     console.log("\n\nPost-merge, run for a few blocks\n\n");
     const {elClient, tearDownCallBack} = await runEL(
@@ -220,7 +218,6 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     });
   });
 
-  // eslint-disable-next-line vitest/expect-expect
   it("Pre-merge, run for a few blocks", async function () {
     console.log("\n\nPre-merge, run for a few blocks\n\n");
     const {elClient, tearDownCallBack} = await runEL(

--- a/packages/beacon-node/test/sim/mergemock.test.ts
+++ b/packages/beacon-node/test/sim/mergemock.test.ts
@@ -64,7 +64,6 @@ describe("executionEngine / ExecutionEngineHttp", function () {
   });
 
   for (const useProduceBlockV3 of [false, true]) {
-    // eslint-disable-next-line vitest/expect-expect
     it(`Test builder with useProduceBlockV3=${useProduceBlockV3}`, async function () {
       console.log("\n\nPost-merge, run for a few blocks\n\n");
       const {elClient, tearDownCallBack} = await runEL(

--- a/packages/beacon-node/test/sim/withdrawal-interop.test.ts
+++ b/packages/beacon-node/test/sim/withdrawal-interop.test.ts
@@ -70,7 +70,6 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     }
   });
 
-  // eslint-disable-next-line vitest/expect-expect
   it("Send stub payloads to EL", async () => {
     const {elClient, tearDownCallBack} = await runEL(
       {...elSetupConfig, mode: ELStartMode.PostMerge, genesisTemplate: "genesisPostWithdraw.tmpl"},
@@ -185,7 +184,6 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     );
   });
 
-  // eslint-disable-next-line vitest/expect-expect
   it("Post-merge, run for a few blocks", async function () {
     console.log("\n\nPost-merge, run for a few blocks\n\n");
     const {elClient, tearDownCallBack} = await runEL(

--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -101,7 +101,6 @@ const forkChoiceTest =
             config: createBeaconConfig(config, state.genesisValidatorsRoot),
             db: getMockedBeaconDb(),
             logger,
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
             processShutdownCallback: () => {},
             clock,
             metrics: null,
@@ -367,7 +366,6 @@ const forkChoiceTest =
           };
         },
         timeout: 10000,
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
         expectFunc: () => {},
         // Do not manually skip tests here, do it in packages/beacon-node/test/spec/presets/index.test.ts
         // EXCEPTION : this test skipped here because prefix match can't be don't for this particular test

--- a/packages/beacon-node/test/spec/presets/light_client/sync.ts
+++ b/packages/beacon-node/test/spec/presets/light_client/sync.ts
@@ -191,7 +191,6 @@ export const sync: TestRunnerFn<SyncTestCase, void> = (fork) => {
         } as SyncTestCase;
       },
       timeout: 10000,
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       expectFunc: () => {},
       // Do not manually skip tests here, do it in packages/beacon-node/test/spec/presets/index.test.ts
     },

--- a/packages/beacon-node/test/spec/presets/light_client/update_ranking.ts
+++ b/packages/beacon-node/test/spec/presets/light_client/update_ranking.ts
@@ -57,7 +57,6 @@ newUpdate = ${renderUpdate(newUpdate)}
           ? ssz.allForksLightClient[fork].LightClientUpdate
           : ssz.altair.LightClientUpdate,
       },
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       expectFunc: () => {},
       // Do not manually skip tests here, do it in packages/beacon-node/test/spec/presets/index.test.ts
     },

--- a/packages/beacon-node/test/spec/presets/ssz_static.test.ts
+++ b/packages/beacon-node/test/spec/presets/ssz_static.test.ts
@@ -60,7 +60,6 @@ const sszStatic =
 
     for (const testCase of fs.readdirSync(testSuiteDirpath)) {
       // Do not manually skip tests here, do it in packages/beacon-node/test/spec/presets/index.test.ts
-      // eslint-disable-next-line vitest/consistent-test-it
       it(testCase, function () {
         // Mainnet must deal with big full states and hash each one multiple times
         if (ACTIVE_PRESET === "mainnet") {

--- a/packages/beacon-node/test/unit/api/impl/beacon/beacon.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/beacon.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import {describe, it, expect, beforeAll} from "vitest";
 import {ApiTestModules, getApiTestModules} from "../../../../utils/api.js";
 import {getBeaconApi} from "../../../../../src/api/impl/beacon/index.js";

--- a/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
@@ -4,7 +4,6 @@ import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {ForkName} from "@lodestar/params";
 import {SignatureSetType} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
-// eslint-disable-next-line import/no-relative-packages
 import {BlsSingleThreadVerifier} from "../../../../../src/chain/bls/singleThread.js";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../../../../../src/chain/errors/index.js";
 import {IBeaconChain} from "../../../../../src/chain/index.js";

--- a/packages/beacon-node/test/unit/chain/validation/lightClientOptimisticUpdate.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/lightClientOptimisticUpdate.test.ts
@@ -9,7 +9,6 @@ import {getMockedBeaconChain} from "../../../mocks/mockedBeaconChain.js";
 
 describe("Light Client Optimistic Update validation", function () {
   const afterEachCallbacks: (() => Promise<void> | void)[] = [];
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   const config = createChainForkConfig({
     ...defaultChainConfig,
     /* eslint-disable @typescript-eslint/naming-convention */

--- a/packages/beacon-node/test/unit/network/reqresp/utils.ts
+++ b/packages/beacon-node/test/unit/network/reqresp/utils.ts
@@ -56,11 +56,8 @@ export class MockLibP2pStream implements Stream {
       this.resultChunks.push(chunk.subarray());
     }
   };
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   close: Stream["close"] = async () => {};
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   closeRead = async (): Promise<void> => {};
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   closeWrite = async (): Promise<void> => {};
   abort: Stream["abort"] = () => this.close();
 }

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -57,7 +57,6 @@ describe("sync / range / chain", () => {
   const zeroBlockBody = ssz.phase0.BeaconBlockBody.defaultValue();
   const interval: NodeJS.Timeout | null = null;
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   const reportPeer: SyncChainFns["reportPeer"] = () => {};
 
   afterEach(() => {
@@ -124,7 +123,6 @@ describe("sync / range / chain", () => {
     const targetEpoch = 16;
     const peers = [peer];
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     const processChainSegment: SyncChainFns["processChainSegment"] = async () => {};
     const downloadBeaconBlocksByRange: SyncChainFns["downloadBeaconBlocksByRange"] = async (peer, request) => {
       const blocks: BlockInput[] = [];

--- a/packages/beacon-node/test/utils/api.ts
+++ b/packages/beacon-node/test/utils/api.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import {Mocked} from "vitest";
 import {config} from "@lodestar/config/default";
 import {ForkChoice} from "@lodestar/fork-choice";

--- a/packages/beacon-node/test/utils/networkWithMockDb.ts
+++ b/packages/beacon-node/test/utils/networkWithMockDb.ts
@@ -59,7 +59,6 @@ export async function getNetworkForTest(
       config: beaconConfig,
       db,
       logger,
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       processShutdownCallback: () => {},
       // set genesis time so that we are at ALTAIR_FORK_EPOCH
       // mock timer does not work on worker thread

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -92,7 +92,6 @@ export async function getDevBeaconNode(
     config: beaconConfig,
     db,
     logger,
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     processShutdownCallback: () => {},
     peerId,
     peerStoreDir,

--- a/packages/beacon-node/test/utils/node/validator.ts
+++ b/packages/beacon-node/test/utils/node/validator.ts
@@ -70,7 +70,6 @@ export async function getAndInitDevValidators({
         api: useRestApi ? getNodeApiUrl(node) : getApiFromServerHandlers(node.api),
         slashingProtection,
         logger,
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
         processShutdownCallback: () => {},
         abortController,
         signers,

--- a/packages/cli/src/applyPreset.ts
+++ b/packages/cli/src/applyPreset.ts
@@ -1,8 +1,8 @@
 // MUST import this file first before anything and not import any Lodestar code.
 
-// eslint-disable-next-line no-restricted-imports, import/no-extraneous-dependencies
+// eslint-disable-next-line no-restricted-imports
 import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/as-sha256.js";
-// eslint-disable-next-line no-restricted-imports, import/no-extraneous-dependencies
+// eslint-disable-next-line no-restricted-imports
 import {setHasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/index.js";
 
 // without setting this first, persistent-merkle-tree will use noble instead

--- a/packages/cli/src/util/command.ts
+++ b/packages/cli/src/util/command.ts
@@ -68,7 +68,6 @@ export function registerCommandToYargs(yargs: Argv, cliCommand: CliCommand<any, 
       }
       return yargs;
     },
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     handler: cliCommand.handler || function emptyHandler(): void {},
   });
 }

--- a/packages/cli/test/utils/simulation/SimulationEnvironment.ts
+++ b/packages/cli/test/utils/simulation/SimulationEnvironment.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import fs from "node:fs";
 import {mkdir, writeFile} from "node:fs/promises";
 import path from "node:path";

--- a/packages/cli/test/utils/simulation/beacon_clients/lighthouse.ts
+++ b/packages/cli/test/utils/simulation/beacon_clients/lighthouse.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import {writeFile} from "node:fs/promises";
 import path from "node:path";
 import got, {RequestError} from "got";

--- a/packages/cli/test/utils/simulation/interfaces.ts
+++ b/packages/cli/test/utils/simulation/interfaces.ts
@@ -143,7 +143,6 @@ export interface ExecutionGeneratorOptions<E extends ExecutionClient = Execution
 
 export type LodestarAPI = Api;
 export type LighthouseAPI = Omit<Api, "lodestar"> & {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   lighthouse: {
     getPeers(): Promise<{
       status: number;

--- a/packages/cli/test/utils/simulation/runner/DockerRunner.ts
+++ b/packages/cli/test/utils/simulation/runner/DockerRunner.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import {ChildProcess} from "node:child_process";
 import {sleep} from "@lodestar/utils";
 import {

--- a/packages/cli/test/utils/simulation/validator_clients/lighthouse.ts
+++ b/packages/cli/test/utils/simulation/validator_clients/lighthouse.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import path from "node:path";
 import {writeFile} from "node:fs/promises";
 import got, {RequestError} from "got";

--- a/packages/flare/src/util/command.ts
+++ b/packages/flare/src/util/command.ts
@@ -47,7 +47,6 @@ export function registerCommandToYargs(yargs: Argv, cliCommand: CliCommand<any, 
       }
       return yargs;
     },
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     handler: cliCommand.handler || function emptyHandler(): void {},
   });
 }

--- a/packages/light-client/src/spec/utils.ts
+++ b/packages/light-client/src/spec/utils.ts
@@ -80,7 +80,6 @@ export function upgradeLightClientHeader(
         `Invalid startUpgradeFromFork=${startUpgradeFromFork} for headerFork=${headerFork} in upgradeLightClientHeader to targetFork=${targetFork}`
       );
 
-    // eslint-disable-next-line no-fallthrough
     case ForkName.altair:
     case ForkName.bellatrix:
       // Break if no further upgradation is required else fall through

--- a/packages/light-client/src/utils/logger.ts
+++ b/packages/light-client/src/utils/logger.ts
@@ -18,7 +18,6 @@ export function getLcLoggerConsole(opts?: {logDebug?: boolean}): ILcLogger {
     error: console.error,
     warn: console.warn,
     info: console.log,
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     debug: opts?.logDebug ? console.log : () => {},
   };
 }

--- a/packages/light-client/test/utils/server.ts
+++ b/packages/light-client/test/utils/server.ts
@@ -1,4 +1,4 @@
-import {parse as queryStringParse} from "qs";
+import {parse as parseQueryString} from "qs";
 import {FastifyInstance, fastify} from "fastify";
 import {fastifyCors} from "@fastify/cors";
 import {Api, ServerApi} from "@lodestar/api";
@@ -18,7 +18,7 @@ export async function startServer(
   const server = fastify({
     logger: false,
     ajv: {customOptions: {coerceTypes: "array"}},
-    querystringParser: (str) => queryStringParse(str, {comma: true, parseArrays: false}),
+    querystringParser: (str) => parseQueryString(str, {comma: true, parseArrays: false}),
   });
 
   registerRoutes(server, config, api, ["lightclient", "proof", "events"]);

--- a/packages/logger/src/node.ts
+++ b/packages/logger/src/node.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import DailyRotateFile from "winston-daily-rotate-file";
 import TransportStream from "winston-transport";
 // We want to keep `winston` export as it's more readable and easier to understand
-// eslint-disable-next-line import/no-named-as-default-member
+/* eslint-disable import/no-named-as-default-member */
 import winston from "winston";
 import type {Logger as Winston} from "winston";
 import {Logger, LogLevel, TimestampFormat} from "./interface.js";

--- a/packages/logger/src/utils/format.ts
+++ b/packages/logger/src/utils/format.ts
@@ -1,5 +1,3 @@
-// We want to keep `winston` export as it's more readable and easier to understand
-// eslint-disable-next-line import/no-named-as-default-member
 import winston, {format} from "winston";
 import {LodestarError, isEmptyObject} from "@lodestar/utils";
 import {LoggerOptions, TimestampFormatCode} from "../interface.js";

--- a/packages/logger/src/winston.ts
+++ b/packages/logger/src/winston.ts
@@ -1,6 +1,6 @@
 // We want to keep `winston` export as it's more readable and easier to understand
-// eslint-disable-next-line import/no-named-as-default-member
-import winston, {createLogger as winstonCreateLogger} from "winston";
+/* eslint-disable import/no-named-as-default-member */
+import winston from "winston";
 import type {Logger as Winston} from "winston";
 import {Logger, LoggerOptions, LogLevel, logLevelNum} from "./interface.js";
 import {getFormat} from "./utils/format.js";
@@ -48,7 +48,7 @@ export class WinstonLogger implements Logger {
   static createWinstonInstance(options: Partial<LoggerOptions> = {}, transports?: winston.transport[]): Winston {
     const defaultMeta: DefaultMeta = {module: options?.module || ""};
 
-    return winstonCreateLogger({
+    return winston.createLogger({
       // Do not set level at the logger level. Always control by Transport, unless for testLogger
       level: options.level,
       defaultMeta,

--- a/packages/logger/test/e2e/logger/workerLoggerHandler.ts
+++ b/packages/logger/test/e2e/logger/workerLoggerHandler.ts
@@ -14,7 +14,6 @@ export async function getLoggerWorker(opts: WorkerData): Promise<LoggerWorker> {
   });
   const worker = workerThreadjs as unknown as workerThreads.Worker;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   await spawn<any>(workerThreadjs, {
     // A Lodestar Node may do very expensive task at start blocking the event loop and causing
     // the initialization to timeout. The number below is big enough to almost disable the timeout

--- a/packages/logger/test/unit/utils/json.test.ts
+++ b/packages/logger/test/unit/utils/json.test.ts
@@ -24,13 +24,9 @@ describe("Json helper", () => {
       {id: "symbol", arg: Symbol("foo"), json: "Symbol(foo)"},
 
       // Functions
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       {id: "function", arg: function () {}, json: "function() {\n      }"},
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       {id: "arrow function", arg: () => {}, json: "() => {\n      }"},
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       {id: "async function", arg: async function () {}, json: "async function() {\n      }"},
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       {id: "async arrow function", arg: async () => {}, json: "async () => {\n      }"},
 
       // Arrays

--- a/packages/prover/src/utils/command.ts
+++ b/packages/prover/src/utils/command.ts
@@ -47,7 +47,6 @@ export function registerCommandToYargs(yargs: Argv, cliCommand: CliCommand<any, 
       }
       return yargs;
     },
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     handler: cliCommand.handler || function emptyHandler(): void {},
   });
 }

--- a/packages/prover/test/e2e/web3_batch_request.test.ts
+++ b/packages/prover/test/e2e/web3_batch_request.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import {describe, it, expect, beforeAll} from "vitest";
 import {Web3} from "web3";
 import {LCTransport} from "../../src/interfaces.js";

--- a/packages/prover/test/e2e/web3_provider.test.ts
+++ b/packages/prover/test/e2e/web3_provider.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import {describe, it, expect, beforeAll} from "vitest";
 import {Web3} from "web3";
 import {ethers} from "ethers";

--- a/packages/reqresp/src/ReqResp.ts
+++ b/packages/reqresp/src/ReqResp.ts
@@ -59,7 +59,6 @@ export class ReqResp {
   /** `${protocolPrefix}/${method}/${version}/${encoding}` */
   // Use any to avoid TS error on registering protocol
   // Type 'unknown' is not assignable to type 'Resp'
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private readonly registeredProtocols = new Map<ProtocolID, MixedProtocol>();
   private readonly dialOnlyProtocols = new Map<ProtocolID, boolean>();
 
@@ -251,7 +250,6 @@ export class ReqResp {
     // Override
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected onIncomingRequestError(_protocol: ProtocolDescriptor, _error: RequestError): void {
     // Override
   }

--- a/packages/reqresp/test/fixtures/messages.ts
+++ b/packages/reqresp/test/fixtures/messages.ts
@@ -181,5 +181,4 @@ const ALTAIR_FORK_EPOCH = Math.floor(slotBlockAltair / SLOTS_PER_EPOCH);
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const beaconConfig = createBeaconConfig({...chainConfig, ALTAIR_FORK_EPOCH}, ZERO_HASH);
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
 export const getEmptyHandler = <T = unknown>() => async function* emptyHandler(): AsyncGenerator<T> {};

--- a/packages/reqresp/test/unit/encoders/responseDecode.test.ts
+++ b/packages/reqresp/test/unit/encoders/responseDecode.test.ts
@@ -13,7 +13,6 @@ describe("encoders / responseDecode", () => {
     it.each(responseEncodersTestCases)("$id", async ({protocol, responseChunks, chunks}) => {
       const responses = (await pipe(
         arrToSource(chunks),
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
         responseDecode(protocol, {onFirstHeader: () => {}, onFirstResponseChunk: () => {}}),
         all
       )) as ResponseIncoming[];
@@ -32,7 +31,6 @@ describe("encoders / responseDecode", () => {
         await expectRejectedWithLodestarError(
           pipe(
             arrToSource(chunks as Uint8Array[]),
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
             responseDecode(protocol, {onFirstHeader: () => {}, onFirstResponseChunk: () => {}}),
             all
           ),

--- a/packages/reqresp/test/utils/index.ts
+++ b/packages/reqresp/test/utils/index.ts
@@ -73,11 +73,8 @@ export class MockLibP2pStream implements Stream {
     }
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   close: Stream["close"] = async () => {};
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   closeRead = async (): Promise<void> => {};
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   closeWrite = async (): Promise<void> => {};
   abort: Stream["abort"] = () => this.close();
 }

--- a/packages/reqresp/test/utils/response.ts
+++ b/packages/reqresp/test/utils/response.ts
@@ -8,11 +8,7 @@ import {arrToSource} from "../utils/index.js";
 export async function* responseEncode(responseChunks: ResponseChunk[], protocol: Protocol): AsyncIterable<Buffer> {
   for (const chunk of responseChunks) {
     if (chunk.status === RespStatus.SUCCESS) {
-      yield* pipe(
-        arrToSource([chunk.payload]),
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        responseEncodeSuccess(protocol, {onChunk: () => {}})
-      );
+      yield* pipe(arrToSource([chunk.payload]), responseEncodeSuccess(protocol, {onChunk: () => {}}));
     } else {
       yield* responseEncodeError(protocol, chunk.status, chunk.errorMessage);
     }

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import fs from "node:fs";
 import path from "node:path";
 import stream from "node:stream";
@@ -10,7 +10,6 @@ import retry from "async-retry";
 
 export const defaultSpecTestsRepoUrl = "https://github.com/ethereum/consensus-spec-tests";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
 const logEmpty = (): void => {};
 
 export type DownloadTestsOptions = {

--- a/packages/utils/src/sleep.ts
+++ b/packages/utils/src/sleep.ts
@@ -12,7 +12,6 @@ export async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal && signal.aborted) return reject(new ErrorAborted());
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
     let onDone: () => void = () => {};
 
     const timeout = setTimeout(() => {

--- a/packages/utils/test/unit/err.test.ts
+++ b/packages/utils/test/unit/err.test.ts
@@ -1,8 +1,6 @@
 import {describe, it, expect} from "vitest";
 import {Err, isErr, mapOkResults, mapOkResultsAsync, Result} from "../../src/err.js";
 
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-
 describe("Result Err", () => {
   describe("isErr works with any type", () => {
     const values: any[] = [
@@ -15,7 +13,6 @@ describe("Result Err", () => {
       null,
       [1, 2],
       new Uint8Array(1),
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
       function test() {},
       {a: 1},
       new AbortController(),

--- a/packages/validator/test/utils/clock.ts
+++ b/packages/validator/test/utils/clock.ts
@@ -11,7 +11,6 @@ export class ClockMock implements IClock {
   private readonly everySlot: RunEveryFn[] = [];
   private readonly everyEpoch: RunEveryFn[] = [];
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   start = (): void => {};
   runEverySlot = (fn: RunEveryFn): number => this.everySlot.push(fn);
   runEveryEpoch = (fn: RunEveryFn): number => this.everyEpoch.push(fn);


### PR DESCRIPTION
**Motivation**

Eslint disable directives are quite noisy and might be confusing if they are unused (related https://github.com/ChainSafe/lodestar/pull/5046)

**Description**

- Remove unused eslint disable directives
- Update yarn lint to [report unused eslint disable directives](https://eslint.org/docs/latest/use/command-line-interface#--report-unused-disable-directives), this will help us detect unused rules early, for example in the case where a plugin we extend removed a rule, or due to other code changes
- Clean up unused rules added in [#6420](https://github.com/ChainSafe/lodestar/pull/6420), and other related changes


The `@typescript-eslint/no-empty-function` (see [docs](https://eslint.org/docs/latest/rules/no-empty-function)) rule seems to have been removed at some point from one of the [plugins we extend](https://github.com/ChainSafe/lodestar/blob/227930cdf61d266d25df466ea08a53a955114a5b/.eslintrc.js#L19-L26) from. I don't think we should add this rule ourselves as it is not really useful and just causes noise.
