### PR TITLE
feat: execution.engineMock considers itself synced by default

### DIFF
--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -35,6 +35,8 @@ export type ExecutionEngineMockOpts = {
   onlyPredefinedResponses?: boolean;
   capellaForkTimestamp?: number;
   denebForkTimestamp?: number;
+  /**  Skip validation of parent and finalized block hash */
+  validateBlockHashes?: boolean;
 };
 
 type ExecutionBlock = {
@@ -168,7 +170,7 @@ export class ExecutionEngineMockBackend implements JsonRpcBackend {
     //    validation is locally available. The validation process is specified in the Payload validation section.
     //
     // > Mock only validates that parent is known
-    if (!this.validBlocks.has(parentHash)) {
+    if (this.opts.validateBlockHashes !== false && !this.validBlocks.has(parentHash)) {
       // if requisite data for the payload's acceptance or validation is missing
       // return {status: SYNCING, latestValidHash: null, validationError: null}
       return {status: ExecutionPayloadStatus.SYNCING, latestValidHash: null, validationError: null};
@@ -253,7 +255,7 @@ export class ExecutionEngineMockBackend implements JsonRpcBackend {
 
     // 5. Client software MUST update its forkchoice state if payloads referenced by forkchoiceState.headBlockHash and
     //    forkchoiceState.finalizedBlockHash are VALID.
-    if (!this.validBlocks.has(finalizedBlockHash)) {
+    if (this.opts.validateBlockHashes !== false && !this.validBlocks.has(finalizedBlockHash)) {
       throw Error(`Unknown finalizedBlockHash ${finalizedBlockHash}`);
     }
     this.headBlockHash = headBlockHash;

--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -72,6 +72,7 @@ const forkChoiceTest =
           genesisBlockHash: isExecutionStateType(anchorState)
             ? toHexString(anchorState.latestExecutionPayloadHeader.blockHash)
             : ZERO_HASH_HEX,
+          validateBlockHashes: true,
         });
 
         const controller = new AbortController();

--- a/packages/cli/src/options/beaconNodeOptions/execution.ts
+++ b/packages/cli/src/options/beaconNodeOptions/execution.ts
@@ -18,6 +18,9 @@ export function parseArgs(args: ExecutionEngineArgs): IBeaconNodeOptions["execut
     return {
       mode: "mock",
       genesisBlockHash: "",
+      // Allows to quickly spin up Lodestar on any network as engine mock
+      // will consider itself synced without having to sync from genesis.
+      validateBlockHashes: false,
     };
   }
 
@@ -72,9 +75,8 @@ export const options: CliCommandOptions<ExecutionEngineArgs> = {
   },
 
   "execution.engineMock": {
-    description: "Set the execution engine to mock mode",
+    description: "Set the execution engine to mock mode (development only)",
     type: "boolean",
-    hidden: true,
     group: "execution",
   },
 


### PR DESCRIPTION
**Motivation**

Allows to quickly spin up Lodestar on any network without requiring a synced EL client. This is also useful for researchers or developers that wanna experiment with Lodestar or run it as part of their CI to test proofs, light client etc.

See related discussion https://github.com/ChainSafe/lodestar/discussions/6188

**Description**

Running Lodestar via `--execution.engineMock` will consider the execution payload status _valid_ by default (instead of _syncing_). This allows to use all apis, and do proper testing on any network which previously required to sync the engine mock from genesis to pass parent hash validation.

For example, to quickly get a synced beacon node on sepolia
```sh
./lodestar beacon --network sepolia --checkpointSyncUrl https://beaconstate-sepolia.chainsafe.io/ --execution.engineMock --eth1 false
```
The execution client will report _valid_, and the api is able to serve all data.
```txt
Jun-10 14:26:54.001[]                 info: Synced - slot: 5191034 - head: (slot -1) 0x13c8…53a7 - exec-block: valid(6078809 0x8120…) - finalized: 0x8261…1617:162217 - peers: 2
Jun-10 14:27:06.004[]                 info: Synced - slot: 5191035 - head: 0xa3bc…ab93 - exec-block: valid(6078811 0x6f01…) - finalized: 0x8261…1617:162217 - peers: 2
Jun-10 14:27:18.003[]                 info: Synced - slot: 5191036 - head: 0x80f1…3a0f - exec-block: valid(6078812 0x3081…) - finalized: 0x8261…1617:162217 - peers: 2
```
