### PR TITLE
feat: add execution requests to builder flow

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -224,7 +224,7 @@ export async function produceBlockBody<T extends BlockType>(
       if (ForkSeq[fork] >= ForkSeq.electra) {
         const {executionRequests} = builderRes;
         if (executionRequests === undefined) {
-          throw Error(`Invalid builder getHeader response for fork=${fork}, missing exeuctionRequests`);
+          throw Error(`Invalid builder getHeader response for fork=${fork}, missing executionRequests`);
         }
         (blockBody as electra.BlindedBeaconBlockBody).executionRequests = executionRequests;
       }

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -220,6 +220,14 @@ export async function produceBlockBody<T extends BlockType>(
       } else {
         blobsResult = {type: BlobsResultType.preDeneb};
       }
+
+      if (ForkSeq[fork] >= ForkSeq.electra) {
+        const {executionRequests} = builderRes;
+        if (executionRequests === undefined) {
+          throw Error(`Invalid builder getHeader response for fork=${fork}, missing exeuctionRequests`);
+        }
+        (blockBody as electra.BlindedBeaconBlockBody).executionRequests = executionRequests;
+      }
     }
 
     // blockType === BlockType.Full
@@ -455,6 +463,7 @@ async function prepareExecutionPayloadHeader(
   header: ExecutionPayloadHeader;
   executionPayloadValue: Wei;
   blobKzgCommitments?: deneb.BlobKzgCommitments;
+  executionRequests?: electra.ExecutionRequests;
 }> {
   if (!chain.executionBuilder) {
     throw Error("executionBuilder required");

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -8,6 +8,7 @@ import {
   SignedBeaconBlockOrContents,
   SignedBlindedBeaconBlock,
   ExecutionPayloadHeader,
+  electra,
 } from "@lodestar/types";
 import {parseExecutionPayloadAndBlobsBundle, reconstructFullBlockOrContents} from "@lodestar/state-transition";
 import {ChainForkConfig} from "@lodestar/config";
@@ -114,6 +115,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
     header: ExecutionPayloadHeader;
     executionPayloadValue: Wei;
     blobKzgCommitments?: deneb.BlobKzgCommitments;
+    executionRequests?: electra.ExecutionRequests;
   }> {
     const signedBuilderBid = (await this.api.getHeader({slot, parentHash, proposerPubkey})).value();
 
@@ -123,7 +125,8 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
 
     const {header, value: executionPayloadValue} = signedBuilderBid.message;
     const {blobKzgCommitments} = signedBuilderBid.message as deneb.BuilderBid;
-    return {header, executionPayloadValue, blobKzgCommitments};
+    const {executionRequests} = signedBuilderBid.message as electra.BuilderBid;
+    return {header, executionPayloadValue, blobKzgCommitments, executionRequests};
   }
 
   async submitBlindedBlock(signedBlindedBlock: SignedBlindedBeaconBlock): Promise<SignedBeaconBlockOrContents> {

--- a/packages/beacon-node/src/execution/builder/interface.ts
+++ b/packages/beacon-node/src/execution/builder/interface.ts
@@ -8,6 +8,7 @@ import {
   SignedBeaconBlockOrContents,
   ExecutionPayloadHeader,
   SignedBlindedBeaconBlock,
+  electra,
 } from "@lodestar/types";
 import {ForkExecution} from "@lodestar/params";
 
@@ -36,6 +37,7 @@ export interface IExecutionBuilder {
     header: ExecutionPayloadHeader;
     executionPayloadValue: Wei;
     blobKzgCommitments?: deneb.BlobKzgCommitments;
+    executionRequests?: electra.ExecutionRequests;
   }>;
   submitBlindedBlock(signedBlock: SignedBlindedBeaconBlock): Promise<SignedBeaconBlockOrContents>;
 }

--- a/packages/types/src/electra/sszTypes.ts
+++ b/packages/types/src/electra/sszTypes.ts
@@ -211,6 +211,7 @@ export const BlindedBeaconBlockBody = new ContainerType(
     executionPayloadHeader: ExecutionPayloadHeader,
     blsToExecutionChanges: capellaSsz.BeaconBlockBody.fields.blsToExecutionChanges,
     blobKzgCommitments: denebSsz.BeaconBlockBody.fields.blobKzgCommitments,
+    executionRequests: ExecutionRequests, // New in ELECTRA
   },
   {typeName: "BlindedBeaconBlockBody", jsonCase: "eth2", cachePermanentRootStruct: true}
 );
@@ -235,6 +236,7 @@ export const BuilderBid = new ContainerType(
   {
     header: ExecutionPayloadHeader, // Modified in ELECTRA
     blindedBlobsBundle: denebSsz.BlobKzgCommitments,
+    executionRequests: ExecutionRequests, // New in ELECTRA
     value: UintBn256,
     pubkey: BLSPubkey,
   },


### PR DESCRIPTION
Add execution requests to blinded beacon block and builder bid.

Related spec ethereum/builder-specs#101 ethereum/builder-specs#105