### PR TITLE
fix: consistently check no pending withdrawals when processing voluntary exit

### DIFF
--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -247,7 +247,7 @@ export class OpPool {
     for (const voluntaryExit of this.voluntaryExits.values()) {
       if (
         !toBeSlashedIndices.has(voluntaryExit.message.validatorIndex) &&
-        isValidVoluntaryExit(state, voluntaryExit, false) &&
+        isValidVoluntaryExit(stateFork, state, voluntaryExit, false) &&
         // Signature validation is skipped in `isValidVoluntaryExit(,,false)` since it was already validated in gossip
         // However we must make sure that the signature fork is the same, or it will become invalid if included through
         // a future fork.

--- a/packages/beacon-node/src/chain/validation/voluntaryExit.ts
+++ b/packages/beacon-node/src/chain/validation/voluntaryExit.ts
@@ -43,7 +43,7 @@ async function validateVoluntaryExit(
 
   // [REJECT] All of the conditions within process_voluntary_exit pass validation.
   // verifySignature = false, verified in batch below
-  if (!isValidVoluntaryExit(state, voluntaryExit, false)) {
+  if (!isValidVoluntaryExit(chain.config.getForkSeq(state.slot), state, voluntaryExit, false)) {
     throw new VoluntaryExitError(GossipAction.REJECT, {
       code: VoluntaryExitErrorCode.INVALID,
     });

--- a/packages/state-transition/src/block/processVoluntaryExit.ts
+++ b/packages/state-transition/src/block/processVoluntaryExit.ts
@@ -1,5 +1,5 @@
 import {FAR_FUTURE_EPOCH, ForkSeq} from "@lodestar/params";
-import {phase0} from "@lodestar/types";
+import {phase0, ValidatorIndex} from "@lodestar/types";
 import {verifyVoluntaryExitSignature} from "../signatureSets/index.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateElectra} from "../types.js";
 import {getPendingBalanceToWithdraw, isActiveValidator} from "../util/index.js";
@@ -16,11 +16,7 @@ export function processVoluntaryExit(
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
   verifySignature = true
 ): void {
-  const isValidExit =
-    fork >= ForkSeq.electra
-      ? isValidVoluntaryExitElectra(state as CachedBeaconStateElectra, signedVoluntaryExit, verifySignature)
-      : isValidVoluntaryExit(state, signedVoluntaryExit, verifySignature);
-  if (!isValidExit) {
+  if (!isValidVoluntaryExit(fork, state, signedVoluntaryExit, verifySignature)) {
     throw Error(`Invalid voluntary exit at forkSeq=${fork}`);
   }
 
@@ -29,6 +25,7 @@ export function processVoluntaryExit(
 }
 
 export function isValidVoluntaryExit(
+  fork: ForkSeq,
   state: CachedBeaconStateAllForks,
   signedVoluntaryExit: phase0.SignedVoluntaryExit,
   verifySignature = true
@@ -47,20 +44,12 @@ export function isValidVoluntaryExit(
     currentEpoch >= voluntaryExit.epoch &&
     // verify the validator had been active long enough
     currentEpoch >= validator.activationEpoch + config.SHARD_COMMITTEE_PERIOD &&
+    (fork >= ForkSeq.electra
+      ? // only exit validator if it has no pending withdrawals in the queue
+        getPendingBalanceToWithdraw(state as CachedBeaconStateElectra, voluntaryExit.validatorIndex) === 0
+      : // there are no pending withdrawals in previous forks
+        true) &&
     // verify signature
     (!verifySignature || verifyVoluntaryExitSignature(state, signedVoluntaryExit))
   );
-}
-
-function isValidVoluntaryExitElectra(
-  state: CachedBeaconStateElectra,
-  signedVoluntaryExit: phase0.SignedVoluntaryExit,
-  verifySignature = true
-): boolean {
-  // only exit validator if it has no pending withdrawals in the queue (post-Electra only)
-  if (getPendingBalanceToWithdraw(state, signedVoluntaryExit.message.validatorIndex) === 0) {
-    return isValidVoluntaryExit(state, signedVoluntaryExit, verifySignature);
-  }
-
-  return false;
 }

--- a/packages/state-transition/src/block/processVoluntaryExit.ts
+++ b/packages/state-transition/src/block/processVoluntaryExit.ts
@@ -1,5 +1,5 @@
 import {FAR_FUTURE_EPOCH, ForkSeq} from "@lodestar/params";
-import {phase0, ValidatorIndex} from "@lodestar/types";
+import {ValidatorIndex, phase0} from "@lodestar/types";
 import {verifyVoluntaryExitSignature} from "../signatureSets/index.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateElectra} from "../types.js";
 import {getPendingBalanceToWithdraw, isActiveValidator} from "../util/index.js";


### PR DESCRIPTION
Fixes another issue, we might build a block with an invalid voluntary exit since we haven't updated the check when building the block post-electra, only in state transition.

This was [caught by pk910](https://discord.com/channels/595666850260713488/1330516498724421692/1330660097818361959)
```
Jan-19 22:03:13.017[api]              warn: Engine failed to produce the block slot=169, fork=electra, builderSelection=executiononly, isBuilderEnabled=false, isEngineEnabled=true, strictFeeRecipientCheck=false, builderBoostFactor=0, durationMs=5 - Invalid voluntary exit at forkSeq=5
Error: Invalid voluntary exit at forkSeq=5
```

Looking at the spec, it's pretty clear that those validations should be applied to gossip as well as block construction

From phase0 p2p / gossip spec [here](https://github.com/ethereum/consensus-specs/blob/b1c70a96883feddb194eba4f3a033a8b53f0d082/specs/phase0/p2p-interface.md?plain=1#L434)
> _[REJECT]_ All of the conditions within `process_voluntary_exit` pass validation.

which references `process_voluntary_exit` which was updated in electra [here](https://github.com/ethereum/consensus-specs/blob/b1c70a96883feddb194eba4f3a033a8b53f0d082/specs/electra/beacon-chain.md?plain=1#L1497C5-L1497C115)
> assert get_pending_balance_to_withdraw(state, voluntary_exit.validator_index) == 0 


Updating the existing `isValidVoluntaryExit` and adding the check there ensures we apply the check everywhere. It also follows the same order of checks now as in the spec, ie. run less expensive checks first.

