### PR TITLE
fix: getSeenAttDataKey apis

### DIFF
--- a/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
@@ -2,8 +2,13 @@ import {BitArray} from "@chainsafe/ssz";
 import {CommitteeIndex, phase0, RootHex, Slot} from "@lodestar/types";
 import {MapDef} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
-import {SeenAttDataKey} from "../../util/sszBytes.js";
 import {InsertOutcome} from "../opPools/types.js";
+
+export type SeenAttDataKey = AttDataBase64 | AttDataCommitteeBitsBase64;
+// pre-electra, AttestationData is used to cache attestations
+type AttDataBase64 = string;
+// electra, AttestationData + CommitteeBits are used to cache attestations
+type AttDataCommitteeBitsBase64 = string;
 
 export type AttestationDataCacheEntry = {
   // part of shuffling data, so this does not take memory

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -9,11 +9,11 @@ import {
 import {IBeaconChain} from "..";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors/index.js";
 import {RegenCaller} from "../regen/index.js";
-import {getSeenAttDataKeyFromSignedAggregateAndProof} from "../../util/sszBytes.js";
 import {getSelectionProofSignatureSet, getAggregateAndProofSignatureSet} from "./signatureSets/index.js";
 import {
   getAttestationDataSigningRoot,
   getCommitteeIndices,
+  getSeenAttDataKeyFromSignedAggregateAndProof,
   getShufflingForAttestationVerification,
   verifyHeadBlockAndTargetRoot,
   verifyPropagationSlotRange,

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -71,9 +71,7 @@ async function validateAggregateAndProof(
   const attData = aggregate.data;
   const attSlot = attData.slot;
 
-  const seenAttDataKey = serializedData
-    ? getSeenAttDataKeyFromSignedAggregateAndProof(ForkSeq[fork], serializedData)
-    : null;
+  const seenAttDataKey = serializedData ? getSeenAttDataKeyFromSignedAggregateAndProof(fork, serializedData) : null;
   const cachedAttData = seenAttDataKey ? chain.seenAttestationDatas.get(attSlot, seenAttDataKey) : null;
 
   let attIndex;

--- a/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
+++ b/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
@@ -5,7 +5,7 @@ import {ssz} from "@lodestar/types";
 import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../state-transition/test/perf/util.js";
 import {validateAttestation, validateGossipAttestationsSameAttData} from "../../../../src/chain/validation/index.js";
 import {getAttestationValidData} from "../../../utils/validationData/attestation.js";
-import {getSeenAttDataKeyPhase0} from "../../../../src/util/sszBytes.js";
+import {getAttDataFromAttestationSerialized} from "../../../../src/util/sszBytes.js";
 
 describe("validate gossip attestation", () => {
   setBenchOpts({
@@ -42,7 +42,7 @@ describe("validate gossip attestation", () => {
           attestation: null,
           serializedData,
           attSlot,
-          seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+          attDataBase64: getAttDataFromAttestationSerialized(serializedData),
         },
         subnet0
       );
@@ -67,7 +67,7 @@ describe("validate gossip attestation", () => {
         attestation: null,
         serializedData,
         attSlot,
-        attDataBase64: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       };
     });
 

--- a/packages/beacon-node/test/unit/chain/validation/attestation/validateAttestation.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation/validateAttestation.test.ts
@@ -1,6 +1,6 @@
 import {BitArray} from "@chainsafe/ssz";
-import {describe, it} from "vitest";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {describe, expect, it} from "vitest";
+import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 // eslint-disable-next-line import/no-relative-packages
 import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../../state-transition/test/perf/util.js";
@@ -9,14 +9,17 @@ import {IBeaconChain} from "../../../../../src/chain/index.js";
 import {
   ApiAttestation,
   GossipAttestation,
+  getSeenAttDataKeyFromGossipAttestation,
+  getSeenAttDataKeyFromSignedAggregateAndProof,
   validateApiAttestation,
   validateAttestation,
 } from "../../../../../src/chain/validation/index.js";
-import {getSeenAttDataKeyPhase0} from "../../../../../src/util/sszBytes.js";
+import {getAttDataFromAttestationSerialized} from "../../../../../src/util/sszBytes.js";
 import {memoOnce} from "../../../../utils/cache.js";
 import {expectRejectedWithLodestarError} from "../../../../utils/errors.js";
 import {AttestationValidDataOpts, getAttestationValidData} from "../../../../utils/validationData/attestation.js";
 
+// TODO: more tests for electra
 describe("validateAttestation", () => {
   const vc = 64;
   const stateSlot = 100;
@@ -52,7 +55,7 @@ describe("validateAttestation", () => {
     const {chain, subnet} = getValidData();
     await expectGossipError(
       chain,
-      {attestation: null, serializedData: Buffer.alloc(0), attSlot: 0, seenAttestationKey: "invalid"},
+      {attestation: null, serializedData: Buffer.alloc(0), attSlot: 0, attDataBase64: "invalid"},
       subnet,
       GossipErrorCode.INVALID_SERIALIZED_BYTES_ERROR_CODE
     );
@@ -72,7 +75,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.BAD_TARGET_EPOCH
@@ -91,7 +94,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.PAST_SLOT
@@ -110,7 +113,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.FUTURE_SLOT
@@ -135,7 +138,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
@@ -155,7 +158,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
@@ -179,7 +182,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.UNKNOWN_OR_PREFINALIZED_BEACON_BLOCK_ROOT
@@ -199,7 +202,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.INVALID_TARGET_ROOT
@@ -226,7 +229,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS
@@ -245,7 +248,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       invalidSubnet,
       AttestationErrorCode.INVALID_SUBNET_ID
@@ -265,7 +268,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.ATTESTATION_ALREADY_KNOWN
@@ -287,7 +290,7 @@ describe("validateAttestation", () => {
         attestation: null,
         serializedData,
         attSlot: attestation.data.slot,
-        seenAttestationKey: getSeenAttDataKeyPhase0(serializedData),
+        attDataBase64: getAttDataFromAttestationSerialized(serializedData),
       },
       subnet,
       AttestationErrorCode.INVALID_SIGNATURE
@@ -313,4 +316,54 @@ describe("validateAttestation", () => {
     const fork = chain.config.getForkName(stateSlot);
     await expectRejectedWithLodestarError(validateAttestation(fork, chain, attestationOrBytes, subnet), errorCode);
   }
+});
+
+describe("getSeenAttDataKey", () => {
+  const slot = 100;
+  const index = 0;
+  const blockRoot = Buffer.alloc(32, 1);
+
+  it("phase0", () => {
+    const attestationData = ssz.phase0.AttestationData.defaultValue();
+    attestationData.slot = slot;
+    attestationData.index = index;
+    attestationData.beaconBlockRoot = blockRoot;
+    const attestation = ssz.phase0.Attestation.defaultValue();
+    attestation.data = attestationData;
+    const attDataBase64 = Buffer.from(ssz.phase0.AttestationData.serialize(attestationData)).toString("base64");
+    const attestationBytes = ssz.phase0.Attestation.serialize(attestation);
+    const gossipAttestation = {attDataBase64, serializedData: attestationBytes, attSlot: slot} as GossipAttestation;
+
+    const signedAggregateAndProof = ssz.phase0.SignedAggregateAndProof.defaultValue();
+    signedAggregateAndProof.message.aggregate.data.slot = slot;
+    signedAggregateAndProof.message.aggregate.data.index = index;
+    signedAggregateAndProof.message.aggregate.data.beaconBlockRoot = blockRoot;
+    const aggregateAndProofBytes = ssz.phase0.SignedAggregateAndProof.serialize(signedAggregateAndProof);
+
+    expect(getSeenAttDataKeyFromGossipAttestation(ForkSeq.phase0, gossipAttestation)).toEqual(
+      getSeenAttDataKeyFromSignedAggregateAndProof(ForkSeq.phase0, aggregateAndProofBytes)
+    );
+  });
+
+  it("electra", () => {
+    const attestationData = ssz.phase0.AttestationData.defaultValue();
+    attestationData.slot = slot;
+    attestationData.index = index;
+    attestationData.beaconBlockRoot = blockRoot;
+    const attestation = ssz.electra.Attestation.defaultValue();
+    attestation.data = attestationData;
+    const attDataBase64 = Buffer.from(ssz.phase0.AttestationData.serialize(attestationData)).toString("base64");
+    const attestationBytes = ssz.electra.Attestation.serialize(attestation);
+    const gossipAttestation = {attDataBase64, serializedData: attestationBytes, attSlot: slot} as GossipAttestation;
+
+    const signedAggregateAndProof = ssz.electra.SignedAggregateAndProof.defaultValue();
+    signedAggregateAndProof.message.aggregate.data.slot = slot;
+    signedAggregateAndProof.message.aggregate.data.index = index;
+    signedAggregateAndProof.message.aggregate.data.beaconBlockRoot = blockRoot;
+    const aggregateAndProofBytes = ssz.electra.SignedAggregateAndProof.serialize(signedAggregateAndProof);
+
+    expect(getSeenAttDataKeyFromGossipAttestation(ForkSeq.electra, gossipAttestation)).toEqual(
+      getSeenAttDataKeyFromSignedAggregateAndProof(ForkSeq.electra, aggregateAndProofBytes)
+    );
+  });
 });

--- a/packages/beacon-node/test/unit/chain/validation/attestation/validateAttestation.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation/validateAttestation.test.ts
@@ -1,6 +1,6 @@
 import {BitArray} from "@chainsafe/ssz";
 import {describe, expect, it} from "vitest";
-import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 // eslint-disable-next-line import/no-relative-packages
 import {generateTestCachedBeaconStateOnlyValidators} from "../../../../../../state-transition/test/perf/util.js";
@@ -340,8 +340,8 @@ describe("getSeenAttDataKey", () => {
     signedAggregateAndProof.message.aggregate.data.beaconBlockRoot = blockRoot;
     const aggregateAndProofBytes = ssz.phase0.SignedAggregateAndProof.serialize(signedAggregateAndProof);
 
-    expect(getSeenAttDataKeyFromGossipAttestation(ForkSeq.phase0, gossipAttestation)).toEqual(
-      getSeenAttDataKeyFromSignedAggregateAndProof(ForkSeq.phase0, aggregateAndProofBytes)
+    expect(getSeenAttDataKeyFromGossipAttestation(ForkName.phase0, gossipAttestation)).toEqual(
+      getSeenAttDataKeyFromSignedAggregateAndProof(ForkName.phase0, aggregateAndProofBytes)
     );
   });
 
@@ -362,8 +362,8 @@ describe("getSeenAttDataKey", () => {
     signedAggregateAndProof.message.aggregate.data.beaconBlockRoot = blockRoot;
     const aggregateAndProofBytes = ssz.electra.SignedAggregateAndProof.serialize(signedAggregateAndProof);
 
-    expect(getSeenAttDataKeyFromGossipAttestation(ForkSeq.electra, gossipAttestation)).toEqual(
-      getSeenAttDataKeyFromSignedAggregateAndProof(ForkSeq.electra, aggregateAndProofBytes)
+    expect(getSeenAttDataKeyFromGossipAttestation(ForkName.electra, gossipAttestation)).toEqual(
+      getSeenAttDataKeyFromSignedAggregateAndProof(ForkName.electra, aggregateAndProofBytes)
     );
   });
 });

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -84,7 +84,7 @@ describe("attestation SSZ serialized picking", () => {
     }
   });
 
-  it("getAttDataBase64FromAttestationSerialized - invalid data", () => {
+  it("getAttDataFromAttestationSerialized - invalid data", () => {
     const invalidAttDataBase64DataSizes = [0, 4, 100, 128, 131];
     for (const size of invalidAttDataBase64DataSizes) {
       expect(getAttDataFromAttestationSerialized(Buffer.alloc(size))).toBeNull();

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -4,8 +4,8 @@ import {deneb, electra, Epoch, isElectraAttestation, phase0, RootHex, Slot, ssz}
 import {fromHex, toHex} from "@lodestar/utils";
 import {ForkName, MAX_COMMITTEES_PER_SLOT} from "@lodestar/params";
 import {
-  getSeenAttDataKeyPhase0,
-  getSeenAttDataKeyFromSignedAggregateAndProofPhase0,
+  getAttDataFromAttestationSerialized,
+  getAttDataFromSignedAggregateAndProofPhase0,
   getAggregationBitsFromAttestationSerialized as getAggregationBitsFromAttestationSerialized,
   getBlockRootFromAttestationSerialized,
   getBlockRootFromSignedAggregateAndProofSerialized,
@@ -15,7 +15,8 @@ import {
   getSlotFromSignedBeaconBlockSerialized,
   getSlotFromBlobSidecarSerialized,
   getCommitteeBitsFromAttestationSerialized,
-  getSeenAttDataKeyFromSignedAggregateAndProofElectra,
+  getCommitteeBitsFromSignedAggregateAndProofElectra,
+  getAttDataFromSignedAggregateAndProofElectra,
 } from "../../../src/util/sszBytes.js";
 
 describe("attestation SSZ serialized picking", () => {
@@ -53,7 +54,9 @@ describe("attestation SSZ serialized picking", () => {
         expect(getAggregationBitsFromAttestationSerialized(ForkName.electra, bytes)?.toBoolArray()).toEqual(
           attestation.aggregationBits.toBoolArray()
         );
-        expect(getCommitteeBitsFromAttestationSerialized(bytes)).toEqual(attestation.committeeBits);
+        expect(getCommitteeBitsFromAttestationSerialized(bytes)).toEqual(
+          Buffer.from(attestation.committeeBits.uint8Array).toString("base64")
+        );
         expect(getSignatureFromAttestationSerialized(bytes)).toEqual(attestation.signature);
       } else {
         expect(getAggregationBitsFromAttestationSerialized(ForkName.phase0, bytes)?.toBoolArray()).toEqual(
@@ -63,7 +66,7 @@ describe("attestation SSZ serialized picking", () => {
       }
 
       const attDataBase64 = ssz.phase0.AttestationData.serialize(attestation.data);
-      expect(getSeenAttDataKeyPhase0(bytes)).toBe(Buffer.from(attDataBase64).toString("base64"));
+      expect(getAttDataFromAttestationSerialized(bytes)).toBe(Buffer.from(attDataBase64).toString("base64"));
     });
   }
 
@@ -84,7 +87,7 @@ describe("attestation SSZ serialized picking", () => {
   it("getAttDataBase64FromAttestationSerialized - invalid data", () => {
     const invalidAttDataBase64DataSizes = [0, 4, 100, 128, 131];
     for (const size of invalidAttDataBase64DataSizes) {
-      expect(getSeenAttDataKeyPhase0(Buffer.alloc(size))).toBeNull();
+      expect(getAttDataFromAttestationSerialized(Buffer.alloc(size))).toBeNull();
     }
   });
 
@@ -128,9 +131,7 @@ describe("phase0 SignedAggregateAndProof SSZ serialized picking", () => {
       );
 
       const attDataBase64 = ssz.phase0.AttestationData.serialize(signedAggregateAndProof.message.aggregate.data);
-      expect(getSeenAttDataKeyFromSignedAggregateAndProofPhase0(bytes)).toBe(
-        Buffer.from(attDataBase64).toString("base64")
-      );
+      expect(getAttDataFromSignedAggregateAndProofPhase0(bytes)).toBe(Buffer.from(attDataBase64).toString("base64"));
     });
   }
 
@@ -151,7 +152,7 @@ describe("phase0 SignedAggregateAndProof SSZ serialized picking", () => {
   it("getAttDataBase64FromSignedAggregateAndProofSerialized - invalid data", () => {
     const invalidAttDataBase64DataSizes = [0, 4, 100, 128, 339];
     for (const size of invalidAttDataBase64DataSizes) {
-      expect(getSeenAttDataKeyFromSignedAggregateAndProofPhase0(Buffer.alloc(size))).toBeNull();
+      expect(getAttDataFromSignedAggregateAndProofPhase0(Buffer.alloc(size))).toBeNull();
     }
   });
 });
@@ -182,8 +183,11 @@ describe("electra SignedAggregateAndProof SSZ serialized picking", () => {
       const committeeBits = ssz.electra.CommitteeBits.serialize(
         signedAggregateAndProof.message.aggregate.committeeBits
       );
-      const seenKey = Buffer.concat([attDataBase64, committeeBits]).toString("base64");
-      expect(getSeenAttDataKeyFromSignedAggregateAndProofElectra(bytes)).toBe(seenKey);
+
+      expect(getAttDataFromSignedAggregateAndProofElectra(bytes)).toBe(Buffer.from(attDataBase64).toString("base64"));
+      expect(getCommitteeBitsFromSignedAggregateAndProofElectra(bytes)).toBe(
+        Buffer.from(committeeBits).toString("base64")
+      );
     });
   }
 
@@ -204,7 +208,7 @@ describe("electra SignedAggregateAndProof SSZ serialized picking", () => {
   it("getAttDataBase64FromSignedAggregateAndProofSerialized - invalid data", () => {
     const invalidAttDataBase64DataSizes = [0, 4, 100, 128, 339];
     for (const size of invalidAttDataBase64DataSizes) {
-      expect(getSeenAttDataKeyFromSignedAggregateAndProofPhase0(Buffer.alloc(size))).toBeNull();
+      expect(getAttDataFromSignedAggregateAndProofPhase0(Buffer.alloc(size))).toBeNull();
     }
   });
   it("getSlotFromSignedAggregateAndProofSerialized - invalid data - large slots", () => {


### PR DESCRIPTION
**Motivation**

- gossip validation: 
  - `seenAttestationKey` is expected but `attDataBase64` is transferred from gossipHandlers 
  - we already have AttestationData base64, should not load it again
- AttDataKey for Attestation and SignedAggregateAndProof are not the same because `toBase64(Buffer.concat[a, b]) !== toBase64(a ) + toBase64(b)`

**Description**

- remove `seenAttestationKey`, always use `attDataBase64`
- implement `getSeenAttDataKey` apis in `packages/beacon-node/src/chain/validation/attestation.ts` and unit tests to make sure they are synchronized
- apis in`sszBytes.ts` becomes utils only instead of `getSeenAttDataKey` apis which are application business logic
- use `subarray()` instead of `slice()` whenever possible
- move type definition to where it makes more sense
cc @ensi321 