### PR TITLE
fix: align WithdrawalRequestV1 field names with latest spec

### DIFF
--- a/packages/beacon-node/src/execution/engine/payloadIdCache.ts
+++ b/packages/beacon-node/src/execution/engine/payloadIdCache.ts
@@ -28,7 +28,7 @@ export type DepositRequestV1 = {
 
 export type ExecutionLayerWithdrawalRequestV1 = {
   sourceAddress: DATA;
-  validatorPublicKey: DATA;
+  validatorPubkey: DATA;
   amount: QUANTITY;
 };
 

--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -423,7 +423,7 @@ export function serializeExecutionLayerWithdrawalRequest(
 ): ExecutionLayerWithdrawalRequestRpc {
   return {
     sourceAddress: bytesToData(withdrawalRequest.sourceAddress),
-    validatorPublicKey: bytesToData(withdrawalRequest.validatorPubkey),
+    validatorPubkey: bytesToData(withdrawalRequest.validatorPubkey),
     amount: numToQuantity(withdrawalRequest.amount),
   };
 }
@@ -433,7 +433,7 @@ export function deserializeExecutionLayerWithdrawalRequest(
 ): electra.ExecutionLayerWithdrawalRequest {
   return {
     sourceAddress: dataToBytes(withdrawalRequest.sourceAddress, 20),
-    validatorPubkey: dataToBytes(withdrawalRequest.validatorPublicKey, 48),
+    validatorPubkey: dataToBytes(withdrawalRequest.validatorPubkey, 48),
     amount: quantityToNum(withdrawalRequest.amount),
   };
 }


### PR DESCRIPTION
**Motivation**

- https://github.com/ethereum/execution-apis/pull/549

**Description**

Align WithdrawalRequestV1 field names with latest spec

`validatorPublicKey` --> `validatorPubkey`

part of https://github.com/ChainSafe/lodestar/issues/6836