### PR TITLE
feat: check aggregationBits length of `SignedAggregateAndProof` in gossip validation

### DIFF
--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -157,7 +157,7 @@ async function validateAggregateAndProof(
     ? cachedAttData.committeeIndices
     : getCommitteeIndices(shuffling, attSlot, attIndex);
 
-  // [IGNORE] The number of aggregation bits matches the committee size
+  // [REJECT] The number of aggregation bits matches the committee size
   // -- i.e. `len(aggregation_bits) == len(get_beacon_committee(state, aggregate.data.slot, index))`.
   if (aggregate.aggregationBits.bitLen !== committeeIndices.length) {
     throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS});

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -127,6 +127,9 @@ async function validateAggregateAndProof(
   // and non-gossip sources) (a client MAY queue attestations for processing once block is retrieved).
   // Lighthouse doesn't check maxSkipSlots option here but Lodestar wants to be more strict
   // to be more DOS protection
+
+  // [REJECT] The aggregate attestation's target block is an ancestor of the block named in the LMD vote
+  // -- i.e. `get_checkpoint_block(store, aggregate.data.beacon_block_root, aggregate.data.target.epoch) == aggregate.data.target.root`
   const attHeadBlock = verifyHeadBlockAndTargetRoot(
     chain,
     attData.beaconBlockRoot,
@@ -148,10 +151,17 @@ async function validateAggregateAndProof(
     RegenCaller.validateGossipAttestation
   );
 
+  // [REJECT] The committee index is within the expected range
+  // -- i.e. data.index < get_committee_count_per_slot(state, data.target.epoch)
   const committeeIndices = cachedAttData
     ? cachedAttData.committeeIndices
     : getCommitteeIndices(shuffling, attSlot, attIndex);
 
+  // [IGNORE] The number of aggregation bits matches the committee size
+  // -- i.e. `len(aggregation_bits) == len(get_beacon_committee(state, aggregate.data.slot, index))`.
+  if (aggregate.aggregationBits.bitLen !== committeeIndices.length) {
+    throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS});
+  }
   const attestingIndices = aggregate.aggregationBits.intersectValues(committeeIndices);
   const indexedAttestation: phase0.IndexedAttestation = {
     attestingIndices,

--- a/packages/beacon-node/test/unit/chain/validation/aggregateAndProof.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/aggregateAndProof.test.ts
@@ -1,4 +1,4 @@
-import {toHexString} from "@chainsafe/ssz";
+import {BitArray, toHexString} from "@chainsafe/ssz";
 import {describe, it} from "vitest";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {phase0, ssz} from "@lodestar/types";
@@ -136,6 +136,18 @@ describe("chain / validation / aggregateAndProof", () => {
     signedAggregateAndProof.message.aggregate.data.index = attIndex - 1;
 
     await expectError(chain, signedAggregateAndProof, AttestationErrorCode.AGGREGATOR_NOT_IN_COMMITTEE);
+  });
+
+  it("WRONG_NUMBER_OF_AGGREGATION_BITS", async () => {
+    const attIndex = 1;
+    const {chain, signedAggregateAndProof} = getValidData({attIndex});
+    const {aggregationBits} = signedAggregateAndProof.message.aggregate;
+    signedAggregateAndProof.message.aggregate.aggregationBits = new BitArray(
+      aggregationBits.uint8Array,
+      aggregationBits.bitLen + 1
+    );
+
+    await expectError(chain, signedAggregateAndProof, AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS);
   });
 
   it("INVALID_SIGNATURE - selection proof sig", async () => {


### PR DESCRIPTION
New validation rule has been added for `beacon_aggregate_and_proof` as per ethereum/consensus-specs#3552


This PR aims to comply with the new validation rule as well as adding comments for existed validations 