### PR TITLE
chore: unhide flags relevant for devnets / testing

### DIFF
--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -33,7 +33,6 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
   },
 
   genesisStateFile: {
-    hidden: true,
     description: "Path or URL to download a genesis state file in ssz-encoded format",
     type: "string",
   },
@@ -80,7 +79,6 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
   ignoreWeakSubjectivityCheck: {
     description:
       "Ignore the checkpoint sync state failing the weak subjectivity check. This is relevant in testnets where the weak subjectivity period is too small for even few epochs of non finalization causing last finalized to be out of range. This flag is not recommended for mainnet use.",
-    hidden: true,
     type: "boolean",
     group: "weak subjectivity",
   },
@@ -120,7 +118,6 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
   },
 
   persistNetworkIdentity: {
-    hidden: true,
     description: "Whether to reuse the same peer-id across restarts",
     type: "boolean",
   },


### PR DESCRIPTION
**Motivation**

Those flags are relevant for devnets or testing and are used quite commonly

**Description**

Unhides the following flags
- `--genesisStateFile` (required to configure custom network)
- `--ignoreWeakSubjectivityCheck` (required in devnets with long non-finality)
- `--persistNetworkIdentity` (has been asked multiple times by users if this options exists)

