### PR TITLE
feat: pass execution requests as bytes to engine API

### DIFF
--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -1,4 +1,4 @@
-import {capella, deneb, electra, Wei, bellatrix, Root, ExecutionPayload, ExecutionRequests} from "@lodestar/types";
+import {capella, deneb, electra, Wei, bellatrix, Root, ExecutionPayload, ExecutionRequests, ssz} from "@lodestar/types";
 import {
   BYTES_PER_LOGS_BLOOM,
   FIELD_ELEMENTS_PER_BLOB,
@@ -161,29 +161,18 @@ export type WithdrawalRpc = {
   amount: QUANTITY;
 };
 
-export type ExecutionRequestsRpc = {
-  deposits: DepositRequestRpc[];
-  withdrawals: WithdrawalRequestRpc[];
-  consolidations: ConsolidationRequestRpc[];
-};
+/**
+ * ExecutionRequestsRpc only holds 3 elements in the following order:
+ * - ssz'ed DepositRequests
+ * - ssz'ed WithdrawalRequests
+ * - ssz'ed ConsolidationRequests
+ */
+export type ExecutionRequestsRpc = [DepositRequestsRpc, WithdrawalRequestsRpc, ConsolidationRequestsRpc];
 
-export type DepositRequestRpc = {
-  pubkey: DATA;
-  withdrawalCredentials: DATA;
-  amount: QUANTITY;
-  signature: DATA;
-  index: QUANTITY;
-};
-export type WithdrawalRequestRpc = {
-  sourceAddress: DATA;
-  validatorPubkey: DATA;
-  amount: QUANTITY;
-};
-export type ConsolidationRequestRpc = {
-  sourceAddress: DATA;
-  sourcePubkey: DATA;
-  targetPubkey: DATA;
-};
+export type DepositRequestsRpc = DATA;
+export type WithdrawalRequestsRpc = DATA;
+export type ConsolidationRequestsRpc = DATA;
+
 
 export type VersionedHashesRpc = DATA[];
 
@@ -406,73 +395,47 @@ export function deserializeWithdrawal(serialized: WithdrawalRpc): capella.Withdr
   } as capella.Withdrawal;
 }
 
