### PR TITLE
fix: prune oldest slots first in aggregator tracker

### DIFF
--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -219,6 +219,8 @@ export class Network implements INetwork {
         this.aggregatorTracker.addAggregator(subscription.subnet, subscription.slot);
       }
     }
+    this.aggregatorTracker.prune();
+
     return this.core.prepareBeaconCommitteeSubnets(subscriptions);
   }
 

--- a/packages/beacon-node/src/network/processor/aggregatorTracker.ts
+++ b/packages/beacon-node/src/network/processor/aggregatorTracker.ts
@@ -28,7 +28,7 @@ export class AggregatorTracker {
 
   prune(): void {
     // We could also `pruneBySlot` as items before current slot are no longer
-    // relevant but due to small cache size (64), the simplest approach is to
+    // relevant but due to small cache size (64), the best approach is to
     // just prune the cache after a batch of subnet subscriptions is processed.
     pruneSetToMax(
       this.subnetAggregatorsBySlot,

--- a/packages/beacon-node/src/network/processor/aggregatorTracker.ts
+++ b/packages/beacon-node/src/network/processor/aggregatorTracker.ts
@@ -16,8 +16,12 @@ export class AggregatorTracker {
 
   addAggregator(subnet: SubnetId, slot: Slot): void {
     this.subnetAggregatorsBySlot.getOrDefault(slot).add(subnet);
-
-    pruneSetToMax(this.subnetAggregatorsBySlot, MAX_SLOTS_CACHED);
+    pruneSetToMax(
+      this.subnetAggregatorsBySlot,
+      MAX_SLOTS_CACHED,
+      // Prune the oldest slots first
+      (a, b) => a - b
+    );
   }
 
   shouldAggregate(subnet: SubnetId, slot: Slot): boolean {

--- a/packages/beacon-node/src/network/processor/aggregatorTracker.ts
+++ b/packages/beacon-node/src/network/processor/aggregatorTracker.ts
@@ -27,6 +27,9 @@ export class AggregatorTracker {
   }
 
   prune(): void {
+    // We could also `pruneBySlot` as items before current slot are no longer
+    // relevant but due to small cache size (64), the simplest approach is to
+    // just prune the cache after a batch of subnet subscriptions is processed.
     pruneSetToMax(
       this.subnetAggregatorsBySlot,
       MAX_SLOTS_CACHED,

--- a/packages/beacon-node/src/network/processor/aggregatorTracker.ts
+++ b/packages/beacon-node/src/network/processor/aggregatorTracker.ts
@@ -20,16 +20,18 @@ export class AggregatorTracker {
 
   addAggregator(subnet: SubnetId, slot: Slot): void {
     this.subnetAggregatorsBySlot.getOrDefault(slot).add(subnet);
+  }
 
+  shouldAggregate(subnet: SubnetId, slot: Slot): boolean {
+    return this.subnetAggregatorsBySlot.get(slot)?.has(subnet) === true;
+  }
+
+  prune(): void {
     pruneSetToMax(
       this.subnetAggregatorsBySlot,
       MAX_SLOTS_CACHED,
       // Prune the oldest slots first
       (a, b) => a - b
     );
-  }
-
-  shouldAggregate(subnet: SubnetId, slot: Slot): boolean {
-    return this.subnetAggregatorsBySlot.get(slot)?.has(subnet) === true;
   }
 }

--- a/packages/beacon-node/src/network/processor/aggregatorTracker.ts
+++ b/packages/beacon-node/src/network/processor/aggregatorTracker.ts
@@ -14,8 +14,13 @@ const MAX_SLOTS_CACHED = SLOTS_PER_EPOCH * 2;
 export class AggregatorTracker {
   private subnetAggregatorsBySlot = new MapDef<Slot, Set<SubnetId>>(() => new Set());
 
+  get maxSlotsCached(): number {
+    return MAX_SLOTS_CACHED;
+  }
+
   addAggregator(subnet: SubnetId, slot: Slot): void {
     this.subnetAggregatorsBySlot.getOrDefault(slot).add(subnet);
+
     pruneSetToMax(
       this.subnetAggregatorsBySlot,
       MAX_SLOTS_CACHED,

--- a/packages/beacon-node/test/unit/network/processor/aggregatorTracker.test.ts
+++ b/packages/beacon-node/test/unit/network/processor/aggregatorTracker.test.ts
@@ -1,5 +1,4 @@
 import {describe, it, expect, beforeEach} from "vitest";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {AggregatorTracker} from "../../../../src/network/processor/aggregatorTracker.js";
 
 describe("AggregatorTracker", () => {
@@ -19,11 +18,11 @@ describe("AggregatorTracker", () => {
   });
 
   it("should prune the oldest slots first when maximum cache size is reached", () => {
-    const maxSlots = SLOTS_PER_EPOCH * 2;
+    const {maxSlotsCached} = aggregatorTracker;
     const firstSlot = 0;
-    const lastSlot = firstSlot + maxSlots - 1;
+    const lastSlot = firstSlot + maxSlotsCached - 1;
     const subnet = 1;
-    const slots = Array.from({length: maxSlots}, (_, i) => firstSlot + i);
+    const slots = Array.from({length: maxSlotsCached}, (_, i) => firstSlot + i);
 
     // Slots should be inserted in random order
     for (let i = slots.length - 1; i > 0; i--) {

--- a/packages/beacon-node/test/unit/network/processor/aggregatorTracker.test.ts
+++ b/packages/beacon-node/test/unit/network/processor/aggregatorTracker.test.ts
@@ -38,6 +38,7 @@ describe("AggregatorTracker", () => {
     // This should prune the first two slots
     aggregatorTracker.addAggregator(subnet, lastSlot + 1);
     aggregatorTracker.addAggregator(subnet, lastSlot + 2);
+    aggregatorTracker.prune();
 
     expect(aggregatorTracker.shouldAggregate(subnet, firstSlot)).toBe(false);
     expect(aggregatorTracker.shouldAggregate(subnet, firstSlot + 1)).toBe(false);

--- a/packages/beacon-node/test/unit/network/processor/aggregatorTracker.test.ts
+++ b/packages/beacon-node/test/unit/network/processor/aggregatorTracker.test.ts
@@ -1,0 +1,54 @@
+import {describe, it, expect, beforeEach} from "vitest";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {AggregatorTracker} from "../../../../src/network/processor/aggregatorTracker.js";
+
+describe("AggregatorTracker", () => {
+  let aggregatorTracker: AggregatorTracker;
+
+  beforeEach(() => {
+    aggregatorTracker = new AggregatorTracker();
+  });
+
+  it("should keep track of aggregator for subnet / slot", () => {
+    const subnet = 1;
+    const slot = 1;
+
+    aggregatorTracker.addAggregator(subnet, slot);
+
+    expect(aggregatorTracker.shouldAggregate(subnet, slot)).toBe(true);
+  });
+
+  it("should prune the oldest slots first when maximum cache size is reached", () => {
+    const maxSlots = SLOTS_PER_EPOCH * 2;
+    const firstSlot = 0;
+    const lastSlot = firstSlot + maxSlots - 1;
+    const subnet = 1;
+    const slots = Array.from({length: maxSlots}, (_, i) => firstSlot + i);
+
+    // Slots should be inserted in random order
+    for (let i = slots.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [slots[i], slots[j]] = [slots[j], slots[i]];
+    }
+
+    // Fill up the cache to its maximum size
+    for (const slot of slots) {
+      aggregatorTracker.addAggregator(subnet, slot);
+    }
+
+    // This should prune the first two slots
+    aggregatorTracker.addAggregator(subnet, lastSlot + 1);
+    aggregatorTracker.addAggregator(subnet, lastSlot + 2);
+
+    expect(aggregatorTracker.shouldAggregate(subnet, firstSlot)).toBe(false);
+    expect(aggregatorTracker.shouldAggregate(subnet, firstSlot + 1)).toBe(false);
+
+    // Verify that all other slots are still available
+    for (let slot = firstSlot + 2; slot <= lastSlot + 2; slot++) {
+      expect(aggregatorTracker.shouldAggregate(subnet, slot)).toBeWithMessage(
+        true,
+        `expected aggregator for slot ${slot}`
+      );
+    }
+  });
+});

--- a/packages/utils/src/map.ts
+++ b/packages/utils/src/map.ts
@@ -82,13 +82,20 @@ export class Map2dArr<K1, V> {
 /**
  * Prune an arbitrary set removing the first keys to have a set.size === maxItems.
  * Returns the count of deleted items.
+ *
+ * Keys can be sorted by `compareFn` to get more control over which items to prune first
  */
-export function pruneSetToMax<T>(set: Set<T> | Map<T, unknown>, maxItems: number): number {
+export function pruneSetToMax<T>(
+  set: Set<T> | Map<T, unknown>,
+  maxItems: number,
+  compareFn?: (a: T, b: T) => number
+): number {
   let itemsToDelete = set.size - maxItems;
   const deletedItems = Math.max(0, itemsToDelete);
 
   if (itemsToDelete > 0) {
-    for (const key of set.keys()) {
+    const keys = compareFn ? Array.from(set.keys()).sort(compareFn) : set.keys();
+    for (const key of keys) {
       set.delete(key);
       itemsToDelete--;
       if (itemsToDelete <= 0) {


### PR DESCRIPTION
**Motivation**

Due to the fact the we are pruning based on FIFO it might happen that we prune a slot which is in the future and should not yet be pruned.

This is completely random as is depends on the order of which the validator client submits the subscriptions, current epoch vs. next epoch first, and the order of the items themselves. For example at the start of epoch 0, the client submits epoch 1 first, then epoch 0 and if there is an aggregator for each slot (likely with a lot of keys) then the cache is already full (64 items). Then at the start of epoch 1, some clients only submit for epoch 2 (next epoch) but this means we start pruning items of epoch 1, but that's the current epoch which should not yet be pruned.

While Lodestar calls [prepareBeaconCommitteeSubnet](https://github.com/ChainSafe/lodestar/blob/ae984f0f6079f78c2445f36ae2ac09c9e868197e/packages/beacon-node/src/api/impl/validator/index.ts#L1200) always for [current and next epoch](https://github.com/ChainSafe/lodestar/blob/ae984f0f6079f78c2445f36ae2ac09c9e868197e/packages/validator/src/services/attestationDuties.ts#L192-L196), other clients like Nimbus, Teku and Vouch do not, which might lead to the issue that Lodestar does not prepare an aggregated attestation (#6631, #6419), as at the time when the attestations are submitted via [submitPoolAttestations](https://github.com/ChainSafe/lodestar/blob/ae984f0f6079f78c2445f36ae2ac09c9e868197e/packages/beacon-node/src/api/impl/beacon/pool/index.ts#L53) the [aggregator check](https://github.com/ChainSafe/lodestar/blob/ae984f0f6079f78c2445f36ae2ac09c9e868197e/packages/beacon-node/src/api/impl/beacon/pool/index.ts#L75) will return false.

**Description**

Prune oldest slots first in aggregator tracker to ensure we only prune slots that are in the past.

**Alternative solution**

We could also increase the [max cache slots](https://github.com/ChainSafe/lodestar/blob/ae984f0f6079f78c2445f36ae2ac09c9e868197e/packages/beacon-node/src/network/processor/aggregatorTracker.ts#L8) to 3 epochs

Closes https://github.com/ChainSafe/lodestar/issues/6631
Closes https://github.com/ChainSafe/lodestar/issues/6419

