### PR TITLE
fix: handle outOfRangeData when range sync Deneb

### DIFF
--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -45,10 +45,11 @@ export async function beaconBlocksMaybeBlobsByRange(
     ]);
 
     return matchBlockWithBlobs(config, allBlocks, allBlobSidecars, endSlot, BlockSource.byRange, BlobsSource.byRange);
-  } else {
-    const blocks = await network.sendBeaconBlocksByRange(peerId, request);
-    return blocks.map((block) => getBlockInput.outOfRangeData(config, block.data, BlockSource.byRange, block.bytes));
   }
+
+  // Data is out of range, only request blocks
+  const blocks = await network.sendBeaconBlocksByRange(peerId, request);
+  return blocks.map((block) => getBlockInput.outOfRangeData(config, block.data, BlockSource.byRange, block.bytes));
 }
 
 // Assumes that the blobs are in the same sequence as blocks, doesn't require block to be sorted

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -36,18 +36,19 @@ export async function beaconBlocksMaybeBlobsByRange(
     return blocks.map((block) => getBlockInput.preData(config, block.data, BlockSource.byRange, block.bytes));
   }
 
+  // From Deneb
   // Only request blobs if they are recent enough
-  if (computeEpochAtSlot(startSlot) >= currentEpoch - config.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS) {
+  if (startEpoch >= currentEpoch - config.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS) {
     const [allBlocks, allBlobSidecars] = await Promise.all([
       network.sendBeaconBlocksByRange(peerId, request),
       network.sendBlobSidecarsByRange(peerId, request),
     ]);
 
     return matchBlockWithBlobs(config, allBlocks, allBlobSidecars, endSlot, BlockSource.byRange, BlobsSource.byRange);
+  } else {
+    const blocks = await network.sendBeaconBlocksByRange(peerId, request);
+    return blocks.map((block) => getBlockInput.outOfRangeData(config, block.data, BlockSource.byRange, block.bytes));
   }
-
-  // Post Deneb but old blobs
-  throw Error("Cannot sync blobs outside of blobs prune window");
 }
 
 // Assumes that the blobs are in the same sequence as blocks, doesn't require block to be sorted


### PR DESCRIPTION
**Motivation**

Cannot sync lodestar from mekong genesis due to this error `Cannot sync blobs outside of blobs prune window`

**Description**

Beacon node should return `BlockInputType.outOfRangeData` block input instead of throwing that error

Closes #7248