### PR TITLE
fix: check pubkey or validator index known to a state

### DIFF
--- a/packages/state-transition/src/block/processConsolidationRequest.ts
+++ b/packages/state-transition/src/block/processConsolidationRequest.ts
@@ -3,7 +3,7 @@ import {electra, ssz} from "@lodestar/types";
 
 import {CachedBeaconStateElectra} from "../types.js";
 import {hasEth1WithdrawalCredential} from "../util/capella.js";
-import {hasExecutionWithdrawalCredential, switchToCompoundingValidator} from "../util/electra.js";
+import {hasExecutionWithdrawalCredential, isPubkeyKnown, switchToCompoundingValidator} from "../util/electra.js";
 import {computeConsolidationEpochAndUpdateChurn} from "../util/epoch.js";
 import {getConsolidationChurnLimit, isActiveValidator} from "../util/validator.js";
 
@@ -13,6 +13,10 @@ export function processConsolidationRequest(
   consolidationRequest: electra.ConsolidationRequest
 ): void {
   const {sourcePubkey, targetPubkey, sourceAddress} = consolidationRequest;
+  if (!isPubkeyKnown(state, sourcePubkey) || !isPubkeyKnown(state, targetPubkey)) {
+    return;
+  }
+
   const sourceIndex = state.epochCtx.getValidatorIndex(sourcePubkey);
   const targetIndex = state.epochCtx.getValidatorIndex(targetPubkey);
 
@@ -95,8 +99,9 @@ function isValidSwitchToCompoundRequest(
   const sourceIndex = state.epochCtx.getValidatorIndex(sourcePubkey);
   const targetIndex = state.epochCtx.getValidatorIndex(targetPubkey);
 
+  // since we share pubkey2index, validatorIndex maybe known by other epoch transition but we don't have that validator in this state
   // Verify pubkey exists
-  if (sourceIndex === null) {
+  if (sourceIndex === null || sourceIndex >= state.validators.length) {
     return false;
   }
 

--- a/packages/state-transition/src/block/processConsolidationRequest.ts
+++ b/packages/state-transition/src/block/processConsolidationRequest.ts
@@ -99,9 +99,9 @@ function isValidSwitchToCompoundRequest(
   const sourceIndex = state.epochCtx.getValidatorIndex(sourcePubkey);
   const targetIndex = state.epochCtx.getValidatorIndex(targetPubkey);
 
-  // since we share pubkey2index, validatorIndex maybe known by other epoch transition but we don't have that validator in this state
   // Verify pubkey exists
-  if (sourceIndex === null || sourceIndex >= state.validators.length) {
+  if (sourceIndex === null) {
+    // this check is mainly to make the compiler happy, pubkey is checked by the consumer already
     return false;
   }
 

--- a/packages/state-transition/src/util/electra.ts
+++ b/packages/state-transition/src/util/electra.ts
@@ -45,3 +45,20 @@ export function queueExcessActiveBalance(state: CachedBeaconStateElectra, index:
     state.pendingDeposits.push(pendingDeposit);
   }
 }
+
+/**
+ * Since we share pubkey2index, pubkey maybe added by other epoch transition but we don't have that validator in this state
+ */
+export function isPubkeyKnown(state: CachedBeaconStateElectra, pubkey: Uint8Array): boolean {
+  return isValidatorKnown(state, state.epochCtx.getValidatorIndex(pubkey));
+}
+
+/**
+ * Since we share pubkey2index, validatorIndex maybe not null but we don't have that validator in this state
+ */
+export function isValidatorKnown(
+  state: CachedBeaconStateElectra,
+  index: ValidatorIndex | null
+): index is ValidatorIndex {
+  return index !== null && index < state.validators.length;
+}


### PR DESCRIPTION
**Motivation**

Got this error in mekong devnet found by @nflaig 

```
Dec-05 20:57:46.624[chain]           debug: Block error slot=207552, code=BLOCK_ERROR_PRESTATE_MISSING, error=Cannot read properties of undefined (reading 'exitEpoch')
```

```
TypeError: Cannot read properties of undefined (reading 'exitEpoch')
    at CustomContainerTreeViewDU.get [as exitEpoch] (/home/nico/projects/ethereum/lodestar/node_modules/@chainsafe/ssz/src/viewDU/containerNodeStruct.ts:78:61)
    at processPendingDeposits (file:///home/nico/projects/ethereum/lodestar/packages/state-transition/src/epoch/processPendingDeposits.ts:55:37)
```

**Description**

Consider this scenario when we have multiple epoch transitions per epoch, given n is the epoch transition slot
<img width="409" alt="Screenshot 2024-12-06 at 10 44 08" src="https://github.com/user-attachments/assets/b3f57f80-417e-43ef-8c06-258f0d4aa675">

pending deposits of the whole epoch are processed by pulling up (n-1) state, then we add pubkeys to `indes2pubkey`
then at slot n, we process epoch transition again, found validator index from `index2pubkey` but validator is not added to registry of the state, then the issue happen

To resolve it, I added `isPubkeyKnown()` function and `isValidatorKnown` utils and use them at concerned place.

**Steps to test or reproduce**

resync mekong?
