### PR TITLE
chore: ssz 0.18.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@chainsafe/persistent-merkle-tree": "^0.8.0",
-    "@chainsafe/ssz": "^0.17.1",
+    "@chainsafe/ssz": "^0.18.0",
     "@lodestar/config": "^1.22.0",
     "@lodestar/params": "^1.22.0",
     "@lodestar/types": "^1.22.0",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -102,7 +102,7 @@
     "@chainsafe/libp2p-noise": "^16.0.0",
     "@chainsafe/persistent-merkle-tree": "^0.8.0",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
-    "@chainsafe/ssz": "^0.17.1",
+    "@chainsafe/ssz": "^0.18.0",
     "@chainsafe/threads": "^1.11.1",
     "@chainsafe/pubkey-index-map": "2.0.0",
     "@ethersproject/abi": "^5.7.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
     "@chainsafe/discv5": "^10.0.1",
     "@chainsafe/enr": "^4.0.1",
     "@chainsafe/persistent-merkle-tree": "^0.8.0",
-    "@chainsafe/ssz": "^0.17.1",
+    "@chainsafe/ssz": "^0.18.0",
     "@chainsafe/threads": "^1.11.1",
     "@libp2p/crypto": "^5.0.4",
     "@libp2p/interface": "^2.1.2",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -64,7 +64,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/ssz": "^0.17.1",
+    "@chainsafe/ssz": "^0.18.0",
     "@lodestar/params": "^1.22.0",
     "@lodestar/utils": "^1.22.0",
     "@lodestar/types": "^1.22.0"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -35,7 +35,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^0.17.1",
+    "@chainsafe/ssz": "^0.18.0",
     "@lodestar/config": "^1.22.0",
     "@lodestar/utils": "^1.22.0",
     "classic-level": "^1.4.1",

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -36,7 +36,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^0.17.1",
+    "@chainsafe/ssz": "^0.18.0",
     "@lodestar/config": "^1.22.0",
     "@lodestar/params": "^1.22.0",
     "@lodestar/state-transition": "^1.22.0",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -76,7 +76,7 @@
     "@chainsafe/bls": "7.1.3",
     "@chainsafe/blst": "^0.2.0",
     "@chainsafe/persistent-merkle-tree": "^0.8.0",
-    "@chainsafe/ssz": "^0.17.1",
+    "@chainsafe/ssz": "^0.18.0",
     "@lodestar/api": "^1.22.0",
     "@lodestar/config": "^1.22.0",
     "@lodestar/params": "^1.22.0",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -62,7 +62,7 @@
     "@chainsafe/blst": "^2.0.3",
     "@chainsafe/persistent-merkle-tree": "^0.8.0",
     "@chainsafe/persistent-ts": "^0.19.1",
-    "@chainsafe/ssz": "^0.17.1",
+    "@chainsafe/ssz": "^0.18.0",
     "@chainsafe/swap-or-not-shuffle": "^0.0.2",
     "@lodestar/config": "^1.22.0",
     "@lodestar/params": "^1.22.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -73,7 +73,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/ssz": "^0.17.1",
+    "@chainsafe/ssz": "^0.18.0",
     "@lodestar/params": "^1.22.0",
     "ethereum-cryptography": "^2.0.0"
   },

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "@chainsafe/blst": "^2.0.3",
-    "@chainsafe/ssz": "^0.17.1",
+    "@chainsafe/ssz": "^0.18.0",
     "@lodestar/api": "^1.22.0",
     "@lodestar/config": "^1.22.0",
     "@lodestar/db": "^1.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -649,10 +649,10 @@
     "@chainsafe/as-sha256" "^0.4.1"
     "@chainsafe/persistent-merkle-tree" "^0.6.1"
 
-"@chainsafe/ssz@^0.17.1":
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.17.1.tgz#7986afbcad5e6971006d596fdb7dfa34bc195131"
-  integrity sha512-1ay46QqYcVTBvUnDXTPTi5WTiENu7tIxpZGMDpUWps1/nYBmh/We/UoCF/jO+o/fkcDD3p8xQPlHbcCfy+jyjA==
+"@chainsafe/ssz@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.18.0.tgz#773d40df9dff3b6a2a4c6685d9797abceb9d36f7"
+  integrity sha512-1ikTjk3JK6+fsGWiT5IvQU0AP6gF3fDzGmPfkKthbcbgTUR8fjB83Ywp9ko/ZoiDGfrSFkATgT4hvRzclu0IAA==
   dependencies:
     "@chainsafe/as-sha256" "0.5.0"
     "@chainsafe/persistent-merkle-tree" "0.8.0"


### PR DESCRIPTION
**Motivation**

To prepare for EIP-4881 #4935

**Description**

Use latest ssz version 0.18.0