### PR TITLE
fix: use Bigint for deposit index to pass spec tests

### DIFF
--- a/packages/types/src/primitive/sszTypes.ts
+++ b/packages/types/src/primitive/sszTypes.ts
@@ -51,7 +51,7 @@ export const SubcommitteeIndex = UintNum64;
  */
 export const ValidatorIndex = UintNum64;
 export const WithdrawalIndex = UintNum64;
-export const DepositIndex = UintNum64;
+export const DepositIndex = UintBn64;
 export const Gwei = UintBn64;
 export const Wei = UintBn256;
 export const Root = new ByteVectorType(32);


### PR DESCRIPTION
This was found by @ensi321 a while ago, deposit index used in spec test is over `uintNum64`

```
deposits: [
    {
      pubkey: <Buffer 97 f1 d3 a7 31 97 d7 94 26 95 63 8c 4f a9 ac 0f c3 68 8c 4f 97 74 b9 05 a1 4e 3a 3f 17 1b ac 58 6c 55 e8 3f f9 7a 1a ef fb 3a f0 0a db 22 c6 bb>,
      withdrawalCredentials: <Buffer 00 cf 47 8a 43 18 37 72 8d ce c3 46 1f 4f 53 b8 74 9c dc 4e 03 49 6d ca ed 45 9d ea 82 b8 2e b8>,
      amount: 1637494791037,
      signature: <Buffer b9 75 d0 0d 57 6b e4 a4 4e 89 1f c2 e0 22 1e 87 0d 90 b7 a7 8c 04 eb d9 41 c9 b0 4a 10 b4 50 8b d9 4a c2 28 c5 01 1f 5f fc c4 a6 73 9e 47 8c 46 03 8a ... 46 more bytes>,
      index: 2280974077699116722n
    }
  ],
```

this causes spec tests to fail on `devnet-5` branch
```
⎯⎯⎯⎯⎯⎯ Failed Tests 15 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_0
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_1
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_10
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_11
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_12
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_13
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_14
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_15
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_2
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_3
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_4
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_6
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_7
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_8
 FAIL  test/spec/presets/sanity.test.ts > electra/random/random/pyspec_tests > electra/random/random/pyspec_tests/randomized_9
Error: Invalid block signature
 ❯ Module.stateTransition ../state-transition/src/stateTransition.ts:96:13
 ❯ testFunction test/spec/presets/sanity.test.ts:67:24
```

I don't think there is a good workaround / patch for this during running tests (similar like [`replaceUintTypeWithUintBigintType`](https://github.com/ChainSafe/lodestar/blob/18a0d681dbcc51fb2ac9456f31e91f4e31a18300/packages/beacon-node/test/spec/presets/ssz_static.test.ts#L64)), but maybe someone has another idea