### PR TITLE
fix: add workaround to fix fetching state from checkpointz

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -2,6 +2,7 @@
 export * from "./beacon/index.js";
 export {HttpStatusCode} from "./utils/httpStatusCode.js";
 export {WireFormat} from "./utils/wireFormat.js";
+export {HttpHeader, MediaType} from "./utils/headers.js";
 export type {HttpErrorCodes, HttpSuccessCodes} from "./utils/httpStatusCode.js";
 export {ApiResponse, HttpClient, FetchError, isFetchError, fetch, defaultInit} from "./utils/client/index.js";
 export type {ApiRequestInit} from "./utils/client/request.js";

--- a/packages/api/src/utils/client/request.ts
+++ b/packages/api/src/utils/client/request.ts
@@ -43,7 +43,7 @@ export function createApiRequest<E extends Endpoint>(
   args: E["args"],
   init: ApiRequestInitRequired
 ): Request {
-  const headers = new Headers(init.headers);
+  const headers = new Headers();
 
   let req: E["request"];
 
@@ -102,7 +102,7 @@ export function createApiRequest<E extends Endpoint>(
   return new Request(url, {
     ...init,
     method: definition.method,
-    headers: mergeHeaders(headers, req.headers),
+    headers: mergeHeaders(headers, req.headers, init.headers),
     body: req.body as BodyInit,
   });
 }

--- a/packages/api/src/utils/headers.ts
+++ b/packages/api/src/utils/headers.ts
@@ -90,28 +90,29 @@ export function setAuthorizationHeader(url: URL, headers: Headers, {bearerToken}
   }
 }
 
-export function mergeHeaders(a: HeadersInit | undefined, b: HeadersInit | undefined): Headers {
-  if (!a) {
-    return new Headers(b);
-  }
-  const headers = new Headers(a);
-  if (!b) {
-    return headers;
-  }
-  if (Array.isArray(b)) {
-    for (const [key, value] of b) {
-      headers.set(key, value);
+export function mergeHeaders(...headersList: (HeadersInit | undefined)[]): Headers {
+  const mergedHeaders = new Headers();
+
+  for (const headers of headersList) {
+    if (!headers) {
+      continue;
     }
-  } else if (b instanceof Headers) {
-    for (const [key, value] of b as unknown as Iterable<[string, string]>) {
-      headers.set(key, value);
-    }
-  } else {
-    for (const [key, value] of Object.entries(b)) {
-      headers.set(key, value);
+    if (Array.isArray(headers)) {
+      for (const [key, value] of headers) {
+        mergedHeaders.set(key, value);
+      }
+    } else if (headers instanceof Headers) {
+      for (const [key, value] of headers as unknown as Iterable<[string, string]>) {
+        mergedHeaders.set(key, value);
+      }
+    } else {
+      for (const [key, value] of Object.entries(headers)) {
+        mergedHeaders.set(key, value);
+      }
     }
   }
-  return headers;
+
+  return mergedHeaders;
 }
 
 /**

--- a/packages/api/test/unit/utils/headers.test.ts
+++ b/packages/api/test/unit/utils/headers.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from "vitest";
-import {MediaType, SUPPORTED_MEDIA_TYPES, parseAcceptHeader} from "../../../src/utils/headers.js";
+import {MediaType, SUPPORTED_MEDIA_TYPES, mergeHeaders, parseAcceptHeader} from "../../../src/utils/headers.js";
 
 describe("utils / headers", () => {
   describe("parseAcceptHeader", () => {
@@ -31,5 +31,61 @@ describe("utils / headers", () => {
     it.each(testCases)("should correctly parse the header $header", ({header, expected}) => {
       expect(parseAcceptHeader(header, SUPPORTED_MEDIA_TYPES)).toBe(expected);
     });
+  });
+
+  describe("mergeHeaders", () => {
+    const testCases: {id: string; input: (HeadersInit | undefined)[]; expected: Headers}[] = [
+      {
+        id: "empty headers",
+        input: [{}, [], new Headers()],
+        expected: new Headers(),
+      },
+      {
+        id: "undefined headers",
+        input: [undefined, undefined],
+        expected: new Headers(),
+      },
+      {
+        id: "different headers",
+        input: [{a: "1"}, {b: "2"}],
+        expected: new Headers({a: "1", b: "2"}),
+      },
+      {
+        id: "override on single header",
+        input: [{a: "1"}, {b: "2"}, {a: "3"}],
+        expected: new Headers({a: "3", b: "2"}),
+      },
+      {
+        id: "multiple overrides on same header",
+        input: [{a: "1"}, {b: "2"}, {a: "3"}, {a: "4"}],
+        expected: new Headers({a: "4", b: "2"}),
+      },
+      {
+        id: "multiple overrides on different headers",
+        input: [{a: "1"}, {b: "2"}, {b: "3"}, {a: "4"}, {c: "5"}],
+        expected: new Headers({a: "4", b: "3", c: "5"}),
+      },
+      {
+        id: "headers from array into plain object",
+        input: [{a: "1"}, [["b", "2"]]],
+        expected: new Headers({a: "1", b: "2"}),
+      },
+      {
+        id: "headers from plain object into array",
+        input: [[["a", "1"]], {b: "2"}],
+        expected: new Headers({a: "1", b: "2"}),
+      },
+      {
+        id: "headers from all input types",
+        input: [[["a", "1"]], {b: "2"}, new Headers({c: "3"}), {d: "4"}],
+        expected: new Headers({a: "1", b: "2", c: "3", d: "4"}),
+      },
+    ];
+
+    for (const {id, input, expected} of testCases) {
+      it(`should correctly merge ${id}`, () => {
+        expect(mergeHeaders(...input)).toEqual(expected);
+      });
+    }
   });
 });


### PR DESCRIPTION
**Motivation**

Adds temporary workaround to fix fetching state from Checkpointz.

**Description**

- Allow overriding all headers via request init
- Update `mergeHeaders` to support multiple headers as args
- Set Accept header explicitly in request to override default q-value weighted header which is not supported by Checkpointz until https://github.com/ethpandaops/checkpointz/issues/165 is resolved and most (or better all) checkpoint sync provider have updated
- Get fork type from state bytes (as previously) as Checkpointz does not yet set `Eth-consensus-version` header as required by the spec, see https://github.com/ethpandaops/checkpointz/issues/164
