### PR TITLE
test: make sure the docker container stopped 

### DIFF
--- a/packages/cli/test/utils/simulation/runner/DockerRunner.ts
+++ b/packages/cli/test/utils/simulation/runner/DockerRunner.ts
@@ -5,7 +5,6 @@ import {
   SpawnChildProcessOptions,
   execChildProcess,
   spawnChildProcess,
-  stopChildProcess,
   ChildProcessResolve,
 } from "@lodestar/test-utils";
 import {Job, JobOptions, RunnerEnv, RunnerType} from "../interfaces.js";
@@ -119,7 +118,9 @@ export class DockerRunner implements RunnerEnv<RunnerType.Docker> {
         if (childProcess === undefined) {
           return;
         }
-        await stopChildProcess(childProcess);
+        // TODO: Debug why stopping the process was not killing the container
+        // await stopChildProcess(childProcess);
+        await execChildProcess(`docker stop ${jobOption.id} --time 2 || true`, {pipeStdioToParent: true});
       },
     };
   }


### PR DESCRIPTION
**Motivation**

Cleanup the resources. 

**Description**

In some edge cases noticed that killing the process was not exiting the docker container. Reverting the logic and stopping the container works for both container and process which is running it. 

**Steps to test or reproduce**

- Run all tests