### PR TITLE
fix: improve processEffectiveBalanceUpdates

### DIFF
--- a/packages/beacon-node/src/chain/historicalState/worker.ts
+++ b/packages/beacon-node/src/chain/historicalState/worker.ts
@@ -82,6 +82,10 @@ if (metricsRegister) {
       buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5],
       labelNames: ["source"],
     }),
+    numEffectiveBalanceUpdates: metricsRegister.gauge({
+      name: "lodestar_historical_state_stfn_num_effective_balance_updates_count",
+      help: "Count of effective balance updates in epoch transition",
+    }),
     preStateBalancesNodesPopulatedMiss: metricsRegister.gauge<{source: StateCloneSource}>({
       name: "lodestar_historical_state_stfn_balances_nodes_populated_miss_total",
       help: "Total count state.balances nodesPopulated is false on stfn",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -332,6 +332,10 @@ export function createLodestarMetrics(
       buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5],
       labelNames: ["source"],
     }),
+    numEffectiveBalanceUpdates: register.gauge({
+      name: "lodestar_stfn_effective_balance_updates_count",
+      help: "Total count of effective balance updates",
+    }),
     preStateBalancesNodesPopulatedMiss: register.gauge<{source: StateCloneSource}>({
       name: "lodestar_stfn_balances_nodes_populated_miss_total",
       help: "Total count state.balances nodesPopulated is false on stfn",

--- a/packages/state-transition/src/cache/epochTransitionCache.ts
+++ b/packages/state-transition/src/cache/epochTransitionCache.ts
@@ -1,4 +1,4 @@
-import {Epoch, ValidatorIndex} from "@lodestar/types";
+import {Epoch, ValidatorIndex, phase0} from "@lodestar/types";
 import {intDiv} from "@lodestar/utils";
 import {EPOCHS_PER_SLASHINGS_VECTOR, FAR_FUTURE_EPOCH, ForkSeq, MIN_ACTIVATION_BALANCE} from "@lodestar/params";
 
@@ -126,6 +126,18 @@ export interface EpochTransitionCache {
   inclusionDelays: number[];
 
   flags: number[];
+
+  /**
+   * Validators in the current epoch, should use it for read-only value instead of accessing state.validators directly.
+   * Note that during epoch processing, validators could be updated so need to use it with care.
+   */
+  validators: phase0.Validator[];
+
+  /**
+   * This is for electra only
+   * Validators that're switched to compounding during processPendingConsolidations(), not available in beforeProcessEpoch()
+   */
+  newCompoundingValidators?: Set<ValidatorIndex>;
 
   /**
    * balances array will be populated by processRewardsAndPenalties() and consumed by processEffectiveBalanceUpdates().
@@ -481,7 +493,9 @@ export function beforeProcessEpoch(
     proposerIndices,
     inclusionDelays,
     flags,
-
+    validators,
+    // will be assigned in processPendingConsolidations()
+    newCompoundingValidators: undefined,
     // Will be assigned in processRewardsAndPenalties()
     balances: undefined,
   };

--- a/packages/state-transition/src/epoch/index.ts
+++ b/packages/state-transition/src/epoch/index.ts
@@ -150,8 +150,9 @@ export function processEpoch(
     const timer = metrics?.epochTransitionStepTime.startTimer({
       step: EpochTransitionStep.processEffectiveBalanceUpdates,
     });
-    processEffectiveBalanceUpdates(fork, state, cache);
+    const numUpdate = processEffectiveBalanceUpdates(fork, state, cache);
     timer?.();
+    metrics?.numEffectiveBalanceUpdates.set(numUpdate);
   }
 
   processSlashingsReset(state, cache);

--- a/packages/state-transition/src/epoch/processPendingConsolidations.ts
+++ b/packages/state-transition/src/epoch/processPendingConsolidations.ts
@@ -1,3 +1,4 @@
+import {ValidatorIndex} from "@lodestar/types";
 import {CachedBeaconStateElectra, EpochTransitionCache} from "../types.js";
 import {decreaseBalance, increaseBalance} from "../util/balance.js";
 import {getActiveBalance} from "../util/validator.js";
@@ -20,6 +21,7 @@ export function processPendingConsolidations(state: CachedBeaconStateElectra, ca
   let nextPendingConsolidation = 0;
   const validators = state.validators;
   const cachedBalances = cache.balances;
+  const newCompoundingValidators = new Set<ValidatorIndex>();
 
   for (const pendingConsolidation of state.pendingConsolidations.getAllReadonly()) {
     const {sourceIndex, targetIndex} = pendingConsolidation;
@@ -35,6 +37,7 @@ export function processPendingConsolidations(state: CachedBeaconStateElectra, ca
     }
     // Churn any target excess active balance of target and raise its max
     switchToCompoundingValidator(state, targetIndex);
+    newCompoundingValidators.add(targetIndex);
     // Move active balance to target. Excess balance is withdrawable.
     const activeBalance = getActiveBalance(state, sourceIndex);
     decreaseBalance(state, sourceIndex, activeBalance);
@@ -47,5 +50,6 @@ export function processPendingConsolidations(state: CachedBeaconStateElectra, ca
     nextPendingConsolidation++;
   }
 
+  cache.newCompoundingValidators = newCompoundingValidators;
   state.pendingConsolidations = state.pendingConsolidations.sliceFrom(nextPendingConsolidation);
 }

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -11,6 +11,7 @@ export type BeaconStateTransitionMetrics = {
   processBlockTime: Histogram;
   processBlockCommitTime: Histogram;
   stateHashTreeRootTime: Histogram<{source: StateHashTreeRootSource}>;
+  numEffectiveBalanceUpdates: Gauge;
   preStateBalancesNodesPopulatedMiss: Gauge<{source: StateCloneSource}>;
   preStateBalancesNodesPopulatedHit: Gauge<{source: StateCloneSource}>;
   preStateValidatorsNodesPopulatedMiss: Gauge<{source: StateCloneSource}>;

--- a/packages/state-transition/test/perf/epoch/epochAltair.test.ts
+++ b/packages/state-transition/test/perf/epoch/epochAltair.test.ts
@@ -141,7 +141,9 @@ function benchmarkAltairEpochSteps(stateOg: LazyValue<CachedBeaconStateAllForks>
   itBench({
     id: `${stateId} - altair processEffectiveBalanceUpdates`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processEffectiveBalanceUpdates(ForkSeq.altair, state, cache.value),
+    fn: (state) => {
+      processEffectiveBalanceUpdates(ForkSeq.altair, state, cache.value);
+    },
   });
 
   itBench({

--- a/packages/state-transition/test/perf/epoch/epochCapella.test.ts
+++ b/packages/state-transition/test/perf/epoch/epochCapella.test.ts
@@ -120,7 +120,9 @@ function benchmarkAltairEpochSteps(stateOg: LazyValue<CachedBeaconStateAllForks>
   itBench({
     id: `${stateId} - capella processEffectiveBalanceUpdates`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processEffectiveBalanceUpdates(ForkSeq.capella, state, cache.value),
+    fn: (state) => {
+      processEffectiveBalanceUpdates(ForkSeq.capella, state, cache.value);
+    },
   });
 
   itBench({

--- a/packages/state-transition/test/perf/epoch/epochPhase0.test.ts
+++ b/packages/state-transition/test/perf/epoch/epochPhase0.test.ts
@@ -123,7 +123,9 @@ function benchmarkPhase0EpochSteps(stateOg: LazyValue<CachedBeaconStateAllForks>
   itBench({
     id: `${stateId} - phase0 processEffectiveBalanceUpdates`,
     beforeEach: () => stateOg.value.clone(),
-    fn: (state) => processEffectiveBalanceUpdates(ForkSeq.phase0, state, cache.value),
+    fn: (state) => {
+      processEffectiveBalanceUpdates(ForkSeq.phase0, state, cache.value);
+    },
   });
 
   itBench({

--- a/packages/state-transition/test/perf/epoch/processEffectiveBalanceUpdates.test.ts
+++ b/packages/state-transition/test/perf/epoch/processEffectiveBalanceUpdates.test.ts
@@ -36,7 +36,9 @@ describe("phase0 processEffectiveBalanceUpdates", () => {
       minRuns: 5, // Worst case is very slow
       before: () => getEffectiveBalanceTestData(vc, changeRatio),
       beforeEach: ({state, cache}) => ({state: state.clone(), cache}),
-      fn: ({state, cache}) => processEffectiveBalanceUpdates(ForkSeq.phase0, state, cache),
+      fn: ({state, cache}) => {
+        processEffectiveBalanceUpdates(ForkSeq.phase0, state, cache);
+      },
     });
   }
 });


### PR DESCRIPTION
**Motivation**

@nflaig found that epoch transition is 10x slower as seen in `altair processEpoch - mainnet_e81889` benchmark. This is because we broke the optimization in #2902

**Description**

- cache validators in `beforeProcessEpoch()`
- cache new compounding validators in `processPendingConsolidations`
- update `processEffectiveBalanceUpdates()`: use the above to compute `effectiveBalanceLimit` to avoid unnecessary updates
- also track it in `numEffectiveBalanceUpdates` metric
