### PR TITLE
feat: peerdas - ensure at least n peers per sampling group

### DIFF
--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -42,4 +42,6 @@ export const defaultNetworkOptions: NetworkOptions = {
   slotsToSubscribeBeforeAggregatorDuty: 2,
   // This will enable the light client server by default
   disableLightClientServer: false,
+  // for PeerDAS, this is the same to TARGET_SUBNET_PEERS, should reavaluate after devnets
+  targetGroupPeers: 6,
 };

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -4,12 +4,12 @@ import type {PeerId, PeerInfo} from "@libp2p/interface";
 import {BeaconConfig} from "@lodestar/config";
 import {LoggerNode} from "@lodestar/logger/node";
 import {ATTESTATION_SUBNET_COUNT, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
-import {SubnetID} from "@lodestar/types";
-import {ssz} from "@lodestar/types";
+import {CustodyIndex, SubnetID} from "@lodestar/types";
 import {pruneSetToMax, sleep} from "@lodestar/utils";
+import {ColumnIndex} from "@lodestar/types";
 import {bytesToInt} from "@lodestar/utils";
 import {Multiaddr} from "@multiformats/multiaddr";
-import {getDataColumns} from "../../util/dataColumns.js";
+import {getCustodyGroups, getDataColumns} from "../../util/dataColumns.js";
 import {NetworkCoreMetrics} from "../core/metrics.js";
 import {Discv5Worker} from "../discv5/index.js";
 import {LodestarDiscv5Opts} from "../discv5/types.js";
@@ -19,6 +19,7 @@ import {NodeId, computeNodeId} from "../subnets/interface.js";
 import {getConnectionsMap, prettyPrintPeerId} from "../util.js";
 import {IPeerRpcScoreStore, ScoreState} from "./score/index.js";
 import {deserializeEnrSubnets, zeroAttnets, zeroSyncnets} from "./utils/enrSubnetsDeserialize.js";
+import {type GroupQueries } from "./utils/prioritizePeers.js";
 
 /** Max number of cached ENRs after discovering a good peer */
 const MAX_CACHED_ENRS = 100;
@@ -31,6 +32,7 @@ export type PeerDiscoveryOpts = {
   discv5: LodestarDiscv5Opts;
   connectToDiscv5Bootnodes?: boolean;
   // experimental flags for debugging
+  // TODO-das: remove
   onlyConnectToBiggerDataNodes?: boolean;
   onlyConnectToMinimalCustodyOverlapNodes?: boolean;
 };
@@ -63,6 +65,11 @@ export enum DiscoveredPeerStatus {
   no_multiaddrs = "no_multiaddrs",
 }
 
+export enum NotDialReason {
+  not_contain_requested_sampling_groups = "not_contain_requested_sampling_groups",
+  not_contain_requested_attnet_syncnet_subnets = "not_contain_requested_attnet_syncnet_subnets",
+}
+
 type UnixMs = number;
 /**
  * Maintain peersToConnect to avoid having too many topic peers at some point.
@@ -86,7 +93,7 @@ type CachedENR = {
   multiaddrTCP: Multiaddr;
   subnets: Record<SubnetType, boolean[]>;
   addedUnixMs: number;
-  custodyGroupCount: number;
+  peerCustodyGroups: number[];
 };
 
 /**
@@ -96,6 +103,7 @@ type CachedENR = {
 export class PeerDiscovery {
   readonly discv5: Discv5Worker;
   private libp2p: Libp2p;
+  // TODO-das: remove nodeId and sampleSubnets once we remove onlyConnect* flag
   private nodeId: NodeId;
   private sampleSubnets: number[];
   private peerRpcScores: IPeerRpcScoreStore;
@@ -103,20 +111,20 @@ export class PeerDiscovery {
   private logger: LoggerNode;
   private config: BeaconConfig;
   private cachedENRs = new Map<PeerIdStr, CachedENR>();
-  private peerIdToCustodyGroupCount = new Map<PeerIdStr, number>();
   private randomNodeQuery: QueryStatus = {code: QueryStatusCode.NotActive};
   private peersToConnect = 0;
   private subnetRequests: Record<SubnetType, Map<number, SubnetRequestInfo>> = {
     attnets: new Map(),
     syncnets: new Map(),
   };
+  // map of peerDAS group to max number of peers to connect
+  private groupRequests: Map<number, number>;
 
-  /** The maximum number of peers we allow (exceptions for subnet peers) */
-  private maxPeers: number;
   private discv5StartMs: number;
   private discv5FirstQueryDelayMs: number;
 
   private connectToDiscv5BootnodesOnStart: boolean | undefined = false;
+  // TODO-das: remove the below 2 flags
   private onlyConnectToBiggerDataNodes: boolean | undefined = false;
   private onlyConnectToMinimalCustodyOverlapNodes: boolean | undefined = false;
 
@@ -128,6 +136,7 @@ export class PeerDiscovery {
     this.logger = logger;
     this.config = config;
     this.discv5 = discv5;
+    // TODO-das: remove
     this.nodeId = nodeId;
     // we will only connect to peers that can provide us custody
     // TODO: @matthewkeil check if this needs to be updated for custody groups
@@ -135,8 +144,8 @@ export class PeerDiscovery {
       nodeId,
       Math.max(config.CUSTODY_REQUIREMENT, config.NODE_CUSTODY_REQUIREMENT, config.SAMPLES_PER_SLOT)
     );
+    this.groupRequests = new Map();
 
-    this.maxPeers = opts.maxPeers;
     this.discv5StartMs = 0;
     this.discv5StartMs = Date.now();
     this.discv5FirstQueryDelayMs = opts.discv5FirstQueryDelayMs;
@@ -169,6 +178,13 @@ export class PeerDiscovery {
       metrics.discovery.cachedENRsSize.addCollect(() => {
         metrics.discovery.cachedENRsSize.set(this.cachedENRs.size);
         metrics.discovery.peersToConnect.set(this.peersToConnect);
+
+        // PeerDAS metrics
+        const groupsToConnect = Array.from(this.groupRequests.values());
+        const groupPeersToConnect = groupsToConnect.reduce((acc, elem) => acc + elem, 0);
+        metrics.discovery.groupPeersToConnect.set(groupPeersToConnect);
+        metrics.discovery.groupsToConnect.set(groupsToConnect.filter((elem) => elem > 0).length);
+
         for (const type of [SubnetType.attnets, SubnetType.syncnets]) {
           const subnetPeersToConnect = Array.from(this.subnetRequests[type].values()).reduce(
             (acc, {peersToConnect}) => acc + peersToConnect,
@@ -202,7 +218,11 @@ export class PeerDiscovery {
   /**
    * Request to find peers, both on specific subnets and in general
    */
-  discoverPeers(peersToConnect: number, subnetRequests: SubnetDiscvQueryMs[] = []): void {
+  discoverPeers(
+    peersToConnect: number,
+    groupRequests: GroupQueries,
+    subnetRequests: SubnetDiscvQueryMs[] = []
+  ): void {
     const subnetsToDiscoverPeers: SubnetDiscvQueryMs[] = [];
     const cachedENRsToDial = new Map<PeerIdStr, CachedENR>();
     // Iterate in reverse to consider first the most recent ENRs
@@ -228,15 +248,40 @@ export class PeerDiscovery {
 
     this.peersToConnect += peersToConnect;
 
+    // starting from PeerDAS, we need to prioritize column subnet peers first in order to have stable subnet sampling
+    const groupsToDiscover = new Set<CustodyIndex>();
+    let groupPeersToDiscover = 0;
+    group: for (const [group, maxPeersToConnect] of groupRequests) {
+      let cachedENRsInGroup = 0;
+      for (const cachedENR of cachedENRsReverse) {
+        if (cachedENR.peerCustodyGroups.includes(group)) {
+          cachedENRsToDial.set(cachedENR.peerId.toString(), cachedENR);
+
+          if (++cachedENRsInGroup >= maxPeersToConnect) {
+            continue group;
+          }
+        }
+
+        const groupPeersToConnect = Math.max(maxPeersToConnect - cachedENRsInGroup, 0);
+        this.groupRequests.set(group, groupPeersToConnect);
+        groupsToDiscover.add(group);
+        groupPeersToDiscover += groupPeersToConnect;
+      }
+    }
+
     subnet: for (const subnetRequest of subnetRequests) {
       // Get cached ENRs from the discovery service that are in the requested `subnetId`, but not connected yet
       let cachedENRsInSubnet = 0;
-      for (const cachedENR of cachedENRsReverse) {
-        if (cachedENR.subnets[subnetRequest.type][subnetRequest.subnet]) {
-          cachedENRsToDial.set(cachedENR.peerId.toString(), cachedENR);
 
-          if (++cachedENRsInSubnet >= subnetRequest.maxPeersToDiscover) {
-            continue subnet;
+      // only dial attnet/syncnet peers if subnet sampling peers are stable
+      if (groupPeersToDiscover === 0) {
+        for (const cachedENR of cachedENRsReverse) {
+          if (cachedENR.subnets[subnetRequest.type][subnetRequest.subnet]) {
+            cachedENRsToDial.set(cachedENR.peerId.toString(), cachedENR);
+
+            if (++cachedENRsInSubnet >= subnetRequest.maxPeersToDiscover) {
+              continue subnet;
+            }
           }
         }
       }
@@ -284,15 +329,10 @@ export class PeerDiscovery {
       peersToConnect,
       peersAvailableToDial: cachedENRsToDial.size,
       subnetsToDiscover: subnetsToDiscoverPeers.length,
+      groupsToDiscover: Array.from(groupsToDiscover).join(","),
+      groupPeersToDiscover,
       shouldRunFindRandomNodeQuery,
     });
-  }
-
-  /**
-   * Get custody group count for a peer
-   */
-  getCustodyGroupCountForPeer(peer: PeerId): number | undefined {
-    return this.peerIdToCustodyGroupCount.get(peer.toString());
   }
 
   /**
@@ -343,12 +383,8 @@ export class PeerDiscovery {
 
     const attnets = zeroAttnets;
     const syncnets = zeroSyncnets;
-    const custodyGroupCount = this.peerIdToCustodyGroupCount.get(id.toString());
-    if (custodyGroupCount === undefined) {
-      this.logger.warn("onDiscoveredPeer with unknown custodyGroupCount assuming 4", {peerId: id.toString()});
-    }
 
-    const status = this.handleDiscoveredPeer(id, multiaddrs[0], attnets, syncnets, custodyGroupCount ?? 4);
+    const status = this.handleDiscoveredPeer(id, multiaddrs[0], attnets, syncnets, undefined);
     this.logger.debug("Discovered peer via libp2p", {peer: prettyPrintPeerId(id), status});
     this.metrics?.discovery.discoveredStatus.inc({status});
   };
@@ -383,13 +419,16 @@ export class PeerDiscovery {
     // never throw and treat too long or too short bitfields as zero-ed
     const attnets = attnetsBytes ? deserializeEnrSubnets(attnetsBytes, ATTESTATION_SUBNET_COUNT) : zeroAttnets;
     const syncnets = syncnetsBytes ? deserializeEnrSubnets(syncnetsBytes, SYNC_COMMITTEE_SUBNET_COUNT) : zeroSyncnets;
-    const custodyGroupCount = custodyGroupCountBytes
-      ? bytesToInt(custodyGroupCountBytes, "be")
-      : this.config.CUSTODY_REQUIREMENT;
-    this.peerIdToCustodyGroupCount.set(peerId.toString(), custodyGroupCount);
+    const custodyGroupCount = custodyGroupCountBytes ? bytesToInt(custodyGroupCountBytes, "be") : undefined;
 
-    const status = this.handleDiscoveredPeer(peerId, multiaddrTCP, attnets, syncnets, custodyGroupCount);
-    this.logger.debug("Discovered peer via discv5", {peer: prettyPrintPeerId(peerId), status});
+    const status = this.handleDiscoveredPeer(
+      peerId,
+      multiaddrTCP,
+      attnets,
+      syncnets,
+      custodyGroupCount
+    );
+    this.logger.debug("Discovered peer via discv5", {peer: prettyPrintPeerId(peerId), status, custodySubnetCount: custodyGroupCount});
     this.metrics?.discovery.discoveredStatus.inc({status});
   };
 
@@ -401,7 +440,7 @@ export class PeerDiscovery {
     multiaddrTCP: Multiaddr,
     attnets: boolean[],
     syncnets: boolean[],
-    custodyGroupCount: number
+    custodySubnetCount?: number
   ): DiscoveredPeerStatus {
     const nodeId = computeNodeId(peerId);
     this.logger.warn("handleDiscoveredPeer", {nodeId: toHexString(nodeId), peerId: peerId.toString()});
@@ -431,7 +470,7 @@ export class PeerDiscovery {
         multiaddrTCP,
         subnets: {attnets, syncnets},
         addedUnixMs: Date.now(),
-        custodyGroupCount: custodyGroupCount,
+        peerCustodyGroups: getCustodyGroups(nodeId, custodySubnetCount ?? this.config.CUSTODY_REQUIREMENT),
       };
 
       // Only dial peer if necessary
@@ -452,8 +491,10 @@ export class PeerDiscovery {
   }
 
   private shouldDialPeer(peer: CachedENR): boolean {
+    // begin onlyConnect* experimental logic
+    // TODO-das: remove
     const nodeId = computeNodeId(peer.peerId);
-    const peerCustodyGroupCount = peer.custodyGroupCount;
+    const peerCustodyGroupCount = peer.peerCustodyGroups.length;
     const peerCustodyColumns = getDataColumns(nodeId, peerCustodyGroupCount);
 
     const matchingSubnetsNum = this.sampleSubnets.reduce(
@@ -475,10 +516,36 @@ export class PeerDiscovery {
     if (this.onlyConnectToBiggerDataNodes && !hasAllColumns) {
       return false;
     }
+
     if (this.onlyConnectToMinimalCustodyOverlapNodes && !hasMinCustodyMatchingColumns) {
       return false;
     }
+    // end onlyConnect* experimental logic
 
+    // starting from PeerDAS fork, we need to make sure we have stable subnet sampling peers first
+    // given CUSTODY_REQUIREMENT = 4 and 100 peers, we have 400 custody columns from peers
+    // with NUMBER_OF_CUSTODY_GROUPS = 128, we have 400 / 128 = 3.125 peers per column in average
+    // it would not be hard to find TARGET_SUBNET_PEERS(6) peers per SAMPLES_PER_SLOT(8) columns
+    // after some first heartbeats, we should have no more column requested, then go with conditions of prior forks
+    let hasMatchingGroup = false;
+    let groupRequestCount = 0;
+    for (const [group, peersToConnect] of this.groupRequests.entries()) {
+      if (peersToConnect <= 0) {
+        this.groupRequests.delete(group);
+      } else if (peer.peerCustodyGroups.includes(group)) {
+        this.groupRequests.set(group, Math.max(0, peersToConnect - 1));
+        hasMatchingGroup = true;
+        groupRequestCount += peersToConnect;
+      }
+    }
+
+    // if subnet sampling peers are not stable and this peer is not in the requested columns, ignore it
+    if (groupRequestCount > 0 && !hasMatchingGroup) {
+      this.metrics?.discovery.notDialReason.inc({reason: NotDialReason.not_contain_requested_sampling_groups});
+      return false;
+    }
+
+    // logics up to Deneb fork
     for (const type of [SubnetType.attnets, SubnetType.syncnets]) {
       for (const [subnet, {toUnixMs, peersToConnect}] of this.subnetRequests[type].entries()) {
         if (toUnixMs < Date.now() || peersToConnect === 0) {
@@ -504,6 +571,7 @@ export class PeerDiscovery {
       return true;
     }
 
+    this.metrics?.discovery.notDialReason.inc({reason: NotDialReason.not_contain_requested_attnet_syncnet_subnets});
     return false;
   }
 

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -3,7 +3,7 @@ import {toHexString} from "@chainsafe/ssz";
 import type {PeerId, PeerInfo} from "@libp2p/interface";
 import {BeaconConfig} from "@lodestar/config";
 import {LoggerNode} from "@lodestar/logger/node";
-import {ATTESTATION_SUBNET_COUNT, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
+import {ATTESTATION_SUBNET_COUNT, ForkSeq, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
 import {CustodyIndex, SubnetID} from "@lodestar/types";
 import {pruneSetToMax, sleep} from "@lodestar/utils";
 import {ColumnIndex} from "@lodestar/types";
@@ -20,6 +20,7 @@ import {getConnectionsMap, prettyPrintPeerId} from "../util.js";
 import {IPeerRpcScoreStore, ScoreState} from "./score/index.js";
 import {deserializeEnrSubnets, zeroAttnets, zeroSyncnets} from "./utils/enrSubnetsDeserialize.js";
 import {type GroupQueries } from "./utils/prioritizePeers.js";
+import {IClock} from "../../util/clock.js";
 
 /** Max number of cached ENRs after discovering a good peer */
 const MAX_CACHED_ENRS = 100;
@@ -40,6 +41,7 @@ export type PeerDiscoveryOpts = {
 export type PeerDiscoveryModules = {
   nodeId: NodeId;
   libp2p: Libp2p;
+  clock: IClock;
   peerRpcScores: IPeerRpcScoreStore;
   metrics: NetworkCoreMetrics | null;
   logger: LoggerNode;
@@ -93,7 +95,8 @@ type CachedENR = {
   multiaddrTCP: Multiaddr;
   subnets: Record<SubnetType, boolean[]>;
   addedUnixMs: number;
-  peerCustodyGroups: number[];
+  // peerCustodyGroups is null for pre-fulu
+  peerCustodyGroups: number[] | null;
 };
 
 /**
@@ -103,6 +106,7 @@ type CachedENR = {
 export class PeerDiscovery {
   readonly discv5: Discv5Worker;
   private libp2p: Libp2p;
+  private readonly clock: IClock;
   // TODO-das: remove nodeId and sampleSubnets once we remove onlyConnect* flag
   private nodeId: NodeId;
   private sampleSubnets: number[];
@@ -129,8 +133,9 @@ export class PeerDiscovery {
   private onlyConnectToMinimalCustodyOverlapNodes: boolean | undefined = false;
 
   constructor(modules: PeerDiscoveryModules, opts: PeerDiscoveryOpts, discv5: Discv5Worker) {
-    const {libp2p, peerRpcScores, metrics, logger, config, nodeId} = modules;
+    const {libp2p, clock, peerRpcScores, metrics, logger, config, nodeId} = modules;
     this.libp2p = libp2p;
+    this.clock = clock;
     this.peerRpcScores = peerRpcScores;
     this.metrics = metrics;
     this.logger = logger;
@@ -217,6 +222,7 @@ export class PeerDiscovery {
 
   /**
    * Request to find peers, both on specific subnets and in general
+   * pre-fulu groupRequests is empty
    */
   discoverPeers(
     peersToConnect: number,
@@ -251,21 +257,25 @@ export class PeerDiscovery {
     // starting from PeerDAS, we need to prioritize column subnet peers first in order to have stable subnet sampling
     const groupsToDiscover = new Set<CustodyIndex>();
     let groupPeersToDiscover = 0;
-    group: for (const [group, maxPeersToConnect] of groupRequests) {
-      let cachedENRsInGroup = 0;
-      for (const cachedENR of cachedENRsReverse) {
-        if (cachedENR.peerCustodyGroups.includes(group)) {
-          cachedENRsToDial.set(cachedENR.peerId.toString(), cachedENR);
 
-          if (++cachedENRsInGroup >= maxPeersToConnect) {
-            continue group;
+    const forkSeq = this.config.getForkSeq(this.clock.currentSlot);
+    if (forkSeq >= ForkSeq.fulu) {
+      group: for (const [group, maxPeersToConnect] of groupRequests) {
+        let cachedENRsInGroup = 0;
+        for (const cachedENR of cachedENRsReverse) {
+          if (cachedENR.peerCustodyGroups && cachedENR.peerCustodyGroups.includes(group)) {
+            cachedENRsToDial.set(cachedENR.peerId.toString(), cachedENR);
+
+            if (++cachedENRsInGroup >= maxPeersToConnect) {
+              continue group;
+            }
           }
-        }
 
-        const groupPeersToConnect = Math.max(maxPeersToConnect - cachedENRsInGroup, 0);
-        this.groupRequests.set(group, groupPeersToConnect);
-        groupsToDiscover.add(group);
-        groupPeersToDiscover += groupPeersToConnect;
+          const groupPeersToConnect = Math.max(maxPeersToConnect - cachedENRsInGroup, 0);
+          this.groupRequests.set(group, groupPeersToConnect);
+          groupsToDiscover.add(group);
+          groupPeersToDiscover += groupPeersToConnect;
+        }
       }
     }
 
@@ -464,13 +474,16 @@ export class PeerDiscovery {
         return DiscoveredPeerStatus.already_dialing;
       }
 
+      const forkSeq = this.config.getForkSeq(this.clock.currentSlot);
+
       // Should dial peer?
       const cachedPeer: CachedENR = {
         peerId,
         multiaddrTCP,
         subnets: {attnets, syncnets},
         addedUnixMs: Date.now(),
-        peerCustodyGroups: getCustodyGroups(nodeId, custodySubnetCount ?? this.config.CUSTODY_REQUIREMENT),
+        // for pre-fulu, peerCustodyGroups is null
+        peerCustodyGroups: forkSeq >= ForkSeq.fulu ? getCustodyGroups(nodeId, custodySubnetCount ?? this.config.CUSTODY_REQUIREMENT) : null,
       };
 
       // Only dial peer if necessary
@@ -491,58 +504,62 @@ export class PeerDiscovery {
   }
 
   private shouldDialPeer(peer: CachedENR): boolean {
-    // begin onlyConnect* experimental logic
-    // TODO-das: remove
-    const nodeId = computeNodeId(peer.peerId);
-    const peerCustodyGroupCount = peer.peerCustodyGroups.length;
-    const peerCustodyColumns = getDataColumns(nodeId, peerCustodyGroupCount);
+    const forkSeq = this.config.getForkSeq(this.clock.currentSlot);
+    if (forkSeq >= ForkSeq.fulu && peer.peerCustodyGroups !== null) {
+      // begin onlyConnect* experimental logic
+      // TODO-das: remove
+      const nodeId = computeNodeId(peer.peerId);
+      const peerCustodyGroupCount = peer.peerCustodyGroups.length;
+      const peerCustodyColumns = getDataColumns(nodeId, peerCustodyGroupCount);
 
-    const matchingSubnetsNum = this.sampleSubnets.reduce(
-      (acc, elem) => acc + (peerCustodyColumns.includes(elem) ? 1 : 0),
-      0
-    );
-    const hasAllColumns = matchingSubnetsNum === this.sampleSubnets.length;
-    const hasMinCustodyMatchingColumns = matchingSubnetsNum >= Math.max(this.config.CUSTODY_REQUIREMENT);
+      const matchingSubnetsNum = this.sampleSubnets.reduce(
+        (acc, elem) => acc + (peerCustodyColumns.includes(elem) ? 1 : 0),
+        0
+      );
+      const hasAllColumns = matchingSubnetsNum === this.sampleSubnets.length;
+      const hasMinCustodyMatchingColumns = matchingSubnetsNum >= Math.max(this.config.CUSTODY_REQUIREMENT);
 
-    this.logger.warn("peerCustodyColumns", {
-      peerId: peer.peerId.toString(),
-      peerNodeId: toHexString(nodeId),
-      hasAllColumns,
-      peerCustodyGroupCount,
-      peerCustodyColumns: peerCustodyColumns.join(" "),
-      sampleSubnets: this.sampleSubnets.join(" "),
-      nodeId: `${toHexString(this.nodeId)}`,
-    });
-    if (this.onlyConnectToBiggerDataNodes && !hasAllColumns) {
-      return false;
-    }
-
-    if (this.onlyConnectToMinimalCustodyOverlapNodes && !hasMinCustodyMatchingColumns) {
-      return false;
-    }
-    // end onlyConnect* experimental logic
-
-    // starting from PeerDAS fork, we need to make sure we have stable subnet sampling peers first
-    // given CUSTODY_REQUIREMENT = 4 and 100 peers, we have 400 custody columns from peers
-    // with NUMBER_OF_CUSTODY_GROUPS = 128, we have 400 / 128 = 3.125 peers per column in average
-    // it would not be hard to find TARGET_SUBNET_PEERS(6) peers per SAMPLES_PER_SLOT(8) columns
-    // after some first heartbeats, we should have no more column requested, then go with conditions of prior forks
-    let hasMatchingGroup = false;
-    let groupRequestCount = 0;
-    for (const [group, peersToConnect] of this.groupRequests.entries()) {
-      if (peersToConnect <= 0) {
-        this.groupRequests.delete(group);
-      } else if (peer.peerCustodyGroups.includes(group)) {
-        this.groupRequests.set(group, Math.max(0, peersToConnect - 1));
-        hasMatchingGroup = true;
-        groupRequestCount += peersToConnect;
+      this.logger.warn("peerCustodyColumns", {
+        peerId: peer.peerId.toString(),
+        peerNodeId: toHexString(nodeId),
+        hasAllColumns,
+        peerCustodyGroupCount,
+        peerCustodyColumns: peerCustodyColumns.join(" "),
+        sampleSubnets: this.sampleSubnets.join(" "),
+        nodeId: `${toHexString(this.nodeId)}`,
+      });
+      if (this.onlyConnectToBiggerDataNodes && !hasAllColumns) {
+        return false;
       }
-    }
 
-    // if subnet sampling peers are not stable and this peer is not in the requested columns, ignore it
-    if (groupRequestCount > 0 && !hasMatchingGroup) {
-      this.metrics?.discovery.notDialReason.inc({reason: NotDialReason.not_contain_requested_sampling_groups});
-      return false;
+      if (this.onlyConnectToMinimalCustodyOverlapNodes && !hasMinCustodyMatchingColumns) {
+        return false;
+      }
+      // end onlyConnect* experimental logic
+
+      // pre-fulu `this.groupRequests` is empty
+      // starting from fulu, we need to make sure we have stable subnet sampling peers first
+      // given CUSTODY_REQUIREMENT = 4 and 100 peers, we have 400 custody columns from peers
+      // with NUMBER_OF_CUSTODY_GROUPS = 128, we have 400 / 128 = 3.125 peers per column in average
+      // it would not be hard to find TARGET_SUBNET_PEERS(6) peers per SAMPLES_PER_SLOT(8) columns
+      // after some first heartbeats, we should have no more column requested, then go with conditions of prior forks
+      let hasMatchingGroup = false;
+      let groupRequestCount = 0;
+      for (const [group, peersToConnect] of this.groupRequests.entries()) {
+        if (peersToConnect <= 0) {
+          this.groupRequests.delete(group);
+        } else if (peer.peerCustodyGroups.includes(group)) {
+          this.groupRequests.set(group, Math.max(0, peersToConnect - 1));
+          hasMatchingGroup = true;
+          groupRequestCount += peersToConnect;
+        }
+      }
+
+      // if subnet sampling peers are not stable and this peer is not in the requested columns, ignore it
+      if (groupRequestCount > 0 && !hasMatchingGroup) {
+        this.metrics?.discovery.notDialReason.inc({reason: NotDialReason.not_contain_requested_sampling_groups});
+        return false;
+      }
     }
 
     // logics up to Deneb fork

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -3,11 +3,11 @@ import {Connection, PeerId} from "@libp2p/interface";
 import {BeaconConfig} from "@lodestar/config";
 import {LoggerNode} from "@lodestar/logger/node";
 import {SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
-import {Metadata, altair, fulu, phase0} from "@lodestar/types";
+import {CustodyIndex, Metadata, fulu, phase0} from "@lodestar/types";
 import {withTimeout} from "@lodestar/utils";
 import {GOODBYE_KNOWN_CODES, GoodByeReasonCode, Libp2pEvent} from "../../constants/index.js";
 import {IClock} from "../../util/clock.js";
-import {getDataColumns} from "../../util/dataColumns.js";
+import {getCustodyGroups, getDataColumns} from "../../util/dataColumns.js";
 import {NetworkCoreMetrics} from "../core/metrics.js";
 import {LodestarDiscv5Opts} from "../discv5/types.js";
 import {INetworkEventBus, NetworkEvent, NetworkEventData} from "../events.js";
@@ -20,14 +20,15 @@ import {NodeId, SubnetsService, computeNodeId} from "../subnets/index.js";
 import {getConnection, getConnectionsMap, prettyPrintPeerId} from "../util.js";
 import {ClientKind, getKnownClientFromAgentVersion} from "./client.js";
 import {PeerDiscovery, SubnetDiscvQueryMs} from "./discover.js";
-import {PeerData, PeersData} from "./peersData.js";
 import {IPeerRpcScoreStore, PeerAction, PeerScoreStats, ScoreState, updateGossipsubScores} from "./score/index.js";
+import {PeersData, PeerData} from "./peersData.js";
 import {
   assertPeerRelevance,
   getConnectedPeerIds,
   hasSomeConnectedPeer,
   prioritizePeers,
   renderIrrelevantPeerType,
+  PrioritizePeersOpts,
 } from "./utils/index.js";
 
 /** heartbeat performs regular updates such as updating reputations and performing discovery requests */
@@ -65,10 +66,6 @@ const ALLOWED_NEGATIVE_GOSSIPSUB_FACTOR = 0.1;
 // to terminal if it deviates significantly from the user's settings
 
 export type PeerManagerOpts = {
-  /** The target number of peers we would like to connect to. */
-  targetPeers: number;
-  /** The maximum number of peers we allow (exceptions for subnet peers) */
-  maxPeers: number;
   /**
    * Delay the 1st query after starting discv5
    * See https://github.com/ChainSafe/lodestar/issues/3423
@@ -83,9 +80,10 @@ export type PeerManagerOpts = {
    */
   connectToDiscv5Bootnodes?: boolean;
   // experimental flags for debugging
+  // TODO-das: remove onlyConnect* flags
   onlyConnectToBiggerDataNodes?: boolean;
   onlyConnectToMinimalCustodyOverlapNodes?: boolean;
-};
+} & PrioritizePeersOpts;
 
 /**
  * ReqResp methods used only be PeerManager, so the main thread never has to call them
@@ -114,6 +112,8 @@ export type PeerManagerModules = {
   statusCache: StatusCache;
 };
 
+export type PeerRequestedSubnetType = SubnetType | "column";
+
 type PeerIdStr = string;
 
 enum RelevantPeerStatus {
@@ -133,6 +133,7 @@ enum RelevantPeerStatus {
 export class PeerManager {
   private nodeId: NodeId;
   private sampleSubnets: number[];
+  private samplingGroups: CustodyIndex[];
   private readonly libp2p: Libp2p;
   private readonly logger: LoggerNode;
   private readonly metrics: NetworkCoreMetrics | null;
@@ -174,6 +175,10 @@ export class PeerManager {
     // we will only connect to peers that can provide us custody
     // TODO: @matthewkeil check if this needs to be updated for custody groups
     this.sampleSubnets = getDataColumns(
+      this.nodeId,
+      Math.max(this.config.CUSTODY_REQUIREMENT, this.config.NODE_CUSTODY_REQUIREMENT, this.config.SAMPLES_PER_SLOT)
+    );
+    this.samplingGroups = getCustodyGroups(
       this.nodeId,
       Math.max(this.config.CUSTODY_REQUIREMENT, this.config.NODE_CUSTODY_REQUIREMENT, this.config.SAMPLES_PER_SLOT)
     );
@@ -336,14 +341,18 @@ export class PeerManager {
     });
     if (peerData) {
       const oldMetadata = peerData.metadata;
+      const cgc = (metadata as Partial<fulu.Metadata>).cgc ?? this.config.CUSTODY_REQUIREMENT;
+      const nodeId = peerData?.nodeId ?? computeNodeId(peer);
+      const custodyGroups = (oldMetadata == null || oldMetadata.custodyGroups == null || cgc !== oldMetadata.cgc) ? getCustodyGroups(nodeId, cgc) : oldMetadata.custodyGroups;
       peerData.metadata = {
         seqNumber: metadata.seqNumber,
         attnets: metadata.attnets,
         syncnets: (metadata as Partial<fulu.Metadata>).syncnets ?? BitArray.fromBitLen(SYNC_COMMITTEE_SUBNET_COUNT),
         cgc:
           (metadata as Partial<fulu.Metadata>).cgc ??
-          this.discovery?.getCustodyGroupCountForPeer(peer) ??
+          // TODO: spec says that Clients MAY reject peers with a value less than CUSTODY_REQUIREMENT
           this.config.CUSTODY_REQUIREMENT,
+        custodyGroups,
       };
       if (oldMetadata === null || oldMetadata.cgc !== peerData.metadata.cgc) {
         void this.requestStatus(peer, this.statusCache.get());
@@ -418,6 +427,8 @@ export class PeerManager {
 
       const peerCustodyGroupCount = custodyGroupCount ?? this.config.CUSTODY_REQUIREMENT;
       const dataColumns = getDataColumns(nodeId, peerCustodyGroupCount);
+      // on metadata, we should have custodyGroupss
+      const peerCustodyGroups = peerData?.metadata?.custodyGroups ?? getCustodyGroups(nodeId, peerCustodyGroupCount);
 
       const matchingSubnetsNum = this.sampleSubnets.reduce(
         (acc, elem) => acc + (dataColumns.includes(elem) ? 1 : 0),
@@ -434,6 +445,8 @@ export class PeerManager {
         custodyGroupCount,
         hasAllColumns,
         dataColumns: dataColumns.join(" "),
+        matchingSubnetsNum,
+        peerCustodyGroups: peerCustodyGroups.join(" "),
         mySampleSubnets: this.sampleSubnets.join(" "),
         clientAgent,
       });
@@ -533,7 +546,7 @@ export class PeerManager {
       }
     }
 
-    const {peersToDisconnect, peersToConnect, attnetQueries, syncnetQueries} = prioritizePeers(
+    const {peersToDisconnect, peersToConnect, attnetQueries, syncnetQueries, groupQueries} = prioritizePeers(
       connectedHealthyPeers.map((peer) => {
         const peerData = this.connectedPeers.get(peer.toString());
         return {
@@ -541,13 +554,16 @@ export class PeerManager {
           direction: peerData?.direction ?? null,
           attnets: peerData?.metadata?.attnets ?? null,
           syncnets: peerData?.metadata?.syncnets ?? null,
+          custodyGroups: peerData?.metadata?.custodyGroups ?? null,
           score: this.peerRpcScores.getScore(peer),
         };
       }),
       // Collect subnets which we need peers for in the current slot
       this.attnetsService.getActiveSubnets(),
       this.syncnetsService.getActiveSubnets(),
-      this.opts
+      this.samplingGroups,
+      this.opts,
+      this.metrics
     );
 
     const queriesMerged: SubnetDiscvQueryMs[] = [];
@@ -572,6 +588,11 @@ export class PeerManager {
       }
     }
 
+    for (const maxPeersToDiscover of groupQueries.values()) {
+      this.metrics?.peersRequestedSubnetsToQuery.inc({type: "column"}, 1);
+      this.metrics?.peersRequestedSubnetsPeerCount.inc({type: "column"}, maxPeersToDiscover);
+    }
+
     // disconnect first to have more slots before we dial new peers
     for (const [reason, peers] of peersToDisconnect) {
       this.metrics?.peersRequestedToDisconnect.inc({reason}, peers.length);
@@ -583,7 +604,8 @@ export class PeerManager {
     if (this.discovery) {
       try {
         this.metrics?.peersRequestedToConnect.inc(peersToConnect);
-        this.discovery.discoverPeers(peersToConnect, queriesMerged);
+        // for PeerDAS, lodestar implements subnet sampling strategy, hence we need to issue columnSubnetQueries to PeerDiscovery
+        this.discovery.discoverPeers(peersToConnect, groupQueries, queriesMerged);
       } catch (e) {
         this.logger.error("Error on discoverPeers", {}, e as Error);
       }
@@ -788,6 +810,7 @@ export class PeerManager {
 
         // TODO: Consider optimizing by doing observe in batch
         metrics.peerLongLivedAttnets.observe(attnets ? attnets.getTrueBitIndexes().length : 0);
+        metrics.peerColumnGroupCount.observe(peerData?.metadata?.cgc ?? 0);
         metrics.peerScoreByClient.observe({client}, this.peerRpcScores.getScore(peerId));
         metrics.peerGossipScoreByClient.observe({client}, this.peerRpcScores.getGossipScore(peerId));
         metrics.peerConnectionLength.observe((now - openCnx.timeline.open) / 1000);

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -2,7 +2,7 @@ import {BitArray, toHexString} from "@chainsafe/ssz";
 import {Connection, PeerId} from "@libp2p/interface";
 import {BeaconConfig} from "@lodestar/config";
 import {LoggerNode} from "@lodestar/logger/node";
-import {SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
+import {ForkSeq, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
 import {CustodyIndex, Metadata, fulu, phase0} from "@lodestar/types";
 import {withTimeout} from "@lodestar/utils";
 import {GOODBYE_KNOWN_CODES, GoodByeReasonCode, Libp2pEvent} from "../../constants/index.js";
@@ -174,10 +174,12 @@ export class PeerManager {
     this.nodeId = modules.nodeId;
     // we will only connect to peers that can provide us custody
     // TODO: @matthewkeil check if this needs to be updated for custody groups
+    // TODO(das): may not need this, use `this.samplingGroups` instead
     this.sampleSubnets = getDataColumns(
       this.nodeId,
       Math.max(this.config.CUSTODY_REQUIREMENT, this.config.NODE_CUSTODY_REQUIREMENT, this.config.SAMPLES_PER_SLOT)
     );
+    // TODO(das): get from custodyConfig or a centralized place every time, instead of computing once here
     this.samplingGroups = getCustodyGroups(
       this.nodeId,
       Math.max(this.config.CUSTODY_REQUIREMENT, this.config.NODE_CUSTODY_REQUIREMENT, this.config.SAMPLES_PER_SLOT)
@@ -546,6 +548,8 @@ export class PeerManager {
       }
     }
 
+    const forkSeq = this.config.getForkSeq(this.clock.currentSlot);
+
     const {peersToDisconnect, peersToConnect, attnetQueries, syncnetQueries, groupQueries} = prioritizePeers(
       connectedHealthyPeers.map((peer) => {
         const peerData = this.connectedPeers.get(peer.toString());
@@ -561,7 +565,8 @@ export class PeerManager {
       // Collect subnets which we need peers for in the current slot
       this.attnetsService.getActiveSubnets(),
       this.syncnetsService.getActiveSubnets(),
-      this.samplingGroups,
+      // ignore samplingGroups for pre-fulu forks
+      forkSeq >= ForkSeq.fulu ? this.samplingGroups : undefined,
       this.opts,
       this.metrics
     );

--- a/packages/beacon-node/src/network/peers/peersData.ts
+++ b/packages/beacon-node/src/network/peers/peersData.ts
@@ -1,10 +1,11 @@
 import {PeerId} from "@libp2p/interface";
 import {Encoding} from "@lodestar/reqresp";
-import {altair, fulu} from "@lodestar/types";
+import {CustodyIndex, altair, fulu} from "@lodestar/types";
 import {NodeId} from "../subnets/interface.js";
 import {ClientKind} from "./client.js";
 
 type PeerIdStr = string;
+type Metadata = fulu.Metadata & {custodyGroups: CustodyIndex[]};
 
 export enum RelevantPeerStatus {
   Unknown = "unknown",
@@ -20,7 +21,7 @@ export type PeerData = {
   direction: "inbound" | "outbound";
   peerId: PeerId;
   nodeId: NodeId | null;
-  metadata: fulu.Metadata | null;
+  metadata: Metadata | null;
   agentVersion: string | null;
   agentClient: ClientKind | null;
   encodingPreference: Encoding | null;

--- a/packages/beacon-node/src/network/peers/utils/prioritizePeers.ts
+++ b/packages/beacon-node/src/network/peers/utils/prioritizePeers.ts
@@ -1,10 +1,11 @@
 import {BitArray} from "@chainsafe/ssz";
 import {Direction, PeerId} from "@libp2p/interface";
 import {ATTESTATION_SUBNET_COUNT, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
-import {SubnetID, altair, phase0} from "@lodestar/types";
+import {CustodyIndex, SubnetID, altair, phase0} from "@lodestar/types";
 import {MapDef} from "@lodestar/utils";
 import {shuffle} from "../../../util/shuffle.js";
 import {sortBy} from "../../../util/sortBy.js";
+import {NetworkCoreMetrics} from "../../core/metrics.js";
 import {RequestedSubnet} from "./subnetMap.js";
 
 /** Target number of peers we'd like to have connected to a given long-lived subnet */
@@ -39,23 +40,29 @@ const attnetsZero = BitArray.fromBitLen(ATTESTATION_SUBNET_COUNT);
 const syncnetsZero = BitArray.fromBitLen(SYNC_COMMITTEE_SUBNET_COUNT);
 
 type SubnetDiscvQuery = {subnet: SubnetID; toSlot: number; maxPeersToDiscover: number};
+/**
+ * A map of column subnet id to maxPeersToDiscover
+ */
+export type GroupQueries = Map<CustodyIndex, number>;
 
 type PeerInfo = {
   id: PeerId;
   direction: Direction | null;
   attnets: phase0.AttestationSubnets;
   syncnets: altair.SyncSubnets;
+  custodyGroups: CustodyIndex[];
   attnetsTrueBitIndices: number[];
   syncnetsTrueBitIndices: number[];
   score: number;
 };
 
-export interface PrioritizePeersOpts {
+export type PrioritizePeersOpts = {
   targetPeers: number;
   maxPeers: number;
+  targetGroupPeers: number;
   outboundPeersRatio?: number;
   targetSubnetPeers?: number;
-}
+};
 
 export enum ExcessPeerDisconnectReason {
   LOW_SCORE = "low_score",
@@ -77,16 +84,20 @@ export function prioritizePeers(
     direction: Direction | null;
     attnets: phase0.AttestationSubnets | null;
     syncnets: altair.SyncSubnets | null;
+    custodyGroups: CustodyIndex[] | null;
     score: number;
   }[],
   activeAttnets: RequestedSubnet[],
   activeSyncnets: RequestedSubnet[],
-  opts: PrioritizePeersOpts
+  samplingGroups: CustodyIndex[],
+  opts: PrioritizePeersOpts,
+  metrics: NetworkCoreMetrics | null
 ): {
   peersToConnect: number;
   peersToDisconnect: Map<ExcessPeerDisconnectReason, PeerId[]>;
   attnetQueries: SubnetDiscvQuery[];
   syncnetQueries: SubnetDiscvQuery[];
+  groupQueries: GroupQueries;
 } {
   const {targetPeers, maxPeers} = opts;
 
@@ -100,17 +111,20 @@ export function prioritizePeers(
       direction: peer.direction,
       attnets: peer.attnets ?? attnetsZero,
       syncnets: peer.syncnets ?? syncnetsZero,
+      custodyGroups: peer.custodyGroups ?? [],
       attnetsTrueBitIndices: peer.attnets?.getTrueBitIndexes() ?? [],
       syncnetsTrueBitIndices: peer.syncnets?.getTrueBitIndexes() ?? [],
       score: peer.score,
     })
   );
 
-  const {attnetQueries, syncnetQueries, dutiesByPeer} = requestAttnetPeers(
+  const {attnetQueries, syncnetQueries, groupQueries, dutiesByPeer} = requestSubnetPeers(
     connectedPeers,
     activeAttnets,
     activeSyncnets,
-    opts
+    samplingGroups,
+    opts,
+    metrics
   );
 
   const connectedPeerCount = connectedPeers.length;
@@ -134,20 +148,24 @@ export function prioritizePeers(
     peersToDisconnect,
     attnetQueries,
     syncnetQueries,
+    groupQueries,
   };
 }
 
 /**
- * If more peers are needed in attnets and syncnets, create SubnetDiscvQuery for each subnet
+ * If more peers are needed in attnets and syncnets and column subnets, create SubnetDiscvQuery for each subnet
  */
-function requestAttnetPeers(
+function requestSubnetPeers(
   connectedPeers: PeerInfo[],
   activeAttnets: RequestedSubnet[],
   activeSyncnets: RequestedSubnet[],
-  opts: PrioritizePeersOpts
+  samplingGroups: CustodyIndex[],
+  opts: PrioritizePeersOpts,
+  metrics: NetworkCoreMetrics | null
 ): {
   attnetQueries: SubnetDiscvQuery[];
   syncnetQueries: SubnetDiscvQuery[];
+  groupQueries: GroupQueries;
   dutiesByPeer: Map<PeerInfo, number>;
 } {
   const {targetSubnetPeers = TARGET_SUBNET_PEERS} = opts;
@@ -209,7 +227,27 @@ function requestAttnetPeers(
     }
   }
 
-  return {attnetQueries, syncnetQueries, dutiesByPeer};
+  // column subnets, do we need queries for more peers
+  const targetGroupPeers = opts.targetGroupPeers;
+  const groupQueries: GroupQueries = new Map();
+  const peersPerGroup = new Map<CustodyIndex, number>();
+  for (const peer of connectedPeers) {
+    const {custodyGroups} = peer;
+    for (const group of custodyGroups) {
+      peersPerGroup.set(group, 1 + (peersPerGroup.get(group) ?? 0));
+    }
+  }
+
+  for (const group of samplingGroups) {
+    const peersInGroup = peersPerGroup.get(group) ?? 0;
+    metrics?.peerCountPerSamplingGroup.set({group}, peersInGroup);
+    if (peersInGroup < targetGroupPeers) {
+      // We need more peers
+      groupQueries.set(group, targetGroupPeers - peersInGroup);
+    }
+  }
+
+  return {attnetQueries, syncnetQueries, groupQueries, dutiesByPeer};
 }
 
 /**

--- a/packages/beacon-node/src/network/peers/utils/prioritizePeers.ts
+++ b/packages/beacon-node/src/network/peers/utils/prioritizePeers.ts
@@ -41,7 +41,7 @@ const syncnetsZero = BitArray.fromBitLen(SYNC_COMMITTEE_SUBNET_COUNT);
 
 type SubnetDiscvQuery = {subnet: SubnetID; toSlot: number; maxPeersToDiscover: number};
 /**
- * A map of column subnet id to maxPeersToDiscover
+ * A map of das custody group index to maxPeersToDiscover
  */
 export type GroupQueries = Map<CustodyIndex, number>;
 
@@ -77,6 +77,8 @@ export enum ExcessPeerDisconnectReason {
  * - Don't exceed `maxPeers`
  * - Ensure there are enough peers per active subnet
  * - Prioritize peers with good score
+ *
+ * pre-fulu samplingGroups is not used and this function returns empty groupQueries
  */
 export function prioritizePeers(
   connectedPeersInfo: {
@@ -89,7 +91,7 @@ export function prioritizePeers(
   }[],
   activeAttnets: RequestedSubnet[],
   activeSyncnets: RequestedSubnet[],
-  samplingGroups: CustodyIndex[],
+  samplingGroups: CustodyIndex[] = [],
   opts: PrioritizePeersOpts,
   metrics: NetworkCoreMetrics | null
 ): {
@@ -154,12 +156,13 @@ export function prioritizePeers(
 
 /**
  * If more peers are needed in attnets and syncnets and column subnets, create SubnetDiscvQuery for each subnet
+ * pre-fulu samplingGroups is not used and this function returns empty groupQueries
  */
 function requestSubnetPeers(
   connectedPeers: PeerInfo[],
   activeAttnets: RequestedSubnet[],
   activeSyncnets: RequestedSubnet[],
-  samplingGroups: CustodyIndex[],
+  samplingGroups: CustodyIndex[] = [],
   opts: PrioritizePeersOpts,
   metrics: NetworkCoreMetrics | null
 ): {

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -38,6 +38,7 @@ export type NetworkArgs = {
   "network.maxGossipTopicConcurrency"?: number;
   "network.useWorker"?: boolean;
   "network.maxYoungGenerationSizeMb"?: number;
+  "network.targetGroupPeers"?: number;
 
   /** @deprecated This option is deprecated and should be removed in next major release. */
   "network.requestCountPeerLimit"?: number;
@@ -157,6 +158,7 @@ export function parseArgs(args: NetworkArgs): IBeaconNodeOptions["network"] {
     maxGossipTopicConcurrency: args["network.maxGossipTopicConcurrency"],
     useWorker: args["network.useWorker"],
     maxYoungGenerationSizeMb: args["network.maxYoungGenerationSizeMb"],
+    targetGroupPeers: args["network.targetGroupPeers"] ?? defaultOptions.network.targetGroupPeers,
   };
 }
 
@@ -403,5 +405,13 @@ export const options: CliCommandOptions<NetworkArgs> = {
     group: "network",
     description: "Max size of young generation in megabytes. Defaults to 152mb",
     defaultDescription: String(defaultOptions.network.maxYoungGenerationSizeMb),
+  },
+
+  "network.targetGroupPeers": {
+    type: "number",
+    hidden: true,
+    group: "network",
+    description: "Target number of peers per sampling group",
+    defaultDescription: String(defaultOptions.network.targetGroupPeers),
   },
 };

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -105,6 +105,7 @@ describe("options / beaconNodeOptions", () => {
       "network.maxGossipTopicConcurrency": 64,
       "network.useWorker": true,
       "network.maxYoungGenerationSizeMb": 152,
+      "network.targetGroupPeers": 12,
 
       "sync.isSingleNode": true,
       "sync.disableProcessAsChainSegment": true,
@@ -217,6 +218,7 @@ describe("options / beaconNodeOptions", () => {
         maxGossipTopicConcurrency: 64,
         useWorker: true,
         maxYoungGenerationSizeMb: 152,
+        targetGroupPeers: 12,
       },
       sync: {
         isSingleNode: true,


### PR DESCRIPTION
**Motivation**

- Lodestar follows subnet sampling strategy. For each block, it's required at least `8` data columns from sampling subnets
- sampling subnet peers are critical for PeerDAS and we don't have a mechanism to maintain at least `n` number of peers per subnet for now
- in the worst case scenario, our beacon node may loose all peers on a column subnet and stay out of synced and we have no way to deal with it for now. If we have too few peers, we may not process blocks on time in order to have a good attestation performance
- this PR makes sure we have at least `n` number of peers per column sampling subnet

**Description**
- store `custodySubnets` in `peersData` so that we don't have to compute it all the times
- use our subnet request mechanism for column sampling subnets
  - if a peer does not have any column subnets that we need, do not dial it
  - in average, a column subnet has 3.125 peer. I made default `targetColumnSubnetPeers = 6` which make it easy to achieve after a few heartbeats but this could be changed with a newly added cli flag with the same name
  - this mechanism replace `onlyConnect*` flags
- more metrics, this answer some questions:
  - what are column subnets we're sampling, how many peers per subnet?
  - number of column subnets requested, how many peers requested
  - reason for not dialing a peer
  - csc value of each ENR


