### PR TITLE
fix: refactor the blockcontent types as fork aware types for api

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -11,8 +11,10 @@ import {
   BeaconBlockBody,
   SignedBeaconBlockOrContents,
   SignedBlindedBeaconBlock,
+  SignedBlockContents,
+  sszTypesFor,
 } from "@lodestar/types";
-import {ForkName, ForkPreExecution, ForkSeq, isForkExecution} from "@lodestar/params";
+import {ForkName, ForkPreExecution, isForkBlobs, isForkExecution} from "@lodestar/params";
 import {Endpoint, RequestCodec, RouteDefinitions, Schema} from "../../../utils/index.js";
 import {EmptyMeta, EmptyResponseCodec, EmptyResponseData, WithVersion} from "../../../utils/codecs.js";
 import {
@@ -37,19 +39,10 @@ export const BlockHeadersResponseType = new ListCompositeType(BlockHeaderRespons
 export const RootResponseType = new ContainerType({
   root: ssz.Root,
 });
-export const SignedBlockContentsType = new ContainerType(
-  {
-    signedBlock: ssz.deneb.SignedBeaconBlock,
-    kzgProofs: ssz.deneb.KZGProofs,
-    blobs: ssz.deneb.Blobs,
-  },
-  {jsonCase: "eth2"}
-);
 
 export type BlockHeaderResponse = ValueOf<typeof BlockHeaderResponseType>;
 export type BlockHeadersResponse = ValueOf<typeof BlockHeadersResponseType>;
 export type RootResponse = ValueOf<typeof RootResponseType>;
-export type SignedBlockContents = ValueOf<typeof SignedBlockContentsType>;
 
 export type BlockId = RootHex | Slot | "head" | "genesis" | "finalized" | "justified";
 
@@ -297,11 +290,12 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           const slot = isSignedBlockContents(signedBlockOrContents)
             ? signedBlockOrContents.signedBlock.message.slot
             : signedBlockOrContents.message.slot;
+          const fork = config.getForkName(slot);
+
           return {
-            body:
-              config.getForkSeq(slot) < ForkSeq.deneb
-                ? config.getForkTypes(slot).SignedBeaconBlock.toJson(signedBlockOrContents as SignedBeaconBlock)
-                : SignedBlockContentsType.toJson(signedBlockOrContents as SignedBlockContents),
+            body: isForkBlobs(fork)
+              ? sszTypesFor(fork).SignedBlockContents.toJson(signedBlockOrContents as SignedBlockContents)
+              : sszTypesFor(fork).SignedBeaconBlock.toJson(signedBlockOrContents as SignedBeaconBlock),
             headers: {
               [MetaHeader.Version]: config.getForkName(slot),
             },
@@ -321,23 +315,22 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
                 : (body as SignedBeaconBlock).message.slot
             );
           }
-          const forkSeq = config.forks[forkName].seq;
           return {
-            signedBlockOrContents:
-              forkSeq < ForkSeq.deneb
-                ? ssz[forkName].SignedBeaconBlock.fromJson(body)
-                : SignedBlockContentsType.fromJson(body),
+            signedBlockOrContents: isForkBlobs(forkName)
+              ? sszTypesFor(forkName).SignedBlockContents.fromJson(body)
+              : ssz[forkName].SignedBeaconBlock.fromJson(body),
           };
         },
         writeReqSsz: ({signedBlockOrContents}) => {
           const slot = isSignedBlockContents(signedBlockOrContents)
             ? signedBlockOrContents.signedBlock.message.slot
             : signedBlockOrContents.message.slot;
+          const fork = config.getForkName(slot);
+
           return {
-            body:
-              config.getForkSeq(slot) < ForkSeq.deneb
-                ? config.getForkTypes(slot).SignedBeaconBlock.serialize(signedBlockOrContents as SignedBeaconBlock)
-                : SignedBlockContentsType.serialize(signedBlockOrContents as SignedBlockContents),
+            body: isForkBlobs(fork)
+              ? sszTypesFor(fork).SignedBlockContents.serialize(signedBlockOrContents as SignedBlockContents)
+              : sszTypesFor(fork).SignedBeaconBlock.serialize(signedBlockOrContents as SignedBeaconBlock),
             headers: {
               [MetaHeader.Version]: config.getForkName(slot),
             },
@@ -345,12 +338,10 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         },
         parseReqSsz: ({body, headers}) => {
           const forkName = toForkName(fromHeaders(headers, MetaHeader.Version));
-          const forkSeq = config.forks[forkName].seq;
           return {
-            signedBlockOrContents:
-              forkSeq < ForkSeq.deneb
-                ? ssz[forkName].SignedBeaconBlock.deserialize(body)
-                : SignedBlockContentsType.deserialize(body),
+            signedBlockOrContents: isForkBlobs(forkName)
+              ? sszTypesFor(forkName).SignedBlockContents.deserialize(body)
+              : ssz[forkName].SignedBeaconBlock.deserialize(body),
           };
         },
         schema: {
@@ -371,25 +362,23 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           const slot = isSignedBlockContents(signedBlockOrContents)
             ? signedBlockOrContents.signedBlock.message.slot
             : signedBlockOrContents.message.slot;
+          const fork = config.getForkName(slot);
           return {
-            body:
-              config.getForkSeq(slot) < ForkSeq.deneb
-                ? config.getForkTypes(slot).SignedBeaconBlock.toJson(signedBlockOrContents as SignedBeaconBlock)
-                : SignedBlockContentsType.toJson(signedBlockOrContents as SignedBlockContents),
+            body: isForkBlobs(fork)
+              ? sszTypesFor(fork).SignedBlockContents.toJson(signedBlockOrContents as SignedBlockContents)
+              : sszTypesFor(fork).SignedBeaconBlock.toJson(signedBlockOrContents as SignedBeaconBlock),
             headers: {
-              [MetaHeader.Version]: config.getForkName(slot),
+              [MetaHeader.Version]: fork,
             },
             query: {broadcast_validation: broadcastValidation},
           };
         },
         parseReqJson: ({body, headers, query}) => {
           const forkName = toForkName(fromHeaders(headers, MetaHeader.Version));
-          const forkSeq = config.forks[forkName].seq;
           return {
-            signedBlockOrContents:
-              forkSeq < ForkSeq.deneb
-                ? ssz[forkName].SignedBeaconBlock.fromJson(body)
-                : SignedBlockContentsType.fromJson(body),
+            signedBlockOrContents: isForkBlobs(forkName)
+              ? sszTypesFor(forkName).SignedBlockContents.fromJson(body)
+              : ssz[forkName].SignedBeaconBlock.fromJson(body),
             broadcastValidation: query.broadcast_validation as BroadcastValidation,
           };
         },
@@ -397,25 +386,24 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           const slot = isSignedBlockContents(signedBlockOrContents)
             ? signedBlockOrContents.signedBlock.message.slot
             : signedBlockOrContents.message.slot;
+          const fork = config.getForkName(slot);
+
           return {
-            body:
-              config.getForkSeq(slot) < ForkSeq.deneb
-                ? config.getForkTypes(slot).SignedBeaconBlock.serialize(signedBlockOrContents as SignedBeaconBlock)
-                : SignedBlockContentsType.serialize(signedBlockOrContents as SignedBlockContents),
+            body: isForkBlobs(fork)
+              ? sszTypesFor(fork).SignedBlockContents.serialize(signedBlockOrContents as SignedBlockContents)
+              : sszTypesFor(fork).SignedBeaconBlock.serialize(signedBlockOrContents as SignedBeaconBlock),
             headers: {
-              [MetaHeader.Version]: config.getForkName(slot),
+              [MetaHeader.Version]: fork,
             },
             query: {broadcast_validation: broadcastValidation},
           };
         },
         parseReqSsz: ({body, headers, query}) => {
           const forkName = toForkName(fromHeaders(headers, MetaHeader.Version));
-          const forkSeq = config.forks[forkName].seq;
           return {
-            signedBlockOrContents:
-              forkSeq < ForkSeq.deneb
-                ? ssz[forkName].SignedBeaconBlock.deserialize(body)
-                : SignedBlockContentsType.deserialize(body),
+            signedBlockOrContents: isForkBlobs(forkName)
+              ? sszTypesFor(forkName).SignedBlockContents.deserialize(body)
+              : ssz[forkName].SignedBeaconBlock.deserialize(body),
             broadcastValidation: query.broadcast_validation as BroadcastValidation,
           };
         },

