### PR TITLE
fix: typos in documentation files

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -343,7 +343,7 @@ export async function importBlock(
     // consumers should not mutate or get the transfered cache
     this.emitter.emit(ChainEvent.checkpoint, cp, checkpointState.clone(true));
 
-    // Note: in-lined code from previos handler of ChainEvent.checkpoint
+    // Note: in-lined code from previous handler of ChainEvent.checkpoint
     this.logger.verbose("Checkpoint processed", toCheckpointHex(cp));
 
     const activeValidatorsCount = checkpointState.epochCtx.currentShuffling.activeIndices.length;

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -47,7 +47,7 @@ export async function verifyBlocksDataAvailability(
     if (signal.aborted) {
       throw new ErrorAborted("verifyBlocksDataAvailability");
     }
-    // Validate status of only not yet finalized blocks, we don't need yet to propogate the status
+    // Validate status of only not yet finalized blocks, we don't need yet to propagate the status
     // as it is not used upstream anywhere
     const {dataAvailabilityStatus, availableBlockInput} = await maybeValidateBlobs(chain, blockInput, signal, opts);
     dataAvailabilityStatuses.push(dataAvailabilityStatus);

--- a/packages/light-client/README.md
+++ b/packages/light-client/README.md
@@ -1,6 +1,6 @@
 # Lodestar Light Client
 
-Ethereum light clients provide a pathway for users to interact with the Ethereum blockchain in a trust-minimized manner, comparable to the level of trust required when engaging with a third-party provider like Infura or EtherScan. Not that those platforms are bad, but trust in any centralized provider goes against the ethos of blockchain. Light clients are a way that low-power devices, like cell phones, can do self validation of transactions and dApp state.
+Ethereum light clients provide a pathway for users to interact with the Ethereum blockchain in a trust-minimized manner, comparable to the level of trust required when engaging with a third-party provider like Infura or EtherScan. Note that those platforms are bad, but trust in any centralized provider goes against the ethos of blockchain. Light clients are a way that low-power devices, like cell phones, can do self validation of transactions and dApp state.
 
 Unlike full nodes, light clients do not download and store the entire blockchain. Instead, they download only the headers of each block and employ Merkle proofs to verify transactions. This enables a quick synchronization with the network and access the latest information without using significant system resources​. This streamlined approach to accessing Ethereum is crucial, especially in scenarios where full-scale network participation is infeasible or undesired.
 

--- a/packages/spec-test-util/README.md
+++ b/packages/spec-test-util/README.md
@@ -4,7 +4,7 @@
 
 Vitest utility for interacting with eth2.0 spec tests.
 
-For usage see [spec tests]("https://github.com/ChainSafe/lodestar/tree/unstable/packages/beacon-node/test/spec")
+For usage see [spec tests](https://github.com/ChainSafe/lodestar/tree/unstable/packages/beacon-node/test/spec)
 
 ## License
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `previos` to `previous`
Corrected `propogate` to `propagate`
Corrected `Not` to `Note` and also correct link

Please review the changes and let me know if any additional changes are needed.

