### PR TITLE
fix: typo fix Update assert_exports.mjs

### DIFF
--- a/scripts/assert_exports.mjs
+++ b/scripts/assert_exports.mjs
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 // ESM modules now reference build files on (package.json).exports
-// This script ensure that the referenced files exist
+// This script ensures that the referenced files exist
 
 const pkgsDirpath = path.resolve("./packages");
 


### PR DESCRIPTION
**Description**

The verb "ensure" should be in the third-person singular form, "ensures", to agree with the subject "script."

Corrected.