### PR TITLE
fix: correctly get signature from single attestation bytes

### DIFF
--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -47,6 +47,7 @@ import {
   getCommitteeBitsFromSignedAggregateAndProofElectra,
   getCommitteeIndexFromSingleAttestationSerialized,
   getSignatureFromAttestationSerialized,
+  getSignatureFromSingleAttestationSerialized,
 } from "../../util/sszBytes.js";
 import {Result, wrapError} from "../../util/wrapError.js";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors/index.js";
@@ -470,7 +471,9 @@ async function validateAttestationNoSignatureCheck(
   let attDataRootHex: RootHex;
   const signature = attestationOrCache.attestation
     ? attestationOrCache.attestation.signature
-    : getSignatureFromAttestationSerialized(attestationOrCache.serializedData);
+    : !isForkPostElectra(fork)
+      ? getSignatureFromAttestationSerialized(attestationOrCache.serializedData)
+      : getSignatureFromSingleAttestationSerialized(attestationOrCache.serializedData);
   if (signature === null) {
     throw new AttestationError(GossipAction.REJECT, {
       code: AttestationErrorCode.INVALID_SERIALIZED_BYTES,


### PR DESCRIPTION
**Motivation**

Need to correctly handle extracting signature from single attestation

**Description**

Use `getSignatureFromSingleAttestationSerialized` to extract signature from bytes for post-electra single attestations

Closes https://github.com/ChainSafe/lodestar/issues/7259
