### PR TITLE
chore: customize docusaurus title

### DIFF
--- a/docs/src/theme/Layout/index.js
+++ b/docs/src/theme/Layout/index.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import Head from '@docusaurus/Head';
+import Layout from '@theme-original/Layout';
+
+export default function LayoutWrapper(props) {
+  return (
+    <>
+      <Layout {...props} />
+      <Head>
+        <title>Lodestar Documentation</title>
+      </Head>
+    </>
+  );
+}


### PR DESCRIPTION
**Motivation**

Make sure new documentation website has a meaningful title, currently set at `Lodestar Documentation`

Fixes #6546