### PR TITLE
fix: get seen AttData key from SignedAggregateAndProof electra

### DIFF
--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -9,7 +9,9 @@ import {
 import {IBeaconChain} from "..";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors/index.js";
 import {RegenCaller} from "../regen/index.js";
-import {getAttDataBase64FromSignedAggregateAndProofSerialized} from "../../util/sszBytes.js";
+import {
+  getSeenAttDataKeyFromSignedAggregateAndProof,
+} from "../../util/sszBytes.js";
 import {getSelectionProofSignatureSet, getAggregateAndProofSignatureSet} from "./signatureSets/index.js";
 import {
   getAttestationDataSigningRoot,
@@ -71,8 +73,10 @@ async function validateAggregateAndProof(
   const attData = aggregate.data;
   const attSlot = attData.slot;
 
-  const attDataBase64 = serializedData ? getAttDataBase64FromSignedAggregateAndProofSerialized(serializedData) : null;
-  const cachedAttData = attDataBase64 ? chain.seenAttestationDatas.get(attSlot, attDataBase64) : null;
+  const seenAttDataKey = serializedData
+    ? getSeenAttDataKeyFromSignedAggregateAndProof(ForkSeq[fork], serializedData)
+    : null;
+  const cachedAttData = seenAttDataKey ? chain.seenAttestationDatas.get(attSlot, seenAttDataKey) : null;
 
   let attIndex;
   if (ForkSeq[fork] >= ForkSeq.electra) {

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -42,7 +42,8 @@ const ATTESTATION_BEACON_BLOCK_ROOT_OFFSET = VARIABLE_FIELD_OFFSET + 8 + 8;
 const ROOT_SIZE = 32;
 const SLOT_SIZE = 8;
 const ATTESTATION_DATA_SIZE = 128;
-const COMMITTEE_BITS_BYTE_SIZE = Math.max(Math.ceil(MAX_COMMITTEES_PER_SLOT / 8), 1);
+// MAX_COMMITTEES_PER_SLOT is in bit, need to convert to byte
+const COMMITTEE_BITS_SIZE = Math.max(Math.ceil(MAX_COMMITTEES_PER_SLOT / 8), 1);
 const SIGNATURE_SIZE = 96;
 
 /**
@@ -82,7 +83,7 @@ export function getSeenAttDataKey(forkSeq: ForkSeq, data: Uint8Array): SeenAttDa
  */
 export function getSeenAttDataKeyElectra(electraAttestationBytes: Uint8Array): AttDataCommitteeBitsBase64 | null {
   const startIndex = VARIABLE_FIELD_OFFSET;
-  const seenKeyLength = ATTESTATION_DATA_SIZE + COMMITTEE_BITS_BYTE_SIZE;
+  const seenKeyLength = ATTESTATION_DATA_SIZE + COMMITTEE_BITS_SIZE;
 
   if (electraAttestationBytes.length < startIndex + seenKeyLength) {
     return null;
@@ -113,7 +114,7 @@ export function getSeenAttDataKeyPhase0(data: Uint8Array): AttDataBase64 | null 
 export function getAggregationBitsFromAttestationSerialized(fork: ForkName, data: Uint8Array): BitArray | null {
   const aggregationBitsStartIndex =
     ForkSeq[fork] >= ForkSeq.electra
-      ? VARIABLE_FIELD_OFFSET + ATTESTATION_DATA_SIZE + COMMITTEE_BITS_BYTE_SIZE + SIGNATURE_SIZE
+      ? VARIABLE_FIELD_OFFSET + ATTESTATION_DATA_SIZE + COMMITTEE_BITS_SIZE + SIGNATURE_SIZE
       : VARIABLE_FIELD_OFFSET + ATTESTATION_DATA_SIZE + SIGNATURE_SIZE;
 
   if (data.length < aggregationBitsStartIndex) {
@@ -131,7 +132,7 @@ export function getAggregationBitsFromAttestationSerialized(fork: ForkName, data
 export function getSignatureFromAttestationSerialized(fork: ForkName, data: Uint8Array): BLSSignature | null {
   const signatureStartIndex =
     ForkSeq[fork] >= ForkSeq.electra
-      ? VARIABLE_FIELD_OFFSET + ATTESTATION_DATA_SIZE + COMMITTEE_BITS_BYTE_SIZE
+      ? VARIABLE_FIELD_OFFSET + ATTESTATION_DATA_SIZE + COMMITTEE_BITS_SIZE
       : VARIABLE_FIELD_OFFSET + ATTESTATION_DATA_SIZE;
 
   if (data.length < signatureStartIndex + SIGNATURE_SIZE) {
@@ -148,11 +149,11 @@ export function getSignatureFromAttestationSerialized(fork: ForkName, data: Uint
 export function getCommitteeBitsFromAttestationSerialized(data: Uint8Array): BitArray | null {
   const committeeBitsStartIndex = VARIABLE_FIELD_OFFSET + ATTESTATION_DATA_SIZE;
 
-  if (data.length < committeeBitsStartIndex + COMMITTEE_BITS_BYTE_SIZE) {
+  if (data.length < committeeBitsStartIndex + COMMITTEE_BITS_SIZE) {
     return null;
   }
 
-  const uint8Array = data.subarray(committeeBitsStartIndex, committeeBitsStartIndex + COMMITTEE_BITS_BYTE_SIZE);
+  const uint8Array = data.subarray(committeeBitsStartIndex, committeeBitsStartIndex + COMMITTEE_BITS_SIZE);
 
   return new BitArray(uint8Array, MAX_COMMITTEES_PER_SLOT);
 }
@@ -221,7 +222,7 @@ export function getSeenAttDataKeyFromSignedAggregateAndProof(
  */
 export function getSeenAttDataKeyFromSignedAggregateAndProofElectra(data: Uint8Array): SeenAttDataKey | null {
   const startIndex = SIGNED_AGGREGATE_AND_PROOF_SLOT_OFFSET;
-  const endIndex = startIndex + ATTESTATION_DATA_SIZE + COMMITTEE_BITS_BYTE_SIZE;
+  const endIndex = startIndex + ATTESTATION_DATA_SIZE + COMMITTEE_BITS_SIZE;
 
   if (data.length < endIndex) {
     return null;

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -89,7 +89,7 @@ export function getSeenAttDataKeyElectra(electraAttestationBytes: Uint8Array): A
     return null;
   }
 
-  return Buffer.from(electraAttestationBytes.subarray(startIndex, startIndex + seenKeyLength)).toString("base64");
+  return toBase64(electraAttestationBytes.subarray(startIndex, startIndex + seenKeyLength));
 }
 
 /**
@@ -102,9 +102,7 @@ export function getSeenAttDataKeyPhase0(data: Uint8Array): AttDataBase64 | null 
   }
 
   // base64 is a bit efficient than hex
-  return Buffer.from(data.subarray(VARIABLE_FIELD_OFFSET, VARIABLE_FIELD_OFFSET + ATTESTATION_DATA_SIZE)).toString(
-    "base64"
-  );
+  return toBase64(data.subarray(VARIABLE_FIELD_OFFSET, VARIABLE_FIELD_OFFSET + ATTESTATION_DATA_SIZE));
 }
 
 /**
@@ -229,7 +227,7 @@ export function getSeenAttDataKeyFromSignedAggregateAndProofElectra(data: Uint8A
   }
 
   // base64 is a bit efficient than hex
-  return Buffer.from(data.subarray(startIndex, endIndex)).toString("base64");
+  return toBase64(data.subarray(startIndex, endIndex));
 }
 
 /**
@@ -242,12 +240,12 @@ export function getSeenAttDataKeyFromSignedAggregateAndProofPhase0(data: Uint8Ar
   }
 
   // base64 is a bit efficient than hex
-  return Buffer.from(
+  return toBase64(
     data.subarray(
       SIGNED_AGGREGATE_AND_PROOF_SLOT_OFFSET,
       SIGNED_AGGREGATE_AND_PROOF_SLOT_OFFSET + ATTESTATION_DATA_SIZE
     )
-  ).toString("base64");
+  );
 }
 
 /**
@@ -300,4 +298,8 @@ function getSlotFromOffset(data: Uint8Array, offset: number): Slot {
   const dv = new DataView(data.buffer, data.byteOffset, data.byteLength);
   // Read only the first 4 bytes of Slot, max value is 4,294,967,295 will be reached 1634 years after genesis
   return dv.getUint32(offset, true);
+}
+
+function toBase64(data: Uint8Array): string {
+  return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("base64");
 }


### PR DESCRIPTION
**Motivation**

Our AggregateAndProof gossip validation was getting worse in electra devnet-0

<img width="1236" alt="Screenshot 2024-05-17 at 18 06 36" src="https://github.com/ChainSafe/lodestar/assets/10568965/7f46db70-7056-4694-b25c-1b9876bce481">


**Description**

It never hit the cache since we get the wrong Attestation Data key.
- phase0: AttestationData
- electra: AttestationData + CommitteeBits