### PR TITLE
fix: fix fork sensitive spec tests

### DIFF
--- a/packages/beacon-node/test/spec/presets/operations.test.ts
+++ b/packages/beacon-node/test/spec/presets/operations.test.ts
@@ -71,7 +71,8 @@ const operationFns: Record<string, BlockProcessFn<CachedBeaconStateAllForks>> = 
   sync_aggregate_random: sync_aggregate,
 
   voluntary_exit: (state, testCase: {voluntary_exit: phase0.SignedVoluntaryExit}) => {
-    blockFns.processVoluntaryExit(state, testCase.voluntary_exit);
+    const fork = state.config.getForkSeq(state.slot);
+    blockFns.processVoluntaryExit(fork, state, testCase.voluntary_exit);
   },
 
   execution_payload: (state, testCase: {body: bellatrix.BeaconBlockBody; execution: {execution_valid: boolean}}) => {


### PR DESCRIPTION
`processVoluntaryExit`, `processRegistryUpdates` and `processEffectiveBalanceUpdates` are modified to require fork info in function parameters. 

Modify runners to pass in fork info

Before:
<img width="990" alt="Screenshot 2024-05-13 at 11 11 01 AM" src="https://github.com/ChainSafe/lodestar/assets/17676176/88dc10d7-82d9-4fe5-92c1-9fe8c39f98e6">

After:
<img width="1173" alt="Screenshot 2024-05-13 at 11 18 24 AM" src="https://github.com/ChainSafe/lodestar/assets/17676176/7f0e6fe8-920f-4bc2-882e-ed9f2005ab99">
