### PR TITLE
test: fix balance spec tests

### DIFF
--- a/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -43,6 +43,9 @@ export function processEffectiveBalanceUpdates(
   // It defaults to `state.balances.getAll()` to make Typescript happy and for spec tests
   const balances = state.balances.getAll();
 
+  // TODO: (@matthewkeil) This was causing additional failures but should not.  Check the EpochTransitionCache for why
+  // const balances = cache.balances ?? state.balances.getAll();
+
   for (let i = 0, len = balances.length; i < len; i++) {
     const balance = balances[i];
 

--- a/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -41,7 +41,7 @@ export function processEffectiveBalanceUpdates(
 
   // epochTransitionCache.balances is set in processRewardsAndPenalties(), so it's recycled here for performance.
   // It defaults to `state.balances.getAll()` to make Typescript happy and for spec tests
-  const balances = cache.balances ?? state.balances.getAll();
+  const balances = state.balances.getAll();
 
   for (let i = 0, len = balances.length; i < len; i++) {
     const balance = balances[i];
@@ -55,7 +55,7 @@ export function processEffectiveBalanceUpdates(
       // Too big
       effectiveBalance > balance + DOWNWARD_THRESHOLD ||
       // Too small. Check effectiveBalance < MAX_EFFECTIVE_BALANCE to prevent unnecessary updates
-      (effectiveBalance < MAX_EFFECTIVE_BALANCE && effectiveBalance < balance - UPWARD_THRESHOLD)
+      effectiveBalance + UPWARD_THRESHOLD < balance
     ) {
       // Update the state tree
       // Should happen rarely, so it's fine to update the tree

--- a/packages/state-transition/src/epoch/processRewardsAndPenalties.ts
+++ b/packages/state-transition/src/epoch/processRewardsAndPenalties.ts
@@ -28,7 +28,8 @@ export function processRewardsAndPenalties(
   const balances = state.balances.getAll();
 
   for (let i = 0, len = rewards.length; i < len; i++) {
-    balances[i] += rewards[i] - penalties[i] - (slashingPenalties[i] ?? 0);
+    const result = balances[i] + rewards[i] - penalties[i] - (slashingPenalties[i] ?? 0)
+    balances[i] = Math.max(result, 0);
   }
 
   // important: do not change state one balance at a time. Set them all at once, constructing the tree in one go


### PR DESCRIPTION
**Motivation**

Fixes several invalid state root errors in the spec tests.  Only three invalid conditions remain.

**Description**
- removes check of cache.balances
- removes additional condition from effective balance check (not in spec)
- prevents negative balances