### PR TITLE
refactor: update retry function

### DIFF
--- a/packages/beacon-node/src/eth1/provider/jsonRpcHttpClient.ts
+++ b/packages/beacon-node/src/eth1/provider/jsonRpcHttpClient.ts
@@ -166,7 +166,7 @@ export class JsonRpcHttpClient implements IJsonRpcHttpClient {
           return this.fetchJson({jsonrpc: "2.0", id: this.id++, ...payload}, opts);
         },
         {
-          retries: opts?.retryAttempts ?? this.opts?.retryAttempts ?? 1,
+          retries: opts?.retryAttempts ?? this.opts?.retryAttempts ?? 0,
           retryDelay: opts?.retryDelay ?? this.opts?.retryDelay ?? 0,
           shouldRetry: opts?.shouldRetry,
           signal: this.opts?.signal,

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -118,7 +118,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
   async submitBlindedBlock(
     signedBlindedBlock: allForks.SignedBlindedBeaconBlock
   ): Promise<allForks.SignedBeaconBlockOrContents> {
-    const res = await this.api.submitBlindedBlock(signedBlindedBlock, {retryAttempts: 3});
+    const res = await this.api.submitBlindedBlock(signedBlindedBlock, {retryAttempts: 2});
     ApiError.assert(res, "execution.builder.submitBlindedBlock");
     const {data} = res.response;
 

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -72,7 +72,7 @@ export const defaultExecutionEngineHttpOpts: ExecutionEngineHttpOpts = {
    * port/url, one can override this and skip providing a jwt secret.
    */
   urls: ["http://localhost:8551"],
-  retryAttempts: 3,
+  retryAttempts: 2,
   retryDelay: 2000,
   timeout: 12000,
 };
@@ -305,7 +305,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     // If we are just fcUing and not asking execution for payload, retry is not required
     // and we can move on, as the next fcU will be issued soon on the new slot
     const fcUReqOpts =
-      payloadAttributes !== undefined ? forkchoiceUpdatedV1Opts : {...forkchoiceUpdatedV1Opts, retryAttempts: 1};
+      payloadAttributes !== undefined ? forkchoiceUpdatedV1Opts : {...forkchoiceUpdatedV1Opts, retryAttempts: 0};
 
     const request = this.rpcFetchQueue.push({
       method,

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -85,7 +85,7 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           log(`Downloaded  ${url}`);
         },
         {
-          retries: 3,
+          retries: 2,
           onRetry: (e, attempt) => {
             log(`Download attempt ${attempt} for ${url} failed: ${e.message}`);
           },

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -85,7 +85,7 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           log(`Downloaded  ${url}`);
         },
         {
-          retries: 2,
+          retries: 3,
           onRetry: (e, attempt) => {
             log(`Download attempt ${attempt} for ${url} failed: ${e.message}`);
           },

--- a/packages/utils/src/retry.ts
+++ b/packages/utils/src/retry.ts
@@ -32,6 +32,7 @@ export type RetryOptions = {
  */
 export async function retry<A>(fn: (attempt: number) => A | Promise<A>, opts?: RetryOptions): Promise<A> {
   const maxRetries = opts?.retries ?? 5;
+  // Number of retries + the initial attempt
   const maxAttempts = maxRetries + 1;
   const shouldRetry = opts?.shouldRetry;
   const onRetry = opts?.onRetry;

--- a/packages/utils/src/retry.ts
+++ b/packages/utils/src/retry.ts
@@ -26,10 +26,12 @@ export type RetryOptions = {
  */
 export async function retry<A>(fn: (attempt: number) => A | Promise<A>, opts?: RetryOptions): Promise<A> {
   const maxRetries = opts?.retries ?? 5;
+  // The maximum number of attempts is the number of retries + the initial attempt
+  const maxAttempts = maxRetries + 1;
   const shouldRetry = opts?.shouldRetry;
 
   let lastError: Error = Error("RetryError");
-  for (let i = 1; i <= maxRetries; i++) {
+  for (let i = 1; i <= maxAttempts; i++) {
     try {
       return await fn(i);
     } catch (e) {

--- a/packages/utils/src/retry.ts
+++ b/packages/utils/src/retry.ts
@@ -36,7 +36,11 @@ export async function retry<A>(fn: (attempt: number) => A | Promise<A>, opts?: R
       return await fn(i);
     } catch (e) {
       lastError = e as Error;
-      if (shouldRetry && !shouldRetry(lastError)) {
+
+      if (i == maxAttempts) {
+        // If we have reached the maximum number of attempts, there's no need to check if we should retry
+        break;
+      } else if (shouldRetry && !shouldRetry(lastError)) {
         break;
       } else if (opts?.retryDelay !== undefined) {
         await sleep(opts?.retryDelay, opts?.signal);

--- a/packages/utils/src/retry.ts
+++ b/packages/utils/src/retry.ts
@@ -26,7 +26,6 @@ export type RetryOptions = {
  */
 export async function retry<A>(fn: (attempt: number) => A | Promise<A>, opts?: RetryOptions): Promise<A> {
   const maxRetries = opts?.retries ?? 5;
-  // The maximum number of attempts is the number of retries + the initial attempt
   const maxAttempts = maxRetries + 1;
   const shouldRetry = opts?.shouldRetry;
 
@@ -37,8 +36,8 @@ export async function retry<A>(fn: (attempt: number) => A | Promise<A>, opts?: R
     } catch (e) {
       lastError = e as Error;
 
-      if (i == maxAttempts) {
-        // If we have reached the maximum number of attempts, there's no need to check if we should retry
+      if (i === maxAttempts) {
+        // Reached maximum number of attempts, there's no need to check if we should retry
         break;
       } else if (shouldRetry && !shouldRetry(lastError)) {
         break;


### PR DESCRIPTION
**Motivation**

Update `retry` function.

**Description**

Updates the `retry` function to follow a more common pattern used in other libraries such as [retry](https://www.npmjs.com/package/retry) and [retry-request](https://www.npmjs.com/package/retry-request), which, if `retries=1` it will call the function and on failure retry it once.

Resolves  #6447

Closes #6447
