### PR TITLE
chore: update references to consensus spec to v1.4.0

### DIFF
--- a/packages/beacon-node/README.md
+++ b/packages/beacon-node/README.md
@@ -1,7 +1,7 @@
 # Lodestar
 
 [![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/aMxzVcr)
-[![Eth Consensus Spec v1.1.10](https://img.shields.io/badge/ETH%20consensus--spec-1.1.10-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.1.10)
+[![Eth Consensus Spec v1.4.0](https://img.shields.io/badge/ETH%20consensus--spec-1.4.0-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0)
 ![ES Version](https://img.shields.io/badge/ES-2021-yellow)
 ![Node Version](https://img.shields.io/badge/node-20.x-green)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,13 +19,13 @@ Command line tool for Lodestar
 We have an experimental new CLI called `lodestar` which currently provides a subset of the `lodestar` CLI functionality.
 
 Here's a quick list of the available CLI commands:
-| Command                    | Description                                                                              |
-| -------------------------- | ---------------------------------------------------------------------------------------- |
-| `./bin/lodestar init`      | Write a configuration and network identity to disk, by default `./.lodestar`             |
-| `./bin/lodestar beacon`    | Run a beacon node using a configuration from disk, by default `./.lodestar`              |
-| `./bin/lodestar account`   | Run various sub-commands for creating/managing Ethereum Consensus accounts               |
-| `./bin/lodestar validator` | Run one or more validator clients                                                        |
-| `./bin/lodestar dev`       | Quickly bootstrap a beacon node and multiple validators. Use for development and testing |
+| Command | Description |
+| - | - |
+| `./bin/lodestar init` | Write a configuration and network identity to disk, by default `./.lodestar`|
+|`./bin/lodestar beacon` | Run a beacon node using a configuration from disk, by default `./.lodestar`|
+|`./bin/lodestar account` | Run various sub-commands for creating/managing Ethereum Consensus accounts|
+|`./bin/lodestar validator` | Run one or more validator clients|
+|`./bin/lodestar dev` | Quickly bootstrap a beacon node and multiple validators. Use for development and testing|
 Append `--help` to any of these commands to print out all options for each command.
 
 For full documentation on cli commands and options, see the [Command Line Reference](https://chainsafe.github.io/lodestar/reference/cli/)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,7 +1,7 @@
 # Command Line Interface for Lodestar
 
 [![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/aMxzVcr)
-[![Eth Consensus Spec v1.1.10](https://img.shields.io/badge/ETH%20consensus--spec-1.1.10-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.1.10)
+[![Eth Consensus Spec v1.4.0](https://img.shields.io/badge/ETH%20consensus--spec-1.4.0-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0)
 ![ES Version](https://img.shields.io/badge/ES-2021-yellow)
 ![Node Version](https://img.shields.io/badge/node-12.x-green)
 
@@ -19,13 +19,13 @@ Command line tool for Lodestar
 We have an experimental new CLI called `lodestar` which currently provides a subset of the `lodestar` CLI functionality.
 
 Here's a quick list of the available CLI commands:
-| Command | Description |
-| - | - |
-| `./bin/lodestar init` | Write a configuration and network identity to disk, by default `./.lodestar`|
-|`./bin/lodestar beacon` | Run a beacon node using a configuration from disk, by default `./.lodestar`|
-|`./bin/lodestar account` | Run various sub-commands for creating/managing Ethereum Consensus accounts|
-|`./bin/lodestar validator` | Run one or more validator clients|
-|`./bin/lodestar dev` | Quickly bootstrap a beacon node and multiple validators. Use for development and testing|
+| Command                    | Description                                                                              |
+| -------------------------- | ---------------------------------------------------------------------------------------- |
+| `./bin/lodestar init`      | Write a configuration and network identity to disk, by default `./.lodestar`             |
+| `./bin/lodestar beacon`    | Run a beacon node using a configuration from disk, by default `./.lodestar`              |
+| `./bin/lodestar account`   | Run various sub-commands for creating/managing Ethereum Consensus accounts               |
+| `./bin/lodestar validator` | Run one or more validator clients                                                        |
+| `./bin/lodestar dev`       | Quickly bootstrap a beacon node and multiple validators. Use for development and testing |
 Append `--help` to any of these commands to print out all options for each command.
 
 For full documentation on cli commands and options, see the [Command Line Reference](https://chainsafe.github.io/lodestar/reference/cli/)

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@lodestar/config)](https://www.npmjs.com/package/@lodestar/config)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Eth Consensus Spec v1.1.10](https://img.shields.io/badge/ETH%20consensus--spec-1.1.10-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.1.10)
+[![Eth Consensus Spec v1.4.0](https://img.shields.io/badge/ETH%20consensus--spec-1.4.0-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0)
 ![ES Version](https://img.shields.io/badge/ES-2021-yellow)
 ![Node Version](https://img.shields.io/badge/node-12.x-green)
 

--- a/packages/flare/README.md
+++ b/packages/flare/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@lodestar/flare)](https://www.npmjs.com/package/@lodestar/flare)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Eth Consensus Spec v1.1.10](https://img.shields.io/badge/ETH%20consensus--spec-1.1.10-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.1.10)
+[![Eth Consensus Spec v1.4.0](https://img.shields.io/badge/ETH%20consensus--spec-1.4.0-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0)
 ![ES Version](https://img.shields.io/badge/ES-2021-yellow)
 ![Node Version](https://img.shields.io/badge/node-12.x-green)
 

--- a/packages/light-client/README.md
+++ b/packages/light-client/README.md
@@ -9,7 +9,7 @@ The evolution of light clients is emblematic of the broader trajectory of Ethere
 ## Prerequisites
 
 [![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/aMxzVcr)
-[![Eth Consensus Spec v1.1.10](https://img.shields.io/badge/ETH%20consensus--spec-1.1.10-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.1.10)
+[![Eth Consensus Spec v1.4.0](https://img.shields.io/badge/ETH%20consensus--spec-1.4.0-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0)
 ![ES Version](https://img.shields.io/badge/ES-2021-yellow)
 ![Node Version](https://img.shields.io/badge/node-16.x-green)
 ![Yarn](https://img.shields.io/badge/yarn-%232C8EBB.svg?style=for-the-badge&logo=yarn&logoColor=white)

--- a/packages/params/README.md
+++ b/packages/params/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@lodestar/types)](https://www.npmjs.com/package/@lodestar/types)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Eth Consensus Spec v1.1.10](https://img.shields.io/badge/ETH%20consensus--spec-1.1.10-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.1.10)
+[![Eth Consensus Spec v1.4.0](https://img.shields.io/badge/ETH%20consensus--spec-1.4.0-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0)
 ![ES Version](https://img.shields.io/badge/ES-2021-yellow)
 ![Node Version](https://img.shields.io/badge/node-20.x-green)
 

--- a/packages/state-transition/README.md
+++ b/packages/state-transition/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@lodestar/state-transition)](https://www.npmjs.com/package/@lodestar/state-transition)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Eth Consensus Spec v1.1.10](https://img.shields.io/badge/ETH%20consensus--spec-1.1.10-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.1.10)
+[![Eth Consensus Spec v1.4.0](https://img.shields.io/badge/ETH%20consensus--spec-1.4.0-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0)
 ![ES Version](https://img.shields.io/badge/ES-2021-yellow)
 ![Node Version](https://img.shields.io/badge/8.x-green)
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@lodestar/types)](https://www.npmjs.com/package/@lodestar/types)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Eth Consensus Spec v1.1.10](https://img.shields.io/badge/ETH%20consensus--spec-1.1.10-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.1.10)
+[![Eth Consensus Spec v1.4.0](https://img.shields.io/badge/ETH%20consensus--spec-1.4.0-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0)
 ![ES Version](https://img.shields.io/badge/ES-2021-yellow)
 ![Node Version](https://img.shields.io/badge/node-20.x-green)
 

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -1,7 +1,7 @@
 # Lodestar Validator
 
 [![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/aMxzVcr)
-[![Eth Consensus Spec v1.1.10](https://img.shields.io/badge/ETH%20consensus--spec-1.1.10-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.1.10)
+[![Eth Consensus Spec v1.4.0](https://img.shields.io/badge/ETH%20consensus--spec-1.4.0-blue)](https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0)
 ![ES Version](https://img.shields.io/badge/ES-2021-yellow)
 ![Node Version](https://img.shields.io/badge/node-20.x-green)
 


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/6127

**Description**

Update references to consensus spec to [v1.4.0](https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0)