### PR TITLE
fix: eth1 provider error logging

### DIFF
--- a/packages/beacon-node/src/eth1/provider/eth1Provider.ts
+++ b/packages/beacon-node/src/eth1/provider/eth1Provider.ts
@@ -91,7 +91,7 @@ export class Eth1Provider implements IEth1Provider {
       this.state = Eth1ProviderState.ONLINE;
 
       if (oldState !== Eth1ProviderState.ONLINE) {
-        this.logger?.info("Eth1Provider is back online", {oldState, newState: this.state});
+        this.logger?.info("Eth1 provider is back online", {oldState, newState: this.state});
       }
     });
 
@@ -109,7 +109,7 @@ export class Eth1Provider implements IEth1Provider {
       if (this.state !== Eth1ProviderState.ONLINE) {
         if (isOneMinutePassed()) {
           this.logger?.error(
-            "Eth1Provider faced error",
+            "Eth1 provider error",
             {
               state: this.state,
               lastErrorAt: new Date(Date.now() - isOneMinutePassed.msSinceLastCall).toLocaleTimeString(),

--- a/packages/utils/src/waitFor.ts
+++ b/packages/utils/src/waitFor.ts
@@ -70,9 +70,13 @@ export function createElapsedTimeTracker({minElapsedTime}: {minElapsedTime: numb
   function elapsedTimeTracker(): boolean {
     const now = Date.now();
     const msSinceLastCall = now - (lastTimeCalled ?? 0);
-    lastTimeCalled = now;
 
-    return msSinceLastCall > minElapsedTime;
+    if (msSinceLastCall > minElapsedTime) {
+      // Do not reset timer if called before timer elapsed
+      lastTimeCalled = now;
+      return true;
+    }
+    return false;
   }
 
   return Object.assign(elapsedTimeTracker, {

--- a/packages/utils/test/unit/waitFor.test.ts
+++ b/packages/utils/test/unit/waitFor.test.ts
@@ -36,8 +36,8 @@ describe("waitFor", () => {
   });
 });
 
-describe("waitForElapsedTime", () => {
-  it("should true for the first time", () => {
+describe("createElapsedTimeTracker", () => {
+  it("should return true for the first time", () => {
     const callIfTimePassed = createElapsedTimeTracker({minElapsedTime: 1000});
 
     expect(callIfTimePassed()).toBe(true);
@@ -48,6 +48,18 @@ describe("waitForElapsedTime", () => {
     callIfTimePassed();
 
     await sleep(150);
+
+    expect(callIfTimePassed()).toBe(true);
+  });
+
+  it("should return true after the minElapsedTime has passed with intermediate calls", async () => {
+    const callIfTimePassed = createElapsedTimeTracker({minElapsedTime: 100});
+    callIfTimePassed();
+
+    await sleep(75);
+    // Time has not elapsed yet but it should not reset timer
+    expect(callIfTimePassed()).toBe(false);
+    await sleep(75);
 
     expect(callIfTimePassed()).toBe(true);
   });


### PR DESCRIPTION
**Motivation**

Currently, we will only log the error once if the eth1 provider throws continuous errors with a frequency of < 1min while the intended behavior should be to log at most an error every minute to not be silent about the issue but also not flood the logs with errors.

**Description**

Update `elapsedTimeTracker` to not reset timer if there are intermediate calls before time has passed

Part of https://github.com/ChainSafe/lodestar/issues/6469