### PR TITLE
fix: do not throw error when trying to prune missing directory

### DIFF
--- a/packages/cli/src/util/pruneOldFilesInDir.ts
+++ b/packages/cli/src/util/pruneOldFilesInDir.ts
@@ -2,6 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 
 export function pruneOldFilesInDir(dirpath: string, maxAgeMs: number): number {
+  if (!fs.existsSync(dirpath)) {
+    return 0; // Nothing to prune
+  }
+
   let deletedFileCount = 0;
   for (const entryName of fs.readdirSync(dirpath)) {
     const entryPath = path.join(dirpath, entryName);

--- a/packages/cli/test/unit/util/pruneOldFilesInDir.test.ts
+++ b/packages/cli/test/unit/util/pruneOldFilesInDir.test.ts
@@ -55,6 +55,10 @@ describe("pruneOldFilesInDir", () => {
     expect(fs.existsSync(emptyDir)).toBe(false);
   });
 
+  it("should handle missing directories", () => {
+    expect(() => pruneOldFilesInDir(path.join(dataDir, "does-not-exist"), DAYS_TO_MS)).not.toThrowError();
+  });
+
   function createFileWithAge(path: string, ageInDays: number): void {
     // Create a new empty file
     fs.closeSync(fs.openSync(path, "w"));


### PR DESCRIPTION
**Motivation**

Noticed the following warning
```
Nov-28 10:42:04.700[]                 warn: Error pruning invalid SSZ objects persistInvalidSszObjectsDir=/data/lodestar/beacon-data/invalidSszObjects - ENOENT: no such file or directory, scandir '/data/lodestar/beacon-data/invalidSszObjects'
Error: ENOENT: no such file or directory, scandir '/data/lodestar/beacon-data/invalidSszObjects'
    at Object.readdirSync (node:fs:1503:26)
    at pruneOldFilesInDir (file:///usr/app/packages/cli/src/util/pruneOldFilesInDir.ts:6:30)
    at Timeout._onTimeout (file:///usr/app/packages/cli/src/cmds/beacon/handler.ts:100:40)
    at listOnTimeout (node:internal/timers:581:17)
    at processTimers (node:internal/timers:519:7)
```

This happens because we don't check if the directory actually exists before pruning it which can happen in case of invalid ssz objects dir.

**Description**

Do not throw error when trying to prune missing directory
