### PR TITLE
feat: add clone option to state caches

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -360,6 +360,7 @@ export async function importBlock(
     const checkpointState = postState;
     const cp = getCheckpointFromState(checkpointState);
     this.regen.addCheckpointState(cp, checkpointState);
+    // consumers should not mutate or get the transfered cache
     this.emitter.emit(ChainEvent.checkpoint, cp, checkpointState.clone(true));
 
     // Note: in-lined code from previos handler of ChainEvent.checkpoint

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -65,6 +65,7 @@ export async function verifyBlocksInEpoch(
   // TODO: Skip in process chain segment
   // Retrieve preState from cache (regen)
   const preState0 = await this.regen
+    // transfer cache to process faster, postState will be in block state cache
     .getPreState(block0.message, {dontTransferCache: false}, RegenCaller.processBlocksInEpoch)
     .catch((e) => {
       throw new BlockError(block0, {code: BlockErrorCode.PRESTATE_MISSING, error: e as Error});

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -107,6 +107,7 @@ export class PrepareNextSlotScheduler {
         headRoot,
         prepareSlot,
         // the slot 0 of next epoch will likely use this Previous Root Checkpoint state for state transition so we transfer cache here
+        // the resulting state with cache will be cached in Checkpoint State Cache which is used for the upcoming block processing
         // for other slots dontTransferCached=true because we don't run state transition on this state
         {dontTransferCache: !isEpochTransition},
         RegenCaller.precomputeEpoch

--- a/packages/beacon-node/src/chain/regen/interface.ts
+++ b/packages/beacon-node/src/chain/regen/interface.ts
@@ -84,5 +84,5 @@ export interface IStateRegeneratorInternal {
   /**
    * Return the exact state with `stateRoot`
    */
-  getState(stateRoot: RootHex, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
+  getState(stateRoot: RootHex, rCaller: RegenCaller, opts?: StateCloneOpts): Promise<CachedBeaconStateAllForks>;
 }

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -130,7 +130,7 @@ export class QueuedStateRegenerator implements IStateRegenerator {
    * Get checkpoint state from cache, this function is not for block processing so don't transfer cache
    */
   getCheckpointStateSync(cp: CheckpointHex): CachedBeaconStateAllForks | null {
-    return this.checkpointStateCache.get(cp, opts, {dontTransferCache: true});
+    return this.checkpointStateCache.get(cp, {dontTransferCache: true});
   }
 
   /**

--- a/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
@@ -4,6 +4,7 @@ import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {routes} from "@lodestar/api";
 import {Metrics} from "../../metrics/index.js";
 import {LinkedList} from "../../util/array.js";
+import {StateCloneOpts} from "../regen/interface.js";
 import {MapTracker} from "./mapMetrics.js";
 import {BlockStateCache} from "./types.js";
 
@@ -70,7 +71,7 @@ export class FIFOBlockStateCache implements BlockStateCache {
   /**
    * Get a state from this cache given a state root hex.
    */
-  get(rootHex: RootHex): CachedBeaconStateAllForks | null {
+  get(rootHex: RootHex, opts?: StateCloneOpts): CachedBeaconStateAllForks | null {
     this.metrics?.lookups.inc();
     const item = this.cache.get(rootHex);
     if (!item) {
@@ -80,7 +81,7 @@ export class FIFOBlockStateCache implements BlockStateCache {
     this.metrics?.hits.inc();
     this.metrics?.stateClonedCount.observe(item.clonedCount);
 
-    return item.clone(true);
+    return item.clone(opts?.dontTransferCache);
   }
 
   /**

--- a/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
@@ -3,6 +3,7 @@ import {Epoch, RootHex} from "@lodestar/types";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {routes} from "@lodestar/api";
 import {Metrics} from "../../metrics/index.js";
+import {StateCloneOpts} from "../regen/interface.js";
 import {MapTracker} from "./mapMetrics.js";
 import {BlockStateCache} from "./types.js";
 
@@ -38,7 +39,7 @@ export class StateContextCache implements BlockStateCache {
     }
   }
 
-  get(rootHex: RootHex): CachedBeaconStateAllForks | null {
+  get(rootHex: RootHex, opts?: StateCloneOpts): CachedBeaconStateAllForks | null {
     this.metrics?.lookups.inc();
     const item = this.head?.stateRoot === rootHex ? this.head.state : this.cache.get(rootHex);
     if (!item) {
@@ -48,7 +49,7 @@ export class StateContextCache implements BlockStateCache {
     this.metrics?.hits.inc();
     this.metrics?.stateClonedCount.observe(item.clonedCount);
 
-    return item.clone(true);
+    return item.clone(opts?.dontTransferCache);
   }
 
   add(item: CachedBeaconStateAllForks): void {

--- a/packages/beacon-node/src/chain/stateCache/stateContextCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/stateContextCheckpointsCache.ts
@@ -4,6 +4,7 @@ import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {MapDef} from "@lodestar/utils";
 import {routes} from "@lodestar/api";
 import {Metrics} from "../../metrics/index.js";
+import {StateCloneOpts} from "../regen/interface.js";
 import {MapTracker} from "./mapMetrics.js";
 import {CheckpointStateCache as CheckpointStateCacheInterface, CacheItemType} from "./types.js";
 
@@ -38,16 +39,21 @@ export class CheckpointStateCache implements CheckpointStateCacheInterface {
     }
   }
 
-  async getOrReload(cp: CheckpointHex): Promise<CachedBeaconStateAllForks | null> {
-    return this.get(cp);
+  async getOrReload(cp: CheckpointHex, opts?: StateCloneOpts): Promise<CachedBeaconStateAllForks | null> {
+    return this.get(cp, opts);
   }
 
   async getStateOrBytes(cp: CheckpointHex): Promise<Uint8Array | CachedBeaconStateAllForks | null> {
-    return this.get(cp);
+    // no need to transfer cache for this api
+    return this.get(cp, {dontTransferCache: true});
   }
 
-  async getOrReloadLatest(rootHex: string, maxEpoch: number): Promise<CachedBeaconStateAllForks | null> {
-    return this.getLatest(rootHex, maxEpoch);
+  async getOrReloadLatest(
+    rootHex: string,
+    maxEpoch: number,
+    opts?: StateCloneOpts
+  ): Promise<CachedBeaconStateAllForks | null> {
+    return this.getLatest(rootHex, maxEpoch, opts);
   }
 
   async processState(): Promise<number> {
@@ -55,7 +61,7 @@ export class CheckpointStateCache implements CheckpointStateCacheInterface {
     return 0;
   }
 
-  get(cp: CheckpointHex): CachedBeaconStateAllForks | null {
+  get(cp: CheckpointHex, opts?: StateCloneOpts): CachedBeaconStateAllForks | null {
     this.metrics?.lookups.inc();
     const cpKey = toCheckpointKey(cp);
     const item = this.cache.get(cpKey);
@@ -72,7 +78,7 @@ export class CheckpointStateCache implements CheckpointStateCacheInterface {
 
     this.metrics?.stateClonedCount.observe(item.clonedCount);
 
-    return item.clone(true);
+    return item.clone(opts?.dontTransferCache);
   }
 
   add(cp: phase0.Checkpoint, item: CachedBeaconStateAllForks): void {
@@ -89,14 +95,14 @@ export class CheckpointStateCache implements CheckpointStateCacheInterface {
   /**
    * Searches for the latest cached state with a `root`, starting with `epoch` and descending
    */
-  getLatest(rootHex: RootHex, maxEpoch: Epoch): CachedBeaconStateAllForks | null {
+  getLatest(rootHex: RootHex, maxEpoch: Epoch, opts?: StateCloneOpts): CachedBeaconStateAllForks | null {
     // sort epochs in descending order, only consider epochs lte `epoch`
     const epochs = Array.from(this.epochIndex.keys())
       .sort((a, b) => b - a)
       .filter((e) => e <= maxEpoch);
     for (const epoch of epochs) {
       if (this.epochIndex.get(epoch)?.has(rootHex)) {
-        return this.get({rootHex, epoch});
+        return this.get({rootHex, epoch}, opts);
       }
     }
     return null;

--- a/packages/beacon-node/src/chain/stateCache/types.ts
+++ b/packages/beacon-node/src/chain/stateCache/types.ts
@@ -1,6 +1,7 @@
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {Epoch, RootHex, phase0} from "@lodestar/types";
 import {routes} from "@lodestar/api";
+import {StateCloneOpts} from "../regen/interface.js";
 
 export type CheckpointHex = {epoch: Epoch; rootHex: RootHex};
 
@@ -20,7 +21,7 @@ export type CheckpointHex = {epoch: Epoch; rootHex: RootHex};
  * The cache key is state root
  */
 export interface BlockStateCache {
-  get(rootHex: RootHex): CachedBeaconStateAllForks | null;
+  get(rootHex: RootHex, opts?: StateCloneOpts): CachedBeaconStateAllForks | null;
   add(item: CachedBeaconStateAllForks): void;
   setHeadState(item: CachedBeaconStateAllForks | null): void;
   clear(): void;
@@ -53,12 +54,16 @@ export interface BlockStateCache {
  */
 export interface CheckpointStateCache {
   init?: () => Promise<void>;
-  getOrReload(cp: CheckpointHex): Promise<CachedBeaconStateAllForks | null>;
+  getOrReload(cp: CheckpointHex, opts?: StateCloneOpts): Promise<CachedBeaconStateAllForks | null>;
   getStateOrBytes(cp: CheckpointHex): Promise<CachedBeaconStateAllForks | Uint8Array | null>;
-  get(cpOrKey: CheckpointHex | string): CachedBeaconStateAllForks | null;
+  get(cpOrKey: CheckpointHex | string, opts?: StateCloneOpts): CachedBeaconStateAllForks | null;
   add(cp: phase0.Checkpoint, state: CachedBeaconStateAllForks): void;
-  getLatest(rootHex: RootHex, maxEpoch: Epoch): CachedBeaconStateAllForks | null;
-  getOrReloadLatest(rootHex: RootHex, maxEpoch: Epoch): Promise<CachedBeaconStateAllForks | null>;
+  getLatest(rootHex: RootHex, maxEpoch: Epoch, opts?: StateCloneOpts): CachedBeaconStateAllForks | null;
+  getOrReloadLatest(
+    rootHex: RootHex,
+    maxEpoch: Epoch,
+    opts?: StateCloneOpts
+  ): Promise<CachedBeaconStateAllForks | null>;
   updatePreComputedCheckpoint(rootHex: RootHex, epoch: Epoch): number | null;
   prune(finalizedEpoch: Epoch, justifiedEpoch: Epoch): void;
   pruneFinalized(finalizedEpoch: Epoch): void;


### PR DESCRIPTION
**Motivation**

- There is high block processing time introduced since #6504, state cache is missed in all block processing, see the analyse in #6511
- We have `StateCloneOpts` for state transition, now we also clone states from state caches so need to add option there also

**Description**

- Add `StateCloneOpts` to state caches add api
- All consumers need to specify that `StateCloneOpts`, it's already done in the current source code for state transition, need to use same params for state caches `get` api


Closes #6511

**Test result**

Metrics look same to v1.16 after ~3h of testing

<img width="1329" alt="Screenshot 2024-03-06 at 13 17 52" src="https://github.com/ChainSafe/lodestar/assets/10568965/c43b1faa-3c95-43a4-a03a-1a2c31b0dbbc">

<img width="1319" alt="Screenshot 2024-03-06 at 13 18 10" src="https://github.com/ChainSafe/lodestar/assets/10568965/a5845063-f7d7-47d9-9a2a-0d472cad5959">

