### PR TITLE
chore: skip fulu fork spec tests

### DIFF
--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -58,7 +58,7 @@ const coveredTestRunners = [
 // ],
 // ```
 export const defaultSkipOpts: SkipOpts = {
-  skippedForks: ["eip7594"],
+  skippedForks: ["eip7594", "fulu"],
   // TODO: capella
   // BeaconBlockBody proof in lightclient is the new addition in v1.3.0-rc.2-hotfix
   // Skip them for now to enable subsequently


### PR DESCRIPTION
We need to skip `fulu` fork in our spec tests for now as it otherwise will fail our ssz static tests on `devnet-5` branch
```
Error: TypeError: Cannot read properties of undefined (reading 'AggregateAndProof')
 ❯ Object.fn test/spec/presets/ssz_static.test.ts:47:24
 ❯ test/spec/utils/specTestIterator.ts:152:28
```
