### PR TITLE
fix: update withdrawal request container to match consensus spec

### DIFF
--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -419,7 +419,7 @@ export function serializeExecutionLayerWithdrawalRequest(
 ): ExecutionLayerWithdrawalRequestRpc {
   return {
     sourceAddress: bytesToData(withdrawalRequest.sourceAddress),
-    validatorPublicKey: bytesToData(withdrawalRequest.validatorPublicKey),
+    validatorPublicKey: bytesToData(withdrawalRequest.validatorPubkey),
     amount: numToQuantity(withdrawalRequest.amount),
   };
 }
@@ -429,7 +429,7 @@ export function deserializeExecutionLayerWithdrawalRequest(
 ): electra.ExecutionLayerWithdrawalRequest {
   return {
     sourceAddress: dataToBytes(withdrawalRequest.sourceAddress, 20),
-    validatorPublicKey: dataToBytes(withdrawalRequest.validatorPublicKey, 48),
+    validatorPubkey: dataToBytes(withdrawalRequest.validatorPublicKey, 48),
     amount: quantityToNum(withdrawalRequest.amount),
   };
 }

--- a/packages/state-transition/src/block/processExecutionLayerWithdrawalRequest.ts
+++ b/packages/state-transition/src/block/processExecutionLayerWithdrawalRequest.ts
@@ -32,7 +32,7 @@ export function processExecutionLayerWithdrawalRequest(
 
   // bail out if validator is not in beacon state
   // note that we don't need to check for 6110 unfinalized vals as they won't be eligible for withdraw/exit anyway
-  const validatorIndex = pubkey2index.get(executionLayerWithdrawalRequest.validatorPublicKey);
+  const validatorIndex = pubkey2index.get(executionLayerWithdrawalRequest.validatorPubkey);
   if (validatorIndex === undefined) {
     return;
   }

--- a/packages/types/src/electra/sszTypes.ts
+++ b/packages/types/src/electra/sszTypes.ts
@@ -128,7 +128,7 @@ export const DepositReceipts = new ListCompositeType(DepositReceipt, MAX_DEPOSIT
 export const ExecutionLayerWithdrawalRequest = new ContainerType(
   {
     sourceAddress: ExecutionAddress,
-    validatorPublicKey: BLSPubkey,
+    validatorPubkey: BLSPubkey,
     amount: UintNum64,
   },
   {typeName: "ExecutionLayerWithdrawalRequest", jsonCase: "eth2"}


### PR DESCRIPTION
**Motivation**

Noticed we are no longer following the consensus spec since https://github.com/ChainSafe/lodestar/pull/6789, the ssz_static tests are failing and there are issues if execution layer withdrawals are submitted to the network.

**Description**

Update withdrawal request container to match consensus spec