### PR TITLE
feat: support electra devnet-1

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -11,7 +11,6 @@ import {
   capella,
   deneb,
   Wei,
-  electra,
 } from "@lodestar/types";
 import {
   CachedBeaconStateAllForks,

--- a/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
+++ b/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
@@ -5,6 +5,7 @@ import {
   EpochTransitionCache,
   BeaconStateAllForks,
   beforeProcessEpoch,
+  CachedBeaconStateAltair,
 } from "@lodestar/state-transition";
 import * as epochFns from "@lodestar/state-transition/epoch";
 import {ssz} from "@lodestar/types";
@@ -40,7 +41,10 @@ const epochTransitionFns: Record<string, EpochTransitionFn> = {
   rewards_and_penalties: epochFns.processRewardsAndPenalties,
   slashings: epochFns.processSlashings,
   slashings_reset: epochFns.processSlashingsReset,
-  sync_committee_updates: epochFns.processSyncCommitteeUpdates as EpochTransitionFn,
+  sync_committee_updates: (state, _) => {
+    const fork = state.config.getForkSeq(state.slot);
+    epochFns.processSyncCommitteeUpdates(fork, state as CachedBeaconStateAltair);
+  },
   historical_summaries_update: epochFns.processHistoricalSummariesUpdate as EpochTransitionFn,
   pending_balance_deposits: epochFns.processPendingBalanceDeposits as EpochTransitionFn,
   pending_consolidations: epochFns.processPendingConsolidations as EpochTransitionFn,

--- a/packages/beacon-node/test/spec/presets/operations.test.ts
+++ b/packages/beacon-node/test/spec/presets/operations.test.ts
@@ -96,6 +96,10 @@ const operationFns: Record<string, BlockProcessFn<CachedBeaconStateAllForks>> = 
     blockFns.processWithdrawalRequest(ForkSeq.electra, state as CachedBeaconStateElectra, testCase.withdrawal_request);
   },
 
+  deposit_request: (state, testCase: {deposit_request: electra.DepositRequest}) => {
+    blockFns.processDepositRequest(ForkSeq.electra, state as CachedBeaconStateElectra, testCase.deposit_request);
+  },
+
   consolidation_request: (state, testCase: {consolidation_request: electra.ConsolidationRequest}) => {
     blockFns.processConsolidationRequest(state as CachedBeaconStateElectra, testCase.consolidation_request);
   },
@@ -151,6 +155,7 @@ const operations: TestRunnerFn<OperationsTestCase, BeaconStateAllForks> = (fork,
         address_change: ssz.capella.SignedBLSToExecutionChange,
         // Electra
         withdrawal_request: ssz.electra.WithdrawalRequest,
+        deposit_request: ssz.electra.DepositRequest,
         consolidation_request: ssz.electra.ConsolidationRequest,
       },
       shouldError: (testCase) => testCase.post === undefined,

--- a/packages/beacon-node/test/spec/presets/operations.test.ts
+++ b/packages/beacon-node/test/spec/presets/operations.test.ts
@@ -103,7 +103,6 @@ const operationFns: Record<string, BlockProcessFn<CachedBeaconStateAllForks>> = 
   consolidation_request: (state, testCase: {consolidation_request: electra.ConsolidationRequest}) => {
     blockFns.processConsolidationRequest(state as CachedBeaconStateElectra, testCase.consolidation_request);
   },
-
 };
 
 export type BlockProcessFn<T extends CachedBeaconStateAllForks> = (state: T, testCase: any) => void;

--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -15,7 +15,7 @@ import {DownloadTestsOptions} from "@lodestar/spec-test-util/downloadTests";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: DownloadTestsOptions = {
-  specVersion: "v1.5.0-alpha.2",
+  specVersion: "v1.5.0-alpha.3",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-spec-tests",

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -66,6 +66,7 @@ export const defaultSkipOpts: SkipOpts = {
     /^capella\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^deneb\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
   ],
+  // TODO Electra: Review this test in the next spec test release
   skippedTests: [/incorrect_not_enough_consolidation_churn_available/],
   skippedRunners: ["merkle_proof", "networking"],
 };

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -66,7 +66,7 @@ export const defaultSkipOpts: SkipOpts = {
     /^capella\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^deneb\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
   ],
