### PR TITLE
fix: effective balance cache is not in sync with validator effective balance

### DIFF
--- a/packages/state-transition/src/util/electra.ts
+++ b/packages/state-transition/src/util/electra.ts
@@ -93,6 +93,7 @@ export function queueEntireBalanceAndResetValidator(state: CachedBeaconStateElec
 
   const validator = state.validators.get(index);
   validator.effectiveBalance = 0;
+  state.epochCtx.effectiveBalanceIncrementsSet(index, 0);
   validator.activationEligibilityEpoch = FAR_FUTURE_EPOCH;
 
   const pendingBalanceDeposit = ssz.electra.PendingBalanceDeposit.toViewDU({


### PR DESCRIPTION
During fork transition, the effective balance and balance of pending activation validators need to be zero out. But effective balance cache in EpochCache is not updated thus the discrepancy 