### PR TITLE
fix: improve sync pubkeys

### DIFF
--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -264,12 +264,6 @@ export class EpochCache {
     {config, pubkey2index, index2pubkey}: EpochCacheImmutableData,
     opts?: EpochCacheOpts
   ): EpochCache {
-    // syncPubkeys here to ensure EpochCacheImmutableData is popualted before computing the rest of caches
-    // - computeSyncCommitteeCache() needs a fully populated pubkey2index cache
-    if (!opts?.skipSyncPubkeys) {
-      syncPubkeys(state, pubkey2index, index2pubkey);
-    }
-
     const currentEpoch = computeEpochAtSlot(state.slot);
     const isGenesis = currentEpoch === GENESIS_EPOCH;
     const previousEpoch = isGenesis ? GENESIS_EPOCH : currentEpoch - 1;
@@ -281,6 +275,12 @@ export class EpochCache {
 
     const validators = state.validators.getAllReadonlyValues();
     const validatorCount = validators.length;
+
+    // syncPubkeys here to ensure EpochCacheImmutableData is popualted before computing the rest of caches
+    // - computeSyncCommitteeCache() needs a fully populated pubkey2index cache
+    if (!opts?.skipSyncPubkeys) {
+      syncPubkeys(validators, pubkey2index, index2pubkey);
+    }
 
     const effectiveBalanceIncrements = getEffectiveBalanceIncrementsWithLen(validatorCount);
     const totalSlashingsByIncrement = getTotalSlashingsByIncrement(state);

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -1,6 +1,5 @@
 import {PublicKey} from "@chainsafe/blst";
 import {ValidatorIndex, phase0} from "@lodestar/types";
-import {BeaconStateAllForks} from "./types.js";
 
 export type Index2PubkeyCache = PublicKey[];
 

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -1,5 +1,5 @@
 import {PublicKey} from "@chainsafe/blst";
-import {ValidatorIndex} from "@lodestar/types";
+import {ValidatorIndex, phase0} from "@lodestar/types";
 import {BeaconStateAllForks} from "./types.js";
 
 export type Index2PubkeyCache = PublicKey[];
@@ -53,7 +53,7 @@ export class PubkeyIndexMap {
  * If pubkey caches are empty: SLOW CODE - 🐢
  */
 export function syncPubkeys(
-  state: BeaconStateAllForks,
+  validators: phase0.Validator[],
   pubkey2index: PubkeyIndexMap,
   index2pubkey: Index2PubkeyCache
 ): void {
@@ -61,16 +61,14 @@ export function syncPubkeys(
     throw new Error(`Pubkey indices have fallen out of sync: ${pubkey2index.size} != ${index2pubkey.length}`);
   }
 
-  // Get the validators sub tree once for all the loop
-  const validators = state.validators;
-
-  const newCount = state.validators.length;
+  const newCount = validators.length;
+  index2pubkey.length = newCount;
   for (let i = pubkey2index.size; i < newCount; i++) {
-    const pubkey = validators.getReadonly(i).pubkey;
+    const pubkey = validators[i].pubkey;
     pubkey2index.set(pubkey, i);
     // Pubkeys must be checked for group + inf. This must be done only once when the validator deposit is processed.
     // Afterwards any public key is the state consider validated.
     // > Do not do any validation here
-    index2pubkey.push(PublicKey.fromBytes(pubkey)); // Optimize for aggregation
+    index2pubkey[i] = PublicKey.fromBytes(pubkey); // Optimize for aggregation
   }
 }


### PR DESCRIPTION
**Motivation**

Improve sync pubkeys at startup time

**Description**

- Reuse validators array from the consumer side
- Preallocate `Index2PubkeyCache` array