### PR TITLE
fix: increase max attestation inclusion slot for post deneb blocks

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -606,7 +606,7 @@ export async function produceCommonBlockBody<T extends BlockType>(
     this.opPool.getSlashingsAndExits(currentState, blockType, this.metrics);
 
   const endAttestations = stepsMetrics?.startTimer();
-  const attestations = this.aggregatedAttestationPool.getAttestationsForBlock(this.forkChoice, currentState);
+  const attestations = this.aggregatedAttestationPool.getAttestationsForBlock(fork, this.forkChoice, currentState);
   endAttestations?.({
     step: BlockProductionStep.attestations,
   });

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -159,7 +159,7 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
         return {state, pool};
       },
       fn: ({state, pool}) => {
-        pool.getAttestationsForBlock(forkchoice, state);
+        pool.getAttestationsForBlock(state.config.getForkName(state.slot), forkchoice, state);
       },
     });
   }

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -3,7 +3,7 @@ import bls from "@chainsafe/bls";
 import {BitArray, fromHexString, toHexString} from "@chainsafe/ssz";
 import {describe, it, expect, beforeEach, beforeAll, afterEach, vi} from "vitest";
 import {CachedBeaconStateAllForks, newFilledArray} from "@lodestar/state-transition";
-import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {FAR_FUTURE_EPOCH, ForkName, MAX_EFFECTIVE_BALANCE, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ssz, phase0} from "@lodestar/types";
 import {CachedBeaconStateAltair} from "@lodestar/state-transition/src/types.js";
 import {MockedForkChoice, getMockedForkChoice} from "../../../mocks/mockedBeaconChain.js";
@@ -28,6 +28,7 @@ const validSignature = fromHexString(
 
 describe("AggregatedAttestationPool", function () {
   let pool: AggregatedAttestationPool;
+  const fork = ForkName.altair;
   const altairForkEpoch = 2020;
   const currentEpoch = altairForkEpoch + 10;
   const currentSlot = SLOTS_PER_EPOCH * currentEpoch;
@@ -115,9 +116,9 @@ describe("AggregatedAttestationPool", function () {
       forkchoiceStub.getBlockHex.mockReturnValue(generateProtoBlock());
       forkchoiceStub.getDependentRoot.mockReturnValue(ZERO_HASH_HEX);
       if (isReturned) {
-        expect(pool.getAttestationsForBlock(forkchoiceStub, altairState).length).toBeGreaterThan(0);
+        expect(pool.getAttestationsForBlock(fork, forkchoiceStub, altairState).length).toBeGreaterThan(0);
       } else {
-        expect(pool.getAttestationsForBlock(forkchoiceStub, altairState).length).toEqual(0);
+        expect(pool.getAttestationsForBlock(fork, forkchoiceStub, altairState).length).toEqual(0);
       }
       // "forkchoice should be called to check pivot block"
       expect(forkchoiceStub.getDependentRoot).toHaveBeenCalledTimes(1);
@@ -129,7 +130,7 @@ describe("AggregatedAttestationPool", function () {
     // all attesters are not seen
     const attestingIndices = [2, 3];
     pool.add(attestation, attDataRootHex, attestingIndices.length, committee);
-    expect(pool.getAttestationsForBlock(forkchoiceStub, altairState)).toEqual([]);
+    expect(pool.getAttestationsForBlock(fork, forkchoiceStub, altairState)).toEqual([]);
     // "forkchoice should not be called"
     expect(forkchoiceStub.iterateAncestorBlocks).not.toHaveBeenCalledTimes(1);
   });
@@ -140,7 +141,7 @@ describe("AggregatedAttestationPool", function () {
     pool.add(attestation, attDataRootHex, attestingIndices.length, committee);
     forkchoiceStub.getBlockHex.mockReturnValue(generateProtoBlock());
     forkchoiceStub.getDependentRoot.mockReturnValue("0xWeird");
-    expect(pool.getAttestationsForBlock(forkchoiceStub, altairState)).toEqual([]);
+    expect(pool.getAttestationsForBlock(fork, forkchoiceStub, altairState)).toEqual([]);
     // "forkchoice should be called to check pivot block"
     expect(forkchoiceStub.getDependentRoot).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
**Motivation**

[EIP-7045](https://eips.ethereum.org/EIPS/eip-7045) allows to include attestations from current and previous epoch in block.


https://eips.ethereum.org/EIPS/eip-7045#consensus-layer
> Modify [process_attestation](https://github.com/ethereum/consensus-specs/blob/95f36d99cf4aa59974da06af24ef9a7c12d3c301/specs/deneb/beacon-chain.md#modified-process_attestation) to not have an upper bound on the slot check and instead define the inclusion range via the minimum slot as well as the target epoch being in either current or previous epoch.


**Description**

Increase max attestation inclusion slot for post deneb blocks by skipping upper bound on the slot check.

Note that we verify before that attestation target epoch is in previous or current epoch
https://github.com/ChainSafe/lodestar/blob/adc0534782436ee45614968c090915f0724121e1/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts#L142-L145

Ref: https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.7/specs/deneb/beacon-chain.md#modified-process_attestation

related https://github.com/ethereum/consensus-specs/pull/3360