### PR TITLE
feat: implement snapshot api EIP-4881

### DIFF
--- a/packages/api/src/beacon/routes/beacon/index.ts
+++ b/packages/api/src/beacon/routes/beacon/index.ts
@@ -46,6 +46,8 @@ export type Endpoints = block.Endpoints &
       phase0.Genesis,
       EmptyMeta
     >;
+  } & {
+    getDepositSnapshot: Endpoint<"GET", EmptyArgs, EmptyRequest, phase0.DepositTreeSnapshot, EmptyMeta>;
   };
 
 export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoints> {
@@ -56,6 +58,15 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       req: EmptyRequestCodec,
       resp: {
         data: ssz.phase0.Genesis,
+        meta: EmptyMetaCodec,
+      },
+    },
+    getDepositSnapshot: {
+      url: "/eth/v1/beacon/deposit_snapshot",
+      method: "GET",
+      req: EmptyRequestCodec,
+      resp: {
+        data: ssz.phase0.DepositTreeSnapshot,
         meta: EmptyMetaCodec,
       },
     },

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -277,6 +277,10 @@ export const testData: GenericServerTestCases<Endpoints> = {
     args: undefined,
     res: {data: ssz.phase0.Genesis.defaultValue()},
   },
+  getDepositSnapshot: {
+    args: undefined,
+    res: {data: ssz.phase0.DepositTreeSnapshot.defaultValue()},
+  },
 };
 
 function getDefaultBlindedBlock(slot: Slot): SignedBlindedBeaconBlock {

--- a/packages/beacon-node/src/api/impl/beacon/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/index.ts
@@ -14,7 +14,7 @@ export function getBeaconApi(
   const state = getBeaconStateApi(modules);
   const rewards = getBeaconRewardsApi(modules);
 
-  const {chain, config} = modules;
+  const {chain, config, db} = modules;
 
   return {
     ...block,
@@ -29,6 +29,17 @@ export function getBeaconApi(
           genesisTime: chain.genesisTime,
           genesisValidatorsRoot: chain.genesisValidatorsRoot,
         },
+      };
+    },
+
+    async getDepositSnapshot() {
+      const snapshot = await db.depositTreeSnapshot.lastValue();
+      if (snapshot == null) {
+        throw new Error("No deposit tree snapshot available");
+      }
+
+      return {
+        data: snapshot,
       };
     },
   };

--- a/packages/beacon-node/src/chain/archiver/archiver.ts
+++ b/packages/beacon-node/src/chain/archiver/archiver.ts
@@ -130,8 +130,9 @@ export class Archiver {
         finalized,
         this.metrics
       );
-      await this.db.depositEvent.deleteOld(finalizedDepositCount);
       await this.db.depositTreeSnapshot.deleteOld(finalizedDepositCount);
+      // do not delete this.db.depositRootTree to keep it compatible to the old implementation
+      await this.db.depositEvent.deleteOld(finalizedDepositCount);
       // TODO: not sure how to delete old Eth1Data as there is no timestamp here
     } catch (e) {
       this.logger.error("Error persisting deposit tree snapshot", {epoch: finalized.epoch}, e as Error);

--- a/packages/beacon-node/src/chain/archiver/archiver.ts
+++ b/packages/beacon-node/src/chain/archiver/archiver.ts
@@ -130,10 +130,16 @@ export class Archiver {
         finalized,
         this.metrics
       );
-      await this.db.depositTreeSnapshot.deleteOld(finalizedDepositCount);
+      const deletedSnapshots = await this.db.depositTreeSnapshot.deleteOld(finalizedDepositCount);
       // do not delete this.db.depositRootTree to keep it compatible to the old implementation
-      await this.db.depositEvent.deleteOld(finalizedDepositCount);
+      const deletedEvents = await this.db.depositEvent.deleteOld(finalizedDepositCount);
       // TODO: not sure how to delete old Eth1Data as there is no timestamp here
+
+      this.logger.verbose("Persisted new finalized deposit snapshot", {
+        depositCount: finalizedDepositCount,
+        deletedSnapshots,
+        deletedEvents,
+      });
     } catch (e) {
       this.logger.error("Error persisting deposit tree snapshot", {epoch: finalized.epoch}, e as Error);
     }

