### PR TITLE
chore: add beacon node info log when publishing block

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -75,7 +75,7 @@ export function getBeaconBlockApi({
     const bodyRoot = toHex(chain.config.getForkTypes(slot).BeaconBlockBody.hashTreeRoot(signedBlock.message.body));
     const blockLocallyProduced =
       chain.producedBlockRoot.has(blockRoot) || chain.producedBlindedBlockRoot.has(blockRoot);
-    const valLogMeta = {broadcastValidation, blockRoot, bodyRoot, blockLocallyProduced, slot};
+    const valLogMeta = {slot, blockRoot, bodyRoot, broadcastValidation, blockLocallyProduced};
 
     switch (broadcastValidation) {
       case routes.beacon.BroadcastValidation.gossip: {
@@ -227,18 +227,18 @@ export function getBeaconBlockApi({
     const executionPayload = chain.producedBlockRoot.get(blockRoot);
     if (executionPayload !== undefined) {
       const source = ProducedBlockSource.engine;
-      chain.logger.debug("Reconstructing  signedBlockOrContents", {blockRoot, slot, source});
+      chain.logger.debug("Reconstructing  signedBlockOrContents", {slot, blockRoot, source});
 
       const contents = executionPayload
         ? chain.producedContentsCache.get(toHex(executionPayload.blockHash)) ?? null
         : null;
       const signedBlockOrContents = reconstructFullBlockOrContents(signedBlindedBlock, {executionPayload, contents});
 
-      chain.logger.info("Publishing assembled block", {blockRoot, slot, source});
+      chain.logger.info("Publishing assembled block", {slot, blockRoot, source});
       return publishBlock(signedBlockOrContents, opts);
     } else {
       const source = ProducedBlockSource.builder;
-      chain.logger.debug("Reconstructing  signedBlockOrContents", {blockRoot, slot, source});
+      chain.logger.debug("Reconstructing  signedBlockOrContents", {slot, blockRoot, source});
 
       const signedBlockOrContents = await reconstructBuilderBlockOrContents(chain, signedBlindedBlock);
 
@@ -246,7 +246,7 @@ export function getBeaconBlockApi({
       // by gossip
       //
       // see: https://github.com/ChainSafe/lodestar/issues/5404
-      chain.logger.info("Publishing assembled block", {blockRoot, slot, source});
+      chain.logger.info("Publishing assembled block", {slot, blockRoot, source});
       return publishBlock(signedBlockOrContents, {...opts, ignoreIfKnown: true});
     }
   };

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -183,6 +183,7 @@ export function getBeaconBlockApi({
 
     // TODO: Validate block
     metrics?.registerBeaconBlock(OpSource.api, seenTimestampSec, blockForImport.block.message);
+    chain.logger.info("Publishing block", valLogMeta);
     const publishPromises = [
       // Send the block, regardless of whether or not it is valid. The API
       // specification is very clear that this is the desired behaviour.

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -542,9 +542,9 @@ export function getValidatorApi({
       }
 
       const loggerContext = {
+        slot,
         fork,
         builderSelection,
-        slot,
         isBuilderEnabled,
         isEngineEnabled,
         strictFeeRecipientCheck,


### PR DESCRIPTION
**Motivation**

Similar to publish blinded block API, it would be nice to have an info log when block is being published
https://github.com/ChainSafe/lodestar/blob/669239be80b8dea985890359344ae3110e41e913/packages/beacon-node/src/api/impl/beacon/blocks/index.ts#L248-L249

**Description**

- Add info log when publishing block on beacon node
- Reorder log context to print slot first in produce and publish logs

**Note:** This log does not indicate that the block was published but rather that publishing has been started, for exact timings it would be required to look into gossip logs / metrics, and other debug logs