### PR TITLE
chore: upgrade to maintained action

### DIFF
--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -81,13 +81,13 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
           body_path: "CHANGELOG.md"
-          release_name: Release ${{ needs.tag.outputs.tag }}
+          name: Release ${{ needs.tag.outputs.tag }}
           prerelease: true
 
       - name: Change and commit version

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -87,13 +87,13 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ needs.tag.outputs.tag }}
           body_path: "CHANGELOG.md"
-          release_name: Release ${{ needs.tag.outputs.tag }}
+          name: Release ${{ needs.tag.outputs.tag }}
           prerelease: false
 
       # From https://github.com/lerna/lerna/issues/2404


### PR DESCRIPTION
**Motivation**

[create-release](https://github.com/actions/create-release) is not maintained anymore since 2021. Switch to the most used maintained one, [action-gh-release](https://github.com/softprops/action-gh-release). It will also allow to add files to release pages.