--- a/packages/beacon-node/src/chain/archiver/archiver.ts
+++ b/packages/beacon-node/src/chain/archiver/archiver.ts
@@ -105,6 +105,9 @@ export class Archiver {
       // should be after ArchiveBlocksTask to handle restart cleanly
       await this.statesArchiverStrategy.maybeArchiveState(finalized, this.metrics);
 
+      // persistDepositTreeSnapshot catches error on its own to avoid breaking finalized checkpoint processing
+      await this.persistDepositTreeSnapshot(finalized);
+
       this.chain.regen.pruneOnFinalized(finalizedEpoch);
 
       // tasks rely on extended fork choice
@@ -118,6 +121,20 @@ export class Archiver {
       });
     } catch (e) {
       this.logger.error("Error processing finalized checkpoint", {epoch: finalized.epoch}, e as Error);
+    }
+  };
+
+  private persistDepositTreeSnapshot = async (finalized: CheckpointWithHex): Promise<void> => {
+    try {
+      const finalizedDepositCount = await this.statesArchiverStrategy.persistDepositTreeSnapshot(
+        finalized,
+        this.metrics
+      );
+      await this.db.depositEvent.deleteOld(finalizedDepositCount);
+      await this.db.depositTreeSnapshot.deleteOld(finalizedDepositCount);
+      // TODO: not sure how to delete old Eth1Data as there is no timestamp here
+    } catch (e) {
+      this.logger.error("Error persisting deposit tree snapshot", {epoch: finalized.epoch}, e as Error);
     }
   };
 

