### PR TITLE
fix: convert getStateV2 response to Buffer without memory copy

### DIFF
--- a/packages/api/src/beacon/server/debug.ts
+++ b/packages/api/src/beacon/server/debug.ts
@@ -39,7 +39,7 @@ export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerR
           const version = config.getForkName(slot);
           void res.header("Eth-Consensus-Version", version);
           // Fastify 3.x.x will automatically add header `Content-Type: application/octet-stream` if Buffer
-          return Buffer.from(response);
+          return Buffer.from(response.buffer, response.byteOffset, response.byteLength);
         } else {
           void res.header("Eth-Consensus-Version", response.version);
           return returnTypes.getStateV2.toJson(response);


### PR DESCRIPTION
**Motivation**

Improve fetching state as SSZ response, and reduce memory increase per request.

Currently we copy the underlying `ArrayBuffer` when converting the serialized state (`Uint8Array`) to a `Buffer` when returning it in the response.

The Buffer conversion is required by Fastify but newer versions will [do this internally](https://github.com/fastify/fastify/blob/13f9b6eb9083e5f5dcd8de5895adc81101603db4/lib/reply.js#L186) in an efficient way already, so we can even just return the `Uint8Array` in the handler.

**Description**

Convert `getStateV2` response to `Buffer` without memory copy

**Benchmarks**

From https://github.com/ChainSafe/lodestar/compare/unstable...nflaig/bench-buffer-from
```sh
Buffer utils
✔ Buffer.from - copy                  7.286412 ops/s    137.2418 ms/op   x1.024         38 runs   5.82 s
✔ Buffer.from - no copy                1117318 ops/s    895.0000 ns/op   x0.982     723013 runs   1.11 s
✔ Buffer.from - no copy with offset    1179245 ops/s    848.0000 ns/op        -    2699558 runs   3.85 s
```

This should also reduce GC after fetching state but don't have good metrics to showcase here.

---

We generally might also wanna review our usage of `Buffer.from`, e.g. here it's not quite clear why we even convert to Buffer
https://github.com/ChainSafe/lodestar/blob/252fd2f50a7e759d53983286dcd89f9e7e8d5f60/packages/validator/src/slashingProtection/block/blockBySlotRepository.ts#L57

Or if we know it safe to not copy memory as it won't be mutated further, we can just convert to Buffer without memory copy.