### PR TITLE
fix: expose metadata headers to scripts running in the browser

### DIFF
--- a/packages/api/src/utils/headers.ts
+++ b/packages/api/src/utils/headers.ts
@@ -4,6 +4,12 @@ export enum HttpHeader {
   ContentType = "content-type",
   Accept = "accept",
   Authorization = "authorization",
+  /**
+   * Used to indicate which response headers should be made available to
+   * scripts running in the browser, in response to a cross-origin request.
+   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+   */
+  ExposeHeaders = "access-control-expose-headers",
 }
 
 export enum MediaType {

--- a/packages/api/src/utils/metadata.ts
+++ b/packages/api/src/utils/metadata.ts
@@ -5,6 +5,7 @@ import {StringType, ssz, stringType} from "@lodestar/types";
 import {ResponseMetadataCodec} from "./types.js";
 import {toBoolean} from "./serdes.js";
 import {toForkName} from "./fork.js";
+import {HttpHeader} from "./headers.js";
 
 export const VersionType = new ContainerType({
   /**
@@ -90,6 +91,7 @@ export const ExecutionOptimisticCodec: ResponseMetadataCodec<ExecutionOptimistic
   fromJson: (val) => ExecutionOptimisticType.fromJson(val),
   toHeadersObject: (val) => ({
     [MetaHeader.ExecutionOptimistic]: val.executionOptimistic.toString(),
+    [HttpHeader.ExposeHeaders]: MetaHeader.ExecutionOptimistic,
   }),
   fromHeaders: (headers) => ({
     executionOptimistic: toBoolean(headers.getOrDefault(MetaHeader.ExecutionOptimistic, "false")),
@@ -101,6 +103,7 @@ export const VersionCodec: ResponseMetadataCodec<VersionMeta> = {
   fromJson: (val) => VersionType.fromJson(val),
   toHeadersObject: (val) => ({
     [MetaHeader.Version]: val.version,
+    [HttpHeader.ExposeHeaders]: MetaHeader.Version,
   }),
   fromHeaders: (headers) => ({
     version: toForkName(headers.getRequired(MetaHeader.Version)),
@@ -113,6 +116,7 @@ export const ExecutionOptimisticAndVersionCodec: ResponseMetadataCodec<Execution
   toHeadersObject: (val) => ({
     [MetaHeader.ExecutionOptimistic]: val.executionOptimistic.toString(),
     [MetaHeader.Version]: val.version,
+    [HttpHeader.ExposeHeaders]: [MetaHeader.ExecutionOptimistic, MetaHeader.Version].toString(),
   }),
   fromHeaders: (headers) => ({
     executionOptimistic: toBoolean(headers.getOrDefault(MetaHeader.ExecutionOptimistic, "false")),
@@ -126,6 +130,7 @@ export const ExecutionOptimisticAndFinalizedCodec: ResponseMetadataCodec<Executi
   toHeadersObject: (val) => ({
     [MetaHeader.ExecutionOptimistic]: val.executionOptimistic.toString(),
     [MetaHeader.Finalized]: val.finalized.toString(),
+    [HttpHeader.ExposeHeaders]: [MetaHeader.ExecutionOptimistic, MetaHeader.Finalized].toString(),
   }),
   fromHeaders: (headers) => ({
     executionOptimistic: toBoolean(headers.getOrDefault(MetaHeader.ExecutionOptimistic, "false")),
@@ -141,6 +146,7 @@ export const ExecutionOptimisticFinalizedAndVersionCodec: ResponseMetadataCodec<
       [MetaHeader.ExecutionOptimistic]: val.executionOptimistic.toString(),
       [MetaHeader.Finalized]: val.finalized.toString(),
       [MetaHeader.Version]: val.version,
+      [HttpHeader.ExposeHeaders]: [MetaHeader.ExecutionOptimistic, MetaHeader.Finalized, MetaHeader.Version].toString(),
     }),
     fromHeaders: (headers) => ({
       executionOptimistic: toBoolean(headers.getOrDefault(MetaHeader.ExecutionOptimistic, "false")),
@@ -156,6 +162,7 @@ export const ExecutionOptimisticAndDependentRootCodec: ResponseMetadataCodec<Exe
     toHeadersObject: (val) => ({
       [MetaHeader.ExecutionOptimistic]: val.executionOptimistic.toString(),
       [MetaHeader.DependentRoot]: val.dependentRoot,
+      [HttpHeader.ExposeHeaders]: [MetaHeader.ExecutionOptimistic, MetaHeader.DependentRoot].toString(),
     }),
     fromHeaders: (headers) => ({
       executionOptimistic: toBoolean(headers.getOrDefault(MetaHeader.ExecutionOptimistic, "false")),

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -2,7 +2,7 @@ import {describe, it, beforeEach, afterEach, expect} from "vitest";
 import bls from "@chainsafe/bls";
 import {createBeaconConfig, ChainConfig} from "@lodestar/config";
 import {chainConfig as chainConfigDef} from "@lodestar/config/default";
-import {getClient, routes} from "@lodestar/api";
+import {getClient, HttpHeader, routes} from "@lodestar/api";
 import {sleep} from "@lodestar/utils";
 import {ForkName, SYNC_COMMITTEE_SIZE} from "@lodestar/params";
 import {Validator} from "@lodestar/validator";
@@ -102,6 +102,8 @@ describe("lightclient api", function () {
     expect(update.attestedHeader.beacon.slot).toBe(slot - 1);
     // version is set
     expect(res.meta().version).toBe(ForkName.altair);
+    // Ensure version header is made available to scripts running in the browser
+    expect(res.headers.get(HttpHeader.ExposeHeaders)?.includes("Eth-Consensus-Version")).toBe(true);
   });
 
   it.skip("getLightClientFinalityUpdate()", async function () {


### PR DESCRIPTION
**Motivation**

When returning data from light client api to the browser in SSZ format we rely on the metadata headers to determine the fork version. Those are [not exposed by default](https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header) so we need explicitly list them in `Access-Control-Expose-Headers` header.

This currently causes issues in our [browser tests](https://github.com/ChainSafe/lodestar/actions/runs/9938559318/job/27452230867#step:6:199) and to users running light client in browser as we return SSZ by default, whereas in JSON responses the version was part of the payload (not header).

**Description**

Expose metadata headers to scripts running in the browser by setting a corresponding [`Access-Control-Expose-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers) header
