### PR TITLE
fix: cache attester index during attestation validation

### DIFF
--- a/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
@@ -1,5 +1,5 @@
 import {BitArray} from "@chainsafe/ssz";
-import {CommitteeIndex, RootHex, Slot, phase0} from "@lodestar/types";
+import {CommitteeIndex, RootHex, Slot, ValidatorIndex, phase0} from "@lodestar/types";
 import {MapDef} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {InsertOutcome} from "../opPools/types.js";
@@ -11,8 +11,8 @@ type AttDataBase64 = string;
 export type AttestationDataCacheEntry = {
   // part of shuffling data, so this does not take memory
   committeeValidatorIndices: Uint32Array;
-  // TODO: remove this? this is available in SingleAttestation
   committeeIndex: CommitteeIndex;
+  attesterIndex: ValidatorIndex;
   // IndexedAttestationData signing root, 32 bytes
   signingRoot: Uint8Array;
   // to be consumed by forkchoice and oppool

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -407,10 +407,16 @@ async function validateAttestationNoSignatureCheck(
   if (!isForkPostElectra(fork)) {
     // The validity of aggregation bits are already checked above
     assert.notNull(aggregationBits);
-    const bitIndex = aggregationBits.getSingleTrueBit();
-    assert.notNull(bitIndex);
 
-    validatorIndex = committeeValidatorIndices[bitIndex];
+    if (attestationOrCache.attestation) {
+      const bitIndex = aggregationBits.getSingleTrueBit();
+      assert.notNull(bitIndex);
+
+      validatorIndex = committeeValidatorIndices[bitIndex];
+    } else {
+      validatorIndex = attestationOrCache.cache.attesterIndex;
+    }
+
     // [REJECT] The number of aggregation bits matches the committee size
     // -- i.e. len(attestation.aggregation_bits) == len(get_beacon_committee(state, data.slot, data.index)).
     // > TODO: Is this necessary? Lighthouse does not do this check.
@@ -420,7 +426,10 @@ async function validateAttestationNoSignatureCheck(
       });
     }
   } else {
-    validatorIndex = (attestationOrCache.attestation as SingleAttestation<ForkPostElectra>).attesterIndex;
+    validatorIndex = attestationOrCache.attestation
+      ? (attestationOrCache.attestation as SingleAttestation<ForkPostElectra>).attesterIndex
+      : attestationOrCache.cache.attesterIndex;
+
     // [REJECT] The attester is a member of the committee -- i.e.
     // `attestation.attester_index in get_beacon_committee(state, attestation.data.slot, index)`.
     // If `aggregationBitsElectra` exists, that means we have already cached it. No need to check again
@@ -498,6 +507,7 @@ async function validateAttestationNoSignatureCheck(
       chain.seenAttestationDatas.add(attSlot, committeeIndex, attDataKey, {
         committeeValidatorIndices,
         committeeIndex,
+        attesterIndex: validatorIndex,
         signingRoot: signatureSet.signingRoot,
         subnet: expectedSubnet,
         // precompute this to be used in forkchoice


### PR DESCRIPTION
**Motivation**

Currently we always try to get the validator index from `attestationOrCache.attestation` but it might be `null` if cached value is used leading to the following error:
```
Nov-28 13:33:21.898[network]         debug: Gossip batch validation beacon_attestation threw a non-AttestationError - Cannot read properties of null (reading 'attesterIndex')
TypeError: Cannot read properties of null (reading 'attesterIndex')
    at validateAttestationNoSignatureCheck (file:///usr/app/packages/beacon-node/src/chain/validation/attestation.ts:426:93)
    at validateGossipAttestationsSameAttData (file:///usr/app/packages/beacon-node/src/chain/validation/attestation.ts:119:43)
    at Object.beacon_attestation (file:///usr/app/packages/beacon-node/src/network/processor/gossipHandlers.ts:625:64)
    at NetworkProcessor.gossipValidatorBatchFn (file:///usr/app/packages/beacon-node/src/network/processor/gossipValidatorFn.ts:36:75)
    at NetworkProcessor.processPendingGossipsubMessage (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:438:20)
    at NetworkProcessor.executeWork (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:398:16)
    at NetworkProcessor.pushPendingGossipsubMessageToQueue (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:310:10)
    at NetworkProcessor.onPendingGossipsubMessage (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:298:10)
    at NetworkEventBus.emit (node:events:520:28)
```

Caching the attester index also has some benefits pre-electra as we can safe a `getSingleTrueBit` call (see https://github.com/ChainSafe/lodestar/pull/7209) if we retrieve the attestation from the cache.

**Description**

Cache attester index during attestation validation
