### PR TITLE
fix: improve performance of getExpectedWithdrawals

### DIFF
--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -89,6 +89,10 @@ export function getExpectedWithdrawals(
   sampledValidators: number;
   partialWithdrawalsCount: number;
 } {
+  if (fork < ForkSeq.capella) {
+    throw new Error(`getExpectedWithdrawals not supported at forkSeq=${fork} < ForkSeq.capella`);
+  }
+
   const epoch = state.epochCtx.epoch;
   let withdrawalIndex = state.nextWithdrawalIndex;
   const {validators, balances, nextWithdrawalValidatorIndex} = state;


### PR DESCRIPTION
**Motivation**

- improve performance of getExpectedWithdrawals()

**Description**

- for EIP-7002 withdrawals, only call `getAllReadonly()` conditionally due to its big length limit
- for capella withdrawals, improve performance by embedding logics of `isFullyWithdrawableValidator()` and `isPartiallyWithdrawableValidator()`
  - these functions are now moved since they are not in use
  - this also match the current implementation
- refactor `partialWithdrawalsCount` to `eip7002WithdrawalsCount` to make it more meaningful. `partialWithdrawalsCount` sounds link to the capella withdrawal

**Note**
- some benchmark may still fails since in electra, max effective balance is per validator and the complexity of `hasWithdrawableCredentials` but the test time is in `us` so should not be an issue. I don't see we can improve it due to spec change.
