### PR TITLE
Change * value to 'all' for improved bash compatibility ( Issue #5963 )

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -1,11 +1,6 @@
 import { defaultOptions, IBeaconNodeOptions, allNamespaces } from "@lodestar/beacon-node";
 import { CliCommandOptions } from "../../util/index.js";
 
-// Before: Original value was "*"
-// The original value "*" is not very friendly to use in bash scripts as it's interpreted as a wildcard character.
-// This change replaces "*" with "all" to improve compatibility with bash scripts.
-
-// After: Changed to "all" for better compatibility with bash scripts
 const enabledAll = "all";
 
 export type ApiArgs = {

--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -1,5 +1,5 @@
-import { defaultOptions, IBeaconNodeOptions, allNamespaces } from "@lodestar/beacon-node";
-import { CliCommandOptions } from "../../util/index.js";
+import {defaultOptions, IBeaconNodeOptions, allNamespaces} from "@lodestar/beacon-node";
+import {CliCommandOptions} from "../../util/index.js";
 
 const enabledAll = "all";
 

--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -1,7 +1,12 @@
-import {defaultOptions, IBeaconNodeOptions, allNamespaces} from "@lodestar/beacon-node";
-import {CliCommandOptions} from "../../util/index.js";
+import { defaultOptions, IBeaconNodeOptions, allNamespaces } from "@lodestar/beacon-node";
+import { CliCommandOptions } from "../../util/index.js";
 
-const enabledAll = "*";
+// Before: Original value was "*"
+// The original value "*" is not very friendly to use in bash scripts as it's interpreted as a wildcard character.
+// This change replaces "*" with "all" to improve compatibility with bash scripts.
+
+// After: Changed to "all" for better compatibility with bash scripts
+const enabledAll = "all";
 
 export type ApiArgs = {
   "api.maxGindicesInProof"?: number;
@@ -49,8 +54,8 @@ export const options: CliCommandOptions<ApiArgs> = {
 
   "rest.namespace": {
     type: "array",
-    choices: [...allNamespaces, enabledAll],
-    description: `Pick namespaces to expose for HTTP API. Set to '${enabledAll}' to enable all namespaces`,
+    choices: [...allNamespaces, enabledAll], // Added 'enabledAll' to the list of choices
+    description: `Pick namespaces to expose for HTTP API. Set to '${enabledAll}' to enable all namespaces`, // Updated description
     defaultDescription: JSON.stringify(defaultOptions.api.rest.api),
     group: "api",
     coerce: (namespaces: string[]): string[] => {

--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -49,8 +49,8 @@ export const options: CliCommandOptions<ApiArgs> = {
 
   "rest.namespace": {
     type: "array",
-    choices: [...allNamespaces, enabledAll], // Added 'enabledAll' to the list of choices
-    description: `Pick namespaces to expose for HTTP API. Set to '${enabledAll}' to enable all namespaces`, // Updated description
+    choices: [...allNamespaces, enabledAll],
+    description: `Pick namespaces to expose for HTTP API. Set to '${enabledAll}' to enable all namespaces`,
     defaultDescription: JSON.stringify(defaultOptions.api.rest.api),
     group: "api",
     coerce: (namespaces: string[]): string[] => {


### PR DESCRIPTION
**Motivation**

<!-- Why is this PR exists? What are the goals of the pull request? -->

The motivation behind this PR is to address issue #5963, which was opened on Sep 18, 2023, by nflaig. The problem described in the issue is that the usage of `"*"` as a value in certain CLI flags is not friendly to use in bash scripts. This is because `*` is interpreted as a wildcard character in bash, rather than as a string. The goal of this PR is to replace the usage of `"*"` with a more bash-friendly value, such as the word "all", to improve compatibility with bash scripts.

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

The changes made in this PR involve replacing the usage of `"*"` with `"all"` in the `enabledAll` variable declaration. This change ensures better compatibility with bash scripts, as `"*"` can cause issues when interpreted as a wildcard character in bash environments. The modification is made in the `api.ts` file located at `lodestar/packages/cli/src/options/beaconNodeOptions/api.ts`, specifically on line 4.

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #5963

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <new_branch>
lodestar beacon --new-flag option1
```
-->