### PR TITLE
feat: implement expected withdrawals API

### DIFF
--- a/packages/api/src/beacon/client/builder.ts
+++ b/packages/api/src/beacon/client/builder.ts
@@ -1,0 +1,13 @@
+import {ChainForkConfig} from "@lodestar/config";
+import {generateGenericJsonClient, IHttpClient} from "../../utils/client/index.js";
+import {Api, getReqSerializers, getReturnTypes, ReqTypes, routesData} from "../routes/builder.js";
+
+/**
+ * REST HTTP client for config routes
+ */
+export function getClient(config: ChainForkConfig, httpClient: IHttpClient): Api {
+  const reqSerializers = getReqSerializers();
+  const returnTypes = getReturnTypes();
+  // All routes return JSON, use a client auto-generator
+  return generateGenericJsonClient<Api, ReqTypes>(routesData, reqSerializers, returnTypes, httpClient);
+}

--- a/packages/api/src/beacon/client/index.ts
+++ b/packages/api/src/beacon/client/index.ts
@@ -11,6 +11,7 @@ import * as lodestar from "./lodestar.js";
 import * as node from "./node.js";
 import * as proof from "./proof.js";
 import * as validator from "./validator.js";
+import * as builder from "./builder.js";
 
 type ClientModules = HttpClientModules & {
   config: ChainForkConfig;
@@ -34,5 +35,6 @@ export function getClient(opts: HttpClientOptions, modules: ClientModules): Api 
     node: node.getClient(config, httpClient),
     proof: proof.getClient(config, httpClient),
     validator: validator.getClient(config, httpClient),
+    builder: builder.getClient(config, httpClient),
   };
 }

--- a/packages/api/src/beacon/index.ts
+++ b/packages/api/src/beacon/index.ts
@@ -18,5 +18,6 @@ const allNamespacesObj: {[K in keyof Api]: true} = {
   node: true,
   proof: true,
   validator: true,
+  builder: true,
 };
 export const allNamespaces = Object.keys(allNamespacesObj) as ApiNamespace[];

--- a/packages/api/src/beacon/routes/builder.ts
+++ b/packages/api/src/beacon/routes/builder.ts
@@ -1,0 +1,65 @@
+import {Slot, ValidatorIndex, WithdrawalIndex} from "@lodestar/types";
+import {ReturnTypes, RoutesData, Schema, sameType, ReqSerializers} from "../../utils/index.js";
+import {HttpStatusCode} from "../../utils/client/httpStatusCode.js";
+import {ApiClientResponse} from "../../interfaces.js";
+import {StateId, ExecutionOptimistic} from "./beacon/state.js";
+
+export type ExpectedWithdrawals = {
+  index: WithdrawalIndex;
+  validatorIndex: ValidatorIndex;
+  address: string;
+  amount: number;
+};
+
+// See /packages/api/src/routes/index.ts for reasoning and instructions to add new routes
+
+export type Api = {
+  getExpectedWithdrawals(
+    stateId: StateId,
+    proposalSlot?: Slot | undefined
+  ): Promise<
+    ApiClientResponse<
+      {
+        [HttpStatusCode.OK]: {
+          executionOptimistic: ExecutionOptimistic;
+          data: ExpectedWithdrawals[];
+        };
+      },
+      HttpStatusCode.NOT_FOUND | HttpStatusCode.BAD_REQUEST
+    >
+  >;
+};
+/**
+ * Define javascript values for each route
+ */
+export const routesData: RoutesData<Api> = {
+  getExpectedWithdrawals: {url: "/eth/v1/builder/states/{state_id}/expected_withdrawals", method: "GET"},
+};
+
+/* eslint-disable @typescript-eslint/naming-convention */
+export type ReqTypes = {
+  getExpectedWithdrawals: {params: {state_id: StateId}; query: {proposal_slot?: Slot | undefined}};
+};
+
+export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
+  return {
+    getExpectedWithdrawals: {
+      writeReq: (state_id, proposal_slot) => ({
+        params: {state_id},
+        query: {proposal_slot},
+      }),
+      parseReq: ({params, query}) => [params.state_id, query.proposal_slot],
+      schema: {
+        params: {state_id: Schema.StringRequired},
+        query: {proposal_slot: Schema.Uint},
+      },
+    },
+  };
+}
+
+export function getReturnTypes(): ReturnTypes<Api> {
+  return {
+    // Just sent the proof JSON as-is
+    getExpectedWithdrawals: sameType(),
+  };
+}

--- a/packages/api/src/beacon/routes/builder.ts
+++ b/packages/api/src/beacon/routes/builder.ts
@@ -1,5 +1,5 @@
 import {Slot, ValidatorIndex, WithdrawalIndex} from "@lodestar/types";
