### PR TITLE
feat: rename getValidatorMaxEffectiveBalance

### DIFF
--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -173,8 +173,7 @@ export function getExpectedWithdrawals(
       });
       withdrawalIndex++;
     } else if (
-      effectiveBalance ===
-        (isPostElectra ? getMaxEffectiveBalance(withdrawalCredentials) : MAX_EFFECTIVE_BALANCE) &&
+      effectiveBalance === (isPostElectra ? getMaxEffectiveBalance(withdrawalCredentials) : MAX_EFFECTIVE_BALANCE) &&
       balance > effectiveBalance
     ) {
       // capella partial withdrawal

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -14,7 +14,7 @@ import {toRootHex} from "@lodestar/utils";
 import {CachedBeaconStateCapella, CachedBeaconStateElectra} from "../types.js";
 import {
   decreaseBalance,
-  getValidatorMaxEffectiveBalance,
+  getMaxEffectiveBalance,
   hasEth1WithdrawalCredential,
   hasExecutionWithdrawalCredential,
   isCapellaPayloadHeader,
@@ -174,7 +174,7 @@ export function getExpectedWithdrawals(
       withdrawalIndex++;
     } else if (
       effectiveBalance ===
-        (isPostElectra ? getValidatorMaxEffectiveBalance(withdrawalCredentials) : MAX_EFFECTIVE_BALANCE) &&
+        (isPostElectra ? getMaxEffectiveBalance(withdrawalCredentials) : MAX_EFFECTIVE_BALANCE) &&
       balance > effectiveBalance
     ) {
       // capella partial withdrawal

--- a/packages/state-transition/src/util/genesis.ts
+++ b/packages/state-transition/src/util/genesis.ts
@@ -18,7 +18,7 @@ import {EpochCacheImmutableData} from "../cache/epochCache.js";
 import {processDeposit} from "../block/processDeposit.js";
 import {increaseBalance} from "../index.js";
 import {computeEpochAtSlot} from "./epoch.js";
-import {getActiveValidatorIndices, getValidatorMaxEffectiveBalance} from "./validator.js";
+import {getActiveValidatorIndices, getMaxEffectiveBalance} from "./validator.js";
 import {getTemporaryBlockHeader} from "./blockRoot.js";
 import {newFilledArray} from "./array.js";
 import {getNextSyncCommittee} from "./syncCommittee.js";
@@ -195,7 +195,7 @@ export function applyDeposits(
     const balance = balancesArr[i];
     const effectiveBalance = Math.min(
       balance - (balance % EFFECTIVE_BALANCE_INCREMENT),
-      getValidatorMaxEffectiveBalance(validator.withdrawalCredentials)
+      getMaxEffectiveBalance(validator.withdrawalCredentials)
     );
 
     validator.effectiveBalance = effectiveBalance;

--- a/packages/state-transition/src/util/validator.ts
+++ b/packages/state-transition/src/util/validator.ts
@@ -75,7 +75,7 @@ export function getConsolidationChurnLimit(epochCtx: EpochCache): number {
   return getBalanceChurnLimit(epochCtx) - getActivationExitChurnLimit(epochCtx);
 }
 
-export function getValidatorMaxEffectiveBalance(withdrawalCredentials: Uint8Array): number {
+export function getMaxEffectiveBalance(withdrawalCredentials: Uint8Array): number {
   // Compounding withdrawal credential only available since Electra
   if (hasCompoundingWithdrawalCredential(withdrawalCredentials)) {
     return MAX_EFFECTIVE_BALANCE_ELECTRA;
@@ -85,7 +85,7 @@ export function getValidatorMaxEffectiveBalance(withdrawalCredentials: Uint8Arra
 }
 
 export function getActiveBalance(state: CachedBeaconStateElectra, validatorIndex: ValidatorIndex): number {
-  const validatorMaxEffectiveBalance = getValidatorMaxEffectiveBalance(
+  const validatorMaxEffectiveBalance = getMaxEffectiveBalance(
     state.validators.getReadonly(validatorIndex).withdrawalCredentials
   );
 


### PR DESCRIPTION
Rename `getValidatorMaxEffectiveBalance` to `getMaxEffectiveBalance`. This rename will be in effect in the next release of consensus spec which will be the target of devnet-4. 

We can rename now for devnet-3 since no functional impact. 