### PR TITLE
docs: display rcConfig flag on CLI reference page

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -110,6 +110,7 @@ Vitalik
 Vitest
 Wagyu
 api
+args
 async
 backfill
 beaconcha
@@ -244,3 +245,4 @@ xRelayPubKey
 xcode
 yaml
 yamux
+yml

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -10,6 +10,7 @@ type GlobalSingleArgs = {
   paramsFile?: string;
   preset: string;
   presetFile?: string;
+  rcConfig?: string;
 };
 
 export const defaultNetwork: NetworkName = "mainnet";
@@ -44,11 +45,16 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
     description: "Preset configuration file to override the active preset with custom values",
     type: "string",
   },
+
+  rcConfig: {
+    description: "RC file to supplement command line args, accepted formats: .yml, .yaml, .json",
+    type: "string",
+  },
 };
 
 export const rcConfigOption: [string, string, (configPath: string) => Record<string, unknown>] = [
   "rcConfig",
-  "RC file to supplement command line args, accepted formats: .yml, .yaml, .json",
+  globalSingleOptions.rcConfig.description as string,
   (configPath: string): Record<string, unknown> => readFile(configPath, ["json", "yml", "yaml"]),
 ];
 


### PR DESCRIPTION
**Motivation**

Some users might be interested in providing the configuration via file instead of CLI flags, this already exists in Lodestar via `--rcConfig` flag but it's a hidden option but I feel like it would be good to document this flag on our CLI reference page, see https://github.com/ChainSafe/lodestar/issues/7234 for more context.

**Description**

Display `--rcConfig` flag on CLI reference page.

I added the flag to global options as it's available for all commands (beacon, validator, bootnode, etc.), this is for documentation purposes only, the behavior of the flag is unchanged.
