### PR TITLE
chore: unpin nodejs version from 22.4

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.4
+          node-version: 22
           check-latest: true
           cache: yarn
       - name: Node.js version

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install -y build-essential python3
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22.4
+          node: 22
       - run: |
           mkdir -p dist
           yarn global add caxa@3.0.1

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.4
+          node-version: 22
           cache: yarn
       - name: Node.js version
         id: node

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.4
+          node-version: 22
           check-latest: true
           cache: yarn
 

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.4
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
           check-latest: true
           cache: yarn

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22.4
+          node: 22
 
       - name: Generate changelog
         run: node scripts/generate_changelog.mjs ${{ needs.tag.outputs.prev_tag }} ${{ needs.tag.outputs.tag }} CHANGELOG.md

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22.4
+          node: 22
 
       - name: Generate changelog
         run: node scripts/generate_changelog.mjs ${{ needs.tag.outputs.prev_tag }} ${{ needs.tag.outputs.tag }} CHANGELOG.md

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.4
+          node-version: 22
           check-latest: true
           cache: yarn
       - name: Node.js version

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22.4
+          node: 22
 
   sim-test-multifork:
     name: Multifork sim test
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22.4
+          node: 22
       - name: Load env variables
         uses: ./.github/actions/dotenv
       - name: Download required docker images before running tests
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22.4
+          node: 22
       - name: Load env variables
         uses: ./.github/actions/dotenv
       - name: Download required docker images before running tests
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22.4
+          node: 22
       - name: Load env variables
         uses: ./.github/actions/dotenv
       - name: Download required docker images before running tests
@@ -129,7 +129,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22.4
+          node: 22
       - name: Load env variables
         uses: ./.github/actions/dotenv
       - name: Download required docker images before running tests
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
         with:
-          node: 22.4
+          node: 22
       - name: Load env variables
         uses: ./.github/actions/dotenv
       - name: Download required docker images before running tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22.4]
+        node: [22]
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22.4]
+        node: [22]
     steps:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22.4]
+        node: [22]
     steps:
       - uses: actions/checkout@v4
 
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22.4]
+        node: [22]
     steps:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22.4]
+        node: [22]
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
@@ -168,7 +168,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22.4]
+        node: [22]
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
@@ -192,7 +192,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [22.4]
+        node: [22]
     steps:
       - uses: actions/checkout@v4
       - uses: "./.github/actions/setup-and-build"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 
 # --platform=$BUILDPLATFORM is used build javascript source with host arch
 # Otherwise TS builds on emulated archs and can be extremely slow (+1h)
-FROM --platform=${BUILDPLATFORM:-amd64} node:22.4-slim AS build_src
+FROM --platform=${BUILDPLATFORM:-amd64} node:22-slim AS build_src
 ARG COMMIT
 WORKDIR /usr/app
 RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -21,7 +21,7 @@ RUN cd packages/cli && GIT_COMMIT=${COMMIT} yarn write-git-data
 
 # Copy built src + node_modules to build native packages for archs different than host.
 # Note: This step is redundant for the host arch
-FROM node:22.4-slim AS build_deps
+FROM node:22-slim AS build_deps
 WORKDIR /usr/app
 RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -35,7 +35,7 @@ RUN cd node_modules/classic-level && yarn rebuild
 
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)
-FROM node:22.4-slim
+FROM node:22-slim
 WORKDIR /usr/app
 COPY --from=build_deps /usr/app .
 


### PR DESCRIPTION
This reverts commit 99794d3b261bb50f9a6c7d9f6ca19291b3f30911.


unpin nodejs version from 22.4
