### PR TITLE
fix: only return local keys from /eth/v1/keystores

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/impl.ts
+++ b/packages/cli/src/cmds/validator/keymanager/impl.ts
@@ -101,12 +101,15 @@ export class KeymanagerApi implements Api {
   }
 
   async listKeys(): ReturnType<Api["listKeys"]> {
-    const pubkeys = this.validator.validatorStore.votingPubkeys();
+    const localKeys = this.validator.validatorStore
+      .votingPubkeys()
+      .filter((pubkey) => this.validator.validatorStore.getSigner(pubkey)?.type === SignerType.Local);
+
     return {
-      data: pubkeys.map((pubkey) => ({
+      data: localKeys.map((pubkey) => ({
         validatingPubkey: pubkey,
         derivationPath: "",
-        readonly: this.validator.validatorStore.getSigner(pubkey)?.type !== SignerType.Local,
+        readonly: false,
       })),
     };
   }

--- a/packages/cli/test/utils/crucible/assertions/nodeAssertion.ts
+++ b/packages/cli/test/utils/crucible/assertions/nodeAssertion.ts
@@ -20,8 +20,13 @@ export const nodeAssertion: Assertion<"node", {health: number; keyManagerKeys: s
     if (node.validator.client === ValidatorClient.Lighthouse || getAllKeys(node.validator.keys).length === 0) {
       keyManagerKeys = [];
     } else {
-      const keys = (await node.validator.keyManager.listKeys()).value();
-      keyManagerKeys = keys.map((k) => k.validatingPubkey);
+      if (node.validator.keys.type === "local") {
+        const keys = (await node.validator.keyManager.listKeys()).value();
+        keyManagerKeys = keys.map((k) => k.validatingPubkey);
+      } else {
+        const keys = (await node.validator.keyManager.listRemoteKeys()).value();
+        keyManagerKeys = keys.map((k) => k.pubkey);
+      }
     }
 
     return {health, keyManagerKeys};


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/issues/7213

**Description**


Only return local keys from `/eth/v1/keystores`

As per spec:
> List all validating pubkeys known to and decrypted by this keymanager binary