### PR TITLE
fix: set Eth-Consensus-Version header in publish block requests

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -9,6 +9,7 @@ import {
   ArrayOf,
   Schema,
   WithVersion,
+  reqOnlyBody,
   TypeJson,
   ReqSerializers,
   ReqSerializer,
@@ -335,14 +336,7 @@ export function getReqSerializers(config: ChainForkConfig): ReqSerializers<Api, 
       schema: {query: {slot: Schema.Uint, parent_root: Schema.String}},
     },
     getBlockRoot: blockIdOnlyReq,
-    publishBlock: {
-      writeReq: (items) => ({
-        body: AllForksSignedBlockOrContents.toJson(items),
-        headers: {"Eth-Consensus-Version": config.getForkName(extractSlot(items))},
-      }),
-      parseReq: ({body}) => [AllForksSignedBlockOrContents.fromJson(body)],
-      schema: {body: Schema.Object},
-    },
+    publishBlock: reqOnlyBody(AllForksSignedBlockOrContents, Schema.Object),
     publishBlockV2: {
       writeReq: (item, {broadcastValidation} = {}) => ({
         body: AllForksSignedBlockOrContents.toJson(item),
@@ -358,14 +352,7 @@ export function getReqSerializers(config: ChainForkConfig): ReqSerializers<Api, 
         query: {broadcast_validation: Schema.String},
       },
     },
-    publishBlindedBlock: {
-      writeReq: (items) => ({
-        body: AllForksSignedBlindedBlock.toJson(items),
-        headers: {"Eth-Consensus-Version": config.getForkName(extractSlot(items))},
-      }),
-      parseReq: ({body}) => [AllForksSignedBlindedBlock.fromJson(body)],
-      schema: {body: Schema.Object},
-    },
+    publishBlindedBlock: reqOnlyBody(AllForksSignedBlindedBlock, Schema.Object),
     publishBlindedBlockV2: {
       writeReq: (item, {broadcastValidation}) => ({
         body: AllForksSignedBlindedBlock.toJson(item),

--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -357,7 +357,7 @@ export function getReqSerializers(config: ChainForkConfig): ReqSerializers<Api, 
       writeReq: (item, {broadcastValidation}) => ({
         body: AllForksSignedBlindedBlock.toJson(item),
         query: {broadcast_validation: broadcastValidation},
-        headers: {"Eth-Consensus-Version": config.getForkName(extractSlot(item))},
+        headers: {"Eth-Consensus-Version": config.getForkName(item.message.slot)},
       }),
       parseReq: ({body, query}) => [
         AllForksSignedBlindedBlock.fromJson(body),


### PR DESCRIPTION
**Motivation**

Follow the [beacon-APIs](https://github.com/ethereum/beacon-APIs) specs.

Note that [submitBlindedBlock](https://github.com/ChainSafe/lodestar/blob/59a49ff945dfef6831d282c85f3818446fefb9e9/packages/api/src/builder/routes.ts#L57) reuses [publishBlindedBlock](https://github.com/ChainSafe/lodestar/blob/59a49ff945dfef6831d282c85f3818446fefb9e9/packages/api/src/builder/routes.ts#L81) serializers.

**Description**

Properly sets `Eth-Consensus-Version` when calling relevant beacon-APIs endpoints. This is a short term fix. The proper solution will ship via a later refactoring.

Fixes https://github.com/ChainSafe/lodestar/issues/6580