### PR TITLE
fix: Simplified level assignment logic in BrowserConsole

### DIFF
--- a/packages/logger/src/browser.ts
+++ b/packages/logger/src/browser.ts
@@ -57,7 +57,7 @@ class BrowserConsole extends Transport {
 
   constructor(opts: winston.transport.TransportStreamOptions | undefined) {
     super(opts);
-    this.level = opts?.level && Object.prototype.hasOwnProperty.call(this.levels, opts.level) ? opts.level : "info";
+    this.level = opts?.level ?? "info";
   }
 
   log(info: WinstonLogInfo, callback: () => void): void {


### PR DESCRIPTION
**Description**

I’ve updated the logic in the `BrowserConsole` function that handles the `level` property. Previously, there was a redundant check for `opts` in the conditional expression. Since we are already checking for the existence of `opts?.level`, it's unnecessary to verify `opts` again. 

I’ve simplified the assignment to use the nullish coalescing operator (`??`), which directly assigns the value of `opts.level` if it exists, or defaults to `"info"` if it doesn't ;)
