### PR TITLE
fix: fix the publish blinded block api parsing for optional header verison

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -444,7 +444,16 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           };
         },
         parseReqJson: ({body, headers}) => {
-          const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
+          let fork: ForkName;
+          // As per spec, version header is optional for JSON requests
+          const versionHeader = fromHeaders(headers, MetaHeader.Version, false);
+          if (versionHeader !== undefined) {
+            fork = toForkName(versionHeader);
+          } else {
+            // Determine fork from slot in JSON payload
+            fork = config.getForkName((body as SignedBlindedBeaconBlock).message.slot);
+          }
+
           return {
             signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body),
           };
@@ -490,7 +499,16 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           };
         },
         parseReqJson: ({body, headers, query}) => {
-          const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
+          let fork: ForkName;
+          // As per spec, version header is optional for JSON requests
+          const versionHeader = fromHeaders(headers, MetaHeader.Version, false);
+          if (versionHeader !== undefined) {
+            fork = toForkName(versionHeader);
+          } else {
+            // Determine fork from slot in JSON payload
+            fork = config.getForkName((body as SignedBlindedBeaconBlock).message.slot);
+          }
+
           return {
             signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body),
             broadcastValidation: query.broadcast_validation as BroadcastValidation,

--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -499,16 +499,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           };
         },
         parseReqJson: ({body, headers, query}) => {
-          let fork: ForkName;
-          // As per spec, version header is optional for JSON requests
-          const versionHeader = fromHeaders(headers, MetaHeader.Version, false);
-          if (versionHeader !== undefined) {
-            fork = toForkName(versionHeader);
-          } else {
-            // Determine fork from slot in JSON payload
-            fork = config.getForkName((body as SignedBlindedBeaconBlock).message.slot);
-          }
-
+          const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
             signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body),
             broadcastValidation: query.broadcast_validation as BroadcastValidation,


### PR DESCRIPTION
lighthouse default still uses produceblinded/publishblinded with json api with option version.

because of this a user failed a block publish.

this pr fixes the scenario and should be released as a patch