### PR TITLE
fix: do not register libp2p handler twice for same protocol

### DIFF
--- a/packages/reqresp/test/unit/ReqResp.test.ts
+++ b/packages/reqresp/test/unit/ReqResp.test.ts
@@ -63,5 +63,13 @@ describe("ResResp", () => {
       expect(reqresp.getRegisteredProtocols()).toEqual(["/eth2/beacon_chain/req/number_to_string/1/ssz_snappy"]);
       expect(libp2p.handle).toHaveBeenCalledOnce();
     });
+
+    it("should not register handler twice for same protocol if ignoreIfDuplicate=true", async () => {
+      await reqresp.registerProtocol(numberToStringProtocol, {ignoreIfDuplicate: true});
+      expect(libp2p.handle).toHaveBeenCalledOnce();
+
+      await reqresp.registerProtocol(numberToStringProtocol, {ignoreIfDuplicate: true});
+      expect(libp2p.handle).toHaveBeenCalledOnce();
+    });
   });
 });


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/6319

**Description**

In https://github.com/ChainSafe/lodestar/pull/5325 we have split out some functionality to be able to register dial only protocols but duplicate check to not register libp2p handler twice for same protocol has been moved in a function which does not even call `libp2p.handle`.

This changes adds it back in the right place and makes sure we do not register libp2p handler twice for same protocol.