### PR TITLE
fix: return `el_offline` as `true` in syncing status response if auth failed

### DIFF
--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -88,7 +88,9 @@ export class BeaconSync implements IBeaconSync {
 
   getSyncStatus(): SyncingStatus {
     const currentSlot = this.chain.clock.currentSlot;
-    const elOffline = this.chain.executionEngine.state === ExecutionEngineState.OFFLINE;
+    const elOffline =
+      this.chain.executionEngine.state === ExecutionEngineState.OFFLINE ||
+      this.chain.executionEngine.state === ExecutionEngineState.AUTH_FAILED;
 
     // If we are pre/at genesis, signal ready
     if (currentSlot <= GENESIS_SLOT) {


### PR DESCRIPTION
**Motivation**

If the EL client authentication fails it does not make sense to mark it as online in the syncing status reponse. This is also aligned with what's stated in https://github.com/sigp/lighthouse/pull/4295.

In the spec, the definition is vague and it might be good to clarify it there as well.

**Description**

Return `el_offline` as `true` in [syncing status api response](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getSyncingStatus) if authentication failed
