### PR TITLE
fix: allocate shared buffer at runtime to fix browser compatibility

### DIFF
--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -57,12 +57,15 @@ export function toHex(buffer: Uint8Array | Parameters<typeof Buffer.from>[0]): s
 }
 
 // Shared buffer to convert root to hex
-const rootBuf = Buffer.alloc(32);
+let rootBuf: Buffer | undefined;
 
 /**
  * Convert a Uint8Array, length 32, to 0x-prefixed hex string
  */
 export function toRootHex(root: Uint8Array): string {
+  if (rootBuf === undefined) {
+    rootBuf = Buffer.alloc(32);
+  }
   rootBuf.set(root);
   return `0x${rootBuf.toString("hex")}`;
 }


### PR DESCRIPTION
**Motivation**

In https://github.com/ChainSafe/lodestar/pull/7016 we added a shared buffer which is allocated at load time in the utils packages. This is problematic as it breaks browser compatibility if Buffer is not polyfilled for every package that imports `@lodestar/utils` which is pretty much all of our packages.

**Description**

Allocate shared buffer at runtime to avoid running into `ReferenceError: Buffer is not defined` when importing utils packages in a browser environment without polyfills.
