### PR TITLE
chore: use regular env for docs publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   docs:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     env:
       DEPLOY_REF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || 'stable' }}
     steps:


### PR DESCRIPTION
**Motivation**

Make it easier for forks to test doc changes

**Description**

Do not depend on `buildjet` for docs deployment. This makes it a bit easier for forks to experiment and deploy docs changes.