-import {ReturnTypes, RoutesData, Schema, sameType, ReqSerializers} from "../../utils/index.js";
+import {ReturnTypes, RoutesData, Schema, ReqSerializers, jsonType} from "../../utils/index.js";
 import {HttpStatusCode} from "../../utils/client/httpStatusCode.js";
 import {ApiClientResponse} from "../../interfaces.js";
 import {StateId, ExecutionOptimistic} from "./beacon/state.js";
@@ -59,7 +59,7 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
 
 export function getReturnTypes(): ReturnTypes<Api> {
   return {
-    // Just sent the proof JSON as-is
-    getExpectedWithdrawals: sameType(),
+    // Just sent the JSON as snake case
+    getExpectedWithdrawals: jsonType("snake"),
   };
 }

--- a/packages/api/src/beacon/routes/index.ts
+++ b/packages/api/src/beacon/routes/index.ts
@@ -7,6 +7,7 @@ import {Api as LodestarApi} from "./lodestar.js";
 import {Api as NodeApi} from "./node.js";
 import {Api as ProofApi} from "./proof.js";
 import {Api as ValidatorApi} from "./validator.js";
+import {Api as BuilderApi} from "./builder.js";
 
 export * as beacon from "./beacon/index.js";
 export * as config from "./config.js";
@@ -17,6 +18,7 @@ export * as lodestar from "./lodestar.js";
 export * as node from "./node.js";
 export * as proof from "./proof.js";
 export * as validator from "./validator.js";
