### PR TITLE
chore: remove apis that are no longer part of beacon spec

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {ContainerType, ListCompositeType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {allForks, Slot, ssz, RootHex, deneb, phase0, isSignedBlockContents} from "@lodestar/types";
+import {allForks, Slot, ssz, RootHex, deneb, isSignedBlockContents} from "@lodestar/types";
 import {ForkName, ForkSeq} from "@lodestar/params";
 import {Endpoint, RequestCodec, RouteDefinitions, Schema} from "../../../utils/index.js";
-import {EmptyMeta, EmptyMetaCodec, EmptyResponseCodec, EmptyResponseData, WithVersion} from "../../../utils/codecs.js";
+import {EmptyMeta, EmptyResponseCodec, EmptyResponseData, WithVersion} from "../../../utils/codecs.js";
 import {
   ExecutionOptimisticAndFinalizedCodec,
   ExecutionOptimisticAndFinalizedMeta,
@@ -66,19 +66,6 @@ export enum BroadcastValidation {
 }
 
 export type Endpoints = {
-  /**
-   * Get block
-   * Returns the complete `SignedBeaconBlock` for a given block ID.
-   */
-  getBlock: Endpoint<
-    // ⏎
-    "GET",
-    BlockArgs,
-    {params: {block_id: string}},
-    phase0.SignedBeaconBlock,
-    EmptyMeta
-  >;
-
   /**
    * Get block
    * Retrieves block details for given block id.
@@ -220,15 +207,6 @@ const blockIdOnlyReq: RequestCodec<Endpoint<"GET", {blockId: BlockId}, {params: 
 
 export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoints> {
   return {
-    getBlock: {
-      url: "/eth/v1/beacon/blocks/{block_id}",
-      method: "GET",
-      req: blockIdOnlyReq,
-      resp: {
-        data: ssz.phase0.SignedBeaconBlock,
-        meta: EmptyMetaCodec,
-      },
-    },
     getBlockV2: {
       url: "/eth/v2/beacon/blocks/{block_id}",
       method: "GET",

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -291,25 +291,6 @@ export type Endpoints = {
   >;
 
   /**
-   * Produce a new block, without signature.
-   * Requests a beacon node to produce a valid block, which can then be signed by a validator.
-   */
-  produceBlock: Endpoint<
-    "GET",
-    {
-      /** The slot for which the block should be proposed. */
-      slot: Slot;
-      /** The validator's randao reveal value */
-      randaoReveal: BLSSignature;
-      /** Arbitrary data validator wants to include in block */
-      graffiti: string;
-    },
-    {params: {slot: number}; query: {randao_reveal: string; graffiti: string}},
-    allForks.BeaconBlock,
-    VersionMeta
-  >;
-
-  /**
    * Requests a beacon node to produce a valid block, which can then be signed by a validator.
    * Metadata in the response indicates the type of block produced, and the supported types of block
    * will be added to as forks progress.
@@ -605,32 +586,6 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       resp: {
         data: SyncDutyListType,
         meta: ExecutionOptimisticCodec,
-      },
-    },
-    produceBlock: {
-      url: "/eth/v1/validator/blocks/{slot}",
-      method: "GET",
-      req: {
-        writeReq: ({slot, randaoReveal, graffiti}) => ({
-          params: {slot},
-          query: {randao_reveal: toHexString(randaoReveal), graffiti: toGraffitiHex(graffiti)},
-        }),
-        parseReq: ({params, query}) => ({
-          slot: params.slot,
-          randaoReveal: fromHexString(query.randao_reveal),
-          graffiti: fromGraffitiHex(query.graffiti),
-        }),
-        schema: {
-          params: {slot: Schema.UintRequired},
-          query: {
-            randao_reveal: Schema.StringRequired,
-            graffiti: Schema.String,
-          },
-        },
-      },
-      resp: {
-        data: WithVersion((fork) => ssz[fork].BeaconBlock),
-        meta: VersionCodec,
       },
     },
     produceBlockV2: {

--- a/packages/api/test/unit/beacon/genericServerTest/debug.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/debug.test.ts
@@ -23,7 +23,7 @@ describe("beacon / debug", () => {
 
   // Get state by SSZ
 
-  describe("getState() in SSZ format", () => {
+  describe("get state in SSZ format", () => {
     const mockApi = getMockApi<Endpoints>(getDefinitions(config));
     let baseUrl: string;
     let server: FastifyInstance;
@@ -41,26 +41,22 @@ describe("beacon / debug", () => {
       if (server !== undefined) await server.close();
     });
 
-    for (const method of ["getState" as const, "getStateV2" as const]) {
-      it(method, async () => {
-        const state = ssz.phase0.BeaconState.defaultValue();
-        const stateSerialized = ssz.phase0.BeaconState.serialize(state);
-        mockApi[method].mockResolvedValue({
-          data: stateSerialized,
-          meta: {version: ForkName.phase0, executionOptimistic: false, finalized: false},
-        });
-
-        const httpClient = new HttpClient({baseUrl});
-        const client = getClient(config, httpClient);
-
-        const res = await client[method]({stateId: "head"}, {responseWireFormat: WireFormat.ssz});
-
-        expect(res.ok).toBe(true);
-
-        if (res.ok) {
-          expect(toHexString(res.ssz())).toBe(toHexString(stateSerialized));
-        }
+    it("getStateV2", async () => {
+      const state = ssz.phase0.BeaconState.defaultValue();
+      const stateSerialized = ssz.phase0.BeaconState.serialize(state);
+      mockApi.getStateV2.mockResolvedValue({
+        data: stateSerialized,
+        meta: {version: ForkName.phase0, executionOptimistic: false, finalized: false},
       });
-    }
+
+      const httpClient = new HttpClient({baseUrl});
+      const client = getClient(config, httpClient);
+
+      const res = await client.getStateV2({stateId: "head"}, {responseWireFormat: WireFormat.ssz});
+
+      expect(res.ok).toBe(true);
+      expect(res.wireFormat()).toBe(WireFormat.ssz);
+      expect(toHexString(res.ssz())).toBe(toHexString(stateSerialized));
+    });
   });
 });

--- a/packages/api/test/unit/beacon/genericServerTest/debug.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/debug.test.ts
@@ -42,11 +42,11 @@ describe("beacon / debug", () => {
     });
 
     it("getStateV2", async () => {
-      const state = ssz.phase0.BeaconState.defaultValue();
-      const stateSerialized = ssz.phase0.BeaconState.serialize(state);
+      const state = ssz.deneb.BeaconState.defaultValue();
+      const stateSerialized = ssz.deneb.BeaconState.serialize(state);
       mockApi.getStateV2.mockResolvedValue({
         data: stateSerialized,
-        meta: {version: ForkName.phase0, executionOptimistic: false, finalized: false},
+        meta: {version: ForkName.deneb, executionOptimistic: false, finalized: false},
       });
 
       const httpClient = new HttpClient({baseUrl});

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -31,10 +31,6 @@ const validatorResponse: ValidatorResponse = {
 export const testData: GenericServerTestCases<Endpoints> = {
   // block
 
-  getBlock: {
-    args: {blockId: "head"},
-    res: {data: ssz.phase0.SignedBeaconBlock.defaultValue()},
-  },
   getBlockV2: {
     args: {blockId: "head"},
     res: {

--- a/packages/api/test/unit/beacon/testData/debug.ts
+++ b/packages/api/test/unit/beacon/testData/debug.ts
@@ -7,10 +7,6 @@ import {GenericServerTestCases} from "../../../utils/genericServerTest.js";
 const rootHex = toHexString(Buffer.alloc(32, 1));
 
 export const testData: GenericServerTestCases<Endpoints> = {
-  getDebugChainHeads: {
-    args: undefined,
-    res: {data: [{slot: 1, root: rootHex}]},
-  },
   getDebugChainHeadsV2: {
     args: undefined,
     res: {data: [{slot: 1, root: rootHex, executionOptimistic: true}]},
@@ -44,10 +40,6 @@ export const testData: GenericServerTestCases<Endpoints> = {
         },
       ],
     },
-  },
-  getState: {
-    args: {stateId: "head"},
-    res: {data: ssz.phase0.BeaconState.defaultValue(), meta: {executionOptimistic: true, finalized: false}},
   },
   getStateV2: {
     args: {stateId: "head"},

--- a/packages/api/test/unit/beacon/testData/validator.ts
+++ b/packages/api/test/unit/beacon/testData/validator.ts
@@ -42,10 +42,6 @@ export const testData: GenericServerTestCases<Endpoints> = {
       meta: {executionOptimistic: true},
     },
   },
-  produceBlock: {
-    args: {slot: 32000, randaoReveal, graffiti},
-    res: {data: ssz.phase0.BeaconBlock.defaultValue(), meta: {version: ForkName.phase0}},
-  },
   produceBlockV2: {
     args: {
       slot: 32000,

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -366,11 +366,6 @@ export function getBeaconBlockApi({
       };
     },
 
-    async getBlock({blockId}) {
-      const {block} = await resolveBlockId(chain, blockId);
-      return {data: block};
-    },
-
     async getBlockV2({blockId}) {
       const {block, executionOptimistic, finalized} = await resolveBlockId(chain, blockId);
       return {

--- a/packages/beacon-node/src/api/impl/debug/index.ts
+++ b/packages/beacon-node/src/api/impl/debug/index.ts
@@ -1,6 +1,5 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
-import {phase0} from "@lodestar/types";
 import {resolveStateId} from "../beacon/state/utils.js";
 import {ApiModules} from "../types.js";
 import {isOptimisticBlock} from "../../../util/forkChoice.js";
@@ -10,13 +9,6 @@ export function getDebugApi({
   config,
 }: Pick<ApiModules, "chain" | "config">): ApplicationMethods<routes.debug.Endpoints> {
   return {
-    async getDebugChainHeads() {
-      const heads = chain.forkChoice.getHeads();
-      return {
-        data: heads.map((blockSummary) => ({slot: blockSummary.slot, root: blockSummary.blockRoot})),
-      };
-    },
-
     async getDebugChainHeadsV2() {
       const heads = chain.forkChoice.getHeads();
       return {
@@ -39,14 +31,6 @@ export function getDebugApi({
         bestDescendant: String(node.bestDescendant),
       }));
       return {data: nodes};
-    },
-
-    async getState({stateId}, context) {
-      const {state, executionOptimistic, finalized} = await resolveStateId(chain, stateId, {allowRegen: true});
-      return {
-        data: context?.returnBytes ? state.serialize() : (state.toValue() as phase0.BeaconState),
-        meta: {executionOptimistic, finalized},
-      };
     },
 
     async getStateV2({stateId}, context) {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -739,17 +739,6 @@ export function getValidatorApi({
   }
 
   return {
-    async produceBlock({slot, randaoReveal, graffiti}) {
-      const {data, ...meta} = await produceEngineFullBlockOrContents(slot, randaoReveal, graffiti);
-      if (isForkBlobs(meta.version)) {
-        throw Error(`Invalid call to produceBlock for deneb+ fork=${meta.version}`);
-      } else {
-        // TODO: need to figure out why typescript requires typecasting here
-        // by typing of produceFullBlockOrContents respose it should have figured this out itself
-        return {data: data as allForks.BeaconBlock, meta};
-      }
-    },
-
     async produceBlockV2({slot, randaoReveal, graffiti, ...opts}) {
       const {data, ...meta} = await produceEngineFullBlockOrContents(slot, randaoReveal, graffiti, opts);
       return {data, meta};


### PR DESCRIPTION
**Motivation**

All the removed apis have been replaced by more forward compatible apis (v2) and are no longer part of beacon spec.

**Description**

Remove apis that are no longer part of beacon spec

Closes https://github.com/ChainSafe/lodestar/issues/6839