### PR TITLE
fix: return correct type from attestation validation when using cache

### DIFF
--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -510,27 +510,31 @@ async function validateAttestationNoSignatureCheck(
   }
 
   // no signature check, leave that for step1
-  const indexedAttestationContent = {
+  const indexedAttestation: IndexedAttestation = {
     attestingIndices,
     data: attData,
     signature,
   };
-  const indexedAttestation =
-    ForkSeq[fork] >= ForkSeq.electra
-      ? (indexedAttestationContent as electra.IndexedAttestation)
-      : (indexedAttestationContent as phase0.IndexedAttestation);
 
-  const attestationContent = attestationOrCache.attestation ?? {
-    aggregationBits,
-    data: attData,
-    committeeIndex,
-    signature,
-  };
-
-  const attestation =
-    ForkSeq[fork] >= ForkSeq.electra
-      ? (attestationContent as SingleAttestation<ForkPostElectra>)
-      : (attestationContent as SingleAttestation<ForkPreElectra>);
+  let attestation: SingleAttestation;
+  if (attestationOrCache.attestation) {
+    attestation = attestationOrCache.attestation;
+  } else {
+    if (!isForkPostElectra(fork)) {
+      attestation = {
+        aggregationBits,
+        data: attData,
+        signature,
+      } as SingleAttestation<ForkPreElectra>;
+    } else {
+      attestation = {
+        committeeIndex,
+        attesterIndex: validatorIndex,
+        data: attData,
+        signature,
+      } as SingleAttestation<ForkPostElectra>;
+    }
+  }
 
   return {
     attestation,

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -523,6 +523,7 @@ async function validateAttestationNoSignatureCheck(
     ? attestationOrCache.attestation
     : !isForkPostElectra(fork)
       ? {
+          // Aggregation bits are already asserted above to not be null
           aggregationBits: aggregationBits as BitArray,
           data: attData,
           signature,

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -515,25 +515,20 @@ async function validateAttestationNoSignatureCheck(
     signature,
   };
 
-  let attestation: SingleAttestation;
-  if (attestationOrCache.attestation) {
-    attestation = attestationOrCache.attestation;
-  } else {
-    if (!isForkPostElectra(fork)) {
-      attestation = {
-        aggregationBits,
-        data: attData,
-        signature,
-      };
-    } else {
-      attestation = {
-        committeeIndex,
-        attesterIndex: validatorIndex,
-        data: attData,
-        signature,
-      };
-    }
-  }
+  const attestation: SingleAttestation = attestationOrCache.attestation
+    ? attestationOrCache.attestation
+    : !isForkPostElectra(fork)
+      ? {
+          aggregationBits,
+          data: attData,
+          signature,
+        }
+      : {
+          committeeIndex,
+          attesterIndex: validatorIndex,
+          data: attData,
+          signature,
+        };
 
   return {
     attestation,

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -30,7 +30,6 @@ import {
   SingleAttestation,
   Slot,
   ValidatorIndex,
-  electra,
   isElectraSingleAttestation,
   phase0,
   ssz,

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -525,14 +525,14 @@ async function validateAttestationNoSignatureCheck(
         aggregationBits,
         data: attData,
         signature,
-      } as SingleAttestation<ForkPreElectra>;
+      };
     } else {
       attestation = {
         committeeIndex,
         attesterIndex: validatorIndex,
         data: attData,
         signature,
-      } as SingleAttestation<ForkPostElectra>;
+      };
     }
   }
 

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -519,7 +519,7 @@ async function validateAttestationNoSignatureCheck(
     ? attestationOrCache.attestation
     : !isForkPostElectra(fork)
       ? {
-          aggregationBits,
+          aggregationBits: aggregationBits as BitArray,
           data: attData,
           signature,
         }


### PR DESCRIPTION
**Motivation**

We use `committeeIndex` to determine if single attestation is from post-electra
https://github.com/ChainSafe/lodestar/blob/59b3b1e8f1cf6c3a59c1d0d1fdf07a13c339739c/packages/types/src/utils/typeguards.ts#L81

This check itself is fine and should be sufficient based on the type but we return incorrect attestation type from validation when using the cache as it always contains the `committeeIndex` leading to the following error pre-electra

```
    at NetworkProcessor.processPendingGossipsubMessage (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:438:9)
Nov-28 08:47:03.349[network]         error: Error adding unaggregated attestation to pool subnet=29 - Attestation should be type phase0.Attestation
Error: Attestation should be type phase0.Attestation
    at Object.true (file:///usr/app/packages/utils/src/assert.ts:7:13)
    at AttestationPool.add (file:///usr/app/packages/beacon-node/src/chain/opPools/attestationPool.ts:139:18)
    at Object.beacon_attestation (file:///usr/app/packages/beacon-node/src/network/processor/gossipHandlers.ts:649:57)
    at NetworkProcessor.gossipValidatorBatchFn (file:///usr/app/packages/beacon-node/src/network/processor/gossipValidatorFn.ts:36:23)
    at NetworkProcessor.processPendingGossipsubMessage (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:438:9)
```

**Description**

Return correct type from attestation validation when using cache