### PR TITLE
feat: add endpoint to fetch blinded blocks

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -12,7 +12,7 @@ import {
   SignedBeaconBlockOrContents,
   SignedBlindedBeaconBlock,
 } from "@lodestar/types";
-import {ForkName, ForkSeq} from "@lodestar/params";
+import {ForkName, ForkPreExecution, ForkSeq, isForkExecution} from "@lodestar/params";
 import {Endpoint, RequestCodec, RouteDefinitions, Schema} from "../../../utils/index.js";
 import {EmptyMeta, EmptyResponseCodec, EmptyResponseData, WithVersion} from "../../../utils/codecs.js";
 import {
@@ -85,6 +85,18 @@ export type Endpoints = {
     BlockArgs,
     {params: {block_id: string}},
     SignedBeaconBlock,
+    ExecutionOptimisticFinalizedAndVersionMeta
+  >;
+
+  /**
+   * Get blinded block
+   * Retrieves blinded block for given block id.
+   */
+  getBlindedBlock: Endpoint<
+    "GET",
+    BlockArgs,
+    {params: {block_id: string}},
+    SignedBlindedBeaconBlock | SignedBeaconBlock<ForkPreExecution>,
     ExecutionOptimisticFinalizedAndVersionMeta
   >;
 
@@ -223,6 +235,17 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       req: blockIdOnlyReq,
       resp: {
         data: WithVersion((fork) => ssz[fork].SignedBeaconBlock),
+        meta: ExecutionOptimisticFinalizedAndVersionCodec,
+      },
+    },
+    getBlindedBlock: {
+      url: "/eth/v1/beacon/blinded_blocks/{block_id}",
+      method: "GET",
+      req: blockIdOnlyReq,
+      resp: {
+        data: WithVersion((fork) =>
+          isForkExecution(fork) ? ssz[fork].SignedBlindedBeaconBlock : ssz[fork].SignedBeaconBlock
+        ),
         meta: ExecutionOptimisticFinalizedAndVersionCodec,
       },
     },

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -56,7 +56,6 @@ const testDatas = {
 const ignoredOperations = [
   /* missing route */
   "getDepositSnapshot", // Won't fix for now, see https://github.com/ChainSafe/lodestar/issues/5697
-  "getBlindedBlock", // https://github.com/ChainSafe/lodestar/issues/5699
   "getNextWithdrawals", // https://github.com/ChainSafe/lodestar/issues/5696
   "getDebugForkChoice", // https://github.com/ChainSafe/lodestar/issues/5700
   /* Must support ssz response body */

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -38,6 +38,13 @@ export const testData: GenericServerTestCases<Endpoints> = {
       meta: {executionOptimistic: true, finalized: false, version: ForkName.bellatrix},
     },
   },
+  getBlindedBlock: {
+    args: {blockId: "head"},
+    res: {
+      data: ssz.deneb.SignedBlindedBeaconBlock.defaultValue(),
+      meta: {executionOptimistic: true, finalized: false, version: ForkName.deneb},
+    },
+  },
   getBlockAttestations: {
     args: {blockId: "head"},
     res: {data: [ssz.phase0.Attestation.defaultValue()], meta: {executionOptimistic: true, finalized: false}},

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -1,7 +1,12 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
-import {computeEpochAtSlot, computeTimeAtSlot, reconstructFullBlockOrContents} from "@lodestar/state-transition";
-import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
+import {
+  computeEpochAtSlot,
+  computeTimeAtSlot,
+  reconstructFullBlockOrContents,
+  signedBeaconBlockToBlinded,
+} from "@lodestar/state-transition";
+import {ForkExecution, SLOTS_PER_HISTORICAL_ROOT, isForkExecution} from "@lodestar/params";
 import {sleep, fromHex, toHex} from "@lodestar/utils";
 import {
   deneb,
@@ -381,6 +386,21 @@ export function getBeaconBlockApi({
           executionOptimistic,
           finalized,
           version: config.getForkName(block.message.slot),
+        },
+      };
+    },
+
+    async getBlindedBlock({blockId}) {
+      const {block, executionOptimistic, finalized} = await resolveBlockId(chain, blockId);
+      const fork = config.getForkName(block.message.slot);
+      return {
+        data: isForkExecution(fork)
+          ? signedBeaconBlockToBlinded(config, block as SignedBeaconBlock<ForkExecution>)
+          : block,
+        meta: {
+          executionOptimistic,
+          finalized,
+          version: fork,
         },
       };
     },

--- a/packages/beacon-node/test/e2e/api/impl/beacon/block/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/beacon/block/endpoint.test.ts
@@ -1,0 +1,99 @@
+import {describe, beforeAll, afterAll, it, expect, vi} from "vitest";
+import {createBeaconConfig} from "@lodestar/config";
+import {ApiClient, WireFormat, getClient} from "@lodestar/api";
+import {
+  SignedBeaconBlock,
+  SignedBlindedBeaconBlock,
+  isBlindedExecutionPayload,
+  isBlindedSignedBeaconBlock,
+  isExecutionPayload,
+} from "@lodestar/types";
+import {ForkName} from "@lodestar/params";
+import {LogLevel, testLogger} from "../../../../../utils/logger.js";
+import {getDevBeaconNode} from "../../../../../utils/node/beacon.js";
+import {BeaconNode} from "../../../../../../src/node/nodejs.js";
+import {getConfig} from "../../../../../utils/config.js";
+
+describe("beacon block api", function () {
+  vi.setConfig({testTimeout: 60_000, hookTimeout: 60_000});
+
+  const restPort = 9596;
+  const fork = ForkName.deneb;
+  const config = createBeaconConfig(getConfig(fork), Buffer.alloc(32, 0xaa));
+  const validatorCount = 8;
+
+  let bn: BeaconNode;
+  let client: ApiClient["beacon"];
+
+  beforeAll(async () => {
+    bn = await getDevBeaconNode({
+      params: config,
+      options: {
+        sync: {isSingleNode: true},
+        network: {allowPublishToZeroPeers: true},
+        api: {
+          rest: {
+            enabled: true,
+            port: restPort,
+          },
+        },
+        chain: {blsVerifyAllMainThread: true},
+      },
+      validatorCount,
+      logger: testLogger("Node-A", {level: LogLevel.info}),
+    });
+    client = getClient({baseUrl: `http://127.0.0.1:${restPort}`}, {config}).beacon;
+  });
+
+  afterAll(async () => {
+    await bn.close();
+  });
+
+  describe("getBlockV2", () => {
+    it("should return signed beacon block", async () => {
+      const res = await client.getBlockV2({blockId: "head"});
+      const beaconBlock = res.value() as SignedBeaconBlock<typeof fork>;
+
+      expect(res.meta().version).toBe(fork);
+      expect(res.wireFormat()).toBe(WireFormat.ssz);
+
+      expect(isBlindedSignedBeaconBlock(beaconBlock)).toBe(false);
+      expect(isExecutionPayload(beaconBlock.message.body.executionPayload)).toBe(true);
+      expect(beaconBlock.message.body).not.toHaveProperty("executionPayloadHeader");
+    });
+
+    it("should return 400 if block id is invalid", async () => {
+      const res = await client.getBlockV2({blockId: "current"});
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 404 if block not found", async () => {
+      const res = await client.getBlockV2({blockId: 999});
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("getBlindedBlock", () => {
+    it("should return signed blinded block", async () => {
+      const res = await client.getBlindedBlock({blockId: "head"});
+      const blindedBlock = res.value() as SignedBlindedBeaconBlock<typeof fork>;
+
+      expect(res.meta().version).toBe(fork);
+      expect(res.wireFormat()).toBe(WireFormat.ssz);
+
+      expect(isBlindedSignedBeaconBlock(blindedBlock)).toBe(true);
+      expect(isBlindedExecutionPayload(blindedBlock.message.body.executionPayloadHeader)).toBe(true);
+      expect(blindedBlock.message.body).not.toHaveProperty("executionPayload");
+    });
+
+    it("should return 400 if block id is invalid", async () => {
+      const res = await client.getBlindedBlock({blockId: "current"});
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 404 if block not found", async () => {
+      const res = await client.getBlindedBlock({blockId: 999});
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/packages/beacon-node/test/e2e/api/impl/beacon/block/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/beacon/block/endpoint.test.ts
@@ -52,10 +52,11 @@ describe("beacon block api", function () {
   describe("getBlockV2", () => {
     it("should return signed beacon block", async () => {
       const res = await client.getBlockV2({blockId: "head"});
-      const beaconBlock = res.value() as SignedBeaconBlock<typeof fork>;
 
       expect(res.meta().version).toBe(fork);
       expect(res.wireFormat()).toBe(WireFormat.ssz);
+
+      const beaconBlock = res.value() as SignedBeaconBlock<typeof fork>;
 
       expect(isBlindedSignedBeaconBlock(beaconBlock)).toBe(false);
       expect(isExecutionPayload(beaconBlock.message.body.executionPayload)).toBe(true);
@@ -76,10 +77,11 @@ describe("beacon block api", function () {
   describe("getBlindedBlock", () => {
     it("should return signed blinded block", async () => {
       const res = await client.getBlindedBlock({blockId: "head"});
-      const blindedBlock = res.value() as SignedBlindedBeaconBlock<typeof fork>;
 
       expect(res.meta().version).toBe(fork);
       expect(res.wireFormat()).toBe(WireFormat.ssz);
+
+      const blindedBlock = res.value() as SignedBlindedBeaconBlock<typeof fork>;
 
       expect(isBlindedSignedBeaconBlock(blindedBlock)).toBe(true);
       expect(isBlindedExecutionPayload(blindedBlock.message.body.executionPayloadHeader)).toBe(true);

--- a/packages/state-transition/src/util/blindedBlock.ts
+++ b/packages/state-transition/src/util/blindedBlock.ts
@@ -52,8 +52,18 @@ export function blindedOrFullBlockToHeader(
 export function beaconBlockToBlinded(config: ChainForkConfig, block: BeaconBlock<ForkExecution>): BlindedBeaconBlock {
   const fork = config.getForkName(block.slot);
   const executionPayloadHeader = executionPayloadToPayloadHeader(ForkSeq[fork], block.body.executionPayload);
-  const blindedBlock = {...block, body: {...block.body, executionPayloadHeader}} as BlindedBeaconBlock;
+  const blindedBlock: BlindedBeaconBlock = {...block, body: {...block.body, executionPayloadHeader}};
   return blindedBlock;
+}
+
+export function signedBeaconBlockToBlinded(
+  config: ChainForkConfig,
+  signedBlock: SignedBeaconBlock<ForkExecution>
+): SignedBlindedBeaconBlock {
+  return {
+    message: beaconBlockToBlinded(config, signedBlock.message),
+    signature: signedBlock.signature,
+  };
 }
 
 export function signedBlindedBlockToFull(


### PR DESCRIPTION
**Motivation**

- https://github.com/ethereum/beacon-APIs/pull/241

**Description**

Adds endpoint to fetch blinded blocks, see [getBlindedBlock](https://ethereum.github.io/beacon-APIs/#/Beacon/getBlindedBlock)

Closes https://github.com/ChainSafe/lodestar/issues/5699