### PR TITLE
chore: use stable firefox release in browser tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Install Chrome browser
         run: npx @puppeteer/browsers install chromedriver@latest --path /tmp
       - name: Install Firefox browser
-        run: npx @puppeteer/browsers install firefox@latest --path /tmp
+        run: npx @puppeteer/browsers install firefox@stable --path /tmp
       - name: Browser tests
         run: |
           export DISPLAY=':99.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,7 +176,7 @@ jobs:
         with:
           node: ${{ matrix.node }}
       - name: Install Chrome browser
-        run: npx @puppeteer/browsers install chromedriver@latest --path /tmp
+        run: npx @puppeteer/browsers install chromedriver@stable --path /tmp
       - name: Install Firefox browser
         run: npx @puppeteer/browsers install firefox@stable --path /tmp
       - name: Browser tests

--- a/vitest.base.browser.config.ts
+++ b/vitest.base.browser.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
       screenshotFailures: false,
       providerOptions: {
         capabilities: {
-          browserVersion: "latest",
+          browserVersion: "stable",
         },
       },
     },


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/7307

**Description**

Use stable firefox release in browser tests

Their latest tag seems to refer to nightly builds (works on mac as confirmed by @nazarhussain)
```
❯ npx @puppeteer/browsers install firefox@latest --path /tmp
Need to install the following packages:
@puppeteer/browsers@2.6.1
Ok to proceed? (y) y

Downloading firefox nightly_135.0a1 - 148.3 MB [====================] 100% 0.0s
```

but the specific version is missing for Linux which causes the CI to fail