### PR TITLE
test: update web3signer e2e tests to verify deneb signatures

### DIFF
--- a/packages/test-utils/src/externalSigner.ts
+++ b/packages/test-utils/src/externalSigner.ts
@@ -4,10 +4,10 @@ import {dirSync as tmpDirSync} from "tmp";
 import {GenericContainer, Wait, StartedTestContainer} from "testcontainers";
 import {ForkSeq} from "@lodestar/params";
 
-const web3signerVersion = "23.11.0";
+const web3signerVersion = "24.2.0";
 
 /** Till what version is the web3signer image updated for signature verification */
-const supportedForkSeq = ForkSeq.capella;
+const supportedForkSeq = ForkSeq.deneb;
 
 export type StartedExternalSigner = {
   container: StartedTestContainer;


### PR DESCRIPTION
**Motivation**

Ensure we are compatible with latest web3signer version and verify deneb signatures

**Description**

- update web3signer to latest version ([v24.2.0](https://github.com/Consensys/web3signer/releases/tag/24.2.0))
- verify deneb block signatures