### PR TITLE
feat: dual export some modules (params, utils, test-utils, spec-test-util)

### DIFF
--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -3,43 +3,12 @@
   "version": "1.18.0",
   "description": "Spec test suite generator from yaml test files",
   "author": "ChainSafe Systems",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/ChainSafe/lodestar/issues"
-  },
-  "homepage": "https://github.com/ChainSafe/lodestar#readme",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": "./lib/index.js"
-    },
-    "./downloadTests": {
-      "import": "./lib/downloadTests.js"
-    }
-  },
-  "types": "lib/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "*",
-        "lib/*",
-        "lib/*/index"
-      ]
-    }
-  },
-  "files": [
-    "lib/**/*.js",
-    "lib/**/*.js.map",
-    "lib/**/*.d.ts",
-    "*.d.ts",
-    "*.js"
-  ],
-  "bin": {
-    "eth2-spec-test-download": "lib/downloadTestsCli.js"
-  },
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",
-    "build": "tsc -p tsconfig.build.json",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build": "yarn build:esm && yarn build:cjs",
+    "postbuild": "node ../../scripts/prepare_cjs_modules.mjs spec-test-util",
     "build:release": "yarn clean && yarn build",
     "build:watch": "yarn run build --watch",
     "check-build": "node -e \"(async function() { await import('./lib/downloadTests.js') })()\"",
@@ -51,16 +20,6 @@
     "test:e2e": "vitest --run --config vitest.e2e.config.ts --dir test/e2e/",
     "check-readme": "typescript-docs-verifier"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com:ChainSafe/lodestar.git"
-  },
-  "keywords": [
-    "ethereum",
-    "eth-consensus",
-    "beacon",
-    "blockchain"
-  ],
   "dependencies": {
     "@lodestar/utils": "^1.18.0",
     "axios": "^1.3.4",
@@ -70,9 +29,63 @@
     "vitest": "^1.2.1"
   },
   "devDependencies": {
-    "@types/tar": "^6.1.4"
+    "@types/tar": "^6.1.4",
+    "@types/snappyjs": "^0.7.0"
   },
   "peerDependencies": {
     "vitest": "^1.2.1"
+  },
+  "type": "module",
+  "bin": {
+    "eth2-spec-test-download": "lib/downloadTestsCli.mjs"
+  },
+  "main": "./lib/cjs/index.cjs",
+  "module": "./lib/esm/index.js",
+  "types": "./lib/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.cjs"
+    },
+    "./downloadTests": {
+      "import": "./lib/esm/downloadTests.js",
+      "require": "./lib/cjs/downloadTests.cjs"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "*",
+        "lib/esm/*",
+        "lib/esm/*/index"
+      ]
+    }
+  },
+  "files": [
+    "*.map",
+    "*.cjs",
+    "*.d.cts",
+    "*.js",
+    "*.d.mts",
+    "lib/**/*.map",
+    "lib/esm/**/*.js",
+    "lib/esm/**/*.d.ts",
+    "lib/cjs/**/*.cjs",
+    "lib/cjs/**/*.d.cts"
+  ],
+  "keywords": [
+    "ethereum",
+    "eth-consensus",
+    "beacon",
+    "blockchain"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/ChainSafe/lodestar#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com:ChainSafe/lodestar.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ChainSafe/lodestar/issues"
   }
 }

--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -8,10 +8,10 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build": "yarn build:esm && yarn build:cjs",
-    "postbuild": "node ../../scripts/prepare_cjs_modules.mjs spec-test-util",
+    "postbuild": "node ../../scripts/fix_dual_modules_lib.mjs spec-test-util",
     "build:release": "yarn clean && yarn build",
     "build:watch": "yarn run build --watch",
-    "check-build": "node -e \"(async function() { await import('./lib/downloadTests.js') })()\"",
+    "check-build": "node -e \"(async function() { await import('./lib/esm/downloadTests.mjs') })()\"",
     "check-types": "tsc",
     "lint": "eslint --color --ext .ts src/ test/",
     "lint:fix": "yarn run lint --fix",
@@ -40,15 +40,15 @@
     "eth2-spec-test-download": "lib/downloadTestsCli.mjs"
   },
   "main": "./lib/cjs/index.cjs",
