### PR TITLE
chore: refactor DLLAttnetsService to AttnetsService

### DIFF
--- a/packages/beacon-node/src/network/core/metrics.ts
+++ b/packages/beacon-node/src/network/core/metrics.ts
@@ -1,7 +1,7 @@
 import {RegistryMetricCreator} from "../../metrics/utils/registryMetricCreator.js";
 import {SubnetType} from "../metadata.js";
 import {DiscoveredPeerStatus} from "../peers/discover.js";
-import {DLLSubnetSource} from "../subnets/dllAttnetsService.js";
+import {SubnetSource} from "../subnets/attnetsService.js";
 
 export type NetworkCoreMetrics = ReturnType<typeof createNetworkCoreMetrics>;
 
@@ -213,12 +213,12 @@ export function createNetworkCoreMetrics(register: RegistryMetricCreator) {
         name: "lodestar_attnets_service_long_lived_subscriptions_total",
         help: "Count of long lived subscriptions",
       }),
-      subscribeSubnets: register.gauge<{subnet: number; src: DLLSubnetSource}>({
+      subscribeSubnets: register.gauge<{subnet: number; src: SubnetSource}>({
         name: "lodestar_attnets_service_subscribe_subnets_total",
         help: "Count of subscribe_subnets calls",
         labelNames: ["subnet", "src"],
       }),
-      unsubscribeSubnets: register.gauge<{subnet: number; src: DLLSubnetSource}>({
+      unsubscribeSubnets: register.gauge<{subnet: number; src: SubnetSource}>({
         name: "lodestar_attnets_service_unsubscribe_subnets_total",
         help: "Count of unsubscribe_subnets calls",
         labelNames: ["subnet", "src"],

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -32,7 +32,7 @@ import {Discv5Worker} from "../discv5/index.js";
 import {LocalStatusCache} from "../statusCache.js";
 import {RegistryMetricCreator} from "../../metrics/index.js";
 import {peerIdFromString, peerIdToString} from "../../util/peerId.js";
-import {DLLAttnetsService} from "../subnets/dllAttnetsService.js";
+import {AttnetsService} from "../subnets/attnetsService.js";
 import {NetworkCoreMetrics, createNetworkCoreMetrics} from "./metrics.js";
 import {INetworkCore, MultiaddrStr, PeerIdStr} from "./types.js";
 
@@ -191,12 +191,12 @@ export class NetworkCore implements INetworkCore {
     await libp2p.start();
 
     await reqResp.start();
-    // should be called before DLLAttnetsService constructor so that node subscribe to deterministic attnet topics
+    // should be called before AttnetsService constructor so that node subscribe to deterministic attnet topics
     await gossip.start();
 
     const enr = opts.discv5?.enr;
     const nodeId = enr ? fromHexString(ENR.decodeTxt(enr).nodeId) : null;
-    const attnetsService = new DLLAttnetsService(config, clock, gossip, metadata, logger, metrics, nodeId, opts);
+    const attnetsService = new AttnetsService(config, clock, gossip, metadata, logger, metrics, nodeId, opts);
     const syncnetsService = new SyncnetsService(config, clock, gossip, metadata, logger, metrics, opts);
 
     const peerManager = await PeerManager.init(

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -20,7 +20,7 @@ import {computeSubscribedSubnet} from "./util.js";
 
 const gossipType = GossipType.beacon_attestation;
 
-export enum DLLSubnetSource {
+export enum SubnetSource {
   committee = "committee",
   longLived = "long_lived",
 }
@@ -40,7 +40,7 @@ const NOT_ABLE_TO_FORM_STABLE_MESH_SEC = -1;
  * - Network call addCommitteeSubscriptions() from API calls
  * - Gossip handler checks shouldProcess to know if validator is aggregator
  */
-export class DLLAttnetsService implements IAttnetsService {
+export class AttnetsService implements IAttnetsService {
   /** Committee subnets - PeerManager must find peers for those */
   private committeeSubnets = new SubnetMap();
   /**
@@ -179,7 +179,7 @@ export class DLLAttnetsService implements IAttnetsService {
         if (dutiedSlot === clockSlot + this.opts.slotsToSubscribeBeforeAggregatorDuty) {
           // Trigger gossip subscription first, in batch
           if (dutiedInfo.size > 0) {
-            this.subscribeToSubnets(Array.from(dutiedInfo.keys()), DLLSubnetSource.committee);
+            this.subscribeToSubnets(Array.from(dutiedInfo.keys()), SubnetSource.committee);
           }
           // Then, register the subscriptions
           for (const subnet of dutiedInfo.keys()) {
@@ -276,7 +276,7 @@ export class DLLAttnetsService implements IAttnetsService {
     }
 
     // First, tell gossip to subscribe to the subnets if not connected already
-    this.subscribeToSubnets(newSubnets, DLLSubnetSource.longLived);
+    this.subscribeToSubnets(newSubnets, SubnetSource.longLived);
 
     // then update longLivedSubscriptions
     for (const subnet of toRemoveSubnets) {
@@ -289,7 +289,7 @@ export class DLLAttnetsService implements IAttnetsService {
     }
 
     // Only tell gossip to unsubsribe last, longLivedSubscriptions has the latest state
-    this.unsubscribeSubnets(toRemoveSubnets, this.clock.currentSlot, DLLSubnetSource.longLived);
+    this.unsubscribeSubnets(toRemoveSubnets, this.clock.currentSlot, SubnetSource.longLived);
     this.updateMetadata();
   }
 
@@ -300,7 +300,7 @@ export class DLLAttnetsService implements IAttnetsService {
   private unsubscribeExpiredCommitteeSubnets(slot: Slot): void {
     const expired = this.shortLivedSubscriptions.getExpired(slot);
     if (expired.length > 0) {
-      this.unsubscribeSubnets(expired, slot, DLLSubnetSource.committee);
+      this.unsubscribeSubnets(expired, slot, SubnetSource.committee);
     }
   }
 
@@ -333,7 +333,7 @@ export class DLLAttnetsService implements IAttnetsService {
    * Trigger a gossip subcription only if not already subscribed
    * shortLivedSubscriptions or longLivedSubscriptions should be updated right AFTER this called
    **/
-  private subscribeToSubnets(subnets: number[], src: DLLSubnetSource): void {
+  private subscribeToSubnets(subnets: number[], src: SubnetSource): void {
     const forks = getActiveForks(this.config, this.clock.currentEpoch);
     for (const subnet of subnets) {
       if (!this.shortLivedSubscriptions.has(subnet) && !this.longLivedSubscriptions.has(subnet)) {
@@ -349,7 +349,7 @@ export class DLLAttnetsService implements IAttnetsService {
    * Trigger a gossip un-subscription only if no-one is still subscribed
    * If unsubscribe long lived subnets, longLivedSubscriptions should be updated right BEFORE this called
    **/
-  private unsubscribeSubnets(subnets: number[], slot: Slot, src: DLLSubnetSource): void {
+  private unsubscribeSubnets(subnets: number[], slot: Slot, src: SubnetSource): void {
     // No need to unsubscribeTopic(). Return early to prevent repetitive extra work
     if (this.opts.subscribeAllSubnets) return;
 

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -14,12 +14,12 @@ import {Clock, IClock} from "../../../../src/util/clock.js";
 import {Eth2Gossipsub} from "../../../../src/network/gossip/gossipsub.js";
 import {MetadataController} from "../../../../src/network/metadata.js";
 import {testLogger} from "../../../utils/logger.js";
-import {DLLAttnetsService} from "../../../../src/network/subnets/dllAttnetsService.js";
+import {AttnetsService} from "../../../../src/network/subnets/attnetsService.js";
 import {CommitteeSubscription} from "../../../../src/network/subnets/interface.js";
 
 vi.mock("../../../../src/network/gossip/gossipsub.js");
 
-describe("DLLAttnetsService", () => {
+describe("AttnetsService", () => {
   const nodeId = bigIntToBytes(
     BigInt("88752428858350697756262172400162263450541348766581994718383409852729519486397"),
     32,
@@ -29,7 +29,7 @@ describe("DLLAttnetsService", () => {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const config = createBeaconConfig({ALTAIR_FORK_EPOCH}, ZERO_HASH);
   // const {SECONDS_PER_SLOT} = config;
-  let service: DLLAttnetsService;
+  let service: AttnetsService;
   let gossipStub: MockedObject<Eth2Gossipsub>;
   let metadata: MetadataController;
 
@@ -52,7 +52,7 @@ describe("DLLAttnetsService", () => {
     // load getCurrentSlot first, vscode not able to debug without this
     getCurrentSlot(config, Math.floor(Date.now() / 1000));
     metadata = new MetadataController({}, {config, onSetValue: () => null});
-    service = new DLLAttnetsService(config, clock, gossipStub, metadata, logger, null, nodeId, {
+    service = new AttnetsService(config, clock, gossipStub, metadata, logger, null, nodeId, {
       slotsToSubscribeBeforeAggregatorDuty: 2,
     });
   });


### PR DESCRIPTION
**Motivation**

Now the DLLAttnetsService is the only one attnet service we have so we should refactor to `AttnetsService` in preparation for an upcoming new attnet service

**Description**

A follow up of https://github.com/ChainSafe/lodestar/pull/6579#pullrequestreview-1960051566

cc @nflaig 
