### PR TITLE
fix: do not report negative sync time and slots/s

### DIFF
--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -92,7 +92,7 @@ export async function runNodeNotifier(modules: NodeNotifierModules): Promise<voi
       switch (sync.state) {
         case SyncState.SyncingFinalized:
         case SyncState.SyncingHead: {
-          const slotsPerSecond = headSlotTimeSeries.computeLinearSpeed();
+          const slotsPerSecond = Math.max(headSlotTimeSeries.computeLinearSpeed(), 0);
           const distance = Math.max(clockSlot - headSlot, 0);
           const secondsLeft = distance / slotsPerSecond;
           const timeLeft = isFinite(secondsLeft) ? prettyTimeDiffSec(secondsLeft) : "?";


### PR DESCRIPTION
**Motivation**

It does not make sense to report syncing negative slots per second and  time left as the node can't sync backwards to head

**Description**

Do not report negative sync time and slots/s

Related https://github.com/ChainSafe/lodestar/issues/6861