### PR TITLE
fix: avoid ssz toHexString

### DIFF
--- a/packages/api/src/beacon/routes/proof.ts
+++ b/packages/api/src/beacon/routes/proof.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {CompactMultiProof, ProofType} from "@chainsafe/persistent-merkle-tree";
-import {ByteListType, ContainerType, fromHexString, toHexString} from "@chainsafe/ssz";
+import {ByteListType, ContainerType, fromHexString} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {ssz} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {ArrayOf} from "../../utils/codecs.js";
 import {VersionCodec, VersionMeta} from "../../utils/metadata.js";
@@ -45,7 +46,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       url: "/eth/v0/beacon/proof/state/{state_id}",
       method: "GET",
       req: {
-        writeReq: ({stateId, descriptor}) => ({params: {state_id: stateId}, query: {format: toHexString(descriptor)}}),
+        writeReq: ({stateId, descriptor}) => ({params: {state_id: stateId}, query: {format: toHex(descriptor)}}),
         parseReq: ({params, query}) => ({stateId: params.state_id, descriptor: fromHexString(query.format)}),
         schema: {params: {state_id: Schema.StringRequired}, query: {format: Schema.StringRequired}},
       },
@@ -63,7 +64,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       url: "/eth/v0/beacon/proof/block/{block_id}",
       method: "GET",
       req: {
-        writeReq: ({blockId, descriptor}) => ({params: {block_id: blockId}, query: {format: toHexString(descriptor)}}),
+        writeReq: ({blockId, descriptor}) => ({params: {block_id: blockId}, query: {format: toHex(descriptor)}}),
         parseReq: ({params, query}) => ({blockId: params.block_id, descriptor: fromHexString(query.format)}),
         schema: {params: {block_id: Schema.StringRequired}, query: {format: Schema.StringRequired}},
       },

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {ContainerType, fromHexString, toHexString, Type, ValueOf} from "@chainsafe/ssz";
+import {ContainerType, fromHexString, Type, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {isForkBlobs} from "@lodestar/params";
 import {
@@ -18,6 +18,7 @@ import {
   BeaconBlockOrContents,
   BlindedBeaconBlock,
 } from "@lodestar/types";
+import {toHex, toRootHex} from "@lodestar/utils";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {fromGraffitiHex, toBoolean, toGraffitiHex} from "../../utils/serdes.js";
 import {getExecutionForkTypes, toForkName} from "../../utils/fork.js";
@@ -596,7 +597,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         writeReq: ({slot, randaoReveal, graffiti, feeRecipient, builderSelection, strictFeeRecipientCheck}) => ({
           params: {slot},
           query: {
-            randao_reveal: toHexString(randaoReveal),
+            randao_reveal: toHex(randaoReveal),
             graffiti: toGraffitiHex(graffiti),
             fee_recipient: feeRecipient,
             builder_selection: builderSelection,
@@ -646,7 +647,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         }) => ({
           params: {slot},
           query: {
-            randao_reveal: toHexString(randaoReveal),
+            randao_reveal: toHex(randaoReveal),
             graffiti: toGraffitiHex(graffiti),
             skip_randao_verification: writeSkipRandaoVerification(skipRandaoVerification),
             fee_recipient: feeRecipient,
@@ -737,7 +738,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       req: {
         writeReq: ({slot, randaoReveal, graffiti}) => ({
           params: {slot},
-          query: {randao_reveal: toHexString(randaoReveal), graffiti: toGraffitiHex(graffiti)},
+          query: {randao_reveal: toHex(randaoReveal), graffiti: toGraffitiHex(graffiti)},
         }),
         parseReq: ({params, query}) => ({
           slot: params.slot,
@@ -777,7 +778,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       method: "GET",
       req: {
         writeReq: ({slot, subcommitteeIndex, beaconBlockRoot}) => ({
-          query: {slot, subcommittee_index: subcommitteeIndex, beacon_block_root: toHexString(beaconBlockRoot)},
+          query: {slot, subcommittee_index: subcommitteeIndex, beacon_block_root: toRootHex(beaconBlockRoot)},
         }),
         parseReq: ({query}) => ({
           slot: query.slot,
@@ -802,7 +803,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       method: "GET",
       req: {
         writeReq: ({attestationDataRoot, slot}) => ({
-          query: {attestation_data_root: toHexString(attestationDataRoot), slot},
+          query: {attestation_data_root: toRootHex(attestationDataRoot), slot},
         }),
         parseReq: ({query}) => ({attestationDataRoot: fromHexString(query.attestation_data_root), slot: query.slot}),
         schema: {

--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {
   ssz,
   bellatrix,
@@ -14,6 +14,7 @@ import {
 import {ForkName, isForkBlobs} from "@lodestar/params";
 import {ChainForkConfig} from "@lodestar/config";
 
+import {toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {Endpoint, RouteDefinitions, Schema} from "../utils/index.js";
 import {MetaHeader, VersionCodec, VersionMeta} from "../utils/metadata.js";
 import {
@@ -105,7 +106,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       method: "GET",
       req: {
         writeReq: ({slot, parentHash, proposerPubkey: proposerPubKey}) => ({
-          params: {slot, parent_hash: toHexString(parentHash), pubkey: toHexString(proposerPubKey)},
+          params: {slot, parent_hash: toRootHex(parentHash), pubkey: toPubkeyHex(proposerPubKey)},
         }),
         parseReq: ({params}) => ({
           slot: params.slot,

--- a/packages/api/src/utils/serdes.ts
+++ b/packages/api/src/utils/serdes.ts
@@ -1,4 +1,5 @@
-import {fromHexString, JsonPath, toHexString} from "@chainsafe/ssz";
+import {fromHexString, JsonPath} from "@chainsafe/ssz";
+import {toHex} from "@lodestar/utils";
 
 /**
  * Serialize proof path to JSON.
@@ -82,7 +83,7 @@ export function toGraffitiHex(utf8?: string): string | undefined {
     return undefined;
   }
 
-  const hex = toHexString(new TextEncoder().encode(utf8));
+  const hex = toHex(new TextEncoder().encode(utf8));
 
   if (hex.length > GRAFFITI_HEX_LENGTH) {
     // remove characters from the end if hex string is too long

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -1,4 +1,3 @@
-import {toHexString} from "@chainsafe/ssz";
 import {capella, ssz, altair, BeaconBlock} from "@lodestar/types";
 import {ForkLightClient, ForkSeq, INTERVALS_PER_SLOT, MAX_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
@@ -8,6 +7,7 @@ import {
   isStateValidatorsNodesPopulated,
   RootCache,
 } from "@lodestar/state-transition";
+import {toHex} from "@lodestar/utils";
 import {routes} from "@lodestar/api";
 import {ForkChoiceError, ForkChoiceErrorCode, EpochDifference, AncestorStatus} from "@lodestar/fork-choice";
 import {isErrorAborted, toRootHex} from "@lodestar/utils";
@@ -431,8 +431,8 @@ export async function importBlock(
             blockRoot: blockRootHex,
             slot: blockSlot,
             index,
-            kzgCommitment: toHexString(kzgCommitment),
-            versionedHash: toHexString(kzgCommitmentToVersionedHash(kzgCommitment)),
+            kzgCommitment: toHex(kzgCommitment),
+            versionedHash: toHex(kzgCommitmentToVersionedHash(kzgCommitment)),
           });
         }
       }

--- a/packages/beacon-node/src/chain/stateCache/datastore/file.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/file.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
-import {toHexString, fromHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {phase0, ssz} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
 import {ensureDir, readFile, readFileNames, removeFile, writeIfNotExist} from "../../../util/file.js";
 import {CPStateDatastore, DatastoreKey} from "./types.js";
 
@@ -28,18 +29,18 @@ export class FileCPStateDatastore implements CPStateDatastore {
 
   async write(cpKey: phase0.Checkpoint, stateBytes: Uint8Array): Promise<DatastoreKey> {
     const serializedCheckpoint = ssz.phase0.Checkpoint.serialize(cpKey);
-    const filePath = path.join(this.folderPath, toHexString(serializedCheckpoint));
+    const filePath = path.join(this.folderPath, toHex(serializedCheckpoint));
     await writeIfNotExist(filePath, stateBytes);
     return serializedCheckpoint;
   }
 
   async remove(serializedCheckpoint: DatastoreKey): Promise<void> {
-    const filePath = path.join(this.folderPath, toHexString(serializedCheckpoint));
+    const filePath = path.join(this.folderPath, toHex(serializedCheckpoint));
     await removeFile(filePath);
   }
 
   async read(serializedCheckpoint: DatastoreKey): Promise<Uint8Array | null> {
-    const filePath = path.join(this.folderPath, toHexString(serializedCheckpoint));
+    const filePath = path.join(this.folderPath, toHex(serializedCheckpoint));
     return readFile(filePath);
   }
 

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -1,7 +1,7 @@
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {phase0, Epoch, RootHex} from "@lodestar/types";
 import {CachedBeaconStateAllForks, computeStartSlotAtEpoch, getBlockRootAtSlot} from "@lodestar/state-transition";
-import {Logger, MapDef, sleep, toRootHex} from "@lodestar/utils";
+import {Logger, MapDef, sleep, toHex, toRootHex} from "@lodestar/utils";
 import {routes} from "@lodestar/api";
 import {loadCachedBeaconState} from "@lodestar/state-transition";
 import {INTERVALS_PER_SLOT} from "@lodestar/params";
@@ -192,7 +192,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       return stateOrStateBytesData?.clone(opts?.dontTransferCache) ?? null;
     }
     const {persistedKey, stateBytes} = stateOrStateBytesData;
-    const logMeta = {persistedKey: toHexString(persistedKey)};
+    const logMeta = {persistedKey: toHex(persistedKey)};
     this.logger.debug("Reload: read state successful", logMeta);
     this.metrics?.stateReloadSecFromSlot.observe(this.clock?.secFromSlot(this.clock?.currentSlot ?? 0) ?? 0);
     const seedState = this.findSeedStateToReload(cp);
@@ -336,7 +336,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       this.logger.verbose("Added checkpoint state to memory but a persisted key existed", {
         epoch: cp.epoch,
         rootHex: cpHex.rootHex,
-        persistedKey: toHexString(persistedKey),
+        persistedKey: toHex(persistedKey),
       });
     } else {
       this.cache.set(key, {type: CacheItemType.inMemory, state});
@@ -675,7 +675,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
           stateSlot: state.slot,
           rootHex,
           epochBoundaryHex,
-          persistedKey: persistedKey ? toHexString(persistedKey) : "",
+          persistedKey: persistedKey ? toHex(persistedKey) : "",
         };
 
         if (persistedRootHexes.has(rootHex)) {
@@ -702,7 +702,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
             persistCount++;
             this.logger.verbose("Pruned checkpoint state from memory and persisted to disk", {
               ...logMeta,
-              persistedKey: toHexString(persistedKey),
+              persistedKey: toHex(persistedKey),
             });
           }
           // overwrite cpKey, this means the state is deleted from memory

--- a/packages/beacon-node/src/eth1/provider/eth1Provider.ts
+++ b/packages/beacon-node/src/eth1/provider/eth1Provider.ts
@@ -1,7 +1,6 @@
-import {toHexString} from "@chainsafe/ssz";
 import {phase0} from "@lodestar/types";
 import {ChainConfig} from "@lodestar/config";
-import {fromHex, isErrorAborted, createElapsedTimeTracker, toPrintableUrl} from "@lodestar/utils";
+import {toHex, fromHex, isErrorAborted, createElapsedTimeTracker, toPrintableUrl} from "@lodestar/utils";
 import {Logger} from "@lodestar/logger";
 
 import {FetchError, isFetchError} from "@lodestar/api";
@@ -72,7 +71,7 @@ export class Eth1Provider implements IEth1Provider {
   ) {
     this.logger = opts.logger;
     this.deployBlock = opts.depositContractDeployBlock ?? 0;
-    this.depositContractAddress = toHexString(config.DEPOSIT_CONTRACT_ADDRESS);
+    this.depositContractAddress = toHex(config.DEPOSIT_CONTRACT_ADDRESS);
 
     const providerUrls = opts.providerUrls ?? DEFAULT_PROVIDER_URLS;
     this.rpc = new JsonRpcHttpClient(providerUrls, {

--- a/packages/beacon-node/src/eth1/provider/utils.ts
+++ b/packages/beacon-node/src/eth1/provider/utils.ts
@@ -1,6 +1,6 @@
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {RootHex} from "@lodestar/types";
-import {bytesToBigInt, bigIntToBytes} from "@lodestar/utils";
+import {bytesToBigInt, bigIntToBytes, toHex} from "@lodestar/utils";
 import {ErrorParseJson} from "./jsonRpcHttpClient.js";
 
 /** QUANTITY as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API */
@@ -32,7 +32,7 @@ export function bytesToHex(bytes: Uint8Array): string {
     return "0x" + bytes[0].toString(16);
   }
 
-  return toHexString(bytes);
+  return toHex(bytes);
 }
 
 /**
@@ -100,7 +100,7 @@ export function bytesToQuantity(bytes: Uint8Array): QUANTITY {
  * - WRONG: 004200 (must be prefixed 0x)
  */
 export function bytesToData(bytes: Uint8Array): DATA {
-  return toHexString(bytes);
+  return toHex(bytes);
 }
 
 /**

--- a/packages/beacon-node/src/network/peers/utils/assertPeerRelevance.ts
+++ b/packages/beacon-node/src/network/peers/utils/assertPeerRelevance.ts
@@ -1,6 +1,5 @@
-import {toHexString} from "@chainsafe/ssz";
 import {ForkDigest, Root, Slot, phase0, ssz} from "@lodestar/types";
-import {toRootHex} from "@lodestar/utils";
+import {toHex, toRootHex} from "@lodestar/utils";
 
 // TODO: Why this value? (From Lighthouse)
 const FUTURE_SLOT_TOLERANCE = 1;
@@ -79,7 +78,7 @@ export function isZeroRoot(root: Root): boolean {
 export function renderIrrelevantPeerType(type: IrrelevantPeerType): string {
   switch (type.code) {
     case IrrelevantPeerCode.INCOMPATIBLE_FORKS:
-      return `INCOMPATIBLE_FORKS ours: ${toHexString(type.ours)} theirs: ${toHexString(type.theirs)}`;
+      return `INCOMPATIBLE_FORKS ours: ${toHex(type.ours)} theirs: ${toHex(type.theirs)}`;
     case IrrelevantPeerCode.DIFFERENT_CLOCKS:
       return `DIFFERENT_CLOCKS slotDiff: ${type.slotDiff}`;
     case IrrelevantPeerCode.DIFFERENT_FINALIZED:

--- a/packages/beacon-node/test/e2e/chain/proposerBoostReorg.test.ts
+++ b/packages/beacon-node/test/e2e/chain/proposerBoostReorg.test.ts
@@ -4,7 +4,7 @@ import {TimestampFormatCode} from "@lodestar/logger";
 import {ChainConfig} from "@lodestar/config";
 import {RootHex, Slot} from "@lodestar/types";
 import {routes} from "@lodestar/api";
-import {toHexString} from "@lodestar/utils";
+import {toHex} from "@lodestar/utils";
 import {LogLevel, TestLoggerOpts, testLogger} from "../../utils/logger.js";
 import {getDevBeaconNode} from "../../utils/node/beacon.js";
 import {TimelinessForkChoice} from "../../mocks/fork-choice/timeliness.js";
@@ -124,10 +124,10 @@ describe("proposer boost reorg", function () {
     expect(reorgEventData.oldHeadBlock).toEqual(reorgBlockRoot);
     expect(reorgEventData.newHeadBlock).toEqual(newBlockEventData.block);
     expect(reorgEventData.depth).toEqual(2);
-    expect(toHexString(newBlock?.block.message.parentRoot)).toEqual(commonAncestorRoot);
+    expect(toHex(newBlock?.block.message.parentRoot)).toEqual(commonAncestorRoot);
     logger.info("New block", {
       slot: newBlock.block.message.slot,
-      parentRoot: toHexString(newBlock.block.message.parentRoot),
+      parentRoot: toHex(newBlock.block.message.parentRoot),
     });
   });
 });

--- a/packages/beacon-node/test/unit/chain/stateCache/persistentCheckpointsCache.test.ts
+++ b/packages/beacon-node/test/unit/chain/stateCache/persistentCheckpointsCache.test.ts
@@ -2,7 +2,7 @@ import {describe, it, expect, beforeAll, beforeEach} from "vitest";
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {CachedBeaconStateAllForks, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {RootHex, phase0} from "@lodestar/types";
-import {mapValues, toHexString} from "@lodestar/utils";
+import {mapValues, toHex} from "@lodestar/utils";
 import {PersistentCheckpointStateCache} from "../../../../src/chain/stateCache/persistentCheckpointsCache.js";
 import {checkpointToDatastoreKey} from "../../../../src/chain/stateCache/datastore/index.js";
 import {generateCachedState} from "../../../utils/state.js";
@@ -45,7 +45,7 @@ describe("PersistentCheckpointStateCache", function () {
     cp1 = {epoch: 21, root: root1};
     cp2 = {epoch: 22, root: root2};
     [cp0aHex, cp0bHex, cp1Hex, cp2Hex] = [cp0a, cp0b, cp1, cp2].map((cp) => toCheckpointHex(cp));
-    persistent0bKey = toHexString(checkpointToDatastoreKey(cp0b));
+    persistent0bKey = toHex(checkpointToDatastoreKey(cp0b));
     const allStates = [cp0a, cp0b, cp1, cp2]
       .map((cp) => generateCachedState({slot: cp.epoch * SLOTS_PER_EPOCH}))
       .map((state, i) => {
@@ -117,7 +117,7 @@ describe("PersistentCheckpointStateCache", function () {
 
   it("getOrReloadLatest", async () => {
     cache.add(cp2, states["cp2"]);
-    expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
+    expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
 
     // cp0b is persisted
     expect(fileApisBuffer.size).toEqual(1);
@@ -140,7 +140,7 @@ describe("PersistentCheckpointStateCache", function () {
     expect(((await cache.getStateOrBytes(cp0bHex)) as CachedBeaconStateAllForks).hashTreeRoot()).toEqual(
       states["cp0b"].hashTreeRoot()
     );
-    expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
+    expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
     // cp0 is persisted
     expect(fileApisBuffer.size).toEqual(1);
     expect(Array.from(fileApisBuffer.keys())).toEqual([persistent0bKey]);
@@ -184,7 +184,7 @@ describe("PersistentCheckpointStateCache", function () {
     //                       0a
     it("single state at lowest memory epoch", async function () {
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
       expect(cache.findSeedStateToReload(cp0aHex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(cache.findSeedStateToReload(cp0bHex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
     });
@@ -200,7 +200,7 @@ describe("PersistentCheckpointStateCache", function () {
     //                           cp1a={0a, 21}       {0a, 22}=cp2a
     it("multiple states at lowest memory epoch", async function () {
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
 
       const cp1a = {epoch: 21, root: root0a};
       const cp1aState = states["cp0a"].clone();
@@ -220,7 +220,7 @@ describe("PersistentCheckpointStateCache", function () {
       const state3 = cp2aState.clone();
       state3.slot = 22 * SLOTS_PER_EPOCH + 3;
       state3.commit();
-      await cache.processState(toHexString(root3), state3);
+      await cache.processState(toHex(root3), state3);
 
       // state of {0a, 21} is choosen because it was built from cp0a
       expect(cache.findSeedStateToReload(cp0aHex)?.hashTreeRoot()).toEqual(cp1aState.hashTreeRoot());
@@ -228,7 +228,7 @@ describe("PersistentCheckpointStateCache", function () {
       expect(cache.findSeedStateToReload(cp0bHex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       const randomRoot = Buffer.alloc(32, 101);
       // for other random root it'll pick the first state of epoch 21 which is states["cp1"]
-      expect(cache.findSeedStateToReload({epoch: 20, rootHex: toHexString(randomRoot)})?.hashTreeRoot()).toEqual(
+      expect(cache.findSeedStateToReload({epoch: 20, rootHex: toHex(randomRoot)})?.hashTreeRoot()).toEqual(
         states["cp1"].hashTreeRoot()
       );
     });
@@ -262,7 +262,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("no reorg", async function () {
       expect(fileApisBuffer.size).toEqual(0);
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
       expect(cache.get(cp2Hex)?.hashTreeRoot()).toEqual(states["cp2"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -271,7 +271,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot3.slot = 22 * SLOTS_PER_EPOCH + 3;
       const root3 = Buffer.alloc(32, 100);
       // process state of root3
-      await cache.processState(toHexString(root3), blockStateRoot3);
+      await cache.processState(toHex(root3), blockStateRoot3);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       // epoch 22 has 1 checkpoint state
@@ -297,7 +297,7 @@ describe("PersistentCheckpointStateCache", function () {
       // mostly the same to the above test
       expect(fileApisBuffer.size).toEqual(0);
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
       expect(cache.get(cp2Hex)?.hashTreeRoot()).toEqual(states["cp2"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -306,14 +306,14 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot3.slot = 22 * SLOTS_PER_EPOCH + 3;
       const root3 = Buffer.alloc(32, 100);
       // process state of root3
-      await cache.processState(toHexString(root3), blockStateRoot3);
+      await cache.processState(toHex(root3), blockStateRoot3);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       const blockStateRoot4 = states["cp2"].clone();
       blockStateRoot4.slot = 22 * SLOTS_PER_EPOCH + 4;
       const root4 = Buffer.alloc(32, 101);
       // process state of root4
-      await cache.processState(toHexString(root4), blockStateRoot4);
+      await cache.processState(toHex(root4), blockStateRoot4);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       // epoch 22 has 1 checkpoint state
@@ -341,7 +341,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("reorg 1 epoch", async function () {
       // process root2 state
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       // regen generates cp2a
@@ -360,7 +360,7 @@ describe("PersistentCheckpointStateCache", function () {
 
       const root3 = Buffer.alloc(32, 101);
       // process state of root3
-      await cache.processState(toHexString(root3), blockStateRoot3);
+      await cache.processState(toHex(root3), blockStateRoot3);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // epoch 22 has 2 checkpoint states
       expect(cache.get(cp2Hex)).not.toBeNull();
@@ -385,7 +385,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("reorg 2 epochs", async function () {
       // process root2 state
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       // reload cp0b from disk
@@ -413,7 +413,7 @@ describe("PersistentCheckpointStateCache", function () {
 
       const root3 = Buffer.alloc(32, 101);
       // process state of root3
-      await cache.processState(toHexString(root3), blockStateRoot3);
+      await cache.processState(toHex(root3), blockStateRoot3);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // epoch 21 and 22 have 2 checkpoint states
       expect(cache.get(cp1Hex)).not.toBeNull();
@@ -438,7 +438,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("reorg 3 epochs, persist cp 0a", async function () {
       // process root2 state
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // cp0a was pruned from memory and not in disc
       expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -469,7 +469,7 @@ describe("PersistentCheckpointStateCache", function () {
 
       const root3 = Buffer.alloc(32, 100);
       // process state of root3
-      expect(await cache.processState(toHexString(root3), blockStateRoot3)).toEqual(1);
+      expect(await cache.processState(toHex(root3), blockStateRoot3)).toEqual(1);
       await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
       // epoch 21 and 22 have 2 checkpoint states
       expect(cache.get(cp1Hex)).not.toBeNull();
@@ -494,7 +494,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("reorg 3 epochs, prune but no persist", async function () {
       // process root2 state
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // cp0a was pruned from memory and not in disc
       expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -524,7 +524,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot3.slot = 22 * SLOTS_PER_EPOCH + 3;
       const root3 = Buffer.alloc(32, 100);
       // process state of root3, nothing is persisted
-      expect(await cache.processState(toHexString(root3), blockStateRoot3)).toEqual(0);
+      expect(await cache.processState(toHex(root3), blockStateRoot3)).toEqual(0);
       // but state of cp0b is pruned from memory
       expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -567,7 +567,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("no reorg", async () => {
       expect(fileApisBuffer.size).toEqual(0);
       cache.add(cp1, states["cp1"]);
-      expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
+      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -576,7 +576,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2
-      await cache.processState(toHexString(root2), blockStateRoot2);
+      await cache.processState(toHex(root2), blockStateRoot2);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
 
@@ -602,7 +602,7 @@ describe("PersistentCheckpointStateCache", function () {
       // almost the same to "no reorg" test
       expect(fileApisBuffer.size).toEqual(0);
       cache.add(cp1, states["cp1"]);
-      expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
+      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -611,14 +611,14 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2
-      await cache.processState(toHexString(root2), blockStateRoot2);
+      await cache.processState(toHex(root2), blockStateRoot2);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       const blockStateRoot3 = states["cp1"].clone();
       blockStateRoot3.slot = 21 * SLOTS_PER_EPOCH + 4;
       const root3 = Buffer.alloc(32, 101);
       // process state of root3
-      await cache.processState(toHexString(root3), blockStateRoot3);
+      await cache.processState(toHex(root3), blockStateRoot3);
 
       // epoch 21 has 1 checkpoint state
       expect(cache.get(cp1Hex)).not.toBeNull();
@@ -646,13 +646,13 @@ describe("PersistentCheckpointStateCache", function () {
       const state1a = states["cp0b"].clone();
       state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - 1;
       state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-      expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(0);
+      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(0);
       expect(fileApisBuffer.size).toEqual(0);
       await assertPersistedCheckpointState([], []);
 
       // cp1
       cache.add(cp1, states["cp1"]);
-      expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
+      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -667,7 +667,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2
-      expect(await cache.processState(toHexString(root2), blockStateRoot2)).toEqual(0);
+      expect(await cache.processState(toHex(root2), blockStateRoot2)).toEqual(0);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       // keep these 2 cp states at epoch 21
@@ -686,7 +686,7 @@ describe("PersistentCheckpointStateCache", function () {
       expect(fileApisBuffer.size).toEqual(0);
       // cp1
       cache.add(cp1, states["cp1"]);
-      expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
+      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -706,7 +706,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2, nothing is persisted
-      expect(await cache.processState(toHexString(root2), blockStateRoot2)).toEqual(0);
+      expect(await cache.processState(toHex(root2), blockStateRoot2)).toEqual(0);
 
       // but cp0b in-memory state is pruned
       expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
@@ -731,7 +731,7 @@ describe("PersistentCheckpointStateCache", function () {
       const state1a = states["cp0a"].clone();
       state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - 1;
       state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-      expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(0);
+      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(0);
       expect(fileApisBuffer.size).toEqual(0);
       // at epoch 20, there should be 2 cps in memory
       expect(cache.get(cp0aHex)).not.toBeNull();
@@ -740,7 +740,7 @@ describe("PersistentCheckpointStateCache", function () {
 
       // cp1
       cache.add(cp1, states["cp1"]);
-      expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
+      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -762,7 +762,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2, persist cp0a
-      expect(await cache.processState(toHexString(root2), blockStateRoot2)).toEqual(1);
+      expect(await cache.processState(toHex(root2), blockStateRoot2)).toEqual(1);
       await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       // keep these 2 cp states at epoch 21
@@ -782,7 +782,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("reorg 2 epochs", async () => {
       // cp1
       cache.add(cp1, states["cp1"]);
-      expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
+      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -804,7 +804,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2, persist cp0a
-      expect(await cache.processState(toHexString(root2), blockStateRoot2)).toEqual(1);
+      expect(await cache.processState(toHex(root2), blockStateRoot2)).toEqual(1);
       await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       // keep these 2 cp states at epoch 21
@@ -837,7 +837,7 @@ describe("PersistentCheckpointStateCache", function () {
       //                       |
       //                       0a
       it("no reorg", async () => {
-        expect(await cache.processState(toHexString(root0b), states["cp0b"])).toEqual(1);
+        expect(await cache.processState(toHex(root0b), states["cp0b"])).toEqual(1);
         await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
@@ -846,7 +846,7 @@ describe("PersistentCheckpointStateCache", function () {
         const state1a = states["cp0b"].clone();
         state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH + 3;
         state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-        expect(await cache.processState(toHexString(root1a), state1a)).toEqual(0);
+        expect(await cache.processState(toHex(root1a), state1a)).toEqual(0);
 
         // nothing change
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -861,7 +861,7 @@ describe("PersistentCheckpointStateCache", function () {
       //                       |  \        |
       //                       0a  \------root1b
       it("reorg in same epoch", async () => {
-        expect(await cache.processState(toHexString(root0b), states["cp0b"])).toEqual(1);
+        expect(await cache.processState(toHex(root0b), states["cp0b"])).toEqual(1);
         await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
@@ -870,7 +870,7 @@ describe("PersistentCheckpointStateCache", function () {
         const state1a = states["cp0b"].clone();
         state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH + 3;
         state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-        expect(await cache.processState(toHexString(root1a), state1a)).toEqual(0);
+        expect(await cache.processState(toHex(root1a), state1a)).toEqual(0);
 
         // nothing change
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -886,7 +886,7 @@ describe("PersistentCheckpointStateCache", function () {
         state1b.slot = state1a.slot + 1;
         state1b.blockRoots.set(state1b.slot % SLOTS_PER_HISTORICAL_ROOT, root1b);
         // but no need to persist cp1b
-        expect(await cache.processState(toHexString(root1b), state1b)).toEqual(0);
+        expect(await cache.processState(toHex(root1b), state1b)).toEqual(0);
         // although states["cp0b"] is pruned
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -934,7 +934,7 @@ describe("PersistentCheckpointStateCache", function () {
         cache.add(cp0a, states["cp0a"]);
 
         // need to persist 2 checkpoint states
-        expect(await cache.processState(toHexString(root1b), state1b)).toEqual(2);
+        expect(await cache.processState(toHex(root1b), state1b)).toEqual(2);
         // both are persisited
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
         expect(await cache.getStateOrBytes(cp0aHex)).toEqual(stateBytes["cp0a"]);
@@ -949,7 +949,7 @@ describe("PersistentCheckpointStateCache", function () {
       //                       |           |
       //                       0a---------root1b
       it("reorg 1 epoch, processState twice", async () => {
-        expect(await cache.processState(toHexString(root0b), states["cp0b"])).toEqual(1);
+        expect(await cache.processState(toHex(root0b), states["cp0b"])).toEqual(1);
         await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
@@ -958,7 +958,7 @@ describe("PersistentCheckpointStateCache", function () {
         const state1a = states["cp0b"].clone();
         state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH + 3;
         state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-        expect(await cache.processState(toHexString(root1a), state1a)).toEqual(0);
+        expect(await cache.processState(toHex(root1a), state1a)).toEqual(0);
 
         // nothing change
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -970,7 +970,7 @@ describe("PersistentCheckpointStateCache", function () {
         state1b.blockRoots.set(state1b.slot % SLOTS_PER_HISTORICAL_ROOT, root1b);
         // regen should reload cp0a from disk
         cache.add(cp0a, states["cp0a"]);
-        expect(await cache.processState(toHexString(root1b), state1b)).toEqual(1);
+        expect(await cache.processState(toHex(root1b), state1b)).toEqual(1);
         await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
 
         // both cp0a and cp0b are persisted
@@ -988,13 +988,13 @@ describe("PersistentCheckpointStateCache", function () {
       //                                    ^
       //                                  {0a, 21}=cp1a
       it("reorg 2 epochs", async () => {
-        expect(await cache.processState(toHexString(root0b), states["cp0b"])).toEqual(1);
+        expect(await cache.processState(toHex(root0b), states["cp0b"])).toEqual(1);
         await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
 
         cache.add(cp1, states["cp1"]);
-        expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(1);
+        expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
         await assertPersistedCheckpointState([cp0b, cp1], [stateBytes["cp0b"], stateBytes["cp1"]]);
 
         // regen should populate cp0a and cp1a checkpoint states
@@ -1010,7 +1010,7 @@ describe("PersistentCheckpointStateCache", function () {
         const state2 = cp1aState.clone();
         state2.slot = 21 * SLOTS_PER_EPOCH + 3;
         state2.blockRoots.set(state2.slot % SLOTS_PER_HISTORICAL_ROOT, root2);
-        expect(await cache.processState(toHexString(root2), state2)).toEqual(2);
+        expect(await cache.processState(toHex(root2), state2)).toEqual(2);
         // expect 4 cp states are persisted
         await assertPersistedCheckpointState(
           [cp0b, cp1, cp0a, cp1a],
@@ -1021,7 +1021,7 @@ describe("PersistentCheckpointStateCache", function () {
   });
 
   async function assertPersistedCheckpointState(cps: phase0.Checkpoint[], stateBytesArr: Uint8Array[]): Promise<void> {
-    const persistedKeys = cps.map((cp) => toHexString(checkpointToDatastoreKey(cp)));
+    const persistedKeys = cps.map((cp) => toHex(checkpointToDatastoreKey(cp)));
     expect(Array.from(fileApisBuffer.keys())).toStrictEqual(persistedKeys);
     for (const [i, persistedKey] of persistedKeys.entries()) {
       expect(fileApisBuffer.get(persistedKey)).toStrictEqual(stateBytesArr[i]);

--- a/packages/beacon-node/test/unit/chain/stateCache/persistentCheckpointsCache.test.ts
+++ b/packages/beacon-node/test/unit/chain/stateCache/persistentCheckpointsCache.test.ts
@@ -2,7 +2,7 @@ import {describe, it, expect, beforeAll, beforeEach} from "vitest";
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {CachedBeaconStateAllForks, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {RootHex, phase0} from "@lodestar/types";
-import {mapValues, toHex} from "@lodestar/utils";
+import {mapValues, toHex, toRootHex} from "@lodestar/utils";
 import {PersistentCheckpointStateCache} from "../../../../src/chain/stateCache/persistentCheckpointsCache.js";
 import {checkpointToDatastoreKey} from "../../../../src/chain/stateCache/datastore/index.js";
 import {generateCachedState} from "../../../utils/state.js";
@@ -117,7 +117,7 @@ describe("PersistentCheckpointStateCache", function () {
 
   it("getOrReloadLatest", async () => {
     cache.add(cp2, states["cp2"]);
-    expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
+    expect(await cache.processState(toRootHex(cp2.root), states["cp2"])).toEqual(1);
 
     // cp0b is persisted
     expect(fileApisBuffer.size).toEqual(1);
@@ -140,7 +140,7 @@ describe("PersistentCheckpointStateCache", function () {
     expect(((await cache.getStateOrBytes(cp0bHex)) as CachedBeaconStateAllForks).hashTreeRoot()).toEqual(
       states["cp0b"].hashTreeRoot()
     );
-    expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
+    expect(await cache.processState(toRootHex(cp2.root), states["cp2"])).toEqual(1);
     // cp0 is persisted
     expect(fileApisBuffer.size).toEqual(1);
     expect(Array.from(fileApisBuffer.keys())).toEqual([persistent0bKey]);
@@ -184,7 +184,7 @@ describe("PersistentCheckpointStateCache", function () {
     //                       0a
     it("single state at lowest memory epoch", async function () {
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp2.root), states["cp2"])).toEqual(1);
       expect(cache.findSeedStateToReload(cp0aHex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(cache.findSeedStateToReload(cp0bHex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
     });
@@ -200,7 +200,7 @@ describe("PersistentCheckpointStateCache", function () {
     //                           cp1a={0a, 21}       {0a, 22}=cp2a
     it("multiple states at lowest memory epoch", async function () {
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp2.root), states["cp2"])).toEqual(1);
 
       const cp1a = {epoch: 21, root: root0a};
       const cp1aState = states["cp0a"].clone();
@@ -220,7 +220,7 @@ describe("PersistentCheckpointStateCache", function () {
       const state3 = cp2aState.clone();
       state3.slot = 22 * SLOTS_PER_EPOCH + 3;
       state3.commit();
-      await cache.processState(toHex(root3), state3);
+      await cache.processState(toRootHex(root3), state3);
 
       // state of {0a, 21} is choosen because it was built from cp0a
       expect(cache.findSeedStateToReload(cp0aHex)?.hashTreeRoot()).toEqual(cp1aState.hashTreeRoot());
@@ -228,7 +228,7 @@ describe("PersistentCheckpointStateCache", function () {
       expect(cache.findSeedStateToReload(cp0bHex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       const randomRoot = Buffer.alloc(32, 101);
       // for other random root it'll pick the first state of epoch 21 which is states["cp1"]
-      expect(cache.findSeedStateToReload({epoch: 20, rootHex: toHex(randomRoot)})?.hashTreeRoot()).toEqual(
+      expect(cache.findSeedStateToReload({epoch: 20, rootHex: toRootHex(randomRoot)})?.hashTreeRoot()).toEqual(
         states["cp1"].hashTreeRoot()
       );
     });
@@ -262,7 +262,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("no reorg", async function () {
       expect(fileApisBuffer.size).toEqual(0);
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp2.root), states["cp2"])).toEqual(1);
       expect(cache.get(cp2Hex)?.hashTreeRoot()).toEqual(states["cp2"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -271,7 +271,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot3.slot = 22 * SLOTS_PER_EPOCH + 3;
       const root3 = Buffer.alloc(32, 100);
       // process state of root3
-      await cache.processState(toHex(root3), blockStateRoot3);
+      await cache.processState(toRootHex(root3), blockStateRoot3);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       // epoch 22 has 1 checkpoint state
@@ -297,7 +297,7 @@ describe("PersistentCheckpointStateCache", function () {
       // mostly the same to the above test
       expect(fileApisBuffer.size).toEqual(0);
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp2.root), states["cp2"])).toEqual(1);
       expect(cache.get(cp2Hex)?.hashTreeRoot()).toEqual(states["cp2"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -306,14 +306,14 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot3.slot = 22 * SLOTS_PER_EPOCH + 3;
       const root3 = Buffer.alloc(32, 100);
       // process state of root3
-      await cache.processState(toHex(root3), blockStateRoot3);
+      await cache.processState(toRootHex(root3), blockStateRoot3);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       const blockStateRoot4 = states["cp2"].clone();
       blockStateRoot4.slot = 22 * SLOTS_PER_EPOCH + 4;
       const root4 = Buffer.alloc(32, 101);
       // process state of root4
-      await cache.processState(toHex(root4), blockStateRoot4);
+      await cache.processState(toRootHex(root4), blockStateRoot4);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       // epoch 22 has 1 checkpoint state
@@ -341,7 +341,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("reorg 1 epoch", async function () {
       // process root2 state
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp2.root), states["cp2"])).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       // regen generates cp2a
@@ -360,7 +360,7 @@ describe("PersistentCheckpointStateCache", function () {
 
       const root3 = Buffer.alloc(32, 101);
       // process state of root3
-      await cache.processState(toHex(root3), blockStateRoot3);
+      await cache.processState(toRootHex(root3), blockStateRoot3);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // epoch 22 has 2 checkpoint states
       expect(cache.get(cp2Hex)).not.toBeNull();
@@ -385,7 +385,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("reorg 2 epochs", async function () {
       // process root2 state
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp2.root), states["cp2"])).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       // reload cp0b from disk
@@ -413,7 +413,7 @@ describe("PersistentCheckpointStateCache", function () {
 
       const root3 = Buffer.alloc(32, 101);
       // process state of root3
-      await cache.processState(toHex(root3), blockStateRoot3);
+      await cache.processState(toRootHex(root3), blockStateRoot3);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // epoch 21 and 22 have 2 checkpoint states
       expect(cache.get(cp1Hex)).not.toBeNull();
@@ -438,7 +438,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("reorg 3 epochs, persist cp 0a", async function () {
       // process root2 state
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp2.root), states["cp2"])).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // cp0a was pruned from memory and not in disc
       expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -469,7 +469,7 @@ describe("PersistentCheckpointStateCache", function () {
 
       const root3 = Buffer.alloc(32, 100);
       // process state of root3
-      expect(await cache.processState(toHex(root3), blockStateRoot3)).toEqual(1);
+      expect(await cache.processState(toRootHex(root3), blockStateRoot3)).toEqual(1);
       await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
       // epoch 21 and 22 have 2 checkpoint states
       expect(cache.get(cp1Hex)).not.toBeNull();
@@ -494,7 +494,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("reorg 3 epochs, prune but no persist", async function () {
       // process root2 state
       cache.add(cp2, states["cp2"]);
-      expect(await cache.processState(toHex(cp2.root), states["cp2"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp2.root), states["cp2"])).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // cp0a was pruned from memory and not in disc
       expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -524,7 +524,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot3.slot = 22 * SLOTS_PER_EPOCH + 3;
       const root3 = Buffer.alloc(32, 100);
       // process state of root3, nothing is persisted
-      expect(await cache.processState(toHex(root3), blockStateRoot3)).toEqual(0);
+      expect(await cache.processState(toRootHex(root3), blockStateRoot3)).toEqual(0);
       // but state of cp0b is pruned from memory
       expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -567,7 +567,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("no reorg", async () => {
       expect(fileApisBuffer.size).toEqual(0);
       cache.add(cp1, states["cp1"]);
-      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -576,7 +576,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2
-      await cache.processState(toHex(root2), blockStateRoot2);
+      await cache.processState(toRootHex(root2), blockStateRoot2);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
 
@@ -602,7 +602,7 @@ describe("PersistentCheckpointStateCache", function () {
       // almost the same to "no reorg" test
       expect(fileApisBuffer.size).toEqual(0);
       cache.add(cp1, states["cp1"]);
-      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -611,14 +611,14 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2
-      await cache.processState(toHex(root2), blockStateRoot2);
+      await cache.processState(toRootHex(root2), blockStateRoot2);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       const blockStateRoot3 = states["cp1"].clone();
       blockStateRoot3.slot = 21 * SLOTS_PER_EPOCH + 4;
       const root3 = Buffer.alloc(32, 101);
       // process state of root3
-      await cache.processState(toHex(root3), blockStateRoot3);
+      await cache.processState(toRootHex(root3), blockStateRoot3);
 
       // epoch 21 has 1 checkpoint state
       expect(cache.get(cp1Hex)).not.toBeNull();
@@ -646,13 +646,13 @@ describe("PersistentCheckpointStateCache", function () {
       const state1a = states["cp0b"].clone();
       state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - 1;
       state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(0);
+      expect(await cache.processState(toRootHex(cp1.root), states["cp1"])).toEqual(0);
       expect(fileApisBuffer.size).toEqual(0);
       await assertPersistedCheckpointState([], []);
 
       // cp1
       cache.add(cp1, states["cp1"]);
-      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -667,7 +667,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2
-      expect(await cache.processState(toHex(root2), blockStateRoot2)).toEqual(0);
+      expect(await cache.processState(toRootHex(root2), blockStateRoot2)).toEqual(0);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       // keep these 2 cp states at epoch 21
@@ -686,7 +686,7 @@ describe("PersistentCheckpointStateCache", function () {
       expect(fileApisBuffer.size).toEqual(0);
       // cp1
       cache.add(cp1, states["cp1"]);
-      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -706,7 +706,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2, nothing is persisted
-      expect(await cache.processState(toHex(root2), blockStateRoot2)).toEqual(0);
+      expect(await cache.processState(toRootHex(root2), blockStateRoot2)).toEqual(0);
 
       // but cp0b in-memory state is pruned
       expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
@@ -731,7 +731,7 @@ describe("PersistentCheckpointStateCache", function () {
       const state1a = states["cp0a"].clone();
       state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - 1;
       state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(0);
+      expect(await cache.processState(toRootHex(cp1.root), states["cp1"])).toEqual(0);
       expect(fileApisBuffer.size).toEqual(0);
       // at epoch 20, there should be 2 cps in memory
       expect(cache.get(cp0aHex)).not.toBeNull();
@@ -740,7 +740,7 @@ describe("PersistentCheckpointStateCache", function () {
 
       // cp1
       cache.add(cp1, states["cp1"]);
-      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -762,7 +762,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2, persist cp0a
-      expect(await cache.processState(toHex(root2), blockStateRoot2)).toEqual(1);
+      expect(await cache.processState(toRootHex(root2), blockStateRoot2)).toEqual(1);
       await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       // keep these 2 cp states at epoch 21
@@ -782,7 +782,7 @@ describe("PersistentCheckpointStateCache", function () {
     it("reorg 2 epochs", async () => {
       // cp1
       cache.add(cp1, states["cp1"]);
-      expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
+      expect(await cache.processState(toRootHex(cp1.root), states["cp1"])).toEqual(1);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -804,7 +804,7 @@ describe("PersistentCheckpointStateCache", function () {
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2, persist cp0a
-      expect(await cache.processState(toHex(root2), blockStateRoot2)).toEqual(1);
+      expect(await cache.processState(toRootHex(root2), blockStateRoot2)).toEqual(1);
       await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       // keep these 2 cp states at epoch 21
@@ -837,7 +837,7 @@ describe("PersistentCheckpointStateCache", function () {
       //                       |
       //                       0a
       it("no reorg", async () => {
-        expect(await cache.processState(toHex(root0b), states["cp0b"])).toEqual(1);
+        expect(await cache.processState(toRootHex(root0b), states["cp0b"])).toEqual(1);
         await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
@@ -846,7 +846,7 @@ describe("PersistentCheckpointStateCache", function () {
         const state1a = states["cp0b"].clone();
         state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH + 3;
         state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-        expect(await cache.processState(toHex(root1a), state1a)).toEqual(0);
+        expect(await cache.processState(toRootHex(root1a), state1a)).toEqual(0);
 
         // nothing change
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -861,7 +861,7 @@ describe("PersistentCheckpointStateCache", function () {
       //                       |  \        |
       //                       0a  \------root1b
       it("reorg in same epoch", async () => {
-        expect(await cache.processState(toHex(root0b), states["cp0b"])).toEqual(1);
+        expect(await cache.processState(toRootHex(root0b), states["cp0b"])).toEqual(1);
         await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
@@ -870,7 +870,7 @@ describe("PersistentCheckpointStateCache", function () {
         const state1a = states["cp0b"].clone();
         state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH + 3;
         state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-        expect(await cache.processState(toHex(root1a), state1a)).toEqual(0);
+        expect(await cache.processState(toRootHex(root1a), state1a)).toEqual(0);
 
         // nothing change
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -886,7 +886,7 @@ describe("PersistentCheckpointStateCache", function () {
         state1b.slot = state1a.slot + 1;
         state1b.blockRoots.set(state1b.slot % SLOTS_PER_HISTORICAL_ROOT, root1b);
         // but no need to persist cp1b
-        expect(await cache.processState(toHex(root1b), state1b)).toEqual(0);
+        expect(await cache.processState(toRootHex(root1b), state1b)).toEqual(0);
         // although states["cp0b"] is pruned
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -934,7 +934,7 @@ describe("PersistentCheckpointStateCache", function () {
         cache.add(cp0a, states["cp0a"]);
 
         // need to persist 2 checkpoint states
-        expect(await cache.processState(toHex(root1b), state1b)).toEqual(2);
+        expect(await cache.processState(toRootHex(root1b), state1b)).toEqual(2);
         // both are persisited
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
         expect(await cache.getStateOrBytes(cp0aHex)).toEqual(stateBytes["cp0a"]);
@@ -949,7 +949,7 @@ describe("PersistentCheckpointStateCache", function () {
       //                       |           |
       //                       0a---------root1b
       it("reorg 1 epoch, processState twice", async () => {
-        expect(await cache.processState(toHex(root0b), states["cp0b"])).toEqual(1);
+        expect(await cache.processState(toRootHex(root0b), states["cp0b"])).toEqual(1);
         await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
@@ -958,7 +958,7 @@ describe("PersistentCheckpointStateCache", function () {
         const state1a = states["cp0b"].clone();
         state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH + 3;
         state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-        expect(await cache.processState(toHex(root1a), state1a)).toEqual(0);
+        expect(await cache.processState(toRootHex(root1a), state1a)).toEqual(0);
 
         // nothing change
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -970,7 +970,7 @@ describe("PersistentCheckpointStateCache", function () {
         state1b.blockRoots.set(state1b.slot % SLOTS_PER_HISTORICAL_ROOT, root1b);
         // regen should reload cp0a from disk
         cache.add(cp0a, states["cp0a"]);
-        expect(await cache.processState(toHex(root1b), state1b)).toEqual(1);
+        expect(await cache.processState(toRootHex(root1b), state1b)).toEqual(1);
         await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
 
         // both cp0a and cp0b are persisted
@@ -988,13 +988,13 @@ describe("PersistentCheckpointStateCache", function () {
       //                                    ^
       //                                  {0a, 21}=cp1a
       it("reorg 2 epochs", async () => {
-        expect(await cache.processState(toHex(root0b), states["cp0b"])).toEqual(1);
+        expect(await cache.processState(toRootHex(root0b), states["cp0b"])).toEqual(1);
         await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
 
         cache.add(cp1, states["cp1"]);
-        expect(await cache.processState(toHex(cp1.root), states["cp1"])).toEqual(1);
+        expect(await cache.processState(toRootHex(cp1.root), states["cp1"])).toEqual(1);
         await assertPersistedCheckpointState([cp0b, cp1], [stateBytes["cp0b"], stateBytes["cp1"]]);
 
         // regen should populate cp0a and cp1a checkpoint states
@@ -1010,7 +1010,7 @@ describe("PersistentCheckpointStateCache", function () {
         const state2 = cp1aState.clone();
         state2.slot = 21 * SLOTS_PER_EPOCH + 3;
         state2.blockRoots.set(state2.slot % SLOTS_PER_HISTORICAL_ROOT, root2);
-        expect(await cache.processState(toHex(root2), state2)).toEqual(2);
+        expect(await cache.processState(toRootHex(root2), state2)).toEqual(2);
         // expect 4 cp states are persisted
         await assertPersistedCheckpointState(
           [cp0b, cp1, cp0a, cp1a],

--- a/packages/cli/src/cmds/validator/keymanager/server.ts
+++ b/packages/cli/src/cmds/validator/keymanager/server.ts
@@ -1,10 +1,10 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import {toHexString} from "@chainsafe/ssz";
 import {RestApiServer, RestApiServerOpts, RestApiServerModules} from "@lodestar/beacon-node";
 import {KeymanagerApiMethods, registerRoutes} from "@lodestar/api/keymanager/server";
 import {ChainForkConfig} from "@lodestar/config";
+import {toRootHex} from "@lodestar/utils";
 import {writeFile600Perm} from "../../../util/index.js";
 
 export type KeymanagerRestApiServerOpts = RestApiServerOpts & {
@@ -50,7 +50,7 @@ export class KeymanagerRestApiServer extends RestApiServer {
 
     if (opts.isAuthEnabled) {
       // Generate a new token if token file does not exist or file do exist, but is empty
-      bearerToken = readFileIfExists(apiTokenPath) ?? `api-token-${toHexString(crypto.randomBytes(32))}`;
+      bearerToken = readFileIfExists(apiTokenPath) ?? `api-token-${toRootHex(crypto.randomBytes(32))}`;
       writeFile600Perm(apiTokenPath, bearerToken, {encoding: "utf8"});
     }
 

--- a/packages/cli/src/cmds/validator/slashingProtection/export.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/export.ts
@@ -1,8 +1,7 @@
 import path from "node:path";
-import {toHexString} from "@chainsafe/ssz";
 import {InterchangeFormatVersion} from "@lodestar/validator";
 import {getNodeLogger} from "@lodestar/logger/node";
-import {CliCommand} from "@lodestar/utils";
+import {CliCommand, toPubkeyHex} from "@lodestar/utils";
 import {YargsError, ensure0xPrefix, isValidatePubkeyHex, writeFile600Perm} from "../../../util/index.js";
 import {parseLoggerArgs} from "../../../util/logger.js";
 import {GlobalArgs} from "../../../options/index.js";
@@ -86,7 +85,7 @@ export const exportCmd: CliCommand<ExportArgs, ISlashingProtectionArgs & Account
           if (!isValidatePubkeyHex(pubkeyHex)) {
             throw new YargsError(`Invalid pubkey ${pubkeyHex}`);
           }
-          const existingPubkey = allPubkeys.find((pubkey) => toHexString(pubkey) === pubkeyHex);
+          const existingPubkey = allPubkeys.find((pubkey) => toPubkeyHex(pubkey) === pubkeyHex);
           if (!existingPubkey) {
             logger.warn("Pubkey not found in slashing protection db", {pubkey: pubkeyHex});
           } else {

--- a/packages/cli/test/utils/crucible/assertions/defaults/headAssertion.ts
+++ b/packages/cli/test/utils/crucible/assertions/defaults/headAssertion.ts
@@ -1,5 +1,5 @@
 import {RootHex, Slot} from "@lodestar/types";
-import {toHexString} from "@lodestar/utils";
+import {toHex} from "@lodestar/utils";
 import {AssertionResult, Assertion} from "../../interfaces.js";
 import {everySlotMatcher} from "../matchers.js";
 
@@ -15,7 +15,7 @@ export const headAssertion: Assertion<"head", HeadSummary> = {
     const head = (await node.beacon.api.beacon.getBlockHeader({blockId: "head"})).value();
 
     return {
-      blockRoot: toHexString(head.root),
+      blockRoot: toHex(head.root),
       slot: head.header.message.slot,
     };
   },

--- a/packages/cli/test/utils/crucible/assertions/defaults/headAssertion.ts
+++ b/packages/cli/test/utils/crucible/assertions/defaults/headAssertion.ts
@@ -1,5 +1,5 @@
 import {RootHex, Slot} from "@lodestar/types";
-import {toHex} from "@lodestar/utils";
+import {toRootHex} from "@lodestar/utils";
 import {AssertionResult, Assertion} from "../../interfaces.js";
 import {everySlotMatcher} from "../matchers.js";
 
@@ -15,7 +15,7 @@ export const headAssertion: Assertion<"head", HeadSummary> = {
     const head = (await node.beacon.api.beacon.getBlockHeader({blockId: "head"})).value();
 
     return {
-      blockRoot: toHex(head.root),
+      blockRoot: toRootHex(head.root),
       slot: head.header.message.slot,
     };
   },

--- a/packages/cli/test/utils/crucible/assertions/forkAssertion.ts
+++ b/packages/cli/test/utils/crucible/assertions/forkAssertion.ts
@@ -1,6 +1,6 @@
 import {ForkName} from "@lodestar/params";
 import {Epoch} from "@lodestar/types";
-import {toHexString} from "@lodestar/utils";
+import {toHex} from "@lodestar/utils";
 import {Match, AssertionResult, Assertion} from "../interfaces.js";
 
 export function createForkAssertion(fork: ForkName, epoch: Epoch): Assertion<string, string> {
@@ -15,8 +15,8 @@ export function createForkAssertion(fork: ForkName, epoch: Epoch): Assertion<str
       const errors: AssertionResult[] = [];
 
       const state = (await node.beacon.api.debug.getStateV2({stateId: "head"})).value();
-      const expectedForkVersion = toHexString(forkConfig.getForkInfo(slot).version);
-      const currentForkVersion = toHexString(state.fork.currentVersion);
+      const expectedForkVersion = toHex(forkConfig.getForkInfo(slot).version);
+      const currentForkVersion = toHex(state.fork.currentVersion);
 
       if (expectedForkVersion !== currentForkVersion) {
         errors.push([

--- a/packages/flare/src/cmds/selfSlashAttester.ts
+++ b/packages/flare/src/cmds/selfSlashAttester.ts
@@ -4,7 +4,7 @@ import {phase0, ssz} from "@lodestar/types";
 import {config as chainConfig} from "@lodestar/config/default";
 import {createBeaconConfig, BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_ATTESTER, MAX_VALIDATORS_PER_COMMITTEE} from "@lodestar/params";
-import {CliCommand, toHexString} from "@lodestar/utils";
+import {CliCommand, toHex} from "@lodestar/utils";
 import {computeSigningRoot} from "@lodestar/state-transition";
 import {deriveSecretKeys, SecretKeysArgs, secretKeysOptions} from "../util/deriveSecretKeys.js";
 
@@ -90,7 +90,7 @@ export async function selfSlashAttesterHandler(args: SelfSlashArgs): Promise<voi
     for (let i = 0; i < pksHex.length; i++) {
       const {index, status, validator} = validators[i];
       const pkHex = pksHex[i];
-      const validatorPkHex = toHexString(validator.pubkey);
+      const validatorPkHex = toHex(validator.pubkey);
       if (validatorPkHex !== pkHex) {
         throw Error(`getStateValidators did not return same validator pubkey: ${validatorPkHex} != ${pkHex}`);
       }

--- a/packages/flare/src/cmds/selfSlashAttester.ts
+++ b/packages/flare/src/cmds/selfSlashAttester.ts
@@ -4,7 +4,7 @@ import {phase0, ssz} from "@lodestar/types";
 import {config as chainConfig} from "@lodestar/config/default";
 import {createBeaconConfig, BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_ATTESTER, MAX_VALIDATORS_PER_COMMITTEE} from "@lodestar/params";
-import {CliCommand, toHex} from "@lodestar/utils";
+import {CliCommand, toPubkeyHex} from "@lodestar/utils";
 import {computeSigningRoot} from "@lodestar/state-transition";
 import {deriveSecretKeys, SecretKeysArgs, secretKeysOptions} from "../util/deriveSecretKeys.js";
 
@@ -90,7 +90,7 @@ export async function selfSlashAttesterHandler(args: SelfSlashArgs): Promise<voi
     for (let i = 0; i < pksHex.length; i++) {
       const {index, status, validator} = validators[i];
       const pkHex = pksHex[i];
-      const validatorPkHex = toHex(validator.pubkey);
+      const validatorPkHex = toPubkeyHex(validator.pubkey);
       if (validatorPkHex !== pkHex) {
         throw Error(`getStateValidators did not return same validator pubkey: ${validatorPkHex} != ${pkHex}`);
       }

--- a/packages/flare/src/cmds/selfSlashProposer.ts
+++ b/packages/flare/src/cmds/selfSlashProposer.ts
@@ -4,7 +4,7 @@ import {phase0, ssz} from "@lodestar/types";
 import {config as chainConfig} from "@lodestar/config/default";
 import {createBeaconConfig, BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_PROPOSER} from "@lodestar/params";
-import {CliCommand, toHex} from "@lodestar/utils";
+import {CliCommand, toPubkeyHex} from "@lodestar/utils";
 import {computeSigningRoot} from "@lodestar/state-transition";
 import {deriveSecretKeys, SecretKeysArgs, secretKeysOptions} from "../util/deriveSecretKeys.js";
 
@@ -86,7 +86,7 @@ export async function selfSlashProposerHandler(args: SelfSlashArgs): Promise<voi
         const {index, status, validator} = validators[i];
 
         try {
-          const validatorPkHex = toHex(validator.pubkey);
+          const validatorPkHex = toPubkeyHex(validator.pubkey);
           if (validatorPkHex !== pkHex) {
             throw Error(`getStateValidators did not return same validator pubkey: ${validatorPkHex} != ${pkHex}`);
           }

--- a/packages/flare/src/cmds/selfSlashProposer.ts
+++ b/packages/flare/src/cmds/selfSlashProposer.ts
@@ -4,7 +4,7 @@ import {phase0, ssz} from "@lodestar/types";
 import {config as chainConfig} from "@lodestar/config/default";
 import {createBeaconConfig, BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_PROPOSER} from "@lodestar/params";
-import {CliCommand, toHexString} from "@lodestar/utils";
+import {CliCommand, toHex} from "@lodestar/utils";
 import {computeSigningRoot} from "@lodestar/state-transition";
 import {deriveSecretKeys, SecretKeysArgs, secretKeysOptions} from "../util/deriveSecretKeys.js";
 
@@ -86,7 +86,7 @@ export async function selfSlashProposerHandler(args: SelfSlashArgs): Promise<voi
         const {index, status, validator} = validators[i];
 
         try {
-          const validatorPkHex = toHexString(validator.pubkey);
+          const validatorPkHex = toHex(validator.pubkey);
           if (validatorPkHex !== pkHex) {
             throw Error(`getStateValidators did not return same validator pubkey: ${validatorPkHex} != ${pkHex}`);
           }

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1,4 +1,3 @@
-import {toHexString} from "@chainsafe/ssz";
 import {Logger, fromHex, toRootHex} from "@lodestar/utils";
 import {SLOTS_PER_HISTORICAL_ROOT, SLOTS_PER_EPOCH, INTERVALS_PER_SLOT} from "@lodestar/params";
 import {bellatrix, Slot, ValidatorIndex, phase0, ssz, RootHex, Epoch, Root, BeaconBlock} from "@lodestar/types";
@@ -643,7 +642,7 @@ export class ForkChoice implements IForkChoice {
 
       ...(isExecutionBlockBodyType(block.body) && isExecutionStateType(state) && isExecutionEnabled(state, block)
         ? {
-            executionPayloadBlockHash: toHexString(block.body.executionPayload.blockHash),
+            executionPayloadBlockHash: toRootHex(block.body.executionPayload.blockHash),
             executionPayloadNumber: block.body.executionPayload.blockNumber,
             executionStatus: this.getPostMergeExecStatus(executionStatus),
             dataAvailabilityStatus,
@@ -1484,7 +1483,7 @@ export function assertValidTerminalPowBlock(
     // powBock.blockHash is hex, so we just pick the corresponding root
     if (!ssz.Root.equals(block.body.executionPayload.parentHash, config.TERMINAL_BLOCK_HASH))
       throw new Error(
-        `Invalid terminal block hash, expected: ${toHexString(config.TERMINAL_BLOCK_HASH)}, actual: ${toHexString(
+        `Invalid terminal block hash, expected: ${toRootHex(config.TERMINAL_BLOCK_HASH)}, actual: ${toRootHex(
           block.body.executionPayload.parentHash
         )}`
       );

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -1,4 +1,4 @@
-import {toHexString} from "@chainsafe/ssz";
+import {toRootHex} from "@lodestar/utils";
 import {Epoch, RootHex, Slot} from "@lodestar/types";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {GENESIS_EPOCH} from "@lodestar/params";
@@ -10,7 +10,7 @@ import {ProtoArrayError, ProtoArrayErrorCode, LVHExecError, LVHExecErrorCode} fr
 export const DEFAULT_PRUNE_THRESHOLD = 0;
 type ProposerBoost = {root: RootHex; score: number};
 
-const ZERO_HASH_HEX = toHexString(Buffer.alloc(32, 0));
+const ZERO_HASH_HEX = toRootHex(Buffer.alloc(32, 0));
 
 export class ProtoArray {
   // Do not attempt to prune the tree unless it has at least this many nodes.

--- a/packages/logger/src/utils/json.ts
+++ b/packages/logger/src/utils/json.ts
@@ -1,4 +1,4 @@
-import {LodestarError, mapValues, toHexString} from "@lodestar/utils";
+import {LodestarError, mapValues, toHex} from "@lodestar/utils";
 
 const MAX_DEPTH = 0;
 
@@ -29,7 +29,7 @@ export function logCtxToJson(arg: unknown, depth = 0, fromError = false): LogDat
       if (arg === null) return "null";
 
       if (arg instanceof Uint8Array) {
-        return toHexString(arg);
+        return toHex(arg);
       }
 
       // For any type that may include recursiveness break early at the first level
@@ -90,7 +90,7 @@ export function logCtxToString(arg: unknown, depth = 0, fromError = false): stri
       if (arg === null) return "null";
 
       if (arg instanceof Uint8Array) {
-        return toHexString(arg);
+        return toHex(arg);
       }
 
       // For any type that may include recursiveness break early at the first level

--- a/packages/prover/test/unit/proof_provider/payload_store.test.ts
+++ b/packages/prover/test/unit/proof_provider/payload_store.test.ts
@@ -1,10 +1,9 @@
 import {describe, it, expect, beforeEach, vi, MockedObject} from "vitest";
 import {when} from "vitest-when";
 import {ApiClient, ApiResponse, HttpStatusCode, routes} from "@lodestar/api";
-import {hash} from "@lodestar/utils";
+import {hash, toRootHex} from "@lodestar/utils";
 import {Logger} from "@lodestar/logger";
 import {ExecutionPayload, SignedBeaconBlock, capella} from "@lodestar/types";
-import {toHexString} from "@lodestar/utils";
 import {ForkName} from "@lodestar/params";
 import {PayloadStore} from "../../../src/proof_provider/payload_store.js";
 import {MAX_PAYLOAD_HISTORY} from "../../../src/constants.js";
@@ -133,7 +132,7 @@ describe("proof_provider/payload_store", function () {
       store.set(payload1, slotNumber, false);
       const nonExistingBlockHash = createHash("non-existing-block-hash");
 
-      await expect(store.get(toHexString(nonExistingBlockHash))).resolves.toBeUndefined();
+      await expect(store.get(toRootHex(nonExistingBlockHash))).resolves.toBeUndefined();
     });
 
     describe("block hash as blockId", () => {
@@ -141,7 +140,7 @@ describe("proof_provider/payload_store", function () {
         const payload1 = buildPayload({blockNumber: 10});
         store.set(payload1, slotNumber, false);
 
-        await expect(store.get(toHexString(payload1.blockHash))).resolves.toEqual(payload1);
+        await expect(store.get(toRootHex(payload1.blockHash))).resolves.toEqual(payload1);
       });
     });
 
@@ -216,7 +215,7 @@ describe("proof_provider/payload_store", function () {
       store.set(payload1, slotNumber, false);
 
       // Unfinalized blocks are not indexed by block hash
-      await expect(store.get(toHexString(payload1.blockHash))).resolves.toEqual(payload1);
+      await expect(store.get(toRootHex(payload1.blockHash))).resolves.toEqual(payload1);
       expect(store.finalized).toEqual(undefined);
     });
 

--- a/packages/state-transition/src/block/processBlsToExecutionChange.ts
+++ b/packages/state-transition/src/block/processBlsToExecutionChange.ts
@@ -1,7 +1,8 @@
-import {toHexString, byteArrayEquals} from "@chainsafe/ssz";
+import {byteArrayEquals} from "@chainsafe/ssz";
 import {digest} from "@chainsafe/as-sha256";
 import {capella} from "@lodestar/types";
 import {BLS_WITHDRAWAL_PREFIX, ETH1_ADDRESS_WITHDRAWAL_PREFIX} from "@lodestar/params";
+import {toHex} from "@lodestar/utils";
 import {verifyBlsToExecutionChangeSignature} from "../signatureSets/index.js";
 
 import {CachedBeaconStateCapella} from "../types.js";
@@ -60,9 +61,7 @@ export function isValidBlsToExecutionChange(
     return {
       valid: false,
       error: Error(
-        `Invalid withdrawalCredentials expected=${toHexString(withdrawalCredentials)} actual=${toHexString(
-          digestCredentials
-        )}`
+        `Invalid withdrawalCredentials expected=${toHex(withdrawalCredentials)} actual=${toHex(digestCredentials)}`
       ),
     };
   }

--- a/packages/state-transition/src/block/processExecutionPayload.ts
+++ b/packages/state-transition/src/block/processExecutionPayload.ts
@@ -1,6 +1,7 @@
-import {toHexString, byteArrayEquals} from "@chainsafe/ssz";
+import {byteArrayEquals} from "@chainsafe/ssz";
 import {BeaconBlockBody, BlindedBeaconBlockBody, deneb, isExecutionPayload} from "@lodestar/types";
 import {ForkSeq, MAX_BLOBS_PER_BLOCK} from "@lodestar/params";
+import {toHex, toRootHex} from "@lodestar/utils";
 import {CachedBeaconStateBellatrix, CachedBeaconStateCapella} from "../types.js";
 import {getRandaoMix} from "../util/index.js";
 import {
@@ -23,7 +24,7 @@ export function processExecutionPayload(
     const {latestExecutionPayloadHeader} = state;
     if (!byteArrayEquals(payload.parentHash, latestExecutionPayloadHeader.blockHash)) {
       throw Error(
-        `Invalid execution payload parentHash ${toHexString(payload.parentHash)} latest blockHash ${toHexString(
+        `Invalid execution payload parentHash ${toRootHex(payload.parentHash)} latest blockHash ${toRootHex(
           latestExecutionPayloadHeader.blockHash
         )}`
       );
@@ -33,9 +34,7 @@ export function processExecutionPayload(
   // Verify random
   const expectedRandom = getRandaoMix(state, state.epochCtx.epoch);
   if (!byteArrayEquals(payload.prevRandao, expectedRandom)) {
-    throw Error(
-      `Invalid execution payload random ${toHexString(payload.prevRandao)} expected=${toHexString(expectedRandom)}`
-    );
+    throw Error(`Invalid execution payload random ${toHex(payload.prevRandao)} expected=${toHex(expectedRandom)}`);
   }
 
   // Verify timestamp

--- a/packages/state-transition/src/cache/syncCommitteeCache.ts
+++ b/packages/state-transition/src/cache/syncCommitteeCache.ts
@@ -1,5 +1,6 @@
-import {CompositeViewDU, toHexString} from "@chainsafe/ssz";
+import {CompositeViewDU} from "@chainsafe/ssz";
 import {ssz, ValidatorIndex} from "@lodestar/types";
+import {toPubkeyHex} from "@lodestar/utils";
 import {PubkeyIndexMap} from "./pubkeyCache.js";
 
 type SyncComitteeValidatorIndexMap = Map<ValidatorIndex, number[]>;
@@ -82,7 +83,7 @@ function computeSyncCommitteeIndices(
   for (const pubkey of pubkeys) {
     const validatorIndex = pubkey2index.get(pubkey);
     if (validatorIndex === undefined) {
-      throw Error(`SyncCommittee pubkey is unknown ${toHexString(pubkey)}`);
+      throw Error(`SyncCommittee pubkey is unknown ${toPubkeyHex(pubkey)}`);
     }
 
     validatorIndices.push(validatorIndex);

--- a/packages/state-transition/test/unit/cachedBeaconState.test.ts
+++ b/packages/state-transition/test/unit/cachedBeaconState.test.ts
@@ -1,8 +1,8 @@
 import {describe, it, expect} from "vitest";
 import {Epoch, ssz, RootHex} from "@lodestar/types";
-import {toHexString} from "@lodestar/utils";
 import {config as defaultConfig} from "@lodestar/config/default";
 import {createBeaconConfig} from "@lodestar/config";
+import {toHex} from "@lodestar/utils";
 import {createCachedBeaconStateTest} from "../utils/state.js";
 import {PubkeyIndexMap} from "../../src/cache/pubkeyCache.js";
 import {createCachedBeaconState, loadCachedBeaconState} from "../../src/cache/stateCache.js";
@@ -22,7 +22,7 @@ describe("CachedBeaconState", () => {
     const prevRoot = state2.currentJustifiedCheckpoint.root;
     const newRoot = Buffer.alloc(32, 1);
     state1.currentJustifiedCheckpoint.root = newRoot;
-    expect(toHexString(state2.currentJustifiedCheckpoint.root)).toBe(toHexString(prevRoot));
+    expect(toHex(state2.currentJustifiedCheckpoint.root)).toBe(toHex(prevRoot));
 
     state1.epochCtx.epoch = 1;
     expect(state2.epochCtx.epoch).toBe(0);
@@ -38,7 +38,7 @@ describe("CachedBeaconState", () => {
 
     // Only commit state1 beforehand
     cp1.commit();
-    expect(toHexString(cp1.hashTreeRoot())).toBe(toHexString(cp2.hashTreeRoot()));
+    expect(toHex(cp1.hashTreeRoot())).toBe(toHex(cp2.hashTreeRoot()));
   });
 
   it("Auto-commit on serialize", () => {
@@ -50,7 +50,7 @@ describe("CachedBeaconState", () => {
 
     // Only commit state1 beforehand
     cp1.commit();
-    expect(toHexString(cp1.serialize())).toBe(toHexString(cp2.serialize()));
+    expect(toHex(cp1.serialize())).toBe(toHex(cp2.serialize()));
   });
 
   describe("loadCachedBeaconState", () => {

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -2,18 +2,6 @@ import {toBufferLE, toBigIntLE, toBufferBE, toBigIntBE} from "bigint-buffer";
 
 type Endianness = "le" | "be";
 
-const hexByByte: string[] = [];
-export function toHexString(bytes: Uint8Array): string {
-  let hex = "0x";
-  for (const byte of bytes) {
-    if (!hexByByte[byte]) {
-      hexByByte[byte] = byte < 16 ? "0" + byte.toString(16) : byte.toString(16);
-    }
-    hex += hexByByte[byte];
-  }
-  return hex;
-}
-
 /**
  * Return a byte array from a number or BigInt
  */

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -59,6 +59,18 @@ export function toRootHex(root: Uint8Array): string {
   return `0x${rootBuf.toString("hex")}`;
 }
 
+// Shared buffer to convert pubkey to hex
+const pubkeyBuf = Buffer.alloc(48);
+
+export function toPubkeyHex(pubkey: Uint8Array): string {
+  if (pubkey.length !== 48) {
+    throw Error(`Expect pubkey to be 48 bytes, got ${pubkey.length}`);
+  }
+
+  pubkeyBuf.set(pubkey);
+  return `0x${pubkeyBuf.toString("hex")}`;
+}
+
 export function fromHex(hex: string): Uint8Array {
   const b = Buffer.from(hex.replace("0x", ""), "hex");
   return new Uint8Array(b.buffer, b.byteOffset, b.length);

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -36,11 +36,11 @@ export function bytesToBigInt(value: Uint8Array, endianness: Endianness = "le"):
 
 export function toHex(buffer: Uint8Array | Parameters<typeof Buffer.from>[0]): string {
   if (Buffer.isBuffer(buffer)) {
-    return "0x" + buffer.toString("hex");
+    return `0x${buffer.toString("hex")}`;
   } else if (buffer instanceof Uint8Array) {
-    return "0x" + Buffer.from(buffer.buffer, buffer.byteOffset, buffer.length).toString("hex");
+    return `0x${Buffer.from(buffer.buffer, buffer.byteOffset, buffer.length).toString("hex")}`;
   } else {
-    return "0x" + Buffer.from(buffer).toString("hex");
+    return `0x${Buffer.from(buffer).toString("hex")}`;
   }
 }
 

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -1,4 +1,4 @@
-import {toHexString} from "./bytes.js";
+import {toRootHex} from "./bytes.js";
 import {ETH_TO_WEI} from "./ethConversion.js";
 
 /**
@@ -6,7 +6,7 @@ import {ETH_TO_WEI} from "./ethConversion.js";
  * 4 bytes can represent 4294967296 values, so the chance of collision is low
  */
 export function prettyBytes(root: Uint8Array | string): string {
-  const str = typeof root === "string" ? root : toHexString(root);
+  const str = typeof root === "string" ? root : toRootHex(root);
   return `${str.slice(0, 6)}…${str.slice(-4)}`;
 }
 
@@ -15,7 +15,7 @@ export function prettyBytes(root: Uint8Array | string): string {
  * Paired with block numbers or slots, it can still act as a decent identify-able format
  */
 export function prettyBytesShort(root: Uint8Array | string): string {
-  const str = typeof root === "string" ? root : toHexString(root);
+  const str = typeof root === "string" ? root : toRootHex(root);
   return `${str.slice(0, 6)}…`;
 }
 
@@ -25,7 +25,7 @@ export function prettyBytesShort(root: Uint8Array | string): string {
  * values on explorers like beaconcha.in while improving readability of logs
  */
 export function truncBytes(root: Uint8Array | string): string {
-  const str = typeof root === "string" ? root : toHexString(root);
+  const str = typeof root === "string" ? root : toRootHex(root);
   return str.slice(0, 14);
 }
 

--- a/packages/utils/test/unit/bytes.test.ts
+++ b/packages/utils/test/unit/bytes.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from "vitest";
-import {intToBytes, bytesToInt, toHex, fromHex, toHexString} from "../../src/index.js";
+import {intToBytes, bytesToInt, toHex, fromHex} from "../../src/index.js";
 
 describe("intToBytes", () => {
   const zeroedArray = (length: number): number[] => Array.from({length}, () => 0);
@@ -77,23 +77,6 @@ describe("fromHex", () => {
   for (const {input, output} of testCases) {
     it(`should convert hex string ${input} to Uint8Array`, () => {
       expect(fromHex(input)).toEqual(output);
-    });
-  }
-});
-
-describe("toHexString", () => {
-  const testCases: {input: Uint8Array; output: string}[] = [
-    {input: new Uint8Array([1, 2, 3]), output: "0x010203"},
-    {input: new Uint8Array([72, 101, 108, 108, 111]), output: "0x48656c6c6f"},
-    {input: new Uint8Array([]), output: "0x"},
-    {input: new Uint8Array([0, 0, 0, 0]), output: "0x00000000"},
-    {input: new Uint8Array([15, 255, 16, 0, 127]), output: "0x0fff10007f"},
-    {input: new Uint8Array(5).fill(255), output: "0x" + "ff".repeat(5)},
-  ];
-
-  for (const {input, output} of testCases) {
-    it(`should convert Uint8Array to hex string ${output}`, () => {
-      expect(toHexString(input)).toBe(output);
     });
   }
 });

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -1,7 +1,6 @@
-import {toHexString} from "@chainsafe/ssz";
 import {BLSSignature, phase0, Slot, ssz} from "@lodestar/types";
 import {computeEpochAtSlot, isAggregatorFromCommitteeLength} from "@lodestar/state-transition";
-import {sleep} from "@lodestar/utils";
+import {sleep, toRootHex} from "@lodestar/utils";
 import {ApiClient, routes} from "@lodestar/api";
 import {IClock, LoggerVc} from "../util/index.js";
 import {PubkeyHex} from "../types.js";
@@ -191,7 +190,7 @@ export class AttestationService {
     duties: AttDutyAndProof[]
   ): Promise<void> {
     const signedAttestations: phase0.Attestation[] = [];
-    const headRootHex = toHexString(attestationNoCommittee.beaconBlockRoot);
+    const headRootHex = toRootHex(attestationNoCommittee.beaconBlockRoot);
     const currentEpoch = computeEpochAtSlot(slot);
 
     await Promise.all(

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -1,6 +1,5 @@
-import {toHexString} from "@chainsafe/ssz";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {sleep} from "@lodestar/utils";
+import {sleep, toPubkeyHex} from "@lodestar/utils";
 import {computeEpochAtSlot, isAggregatorFromCommitteeLength, isStartSlotOfEpoch} from "@lodestar/state-transition";
 import {BLSSignature, Epoch, Slot, ValidatorIndex, RootHex} from "@lodestar/types";
 import {ApiClient, routes} from "@lodestar/api";
@@ -97,7 +96,7 @@ export class AttestationDutiesService {
   removeDutiesForKey(pubkey: PubkeyHex): void {
     for (const [epoch, attDutiesAtEpoch] of this.dutiesByIndexByEpoch) {
       for (const [vIndex, attDutyAndProof] of attDutiesAtEpoch.dutiesByIndex) {
-        if (toHexString(attDutyAndProof.duty.pubkey) === pubkey) {
+        if (toPubkeyHex(attDutyAndProof.duty.pubkey) === pubkey) {
           attDutiesAtEpoch.dutiesByIndex.delete(vIndex);
           if (attDutiesAtEpoch.dutiesByIndex.size === 0) {
             this.dutiesByIndexByEpoch.delete(epoch);
@@ -244,7 +243,7 @@ export class AttestationDutiesService {
     const attesterDuties = res.value();
     const {dependentRoot} = res.meta();
     const relevantDuties = attesterDuties.filter((duty) => {
-      const pubkeyHex = toHexString(duty.pubkey);
+      const pubkeyHex = toPubkeyHex(duty.pubkey);
       return this.validatorStore.hasVotingPubkey(pubkeyHex) && this.validatorStore.isDoppelgangerSafe(pubkeyHex);
     });
 

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -1,4 +1,3 @@
-import {toHexString} from "@chainsafe/ssz";
 import {
   BLSPubkey,
   Slot,
@@ -15,7 +14,7 @@ import {
 } from "@lodestar/types";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPreBlobs, ForkBlobs, ForkSeq, ForkExecution, ForkName} from "@lodestar/params";
-import {extendError, prettyBytes, prettyWeiToEth} from "@lodestar/utils";
+import {extendError, prettyBytes, prettyWeiToEth, toPubkeyHex} from "@lodestar/utils";
 import {ApiClient, routes} from "@lodestar/api";
 import {IClock, LoggerVc} from "../util/index.js";
 import {PubkeyHex} from "../types.js";
@@ -110,7 +109,7 @@ export class BlockProposingService {
 
   /** Produce a block at the given slot for pubkey */
   private async createAndPublishBlock(pubkey: BLSPubkey, slot: Slot): Promise<void> {
-    const pubkeyHex = toHexString(pubkey);
+    const pubkeyHex = toPubkeyHex(pubkey);
     const logCtx = {slot, validator: prettyBytes(pubkeyHex)};
 
     // Wrap with try catch here to re-use `logCtx`

--- a/packages/validator/src/services/blockDuties.ts
+++ b/packages/validator/src/services/blockDuties.ts
@@ -1,8 +1,7 @@
-import {toHexString} from "@chainsafe/ssz";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {BLSPubkey, Epoch, RootHex, Slot} from "@lodestar/types";
 import {ApiClient, routes} from "@lodestar/api";
-import {sleep} from "@lodestar/utils";
+import {sleep, toPubkeyHex} from "@lodestar/utils";
 import {ChainConfig} from "@lodestar/config";
 import {IClock, differenceHex, LoggerVc} from "../util/index.js";
 import {PubkeyHex} from "../types.js";
@@ -67,7 +66,7 @@ export class BlockDutiesService {
     if (dutyAtEpoch) {
       for (const proposer of dutyAtEpoch.data) {
         if (proposer.slot === slot) {
-          publicKeys.set(toHexString(proposer.pubkey), proposer.pubkey);
+          publicKeys.set(toPubkeyHex(proposer.pubkey), proposer.pubkey);
         }
       }
     }
@@ -78,7 +77,7 @@ export class BlockDutiesService {
   removeDutiesForKey(pubkey: PubkeyHex): void {
     for (const blockDutyAtEpoch of this.proposers.values()) {
       blockDutyAtEpoch.data = blockDutyAtEpoch.data.filter((proposer) => {
-        return toHexString(proposer.pubkey) !== pubkey;
+        return toPubkeyHex(proposer.pubkey) !== pubkey;
       });
     }
   }
@@ -187,7 +186,7 @@ export class BlockDutiesService {
     const proposerDuties = res.value();
     const {dependentRoot} = res.meta();
     const relevantDuties = proposerDuties.filter((duty) => {
-      const pubkeyHex = toHexString(duty.pubkey);
+      const pubkeyHex = toPubkeyHex(duty.pubkey);
       return this.validatorStore.hasVotingPubkey(pubkeyHex) && this.validatorStore.isDoppelgangerSafe(pubkeyHex);
     });
 

--- a/packages/validator/src/services/indices.ts
+++ b/packages/validator/src/services/indices.ts
@@ -1,6 +1,5 @@
-import {toHexString} from "@chainsafe/ssz";
 import {ValidatorIndex} from "@lodestar/types";
-import {Logger, MapDef} from "@lodestar/utils";
+import {Logger, MapDef, toPubkeyHex} from "@lodestar/utils";
 import {ApiClient, routes} from "@lodestar/api";
 import {batchItems} from "../util/index.js";
 import {Metrics} from "../metrics.js";
@@ -135,7 +134,7 @@ export class IndicesService {
       const status = statusToSimpleStatusMapping(validator.status);
       allValidatorStatuses.set(status, allValidatorStatuses.getOrDefault(status) + 1);
 
-      const pubkeyHex = toHexString(validator.validator.pubkey);
+      const pubkeyHex = toPubkeyHex(validator.validator.pubkey);
       if (!this.pubkey2index.has(pubkeyHex)) {
         this.logger.info("Validator seen on beacon chain", {
           validatorIndex: validator.index,

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -1,4 +1,3 @@
-import {toHexString} from "@chainsafe/ssz";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
 import {
   computeEpochAtSlot,
@@ -10,6 +9,7 @@ import {
 import {ChainForkConfig} from "@lodestar/config";
 import {BLSSignature, Epoch, Slot, SyncPeriod, ValidatorIndex} from "@lodestar/types";
 import {ApiClient, routes} from "@lodestar/api";
+import {toPubkeyHex} from "@lodestar/utils";
 import {IClock, LoggerVc} from "../util/index.js";
 import {PubkeyHex} from "../types.js";
 import {Metrics} from "../metrics.js";
@@ -287,7 +287,7 @@ export class SyncCommitteeDutiesService {
       // Using `alreadyWarnedReorg` avoids excessive logs.
 
       // TODO: Use memory-efficient toHexString()
-      const pubkeyHex = toHexString(duty.pubkey);
+      const pubkeyHex = toPubkeyHex(duty.pubkey);
       dutiesByIndex.set(validatorIndex, {duty: {pubkey: pubkeyHex, validatorIndex, subnets}});
     }
 

--- a/packages/validator/src/slashingProtection/index.ts
+++ b/packages/validator/src/slashingProtection/index.ts
@@ -1,6 +1,5 @@
-import {toHexString} from "@chainsafe/ssz";
 import {BLSPubkey, Epoch, Root} from "@lodestar/types";
-import {Logger} from "@lodestar/utils";
+import {Logger, toPubkeyHex} from "@lodestar/utils";
 import {LodestarValidatorDatabaseController} from "../types.js";
 import {uniqueVectorArr} from "../slashingProtection/utils.js";
 import {BlockBySlotRepository, SlashingProtectionBlockService} from "./block/index.js";
@@ -63,7 +62,7 @@ export class SlashingProtection implements ISlashingProtection {
   async importInterchange(interchange: Interchange, genesisValidatorsRoot: Root, logger?: Logger): Promise<void> {
     const {data} = parseInterchange(interchange, genesisValidatorsRoot);
     for (const validator of data) {
-      logger?.info("Importing slashing protection", {pubkey: toHexString(validator.pubkey)});
+      logger?.info("Importing slashing protection", {pubkey: toPubkeyHex(validator.pubkey)});
       await this.blockService.importBlocks(validator.pubkey, validator.signedBlocks);
       await this.attestationService.importAttestations(validator.pubkey, validator.signedAttestations);
     }
@@ -77,7 +76,7 @@ export class SlashingProtection implements ISlashingProtection {
   ): Promise<Interchange> {
     const validatorData: InterchangeLodestar["data"] = [];
     for (const pubkey of pubkeys) {
-      logger?.info("Exporting slashing protection", {pubkey: toHexString(pubkey)});
+      logger?.info("Exporting slashing protection", {pubkey: toPubkeyHex(pubkey)});
       validatorData.push({
         pubkey,
         signedBlocks: await this.blockService.exportBlocks(pubkey),

--- a/packages/validator/src/slashingProtection/interchange/formats/completeV4.ts
+++ b/packages/validator/src/slashingProtection/interchange/formats/completeV4.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
+import {toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {InterchangeLodestar} from "../types.js";
 import {fromOptionalHexString, numToString, toOptionalHexString} from "../../utils.js";
 
@@ -90,10 +91,10 @@ export function serializeInterchangeCompleteV4({
     metadata: {
       interchange_format: "complete",
       interchange_format_version: "4",
-      genesis_validators_root: toHexString(genesisValidatorsRoot),
+      genesis_validators_root: toRootHex(genesisValidatorsRoot),
     },
     data: data.map((validator) => ({
-      pubkey: toHexString(validator.pubkey),
+      pubkey: toPubkeyHex(validator.pubkey),
       signed_blocks: validator.signedBlocks.map((block) => ({
         slot: numToString(block.slot),
         signing_root: toOptionalHexString(block.signingRoot),

--- a/packages/validator/src/slashingProtection/interchange/formats/v5.ts
+++ b/packages/validator/src/slashingProtection/interchange/formats/v5.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
+import {toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {InterchangeLodestar} from "../types.js";
 import {fromOptionalHexString, numToString, toOptionalHexString} from "../../utils.js";
 
@@ -85,10 +86,10 @@ export function serializeInterchangeV5({data, genesisValidatorsRoot}: Interchang
   return {
     metadata: {
       interchange_format_version: "5",
-      genesis_validators_root: toHexString(genesisValidatorsRoot),
+      genesis_validators_root: toRootHex(genesisValidatorsRoot),
     },
     data: data.map((validator) => ({
-      pubkey: toHexString(validator.pubkey),
+      pubkey: toPubkeyHex(validator.pubkey),
       signed_blocks: validator.signedBlocks.map((block) => ({
         slot: numToString(block.slot),
         signing_root: toOptionalHexString(block.signingRoot),

--- a/packages/validator/src/slashingProtection/utils.ts
+++ b/packages/validator/src/slashingProtection/utils.ts
@@ -1,5 +1,6 @@
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {Epoch, Root, ssz} from "@lodestar/types";
+import {toHex, toRootHex} from "@lodestar/utils";
 
 export const blsPubkeyLen = 48;
 export const ZERO_ROOT = ssz.Root.defaultValue();
@@ -17,7 +18,7 @@ export function fromOptionalHexString(hex: string | undefined): Root {
 }
 
 export function toOptionalHexString(root: Root): string | undefined {
-  return isEqualRoot(root, ZERO_ROOT) ? undefined : toHexString(root);
+  return isEqualRoot(root, ZERO_ROOT) ? undefined : toRootHex(root);
 }
 
 /**
@@ -34,7 +35,7 @@ export function minEpoch(epochs: Epoch[]): Epoch | null {
 export function uniqueVectorArr(buffers: Uint8Array[]): Uint8Array[] {
   const bufferStr = new Set<string>();
   return buffers.filter((buffer) => {
-    const str = toHexString(buffer);
+    const str = toHex(buffer);
     const seen = bufferStr.has(str);
     bufferStr.add(str);
     return !seen;

--- a/packages/validator/src/util/difference.ts
+++ b/packages/validator/src/util/difference.ts
@@ -1,10 +1,10 @@
-import {toHexString} from "@chainsafe/ssz";
 import {Root} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
 
 /**
  * Return items included in `next` but not in `prev`
  */
 export function differenceHex<T extends Uint8Array | Root>(prev: T[], next: T[]): T[] {
-  const existing = new Set(prev.map((item) => toHexString(item)));
-  return next.filter((item) => !existing.has(toHexString(item)));
+  const existing = new Set(prev.map((item) => toHex(item)));
+  return next.filter((item) => !existing.has(toHex(item)));
 }

--- a/packages/validator/src/util/externalSignerClient.ts
+++ b/packages/validator/src/util/externalSignerClient.ts
@@ -1,4 +1,4 @@
-import {ContainerType, toHexString, ValueOf} from "@chainsafe/ssz";
+import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {fetch} from "@lodestar/api";
 import {phase0, altair, capella, BeaconBlock, BlindedBeaconBlock} from "@lodestar/types";
 import {ForkSeq} from "@lodestar/params";
@@ -6,6 +6,7 @@ import {ValidatorRegistrationV1} from "@lodestar/types/bellatrix";
 import {BeaconConfig} from "@lodestar/config";
 import {computeEpochAtSlot, blindedOrFullBlockToHeader} from "@lodestar/state-transition";
 import {Epoch, Root, RootHex, Slot, ssz} from "@lodestar/types";
+import {toHex, toRootHex} from "@lodestar/utils";
 import {PubkeyHex} from "../types.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -131,17 +132,17 @@ export async function externalSignerPostSignature(
   const requestObj = serializerSignableMessagePayload(config, signableMessage) as Web3SignerSerializedRequest;
 
   requestObj.type = signableMessage.type;
-  requestObj.signingRoot = toHexString(signingRoot);
+  requestObj.signingRoot = toRootHex(signingRoot);
 
   if (requiresForkInfo[signableMessage.type]) {
     const forkInfo = config.getForkInfo(signingSlot);
     requestObj.fork_info = {
       fork: {
-        previous_version: toHexString(forkInfo.prevVersion),
-        current_version: toHexString(forkInfo.version),
+        previous_version: toHex(forkInfo.prevVersion),
+        current_version: toHex(forkInfo.version),
         epoch: String(computeEpochAtSlot(signingSlot)),
       },
-      genesis_validators_root: toHexString(config.genesisValidatorsRoot),
+      genesis_validators_root: toRootHex(config.genesisValidatorsRoot),
     };
   }
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -1,8 +1,7 @@
-import {toHexString} from "@chainsafe/ssz";
 import {BLSPubkey, phase0, ssz} from "@lodestar/types";
 import {createBeaconConfig, BeaconConfig, ChainForkConfig} from "@lodestar/config";
 import {Genesis} from "@lodestar/types/phase0";
-import {Logger, toPrintableUrl} from "@lodestar/utils";
+import {Logger, toPrintableUrl, toRootHex} from "@lodestar/utils";
 import {getClient, ApiClient, routes, ApiRequestInit, defaultInit} from "@lodestar/api";
 import {computeEpochAtSlot, getCurrentSlot} from "@lodestar/state-transition";
 import {Clock, IClock} from "./util/clock.js";
@@ -396,14 +395,14 @@ async function assertEqualGenesis(opts: ValidatorOptions, genesis: Genesis): Pro
     if (!ssz.Root.equals(genesisValidatorsRoot, nodeGenesisValidatorRoot)) {
       // this happens when the existing validator db served another network before
       opts.logger.error("Not the same genesisValidatorRoot", {
-        expected: toHexString(nodeGenesisValidatorRoot),
-        actual: toHexString(genesisValidatorsRoot),
+        expected: toRootHex(nodeGenesisValidatorRoot),
+        actual: toRootHex(genesisValidatorsRoot),
       });
       throw new NotEqualParamsError("Not the same genesisValidatorRoot");
     }
   } else {
     await metaDataRepository.setGenesisValidatorsRoot(nodeGenesisValidatorRoot);
-    opts.logger.info("Persisted genesisValidatorRoot", toHexString(nodeGenesisValidatorRoot));
+    opts.logger.info("Persisted genesisValidatorRoot", toRootHex(nodeGenesisValidatorRoot));
   }
 
   const nodeGenesisTime = genesis.genesisTime;


### PR DESCRIPTION
**Motivation**

since switching to `toRootHex()` it reduced `gc` time a lot (from ~2.9% to <2.3% on the unstable mainnet node)

<img width="1331" alt="Screenshot 2024-08-19 at 15 28 18" src="https://github.com/user-attachments/assets/d2a1c999-0ebc-42ef-b3db-3921b8937c91">

so we should continue with similar improvement
- ssz toHexString() is not memory efficient so should not use it. There's an issue to improve it https://github.com/ChainSafe/ssz/issues/277
- lodestar util toHexString() also uses string concatenation so should not use it. It's a duplicate to ssz version so remove it and use ssz version if needed (which will be improved in the above issue)

**Description**

- do not use ssz toHexString() api
- remove lodestar util toHexString()
- replace by:
  - if 32 bytes: `toRootHex()`
  - if pubkey: `toPubkeyHex()` (this is new api)
  - else `toHex()`
