### PR TITLE
chore: cleanup usage of blinded types

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -22,7 +22,7 @@ import {
   ExecutionOptimisticFinalizedAndVersionMeta,
   MetaHeader,
 } from "../../../utils/metadata.js";
-import {getBlindedForkTypes, toForkName} from "../../../utils/fork.js";
+import {getExecutionForkTypes, toForkName} from "../../../utils/fork.js";
 import {fromHeaders} from "../../../utils/headers.js";
 import {WireFormat} from "../../../utils/wireFormat.js";
 
@@ -414,7 +414,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         writeReqJson: ({signedBlindedBlock}) => {
           const fork = config.getForkName(signedBlindedBlock.message.slot);
           return {
-            body: getBlindedForkTypes(fork).SignedBeaconBlock.toJson(signedBlindedBlock),
+            body: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.toJson(signedBlindedBlock),
             headers: {
               [MetaHeader.Version]: fork,
             },
@@ -423,13 +423,13 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqJson: ({body, headers}) => {
           const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlindedBlock: getBlindedForkTypes(fork).SignedBeaconBlock.fromJson(body),
+            signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body),
           };
         },
         writeReqSsz: ({signedBlindedBlock}) => {
           const fork = config.getForkName(signedBlindedBlock.message.slot);
           return {
-            body: getBlindedForkTypes(fork).SignedBeaconBlock.serialize(signedBlindedBlock),
+            body: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.serialize(signedBlindedBlock),
             headers: {
               [MetaHeader.Version]: fork,
             },
@@ -438,7 +438,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqSsz: ({body, headers}) => {
           const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlindedBlock: getBlindedForkTypes(fork).SignedBeaconBlock.deserialize(body),
+            signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.deserialize(body),
           };
         },
         schema: {
@@ -458,7 +458,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         writeReqJson: ({signedBlindedBlock, broadcastValidation}) => {
           const fork = config.getForkName(signedBlindedBlock.message.slot);
           return {
-            body: getBlindedForkTypes(fork).SignedBeaconBlock.toJson(signedBlindedBlock),
+            body: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.toJson(signedBlindedBlock),
 
             headers: {
               [MetaHeader.Version]: fork,
@@ -469,14 +469,14 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqJson: ({body, headers, query}) => {
           const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlindedBlock: getBlindedForkTypes(fork).SignedBeaconBlock.fromJson(body),
+            signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body),
             broadcastValidation: query.broadcast_validation as BroadcastValidation,
           };
         },
         writeReqSsz: ({signedBlindedBlock, broadcastValidation}) => {
           const fork = config.getForkName(signedBlindedBlock.message.slot);
           return {
-            body: getBlindedForkTypes(fork).SignedBeaconBlock.serialize(signedBlindedBlock),
+            body: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.serialize(signedBlindedBlock),
             headers: {
               [MetaHeader.Version]: fork,
             },
@@ -486,7 +486,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqSsz: ({body, headers, query}) => {
           const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlindedBlock: getBlindedForkTypes(fork).SignedBeaconBlock.deserialize(body),
+            signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.deserialize(body),
             broadcastValidation: query.broadcast_validation as BroadcastValidation,
           };
         },

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -20,7 +20,7 @@ import {
 } from "@lodestar/types";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {fromGraffitiHex, toBoolean, toGraffitiHex} from "../../utils/serdes.js";
-import {getBlindedForkTypes, toForkName} from "../../utils/fork.js";
+import {getExecutionForkTypes, toForkName} from "../../utils/fork.js";
 import {
   ArrayOf,
   EmptyMeta,
@@ -685,7 +685,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         data: WithMeta(
           ({version, executionPayloadBlinded}) =>
             (executionPayloadBlinded
-              ? getBlindedForkTypes(version).BeaconBlock
+              ? getExecutionForkTypes(version).BlindedBeaconBlock
               : isForkBlobs(version)
                 ? BlockContentsType
                 : ssz[version].BeaconBlock) as Type<BeaconBlockOrContents | BlindedBeaconBlock>
@@ -753,7 +753,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         },
       },
       resp: {
-        data: WithVersion((fork) => getBlindedForkTypes(fork).BeaconBlock),
+        data: WithVersion((fork) => getExecutionForkTypes(fork).BlindedBeaconBlock),
         meta: VersionCodec,
       },
     },

--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -27,7 +27,7 @@ import {
   JsonOnlyReq,
   WithVersion,
 } from "../utils/codecs.js";
-import {getBlindedForkTypes, getExecutionForkTypes, toForkName} from "../utils/fork.js";
+import {getExecutionForkTypes, toForkName} from "../utils/fork.js";
 import {fromHeaders} from "../utils/headers.js";
 
 // See /packages/api/src/routes/index.ts for reasoning and instructions to add new routes
@@ -130,7 +130,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         writeReqJson: ({signedBlindedBlock}) => {
           const fork = config.getForkName(signedBlindedBlock.message.slot);
           return {
-            body: getBlindedForkTypes(fork).SignedBeaconBlock.toJson(signedBlindedBlock),
+            body: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.toJson(signedBlindedBlock),
             headers: {
               [MetaHeader.Version]: fork,
             },
@@ -139,7 +139,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqJson: ({body, headers}) => {
           const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlindedBlock: getBlindedForkTypes(fork).SignedBeaconBlock.fromJson(body),
+            signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body),
           };
         },
         schema: {

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -7,7 +7,7 @@ import {
   isForkExecution,
   isForkLightClient,
 } from "@lodestar/params";
-import {SSZTypesFor, ssz, sszTypesFor} from "@lodestar/types";
+import {SSZTypesFor, sszTypesFor} from "@lodestar/types";
 
 export function toForkName(version: string): ForkName {
   // Teku returns fork as UPPERCASE

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -7,7 +7,7 @@ import {
   isForkExecution,
   isForkLightClient,
 } from "@lodestar/params";
-import {SSZBlindedTypesFor, SSZTypesFor, ssz, sszTypesFor} from "@lodestar/types";
+import {SSZTypesFor, ssz, sszTypesFor} from "@lodestar/types";
 
 export function toForkName(version: string): ForkName {
   // Teku returns fork as UPPERCASE
@@ -33,13 +33,6 @@ export function getExecutionForkTypes(fork: ForkName): SSZTypesFor<ForkExecution
   }
 
   return sszTypesFor(fork);
-}
-
-export function getBlindedForkTypes(fork: ForkName): SSZBlindedTypesFor<ForkExecution> {
-  if (!isForkExecution(fork)) {
-    throw Error(`Invalid fork=${fork} for blinded fork types`);
-  }
-  return ssz.allForksBlinded[fork];
 }
 
 export function getBlobsForkTypes(fork: ForkName): SSZTypesFor<ForkBlobs> {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -240,8 +240,8 @@ export function getBeaconBlockApi({
     const slot = signedBlindedBlock.message.slot;
     const blockRoot = toHex(
       chain.config
-        .getBlindedForkTypes(signedBlindedBlock.message.slot)
-        .BeaconBlock.hashTreeRoot(signedBlindedBlock.message)
+        .getExecutionForkTypes(signedBlindedBlock.message.slot)
+        .BlindedBeaconBlock.hashTreeRoot(signedBlindedBlock.message)
     );
 
     // Either the payload/blobs are cached from i) engine locally or ii) they are from the builder

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -416,7 +416,7 @@ export function getValidatorApi({
         slot,
         executionPayloadValue,
         consensusBlockValue,
-        root: toHex(config.getBlindedForkTypes(slot).BeaconBlock.hashTreeRoot(block)),
+        root: toHex(config.getExecutionForkTypes(slot).BlindedBeaconBlock.hashTreeRoot(block)),
       });
 
       if (chain.opts.persistProducedBlocks) {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -620,7 +620,7 @@ export class BeaconChain implements IBeaconChain {
     const bodyRoot =
       blockType === BlockType.Full
         ? this.config.getForkTypes(slot).BeaconBlockBody.hashTreeRoot(body)
-        : this.config.getBlindedForkTypes(slot).BeaconBlockBody.hashTreeRoot(body as BlindedBeaconBlockBody);
+        : this.config.getExecutionForkTypes(slot).BlindedBeaconBlockBody.hashTreeRoot(body as BlindedBeaconBlockBody);
     this.logger.debug("Computing block post state from the produced body", {
       slot,
       bodyRoot: toHexString(bodyRoot),
@@ -640,7 +640,7 @@ export class BeaconChain implements IBeaconChain {
     const blockRoot =
       blockType === BlockType.Full
         ? this.config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block)
-        : this.config.getBlindedForkTypes(slot).BeaconBlock.hashTreeRoot(block as BlindedBeaconBlock);
+        : this.config.getExecutionForkTypes(slot).BlindedBeaconBlock.hashTreeRoot(block as BlindedBeaconBlock);
     const blockRootHex = toHex(blockRoot);
 
     // track the produced block for consensus broadcast validations
@@ -777,7 +777,7 @@ export class BeaconChain implements IBeaconChain {
   persistBlock(data: BeaconBlock | BlindedBeaconBlock, suffix?: string): void {
     const slot = data.slot;
     if (isBlindedBeaconBlock(data)) {
-      const sszType = this.config.getBlindedForkTypes(slot).BeaconBlock;
+      const sszType = this.config.getExecutionForkTypes(slot).BlindedBeaconBlock;
       void this.persistSszObject("BlindedBeaconBlock", sszType.serialize(data), sszType.hashTreeRoot(data), suffix);
     } else {
       const sszType = this.config.getForkTypes(slot).BeaconBlock;

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -101,13 +101,6 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       }
       return ssz.allForksExecution[forkName];
     },
-    getBlindedForkTypes(slot: Slot): (typeof ssz.allForksBlinded)[ForkExecution] {
-      const forkName = this.getForkName(slot);
-      if (!isForkExecution(forkName)) {
-        throw Error(`Invalid slot=${slot} fork=${forkName} for blinded fork types`);
-      }
-      return ssz.allForksBlinded[forkName];
-    },
     getLightClientForkTypes(slot: Slot): SSZTypesFor<ForkLightClient> {
       const forkName = this.getForkName(slot);
       if (!isForkLightClient(forkName)) {

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -1,5 +1,5 @@
 import {ForkAll, ForkBlobs, ForkExecution, ForkLightClient, ForkName, ForkSeq} from "@lodestar/params";
-import {Epoch, SSZBlindedTypesFor, SSZTypesFor, Slot, Version} from "@lodestar/types";
+import {Epoch, SSZTypesFor, Slot, Version} from "@lodestar/types";
 
 export type ForkInfo = {
   name: ForkName;
@@ -34,8 +34,6 @@ export type ForkConfig = {
   getLightClientForkTypes(slot: Slot): SSZTypesFor<ForkLightClient>;
   /** Get execution SSZ types by hard-fork*/
   getExecutionForkTypes(slot: Slot): SSZTypesFor<ForkExecution>;
-  /** Get blinded SSZ types by hard-fork */
-  getBlindedForkTypes(slot: Slot): SSZBlindedTypesFor<ForkExecution>;
   /** Get blobs SSZ types by hard-fork*/
   getBlobsForkTypes(slot: Slot): SSZTypesFor<ForkBlobs>;
 };

--- a/packages/state-transition/src/signatureSets/proposer.ts
+++ b/packages/state-transition/src/signatureSets/proposer.ts
@@ -20,7 +20,7 @@ export function getBlockProposerSignatureSet(
   const domain = config.getDomain(state.slot, DOMAIN_BEACON_PROPOSER, signedBlock.message.slot);
 
   const blockType = isBlindedBeaconBlock(signedBlock.message)
-    ? config.getBlindedForkTypes(signedBlock.message.slot).BeaconBlock
+    ? config.getExecutionForkTypes(signedBlock.message.slot).BlindedBeaconBlock
     : config.getForkTypes(signedBlock.message.slot).BeaconBlock;
 
   return {

--- a/packages/state-transition/src/util/blindedBlock.ts
+++ b/packages/state-transition/src/util/blindedBlock.ts
@@ -25,7 +25,7 @@ export function blindedOrFullBlockHashTreeRoot(
 ): Root {
   return isBlindedBeaconBlock(blindedOrFull)
     ? // Blinded
-      config.getBlindedForkTypes(blindedOrFull.slot).BeaconBlock.hashTreeRoot(blindedOrFull)
+      config.getExecutionForkTypes(blindedOrFull.slot).BlindedBeaconBlock.hashTreeRoot(blindedOrFull)
     : // Full
       config.getForkTypes(blindedOrFull.slot).BeaconBlock.hashTreeRoot(blindedOrFull);
 }
@@ -36,7 +36,7 @@ export function blindedOrFullBlockToHeader(
 ): BeaconBlockHeader {
   const bodyRoot = isBlindedBeaconBlock(blindedOrFull)
     ? // Blinded
-      config.getBlindedForkTypes(blindedOrFull.slot).BeaconBlockBody.hashTreeRoot(blindedOrFull.body)
+      config.getExecutionForkTypes(blindedOrFull.slot).BlindedBeaconBlockBody.hashTreeRoot(blindedOrFull.body)
     : // Full
       config.getForkTypes(blindedOrFull.slot).BeaconBlockBody.hashTreeRoot(blindedOrFull.body);
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,8 +1,8 @@
 export * from "./types.js";
 import * as ssz from "./sszTypes.js";
 import {sszTypesFor} from "./sszTypes.js";
-import type {SSZBlindedTypesFor, SSZTypesFor} from "./sszTypes.js";
-export {sszTypesFor, SSZBlindedTypesFor, SSZTypesFor, ssz};
+import type {SSZTypesFor} from "./sszTypes.js";
+export {sszTypesFor, SSZTypesFor, ssz};
 // Typeguards
 export * from "./utils/typeguards.js";
 // String type

--- a/packages/types/src/sszTypes.ts
+++ b/packages/types/src/sszTypes.ts
@@ -110,44 +110,6 @@ const blobsForks: ForkBlobs[] = [ForkName.deneb];
 export const allForksExecution = pick(typesByFork, ...executionForks);
 export const allForksLightClient = pick(typesByFork, ...lightCLientForks);
 export const allForksBlobs = pick(typesByFork, ...blobsForks);
-export const allForksBlinded = {
-  bellatrix: {
-    BeaconBlockBody: bellatrix.BlindedBeaconBlockBody,
-    BeaconBlock: bellatrix.BlindedBeaconBlock,
-    SignedBeaconBlock: bellatrix.SignedBlindedBeaconBlock,
-  },
-  capella: {
-    BeaconBlockBody: capella.BlindedBeaconBlockBody,
-    BeaconBlock: capella.BlindedBeaconBlock,
-    SignedBeaconBlock: capella.SignedBlindedBeaconBlock,
-  },
-  deneb: {
-    BeaconBlockBody: deneb.BlindedBeaconBlockBody,
-    BeaconBlock: deneb.BlindedBeaconBlock,
-    SignedBeaconBlock: deneb.SignedBlindedBeaconBlock,
-  },
-};
-
-// TODO: These helpers should be removed along with `allForksBlinded`
-type SSZBlindedTypesByFork = {
-  [F in keyof typeof allForksBlinded]: {
-    [T in keyof (typeof allForksBlinded)[F]]: (typeof allForksBlinded)[F][T];
-  };
-};
-
-// TODO: These helpers should be removed along with `allForksBlinded`
-export type SSZBlindedTypesFor<
-  F extends ForkExecution,
-  K extends keyof SSZBlindedTypesByFork[F] | void = void,
-> = K extends void
-  ? // It compiles fine, need to debug the error
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    {[K2 in keyof SSZBlindedTypesByFork[F]]: UnionSSZForksTypeOf<SSZBlindedTypesByFork[F][K2]>}
-  : // It compiles fine, need to debug the error
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-expect-error
-    UnionSSZForksTypeOf<SSZBlindedTypesByFork[F][Exclude<K, void>]>;
 
 /**
  * A type of union of forks must accept as any parameter the UNION of all fork types.


### PR DESCRIPTION
**Motivation**

We don't want to hide or shadow an actual consensus type name. And as defined in `params` package **the blinded** is not a defined fork group, so rather tend to use actual group name everywhere which is execution. 

**Description**

- Based on [discussion](https://github.com/ChainSafe/lodestar/pull/6825#discussion_r1649012706) we dont want to hide/shadow an actual type. The blinded types implementation renames types, e.g. `BlindedBeaconBlock` to `BeaconBlock`. Which is another consensus type. No such pattern used elsewhere for other fork groups. 

- Blinded itself is not defined as a fork group in `params` package, so keeping that implementation requires an extra effort. 


**Steps to test or reproduce**

- Run all tests