### PR TITLE
fix: add logger to builder http client

### DIFF
--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -68,7 +68,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
           headers: opts.userAgent ? {"User-Agent": opts.userAgent} : undefined,
         },
       },
-      {config, metrics: metrics?.builderHttpClient}
+      {config, metrics: metrics?.builderHttpClient, logger}
     );
     logger?.info("External builder", {url: toPrintableUrl(baseUrl)});
     this.config = config;


### PR DESCRIPTION
**Motivation**

Those logs would be nice to have to better investigate builder api times and wire format used

**Description**

Adds logger to builder http client