### PR TITLE
fix: use bigint gwei type for amount in requests instead of num 64

### DIFF
--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -461,7 +461,7 @@ export function deserializeWithdrawalRequest(withdrawalRequest: WithdrawalReques
   return {
     sourceAddress: dataToBytes(withdrawalRequest.sourceAddress, 20),
     validatorPubkey: dataToBytes(withdrawalRequest.validatorPubkey, 48),
-    amount: quantityToNum(withdrawalRequest.amount),
+    amount: quantityToBigint(withdrawalRequest.amount),
   };
 }
 

--- a/packages/types/src/electra/sszTypes.ts
+++ b/packages/types/src/electra/sszTypes.ts
@@ -116,7 +116,7 @@ export const DepositRequest = new ContainerType(
   {
     pubkey: BLSPubkey,
     withdrawalCredentials: Bytes32,
-    amount: UintNum64,
+    amount: Gwei,
     signature: BLSSignature,
     index: DepositIndex,
   },
@@ -129,7 +129,7 @@ export const WithdrawalRequest = new ContainerType(
   {
     sourceAddress: ExecutionAddress,
     validatorPubkey: BLSPubkey,
-    amount: UintNum64,
+    amount: Gwei,
   },
   {typeName: "WithdrawalRequest", jsonCase: "eth2"}
 );

--- a/packages/types/src/electra/sszTypes.ts
+++ b/packages/types/src/electra/sszTypes.ts
@@ -116,7 +116,9 @@ export const DepositRequest = new ContainerType(
   {
     pubkey: BLSPubkey,
     withdrawalCredentials: Bytes32,
-    amount: Gwei,
+    // this is actually gwei uintbn64 type, but super unlikely to get a high amount here
+    // to warrant a bn type
+    amount: UintNum64,
     signature: BLSSignature,
     index: DepositIndex,
   },


### PR DESCRIPTION
amount type in the requests are 64 bit gwei which is to be treated as a uintbn64 ssz type and not uintnum64

the bug lead to incorrect amount deserializing in block because of inherent limitations of number type in javascript object leading to incorrect calculation of hash in a devnet3 block causing lodestar nodes to stall

this PR fixes