### PR TITLE
fix: remove warning log if validator pubkey not found or invalid

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -18,8 +18,7 @@ import {filterStateValidatorsByStatus, getStateValidatorIndex, getStateResponse,
 export function getBeaconStateApi({
   chain,
   config,
-  logger,
-}: Pick<ApiModules, "chain" | "config" | "logger">): ApplicationMethods<routes.beacon.state.Endpoints> {
+}: Pick<ApiModules, "chain" | "config">): ApplicationMethods<routes.beacon.state.Endpoints> {
   async function getState(
     stateId: routes.beacon.StateId
   ): Promise<{state: BeaconStateAllForks; executionOptimistic: boolean; finalized: boolean}> {
@@ -95,8 +94,6 @@ export function getBeaconStateApi({
               currentEpoch
             );
             validatorResponses.push(validatorResponse);
-          } else {
-            logger.warn(resp.reason, {id});
           }
         }
         return {
@@ -145,8 +142,6 @@ export function getBeaconStateApi({
             const index = resp.validatorIndex;
             const {pubkey, activationEpoch} = state.validators.getReadonly(index);
             validatorIdentities.push({index, pubkey, activationEpoch});
-          } else {
-            logger.warn(resp.reason, {id});
           }
         }
       } else {


### PR DESCRIPTION
**Motivation**

This log is too noisy and quite common if the validator client has loaded pubkeys which are not yet active. We can't log this as `warn`, an alternative would be to log it was `debug` but the scenario where this log would be useful, e.g. a user querying the api manually, a debug log will hardly be visible and likely the user it better of just double checking the pubkey sent (ie. in case it is malformed).

**Description**

Remove warning log if validator pubkey not found or invalid, this reverts https://github.com/ChainSafe/lodestar/pull/7107/commits/e595ab713d16893ea35f9b70e92ec4cacb608dde added in https://github.com/ChainSafe/lodestar/pull/7107
