### PR TITLE
fix: archive finalized state when shutting down beacon node

### DIFF
--- a/packages/beacon-node/src/chain/archiver/archiver.ts
+++ b/packages/beacon-node/src/chain/archiver/archiver.ts
@@ -64,7 +64,7 @@ export class Archiver {
 
   /** Archive latest finalized state */
   async persistToDisk(): Promise<void> {
-    return this.statesArchiverStrategy.maybeArchiveState(this.chain.forkChoice.getFinalizedCheckpoint());
+    return this.statesArchiverStrategy.archiveState(this.chain.forkChoice.getFinalizedCheckpoint());
   }
 
   private onFinalizedCheckpoint = async (finalized: CheckpointWithHex): Promise<void> => {

--- a/packages/beacon-node/src/chain/archiver/interface.ts
+++ b/packages/beacon-node/src/chain/archiver/interface.ts
@@ -44,4 +44,5 @@ export interface StateArchiveStrategy {
   onCheckpoint(stateRoot: RootHex, metrics?: Metrics | null): Promise<void>;
   onFinalizedCheckpoint(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<void>;
   maybeArchiveState(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<void>;
+  archiveState(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<void>;
 }

--- a/packages/beacon-node/src/chain/archiver/strategies/frequencyStateArchiveStrategy.ts
+++ b/packages/beacon-node/src/chain/archiver/strategies/frequencyStateArchiveStrategy.ts
@@ -84,7 +84,7 @@ export class FrequencyStateArchiveStrategy implements StateArchiveStrategy {
    * Archives finalized states from active bucket to archive bucket.
    * Only the new finalized state is stored to disk
    */
-  private async archiveState(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<void> {
+  async archiveState(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<void> {
     // starting from Mar 2024, the finalized state could be from disk or in memory
     const finalizedStateOrBytes = await this.regen.getCheckpointStateOrBytes(finalized);
     const {rootHex} = finalized;


### PR DESCRIPTION
**Motivation**

State archiving when shutting down the beacon node is broken at the moment, this means we might load a state that's up to 32 epochs old when restarting the node, causing high sync times (~5-10 mins).


**Description**

Archive finalized state when shutting down beacon node. This restores behavior before changes done in https://github.com/ChainSafe/lodestar/pull/7170. 

