### PR TITLE
feat: introduce proposer boost reorg to fork choice

### DIFF
--- a/packages/api/src/beacon/routes/debug.ts
+++ b/packages/api/src/beacon/routes/debug.ts
@@ -34,6 +34,7 @@ const protoNodeSszType = new ContainerType(
     parentRoot: stringType,
     stateRoot: stringType,
     targetRoot: stringType,
+    timeliness: ssz.Boolean,
     justifiedEpoch: ssz.Epoch,
     justifiedRoot: stringType,
     finalizedEpoch: ssz.Epoch,

--- a/packages/api/test/unit/beacon/testData/debug.ts
+++ b/packages/api/test/unit/beacon/testData/debug.ts
@@ -40,6 +40,7 @@ export const testData: GenericServerTestCases<Api> = {
           weight: 1,
           bestChild: "1",
           bestDescendant: "1",
+          timeliness: false,
         },
       ],
     },

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -16,6 +16,7 @@ import {
   isMergeTransitionComplete,
 } from "@lodestar/state-transition";
 
+import {Logger} from "@lodestar/utils";
 import {computeAnchorCheckpoint} from "../initState.js";
 import {ChainEventEmitter} from "../emitter.js";
 import {ChainEvent} from "../emitter.js";
@@ -35,7 +36,8 @@ export function initializeForkChoice(
   currentSlot: Slot,
   state: CachedBeaconStateAllForks,
   opts: ForkChoiceOpts,
-  justifiedBalancesGetter: JustifiedBalancesGetter
+  justifiedBalancesGetter: JustifiedBalancesGetter,
+  logger?: Logger
 ): ForkChoice {
   const {blockHeader, checkpoint} = computeAnchorCheckpoint(config, state);
   const finalizedCheckpoint = {...checkpoint};
@@ -75,6 +77,7 @@ export function initializeForkChoice(
         parentRoot: toHexString(blockHeader.parentRoot),
         stateRoot: toHexString(blockHeader.stateRoot),
         blockRoot: toHexString(checkpoint.root),
+        timeliness: true, // Optimisitcally assume is timely
 
         justifiedEpoch: justifiedCheckpoint.epoch,
         justifiedRoot: toHexString(justifiedCheckpoint.root),
@@ -95,7 +98,7 @@ export function initializeForkChoice(
       },
       currentSlot
     ),
-
+    logger,
     opts
   );
 }

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -98,7 +98,7 @@ export function initializeForkChoice(
       },
       currentSlot
     ),
+    opts,
     logger,
-    opts
   );
 }

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -99,6 +99,6 @@ export function initializeForkChoice(
       currentSlot
     ),
     opts,
-    logger,
+    logger
   );
 }

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -64,6 +64,8 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
         unrealizedFinalizedRoot: toHexString(finalizedCheckpoint.root),
         executionPayloadBlockHash: null,
         executionStatus: ExecutionStatus.PreMerge,
+
+        timeliness: false,
       },
       originalState.slot
     );
@@ -87,6 +89,7 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
           unrealizedFinalizedRoot: toHexString(finalizedCheckpoint.root),
           executionPayloadBlockHash: null,
           executionStatus: ExecutionStatus.PreMerge,
+          timeliness: false,
         },
         slot
       );
@@ -159,7 +162,7 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
         return {state, pool};
       },
       fn: ({state, pool}) => {
-        pool.getAttestationsForBlock(state.config.getForkName(state.slot), forkchoice, state);
+        pool.getAttestationsForBlock(forkchoice, state);
       },
     });
   }

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -162,7 +162,7 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
         return {state, pool};
       },
       fn: ({state, pool}) => {
-        pool.getAttestationsForBlock(forkchoice, state);
+        pool.getAttestationsForBlock(state.config.getForkName(state.slot), forkchoice, state);
       },
     });
   }

--- a/packages/beacon-node/test/utils/state.ts
+++ b/packages/beacon-node/test/utils/state.ts
@@ -153,5 +153,7 @@ export const zeroProtoBlock: ProtoBlock = {
   unrealizedFinalizedEpoch: 0,
   unrealizedFinalizedRoot: ZERO_HASH_HEX,
 
+  timeliness: false,
+
   ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
 };

--- a/packages/beacon-node/test/utils/typeGenerator.ts
+++ b/packages/beacon-node/test/utils/typeGenerator.ts
@@ -40,6 +40,8 @@ export function generateProtoBlock(overrides: Partial<ProtoBlock> = {}): ProtoBl
     unrealizedFinalizedEpoch: 0,
     unrealizedFinalizedRoot: ZERO_HASH_HEX,
 
