### PR TITLE
fix: move server api method invocation out of try-catch for parsing

### DIFF
--- a/packages/api/src/utils/server/handler.ts
+++ b/packages/api/src/utils/server/handler.ts
@@ -14,7 +14,7 @@ import {
 } from "../types.js";
 import {WireFormat, fromWireFormat, getWireFormat} from "../wireFormat.js";
 import {ApiError} from "./error.js";
-import {ApplicationMethod, ApplicationResponse} from "./method.js";
+import {ApplicationMethod} from "./method.js";
 
 export type FastifyHandler<E extends Endpoint> = fastify.RouteHandlerMethod<
   fastify.RawServerDefault,
@@ -57,15 +57,12 @@ export function createFastifyHandler<E extends Endpoint>(
     }
     const responseWireFormat = responseMediaType !== null ? getWireFormat(responseMediaType) : null;
 
-    let response: ApplicationResponse<E>;
+    let args: E["args"], requestWireFormat: WireFormat | null;
     try {
       if (isRequestWithoutBody(definition)) {
-        response = await method(definition.req.parseReq(req as RequestData), {
-          sszBytes: null,
-          returnBytes: responseWireFormat === WireFormat.ssz,
-        });
+        requestWireFormat = null;
+        args = definition.req.parseReq(req as RequestData);
       } else {
-        let requestWireFormat: WireFormat;
         const contentType = req.headers[HttpHeader.ContentType];
         if (contentType === undefined && req.body === undefined) {
           // Default to json parser if body is omitted. This is not possible for most
@@ -89,19 +86,10 @@ export function createFastifyHandler<E extends Endpoint>(
 
         switch (requestWireFormat) {
           case WireFormat.json:
-            response = await method((definition.req as JsonRequestMethods<E>).parseReqJson(req as JsonRequestData), {
-              sszBytes: null,
-              returnBytes: responseWireFormat === WireFormat.ssz,
-            });
+            args = (definition.req as JsonRequestMethods<E>).parseReqJson(req as JsonRequestData);
             break;
           case WireFormat.ssz:
-            response = await method(
-              (definition.req as SszRequestMethods<E>).parseReqSsz(req as SszRequestData<E["request"]>),
-              {
-                sszBytes: req.body as Uint8Array,
-                returnBytes: responseWireFormat === WireFormat.ssz,
-              }
-            );
+            args = (definition.req as SszRequestMethods<E>).parseReqSsz(req as SszRequestData<E["request"]>);
             break;
         }
       }
@@ -110,6 +98,11 @@ export function createFastifyHandler<E extends Endpoint>(
       // Errors related to parsing should return 400 status code
       throw new ApiError(400, (e as Error).message);
     }
+
+    const response = await method(args, {
+      sszBytes: requestWireFormat === WireFormat.ssz ? (req.body as Uint8Array) : null,
+      returnBytes: responseWireFormat === WireFormat.ssz,
+    });
 
     if (response?.status !== undefined) {
       resp.statusCode = response.status;


### PR DESCRIPTION
**Motivation**

Noticed method invocation calls are part of try-catch for parsing, in the case the server throws any non-`ApiError` it would still result in a 400 response which is not desired as this status code would indicate a client issue while if we throw `Error` on the server it indicates some internal issue and should be a 500 response.

This also simplifies the server handler a bit and better separates parsing from method invocation.

**Description**

Move server api method invocation out of try-catch for parsing
