### PR TITLE
fix: avoid toHexString()

### DIFF
--- a/packages/api/src/beacon/routes/proof.ts
+++ b/packages/api/src/beacon/routes/proof.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {CompactMultiProof, ProofType} from "@chainsafe/persistent-merkle-tree";
-import {ByteListType, ContainerType, fromHexString, toHexString} from "@chainsafe/ssz";
+import {ByteListType, ContainerType, fromHexString} from "@chainsafe/ssz";
+import {toHex} from "@lodestar/utils";
 import {ChainForkConfig} from "@lodestar/config";
 import {ssz} from "@lodestar/types";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
@@ -45,7 +46,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       url: "/eth/v0/beacon/proof/state/{state_id}",
       method: "GET",
       req: {
-        writeReq: ({stateId, descriptor}) => ({params: {state_id: stateId}, query: {format: toHexString(descriptor)}}),
+        writeReq: ({stateId, descriptor}) => ({params: {state_id: stateId}, query: {format: toHex(descriptor)}}),
         parseReq: ({params, query}) => ({stateId: params.state_id, descriptor: fromHexString(query.format)}),
         schema: {params: {state_id: Schema.StringRequired}, query: {format: Schema.StringRequired}},
       },
@@ -63,7 +64,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       url: "/eth/v0/beacon/proof/block/{block_id}",
       method: "GET",
       req: {
-        writeReq: ({blockId, descriptor}) => ({params: {block_id: blockId}, query: {format: toHexString(descriptor)}}),
+        writeReq: ({blockId, descriptor}) => ({params: {block_id: blockId}, query: {format: toHex(descriptor)}}),
         parseReq: ({params, query}) => ({blockId: params.block_id, descriptor: fromHexString(query.format)}),
         schema: {params: {block_id: Schema.StringRequired}, query: {format: Schema.StringRequired}},
       },

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -20,7 +20,7 @@ import {
   Attestation,
   sszTypesFor,
 } from "@lodestar/types";
-import {toHex} from "@lodestar/utils";
+import {toHex, toRootHex} from "@lodestar/utils";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {fromGraffitiHex, toBoolean, toGraffitiHex} from "../../utils/serdes.js";
 import {getExecutionForkTypes, toForkName} from "../../utils/fork.js";
