### PR TITLE
chore: fix api handler used during testing

### DIFF
--- a/packages/beacon-node/test/utils/node/validator.ts
+++ b/packages/beacon-node/test/utils/node/validator.ts
@@ -97,7 +97,7 @@ export function getApiFromServerHandlers(api: BeaconApiMethods): ApiClient {
       return async (args: unknown) => {
         try {
           const apiResponse = new ApiResponse({} as any, null, new Response(null, {status: HttpStatusCode.OK}));
-          const result = await api(args, {});
+          const result = await api.call(apiModule, args, {});
           apiResponse.value = () => result.data;
           apiResponse.meta = () => result.meta;
           return apiResponse;


### PR DESCRIPTION
**Motivation**

Fix e2e tests on electra branch, see [job run](https://github.com/ChainSafe/lodestar/actions/runs/10523250967/job/29157661342?pr=6986#step:6:45995)

**Description**

Fix api handler used during testing by supplying api module to call to set as `this` object

https://github.com/ChainSafe/lodestar/blob/81b6d7a5cc6695c357c55e4c14edc6469b5f966a/packages/beacon-node/src/api/impl/beacon/pool/index.ts#L85-L87