### PR TITLE
fix: single state tree at start up

### DIFF
--- a/packages/beacon-node/src/chain/initState.ts
+++ b/packages/beacon-node/src/chain/initState.ts
@@ -154,7 +154,7 @@ export async function initStateFromDb(
 /**
  * Initialize and persist an anchor state (either weak subjectivity or genesis)
  */
-export async function initStateFromAnchorState(
+export async function checkAndPersistAnchorState(
   config: ChainForkConfig,
   db: IBeaconDb,
   logger: Logger,

--- a/packages/beacon-node/src/chain/initState.ts
+++ b/packages/beacon-node/src/chain/initState.ts
@@ -37,17 +37,18 @@ export async function persistGenesisResult(
 export async function persistAnchorState(
   config: ChainForkConfig,
   db: IBeaconDb,
-  anchorState: BeaconStateAllForks
+  anchorState: BeaconStateAllForks,
+  anchorStateBytes: Uint8Array
 ): Promise<void> {
   if (anchorState.slot === GENESIS_SLOT) {
     const genesisBlock = createGenesisBlock(config, anchorState);
     await Promise.all([
       db.blockArchive.add(genesisBlock),
       db.block.add(genesisBlock),
-      db.stateArchive.add(anchorState),
+      db.stateArchive.putBinary(anchorState.slot, anchorStateBytes),
     ]);
   } else {
-    await db.stateArchive.add(anchorState);
+    await db.stateArchive.putBinary(anchorState.slot, anchorStateBytes);
   }
 }
 
@@ -159,11 +160,12 @@ export async function checkAndPersistAnchorState(
   db: IBeaconDb,
   logger: Logger,
   anchorState: BeaconStateAllForks,
+  anchorStateBytes: Uint8Array,
   {
     isWithinWeakSubjectivityPeriod,
     isCheckpointState,
   }: {isWithinWeakSubjectivityPeriod: boolean; isCheckpointState: boolean}
-): Promise<BeaconStateAllForks> {
+): Promise<void> {
   const expectedFork = config.getForkInfo(computeStartSlotAtEpoch(anchorState.fork.epoch));
   const expectedForkVersion = toHex(expectedFork.version);
   const stateFork = toHex(anchorState.fork.currentVersion);
@@ -192,10 +194,8 @@ export async function checkAndPersistAnchorState(
   }
 
   if (isCheckpointState || anchorState.slot === GENESIS_SLOT) {
-    await persistAnchorState(config, db, anchorState);
+    await persistAnchorState(config, db, anchorState, anchorStateBytes);
   }
-
-  return anchorState;
 }
 
 export function initBeaconMetrics(metrics: Metrics, state: BeaconStateAllForks): void {

--- a/packages/beacon-node/src/chain/initState.ts
+++ b/packages/beacon-node/src/chain/initState.ts
@@ -191,7 +191,9 @@ export async function checkAndPersistAnchorState(
     logger.warn("Checkpoint sync recommended, please use --help to see checkpoint sync options");
   }
 
-  await persistAnchorState(config, db, anchorState);
+  if (isCheckpointState || anchorState.slot === GENESIS_SLOT) {
+    await persistAnchorState(config, db, anchorState);
+  }
 
   return anchorState;
 }

--- a/packages/beacon-node/src/index.ts
+++ b/packages/beacon-node/src/index.ts
@@ -1,4 +1,4 @@
-export {initStateFromAnchorState, initStateFromDb, initStateFromEth1} from "./chain/index.js";
+export {checkAndPersistAnchorState, initStateFromDb, initStateFromEth1} from "./chain/index.js";
 export {BeaconDb, type IBeaconDb} from "./db/index.js";
 export {Eth1Provider, type IEth1Provider} from "./eth1/index.js";
 export {createNodeJsLibp2p, type NodeJsLibp2pOpts} from "./network/index.js";

--- a/packages/beacon-node/src/index.ts
+++ b/packages/beacon-node/src/index.ts
@@ -20,4 +20,4 @@ export {RestApiServer} from "./api/rest/base.js";
 export type {RestApiServerOpts, RestApiServerModules, RestApiServerMetrics} from "./api/rest/base.js";
 
 // Export type util for CLI - TEMP move to lodestar-types eventually
-export {getStateTypeFromBytes} from "./util/multifork.js";
+export {getStateTypeFromBytes, getStateSlotFromBytes} from "./util/multifork.js";

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -1,6 +1,6 @@
 import {ssz} from "@lodestar/types";
 import {createBeaconConfig, BeaconConfig, ChainForkConfig} from "@lodestar/config";
-import {Logger} from "@lodestar/utils";
+import {Logger, formatBytes} from "@lodestar/utils";
 import {
   isWithinWeakSubjectivityPeriod,
   ensureWithinWeakSubjectivityPeriod,
@@ -104,6 +104,7 @@ export async function initBeaconState(
   let lastDbState: BeaconStateAllForks | null = null;
   let lastDbValidatorsBytes: Uint8Array | null = null;
   if (lastDbStateBytes) {
+    logger.verbose("Found the last archived state", {slot: lastDbSlot, size: formatBytes(lastDbStateBytes.length)});
     const {state, validatorsBytes} = loadStateAndValidators(chainForkConfig, lastDbStateBytes);
     lastDbState = state;
     lastDbValidatorsBytes = validatorsBytes;

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -27,19 +27,23 @@ import {
 } from "../../networks/index.js";
 import {BeaconArgs} from "./options.js";
 
+type StateWithBytes = {state: BeaconStateAllForks; stateBytes: Uint8Array};
+
 async function initAndVerifyWeakSubjectivityState(
   config: BeaconConfig,
   db: IBeaconDb,
   logger: Logger,
-  store: BeaconStateAllForks,
-  wsState: BeaconStateAllForks,
+  dbStateBytes: StateWithBytes,
+  wsStateBytes: StateWithBytes,
   wsCheckpoint: Checkpoint,
   opts: {ignoreWeakSubjectivityCheck?: boolean} = {}
 ): Promise<{anchorState: BeaconStateAllForks; wsCheckpoint: Checkpoint}> {
+  const dbState = dbStateBytes.state;
+  const wsState = wsStateBytes.state;
   // Check if the store's state and wsState are compatible
   if (
-    store.genesisTime !== wsState.genesisTime ||
-    !ssz.Root.equals(store.genesisValidatorsRoot, wsState.genesisValidatorsRoot)
+    dbState.genesisTime !== wsState.genesisTime ||
+    !ssz.Root.equals(dbState.genesisValidatorsRoot, wsState.genesisValidatorsRoot)
   ) {
     throw new Error(
       "Db state and checkpoint state are not compatible, either clear the db or verify your checkpoint source"
@@ -47,12 +51,12 @@ async function initAndVerifyWeakSubjectivityState(
   }
 
   // Pick the state which is ahead as an anchor to initialize the beacon chain
-  let anchorState = wsState;
+  let anchorState = wsStateBytes;
   let anchorCheckpoint = wsCheckpoint;
   let isCheckpointState = true;
-  if (store.slot > wsState.slot) {
-    anchorState = store;
-    anchorCheckpoint = getCheckpointFromState(store);
+  if (dbState.slot > wsState.slot) {
+    anchorState = dbStateBytes;
+    anchorCheckpoint = getCheckpointFromState(dbState);
     isCheckpointState = false;
     logger.verbose(
       "Db state is ahead of the provided checkpoint state, using the db state to initialize the beacon chain"
@@ -61,19 +65,19 @@ async function initAndVerifyWeakSubjectivityState(
 
   // Throw error unless user explicitly asked not to, in testnets can happen that wss period is too small
   // that even some epochs of non finalization can cause finalized checkpoint to be out of valid range
-  const wssCheck = wrapFnError(() => ensureWithinWeakSubjectivityPeriod(config, anchorState, anchorCheckpoint));
+  const wssCheck = wrapFnError(() => ensureWithinWeakSubjectivityPeriod(config, anchorState.state, anchorCheckpoint));
   const isWithinWeakSubjectivityPeriod = wssCheck.err === null;
   if (!isWithinWeakSubjectivityPeriod && !opts.ignoreWeakSubjectivityCheck) {
     throw wssCheck.err;
   }
 
-  anchorState = await checkAndPersistAnchorState(config, db, logger, anchorState, {
+  await checkAndPersistAnchorState(config, db, logger, anchorState.state, anchorState.stateBytes, {
     isWithinWeakSubjectivityPeriod,
     isCheckpointState,
   });
 
   // Return the latest anchorState but still return original wsCheckpoint to validate in backfill
-  return {anchorState, wsCheckpoint};
+  return {anchorState: anchorState.state, wsCheckpoint};
 }
 
 /**
@@ -100,14 +104,16 @@ export async function initBeaconState(
   //   i)  used directly as the anchor state
   //   ii) used to load and verify a weak subjectivity state,
   const lastDbSlot = await db.stateArchive.lastKey();
-  const lastDbStateBytes = lastDbSlot !== null ? await db.stateArchive.getBinary(lastDbSlot) : null;
+  const stateBytes = lastDbSlot !== null ? await db.stateArchive.getBinary(lastDbSlot) : null;
   let lastDbState: BeaconStateAllForks | null = null;
   let lastDbValidatorsBytes: Uint8Array | null = null;
-  if (lastDbStateBytes) {
-    logger.verbose("Found the last archived state", {slot: lastDbSlot, size: formatBytes(lastDbStateBytes.length)});
-    const {state, validatorsBytes} = loadStateAndValidators(chainForkConfig, lastDbStateBytes);
+  let lastDbStateWithBytes: StateWithBytes | null = null;
+  if (stateBytes) {
+    logger.verbose("Found the last archived state", {slot: lastDbSlot, size: formatBytes(stateBytes.length)});
+    const {state, validatorsBytes} = loadStateAndValidators(chainForkConfig, stateBytes);
     lastDbState = state;
     lastDbValidatorsBytes = validatorsBytes;
+    lastDbStateWithBytes = {state, stateBytes: stateBytes};
   }
 
   if (lastDbState) {
@@ -129,11 +135,15 @@ export async function initBeaconState(
       //  - if no checkpoint sync args provided, or
       //  - the lastDbState is within weak subjectivity period:
       if ((!args.checkpointState && !args.checkpointSyncUrl) || wssCheck) {
-        const anchorState = await checkAndPersistAnchorState(config, db, logger, lastDbState, {
+        if (stateBytes === null) {
+          // this never happens
+          throw Error(`There is no stateBytes for the lastDbState at slot ${lastDbState.slot}`);
+        }
+        await checkAndPersistAnchorState(config, db, logger, lastDbState, stateBytes, {
           isWithinWeakSubjectivityPeriod: wssCheck,
           isCheckpointState: false,
         });
-        return {anchorState};
+        return {anchorState: lastDbState};
       }
     }
   }
@@ -141,7 +151,7 @@ export async function initBeaconState(
   // See if we can sync state using checkpoint sync args or else start from genesis
   if (args.checkpointState) {
     return readWSState(
-      lastDbState,
+      lastDbStateWithBytes,
       lastDbValidatorsBytes,
       {
         checkpointState: args.checkpointState,
@@ -154,7 +164,7 @@ export async function initBeaconState(
     );
   } else if (args.checkpointSyncUrl) {
     return fetchWSStateFromBeaconApi(
-      lastDbState,
+      lastDbStateWithBytes,
       lastDbValidatorsBytes,
       {
         checkpointSyncUrl: args.checkpointSyncUrl,
@@ -169,10 +179,10 @@ export async function initBeaconState(
     const genesisStateFile = args.genesisStateFile || getGenesisFileUrl(args.network || defaultNetwork);
     if (genesisStateFile && !args.forceGenesis) {
       const stateBytes = await downloadOrLoadFile(genesisStateFile);
-      let anchorState = getStateTypeFromBytes(chainForkConfig, stateBytes).deserializeToViewDU(stateBytes);
+      const anchorState = getStateTypeFromBytes(chainForkConfig, stateBytes).deserializeToViewDU(stateBytes);
       const config = createBeaconConfig(chainForkConfig, anchorState.genesisValidatorsRoot);
       const wssCheck = isWithinWeakSubjectivityPeriod(config, anchorState, getCheckpointFromState(anchorState));
-      anchorState = await checkAndPersistAnchorState(config, db, logger, anchorState, {
+      await checkAndPersistAnchorState(config, db, logger, anchorState, stateBytes, {
         isWithinWeakSubjectivityPeriod: wssCheck,
         isCheckpointState: true,
       });
@@ -186,7 +196,7 @@ export async function initBeaconState(
 }
 
 async function readWSState(
-  lastDbState: BeaconStateAllForks | null,
+  lastDbStateBytes: StateWithBytes | null,
   lastDbValidatorsBytes: Uint8Array | null,
   wssOpts: {checkpointState: string; wssCheckpoint?: string; ignoreWeakSubjectivityCheck?: boolean},
   chainForkConfig: ChainForkConfig,
@@ -197,6 +207,7 @@ async function readWSState(
   // if a weak subjectivity checkpoint has been provided, it is used for additional verification
   // otherwise, the state itself is used for verification (not bad, because the trusted state has been explicitly provided)
   const {checkpointState, wssCheckpoint, ignoreWeakSubjectivityCheck} = wssOpts;
+  const lastDbState = lastDbStateBytes?.state ?? null;
 
   const stateBytes = await downloadOrLoadFile(checkpointState);
   let wsState: BeaconStateAllForks;
@@ -207,15 +218,16 @@ async function readWSState(
     wsState = getStateTypeFromBytes(chainForkConfig, stateBytes).deserializeToViewDU(stateBytes);
   }
   const config = createBeaconConfig(chainForkConfig, wsState.genesisValidatorsRoot);
-  const store = lastDbState ?? wsState;
+  const wsStateBytes = {state: wsState, stateBytes};
+  const store = lastDbStateBytes ?? wsStateBytes;
   const checkpoint = wssCheckpoint ? getCheckpointFromArg(wssCheckpoint) : getCheckpointFromState(wsState);
-  return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsState, checkpoint, {
+  return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsStateBytes, checkpoint, {
     ignoreWeakSubjectivityCheck,
   });
 }
 
 async function fetchWSStateFromBeaconApi(
-  lastDbState: BeaconStateAllForks | null,
+  lastDbStateBytes: StateWithBytes | null,
   lastDbValidatorsBytes: Uint8Array | null,
   wssOpts: {checkpointSyncUrl: string; wssCheckpoint?: string; ignoreWeakSubjectivityCheck?: boolean},
   chainForkConfig: ChainForkConfig,
@@ -237,13 +249,15 @@ async function fetchWSStateFromBeaconApi(
     throw e;
   }
 
-  const {wsState, wsCheckpoint} = await fetchWeakSubjectivityState(chainForkConfig, logger, wssOpts, {
-    lastDbState,
+  const {wsState, wsStateBytes, wsCheckpoint} = await fetchWeakSubjectivityState(chainForkConfig, logger, wssOpts, {
+    lastDbState: lastDbStateBytes?.state ?? null,
     lastDbValidatorsBytes,
   });
+
   const config = createBeaconConfig(chainForkConfig, wsState.genesisValidatorsRoot);
-  const store = lastDbState ?? wsState;
-  return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsState, wsCheckpoint, {
+  const wsStateWithBytes = {state: wsState, stateBytes: wsStateBytes};
+  const store = lastDbStateBytes ?? wsStateWithBytes;
+  return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsStateWithBytes, wsCheckpoint, {
     ignoreWeakSubjectivityCheck: wssOpts.ignoreWeakSubjectivityCheck,
   });
 }

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -11,7 +11,7 @@ import {
 import {
   IBeaconDb,
   IBeaconNodeOptions,
-  initStateFromAnchorState,
+  checkAndPersistAnchorState,
   initStateFromEth1,
   getStateTypeFromBytes,
 } from "@lodestar/beacon-node";
@@ -67,7 +67,7 @@ async function initAndVerifyWeakSubjectivityState(
     throw wssCheck.err;
   }
 
-  anchorState = await initStateFromAnchorState(config, db, logger, anchorState, {
+  anchorState = await checkAndPersistAnchorState(config, db, logger, anchorState, {
     isWithinWeakSubjectivityPeriod,
     isCheckpointState,
   });
@@ -129,7 +129,7 @@ export async function initBeaconState(
       //  - if no checkpoint sync args provided, or
       //  - the lastDbState is within weak subjectivity period:
       if ((!args.checkpointState && !args.checkpointSyncUrl) || wssCheck) {
-        const anchorState = await initStateFromAnchorState(config, db, logger, lastDbState, {
+        const anchorState = await checkAndPersistAnchorState(config, db, logger, lastDbState, {
           isWithinWeakSubjectivityPeriod: wssCheck,
           isCheckpointState: false,
         });
@@ -172,7 +172,7 @@ export async function initBeaconState(
       let anchorState = getStateTypeFromBytes(chainForkConfig, stateBytes).deserializeToViewDU(stateBytes);
       const config = createBeaconConfig(chainForkConfig, anchorState.genesisValidatorsRoot);
       const wssCheck = isWithinWeakSubjectivityPeriod(config, anchorState, getCheckpointFromState(anchorState));
-      anchorState = await initStateFromAnchorState(config, db, logger, anchorState, {
+      anchorState = await checkAndPersistAnchorState(config, db, logger, anchorState, {
         isWithinWeakSubjectivityPeriod: wssCheck,
         isCheckpointState: true,
       });

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -7,7 +7,7 @@ import {getStateSlotFromBytes} from "@lodestar/beacon-node";
 import {ChainConfig, ChainForkConfig} from "@lodestar/config";
 import {Checkpoint} from "@lodestar/types/phase0";
 import {Slot} from "@lodestar/types";
-import {fromHex, callFnWhenAwait, Logger} from "@lodestar/utils";
+import {fromHex, callFnWhenAwait, Logger, formatBytes} from "@lodestar/utils";
 import {
   BeaconStateAllForks,
   getLatestBlockRoot,
@@ -187,7 +187,8 @@ export async function fetchWeakSubjectivityState(
     });
 
     const wsSlot = getStateSlotFromBytes(wsStateBytes);
-    logger.info("Download completed", typeof stateId === "number" ? {stateId} : {stateId, slot: wsSlot});
+    const logData = {stateId, size: formatBytes(wsStateBytes.length)};
+    logger.info("Download completed", typeof stateId === "number" ? logData : {...logData, slot: wsSlot});
     // It should not be required to get fork type from bytes but Checkpointz does not return
     // Eth-Consensus-Version header, see https://github.com/ethpandaops/checkpointz/issues/164
     let wsState: BeaconStateAllForks;

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -150,7 +150,7 @@ export async function fetchWeakSubjectivityState(
     lastDbState,
     lastDbValidatorsBytes,
   }: {lastDbState: BeaconStateAllForks | null; lastDbValidatorsBytes: Uint8Array | null}
-): Promise<{wsState: BeaconStateAllForks; wsCheckpoint: Checkpoint}> {
+): Promise<{wsState: BeaconStateAllForks; wsStateBytes: Uint8Array; wsCheckpoint: Checkpoint}> {
   try {
     let wsCheckpoint: Checkpoint | null;
     let stateId: Slot | "finalized";
@@ -202,6 +202,7 @@ export async function fetchWeakSubjectivityState(
 
     return {
       wsState,
+      wsStateBytes,
       wsCheckpoint: wsCheckpoint ?? getCheckpointFromState(wsState),
     };
   } catch (e) {

--- a/packages/state-transition/src/util/index.ts
+++ b/packages/state-transition/src/util/index.ts
@@ -25,3 +25,4 @@ export * from "./validator.js";
 export * from "./weakSubjectivity.js";
 export * from "./deposit.js";
 export * from "./electra.js";
+export * from "./loadState/index.js";

--- a/packages/state-transition/src/util/loadState/index.ts
+++ b/packages/state-transition/src/util/loadState/index.ts
@@ -1,1 +1,1 @@
-export {loadState} from "./loadState.js";
+export {loadState, loadStateAndValidators} from "./loadState.js";

--- a/packages/state-transition/test/unit/util/loadState.test.ts
+++ b/packages/state-transition/test/unit/util/loadState.test.ts
@@ -1,0 +1,40 @@
+import {describe, it, expect} from "vitest";
+import {ssz} from "@lodestar/types";
+import {mainnetChainConfig} from "@lodestar/config/networks";
+import {createChainForkConfig} from "@lodestar/config";
+import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {loadStateAndValidators} from "../../../src/util/loadState/loadState.js";
+
+describe("loadStateAndValidators", () => {
+  const numValidator = 10;
+  const config = createChainForkConfig(mainnetChainConfig);
+
+  const testCases: {name: ForkName; slot: number}[] = [
+    {name: ForkName.phase0, slot: 100},
+    {name: ForkName.altair, slot: mainnetChainConfig.ALTAIR_FORK_EPOCH * SLOTS_PER_EPOCH + 100},
+    {name: ForkName.capella, slot: mainnetChainConfig.CAPELLA_FORK_EPOCH * SLOTS_PER_EPOCH + 100},
+    {name: ForkName.deneb, slot: mainnetChainConfig.DENEB_FORK_EPOCH * SLOTS_PER_EPOCH + 100},
+  ];
+
+  for (const {name, slot} of testCases) {
+    it(`fork: ${name}, slot: ${slot}`, () => {
+      const state = config.getForkTypes(slot).BeaconState.defaultViewDU();
+      state.slot = slot;
+      for (let i = 0; i < numValidator; i++) {
+        const validator = ssz.phase0.Validator.defaultViewDU();
+        validator.pubkey = Buffer.alloc(48, i);
+        state.validators.push(validator);
+        state.balances.push(32 * 1e9);
+      }
+      state.commit();
+
+      const stateBytes = state.serialize();
+      const stateRoot = state.hashTreeRoot();
+      const {state: loadedState, validatorsBytes} = loadStateAndValidators(config, stateBytes);
+      expect(loadedState.hashTreeRoot()).toEqual(stateRoot);
+      // serialize() somehow takes time, however comparing state root would be enough
+      // expect(loadedState.serialize()).toEqual(stateBytes);
+      expect(validatorsBytes).toEqual(state.validators.serialize());
+    });
+  }
+});

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -48,3 +48,23 @@ export function bytesToBigInt(value: Uint8Array, endianness: Endianness = "le"):
   }
   throw new Error("endianness must be either 'le' or 'be'");
 }
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 0) {
+    throw new Error("bytes must be a positive number, got " + bytes);
+  }
+
+  if (bytes === 0) {
+    return "0 Bytes";
+  }
+
+  // size of a kb
+  const k = 1024;
+
+  // only support up to GB
+  const units = ["Bytes", "KB", "MB", "GB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), units.length - 1);
+  const formattedSize = (bytes / Math.pow(k, i)).toFixed(2);
+
+  return `${formattedSize} ${units[i]}`;
+}

--- a/packages/utils/test/unit/bytes.test.ts
+++ b/packages/utils/test/unit/bytes.test.ts
@@ -1,5 +1,14 @@
 import {describe, it, expect} from "vitest";
-import {intToBytes, bytesToInt, toHex, fromHex, toHexString, toRootHex, toPubkeyHex} from "../../src/index.js";
+import {
+  intToBytes,
+  bytesToInt,
+  toHex,
+  fromHex,
+  toHexString,
+  toRootHex,
+  toPubkeyHex,
+  formatBytes,
+} from "../../src/index.js";
 
 describe("intToBytes", () => {
   const zeroedArray = (length: number): number[] => Array.from({length}, () => 0);
@@ -132,6 +141,27 @@ describe("toHexString", () => {
   for (const {input, output} of testCases) {
     it(`should convert Uint8Array to hex string ${output}`, () => {
       expect(toHexString(input)).toBe(output);
+    });
+  }
+});
+
+describe("formatBytes", () => {
+  const testCases: {input: number; output: string}[] = [
+    {input: 0, output: "0 Bytes"},
+    {input: 1, output: "1.00 Bytes"},
+    {input: 1024, output: "1.00 KB"},
+    {input: 1024 + 0.12 * 1024, output: "1.12 KB"},
+    {input: 1024 * 1024, output: "1.00 MB"},
+    {input: 1024 * 1024 + 0.12 * (1024 * 1024), output: "1.12 MB"},
+    {input: 1024 * 1024 * 1024, output: "1.00 GB"},
+    {input: 1024 * 1024 * 1024 + 0.12 * 1024 * 1024 * 1024, output: "1.12 GB"},
+    // too big
+    {input: 1024 * 1024 * 1024 * 1024, output: "1024.00 GB"},
+  ];
+
+  for (const {input, output} of testCases) {
+    it(`should format ${input} bytes as ${output}`, () => {
+      expect(formatBytes(input)).toBe(output);
     });
   }
 });


### PR DESCRIPTION
**Motivation**

- we deserialize states 2 times to 2 separate tree: one for db state and one for ws state, and each `hashTreeRoot()` call takes ~24s of blocking time at startup
- when persisting anchor state, we serialize it again while we've just downloaded it. Also with db state, we should not persist it to db again

**Description**

- after we got db state, use `loadState()` api to load ws state
- only persist anchor state if it's ws state, and do not serialize again
- rename `initStateFromAnchorState` to `checkAndPersistAnchorState` and no return value, this is to reflect its implementation
- minor thing: add `formatBytes()` util to log how many bytes we downloaded/loaded. Later on we should use the same api to track state diff PR #7005

Closes #7027

**Test**

```
Aug-28 07:44:40.777[]                 ^[[32minfo^[[39m: Lodestar network=holesky, version=v1.21.0/te/single_state_tree_at_start_up/ba3cd96, commit=ba3cd96ac968f5598bbc998c7a3b5ebf650a91e3
Aug-28 07:44:40.962[]                 ^[[32minfo^[[39m: Connected to LevelDB database
Aug-28 07:44:41.732[]              ^[[36mverbose^[[39m: Found the last archived state slot=2410272, size=241.63 MB
Aug-28 07:45:04.668[]                 ^[[33mwarn^[[39m: Forced syncing from checkpoint even though db state at slot 2410272 is within weak subjectivity period
Aug-28 07:45:04.668[]                 ^[[33mwarn^[[39m: Please consider removing --forceCheckpointSync flag unless absolutely necessary
Aug-28 07:45:04.669[]                 ^[[32minfo^[[39m: Fetching checkpoint state checkpointSyncUrl=https://beaconstate-holesky.chainsafe.io

Aug-28 07:45:09.532[]                 ^[[32minfo^[[39m: Download completed stateId=finalized, size=241.53 MB, slot=2410656
Aug-28 07:45:10.858[]                 ^[[32minfo^[[39m: Initializing beacon from a valid checkpoint state slot=2410656, epoch=75333, stateRoot=0x68615af64eed72e6381584063955956a9cbe74a6d8e37c95a10dd0989493f05b, isWithinWeakSubjectivityPeriod=true
```

after "Download completed" log, the beacon node can continue almost immediately instead of blocking for ~24s as currently https://github.com/ChainSafe/lodestar/issues/7027#issuecomment-2311468547