### PR TITLE
chore: add default message if server closes eventstream

### DIFF
--- a/packages/api/src/beacon/client/events.ts
+++ b/packages/api/src/beacon/client/events.ts
@@ -45,7 +45,8 @@ export function getClient(config: ChainForkConfig, baseUrl: string): ApiClient {
 
         // Ignore noisy errors due to beacon node being offline
         if (!errEs.message?.includes("ECONNREFUSED")) {
-          onError?.(new Error(errEs.message));
+          // If there is no message it likely indicates that the server closed the connection
+          onError?.(new Error(errEs.message ?? "Server closed connection"));
         }
 
         // Consider 400 and 500 status errors unrecoverable, close the eventsource


### PR DESCRIPTION
**Motivation**

Since we now log evenstream errors, I noticed that if server calls `socket.end` it will result in an empty error message.

Just minor UX thing, I've seen similar with other clients when shutting down the node. Best guess if there is no message is that the server closed the connection, can observe if this results in wrong messages for some clients but so far haven't seen other cases.

**Description**

Add default message if server closes eventstream
