### PR TITLE
feat: add ssz support to builder api

### DIFF
--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -56,8 +56,8 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
 
   /**
    * Determine if SSZ is supported by requesting an SSZ encoded response in the `getHeader` request.
-   * If the builder responds with a SSZ serialized `SignedBuilderBid` it indicates support for submitting
-   * the `SignedBlindedBeaconBlock` as SSZ serialized bytes instead of JSON via `submitBlindedBlock`.
+   * The builder responding with a SSZ serialized `SignedBuilderBid` indicates support to handle the
+   * `SignedBlindedBeaconBlock` as SSZ serialized bytes instead of JSON when calling `submitBlindedBlock`.
    */
   private sszSupported = false;
 


### PR DESCRIPTION
**Motivation**

- https://github.com/ethereum/builder-specs/pull/104

**Description**

Minimal implementation to add SSZ support to Builder API as per https://github.com/ethereum/builder-specs/pull/104.

Few more things to consider
- forward blinded block bytes directly to `submitBlindedBlock`, this saves an extra serialization step
- possibly add CLI flag to enforce JSON for all requests / responses, could be useful for debugging
- while de-/serialization is covered by generic api tests, we need to consider how we better e2e test builder flow
