### PR TITLE
test: only skip ssz_static tests associated to missing type

### DIFF
--- a/packages/beacon-node/test/spec/presets/ssz_static.test.ts
+++ b/packages/beacon-node/test/spec/presets/ssz_static.test.ts
@@ -57,25 +57,28 @@ const sszStatic =
       (ssz.altair as Types)[typeName] ||
       (ssz.phase0 as Types)[typeName];
 
+    it(`SSZ type ${typeName} for fork ${fork} is defined`, function () {
+      expect(sszType).toBeDefined();
+    });
+
     if (!sszType) {
-      expect.fail(
-        `Missing SSZ type definition for ${typeName}; this will prevent associated ssz_static tests to be executed`
-      );
-    } else {
-      const sszTypeNoUint = replaceUintTypeWithUintBigintType(sszType);
+      // Return instead of throwing an error to only skip ssz_static tests associated to missing type
+      return;
+    }
 
-      for (const testCase of fs.readdirSync(testSuiteDirpath)) {
-        // Do not manually skip tests here, do it in packages/beacon-node/test/spec/presets/index.test.ts
-        it(testCase, function () {
-          // Mainnet must deal with big full states and hash each one multiple times
-          if (ACTIVE_PRESET === "mainnet") {
-            vi.setConfig({testTimeout: 30 * 1000});
-          }
+    const sszTypeNoUint = replaceUintTypeWithUintBigintType(sszType);
 
-          const testData = parseSszStaticTestcase(path.join(testSuiteDirpath, testCase));
-          runValidSszTest(sszTypeNoUint, testData);
-        });
-      }
+    for (const testCase of fs.readdirSync(testSuiteDirpath)) {
+      // Do not manually skip tests here, do it in packages/beacon-node/test/spec/presets/index.test.ts
+      it(testCase, function () {
+        // Mainnet must deal with big full states and hash each one multiple times
+        if (ACTIVE_PRESET === "mainnet") {
+          vi.setConfig({testTimeout: 30 * 1000});
+        }
+
+        const testData = parseSszStaticTestcase(path.join(testSuiteDirpath, testCase));
+        runValidSszTest(sszTypeNoUint, testData);
+      });
     }
   };
 

--- a/packages/beacon-node/test/spec/presets/ssz_static.test.ts
+++ b/packages/beacon-node/test/spec/presets/ssz_static.test.ts
@@ -57,8 +57,8 @@ const sszStatic =
       (ssz.altair as Types)[typeName] ||
       (ssz.phase0 as Types)[typeName];
 
-    it(`SSZ type ${typeName} for fork ${fork} is defined`, function () {
-      expect(sszType).toBeDefined();
+    it(`${fork} - ${typeName} type exists`, function () {
+      expect(sszType).toEqualWithMessage(expect.any(Type), `SSZ type ${typeName} for fork ${fork} is not defined`);
     });
 
     if (!sszType) {


### PR DESCRIPTION
**Motivation**

Motivation from https://github.com/ChainSafe/lodestar/pull/6776 to only skip ssz_static tests associated to missing type instead of all ssz_static tests.

**Description**

- add separate `it`-statement to assert that type is defined
- return instead of throwing an error if type is not defined
