### PR TITLE
feat: add metric to track default validator configuration

### DIFF
--- a/dashboards/lodestar_validator_client.json
+++ b/dashboards/lodestar_validator_client.json
@@ -497,7 +497,7 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 6,
+        "w": 3,
         "x": 12,
         "y": 2
       },
@@ -552,8 +552,8 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 6,
-        "x": 18,
+        "w": 3,
+        "x": 15,
         "y": 2
       },
       "id": 37,
@@ -589,6 +589,91 @@
       ],
       "title": "Heap used",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "type": "color-text"
+            },
+            "inspect": false
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 2
+      },
+      "id": 48,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "vc_default_configuration",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "client_name": true,
+              "group": true,
+              "host_type": true,
+              "instance": true,
+              "job": true,
+              "network": true,
+              "scrape_location": true
+            },
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "broadcastValidation": "Broadcast validation",
+              "builderSelection": "Builder selection strategy"
+            }
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "datasource": {

--- a/dashboards/lodestar_validator_client.json
+++ b/dashboards/lodestar_validator_client.json
@@ -668,7 +668,7 @@
             "indexByName": {},
             "renameByName": {
               "broadcastValidation": "Broadcast validation",
-              "builderSelection": "Builder selection strategy"
+              "builderSelection": "Builder selection"
             }
           }
         }

--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -1,3 +1,4 @@
+import {routes} from "@lodestar/api";
 import {MetricsRegisterExtra} from "@lodestar/utils";
 
 export enum MessageSource {
@@ -38,6 +39,15 @@ export function getMetrics(register: MetricsRegisterExtra, gitData: LodestarGitD
     .set(gitData, 1);
 
   return {
+    defaultConfiguration: register.gauge<{
+      builderSelection: routes.validator.BuilderSelection;
+      broadcastValidation: routes.beacon.BroadcastValidation;
+    }>({
+      name: "vc_default_configuration",
+      help: "Default validator configuration",
+      labelNames: ["builderSelection", "broadcastValidation"],
+    }),
+
     // Attestation journey:
     // - Wait for block or 1/3, call prepare attestation
     // - Get attestation, sign, call publish

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -329,6 +329,8 @@ export class Validator {
       strictFeeRecipientCheck,
     });
 
+    metrics?.defaultConfiguration.set({builderSelection: defaultBuilderSelection, broadcastValidation}, 1);
+
     // Instantiates block and attestation services and runs them once the chain has been started.
     return Validator.init(opts, genesis, metrics);
   }


### PR DESCRIPTION
**Motivation**

Related to https://github.com/ChainSafe/lodestar/issues/5932, it seems useful to see in grafana how the validator client is configured and detect misconfigurations.

**Description**

Add metric to track default validator configuration

![image](https://github.com/user-attachments/assets/21ac8140-3439-491e-883d-45529b7be85b)

We can extend the tracked default configuration values as needed by simply adding a new label to the metric.

@wemeetagain does this resolve https://github.com/ChainSafe/lodestar/issues/5932?

> We should track when we select builder vs local block building and why.

This will require more work and will have to be tracked on the beacon node side, we have https://github.com/ChainSafe/lodestar/pull/7190 now which shows engine and builder errors which gives some insights but in case that both blocks succeed, we have to add more metrics to properly track the reason why we selected builder over engine block or vice-versa.
