### PR TITLE
feat: only extract roots of early gossip messages

### DIFF
--- a/packages/beacon-node/src/network/processor/extractSlotRootFns.ts
+++ b/packages/beacon-node/src/network/processor/extractSlotRootFns.ts
@@ -16,23 +16,40 @@ import {ExtractSlotRootFns} from "./types.js";
  */
 export function createExtractBlockSlotRootFns(): ExtractSlotRootFns {
   return {
-    [GossipType.beacon_attestation]: (data: Uint8Array): SlotRootHex | null => {
+    [GossipType.beacon_attestation]: (data: Uint8Array, extractRoot: boolean): SlotOptionalRoot | null => {
       const slot = getSlotFromAttestationSerialized(data);
-      const root = getBlockRootFromAttestationSerialized(data);
-
-      if (slot === null || root === null) {
+      if (slot === null) {
         return null;
       }
-      return {slot, root};
+
+      if (extractRoot) {
+        const root = getBlockRootFromAttestationSerialized(data);
+        if (root === null) {
+          return null;
+        }
+
+        return {slot, root};
+      }
+
+      return {slot};
     },
-    [GossipType.beacon_aggregate_and_proof]: (data: Uint8Array): SlotRootHex | null => {
+    [GossipType.beacon_aggregate_and_proof]: (data: Uint8Array, extractRoot: boolean): SlotOptionalRoot | null => {
       const slot = getSlotFromSignedAggregateAndProofSerialized(data);
-      const root = getBlockRootFromSignedAggregateAndProofSerialized(data);
-
-      if (slot === null || root === null) {
+      if (slot === null) {
         return null;
       }
-      return {slot, root};
+
+      if (extractRoot) {
+        const root = getBlockRootFromSignedAggregateAndProofSerialized(data);
+
+        if (root === null) {
+          return null;
+        }
+
+        return {slot, root};
+      }
+
+      return {slot};
     },
     [GossipType.beacon_block]: (data: Uint8Array): SlotOptionalRoot | null => {
       const slot = getSlotFromSignedBeaconBlockSerialized(data);

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -248,6 +248,8 @@ export class NetworkProcessor {
     const extractBlockSlotRootFn = this.extractBlockSlotRootFns[topicType];
     // check block root of Attestation and SignedAggregateAndProof messages
     if (extractBlockSlotRootFn) {
+      // only extract roots for early gossip messages
+      // see https://github.com/ChainSafe/lodestar/issues/7205
       const extractRoot = !this.receivedGossipBlock;
       const slotRoot = extractBlockSlotRootFn(message.msg.data, extractRoot);
       // if slotRoot is null, it means the msg.data is invalid

--- a/packages/beacon-node/src/network/processor/types.ts
+++ b/packages/beacon-node/src/network/processor/types.ts
@@ -22,5 +22,5 @@ export type PendingGossipsubMessage = {
 };
 
 export type ExtractSlotRootFns = {
-  [K in GossipType]?: (data: Uint8Array) => SlotOptionalRoot | null;
+  [K in GossipType]?: (data: Uint8Array, extractRoot: boolean) => SlotOptionalRoot | null;
 };


### PR DESCRIPTION
**Motivation**

- right now we extract roots of all gossip messages and it's not efficient especially when we subscribe to all subnets, see #7205

**Description**

- only extract roots of gossip messages coming before beacon block, this could save up to 0.4% of `gc` time on a test mainnet node subscribing to all subnets
- for skipped slots, it fallbacks to extracting roots of all gossip messages which is the same to `unstable`, but it's rare

Closes #7205