### PR TITLE
chore: remove prettier as default formatter for all file types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "window.title": "${activeEditorShort}${separator}${rootName}${separator}${profileName}${separator}[${activeRepositoryBranchName}]",
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
   // For `sysoev.vscode-open-in-github` extension
   "openInGitHub.defaultBranch": "unstable",
   "editor.formatOnSave": true,
@@ -18,5 +17,11 @@
   },
   "[jsonc]": {
     "editor.defaultFormatter": "biomejs.biome" 
-  }
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
 }


### PR DESCRIPTION
**Motivation**

Noticed if I try save a shell script (.sh files) I get a annoying error popup
![image](https://github.com/user-attachments/assets/dcad75f6-3c04-4b1e-9c6c-5124e392609e)

We should not specify a default formatter in vs code settings, instead make sure we only define formatters for file types that they can handle.

**Description**

Remove prettier as default formatter for all file types and instead adds it only for markdown and yaml files.
