### PR TITLE
feat: add token-file as an alias to configure keymanager token file

### DIFF
--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -102,6 +102,7 @@ export const keymanagerOptions: CliCommandOptions<KeymanagerArgs> = {
     group: "keymanager",
   },
   "keymanager.tokenFile": {
+    alias: ["tokenFile"],
     type: "string",
     description: "Path to file containing bearer token used for key manager API authentication",
     group: "keymanager",


### PR DESCRIPTION
**Motivation**

Follow up to https://github.com/ChainSafe/lodestar/pull/6525 which adds an alias that matches the spec value https://github.com/ethereum/keymanager-APIs/pull/74.

**Description**

Adds `--tokenFile` / `--token-file` as an alias to configure keymanager token file.

Note: yargs automatically supports both camel case and kebab (hyphen) case

**Steps to test or reproduce**

```sh
./lodestar validator --token-file /path/to/file
```
