### PR TITLE
chore: use mitt where possible

### DIFF
--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -73,8 +73,7 @@
     "@lodestar/params": "^1.17.0",
     "@lodestar/types": "^1.17.0",
     "@lodestar/utils": "^1.17.0",
-    "mitt": "^3.0.0",
-    "strict-event-emitter-types": "^2.0.0"
+    "mitt": "^3.0.0"
   },
   "devDependencies": {
     "@chainsafe/as-sha256": "^0.4.1",

--- a/packages/light-client/src/transport/rest.ts
+++ b/packages/light-client/src/transport/rest.ts
@@ -1,18 +1,20 @@
-import EventEmitter from "events";
-import {type StrictEventEmitter} from "strict-event-emitter-types";
+import mitt from "mitt";
 import {type allForks, type SyncPeriod} from "@lodestar/types";
 import {type Api, ApiError, routes} from "@lodestar/api";
 import {type ForkName} from "@lodestar/params";
+import {MittEmitter} from "../events.js";
 import {type LightClientTransport} from "./interface.js";
 
 export type LightClientRestEvents = {
-  [routes.events.EventType.lightClientFinalityUpdate]: allForks.LightClientFinalityUpdate;
-  [routes.events.EventType.lightClientOptimisticUpdate]: allForks.LightClientOptimisticUpdate;
+  [routes.events.EventType.lightClientFinalityUpdate]: (update: allForks.LightClientFinalityUpdate) => void;
+  [routes.events.EventType.lightClientOptimisticUpdate]: (update: allForks.LightClientOptimisticUpdate) => void;
 };
+
+export type LightClientRestEmitter = MittEmitter<LightClientRestEvents>;
 
 export class LightClientRestTransport implements LightClientTransport {
   private controller = new AbortController();
-  private readonly eventEmitter: StrictEventEmitter<EventEmitter, LightClientRestEvents> = new EventEmitter();
+  private readonly eventEmitter: LightClientRestEmitter = mitt();
   private subscribedEventstream = false;
 
   constructor(private readonly api: Api) {}


### PR DESCRIPTION
**Motivation**

Make sure `events` is not used in non `nodejs` runtime.

