### PR TITLE
feat: add cli flag to ignore the wss check failure on checkpoint sync

### DIFF
--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -12,6 +12,7 @@ type BeaconExtraArgs = {
   checkpointState?: string;
   wssCheckpoint?: string;
   forceCheckpointSync?: boolean;
+  ignoreWeakSubjectivityCheck?: boolean;
   beaconDir?: string;
   dbDir?: string;
   persistInvalidSszObjectsDir?: string;
@@ -71,6 +72,14 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
   forceCheckpointSync: {
     description:
       "Force syncing from checkpoint state even if db state is within weak subjectivity period. This helps to avoid long sync times after node has been offline for a while.",
+    type: "boolean",
+    group: "weak subjectivity",
+  },
+
+  ignoreWeakSubjectivityCheck: {
+    description:
+      "Ignore the checkpoint sync state failing the weak subjectivity check. This is relevant in testnets where the weak subjectivity period is too small for even few epochs of non finalization causing last finalized to be out of range. This flag is not recommended for mainnet use.",
+    hidden: true,
     type: "boolean",
     group: "weak subjectivity",
   },

--- a/packages/cli/src/util/errors.ts
+++ b/packages/cli/src/util/errors.ts
@@ -11,9 +11,9 @@ export async function wrapError<T>(promise: Promise<T>): Promise<Result<T>> {
     return {err: err as Error};
   }
 }
-export function wrapFnError<T>(evalFn: () => T): Result<T> {
+export function wrapFnError<T>(fn: () => T): Result<T> {
   try {
-    return {err: null, result: evalFn()};
+    return {err: null, result: fn()};
   } catch (err) {
     return {err: err as Error};
   }

--- a/packages/cli/src/util/errors.ts
+++ b/packages/cli/src/util/errors.ts
@@ -11,3 +11,10 @@ export async function wrapError<T>(promise: Promise<T>): Promise<Result<T>> {
     return {err: err as Error};
   }
 }
+export function wrapFnError<T>(evalFn: () => T): Result<T> {
+  try {
+    return {err: null, result: evalFn()};
+  } catch (err) {
+    return {err: err as Error};
+  }
+}


### PR DESCRIPTION
another one of the asks of EF devops @barnabasbusa @parithosh):

on testnets sometimes finalized gets soon out of wss range (or checkpointz software lags a big in updating the finalized) causing checkpoint sync to fail. this flag ignore the failure