### PR TITLE
fix: fix e2e test in electra-fork

### DIFF
--- a/packages/params/test/e2e/ensure-config-is-synced.test.ts
+++ b/packages/params/test/e2e/ensure-config-is-synced.test.ts
@@ -8,7 +8,7 @@ import {loadConfigYaml} from "../yaml.js";
 // Not e2e, but slow. Run with e2e tests
 
 /** https://github.com/ethereum/consensus-specs/releases */
-const specConfigCommit = "v1.4.0-beta.5";
+const specConfigCommit = "v1.5.0-alpha.2";
 
 describe("Ensure config is synced", function () {
   vi.setConfig({testTimeout: 60 * 1000});


### PR DESCRIPTION
See sample log [here](https://github.com/ChainSafe/lodestar/actions/runs/9003819737/job/24735492071?pr=6750)

This is due to `ensure-config-is-synced.test.ts` is attempting to download electra config from `v1.4.0-beta.5` which didn't exist back then