-function serializeDepositRequest(depositRequest: electra.DepositRequest): DepositRequestRpc {
-  return {
-    pubkey: bytesToData(depositRequest.pubkey),
-    withdrawalCredentials: bytesToData(depositRequest.withdrawalCredentials),
-    amount: numToQuantity(depositRequest.amount),
-    signature: bytesToData(depositRequest.signature),
-    index: numToQuantity(depositRequest.index),
-  };
+function serializeDepositRequests(depositRequests: electra.DepositRequests): DepositRequestsRpc {
+  return bytesToData(ssz.electra.DepositRequests.serialize(depositRequests));
 }
 
-function deserializeDepositRequest(serialized: DepositRequestRpc): electra.DepositRequest {
-  return {
-    pubkey: dataToBytes(serialized.pubkey, 48),
-    withdrawalCredentials: dataToBytes(serialized.withdrawalCredentials, 32),
-    amount: quantityToNum(serialized.amount),
-    signature: dataToBytes(serialized.signature, 96),
-    index: quantityToNum(serialized.index),
-  } as electra.DepositRequest;
+function deserializeDepositRequests(serialized: DepositRequestsRpc): electra.DepositRequests {
+  return ssz.electra.DepositRequests.deserialize(dataToBytes(serialized, null));
 }
 
-function serializeWithdrawalRequest(withdrawalRequest: electra.WithdrawalRequest): WithdrawalRequestRpc {
-  return {
-    sourceAddress: bytesToData(withdrawalRequest.sourceAddress),
-    validatorPubkey: bytesToData(withdrawalRequest.validatorPubkey),
-    amount: numToQuantity(withdrawalRequest.amount),
-  };
+function serializeWithdrawalRequests(withdrawalRequests: electra.WithdrawalRequests): WithdrawalRequestsRpc {
+  return bytesToData(ssz.electra.WithdrawalRequests.serialize(withdrawalRequests));
 }
 
-function deserializeWithdrawalRequest(withdrawalRequest: WithdrawalRequestRpc): electra.WithdrawalRequest {
-  return {
-    sourceAddress: dataToBytes(withdrawalRequest.sourceAddress, 20),
-    validatorPubkey: dataToBytes(withdrawalRequest.validatorPubkey, 48),
-    amount: quantityToBigint(withdrawalRequest.amount),
-  };
+function deserializeWithdrawalRequest(serialized: WithdrawalRequestsRpc): electra.WithdrawalRequests {
+  return ssz.electra.WithdrawalRequests.deserialize(dataToBytes(serialized, null));
 }
 
-function serializeConsolidationRequest(consolidationRequest: electra.ConsolidationRequest): ConsolidationRequestRpc {
-  return {
-    sourceAddress: bytesToData(consolidationRequest.sourceAddress),
-    sourcePubkey: bytesToData(consolidationRequest.sourcePubkey),
-    targetPubkey: bytesToData(consolidationRequest.targetPubkey),
-  };
+function serializeConsolidationRequests(consolidationRequests: electra.ConsolidationRequests): ConsolidationRequestsRpc {
+  return bytesToData(ssz.electra.ConsolidationRequests.serialize(consolidationRequests));
 }
 
-function deserializeConsolidationRequest(consolidationRequest: ConsolidationRequestRpc): electra.ConsolidationRequest {
-  return {
-    sourceAddress: dataToBytes(consolidationRequest.sourceAddress, 20),
-    sourcePubkey: dataToBytes(consolidationRequest.sourcePubkey, 48),
-    targetPubkey: dataToBytes(consolidationRequest.targetPubkey, 48),
-  };
+function deserializeConsolidationRequests(serialized: ConsolidationRequestsRpc): electra.ConsolidationRequests {
+  return ssz.electra.ConsolidationRequests.deserialize(dataToBytes(serialized, null));
 }
 
+/**
+ * This is identical to get_execution_requests_list in
+ * https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/electra/beacon-chain.md#new-get_execution_requests_list 
+ */
 export function serializeExecutionRequests(executionRequests: ExecutionRequests): ExecutionRequestsRpc {
   const {deposits, withdrawals, consolidations} = executionRequests;
-  return {
-    deposits: deposits.map(serializeDepositRequest),
-    withdrawals: withdrawals.map(serializeWithdrawalRequest),
-    consolidations: consolidations.map(serializeConsolidationRequest),
-  };
+
+  return [serializeDepositRequests(deposits), serializeWithdrawalRequests(withdrawals), serializeConsolidationRequests(consolidations)];
 }
 
-export function deserializeExecutionRequests(executionRequests: ExecutionRequestsRpc): ExecutionRequests {
-  const {deposits, withdrawals, consolidations} = executionRequests;
+export function deserializeExecutionRequests(serialized: ExecutionRequestsRpc): ExecutionRequests {
+  const [deposits, withdrawals, consolidations] = serialized;
+
   return {
-    deposits: deposits.map(deserializeDepositRequest),
-    withdrawals: withdrawals.map(deserializeWithdrawalRequest),
-    consolidations: consolidations.map(deserializeConsolidationRequest),
+    deposits: deserializeDepositRequests(deposits),
+    withdrawals: deserializeWithdrawalRequest(withdrawals),
+    consolidations: deserializeConsolidationRequests(consolidations),
   };
 }
 

--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -173,7 +173,6 @@ export type DepositRequestsRpc = DATA;
 export type WithdrawalRequestsRpc = DATA;
 export type ConsolidationRequestsRpc = DATA;
 
-
 export type VersionedHashesRpc = DATA[];
 
 export type PayloadAttributesRpc = {
@@ -411,7 +410,9 @@ function deserializeWithdrawalRequest(serialized: WithdrawalRequestsRpc): electr
   return ssz.electra.WithdrawalRequests.deserialize(dataToBytes(serialized, null));
 }
 
-function serializeConsolidationRequests(consolidationRequests: electra.ConsolidationRequests): ConsolidationRequestsRpc {
+function serializeConsolidationRequests(
+  consolidationRequests: electra.ConsolidationRequests
+): ConsolidationRequestsRpc {
   return bytesToData(ssz.electra.ConsolidationRequests.serialize(consolidationRequests));
 }
 
@@ -421,12 +422,16 @@ function deserializeConsolidationRequests(serialized: ConsolidationRequestsRpc):
 
 /**
  * This is identical to get_execution_requests_list in
- * https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/electra/beacon-chain.md#new-get_execution_requests_list 
+ * https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/electra/beacon-chain.md#new-get_execution_requests_list
  */
 export function serializeExecutionRequests(executionRequests: ExecutionRequests): ExecutionRequestsRpc {
   const {deposits, withdrawals, consolidations} = executionRequests;
 
-  return [serializeDepositRequests(deposits), serializeWithdrawalRequests(withdrawals), serializeConsolidationRequests(consolidations)];
+  return [
+    serializeDepositRequests(deposits),
+    serializeWithdrawalRequests(withdrawals),
+    serializeConsolidationRequests(consolidations),
+  ];
 }
 
 export function deserializeExecutionRequests(serialized: ExecutionRequestsRpc): ExecutionRequests {


### PR DESCRIPTION
According to the latest change to the spec, execution requests are passed as bytes to `engine_newPayloadV4`, and EL will also return execution requests in bytes from `engine_getPayloadV4`.

- execution requests rpc type is defined as `DATA[3]`, with deposit, withdrawal and consolidation requests rpc being the first, second and third element respectively
- Deposit requests RPC is the ssz serialized bytes of `DepositRequests`. Withdrawal and consolidation requests are in a similar fashion

Relevant spec can be found in the following:
- engine newPayload: https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-get_execution_requests_list
- engine getPayload: https://github.com/ethereum/consensus-specs/pull/3976
- Engine API: https://github.com/ethereum/execution-apis/pull/591
- Engine API elaboration: https://github.com/ethereum/execution-apis/pull/597