### PR TITLE
fix: log as info instead of warn if builder does not provide a bid

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -70,6 +70,7 @@ import {validateGossipFnRetryUnknownRoot} from "../../../network/processor/gossi
 import {SCHEDULER_LOOKAHEAD_FACTOR} from "../../../chain/prepareNextSlot.js";
 import {ChainEvent, CheckpointHex, CommonBlockBody} from "../../../chain/index.js";
 import {ApiOptions} from "../../options.js";
+import {NoBidReceived} from "../../../execution/builder/http.js";
 import {getLodestarClientVersion} from "../../../util/metadata.js";
 import {computeSubnetForCommitteesAtSlot, getPubkeysForIndices, selectBlockProductionSource} from "./utils.js";
 
@@ -661,14 +662,21 @@ export function getValidatorApi(
     }
 
     if (builder.status === "rejected" && isBuilderEnabled) {
-      logger.warn(
-        "Builder failed to produce the block",
-        {
+      if (builder.reason instanceof NoBidReceived) {
+        logger.info("Builder did not provide a bid", {
           ...loggerContext,
           durationMs: builder.durationMs,
-        },
-        builder.reason
-      );
+        });
+      } else {
+        logger.warn(
+          "Builder failed to produce the block",
+          {
+            ...loggerContext,
+            durationMs: builder.durationMs,
+          },
+          builder.reason
+        );
+      }
     }
 
     if (builder.status === "rejected" && engine.status === "rejected") {

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -39,6 +39,11 @@ export const defaultExecutionBuilderHttpOpts: ExecutionBuilderHttpOpts = {
   timeout: 12000,
 };
 
+/**
+ * Expected error if builder does not provide a bid. Most of the time, this
+ * is due to `min-bid` setting on the mev-boost side but in rare cases could
+ * also happen if there are no bids from any of the connected relayers.
+ */
 export class NoBidReceived extends Error {
   constructor() {
     super("No bid received");

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -39,6 +39,12 @@ export const defaultExecutionBuilderHttpOpts: ExecutionBuilderHttpOpts = {
   timeout: 12000,
 };
 
+export class NoBidReceived extends Error {
+  constructor() {
+    super("No bid received");
+  }
+}
+
 /**
  * Duration given to the builder to provide a `SignedBuilderBid` before the deadline
  * is reached, aborting the external builder flow in favor of the local build process.
@@ -138,7 +144,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
     const signedBuilderBid = res.value();
 
     if (!signedBuilderBid) {
-      throw Error("No bid received");
+      throw new NoBidReceived();
     }
 
     this.sszSupported = res.wireFormat() === WireFormat.ssz;


### PR DESCRIPTION
**Motivation**

We previously had a really bad JSON parse error which created too much noise if builder didn't provide a bid but since the api client refactor we can handle this case properly but we still log it as a `warn` currently if builder does not provide a bid. While I think it's not as bad as it was, after further discussion and input in https://github.com/ChainSafe/lodestar/issues/6574 I think it's reasonable to just log it as `info` and create less noise (no stacktrace).

**Description**

Log as `info` instead of `warn` if builder does not provide a bid

Closes https://github.com/ChainSafe/lodestar/issues/6574
