### PR TITLE
feat: add basic devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "yarn install",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -87,9 +87,9 @@ UID
 UPnP
 UTF
 VM
+VSCode
 Vitalik
 Vitest
-VSCode
 Wagyu
 api
 async

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -12,6 +12,7 @@ CTRL
 Casper
 Chai
 ChainSafe
+Codespaces
 Customizations
 DPoS
 DVs
@@ -88,6 +89,7 @@ UTF
 VM
 Vitalik
 Vitest
+VSCode
 Wagyu
 api
 async
@@ -117,6 +119,7 @@ ddos
 decrypt
 deserialization
 dev
+devcontainer
 devnet
 devnets
 devtools

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -87,7 +87,6 @@ UID
 UPnP
 UTF
 VM
-VSCode
 Vitalik
 Vitest
 Wagyu

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Contributing to tests:
 
 ## Devcontainer
 
-A [devcontainer](https://containers.dev/) [configuration](.devcontainer/devcontainer.json) is provided to help speed up linux based development environment setup. It will be used by [GitHub Codespaces](https://github.com/features/codespaces) or directly inside VSCode via your local through this [extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+A [devcontainer](https://containers.dev/) [configuration](.devcontainer/devcontainer.json) is provided to help speed up linux based development environment setup. It will be used by [GitHub Codespaces](https://github.com/features/codespaces) or directly inside VS Code via your local through this [extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 
 ### Common Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,10 @@ Contributing to tests:
   - Do not pull unpinned versions from DockerHub (use deterministic tag) or Github (checkout commit not branch).
   - Carefully design tests that depend on timing sensitive events like p2p network e2e tests. Consider that Github runners are significantly less powerful than your development environment.
 
+## Devcontainer
+
+A [devcontainer](https://containers.dev/) [configuration](.devcontainer/devcontainer.json) is provided to help speed up linux based development environment setup. It will be used by [GitHub Codespaces](https://github.com/features/codespaces) or directly inside VSCode via your local through this [extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+
 ### Common Issues
 
 **Error: [vitest] Cannot mock "../../src/db/repositories/index.js" because it is already loaded by "src/db/beacon.ts"**


### PR DESCRIPTION
**Motivation**

Ease setup for environment supporting [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers).
e.g. allows MacOS users to easily develop with vscode under linux via [docker](https://code.visualstudio.com/docs/devcontainers/containers) or remote via [ssh](https://code.visualstudio.com/docs/remote/ssh). Also improves the [Codespaces](https://github.com/features/codespaces) experience.

