### PR TITLE
feat: minimal alloc viewdu batch hash

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -12,6 +12,12 @@ import {BlockProcessOpts} from "../options.js";
 import {byteArrayEquals} from "../../util/bytes.js";
 import {nextEventLoop} from "../../util/eventLoop.js";
 import {BlockInput, ImportBlockOpts} from "./types.js";
+import {HashComputationGroup} from "@chainsafe/persistent-merkle-tree";
+
+/**
+ * Data in a BeaconBlock is bounded so we can use a single HashComputationGroup for all blocks
+ */
+const blockHCGroup = new HashComputationGroup([]);
 
 /**
  * Verifies 1 or more blocks are fully valid running the full state transition; from a linear sequence of blocks.
@@ -63,7 +69,7 @@ export async function verifyBlocksStateTransitionOnly(
     const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
       source: StateHashTreeRootSource.blockTransition,
     });
-    const stateRoot = postState.hashTreeRoot();
+    const stateRoot = postState.hashTreeRoot(blockHCGroup);
     hashTreeRootTimer?.();
 
     // Check state root matches

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -17,7 +17,7 @@ import {HashComputationGroup} from "@chainsafe/persistent-merkle-tree";
 /**
  * Data in a BeaconBlock is bounded so we can use a single HashComputationGroup for all blocks
  */
-const blockHCGroup = new HashComputationGroup([]);
+const blockHCGroup = new HashComputationGroup();
 
 /**
  * Verifies 1 or more blocks are fully valid running the full state transition; from a linear sequence of blocks.

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -27,9 +27,9 @@ export const SCHEDULER_LOOKAHEAD_FACTOR = 3;
 const PREPARE_EPOCH_LIMIT = 1;
 
 /**
- * We always modify balances for every epoch transition so it makes sense to reuse HashComputationGroup there.
+ * The same HashComputationGroup to be used for all epoch transition.
  */
-const balancesHCGroup = new HashComputationGroup([]);
+const epochTransitionHCGroup = new HashComputationGroup();
 
 /**
  * At Bellatrix, if we are responsible for proposing in next slot, we want to prepare payload
@@ -236,10 +236,9 @@ export class PrepareNextSlotScheduler {
       source: isEpochTransition ? StateHashTreeRootSource.prepareNextEpoch : StateHashTreeRootSource.prepareNextSlot,
     });
     if (isEpochTransition) {
-      state.balances.hashTreeRoot(balancesHCGroup);
-      state.node.rootHashObject;
+      state.hashTreeRoot(epochTransitionHCGroup);
     } else {
-      // normal slot
+      // normal slot, not worth to batch hash
       state.node.rootHashObject;
     }
     hashTreeRootTimer?.();

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -29,7 +29,7 @@ const PREPARE_EPOCH_LIMIT = 1;
 /**
  * The same HashComputationGroup to be used for all epoch transition.
  */
