### PR TITLE
fix: allow to disable peer discovery / discv5

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -175,14 +175,6 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
   // Add detailed version string for API node/version endpoint
   beaconNodeOptions.set({api: {commit, version}});
 
-  // Combine bootnodes from different sources
-  const bootnodes = (beaconNodeOptions.get().network?.discv5?.bootEnrs ?? []).concat(
-    args.bootnodesFile ? readBootnodes(args.bootnodesFile) : [],
-    isKnownNetworkName(network) ? await getNetworkBootnodes(network) : []
-  );
-  // Deduplicate and set combined bootnodes
-  beaconNodeOptions.set({network: {discv5: {bootEnrs: [...new Set(bootnodes)]}}});
-
   // Set known depositContractDeployBlock
   if (isKnownNetworkName(network)) {
     const {depositContractDeployBlock} = getNetworkData(network);
@@ -191,8 +183,19 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
 
   const logger = initLogger(args, beaconPaths.dataDir, config);
   const {peerId, enr} = await initPeerIdAndEnr(args, beaconPaths.beaconDir, logger);
-  // Inject ENR to beacon options
-  beaconNodeOptions.set({network: {discv5: {enr: enr.encodeTxt(), config: {enrUpdate: !enr.ip && !enr.ip6}}}});
+
+  if (args.discv5) {
+    // Inject ENR to beacon options
+    beaconNodeOptions.set({network: {discv5: {enr: enr.encodeTxt(), config: {enrUpdate: !enr.ip && !enr.ip6}}}});
+
+    // Combine bootnodes from different sources
+    const bootnodes = (beaconNodeOptions.get().network?.discv5?.bootEnrs ?? []).concat(
+      args.bootnodesFile ? readBootnodes(args.bootnodesFile) : [],
+      isKnownNetworkName(network) ? await getNetworkBootnodes(network) : []
+    );
+    // Deduplicate and set combined bootnodes
+    beaconNodeOptions.set({network: {discv5: {bootEnrs: [...new Set(bootnodes)]}}});
+  }
 
   if (args.disableLightClientServer) {
     beaconNodeOptions.set({chain: {disableLightClientServer: true}});

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -184,7 +184,7 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
   const logger = initLogger(args, beaconPaths.dataDir, config);
   const {peerId, enr} = await initPeerIdAndEnr(args, beaconPaths.beaconDir, logger);
 
-  if (args.discv5) {
+  if (args.discv5 !== false) {
     // Inject ENR to beacon options
     beaconNodeOptions.set({network: {discv5: {enr: enr.encodeTxt(), config: {enrUpdate: !enr.ip && !enr.ip6}}}});
 


### PR DESCRIPTION
**Motivation**

It's not possible right now to disable peer discovery by passing `--discv5 false` as it results in an uncaught expection when initializing the worker which crashes the process.

```
Oct-09 19:31:58.305[network]         error: uncaughtException: Cannot read properties of undefined (reading 'ip4')
TypeError: Cannot read properties of undefined (reading 'ip4')
    at file:///home/nico/projects/ethereum/lodestar/packages/beacon-node/lib/network/discv5/worker.js:47:36 - Cannot read properties of undefined (reading 'ip4')
TypeError: Cannot read properties of undefined (reading 'ip4')
    at file:///home/nico/projects/ethereum/lodestar/packages/beacon-node/lib/network/discv5/worker.js:47:36
 ✖ TypeError: Cannot read properties of undefined (reading 'ip4')
    at file:///home/nico/projects/ethereum/lodestar/packages/beacon-node/lib/network/discv5/worker.js:47:36
```


**Description**


We disable peer discovery if `opts.discv5` is `null`

https://github.com/ChainSafe/lodestar/blob/068fbae928989295706443887c645d476bb95695/packages/beacon-node/src/network/peers/peerManager.ts#L189-L191

the issue is though that we set discv5 optiosn in beacon handler, which means we have partial discv5 options and still initialize the worker with those resulting in the error.
