### PR TITLE
fix: electra fork transition spec tests

### DIFF
--- a/packages/state-transition/src/slot/upgradeStateToElectra.ts
+++ b/packages/state-transition/src/slot/upgradeStateToElectra.ts
@@ -58,8 +58,8 @@ export function upgradeStateToElectra(stateDeneb: CachedBeaconStateDeneb): Cache
   stateElectraView.historicalSummaries = stateElectraCloned.historicalSummaries;
 
   // latestExecutionPayloadHeader's depositRequestsRoot and withdrawalRequestsRoot set to zeros by default
-  // default value of depositRequestsStartIndex is UNSET_DEPOSIT_RECEIPTS_START_INDEX
-  stateElectraView.depositRequestsStartIndex = UNSET_DEPOSIT_RECEIPTS_START_INDEX;
+  // default value of depositReceiptsStartIndex is UNSET_DEPOSIT_RECEIPTS_START_INDEX
+  stateElectraView.depositReceiptsStartIndex = UNSET_DEPOSIT_RECEIPTS_START_INDEX;
   stateElectraView.depositBalanceToConsume = BigInt(0);
   stateElectraView.exitBalanceToConsume = BigInt(0);
 

--- a/packages/state-transition/src/slot/upgradeStateToElectra.ts
+++ b/packages/state-transition/src/slot/upgradeStateToElectra.ts
@@ -57,7 +57,7 @@ export function upgradeStateToElectra(stateDeneb: CachedBeaconStateDeneb): Cache
   stateElectraView.nextWithdrawalValidatorIndex = stateDeneb.nextWithdrawalValidatorIndex;
   stateElectraView.historicalSummaries = stateElectraCloned.historicalSummaries;
 
-  // latestExecutionPayloadHeader's depositRequestsRoot and withdrawalRequestsRoot set to zeros by default
+  // latestExecutionPayloadHeader's depositReceiptsRoot and withdrawalRequestsRoot set to zeros by default
   // default value of depositReceiptsStartIndex is UNSET_DEPOSIT_RECEIPTS_START_INDEX
   stateElectraView.depositReceiptsStartIndex = UNSET_DEPOSIT_RECEIPTS_START_INDEX;
   stateElectraView.depositBalanceToConsume = BigInt(0);


### PR DESCRIPTION
**Motivation**

Fix electra fork transition spec tests

**Description**

Follow https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/fork.md


