### PR TITLE
feat: check gas limit in header received from builder

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1517,7 +1517,7 @@ export function getValidatorApi(
         );
       });
 
-      await chain.executionBuilder.registerValidator(filteredRegistrations);
+      await chain.executionBuilder.registerValidator(currentEpoch, filteredRegistrations);
 
       logger.debug("Forwarded validator registrations to connected builder", {
         epoch: currentEpoch,

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -252,10 +252,12 @@ export async function produceBlockBody<T extends BlockType>(
         }
 
         if (headerGasLimit !== expectedGasLimit) {
-          this.logger.warn("Header gas limit does not match the expected value", {
+          this.logger.warn("Header gas limit does not match expected value", {
             slot: blockSlot,
             headerGasLimit,
             expectedGasLimit,
+            parentGasLimit,
+            targetGasLimit,
           });
         }
       }

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -32,11 +32,17 @@ import {
   ssz,
   sszTypesFor,
 } from "@lodestar/types";
-import {Logger, sleep, toHex, toRootHex} from "@lodestar/utils";
+import {Logger, sleep, toHex, toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {ZERO_HASH, ZERO_HASH_HEX} from "../../constants/index.js";
 import {IEth1ForBlockProduction} from "../../eth1/index.js";
 import {numToQuantity} from "../../eth1/provider/utils.js";
-import {IExecutionBuilder, IExecutionEngine, PayloadAttributes, PayloadId} from "../../execution/index.js";
+import {
+  IExecutionBuilder,
+  IExecutionEngine,
+  PayloadAttributes,
+  PayloadId,
+  getExpectedGasLimit,
+} from "../../execution/index.js";
 import {fromGraffitiBuffer} from "../../util/graffiti.js";
 import type {BeaconChain} from "../chain.js";
 import {CommonBlockBody} from "../interface.js";
@@ -222,6 +228,23 @@ export async function produceBlockBody<T extends BlockType>(
         prepType,
         fetchedTime,
       });
+
+      const targetGasLimit = this.executionBuilder.getValidatorRegistration(proposerPubKey)?.gasLimit;
+      if (!targetGasLimit) {
+        // This should only happen if cache was cleared due to restart of beacon node
+        this.logger.warn("Failed to get validator registration, could not check header gas limit", {
+          slot: blockSlot,
+          proposerIndex,
+          proposerPubKey: toPubkeyHex(proposerPubKey),
+        });
+      } else {
+        const parentGasLimit = (currentState as CachedBeaconStateBellatrix).latestExecutionPayloadHeader.gasLimit;
+        const expectedGasLimit = getExpectedGasLimit(parentGasLimit, targetGasLimit);
+
+        if (builderRes.header.gasLimit !== expectedGasLimit) {
+          throw Error(`Incorrect header gas limit ${builderRes.header.gasLimit} != ${expectedGasLimit}`);
+        }
+      }
 
       if (ForkSeq[fork] >= ForkSeq.deneb) {
         const {blobKzgCommitments} = builderRes;

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -238,11 +238,25 @@ export async function produceBlockBody<T extends BlockType>(
           proposerPubKey: toPubkeyHex(proposerPubKey),
         });
       } else {
+        const headerGasLimit = builderRes.header.gasLimit;
         const parentGasLimit = (currentState as CachedBeaconStateBellatrix).latestExecutionPayloadHeader.gasLimit;
         const expectedGasLimit = getExpectedGasLimit(parentGasLimit, targetGasLimit);
 
-        if (builderRes.header.gasLimit !== expectedGasLimit) {
-          throw Error(`Incorrect header gas limit ${builderRes.header.gasLimit} != ${expectedGasLimit}`);
+        const lowerBound = Math.min(parentGasLimit, expectedGasLimit);
+        const upperBound = Math.max(parentGasLimit, expectedGasLimit);
+
+        if (headerGasLimit < lowerBound || headerGasLimit > upperBound) {
+          throw Error(
+            `Header gas limit ${headerGasLimit} is outside of acceptable range [${lowerBound}, ${upperBound}]`
+          );
+        }
+
+        if (headerGasLimit !== expectedGasLimit) {
+          this.logger.warn("Header gas limit does not match the expected value", {
+            slot: blockSlot,
+            headerGasLimit,
+            expectedGasLimit,
+          });
         }
       }
 

--- a/packages/beacon-node/src/execution/builder/cache.ts
+++ b/packages/beacon-node/src/execution/builder/cache.ts
@@ -1,0 +1,34 @@
+import {BLSPubkey, Epoch, bellatrix} from "@lodestar/types";
+import {toPubkeyHex} from "@lodestar/utils";
+
+const REGISTRATION_PRESERVE_EPOCHS = 2;
+
+export type ValidatorRegistration = {
+  epoch: Epoch;
+  /** Preferred gas limit of validator */
+  gasLimit: number;
+};
+
+export class ValidatorRegistrationCache {
+  private readonly registrationByValidatorPubkey: Map<string, ValidatorRegistration>;
+  constructor() {
+    this.registrationByValidatorPubkey = new Map();
+  }
+
+  add(epoch: Epoch, {pubkey, gasLimit}: bellatrix.ValidatorRegistrationV1): void {
+    this.registrationByValidatorPubkey.set(toPubkeyHex(pubkey), {epoch, gasLimit});
+  }
+
+  prune(epoch: Epoch): void {
+    for (const [pubkeyHex, registration] of this.registrationByValidatorPubkey.entries()) {
+      // We only retain an registrations for REGISTRATION_PRESERVE_EPOCHS epochs
+      if (registration.epoch + REGISTRATION_PRESERVE_EPOCHS < epoch) {
+        this.registrationByValidatorPubkey.delete(pubkeyHex);
+      }
+    }
+  }
+
+  get(pubkey: BLSPubkey): ValidatorRegistration | undefined {
+    return this.registrationByValidatorPubkey.get(toPubkeyHex(pubkey));
+  }
+}

--- a/packages/beacon-node/src/execution/builder/cache.ts
+++ b/packages/beacon-node/src/execution/builder/cache.ts
@@ -10,6 +10,11 @@ export type ValidatorRegistration = {
 };
 
 export class ValidatorRegistrationCache {
+  /**
+   * Map to track registrations by validator pubkey which is used here instead of
+   * validator index as `bellatrix.ValidatorRegistrationV1` does not contain the index
+   * and builder flow in general prefers to use pubkey over index.
+   */
   private readonly registrationByValidatorPubkey: Map<string, ValidatorRegistration>;
   constructor() {
     this.registrationByValidatorPubkey = new Map();

--- a/packages/beacon-node/src/execution/builder/index.ts
+++ b/packages/beacon-node/src/execution/builder/index.ts
@@ -2,6 +2,7 @@ import {ChainForkConfig} from "@lodestar/config";
 import {Logger} from "@lodestar/logger";
 import {Metrics} from "../../metrics/metrics.js";
 import {IExecutionBuilder} from "./interface.js";
+export {getExpectedGasLimit} from "./utils.js";
 
 import {ExecutionBuilderHttp, ExecutionBuilderHttpOpts, defaultExecutionBuilderHttpOpts} from "./http.js";
 

--- a/packages/beacon-node/src/execution/builder/interface.ts
+++ b/packages/beacon-node/src/execution/builder/interface.ts
@@ -1,6 +1,7 @@
 import {ForkExecution} from "@lodestar/params";
 import {
   BLSPubkey,
+  Epoch,
   ExecutionPayloadHeader,
   Root,
   SignedBeaconBlockOrContents,
@@ -12,6 +13,7 @@ import {
   deneb,
   electra,
 } from "@lodestar/types";
+import {ValidatorRegistration} from "./cache.js";
 
 export interface IExecutionBuilder {
   /**
@@ -28,7 +30,8 @@ export interface IExecutionBuilder {
 
   updateStatus(shouldEnable: boolean): void;
   checkStatus(): Promise<void>;
-  registerValidator(registrations: bellatrix.SignedValidatorRegistrationV1[]): Promise<void>;
+  registerValidator(epoch: Epoch, registrations: bellatrix.SignedValidatorRegistrationV1[]): Promise<void>;
+  getValidatorRegistration(pubkey: BLSPubkey): ValidatorRegistration | undefined;
   getHeader(
     fork: ForkExecution,
     slot: Slot,

--- a/packages/beacon-node/src/execution/builder/utils.ts
+++ b/packages/beacon-node/src/execution/builder/utils.ts
@@ -1,8 +1,13 @@
 /**
+ * From https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md
+ */
+const gasLimitAdjustmentFactor = 1024;
+
+/**
  * Calculates expected gas limit based on parent gas limit and target gas limit
  */
 export function getExpectedGasLimit(parentGasLimit: number, targetGasLimit: number): number {
-  const maxGasLimitDifference = Math.max(Math.floor(parentGasLimit / 1024) - 1, 0);
+  const maxGasLimitDifference = Math.max(Math.floor(parentGasLimit / gasLimitAdjustmentFactor) - 1, 0);
 
   if (targetGasLimit > parentGasLimit) {
     const gasDiff = targetGasLimit - parentGasLimit;

--- a/packages/beacon-node/src/execution/builder/utils.ts
+++ b/packages/beacon-node/src/execution/builder/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Calculates expected gas limit based on parent gas limit and target gas limit
+ */
+export function getExpectedGasLimit(parentGasLimit: number, targetGasLimit: number): number {
+  const maxGasLimitDifference = Math.max(Math.floor(parentGasLimit / 1024) - 1, 0);
+
+  if (targetGasLimit > parentGasLimit) {
+    const gasDiff = targetGasLimit - parentGasLimit;
+    return parentGasLimit + Math.min(gasDiff, maxGasLimitDifference);
+  }
+
+  const gasDiff = parentGasLimit - targetGasLimit;
+  return parentGasLimit - Math.min(gasDiff, maxGasLimitDifference);
+}

--- a/packages/beacon-node/test/unit/execution/builder/cache.test.ts
+++ b/packages/beacon-node/test/unit/execution/builder/cache.test.ts
@@ -1,0 +1,58 @@
+import {ssz} from "@lodestar/types";
+import {beforeEach, describe, expect, it} from "vitest";
+import {ValidatorRegistrationCache} from "../../../../src/execution/builder/cache.js";
+
+describe("ValidatorRegistrationCache", () => {
+  const gasLimit1 = 30000000;
+  const gasLimit2 = 36000000;
+
+  const validatorPubkey1 = new Uint8Array(48).fill(1);
+  const validatorPubkey2 = new Uint8Array(48).fill(2);
+
+  const validatorRegistration1 = ssz.bellatrix.ValidatorRegistrationV1.defaultValue();
+  validatorRegistration1.pubkey = validatorPubkey1;
+  validatorRegistration1.gasLimit = gasLimit1;
+
+  const validatorRegistration2 = ssz.bellatrix.ValidatorRegistrationV1.defaultValue();
+  validatorRegistration2.pubkey = validatorPubkey2;
+  validatorRegistration2.gasLimit = gasLimit2;
+
+  let cache: ValidatorRegistrationCache;
+
+  beforeEach(() => {
+    // max 2 items
+    cache = new ValidatorRegistrationCache();
+    cache.add(1, validatorRegistration1);
+    cache.add(3, validatorRegistration2);
+  });
+
+  it("get for registered validator", () => {
+    expect(cache.get(validatorPubkey1)?.gasLimit).toBe(gasLimit1);
+  });
+
+  it("get for unknown validator", () => {
+    const unknownValidatorPubkey = new Uint8Array(48).fill(3);
+    expect(cache.get(unknownValidatorPubkey)).toBe(undefined);
+  });
+
+  it("override and get latest", () => {
+    const newGasLimit = 60000000;
+    const registration = ssz.bellatrix.ValidatorRegistrationV1.defaultValue();
+    registration.pubkey = validatorPubkey1;
+    registration.gasLimit = newGasLimit;
+
+    cache.add(5, registration);
+
+    expect(cache.get(validatorPubkey1)?.gasLimit).toBe(newGasLimit);
+  });
+
+  it("prune", () => {
+    cache.prune(4);
+
+    // No registration as it has been pruned
+    expect(cache.get(validatorPubkey1)).toBe(undefined);
+
+    // Registration hasn't been pruned
+    expect(cache.get(validatorPubkey2)?.gasLimit).toBe(gasLimit2);
+  });
+});

--- a/packages/beacon-node/test/unit/execution/builder/utils.test.ts
+++ b/packages/beacon-node/test/unit/execution/builder/utils.test.ts
@@ -1,0 +1,66 @@
+import {describe, expect, it} from "vitest";
+import {getExpectedGasLimit} from "../../../../src/execution/builder/utils.js";
+
+describe("execution / builder / utils", () => {
+  describe("getExpectedGasLimit", () => {
+    const testCases: {
+      name: string;
+      parentGasLimit: number;
+      targetGasLimit: number;
+      expected: number;
+    }[] = [
+      {
+        name: "Increase within limit",
+        parentGasLimit: 30000000,
+        targetGasLimit: 30000100,
+        expected: 30000100,
+      },
+      {
+        name: "Increase exceeding limit",
+        parentGasLimit: 30000000,
+        targetGasLimit: 36000000,
+        expected: 30029295, // maxGasLimitDifference = (30000000 / 1024) - 1 = 29295
+      },
+      {
+        name: "Decrease within limit",
+        parentGasLimit: 30000000,
+        targetGasLimit: 29999990,
+        expected: 29999990,
+      },
+      {
+        name: "Decrease exceeding limit",
+        parentGasLimit: 36000000,
+        targetGasLimit: 30000000,
+        expected: 35964845, // maxGasLimitDifference = (36000000 / 1024) - 1 = 35155
+      },
+      {
+        name: "Target equals parent",
+        parentGasLimit: 30000000,
+        targetGasLimit: 30000000,
+        expected: 30000000, // No change
+      },
+      {
+        name: "Very small parent gas limit",
+        parentGasLimit: 1025,
+        targetGasLimit: 2000,
+        expected: 1025,
+      },
+      {
+        name: "Target far below parent but limited",
+        parentGasLimit: 30000000,
+        targetGasLimit: 10000000,
+        expected: 29970705, // maxGasLimitDifference = (30000000 / 1024) - 1 = 29295
+      },
+      {
+        name: "Parent gas limit underflows",
+        parentGasLimit: 1023,
+        targetGasLimit: 30000000,
+        expected: 1023,
+      },
+    ];
+
+    it.each(testCases)("$name", ({parentGasLimit, targetGasLimit, expected}) => {
+      expect(getExpectedGasLimit(parentGasLimit, targetGasLimit)).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
**Motivation**

As per spec the builder must adhere to the preferred gas limit of the validator
>  The builder MUST build an execution payload whose gas_limit is equal to the gas_limit of the latest registration for pubkey, or as close as is possible under the consensus rules.

but currently we are not validating this anywhere and rely on honest builder behavior which is not great considering there are only two builder that produce most of the blocks.

**Description**

This PR adds a check the to builder flow that compares the expected gas limit against the target gas limit (ie. preferred gas limit of validator) and rejects the builder block in case there is a mismatch which will trigger the fallback to local block.

The expected gas limit is calculated based on this spec
```python
def expected_gas_limit(parent_gas_limit, target_gas_limit):
  max_gas_limit_difference = (parent_gas_limit // 1024) - 1
  if target_gas_limit > parent_gas_limit:
    gas_diff = target_gas_limit - parent_gas_limit
    return parent_gas_limit + min(gas_diff, max_gas_limit_difference)
  else:
    gas_diff = parent_gas_limit - target_gas_limit
    return parent_gas_limit - min(gas_diff, max_gas_limit_difference)
```

I haven't found where this is defined but it's based on what other clients implement (eg. https://github.com/prysmaticlabs/prysm/pull/14707 and https://github.com/Consensys/teku/pull/8909) and makes sense considering gas limit checks in [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md).

![image](https://github.com/user-attachments/assets/f5ef987d-03bb-46bb-9fb6-f2dae218eab9)


