### PR TITLE
chore: relax node version restriction in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "engines": {
-    "node": ">=20.1.0 <21 || >=22 <22.5"
+    "node": ">=20.1.0 <21 || >=22 <23"
   },
   "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca",
   "workspaces": [


### PR DESCRIPTION
**Motivation**

For development and source install it should be fine to relax the node requirement. Should be able to use latest 22.x in CI and build as well in ~2 months when it becomes LTS.


**Description**

Relax node version restriction in package.json, allow any 22.x version