### PR TITLE
fix: checkpoint state cache grafana panel labels

### DIFF
--- a/dashboards/lodestar_state_cache_regen.json
+++ b/dashboards/lodestar_state_cache_regen.json
@@ -452,10 +452,12 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
+          "editorMode": "code",
           "exemplar": false,
           "expr": "lodestar_cp_state_cache_size{}",
           "interval": "",
-          "legendFormat": "states",
+          "legendFormat": "states_{{type}}",
+          "range": true,
           "refId": "A"
         },
         {
@@ -463,11 +465,13 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
+          "editorMode": "code",
           "exemplar": false,
           "expr": "lodestar_cp_state_epoch_size",
           "hide": false,
           "interval": "",
-          "legendFormat": "epochs",
+          "legendFormat": "epochs_{{type}}",
+          "range": true,
           "refId": "B"
         }
       ],


### PR DESCRIPTION
**Motivation**

The checkpoint state cache labels are duplicate

<img width="845" alt="Screenshot 2024-04-01 at 16 37 54" src="https://github.com/ChainSafe/lodestar/assets/10568965/d77d095a-cc79-4be3-a0b4-f81844a39f31">


**Description**

Add `{{type}}` to labels

<img width="1309" alt="Screenshot 2024-04-01 at 16 42 41" src="https://github.com/ChainSafe/lodestar/assets/10568965/33650b87-4d1c-4bf4-949c-7cd4c87dfe69">
