### PR TITLE
feat: add standard endpoint to retrieve fork choice context

### DIFF
--- a/packages/api/src/beacon/routes/debug.ts
+++ b/packages/api/src/beacon/routes/debug.ts
@@ -58,11 +58,34 @@ const DebugChainHeadType = new ContainerType(
   {jsonCase: "eth2"}
 );
 
+const ForkChoiceNodeType = new ContainerType(
+  {
+    slot: ssz.Slot,
+    blockRoot: stringType,
+    parentRoot: stringType,
+    justifiedEpoch: ssz.Epoch,
+    finalizedEpoch: ssz.Epoch,
+    weight: ssz.UintNum64,
+    validity: new StringType<"valid" | "invalid" | "optimistic">(),
+    executionBlockHash: stringType,
+  },
+  {jsonCase: "eth2"}
+);
+const ForkChoiceResponseType = new ContainerType(
+  {
+    justifiedCheckpoint: ssz.phase0.Checkpoint,
+    finalizedCheckpoint: ssz.phase0.Checkpoint,
+    forkChoiceNodes: ArrayOf(ForkChoiceNodeType),
+  },
+  {jsonCase: "eth2"}
+);
+
 const ProtoNodeListType = ArrayOf(ProtoNodeType);
 const DebugChainHeadListType = ArrayOf(DebugChainHeadType);
 
 type ProtoNodeList = ValueOf<typeof ProtoNodeListType>;
 type DebugChainHeadList = ValueOf<typeof DebugChainHeadListType>;
+type ForkChoiceResponse = ValueOf<typeof ForkChoiceResponseType>;
 
 export type Endpoints = {
   /**
@@ -74,6 +97,18 @@ export type Endpoints = {
     EmptyArgs,
     EmptyRequest,
     DebugChainHeadList,
+    EmptyMeta
+  >;
+
+  /**
+   * Retrieves all current fork choice context
+   */
+  getDebugForkChoice: Endpoint<
+    // ⏎
+    "GET",
+    EmptyArgs,
+    EmptyRequest,
+    ForkChoiceResponse,
     EmptyMeta
   >;
 
@@ -113,6 +148,24 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         data: DebugChainHeadListType,
         meta: EmptyMetaCodec,
         onlySupport: WireFormat.json,
+      },
+    },
+    getDebugForkChoice: {
+      url: "/eth/v1/debug/fork_choice",
+      method: "GET",
+      req: EmptyRequestCodec,
+      resp: {
+        data: ForkChoiceResponseType,
+        meta: EmptyMetaCodec,
+        onlySupport: WireFormat.json,
+        transform: {
+          toResponse: (data) => ({
+            ...(data as ForkChoiceResponse),
+          }),
+          fromResponse: (resp) => ({
+            data: resp as ForkChoiceResponse,
+          }),
+        },
       },
     },
     getProtoArrayNodes: {

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -57,7 +57,6 @@ const ignoredOperations = [
   /* missing route */
   "getDepositSnapshot", // Won't fix for now, see https://github.com/ChainSafe/lodestar/issues/5697
   "getNextWithdrawals", // https://github.com/ChainSafe/lodestar/issues/5696
-  "getDebugForkChoice", // https://github.com/ChainSafe/lodestar/issues/5700
   /* Must support ssz response body */
   "getLightClientUpdatesByRange", // https://github.com/ChainSafe/lodestar/issues/6841
 ];

--- a/packages/api/test/unit/beacon/testData/debug.ts
+++ b/packages/api/test/unit/beacon/testData/debug.ts
@@ -4,12 +4,40 @@ import {ssz} from "@lodestar/types";
 import {Endpoints} from "../../../../src/beacon/routes/debug.js";
 import {GenericServerTestCases} from "../../../utils/genericServerTest.js";
 
-const rootHex = toHexString(Buffer.alloc(32, 1));
+const root = new Uint8Array(32).fill(1);
+const rootHex = toHexString(root);
 
 export const testData: GenericServerTestCases<Endpoints> = {
   getDebugChainHeadsV2: {
     args: undefined,
     res: {data: [{slot: 1, root: rootHex, executionOptimistic: true}]},
+  },
+  getDebugForkChoice: {
+    args: undefined,
+    res: {
+      data: {
+        justifiedCheckpoint: {
+          epoch: 2,
+          root,
+        },
+        finalizedCheckpoint: {
+          epoch: 1,
+          root,
+        },
+        forkChoiceNodes: [
+          {
+            slot: 1,
+            blockRoot: rootHex,
+            parentRoot: rootHex,
+            justifiedEpoch: 1,
+            finalizedEpoch: 1,
+            weight: 1,
+            validity: "valid",
+            executionBlockHash: rootHex,
+          },
+        ],
+      },
+    },
   },
   getProtoArrayNodes: {
     args: undefined,

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -96,7 +96,7 @@ export class RestApiServer {
       if (err.validation) {
         const {instancePath, message} = err.validation[0];
         const payload: ErrorResponse = {
-          code: err.statusCode ?? 400,
+          code: 400,
           message: `${instancePath.substring(instancePath.lastIndexOf("/") + 1)} ${message}`,
           stacktraces,
         };


### PR DESCRIPTION
**Motivation**

- https://github.com/ethereum/beacon-APIs/pull/232

**Description**

Add standardized endpoint from beacon-api spec to retrieve fork choice context

Closes  https://github.com/ChainSafe/lodestar/issues/5700
