### PR TITLE
fix: sync cached isCompoundingValidatorArr at epoch transition

### DIFF
--- a/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -5,10 +5,11 @@ import {
   HYSTERESIS_QUOTIENT,
   HYSTERESIS_UPWARD_MULTIPLIER,
   MAX_EFFECTIVE_BALANCE,
+  MAX_EFFECTIVE_BALANCE_ELECTRA,
+  MIN_ACTIVATION_BALANCE,
   TIMELY_TARGET_FLAG_INDEX,
 } from "@lodestar/params";
 import {BeaconStateAltair, CachedBeaconStateAllForks, EpochTransitionCache} from "../types.js";
-import {getMaxEffectiveBalance} from "../util/validator.js";
 
 /** Same to https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.5/specs/altair/beacon-chain.md#has_flag */
 const TIMELY_TARGET = 1 << TIMELY_TARGET_FLAG_INDEX;
@@ -43,7 +44,7 @@ export function processEffectiveBalanceUpdates(
   // and updated in processPendingDeposits() and processPendingConsolidations()
   // so it's recycled here for performance.
   const balances = cache.balances ?? state.balances.getAll();
-  const currentEpochValidators = cache.validators;
+  const isCompoundingValidatorArr = cache.isCompoundingValidatorArr;
 
   let numUpdate = 0;
   for (let i = 0, len = balances.length; i < len; i++) {
@@ -58,7 +59,7 @@ export function processEffectiveBalanceUpdates(
       effectiveBalanceLimit = MAX_EFFECTIVE_BALANCE;
     } else {
       // from electra, effectiveBalanceLimit is per validator
-      effectiveBalanceLimit = getMaxEffectiveBalance(currentEpochValidators[i].withdrawalCredentials);
+      effectiveBalanceLimit = isCompoundingValidatorArr[i] ? MAX_EFFECTIVE_BALANCE_ELECTRA : MIN_ACTIVATION_BALANCE;
     }
 
     if (

--- a/packages/state-transition/src/epoch/processPendingDeposits.ts
+++ b/packages/state-transition/src/epoch/processPendingDeposits.ts
@@ -3,6 +3,7 @@ import {PendingDeposit} from "@lodestar/types/lib/electra/types.js";
 import {addValidatorToRegistry, isValidDepositSignature} from "../block/processDeposit.js";
 import {CachedBeaconStateElectra, EpochTransitionCache} from "../types.js";
 import {increaseBalance} from "../util/balance.js";
+import {hasCompoundingWithdrawalCredential} from "../util/electra.js";
 import {computeStartSlotAtEpoch} from "../util/epoch.js";
 import {getActivationExitChurnLimit} from "../util/validator.js";
 
@@ -106,6 +107,8 @@ function applyPendingDeposit(
     // Verify the deposit signature (proof of possession) which is not checked by the deposit contract
     if (isValidDepositSignature(state.config, pubkey, withdrawalCredentials, amount, signature)) {
       addValidatorToRegistry(ForkSeq.electra, state, pubkey, withdrawalCredentials, amount);
+      const newValidatorIndex = state.validators.length - 1;
+      cache.isCompoundingValidatorArr[newValidatorIndex] = hasCompoundingWithdrawalCredential(withdrawalCredentials);
     }
   } else {
     // Increase balance


### PR DESCRIPTION
**Motivation**

Fix this error in mekong devnet-0:

```
Nov-25 14:55:56.131[chain]           error: Failed to run prepareForNextSlot nextEpoch=4490, isEpochTransition=true, prepareSlot=143680 - Cannot read properties of undefined (reading 'withdrawalCredentials')
TypeError: Cannot read properties of undefined (reading 'withdrawalCredentials')
```

**Description**

- the cached `validators` is not synced when we add new validator during epoch transition
- but tracking `validators` is heavy, and add validators may cause `gc`
- so we should track lightweight `isCompoundingValidatorArr` array similar to what we did in batch hash branch https://github.com/ChainSafe/lodestar/pull/7171/files#diff-2aa72e8ced03b2c2844b434f06316a5d2b4c402774965c42ebdf035a74d3c7fdR141
