### PR TITLE
refactor: export beacon utils to be reused by other packages

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -46,6 +46,9 @@
     },
     "./sync": {
       "import": "./lib/sync/index.js"
+    },
+    "./util": {
+      "import": "./lib/util/index.js"
     }
   },
   "typesVersions": {

--- a/packages/beacon-node/src/util/index.ts
+++ b/packages/beacon-node/src/util/index.ts
@@ -1,0 +1,2 @@
+//  Only export the functions which are useful for external packages and difficult to reproduce or mock
+export * from "./kzg.js";


### PR DESCRIPTION
**Motivation**

Make the packages and complex code more re-useable. 

**Description**

We need to use `kzg` implementation and trusted setup during the blobs testing on the CLI package and sim tests.

It would be difficult to maintain if we duplicate logic like `kzg` in different packages, so we have to export such utils. 

**Limit the utils export only to important ones, which are integral for application behavior.**


**Steps to test or reproduce**

- Run all tests 