### PR TITLE
Typo Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,4 +22,4 @@ This command starts a local development server and opens up a browser window. Mo
 $ yarn build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+This command generates static content into the `build` directory and can be served using any static content hosting service.


### PR DESCRIPTION
**Description**:

I found a typo in the following sentence:

- **"static contents hosting service"** should be **"static content hosting service"**.

"Content" is an uncountable noun, so it should not be pluralized in this context. The corrected phrase is:

- **"static content hosting service"**.

This change is important for grammatical accuracy, as "content" is always used in the singular form when referring to data or information, making "contents" incorrect in this case.

