### PR TITLE
feat: properly consider Eth-Consensus-Version header

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -341,11 +341,17 @@ export function getReqSerializers(config: ChainForkConfig): ReqSerializers<Api, 
     getBlockRoot: blockIdOnlyReq,
     publishBlock: reqOnlyBody(createAllForksSignedBlockOrContents(), Schema.Object),
     publishBlockV2: {
-      writeReq: (item, {broadcastValidation, version} = {}) => ({
-        body: createAllForksSignedBlockOrContents(version).toJson(item),
-        query: {broadcast_validation: broadcastValidation},
-        headers: {"eth-consensus-version": version},
-      }),
+      writeReq: (item, {broadcastValidation, version} = {}) => {
+        const req = {
+          body: createAllForksSignedBlockOrContents(version).toJson(item),
+          query: {broadcast_validation: broadcastValidation},
+        };
+        const headers = version !== undefined ? {"eth-consensus-version": version} : {};
+        return {
+          ...req,
+          ...{headers},
+        };
+      },
       parseReq: ({body, query, headers}) => {
         const version = headers["eth-consensus-version"];
         return [

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -60,7 +60,10 @@ export const testData: GenericServerTestCases<Api> = {
     res: undefined,
   },
   publishBlockV2: {
-    args: [ssz.phase0.SignedBeaconBlock.defaultValue(), {broadcastValidation: BroadcastValidation.consensus}],
+    args: [
+      ssz.phase0.SignedBeaconBlock.defaultValue(),
+      {broadcastValidation: BroadcastValidation.consensus, version: ForkName.phase0},
+    ],
     res: undefined,
   },
   publishBlindedBlock: {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -1,7 +1,7 @@
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {routes, ServerApi, ResponseFormat} from "@lodestar/api";
 import {computeTimeAtSlot, reconstructFullBlockOrContents} from "@lodestar/state-transition";
-import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
+import {ForkName, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {sleep, toHex} from "@lodestar/utils";
 import {allForks, deneb, isSignedBlockContents, ProducedBlockSource} from "@lodestar/types";
 import {BlockSource, getBlockInput, ImportBlockOpts, BlockInput} from "../../../../chain/blocks/types.js";
@@ -17,7 +17,10 @@ import {verifyBlocksInEpoch} from "../../../../chain/blocks/verifyBlock.js";
 import {BeaconChain} from "../../../../chain/chain.js";
 import {resolveBlockId, toBeaconHeaderResponse} from "./utils.js";
 
-type PublishBlockOpts = ImportBlockOpts & {broadcastValidation?: routes.beacon.BroadcastValidation};
+type PublishBlockOpts = ImportBlockOpts & {
+  version?: ForkName;
+  broadcastValidation?: routes.beacon.BroadcastValidation;
+};
 
 /**
  * Validator clock may be advanced from beacon's clock. If the validator requests a resource in a
@@ -69,7 +72,7 @@ export function getBeaconBlockApi({
     // if block is locally produced, full or blinded, it already is 'consensus' validated as it went through
     // state transition to produce the stateRoot
     const slot = signedBlock.message.slot;
-    const fork = config.getForkName(slot);
+    const fork = opts.version ?? config.getForkName(slot);
     const blockRoot = toHex(chain.config.getForkTypes(slot).BeaconBlock.hashTreeRoot(signedBlock.message));
     // bodyRoot should be the same to produced block
     const bodyRoot = toHex(chain.config.getForkTypes(slot).BeaconBlockBody.hashTreeRoot(signedBlock.message.body));


### PR DESCRIPTION
**Motivation**

Follow the [beacon-APIs](https://github.com/ethereum/beacon-APIs) specs.

**Description**

Get the consensus version of submitted block from the `Eth-Consensus-Version` header value. Falls back to current behavior (extract from the submitted block payload) if not submitted.
Test by executing the following command, with `block.json` containing the appropriate block data:

```
curl -H "Eth-Consensus-Version: altair" localhost:9596/eth/v2/beacon/blocks -X POST -d @block.json -H "Content-Type: application/json"
````

Fixes https://github.com/ChainSafe/lodestar/issues/6580
