### PR TITLE
Fix typo Update await-release.sh

### DIFF
--- a/scripts/await-release.sh
+++ b/scripts/await-release.sh
@@ -3,7 +3,7 @@
 # Should ONLY run on CI/GA for releases, installing `jq` for Ubuntu latest
 sudo apt install jq # sudo without password on ubuntu-latest
 
-# Using the lodestar-cli packacke to reference against
+# Using the lodestar-cli package to reference against
 declare PACKAGE="@chainsafe/lodestar"
 
 # Using `npm view -j` to get all available versions as JSON


### PR DESCRIPTION
**Description**:

This pull request fixes a typo in the comment for the `PACKAGE` variable. The original comment contains the word "packacke," which is a misspelling of "package." The corrected comment now accurately describes the purpose of the variable.

**Changes**:
- Fixed the typo "packacke" to "package" in the comment for the `PACKAGE` variable.

**Why is this important?**:
Correcting typos in comments is important for maintaining clarity and professionalism in the codebase. This change ensures that the comment accurately reflects the purpose of the `PACKAGE` variable, improving readability and preventing confusion for future developers working with the code.
