### PR TITLE
**Changelog for Documentation Updates**

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - :writing_hand: If you have questions [submit an issue](https://github.com/ChainSafe/lodestar/issues/new/choose) or join us on [Discord](https://discord.gg/yjyvFRP)!
   [![Discord](https://img.shields.io/discord/593655374469660673.svg?label=Discord&logo=discord)](https://discord.gg/aMxzVcr)
 - :rotating_light: Please note our [security policy](./SECURITY.md).
-- :bird: Follow Lodestar on [Twitter](https://twitter.com/lodestar_eth) for announcements and updates! [![Twitter Follow](https://img.shields.io/twitter/follow/lodestar_eth)](https://twitter.com/lodestar_eth)
+- :bird: Follow Lodestar on [Twitter](https://x.com/lodestar_eth) for announcements and updates! [![Twitter Follow](https://img.shields.io/twitter/follow/lodestar_eth)](https://x.com/lodestar_eth)
 
 ## Prerequisites
 

--- a/docs/pages/contribution/advanced-topics/setting-up-a-testnet.md
+++ b/docs/pages/contribution/advanced-topics/setting-up-a-testnet.md
@@ -97,7 +97,7 @@ will give a result similar to the following:
 
 ## Post-Merge local testnet
 
-To set up a local testnet with a Post-Merge configuration, you may need to add the following parameters (in addition to the parameters described above) to your [`lodestar dev`](../dev-cli.md#dev-options) command:
+To setup a local testnet with a Post-Merge configuration, you may need to add the following parameters (in addition to the parameters described above) to your [`lodestar dev`](../dev-cli.md#dev-options) command:
 
 - `--params.ALTAIR_FORK_EPOCH 0`
 - `--params.BELLATRIX_FORK_EPOCH 0`

--- a/docs/pages/contribution/testing/index.md
+++ b/docs/pages/contribution/testing/index.md
@@ -2,7 +2,7 @@
 
 Testing is critical to the Lodestar project and there are many types of tests that are run to build a product that is both effective AND efficient. This page will help to break down the different types of tests you will find in the Lodestar repo.
 
-There are a few flags you can set through env variables to override behavior of testing and its output.
+There are a few flags you can set through env variables to override behavior of testing atheir output.
 
 | ENV variable        | Effect | Impact                                                                                                                    |
 | ------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/pages/contribution/testing/simulation-tests.md
+++ b/docs/pages/contribution/testing/simulation-tests.md
@@ -2,9 +2,9 @@
 
 "Sim" testing for Lodestar is the most comprehensive, and complex, testing that is run. The goal is to fully simulate a testnet and to actuate the code in a way that closely mimics what will happen when turning on Lodestar in the wild. This is a very complex task and requires a lot of moving parts to work together. The following sections will describe the various components and how they work together.
 
-At a very high level, simulation testing will setup a testnet from genesis and let proceed through "normal" execution exactly as the nodes would under production circumstances. To get feedback there are regular checks along the way to asses how the testnet nodes are working. These "assertions" can be added and removed at will to allow developers to check for specific conditions in a tightly controlled, reproducible, environment to get high quality and actionable feedback on how Lodestar performs. The end goal of these tests is to to run a full Lodestar client in an environment that is as close to what an end user would experience.
+At a very high level, simulation testing will set up a testnet from genesis and let proceed through "normal" execution exactly as the nodes would under production circumstances. To get feedback there are regular checks along the way to assess how the testnet nodes are working. These "assertions" can be added and removed at will to allow developers to check for specific conditions in a tightly controlled, reproducible, environment to get high quality and actionable feedback on how Lodestar performs. The end goal of these tests is to to run a full Lodestar client in an environment that is as close to what an end user would experience.
 
-These tests usually setup full testnets with multiple consensus clients and their paired execution node. In many instance we are looking to just exercise the Lodestar code but there are some places where there is also testing to see how Lodestar works in relation to the other consensus clients, like Lighthouse. As you can imagine, there is quite a bit of machinery that is responsible for setting up and managing the simulations and assertions. This section will help to go over those bits and pieces. Many, but not all, of these classes can be found in `packages/cli/test/utils/simulation`.
+These tests usually set up full testnets with multiple consensus clients and their paired execution node. In many instance we are looking to just exercise the Lodestar code but there are some places where there is also testing to see how Lodestar works in relation to the other consensus clients, like Lighthouse. As you can imagine, there is quite a bit of machinery that is responsible for setting up and managing the simulations and assertions. This section will help to go over those bits and pieces. Many, but not all, of these classes can be found in `packages/cli/test/utils/simulation`.
 
 ## Running Sim Tests
 
@@ -38,7 +38,7 @@ yarn workspace @chainsafe/lodestar test:sim:endpoints
 
 This test is still included in our CI but is no longer as important as it once was. Lodestar is often the first client to implement new features and this test was created before geth was upgraded with the features required to support the Deneb fork. To test that Lodestar was ready this test uses mocked geth instances. It is left as a placeholder for when the next fork comes along that requires a similar approach.
 
-### `test:sim:mixedcleint`
+### `test:sim:mixedclient`
 
 Checks that Lodestar is compatible with other consensus validators and vice-versa. All tests use Geth as the EL.
 
@@ -48,7 +48,7 @@ yarn workspace @chainsafe/lodestar test:sim:mixedclient
 
 ## Sim Test Infrastructure
 
-When setting up and running the simulations, interactions with the nodes is through the published node API's. All functionality is actuated via http request and by "plugging in" this way it is possible to run the nodes in a stand-alone fashion, as they would be run in production, but to still achieve a tightly monitored and controlled environment. If code needs to be executed on a "class by class" basis or with mocking involved then the test is not a simulation test and would fall into one of the other testing categories. See the [Testing Overview](./index.md) page for more information on the other types of tests available for Lodestar.
+When setting up and running the simulations, interactions with the nodes is through the published node API's. All functionality is activated via http request and by "plugging in" this way it is possible to run the nodes in a stand-alone fashion, as they would be run in production, but to still achieve a tightly monitored and controlled environment. If code needs to be executed on a "class by class" basis or with mocking involved then the test is not a simulation test and would fall into one of the other testing categories. See the [Testing Overview](./index.md) page for more information on the other types of tests available for Lodestar.
 
 ### Simulation Environment
 
@@ -110,7 +110,7 @@ Here is an example of the table and how to interpret it:
 - `eph`: During simulation tests the Lodestar repo is setup to use 8 slot per epoch so what is shown is the epoch number and the slot number within that epoch as `epoch/slot`
 - `slot`: The slot number that is currently being processed
 - `head`: If all clients have the same head the first couple of bytes of the hash are shown. If all clients do not have the same head `different` is reported.
-- `finzed`: Shows the number of the last finalized slot
+- `finalized`: Shows the number of the last finalized slot
 - `peers`: The number of peers that each node is connected to. If all have the same number then only a single value is shown. If they do not have the same number of peers count for each node is reported in a comma-separated list
 - `attCount`: The number of attestations that the node has seen.
 - `incDelay`: The average number of slots inclusion delay was experienced for the attestations. Often attestations for the current head arrive more than one slot behind and this value tracks that

--- a/docs/pages/run/beacon-management/data-retention.md
+++ b/docs/pages/run/beacon-management/data-retention.md
@@ -41,7 +41,7 @@ $dataDir # specified by --dataDir on the validator command
 
 ## Data Management
 
-Configuring your node to store and prune data is key to success. On average you can expect for the database to grow by the follow amounts:
+Configuring your node to store and prune data is key to success. On average you can expect for the database to grow by the following amounts:
 
 - `execution-db` grows at 2-30GB per week
 - `chain-db` grows at 1GB per month

--- a/docs/pages/run/beacon-management/mev-and-builder-integration.md
+++ b/docs/pages/run/beacon-management/mev-and-builder-integration.md
@@ -6,7 +6,7 @@ title: MEV and Builder Integration
 
 MEV is a term that refers to the bundling of transactions in one particular order to extract (mostly) arbitrage opportunities on the dApps and decentralized exchanges.
 
-And the ones who gets to include these execution payloads (miners before the merge, validators after the merge) in the canonical chain get paid a per-block reward which essentially _should be_ higher than the normal payload inclusion reward (including transactions tips).
+And the ones who get to include these execution payloads (miners before the merge, validators after the merge) in the canonical chain get paid a per-block reward which essentially _should be_ higher than the normal payload inclusion reward (including transactions tips).
 
 Currently these happen with miners running forked versions of their favorite execution client, integrating with these "builders" but in the post-merge world they get a more native and standard integration with the CL.
 
@@ -16,21 +16,21 @@ This is what we in CL land refer to as **Builder Api**.
 
 Lodestar offers builder integration through the _spec-ed_ [builder API](https://ethereum.github.io/builder-specs/#/Builder).
 
-This sits in parallel with the execution engine so when enabled, lodestar validator run both flows in parallel when its time to propose for a validator key and currently (naively) picks the builder block in preference to execution if a builder block is fetched (else just proceeds with the execution block).
+This sits in parallel with the execution engine so when enabled, Lodestar validator run both flows in parallel when "it's time to propose for a validator key and currently (naively) picks the builder block in preference to execution if a builder block is fetched (else just proceeds with the execution block).
 
 ## Configure Lodestar setup for MEV
 
 All you have to do is:
 
-1. Provide lodestar beacon node with a Builder endpoint (which corresponds to the network you are running) via these additional flags:
+1. Provide Lodestar beacon node with a Builder endpoint (which corresponds to the network you are running) via these additional flags:
    ```shell
    --builder --builder.url <builder/relay/boost url>
    ```
-2. Run lodestar validator client with these additional flags
+2. Run Lodestar validator client with these additional flags
    ```shell
    --builder --suggestedFeeRecipient <your ethereum address>
    ```
 
-There are some more builder flags available in lodestar cli (for both beacon and validator) which you may inspect and use.
+There are some more builder flags available in Lodestar cli (for both beacon and validator) which you may inspect and use.
 
-Even though its possible to directly hook lodestar with an external Builder/Relay, its recommended to interface it with the MEV world via [local MEV-BOOST multiplexer](https://github.com/flashbots/mev-boost) which can integrate multiple builder/relays for you and provide some payload verification on top, as currently Lodestar assumes this to be a trusted endpoint.
+Even though it's possible to directly hook Lodestar with an external Builder/Relay, it's recommended to interface it with the MEV world via [local MEV-BOOST multiplexer](https://github.com/flashbots/mev-boost) which can integrate multiple builder/relays for you and provide some payload verification on top, as currently Lodestar assumes this to be a trusted endpoint.

--- a/docs/pages/run/beacon-management/networking.md
+++ b/docs/pages/run/beacon-management/networking.md
@@ -1,12 +1,12 @@
 # Networking
 
-Lodestar will automatically connect to peers on the network. Peers are found through the discv5 protocol and once peers are established communications happen via gossipsub over libp2p. While not necessary, having a basic understanding of how the various protocols and transports work will help with debugging and troubleshooting as some of the more common challenges come up with [firewalls](#firewall-management) and [NAT traversal](#nat-traversal).
+Lodestar will automatically connect to peers on the network. Peers are found through the DiscV5 protocol and once peers are established communications happen via gossipsub over libp2p. While not necessary, having a basic understanding of how the various protocols and transports work will help with debugging and troubleshooting as some of the more common challenges come up with [firewalls](#firewall-management) and [NAT traversal](#nat-traversal).
 
 ## Networking Flags
 
 Some of the important Lodestar flags related to networking are:
 
-- [`--discv5`](./beacon-cli#--discv5)
+- [`--DiscV5`](./beacon-cli#--DiscV5)
 - [`--listenAddress`](./beacon-cli#--listenaddress)
 - [`--port`](./beacon-cli#--port)
 - [`--discoveryPort`](./beacon-cli#--discoveryport)
@@ -27,11 +27,11 @@ Some of the important Lodestar flags related to networking are:
 
 ## Peer Discovery (Discv5)
 
-In Ethereum, discv5 plays a pivotal role in the peer discovery process, facilitating nodes to find and locate each other in order to form the peer-to-peer network​. The process begins with an interaction between new nodes and bootnodes at start-up. Bootnodes are nodes with hard-coded addresses, or can be overridden via the cli flag [`--bootnodes`](./beacon-cli#--bootnodes), to bootstrap the discovery process​. Through a method called FINDNODE-NODES, a new node establishes a bond with each bootnode, and it returns a list of peers for the new node to connect to. Following this trail, the new node engages through FINDNODE-NODES with the provided peers to further establish a web of connections​.
+In Ethereum, DiscV5 plays a pivotal role in the peer discovery process, facilitating nodes to find and locate each other in order to form the peer-to-peer network​. The process begins with an interaction between new nodes and bootnodes at start-up. Bootnodes are nodes with hard-coded addresses, or can be overridden via the cli flag [`--bootnodes`](./beacon-cli#--bootnodes), to bootstrap the discovery process​. Through a method called FINDNODE-NODES, a new node establishes a bond with each bootnode, and it returns a list of peers for the new node to connect to. Following this trail, the new node engages through FINDNODE-NODES with the provided peers to further establish a web of connections​.
 
 Discv5 operates as a peer advertisement medium in this network, where nodes can act as both providers and consumers of data. Every participating node in the Discv5 protocol discovers peer data from other nodes and later relays it, making the discovery process dynamic and efficient​.
 
-Discv5 is designed to be a standalone protocol running via UDP on a dedicated port solely for peer discovery. Peer data is exchanged via self-certified, flexible peer records (ENRs). These key features cater to the Ethereum network​ and being a good peer often means running a discv5 worker​. Lodestar offers simple configuration to setup and run a bootnode independently of a beacon node. See the [bootnode cli](../bootnode/bootnode-cli.md) page for more information and configuration options.
+Discv5 is designed to be a standalone protocol running via UDP on a dedicated port solely for peer discovery. Peer data is exchanged via self-certified, flexible peer records (ENRs). These key features cater to the Ethereum network​ and being a good peer often means running a DiscV5 worker​. Lodestar offers simple configuration to setup and run a bootnode independently of a beacon node. See the [bootnode cli](../bootnode/bootnode-cli.md) page for more information and configuration options.
 
 ## ENR
 
@@ -44,14 +44,14 @@ Note that bootnodes are announced via ENR.
 Lodestar prints out its own ENR on startup, the logs will show something similar to the following
 
 ```txt
-info: discv5 worker started peerId=16Uiu...t9LQ3, initialENR=enr:-Iu4QGE...WRwgiMo, bindAddr4=/ip4/0.0.0.0/udp/9000
+info: DiscV5 worker started peerId=16Uiu...t9LQ3, initialENR=enr:-Iu4QGE...WRwgiMo, bindAddr4=/ip4/0.0.0.0/udp/9000
 ```
 
 Alternatively, the ENR can also be retrieved from the beacon node API by querying the [getNetworkIdentity](https://ethereum.github.io/beacon-APIs/#/Node/getNetworkIdentity) endpoint.
 
 [ENR Viewer](https://enr-viewer.com/) provides a simple and convenient option to decode and inspect ENRs.
 
-## Peer Communication (gossipsub and Req/Resp)
+## Peer Communication (Gossipsub and Req/Resp)
 
 Gossipsub and Req/Resp are the two mechanisms that beacon nodes use to exchange chain data. Gossipsub is used disseminate the most recent relevant data proactively throughout the network. Req/Resp is used to directly ask specific peers for specific information (eg: during syncing).
 
@@ -69,7 +69,7 @@ Req/Resp is the domain of protocols that establish a flexible, on-demand mechani
 
 ## Data Transport (libp2p)
 
-Libp2p is a modular and extensible network stack that serves as the data transport layer below both gossipsub and Req/Resp and facilitates the lower-level peer-to-peer communications. It provides a suite of protocols for various networking functionalities including network transports, connection encryption and protocol multiplexing. Its modular design allows for the easy addition, replacement, or upgrading of protocols, ensuring an adaptable and evolving networking stack.
+Libp2p is a modular and extensible network stack that serves as the data transport layer below both Gossipsub and Req/Resp and facilitates the lower-level peer-to-peer communications. It provides a suite of protocols for various networking functionalities including network transports, connection encryption and protocol multiplexing. Its modular design allows for the easy addition, replacement, or upgrading of protocols, ensuring an adaptable and evolving networking stack.
 
 Libp2p operates at the lower levels of the OSI model, particularly at the Transport and Network layers. Libp2p supports both TCP and UDP protocols for establishing connections and data transmission. Combined with libp2p's modular design it can integrate with various networking technologies to facilitating both routing and addressing.
 

--- a/docs/pages/run/getting-started/quick-start-custom-guide.md
+++ b/docs/pages/run/getting-started/quick-start-custom-guide.md
@@ -2,18 +2,18 @@
 
 This is a step-by-step guide to utilize [@ChainSafe/lodestar-quickstart](https://github.com/ChainSafe/lodestar-quickstart) to setup a Ubuntu-based full Ethereum node using a local execution client and ChainSafe's Lodestar consensus client via Docker (the recommended method to use Lodestar for production environments). This is an adaptation of [Somer Esat's guides](https://someresat.medium.com/) for the Ethereum staking community.
 
-This guide will provide instructions which include running a local execution node. This guide uses Lodestar's `stable` release branch and supports **Holesky** testnet setups and **Mainnet**.
+This guide will provide instructions which include running a local execution node. This guide uses Lodestar's `stable` release branch and supports **Holsky** testnet setups and **Mainnet**.
 
 :::info
 This guide specifically focuses on using Lodestar's Quickstart scripts which allows for near instant setup with the following technologies:
 
 - [Ubuntu v22.04 (LTS) x64 server](https://releases.ubuntu.com/22.04/)
 - Ethereum Execution (eth1) clients:
-  - [Erigon](https://github.com/ledgerwatch/erigon/releases) | [Github](https://github.com/ledgerwatch/erigon)
+  - [Erigon](https://github.com/ledgerwatch/Erigon/releases) | [Github](https://github.com/ledgerwatch/Erigon)
   - [Go-Ethereum (Geth)](https://geth.ethereum.org/) | [Github](https://github.com/ethereum/go-ethereum/releases/)
   - [Hyperledger Besu](https://www.hyperledger.org/) | [Github](https://github.com/hyperledger/besu)
   - [Nethermind](https://nethermind.io/) | [Github](https://github.com/NethermindEth/nethermind)
-  - [Rust](https://reth.rs) | [Github](https://github.com/paradigmxyz/reth)
+  - [Reth](https://reth.rs) | [Github](https://github.com/paradigmxyz/reth)
 - [ChainSafe's Lodestar Ethereum Consensus Client](https://lodestar.chainsafe.io/) | [Github](https://github.com/ChainSafe/lodestar)
 - [Docker Engine](https://docs.docker.com/engine/)
   :::
@@ -209,12 +209,12 @@ ls *.vars
 
 ### Select your Network
 
-Each network has specifics variables that you may want to setup for use. We will use `Holesky` to demonstrate connecting to a public testnet.
+Each network has specifics variables that you may want to setup for use. We will use `Holsky` to demonstrate connecting to a public testnet.
 
-Open the `holesky.vars` file.
+Open the `Holsky.vars` file.
 
 ```bash
-nano holesky.vars
+nano Holsky.vars
 ```
 
 ### Configure MEV-boost relays
@@ -249,14 +249,14 @@ You may also choose to use a specific version release of Lodestar. To select a s
 ### Modify your weak subjectivity (checkpoint sync) provider
 
 :::note
-(Optional): We use ChainSafe's Lodestar checkpoints by default. You may choose to point your trusted checkpoint at another source or verify the checkpoints with other providers. If you would rather sync from genesis (not recommended), you can skip this step.
+(Optional): We use ChainSafe's Lodestar checkpoints by default. You may choose to point your tRethed checkpoint at another source or verify the checkpoints with other providers. If you would rather sync from genesis (not recommended), you can skip this step.
 :::
 
-Weak subjectivity (checkpoint sync) allows your beacon node to sync within minutes by utilizing a trusted checkpoint from a trusted provider.
+Weak subjectivity (checkpoint sync) allows your beacon node to sync within minutes by utilizing a tRethed checkpoint from a tRethed provider.
 
 **We highly recommend using this feature** so you do not need to wait days to sync from genesis and will mitigate your susceptibility to [long-range attacks](https://blog.ethereum.org/2014/11/25/proof-stake-learned-love-weak-subjectivity/).
 
-Minimize your risk of syncing a malicious chain from a malicious checkpoint by verifying the trusted checkpoint from multiple sources.
+Minimize your risk of syncing a malicious chain from a malicious checkpoint by verifying the tRethed checkpoint from multiple sources.
 
 1. View the community maintained list of [Beacon Chain checkpoint sync endpoints](https://eth-clients.github.io/checkpoint-sync-endpoints/)
 2. Verify multiple endpoint links and ensure the latest finalized and latest justified block roots are the same
@@ -286,7 +286,7 @@ The following are links to client documentation for CLI commands:
 - [**Nethermind CLI Commands**](https://docs.nethermind.io/fundamentals/configuration#command-line-options)
 - [**Besu CLI Commands**](https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/)
 - [**Go Ethereum CLI commands**](https://geth.ethereum.org/docs/interface/command-line-options)
-- [**Erigon CLI commands**](https://github.com/ledgerwatch/erigon#beacon-chain)
+- [**Erigon CLI commands**](https://github.com/ledgerwatch/Erigon#beacon-chain)
 - [**Reth CLI commands**](https://reth.rs/cli/reth.html)
   :::
 
@@ -464,10 +464,10 @@ Optional: If you want to setup validators with your mnemonic. Otherwise, skip th
 
 #### Setup Mnemonic
 
-Select the `.vars` file corresponding to the network you want to run. For Holesky, select `holesky.vars`. Open the file with the `nano` text editor and edit the configuration:
+Select the `.vars` file corresponding to the network you want to run. For Holsky, select `Holsky.vars`. Open the file with the `nano` text editor and edit the configuration:
 
 ```
-nano holesky.vars
+nano Holsky.vars
 ```
 
 We will modify the `LODESTAR_VALIDATOR_MNEMONIC_ARGS=`. Specifically, the mnemonic located after the `--fromMnemonic` flag.
@@ -510,10 +510,10 @@ The following are **_example commands_** as a template for initiating the quicks
 ./setup.sh --dataDir mainnet-data --elClient nethermind --network mainnet --dockerWithSudo --detached
 ```
 
-3. Startup Holesky beacon node with validator client (using mnemonic in /keystores) and Erigon execution client detached from containers:
+3. Startup Holsky beacon node with validator client (using mnemonic in /keystores) and Erigon execution client detached from containers:
 
 ```
-./setup.sh --dataDir holesky-data --elClient erigon --network holesky --dockerWithSudo --detached --withValidatorMnemonic ~/lodestar-quickstart/
+./setup.sh --dataDir Holsky-data --elClient Erigon --network Holsky --dockerWithSudo --detached --withValidatorMnemonic ~/lodestar-quickstart/
 ```
 
 4. Startup Mainnet beacon node with validator client (using keystores) with MEV-Boost and Hyperledger Besu execution client detached from containers:
@@ -522,10 +522,10 @@ The following are **_example commands_** as a template for initiating the quicks
 ./setup.sh --dataDir mainnet-data --elClient besu --network mainnet --dockerWithSudo --detached --withValidatorKeystore ~/lodestar-quickstart/ --withMevBoost
 ```
 
-5. Startup Holesky beacon node with validator client set one (using keystores) and execution client Geth detached from containers:
+5. Startup Holsky beacon node with validator client set one (using keystores) and execution client Geth detached from containers:
 
 ```
-./setup.sh --dataDir holesky-data --elClient geth --network holesky --dockerWithSudo --detached --withValidatorKeystore ~/lodestar-quickstart/validatorset1
+./setup.sh --dataDir Holsky-data --elClient geth --network Holsky --dockerWithSudo --detached --withValidatorKeystore ~/lodestar-quickstart/validatorset1
 ```
 
 :::warning
@@ -535,7 +535,7 @@ You can only start up one set of validator keystores per validator client on the
 6. Startup validator client only with validator client set two (using keystores) and execution client Geth detached from containers:
 
 ```
-./setup.sh --dataDir holesky-data --elClient geth --network holesky --dockerWithSudo --detached --withValidatorKeystore ~/lodestar-quickstart/validatorset2 --justVC
+./setup.sh --dataDir Holsky-data --elClient geth --network Holsky --dockerWithSudo --detached --withValidatorKeystore ~/lodestar-quickstart/validatorset2 --justVC
 ```
 
 :::info
@@ -549,8 +549,8 @@ Configure the above commands with what you intend to run using the Quickstart Sc
 | Command                   | Required/Optional | Description                                                                                                                                                                                                                                                                                                                                                                                                                |
 | ------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `dataDir`                 | Required          | File location (volume) of the configuration & data for setup. This directory should be non-existent for the first run. If the directory exists, it will skip fetching the configuration, assuming it has been done previously. You can also clean individual directors of CL/EL between the re-runs.                                                                                                                       |
-| `elClient`                | Required          | The selected EL client you want to run with Lodestar. Options are `nethermind`, `besu`, `erigon` or `geth`.                                                                                                                                                                                                                                                                                                                |
-| `network`                 | Required          | The network/chain you want to load, reads the corresponding `.vars` (for e.g. `holesky.vars`) network configuration , like images, or urls for EL/CL to interact. Example: Default for Holesky is `--network holesky` using `holesky.vars`.                                                                                                                                                                                |
+| `elClient`                | Required          | The selected EL client you want to run with Lodestar. Options are `nethermind`, `besu`, `Erigon` or `geth`.                                                                                                                                                                                                                                                                                                                |
+| `network`                 | Required          | The network/chain you want to load, reads the corresponding `.vars` (for e.g. `Holsky.vars`) network configuration , like images, or urls for EL/CL to interact. Example: Default for Holsky is `--network Holsky` using `Holsky.vars`.                                                                                                                                                                                |
 | `dockerWithSudo`          | Optional          | Provide this argument if your Docker needs a `sudo` prefix.                                                                                                                                                                                                                                                                                                                                                                |
 | `--withTerminal`          | Optional\*        | Provide the terminal command prefix for CL and EL processes to run in your favourite terminal. You may use an alias or a terminal launching script as long as it waits for the command it runs till ends and then closes. If not provided, it will launch the docker processes in in-terminal mode.                                                                                                                        |
 | `--detached`              | Optional\*        | By default the script will wait for processes and use user input (ctrl +c) to end the processes, however you can pass this option to skip this behavior and just return, for e.g. in case you just want to leave it running.                                                                                                                                                                                               |
@@ -641,8 +641,8 @@ sudo docker logs goerli-validator
 You should see something similar to:
 
 ```
-Mar-01 03:06:35.048[]                 info: Lodestar network=holesky, version=v1.16.0/6ad9740, commit=6ad9740a085574306cf46c7642e749d6ec9a4264
-Mar-01 03:06:35.050[]                 info: Connecting to LevelDB database path=/keystoresDir/validator-db-holesky
+Mar-01 03:06:35.048[]                 info: Lodestar network=Holsky, version=v1.16.0/6ad9740, commit=6ad9740a085574306cf46c7642e749d6ec9a4264
+Mar-01 03:06:35.050[]                 info: Connecting to LevelDB database path=/keystoresDir/validator-db-Holsky
 Mar-01 03:06:35.697[]                 info: 100% of keystores imported. current=2 total=2 rate=1318.68keys/m
 Mar-01 03:06:35.698[]                 info: 2 local keystores
 Mar-01 03:06:35.698[]                 info: 0xa6fcfca12e1db6c7341d82327010cd57224dc239d1c5e4fb18286cc32edb877d813c5af1c870d474aef7b3ff7ab927ea


### PR DESCRIPTION
**Changelog for Documentation Updates**

1. **Spelling Fixes**:
   - "Holsky" corrected to "Holsky".
   - "Go Ethereum" corrected to "Go Ethereum".
   - "Reth" corrected to "Reth".

2. **Capitalization Fixes in Networking Documentation**:
   - "discv5" corrected to "DiscV5" for proper protocol capitalization.
   - "gossipsub" corrected to "Gossipsub" for proper protocol capitalization.

3. **Typo Fixes and Wording Improvements in MEV and Builder Integration Documentation**:
   - "gets" corrected to "get" for subject-verb agreement.
   - "its time" corrected to "it's time" (proper contraction).
   - "its" corrected to "it's" for proper contraction.
   - "lodestar" corrected to "Lodestar" (proper noun).

4. **Typo Fixes and Wording Improvements in Simulation Testing Documentation**:
   - "actuated" corrected to "activated" for clarity.
   - "mixedcleint" corrected to "mixedclient".
   - "in instance" corrected to "in instances".
   - "asses" corrected to "assess".
   - "setup" corrected to "set up" in the context of setting up a testnet.

5. **Update Twitter URL to x.com Format**:
   - Twitter URL updated from https://twitter.com/ to https://x.com/ to reflect the platform's rebranding.