### PR TITLE
fix: use cjs version of hasher

### DIFF
--- a/packages/cli/src/applyPreset.ts
+++ b/packages/cli/src/applyPreset.ts
@@ -1,7 +1,8 @@
 // MUST import this file first before anything and not import any Lodestar code.
-
-import {hasher} from "@chainsafe/persistent-merkle-tree/lib/cjs/hasher/as-sha256.js";
-import {setHasher} from "@chainsafe/persistent-merkle-tree/lib/cjs/hasher/index.js";
+import {createRequire} from "node:module"
+const require = createRequire(import.meta.url)
+const {hasher} = require("@chainsafe/persistent-merkle-tree/lib/cjs/hasher/as-sha256.js");
+const {setHasher} = require("@chainsafe/persistent-merkle-tree/lib/cjs/hasher/index.js");
 
 // without setting this first, persistent-merkle-tree will use noble instead
 setHasher(hasher);

--- a/packages/cli/src/applyPreset.ts
+++ b/packages/cli/src/applyPreset.ts
@@ -1,7 +1,7 @@
 // MUST import this file first before anything and not import any Lodestar code.
 
-import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/as-sha256.js";
-import {setHasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/index.js";
+import {hasher} from "@chainsafe/persistent-merkle-tree/lib/cjs/hasher/as-sha256.js";
+import {setHasher} from "@chainsafe/persistent-merkle-tree/lib/cjs/hasher/index.js";
 
 // without setting this first, persistent-merkle-tree will use noble instead
 setHasher(hasher);


### PR DESCRIPTION
**Motivation**

There was a performance regression because the wrong hasher (default noble) was getting used by the ssz lib even though the as-sha256 was set.  Has to do with dual module export and node resolving both versions of the library.