### PR TITLE
feat: set proper user-agent in validator client http requests

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -157,6 +157,7 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
         globalInit: {
           requestWireFormat: parseWireFormat(args, "http.requestWireFormat"),
           responseWireFormat: parseWireFormat(args, "http.responseWireFormat"),
+          headers: {"User-Agent": `Lodestar/${version}`},
         },
       },
       logger,


### PR DESCRIPTION
**Motivation**

- https://github.com/ChainSafe/lodestar/issues/6959

**Description**

Set proper user-agent in validator client http requests

e.g.
```
Lodestar/v1.22.0/d0ba6bc
```

Closes https://github.com/ChainSafe/lodestar/issues/6959