### PR TITLE
fix: improve state serialization

### DIFF
--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -649,8 +649,8 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
                 this.metrics?.persistedStateAllocCount.inc();
                 stateBytes = state.serialize();
               }
-              persistedKey = await this.datastore.write(cpPersist, stateBytes);
               timer?.();
+              persistedKey = await this.datastore.write(cpPersist, stateBytes);
             }
             persistCount++;
             this.logger.verbose("Pruned checkpoint state from memory and persisted to disk", {
@@ -723,7 +723,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       if (bufferWithKey) {
         const stateBytes = bufferWithKey.buffer;
         const dataView = new DataView(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength);
-        state.type.tree_serializeToBytes({uint8Array: stateBytes, dataView}, 0, state.node);
+        state.serializeToBytes({uint8Array: stateBytes, dataView}, 0);
         return bufferWithKey;
       }
     }
@@ -736,10 +736,8 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    *   - As monitored on holesky as of Jan 2024, it helps save ~500ms state reload time (4.3s vs 3.8s)
    *   - Also `serializeState.test.ts` perf test shows a lot of differences allocating validators bytes once vs every time,
    * This is 2x - 3x faster than allocating memory every time.
-   * TODO: consider serializing validators manually like in `serializeState.test.ts` perf test, this could be 3x faster than this
    */
   private serializeStateValidators(state: CachedBeaconStateAllForks): BufferWithKey | null {
-    // const validatorsSszTimer = this.metrics?.stateReloadValidatorsSszDuration.startTimer();
     const type = state.type.fields.validators;
     const size = type.tree_serializedSize(state.validators.node);
     if (this.bufferPool) {
@@ -747,7 +745,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       if (bufferWithKey) {
         const validatorsBytes = bufferWithKey.buffer;
         const dataView = new DataView(validatorsBytes.buffer, validatorsBytes.byteOffset, validatorsBytes.byteLength);
-        type.tree_serializeToBytes({uint8Array: validatorsBytes, dataView}, 0, state.validators.node);
+        state.validators.serializeToBytes({uint8Array: validatorsBytes, dataView}, 0);
         return bufferWithKey;
       }
     }

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -640,7 +640,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
             this.metrics?.statePersistSecFromSlot.observe(this.clock?.secFromSlot(this.clock?.currentSlot ?? 0) ?? 0);
             const cpPersist = {epoch: epoch, root: epochBoundaryRoot};
             {
-              const timer = this.metrics?.statePersistDuration.startTimer();
+              const timer = this.metrics?.stateSszDuration.startTimer();
               // automatically free the buffer pool after this scope
               using stateBytesWithKey = this.serializeState(state);
               let stateBytes = stateBytesWithKey?.buffer;

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -640,7 +640,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
             this.metrics?.statePersistSecFromSlot.observe(this.clock?.secFromSlot(this.clock?.currentSlot ?? 0) ?? 0);
             const cpPersist = {epoch: epoch, root: epochBoundaryRoot};
             {
-              const timer = this.metrics?.stateSszDuration.startTimer();
+              const timer = this.metrics?.stateSerializeDuration.startTimer();
               // automatically free the buffer pool after this scope
               using stateBytesWithKey = this.serializeState(state);
               let stateBytes = stateBytesWithKey?.buffer;

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1195,9 +1195,9 @@ export function createLodestarMetrics(
         help: "Histogram of cloned count per state every time state.clone() is called",
         buckets: [1, 2, 5, 10, 50, 250],
       }),
-      statePersistDuration: register.histogram({
-        name: "lodestar_cp_state_cache_state_persist_seconds",
-        help: "Histogram of time to persist state to db",
+      stateSszDuration: register.histogram({
+        name: "lodestar_cp_state_cache_state_ssz_seconds",
+        help: "Histogram of time to serialize state to db",
         buckets: [0.1, 0.5, 1, 2, 3, 4],
       }),
       statePruneFromMemoryCount: register.gauge({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1195,8 +1195,8 @@ export function createLodestarMetrics(
         help: "Histogram of cloned count per state every time state.clone() is called",
         buckets: [1, 2, 5, 10, 50, 250],
       }),
-      stateSszDuration: register.histogram({
-        name: "lodestar_cp_state_cache_state_ssz_seconds",
+      stateSerializeDuration: register.histogram({
+        name: "lodestar_cp_state_cache_state_serialize_seconds",
         help: "Histogram of time to serialize state to db",
         buckets: [0.1, 0.5, 1, 2, 3, 4],
       }),

--- a/packages/beacon-node/test/e2e/chain/stateCache/nHistoricalStates.test.ts
+++ b/packages/beacon-node/test/e2e/chain/stateCache/nHistoricalStates.test.ts
@@ -399,10 +399,10 @@ describe(
           )?.value
         ).toEqual(reloadCount);
 
-        const stateSszMetricValues = await (followupBn.metrics?.cpStateCache.stateSszDuration as Histogram).get();
+        const stateSszMetricValues = await (followupBn.metrics?.cpStateCache.stateSerializeDuration as Histogram).get();
         expect(
           stateSszMetricValues?.values.find(
-            (value) => value.metricName === "lodestar_cp_state_cache_state_ssz_seconds_count"
+            (value) => value.metricName === "lodestar_cp_state_cache_state_serialize_seconds_count"
           )?.value
         ).toEqual(persistCount);
 

--- a/packages/beacon-node/test/e2e/chain/stateCache/nHistoricalStates.test.ts
+++ b/packages/beacon-node/test/e2e/chain/stateCache/nHistoricalStates.test.ts
@@ -399,10 +399,10 @@ describe(
           )?.value
         ).toEqual(reloadCount);
 
-        const persistMetricValues = await (followupBn.metrics?.cpStateCache.statePersistDuration as Histogram).get();
+        const stateSszMetricValues = await (followupBn.metrics?.cpStateCache.stateSszDuration as Histogram).get();
         expect(
-          persistMetricValues?.values.find(
-            (value) => value.metricName === "lodestar_cp_state_cache_state_persist_seconds_count"
+          stateSszMetricValues?.values.find(
+            (value) => value.metricName === "lodestar_cp_state_cache_state_ssz_seconds_count"
           )?.value
         ).toEqual(persistCount);
 

--- a/packages/state-transition/test/perf/util/serializeState.test.ts
+++ b/packages/state-transition/test/perf/util/serializeState.test.ts
@@ -1,6 +1,6 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
 import {ssz} from "@lodestar/types";
-import {generatePerfTestCachedStateAltair} from "../util.js";
+import {cachedStateAltairPopulateCaches, generatePerfTestCachedStateAltair} from "../util.js";
 
 /**
  * This shows different statistics between allocating memory once vs every time.
@@ -13,8 +13,9 @@ describe.skip("serialize state and validators", function () {
     // increasing this may have different statistics due to gc time
     minMs: 60_000,
   });
-  const valicatorCount = 1_500_000;
-  const seedState = generatePerfTestCachedStateAltair({vc: 1_500_000, goBackOneSlot: false});
+  // change to 170_000 for holesky size
+  const valicatorCount = 20_000;
+  const seedState = generatePerfTestCachedStateAltair({vc: valicatorCount, goBackOneSlot: false});
 
   /**
    * Allocate memory every time, on a Mac M1:
@@ -32,6 +33,17 @@ describe.skip("serialize state and validators", function () {
     fn: () => {
       stateBytes.fill(0);
       stateType.tree_serializeToBytes({uint8Array: stateBytes, dataView: stateDataView}, 0, rootNode);
+    },
+  });
+
+  // now cache nodes
+  cachedStateAltairPopulateCaches(seedState);
+
+  itBench({
+    id: `serialize state ${valicatorCount} validators using new serializeToBytes() method`,
+    fn: () => {
+      stateBytes.fill(0);
+      seedState.serializeToBytes({uint8Array: stateBytes, dataView: stateDataView}, 0);
     },
   });
 
@@ -80,7 +92,7 @@ describe.skip("serialize state and validators", function () {
    * this is 3x faster than the previous approach.
    */
   const NUMBER_2_POW_32 = 2 ** 32;
-  const output = new Uint8Array(121 * 1_500_000);
+  const output = new Uint8Array(121 * valicatorCount);
   const dataView = new DataView(output.buffer, output.byteOffset, output.byteLength);
   // this caches validators nodes which is what happen after we run a state transition
   const validators = seedState.validators.getAllReadonlyValues();
@@ -117,6 +129,13 @@ describe.skip("serialize state and validators", function () {
         dataView.setUint32(offset, (withdrawableEpoch / NUMBER_2_POW_32) & 0xffffffff, true);
         offset += 4;
       }
+    },
+  });
+
+  itBench({
+    id: `serialize ${valicatorCount} validators from state `,
+    fn: () => {
+      seedState.validators.serializeToBytes({uint8Array: output, dataView}, 0);
     },
   });
 });

--- a/packages/state-transition/test/perf/util/serializeState.test.ts
+++ b/packages/state-transition/test/perf/util/serializeState.test.ts
@@ -13,7 +13,7 @@ describe.skip("serialize state and validators", function () {
     // increasing this may have different statistics due to gc time
     minMs: 60_000,
   });
-  // change to 170_000 for holesky size
+  // change to 1_700_000 for holesky size
   const valicatorCount = 20_000;
   const seedState = generatePerfTestCachedStateAltair({vc: valicatorCount, goBackOneSlot: false});
 

--- a/packages/types/src/phase0/sszTypes.ts
+++ b/packages/types/src/phase0/sszTypes.ts
@@ -7,7 +7,6 @@ import {
   VectorBasicType,
   ListUintNum64Type,
   VectorCompositeType,
-  ListUintNum64Type,
 } from "@chainsafe/ssz";
 import {
   ATTESTATION_SUBNET_COUNT,

--- a/packages/types/src/phase0/sszTypes.ts
+++ b/packages/types/src/phase0/sszTypes.ts
@@ -2,12 +2,12 @@ import {
   BitListType,
   BitVectorType,
   ContainerType,
-  ContainerNodeStructType,
   ListBasicType,
   ListCompositeType,
   VectorBasicType,
   ListUintNum64Type,
   VectorCompositeType,
+  ListUintNum64Type,
 } from "@chainsafe/ssz";
 import {
   ATTESTATION_SUBNET_COUNT,
@@ -29,15 +29,14 @@ import {
   VALIDATOR_REGISTRY_LIMIT,
 } from "@lodestar/params";
 import * as primitiveSsz from "../primitive/sszTypes.js";
+import {ValidatorNodeStruct} from "./validator.js";
 
 const {
-  Boolean,
   Bytes32,
   UintNum64,
   UintBn64,
   Slot,
   Epoch,
-  EpochInf,
   CommitteeIndex,
   ValidatorIndex,
   Root,
@@ -226,21 +225,6 @@ export const HistoricalBatchRoots = new ContainerType(
   {typeName: "HistoricalBatchRoots", jsonCase: "eth2"}
 );
 
-export const ValidatorContainer = new ContainerType(
-  {
-    pubkey: BLSPubkey,
-    withdrawalCredentials: Bytes32,
-    effectiveBalance: UintNum64,
-    slashed: Boolean,
-    activationEligibilityEpoch: EpochInf,
-    activationEpoch: EpochInf,
-    exitEpoch: EpochInf,
-    withdrawableEpoch: EpochInf,
-  },
-  {typeName: "Validator", jsonCase: "eth2"}
-);
-
-export const ValidatorNodeStruct = new ContainerNodeStructType(ValidatorContainer.fields, ValidatorContainer.opts);
 // The main Validator type is the 'ContainerNodeStructType' version
 export const Validator = ValidatorNodeStruct;
 

--- a/packages/types/src/phase0/validator.ts
+++ b/packages/types/src/phase0/validator.ts
@@ -6,7 +6,7 @@ const {Boolean, Bytes32, UintNum64, BLSPubkey, EpochInf} = primitiveSsz;
 // this is to work with uint32, see https://github.com/ChainSafe/ssz/blob/ssz-v0.15.1/packages/ssz/src/type/uint.ts
 const NUMBER_2_POW_32 = 2 ** 32;
 
-/**
+/*
  * Below constants are respective to their ssz type in `ValidatorType`.
  */
 const UINT32_SIZE = 4;

--- a/packages/types/src/phase0/validator.ts
+++ b/packages/types/src/phase0/validator.ts
@@ -1,0 +1,67 @@
+import {ByteViews, ContainerNodeStructType, ValueOfFields} from "@chainsafe/ssz";
+import * as primitiveSsz from "../primitive/sszTypes.js";
+
+const {Boolean, Bytes32, UintNum64, BLSPubkey, EpochInf} = primitiveSsz;
+
+const NUMBER_2_POW_32 = 2 ** 32;
+
+export const ValidatorType = {
+  pubkey: BLSPubkey,
+  withdrawalCredentials: Bytes32,
+  effectiveBalance: UintNum64,
+  slashed: Boolean,
+  activationEligibilityEpoch: EpochInf,
+  activationEpoch: EpochInf,
+  exitEpoch: EpochInf,
+  withdrawableEpoch: EpochInf,
+};
+
+/**
+ * Improve serialization performance for state.validators.serialize();
+ */
+export class ValidatorNodeStructType extends ContainerNodeStructType<typeof ValidatorType> {
+  constructor() {
+    super(ValidatorType, {typeName: "Validator", jsonCase: "eth2"});
+  }
+
+  value_serializeToBytes(
+    {uint8Array: output, dataView}: ByteViews,
+    offset: number,
+    validator: ValueOfFields<typeof ValidatorType>
+  ): number {
+    output.set(validator.pubkey, offset);
+    offset += 48;
+    output.set(validator.withdrawalCredentials, offset);
+    offset += 32;
+    const {effectiveBalance, activationEligibilityEpoch, activationEpoch, exitEpoch, withdrawableEpoch} = validator;
+    // TODO: writeUintNum64?
+    dataView.setUint32(offset, effectiveBalance & 0xffffffff, true);
+    offset += 4;
+    dataView.setUint32(offset, (effectiveBalance / NUMBER_2_POW_32) & 0xffffffff, true);
+    offset += 4;
+    output[offset] = validator.slashed ? 1 : 0;
+    offset += 1;
+    offset = writeEpochInf(dataView, offset, activationEligibilityEpoch);
+    offset = writeEpochInf(dataView, offset, activationEpoch);
+    offset = writeEpochInf(dataView, offset, exitEpoch);
+    offset = writeEpochInf(dataView, offset, withdrawableEpoch);
+
+    return offset;
+  }
+}
+
+function writeEpochInf(dataView: DataView, offset: number, value: number): number {
+  if (value === Infinity) {
+    dataView.setUint32(offset, 0xffffffff, true);
+    offset += 4;
+    dataView.setUint32(offset, 0xffffffff, true);
+    offset += 4;
+  } else {
+    dataView.setUint32(offset, value & 0xffffffff, true);
+    offset += 4;
+    dataView.setUint32(offset, (value / NUMBER_2_POW_32) & 0xffffffff, true);
+    offset += 4;
+  }
+  return offset;
+}
+export const ValidatorNodeStruct = new ValidatorNodeStructType();

--- a/packages/types/src/phase0/validator.ts
+++ b/packages/types/src/phase0/validator.ts
@@ -34,7 +34,7 @@ export class ValidatorNodeStructType extends ContainerNodeStructType<typeof Vali
     output.set(validator.withdrawalCredentials, offset);
     offset += 32;
     const {effectiveBalance, activationEligibilityEpoch, activationEpoch, exitEpoch, withdrawableEpoch} = validator;
-    // TODO: writeUintNum64?
+    // effectiveBalance is UintNum64
     dataView.setUint32(offset, effectiveBalance & 0xffffffff, true);
     offset += 4;
     dataView.setUint32(offset, (effectiveBalance / NUMBER_2_POW_32) & 0xffffffff, true);

--- a/packages/types/test/unit/phase0/sszTypes.test.ts
+++ b/packages/types/test/unit/phase0/sszTypes.test.ts
@@ -1,0 +1,24 @@
+import {ContainerType} from "@chainsafe/ssz";
+import {describe, it, expect} from "vitest";
+import {ssz} from "../../../src/index.js";
+import {ValidatorType} from "../../../src/phase0/validator.js";
+
+const ValidatorContainer = new ContainerType(ValidatorType, {typeName: "Validator", jsonCase: "eth2"});
+
+describe("Validator ssz types", function () {
+  it("should serialize to the same value", () => {
+    const validator = ValidatorContainer.defaultValue();
+    validator.activationEligibilityEpoch = 10;
+    validator.activationEpoch = 11;
+    validator.exitEpoch = Infinity;
+    validator.slashed = false;
+    validator.effectiveBalance = 31000000000;
+    validator.withdrawableEpoch = 13;
+    validator.pubkey = Buffer.alloc(48, 100);
+    validator.withdrawalCredentials = Buffer.alloc(32, 100);
+
+    const serialized = ValidatorContainer.serialize(validator);
+    const serialized2 = ssz.phase0.Validator.serialize(validator);
+    expect(serialized).toEqual(serialized2);
+  });
+});

--- a/packages/types/test/unit/phase0/sszTypes.test.ts
+++ b/packages/types/test/unit/phase0/sszTypes.test.ts
@@ -7,18 +7,25 @@ const ValidatorContainer = new ContainerType(ValidatorType, {typeName: "Validato
 
 describe("Validator ssz types", function () {
   it("should serialize to the same value", () => {
-    const validator = ValidatorContainer.defaultValue();
-    validator.activationEligibilityEpoch = 10;
-    validator.activationEpoch = 11;
-    validator.exitEpoch = Infinity;
-    validator.slashed = false;
-    validator.effectiveBalance = 31000000000;
-    validator.withdrawableEpoch = 13;
-    validator.pubkey = Buffer.alloc(48, 100);
-    validator.withdrawalCredentials = Buffer.alloc(32, 100);
+    const seedValidator = {
+      activationEligibilityEpoch: 10,
+      activationEpoch: 11,
+      exitEpoch: Infinity,
+      slashed: false,
+      withdrawableEpoch: 13,
+      pubkey: Buffer.alloc(48, 100),
+      withdrawalCredentials: Buffer.alloc(32, 100),
+    };
 
-    const serialized = ValidatorContainer.serialize(validator);
-    const serialized2 = ssz.phase0.Validator.serialize(validator);
-    expect(serialized).toEqual(serialized2);
+    const validators = [
+      {...seedValidator, effectiveBalance: 31000000000, slashed: false},
+      {...seedValidator, effectiveBalance: 32000000000, slashed: true},
+    ];
+
+    for (const validator of validators) {
+      const serialized = ValidatorContainer.serialize(validator);
+      const serialized2 = ssz.phase0.Validator.serialize(validator);
+      expect(serialized).toEqual(serialized2);
+    }
   });
 });


### PR DESCRIPTION
**Motivation**

State serialization happens once per epoch in n-historical state so its performance is important

**Description**

- New validator type to optimize its `value_serializeToBytes` performance, this helps make `state.validators.serialize()` 3.4x faster

before
```
    ✔ serialize 20000 validators manually                                 773.4012 ops/s    1.292990 ms/op        -      45968 runs   60.0 s
    ✔ serialize 20000 validators from state                               206.3978 ops/s    4.845013 ms/op        -      12271 runs   60.0 s
```

after
```
    ✔ serialize 20000 validators manually                                 768.2498 ops/s    1.301660 ms/op        -      45667 runs   60.0 s
    ✔ serialize 20000 validators from state                               694.0964 ops/s    1.440722 ms/op        -      41260 runs   60.0 s
```

- use the new `serializeToBytes()` api of ssz v0.15.1

part of #5968