### PR TITLE
fix: sync cached balance when adding new validator to registry

### DIFF
--- a/packages/state-transition/src/epoch/processPendingDeposits.ts
+++ b/packages/state-transition/src/epoch/processPendingDeposits.ts
@@ -109,6 +109,9 @@ function applyPendingDeposit(
       addValidatorToRegistry(ForkSeq.electra, state, pubkey, withdrawalCredentials, amount);
       const newValidatorIndex = state.validators.length - 1;
       cache.isCompoundingValidatorArr[newValidatorIndex] = hasCompoundingWithdrawalCredential(withdrawalCredentials);
+      // set balance, so that the next deposit of same pubkey will increase the balance correctly
+      // this is to fix the double deposit issue found in mekong
+      // see https://github.com/ChainSafe/lodestar/pull/7255
       if (cachedBalances) {
         cachedBalances[newValidatorIndex] = amount;
       }

--- a/packages/state-transition/src/epoch/processPendingDeposits.ts
+++ b/packages/state-transition/src/epoch/processPendingDeposits.ts
@@ -109,6 +109,9 @@ function applyPendingDeposit(
       addValidatorToRegistry(ForkSeq.electra, state, pubkey, withdrawalCredentials, amount);
       const newValidatorIndex = state.validators.length - 1;
       cache.isCompoundingValidatorArr[newValidatorIndex] = hasCompoundingWithdrawalCredential(withdrawalCredentials);
+      if (cachedBalances) {
+        cachedBalances[newValidatorIndex] = amount;
+      }
     }
   } else {
     // Increase balance


### PR DESCRIPTION
**Motivation**

Got "invalid state root" issue in mekong

```
debug: Block error slot=143681, code=BLOCK_ERROR_INVALID_STATE_ROOT, slot=143681, root=0xbffe8157d89ac64e41c6e856b91f2a26229d06183cbeff804df82ef460f3971e, expectedRoot=0x1b43fb4c8e07039aa3c28255899f385671ad499759b047465f144005f6a7a1f8
```

**Description**

- we did not sync cached balance when adding a new validator to registry. When top up in 2nd deposit, the cached balance is undefined hence the `processEffectiveBalanceUpdates` is not correct

Closes #issue_number

**Testtomg**
- [x]  I was able to reproduce the issue in unit test [here](https://gist.github.com/twoeths/f5e78905bc59610df2656b6c580a74e7)
- [ ] however it does not work in my node, still got same issue

