### PR TITLE
chore: revert "ci: add paths-ignore to workflows (#6713)"

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,16 +13,10 @@ on:
       - stable
       - unstable
       - benchmark # For debugging
-    paths-ignore:
-      - 'dashboards/**'
-      - 'docs/**'
   pull_request:
     branches:
       - stable
       - unstable
-    paths-ignore:
-      - 'dashboards/**'
-      - 'docs/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -4,11 +4,7 @@ on:
   push:
     # We intentionally don't run push on feature branches. See PR for rational.
     branches: [unstable, stable]
-    paths-ignore:
-      - 'dashboards/**'
   pull_request:
-    paths-ignore:
-      - 'dashboards/**'
 
 jobs:
   build:

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -8,9 +8,6 @@ on:
   push:
     branches:
       - unstable
-    paths-ignore:
-      - 'dashboards/**'
-      - 'docs/**'
 
 jobs:
   npm:

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -9,13 +9,7 @@ on:
   push:
     # We intentionally don't run push on feature branches. See PR for rational.
     branches: [unstable, stable]
-    paths-ignore:
-      - 'dashboards/**'
-      - 'docs/**'
   pull_request:
-    paths-ignore:
-      - 'dashboards/**'
-      - 'docs/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -9,13 +9,7 @@ on:
   push:
     # We intentionally don't run push on feature branches. See PR for rational.
     branches: [unstable, stable]
-    paths-ignore:
-      - 'dashboards/**'
-      - 'docs/**'
   pull_request:
-    paths-ignore:
-      - 'dashboards/**'
-      - 'docs/**'
   workflow_dispatch:
     inputs:
       debug:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,7 @@ on:
   push:
     # We intentionally don't run push on feature branches. See PR for rational.
     branches: [unstable, stable]
-    paths-ignore:
-      - 'docs/**'
   pull_request:
-    paths-ignore:
-      - 'docs/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**Motivation**

Reverts https://github.com/ChainSafe/lodestar/pull/6713 until we can come up with a better solution that does not block PRs from being mergeable because required jobs are skipped.

See [handling-skipped-but-required-checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks)

**Description**

Revert "ci: add paths-ignore to workflows (#6713)"
