### PR TITLE
chore: print graffiti when producing beacon block body

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -143,6 +143,7 @@ export async function produceBlockBody<T extends BlockType>(
     : await produceCommonBlockBody.call(this, blockType, currentState, blockAttr);
 
   const {
+    graffiti,
     attestations,
     deposits,
     voluntaryExits,
@@ -153,6 +154,7 @@ export async function produceBlockBody<T extends BlockType>(
   } = blockBody;
 
   Object.assign(logMeta, {
+    graffiti,
     attestations: attestations.length,
     deposits: deposits.length,
     voluntaryExits: voluntaryExits.length,


### PR DESCRIPTION
**Motivation**

In https://github.com/ChainSafe/lodestar/pull/6753 we moved setting the default graffiti to the beacon node side and since then we are not printing the graffiti anywhere, although we still print it on the vc side but if it's not explicitly set there it won't show the actual value that will be used during block proposal.

This also would have helped to catch https://github.com/ChainSafe/lodestar/issues/7217.

**Description**

Print graffiti when producing beacon block body
