### PR TITLE
fix: publish electra attestations / aggregates through api

### DIFF
--- a/packages/api/src/beacon/client/validator.ts
+++ b/packages/api/src/beacon/client/validator.ts
@@ -5,8 +5,8 @@ import {IHttpClient, generateGenericJsonClient} from "../../utils/client/index.j
 /**
  * REST HTTP client for validator routes
  */
-export function getClient(_config: ChainForkConfig, httpClient: IHttpClient): Api {
-  const reqSerializers = getReqSerializers();
+export function getClient(config: ChainForkConfig, httpClient: IHttpClient): Api {
+  const reqSerializers = getReqSerializers(config);
   const returnTypes = getReturnTypes();
   // All routes return JSON, use a client auto-generator
   return generateGenericJsonClient<Api, ReqTypes>(routesData, reqSerializers, returnTypes, httpClient);

--- a/packages/api/src/beacon/routes/beacon/index.ts
+++ b/packages/api/src/beacon/routes/beacon/index.ts
@@ -61,7 +61,7 @@ export function getReqSerializers(config: ChainForkConfig) {
   return {
     getGenesis: reqEmpty,
     ...block.getReqSerializers(config),
-    ...pool.getReqSerializers(),
+    ...pool.getReqSerializers(config),
     ...state.getReqSerializers(),
     ...rewards.getReqSerializers(),
   };

--- a/packages/api/src/beacon/server/validator.ts
+++ b/packages/api/src/beacon/server/validator.ts
@@ -4,7 +4,7 @@ import {ServerRoutes, getGenericJsonServer} from "../../utils/server/index.js";
 import {ServerApi} from "../../interfaces.js";
 
 export function getRoutes(config: ChainForkConfig, api: ServerApi<Api>): ServerRoutes<Api, ReqTypes> {
-  const reqSerializers = getReqSerializers();
+  const reqSerializers = getReqSerializers(config);
   const returnTypes = getReturnTypes();
 
   // Most of routes return JSON, use a server auto-generator


### PR DESCRIPTION
**Motivation**

Fixes publishing of electra attestations and aggregates through api

**Description**

Make publish apis fork aware to correctly de-/serialize electra attestations and aggregates.

**NOTE:** This is not a long-term approach we can use, a proper solution requires to add new v2 apis which are fork aware
