### PR TITLE
chore: fix type inference of exclude function

### DIFF
--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -20,8 +20,8 @@ export enum ForkSeq {
   deneb = 4,
 }
 
-function exclude<T>(coll: T[], val: T[]): T[] {
-  return coll.filter((f) => !val.includes(f));
+function exclude<T extends ForkName, U extends T>(coll: T[], val: U[]): Exclude<T, U>[] {
+  return coll.filter((f) => !val.includes(f as U)) as Exclude<T, U>[];
 }
 
 export function highestFork<F extends ForkName>(forkNames: F[]): F {
@@ -53,37 +53,28 @@ export const forkAll = Object.values(ForkName);
 
 export type ForkPreLightClient = ForkName.phase0;
 export type ForkLightClient = Exclude<ForkName, ForkPreLightClient>;
-export const forkLightClient = exclude(forkAll, [ForkName.phase0]) as ForkLightClient[];
+export const forkLightClient = exclude(forkAll, [ForkName.phase0]);
 export function isForkLightClient(fork: ForkName): fork is ForkLightClient {
   return fork !== ForkName.phase0;
 }
 
 export type ForkPreExecution = ForkPreLightClient | ForkName.altair;
 export type ForkExecution = Exclude<ForkName, ForkPreExecution>;
-export const forkExecution = exclude(forkAll, [ForkName.phase0, ForkName.altair]) as ForkExecution[];
+export const forkExecution = exclude(forkAll, [ForkName.phase0, ForkName.altair]);
 export function isForkExecution(fork: ForkName): fork is ForkExecution {
   return isForkLightClient(fork) && fork !== ForkName.altair;
 }
 
 export type ForkPreWithdrawals = ForkPreExecution | ForkName.bellatrix;
 export type ForkWithdrawals = Exclude<ForkName, ForkPreWithdrawals>;
-export const forkWithdrawals = exclude(forkAll, [
-  ForkName.phase0,
-  ForkName.altair,
-  ForkName.bellatrix,
-]) as ForkWithdrawals[];
+export const forkWithdrawals = exclude(forkAll, [ForkName.phase0, ForkName.altair, ForkName.bellatrix]);
 export function isForkWithdrawals(fork: ForkName): fork is ForkWithdrawals {
   return isForkExecution(fork) && fork !== ForkName.bellatrix;
 }
 
 export type ForkPreBlobs = ForkPreWithdrawals | ForkName.capella;
 export type ForkBlobs = Exclude<ForkName, ForkPreBlobs>;
-export const forkBlobs = exclude(forkAll, [
-  ForkName.phase0,
-  ForkName.altair,
-  ForkName.bellatrix,
-  ForkName.capella,
-]) as ForkBlobs[];
+export const forkBlobs = exclude(forkAll, [ForkName.phase0, ForkName.altair, ForkName.bellatrix, ForkName.capella]);
 export function isForkBlobs(fork: ForkName): fork is ForkBlobs {
   return isForkWithdrawals(fork) && fork !== ForkName.capella;
 }


### PR DESCRIPTION
Properly infer types when excluding forks, makes the code much safer as we can remove type casts, it also shows an error if you try to exclude a fork which is not declared.

We could further type forks as tuples, as the arrays (`forkAll`, `forkExecution`, etc.) are ordered fork arrays containing each fork exactly once.