### PR TITLE
feat: add validator identities endpoint

### DIFF
--- a/packages/api/src/beacon/routes/beacon/index.ts
+++ b/packages/api/src/beacon/routes/beacon/index.ts
@@ -25,6 +25,7 @@ export type {
 export type {
   StateId,
   ValidatorId,
+  ValidatorIdentities,
   ValidatorStatus,
   FinalityCheckpoints,
   ValidatorResponse,

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -21,9 +21,9 @@ import {testData as validatorTestData} from "./testData/validator.js";
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const version = "v2.6.0-alpha.1";
+const version = "v3.0.0-alpha.6";
 const openApiFile: OpenApiFile = {
-  url: `https://raw.githubusercontent.com/nflaig/beacon-api-spec/main/${version}/beacon-node-oapi.json`,
+  url: `https://github.com/ethereum/beacon-APIs/releases/download/${version}/beacon-node-oapi.json`,
   filepath: path.join(__dirname, "../../../oapi-schemas/beacon-node-oapi.json"),
   version: RegExp(version),
 };

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -191,6 +191,13 @@ export const testData: GenericServerTestCases<Endpoints> = {
     args: {stateId: "head", validatorIds: [pubkeyHex, 1300], statuses: ["active_ongoing"]},
     res: {data: [validatorResponse], meta: {executionOptimistic: true, finalized: false}},
   },
+  postStateValidatorIdentities: {
+    args: {stateId: "head", validatorIds: [1300]},
+    res: {
+      data: [{index: 1300, pubkey: ssz.BLSPubkey.defaultValue(), activationEpoch: 1}],
+      meta: {executionOptimistic: true, finalized: false},
+    },
+  },
   getStateValidator: {
     args: {stateId: "head", validatorId: pubkeyHex},
     res: {data: validatorResponse, meta: {executionOptimistic: true, finalized: false}},

--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -134,9 +134,10 @@ export function getBeaconStateApi({
       const {state, executionOptimistic, finalized} = await getStateResponse(chain, stateId);
       const {pubkey2index} = chain.getHeadState().epochCtx;
 
-      const validatorIdentities: routes.beacon.ValidatorIdentities = [];
+      let validatorIdentities: routes.beacon.ValidatorIdentities;
 
       if (validatorIds.length) {
+        validatorIdentities = [];
         for (const id of validatorIds) {
           const resp = getStateValidatorIndex(id, state, pubkey2index);
           if (resp.valid) {
@@ -147,9 +148,10 @@ export function getBeaconStateApi({
         }
       } else {
         const validatorsArr = state.validators.getAllReadonlyValues();
+        validatorIdentities = new Array(validatorsArr.length) as routes.beacon.ValidatorIdentities;
         for (let i = 0; i < validatorsArr.length; i++) {
           const {pubkey, activationEpoch} = validatorsArr[i];
-          validatorIdentities.push({index: i, pubkey, activationEpoch});
+          validatorIdentities[i] = {index: i, pubkey, activationEpoch};
         }
       }
 

--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -22,7 +22,8 @@ import {
 export function getBeaconStateApi({
   chain,
   config,
-}: Pick<ApiModules, "chain" | "config">): ApplicationMethods<routes.beacon.state.Endpoints> {
+  logger,
+}: Pick<ApiModules, "chain" | "config" | "logger">): ApplicationMethods<routes.beacon.state.Endpoints> {
   async function getState(
     stateId: routes.beacon.StateId
   ): Promise<{state: BeaconStateAllForks; executionOptimistic: boolean; finalized: boolean}> {
@@ -98,6 +99,8 @@ export function getBeaconStateApi({
               currentEpoch
             );
             validatorResponses.push(validatorResponse);
+          } else {
+            logger.warn(resp.reason, {id});
           }
         }
         return {
@@ -144,6 +147,8 @@ export function getBeaconStateApi({
             const index = resp.validatorIndex;
             const {pubkey, activationEpoch} = state.validators.getReadonly(index);
             validatorIdentities.push({index, pubkey, activationEpoch});
+          } else {
+            logger.warn(resp.reason, {id});
           }
         }
       } else {


### PR DESCRIPTION
**Motivation**

- https://github.com/ethereum/beacon-APIs/pull/452

**Description**

Adds validator identities endpoint which is a much more lightweight alternative to retrieve the validator index from state compared to [getStateValidators](https://ethereum.github.io/beacon-APIs/#/Beacon/getStateValidators) and also allows SSZ encoding of response.

There still needs to be another endpoint (see https://github.com/ethereum/beacon-APIs/pull/449) before we can make use of this in the validator client as we currently also print out the status of the validator (although this is purely informational) but other clients that only need the index can make use of this as is.

Keep as draft for now until spec PR is merged.

Closes https://github.com/ChainSafe/lodestar/issues/7105