### PR TITLE
feat: add logs to track number of http retries

### DIFF
--- a/packages/api/src/utils/client/client.ts
+++ b/packages/api/src/utils/client/client.ts
@@ -8,10 +8,10 @@ import {HttpStatusCode} from "./httpStatusCode.js";
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 type ExtraOpts = {retryAttempts?: number};
-type ParamatersWithOptionalExtaOpts<T extends (...args: any) => any> = [...Parameters<T>, ExtraOpts] | Parameters<T>;
+type ParametersWithOptionalExtraOpts<T extends (...args: any) => any> = [...Parameters<T>, ExtraOpts] | Parameters<T>;
 
 export type ApiWithExtraOpts<T extends Record<string, APIClientHandler>> = {
-  [K in keyof T]: (...args: ParamatersWithOptionalExtaOpts<T[K]>) => ReturnType<T[K]>;
+  [K in keyof T]: (...args: ParametersWithOptionalExtraOpts<T[K]>) => ReturnType<T[K]>;
 };
 
 // See /packages/api/src/routes/index.ts for reasoning
@@ -71,7 +71,7 @@ export function generateGenericJsonClient<
     const returnType = returnTypes[routeId as keyof ReturnTypes<Api>] as TypeJson<any> | null;
 
     return async function request(
-      ...args: ParamatersWithOptionalExtaOpts<Api[keyof Api]>
+      ...args: ParametersWithOptionalExtraOpts<Api[keyof Api]>
     ): Promise<ReturnType<Api[keyof Api]>> {
       try {
         // extract the extraOpts if provided

--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -63,7 +63,6 @@
   ],
   "dependencies": {
     "@lodestar/utils": "^1.15.1",
-    "async-retry": "^1.3.3",
     "axios": "^1.3.4",
     "rimraf": "^4.4.1",
     "snappyjs": "^0.7.0",
@@ -71,7 +70,6 @@
     "vitest": "^1.2.1"
   },
   "devDependencies": {
-    "@types/async-retry": "1.4.3",
     "@types/tar": "^6.1.4"
   },
   "peerDependencies": {

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -6,7 +6,7 @@ import {promisify} from "node:util";
 import {rimraf} from "rimraf";
 import axios from "axios";
 import {x as extractTar} from "tar";
-import retry from "async-retry";
+import {retry} from "@lodestar/utils";
 
 export const defaultSpecTestsRepoUrl = "https://github.com/ethereum/consensus-spec-tests";
 
@@ -67,7 +67,6 @@ export async function downloadGenericSpecTests<TestNames extends string>(
       const url = `${specTestsRepoUrl ?? defaultSpecTestsRepoUrl}/releases/download/${specVersion}/${test}.tar.gz`;
 
       await retry(
-        // async (bail) => {
         async () => {
           const {data, headers} = await axios({
             method: "get",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,13 +2810,6 @@
   resolved "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz"
   integrity sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ==
 
-"@types/async-retry@1.4.3":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/@types/async-retry/-/async-retry-1.4.3.tgz#8b78f6ce88d97e568961732cdd9e5325cdc8c246"
-  integrity sha512-B3C9QmmNULVPL2uSJQ088eGWTNPIeUk35hca6CV8rRDJ8GXuQJP5CCVWA1ZUCrb9xYP7Js/RkLqnNNwKhe+Zsw==
-  dependencies:
-    "@types/retry" "*"
-
 "@types/buffer-xor@^2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@types/buffer-xor/-/buffer-xor-2.0.0.tgz"
@@ -3964,13 +3957,6 @@ async-lock@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/async-lock/-/async-lock-1.4.0.tgz#c8b6630eff68fbbdd8a5b6eb763dac3bfbb8bf02"
   integrity sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ==
-
-async-retry@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz"
-  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
-  dependencies:
-    retry "0.13.1"
 
 async@^3.2.3:
   version "3.2.4"
@@ -10938,11 +10924,6 @@ ret@~0.2.0:
   version "0.2.2"
   resolved "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz"
   integrity sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==
-
-retry@0.13.1:
-  version "0.13.1"
-  resolved "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz"
-  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 retry@^0.12.0:
   version "0.12.0"


### PR DESCRIPTION
**Motivation**

We added retry functionality to builder publish requests in https://github.com/ChainSafe/lodestar/pull/6387 but there is no way to see if retries were actually required or not, and what was the error that caused the retry. This information is important in case we miss or orphan a block due to delayed publishing.

**Description**

Add logs to track number of http retries
