### PR TITLE
fix: increase bodyLimit of the beacon api server

### DIFF
--- a/packages/beacon-node/src/api/rest/index.ts
+++ b/packages/beacon-node/src/api/rest/index.ts
@@ -21,7 +21,7 @@ export const beaconRestApiServerOpts: BeaconRestApiServerOpts = {
   port: 9596,
   cors: "*",
   // beacon -> validator API is trusted, and for large amounts of keys the payload is multi-MB
-  bodyLimit: 100 * 1024 * 1024, // 100MB for block + blobs
+  bodyLimit: 20 * 1024 * 1024, // 20MB for big block + blobs
 };
 
 export type BeaconRestApiServerModules = RestApiServerModules & {

--- a/packages/beacon-node/src/api/rest/index.ts
+++ b/packages/beacon-node/src/api/rest/index.ts
@@ -21,7 +21,7 @@ export const beaconRestApiServerOpts: BeaconRestApiServerOpts = {
   port: 9596,
   cors: "*",
   // beacon -> validator API is trusted, and for large amounts of keys the payload is multi-MB
-  bodyLimit: 10 * 1024 * 1024, // 10MB
+  bodyLimit: 100 * 1024 * 1024, // 100MB for block + blobs
 };
 
 export type BeaconRestApiServerModules = RestApiServerModules & {


### PR DESCRIPTION
EF devops reported that while testing  https://dora.dencun-msf-1.ethpandaops.io/slots

```
Feb-23 11:43:53.455[rest]            error: Req req-aiw publishBlockV2 error - Request body is too large
FastifyError: Request body is too large
    at rawBody (/usr/app/node_modules/fastify/lib/contentTypeParser.js:209:16)
    at ContentTypeParser.run (/usr/app/node_modules/fastify/lib/contentTypeParser.js:169:5)
    at handleRequest (/usr/app/node_modules/fastify/lib/handleRequest.js:41:33)
    at runPreParsing (/usr/app/node_modules/fastify/lib/route.js:569:5)
    at next (/usr/app/node_modules/fastify/lib/hooks.js:179:7)
    at handleResolve (/usr/app/node_modules/fastify/lib/hooks.js:196:5)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

probably 7Mb blocks + blobs are pushing over the limit, locally fix seems to be working on resolving this error but there is another issue of latency between val<>beacon for these big blocks which needs to be looked as as well, but its an independent issue to be tackled (currently looking into that)

@philknows  @wemeetagain  we might need to cut a patch release with this