### PR TITLE
chore: rename execution payload header type guard

### DIFF
--- a/packages/beacon-node/test/e2e/api/impl/beacon/block/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/beacon/block/endpoint.test.ts
@@ -4,9 +4,9 @@ import {ApiClient, WireFormat, getClient} from "@lodestar/api";
 import {
   SignedBeaconBlock,
   SignedBlindedBeaconBlock,
-  isBlindedExecutionPayload,
   isBlindedSignedBeaconBlock,
   isExecutionPayload,
+  isExecutionPayloadHeader,
 } from "@lodestar/types";
 import {ForkName} from "@lodestar/params";
 import {LogLevel, testLogger} from "../../../../../utils/logger.js";
@@ -84,7 +84,7 @@ describe("beacon block api", function () {
       const blindedBlock = res.value() as SignedBlindedBeaconBlock<typeof fork>;
 
       expect(isBlindedSignedBeaconBlock(blindedBlock)).toBe(true);
-      expect(isBlindedExecutionPayload(blindedBlock.message.body.executionPayloadHeader)).toBe(true);
+      expect(isExecutionPayloadHeader(blindedBlock.message.body.executionPayloadHeader)).toBe(true);
       expect(blindedBlock.message.body).not.toHaveProperty("executionPayload");
     });
 

--- a/packages/types/src/utils/typeguards.ts
+++ b/packages/types/src/utils/typeguards.ts
@@ -23,7 +23,7 @@ export function isExecutionPayload<F extends ForkExecution>(
   return (payload as ExecutionPayload<F>).transactions !== undefined;
 }
 
-export function isBlindedExecutionPayload<F extends ForkExecution>(
+export function isExecutionPayloadHeader<F extends ForkExecution>(
   payload: ExecutionPayload<F> | ExecutionPayloadHeader<F>
 ): payload is ExecutionPayloadHeader<F> {
   // we just check transactionsRoot for determining as it the base field


### PR DESCRIPTION
**Motivation**

Align execution payload header type guard naming with type and spec

**Description**

Rename execution payload header type guard

`isBlindedExecutionPayload` --> `isExecutionPayloadHeader`
