### PR TITLE
chore: revert async aggregate with randomness

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "@chainsafe/as-sha256": "^0.5.0",
-    "@chainsafe/blst": "^2.2.0",
+    "@chainsafe/blst": "^2.1.0",
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",
     "@chainsafe/libp2p-gossipsub": "^13.0.0",

--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -394,7 +394,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
         try {
           // Note: This can throw, must be handled per-job.
           // Pubkey and signature aggregation is defered here
-          workReq = await jobItemWorkReq(job, this.metrics);
+          workReq = jobItemWorkReq(job, this.metrics);
         } catch (e) {
           this.metrics?.blsThreadPool.errorAggregateSignatureSetsCount.inc({type: job.type});
 

--- a/packages/beacon-node/src/chain/bls/multithread/jobItem.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/jobItem.ts
@@ -1,4 +1,4 @@
-import {PublicKey, asyncAggregateWithRandomness} from "@chainsafe/blst";
+import {PublicKey, aggregateWithRandomness} from "@chainsafe/blst";
 import {ISignatureSet, SignatureSetType} from "@lodestar/state-transition";
 import {Metrics} from "../../../metrics/metrics.js";
 import {LinkedList} from "../../../util/array.js";
@@ -48,7 +48,7 @@ export function jobItemSigSets(job: JobQueueItem): number {
  * Prepare BlsWorkReq from JobQueueItem
  * WARNING: May throw with untrusted user input
  */
-export async function jobItemWorkReq(job: JobQueueItem, metrics: Metrics | null): Promise<BlsWorkReq> {
+export function jobItemWorkReq(job: JobQueueItem, metrics: Metrics | null): BlsWorkReq {
   switch (job.type) {
     case JobQueueItemType.default:
       return {
@@ -61,9 +61,17 @@ export async function jobItemWorkReq(job: JobQueueItem, metrics: Metrics | null)
         })),
       };
     case JobQueueItemType.sameMessage: {
-      const {pk, sig} = await asyncAggregateWithRandomness(
-        job.sets.map((set) => ({pk: set.publicKey, sig: set.signature}))
-      );
+      // This is slow code on main thread (mainly signature deserialization + group check).
+      // Ideally it can be taken off-thread, but in the mean time, keep track of total time spent here.
+      // As of July 2024, for a node subscribing to all subnets, with 1 signature per validator per epoch,
+      // it takes around 2.02 min to perform this operation for a single epoch.
+      // cpu profile on main thread has 250s idle so this only works until we reach 3M validators
+      // However, for normal node with only 2 to 7 subnet subscriptions per epoch this works until 27M validators
+      // and not a problem in the near future
+      // this is monitored on v1.21.0 https://github.com/ChainSafe/lodestar/pull/6894/files#r1687359225
+      const timer = metrics?.blsThreadPool.aggregateWithRandomnessMainThreadDuration.startTimer();
+      const {pk, sig} = aggregateWithRandomness(job.sets.map((set) => ({pk: set.publicKey, sig: set.signature})));
+      timer?.();
 
       return {
         opts: job.opts,

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -497,6 +497,11 @@ export function createLodestarMetrics(
         name: "lodestar_bls_thread_pool_batchable_sig_sets_total",
         help: "Count of total batchable signature sets",
       }),
+      aggregateWithRandomnessMainThreadDuration: register.histogram({
+        name: "lodestar_bls_thread_pool_aggregate_with_randomness_main_thread_time_seconds",
+        help: "Total time performing aggregateWithRandomness on main thread",
+        buckets: [0.001, 0.005, 0.01, 0.1],
+      }),
       pubkeysAggregationMainThreadDuration: register.histogram({
         name: "lodestar_bls_thread_pool_pubkeys_aggregation_main_thread_time_seconds",
         help: "Total time spent aggregating pubkeys on main thread",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@chainsafe/bls-keygen": "^0.4.0",
     "@chainsafe/bls-keystore": "^3.1.0",
-    "@chainsafe/blst": "^2.2.0",
+    "@chainsafe/blst": "^2.1.0",
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",
     "@chainsafe/persistent-merkle-tree": "^0.8.0",

--- a/packages/flare/package.json
+++ b/packages/flare/package.json
@@ -59,7 +59,7 @@
   ],
   "dependencies": {
     "@chainsafe/bls-keygen": "^0.4.0",
-    "@chainsafe/blst": "^2.2.0",
+    "@chainsafe/blst": "^2.1.0",
     "@lodestar/api": "^1.22.0",
     "@lodestar/config": "^1.22.0",
     "@lodestar/params": "^1.22.0",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -59,7 +59,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.5.0",
-    "@chainsafe/blst": "^2.2.0",
+    "@chainsafe/blst": "^2.1.0",
     "@chainsafe/persistent-merkle-tree": "^0.8.0",
     "@chainsafe/persistent-ts": "^0.19.1",
     "@chainsafe/ssz": "^0.18.0",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -58,7 +58,7 @@
   ],
   "dependencies": {
     "@chainsafe/bls-keystore": "^3.1.0",
-    "@chainsafe/blst": "^2.2.0",
+    "@chainsafe/blst": "^2.1.0",
     "@lodestar/params": "^1.22.0",
     "@lodestar/utils": "^1.22.0",
     "axios": "^1.3.4",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -45,7 +45,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/blst": "^2.2.0",
+    "@chainsafe/blst": "^2.1.0",
     "@chainsafe/ssz": "^0.18.0",
     "@lodestar/api": "^1.22.0",
     "@lodestar/config": "^1.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -399,40 +399,40 @@
     "@chainsafe/bls-keygen" "^0.4.0"
     bls-eth-wasm "^0.4.8"
 
-"@chainsafe/blst-darwin-arm64@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst-darwin-arm64/-/blst-darwin-arm64-2.2.0.tgz#0ab9083805c308106c2f2107df1e6376d9190b1b"
-  integrity sha512-BOOy2KHbV028cioPWaAMqHdLRKd6/3XyEmUEcQC2E/SpyYLdNcaKiBUYIU4pT9CrWBbJJxX68UI+3vZVg0M8/w==
+"@chainsafe/blst-darwin-arm64@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst-darwin-arm64/-/blst-darwin-arm64-2.1.0.tgz#8871d62dc0402df30adbd6f52fbbd02d59f3c5ff"
+  integrity sha512-7iPRlSbQxEZ2AblmkFLuhnVPUipvA0UenEaUCaLC1MhGFpSwy5bSrF8Krs/E++GN3p2LVz7ZH3tlDfFL0z1EvQ==
 
-"@chainsafe/blst-darwin-x64@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst-darwin-x64/-/blst-darwin-x64-2.2.0.tgz#231943a7736f3f89d35e03fec890b7809c98ff1a"
-  integrity sha512-jG64cwIdPT7u/haRrW26tWCpfMfHBQCfGY169mFQifCwO4VEwvaiVBPOh5olFis6LjpcmD+O0jpM8GqrnsmUHQ==
+"@chainsafe/blst-darwin-x64@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst-darwin-x64/-/blst-darwin-x64-2.1.0.tgz#8fe58d92b72b1b872f8b687a0aad8beda3e09072"
+  integrity sha512-aeoidOpOYVmRFeHVm1p/Axd6CfqWpr6SIift216/HTDBTiuJCGSJqHzk9RHf7gzkr6WtxO7g/6AtkagZA2VPFg==
 
-"@chainsafe/blst-linux-arm64-gnu@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst-linux-arm64-gnu/-/blst-linux-arm64-gnu-2.2.0.tgz#721aeec63e8e02aba3358a0084c095403a5438fa"
-  integrity sha512-L8xV2uuLn8we76vdzfryS9ePdheuZrmY6yArGUFaF1Uzcwml6V1/VvyPl9/uooo/YfVRIrvF/D+lQfI2GFAnhw==
+"@chainsafe/blst-linux-arm64-gnu@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst-linux-arm64-gnu/-/blst-linux-arm64-gnu-2.1.0.tgz#323789a10679cf81813b1e664ef4187a2e941cff"
+  integrity sha512-d2zgqoJOqkWg2sZbNR7pv8f+oYPOJmnMu46Uulm6NkW3iYNZIc2KkVjBXGYk7xJ+U8ZEzb7KZ7gRB9315sWBcg==
 
-"@chainsafe/blst-linux-arm64-musl@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst-linux-arm64-musl/-/blst-linux-arm64-musl-2.2.0.tgz#dbbabaab93156548c86e2b2b3a1d27160b715000"
-  integrity sha512-0Vn0luxLYVgC3lvWT1MapFHSAoz99PldqjhilXTGv0AcAk/X5LXPH2RC9Dp2KJGqthyUkpbk1j47jUBfBI+BIg==
+"@chainsafe/blst-linux-arm64-musl@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst-linux-arm64-musl/-/blst-linux-arm64-musl-2.1.0.tgz#4a308d6b1f71a57a6ecc6cc0531746f5cd8ae3d0"
+  integrity sha512-w+KiL8ViLXigZVS++tdCwnMBnbc4HXb8claKOnlCppE1rAeF0Dt186AU2TRpqOop3QoOqckqvsguR9iQwZlTUw==
 
-"@chainsafe/blst-linux-x64-gnu@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst-linux-x64-gnu/-/blst-linux-x64-gnu-2.2.0.tgz#9f8ab825621b75227c75bb75d369d3d42e91fa74"
-  integrity sha512-gEY/z2SDBA7kXtFEI9VNhWTJAIjx16jdeAyCaS2k4ACGurWZaWk+Ee4KniTsr4WieSqeuNTUr7Pdja0Sr4EKNQ==
+"@chainsafe/blst-linux-x64-gnu@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst-linux-x64-gnu/-/blst-linux-x64-gnu-2.1.0.tgz#c015f9f25aab10bba7720518ba9dc19bb850dcc3"
+  integrity sha512-2xdOIkkJTvi+/gUoiPQO+p+2o19pixLsH5BOrwxY+EABLL6wxZ82w5LatV3x27YJTk7PbAlyT36n7CjmzaZ/tw==
 
-"@chainsafe/blst-linux-x64-musl@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst-linux-x64-musl/-/blst-linux-x64-musl-2.2.0.tgz#11e99ac12b0f83cad68da56f4e9cfc4aa403a2e6"
-  integrity sha512-58GKtiUmtVSuerRzPEcMNQZpICPboBKFnL7+1Wo+PSuajkvbae7tEFrFTtWeMoKIPgOEsPMnk96LF+0yNgavUg==
+"@chainsafe/blst-linux-x64-musl@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst-linux-x64-musl/-/blst-linux-x64-musl-2.1.0.tgz#da4ac690cc3b59bc21c4578d30502490c044f7fb"
+  integrity sha512-/ddO38KkTTgTmXBLAubU1fjUWcQy90sdUi0IoRm5RprdpXvTSGZ1m8XrcxwEYkUO+KpnacOuU0UDwerHMJl4DA==
 
-"@chainsafe/blst-win32-x64-msvc@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst-win32-x64-msvc/-/blst-win32-x64-msvc-2.2.0.tgz#f32b164721ff5edc279f6d6cd0fffde0ad2fe16c"
-  integrity sha512-UFrZshl4dfX5Uh2zeKXAZtrkQ+otczHMON2tsrapQNICWmfHZrzE6pKuBL+9QeGAbgflwpbz7+D5nQRDpiuHxQ==
+"@chainsafe/blst-win32-x64-msvc@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst-win32-x64-msvc/-/blst-win32-x64-msvc-2.1.0.tgz#edaff899194caa4e40901af90779721673671631"
+  integrity sha512-wSRVGoLrluus38fmYYS0ft3VSG2EaeeWvb7yxvrAS8xUsaRFRClYo/3kaEHR3D9B9Nu5wiuWfob6DoM3w9deLw==
 
 "@chainsafe/blst@^0.2.0":
   version "0.2.11"
@@ -443,18 +443,18 @@
     node-fetch "^2.6.1"
     node-gyp "^8.4.0"
 
-"@chainsafe/blst@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-2.2.0.tgz#ced8b861b94934e3c1c53e173c3e1205d775d93b"
-  integrity sha512-VBaQoNE2a9d9+skAjQKv3Suk0yGKqp3mZM0YWYJNPj/Ae/f6lAyeVSgKqo2LrsNQBzD/LqrJLKUY8rJT3vDKLA==
+"@chainsafe/blst@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/blst/-/blst-2.1.0.tgz#1df4fa8e390db5c3cceed673b57468e23b4da36f"
+  integrity sha512-oY5k4whglgVOkisfujO0s1QgCOp3N/J3GogRbHhuNLrf6KN0zs1C3pKHg66EQhQqWVYnFY2Shx2s71/NFD7y+A==
   optionalDependencies:
-    "@chainsafe/blst-darwin-arm64" "2.2.0"
-    "@chainsafe/blst-darwin-x64" "2.2.0"
-    "@chainsafe/blst-linux-arm64-gnu" "2.2.0"
-    "@chainsafe/blst-linux-arm64-musl" "2.2.0"
-    "@chainsafe/blst-linux-x64-gnu" "2.2.0"
-    "@chainsafe/blst-linux-x64-musl" "2.2.0"
-    "@chainsafe/blst-win32-x64-msvc" "2.2.0"
+    "@chainsafe/blst-darwin-arm64" "2.1.0"
+    "@chainsafe/blst-darwin-x64" "2.1.0"
+    "@chainsafe/blst-linux-arm64-gnu" "2.1.0"
+    "@chainsafe/blst-linux-arm64-musl" "2.1.0"
+    "@chainsafe/blst-linux-x64-gnu" "2.1.0"
+    "@chainsafe/blst-linux-x64-musl" "2.1.0"
+    "@chainsafe/blst-win32-x64-msvc" "2.1.0"
 
 "@chainsafe/discv5@^9.0.0":
   version "9.0.0"


### PR DESCRIPTION
**Motivation**

Change is choking network thread when `—subscribeAllSubnets` flag is applied.  Need to further investigate that issue so reverting for 1.23 and will reapply for 1.24 once network issue is resolved.