--- a/packages/types/src/deneb/sszTypes.ts
+++ b/packages/types/src/deneb/sszTypes.ts
@@ -328,5 +328,5 @@ export const SignedBlockContents = new ContainerType(
     kzgProofs: KZGProofs,
     blobs: Blobs,
   },
-  {typeName: "BlockContents", jsonCase: "eth2"}
+  {typeName: "SignedBlockContents", jsonCase: "eth2"}
 );

--- a/packages/types/src/deneb/sszTypes.ts
+++ b/packages/types/src/deneb/sszTypes.ts
@@ -312,3 +312,21 @@ export const SSEPayloadAttributes = new ContainerType(
   },
   {typeName: "SSEPayloadAttributes", jsonCase: "eth2"}
 );
+
+export const BlockContents = new ContainerType(
+  {
+    block: BeaconBlock,
+    kzgProofs: KZGProofs,
+    blobs: Blobs,
+  },
+  {typeName: "BlockContents", jsonCase: "eth2"}
+);
+
+export const SignedBlockContents = new ContainerType(
+  {
+    signedBlock: SignedBeaconBlock,
+    kzgProofs: KZGProofs,
+    blobs: Blobs,
+  },
+  {typeName: "BlockContents", jsonCase: "eth2"}
+);

--- a/packages/types/src/deneb/types.ts
+++ b/packages/types/src/deneb/types.ts
@@ -1,6 +1,4 @@
 import {ValueOf} from "@chainsafe/ssz";
