### PR TITLE
fix: batch hash tree root in state transition

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -69,6 +69,7 @@ export async function verifyBlocksStateTransitionOnly(
     const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
       source: StateHashTreeRootSource.blockTransition,
     });
+    // state root is computed inside stateTransition(), so it should take no time here
     const stateRoot = postState.batchHashTreeRoot(blockHCGroup);
     hashTreeRootTimer?.();
 

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -1,4 +1,3 @@
-import {HashComputationGroup} from "@chainsafe/persistent-merkle-tree";
 import {
   CachedBeaconStateAllForks,
   stateTransition,
@@ -13,11 +12,6 @@ import {BlockProcessOpts} from "../options.js";
 import {byteArrayEquals} from "../../util/bytes.js";
 import {nextEventLoop} from "../../util/eventLoop.js";
 import {BlockInput, ImportBlockOpts} from "./types.js";
-
-/**
- * Data in a BeaconBlock is bounded so we can use a single HashComputationGroup for all blocks
- */
-const blockHCGroup = new HashComputationGroup();
 
 /**
  * Verifies 1 or more blocks are fully valid running the full state transition; from a linear sequence of blocks.
@@ -69,8 +63,7 @@ export async function verifyBlocksStateTransitionOnly(
     const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
       source: StateHashTreeRootSource.blockTransition,
     });
-    // state root is computed inside stateTransition(), so it should take no time here
-    const stateRoot = postState.batchHashTreeRoot(blockHCGroup);
+    const stateRoot = postState.hashTreeRoot();
     hashTreeRootTimer?.();
 
     // Check state root matches

--- a/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
+++ b/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
@@ -48,6 +48,7 @@ export function computeNewStateRoot(
   const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
     source: StateHashTreeRootSource.computeNewStateRoot,
   });
+  // state root is computed inside stateTransition(), so it should take no time here
   const newStateRoot = postState.hashTreeRoot();
   hashTreeRootTimer?.();
 

--- a/packages/state-transition/src/cache/epochTransitionCache.ts
+++ b/packages/state-transition/src/cache/epochTransitionCache.ts
@@ -1,3 +1,4 @@
+import {ReusableListIterator} from "@chainsafe/ssz";
 import {Epoch, ValidatorIndex, phase0} from "@lodestar/types";
 import {intDiv} from "@lodestar/utils";
 import {EPOCHS_PER_SLASHINGS_VECTOR, FAR_FUTURE_EPOCH, ForkSeq, MAX_EFFECTIVE_BALANCE} from "@lodestar/params";
@@ -16,7 +17,6 @@ import {
 import {CachedBeaconStateAllForks, CachedBeaconStateAltair, CachedBeaconStatePhase0} from "../index.js";
 import {computeBaseRewardPerIncrement} from "../util/altair.js";
 import {processPendingAttestations} from "../epoch/processPendingAttestations.js";
-import {ReusableListIterator} from "@chainsafe/ssz";
 
 export type EpochTransitionCacheOpts = {
   /**
@@ -332,7 +332,10 @@ export function beforeProcessEpoch(
     //
     // Use `else` since indicesEligibleForActivationQueue + indicesEligibleForActivation are mutually exclusive
     else if (validator.activationEpoch === FAR_FUTURE_EPOCH && validator.activationEligibilityEpoch <= currentEpoch) {
-      indicesEligibleForActivation.push({validatorIndex: i, activationEligibilityEpoch: validator.activationEligibilityEpoch});
+      indicesEligibleForActivation.push({
+        validatorIndex: i,
+        activationEligibilityEpoch: validator.activationEligibilityEpoch,
+      });
     }
 
     // To optimize process_registry_updates():

--- a/packages/state-transition/src/epoch/processParticipationFlagUpdates.ts
+++ b/packages/state-transition/src/epoch/processParticipationFlagUpdates.ts
@@ -20,7 +20,7 @@ export function processParticipationFlagUpdates(state: CachedBeaconStateAltair):
   const currentEpochParticipationNode = ssz.altair.EpochParticipation.tree_setChunksNode(
     state.currentEpochParticipation.node,
     zeroNode(ssz.altair.EpochParticipation.chunkDepth),
-    state.currentEpochParticipation.length,
+    state.currentEpochParticipation.length
   );
 
   state.currentEpochParticipation = ssz.altair.EpochParticipation.getViewDU(currentEpochParticipationNode);

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -108,6 +108,9 @@ export function stateTransition(
 
   processBlock(fork, postState, block, options, options);
 
+  // Note: time only on success. This does not include hashTreeRoot() time
+  processBlockTimer?.();
+
   // TODO - batch: remove processBlockCommitTime?
   const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
     source: StateHashTreeRootSource.stateTransition,
@@ -116,8 +119,6 @@ export function stateTransition(
   const stateRoot = postState.batchHashTreeRoot(hcGroup);
   hashTreeRootTimer?.();
 
-  // Note: time only on success. Include processBlock and commit
-  processBlockTimer?.();
 
   if (metrics) {
     onPostStateMetrics(postState, metrics);

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -1,4 +1,5 @@
 import {toHexString} from "@chainsafe/ssz";
+import {HashComputationGroup} from "@chainsafe/persistent-merkle-tree";
 import {SignedBeaconBlock, SignedBlindedBeaconBlock, Slot, ssz} from "@lodestar/types";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {BeaconStateTransitionMetrics, onPostStateMetrics, onStateCloneMetrics} from "./metrics.js";
@@ -56,6 +57,11 @@ export enum StateHashTreeRootSource {
 }
 
 /**
+ * Data in a BeaconBlock is bounded so we can use a single HashComputationGroup for all blocks
+ */
+const hcGroup = new HashComputationGroup();
+
+/**
  * Implementation Note: follows the optimizations in protolambda's eth2fastspec (https://github.com/protolambda/eth2fastspec)
  */
 export function stateTransition(
@@ -102,9 +108,13 @@ export function stateTransition(
 
   processBlock(fork, postState, block, options, options);
 
-  const processBlockCommitTimer = metrics?.processBlockCommitTime.startTimer();
-  postState.commit();
-  processBlockCommitTimer?.();
+  // TODO - batch: remove processBlockCommitTime?
+  const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
+    source: StateHashTreeRootSource.stateTransition,
+  });
+  // commit() is done inside batchHashTreeRoot()
+  const stateRoot = postState.batchHashTreeRoot(hcGroup);
+  hashTreeRootTimer?.();
 
   // Note: time only on success. Include processBlock and commit
   processBlockTimer?.();
@@ -115,12 +125,6 @@ export function stateTransition(
 
   // Verify state root
   if (verifyStateRoot) {
-    const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
-      source: StateHashTreeRootSource.stateTransition,
-    });
-    const stateRoot = postState.hashTreeRoot();
-    hashTreeRootTimer?.();
-
     if (!ssz.Root.equals(block.stateRoot, stateRoot)) {
       throw new Error(
         `Invalid state root at slot ${block.slot}, expected=${toHexString(block.stateRoot)}, actual=${toHexString(

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -116,6 +116,8 @@ export function stateTransition(
     source: StateHashTreeRootSource.stateTransition,
   });
   // commit() is done inside batchHashTreeRoot()
+  // with batchHashTreeRoot(), we're not able to measure commit() time separately
+  // note that at commit() phase, we batch hash validators via ListValidatorTreeViewDU so this metric is a little bit confusing
   const stateRoot = postState.batchHashTreeRoot(hcGroup);
   hashTreeRootTimer?.();
 

--- a/packages/state-transition/src/util/balance.ts
+++ b/packages/state-transition/src/util/balance.ts
@@ -1,10 +1,10 @@
+import {ReusableListIterator} from "@chainsafe/ssz";
 import {EFFECTIVE_BALANCE_INCREMENT} from "@lodestar/params";
 import {Gwei, ValidatorIndex, phase0} from "@lodestar/types";
 import {bigIntMax} from "@lodestar/utils";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";
 import {BeaconStateAllForks} from "..";
 import {CachedBeaconStateAllForks} from "../types.js";
-import {ReusableListIterator} from "@chainsafe/ssz";
 
 /**
  * Return the combined effective balance of the [[indices]].

--- a/packages/types/src/phase0/viewDU/listValidator.ts
+++ b/packages/types/src/phase0/viewDU/listValidator.ts
@@ -40,6 +40,7 @@ const validatorRoots: Uint8Array[] = [];
 for (let i = 0; i < PARALLEL_FACTOR; i++) {
   validatorRoots.push(batchLevel3Bytes.subarray(i * 32, (i + 1) * 32));
 }
+const validatorRoot = new Uint8Array(32);
 
 export class ListValidatorTreeViewDU extends ListCompositeTreeViewDU<ValidatorNodeStructType> {
   constructor(
@@ -114,8 +115,11 @@ export class ListValidatorTreeViewDU extends ListCompositeTreeViewDU<ValidatorNo
       const viewIndex = indicesChanged[i];
       const viewChanged = viewsChanged.get(viewIndex);
       if (viewChanged) {
-        // commit and hash
+        // commit
         viewChanged.commit();
+        // compute root for each validator
+        viewChanged.type.hashTreeRootInto(viewChanged.value, validatorRoot, 0);
+        byteArrayIntoHashObject(validatorRoot, 0, viewChanged.node);
         nodesChanged.push({index: viewIndex, node: viewChanged.node});
         // Set new node in nodes array to ensure data represented in the tree and fast nodes access is equal
         this.nodes[viewIndex] = viewChanged.node;


### PR DESCRIPTION
**Motivation**

- right now we do the `commit()` in state-transition and compute hashTreeRoot() in batch in `beacon-node`, this wastes an extra traversal from root
- during commit() we can also get HashComputation and then execute it. This does not save much time (around 2ms), however it's reasonable to do so

**Description**

- do `batchHashTreeRoot()` in `state-transition`
- fix lint

**Test**
- Deployed to the test mainnet node and 1k for 3 days, we cannot see commit() time anymore, process block time is increased as expected

<img width="865" alt="Screenshot 2024-08-19 at 08 24 54" src="https://github.com/user-attachments/assets/05d2c442-0cf3-4321-8d9f-de932e376171">

- The "block received to state transition" is the same or a little bit better

<img width="1341" alt="Screenshot 2024-08-19 at 09 00 47" src="https://github.com/user-attachments/assets/d89ecfdf-677e-4b14-8391-f7d8b0b62a14">

on stable it takes more than 50m

<img width="1330" alt="Screenshot 2024-08-19 at 09 01 21" src="https://github.com/user-attachments/assets/e4ea630a-515b-4dc3-81c8-b4231256bf26">


- I'm not sure how can `gc` decreased due to this

<img width="1348" alt="Screenshot 2024-08-19 at 08 25 56" src="https://github.com/user-attachments/assets/6f1d9fbc-accc-4b6a-8ac5-6da46b8e250a">


above is metric for the test mainnet node, it's consistent to 1k