### PR TITLE
fix: warn if engine / builder failed to produce block within cutoff time

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -695,32 +695,46 @@ export function getValidatorApi(
       throw Error("Builder and engine both failed to produce the block within timeout");
     }
 
-    if (engine.status === "rejected" && isEngineEnabled) {
-      logger.warn(
-        "Engine failed to produce the block",
-        {
-          ...loggerContext,
-          durationMs: engine.durationMs,
-        },
-        engine.reason
-      );
-    }
-
-    if (builder.status === "rejected" && isBuilderEnabled) {
-      if (builder.reason instanceof NoBidReceived) {
-        logger.info("Builder did not provide a bid", {
-          ...loggerContext,
-          durationMs: builder.durationMs,
-        });
-      } else {
+    if (isEngineEnabled) {
+      if (engine.status === "rejected") {
         logger.warn(
-          "Builder failed to produce the block",
+          "Engine failed to produce the block",
           {
             ...loggerContext,
-            durationMs: builder.durationMs,
+            durationMs: engine.durationMs,
           },
-          builder.reason
+          engine.reason
         );
+      } else if (engine.status === "pending") {
+        logger.warn("Engine failed to produce the block within cutoff time", {
+          ...loggerContext,
+          cutoffMs,
+        });
+      }
+    }
+
+    if (isBuilderEnabled) {
+      if (builder.status === "rejected") {
+        if (builder.reason instanceof NoBidReceived) {
+          logger.info("Builder did not provide a bid", {
+            ...loggerContext,
+            durationMs: builder.durationMs,
+          });
+        } else {
+          logger.warn(
+            "Builder failed to produce the block",
+            {
+              ...loggerContext,
+              durationMs: builder.durationMs,
+            },
+            builder.reason
+          );
+        }
+      } else if (builder.status === "pending") {
+        logger.warn("Builder failed to produce the block within cutoff time", {
+          ...loggerContext,
+          cutoffMs,
+        });
       }
     }
 


### PR DESCRIPTION
**Motivation**

Noticed we don't log any warning if engine or builder failed to produce block within cutoff time. In this case the status will be "pending" and the other block (if resolved) will be picked.

This scenario is pretty rare but can happen in some cases, eg. if block production is started late into the slot due to event loop lag or other reasons.

I have not seen this happen for engine blocks but noticed one case where we did not pick the builder block due to this (see [logs](https://grafana-lodestar.chainsafe.io/explore?schemaVersion=1&panes=%7B%2203w%22:%7B%22datasource%22:%22mWyrm924z%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Binstance%3D%5C%22hetzner-lido-prod-bn-1%5C%22,%20container%3D%5C%22beacon%5C%22%7D%20%7C%3D%20%6010550752%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22mWyrm924z%22%7D,%22editorMode%22:%22builder%22%7D%5D,%22range%22:%7B%22from%22:%22now-30d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1))

**Description**

Log a warning if engine / builder failed to produce block within cutoff time