### PR TITLE
fix: ignore noisy eventstream errors due to DNS resolution errors

### DIFF
--- a/packages/api/src/beacon/client/events.ts
+++ b/packages/api/src/beacon/client/events.ts
@@ -44,7 +44,7 @@ export function getClient(config: ChainForkConfig, baseUrl: string): ApiClient {
         const errEs = err as unknown as EventSourceError;
 
         // Ignore noisy errors due to beacon node being offline
-        if (!errEs.message?.includes("ECONNREFUSED")) {
+        if (!/ECONNREFUSED|EAI_AGAIN/.test(errEs.message ?? "")) {
           // If there is no message it likely indicates that the server closed the connection
           onError?.(new Error(errEs.message ?? "Server closed connection"));
         }


### PR DESCRIPTION
**Motivation**

This is similar to `ECONNREFUSED` if connected beacon node is offline and happens mostly in docker-based setups if container is stopped / crashed.

**Description**

Ignore noisy eventstream errors due to DNS resolution errors

E.g. `error: Failed to receive head event - getaddrinfo EAI_AGAIN consensus`