### PR TITLE
chore: update bootnodes file url for holesky and sepolia

### DIFF
--- a/packages/cli/src/networks/holesky.ts
+++ b/packages/cli/src/networks/holesky.ts
@@ -3,7 +3,7 @@ export {holeskyChainConfig as chainConfig} from "@lodestar/config/networks";
 export const depositContractDeployBlock = 0;
 export const genesisFileUrl = "https://media.githubusercontent.com/media/eth-clients/holesky/main/metadata/genesis.ssz";
 export const bootnodesFileUrl =
-  "https://raw.githubusercontent.com/eth-clients/holesky/main/metadata/bootstrap_nodes.txt";
+  "https://raw.githubusercontent.com/eth-clients/holesky/main/metadata/bootstrap_nodes.yaml";
 
 export const bootEnrs = [
   "enr:-Ku4QFo-9q73SspYI8cac_4kTX7yF800VXqJW4Lj3HkIkb5CMqFLxciNHePmMt4XdJzHvhrCC5ADI4D_GkAsxGJRLnQBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAhnTT-AQFwAP__________gmlkgnY0gmlwhLKAiOmJc2VjcDI1NmsxoQORcM6e19T1T9gi7jxEZjk_sjVLGFscUNqAY9obgZaxbIN1ZHCCIyk",

--- a/packages/cli/src/networks/sepolia.ts
+++ b/packages/cli/src/networks/sepolia.ts
@@ -3,7 +3,7 @@ export {sepoliaChainConfig as chainConfig} from "@lodestar/config/networks";
 export const depositContractDeployBlock = 1273020;
 export const genesisFileUrl = "https://github.com/eth-clients/sepolia/raw/main/metadata/genesis.ssz";
 export const bootnodesFileUrl =
-  "https://raw.githubusercontent.com/eth-clients/sepolia/main/metadata/bootstrap_nodes.txt";
+  "https://raw.githubusercontent.com/eth-clients/sepolia/main/metadata/bootstrap_nodes.yaml";
 
 export const bootEnrs = [
   "enr:-KO4QP7MmB3juk8rUjJHcUoxZDU9Np4FlW0HyDEGIjSO7GD9PbSsabu7713cWSUWKDkxIypIXg1A-6lG7ySRGOMZHeGCAmuEZXRoMpDTH2GRkAAAc___________gmlkgnY0gmlwhBSoyGOJc2VjcDI1NmsxoQNta5b_bexSSwwrGW2Re24MjfMntzFd0f2SAxQtMj3ueYN0Y3CCIyiDdWRwgiMo",


### PR DESCRIPTION
**Motivation**

The txt files got removed in https://github.com/eth-clients/holesky/pull/116 and https://github.com/eth-clients/sepolia/pull/94


**Description**

Update bootnodes file url for holesky and sepolia to point to yaml instead of txt files.