+    timeliness: false,
+
     ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
 
     ...overrides,

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -75,6 +75,8 @@ export function getAttestationValidData(opts: AttestationValidDataOpts): {
     unrealizedFinalizedEpoch: 0,
     unrealizedFinalizedRoot: ZERO_HASH_HEX,
 
+    timeliness: false,
+
     ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
   };
 

--- a/packages/config/src/chainConfig/configs/mainnet.ts
+++ b/packages/config/src/chainConfig/configs/mainnet.ts
@@ -81,6 +81,9 @@ export const chainConfig: ChainConfig = {
   // ---------------------------------------------------------------
   // 40%
   PROPOSER_SCORE_BOOST: 40,
+  REORG_HEAD_WEIGHT_THRESHOLD: 20,
+  REORG_PARENT_WEIGHT_THRESHOLD: 160,
+  REORG_MAX_EPOCHS_SINCE_FINALIZATION: 2,
 
   // Deposit contract
   // ---------------------------------------------------------------

--- a/packages/config/src/chainConfig/configs/minimal.ts
+++ b/packages/config/src/chainConfig/configs/minimal.ts
@@ -78,6 +78,9 @@ export const chainConfig: ChainConfig = {
   // ---------------------------------------------------------------
   // 40%
   PROPOSER_SCORE_BOOST: 40,
+  REORG_HEAD_WEIGHT_THRESHOLD: 20,
+  REORG_PARENT_WEIGHT_THRESHOLD: 160,
+  REORG_MAX_EPOCHS_SINCE_FINALIZATION: 2,
 
   // Deposit contract
   // ---------------------------------------------------------------

--- a/packages/config/src/chainConfig/types.ts
+++ b/packages/config/src/chainConfig/types.ts
@@ -58,6 +58,9 @@ export type ChainConfig = {
 
   // Fork choice
   PROPOSER_SCORE_BOOST: number;
+  REORG_HEAD_WEIGHT_THRESHOLD: number;
+  REORG_PARENT_WEIGHT_THRESHOLD: number;
+  REORG_MAX_EPOCHS_SINCE_FINALIZATION: number;
 
   // Deposit contract
   DEPOSIT_CHAIN_ID: number;
@@ -114,6 +117,9 @@ export const chainConfigTypes: SpecTypes<ChainConfig> = {
 
   // Fork choice
   PROPOSER_SCORE_BOOST: "number",
+  REORG_HEAD_WEIGHT_THRESHOLD: "number",
+  REORG_PARENT_WEIGHT_THRESHOLD: "number",
+  REORG_MAX_EPOCHS_SINCE_FINALIZATION: "number",
 
   // Deposit contract
   DEPOSIT_CHAIN_ID: "number",

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -174,7 +174,7 @@ export class ForkChoice implements IForkChoice {
    *
    * https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/bellatrix/fork-choice.md#should_override_forkchoice_update
    */
-  predictProposerHead(headBlock: ProtoBlock, currentSlot?: Slot): ProtoBlock {
+  predictProposerHead(headBlock: ProtoBlock, secFromSlot: number, currentSlot?: Slot): ProtoBlock {
     // Skip re-org attempt if proposer boost (reorg) are disabled
     if (!this.opts?.proposerBoostEnabled) {
       this.logger?.verbose("No proposer boot reorg prediction since the related flags are disabled");
@@ -190,7 +190,7 @@ export class ForkChoice implements IForkChoice {
       return headBlock;
     }
 
-    const {prelimProposerHead} = this.getPreliminaryProposerHead(headBlock, parentBlock, proposalSlot);
+    const {prelimProposerHead} = this.getPreliminaryProposerHead(headBlock, parentBlock, secFromSlot, proposalSlot);
 
     if (prelimProposerHead === headBlock) {
       return headBlock;
@@ -215,6 +215,7 @@ export class ForkChoice implements IForkChoice {
    */
   getProposerHead(
     headBlock: ProtoBlock,
+    secFromSlot: number,
     slot: Slot
   ): {proposerHead: ProtoBlock; isHeadTimely: boolean; notReorgedReason?: NotReorgedReason} {
     const isHeadTimely = headBlock.timeliness;
@@ -233,7 +234,7 @@ export class ForkChoice implements IForkChoice {
       return {proposerHead, isHeadTimely, notReorgedReason: NotReorgedReason.ParentBlockNotAvailable};
     }
 
-    const {prelimProposerHead, prelimNotReorgedReason} = this.getPreliminaryProposerHead(headBlock, parentBlock, slot);
+    const {prelimProposerHead, prelimNotReorgedReason} = this.getPreliminaryProposerHead(headBlock, parentBlock, secFromSlot, slot);
 
     if (prelimProposerHead === headBlock && prelimNotReorgedReason !== undefined) {
       return {proposerHead, isHeadTimely, notReorgedReason: prelimNotReorgedReason};
@@ -1344,6 +1345,7 @@ export class ForkChoice implements IForkChoice {
   private getPreliminaryProposerHead(
     headBlock: ProtoBlock,
     parentBlock: ProtoBlock,
+    secFromSlot: number,
     slot: Slot
   ): {prelimProposerHead: ProtoBlock; prelimNotReorgedReason?: NotReorgedReason} {
     let prelimProposerHead = headBlock;
@@ -1381,6 +1383,11 @@ export class ForkChoice implements IForkChoice {
     // -No reorg if we are not proposing on time.-
     // Note: Skipping this check as store.time in Lodestar is stored in slot and not unix time
     // https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/phase0/fork-choice.md#is_proposing_on_time
+    const proposerReorgCutoff = this.config.SECONDS_PER_SLOT / INTERVALS_PER_SLOT / 2;
+    const isProposingOnTime = secFromSlot <= proposerReorgCutoff;
+    if (!isProposingOnTime) {
+      return {prelimProposerHead, prelimNotReorgedReason: NotReorgedReason.NotProposingOnTime};
+    }
 
     // No reorg if this reorg spans more than a single slot
     const parentSlotOk = parentBlock.slot + 1 === headBlock.slot;

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -108,8 +108,8 @@ export class ForkChoice implements IForkChoice {
     private readonly fcStore: IForkChoiceStore,
     /** The underlying representation of the block DAG. */
     private readonly protoArray: ProtoArray,
-    private readonly logger?: Logger,
-    private readonly opts?: ForkChoiceOpts
+    private readonly opts?: ForkChoiceOpts,
+    private readonly logger?: Logger
   ) {
     this.head = this.updateHead();
     this.balances = this.fcStore.justified.balances;

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -468,8 +468,7 @@ export class ForkChoice implements IForkChoice {
 
     // Assign proposer score boost if the block is timely
     // before attesting interval = before 1st interval
-    const isBeforeAttestingInterval = blockDelaySec < this.config.SECONDS_PER_SLOT / INTERVALS_PER_SLOT;
-    const isTimely = this.fcStore.currentSlot === slot && isBeforeAttestingInterval;
+    const isTimely = this.isBlockTimely(block, blockDelaySec);
     if (
       this.opts?.proposerBoostEnabled &&
       isTimely &&
@@ -1013,6 +1012,15 @@ export class ForkChoice implements IForkChoice {
     }
 
     throw Error(`Not found dependent root for block slot ${block.slot}, epoch difference ${epochDifference}`);
+  }
+
+  /**
+   * Return true if the block is timely for the current slot.
+   * Child class can overwrite this for testing purpose.
+   */
+  protected isBlockTimely(block: allForks.BeaconBlock, blockDelaySec: number): boolean {
+    const isBeforeAttestingInterval = blockDelaySec < this.config.SECONDS_PER_SLOT / INTERVALS_PER_SLOT;
+    return this.fcStore.currentSlot === block.slot && isBeforeAttestingInterval;
   }
 
   private getPreMergeExecStatus(executionStatus: MaybeValidExecutionStatus): ExecutionStatus.PreMerge {

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -240,8 +240,6 @@ export class ForkChoice implements IForkChoice {
       return {proposerHead, isHeadTimely, notReorgedReason: prelimNotReorgedReason};
     }
 
-    // -No reorg if we are not proposing on time.-
-    // Note: Skipping this check as store.time in Lodestar is stored in slot and not unix time
     // https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/phase0/fork-choice.md#is_proposing_on_time
     const proposerReorgCutoff = this.config.SECONDS_PER_SLOT / INTERVALS_PER_SLOT / 2;
     const isProposingOnTime = secFromSlot <= proposerReorgCutoff;

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -234,7 +234,12 @@ export class ForkChoice implements IForkChoice {
       return {proposerHead, isHeadTimely, notReorgedReason: NotReorgedReason.ParentBlockNotAvailable};
     }
 
-    const {prelimProposerHead, prelimNotReorgedReason} = this.getPreliminaryProposerHead(headBlock, parentBlock, secFromSlot, slot);
+    const {prelimProposerHead, prelimNotReorgedReason} = this.getPreliminaryProposerHead(
+      headBlock,
+      parentBlock,
+      secFromSlot,
+      slot
+    );
 
     if (prelimProposerHead === headBlock && prelimNotReorgedReason !== undefined) {
       return {proposerHead, isHeadTimely, notReorgedReason: prelimNotReorgedReason};

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -45,20 +45,8 @@ import {IForkChoiceStore, CheckpointWithHex, toCheckpointWithHex, JustifiedBalan
 
 export type ForkChoiceOpts = {
   proposerBoostEnabled?: boolean;
-  proposerBoostReorgEnabled?: boolean;
   computeUnrealized?: boolean;
 };
-
-export enum UpdateHeadOpt {
-  GetCanonicialHead, // Skip getProposerHead
-  GetProposerHead, // With getProposerHead
-  GetPredictedProposerHead, // With predictProposerHead
-}
-
-export type UpdateAndGetHeadOpt =
-  | {mode: UpdateHeadOpt.GetCanonicialHead}
-  | {mode: UpdateHeadOpt.GetProposerHead; slot: Slot}
-  | {mode: UpdateHeadOpt.GetPredictedProposerHead; slot: Slot};
 
 /**
  * Provides an implementation of "Ethereum Consensus -- Beacon Chain Fork Choice":
@@ -168,29 +156,6 @@ export class ForkChoice implements IForkChoice {
   }
 
   /**
-   *
-   * A multiplexer to wrap around the traditional `updateHead()` according to the scenario
-   * Scenarios as follow:
-   *    Prepare to propose in the next slot: getHead() -> predictProposerHead()
-   *    Proposing in the current slot: updateHead() -> getProposerHead()
-   *    Others eg. initializing forkchoice, importBlock: updateHead()
-   */
-  updateAndGetHead(opt: UpdateAndGetHeadOpt): ProtoBlock {
-    const {mode} = opt;
-
-    const canonicialHeadBlock = mode === UpdateHeadOpt.GetPredictedProposerHead ? this.getHead() : this.updateHead();
-    switch (mode) {
-      case UpdateHeadOpt.GetPredictedProposerHead:
-        return this.predictProposerHead(canonicialHeadBlock, opt.slot);
-      case UpdateHeadOpt.GetProposerHead:
-        return this.getProposerHead(canonicialHeadBlock, opt.slot);
-      case UpdateHeadOpt.GetCanonicialHead:
-      default:
-        return canonicialHeadBlock;
-    }
-  }
-
-  /**
    * Get the proposer boost root
    */
   getProposerBoostRoot(): RootHex {
@@ -210,7 +175,7 @@ export class ForkChoice implements IForkChoice {
    */
   predictProposerHead(headBlock: ProtoBlock, currentSlot?: Slot): ProtoBlock {
     // Skip re-org attempt if proposer boost (reorg) are disabled
-    if (!this.opts?.proposerBoostEnabled || !this.opts?.proposerBoostReorgEnabled) {
+    if (!this.opts?.proposerBoostEnabled) {
       this.logger?.verbose("No proposer boot reorg prediction since the related flags are disabled");
       return headBlock;
     }
@@ -243,13 +208,13 @@ export class ForkChoice implements IForkChoice {
    *
    * This function takes in the canonical head block and determine the proposer head (canonical head block or its parent)
    * https://github.com/ethereum/consensus-specs/pull/3034 for info about proposer boost reorg
-   * This function should only be called during block proposal and only be called after `updateHead()` in `updateAndGetHead()`
+   * This function should only be called during block proposal and only be called after `updateHead()`
    *
    * Same as https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/phase0/fork-choice.md#get_proposer_head
    */
   getProposerHead(headBlock: ProtoBlock, slot: Slot): ProtoBlock {
     // Skip re-org attempt if proposer boost (reorg) are disabled
-    if (!this.opts?.proposerBoostEnabled || !this.opts?.proposerBoostReorgEnabled) {
+    if (!this.opts?.proposerBoostEnabled) {
       this.logger?.verbose("No proposer boot reorg attempt since the related flags are disabled");
       return headBlock;
     }

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -3,6 +3,7 @@ import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {Epoch, Slot, ValidatorIndex, phase0, allForks, Root, RootHex} from "@lodestar/types";
 import {ProtoBlock, MaybeValidExecutionStatus, LVHExecResponse, ProtoNode} from "../protoArray/interface.js";
 import {CheckpointWithHex} from "./store.js";
+import {UpdateAndGetHeadOpt} from "./forkChoice.js";
 
 export type CheckpointHex = {
   epoch: Epoch;
@@ -77,6 +78,7 @@ export interface IForkChoice {
   getHeadRoot(): RootHex;
   getHead(): ProtoBlock;
   updateHead(): ProtoBlock;
+  updateAndGetHead(mode: UpdateAndGetHeadOpt): ProtoBlock;
   /**
    * Retrieves all possible chain heads (leaves of fork choice tree).
    */

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -54,6 +54,7 @@ export enum NotReorgedReason {
   ProposerBoostNotWornOff,
   HeadBlockNotWeak,
   ParentBlockIsStrong,
+  NotProposingOnTime,
 }
 
 export type ForkChoiceMetrics = {

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -3,7 +3,6 @@ import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {Epoch, Slot, ValidatorIndex, phase0, allForks, Root, RootHex} from "@lodestar/types";
 import {ProtoBlock, MaybeValidExecutionStatus, LVHExecResponse, ProtoNode} from "../protoArray/interface.js";
 import {CheckpointWithHex} from "./store.js";
-import {UpdateAndGetHeadOpt} from "./forkChoice.js";
 
 export type CheckpointHex = {
   epoch: Epoch;
@@ -78,7 +77,6 @@ export interface IForkChoice {
   getHeadRoot(): RootHex;
   getHead(): ProtoBlock;
   updateHead(): ProtoBlock;
-  updateAndGetHead(mode: UpdateAndGetHeadOpt): ProtoBlock;
   /**
    * Retrieves all possible chain heads (leaves of fork choice tree).
    */

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -41,6 +41,21 @@ export type AncestorResult =
   | {code: AncestorStatus.NoCommonAncenstor}
   | {code: AncestorStatus.BlockUnknown};
 
+// Reason for not proposer boost reorging
+export enum NotReorgedReason {
+  HeadBlockIsTimely,
+  ParentBlockNotAvailable,
+  ProposerBoostReorgDisabled,
+  NotShufflingStable,
+  NotFFGCompetitive,
+  ChainLongUnfinality,
+  ParentBlockDistanceMoreThanOneSlot,
+  ReorgMoreThanOneSlot,
+  ProposerBoostNotWornOff,
+  HeadBlockNotWeak,
+  ParentBlockIsStrong,
+}
+
 export type ForkChoiceMetrics = {
   votes: number;
   queuedAttestations: number;

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -78,6 +78,9 @@ export type ProtoBlock = BlockExecution & {
   unrealizedJustifiedRoot: RootHex;
   unrealizedFinalizedEpoch: Epoch;
   unrealizedFinalizedRoot: RootHex;
+
+  // Indicate whether block arrives in a timely manner ie. before the 4 second mark
+  timeliness: boolean;
 };
 
 /**

--- a/packages/fork-choice/test/perf/forkChoice/util.ts
+++ b/packages/fork-choice/test/perf/forkChoice/util.ts
@@ -75,6 +75,8 @@ export function initializeForkChoice(opts: Opts): ForkChoice {
 
       executionPayloadBlockHash: null,
       executionStatus: ExecutionStatus.PreMerge,
+
+      timeliness: false,
     };
 
     protoArr.onBlock(block, block.slot);

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -101,6 +101,8 @@ describe("Forkchoice", function () {
 
       executionPayloadBlockHash: null,
       executionStatus: ExecutionStatus.PreMerge,
+
+      timeliness: false,
     };
   };
 
@@ -170,14 +172,14 @@ describe("Forkchoice", function () {
   // TODO: more unit tests for other apis
 });
 
-function getStateRoot(slot: number): RootHex {
+export function getStateRoot(slot: number): RootHex {
   const root = Buffer.alloc(32, 0x00);
   root[0] = rootStateBytePrefix;
   root[31] = slot;
   return toHex(root);
 }
 
-function getBlockRoot(slot: number): RootHex {
+export function getBlockRoot(slot: number): RootHex {
   const root = Buffer.alloc(32, 0x00);
   root[0] = rootBlockBytePrefix;
   root[31] = slot;

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -223,7 +223,7 @@ describe("Forkchoice / GetProposerHead", function () {
         currentSlot,
       });
 
-      const forkChoice = new ForkChoice(config, fcStore, protoArr, undefined, {
+      const forkChoice = new ForkChoice(config, fcStore, protoArr, {
         proposerBoostEnabled: true,
         // proposerBoostReorgEnabled: true,
       });

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -1,0 +1,218 @@
+import {describe, it, expect, beforeEach} from "vitest";
+import {fromHexString} from "@chainsafe/ssz";
+import {config} from "@lodestar/config/default";
+import {Slot} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkChoice, IForkChoiceStore, ProtoArray, ExecutionStatus, ProtoBlock} from "../../../src/index.js";
+import {getBlockRoot, getStateRoot} from "./forkChoice.test.js";
+
+type ProtoBlockWithWeight = ProtoBlock & {weight: number}; // weight of the block itself
+
+describe("Forkchoice / GetProposerHead", function () {
+  const genesisSlot = 0;
+  const genesisEpoch = 0;
+  const genesisRoot = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+  const parentSlot = genesisSlot + 1;
+  const headSlot = genesisSlot + 2;
+
+  let protoArr: ProtoArray;
+
+  const genesisBlock: Omit<ProtoBlock, "targetRoot"> = {
+    slot: genesisSlot,
+    stateRoot: getStateRoot(genesisSlot),
+    parentRoot: toHex(Buffer.alloc(32, 0xff)),
+    blockRoot: getBlockRoot(genesisSlot),
+
+    justifiedEpoch: genesisEpoch,
+    justifiedRoot: genesisRoot,
+    finalizedEpoch: genesisEpoch,
+    finalizedRoot: genesisRoot,
+    unrealizedJustifiedEpoch: genesisEpoch,
+    unrealizedJustifiedRoot: genesisRoot,
+    unrealizedFinalizedEpoch: genesisEpoch,
+    unrealizedFinalizedRoot: genesisRoot,
+
+    executionPayloadBlockHash: null,
+    executionStatus: ExecutionStatus.PreMerge,
+
+    timeliness: false,
+  };
+
+  const baseHeadBlock: ProtoBlockWithWeight = {
+    slot: headSlot,
+    stateRoot: getStateRoot(headSlot),
+    parentRoot: getBlockRoot(parentSlot),
+    blockRoot: getBlockRoot(headSlot),
+    targetRoot: getBlockRoot(headSlot),
+
+    justifiedEpoch: genesisEpoch,
+    justifiedRoot: genesisRoot,
+    finalizedEpoch: genesisEpoch,
+    finalizedRoot: genesisRoot,
+    unrealizedJustifiedEpoch: genesisEpoch,
+    unrealizedJustifiedRoot: genesisRoot,
+    unrealizedFinalizedEpoch: genesisEpoch,
+    unrealizedFinalizedRoot: genesisRoot,
+
+    executionPayloadBlockHash: null,
+    executionStatus: ExecutionStatus.PreMerge,
+
+    timeliness: false,
+
+    weight: 29,
+  };
+
+  const baseParentHeadBlock: ProtoBlockWithWeight = {
+    slot: parentSlot,
+    stateRoot: getStateRoot(parentSlot),
+    parentRoot: getBlockRoot(genesisSlot),
+    blockRoot: getBlockRoot(parentSlot),
+    targetRoot: getBlockRoot(parentSlot),
+
+    justifiedEpoch: genesisEpoch,
+    justifiedRoot: genesisRoot,
+    finalizedEpoch: genesisEpoch,
+    finalizedRoot: genesisRoot,
+    unrealizedJustifiedEpoch: genesisEpoch,
+    unrealizedJustifiedRoot: genesisRoot,
+    unrealizedFinalizedEpoch: genesisEpoch,
+    unrealizedFinalizedRoot: genesisRoot,
+
+    executionPayloadBlockHash: null,
+    executionStatus: ExecutionStatus.PreMerge,
+
+    timeliness: false,
+    weight: 212, // 240 - 29 + 1
+  };
+
+  const fcStore: IForkChoiceStore = {
+    currentSlot: genesisSlot + 1,
+    justified: {
+      checkpoint: {epoch: genesisEpoch, root: fromHexString(genesisBlock.blockRoot), rootHex: genesisBlock.blockRoot},
+      balances: new Uint8Array(Array(32).fill(150)),
+      totalBalance: 32 * 150,
+    },
+    unrealizedJustified: {
+      checkpoint: {epoch: genesisEpoch, root: fromHexString(genesisBlock.blockRoot), rootHex: genesisBlock.blockRoot},
+      balances: new Uint8Array(Array(32).fill(150)),
+    },
+    finalizedCheckpoint: {
+      epoch: genesisEpoch,
+      root: fromHexString(genesisBlock.blockRoot),
+      rootHex: genesisBlock.blockRoot,
+    },
+    unrealizedFinalizedCheckpoint: {
+      epoch: genesisEpoch,
+      root: fromHexString(genesisBlock.blockRoot),
+      rootHex: genesisBlock.blockRoot,
+    },
+    justifiedBalancesGetter: () => new Uint8Array(Array(32).fill(150)),
+    equivocatingIndices: new Set(),
+  };
+
+  // head block's weight < 30 is considered weak. parent block's total weight > 240 is considered strong
+  const testCases: {
+    id: string;
+    parentBlock: ProtoBlockWithWeight;
+    headBlock: ProtoBlockWithWeight;
+    expectReorg: boolean;
+    currentSlot?: Slot;
+  }[] = [
+    {
+      id: "Case that meets all conditions to be re-orged",
+      parentBlock: {...baseParentHeadBlock},
+      headBlock: {...baseHeadBlock},
+      expectReorg: true,
+    },
+    {
+      id: "No reorg when head block is timly",
+      parentBlock: {...baseParentHeadBlock},
+      headBlock: {...baseHeadBlock, timeliness: true},
+      expectReorg: false,
+    },
+    {
+      id: "No reorg when currenSlot is at epoch boundary",
+      parentBlock: {...baseParentHeadBlock},
+      headBlock: {...baseHeadBlock},
+      expectReorg: false,
+      currentSlot: SLOTS_PER_EPOCH * 2,
+    },
+    {
+      id: "No reorg when the blocks are not ffg competitive",
+      parentBlock: {...baseParentHeadBlock},
+      headBlock: {...baseHeadBlock, unrealizedJustifiedEpoch: 1},
+      expectReorg: false,
+    },
+    {
+      id: "No reorg when the blocks are not ffg competitive 2",
+      parentBlock: {...baseParentHeadBlock},
+      headBlock: {...baseHeadBlock, unrealizedJustifiedRoot: "-"},
+      expectReorg: false,
+    },
+    {
+      id: "No reorg if long unfinality",
+      parentBlock: {...baseParentHeadBlock},
+      headBlock: {...baseHeadBlock},
+      expectReorg: false,
+      currentSlot: (genesisEpoch + 2) * SLOTS_PER_EPOCH + 1,
+    },
+    {
+      id: "No reorg if reorg spans more than a single slot",
+      parentBlock: {...baseParentHeadBlock},
+      headBlock: {...baseHeadBlock, slot: headSlot + 1},
+      expectReorg: false,
+    },
+    {
+      id: "No reorg if current slot is more than one slot from head block",
+      parentBlock: {...baseParentHeadBlock},
+      headBlock: {...baseHeadBlock},
+      expectReorg: false,
+      currentSlot: headSlot + 2,
+    },
+    {
+      id: "No reorg if head is strong",
+      parentBlock: {...baseParentHeadBlock},
+      headBlock: {...baseHeadBlock, weight: 30},
+      expectReorg: false,
+    },
+    {
+      id: "No reorg if parent is weak",
+      parentBlock: {...baseParentHeadBlock, weight: 211},
+      headBlock: {...baseHeadBlock},
+      expectReorg: false,
+    },
+  ];
+
+  beforeEach(() => {
+    protoArr = ProtoArray.initialize(genesisBlock, genesisSlot);
+  });
+
+  for (const {id, parentBlock, headBlock, expectReorg, currentSlot: proposalSlot} of testCases) {
+    it(`${id}`, async () => {
+      protoArr.onBlock(parentBlock, parentBlock.slot);
+      protoArr.onBlock(headBlock, headBlock.slot);
+
+      const currentSlot = proposalSlot ?? headBlock.slot + 1;
+      protoArr.applyScoreChanges({
+        deltas: [0, parentBlock.weight, headBlock.weight],
+        proposerBoost: null,
+        justifiedEpoch: genesisEpoch,
+        justifiedRoot: genesisRoot,
+        finalizedEpoch: genesisEpoch,
+        finalizedRoot: genesisRoot,
+        currentSlot,
+      });
+
+      const forkChoice = new ForkChoice(config, fcStore, protoArr, undefined, {
+        proposerBoostEnabled: true,
+        proposerBoostReorgEnabled: true,
+      });
+
+      const proposerHead = forkChoice.getProposerHead(headBlock, currentSlot);
+
+      expect(proposerHead.blockRoot).toBe(expectReorg ? parentBlock.blockRoot : headBlock.blockRoot);
+    });
+  }
+});

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -200,9 +200,9 @@ describe("Forkchoice / GetProposerHead", function () {
       parentBlock: {...baseParentHeadBlock, weight: 211},
       headBlock: {...baseHeadBlock},
       expectReorg: false,
-      secFromSlot: (config.SECONDS_PER_SLOT / INTERVALS_PER_SLOT / 2) + 1,
+      secFromSlot: config.SECONDS_PER_SLOT / INTERVALS_PER_SLOT / 2 + 1,
       expectedNotReorgedReason: NotReorgedReason.NotProposingOnTime,
-    }
+    },
   ];
 
   beforeEach(() => {
@@ -239,7 +239,11 @@ describe("Forkchoice / GetProposerHead", function () {
         // proposerBoostReorgEnabled: true,
       });
 
-      const {proposerHead, isHeadTimely, notReorgedReason} = forkChoice.getProposerHead(headBlock, currentSecFromSlot, currentSlot);
+      const {proposerHead, isHeadTimely, notReorgedReason} = forkChoice.getProposerHead(
+        headBlock,
+        currentSecFromSlot,
+        currentSlot
+      );
 
       expect(isHeadTimely).toBe(headBlock.timeliness);
       expect(notReorgedReason).toBe(expectedNotReorgedReason);

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -106,6 +106,8 @@ function setupForkChoice(): ProtoArray {
         unrealizedFinalizedEpoch: 0,
         unrealizedFinalizedRoot: "-",
 
+        timeliness: false,
+
         ...executionData,
       },
       block.slot

--- a/packages/fork-choice/test/unit/protoArray/getCommonAncestor.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/getCommonAncestor.test.ts
@@ -40,6 +40,8 @@ describe("getCommonAncestor", () => {
       unrealizedFinalizedEpoch: 0,
       unrealizedFinalizedRoot: "-",
 
+      timeliness: false,
+
       ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
     },
     0
@@ -62,6 +64,8 @@ describe("getCommonAncestor", () => {
         unrealizedJustifiedRoot: "-",
         unrealizedFinalizedEpoch: 0,
         unrealizedFinalizedRoot: "-",
+
+        timeliness: false,
 
         ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
       },

--- a/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
@@ -30,6 +30,8 @@ describe("ProtoArray", () => {
         unrealizedFinalizedEpoch: genesisEpoch,
         unrealizedFinalizedRoot: stateRoot,
 
+        timeliness: false,
+
         ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
       },
       genesisSlot
@@ -53,6 +55,8 @@ describe("ProtoArray", () => {
         unrealizedFinalizedEpoch: genesisEpoch,
         unrealizedFinalizedRoot: stateRoot,
 
+        timeliness: false,
+
         ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
       },
       genesisSlot + 1
@@ -75,6 +79,8 @@ describe("ProtoArray", () => {
         unrealizedJustifiedRoot: stateRoot,
         unrealizedFinalizedEpoch: genesisEpoch,
         unrealizedFinalizedRoot: stateRoot,
+
+        timeliness: false,
 
         ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
       },

--- a/packages/state-transition/src/util/execution.ts
+++ b/packages/state-transition/src/util/execution.ts
@@ -114,7 +114,6 @@ export function isExecutionPayload(
   payload: allForks.FullOrBlindedExecutionPayload
 ): payload is allForks.ExecutionPayload {
   return (payload as allForks.ExecutionPayload).transactions !== undefined;
-
 }
 
 export function isCapellaPayload(

--- a/packages/state-transition/src/util/execution.ts
+++ b/packages/state-transition/src/util/execution.ts
@@ -114,6 +114,7 @@ export function isExecutionPayload(
   payload: allForks.FullOrBlindedExecutionPayload
 ): payload is allForks.ExecutionPayload {
   return (payload as allForks.ExecutionPayload).transactions !== undefined;
+
 }
 
 export function isCapellaPayload(

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -123,6 +123,9 @@ function getSpecCriticalParams(localConfig: ChainConfig): Record<keyof ConfigWit
 
     // Fork choice
     PROPOSER_SCORE_BOOST: false, // Ignored as it's changing https://github.com/ethereum/consensus-specs/pull/2895
+    REORG_HEAD_WEIGHT_THRESHOLD: false, // Non-critical since proposer boost reorg is optional feature
+    REORG_PARENT_WEIGHT_THRESHOLD: false, // Non-critical since proposer boost reorg is optional feature
+    REORG_MAX_EPOCHS_SINCE_FINALIZATION: false, // Non-critical since proposer boost reorg is optional feature
 
     // Deposit contract
     DEPOSIT_CHAIN_ID: false, // Non-critical


### PR DESCRIPTION
**Motivation**

Lay ground work for proposer boost reorg. 

**Description**

- Add reorg related constants to chain configs
- Add `timeliness: boolean` field to ProtoBlock to indicate if block was arrived on time or not
- Add `getProposerHead()` that will be used to determine which head block to build on when proposing block
- Add `predictProposerHead()` to predict which head block to build on when proposing in the next slot
- Clean up some existed code in forkChoice.ts to play nicely with the new changes

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Part of #5125
