### PR TITLE
feat: queue messages at gossipsub

### DIFF
--- a/packages/beacon-node/src/network/events.ts
+++ b/packages/beacon-node/src/network/events.ts
@@ -24,6 +24,7 @@ export enum NetworkEvent {
   pendingGossipsubMessage = "gossip.pendingGossipsubMessage",
   /** (App -> Network) A gossip message has been validated */
   gossipMessageValidationResult = "gossip.messageValidationResult",
+  blockProcessed = "blockProcessed",
 }
 
 export type NetworkEventData = {
@@ -39,6 +40,7 @@ export type NetworkEventData = {
     propagationSource: PeerIdStr;
     acceptance: TopicValidatorResult;
   };
+  [NetworkEvent.blockProcessed]: {rootHex: RootHex};
 };
 
 export const networkEventDirection: Record<NetworkEvent, EventDirection> = {
@@ -50,6 +52,7 @@ export const networkEventDirection: Record<NetworkEvent, EventDirection> = {
   [NetworkEvent.unknownBlockInput]: EventDirection.workerToMain,
   [NetworkEvent.pendingGossipsubMessage]: EventDirection.workerToMain,
   [NetworkEvent.gossipMessageValidationResult]: EventDirection.mainToWorker,
+  [NetworkEvent.blockProcessed]: EventDirection.mainToWorker,
 };
 
 export type INetworkEventBus = StrictEventEmitterSingleArg<NetworkEventData>;

--- a/packages/beacon-node/src/network/events.ts
+++ b/packages/beacon-node/src/network/events.ts
@@ -1,6 +1,6 @@
 import {EventEmitter} from "node:events";
 import {PeerId, TopicValidatorResult} from "@libp2p/interface";
-import {phase0, RootHex} from "@lodestar/types";
+import {phase0, RootHex, Slot} from "@lodestar/types";
 import {BlockInput, NullBlockInput} from "../chain/blocks/types.js";
 import {StrictEventEmitterSingleArg} from "../util/strictEvents.js";
 import {PeerIdStr} from "../util/peerId.js";
@@ -40,7 +40,7 @@ export type NetworkEventData = {
     propagationSource: PeerIdStr;
     acceptance: TopicValidatorResult;
   };
-  [NetworkEvent.blockProcessed]: {rootHex: RootHex};
+  [NetworkEvent.blockProcessed]: {slot: Slot; rootHex: RootHex};
 };
 
 export const networkEventDirection: Record<NetworkEvent, EventDirection> = {

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -154,6 +154,7 @@ export class Eth2Gossipsub extends GossipSub {
 
     this.addEventListener("gossipsub:message", this.onGossipsubMessage.bind(this));
     this.events.on(NetworkEvent.gossipMessageValidationResult, this.onValidationResult.bind(this));
+    this.events.on(NetworkEvent.blockProcessed, this.onBlockProcessed.bind(this));
 
     // Having access to this data is CRUCIAL for debugging. While this is a massive log, it must not be deleted.
     // Scoring issues require this dump + current peer score stats to re-calculate scores.
@@ -317,6 +318,10 @@ export class Eth2Gossipsub extends GossipSub {
       this.reportMessageValidationResult(data.msgId, data.propagationSource, data.acceptance);
     });
   }
+
+  private onBlockProcessed(data: NetworkEventData[NetworkEvent.blockProcessed]): void {
+  }
+
 }
 
 /**

--- a/packages/beacon-node/src/network/gossip/metrics.ts
+++ b/packages/beacon-node/src/network/gossip/metrics.ts
@@ -56,5 +56,12 @@ export function createEth2GossipsubMetrics(register: RegistryMetricCreator) {
         labelNames: ["subnet", "fork"],
       }),
     },
+    queuedEvents: {
+      countPerSlot: register.gauge({
+        name: "lodestar_gossip_queued_messages_per_slot_total",
+        help: "Total number of gossip messages waiting to be sent to main thread pet slot",
+      }),
+      // TODO: more metrics, for example messages that's too old
+    }
   };
 }

--- a/packages/beacon-node/src/network/processor/extractSlotRootFns.ts
+++ b/packages/beacon-node/src/network/processor/extractSlotRootFns.ts
@@ -50,5 +50,6 @@ export function createExtractBlockSlotRootFns(): ExtractSlotRootFns {
       }
       return {slot};
     },
+    // TODO: sync committee messages
   };
 }

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -318,6 +318,7 @@ export class NetworkProcessor {
     block: string;
     executionOptimistic: boolean;
   }): Promise<void> {
+    this.events.emit(NetworkEvent.blockProcessed, {rootHex});
     this.isProcessingCurrentSlotBlock = false;
     const byRootGossipsubMessages = this.awaitingGossipsubMessagesByRootBySlot.getOrDefault(slot);
     const waitingGossipsubMessages = byRootGossipsubMessages.getOrDefault(rootHex);

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -318,7 +318,7 @@ export class NetworkProcessor {
     block: string;
     executionOptimistic: boolean;
   }): Promise<void> {
-    this.events.emit(NetworkEvent.blockProcessed, {rootHex});
+    this.events.emit(NetworkEvent.blockProcessed, {slot, rootHex});
     this.isProcessingCurrentSlotBlock = false;
     const byRootGossipsubMessages = this.awaitingGossipsubMessagesByRootBySlot.getOrDefault(slot);
     const waitingGossipsubMessages = byRootGossipsubMessages.getOrDefault(rootHex);


### PR DESCRIPTION
**Motivation**

- when subscribing to all subnets, there are ~300ms delay between the time we first see gossip block at network thread and gossip handler
- there's a hypothesis that the queued attestations in main thread may cause this 

**Description**

- this PR queue attestations of unknown root in network thread, specifically in the gossip class
- however the result is the same, I still see the delay, it seems that queuing at gossip side does not help a lot. Need to revisit this later to see if it helps
- it seems to me the latency from network thread to main thread is due to garbage collection instead, could be the structural clone

part of #7188
