### PR TITLE
chore: add drips network ownership address

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,5 +1,10 @@
 {
   "opRetro": {
     "projectId": "0x8ec88058175ef4c1c9b1f26910c4d4f2cfa733d6fcd1dbd9385476a313d9e12d"
+  },
+  "drips": {
+    "ethereum": {
+      "ownedBy": "0x94107e24Ba695aeb884fe9e896BA0Bbc14D3B509"
+    }
   }
 }


### PR DESCRIPTION
**Motivation**

[Drips Network](https://www.drips.network/) is another avenue of public goods funding for the project. 

**Description**

Drips Network also utilizes Ethereum to "drip" value to other dependencies in your ["Drip List" ](https://docs.drips.network/support-your-dependencies/overview) in a decentralized fashion. This way when public goods support our project, we also end up supporting other projects which we depend on.

This PR allows for us to claim this repository and configure it to our liking. The address is a secure EOA controlled by me to avoid having to utilize the multisig for access/configuration. Drips to our project will be directed to the Lodestar multisig.
