### PR TITLE
fix: update HTTP error response format to be spec compliant

### DIFF
--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -15,6 +15,7 @@ export type RestApiServerOpts = {
   bearerToken?: string;
   headerLimit?: number;
   bodyLimit?: number;
+  stacktraces?: boolean;
   swaggerUI?: boolean;
 };
 
@@ -30,9 +31,25 @@ export type RestApiServerMetrics = SocketMetrics & {
 };
 
 /**
+ * Error response body format as defined in beacon-api spec
+ *
+ * See https://github.com/ethereum/beacon-APIs/blob/v2.5.0/types/http.yaml
+ */
+type ErrorResponse = {
+  code: number;
+  message: string;
+  stacktraces?: string[];
+};
+
+/**
  * Error code used by Fastify if media type is not supported (415)
  */
 const INVALID_MEDIA_TYPE_CODE = errorCodes.FST_ERR_CTP_INVALID_MEDIA_TYPE().code;
+
+/**
+ * Error code used by Fastify if JSON schema validation failed
+ */
+const SCHEMA_VALIDATION_ERROR_CODE = errorCodes.FST_ERR_VALIDATION().code;
 
 /**
  * REST API powered by `fastify` server.
@@ -71,13 +88,28 @@ export class RestApiServer {
 
     // To parse our ApiError -> statusCode
     server.setErrorHandler((err, _req, res) => {
+      const stacktraces = opts.stacktraces ? err.stack?.split("\n") : undefined;
       if (err.validation) {
-        void res.status(400).send(err.validation);
+        const {instancePath, message} = err.validation[0];
+        const payload: ErrorResponse = {
+          code: err.statusCode ?? 400,
+          message: `${instancePath.substring(instancePath.lastIndexOf("/") + 1)} ${message}`,
+          stacktraces,
+        };
+        void res.status(400).send(payload);
       } else {
         // Convert our custom ApiError into status code
         const statusCode = err instanceof ApiError ? err.statusCode : 500;
-        void res.status(statusCode).send(err);
+        const payload: ErrorResponse = {code: statusCode, message: err.message, stacktraces};
+        void res.status(statusCode).send(payload);
       }
+    });
+
+    server.setNotFoundHandler((req, res) => {
+      const message = `Route ${req.raw.method}:${req.raw.url} not found`;
+      this.logger.warn(message);
+      const payload: ErrorResponse = {code: 404, message};
+      void res.code(404).send(payload);
     });
 
     if (opts.cors) {
@@ -127,7 +159,7 @@ export class RestApiServer {
 
       const operationId = getOperationId(req);
 
-      if (err instanceof ApiError || err.code === INVALID_MEDIA_TYPE_CODE) {
+      if (err instanceof ApiError || [INVALID_MEDIA_TYPE_CODE, SCHEMA_VALIDATION_ERROR_CODE].includes(err.code)) {
         this.logger.warn(`Req ${req.id} ${operationId} failed`, {reason: err.message});
       } else {
         this.logger.error(`Req ${req.id} ${operationId} error`, {}, err);

--- a/packages/beacon-node/src/api/rest/index.ts
+++ b/packages/beacon-node/src/api/rest/index.ts
@@ -22,6 +22,7 @@ export const beaconRestApiServerOpts: BeaconRestApiServerOpts = {
   cors: "*",
   // beacon -> validator API is trusted, and for large amounts of keys the payload is multi-MB
   bodyLimit: 20 * 1024 * 1024, // 20MB for big block + blobs
+  stacktraces: false,
 };
 
 export type BeaconRestApiServerModules = RestApiServerModules & {

--- a/packages/cli/src/cmds/dev/options.ts
+++ b/packages/cli/src/cmds/dev/options.ts
@@ -90,6 +90,10 @@ const externalOptionsOverrides: Partial<Record<"network" | keyof typeof beaconNo
     defaultDescription: undefined,
     default: true,
   },
+  "rest.stacktraces": {
+    ...beaconNodeOptions["rest.stacktraces"],
+    default: true,
+  },
   "rest.swaggerUI": {
     ...beaconNodeOptions["rest.swaggerUI"],
     default: true,

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -209,6 +209,7 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
         isAuthEnabled: args["keymanager.auth"],
         headerLimit: args["keymanager.headerLimit"],
         bodyLimit: args["keymanager.bodyLimit"],
+        stacktraces: args["keymanager.stacktraces"],
         tokenFile: args["keymanager.tokenFile"],
         tokenDir: dbPath,
       },

--- a/packages/cli/src/cmds/validator/keymanager/server.ts
+++ b/packages/cli/src/cmds/validator/keymanager/server.ts
@@ -21,6 +21,7 @@ export const keymanagerRestApiServerOptsDefault: KeymanagerRestApiServerOpts = {
   isAuthEnabled: true,
   // Slashing protection DB has been reported to be 3MB https://github.com/ChainSafe/lodestar/issues/4530
   bodyLimit: 20 * 1024 * 1024, // 20MB
+  stacktraces: false,
 };
 
 export type KeymanagerRestApiServerModules = RestApiServerModules & {

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -91,6 +91,7 @@ export type KeymanagerArgs = {
   "keymanager.cors"?: string;
   "keymanager.headerLimit"?: number;
   "keymanager.bodyLimit"?: number;
+  "keymanager.stacktraces"?: boolean;
 };
 
 export const keymanagerOptions: CliCommandOptions<KeymanagerArgs> = {
@@ -140,6 +141,12 @@ export const keymanagerOptions: CliCommandOptions<KeymanagerArgs> = {
     hidden: true,
     type: "number",
     description: "Defines the maximum payload, in bytes, the server is allowed to accept",
+  },
+  "keymanager.stacktraces": {
+    hidden: true,
+    type: "boolean",
+    description: "Return stacktraces in HTTP error responses",
+    group: "api",
   },
 };
 

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -146,7 +146,6 @@ export const keymanagerOptions: CliCommandOptions<KeymanagerArgs> = {
     hidden: true,
     type: "boolean",
     description: "Return stacktraces in HTTP error responses",
-    group: "api",
   },
 };
 

--- a/packages/cli/src/options/beaconNodeOptions/api.ts
+++ b/packages/cli/src/options/beaconNodeOptions/api.ts
@@ -12,6 +12,7 @@ export type ApiArgs = {
   "rest.port": number;
   "rest.headerLimit"?: number;
   "rest.bodyLimit"?: number;
+  "rest.stacktraces"?: boolean;
   "rest.swaggerUI"?: boolean;
 };
 
@@ -26,6 +27,7 @@ export function parseArgs(args: ApiArgs): IBeaconNodeOptions["api"] {
       port: args["rest.port"],
       headerLimit: args["rest.headerLimit"],
       bodyLimit: args["rest.bodyLimit"],
+      stacktraces: args["rest.stacktraces"],
       swaggerUI: args["rest.swaggerUI"],
     },
   };
@@ -90,6 +92,13 @@ export const options: CliCommandOptions<ApiArgs> = {
     hidden: true,
     type: "number",
     description: "Defines the maximum payload, in bytes, the server is allowed to accept",
+  },
+
+  "rest.stacktraces": {
+    hidden: true,
+    type: "boolean",
+    description: "Return stacktraces in HTTP error responses",
+    group: "api",
   },
 
   "rest.swaggerUI": {

--- a/packages/cli/test/sim/endpoints.test.ts
+++ b/packages/cli/test/sim/endpoints.test.ts
@@ -108,15 +108,15 @@ await env.tracker.assert(
 await env.tracker.assert("should return HTTP error responses in a spec compliant format", async () => {
   // ApiError with status 400 is thrown by handler
   const res1 = await node.api.beacon.getStateValidator({stateId: "current", validatorId: 1});
-  assert.equal(res1.json(), {code: 400, message: "Invalid block id 'current'"});
+  assert.equal(JSON.parse(await res1.text()), {code: 400, message: "Invalid block id 'current'"});
 
-  // JSON schema validation failed"
+  // JSON schema validation failed
   const res2 = await node.api.beacon.getPoolAttestationsV2({slot: "current" as unknown as number, committeeIndex: 123});
-  assert.equal(res2.json(), {code: 400, message: "slot must be integer"});
+  assert.equal(JSON.parse(await res2.text()), {code: 400, message: "slot must be integer"});
 
   // Route does not exist
   const res3 = await fetch(`${node.restPublicUrl}/not/implemented/route`);
-  assert.equal(res3.json(), {code: 404, message: "Route GET:/not/implemented/route not found"});
+  assert.equal(JSON.parse(await res3.text()), {code: 404, message: "Route GET:/not/implemented/route not found"});
 });
 
 await env.tracker.assert("BN Not Synced", async () => {

--- a/packages/cli/test/sim/endpoints.test.ts
+++ b/packages/cli/test/sim/endpoints.test.ts
@@ -108,11 +108,11 @@ await env.tracker.assert(
 await env.tracker.assert("should return HTTP error responses in a spec compliant format", async () => {
   // ApiError with status 400 is thrown by handler
   const res1 = await node.api.beacon.getStateValidator({stateId: "current", validatorId: 1});
-  assert.equal(JSON.parse(await res1.text()), {code: 400, message: "Invalid block id 'current'"});
+  assert.equal(JSON.parse(await res1.errorBody()), {code: 400, message: "Invalid block id 'current'"});
 
   // JSON schema validation failed
   const res2 = await node.api.beacon.getPoolAttestationsV2({slot: "current" as unknown as number, committeeIndex: 123});
-  assert.equal(JSON.parse(await res2.text()), {code: 400, message: "slot must be integer"});
+  assert.equal(JSON.parse(await res2.errorBody()), {code: 400, message: "slot must be integer"});
 
   // Route does not exist
   const res3 = await fetch(`${node.restPublicUrl}/not/implemented/route`);

--- a/packages/cli/test/sim/endpoints.test.ts
+++ b/packages/cli/test/sim/endpoints.test.ts
@@ -108,15 +108,15 @@ await env.tracker.assert(
 await env.tracker.assert("should return HTTP error responses in a spec compliant format", async () => {
   // ApiError with status 400 is thrown by handler
   const res1 = await node.api.beacon.getStateValidator({stateId: "current", validatorId: 1});
-  assert.equal(JSON.parse(await res1.errorBody()), {code: 400, message: "Invalid block id 'current'"});
+  assert.deepEqual(JSON.parse(await res1.errorBody()), {code: 400, message: "Invalid block id 'current'"});
 
   // JSON schema validation failed
   const res2 = await node.api.beacon.getPoolAttestationsV2({slot: "current" as unknown as number, committeeIndex: 123});
-  assert.equal(JSON.parse(await res2.errorBody()), {code: 400, message: "slot must be integer"});
+  assert.deepEqual(JSON.parse(await res2.errorBody()), {code: 400, message: "slot must be integer"});
 
   // Route does not exist
   const res3 = await fetch(`${node.restPublicUrl}/not/implemented/route`);
-  assert.equal(JSON.parse(await res3.text()), {code: 404, message: "Route GET:/not/implemented/route not found"});
+  assert.deepEqual(JSON.parse(await res3.text()), {code: 404, message: "Route GET:/not/implemented/route not found"});
 });
 
 await env.tracker.assert("BN Not Synced", async () => {

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -17,6 +17,7 @@ describe("options / beaconNodeOptions", () => {
       "rest.port": 7654,
       "rest.headerLimit": 16384,
       "rest.bodyLimit": 30e6,
+      "rest.stacktraces": true,
 
       "chain.blsVerifyAllMultiThread": true,
       "chain.blsVerifyAllMainThread": true,
@@ -122,6 +123,7 @@ describe("options / beaconNodeOptions", () => {
           port: 7654,
           headerLimit: 16384,
           bodyLimit: 30e6,
+          stacktraces: true,
         },
       },
       chain: {


### PR DESCRIPTION
**Motivation**

- https://github.com/ChainSafe/lodestar/issues/6480

**Description**

- convert error responses to consistent format as [defined by beacon-api spec](https://github.com/ethereum/beacon-APIs/blob/v2.5.0/types/http.yaml)
- log 404 errors as warnings (currently silently ignored since we don't use fastify built-in logger)
- log JSON schema validation errors as `warn` instead of `error`
- add option to include stacktraces in HTTP error responses (by setting `--rest.stacktraces` CLI flag)


Closes https://github.com/ChainSafe/lodestar/issues/6480
