### PR TITLE
chore: upgrade classic-level

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "release:tag-stable": "node scripts/release/tag_stable.mjs",
     "release:publish": "lerna publish from-package --yes --no-verify-access"
   },
+  "dependencies": {
+    "classic-level": "1.4.1"
+  },
   "devDependencies": {
     "@actions/core": "^1.10.1",
     "@chainsafe/eslint-plugin-node": "^11.2.3",
@@ -51,8 +54,8 @@
     "@types/node": "^20.11.28",
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@typescript-eslint/parser": "^7.2.0",
-    "@vitest/coverage-v8": "^1.6.0",
     "@vitest/browser": "^1.6.0",
+    "@vitest/coverage-v8": "^1.6.0",
     "crypto-browserify": "^3.12.0",
     "dotenv": "^16.4.5",
     "electron": "^26.2.2",
@@ -78,10 +81,10 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.4.2",
     "typescript-docs-verifier": "^2.5.0",
+    "vite": "^5.2.11",
+    "vite-plugin-dts": "^3.9.1",
     "vite-plugin-node-polyfills": "^0.21.0",
     "vite-plugin-top-level-await": "^1.4.1",
-    "vite-plugin-dts": "^3.9.1",
-    "vite": "^5.2.11",
     "vitest": "^1.6.0",
     "vitest-when": "^0.3.1",
     "wait-port": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
     "release:tag-stable": "node scripts/release/tag_stable.mjs",
     "release:publish": "lerna publish from-package --yes --no-verify-access"
   },
-  "dependencies": {
-    "classic-level": "1.4.1"
-  },
   "devDependencies": {
     "@actions/core": "^1.10.1",
     "@chainsafe/eslint-plugin-node": "^11.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4808,6 +4808,17 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+classic-level@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/classic-level/-/classic-level-1.4.1.tgz#169ecf9f9c6200ad42a98c8576af449c1badbaee"
+  integrity sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==
+  dependencies:
+    abstract-level "^1.0.2"
+    catering "^2.1.0"
+    module-error "^1.0.1"
+    napi-macros "^2.2.2"
+    node-gyp-build "^4.3.0"
+
 classic-level@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/classic-level/-/classic-level-1.2.0.tgz#2d52bdec8e7a27f534e67fdeb890abef3e643c27"
@@ -9499,6 +9510,11 @@ nanoid@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
+
+napi-macros@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/napi-macros/-/napi-macros-2.2.2.tgz#817fef20c3e0e40a963fbf7b37d1600bd0201044"
+  integrity sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==
 
 napi-macros@~2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4808,7 +4808,7 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-classic-level@1.4.1:
+classic-level@^1.2.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/classic-level/-/classic-level-1.4.1.tgz#169ecf9f9c6200ad42a98c8576af449c1badbaee"
   integrity sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==
@@ -4817,17 +4817,6 @@ classic-level@1.4.1:
     catering "^2.1.0"
     module-error "^1.0.1"
     napi-macros "^2.2.2"
-    node-gyp-build "^4.3.0"
-
-classic-level@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/classic-level/-/classic-level-1.2.0.tgz#2d52bdec8e7a27f534e67fdeb890abef3e643c27"
-  integrity sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==
-  dependencies:
-    abstract-level "^1.0.2"
-    catering "^2.1.0"
-    module-error "^1.0.1"
-    napi-macros "~2.0.0"
     node-gyp-build "^4.3.0"
 
 clean-stack@^2.0.0:


### PR DESCRIPTION
**Motivation**

Make sure latest `classic-level` version is used. It introduces changes by @matthewkeil 

**Description**

Ran `yarn upgrade classic-level@1.4.1` to use latest transitive dependency of `level`, `classic-level`.
Note that it introduces a top-level `dependencies` element in root `package.json`. Is that the recommended approach?