### PR TITLE
chore: fix CI failure due to recent merge from `unstable`

### DIFF
--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -179,10 +179,10 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       ForkSeq[fork] >= ForkSeq.electra
         ? "engine_newPayloadV6110"
         : ForkSeq[fork] >= ForkSeq.deneb
-        ? "engine_newPayloadV3"
-        : ForkSeq[fork] >= ForkSeq.capella
-          ? "engine_newPayloadV2"
-          : "engine_newPayloadV1";
+          ? "engine_newPayloadV3"
+          : ForkSeq[fork] >= ForkSeq.capella
+            ? "engine_newPayloadV2"
+            : "engine_newPayloadV1";
 
     const serializedExecutionPayload = serializeExecutionPayload(fork, executionPayload);
 
@@ -375,10 +375,10 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       ForkSeq[fork] >= ForkSeq.electra
         ? "engine_getPayloadV6110"
         : ForkSeq[fork] >= ForkSeq.deneb
-        ? "engine_getPayloadV3"
-        : ForkSeq[fork] >= ForkSeq.capella
-          ? "engine_getPayloadV2"
-          : "engine_getPayloadV1";
+          ? "engine_getPayloadV3"
+          : ForkSeq[fork] >= ForkSeq.capella
+            ? "engine_getPayloadV2"
+            : "engine_getPayloadV1";
     const payloadResponse = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]

--- a/packages/beacon-node/test/perf/chain/stateCache/updateUnfinalizedPubkeys.test.ts
+++ b/packages/beacon-node/test/perf/chain/stateCache/updateUnfinalizedPubkeys.test.ts
@@ -7,7 +7,7 @@ import bls from "@chainsafe/bls";
 import {ssz} from "@lodestar/types";
 import {type CachedBeaconStateAllForks, PubkeyIndexMap} from "@lodestar/state-transition";
 import {bytesToBigInt, intToBytes} from "@lodestar/utils";
-import {CheckpointStateCache, StateContextCache} from "../../../../src/chain/stateCache/index.js";
+import {InMemoryCheckpointStateCache, StateContextCache} from "../../../../src/chain/stateCache/index.js";
 import {generateCachedElectraState} from "../../../utils/state.js";
 
 // Benchmark date from Mon Nov 21 2023 - Intel Core i7-9750H @ 2.60Ghz
