### PR TITLE
fix: ignore empty array when filtering validator balances

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -151,10 +151,10 @@ export function getBeaconStateApi({
       };
     },
 
-    async getStateValidatorBalances({stateId, validatorIds}) {
+    async getStateValidatorBalances({stateId, validatorIds = []}) {
       const {state, executionOptimistic, finalized} = await resolveStateId(chain, stateId);
 
-      if (validatorIds) {
+      if (validatorIds.length) {
         const headState = chain.getHeadState();
         const balances: routes.beacon.ValidatorBalance[] = [];
         for (const id of validatorIds) {


### PR DESCRIPTION
**Motivation**

Similar to https://github.com/ChainSafe/lodestar/pull/6876, and further clarified in https://github.com/ethereum/beacon-APIs/pull/453

**Description**

 Ignore empty array when filtering validator balances