-import {ForkName} from "@lodestar/params";
-import type {BlockContents} from "../types.js";
 import * as ssz from "./sszTypes.js";
 
 export type KZGProof = ValueOf<typeof ssz.KZGProof>;
@@ -49,4 +47,7 @@ export type LightClientOptimisticUpdate = ValueOf<typeof ssz.LightClientOptimist
 export type LightClientStore = ValueOf<typeof ssz.LightClientStore>;
 
 export type ProducedBlobSidecars = Omit<BlobSidecars, "signedBlockHeader" | "kzgCommitmentInclusionProof">;
-export type Contents = Omit<BlockContents<ForkName.deneb>, "block">;
+
+export type BlockContents = ValueOf<typeof ssz.BlockContents>;
+export type SignedBlockContents = ValueOf<typeof ssz.SignedBlockContents>;
+export type Contents = Omit<BlockContents, "block">;

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -124,12 +124,8 @@ type TypesByFork = {
     BuilderBid: deneb.BuilderBid;
     SignedBuilderBid: deneb.SignedBuilderBid;
     SSEPayloadAttributes: deneb.SSEPayloadAttributes;
-    BlockContents: {block: BeaconBlock<ForkName.deneb>; kzgProofs: deneb.KZGProofs; blobs: deneb.Blobs};
-    SignedBlockContents: {
-      signedBlock: SignedBeaconBlock<ForkName.deneb>;
-      kzgProofs: deneb.KZGProofs;
-      blobs: deneb.Blobs;
-    };
+    BlockContents: deneb.BlockContents;
+    SignedBlockContents: deneb.SignedBlockContents;
     ExecutionPayloadAndBlobsBundle: deneb.ExecutionPayloadAndBlobsBundle;
     BlobsBundle: deneb.BlobsBundle;
     Contents: deneb.Contents;


### PR DESCRIPTION
as noticed by @wemeetagain in electra pr review, this change can be abstracted out in general and propagated against other work like peerdas , epbs while electra branch gets merged