### PR TITLE
feat: apply some fixes and hacks to get the single node devnet working with fork transition

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -11,6 +11,7 @@ import {
   capella,
   deneb,
   Wei,
+  electra,
 } from "@lodestar/types";
 import {
   CachedBeaconStateAllForks,
@@ -337,6 +338,10 @@ export async function produceBlockBody<T extends BlockType>(
         withdrawals: (blockBody as capella.BeaconBlockBody).executionPayload.withdrawals.length,
       });
     }
+  }
+
+  if (ForkSeq[fork] >= ForkSeq.electra) {
+    (blockBody as electra.BeaconBlockBody).consolidations = [];
   }
 
   Object.assign(logMeta, {executionPayloadValue});

--- a/packages/state-transition/src/slot/upgradeStateToElectra.ts
+++ b/packages/state-transition/src/slot/upgradeStateToElectra.ts
@@ -14,6 +14,80 @@ import {
 export function upgradeStateToElectra(stateDeneb: CachedBeaconStateDeneb): CachedBeaconStateElectra {
   const {config} = stateDeneb;
 
+  ssz.deneb.BeaconState.commitViewDU(stateDeneb);
+  const stateElectraCloned = stateDeneb;
+
+  const stateElectraView = ssz.electra.BeaconState.defaultViewDU();
+  stateElectraView.genesisTime = stateElectraCloned.genesisTime;
+  stateElectraView.genesisValidatorsRoot = stateElectraCloned.genesisValidatorsRoot;
+  stateElectraView.slot = stateElectraCloned.slot;
+  stateElectraView.fork = ssz.phase0.Fork.toViewDU({
+    previousVersion: stateDeneb.fork.currentVersion,
+    currentVersion: config.ELECTRA_FORK_VERSION,
+    epoch: stateDeneb.epochCtx.epoch,
+  });
+  stateElectraView.latestBlockHeader = stateElectraCloned.latestBlockHeader;
+  stateElectraView.blockRoots = stateElectraCloned.blockRoots;
+  stateElectraView.stateRoots = stateElectraCloned.stateRoots;
+  stateElectraView.historicalRoots = stateElectraCloned.historicalRoots;
+  stateElectraView.eth1Data = stateElectraCloned.eth1Data;
+  stateElectraView.eth1DataVotes = stateElectraCloned.eth1DataVotes;
+  stateElectraView.eth1DepositIndex = stateElectraCloned.eth1DepositIndex;
+  stateElectraView.validators = stateElectraCloned.validators;
+  stateElectraView.balances = stateElectraCloned.balances;
+  stateElectraView.randaoMixes = stateElectraCloned.randaoMixes;
+  stateElectraView.slashings = stateElectraCloned.slashings;
+  stateElectraView.previousEpochParticipation = stateElectraCloned.previousEpochParticipation;
+  stateElectraView.currentEpochParticipation = stateElectraCloned.currentEpochParticipation;
+  stateElectraView.justificationBits = stateElectraCloned.justificationBits;
+  stateElectraView.previousJustifiedCheckpoint = stateElectraCloned.previousJustifiedCheckpoint;
+  stateElectraView.currentJustifiedCheckpoint = stateElectraCloned.currentJustifiedCheckpoint;
+  stateElectraView.finalizedCheckpoint = stateElectraCloned.finalizedCheckpoint;
+  stateElectraView.inactivityScores = stateElectraCloned.inactivityScores;
+  stateElectraView.currentSyncCommittee = stateElectraCloned.currentSyncCommittee;
+  stateElectraView.nextSyncCommittee = stateElectraCloned.nextSyncCommittee;
+  stateElectraView.latestExecutionPayloadHeader = ssz.electra.BeaconState.fields.latestExecutionPayloadHeader.toViewDU({
+    ...stateElectraCloned.latestExecutionPayloadHeader.toValue(),
+    depositRequestsRoot: ssz.Root.defaultValue(),
+    withdrawalRequestsRoot: ssz.Root.defaultValue(),
+  });
+  stateElectraView.nextWithdrawalIndex = stateDeneb.nextWithdrawalIndex;
+  stateElectraView.nextWithdrawalValidatorIndex = stateDeneb.nextWithdrawalValidatorIndex;
+  stateElectraView.historicalSummaries = stateElectraCloned.historicalSummaries;
+
+  // latestExecutionPayloadHeader's depositRequestsRoot and withdrawalRequestsRoot set to zeros by default
+  // default value of depositRequestsStartIndex is UNSET_DEPOSIT_RECEIPTS_START_INDEX
+  stateElectraView.depositRequestsStartIndex = UNSET_DEPOSIT_RECEIPTS_START_INDEX;
+
+  const validatorsArr = stateElectraView.validators.getAllReadonly();
+
+  for (let i = 0; i < validatorsArr.length; i++) {
+    const validator = validatorsArr[i];
+
+    // [EIP-7251]: add validators that are not yet active to pending balance deposits
+    if (validator.activationEligibilityEpoch === FAR_FUTURE_EPOCH) {
+      queueEntireBalanceAndResetValidator(stateElectraView as CachedBeaconStateElectra, i);
+    }
+
+    // [EIP-7251]: Ensure early adopters of compounding credentials go through the activation churn
+    const withdrawalCredential = validator.withdrawalCredentials;
+    if (hasCompoundingWithdrawalCredential(withdrawalCredential)) {
+      queueExcessActiveBalance(stateElectraView as CachedBeaconStateElectra, i);
+    }
+  }
+
+  const stateElectra = getCachedBeaconState(stateElectraView, stateDeneb);
+  // Commit new added fields ViewDU to the root node
+  stateElectra.commit();
+  // Clear cache to ensure the cache of deneb fields is not used by new ELECTRA fields
+  stateElectra["clearCache"]();
+
+  return stateElectra;
+}
+
+export function upgradeStateToElectraOriginal(stateDeneb: CachedBeaconStateDeneb): CachedBeaconStateElectra {
+  const {config} = stateDeneb;
+
   const stateElectraNode = ssz.deneb.BeaconState.commitViewDU(stateDeneb);
   const stateElectraView = ssz.electra.BeaconState.getViewDU(stateElectraNode);
 


### PR DESCRIPTION
two issues:
1. consolidation was not part of blockbody
2. stateupgrade was erroring and not working in previous way of taking an electra view and making updates
  - most likely the tree state of deneb is not compatible with the electra type? someone @twoeths needs to figure this out (original upgrade state fn has been copied over for debugging and fixing)
  - did a "hack" to fully copy over the state from deneb to electra state starting from a default view, can be removed once we have the original working