### PR TITLE
chore: allow to pass extra args to dev scripts

### DIFF
--- a/scripts/dev/node1.sh
+++ b/scripts/dev/node1.sh
@@ -14,4 +14,5 @@ GENESIS_TIME=$(date +%s)
   --metrics \
   --logLevel debug \
   --eth1 false \
-  --network.rateLimitMultiplier 0
+  --network.rateLimitMultiplier 0 \
+  $@

--- a/scripts/dev/node2.sh
+++ b/scripts/dev/node2.sh
@@ -19,4 +19,5 @@ GENESIS_TIME=$(curl -s http://localhost:9596/eth/v1/beacon/genesis | jq -r .data
   --port 9001 \
   --rest.port 9597 \
   --network.connectToDiscv5Bootnodes true \
-  --bootnodes $ENR
+  --bootnodes $ENR \
+  $@


### PR DESCRIPTION
**Motivation**

Allow to pass extra args to node `scripts`

**Description**

Allows the following:

`./scripts/dev/node1.sh --blindedLocal`