### PR TITLE
fix: prepareNextEpoch metric

### DIFF
--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -51,7 +51,7 @@ export enum StateHashTreeRootSource {
   stateTransition = "state_transition",
   blockTransition = "block_transition",
   prepareNextSlot = "prepare_next_slot",
-  prepareNextEpoch = "prepare_next_Epoch",
+  prepareNextEpoch = "prepare_next_epoch",
   computeNewStateRoot = "compute_new_state_root",
 }
 

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -51,6 +51,7 @@ export enum StateHashTreeRootSource {
   stateTransition = "state_transition",
   blockTransition = "block_transition",
   prepareNextSlot = "prepare_next_slot",
+  prepareNextEpoch = "prepare_next_Epoch",
   computeNewStateRoot = "compute_new_state_root",
 }
 


### PR DESCRIPTION
**Motivation**

PrepareNextEpoch time was incorrect since #6652 because it did not count `state.hashTreeRoot()` time for the next epoch

**Description**

- Only observe `precomputeNextEpochTransition` metric as the last step 
- Add `prepareNextEpoch` label specifically for observing `state.hashTreeRoot()` time for the next epoch since it takes much longer compared to next slot (some could be > 1.5s), see #6598