### PR TITLE
chore: review lightclient routes

### DIFF
--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -59,6 +59,8 @@ const ignoredOperations = [
   "getBlindedBlock", // https://github.com/ChainSafe/lodestar/issues/5699
   "getNextWithdrawals", // https://github.com/ChainSafe/lodestar/issues/5696
   "getDebugForkChoice", // https://github.com/ChainSafe/lodestar/issues/5700
+  /* Must support ssz response body */
+  "getLightClientUpdatesByRange", // https://github.com/ChainSafe/lodestar/issues/6841
 ];
 
 const ignoredProperties: Record<string, IgnoredProperty> = {


### PR DESCRIPTION
**Motivation**

Pulled out of https://github.com/ChainSafe/lodestar/pull/6749 to discuss changes separately and for easier review.

**Description**

This essentially just drops (broken) ssz response support from `getLightClientUpdatesByRange`. While the current approach works to deserialize on the client, it does not work like this on the server as the cached `beaconConfig` is not defined there, and the implementation does not follow the spec. It might be better to implement this separate from #6749, I have created a separate issue to track it https://github.com/ChainSafe/lodestar/issues/6841.

Changes are
- drop ssz response support by wrapping with `JsonOnlyResp`
- more validation on untrusted server response in `fromResponse`
- drop any non-spec compliant logic


