### PR TITLE
feat: implement isomorphic utils for nodejs and browser

### DIFF
--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -3,6 +3,9 @@ import {toBufferLE, toBigIntLE, toBufferBE, toBigIntBE} from "bigint-buffer";
 type Endianness = "le" | "be";
 
 const hexByByte: string[] = [];
+/**
+ * Deprecated. Use toHex() instead.
+ */
 export function toHexString(bytes: Uint8Array): string {
   let hex = "0x";
   for (const byte of bytes) {
@@ -44,34 +47,4 @@ export function bytesToBigInt(value: Uint8Array, endianness: Endianness = "le"):
     return toBigIntBE(value as Buffer);
   }
   throw new Error("endianness must be either 'le' or 'be'");
-}
-
-export function toHex(buffer: Uint8Array | Parameters<typeof Buffer.from>[0]): string {
-  if (Buffer.isBuffer(buffer)) {
-    return "0x" + buffer.toString("hex");
-  } else if (buffer instanceof Uint8Array) {
-    return "0x" + Buffer.from(buffer.buffer, buffer.byteOffset, buffer.length).toString("hex");
-  } else {
-    return "0x" + Buffer.from(buffer).toString("hex");
-  }
-}
-
-// Shared buffer to convert root to hex
-const rootBuf = Buffer.alloc(32);
-
-/**
- * Convert a Uint8Array, length 32, to 0x-prefixed hex string
- */
-export function toRootHex(root: Uint8Array): string {
-  if (root.length !== 32) {
-    throw Error(`Expect root to be 32 bytes, got ${root.length}`);
-  }
-
-  rootBuf.set(root);
-  return `0x${rootBuf.toString("hex")}`;
-}
-
-export function fromHex(hex: string): Uint8Array {
-  const b = Buffer.from(hex.replace("0x", ""), "hex");
-  return new Uint8Array(b.buffer, b.byteOffset, b.length);
 }

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -4,7 +4,7 @@ type Endianness = "le" | "be";
 
 const hexByByte: string[] = [];
 /**
- * Deprecated. Use toHex() instead.
+ * @deprecated Use toHex() instead.
  */
 export function toHexString(bytes: Uint8Array): string {
   let hex = "0x";

--- a/packages/utils/src/bytes/browser.ts
+++ b/packages/utils/src/bytes/browser.ts
@@ -1,0 +1,66 @@
+export function toHex(bytes: Uint8Array): string {
+  const charCodes = new Array<number>(bytes.length * 2 + 2);
+  charCodes[0] = 48;
+  charCodes[1] = 120;
+
+  for (let i = 0; i < bytes.length; i++) {
+    const byte = bytes[i];
+    const first = (byte & 0xf0) >> 4;
+    const second = byte & 0x0f;
+
+    // "0".charCodeAt(0) = 48
+    // "a".charCodeAt(0) = 97 => delta = 87
+    charCodes[2 + 2 * i] = first < 10 ? first + 48 : first + 87;
+    charCodes[2 + 2 * i + 1] = second < 10 ? second + 48 : second + 87;
+  }
+  return String.fromCharCode(...charCodes);
+}
+
+const rootCharCodes = new Array<number>(32 * 2 + 2);
+// "0".charCodeAt(0)
+rootCharCodes[0] = 48;
+// "x".charCodeAt(0)
+rootCharCodes[1] = 120;
+
+/**
+ * Convert a Uint8Array, length 32, to 0x-prefixed hex string
+ */
+export function toRootHex(root: Uint8Array): string {
+  if (root.length !== 32) {
+    throw Error(`Expect root to be 32 bytes, got ${root.length}`);
+  }
+
+  for (let i = 0; i < root.length; i++) {
+    const byte = root[i];
+    const first = (byte & 0xf0) >> 4;
+    const second = byte & 0x0f;
+
+    // "0".charCodeAt(0) = 48
+    // "a".charCodeAt(0) = 97 => delta = 87
+    rootCharCodes[2 + 2 * i] = first < 10 ? first + 48 : first + 87;
+    rootCharCodes[2 + 2 * i + 1] = second < 10 ? second + 48 : second + 87;
+  }
+  return String.fromCharCode(...rootCharCodes);
+}
+
+export function fromHex(hex: string): Uint8Array {
+  if (typeof hex !== "string") {
+    throw new Error(`hex argument type ${typeof hex} must be of type string`);
+  }
+
+  if (hex.startsWith("0x")) {
+    hex = hex.slice(2);
+  }
+
+  if (hex.length % 2 !== 0) {
+    throw new Error(`hex string length ${hex.length} must be multiple of 2`);
+  }
+
+  const byteLen = hex.length / 2;
+  const bytes = new Uint8Array(byteLen);
+  for (let i = 0; i < byteLen; i++) {
+    const byte = parseInt(hex.slice(i * 2, (i + 1) * 2), 16);
+    bytes[i] = byte;
+  }
+  return bytes;
+}

--- a/packages/utils/src/bytes/index.ts
+++ b/packages/utils/src/bytes/index.ts
@@ -1,0 +1,15 @@
+let toHex: (bytes: Uint8Array) => string;
+let toRootHex: (root: Uint8Array) => string;
+let fromHex: (hex: string) => Uint8Array;
+
+if (typeof Buffer !== "undefined") {
+  toHex = (await import("./nodejs.js")).toHex;
+  toRootHex = (await import("./nodejs.js")).toRootHex;
+  fromHex = (await import("./nodejs.js")).fromHex;
+} else {
+  toHex = (await import("./browser.js")).toHex;
+  toRootHex = (await import("./browser.js")).toRootHex;
+  fromHex = (await import("./browser.js")).fromHex;
+}
+
+export {toHex, toRootHex, fromHex};

--- a/packages/utils/src/bytes/index.ts
+++ b/packages/utils/src/bytes/index.ts
@@ -1,15 +1,14 @@
-let toHex: (bytes: Uint8Array) => string;
-let toRootHex: (root: Uint8Array) => string;
-let fromHex: (hex: string) => Uint8Array;
+import {toHex as browserToHex, toRootHex as browserToRootHex, fromHex as browserFromHex} from "./browser.js";
+import {toHex as nodeToHex, toRootHex as nodeToRootHex, fromHex as nodeFromHex} from "./nodejs.js";
+
+let toHex = browserToHex;
+let toRootHex = browserToRootHex;
+let fromHex = browserFromHex;
 
 if (typeof Buffer !== "undefined") {
-  toHex = (await import("./nodejs.js")).toHex;
-  toRootHex = (await import("./nodejs.js")).toRootHex;
-  fromHex = (await import("./nodejs.js")).fromHex;
-} else {
-  toHex = (await import("./browser.js")).toHex;
-  toRootHex = (await import("./browser.js")).toRootHex;
-  fromHex = (await import("./browser.js")).fromHex;
+  toHex = nodeToHex;
+  toRootHex = nodeToRootHex;
+  fromHex = nodeFromHex;
 }
 
 export {toHex, toRootHex, fromHex};

--- a/packages/utils/src/bytes/nodejs.ts
+++ b/packages/utils/src/bytes/nodejs.ts
@@ -1,0 +1,29 @@
+export function toHex(buffer: Uint8Array | Parameters<typeof Buffer.from>[0]): string {
+  if (Buffer.isBuffer(buffer)) {
+    return "0x" + buffer.toString("hex");
+  } else if (buffer instanceof Uint8Array) {
+    return "0x" + Buffer.from(buffer.buffer, buffer.byteOffset, buffer.length).toString("hex");
+  } else {
+    return "0x" + Buffer.from(buffer).toString("hex");
+  }
+}
+
+// Shared buffer to convert root to hex
+const rootBuf = Buffer.alloc(32);
+
+/**
+ * Convert a Uint8Array, length 32, to 0x-prefixed hex string
+ */
+export function toRootHex(root: Uint8Array): string {
+  if (root.length !== 32) {
+    throw Error(`Expect root to be 32 bytes, got ${root.length}`);
+  }
+
+  rootBuf.set(root);
+  return `0x${rootBuf.toString("hex")}`;
+}
+
+export function fromHex(hex: string): Uint8Array {
+  const b = Buffer.from(hex.replace("0x", ""), "hex");
+  return new Uint8Array(b.buffer, b.byteOffset, b.length);
+}

--- a/packages/utils/src/bytes/nodejs.ts
+++ b/packages/utils/src/bytes/nodejs.ts
@@ -9,7 +9,7 @@ export function toHex(buffer: Uint8Array | Parameters<typeof Buffer.from>[0]): s
 }
 
 // Shared buffer to convert root to hex
