### PR TITLE
fix: full batch hash on epoch transition

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -1,3 +1,4 @@
+import {HashComputationGroup} from "@chainsafe/persistent-merkle-tree";
 import {
   CachedBeaconStateAllForks,
   stateTransition,
@@ -12,7 +13,6 @@ import {BlockProcessOpts} from "../options.js";
 import {byteArrayEquals} from "../../util/bytes.js";
 import {nextEventLoop} from "../../util/eventLoop.js";
 import {BlockInput, ImportBlockOpts} from "./types.js";
-import {HashComputationGroup} from "@chainsafe/persistent-merkle-tree";
 
 /**
  * Data in a BeaconBlock is bounded so we can use a single HashComputationGroup for all blocks


### PR DESCRIPTION
**Motivation**

- Previously the batch hash of state happen in every `hashTreeRoot()`, and I found only batch hash balances gave more performant because there is less gc, but not able to find the root cause of it

**Description**

- With new `batchHashTreeRoot()` api, we only apply when process epoch and block
- lg1k shows comparable performance

<img width="1317" alt="Screenshot 2024-08-16 at 09 51 48" src="https://github.com/user-attachments/assets/45b24872-1f34-4cfa-b7e1-c24773470ab4">

- while the test mainnet node showed better performance

<img width="1335" alt="Screenshot 2024-08-16 at 09 52 22" src="https://github.com/user-attachments/assets/b3ea28ce-ee24-4c4d-8149-770ae1471baf">
