### PR TITLE
chore: optimize getSlotFromOffset

### DIFF
--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -198,11 +198,24 @@ export function getSlotFromBlobSidecarSerialized(data: Uint8Array): Slot | null 
   return getSlotFromOffset(data, SLOT_BYTES_POSITION_IN_SIGNED_BLOB_SIDECAR);
 }
 
-function getSlotFromOffset(data: Uint8Array, offset: number): Slot {
-  // TODO: Optimize
-  const dv = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  // Read only the first 4 bytes of Slot, max value is 4,294,967,295 will be reached 1634 years after genesis
-  return dv.getUint32(offset, true);
+/**
+ * Read only the first 4 bytes of Slot, max value is 4,294,967,295 will be reached 1634 years after genesis
+ *
+ * If the high bytes are not zero, return null
+ */
+function getSlotFromOffset(data: Uint8Array, offset: number): Slot | null {
+  return checkSlotHighBytes(data, offset) ? getSlotFromOffsetTrusted(data, offset) : null;
+}
+
+/**
+ * Read only the first 4 bytes of Slot, max value is 4,294,967,295 will be reached 1634 years after genesis
+ */
+function getSlotFromOffsetTrusted(data: Uint8Array, offset: number): Slot {
+  return (data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24)) >>> 0;
+}
+
+function checkSlotHighBytes(data: Uint8Array, offset: number): boolean {
+  return (data[offset + 4] | data[offset + 5] | data[offset + 6] | data[offset + 7]) === 0;
 }
 
 function toBase64(data: Uint8Array): string {

--- a/packages/beacon-node/test/perf/util/dataview.test.ts
+++ b/packages/beacon-node/test/perf/util/dataview.test.ts
@@ -1,0 +1,29 @@
+import {itBench} from "@dapplion/benchmark";
+
+describe("dataview", function () {
+  const data = Uint8Array.from([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]);
+
+  itBench({
+    id: "getUint32 - dataview",
+    beforeEach: () => {
+      return 0;
+    },
+    fn: (offset) => {
+      const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+      view.getUint32(offset, true);
+    },
+  });
+
+  itBench({
+    id: "getUint32 - manual",
+    beforeEach: () => {
+      return 0;
+    },
+    fn: (offset) => {
+      // check high bytes for non-zero values
+      (data[offset + 4] | data[offset + 5] | data[offset + 6] | data[offset + 7]) === 0;
+      // create the uint32
+      (data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24)) >>> 0;
+    },
+  });
+});

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -4,7 +4,7 @@ import {fromHex, toHex} from "@lodestar/utils";
 import {
   getAttDataBase64FromAttestationSerialized,
   getAttDataBase64FromSignedAggregateAndProofSerialized,
-  getAggregationBitsFromAttestationSerialized as getAggregationBitsFromAttestationSerialized,
+  getAggregationBitsFromAttestationSerialized,
   getBlockRootFromAttestationSerialized,
   getBlockRootFromSignedAggregateAndProofSerialized,
   getSlotFromAttestationSerialized,
@@ -125,6 +125,15 @@ describe("aggregateAndProof SSZ serialized picking", () => {
     for (const size of invalidAttDataBase64DataSizes) {
       expect(getAttDataBase64FromSignedAggregateAndProofSerialized(Buffer.alloc(size))).toBeNull();
     }
+  });
+  it("getSlotFromSignedAggregateAndProofSerialized - invalid data - large slots", () => {
+    const serialize = (slot: Slot): Uint8Array => {
+      const s = ssz.phase0.SignedAggregateAndProof.defaultValue();
+      s.message.aggregate.data.slot = slot;
+      return ssz.phase0.SignedAggregateAndProof.serialize(s);
+    };
+    expect(getSlotFromSignedAggregateAndProofSerialized(serialize(0xffffffff))).toBe(0xffffffff);
+    expect(getSlotFromSignedAggregateAndProofSerialized(serialize(0x0100000000))).toBeNull();
   });
 });
 


### PR DESCRIPTION
**Description**

This is just a small optimization, likely of little consequence.
- instead of creating/using a `DataView#getUint32` to get the slot, just use the underlying Uint8Array bytes

```
  dataview
    ✔ getUint32 - dataview                                                 2544529 ops/s    393.0000 ns/op        -    1909649 runs   1.41 s
    ✔ getUint32 - manual                                                   4854369 ops/s    206.0000 ns/op        -     930789 runs  0.505 s
```
