### PR TITLE
chore: review proof routes

### DIFF
--- a/packages/api/src/beacon/client/proof.ts
+++ b/packages/api/src/beacon/client/proof.ts
@@ -2,8 +2,6 @@ import {ChainForkConfig} from "@lodestar/config";
 import {ApiClientMethods, IHttpClient, createApiClientMethods} from "../../utils/client/index.js";
 import {Endpoints, getDefinitions} from "../routes/proof.js";
 
-// TODO: revisit, do we still need to override methods? Make sure we still return same format as previously
-
 export type ApiClient = ApiClientMethods<Endpoints>;
 
 /**

--- a/packages/api/src/beacon/routes/proof.ts
+++ b/packages/api/src/beacon/routes/proof.ts
@@ -8,8 +8,7 @@ import {ArrayOf} from "../../utils/codecs.js";
 import {VersionCodec, VersionMeta} from "../../utils/metadata.js";
 
 export const CompactMultiProofType = new ContainerType({
-  // TODO ensure limit of all lists is sane
-  leaves: ArrayOf(ssz.Root),
+  leaves: ArrayOf(ssz.Root, 10000),
   descriptor: new ByteListType(2048),
 });
 

--- a/packages/api/src/beacon/server/proof.ts
+++ b/packages/api/src/beacon/server/proof.ts
@@ -3,41 +3,6 @@ import {ChainForkConfig} from "@lodestar/config";
 import {ApplicationMethods, FastifyRoutes, createFastifyRoutes} from "../../utils/server/index.js";
 import {Endpoints, getDefinitions} from "../routes/proof.js";
 
-// TODO: revisit, do we need still need to override handlers?
-
 export function getRoutes(config: ChainForkConfig, methods: ApplicationMethods<Endpoints>): FastifyRoutes<Endpoints> {
   return createFastifyRoutes(getDefinitions(config), methods);
-  // const serverRoutes = createFastifyRoutes(definitions, methods);
-
-  // return {
-  //   // Non-JSON routes. Return binary
-  //   getStateProof: {
-  //     ...serverRoutes.getStateProof,
-  //     handler: async (req) => {
-  //       const args = definitions.getStateProof.req.parseReq(req);
-  //       const {data} = await methods.getStateProof(args);
-  //       const leaves = (data as CompactMultiProof).leaves;
-  //       const response = new Uint8Array(32 * leaves.length);
-  //       for (let i = 0; i < leaves.length; i++) {
-  //         response.set(leaves[i], i * 32);
-  //       }
-  //       // Fastify 3.x.x will automatically add header `Content-Type: application/octet-stream` if Buffer
-  //       return Buffer.from(response);
-  //     },
-  //   },
-  //   getBlockProof: {
-  //     ...serverRoutes.getBlockProof,
-  //     handler: async (req) => {
-  //       const args = definitions.getBlockProof.req.parseReq(req);
-  //       const {data} = await methods.getBlockProof(args);
-  //       const leaves = (data as CompactMultiProof).leaves;
-  //       const response = new Uint8Array(32 * leaves.length);
-  //       for (let i = 0; i < leaves.length; i++) {
-  //         response.set(leaves[i], i * 32);
-  //       }
-  //       // Fastify 3.x.x will automatically add header `Content-Type: application/octet-stream` if Buffer
-  //       return Buffer.from(response);
-  //     },
-  //   },
-  // };
 }


### PR DESCRIPTION
**Motivation**

Pulled out of https://github.com/ChainSafe/lodestar/pull/6749 to discuss changes separately and for easier review.

**Description**

We broke (in terms of a breaking change) the ssz response of proof routes and it is no longer aligned with spec proposal https://github.com/ethereum/beacon-APIs/pull/267 (which did not get merged).

This PR is mostly just cleanup and to confirm that we are fine with doing a breaking change to the route. As it is not spec'd and has very limited amount of users it might not be relevant, could still add a note in the release this gets included.
