### PR TITLE
fix: remove aggregation bits from seen attestation cache

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -105,7 +105,7 @@ export function getBeaconPoolApi({
             // when a validator is configured with multiple beacon node urls, this attestation data may come from another beacon node
             // and the block hasn't been in our forkchoice since we haven't seen / processing that block
             // see https://github.com/ChainSafe/lodestar/issues/5098
-            const {indexedAttestation, subnet, attDataRootHex, committeeIndex, aggregationBits} =
+            const {indexedAttestation, subnet, attDataRootHex, committeeIndex, committeeValidatorIndex, committeeSize} =
               await validateGossipFnRetryUnknownRoot(validateFn, network, chain, slot, beaconBlockRoot);
 
             if (network.shouldAggregate(subnet, slot)) {
@@ -113,7 +113,8 @@ export function getBeaconPoolApi({
                 committeeIndex,
                 attestation,
                 attDataRootHex,
-                aggregationBits
+                committeeValidatorIndex,
+                committeeSize
               );
               metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
             }

--- a/packages/beacon-node/src/chain/opPools/attestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/attestationPool.ts
@@ -109,7 +109,7 @@ export class AttestationPool {
     committeeIndex: CommitteeIndex,
     attestation: SingleAttestation,
     attDataRootHex: RootHex,
-    aggregationBits: BitArray
+    aggregationBits: BitArray | null
   ): InsertOutcome {
     const slot = attestation.data.slot;
     const fork = this.config.getForkName(slot);
@@ -224,7 +224,7 @@ export class AttestationPool {
 function aggregateAttestationInto(
   aggregate: AggregateFast,
   attestation: SingleAttestation,
-  aggregationBits: BitArray
+  aggregationBits: BitArray | null
 ): InsertOutcome {
   let bitIndex: number | null;
 
@@ -250,7 +250,7 @@ function aggregateAttestationInto(
 /**
  * Format `contribution` into an efficient `aggregate` to add more contributions in with aggregateContributionInto()
  */
-function attestationToAggregate(attestation: SingleAttestation, aggregationBits: BitArray): AggregateFast {
+function attestationToAggregate(attestation: SingleAttestation, aggregationBits: BitArray | null): AggregateFast {
   if (isElectraSingleAttestation(attestation)) {
     assert.notNull(aggregationBits, "aggregationBits missing post-electra to generate aggregate");
     return {

--- a/packages/beacon-node/src/chain/opPools/attestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/attestationPool.ts
@@ -109,7 +109,7 @@ export class AttestationPool {
     committeeIndex: CommitteeIndex,
     attestation: SingleAttestation,
     attDataRootHex: RootHex,
-    aggregationBits: BitArray | null
+    aggregationBits: BitArray
   ): InsertOutcome {
     const slot = attestation.data.slot;
     const fork = this.config.getForkName(slot);
@@ -224,7 +224,7 @@ export class AttestationPool {
 function aggregateAttestationInto(
   aggregate: AggregateFast,
   attestation: SingleAttestation,
-  aggregationBits: BitArray | null
+  aggregationBits: BitArray
 ): InsertOutcome {
   let bitIndex: number | null;
 
@@ -250,7 +250,7 @@ function aggregateAttestationInto(
 /**
  * Format `contribution` into an efficient `aggregate` to add more contributions in with aggregateContributionInto()
  */
-function attestationToAggregate(attestation: SingleAttestation, aggregationBits: BitArray | null): AggregateFast {
+function attestationToAggregate(attestation: SingleAttestation, aggregationBits: BitArray): AggregateFast {
   if (isElectraSingleAttestation(attestation)) {
     assert.notNull(aggregationBits, "aggregationBits missing post-electra to generate aggregate");
     return {

--- a/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts
@@ -11,7 +11,6 @@ type AttDataBase64 = string;
 export type AttestationDataCacheEntry = {
   // part of shuffling data, so this does not take memory
   committeeValidatorIndices: Uint32Array;
-  // TODO: remove this? this is available in SingleAttestation
   committeeIndex: CommitteeIndex;
   // IndexedAttestationData signing root, 32 bytes
   signingRoot: Uint8Array;
@@ -21,8 +20,6 @@ export type AttestationDataCacheEntry = {
   // for example in a mainnet node subscribing to all subnets, attestations are processed up to 20k per slot
   attestationData: phase0.AttestationData;
   subnet: number;
-  // aggregationBits only populates post-electra. Pre-electra can use get it directly from attestationOrBytes
-  aggregationBits: BitArray | null;
 };
 
 export enum RejectReason {

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -69,7 +69,8 @@ export type AttestationValidationResult = {
   subnet: number;
   attDataRootHex: RootHex;
   committeeIndex: CommitteeIndex;
-  aggregationBits: BitArray;
+  committeeValidatorIndex: number;
+  committeeSize: number;
 };
 
 export type AttestationOrBytes = ApiAttestation | GossipAttestation;
@@ -398,6 +399,7 @@ async function validateAttestationNoSignatureCheck(
   }
 
   let validatorIndex: number;
+  let committeeValidatorIndex: number;
 
   if (!isForkPostElectra(fork)) {
     // The validity of aggregation bits are already checked above
@@ -406,6 +408,7 @@ async function validateAttestationNoSignatureCheck(
     assert.notNull(bitIndex);
 
     validatorIndex = committeeValidatorIndices[bitIndex];
+    committeeValidatorIndex = bitIndex;
     // [REJECT] The number of aggregation bits matches the committee size
     // -- i.e. len(attestation.aggregation_bits) == len(get_beacon_committee(state, data.slot, data.index)).
     // > TODO: Is this necessary? Lighthouse does not do this check.
@@ -419,14 +422,12 @@ async function validateAttestationNoSignatureCheck(
     // [REJECT] The attester is a member of the committee -- i.e.
     // `attestation.attester_index in get_beacon_committee(state, attestation.data.slot, index)`.
     // Position of the validator in its committee
-    const committeeValidatorIndex = committeeValidatorIndices.indexOf(validatorIndex);
+    committeeValidatorIndex = committeeValidatorIndices.indexOf(validatorIndex);
     if (committeeValidatorIndex === -1) {
       throw new AttestationError(GossipAction.REJECT, {
         code: AttestationErrorCode.ATTESTER_NOT_IN_COMMITTEE,
       });
     }
-
-    aggregationBits = BitArray.fromSingleBit(committeeValidatorIndices.length, committeeValidatorIndex);
   }
 
   // LH > verify_middle_checks
@@ -531,7 +532,8 @@ async function validateAttestationNoSignatureCheck(
     signatureSet,
     validatorIndex,
     committeeIndex,
-    aggregationBits,
+    committeeValidatorIndex,
+    committeeSize: committeeValidatorIndices.length,
   };
 }
 

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -69,7 +69,7 @@ export type AttestationValidationResult = {
   subnet: number;
   attDataRootHex: RootHex;
   committeeIndex: CommitteeIndex;
-  aggregationBits: BitArray | null; // Field populated post-electra only
+  aggregationBits: BitArray;
 };
 
 export type AttestationOrBytes = ApiAttestation | GossipAttestation;
@@ -344,11 +344,6 @@ async function validateAttestationNoSignatureCheck(
         code: AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET,
       });
     }
-  } else {
-    // Populate aggregationBits if cached post-electra, else we populate later
-    if (attestationOrCache.cache && attestationOrCache.cache.aggregationBits !== null) {
-      aggregationBits = attestationOrCache.cache.aggregationBits;
-    }
   }
 
   let committeeValidatorIndices: Uint32Array;
@@ -423,18 +418,15 @@ async function validateAttestationNoSignatureCheck(
     validatorIndex = (attestationOrCache.attestation as SingleAttestation<ForkPostElectra>).attesterIndex;
     // [REJECT] The attester is a member of the committee -- i.e.
     // `attestation.attester_index in get_beacon_committee(state, attestation.data.slot, index)`.
-    // If `aggregationBitsElectra` exists, that means we have already cached it. No need to check again
-    if (aggregationBits === null) {
-      // Position of the validator in its committee
-      const committeeValidatorIndex = committeeValidatorIndices.indexOf(validatorIndex);
-      if (committeeValidatorIndex === -1) {
-        throw new AttestationError(GossipAction.REJECT, {
-          code: AttestationErrorCode.ATTESTER_NOT_IN_COMMITTEE,
-        });
-      }
-
-      aggregationBits = BitArray.fromSingleBit(committeeValidatorIndices.length, committeeValidatorIndex);
+    // Position of the validator in its committee
+    const committeeValidatorIndex = committeeValidatorIndices.indexOf(validatorIndex);
+    if (committeeValidatorIndex === -1) {
+      throw new AttestationError(GossipAction.REJECT, {
+        code: AttestationErrorCode.ATTESTER_NOT_IN_COMMITTEE,
+      });
     }
+
+    aggregationBits = BitArray.fromSingleBit(committeeValidatorIndices.length, committeeValidatorIndex);
   }
 
   // LH > verify_middle_checks
@@ -504,7 +496,6 @@ async function validateAttestationNoSignatureCheck(
         // root of AttestationData was already cached during getIndexedAttestationSignatureSet
         attDataRootHex,
         attestationData: attData,
-        aggregationBits: isForkPostElectra(fork) ? aggregationBits : null,
       });
     }
   }
@@ -540,7 +531,7 @@ async function validateAttestationNoSignatureCheck(
     signatureSet,
     validatorIndex,
     committeeIndex,
-    aggregationBits: isForkPostElectra(fork) ? aggregationBits : null,
+    aggregationBits,
   };
 }
 

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -326,6 +326,7 @@ async function validateAttestationNoSignatureCheck(
   }
 
   let aggregationBits: BitArray | null = null;
+  let committeeValidatorIndex: number | null = null;
   if (!isForkPostElectra(fork)) {
     // [REJECT] The attestation is unaggregated -- that is, it has exactly one participating validator
     // (len([bit for bit in attestation.aggregation_bits if bit]) == 1, i.e. exactly 1 bit is set).
@@ -345,6 +346,7 @@ async function validateAttestationNoSignatureCheck(
         code: AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET,
       });
     }
+    committeeValidatorIndex = bitIndex;
   }
 
   let committeeValidatorIndices: Uint32Array;
@@ -399,16 +401,13 @@ async function validateAttestationNoSignatureCheck(
   }
 
   let validatorIndex: number;
-  let committeeValidatorIndex: number;
 
   if (!isForkPostElectra(fork)) {
     // The validity of aggregation bits are already checked above
     assert.notNull(aggregationBits);
-    const bitIndex = aggregationBits.getSingleTrueBit();
-    assert.notNull(bitIndex);
+    assert.notNull(committeeValidatorIndex);
 
-    validatorIndex = committeeValidatorIndices[bitIndex];
-    committeeValidatorIndex = bitIndex;
+    validatorIndex = committeeValidatorIndices[committeeValidatorIndex];
     // [REJECT] The number of aggregation bits matches the committee size
     // -- i.e. len(attestation.aggregation_bits) == len(get_beacon_committee(state, data.slot, data.index)).
     // > TODO: Is this necessary? Lighthouse does not do this check.

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -637,8 +637,14 @@ function getBatchHandlers(modules: ValidatorFnsModules, options: GossipHandlerOp
         results.push(null);
 
         // Handler
-        const {indexedAttestation, attDataRootHex, attestation, committeeIndex, aggregationBits} =
-          validationResult.result;
+        const {
+          indexedAttestation,
+          attDataRootHex,
+          attestation,
+          committeeIndex,
+          committeeValidatorIndex,
+          committeeSize,
+        } = validationResult.result;
         metrics?.registerGossipUnaggregatedAttestation(gossipHandlerParams[i].seenTimestampSec, indexedAttestation);
 
         try {
@@ -650,7 +656,8 @@ function getBatchHandlers(modules: ValidatorFnsModules, options: GossipHandlerOp
               committeeIndex,
               attestation,
               attDataRootHex,
-              aggregationBits
+              committeeValidatorIndex,
+              committeeSize
             );
             metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
           }


### PR DESCRIPTION
**Motivation**

As noted by @twoeths in https://github.com/ChainSafe/lodestar/pull/7260#discussion_r1863112502, the cache is used for whole committee and not just a single validator which means the cached `aggregationBits` would be incorrect if reused for another attestation from a different validator.

**Description**

Remove aggregation bits from seen attestation cache
