### PR TITLE
Fix/err

### DIFF
--- a/packages/beacon-node/src/chain/archiver/strategies/frequencyStateArchiveStrategy.ts
+++ b/packages/beacon-node/src/chain/archiver/strategies/frequencyStateArchiveStrategy.ts
@@ -39,7 +39,7 @@ export class FrequencyStateArchiveStrategy implements StateArchiveStrategy {
    * - Minimize disk space, storing the least states possible
    * - Minimize the sync progress lost on unexpected crash, storing temp state every few epochs
    *
-   * At epoch `e` there will be states peristed at intervals of `PERSIST_STATE_EVERY_EPOCHS` = 32
+   * At epoch `e` there will be states persisted at intervals of `PERSIST_STATE_EVERY_EPOCHS` = 32
    * and one at `PERSIST_TEMP_STATE_EVERY_EPOCHS` = 1024
    * ```
    *        |                |             |           .

--- a/packages/beacon-node/src/chain/reprocess.ts
+++ b/packages/beacon-node/src/chain/reprocess.ts
@@ -155,7 +155,7 @@ export class ReprocessController {
     }
 
     // in theory there are maybe some awaiting promises waiting for a slot > clockSlot
-    // in reality this never happens so reseting awaitingPromisesCount to 0 to make it simple
+    // in reality this never happens so resetting awaitingPromisesCount to 0 to make it simple
     this.awaitingPromisesCount = 0;
   }
 }


### PR DESCRIPTION
# Fix: Corrected typos in source files

## Changes
1. **Corrected typo in `frequencyStateArchiveStrategy.ts:42`**:
   - "peristed" corrected to "persisted".

2. **Corrected typo in `reprocess.ts:158`**:
   - "reseting" corrected to "resetting".

## Purpose
- Improved code accuracy and professionalism by fixing typos.

