### PR TITLE
chore: skip web3_provider unit tests

### DIFF
--- a/packages/prover/test/unit/web3_provider.node.test.ts
+++ b/packages/prover/test/unit/web3_provider.node.test.ts
@@ -7,7 +7,8 @@ import {JsonRpcRequest, JsonRpcRequestOrBatch, JsonRpcResponse} from "../../src/
 import {ELRpcProvider} from "../../src/utils/rpc_provider.js";
 import {createVerifiedExecutionProvider} from "../../src/web3_provider.js";
 
-describe("web3_provider", () => {
+// https://github.com/ChainSafe/lodestar/issues/7250
+describe.skip("web3_provider", () => {
   afterEach(() => {
     vi.clearAllMocks();
   });


### PR DESCRIPTION
**Motivation**

see https://github.com/ChainSafe/lodestar/issues/7250

**Description**

This PR skips the web3_provider unit tests for now until we figure out a more robust solution to test this code without relying on external sources
