### PR TITLE
chore: add eslint rule to restrict global fetch

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -134,6 +134,13 @@ module.exports = {
     "no-console": "error",
     "no-loss-of-precision": "error",
     "no-prototype-builtins": 0,
+    "no-restricted-globals": [
+      "error",
+      {
+        name: "fetch",
+        message: "Please use 'fetch' from '@lodestar/api' instead.",
+      },
+    ],
     "no-restricted-imports": [
       "error",
       {

--- a/packages/api/src/utils/client/fetch.ts
+++ b/packages/api/src/utils/client/fetch.ts
@@ -5,7 +5,7 @@
  */
 async function wrappedFetch(url: string | URL, init?: RequestInit): Promise<Response> {
   try {
-    // This function wraps global fetch and we should only directly call it here
+    // This function wraps global `fetch` which should only be directly called here
     // eslint-disable-next-line no-restricted-globals
     return await fetch(url, init);
   } catch (e) {

--- a/packages/api/src/utils/client/fetch.ts
+++ b/packages/api/src/utils/client/fetch.ts
@@ -5,6 +5,7 @@
  */
 async function wrappedFetch(url: string | URL, init?: RequestInit): Promise<Response> {
   try {
+    // This function wraps global fetch and we should only directly call it here
     // eslint-disable-next-line no-restricted-globals
     return await fetch(url, init);
   } catch (e) {

--- a/packages/api/src/utils/client/fetch.ts
+++ b/packages/api/src/utils/client/fetch.ts
@@ -5,6 +5,7 @@
  */
 async function wrappedFetch(url: string | URL, init?: RequestInit): Promise<Response> {
   try {
+    // eslint-disable-next-line no-restricted-globals
     return await fetch(url, init);
   } catch (e) {
     throw new FetchError(url, e);


### PR DESCRIPTION
**Motivation**

We should make sure that we don't accidentally use native fetch without error wrapper.

**Description**

Add eslint rule to restrict global fetch


Related https://github.com/ChainSafe/lodestar/pull/6497