### PR TITLE
feat: add warning log to notifier if execution client is offline

### DIFF
--- a/packages/beacon-node/src/execution/engine/disabled.ts
+++ b/packages/beacon-node/src/execution/engine/disabled.ts
@@ -1,6 +1,8 @@
 import {ExecutionEngineState, IExecutionEngine, PayloadIdCache} from "./interface.js";
 
 export class ExecutionEngineDisabled implements IExecutionEngine {
+  state = ExecutionEngineState.OFFLINE;
+
   readonly payloadIdCache = new PayloadIdCache();
 
   async notifyNewPayload(): Promise<never> {
@@ -24,10 +26,6 @@ export class ExecutionEngineDisabled implements IExecutionEngine {
   }
 
   getPayloadBodiesByRange(): Promise<never> {
-    throw Error("Execution engine disabled");
-  }
-
-  getState(): ExecutionEngineState {
     throw Error("Execution engine disabled");
   }
 }

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -103,7 +103,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
   // The default state is ONLINE, it will be updated to SYNCING once we receive the first payload
   // This assumption is better than the OFFLINE state, since we can't be sure if the EL is offline and being offline may trigger some notifications
   // It's safer to to avoid false positives and assume that the EL is syncing until we receive the first payload
-  private state: ExecutionEngineState = ExecutionEngineState.ONLINE;
+  state: ExecutionEngineState = ExecutionEngineState.ONLINE;
 
   readonly payloadIdCache = new PayloadIdCache();
   /**
@@ -415,10 +415,6 @@ export class ExecutionEngineHttp implements IExecutionEngine {
       EngineApiRpcParamTypes[typeof method]
     >({method, params: [start, count]});
     return response.map(deserializeExecutionPayloadBody);
-  }
-
-  getState(): ExecutionEngineState {
-    return this.state;
   }
 
   private updateEngineState(newState: ExecutionEngineState): void {

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -89,6 +89,8 @@ export type VersionedHashes = Uint8Array[];
  * - Integrated code into the same binary
  */
 export interface IExecutionEngine {
+  readonly state: ExecutionEngineState;
+
   payloadIdCache: PayloadIdCache;
   /**
    * A state transition function which applies changes to the self.execution_state.
@@ -146,6 +148,4 @@ export interface IExecutionEngine {
   getPayloadBodiesByHash(blockHash: DATA[]): Promise<(ExecutionPayloadBody | null)[]>;
 
   getPayloadBodiesByRange(start: number, count: number): Promise<(ExecutionPayloadBody | null)[]>;
-
-  getState(): ExecutionEngineState;
 }

--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -57,7 +57,7 @@ export async function runNodeNotifier(modules: NodeNotifierModules): Promise<voi
       if (
         clockEpoch >= config.BELLATRIX_FORK_EPOCH &&
         computeStartSlotAtEpoch(clockEpoch) === clockSlot &&
-        chain.executionEngine.getState() === ExecutionEngineState.OFFLINE
+        chain.executionEngine.state === ExecutionEngineState.OFFLINE
       ) {
         logger.warn("Execution client is offline");
       }

--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -1,10 +1,11 @@
 import {BeaconConfig} from "@lodestar/config";
 import {Epoch} from "@lodestar/types";
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {CachedBeaconStateAllForks, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {ProtoBlock, ExecutionStatus} from "@lodestar/fork-choice";
 import {ErrorAborted, Logger, sleep, prettyBytes, prettyBytesShort} from "@lodestar/utils";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeEpochAtSlot, isExecutionCachedStateType, isMergeTransitionComplete} from "@lodestar/state-transition";
+import {ExecutionEngineState} from "../execution/index.js";
 import {IBeaconChain} from "../chain/index.js";
 import {INetwork} from "../network/index.js";
 import {IBeaconSync, SyncState} from "../sync/index.js";
@@ -52,6 +53,14 @@ export async function runNodeNotifier(modules: NodeNotifierModules): Promise<voi
 
       const clockSlot = chain.clock.currentSlot;
       const clockEpoch = computeEpochAtSlot(clockSlot);
+
+      if (
+        clockEpoch >= config.BELLATRIX_FORK_EPOCH &&
+        computeStartSlotAtEpoch(clockEpoch) === clockSlot &&
+        chain.executionEngine.getState() === ExecutionEngineState.OFFLINE
+      ) {
+        logger.warn("Execution client is offline");
+      }
 
       const headInfo = chain.forkChoice.getHead();
       const headState = chain.getHeadState();

--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -88,7 +88,7 @@ export class BeaconSync implements IBeaconSync {
 
   getSyncStatus(): SyncingStatus {
     const currentSlot = this.chain.clock.currentSlot;
-    const elOffline = this.chain.executionEngine.getState() === ExecutionEngineState.OFFLINE;
+    const elOffline = this.chain.executionEngine.state === ExecutionEngineState.OFFLINE;
 
     // If we are pre/at genesis, signal ready
     if (currentSlot <= GENESIS_SLOT) {


### PR DESCRIPTION
**Motivation**

We are pretty silent about the execution client being offline after the initial error. The logs just show that the node is stalling and not updating head but we should make it more apparent that the issue is related to EL being offline and also notify the user about the issue.

Most users (including myself) just check the logs of the consensus client to see if their node is performing well and healthy.

**Description**

Add warning log to notifier if execution client is offline. The warning will be logged at the start of every epoch if EL is offline.

Related https://github.com/ChainSafe/lodestar/issues/6861
