### PR TITLE
chore: update block proposal errors dashboard panel

### DIFF
--- a/dashboards/lodestar_block_production.json
+++ b/dashboards/lodestar_block_production.json
@@ -746,7 +746,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(lodestar_api_rest_errors_total{operationId=~\"produceBlockV2|produceBlindedBlock|publishBlock|publishBlindedBlock\"}[$rate_interval])",
+          "expr": "rate(lodestar_api_rest_errors_total{operationId=~\"produceBlockV3|publishBlockV2|publishBlindedBlockV2\"}[$rate_interval])",
           "legendFormat": "{{operationId}}",
           "range": true,
           "refId": "A"

--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -499,7 +499,6 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           const fork = config.getForkName(signedBlindedBlock.message.slot);
           return {
             body: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.toJson(signedBlindedBlock),
-
             headers: {
               [MetaHeader.Version]: fork,
             },


### PR DESCRIPTION
Update `operationId` in block proposal errors dashboard panel to use latest version of apis as previous (deprecated) apis are unused in Lodestar by default (and soon to be removed).