### PR TITLE
chore: update spec test version

### DIFF
--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -15,7 +15,7 @@ import {DownloadTestsOptions} from "@lodestar/spec-test-util/downloadTests";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: DownloadTestsOptions = {
-  specVersion: "v1.5.0-alpha.3",
+  specVersion: "v1.5.0-alpha.5",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-spec-tests",


### PR DESCRIPTION
**Motivation**

Spec `v1.5.0-alpha3` consistently doesn't download.  Update to `alpha5` to get specs tests running consistently