### PR TITLE
docs: fix plausible domain

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -106,7 +106,7 @@ const config: Config = {
       maxHeadingLevel: 5,
     },
   } satisfies Preset.ThemeConfig,
-  scripts: [{src: "https://plausible.io/js/script.js", defer: true, "data-domain": "chainsafe.github.io/lodestar/"}],
+  scripts: [{src: "https://plausible.io/js/script.js", defer: true, "data-domain": "chainsafe.github.io/lodestar"}],
 };
 
 export default config;


### PR DESCRIPTION
**Motivation**

Make sure plausible receive events.

**Description**

`plausible` expects exact domain matching based on what has been provided during account creation.