### PR TITLE
Typo fix  README.md

### DIFF
--- a/packages/cli/test/utils/crucible/README.md
+++ b/packages/cli/test/utils/crucible/README.md
@@ -27,7 +27,7 @@ You can run any of npm task prefixed with `test:sim:*`. There are different scen
 | Lighthouse | LIGHTHOUSE_DOCKER_IMAGE | Similar to other clients use it to set Lighouse docker image. Make use you use `-dev` suffixed image tags as these are the only one supporting `minimal` preset.                                                      |
 | Lighthouse | LIGHTHOUSE_BINARY_PATH  | Use local compiled binary. Make sure it's compiled with the `minimal` spec enabled.                                                                                                                                   |
 
-### Enable Metics for the sim tests
+### Enable Metrics for the sim tests
 
 To enable metrics for the SIM tests you can set `SIM_METRIC_SERVER_URL` environment variable with the host and port e.g. `127.0.0.1:4000`.
 


### PR DESCRIPTION
# Typo Fix in `README.md`

## Description

This pull request corrects a typographical error in the **`README.md`** file located in the `packages/cli/test/utils/crucible` directory:

- **Typo:** Corrected "Metics" to "Metrics" in the section title:
  - **Original:** "Enable Metics for the sim tests"
  - **Corrected:** "Enable Metrics for the sim tests"

### Changes
- **File:** `packages/cli/test/utils/crucible/README.md`
- **Details:**
  - Updated the section heading for better clarity and accuracy.


