### PR TITLE
chore: remove trailing null bytes from printed graffiti

### DIFF
--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -12,7 +12,7 @@ export function toGraffitiBuffer(graffiti: string): Buffer {
  * Converts a graffiti from 32 bytes buffer back to a UTF-8 string
  */
 export function fromGraffitiBuffer(graffiti: Uint8Array): string {
-  return Buffer.from(graffiti.buffer, graffiti.byteOffset, graffiti.byteLength).toString("utf8");
+  return Buffer.from(graffiti.buffer, graffiti.byteOffset, graffiti.byteLength).toString("utf8").replace(/\0+$/, "");
 }
 
 export function getDefaultGraffiti(

--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -12,7 +12,9 @@ export function toGraffitiBuffer(graffiti: string): Buffer {
  * Converts a graffiti from 32 bytes buffer back to a UTF-8 string
  */
 export function fromGraffitiBuffer(graffiti: Uint8Array): string {
-  return Buffer.from(graffiti.buffer, graffiti.byteOffset, graffiti.byteLength).toString("utf8").replace(/\0+$/, "");
+  return Buffer.from(graffiti.buffer, graffiti.byteOffset, graffiti.byteLength)
+    .toString("utf8")
+    .replaceAll("\u0000", "");
 }
 
 export function getDefaultGraffiti(


### PR DESCRIPTION
Turns out the graffiti is still not printed correctly in some rear cases, eg. in log files trailing null bytes might be displayed

```
Produced beacon block body fork=electra, blockType=Full, slot=70, graffiti=1-besu-lodestar                 
```

Even though this is not disabled in any console, we should probably get rid of the null bytes