-  skippedTests: [],
+  skippedTests: [/incorrect_not_enough_consolidation_churn_available/],
   skippedRunners: ["merkle_proof", "networking"],
 };
 

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -7,7 +7,7 @@ import {
   isForkExecution,
   isForkBlobs,
 } from "@lodestar/params";
-import {Slot, allForks, Version, ssz} from "@lodestar/types";
+import {Slot, allForks, Version, ssz, Epoch} from "@lodestar/types";
 import {ChainConfig} from "../chainConfig/index.js";
 import {ForkConfig, ForkInfo} from "./types.js";
 
@@ -80,6 +80,9 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
     // Fork convenience methods
     getForkInfo(slot: Slot): ForkInfo {
       const epoch = Math.floor(Math.max(slot, 0) / SLOTS_PER_EPOCH);
+      return this.getForkInfoFromEpoch(epoch);
+    },
+    getForkInfoFromEpoch(epoch: Epoch): ForkInfo {
       // NOTE: forks must be sorted by descending epoch, latest fork first
       for (const fork of forksDescendingEpochOrder) {
         if (epoch >= fork.epoch) return fork;
@@ -91,6 +94,9 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
     },
     getForkSeq(slot: Slot): ForkSeq {
       return this.getForkInfo(slot).seq;
+    },
+    getForkSeqFromEpoch(epoch: Epoch): ForkSeq {
+      return this.getForkInfoFromEpoch(epoch).seq;
     },
     getForkVersion(slot: Slot): Version {
       return this.getForkInfo(slot).version;

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -21,11 +21,14 @@ export type ForkConfig = {
 
   /** Get the hard-fork info for the active fork at `slot` */
   getForkInfo(slot: Slot): ForkInfo;
-
+  /** Get the hard-fork info for the active fork at `epoch` */
+  getForkInfoFromEpoch(epoch: Epoch): ForkInfo;
   /** Get the hard-fork name at a given slot */
   getForkName(slot: Slot): ForkName;
   /** Get the hard-fork sequence number at a given slot */
   getForkSeq(slot: Slot): ForkSeq;
+  /** Get the hard-fork sequence number at a given epoch */
+  getForkSeqFromEpoch(epoch: Epoch): ForkSeq;
   /** Get the hard-fork version at a given slot */
   getForkVersion(slot: Slot): Version;
   /** Get SSZ types by hard-fork */

--- a/packages/state-transition/src/block/processConsolidationRequest.ts
+++ b/packages/state-transition/src/block/processConsolidationRequest.ts
@@ -34,7 +34,7 @@ export function processConsolidationRequest(
     return;
   }
 
-  const sourceValidator = state.validators.getReadonly(sourceIndex);
+  const sourceValidator = state.validators.get(sourceIndex);
   const targetValidator = state.validators.getReadonly(targetIndex);
   const sourceWithdrawalAddress = sourceValidator.withdrawalCredentials.subarray(12);
   const currentEpoch = state.epochCtx.epoch;

--- a/packages/state-transition/src/block/processConsolidationRequest.ts
+++ b/packages/state-transition/src/block/processConsolidationRequest.ts
@@ -10,7 +10,6 @@ export function processConsolidationRequest(
   state: CachedBeaconStateElectra,
   consolidationRequest: electra.ConsolidationRequest
 ): void {
-
   // If the pending consolidations queue is full, consolidation requests are ignored
   if (state.pendingConsolidations.length >= PENDING_CONSOLIDATIONS_LIMIT) {
     return;
@@ -30,7 +29,7 @@ export function processConsolidationRequest(
   }
 
   // Verify that source != target, so a consolidation cannot be used as an exit.
-  if (sourceIndex === targetIndex){
+  if (sourceIndex === targetIndex) {
     return;
   }
 

--- a/packages/state-transition/src/block/processOperations.ts
+++ b/packages/state-transition/src/block/processOperations.ts
@@ -67,7 +67,7 @@ export function processOperations(
     const stateElectra = state as CachedBeaconStateElectra;
     const bodyElectra = body as electra.BeaconBlockBody;
 
-    for (const depositRequest of bodyElectra.executionPayload.depositReceipts) {
+    for (const depositRequest of bodyElectra.executionPayload.depositRequests) {
       processDepositRequest(fork, stateElectra, depositRequest);
     }
 

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -394,7 +394,12 @@ export class EpochCache {
     // Allow to create CachedBeaconState for empty states, or no active validators
     const proposers =
       currentShuffling.activeIndices.length > 0
-        ? computeProposers(currentProposerSeed, currentShuffling, effectiveBalanceIncrements, currentEpoch >= config.ELECTRA_FORK_EPOCH)
+        ? computeProposers(
+            currentProposerSeed,
+            currentShuffling,
+            effectiveBalanceIncrements,
+            currentEpoch >= config.ELECTRA_FORK_EPOCH
+          )
         : [];
 
     const proposersNextEpoch: ProposersDeferred = {
@@ -571,7 +576,12 @@ export class EpochCache {
     this.proposersPrevEpoch = this.proposers;
 
     const currentProposerSeed = getSeed(state, this.currentShuffling.epoch, DOMAIN_BEACON_PROPOSER);
-    this.proposers = computeProposers(currentProposerSeed, this.currentShuffling, this.effectiveBalanceIncrements, currEpoch >= this.config.ELECTRA_FORK_EPOCH);
+    this.proposers = computeProposers(
+      currentProposerSeed,
+      this.currentShuffling,
+      this.effectiveBalanceIncrements,
+      currEpoch >= this.config.ELECTRA_FORK_EPOCH
+    );
 
     // Only pre-compute the seed since it's very cheap. Do the expensive computeProposers() call only on demand.
     this.proposersNextEpoch = {computed: false, seed: getSeed(state, this.nextShuffling.epoch, DOMAIN_BEACON_PROPOSER)};
@@ -771,7 +781,7 @@ export class EpochCache {
         this.proposersNextEpoch.seed,
         this.nextShuffling,
         this.effectiveBalanceIncrements,
-        this.epoch + 1 >= this.config.ELECTRA_FORK_EPOCH,
+        this.epoch + 1 >= this.config.ELECTRA_FORK_EPOCH
       );
       this.proposersNextEpoch = {computed: true, indexes};
     }

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -395,10 +395,10 @@ export class EpochCache {
     const proposers =
       currentShuffling.activeIndices.length > 0
         ? computeProposers(
+            config.getForkSeqFromEpoch(currentEpoch),
             currentProposerSeed,
             currentShuffling,
-            effectiveBalanceIncrements,
-            currentEpoch >= config.ELECTRA_FORK_EPOCH
+            effectiveBalanceIncrements
           )
         : [];
 
@@ -577,10 +577,10 @@ export class EpochCache {
 
     const currentProposerSeed = getSeed(state, this.currentShuffling.epoch, DOMAIN_BEACON_PROPOSER);
     this.proposers = computeProposers(
+      this.config.getForkSeqFromEpoch(currEpoch),
       currentProposerSeed,
       this.currentShuffling,
-      this.effectiveBalanceIncrements,
-      currEpoch >= this.config.ELECTRA_FORK_EPOCH
+      this.effectiveBalanceIncrements
     );
 
     // Only pre-compute the seed since it's very cheap. Do the expensive computeProposers() call only on demand.
@@ -778,10 +778,10 @@ export class EpochCache {
   getBeaconProposersNextEpoch(): ValidatorIndex[] {
     if (!this.proposersNextEpoch.computed) {
       const indexes = computeProposers(
+        this.config.getForkSeqFromEpoch(this.epoch + 1),
         this.proposersNextEpoch.seed,
         this.nextShuffling,
-        this.effectiveBalanceIncrements,
-        this.epoch + 1 >= this.config.ELECTRA_FORK_EPOCH
+        this.effectiveBalanceIncrements
       );
       this.proposersNextEpoch = {computed: true, indexes};
     }

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -394,7 +394,7 @@ export class EpochCache {
     // Allow to create CachedBeaconState for empty states, or no active validators
     const proposers =
       currentShuffling.activeIndices.length > 0
-        ? computeProposers(currentProposerSeed, currentShuffling, effectiveBalanceIncrements)
+        ? computeProposers(currentProposerSeed, currentShuffling, effectiveBalanceIncrements, currentEpoch >= config.ELECTRA_FORK_EPOCH)
         : [];
 
     const proposersNextEpoch: ProposersDeferred = {
@@ -571,7 +571,7 @@ export class EpochCache {
     this.proposersPrevEpoch = this.proposers;
 
     const currentProposerSeed = getSeed(state, this.currentShuffling.epoch, DOMAIN_BEACON_PROPOSER);
-    this.proposers = computeProposers(currentProposerSeed, this.currentShuffling, this.effectiveBalanceIncrements);
+    this.proposers = computeProposers(currentProposerSeed, this.currentShuffling, this.effectiveBalanceIncrements, currEpoch >= this.config.ELECTRA_FORK_EPOCH);
 
     // Only pre-compute the seed since it's very cheap. Do the expensive computeProposers() call only on demand.
     this.proposersNextEpoch = {computed: false, seed: getSeed(state, this.nextShuffling.epoch, DOMAIN_BEACON_PROPOSER)};
@@ -770,7 +770,8 @@ export class EpochCache {
       const indexes = computeProposers(
         this.proposersNextEpoch.seed,
         this.nextShuffling,
-        this.effectiveBalanceIncrements
+        this.effectiveBalanceIncrements,
+        this.epoch + 1 >= this.config.ELECTRA_FORK_EPOCH,
       );
       this.proposersNextEpoch = {computed: true, indexes};
     }

--- a/packages/state-transition/src/epoch/index.ts
+++ b/packages/state-transition/src/epoch/index.ts
@@ -178,7 +178,7 @@ export function processEpoch(
       const timer = metrics?.epochTransitionStepTime.startTimer({
         step: EpochTransitionStep.processSyncCommitteeUpdates,
       });
-      processSyncCommitteeUpdates(state as CachedBeaconStateAltair);
+      processSyncCommitteeUpdates(fork, state as CachedBeaconStateAltair);
       timer?.();
     }
   }

--- a/packages/state-transition/src/epoch/processPendingBalanceDeposits.ts
+++ b/packages/state-transition/src/epoch/processPendingBalanceDeposits.ts
@@ -10,7 +10,7 @@ import {getCurrentEpoch} from "../util/epoch.js";
  * For each eligible `deposit`, call `increaseBalance()`.
  * Remove the processed deposits from `state.pendingBalanceDeposits`.
  * Update `state.depositBalanceToConsume` for the next epoch
- * 
+ *
  * TODO Electra: Update ssz library to support batch push to `pendingBalanceDeposits`
  */
 export function processPendingBalanceDeposits(state: CachedBeaconStateElectra): void {

--- a/packages/state-transition/src/epoch/processSyncCommitteeUpdates.ts
+++ b/packages/state-transition/src/epoch/processSyncCommitteeUpdates.ts
@@ -1,5 +1,5 @@
 import bls from "@chainsafe/bls";
-import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD} from "@lodestar/params";
+import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, ForkSeq} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {getNextSyncCommitteeIndices} from "../util/seed.js";
 import {CachedBeaconStateAltair} from "../types.js";
@@ -10,7 +10,7 @@ import {CachedBeaconStateAltair} from "../types.js";
  * PERF: Once every `EPOCHS_PER_SYNC_COMMITTEE_PERIOD`, do an expensive operation to compute the next committee.
  * Calculating the next sync committee has a proportional cost to $VALIDATOR_COUNT
  */
-export function processSyncCommitteeUpdates(state: CachedBeaconStateAltair): void {
+export function processSyncCommitteeUpdates(fork: ForkSeq, state: CachedBeaconStateAltair): void {
   const nextEpoch = state.epochCtx.epoch + 1;
 
   if (nextEpoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD === 0) {
@@ -18,6 +18,7 @@ export function processSyncCommitteeUpdates(state: CachedBeaconStateAltair): voi
     const {effectiveBalanceIncrements} = state.epochCtx;
 
     const nextSyncCommitteeIndices = getNextSyncCommitteeIndices(
+      fork,
       state,
       activeValidatorIndices,
       effectiveBalanceIncrements

--- a/packages/state-transition/src/signatureSets/index.ts
+++ b/packages/state-transition/src/signatureSets/index.ts
@@ -1,7 +1,7 @@
 import {ForkSeq} from "@lodestar/params";
-import {allForks, altair, capella, electra} from "@lodestar/types";
+import {allForks, altair, capella} from "@lodestar/types";
 import {ISignatureSet} from "../util/index.js";
-import {CachedBeaconStateAllForks, CachedBeaconStateAltair, CachedBeaconStateElectra} from "../types.js";
+import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../types.js";
 import {getSyncCommitteeSignatureSet} from "../block/processSyncCommittee.js";
 import {getProposerSlashingsSignatureSets} from "./proposerSlashings.js";
 import {getAttesterSlashingsSignatureSets} from "./attesterSlashings.js";

--- a/packages/state-transition/src/slot/upgradeStateToAltair.ts
+++ b/packages/state-transition/src/slot/upgradeStateToAltair.ts
@@ -70,6 +70,7 @@ export function upgradeStateToAltair(statePhase0: CachedBeaconStatePhase0): Cach
   stateAltair.inactivityScores = ssz.altair.InactivityScores.toViewDU(newZeroedArray(validatorCount));
 
   const {syncCommittee, indices} = getNextSyncCommittee(
+    ForkSeq.altair,
     stateAltair,
     stateAltair.epochCtx.nextShuffling.activeIndices,
     stateAltair.epochCtx.effectiveBalanceIncrements

--- a/packages/state-transition/src/util/execution.ts
+++ b/packages/state-transition/src/util/execution.ts
@@ -175,6 +175,8 @@ export function executionPayloadToPayloadHeader(
       ssz.electra.DepositRequests.hashTreeRoot((payload as electra.ExecutionPayload).depositRequests);
     (bellatrixPayloadFields as electra.ExecutionPayloadHeader).withdrawalRequestsRoot =
       ssz.electra.WithdrawalRequests.hashTreeRoot((payload as electra.ExecutionPayload).withdrawalRequests);
+    (bellatrixPayloadFields as electra.ExecutionPayloadHeader).consolidationRequestsRoot =
+      ssz.electra.ConsolidationRequests.hashTreeRoot((payload as electra.ExecutionPayload).consolidationRequests);
   }
 
   return bellatrixPayloadFields;

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -193,7 +193,10 @@ export function applyDeposits(
     }
 
     const balance = balancesArr[i];
-    const effectiveBalance = Math.min(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), getValidatorMaxEffectiveBalance(validator.withdrawalCredentials));
+    const effectiveBalance = Math.min(
+      balance - (balance % EFFECTIVE_BALANCE_INCREMENT),
+      getValidatorMaxEffectiveBalance(validator.withdrawalCredentials)
+    );
 
     validator.effectiveBalance = effectiveBalance;
     epochCtx.effectiveBalanceIncrementsSet(i, effectiveBalance);

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -18,7 +18,7 @@ import {EpochCacheImmutableData} from "../cache/epochCache.js";
 import {processDeposit} from "../block/processDeposit.js";
 import {increaseBalance} from "../index.js";
 import {computeEpochAtSlot} from "./epoch.js";
-import {getActiveValidatorIndices} from "./validator.js";
+import {getActiveValidatorIndices, getValidatorMaxEffectiveBalance} from "./validator.js";
 import {getTemporaryBlockHeader} from "./blockRoot.js";
 import {newFilledArray} from "./array.js";
 import {getNextSyncCommittee} from "./syncCommittee.js";
@@ -193,7 +193,7 @@ export function applyDeposits(
     }
 
     const balance = balancesArr[i];
-    const effectiveBalance = Math.min(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), MAX_EFFECTIVE_BALANCE);
+    const effectiveBalance = Math.min(balance - (balance % EFFECTIVE_BALANCE_INCREMENT), getValidatorMaxEffectiveBalance(validator.withdrawalCredentials));
 
     validator.effectiveBalance = effectiveBalance;
     epochCtx.effectiveBalanceIncrementsSet(i, effectiveBalance);
@@ -263,6 +263,7 @@ export function initializeBeaconStateFromEth1(
 
   if (fork >= ForkSeq.altair) {
     const {syncCommittee} = getNextSyncCommittee(
+      fork,
       state,
       activeValidatorIndices,
       state.epochCtx.effectiveBalanceIncrements

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -22,20 +22,20 @@ import {computeEpochAtSlot} from "./epoch.js";
  * Compute proposer indices for an epoch
  */
 export function computeProposers(
+  fork: ForkSeq,
   epochSeed: Uint8Array,
   shuffling: {epoch: Epoch; activeIndices: ArrayLike<ValidatorIndex>},
-  effectiveBalanceIncrements: EffectiveBalanceIncrements,
-  isAfterElectra: boolean
+  effectiveBalanceIncrements: EffectiveBalanceIncrements
 ): number[] {
   const startSlot = computeStartSlotAtEpoch(shuffling.epoch);
   const proposers = [];
   for (let slot = startSlot; slot < startSlot + SLOTS_PER_EPOCH; slot++) {
     proposers.push(
       computeProposerIndex(
+        fork,
         effectiveBalanceIncrements,
         shuffling.activeIndices,
-        digest(Buffer.concat([epochSeed, intToBytes(slot, 8)])),
-        isAfterElectra
+        digest(Buffer.concat([epochSeed, intToBytes(slot, 8)]))
       )
     );
   }
@@ -48,10 +48,10 @@ export function computeProposers(
  * SLOW CODE - 🐢
  */
 export function computeProposerIndex(
+  fork: ForkSeq,
   effectiveBalanceIncrements: EffectiveBalanceIncrements,
   indices: ArrayLike<ValidatorIndex>,
-  seed: Uint8Array,
-  isAfterElectra: boolean
+  seed: Uint8Array
 ): ValidatorIndex {
   if (indices.length === 0) {
     throw Error("Validator indices must not be empty");
@@ -59,9 +59,10 @@ export function computeProposerIndex(
 
   // TODO: Inline outside this function
   const MAX_RANDOM_BYTE = 2 ** 8 - 1;
-  const MAX_EFFECTIVE_BALANCE_INCREMENT = isAfterElectra
-    ? MAX_EFFECTIVE_BALANCE_ELECTRA / EFFECTIVE_BALANCE_INCREMENT
-    : MAX_EFFECTIVE_BALANCE / EFFECTIVE_BALANCE_INCREMENT;
+  const MAX_EFFECTIVE_BALANCE_INCREMENT =
+    fork >= ForkSeq.electra
+      ? MAX_EFFECTIVE_BALANCE_ELECTRA / EFFECTIVE_BALANCE_INCREMENT
+      : MAX_EFFECTIVE_BALANCE / EFFECTIVE_BALANCE_INCREMENT;
 
   let i = 0;
   /* eslint-disable-next-line no-constant-condition */

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -18,9 +18,6 @@ import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js
 import {computeStartSlotAtEpoch} from "./epoch.js";
 import {computeEpochAtSlot} from "./epoch.js";
 
-// Max number of iterations over validator set when computing proposer index
-const MAX_ITERATION_OVER_VALIDATORS = 10;
-
 /**
  * Compute proposer indices for an epoch
  */
@@ -83,11 +80,6 @@ export function computeProposerIndex(
       return candidateIndex;
     }
     i += 1;
-    // Spec does not have this condition to end infinite loop. Spec test won't pass if we
-    // only loop the validator indices once. Electra spec test requires MAX_ITERATION_OVER_VALIDATORS >= 6
-    if (i === indices.length * MAX_ITERATION_OVER_VALIDATORS) {
-      return -1;
-    }
   }
 }
 

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -78,7 +78,9 @@ export function computeProposerIndex(
       return candidateIndex;
     }
     i += 1;
-    if (i === indices.length) {
+    // TODO Electra: Spec does not have this condition to end infinite loop. Spec test won't pass if we
+    // only loop the validator indices once
+    if (i === indices.length * 2) {
       return -1;
     }
   }

--- a/packages/state-transition/src/util/syncCommittee.ts
+++ b/packages/state-transition/src/util/syncCommittee.ts
@@ -2,6 +2,7 @@ import bls from "@chainsafe/bls";
 import {
   BASE_REWARD_FACTOR,
   EFFECTIVE_BALANCE_INCREMENT,
+  ForkSeq,
   SLOTS_PER_EPOCH,
   SYNC_COMMITTEE_SIZE,
   SYNC_REWARD_WEIGHT,
@@ -19,11 +20,12 @@ import {getNextSyncCommitteeIndices} from "./seed.js";
  * SLOW CODE - 🐢
  */
 export function getNextSyncCommittee(
+  fork: ForkSeq,
   state: BeaconStateAllForks,
   activeValidatorIndices: ArrayLike<ValidatorIndex>,
   effectiveBalanceIncrements: EffectiveBalanceIncrements
 ): {indices: ValidatorIndex[]; syncCommittee: altair.SyncCommittee} {
-  const indices = getNextSyncCommitteeIndices(state, activeValidatorIndices, effectiveBalanceIncrements);
+  const indices = getNextSyncCommitteeIndices(fork, state, activeValidatorIndices, effectiveBalanceIncrements);
 
   // Using the index2pubkey cache is slower because it needs the serialized pubkey.
   const pubkeys = indices.map((index) => state.validators.getReadonly(index).pubkey);

--- a/packages/state-transition/test/perf/epoch/epochAltair.test.ts
+++ b/packages/state-transition/test/perf/epoch/epochAltair.test.ts
@@ -172,7 +172,7 @@ function benchmarkAltairEpochSteps(stateOg: LazyValue<CachedBeaconStateAllForks>
     id: `${stateId} - altair processSyncCommitteeUpdates`,
     convergeFactor: 1 / 100, // Very unstable make it converge faster
     beforeEach: () => stateOg.value.clone() as CachedBeaconStateAltair,
-    fn: (state) => processSyncCommitteeUpdates(state),
+    fn: (state) => processSyncCommitteeUpdates(ForkSeq.altair, state),
   });
 
   itBench<StateEpoch, StateEpoch>({

--- a/packages/state-transition/test/perf/epoch/processSyncCommitteeUpdates.test.ts
+++ b/packages/state-transition/test/perf/epoch/processSyncCommitteeUpdates.test.ts
@@ -1,5 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD} from "@lodestar/params";
+import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, ForkSeq} from "@lodestar/params";
 import {processSyncCommitteeUpdates} from "../../../src/epoch/processSyncCommitteeUpdates.js";
 import {StateAltair} from "../types.js";
 import {generatePerfTestCachedStateAltair, numValidators} from "../util.js";
@@ -21,7 +21,7 @@ describe("altair processSyncCommitteeUpdates", () => {
     },
     fn: (state) => {
       const nextSyncCommitteeBefore = state.nextSyncCommittee;
-      processSyncCommitteeUpdates(state);
+      processSyncCommitteeUpdates(ForkSeq.altair, state);
       if (state.nextSyncCommittee === nextSyncCommitteeBefore) {
         throw Error("nextSyncCommittee instance has not changed");
       }

--- a/packages/state-transition/test/perf/util.ts
+++ b/packages/state-transition/test/perf/util.ts
@@ -7,6 +7,7 @@ import {createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {
   EPOCHS_PER_ETH1_VOTING_PERIOD,
   EPOCHS_PER_HISTORICAL_VECTOR,
+  ForkSeq,
   MAX_ATTESTATIONS,
   MAX_EFFECTIVE_BALANCE,
   SLOTS_PER_EPOCH,
@@ -273,7 +274,12 @@ export function generatePerformanceStateAltair(pubkeysArg?: Uint8Array[]): Beaco
     const activeValidatorIndices = getActiveValidatorIndices(altairState, epoch);
 
     const effectiveBalanceIncrements = getEffectiveBalanceIncrements(altairState);
-    const {syncCommittee} = getNextSyncCommittee(altairState, activeValidatorIndices, effectiveBalanceIncrements);
+    const {syncCommittee} = getNextSyncCommittee(
+      ForkSeq.altair,
+      altairState,
+      activeValidatorIndices,
+      effectiveBalanceIncrements
+    );
     state.currentSyncCommittee = syncCommittee;
     state.nextSyncCommittee = syncCommittee;
 

--- a/packages/state-transition/test/perf/util/shufflings.test.ts
+++ b/packages/state-transition/test/perf/util/shufflings.test.ts
@@ -1,6 +1,6 @@
 import {itBench} from "@dapplion/benchmark";
 import {Epoch} from "@lodestar/types";
-import {DOMAIN_BEACON_PROPOSER} from "@lodestar/params";
+import {DOMAIN_BEACON_PROPOSER, ForkSeq} from "@lodestar/params";
 import {
   computeEpochAtSlot,
   CachedBeaconStateAllForks,
@@ -28,7 +28,13 @@ describe("epoch shufflings", () => {
     id: `computeProposers - vc ${numValidators}`,
     fn: () => {
       const epochSeed = getSeed(state, state.epochCtx.nextShuffling.epoch, DOMAIN_BEACON_PROPOSER);
-      computeProposers(epochSeed, state.epochCtx.nextShuffling, state.epochCtx.effectiveBalanceIncrements);
+      const fork = state.config.getForkSeq(state.slot);
+      computeProposers(
+        epochSeed,
+        state.epochCtx.nextShuffling,
+        state.epochCtx.effectiveBalanceIncrements,
+        fork >= ForkSeq.electra
+      );
     },
   });
 
@@ -42,7 +48,9 @@ describe("epoch shufflings", () => {
   itBench({
     id: `getNextSyncCommittee - vc ${numValidators}`,
     fn: () => {
+      const fork = state.config.getForkSeq(state.slot);
       getNextSyncCommittee(
+        fork,
         state,
         state.epochCtx.nextShuffling.activeIndices,
         state.epochCtx.effectiveBalanceIncrements

--- a/packages/state-transition/test/perf/util/shufflings.test.ts
+++ b/packages/state-transition/test/perf/util/shufflings.test.ts
@@ -1,6 +1,6 @@
 import {itBench} from "@dapplion/benchmark";
 import {Epoch} from "@lodestar/types";
-import {DOMAIN_BEACON_PROPOSER, ForkSeq} from "@lodestar/params";
+import {DOMAIN_BEACON_PROPOSER} from "@lodestar/params";
 import {
   computeEpochAtSlot,
   CachedBeaconStateAllForks,
@@ -29,12 +29,7 @@ describe("epoch shufflings", () => {
     fn: () => {
       const epochSeed = getSeed(state, state.epochCtx.nextShuffling.epoch, DOMAIN_BEACON_PROPOSER);
       const fork = state.config.getForkSeq(state.slot);
-      computeProposers(
-        epochSeed,
-        state.epochCtx.nextShuffling,
-        state.epochCtx.effectiveBalanceIncrements,
-        fork >= ForkSeq.electra
-      );
+      computeProposers(fork, epochSeed, state.epochCtx.nextShuffling, state.epochCtx.effectiveBalanceIncrements);
     },
   });
 


### PR DESCRIPTION
Bump spec test version to `v1.5.0-alpha.3`. 

Fix everything to make it pass:
- `computeProposers` is now fork aware to use `MAX_EFFECTIVE_BALANCE_ELECTRA` to determine post-electra
- Update `epoch_processing.test.ts` and `operations.test.ts` to correctly run associated test cases
- Skipping `incorrect_not_enough_consolidation_churn_available` test as it passes in an invalid beacon state. This test will also be rewritten in the next release. See ethereum/consensus-specs#3814

Misc:
- Add `getForkSeqFromEpoch` to better convert epoch to `ForkSeq`
