### PR TITLE
fix: ignore empty array when filtering validator rewards

### DIFF
--- a/packages/beacon-node/src/chain/rewards/attestationsRewards.ts
+++ b/packages/beacon-node/src/chain/rewards/attestationsRewards.ts
@@ -137,19 +137,19 @@ function computeTotalAttestationsRewardsAltair(
   transitionCache: EpochTransitionCache,
   idealRewards: IdealAttestationsReward[],
   penalties: AttestationsPenalty[],
-  validatorIds?: (ValidatorIndex | string)[] // validatorIds filter
+  validatorIds: (ValidatorIndex | string)[] = []
 ): TotalAttestationsReward[] {
   const rewards = [];
   const {statuses} = transitionCache;
   const {epochCtx, config} = state;
   const validatorIndices = validatorIds
-    ?.map((id) => (typeof id === "number" ? id : epochCtx.pubkey2index.get(id)))
+    .map((id) => (typeof id === "number" ? id : epochCtx.pubkey2index.get(id)))
     .filter((index) => index !== undefined); // Validator indices to include in the result
 
   const inactivityPenaltyDenominator = config.INACTIVITY_SCORE_BIAS * INACTIVITY_PENALTY_QUOTIENT_ALTAIR;
 
   for (let i = 0; i < statuses.length; i++) {
-    if (validatorIndices !== undefined && !validatorIndices.includes(i)) {
+    if (validatorIndices.length && !validatorIndices.includes(i)) {
       continue;
     }
 

--- a/packages/beacon-node/src/chain/rewards/syncCommitteeRewards.ts
+++ b/packages/beacon-node/src/chain/rewards/syncCommitteeRewards.ts
@@ -9,7 +9,7 @@ type BalanceRecord = {val: number}; // Use val for convenient way to increment/d
 export async function computeSyncCommitteeRewards(
   block: allForks.BeaconBlock,
   preState: CachedBeaconStateAllForks,
-  validatorIds?: (ValidatorIndex | string)[]
+  validatorIds: (ValidatorIndex | string)[] = []
 ): Promise<SyncCommitteeRewards> {
   const fork = preState.config.getForkName(block.slot);
   if (fork === ForkName.phase0) {
@@ -46,7 +46,7 @@ export async function computeSyncCommitteeRewards(
 
   const rewards = Array.from(balances, ([validatorIndex, v]) => ({validatorIndex, reward: v.val}));
 
-  if (validatorIds !== undefined) {
+  if (validatorIds.length) {
     const filtersSet = new Set(validatorIds);
     return rewards.filter(
       (reward) => filtersSet.has(reward.validatorIndex) || filtersSet.has(index2pubkey[reward.validatorIndex].toHex())


### PR DESCRIPTION
**Motivation**

Fix all remaining routes to properly handle empty `[]` filter

**Description**

Ignore empty array when filtering validator rewards

These two request will result in return data for all validators, without filtering


with empty array body
```sh
curl -X POST http://localhost:9596/eth/v1/beacon/rewards/attestations/290253 -H "content-type: application/json" -d "[]"
```

and without body (depends on https://github.com/ChainSafe/lodestar/pull/6881)
```sh
curl -X POST http://localhost:9596/eth/v1/beacon/rewards/attestations/290253
```