### PR TITLE
feat: support missing electra spec test

### DIFF
--- a/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
+++ b/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
@@ -42,6 +42,8 @@ const epochTransitionFns: Record<string, EpochTransitionFn> = {
   slashings_reset: epochFns.processSlashingsReset,
   sync_committee_updates: epochFns.processSyncCommitteeUpdates as EpochTransitionFn,
   historical_summaries_update: epochFns.processHistoricalSummariesUpdate as EpochTransitionFn,
+  pending_balance_deposits: epochFns.processPendingBalanceDeposits as EpochTransitionFn,
+  pending_consolidations: epochFns.processPendingConsolidations as EpochTransitionFn,
 };
 
 /**

--- a/packages/beacon-node/test/spec/presets/operations.test.ts
+++ b/packages/beacon-node/test/spec/presets/operations.test.ts
@@ -91,6 +91,21 @@ const operationFns: Record<string, BlockProcessFn<CachedBeaconStateAllForks>> = 
   withdrawals: (state, testCase: {execution_payload: capella.ExecutionPayload}) => {
     blockFns.processWithdrawals(ForkSeq.capella, state as CachedBeaconStateCapella, testCase.execution_payload);
   },
+
+  consolidation: (state, testCase: {consolidation: electra.SignedConsolidation}) => {
+    blockFns.processConsolidation(state as CachedBeaconStateElectra, testCase.consolidation);
+  },
+
+  execution_layer_withdrawal_request: (
+    state,
+    testCase: {execution_layer_withdrawal_request: electra.ExecutionLayerWithdrawalRequest}
+  ) => {
+    blockFns.processExecutionLayerWithdrawalRequest(
+      ForkSeq.electra,
+      state as CachedBeaconStateElectra,
+      testCase.execution_layer_withdrawal_request
+    );
+  },
 };
 
 export type BlockProcessFn<T extends CachedBeaconStateAllForks> = (state: T, testCase: any) => void;
@@ -140,6 +155,8 @@ const operations: TestRunnerFn<OperationsTestCase, BeaconStateAllForks> = (fork,
             : ssz.bellatrix.ExecutionPayload,
         // Capella
         address_change: ssz.capella.SignedBLSToExecutionChange,
+        consolidation: ssz.electra.SignedConsolidation,
+        execution_layer_withdrawal_request: ssz.electra.ExecutionLayerWithdrawalRequest,
       },
       shouldError: (testCase) => testCase.post === undefined,
       getExpected: (testCase) => testCase.post,

--- a/packages/state-transition/src/block/processOperations.ts
+++ b/packages/state-transition/src/block/processOperations.ts
@@ -23,6 +23,7 @@ export {
   processExecutionLayerWithdrawalRequest,
   processBlsToExecutionChange,
   processDepositRequest,
+  processConsolidation,
 };
 
 export function processOperations(


### PR DESCRIPTION
`processPendingBalanceDeposits`, `processPendingConsolidations`, `processConsolidation` and `processExecutionLayerWithdrawalRequest` are introduced in electra.

This PR adds support to run spec tests related to these 4 functions