### PR TITLE
feat: pre-electra support from attestation pool

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -1,7 +1,7 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
-import {Epoch, isElectraAttestation, ssz} from "@lodestar/types";
-import {ForkName, ForkSeq, SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
+import {Attestation, Epoch, isElectraAttestation, ssz} from "@lodestar/types";
+import {ForkName, SYNC_COMMITTEE_SUBNET_SIZE, isForkPostElectra} from "@lodestar/params";
 import {validateApiAttestation} from "../../../../chain/validation/index.js";
 import {validateApiAttesterSlashing} from "../../../../chain/validation/attesterSlashing.js";
 import {validateApiProposerSlashing} from "../../../../chain/validation/proposerSlashing.js";
@@ -26,9 +26,11 @@ export function getBeaconPoolApi({
   return {
     async getPoolAttestations({slot, committeeIndex}) {
       // Already filtered by slot
-      let attestations = chain.aggregatedAttestationPool
-        .getAll(slot)
-        .filter((attestation) => !isElectraAttestation(attestation));
+      let attestations: Attestation[] = chain.aggregatedAttestationPool.getAll(slot);
+
+      if (attestations.some((att) => isElectraAttestation(att))) {
+        throw new Error(`Aggregated attestation pool contains electra attestations at slot ${slot}`);
+      }
 
       if (committeeIndex !== undefined) {
         attestations = attestations.filter((attestation) => committeeIndex === attestation.data.index);
@@ -41,12 +43,9 @@ export function getBeaconPoolApi({
       // Already filtered by slot
       let attestations = chain.aggregatedAttestationPool.getAll(slot);
       const fork = chain.config.getForkName(slot ?? attestations[0]?.data.slot ?? chain.clock.currentSlot);
-      const isAfterElectra = ForkSeq[fork] >= ForkSeq.electra;
-      attestations = attestations.filter(
-        (attestation) =>
-          (isAfterElectra && isElectraAttestation(attestation)) ||
-          (!isAfterElectra && !isElectraAttestation(attestation))
-      );
+      const attestationFilterPredicate = (att: Attestation): boolean =>
+        isForkPostElectra(fork) ? isElectraAttestation(att) : !isElectraAttestation(att);
+      attestations = attestations.filter(attestationFilterPredicate);
 
       if (committeeIndex !== undefined) {
         attestations = attestations.filter((attestation) => committeeIndex === attestation.data.index);

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -16,6 +16,7 @@ import {
   SyncCommitteeError,
 } from "../../../../chain/errors/index.js";
 import {validateGossipFnRetryUnknownRoot} from "../../../../network/processor/gossipHandlers.js";
+import {ApiError} from "../../errors.js";
 
 export function getBeaconPoolApi({
   chain,
@@ -27,9 +28,13 @@ export function getBeaconPoolApi({
     async getPoolAttestations({slot, committeeIndex}) {
       // Already filtered by slot
       let attestations: Attestation[] = chain.aggregatedAttestationPool.getAll(slot);
+      const fork = chain.config.getForkName(slot ?? chain.clock.currentSlot);
 
-      if (attestations.some((att) => isElectraAttestation(att))) {
-        throw new Error(`Aggregated attestation pool contains electra attestations at slot ${slot}`);
+      if (isForkPostElectra(fork)) {
+        throw new ApiError(
+          400,
+          `Use getPoolAttestationsV2 to retrieve pool attestations for post-electra fork=${fork}`
+        );
       }
 
       if (committeeIndex !== undefined) {

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -48,9 +48,11 @@ export function getBeaconPoolApi({
       // Already filtered by slot
       let attestations = chain.aggregatedAttestationPool.getAll(slot);
       const fork = chain.config.getForkName(slot ?? attestations[0]?.data.slot ?? chain.clock.currentSlot);
-      const attestationFilterPredicate = (att: Attestation): boolean =>
-        isForkPostElectra(fork) ? isElectraAttestation(att) : !isElectraAttestation(att);
-      attestations = attestations.filter(attestationFilterPredicate);
+      const isPostElectra = isForkPostElectra(fork);
+
+      attestations = attestations.filter((attestation) =>
+        isPostElectra ? isElectraAttestation(attestation) : !isElectraAttestation(attestation)
+      );
 
       if (committeeIndex !== undefined) {
         attestations = attestations.filter((attestation) => committeeIndex === attestation.data.index);

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1077,7 +1077,7 @@ export function getValidatorApi(
       const aggregate = chain.attestationPool.getAggregate(slot, null, dataRootHex);
 
       if (!aggregate) {
-        throw new ApiError(404, `No aggregated attestation for slot=${slot},  dataRoot=${dataRootHex}`);
+       throw new ApiError(404, `No aggregated attestation for slot=${slot}, dataRoot=${dataRootHex}`);
       }
 
       metrics?.production.producedAggregateParticipants.observe(aggregate.aggregationBits.getTrueBitIndexes().length);

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1067,7 +1067,6 @@ export function getValidatorApi(
       };
     },
 
-    // TODO Electra: Implement getAggregatedAttestation to properly handle pre-electra
     async getAggregatedAttestation({attestationDataRoot, slot}) {
       notWhileSyncing();
 
@@ -1077,7 +1076,7 @@ export function getValidatorApi(
       const aggregate = chain.attestationPool.getAggregate(slot, null, dataRootHex);
 
       if (!aggregate) {
-       throw new ApiError(404, `No aggregated attestation for slot=${slot}, dataRoot=${dataRootHex}`);
+        throw new ApiError(404, `No aggregated attestation for slot=${slot}, dataRoot=${dataRootHex}`);
       }
 
       metrics?.production.producedAggregateParticipants.observe(aggregate.aggregationBits.getTrueBitIndexes().length);

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1068,8 +1068,23 @@ export function getValidatorApi(
     },
 
     // TODO Electra: Implement getAggregatedAttestation to properly handle pre-electra
-    async getAggregatedAttestation() {
-      throw new Error("Not implemented. Use getAggregatedAttestationV2 for now.");
+    async getAggregatedAttestation({attestationDataRoot, slot}) {
+      notWhileSyncing();
+
+      await waitForSlot(slot); // Must never request for a future slot > currentSlot
+
+      const dataRootHex = toHex(attestationDataRoot);
+      const aggregate = chain.attestationPool.getAggregate(slot, null, dataRootHex);
+
+      if (!aggregate) {
+        throw new ApiError(404, `No aggregated attestation for slot=${slot},  dataRoot=${dataRootHex}`);
+      }
+
+      metrics?.production.producedAggregateParticipants.observe(aggregate.aggregationBits.getTrueBitIndexes().length);
+
+      return {
+        data: aggregate,
+      };
     },
 
     async getAggregatedAttestationV2({attestationDataRoot, slot, committeeIndex}) {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -21,6 +21,7 @@ import {
   ForkPreBlobs,
   ForkBlobs,
   ForkExecution,
+  isForkPostElectra,
 } from "@lodestar/params";
 import {MAX_BUILDER_BOOST_FACTOR} from "@lodestar/validator";
 import {
@@ -1074,6 +1075,14 @@ export function getValidatorApi(
 
       const dataRootHex = toHex(attestationDataRoot);
       const aggregate = chain.attestationPool.getAggregate(slot, null, dataRootHex);
+      const fork = chain.config.getForkName(slot);
+
+      if (isForkPostElectra(fork)) {
+        throw new ApiError(
+          400,
+          `Use getAggregatedAttestationV2 to retrieve aggregated attestations for post-electra fork=${fork}`
+        );
+      }
 
       if (!aggregate) {
         throw new ApiError(404, `No aggregated attestation for slot=${slot}, dataRoot=${dataRootHex}`);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -133,7 +133,7 @@ export class BeaconChain implements IBeaconChain {
 
   // Ops pool
   readonly attestationPool: AttestationPool;
-  readonly aggregatedAttestationPool = new AggregatedAttestationPool();
+  readonly aggregatedAttestationPool: AggregatedAttestationPool;
   readonly syncCommitteeMessagePool: SyncCommitteeMessagePool;
   readonly syncContributionAndProofPool = new SyncContributionAndProofPool();
   readonly opPool = new OpPool();
@@ -226,7 +226,13 @@ export class BeaconChain implements IBeaconChain {
     if (!clock) clock = new Clock({config, genesisTime: this.genesisTime, signal});
 
     const preAggregateCutOffTime = (2 / 3) * this.config.SECONDS_PER_SLOT;
-    this.attestationPool = new AttestationPool(clock, preAggregateCutOffTime, this.opts?.preaggregateSlotDistance);
+    this.attestationPool = new AttestationPool(
+      this.config,
+      clock,
+      preAggregateCutOffTime,
+      this.opts?.preaggregateSlotDistance
+    );
+    this.aggregatedAttestationPool = new AggregatedAttestationPool(this.config);
     this.syncCommitteeMessagePool = new SyncCommitteeMessagePool(
       clock,
       preAggregateCutOffTime,

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -227,7 +227,7 @@ export class BeaconChain implements IBeaconChain {
 
     const preAggregateCutOffTime = (2 / 3) * this.config.SECONDS_PER_SLOT;
     this.attestationPool = new AttestationPool(
-      this.config,
+      config,
       clock,
       preAggregateCutOffTime,
       this.opts?.preaggregateSlotDistance

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -145,7 +145,7 @@ export class AggregatedAttestationPool {
 
     if (isForkPostElectra(this.config.getForkName(slot))) {
       if (!isElectraAttestation(attestation)) {
-        throw new Error("Attestation should be type electra.Attestation");
+        throw Error(`Attestation should be type electra.Attestation for slot ${slot}`);
       }
       committeeIndex = attestation.committeeBits.getSingleTrueBit();
     } else {

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -145,12 +145,12 @@ export class AggregatedAttestationPool {
 
     if (isForkPostElectra(this.config.getForkName(slot))) {
       if (!isElectraAttestation(attestation)) {
-        throw new Error(`Expect electra attestation at slot ${slot} but received phase0 attestation.`);
+        throw new Error("Attestation should be type electra.Attestation");
       }
       committeeIndex = attestation.committeeBits.getSingleTrueBit();
     } else {
       if (isElectraAttestation(attestation)) {
-        throw new Error(`Expect phase0 attestation at slot ${slot} but received electra attestation.`);
+        throw new Error("Attestation should be type phase0.Attestation");
       }
       committeeIndex = attestation.data.index;
     }

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -527,7 +527,6 @@ export class MatchingDataAttestationGroup {
         (isForkPostElectra(fork) && !isElectraAttestation(attestation)) ||
         (!isForkPostElectra(fork) && isElectraAttestation(attestation))
       ) {
-        // TODO Electra: log warning
         continue;
       }
 
@@ -539,7 +538,6 @@ export class MatchingDataAttestationGroup {
         }
       }
 
-      // if fork >= electra, should return electra-only attestations
       if (notSeenAttesterCount > 0) {
         attestations.push({attestation, notSeenAttesterCount});
       }

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -525,7 +525,7 @@ export class MatchingDataAttestationGroup {
   getAttestationsForBlock(fork: ForkName, notSeenAttestingIndices: Set<number>): AttestationNonParticipant[] {
     const attestations: AttestationNonParticipant[] = [];
     const forkSeq = ForkSeq[fork];
-    const isAfterElectra = forkSeq >= ForkSeq.electra;
+    const isPostElectra = forkSeq >= ForkSeq.electra;
     for (const {attestation} of this.attestations) {
       if (
         (isAfterElectra && !isElectraAttestation(attestation)) ||

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -144,11 +144,10 @@ export class AggregatedAttestationPool {
     let committeeIndex;
 
     if (isForkPostElectra(this.config.getForkName(slot))) {
-      if (isElectraAttestation(attestation)) {
-        committeeIndex = attestation.committeeBits.getSingleTrueBit();
-      } else {
+      if (!isElectraAttestation(attestation)) {
         throw new Error(`Expect electra attestation but received phase0 attestation. Slot: ${slot}`);
       }
+      committeeIndex = attestation.committeeBits.getSingleTrueBit();
     } else {
       if (!isElectraAttestation(attestation)) {
         committeeIndex = attestation.data.index;

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -145,15 +145,14 @@ export class AggregatedAttestationPool {
 
     if (isForkPostElectra(this.config.getForkName(slot))) {
       if (!isElectraAttestation(attestation)) {
-        throw new Error(`Expect electra attestation but received phase0 attestation. Slot: ${slot}`);
+        throw new Error(`Expect electra attestation at slot ${slot} but received phase0 attestation.`);
       }
       committeeIndex = attestation.committeeBits.getSingleTrueBit();
     } else {
-      if (!isElectraAttestation(attestation)) {
-        committeeIndex = attestation.data.index;
-      } else {
-        throw new Error(`Expect phase0 attestation but received electra attestation. Slot: ${slot}`);
+      if (isElectraAttestation(attestation)) {
+        throw new Error(`Expect phase0 attestation at slot ${slot} but received electra attestation.`);
       }
+      committeeIndex = attestation.data.index;
     }
     // this should not happen because attestation should be validated before reaching this
     assert.notNull(committeeIndex, "Committee index should not be null in aggregated attestation pool");

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -150,7 +150,7 @@ export class AggregatedAttestationPool {
       committeeIndex = attestation.committeeBits.getSingleTrueBit();
     } else {
       if (isElectraAttestation(attestation)) {
-        throw new Error("Attestation should be type phase0.Attestation");
+        throw Error(`Attestation should be type phase0.Attestation for slot ${slot}`);
       }
       committeeIndex = attestation.data.index;
     }
@@ -522,10 +522,11 @@ export class MatchingDataAttestationGroup {
    */
   getAttestationsForBlock(fork: ForkName, notSeenAttestingIndices: Set<number>): AttestationNonParticipant[] {
     const attestations: AttestationNonParticipant[] = [];
+    const isPostElectra = isForkPostElectra(fork);
     for (const {attestation} of this.attestations) {
       if (
-        (isForkPostElectra(fork) && !isElectraAttestation(attestation)) ||
-        (!isForkPostElectra(fork) && isElectraAttestation(attestation))
+        (isPostElectra && !isElectraAttestation(attestation)) ||
+        (!isPostElectra && isElectraAttestation(attestation))
       ) {
         continue;
       }
@@ -543,7 +544,7 @@ export class MatchingDataAttestationGroup {
       }
     }
 
-    const maxAttestation = isForkPostElectra(fork) ? MAX_ATTESTATIONS_PER_GROUP_ELECTRA : MAX_ATTESTATIONS_PER_GROUP;
+    const maxAttestation = isPostElectra ? MAX_ATTESTATIONS_PER_GROUP_ELECTRA : MAX_ATTESTATIONS_PER_GROUP;
     if (attestations.length <= maxAttestation) {
       return attestations;
     } else {

--- a/packages/beacon-node/src/chain/opPools/attestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/attestationPool.ts
@@ -157,7 +157,8 @@ export class AttestationPool {
    */
   getAggregate(slot: Slot, committeeIndex: CommitteeIndex, dataRootHex: RootHex): Attestation | null {
     const fork = this.config.getForkName(slot);
-    committeeIndex = isForkPostElectra(fork) ? committeeIndex : null;
+    const isPostElectra = isForkPostElectra(fork);
+    committeeIndex = isPostElectra ? committeeIndex : null;
 
     const aggregate = this.aggregateByIndexByRootBySlot.get(slot)?.get(dataRootHex)?.get(committeeIndex);
     if (!aggregate) {
@@ -165,7 +166,7 @@ export class AttestationPool {
       return null;
     }
 
-    if (isForkPostElectra(fork)) {
+    if (isPostElectra) {
       assert.true(isElectraAggregate(aggregate), "Aggregate should be type AggregateFastElectra");
     } else {
       assert.true(!isElectraAggregate(aggregate), "Aggregate should be type AggregateFastPhase0");

--- a/packages/beacon-node/src/chain/opPools/utils.ts
+++ b/packages/beacon-node/src/chain/opPools/utils.ts
@@ -2,6 +2,7 @@ import {Signature} from "@chainsafe/blst";
 import {BLS_WITHDRAWAL_PREFIX} from "@lodestar/params";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {Slot, capella} from "@lodestar/types";
+import {AggregateFast, AggregateFastElectra} from "./attestationPool.js";
 
 /**
  * Prune a Map indexed by slot to keep the most recent slots, up to `slotsRetained`
@@ -57,4 +58,8 @@ export function isValidBlsToExecutionChangeForBlockInclusion(
   //    If valid before will always be valid in the future, no need to check
 
   return true;
+}
+
+export function isElectraAggregate(aggregate: AggregateFast): aggregate is AggregateFastElectra {
+  return (aggregate as AggregateFastElectra).committeeBits !== undefined;
 }

--- a/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
@@ -2,8 +2,13 @@ import {BitArray} from "@chainsafe/ssz";
 import {CommitteeIndex, phase0, RootHex, Slot} from "@lodestar/types";
 import {MapDef} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
-import {SeenAttDataKey} from "../../util/sszBytes.js";
 import {InsertOutcome} from "../opPools/types.js";
+
+export type SeenAttDataKey = AttDataBase64 | AttDataCommitteeBitsBase64;
+// pre-electra, AttestationData is used to cache attestations
+type AttDataBase64 = string;
+// electra, AttestationData + CommitteeBits are used to cache attestations
+type AttDataCommitteeBitsBase64 = string;
 
 export type AttestationDataCacheEntry = {
   // part of shuffling data, so this does not take memory

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -9,11 +9,11 @@ import {
 import {IBeaconChain} from "..";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors/index.js";
 import {RegenCaller} from "../regen/index.js";
-import {getSeenAttDataKeyFromSignedAggregateAndProof} from "../../util/sszBytes.js";
 import {getSelectionProofSignatureSet, getAggregateAndProofSignatureSet} from "./signatureSets/index.js";
 import {
   getAttestationDataSigningRoot,
   getCommitteeIndices,
+  getSeenAttDataKeyFromSignedAggregateAndProof,
   getShufflingForAttestationVerification,
   verifyHeadBlockAndTargetRoot,
   verifyPropagationSlotRange,
@@ -71,9 +71,7 @@ async function validateAggregateAndProof(
   const attData = aggregate.data;
   const attSlot = attData.slot;
 
-  const seenAttDataKey = serializedData
-    ? getSeenAttDataKeyFromSignedAggregateAndProof(ForkSeq[fork], serializedData)
-    : null;
+  const seenAttDataKey = serializedData ? getSeenAttDataKeyFromSignedAggregateAndProof(fork, serializedData) : null;
   const cachedAttData = seenAttDataKey ? chain.seenAttestationDatas.get(attSlot, seenAttDataKey) : null;
 
   let attIndex;

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -13,7 +13,14 @@ import {
   IndexedAttestation,
 } from "@lodestar/types";
 import {ProtoBlock} from "@lodestar/fork-choice";
-import {ATTESTATION_SUBNET_COUNT, SLOTS_PER_EPOCH, ForkName, ForkSeq, DOMAIN_BEACON_ATTESTER} from "@lodestar/params";
+import {
+  ATTESTATION_SUBNET_COUNT,
+  SLOTS_PER_EPOCH,
+  ForkName,
+  ForkSeq,
+  DOMAIN_BEACON_ATTESTER,
+  isForkPostElectra,
+} from "@lodestar/params";
 import {
   computeEpochAtSlot,
   createSingleSignatureSetFromComponents,
@@ -29,12 +36,15 @@ import {AttestationError, AttestationErrorCode, GossipAction} from "../errors/in
 import {MAXIMUM_GOSSIP_CLOCK_DISPARITY_SEC} from "../../constants/index.js";
 import {RegenCaller} from "../regen/index.js";
 import {
-  SeenAttDataKey,
   getAggregationBitsFromAttestationSerialized,
-  getSeenAttDataKey,
+  getAttDataFromAttestationSerialized,
+  getAttDataFromSignedAggregateAndProofElectra,
+  getCommitteeBitsFromAttestationSerialized,
+  getCommitteeBitsFromSignedAggregateAndProofElectra,
+  getAttDataFromSignedAggregateAndProofPhase0,
   getSignatureFromAttestationSerialized,
 } from "../../util/sszBytes.js";
-import {AttestationDataCacheEntry} from "../seenCache/seenAttestationData.js";
+import {AttestationDataCacheEntry, SeenAttDataKey} from "../seenCache/seenAttestationData.js";
 import {sszDeserializeAttestation} from "../../network/gossip/topic.js";
 import {Result, wrapError} from "../../util/wrapError.js";
 import {IBeaconChain} from "../interface.js";
@@ -66,7 +76,7 @@ export type GossipAttestation = {
   attSlot: Slot;
   // for old LIFO linear gossip queue we don't have attDataBase64
   // for indexed gossip queue we have attDataBase64
-  seenAttestationKey?: SeenAttDataKey | null;
+  attDataBase64?: SeenAttDataKey | null;
 };
 
 export type Step0Result = AttestationValidationResult & {
@@ -269,11 +279,7 @@ async function validateGossipAttestationNoSignatureCheck(
   if (attestationOrBytes.serializedData) {
     // gossip
     const attSlot = attestationOrBytes.attSlot;
-    attDataKey =
-      // we always have seenAttestationKey from the IndexedGossipQueue, getSeenAttDataKey() just for backward
-      // compatible in case beaconAttestationBatchValidation is false
-      // TODO: remove beaconAttestationBatchValidation flag since the batch attestation is stable
-      attestationOrBytes.seenAttestationKey ?? getSeenAttDataKey(ForkSeq[fork], attestationOrBytes.serializedData);
+    attDataKey = getSeenAttDataKeyFromGossipAttestation(fork, attestationOrBytes);
     const cachedAttData = attDataKey !== null ? chain.seenAttestationDatas.get(attSlot, attDataKey) : null;
     if (cachedAttData === null) {
       const attestation = sszDeserializeAttestation(fork, attestationOrBytes.serializedData);
@@ -788,4 +794,46 @@ export function computeSubnetForSlot(shuffling: EpochShuffling, slot: number, co
   const slotsSinceEpochStart = slot % SLOTS_PER_EPOCH;
   const committeesSinceEpochStart = shuffling.committeesPerSlot * slotsSinceEpochStart;
   return (committeesSinceEpochStart + committeeIndex) % ATTESTATION_SUBNET_COUNT;
+}
+
+/**
+ * Return fork-dependent seen attestation key
+ *   - for pre-electra, it's the AttestationData base64
+ *   - for electra and later, it's the AttestationData base64 + committeeBits base64
+ *
+ * we always have attDataBase64 from the IndexedGossipQueue, getAttDataFromAttestationSerialized() just for backward compatible when beaconAttestationBatchValidation is false
+ * TODO: remove beaconAttestationBatchValidation flag since the batch attestation is stable
+ */
+export function getSeenAttDataKeyFromGossipAttestation(
+  fork: ForkName,
+  attestation: GossipAttestation
+): SeenAttDataKey | null {
+  const {attDataBase64, serializedData} = attestation;
+  if (isForkPostElectra(fork)) {
+    const attData = attDataBase64 ?? getAttDataFromAttestationSerialized(serializedData);
+    const committeeBits = getCommitteeBitsFromAttestationSerialized(serializedData);
+    return attData && committeeBits ? attDataBase64 + committeeBits : null;
+  }
+
+  // pre-electra
+  return attDataBase64 ?? getAttDataFromAttestationSerialized(serializedData);
+}
+
+/**
+ * Extract attestation data key from SignedAggregateAndProof Uint8Array to use cached data from SeenAttestationDatas
+ *   - for pre-electra, it's the AttestationData base64
+ *   - for electra and later, it's the AttestationData base64 + committeeBits base64
+ */
+export function getSeenAttDataKeyFromSignedAggregateAndProof(
+  fork: ForkName,
+  aggregateAndProof: Uint8Array
+): SeenAttDataKey | null {
+  if (isForkPostElectra(fork)) {
+    const attData = getAttDataFromSignedAggregateAndProofElectra(aggregateAndProof);
+    const committeeBits = getCommitteeBitsFromSignedAggregateAndProofElectra(aggregateAndProof);
+    return attData && committeeBits ? attData + committeeBits : null;
+  }
+
+  // pre-electra
+  return getAttDataFromSignedAggregateAndProofPhase0(aggregateAndProof);
 }

--- a/packages/beacon-node/src/network/processor/gossipQueues/index.ts
+++ b/packages/beacon-node/src/network/processor/gossipQueues/index.ts
@@ -1,8 +1,7 @@
 import {mapValues} from "@lodestar/utils";
-import {ForkSeq} from "@lodestar/params";
 import {GossipType} from "../../gossip/interface.js";
 import {PendingGossipsubMessage} from "../types.js";
-import {getSeenAttDataKey} from "../../../util/sszBytes.js";
+import {getGossipAttestationIndex} from "../../../util/sszBytes.js";
 import {LinearGossipQueue} from "./linear.js";
 import {
   DropType,
@@ -88,8 +87,8 @@ const indexedGossipQueueOpts: {
   [GossipType.beacon_attestation]: {
     maxLength: 24576,
     indexFn: (item: PendingGossipsubMessage) => {
-      const {topic, msg} = item;
-      return getSeenAttDataKey(ForkSeq[topic.fork], msg.data);
+      // Note indexFn is fork agnostic despite changes introduced in Electra
+      return getGossipAttestationIndex(item.msg.data);
     },
     minChunkSize: MIN_SIGNATURE_SETS_TO_BATCH_VERIFY,
     maxChunkSize: MAX_GOSSIP_ATTESTATION_BATCH_SIZE,

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -111,6 +111,13 @@ export function getSeenAttDataKeyPhase0(data: Uint8Array): AttDataBase64 | null 
 }
 
 /**
+ * Alias of `getSeenAttDataKeyPhase0` specifically for batch handling indexing in gossip queue
+ */
+export function getGossipAttestationIndex(data: Uint8Array): AttDataBase64 | null {
+  return getSeenAttDataKeyPhase0(data);
+}
+
+/**
  * Extract aggregation bits from attestation serialized bytes.
  * Return null if data is not long enough to extract aggregation bits.
  */

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -295,7 +295,7 @@ function checkSlotHighBytes(data: Uint8Array, offset: number): boolean {
 }
 
 /**
- * base64 is a bit efficient than hex
+ * base64 is a bit more efficient than hex
  */
 function toBase64(data: Uint8Array): string {
   return Buffer.from(data.buffer, data.byteOffset, data.byteLength).toString("base64");

--- a/packages/beacon-node/test/mocks/clock.ts
+++ b/packages/beacon-node/test/mocks/clock.ts
@@ -74,5 +74,6 @@ export function getMockedClock(): Mocked<IClock> {
     },
     currentSlotWithGossipDisparity: undefined,
     isCurrentSlotGivenGossipDisparity: vi.fn(),
+    secFromSlot: vi.fn(),
   } as unknown as Mocked<IClock>;
 }

--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -124,7 +124,7 @@ vi.mock("../../src/chain/chain.js", async (importActual) => {
       // @ts-expect-error
       eth1: new Eth1ForBlockProduction(),
       opPool: new OpPool(),
-      aggregatedAttestationPool: new AggregatedAttestationPool(),
+      aggregatedAttestationPool: new AggregatedAttestationPool(config),
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       beaconProposerCache: new BeaconProposerCache(),

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -10,8 +10,9 @@ import {
 import {HISTORICAL_ROOTS_LIMIT, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ExecutionStatus, ForkChoice, IForkChoiceStore, ProtoArray, DataAvailabilityStatus} from "@lodestar/fork-choice";
 import {ssz} from "@lodestar/types";
-// eslint-disable-next-line import/no-relative-packages
-import {generatePerfTestCachedStateAltair} from "../../../../../state-transition/test/perf/util.js";
+
+import {createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {generatePerfTestCachedStateAltair} from "@lodestar/state-transition/test/perf/util.js";
 import {AggregatedAttestationPool} from "../../../../src/chain/opPools/aggregatedAttestationPool.js";
 import {computeAnchorCheckpoint} from "../../../../src/chain/initState.js";
 
@@ -230,7 +231,10 @@ function getAggregatedAttestationPool(
   numMissedVotes: number,
   numBadVotes: number
 ): AggregatedAttestationPool {
-  const pool = new AggregatedAttestationPool();
+  const config = createChainForkConfig({
+    ...defaultChainConfig,
+  });
+  const pool = new AggregatedAttestationPool(config);
   for (let epochSlot = 0; epochSlot < SLOTS_PER_EPOCH; epochSlot++) {
     const slot = state.slot - 1 - epochSlot;
     const epoch = computeEpochAtSlot(slot);

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -231,9 +231,8 @@ function getAggregatedAttestationPool(
   numMissedVotes: number,
   numBadVotes: number
 ): AggregatedAttestationPool {
-  const config = createChainForkConfig({
-    ...defaultChainConfig,
-  });
+  const config = createChainForkConfig(defaultChainConfig);
+
   const pool = new AggregatedAttestationPool(config);
   for (let epochSlot = 0; epochSlot < SLOTS_PER_EPOCH; epochSlot++) {
     const slot = state.slot - 1 - epochSlot;

--- a/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
+++ b/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
@@ -5,7 +5,7 @@ import {ssz} from "@lodestar/types";
 import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../state-transition/test/perf/util.js";
 import {validateAttestation, validateGossipAttestationsSameAttData} from "../../../../src/chain/validation/index.js";
 import {getAttestationValidData} from "../../../utils/validationData/attestation.js";
-import {getSeenAttDataKeyPhase0} from "../../../../src/util/sszBytes.js";
+import {getAttDataFromAttestationSerialized} from "../../../../src/util/sszBytes.js";
 
 describe("validate gossip attestation", () => {
   setBenchOpts({
@@ -42,7 +42,7 @@ describe("validate gossip attestation", () => {
           attestation: null,
           serializedData,
           attSlot,
-          seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+          attDataBase64: getAttDataFromAttestationSerialized(serializedData),
         },
         subnet0
       );
@@ -67,7 +67,7 @@ describe("validate gossip attestation", () => {
         attestation: null,
         serializedData,
         attSlot,
-        attDataBase64: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       };
     });
 

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@lodestar/params";
 import {ssz, phase0} from "@lodestar/types";
 import {CachedBeaconStateAltair} from "@lodestar/state-transition/src/types.js";
+import {createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {MockedForkChoice, getMockedForkChoice} from "../../../mocks/mockedBeaconChain.js";
 import {
   aggregateConsolidation,
@@ -36,6 +37,9 @@ const validSignature = fromHexString(
 describe("AggregatedAttestationPool", function () {
   let pool: AggregatedAttestationPool;
   const fork = ForkName.altair;
+  const config = createChainForkConfig({
+    ...defaultChainConfig,
+  });
   const altairForkEpoch = 2020;
   const currentEpoch = altairForkEpoch + 10;
   const currentSlot = SLOTS_PER_EPOCH * currentEpoch;
@@ -79,7 +83,7 @@ describe("AggregatedAttestationPool", function () {
   let forkchoiceStub: MockedForkChoice;
 
   beforeEach(() => {
-    pool = new AggregatedAttestationPool();
+    pool = new AggregatedAttestationPool(config);
     altairState = originalState.clone();
     forkchoiceStub = getMockedForkChoice();
   });

--- a/packages/beacon-node/test/unit/chain/opPools/attestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/attestationPool.test.ts
@@ -1,0 +1,120 @@
+import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {describe, it, expect, beforeEach, vi} from "vitest";
+import {GENESIS_SLOT, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
+import {createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {InsertOutcome} from "../../../../src/chain/opPools/types.js";
+import {AttestationPool} from "../../../../src/chain/opPools/attestationPool.js";
+import {getMockedClock} from "../../../mocks/clock.js";
+
+/** Valid signature of random data to prevent BLS errors */
+export const validSignature = fromHexString(
+  "0xb2afb700f6c561ce5e1b4fedaec9d7c06b822d38c720cf588adfda748860a940adf51634b6788f298c552de40183b5a203b2bbe8b7dd147f0bb5bc97080a12efbb631c8888cb31a99cc4706eb3711865b8ea818c10126e4d818b542e9dbf9ae8"
+);
+
+describe("AttestationPool", function () {
+  /* eslint-disable @typescript-eslint/naming-convention */
+  const config = createChainForkConfig({
+    ...defaultChainConfig,
+    ELECTRA_FORK_EPOCH: 5,
+    DENEB_FORK_EPOCH: 4,
+    CAPELLA_FORK_EPOCH: 3,
+    BELLATRIX_FORK_EPOCH: 2,
+    ALTAIR_FORK_EPOCH: 1,
+  });
+  const clockStub = getMockedClock();
+  vi.spyOn(clockStub, "secFromSlot").mockReturnValue(0);
+
+  const cutOffSecFromSlot = (2 / 3) * config.SECONDS_PER_SLOT;
+
+  // Mock attestations
+  const electraAttestationData = {
+    ...ssz.phase0.AttestationData.defaultValue(),
+    slot: config.ELECTRA_FORK_EPOCH * SLOTS_PER_EPOCH,
+  };
+  const electraAttestation = {
+    ...ssz.electra.Attestation.defaultValue(),
+    data: electraAttestationData,
+    signature: validSignature,
+  };
+  const phase0AttestationData = {...ssz.phase0.AttestationData.defaultValue(), slot: GENESIS_SLOT};
+  const phase0Attestation = {
+    ...ssz.phase0.Attestation.defaultValue(),
+    data: phase0AttestationData,
+    signature: validSignature,
+  };
+
+  let pool: AttestationPool;
+
+  beforeEach(() => {
+    pool = new AttestationPool(config, clockStub, cutOffSecFromSlot);
+  });
+
+  it("add correct electra attestation", () => {
+    const committeeIndex = 0;
+    const attDataRootHex = toHexString(ssz.phase0.AttestationData.hashTreeRoot(electraAttestation.data));
+    const outcome = pool.add(committeeIndex, electraAttestation, attDataRootHex);
+
+    expect(outcome).equal(InsertOutcome.NewData);
+    expect(pool.getAggregate(electraAttestationData.slot, committeeIndex, attDataRootHex)).toEqual(electraAttestation);
+  });
+
+  it("add correct phase0 attestation", () => {
+    const committeeIndex = null;
+    const attDataRootHex = toHexString(ssz.phase0.AttestationData.hashTreeRoot(phase0Attestation.data));
+    const outcome = pool.add(committeeIndex, phase0Attestation, attDataRootHex);
+
+    expect(outcome).equal(InsertOutcome.NewData);
+    expect(pool.getAggregate(phase0AttestationData.slot, committeeIndex, attDataRootHex)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, 10, attDataRootHex)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, 42, attDataRootHex)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, null, attDataRootHex)).toEqual(phase0Attestation);
+  });
+
+  it("add electra attestation without committee index", () => {
+    const committeeIndex = null;
+    const attDataRootHex = toHexString(ssz.phase0.AttestationData.hashTreeRoot(electraAttestation.data));
+
+    expect(() => pool.add(committeeIndex, electraAttestation, attDataRootHex)).toThrow();
+    expect(pool.getAggregate(electraAttestationData.slot, committeeIndex, attDataRootHex)).toBeNull();
+  });
+
+  it("add phase0 attestation with committee index", () => {
+    const committeeIndex = 0;
+    const attDataRootHex = toHexString(ssz.phase0.AttestationData.hashTreeRoot(phase0Attestation.data));
+    const outcome = pool.add(committeeIndex, phase0Attestation, attDataRootHex);
+
+    expect(outcome).equal(InsertOutcome.NewData);
+    expect(pool.getAggregate(phase0AttestationData.slot, committeeIndex, attDataRootHex)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, 123, attDataRootHex)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, 456, attDataRootHex)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, null, attDataRootHex)).toEqual(phase0Attestation);
+  });
+
+  it("add electra attestation with phase0 slot", () => {
+    const electraAttestationDataWithPhase0Slot = {...ssz.phase0.AttestationData.defaultValue(), slot: GENESIS_SLOT};
+    const attestation = {
+      ...ssz.electra.Attestation.defaultValue(),
+      data: electraAttestationDataWithPhase0Slot,
+      signature: validSignature,
+    };
+    const attDataRootHex = toHexString(ssz.phase0.AttestationData.hashTreeRoot(electraAttestationDataWithPhase0Slot));
+
+    expect(() => pool.add(0, attestation, attDataRootHex)).toThrow();
+  });
+
+  it("add phase0 attestation with electra slot", () => {
+    const phase0AttestationDataWithElectraSlot = {
+      ...ssz.phase0.AttestationData.defaultValue(),
+      slot: config.ELECTRA_FORK_EPOCH * SLOTS_PER_EPOCH,
+    };
+    const attestation = {
+      ...ssz.phase0.Attestation.defaultValue(),
+      data: phase0AttestationDataWithElectraSlot,
+      signature: validSignature,
+    };
+    const attDataRootHex = toHexString(ssz.phase0.AttestationData.hashTreeRoot(phase0AttestationDataWithElectraSlot));
+
+    expect(() => pool.add(0, attestation, attDataRootHex)).toThrow();
+  });
+});

--- a/packages/beacon-node/test/unit/chain/validation/attestation/validateAttestation.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation/validateAttestation.test.ts
@@ -1,6 +1,6 @@
 import {BitArray} from "@chainsafe/ssz";
-import {describe, it} from "vitest";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {describe, expect, it} from "vitest";
+import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 // eslint-disable-next-line import/no-relative-packages
 import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../../state-transition/test/perf/util.js";
@@ -9,14 +9,17 @@ import {IBeaconChain} from "../../../../../src/chain/index.js";
 import {
   ApiAttestation,
   GossipAttestation,
+  getSeenAttDataKeyFromGossipAttestation,
+  getSeenAttDataKeyFromSignedAggregateAndProof,
   validateApiAttestation,
   validateAttestation,
 } from "../../../../../src/chain/validation/index.js";
-import {getSeenAttDataKeyPhase0} from "../../../../../src/util/sszBytes.js";
+import {getAttDataFromAttestationSerialized} from "../../../../../src/util/sszBytes.js";
 import {memoOnce} from "../../../../utils/cache.js";
 import {expectRejectedWithLodestarError} from "../../../../utils/errors.js";
 import {AttestationValidDataOpts, getAttestationValidData} from "../../../../utils/validationData/attestation.js";
 
+// TODO: more tests for electra
 describe("validateAttestation", () => {
   const vc = 64;
   const stateSlot = 100;
@@ -52,7 +55,7 @@ describe("validateAttestation", () => {
     const {chain, subnet} = getValidData();
     await expectGossipError(
       chain,
-      {attestation: null, serializedData: Buffer.alloc(0), attSlot: 0, seenAttestationKey: "invalid"},
+      {attestation: null, serializedData: Buffer.alloc(0), attSlot: 0, attDataBase64: "invalid"},
       subnet,
       GossipErrorCode.INVALID_SERIALIZED_BYTES_ERROR_CODE
     );
@@ -72,7 +75,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.BAD_TARGET_EPOCH
@@ -91,7 +94,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.PAST_SLOT
@@ -110,7 +113,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.FUTURE_SLOT
@@ -135,7 +138,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
@@ -155,7 +158,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
@@ -179,7 +182,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.UNKNOWN_OR_PREFINALIZED_BEACON_BLOCK_ROOT
@@ -199,7 +202,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.INVALID_TARGET_ROOT
@@ -226,7 +229,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS
@@ -245,7 +248,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       invalidSubnet,
       AttestationErrorCode.INVALID_SUBNET_ID
@@ -265,7 +268,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.ATTESTATION_ALREADY_KNOWN
@@ -287,7 +290,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.INVALID_SIGNATURE
@@ -313,4 +316,54 @@ describe("validateAttestation", () => {
     const fork = chain.config.getForkName(stateSlot);
     await expectRejectedWithLodestarError(validateAttestation(fork, chain, attestationOrBytes, subnet), errorCode);
   }
+});
+
+describe("getSeenAttDataKey", () => {
+  const slot = 100;
+  const index = 0;
+  const blockRoot = Buffer.alloc(32, 1);
+
+  it("phase0", () => {
+    const attestationData = ssz.phase0.AttestationData.defaultValue();
+    attestationData.slot = slot;
+    attestationData.index = index;
+    attestationData.beaconBlockRoot = blockRoot;
+    const attestation = ssz.phase0.Attestation.defaultValue();
+    attestation.data = attestationData;
+    const attDataBase64 = Buffer.from(ssz.phase0.AttestationData.serialize(attestationData)).toString("base64");
+    const attestationBytes = ssz.phase0.Attestation.serialize(attestation);
+    const gossipAttestation = {attDataBase64, serializedData: attestationBytes, attSlot: slot} as GossipAttestation;
+
+    const signedAggregateAndProof = ssz.phase0.SignedAggregateAndProof.defaultValue();
+    signedAggregateAndProof.message.aggregate.data.slot = slot;
+    signedAggregateAndProof.message.aggregate.data.index = index;
+    signedAggregateAndProof.message.aggregate.data.beaconBlockRoot = blockRoot;
+    const aggregateAndProofBytes = ssz.phase0.SignedAggregateAndProof.serialize(signedAggregateAndProof);
+
+    expect(getSeenAttDataKeyFromGossipAttestation(ForkName.phase0, gossipAttestation)).toEqual(
+      getSeenAttDataKeyFromSignedAggregateAndProof(ForkName.phase0, aggregateAndProofBytes)
+    );
+  });
+
+  it("electra", () => {
+    const attestationData = ssz.phase0.AttestationData.defaultValue();
+    attestationData.slot = slot;
+    attestationData.index = index;
+    attestationData.beaconBlockRoot = blockRoot;
+    const attestation = ssz.electra.Attestation.defaultValue();
+    attestation.data = attestationData;
+    const attDataBase64 = Buffer.from(ssz.phase0.AttestationData.serialize(attestationData)).toString("base64");
+    const attestationBytes = ssz.electra.Attestation.serialize(attestation);
+    const gossipAttestation = {attDataBase64, serializedData: attestationBytes, attSlot: slot} as GossipAttestation;
+
+    const signedAggregateAndProof = ssz.electra.SignedAggregateAndProof.defaultValue();
+    signedAggregateAndProof.message.aggregate.data.slot = slot;
+    signedAggregateAndProof.message.aggregate.data.index = index;
+    signedAggregateAndProof.message.aggregate.data.beaconBlockRoot = blockRoot;
+    const aggregateAndProofBytes = ssz.electra.SignedAggregateAndProof.serialize(signedAggregateAndProof);
+
+    expect(getSeenAttDataKeyFromGossipAttestation(ForkName.electra, gossipAttestation)).toEqual(
+      getSeenAttDataKeyFromSignedAggregateAndProof(ForkName.electra, aggregateAndProofBytes)
+    );
+  });
 });

--- a/packages/state-transition/src/block/processAttestationPhase0.ts
+++ b/packages/state-transition/src/block/processAttestationPhase0.ts
@@ -88,7 +88,6 @@ export function validateAttestation(fork: ForkSeq, state: CachedBeaconStateAllFo
   if (fork >= ForkSeq.electra) {
     assert.equal(data.index, 0, `AttestationData.index must be zero: index=${data.index}`);
     const attestationElectra = attestation as electra.Attestation;
-    // TODO Electra: this should be obsolete soon when the spec switches to committeeIndices
     const committeeIndices = attestationElectra.committeeBits.getTrueBitIndexes();
 
     if (committeeIndices.length === 0) {


### PR DESCRIPTION
- Attestation pool
    - Add type check to ensure adding and getting correct attestation type according to the fork
    - `aggregateByIndexByRootBySlot` is modified to allow null committee index to only handle pre-electra attestations. null committee index is not allowed post-electra attestations
- Aggregated attestation pool
    - Add type check to ensure adding and getting correct attestation type according to the fork
- Gossip
     - `beacon_attestation` in gossip queue is indexed by attestation data instead of attestation data + committee bits.
- API
     - Adjust implementations of several APIs to handle correct attestation type: getPoolAttestations, getPoolAttestationsV2, getAggregatedAttestation