### PR TITLE
fix: use mutable validator object

### DIFF
--- a/packages/state-transition/src/block/processExecutionLayerWithdrawalRequest.ts
+++ b/packages/state-transition/src/block/processExecutionLayerWithdrawalRequest.ts
@@ -37,7 +37,7 @@ export function processExecutionLayerWithdrawalRequest(
     return;
   }
 
-  const validator = validators.getReadonly(validatorIndex);
+  const validator = validators.get(validatorIndex);
   if (!isValidatorEligibleForWithdrawOrExit(validator, executionLayerWithdrawalRequest.sourceAddress, state)) {
     return;
   }


### PR DESCRIPTION
Used `getReadOnly()` validator object when setting epochs. Use `get()` instead