### PR TITLE
fix: prune invalid ssz objects

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -107,11 +107,11 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       persistInvalidSszObjectsDir && persistInvalidSszObjects
         ? setInterval(() => {
             try {
-              const deletedFiles = pruneOldFilesInDir(
+              const deletedFileCount = pruneOldFilesInDir(
                 persistInvalidSszObjectsDir,
                 (args.persistInvalidSszObjectsRetentionHours ?? DEFAULT_RETENTION_SSZ_OBJECTS_HOURS) * HOURS_TO_MS
               );
-              logger.info("Pruned invalid SSZ objects", {deletedFiles});
+              logger.info("Pruned invalid SSZ objects", {deletedFileCount});
             } catch (e) {
               logger.warn("Error pruning invalid SSZ objects", {persistInvalidSszObjectsDir}, e as Error);
             }

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -102,21 +102,22 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
     }
 
     // Prune invalid SSZ objects every interval
-    const {persistInvalidSszObjectsDir} = options.chain;
-    const pruneInvalidSSZObjectsInterval = persistInvalidSszObjectsDir
-      ? setInterval(() => {
-          try {
-            const deletedFiles = pruneOldFilesInDir(
-              persistInvalidSszObjectsDir,
-              (args.persistInvalidSszObjectsRetentionHours ?? DEFAULT_RETENTION_SSZ_OBJECTS_HOURS) * HOURS_TO_MS
-            );
-            logger.info("Pruned invalid SSZ objects", {deletedFiles});
-          } catch (e) {
-            logger.warn("Error pruning invalid SSZ objects", {persistInvalidSszObjectsDir}, e as Error);
-          }
-          // Run every ~1 hour
-        }, HOURS_TO_MS)
-      : null;
+    const {persistInvalidSszObjectsDir, persistInvalidSszObjects} = options.chain;
+    const pruneInvalidSSZObjectsInterval =
+      persistInvalidSszObjectsDir && persistInvalidSszObjects
+        ? setInterval(() => {
+            try {
+              const deletedFiles = pruneOldFilesInDir(
+                persistInvalidSszObjectsDir,
+                (args.persistInvalidSszObjectsRetentionHours ?? DEFAULT_RETENTION_SSZ_OBJECTS_HOURS) * HOURS_TO_MS
+              );
+              logger.info("Pruned invalid SSZ objects", {deletedFiles});
+            } catch (e) {
+              logger.warn("Error pruning invalid SSZ objects", {persistInvalidSszObjectsDir}, e as Error);
+            }
+            // Run every ~1 hour
+          }, HOURS_TO_MS)
+        : null;
 
     // Intercept SIGINT signal, to perform final ops before exiting
     onGracefulShutdown(async () => {

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -102,14 +102,15 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
     }
 
     // Prune invalid SSZ objects every interval
-    const {persistInvalidSszObjectsDir} = args;
+    const {persistInvalidSszObjectsDir} = options.chain;
     const pruneInvalidSSZObjectsInterval = persistInvalidSszObjectsDir
       ? setInterval(() => {
           try {
-            pruneOldFilesInDir(
+            const deletedFiles = pruneOldFilesInDir(
               persistInvalidSszObjectsDir,
               (args.persistInvalidSszObjectsRetentionHours ?? DEFAULT_RETENTION_SSZ_OBJECTS_HOURS) * HOURS_TO_MS
             );
+            logger.info("Pruned invalid SSZ objects", {deletedFiles});
           } catch (e) {
             logger.warn("Error pruning invalid SSZ objects", {persistInvalidSszObjectsDir}, e as Error);
           }

--- a/packages/cli/src/util/pruneOldFilesInDir.ts
+++ b/packages/cli/src/util/pruneOldFilesInDir.ts
@@ -2,17 +2,17 @@ import fs from "node:fs";
 import path from "node:path";
 
 export function pruneOldFilesInDir(dirpath: string, maxAgeMs: number): number {
-  let deletedFiles = 0;
+  let deletedFileCount = 0;
   for (const entryName of fs.readdirSync(dirpath)) {
     const entryPath = path.join(dirpath, entryName);
 
     const stat = fs.statSync(entryPath);
     if (stat.isDirectory()) {
-      deletedFiles += pruneOldFilesInDir(entryPath, maxAgeMs);
+      deletedFileCount += pruneOldFilesInDir(entryPath, maxAgeMs);
     } else if (stat.isFile()) {
       if (Date.now() - stat.mtimeMs > maxAgeMs) {
         fs.unlinkSync(entryPath);
-        deletedFiles += 1;
+        deletedFileCount += 1;
       }
     }
   }
@@ -21,5 +21,5 @@ export function pruneOldFilesInDir(dirpath: string, maxAgeMs: number): number {
   if (fs.readdirSync(dirpath).length === 0) {
     fs.rmdirSync(dirpath);
   }
-  return deletedFiles;
+  return deletedFileCount;
 }

--- a/packages/cli/src/util/pruneOldFilesInDir.ts
+++ b/packages/cli/src/util/pruneOldFilesInDir.ts
@@ -1,17 +1,25 @@
 import fs from "node:fs";
 import path from "node:path";
 
-export function pruneOldFilesInDir(dirpath: string, maxAgeMs: number): void {
+export function pruneOldFilesInDir(dirpath: string, maxAgeMs: number): number {
+  let deletedFiles = 0;
   for (const entryName of fs.readdirSync(dirpath)) {
     const entryPath = path.join(dirpath, entryName);
 
     const stat = fs.statSync(entryPath);
     if (stat.isDirectory()) {
-      pruneOldFilesInDir(entryPath, maxAgeMs);
+      deletedFiles += pruneOldFilesInDir(entryPath, maxAgeMs);
     } else if (stat.isFile()) {
       if (Date.now() - stat.mtimeMs > maxAgeMs) {
         fs.unlinkSync(entryPath);
+        deletedFiles += 1;
       }
     }
   }
+
+  // if all files are deleted, delete the directory
+  if (fs.readdirSync(dirpath).length === 0) {
+    fs.rmdirSync(dirpath);
+  }
+  return deletedFiles;
 }

--- a/packages/cli/test/unit/util/pruneOldFilesInDir.test.ts
+++ b/packages/cli/test/unit/util/pruneOldFilesInDir.test.ts
@@ -43,7 +43,7 @@ describe("pruneOldFilesInDir", () => {
 
     pruneOldFilesInDir(dataDir, DAYS_TO_MS);
 
-    expect(fs.readdirSync(nestedDir)).toHaveLength(0);
+    expect(fs.existsSync(nestedDir)).toBe(false);
   });
 
   it("should handle empty directories", () => {
@@ -52,7 +52,7 @@ describe("pruneOldFilesInDir", () => {
 
     pruneOldFilesInDir(emptyDir, DAYS_TO_MS);
 
-    expect(fs.readdirSync(emptyDir)).toHaveLength(0);
+    expect(fs.existsSync(emptyDir)).toBe(false);
   });
 
   function createFileWithAge(path: string, ageInDays: number): void {


### PR DESCRIPTION
**Motivation**

We implemented a feature to prune invalid ssz objects but still see a lot of them there

**Description**

- I think it's not triggered because we should get `persistInvalidSszObjectsDir` from chain options instead of `args`
- Also add some logs to confirm