### PR TITLE
chore: fix verification of README code snippets

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -64,7 +64,7 @@
     "lint:fix": "yarn run lint --fix",
     "test": "yarn test:unit",
     "test:unit": "vitest --run --dir test/unit/",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "dependencies": {
     "@chainsafe/persistent-merkle-tree": "^0.7.1",

--- a/packages/api/tsconfig.doc.json
+++ b/packages/api/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -91,7 +91,7 @@
     "test:spec:minimal": "LODESTAR_PRESET=minimal vitest --run --config vitest.spec.config.ts --dir test/spec/presets/",
     "test:spec:mainnet": "LODESTAR_PRESET=mainnet vitest --run --config vitest.spec.config.ts --dir test/spec/presets/",
     "test:spec": "yarn test:spec:bls && yarn test:spec:general && yarn test:spec:minimal && yarn test:spec:mainnet",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "dependencies": {
     "@chainsafe/as-sha256": "^0.4.1",

--- a/packages/beacon-node/tsconfig.doc.json
+++ b/packages/beacon-node/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
     "test:sim:deneb": "LODESTAR_PRESET=minimal DOTENV_CONFIG_PATH=../../.env.test node -r dotenv/config --loader ts-node/esm test/sim/deneb.test.ts",
     "test:sim:backup_eth_provider": "LODESTAR_PRESET=minimal DOTENV_CONFIG_PATH=../../.env.test node -r dotenv/config --loader ts-node/esm test/sim/backupEthProvider.test.ts",
     "test": "yarn test:unit && yarn test:e2e",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "repository": {
     "type": "git",

--- a/packages/cli/tsconfig.doc.json
+++ b/packages/cli/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -51,7 +51,7 @@
     "lint:fix": "yarn run lint --fix",
     "test": "yarn test:unit",
     "test:unit": "yarn vitest --run --dir test/unit/",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "repository": {
     "type": "git",

--- a/packages/config/tsconfig.doc.json
+++ b/packages/config/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -32,7 +32,7 @@
     "lint:fix": "yarn run lint --fix",
     "test": "yarn test:unit",
     "test:unit": "vitest --run --dir test/unit/",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "dependencies": {
     "@chainsafe/ssz": "^0.15.1",

--- a/packages/db/tsconfig.doc.json
+++ b/packages/db/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/flare/package.json
+++ b/packages/flare/package.json
@@ -45,7 +45,7 @@
     "lint:fix": "yarn run lint --fix",
     "test": "yarn test:unit",
     "test:unit": "vitest --run --dir test/unit/",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "repository": {
     "type": "git",

--- a/packages/flare/tsconfig.doc.json
+++ b/packages/flare/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -33,7 +33,7 @@
     "lint:fix": "yarn run lint --fix",
     "test": "yarn test:unit",
     "test:unit": "vitest --run --dir test/unit/",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "dependencies": {
     "@chainsafe/ssz": "^0.15.1",

--- a/packages/fork-choice/tsconfig.doc.json
+++ b/packages/fork-choice/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/light-client/README.md
+++ b/packages/light-client/README.md
@@ -63,7 +63,7 @@ import {
 
 const config = getChainForkConfigFromNetwork("sepolia");
 const logger = getConsoleLogger({logDebug: Boolean(process.env.DEBUG)});
-const api = getApiFromUrl({urls: ["https://lodestar-sepolia.chainsafe.io"]}, {config});
+const api = getApiFromUrl("https://lodestar-sepolia.chainsafe.io", "sepolia");
 
 const lightclient = await Lightclient.initializeFromCheckpointRoot({
   config,
@@ -83,11 +83,11 @@ await lightclient.start();
 logger.info("Lightclient synced");
 
 lightclient.emitter.on(LightclientEvent.lightClientFinalityHeader, async (finalityUpdate) => {
-  logger.info(finalityUpdate);
+  logger.info("Received finality update", {slot: finalityUpdate.beacon.slot});
 });
 
 lightclient.emitter.on(LightclientEvent.lightClientOptimisticHeader, async (optimisticUpdate) => {
-  logger.info(optimisticUpdate);
+  logger.info("Received optimistic update", {slot: optimisticUpdate.beacon.slot});
 });
 ```
 

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -69,7 +69,7 @@
     "test:browsers:chrome": "yarn run build:dist && vitest --run --browser chrome --config ./vitest.browser.config.ts --dir test/unit",
     "test:browsers:firefox": "yarn run build:dist && vitest --run --browser firefox --config ./vitest.browser.config.ts --dir test/unit",
     "test:browsers:electron": "echo 'Electron tests will be introduced back in the future as soon vitest supports electron.'",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "dependencies": {
     "@chainsafe/bls": "7.1.3",

--- a/packages/light-client/tsconfig.doc.json
+++ b/packages/light-client/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -62,7 +62,7 @@
     "test:browsers:firefox": "vitest --run --browser firefox --config ./vitest.browser.config.ts --dir test/unit",
     "test:browsers:electron": "echo 'Electron tests will be introduced back in the future as soon vitest supports electron.'",
     "test:e2e": "vitest --run --config vitest.e2e.config.ts --dir test/e2e",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "types": "lib/index.d.ts",
   "dependencies": {

--- a/packages/logger/tsconfig.doc.json
+++ b/packages/logger/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/params/package.json
+++ b/packages/params/package.json
@@ -59,7 +59,7 @@
     "test:browsers:firefox": "vitest --run --browser firefox --config ./vitest.browser.config.ts --dir test/unit",
     "test:browsers:electron": "echo 'Electron tests will be introduced back in the future as soon vitest supports electron.'",
     "test:e2e": "vitest --run --config vitest.e2e.config.ts --dir test/e2e/",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "repository": {
     "type": "git",

--- a/packages/params/tsconfig.doc.json
+++ b/packages/params/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/prover/README.md
+++ b/packages/prover/README.md
@@ -14,7 +14,7 @@ A set of tools allowing to verify EL client JSON-RPC calls.
 You can use the `@lodestar/prover` in two ways, as a Web3 Provider and as proxy. For prover use case see below example.
 
 ```ts
-import Web3 from "web3";
+import {Web3} from "web3";
 import {createVerifiedExecutionProvider, LCTransport} from "@lodestar/prover";
 
 const httpProvider = new Web3.providers.HttpProvider("https://lodestar-sepoliarpc.chainsafe.io");
@@ -38,7 +38,7 @@ In this scenario the actual provider is mutated to handle the RPC requests and v
 For some scenarios when you don't want to mutate the provider you can pass an option `mutateProvider` as `false`. In this scenario the object `httpProvider` is not mutated and you get a new object `provider`. This is useful when your provider object does not allow mutation, e.g. Metamask provider accessible through `window.ethereum`. If not provided `mutateProvider` is considered as `true` by default. In coming releases we will switch its default behavior to `false`.
 
 ```ts
-import Web3 from "web3";
+import {Web3} from "web3";
 import {createVerifiedExecutionProvider, LCTransport} from "@lodestar/prover";
 
 const httpProvider = new Web3.providers.HttpProvider("https://lodestar-sepoliarpc.chainsafe.io");
@@ -51,7 +51,7 @@ const {provider, proofProvider} = createVerifiedExecutionProvider(httpProvider, 
   mutateProvider: false,
 });
 
-const web3 = new Web3(provider);
+const web3 = new Web3(provider); // TODO: type is not compatible
 
 const address = "0xf97e180c050e5Ab072211Ad2C213Eb5AEE4DF134";
 const balance = await web3.eth.getBalance(address, "latest");

--- a/packages/prover/package.json
+++ b/packages/prover/package.json
@@ -57,7 +57,7 @@
     "test:browsers:firefox": "vitest --run --browser firefox --config ./vitest.browser.config.ts --dir test/unit",
     "test:browsers:electron": "echo 'Electron tests will be introduced back in the future as soon vitest supports electron.'",
     "test:e2e": "LODESTAR_PRESET=minimal vitest --run --config vitest.e2e.config.ts --dir test/e2e",
-    "check-readme": "typescript-docs-verifier",
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json",
     "generate-fixtures": "node --loader ts-node/esm scripts/generate_fixtures.ts"
   },
   "dependencies": {

--- a/packages/prover/test/e2e/web3_provider.test.ts
+++ b/packages/prover/test/e2e/web3_provider.test.ts
@@ -54,7 +54,7 @@ describe("web3_provider", function () {
           mutateProvider: false,
         });
 
-        const web3 = new Web3(nonVerifiedProvider);
+        const web3 = new Web3(verifiedProvider); //TODO: type is not compatible
         const accounts = await web3.eth.getAccounts();
 
         await expect(verifiedProvider.request("eth_getBalance", [accounts[0], "latest"])).resolves.toBeDefined();

--- a/packages/prover/tsconfig.doc.json
+++ b/packages/prover/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/reqresp/package.json
+++ b/packages/reqresp/package.json
@@ -49,7 +49,7 @@
     "lint:fix": "yarn run lint --fix",
     "test": "yarn test:unit",
     "test:unit": "vitest --run --dir test/unit/",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "dependencies": {
     "@chainsafe/fast-crc32c": "^4.1.1",

--- a/packages/reqresp/tsconfig.doc.json
+++ b/packages/reqresp/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -49,7 +49,7 @@
     "test": "yarn test:unit && yarn test:e2e",
     "test:unit": "vitest --run --passWithNoTests --dir test/unit/",
     "test:e2e": "vitest --run --config vitest.e2e.config.ts --dir test/e2e/",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "repository": {
     "type": "git",

--- a/packages/spec-test-util/tsconfig.doc.json
+++ b/packages/spec-test-util/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -54,7 +54,7 @@
     "lint:fix": "yarn run lint --fix",
     "test": "yarn test:unit",
     "test:unit": "vitest --run --dir test/unit/",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "types": "lib/index.d.ts",
   "dependencies": {

--- a/packages/state-transition/tsconfig.doc.json
+++ b/packages/state-transition/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -44,7 +44,7 @@
     "check-types": "tsc",
     "lint": "eslint --color --ext .ts src/",
     "lint:fix": "yarn run lint --fix",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "repository": {
     "type": "git",

--- a/packages/test-utils/tsconfig.doc.json
+++ b/packages/test-utils/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -69,7 +69,7 @@
     "test:browsers:chrome": "vitest --run --browser chrome --config ./vitest.browser.config.ts --dir test/unit",
     "test:browsers:firefox": "vitest --run --browser firefox --config ./vitest.browser.config.ts --dir test/unit",
     "test:browsers:electron": "echo 'Electron tests will be introduced back in the future as soon vitest supports electron.'",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "types": "lib/index.d.ts",
   "dependencies": {

--- a/packages/types/tsconfig.doc.json
+++ b/packages/types/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,7 +35,7 @@
     "test:browsers:chrome": "vitest --run --browser chrome --config ./vitest.browser.config.ts --dir test/unit",
     "test:browsers:firefox": "vitest --run --browser firefox --config ./vitest.browser.config.ts --dir test/unit",
     "test:browsers:electron": "echo 'Electron tests will be introduced back in the future as soon vitest supports electron.'",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "types": "lib/index.d.ts",
   "dependencies": {

--- a/packages/utils/tsconfig.doc.json
+++ b/packages/utils/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -32,7 +32,7 @@
     "test:spec": "vitest --run --config vitest.spec.config.ts --dir test/spec/",
     "test:e2e": "vitest --run --config vitest.e2e.config.ts --dir test/e2e",
     "download-spec-tests": "node --loader=ts-node/esm test/spec/downloadTests.ts",
-    "check-readme": "typescript-docs-verifier"
+    "check-readme": "typescript-docs-verifier --project tsconfig.doc.json"
   },
   "repository": {
     "type": "git",

--- a/packages/validator/tsconfig.doc.json
+++ b/packages/validator/tsconfig.doc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {},
+  // `typescript-docs-verifier` uses `ts-node` to compile README snippets
+  // and hence it is required to disable `transpileOnly` mode as it disables
+  // all type checks. Set at root to be directly forwarded to `ts-node` until
+  // https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved
+  "transpileOnly": false
+}


### PR DESCRIPTION
**Motivation**

Code snippets in README files are currently not validated, and some are broken. We should make sure that examples can be copy-pasted and are runnable

**Description**

Fix verification of README code snippets

There is a bug in `typescript-docs-verifier` which requires to have a override tsconfig per project and pass `ts-node` options in root as extends does not work.

Workaround can be removed once https://github.com/bbc/typescript-docs-verifier/issues/31 is resolved.

Closes https://github.com/ChainSafe/lodestar/issues/6300