### PR TITLE
chore: n-historical state - track state persist count per epoch

### DIFF
--- a/dashboards/lodestar_state_cache_regen.json
+++ b/dashboards/lodestar_state_cache_regen.json
@@ -1309,7 +1309,48 @@
           "mappings": [],
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "count_per_epoch"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "count_per_epoch"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -1356,6 +1397,19 @@
           "legendFormat": "sec_from_slot",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(lodestar_cp_state_cache_state_persist_seconds_from_slot_count[$rate_interval]) * 384",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "count_per_epoch",
+          "range": true,
+          "refId": "C"
         }
       ],
       "title": "State persist",


### PR DESCRIPTION
**Motivation**

- This is in n-historical state configuration, starting from #6620 we may persist more than 1 checkpoint state per epoch

**Description**

- Track persist count per epoch in grafana

Closes #5968

<img width="1332" alt="Screenshot 2024-04-23 at 16 18 08" src="https://github.com/ChainSafe/lodestar/assets/10568965/ac3a9913-df61-439c-9274-c12ef758abb2">
