### PR TITLE
perf(reqresp): improve the reqresp request/response methods

### DIFF
--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -50,7 +50,7 @@ export interface ReqRespBeaconNodeModules {
   getHandler: GetReqRespHandlerFn;
 }
 
-export type ReqRespBeaconNodeOpts = ReqRespOpts;
+export type ReqRespBeaconNodeOpts = Partial<ReqRespOpts>;
 
 /**
  * Implementation of Ethereum Consensus p2p Req/Resp domain.

--- a/packages/reqresp/src/constants.ts
+++ b/packages/reqresp/src/constants.ts
@@ -1,0 +1,12 @@
+// Default spec values from https://github.com/ethereum/consensus-specs/blob/v1.2.0/specs/phase0/p2p-interface.md#configuration
+export const DEFAULT_DIAL_TIMEOUT = 5 * 1000; // 5 sec
+export const DEFAULT_REQUEST_TIMEOUT = 5 * 1000; // 5 sec
+export const DEFAULT_TTFB_TIMEOUT = 5 * 1000; // 5 sec
+export const DEFAULT_RESP_TIMEOUT = 10 * 1000; // 10 sec
+
+export const DEFAULT_TIMEOUTS = {
+  requestTimeoutMs: DEFAULT_REQUEST_TIMEOUT,
+  dialTimeoutMs: DEFAULT_DIAL_TIMEOUT,
+  ttfbTimeoutMs: DEFAULT_TTFB_TIMEOUT,
+  respTimeoutMs: DEFAULT_RESP_TIMEOUT,
+};

--- a/packages/reqresp/src/constants.ts
+++ b/packages/reqresp/src/constants.ts
@@ -3,10 +3,3 @@ export const DEFAULT_DIAL_TIMEOUT = 5 * 1000; // 5 sec
 export const DEFAULT_REQUEST_TIMEOUT = 5 * 1000; // 5 sec
 export const DEFAULT_TTFB_TIMEOUT = 5 * 1000; // 5 sec
 export const DEFAULT_RESP_TIMEOUT = 10 * 1000; // 10 sec
-
-export const DEFAULT_TIMEOUTS = {
-  requestTimeoutMs: DEFAULT_REQUEST_TIMEOUT,
-  dialTimeoutMs: DEFAULT_DIAL_TIMEOUT,
-  ttfbTimeoutMs: DEFAULT_TTFB_TIMEOUT,
-  respTimeoutMs: DEFAULT_RESP_TIMEOUT,
-};

--- a/packages/reqresp/test/unit/request/index.test.ts
+++ b/packages/reqresp/test/unit/request/index.test.ts
@@ -14,7 +14,19 @@ import {responseEncode} from "../../utils/response.js";
 import {RespStatus} from "../../../src/interface.js";
 import {expectRejectedWithLodestarError} from "../../utils/errors.js";
 import {pingProtocol} from "../../fixtures/protocols.js";
-import {DEFAULT_TIMEOUTS} from "../../../src/constants.js";
+import {
+  DEFAULT_DIAL_TIMEOUT,
+  DEFAULT_REQUEST_TIMEOUT,
+  DEFAULT_RESP_TIMEOUT,
+  DEFAULT_TTFB_TIMEOUT,
+} from "../../../src/constants.js";
+
+const DEFAULT_TIMEOUTS = {
+  requestTimeoutMs: DEFAULT_REQUEST_TIMEOUT,
+  dialTimeoutMs: DEFAULT_DIAL_TIMEOUT,
+  ttfbTimeoutMs: DEFAULT_TTFB_TIMEOUT,
+  respTimeoutMs: DEFAULT_RESP_TIMEOUT,
+};
 
 describe("request / sendRequest", () => {
   const logger = getEmptyLogger();

--- a/packages/reqresp/test/unit/response/index.test.ts
+++ b/packages/reqresp/test/unit/response/index.test.ts
@@ -4,12 +4,13 @@ import {LodestarError, fromHex} from "@lodestar/utils";
 import {getEmptyLogger} from "@lodestar/logger/empty";
 import {Protocol, RespStatus} from "../../../src/index.js";
 import {ReqRespRateLimiter} from "../../../src/rate_limiter/ReqRespRateLimiter.js";
-import {handleRequest} from "../../../src/response/index.js";
+import {sendResponse} from "../../../src/response/index.js";
 import {sszSnappyPing} from "../../fixtures/messages.js";
 import {expectRejectedWithLodestarError} from "../../utils/errors.js";
 import {MockLibP2pStream, expectEqualByteChunks} from "../../utils/index.js";
 import {getValidPeerId} from "../../utils/peer.js";
 import {pingProtocol} from "../../fixtures/protocols.js";
+import {DEFAULT_REQUEST_TIMEOUT} from "../../../src/constants.js";
 
 const testCases: {
   id: string;
@@ -58,15 +59,12 @@ describe("response / handleRequest", () => {
     const stream = new MockLibP2pStream(requestChunks as any);
     const rateLimiter = new ReqRespRateLimiter({rateLimitMultiplier: 0});
 
-    const resultPromise = handleRequest({
-      logger,
-      metrics: null,
+    const resultPromise = sendResponse(peerId, protocol.method, {
+      modules: {logger, metrics: null, rateLimiter},
       protocol,
-      protocolID: protocol.method,
       stream,
-      peerId,
       signal: controller.signal,
-      rateLimiter,
+      requestTimeoutMs: DEFAULT_REQUEST_TIMEOUT,
     });
 
     // Make sure the test error-ed with expected error, otherwise it's hard to debug with responseChunks


### PR DESCRIPTION
**Motivation**

Avoid conditional parameters inside most frequently used methods. 

**Description**

- For every message on the network `sendRequest` is used and that includes 4 conditions with `??` on timeout values. These can be avoided. 
- The `handleRequest` is now renamed as `sendResponse` to make it aligned with counter part function.
- For every response to network message `handleRequest` was extra conditions for timeout values that can be avoided. 

**Steps to test or reproduce**

- Run all tests 