### PR TITLE
chore: release script commit update for clarity

### DIFF
--- a/scripts/release/create_rc.mjs
+++ b/scripts/release/create_rc.mjs
@@ -110,7 +110,7 @@ shell(`git checkout -b ${rcBranchName} ${commit}`);
 shell(`lerna version ${packageVersion} --no-git-tag-version --force-publish --yes`);
 
 // Commit changes
-shell(`git commit -am "chore: bump package versions to v${versionMMP}"`);
+shell(`git commit -am "chore: bump package versions to ${versionMMP}"`);
 
 // Push branch, specifying upstream
 shell(`git push ${GIT_REPO_URL} ${rcBranchName}`);

--- a/scripts/release/create_rc.mjs
+++ b/scripts/release/create_rc.mjs
@@ -110,7 +110,7 @@ shell(`git checkout -b ${rcBranchName} ${commit}`);
 shell(`lerna version ${packageVersion} --no-git-tag-version --force-publish --yes`);
 
 // Commit changes
-shell(`git commit -am "chore: v${versionMMP}"`);
+shell(`git commit -am "chore: bump package versions to v${versionMMP}"`);
 
 // Push branch, specifying upstream
 shell(`git push ${GIT_REPO_URL} ${rcBranchName}`);


### PR DESCRIPTION
**Motivation**

This is a follow up to #6524 with a [comment](https://github.com/ChainSafe/lodestar/pull/6524#discussion_r1517936578) from @nflaig for clarity on the automated commit made by the release script. Since it does show up as part of the history, we should clarify what the commit is actually doing.