### PR TITLE
chore: allow to serve docs from root folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,7 +250,7 @@ node scripts/download_dashboards.mjs
 
 ## Contributing to Documentation
 
-When submitting PRs for documentation updates, build and run the documentation locally to ensure functionality before submission. First generate the CLI documentation with `yarn docs:build`. Then in the `docs` folder, build the documentation locally with `yarn install` and serve with `yarn start`.
+When submitting PRs for documentation updates, build and run the documentation locally to ensure functionality before submission. First generate the CLI documentation with `yarn docs:build`. Build and serve the documentation locally with `yarn docs:serve`.
 
 Your locally served documentation will then be accessible at http://localhost:3000/lodestar/.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,7 +250,7 @@ node scripts/download_dashboards.mjs
 
 ## Contributing to Documentation
 
-When submitting PRs for documentation updates, build and run the documentation locally to ensure functionality before submission. First generate the CLI documentation with `yarn docs:build`. Build and serve the documentation locally with `yarn docs:serve`.
+When submitting PRs for documentation updates, build and run the documentation locally to ensure functionality before submission. First generate the CLI documentation with `yarn docs:build`. Then build and serve the documentation locally with `yarn docs:serve`.
 
 Your locally served documentation will then be accessible at http://localhost:3000/lodestar/.
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "check-types": "lerna run check-types",
     "check-spelling": "pyspelling -c .pyspelling.yml -v",
     "docs:build": "lerna run check-readme && lerna run docs:build && ./scripts/prepare-docs.sh",
+    "docs:serve": "yarn --cwd docs install && yarn --cwd docs start",
     "docs:lint": "prettier '**/*.md' --check",
     "docs:lint:fix": "prettier '**/*.md' --write",
     "test": "lerna run test --concurrency 1",


### PR DESCRIPTION
**Motivation**

Allow to serve docs using `yarn docs:serve`