### PR TITLE
feat: forward blinded block ssz bytes to submitBlindedBlock api

### DIFF
--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -71,7 +71,7 @@ export type Endpoints = {
 
   submitBlindedBlock: Endpoint<
     "POST",
-    {signedBlindedBlock: SignedBlindedBeaconBlock},
+    {signedBlindedBlock: SignedBlindedBeaconBlock; blockBytes?: Uint8Array | null},
     {body: unknown; headers: {[MetaHeader.Version]: string}},
     ExecutionPayload | ExecutionPayloadAndBlobsBundle,
     VersionMeta
@@ -138,10 +138,10 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
             signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body),
           };
         },
-        writeReqSsz: ({signedBlindedBlock}) => {
+        writeReqSsz: ({signedBlindedBlock, blockBytes}) => {
           const fork = config.getForkName(signedBlindedBlock.message.slot);
           return {
-            body: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.serialize(signedBlindedBlock),
+            body: blockBytes ?? getExecutionForkTypes(fork).SignedBlindedBeaconBlock.serialize(signedBlindedBlock),
             headers: {
               [MetaHeader.Version]: fork,
             },

--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -71,7 +71,11 @@ export type Endpoints = {
 
   submitBlindedBlock: Endpoint<
     "POST",
-    {signedBlindedBlock: SignedBlindedBeaconBlock; blockBytes?: Uint8Array | null},
+    {
+      signedBlindedBlock: SignedBlindedBeaconBlock;
+      /** SSZ serialized `signedBlindedBlock` bytes */
+      blockBytes?: Uint8Array | null;
+    },
     {body: unknown; headers: {[MetaHeader.Version]: string}},
     ExecutionPayload | ExecutionPayloadAndBlobsBundle,
     VersionMeta

--- a/packages/api/test/unit/builder/testData.ts
+++ b/packages/api/test/unit/builder/testData.ts
@@ -23,7 +23,7 @@ export const testData: GenericServerTestCases<Endpoints> = {
     res: {data: ssz.bellatrix.SignedBuilderBid.defaultValue(), meta: {version: ForkName.bellatrix}},
   },
   submitBlindedBlock: {
-    args: {signedBlindedBlock: ssz.deneb.SignedBlindedBeaconBlock.defaultValue()},
+    args: {signedBlindedBlock: {data: ssz.deneb.SignedBlindedBeaconBlock.defaultValue()}},
     res: {data: ssz.bellatrix.ExecutionPayload.defaultValue(), meta: {version: ForkName.bellatrix}},
   },
 };

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -15,6 +15,7 @@ import {
   SignedBeaconBlock,
   SignedBeaconBlockOrContents,
   SignedBlindedBeaconBlock,
+  WithOptionalBytes,
 } from "@lodestar/types";
 import {
   BlockSource,
@@ -269,7 +270,10 @@ export function getBeaconBlockApi({
     const source = ProducedBlockSource.builder;
     chain.logger.debug("Reconstructing  signedBlockOrContents", {slot, blockRoot, source});
 
-    const signedBlockOrContents = await reconstructBuilderBlockOrContents(chain, signedBlindedBlock, context?.sszBytes);
+    const signedBlockOrContents = await reconstructBuilderBlockOrContents(chain, {
+      data: signedBlindedBlock,
+      bytes: context?.sszBytes,
+    });
 
     // the full block is published by relay and it's possible that the block is already known to us
     // by gossip
@@ -507,14 +511,13 @@ export function getBeaconBlockApi({
 
 async function reconstructBuilderBlockOrContents(
   chain: ApiModules["chain"],
-  signedBlindedBlock: SignedBlindedBeaconBlock,
-  blockBytes?: Uint8Array | null
+  signedBlindedBlock: WithOptionalBytes<SignedBlindedBeaconBlock>
 ): Promise<SignedBeaconBlockOrContents> {
   const executionBuilder = chain.executionBuilder;
   if (!executionBuilder) {
     throw Error("executionBuilder required to publish SignedBlindedBeaconBlock");
   }
 
-  const signedBlockOrContents = await executionBuilder.submitBlindedBlock(signedBlindedBlock, blockBytes);
+  const signedBlockOrContents = await executionBuilder.submitBlindedBlock(signedBlindedBlock);
   return signedBlockOrContents;
 }

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -269,7 +269,7 @@ export function getBeaconBlockApi({
     const source = ProducedBlockSource.builder;
     chain.logger.debug("Reconstructing  signedBlockOrContents", {slot, blockRoot, source});
 
-    const signedBlockOrContents = await reconstructBuilderBlockOrContents(chain, signedBlindedBlock);
+    const signedBlockOrContents = await reconstructBuilderBlockOrContents(chain, signedBlindedBlock, context?.sszBytes);
 
     // the full block is published by relay and it's possible that the block is already known to us
     // by gossip
@@ -507,13 +507,14 @@ export function getBeaconBlockApi({
 
 async function reconstructBuilderBlockOrContents(
   chain: ApiModules["chain"],
-  signedBlindedBlock: SignedBlindedBeaconBlock
+  signedBlindedBlock: SignedBlindedBeaconBlock,
+  blockBytes?: Uint8Array | null
 ): Promise<SignedBeaconBlockOrContents> {
   const executionBuilder = chain.executionBuilder;
   if (!executionBuilder) {
     throw Error("executionBuilder required to publish SignedBlindedBeaconBlock");
   }
 
-  const signedBlockOrContents = await executionBuilder.submitBlindedBlock(signedBlindedBlock);
+  const signedBlockOrContents = await executionBuilder.submitBlindedBlock(signedBlindedBlock, blockBytes);
   return signedBlockOrContents;
 }

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -9,6 +9,7 @@ import {
   SignedBlindedBeaconBlock,
   ExecutionPayloadHeader,
   electra,
+  WithOptionalBytes,
 } from "@lodestar/types";
 import {parseExecutionPayloadAndBlobsBundle, reconstructFullBlockOrContents} from "@lodestar/state-transition";
 import {ChainForkConfig} from "@lodestar/config";
@@ -150,11 +151,10 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
   }
 
   async submitBlindedBlock(
-    signedBlindedBlock: SignedBlindedBeaconBlock,
-    blockBytes?: Uint8Array | null
+    signedBlindedBlock: WithOptionalBytes<SignedBlindedBeaconBlock>
   ): Promise<SignedBeaconBlockOrContents> {
     const res = await this.api.submitBlindedBlock(
-      {signedBlindedBlock, blockBytes},
+      {signedBlindedBlock},
       {retries: 2, requestWireFormat: this.sszSupported ? WireFormat.ssz : WireFormat.json}
     );
 
@@ -166,6 +166,6 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
     // probably need diagonis if this block turns out to be invalid because of some bug
     //
     const contents = blobsBundle ? {blobs: blobsBundle.blobs, kzgProofs: blobsBundle.proofs} : null;
-    return reconstructFullBlockOrContents(signedBlindedBlock, {executionPayload, contents});
+    return reconstructFullBlockOrContents(signedBlindedBlock.data, {executionPayload, contents});
   }
 }

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -149,9 +149,12 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
     return {header, executionPayloadValue, blobKzgCommitments, executionRequests};
   }
 
-  async submitBlindedBlock(signedBlindedBlock: SignedBlindedBeaconBlock): Promise<SignedBeaconBlockOrContents> {
+  async submitBlindedBlock(
+    signedBlindedBlock: SignedBlindedBeaconBlock,
+    blockBytes?: Uint8Array | null
+  ): Promise<SignedBeaconBlockOrContents> {
     const res = await this.api.submitBlindedBlock(
-      {signedBlindedBlock},
+      {signedBlindedBlock, blockBytes},
       {retries: 2, requestWireFormat: this.sszSupported ? WireFormat.ssz : WireFormat.json}
     );
 

--- a/packages/beacon-node/src/execution/builder/interface.ts
+++ b/packages/beacon-node/src/execution/builder/interface.ts
@@ -9,6 +9,7 @@ import {
   ExecutionPayloadHeader,
   SignedBlindedBeaconBlock,
   electra,
+  WithOptionalBytes,
 } from "@lodestar/types";
 import {ForkExecution} from "@lodestar/params";
 
@@ -40,7 +41,6 @@ export interface IExecutionBuilder {
     executionRequests?: electra.ExecutionRequests;
   }>;
   submitBlindedBlock(
-    signedBlindedBlock: SignedBlindedBeaconBlock,
-    blockBytes?: Uint8Array | null
+    signedBlindedBlock: WithOptionalBytes<SignedBlindedBeaconBlock>
   ): Promise<SignedBeaconBlockOrContents>;
 }

--- a/packages/beacon-node/src/execution/builder/interface.ts
+++ b/packages/beacon-node/src/execution/builder/interface.ts
@@ -39,5 +39,8 @@ export interface IExecutionBuilder {
     blobKzgCommitments?: deneb.BlobKzgCommitments;
     executionRequests?: electra.ExecutionRequests;
   }>;
-  submitBlindedBlock(signedBlock: SignedBlindedBeaconBlock): Promise<SignedBeaconBlockOrContents>;
+  submitBlindedBlock(
+    signedBlindedBlock: SignedBlindedBeaconBlock,
+    blockBytes?: Uint8Array | null
+  ): Promise<SignedBeaconBlockOrContents>;
 }

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -32,6 +32,12 @@ export enum ProducedBlockSource {
   engine = "engine",
 }
 
+export type WithOptionalBytes<T> = {
+  data: T;
+  /** SSZ serialized `data` bytes */
+  bytes?: Uint8Array | null;
+};
+
 export type SlotRootHex = {slot: Slot; root: RootHex};
 export type SlotOptionalRoot = {slot: Slot; root?: RootHex};
 


### PR DESCRIPTION
**Motivation**

Follow up on https://github.com/ChainSafe/lodestar/pull/7180 to forward blinded block bytes directly to `submitBlindedBlock` to save an extra serialization step.

**Description**

Forwards the raw ssz bytes of blinded block and use those when submitting blinded block to the builder.

I went with an optional extra argument as this seemed the least complicated / messy in terms of handling.

From a simple function signature point of view, something like
```ts
signedBlindedBlock: SignedBlindedBeaconBlock | Uint8Array
```

might be cleaner but this causes bunch of issues such as having to extract slot from bytes or handling bytes in JSON serialization case.

We always have to deserialize the `SignedBlindedBeaconBlock` to reconstruct the full block, so there would be no benefit there.
