### PR TITLE
ci: remove duplicate debug logs upload step

### DIFF
--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: 20
           check-latest: true
-          cache: yarn          
+          cache: yarn
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
@@ -89,13 +89,6 @@ jobs:
           LODESTAR_PRESET: mainnet
           ENGINE_PORT: 8551
           ETH_PORT: 8661
-
-      - name: Upload debug log test files
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: debug-test-logs
-          path: packages/beacon-node/test-logs
 
       - name: Pull geth withdrawals
         run: docker pull $GETH_WITHDRAWALS_IMAGE


### PR DESCRIPTION
**Motivation**

https://github.com/ChainSafe/lodestar/actions/runs/8006063823/job/21866912900#step:19:20

![image](https://github.com/ChainSafe/lodestar/assets/38436224/e0653c08-387e-4681-95f9-1090f04477a4)

**Description**

Remove duplicate debug logs upload step causing 409 error. See related issue https://github.com/actions/upload-artifact/issues/478, previously v3 would just override files while v4 now throws an error.
