### PR TITLE
chore: skip light client data_collection spec tests

### DIFF
--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -66,6 +66,7 @@ export const defaultSkipOpts: SkipOpts = {
     /^capella\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^deneb\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^electra\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
+    /^.+\/light_client\/data_collection\/.*/,
   ],
   skippedTests: [],
   skippedRunners: ["merkle_proof", "networking"],


### PR DESCRIPTION
Need to disable those for now to pass spec tests until https://github.com/ChainSafe/lodestar/issues/7348 is implemented. This is not a electra / devnet-5 specific change but was included [v1.5.0-beta.0](https://github.com/ethereum/consensus-specs/releases/tag/v1.5.0-beta.0) spec release.