### PR TITLE
fix: return 404 error if no aggregated attestation is available

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1067,7 +1067,13 @@ export function getValidatorApi({
 
       await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
-      const aggregate = chain.attestationPool.getAggregate(slot, attestationDataRoot);
+      const dataRootHex = toHexString(attestationDataRoot);
+      const aggregate = chain.attestationPool.getAggregate(slot, dataRootHex);
+
+      if (!aggregate) {
+        throw new ApiError(404, `No aggregated attestation for slot=${slot}, dataRoot=${dataRootHex}`);
+      }
+
       metrics?.production.producedAggregateParticipants.observe(aggregate.aggregationBits.getTrueBitIndexes().length);
 
       return {

--- a/packages/beacon-node/src/chain/opPools/attestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/attestationPool.ts
@@ -1,7 +1,7 @@
 import {PointFormat, Signature} from "@chainsafe/bls/types";
 import bls from "@chainsafe/bls";
-import {BitArray, toHexString} from "@chainsafe/ssz";
-import {phase0, Slot, Root, RootHex} from "@lodestar/types";
+import {BitArray} from "@chainsafe/ssz";
+import {phase0, Slot, RootHex} from "@lodestar/types";
 import {MapDef} from "@lodestar/utils";
 import {IClock} from "../../util/clock.js";
 import {InsertOutcome, OpPoolError, OpPoolErrorCode} from "./types.js";
@@ -128,12 +128,11 @@ export class AttestationPool {
   /**
    * For validator API to get an aggregate
    */
-  getAggregate(slot: Slot, dataRoot: Root): phase0.Attestation {
-    const dataRootHex = toHexString(dataRoot);
+  getAggregate(slot: Slot, dataRootHex: RootHex): phase0.Attestation | null {
     const aggregate = this.attestationByRootBySlot.get(slot)?.get(dataRootHex);
     if (!aggregate) {
       // TODO: Add metric for missing aggregates
-      throw Error(`No attestation for slot=${slot} dataRoot=${dataRootHex}`);
+      return null;
     }
 
     return fastToAttestation(aggregate);


### PR DESCRIPTION
**Motivation**

This API has caused a lot of confusing (https://github.com/ChainSafe/lodestar/issues/6631, https://github.com/ChainSafe/lodestar/issues/5553, https://github.com/ChainSafe/lodestar/issues/6419) due to how we currently handle the case if no aggregated attestation can be served to the client.
- we throw an internal server error (500) which will be logged as `error` with a verbose stack trace
- the log message talks about attestation but the issue is about not being able to serve the aggregated attestation

This error is somewhat expected if a validator client is connected to multiple beacon nodes as it might happen that the attestation for slot was not produced by the beacon node while the validator client could be requesting it later on due to the other (primary) beacon node being unhealthy.

This behavior has also recently been clarified in the spec, see https://github.com/ethereum/beacon-APIs/pull/380.
> A 404 error must be returned if no attestation is available for the requested `attestation_data_root`.

**Description**

Return 404 error if aggregated attestation is not available for slot / data root