### PR TITLE
Fix Typo in Comment for Clarity

### DIFF
--- a/scripts/await-release.sh
+++ b/scripts/await-release.sh
@@ -3,7 +3,7 @@
 # Should ONLY run on CI/GA for releases, installing `jq` for Ubuntu latest
 sudo apt install jq # sudo without password on ubuntu-latest
 
-# Using the lodestar-cli packacke to reference against
+# Using the lodestar-cli package to reference against
 declare PACKAGE="@chainsafe/lodestar"
 
 # Using `npm view -j` to get all available versions as JSON


### PR DESCRIPTION
**Description:**
This update corrects a minor typo in the comment within the script. The word "packacke" has been changed to "package" for clarity and accuracy. This change is important as it ensures the comment correctly reflects the intended reference to the "lodestar-cli package," helping avoid confusion for future contributors or users reading the script. The typo could lead to misunderstandings, especially for those unfamiliar with the context.

**Changed line:**

Before:
```bash
# Using the lodestar-cli packacke to reference against
```

After:
```bash
# Using the lodestar-cli package to reference against
```