### PR TITLE
docs: add note to local testnet setup

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -54,6 +54,7 @@ JSObjects
 JWT
 KDE
 Kubernetes
+Kurtosis
 LGPL
 LGPLv
 LMD

--- a/docs/pages/contribution/advanced-topics/setting-up-a-testnet.md
+++ b/docs/pages/contribution/advanced-topics/setting-up-a-testnet.md
@@ -6,6 +6,10 @@ title: Setting Up a Testnet
 
 To quickly test and run Lodestar we recommend starting a local testnet. We recommend a simple configuration of two beacon nodes with multiple validators. The [dev scripts](https://github.com/ChainSafe/lodestar/tree/unstable/scripts/dev) can used for simplicity but below instructions provide more insights on how it works and include details about different configurations.
 
+:::note
+The testnet set up in this guide is meant to be short-lived / ephemeral and should primarily be used for development and testing. Please refer to [Ethereum In a Box](https://github.com/rocknet/ethiab) or [Kurtosis ethereum package](https://github.com/ethpandaops/ethereum-package) to set up a long-lived private network or devnet.
+:::
+
 **Terminal 1**
 
 Run a beacon node as a **bootnode**, with 8 validators with the following command.


### PR DESCRIPTION
**Motivation**

Clarify expectations on what the local testnet can be used for

**Description**

Adds note that local testnet is supposed to be short-lived / ephemeral and used for development and testing.

Links to [Ethereum In a Box](https://github.com/rocknet/ethiab) and [Kurtosis ethereum package](https://github.com/ethpandaops/ethereum-package) for users who wanna set up a long-lived private network or devnet.
