### PR TITLE
test: update clock tests to run deterministically

### DIFF
--- a/packages/validator/test/unit/utils/clock.test.ts
+++ b/packages/validator/test/unit/utils/clock.test.ts
@@ -84,6 +84,14 @@ describe("util / Clock", function () {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const testConfig = {SECONDS_PER_SLOT: 12} as BeaconConfig;
     const genesisTime = Math.floor(new Date("2021-01-01").getTime() / 1000);
+
+    // Tests can fail under certain time slots, overriding the system time 
+    // with a specific value allows us to run tests deterministically
+    // See : https://github.com/ChainSafe/lodestar/issues/6734
+    beforeEach(() => {
+      vi.setSystemTime(genesisTime * 1000);
+    });
+
     const testCase: {name: string; delta: number}[] = [
       {name: "should return next slot after 11.5s", delta: 11.5},
       {name: "should return next slot after 12s", delta: 12},

--- a/packages/validator/test/unit/utils/clock.test.ts
+++ b/packages/validator/test/unit/utils/clock.test.ts
@@ -85,9 +85,8 @@ describe("util / Clock", function () {
     const testConfig = {SECONDS_PER_SLOT: 12} as BeaconConfig;
     const genesisTime = Math.floor(new Date("2021-01-01").getTime() / 1000);
 
-    // Tests can fail under certain time slots, overriding the system time 
+    // Tests can fail under certain time slots, overriding the system time
     // with a specific value allows us to run tests deterministically
-    // See : https://github.com/ChainSafe/lodestar/issues/6734
     beforeEach(() => {
       vi.setSystemTime(genesisTime * 1000);
     });


### PR DESCRIPTION
**Motivation**

Clock tests at `clock.test.ts` keep failing from time to time due to edge cases arising from the use of `Date.now`
This aims to fix that.

**Description**

This change overrides the system time before each test case to make the tests run deterministically.

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #6734 
