### PR TITLE
fix: queued attestations metric

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -94,7 +94,7 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       }),
       queuedAttestations: register.gauge({
         name: "beacon_fork_choice_queued_attestations_count",
-        help: "Current count of queued_attestations in fork choice data structures",
+        help: "Count of queued_attestations in fork choice per slot",
       }),
       validatedAttestationDatas: register.gauge({
         name: "beacon_fork_choice_validated_attestation_datas_count",


### PR DESCRIPTION
**Motivation**

Make queued attestations metric consistent and helpful

**Description**

- When applying queued attestations, compute `queuedAttestationsPreviousSlot ` which is reset per slot
- For metric, use `queuedAttestationsPreviousSlot` instead of computing on the fly value
- The result is consistent across holesky nodes after deploying on feat3

<img width="1335" alt="Screenshot 2024-10-14 at 13 42 52" src="https://github.com/user-attachments/assets/787388d5-704d-4af6-af7e-fc415a328c1e">


Closes #7157
