### PR TITLE
feat: support post-electra attestation and attester slashing events

### DIFF
--- a/packages/api/src/beacon/client/events.ts
+++ b/packages/api/src/beacon/client/events.ts
@@ -13,7 +13,7 @@ export type ApiClient = ApiClientMethods<Endpoints>;
  */
 export function getClient(config: ChainForkConfig, baseUrl: string): ApiClient {
   const definitions = getDefinitions(config);
-  const eventSerdes = getEventSerdes();
+  const eventSerdes = getEventSerdes(config);
 
   return {
     eventstream: async ({topics, signal, onEvent, onError, onClose}) => {

--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -13,6 +13,9 @@ import {
   LightClientOptimisticUpdate,
   LightClientFinalityUpdate,
   SSEPayloadAttributes,
+  Attestation,
+  AttesterSlashing,
+  sszTypesFor,
 } from "@lodestar/types";
 import {ForkName} from "@lodestar/params";
 
@@ -104,10 +107,10 @@ export type EventData = {
     block: RootHex;
     executionOptimistic: boolean;
   };
-  [EventType.attestation]: phase0.Attestation;
+  [EventType.attestation]: Attestation;
   [EventType.voluntaryExit]: phase0.SignedVoluntaryExit;
   [EventType.proposerSlashing]: phase0.ProposerSlashing;
-  [EventType.attesterSlashing]: phase0.AttesterSlashing;
+  [EventType.attesterSlashing]: AttesterSlashing;
   [EventType.blsToExecutionChange]: capella.SignedBLSToExecutionChange;
   [EventType.finalizedCheckpoint]: {
     block: RootHex;
@@ -184,7 +187,7 @@ export type TypeJson<T> = {
   fromJson: (data: unknown) => T; // client
 };
 
-export function getTypeByEvent(): {[K in EventType]: TypeJson<EventData[K]>} {
+export function getTypeByEvent(config: ChainForkConfig): {[K in EventType]: TypeJson<EventData[K]>} {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const WithVersion = <T>(getType: (fork: ForkName) => TypeJson<T>): TypeJson<{data: T; version: ForkName}> => {
     return {
@@ -225,10 +228,28 @@ export function getTypeByEvent(): {[K in EventType]: TypeJson<EventData[K]>} {
       {jsonCase: "eth2"}
     ),
 
-    [EventType.attestation]: ssz.phase0.Attestation,
+    [EventType.attestation]: {
+      toJson: (attestation) => {
+        const fork = config.getForkName(attestation.data.slot);
+        return sszTypesFor(fork).Attestation.toJson(attestation);
+      },
+      fromJson: (attestation) => {
+        const fork = config.getForkName((attestation as Attestation).data.slot);
+        return sszTypesFor(fork).Attestation.fromJson(attestation);
+      },
+    },
     [EventType.voluntaryExit]: ssz.phase0.SignedVoluntaryExit,
     [EventType.proposerSlashing]: ssz.phase0.ProposerSlashing,
-    [EventType.attesterSlashing]: ssz.phase0.AttesterSlashing,
+    [EventType.attesterSlashing]: {
+      toJson: (attesterSlashing) => {
+        const fork = config.getForkName(Number(attesterSlashing.attestation1.data.slot));
+        return sszTypesFor(fork).AttesterSlashing.toJson(attesterSlashing);
+      },
+      fromJson: (attesterSlashing) => {
+        const fork = config.getForkName(Number((attesterSlashing as AttesterSlashing).attestation1.data.slot));
+        return sszTypesFor(fork).AttesterSlashing.fromJson(attesterSlashing);
+      },
+    },
     [EventType.blsToExecutionChange]: ssz.capella.SignedBLSToExecutionChange,
 
     [EventType.finalizedCheckpoint]: new ContainerType(
@@ -269,8 +290,8 @@ export function getTypeByEvent(): {[K in EventType]: TypeJson<EventData[K]>} {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function getEventSerdes() {
-  const typeByEvent = getTypeByEvent();
+export function getEventSerdes(config: ChainForkConfig) {
+  const typeByEvent = getTypeByEvent(config);
 
   return {
     toJson: (event: BeaconEvent): unknown => {

--- a/packages/api/src/beacon/server/events.ts
+++ b/packages/api/src/beacon/server/events.ts
@@ -3,7 +3,7 @@ import {ApiError, ApplicationMethods, FastifyRoutes, createFastifyRoutes} from "
 import {Endpoints, getDefinitions, eventTypes, getEventSerdes} from "../routes/events.js";
 
 export function getRoutes(config: ChainForkConfig, methods: ApplicationMethods<Endpoints>): FastifyRoutes<Endpoints> {
-  const eventSerdes = getEventSerdes();
+  const eventSerdes = getEventSerdes(config);
   const serverRoutes = createFastifyRoutes(getDefinitions(config), methods);
 
   return {

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -108,7 +108,7 @@ describe("eventstream event data", () => {
     }
   });
 
-  const eventSerdes = routes.events.getEventSerdes();
+  const eventSerdes = routes.events.getEventSerdes(config);
   const knownTopics = new Set<string>(Object.values(routes.events.eventTypes));
 
   for (const [topic, {value}] of Object.entries(eventstreamExamples ?? {}).filter(


### PR DESCRIPTION
**Motivation**

This is a backward compatible implementation to support post-electra attestation and attester slashing events. There is still ongoing discussion on the spec side if we wanna bump the whole events api to v2 or add new versioned events but until then we can just get the fork from the slot.

**Description**

Support post-electra attestation and attester slashing events by determining fork based on slot in data.