### PR TITLE
feat: add cli flags to configure http wire format

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,7 +3,8 @@ export * from "./beacon/index.js";
 export {HttpStatusCode} from "./utils/httpStatusCode.js";
 export {WireFormat} from "./utils/wireFormat.js";
 export type {HttpErrorCodes, HttpSuccessCodes} from "./utils/httpStatusCode.js";
-export {ApiResponse, HttpClient, FetchError, isFetchError, fetch} from "./utils/client/index.js";
+export {ApiResponse, HttpClient, FetchError, isFetchError, fetch, defaultInit} from "./utils/client/index.js";
+export type {ApiRequestInit} from "./utils/client/request.js";
 export type {Endpoint} from "./utils/types.js";
 export type {
   ApiClientMethods,

--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -40,7 +40,7 @@ const URL_SCORE_DELTA_ERROR = 2 * URL_SCORE_DELTA_SUCCESS;
 const URL_SCORE_MAX = 10 * URL_SCORE_DELTA_SUCCESS;
 const URL_SCORE_MIN = 0;
 
-const defaultInit: Required<ExtraRequestInit> = {
+export const defaultInit: Required<ExtraRequestInit> = {
   timeoutMs: DEFAULT_TIMEOUT_MS,
   retries: DEFAULT_RETRIES,
   retryDelay: DEFAULT_RETRY_DELAY,

--- a/packages/beacon-node/test/utils/node/validator.ts
+++ b/packages/beacon-node/test/utils/node/validator.ts
@@ -68,7 +68,9 @@ export async function getAndInitDevValidators({
       Validator.initializeFromBeaconNode({
         db,
         config: node.config,
-        api: useRestApi ? getNodeApiUrl(node) : getApiFromServerHandlers(node.api),
+        api: {
+          clientOrUrls: useRestApi ? getNodeApiUrl(node) : getApiFromServerHandlers(node.api),
+        },
         slashingProtection,
         logger,
         processShutdownCallback: () => {},

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -8,7 +8,7 @@ import {
   ValidatorProposerConfig,
   defaultOptions,
 } from "@lodestar/validator";
-import {routes} from "@lodestar/api";
+import {WireFormat, routes} from "@lodestar/api";
 import {getMetrics} from "@lodestar/validator";
 import {
   RegistryMetricCreator,
@@ -152,7 +152,13 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
       db,
       config,
       slashingProtection,
-      api: args.beaconNodes,
+      api: {
+        clientOrUrls: args.beaconNodes,
+        globalInit: {
+          requestWireFormat: parseWireFormat(args, "http.requestWireFormat"),
+          responseWireFormat: parseWireFormat(args, "http.responseWireFormat"),
+        },
+      },
       logger,
       processShutdownCallback,
       signers,
@@ -268,4 +274,20 @@ function parseBroadcastValidation(broadcastValidation?: string): routes.beacon.B
   }
 
   return broadcastValidation as routes.beacon.BroadcastValidation;
+}
+
+function parseWireFormat(args: IValidatorCliArgs, key: keyof IValidatorCliArgs): WireFormat | undefined {
+  const wireFormat = args[key];
+
+  if (wireFormat !== undefined) {
+    switch (wireFormat) {
+      case WireFormat.json:
+      case WireFormat.ssz:
+        break;
+      default:
+        throw new YargsError(`Invalid input for ${key}, must be one of "${WireFormat.json}" or "${WireFormat.ssz}"`);
+    }
+  }
+
+  return wireFormat;
 }

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -1,3 +1,4 @@
+import {WireFormat, defaultInit} from "@lodestar/api";
 import {defaultOptions} from "@lodestar/validator";
 import {CliCommandOptions} from "@lodestar/utils";
 import {LogArgs, logOptions} from "../../options/logOptions.js";
@@ -54,6 +55,9 @@ export type IValidatorCliArgs = AccountValidatorArgs &
 
     importKeystores?: string[];
     importKeystoresPassword?: string;
+
+    "http.requestWireFormat"?: string;
+    "http.responseWireFormat"?: string;
 
     "externalSigner.url"?: string;
     "externalSigner.pubkeys"?: string[];
@@ -302,6 +306,20 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
     description: "Enables Doppelganger protection",
     default: false,
     type: "boolean",
+  },
+
+  "http.requestWireFormat": {
+    type: "string",
+    description: `Wire format to use in HTTP requests to beacon node. Can be one of \`${WireFormat.json}\` or \`${WireFormat.ssz}\``,
+    defaultDescription: `${defaultInit.requestWireFormat}`,
+    group: "http",
+  },
+
+  "http.responseWireFormat": {
+    type: "string",
+    description: `Preferred wire format for HTTP responses from beacon node. Can be one of \`${WireFormat.json}\` or \`${WireFormat.ssz}\``,
+    defaultDescription: `${defaultInit.responseWireFormat}`,
+    group: "http",
   },
 
   // External signer


### PR DESCRIPTION
**Motivation**

Part of https://github.com/ChainSafe/lodestar/pull/6749 but created a separate PR for easier review as this change is mostly in the cli package and could be merged separately to unstable branch after #6749 is merged, although for sake of testing it earlier, we might wanna merge in the refactor branch itself.

**Description**

Add CLI flags to configure http wire format.

### requestWireFormat

The default is `json` to ensure compatibility with other clients, there are exceptions if an api must support `ssz` requests as per spec, then we will use `ssz` as wire format but only for those. This allows to gradually adopt for more routes as the spec improves support for it.

For debugging purposes, it is possible to set the CLI flag explicitly to `--http.requestWireFormat=json` to enforce `json` on all routes. In a Lodestar-only setup, it is safe to set this to `--requestWireFormat=ssz` to get [the benefits of using ssz](https://github.com/ChainSafe/lodestar/pull/6749#issuecomment-2128847283) for all apis.

I have been opening issues on other clients to properly support 415 status code (only Teku supports it), and once this is more broadly supported we might be able to use `ssz` as default wire format for all routes as Lodestar will just retry the request with `json` and use the same for all subsequent requests.

**Note:** there is no guarantee that the request will use `ssz` if the server does not support it as failed (415) requests are retried using `json` 

### responseWireFormat

We can default to `ssz` for responses as it just states a preference on what the server should return. This has been tested with all other clients and does not cause compatibility issues.

For debugging purposes, it is possible to set `--http.responseWireFormat=json` to state the preference to the server to receive responses as `json`.

**Note:** it's not guaranteed that we will be receiving the wire format as requested as this pretty much depends on the server, especially for `ssz` as it is not supported for most routes by other clients.

