### PR TITLE
fix: improve forkchoice

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -389,10 +389,6 @@ export function getValidatorApi(
       notWhileSyncing();
       await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
-      // Process the queued attestations in the forkchoice for correct head estimation
-      // forkChoice.updateTime() might have already been called by the onSlot clock
-      // handler, in which case this should just return.
-      chain.forkChoice.updateTime(slot);
       parentBlockRoot = fromHex(chain.getProposerHead(slot).blockRoot);
     } else {
       parentBlockRoot = inParentBlockRoot;
@@ -459,10 +455,6 @@ export function getValidatorApi(
       notWhileSyncing();
       await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
-      // Process the queued attestations in the forkchoice for correct head estimation
-      // forkChoice.updateTime() might have already been called by the onSlot clock
-      // handler, in which case this should just return.
-      chain.forkChoice.updateTime(slot);
       parentBlockRoot = fromHex(chain.getProposerHead(slot).blockRoot);
     } else {
       parentBlockRoot = inParentBlockRoot;
@@ -535,10 +527,6 @@ export function getValidatorApi(
     notWhileSyncing();
     await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
-    // Process the queued attestations in the forkchoice for correct head estimation
-    // forkChoice.updateTime() might have already been called by the onSlot clock
-    // handler, in which case this should just return.
-    chain.forkChoice.updateTime(slot);
     const parentBlockRoot = fromHex(chain.getProposerHead(slot).blockRoot);
     notOnOutOfRangeData(parentBlockRoot);
 

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -19,6 +19,7 @@ import {ChainEvent, ReorgEventData} from "../emitter.js";
 import {REPROCESS_MIN_TIME_TO_NEXT_SLOT_SEC} from "../reprocess.js";
 import type {BeaconChain} from "../chain.js";
 import {callInNextEventLoop} from "../../util/eventLoop.js";
+import {ForkchoiceCaller} from "../forkChoice/index.js";
 import {FullyVerifiedBlock, ImportBlockOpts, AttestationImportOpt, BlockInputType} from "./types.js";
 import {getCheckpointFromState} from "./utils/checkpoint.js";
 import {writeBlockInputToDb} from "./writeBlockInputToDb.js";
@@ -208,7 +209,7 @@ export async function importBlock(
   // 5. Compute head. If new head, immediately stateCache.setHeadState()
 
   const oldHead = this.forkChoice.getHead();
-  const newHead = this.recomputeForkChoiceHead();
+  const newHead = this.recomputeForkChoiceHead(ForkchoiceCaller.importBlock);
   const currFinalizedEpoch = this.forkChoice.getFinalizedCheckpoint().epoch;
 
   if (newHead.blockRoot !== oldHead.blockRoot) {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1060,13 +1060,8 @@ export class BeaconChain implements IBeaconChain {
     if (this.forkChoice.irrecoverableError) {
       this.processShutdownCallback(this.forkChoice.irrecoverableError);
     }
-    this.forkChoice.updateTime(slot);
-    // at slot boundary, the node is free
-    // it's most likely all attestations in old slots are seen, we want to process them so that at importBlock()
-    // time, the computeDeltas() function is faster because we don't have to process them again
-    // attestations in the current slot stay in the queue and they have no affect
-    this.recomputeForkChoiceHead(ForkchoiceCaller.onClockSlot);
 
+    this.forkChoice.updateTime(slot);
     this.metrics?.clockSlot.set(slot);
 
     this.attestationPool.prune(slot);

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -27,6 +27,12 @@ export type ForkChoiceOpts = RawForkChoiceOpts & {
   forkchoiceConstructor?: typeof ForkChoice;
 };
 
+export enum ForkchoiceCaller {
+  prepareNextSlot = "prepare_next_slot",
+  onClockSlot = "on_clock_slot",
+  importBlock = "import_block",
+}
+
 /**
  * Fork Choice extended with a ChainEventEmitter
  */

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -29,7 +29,6 @@ export type ForkChoiceOpts = RawForkChoiceOpts & {
 
 export enum ForkchoiceCaller {
   prepareNextSlot = "prepare_next_slot",
-  onClockSlot = "on_clock_slot",
   importBlock = "import_block",
 }
 

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -58,6 +58,7 @@ import {ShufflingCache} from "./shufflingCache.js";
 import {BlockRewards} from "./rewards/blockRewards.js";
 import {AttestationsRewards} from "./rewards/attestationsRewards.js";
 import {SyncCommitteeRewards} from "./rewards/syncCommitteeRewards.js";
+import {ForkchoiceCaller} from "./forkChoice/index.js";
 
 export {BlockType, type AssembledBlockType};
 export {type ProposerPreparationData};
@@ -204,7 +205,7 @@ export interface IBeaconChain {
 
   getStatus(): phase0.Status;
 
-  recomputeForkChoiceHead(): ProtoBlock;
+  recomputeForkChoiceHead(caller: ForkchoiceCaller): ProtoBlock;
 
   /** When proposerBoostReorg is enabled, this is called at slot n-1 to predict the head block to build on if we are proposing at slot n */
   predictProposerHead(slot: Slot): ProtoBlock;

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -18,6 +18,7 @@ import {isQueueErrorAborted} from "../util/queue/index.js";
 import {prepareExecutionPayload, getPayloadAttributesForSSE} from "./produceBlock/produceBlockBody.js";
 import {IBeaconChain} from "./interface.js";
 import {RegenCaller} from "./regen/index.js";
+import {ForkchoiceCaller} from "./forkChoice/index.js";
 
 /* With 12s slot times, this scheduler will run 4s before the start of each slot (`12 / 3 = 4`). */
 export const SCHEDULER_LOOKAHEAD_FACTOR = 3;
@@ -77,7 +78,9 @@ export class PrepareNextSlotScheduler {
       await sleep(slotMs - slotMs / SCHEDULER_LOOKAHEAD_FACTOR, this.signal);
 
       // calling updateHead() here before we produce a block to reduce reorg possibility
-      const {slot: headSlot, blockRoot: headRoot} = this.chain.recomputeForkChoiceHead();
+      const {slot: headSlot, blockRoot: headRoot} = this.chain.recomputeForkChoiceHead(
+        ForkchoiceCaller.prepareNextSlot
+      );
 
       // PS: previously this was comparing slots, but that gave no leway on the skipped
       // slots on epoch bounday. Making it more fluid.

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -59,11 +59,11 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
     // Non-spec'ed
 
     forkChoice: {
-      findHead: register.histogram<{entrypoint: string}>({
+      findHead: register.histogram<{caller: string}>({
         name: "beacon_fork_choice_find_head_seconds",
         help: "Time taken to find head in seconds",
         buckets: [0.1, 1, 10],
-        labelNames: ["entrypoint"],
+        labelNames: ["caller"],
       }),
       requests: register.gauge({
         name: "beacon_fork_choice_requests_total",

--- a/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
+++ b/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
@@ -98,7 +98,7 @@ describe("PrepareNextSlot scheduler", () => {
       scheduler.prepareForNextSlot(2 * SLOTS_PER_EPOCH - 1),
       vi.advanceTimersByTimeAsync((config.SECONDS_PER_SLOT * 1000 * 2) / 3),
     ]);
-    expect(chainStub.recomputeForkChoiceHead).toHaveBeenCalledWith();
+    expect(chainStub.recomputeForkChoiceHead).toHaveBeenCalledOnce();
     expect(regenStub.getBlockSlotState).not.toHaveBeenCalled();
   });
 

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -755,6 +755,11 @@ export class ForkChoice implements IForkChoice {
 
   /**
    * Call `onTick` for all slots between `fcStore.getCurrentSlot()` and the provided `currentSlot`.
+   * This should only be called once per slot because:
+   *   - calling this multiple times in the same slot does not update `votes`
+   *     - new attestations in the current slot must stay in the queue
+   *     - new attestations in the old slots are applied to the `votes` already
+   *   - also side effect of this function is `validatedAttestationDatas` reseted
    */
   updateTime(currentSlot: Slot): void {
     if (this.fcStore.currentSlot >= currentSlot) return;
@@ -1363,6 +1368,7 @@ export class ForkChoice implements IForkChoice {
         for (const [blockRoot, validatorIndices] of byRoot.entries()) {
           const blockRootHex = blockRoot;
           for (const validatorIndex of validatorIndices) {
+            // equivocatingIndices was checked in onAttestation
             this.addLatestMessage(validatorIndex, targetEpoch, blockRootHex);
           }
         }

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -250,14 +250,3 @@ export type LatestMessage = {
   epoch: Epoch;
   root: RootHex;
 };
-
-/**
- * Used for queuing attestations from the current slot. Only contains the minimum necessary
- * information about the attestation.
- */
-export type QueuedAttestation = {
-  slot: Slot;
-  attestingIndices: ValidatorIndex[];
-  blockRoot: RootHex;
-  targetEpoch: Epoch;
-};

--- a/packages/fork-choice/src/protoArray/computeDeltas.ts
+++ b/packages/fork-choice/src/protoArray/computeDeltas.ts
@@ -48,7 +48,7 @@ export function computeDeltas(
     // It is possible that there was a vote for an unknown validator if we change our justified
     // state to a new state with a higher epoch that is on a different fork because that fork may have
     // on-boarded fewer validators than the prior fork.
-    newBalance = newBalances[vIndex] ?? 0;
+    newBalance = newBalances === oldBalances ? oldBalance : newBalances[vIndex] ?? 0;
 
     if (equivocatingIndices.size > 0 && equivocatingIndices.has(vIndex)) {
       // this function could be called multiple times but we only want to process slashing validator for 1 time

--- a/packages/fork-choice/src/protoArray/computeDeltas.ts
+++ b/packages/fork-choice/src/protoArray/computeDeltas.ts
@@ -3,6 +3,9 @@ import {EffectiveBalanceIncrements} from "@lodestar/state-transition";
 import {VoteTracker} from "./interface.js";
 import {ProtoArrayError, ProtoArrayErrorCode} from "./errors.js";
 
+// reuse arrays to avoid memory reallocation and gc
+const deltas = new Array<number>();
+
 /**
  * Returns a list of `deltas`, where there is one delta for each of the indices in `indices`
  *
@@ -19,10 +22,8 @@ export function computeDeltas(
   newBalances: EffectiveBalanceIncrements,
   equivocatingIndices: Set<ValidatorIndex>
 ): number[] {
-  const deltas = new Array<number>(numProtoNodes);
-  for (let i = 0; i < numProtoNodes; i++) {
-    deltas[i] = 0;
-  }
+  deltas.length = numProtoNodes;
+  deltas.fill(0);
 
   // avoid creating new variables in the loop to potentially reduce GC pressure
   let oldBalance, newBalance: number;


### PR DESCRIPTION
**Motivation**

Improve forkchoice

**Description**

Some different small optimizations for forkchoice:
- `updateTime()` is designed to called once per slot and we do that per clock slot, so no need to do that again when producing block. No need to process queued attestations again in the same slot because:
  - current slot attestations keeps staying in the queue
  - old attestations should be applied to the `votes` already
- improve `processAttestationQueue()`:
  - right now we delete queued attestations one by one in a Set, as metrics show there could be more than 30k of them per slot on the test mainnet node 
  - instead of that just partition queued attestations by slot then root, then we can delete them way more efficiently. This also helps save us a little memory
- improve metrics: right now we label `get_head()` metric by entry point and we have no idea for the time to recompute head for `prepare_next_slot` vs `import_block`, we should label by `"caller"` instead
- improve `computeDeltas()`:
  - reuse `deltas` array over time
  - handle `newBalances === oldBalances` to speed up the computation a little bit

Metric look like (will add in a separate PR):
<img width="1325" alt="Screenshot 2024-10-09 at 14 26 01" src="https://github.com/user-attachments/assets/a07afb21-9475-45b6-ba79-c8c0625e1286">

