### PR TITLE
fix: cached balances in epoch transition

### DIFF
--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -75,6 +75,7 @@ export function processAttestationsAltair(
     // For each participant, update their participation
     // In epoch processing, this participation info is used to calculate balance updates
     let totalBalanceIncrementsWithWeight = 0;
+    const validators = state.validators;
     for (const index of attestingIndices) {
       const flags = epochParticipation.get(index);
 
@@ -104,7 +105,7 @@ export function processAttestationsAltair(
       // TODO: describe issue. Compute progressive target balances
       // When processing each attestation, increase the cummulative target balance. Only applies post-altair
       if ((flagsNewSet & TIMELY_TARGET) === TIMELY_TARGET) {
-        const validator = state.validators.getReadonly(index);
+        const validator = validators.getReadonly(index);
         if (!validator.slashed) {
           if (inCurrentEpoch) {
             epochCtx.currentTargetUnslashedBalanceIncrements += effectiveBalanceIncrements[index];

--- a/packages/state-transition/src/epoch/index.ts
+++ b/packages/state-transition/src/epoch/index.ts
@@ -133,7 +133,7 @@ export function processEpoch(
       const timer = metrics?.epochTransitionStepTime.startTimer({
         step: EpochTransitionStep.processPendingBalanceDeposits,
       });
-      processPendingBalanceDeposits(stateElectra);
+      processPendingBalanceDeposits(stateElectra, cache);
       timer?.();
     }
 
@@ -141,7 +141,7 @@ export function processEpoch(
       const timer = metrics?.epochTransitionStepTime.startTimer({
         step: EpochTransitionStep.processPendingConsolidations,
       });
-      processPendingConsolidations(stateElectra);
+      processPendingConsolidations(stateElectra, cache);
       timer?.();
     }
   }

--- a/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -39,7 +39,9 @@ export function processEffectiveBalanceUpdates(
 
   // update effective balances with hysteresis
 
-  // epochTransitionCache.balances is set in processRewardsAndPenalties(), so it's recycled here for performance.
+  // epochTransitionCache.balances is initialized in processRewardsAndPenalties()
+  // and updated in processPendingBalanceDeposits() and processPendingConsolidations()
+  // so it's recycled here for performance.
   const balances = cache.balances ?? state.balances.getAll();
 
   for (let i = 0, len = balances.length; i < len; i++) {

--- a/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -40,11 +40,7 @@ export function processEffectiveBalanceUpdates(
   // update effective balances with hysteresis
 
   // epochTransitionCache.balances is set in processRewardsAndPenalties(), so it's recycled here for performance.
-  // It defaults to `state.balances.getAll()` to make Typescript happy and for spec tests
-  const balances = state.balances.getAll();
-
-  // TODO: (@matthewkeil) This was causing additional failures but should not.  Check the EpochTransitionCache for why
-  // const balances = cache.balances ?? state.balances.getAll();
+  const balances = cache.balances ?? state.balances.getAll();
 
   for (let i = 0, len = balances.length; i < len; i++) {
     const balance = balances[i];

--- a/packages/state-transition/src/epoch/processSyncCommitteeUpdates.ts
+++ b/packages/state-transition/src/epoch/processSyncCommitteeUpdates.ts
@@ -23,11 +23,10 @@ export function processSyncCommitteeUpdates(fork: ForkSeq, state: CachedBeaconSt
       activeValidatorIndices,
       effectiveBalanceIncrements
     );
+    const validators = state.validators;
 
     // Using the index2pubkey cache is slower because it needs the serialized pubkey.
-    const nextSyncCommitteePubkeys = nextSyncCommitteeIndices.map(
-      (index) => state.validators.getReadonly(index).pubkey
-    );
+    const nextSyncCommitteePubkeys = nextSyncCommitteeIndices.map((index) => validators.getReadonly(index).pubkey);
 
     // Rotate syncCommittee in state
     state.currentSyncCommittee = state.nextSyncCommittee;


### PR DESCRIPTION
**Motivation**

- Use cached balances in `processEffectiveBalanceUpdates`
- Use state.validators.getReadonly() if possible

**Description**

- Update cached balances in `processPendingBalanceDeposits` and `processPendingConsolidations`
- Use it in `processEffectiveBalanceUpdates`
