### PR TITLE
feat: disable flood publish

### DIFF
--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -131,7 +131,7 @@ export class Eth2Gossipsub extends GossipSub {
       batchPublish: true,
       // if this is false, only publish to mesh peers. If there is not enough GOSSIP_D mesh peers,
       // publish to some more topic peers to make sure we always publish to at least GOSSIP_D peers
-      floodPublish: !(opts?.disableFloodPublish ?? false),
+      floodPublish: !opts?.disableFloodPublish,
     });
     this.scoreParams = scoreParams;
     this.config = config;

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -53,6 +53,7 @@ export type Eth2GossipsubOpts = {
   gossipsubDLow?: number;
   gossipsubDHigh?: number;
   gossipsubAwaitHandler?: boolean;
+  disableFloodPublish?: boolean;
   skipParamsLog?: boolean;
 };
 
@@ -128,9 +129,9 @@ export class Eth2Gossipsub extends GossipSub {
       maxOutboundBufferSize: MAX_OUTBOUND_BUFFER_SIZE,
       // serialize message once and send to all peers when publishing
       batchPublish: true,
-      // only publish to mesh peers. If there is not enough GOSSIP_D mesh peers, publish to some more topic peers
-      // to make sure we always publish to at least GOSSIP_D peers
-      floodPublish: true,
+      // if this is false, only publish to mesh peers. If there is not enough GOSSIP_D mesh peers,
+      // publish to some more topic peers to make sure we always publish to at least GOSSIP_D peers
+      floodPublish: !(opts?.disableFloodPublish ?? false),
     });
     this.scoreParams = scoreParams;
     this.config = config;

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -128,6 +128,9 @@ export class Eth2Gossipsub extends GossipSub {
       maxOutboundBufferSize: MAX_OUTBOUND_BUFFER_SIZE,
       // serialize message once and send to all peers when publishing
       batchPublish: true,
+      // only publish to mesh peers. If there is not enough GOSSIP_D mesh peers, publish to some more topic peers
+      // to make sure we always publish to at least GOSSIP_D peers
+      floodPublish: true,
     });
     this.scoreParams = scoreParams;
     this.config = config;

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -364,7 +364,7 @@ export const options: CliCommandOptions<NetworkArgs> = {
 
   "network.disableFloodPublish": {
     hidden: true,
-    description: "Disable gossipsub flood publish or not.",
+    description: "Disable gossipsub flood publish",
     type: "boolean",
     group: "network",
   },

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -32,6 +32,7 @@ export type NetworkArgs = {
   "network.gossipsubDLow"?: number;
   "network.gossipsubDHigh"?: number;
   "network.gossipsubAwaitHandler"?: boolean;
+  "network.disableFloodPublish"?: boolean;
   "network.rateLimitMultiplier"?: number;
   "network.maxGossipTopicConcurrency"?: number;
   "network.useWorker"?: boolean;
@@ -149,6 +150,7 @@ export function parseArgs(args: NetworkArgs): IBeaconNodeOptions["network"] {
     gossipsubDLow: args["network.gossipsubDLow"],
     gossipsubDHigh: args["network.gossipsubDHigh"],
     gossipsubAwaitHandler: args["network.gossipsubAwaitHandler"],
+    disableFloodPublish: args["network.disableFloodPublish"],
     mdns: args["mdns"],
     rateLimitMultiplier: args["network.rateLimitMultiplier"],
     maxGossipTopicConcurrency: args["network.maxGossipTopicConcurrency"],
@@ -356,6 +358,13 @@ export const options: CliCommandOptions<NetworkArgs> = {
 
   "network.gossipsubAwaitHandler": {
     hidden: true,
+    type: "boolean",
+    group: "network",
+  },
+
+  "network.disableFloodPublish": {
+    hidden: true,
+    description: "Disable gossipsub flood publish or not.",
     type: "boolean",
     group: "network",
   },


### PR DESCRIPTION
**Motivation**

Since we increase target peers to 100 we more missed block proposals due to a delay in gossipsub, see #6596

**Description**

As analysed by lighthouse, flood publishing contribute to this delay so we should experiment disabling it

part of #6596