-  "module": "./lib/esm/index.js",
-  "types": "./lib/esm/index.d.ts",
+  "module": "./lib/esm/index.mjs",
+  "types": "./lib/esm/index.d.mts",
   "exports": {
     ".": {
-      "import": "./lib/esm/index.js",
+      "import": "./lib/esm/index.mjs",
       "require": "./lib/cjs/index.cjs"
     },
     "./downloadTests": {
-      "import": "./lib/esm/downloadTests.js",
+      "import": "./lib/esm/downloadTests.mjs",
       "require": "./lib/cjs/downloadTests.cjs"
     }
   },
@@ -65,11 +65,11 @@
     "*.map",
     "*.cjs",
     "*.d.cts",
-    "*.js",
+    "*.mjs",
     "*.d.mts",
     "lib/**/*.map",
-    "lib/esm/**/*.js",
-    "lib/esm/**/*.d.ts",
+    "lib/esm/**/*.mjs",
+    "lib/esm/**/*.d.mts",
     "lib/cjs/**/*.cjs",
     "lib/cjs/**/*.d.cts"
   ],

--- a/packages/spec-test-util/tsconfig.cjs.json
+++ b/packages/spec-test-util/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "target": "ESNext",
+    "outDir": "./lib/cjs"
+  }
+}

--- a/packages/spec-test-util/tsconfig.esm.json
+++ b/packages/spec-test-util/tsconfig.esm.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "include": ["src"],
   "compilerOptions": {
-    "outDir": "./lib",
+    "outDir": "./lib/esm",
     "typeRoots": ["../../node_modules/@types", "./node_modules/@types", "../../types"]
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.18.0",
   "name": "@lodestar/utils",
+  "version": "1.18.0",
   "description": "Utilities required across multiple lodestar packages",
   "author": "ChainSafe Systems",
   "scripts": {
@@ -8,10 +8,10 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build": "yarn build:esm && yarn build:cjs",
-    "postbuild": "node ../../scripts/prepare_cjs_modules.mjs utils",
+    "postbuild": "node ../../scripts/fix_dual_modules_lib.mjs utils",
     "build:watch": "yarn run build --watch",
     "build:release": "yarn clean && yarn build",
-    "check-build": "node -e \"(async function() { await import('./lib/index.js') })()\"",
+    "check-build": "node -e \"(async function() { await import('./lib/esm/index.mjs') })()\"",
     "check-types": "tsc && vitest --run --typecheck --dir test/types/",
     "lint": "eslint --color --ext .ts src/ test/",
     "lint:fix": "yarn run lint --fix",
@@ -36,11 +36,11 @@
   },
   "type": "module",
   "main": "./lib/cjs/index.cjs",
-  "module": "./lib/esm/index.js",
-  "types": "./lib/esm/index.d.ts",
+  "module": "./lib/esm/index.mjs",
+  "types": "./lib/esm/index.d.mts",
   "exports": {
     ".": {
-      "import": "./lib/esm/index.js",
+      "import": "./lib/esm/index.mjs",
       "require": "./lib/cjs/index.cjs"
     }
   },
@@ -57,11 +57,11 @@
     "*.map",
     "*.cjs",
     "*.d.cts",
-    "*.js",
-    "*.d.ts",
+    "*.mjs",
+    "*.d.mts",
     "lib/**/*.map",
-    "lib/esm/**/*.js",
-    "lib/esm/**/*.d.ts",
+    "lib/esm/**/*.mjs",
+    "lib/esm/**/*.d.mts",
     "lib/cjs/**/*.cjs",
     "lib/cjs/**/*.d.cts"
   ],

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,29 +1,14 @@
 {
+  "version": "1.18.0",
   "name": "@lodestar/utils",
   "description": "Utilities required across multiple lodestar packages",
-  "license": "Apache-2.0",
   "author": "ChainSafe Systems",
-  "homepage": "https://github.com/ChainSafe/lodestar#readme",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com:ChainSafe/lodestar.git"
-  },
-  "bugs": {
-    "url": "https://github.com/ChainSafe/lodestar/issues"
-  },
-  "version": "1.18.0",
-  "type": "module",
-  "exports": "./lib/index.js",
-  "files": [
-    "lib/**/*.d.ts",
-    "lib/**/*.js",
-    "lib/**/*.js.map",
-    "*.d.ts",
-    "*.js"
-  ],
   "scripts": {
     "clean": "rm -rf lib && rm -f *.tsbuildinfo",
-    "build": "tsc -p tsconfig.build.json",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build": "yarn build:esm && yarn build:cjs",
+    "postbuild": "node ../../scripts/prepare_cjs_modules.mjs utils",
     "build:watch": "yarn run build --watch",
     "build:release": "yarn clean && yarn build",
     "check-build": "node -e \"(async function() { await import('./lib/index.js') })()\"",
@@ -37,7 +22,6 @@
     "test:browsers:electron": "echo 'Electron tests will be introduced back in the future as soon vitest supports electron.'",
     "check-readme": "typescript-docs-verifier"
   },
