### PR TITLE
feat: allow filtering of validators by top-level validator status

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -83,17 +83,26 @@ export async function getStateResponseWithRegen(
   return res;
 }
 
-function mapToGeneralStatus(subStatus: string): string {
-  if (["active_ongoing", "active_exiting", "active_slashed"].includes(subStatus)) {
-    return "active";
-  } else if (["pending_initialized", "pending_queued"].includes(subStatus)) {
-    return "pending";
-  } else if (["exited_slashed", "exited_unslashed"].includes(subStatus)) {
-    return "exited";
-  } else if (["withdrawal_possible", "withdrawal_done"].includes(subStatus)) {
-    return "withdrawal";
+export type GeneralValidatorStatus = routes.beacon.ValidatorStatus | "active" | "pending" | "exited" | "withdrawal";
+
+function mapToGeneralStatus(subStatus: routes.beacon.ValidatorStatus): GeneralValidatorStatus {
+  switch (subStatus) {
+    case "active_ongoing":
+    case "active_exiting":
+    case "active_slashed":
+      return "active";
+    case "pending_initialized":
+    case "pending_queued":
+      return "pending";
+    case "exited_slashed":
+    case "exited_unslashed":
+      return "exited";
+    case "withdrawal_possible":
+    case "withdrawal_done":
+      return "withdrawal";
+    default:
+      throw new Error(`Unknown substatus: ${subStatus}`);
   }
-  throw new Error(`Unknown substatus: ${subStatus}`);
 }
 
 /**

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -1,8 +1,8 @@
 import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {routes} from "@lodestar/api";
-import {FAR_FUTURE_EPOCH, GENESIS_SLOT} from "@lodestar/params";
+import {GENESIS_SLOT} from "@lodestar/params";
 import {BeaconStateAllForks} from "@lodestar/state-transition";
-import {BLSPubkey, Epoch, phase0, RootHex, Slot, ValidatorIndex} from "@lodestar/types";
+import {BLSPubkey, Epoch, getValidatorStatus, phase0, RootHex, Slot, ValidatorIndex} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {CheckpointWithHex, IForkChoice} from "@lodestar/fork-choice";
 import {IBeaconChain} from "../../../../chain/index.js";
@@ -105,38 +105,6 @@ function mapToGeneralStatus(subStatus: routes.beacon.ValidatorStatus): GeneralVa
   }
 }
 
-/**
- * Get the status of the validator
- * based on conditions outlined in https://hackmd.io/ofFJ5gOmQpu1jjHilHbdQQ
- */
-export function getValidatorStatus(validator: phase0.Validator, currentEpoch: Epoch): routes.beacon.ValidatorStatus {
-  // pending
-  if (validator.activationEpoch > currentEpoch) {
-    if (validator.activationEligibilityEpoch === FAR_FUTURE_EPOCH) {
-      return "pending_initialized";
-    } else if (validator.activationEligibilityEpoch < FAR_FUTURE_EPOCH) {
-      return "pending_queued";
-    }
-  }
-  // active
-  if (validator.activationEpoch <= currentEpoch && currentEpoch < validator.exitEpoch) {
-    if (validator.exitEpoch === FAR_FUTURE_EPOCH) {
-      return "active_ongoing";
-    } else if (validator.exitEpoch < FAR_FUTURE_EPOCH) {
-      return validator.slashed ? "active_slashed" : "active_exiting";
-    }
-  }
-  // exited
-  if (validator.exitEpoch <= currentEpoch && currentEpoch < validator.withdrawableEpoch) {
-    return validator.slashed ? "exited_slashed" : "exited_unslashed";
-  }
-  // withdrawal
-  if (validator.withdrawableEpoch <= currentEpoch) {
-    return validator.effectiveBalance !== 0 ? "withdrawal_possible" : "withdrawal_done";
-  }
-  throw new Error("ValidatorStatus unknown");
-}
-
 export function toValidatorResponse(
   index: ValidatorIndex,
   validator: phase0.Validator,
@@ -163,9 +131,10 @@ export function filterStateValidatorsByStatus(
 
   for (const validator of validatorsArr) {
     const validatorStatus = getValidatorStatus(validator, currentEpoch);
+    const generalStatus = mapToGeneralStatus(validatorStatus);
 
     const resp = getStateValidatorIndex(validator.pubkey, state, pubkey2index);
-    if (resp.valid && statusSet.has(validatorStatus)) {
+    if (resp.valid && (statusSet.has(validatorStatus) || statusSet.has(generalStatus))) {
       responses.push(
         toValidatorResponse(resp.validatorIndex, validator, state.balances.get(resp.validatorIndex), currentEpoch)
       );

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -163,10 +163,9 @@ export function filterStateValidatorsByStatus(
 
   for (const validator of validatorsArr) {
     const validatorStatus = getValidatorStatus(validator, currentEpoch);
-    const generalStatus = mapToGeneralStatus(validatorStatus);
 
     const resp = getStateValidatorIndex(validator.pubkey, state, pubkey2index);
-    if (resp.valid && (statusSet.has(validatorStatus) || statusSet.has(generalStatus))) {
+    if (resp.valid && statusSet.has(validatorStatus)) {
       responses.push(
         toValidatorResponse(resp.validatorIndex, validator, state.balances.get(resp.validatorIndex), currentEpoch)
       );

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -83,7 +83,7 @@ export async function getStateResponseWithRegen(
   return res;
 }
 
-export type GeneralValidatorStatus = routes.beacon.ValidatorStatus | "active" | "pending" | "exited" | "withdrawal";
+export type GeneralValidatorStatus = "active" | "pending" | "exited" | "withdrawal";
 
 function mapToGeneralStatus(subStatus: routes.beacon.ValidatorStatus): GeneralValidatorStatus {
   switch (subStatus) {

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -83,7 +83,7 @@ export async function getStateResponseWithRegen(
   return res;
 }
 
-export type GeneralValidatorStatus = "active" | "pending" | "exited" | "withdrawal";
+type GeneralValidatorStatus = "active" | "pending" | "exited" | "withdrawal";
 
 function mapToGeneralStatus(subStatus: routes.beacon.ValidatorStatus): GeneralValidatorStatus {
   switch (subStatus) {


### PR DESCRIPTION
## Add support for filtering validators by top-level status

This pull request implements support for filtering validators by top-level statuses such as `active`, `pending`, `exited`, and `withdrawal` as specified in the beacon-api spec.

### Changes:
- Added `mapToGeneralStatus` function to map detailed statuses to top-level statuses (`active`, `pending`, `exited`, and `withdrawal`).
- Updated `filterStateValidatorsByStatus` to support filtering validators by both detailed and top-level statuses.

### Related issue:
Closes #7141
