### PR TITLE
chore: refactor chain event emits

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -101,34 +101,6 @@ export async function importBlock(
   this.metrics?.importBlock.bySource.inc({source});
   this.logger.verbose("Added block to forkchoice and state cache", {slot: blockSlot, root: blockRootHex});
 
-  // We want to import block asap so call all event handler in the next event loop
-  callInNextEventLoop(async () => {
-    this.emitter.emit(routes.events.EventType.block, {
-      block: blockRootHex,
-      slot: blockSlot,
-      executionOptimistic: blockSummary != null && isOptimisticBlock(blockSummary),
-    });
-
-    // dataPromise will not end up here, but preDeneb could. In future we might also allow syncing
-    // out of data range blocks and import then in forkchoice although one would not be able to
-    // attest and propose with such head similar to optimistic sync
-    if (blockInput.type === BlockInputType.availableData) {
-      const {blobsSource, blobs} = blockInput.blockData;
-
-      this.metrics?.importBlock.blobsBySource.inc({blobsSource});
-      for (const blobSidecar of blobs) {
-        const {index, kzgCommitment} = blobSidecar;
-        this.emitter.emit(routes.events.EventType.blobSidecar, {
-          blockRoot: blockRootHex,
-          slot: blockSlot,
-          index,
-          kzgCommitment: toHexString(kzgCommitment),
-          versionedHash: toHexString(kzgCommitmentToVersionedHash(kzgCommitment)),
-        });
-      }
-    }
-  });
-
   // 3. Import attestations to fork choice
   //
   // - For each attestation
@@ -414,6 +386,14 @@ export async function importBlock(
 
   if (this.clock.currentSlot - blockSlot < EVENTSTREAM_EMIT_RECENT_BLOCK_SLOTS) {
     // NOTE: Skip looping if there are no listeners from the API
+
+    if (this.emitter.listenerCount(routes.events.EventType.block)) {
+      this.emitter.emit(routes.events.EventType.block, {
+        block: blockRootHex,
+        slot: blockSlot,
+        executionOptimistic: blockSummary != null && isOptimisticBlock(blockSummary),
+      });
+    }
     if (this.emitter.listenerCount(routes.events.EventType.voluntaryExit)) {
       for (const voluntaryExit of block.message.body.voluntaryExits) {
         this.emitter.emit(routes.events.EventType.voluntaryExit, voluntaryExit);
@@ -439,6 +419,22 @@ export async function importBlock(
         this.emitter.emit(routes.events.EventType.proposerSlashing, proposerSlashing);
       }
     }
+    if (
+      blockInput.type === BlockInputType.availableData &&
+      this.emitter.listenerCount(routes.events.EventType.blobSidecar)
+    ) {
+      const {blobs} = blockInput.blockData;
+      for (const blobSidecar of blobs) {
+        const {index, kzgCommitment} = blobSidecar;
+        this.emitter.emit(routes.events.EventType.blobSidecar, {
+          blockRoot: blockRootHex,
+          slot: blockSlot,
+          index,
+          kzgCommitment: toHexString(kzgCommitment),
+          versionedHash: toHexString(kzgCommitmentToVersionedHash(kzgCommitment)),
+        });
+      }
+    }
   }
 
   // Register stat metrics about the block after importing it
@@ -451,6 +447,13 @@ export async function importBlock(
       (block as altair.SignedBeaconBlock).message.body.syncAggregate,
       fullyVerifiedBlock.postState.epochCtx.currentSyncCommitteeIndexed.validatorIndices
     );
+  }
+  // dataPromise will not end up here, but preDeneb could. In future we might also allow syncing
+  // out of data range blocks and import then in forkchoice although one would not be able to
+  // attest and propose with such head similar to optimistic sync
+  if (blockInput.type === BlockInputType.availableData) {
+    const {blobsSource} = blockInput.blockData;
+    this.metrics?.importBlock.blobsBySource.inc({blobsSource});
   }
 
   const advancedSlot = this.clock.slotWithFutureTolerance(REPROCESS_MIN_TIME_TO_NEXT_SLOT_SEC);


### PR DESCRIPTION
**Motivation**

- small thing noticed when looking thru the code

**Description**

- move event emitting of block and blob sidecar events to the place in code where the rest are emitted
- move blob source metrics with other metrics
- wrap all chain event emits in a callOnNextEventLoop