### PR TITLE
feat: increase default target peers to 100

### DIFF
--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -25,8 +25,8 @@ export interface NetworkOptions
 }
 
 export const defaultNetworkOptions: NetworkOptions = {
-  maxPeers: 55, // Allow some room above targetPeers for new inbound peers
-  targetPeers: 50,
+  maxPeers: 110, // Allow some room above targetPeers for new inbound peers
+  targetPeers: 100,
   localMultiaddrs: ["/ip4/0.0.0.0/tcp/9000"],
   bootMultiaddrs: [],
   /** disabled by default */


### PR DESCRIPTION
**Motivation**

- Increase target peers to 100 like other clients
- Has tested this option for 3 days and haven't seen it affect memory. Now this branch makes it as default option

**Description**

- Also it make sense to enable gossipsub batch publish option to serialize published messages once in gossipsub

Closes #5799
