### PR TITLE
fix: use attestation v1 endpoints pre-electra

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -410,7 +410,10 @@ export function getBeaconBlockApi({
       const fork = config.getForkName(block.message.slot);
 
       if (isForkPostElectra(fork)) {
-        throw new ApiError(400, `Use getBlockAttestationsV2 to retrieve electra+ block attestations fork=${fork}`);
+        throw new ApiError(
+          400,
+          `Use getBlockAttestationsV2 to retrieve block attestations for post-electra fork=${fork}`
+        );
       }
 
       return {

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -3,8 +3,8 @@ import {toHexString} from "@chainsafe/ssz";
 import {SecretKey} from "@chainsafe/blst";
 import {ssz} from "@lodestar/types";
 import {routes} from "@lodestar/api";
-import {createChainForkConfig} from "@lodestar/config";
-import {config} from "@lodestar/config/default";
+import {ChainConfig, createChainForkConfig} from "@lodestar/config";
+import {config as defaultConfig} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
 import {AttestationService, AttestationServiceOpts} from "../../../src/services/attestation.js";
 import {AttDutyAndProof} from "../../../src/services/attestationDuties.js";
@@ -52,16 +52,23 @@ describe("AttestationService", function () {
     vi.resetAllMocks();
   });
 
-  const testContexts: [string, AttestationServiceOpts][] = [
-    ["With default configuration", {}],
-    ["With attestation grouping disabled", {disableAttestationGrouping: true}],
-    ["With distributed aggregation selection enabled", {distributedAggregationSelection: true}],
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const electraConfig: Partial<ChainConfig> = {ELECTRA_FORK_EPOCH: 0};
+
+  const testContexts: [string, AttestationServiceOpts, Partial<ChainConfig>][] = [
+    ["With default configuration", {}, {}],
+    ["With default configuration post-electra", {}, electraConfig],
+    ["With attestation grouping disabled", {disableAttestationGrouping: true}, {}],
+    ["With attestation grouping disabled post-electra", {disableAttestationGrouping: true}, electraConfig],
+    ["With distributed aggregation selection enabled", {distributedAggregationSelection: true}, {}],
   ];
 
-  for (const [title, opts] of testContexts) {
+  for (const [title, opts, chainConfig] of testContexts) {
     describe(title, () => {
       it("Should produce, sign, and publish an attestation + aggregate", async () => {
         const clock = new ClockMock();
+        const config = createChainForkConfig({...defaultConfig, ...chainConfig});
+        const isPostElectra = chainConfig.ELECTRA_FORK_EPOCH === 0;
         const attestationService = new AttestationService(
           loggerVc,
           api,
@@ -71,12 +78,16 @@ describe("AttestationService", function () {
           chainHeadTracker,
           syncingStatusTracker,
           null,
-          createChainForkConfig(config),
+          config,
           opts
         );
 
-        const attestation = ssz.phase0.Attestation.defaultValue();
-        const aggregate = ssz.phase0.SignedAggregateAndProof.defaultValue();
+        const attestation = isPostElectra
+          ? ssz.electra.Attestation.defaultValue()
+          : ssz.phase0.Attestation.defaultValue();
+        const aggregate = isPostElectra
+          ? ssz.electra.SignedAggregateAndProof.defaultValue()
+          : ssz.phase0.SignedAggregateAndProof.defaultValue();
         const duties: AttDutyAndProof[] = [
           {
             duty: {
@@ -106,12 +117,17 @@ describe("AttestationService", function () {
 
         // Mock beacon's attestation and aggregates endpoints
         api.validator.produceAttestationData.mockResolvedValue(mockApiResponse({data: attestation.data}));
-        api.validator.getAggregatedAttestationV2.mockResolvedValue(
-          mockApiResponse({data: attestation, meta: {version: ForkName.phase0}})
-        );
-
-        api.beacon.submitPoolAttestationsV2.mockResolvedValue(mockApiResponse({}));
-        api.validator.publishAggregateAndProofsV2.mockResolvedValue(mockApiResponse({}));
+        if (isPostElectra) {
+          api.validator.getAggregatedAttestationV2.mockResolvedValue(
+            mockApiResponse({data: attestation, meta: {version: ForkName.electra}})
+          );
+          api.beacon.submitPoolAttestationsV2.mockResolvedValue(mockApiResponse({}));
+          api.validator.publishAggregateAndProofsV2.mockResolvedValue(mockApiResponse({}));
+        } else {
+          api.validator.getAggregatedAttestation.mockResolvedValue(mockApiResponse({data: attestation}));
+          api.beacon.submitPoolAttestations.mockResolvedValue(mockApiResponse({}));
+          api.validator.publishAggregateAndProofs.mockResolvedValue(mockApiResponse({}));
+        }
 
         if (opts.distributedAggregationSelection) {
           // Mock distributed validator middleware client selections endpoint
@@ -152,13 +168,25 @@ describe("AttestationService", function () {
           expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledWith({subscriptions: [subscription]});
         }
 
-        // Must submit the attestation received through produceAttestationData()
-        expect(api.beacon.submitPoolAttestationsV2).toHaveBeenCalledOnce();
-        expect(api.beacon.submitPoolAttestationsV2).toHaveBeenCalledWith({signedAttestations: [attestation]});
+        if (isPostElectra) {
+          // Must submit the attestation received through produceAttestationData()
+          expect(api.beacon.submitPoolAttestationsV2).toHaveBeenCalledOnce();
+          expect(api.beacon.submitPoolAttestationsV2).toHaveBeenCalledWith({signedAttestations: [attestation]});
 
-        // Must submit the aggregate received through getAggregatedAttestationV2() then createAndSignAggregateAndProof()
-        expect(api.validator.publishAggregateAndProofsV2).toHaveBeenCalledOnce();
-        expect(api.validator.publishAggregateAndProofsV2).toHaveBeenCalledWith({signedAggregateAndProofs: [aggregate]});
+          // Must submit the aggregate received through getAggregatedAttestationV2() then createAndSignAggregateAndProof()
+          expect(api.validator.publishAggregateAndProofsV2).toHaveBeenCalledOnce();
+          expect(api.validator.publishAggregateAndProofsV2).toHaveBeenCalledWith({
+            signedAggregateAndProofs: [aggregate],
+          });
+        } else {
+          // Must submit the attestation received through produceAttestationData()
+          expect(api.beacon.submitPoolAttestations).toHaveBeenCalledOnce();
+          expect(api.beacon.submitPoolAttestations).toHaveBeenCalledWith({signedAttestations: [attestation]});
+
+          // Must submit the aggregate received through getAggregatedAttestation() then createAndSignAggregateAndProof()
+          expect(api.validator.publishAggregateAndProofs).toHaveBeenCalledOnce();
+          expect(api.validator.publishAggregateAndProofs).toHaveBeenCalledWith({signedAggregateAndProofs: [aggregate]});
+        }
       });
     });
   }


### PR DESCRIPTION
**Motivation**

Fix compatiblity with other clients that have not yet implemented attestation v2 endpoints.


**Description**

Use attestation v1 endpoints pre-electra, after fork transition, the validator client will start using v2 apis.