### PR TITLE
Fix broken links in documentation

### DIFF
--- a/packages/light-client/README.md
+++ b/packages/light-client/README.md
@@ -32,7 +32,7 @@ You can find more information about the light-client protocol in the [specificat
 ## Getting started
 
 - Follow the [installation guide](https://chainsafe.github.io/lodestar/run/getting-started/installation) to install Lodestar.
-- Quickly try out the whole stack by [starting a local testnet](https://chainsafe.github.io/lodestar/advanced-topics/setting-up-a-testnet).
+- Quickly try out the whole stack by [starting a local testnet](https://chainsafe.github.io/lodestar/contribution/advanced-topics/setting-up-a-testnet).
 
 ## Light-Client CLI Example
 

--- a/packages/prover/README.md
+++ b/packages/prover/README.md
@@ -153,7 +153,7 @@ You will need to go over the [specification](https://github.com/ethereum/beacon-
 ## Getting started
 
 - Follow the [installation guide](https://chainsafe.github.io/lodestar/run/getting-started/installation) to install Lodestar.
-- Quickly try out the whole stack by [starting a local testnet](https://chainsafe.github.io/lodestar/advanced-topics/setting-up-a-testnet).
+- Quickly try out the whole stack by [starting a local testnet](https://chainsafe.github.io/lodestar/contribution/advanced-topics/setting-up-a-testnet).
 
 ## Contributors
 


### PR DESCRIPTION
This pull request fixes a broken link in the documentation:

"https://chainsafe.github.io/lodestar/advanced-topics/setting-up-a-testnet" corrected to "https://chainsafe.github.io/lodestar/contribution/advanced-topics/setting-up-a-testnet"