### PR TITLE
chore: update keymanager spec tests to run against v1.1.0

### DIFF
--- a/packages/api/test/unit/keymanager/oapiSpec.test.ts
+++ b/packages/api/test/unit/keymanager/oapiSpec.test.ts
@@ -12,7 +12,7 @@ import {testData} from "./testData.js";
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const version = "v1.0.0";
+const version = "v1.1.0";
 const openApiFile: OpenApiFile = {
   url: `https://github.com/ethereum/keymanager-APIs/releases/download/${version}/keymanager-oapi.json`,
   filepath: path.join(__dirname, "../../../oapi-schemas/keymanager-oapi.json"),


### PR DESCRIPTION
**Motivation**

Latest spec now covers voluntary exit and graffiti apis which we have implemented already but are not tested right now.

**Description**

Update keymanager spec tests to run against v1.1.0
