### PR TITLE
Typo Update faqs.md

### DIFF
--- a/docs/pages/faqs.md
+++ b/docs/pages/faqs.md
@@ -1,6 +1,6 @@
 # Frequently Asked Questions
 
-This section of the documentation will cover common questions and encounters often asked by users and developers.
+This section of the documentation will cover common questions and common encounters by users and developers.
 
 ## Tooling
 


### PR DESCRIPTION
**Description:**

This PR corrects an awkwardly phrased sentence in the FAQ section of the documentation. The original sentence:

```
This section of the documentation will cover common questions and encounters often asked by users and developers.
```

has been updated to:

```
This section of the documentation will cover common questions and common encounters by users and developers.
```

**Explanation of the fix:**

The phrase "encounters often asked" is grammatically incorrect and unclear. It has been replaced with "common encounters," which is more appropriate and natural in this context.

**Why this is important:**

Clarity in documentation is essential for users and developers to easily understand the content. This change improves the sentence structure and ensures the meaning is clear, avoiding any confusion for those reading the FAQ section.
