### PR TITLE
fix: inline sourcemaps to help with debugging

### DIFF
--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -40,6 +40,7 @@ export function getBaseViteConfig(
     esbuild: {
       banner,
       legalComments: "none",
+      sourcemap: "inline",
     },
     build: {
       // "modules" refer to ['es2020', 'edge88', 'firefox78', 'chrome87', 'safari14']


### PR DESCRIPTION
**Motivation**

Turns on inline sourcemaps to help with debugging under vitest.  Only works with vscode enabled debugging console and will work to get this expended to a debug launch profile

<img width="1728" alt="Screenshot 2024-05-14 at 10 42 43 AM" src="https://github.com/ChainSafe/lodestar/assets/18608739/a95ce5fe-56f1-4809-af5b-f5857424e063">

