### PR TITLE
feat: enable gossipsub batch publish

### DIFF
--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -125,6 +125,8 @@ export class Eth2Gossipsub extends GossipSub {
       asyncValidation: true,
 
       maxOutboundBufferSize: MAX_OUTBOUND_BUFFER_SIZE,
+      // serialize message once and send to all peers when publishing
+      batchPublish: true,
     });
     this.scoreParams = scoreParams;
     this.config = config;


### PR DESCRIPTION
**Motivation**

Improve memory on network thread

**Description**

Enable `batchPublish` option to serialize message once and send to all peers when publishing

related to #6595 #6106