### PR TITLE
feat: add blob sidecar index check

### DIFF
--- a/packages/beacon-node/src/chain/errors/blobSidecarError.ts
+++ b/packages/beacon-node/src/chain/errors/blobSidecarError.ts
@@ -2,6 +2,7 @@ import {RootHex, Slot, ValidatorIndex} from "@lodestar/types";
 import {GossipActionError} from "./gossipValidation.js";
 
 export enum BlobSidecarErrorCode {
+  INDEX_TOO_LARGE = "BLOB_SIDECAR_ERROR_INDEX_TOO_LARGE",
   INVALID_INDEX = "BLOB_SIDECAR_ERROR_INVALID_INDEX",
   /** !bls.KeyValidate(block.body.blob_kzg_commitments[i]) */
   INVALID_KZG = "BLOB_SIDECAR_ERROR_INVALID_KZG",
@@ -26,6 +27,7 @@ export enum BlobSidecarErrorCode {
 }
 
 export type BlobSidecarErrorType =
+  | {code: BlobSidecarErrorCode.INDEX_TOO_LARGE; blobIdx: number; maxBlobsPerBlock: number}
   | {code: BlobSidecarErrorCode.INVALID_INDEX; blobIdx: number; subnet: number}
   | {code: BlobSidecarErrorCode.INVALID_KZG; blobIdx: number}
   | {code: BlobSidecarErrorCode.INVALID_KZG_TXS}

--- a/packages/beacon-node/src/chain/validation/blobSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -18,6 +18,15 @@ export async function validateGossipBlobSidecar(
 ): Promise<void> {
   const blobSlot = blobSidecar.signedBlockHeader.message.slot;
 
+  // [REJECT] The sidecar's index is consistent with `MAX_BLOBS_PER_BLOCK` -- i.e. `blob_sidecar.index < MAX_BLOBS_PER_BLOCK`.
+  if (blobSidecar.index < chain.config.MAX_BLOBS_PER_BLOCK) {
+    throw new BlobSidecarGossipError(GossipAction.REJECT, {
+      code: BlobSidecarErrorCode.INDEX_TOO_LARGE,
+      blobIdx: blobSidecar.index,
+      maxBlobsPerBlock: chain.config.MAX_BLOBS_PER_BLOCK,
+    });
+  }
+
   // [REJECT] The sidecar is for the correct subnet -- i.e. `compute_subnet_for_blob_sidecar(sidecar.index) == subnet_id`.
   if (computeSubnetForBlobSidecar(blobSidecar.index, chain.config) !== subnet) {
     throw new BlobSidecarGossipError(GossipAction.REJECT, {


### PR DESCRIPTION
Adding a validation rule we've missed when validating blob sidecar:
https://github.com/ethereum/consensus-specs/blob/5567434a77a87b53cb9b2e2c8812220fc5e9ee84/specs/deneb/p2p-interface.md?plain=1#L179

