### PR TITLE
ci: add paths-ignore to workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,6 @@ on:
       - unstable
       - benchmark # For debugging
     paths-ignore:
-      - 'assets/**'
       - 'dashboards/**'
       - 'docs/**'
   pull_request:
@@ -22,7 +21,6 @@ on:
       - stable
       - unstable
     paths-ignore:
-      - 'assets/**'
       - 'dashboards/**'
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,10 +13,18 @@ on:
       - stable
       - unstable
       - benchmark # For debugging
+    paths-ignore:
+      - 'assets/**'
+      - 'dashboards/**'
+      - 'docs/**'
   pull_request:
     branches:
       - stable
       - unstable
+    paths-ignore:
+      - 'assets/**'
+      - 'dashboards/**'
+      - 'docs/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -4,7 +4,13 @@ on:
   push:
     # We intentionally don't run push on feature branches. See PR for rational.
     branches: [unstable, stable]
+    paths-ignore:
+      - 'assets/**'
+      - 'dashboards/**'
   pull_request:
+    paths-ignore:
+      - 'assets/**'
+      - 'dashboards/**'
 
 jobs:
   build:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -5,11 +5,9 @@ on:
     # We intentionally don't run push on feature branches. See PR for rational.
     branches: [unstable, stable]
     paths-ignore:
-      - 'assets/**'
       - 'dashboards/**'
   pull_request:
     paths-ignore:
-      - 'assets/**'
       - 'dashboards/**'
 
 jobs:

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches:
       - unstable
+    paths-ignore:
+      - 'assets/**'
+      - 'dashboards/**'
+      - 'docs/**'
 
 jobs:
   npm:

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - unstable
     paths-ignore:
-      - 'assets/**'
       - 'dashboards/**'
       - 'docs/**'
 

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -9,7 +9,15 @@ on:
   push:
     # We intentionally don't run push on feature branches. See PR for rational.
     branches: [unstable, stable]
+    paths-ignore:
+      - 'assets/**'
+      - 'dashboards/**'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - 'assets/**'
+      - 'dashboards/**'
+      - 'docs/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -10,12 +10,10 @@ on:
     # We intentionally don't run push on feature branches. See PR for rational.
     branches: [unstable, stable]
     paths-ignore:
-      - 'assets/**'
       - 'dashboards/**'
       - 'docs/**'
   pull_request:
     paths-ignore:
-      - 'assets/**'
       - 'dashboards/**'
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -9,7 +9,15 @@ on:
   push:
     # We intentionally don't run push on feature branches. See PR for rational.
     branches: [unstable, stable]
+    paths-ignore:
+      - 'assets/**'
+      - 'dashboards/**'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - 'assets/**'
+      - 'dashboards/**'
+      - 'docs/**'
   workflow_dispatch:
     inputs:
       debug:

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -10,12 +10,10 @@ on:
     # We intentionally don't run push on feature branches. See PR for rational.
     branches: [unstable, stable]
     paths-ignore:
-      - 'assets/**'
       - 'dashboards/**'
       - 'docs/**'
   pull_request:
     paths-ignore:
-      - 'assets/**'
       - 'dashboards/**'
       - 'docs/**'
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,9 @@ on:
     # We intentionally don't run push on feature branches. See PR for rational.
     branches: [unstable, stable]
     paths-ignore:
-      - 'assets/**'
-      - 'dashboards/**'
       - 'docs/**'
   pull_request:
     paths-ignore:
-      - 'assets/**'
-      - 'dashboards/**'
       - 'docs/**'
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,15 @@ on:
   push:
     # We intentionally don't run push on feature branches. See PR for rational.
     branches: [unstable, stable]
+    paths-ignore:
+      - 'assets/**'
+      - 'dashboards/**'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - 'assets/**'
+      - 'dashboards/**'
+      - 'docs/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**Motivation**

Do not trigger all workflows when irrelevant files are modified (e.g. `docs`).