### PR TITLE
chore: fix vitest performance with spec tests artifacts in place

### DIFF
--- a/vitest.base.unit.config.ts
+++ b/vitest.base.unit.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
     pool: "threads",
     include: ["**/*.test.ts"],
     exclude: [
+      "**/spec-tests/**",
+      "**/spec-tests-bls/**",
       "**/*.browser.test.ts",
       "**/node_modules/**",
       "**/dist/**",
@@ -39,6 +41,8 @@ export default defineConfig({
         "**/types/**",
         "**/bin/**",
         "**/node_modules/**",
+        "**/spec-tests/**",
+        "**/spec-tests-bls/**",
       ],
     },
     diff: process.env.TEST_COMPACT_DIFF ? path.join(import.meta.dirname, "./scripts/vitest/vitest.diff.ts") : undefined,


### PR DESCRIPTION
**Motivation**

Vitest runs a bit slow when we have spec tests files placed in beacon-node directory. 

**Description**

Without the change. 

<img width="742" alt="image" src="https://github.com/ChainSafe/lodestar/assets/112468/321a0c23-55d4-4531-84f4-348babd18b1e">


With the change. 

<img width="729" alt="image" src="https://github.com/ChainSafe/lodestar/assets/112468/169d8ef3-1e8c-491c-950a-cd9e128b24fd">


**Steps to test or reproduce**

Run all tests