@@ -806,7 +806,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       method: "GET",
       req: {
         writeReq: ({slot, subcommitteeIndex, beaconBlockRoot}) => ({
-          query: {slot, subcommittee_index: subcommitteeIndex, beacon_block_root: toHex(beaconBlockRoot)},
+          query: {slot, subcommittee_index: subcommitteeIndex, beacon_block_root: toRootHex(beaconBlockRoot)},
         }),
         parseReq: ({query}) => ({
           slot: query.slot,
@@ -831,7 +831,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       method: "GET",
       req: {
         writeReq: ({attestationDataRoot, slot}) => ({
-          query: {attestation_data_root: toHex(attestationDataRoot), slot},
+          query: {attestation_data_root: toRootHex(attestationDataRoot), slot},
         }),
         parseReq: ({query}) => ({
           attestationDataRoot: fromHexString(query.attestation_data_root),

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {ContainerType, fromHexString, toHexString, Type, ValueOf} from "@chainsafe/ssz";
+import {ContainerType, fromHexString, Type, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {isForkBlobs, isForkPostElectra} from "@lodestar/params";
 import {
@@ -20,6 +20,7 @@ import {
   Attestation,
   sszTypesFor,
 } from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {fromGraffitiHex, toBoolean, toGraffitiHex} from "../../utils/serdes.js";
 import {getExecutionForkTypes, toForkName} from "../../utils/fork.js";
@@ -623,7 +624,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         writeReq: ({slot, randaoReveal, graffiti, feeRecipient, builderSelection, strictFeeRecipientCheck}) => ({
           params: {slot},
           query: {
-            randao_reveal: toHexString(randaoReveal),
+            randao_reveal: toHex(randaoReveal),
             graffiti: toGraffitiHex(graffiti),
             fee_recipient: feeRecipient,
             builder_selection: builderSelection,
@@ -674,7 +675,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         }) => ({
           params: {slot},
           query: {
-            randao_reveal: toHexString(randaoReveal),
+            randao_reveal: toHex(randaoReveal),
             graffiti: toGraffitiHex(graffiti),
             skip_randao_verification: writeSkipRandaoVerification(skipRandaoVerification),
             fee_recipient: feeRecipient,
@@ -765,7 +766,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       req: {
         writeReq: ({slot, randaoReveal, graffiti}) => ({
           params: {slot},
-          query: {randao_reveal: toHexString(randaoReveal), graffiti: toGraffitiHex(graffiti)},
+          query: {randao_reveal: toHex(randaoReveal), graffiti: toGraffitiHex(graffiti)},
         }),
         parseReq: ({params, query}) => ({
           slot: params.slot,
@@ -805,7 +806,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       method: "GET",
       req: {
         writeReq: ({slot, subcommitteeIndex, beaconBlockRoot}) => ({
-          query: {slot, subcommittee_index: subcommitteeIndex, beacon_block_root: toHexString(beaconBlockRoot)},
+          query: {slot, subcommittee_index: subcommitteeIndex, beacon_block_root: toHex(beaconBlockRoot)},
         }),
         parseReq: ({query}) => ({
           slot: query.slot,
@@ -830,7 +831,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       method: "GET",
       req: {
         writeReq: ({attestationDataRoot, slot}) => ({
-          query: {attestation_data_root: toHexString(attestationDataRoot), slot},
+          query: {attestation_data_root: toHex(attestationDataRoot), slot},
         }),
         parseReq: ({query}) => ({
           attestationDataRoot: fromHexString(query.attestation_data_root),
@@ -853,7 +854,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       method: "GET",
       req: {
         writeReq: ({attestationDataRoot, slot, committeeIndex}) => ({
-          query: {attestation_data_root: toHexString(attestationDataRoot), slot, committee_index: committeeIndex},
+          query: {attestation_data_root: toHex(attestationDataRoot), slot, committee_index: committeeIndex},
         }),
         parseReq: ({query}) => ({
           attestationDataRoot: fromHexString(query.attestation_data_root),

--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -13,7 +13,7 @@ import {
 } from "@lodestar/types";
 import {ForkName, isForkBlobs} from "@lodestar/params";
 import {ChainForkConfig} from "@lodestar/config";
-import {toHex, toPubkeyHex} from "@lodestar/utils";
+import {toPubkeyHex, toRootHex} from "@lodestar/utils";
 
 import {Endpoint, RouteDefinitions, Schema} from "../utils/index.js";
 import {MetaHeader, VersionCodec, VersionMeta} from "../utils/metadata.js";
@@ -106,7 +106,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       method: "GET",
       req: {
         writeReq: ({slot, parentHash, proposerPubkey: proposerPubKey}) => ({
-          params: {slot, parent_hash: toHex(parentHash), pubkey: toPubkeyHex(proposerPubKey)},
+          params: {slot, parent_hash: toRootHex(parentHash), pubkey: toPubkeyHex(proposerPubKey)},
         }),
         parseReq: ({params}) => ({
           slot: params.slot,

--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {
   ssz,
   bellatrix,
@@ -13,7 +13,7 @@ import {
 } from "@lodestar/types";
 import {ForkName, isForkBlobs} from "@lodestar/params";
 import {ChainForkConfig} from "@lodestar/config";
-import {toPubkeyHex} from "@lodestar/utils";
+import {toHex, toPubkeyHex} from "@lodestar/utils";
 
 import {Endpoint, RouteDefinitions, Schema} from "../utils/index.js";
 import {MetaHeader, VersionCodec, VersionMeta} from "../utils/metadata.js";
@@ -106,7 +106,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       method: "GET",
       req: {
         writeReq: ({slot, parentHash, proposerPubkey: proposerPubKey}) => ({
-          params: {slot, parent_hash: toHexString(parentHash), pubkey: toPubkeyHex(proposerPubKey)},
+          params: {slot, parent_hash: toHex(parentHash), pubkey: toPubkeyHex(proposerPubKey)},
         }),
         parseReq: ({params}) => ({
           slot: params.slot,

--- a/packages/api/src/utils/serdes.ts
+++ b/packages/api/src/utils/serdes.ts
@@ -1,4 +1,5 @@
-import {fromHexString, JsonPath, toHexString} from "@chainsafe/ssz";
+import {fromHexString, JsonPath} from "@chainsafe/ssz";
+import {toHex} from "@lodestar/utils";
 
 /**
  * Serialize proof path to JSON.
@@ -82,7 +83,7 @@ export function toGraffitiHex(utf8?: string): string | undefined {
     return undefined;
   }
 
-  const hex = toHexString(new TextEncoder().encode(utf8));
+  const hex = toHex(new TextEncoder().encode(utf8));
 
   if (hex.length > GRAFFITI_HEX_LENGTH) {
     // remove characters from the end if hex string is too long

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -1,4 +1,3 @@
-import {toHexString} from "@chainsafe/ssz";
 import {capella, ssz, altair, BeaconBlock} from "@lodestar/types";
 import {ForkLightClient, ForkSeq, INTERVALS_PER_SLOT, MAX_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
@@ -10,7 +9,7 @@ import {
 } from "@lodestar/state-transition";
 import {routes} from "@lodestar/api";
 import {ForkChoiceError, ForkChoiceErrorCode, EpochDifference, AncestorStatus} from "@lodestar/fork-choice";
-import {isErrorAborted, toRootHex} from "@lodestar/utils";
+import {isErrorAborted, toHex, toRootHex} from "@lodestar/utils";
 import {ZERO_HASH_HEX} from "../../constants/index.js";
 import {toCheckpointHex} from "../stateCache/index.js";
 import {isOptimisticBlock} from "../../util/forkChoice.js";
@@ -433,8 +432,8 @@ export async function importBlock(
             blockRoot: blockRootHex,
             slot: blockSlot,
             index,
-            kzgCommitment: toHexString(kzgCommitment),
-            versionedHash: toHexString(kzgCommitmentToVersionedHash(kzgCommitment)),
+            kzgCommitment: toHex(kzgCommitment),
+            versionedHash: toHex(kzgCommitmentToVersionedHash(kzgCommitment)),
           });
         }
       }

--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -1,4 +1,4 @@
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {
   CachedBeaconStateAllForks,
   computeEpochAtSlot,
@@ -16,7 +16,7 @@ import {
   ForkSeq,
   MAX_ATTESTER_SLASHINGS_ELECTRA,
 } from "@lodestar/params";
-import {toRootHex} from "@lodestar/utils";
+import {toHex, toRootHex} from "@lodestar/utils";
 import {Epoch, phase0, capella, ssz, ValidatorIndex, SignedBeaconBlock, AttesterSlashing} from "@lodestar/types";
 import {IBeaconDb} from "../../db/index.js";
 import {SignedBLSToExecutionChangeVersioned} from "../../util/types.js";
@@ -88,7 +88,7 @@ export class OpPool {
           key: fromHexString(key),
           value: value.attesterSlashing,
         })),
-        toHexString
+        toHex
       ),
       persistDiff(
         db.proposerSlashing,

--- a/packages/beacon-node/src/chain/stateCache/datastore/file.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/file.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
-import {toHexString, fromHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {phase0, ssz} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
 import {ensureDir, readFile, readFileNames, removeFile, writeIfNotExist} from "../../../util/file.js";
 import {CPStateDatastore, DatastoreKey} from "./types.js";
 
@@ -28,18 +29,18 @@ export class FileCPStateDatastore implements CPStateDatastore {
 
   async write(cpKey: phase0.Checkpoint, stateBytes: Uint8Array): Promise<DatastoreKey> {
     const serializedCheckpoint = ssz.phase0.Checkpoint.serialize(cpKey);
-    const filePath = path.join(this.folderPath, toHexString(serializedCheckpoint));
+    const filePath = path.join(this.folderPath, toHex(serializedCheckpoint));
     await writeIfNotExist(filePath, stateBytes);
     return serializedCheckpoint;
   }
 
   async remove(serializedCheckpoint: DatastoreKey): Promise<void> {
-    const filePath = path.join(this.folderPath, toHexString(serializedCheckpoint));
+    const filePath = path.join(this.folderPath, toHex(serializedCheckpoint));
     await removeFile(filePath);
   }
 
   async read(serializedCheckpoint: DatastoreKey): Promise<Uint8Array | null> {
-    const filePath = path.join(this.folderPath, toHexString(serializedCheckpoint));
+    const filePath = path.join(this.folderPath, toHex(serializedCheckpoint));
     return readFile(filePath);
   }
 

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -1,7 +1,7 @@
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {phase0, Epoch, RootHex} from "@lodestar/types";
 import {CachedBeaconStateAllForks, computeStartSlotAtEpoch, getBlockRootAtSlot} from "@lodestar/state-transition";
-import {Logger, MapDef, sleep, toRootHex} from "@lodestar/utils";
+import {Logger, MapDef, sleep, toHex, toRootHex} from "@lodestar/utils";
 import {routes} from "@lodestar/api";
 import {loadCachedBeaconState} from "@lodestar/state-transition";
 import {INTERVALS_PER_SLOT} from "@lodestar/params";
@@ -193,7 +193,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       return stateOrStateBytesData?.clone(opts?.dontTransferCache) ?? null;
     }
     const {persistedKey, stateBytes} = stateOrStateBytesData;
-    const logMeta = {persistedKey: toHexString(persistedKey)};
+    const logMeta = {persistedKey: toHex(persistedKey)};
     this.logger.debug("Reload: read state successful", logMeta);
     this.metrics?.stateReloadSecFromSlot.observe(this.clock?.secFromSlot(this.clock?.currentSlot ?? 0) ?? 0);
     const seedState = this.findSeedStateToReload(cp);
@@ -341,7 +341,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       this.logger.verbose("Added checkpoint state to memory but a persisted key existed", {
         epoch: cp.epoch,
         rootHex: cpHex.rootHex,
-        persistedKey: toHexString(persistedKey),
+        persistedKey: toHex(persistedKey),
       });
     } else {
       this.cache.set(key, {type: CacheItemType.inMemory, state});
@@ -688,7 +688,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
           stateSlot: state.slot,
           rootHex,
           epochBoundaryHex,
-          persistedKey: persistedKey ? toHexString(persistedKey) : "",
+          persistedKey: persistedKey ? toHex(persistedKey) : "",
         };
 
         if (persistedRootHexes.has(rootHex)) {
@@ -716,7 +716,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
             persistCount++;
             this.logger.verbose("Pruned checkpoint state from memory and persisted to disk", {
               ...logMeta,
-              persistedKey: toHexString(persistedKey),
+              persistedKey: toHex(persistedKey),
             });
           }
           // overwrite cpKey, this means the state is deleted from memory

--- a/packages/beacon-node/src/eth1/provider/eth1Provider.ts
+++ b/packages/beacon-node/src/eth1/provider/eth1Provider.ts
@@ -1,7 +1,6 @@
-import {toHexString} from "@chainsafe/ssz";
 import {phase0} from "@lodestar/types";
 import {ChainConfig} from "@lodestar/config";
-import {fromHex, isErrorAborted, createElapsedTimeTracker, toPrintableUrl} from "@lodestar/utils";
+import {fromHex, isErrorAborted, createElapsedTimeTracker, toPrintableUrl, toHex} from "@lodestar/utils";
 import {Logger} from "@lodestar/logger";
 
 import {FetchError, isFetchError} from "@lodestar/api";
@@ -72,7 +71,7 @@ export class Eth1Provider implements IEth1Provider {
   ) {
     this.logger = opts.logger;
     this.deployBlock = opts.depositContractDeployBlock ?? 0;
-    this.depositContractAddress = toHexString(config.DEPOSIT_CONTRACT_ADDRESS);
+    this.depositContractAddress = toHex(config.DEPOSIT_CONTRACT_ADDRESS);
 
     const providerUrls = opts.providerUrls ?? DEFAULT_PROVIDER_URLS;
     this.rpc = new JsonRpcHttpClient(providerUrls, {

--- a/packages/beacon-node/src/eth1/provider/utils.ts
+++ b/packages/beacon-node/src/eth1/provider/utils.ts
@@ -1,6 +1,6 @@
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {RootHex} from "@lodestar/types";
-import {bytesToBigInt, bigIntToBytes} from "@lodestar/utils";
+import {bytesToBigInt, bigIntToBytes, toHex} from "@lodestar/utils";
 import {ErrorParseJson} from "./jsonRpcHttpClient.js";
 
 /** QUANTITY as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API */
@@ -32,7 +32,7 @@ export function bytesToHex(bytes: Uint8Array): string {
     return "0x" + bytes[0].toString(16);
   }
 
-  return toHexString(bytes);
+  return toHex(bytes);
 }
 
 /**
@@ -100,7 +100,7 @@ export function bytesToQuantity(bytes: Uint8Array): QUANTITY {
  * - WRONG: 004200 (must be prefixed 0x)
  */
 export function bytesToData(bytes: Uint8Array): DATA {
-  return toHexString(bytes);
+  return toHex(bytes);
 }
 
 /**

--- a/packages/beacon-node/src/eth1/utils/eth1Vote.ts
+++ b/packages/beacon-node/src/eth1/utils/eth1Vote.ts
@@ -120,7 +120,6 @@ function getKeysWithMaxValue<T>(map: Map<T, number>): T[] {
  * ✓ pickEth1Vote - max votes                                            37.89912 ops/s    26.38583 ms/op        -         29 runs   1.27 s
  */
 function getEth1DataKey(eth1Data: phase0.Eth1Data): string {
-  // return toHexString(ssz.phase0.Eth1Data.hashTreeRoot(eth1Data));
   return fastSerializeEth1Data(eth1Data);
 }
 

--- a/packages/beacon-node/src/network/peers/utils/assertPeerRelevance.ts
+++ b/packages/beacon-node/src/network/peers/utils/assertPeerRelevance.ts
@@ -1,6 +1,5 @@
-import {toHexString} from "@chainsafe/ssz";
 import {ForkDigest, Root, Slot, phase0, ssz} from "@lodestar/types";
-import {toRootHex} from "@lodestar/utils";
+import {toHex, toRootHex} from "@lodestar/utils";
 
 // TODO: Why this value? (From Lighthouse)
 const FUTURE_SLOT_TOLERANCE = 1;
@@ -79,7 +78,7 @@ export function isZeroRoot(root: Root): boolean {
 export function renderIrrelevantPeerType(type: IrrelevantPeerType): string {
   switch (type.code) {
     case IrrelevantPeerCode.INCOMPATIBLE_FORKS:
-      return `INCOMPATIBLE_FORKS ours: ${toHexString(type.ours)} theirs: ${toHexString(type.theirs)}`;
+      return `INCOMPATIBLE_FORKS ours: ${toHex(type.ours)} theirs: ${toHex(type.theirs)}`;
     case IrrelevantPeerCode.DIFFERENT_CLOCKS:
       return `DIFFERENT_CLOCKS slotDiff: ${type.slotDiff}`;
     case IrrelevantPeerCode.DIFFERENT_FINALIZED:

--- a/packages/cli/src/cmds/validator/keymanager/server.ts
+++ b/packages/cli/src/cmds/validator/keymanager/server.ts
@@ -1,10 +1,10 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import {toHexString} from "@chainsafe/ssz";
 import {RestApiServer, RestApiServerOpts, RestApiServerModules} from "@lodestar/beacon-node";
 import {KeymanagerApiMethods, registerRoutes} from "@lodestar/api/keymanager/server";
 import {ChainForkConfig} from "@lodestar/config";
+import {toHex} from "@lodestar/utils";
 import {writeFile600Perm} from "../../../util/index.js";
 
 export type KeymanagerRestApiServerOpts = RestApiServerOpts & {
@@ -50,7 +50,7 @@ export class KeymanagerRestApiServer extends RestApiServer {
 
     if (opts.isAuthEnabled) {
       // Generate a new token if token file does not exist or file do exist, but is empty
-      bearerToken = readFileIfExists(apiTokenPath) ?? `api-token-${toHexString(crypto.randomBytes(32))}`;
+      bearerToken = readFileIfExists(apiTokenPath) ?? `api-token-${toHex(crypto.randomBytes(32))}`;
       writeFile600Perm(apiTokenPath, bearerToken, {encoding: "utf8"});
     }
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "@chainsafe/ssz": "^0.17.1",
     "@lodestar/params": "^1.21.0",
+    "@lodestar/utils": "^1.21.0",
     "@lodestar/types": "^1.21.0"
   }
 }

--- a/packages/config/src/chainConfig/json.ts
+++ b/packages/config/src/chainConfig/json.ts
@@ -1,4 +1,5 @@
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
+import {toHex} from "@lodestar/utils";
 import {ChainConfig, chainConfigTypes, SpecValue, SpecValueTypeName} from "./types.js";
 
 const MAX_UINT64_JSON = "18446744073709551615";
@@ -69,7 +70,7 @@ export function serializeSpecValue(value: SpecValue, typeName: SpecValueTypeName
       if (!(value instanceof Uint8Array)) {
         throw Error(`Invalid value ${value.toString()} expected Uint8Array`);
       }
-      return toHexString(value);
+      return toHex(value);
 
     case "string":
       if (typeof value !== "string") {

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -1,6 +1,6 @@
-import {toHexString} from "@chainsafe/ssz";
 import {ForkName, SLOTS_PER_EPOCH, DOMAIN_VOLUNTARY_EXIT} from "@lodestar/params";
 import {DomainType, ForkDigest, phase0, Root, Slot, ssz, Version} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
 import {ChainForkConfig} from "../beaconConfig.js";
 import {ForkDigestHex, CachedGenesis} from "./types.js";
 export type {ForkDigestContext} from "./types.js";
@@ -139,7 +139,7 @@ function computeForkDataRoot(currentVersion: Version, genesisValidatorsRoot: Roo
 }
 
 function toHexStringNoPrefix(hex: string | Uint8Array): string {
-  return strip0xPrefix(typeof hex === "string" ? hex : toHexString(hex));
+  return strip0xPrefix(typeof hex === "string" ? hex : toHex(hex));
 }
 
 function strip0xPrefix(hex: string): string {

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1,4 +1,4 @@
-import {Logger, fromHex, toHex, toRootHex} from "@lodestar/utils";
+import {Logger, fromHex, toRootHex} from "@lodestar/utils";
 import {SLOTS_PER_HISTORICAL_ROOT, SLOTS_PER_EPOCH, INTERVALS_PER_SLOT} from "@lodestar/params";
 import {bellatrix, Slot, ValidatorIndex, phase0, ssz, RootHex, Epoch, Root, BeaconBlock} from "@lodestar/types";
 import {
@@ -642,7 +642,7 @@ export class ForkChoice implements IForkChoice {
 
       ...(isExecutionBlockBodyType(block.body) && isExecutionStateType(state) && isExecutionEnabled(state, block)
         ? {
-            executionPayloadBlockHash: toHex(block.body.executionPayload.blockHash),
+            executionPayloadBlockHash: toRootHex(block.body.executionPayload.blockHash),
             executionPayloadNumber: block.body.executionPayload.blockNumber,
             executionStatus: this.getPostMergeExecStatus(executionStatus),
             dataAvailabilityStatus,
@@ -1483,7 +1483,7 @@ export function assertValidTerminalPowBlock(
     // powBock.blockHash is hex, so we just pick the corresponding root
     if (!ssz.Root.equals(block.body.executionPayload.parentHash, config.TERMINAL_BLOCK_HASH))
       throw new Error(
-        `Invalid terminal block hash, expected: ${toHex(config.TERMINAL_BLOCK_HASH)}, actual: ${toHex(
+        `Invalid terminal block hash, expected: ${toRootHex(config.TERMINAL_BLOCK_HASH)}, actual: ${toRootHex(
           block.body.executionPayload.parentHash
         )}`
       );

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1,5 +1,4 @@
-import {toHexString} from "@chainsafe/ssz";
-import {Logger, fromHex, toRootHex} from "@lodestar/utils";
+import {Logger, fromHex, toHex, toRootHex} from "@lodestar/utils";
 import {SLOTS_PER_HISTORICAL_ROOT, SLOTS_PER_EPOCH, INTERVALS_PER_SLOT} from "@lodestar/params";
 import {bellatrix, Slot, ValidatorIndex, phase0, ssz, RootHex, Epoch, Root, BeaconBlock} from "@lodestar/types";
 import {
@@ -643,7 +642,7 @@ export class ForkChoice implements IForkChoice {
 
       ...(isExecutionBlockBodyType(block.body) && isExecutionStateType(state) && isExecutionEnabled(state, block)
         ? {
-            executionPayloadBlockHash: toHexString(block.body.executionPayload.blockHash),
+            executionPayloadBlockHash: toHex(block.body.executionPayload.blockHash),
             executionPayloadNumber: block.body.executionPayload.blockNumber,
             executionStatus: this.getPostMergeExecStatus(executionStatus),
             dataAvailabilityStatus,
@@ -1484,7 +1483,7 @@ export function assertValidTerminalPowBlock(
     // powBock.blockHash is hex, so we just pick the corresponding root
     if (!ssz.Root.equals(block.body.executionPayload.parentHash, config.TERMINAL_BLOCK_HASH))
       throw new Error(
-        `Invalid terminal block hash, expected: ${toHexString(config.TERMINAL_BLOCK_HASH)}, actual: ${toHexString(
+        `Invalid terminal block hash, expected: ${toHex(config.TERMINAL_BLOCK_HASH)}, actual: ${toHex(
           block.body.executionPayload.parentHash
         )}`
       );

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -1,8 +1,8 @@
-import {toHexString} from "@chainsafe/ssz";
 import {Epoch, RootHex, Slot} from "@lodestar/types";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {GENESIS_EPOCH} from "@lodestar/params";
 
+import {toHex} from "@lodestar/utils";
 import {ForkChoiceError, ForkChoiceErrorCode} from "../forkChoice/errors.js";
 import {ProtoBlock, ProtoNode, HEX_ZERO_HASH, ExecutionStatus, LVHExecResponse} from "./interface.js";
 import {ProtoArrayError, ProtoArrayErrorCode, LVHExecError, LVHExecErrorCode} from "./errors.js";
@@ -10,7 +10,7 @@ import {ProtoArrayError, ProtoArrayErrorCode, LVHExecError, LVHExecErrorCode} fr
 export const DEFAULT_PRUNE_THRESHOLD = 0;
 type ProposerBoost = {root: RootHex; score: number};
 
-const ZERO_HASH_HEX = toHexString(Buffer.alloc(32, 0));
+const ZERO_HASH_HEX = toHex(Buffer.alloc(32, 0));
 
 export class ProtoArray {
   // Do not attempt to prune the tree unless it has at least this many nodes.

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -2,7 +2,7 @@ import {Epoch, RootHex, Slot} from "@lodestar/types";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {GENESIS_EPOCH} from "@lodestar/params";
 
-import {toHex} from "@lodestar/utils";
+import {toRootHex} from "@lodestar/utils";
 import {ForkChoiceError, ForkChoiceErrorCode} from "../forkChoice/errors.js";
 import {ProtoBlock, ProtoNode, HEX_ZERO_HASH, ExecutionStatus, LVHExecResponse} from "./interface.js";
 import {ProtoArrayError, ProtoArrayErrorCode, LVHExecError, LVHExecErrorCode} from "./errors.js";
@@ -10,7 +10,7 @@ import {ProtoArrayError, ProtoArrayErrorCode, LVHExecError, LVHExecErrorCode} fr
 export const DEFAULT_PRUNE_THRESHOLD = 0;
 type ProposerBoost = {root: RootHex; score: number};
 
-const ZERO_HASH_HEX = toHex(Buffer.alloc(32, 0));
+const ZERO_HASH_HEX = toRootHex(Buffer.alloc(32, 0));
 
 export class ProtoArray {
   // Do not attempt to prune the tree unless it has at least this many nodes.

--- a/packages/light-client/src/index.ts
+++ b/packages/light-client/src/index.ts
@@ -13,7 +13,7 @@ import {
   SyncPeriod,
 } from "@lodestar/types";
 import {createBeaconConfig, BeaconConfig, ChainForkConfig} from "@lodestar/config";
-import {isErrorAborted, sleep, toHex} from "@lodestar/utils";
+import {isErrorAborted, sleep, toRootHex} from "@lodestar/utils";
 import {getCurrentSlot, slotWithFutureTolerance, timeUntilNextEpoch} from "./utils/clock.js";
 import {chunkifyInclusiveRange} from "./utils/chunkify.js";
 import {LightclientEmitter, LightclientEvent} from "./events.js";
@@ -162,7 +162,7 @@ export class Lightclient {
     const {transport, checkpointRoot} = args;
 
     // Fetch bootstrap state with proof at the trusted block root
-    const {data: bootstrap} = await transport.getBootstrap(toHex(checkpointRoot));
+    const {data: bootstrap} = await transport.getBootstrap(toRootHex(checkpointRoot));
 
     validateLightClientBootstrap(args.config, checkpointRoot, bootstrap);
 

--- a/packages/light-client/src/index.ts
+++ b/packages/light-client/src/index.ts
@@ -1,5 +1,5 @@
 import mitt from "mitt";
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD} from "@lodestar/params";
 import {
   LightClientBootstrap,
@@ -13,7 +13,7 @@ import {
   SyncPeriod,
 } from "@lodestar/types";
 import {createBeaconConfig, BeaconConfig, ChainForkConfig} from "@lodestar/config";
-import {isErrorAborted, sleep} from "@lodestar/utils";
+import {isErrorAborted, sleep, toHex} from "@lodestar/utils";
 import {getCurrentSlot, slotWithFutureTolerance, timeUntilNextEpoch} from "./utils/clock.js";
 import {chunkifyInclusiveRange} from "./utils/chunkify.js";
 import {LightclientEmitter, LightclientEvent} from "./events.js";
@@ -162,7 +162,7 @@ export class Lightclient {
     const {transport, checkpointRoot} = args;
 
     // Fetch bootstrap state with proof at the trusted block root
-    const {data: bootstrap} = await transport.getBootstrap(toHexString(checkpointRoot));
+    const {data: bootstrap} = await transport.getBootstrap(toHex(checkpointRoot));
 
     validateLightClientBootstrap(args.config, checkpointRoot, bootstrap);
 

--- a/packages/logger/src/utils/json.ts
+++ b/packages/logger/src/utils/json.ts
@@ -1,4 +1,4 @@
-import {LodestarError, mapValues, toHexString} from "@lodestar/utils";
+import {LodestarError, mapValues, toHex} from "@lodestar/utils";
 
 const MAX_DEPTH = 0;
 
@@ -29,7 +29,7 @@ export function logCtxToJson(arg: unknown, depth = 0, fromError = false): LogDat
       if (arg === null) return "null";
 
       if (arg instanceof Uint8Array) {
-        return toHexString(arg);
+        return toHex(arg);
       }
 
       // For any type that may include recursiveness break early at the first level
@@ -90,7 +90,7 @@ export function logCtxToString(arg: unknown, depth = 0, fromError = false): stri
       if (arg === null) return "null";
 
       if (arg instanceof Uint8Array) {
-        return toHexString(arg);
+        return toHex(arg);
       }
 
       // For any type that may include recursiveness break early at the first level

--- a/packages/state-transition/src/block/processBlsToExecutionChange.ts
+++ b/packages/state-transition/src/block/processBlsToExecutionChange.ts
@@ -1,7 +1,8 @@
-import {toHexString, byteArrayEquals} from "@chainsafe/ssz";
+import {byteArrayEquals} from "@chainsafe/ssz";
 import {digest} from "@chainsafe/as-sha256";
 import {capella} from "@lodestar/types";
 import {BLS_WITHDRAWAL_PREFIX, ETH1_ADDRESS_WITHDRAWAL_PREFIX} from "@lodestar/params";
+import {toHex} from "@lodestar/utils";
 import {verifyBlsToExecutionChangeSignature} from "../signatureSets/index.js";
 
 import {CachedBeaconStateCapella} from "../types.js";
@@ -60,9 +61,7 @@ export function isValidBlsToExecutionChange(
     return {
       valid: false,
       error: Error(
-        `Invalid withdrawalCredentials expected=${toHexString(withdrawalCredentials)} actual=${toHexString(
-          digestCredentials
-        )}`
+        `Invalid withdrawalCredentials expected=${toHex(withdrawalCredentials)} actual=${toHex(digestCredentials)}`
       ),
     };
   }

--- a/packages/state-transition/src/block/processExecutionPayload.ts
+++ b/packages/state-transition/src/block/processExecutionPayload.ts
@@ -1,6 +1,7 @@
-import {toHexString, byteArrayEquals} from "@chainsafe/ssz";
+import {byteArrayEquals} from "@chainsafe/ssz";
 import {BeaconBlockBody, BlindedBeaconBlockBody, deneb, isExecutionPayload} from "@lodestar/types";
 import {ForkSeq, MAX_BLOBS_PER_BLOCK} from "@lodestar/params";
+import {toHex} from "@lodestar/utils";
 import {CachedBeaconStateBellatrix, CachedBeaconStateCapella} from "../types.js";
 import {getRandaoMix} from "../util/index.js";
 import {
@@ -23,7 +24,7 @@ export function processExecutionPayload(
     const {latestExecutionPayloadHeader} = state;
     if (!byteArrayEquals(payload.parentHash, latestExecutionPayloadHeader.blockHash)) {
       throw Error(
-        `Invalid execution payload parentHash ${toHexString(payload.parentHash)} latest blockHash ${toHexString(
+        `Invalid execution payload parentHash ${toHex(payload.parentHash)} latest blockHash ${toHex(
           latestExecutionPayloadHeader.blockHash
         )}`
       );
@@ -33,9 +34,7 @@ export function processExecutionPayload(
   // Verify random
   const expectedRandom = getRandaoMix(state, state.epochCtx.epoch);
   if (!byteArrayEquals(payload.prevRandao, expectedRandom)) {
-    throw Error(
-      `Invalid execution payload random ${toHexString(payload.prevRandao)} expected=${toHexString(expectedRandom)}`
-    );
+    throw Error(`Invalid execution payload random ${toHex(payload.prevRandao)} expected=${toHex(expectedRandom)}`);
   }
 
   // Verify timestamp

--- a/packages/state-transition/src/block/processExecutionPayload.ts
+++ b/packages/state-transition/src/block/processExecutionPayload.ts
@@ -1,7 +1,7 @@
 import {byteArrayEquals} from "@chainsafe/ssz";
 import {BeaconBlockBody, BlindedBeaconBlockBody, deneb, isExecutionPayload} from "@lodestar/types";
 import {ForkSeq, MAX_BLOBS_PER_BLOCK} from "@lodestar/params";
-import {toHex} from "@lodestar/utils";
+import {toHex, toRootHex} from "@lodestar/utils";
 import {CachedBeaconStateBellatrix, CachedBeaconStateCapella} from "../types.js";
 import {getRandaoMix} from "../util/index.js";
 import {
@@ -24,7 +24,7 @@ export function processExecutionPayload(
     const {latestExecutionPayloadHeader} = state;
     if (!byteArrayEquals(payload.parentHash, latestExecutionPayloadHeader.blockHash)) {
       throw Error(
-        `Invalid execution payload parentHash ${toHex(payload.parentHash)} latest blockHash ${toHex(
+        `Invalid execution payload parentHash ${toRootHex(payload.parentHash)} latest blockHash ${toRootHex(
           latestExecutionPayloadHeader.blockHash
         )}`
       );

--- a/packages/state-transition/src/block/processWithdrawalRequest.ts
+++ b/packages/state-transition/src/block/processWithdrawalRequest.ts
@@ -1,4 +1,3 @@
-import {toHexString} from "@chainsafe/ssz";
 import {electra, phase0, ssz} from "@lodestar/types";
 import {
   FAR_FUTURE_EPOCH,
@@ -8,6 +7,7 @@ import {
   ForkSeq,
 } from "@lodestar/params";
 
+import {toHex} from "@lodestar/utils";
 import {CachedBeaconStateElectra} from "../types.js";
 import {hasCompoundingWithdrawalCredential, hasExecutionWithdrawalCredential} from "../util/electra.js";
 import {getPendingBalanceToWithdraw, isActiveValidator} from "../util/validator.js";
@@ -85,8 +85,8 @@ function isValidatorEligibleForWithdrawOrExit(
   state: CachedBeaconStateElectra
 ): boolean {
   const {withdrawalCredentials} = validator;
-  const addressStr = toHexString(withdrawalCredentials.subarray(12));
-  const sourceAddressStr = toHexString(sourceAddress);
+  const addressStr = toHex(withdrawalCredentials.subarray(12));
+  const sourceAddressStr = toHex(sourceAddress);
   const {epoch: currentEpoch, config} = state.epochCtx;
 
   return (

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -1,4 +1,4 @@
-import {toHex} from "./bytes/index.js";
+import {toRootHex} from "./bytes/index.js";
 import {ETH_TO_WEI} from "./ethConversion.js";
 
 /**
@@ -6,7 +6,7 @@ import {ETH_TO_WEI} from "./ethConversion.js";
  * 4 bytes can represent 4294967296 values, so the chance of collision is low
  */
 export function prettyBytes(root: Uint8Array | string): string {
-  const str = typeof root === "string" ? root : toHex(root);
+  const str = typeof root === "string" ? root : toRootHex(root);
   return `${str.slice(0, 6)}…${str.slice(-4)}`;
 }
 
@@ -15,7 +15,7 @@ export function prettyBytes(root: Uint8Array | string): string {
  * Paired with block numbers or slots, it can still act as a decent identify-able format
  */
 export function prettyBytesShort(root: Uint8Array | string): string {
-  const str = typeof root === "string" ? root : toHex(root);
+  const str = typeof root === "string" ? root : toRootHex(root);
   return `${str.slice(0, 6)}…`;
 }
 
@@ -25,7 +25,7 @@ export function prettyBytesShort(root: Uint8Array | string): string {
  * values on explorers like beaconcha.in while improving readability of logs
  */
 export function truncBytes(root: Uint8Array | string): string {
-  const str = typeof root === "string" ? root : toHex(root);
+  const str = typeof root === "string" ? root : toRootHex(root);
   return str.slice(0, 14);
 }
 

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -1,4 +1,4 @@
-import {toHexString} from "./bytes.js";
+import {toHex} from "./bytes/index.js";
 import {ETH_TO_WEI} from "./ethConversion.js";
 
 /**
@@ -6,7 +6,7 @@ import {ETH_TO_WEI} from "./ethConversion.js";
  * 4 bytes can represent 4294967296 values, so the chance of collision is low
  */
 export function prettyBytes(root: Uint8Array | string): string {
-  const str = typeof root === "string" ? root : toHexString(root);
+  const str = typeof root === "string" ? root : toHex(root);
   return `${str.slice(0, 6)}…${str.slice(-4)}`;
 }
 
@@ -15,7 +15,7 @@ export function prettyBytes(root: Uint8Array | string): string {
  * Paired with block numbers or slots, it can still act as a decent identify-able format
  */
 export function prettyBytesShort(root: Uint8Array | string): string {
-  const str = typeof root === "string" ? root : toHexString(root);
+  const str = typeof root === "string" ? root : toHex(root);
   return `${str.slice(0, 6)}…`;
 }
 
@@ -25,7 +25,7 @@ export function prettyBytesShort(root: Uint8Array | string): string {
  * values on explorers like beaconcha.in while improving readability of logs
  */
 export function truncBytes(root: Uint8Array | string): string {
-  const str = typeof root === "string" ? root : toHexString(root);
+  const str = typeof root === "string" ? root : toHex(root);
   return str.slice(0, 14);
 }
 

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -1,7 +1,7 @@
 import {BLSSignature, phase0, Slot, ssz, Attestation, SignedAggregateAndProof} from "@lodestar/types";
 import {ForkSeq} from "@lodestar/params";
 import {computeEpochAtSlot, isAggregatorFromCommitteeLength} from "@lodestar/state-transition";
-import {prettyBytes, sleep, toHex} from "@lodestar/utils";
+import {prettyBytes, sleep, toRootHex} from "@lodestar/utils";
 import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {IClock, LoggerVc} from "../util/index.js";
@@ -194,7 +194,7 @@ export class AttestationService {
     duties: AttDutyAndProof[]
   ): Promise<void> {
     const signedAttestations: Attestation[] = [];
-    const headRootHex = toHex(attestationNoCommittee.beaconBlockRoot);
+    const headRootHex = toRootHex(attestationNoCommittee.beaconBlockRoot);
     const currentEpoch = computeEpochAtSlot(slot);
     const isPostElectra = currentEpoch >= this.config.ELECTRA_FORK_EPOCH;
 

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -1,8 +1,7 @@
-import {toHexString} from "@chainsafe/ssz";
 import {BLSSignature, phase0, Slot, ssz, Attestation, SignedAggregateAndProof} from "@lodestar/types";
 import {ForkSeq} from "@lodestar/params";
 import {computeEpochAtSlot, isAggregatorFromCommitteeLength} from "@lodestar/state-transition";
-import {prettyBytes, sleep} from "@lodestar/utils";
+import {prettyBytes, sleep, toHex} from "@lodestar/utils";
 import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {IClock, LoggerVc} from "../util/index.js";
@@ -195,7 +194,7 @@ export class AttestationService {
     duties: AttDutyAndProof[]
   ): Promise<void> {
     const signedAttestations: Attestation[] = [];
-    const headRootHex = toHexString(attestationNoCommittee.beaconBlockRoot);
+    const headRootHex = toHex(attestationNoCommittee.beaconBlockRoot);
     const currentEpoch = computeEpochAtSlot(slot);
     const isPostElectra = currentEpoch >= this.config.ELECTRA_FORK_EPOCH;
 

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -1,4 +1,4 @@
-import {BitArray, fromHexString, toHexString} from "@chainsafe/ssz";
+import {BitArray, fromHexString} from "@chainsafe/ssz";
 import {SecretKey} from "@chainsafe/blst";
 import {
   computeEpochAtSlot,
@@ -42,7 +42,7 @@ import {
   SignedAggregateAndProof,
 } from "@lodestar/types";
 import {routes} from "@lodestar/api";
-import {toPubkeyHex} from "@lodestar/utils";
+import {toHex, toPubkeyHex} from "@lodestar/utils";
 import {ISlashingProtection} from "../slashingProtection/index.js";
 import {PubkeyHex} from "../types.js";
 import {externalSignerPostSignature, SignableMessageType, SignableMessage} from "../util/externalSignerClient.js";
@@ -459,8 +459,8 @@ export class ValidatorStore {
 
     logger?.debug("Signing the block proposal", {
       slot: signingSlot,
-      blockRoot: toHexString(blockRoot),
-      signingRoot: toHexString(signingRoot),
+      blockRoot: toHex(blockRoot),
+      signingRoot: toHex(signingRoot),
     });
 
     try {
@@ -748,7 +748,7 @@ export class ValidatorStore {
     signingSlot: Slot,
     signableMessage: SignableMessage
   ): Promise<BLSSignature> {
-    // TODO: Refactor indexing to not have to run toHexString() on the pubkey every time
+    // TODO: Refactor indexing to not have to run toHex() on the pubkey every time
     const pubkeyHex = typeof pubkey === "string" ? pubkey : toPubkeyHex(pubkey);
 
     const signer = this.validators.get(pubkeyHex)?.signer;
@@ -787,7 +787,7 @@ export class ValidatorStore {
   }
 
   private getSignerAndPubkeyHex(pubkey: BLSPubkeyMaybeHex): [Signer, string] {
-    // TODO: Refactor indexing to not have to run toHexString() on the pubkey every time
+    // TODO: Refactor indexing to not have to run toHex() on the pubkey every time
     const pubkeyHex = typeof pubkey === "string" ? pubkey : toPubkeyHex(pubkey);
     const signer = this.validators.get(pubkeyHex)?.signer;
     if (!signer) {
@@ -824,7 +824,7 @@ export class ValidatorStore {
 function getSignerPubkeyHex(signer: Signer): PubkeyHex {
   switch (signer.type) {
     case SignerType.Local:
-      return toHexString(signer.secretKey.toPublicKey().toBytes());
+      return toHex(signer.secretKey.toPublicKey().toBytes());
 
     case SignerType.Remote:
       if (!isValidatePubkeyHex(signer.pubkey)) {

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -42,7 +42,7 @@ import {
   SignedAggregateAndProof,
 } from "@lodestar/types";
 import {routes} from "@lodestar/api";
-import {toHex, toPubkeyHex} from "@lodestar/utils";
+import {toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {ISlashingProtection} from "../slashingProtection/index.js";
 import {PubkeyHex} from "../types.js";
 import {externalSignerPostSignature, SignableMessageType, SignableMessage} from "../util/externalSignerClient.js";
@@ -459,8 +459,8 @@ export class ValidatorStore {
 
     logger?.debug("Signing the block proposal", {
       slot: signingSlot,
-      blockRoot: toHex(blockRoot),
-      signingRoot: toHex(signingRoot),
+      blockRoot: toRootHex(blockRoot),
+      signingRoot: toRootHex(signingRoot),
     });
 
     try {
@@ -824,7 +824,7 @@ export class ValidatorStore {
 function getSignerPubkeyHex(signer: Signer): PubkeyHex {
   switch (signer.type) {
     case SignerType.Local:
-      return toHex(signer.secretKey.toPublicKey().toBytes());
+      return toPubkeyHex(signer.secretKey.toPublicKey().toBytes());
 
     case SignerType.Remote:
       if (!isValidatePubkeyHex(signer.pubkey)) {

--- a/packages/validator/src/slashingProtection/interchange/formats/completeV4.ts
+++ b/packages/validator/src/slashingProtection/interchange/formats/completeV4.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {fromHexString} from "@chainsafe/ssz";
-import {toHex, toPubkeyHex} from "@lodestar/utils";
+import {toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {InterchangeLodestar} from "../types.js";
 import {fromOptionalHexString, numToString, toOptionalHexString} from "../../utils.js";
 
@@ -91,7 +91,7 @@ export function serializeInterchangeCompleteV4({
     metadata: {
       interchange_format: "complete",
       interchange_format_version: "4",
-      genesis_validators_root: toHex(genesisValidatorsRoot),
+      genesis_validators_root: toRootHex(genesisValidatorsRoot),
     },
     data: data.map((validator) => ({
       pubkey: toPubkeyHex(validator.pubkey),

--- a/packages/validator/src/slashingProtection/interchange/formats/completeV4.ts
+++ b/packages/validator/src/slashingProtection/interchange/formats/completeV4.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString, toHexString} from "@chainsafe/ssz";
-import {toPubkeyHex} from "@lodestar/utils";
+import {fromHexString} from "@chainsafe/ssz";
+import {toHex, toPubkeyHex} from "@lodestar/utils";
 import {InterchangeLodestar} from "../types.js";
 import {fromOptionalHexString, numToString, toOptionalHexString} from "../../utils.js";
 
@@ -91,7 +91,7 @@ export function serializeInterchangeCompleteV4({
     metadata: {
       interchange_format: "complete",
       interchange_format_version: "4",
-      genesis_validators_root: toHexString(genesisValidatorsRoot),
+      genesis_validators_root: toHex(genesisValidatorsRoot),
     },
     data: data.map((validator) => ({
       pubkey: toPubkeyHex(validator.pubkey),

--- a/packages/validator/src/slashingProtection/interchange/formats/v5.ts
+++ b/packages/validator/src/slashingProtection/interchange/formats/v5.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString, toHexString} from "@chainsafe/ssz";
-import {toPubkeyHex} from "@lodestar/utils";
+import {fromHexString} from "@chainsafe/ssz";
+import {toHex, toPubkeyHex} from "@lodestar/utils";
 import {InterchangeLodestar} from "../types.js";
 import {fromOptionalHexString, numToString, toOptionalHexString} from "../../utils.js";
 
@@ -86,7 +86,7 @@ export function serializeInterchangeV5({data, genesisValidatorsRoot}: Interchang
   return {
     metadata: {
       interchange_format_version: "5",
-      genesis_validators_root: toHexString(genesisValidatorsRoot),
+      genesis_validators_root: toHex(genesisValidatorsRoot),
     },
     data: data.map((validator) => ({
       pubkey: toPubkeyHex(validator.pubkey),

--- a/packages/validator/src/slashingProtection/interchange/formats/v5.ts
+++ b/packages/validator/src/slashingProtection/interchange/formats/v5.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {fromHexString} from "@chainsafe/ssz";
-import {toHex, toPubkeyHex} from "@lodestar/utils";
+import {toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {InterchangeLodestar} from "../types.js";
 import {fromOptionalHexString, numToString, toOptionalHexString} from "../../utils.js";
 
@@ -86,7 +86,7 @@ export function serializeInterchangeV5({data, genesisValidatorsRoot}: Interchang
   return {
     metadata: {
       interchange_format_version: "5",
-      genesis_validators_root: toHex(genesisValidatorsRoot),
+      genesis_validators_root: toRootHex(genesisValidatorsRoot),
     },
     data: data.map((validator) => ({
       pubkey: toPubkeyHex(validator.pubkey),

--- a/packages/validator/src/slashingProtection/utils.ts
+++ b/packages/validator/src/slashingProtection/utils.ts
@@ -1,5 +1,6 @@
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {Epoch, Root, ssz} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
 
 export const blsPubkeyLen = 48;
 export const ZERO_ROOT = ssz.Root.defaultValue();
@@ -17,7 +18,7 @@ export function fromOptionalHexString(hex: string | undefined): Root {
 }
 
 export function toOptionalHexString(root: Root): string | undefined {
-  return isEqualRoot(root, ZERO_ROOT) ? undefined : toHexString(root);
+  return isEqualRoot(root, ZERO_ROOT) ? undefined : toHex(root);
 }
 
 /**
@@ -34,7 +35,7 @@ export function minEpoch(epochs: Epoch[]): Epoch | null {
 export function uniqueVectorArr(buffers: Uint8Array[]): Uint8Array[] {
   const bufferStr = new Set<string>();
   return buffers.filter((buffer) => {
-    const str = toHexString(buffer);
+    const str = toHex(buffer);
     const seen = bufferStr.has(str);
     bufferStr.add(str);
     return !seen;

--- a/packages/validator/src/slashingProtection/utils.ts
+++ b/packages/validator/src/slashingProtection/utils.ts
@@ -1,6 +1,6 @@
 import {fromHexString} from "@chainsafe/ssz";
 import {Epoch, Root, ssz} from "@lodestar/types";
-import {toHex} from "@lodestar/utils";
+import {toHex, toRootHex} from "@lodestar/utils";
 
 export const blsPubkeyLen = 48;
 export const ZERO_ROOT = ssz.Root.defaultValue();
@@ -18,7 +18,7 @@ export function fromOptionalHexString(hex: string | undefined): Root {
 }
 
 export function toOptionalHexString(root: Root): string | undefined {
-  return isEqualRoot(root, ZERO_ROOT) ? undefined : toHex(root);
+  return isEqualRoot(root, ZERO_ROOT) ? undefined : toRootHex(root);
 }
 
 /**

--- a/packages/validator/src/util/difference.ts
+++ b/packages/validator/src/util/difference.ts
@@ -1,10 +1,10 @@
-import {toHexString} from "@chainsafe/ssz";
 import {Root} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
 
 /**
  * Return items included in `next` but not in `prev`
  */
 export function differenceHex<T extends Uint8Array | Root>(prev: T[], next: T[]): T[] {
-  const existing = new Set(prev.map((item) => toHexString(item)));
-  return next.filter((item) => !existing.has(toHexString(item)));
+  const existing = new Set(prev.map((item) => toHex(item)));
+  return next.filter((item) => !existing.has(toHex(item)));
 }

--- a/packages/validator/src/util/externalSignerClient.ts
+++ b/packages/validator/src/util/externalSignerClient.ts
@@ -1,4 +1,4 @@
-import {ContainerType, toHexString, ValueOf} from "@chainsafe/ssz";
+import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {fetch} from "@lodestar/api";
 import {phase0, altair, capella, BeaconBlock, BlindedBeaconBlock} from "@lodestar/types";
 import {ForkSeq} from "@lodestar/params";
@@ -6,6 +6,7 @@ import {ValidatorRegistrationV1} from "@lodestar/types/bellatrix";
 import {BeaconConfig} from "@lodestar/config";
 import {computeEpochAtSlot, blindedOrFullBlockToHeader} from "@lodestar/state-transition";
 import {Epoch, Root, RootHex, Slot, ssz} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
 import {PubkeyHex} from "../types.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -131,17 +132,17 @@ export async function externalSignerPostSignature(
   const requestObj = serializerSignableMessagePayload(config, signableMessage) as Web3SignerSerializedRequest;
 
   requestObj.type = signableMessage.type;
-  requestObj.signingRoot = toHexString(signingRoot);
+  requestObj.signingRoot = toHex(signingRoot);
 
   if (requiresForkInfo[signableMessage.type]) {
     const forkInfo = config.getForkInfo(signingSlot);
     requestObj.fork_info = {
       fork: {
-        previous_version: toHexString(forkInfo.prevVersion),
-        current_version: toHexString(forkInfo.version),
+        previous_version: toHex(forkInfo.prevVersion),
+        current_version: toHex(forkInfo.version),
         epoch: String(computeEpochAtSlot(signingSlot)),
       },
-      genesis_validators_root: toHexString(config.genesisValidatorsRoot),
+      genesis_validators_root: toHex(config.genesisValidatorsRoot),
     };
   }
 

--- a/packages/validator/src/util/externalSignerClient.ts
+++ b/packages/validator/src/util/externalSignerClient.ts
@@ -6,7 +6,7 @@ import {ValidatorRegistrationV1} from "@lodestar/types/bellatrix";
 import {BeaconConfig} from "@lodestar/config";
 import {computeEpochAtSlot, blindedOrFullBlockToHeader} from "@lodestar/state-transition";
 import {Epoch, Root, RootHex, Slot, ssz} from "@lodestar/types";
-import {toHex} from "@lodestar/utils";
+import {toHex, toRootHex} from "@lodestar/utils";
 import {PubkeyHex} from "../types.js";
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -132,7 +132,7 @@ export async function externalSignerPostSignature(
   const requestObj = serializerSignableMessagePayload(config, signableMessage) as Web3SignerSerializedRequest;
 
   requestObj.type = signableMessage.type;
-  requestObj.signingRoot = toHex(signingRoot);
+  requestObj.signingRoot = toRootHex(signingRoot);
 
   if (requiresForkInfo[signableMessage.type]) {
     const forkInfo = config.getForkInfo(signingSlot);
@@ -142,7 +142,7 @@ export async function externalSignerPostSignature(
         current_version: toHex(forkInfo.version),
         epoch: String(computeEpochAtSlot(signingSlot)),
       },
-      genesis_validators_root: toHex(config.genesisValidatorsRoot),
+      genesis_validators_root: toRootHex(config.genesisValidatorsRoot),
     };
   }
 

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -1,7 +1,7 @@
 import {BLSPubkey, phase0, ssz} from "@lodestar/types";
 import {createBeaconConfig, BeaconConfig, ChainForkConfig} from "@lodestar/config";
 import {Genesis} from "@lodestar/types/phase0";
-import {Logger, toHex, toPrintableUrl} from "@lodestar/utils";
+import {Logger, toPrintableUrl, toRootHex} from "@lodestar/utils";
 import {getClient, ApiClient, routes, ApiRequestInit, defaultInit} from "@lodestar/api";
 import {computeEpochAtSlot, getCurrentSlot} from "@lodestar/state-transition";
 import {Clock, IClock} from "./util/clock.js";
@@ -396,14 +396,14 @@ async function assertEqualGenesis(opts: ValidatorOptions, genesis: Genesis): Pro
     if (!ssz.Root.equals(genesisValidatorsRoot, nodeGenesisValidatorRoot)) {
       // this happens when the existing validator db served another network before
       opts.logger.error("Not the same genesisValidatorRoot", {
-        expected: toHex(nodeGenesisValidatorRoot),
-        actual: toHex(genesisValidatorsRoot),
+        expected: toRootHex(nodeGenesisValidatorRoot),
+        actual: toRootHex(genesisValidatorsRoot),
       });
       throw new NotEqualParamsError("Not the same genesisValidatorRoot");
     }
   } else {
     await metaDataRepository.setGenesisValidatorsRoot(nodeGenesisValidatorRoot);
-    opts.logger.info("Persisted genesisValidatorRoot", toHex(nodeGenesisValidatorRoot));
+    opts.logger.info("Persisted genesisValidatorRoot", toRootHex(nodeGenesisValidatorRoot));
   }
 
   const nodeGenesisTime = genesis.genesisTime;

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -1,8 +1,7 @@
-import {toHexString} from "@chainsafe/ssz";
 import {BLSPubkey, phase0, ssz} from "@lodestar/types";
 import {createBeaconConfig, BeaconConfig, ChainForkConfig} from "@lodestar/config";
 import {Genesis} from "@lodestar/types/phase0";
-import {Logger, toPrintableUrl} from "@lodestar/utils";
+import {Logger, toHex, toPrintableUrl} from "@lodestar/utils";
 import {getClient, ApiClient, routes, ApiRequestInit, defaultInit} from "@lodestar/api";
 import {computeEpochAtSlot, getCurrentSlot} from "@lodestar/state-transition";
 import {Clock, IClock} from "./util/clock.js";
@@ -397,14 +396,14 @@ async function assertEqualGenesis(opts: ValidatorOptions, genesis: Genesis): Pro
     if (!ssz.Root.equals(genesisValidatorsRoot, nodeGenesisValidatorRoot)) {
       // this happens when the existing validator db served another network before
       opts.logger.error("Not the same genesisValidatorRoot", {
-        expected: toHexString(nodeGenesisValidatorRoot),
-        actual: toHexString(genesisValidatorsRoot),
+        expected: toHex(nodeGenesisValidatorRoot),
+        actual: toHex(genesisValidatorsRoot),
       });
       throw new NotEqualParamsError("Not the same genesisValidatorRoot");
     }
   } else {
     await metaDataRepository.setGenesisValidatorsRoot(nodeGenesisValidatorRoot);
-    opts.logger.info("Persisted genesisValidatorRoot", toHexString(nodeGenesisValidatorRoot));
+    opts.logger.info("Persisted genesisValidatorRoot", toHex(nodeGenesisValidatorRoot));
   }
 
   const nodeGenesisTime = genesis.genesisTime;


### PR DESCRIPTION
**Motivation**

- toHexString() is not great and was deprecated
- we want to reduce gc, see https://github.com/ChainSafe/lodestar/pull/7036#issue-2472773106

**Description**
- use toPubkeyHex() and toRootHex() if applicable
- otherwise use toHex() instead