### PR TITLE
fix: properly handle missing schema if route is not defined

### DIFF
--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -159,6 +159,6 @@ export class RestApiServer {
 }
 
 function getOperationId(req: FastifyRequest): string {
-  // Note: `routeSchema` will be `undefined` if route is not defined
-  return req.routeSchema?.operationId ?? "unknown";
+  // Note: `schema` will be `undefined` if route is not defined
+  return req.routeOptions.schema?.operationId ?? "unknown";
 }


### PR DESCRIPTION
**Motivation**

Follow up to previous PR https://github.com/ChainSafe/lodestar/pull/6626 which improves handling of missing schema if route is not defined.

The type provided by fastify is not correct as schema might be `undefined` which results in an uncaught exception if you call a route that does not exist.

We also had a type cast previously which was not correct and result in unlabeled metrics if someone called a route that does not exist.

**Description**

Properly handle missing schema if route is not defined