### PR TITLE
chore: explicitly import node:buffer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -147,6 +147,7 @@ module.exports = {
         patterns: ["../lib/*", "@chainsafe/*/lib/*"],
         paths: [
           ...restrictNodeModuleImports(
+            "buffer",
             "child_process",
             "crypto",
             "fs",
@@ -175,6 +176,7 @@ module.exports = {
   },
   settings: {
     "import/core-modules": [
+      "node:buffer",
       "node:child_process",
       "node:crypto",
       "node:fs",

--- a/packages/api/src/beacon/server/beacon.ts
+++ b/packages/api/src/beacon/server/beacon.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {ChainForkConfig} from "@lodestar/config";
 import {ssz} from "@lodestar/types";
 import {Api, ReqTypes, routesData, getReturnTypes, getReqSerializers} from "../routes/beacon/index.js";

--- a/packages/api/src/beacon/server/debug.ts
+++ b/packages/api/src/beacon/server/debug.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {ChainForkConfig} from "@lodestar/config";
 import {ssz} from "@lodestar/types";
 import {Api, ReqTypes, routesData, getReturnTypes, getReqSerializers} from "../routes/debug.js";

--- a/packages/api/src/beacon/server/proof.ts
+++ b/packages/api/src/beacon/server/proof.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {CompactMultiProof} from "@chainsafe/persistent-merkle-tree";
 import {ChainForkConfig} from "@lodestar/config";
 import {Api, ReqTypes, routesData, getReturnTypes, getReqSerializers} from "../routes/proof.js";

--- a/packages/api/test/unit/beacon/testData/validator.ts
+++ b/packages/api/test/unit/beacon/testData/validator.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {ForkName} from "@lodestar/params";
 import {ssz, ProducedBlockSource} from "@lodestar/types";
 import {Api} from "../../../../src/beacon/routes/validator.js";

--- a/packages/beacon-node/src/constants/constants.ts
+++ b/packages/beacon-node/src/constants/constants.ts
@@ -1,3 +1,5 @@
+import {Buffer} from "node:buffer";
+
 export const DEPOSIT_CONTRACT_TREE_DEPTH = 2 ** 5; // 32
 export const GENESIS_SLOT = 0;
 export const GENESIS_EPOCH = 0;

--- a/packages/beacon-node/src/network/gossip/constants.ts
+++ b/packages/beacon-node/src/network/gossip/constants.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {GossipEncoding} from "./interface.js";
 
 export const GOSSIP_MSGID_LENGTH = 20;

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {compress, uncompress} from "snappyjs";
 import xxhashFactory from "xxhash-wasm";
 import {Message} from "@libp2p/interface";

--- a/packages/beacon-node/src/node/utils/interop/deposits.ts
+++ b/packages/beacon-node/src/node/utils/interop/deposits.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {digest} from "@chainsafe/as-sha256";
 import {toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
 import {phase0, ssz} from "@lodestar/types";

--- a/packages/beacon-node/src/node/utils/interop/state.ts
+++ b/packages/beacon-node/src/node/utils/interop/state.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {Bytes32, phase0, ssz, TimeSeconds} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
 import {BeaconStateAllForks, initializeBeaconStateFromEth1} from "@lodestar/state-transition";

--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {GRAFFITI_SIZE} from "../constants/index.js";
 
 /**

--- a/packages/beacon-node/src/util/hex.ts
+++ b/packages/beacon-node/src/util/hex.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {RootHex} from "@lodestar/types";
 
 export function bufferToHex(buffer: Buffer): RootHex {

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {BitArray, deserializeUint8ArrayBitListFromBytes} from "@chainsafe/ssz";
 import {BLSSignature, RootHex, Slot} from "@lodestar/types";
 import {toHex} from "@lodestar/utils";

--- a/packages/beacon-node/test/e2e/api/impl/beacon/node/endpoints.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/beacon/node/endpoints.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, beforeAll, afterAll, it, expect, vi} from "vitest";
 import {createBeaconConfig} from "@lodestar/config";
 import {chainConfig as chainConfigDef} from "@lodestar/config/default";

--- a/packages/beacon-node/test/e2e/api/impl/beacon/state/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/beacon/state/endpoint.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, beforeAll, afterAll, it, expect} from "vitest";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {createBeaconConfig} from "@lodestar/config";

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, beforeEach, afterEach, expect} from "vitest";
 import bls from "@chainsafe/bls";
 import {createBeaconConfig, ChainConfig} from "@lodestar/config";

--- a/packages/beacon-node/test/e2e/api/lodestar/lodestar.test.ts
+++ b/packages/beacon-node/test/e2e/api/lodestar/lodestar.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, afterEach, expect, vi} from "vitest";
 import {createBeaconConfig, ChainConfig} from "@lodestar/config";
 import {chainConfig as chainConfigDef} from "@lodestar/config/default";

--- a/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, beforeAll, expect, beforeEach, afterEach} from "vitest";
 import bls from "@chainsafe/bls";
 import {PublicKey} from "@chainsafe/bls/types";

--- a/packages/beacon-node/test/e2e/doppelganger/doppelganger.test.ts
+++ b/packages/beacon-node/test/e2e/doppelganger/doppelganger.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, afterEach, it, expect} from "vitest";
 import {fromHexString} from "@chainsafe/ssz";
 import {routes} from "@lodestar/api/beacon";

--- a/packages/beacon-node/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/beacon-node/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {promisify} from "node:util";
 import {describe, it, beforeAll, afterAll, expect} from "vitest";
 import leveldown from "leveldown";

--- a/packages/beacon-node/test/e2e/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/beacon-node/test/e2e/eth1/eth1MergeBlockTracker.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, beforeAll, expect, beforeEach, afterEach} from "vitest";
 import {fromHexString} from "@chainsafe/ssz";
 import {ChainConfig} from "@lodestar/config";

--- a/packages/beacon-node/test/e2e/interop/genesisState.test.ts
+++ b/packages/beacon-node/test/e2e/interop/genesisState.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";

--- a/packages/beacon-node/test/e2e/network/gossipsub.test.ts
+++ b/packages/beacon-node/test/e2e/network/gossipsub.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, afterEach} from "vitest";
 import {createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {sleep} from "@lodestar/utils";

--- a/packages/beacon-node/test/fixtures/capella.ts
+++ b/packages/beacon-node/test/fixtures/capella.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {CachedBeaconStateAltair} from "@lodestar/state-transition";
 import {capella} from "@lodestar/types";
 

--- a/packages/beacon-node/test/fixtures/phase0.ts
+++ b/packages/beacon-node/test/fixtures/phase0.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
   CachedBeaconStateAltair,

--- a/packages/beacon-node/test/memory/bytesHex.ts
+++ b/packages/beacon-node/test/memory/bytesHex.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import crypto from "node:crypto";
 import {toHexString} from "@chainsafe/ssz";
 import {testRunnerMemory} from "./testRunnerMemory.js";

--- a/packages/beacon-node/test/memory/seenAttestationData.ts
+++ b/packages/beacon-node/test/memory/seenAttestationData.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import crypto from "node:crypto";
 import {toHexString} from "@chainsafe/ssz";
 import {AttestationDataCacheEntry, SeenAttestationDatas} from "../../src/chain/seenCache/seenAttestationData.js";

--- a/packages/beacon-node/test/perf/bls/bls.test.ts
+++ b/packages/beacon-node/test/perf/bls/bls.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import crypto from "node:crypto";
 import {itBench} from "@dapplion/benchmark";
 import bls from "@chainsafe/bls";

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {itBench} from "@dapplion/benchmark";
 import {BitArray, toHexString} from "@chainsafe/ssz";
 import {

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {fromHexString} from "@chainsafe/ssz";
 import {itBench} from "@dapplion/benchmark";
 import {config} from "@lodestar/config/default";

--- a/packages/beacon-node/test/perf/eth1/pickEth1Vote.test.ts
+++ b/packages/beacon-node/test/perf/eth1/pickEth1Vote.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
 import {ContainerType, ListCompositeType} from "@chainsafe/ssz";
 import {phase0, ssz} from "@lodestar/types";

--- a/packages/beacon-node/test/perf/misc/bytesHex.test.ts
+++ b/packages/beacon-node/test/perf/misc/bytesHex.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import crypto from "node:crypto";
 import {itBench} from "@dapplion/benchmark";
 import {toHexString} from "@chainsafe/ssz";

--- a/packages/beacon-node/test/perf/network/gossip/fastMsgIdFn.test.ts
+++ b/packages/beacon-node/test/perf/network/gossip/fastMsgIdFn.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {randomBytes} from "node:crypto";
 import xxhashFactory from "xxhash-wasm";
 import {itBench} from "@dapplion/benchmark";

--- a/packages/beacon-node/test/perf/network/peers/enrSubnetsDeserialize.test.ts
+++ b/packages/beacon-node/test/perf/network/peers/enrSubnetsDeserialize.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {itBench} from "@dapplion/benchmark";
 import {expect} from "chai";
 import {SYNC_COMMITTEE_SUBNET_COUNT, ATTESTATION_SUBNET_COUNT} from "@lodestar/params";

--- a/packages/beacon-node/test/perf/util/bytes.test.ts
+++ b/packages/beacon-node/test/perf/util/bytes.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {itBench} from "@dapplion/benchmark";
 
 describe("bytes utils", function () {

--- a/packages/beacon-node/test/scripts/blsPubkeyBytesFrequency.ts
+++ b/packages/beacon-node/test/scripts/blsPubkeyBytesFrequency.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import fs from "node:fs";
 import {digest} from "@chainsafe/as-sha256";
 import {ApiError, getClient} from "@lodestar/api";

--- a/packages/beacon-node/test/spec/general/ssz_generic.ts
+++ b/packages/beacon-node/test/spec/general/ssz_generic.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import fs from "node:fs";
 import path from "node:path";
 import {expect, it} from "vitest";

--- a/packages/beacon-node/test/spec/presets/genesis.test.ts
+++ b/packages/beacon-node/test/spec/presets/genesis.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import path from "node:path";
 import {expect} from "vitest";
 import {phase0, Root, ssz, TimeSeconds, allForks, deneb} from "@lodestar/types";

--- a/packages/beacon-node/test/unit-mainnet/network/gossip/scoringParameters.test.ts
+++ b/packages/beacon-node/test/unit-mainnet/network/gossip/scoringParameters.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {TopicScoreParams} from "@chainsafe/libp2p-gossipsub/score";
 import {ATTESTATION_SUBNET_COUNT, ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";

--- a/packages/beacon-node/test/unit/api/impl/beacon/beacon.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/beacon.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeAll} from "vitest";
 import {ApiTestModules, getApiTestModules} from "../../../../utils/api.js";
 import {getBeaconApi} from "../../../../../src/api/impl/beacon/index.js";

--- a/packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeEach, vi} from "vitest";
 import {config} from "@lodestar/config/default";
 import {MAX_EFFECTIVE_BALANCE, SLOTS_PER_EPOCH} from "@lodestar/params";

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeEach, afterEach, vi} from "vitest";
 import {ssz} from "@lodestar/types";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";

--- a/packages/beacon-node/test/unit/chain/archive/blockArchiver.test.ts
+++ b/packages/beacon-node/test/unit/chain/archive/blockArchiver.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {describe, it, expect, beforeEach, vi, afterEach} from "vitest";
 import {ssz} from "@lodestar/types";

--- a/packages/beacon-node/test/unit/chain/blocks/verifyBlocksSanityChecks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyBlocksSanityChecks.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeEach} from "vitest";
 import {config} from "@lodestar/config/default";
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";

--- a/packages/beacon-node/test/unit/chain/bls/bls.test.ts
+++ b/packages/beacon-node/test/unit/chain/bls/bls.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import bls from "@chainsafe/bls";
 import {CoordType} from "@chainsafe/blst";
 import {PublicKey} from "@chainsafe/bls/types";

--- a/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {toHexString} from "@chainsafe/ssz";
 import {describe, it, expect, beforeEach, beforeAll, vi} from "vitest";
 import {config} from "@lodestar/config/default";

--- a/packages/beacon-node/test/unit/chain/genesis/genesis.test.ts
+++ b/packages/beacon-node/test/unit/chain/genesis/genesis.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
+import {Buffer} from "node:buffer";
 import type {SecretKey, PublicKey} from "@chainsafe/bls/types";
 import {toHexString} from "@chainsafe/ssz";
 import {describe, it, expect} from "vitest";

--- a/packages/beacon-node/test/unit/chain/lightclient/upgradeLightClientHeader.test.ts
+++ b/packages/beacon-node/test/unit/chain/lightclient/upgradeLightClientHeader.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeEach} from "vitest";
 import {ssz, allForks} from "@lodestar/types";
 import {ForkName, ForkSeq} from "@lodestar/params";

--- a/packages/beacon-node/test/unit/chain/opPools/syncCommittee.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/syncCommittee.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import bls from "@chainsafe/bls";
 import {toHexString} from "@chainsafe/ssz";
 import {describe, it, expect, beforeEach, beforeAll, afterEach, vi, MockedObject} from "vitest";

--- a/packages/beacon-node/test/unit/chain/opPools/syncCommitteeContribution.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/syncCommitteeContribution.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import type {SecretKey} from "@chainsafe/bls/types";
 import bls from "@chainsafe/bls";
 import {BitArray} from "@chainsafe/ssz";

--- a/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {ssz} from "@lodestar/types";

--- a/packages/beacon-node/test/unit/chain/stateCache/persistentCheckpointsCache.test.ts
+++ b/packages/beacon-node/test/unit/chain/stateCache/persistentCheckpointsCache.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeAll, beforeEach} from "vitest";
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {CachedBeaconStateAllForks, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";

--- a/packages/beacon-node/test/unit/chain/validation/aggregateAndProof.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/aggregateAndProof.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {toHexString} from "@chainsafe/ssz";
 import {describe, it} from "vitest";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";

--- a/packages/beacon-node/test/unit/chain/validation/attestation/validateAttestation.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation/validateAttestation.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {BitArray} from "@chainsafe/ssz";
 import {describe, it} from "vitest";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";

--- a/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import bls from "@chainsafe/bls";
 import type {PublicKey, SecretKey} from "@chainsafe/bls/types";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";

--- a/packages/beacon-node/test/unit/chain/validation/attesterSlashing.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attesterSlashing.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, beforeEach, afterEach, vi} from "vitest";
 import {phase0, ssz} from "@lodestar/types";
 import {MockedBeaconChain, getMockedBeaconChain} from "../../../mocks/mockedBeaconChain.js";

--- a/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {digest} from "@chainsafe/as-sha256";
 import bls from "@chainsafe/bls";
 import {PointFormat} from "@chainsafe/bls/types";

--- a/packages/beacon-node/test/unit/chain/validation/proposerSlashing.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/proposerSlashing.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, beforeEach, afterEach, vi} from "vitest";
 import {phase0, ssz} from "@lodestar/types";
 import {MockedBeaconChain, getMockedBeaconChain} from "../../../mocks/mockedBeaconChain.js";

--- a/packages/beacon-node/test/unit/chain/validation/voluntaryExit.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/voluntaryExit.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import bls from "@chainsafe/bls";
 import {PointFormat} from "@chainsafe/bls/types";
 import {describe, it, beforeEach, beforeAll, vi, afterEach} from "vitest";

--- a/packages/beacon-node/test/unit/db/api/repository.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repository.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import all from "it-all";
 import {ContainerType} from "@chainsafe/ssz";
 import {describe, it, expect, beforeEach, vi, afterEach, MockedObject} from "vitest";

--- a/packages/beacon-node/test/unit/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/beacon-node/test/unit/eth1/eth1MergeBlockTracker.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {toHexString} from "@chainsafe/ssz";
 import {describe, it, expect, beforeEach, afterEach} from "vitest";
 import {ChainConfig} from "@lodestar/config";

--- a/packages/beacon-node/test/unit/eth1/jwt.test.ts
+++ b/packages/beacon-node/test/unit/eth1/jwt.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {encodeJwtToken, decodeJwtToken} from "../../../src/eth1/provider/jwt.js";
 

--- a/packages/beacon-node/test/unit/eth1/utils/deposits.test.ts
+++ b/packages/beacon-node/test/unit/eth1/utils/deposits.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {phase0, ssz} from "@lodestar/types";
 import {MAX_DEPOSITS} from "@lodestar/params";

--- a/packages/beacon-node/test/unit/eth1/utils/eth1Data.test.ts
+++ b/packages/beacon-node/test/unit/eth1/utils/eth1Data.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {Root, phase0, ssz} from "@lodestar/types";
 import {toHex} from "@lodestar/utils";

--- a/packages/beacon-node/test/unit/eth1/utils/eth1Vote.test.ts
+++ b/packages/beacon-node/test/unit/eth1/utils/eth1Vote.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {config} from "@lodestar/config/default";
 import {phase0, ssz} from "@lodestar/types";

--- a/packages/beacon-node/test/unit/eth1/utils/groupDepositEventsByBlock.test.ts
+++ b/packages/beacon-node/test/unit/eth1/utils/groupDepositEventsByBlock.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {phase0} from "@lodestar/types";
 import {groupDepositEventsByBlock} from "../../../../src/eth1/utils/groupDepositEventsByBlock.js";

--- a/packages/beacon-node/test/unit/eth1/utils/optimizeNextBlockDiffForGenesis.test.ts
+++ b/packages/beacon-node/test/unit/eth1/utils/optimizeNextBlockDiffForGenesis.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {optimizeNextBlockDiffForGenesis} from "../../../../src/eth1/utils/optimizeNextBlockDiffForGenesis.js";
 import {Eth1Block} from "../../../../src/eth1/interface.js";

--- a/packages/beacon-node/test/unit/executionEngine/httpRetry.test.ts
+++ b/packages/beacon-node/test/unit/executionEngine/httpRetry.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {fastify} from "fastify";
 import {fromHexString} from "@chainsafe/ssz";
 import {describe, it, expect, beforeAll, afterAll} from "vitest";

--- a/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeAll} from "vitest";
 import {ssz, deneb} from "@lodestar/types";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";

--- a/packages/beacon-node/test/unit/network/fork.test.ts
+++ b/packages/beacon-node/test/unit/network/fork.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {ForkName, ForkSeq} from "@lodestar/params";
 import {BeaconConfig, ForkInfo} from "@lodestar/config";

--- a/packages/beacon-node/test/unit/network/peers/datastore.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/datastore.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {LevelDatastore} from "datastore-level";
 import {Key} from "interface-datastore";
 import {describe, it, expect, beforeEach, afterEach, vi, MockedObject} from "vitest";

--- a/packages/beacon-node/test/unit/network/peers/utils/assertPeerRelevance.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/utils/assertPeerRelevance.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {phase0} from "@lodestar/types";
 import {assertPeerRelevance, IrrelevantPeerCode} from "../../../../../src/network/peers/utils/assertPeerRelevance.js";

--- a/packages/beacon-node/test/unit/network/peers/utils/enrSubnets.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/utils/enrSubnets.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {BitArray} from "@chainsafe/ssz";
 import {describe, it, expect} from "vitest";
 import {SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, afterEach} from "vitest";
 import {config} from "@lodestar/config/default";
 import {Logger} from "@lodestar/utils";

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import EventEmitter from "node:events";
 import {toHexString} from "@chainsafe/ssz";
 import {describe, it, expect, beforeEach, afterEach, vi} from "vitest";

--- a/packages/beacon-node/test/unit/sync/utils/remoteSyncType.test.ts
+++ b/packages/beacon-node/test/unit/sync/utils/remoteSyncType.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {toHexString} from "@chainsafe/ssz";
 import {describe, it, expect} from "vitest";
 import {IForkChoice} from "@lodestar/fork-choice";

--- a/packages/beacon-node/test/unit/util/bytes.test.ts
+++ b/packages/beacon-node/test/unit/util/bytes.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 

--- a/packages/beacon-node/test/unit/util/kzg.test.ts
+++ b/packages/beacon-node/test/unit/util/kzg.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, afterEach, beforeAll} from "vitest";
 import {bellatrix, deneb, ssz} from "@lodestar/types";
 import {BYTES_PER_FIELD_ELEMENT, BLOB_TX_TYPE} from "@lodestar/params";

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {deneb, Epoch, phase0, RootHex, Slot, ssz} from "@lodestar/types";
 import {fromHex, toHex} from "@lodestar/utils";

--- a/packages/beacon-node/test/utils/peer.ts
+++ b/packages/beacon-node/test/utils/peer.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {PeerId} from "@libp2p/interface";
 import {createSecp256k1PeerId} from "@libp2p/peer-id-factory";
 import {peerIdFromBytes} from "@libp2p/peer-id";

--- a/packages/beacon-node/test/utils/render.ts
+++ b/packages/beacon-node/test/utils/render.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {BitArray} from "@chainsafe/ssz";
 
 export function renderBitArray(bitArray: BitArray): string {

--- a/packages/beacon-node/test/utils/runEl.ts
+++ b/packages/beacon-node/test/utils/runEl.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import fs from "node:fs";
 import net from "node:net";
 import {spawn} from "node:child_process";

--- a/packages/beacon-node/test/utils/testnet.ts
+++ b/packages/beacon-node/test/utils/testnet.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {fromHexString} from "@chainsafe/ssz";
 import {phase0} from "@lodestar/types";
 import {createChainForkConfig, ChainForkConfig} from "@lodestar/config";

--- a/packages/beacon-node/test/utils/validator.ts
+++ b/packages/beacon-node/test/utils/validator.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {fromHexString} from "@chainsafe/ssz";
 import {phase0} from "@lodestar/types";
 import {FAR_FUTURE_EPOCH} from "../../src/constants/index.js";

--- a/packages/cli/src/cmds/dev/files.ts
+++ b/packages/cli/src/cmds/dev/files.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import fs from "node:fs";
 import path from "node:path";
 import {Keystore} from "@chainsafe/bls-keystore";

--- a/packages/cli/src/cmds/validator/keymanager/keystoreCache.ts
+++ b/packages/cli/src/cmds/validator/keymanager/keystoreCache.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import fs from "node:fs";
 import path from "node:path";
 import bls from "@chainsafe/bls";

--- a/packages/cli/src/cmds/validator/slashingProtection/utils.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/utils.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {Root} from "@lodestar/types";
 import {ApiError, getClient} from "@lodestar/api";
 import {fromHex, Logger} from "@lodestar/utils";

--- a/packages/cli/test/unit/validator/options.test.ts
+++ b/packages/cli/test/unit/validator/options.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {parseFeeRecipient} from "../../../src/util/index.js";
 

--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {Type} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {BUCKET_LENGTH} from "./const.js";

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {Level} from "level";
 import type {ClassicLevel} from "classic-level";
 import {Logger} from "@lodestar/utils";

--- a/packages/db/src/util.ts
+++ b/packages/db/src/util.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {intToBytes} from "@lodestar/utils";
 import {BUCKET_LENGTH} from "./const.js";
 

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {execSync} from "node:child_process";
 import os from "node:os";
 import {describe, it, expect, beforeAll, afterAll} from "vitest";

--- a/packages/db/test/unit/schema.test.ts
+++ b/packages/db/test/unit/schema.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {intToBytes} from "@lodestar/utils";
 import {BUCKET_LENGTH, encodeKey} from "../../src/index.js";

--- a/packages/flare/src/cmds/selfSlashAttester.ts
+++ b/packages/flare/src/cmds/selfSlashAttester.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import bls from "@chainsafe/bls";
 import type {SecretKey} from "@chainsafe/bls/types";
 import {ApiError, getClient} from "@lodestar/api";

--- a/packages/flare/src/cmds/selfSlashProposer.ts
+++ b/packages/flare/src/cmds/selfSlashProposer.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import type {SecretKey} from "@chainsafe/bls/types";
 import {ApiError, getClient} from "@lodestar/api";
 import {phase0, ssz} from "@lodestar/types";

--- a/packages/fork-choice/test/perf/forkChoice/onAttestation.test.ts
+++ b/packages/fork-choice/test/perf/forkChoice/onAttestation.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {itBench} from "@dapplion/benchmark";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {AttestationData, IndexedAttestation} from "@lodestar/types/phase0";

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeEach, beforeAll} from "vitest";
 import {fromHexString} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";

--- a/packages/light-client/test/unit/isValidLightClientHeader.test.ts
+++ b/packages/light-client/test/unit/isValidLightClientHeader.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {fromHexString} from "@chainsafe/ssz";
 import {ssz, allForks} from "@lodestar/types";

--- a/packages/light-client/test/unit/sync.node.test.ts
+++ b/packages/light-client/test/unit/sync.node.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, afterEach, vi} from "vitest";
 import {JsonPath, toHexString} from "@chainsafe/ssz";
 import {computeDescriptor, TreeOffsetProof} from "@chainsafe/persistent-merkle-tree";

--- a/packages/light-client/test/unit/syncInMemory.test.ts
+++ b/packages/light-client/test/unit/syncInMemory.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeAll, vi} from "vitest";
 import bls from "@chainsafe/bls";
 import {createBeaconConfig} from "@lodestar/config";

--- a/packages/light-client/test/unit/utils.test.ts
+++ b/packages/light-client/test/unit/utils.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {isValidMerkleBranch} from "../../src/utils/verifyMerkleBranch.js";
 import {computeMerkleBranch} from "../utils/utils.js";

--- a/packages/light-client/test/unit/validation.test.ts
+++ b/packages/light-client/test/unit/validation.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeAll, vi} from "vitest";
 import bls from "@chainsafe/bls";
 import {Tree} from "@chainsafe/persistent-merkle-tree";

--- a/packages/light-client/test/utils/getGenesisData.ts
+++ b/packages/light-client/test/utils/getGenesisData.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {ApiError, getClient} from "@lodestar/api";
 import {config} from "@lodestar/config/default";
 import {NetworkName} from "@lodestar/config/networks.js";

--- a/packages/light-client/test/utils/utils.ts
+++ b/packages/light-client/test/utils/utils.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import bls from "@chainsafe/bls";
 import {PointFormat, PublicKey, SecretKey} from "@chainsafe/bls/types";
 import {hasher, Tree} from "@chainsafe/persistent-merkle-tree";

--- a/packages/prover/src/utils/conversion.ts
+++ b/packages/prover/src/utils/conversion.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {BlockData, HeaderData} from "@ethereumjs/block";
 import {ELBlock, ELTransaction} from "../types.js";
 import {isTruthy} from "./assertion.js";

--- a/packages/prover/src/utils/evm.ts
+++ b/packages/prover/src/utils/evm.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {Blockchain} from "@ethereumjs/blockchain";
 import {Account, Address} from "@ethereumjs/util";
 import {VM, RunTxResult} from "@ethereumjs/vm";

--- a/packages/prover/src/utils/validation.ts
+++ b/packages/prover/src/utils/validation.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {Block} from "@ethereumjs/block";
 import {RLP} from "@ethereumjs/rlp";
 import {Trie} from "@ethereumjs/trie";

--- a/packages/prover/test/unit/utils/execution.test.ts
+++ b/packages/prover/test/unit/utils/execution.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import deepmerge from "deepmerge";
 import {getEnvLogger} from "@lodestar/logger/env";

--- a/packages/reqresp/src/encoders/responseDecode.ts
+++ b/packages/reqresp/src/encoders/responseDecode.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {Uint8ArrayList} from "uint8arraylist";
 import {ForkName} from "@lodestar/params";
 import {BufferedSource, decodeErrorMessage} from "../utils/index.js";

--- a/packages/reqresp/src/encoders/responseEncode.ts
+++ b/packages/reqresp/src/encoders/responseEncode.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {writeEncodedPayload} from "../encodingStrategies/index.js";
 import {encodeErrorMessage} from "../utils/index.js";
 import {ContextBytesType, ContextBytesFactory, MixedProtocol, Protocol, ResponseOutgoing} from "../types.js";

--- a/packages/reqresp/src/encodingStrategies/sszSnappy/encode.ts
+++ b/packages/reqresp/src/encodingStrategies/sszSnappy/encode.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {encode as varintEncode} from "uint8-varint";
 import {encodeSnappy} from "./snappyFrames/compress.js";
 

--- a/packages/reqresp/src/encodingStrategies/sszSnappy/snappyFrames/common.ts
+++ b/packages/reqresp/src/encodingStrategies/sszSnappy/snappyFrames/common.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 export enum ChunkType {
   IDENTIFIER = 0xff,
   COMPRESSED = 0x00,

--- a/packages/reqresp/src/encodingStrategies/sszSnappy/snappyFrames/compress.ts
+++ b/packages/reqresp/src/encodingStrategies/sszSnappy/snappyFrames/compress.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import snappy from "snappy";
 import crc32c from "@chainsafe/fast-crc32c";
 import {ChunkType, IDENTIFIER_FRAME} from "./common.js";

--- a/packages/reqresp/src/utils/errorMessage.ts
+++ b/packages/reqresp/src/utils/errorMessage.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {encodeSszSnappy} from "../encodingStrategies/sszSnappy/encode.js";
 import {Encoding} from "../types.js";
 

--- a/packages/reqresp/test/fixtures/encoders.ts
+++ b/packages/reqresp/test/fixtures/encoders.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {ForkName} from "@lodestar/params";
 import {LodestarError} from "@lodestar/utils";
 import {SszSnappyError, SszSnappyErrorCode} from "../../src/encodingStrategies/sszSnappy/index.js";

--- a/packages/reqresp/test/fixtures/encodingStrategies.ts
+++ b/packages/reqresp/test/fixtures/encodingStrategies.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import fs from "node:fs";
 import path from "node:path";
 import {fileURLToPath} from "node:url";

--- a/packages/reqresp/test/fixtures/messages.ts
+++ b/packages/reqresp/test/fixtures/messages.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {fromHexString} from "@chainsafe/ssz";
 import {createBeaconConfig} from "@lodestar/config";
 import {chainConfig} from "@lodestar/config/default";

--- a/packages/reqresp/test/fixtures/protocols.ts
+++ b/packages/reqresp/test/fixtures/protocols.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {ContainerType, UintNumberType, ListBasicType, ValueOf} from "@chainsafe/ssz";
 import {ssz} from "@lodestar/types";
 import {ForkName} from "@lodestar/params";

--- a/packages/reqresp/test/unit/encoders/responseDecode.test.ts
+++ b/packages/reqresp/test/unit/encoders/responseDecode.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import all from "it-all";
 import {pipe} from "it-pipe";

--- a/packages/reqresp/test/unit/encodingStrategies/sszSnappy/encode.test.ts
+++ b/packages/reqresp/test/unit/encodingStrategies/sszSnappy/encode.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import all from "it-all";
 import {pipe} from "it-pipe";

--- a/packages/reqresp/test/unit/encodingStrategies/sszSnappy/snappyFrames/uncompress.test.ts
+++ b/packages/reqresp/test/unit/encodingStrategies/sszSnappy/snappyFrames/uncompress.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {Uint8ArrayList} from "uint8arraylist";
 import {pipe} from "it-pipe";

--- a/packages/reqresp/test/unit/request/index.test.ts
+++ b/packages/reqresp/test/unit/request/index.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, vi, beforeEach, afterEach} from "vitest";
 import {PeerId} from "@libp2p/interface";
 import all from "it-all";

--- a/packages/reqresp/test/unit/response/index.test.ts
+++ b/packages/reqresp/test/unit/response/index.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeEach, afterEach} from "vitest";
 import {PeerId} from "@libp2p/interface";
 import {LodestarError, fromHex} from "@lodestar/utils";

--- a/packages/reqresp/test/utils/index.ts
+++ b/packages/reqresp/test/utils/index.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {Direction, ReadStatus, Stream, StreamStatus, WriteStatus} from "@libp2p/interface";
 import {logger} from "@libp2p/logger";
 import {expect} from "vitest";

--- a/packages/reqresp/test/utils/peer.ts
+++ b/packages/reqresp/test/utils/peer.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {PeerId} from "@libp2p/interface";
 import {peerIdFromBytes} from "@libp2p/peer-id";
 

--- a/packages/state-transition/src/block/processRandao.ts
+++ b/packages/state-transition/src/block/processRandao.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import xor from "buffer-xor";
 import {digest} from "@chainsafe/as-sha256";
 import {allForks} from "@lodestar/types";

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {CoordType, PublicKey} from "@chainsafe/bls/types";
 import bls from "@chainsafe/bls";
 import {ValidatorIndex} from "@lodestar/types";

--- a/packages/state-transition/src/constants/constants.ts
+++ b/packages/state-transition/src/constants/constants.ts
@@ -1,3 +1,5 @@
+import {Buffer} from "node:buffer";
+
 export const ZERO_HASH = Buffer.alloc(32, 0);
 export const EMPTY_SIGNATURE = Buffer.alloc(96, 0);
 export const SECONDS_PER_DAY = 86400;

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {digest} from "@chainsafe/as-sha256";
 import {Epoch, Bytes32, DomainType, ValidatorIndex} from "@lodestar/types";
 import {assert, bytesToBigInt, intToBytes} from "@lodestar/utils";

--- a/packages/state-transition/src/util/shuffle.ts
+++ b/packages/state-transition/src/util/shuffle.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {digest} from "@chainsafe/as-sha256";
 import {SHUFFLE_ROUND_COUNT} from "@lodestar/params";
 import {ValidatorIndex, Bytes32} from "@lodestar/types";

--- a/packages/state-transition/test/perf/block/util.ts
+++ b/packages/state-transition/test/perf/block/util.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import bls from "@chainsafe/bls";
 import {toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
 import {BitArray} from "@chainsafe/ssz";

--- a/packages/state-transition/test/perf/misc/byteArrayEquals.test.ts
+++ b/packages/state-transition/test/perf/misc/byteArrayEquals.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import crypto from "node:crypto";
 import {itBench} from "@dapplion/benchmark";
 import {byteArrayEquals} from "@chainsafe/ssz";

--- a/packages/state-transition/test/perf/misc/rootEquals.test.ts
+++ b/packages/state-transition/test/perf/misc/rootEquals.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
 import {byteArrayEquals, fromHexString} from "@chainsafe/ssz";
 import {ssz} from "@lodestar/types";

--- a/packages/state-transition/test/perf/util.ts
+++ b/packages/state-transition/test/perf/util.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {CoordType, PublicKey, SecretKey} from "@chainsafe/bls/types";
 import bls from "@chainsafe/bls";
 import {BitArray, fromHexString} from "@chainsafe/ssz";

--- a/packages/state-transition/test/perf/util/loadState/findModifiedValidators.test.ts
+++ b/packages/state-transition/test/perf/util/loadState/findModifiedValidators.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {expect} from "chai";
 import {itBench} from "@dapplion/benchmark";
 import {CompositeViewDU} from "@chainsafe/ssz";

--- a/packages/state-transition/test/perf/util/loadState/loadState.test.ts
+++ b/packages/state-transition/test/perf/util/loadState/loadState.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import bls from "@chainsafe/bls";
 import {CoordType} from "@chainsafe/bls/types";
 import {itBench, setBenchOpts} from "@dapplion/benchmark";

--- a/packages/state-transition/test/perf/util/signingRoot.test.ts
+++ b/packages/state-transition/test/perf/util/signingRoot.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
 import {digest} from "@chainsafe/as-sha256";
 import {fromHexString, toHexString} from "@chainsafe/ssz";

--- a/packages/state-transition/test/unit/cachedBeaconState.test.ts
+++ b/packages/state-transition/test/unit/cachedBeaconState.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {Epoch, ssz, RootHex} from "@lodestar/types";
 import {toHexString} from "@lodestar/utils";

--- a/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import crypto from "node:crypto";
 import {describe, it, expect} from "vitest";
 import bls from "@chainsafe/bls";

--- a/packages/state-transition/test/unit/upgradeState.test.ts
+++ b/packages/state-transition/test/unit/upgradeState.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {expect, describe, it} from "vitest";
 import {ssz} from "@lodestar/types";
 import {ForkName} from "@lodestar/params";

--- a/packages/state-transition/test/unit/util/loadState/loadValidator.test.ts
+++ b/packages/state-transition/test/unit/util/loadState/loadValidator.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {CompositeViewDU} from "@chainsafe/ssz";
 import {phase0, ssz} from "@lodestar/types";

--- a/packages/state-transition/test/unit/util/misc.test.ts
+++ b/packages/state-transition/test/unit/util/misc.test.ts
@@ -1,5 +1,5 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
-
 import {toBigIntLE} from "bigint-buffer";
 import {GENESIS_SLOT, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {getBlockRoot} from "../../../src/util/index.js";

--- a/packages/state-transition/test/unit/util/seed.test.ts
+++ b/packages/state-transition/test/unit/util/seed.test.ts
@@ -1,5 +1,5 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
-
 import {toHexString} from "@chainsafe/ssz";
 import {GENESIS_EPOCH, GENESIS_SLOT, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {getRandaoMix} from "../../../src/util/index.js";

--- a/packages/state-transition/test/utils/capella.ts
+++ b/packages/state-transition/test/utils/capella.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import crypto from "node:crypto";
 import {ssz} from "@lodestar/types";
 import {config} from "@lodestar/config/default";

--- a/packages/state-transition/test/utils/state.ts
+++ b/packages/state-transition/test/utils/state.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {config as minimalConfig} from "@lodestar/config/default";
 import {
   EPOCHS_PER_HISTORICAL_VECTOR,

--- a/packages/state-transition/test/utils/validator.ts
+++ b/packages/state-transition/test/utils/validator.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {fromHexString} from "@chainsafe/ssz";
 import {FAR_FUTURE_EPOCH} from "@lodestar/params";
 import {phase0} from "@lodestar/types";

--- a/packages/test-utils/src/childProcess.ts
+++ b/packages/test-utils/src/childProcess.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import {Buffer} from "node:buffer";
 import childProcess from "node:child_process";
 import stream from "node:stream";
 import fs from "node:fs";

--- a/packages/utils/src/base64.ts
+++ b/packages/utils/src/base64.ts
@@ -1,3 +1,5 @@
+import {Buffer} from "node:buffer";
+
 const hasBufferFrom = typeof Buffer !== "undefined" && typeof Buffer.from === "function";
 
 export function toBase64(value: string): string {

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {toBufferLE, toBigIntLE, toBufferBE, toBigIntBE} from "bigint-buffer";
 
 type Endianness = "le" | "be";

--- a/packages/utils/src/verifyMerkleBranch.ts
+++ b/packages/utils/src/verifyMerkleBranch.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {digest, digest64} from "@chainsafe/as-sha256";
 
 export function hash(...inputs: Uint8Array[]): Uint8Array {

--- a/packages/utils/test/unit/bytes.test.ts
+++ b/packages/utils/test/unit/bytes.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {intToBytes, bytesToInt, toHex, fromHex, toHexString} from "../../src/index.js";
 

--- a/packages/validator/src/repositories/metaDataRepository.ts
+++ b/packages/validator/src/repositories/metaDataRepository.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {encodeKey, DbReqOpts} from "@lodestar/db";
 import {Root, UintNum64} from "@lodestar/types";
 import {ssz} from "@lodestar/types";

--- a/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
+++ b/packages/validator/src/slashingProtection/attestation/attestationByTargetRepository.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {ContainerType, Type} from "@chainsafe/ssz";
 import {BLSPubkey, Epoch, ssz} from "@lodestar/types";
 import {intToBytes, bytesToInt} from "@lodestar/utils";

--- a/packages/validator/src/slashingProtection/attestation/attestationLowerBoundRepository.ts
+++ b/packages/validator/src/slashingProtection/attestation/attestationLowerBoundRepository.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {ContainerType, Type} from "@chainsafe/ssz";
 import {BLSPubkey, Epoch, ssz} from "@lodestar/types";
 import {encodeKey, DbReqOpts} from "@lodestar/db";

--- a/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
+++ b/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {ContainerType, Type} from "@chainsafe/ssz";
 import {BLSPubkey, Slot, ssz} from "@lodestar/types";
 import {intToBytes, bytesToInt} from "@lodestar/utils";

--- a/packages/validator/src/slashingProtection/minMaxSurround/distanceStoreRepository.ts
+++ b/packages/validator/src/slashingProtection/minMaxSurround/distanceStoreRepository.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {Type} from "@chainsafe/ssz";
 import {encodeKey, DbReqOpts} from "@lodestar/db";
 import {BLSPubkey, Epoch, ssz} from "@lodestar/types";

--- a/packages/validator/test/spec/index.test.ts
+++ b/packages/validator/test/spec/index.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {expect, describe, it, beforeAll, afterAll} from "vitest";
 import {rimraf} from "rimraf";
 import {LevelDbController} from "@lodestar/db";

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeAll, beforeEach, afterEach, vi} from "vitest";
 import bls from "@chainsafe/bls";
 import {toHexString} from "@chainsafe/ssz";

--- a/packages/validator/test/unit/services/syncCommittee.test.ts
+++ b/packages/validator/test/unit/services/syncCommittee.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeAll, beforeEach, afterEach, vi} from "vitest";
 import bls from "@chainsafe/bls";
 import {toHexString} from "@chainsafe/ssz";

--- a/packages/validator/test/unit/utils/difference.test.ts
+++ b/packages/validator/test/unit/utils/difference.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect} from "vitest";
 import {differenceHex} from "../../../src/util/difference.js";
 

--- a/packages/validator/test/unit/validatorStore.test.ts
+++ b/packages/validator/test/unit/validatorStore.test.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {describe, it, expect, beforeEach, afterEach, vi} from "vitest";
 import {toBufferBE} from "bigint-buffer";
 import bls from "@chainsafe/bls";

--- a/packages/validator/test/utils/types.ts
+++ b/packages/validator/test/utils/types.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {toHex} from "@lodestar/utils";
 
 export const ZERO_HASH = Buffer.alloc(32, 0);

--- a/packages/validator/test/utils/validatorStore.ts
+++ b/packages/validator/test/utils/validatorStore.ts
@@ -1,3 +1,4 @@
+import {Buffer} from "node:buffer";
 import {SecretKey} from "@chainsafe/bls/types";
 import {Api} from "@lodestar/api";
 import {chainConfig} from "@lodestar/config/default";


### PR DESCRIPTION
**Description**

Explicitly import `Buffer` via `node:buffer`, as recommended [here](https://nodejs.org/api/buffer.html#buffer):

```
While the Buffer class is available within the global scope, it is still recommended to explicitly reference it via an import or require statement.
```

This allows to spot more easily dependencies on `Buffer` and helps with polyfills on platforms without `Buffer` support.

TODO

* [ ] figure out best option for browser
* [ ] add eslint rule