### PR TITLE
feat: consume forEach api of ssz

### DIFF
--- a/packages/state-transition/src/block/processEth1Data.ts
+++ b/packages/state-transition/src/block/processEth1Data.ts
@@ -24,10 +24,6 @@ export function processEth1Data(state: CachedBeaconStateAllForks, eth1Data: phas
 }
 
 /**
- * This data is reused and never gc.
- */
-const eth1DataVotes: CompositeViewDU<typeof ssz.phase0.Eth1Data>[] = [];
-/**
  * Returns true if adding the given `eth1Data` to `state.eth1DataVotes` would
  * result in a change to `state.eth1Data`.
  */
@@ -52,13 +48,11 @@ export function becomesNewEth1Data(
   // Then isEqualEth1DataView compares cached roots (HashObject as of Jan 2022) which is much cheaper
   // than doing structural equality, which requires tree -> value conversions
   let sameVotesCount = 0;
-  eth1DataVotes.length = state.eth1DataVotes.length;
-  state.eth1DataVotes.getAllReadonly(eth1DataVotes);
-  for (const eth1DataVote of eth1DataVotes) {
+  state.eth1DataVotes.forEach((eth1DataVote) => {
     if (isEqualEth1DataView(eth1DataVote, newEth1Data)) {
       sameVotesCount++;
     }
-  }
+  });
 
   // The +1 is to account for the `eth1Data` supplied to the function.
   if ((sameVotesCount + 1) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD) {

--- a/packages/state-transition/src/block/processEth1Data.ts
+++ b/packages/state-transition/src/block/processEth1Data.ts
@@ -26,7 +26,7 @@ export function processEth1Data(state: CachedBeaconStateAllForks, eth1Data: phas
 /**
  * This data is reused and never gc.
  */
-const eth1DataVotes = new ReusableListIterator<CompositeViewDU<typeof ssz.phase0.Eth1Data>>();
+const eth1DataVotes: CompositeViewDU<typeof ssz.phase0.Eth1Data>[] = [];
 /**
  * Returns true if adding the given `eth1Data` to `state.eth1DataVotes` would
  * result in a change to `state.eth1Data`.
@@ -52,9 +52,8 @@ export function becomesNewEth1Data(
   // Then isEqualEth1DataView compares cached roots (HashObject as of Jan 2022) which is much cheaper
   // than doing structural equality, which requires tree -> value conversions
   let sameVotesCount = 0;
-  eth1DataVotes.reset();
-  state.eth1DataVotes.getAllReadonlyIter(eth1DataVotes);
-  eth1DataVotes.clean();
+  eth1DataVotes.length = state.eth1DataVotes.length;
+  state.eth1DataVotes.getAllReadonly(eth1DataVotes);
   for (const eth1DataVote of eth1DataVotes) {
     if (isEqualEth1DataView(eth1DataVote, newEth1Data)) {
       sameVotesCount++;

--- a/packages/state-transition/src/block/processEth1Data.ts
+++ b/packages/state-transition/src/block/processEth1Data.ts
@@ -1,5 +1,5 @@
 import {Node} from "@chainsafe/persistent-merkle-tree";
-import {CompositeViewDU, ReusableListIterator} from "@chainsafe/ssz";
+import {CompositeViewDU} from "@chainsafe/ssz";
 import {EPOCHS_PER_ETH1_VOTING_PERIOD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {phase0, ssz} from "@lodestar/types";
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "../types.js";

--- a/packages/state-transition/src/cache/epochTransitionCache.ts
+++ b/packages/state-transition/src/cache/epochTransitionCache.ts
@@ -211,10 +211,8 @@ const inclusionDelays = new Array<number>();
 const flags = new Array<number>();
 /** WARNING: reused, never gc'd */
 const nextEpochShufflingActiveValidatorIndices = new Array<number>();
-/**
- * This decomposed validator data is reused and never gc.
- */
-const isCompoundingValidatorArr: boolean[] = [];
+/** WARNING: reused, never gc'd */
+const isCompoundingValidatorArr = new Array<boolean>();
 
 const previousEpochParticipation = new Array<number>();
 const currentEpochParticipation = new Array<number>();
@@ -240,7 +238,9 @@ export function beforeProcessEpoch(
 
   let totalActiveStakeByIncrement = 0;
   const validatorCount = state.validators.length;
-  isCompoundingValidatorArr.length = validatorCount;
+  if (forkSeq >= ForkSeq.electra) {
+    isCompoundingValidatorArr.length = validatorCount;
+  }
   nextEpochShufflingActiveValidatorIndices.length = validatorCount;
   let nextEpochShufflingActiveIndicesLength = 0;
   // pre-fill with true (most validators are active)
@@ -281,7 +281,10 @@ export function beforeProcessEpoch(
       withdrawableEpoch,
       withdrawalCredentials,
     } = validator;
-    isCompoundingValidatorArr[i] = hasCompoundingWithdrawalCredential(withdrawalCredentials);
+
+    if (forkSeq >= ForkSeq.electra) {
+      isCompoundingValidatorArr[i] = hasCompoundingWithdrawalCredential(withdrawalCredentials);
+    }
 
     if (slashed) {
       if (slashingsEpoch === withdrawableEpoch) {

--- a/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -10,7 +10,6 @@ import {
   TIMELY_TARGET_FLAG_INDEX,
 } from "@lodestar/params";
 import {EpochTransitionCache, CachedBeaconStateAllForks, BeaconStateAltair} from "../types.js";
-import {hasCompoundingWithdrawalCredential} from "../util/electra.js";
 
 /** Same to https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.5/specs/altair/beacon-chain.md#has_flag */
 const TIMELY_TARGET = 1 << TIMELY_TARGET_FLAG_INDEX;
@@ -45,7 +44,7 @@ export function processEffectiveBalanceUpdates(
   // and updated in processPendingBalanceDeposits() and processPendingConsolidations()
   // so it's recycled here for performance.
   const balances = cache.balances ?? state.balances.getAll();
-  const currentEpochValidators = cache.validators;
+  const {isCompoundingValidatorArr} = cache;
   const newCompoundingValidators = cache.newCompoundingValidators ?? new Set();
 
   let numUpdate = 0;
@@ -61,9 +60,7 @@ export function processEffectiveBalanceUpdates(
       effectiveBalanceLimit = MAX_EFFECTIVE_BALANCE;
     } else {
       // from electra, effectiveBalanceLimit is per validator
-      const isCompoundingValidator =
-        hasCompoundingWithdrawalCredential(currentEpochValidators[i].withdrawalCredentials) ||
-        newCompoundingValidators.has(i);
+      const isCompoundingValidator = isCompoundingValidatorArr[i] || newCompoundingValidators.has(i);
       effectiveBalanceLimit = isCompoundingValidator ? MAX_EFFECTIVE_BALANCE_ELECTRA : MIN_ACTIVATION_BALANCE;
     }
 

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -124,7 +124,6 @@ export function stateTransition(
   const stateRoot = postState.batchHashTreeRoot(hcGroup);
   hashTreeRootTimer?.();
 
-
   if (metrics) {
     onPostStateMetrics(postState, metrics);
   }

--- a/packages/state-transition/src/util/balance.ts
+++ b/packages/state-transition/src/util/balance.ts
@@ -43,6 +43,7 @@ export function decreaseBalance(state: BeaconStateAllForks, index: ValidatorInde
   state.balances.set(index, Math.max(0, newBalance));
 }
 
+/** WARNING: reused, never gc'd */
 const validatorSlashes: boolean[] = [];
 
 /**

--- a/packages/state-transition/src/util/balance.ts
+++ b/packages/state-transition/src/util/balance.ts
@@ -43,9 +43,6 @@ export function decreaseBalance(state: BeaconStateAllForks, index: ValidatorInde
   state.balances.set(index, Math.max(0, newBalance));
 }
 
-/** WARNING: reused, never gc'd */
-const validatorSlashes: boolean[] = [];
-
 /**
  * This method is used to get justified balances from a justified state.
  * This is consumed by forkchoice which based on delta so we return "by increment" (in ether) value,
@@ -66,10 +63,9 @@ export function getEffectiveBalanceIncrementsZeroInactive(
     validatorCount
   );
 
-  validatorSlashes.length = justifiedState.validators.length;
-  justifiedState.validators.forEachValue((v, i) => (validatorSlashes[i] = v.slashed));
   let j = 0;
-  for (const [i, slashed] of validatorSlashes.entries()) {
+  justifiedState.validators.forEachValue((validator, i) => {
+    const {slashed} = validator;
     if (i === activeIndices[j]) {
       // active validator
       j++;
@@ -81,7 +77,7 @@ export function getEffectiveBalanceIncrementsZeroInactive(
       // inactive validator
       effectiveBalanceIncrementsZeroInactive[i] = 0;
     }
-  }
+  });
 
   return effectiveBalanceIncrementsZeroInactive;
 }

--- a/packages/state-transition/src/util/balance.ts
+++ b/packages/state-transition/src/util/balance.ts
@@ -1,6 +1,5 @@
-import {ReusableListIterator} from "@chainsafe/ssz";
 import {EFFECTIVE_BALANCE_INCREMENT} from "@lodestar/params";
-import {Gwei, ValidatorIndex, phase0} from "@lodestar/types";
+import {Gwei, ValidatorIndex} from "@lodestar/types";
 import {bigIntMax} from "@lodestar/utils";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";
 import {BeaconStateAllForks} from "..";
@@ -67,7 +66,7 @@ export function getEffectiveBalanceIncrementsZeroInactive(
   );
 
   validatorSlashes.length = justifiedState.validators.length;
-  justifiedState.validators.forEachValue((v, i) => validatorSlashes[i] = v.slashed);
+  justifiedState.validators.forEachValue((v, i) => (validatorSlashes[i] = v.slashed));
   let j = 0;
   for (const [i, slashed] of validatorSlashes.entries()) {
     if (i === activeIndices[j]) {


### PR DESCRIPTION
**Motivation**

- Use new `forEach()` and `forEachValue()` of ArrayComposite ViewDU in ssz
- No need to create intermediate regular objects

`gc` metric in the test mainnet node (which merged v1.22.0-rc.0)

<img width="1328" alt="Screenshot 2024-09-12 at 14 54 08" src="https://github.com/user-attachments/assets/db5c72be-a171-4384-80ff-0cfe30289621">


vs beta (v1.22.0-rc.0)

<img width="1323" alt="Screenshot 2024-09-12 at 14 54 56" src="https://github.com/user-attachments/assets/83d742e1-cdea-4b66-924f-69daef194bbb">
