### PR TITLE
chore: unhide execution engine mock flag

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/execution.ts
+++ b/packages/cli/src/options/beaconNodeOptions/execution.ts
@@ -72,9 +72,9 @@ export const options: CliCommandOptions<ExecutionEngineArgs> = {
   },
 
   "execution.engineMock": {
-    description: "Set the execution engine to mock mode",
+    description: "Set the execution engine to mock mode (development only)",
     type: "boolean",
-    hidden: true,
+    hidden: false,
     group: "execution",
   },
 


### PR DESCRIPTION
**Motivation**

This flag is useful to quickly spin up or node on any network for testing / development and different users have asked for something like this.

**Description**

Unhide execution engine mock flag `--execution.engineMock`

Previous discussion https://github.com/ChainSafe/lodestar/pull/6872