### PR TITLE
fix: handle skip_randao_verification query param as per spec

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,7 +4,7 @@
 GETH_DOCKER_IMAGE=ethereum/client-go:v1.13.14
 # Use either image or local binary for the testing
 GETH_BINARY_DIR=
-LIGHTHOUSE_DOCKER_IMAGE=sigp/lighthouse:v4.6.0-amd64-modern-dev
+LIGHTHOUSE_DOCKER_IMAGE=sigp/lighthouse:v5.1.1-amd64-modern-dev
 
 # We can't upgrade nethermind further due to genesis hash mismatch with the geth
 # https://github.com/NethermindEth/nethermind/issues/6683

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -589,7 +589,7 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
         randao_reveal: Schema.StringRequired,
         graffiti: Schema.String,
         fee_recipient: Schema.String,
-        skip_randao_verification: Schema.Boolean,
+        skip_randao_verification: Schema.String,
         builder_selection: Schema.String,
         builder_boost_factor: Schema.String,
         strict_fee_recipient_check: Schema.Boolean,

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -550,26 +550,19 @@ export function getReqSerializers(): ReqSerializers<Api, ReqTypes> {
   );
 
   const produceBlockV3: ReqSerializers<Api, ReqTypes>["produceBlockV3"] = {
-    writeReq(slot, randaoReveal, graffiti, skipRandaoVerification, opts) {
-      const query: ReqTypes["produceBlockV3"]["query"] = {
+    writeReq: (slot, randaoReveal, graffiti, skipRandaoVerification, opts) => ({
+      params: {slot},
+      query: {
         randao_reveal: toHexString(randaoReveal),
         graffiti: toGraffitiHex(graffiti),
         fee_recipient: opts?.feeRecipient,
+        ...(skipRandaoVerification && {skip_randao_verification: ""}),
         builder_selection: opts?.builderSelection,
         builder_boost_factor: opts?.builderBoostFactor?.toString(),
         strict_fee_recipient_check: opts?.strictFeeRecipientCheck,
         blinded_local: opts?.blindedLocal,
-      };
-
-      if (skipRandaoVerification) {
-        query["skip_randao_verification"] = "";
-      }
-
-      return {
-        params: {slot},
-        query,
-      };
-    },
+      },
+    }),
     parseReq: ({params, query}) => [
       params.slot,
       fromHexString(query.randao_reveal),

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -797,5 +797,5 @@ function parseBuilderBoostFactor(builderBoostFactorInput?: string | number | big
 }
 
 function parseSkipRandaoVerification(skipRandaoVerification?: string): boolean {
-  return skipRandaoVerification !== undefined && ["", "true"].includes(skipRandaoVerification) ? true : false;
+  return skipRandaoVerification !== undefined && skipRandaoVerification === "";
 }

--- a/packages/api/test/unit/beacon/testData/validator.ts
+++ b/packages/api/test/unit/beacon/testData/validator.ts
@@ -49,7 +49,7 @@ export const testData: GenericServerTestCases<Api> = {
       32000,
       randaoReveal,
       graffiti,
-      undefined,
+      false,
       {
         feeRecipient,
         builderSelection: undefined,
@@ -65,7 +65,7 @@ export const testData: GenericServerTestCases<Api> = {
       32000,
       randaoReveal,
       graffiti,
-      undefined,
+      false,
       {
         feeRecipient,
         builderSelection: undefined,
@@ -109,7 +109,7 @@ export const testData: GenericServerTestCases<Api> = {
       32000,
       randaoReveal,
       graffiti,
-      undefined,
+      false,
       {
         feeRecipient,
         builderSelection: undefined,

--- a/packages/cli/test/sim/mixed_client.test.ts
+++ b/packages/cli/test/sim/mixed_client.test.ts
@@ -9,13 +9,15 @@ import {connectAllNodes, waitForSlot} from "../utils/simulation/utils/network.js
 const altairForkEpoch = 2;
 const bellatrixForkEpoch = 4;
 const capellaForkEpoch = 6;
-const runTillEpoch = 8;
+const denebForkEpoch = 8;
+const runTillEpoch = 10;
 const syncWaitEpoch = 2;
 
 const {estimatedTimeoutMs, forkConfig} = defineSimTestConfig({
   ALTAIR_FORK_EPOCH: altairForkEpoch,
   BELLATRIX_FORK_EPOCH: bellatrixForkEpoch,
   CAPELLA_FORK_EPOCH: capellaForkEpoch,
+  DENEB_FORK_EPOCH: denebForkEpoch,
   runTillEpoch: runTillEpoch + syncWaitEpoch,
   initialNodes: 2,
 });
@@ -41,18 +43,11 @@ const env = await SimulationEnvironment.initWithDefaults(
       keysCount: 32,
       remote: true,
       beacon: BeaconClient.Lighthouse,
-      // for cross client make sure lodestar doesn't use v3 for now untill lighthouse supports
       validator: {
         type: ValidatorClient.Lodestar,
         options: {
           clientOptions: {
-            useProduceBlockV3: false,
-            // this should cause usage of produceBlockV2
-            //
-            // but if blinded production is enabled in lighthouse beacon then this should cause
-            // usage of produce blinded block which should return execution block in blinded format
-            // but only enable that after testing lighthouse beacon
-            "builder.selection": "executiononly",
+            useProduceBlockV3: true,
           },
         },
       },

--- a/packages/cli/test/sim/multi_fork.test.ts
+++ b/packages/cli/test/sim/multi_fork.test.ts
@@ -24,13 +24,15 @@ import {createWithdrawalAssertions} from "../utils/simulation/assertions/withdra
 const altairForkEpoch = 2;
 const bellatrixForkEpoch = 4;
 const capellaForkEpoch = 6;
-const runTillEpoch = 8;
+const denebForkEpoch = 8;
+const runTillEpoch = 10;
 const syncWaitEpoch = 2;
 
 const {estimatedTimeoutMs, forkConfig} = defineSimTestConfig({
   ALTAIR_FORK_EPOCH: altairForkEpoch,
   BELLATRIX_FORK_EPOCH: bellatrixForkEpoch,
   CAPELLA_FORK_EPOCH: capellaForkEpoch,
+  DENEB_FORK_EPOCH: denebForkEpoch,
   runTillEpoch: runTillEpoch + syncWaitEpoch,
   initialNodes: 5,
 });

--- a/packages/cli/test/utils/simulation/execution_clients/index.ts
+++ b/packages/cli/test/utils/simulation/execution_clients/index.ts
@@ -8,7 +8,7 @@ import {
   ExecutionNode,
   ExecutionStartMode,
 } from "../interfaces.js";
-import {getEstimatedShanghaiTime} from "../utils/index.js";
+import {getEstimatedForkTime} from "../utils/index.js";
 import {getGethGenesisBlock} from "../utils/execution_genesis.js";
 import {ensureDirectories} from "../utils/paths.js";
 import {generateGethNode} from "./geth.js";
@@ -28,8 +28,16 @@ export async function createExecutionNode<E extends ExecutionClient>(
     cliqueSealingPeriod: options.cliqueSealingPeriod ?? CLIQUE_SEALING_PERIOD,
     shanghaiTime:
       options.shanghaiTime ??
-      getEstimatedShanghaiTime({
-        capellaForkEpoch: forkConfig.CAPELLA_FORK_EPOCH,
+      getEstimatedForkTime({
+        forkEpoch: forkConfig.CAPELLA_FORK_EPOCH,
+        genesisTime: options.genesisTime,
+        secondsPerSlot: forkConfig.SECONDS_PER_SLOT,
+        additionalSlots: 0,
+      }),
+    cancunTime:
+      options.cancunTime ??
+      getEstimatedForkTime({
+        forkEpoch: forkConfig.DENEB_FORK_EPOCH,
         genesisTime: options.genesisTime,
         secondsPerSlot: forkConfig.SECONDS_PER_SLOT,
         additionalSlots: 0,

--- a/packages/cli/test/utils/simulation/execution_clients/nethermind.ts
+++ b/packages/cli/test/utils/simulation/execution_clients/nethermind.ts
@@ -15,8 +15,19 @@ export const generateNethermindNode: ExecutionNodeGenerator<ExecutionClient.Neth
     throw Error(`EL ENV must be provided, NETHERMIND_DOCKER_IMAGE: ${process.env.NETHERMIND_DOCKER_IMAGE}`);
   }
 
-  const {id, mode, ttd, address, mining, clientOptions, nodeIndex, cliqueSealingPeriod, shanghaiTime, genesisTime} =
-    opts;
+  const {
+    id,
+    mode,
+    ttd,
+    address,
+    mining,
+    clientOptions,
+    nodeIndex,
+    cliqueSealingPeriod,
+    shanghaiTime,
+    cancunTime,
+    genesisTime,
+  } = opts;
   const ports = getNodePorts(nodeIndex);
 
   const {rootDir, rootDirMounted, logFilePath, jwtsecretFilePathMounted} = getNodeMountedPaths(
@@ -48,7 +59,14 @@ export const generateNethermindNode: ExecutionNodeGenerator<ExecutionClient.Neth
       await writeFile(
         chainSpecPath,
         JSON.stringify(
-          getNethermindChainSpec(mode, {ttd, cliqueSealingPeriod, shanghaiTime, genesisTime, clientOptions: []})
+          getNethermindChainSpec(mode, {
+            ttd,
+            cliqueSealingPeriod,
+            shanghaiTime,
+            cancunTime,
+            genesisTime,
+            clientOptions: [],
+          })
         )
       );
     },

--- a/packages/cli/test/utils/simulation/interfaces.ts
+++ b/packages/cli/test/utils/simulation/interfaces.ts
@@ -128,6 +128,7 @@ export interface ExecutionGenesisOptions<E extends ExecutionClient = ExecutionCl
   ttd: bigint;
   cliqueSealingPeriod: number;
   shanghaiTime: number;
+  cancunTime: number;
   genesisTime: number;
   clientOptions: ExecutionClientsOptions[E];
 }

--- a/packages/cli/test/utils/simulation/utils/execution_genesis.ts
+++ b/packages/cli/test/utils/simulation/utils/execution_genesis.ts
@@ -5,7 +5,7 @@ export const getGethGenesisBlock = (
   mode: ExecutionStartMode,
   options: ExecutionGenesisOptions
 ): Record<string, unknown> => {
-  const {ttd, cliqueSealingPeriod, shanghaiTime, genesisTime} = options;
+  const {ttd, cliqueSealingPeriod, shanghaiTime, genesisTime, cancunTime} = options;
 
   const genesis = {
     config: {
@@ -24,6 +24,7 @@ export const getGethGenesisBlock = (
       berlinBlock: 0,
       londonBlock: 0,
       shanghaiTime,
+      cancunTime,
       terminalTotalDifficulty: Number(ttd as bigint),
       clique: {period: cliqueSealingPeriod, epoch: 30000},
     },

--- a/packages/cli/test/utils/simulation/utils/index.ts
+++ b/packages/cli/test/utils/simulation/utils/index.ts
@@ -125,20 +125,20 @@ export const getEstimatedTTD = ({
   return BigInt(Math.ceil(secondsTillBellatrix / cliqueSealingPeriod) * ETH_TTD_INCREMENT);
 };
 
-export const getEstimatedShanghaiTime = ({
+export const getEstimatedForkTime = ({
   genesisTime,
   secondsPerSlot,
-  capellaForkEpoch,
+  forkEpoch,
   additionalSlots,
 }: {
   genesisTime: number;
   secondsPerSlot: number;
-  capellaForkEpoch: number;
+  forkEpoch: number;
   additionalSlots: number;
 }): number => {
-  const secondsTillCapella = capellaForkEpoch * activePreset.SLOTS_PER_EPOCH * secondsPerSlot;
+  const secondsTillFork = forkEpoch * activePreset.SLOTS_PER_EPOCH * secondsPerSlot;
 
-  return genesisTime + secondsTillCapella + additionalSlots * secondsPerSlot;
+  return genesisTime + secondsTillFork + additionalSlots * secondsPerSlot;
 };
 
 export const squeezeString = (val: string, length: number, sep = "..."): string => {


### PR DESCRIPTION
**Motivation**

Make sure Lodestar VC works with other clients. 

**Description**

- Make the validator `produceBlockV3` more flexible on `skip_randao_verification`
- Change the type of `skip_randao_verification` to string, which is inferred type for query parameters. 
- Make sure `empty string` is treated as `true` and not ` false`. 
- Test the lodestar VC with latest version of Lighthouse Beacon Node. 


**Steps to test or reproduce**

- Run all tests