### PR TITLE
chore: fix format of printed graffiti from hex to utf-8

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -37,6 +37,7 @@ import {ZERO_HASH, ZERO_HASH_HEX} from "../../constants/index.js";
 import {IEth1ForBlockProduction} from "../../eth1/index.js";
 import {numToQuantity} from "../../eth1/provider/utils.js";
 import {IExecutionBuilder, IExecutionEngine, PayloadAttributes, PayloadId} from "../../execution/index.js";
+import {fromGraffitiBuffer} from "../../util/graffiti.js";
 import type {BeaconChain} from "../chain.js";
 import {CommonBlockBody} from "../interface.js";
 import {validateBlobsAndKzgCommitments} from "./validateBlobsAndKzgCommitments.js";
@@ -154,7 +155,7 @@ export async function produceBlockBody<T extends BlockType>(
   } = blockBody;
 
   Object.assign(logMeta, {
-    graffiti,
+    graffiti: fromGraffitiBuffer(graffiti),
     attestations: attestations.length,
     deposits: deposits.length,
     voluntaryExits: voluntaryExits.length,

--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -12,7 +12,7 @@ export function toGraffitiBuffer(graffiti: string): Buffer {
  * Converts a graffiti from 32 bytes buffer back to a UTF-8 string
  */
 export function fromGraffitiBuffer(graffiti: Uint8Array): string {
-  return Buffer.from(graffiti).toString("utf8");
+  return Buffer.from(graffiti.buffer, graffiti.byteOffset, graffiti.byteLength).toString("utf8");
 }
 
 export function getDefaultGraffiti(

--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -8,6 +8,13 @@ export function toGraffitiBuffer(graffiti: string): Buffer {
   return Buffer.concat([Buffer.from(graffiti, "utf8"), Buffer.alloc(GRAFFITI_SIZE, 0)], GRAFFITI_SIZE);
 }
 
+/**
+ * Converts a graffiti from 32 bytes buffer back to a UTF-8 string
+ */
+export function fromGraffitiBuffer(graffiti: Uint8Array): string {
+  return Buffer.from(graffiti).toString("utf8");
+}
+
 export function getDefaultGraffiti(
   consensusClientVersion: ClientVersion,
   executionClientVersion: ClientVersion | null | undefined,


### PR DESCRIPTION
Follow up to https://github.com/ChainSafe/lodestar/pull/7303, forgot we pass the graffiti around as `Buffer` and the logger formats it to hex internally but we want this to be formatted utf-8 in logs.

Properly tested it this time :)
