### PR TITLE
feat: implement BalancesTreeCache

### DIFF
--- a/packages/beacon-node/src/chain/archiver/index.ts
+++ b/packages/beacon-node/src/chain/archiver/index.ts
@@ -107,7 +107,7 @@ export class Archiver {
       // should be after ArchiveBlocksTask to handle restart cleanly
       await this.statesArchiver.maybeArchiveState(finalized);
 
-      this.chain.regen.pruneOnFinalized(finalizedEpoch);
+      this.chain.pruneOnFinalized(finalizedEpoch);
 
       // tasks rely on extended fork choice
       const prunedBlocks = this.chain.forkChoice.prune(finalized.rootHex);

--- a/packages/beacon-node/src/chain/balancesTreeCache.ts
+++ b/packages/beacon-node/src/chain/balancesTreeCache.ts
@@ -21,7 +21,7 @@ export class BalancesTreeCache implements IBalancesTreeCache {
     }
 
     this.unusedBalancesTrees.push(state.balances);
-    if (this.unusedBalancesTrees.length > MAX_ITEMS) {
+    while (this.unusedBalancesTrees.length > MAX_ITEMS) {
       this.unusedBalancesTrees.shift();
     }
   }

--- a/packages/beacon-node/src/chain/balancesTreeCache.ts
+++ b/packages/beacon-node/src/chain/balancesTreeCache.ts
@@ -1,0 +1,38 @@
+import {ListBasicTreeViewDU, UintNumberType} from "@chainsafe/ssz";
+import {IBalancesTreeCache, CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {Metrics} from "../metrics/index.js";
+
+const MAX_ITEMS = 2;
+
+export class BalancesTreeCache implements IBalancesTreeCache {
+  private readonly unusedBalancesTrees: ListBasicTreeViewDU<UintNumberType>[] = [];
+
+  constructor(private readonly metrics: Metrics | null = null) {
+    if (metrics) {
+      metrics.balancesTreeCache.size.addCollect(() => {
+        metrics.balancesTreeCache.size.set(this.unusedBalancesTrees.length);
+      });
+    }
+  }
+
+  processUnusedState(state: CachedBeaconStateAllForks | undefined): void {
+    if (state === undefined) {
+      return;
+    }
+
+    this.unusedBalancesTrees.push(state.balances);
+    if (this.unusedBalancesTrees.length > MAX_ITEMS) {
+      this.unusedBalancesTrees.shift();
+    }
+  }
+
+  getUnusedBalances(): ListBasicTreeViewDU<UintNumberType> | undefined {
+    if (this.unusedBalancesTrees.length === 0) {
+      this.metrics?.balancesTreeCache.miss.inc();
+      return undefined;
+    }
+
+    this.metrics?.balancesTreeCache.hit.inc();
+    return this.unusedBalancesTrees.shift();
+  }
+}

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -97,7 +97,16 @@ export async function importBlock(
 
   // This adds the state necessary to process the next block
   // Some block event handlers require state being in state cache so need to do this before emitting EventType.block
-  this.regen.processState(blockRootHex, postState);
+  this.regen.processState(blockRootHex, postState).then((prunedStates) => {
+    if (prunedStates) {
+      for (const states of prunedStates.values()) {
+        // cp states on the same epoch shares the same balances seed tree so only need one of them
+        this.balancesTreeCache.processUnusedState(states[0]);
+      }
+    }
+  }).catch((e) => {
+    this.logger.error("Regen error to process state for block", {slot: blockSlot, root: blockRootHex}, e as Error);
+  });
 
   this.metrics?.importBlock.bySource.inc({source});
   this.logger.verbose("Added block to forkchoice and state cache", {slot: blockSlot, root: blockRootHex});

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -241,6 +241,8 @@ export interface IBeaconChain {
     blockRef: BeaconBlock | BlindedBeaconBlock,
     validatorIds?: (ValidatorIndex | string)[]
   ): Promise<SyncCommitteeRewards>;
+
+  pruneOnFinalized(finalizedEpoch: Epoch): void;
 }
 
 export type SSZObjectType =

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -148,16 +148,26 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     this.blockStateCache.prune(headStateRoot);
   }
 
-  pruneOnFinalized(finalizedEpoch: number): void {
-    this.checkpointStateCache.pruneFinalized(finalizedEpoch);
+  pruneOnFinalized(finalizedEpoch: number): Map<Epoch, CachedBeaconStateAllForks[]> | null {
+    const prunedStates = this.checkpointStateCache.pruneFinalized(finalizedEpoch);
     this.blockStateCache.deleteAllBeforeEpoch(finalizedEpoch);
+
+    return prunedStates;
   }
 
-  processState(blockRootHex: RootHex, postState: CachedBeaconStateAllForks): void {
+  async processState(
+    blockRootHex: RootHex,
+    postState: CachedBeaconStateAllForks
+  ): Promise<Map<Epoch, CachedBeaconStateAllForks[]> | null> {
     this.blockStateCache.add(postState);
-    this.checkpointStateCache.processState(blockRootHex, postState).catch((e) => {
-      this.logger.debug("Error processing block state", {blockRootHex, slot: postState.slot}, e);
-    });
+    let prunedStates: Map<Epoch, CachedBeaconStateAllForks[]> | null = null;
+    try {
+      prunedStates = await this.checkpointStateCache.processState(blockRootHex, postState);
+    } catch (e) {
+      this.logger.debug("Error processing block state", {blockRootHex, slot: postState.slot}, e as Error);
+    }
+
+    return prunedStates;
   }
 
   addCheckpointState(cp: phase0.Checkpoint, item: CachedBeaconStateAllForks): void {

--- a/packages/beacon-node/src/chain/stateCache/inMemoryCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/inMemoryCheckpointsCache.ts
@@ -59,9 +59,9 @@ export class InMemoryCheckpointStateCache implements CheckpointStateCache {
     return this.getLatest(rootHex, maxEpoch, opts);
   }
 
-  async processState(): Promise<number> {
+  async processState(): Promise<Map<Epoch, CachedBeaconStateAllForks[]> | null> {
     // do nothing, this class does not support prunning
-    return 0;
+    return null;
   }
 
   get(cp: CheckpointHex, opts?: StateCloneOpts): CachedBeaconStateAllForks | null {
@@ -122,12 +122,17 @@ export class InMemoryCheckpointStateCache implements CheckpointStateCache {
     return previousHits;
   }
 
-  pruneFinalized(finalizedEpoch: Epoch): void {
+  pruneFinalized(finalizedEpoch: Epoch): Map<Epoch, CachedBeaconStateAllForks[]> {
+    const result = new Map<Epoch, CachedBeaconStateAllForks[]>();
+
     for (const epoch of this.epochIndex.keys()) {
       if (epoch < finalizedEpoch) {
-        this.deleteAllEpochItems(epoch);
+        const deletedStates = this.deleteAllEpochItems(epoch);
+        result.set(epoch, deletedStates);
       }
     }
+
+    return result;
   }
 
   prune(finalizedEpoch: Epoch, justifiedEpoch: Epoch): void {
@@ -153,11 +158,19 @@ export class InMemoryCheckpointStateCache implements CheckpointStateCache {
     }
   }
 
-  deleteAllEpochItems(epoch: Epoch): void {
+  deleteAllEpochItems(epoch: Epoch): CachedBeaconStateAllForks[] {
+    const states = [];
     for (const rootHex of this.epochIndex.get(epoch) || []) {
-      this.cache.delete(toCheckpointKey({rootHex, epoch}));
+      const key = toCheckpointKey({rootHex, epoch});
+      const state = this.cache.get(key);
+      if (state) {
+        states.push(state);
+      }
+      this.cache.delete(key);
     }
     this.epochIndex.delete(epoch);
+
+    return states;
   }
 
   clear(): void {

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -421,7 +421,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   /**
    * Prune all checkpoint states before the provided finalized epoch.
    */
-  pruneFinalized(finalizedEpoch: Epoch): void {
+  pruneFinalized(finalizedEpoch: Epoch): Map<Epoch, CachedBeaconStateAllForks[]> | null {
     for (const epoch of this.epochIndex.keys()) {
       if (epoch < finalizedEpoch) {
         this.deleteAllEpochItems(epoch).catch((e) =>
@@ -429,6 +429,9 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
         );
       }
     }
+
+    // not likely to return anything in-memory state because we may persist states even before they are finalized
+    return null;
   }
 
   /**
@@ -481,12 +484,14 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    *
    * As of Mar 2024, it takes <=350ms to persist a holesky state on fast server
    */
-  async processState(blockRootHex: RootHex, state: CachedBeaconStateAllForks): Promise<number> {
-    let persistCount = 0;
+  async processState(
+    blockRootHex: RootHex,
+    state: CachedBeaconStateAllForks
+  ): Promise<Map<Epoch, CachedBeaconStateAllForks[]> | null> {
     // it's important to sort the epochs in ascending order, in case of big reorg we always want to keep the most recent checkpoint states
     const sortedEpochs = Array.from(this.epochIndex.keys()).sort((a, b) => a - b);
     if (sortedEpochs.length <= this.maxEpochsInMemory) {
-      return 0;
+      return null;
     }
 
     const blockSlot = state.slot;
@@ -502,24 +507,19 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       // normally the block persist happens at 2/3 of slot 0 of epoch, if it's already late then just skip to allow other tasks to run
       // there are plenty of chances in the same epoch to persist checkpoint states, also if block is late it could be reorged
       this.logger.verbose("Skip persist checkpoint states", {blockSlot, root: blockRootHex});
-      return 0;
+      return null;
     }
 
     const persistEpochs = sortedEpochs.slice(0, sortedEpochs.length - this.maxEpochsInMemory);
+
+    const result = new Map<Epoch, CachedBeaconStateAllForks[]>();
     for (const lowestEpoch of persistEpochs) {
       // usually there is only 0 or 1 epoch to persist in this loop
-      persistCount += await this.processPastEpoch(blockRootHex, state, lowestEpoch);
+      const prunedStates = await this.processPastEpoch(blockRootHex, state, lowestEpoch);
+      result.set(lowestEpoch, prunedStates);
     }
 
-    if (persistCount > 0) {
-      this.logger.verbose("Persisted checkpoint states", {
-        slot: blockSlot,
-        root: blockRootHex,
-        persistCount,
-        persistEpochs: persistEpochs.length,
-      });
-    }
-    return persistCount;
+    return result;
   }
 
   /**
@@ -648,13 +648,16 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    * Performance note:
    *   - In normal condition, we persist 1 checkpoint state per epoch.
    *   - In reorged condition, we may persist multiple (most likely 2) checkpoint states per epoch.
+   *
+   * Return the pruned states from memory
    */
   private async processPastEpoch(
     blockRootHex: RootHex,
     state: CachedBeaconStateAllForks,
     epoch: Epoch
-  ): Promise<number> {
+  ): Promise<CachedBeaconStateAllForks[]> {
     let persistCount = 0;
+    const prunedStates: CachedBeaconStateAllForks[] = [];
     const epochBoundarySlot = computeStartSlotAtEpoch(epoch);
     const epochBoundaryRoot =
       epochBoundarySlot === state.slot ? fromHexString(blockRootHex) : getBlockRootAtSlot(state, epochBoundarySlot);
@@ -735,10 +738,20 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
           this.metrics?.statePruneFromMemoryCount.inc();
           this.logger.verbose("Pruned checkpoint state from memory", logMeta);
         }
+
+        prunedStates.push(state);
       }
     }
 
-    return persistCount;
+    if (persistCount > 0) {
+      this.logger.verbose("Persisted checkpoint states", {
+        stateSlot: state.slot,
+        blockRoot: blockRootHex,
+        persistCount,
+      });
+    }
+
+    return prunedStates;
   }
 
   /**

--- a/packages/beacon-node/src/chain/stateCache/types.ts
+++ b/packages/beacon-node/src/chain/stateCache/types.ts
@@ -72,8 +72,11 @@ export interface CheckpointStateCache {
   ): Promise<CachedBeaconStateAllForks | null>;
   updatePreComputedCheckpoint(rootHex: RootHex, epoch: Epoch): number | null;
   prune(finalizedEpoch: Epoch, justifiedEpoch: Epoch): void;
-  pruneFinalized(finalizedEpoch: Epoch): void;
-  processState(blockRootHex: RootHex, state: CachedBeaconStateAllForks): Promise<number>;
+  pruneFinalized(finalizedEpoch: Epoch): Map<Epoch, CachedBeaconStateAllForks[]> | null;
+  processState(
+    blockRootHex: RootHex,
+    state: CachedBeaconStateAllForks
+  ): Promise<Map<Epoch, CachedBeaconStateAllForks[]> | null>;
   clear(): void;
   dumpSummary(): routes.lodestar.StateCacheItem[];
   /** Expose beacon states stored in cache. Use with caution */

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1315,6 +1315,21 @@ export function createLodestarMetrics(
       }),
     },
 
+    balancesTreeCache: {
+      size: register.gauge({
+        name: "lodestar_balances_tree_cache_size",
+        help: "Balances tree cache size",
+      }),
+      hit: register.gauge({
+        name: "lodestar_balances_tree_cache_hit_total",
+        help: "Total number of balances tree cache hits",
+      }),
+      miss: register.gauge({
+        name: "lodestar_balances_tree_cache_miss_total",
+        help: "Total number of balances tree cache misses",
+      }),
+    },
+
     seenCache: {
       aggregatedAttestations: {
         superSetCheckTotal: register.histogram({

--- a/packages/state-transition/src/cache/balancesTreeCache.ts
+++ b/packages/state-transition/src/cache/balancesTreeCache.ts
@@ -1,0 +1,5 @@
+import {UintNumberType, ListBasicTreeViewDU} from "@chainsafe/ssz";
+
+export interface IBalancesTreeCache {
+  getUnusedBalances(): ListBasicTreeViewDU<UintNumberType> | undefined;
+}

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -60,6 +60,7 @@ import {
   SyncCommitteeCache,
   SyncCommitteeCacheEmpty,
 } from "./syncCommitteeCache.js";
+import {IBalancesTreeCache} from "./balancesTreeCache.js";
 
 /** `= PROPOSER_WEIGHT / (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT)` */
 export const PROPOSER_WEIGHT_FACTOR = PROPOSER_WEIGHT / (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT);
@@ -68,6 +69,7 @@ export type EpochCacheImmutableData = {
   config: BeaconConfig;
   pubkey2index: PubkeyIndexMap;
   index2pubkey: Index2PubkeyCache;
+  balancesTreeCache?: IBalancesTreeCache;
 };
 
 export type EpochCacheOpts = {
@@ -128,6 +130,8 @@ export class EpochCache {
    * Unique pubkey registry shared in the same fork. There should only exist one for the fork.
    */
   unfinalizedPubkey2index: UnfinalizedPubkeyIndexMap;
+
+  balancesTreeCache?: IBalancesTreeCache;
 
   /**
    * Indexes of the block proposers for the current epoch.
@@ -245,6 +249,7 @@ export class EpochCache {
     pubkey2index: PubkeyIndexMap;
     index2pubkey: Index2PubkeyCache;
     unfinalizedPubkey2index: UnfinalizedPubkeyIndexMap;
+    balancesTreeCache?: IBalancesTreeCache;
     proposers: number[];
     proposersPrevEpoch: number[] | null;
     proposersNextEpoch: ProposersDeferred;
@@ -273,6 +278,7 @@ export class EpochCache {
     this.pubkey2index = data.pubkey2index;
     this.index2pubkey = data.index2pubkey;
     this.unfinalizedPubkey2index = data.unfinalizedPubkey2index;
+    this.balancesTreeCache = data.balancesTreeCache;
     this.proposers = data.proposers;
     this.proposersPrevEpoch = data.proposersPrevEpoch;
     this.proposersNextEpoch = data.proposersNextEpoch;
@@ -306,7 +312,7 @@ export class EpochCache {
    */
   static createFromState(
     state: BeaconStateAllForks,
-    {config, pubkey2index, index2pubkey}: EpochCacheImmutableData,
+    {config, pubkey2index, index2pubkey, balancesTreeCache}: EpochCacheImmutableData,
     opts?: EpochCacheOpts
   ): EpochCache {
     const currentEpoch = computeEpochAtSlot(state.slot);
@@ -483,6 +489,7 @@ export class EpochCache {
       index2pubkey,
       // `createFromFinalizedState()` creates cache with empty unfinalizedPubkey2index. Be cautious to only pass in finalized state
       unfinalizedPubkey2index: newUnfinalizedPubkeyIndexMap(),
+      balancesTreeCache,
       proposers,
       // On first epoch, set to null to prevent unnecessary work since this is only used for metrics
       proposersPrevEpoch: null,

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -531,6 +531,7 @@ export class EpochCache {
       index2pubkey: this.index2pubkey,
       // No need to clone this reference. On each mutation the `unfinalizedPubkey2index` reference is replaced, @see `addPubkey`
       unfinalizedPubkey2index: this.unfinalizedPubkey2index,
+      balancesTreeCache: this.balancesTreeCache,
       // Immutable data
       proposers: this.proposers,
       proposersPrevEpoch: this.proposersPrevEpoch,

--- a/packages/state-transition/src/epoch/processRewardsAndPenalties.ts
+++ b/packages/state-transition/src/epoch/processRewardsAndPenalties.ts
@@ -39,7 +39,7 @@ export function processRewardsAndPenalties(
 
   // important: do not change state one balance at a time. Set them all at once, constructing the tree in one go
   // cache the balances array, too
-  state.balances = ssz.phase0.Balances.toViewDU(balances);
+  state.balances = ssz.phase0.Balances.toViewDU(balances, state.epochCtx.balancesTreeCache?.getUnusedBalances());
 
   // For processEffectiveBalanceUpdates() to prevent having to re-compute the balances array.
   // For validator metrics

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -42,6 +42,7 @@ export {
   EpochCacheErrorCode,
 } from "./cache/epochCache.js";
 export {type EpochTransitionCache, beforeProcessEpoch} from "./cache/epochTransitionCache.js";
+export type {IBalancesTreeCache} from "./cache/balancesTreeCache.js";
 
 // Aux data-structures
 export {


### PR DESCRIPTION
**Motivation**

- At every epoch transition, we always create `balances` tree from scratch and it causes memory spikes at `processRewardsAndPenalties` step (10m) chart:

<img width="1321" alt="Screenshot 2024-09-14 at 14 33 10" src="https://github.com/user-attachments/assets/0d0a7cc4-c09d-43d4-80f6-88cf1abc1aab">

- while after a state is finalized, we remove checkpoint state and don't use it anymore. We can recreate the `balances` tree using that unused `balances` tree from that state leveraging https://github.com/ChainSafe/ssz/pull/402 

- see also #6229

**Description**

- create `BalancesTreeCache` which is populated after we remove a checkpoint state, and consume by epoch transition using same design of #6938
  - state-transition defines `IBalancesTreeCache` interface and consume it if exists
  - spec test does not have it
  - prod node provide an implementation of `BalancesTreeCache` and put that to `EpochCache`
- use this api https://github.com/ChainSafe/ssz/pull/402 `ListUintNum64Type.toViewDU(value, viewDU)` 

Resolves #6229

**Testing**

- `processRewardsAndPenalties` 10m is improved a lot, there are 2 spikes in 12h time frame, most likely due to `batchHashTreeRoot()` we used inside `ListUintNum64Type.toViewDU(value, viewDU)`

<img width="1324" alt="Screenshot 2024-09-14 at 14 42 13" src="https://github.com/user-attachments/assets/5cd28ef7-a90e-4f52-b6d9-0d77445c9a58">

- 6h chart shows ~250ms save in average
<img width="1390" alt="Screenshot 2024-09-14 at 14 44 29" src="https://github.com/user-attachments/assets/ce8d4e56-2c8e-414f-9bfc-971a44f5a79e">

- but `prepareNextEpoch` is saved ~350ms because we hashed `state.balances` in `ListUintNum64Type.toViewDU(value, viewDU)`, and that's majority of hash work for `prepareNextEpoch`

<img width="1524" alt="Screenshot 2024-09-14 at 14 47 28" src="https://github.com/user-attachments/assets/db8b9483-f366-42e2-9cd5-cfe98cafabed">

- `state.hashTreeRoot()` is ~~not~~ a little bit confusing, but majority of work is done by this work and `state.validators.commit()`
<img width="853" alt="Screenshot 2024-09-14 at 14 49 01" src="https://github.com/user-attachments/assets/1dbd0c9b-2d73-491c-abac-6bf5ff2cb786">



