### PR TITLE
docs: add list of public endpoints to getting started page

### DIFF
--- a/docs/pages/getting-started/starting-a-node.md
+++ b/docs/pages/getting-started/starting-a-node.md
@@ -115,6 +115,7 @@ In case you really trust `checkpointSyncUrl` then you may skip providing `wssChe
 :::warning
 Please use this option very carefully (and at your own risk), a malicious server URL can put you on the wrong chain with a danger of you losing your funds by social engineering.
 If possible, validate your `wssCheckpoint` from multiple places (e.g. different client distributions) or from other trusted sources. This will highly reduce the risk of starting off on a malicious chain.
+This list of [public endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints/) maintained by the Ethereum community may be used for reference.
 :::
 
 **Taking too long to sync?**


### PR DESCRIPTION
**Motivation**

I found it frustrating not being able to start up a Lodestar node without having to google for public endpoints, which actually sent me to the docs of another CL client. Having to do that is much more error-prone than following a link from your docs.

**Description**

I added a link to the same public endpoints page linked from the docs of another major CL client.
I don't think an additional `at your own risk` is necessary here, since this link is already in the `warning` block that starts off with ` Please use this option very carefully (and at your own risk)`.