### PR TITLE
chore: remove state-transition dependency

### DIFF
--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -71,7 +71,6 @@
     "@lodestar/api": "^1.16.0",
     "@lodestar/config": "^1.16.0",
     "@lodestar/params": "^1.16.0",
-    "@lodestar/state-transition": "^1.16.0",
     "@lodestar/types": "^1.16.0",
     "@lodestar/utils": "^1.16.0",
     "mitt": "^3.0.0",

--- a/packages/light-client/src/spec/utils.ts
+++ b/packages/light-client/src/spec/utils.ts
@@ -10,9 +10,8 @@ import {
 } from "@lodestar/params";
 import {altair, phase0, ssz, allForks, capella, deneb, Slot} from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
 
-import {isValidMerkleBranch, computeSyncPeriodAtSlot} from "../utils/index.js";
+import {isValidMerkleBranch, computeEpochAtSlot, computeSyncPeriodAtSlot} from "../utils/index.js";
 import {LightClientStore} from "./store.js";
 
 export const GENESIS_SLOT = 0;


### PR DESCRIPTION
**Motivation**

Reduce inter-module dependency

**Description**

`light-client` only depends on `state-transition` for [computeEpochAtSlot](https://github.com/ChainSafe/lodestar/blob/36f50cf08337e70b0f8078949a23162256ec03a2/packages/state-transition/src/util/epoch.ts#L7). Replace it with the equivalent [computeEpochAtSlot](https://github.com/ChainSafe/lodestar/blob/36f50cf08337e70b0f8078949a23162256ec03a2/packages/light-client/src/utils/clock.ts#L19) from `light-client`.

Note that this code duplication should probably be addressed. An idea would be to have a separate module (deps free) containing those utilities.