### PR TITLE
refactor: move WithBytes to types package

### DIFF
--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -28,6 +28,7 @@ import {
   deneb,
   phase0,
   SignedAggregateAndProof,
+  WithBytes,
 } from "@lodestar/types";
 import {PeerIdStr} from "../util/peerId.js";
 import {INetworkEventBus} from "./events.js";
@@ -35,8 +36,6 @@ import {INetworkCorePublic} from "./core/types.js";
 import {GossipType} from "./gossip/interface.js";
 import {PendingGossipsubMessage} from "./processor/types.js";
 import {PeerAction} from "./peers/index.js";
-
-export type WithBytes<T> = {data: T; bytes: Uint8Array};
 
 /**
  * The architecture of the network looks like so:

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -19,6 +19,7 @@ import {
   LightClientOptimisticUpdate,
   LightClientUpdate,
   SignedAggregateAndProof,
+  WithBytes,
 } from "@lodestar/types";
 import {routes} from "@lodestar/api";
 import {ResponseIncoming} from "@lodestar/reqresp";
@@ -29,7 +30,7 @@ import {IBeaconDb} from "../db/interface.js";
 import {PeerIdStr, peerIdToString} from "../util/peerId.js";
 import {IClock} from "../util/clock.js";
 import {NetworkOptions} from "./options.js";
-import {WithBytes, INetwork} from "./interface.js";
+import {INetwork} from "./interface.js";
 import {ReqRespMethod} from "./reqresp/index.js";
 import {GossipHandlers, GossipTopicMap, GossipType, GossipTypeMap} from "./gossip/index.js";
 import {PeerAction, PeerScoreStats} from "./peers/index.js";

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -1,11 +1,11 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {deneb, Epoch, phase0, SignedBeaconBlock, Slot} from "@lodestar/types";
+import {deneb, Epoch, phase0, SignedBeaconBlock, Slot, WithBytes} from "@lodestar/types";
 import {ForkSeq} from "@lodestar/params";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 
 import {BlobsSource, BlockInput, BlockSource, getBlockInput, BlockInputDataBlobs} from "../../chain/blocks/types.js";
 import {PeerIdStr} from "../../util/peerId.js";
-import {INetwork, WithBytes} from "../interface.js";
+import {INetwork} from "../interface.js";
 
 export async function beaconBlocksMaybeBlobsByRange(
   config: ChainForkConfig,

--- a/packages/beacon-node/src/network/reqresp/utils/collect.ts
+++ b/packages/beacon-node/src/network/reqresp/utils/collect.ts
@@ -1,7 +1,7 @@
 import {Type} from "@chainsafe/ssz";
 import {ResponseIncoming, RequestErrorCode, RequestError} from "@lodestar/reqresp";
+import {WithBytes} from "@lodestar/types";
 import {ResponseTypeGetter} from "../types.js";
-import {WithBytes} from "../../interface.js";
 
 /**
  * Sink for `<response_chunk>*`, from

--- a/packages/beacon-node/src/network/reqresp/utils/collectSequentialBlocksInRange.ts
+++ b/packages/beacon-node/src/network/reqresp/utils/collectSequentialBlocksInRange.ts
@@ -1,7 +1,6 @@
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {LodestarError} from "@lodestar/utils";
-import {phase0, SignedBeaconBlock} from "@lodestar/types";
-import {WithBytes} from "../../interface.js";
+import {phase0, SignedBeaconBlock, WithBytes} from "@lodestar/types";
 import {ReqRespMethod, responseSszTypeByMethod} from "../types.js";
 import {sszDeserializeResponse} from "./collect.js";
 

--- a/packages/beacon-node/src/sync/backfill/verify.ts
+++ b/packages/beacon-node/src/sync/backfill/verify.ts
@@ -1,9 +1,8 @@
 import {CachedBeaconStateAllForks, ISignatureSet, getBlockProposerSignatureSet} from "@lodestar/state-transition";
 import {BeaconConfig} from "@lodestar/config";
-import {Root, ssz, Slot, SignedBeaconBlock} from "@lodestar/types";
+import {Root, ssz, Slot, SignedBeaconBlock, WithBytes} from "@lodestar/types";
 import {GENESIS_SLOT} from "@lodestar/params";
 import {IBlsVerifier} from "../../chain/bls/index.js";
-import {WithBytes} from "../../network/interface.js";
 import {BackfillSyncError, BackfillSyncErrorCode} from "./errors.js";
 
 export type BackfillBlockHeader = {

--- a/packages/beacon-node/test/unit/sync/backfill/verify.test.ts
+++ b/packages/beacon-node/test/unit/sync/backfill/verify.test.ts
@@ -4,9 +4,8 @@ import {fileURLToPath} from "node:url";
 import {describe, it, expect} from "vitest";
 import {createBeaconConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
-import {phase0, ssz} from "@lodestar/types";
+import {phase0, ssz, WithBytes} from "@lodestar/types";
 import {verifyBlockSequence} from "../../../../src/sync/backfill/verify.js";
-import {WithBytes} from "../../../../src/network/interface.js";
 import {ZERO_HASH} from "../../../../src/constants/constants.js";
 import {BackfillSyncErrorCode, BackfillSyncError} from "./../../../../src/sync/backfill/errors.js";
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -32,6 +32,12 @@ export enum ProducedBlockSource {
   engine = "engine",
 }
 
+export type WithBytes<T> = {
+  data: T;
+  /** SSZ serialized `data` bytes */
+  bytes: Uint8Array;
+};
+
 export type WithOptionalBytes<T> = {
   data: T;
   /** SSZ serialized `data` bytes */


### PR DESCRIPTION
Moves `WithBytes` to types packages to be consistent with new type added in https://github.com/ChainSafe/lodestar/pull/7185 and allow reuse.