### PR TITLE
fix: add workaround to fix compatibility with go-eth2-client

### DIFF
--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -95,15 +95,15 @@ export class RestApiServer {
       this.logger.debug(`Req ${req.id} ${req.ip} ${operationId}`);
       metrics?.requests.inc({operationId});
 
-      const userAgent = req.headers["user-agent"]?.split("/")[0] ?? "";
+      // Workaround to fix compatibility with go-eth2-client
+      // See https://github.com/attestantio/go-eth2-client/issues/144
       if (
         // go-eth2-client supports handling SSZ data in response for these endpoints
         ["produceBlindedBlock", "produceBlockV3", "getBlockV2", "getStateV2"].includes(operationId) &&
         // Only Vouch seems to override default header
-        ["Go-http-client", "Vouch"].includes(userAgent)
+        ["Go-http-client", "Vouch"].includes(req.headers["user-agent"]?.split("/")[0] ?? "")
       ) {
         // Override Accept header to force server to return JSON
-        // See https://github.com/attestantio/go-eth2-client/issues/144
         req.headers.accept = "application/json";
       }
     });

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -94,6 +94,13 @@ export class RestApiServer {
       const operationId = getOperationId(req);
       this.logger.debug(`Req ${req.id} ${req.ip} ${operationId}`);
       metrics?.requests.inc({operationId});
+
+      const userAgent = req.headers["user-agent"]?.split("/")[0];
+      if (operationId !== "produceBlockV3" && userAgent && ["Go-http-client", "Vouch"].includes(userAgent)) {
+        // Override Accept header to force server to return JSON
+        // See https://github.com/attestantio/go-eth2-client/issues/144
+        req.headers.accept = "application/json";
+      }
     });
 
     server.addHook("preHandler", async (req, _res) => {

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -99,7 +99,7 @@ export class RestApiServer {
       // See https://github.com/attestantio/go-eth2-client/issues/144
       if (
         // go-eth2-client supports handling SSZ data in response for these endpoints
-        ["produceBlindedBlock", "produceBlockV3", "getBlockV2", "getStateV2"].includes(operationId) &&
+        !["produceBlindedBlock", "produceBlockV3", "getBlockV2", "getStateV2"].includes(operationId) &&
         // Only Vouch seems to override default header
         ["Go-http-client", "Vouch"].includes(req.headers["user-agent"]?.split("/")[0] ?? "")
       ) {

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -95,8 +95,13 @@ export class RestApiServer {
       this.logger.debug(`Req ${req.id} ${req.ip} ${operationId}`);
       metrics?.requests.inc({operationId});
 
-      const userAgent = req.headers["user-agent"]?.split("/")[0];
-      if (operationId !== "produceBlockV3" && userAgent && ["Go-http-client", "Vouch"].includes(userAgent)) {
+      const userAgent = req.headers["user-agent"]?.split("/")[0] ?? "";
+      if (
+        // go-eth2-client supports handling SSZ data in response for these endpoints
+        ["produceBlindedBlock", "produceBlockV3", "getBlockV2", "getStateV2"].includes(operationId) &&
+        // Only Vouch seems to override default header
+        ["Go-http-client", "Vouch"].includes(userAgent)
+      ) {
         // Override Accept header to force server to return JSON
         // See https://github.com/attestantio/go-eth2-client/issues/144
         req.headers.accept = "application/json";


### PR DESCRIPTION
**Motivation**

There is a compatibility issue (https://github.com/attestantio/go-eth2-client/issues/144) with any software that uses [go-eth2-client](https://github.com/attestantio/go-eth2-client) with a version less than `v0.21.6`.

While this has been fixed over a month ago by https://github.com/attestantio/go-eth2-client/pull/145, upstream software using the client have not yet updated it and cut a release.

This workaround is to avoid compatiblity issues with our stable release and can hopefully be removed in our next release.


**Description**

Force beacon api server to return JSON if client uses go-eth2-client as determined by `user-agent` header.

The user agents I have checked are for
- charon (based on testing)
- ssv (based on code)
- vouch (based on code)
- checkpointz (based on code)
- did I miss any?

It seems like that only Vouch overrides the default header but I haven't tested this for all others yet.

Also we can skip this check for produce block api (and others) as go-eth2-client supports handling SSZ data in response for these endpoints.