-  "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
     "any-signal": "3.0.1",
@@ -50,10 +34,50 @@
     "@types/yargs": "^17.0.24",
     "prom-client": "^15.1.0"
   },
+  "type": "module",
+  "main": "./lib/cjs/index.cjs",
+  "module": "./lib/esm/index.js",
+  "types": "./lib/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.cjs"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "*",
+        "lib/esm/*",
+        "lib/esm/*/index"
+      ]
+    }
+  },
+  "files": [
+    "*.map",
+    "*.cjs",
+    "*.d.cts",
+    "*.js",
+    "*.d.ts",
+    "lib/**/*.map",
+    "lib/esm/**/*.js",
+    "lib/esm/**/*.d.ts",
+    "lib/cjs/**/*.cjs",
+    "lib/cjs/**/*.d.cts"
+  ],
   "keywords": [
     "ethereum",
     "eth-consensus",
     "beacon",
     "blockchain"
-  ]
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/ChainSafe/lodestar#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com:ChainSafe/lodestar.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ChainSafe/lodestar/issues"
+  }
 }

--- a/packages/utils/tsconfig.cjs.json
+++ b/packages/utils/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "target": "ESNext",
+    "outDir": "./lib/cjs"
+  }
+}

--- a/packages/utils/tsconfig.esm.json
+++ b/packages/utils/tsconfig.esm.json
@@ -2,6 +2,6 @@
   "extends": "../../tsconfig.build.json",
   "include": ["src"],
   "compilerOptions": {
-    "outDir": "./lib"
+    "outDir": "./lib/esm"
   }
 }

