### PR TITLE
refactor(test): use the configurable logger consistently via top level interface of crucible

### DIFF
--- a/packages/cli/test/utils/crucible/clients/beacon/lighthouse.ts
+++ b/packages/cli/test/utils/crucible/clients/beacon/lighthouse.ts
@@ -93,12 +93,11 @@ export const generateLighthouseBeaconNode: BeaconNodeGenerator<BeaconClient.Ligh
       health: async () => {
         try {
           await got.get(`http://127.0.0.1:${ports.beacon.httpPort}/eth/v1/node/health`);
-          return {ok: true};
         } catch (err) {
           if (err instanceof RequestError && err.code !== "ECONNREFUSED") {
-            return {ok: true};
+            return;
           }
-          return {ok: false, reason: (err as Error).message, checkId: "/eth/v1/node/health query"};
+          throw err;
         }
       },
     },

--- a/packages/cli/test/utils/crucible/clients/beacon/lodestar.ts
+++ b/packages/cli/test/utils/crucible/clients/beacon/lodestar.ts
@@ -95,12 +95,7 @@ export const generateLodestarBeaconNode: BeaconNodeGenerator<BeaconClient.Lodest
         stdoutFilePath: logFilePath,
       },
       health: async () => {
-        try {
-          await got.get(`http://${address}:${ports.beacon.httpPort}/eth/v1/node/health`);
-          return {ok: true};
-        } catch (err) {
-          return {ok: false, reason: (err as Error).message, checkId: "eth/v1/node/health query"};
-        }
+        await got.get(`http://${address}:${ports.beacon.httpPort}/eth/v1/node/health`);
       },
     },
   ]);

--- a/packages/cli/test/utils/crucible/clients/execution/geth.ts
+++ b/packages/cli/test/utils/crucible/clients/execution/geth.ts
@@ -154,12 +154,7 @@ export const generateGethNode: ExecutionNodeGenerator<ExecutionClient.Geth> = (o
       stdoutFilePath: logFilePath,
     },
     health: async () => {
-      try {
-        await got.post(ethRpcPublicUrl, {json: {jsonrpc: "2.0", method: "net_version", params: [], id: 67}});
-        return {ok: true};
-      } catch (err) {
-        return {ok: false, reason: (err as Error).message, checkId: "JSON RPC query net_version"};
-      }
+      await got.post(ethRpcPublicUrl, {json: {jsonrpc: "2.0", method: "net_version", params: [], id: 67}});
     },
   };
 

--- a/packages/cli/test/utils/crucible/clients/execution/nethermind.ts
+++ b/packages/cli/test/utils/crucible/clients/execution/nethermind.ts
@@ -118,12 +118,7 @@ export const generateNethermindNode: ExecutionNodeGenerator<ExecutionClient.Neth
       stdoutFilePath: logFilePath,
     },
     health: async () => {
-      try {
-        await got.post(ethRpcPublicUrl, {json: {jsonrpc: "2.0", method: "net_version", params: [], id: 67}});
-        return {ok: true};
-      } catch (err) {
-        return {ok: false, reason: (err as Error).message, checkId: "JSON RPC query net_version"};
-      }
+      await got.post(ethRpcPublicUrl, {json: {jsonrpc: "2.0", method: "net_version", params: [], id: 67}});
     },
   };
 

--- a/packages/cli/test/utils/crucible/clients/validator/lighthouse.ts
+++ b/packages/cli/test/utils/crucible/clients/validator/lighthouse.ts
@@ -83,12 +83,11 @@ export const generateLighthouseValidatorNode: ValidatorNodeGenerator<ValidatorCl
       health: async () => {
         try {
           await got.get(`http://127.0.0.1:${ports.validator.keymanagerPort}/lighthouse/health`);
-          return {ok: true};
         } catch (err) {
           if (err instanceof RequestError) {
-            return {ok: true};
+            return;
           }
-          return {ok: false, reason: (err as Error).message, checkId: "/lighthouse/health query"};
+          throw err;
         }
       },
     },

