### PR TITLE
fix: head state regen in n-historical state

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -257,7 +257,7 @@ export class BeaconChain implements IBeaconChain {
             logger,
             clock,
             shufflingCache: this.shufflingCache,
-            getHeadState: this.getHeadState.bind(this),
+            blockStateCache: stateCache,
             bufferPool: new BufferPool(anchorState.type.tree_serializedSize(anchorState.node), metrics),
             datastore: fileDataStore
               ? // debug option if we want to investigate any issues with the DB

--- a/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
@@ -69,6 +69,21 @@ export class FIFOBlockStateCache implements BlockStateCache {
   }
 
   /**
+   * Get a seed state for state reload.
+   */
+  getSeedState(): CachedBeaconStateAllForks {
+    const firstValue = this.cache.values().next();
+    if (!firstValue.done) {
+      const firstState = firstValue.value;
+      // don't transfer cache because consumer only use this cache to reload another state from disc
+      return firstState.clone(true);
+    } else {
+      // should not happen
+      throw Error("No state in FIFOBlockStateCache");
+    }
+  }
+
+  /**
    * Get a state from this cache given a state root hex.
    */
   get(rootHex: RootHex, opts?: StateCloneOpts): CachedBeaconStateAllForks | null {

--- a/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
@@ -73,14 +73,14 @@ export class FIFOBlockStateCache implements BlockStateCache {
    */
   getSeedState(): CachedBeaconStateAllForks {
     const firstValue = this.cache.values().next();
-    if (!firstValue.done) {
-      const firstState = firstValue.value;
-      // don't transfer cache because consumer only use this cache to reload another state from disc
-      return firstState.clone(true);
-    } else {
+    if (firstValue.done) {
       // should not happen
       throw Error("No state in FIFOBlockStateCache");
     }
+
+    const firstState = firstValue.value;
+    // don't transfer cache because consumer only use this cache to reload another state from disc
+    return firstState.clone(true);
   }
 
   /**

--- a/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
@@ -69,7 +69,9 @@ export class FIFOBlockStateCache implements BlockStateCache {
   }
 
   /**
-   * Get a seed state for state reload.
+   * Get a seed state for state reload, this could be any states. The goal is to have the same
+   * base merkle tree for all BeaconState objects across application.
+   * See packages/state-transition/src/util/loadState/loadState.ts for more detail
    */
   getSeedState(): CachedBeaconStateAllForks {
     const firstValue = this.cache.values().next();

--- a/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
@@ -77,6 +77,14 @@ export class StateContextCache implements BlockStateCache {
     }
   }
 
+  /**
+   * Get a seed state for state reload.
+   * This is to conform to the api only as this cache is not used in n-historical state.
+   */
+  getSeedState(): CachedBeaconStateAllForks {
+    throw Error("Not implemented for StateContextCache");
+  }
+
   clear(): void {
     this.cache.clear();
     this.epochIndex.clear();

--- a/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/stateContextCache.ts
@@ -80,6 +80,7 @@ export class StateContextCache implements BlockStateCache {
   /**
    * Get a seed state for state reload.
    * This is to conform to the api only as this cache is not used in n-historical state.
+   * See ./fifoBlockStateCache.ts for implementation
    */
   getSeedState(): CachedBeaconStateAllForks {
     throw Error("Not implemented for StateContextCache");

--- a/packages/beacon-node/src/chain/stateCache/types.ts
+++ b/packages/beacon-node/src/chain/stateCache/types.ts
@@ -24,6 +24,10 @@ export interface BlockStateCache {
   get(rootHex: RootHex, opts?: StateCloneOpts): CachedBeaconStateAllForks | null;
   add(item: CachedBeaconStateAllForks): void;
   setHeadState(item: CachedBeaconStateAllForks | null): void;
+  /**
+   * Get a seed state for state reload.
+   */
+  getSeedState(): CachedBeaconStateAllForks;
   clear(): void;
   size: number;
   prune(headStateRootHex: RootHex): void;

--- a/packages/beacon-node/test/e2e/chain/stateCache/nHistoricalStates.test.ts
+++ b/packages/beacon-node/test/e2e/chain/stateCache/nHistoricalStates.test.ts
@@ -249,6 +249,7 @@ describe(
         // chain is not finalized, epoch 4 is in-memory so CP state at epoch 0 1 2 3 are persisted
         numEpochsPersisted: 4,
         // chain is NOT finalized end of test
+        // TODO: remove this after proposer boost reorg is fully implemented
         skip: true,
       },
     ];

--- a/packages/beacon-node/test/unit/chain/stateCache/fifoBlockStateCache.test.ts
+++ b/packages/beacon-node/test/unit/chain/stateCache/fifoBlockStateCache.test.ts
@@ -89,6 +89,7 @@ describe("FIFOBlockStateCache", function () {
 
   for (const {name, headState, addAsHeadArr, keptStates, prunedState} of testCases) {
     it(name, () => {
+      expect(cache.getSeedState().hashTreeRoot()).toEqual(state1.hashTreeRoot());
       // move to head this state
       cache.setHeadState(headState);
       expect(cache.size).toEqualWithMessage(2, "Size must be same as initial 2");

--- a/packages/beacon-node/test/unit/chain/stateCache/persistentCheckpointsCache.test.ts
+++ b/packages/beacon-node/test/unit/chain/stateCache/persistentCheckpointsCache.test.ts
@@ -10,7 +10,7 @@ import {ShufflingCache} from "../../../../src/chain/shufflingCache.js";
 import {testLogger} from "../../../utils/logger.js";
 import {getTestDatastore} from "../../../utils/chain/stateCache/datastore.js";
 import {CheckpointHex} from "../../../../src/chain/stateCache/types.js";
-import {toCheckpointHex} from "../../../../src/chain/index.js";
+import {FIFOBlockStateCache, toCheckpointHex} from "../../../../src/chain/index.js";
 
 describe("PersistentCheckpointStateCache", function () {
   let root0a: Buffer, root0b: Buffer, root1: Buffer, root2: Buffer;
@@ -87,7 +87,12 @@ describe("PersistentCheckpointStateCache", function () {
     fileApisBuffer = new Map();
     const datastore = getTestDatastore(fileApisBuffer);
     cache = new PersistentCheckpointStateCache(
-      {datastore, logger: testLogger(), shufflingCache: new ShufflingCache()},
+      {
+        datastore,
+        logger: testLogger(),
+        shufflingCache: new ShufflingCache(),
+        blockStateCache: new FIFOBlockStateCache({}, {}),
+      },
       {maxCPStateEpochsInMemory: 2, processLateBlock: true}
     );
     cache.add(cp0a, states["cp0a"]);
@@ -157,7 +162,12 @@ describe("PersistentCheckpointStateCache", function () {
       fileApisBuffer = new Map();
       const datastore = getTestDatastore(fileApisBuffer);
       cache = new PersistentCheckpointStateCache(
-        {datastore, logger: testLogger(), shufflingCache: new ShufflingCache()},
+        {
+          datastore,
+          logger: testLogger(),
+          shufflingCache: new ShufflingCache(),
+          blockStateCache: new FIFOBlockStateCache({}, {}),
+        },
         {maxCPStateEpochsInMemory: 2, processLateBlock: true}
       );
       cache.add(cp0a, states["cp0a"]);
@@ -229,7 +239,12 @@ describe("PersistentCheckpointStateCache", function () {
       fileApisBuffer = new Map();
       const datastore = getTestDatastore(fileApisBuffer);
       cache = new PersistentCheckpointStateCache(
-        {datastore, logger: testLogger(), shufflingCache: new ShufflingCache()},
+        {
+          datastore,
+          logger: testLogger(),
+          shufflingCache: new ShufflingCache(),
+          blockStateCache: new FIFOBlockStateCache({}, {}),
+        },
         {maxCPStateEpochsInMemory: 2, processLateBlock: true}
       );
       cache.add(cp0a, states["cp0a"]);
@@ -530,7 +545,12 @@ describe("PersistentCheckpointStateCache", function () {
       fileApisBuffer = new Map();
       const datastore = getTestDatastore(fileApisBuffer);
       cache = new PersistentCheckpointStateCache(
-        {datastore, logger: testLogger(), shufflingCache: new ShufflingCache()},
+        {
+          datastore,
+          logger: testLogger(),
+          shufflingCache: new ShufflingCache(),
+          blockStateCache: new FIFOBlockStateCache({}, {}),
+        },
         {maxCPStateEpochsInMemory: 1, processLateBlock: true}
       );
       cache.add(cp0a, states["cp0a"]);
@@ -797,7 +817,12 @@ describe("PersistentCheckpointStateCache", function () {
         fileApisBuffer = new Map();
         const datastore = getTestDatastore(fileApisBuffer);
         cache = new PersistentCheckpointStateCache(
-          {datastore, logger: testLogger(), shufflingCache: new ShufflingCache()},
+          {
+            datastore,
+            logger: testLogger(),
+            shufflingCache: new ShufflingCache(),
+            blockStateCache: new FIFOBlockStateCache({}, {}),
+          },
           {maxCPStateEpochsInMemory: 0, processLateBlock: true}
         );
         cache.add(cp0a, states["cp0a"]);
@@ -883,7 +908,12 @@ describe("PersistentCheckpointStateCache", function () {
         fileApisBuffer = new Map();
         const datastore = getTestDatastore(fileApisBuffer);
         cache = new PersistentCheckpointStateCache(
-          {datastore, logger: testLogger(), shufflingCache: new ShufflingCache()},
+          {
+            datastore,
+            logger: testLogger(),
+            shufflingCache: new ShufflingCache(),
+            blockStateCache: new FIFOBlockStateCache({}, {}),
+          },
           {maxCPStateEpochsInMemory: 0, processLateBlock: true}
         );
 


### PR DESCRIPTION
**Motivation**

- There was an error in holesky when I run with 0 epoch checkpoint state and 1 block state:
```
Apr-16 03:16:15.481[chain]            ^[[33mwarn^[[39m: Head state not available, triggering regen stateRoot=0x122ee97b202ea88964b50370e5ded3a700393ebaeb9003b32672bcc025655841
Apr-16 03:16:16.841[chain]           ^[[34mdebug^[[39m: Error get or reload state epoch=45141, rootHex=0x22f307ee9f83f0b114dff680f8820860975d12871211f4127cd3217b7a1ba1eb - headState does not exist for head root=0x8cd7a19301eef803ceda3dfc51a0758ff348d6f5832d81843949a00b7702ae2f slot=1444579
Apr-16 03:16:16.841[chain]           ^[[31merror^[[39m: Error on head state regen - REGEN_ERROR_NO_SEED_STATE
```
- When there is a reorg that caused head state to be regen and reloaded, persistent checkpoint state cache try to load a seed state, and since it was configed as 0 epoch retained, it gets head state for seed state and head state is not available. We need to break this circular dependency

**Description**

- New `getSeedState()` api in block state cache returning 1st state to guarantee we can always get one
- This is only needed for 0 epoch checkpoint state cache, we can actually get through it by limiting retained epoch to be at least 1. But I'd like to test n-historical flag with only 1 block state in memory to cause the node to reload multiple times in different networks before we go production

part of #5968
