### PR TITLE
fix: use default node image to build docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 # --platform=$BUILDPLATFORM is used build javascript source with host arch
 # Otherwise TS builds on emulated archs and can be extremely slow (+1h)
-FROM --platform=${BUILDPLATFORM:-amd64} node:22.4 as build_src
+FROM --platform=${BUILDPLATFORM:-amd64} node:22.4-slim as build_src
 ARG COMMIT
 WORKDIR /usr/app
 RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -21,7 +21,7 @@ RUN cd packages/cli && GIT_COMMIT=${COMMIT} yarn write-git-data
 
 # Copy built src + node_modules to build native packages for archs different than host.
 # Note: This step is redundant for the host arch
-FROM node:22.4 as build_deps
+FROM node:22.4-slim as build_deps
 WORKDIR /usr/app
 RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -35,7 +35,7 @@ RUN cd node_modules/classic-level && yarn rebuild
 
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)
-FROM node:22.4
+FROM node:22.4-slim
 WORKDIR /usr/app
 COPY --from=build_deps /usr/app .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM --platform=${BUILDPLATFORM:-amd64} node:22.4 as build_src
 ARG COMMIT
 WORKDIR /usr/app
-RUN apk update && apk add --no-cache g++ make python3 py3-setuptools && rm -rf /var/cache/apk/*
+RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY . .
 
@@ -21,9 +21,9 @@ RUN cd packages/cli && GIT_COMMIT=${COMMIT} yarn write-git-data
 
 # Copy built src + node_modules to build native packages for archs different than host.
 # Note: This step is redundant for the host arch
-FROM node:22.4-alpine as build_deps
+FROM node:22.4 as build_deps
 WORKDIR /usr/app
-RUN apk update && apk add --no-cache g++ make python3 py3-setuptools && rm -rf /var/cache/apk/*
+RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build_src /usr/app .
 
@@ -35,7 +35,7 @@ RUN cd node_modules/classic-level && yarn rebuild
 
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)
-FROM node:22.4-alpine
+FROM node:22.4
 WORKDIR /usr/app
 COPY --from=build_deps /usr/app .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 # --platform=$BUILDPLATFORM is used build javascript source with host arch
 # Otherwise TS builds on emulated archs and can be extremely slow (+1h)
-FROM --platform=${BUILDPLATFORM:-amd64} node:22.4-alpine as build_src
+FROM --platform=${BUILDPLATFORM:-amd64} node:22.4 as build_src
 ARG COMMIT
 WORKDIR /usr/app
 RUN apk update && apk add --no-cache g++ make python3 py3-setuptools && rm -rf /var/cache/apk/*
@@ -28,7 +28,7 @@ RUN apk update && apk add --no-cache g++ make python3 py3-setuptools && rm -rf /
 COPY --from=build_src /usr/app .
 
 # Do yarn --force to trigger a rebuild of the native packages
-# Emmulates `yarn rebuild` which is not available in v1 https://yarnpkg.com/cli/rebuild 
+# Emmulates `yarn rebuild` which is not available in v1 https://yarnpkg.com/cli/rebuild
 RUN yarn install --non-interactive --frozen-lockfile --production --force
 # Rebuild leveldb bindings (required for arm64 build)
 RUN cd node_modules/classic-level && yarn rebuild


### PR DESCRIPTION
**Motivation**

- Starting from this release, we use napi-rs version of blst and it's notice a performance difference between docker vs service deployment,  see #7003

**Description**
Two things that may cause the performance issue on docker:
- NodeJS version: the one I run on feat2 is v22.2.0 while Docker image uses v22.4.1
- Node alpine vs default node image. Notice that blst may switch the implementation using `musl` libc in the docker image https://github.com/ChainSafe/blst-ts/blob/f70469ef04507934b38560b94ff9d3897c01bbf3/index.js#L169

this PR uses the default node image which is supposed to have no different to service deployment. The down side is its image size, now it's ~493MB which is >3x the current image size so we need to consider this fact

Closes #7003