@@ -21,7 +21,7 @@ describe("updateUnfinalizedPubkeys perf tests", function () {
   const numCheckpointStateCache = 8;
   const numStateCache = 3 * 32;
 
-  let checkpointStateCache: CheckpointStateCache;
+  let checkpointStateCache: InMemoryCheckpointStateCache;
   let stateCache: StateContextCache;
 
   const unfinalizedPubkey2Index = generatePubkey2Index(0, Math.max.apply(null, numPubkeysToBeFinalizedCases));
@@ -35,7 +35,7 @@ describe("updateUnfinalizedPubkeys perf tests", function () {
         baseState.epochCtx.pubkey2index = new PubkeyIndexMap();
         baseState.epochCtx.index2pubkey = [];
 
-        checkpointStateCache = new CheckpointStateCache({});
+        checkpointStateCache = new InMemoryCheckpointStateCache({});
         stateCache = new StateContextCache({});
 
         for (let i = 0; i < numCheckpointStateCache; i++) {

--- a/packages/beacon-node/test/sim/electra-interop.test.ts
+++ b/packages/beacon-node/test/sim/electra-interop.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import assert from "node:assert";
 import {describe, it, vi, afterAll, afterEach} from "vitest";
 
 import {LogLevel, sleep} from "@lodestar/utils";
@@ -224,13 +225,13 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     }
 
     const actualDepositReceipt = payload.depositReceipts[0];
-    if (actualDepositReceipt !== depositReceiptB) {
-      throw Error(
-        `Deposit receipts mismatched. Expected: ${JSON.stringify(depositReceiptB)}, actual: ${JSON.stringify(
-          actualDepositReceipt
-        )}`
-      );
-    }
+    assert.deepStrictEqual(
+      actualDepositReceipt,
+      depositReceiptB,
+      `Deposit receipts mismatched. Expected: ${JSON.stringify(depositReceiptB)}, actual: ${JSON.stringify(
+        actualDepositReceipt
+      )}`
+    );
   });
 
   it("Post-merge, run for a few blocks", async function () {

--- a/packages/beacon-node/test/sim/electra-interop.test.ts
+++ b/packages/beacon-node/test/sim/electra-interop.test.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import {describe, it, vi, afterAll, afterEach} from "vitest";
-/* eslint-disable @typescript-eslint/naming-convention */
-import _ from "lodash";
+
 import {LogLevel, sleep} from "@lodestar/utils";
 import {ForkName, SLOTS_PER_EPOCH, UNSET_DEPOSIT_RECEIPTS_START_INDEX} from "@lodestar/params";
 import {electra, Epoch, Slot} from "@lodestar/types";
@@ -225,7 +224,7 @@ describe("executionEngine / ExecutionEngineHttp", function () {
     }
 
     const actualDepositReceipt = payload.depositReceipts[0];
-    if (!_.isEqual(actualDepositReceipt, depositReceiptB)) {
+    if (actualDepositReceipt !== depositReceiptB) {
       throw Error(
         `Deposit receipts mismatched. Expected: ${JSON.stringify(depositReceiptB)}, actual: ${JSON.stringify(
           actualDepositReceipt

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -57,6 +57,7 @@ const coveredTestRunners = [
 // ],
 // ```
 export const defaultSkipOpts: SkipOpts = {
+  skippedForks: ["eip6110"],
   // TODO: capella
   // BeaconBlockBody proof in lightclient is the new addition in v1.3.0-rc.2-hotfix
   // Skip them for now to enable subsequently

--- a/packages/beacon-node/test/unit/chain/rewards/blockRewards.test.ts
+++ b/packages/beacon-node/test/unit/chain/rewards/blockRewards.test.ts
@@ -89,10 +89,7 @@ describe("chain / rewards / blockRewards", () => {
       // Populate tree root caches of the state
       state.hashTreeRoot();
       cachedStateAltairPopulateCaches(state);
-      const calculatedBlockReward = await computeBlockRewards(
-        block.message,
-        state as unknown as CachedBeaconStateAllForks
-      );
+      const calculatedBlockReward = await computeBlockRewards(block.message, state as CachedBeaconStateAllForks);
       const {proposerIndex, total, attestations, syncAggregate, proposerSlashings, attesterSlashings} =
         calculatedBlockReward;
 
@@ -112,7 +109,7 @@ describe("chain / rewards / blockRewards", () => {
         expect(attesterSlashings).toBe(0);
       }
 
-      const postState = stateTransition(state as unknown as CachedBeaconStateAllForks, block, {
+      const postState = stateTransition(state as CachedBeaconStateAllForks, block, {
         executionPayloadStatus: ExecutionPayloadStatus.valid,
         dataAvailableStatus: DataAvailableStatus.available,
         verifyProposer: false,
@@ -140,7 +137,7 @@ describe("chain / rewards / blockRewards", () => {
     preState.hashTreeRoot();
     cachedStateAltairPopulateCaches(preState);
 
-    const postState = stateTransition(preState as unknown as CachedBeaconStateAllForks, block, {
+    const postState = stateTransition(preState as CachedBeaconStateAllForks, block, {
       executionPayloadStatus: ExecutionPayloadStatus.valid,
       dataAvailableStatus: DataAvailableStatus.available,
       verifyProposer: false,
@@ -154,7 +151,7 @@ describe("chain / rewards / blockRewards", () => {
 
     const calculatedBlockReward = await computeBlockRewards(
       block.message,
-      preState as unknown as CachedBeaconStateAllForks,
+      preState as CachedBeaconStateAllForks,
       postState
     );
     const {proposerIndex, total, attestations, syncAggregate, proposerSlashings, attesterSlashings} =

--- a/packages/beacon-node/test/unit/chain/rewards/blockRewards.test.ts
+++ b/packages/beacon-node/test/unit/chain/rewards/blockRewards.test.ts
@@ -89,7 +89,10 @@ describe("chain / rewards / blockRewards", () => {
       // Populate tree root caches of the state
       state.hashTreeRoot();
       cachedStateAltairPopulateCaches(state);
-      const calculatedBlockReward = await computeBlockRewards(block.message, state as CachedBeaconStateAllForks);
+      const calculatedBlockReward = await computeBlockRewards(
+        block.message,
+        state as unknown as CachedBeaconStateAllForks
+      );
       const {proposerIndex, total, attestations, syncAggregate, proposerSlashings, attesterSlashings} =
         calculatedBlockReward;
 
@@ -109,7 +112,7 @@ describe("chain / rewards / blockRewards", () => {
         expect(attesterSlashings).toBe(0);
       }
 
-      const postState = stateTransition(state as CachedBeaconStateAllForks, block, {
+      const postState = stateTransition(state as unknown as CachedBeaconStateAllForks, block, {
         executionPayloadStatus: ExecutionPayloadStatus.valid,
         dataAvailableStatus: DataAvailableStatus.available,
         verifyProposer: false,
@@ -137,7 +140,7 @@ describe("chain / rewards / blockRewards", () => {
     preState.hashTreeRoot();
     cachedStateAltairPopulateCaches(preState);
 
-    const postState = stateTransition(preState as CachedBeaconStateAllForks, block, {
+    const postState = stateTransition(preState as unknown as CachedBeaconStateAllForks, block, {
       executionPayloadStatus: ExecutionPayloadStatus.valid,
       dataAvailableStatus: DataAvailableStatus.available,
       verifyProposer: false,
@@ -151,7 +154,7 @@ describe("chain / rewards / blockRewards", () => {
 
     const calculatedBlockReward = await computeBlockRewards(
       block.message,
-      preState as CachedBeaconStateAllForks,
+      preState as unknown as CachedBeaconStateAllForks,
       postState
     );
     const {proposerIndex, total, attestations, syncAggregate, proposerSlashings, attesterSlashings} =

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -226,7 +226,7 @@ export class EpochCache {
    * eg. latest epoch = 105, latest finalized cp state epoch = 102
    * then the list will be (in terms of epoch) [103, 104, 105]
    */
-  private historicalValidatorLengths: immutable.List<number>;
+  historicalValidatorLengths: immutable.List<number>;
 
   constructor(data: {
     config: BeaconConfig;


### PR DESCRIPTION
Fix CI errors on `electra-fork` branch

## Motivation

Currently `electra-fork` branch has some CIs not passing due to the recent merge from `unstable`. This includes

1. Lint fail - `electra-interop.test.ts` imports `lodash` package, which was removed in `unstable`. See the job [log](https://github.com/ChainSafe/lodestar/actions/runs/8554667832/job/23473887535?pr=6528) for detail
2. Check types fail - `blockRewards.test.ts` has relies on `generatePerfTestCachedStateAltair()` to generate `CachedBeaconStateAltair` (I know this is bad and we need to fix this soon). `CachedBeaconStateAltair` is later casted as `CachedBeaconStateAllForks`. This is due to a private property named `historicalValidatorLengths` being added to `EpochCache`. See the job [log](https://github.com/ChainSafe/lodestar/actions/runs/8554667832/job/23473887770?pr=6528)
3. Spec test fail - We are using `v1.4.0-beta.6` for spec test which contains experimental fork `eip6110`. In `electra-fork` we remove `eip6110` fork and 6110 related code to fork `electra`. Spec test failed because it is looking for fork `eip6110` See the job [log](https://github.com/ChainSafe/lodestar/actions/runs/8554667832/job/23473887895?pr=6528)
4. e2e test fail - Attempt to download presets from electra fork, which doesn't exist until later spec version

## Description

1. Cease lodash dependency in `electra-interop.test.ts`
2. Remove private modifier for `Epoch.historicalValidatorLengths` 
3. Ignore `eip6110` spec test


## Long Term Solution
1. Stops `blockRewards.test.ts` from using `generatePerfTestCachedStateAltair()` when there is a better utility class to generate a well-formed state
2. Bump spec test version - Recent spec test release removes `eip6110` fork and adds `electra` fork