### PR TITLE
fix: get aggregate and proofs signature sets

### DIFF
--- a/packages/beacon-node/src/chain/validation/signatureSets/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/aggregateAndProof.ts
@@ -1,6 +1,6 @@
 import type {PublicKey} from "@chainsafe/bls/types";
-import {DOMAIN_AGGREGATE_AND_PROOF} from "@lodestar/params";
-import {ssz} from "@lodestar/types";
+import {DOMAIN_AGGREGATE_AND_PROOF, ForkSeq} from "@lodestar/params";
+import {allForks, ssz} from "@lodestar/types";
 import {Epoch, phase0} from "@lodestar/types";
 import {
   computeSigningRoot,
@@ -13,7 +13,7 @@ import {BeaconConfig} from "@lodestar/config";
 export function getAggregateAndProofSigningRoot(
   config: BeaconConfig,
   epoch: Epoch,
-  aggregateAndProof: phase0.SignedAggregateAndProof
+  aggregateAndProof: allForks.SignedAggregateAndProof
 ): Uint8Array {
   // previously, we call `const aggregatorDomain = state.config.getDomain(state.slot, DOMAIN_AGGREGATE_AND_PROOF, slot);`
   // at fork boundary, it's required to dial to target epoch https://github.com/ChainSafe/lodestar/blob/v1.11.3/packages/beacon-node/src/chain/validation/attestation.ts#L573
@@ -21,14 +21,15 @@ export function getAggregateAndProofSigningRoot(
   const slot = computeStartSlotAtEpoch(epoch);
   const fork = config.getForkName(slot);
   const aggregatorDomain = config.getDomainAtFork(fork, DOMAIN_AGGREGATE_AND_PROOF);
-  return computeSigningRoot(ssz.phase0.AggregateAndProof, aggregateAndProof.message, aggregatorDomain);
+  const sszType = ForkSeq[fork] >= ForkSeq.electra ? ssz.electra.AggregateAndProof : ssz.phase0.AggregateAndProof;
+  return computeSigningRoot(sszType, aggregateAndProof.message, aggregatorDomain);
 }
 
 export function getAggregateAndProofSignatureSet(
   config: BeaconConfig,
   epoch: Epoch,
   aggregator: PublicKey,
-  aggregateAndProof: phase0.SignedAggregateAndProof
+  aggregateAndProof: allForks.SignedAggregateAndProof
 ): ISignatureSet {
   return createSingleSignatureSetFromComponents(
     aggregator,


### PR DESCRIPTION
**Motivation**

The submitted SignedAggregateAndProof from `vc` failed validation with `ATTESTATION_ERROR_INVALID_SIGNATURE` error

**Description**

Beacon node to get signature set of SignedAggregateAndProof based on fork

found from #6756

cc @ensi321 @g11tech 