### PR TITLE
chore: reuse setup and build action in sim merge tests

### DIFF
--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -26,31 +26,10 @@ jobs:
     name: Sim merge tests
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: "./.github/actions/setup-and-build"
         with:
-          node-version: 22
-          check-latest: true
-          cache: yarn
-      - name: Node.js version
-        id: node
-        run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
-      - name: Restore dependencies
-        uses: actions/cache@master
-        id: cache-deps
-        with:
-          path: |
-            node_modules
-            packages/*/node_modules
-          key: ${{ runner.os }}-${{ steps.node.outputs.v8CppApiVersion }}-${{ hashFiles('**/yarn.lock', '**/package.json') }}
-      - name: Install & build
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile && yarn build
-      - name: Build
-        run: yarn build
-        if: steps.cache-deps.outputs.cache-hit == 'true'
-      # </common-build>
+          node: 22
 
       - name: Pull Geth
         run: docker pull $GETH_IMAGE


### PR DESCRIPTION
**Motivation**

Sim merge tests are broken https://github.com/ChainSafe/lodestar/actions/runs/12677099857/job/35331680453#step:11:230
```
 × test/sim/mergemock.test.ts > executionEngine / ExecutionEngineHttp > Test builder with useProduceBlockV3=true 9710ms
   → /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /home/runner/actions-runner/_work/lodestar/lodestar/node_modules/c-kzg/build/Release/kzg.node)
```

**Description**

This reuses the setup and build action in sim merge tests, I am actually not sure why this fixes the issue somehow related to how we restore dependencies or that's my assumption at least.

The root cause of this is that ubuntu 22 might not have `GLIBCXX_3.4.32` which I also encountered on my local system but only when running the binary, seems related to the node version, likely due to openssl bump on nodejs side

other fix would be to update system dependencies manually
```sh
sudo add-apt-repository ppa:ubuntu-toolchain-r/test
sudo apt-get update
sudo apt-get install --only-upgrade libstdc++6
```
as suggested [here](https://stackoverflow.com/questions/76974555/glibcxx-3-4-32-not-found-error-at-runtime-gcc-13-2-0)