### PR TITLE
fix: update user-agent check for go-eth2-client

### DIFF
--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -100,7 +100,7 @@ export class RestApiServer {
       if (
         // go-eth2-client supports handling SSZ data in response for these endpoints
         !["produceBlindedBlock", "produceBlockV3", "getBlockV2", "getStateV2"].includes(operationId) &&
-        // Only Vouch (and Charon?) seems to override default header
+        // Only Vouch seems to override default header
         ["go-eth2-client", "Go-http-client", "Vouch"].includes(req.headers["user-agent"]?.split("/")[0] ?? "")
       ) {
         // Override Accept header to force server to return JSON

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -100,8 +100,8 @@ export class RestApiServer {
       if (
         // go-eth2-client supports handling SSZ data in response for these endpoints
         !["produceBlindedBlock", "produceBlockV3", "getBlockV2", "getStateV2"].includes(operationId) &&
-        // Only Vouch seems to override default header
-        ["Go-http-client", "Vouch"].includes(req.headers["user-agent"]?.split("/")[0] ?? "")
+        // Only Vouch (and Charon?) seems to override default header
+        ["go-eth2-client", "Go-http-client", "Vouch"].includes(req.headers["user-agent"]?.split("/")[0] ?? "")
       ) {
         // Override Accept header to force server to return JSON
         req.headers.accept = "application/json";


### PR DESCRIPTION
**Motivation**

Follow up to https://github.com/ChainSafe/lodestar/pull/6953 to check proper [default header](https://github.com/attestantio/go-eth2-client/blob/5f15ea2fead860462ef760fdc26a3ed6a43c7980/http/http.go#L37) of go-eth-client.

**Description**

Update user-agent check for go-eth2-client

[attestantio/go-eth2-client/http/http.go#L36-L37](https://github.com/attestantio/go-eth2-client/blob/5f15ea2fead860462ef760fdc26a3ed6a43c7980/http/http.go#L36-L37)

```go
// defaultUserAgent is sent with requests if no other user agent has been supplied.
const defaultUserAgent = "go-eth2-client/0.21.7"
```

For some requests it sets the other header `Go-http-client`, which is set by [Go by default](https://www.practical-go-lessons.com/chap-35-build-an-http-client#headers-automatically-sent).