### PR TITLE
chore: reorder block production log statements

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -616,7 +616,9 @@ export function getValidatorApi({
       }
 
       if (builder.status === "rejected" && engine.status === "rejected") {
-        throw Error("Builder and engine both failed to produce the block");
+        const failureSource =
+          isEngineEnabled && isBuilderEnabled ? "Builder and engine both" : isEngineEnabled ? "Engine" : "Builder";
+        throw Error(`${failureSource} failed to produce the block`);
       }
 
       // handle shouldOverrideBuilder separately

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -588,7 +588,9 @@ export function getValidatorApi({
       });
 
       if (builder.status === "pending" && engine.status === "pending") {
-        throw Error("Builder and engine both failed to produce the block within timeout");
+        const failureSource =
+          isEngineEnabled && isBuilderEnabled ? "Builder and engine both" : isEngineEnabled ? "Engine" : "Builder";
+        throw Error(`${failureSource} both failed to produce the block within timeout`);
       }
 
       if (engine.status === "rejected" && isEngineEnabled) {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -588,9 +588,7 @@ export function getValidatorApi({
       });
 
       if (builder.status === "pending" && engine.status === "pending") {
-        const failureSource =
-          isEngineEnabled && isBuilderEnabled ? "Builder and engine both" : isEngineEnabled ? "Engine" : "Builder";
-        throw Error(`${failureSource} both failed to produce the block within timeout`);
+        throw Error("Builder and engine both failed to produce the block within timeout");
       }
 
       if (engine.status === "rejected" && isEngineEnabled) {
@@ -616,9 +614,9 @@ export function getValidatorApi({
       }
 
       if (builder.status === "rejected" && engine.status === "rejected") {
-        const failureSource =
-          isEngineEnabled && isBuilderEnabled ? "Builder and engine both" : isEngineEnabled ? "Engine" : "Builder";
-        throw Error(`${failureSource} failed to produce the block`);
+        throw Error(
+          `${isBuilderEnabled && isEngineEnabled ? "Builder and engine both" : isBuilderEnabled ? "Builder" : "Engine"} failed to produce the block`
+        );
       }
 
       // handle shouldOverrideBuilder separately

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -591,10 +591,6 @@ export function getValidatorApi({
         throw Error("Builder and engine both failed to produce the block within timeout");
       }
 
-      if (builder.status === "rejected" && engine.status === "rejected") {
-        throw Error("Builder and engine both failed to produce the block");
-      }
-
       if (engine.status === "rejected" && isEngineEnabled) {
         logger.warn(
           "Engine failed to produce the block",
@@ -615,6 +611,10 @@ export function getValidatorApi({
           },
           builder.reason
         );
+      }
+
+      if (builder.status === "rejected" && engine.status === "rejected") {
+        throw Error("Builder and engine both failed to produce the block");
       }
 
       // handle shouldOverrideBuilder separately


### PR DESCRIPTION
**Motivation**

Make sure logs are not discarded

**Description**

[Logs](https://github.com/ChainSafe/lodestar/blob/971871eee2e3bdbca6506d3415d5f40d8a4c74f0/packages/beacon-node/src/api/impl/validator/index.ts#L598) can be discarded by an exception thrown beforehand. Reorder logic so that it doesn't happen.