### PR TITLE
fix: resolve state id as checkpoint

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -3,11 +3,14 @@ import {FAR_FUTURE_EPOCH, GENESIS_SLOT} from "@lodestar/params";
 import {BeaconStateAllForks, PubkeyIndexMap} from "@lodestar/state-transition";
 import {BLSPubkey, Epoch, phase0, RootHex, Slot, ValidatorIndex} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
-import {IForkChoice} from "@lodestar/fork-choice";
+import {CheckpointWithHex, IForkChoice} from "@lodestar/fork-choice";
 import {IBeaconChain} from "../../../../chain/index.js";
 import {ApiError, ValidationError} from "../../errors.js";
 
-export function resolveStateId(forkChoice: IForkChoice, stateId: routes.beacon.StateId): RootHex | Slot {
+export function resolveStateId(
+  forkChoice: IForkChoice,
+  stateId: routes.beacon.StateId
+): RootHex | Slot | CheckpointWithHex {
   if (stateId === "head") {
     return forkChoice.getHead().stateRoot;
   }
@@ -17,11 +20,11 @@ export function resolveStateId(forkChoice: IForkChoice, stateId: routes.beacon.S
   }
 
   if (stateId === "finalized") {
-    return forkChoice.getFinalizedBlock().stateRoot;
+    return forkChoice.getFinalizedCheckpoint();
   }
 
   if (stateId === "justified") {
-    return forkChoice.getJustifiedBlock().stateRoot;
+    return forkChoice.getJustifiedCheckpoint();
   }
 
   if (typeof stateId === "string" && stateId.startsWith("0x")) {
@@ -39,17 +42,19 @@ export function resolveStateId(forkChoice: IForkChoice, stateId: routes.beacon.S
 
 export async function getStateResponse(
   chain: IBeaconChain,
-  stateId: routes.beacon.StateId
+  inStateId: routes.beacon.StateId
 ): Promise<{state: BeaconStateAllForks; executionOptimistic: boolean; finalized: boolean}> {
-  const rootOrSlot = resolveStateId(chain.forkChoice, stateId);
+  const stateId = resolveStateId(chain.forkChoice, inStateId);
 
   const res =
-    typeof rootOrSlot === "string"
-      ? await chain.getStateByStateRoot(rootOrSlot)
-      : await chain.getStateBySlot(rootOrSlot);
+    typeof stateId === "string"
+      ? await chain.getStateByStateRoot(stateId)
+      : typeof stateId === "number"
+        ? await chain.getStateBySlot(stateId)
+        : chain.getStateByCheckpoint(stateId);
 
   if (!res) {
-    throw new ApiError(404, `No state found for id '${stateId}'`);
+    throw new ApiError(404, `No state found for id '${inStateId}'`);
   }
 
   return res;
@@ -57,19 +62,21 @@ export async function getStateResponse(
 
 export async function getStateResponseWithRegen(
   chain: IBeaconChain,
-  stateId: routes.beacon.StateId
+  inStateId: routes.beacon.StateId
 ): Promise<{state: BeaconStateAllForks | Uint8Array; executionOptimistic: boolean; finalized: boolean}> {
-  const rootOrSlot = resolveStateId(chain.forkChoice, stateId);
+  const stateId = resolveStateId(chain.forkChoice, inStateId);
 
   const res =
-    typeof rootOrSlot === "string"
-      ? await chain.getStateByStateRoot(rootOrSlot, {allowRegen: true})
-      : rootOrSlot >= chain.forkChoice.getFinalizedBlock().slot
-        ? await chain.getStateBySlot(rootOrSlot, {allowRegen: true})
-        : await chain.getHistoricalStateBySlot(rootOrSlot);
+    typeof stateId === "string"
+      ? await chain.getStateByStateRoot(stateId, {allowRegen: true})
+      : typeof stateId === "number"
+        ? stateId >= chain.forkChoice.getFinalizedBlock().slot
+          ? await chain.getStateBySlot(stateId, {allowRegen: true})
+          : await chain.getHistoricalStateBySlot(stateId)
+        : await chain.getStateOrBytesByCheckpoint(stateId);
 
   if (!res) {
-    throw new ApiError(404, `No state found for id '${stateId}'`);
+    throw new ApiError(404, `No state found for id '${inStateId}'`);
   }
 
   return res;

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -160,6 +160,10 @@ export interface IBeaconChain {
   getStateByCheckpoint(
     checkpoint: CheckpointWithHex
   ): {state: BeaconStateAllForks; executionOptimistic: boolean; finalized: boolean} | null;
+  /** Return state bytes by checkpoint */
+  getStateOrBytesByCheckpoint(
+    checkpoint: CheckpointWithHex
+  ): Promise<{state: CachedBeaconStateAllForks | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null>;
 
   /**
    * Since we can have multiple parallel chains,


### PR DESCRIPTION
**Motivation**

- When state id is "justified" or "finalized", we need to resolve it to a checkpoint instead of the block root
  - for example, a finalized checkpoint at {root: block_root_31, epoch: 1} should not be the state at block 31, it's the state at block 31 dialed to the next epoch
- Need to handle different types of state based on `n-historicalStates` flag

**Description**

- resolve state id as checkpoint when it's "finalized" or "justified"
- implement respective chain apis

part of #5968