### PR TITLE
fix: select correct gossip type when publishing single attestation

### DIFF
--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -89,7 +89,7 @@ export function getGossipSSZType(topic: GossipTopic) {
     case GossipType.beacon_aggregate_and_proof:
       return sszTypesFor(topic.fork).SignedAggregateAndProof;
     case GossipType.beacon_attestation:
-      return sszTypesFor(topic.fork).Attestation;
+      return isForkPostElectra(topic.fork) ? ssz.electra.SingleAttestation : ssz.phase0.Attestation;
     case GossipType.proposer_slashing:
       return ssz.phase0.ProposerSlashing;
     case GossipType.attester_slashing:

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -89,7 +89,7 @@ export function getGossipSSZType(topic: GossipTopic) {
     case GossipType.beacon_aggregate_and_proof:
       return sszTypesFor(topic.fork).SignedAggregateAndProof;
     case GossipType.beacon_attestation:
-      return isForkPostElectra(topic.fork) ? ssz.electra.SingleAttestation : ssz.phase0.Attestation;
+      return sszTypesFor(topic.fork).SingleAttestation;
     case GossipType.proposer_slashing:
       return ssz.phase0.ProposerSlashing;
     case GossipType.attester_slashing:

--- a/packages/types/src/phase0/sszTypes.ts
+++ b/packages/types/src/phase0/sszTypes.ts
@@ -316,6 +316,8 @@ export const Attestation = new ContainerType(
   {typeName: "Attestation", jsonCase: "eth2"}
 );
 
+export const SingleAttestation = Attestation;
+
 export const AttesterSlashing = new ContainerType(
   {
     // In state transition, AttesterSlashing attestations are only partially validated. Their slot and epoch could


### PR DESCRIPTION
**Motivation**

We are not selecting the correct type to serialize single attestation when publishing to gossip
```
Nov-28 09:00:03.241[api]             error: Error on submitPoolAttestations [0] slot=94, index=0 - Cannot read properties of undefined (reading 'bitLen')
TypeError: Cannot read properties of undefined (reading 'bitLen')
    at BitListType.value_serializedSize (/usr/app/node_modules/@chainsafe/ssz/src/type/bitList.ts:60:43)
    at ContainerType.value_serializedSize (/usr/app/node_modules/@chainsafe/ssz/src/type/container.ts:189:54)
    at ContainerType.serialize (/usr/app/node_modules/@chainsafe/ssz/src/type/abstract.ts:119:44)
    at Network.publishGossip (file:///usr/app/packages/beacon-node/src/network/network.ts:421:34)
    at Network.publishBeaconAttestation (file:///usr/app/packages/beacon-node/src/network/network.ts:333:17)
    at file:///usr/app/packages/beacon-node/src/api/impl/beacon/pool/index.ts:137:45
    at async Promise.all (index 0)
    at Object.submitPoolAttestationsV2 (file:///usr/app/packages/beacon-node/src/api/impl/beacon/pool/index.ts:99:7)
    at Object.<anonymous> (file:///usr/app/packages/api/src/utils/server/handler.ts:105:22)
```

**Description**

Select correct gossip type when publishing single attestation, instead of `electra.Attestation`, we need to use `electra.SingleAttestation`
