### PR TITLE
feat: de-duplicate payloads from persisted beacon blocks

### DIFF
--- a/packages/beacon-node/src/api/impl/proof/index.ts
+++ b/packages/beacon-node/src/api/impl/proof/index.ts
@@ -1,6 +1,7 @@
 import {CompactMultiProof, createProof, ProofType} from "@chainsafe/persistent-merkle-tree";
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
+import {isBlindedBeaconBlock} from "@lodestar/types";
 import {ApiModules} from "../types.js";
 import {getStateResponse} from "../beacon/state/utils.js";
 import {getBlockResponse} from "../beacon/blocks/utils.js";
@@ -43,7 +44,9 @@ export function getProofApi(
       const {block} = await getBlockResponse(chain, blockId);
 
       // Commit any changes before computing the state root. In normal cases the state should have no changes here
-      const blockNode = config.getForkTypes(block.message.slot).BeaconBlock.toView(block.message).node;
+      const blockNode = isBlindedBeaconBlock(block.message)
+        ? config.getExecutionForkTypes(block.message.slot).BlindedBeaconBlock.toView(block.message).node
+        : config.getForkTypes(block.message.slot).BeaconBlock.toView(block.message).node;
 
       const proof = createProof(blockNode, {type: ProofType.compactMulti, descriptor});
 

--- a/packages/beacon-node/src/api/impl/proof/index.ts
+++ b/packages/beacon-node/src/api/impl/proof/index.ts
@@ -1,7 +1,7 @@
 import {CompactMultiProof, createProof, ProofType} from "@chainsafe/persistent-merkle-tree";
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
-import {isBlindedBeaconBlock} from "@lodestar/types";
+import {isBlindedBlock} from "@lodestar/state-transition";
 import {ApiModules} from "../types.js";
 import {getStateResponse} from "../beacon/state/utils.js";
 import {getBlockResponse} from "../beacon/blocks/utils.js";
@@ -44,7 +44,7 @@ export function getProofApi(
       const {block} = await getBlockResponse(chain, blockId);
 
       // Commit any changes before computing the state root. In normal cases the state should have no changes here
-      const blockNode = isBlindedBeaconBlock(block.message)
+      const blockNode = isBlindedBlock(block.message)
         ? config.getExecutionForkTypes(block.message.slot).BlindedBeaconBlock.toView(block.message).node
         : config.getForkTypes(block.message.slot).BeaconBlock.toView(block.message).node;
 

--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -13,17 +13,11 @@ export async function writeBlockInputToDb(this: BeaconChain, blocksInput: BlockI
   const fnPromises: Promise<void>[] = [];
 
   for (const blockInput of blocksInput) {
-    const {block, blockBytes} = blockInput;
+    const {block} = blockInput;
     const blockRoot = this.config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
     const blockRootHex = toRootHex(blockRoot);
-    if (blockBytes) {
-      // skip serializing data if we already have it
-      this.metrics?.importBlock.persistBlockWithSerializedDataCount.inc();
-      fnPromises.push(this.db.block.putBinary(this.db.block.getId(block), blockBytes));
-    } else {
-      this.metrics?.importBlock.persistBlockNoSerializedDataCount.inc();
-      fnPromises.push(this.db.block.add(block));
-    }
+    this.metrics?.importBlock.persistBlockNoSerializedDataCount.inc();
+    fnPromises.push(this.db.block.add(block));
     this.logger.debug("Persist block to hot DB", {
       slot: block.message.slot,
       root: blockRootHex,

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -14,6 +14,7 @@ import {
   EpochShuffling,
   computeEndSlotAtEpoch,
   blindedOrFullBlockHashTreeRoot,
+  isBlindedBlock,
 } from "@lodestar/state-transition";
 import {BeaconConfig} from "@lodestar/config";
 import {
@@ -27,7 +28,6 @@ import {
   deneb,
   Wei,
   bellatrix,
-  isBlindedBeaconBlock,
   BeaconBlock,
   SignedBeaconBlock,
   ExecutionPayload,
@@ -844,7 +844,7 @@ export class BeaconChain implements IBeaconChain {
 
   persistBlock(data: BeaconBlock | BlindedBeaconBlock, suffix?: string): void {
     const slot = data.slot;
-    if (isBlindedBeaconBlock(data)) {
+    if (isBlindedBlock(data)) {
       const sszType = this.config.getExecutionForkTypes(slot).BlindedBeaconBlock;
       void this.persistSszObject("BlindedBeaconBlock", sszType.serialize(data), sszType.hashTreeRoot(data), suffix);
     } else {
@@ -1006,7 +1006,7 @@ export class BeaconChain implements IBeaconChain {
   async fullOrBlindedSignedBeaconBlockToFull(
     block: SignedBeaconBlock | SignedBlindedBeaconBlock
   ): Promise<SignedBeaconBlock> {
-    if (!isBlindedBeaconBlock(block)) {
+    if (!isBlindedBlock(block)) {
       return block;
     }
     const blockHash = toHex(blindedOrFullBlockHashTreeRoot(this.config, block.message));

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1010,7 +1010,9 @@ export class BeaconChain implements IBeaconChain {
       return block;
     }
     const blockHash = toHex(blindedOrFullBlockHashTreeRoot(this.config, block.message));
-    const [payload] = await this.executionEngine.getPayloadBodiesByHash([blockHash]);
+    const [payload] = await this.executionEngine.getPayloadBodiesByHash(this.config.getForkName(block.message.slot), [
+      blockHash,
+    ]);
     if (!payload) {
       throw new Eth1Error(
         {code: Eth1ErrorCode.INVALID_PAYLOAD_BODY, blockHash},

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1006,7 +1006,9 @@ export class BeaconChain implements IBeaconChain {
   async fullOrBlindedSignedBeaconBlockToFull(
     block: SignedBeaconBlock | SignedBlindedBeaconBlock
   ): Promise<SignedBeaconBlock> {
-    if (!isBlindedBeaconBlock(block)) return block;
+    if (!isBlindedBeaconBlock(block)) {
+      return block;
+    }
     const blockHash = toHex(blindedOrFullBlockHashTreeRoot(this.config, block.message));
     const [payload] = await this.executionEngine.getPayloadBodiesByHash([blockHash]);
     if (!payload) {

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -15,6 +15,7 @@ import {
   ExecutionPayload,
   SignedBeaconBlock,
   BlindedBeaconBlock,
+  SignedBlindedBeaconBlock,
 } from "@lodestar/types";
 import {
   BeaconStateAllForks,
@@ -172,15 +173,19 @@ export interface IBeaconChain {
    * this methods returns blocks in current chain head according to
    * forkchoice. Works for finalized slots as well
    */
-  getCanonicalBlockAtSlot(
-    slot: Slot
-  ): Promise<{block: SignedBeaconBlock; executionOptimistic: boolean; finalized: boolean} | null>;
+  getCanonicalBlockAtSlot(slot: Slot): Promise<{
+    block: SignedBeaconBlock | SignedBlindedBeaconBlock;
+    executionOptimistic: boolean;
+    finalized: boolean;
+  } | null>;
   /**
    * Get local block by root, does not fetch from the network
    */
-  getBlockByRoot(
-    root: RootHex
-  ): Promise<{block: SignedBeaconBlock; executionOptimistic: boolean; finalized: boolean} | null>;
+  getBlockByRoot(root: RootHex): Promise<{
+    block: SignedBeaconBlock | SignedBlindedBeaconBlock;
+    executionOptimistic: boolean;
+    finalized: boolean;
+  } | null>;
 
   getContents(beaconBlock: deneb.BeaconBlock): deneb.Contents;
 
@@ -196,6 +201,8 @@ export interface IBeaconChain {
     executionPayloadValue: Wei;
     consensusBlockValue: Wei;
   }>;
+
+  fullOrBlindedSignedBeaconBlockToFull(block: SignedBeaconBlock | SignedBlindedBeaconBlock): Promise<SignedBeaconBlock>;
 
   /** Process a block until complete */
   processBlock(block: BlockInput, opts?: ImportBlockOpts): Promise<void>;

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -173,7 +173,10 @@ export interface IBeaconChain {
    * this methods returns blocks in current chain head according to
    * forkchoice. Works for finalized slots as well
    */
-  getCanonicalBlockAtSlot(slot: Slot): Promise<{
+  getCanonicalBlockAtSlot(
+    slot: Slot,
+    getFull?: boolean
+  ): Promise<{
     block: SignedBeaconBlock | SignedBlindedBeaconBlock;
     executionOptimistic: boolean;
     finalized: boolean;
@@ -181,7 +184,10 @@ export interface IBeaconChain {
   /**
    * Get local block by root, does not fetch from the network
    */
-  getBlockByRoot(root: RootHex): Promise<{
+  getBlockByRoot(
+    root: RootHex,
+    getFull?: boolean
+  ): Promise<{
     block: SignedBeaconBlock | SignedBlindedBeaconBlock;
     executionOptimistic: boolean;
     finalized: boolean;

--- a/packages/beacon-node/src/db/repositories/block.ts
+++ b/packages/beacon-node/src/db/repositories/block.ts
@@ -1,10 +1,9 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {Db, Repository} from "@lodestar/db";
 import {ssz} from "@lodestar/types";
-import {blindedOrFullBlockHashTreeRoot} from "@lodestar/state-transition";
+import {blindedOrFullBlockHashTreeRoot, fullOrBlindedSignedBlockToBlinded} from "@lodestar/state-transition";
 import {
   FullOrBlindedSignedBeaconBlock,
-  blindedOrFullBlockToBlinded,
   serializeFullOrBlindedSignedBeaconBlock,
   deserializeFullOrBlindedSignedBeaconBlock,
 } from "../../util/fullOrBlindedBlock.js";
@@ -44,6 +43,6 @@ export class BlockRepository extends Repository<Uint8Array, FullOrBlindedSignedB
   }
 
   async add(value: FullOrBlindedSignedBeaconBlock): Promise<void> {
-    return super.add(blindedOrFullBlockToBlinded(value));
+    return super.add(fullOrBlindedSignedBlockToBlinded(this.config, value));
   }
 }

--- a/packages/beacon-node/src/db/repositories/block.ts
+++ b/packages/beacon-node/src/db/repositories/block.ts
@@ -1,9 +1,8 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {Db, Repository} from "@lodestar/db";
-import {ssz} from "@lodestar/types";
+import {SignedBeaconBlock, SignedBlindedBeaconBlock, ssz} from "@lodestar/types";
 import {blindedOrFullBlockHashTreeRoot, fullOrBlindedSignedBlockToBlinded} from "@lodestar/state-transition";
 import {
-  FullOrBlindedSignedBeaconBlock,
   serializeFullOrBlindedSignedBeaconBlock,
   deserializeFullOrBlindedSignedBeaconBlock,
 } from "../../util/fullOrBlindedBlock.js";
@@ -14,7 +13,7 @@ import {Bucket, getBucketNameByValue} from "../buckets.js";
  *
  * Used to store unfinalized blocks
  */
-export class BlockRepository extends Repository<Uint8Array, FullOrBlindedSignedBeaconBlock> {
+export class BlockRepository extends Repository<Uint8Array, SignedBeaconBlock | SignedBlindedBeaconBlock> {
   constructor(config: ChainForkConfig, db: Db) {
     const bucket = Bucket.allForks_block;
     // Pick some type but won't be used, override below so correct container is used
@@ -25,24 +24,25 @@ export class BlockRepository extends Repository<Uint8Array, FullOrBlindedSignedB
   /**
    * Id is hashTreeRoot of unsigned BeaconBlock
    */
-  getId(value: FullOrBlindedSignedBeaconBlock): Uint8Array {
+  getId(value: SignedBeaconBlock | SignedBlindedBeaconBlock): Uint8Array {
     return blindedOrFullBlockHashTreeRoot(this.config, value.message);
   }
 
-  encodeValue(value: FullOrBlindedSignedBeaconBlock): Uint8Array {
+  encodeValue(value: SignedBeaconBlock | SignedBlindedBeaconBlock): Uint8Array {
     return serializeFullOrBlindedSignedBeaconBlock(this.config, value);
   }
 
-  decodeValue(data: Uint8Array): FullOrBlindedSignedBeaconBlock {
+  decodeValue(data: Uint8Array): SignedBeaconBlock | SignedBlindedBeaconBlock {
     return deserializeFullOrBlindedSignedBeaconBlock(this.config, data);
   }
 
+  // TODO: (@matthewkeil) should this throw or should we allow puts of binary blocks?
   // eslint-disable-next-line @typescript-eslint/naming-convention
   async putBinary(_: Uint8Array, __: Uint8Array): Promise<void> {
     throw new Error("cannot .putBinary into BlockRepository. must use .add so can be saved blinded");
   }
 
-  async add(value: FullOrBlindedSignedBeaconBlock): Promise<void> {
+  async add(value: SignedBeaconBlock | SignedBlindedBeaconBlock): Promise<void> {
     return super.add(fullOrBlindedSignedBlockToBlinded(this.config, value));
   }
 }

--- a/packages/beacon-node/src/db/repositories/block.ts
+++ b/packages/beacon-node/src/db/repositories/block.ts
@@ -1,7 +1,12 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {Db, Repository} from "@lodestar/db";
-import {SignedBeaconBlock, ssz} from "@lodestar/types";
-import {getSignedBlockTypeFromBytes} from "../../util/multifork.js";
+import {ssz} from "@lodestar/types";
+import {blindedOrFullBlockHashTreeRoot} from "@lodestar/state-transition";
+import {
+  FullOrBlindedSignedBeaconBlock,
+  serializeFullOrBlindedSignedBeaconBlock,
+  deserializeFullOrBlindedSignedBeaconBlock,
+} from "../../util/fullOrBlindedBlock.js";
 import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 /**
@@ -9,25 +14,26 @@ import {Bucket, getBucketNameByValue} from "../buckets.js";
  *
  * Used to store unfinalized blocks
  */
-export class BlockRepository extends Repository<Uint8Array, SignedBeaconBlock> {
+export class BlockRepository extends Repository<Uint8Array, FullOrBlindedSignedBeaconBlock> {
   constructor(config: ChainForkConfig, db: Db) {
     const bucket = Bucket.allForks_block;
-    const type = ssz.phase0.SignedBeaconBlock; // Pick some type but won't be used
+    // Pick some type but won't be used, override below so correct container is used
+    const type = ssz.phase0.SignedBeaconBlock;
     super(config, db, bucket, type, getBucketNameByValue(bucket));
   }
 
   /**
    * Id is hashTreeRoot of unsigned BeaconBlock
    */
-  getId(value: SignedBeaconBlock): Uint8Array {
-    return this.config.getForkTypes(value.message.slot).BeaconBlock.hashTreeRoot(value.message);
+  getId(value: FullOrBlindedSignedBeaconBlock): Uint8Array {
+    return blindedOrFullBlockHashTreeRoot(this.config, value.message);
   }
 
-  encodeValue(value: SignedBeaconBlock): Buffer {
-    return this.config.getForkTypes(value.message.slot).SignedBeaconBlock.serialize(value) as Buffer;
+  encodeValue(value: FullOrBlindedSignedBeaconBlock): Uint8Array {
+    return serializeFullOrBlindedSignedBeaconBlock(this.config, value);
   }
 
-  decodeValue(data: Buffer): SignedBeaconBlock {
-    return getSignedBlockTypeFromBytes(this.config, data).deserialize(data);
+  decodeValue(data: Uint8Array): FullOrBlindedSignedBeaconBlock {
+    return deserializeFullOrBlindedSignedBeaconBlock(this.config, data);
   }
 }

--- a/packages/beacon-node/src/db/repositories/block.ts
+++ b/packages/beacon-node/src/db/repositories/block.ts
@@ -4,6 +4,7 @@ import {ssz} from "@lodestar/types";
 import {blindedOrFullBlockHashTreeRoot} from "@lodestar/state-transition";
 import {
   FullOrBlindedSignedBeaconBlock,
+  blindedOrFullBlockToBlinded,
   serializeFullOrBlindedSignedBeaconBlock,
   deserializeFullOrBlindedSignedBeaconBlock,
 } from "../../util/fullOrBlindedBlock.js";
@@ -35,5 +36,14 @@ export class BlockRepository extends Repository<Uint8Array, FullOrBlindedSignedB
 
   decodeValue(data: Uint8Array): FullOrBlindedSignedBeaconBlock {
     return deserializeFullOrBlindedSignedBeaconBlock(this.config, data);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  async putBinary(_: Uint8Array, __: Uint8Array): Promise<void> {
+    throw new Error("cannot .putBinary into BlockRepository. must use .add so can be saved blinded");
+  }
+
+  async add(value: FullOrBlindedSignedBeaconBlock): Promise<void> {
+    return super.add(blindedOrFullBlockToBlinded(value));
   }
 }

--- a/packages/beacon-node/src/db/repositories/blockArchiveIndex.ts
+++ b/packages/beacon-node/src/db/repositories/blockArchiveIndex.ts
@@ -1,8 +1,6 @@
 import {Db, encodeKey} from "@lodestar/db";
-import {Slot, Root, ssz, SSZTypesFor} from "@lodestar/types";
+import {Slot, Root, SignedBeaconBlock, SignedBlindedBeaconBlock} from "@lodestar/types";
 import {intToBytes} from "@lodestar/utils";
-import {ForkAll} from "@lodestar/params";
-import {FullOrBlindedSignedBeaconBlock} from "../../util/fullOrBlindedBlock.js";
 import {Bucket} from "../buckets.js";
 
 export async function storeRootIndex(db: Db, slot: Slot, blockRoot: Root): Promise<void> {
@@ -13,16 +11,14 @@ export async function storeParentRootIndex(db: Db, slot: Slot, parentRoot: Root)
   return db.put(getParentRootIndexKey(parentRoot), intToBytes(slot, 8, "be"));
 }
 
-export async function deleteRootIndex(
-  db: Db,
-  signedBeaconBlockType: SSZTypesFor<ForkAll, "SignedBeaconBlock">,
-  block: FullOrBlindedSignedBeaconBlock
-): Promise<void> {
-  const beaconBlockType = (signedBeaconBlockType as typeof ssz.phase0.SignedBeaconBlock).fields["message"];
-  return db.delete(getRootIndexKey(beaconBlockType.hashTreeRoot(block.message)));
+export async function deleteRootIndex(db: Db, blockRoot: Uint8Array): Promise<void> {
+  return db.delete(getRootIndexKey(blockRoot));
 }
 
-export async function deleteParentRootIndex(db: Db, block: FullOrBlindedSignedBeaconBlock): Promise<void> {
+export async function deleteParentRootIndex(
+  db: Db,
+  block: SignedBeaconBlock | SignedBlindedBeaconBlock
+): Promise<void> {
   return db.delete(getParentRootIndexKey(block.message.parentRoot));
 }
 

--- a/packages/beacon-node/src/db/repositories/blockArchiveIndex.ts
+++ b/packages/beacon-node/src/db/repositories/blockArchiveIndex.ts
@@ -1,7 +1,8 @@
 import {Db, encodeKey} from "@lodestar/db";
-import {Slot, Root, ssz, SignedBeaconBlock, SSZTypesFor} from "@lodestar/types";
+import {Slot, Root, ssz, SSZTypesFor} from "@lodestar/types";
 import {intToBytes} from "@lodestar/utils";
 import {ForkAll} from "@lodestar/params";
+import {FullOrBlindedSignedBeaconBlock} from "../../util/fullOrBlindedBlock.js";
 import {Bucket} from "../buckets.js";
 
 export async function storeRootIndex(db: Db, slot: Slot, blockRoot: Root): Promise<void> {
@@ -15,13 +16,13 @@ export async function storeParentRootIndex(db: Db, slot: Slot, parentRoot: Root)
 export async function deleteRootIndex(
   db: Db,
   signedBeaconBlockType: SSZTypesFor<ForkAll, "SignedBeaconBlock">,
-  block: SignedBeaconBlock
+  block: FullOrBlindedSignedBeaconBlock
 ): Promise<void> {
   const beaconBlockType = (signedBeaconBlockType as typeof ssz.phase0.SignedBeaconBlock).fields["message"];
   return db.delete(getRootIndexKey(beaconBlockType.hashTreeRoot(block.message)));
 }
 
-export async function deleteParentRootIndex(db: Db, block: SignedBeaconBlock): Promise<void> {
+export async function deleteParentRootIndex(db: Db, block: FullOrBlindedSignedBeaconBlock): Promise<void> {
   return db.delete(getParentRootIndexKey(block.message.parentRoot));
 }
 

--- a/packages/beacon-node/src/eth1/errors.ts
+++ b/packages/beacon-node/src/eth1/errors.ts
@@ -23,6 +23,8 @@ export enum Eth1ErrorCode {
   NON_CONSECUTIVE_LOGS = "ETH1_ERROR_NON_CONSECUTIVE_LOGS",
   /** Expected a deposit log in the db for the index, missing log implies a corrupted db */
   MISSING_DEPOSIT_LOG = "ETH1_ERROR_MISSING_DEPOSIT_LOG",
+  /** Expected transactions or withdrawals for un-blinding block from db before serving */
+  INVALID_PAYLOAD_BODY = "ETH1_ERROR_INVALID_PAYLOAD_BODY",
 }
 
 export type Eth1ErrorType =
@@ -35,6 +37,7 @@ export type Eth1ErrorType =
   | {code: Eth1ErrorCode.NOT_ENOUGH_DEPOSIT_ROOTS; index: number; treeLength: number}
   | {code: Eth1ErrorCode.DUPLICATE_DISTINCT_LOG; newIndex: number; lastLogIndex: number}
   | {code: Eth1ErrorCode.NON_CONSECUTIVE_LOGS; newIndex: number; lastLogIndex: number}
-  | {code: Eth1ErrorCode.MISSING_DEPOSIT_LOG; newIndex: number; lastLogIndex: number};
+  | {code: Eth1ErrorCode.MISSING_DEPOSIT_LOG; newIndex: number; lastLogIndex: number}
+  | {code: Eth1ErrorCode.INVALID_PAYLOAD_BODY; blockHash: string};
 
 export class Eth1Error extends LodestarError<Eth1ErrorType> {}

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRoot.ts
@@ -4,6 +4,7 @@ import {toRootHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
 import {IBeaconDb} from "../../../db/index.js";
 import {getSlotFromSignedBeaconBlockSerialized} from "../../../util/sszBytes.js";
+import {deserializeFullOrBlindedSignedBeaconBlock} from "../../../util/fullOrBlindedBlock.js";
 
 export async function* onBeaconBlocksByRoot(
   requestBody: phase0.BeaconBlocksByRootRequest,
@@ -38,8 +39,11 @@ export async function* onBeaconBlocksByRoot(
         slot = slotFromBytes;
       }
 
+      const block = await chain.fullOrBlindedSignedBeaconBlockToFull(
+        deserializeFullOrBlindedSignedBeaconBlock(chain.config, blockBytes)
+      );
       yield {
-        data: blockBytes,
+        data: chain.config.getForkTypes(slot).SignedBeaconBlock.serialize(block),
         fork: chain.config.getForkName(slot),
       };
     }

--- a/packages/beacon-node/src/util/fullOrBlindedBlock.ts
+++ b/packages/beacon-node/src/util/fullOrBlindedBlock.ts
@@ -1,8 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {
-  BeaconBlock,
   bellatrix,
-  BlindedBeaconBlock,
   capella,
   deneb,
   ExecutionPayload,

--- a/packages/beacon-node/src/util/fullOrBlindedBlock.ts
+++ b/packages/beacon-node/src/util/fullOrBlindedBlock.ts
@@ -15,8 +15,6 @@ import {BYTES_PER_LOGS_BLOOM, ForkSeq, ForkName, isForkExecution, SYNC_COMMITTEE
 import {ExecutionPayloadBody} from "../execution/engine/types.js";
 import {ROOT_SIZE, getSlotFromSignedBeaconBlockSerialized} from "./sszBytes.js";
 
-export type FullOrBlindedSignedBeaconBlock = SignedBeaconBlock | SignedBlindedBeaconBlock;
-export type FullOrBlindedBeaconBlock = BeaconBlock | BlindedBeaconBlock;
 /**
  *  * class SignedBeaconBlock(Container):
  *   message: BeaconBlock [offset - 4 bytes]
@@ -131,7 +129,7 @@ export function isBlindedBytes(forkSeq: ForkSeq, blockBytes: Uint8Array): boolea
 
 export function serializeFullOrBlindedSignedBeaconBlock(
   config: ChainForkConfig,
-  value: FullOrBlindedSignedBeaconBlock
+  value: SignedBeaconBlock | SignedBlindedBeaconBlock
 ): Uint8Array {
   if (isBlindedSignedBeaconBlock(value)) {
     const type = config.getExecutionForkTypes(value.message.slot).SignedBlindedBeaconBlock;
@@ -144,7 +142,7 @@ export function serializeFullOrBlindedSignedBeaconBlock(
 export function deserializeFullOrBlindedSignedBeaconBlock(
   config: ChainForkConfig,
   bytes: Buffer | Uint8Array
-): FullOrBlindedSignedBeaconBlock {
+): SignedBeaconBlock | SignedBlindedBeaconBlock {
   const slot = getSlotFromSignedBeaconBlockSerialized(bytes);
   if (slot === null) {
     throw Error("getSignedBlockTypeFromBytes: invalid bytes");
@@ -197,7 +195,7 @@ function executionPayloadHeaderToPayload(
 // TODO: (@matthewkeil) not the same as blindedOrFullBlockToFull in state-transition. consider merging?
 export function blindedOrFullBlockToFull(
   config: ChainForkConfig,
-  block: FullOrBlindedSignedBeaconBlock,
+  block: SignedBeaconBlock | SignedBlindedBeaconBlock,
   transactionsAndWithdrawals: Partial<ExecutionPayloadBody>
 ): SignedBeaconBlock {
   if (

--- a/packages/beacon-node/src/util/fullOrBlindedBlock.ts
+++ b/packages/beacon-node/src/util/fullOrBlindedBlock.ts
@@ -199,7 +199,7 @@ export function blindedOrFullBlockToFull(
   if (
     !isBlindedSignedBeaconBlock(block) || // already full
     !isForkExecution(config.getForkName(block.message.slot)) || // no execution payload
-    (block as unknown as SignedBeaconBlock<ForkName.bellatrix>).message.body.executionPayload.timestamp === 0 // before merge
+    (block as unknown as SignedBeaconBlock<ForkName.bellatrix>).message.body.executionPayload?.timestamp === 0 // before merge
   ) {
     return block;
   }

--- a/packages/beacon-node/src/util/fullOrBlindedBlock.ts
+++ b/packages/beacon-node/src/util/fullOrBlindedBlock.ts
@@ -147,7 +147,7 @@ export function deserializeFullOrBlindedSignedBeaconBlock(
   }
 
   return isBlindedBytes(config.getForkSeq(slot), bytes)
-    ? config.getExecutionForkTypes(slot).SignedBeaconBlock.deserialize(bytes)
+    ? config.getExecutionForkTypes(slot).SignedBlindedBeaconBlock.deserialize(bytes)
     : config.getForkTypes(slot).SignedBeaconBlock.deserialize(bytes);
 }
 

--- a/packages/beacon-node/src/util/fullOrBlindedBlock.ts
+++ b/packages/beacon-node/src/util/fullOrBlindedBlock.ts
@@ -1,0 +1,272 @@
+import {ChainForkConfig} from "@lodestar/config";
+import {
+  bellatrix,
+  capella,
+  deneb,
+  ExecutionPayload,
+  ExecutionPayloadHeader,
+  SignedBeaconBlock,
+  SignedBlindedBeaconBlock,
+} from "@lodestar/types";
+import {BYTES_PER_LOGS_BLOOM, ForkSeq, ForkName, isForkExecution, SYNC_COMMITTEE_SIZE} from "@lodestar/params";
+import {executionPayloadToPayloadHeader} from "@lodestar/state-transition";
+import {ExecutionPayloadBody} from "../execution/engine/types.js";
+import {ROOT_SIZE, getSlotFromSignedBeaconBlockSerialized} from "./sszBytes.js";
+
+export type FullOrBlindedSignedBeaconBlock = SignedBeaconBlock | SignedBlindedBeaconBlock;
+/**
+ *  * class SignedBeaconBlock(Container):
+ *   message: BeaconBlock [offset - 4 bytes]
+ *   signature: BLSSignature [fixed - 96 bytes]
+ */
+const SIGNED_BEACON_BLOCK_FIXED_LENGTH = 4 + 96;
+/**
+ * class BeaconBlock(Container) or class BlindedBeaconBlock(Container):
+ *   slot: Slot                      [fixed - 8 bytes]
+ *   proposer_index: ValidatorIndex  [fixed - 8 bytes]
+ *   parent_root: Root               [fixed - 32 bytes]
+ *   state_root: Root                [fixed - 32 bytes]
+ *   body: MaybeBlindBeaconBlockBody [offset - 4 bytes]
+ */
+const BEACON_BLOCK_FIXED_LENGTH = 8 + 8 + 32 + 32 + 4;
+/**
+ * class BeaconBlockBody(Container) or class BlindedBeaconBlockBody(Container):
+ *
+ * Phase 0:
+ *   randaoReveal:                  [fixed -  96 bytes]
+ *   eth1Data: [Container]
+ *     depositRoot:                 [fixed -  32 bytes]
+ *     depositCount:                [fixed -   8 bytes]
+ *     blockHash:                   [fixed -  32 bytes]
+ *   graffiti:                      [fixed -  32 bytes]
+ *   proposerSlashings:             [offset -  4 bytes]
+ *   attesterSlashings:             [offset -  4 bytes]
+ *   attestations:                  [offset -  4 bytes]
+ *   deposits:                      [offset -  4 bytes]
+ *   voluntaryExits:                [offset -  4 bytes]
+ *
+ * Altair:
+ *   syncCommitteeBits:             [fixed -  4 or 64 bytes] (pull from params)
+ *   syncCommitteeSignature:        [fixed -  96 bytes]
+ *
+ * Bellatrix:
+ *   executionPayload:              [offset -  4 bytes]
+ *
+ * Capella:
+ *   blsToExecutionChanges          [offset -  4 bytes]
+ *
+ * Deneb:
+ *   blobKzgCommitments             [offset -  4 bytes]
+ */
+
+const LOCATION_OF_ETH1_BLOCK_HASH = 96 + 32 + 8;
+export function getEth1BlockHashFromSerializedBlock(block: Uint8Array): Uint8Array {
+  const firstByte = SIGNED_BEACON_BLOCK_FIXED_LENGTH + BEACON_BLOCK_FIXED_LENGTH + LOCATION_OF_ETH1_BLOCK_HASH;
+  return block.slice(firstByte, firstByte + ROOT_SIZE);
+}
+
+const LOCATION_OF_EXECUTION_PAYLOAD_OFFSET =
+  LOCATION_OF_ETH1_BLOCK_HASH + 32 + 32 + 4 + 4 + 4 + 4 + 4 + SYNC_COMMITTEE_SIZE / 8 + 96;
+
+/**
+ * class ExecutionPayload(Container) or class ExecutionPayloadHeader(Container)
+ *     parentHash:                  [fixed -  32 bytes]
+ *     feeRecipient:                [fixed -  20 bytes]
+ *     stateRoot:                   [fixed -  32 bytes]
+ *     receiptsRoot:                [fixed -  32 bytes]
+ *     logsBloom:                   [fixed - 256 bytes] (pull from params)
+ *     prevRandao:                  [fixed -  32 bytes]
+ *     blockNumber:                 [fixed -   8 bytes]
+ *     gasLimit:                    [fixed -   8 bytes]
+ *     gasUsed:                     [fixed -   8 bytes]
+ *     timestamp:                   [fixed -   8 bytes]
+ *     extraData:                   [offset -  4 bytes]
+ *     baseFeePerGas:               [fixed -  32 bytes]
+ *     blockHash:                   [fixed -  32 bytes]
+ *     ------------------------------------------------
+ *     transactions:                [offset -  4 bytes]
+ *     - or -
+ *     transactionsRoot:            [fixed -  32 bytes]
+ *
+ * Capella:
+ *     withdrawals:                 [offset -  4 bytes]
+ *     - or -
+ *     withdrawalsRoot:             [fixed -  32 bytes]
+ *     ------------------------------------------------
+ * Deneb:
+ *     dataGasUsed:                 [fixed -   8 bytes]
+ *     excessDataGas:               [fixed -   8 bytes]
+ */
+
+const LOCATION_OF_EXTRA_DATA_OFFSET_WITHIN_EXECUTION_PAYLOAD =
+  32 + 20 + 32 + 32 + BYTES_PER_LOGS_BLOOM + 32 + 8 + 8 + 8 + 8;
+
+export function isBlindedBytes(forkSeq: ForkSeq, blockBytes: Uint8Array): boolean {
+  if (forkSeq < ForkSeq.bellatrix) {
+    return false;
+  }
+
+  const dv = new DataView(blockBytes.buffer, blockBytes.byteOffset, blockBytes.byteLength);
+
+  // read the executionPayload offset, encoded as offset from start of BeaconBlockBody and compensate with the fixed
+  // data length of the SignedBeaconBlock and BeaconBlock to get absolute offset from start of bytes
+  const readExecutionPayloadOffsetAt =
+    LOCATION_OF_EXECUTION_PAYLOAD_OFFSET + SIGNED_BEACON_BLOCK_FIXED_LENGTH + BEACON_BLOCK_FIXED_LENGTH;
+  const executionPayloadOffset =
+    dv.getUint32(readExecutionPayloadOffsetAt, true) + SIGNED_BEACON_BLOCK_FIXED_LENGTH + BEACON_BLOCK_FIXED_LENGTH;
+
+  // read the extraData offset, encoded as offset from start of ExecutionPayload and compensate with absolute offset of
+  // executionPayload to get location of first byte of extraData
+  const readExtraDataOffsetAt = LOCATION_OF_EXTRA_DATA_OFFSET_WITHIN_EXECUTION_PAYLOAD + executionPayloadOffset;
+  const firstByte = dv.getUint32(readExtraDataOffsetAt, true) + executionPayloadOffset;
+
+  // compare first byte of extraData with location of the offset of the extraData.  In full blocks the distance between
+  // the offset and first byte is at maximum 4 + 32 + 32 + 4 + 4 + 8 + 8 = 92.  In blinded blocks the distance at minimum
+  // is 4 + 32 + 32 + 4 + 4 + 32 = 108.  Therefore if the distance is 93 or greater it must be blinded
+  return firstByte - readExtraDataOffsetAt > 92;
+}
+
+// same as isBlindedSignedBeaconBlock but without type narrowing
+export function isBlinded(block: FullOrBlindedSignedBeaconBlock): block is SignedBlindedBeaconBlock {
+  return (block as bellatrix.SignedBlindedBeaconBlock).message.body.executionPayloadHeader !== undefined;
+}
+
+export function serializeFullOrBlindedSignedBeaconBlock(
+  config: ChainForkConfig,
+  value: FullOrBlindedSignedBeaconBlock
+): Uint8Array {
+  if (isBlinded(value)) {
+    const type = config.getExecutionForkTypes(value.message.slot).SignedBlindedBeaconBlock;
+    return type.serialize(value);
+  }
+  const type = config.getForkTypes(value.message.slot).SignedBeaconBlock;
+  return type.serialize(value);
+}
+
+export function deserializeFullOrBlindedSignedBeaconBlock(
+  config: ChainForkConfig,
+  bytes: Buffer | Uint8Array
+): FullOrBlindedSignedBeaconBlock {
+  const slot = getSlotFromSignedBeaconBlockSerialized(bytes);
+  if (slot === null) {
+    throw Error("getSignedBlockTypeFromBytes: invalid bytes");
+  }
+
+  return isBlindedBytes(config.getForkSeq(slot), bytes)
+    ? config.getExecutionForkTypes(slot).SignedBeaconBlock.deserialize(bytes)
+    : config.getForkTypes(slot).SignedBeaconBlock.deserialize(bytes);
+}
+
+export function blindedOrFullBlockToBlinded(
+  config: ChainForkConfig,
+  block: FullOrBlindedSignedBeaconBlock
+): SignedBlindedBeaconBlock {
+  const forkSeq = config.getForkSeq(block.message.slot);
+  if (isBlinded(block) || forkSeq < ForkSeq.bellatrix) {
+    return block as SignedBlindedBeaconBlock;
+  }
+
+  const blinded = {
+    signature: block.signature,
+    message: {
+      ...block.message,
+      body: {
+        randaoReveal: block.message.body.randaoReveal,
+        eth1Data: block.message.body.eth1Data,
+        graffiti: block.message.body.graffiti,
+        proposerSlashings: block.message.body.proposerSlashings,
+        attesterSlashings: block.message.body.attesterSlashings,
+        attestations: block.message.body.attestations,
+        deposits: block.message.body.deposits,
+        voluntaryExits: block.message.body.voluntaryExits,
+        syncAggregate: (block.message.body as bellatrix.BeaconBlockBody).syncAggregate,
+        executionPayloadHeader: executionPayloadToPayloadHeader(
+          forkSeq,
+          (block.message.body as deneb.BeaconBlockBody).executionPayload
+        ),
+      },
+    },
+  };
+
+  if (forkSeq >= ForkSeq.capella) {
+    (blinded as capella.SignedBlindedBeaconBlock).message.body.blsToExecutionChanges = (
+      block as capella.SignedBeaconBlock
+    ).message.body.blsToExecutionChanges;
+  }
+
+  if (forkSeq >= ForkSeq.deneb) {
+    (blinded as deneb.SignedBlindedBeaconBlock).message.body.blobKzgCommitments = (
+      block as deneb.SignedBeaconBlock
+    ).message.body.blobKzgCommitments;
+  }
+
+  return blinded;
+}
+
+function executionPayloadHeaderToPayload(
+  forkSeq: ForkSeq,
+  header: ExecutionPayloadHeader,
+  {transactions, withdrawals}: Partial<ExecutionPayloadBody>
+): ExecutionPayload {
+  const bellatrixPayloadFields: ExecutionPayload = {
+    parentHash: header.parentHash,
+    feeRecipient: header.feeRecipient,
+    stateRoot: header.stateRoot,
+    receiptsRoot: header.receiptsRoot,
+    logsBloom: header.logsBloom,
+    prevRandao: header.prevRandao,
+    blockNumber: header.blockNumber,
+    gasLimit: header.gasLimit,
+    gasUsed: header.gasUsed,
+    timestamp: header.timestamp,
+    extraData: header.extraData,
+    baseFeePerGas: header.baseFeePerGas,
+    blockHash: header.blockHash,
+    transactions: transactions ?? [],
+  };
+
+  if (forkSeq >= ForkSeq.capella) {
+    (bellatrixPayloadFields as capella.ExecutionPayload).withdrawals = withdrawals ?? [];
+  }
+
+  if (forkSeq >= ForkSeq.deneb) {
+    // https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/beacon-chain.md#process_execution_payload
+    (bellatrixPayloadFields as deneb.ExecutionPayload).blobGasUsed = (
+      header as deneb.ExecutionPayloadHeader
+    ).blobGasUsed;
+    (bellatrixPayloadFields as deneb.ExecutionPayload).excessBlobGas = (
+      header as deneb.ExecutionPayloadHeader
+    ).excessBlobGas;
+  }
+
+  return bellatrixPayloadFields;
+}
+
+export function blindedOrFullBlockToFull(
+  config: ChainForkConfig,
+  block: FullOrBlindedSignedBeaconBlock,
+  transactionsAndWithdrawals: Partial<ExecutionPayloadBody>
+): SignedBeaconBlock {
+  if (
+    !isBlinded(block) || // already full
+    !isForkExecution(config.getForkName(block.message.slot)) || // no execution payload
+    (block as unknown as SignedBeaconBlock<ForkName.bellatrix>).message.body.executionPayload.timestamp === 0 // before merge
+  ) {
+    return block;
+  }
+
+  return config.getForkTypes(block.message.slot).SignedBeaconBlock.clone({
+    signature: block.signature,
+    message: {
+      ...block.message,
+      body: {
+        ...block.message.body,
+        executionPayload: executionPayloadHeaderToPayload(
+          config.getForkSeq(block.message.slot),
+          (block.message.body as bellatrix.BlindedBeaconBlockBody).executionPayloadHeader,
+          transactionsAndWithdrawals
+        ),
+      },
+    },
+  });
+}

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -37,7 +37,7 @@ export type CommitteeBitsBase64 = string;
 
 const VARIABLE_FIELD_OFFSET = 4;
 const ATTESTATION_BEACON_BLOCK_ROOT_OFFSET = VARIABLE_FIELD_OFFSET + 8 + 8;
-const ROOT_SIZE = 32;
+export const ROOT_SIZE = 32;
 const SLOT_SIZE = 8;
 const ATTESTATION_DATA_SIZE = 128;
 // MAX_COMMITTEES_PER_SLOT is in bit, need to convert to byte

--- a/packages/beacon-node/test/fixtures/altair.ts
+++ b/packages/beacon-node/test/fixtures/altair.ts
@@ -1,0 +1,28 @@
+import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {ssz, altair} from "@lodestar/types";
+import {BlockGenerationOptionsPhase0, generatePhase0BeaconBlocks} from "./phase0.js";
+import {generateSignature} from "./utils.js";
+
+export function generateSyncAggregate(
+  state: CachedBeaconStateAllForks,
+  block: altair.BeaconBlock
+): altair.SyncAggregate {
+  return {
+    syncCommitteeBits: ssz.altair.SyncCommitteeBits.defaultValue(),
+    syncCommitteeSignature: generateSignature(),
+  };
+}
+
+export interface BlockGenerationOptionsAltair extends BlockGenerationOptionsPhase0 {}
+
+export function generateAltairBeaconBlocks(
+  state: CachedBeaconStateAllForks,
+  count: number,
+  opts?: BlockGenerationOptionsAltair
+): altair.BeaconBlock[] {
+  const blocks = generatePhase0BeaconBlocks(state, count, opts) as altair.BeaconBlock[];
+  for (const block of blocks) {
+    block.body.syncAggregate = generateSyncAggregate(state, block);
+  }
+  return blocks;
+}

--- a/packages/beacon-node/test/fixtures/bellatrix.ts
+++ b/packages/beacon-node/test/fixtures/bellatrix.ts
@@ -1,0 +1,36 @@
+import {ssz, bellatrix} from "@lodestar/types";
+import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {BlockGenerationOptionsAltair, generateAltairBeaconBlocks} from "./altair.js";
+
+export function generateBellatrixExecutionPayload(): bellatrix.ExecutionPayload {
+  return {
+    baseFeePerGas: BigInt(0),
+    blockHash: new Uint8Array(),
+    blockNumber: 0,
+    extraData: new Uint8Array(),
+    feeRecipient: new Uint8Array(),
+    gasLimit: 0,
+    gasUsed: 0,
+    logsBloom: new Uint8Array(),
+    parentHash: new Uint8Array(),
+    prevRandao: new Uint8Array(),
+    receiptsRoot: new Uint8Array(),
+    stateRoot: new Uint8Array(),
+    timestamp: 0,
+    transactions: [ssz.bellatrix.Transaction.defaultValue()],
+  };
+}
+
+export interface BlockGenerationOptionsBellatrix extends BlockGenerationOptionsAltair {}
+
+export function generateBellatrixBeaconBlocks(
+  state: CachedBeaconStateAllForks,
+  count: number,
+  opts?: BlockGenerationOptionsBellatrix
+): bellatrix.BeaconBlock[] {
+  const blocks = generateAltairBeaconBlocks(state, count, opts) as bellatrix.BeaconBlock[];
+  for (const block of blocks) {
+    block.body.executionPayload = generateBellatrixExecutionPayload();
+  }
+  return blocks;
+}

--- a/packages/beacon-node/test/fixtures/capella.ts
+++ b/packages/beacon-node/test/fixtures/capella.ts
@@ -1,8 +1,16 @@
-import {CachedBeaconStateAltair} from "@lodestar/state-transition";
-import {capella} from "@lodestar/types";
+import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {ssz, bellatrix, capella} from "@lodestar/types";
+import {BlockGenerationOptionsBellatrix, generateBellatrixBeaconBlocks} from "./bellatrix.js";
+
+export function generateCapellaExecutionPayload(payload: bellatrix.ExecutionPayload): capella.ExecutionPayload {
+  return {
+    ...payload,
+    withdrawals: [ssz.capella.Withdrawal.defaultValue()],
+  };
+}
 
 export function generateBlsToExecutionChanges(
-  state: CachedBeaconStateAltair,
+  state: CachedBeaconStateAllForks,
   count: number
 ): capella.SignedBLSToExecutionChange[] {
   const result: capella.SignedBLSToExecutionChange[] = [];
@@ -21,4 +29,19 @@ export function generateBlsToExecutionChanges(
   }
 
   return result;
+}
+
+export interface BlockGenerationOptionsCapella extends BlockGenerationOptionsBellatrix {}
+
+export function generateCapellaBeaconBlocks(
+  state: CachedBeaconStateAllForks,
+  count: number,
+  opts?: BlockGenerationOptionsCapella
+): capella.BeaconBlock[] {
+  const blocks = generateBellatrixBeaconBlocks(state, count, opts) as capella.BeaconBlock[];
+  for (const block of blocks) {
+    block.body.executionPayload = generateCapellaExecutionPayload(block.body.executionPayload);
+    block.body.blsToExecutionChanges = generateBlsToExecutionChanges(state, count);
+  }
+  return blocks;
 }

--- a/packages/beacon-node/test/fixtures/deneb.ts
+++ b/packages/beacon-node/test/fixtures/deneb.ts
@@ -1,0 +1,34 @@
+import crypto from "node:crypto";
+import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {capella, deneb} from "@lodestar/types";
+import {MAX_BLOBS_PER_BLOCK} from "@lodestar/params";
+import {generateCapellaBeaconBlocks, BlockGenerationOptionsCapella} from "./capella.js";
+
+export function generateDenebExecutionPayload(payload: capella.ExecutionPayload): deneb.ExecutionPayload {
+  return {
+    ...payload,
+    blobGasUsed: BigInt(0),
+    excessBlobGas: BigInt(0),
+  };
+}
+
+export function generateKzgCommitments(count: number): deneb.BlobKzgCommitments {
+  return Array.from({length: count}, () => Uint8Array.from(crypto.randomBytes(48)));
+}
+
+export interface BlockGenerationOptionsDeneb extends BlockGenerationOptionsCapella {
+  numKzgCommitments: number;
+}
+
+export function generateDenebBeaconBlocks(
+  state: CachedBeaconStateAllForks,
+  count: number,
+  opts?: BlockGenerationOptionsDeneb
+): capella.BeaconBlock[] {
+  const blocks = generateCapellaBeaconBlocks(state, count, opts) as deneb.BeaconBlock[];
+  for (const block of blocks) {
+    block.body.executionPayload = generateDenebExecutionPayload(block.body.executionPayload);
+    block.body.blobKzgCommitments = generateKzgCommitments(opts?.numKzgCommitments ?? MAX_BLOBS_PER_BLOCK);
+  }
+  return blocks;
+}

--- a/packages/beacon-node/test/fixtures/electra.ts
+++ b/packages/beacon-node/test/fixtures/electra.ts
@@ -1,0 +1,26 @@
+import {deneb, electra} from "@lodestar/types";
+import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {BlockGenerationOptionsDeneb, generateDenebBeaconBlocks} from "./deneb.js";
+
+export function generateElectraExecutionPayload(payload: deneb.ExecutionPayload): electra.ExecutionPayload {
+  return {
+    ...payload,
+    depositRequests: [],
+    withdrawalRequests: [],
+    consolidationRequests: [],
+  };
+}
+
+export interface BlockGenerationOptionsElectra extends BlockGenerationOptionsDeneb {}
+
+export function generateElectraBeaconBlocks(
+  state: CachedBeaconStateAllForks,
+  count: number,
+  opts?: BlockGenerationOptionsElectra
+): electra.BeaconBlock[] {
+  const blocks = generateDenebBeaconBlocks(state, count, opts) as electra.BeaconBlock[];
+  for (const block of blocks) {
+    block.body.executionPayload = generateElectraExecutionPayload(block.body.executionPayload);
+  }
+  return blocks;
+}

--- a/packages/beacon-node/test/fixtures/phase0.ts
+++ b/packages/beacon-node/test/fixtures/phase0.ts
@@ -1,14 +1,84 @@
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import crypto from "node:crypto";
 import {
-  CachedBeaconStateAltair,
+  MAX_ATTESTER_SLASHINGS,
+  MAX_DEPOSITS,
+  MAX_PROPOSER_SLASHINGS,
+  MAX_VOLUNTARY_EXITS,
+  SLOTS_PER_EPOCH,
+} from "@lodestar/params";
+import {
+  CachedBeaconStateAllForks,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   getBlockRootAtSlot,
+  getRandaoMix,
 } from "@lodestar/state-transition";
-import {phase0} from "@lodestar/types";
+import {phase0, ssz} from "@lodestar/types";
+import {getDefaultGraffiti} from "../../src/util/graffiti.js";
+import {getLodestarClientVersion} from "../../src/util/metadata.js";
+import {getDepositsWithProofs} from "../../src/eth1/utils/deposits.js";
+import {generateKey, generateSignature, signContainer} from "./utils.js";
+
+export function generateAttestationData(
+  state: CachedBeaconStateAllForks,
+  committeeIndex: number
+): phase0.AttestationData {
+  const slot = state.slot;
+  const epoch = computeEpochAtSlot(slot);
+  return {
+    slot,
+    index: committeeIndex,
+    beaconBlockRoot: getBlockRootAtSlot(state, slot),
+    source: {
+      epoch: state.currentJustifiedCheckpoint.epoch,
+      root: state.currentJustifiedCheckpoint.root,
+    },
+    target: {
+      epoch: epoch,
+      root: getBlockRootAtSlot(state, computeStartSlotAtEpoch(epoch)),
+    },
+  };
+}
+
+export function generateAttestation<T extends boolean>(
+  state: CachedBeaconStateAllForks,
+  committeeIndex: number,
+  indexed: T
+): T extends true ? phase0.IndexedAttestation : phase0.Attestation {
+  const slot = state.slot;
+  const attestation = {
+    data: generateAttestationData(state, committeeIndex),
+    signature: generateSignature(),
+  } as unknown as T extends true ? phase0.IndexedAttestation : phase0.Attestation;
+
+  if (indexed) {
+    (attestation as phase0.IndexedAttestation).attestingIndices = Array.from(
+      state.epochCtx.getBeaconCommittee(slot, committeeIndex)
+    );
+  } else {
+    // TODO: (@matthewkeil) add some mock data here so its not all zeros
+    (attestation as phase0.Attestation).aggregationBits = ssz.phase0.CommitteeBits.defaultValue();
+  }
+
+  return attestation;
+}
+
+export function generateAttestations(state: CachedBeaconStateAllForks): phase0.Attestation[] {
+  const epoch = computeEpochAtSlot(state.slot);
+  const committeeCount = state.epochCtx.getCommitteeCountPerSlot(epoch);
+  const attestations: phase0.Attestation[] = [];
+  for (let committeeIndex = 0; committeeIndex < committeeCount; committeeIndex++) {
+    attestations.push(
+      ...Array.from({length: state.epochCtx.getBeaconCommittee(state.slot, committeeIndex).length}, () =>
+        generateAttestation(state, committeeIndex, false)
+      )
+    );
+  }
+  return attestations;
+}
 
 export function generateIndexedAttestations(
-  state: CachedBeaconStateAltair,
+  state: CachedBeaconStateAllForks,
   count: number
 ): phase0.IndexedAttestation[] {
   const result: phase0.IndexedAttestation[] = [];
@@ -19,24 +89,7 @@ export function generateIndexedAttestations(
     const committeeCount = state.epochCtx.getCommitteeCountPerSlot(epoch);
 
     for (let committeeIndex = 0; committeeIndex < committeeCount; committeeIndex++) {
-      result.push({
-        attestingIndices: Array.from(state.epochCtx.getBeaconCommittee(slot, committeeIndex)),
-        data: {
-          slot: slot,
-          index: committeeIndex,
-          beaconBlockRoot: getBlockRootAtSlot(state, slot),
-          source: {
-            epoch: state.currentJustifiedCheckpoint.epoch,
-            root: state.currentJustifiedCheckpoint.root,
-          },
-          target: {
-            epoch: epoch,
-            root: getBlockRootAtSlot(state, computeStartSlotAtEpoch(epoch)),
-          },
-        },
-        signature: Buffer.alloc(96),
-      });
-
+      result.push(generateAttestation(state, committeeIndex, true));
       if (result.length >= count) return result;
     }
   }
@@ -44,7 +97,10 @@ export function generateIndexedAttestations(
   return result;
 }
 
-export function generateBeaconBlockHeader(state: CachedBeaconStateAltair, count: number): phase0.BeaconBlockHeader[] {
+export function generateBeaconBlockHeaders(
+  state: CachedBeaconStateAllForks,
+  count: number
+): phase0.BeaconBlockHeader[] {
   const headers: phase0.BeaconBlockHeader[] = [];
 
   for (let i = 1; i <= count; i++) {
@@ -67,20 +123,20 @@ export function generateBeaconBlockHeader(state: CachedBeaconStateAltair, count:
   return headers;
 }
 
-export function generateSignedBeaconBlockHeader(
-  state: CachedBeaconStateAltair,
+export function generateSignedBeaconBlockHeaders(
+  state: CachedBeaconStateAllForks,
   count: number
 ): phase0.SignedBeaconBlockHeader[] {
-  const headers = generateBeaconBlockHeader(state, count);
-
-  return headers.map((header) => ({
-    message: header,
-    signature: Buffer.alloc(96),
-  }));
+  return generateBeaconBlockHeaders(state, count).map(signContainer);
 }
 
-export function generateVoluntaryExits(state: CachedBeaconStateAltair, count: number): phase0.SignedVoluntaryExit[] {
+export function generateVoluntaryExits(
+  state: CachedBeaconStateAllForks,
+  count: number = MAX_VOLUNTARY_EXITS
+): phase0.SignedVoluntaryExit[] {
   const result: phase0.SignedVoluntaryExit[] = [];
+
+  if (count > MAX_VOLUNTARY_EXITS) count = MAX_VOLUNTARY_EXITS;
 
   for (const validatorIndex of state.epochCtx.proposers) {
     result.push({
@@ -88,11 +144,129 @@ export function generateVoluntaryExits(state: CachedBeaconStateAltair, count: nu
         epoch: state.currentJustifiedCheckpoint.epoch,
         validatorIndex,
       },
-      signature: Buffer.alloc(96),
+      signature: generateSignature(),
     });
 
     if (result.length >= count) return result;
   }
 
   return result;
+}
+
+export function generateAttesterSlashings(attestations: phase0.IndexedAttestation[]): phase0.AttesterSlashing[] {
+  const slashings: phase0.AttesterSlashing[] = [];
+  for (const attestation of attestations) {
+    slashings.push({
+      attestation1: ssz.phase0.IndexedAttestationBigint.fromJson(ssz.phase0.IndexedAttestation.toJson(attestation)),
+      attestation2: ssz.phase0.IndexedAttestationBigint.fromJson(ssz.phase0.IndexedAttestation.toJson(attestation)),
+    });
+
+    if (slashings.length >= MAX_ATTESTER_SLASHINGS) {
+      return slashings;
+    }
+  }
+  return slashings;
+}
+
+export function generateProposerSlashings(blockHeaders: phase0.SignedBeaconBlockHeader[]): phase0.ProposerSlashing[] {
+  const slashings: phase0.ProposerSlashing[] = [];
+  for (const blockHeader of blockHeaders) {
+    const signedHeader2 = ssz.phase0.SignedBeaconBlockHeaderBigint.fromJson(
+      ssz.phase0.SignedBeaconBlockHeader.toJson(blockHeader)
+    );
+    signedHeader2.message.bodyRoot = crypto.randomBytes(32);
+
+    slashings.push({
+      signedHeader1: ssz.phase0.SignedBeaconBlockHeaderBigint.fromJson(
+        ssz.phase0.SignedBeaconBlockHeader.toJson(blockHeader)
+      ),
+      signedHeader2,
+    });
+
+    if (slashings.length >= MAX_PROPOSER_SLASHINGS) {
+      return slashings;
+    }
+  }
+  return slashings;
+}
+
+export function generateDepositEvents(count: number = MAX_DEPOSITS): phase0.DepositEvent[] {
+  const deposits: phase0.DepositEvent[] = [];
+  if (count > MAX_DEPOSITS) count = MAX_DEPOSITS;
+  for (let i = 0; i < count; i++) {
+    deposits.push({
+      blockNumber: 1,
+      index: 1,
+      depositData: {
+        pubkey: generateKey(),
+        amount: 32 * 10 ** 9,
+        withdrawalCredentials: Buffer.alloc(32, 0x77),
+        signature: generateSignature(),
+      },
+    });
+  }
+  return deposits;
+}
+
+export function generateDeposits(state: CachedBeaconStateAllForks, count: number = MAX_DEPOSITS): phase0.Deposit[] {
+  const depositEvents = generateDepositEvents(count);
+  // TODO: (@matthewkeil) how do you set the deposit root as root node?
+  const depositRootTree = ssz.phase0.DepositDataRootList.toViewDU([state.eth1Data.depositRoot]);
+  return getDepositsWithProofs(depositEvents, depositRootTree, state.eth1Data);
+}
+
+export interface BlockGenerationOptionsPhase0 {
+  numAttesterSlashings?: number;
+  numProposerSlashings?: number;
+  numVoluntaryExits?: number;
+  numDeposits?: number;
+}
+
+export function generatePhase0BeaconBlocks(
+  state: CachedBeaconStateAllForks,
+  count: number,
+  opts?: BlockGenerationOptionsPhase0
+): phase0.BeaconBlock[] {
+  const headers = generateBeaconBlockHeaders(state, count);
+  const attesterSlashings: phase0.AttesterSlashing[] = [];
+  const proposerSlashings: phase0.ProposerSlashing[] = [];
+
+  if (opts?.numProposerSlashings !== undefined) {
+    if (opts.numProposerSlashings > headers.length) {
+      opts.numProposerSlashings = headers.length;
+    }
+    proposerSlashings.push(
+      ...generateProposerSlashings(headers.slice(0, opts.numProposerSlashings).map(signContainer))
+    );
+  }
+
+  if (opts?.numAttesterSlashings !== undefined) {
+    const indexedAttestations = generateIndexedAttestations(state, opts.numAttesterSlashings);
+    attesterSlashings.push(...generateAttesterSlashings(indexedAttestations));
+  }
+
+  const blocks: phase0.BeaconBlock[] = [];
+  for (const header of headers) {
+    // @ts-expect-error can delete
+    delete header.bodyRoot;
+    const block: phase0.BeaconBlock = {
+      ...header,
+      body: {
+        eth1Data: {
+          blockHash: state.eth1Data.blockHash,
+          depositCount: state.eth1Data.depositCount,
+          depositRoot: state.eth1Data.depositRoot,
+        },
+        graffiti: Uint8Array.from(Buffer.from(getDefaultGraffiti(getLodestarClientVersion(), null, {}), "utf8")),
+        randaoReveal: getRandaoMix(state, state.epochCtx.epoch),
+        attestations: generateAttestations(state),
+        attesterSlashings,
+        deposits: generateDeposits(state, opts?.numDeposits),
+        proposerSlashings,
+        voluntaryExits: generateVoluntaryExits(state, opts?.numVoluntaryExits),
+      },
+    };
+    blocks.push(block);
+  }
+  return blocks;
 }

--- a/packages/beacon-node/test/fixtures/utils.ts
+++ b/packages/beacon-node/test/fixtures/utils.ts
@@ -1,0 +1,18 @@
+export function generateKey(): Buffer {
+  return Buffer.alloc(48, 0xaa);
+}
+
+export function generateSignature(): Buffer {
+  return Buffer.alloc(96, 0xaa);
+}
+
+export interface SignedContainer<T> {
+  message: T;
+  signature: Uint8Array;
+}
+export function signContainer<T>(container: T): SignedContainer<T> {
+  return {
+    message: container,
+    signature: generateSignature(),
+  };
+}

--- a/packages/beacon-node/test/mocks/block.ts
+++ b/packages/beacon-node/test/mocks/block.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import {ssz, SignedBlindedBeaconBlock, SignedBeaconBlock} from "@lodestar/types";
+import {ForkInfo, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {mainnetChainConfig} from "@lodestar/config/configs";
+
+const fixturesDirectory = "./__fixtures__/";
+
+/* eslint-disable @typescript-eslint/naming-convention */
+// export this chainConfig for use in tests that consume the mock blocks
+//
+// slots / epoch is 8 vs 32 so need to make epoch transition 4 times larger to match slot numbers in mocks
+// that were taken from mainnet
+export const chainConfig = createChainForkConfig({
+  ...defaultChainConfig,
+  ALTAIR_FORK_EPOCH: mainnetChainConfig.ALTAIR_FORK_EPOCH * 4,
+  BELLATRIX_FORK_EPOCH: mainnetChainConfig.BELLATRIX_FORK_EPOCH * 4,
+  CAPELLA_FORK_EPOCH: mainnetChainConfig.CAPELLA_FORK_EPOCH * 4,
+  DENEB_FORK_EPOCH: mainnetChainConfig.DENEB_FORK_EPOCH * 4,
+});
+/* eslint-enable @typescript-eslint/naming-convention */
+
+const loadSerialized = (filename: string): Buffer =>
+  fs.readFileSync(new URL(fixturesDirectory.concat(filename), import.meta.url));
+
+// NOTE: these mocks were slightly modified so that they would serialize/deserialize with LODESTAR_PRESET=minimal
+// and in particular the sync_committee_bits were shortened to match the minimal preset.  All other conversion is handled
+// via the slots/epoch adjustment above.
+export const phase0SerializedSignedBeaconBlock = loadSerialized("block.phase0.ssz");
+export const altairSerializedSignedBeaconBlock = loadSerialized("block.altair.ssz");
+export const bellatrixSerializedSignedBeaconBlock = loadSerialized("block.bellatrix.ssz");
+export const capellaSerializedSignedBeaconBlock = loadSerialized("block.capella.ssz");
+export const denebSerializedSignedBeaconBlock = loadSerialized("block.deneb.ssz");
+export const bellatrixSerializedSignedBlindedBeaconBlock = loadSerialized("blindedBlock.bellatrix.ssz");
+export const capellaSerializedSignedBlindedBeaconBlock = loadSerialized("blindedBlock.capella.ssz");
+export const denebSerializedSignedBlindedBeaconBlock = loadSerialized("blindedBlock.deneb.ssz");
+
+export const phase0SignedBeaconBlock = ssz.phase0.SignedBeaconBlock.deserialize(phase0SerializedSignedBeaconBlock);
+export const altairSignedBeaconBlock = ssz.altair.SignedBeaconBlock.deserialize(altairSerializedSignedBeaconBlock);
+export const bellatrixSignedBeaconBlock = ssz.bellatrix.SignedBeaconBlock.deserialize(
+  bellatrixSerializedSignedBeaconBlock
+);
+export const capellaSignedBeaconBlock = ssz.capella.SignedBeaconBlock.deserialize(capellaSerializedSignedBeaconBlock);
+export const denebSignedBeaconBlock = ssz.deneb.SignedBeaconBlock.deserialize(denebSerializedSignedBeaconBlock);
+
+export const bellatrixSignedBlindedBeaconBlock = ssz.bellatrix.SignedBlindedBeaconBlock.deserialize(
+  bellatrixSerializedSignedBlindedBeaconBlock
+);
+export const capellaSignedBlindedBeaconBlock = ssz.capella.SignedBlindedBeaconBlock.deserialize(
+  capellaSerializedSignedBlindedBeaconBlock
+);
+export const denebSignedBlindedBeaconBlock = ssz.deneb.SignedBlindedBeaconBlock.deserialize(
+  denebSerializedSignedBlindedBeaconBlock
+);
+
+interface MockBlock {
+  forkInfo: ForkInfo;
+  full: SignedBeaconBlock;
+  fullSerialized: Uint8Array;
+  blinded?: SignedBlindedBeaconBlock;
+  blindedSerialized?: Uint8Array;
+}
+
+export const mockBlocks: MockBlock[] = [
+  {
+    forkInfo: chainConfig.getForkInfo(phase0SignedBeaconBlock.message.slot),
+    full: phase0SignedBeaconBlock,
+    fullSerialized: phase0SerializedSignedBeaconBlock,
+  },
+  {
+    forkInfo: chainConfig.getForkInfo(altairSignedBeaconBlock.message.slot),
+    full: altairSignedBeaconBlock,
+    fullSerialized: altairSerializedSignedBeaconBlock,
+  },
+  {
+    forkInfo: chainConfig.getForkInfo(bellatrixSignedBeaconBlock.message.slot),
+    full: bellatrixSignedBeaconBlock,
+    fullSerialized: bellatrixSerializedSignedBeaconBlock,
+    blinded: bellatrixSignedBlindedBeaconBlock,
+    blindedSerialized: bellatrixSerializedSignedBlindedBeaconBlock,
+  },
+  {
+    forkInfo: chainConfig.getForkInfo(capellaSignedBeaconBlock.message.slot),
+    full: capellaSignedBeaconBlock,
+    fullSerialized: capellaSerializedSignedBeaconBlock,
+    blinded: capellaSignedBlindedBeaconBlock,
+    blindedSerialized: capellaSerializedSignedBlindedBeaconBlock,
+  },
+  {
+    forkInfo: chainConfig.getForkInfo(denebSignedBeaconBlock.message.slot),
+    full: denebSignedBeaconBlock,
+    fullSerialized: denebSerializedSignedBeaconBlock,
+    blinded: denebSignedBlindedBeaconBlock,
+    blindedSerialized: denebSerializedSignedBlindedBeaconBlock,
+  },
+];

--- a/packages/beacon-node/test/perf/chain/opPools/opPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/opPool.test.ts
@@ -13,7 +13,7 @@ import {OpPool} from "../../../../src/chain/opPools/opPool.js";
 import {generateBlsToExecutionChanges} from "../../../fixtures/capella.js";
 import {
   generateIndexedAttestations,
-  generateSignedBeaconBlockHeader,
+  generateSignedBeaconBlockHeaders,
   generateVoluntaryExits,
 } from "../../../fixtures/phase0.js";
 import {BlockType} from "../../../../src/chain/interface.js";
@@ -74,7 +74,7 @@ function fillAttesterSlashing(pool: OpPool, state: CachedBeaconStateAltair, coun
 }
 
 function fillProposerSlashing(pool: OpPool, state: CachedBeaconStateAltair, count: number): OpPool {
-  for (const blockHeader of generateSignedBeaconBlockHeader(state, count)) {
+  for (const blockHeader of generateSignedBeaconBlockHeaders(state, count)) {
     pool.insertProposerSlashing({
       signedHeader1: ssz.phase0.SignedBeaconBlockHeaderBigint.fromJson(
         ssz.phase0.SignedBeaconBlockHeader.toJson(blockHeader)

--- a/packages/beacon-node/test/unit/util/fullOrBlindedBlock.test.ts
+++ b/packages/beacon-node/test/unit/util/fullOrBlindedBlock.test.ts
@@ -1,0 +1,77 @@
+import {describe, it, expect} from "vitest";
+import {ForkInfo} from "@lodestar/config";
+import {SignedBlindedBeaconBlock, SignedBeaconBlock} from "@lodestar/types";
+import {ForkWithdrawals, isForkExecution} from "@lodestar/params";
+import {
+  blindedOrFullBlockToFull,
+  deserializeFullOrBlindedSignedBeaconBlock,
+  isBlindedBytes,
+  serializeFullOrBlindedSignedBeaconBlock,
+} from "../../../src/util/fullOrBlindedBlock.js";
+import {chainConfig, mockBlocks} from "../../mocks/block.js";
+import {byteArrayEquals} from "../../../src/util/bytes.js";
+
+type FullOrBlind = "full" | "blinded";
+type FullOrBlindBlock = [FullOrBlind, ForkInfo, SignedBlindedBeaconBlock | SignedBeaconBlock, Uint8Array];
+
+const fullOrBlindedBlocks = Object.values(mockBlocks)
+  .map(({forkInfo, full, fullSerialized, blinded, blindedSerialized}) => {
+    const fullOrBlindBlock: FullOrBlindBlock[] = [["full", forkInfo, full, fullSerialized]];
+    if (blinded && blindedSerialized) {
+      fullOrBlindBlock.push(["blinded", forkInfo, blinded, blindedSerialized]);
+    }
+    return fullOrBlindBlock;
+  })
+  .flat();
+
+describe("isBlindedBytes", () => {
+  for (const [fullOrBlinded, {seq, name}, , block] of fullOrBlindedBlocks) {
+    it(`should return ${fullOrBlinded === "blinded"} for ${name} ${fullOrBlinded} blocks`, () => {
+      expect(isBlindedBytes(seq, block)).toEqual(isForkExecution(name) && fullOrBlinded === "blinded");
+    });
+  }
+});
+
+describe("serializeFullOrBlindedSignedBeaconBlock", () => {
+  for (const [fullOrBlinded, {name}, block, expected] of fullOrBlindedBlocks) {
+    it(`should serialize ${name} ${fullOrBlinded} block`, () => {
+      const serialized = serializeFullOrBlindedSignedBeaconBlock(chainConfig, block);
+      expect(byteArrayEquals(serialized, expected)).toBeTruthy();
+    });
+  }
+});
+
+describe("deserializeFullOrBlindedSignedBeaconBlock", () => {
+  for (const [fullOrBlinded, {name}, block, serialized] of fullOrBlindedBlocks) {
+    it(`should deserialize ${name} ${fullOrBlinded} block`, () => {
+      const deserialized = deserializeFullOrBlindedSignedBeaconBlock(chainConfig, serialized);
+      const type =
+        isForkExecution(name) && fullOrBlinded === "blinded"
+          ? chainConfig.getExecutionForkTypes(block.message.slot).SignedBlindedBeaconBlock
+          : chainConfig.getForkTypes(block.message.slot).SignedBeaconBlock;
+      expect(type.equals(deserialized as any, block as any)).toBeTruthy();
+    });
+  }
+});
+
+describe("blindedOrFullBlockToFull", function () {
+  for (const {
+    forkInfo: {name},
+    full,
+    blinded,
+  } of mockBlocks) {
+    const transactionsAndWithdrawals = {
+      transactions: (full as SignedBeaconBlock<ForkWithdrawals>).message.body.executionPayload?.transactions ?? [],
+      withdrawals: (full as SignedBeaconBlock<ForkWithdrawals>).message.body.executionPayload?.withdrawals ?? [],
+    };
+    it(`should convert ${name} full to full block`, () => {
+      const result = blindedOrFullBlockToFull(chainConfig, full, transactionsAndWithdrawals);
+      expect(chainConfig.getForkTypes(full.message.slot).SignedBeaconBlock.equals(result, full)).toBeTruthy();
+    });
+    if (!blinded) continue;
+    it(`should convert ${name} blinded to full block`, () => {
+      const result = blindedOrFullBlockToFull(chainConfig, blinded, transactionsAndWithdrawals);
+      expect(chainConfig.getForkTypes(full.message.slot).SignedBeaconBlock.equals(result, full)).toBeTruthy();
+    });
+  }
+});

--- a/packages/cli/test/utils/crucible/assertions/defaults/headAssertion.ts
+++ b/packages/cli/test/utils/crucible/assertions/defaults/headAssertion.ts
@@ -46,7 +46,16 @@ export const headAssertion: Assertion<"head", HeadSummary> = {
      */
     const result = [`Slot,${nodes.map((n) => n.beacon.id).join(", ")}`];
     for (let s = 1; s <= slot; s++) {
-      result.push(`${s}, ${nodes.map((n) => store[n.beacon.id][s].blockRoot ?? "-").join(",")}`);
+      result.push(
+        `${s}, ${nodes
+          .map((n) => {
+            const nodeStore = store[n.beacon.id];
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+            const desiredSlot = nodeStore ? nodeStore[s] : undefined;
+            return desiredSlot ? desiredSlot.blockRoot : "not found";
+          })
+          .join(",")}`
+      );
     }
     return {"headAssertion.csv": result.join("\n")};
   },

--- a/packages/cli/test/utils/crucible/utils/index.ts
+++ b/packages/cli/test/utils/crucible/utils/index.ts
@@ -62,7 +62,7 @@ export function defineSimTestConfig(
       secondsPerSlot: SIM_TESTS_SECONDS_PER_SLOT,
       runTill: opts.runTillEpoch,
       // After adding Nethermind its took longer to complete
-      graceExtraTimeFraction: 0.3,
+      graceExtraTimeFraction: 0.5,
     }) * 1000;
 
   const ttd = getEstimatedTTD({

--- a/packages/cli/test/utils/crucible/utils/index.ts
+++ b/packages/cli/test/utils/crucible/utils/index.ts
@@ -62,7 +62,7 @@ export function defineSimTestConfig(
       secondsPerSlot: SIM_TESTS_SECONDS_PER_SLOT,
       runTill: opts.runTillEpoch,
       // After adding Nethermind its took longer to complete
-      graceExtraTimeFraction: 0.5,
+      graceExtraTimeFraction: 0.8,
     }) * 1000;
 
   const ttd = getEstimatedTTD({

--- a/packages/state-transition/src/signatureSets/proposer.ts
+++ b/packages/state-transition/src/signatureSets/proposer.ts
@@ -1,6 +1,6 @@
 import {DOMAIN_BEACON_PROPOSER} from "@lodestar/params";
-import {SignedBeaconBlock, SignedBlindedBeaconBlock, isBlindedBeaconBlock, phase0, ssz} from "@lodestar/types";
-import {computeSigningRoot} from "../util/index.js";
+import {SignedBeaconBlock, SignedBlindedBeaconBlock, phase0, ssz} from "@lodestar/types";
+import {computeSigningRoot, isBlindedBlock} from "../util/index.js";
 import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../util/signatureSets.js";
 import {CachedBeaconStateAllForks} from "../types.js";
 
@@ -19,7 +19,7 @@ export function getBlockProposerSignatureSet(
   const {config, epochCtx} = state;
   const domain = config.getDomain(state.slot, DOMAIN_BEACON_PROPOSER, signedBlock.message.slot);
 
-  const blockType = isBlindedBeaconBlock(signedBlock.message)
+  const blockType = isBlindedBlock(signedBlock.message)
     ? config.getExecutionForkTypes(signedBlock.message.slot).BlindedBeaconBlock
     : config.getForkTypes(signedBlock.message.slot).BeaconBlock;
 

--- a/packages/state-transition/src/util/blockRoot.ts
+++ b/packages/state-transition/src/util/blockRoot.ts
@@ -6,12 +6,14 @@ import {
   SignedBeaconBlock,
   BeaconBlockHeader,
   SignedBeaconBlockHeader,
+  BlindedBeaconBlock,
 } from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
 import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {ZERO_HASH} from "../constants/index.js";
 import {BeaconStateAllForks} from "../types.js";
 import {computeStartSlotAtEpoch} from "./epoch.js";
+import {blindedOrFullBlockBodyHashTreeRoot} from "./fullOrBlindedBlock.js";
 
 /**
  * Return the block root at a recent [[slot]].
@@ -47,15 +49,16 @@ export function getTemporaryBlockHeader(config: ChainForkConfig, block: BeaconBl
 }
 
 /**
- * Receives a BeaconBlock, and produces the corresponding BeaconBlockHeader.
+ * Receives a FullOrBlindedBeaconBlock, and produces the corresponding BeaconBlockHeader.
  */
-export function blockToHeader(config: ChainForkConfig, block: BeaconBlock): BeaconBlockHeader {
+export function blockToHeader(config: ChainForkConfig, block: BeaconBlock | BlindedBeaconBlock): BeaconBlockHeader {
+  const bodyRoot = blindedOrFullBlockBodyHashTreeRoot(config, block);
   return {
     stateRoot: block.stateRoot,
     proposerIndex: block.proposerIndex,
     slot: block.slot,
     parentRoot: block.parentRoot,
-    bodyRoot: config.getForkTypes(block.slot).BeaconBlockBody.hashTreeRoot(block.body),
+    bodyRoot,
   };
 }
 

--- a/packages/state-transition/src/util/fullOrBlindedBlock.ts
+++ b/packages/state-transition/src/util/fullOrBlindedBlock.ts
@@ -30,6 +30,17 @@ export function blindedOrFullBlockHashTreeRoot(
       config.getForkTypes(blindedOrFull.slot).BeaconBlock.hashTreeRoot(blindedOrFull);
 }
 
+export function blindedOrFullBlockBodyHashTreeRoot(
+  config: ChainForkConfig,
+  blindedOrFull: BeaconBlock | BlindedBeaconBlock
+): Root {
+  return isBlindedBeaconBlock(blindedOrFull)
+    ? // Blinded
+      config.getExecutionForkTypes(blindedOrFull.slot).BlindedBeaconBlockBody.hashTreeRoot(blindedOrFull.body)
+    : // Full
+      config.getForkTypes(blindedOrFull.slot).BeaconBlockBody.hashTreeRoot(blindedOrFull.body);
+}
+
 export function blindedOrFullBlockToHeader(
   config: ChainForkConfig,
   blindedOrFull: BeaconBlock | BlindedBeaconBlock

--- a/packages/state-transition/src/util/index.ts
+++ b/packages/state-transition/src/util/index.ts
@@ -3,7 +3,7 @@ export * from "./array.js";
 export * from "./attestation.js";
 export * from "./attesterStatus.js";
 export * from "./balance.js";
-export * from "./blindedBlock.js";
+export * from "./fullOrBlindedBlock.js";
 export * from "./capella.js";
 export * from "./execution.js";
 export * from "./blockRoot.js";


### PR DESCRIPTION
**Motivation**

Replace #6029 

**Motivation**

Lodestar is saving data that is also saved in the execution client database.  In particular we are persisting transactions and withdrawals in the `block` and `blockArchive` databases.

**Description**

Stores blinded blocks in both the hot and cold db.  Modifies calls for data retrieval that require the full block, ReqResp and API, to splice in the missing transactions and withdrawals.
