### PR TITLE
ci: fix incorrect build caching

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -30,7 +30,7 @@ runs:
           lib/
           packages/*/lib
           packages/*/.git-data.json
-        key: ${{ runner.os }}-node-${{ inputs.node }}-${{ github.sha }}
+        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node }}-${{ github.sha }}
 
     - name: Install & build
       if: steps.cache-build-restore.outputs.cache-hit != 'true'
@@ -55,4 +55,4 @@ runs:
           lib/
           packages/*/lib
           packages/*/.git-data.json
-        key: ${{ runner.os }}-node-${{ inputs.node }}-${{ github.sha }}
+        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node }}-${{ github.sha }}


### PR DESCRIPTION
**Motivation**

Make sure build cache is correctly used. This fixes the `arm64` binary creation.

**Description**

`arm64` [binary build](https://github.com/ChainSafe/lodestar/blob/unstable/.github/workflows/binaries.yml#L16) fails with the following error:

```js
2024-04-30T15:04:36.6769640Z Error: Cannot find module '@nx/nx-linux-arm64-gnu'
2024-04-30T15:04:36.6774450Z Require stack:
2024-04-30T15:04:36.6775682Z - /home/runner/work/lodestar/lodestar/node_modules/nx/src/native/index.js
2024-04-30T15:04:36.6777257Z - /home/runner/work/lodestar/lodestar/node_modules/nx/src/hasher/task-hasher.js
2024-04-30T15:04:36.6778825Z - /home/runner/work/lodestar/lodestar/node_modules/nx/src/hasher/hash-task.js
2024-04-30T15:04:36.6780490Z - /home/runner/work/lodestar/lodestar/node_modules/nx/src/tasks-runner/tasks-schedule.js
2024-04-30T15:04:36.6782539Z - /home/runner/work/lodestar/lodestar/node_modules/nx/src/tasks-runner/task-orchestrator.js
2024-04-30T15:04:36.6784446Z - /home/runner/work/lodestar/lodestar/node_modules/nx/src/tasks-runner/default-tasks-runner.js
2024-04-30T15:04:36.6786218Z - /home/runner/work/lodestar/lodestar/node_modules/@nx/devkit/nx-reexports-pre16.js
2024-04-30T15:04:36.6787761Z - /home/runner/work/lodestar/lodestar/node_modules/@nx/devkit/index.js
2024-04-30T15:04:36.6789182Z - /home/runner/work/lodestar/lodestar/node_modules/lerna/dist/index.js
2024-04-30T15:04:36.6790598Z - /home/runner/work/lodestar/lodestar/node_modules/lerna/dist/cli.js
2024-04-30T15:04:36.6792614Z     at Module._resolveFilename (node:internal/modules/cjs/loader:1143:15)
2024-04-30T15:04:36.6793636Z     at Module._load (node:internal/modules/cjs/loader:984:27)
2024-04-30T15:04:36.6794570Z     at Module.require (node:internal/modules/cjs/loader:1231:19)
2024-04-30T15:04:36.6795456Z     at require (node:internal/modules/helpers:179:18)
2024-04-30T15:04:36.6796858Z     at Object.<anonymous> (/home/runner/work/lodestar/lodestar/node_modules/nx/src/native/index.js:213:31)
2024-04-30T15:04:36.6798171Z     at Module._compile (node:internal/modules/cjs/loader:1369:14)
2024-04-30T15:04:36.6799183Z     at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
2024-04-30T15:04:36.6800196Z     at Module.load (node:internal/modules/cjs/loader:1206:32)
2024-04-30T15:04:36.6801122Z     at Module._load (node:internal/modules/cjs/loader:1022:12)
2024-04-30T15:04:36.6802078Z     at Module.require (node:internal/modules/cjs/loader:1231:19) {
```

This relates to this [nx issue](https://github.com/nrwl/nx/issues/15452), nx being a dependency of `lerna`.

Properly caching build per architecture fixes it.