### PR TITLE
ci: publish binaries for release candidates

### DIFF
--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -42,10 +42,17 @@ jobs:
       tag: ${{ steps.get_tag.outputs.tag }}
       prev_tag: ${{ steps.get_prev_tag.outputs.prev_tag }}
 
+  binaries:
+    name: Build lodestar binaries
+    uses: ./.github/workflows/binaries.yml
+    needs: tag
+    with:
+      version: ${{ needs.tag.outputs.tag }}
+
   npm:
     name: Publish to NPM & Github
     runs-on: buildjet-4vcpu-ubuntu-2204
-    needs: tag
+    needs: [tag, binaries]
     if: needs.tag.outputs.is_rc == 'true'
     steps:
       - uses: actions/checkout@v4
@@ -59,12 +66,20 @@ jobs:
       - name: Generate changelog
         run: node scripts/generate_changelog.mjs ${{ needs.tag.outputs.prev_tag }} ${{ needs.tag.outputs.tag }} CHANGELOG.md
 
+      - name: Get binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          files: dist/*
+          fail_on_unmatched_files: true
           tag_name: ${{ needs.tag.outputs.tag }}
           body_path: "CHANGELOG.md"
           name: Release ${{ needs.tag.outputs.tag }}


### PR DESCRIPTION
**Motivation**

We publish everything else (npm, docker) for release candidates, I don't see a good reason we shouldn't publish binaries as well.

This also gives us the ability to test binaries, and make sure it doesn't break the release process. And we should also deploy rc binaries on our beta fleet if possible.

**Description**

Publish binaries for release candidates