### PR TITLE
fix: enforce strict timeout for builder to provide bid

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -631,7 +631,7 @@ export function getValidatorApi(
       : Promise.reject(new Error("Engine disabled"));
 
     const [builder, engine] = await resolveOrRacePromises([builderPromise, enginePromise], {
-      resolveTimeoutMs: Math.max(0, BLOCK_PRODUCTION_RACE_CUTOFF_MS - chain.clock.secFromSlot(slot) * 1000),
+      resolveTimeoutMs: Math.max(0, BLOCK_PRODUCTION_RACE_CUTOFF_MS - Math.round(chain.clock.secFromSlot(slot) * 1000)),
       raceTimeoutMs: BLOCK_PRODUCTION_RACE_TIMEOUT_MS,
       signal: controller.signal,
     });

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -85,7 +85,7 @@ import {computeSubnetForCommitteesAtSlot, getPubkeysForIndices, selectBlockProdu
 export const SYNC_TOLERANCE_EPOCHS = 1;
 
 /**
- * Cutoff time to wait for execution and builder block production apis to resolve
+ * Cutoff time to wait from start of the slot for execution and builder block production apis to resolve
  * Post this time, race execution and builder to pick whatever resolves first
  *
  * Empirically the builder block resolves in ~1.5+ seconds, and execution should resolve <1 sec.
@@ -631,7 +631,7 @@ export function getValidatorApi(
       : Promise.reject(new Error("Engine disabled"));
 
     const [builder, engine] = await resolveOrRacePromises([builderPromise, enginePromise], {
-      resolveTimeoutMs: BLOCK_PRODUCTION_RACE_CUTOFF_MS,
+      resolveTimeoutMs: Math.max(0, BLOCK_PRODUCTION_RACE_CUTOFF_MS - chain.clock.secFromSlot(slot) * 1000),
       raceTimeoutMs: BLOCK_PRODUCTION_RACE_TIMEOUT_MS,
       signal: controller.signal,
     });

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -37,6 +37,12 @@ export const defaultExecutionBuilderHttpOpts: ExecutionBuilderHttpOpts = {
   timeout: 12000,
 };
 
+/**
+ * Duration given to the builder to provide a `SignedBuilderBid` before the deadline
+ * is reached, aborting the external builder flow in favor of the local build process.
+ */
+const BUILDER_PROPOSAL_DELAY_TOLERANCE = 1000;
+
 export class ExecutionBuilderHttp implements IExecutionBuilder {
   readonly api: BuilderApi;
   readonly config: ChainForkConfig;
@@ -115,7 +121,9 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
     executionPayloadValue: Wei;
     blobKzgCommitments?: deneb.BlobKzgCommitments;
   }> {
-    const signedBuilderBid = (await this.api.getHeader({slot, parentHash, proposerPubkey})).value();
+    const signedBuilderBid = (
+      await this.api.getHeader({slot, parentHash, proposerPubkey}, {timeoutMs: BUILDER_PROPOSAL_DELAY_TOLERANCE})
+    ).value();
 
     if (!signedBuilderBid) {
       throw Error("No bid received");


### PR DESCRIPTION
**Motivation**

Adhere to spec and enforce [`BUILDER_PROPOSAL_DELAY_TOLERANCE`](https://github.com/ethereum/builder-specs/blob/5cb324e34e173d963d1233e238bf50e4d7497653/specs/bellatrix/validator.md?plain=1#L50) when requesting a bid from builder via `getHeader` api. This timeout is enforced by mev-boost (and other sidecars) as well but those allow to configure it and play [timing games](https://timing.pics/).

**Description**

- Enforce strict timeout on `getHeader` request [as per builder spec](https://github.com/ethereum/builder-specs/blob/5cb324e34e173d963d1233e238bf50e4d7497653/specs/bellatrix/validator.md?plain=1#L153-L155)
- Make race-cutoff of local vs. builder block relative to slot start to avoid edge cases that could delay block proposal past 2 seconds in the slot which increases the risk of orphaning the block