### PR TITLE
chore: fix broken docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM --platform=${BUILDPLATFORM:-amd64} node:20-alpine as build_src
 ARG COMMIT
 WORKDIR /usr/app
-RUN apk update && apk add --no-cache g++ make python3 && rm -rf /var/cache/apk/*
+RUN apk update && apk add --no-cache g++ make python3 py3-setuptools && rm -rf /var/cache/apk/*
 
 COPY . .
 


### PR DESCRIPTION
**Motivation**

Fix broken `Dockerfile`

**Description**

Make sure `python` is correctly setup

It might make sense to fix the base docker images versions to ensure no regression can be introduced transparently.