### PR TITLE
chore: log newPayload engine api

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -305,12 +305,16 @@ export async function verifyBlockExecutionPayload(
       ? (block.message.body as deneb.BeaconBlockBody).blobKzgCommitments.map(kzgCommitmentToVersionedHash)
       : undefined;
   const parentBlockRoot = ForkSeq[fork] >= ForkSeq.deneb ? block.message.parentRoot : undefined;
+
+  const logCtx = {slot: block.message.slot, executionBlock: executionPayloadEnabled.blockNumber};
+  chain.logger.debug("Call engine api newPayload", logCtx);
   const execResult = await chain.executionEngine.notifyNewPayload(
     fork,
     executionPayloadEnabled,
     versionedHashes,
     parentBlockRoot
   );
+  chain.logger.debug("Receive engine api newPayload result", {...logCtx, status: execResult.status});
 
   chain.metrics?.engineNotifyNewPayloadResult.inc({result: execResult.status});
 


### PR DESCRIPTION
**Motivation**

- Not able to see Netheremind response on some nodes, which cause the node to be out of sync while nethermind log shows block as valid
- We have this log but it did not show https://github.com/ChainSafe/lodestar/blob/8ed9109ddd394e6406c3c4feefb9140d71e88082/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts#L256


**Description**

- Log raw result from newPayload engine api
- It's a litlte bit too much at sync time but at gossip time, it happens once per slot so should be fine
