### PR TITLE
fix: ignore lockfiles when listing validator public keys

### DIFF
--- a/packages/cli/src/cmds/validator/list.ts
+++ b/packages/cli/src/cmds/validator/list.ts
@@ -22,6 +22,9 @@ export const list: CliCommand<IValidatorCliArgs, GlobalArgs, ReturnType> = {
   handler: async (args) => {
     const {network} = getBeaconConfigFromArgs(args);
 
+    // Ignore lockfiles to allow listing while validator client is running
+    args.force = true;
+
     const signers = await getSignersFromArgs(args, network, {logger: console, signal: new AbortController().signal});
 
     logSigners(console, signers);


### PR DESCRIPTION
**Motivation**

Similar to https://github.com/ChainSafe/lodestar/pull/5950, there is no risk in ignoring lockfiles.

**Description**

Ignore lockfiles when listing validator public keys