### PR TITLE
fix: reject promise on file stream error when writing heap snapshot

### DIFF
--- a/packages/beacon-node/src/util/profile.ts
+++ b/packages/beacon-node/src/util/profile.ts
@@ -41,7 +41,11 @@ export async function writeHeapSnapshot(prefix: string, dirpath: string): Promis
   const snapshotStream = v8.getHeapSnapshot();
   const filepath = `${dirpath}/${prefix}_${new Date().toISOString()}.heapsnapshot`;
   const fileStream = fs.createWriteStream(filepath);
-  return new Promise<string>((resolve) => {
+  return new Promise<string>((resolve, reject) => {
+    fileStream.on("error", (err) => {
+      reject(err);
+    });
+
     snapshotStream.pipe(fileStream);
     snapshotStream.on("end", () => {
       resolve(filepath);


### PR DESCRIPTION
**Motivation**

Writing a heap snapshot might fail due to missing permissions to write the file or misconfigured dirpath passed via query param. 

In any case, we should reject and return a response to the caller but currently it results in an uncaught expection
```
Mar-27 20:40:32.388[network]         error: uncaughtException: EACCES: permission denied, open './network_thread_2024-03-27T20:40:32.037Z.heapsnapshot'
Error: EACCES: permission denied, open './network_thread_2024-03-27T20:40:32.037Z.heapsnapshot' - EACCES: permission denied, open './network_thread_2024-03-27T20:40:32.037Z.heapsnapshot'
Error: EACCES: permission denied, open './network_thread_2024-03-27T20:40:32.037Z.heapsnapshot'
```

Another issue is also that it is not possible to write another snapshot if the previous one failed as promise is stuck forever until process is restarted

```
curl -X POST http://localhost:5052/eth/v1/lodestar/write_heapdump?thread=network
{"statusCode":500,"error":"Internal Server Error","message":"Already writing heapdump"}
```

 

**Description**

Reject promise on file stream error when writing heap snapshot