### PR TITLE
chore: log sync committee signature errors as `error`

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -257,7 +257,7 @@ export function getBeaconPoolApi({
             }
 
             failures.push({index: i, message: (e as Error).message});
-            logger.debug(
+            logger.error(
               `Error on submitPoolSyncCommitteeSignatures [${i}]`,
               {slot: signature.slot, validatorIndex: signature.validatorIndex},
               e as Error


### PR DESCRIPTION
**Motivation**

The log level was previously changed from `error` to `debug` in https://github.com/ChainSafe/lodestar/pull/5256 but I can't find a rationale for this, but my guess is that those were quite noisy back than as Lodestar was not performing as well but now I think we should be more verbose here to better detect sync committee issues, and if it turns out to be too noisy we could always roll back.

@twoeths maybe you remember why it was changed previously

**Description**

Log sync committee signature errors as `error` instead of `debug`.

