### PR TITLE
chore: update yarn links to point to classic yarn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing to Lodestar. It's people like you that 
 ## Prerequisites
 
 - :gear: [NodeJS](https://nodejs.org/) (LTS)
-- :toolbox: [Yarn](https://yarnpkg.com/)
+- :toolbox: [Yarn](https://classic.yarnpkg.com/lang/en/)
 
 ### MacOS Specifics
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ## Prerequisites
 
 - :gear: [NodeJS](https://nodejs.org/) (LTS)
-- :toolbox: [Yarn](https://yarnpkg.com/)
+- :toolbox: [Yarn](https://classic.yarnpkg.com/lang/en/)
 
 ###### Developer Quickstart:
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -36,7 +36,7 @@ api.beacon
 ## Prerequisites
 
 - [NodeJS](https://nodejs.org/) (LTS)
-- [Yarn](https://yarnpkg.com/)
+- [Yarn](https://classic.yarnpkg.com/lang/en/)
 
 ## What you need
 

--- a/packages/beacon-node/README.md
+++ b/packages/beacon-node/README.md
@@ -9,7 +9,7 @@
 
 ## Prerequisites
 
-- [Yarn](https://yarnpkg.com/)
+- [Yarn](https://classic.yarnpkg.com/lang/en/)
 
 ## What you need
 

--- a/packages/prover/README.md
+++ b/packages/prover/README.md
@@ -114,7 +114,7 @@ lodestar-prover proxy \
 ## Prerequisites
 
 - [NodeJS](https://nodejs.org/) (LTS)
-- [Yarn](https://yarnpkg.com/)
+- [Yarn](https://classic.yarnpkg.com/lang/en/)
 
 ## What you need
 

--- a/packages/reqresp/README.md
+++ b/packages/reqresp/README.md
@@ -44,7 +44,7 @@ async function getReqResp(libp2p: Libp2p, logger: Logger): Promise<void> {
 ## Prerequisites
 
 - [NodeJS](https://nodejs.org/) (LTS)
-- [Yarn](https://yarnpkg.com/)
+- [Yarn](https://classic.yarnpkg.com/lang/en/)
 
 ## What you need
 


### PR DESCRIPTION
**Motivation**

Lodestar uses classic yarn(1.x) but all the links in the README's point to the latest release of yarn(4.x). 

**Description**

Yarn now points to `https://classic.yarnpkg.com/lang/en/` instead of `https://yarnpkg.com/`
