### PR TITLE
chore: refactor KZG API indicating deprecated functions and add `recoverCellsAndKzgProofs`

### DIFF
--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import fs from "node:fs";
-import { fileURLToPath } from "node:url";
-import { fromHex, toHex } from "@lodestar/utils";
+import {fileURLToPath} from "node:url";
+import {fromHex, toHex} from "@lodestar/utils";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -22,14 +22,14 @@ export let ckzg: {
   // Deprecated: Use `computeCellsAndKzgProofs`
   computeCells(blob: Uint8Array): Uint8Array[];
   computeCellsAndKzgProofs(blob: Uint8Array): [Uint8Array[], Uint8Array[]];
-  // Deprecated
+  // Deprecated: Now being done internally in `recoverCellsAndKzgProofs`
   cellsToBlob(cells: Uint8Array[]): Uint8Array;
   // Deprecated: Use recoverCellsAndKzgProofs
   recoverAllCells(cellIds: number[], cells: Uint8Array[]): Uint8Array[];
   recoverCellsAndKzgProofs(cellIndices: number[], cells: Uint8Array[]): [Uint8Array[], Uint8Array[]];
-  // Deprecated: not used
+  // Deprecated: not used and removed from specs
   verifyCellKzgProof(commitmentBytes: Uint8Array, cellId: number, cell: Uint8Array, proofBytes: Uint8Array): boolean;
-  // This API will no longer take rowIndices in the future, in particular the rowIndices is no longer used
+  // This API will no longer take rowIndices in the future, in particular the rowIndices is no longer used.
   verifyCellKzgProofBatch(
     commitmentsBytes: Uint8Array[],
     rowIndices: number[],

--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -19,7 +19,7 @@ export let ckzg: {
   computeBlobKzgProof(blob: Uint8Array, commitment: Uint8Array): Uint8Array;
   verifyBlobKzgProof(blob: Uint8Array, commitment: Uint8Array, proof: Uint8Array): boolean;
   verifyBlobKzgProofBatch(blobs: Uint8Array[], expectedKzgCommitments: Uint8Array[], kzgProofs: Uint8Array[]): boolean;
-  // Deprecated: Use `computeCellsAndKzgProofs`
+  /** @deprecated Use `computeCellsAndKzgProofs` */
   computeCells(blob: Uint8Array): Uint8Array[];
   computeCellsAndKzgProofs(blob: Uint8Array): [Uint8Array[], Uint8Array[]];
   // Deprecated: Now being done internally in `recoverCellsAndKzgProofs`

--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -22,14 +22,14 @@ export let ckzg: {
   /** @deprecated Use `computeCellsAndKzgProofs` */
   computeCells(blob: Uint8Array): Uint8Array[];
   computeCellsAndKzgProofs(blob: Uint8Array): [Uint8Array[], Uint8Array[]];
-  // Deprecated: Now being done internally in `recoverCellsAndKzgProofs`
+  /** @deprecated Now being done internally in `recoverCellsAndKzgProofs` */
   cellsToBlob(cells: Uint8Array[]): Uint8Array;
-  // Deprecated: Use recoverCellsAndKzgProofs
+  /** @deprecated Use recoverCellsAndKzgProofs */
   recoverAllCells(cellIds: number[], cells: Uint8Array[]): Uint8Array[];
   recoverCellsAndKzgProofs(cellIndices: number[], cells: Uint8Array[]): [Uint8Array[], Uint8Array[]];
-  // Deprecated: not used and removed from specs
+  /** @deprecated This method is not used and has been removed from specs */
   verifyCellKzgProof(commitmentBytes: Uint8Array, cellId: number, cell: Uint8Array, proofBytes: Uint8Array): boolean;
-  // This API will no longer take rowIndices in the future, in particular the rowIndices is no longer used.
+  /** @deprecated This API will no longer take rowIndices in the future, in particular the rowIndices is no longer used. */
   verifyCellKzgProofBatch(
     commitmentsBytes: Uint8Array[],
     rowIndices: number[],

--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import fs from "node:fs";
-import {fileURLToPath} from "node:url";
-import {fromHex, toHex} from "@lodestar/utils";
+import { fileURLToPath } from "node:url";
+import { fromHex, toHex } from "@lodestar/utils";
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -19,11 +19,17 @@ export let ckzg: {
   computeBlobKzgProof(blob: Uint8Array, commitment: Uint8Array): Uint8Array;
   verifyBlobKzgProof(blob: Uint8Array, commitment: Uint8Array, proof: Uint8Array): boolean;
   verifyBlobKzgProofBatch(blobs: Uint8Array[], expectedKzgCommitments: Uint8Array[], kzgProofs: Uint8Array[]): boolean;
+  // Deprecated: Use `computeCellsAndKzgProofs`
   computeCells(blob: Uint8Array): Uint8Array[];
   computeCellsAndKzgProofs(blob: Uint8Array): [Uint8Array[], Uint8Array[]];
+  // Deprecated
   cellsToBlob(cells: Uint8Array[]): Uint8Array;
+  // Deprecated: Use recoverCellsAndKzgProofs
   recoverAllCells(cellIds: number[], cells: Uint8Array[]): Uint8Array[];
+  recoverCellsAndKzgProofs(cellIndices: number[], cells: Uint8Array[]): [Uint8Array[], Uint8Array[]];
+  // Deprecated: not used
   verifyCellKzgProof(commitmentBytes: Uint8Array, cellId: number, cell: Uint8Array, proofBytes: Uint8Array): boolean;
+  // This API will no longer take rowIndices in the future, in particular the rowIndices is no longer used
   verifyCellKzgProofBatch(
     commitmentsBytes: Uint8Array[],
     rowIndices: number[],
@@ -44,6 +50,14 @@ export let ckzg: {
   recoverAllCells: ckzgNotLoaded,
   verifyCellKzgProof: ckzgNotLoaded,
   verifyCellKzgProofBatch: ckzgNotLoaded,
+  recoverCellsAndKzgProofs(cellIndices: number[], cells: Uint8Array[]): [Uint8Array[], Uint8Array[]] {
+    // First recover all of the cells
+    const recoveredCells = this.recoverAllCells(cellIndices, cells);
+    // Convert the cells to a Blob
+    const blob = this.cellsToBlob(recoveredCells);
+    // Compute Cells and Proofs
+    return this.computeCellsAndKzgProofs(blob);
+  },
 };
 
 // Global variable __dirname no longer available in ES6 modules.


### PR DESCRIPTION
**Motivation**

This adds deprecation notes on the functions that will be deprecated once c-kzg is updated and notes on functions that have been changed slightly.

**Description**

- Adds deprecation notes on the functions that will no longer be available
- Adds recoverCellsAndKzgProofs method which is what the spec now uses
- Adds a note on verifyCellKzgBatch, sice the API of it changes slightly (rowIndices is no longer available)

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