--- a/packages/cli/test/utils/crucible/clients/validator/lodestar.ts
+++ b/packages/cli/test/utils/crucible/clients/validator/lodestar.ts
@@ -69,12 +69,7 @@ export const generateLodestarValidatorNode: ValidatorNodeGenerator<ValidatorClie
         stdoutFilePath: logFilePath,
       },
       health: async () => {
-        try {
-          await got.get(`http://127.0.0.1:${ports.validator.keymanagerPort}/eth/v1/keystores`);
-          return {ok: true};
-        } catch (err) {
-          return {ok: false, reason: (err as Error).message, checkId: "eth/v1/keystores query"};
-        }
+        await got.get(`http://127.0.0.1:${ports.validator.keymanagerPort}/eth/v1/keystores`);
       },
     },
   ]);

--- a/packages/cli/test/utils/crucible/interfaces.ts
+++ b/packages/cli/test/utils/crucible/interfaces.ts
@@ -7,7 +7,7 @@ import {Api as KeyManagerApi} from "@lodestar/api/keymanager";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkName} from "@lodestar/params";
 import {Slot, allForks, Epoch} from "@lodestar/types";
-import {Logger} from "@lodestar/logger";
+import {LogLevel, Logger} from "@lodestar/logger";
 import {BeaconArgs} from "../../../src/cmds/beacon/options.js";
 import {IValidatorCliArgs} from "../../../src/cmds/validator/options.js";
 import {GlobalArgs} from "../../../src/options/index.js";
