### PR TITLE
feat: add keymanager endpoint to retrieve proposer config

### DIFF
--- a/packages/api/src/keymanager/index.ts
+++ b/packages/api/src/keymanager/index.ts
@@ -18,6 +18,7 @@ export type {
   GraffitiData,
   GasLimitData,
   BuilderBoostFactorData,
+  ProposerConfigResponse,
 } from "./routes.js";
 
 export type {ApiClient};

--- a/packages/api/src/keymanager/routes.ts
+++ b/packages/api/src/keymanager/routes.ts
@@ -109,6 +109,17 @@ export type SignerDefinition = {
 
 export type RemoteSignerDefinition = Pick<SignerDefinition, "pubkey" | "url">;
 
+export type ProposerConfig = {
+  graffiti?: string;
+  strictFeeRecipientCheck?: boolean;
+  feeRecipient?: string;
+  builder?: {
+    gasLimit?: number;
+    selection?: string;
+    boostFactor?: bigint;
+  };
+};
+
 /**
  * JSON serialized representation of a single keystore in EIP-2335: BLS12-381 Keystore format.
  * ```
@@ -353,6 +364,15 @@ export type Endpoints = {
     {pubkey: PubkeyHex},
     {params: {pubkey: string}},
     EmptyResponseData,
+    EmptyMeta
+  >;
+
+  getProposerConfig: Endpoint<
+    // ⏎
+    "GET",
+    {pubkey: PubkeyHex},
+    {params: {pubkey: string}},
+    ProposerConfig,
     EmptyMeta
   >;
 
@@ -633,6 +653,19 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         },
       },
       resp: EmptyResponseCodec,
+    },
+
+    getProposerConfig: {
+      url: "/eth/v0/validator/{pubkey}/proposer_config",
+      method: "GET",
+      req: {
+        writeReq: ({pubkey}) => ({params: {pubkey}}),
+        parseReq: ({params: {pubkey}}) => ({pubkey}),
+        schema: {
+          params: {pubkey: Schema.StringRequired},
+        },
+      },
+      resp: JsonOnlyResponseCodec,
     },
 
     signVoluntaryExit: {

--- a/packages/api/src/keymanager/routes.ts
+++ b/packages/api/src/keymanager/routes.ts
@@ -109,14 +109,14 @@ export type SignerDefinition = {
 
 export type RemoteSignerDefinition = Pick<SignerDefinition, "pubkey" | "url">;
 
-export type ProposerConfig = {
+export type ProposerConfigResponse = {
   graffiti?: string;
   strictFeeRecipientCheck?: boolean;
   feeRecipient?: string;
   builder?: {
     gasLimit?: number;
     selection?: string;
-    boostFactor?: bigint;
+    boostFactor?: string;
   };
 };
 
@@ -372,7 +372,7 @@ export type Endpoints = {
     "GET",
     {pubkey: PubkeyHex},
     {params: {pubkey: string}},
-    ProposerConfig,
+    ProposerConfigResponse,
     EmptyMeta
   >;
 

--- a/packages/api/src/keymanager/routes.ts
+++ b/packages/api/src/keymanager/routes.ts
@@ -1,7 +1,8 @@
 import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {Epoch, phase0, ssz, stringType} from "@lodestar/types";
-import {Schema, Endpoint, RouteDefinitions} from "../utils/index.js";
+import {RecursivePartial} from "@lodestar/utils";
+import {Schema, Endpoint, RouteDefinitions, ResponseDataCodec} from "../utils/index.js";
 import {WireFormat} from "../utils/wireFormat.js";
 import {
   EmptyArgs,
@@ -90,11 +91,28 @@ export const BuilderBoostFactorDataType = new ContainerType(
   },
   {jsonCase: "eth2"}
 );
+export const ProposerConfigType = new ContainerType(
+  {
+    graffiti: stringType,
+    strictFeeRecipientCheck: ssz.Boolean,
+    feeRecipient: stringType,
+    builder: new ContainerType(
+      {
+        gasLimit: ssz.UintNum64,
+        selection: stringType,
+        boostFactor: ssz.UintBn64,
+      },
+      {jsonCase: "eth2"}
+    ),
+  },
+  {jsonCase: "eth2"}
+);
 
 export type FeeRecipientData = ValueOf<typeof FeeRecipientDataType>;
 export type GraffitiData = ValueOf<typeof GraffitiDataType>;
 export type GasLimitData = ValueOf<typeof GasLimitDataType>;
 export type BuilderBoostFactorData = ValueOf<typeof BuilderBoostFactorDataType>;
+export type ProposerConfig = RecursivePartial<ValueOf<typeof ProposerConfigType>>;
 
 export type SignerDefinition = {
   pubkey: PubkeyHex;
@@ -108,17 +126,6 @@ export type SignerDefinition = {
 };
 
 export type RemoteSignerDefinition = Pick<SignerDefinition, "pubkey" | "url">;
-
-export type ProposerConfig = {
-  graffiti?: string;
-  strictFeeRecipientCheck?: boolean;
-  feeRecipient?: string;
-  builder?: {
-    gasLimit?: number;
-    selection?: string;
-    boostFactor?: bigint;
-  };
-};
 
 /**
  * JSON serialized representation of a single keystore in EIP-2335: BLS12-381 Keystore format.
@@ -665,7 +672,11 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
           params: {pubkey: Schema.StringRequired},
         },
       },
-      resp: JsonOnlyResponseCodec,
+      resp: {
+        onlySupport: WireFormat.json,
+        data: ProposerConfigType as ResponseDataCodec<ProposerConfig, EmptyMeta>,
+        meta: EmptyMetaCodec,
+      },
     },
 
     signVoluntaryExit: {

--- a/packages/api/src/keymanager/routes.ts
+++ b/packages/api/src/keymanager/routes.ts
@@ -1,8 +1,7 @@
 import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {Epoch, phase0, ssz, stringType} from "@lodestar/types";
-import {RecursivePartial} from "@lodestar/utils";
-import {Schema, Endpoint, RouteDefinitions, ResponseDataCodec} from "../utils/index.js";
+import {Schema, Endpoint, RouteDefinitions} from "../utils/index.js";
 import {WireFormat} from "../utils/wireFormat.js";
 import {
   EmptyArgs,
@@ -91,28 +90,11 @@ export const BuilderBoostFactorDataType = new ContainerType(
   },
   {jsonCase: "eth2"}
 );
-export const ProposerConfigType = new ContainerType(
-  {
-    graffiti: stringType,
-    strictFeeRecipientCheck: ssz.Boolean,
-    feeRecipient: stringType,
-    builder: new ContainerType(
-      {
-        gasLimit: ssz.UintNum64,
-        selection: stringType,
-        boostFactor: ssz.UintBn64,
-      },
-      {jsonCase: "eth2"}
-    ),
-  },
-  {jsonCase: "eth2"}
-);
 
 export type FeeRecipientData = ValueOf<typeof FeeRecipientDataType>;
 export type GraffitiData = ValueOf<typeof GraffitiDataType>;
 export type GasLimitData = ValueOf<typeof GasLimitDataType>;
 export type BuilderBoostFactorData = ValueOf<typeof BuilderBoostFactorDataType>;
-export type ProposerConfig = RecursivePartial<ValueOf<typeof ProposerConfigType>>;
 
 export type SignerDefinition = {
   pubkey: PubkeyHex;
@@ -126,6 +108,17 @@ export type SignerDefinition = {
 };
 
 export type RemoteSignerDefinition = Pick<SignerDefinition, "pubkey" | "url">;
+
+export type ProposerConfig = {
+  graffiti?: string;
+  strictFeeRecipientCheck?: boolean;
+  feeRecipient?: string;
+  builder?: {
+    gasLimit?: number;
+    selection?: string;
+    boostFactor?: bigint;
+  };
+};
 
 /**
  * JSON serialized representation of a single keystore in EIP-2335: BLS12-381 Keystore format.
@@ -672,11 +665,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
           params: {pubkey: Schema.StringRequired},
         },
       },
-      resp: {
-        onlySupport: WireFormat.json,
-        data: ProposerConfigType as ResponseDataCodec<ProposerConfig, EmptyMeta>,
-        meta: EmptyMetaCodec,
-      },
+      resp: JsonOnlyResponseCodec,
     },
 
     signVoluntaryExit: {

--- a/packages/api/test/unit/keymanager/testData.ts
+++ b/packages/api/test/unit/keymanager/testData.ts
@@ -112,4 +112,19 @@ export const testData: GenericServerTestCases<Endpoints> = {
     args: {pubkey: pubkeyRand},
     res: undefined,
   },
+  getProposerConfig: {
+    args: {pubkey: pubkeyRand},
+    res: {
+      data: {
+        graffiti: "graffiti",
+        strictFeeRecipientCheck: false,
+        feeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        builder: {
+          gasLimit: 30000000,
+          selection: "maxprofit",
+          boostFactor: BigInt(50),
+        },
+      },
+    },
+  },
 };

--- a/packages/api/test/unit/keymanager/testData.ts
+++ b/packages/api/test/unit/keymanager/testData.ts
@@ -116,13 +116,13 @@ export const testData: GenericServerTestCases<Endpoints> = {
     args: {pubkey: pubkeyRand},
     res: {
       data: {
-        graffiti: "graffiti",
+        graffiti: graffitiRandUtf8,
         strictFeeRecipientCheck: false,
-        feeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        feeRecipient: ethaddressRand,
         builder: {
-          gasLimit: 30000000,
+          gasLimit: gasLimitRand,
           selection: "maxprofit",
-          boostFactor: "50",
+          boostFactor: builderBoostFactorRand.toString(),
         },
       },
     },

--- a/packages/api/test/unit/keymanager/testData.ts
+++ b/packages/api/test/unit/keymanager/testData.ts
@@ -122,7 +122,7 @@ export const testData: GenericServerTestCases<Endpoints> = {
         builder: {
           gasLimit: 30000000,
           selection: "maxprofit",
-          boostFactor: BigInt(50),
+          boostFactor: "50",
         },
       },
     },

--- a/packages/cli/src/cmds/validator/keymanager/impl.ts
+++ b/packages/cli/src/cmds/validator/keymanager/impl.ts
@@ -15,6 +15,7 @@ import {
   GraffitiData,
   GasLimitData,
   BuilderBoostFactorData,
+  ProposerConfigResponse,
 } from "@lodestar/api/keymanager";
 import {KeymanagerApiMethods as Api} from "@lodestar/api/keymanager/server";
 import {Interchange, SignerType, Validator} from "@lodestar/validator";
@@ -365,7 +366,20 @@ export class KeymanagerApi implements Api {
   }
 
   async getProposerConfig({pubkey}: {pubkey: PubkeyHex}): ReturnType<Api["getProposerConfig"]> {
-    return {data: this.validator.validatorStore.getProposerConfig(pubkey) ?? {}};
+    const config = this.validator.validatorStore.getProposerConfig(pubkey);
+
+    const data: ProposerConfigResponse = {
+      ...config,
+      builder: config?.builder
+        ? {
+            ...config.builder,
+            // Default JSON serialization can't handle BigInt
+            boostFactor: config.builder.boostFactor ? config.builder.boostFactor.toString() : undefined,
+          }
+        : undefined,
+    };
+
+    return {data};
   }
 
   async signVoluntaryExit({pubkey, epoch}: {pubkey: PubkeyHex; epoch?: Epoch}): ReturnType<Api["signVoluntaryExit"]> {

--- a/packages/cli/src/cmds/validator/keymanager/impl.ts
+++ b/packages/cli/src/cmds/validator/keymanager/impl.ts
@@ -364,6 +364,10 @@ export class KeymanagerApi implements Api {
     return {status: 204};
   }
 
+  async getProposerConfig({pubkey}: {pubkey: PubkeyHex}): ReturnType<Api["getProposerConfig"]> {
+    return {data: this.validator.validatorStore.getProposerConfig(pubkey) ?? {}};
+  }
+
   async signVoluntaryExit({pubkey, epoch}: {pubkey: PubkeyHex; epoch?: Epoch}): ReturnType<Api["signVoluntaryExit"]> {
     if (!isValidatePubkeyHex(pubkey)) {
       throw new ApiError(400, `Invalid pubkey ${pubkey}`);

--- a/packages/cli/src/util/proposerConfig.ts
+++ b/packages/cli/src/util/proposerConfig.ts
@@ -88,13 +88,14 @@ function parseProposerConfigSection(
       overrideConfig?.strictFeeRecipientCheck ??
       (strict_fee_recipient_check ? stringtoBool(strict_fee_recipient_check) : undefined),
     feeRecipient: overrideConfig?.feeRecipient ?? (fee_recipient ? parseFeeRecipient(fee_recipient) : undefined),
-    builder: overrideConfig?.builder
-      ? {
-          gasLimit: overrideConfig?.builder?.gasLimit ?? (gas_limit !== undefined ? Number(gas_limit) : undefined),
-          selection: overrideConfig?.builder?.selection ?? parseBuilderSelection(builderSelection),
-          boostFactor: overrideConfig?.builder?.boostFactor ?? parseBuilderBoostFactor(boost_factor),
-        }
-      : undefined,
+    builder:
+      overrideConfig?.builder || builder
+        ? {
+            gasLimit: overrideConfig?.builder?.gasLimit ?? (gas_limit !== undefined ? Number(gas_limit) : undefined),
+            selection: overrideConfig?.builder?.selection ?? parseBuilderSelection(builderSelection),
+            boostFactor: overrideConfig?.builder?.boostFactor ?? parseBuilderBoostFactor(boost_factor),
+          }
+        : undefined,
   };
 }
 

--- a/packages/cli/src/util/proposerConfig.ts
+++ b/packages/cli/src/util/proposerConfig.ts
@@ -6,6 +6,7 @@ import {routes} from "@lodestar/api";
 import {parseFeeRecipient} from "./feeRecipient.js";
 
 import {readFile} from "./file.js";
+import {isEmptyObject} from "@lodestar/utils";
 
 type ProposerConfig = ValidatorProposerConfig["defaultConfig"];
 
@@ -88,11 +89,13 @@ function parseProposerConfigSection(
       overrideConfig?.strictFeeRecipientCheck ??
       (strict_fee_recipient_check ? stringtoBool(strict_fee_recipient_check) : undefined),
     feeRecipient: overrideConfig?.feeRecipient ?? (fee_recipient ? parseFeeRecipient(fee_recipient) : undefined),
-    builder: {
-      gasLimit: overrideConfig?.builder?.gasLimit ?? (gas_limit !== undefined ? Number(gas_limit) : undefined),
-      selection: overrideConfig?.builder?.selection ?? parseBuilderSelection(builderSelection),
-      boostFactor: overrideConfig?.builder?.boostFactor ?? parseBuilderBoostFactor(boost_factor),
-    },
+    builder: !isEmptyObject(overrideConfig?.builder)
+      ? {
+          gasLimit: overrideConfig?.builder?.gasLimit ?? (gas_limit !== undefined ? Number(gas_limit) : undefined),
+          selection: overrideConfig?.builder?.selection ?? parseBuilderSelection(builderSelection),
+          boostFactor: overrideConfig?.builder?.boostFactor ?? parseBuilderBoostFactor(boost_factor),
+        }
+      : undefined,
   };
 }
 

--- a/packages/cli/src/util/proposerConfig.ts
+++ b/packages/cli/src/util/proposerConfig.ts
@@ -1,12 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import {ValidatorProposerConfig} from "@lodestar/validator";
+import {isEmptyObject} from "@lodestar/utils";
 import {routes} from "@lodestar/api";
 
 import {parseFeeRecipient} from "./feeRecipient.js";
 
 import {readFile} from "./file.js";
-import {isEmptyObject} from "@lodestar/utils";
 
 type ProposerConfig = ValidatorProposerConfig["defaultConfig"];
 

--- a/packages/cli/src/util/proposerConfig.ts
+++ b/packages/cli/src/util/proposerConfig.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import {ValidatorProposerConfig} from "@lodestar/validator";
-import {isEmptyObject} from "@lodestar/utils";
 import {routes} from "@lodestar/api";
 
 import {parseFeeRecipient} from "./feeRecipient.js";
@@ -89,7 +88,7 @@ function parseProposerConfigSection(
       overrideConfig?.strictFeeRecipientCheck ??
       (strict_fee_recipient_check ? stringtoBool(strict_fee_recipient_check) : undefined),
     feeRecipient: overrideConfig?.feeRecipient ?? (fee_recipient ? parseFeeRecipient(fee_recipient) : undefined),
-    builder: !isEmptyObject(overrideConfig?.builder)
+    builder: overrideConfig?.builder
       ? {
           gasLimit: overrideConfig?.builder?.gasLimit ?? (gas_limit !== undefined ? Number(gas_limit) : undefined),
           selection: overrideConfig?.builder?.selection ?? parseBuilderSelection(builderSelection),

--- a/packages/cli/test/unit/validator/parseProposerConfig.test.ts
+++ b/packages/cli/test/unit/validator/parseProposerConfig.test.ts
@@ -26,8 +26,7 @@ const testValue = {
       builder: {
         gasLimit: 35000000,
         selection: routes.validator.BuilderSelection.BuilderAlways,
-        // biome-ignore lint/correctness/noPrecisionLoss: <explanation>
-        boostFactor: BigInt(18446744073709551616),
+        boostFactor: 18446744073709551616n,
       },
     },
   },

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -42,7 +42,7 @@ import {
   SignedAggregateAndProof,
 } from "@lodestar/types";
 import {routes} from "@lodestar/api";
-import {fromHex, toPubkeyHex, toRootHex} from "@lodestar/utils";
+import {fromHex, isEmptyObject, toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {ISlashingProtection} from "../slashingProtection/index.js";
 import {PubkeyHex} from "../types.js";
 import {externalSignerPostSignature, SignableMessageType, SignableMessage} from "../util/externalSignerClient.js";
@@ -377,7 +377,7 @@ export class ValidatorStore {
       graffiti !== undefined ||
       strictFeeRecipientCheck !== undefined ||
       feeRecipient !== undefined ||
-      builder?.gasLimit !== undefined
+      !isEmptyObject(builder)
     ) {
       proposerConfig = {graffiti, strictFeeRecipientCheck, feeRecipient, builder};
     }

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -42,7 +42,7 @@ import {
   SignedAggregateAndProof,
 } from "@lodestar/types";
 import {routes} from "@lodestar/api";
-import {fromHex, isEmptyObject, toPubkeyHex, toRootHex} from "@lodestar/utils";
+import {fromHex, toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {ISlashingProtection} from "../slashingProtection/index.js";
 import {PubkeyHex} from "../types.js";
 import {externalSignerPostSignature, SignableMessageType, SignableMessage} from "../util/externalSignerClient.js";

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -377,7 +377,9 @@ export class ValidatorStore {
       graffiti !== undefined ||
       strictFeeRecipientCheck !== undefined ||
       feeRecipient !== undefined ||
-      !isEmptyObject(builder)
+      builder?.gasLimit !== undefined ||
+      builder?.selection !== undefined ||
+      builder?.boostFactor !== undefined
     ) {
       proposerConfig = {graffiti, strictFeeRecipientCheck, feeRecipient, builder};
     }


### PR DESCRIPTION
**Motivation**

As discussed on discord with @g11tech this can be useful for some users.

**Description**

Adds `GET /eth/v0/validator/{pubkey}/proposer_config` endpoint to keymanager api. As this is non-standardized it's versioned as v0 (similar to proof apis) as it might be part of the spec in the future which would then be v1.

The return format of this api might change based on proposer config format which is still considered an alpha feature.