### PR TITLE
Typo Update index.d.ts

### DIFF
--- a/types/vitest/index.d.ts
+++ b/types/vitest/index.d.ts
@@ -4,7 +4,7 @@ interface CustomMatchers<R = unknown> {
   toBeValidEpochCommittee(opts: {committeeCount: number; validatorsPerCommittee: number; slotsPerEpoch: number}): R;
   /**
    * @deprecated
-   * We highly recommend to not use this matcher instead use detail test case
+   * We highly recommend to not use this matcher instead use detailed test case
    * where you don't need message to explain assertion
    *
    * @example
@@ -27,7 +27,7 @@ interface CustomMatchers<R = unknown> {
   toBeWithMessage(expected: unknown, message: string): R;
   /**
    * @deprecated
-   * We highly recommend to not use this matcher instead use detail test case with .toEqual
+   * We highly recommend to not use this matcher instead use detailed test case with .toEqual
    * where you don't need message to explain assertion
    * */
   toEqualWithMessage(expected: unknown, message: string): R;


### PR DESCRIPTION
**Description:**

This PR addresses an issue in the comments where the word "detail" was incorrectly used. The correct term should be "detailed" when referring to test cases, as it better describes the nature of the test case being suggested.

### Changes:
- Updated comments to replace "detail" with "detailed" in the following sections of the code:
  - In the `toBeWithMessage` matcher comment.
  - In the `toEqualWithMessage` matcher comment.

### Reason for Change:
The use of "detail" in this context was grammatically incorrect. The appropriate term is "detailed," which is used to describe test cases that are more thorough and precise. This change ensures better clarity and correctness in the code documentation, improving readability and professionalism.

Example:
```ts
// Original comment:
// "We highly recommend to not use this matcher instead use detail test case"

// Corrected comment:
"We highly recommend **not** to use this matcher. Instead, use a **detailed** test case."
```

### Impact:
- Improves the clarity and accuracy of the comments in the code.
- Enhances the documentation for future developers to understand the purpose of the matcher better.
