### PR TITLE
feat: pull block from peers after a cutoff if corresponding gossip blobs are seen

### DIFF
--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -34,7 +34,7 @@ type BlockInputCacheType = {
   resolveAvailability: (blobs: BlockInputBlobs) => void;
   // block promise and its callback cached for delayed resolution
   blockInputPromise: Promise<BlockInput>;
-  resolveBlock: (blockInput: BlockInput) => void;
+  resolveBlockInput: (blockInput: BlockInput) => void;
 };
 
 const MAX_GOSSIPINPUT_CACHE = 5;
@@ -112,7 +112,7 @@ export class SeenGossipBlockInput {
       availabilityPromise,
       resolveAvailability,
       blockInputPromise,
-      resolveBlock,
+      resolveBlockInput,
     } = blockCache;
 
     if (signedBlock !== undefined) {
@@ -147,7 +147,7 @@ export class SeenGossipBlockInput {
           blobsBytes
         );
 
-        resolveBlock(blockInput);
+        resolveBlockInput(blockInput);
         return {
           blockInput,
           blockInputMeta: {pending: null, haveBlobs: blobs.length, expectedBlobs: blobKzgCommitments.length},
@@ -163,7 +163,7 @@ export class SeenGossipBlockInput {
           resolveAvailability
         );
 
-        resolveBlock(blockInput);
+        resolveBlockInput(blockInput);
         return {
           blockInput,
           blockInputMeta: {
@@ -193,9 +193,9 @@ export class SeenGossipBlockInput {
 function getEmptyBlockInputCacheEntry(): BlockInputCacheType {
   // Capture both the promise and its callbacks for blockInput and final availability
   // It is not spec'ed but in tests in Firefox and NodeJS the promise constructor is run immediately
-  let resolveBlock: ((block: BlockInput) => void) | null = null;
+  let resolveBlockInput: ((block: BlockInput) => void) | null = null;
   const blockInputPromise = new Promise<BlockInput>((resolveCB) => {
-    resolveBlock = resolveCB;
+    resolveBlockInput = resolveCB;
   });
 
   let resolveAvailability: ((blobs: BlockInputBlobs) => void) | null = null;
@@ -203,9 +203,9 @@ function getEmptyBlockInputCacheEntry(): BlockInputCacheType {
     resolveAvailability = resolveCB;
   });
 
-  if (resolveAvailability === null || resolveBlock === null) {
+  if (resolveAvailability === null || resolveBlockInput === null) {
     throw Error("Promise Constructor was not executed immediately");
   }
   const blobsCache = new Map();
-  return {blockInputPromise, resolveBlock, availabilityPromise, resolveAvailability, blobsCache};
+  return {blockInputPromise, resolveBlockInput, availabilityPromise, resolveAvailability, blobsCache};
 }

--- a/packages/beacon-node/src/network/events.ts
+++ b/packages/beacon-node/src/network/events.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from "events";
 import {PeerId, TopicValidatorResult} from "@libp2p/interface";
 import {phase0, RootHex} from "@lodestar/types";
-import {BlockInput} from "../chain/blocks/types.js";
+import {BlockInput, NullBlockInput} from "../chain/blocks/types.js";
 import {StrictEventEmitterSingleArg} from "../util/strictEvents.js";
 import {PeerIdStr} from "../util/peerId.js";
 import {EventDirection} from "../util/workerEvents.js";
@@ -32,7 +32,7 @@ export type NetworkEventData = {
   [NetworkEvent.reqRespRequest]: {request: RequestTypedContainer; peer: PeerId};
   [NetworkEvent.unknownBlockParent]: {blockInput: BlockInput; peer: PeerIdStr};
   [NetworkEvent.unknownBlock]: {rootHex: RootHex; peer?: PeerIdStr};
-  [NetworkEvent.unknownBlockInput]: {blockInput: BlockInput; peer?: PeerIdStr};
+  [NetworkEvent.unknownBlockInput]: {blockInput: BlockInput | NullBlockInput; peer?: PeerIdStr};
   [NetworkEvent.pendingGossipsubMessage]: PendingGossipsubMessage;
   [NetworkEvent.gossipMessageValidationResult]: {
     msgId: string;

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -1,9 +1,10 @@
 import {toHexString} from "@chainsafe/ssz";
-import {BeaconConfig} from "@lodestar/config";
+import {BeaconConfig, ChainForkConfig} from "@lodestar/config";
 import {LogLevel, Logger, prettyBytes} from "@lodestar/utils";
-import {Root, Slot, ssz, allForks, deneb} from "@lodestar/types";
+import {Root, Slot, ssz, allForks, deneb, UintNum64} from "@lodestar/types";
 import {ForkName, ForkSeq} from "@lodestar/params";
 import {routes} from "@lodestar/api";
+import {computeTimeAtSlot} from "@lodestar/state-transition";
 import {Metrics} from "../../metrics/index.js";
 import {OpSource} from "../../metrics/validatorMonitor.js";
 import {
@@ -45,7 +46,13 @@ import {PeerAction} from "../peers/index.js";
 import {validateLightClientFinalityUpdate} from "../../chain/validation/lightClientFinalityUpdate.js";
 import {validateLightClientOptimisticUpdate} from "../../chain/validation/lightClientOptimisticUpdate.js";
 import {validateGossipBlobSidecar} from "../../chain/validation/blobSidecar.js";
-import {BlockInput, GossipedInputType, BlobSidecarValidation, BlockInputType} from "../../chain/blocks/types.js";
+import {
+  BlockInput,
+  GossipedInputType,
+  BlobSidecarValidation,
+  BlockInputType,
+  NullBlockInput,
+} from "../../chain/blocks/types.js";
 import {sszDeserialize} from "../gossip/topic.js";
 import {INetworkCore} from "../core/index.js";
 import {INetwork} from "../interface.js";
@@ -73,6 +80,7 @@ export type ValidatorFnsModules = {
 };
 
 const MAX_UNKNOWN_BLOCK_ROOT_RETRIES = 1;
+const BLOCK_AVAILABILITY_CUTOFF_MS = 3_000;
 
 /**
  * Gossip handlers perform validation + handling in a single function.
@@ -129,7 +137,7 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
     );
     const blockInput = blockInputRes.blockInput;
     // blockInput can't be returned null, improve by enforcing via return types
-    if (blockInput === null) {
+    if (blockInput.block === null) {
       throw Error(
         `Invalid null blockInput returned by getGossipBlockInput for type=${GossipedInputType.block} blockHex=${blockHex} slot=${slot}`
       );
@@ -182,7 +190,7 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
     gossipIndex: number,
     peerIdStr: string,
     seenTimestampSec: number
-  ): Promise<BlockInput | null> {
+  ): Promise<BlockInput | NullBlockInput> {
     const blobBlockHeader = blobSidecar.signedBlockHeader.message;
     const slot = blobBlockHeader.slot;
     const blockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(blobBlockHeader);
@@ -226,7 +234,7 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
     } catch (e) {
       if (e instanceof BlobSidecarGossipError) {
         // Don't trigger this yet if full block and blobs haven't arrived yet
-        if (e.type.code === BlobSidecarErrorCode.PARENT_UNKNOWN && blockInput !== null) {
+        if (e.type.code === BlobSidecarErrorCode.PARENT_UNKNOWN && blockInput.block !== null) {
           logger.debug("Gossip blob has error", {slot, root: blockHex, code: e.type.code});
           events.emit(NetworkEvent.unknownBlockParent, {blockInput, peer: peerIdStr});
         }
@@ -252,7 +260,7 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
     metrics?.registerBeaconBlock(OpSource.gossip, seenTimestampSec, signedBlock.message);
     // if blobs are not yet fully available start an aggressive blob pull
     if (blockInput.type === BlockInputType.blobsPromise) {
-      events.emit(NetworkEvent.unknownBlockInput, {blockInput: blockInput, peer: peerIdStr});
+      events.emit(NetworkEvent.unknownBlockInput, {blockInput, peer: peerIdStr});
     }
 
     chain
@@ -351,7 +359,10 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
     }: GossipHandlerParamGeneric<GossipType.blob_sidecar>) => {
       const {serializedData} = gossipData;
       const blobSidecar = sszDeserialize(topic, serializedData);
-      if (config.getForkSeq(blobSidecar.signedBlockHeader.message.slot) < ForkSeq.deneb) {
+      const blobSlot = blobSidecar.signedBlockHeader.message.slot;
+      const index = blobSidecar.index;
+
+      if (config.getForkSeq(blobSlot) < ForkSeq.deneb) {
         throw new GossipActionError(GossipAction.REJECT, {code: "PRE_DENEB_BLOCK"});
       }
       const blockInput = await validateBeaconBlob(
@@ -361,20 +372,39 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
         peerIdStr,
         seenTimestampSec
       );
-      if (blockInput !== null) {
-        // TODO DENEB:
-        //
-        // With blobsPromise the block import would have been attempted with the receipt of the block gossip
-        // and should have resolved the availability promise, however we could track if the block processing
-        // was halted and requeue it
+      if (blockInput.block !== null) {
+        // we can just queue up the blockInput in the processor, but block gossip handler would have already
+        // queued it up.
         //
         // handleValidBeaconBlock(blockInput, peerIdStr, seenTimestampSec);
       } else {
-        // TODO DENEB:
-        //
-        // If block + blobs not fully received in the slot within some deadline, we should trigger block/blob
-        // pull using req/resp by root pre-emptively even though it will be trigged on seeing any block/blob
-        // gossip on next slot via missing parent checks
+        // wait for the block to arrive till some cutoff else emit unknownBlockInput event
+        chain.logger.debug("Block not yet available, racing with cutoff", {blobSlot, index});
+        const normalBlockInput = await raceWithCutoff(
+          chain,
+          blobSlot,
+          blockInput.blockInputPromise,
+          BLOCK_AVAILABILITY_CUTOFF_MS
+        ).catch((_e) => {
+          return null;
+        });
+
+        if (normalBlockInput !== null) {
+          chain.logger.debug("Block corresponding to blob is now available for processing", {blobSlot, index});
+          // we can directly send it for processing but block gossip handler will queue it up anyway
+          // if we see any issues later, we can send it to handleValidBeaconBlock
+          //
+          // handleValidBeaconBlock(normalBlockInput, peerIdStr, seenTimestampSec);
+          //
+          // however we can emit the event which will atleast add the peer to the list of peers to pull
+          // data from
+          if (normalBlockInput.type === BlockInputType.blobsPromise) {
+            events.emit(NetworkEvent.unknownBlockInput, {blockInput: normalBlockInput, peer: peerIdStr});
+          }
+        } else {
+          chain.logger.debug("Block not available till BLOCK_AVAILABILITY_CUTOFF_MS", {blobSlot, index});
+          events.emit(NetworkEvent.unknownBlockInput, {blockInput, peer: peerIdStr});
+        }
       }
     },
 
@@ -734,4 +764,20 @@ export async function validateGossipFnRetryUnknownRoot<T>(
       throw e;
     }
   }
+}
+
+async function raceWithCutoff<T>(
+  chain: {config: ChainForkConfig; genesisTime: UintNum64; logger: Logger},
+  blockSlot: Slot,
+  availabilityPromise: Promise<T>,
+  cutoffMsFromSlotStart: number
+): Promise<T> {
+  const cutoffTimeMs = Math.max(
+    computeTimeAtSlot(chain.config, blockSlot, chain.genesisTime) * 1000 + cutoffMsFromSlotStart - Date.now(),
+    0
+  );
+  const cutoffTimeout = new Promise((_resolve, reject) => setTimeout(reject, cutoffTimeMs));
+  await Promise.race([availabilityPromise, cutoffTimeout]);
+  // we can only be here if availabilityPromise has resolved else an error will be thrown
+  return availabilityPromise;
 }

--- a/packages/beacon-node/src/sync/interface.ts
+++ b/packages/beacon-node/src/sync/interface.ts
@@ -56,7 +56,7 @@ export interface SyncModules {
 }
 
 export type UnknownAndAncestorBlocks = {
-  unknowns: (UnknownBlock | UnknownBlockInput)[];
+  unknowns: UnknownBlock[];
   ancestors: DownloadedBlock[];
 };
 
@@ -66,7 +66,7 @@ export type UnknownAndAncestorBlocks = {
  *   - store 1 record with known parentBlockRootHex & blockInput, blockRootHex as key, status downloaded
  *   - store 1 record with undefined parentBlockRootHex & blockInput, parentBlockRootHex as key, status pending
  */
-export type PendingBlock = UnknownBlock | UnknownBlockInput | DownloadedBlock;
+export type PendingBlock = UnknownBlock | DownloadedBlock;
 
 type PendingBlockCommon = {
   blockRootHex: RootHex;
@@ -77,17 +77,15 @@ type PendingBlockCommon = {
 export type UnknownBlock = PendingBlockCommon & {
   status: PendingBlockStatus.pending | PendingBlockStatus.fetching;
   parentBlockRootHex: null;
-  blockInput: null;
-};
+} & (
+    | {unknownBlockType: PendingBlockType.UNKNOWN_BLOCK; blockInput: null}
+    | {unknownBlockType: PendingBlockType.UNKNOWN_BLOBS; blockInput: BlockInput & {type: BlockInputType.blobsPromise}}
+    | {unknownBlockType: PendingBlockType.UNKNOWN_BLOCKINPUT; blockInput: NullBlockInput}
+  );
 
 /**
  * either the blobs are unknown or in future some blobs and even the block is unknown
  */
-export type UnknownBlockInput = PendingBlockCommon & {
-  status: PendingBlockStatus.pending | PendingBlockStatus.fetching;
-  parentBlockRootHex: null;
-  blockInput: (BlockInput & {type: BlockInputType.blobsPromise}) | NullBlockInput;
-};
 
 export type DownloadedBlock = PendingBlockCommon & {
   status: PendingBlockStatus.downloaded | PendingBlockStatus.processing;
@@ -113,4 +111,5 @@ export enum PendingBlockType {
   UNKNOWN_PARENT = "unknown_parent",
 
   UNKNOWN_BLOCKINPUT = "unknown_blockinput",
+  UNKNOWN_BLOBS = "unknown_blobs",
 }

--- a/packages/beacon-node/src/sync/interface.ts
+++ b/packages/beacon-node/src/sync/interface.ts
@@ -2,7 +2,7 @@ import {Logger} from "@lodestar/utils";
 import {RootHex, Slot, phase0} from "@lodestar/types";
 import {BeaconConfig} from "@lodestar/config";
 import {routes} from "@lodestar/api";
-import {BlockInput, BlockInputType} from "../chain/blocks/types.js";
+import {BlockInput, BlockInputType, NullBlockInput} from "../chain/blocks/types.js";
 import {INetwork} from "../network/index.js";
 import {IBeaconChain} from "../chain/index.js";
 import {Metrics} from "../metrics/index.js";
@@ -86,7 +86,7 @@ export type UnknownBlock = PendingBlockCommon & {
 export type UnknownBlockInput = PendingBlockCommon & {
   status: PendingBlockStatus.pending | PendingBlockStatus.fetching;
   parentBlockRootHex: null;
-  blockInput: BlockInput & {type: BlockInputType.blobsPromise};
+  blockInput: (BlockInput & {type: BlockInputType.blobsPromise}) | NullBlockInput;
 };
 
 export type DownloadedBlock = PendingBlockCommon & {

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -204,22 +204,11 @@ export class UnknownBlockSync {
       } as PendingBlock;
       this.pendingBlocks.set(blockRootHex, pendingBlock);
 
-      if (pendingBlock.blockInput?.block === null) {
-        this.logger.verbose("Added blockInput with unknown block to pendingBlocks", {
-          root: pendingBlock.blockInput.blockRootHex,
-          slot: "unknown",
-        });
-      } else if (pendingBlock.blockInput?.type === BlockInputType.blobsPromise) {
-        this.logger.verbose("Added blockInput with unknown blobs to pendingBlocks", {
-          root: blockRootHex,
-          slot: blockInput?.block?.message.slot ?? "unknown",
-        });
-      } else {
-        this.logger.verbose("Added unknown block to pendingBlocks", {
-          root: blockRootHex,
-          slot: blockInput?.block?.message.slot ?? "unknown",
-        });
-      }
+      this.logger.verbose("Added unknown block to pendingBlocks", {
+        unknownBlockType,
+        root: blockRootHex,
+        slot: blockInput?.block?.message.slot ?? "unknown",
+      });
     }
 
     if (peerIdStr) {
@@ -289,28 +278,13 @@ export class UnknownBlockSync {
     }
 
     const unknownBlockType = block.unknownBlockType;
-    if (block.blockInput === null) {
-      this.logger.verbose("Downloading unknown block", {
-        root: block.blockRootHex,
-        pendingBlocks: this.pendingBlocks.size,
-        slot: "unknown",
-        unknownBlockType,
-      });
-    } else if (block.blockInput.block === null) {
-      this.logger.verbose("Downloading unknown block with known blobs", {
-        root: block.blockInput.blockRootHex,
-        pendingBlocks: this.pendingBlocks.size,
-        unknownBlockType,
-      });
-    } else {
-      this.logger.verbose("Downloading unknown blobs", {
-        root: block.blockRootHex,
-        pendingBlocks: this.pendingBlocks.size,
-        blockInputType: block.blockInput.type,
-        slot: block.blockInput?.block?.message.slot ?? "unknown",
-        unknownBlockType,
-      });
-    }
+
+    this.logger.verbose("Downloading unknown block", {
+      root: block.blockRootHex,
+      pendingBlocks: this.pendingBlocks.size,
+      slot: block.blockInput?.block?.message.slot ?? "unknown",
+      unknownBlockType,
+    });
 
     block.status = PendingBlockStatus.fetching;
 

--- a/packages/beacon-node/src/sync/utils/pendingBlocksTree.ts
+++ b/packages/beacon-node/src/sync/utils/pendingBlocksTree.ts
@@ -66,7 +66,7 @@ export function getUnknownAndAncestorBlocks(blocks: Map<RootHex, PendingBlock>):
     const parentHex = block.parentBlockRootHex;
     if (
       block.status === PendingBlockStatus.pending &&
-      (block.blockInput == null || block.blockInput.type === BlockInputType.blobsPromise) &&
+      (block.blockInput?.block == null || block.blockInput?.type === BlockInputType.blobsPromise) &&
       parentHex == null
     ) {
       unknowns.push(block);

--- a/packages/beacon-node/src/sync/utils/pendingBlocksTree.ts
+++ b/packages/beacon-node/src/sync/utils/pendingBlocksTree.ts
@@ -5,7 +5,6 @@ import {
   PendingBlock,
   PendingBlockStatus,
   UnknownAndAncestorBlocks,
-  UnknownBlockInput,
   UnknownBlock,
 } from "../interface.js";
 import {BlockInputType} from "../../chain/blocks/types.js";
@@ -59,7 +58,7 @@ export function getDescendantBlocks(blockRootHex: RootHex, blocks: Map<RootHex, 
  *   return {unknowns: [], ancestors: [n]}
  */
 export function getUnknownAndAncestorBlocks(blocks: Map<RootHex, PendingBlock>): UnknownAndAncestorBlocks {
-  const unknowns: (UnknownBlock | UnknownBlockInput)[] = [];
+  const unknowns: UnknownBlock[] = [];
   const ancestors: DownloadedBlock[] = [];
 
   for (const block of blocks.values()) {

--- a/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
@@ -3,7 +3,7 @@ import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lo
 import {ssz} from "@lodestar/types";
 
 import {SeenGossipBlockInput} from "../../../../src/chain/seenCache/seenGossipBlockInput.js";
-import {BlockInputType, GossipedInputType} from "../../../../src/chain/blocks/types.js";
+import {BlockInputType, GossipedInputType, BlockInput} from "../../../../src/chain/blocks/types.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 describe("SeenGossipBlockInput", () => {
@@ -120,7 +120,7 @@ describe("SeenGossipBlockInput", () => {
             } else if (expectedResponseType === null) {
               expect(blockInputRes).toBeNull();
             } else {
-              expect(blockInputRes.blockInput?.type).toEqual(expectedResponseType);
+              expect((blockInputRes.blockInput as BlockInput)?.type).toEqual(expectedResponseType);
             }
           } else {
             const index = parseInt(inputEvent.split("blob")[1] ?? "0");
@@ -140,10 +140,10 @@ describe("SeenGossipBlockInput", () => {
             if (expectedResponseType instanceof Error) {
               expect.fail(`expected to fail with error: ${expectedResponseType.message}`);
             } else if (expectedResponseType === null) {
-              expect(blobInputRes.blockInput).toBeNull();
+              expect(blobInputRes.blockInput.block).toBeNull();
               expect(blobInputRes.blockInputMeta.expectedBlobs).toBeNull();
             } else {
-              expect(blobInputRes.blockInput?.type).toEqual(expectedResponseType);
+              expect((blobInputRes.blockInput as BlockInput)?.type).toEqual(expectedResponseType);
             }
           }
         } catch (e) {


### PR DESCRIPTION
generally we now start block import as soon as we see a block and pull blobs if not all blobs seen.
However in edgecases, even block might arrive too late

This PR starts pulling the block (and remaining blobs) from peers if we don't see a block past a certain cutoff 