### PR TITLE
feat: track leaked libp2p connections

### DIFF
--- a/packages/beacon-node/src/network/core/metrics.ts
+++ b/packages/beacon-node/src/network/core/metrics.ts
@@ -112,7 +112,7 @@ export function createNetworkCoreMetrics(register: RegistryMetricCreator) {
         buckets: [0.001, 0.01, 0.1, 1],
       }),
     },
-    leakedConnectionCount: register.gauge({
+    leakedConnectionsCount: register.gauge({
       name: "lodestar_peer_manager_leaked_connections_count",
       help: "Total libp2p leaked connections detected by lodestar",
     }),

--- a/packages/beacon-node/src/network/core/metrics.ts
+++ b/packages/beacon-node/src/network/core/metrics.ts
@@ -112,6 +112,10 @@ export function createNetworkCoreMetrics(register: RegistryMetricCreator) {
         buckets: [0.001, 0.01, 0.1, 1],
       }),
     },
+    leakedConnectionCount: register.gauge({
+      name: "lodestar_peer_manager_leaked_connections_count",
+      help: "Total libp2p leaked connections detected by lodestar",
+    }),
 
     discovery: {
       peersToConnect: register.gauge({

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -509,7 +509,7 @@ export class PeerManager {
       for (const peerIdStr of this.connectedPeers.keys()) {
         if (!actualConnectedPeerIds.has(peerIdStr)) {
           this.connectedPeers.delete(peerIdStr);
-          this.metrics?.leakedConnectionCount.inc();
+          this.metrics?.leakedConnectionsCount.inc();
         }
       }
     }

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -504,11 +504,12 @@ export class PeerManager {
 
     // Prune connectedPeers map in case it leaks. It has happen in previous nodes,
     // disconnect is not always called for all peers
-    if (this.connectedPeers.size > connectedPeers.length * 2) {
+    if (this.connectedPeers.size > connectedPeers.length * 1.1) {
       const actualConnectedPeerIds = new Set(connectedPeers.map((peerId) => peerId.toString()));
       for (const peerIdStr of this.connectedPeers.keys()) {
         if (!actualConnectedPeerIds.has(peerIdStr)) {
           this.connectedPeers.delete(peerIdStr);
+          this.metrics?.leakedConnectionCount.inc();
         }
       }
     }


### PR DESCRIPTION
**Motivation**

Lodestar periodically prune leaked connections if our peer data is > 2x actual connections, and we don't track it while in the profile shown [here](https://github.com/ChainSafe/lodestar/pull/6556#issuecomment-2043250725) there are > 15k of leaked connections

**Description**

- Track it in `lodestar_peer_manager_leaked_connections_count` metric
- The constant of 2 is too big to me, if we increase max peer count to 110 it'd mean we only prune until we have 220 peer data. I think it makes sense to do the prune if peer data is > 10% of actual connections as the check is not too expensive there and it does not happen in every heartbeat
- Will do a follow up PR for Grafana once this PR is merged

part of #6595

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
