### PR TITLE
chore: more log on updateHeadState()

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -241,7 +241,7 @@ export async function importBlock(
 
   if (newHead.blockRoot !== oldHead.blockRoot) {
     // Set head state as strong reference
-    this.regen.updateHeadState(newHead.stateRoot, postState);
+    this.regen.updateHeadState(newHead, postState);
 
     this.emitter.emit(routes.events.EventType.head, {
       block: newHead.blockRoot,

--- a/packages/beacon-node/src/chain/regen/interface.ts
+++ b/packages/beacon-node/src/chain/regen/interface.ts
@@ -44,7 +44,7 @@ export interface IStateRegenerator extends IStateRegeneratorInternal {
   pruneOnFinalized(finalizedEpoch: Epoch): void;
   processState(blockRootHex: RootHex, postState: CachedBeaconStateAllForks): void;
   addCheckpointState(cp: phase0.Checkpoint, item: CachedBeaconStateAllForks): void;
-  updateHeadState(newHeadStateRoot: RootHex, maybeHeadState: CachedBeaconStateAllForks): void;
+  updateHeadState(newHead: ProtoBlock, maybeHeadState: CachedBeaconStateAllForks): void;
   updatePreComputedCheckpoint(rootHex: RootHex, epoch: Epoch): number | null;
 }
 

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -169,11 +169,16 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     // the resulting state will be added to block state cache so we transfer the cache in this flow
     const cloneOpts = {dontTransferCache: true};
     const {stateRoot: newHeadStateRoot, blockRoot: newHeadBlockRoot, slot: newHeadSlot} = newHead;
-    const logCtx = {newHeadSlot, newHeadBlockRoot, newHeadStateRoot, maybeHeadSlot: maybeHeadState.slot};
+    const maybeHeadStateRoot = toHexString(maybeHeadState.hashTreeRoot());
+    const logCtx = {
+      newHeadSlot,
+      newHeadBlockRoot,
+      newHeadStateRoot,
+      maybeHeadSlot: maybeHeadState.slot,
+      maybeHeadStateRoot,
+    };
     const headState =
-      newHeadStateRoot === toHexString(maybeHeadState.hashTreeRoot())
-        ? maybeHeadState
-        : this.blockStateCache.get(newHeadStateRoot, cloneOpts);
+      newHeadStateRoot === maybeHeadStateRoot ? maybeHeadState : this.blockStateCache.get(newHeadStateRoot, cloneOpts);
 
     if (headState) {
       this.blockStateCache.setHeadState(headState);


### PR DESCRIPTION
**Motivation**

@nflaig found this log but but state root gives no information on which block caused the issue

```
consensus-1  | Aug-01 22:08:23.895[chain]            warn: Head state not available, triggering regen stateRoot=0x8363987c4209e3486db33b858353057ccc876e11edfa815bcca3dce7be0af2b9
consensus-1  | Aug-01 22:08:23.896[chain]           error: Error on head state regen - REGEN_ERROR_NO_SEED_STATE
consensus-1  | Error: REGEN_ERROR_NO_SEED_STATE
consensus-1  |     at StateRegenerator.getState (file:///usr/app/packages/beacon-node/src/chain/regen/regen.ts:186:13)
consensus-1  |     at QueuedStateRegenerator.updateHeadState (file:///usr/app/packages/beacon-node/src/chain/regen/queued.ts:187:18)
consensus-1  |     at BeaconChain.importBlock (file:///usr/app/packages/beacon-node/src/chain/blocks/importBlock.ts:244:16)
consensus-1  |     at BeaconChain.processBlocks (file:///usr/app/packages/beacon-node/src/chain/blocks/index.ts:101:7)
consensus-1  |     at JobItemQueue.runJob (file:///usr/app/packages/beacon-node/src/util/queue/itemQueue.ts:101:22)
```

note that this flow is critical for the beacon node to proceed

**Description**

- add more log to the `updateHeadState()` function
- also fix `dontTransferCache` option when regen head state
