### PR TITLE
fix: update engine_getClientVersionV1 commit encoding

### DIFF
--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -2,6 +2,7 @@ import {Logger} from "@lodestar/logger";
 import {ForkName, ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ExecutionPayload, ExecutionRequests, Root, RootHex, Wei} from "@lodestar/types";
 import {BlobAndProof} from "@lodestar/types/deneb";
+import {strip0xPrefix} from "@lodestar/utils";
 import {
   ErrorJsonRpcResponse,
   HttpRpcError,
@@ -522,11 +523,11 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     const response = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
-    >({method, params: [clientVersion]});
+    >({method, params: [{...clientVersion, commit: `0x${clientVersion.commit}`}]});
 
     const clientVersions = response.map((cv) => {
       const code = cv.code in ClientCode ? ClientCode[cv.code as keyof typeof ClientCode] : ClientCode.XX;
-      return {code, name: cv.name, version: cv.version, commit: cv.commit};
+      return {code, name: cv.name, version: cv.version, commit: strip0xPrefix(cv.commit)};
     });
 
     if (clientVersions.length === 0) {

--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import {fileURLToPath} from "node:url";
-import {fromHex, toHex} from "@lodestar/utils";
+import {fromHex, strip0xPrefix, toHex} from "@lodestar/utils";
 
 // "c-kzg" has hardcoded the mainnet value, do not use params
 export const FIELD_ELEMENTS_PER_BLOB_MAINNET = 4096;
@@ -153,11 +153,4 @@ export function trustedSetupJsonToTxt(data: TrustedSetupJSON): TrustedSetupTXT {
     ...data.setup_G1.map(strip0xPrefix),
     ...data.setup_G2.map(strip0xPrefix),
   ].join("\n");
-}
-
-function strip0xPrefix(hex: string): string {
-  if (hex.startsWith("0x")) {
-    return hex.slice(2);
-  }
-  return hex;
 }

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -1,6 +1,6 @@
 import {DOMAIN_VOLUNTARY_EXIT, ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {DomainType, ForkDigest, Root, Slot, Version, phase0, ssz} from "@lodestar/types";
-import {toHex} from "@lodestar/utils";
+import {strip0xPrefix, toHex} from "@lodestar/utils";
 import {ChainForkConfig} from "../beaconConfig.js";
 import {CachedGenesis, ForkDigestHex} from "./types.js";
 export type {ForkDigestContext} from "./types.js";
@@ -140,10 +140,6 @@ function computeForkDataRoot(currentVersion: Version, genesisValidatorsRoot: Roo
 
 function toHexStringNoPrefix(hex: string | Uint8Array): string {
   return strip0xPrefix(typeof hex === "string" ? hex : toHex(hex));
-}
-
-function strip0xPrefix(hex: string): string {
-  return hex.startsWith("0x") ? hex.slice(2) : hex;
 }
 
 function computeForkDigest(currentVersion: Version, genesisValidatorsRoot: Root): ForkDigest {

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -65,3 +65,10 @@ export function prettyMsToTime(timeMs: number): string {
   const date = new Date(0, 0, 0, 0, 0, 0, timeMs);
   return `${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}.${date.getMilliseconds()}`;
 }
+
+/**
+ * Remove 0x prefix from a string
+ */
+export function strip0xPrefix(hex: string): string {
+  return hex.startsWith("0x") ? hex.slice(2) : hex;
+}


### PR DESCRIPTION
**Motivation**

Alternative to https://github.com/ChainSafe/lodestar/pull/7273 which also handles the incorrect encoding when passing the data to the EL via `engine_getClientVersionV1`.

**Description**

Update `engine_getClientVersionV1` commit encoding
- strip 0x prefix when receiving commit from EL
- add 0x prefix when passing commit to EL

Closes https://github.com/ChainSafe/lodestar/issues/7217
