### PR TITLE
fix: update SSE payload attributes to be spec compliant

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -519,7 +519,7 @@ export async function getPayloadAttributesForSSE(
     const ssePayloadAttributes: allForks.SSEPayloadAttributes = {
       proposerIndex: prepareState.epochCtx.getBeaconProposer(prepareSlot),
       proposalSlot: prepareSlot,
-      proposalBlockNumber: prepareState.latestExecutionPayloadHeader.blockNumber + 1,
+      parentBlockNumber: prepareState.latestExecutionPayloadHeader.blockNumber,
       parentBlockRoot,
       parentBlockHash: parentHash,
       payloadAttributes,

--- a/packages/types/src/bellatrix/sszTypes.ts
+++ b/packages/types/src/bellatrix/sszTypes.ts
@@ -222,7 +222,7 @@ export const SSEPayloadAttributesCommon = new ContainerType(
   {
     proposerIndex: UintNum64,
     proposalSlot: Slot,
-    proposalBlockNumber: UintNum64,
+    parentBlockNumber: UintNum64,
     parentBlockRoot: Root,
     parentBlockHash: Root,
   },


### PR DESCRIPTION
**Motivation**

We have added SSE payload attributes in https://github.com/ChainSafe/lodestar/pull/5281 but the ssz type is not according to the spec as it should include the parent block number instead of proposal slot number.

[apis/eventstream/index.yaml#L126](https://github.com/ethereum/beacon-APIs/blob/0fc77b79df7e6293192cf4cd97a8d94387ea640d/apis/eventstream/index.yaml#L126)
> `parent_block_number`: the execution block number of the parent block.


**Description**

Updates `SSEPayloadAttributes` ssz type and sets block number based on latest execution payload header (from pre-state)