-const epochTransitionHCGroup = new HashComputationGroup();
+const balancesHCGroup = new HashComputationGroup();
 
 /**
  * At Bellatrix, if we are responsible for proposing in next slot, we want to prepare payload
@@ -236,7 +236,11 @@ export class PrepareNextSlotScheduler {
       source: isEpochTransition ? StateHashTreeRootSource.prepareNextEpoch : StateHashTreeRootSource.prepareNextSlot,
     });
     if (isEpochTransition) {
-      state.hashTreeRoot(epochTransitionHCGroup);
+      // balances are completely changed per epoch and it's not much different so we can reuse the HashComputationGroup
+      state.balances.hashTreeRoot(balancesHCGroup);
+      // it's more performant to use normal hashTreeRoot() for the rest of the state
+      // this saves ~10ms per ~100ms as monitored on mainnet as of Jul 2024
+      state.node.rootHashObject;
     } else {
       // normal slot, not worth to batch hash
       state.node.rootHashObject;

--- a/packages/state-transition/src/epoch/processParticipationFlagUpdates.ts
+++ b/packages/state-transition/src/epoch/processParticipationFlagUpdates.ts
@@ -21,7 +21,6 @@ export function processParticipationFlagUpdates(state: CachedBeaconStateAltair):
     state.currentEpochParticipation.node,
     zeroNode(ssz.altair.EpochParticipation.chunkDepth),
     state.currentEpochParticipation.length,
-    null
   );
 
   state.currentEpochParticipation = ssz.altair.EpochParticipation.getViewDU(currentEpochParticipationNode);

--- a/packages/types/src/phase0/viewDU/listValidator.ts
+++ b/packages/types/src/phase0/viewDU/listValidator.ts
@@ -5,7 +5,7 @@ import {
   ByteViews,
   ContainerNodeStructTreeViewDU,
 } from "@chainsafe/ssz";
-import {HashComputationGroup, Node, digestNLevel, setNodesAtDepth} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, HashComputationLevel, Node, digestNLevel, setNodesAtDepth} from "@chainsafe/persistent-merkle-tree";
 import {byteArrayIntoHashObject} from "@chainsafe/as-sha256";
 import {ValidatorNodeStructType, ValidatorType, validatorToChunkBytes} from "../validator.js";
 
@@ -50,10 +50,10 @@ export class ListValidatorTreeViewDU extends ListCompositeTreeViewDU<ValidatorNo
     super(type, _rootNode, cache);
   }
 
-  commit(hashComps: HashComputationGroup | null = null): void {
+  commit(hcOffset = 0, hcByLevel: HashComputationLevel[] | null = null): void {
     const isOldRootHashed = this._rootNode.h0 !== null;
     if (this.viewsChanged.size === 0) {
-      if (!isOldRootHashed && hashComps !== null) {
+      if (!isOldRootHashed && hcByLevel !== null) {
         // not possible to get HashComputations due to BranchNodeStruct
         this._rootNode.root;
       }
@@ -125,23 +125,19 @@ export class ListValidatorTreeViewDU extends ListCompositeTreeViewDU<ValidatorNo
     const indexes = nodesChanged.map((entry) => entry.index);
     const nodes = nodesChanged.map((entry) => entry.node);
     const chunksNode = this.type.tree_getChunksNode(this._rootNode);
-    const hashCompsThis =
-      hashComps != null && isOldRootHashed
-        ? {
-            byLevel: hashComps.byLevel,
-            offset: hashComps.offset + this.type.tree_chunksNodeOffset(),
-          }
-        : null;
-    const newChunksNode = setNodesAtDepth(chunksNode, this.type.chunkDepth, indexes, nodes, hashCompsThis);
+    const offsetThis = hcOffset + this.type.tree_chunksNodeOffset();
+    const byLevelThis = hcByLevel != null && isOldRootHashed ? hcByLevel : null;
+    const newChunksNode = setNodesAtDepth(chunksNode, this.type.chunkDepth, indexes, nodes, offsetThis, byLevelThis);
 
     this._rootNode = this.type.tree_setChunksNode(
       this._rootNode,
       newChunksNode,
       this.dirtyLength ? this._length : null,
-      hashComps
+      hcOffset,
+      hcByLevel
     );
 
-    if (!isOldRootHashed && hashComps !== null) {
+    if (!isOldRootHashed && hcByLevel !== null) {
       // should never happen, handle just in case
       // not possible to get HashComputations due to BranchNodeStruct
       this._rootNode.root;


### PR DESCRIPTION
**Motivation**

- Minimal memory allocation when batch hash state
  - process block
  - state.balances after an epoch transition

**Description**

Consume https://github.com/ChainSafe/ssz/pull/388

**Testing**
- this branch - 1k: spiked 10 times in the last 2 days, average at base level is ~120ms to 130ms

<img width="1330" alt="Screenshot 2024-07-24 at 13 45 19" src="https://github.com/user-attachments/assets/b8121dae-7ff1-49f4-a33c-ef13866b4549">

- `te/batch_hash_tree_root` - 64: spiked 20 times in the last 2 days, average at base level is not stable ranging from ~130ms to 250ms
<img width="1339" alt="Screenshot 2024-07-24 at 13 47 55" src="https://github.com/user-attachments/assets/667ca941-faeb-40f4-b24d-de21bf86c385">