--- a/scripts/prepare_cjs_modules.mjs
+++ b/scripts/prepare_cjs_modules.mjs
@@ -1,0 +1,111 @@
+/* eslint-disable
+  quotes,
+  @typescript-eslint/explicit-function-return-type,
+  @typescript-eslint/no-unsafe-member-access,
+  @typescript-eslint/no-unsafe-assignment,
+  @typescript-eslint/naming-convention,
+  @typescript-eslint/no-unsafe-return,
+  @typescript-eslint/no-unsafe-call,
+*/
+
+import fs from "node:fs";
+import url from "node:url";
+import path from "node:path";
+
+function getSwapPairs(prefix) {
+  return {
+    ".js": `.${prefix}js`,
+    ".js.map": `.${prefix}js.map`,
+    ".d.ts": `.d.${prefix}ts`,
+    ".ts.map": `.${prefix}ts.map`,
+  };
+}
+
+/**
+ * Recursively walk directories and get list of all files in a folder
+ */
+function getAllFilesInFolder(dirname) {
+  if (!fs.existsSync(dirname)) {
+    throw new Error(`No folder found at ${dirname}`);
+  }
+
+  const pathList = [];
+  for (const filename of fs.readdirSync(dirname)) {
+    const itemPath = path.resolve(dirname, filename);
+    const stat = fs.statSync(itemPath);
+    if (stat.isSymbolicLink()) {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      pathList.push(...getAllFilesInFolder(itemPath));
+    }
+    if (stat.isFile()) {
+      pathList.push(itemPath);
+    }
+  }
+
+  return pathList;
+}
+
+/**
+ * Update internal references in map files for updated filenames
+ */
+function rewriteMapReferences(filepath, swapPairs) {
+  if (!filepath.endsWith(".map")) return;
+  const data = JSON.parse(fs.readFileSync(filepath, "utf8"));
+  if (filepath.endsWith(".d.ts.map")) {
+    data.file = data.file.replace(".d.ts", swapPairs[".d.ts"]);
+  } else {
+    data.file = data.file.replace(".js", swapPairs[".js"]);
+  }
+  fs.writeFileSync(filepath, JSON.stringify(data));
+}
+
+function rewriteRequireStatements(filepath) {
+  let data = fs.readFileSync(filepath, "utf8");
+  if (filepath.endsWith(".js")) {
+    data = data.replace(/.js"\)/gi, '.cjs")');
+  } else if (filepath.endsWith("d.ts")) {
+    data = data.replace(/.js";/gi, '.cjs";');
+  } else {
+    return;
+  }
+  fs.writeFileSync(filepath, data);
+}
+
+/**
+ * Rewrite file names from `.js` to `.cjs` or `.ts` to `.cts` including map files
+ */
+function rewriteFileName(filepath, swapPairs) {
+  for (const [searchString, replacement] of Object.entries(swapPairs)) {
+    if (filepath.endsWith(searchString)) {
+      const newFilepath = filepath.replace(searchString, replacement);
+      fs.renameSync(filepath, newFilepath);
+      return;
+    }
+  }
+}
+
+function updateDistribution(dirname, swapPairs) {
+  const filepaths = getAllFilesInFolder(dirname);
+  for (const filepath of filepaths) {
+    rewriteRequireStatements(filepath);
+    rewriteMapReferences(filepath, swapPairs);
+    rewriteFileName(filepath, swapPairs);
+  }
+}
+
+/**
+ *
+ * File entrance below here
+ *
+ */
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const packageName = process.argv[2];
+if (!packageName) {
+  throw new Error("Must pass packageName as positional param after calling script");
+}
+
+updateDistribution(path.resolve(__dirname, "..", "packages", packageName, "lib", "cjs"), getSwapPairs("c"));
+updateDistribution(path.resolve(__dirname, "..", "packages", packageName, "lib", "esm"), getSwapPairs("m"));

--- a/scripts/utils/get_filenames_recursively.mjs
+++ b/scripts/utils/get_filenames_recursively.mjs
@@ -1,0 +1,33 @@
+/* eslint-disable
+  @typescript-eslint/explicit-function-return-type,
+  @typescript-eslint/no-unsafe-return,
+*/
+
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Recursively walk directories and get list of all files in a folder
+ */
+export function getFilenameRecursively(dirname) {
+  if (!fs.existsSync(dirname)) {
+    throw new Error(`No folder found at ${dirname}`);
+  }
+
+  const pathList = [];
+  for (const filename of fs.readdirSync(dirname)) {
+    const itemPath = path.resolve(dirname, filename);
+    const stat = fs.statSync(itemPath);
+    if (stat.isSymbolicLink()) {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      pathList.push(...getFilenameRecursively(itemPath));
+    }
+    if (stat.isFile()) {
+      pathList.push(itemPath);
+    }
+  }
+
+  return pathList;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3174,6 +3174,11 @@
   resolved "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz"
   integrity sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
 
+"@types/snappyjs@^0.7.0":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@types/snappyjs/-/snappyjs-0.7.1.tgz#57a92e9159e13badd5c2f067d98a9f36c2e1f249"
+  integrity sha512-OxjzJ6cQZstysMh6PEwZWmK9qlKZyezHJKOkcUkZDooSFuog2votUEKkxMaTq51UQF3cJkXKQ+XGlj4FSl8JQQ==
+
 "@types/ssh2-streams@*":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@types/ssh2-streams/-/ssh2-streams-0.1.9.tgz#8ca51b26f08750a780f82ee75ff18d7160c07a87"
@@ -12000,16 +12005,7 @@ string-argv@~0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13644,16 +13640,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
**Motivation**

I updated the spec tests in blst-ts and the util in lodestar is much better.  Need a CJS module though to be able to import it there.  Dual-module export of `spec-test-util` depends on  `utils` so update that one as well.  There are some good other `test-utils` that may be helpful in other repos and the script was already written so exported that as well.  That depends on `params` so updated that also.  Sets a pretty good precedent for how we can export packages as dual module should we want to.

**Description**

- Adds `scripts/fix_dual_modules_lib.mjs`
- Adds `scripts/fix_dirname_and_filename.mjs`
- Rename `tsconfig.build.json` to `tsconfig.esm.json` for all dual module packages
- Adds `tsconfig.cjs.json` to all dual module packages
- Updates package.json in all dual module packages
   * Correct exports/types/files that are exported/bundled
   * Adds scripts for build process