### PR TITLE
docs: remove description prefix from CLI options

### DIFF
--- a/packages/cli/docsgen/markdown.ts
+++ b/packages/cli/docsgen/markdown.ts
@@ -91,7 +91,7 @@ function renderOption(optionName: string, option: CliOptionDefinition): string |
   if (option.hidden) return;
 
   const commandOption = [`#### \`--${optionName}\``];
-  if (option.description) commandOption.push(`description: ${sanitizeDescription(option.description)}`);
+  if (option.description) commandOption.push(`${sanitizeDescription(option.description)}`);
 
   if (option.demandOption === true) {
     commandOption.push("required: true");


### PR DESCRIPTION
**Motivation**

It seems unnecessary that we prefix the description with `description:`, should be clear from context that this is the description of the CLI option, and I think it supports readability to remove it.

With description:

![image](https://github.com/ChainSafe/lodestar/assets/38436224/5104531f-3221-445d-a892-72b619a916a9)

Without description:

![image](https://github.com/ChainSafe/lodestar/assets/38436224/b98eea8f-c496-49e8-be5f-0487717bb5bf)


**Description**

Remove `description:` prefix from description of CLI options, for everything else the prefix adds important information.