### PR TITLE
chore: update release script to bump packages commit conventionally

### DIFF
--- a/scripts/release/create_rc.mjs
+++ b/scripts/release/create_rc.mjs
@@ -110,7 +110,7 @@ shell(`git checkout -b ${rcBranchName} ${commit}`);
 shell(`lerna version ${packageVersion} --no-git-tag-version --force-publish --yes`);
 
 // Commit changes
-shell(`git commit -am "v${versionMMP}"`);
+shell(`git commit -am "chore: v${versionMMP}"`);
 
 // Push branch, specifying upstream
 shell(`git push ${GIT_REPO_URL} ${rcBranchName}`);


### PR DESCRIPTION
**Motivation**

The release script currently creates an additional commit to bump the versioning but the commit itself does not conform to conventional commits.

**Description**

Allows the script to automatically mark the version bump commit as a `chore:`