### PR TITLE
fix: align BeaconBlockBody and BlindedBeaconBlockBody

### DIFF
--- a/packages/types/src/electra/sszTypes.ts
+++ b/packages/types/src/electra/sszTypes.ts
@@ -223,6 +223,7 @@ export const BlindedBeaconBlockBody = new ContainerType(
     executionPayloadHeader: ExecutionPayloadHeader, // Modified in ELECTRA
     blsToExecutionChanges: capellaSsz.BeaconBlockBody.fields.blsToExecutionChanges,
     blobKzgCommitments: denebSsz.BeaconBlockBody.fields.blobKzgCommitments,
+    consolidations: new ListCompositeType(SignedConsolidation, MAX_CONSOLIDATIONS), // [New in Electra]
   },
   {typeName: "BlindedBeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
 );

--- a/packages/types/test/unit/blinded.test.ts
+++ b/packages/types/test/unit/blinded.test.ts
@@ -1,0 +1,31 @@
+import {describe, it, expect} from "vitest";
+import {ContainerType} from "@chainsafe/ssz";
+import {ssz} from "../../src/index.js";
+
+describe("blinded datastructures", function () {
+  it("should have the same number of fields as non-blinded", () => {
+    const blindedTypes = [
+      {a: "BlindedBeaconBlockBody", b: "BeaconBlockBody"},
+      {a: "ExecutionPayloadHeader", b: "ExecutionPayload"},
+    ];
+
+    for (const {a, b} of blindedTypes) {
+      for (const fork of Object.keys(ssz.allForks) as (keyof typeof ssz.allForks)[]) {
+        // @ts-expect-error generic string typenames used across forks
+        const blindedType = ssz[fork][a] as ContainerType<any> | undefined;
+        // @ts-expect-error generic string typenames used across forks
+        const type = ssz[fork][b] as ContainerType<any> | undefined;
+
+        if (!blindedType || !type) {
+          continue;
+        }
+
+        expect(
+          Object.keys(blindedType.fields).length,
+          // eslint-disable-next-line vitest/valid-expect
+          `fork: ${fork}, types ${a} and ${b} have different number of fields`
+        ).toBe(Object.keys(type.fields).length);
+      }
+    }
+  });
+});


### PR DESCRIPTION
**Motivation**

- eip-7688 uncovered an inconsistency between our electra BeaconBlockBody and BlindedBeaconBlockBody definitions

**Description**

- align BeaconBlockBody and BlindedBeaconBlockBody
- add unit test that enforces equal # of fields between known blinded/unblinded variant types