### PR TITLE
chore: upgrade blst

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -94,7 +94,7 @@
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
     "@chainsafe/bls": "7.1.3",
-    "@chainsafe/blst": "^0.2.9",
+    "@chainsafe/blst": "^0.2.10",
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",
     "@chainsafe/libp2p-gossipsub": "^11.2.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "@chainsafe/bls": "7.1.3",
     "@chainsafe/bls-keygen": "^0.4.0",
     "@chainsafe/bls-keystore": "^3.0.1",
-    "@chainsafe/blst": "^0.2.9",
+    "@chainsafe/blst": "^0.2.10",
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",
     "@chainsafe/persistent-merkle-tree": "^0.6.1",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
     "@chainsafe/bls": "7.1.3",
-    "@chainsafe/blst": "^0.2.9",
+    "@chainsafe/blst": "^0.2.10",
     "@chainsafe/persistent-merkle-tree": "^0.6.1",
     "@chainsafe/persistent-ts": "^0.19.1",
     "@chainsafe/ssz": "^0.14.0",
@@ -72,7 +72,6 @@
     "buffer-xor": "^2.0.2"
   },
   "devDependencies": {
-    "@chainsafe/blst": "^0.2.9",
     "@types/buffer-xor": "^2.0.0"
   },
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,10 +301,10 @@
     "@chainsafe/bls-keygen" "^0.4.0"
     bls-eth-wasm "^0.4.8"
 
-"@chainsafe/blst@^0.2.9":
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.2.9.tgz#b356b47759c3ce127677227fc24faa3ac6c72032"
-  integrity sha512-6MXBUy5Co6k6V9Bv0EC5YrHD7kwWIpzwBO4yCqurLw//Zm3cUmN6DohuYuEGcS4QMNEswa/cXqzZLf+LFBJPiw==
+"@chainsafe/blst@^0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.2.10.tgz#77802e5b1ff2d98ec1d25dcd5f7d27b89d376a40"
+  integrity sha512-ofecTL5fWsNwnpS2oUh56dDXJRmCEcDKNNBFDb2ux+WtvdjrdSq6B+L/eNlg+sVBzXbzrCw1jq8Y8+cYiHg32w==
   dependencies:
     "@types/tar" "^6.1.4"
     node-fetch "^2.6.1"


### PR DESCRIPTION
**Motivation**

Upgrade `blst` to latest version. Should improve DX for apple silicon users.
Notte that it will only help for users of [supported node versions](https://github.com/ChainSafe/blst-ts/blob/8e81896f9ff740aef7f7eb29f55bd9ded64b9a83/.github/workflows/main.yml#L57).

Successfully [validated here](https://github.com/ChainSafe/lodestar/issues/6409#issuecomment-1967834495).