### PR TITLE
fix: fix uncaught exception on poll validator indices causing sync and attestation duties failure for that epoch

### DIFF
--- a/packages/validator/src/services/indices.ts
+++ b/packages/validator/src/services/indices.ts
@@ -85,7 +85,10 @@ export class IndicesService {
 
     // Once the pollValidatorIndicesInternal() resolves or rejects null the cached promise so it can be called again.
     this.pollValidatorIndicesPromise = this.pollValidatorIndicesInternal(pubkeysHex)
-      .catch((_e) => [])
+      .catch((e) => {
+        this.logger.warn("Failed to get indices for pending pubkeys", {pending: pubkeysHex.length}, e);
+        return [];
+      })
       .finally(() => {
         this.pollValidatorIndicesPromise = null;
       });

--- a/packages/validator/src/services/indices.ts
+++ b/packages/validator/src/services/indices.ts
@@ -86,7 +86,7 @@ export class IndicesService {
     // Once the pollValidatorIndicesInternal() resolves or rejects null the cached promise so it can be called again.
     this.pollValidatorIndicesPromise = this.pollValidatorIndicesInternal(pubkeysHex)
       .catch((e) => {
-        this.logger.warn("Failed to get indices for pending pubkeys", {pending: pubkeysHex.length}, e);
+        this.logger.warn("Failed to get indices for pending pubkeys", {}, e);
         return [];
       })
       .finally(() => {

--- a/packages/validator/src/services/indices.ts
+++ b/packages/validator/src/services/indices.ts
@@ -83,12 +83,12 @@ export class IndicesService {
       return this.pollValidatorIndicesPromise;
     }
 
-    this.pollValidatorIndicesPromise = this.pollValidatorIndicesInternal(pubkeysHex);
     // Once the pollValidatorIndicesInternal() resolves or rejects null the cached promise so it can be called again.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.pollValidatorIndicesPromise.finally(() => {
-      this.pollValidatorIndicesPromise = null;
-    });
+    this.pollValidatorIndicesPromise = this.pollValidatorIndicesInternal(pubkeysHex)
+      .catch((_e) => [])
+      .finally(() => {
+        this.pollValidatorIndicesPromise = null;
+      });
     return this.pollValidatorIndicesPromise;
   }
 


### PR DESCRIPTION
fixes the following scenario where validator doesn't even perform attestations and sync duties for the indices it already knows for the epoch where this api errors


```bash
un-15 18:49:36.030[]                error: uncaughtException: Can not fetch state validators from beacon node - Internal Server Error: Internal server error
Error: Can not fetch state validators from beacon node - Internal Server Error: Internal server error
    at Function.assert (file:///usr/app/packages/api/src/utils/client/httpClient.ts:44:13)
    at IndicesService.fetchValidatorIndices (file:///usr/app/packages/validator/src/services/indices.ts:130:14)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at IndicesService.pollValidatorIndicesInternal (file:///usr/app/packages/validator/src/services/indices.ts:119:35) - Can not fetch state validators from beacon node - Internal Server Error: Internal server error
Error: Can not fetch state validators from beacon node - Internal Server Error: Internal server error
    at Function.assert (file:///usr/app/packages/api/src/utils/client/httpClient.ts:44:13)
    at IndicesService.fetchValidatorIndices (file:///usr/app/packages/validator/src/services/indices.ts:130:14)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at IndicesService.pollValidatorIndicesInternal (file:///usr/app/packages/validator/src/services/indices.ts:119:35)
Jun-15 18:49:36.035[]                error: Failed to download SyncDuties epoch=58789 - Failed to obtain SyncDuties - Internal Server Error: Internal server error
Error: Failed to obtain SyncDuties - Internal Server Error: Internal server error
    at Function.assert (file:///usr/app/packages/api/src/utils/client/httpClient.ts:44:13)
    at SyncCommitteeDutiesService.pollSyncCommitteesForEpoch (file:///usr/app/packages/validator/src/services/syncCommitteeDuties.ts:240:14)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at SyncCommitteeDutiesService.pollSyncCommittees (file:///usr/app/packages/validator/src/services/syncCommitteeDuties.ts:185:7)
    at async Promise.all (index 0)
    at SyncCommitteeDutiesService.runDutiesTasks (file:///usr/app/packages/validator/src/services/syncCommitteeDuties.ts:147:5)
    at Clock.runAtMostEvery (file:///usr/app/packages/validator/src/util/clock.ts:96:7)
Jun-15 18:49:36.043[]                error: Failed to download attester duties epoch=58789 - Failed to obtain attester duty - Internal Server Error: Internal server error
Error: Failed to obtain attester duty - Internal Server Error: Internal server error
    at Function.assert (file:///usr/app/packages/api/src/utils/client/httpClient.ts:44:13)
    at AttestationDutiesService.pollBeaconAttestersForEpoch (file:///usr/app/packages/validator/src/services/attestationDuties.ts:234:14)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at AttestationDutiesService.pollBeaconAttesters (file:///usr/app/packages/validator/src/s
```