### PR TITLE
feat: add error log to notifier if execution client auth failed

### DIFF
--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -54,12 +54,12 @@ export async function runNodeNotifier(modules: NodeNotifierModules): Promise<voi
       const clockSlot = chain.clock.currentSlot;
       const clockEpoch = computeEpochAtSlot(clockSlot);
 
-      if (
-        clockEpoch >= config.BELLATRIX_FORK_EPOCH &&
-        computeStartSlotAtEpoch(clockEpoch) === clockSlot &&
-        chain.executionEngine.state === ExecutionEngineState.OFFLINE
-      ) {
-        logger.warn("Execution client is offline");
+      if (clockEpoch >= config.BELLATRIX_FORK_EPOCH && computeStartSlotAtEpoch(clockEpoch) === clockSlot) {
+        if (chain.executionEngine.state === ExecutionEngineState.OFFLINE) {
+          logger.warn("Execution client is offline");
+        } else if (chain.executionEngine.state === ExecutionEngineState.AUTH_FAILED) {
+          logger.error("Execution client authentication failed. Verify the JWT secret matches on both clients");
+        }
       }
 
       const headInfo = chain.forkChoice.getHead();

--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -58,7 +58,7 @@ export async function runNodeNotifier(modules: NodeNotifierModules): Promise<voi
         if (chain.executionEngine.state === ExecutionEngineState.OFFLINE) {
           logger.warn("Execution client is offline");
         } else if (chain.executionEngine.state === ExecutionEngineState.AUTH_FAILED) {
-          logger.error("Execution client authentication failed. Verify the JWT secret matches on both clients");
+          logger.error("Execution client authentication failed. Verify if the JWT secret matches on both clients");
         }
       }
 


### PR DESCRIPTION
**Motivation**

Follow up on https://github.com/ChainSafe/lodestar/pull/6919, while it's less likely that this happens unnoticed, ie. in case the initial error is missed, a user might still miss it when updating EL client and for some reason changing the secret.

**Description**

Add error log to notifier if execution client auth failed. The error will be logged at the start of every epoch if EL authentication is not working (eg. due to mismatching JWT secret)