### PR TITLE
fix: handle 0x prefix from execution client commit

### DIFF
--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -18,10 +18,12 @@ export function getDefaultGraffiti(
   }
 
   if (executionClientVersion != null) {
-    const {code: executionCode, commit: executionCommit} = executionClientVersion;
+    let {code: executionCode, commit: executionCommit} = executionClientVersion;
+
+    executionCommit = executionCommit.startsWith("0x") ? executionCommit.slice(2, 6) : executionCommit.slice(0, 4);
 
     // Follow the 2-byte commit format in https://github.com/ethereum/execution-apis/pull/517#issuecomment-1918512560
-    return `${executionCode}${executionCommit.slice(0, 4)}${consensusClientVersion.code}${consensusClientVersion.commit.slice(0, 4)}`;
+    return `${executionCode}${executionCommit}${consensusClientVersion.code}${consensusClientVersion.commit.slice(0, 4)}`;
   }
 
   // No EL client info available. We still want to include CL info albeit not spec compliant

--- a/packages/beacon-node/test/unit/util/graffiti.test.ts
+++ b/packages/beacon-node/test/unit/util/graffiti.test.ts
@@ -29,7 +29,7 @@ describe("Graffiti helper", () => {
   });
 
   describe("getDefaultGraffiti", () => {
-    const executionClientVersion = {code: ClientCode.BU, name: "Besu", version: "24.1.1", commit: "9b0e38fa"};
+    const executionClientVersion = {code: ClientCode.BU, name: "Besu", version: "24.1.1", commit: "0x9b0e38fa"};
     const consensusClientVersion = {
       code: ClientCode.LS,
       name: "Lodestar",


### PR DESCRIPTION
Lodestar currently sets default graffiti containing execution client commit with 0x prefix eg. `GE0x2bLSae1f`.

We should not include the prefix in the graffiti. 