### PR TITLE
deps: update systeminformation to 5.22.9

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -147,7 +147,7 @@
     "qs": "^6.11.1",
     "snappyjs": "^0.7.0",
     "strict-event-emitter-types": "^2.0.0",
-    "systeminformation": "^5.17.12",
+    "systeminformation": "^5.22.9",
     "uint8arraylist": "^2.4.7",
     "xxhash-wasm": "1.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12003,10 +12003,10 @@ synckit@^0.8.6:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
 
-systeminformation@^5.17.12:
-  version "5.21.7"
-  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.21.7.tgz#53ef75daaf5d756d015f4bb02e059126ccac74f2"
-  integrity sha512-K3LjnajrazTLTD61+87DFg8IXFk5ljx6nSBqB8pQLtC1UPivAjDtTYGPZ8jaBFxcesPaCOkvLRtBq+RFscrsLw==
+systeminformation@^5.22.9:
+  version "5.22.9"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.22.9.tgz#68700a895a48cbf96e2cd6a34c5027d1fe58f053"
+  integrity sha512-qUWJhQ9JSBhdjzNUQywpvc0icxUAjMY3sZqUoS0GOtaJV9Ijq8s9zEP8Gaqmymn1dOefcICyPXK1L3kgKxlUpg==
 
 tapable@^2.2.0:
   version "2.2.1"


### PR DESCRIPTION
**Motivation**

Fixes deprecation warning on node 22
```
(node:506794) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
    at Object.<anonymous> (/home/devops/holesky/lodestar/node_modules/systeminformation/lib/util.js:54:13)
    at Module._compile (node:internal/modules/cjs/loader:1434:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1518:10)
    at Module.load (node:internal/modules/cjs/loader:1249:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1065:12)
    at Module.require (node:internal/modules/cjs/loader:1271:19)
    at require (node:internal/modules/helpers:123:16)
    at Object.<anonymous> (/home/devops/holesky/lodestar/node_modules/systeminformation/lib/index.js:25:14)
    at Module._compile (node:internal/modules/cjs/loader:1434:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1518:10)
```

**Description**

Update [systeminformation](https://www.npmjs.com/package/systeminformation) to 5.22.9
