### PR TITLE
chore: add `get_proposer_head` check in fork choice spec test

### DIFF
--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -307,7 +307,11 @@ const forkChoiceTest =
               }
               if (step.checks.get_proposer_head) {
                 const currentSlot = Math.floor(tickTime / config.SECONDS_PER_SLOT);
-                const {proposerHead, notReorgedReason} = (chain.forkChoice as ForkChoice).getProposerHead(head, tickTime % config.SECONDS_PER_SLOT, currentSlot);
+                const {proposerHead, notReorgedReason} = (chain.forkChoice as ForkChoice).getProposerHead(
+                  head,
+                  tickTime % config.SECONDS_PER_SLOT,
+                  currentSlot
+                );
                 logger.debug(`Not reorged reason ${notReorgedReason} at step ${i}`);
                 expect(proposerHead.blockRoot).toEqualWithMessage(
                   step.checks.get_proposer_head,

--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -305,6 +305,15 @@ const forkChoiceTest =
                   `Invalid finalized checkpoint at step ${i}`
                 );
               }
+              if (step.checks.get_proposer_head) {
+                const currentSlot = Math.floor(tickTime / config.SECONDS_PER_SLOT);
+                const {proposerHead, notReorgedReason} = (chain.forkChoice as ForkChoice).getProposerHead(head, tickTime % config.SECONDS_PER_SLOT, currentSlot);
+                logger.debug(`Not reorged reason ${notReorgedReason} at step ${i}`);
+                expect(proposerHead.blockRoot).toEqualWithMessage(
+                  step.checks.get_proposer_head,
+                  `Invalid proposer head at step ${i}`
+                );
+              }
             }
 
             // None of the above
@@ -465,6 +474,7 @@ type Checks = {
     justified_checkpoint?: SpecTestCheckpoint;
     finalized_checkpoint?: SpecTestCheckpoint;
     proposer_boost_root?: RootHex;
+    get_proposer_head?: string;
   };
 };
 

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -281,7 +281,7 @@ export class ForkChoice implements IForkChoice {
     const parentNode = this.protoArray.getNode(parentBlock.blockRoot);
     // If parentNode is unavailable, give up reorg
     if (parentNode === undefined || parentNode.weight <= parentThreshold) {
-      return {proposerHead, isHeadTimely, notReorgedReason: NotReorgedReason.ParentBlockIsStrong};
+      return {proposerHead, isHeadTimely, notReorgedReason: NotReorgedReason.ParentBlockNotStrong};
     }
 
     // Reorg if all above checks fail

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -53,7 +53,7 @@ export enum NotReorgedReason {
   ReorgMoreThanOneSlot,
   ProposerBoostNotWornOff,
   HeadBlockNotWeak,
-  ParentBlockIsStrong,
+  ParentBlockNotStrong,
   NotProposingOnTime,
 }
 

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -193,7 +193,7 @@ describe("Forkchoice / GetProposerHead", function () {
       parentBlock: {...baseParentHeadBlock, weight: 211},
       headBlock: {...baseHeadBlock},
       expectReorg: false,
-      expectedNotReorgedReason: NotReorgedReason.ParentBlockIsStrong,
+      expectedNotReorgedReason: NotReorgedReason.ParentBlockNotStrong,
     },
     {
       id: "No reorg if not proposing on time",


### PR DESCRIPTION
The current fork choice spec test checks for `get_proposer_head` which is for the purpose of proposer boost reorg.

However the current codebase omit that check. This PR adds it.

Part of #5125 