```
· deneb/fork/fork/pyspec_tests/deneb_fork_random_2
     ✓ deneb/fork/fork/pyspec_tests/deneb_fork_random_2
 ✓ test/spec/presets/fork.test.ts (72) 1554ms
   ✓ altair/fork/fork/pyspec_tests (16) 475ms
     ✓ altair/fork/fork/pyspec_tests/altair_fork_random_0
     ✓ altair/fork/fork/pyspec_tests/altair_fork_random_1
     ✓ altair/fork/fork/pyspec_tests/altair_fork_random_2
     ✓ altair/fork/fork/pyspec_tests/altair_fork_random_3
     ✓ altair/fork/fork/pyspec_tests/altair_fork_random_duplicate_attestations
     ✓ altair/fork/fork/pyspec_tests/altair_fork_random_large_validator_set
     ✓ altair/fork/fork/pyspec_tests/altair_fork_random_low_balances
     ✓ altair/fork/fork/pyspec_tests/altair_fork_random_misc_balances
     ✓ altair/fork/fork/pyspec_tests/altair_fork_random_mismatched_attestations
     ✓ altair/fork/fork/pyspec_tests/fork_base_state
     ✓ altair/fork/fork/pyspec_tests/fork_many_next_epoch
     ✓ altair/fork/fork/pyspec_tests/fork_next_epoch
     ✓ altair/fork/fork/pyspec_tests/fork_next_epoch_with_block
     ✓ altair/fork/fork/pyspec_tests/fork_random_large_validator_set
     ✓ altair/fork/fork/pyspec_tests/fork_random_low_balances
     ✓ altair/fork/fork/pyspec_tests/fork_random_misc_balances
   ✓ bellatrix/fork/fork/pyspec_tests (14)
     ✓ bellatrix/fork/fork/pyspec_tests/bellatrix_fork_random_0
     ✓ bellatrix/fork/fork/pyspec_tests/bellatrix_fork_random_1
     ✓ bellatrix/fork/fork/pyspec_tests/bellatrix_fork_random_2
     ✓ bellatrix/fork/fork/pyspec_tests/bellatrix_fork_random_3
     ✓ bellatrix/fork/fork/pyspec_tests/bellatrix_fork_random_large_validator_set
     ✓ bellatrix/fork/fork/pyspec_tests/bellatrix_fork_random_low_balances
     ✓ bellatrix/fork/fork/pyspec_tests/bellatrix_fork_random_misc_balances
     ✓ bellatrix/fork/fork/pyspec_tests/fork_base_state
     ✓ bellatrix/fork/fork/pyspec_tests/fork_many_next_epoch
     ✓ bellatrix/fork/fork/pyspec_tests/fork_next_epoch
     ✓ bellatrix/fork/fork/pyspec_tests/fork_next_epoch_with_block
     ✓ bellatrix/fork/fork/pyspec_tests/fork_random_large_validator_set
     ✓ bellatrix/fork/fork/pyspec_tests/fork_random_low_balances
     ✓ bellatrix/fork/fork/pyspec_tests/fork_random_misc_balances
   ✓ capella/fork/fork/pyspec_tests (14)
     ✓ capella/fork/fork/pyspec_tests/capella_fork_random_0
     ✓ capella/fork/fork/pyspec_tests/capella_fork_random_1
     ✓ capella/fork/fork/pyspec_tests/capella_fork_random_2
     ✓ capella/fork/fork/pyspec_tests/capella_fork_random_3
     ✓ capella/fork/fork/pyspec_tests/capella_fork_random_large_validator_set
     ✓ capella/fork/fork/pyspec_tests/capella_fork_random_low_balances
     ✓ capella/fork/fork/pyspec_tests/capella_fork_random_misc_balances
     ✓ capella/fork/fork/pyspec_tests/fork_base_state
     ✓ capella/fork/fork/pyspec_tests/fork_many_next_epoch
     ✓ capella/fork/fork/pyspec_tests/fork_next_epoch
     ✓ capella/fork/fork/pyspec_tests/fork_next_epoch_with_block
     ✓ capella/fork/fork/pyspec_tests/fork_random_large_validator_set
     ✓ capella/fork/fork/pyspec_tests/fork_random_low_balances
     ✓ capella/fork/fork/pyspec_tests/fork_random_misc_balances
   ✓ deneb/fork/fork/pyspec_tests (14) 381ms
     ✓ deneb/fork/fork/pyspec_tests/deneb_fork_random_0
     ✓ deneb/fork/fork/pyspec_tests/deneb_fork_random_1
     ✓ deneb/fork/fork/pyspec_tests/deneb_fork_random_2
     ✓ deneb/fork/fork/pyspec_tests/deneb_fork_random_3
     ✓ deneb/fork/fork/pyspec_tests/deneb_fork_random_large_validator_set
     ✓ deneb/fork/fork/pyspec_tests/deneb_fork_random_low_balances
     ✓ deneb/fork/fork/pyspec_tests/deneb_fork_random_misc_balances
     ✓ deneb/fork/fork/pyspec_tests/fork_base_state
     ✓ deneb/fork/fork/pyspec_tests/fork_many_next_epoch
     ✓ deneb/fork/fork/pyspec_tests/fork_next_epoch
     ✓ deneb/fork/fork/pyspec_tests/fork_next_epoch_with_block
     ✓ deneb/fork/fork/pyspec_tests/fork_random_large_validator_set
     ✓ deneb/fork/fork/pyspec_tests/fork_random_low_balances
     ✓ deneb/fork/fork/pyspec_tests/fork_random_misc_balances
   ✓ electra/fork/fork/pyspec_tests (14)
     ✓ electra/fork/fork/pyspec_tests/electra_fork_random_0
     ✓ electra/fork/fork/pyspec_tests/electra_fork_random_1
     ✓ electra/fork/fork/pyspec_tests/electra_fork_random_2
     ✓ electra/fork/fork/pyspec_tests/electra_fork_random_3
     ✓ electra/fork/fork/pyspec_tests/electra_fork_random_large_validator_set
     ✓ electra/fork/fork/pyspec_tests/electra_fork_random_low_balances
     ✓ electra/fork/fork/pyspec_tests/electra_fork_random_misc_balances
     ✓ electra/fork/fork/pyspec_tests/fork_base_state
     ✓ electra/fork/fork/pyspec_tests/fork_many_next_epoch
     ✓ electra/fork/fork/pyspec_tests/fork_next_epoch
     ✓ electra/fork/fork/pyspec_tests/fork_next_epoch_with_block
     ✓ electra/fork/fork/pyspec_tests/fork_random_large_validator_set
     ✓ electra/fork/fork/pyspec_tests/fork_random_low_balances
     ✓ electra/fork/fork/pyspec_tests/fork_random_misc_balances

 Test Files  1 passed (1)
      Tests  72 passed (72)
```
