### PR TITLE
fix: getHealth returns 206 status code if EL is optimistic or offline

### DIFF
--- a/packages/beacon-node/src/api/impl/node/index.ts
+++ b/packages/beacon-node/src/api/impl/node/index.ts
@@ -71,7 +71,9 @@ export function getNodeApi(
         throw new ApiError(400, `Invalid syncing status code: ${syncingStatus}`);
       }
 
-      if (sync.getSyncStatus().isSyncing) {
+      const {isSyncing, isOptimistic} = sync.getSyncStatus();
+
+      if (isSyncing || isOptimistic) {
         // 206: Node is syncing but can serve incomplete data
         return {status: syncingStatus ?? routes.node.NodeHealth.SYNCING};
       } else {

--- a/packages/beacon-node/src/api/impl/node/index.ts
+++ b/packages/beacon-node/src/api/impl/node/index.ts
@@ -71,9 +71,9 @@ export function getNodeApi(
         throw new ApiError(400, `Invalid syncing status code: ${syncingStatus}`);
       }
 
-      const {isSyncing, isOptimistic} = sync.getSyncStatus();
+      const {isSyncing, isOptimistic, elOffline} = sync.getSyncStatus();
 
-      if (isSyncing || isOptimistic) {
+      if (isSyncing || isOptimistic || elOffline) {
         // 206: Node is syncing but can serve incomplete data
         return {status: syncingStatus ?? routes.node.NodeHealth.SYNCING};
       } else {


### PR DESCRIPTION
**Motivation**

- https://github.com/ethereum/beacon-APIs/pull/442

**Description**

`getHealth` returns 206 status code if EL is syncing / optimistic

Closes https://github.com/ChainSafe/lodestar/issues/6664
