### PR TITLE
feat: archive state using BufferPool if provided

### DIFF
--- a/packages/beacon-node/src/chain/archiver/archiveStates.ts
+++ b/packages/beacon-node/src/chain/archiver/archiveStates.ts
@@ -98,7 +98,7 @@ export class StatesArchiver {
       await this.db.stateArchive.putBinary(slot, finalizedStateOrBytes);
       this.logger.verbose("Archived finalized state bytes", {epoch: finalized.epoch, slot, root: rootHex});
     } else {
-      // serialize state using
+      // serialize state using BufferPool if provided
       await serializeState(
         finalizedStateOrBytes,
         AllocSource.ARCHIVE_STATE,

--- a/packages/beacon-node/src/chain/archiver/index.ts
+++ b/packages/beacon-node/src/chain/archiver/index.ts
@@ -48,7 +48,7 @@ export class Archiver {
     opts: ArchiverOpts
   ) {
     this.archiveBlobEpochs = opts.archiveBlobEpochs;
-    this.statesArchiver = new StatesArchiver(chain.regen, db, logger, opts);
+    this.statesArchiver = new StatesArchiver(chain.regen, db, logger, opts, chain.bufferPool);
     this.prevFinalized = chain.forkChoice.getFinalizedCheckpoint();
     this.jobQueue = new JobItemQueue<[CheckpointWithHex], void>(this.processFinalizedCheckpoint, {
       maxLength: PROCESS_FINALIZED_CHECKPOINT_QUEUE_LEN,

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -119,6 +119,7 @@ export class BeaconChain implements IBeaconChain {
   readonly config: BeaconConfig;
   readonly logger: Logger;
   readonly metrics: Metrics | null;
+  readonly bufferPool: BufferPool | null;
 
   readonly anchorStateLatestBlockSlot: Slot;
 
@@ -266,6 +267,9 @@ export class BeaconChain implements IBeaconChain {
     const blockStateCache = this.opts.nHistoricalStates
       ? new FIFOBlockStateCache(this.opts, {metrics})
       : new BlockStateCacheImpl({metrics});
+    this.bufferPool = this.opts.nHistoricalStates
+      ? new BufferPool(anchorState.type.tree_serializedSize(anchorState.node), metrics)
+      : null;
     const checkpointStateCache = this.opts.nHistoricalStates
       ? new PersistentCheckpointStateCache(
           {
@@ -274,7 +278,7 @@ export class BeaconChain implements IBeaconChain {
             clock,
             shufflingCache: this.shufflingCache,
             blockStateCache,
-            bufferPool: new BufferPool(anchorState.type.tree_serializedSize(anchorState.node), metrics),
+            bufferPool: this.bufferPool,
             datastore: fileDataStore
               ? // debug option if we want to investigate any issues with the DB
                 new FileCPStateDatastore()

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -30,6 +30,7 @@ import {IEth1ForBlockProduction} from "../eth1/index.js";
 import {IExecutionEngine, IExecutionBuilder} from "../execution/index.js";
 import {Metrics} from "../metrics/metrics.js";
 import {IClock} from "../util/clock.js";
+import {BufferPool} from "../util/bufferPool.js";
 import {ChainEventEmitter} from "./emitter.js";
 import {IStateRegenerator, RegenCaller} from "./regen/index.js";
 import {IBlsVerifier} from "./bls/index.js";
@@ -86,6 +87,7 @@ export interface IBeaconChain {
   readonly config: BeaconConfig;
   readonly logger: Logger;
   readonly metrics: Metrics | null;
+  readonly bufferPool: BufferPool | null;
 
   /** The initial slot that the chain is started with */
   readonly anchorStateLatestBlockSlot: Slot;

--- a/packages/beacon-node/src/chain/serializeState.ts
+++ b/packages/beacon-node/src/chain/serializeState.ts
@@ -1,0 +1,33 @@
+import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {AllocSource, BufferPool} from "../util/bufferPool.js";
+
+type ProcessStateBytesFn<T> = (stateBytes: Uint8Array) => Promise<T>;
+
+/*
+ * Serialize state using the BufferPool if provided.
+ */
+export async function serializeState<T>(
+  state: CachedBeaconStateAllForks,
+  source: AllocSource,
+  processFn: ProcessStateBytesFn<T>,
+  bufferPool?: BufferPool | null
+): Promise<T> {
+  const size = state.type.tree_serializedSize(state.node);
+  let stateBytes: Uint8Array | null = null;
+  if (bufferPool) {
+    const bufferWithKey = bufferPool.alloc(size, source);
+    if (bufferWithKey) {
+      stateBytes = bufferWithKey.buffer;
+      const dataView = new DataView(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength);
+      state.serializeToBytes({uint8Array: stateBytes, dataView}, 0);
+    }
+  }
+
+  if (!stateBytes) {
+    // we already have metrics in BufferPool so no need to do it here
+    stateBytes = state.serialize();
+  }
+
+  return processFn(stateBytes);
+  // release the buffer back to the pool automatically
+}

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -18,6 +18,7 @@ import {LodestarMetadata} from "../options.js";
 import {RegistryMetricCreator} from "../utils/registryMetricCreator.js";
 import {OpSource} from "../validatorMonitor.js";
 import {CacheItemType} from "../../chain/stateCache/types.js";
+import {AllocSource} from "../../util/bufferPool.js";
 
 export type LodestarMetrics = ReturnType<typeof createLodestarMetrics>;
 
@@ -1150,13 +1151,15 @@ export function createLodestarMetrics(
         name: "lodestar_buffer_pool_length",
         help: "Buffer pool length",
       }),
-      hits: register.counter({
+      hits: register.counter<{source: AllocSource}>({
         name: "lodestar_buffer_pool_hits_total",
         help: "Total number of buffer pool hits",
+        labelNames: ["source"],
       }),
-      misses: register.counter({
+      misses: register.counter<{source: AllocSource}>({
         name: "lodestar_buffer_pool_misses_total",
         help: "Total number of buffer pool misses",
+        labelNames: ["source"],
       }),
       grows: register.counter({
         name: "lodestar_buffer_pool_grows_total",
@@ -1250,10 +1253,6 @@ export function createLodestarMetrics(
       persistedStateRemoveCount: register.gauge({
         name: "lodestar_cp_state_cache_persisted_state_remove_count",
         help: "Total number of persisted states removed",
-      }),
-      persistedStateAllocCount: register.counter({
-        name: "lodestar_cp_state_cache_persisted_state_alloc_count",
-        help: "Total number time to allocate memory for persisted state",
       }),
     },
 

--- a/packages/beacon-node/test/unit/util/bufferPool.test.ts
+++ b/packages/beacon-node/test/unit/util/bufferPool.test.ts
@@ -1,12 +1,12 @@
 import {describe, it, expect} from "vitest";
-import {BufferPool} from "../../../src/util/bufferPool.js";
+import {AllocSource, BufferPool} from "../../../src/util/bufferPool.js";
 
 describe("BufferPool", () => {
   const pool = new BufferPool(100);
 
   it("should increase length", () => {
     expect(pool.length).toEqual(110);
-    using mem = pool.alloc(200);
+    using mem = pool.alloc(200, AllocSource.PERSISTENT_CHECKPOINTS_CACHE_STATE);
     if (mem === null) {
       throw Error("Expected non-null mem");
     }
@@ -15,15 +15,15 @@ describe("BufferPool", () => {
 
   it("should not allow alloc if in use", () => {
     {
-      using mem = pool.alloc(20);
+      using mem = pool.alloc(20, AllocSource.PERSISTENT_CHECKPOINTS_CACHE_STATE);
       if (mem === null) {
         throw Error("Expected non-null mem");
       }
       // in the same scope we can't allocate again
-      expect(pool.alloc(20)).toEqual(null);
+      expect(pool.alloc(20, AllocSource.PERSISTENT_CHECKPOINTS_CACHE_STATE)).toEqual(null);
     }
 
     // out of the scope we can allocate again
-    expect(pool.alloc(20)).not.toEqual(null);
+    expect(pool.alloc(20, AllocSource.PERSISTENT_CHECKPOINTS_CACHE_STATE)).not.toEqual(null);
   });
 });


### PR DESCRIPTION
**Motivation**

- When n-historical state flag is lived, we have a BufferPool. We should use it to archive state better
- It's also a prerequisite for [state-diff PR](https://github.com/ChainSafe/lodestar/pull/7005)

**Description**

- enhance `BufferPool` to have metric labels based on source
- publish `BufferPool` on BeaconChain based on n-historical flag
- refactor `serializeState()` api
- bot state archiver and PersistentCheckpointsCache use `serializeState()` api
- remove unused Grafana metrics

**Follow up**
- Update Grafana panels
- Move `serializeState.ts` and `initState.ts` to new `chain/states` if we want to

Closes #6935

cc @nazarhussain 