### PR TITLE
fix: ignore empty ids/statuses arrays when filtering validators

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -75,20 +75,20 @@ export function getBeaconStateApi({
       };
     },
 
-    async getStateValidators({stateId, validatorIds, statuses}) {
+    async getStateValidators({stateId, validatorIds = [], statuses = []}) {
       const {state, executionOptimistic, finalized} = await resolveStateId(chain, stateId);
       const currentEpoch = getCurrentEpoch(state);
       const {validators, balances} = state; // Get the validators sub tree once for all the loop
       const {pubkey2index} = chain.getHeadState().epochCtx;
 
       const validatorResponses: routes.beacon.ValidatorResponse[] = [];
-      if (validatorIds) {
+      if (validatorIds.length) {
         for (const id of validatorIds) {
           const resp = getStateValidatorIndex(id, state, pubkey2index);
           if (resp.valid) {
             const validatorIndex = resp.validatorIndex;
             const validator = validators.getReadonly(validatorIndex);
-            if (statuses && !statuses.includes(getValidatorStatus(validator, currentEpoch))) {
+            if (statuses.length && !statuses.includes(getValidatorStatus(validator, currentEpoch))) {
               continue;
             }
             const validatorResponse = toValidatorResponse(
@@ -104,7 +104,7 @@ export function getBeaconStateApi({
           data: validatorResponses,
           meta: {executionOptimistic, finalized},
         };
-      } else if (statuses) {
+      } else if (statuses.length) {
         const validatorsByStatus = filterStateValidatorsByStatus(statuses, state, pubkey2index, currentEpoch);
         return {
           data: validatorsByStatus,


### PR DESCRIPTION
**Motivation**

Prysm VC is sending an empty array of statuses when calling `POST /eth/v1/beacon/states/head/validators`. While previously, when using the GET method, clients would just omit the query param, with the new POST endpoint it's more likely that we receive an empty array. The spec does not specifically note that there must be at least on item in the array, we should handle an empty array in the same way as if the statuses property is omitted, as otherwise it would always return no validators.

**Description**

Ignore empty ids/statuses when filtering validators