### PR TITLE
fix: return finalized as false if finalized epoch is genesis epoch

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -433,7 +433,7 @@ export class BeaconChain implements IBeaconChain {
         return {
           state,
           executionOptimistic: isOptimisticBlock(block),
-          finalized: slot !== GENESIS_SLOT && slot === finalizedBlock.slot,
+          finalized: slot === finalizedBlock.slot && finalizedBlock.slot !== GENESIS_SLOT,
         };
       } else {
         // Just check if state is already in the cache. If it's not dialed to the correct slot,
@@ -448,7 +448,7 @@ export class BeaconChain implements IBeaconChain {
           state && {
             state,
             executionOptimistic: isOptimisticBlock(block),
-            finalized: slot !== GENESIS_SLOT && slot === finalizedBlock.slot,
+            finalized: slot === finalizedBlock.slot && finalizedBlock.slot !== GENESIS_SLOT,
           }
         );
       }
@@ -468,11 +468,11 @@ export class BeaconChain implements IBeaconChain {
     if (opts?.allowRegen) {
       const state = await this.regen.getState(stateRoot, RegenCaller.restApi);
       const block = this.forkChoice.getBlock(state.latestBlockHeader.hashTreeRoot());
-      const stateEpoch = state.epochCtx.epoch;
+      const finalizedEpoch = this.forkChoice.getFinalizedCheckpoint().epoch;
       return {
         state,
         executionOptimistic: block != null && isOptimisticBlock(block),
-        finalized: stateEpoch !== GENESIS_EPOCH && stateEpoch <= this.forkChoice.getFinalizedCheckpoint().epoch,
+        finalized: state.epochCtx.epoch <= finalizedEpoch && finalizedEpoch !== GENESIS_EPOCH,
       };
     }
 
@@ -484,11 +484,11 @@ export class BeaconChain implements IBeaconChain {
     const cachedStateCtx = this.regen.getStateSync(stateRoot);
     if (cachedStateCtx) {
       const block = this.forkChoice.getBlock(cachedStateCtx.latestBlockHeader.hashTreeRoot());
-      const stateEpoch = cachedStateCtx.epochCtx.epoch;
+      const finalizedEpoch = this.forkChoice.getFinalizedCheckpoint().epoch;
       return {
         state: cachedStateCtx,
         executionOptimistic: block != null && isOptimisticBlock(block),
-        finalized: stateEpoch !== GENESIS_EPOCH && stateEpoch <= this.forkChoice.getFinalizedCheckpoint().epoch,
+        finalized: cachedStateCtx.epochCtx.epoch <= finalizedEpoch && finalizedEpoch !== GENESIS_EPOCH,
       };
     }
 
@@ -503,11 +503,11 @@ export class BeaconChain implements IBeaconChain {
     const cachedStateCtx = this.regen.getCheckpointStateSync(checkpoint);
     if (cachedStateCtx) {
       const block = this.forkChoice.getBlock(cachedStateCtx.latestBlockHeader.hashTreeRoot());
-      const stateEpoch = cachedStateCtx.epochCtx.epoch;
+      const finalizedEpoch = this.forkChoice.getFinalizedCheckpoint().epoch;
       return {
         state: cachedStateCtx,
         executionOptimistic: block != null && isOptimisticBlock(block),
-        finalized: stateEpoch !== GENESIS_EPOCH && stateEpoch <= this.forkChoice.getFinalizedCheckpoint().epoch,
+        finalized: cachedStateCtx.epochCtx.epoch <= finalizedEpoch && finalizedEpoch !== GENESIS_EPOCH,
       };
     }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -36,7 +36,7 @@ import {
 import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
 import {ProcessShutdownCallback} from "@lodestar/validator";
 import {Logger, gweiToWei, isErrorAborted, pruneSetToMax, sleep, toHex} from "@lodestar/utils";
-import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkSeq, GENESIS_SLOT, SLOTS_PER_EPOCH} from "@lodestar/params";
 
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants/index.js";
 import {IBeaconDb} from "../db/index.js";
@@ -430,7 +430,11 @@ export class BeaconChain implements IBeaconChain {
           {dontTransferCache: true},
           RegenCaller.restApi
         );
-        return {state, executionOptimistic: isOptimisticBlock(block), finalized: slot === finalizedBlock.slot};
+        return {
+          state,
+          executionOptimistic: isOptimisticBlock(block),
+          finalized: slot !== GENESIS_SLOT && slot === finalizedBlock.slot,
+        };
       } else {
         // Just check if state is already in the cache. If it's not dialed to the correct slot,
         // do not bother in advancing the state. restApiCanTriggerRegen == false means do no work
@@ -440,7 +444,13 @@ export class BeaconChain implements IBeaconChain {
         }
 
         const state = this.regen.getStateSync(block.stateRoot);
-        return state && {state, executionOptimistic: isOptimisticBlock(block), finalized: slot === finalizedBlock.slot};
+        return (
+          state && {
+            state,
+            executionOptimistic: isOptimisticBlock(block),
+            finalized: slot !== GENESIS_SLOT && slot === finalizedBlock.slot,
+          }
+        );
       }
     } else {
       // request for finalized state
@@ -458,10 +468,11 @@ export class BeaconChain implements IBeaconChain {
     if (opts?.allowRegen) {
       const state = await this.regen.getState(stateRoot, RegenCaller.restApi);
       const block = this.forkChoice.getBlock(state.latestBlockHeader.hashTreeRoot());
+      const stateEpoch = state.epochCtx.epoch;
       return {
         state,
         executionOptimistic: block != null && isOptimisticBlock(block),
-        finalized: state.epochCtx.epoch <= this.forkChoice.getFinalizedCheckpoint().epoch,
+        finalized: stateEpoch !== GENESIS_EPOCH && stateEpoch <= this.forkChoice.getFinalizedCheckpoint().epoch,
       };
     }
 
@@ -473,10 +484,11 @@ export class BeaconChain implements IBeaconChain {
     const cachedStateCtx = this.regen.getStateSync(stateRoot);
     if (cachedStateCtx) {
       const block = this.forkChoice.getBlock(cachedStateCtx.latestBlockHeader.hashTreeRoot());
+      const stateEpoch = cachedStateCtx.epochCtx.epoch;
       return {
         state: cachedStateCtx,
         executionOptimistic: block != null && isOptimisticBlock(block),
-        finalized: cachedStateCtx.epochCtx.epoch <= this.forkChoice.getFinalizedCheckpoint().epoch,
+        finalized: stateEpoch !== GENESIS_EPOCH && stateEpoch <= this.forkChoice.getFinalizedCheckpoint().epoch,
       };
     }
 
@@ -491,10 +503,11 @@ export class BeaconChain implements IBeaconChain {
     const cachedStateCtx = this.regen.getCheckpointStateSync(checkpoint);
     if (cachedStateCtx) {
       const block = this.forkChoice.getBlock(cachedStateCtx.latestBlockHeader.hashTreeRoot());
+      const stateEpoch = cachedStateCtx.epochCtx.epoch;
       return {
         state: cachedStateCtx,
         executionOptimistic: block != null && isOptimisticBlock(block),
-        finalized: cachedStateCtx.epochCtx.epoch <= this.forkChoice.getFinalizedCheckpoint().epoch,
+        finalized: stateEpoch !== GENESIS_EPOCH && stateEpoch <= this.forkChoice.getFinalizedCheckpoint().epoch,
       };
     }
 

--- a/packages/cli/test/sim/endpoints.test.ts
+++ b/packages/cli/test/sim/endpoints.test.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import assert from "node:assert";
 import {toHexString} from "@chainsafe/ssz";
 import {routes} from "@lodestar/api";
-import {GENESIS_SLOT} from "@lodestar/params";
 import {Simulation} from "../utils/crucible/simulation.js";
 import {BeaconClient, ExecutionClient} from "../utils/crucible/interfaces.js";
 import {defineSimTestConfig, logFilesDir} from "../utils/crucible/utils/index.js";
@@ -103,15 +102,6 @@ await env.tracker.assert(
     const res = await node.api.beacon.getStateValidator({stateId: "head", validatorId: hexPubKey});
 
     assert.equal(toHexString(res.value().validator.pubkey), hexPubKey);
-  }
-);
-
-await env.tracker.assert(
-  "should return 'finalized' as 'false' when getStateValidator is called with genesis slot",
-  async () => {
-    const res = await node.api.beacon.getStateValidator({stateId: GENESIS_SLOT, validatorId: 0});
-
-    assert.equal(res.meta().finalized, false);
   }
 );
 

--- a/packages/cli/test/sim/endpoints.test.ts
+++ b/packages/cli/test/sim/endpoints.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import assert from "node:assert";
 import {toHexString} from "@chainsafe/ssz";
 import {routes} from "@lodestar/api";
+import {GENESIS_SLOT} from "@lodestar/params";
 import {Simulation} from "../utils/crucible/simulation.js";
 import {BeaconClient, ExecutionClient} from "../utils/crucible/interfaces.js";
 import {defineSimTestConfig, logFilesDir} from "../utils/crucible/utils/index.js";
@@ -102,6 +103,15 @@ await env.tracker.assert(
     const res = await node.api.beacon.getStateValidator({stateId: "head", validatorId: hexPubKey});
 
     assert.equal(toHexString(res.value().validator.pubkey), hexPubKey);
+  }
+);
+
+await env.tracker.assert(
+  "should return 'finalized' as 'false' when getStateValidator is called with genesis slot",
+  async () => {
+    const res = await node.api.beacon.getStateValidator({stateId: GENESIS_SLOT, validatorId: 0});
+
+    assert.equal(res.meta().finalized, false);
   }
 );
 


### PR DESCRIPTION
**Motivation**

E2E tests and Sim endpoint tests are failing since we merged https://github.com/ChainSafe/lodestar/pull/6963. The issue happens because removed [handling "head" explicitly](https://github.com/ChainSafe/lodestar/pull/6963/files#diff-e8679fe2d8d177d8d05972484c26221ca9d1f85c66b22d741583f2d6c78c866bL32) but actual problem is that we rather need to check genesis slot / epoch explicitly as it is done in LC server for example.
https://github.com/ChainSafe/lodestar/blob/fed08fe5107a809d8862494ae6a86ebc6f2f0ee9/packages/beacon-node/src/chain/lightClient/index.ts#L436

**Description**

Return `finalized` as `false` in metadata if finalized epoch is genesis epoch / block slot
