### PR TITLE
fix: revert BlobSidecarsByRoot/Range version bump

### DIFF
--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -504,12 +504,7 @@ export class Network implements INetwork {
   ): Promise<deneb.BlobSidecar[]> {
     const fork = this.config.getForkName(request.startSlot);
     return collectMaxResponseTyped(
-      this.sendReqRespRequest(
-        peerId,
-        ReqRespMethod.BlobSidecarsByRange,
-        [isForkPostElectra(fork) ? Version.V2 : Version.V1],
-        request
-      ),
+      this.sendReqRespRequest(peerId, ReqRespMethod.BlobSidecarsByRange, [Version.V1], request),
       // request's count represent the slots, so the actual max count received could be slots * blobs per slot
       request.count * this.config.getMaxBlobsPerBlock(fork),
       responseSszTypeByMethod[ReqRespMethod.BlobSidecarsByRange]
@@ -517,14 +512,8 @@ export class Network implements INetwork {
   }
 
   async sendBlobSidecarsByRoot(peerId: PeerIdStr, request: BlobSidecarsByRootRequest): Promise<deneb.BlobSidecar[]> {
-    const fork = this.config.getForkName(this.clock.currentSlot);
     return collectMaxResponseTyped(
-      this.sendReqRespRequest(
-        peerId,
-        ReqRespMethod.BlobSidecarsByRoot,
-        [isForkPostElectra(fork) ? Version.V2 : Version.V1],
-        request
-      ),
+      this.sendReqRespRequest(peerId, ReqRespMethod.BlobSidecarsByRoot, [Version.V1], request),
       request.length,
       responseSszTypeByMethod[ReqRespMethod.BlobSidecarsByRoot]
     );

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -4,7 +4,7 @@ import {PeerId} from "@libp2p/interface";
 import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
 import {LoggerNode} from "@lodestar/logger/node";
-import {ForkSeq, isForkPostElectra} from "@lodestar/params";
+import {ForkSeq} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {computeStartSlotAtEpoch, computeTimeAtSlot} from "@lodestar/state-transition";
 import {

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -252,17 +252,9 @@ export class ReqRespBeaconNode extends ReqResp {
     }
 
     if (ForkSeq[fork] >= ForkSeq.deneb) {
-      // TODO Electra: Consider deprecating BlobSidecarsByRootV1 and BlobSidecarsByRangeV1 at fork boundary or after Electra is stable
       protocolsAtFork.push(
         [protocols.BlobSidecarsByRoot(this.config), this.getHandler(ReqRespMethod.BlobSidecarsByRoot)],
         [protocols.BlobSidecarsByRange(this.config), this.getHandler(ReqRespMethod.BlobSidecarsByRange)]
-      );
-    }
-
-    if (ForkSeq[fork] >= ForkSeq.electra) {
-      protocolsAtFork.push(
-        [protocols.BlobSidecarsByRootV2(this.config), this.getHandler(ReqRespMethod.BlobSidecarsByRoot)],
-        [protocols.BlobSidecarsByRangeV2(this.config), this.getHandler(ReqRespMethod.BlobSidecarsByRange)]
       );
     }
 

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -39,7 +39,7 @@ export function getReqRespHandlers({db, chain}: {db: IBeaconDb; chain: IBeaconCh
       return onBeaconBlocksByRoot(body, chain, db);
     },
     [ReqRespMethod.BlobSidecarsByRoot]: (req) => {
-      const fork = req.version === Version.V2 ? ForkName.electra : ForkName.deneb;
+      const fork = chain.config.getForkName(chain.clock.currentSlot);
       const body = BlobSidecarsByRootRequestType(fork, chain.config).deserialize(req.data);
       return onBlobSidecarsByRoot(body, chain, db);
     },

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -1,10 +1,9 @@
-import {ForkName} from "@lodestar/params";
 import {ProtocolHandler} from "@lodestar/reqresp";
 import {ssz} from "@lodestar/types";
 import {IBeaconChain} from "../../../chain/index.js";
 import {IBeaconDb} from "../../../db/index.js";
 import {BlobSidecarsByRootRequestType} from "../../../util/types.js";
-import {GetReqRespHandlerFn, ReqRespMethod, Version} from "../types.js";
+import {GetReqRespHandlerFn, ReqRespMethod} from "../types.js";
 import {onBeaconBlocksByRange} from "./beaconBlocksByRange.js";
 import {onBeaconBlocksByRoot} from "./beaconBlocksByRoot.js";
 import {onBlobSidecarsByRange} from "./blobSidecarsByRange.js";

--- a/packages/beacon-node/src/network/reqresp/protocols.ts
+++ b/packages/beacon-node/src/network/reqresp/protocols.ts
@@ -63,21 +63,9 @@ export const BlobSidecarsByRange = toProtocol({
   contextBytesType: ContextBytesType.ForkDigest,
 });
 
-export const BlobSidecarsByRangeV2 = toProtocol({
-  method: ReqRespMethod.BlobSidecarsByRange,
-  version: Version.V2,
-  contextBytesType: ContextBytesType.ForkDigest,
-});
-
 export const BlobSidecarsByRoot = toProtocol({
   method: ReqRespMethod.BlobSidecarsByRoot,
   version: Version.V1,
-  contextBytesType: ContextBytesType.ForkDigest,
-});
-
-export const BlobSidecarsByRootV2 = toProtocol({
-  method: ReqRespMethod.BlobSidecarsByRoot,
-  version: Version.V2,
   contextBytesType: ContextBytesType.ForkDigest,
 });
 


### PR DESCRIPTION
There is no need to bump the version to v2 (https://github.com/ethereum/consensus-specs/pull/4077)
