### PR TITLE
fix: consistently validate pubkey and throw 404 if not found

### DIFF
--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -251,7 +251,11 @@ export class ValidatorStore {
   }
 
   getGraffiti(pubkeyHex: PubkeyHex): string | undefined {
-    return this.validators.get(pubkeyHex)?.graffiti ?? this.defaultProposerConfig.graffiti;
+    const validatorData = this.validators.get(pubkeyHex);
+    if (validatorData === undefined) {
+      throw Error(`Validator pubkey ${pubkeyHex} not known`);
+    }
+    return validatorData.graffiti ?? this.defaultProposerConfig.graffiti;
   }
 
   setGraffiti(pubkeyHex: PubkeyHex, graffiti: string): void {


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/issues/7213

**Description**

Consistently validate pubkey and throw 404 if not found in keymanager api implementation before querying validator store.
