### PR TITLE
chore: restrict node version to 20.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "engines": {
-    "node": ">=18.17.0 <19 || >=20.1.0"
+    "node": ">=20.1.0 <21"
   },
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
**Motivation**

There is no reason to keep support for node 18, and node 22 is not yet a stable release.

| Release  | Status              | Codename     |Initial Release | Active LTS Start | Maintenance Start | End-of-life               |
| :--:     | :---:               | :---:        | :---:          | :---:            | :---:             | :---:                     |
| 20.x | **LTS**             | Iron     | 2023-04-18     | 2023-10-24       | 2024-10-22        | 2026-04-30                |
| 22.x     | **Pending**         |              | 2024-04-23     | 2024-10-29       | 2025-10-21        | 2027-04-30                |

**Description**

Restrict node version to 20.x, once node 22 is released we might wanna support two node versions (20,22) again and at this point we can reconsider running units tests against both supported versions.


Related https://github.com/ChainSafe/lodestar/issues/6487