### PR TITLE
chore: bump @chainsafe/blst to v0.2.11

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -96,7 +96,7 @@
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
     "@chainsafe/bls": "7.1.3",
-    "@chainsafe/blst": "^0.2.10",
+    "@chainsafe/blst": "^0.2.11",
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",
     "@chainsafe/libp2p-gossipsub": "^13.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "@chainsafe/bls": "7.1.3",
     "@chainsafe/bls-keygen": "^0.4.0",
     "@chainsafe/bls-keystore": "^3.0.1",
-    "@chainsafe/blst": "^0.2.10",
+    "@chainsafe/blst": "^0.2.11",
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",
     "@chainsafe/persistent-merkle-tree": "^0.7.1",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",
     "@chainsafe/bls": "7.1.3",
-    "@chainsafe/blst": "^0.2.10",
+    "@chainsafe/blst": "^0.2.11",
     "@chainsafe/persistent-merkle-tree": "^0.7.1",
     "@chainsafe/persistent-ts": "^0.19.1",
     "@chainsafe/ssz": "^0.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,10 +306,10 @@
     "@chainsafe/bls-keygen" "^0.4.0"
     bls-eth-wasm "^0.4.8"
 
-"@chainsafe/blst@^0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.2.10.tgz#77802e5b1ff2d98ec1d25dcd5f7d27b89d376a40"
-  integrity sha512-ofecTL5fWsNwnpS2oUh56dDXJRmCEcDKNNBFDb2ux+WtvdjrdSq6B+L/eNlg+sVBzXbzrCw1jq8Y8+cYiHg32w==
+"@chainsafe/blst@^0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-0.2.11.tgz#5ec85cd663592819d1dc51127e75dfd834250e3d"
+  integrity sha512-URyOLq5GtxBoxibOnd2pgLydCy0UZzbiIIBcsRAvGxAsRzjZL04TsQfwRkz5aphU3a1ebeRoMmI/HHyMCiFSQg==
   dependencies:
     "@types/tar" "^6.1.4"
     node-fetch "^2.6.1"


### PR DESCRIPTION
**Motivation**

To unblock 1.19.0, we need a newly build blst for node 22

**Description**

- bump `@chainsafe/blst` to v0.2.11