### PR TITLE
fix: make sure shuffling is calculated when querying next epoch proposers

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -957,9 +957,11 @@ export function getValidatorApi(
           break;
 
         case stateEpoch + 1:
+          // make sure shuffling is calculated and ready for next call to calculate nextProposers
+          await chain.shufflingCache.get(state.epochCtx.nextEpoch, state.epochCtx.nextDecisionRoot);
           // Requesting duties for next epoch is allowed since they can be predicted with high probabilities.
           // @see `epochCtx.getBeaconProposersNextEpoch` JSDocs for rationale.
-          indexes = await state.epochCtx.getBeaconProposersNextEpoch();
+          indexes = state.epochCtx.getBeaconProposersNextEpoch();
           break;
 
         case stateEpoch - 1: {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -959,7 +959,7 @@ export function getValidatorApi(
         case stateEpoch + 1:
           // Requesting duties for next epoch is allowed since they can be predicted with high probabilities.
           // @see `epochCtx.getBeaconProposersNextEpoch` JSDocs for rationale.
-          indexes = state.epochCtx.getBeaconProposersNextEpoch();
+          indexes = await state.epochCtx.getBeaconProposersNextEpoch();
           break;
 
         case stateEpoch - 1: {

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -918,22 +918,12 @@ export class EpochCache {
    * balances are sampled to adjust the probability of the next selection (32 per epoch on average). So to invalidate
    * the prediction the effective of one of those 32 samples should change and change the random_byte inequality.
    */
-  async getBeaconProposersNextEpoch(): Promise<ValidatorIndex[]> {
+  getBeaconProposersNextEpoch(): ValidatorIndex[] {
     if (!this.proposersNextEpoch.computed) {
-      if (!this.nextShuffling) {
-        this.nextShuffling = (await this.shufflingCache?.get(this.nextEpoch, this.nextDecisionRoot)) ?? null;
-      }
-      if (!this.nextShuffling) {
-        throw new EpochCacheError({
-          code: EpochCacheErrorCode.NEXT_SHUFFLING_NOT_AVAILABLE,
-          epoch: this.nextEpoch,
-          decisionRoot: this.getShufflingDecisionRoot(this.nextEpoch),
-        });
-      }
       const indexes = computeProposers(
-        this.config.getForkSeqAtEpoch(this.epoch + 1),
+        this.config.getForkSeqAtEpoch(this.nextEpoch),
         this.proposersNextEpoch.seed,
-        this.nextShuffling,
+        this.getShufflingAtEpoch(this.nextEpoch),
         this.effectiveBalanceIncrements
       );
       this.proposersNextEpoch = {computed: true, indexes};

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -918,12 +918,12 @@ export class EpochCache {
    * balances are sampled to adjust the probability of the next selection (32 per epoch on average). So to invalidate
    * the prediction the effective of one of those 32 samples should change and change the random_byte inequality.
    */
-  getBeaconProposersNextEpoch(): ValidatorIndex[] {
+  async getBeaconProposersNextEpoch(): Promise<ValidatorIndex[]> {
     if (!this.proposersNextEpoch.computed) {
       const indexes = computeProposers(
         this.config.getForkSeqAtEpoch(this.epoch + 1),
         this.proposersNextEpoch.seed,
-        this.getShufflingAtEpoch(this.nextEpoch),
+        await this.shufflingCache?.get(this.nextEpoch, this.nextDecisionRoot);
         this.effectiveBalanceIncrements
       );
       this.proposersNextEpoch = {computed: true, indexes};

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -920,10 +920,18 @@ export class EpochCache {
    */
   async getBeaconProposersNextEpoch(): Promise<ValidatorIndex[]> {
     if (!this.proposersNextEpoch.computed) {
+      const shuffling = await this.shufflingCache?.get(this.nextEpoch, this.nextDecisionRoot);
+      if (!shuffling) {
+        throw new EpochCacheError({
+          code: EpochCacheErrorCode.NEXT_SHUFFLING_NOT_AVAILABLE,
+          epoch: this.nextEpoch,
+          decisionRoot: this.getShufflingDecisionRoot(this.nextEpoch),
+        });
+      }  
       const indexes = computeProposers(
         this.config.getForkSeqAtEpoch(this.epoch + 1),
         this.proposersNextEpoch.seed,
-        await this.shufflingCache?.get(this.nextEpoch, this.nextDecisionRoot);
+        shuffling,
         this.effectiveBalanceIncrements
       );
       this.proposersNextEpoch = {computed: true, indexes};

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -920,18 +920,20 @@ export class EpochCache {
    */
   async getBeaconProposersNextEpoch(): Promise<ValidatorIndex[]> {
     if (!this.proposersNextEpoch.computed) {
-      const shuffling = await this.shufflingCache?.get(this.nextEpoch, this.nextDecisionRoot);
-      if (!shuffling) {
+      if (!this.nextShuffling) {
+        this.nextShuffling = (await this.shufflingCache?.get(this.nextEpoch, this.nextDecisionRoot)) ?? null;
+      }
+      if (!this.nextShuffling) {
         throw new EpochCacheError({
           code: EpochCacheErrorCode.NEXT_SHUFFLING_NOT_AVAILABLE,
           epoch: this.nextEpoch,
           decisionRoot: this.getShufflingDecisionRoot(this.nextEpoch),
         });
-      }  
+      }
       const indexes = computeProposers(
         this.config.getForkSeqAtEpoch(this.epoch + 1),
         this.proposersNextEpoch.seed,
-        shuffling,
+        this.nextShuffling,
         this.effectiveBalanceIncrements
       );
       this.proposersNextEpoch = {computed: true, indexes};


### PR DESCRIPTION
**Description**

Make pulling of next proposers async to await for shuffling calculation

**Motivation**
Error was found on 1.23 release after #7120 was merged with unstable due to change made in #7130

**Notes**
@twoeths I made `getBeaconProposersNextEpoch` async to resolve this but curious if you would prefer and async helper function instead.  This is the only place where `getBeaconProposersNextEpoch` gets called so will be an easy switch if you want to keep everything on `EpochCache` sync.  Just let me know and will fix it quickly.  Currently the proposers are cached on the `epochCtx` so i could just pass that through the free function to maintain the caching or we can just recompute on each API call if there will not be many.  Just let me know which way you prefer to go but I built it like this because it seemed like the best way forward.