### PR TITLE
fix: n-historical-states state serialization panel

### DIFF
--- a/dashboards/lodestar_state_cache_regen.json
+++ b/dashboards/lodestar_state_cache_regen.json
@@ -425,7 +425,32 @@
           },
           "mappings": []
         },
-        "overrides": []
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "epochs_in-memory"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
@@ -1325,30 +1350,6 @@
                 "value": "none"
               }
             ]
-          },
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "sec_from_slot"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
           }
         ]
       },
@@ -1378,7 +1379,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(lodestar_cp_state_cache_state_serialize_seconds_sum[$rate_interval])\n/\nrate(lodestar_cp_state_cache_state_serialize_seconds_count[$rate_interval])",
+          "expr": "rate(lodestar_state_serialize_seconds_sum{source=\"persistent_checkpoints_cache_state\"}[$rate_interval])\n/\nrate(lodestar_state_serialize_seconds_count{source=\"persistent_checkpoints_cache_state\"}[$rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "serialize_duration",
@@ -1473,6 +1474,30 @@
               },
               {
                 "id": "unit"
+              }
+            ]
+          },
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "reload_duration"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
               }
             ]
           }
@@ -1618,7 +1643,7 @@
               "options": {
                 "mode": "exclude",
                 "names": [
-                  "from_persistent"
+                  "from_memory"
                 ],
                 "prefix": "All except:",
                 "readOnly": true


### PR DESCRIPTION
**Motivation**

The metric name for state serialization was changed in #7109 so need to apply the new name to Grafana Dashboard

**Description**

- Fix state serialization metric on n-historical state row. As of Sep 2024 it takes ~300ms to ~330ms to serialize states for both mainnet and holesky


<img width="843" alt="Screenshot 2024-09-27 at 09 33 36" src="https://github.com/user-attachments/assets/7ca42dd2-aaf5-4280-aa0d-76ec79280ef3">



- there are 2 missing panels for same metric when archiving states, also the buffer pool which I don't see they fit the current Dashboard. We can discuss/address them in #7098