### PR TITLE
fix: improve error if lockfile exists but not a directory

### DIFF
--- a/packages/cli/src/util/lockfile.ts
+++ b/packages/cli/src/util/lockfile.ts
@@ -11,8 +11,8 @@ export function lockFilepath(filepath: string): void {
       realpath: false,
     });
   } catch (e) {
-    if (isLockfileError(e) && e.code === "ELOCKED") {
-      e.message = `${filepath} is already in use by another process`;
+    if (isLockfileError(e) && (e.code === "ELOCKED" || e.code === "ENOTDIR")) {
+      e.message = `'${filepath}' already in use by another process`;
     }
     throw e;
   }
@@ -38,7 +38,7 @@ export function unlockFilepath(filepath: string): void {
 }
 
 // https://github.com/moxystudio/node-proper-lockfile/blob/9f8c303c91998e8404a911dc11c54029812bca69/lib/lockfile.js#L53
-export type LockfileError = Error & {code: "ELOCKED" | "ENOTACQUIRED"};
+export type LockfileError = Error & {code: "ELOCKED" | "ENOTACQUIRED" | "ENOTDIR"};
 
 function isLockfileError(e: unknown): e is LockfileError {
   return e instanceof Error && (e as LockfileError).code !== undefined;

--- a/packages/cli/test/e2e/importKeystoresFromApi.test.ts
+++ b/packages/cli/test/e2e/importKeystoresFromApi.test.ts
@@ -95,10 +95,10 @@ describe("import keystores from api", function () {
       validator.on("exit", (code) => {
         if (code !== null && code > 0) {
           // process should exit with code > 0, and an error related to locks. Sample error:
-          // vc 351591:  ✖ Error: /tmp/tmp-5080-lwNxdM5Ok9ya/import-keystores-test/keystores/0x8be678633e927aa0435addad5dcd5283fef6110d91362519cd6d43e61f6c017d724fa579cc4b2972134e050b6ba120c0/voting-keystore.json is already in use by another process
+          // vc 351591:  ✖ Error: '/tmp/tmp-5080-lwNxdM5Ok9ya/import-keystores-test/keystores/0x8be678633e927aa0435addad5dcd5283fef6110d91362519cd6d43e61f6c017d724fa579cc4b2972134e050b6ba120c0/voting-keystore.json' already in use by another process
           // at /home/runner/actions-runner/_work/lodestar/lodestar/node_modules/proper-lockfile/lib/lockfile.js:68:47
           // ... more stack trace
-          if (/Error.*voting-keystore\.json is already in use by another process/.test(vcProc2Stderr.read())) {
+          if (/Error.*voting-keystore\.json' already in use by another process/.test(vcProc2Stderr.read())) {
             resolve();
           } else {
             reject(Error(`Second validator proc exited with unknown error. stderr:\n${vcProc2Stderr.read()}`));

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -52,7 +52,7 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
       await db.open();
     } catch (e) {
       if ((e as LevelDbError).cause?.code === "LEVEL_LOCKED") {
-        throw new Error("Database is already in use by another process");
+        throw new Error("Database already in use by another process");
       }
       throw e;
     }


### PR DESCRIPTION
**Motivation**

We have upgraded the locking library in 1.15.1 (https://github.com/ChainSafe/lodestar/pull/6363) which now uses directories as .lock "files" this leads to a misleading error if users upgraded from previous versions and for some reason their previous .lock files are not cleaned up, see https://github.com/ChainSafe/lodestar/issues/6449.

There is also another case, where a user runs another client such as Teku which [implements its own file locking](https://docs.teku.consensys.io/how-to/troubleshoot/general#keystore-file-already-in-use) but might also use files for locking instead of directories.

P.S. In case you wonder why [proper-lockfile](https://www.npmjs.com/package/proper-lockfile) uses directories
> This library utilizes the mkdir strategy which works atomically on any kind of file system, even network based ones.


**Description**

Improve error if lockfile exists but not a directory

