### PR TITLE
chore: avoid fromHexString

### DIFF
--- a/packages/api/src/beacon/routes/proof.ts
+++ b/packages/api/src/beacon/routes/proof.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import {CompactMultiProof, ProofType} from "@chainsafe/persistent-merkle-tree";
-import {ByteListType, ContainerType, fromHexString} from "@chainsafe/ssz";
-import {toHex} from "@lodestar/utils";
+import {ByteListType, ContainerType} from "@chainsafe/ssz";
+import {fromHex, toHex} from "@lodestar/utils";
 import {ChainForkConfig} from "@lodestar/config";
 import {ssz} from "@lodestar/types";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
@@ -47,7 +47,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       method: "GET",
       req: {
         writeReq: ({stateId, descriptor}) => ({params: {state_id: stateId}, query: {format: toHex(descriptor)}}),
-        parseReq: ({params, query}) => ({stateId: params.state_id, descriptor: fromHexString(query.format)}),
+        parseReq: ({params, query}) => ({stateId: params.state_id, descriptor: fromHex(query.format)}),
         schema: {params: {state_id: Schema.StringRequired}, query: {format: Schema.StringRequired}},
       },
       resp: {
@@ -65,7 +65,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       method: "GET",
       req: {
         writeReq: ({blockId, descriptor}) => ({params: {block_id: blockId}, query: {format: toHex(descriptor)}}),
-        parseReq: ({params, query}) => ({blockId: params.block_id, descriptor: fromHexString(query.format)}),
+        parseReq: ({params, query}) => ({blockId: params.block_id, descriptor: fromHex(query.format)}),
         schema: {params: {block_id: Schema.StringRequired}, query: {format: Schema.StringRequired}},
       },
       resp: {

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {ContainerType, fromHexString, Type, ValueOf} from "@chainsafe/ssz";
+import {ContainerType, Type, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {isForkBlobs, isForkPostElectra} from "@lodestar/params";
 import {
@@ -20,7 +20,7 @@ import {
   Attestation,
   sszTypesFor,
 } from "@lodestar/types";
-import {toHex, toRootHex} from "@lodestar/utils";
+import {fromHex, toHex, toRootHex} from "@lodestar/utils";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {fromGraffitiHex, toBoolean, toGraffitiHex} from "../../utils/serdes.js";
 import {getExecutionForkTypes, toForkName} from "../../utils/fork.js";
@@ -633,7 +633,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         }),
         parseReq: ({params, query}) => ({
           slot: params.slot,
-          randaoReveal: fromHexString(query.randao_reveal),
+          randaoReveal: fromHex(query.randao_reveal),
           graffiti: fromGraffitiHex(query.graffiti),
           feeRecipient: query.fee_recipient,
           builderSelection: query.builder_selection as BuilderSelection,
@@ -687,7 +687,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         }),
         parseReq: ({params, query}) => ({
           slot: params.slot,
-          randaoReveal: fromHexString(query.randao_reveal),
+          randaoReveal: fromHex(query.randao_reveal),
           graffiti: fromGraffitiHex(query.graffiti),
           skipRandaoVerification: parseSkipRandaoVerification(query.skip_randao_verification),
           feeRecipient: query.fee_recipient,
@@ -770,7 +770,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         }),
         parseReq: ({params, query}) => ({
           slot: params.slot,
-          randaoReveal: fromHexString(query.randao_reveal),
+          randaoReveal: fromHex(query.randao_reveal),
           graffiti: fromGraffitiHex(query.graffiti),
         }),
         schema: {
@@ -811,7 +811,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReq: ({query}) => ({
           slot: query.slot,
           subcommitteeIndex: query.subcommittee_index,
-          beaconBlockRoot: fromHexString(query.beacon_block_root),
+          beaconBlockRoot: fromHex(query.beacon_block_root),
         }),
         schema: {
           query: {
@@ -834,7 +834,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           query: {attestation_data_root: toRootHex(attestationDataRoot), slot},
         }),
         parseReq: ({query}) => ({
-          attestationDataRoot: fromHexString(query.attestation_data_root),
+          attestationDataRoot: fromHex(query.attestation_data_root),
           slot: query.slot,
         }),
         schema: {
@@ -857,7 +857,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           query: {attestation_data_root: toHex(attestationDataRoot), slot, committee_index: committeeIndex},
         }),
         parseReq: ({query}) => ({
-          attestationDataRoot: fromHexString(query.attestation_data_root),
+          attestationDataRoot: fromHex(query.attestation_data_root),
           slot: query.slot,
           committeeIndex: query.committee_index,
         }),

--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString} from "@chainsafe/ssz";
 import {
   ssz,
   bellatrix,
@@ -13,7 +12,7 @@ import {
 } from "@lodestar/types";
 import {ForkName, isForkBlobs} from "@lodestar/params";
 import {ChainForkConfig} from "@lodestar/config";
-import {toPubkeyHex, toRootHex} from "@lodestar/utils";
+import {fromHex, toPubkeyHex, toRootHex} from "@lodestar/utils";
 
 import {Endpoint, RouteDefinitions, Schema} from "../utils/index.js";
 import {MetaHeader, VersionCodec, VersionMeta} from "../utils/metadata.js";
@@ -110,8 +109,8 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         }),
         parseReq: ({params}) => ({
           slot: params.slot,
-          parentHash: fromHexString(params.parent_hash),
-          proposerPubkey: fromHexString(params.pubkey),
+          parentHash: fromHex(params.parent_hash),
+          proposerPubkey: fromHex(params.pubkey),
         }),
         schema: {
           params: {slot: Schema.UintRequired, parent_hash: Schema.StringRequired, pubkey: Schema.StringRequired},

--- a/packages/api/src/utils/serdes.ts
+++ b/packages/api/src/utils/serdes.ts
@@ -1,5 +1,5 @@
-import {fromHexString, JsonPath} from "@chainsafe/ssz";
-import {toHex} from "@lodestar/utils";
+import {JsonPath} from "@chainsafe/ssz";
+import {fromHex, toHex} from "@lodestar/utils";
 
 /**
  * Serialize proof path to JSON.
@@ -103,7 +103,7 @@ export function fromGraffitiHex(hex?: string): string | undefined {
     return undefined;
   }
   try {
-    return new TextDecoder("utf8").decode(fromHexString(hex));
+    return new TextDecoder("utf8").decode(fromHex(hex));
   } catch {
     // allow malformed graffiti hex string
     return hex;

--- a/packages/beacon-node/src/chain/archiver/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiver/archiveBlocks.ts
@@ -1,7 +1,6 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {Epoch, Slot, RootHex} from "@lodestar/types";
 import {IForkChoice} from "@lodestar/fork-choice";
-import {Logger, toRootHex} from "@lodestar/utils";
+import {Logger, fromHex, toRootHex} from "@lodestar/utils";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {KeyValue} from "@lodestar/db";
@@ -48,7 +47,7 @@ export async function archiveBlocks(
 
   const finalizedCanonicalBlockRoots: BlockRootSlot[] = finalizedCanonicalBlocks.map((block) => ({
     slot: block.slot,
-    root: fromHexString(block.blockRoot),
+    root: fromHex(block.blockRoot),
   }));
 
   if (finalizedCanonicalBlockRoots.length > 0) {
@@ -68,7 +67,7 @@ export async function archiveBlocks(
   // deleteNonCanonicalBlocks
   // loop through forkchoice single time
 
-  const nonCanonicalBlockRoots = finalizedNonCanonicalBlocks.map((summary) => fromHexString(summary.blockRoot));
+  const nonCanonicalBlockRoots = finalizedNonCanonicalBlocks.map((summary) => fromHex(summary.blockRoot));
   if (nonCanonicalBlockRoots.length > 0) {
     await db.block.batchDelete(nonCanonicalBlockRoots);
     logger.verbose("Deleted non canonical blocks from hot DB", {
@@ -144,7 +143,7 @@ async function migrateBlocksFromHotToColdDb(db: IBeaconDb, blocks: BlockRootSlot
           value: blockBuffer,
           slot: block.slot,
           blockRoot: block.root,
-          // TODO: Benchmark if faster to slice Buffer or fromHexString()
+          // TODO: Benchmark if faster to slice Buffer or fromHex()
           parentRoot: getParentRootFromSignedBlock(blockBuffer),
         };
       })

--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -1,4 +1,3 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {
   CachedBeaconStateAllForks,
   computeEpochAtSlot,
@@ -16,7 +15,7 @@ import {
   ForkSeq,
   MAX_ATTESTER_SLASHINGS_ELECTRA,
 } from "@lodestar/params";
-import {toHex, toRootHex} from "@lodestar/utils";
+import {fromHex, toHex, toRootHex} from "@lodestar/utils";
 import {Epoch, phase0, capella, ssz, ValidatorIndex, SignedBeaconBlock, AttesterSlashing} from "@lodestar/types";
 import {IBeaconDb} from "../../db/index.js";
 import {SignedBLSToExecutionChangeVersioned} from "../../util/types.js";
@@ -85,7 +84,7 @@ export class OpPool {
       persistDiff(
         db.attesterSlashing,
         Array.from(this.attesterSlashings.entries()).map(([key, value]) => ({
-          key: fromHexString(key),
+          key: fromHex(key),
           value: value.attesterSlashing,
         })),
         toHex

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -1,4 +1,3 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {phase0, Slot, RootHex, BeaconBlock, SignedBeaconBlock} from "@lodestar/types";
 import {
   CachedBeaconStateAllForks,
@@ -11,7 +10,7 @@ import {
   StateHashTreeRootSource,
 } from "@lodestar/state-transition";
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
-import {Logger, toRootHex} from "@lodestar/utils";
+import {Logger, fromHex, toRootHex} from "@lodestar/utils";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ChainForkConfig} from "@lodestar/config";
 import {Metrics} from "../../metrics/index.js";
@@ -216,7 +215,7 @@ export class StateRegenerator implements IStateRegeneratorInternal {
     const protoBlocksAsc = blocksToReplay.reverse();
     for (const [i, protoBlock] of protoBlocksAsc.entries()) {
       replaySlots[i] = protoBlock.slot;
-      blockPromises[i] = this.modules.db.block.get(fromHexString(protoBlock.blockRoot));
+      blockPromises[i] = this.modules.db.block.get(fromHex(protoBlock.blockRoot));
     }
 
     const logCtx = {stateRoot, replaySlots: replaySlots.join(",")};

--- a/packages/beacon-node/src/chain/stateCache/datastore/file.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/file.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
-import {fromHexString} from "@chainsafe/ssz";
 import {phase0, ssz} from "@lodestar/types";
-import {toHex} from "@lodestar/utils";
+import {fromHex, toHex} from "@lodestar/utils";
 import {ensureDir, readFile, readFileNames, removeFile, writeIfNotExist} from "../../../util/file.js";
 import {CPStateDatastore, DatastoreKey} from "./types.js";
 
@@ -48,6 +47,6 @@ export class FileCPStateDatastore implements CPStateDatastore {
     const fileNames = await readFileNames(this.folderPath);
     return fileNames
       .filter((fileName) => fileName.startsWith("0x") && fileName.length === CHECKPOINT_FILE_NAME_LENGTH)
-      .map((fileName) => fromHexString(fileName));
+      .map((fileName) => fromHex(fileName));
   }
 }

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -1,7 +1,6 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {phase0, Epoch, RootHex} from "@lodestar/types";
 import {CachedBeaconStateAllForks, computeStartSlotAtEpoch, getBlockRootAtSlot} from "@lodestar/state-transition";
-import {Logger, MapDef, sleep, toHex, toRootHex} from "@lodestar/utils";
+import {Logger, MapDef, fromHex, sleep, toHex, toRootHex} from "@lodestar/utils";
 import {routes} from "@lodestar/api";
 import {loadCachedBeaconState} from "@lodestar/state-transition";
 import {INTERVALS_PER_SLOT} from "@lodestar/params";
@@ -657,7 +656,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     let persistCount = 0;
     const epochBoundarySlot = computeStartSlotAtEpoch(epoch);
     const epochBoundaryRoot =
-      epochBoundarySlot === state.slot ? fromHexString(blockRootHex) : getBlockRootAtSlot(state, epochBoundarySlot);
+      epochBoundarySlot === state.slot ? fromHex(blockRootHex) : getBlockRootAtSlot(state, epochBoundarySlot);
     const epochBoundaryHex = toRootHex(epochBoundaryRoot);
     const prevEpochRoot = toRootHex(getBlockRootAtSlot(state, epochBoundarySlot - 1));
 
@@ -698,7 +697,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
           } else {
             // persist and do not update epochIndex
             this.metrics?.statePersistSecFromSlot.observe(this.clock?.secFromSlot(this.clock?.currentSlot ?? 0) ?? 0);
-            const cpPersist = {epoch: epoch, root: fromHexString(rootHex)};
+            const cpPersist = {epoch: epoch, root: fromHex(rootHex)};
             // It's not sustainable to allocate ~240MB for each state every epoch, so we use buffer pool to reuse the memory.
             // As monitored on holesky as of Jan 2024:
             //   - This does not increase heap allocation while gc time is the same

--- a/packages/beacon-node/src/eth1/index.ts
+++ b/packages/beacon-node/src/eth1/index.ts
@@ -1,6 +1,6 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {Root} from "@lodestar/types";
+import {fromHex} from "@lodestar/utils";
 import {IEth1ForBlockProduction, Eth1DataAndDeposits, IEth1Provider, PowMergeBlock, TDProgress} from "./interface.js";
 import {Eth1DepositDataTracker, Eth1DepositDataTrackerModules} from "./eth1DepositDataTracker.js";
 import {Eth1MergeBlockTracker, Eth1MergeBlockTrackerModules} from "./eth1MergeBlockTracker.js";
@@ -92,7 +92,7 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
 
   async getTerminalPowBlock(): Promise<Root | null> {
     const block = await this.eth1MergeBlockTracker.getTerminalPowBlock();
-    return block && fromHexString(block.blockHash);
+    return block && fromHex(block.blockHash);
   }
 
   getPowBlock(powBlockHash: string): Promise<PowMergeBlock | null> {

--- a/packages/beacon-node/src/eth1/provider/utils.ts
+++ b/packages/beacon-node/src/eth1/provider/utils.ts
@@ -1,6 +1,5 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {RootHex} from "@lodestar/types";
-import {bytesToBigInt, bigIntToBytes, toHex} from "@lodestar/utils";
+import {bytesToBigInt, bigIntToBytes, toHex, fromHex} from "@lodestar/utils";
 import {ErrorParseJson} from "./jsonRpcHttpClient.js";
 
 /** QUANTITY as defined in ethereum execution layer JSON RPC https://eth.wiki/json-rpc/API */
@@ -108,7 +107,7 @@ export function bytesToData(bytes: Uint8Array): DATA {
  */
 export function dataToBytes(hex: DATA, fixedLength: number | null): Uint8Array {
   try {
-    const bytes = fromHexString(hex);
+    const bytes = fromHex(hex);
     if (fixedLength != null && bytes.length !== fixedLength) {
       throw Error(`Wrong data length ${bytes.length} expected ${fixedLength}`);
     }

--- a/packages/beacon-node/src/eth1/utils/depositContract.ts
+++ b/packages/beacon-node/src/eth1/utils/depositContract.ts
@@ -1,6 +1,6 @@
 import {Interface} from "@ethersproject/abi";
-import {fromHexString} from "@chainsafe/ssz";
 import {phase0, ssz} from "@lodestar/types";
+import {fromHex} from "@lodestar/utils";
 
 const depositEventFragment =
   "event DepositEvent(bytes pubkey, bytes withdrawal_credentials, bytes amount, bytes signature, bytes index)";
@@ -23,15 +23,15 @@ export function parseDepositLog(log: {blockNumber: number; data: string; topics:
     blockNumber: log.blockNumber,
     index: parseHexNumLittleEndian(values.index),
     depositData: {
-      pubkey: fromHexString(values.pubkey),
-      withdrawalCredentials: fromHexString(values.withdrawal_credentials),
+      pubkey: fromHex(values.pubkey),
+      withdrawalCredentials: fromHex(values.withdrawal_credentials),
       amount: parseHexNumLittleEndian(values.amount),
-      signature: fromHexString(values.signature),
+      signature: fromHex(values.signature),
     },
   };
 }
 
 function parseHexNumLittleEndian(hex: string): number {
   // Can't use parseInt() because amount is a hex string in little endian
-  return ssz.UintNum64.deserialize(fromHexString(hex));
+  return ssz.UintNum64.deserialize(fromHex(hex));
 }

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -2,13 +2,12 @@ import {Connection, PeerId} from "@libp2p/interface";
 import {multiaddr} from "@multiformats/multiaddr";
 import {PublishOpts} from "@chainsafe/libp2p-gossipsub/types";
 import {PeerScoreStatsDump} from "@chainsafe/libp2p-gossipsub/dist/src/score/peer-score.js";
-import {fromHexString} from "@chainsafe/ssz";
 import {ENR} from "@chainsafe/enr";
 import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
 import {Epoch, phase0} from "@lodestar/types";
-import {withTimeout} from "@lodestar/utils";
+import {fromHex, withTimeout} from "@lodestar/utils";
 import {ForkName} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {Libp2p} from "../interface.js";
@@ -195,7 +194,7 @@ export class NetworkCore implements INetworkCore {
     await gossip.start();
 
     const enr = opts.discv5?.enr;
-    const nodeId = enr ? fromHexString(ENR.decodeTxt(enr).nodeId) : null;
+    const nodeId = enr ? fromHex(ENR.decodeTxt(enr).nodeId) : null;
     const attnetsService = new AttnetsService(config, clock, gossip, metadata, logger, metrics, nodeId, opts);
     const syncnetsService = new SyncnetsService(config, clock, gossip, metadata, logger, metrics, opts);
 

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -1,7 +1,7 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {phase0, deneb} from "@lodestar/types";
 import {ForkSeq} from "@lodestar/params";
+import {fromHex} from "@lodestar/utils";
 import {
   BlockInput,
   BlockInputType,
@@ -66,7 +66,7 @@ export async function unavailableBeaconBlobsByRoot(
   // resolve the block if thats unavailable
   let block, blobsCache, blockBytes, resolveAvailability, cachedData;
   if (unavailableBlockInput.block === null) {
-    const allBlocks = await network.sendBeaconBlocksByRoot(peerId, [fromHexString(unavailableBlockInput.blockRootHex)]);
+    const allBlocks = await network.sendBeaconBlocksByRoot(peerId, [fromHex(unavailableBlockInput.blockRootHex)]);
     block = allBlocks[0].data;
     blockBytes = allBlocks[0].bytes;
     cachedData = unavailableBlockInput.cachedData;

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -1,6 +1,5 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {Logger, pruneSetToMax, toRootHex} from "@lodestar/utils";
+import {Logger, fromHex, pruneSetToMax, toRootHex} from "@lodestar/utils";
 import {Root, RootHex, deneb} from "@lodestar/types";
 import {INTERVALS_PER_SLOT} from "@lodestar/params";
 import {sleep} from "@lodestar/utils";
@@ -288,7 +287,7 @@ export class UnknownBlockSync {
 
     let res;
     if (block.blockInput === null) {
-      res = await wrapError(this.fetchUnknownBlockRoot(fromHexString(block.blockRootHex), connectedPeers));
+      res = await wrapError(this.fetchUnknownBlockRoot(fromHex(block.blockRootHex), connectedPeers));
     } else {
       res = await wrapError(this.fetchUnavailableBlockInput(block.blockInput, connectedPeers));
     }
@@ -519,7 +518,7 @@ export class UnknownBlockSync {
 
     if (unavailableBlockInput.block === null) {
       blockRootHex = unavailableBlockInput.blockRootHex;
-      blockRoot = fromHexString(blockRootHex);
+      blockRoot = fromHex(blockRootHex);
     } else {
       const unavailableBlock = unavailableBlockInput.block;
       blockRoot = this.config

--- a/packages/cli/src/cmds/lightclient/handler.ts
+++ b/packages/cli/src/cmds/lightclient/handler.ts
@@ -1,9 +1,9 @@
 import path from "node:path";
-import {fromHexString} from "@chainsafe/ssz";
 import {getClient} from "@lodestar/api";
 import {Lightclient} from "@lodestar/light-client";
 import {LightClientRestTransport} from "@lodestar/light-client/transport";
 import {getNodeLogger} from "@lodestar/logger/node";
+import {fromHex} from "@lodestar/utils";
 import {getBeaconConfigFromArgs} from "../../config/beaconParams.js";
 import {getGlobalPaths} from "../../paths/global.js";
 import {parseLoggerArgs} from "../../util/logger.js";
@@ -28,7 +28,7 @@ export async function lightclientHandler(args: ILightClientArgs & GlobalArgs): P
       genesisTime,
       genesisValidatorsRoot,
     },
-    checkpointRoot: fromHexString(args.checkpointRoot),
+    checkpointRoot: fromHex(args.checkpointRoot),
     transport: new LightClientRestTransport(api),
   });
 

--- a/packages/cli/src/cmds/validator/blsToExecutionChange.ts
+++ b/packages/cli/src/cmds/validator/blsToExecutionChange.ts
@@ -1,11 +1,10 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {SecretKey} from "@chainsafe/blst";
 import {computeSigningRoot} from "@lodestar/state-transition";
 import {DOMAIN_BLS_TO_EXECUTION_CHANGE, ForkName} from "@lodestar/params";
 import {createBeaconConfig} from "@lodestar/config";
 import {ssz, capella} from "@lodestar/types";
 import {getClient} from "@lodestar/api";
-import {CliCommand} from "@lodestar/utils";
+import {CliCommand, fromHex} from "@lodestar/utils";
 
 import {GlobalArgs} from "../../options/index.js";
 import {getBeaconConfigFromArgs} from "../../config/index.js";
@@ -67,13 +66,13 @@ like to choose for BLS To Execution Change.",
       throw new Error(`Validator pubkey ${publicKey} not found in state`);
     }
 
-    const blsPrivkey = SecretKey.fromBytes(fromHexString(args.fromBlsPrivkey));
+    const blsPrivkey = SecretKey.fromBytes(fromHex(args.fromBlsPrivkey));
     const fromBlsPubkey = blsPrivkey.toPublicKey().toBytes();
 
     const blsToExecutionChange: capella.BLSToExecutionChange = {
       validatorIndex: validator.index,
       fromBlsPubkey,
-      toExecutionAddress: fromHexString(args.toExecutionAddress),
+      toExecutionAddress: fromHex(args.toExecutionAddress),
     };
 
     const signatureFork = ForkName.phase0;

--- a/packages/cli/src/cmds/validator/keymanager/impl.ts
+++ b/packages/cli/src/cmds/validator/keymanager/impl.ts
@@ -1,5 +1,4 @@
 import {Keystore} from "@chainsafe/bls-keystore";
-import {fromHexString} from "@chainsafe/ssz";
 import {SecretKey} from "@chainsafe/blst";
 import {
   DeleteRemoteKeyStatus,
@@ -21,7 +20,7 @@ import {KeymanagerApiMethods as Api} from "@lodestar/api/keymanager/server";
 import {Interchange, SignerType, Validator} from "@lodestar/validator";
 import {ApiError} from "@lodestar/api/server";
 import {Epoch} from "@lodestar/types";
-import {isValidHttpUrl} from "@lodestar/utils";
+import {fromHex, isValidHttpUrl} from "@lodestar/utils";
 import {getPubkeyHexFromKeystore, isValidatePubkeyHex} from "../../../util/format.js";
 import {parseFeeRecipient} from "../../../util/index.js";
 import {DecryptKeystoresThreadPool} from "./decryptKeystores/index.js";
@@ -224,7 +223,7 @@ export class KeymanagerApi implements Api {
       }
     }
 
-    const pubkeysBytes = pubkeys.map((pubkeyHex) => fromHexString(pubkeyHex));
+    const pubkeysBytes = pubkeys.map((pubkeyHex) => fromHex(pubkeyHex));
 
     const interchangeV5 = await this.validator.exportInterchange(pubkeysBytes, {
       version: "5",

--- a/packages/cli/src/util/format.ts
+++ b/packages/cli/src/util/format.ts
@@ -1,5 +1,5 @@
 import {PublicKey} from "@chainsafe/blst";
-import {fromHexString} from "@chainsafe/ssz";
+import {fromHex} from "@lodestar/utils";
 
 /**
  * 0x prefix a string if not prefixed already
@@ -50,7 +50,7 @@ export function parseRange(range: string): number[] {
 
 export function assertValidPubkeysHex(pubkeysHex: string[]): void {
   for (const pubkeyHex of pubkeysHex) {
-    const pubkeyBytes = fromHexString(pubkeyHex);
+    const pubkeyBytes = fromHex(pubkeyHex);
     PublicKey.fromBytes(pubkeyBytes, true);
   }
 }

--- a/packages/cli/test/utils/crucible/assertions/blobsAssertion.ts
+++ b/packages/cli/test/utils/crucible/assertions/blobsAssertion.ts
@@ -35,7 +35,7 @@ export function createBlobsAssertion(
           gasLimit: "0xc350",
           maxPriorityFeePerGas: "0x3b9aca00",
           maxFeePerGas: "0x3ba26b20",
-          maxFeePerBlobGas: "0x3e8",
+          maxFeePerBlobGas: "0x3e",
           value: "0x10000",
           nonce: `0x${(nonce ?? 0).toString(16)}`,
           blobVersionedHashes,

--- a/packages/config/src/chainConfig/configs/mainnet.ts
+++ b/packages/config/src/chainConfig/configs/mainnet.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString as b} from "@chainsafe/ssz";
+import {fromHex as b} from "@lodestar/utils";
 import {PresetName} from "@lodestar/params";
 import {ChainConfig} from "../types.js";
 

--- a/packages/config/src/chainConfig/configs/minimal.ts
+++ b/packages/config/src/chainConfig/configs/minimal.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString as b} from "@chainsafe/ssz";
+import {fromHex as b} from "@lodestar/utils";
 import {PresetName} from "@lodestar/params";
 import {ChainConfig} from "../types.js";
 

--- a/packages/config/src/chainConfig/json.ts
+++ b/packages/config/src/chainConfig/json.ts
@@ -1,5 +1,4 @@
-import {fromHexString} from "@chainsafe/ssz";
-import {toHex} from "@lodestar/utils";
+import {fromHex, toHex} from "@lodestar/utils";
 import {ChainConfig, chainConfigTypes, SpecValue, SpecValueTypeName} from "./types.js";
 
 const MAX_UINT64_JSON = "18446744073709551615";
@@ -96,7 +95,7 @@ export function deserializeSpecValue(valueStr: unknown, typeName: SpecValueTypeN
       return BigInt(valueStr);
 
     case "bytes":
-      return fromHexString(valueStr);
+      return fromHex(valueStr);
 
     case "string":
       return valueStr;

--- a/packages/config/src/chainConfig/networks/chiado.ts
+++ b/packages/config/src/chainConfig/networks/chiado.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString as b} from "@chainsafe/ssz";
+import {fromHex as b} from "@lodestar/utils";
 import {ChainConfig} from "../types.js";
 import {gnosisChainConfig as gnosis} from "./gnosis.js";
 

--- a/packages/config/src/chainConfig/networks/ephemery.ts
+++ b/packages/config/src/chainConfig/networks/ephemery.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString as b} from "@chainsafe/ssz";
+import {fromHex as b} from "@lodestar/utils";
 import {ChainConfig} from "../types.js";
 import {chainConfig as mainnet} from "../configs/mainnet.js";
 

--- a/packages/config/src/chainConfig/networks/gnosis.ts
+++ b/packages/config/src/chainConfig/networks/gnosis.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString as b} from "@chainsafe/ssz";
+import {fromHex as b} from "@lodestar/utils";
 import {PresetName} from "@lodestar/params";
 import {ChainConfig} from "../types.js";
 import {chainConfig as mainnet} from "../configs/mainnet.js";

--- a/packages/config/src/chainConfig/networks/holesky.ts
+++ b/packages/config/src/chainConfig/networks/holesky.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString as b} from "@chainsafe/ssz";
+import {fromHex as b} from "@lodestar/utils";
 import {ChainConfig} from "../types.js";
 import {chainConfig as mainnet} from "../configs/mainnet.js";
 

--- a/packages/config/src/chainConfig/networks/mainnet.ts
+++ b/packages/config/src/chainConfig/networks/mainnet.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString as b} from "@chainsafe/ssz";
+import {fromHex as b} from "@lodestar/utils";
 import {ChainConfig} from "../types.js";
 import {chainConfig as mainnet} from "../configs/mainnet.js";
 

--- a/packages/config/src/chainConfig/networks/sepolia.ts
+++ b/packages/config/src/chainConfig/networks/sepolia.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString as b} from "@chainsafe/ssz";
+import {fromHex as b} from "@lodestar/utils";
 import {ChainConfig} from "../types.js";
 import {chainConfig as mainnet} from "../configs/mainnet.js";
 

--- a/packages/light-client/src/index.ts
+++ b/packages/light-client/src/index.ts
@@ -1,5 +1,4 @@
 import mitt from "mitt";
-import {fromHexString} from "@chainsafe/ssz";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD} from "@lodestar/params";
 import {
   LightClientBootstrap,
@@ -13,7 +12,7 @@ import {
   SyncPeriod,
 } from "@lodestar/types";
 import {createBeaconConfig, BeaconConfig, ChainForkConfig} from "@lodestar/config";
-import {isErrorAborted, sleep, toRootHex} from "@lodestar/utils";
+import {fromHex, isErrorAborted, sleep, toRootHex} from "@lodestar/utils";
 import {getCurrentSlot, slotWithFutureTolerance, timeUntilNextEpoch} from "./utils/clock.js";
 import {chunkifyInclusiveRange} from "./utils/chunkify.js";
 import {LightclientEmitter, LightclientEvent} from "./events.js";
@@ -120,7 +119,7 @@ export class Lightclient {
     this.genesisTime = genesisData.genesisTime;
     this.genesisValidatorsRoot =
       typeof genesisData.genesisValidatorsRoot === "string"
-        ? fromHexString(genesisData.genesisValidatorsRoot)
+        ? fromHex(genesisData.genesisValidatorsRoot)
         : genesisData.genesisValidatorsRoot;
 
     this.config = createBeaconConfig(config, this.genesisValidatorsRoot);

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -1,6 +1,5 @@
 import {PublicKey} from "@chainsafe/blst";
 import * as immutable from "immutable";
-import {fromHexString} from "@chainsafe/ssz";
 import {
   BLSSignature,
   CommitteeIndex,
@@ -25,7 +24,7 @@ import {
   SLOTS_PER_EPOCH,
   WEIGHT_DENOMINATOR,
 } from "@lodestar/params";
-import {LodestarError} from "@lodestar/utils";
+import {LodestarError, fromHex} from "@lodestar/utils";
 import {
   computeActivationExitEpoch,
   computeEpochAtSlot,
@@ -964,7 +963,7 @@ export class EpochCache {
     }
 
     this.pubkey2index.set(pubkey, index);
-    const pubkeyBytes = pubkey instanceof Uint8Array ? pubkey : fromHexString(pubkey);
+    const pubkeyBytes = pubkey instanceof Uint8Array ? pubkey : fromHex(pubkey);
     this.index2pubkey[index] = PublicKey.fromBytes(pubkeyBytes); // Optimize for aggregation
   }
 

--- a/packages/utils/src/bytes/nodejs.ts
+++ b/packages/utils/src/bytes/nodejs.ts
@@ -44,6 +44,18 @@ export function toPubkeyHex(pubkey: Uint8Array): string {
 }
 
 export function fromHex(hex: string): Uint8Array {
-  const b = Buffer.from(hex.replace("0x", ""), "hex");
+  if (typeof hex !== "string") {
+    throw new Error(`hex argument type ${typeof hex} must be of type string`);
+  }
+
+  if (hex.startsWith("0x")) {
+    hex = hex.slice(2);
+  }
+
+  if (hex.length % 2 !== 0) {
+    throw new Error(`hex string length ${hex.length} must be multiple of 2`);
+  }
+
+  const b = Buffer.from(hex, "hex");
   return new Uint8Array(b.buffer, b.byteOffset, b.length);
 }

--- a/packages/validator/src/services/chainHeaderTracker.ts
+++ b/packages/validator/src/services/chainHeaderTracker.ts
@@ -1,6 +1,5 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {ApiClient, routes} from "@lodestar/api";
-import {Logger} from "@lodestar/utils";
+import {Logger, fromHex} from "@lodestar/utils";
 import {Slot, Root, RootHex} from "@lodestar/types";
 import {GENESIS_SLOT} from "@lodestar/params";
 import {ValidatorEvent, ValidatorEventEmitter} from "./emitter.js";
@@ -64,7 +63,7 @@ export class ChainHeaderTracker {
       const {message} = event;
       const {slot, block, previousDutyDependentRoot, currentDutyDependentRoot} = message;
       this.headBlockSlot = slot;
-      this.headBlockRoot = fromHexString(block);
+      this.headBlockRoot = fromHex(block);
 
       const headEventData = {
         slot: this.headBlockSlot,

--- a/packages/validator/src/services/doppelgangerService.ts
+++ b/packages/validator/src/services/doppelgangerService.ts
@@ -1,7 +1,6 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {Epoch, ValidatorIndex} from "@lodestar/types";
 import {ApiClient, routes} from "@lodestar/api";
-import {Logger, sleep, truncBytes} from "@lodestar/utils";
+import {Logger, fromHex, sleep, truncBytes} from "@lodestar/utils";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {ISlashingProtection} from "../slashingProtection/index.js";
 import {ProcessShutdownCallback, PubkeyHex} from "../types.js";
@@ -69,7 +68,7 @@ export class DoppelgangerService {
     if (remainingEpochs > 0) {
       const previousEpoch = currentEpoch - 1;
       const attestedInPreviousEpoch = await this.slashingProtection.hasAttestedInEpoch(
-        fromHexString(pubkeyHex),
+        fromHex(pubkeyHex),
         previousEpoch
       );
 

--- a/packages/validator/src/services/externalSignerSync.ts
+++ b/packages/validator/src/services/externalSignerSync.ts
@@ -1,8 +1,7 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {PublicKey} from "@chainsafe/blst";
 import {ChainForkConfig} from "@lodestar/config";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {toPrintableUrl} from "@lodestar/utils";
+import {fromHex, toPrintableUrl} from "@lodestar/utils";
 
 import {LoggerVc} from "../util/index.js";
 import {externalSignerGetKeys} from "../util/externalSignerClient.js";
@@ -77,7 +76,7 @@ export function pollExternalSignerPubkeys(
 
 function assertValidPubkeysHex(pubkeysHex: string[]): void {
   for (const pubkeyHex of pubkeysHex) {
-    const pubkeyBytes = fromHexString(pubkeyHex);
+    const pubkeyBytes = fromHex(pubkeyHex);
     PublicKey.fromBytes(pubkeyBytes, true);
   }
 }

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -1,4 +1,4 @@
-import {BitArray, fromHexString} from "@chainsafe/ssz";
+import {BitArray} from "@chainsafe/ssz";
 import {SecretKey} from "@chainsafe/blst";
 import {
   computeEpochAtSlot,
@@ -42,7 +42,7 @@ import {
   SignedAggregateAndProof,
 } from "@lodestar/types";
 import {routes} from "@lodestar/api";
-import {toPubkeyHex, toRootHex} from "@lodestar/utils";
+import {fromHex, toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {ISlashingProtection} from "../slashingProtection/index.js";
 import {PubkeyHex} from "../types.js";
 import {externalSignerPostSignature, SignableMessageType, SignableMessage} from "../util/externalSignerClient.js";
@@ -693,8 +693,8 @@ export class ValidatorStore {
     regAttributes: {feeRecipient: Eth1Address; gasLimit: number},
     _slot: Slot
   ): Promise<bellatrix.SignedValidatorRegistrationV1> {
-    const pubkey = typeof pubkeyMaybeHex === "string" ? fromHexString(pubkeyMaybeHex) : pubkeyMaybeHex;
-    const feeRecipient = fromHexString(regAttributes.feeRecipient);
+    const pubkey = typeof pubkeyMaybeHex === "string" ? fromHex(pubkeyMaybeHex) : pubkeyMaybeHex;
+    const feeRecipient = fromHex(regAttributes.feeRecipient);
     const {gasLimit} = regAttributes;
 
     const validatorRegistration: bellatrix.ValidatorRegistrationV1 = {
@@ -775,7 +775,7 @@ export class ValidatorStore {
             signingSlot,
             signableMessage
           );
-          return fromHexString(signatureHex);
+          return fromHex(signatureHex);
         } catch (e) {
           this.metrics?.remoteSignErrors.inc();
           throw e;

--- a/packages/validator/src/slashingProtection/interchange/formats/completeV4.ts
+++ b/packages/validator/src/slashingProtection/interchange/formats/completeV4.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString} from "@chainsafe/ssz";
-import {toPubkeyHex, toRootHex} from "@lodestar/utils";
+import {fromHex, toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {InterchangeLodestar} from "../types.js";
 import {fromOptionalHexString, numToString, toOptionalHexString} from "../../utils.js";
 
@@ -110,9 +109,9 @@ export function serializeInterchangeCompleteV4({
 
 export function parseInterchangeCompleteV4(interchange: InterchangeCompleteV4): InterchangeLodestar {
   return {
-    genesisValidatorsRoot: fromHexString(interchange.metadata.genesis_validators_root),
+    genesisValidatorsRoot: fromHex(interchange.metadata.genesis_validators_root),
     data: interchange.data.map((validator) => ({
-      pubkey: fromHexString(validator.pubkey),
+      pubkey: fromHex(validator.pubkey),
       signedBlocks: validator.signed_blocks.map((block) => ({
         slot: parseInt(block.slot, 10),
         signingRoot: fromOptionalHexString(block.signing_root),

--- a/packages/validator/src/slashingProtection/interchange/formats/v5.ts
+++ b/packages/validator/src/slashingProtection/interchange/formats/v5.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import {fromHexString} from "@chainsafe/ssz";
-import {toPubkeyHex, toRootHex} from "@lodestar/utils";
+import {fromHex, toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {InterchangeLodestar} from "../types.js";
 import {fromOptionalHexString, numToString, toOptionalHexString} from "../../utils.js";
 
@@ -105,9 +104,9 @@ export function serializeInterchangeV5({data, genesisValidatorsRoot}: Interchang
 
 export function parseInterchangeV5(interchange: InterchangeV5): InterchangeLodestar {
   return {
-    genesisValidatorsRoot: fromHexString(interchange.metadata.genesis_validators_root),
+    genesisValidatorsRoot: fromHex(interchange.metadata.genesis_validators_root),
     data: interchange.data.map((validator) => ({
-      pubkey: fromHexString(validator.pubkey),
+      pubkey: fromHex(validator.pubkey),
       signedBlocks: validator.signed_blocks.map((block) => ({
         slot: parseInt(block.slot, 10),
         signingRoot: fromOptionalHexString(block.signing_root),

--- a/packages/validator/src/slashingProtection/utils.ts
+++ b/packages/validator/src/slashingProtection/utils.ts
@@ -1,6 +1,5 @@
-import {fromHexString} from "@chainsafe/ssz";
 import {Epoch, Root, ssz} from "@lodestar/types";
-import {toHex, toRootHex} from "@lodestar/utils";
+import {fromHex, toHex, toRootHex} from "@lodestar/utils";
 
 export const blsPubkeyLen = 48;
 export const ZERO_ROOT = ssz.Root.defaultValue();
@@ -14,7 +13,7 @@ export function isEqualNonZeroRoot(root1: Root, root2: Root): boolean {
 }
 
 export function fromOptionalHexString(hex: string | undefined): Root {
-  return hex ? fromHexString(hex) : ZERO_ROOT;
+  return hex ? fromHex(hex) : ZERO_ROOT;
 }
 
 export function toOptionalHexString(root: Root): string | undefined {


### PR DESCRIPTION
**Motivation**

Similar to #7075 we should use `fromHex` instead of `fromHexString` because it has better performance on NodeJS

**Description**

- Use the isomorphic `fromHex()` api instead of `fromHexString()` of ssz
