### PR TITLE
fix: timeUntilNext calculation before genesis

### DIFF
--- a/packages/validator/src/util/clock.ts
+++ b/packages/validator/src/util/clock.ts
@@ -120,13 +120,13 @@ export class Clock implements IClock {
       if (msFromGenesis >= 0) {
         return milliSecondsPerSlot - (msFromGenesis % milliSecondsPerSlot);
       }
-      return Math.abs(msFromGenesis % milliSecondsPerSlot);
+      return Math.abs(msFromGenesis) % milliSecondsPerSlot;
     }
     const milliSecondsPerEpoch = SLOTS_PER_EPOCH * milliSecondsPerSlot;
     if (msFromGenesis >= 0) {
       return milliSecondsPerEpoch - (msFromGenesis % milliSecondsPerEpoch);
     }
-    return Math.abs(msFromGenesis % milliSecondsPerEpoch);
+    return Math.abs(msFromGenesis) % milliSecondsPerEpoch;
   }
 }
 


### PR DESCRIPTION
### Description
Currently `Clock.runEverySlot()` and `Clock.runEveryEpoch()` will run at odd timing during epoch 0 due to calculation of `timeUntilNext` before genesis being incorrect.

Fixing the calculation ensures both functions will execute at t=0 in epoch 0.

### Example 1

Suppose current time is 7 seconds before genesis, we want to sleep for 7 seconds before we run the next execution of per-slot and per-epoch task.

In current calculation, next per-slot execution will happen in 5s, which is still 2s before genesis. And next per-epoch execution will happen in 377s, which is 370s after genesis (or 10s into slot 30).
```
msFromGenesis = -7000
Math.abs(msFromGenesis % milliSecondsPerSlot) = Math.abs(-7000 % 12000) = 5000 // TimeItem.Slot - before
Math.abs(msFromGenesis % milliSecondsPerEpoch) = Math.abs(-7000 % 384000) = 377000 // TimeItem.Epoch - before
Math.abs(msFromGenesis) % milliSecondsPerSlot = Math.abs(-7000) % 12000 = 7000 // TimeItem.Slot - after
Math.abs(msFromGenesis) % milliSecondsPerEpoch = Math.abs(-7000) % 384000 = 7000 // TimeItem.Epoch - after
```

### Example 2

Following the per-slot execution in the previous example, if we are at 2s before genesis, we want to sleep for 2s.

However current calculation wants us to sleep for 10s:
```
msFromGenesis = -2000
Math.abs(msFromGenesis % milliSecondsPerSlot) = Math.abs(-2000 % 12000) = 10000 // TimeItem.Slot - before
Math.abs(msFromGenesis) % milliSecondsPerSlot = Math.abs(-2000) % 12000 = 2000 // TimeItem.Slot - after
```

### Example 3

Current time 864s (2.25 epoch) before genesis. We want next execution to be at t=-768 by waiting for 96s:

```
msFromGenesis = -960000
Math.abs(msFromGenesis % milliSecondsPerSlot) = Math.abs(-864000 % 384000) = 288000 // TimeItem.Epoch - before
Math.abs(msFromGenesis) % milliSecondsPerSlot = Math.abs(-864000) % 384000 = 96000 // TimeItem.Epoch - after
```