### PR TITLE
feat: add option to disable thread pool for keystore decryption

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions.ts
+++ b/packages/cli/src/cmds/validator/keymanager/decryptKeystoreDefinitions.ts
@@ -1,5 +1,7 @@
+import fs from "node:fs";
 import path from "node:path";
 import bls from "@chainsafe/bls";
+import {Keystore} from "@chainsafe/bls-keystore";
 import {SignerLocal, SignerType} from "@lodestar/validator";
 import {LogLevel, Logger} from "@lodestar/utils";
 import {lockFilepath, unlockFilepath} from "../../../util/lockfile.js";
@@ -7,11 +9,13 @@ import {LocalKeystoreDefinition} from "./interface.js";
 import {clearKeystoreCache, loadKeystoreCache, writeKeystoreCache} from "./keystoreCache.js";
 import {DecryptKeystoresThreadPool} from "./decryptKeystores/index.js";
 
-type KeystoreDecryptOptions = {
+export type KeystoreDecryptOptions = {
   ignoreLockFile?: boolean;
   onDecrypt?: (index: number) => void;
   // Try to use the cache file if it exists
   cacheFilePath?: string;
+  /** Use main thread to decrypt keystores */
+  disableThreadPool?: boolean;
   logger: Pick<Logger, LogLevel.info | LogLevel.warn | LogLevel.debug>;
   signal: AbortSignal;
 };
@@ -57,14 +61,50 @@ export async function decryptKeystoreDefinitions(
   const signers = new Array<SignerLocal>(keystoreCount);
   const passwords = new Array<string>(keystoreCount);
   const errors: KeystoreDecryptError[] = [];
-  const decryptKeystores = new DecryptKeystoresThreadPool(keystoreCount, opts.signal);
 
-  for (const [index, definition] of keystoreDefinitions.entries()) {
-    lockKeystore(definition.keystorePath, opts);
+  if (!opts.disableThreadPool) {
+    const decryptKeystores = new DecryptKeystoresThreadPool(keystoreCount, opts.signal);
 
-    decryptKeystores.queue(
-      definition,
-      (secretKeyBytes: Uint8Array) => {
+    for (const [index, definition] of keystoreDefinitions.entries()) {
+      lockKeystore(definition.keystorePath, opts);
+
+      decryptKeystores.queue(
+        definition,
+        (secretKeyBytes: Uint8Array) => {
+          const signer: SignerLocal = {
+            type: SignerType.Local,
+            secretKey: bls.SecretKey.fromBytes(secretKeyBytes),
+          };
+
+          signers[index] = signer;
+          passwords[index] = definition.password;
+
+          if (opts?.onDecrypt) {
+            opts?.onDecrypt(index);
+          }
+        },
+        (error: Error) => {
+          // In-progress tasks can't be canceled, so there's a chance that multiple errors may be caught
+          // add to the list of errors
+          errors.push({keystoreFile: path.basename(definition.keystorePath), error});
+          // cancel all pending tasks, no need to continue decrypting after we hit one error
+          decryptKeystores.cancel();
+        }
+      );
+    }
+
+    await decryptKeystores.completed();
+  } else {
+    // Decrypt keystores in main thread
+    for (const [index, definition] of keystoreDefinitions.entries()) {
+      lockKeystore(definition.keystorePath, opts);
+
+      try {
+        const keystore = Keystore.parse(fs.readFileSync(definition.keystorePath, "utf8"));
+
+        // Memory-hogging function
+        const secretKeyBytes = await keystore.decrypt(definition.password);
+
         const signer: SignerLocal = {
           type: SignerType.Local,
           secretKey: bls.SecretKey.fromBytes(secretKeyBytes),
@@ -76,18 +116,13 @@ export async function decryptKeystoreDefinitions(
         if (opts?.onDecrypt) {
           opts?.onDecrypt(index);
         }
-      },
-      (error: Error) => {
-        // In-progress tasks can't be canceled, so there's a chance that multiple errors may be caught
-        // add to the list of errors
-        errors.push({keystoreFile: path.basename(definition.keystorePath), error});
-        // cancel all pending tasks, no need to continue decrypting after we hit one error
-        decryptKeystores.cancel();
+      } catch (e) {
+        errors.push({keystoreFile: path.basename(definition.keystorePath), error: e as Error});
+        // stop processing, no need to continue decrypting after we hit one error
+        break;
       }
-    );
+    }
   }
-
-  await decryptKeystores.completed();
 
   if (errors.length > 0) {
     // If an error occurs, the program isn't going to be running,

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -55,6 +55,7 @@ export type IValidatorCliArgs = AccountValidatorArgs &
 
     importKeystores?: string[];
     importKeystoresPassword?: string;
+    disableKeystoresThreadPool?: boolean;
 
     "http.requestWireFormat"?: string;
     "http.responseWireFormat"?: string;
@@ -299,6 +300,13 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
     description: "Path to a file with password to decrypt all keystores from `importKeystores` option",
     defaultDescription: "./password.txt",
     type: "string",
+  },
+
+  disableKeystoresThreadPool: {
+    hidden: true,
+    description:
+      "Disable thread pool and instead use main thread to decrypt keystores. This can speed up decryption in testing environments like Kurtosis",
+    type: "boolean",
   },
 
   doppelgangerProtection: {

--- a/packages/cli/src/cmds/validator/signers/index.ts
+++ b/packages/cli/src/cmds/validator/signers/index.ts
@@ -99,6 +99,7 @@ export async function getSignersFromArgs(
       ignoreLockFile: args.force,
       onDecrypt: needle,
       cacheFilePath: path.join(accountPaths.cacheDir, "imported_keystores.cache"),
+      disableThreadPool: args["disableKeystoresThreadPool"],
       logger,
       signal,
     });
@@ -133,6 +134,7 @@ export async function getSignersFromArgs(
       ignoreLockFile: args.force,
       onDecrypt: needle,
       cacheFilePath: path.join(accountPaths.cacheDir, "local_keystores.cache"),
+      disableThreadPool: args["disableKeystoresThreadPool"],
       logger,
       signal,
     });


### PR DESCRIPTION
**Motivation**

During testing in https://github.com/ChainSafe/bls-keystore/pull/61 (see benchmarks) I noticed that spawning worker threads to decrypt keystores is quite slow in some environments like docker and it takes a few seconds for decrypt operations to speed up.


It takes around ~10-16 seconds in kurtosis to decrypt 64 keystores

```
Jul-14 10:03:14.591[]                 info: 0% of local keystores imported. current=0 total=64 rate=0.00keys/m
Jul-14 10:03:24.589[]                 info: 0% of local keystores imported. current=0 total=64 rate=0.00keys/m
Jul-14 10:03:28.690[]                 info: 100% of local keystores imported. current=64 total=64 rate=936.59keys/m
```

The reason for this seems to be that 1) spawning workers takes a bit of time, and 2) there seems to be a warm up period (especially inside docker) which leads to bad results. More details in https://github.com/ChainSafe/bls-keystore/pull/61#issuecomment-2227299134.

Looking at the keystores used by Kurtosis, those are pbkdf2 and in addition set c=2 in kdf params which is insecure but much faster and good for testing while most normal users use scrypt which is much slower per decrypt operation, like 1000x slower than that.

This means ideally, we wanna keep workers for normal usage but disable the thread pool for testing environments like Kurtosis.

Disabling the worker pool, it takes ~1 sec to decrypt 64 keys in Kurtosis
```
Jul-15 09:11:56.107[]                 info: Connecting to LevelDB database path=/root/.local/share/lodestar/testnet/validator-db
Jul-15 09:11:56.614[]                 info: 100% of local keystores imported. current=64 total=64 rate=7664.67keys/m
Jul-15 09:11:57.514[]                 info: 64 local keystores
```

This is on par with other clients, as noted in https://github.com/ChainSafe/lodestar/issues/6946.


**Description**

Add option `--disableKeystoresThreadPool` to disable thread pool for keystore decryption. 
