### PR TITLE
fix: adjust n-historical-states param

### DIFF
--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -111,7 +111,7 @@ export const defaultChainOptions: IChainOptions = {
   // batching too much may block the I/O thread so if useWorker=false, suggest this value to be 32
   // since this batch attestation work is designed to work with useWorker=true, make this the lowest value
   minSameMessageSignatureSetsToBatch: 2,
-  nHistoricalStates: false,
+  nHistoricalStates: true,
   nHistoricalStatesFileDataStore: false,
   maxBlockStates: DEFAULT_MAX_BLOCK_STATES,
   maxCPStateEpochsInMemory: DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY,

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -218,7 +218,7 @@ export class StateRegenerator implements IStateRegeneratorInternal {
       blockPromises[i] = this.modules.db.block.get(fromHex(protoBlock.blockRoot));
     }
 
-    const logCtx = {stateRoot, replaySlots: replaySlots.join(",")};
+    const logCtx = {stateRoot, caller, replaySlots: replaySlots.join(",")};
     this.modules.logger.debug("Replaying blocks to get state", logCtx);
 
     const loadBlocksTimer = this.modules.metrics?.regenGetState.loadBlocks.startTimer({caller});

--- a/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
@@ -13,9 +13,14 @@ export type FIFOBlockStateCacheOpts = {
 };
 
 /**
- * Regen state if there's a reorg distance > 32 slots.
+ * Given `maxSkipSlots` = 32 and `DEFAULT_EARLIEST_PERMISSIBLE_SLOT_DISTANCE` = 32, lodestar doesn't need to
+ * reload states in order to process a gossip block.
+ *
+ * |-----------------------------------------------|-----------------------------------------------|
+ *                 maxSkipSlots                      DEFAULT_EARLIEST_PERMISSIBLE_SLOT_DISTANCE    ^
+ *                                                                                             clock slot
  */
-export const DEFAULT_MAX_BLOCK_STATES = 32;
+export const DEFAULT_MAX_BLOCK_STATES = 64;
 
 /**
  * New implementation of BlockStateCache that keeps the most recent n states consistently

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -53,10 +53,11 @@ type CacheItem = InMemoryCacheItem | PersistedCacheItem;
 type LoadedStateBytesData = {persistedKey: DatastoreKey; stateBytes: Uint8Array};
 
 /**
- * Before n-historical states, lodestar keeps mostly 3 states in memory with 1 finalized state
- * Since Jan 2024, lodestar stores the finalized state in disk and keeps up to 2 epochs in memory
+ * Before n-historical states, lodestar keeps all checkpoint states since finalized
+ * Since Sep 2024, lodestar stores 3 most recent checkpoint states in memory and the rest on disk. The finalized state
+ * may not be available in memory, and stay on disk instead.
  */
-export const DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY = 2;
+export const DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY = 3;
 
 /**
  * An implementation of CheckpointStateCache that keep up to n epoch checkpoint states in memory and persist the rest to disk

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -144,6 +144,18 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
     const blockInputMeta =
       config.getForkSeq(signedBlock.message.slot) >= ForkSeq.deneb ? blockInputRes.blockInputMeta : {};
 
+    const logCtx = {
+      slot: slot,
+      root: blockHex,
+      curentSlot: chain.clock.currentSlot,
+      peerId: peerIdStr,
+      delaySec,
+      ...blockInputMeta,
+      recvToValLatency,
+    };
+
+    logger.debug("Received gossip block", {...logCtx});
+
     try {
       await validateGossipBlock(config, chain, signedBlock, fork);
 
@@ -153,17 +165,7 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
       metrics?.gossipBlock.gossipValidation.recvToValidation.observe(recvToValidation);
       metrics?.gossipBlock.gossipValidation.validationTime.observe(validationTime);
 
-      logger.debug("Received gossip block", {
-        slot: slot,
-        root: blockHex,
-        curentSlot: chain.clock.currentSlot,
-        peerId: peerIdStr,
-        delaySec,
-        ...blockInputMeta,
-        recvToValLatency,
-        recvToValidation,
-        validationTime,
-      });
+      logger.debug("Validated gossip block", {...logCtx, recvToValidation, validationTime});
 
       return blockInput;
     } catch (e) {

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -147,7 +147,7 @@ function getDefaultHandlers(modules: ValidatorFnsModules, options: GossipHandler
     const logCtx = {
       slot: slot,
       root: blockHex,
-      curentSlot: chain.clock.currentSlot,
+      currentSlot: chain.clock.currentSlot,
       peerId: peerIdStr,
       delaySec,
       ...blockInputMeta,


### PR DESCRIPTION
**Motivation**

In holesky, lodestar had to reload and regen state for a weird orphaned block

```
Sep-22 00:17:11.240[chain]           ^[[34mdebug^[[39m: Replayed blocks to get state stateRoot=0x6f30844c4055a9e5567eab7fc205a7de97d7d40ca1e53b56a6381dcce4f58fd2, replaySlots=2588428,2588427,2588425,2588424,2588423,2588422,2588421,2588420,2588419,2588418,2588417
Sep-22 00:17:12.740[chain]         ^[[36mverbose^[[39m: Added checkpoint state to memory epoch=80889, rootHex=0xf41b326bcb2c7dfb29cf52dd0c70fd14dd58b280cf3069ff14dcc38b3ea9d2d0
Sep-22 00:17:12.740[chain]         ^[[36mverbose^[[39m: Clock slot slot=2588486  ====== epoch 80890
Sep-22 00:17:12.765[network]         ^[[34mdebug^[[39m: Received gossip block slot=2588454, root=0x5c40…cdc1, curentSlot=2588486, peerId=16Uiu2HAm5mSqbUSWaUwUHpDjy6VSoQAtdic7xnfshhZjsTiK35yh, delaySec=376.0390000343323, pending=blob, haveBlobs=0, expectedBlobs=3, recvToValLatency=0.034999847412109375, recvToValidation=8.7260000705719, validationTime=8.69100022315979
```

this happens on a n-historical states node

**Description**

- Change `DEFAULT_MAX_BLOCK_STATES` to 64, this guarantees we don't have to reload state due to gossip block
- Due to that, change `DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY` to 3.

| #  | current config | n-historical-states default config|
| ------------- | ------------- | ------------- |
|block state cache size| 64-96 | 64 |
|checkpoint state cache epochs| 3-4| 3 |

- Modify some logs to make it easier to debug later
