### PR TITLE
feat: allow to configure api client when initializing light client

### DIFF
--- a/packages/light-client/README.md
+++ b/packages/light-client/README.md
@@ -62,7 +62,7 @@ import {
 
 const config = getChainForkConfigFromNetwork("sepolia");
 const logger = getConsoleLogger({logDebug: Boolean(process.env.DEBUG)});
-const api = getApiFromUrl({urls: ["https://lodestar-sepolia.chainsafe.io"]}, {config});
+const api = getApiFromUrl("https://lodestar-sepolia.chainsafe.io", "sepolia");
 
 const lightclient = await Lightclient.initializeFromCheckpointRoot({
   config,
@@ -82,11 +82,11 @@ await lightclient.start();
 logger.info("Lightclient synced");
 
 lightclient.emitter.on(LightclientEvent.lightClientFinalityHeader, async (finalityUpdate) => {
-  logger.info(finalityUpdate);
+  logger.info("Received finality update", {slot: finalityUpdate.beacon.slot});
 });
 
 lightclient.emitter.on(LightclientEvent.lightClientOptimisticHeader, async (optimisticUpdate) => {
-  logger.info(optimisticUpdate);
+  logger.info("Received optimistic update", {slot: optimisticUpdate.beacon.slot});
 });
 ```
 

--- a/packages/light-client/src/utils/api.ts
+++ b/packages/light-client/src/utils/api.ts
@@ -1,13 +1,13 @@
-import {getClient, ApiClient} from "@lodestar/api";
+import {getClient, ApiClient, ApiRequestInit} from "@lodestar/api";
 import {ChainForkConfig, createChainForkConfig} from "@lodestar/config";
 import {NetworkName, networksChainConfig} from "@lodestar/config/networks";
 
-export function getApiFromUrl(url: string, network: NetworkName): ApiClient {
+export function getApiFromUrl(url: string, network: NetworkName, init?: ApiRequestInit): ApiClient {
   if (!(network in networksChainConfig)) {
     throw Error(`Invalid network name "${network}". Valid options are: ${Object.keys(networksChainConfig).join()}`);
   }
 
-  return getClient({urls: [url]}, {config: createChainForkConfig(networksChainConfig[network])});
+  return getClient({urls: [url], globalInit: init}, {config: createChainForkConfig(networksChainConfig[network])});
 }
 
 export function getChainForkConfigFromNetwork(network: NetworkName): ChainForkConfig {


### PR DESCRIPTION
**Motivation**

Since https://github.com/ChainSafe/lodestar/pull/6749 it is possible to configure the wire format. The light client uses SSZ by default, but for debugging purposes or just user preference we should allow to configure the LC to use JSON instead. Being able to control other api client options like timeout might be useful as well.

**Description**

- allow to configure api client when initializing light client
- fix README examples
