### PR TITLE
feat: add arm64 binary support

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -27,15 +27,18 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
-      # Install yarn for arm64 as currently it's not part of the provided image
-      # See https://github.com/github-early-access/arm-runners-beta/issues/5
-      - name: Install yarn
+      - name: Install arm64 specifics
         if: matrix.arch == 'arm64'
         run: |-
+          # Install missing yarn
+          # See https://github.com/github-early-access/arm-runners-beta/issues/5
           curl -fsSL --create-dirs -o $HOME/bin/yarn \
           https://github.com/yarnpkg/yarn/releases/download/v1.22.22/yarn-1.22.22.js
           chmod +x $HOME/bin/yarn
           echo "$HOME/bin" >> $GITHUB_PATH
+          # Install missing build-essential
+          sudo apt-get update
+          sudo apt-get install -y build-essential
       - uses: "./.github/actions/setup-and-build"
         with:
           node: 20

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -27,6 +27,13 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
+      - name: Install yarn
+        if: matrix.arch == 'arm64'
+        run: |-
+          curl -fsSL --create-dirs -o $HOME/bin/yarn \
+          https://github.com/yarnpkg/yarn/releases/download/v1.22.22/yarn-1.22.22.js
+          chmod +x $HOME/bin/yarn
+          echo "$HOME/bin" >> $GITHUB_PATH
       - uses: "./.github/actions/setup-and-build"
         with:
           node: 20

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -19,9 +19,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            build: |
-              npx caxa -m "Unpacking Lodestar binary, please wait..." -e "dashboards/**" -e "docs/**" -D -p "yarn install --frozen-lockfile --production" --input . --output "lodestar" -- "{{caxa}}/node_modules/.bin/node" "--max-old-space-size=8192" "{{caxa}}/node_modules/.bin/lodestar"
-              tar -czf "dist/lodestar-${{ inputs.version }}-linux-amd64.tar.gz" "lodestar"
+            platform: linux
+            arch: amd64
+          - os: lodestar-arm64-runner
+            platform: linux
+            arch: arm64
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +33,8 @@ jobs:
       - run: |
           mkdir -p dist
           yarn global add caxa@3.0.1
-          ${{ matrix.build }}
+          npx caxa -m "Unpacking Lodestar binary, please wait..." -e "dashboards/**" -e "docs/**" -D -p "yarn install --frozen-lockfile --production" --input . --output "lodestar" -- "{{caxa}}/node_modules/.bin/node" "--max-old-space-size=8192" "{{caxa}}/node_modules/.bin/lodestar"
+          tar -czf "dist/lodestar-${{ inputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz" "lodestar"
       - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
+      # Install yarn for arm64 as currently it's not part of the provided image
+      # See https://github.com/github-early-access/arm-runners-beta/issues/5
       - name: Install yarn
         if: matrix.arch == 'arm64'
         run: |-


### PR DESCRIPTION
**Motivation**

Add `arm64` binary support. Those binaries are generated and published during a release publication.
Tested on `linux arm64`, works fine. A test binary can be found [here](https://github.com/ChainSafe/lodestar/actions/runs/8847869356/artifacts/1450708201)
