### PR TITLE
chore: fix heap allocations panel in VM + host dashboard

### DIFF
--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -291,7 +291,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by (space) ({__name__=~\"nodejs_heap_space_size_used_bytes|network_worker_nodejs_heap_space_size_used_bytes|discv5_worker_nodejs_heap_space_size_used_bytes\")",
+          "expr": "sum by (space) ({__name__=~\"nodejs_heap_space_size_used_bytes|network_worker_nodejs_heap_space_size_used_bytes|discv5_worker_nodejs_heap_space_size_used_bytes\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "{{space}}",


### PR DESCRIPTION
**Motivation**

Dashboard panel is broken because of an invalid promql query

![image](https://github.com/ChainSafe/lodestar/assets/38436224/e0e2d58b-0f6e-49cc-a2eb-7393c7ee909c)


**Description**

Fix promql query of heap allocations panel in VM + host dashboard
