### PR TITLE
chore: pin nodejs version to 22.4

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.4
           check-latest: true
           cache: yarn
       - name: Node.js version

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install -y build-essential python3
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22
+          node: 22.4
       - run: |
           mkdir -p dist
           yarn global add caxa@3.0.1

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-          cache: yarn          
+          node-version: 22.4
+          cache: yarn
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Ref to deploy, defaults to `unstable`'
+        description: "Ref to deploy, defaults to `unstable`"
         required: false
-        default: 'unstable'
+        default: "unstable"
         type: string
 
 jobs:
@@ -31,9 +31,9 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.4
           check-latest: true
-          cache: yarn          
+          cache: yarn
 
       - name: Node.js version
         id: node

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -20,10 +20,10 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.4
           registry-url: "https://registry.npmjs.org"
           check-latest: true
-          cache: yarn          
+          cache: yarn
       - name: Node.js version
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22
+          node: 22.4
 
       - name: Generate changelog
         run: node scripts/generate_changelog.mjs ${{ needs.tag.outputs.prev_tag }} ${{ needs.tag.outputs.tag }} CHANGELOG.md

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22
+          node: 22.4
 
       - name: Generate changelog
         run: node scripts/generate_changelog.mjs ${{ needs.tag.outputs.prev_tag }} ${{ needs.tag.outputs.tag }} CHANGELOG.md

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.4
           check-latest: true
           cache: yarn
       - name: Node.js version

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22
+          node: 22.4
 
   sim-test-multifork:
     name: Multifork sim test
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22
+          node: 22.4
       - name: Load env variables
         uses: ./.github/actions/dotenv
       - name: Download required docker images before running tests
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22
+          node: 22.4
       - name: Load env variables
         uses: ./.github/actions/dotenv
       - name: Download required docker images before running tests
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22
+          node: 22.4
       - name: Load env variables
         uses: ./.github/actions/dotenv
       - name: Download required docker images before running tests
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22
+          node: 22.4
       - name: Load env variables
         uses: ./.github/actions/dotenv
       - name: Download required docker images before running tests
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22
+          node: 22.4
       - name: Load env variables
         uses: ./.github/actions/dotenv
       - name: Download required docker images before running tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22]
+        node: [22.4]
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22]
+        node: [22.4]
     steps:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22]
+        node: [22.4]
     steps:
       - uses: actions/checkout@v4
 
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22]
+        node: [22.4]
     steps:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
@@ -134,7 +134,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22]
+        node: [22.4]
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
@@ -171,7 +171,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22]
+        node: [22.4]
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
@@ -195,7 +195,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22]
+        node: [22.4]
     steps:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 # --platform=$BUILDPLATFORM is used build javascript source with host arch
 # Otherwise TS builds on emulated archs and can be extremely slow (+1h)
-FROM --platform=${BUILDPLATFORM:-amd64} node:22-alpine as build_src
+FROM --platform=${BUILDPLATFORM:-amd64} node:22.4-alpine as build_src
 ARG COMMIT
 WORKDIR /usr/app
 RUN apk update && apk add --no-cache g++ make python3 py3-setuptools && rm -rf /var/cache/apk/*
@@ -21,7 +21,7 @@ RUN cd packages/cli && GIT_COMMIT=${COMMIT} yarn write-git-data
 
 # Copy built src + node_modules to build native packages for archs different than host.
 # Note: This step is redundant for the host arch
-FROM node:22-alpine as build_deps
+FROM node:22.4-alpine as build_deps
 WORKDIR /usr/app
 RUN apk update && apk add --no-cache g++ make python3 py3-setuptools && rm -rf /var/cache/apk/*
 
@@ -35,7 +35,7 @@ RUN cd node_modules/classic-level && yarn rebuild
 
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)
-FROM node:22-alpine
+FROM node:22.4-alpine
 WORKDIR /usr/app
 COPY --from=build_deps /usr/app .
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "engines": {
-    "node": ">=20.1.0 <21 || >=22 <23"
+    "node": ">=20.1.0 <21 || >=22 <22.5"
   },
   "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca",
   "workspaces": [


### PR DESCRIPTION
**Motivation**

Node 22.5 seems broken

**Description**

Pin nodejs version to 22.4

https://github.com/nodejs/node/issues/53902 (and other issues)
