### PR TITLE
fix: update valid voluntary exit check when building block

### DIFF
--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -23,6 +23,7 @@ import {SignedBLSToExecutionChangeVersioned} from "../../util/types.js";
 import {BlockType} from "../interface.js";
 import {BlockProductionStep} from "../produceBlock/produceBlockBody.js";
 import {isValidBlsToExecutionChangeForBlockInclusion} from "./utils.js";
+import {CachedBeaconStateElectra, isValidVoluntaryExitElectra} from "@lodestar/state-transition/src/index.js";
 
 type HexRoot = string;
 type AttesterSlashingCached = {
@@ -247,7 +248,9 @@ export class OpPool {
     for (const voluntaryExit of this.voluntaryExits.values()) {
       if (
         !toBeSlashedIndices.has(voluntaryExit.message.validatorIndex) &&
-        isValidVoluntaryExit(state, voluntaryExit, false) &&
+        (stateFork >= ForkSeq.electra
+          ? isValidVoluntaryExitElectra(state as CachedBeaconStateElectra, voluntaryExit, false)
+          : isValidVoluntaryExit(state, voluntaryExit, false)) &&
         // Signature validation is skipped in `isValidVoluntaryExit(,,false)` since it was already validated in gossip
         // However we must make sure that the signature fork is the same, or it will become invalid if included through
         // a future fork.

--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -10,10 +10,12 @@ import {
 } from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
+  CachedBeaconStateElectra,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   getAttesterSlashableIndices,
   isValidVoluntaryExit,
+  isValidVoluntaryExitElectra,
 } from "@lodestar/state-transition";
 import {AttesterSlashing, Epoch, SignedBeaconBlock, ValidatorIndex, capella, phase0, ssz} from "@lodestar/types";
 import {fromHex, toHex, toRootHex} from "@lodestar/utils";
@@ -23,7 +25,6 @@ import {SignedBLSToExecutionChangeVersioned} from "../../util/types.js";
 import {BlockType} from "../interface.js";
 import {BlockProductionStep} from "../produceBlock/produceBlockBody.js";
 import {isValidBlsToExecutionChangeForBlockInclusion} from "./utils.js";
-import {CachedBeaconStateElectra, isValidVoluntaryExitElectra} from "@lodestar/state-transition/src/index.js";
 
 type HexRoot = string;
 type AttesterSlashingCached = {

--- a/packages/state-transition/src/block/processVoluntaryExit.ts
+++ b/packages/state-transition/src/block/processVoluntaryExit.ts
@@ -52,7 +52,7 @@ export function isValidVoluntaryExit(
   );
 }
 
-function isValidVoluntaryExitElectra(
+export function isValidVoluntaryExitElectra(
   state: CachedBeaconStateElectra,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
   verifySignature = true

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -53,7 +53,7 @@ export {
 } from "./cache/effectiveBalanceIncrements.js";
 
 // BeaconChain validation
-export {isValidVoluntaryExit} from "./block/processVoluntaryExit.js";
+export {isValidVoluntaryExit, isValidVoluntaryExitElectra} from "./block/processVoluntaryExit.js";
 export {isValidBlsToExecutionChange} from "./block/processBlsToExecutionChange.js";
 export {assertValidProposerSlashing} from "./block/processProposerSlashing.js";
 export {assertValidAttesterSlashing} from "./block/processAttesterSlashing.js";


### PR DESCRIPTION
Fixes another issue, we might build a block with a invalid voluntary exit since we haven't updated the check when building the block, only in state transition.
