### PR TITLE
fix: get attester index from single attestation bytes if cache is used

### DIFF
--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -7,7 +7,7 @@ import {
   MAX_COMMITTEES_PER_SLOT,
   isForkPostElectra,
 } from "@lodestar/params";
-import {BLSSignature, CommitteeIndex, RootHex, Slot} from "@lodestar/types";
+import {BLSSignature, CommitteeIndex, RootHex, Slot, ValidatorIndex} from "@lodestar/types";
 
 export type BlockRootHex = RootHex;
 // pre-electra, AttestationData is used to cache attestations
@@ -54,6 +54,7 @@ const SIGNATURE_SIZE = 96;
 const SINGLE_ATTESTATION_ATTDATA_OFFSET = 8 + 8;
 const SINGLE_ATTESTATION_SLOT_OFFSET = SINGLE_ATTESTATION_ATTDATA_OFFSET;
 const SINGLE_ATTESTATION_COMMITTEE_INDEX_OFFSET = 0;
+const SINGLE_ATTESTATION_ATTESTER_INDEX_OFFSET = 8;
 const SINGLE_ATTESTATION_BEACON_BLOCK_ROOT_OFFSET = SINGLE_ATTESTATION_ATTDATA_OFFSET + 8 + 8;
 const SINGLE_ATTESTATION_SIGNATURE_OFFSET = SINGLE_ATTESTATION_ATTDATA_OFFSET + ATTESTATION_DATA_SIZE;
 const SINGLE_ATTESTATION_SIZE = SINGLE_ATTESTATION_SIGNATURE_OFFSET + SIGNATURE_SIZE;
@@ -199,6 +200,19 @@ export function getCommitteeIndexFromSingleAttestationSerialized(
   }
 
   return getSlotFromOffset(data, VARIABLE_FIELD_OFFSET + SLOT_SIZE);
+}
+
+/**
+ * Extract attester index from SingleAttestation serialized bytes.
+ * Return null if data is not long enough to extract index.
+ * TODO Electra: Rename getSlotFromOffset to reflect generic usage
+ */
+export function getAttesterIndexFromSingleAttestationSerialized(data: Uint8Array): ValidatorIndex | null {
+  if (data.length !== SINGLE_ATTESTATION_SIZE) {
+    return null;
+  }
+
+  return getSlotFromOffset(data, SINGLE_ATTESTATION_ATTESTER_INDEX_OFFSET);
 }
 
 /**

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -6,6 +6,7 @@ import {
   RootHex,
   SingleAttestation,
   Slot,
+  ValidatorIndex,
   deneb,
   electra,
   isElectraSingleAttestation,
@@ -21,6 +22,7 @@ import {
   getAttDataFromSignedAggregateAndProofElectra,
   getAttDataFromSignedAggregateAndProofPhase0,
   getAttDataFromSingleAttestationSerialized,
+  getAttesterIndexFromSingleAttestationSerialized,
   getBlockRootFromAttestationSerialized,
   getBlockRootFromSignedAggregateAndProofSerialized,
   getBlockRootFromSingleAttestationSerialized,
@@ -49,6 +51,7 @@ describe("SinlgeAttestation SSZ serialized picking", () => {
       ...electraSingleAttestationFromValues(
         4_000_000,
         127,
+        1,
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         200_00,
         "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffffffffffff"
@@ -68,6 +71,7 @@ describe("SinlgeAttestation SSZ serialized picking", () => {
         expect(getCommitteeIndexFromSingleAttestationSerialized(ForkName.electra, bytes)).toEqual(
           attestation.committeeIndex
         );
+        expect(getAttesterIndexFromSingleAttestationSerialized(bytes)).toEqual(attestation.attesterIndex);
         expect(getBlockRootFromSingleAttestationSerialized(bytes)).toEqual(toRootHex(attestation.data.beaconBlockRoot));
         // base64, not hex
         expect(getAttDataFromSingleAttestationSerialized(bytes)).toEqual(
@@ -332,6 +336,7 @@ function phase0SingleAttestationFromValues(
 function electraSingleAttestationFromValues(
   slot: Slot,
   committeeIndex: CommitteeIndex,
+  attesterIndex: ValidatorIndex,
   blockRoot: RootHex,
   targetEpoch: Epoch,
   targetRoot: RootHex
@@ -342,6 +347,7 @@ function electraSingleAttestationFromValues(
   attestation.data.target.epoch = targetEpoch;
   attestation.data.target.root = fromHex(targetRoot);
   attestation.committeeIndex = committeeIndex;
+  attestation.attesterIndex = attesterIndex;
   return attestation;
 }
 


### PR DESCRIPTION
**Motivation**

As per discussion in https://github.com/ChainSafe/lodestar/pull/7260 we need to get the attester index from serialized bytes.

Currently we get the following error if cache entry is used
```
Nov-28 13:33:21.898[network]         debug: Gossip batch validation beacon_attestation threw a non-AttestationError - Cannot read properties of null (reading 'attesterIndex')
TypeError: Cannot read properties of null (reading 'attesterIndex')
    at validateAttestationNoSignatureCheck (file:///usr/app/packages/beacon-node/src/chain/validation/attestation.ts:426:93)
    at validateGossipAttestationsSameAttData (file:///usr/app/packages/beacon-node/src/chain/validation/attestation.ts:119:43)
    at Object.beacon_attestation (file:///usr/app/packages/beacon-node/src/network/processor/gossipHandlers.ts:625:64)
    at NetworkProcessor.gossipValidatorBatchFn (file:///usr/app/packages/beacon-node/src/network/processor/gossipValidatorFn.ts:36:75)
    at NetworkProcessor.processPendingGossipsubMessage (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:438:20)
    at NetworkProcessor.executeWork (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:398:16)
    at NetworkProcessor.pushPendingGossipsubMessageToQueue (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:310:10)
    at NetworkProcessor.onPendingGossipsubMessage (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:298:10)
    at NetworkEventBus.emit (node:events:520:28)
```

**Description**

Get attester index from single attestation bytes if cache is used