--- a/packages/beacon-node/src/chain/archiver/interface.ts
+++ b/packages/beacon-node/src/chain/archiver/interface.ts
@@ -44,5 +44,6 @@ export interface StateArchiveStrategy {
   onCheckpoint(stateRoot: RootHex, metrics?: Metrics | null): Promise<void>;
   onFinalizedCheckpoint(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<void>;
   maybeArchiveState(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<void>;
+  persistDepositTreeSnapshot(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<number>;
   archiveState(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<void>;
 }

--- a/packages/beacon-node/src/chain/archiver/strategies/frequencyStateArchiveStrategy.ts
+++ b/packages/beacon-node/src/chain/archiver/strategies/frequencyStateArchiveStrategy.ts
@@ -1,6 +1,6 @@
 import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {CachedBeaconStateElectra, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {IBeaconDb} from "../../../db/index.js";
@@ -16,6 +16,13 @@ import {StateArchiveStrategy, StatesArchiverOpts} from "../interface.js";
  * These states will be pruned once a new state is persisted
  */
 export const PERSIST_TEMP_STATE_EVERY_EPOCHS = 32;
+
+enum PersistSnapshotResult {
+  NoTreeBackedState = "no_tree_backed_state",
+  NoDepositEvent = "no_deposit_event",
+  NotSyncedDepositRootTree = "not_synced_deposit_root_tree",
+  Success = "success",
+}
 
 /**
  * Archives finalized states from active bucket to archive bucket.
@@ -114,6 +121,55 @@ export class FrequencyStateArchiveStrategy implements StateArchiveStrategy {
         root: rootHex,
       });
     }
+  }
+
+  async persistDepositTreeSnapshot(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<number> {
+    // starting from Mar 2024, the finalized state could be from disk or in memory
+    const finalizedState = await this.regen.getCheckpointStateOrBytes(finalized);
+    const {rootHex} = finalized;
+    if (!finalizedState) {
+      throw Error(`No state in cache for finalized checkpoint state epoch #${finalized.epoch} root ${rootHex}`);
+    }
+
+    if (finalizedState instanceof Uint8Array) {
+      // with the current DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY = 3, it's most likely the state is in memory
+      // it's not worth to reload the state from disk just to persist snapshot
+      // in this case, we should be able to server snapshot api using the old snapshot
+      // the next time the network is stable, we should be able to persist the new snapshot
+      metrics?.eth1.persistSnapshotResult.inc({result: PersistSnapshotResult.NoTreeBackedState});
+      throw Error("Finalized state is not in cache");
+    }
+
+    const eth1Data = finalizedState.eth1Data;
+    const finalizedDepositCount = eth1Data.depositCount;
+
+    if (
+      finalizedState.epochCtx.isPostElectra() &&
+      finalizedState.eth1DepositIndex >= (finalizedState as CachedBeaconStateElectra).depositRequestsStartIndex
+    ) {
+      // No need to poll eth1Data since Electra deprecates the mechanism after depositRequestsStartIndex is reached
+      return finalizedDepositCount;
+    }
+
+    metrics?.eth1.finalizedDepositCount.set(finalizedDepositCount);
+    const lastFinalizedDepositEvent = await this.db.depositEvent.get(finalizedDepositCount - 1);
+    if (lastFinalizedDepositEvent == null) {
+      // ignore if we our depositEvent db is not synced
+      metrics?.eth1.persistSnapshotResult.inc({result: PersistSnapshotResult.NoDepositEvent});
+      throw Error(`No deposit event found for index ${finalizedDepositCount - 1}`);
+    }
+
+    const persistSuccess = await this.db.depositDataRoot.onFinalizedEth1Data(
+      eth1Data,
+      lastFinalizedDepositEvent.blockNumber
+    );
+    if (!persistSuccess) {
+      metrics?.eth1.persistSnapshotResult.inc({result: PersistSnapshotResult.NotSyncedDepositRootTree});
+    } else {
+      metrics?.eth1.persistSnapshotResult.inc({result: PersistSnapshotResult.Success});
+    }
+
+    return finalizedDepositCount;
   }
 }
 

--- a/packages/beacon-node/src/db/beacon.ts
+++ b/packages/beacon-node/src/db/beacon.ts
@@ -2,6 +2,7 @@ import {ChainForkConfig} from "@lodestar/config";
 import {Db, LevelDbControllerMetrics} from "@lodestar/db";
 import {IBeaconDb} from "./interface.js";
 import {CheckpointStateRepository} from "./repositories/checkpointState.js";
+import {DepositTreeSnapshotRepository} from "./repositories/depositTreeSnapshot.js";
 import {
   AttesterSlashingRepository,
   BLSToExecutionChangeRepository,
@@ -45,6 +46,7 @@ export class BeaconDb implements IBeaconDb {
   blsToExecutionChange: BLSToExecutionChangeRepository;
 
   depositDataRoot: DepositDataRootRepository;
+  depositTreeSnapshot: DepositTreeSnapshotRepository;
   eth1Data: Eth1DataRepository;
   preGenesisState: PreGenesisState;
   preGenesisStateLastProcessedBlock: PreGenesisStateLastProcessedBlock;
@@ -75,7 +77,8 @@ export class BeaconDb implements IBeaconDb {
     this.proposerSlashing = new ProposerSlashingRepository(config, db);
     this.attesterSlashing = new AttesterSlashingRepository(config, db);
     this.depositEvent = new DepositEventRepository(config, db);
-    this.depositDataRoot = new DepositDataRootRepository(config, db);
+    this.depositTreeSnapshot = new DepositTreeSnapshotRepository(config, db);
+    this.depositDataRoot = new DepositDataRootRepository(config, db, this.depositTreeSnapshot);
     this.eth1Data = new Eth1DataRepository(config, db);
     this.preGenesisState = new PreGenesisState(config, db);
     this.preGenesisStateLastProcessedBlock = new PreGenesisStateLastProcessedBlock(config, db);

--- a/packages/beacon-node/src/db/buckets.ts
+++ b/packages/beacon-node/src/db/buckets.ts
@@ -61,6 +61,7 @@ export enum Bucket {
   // 54 was for bestPartialLightClientUpdate, allocate a fresh one
   // lightClient_bestLightClientUpdate = 55, // SyncPeriod -> LightClientUpdate // DEPRECATED on v1.5.0
   lightClient_bestLightClientUpdate = 56, // SyncPeriod -> [Slot, LightClientUpdate]
+  phase0_depositTreeSnapshot = 57, // deposit count -> DepositTreeSnapshot
 }
 
 export function getBucketNameByValue<T extends Bucket>(enumValue: T): keyof typeof Bucket {

--- a/packages/beacon-node/src/db/interface.ts
+++ b/packages/beacon-node/src/db/interface.ts
@@ -12,6 +12,7 @@ import {
   CheckpointHeaderRepository,
   DepositDataRootRepository,
   DepositEventRepository,
+  DepositTreeSnapshotRepository,
   Eth1DataRepository,
   ProposerSlashingRepository,
   StateArchiveRepository,
@@ -51,6 +52,7 @@ export interface IBeaconDb {
   preGenesisState: PreGenesisState;
   preGenesisStateLastProcessedBlock: PreGenesisStateLastProcessedBlock;
 
+  depositTreeSnapshot: DepositTreeSnapshotRepository;
   // all deposit data roots and merkle tree
   depositDataRoot: DepositDataRootRepository;
   eth1Data: Eth1DataRepository;

--- a/packages/beacon-node/src/db/repositories/depositDataRoot.ts
+++ b/packages/beacon-node/src/db/repositories/depositDataRoot.ts
@@ -68,6 +68,7 @@ export class DepositDataRootRepository extends Repository<number, Root> {
         this.depositRootTree.commit();
         return this.depositRootTree;
       }
+
       const values = await this.values({gte: snapshot.depositCount});
       this.depositRootTree = ssz.phase0.DepositDataRootPartialList.toPartialViewDU({
         finalized: snapshot.finalized,
@@ -76,6 +77,17 @@ export class DepositDataRootRepository extends Repository<number, Root> {
       });
       for (const root of values) {
         this.depositRootTree.push(root);
+      }
+
+      // for nodes synced from genesis, we have all values in db, it's good to confirm depositRootTree is correct
+      // it happens only 1 time so not a big deal
+      const firstEntry = await this.get(0);
+      if (firstEntry != null) {
+        const allValues = await this.values();
+        const fullTree = ssz.phase0.DepositDataRootList.toViewDU(allValues);
+        if(Buffer.compare(fullTree.hashTreeRoot(), this.depositRootTree.hashTreeRoot()) !== 0) {
+          throw new Error("Partial deposit root tree is not correct");
+        }
       }
     }
     return this.depositRootTree;

--- a/packages/beacon-node/src/db/repositories/depositDataRoot.ts
+++ b/packages/beacon-node/src/db/repositories/depositDataRoot.ts
@@ -57,7 +57,16 @@ export class DepositDataRootRepository extends Repository<number, Root> {
     // at startup, we should use db's snapshot or download from checkpoint sync and persist there
     if (!this.depositRootTree) {
       const snapshot = await this.snapshotRepo.lastValue();
-      if (snapshot == null) {
+      const lastKey = await this.lastKey();
+      const firstEntry = await this.get(0);
+      if (snapshot == null || (lastKey != null && lastKey + 1 < snapshot.depositCount)) {
+        // no snapshot or snapshot is too new, see if we can rebuild the full tree via DepositDataRootPartialList type
+        if (firstEntry == null) {
+          throw new Error(
+            `Partial deposit root tree persisted but there is no snapshot or cannot use it, snapshot depositCount ${snapshot?.depositCount} lastKey ${lastKey}`
+          );
+        }
+
         // snapshot may not be available for the 1st time because the checkpointSync URL does not support
         // after some time, the beacon node will finalize and populate the snapshot
         this.depositRootTree = ssz.phase0.DepositDataRootPartialList.defaultPartialViewDU();
@@ -78,14 +87,14 @@ export class DepositDataRootRepository extends Repository<number, Root> {
       for (const root of values) {
         this.depositRootTree.push(root);
       }
+      this.depositRootTree.commit();
 
       // for nodes synced from genesis, we have all values in db, it's good to confirm depositRootTree is correct
       // it happens only 1 time so not a big deal
-      const firstEntry = await this.get(0);
       if (firstEntry != null) {
         const allValues = await this.values();
         const fullTree = ssz.phase0.DepositDataRootList.toViewDU(allValues);
-        if(Buffer.compare(fullTree.hashTreeRoot(), this.depositRootTree.hashTreeRoot()) !== 0) {
+        if (Buffer.compare(fullTree.hashTreeRoot(), this.depositRootTree.hashTreeRoot()) !== 0) {
           throw new Error("Partial deposit root tree is not correct");
         }
       }
@@ -119,7 +128,7 @@ export class DepositDataRootRepository extends Repository<number, Root> {
       // blockHash + blockHeight come from different sources
       // blockHash is from finalized BeaconState's eth1data.
       // blockHeight is from `depositCount - 1` deposit event
-      // when we fetch snapshot from db in `getDepositRootTree()`, we don't need execution blockHash + blockHeight anyway
+      // when we fetch snapshot from db in `getDepositRootTree()`, we only need blockHeight to know where to start the fetch at the very 1st time
       executionBlockHeight: blockNumber,
     };
 

--- a/packages/beacon-node/src/db/repositories/depositDataRoot.ts
+++ b/packages/beacon-node/src/db/repositories/depositDataRoot.ts
@@ -58,7 +58,15 @@ export class DepositDataRootRepository extends Repository<number, Root> {
     if (!this.depositRootTree) {
       const snapshot = await this.snapshotRepo.lastValue();
       if (snapshot == null) {
-        throw new Error("DepositTreeSnapshot not found");
+        // snapshot may not be available for the 1st time because the checkpointSync URL does not support
+        // after some time, the beacon node will finalize and populate the snapshot
+        this.depositRootTree = ssz.phase0.DepositDataRootPartialList.defaultPartialViewDU();
+        const values = await this.values();
+        for (const root of values) {
+          this.depositRootTree.push(root);
+        }
+        this.depositRootTree.commit();
+        return this.depositRootTree;
       }
       const values = await this.values({gte: snapshot.depositCount});
       this.depositRootTree = ssz.phase0.DepositDataRootPartialList.toPartialViewDU({

--- a/packages/beacon-node/src/db/repositories/depositDataRoot.ts
+++ b/packages/beacon-node/src/db/repositories/depositDataRoot.ts
@@ -1,19 +1,22 @@
-import {ByteVectorType, CompositeViewDU, ListCompositeType} from "@chainsafe/ssz";
+import {CompositeViewDU} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {Db, KeyValue, Repository} from "@lodestar/db";
-import {Root, ssz} from "@lodestar/types";
+import {Root, phase0, ssz} from "@lodestar/types";
 import {bytesToInt} from "@lodestar/utils";
 import {Bucket, getBucketNameByValue} from "../buckets.js";
+import {DepositTreeSnapshotRepository} from "./depositTreeSnapshot.js";
 
-// TODO: Review where is best to put this type
-export type DepositTree = CompositeViewDU<ListCompositeType<ByteVectorType>>;
+export type DepositTree = CompositeViewDU<typeof ssz.phase0.DepositDataRootPartialList>;
 
 export class DepositDataRootRepository extends Repository<number, Root> {
+  // partial deposit root tree
   private depositRootTree?: DepositTree;
+  private snapshotRepo: DepositTreeSnapshotRepository;
 
-  constructor(config: ChainForkConfig, db: Db) {
+  constructor(config: ChainForkConfig, db: Db, snapshotRepo: DepositTreeSnapshotRepository) {
     const bucket = Bucket.index_depositDataRoot;
     super(config, db, bucket, ssz.Root, getBucketNameByValue(bucket));
+    this.snapshotRepo = snapshotRepo;
   }
 
   decodeKey(data: Buffer): number {
@@ -51,9 +54,21 @@ export class DepositDataRootRepository extends Repository<number, Root> {
   }
 
   async getDepositRootTree(): Promise<DepositTree> {
+    // at startup, we should use db's snapshot or download from checkpoint sync and persist there
     if (!this.depositRootTree) {
-      const values = await this.values();
-      this.depositRootTree = ssz.phase0.DepositDataRootList.toViewDU(values);
+      const snapshot = await this.snapshotRepo.lastValue();
+      if (snapshot == null) {
+        throw new Error("DepositTreeSnapshot not found");
+      }
+      const values = await this.values({gte: snapshot.depositCount});
+      this.depositRootTree = ssz.phase0.DepositDataRootPartialList.toPartialViewDU({
+        finalized: snapshot.finalized,
+        root: snapshot.depositRoot,
+        count: snapshot.depositCount,
+      });
+      for (const root of values) {
+        this.depositRootTree.push(root);
+      }
     }
     return this.depositRootTree;
   }
@@ -61,6 +76,37 @@ export class DepositDataRootRepository extends Repository<number, Root> {
   async getDepositRootTreeAtIndex(depositIndex: number): Promise<DepositTree> {
     const depositRootTree = await this.getDepositRootTree();
     return depositRootTree.sliceTo(depositIndex);
+  }
+
+  /**
+   * Return true if we successfully persist the snapshot and updated the deposit root tree
+   */
+  async onFinalizedEth1Data(eth1Data: phase0.Eth1Data, blockNumber: number): Promise<boolean> {
+    const finalizedDepositCount = eth1Data.depositCount;
+    const depositRootTree = await this.getDepositRootTree();
+    if (depositRootTree.length <= finalizedDepositCount) {
+      // ignore if our deposit root tree is not synced
+      // finalizedDepositCount could be the same over epochs, no need to process again
+      return false;
+    }
+
+    const snapshot = depositRootTree.toSnapshot(finalizedDepositCount);
+    const depositSnapshot: phase0.DepositTreeSnapshot = {
+      finalized: snapshot.finalized,
+      depositRoot: snapshot.root,
+      depositCount: snapshot.count,
+      executionBlockHash: eth1Data.blockHash,
+      // blockHash + blockHeight come from different sources
+      // blockHash is from finalized BeaconState's eth1data.
+      // blockHeight is from `depositCount - 1` deposit event
+      // when we fetch snapshot from db in `getDepositRootTree()`, we don't need execution blockHash + blockHeight anyway
+      executionBlockHeight: blockNumber,
+    };
+
+    await this.snapshotRepo.put(finalizedDepositCount, depositSnapshot);
+    this.depositRootTree = depositRootTree.sliceFrom(finalizedDepositCount);
+
+    return true;
   }
 
   private async depositRootTreeSet(index: number, value: Uint8Array): Promise<void> {

--- a/packages/beacon-node/src/db/repositories/depositEvent.ts
+++ b/packages/beacon-node/src/db/repositories/depositEvent.ts
@@ -13,12 +13,15 @@ export class DepositEventRepository extends Repository<number, phase0.DepositEve
     super(config, db, bucket, ssz.phase0.DepositEvent, getBucketNameByValue(bucket));
   }
 
-  async deleteOld(depositCount: number): Promise<void> {
+  async deleteOld(depositCount: number): Promise<number> {
     const firstDepositIndex = await this.firstKey();
     if (firstDepositIndex === null) {
-      return;
+      return 0;
     }
-    await this.batchDelete(Array.from({length: depositCount - firstDepositIndex}, (_, i) => i + firstDepositIndex));
+
+    const length = depositCount - firstDepositIndex;
+    await this.batchDelete(Array.from({length}, (_, i) => i + firstDepositIndex));
+    return length;
   }
 
   async batchPutValues(depositEvents: phase0.DepositEvent[]): Promise<void> {

--- a/packages/beacon-node/src/db/repositories/depositTreeSnapshot.ts
+++ b/packages/beacon-node/src/db/repositories/depositTreeSnapshot.ts
@@ -16,8 +16,12 @@ export class DepositTreeSnapshotRepository extends Repository<number, phase0.Dep
   /**
    * Only keep the snapshot of the last finalized deposit count
    */
-  async deleteOld(finalizedDepositCount: number): Promise<void> {
+  async deleteOld(finalizedDepositCount: number): Promise<number> {
     const oldKeys = await this.keys({lt: finalizedDepositCount});
-    await this.batchDelete(oldKeys);
+    if (oldKeys.length > 0) {
+      await this.batchDelete(oldKeys);
+    }
+
+    return oldKeys.length;
   }
 }

--- a/packages/beacon-node/src/db/repositories/depositTreeSnapshot.ts
+++ b/packages/beacon-node/src/db/repositories/depositTreeSnapshot.ts
@@ -1,0 +1,23 @@
+import {ChainForkConfig} from "@lodestar/config";
+import {Db, Repository} from "@lodestar/db";
+import {phase0, ssz} from "@lodestar/types";
+import {Bucket, getBucketNameByValue} from "../buckets.js";
+
+export class DepositTreeSnapshotRepository extends Repository<number, phase0.DepositTreeSnapshot> {
+  constructor(config: ChainForkConfig, db: Db) {
+    const bucket = Bucket.phase0_depositTreeSnapshot;
+    super(config, db, bucket, ssz.phase0.DepositTreeSnapshot, getBucketNameByValue(bucket));
+  }
+
+  getId(value: phase0.DepositTreeSnapshot): number {
+    return value.depositCount;
+  }
+
+  /**
+   * Only keep the snapshot of the last finalized deposit count
+   */
+  async deleteOld(finalizedDepositCount: number): Promise<void> {
+    const oldKeys = await this.keys({lt: finalizedDepositCount});
+    await this.batchDelete(oldKeys);
+  }
+}

--- a/packages/beacon-node/src/db/repositories/index.ts
+++ b/packages/beacon-node/src/db/repositories/index.ts
@@ -11,6 +11,7 @@ export {ProposerSlashingRepository} from "./proposerSlashing.js";
 export {VoluntaryExitRepository} from "./voluntaryExit.js";
 export {DepositEventRepository} from "./depositEvent.js";
 
+export {DepositTreeSnapshotRepository} from "./depositTreeSnapshot.js";
 export {DepositDataRootRepository} from "./depositDataRoot.js";
 export {Eth1DataRepository} from "./eth1Data.js";
 

--- a/packages/beacon-node/src/eth1/eth1DataCache.ts
+++ b/packages/beacon-node/src/eth1/eth1DataCache.ts
@@ -21,6 +21,10 @@ export class Eth1DataCache {
 
   async getHighestCachedBlockNumber(): Promise<number | null> {
     const highestEth1Data = await this.db.eth1Data.lastValue();
-    return highestEth1Data?.blockNumber ?? null;
+    const snapshot = await this.db.depositTreeSnapshot.lastValue();
+
+    // for the first time, when there is no eth1 data in the db, go with snapshot block height if we have it
+    // otherwise start with the last eth1 block number
+    return highestEth1Data?.blockNumber ?? snapshot?.executionBlockHeight ?? null;
   }
 }

--- a/packages/beacon-node/src/eth1/eth1DepositsCache.ts
+++ b/packages/beacon-node/src/eth1/eth1DepositsCache.ts
@@ -129,7 +129,11 @@ export class Eth1DepositsCache {
    */
   async getHighestDepositEventBlockNumber(): Promise<number | null> {
     const latestEvent = await this.db.depositEvent.lastValue();
-    return latestEvent?.blockNumber || null;
+    const snapshot = await this.db.depositTreeSnapshot.lastValue();
+
+    // for the first time, when there is no deposit event in the db, go with snapshot block height if we have it
+    // otherwise start with the last deposit event block number
+    return latestEvent?.blockNumber ?? snapshot?.executionBlockHeight ?? null;
   }
 
   /**

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1656,6 +1656,17 @@ export function createLodestarMetrics(
         help: "If found then 1 with terminal block details",
         labelNames: ["terminalBlockHash", "terminalBlockNumber", "terminalBlockTD"],
       }),
+
+      // EIP-4881 Snapshot
+      persistSnapshotResult: register.gauge<{result: string}>({
+        name: "lodestar_eth1_persist_snapshot_result_total",
+        help: "Total number of persistSnapshot runs by result",
+        labelNames: ["result"],
+      }),
+      finalizedDepositCount: register.gauge({
+        name: "lodestar_eth1_finalized_deposit_count",
+        help: "The finalized deposit count",
+      }),
     },
 
     eth1HttpClient: {

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -175,7 +175,10 @@ export class BeaconNode {
       // we already checked that we didn't have any snapshot before fetching it, but just to make sure
       const deletedSnapshots = await db.depositTreeSnapshot.deleteOld(wsDepositSnapshot.depositCount);
       await db.depositTreeSnapshot.add(wsDepositSnapshot);
-      logger.info("Persisted ws deposit snapshot at startup", {depositCount: wsDepositSnapshot.depositCount, deletedSnapshots});
+      logger.info("Persisted ws deposit snapshot at startup", {
+        depositCount: wsDepositSnapshot.depositCount,
+        deletedSnapshots,
+      });
     }
 
     let metrics = null;

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -7,6 +7,7 @@ import {BeaconConfig} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
 import {BeaconStateAllForks} from "@lodestar/state-transition";
 import {phase0} from "@lodestar/types";
+import {DepositTreeSnapshot} from "@lodestar/types/phase0";
 import {sleep} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
 
@@ -52,6 +53,7 @@ export type BeaconNodeInitModules = {
   peerId: PeerId;
   peerStoreDir?: string;
   anchorState: BeaconStateAllForks;
+  wsDepositSnapshot: DepositTreeSnapshot | null;
   wsCheckpoint?: phase0.Checkpoint;
   metricsRegistries?: Registry[];
 };
@@ -149,6 +151,7 @@ export class BeaconNode {
     peerId,
     peerStoreDir,
     anchorState,
+    wsDepositSnapshot,
     wsCheckpoint,
     metricsRegistries = [],
   }: BeaconNodeInitModules): Promise<T> {
@@ -167,6 +170,13 @@ export class BeaconNode {
     // Prune hot db repos
     // TODO: Should this call be awaited?
     await db.pruneHotDb();
+
+    if (wsDepositSnapshot != null) {
+      // we already checked that we didn't have any snapshot before fetching it, but just to make sure
+      const deletedSnapshots = await db.depositTreeSnapshot.deleteOld(wsDepositSnapshot.depositCount);
+      await db.depositTreeSnapshot.add(wsDepositSnapshot);
+      logger.info("Persisted ws deposit snapshot at startup", {depositCount: wsDepositSnapshot.depositCount, deletedSnapshots});
+    }
 
     let metrics = null;
     if (

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -5,9 +5,11 @@ import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db";
 import {LoggerNode, getNodeLogger} from "@lodestar/logger/node";
 import {ACTIVE_PRESET, PresetName} from "@lodestar/params";
+import {DepositTreeSnapshot} from "@lodestar/types/phase0";
 import {ErrorAborted} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
 
+import {HttpHeader, MediaType, WireFormat, getClient} from "@lodestar/api";
 import {BeaconNodeOptions, getBeaconConfigFromArgs} from "../../config/index.js";
 import {getNetworkBootnodes, getNetworkData, isKnownNetworkName, readBootnodes} from "../../networks/index.js";
 import {GlobalArgs, parseBeaconNodeArgs} from "../../options/index.js";
@@ -73,6 +75,39 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       logger,
       abortController.signal
     );
+
+    const dbSnapshot = await db.depositTreeSnapshot.lastKey();
+    let wsDepositSnapshot: DepositTreeSnapshot | null = null;
+    if (dbSnapshot == null && args.checkpointSyncUrl != null) {
+      try {
+        // Validate the weakSubjectivityServerUrl and only log the origin to mask the
+        // username password credentials
+        const checkpointSyncUrl = new URL(args.checkpointSyncUrl);
+        logger.info("Fetching deposit snapshot", {
+          checkpointSyncUrl: checkpointSyncUrl.origin,
+        });
+        const api = getClient({baseUrl: args.checkpointSyncUrl}, {config});
+        wsDepositSnapshot = (
+          await api.beacon.getDepositSnapshot({
+            responseWireFormat: WireFormat.json,
+            headers: {
+              [HttpHeader.Accept]: MediaType.json,
+            },
+          })
+        ).json();
+        logger.info("Fetched deposit snapshot", {depositCount: wsDepositSnapshot?.depositCount});
+      } catch (e) {
+        logger.error("Invalid", {checkpointSyncUrl: args.checkpointSyncUrl}, e as Error);
+        throw e;
+      }
+    } else {
+      if (dbSnapshot != null) {
+        logger.verbose("Using deposit snapshot from database", {depositCount: dbSnapshot});
+      } else if (args.checkpointSyncUrl == null) {
+        logger.verbose("No deposit snapshot from database and no checkpointSyncUrl provided");
+      }
+    }
+
     const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
     const node = await BeaconNode.init({
       opts: options,
@@ -83,6 +118,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       peerId,
       peerStoreDir: beaconPaths.peerStoreDir,
       anchorState,
+      wsDepositSnapshot,
       wsCheckpoint,
     });
 

--- a/packages/types/src/phase0/sszTypes.ts
+++ b/packages/types/src/phase0/sszTypes.ts
@@ -5,6 +5,7 @@ import {
   ListBasicType,
   ListCompositeType,
   ListUintNum64Type,
+  PartialListCompositeType,
   VectorBasicType,
   VectorCompositeType,
 } from "@chainsafe/ssz";
@@ -134,6 +135,18 @@ export const DepositData = new ContainerType(
 );
 
 export const DepositDataRootList = new ListCompositeType(Root, 2 ** DEPOSIT_CONTRACT_TREE_DEPTH);
+export const DepositTreeSnapshot = new ContainerType(
+  {
+    finalized: DepositDataRootList,
+    depositRoot: Root,
+    depositCount: UintNum64,
+    executionBlockHash: Root,
+    executionBlockHeight: UintNum64,
+  },
+  {typeName: "DepositsDataSnapshot", jsonCase: "eth2"}
+);
+
+export const DepositDataRootPartialList = new PartialListCompositeType(Root, 2 ** DEPOSIT_CONTRACT_TREE_DEPTH);
 
 export const DepositEvent = new ContainerType(
   {

--- a/packages/types/src/phase0/types.ts
+++ b/packages/types/src/phase0/types.ts
@@ -10,6 +10,7 @@ export type Checkpoint = ValueOf<typeof ssz.Checkpoint>;
 export type DepositMessage = ValueOf<typeof ssz.DepositMessage>;
 export type DepositData = ValueOf<typeof ssz.DepositData>;
 export type DepositEvent = ValueOf<typeof ssz.DepositEvent>;
+export type DepositTreeSnapshot = ValueOf<typeof ssz.DepositTreeSnapshot>;
 export type Eth1Data = ValueOf<typeof ssz.Eth1Data>;
 export type Eth1DataOrdered = ValueOf<typeof ssz.Eth1DataOrdered>;
 export type Eth1Block = ValueOf<typeof ssz.Eth1Block>;


### PR DESCRIPTION
**Motivation**

- implement EIP-4881 https://eips.ethereum.org/EIPS/eip-4881
- as a preparation for EIP-4444 https://eips.ethereum.org/EIPS/eip-4444

**Description**

- new `DepositTreeSnapshotRepository` repository
  - populated by fetching from ws checkpoint at the first time
  - or populated once we have finalized checkpoint by beacon node
  - only 1 item stored at a time
  - once we have a snapshot in db, we never have to fetch it again
- DepositDataRootRepository: replace deposit tree by the new `DepositDataRootPartialList`
  - built from the latest finalized snapshot up until latest value
- implement `/eth/v1/beacon/deposit_snapshot` api

note that once Electra goes lives, after `depositRequestsStartIndex` we will not poll eth1 anymore so this is short lived

Closes #4935

**Steps to test**

- [ ] compare our snapshot responses to others
- [ ] test node sync/publish blocks without db, checkpointSync support snapshot
- [ ] test node sync/publish blocks without db, checkpointSync DOES NOT support snapshot
- [ ] test node sync/publish blocks with existing db, checkpointSync support snapshot
- [ ] test node sync/publish blocks with existing db, checkpointSync DOES NOT support snapshot


