### PR TITLE
feat: handle exited/exiting validators during top up

### DIFF
--- a/packages/state-transition/src/epoch/processPendingBalanceDeposits.ts
+++ b/packages/state-transition/src/epoch/processPendingBalanceDeposits.ts
@@ -10,6 +10,8 @@ import {getCurrentEpoch} from "../util/epoch.js";
  * For each eligible `deposit`, call `increaseBalance()`.
  * Remove the processed deposits from `state.pendingBalanceDeposits`.
  * Update `state.depositBalanceToConsume` for the next epoch
+ * 
+ * TODO Electra: Update ssz library to support batch push to `pendingBalanceDeposits`
  */
 export function processPendingBalanceDeposits(state: CachedBeaconStateElectra): void {
   const availableForProcessing = state.depositBalanceToConsume + BigInt(getActivationExitChurnLimit(state));


### PR DESCRIPTION
Handle deposit for exiting and exited validators:
- If the validator is exiting, move the deposit to the end of `state.pendingBalanceDeposits` via `depositsToPostpone`
- If the validator is already exited, directly increase its balance without consuming churn (`state.depositBalanceToConsume`)


Spec PR: https://github.com/ethereum/consensus-specs/pull/3776