### PR TITLE
fix: avoid uncaught exception when polling validator indices

### DIFF
--- a/packages/validator/src/services/indices.ts
+++ b/packages/validator/src/services/indices.ts
@@ -83,10 +83,8 @@ export class IndicesService {
       return this.pollValidatorIndicesPromise;
     }
 
-    this.pollValidatorIndicesPromise = this.pollValidatorIndicesInternal(pubkeysHex);
-    // Once the pollValidatorIndicesInternal() resolves or rejects null the cached promise so it can be called again.
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.pollValidatorIndicesPromise.finally(() => {
+    this.pollValidatorIndicesPromise = this.pollValidatorIndicesInternal(pubkeysHex).finally(() => {
+      // Once the pollValidatorIndicesInternal() resolves or rejects null the cached promise so it can be called again.
       this.pollValidatorIndicesPromise = null;
     });
     return this.pollValidatorIndicesPromise;


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/pull/6888 for logs and more context

**Description**

Avoid uncaught exception when polling validator indices. The `finally` was called in a different context, causing an uncaught exception as `catch` handlers of upstream code where called earlier.
