### PR TITLE
fix: ensure generated historical state slot matches requested slot

### DIFF
--- a/packages/beacon-node/src/chain/historicalState/getHistoricalState.ts
+++ b/packages/beacon-node/src/chain/historicalState/getHistoricalState.ts
@@ -102,6 +102,10 @@ export async function getHistoricalState(
   metrics?.stateTransitionBlocks.observe(blockCount);
   transitionTimer?.();
 
+  if (state.slot !== slot) {
+    throw Error(`Failed to generate historical state for slot ${slot}`);
+  }
+
   const serializeTimer = metrics?.stateSerializationTime.startTimer();
   const stateBytes = state.serialize();
   serializeTimer?.();


### PR DESCRIPTION
**Motivation**

`getHistoricalState` might not be able to transition to the request state of slot if nearest state from state archive in combination with archived blocks from db are insufficient. There might be a gap in archive blocks db depending on how long the node was running and if it was stopped a few times, this would likely be resolved by backfill sync but we don't support it yet.

Currently this results in returning a state for a different slot which can lead to unexpected results.

**Description**

Ensure generated historical state slot matches requested slot, throw error if state slot does not match requested slot
