### PR TITLE
fix: fix electra genesis spec test

### DIFF
--- a/packages/beacon-node/src/chain/genesis/genesis.ts
+++ b/packages/beacon-node/src/chain/genesis/genesis.ts
@@ -174,7 +174,13 @@ export class GenesisBuilder implements IGenesisBuilder {
         };
       });
 
-    const {activatedValidatorCount} = applyDeposits(this.config, this.state, newDeposits, this.depositTree);
+    const {activatedValidatorCount} = applyDeposits(
+      this.config.getForkSeq(this.state.slot),
+      this.config,
+      this.state,
+      newDeposits,
+      this.depositTree
+    );
     this.activatedValidatorCount += activatedValidatorCount;
 
     // TODO: If necessary persist deposits here to this.db.depositData, this.db.depositDataRoot

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -313,7 +313,6 @@ export class ForkChoice implements IForkChoice {
     // No need to cache the head anymore
 
     // Check if scores need to be calculated/updated
-    console.log("updateHead");
     const oldBalances = this.balances;
     const newBalances = this.fcStore.justified.balances;
     const deltas = computeDeltas(

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -313,6 +313,7 @@ export class ForkChoice implements IForkChoice {
     // No need to cache the head anymore
 
     // Check if scores need to be calculated/updated
+    console.log("updateHead");
     const oldBalances = this.balances;
     const newBalances = this.fcStore.justified.balances;
     const deltas = computeDeltas(

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -239,18 +239,7 @@ export function initializeBeaconStateFromEth1(
     getTemporaryBlockHeader(config, config.getForkTypes(GENESIS_SLOT).BeaconBlock.defaultValue())
   );
 
-  const fork: ForkSeq =
-    GENESIS_SLOT >= config.ELECTRA_FORK_EPOCH
-      ? ForkSeq.electra
-      : GENESIS_SLOT >= config.DENEB_FORK_EPOCH
-        ? ForkSeq.deneb
-        : GENESIS_SLOT >= config.CAPELLA_FORK_EPOCH
-          ? ForkSeq.capella
-          : GENESIS_SLOT >= config.BELLATRIX_FORK_EPOCH
-            ? ForkSeq.bellatrix
-            : GENESIS_SLOT >= config.ALTAIR_FORK_EPOCH
-              ? ForkSeq.altair
-              : ForkSeq.phase0;
+  const fork = config.getForkSeq(GENESIS_SLOT);
 
   // We need a CachedBeaconState to run processDeposit() which uses various caches.
   // However at this point the state's syncCommittees are not known.

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -170,6 +170,7 @@ export function applyDeposits(
   // Process deposit balance updates
   if (fork >= ForkSeq.electra) {
     const stateElectra = state as CachedBeaconStateElectra;
+    stateElectra.commit();
     for (const {index: validatorIndex, amount} of stateElectra.pendingBalanceDeposits.getAllReadonly()) {
       increaseBalance(state, validatorIndex, Number(amount));
     }
@@ -271,7 +272,7 @@ export function initializeBeaconStateFromEth1(
   state.commit();
   const activeValidatorIndices = getActiveValidatorIndices(state, computeEpochAtSlot(GENESIS_SLOT));
 
-  if (fork === ForkSeq.altair) {
+  if (fork >= ForkSeq.altair) {
     const {syncCommittee} = getNextSyncCommittee(
       state,
       activeValidatorIndices,
@@ -284,7 +285,7 @@ export function initializeBeaconStateFromEth1(
     stateAltair.nextSyncCommittee = ssz.altair.SyncCommittee.toViewDU(syncCommittee);
   }
 
-  if (fork === ForkSeq.bellatrix) {
+  if (fork >= ForkSeq.bellatrix) {
     const stateBellatrix = state as CompositeViewDU<typeof ssz.bellatrix.BeaconState>;
     stateBellatrix.fork.previousVersion = config.BELLATRIX_FORK_VERSION;
     stateBellatrix.fork.currentVersion = config.BELLATRIX_FORK_VERSION;
@@ -293,7 +294,7 @@ export function initializeBeaconStateFromEth1(
       ssz.bellatrix.ExecutionPayloadHeader.defaultViewDU();
   }
 
-  if (fork === ForkSeq.capella) {
+  if (fork >= ForkSeq.capella) {
     const stateCapella = state as CompositeViewDU<typeof ssz.capella.BeaconState>;
     stateCapella.fork.previousVersion = config.CAPELLA_FORK_VERSION;
     stateCapella.fork.currentVersion = config.CAPELLA_FORK_VERSION;
@@ -302,7 +303,7 @@ export function initializeBeaconStateFromEth1(
       ssz.capella.ExecutionPayloadHeader.defaultViewDU();
   }
 
-  if (fork === ForkSeq.deneb) {
+  if (fork >= ForkSeq.deneb) {
     const stateDeneb = state as CompositeViewDU<typeof ssz.deneb.BeaconState>;
     stateDeneb.fork.previousVersion = config.DENEB_FORK_VERSION;
     stateDeneb.fork.currentVersion = config.DENEB_FORK_VERSION;
@@ -311,7 +312,7 @@ export function initializeBeaconStateFromEth1(
       ssz.deneb.ExecutionPayloadHeader.defaultViewDU();
   }
 
-  if (fork === ForkSeq.electra) {
+  if (fork >= ForkSeq.electra) {
     const stateElectra = state as CompositeViewDU<typeof ssz.electra.BeaconState>;
     stateElectra.fork.previousVersion = config.ELECTRA_FORK_VERSION;
     stateElectra.fork.currentVersion = config.ELECTRA_FORK_VERSION;

--- a/packages/types/src/electra/sszTypes.ts
+++ b/packages/types/src/electra/sszTypes.ts
@@ -275,6 +275,11 @@ export const PendingBalanceDeposit = new ContainerType(
   {typeName: "PendingBalanceDeposit", jsonCase: "eth2"}
 );
 
+export const PendingBalanceDeposits = new ListCompositeType(
+  PendingBalanceDeposit,
+  Number(PENDING_BALANCE_DEPOSITS_LIMIT)
+);
+
 export const PartialWithdrawal = new ContainerType(
   {
     index: ValidatorIndex,
@@ -341,7 +346,7 @@ export const BeaconState = new ContainerType(
     earliestExitEpoch: Epoch, // New in Electra:EIP7251
     consolidationBalanceToConsume: Gwei, // New in Electra:EIP7251
     earliestConsolidationEpoch: Epoch, // New in Electra:EIP7251
-    pendingBalanceDeposits: new ListCompositeType(PendingBalanceDeposit, Number(PENDING_BALANCE_DEPOSITS_LIMIT)), // new in electra:eip7251
+    pendingBalanceDeposits: PendingBalanceDeposits, // new in electra:eip7251
     pendingPartialWithdrawals: new ListCompositeType(PartialWithdrawal, Number(PENDING_PARTIAL_WITHDRAWALS_LIMIT)), // New in Electra:EIP7251
     pendingConsolidations: new ListCompositeType(PendingConsolidation, Number(PENDING_CONSOLIDATIONS_LIMIT)), // new in electra:eip7251
   },


### PR DESCRIPTION
Fix genesis spec test

```
   ✓ electra/genesis/initialization/pyspec_tests (7) 813ms
     ✓ electra/genesis/initialization/pyspec_tests/initialize_beacon_state_from_eth1
     ✓ electra/genesis/initialization/pyspec_tests/initialize_beacon_state_one_topup_activation
     ✓ electra/genesis/initialization/pyspec_tests/initialize_beacon_state_random_invalid_genesis
     ✓ electra/genesis/initialization/pyspec_tests/initialize_beacon_state_random_valid_genesis
     ✓ electra/genesis/initialization/pyspec_tests/initialize_beacon_state_some_small_balances 334ms
     ✓ electra/genesis/initialization/pyspec_tests/initialize_post_transition
     ✓ electra/genesis/initialization/pyspec_tests/initialize_pre_transition_empty_payload
   ✓ electra/genesis/validity/pyspec_tests (5)
     ✓ electra/genesis/validity/pyspec_tests/extra_balance
     ✓ electra/genesis/validity/pyspec_tests/full_genesis_deposits
     ✓ electra/genesis/validity/pyspec_tests/invalid_invalid_timestamp
     ✓ electra/genesis/validity/pyspec_tests/invalid_not_enough_validator_count
     ✓ electra/genesis/validity/pyspec_tests/one_more_validator
```