### PR TITLE
docs: add Lodestar Gurubase link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![codecov](https://codecov.io/gh/ChainSafe/lodestar/graph/badge.svg)](https://codecov.io/gh/ChainSafe/lodestar)
 [![gitpoap badge](https://public-api.gitpoap.io/v1/repo/ChainSafe/lodestar/badge)](https://www.gitpoap.io/gh/ChainSafe/lodestar)
 
+
 [Lodestar](https://lodestar.chainsafe.io) is a TypeScript implementation of the [Ethereum Consensus specification](https://github.com/ethereum/consensus-specs) developed by [ChainSafe Systems](https://chainsafe.io).
 
 ## Getting started
@@ -25,6 +26,7 @@
   [![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/aMxzVcr)
 - :rotating_light: Please note our [security policy](./SECURITY.md).
 - :bird: Follow Lodestar on [Twitter](https://twitter.com/lodestar_eth) for announcements and updates! [![Twitter Follow](https://img.shields.io/twitter/follow/lodestar_eth)](https://twitter.com/lodestar_eth)
+- ✨ Ask [Lodestar Guru](https://gurubase.io/g/lodestar), an AI focused on Lodestar, to answer your questions based on data from Lodestar Docs. [![](https://img.shields.io/badge/Gurubase-Ask%20Lodestar%20Guru-006BFF)](https://gurubase.io/g/lodestar) 
 
 ## Prerequisites
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Lodestar Guru](https://gurubase.io/g/lodestar) to Gurubase. Lodestar Guru uses the data from this repo and data from the [docs](https://chainsafe.github.io/lodestar/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Lodestar Guru" badge, which highlights that Lodestar now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Lodestar Guru in Gurubase, just let me know that's totally fine.