+export * as builder from "./builder.js";
 
 export type Api = {
   beacon: BeaconApi;
@@ -28,6 +30,7 @@ export type Api = {
   node: NodeApi;
   proof: ProofApi;
   validator: ValidatorApi;
+  builder: BuilderApi;
 };
 
 // Reasoning of the API definitions

--- a/packages/api/src/beacon/server/builder.ts
+++ b/packages/api/src/beacon/server/builder.ts
@@ -1,0 +1,9 @@
+import {ChainForkConfig} from "@lodestar/config";
+import {Api, ReqTypes, routesData, getReturnTypes, getReqSerializers} from "../routes/builder.js";
+import {ServerRoutes, getGenericJsonServer} from "../../utils/server/index.js";
+import {ServerApi} from "../../interfaces.js";
+
+export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerRoutes<Api, ReqTypes> {
+  // All routes return JSON, use a server auto-generator
+  return getGenericJsonServer<ServerApi<Api>, ReqTypes>({routesData, getReturnTypes, getReqSerializers}, config, api);
+}

--- a/packages/api/src/beacon/server/index.ts
+++ b/packages/api/src/beacon/server/index.ts
@@ -12,6 +12,7 @@ import * as lodestar from "./lodestar.js";
 import * as node from "./node.js";
 import * as proof from "./proof.js";
 import * as validator from "./validator.js";
+import * as builder from "./builder.js";
 
 // Re-export for usage in beacon-node
 export {ApiError};
@@ -43,6 +44,7 @@ export function registerRoutes(
     node: () => node.getRoutes(config, api.node),
     proof: () => proof.getRoutes(config, api.proof),
     validator: () => validator.getRoutes(config, api.validator),
+    builder: () => builder.getRoutes(config, api.builder),
   };
 
   for (const namespace of enabledNamespaces) {

--- a/packages/beacon-node/src/api/impl/api.ts
+++ b/packages/beacon-node/src/api/impl/api.ts
@@ -10,6 +10,7 @@ import {getLodestarApi} from "./lodestar/index.js";
 import {getNodeApi} from "./node/index.js";
 import {getProofApi} from "./proof/index.js";
 import {getValidatorApi} from "./validator/index.js";
+import {getBuilderApi} from "./builder/index.js";
 
 export function getApi(opts: ApiOptions, modules: ApiModules): {[K in keyof Api]: ServerApi<Api[K]>} {
   return {
@@ -22,5 +23,6 @@ export function getApi(opts: ApiOptions, modules: ApiModules): {[K in keyof Api]
     node: getNodeApi(opts, modules),
     proof: getProofApi(opts, modules),
     validator: getValidatorApi(modules),
+    builder: getBuilderApi(modules),
   };
 }

--- a/packages/beacon-node/src/api/impl/builder/index.ts
+++ b/packages/beacon-node/src/api/impl/builder/index.ts
@@ -1,23 +1,34 @@
 import {routes, ServerApi} from "@lodestar/api";
 import {Slot} from "@lodestar/types";
+import {getExpectedWithdrawals} from "@lodestar/state-transition";
+import {CachedBeaconStateCapella} from "@lodestar/state-transition/src/types.js";
+import {ExpectedWithdrawals} from "@lodestar/api/src/beacon/routes/builder.js";
 import {ApiModules} from "../types.js";
+import {resolveStateId} from "../beacon/state/utils.js";
 
-export function getBuilderApi({chain, config}: Pick<ApiModules, "chain" | "config">): ServerApi<routes.builder.Api> {
+export function getBuilderApi({chain}: Pick<ApiModules, "chain" | "config">): ServerApi<routes.builder.Api> {
   return {
     async getExpectedWithdrawals(stateId: routes.beacon.StateId, proposalSlot?: Slot | undefined) {
+      const {state, executionOptimistic} = await resolveStateId(chain, stateId, {allowRegen: true});
+      const expectedWithdrawals = getExpectedWithdrawals(state as CachedBeaconStateCapella).withdrawals;
       // eslint-disable-next-line no-console
-      console.log(chain, config, stateId, proposalSlot);
+      console.log("Prolosal Slot", proposalSlot, "State data", state, "expectedWithdrawlsData", expectedWithdrawals);
       return {
-        executionOptimistic: false,
-        data: [
-          {
-            index: 1,
-            validatorIndex: 1,
-            address: "0xAbcF8e0d4e9587369b2301D0790347320302cc09",
-            amount: 1,
-          },
-        ],
+        executionOptimistic: executionOptimistic,
+        data: expectedWithdrawals.map((item: {address: Uint8Array}) => ({
+          ...item,
+          address: Buffer.from(item.address).toString("hex"), // Convert Uint8Array to hexadecimal string
+        })) as ExpectedWithdrawals[],
       };
     },
   };
 }
+
+// data: [
+//   {
+//     index: 1,
+//     validatorIndex: 1,
+//     address: "0xAbcF8e0d4e9587369b2301D0790347320302cc09",
+//     amount: 1,
+//   },
+// ],

--- a/packages/beacon-node/src/api/impl/builder/index.ts
+++ b/packages/beacon-node/src/api/impl/builder/index.ts
@@ -1,0 +1,23 @@
+import {routes, ServerApi} from "@lodestar/api";
+import {Slot} from "@lodestar/types";
+import {ApiModules} from "../types.js";
+
+export function getBuilderApi({chain, config}: Pick<ApiModules, "chain" | "config">): ServerApi<routes.builder.Api> {
+  return {
+    async getExpectedWithdrawals(stateId: routes.beacon.StateId, proposalSlot?: Slot | undefined) {
+      // eslint-disable-next-line no-console
+      console.log(chain, config, stateId, proposalSlot);
+      return {
+        executionOptimistic: false,
+        data: [
+          {
+            index: 1,
+            validatorIndex: 1,
+            address: "0xAbcF8e0d4e9587369b2301D0790347320302cc09",
+            amount: 1,
+          },
+        ],
+      };
+    },
+  };
+}


### PR DESCRIPTION
**Motivation**

Latest beacon API spec requires expected withdrawals API

**Description**

Implement the following route:

https://ethereum.github.io/beacon-APIs/#/Builder/getNextWithdrawals

Closes #5696

**Steps to test or reproduce**

```sh
curl -X 'GET' \
  'http://localhost:9596/eth/v1/builder/states/head/expected_withdrawals?proposal_slot=1' \
  -H 'accept: application/json'
```

**Progress**
- [x] Creating routes packages/api/src/beacon/routes/builder.ts
- [x] Defining types  packages/api/src/beacon/routes/builder.ts
- [x] Implementing route and namaspace
- packages/api/src/beacon/client/builder.ts
- packages/api/src/beacon/client/index.ts
- packages/api/src/beacon/index.ts
- packages/api/src/beacon/routes/index.ts
- packages/api/src/beacon/server/builder.ts
- packages/api/src/beacon/server/index.ts
- packages/beacon-node/src/api/impl/api.ts
- [ ] Implementing function
- packages/beacon-node/src/api/impl/builder/index.ts
- [ ] Implementing unit test

**Components**

1. get state from state_id
https://github.com/ChainSafe/lodestar/blob/c94ecd23e40ed0eaa3b5f7dd7351a4e2693e2b3a/packages/beacon-node/src/api/impl/debug/index.ts#L39
3. get expectedWithdrawals array from  getExpectedWithdrawls(state from 1.) 
4. filter proposal_slot form the 2. data
 
- data: https://github.com/ChainSafe/lodestar/blob/918924eabad9ca615acf3d92ff50828fb40fedea/packages/state-transition/src/block/processWithdrawals.ts#L65
- finalized: N/A
 >Currently Lodestar doesn't support finalized in the apis. You can discard this field for now. See https://github.com/ChainSafe/lodestar/issues/5693 for more.
- execution_optimistic: https://github.com/ChainSafe/lodestar/blob/1d3bf0412ab8ac169f8cbcdfabcbc8505e3e5cc7/packages/beacon-node/src/util/forkChoice.ts#L3