### PR TITLE
feat: added ELU metrics

### DIFF
--- a/packages/beacon-node/src/metrics/nodeJsMetrics.ts
+++ b/packages/beacon-node/src/metrics/nodeJsMetrics.ts
@@ -5,7 +5,7 @@ import {gcStats} from "@chainsafe/prometheus-gc-stats";
 /**
  * Collects event loop utilization metrics compared to the last call
  */
-function collectEvenLoopUtilization(register: Registry, prefix?: string, intervalMs: number = 5000): () => void {
+function collectEventLoopUtilization(register: Registry, prefix?: string, intervalMs: number = 5000): () => void {
   const key = `${prefix}_` ?? "";
 
   const metricUtilization = new Histogram({
@@ -16,14 +16,14 @@ function collectEvenLoopUtilization(register: Registry, prefix?: string, interva
   });
 
   const metricIdle = new Histogram({
-    name: `${key}_nodejs_eventloop_idle`,
+    name: `${key}nodejs_eventloop_idle`,
     help: "Histogram of Event Loop idle time between two successive calls.",
     registers: [register],
     buckets: [1, intervalMs / 10, intervalMs / 2, intervalMs],
   });
 
   const metricActive = new Histogram({
-    name: `${key}_nodejs_eventloop_active`,
+    name: `${key}nodejs_eventloop_active`,
     help: "Histogram of Event Loop active time between two successive calls.",
     registers: [register],
     buckets: [1, intervalMs / 10, intervalMs / 2, intervalMs],
@@ -54,7 +54,7 @@ export function collectNodeJSMetrics(register: Registry, prefix?: string): () =>
     eventLoopMonitoringPrecision: 10,
   });
 
-  const terminateEluCollection = collectEvenLoopUtilization(register, prefix);
+  const terminateEluCollection = collectEventLoopUtilization(register, prefix);
 
   // Collects GC metrics using a native binding module
   // - nodejs_gc_runs_total: Counts the number of time GC is invoked

--- a/packages/beacon-node/src/metrics/nodeJsMetrics.ts
+++ b/packages/beacon-node/src/metrics/nodeJsMetrics.ts
@@ -1,5 +1,50 @@
-import {collectDefaultMetrics, Registry} from "prom-client";
+import {EventLoopUtilization, performance} from "node:perf_hooks";
+import {collectDefaultMetrics, Histogram, Registry} from "prom-client";
 import {gcStats} from "@chainsafe/prometheus-gc-stats";
+
+/**
+ * Collects event loop utilization metrics compared to the last call
+ */
+function collectEvenLoopUtilization(register: Registry, prefix?: string, intervalMs: number = 5000): () => void {
+  const key = `${prefix}_` ?? "";
+
+  const metricUtilization = new Histogram({
+    name: `${key}nodejs_eventloop_utilization`,
+    help: "Histogram of Event Loop utilization between two successive calls.",
+    registers: [register],
+    buckets: [0.001, 0.01, 0.1, 0.5, 1],
+  });
+
+  const metricIdle = new Histogram({
+    name: `${key}_nodejs_eventloop_idle`,
+    help: "Histogram of Event Loop idle time between two successive calls.",
+    registers: [register],
+    buckets: [1, intervalMs / 10, intervalMs / 2, intervalMs],
+  });
+
+  const metricActive = new Histogram({
+    name: `${key}_nodejs_eventloop_active`,
+    help: "Histogram of Event Loop active time between two successive calls.",
+    registers: [register],
+    buckets: [1, intervalMs / 10, intervalMs / 2, intervalMs],
+  });
+
+  const previousEventLoopUtilizations = new Map<string, EventLoopUtilization>();
+  const interval = setInterval(() => {
+    const previousElu = previousEventLoopUtilizations.get(key);
+    const currentElu = performance.eventLoopUtilization();
+    const {utilization, idle, active} = performance.eventLoopUtilization(currentElu, previousElu);
+    metricUtilization.observe(utilization); /* between 0-1 */
+    metricIdle.observe(idle); /* in ms, max `intervalMs` */
+    metricActive.observe(active); /* in ms, max `intervalMs` */
+    previousEventLoopUtilizations.set(key, currentElu);
+  }, intervalMs);
+
+  return () => {
+    clearInterval(interval);
+    previousEventLoopUtilizations.clear();
+  };
+}
 
 export function collectNodeJSMetrics(register: Registry, prefix?: string): () => void {
   collectDefaultMetrics({
@@ -9,11 +54,17 @@ export function collectNodeJSMetrics(register: Registry, prefix?: string): () =>
     eventLoopMonitoringPrecision: 10,
   });
 
+  const terminateEluCollection = collectEvenLoopUtilization(register, prefix);
+
   // Collects GC metrics using a native binding module
   // - nodejs_gc_runs_total: Counts the number of time GC is invoked
   // - nodejs_gc_pause_seconds_total: Time spent in GC in seconds
   // - nodejs_gc_reclaimed_bytes_total: The number of bytes GC has freed
   // `close` must be called to stop the gc collection process from continuing
-  const close = gcStats(register, {collectionInterval: 6000, prefix});
-  return close;
+  const terminateGCCollection = gcStats(register, {collectionInterval: 6000, prefix});
+
+  return () => {
+    terminateGCCollection();
+    terminateEluCollection();
+  };
 }

--- a/packages/beacon-node/src/metrics/nodeJsMetrics.ts
+++ b/packages/beacon-node/src/metrics/nodeJsMetrics.ts
@@ -4,8 +4,8 @@ import {gcStats} from "@chainsafe/prometheus-gc-stats";
 
 /**
  * Collects event loop utilization metrics compared to the last call
- * 
- * @param interval how often to collect the metrics in seconds 
+ *
+ * @param interval how often to collect the metrics in seconds
  */
 function collectEventLoopUtilization(register: Registry, prefix?: string, interval: number = 5): () => void {
   const key = `${prefix}_` ?? "";
@@ -39,8 +39,8 @@ function collectEventLoopUtilization(register: Registry, prefix?: string, interv
     // `utilization` is a ratio between 0 and 1, similar to regular CPU utilization
     const {utilization, idle, active} = performance.eventLoopUtilization(currentElu, previousElu);
     metricUtilization.observe(utilization);
-    metricIdle.observe(idle*1000);
-    metricActive.observe(active*1000);
+    metricIdle.observe(idle * 1000);
+    metricActive.observe(active * 1000);
     previousEventLoopUtilizations.set(key, currentElu);
   }, interval * 1000);
 


### PR DESCRIPTION
**Motivation**

Add extra metrics related to Event Loop utilization

**Description**

Relies on [node:perf_hooks](https://nodejs.org/api/perf_hooks.html#performanceeventlooputilizationutilization1-utilization2) to track Event Loop utilization metrics: Adds the following `histograms`:

* `utilization` akin to CPU utilization, but for ELU; between `0` and `1`
* `idle` how long the ELU was idle since last poll (every 5s by default)
* `active` how long the ELU was active since last poll (every 5s by default)

Those metrics are tracked on `main` thread and currently monitored worker threads.