### PR TITLE
fix: validator monitor summaries should not render during epoch 0

### DIFF
--- a/packages/beacon-node/src/metrics/validatorMonitor.ts
+++ b/packages/beacon-node/src/metrics/validatorMonitor.ts
@@ -633,7 +633,14 @@ export function createValidatorMonitor(
       }
 
       // Compute summaries of previous epoch attestation performance
-      const prevEpoch = Math.max(0, computeEpochAtSlot(headState.slot) - 1);
+      const prevEpoch = computeEpochAtSlot(headState.slot) - 1;
+
+      // During the end of first epoch, the prev epoch with be -1
+      // Skip this as there is no attestation and block proposal summary in epoch -1
+      if (prevEpoch === -1) {
+        return;
+      }
+
       const rootCache = new RootHexCache(headState);
 
       if (config.getForkSeq(headState.slot) >= ForkSeq.altair) {


### PR DESCRIPTION
Currently at the end of epoch n, we render attestation and block proposal summaries from the epoch n - 1. 

At epoch 0, since no epoch -1 summary is available, we should not render any summaries but current behaviour renders summaries from epoch 0.

Note this issue exists in `unstable` branch as well. Merging to `electra-fork` for now as it doesn't show up in nodes connected to mainnet so it's not urgent

closes #6784 