### PR TITLE
feat: check for no commitments on block or column in sidecar validation

### DIFF
--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -72,6 +72,8 @@ export function validateDataColumnsSidecars(
     if (
       columnBlockHeader.slot !== blockSlot ||
       !byteArrayEquals(columnBlockRoot, blockRoot) ||
+      kzgCommitments.length === 0 ||
+      blockKzgCommitments.length === 0 ||
       blockKzgCommitments.length !== kzgCommitments.length ||
       blockKzgCommitments
         .map((commitment, i) => byteArrayEquals(commitment, kzgCommitments[i]))

--- a/packages/beacon-node/test/unit/util/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/util/dataColumn.test.ts
@@ -136,9 +136,7 @@ describe("data column sidecars", () => {
     expect(columnSidecars.length).toEqual(NUMBER_OF_COLUMNS);
     expect(columnSidecars[0].column.length).toEqual(blobs.length);
 
-    signedBeaconBlock.message.body.blobKzgCommitments = [];
-
-    expect(() => validateDataColumnsSidecars(slot, blockRoot, kzgCommitments, columnSidecars)).toThrow(
+    expect(() => validateDataColumnsSidecars(slot, blockRoot, [], columnSidecars)).toThrow(
       `Invalid data column sidecar slot=${slot}`
     );
   });

--- a/packages/beacon-node/test/unit/util/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/util/dataColumn.test.ts
@@ -103,4 +103,43 @@ describe("data column sidecars", () => {
 
     expect(validateDataColumnsSidecars(slot, blockRoot, kzgCommitments, columnSidecars)).toBeUndefined();
   });
+
+  it("fail for no blob commitments in validateDataColumnsSidecars", () => {
+    const chainConfig = createChainForkConfig({
+      ...defaultChainConfig,
+      ALTAIR_FORK_EPOCH: 0,
+      BELLATRIX_FORK_EPOCH: 0,
+      DENEB_FORK_EPOCH: 0,
+      ELECTRA_FORK_EPOCH: 0,
+    });
+    const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
+    const config = createBeaconConfig(chainConfig, genesisValidatorsRoot);
+
+    const chain = getMockedBeaconChain({config});
+    afterEachCallbacks.push(() => chain.close());
+
+    const slot = 0;
+    const blobs = [generateRandomBlob(), generateRandomBlob()];
+    const kzgCommitments = blobs.map((blob) => ckzg.blobToKzgCommitment(blob));
+
+    const signedBeaconBlock = ssz.deneb.SignedBeaconBlock.defaultValue();
+
+    for (const kzgCommitment of kzgCommitments) {
+      signedBeaconBlock.message.body.executionPayload.transactions.push(transactionForKzgCommitment(kzgCommitment));
+      signedBeaconBlock.message.body.blobKzgCommitments.push(kzgCommitment);
+    }
+    const blockRoot = ssz.deneb.BeaconBlock.hashTreeRoot(signedBeaconBlock.message);
+    const columnSidecars = computeDataColumnSidecars(config, signedBeaconBlock, {
+      blobs,
+    });
+
+    expect(columnSidecars.length).toEqual(NUMBER_OF_COLUMNS);
+    expect(columnSidecars[0].column.length).toEqual(blobs.length);
+
+    signedBeaconBlock.message.body.blobKzgCommitments.length = [];
+
+    expect(() => validateDataColumnsSidecars(slot, blockRoot, kzgCommitments, columnSidecars)).toThrow(
+      `Invalid data column sidecar slot=${slot}`
+    );
+  });
 });

--- a/packages/beacon-node/test/unit/util/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/util/dataColumn.test.ts
@@ -136,7 +136,7 @@ describe("data column sidecars", () => {
     expect(columnSidecars.length).toEqual(NUMBER_OF_COLUMNS);
     expect(columnSidecars[0].column.length).toEqual(blobs.length);
 
-    signedBeaconBlock.message.body.blobKzgCommitments.length = [];
+    signedBeaconBlock.message.body.blobKzgCommitments = [];
 
     expect(() => validateDataColumnsSidecars(slot, blockRoot, kzgCommitments, columnSidecars)).toThrow(
       `Invalid data column sidecar slot=${slot}`


### PR DESCRIPTION
**Motivation**

Saves compute when there are no commitments to validate against.

- Adds check for empty blob commitments and empty column sidecar commitments
- Add test to check that validation throws is there are no blob commitments

Requested during peerDas testing.
https://discord.com/channels/595666850260713488/1292591633782800385/1292804781597003807
