### PR TITLE
feat: update correlation penalty computation

### DIFF
--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -66,8 +66,6 @@ export const defaultSkipOpts: SkipOpts = {
     /^capella\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^deneb\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^electra\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
-    // TODO Electra: slashings tests to be enabled in PR#7071
-    /^electra\/epoch_processing\/slashings.*/,
   ],
   skippedTests: [],
   skippedRunners: ["merkle_proof", "networking"],

--- a/packages/state-transition/src/epoch/processSlashings.ts
+++ b/packages/state-transition/src/epoch/processSlashings.ts
@@ -51,8 +51,7 @@ export function processSlashings(
   );
   const increment = EFFECTIVE_BALANCE_INCREMENT;
 
-  const penaltyPerEffectiveBalanceIncrement =
-    Math.floor(adjustedTotalSlashingBalanceByIncrement / totalBalanceByIncrement) * increment;
+  const penaltyPerEffectiveBalanceIncrement = Math.floor((adjustedTotalSlashingBalanceByIncrement * increment) / totalBalanceByIncrement);
   const penalties: number[] = [];
 
   const penaltiesByEffectiveBalanceIncrement = new Map<number, number>();

--- a/packages/state-transition/src/epoch/processSlashings.ts
+++ b/packages/state-transition/src/epoch/processSlashings.ts
@@ -59,7 +59,12 @@ export function processSlashings(
     const effectiveBalanceIncrement = effectiveBalanceIncrements[index];
     let penalty = penaltiesByEffectiveBalanceIncrement.get(effectiveBalanceIncrement);
     if (penalty === undefined) {
-      penalty = penaltyPerEffectiveBalanceIncrement * effectiveBalanceIncrement;
+      if (fork < ForkSeq.electra) {
+        const penaltyNumeratorByIncrement = effectiveBalanceIncrement * adjustedTotalSlashingBalanceByIncrement;
+        penalty = Math.floor(penaltyNumeratorByIncrement / totalBalanceByIncrement) * increment;
+      } else {
+        penalty = penaltyPerEffectiveBalanceIncrement * effectiveBalanceIncrement;
+      }
       penaltiesByEffectiveBalanceIncrement.set(effectiveBalanceIncrement, penalty);
     }
 

--- a/packages/state-transition/src/epoch/processSlashings.ts
+++ b/packages/state-transition/src/epoch/processSlashings.ts
@@ -51,7 +51,9 @@ export function processSlashings(
   );
   const increment = EFFECTIVE_BALANCE_INCREMENT;
 
-  const penaltyPerEffectiveBalanceIncrement = Math.floor((adjustedTotalSlashingBalanceByIncrement * increment) / totalBalanceByIncrement);
+  const penaltyPerEffectiveBalanceIncrement = Math.floor(
+    (adjustedTotalSlashingBalanceByIncrement * increment) / totalBalanceByIncrement
+  );
   const penalties: number[] = [];
 
   const penaltiesByEffectiveBalanceIncrement = new Map<number, number>();

--- a/packages/state-transition/src/epoch/processSlashings.ts
+++ b/packages/state-transition/src/epoch/processSlashings.ts
@@ -50,6 +50,9 @@ export function processSlashings(
     totalBalanceByIncrement
   );
   const increment = EFFECTIVE_BALANCE_INCREMENT;
+  const adjustedTotalSlashingBalance = adjustedTotalSlashingBalanceByIncrement * increment;
+
+  const penaltyPerEffectiveBalanceIncrement = Math.floor(adjustedTotalSlashingBalance / totalBalanceByIncrement);
   const penalties: number[] = [];
 
   const penaltiesByEffectiveBalanceIncrement = new Map<number, number>();
@@ -57,8 +60,7 @@ export function processSlashings(
     const effectiveBalanceIncrement = effectiveBalanceIncrements[index];
     let penalty = penaltiesByEffectiveBalanceIncrement.get(effectiveBalanceIncrement);
     if (penalty === undefined) {
-      const penaltyNumeratorByIncrement = effectiveBalanceIncrement * adjustedTotalSlashingBalanceByIncrement;
-      penalty = Math.floor(penaltyNumeratorByIncrement / totalBalanceByIncrement) * increment;
+      penalty = penaltyPerEffectiveBalanceIncrement * effectiveBalanceIncrement;
       penaltiesByEffectiveBalanceIncrement.set(effectiveBalanceIncrement, penalty);
     }
 

--- a/packages/state-transition/src/epoch/processSlashings.ts
+++ b/packages/state-transition/src/epoch/processSlashings.ts
@@ -50,9 +50,8 @@ export function processSlashings(
     totalBalanceByIncrement
   );
   const increment = EFFECTIVE_BALANCE_INCREMENT;
-  const adjustedTotalSlashingBalance = adjustedTotalSlashingBalanceByIncrement * increment;
 
-  const penaltyPerEffectiveBalanceIncrement = Math.floor(adjustedTotalSlashingBalance / totalBalanceByIncrement);
+  const penaltyPerEffectiveBalanceIncrement = Math.floor(adjustedTotalSlashingBalanceByIncrement / totalBalanceByIncrement) * increment;
   const penalties: number[] = [];
 
   const penaltiesByEffectiveBalanceIncrement = new Map<number, number>();

--- a/packages/state-transition/src/epoch/processSlashings.ts
+++ b/packages/state-transition/src/epoch/processSlashings.ts
@@ -51,7 +51,8 @@ export function processSlashings(
   );
   const increment = EFFECTIVE_BALANCE_INCREMENT;
 
-  const penaltyPerEffectiveBalanceIncrement = Math.floor(adjustedTotalSlashingBalanceByIncrement / totalBalanceByIncrement) * increment;
+  const penaltyPerEffectiveBalanceIncrement =
+    Math.floor(adjustedTotalSlashingBalanceByIncrement / totalBalanceByIncrement) * increment;
   const penalties: number[] = [];
 
   const penaltiesByEffectiveBalanceIncrement = new Map<number, number>();


### PR DESCRIPTION
ethereum/consensus-specs#3882 proposes to reformat slashing penalty calculation due to overflow issue.

Lodestar does not have such issue as we've already been tracking everything in increments. 

This PR restyle the calculation to be more in line with the spec. 

Although spec change supposedly will be live for devnet-4, we can make the code change now for devnet-3 since no functional difference.