### PR TITLE
chore: do not build all binaries atomically

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -16,6 +16,7 @@ jobs:
   binaries:
     name: Build lodestar binaries
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest


### PR DESCRIPTION
**Description**

Make sure one failing binary builds doesn't cancel all others. This is useful when experimenting and you still want others binary to build.
The step will still fail if one of the binary build fails, retaining the current atomicity of the release.