-const rootBuf = Buffer.alloc(32);
+let rootBuf: Buffer | undefined;
 
 /**
  * Convert a Uint8Array, length 32, to 0x-prefixed hex string
@@ -17,6 +17,10 @@ const rootBuf = Buffer.alloc(32);
 export function toRootHex(root: Uint8Array): string {
   if (root.length !== 32) {
     throw Error(`Expect root to be 32 bytes, got ${root.length}`);
+  }
+
+  if (rootBuf === undefined) {
+    rootBuf = Buffer.alloc(32);
   }
 
   rootBuf.set(root);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,6 +2,7 @@ export * from "./yaml/index.js";
 export * from "./assert.js";
 export * from "./base64.js";
 export * from "./bytes.js";
+export * from "./bytes/index.js";
 export * from "./command.js";
 export * from "./err.js";
 export * from "./errors.js";

--- a/packages/utils/test/perf/bytes.test.ts
+++ b/packages/utils/test/perf/bytes.test.ts
@@ -1,12 +1,14 @@
 import {itBench} from "@dapplion/benchmark";
-import {toHex, toRootHex} from "../../src/bytes.js";
+import {toHex, toRootHex} from "../../src/bytes/nodejs.js";
+import {toHex as browserToHex, toRootHex as browserToRootHex} from "../../src/bytes/browser.js";
+import {toHexString} from "../../src/bytes.js";
 
 describe("bytes utils", function () {
   const runsFactor = 1000;
   const blockRoot = new Uint8Array(Array.from({length: 32}, (_, i) => i));
 
   itBench({
-    id: "block root to RootHex using toHex",
+    id: "nodejs block root to RootHex using toHex",
     fn: () => {
       for (let i = 0; i < runsFactor; i++) {
         toHex(blockRoot);
@@ -16,10 +18,40 @@ describe("bytes utils", function () {
   });
 
   itBench({
-    id: "block root to RootHex using toRootHex",
+    id: "nodejs block root to RootHex using toRootHex",
     fn: () => {
       for (let i = 0; i < runsFactor; i++) {
         toRootHex(blockRoot);
+      }
+    },
+    runsFactor,
+  });
+
+  itBench({
+    id: "browser block root to RootHex using the deprecated toHexString",
+    fn: () => {
+      for (let i = 0; i < runsFactor; i++) {
+        toHexString(blockRoot);
+      }
+    },
+    runsFactor,
+  });
+
+  itBench({
+    id: "browser block root to RootHex using toHex",
+    fn: () => {
+      for (let i = 0; i < runsFactor; i++) {
+        browserToHex(blockRoot);
+      }
+    },
+    runsFactor,
+  });
+
+  itBench({
+    id: "browser block root to RootHex using toRootHex",
+    fn: () => {
+      for (let i = 0; i < runsFactor; i++) {
+        browserToRootHex(blockRoot);
       }
     },
     runsFactor,

--- a/packages/utils/test/unit/bytes.test.ts
+++ b/packages/utils/test/unit/bytes.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect} from "vitest";
-import {intToBytes, bytesToInt, toHex, fromHex, toHexString} from "../../src/index.js";
+import {intToBytes, bytesToInt, toHex, fromHex, toHexString, toRootHex} from "../../src/index.js";
 
 describe("intToBytes", () => {
   const zeroedArray = (length: number): number[] => Array.from({length}, () => 0);
@@ -48,7 +48,7 @@ describe("bytesToInt", () => {
 });
 
 describe("toHex", () => {
-  const testCases: {input: Buffer | Uint8Array | string; output: string}[] = [
+  const testCases: {input: Uint8Array; output: string}[] = [
     {input: Buffer.from("Hello, World!", "utf-8"), output: "0x48656c6c6f2c20576f726c6421"},
     {input: new Uint8Array([72, 101, 108, 108, 111]), output: "0x48656c6c6f"},
     {input: Buffer.from([72, 101, 108, 108, 111]), output: "0x48656c6c6f"},
@@ -57,6 +57,25 @@ describe("toHex", () => {
   for (const {input, output} of testCases) {
     it(`should convert Uint8Array to hex string ${output}`, () => {
       expect(toHex(input)).toBe(output);
+    });
+  }
+});
+
+describe("toRootHex", () => {
+  const testCases: {input: Uint8Array; output: string}[] = [
+    {
+      input: new Uint8Array(Array.from({length: 32}, (_, i) => i)),
+      output: "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    },
+    {
+      input: new Uint8Array(Array.from({length: 32}, () => 0)),
+      output: "0x0000000000000000000000000000000000000000000000000000000000000000",
+    },
+  ];
+
+  for (const {input, output} of testCases) {
+    it(`should convert root to hex string ${output}`, () => {
+      expect(toRootHex(input)).toBe(output);
     });
   }
 });


### PR DESCRIPTION
**Motivation**

- implement isomorphic utils for nodejs and browser
- try nodejs first, if not use browser version

**Description**

- the 3 utils are: toHex, toRootHex and fromHex
  - remove from `bytes.ts`, implement nodejs and browser versions
- the browser version follows https://github.com/ChainSafe/ssz/issues/277
- deprecate toHexString
- tests are scanned through browser tests in this package, perf tests are included

```
bytes utils
    ✔ nodejs block root to RootHex using toHex                             6396520 ops/s    156.3350 ns/op        -       3868 runs  0.765 s
    ✔ nodejs block root to RootHex using toRootHex                         9505523 ops/s    105.2020 ns/op        -       6710 runs  0.812 s
    ✔ browser block root to RootHex using the deprecated toHexString       3742921 ops/s    267.1710 ns/op        -       1891 runs  0.797 s
    ✔ browser block root to RootHex using toHex                            5582008 ops/s    179.1470 ns/op        -       1690 runs  0.487 s
    ✔ browser block root to RootHex using toRootHex                        6455194 ops/s    154.9140 ns/op        -       2605 runs  0.562 s
```

related to https://github.com/ChainSafe/ssz/issues/283

this only implement the utils, need multiple PRs to consume this work