@@ -29,6 +29,7 @@ export type SimulationOptions = {
   controller: AbortController;
   genesisTime: number;
   trustedSetup?: boolean;
+  logLevel?: LogLevel;
 };
 
 export enum BeaconClient {
@@ -234,8 +235,6 @@ export type ExecutionNodeGenerator<E extends ExecutionClient> = (
   runner: IRunner
 ) => ExecutionNode;
 
-export type HealthStatus = {ok: true} | {ok: false; reason: string; checkId: string};
-
 export type JobOptions<T extends RunnerType = RunnerType.ChildProcess | RunnerType.Docker> = {
   readonly id: string;
 
@@ -257,7 +256,7 @@ export type JobOptions<T extends RunnerType = RunnerType.ChildProcess | RunnerTy
 
   // Will be called frequently to check the health of job startup
   // If not present then wait for the job to exit
-  health?(): Promise<HealthStatus>;
+  health?(): Promise<void>;
 
   // Called once before the `job.start` is called
   bootstrap?(): Promise<void>;

--- a/packages/cli/test/utils/crucible/runner/childProcessRunner.ts
+++ b/packages/cli/test/utils/crucible/runner/childProcessRunner.ts
@@ -1,15 +1,15 @@
 import {ChildProcess} from "node:child_process";
-import {
-  spawnChildProcess,
-  stopChildProcess,
-  ChildProcessHealthStatus,
-  SpawnChildProcessOptions,
-  ChildProcessResolve,
-} from "@lodestar/test-utils";
+import {spawnChildProcess, stopChildProcess, SpawnChildProcessOptions, ChildProcessResolve} from "@lodestar/test-utils";
+import {Logger} from "@lodestar/logger";
 import {Job, JobOptions, RunnerEnv, RunnerType} from "../interfaces.js";
 
 export class ChildProcessRunner implements RunnerEnv<RunnerType.ChildProcess> {
   type = RunnerType.ChildProcess as const;
+  private logger: Logger;
+
+  constructor(opts: {logger: Logger}) {
+    this.logger = opts.logger;
+  }
 
   create(jobOption: Omit<JobOptions<RunnerType.ChildProcess>, "children">): Job {
     let childProcess: ChildProcess;
@@ -17,21 +17,14 @@ export class ChildProcessRunner implements RunnerEnv<RunnerType.ChildProcess> {
     const spawnOpts: SpawnChildProcessOptions = {
       env: jobOption.cli.env,
       pipeStdioToFile: jobOption.logs.stdoutFilePath,
-      logPrefix: jobOption.id,
+      id: jobOption.id,
     };
 
     const health = jobOption.health;
 
     if (health) {
       spawnOpts.healthTimeoutMs = 30000;
-      spawnOpts.health = async (): Promise<ChildProcessHealthStatus> =>
-        health()
-          .then((status) => {
-            return status.ok ? {healthy: true} : {healthy: false};
-          })
-          .catch((error) => {
-            return {healthy: false, message: (error as Error).message};
-          });
+      spawnOpts.health = health;
     } else {
       spawnOpts.resolveOn = ChildProcessResolve.Completion;
     }

--- a/packages/cli/test/utils/crucible/runner/childProcessRunner.ts
+++ b/packages/cli/test/utils/crucible/runner/childProcessRunner.ts
@@ -17,7 +17,7 @@ export class ChildProcessRunner implements RunnerEnv<RunnerType.ChildProcess> {
     const spawnOpts: SpawnChildProcessOptions = {
       env: jobOption.cli.env,
       pipeStdioToFile: jobOption.logs.stdoutFilePath,
-      id: jobOption.id,
+      logPrefix: jobOption.id,
     };
 
     const health = jobOption.health;

--- a/packages/cli/test/utils/crucible/runner/dockerRunner.ts
+++ b/packages/cli/test/utils/crucible/runner/dockerRunner.ts
@@ -83,7 +83,7 @@ export class DockerRunner implements RunnerEnv<RunnerType.Docker> {
     const spawnOpts: SpawnChildProcessOptions = {
       env: jobOption.cli.env,
       pipeStdioToFile: jobOption.logs.stdoutFilePath,
-      id: jobOption.id,
+      logPrefix: jobOption.id,
     };
 
     const health = jobOption.health;

--- a/packages/cli/test/utils/crucible/runner/index.ts
+++ b/packages/cli/test/utils/crucible/runner/index.ts
@@ -9,7 +9,7 @@ export class Runner implements IRunner {
   private emitter = new EventEmitter({captureRejections: true});
   private runners: {[RunnerType.ChildProcess]: ChildProcessRunner; [RunnerType.Docker]: DockerRunner};
 
-  constructor({logger, logsDir}: {logger: LoggerNode; logsDir: string}) {
+  constructor({logger}: {logger: LoggerNode}) {
     this.logger = logger;
     this.runners = {
       [RunnerType.ChildProcess]: new ChildProcessRunner({logger: this.logger.child({module: "cp"})}),

--- a/packages/cli/test/utils/crucible/simulation.ts
+++ b/packages/cli/test/utils/crucible/simulation.ts
@@ -77,7 +77,7 @@ export class Simulation {
     });
 
     this.externalSigner = new ExternalSignerServer([]);
-    this.runner = new Runner({logsDir: this.options.logsDir, logger: this.logger});
+    this.runner = new Runner({logger: this.logger});
     this.tracker = SimulationTracker.initWithDefaults({
       logsDir: options.logsDir,
       logger: this.logger,

--- a/packages/cli/test/utils/crucible/simulation.ts
+++ b/packages/cli/test/utils/crucible/simulation.ts
@@ -64,7 +64,10 @@ export class Simulation {
       timestampFormat: {
         format: TimestampFormatCode.DateRegular,
       },
-      file: {level: LogLevel.debug, filepath: path.join(options.logsDir, `simulation-${this.options.id}.log`)},
+      file: {
+        level: options.logLevel ?? LogLevel.debug,
+        filepath: path.join(options.logsDir, `simulation-${this.options.id}.log`),
+      },
     });
     this.clock = new EpochClock({
       genesisTime: this.options.genesisTime + this.forkConfig.GENESIS_DELAY,
@@ -74,7 +77,7 @@ export class Simulation {
     });
 
     this.externalSigner = new ExternalSignerServer([]);
-    this.runner = new Runner({logsDir: this.options.logsDir, logger: this.logger.child({module: "runner"})});
+    this.runner = new Runner({logsDir: this.options.logsDir, logger: this.logger});
     this.tracker = SimulationTracker.initWithDefaults({
       logsDir: options.logsDir,
       logger: this.logger,

--- a/packages/test-utils/src/childProcess.ts
+++ b/packages/test-utils/src/childProcess.ts
@@ -1,10 +1,34 @@
 /* eslint-disable no-console */
-import childProcess from "node:child_process";
+import childProcess, {ChildProcess, ChildProcessWithoutNullStreams} from "node:child_process";
 import stream from "node:stream";
 import fs from "node:fs";
 import path from "node:path";
-import {prettyMsToTime, sleep} from "@lodestar/utils";
+import {prettyMsToTime, retry, sleep, Logger} from "@lodestar/utils";
 import {TestContext} from "./interfaces.js";
+
+export type ChildProcessLogOptions = {
+  /**
+   * A string key to identify the process in logs
+   */
+  id?: string;
+  /**
+   * Hide stdio from parent process and only show errors
+   */
+  pipeOnlyError?: boolean;
+} & (
+  | {
+      /**
+       * If true, pipe child process stdio to parent process
+       */
+      pipeStdioToFile?: string;
+      /**
+       * If true, pipe child process stdio to parent process
+       */
+      pipeStdioToParent?: boolean;
+      logger?: never;
+    }
+  | {logger?: Logger; pipeStdioToFile?: never; pipeStdioToParent?: never; logPrefix?: never}
+);
 
 /**
  * If timeout is greater than 0, the parent will send the signal
@@ -13,11 +37,8 @@ import {TestContext} from "./interfaces.js";
  */
 const defaultTimeout = 15 * 60 * 1000; // ms
 
-export type ExecChildProcessOptions = {
+export type ExecChildProcessOptions = ChildProcessLogOptions & {
   env?: Record<string, string>;
-  pipeStdioToFile?: string;
-  pipeStdioToParent?: boolean;
-  logPrefix?: string;
   timeoutMs?: number;
   maxBuffer?: number;
   signal?: AbortSignal;
@@ -28,7 +49,7 @@ export type ExecChildProcessOptions = {
  * If the child process exits with code > 0, rejects
  */
 export async function execChildProcess(cmd: string | string[], options?: ExecChildProcessOptions): Promise<string> {
-  const {timeoutMs, maxBuffer, logPrefix, pipeStdioToParent, pipeStdioToFile} = options ?? {};
+  const {timeoutMs, maxBuffer} = options ?? {};
   const cmdStr = Array.isArray(cmd) ? cmd.join(" ") : cmd;
 
   return new Promise((resolve, reject) => {
@@ -44,28 +65,7 @@ export async function execChildProcess(cmd: string | string[], options?: ExecChi
       }
     );
 
-    const logPrefixStream = new stream.Transform({
-      transform(chunk, _encoding, callback) {
-        callback(null, `${logPrefix} ${proc.pid}: ${Buffer.from(chunk).toString("utf8")}`);
-      },
-    });
-
-    if (pipeStdioToParent) {
-      proc.stdout?.pipe(logPrefixStream).pipe(process.stdout);
-      proc.stderr?.pipe(logPrefixStream).pipe(process.stderr);
-    }
-
-    if (pipeStdioToFile) {
-      fs.mkdirSync(path.dirname(pipeStdioToFile), {recursive: true});
-      const stdoutFileStream = fs.createWriteStream(pipeStdioToFile);
-
-      proc.stdout?.pipe(logPrefixStream).pipe(stdoutFileStream);
-      proc.stderr?.pipe(logPrefixStream).pipe(stdoutFileStream);
-
-      proc.once("exit", (_code: number) => {
-        stdoutFileStream.close();
-      });
-    }
+    handleLoggingForChildProcess(proc, options ?? {});
 
     if (options?.signal) {
       options.signal.addEventListener(
@@ -161,33 +161,11 @@ export enum ChildProcessResolve {
   Healthy,
 }
 
-export type ChildProcessHealthStatus = {healthy: boolean; error?: string};
-
-export type SpawnChildProcessOptions = {
+export type HealthCheckOptions = {
   /**
-   * Environment variables to pass to child process
+   * If health attribute defined we will consider resolveOn = ChildProcessResolve.Healthy
    */
-  env?: Record<string, string>;
-  /**
-   * If true, pipe child process stdio to parent process
-   */
-  pipeStdioToFile?: string;
-  /**
-   * If true, pipe child process stdio to parent process
-   */
-  pipeStdioToParent?: boolean;
-  /**
-   * The prefix to add to child process stdio to identify it from logs
-   */
-  logPrefix?: string;
-  /**
-   * Hide stdio from parent process and only show errors
-   */
-  pipeOnlyError?: boolean;
-  /**
-   * Child process resolve behavior
-   */
-  resolveOn?: ChildProcessResolve;
+  health: () => Promise<void>;
   /**
    * Timeout to wait for child process before considering it unhealthy
    */
@@ -200,29 +178,70 @@ export type SpawnChildProcessOptions = {
    * Log health checks after this time
    */
   logHealthChecksAfterMs?: number;
-  /**
-   * Test context to pass to child process. Useful for testing to close the process after test case
-   */
-  testContext?: TestContext;
-  /**
-   * Abort signal to stop child process
-   */
-  signal?: AbortSignal;
-  /**
-   * If health attribute defined we will consider resolveOn = ChildProcessResolve.Healthy
-   */
-  health?: () => Promise<{healthy: boolean; error?: string}>;
+};
+
+export type SpawnChildProcessOptions = Partial<HealthCheckOptions> &
+  ChildProcessLogOptions & {
+    /**
+     * Environment variables to pass to child process
+     */
+    env?: Record<string, string>;
+    /**
+     * Child process resolve behavior
+     */
+    resolveOn?: ChildProcessResolve;
+    /**
+     * Test context to pass to child process. Useful for testing to close the process after test case
+     */
+    testContext?: TestContext;
+    /**
+     * Abort signal to stop child process
+     */
+    signal?: AbortSignal;
+  };
+
+const defaultHealthOptions = {
+  healthCheckIntervalMs: 1000,
+  logHealthChecksAfterMs: 2000,
+  healthTimeoutMs: 10000,
 };
 
 const defaultStartOpts = {
+  ...defaultHealthOptions,
   env: {},
-  pipeStdToParent: false,
-  pipeOnlyError: false,
-  logPrefix: "",
-  healthCheckIntervalMs: 1000,
-  logHealthChecksAfterMs: 2000,
   resolveOn: ChildProcessResolve.Immediate,
 };
+
+export async function waitForHealth({
+  id,
+  health,
+  healthTimeoutMs = defaultHealthOptions.healthTimeoutMs,
+  logHealthChecksAfterMs = defaultHealthOptions.logHealthChecksAfterMs,
+  healthCheckIntervalMs = defaultHealthOptions.healthCheckIntervalMs,
+}: HealthCheckOptions & {id: string}): Promise<void> {
+  console.log({healthTimeoutMs, logHealthChecksAfterMs, healthCheckIntervalMs});
+  const startHealthCheckMs = Date.now();
+
+  await retry(
+    async () => {
+      try {
+        await health();
+      } catch (error) {
+        const timeSinceHealthCheckStart = Date.now() - startHealthCheckMs;
+        if (timeSinceHealthCheckStart > logHealthChecksAfterMs) {
+          console.log(
+            `Health check unsuccessful. id=${id} timeSinceHealthCheckStart=${prettyMsToTime(timeSinceHealthCheckStart)}`
+          );
+        }
+        throw error;
+      }
+    },
+    {
+      retryDelay: healthCheckIntervalMs,
+      retries: healthTimeoutMs === undefined ? 1 : Math.floor(healthTimeoutMs / healthCheckIntervalMs),
+    }
+  );
+}
 
 /**
  * Spawn child process and return it
@@ -237,9 +256,9 @@ export async function spawnChildProcess(
   args: string[],
   opts?: Partial<SpawnChildProcessOptions>
 ): Promise<childProcess.ChildProcessWithoutNullStreams> {
-  const options = {...defaultStartOpts, ...opts};
-  const {env, pipeStdioToFile, pipeStdioToParent, logPrefix, pipeOnlyError, signal} = options;
-  const {health, resolveOn, healthCheckIntervalMs, logHealthChecksAfterMs, healthTimeoutMs, testContext} = options;
+  const options = {...defaultStartOpts, ...opts} as SpawnChildProcessOptions;
+  const {env, signal, health, resolveOn, healthCheckIntervalMs, logHealthChecksAfterMs, healthTimeoutMs} = options;
+  const {id, testContext} = options;
 
   return new Promise<childProcess.ChildProcessWithoutNullStreams>((resolve, reject) => {
     void (async () => {
@@ -247,12 +266,7 @@ export async function spawnChildProcess(
         env: {...process.env, ...env},
       });
 
-      const getLogPrefixStream = (): stream.Transform =>
-        new stream.Transform({
-          transform(chunk, _encoding, callback) {
-            callback(null, `[${logPrefix}] [${proc.pid}]: ${Buffer.from(chunk).toString("utf8")}`);
-          },
-        });
+      handleLoggingForChildProcess(proc, options);
 
       if (testContext) {
         testContext.afterEach(async () => {
@@ -270,28 +284,6 @@ export async function spawnChildProcess(
           },
           {once: true}
         );
-      }
-
-      if (pipeStdioToFile) {
-        fs.mkdirSync(path.dirname(pipeStdioToFile), {recursive: true});
-        const stdoutFileStream = fs.createWriteStream(pipeStdioToFile);
-
-        proc.stdout.pipe(getLogPrefixStream()).pipe(stdoutFileStream);
-        proc.stderr.pipe(getLogPrefixStream()).pipe(stdoutFileStream);
-
-        proc.once("exit", (_code: number) => {
-          stdoutFileStream.close();
-        });
-      }
-
-      if (pipeStdioToParent) {
-        proc.stdout.pipe(getLogPrefixStream()).pipe(process.stdout);
-        proc.stderr.pipe(getLogPrefixStream()).pipe(process.stderr);
-      }
-
-      if (!pipeStdioToParent && pipeOnlyError) {
-        // If want to see only errors then show it on the output stream of main process
-        proc.stderr.pipe(getLogPrefixStream()).pipe(process.stdout);
       }
 
       // If there is any error in running the child process, reject the promise
@@ -315,54 +307,28 @@ export async function spawnChildProcess(
 
       // If there is a health check, wait for it to pass
       if (health) {
-        const startHealthCheckMs = Date.now();
-        const intervalId = setInterval(() => {
-          health()
-            .then((isHealthy) => {
-              if (isHealthy.healthy) {
-                clearInterval(intervalId);
-                clearTimeout(healthTimeoutId);
-                proc.removeAllListeners("exit");
-                resolve(proc);
-              } else {
-                const timeSinceHealthCheckStart = Date.now() - startHealthCheckMs;
-                if (timeSinceHealthCheckStart > logHealthChecksAfterMs) {
-                  console.log(
-                    `Health check unsuccessful. logPrefix=${logPrefix} pid=${
-                      proc.pid
-                    } timeSinceHealthCheckStart=${prettyMsToTime(timeSinceHealthCheckStart)}`
-                  );
-                }
-              }
-            })
-            .catch((e) => {
-              console.error("Error on health check, health functions must never throw", e);
-            });
-        }, healthCheckIntervalMs);
-
-        const healthTimeoutId = setTimeout(() => {
-          clearTimeout(healthTimeoutId);
-
-          if (intervalId !== undefined) {
-            reject(
-              new Error(
-                `Health check timeout. logPrefix=${logPrefix} pid=${proc.pid} healthTimeout=${prettyMsToTime(
-                  healthTimeoutMs ?? 0
-                )}`
-              )
-            );
-          }
-        }, healthTimeoutMs);
-
-        proc.once("exit", (code: number) => {
-          if (healthTimeoutId !== undefined) return;
-
-          clearInterval(intervalId);
-          clearTimeout(healthTimeoutId);
-
+        try {
+          await waitForHealth({
+            health,
+            id: id ?? String(proc.pid as number) ?? "",
+            logHealthChecksAfterMs,
+            healthTimeoutMs,
+            healthCheckIntervalMs,
+          });
+          proc.removeAllListeners("exit");
+          resolve(proc);
+        } catch (error) {
           reject(
             new Error(
-              `Process exited before healthy. logPrefix=${logPrefix} pid=${proc.pid} healthTimeout=${prettyMsToTime(
+              `Health check timeout. id=${id} pid=${proc.pid} healthTimeout=${prettyMsToTime(healthTimeoutMs ?? 0)}`
+            )
+          );
+        }
+
+        proc.once("exit", (code: number) => {
+          reject(
+            new Error(
+              `Process exited before healthy. id=${id} pid=${proc.pid} healthTimeout=${prettyMsToTime(
                 healthTimeoutMs ?? 0
               )} code=${code} command="${command} ${args.join(" ")}"`
             )
@@ -382,4 +348,59 @@ export function bufferStderr(proc: childProcess.ChildProcessWithoutNullStreams):
   return {
     read: () => data,
   };
+}
+
+export function handleLoggingForChildProcess(
+  proc: ChildProcessWithoutNullStreams | ChildProcess,
+  options: ChildProcessLogOptions
+): void {
+  const {id, logger, pipeOnlyError, pipeStdioToFile, pipeStdioToParent} = options;
+
+  if (logger && !pipeOnlyError) {
+    proc.stdout?.on("data", (chunk) => {
+      logger.debug(Buffer.from(chunk).toString("utf8"));
+    });
+
+    proc.stderr?.on("data", (chunk) => {
+      logger.debug(Buffer.from(chunk).toString("utf8"));
+    });
+  }
+
+  if (logger && pipeOnlyError) {
+    proc.stderr?.on("data", (chunk) => {
+      logger.debug(Buffer.from(chunk).toString("utf8"));
+    });
+  }
+
+  const getLogPrefixStream = (): stream.Transform =>
+    new stream.Transform({
+      transform(chunk, _encoding, callback) {
+        callback(null, `[${id}] [${proc.pid}]: ${Buffer.from(chunk).toString("utf8")}`);
+      },
+    });
+
+  if (pipeStdioToFile) {
+    fs.mkdirSync(path.dirname(pipeStdioToFile), {recursive: true});
+    const stdoutFileStream = fs.createWriteStream(pipeStdioToFile);
+
+    proc.once("exit", (_code: number) => {
+      stdoutFileStream.close();
+    });
+
+    if (pipeOnlyError) {
+      proc.stderr?.pipe(getLogPrefixStream()).pipe(stdoutFileStream);
+    } else {
+      proc.stdout?.pipe(getLogPrefixStream()).pipe(stdoutFileStream);
+      proc.stderr?.pipe(getLogPrefixStream()).pipe(stdoutFileStream);
+    }
+  }
+
+  if (pipeStdioToParent) {
+    if (pipeOnlyError) {
+      proc.stderr?.pipe(getLogPrefixStream()).pipe(process.stderr);
+    } else {
+      proc.stdout?.pipe(getLogPrefixStream()).pipe(process.stdout);
+      proc.stderr?.pipe(getLogPrefixStream()).pipe(process.stderr);
+    }
+  }
 }


### PR DESCRIPTION
**Motivation**

Use the configurable logging in the sim tests. 

**Description**

- Use the logger consistently across different components of the crucible
- The log level should be configurable via the Simulation interface
- Simplify the `health` interface 

**Steps to test or reproduce**

- Run all tests 
