### PR TITLE
refactor: remove blockBytes/blobBytes

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -62,7 +62,7 @@ export function getBeaconBlockApi({
 >): ApplicationMethods<routes.beacon.block.Endpoints> {
   const publishBlock: ApplicationMethods<routes.beacon.block.Endpoints>["publishBlockV2"] = async (
     {signedBlockOrContents, broadcastValidation},
-    context,
+    _context,
     opts: PublishBlockOpts = {}
   ) => {
     const seenTimestampSec = Date.now() / 1000;
@@ -77,18 +77,11 @@ export function getBeaconBlockApi({
         blobsSource: BlobsSource.api,
         blobsBytes: blobSidecars.map(() => null),
       } as BlockInputDataBlobs;
-      blockForImport = getBlockInput.availableData(
-        config,
-        signedBlock,
-        BlockSource.api,
-        // don't bundle any bytes for block and blobs
-        null,
-        blockData
-      );
+      blockForImport = getBlockInput.availableData(config, signedBlock, BlockSource.api, blockData);
     } else {
       signedBlock = signedBlockOrContents;
       blobSidecars = [];
-      blockForImport = getBlockInput.preData(config, signedBlock, BlockSource.api, context?.sszBytes ?? null);
+      blockForImport = getBlockInput.preData(config, signedBlock, BlockSource.api);
     }
 
     // check what validations have been requested before broadcasting and publishing the block

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -75,7 +75,6 @@ export function getBeaconBlockApi({
         fork: config.getForkName(signedBlock.message.slot),
         blobs: blobSidecars,
         blobsSource: BlobsSource.api,
-        blobsBytes: blobSidecars.map(() => null),
       } as BlockInputDataBlobs;
       blockForImport = getBlockInput.availableData(config, signedBlock, BlockSource.api, blockData);
     } else {

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -34,13 +34,15 @@ export enum GossipedInputType {
   blob = "blob",
 }
 
-type BlobsCacheMap = Map<number, {
-  blobSidecar: deneb.BlobSidecar;
-  blobBytes: Uint8Array | null,
-}>;
+type BlobsCacheMap = Map<
+  number,
+  {
+    blobSidecar: deneb.BlobSidecar;
+  }
+>;
 
 type ForkBlobsInfo = {fork: ForkBlobs};
-export type BlockInputBlobs = {blobs: deneb.BlobSidecars; blobsBytes: (Uint8Array | null)[]; blobsSource: BlobsSource};
+export type BlockInputBlobs = {blobs: deneb.BlobSidecar[]; blobsSource: BlobsSource};
 export type BlockInputDataBlobs = ForkBlobsInfo & BlockInputBlobs;
 export type BlockInputData = BlockInputDataBlobs;
 
@@ -49,7 +51,7 @@ type Availability<T> = {availabilityPromise: Promise<T>; resolveAvailability: (d
 type CachedBlobs = {blobsCache: BlobsCacheMap} & Availability<BlockInputDataBlobs>;
 export type CachedData = ForkBlobsInfo & CachedBlobs;
 
-export type BlockInput = {block: SignedBeaconBlock; source: BlockSource; blockBytes: Uint8Array | null} & (
+export type BlockInput = {block: SignedBeaconBlock; source: BlockSource} & (
   | {type: BlockInputType.preData | BlockInputType.outOfRangeData}
   | ({type: BlockInputType.availableData} & {blockData: BlockInputData})
   // the blobsSource here is added to BlockInputBlobs when availability is resolved
@@ -68,12 +70,7 @@ export function blockRequiresBlobs(config: ChainForkConfig, blockSlot: Slot, clo
 }
 
 export const getBlockInput = {
-  preData(
-    config: ChainForkConfig,
-    block: SignedBeaconBlock,
-    source: BlockSource,
-    blockBytes: Uint8Array | null
-  ): BlockInput {
+  preData(config: ChainForkConfig, block: SignedBeaconBlock, source: BlockSource): BlockInput {
     if (config.getForkSeq(block.message.slot) >= ForkSeq.deneb) {
       throw Error(`Post Deneb block slot ${block.message.slot}`);
     }
@@ -81,7 +78,6 @@ export const getBlockInput = {
       type: BlockInputType.preData,
       block,
       source,
-      blockBytes,
     };
   },
 
@@ -91,12 +87,7 @@ export const getBlockInput = {
   //
   // This can help with some of the requests of syncing without data for some use cases for e.g.
   // building states or where importing data isn't important if valid child exists like ILs
-  outOfRangeData(
-    config: ChainForkConfig,
-    block: SignedBeaconBlock,
-    source: BlockSource,
-    blockBytes: Uint8Array | null
-  ): BlockInput {
+  outOfRangeData(config: ChainForkConfig, block: SignedBeaconBlock, source: BlockSource): BlockInput {
     if (config.getForkSeq(block.message.slot) < ForkSeq.deneb) {
       throw Error(`Pre Deneb block slot ${block.message.slot}`);
     }
@@ -104,7 +95,6 @@ export const getBlockInput = {
       type: BlockInputType.outOfRangeData,
       block,
       source,
-      blockBytes,
     };
   },
 
@@ -112,7 +102,6 @@ export const getBlockInput = {
     config: ChainForkConfig,
     block: SignedBeaconBlock,
     source: BlockSource,
-    blockBytes: Uint8Array | null,
     blockData: BlockInputData
   ): BlockInput {
     if (config.getForkSeq(block.message.slot) < ForkSeq.deneb) {
@@ -122,7 +111,6 @@ export const getBlockInput = {
       type: BlockInputType.availableData,
       block,
       source,
-      blockBytes,
       blockData,
     };
   },
@@ -131,7 +119,6 @@ export const getBlockInput = {
     config: ChainForkConfig,
     block: SignedBeaconBlock,
     source: BlockSource,
-    blockBytes: Uint8Array | null,
     cachedData: CachedData
   ): BlockInput {
     if (config.getForkSeq(block.message.slot) < ForkSeq.deneb) {
@@ -141,7 +128,6 @@ export const getBlockInput = {
       type: BlockInputType.dataPromise,
       block,
       source,
-      blockBytes,
       cachedData,
     };
   },
@@ -149,18 +135,16 @@ export const getBlockInput = {
 
 export function getBlockInputBlobs(blobsCache: BlobsCacheMap): Omit<BlockInputBlobs, "blobsSource"> {
   const blobs = [];
-  const blobsBytes = [];
 
   for (let index = 0; index < blobsCache.size; index++) {
     const blobCache = blobsCache.get(index);
     if (blobCache === undefined) {
       throw Error(`Missing blobSidecar at index=${index}`);
     }
-    const {blobSidecar, blobBytes} = blobCache;
+    const {blobSidecar} = blobCache;
     blobs.push(blobSidecar);
-    blobsBytes.push(blobBytes);
   }
-  return {blobs, blobsBytes};
+  return {blobs};
 }
 
 export enum AttestationImportOpt {

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -34,12 +34,7 @@ export enum GossipedInputType {
   blob = "blob",
 }
 
-type BlobsCacheMap = Map<
-  number,
-  {
-    blobSidecar: deneb.BlobSidecar;
-  }
->;
+type BlobsCacheMap = Map<number, deneb.BlobSidecar>;
 
 type ForkBlobsInfo = {fork: ForkBlobs};
 export type BlockInputBlobs = {blobs: deneb.BlobSidecar[]; blobsSource: BlobsSource};
@@ -137,11 +132,10 @@ export function getBlockInputBlobs(blobsCache: BlobsCacheMap): Omit<BlockInputBl
   const blobs = [];
 
   for (let index = 0; index < blobsCache.size; index++) {
-    const blobCache = blobsCache.get(index);
-    if (blobCache === undefined) {
+    const blobSidecar = blobsCache.get(index);
+    if (blobSidecar === undefined) {
       throw Error(`Missing blobSidecar at index=${index}`);
     }
-    const {blobSidecar} = blobCache;
     blobs.push(blobSidecar);
   }
   return {blobs};

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -34,14 +34,16 @@ export enum GossipedInputType {
   blob = "blob",
 }
 
-type BlobsCacheMap = Map<number, {blobSidecar: deneb.BlobSidecar; blobBytes: Uint8Array | null}>;
+type BlobsCacheMap = Map<number, {
+  blobSidecar: deneb.BlobSidecar;
+  blobBytes: Uint8Array | null,
+}>;
 
 type ForkBlobsInfo = {fork: ForkBlobs};
-type BlobsData = {blobs: deneb.BlobSidecars; blobsBytes: (Uint8Array | null)[]; blobsSource: BlobsSource};
-export type BlockInputDataBlobs = ForkBlobsInfo & BlobsData;
+export type BlockInputBlobs = {blobs: deneb.BlobSidecars; blobsBytes: (Uint8Array | null)[]; blobsSource: BlobsSource};
+export type BlockInputDataBlobs = ForkBlobsInfo & BlockInputBlobs;
 export type BlockInputData = BlockInputDataBlobs;
 
-export type BlockInputBlobs = {blobs: deneb.BlobSidecars; blobsBytes: (Uint8Array | null)[]; blobsSource: BlobsSource};
 type Availability<T> = {availabilityPromise: Promise<T>; resolveAvailability: (data: T) => void};
 
 type CachedBlobs = {blobsCache: BlobsCacheMap} & Availability<BlockInputDataBlobs>;
@@ -145,7 +147,7 @@ export const getBlockInput = {
   },
 };
 
-export function getBlockInputBlobs(blobsCache: BlobsCacheMap): Omit<BlobsData, "blobsSource"> {
+export function getBlockInputBlobs(blobsCache: BlobsCacheMap): Omit<BlockInputBlobs, "blobsSource"> {
   const blobs = [];
   const blobsBytes = [];
 

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -112,7 +112,6 @@ async function maybeValidateBlobs(
         chain.config,
         blockInput.block,
         blockInput.source,
-        blockInput.blockBytes,
         blobsData
       );
       return {dataAvailabilityStatus: DataAvailabilityStatus.Available, availableBlockInput: availableBlockInput};

--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -13,9 +13,10 @@ export async function writeBlockInputToDb(this: BeaconChain, blocksInput: BlockI
   const fnPromises: Promise<void>[] = [];
 
   for (const blockInput of blocksInput) {
-    const {block, blockBytes} = blockInput;
+    const {block} = blockInput;
     const blockRoot = this.config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
     const blockRootHex = toRootHex(blockRoot);
+    const blockBytes = this.serializedCache.get(block);
     if (blockBytes) {
       // skip serializing data if we already have it
       this.metrics?.importBlock.persistBlockWithSerializedDataCount.inc();

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -48,6 +48,7 @@ import {BufferPool} from "../util/bufferPool.js";
 import {Clock, ClockEvent, IClock} from "../util/clock.js";
 import {ensureDir, writeIfNotExist} from "../util/file.js";
 import {isOptimisticBlock} from "../util/forkChoice.js";
+import {SerializedCache} from "../util/serializedCache.js";
 import {Archiver} from "./archiver/archiver.js";
 import {CheckpointBalancesCache} from "./balancesCache.js";
 import {BeaconProposerCache} from "./beaconProposerCache.js";
@@ -101,7 +102,6 @@ import {FileCPStateDatastore} from "./stateCache/datastore/file.js";
 import {FIFOBlockStateCache} from "./stateCache/fifoBlockStateCache.js";
 import {InMemoryCheckpointStateCache} from "./stateCache/inMemoryCheckpointsCache.js";
 import {PersistentCheckpointStateCache} from "./stateCache/persistentCheckpointsCache.js";
-import {SerializedCache} from "../util/serializedCache.js";
 
 /**
  * Arbitrary constants, blobs and payloads should be consumed immediately in the same slot

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -101,6 +101,7 @@ import {FileCPStateDatastore} from "./stateCache/datastore/file.js";
 import {FIFOBlockStateCache} from "./stateCache/fifoBlockStateCache.js";
 import {InMemoryCheckpointStateCache} from "./stateCache/inMemoryCheckpointsCache.js";
 import {PersistentCheckpointStateCache} from "./stateCache/persistentCheckpointsCache.js";
+import {SerializedCache} from "../util/serializedCache.js";
 
 /**
  * Arbitrary constants, blobs and payloads should be consumed immediately in the same slot
@@ -166,6 +167,8 @@ export class BeaconChain implements IBeaconChain {
   // actual publish
   readonly producedBlockRoot = new Map<RootHex, ExecutionPayload | null>();
   readonly producedBlindedBlockRoot = new Set<RootHex>();
+
+  readonly serializedCache: SerializedCache;
 
   readonly opts: IChainOptions;
 
@@ -343,6 +346,8 @@ export class BeaconChain implements IBeaconChain {
     this.regen = regen;
     this.bls = bls;
     this.emitter = emitter;
+
+    this.serializedCache = new SerializedCache();
 
     this.archiver = new Archiver(db, this, logger, signal, opts, metrics);
     // always run PrepareNextSlotScheduler except for fork_choice spec tests

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -59,6 +59,7 @@ import {SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof.js";
 import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
 import {SeenBlockAttesters} from "./seenCache/seenBlockAttesters.js";
 import {ShufflingCache} from "./shufflingCache.js";
+import {SerializedCache} from "../util/serializedCache.js";
 
 export {BlockType, type AssembledBlockType};
 export {type ProposerPreparationData};
@@ -128,6 +129,9 @@ export interface IBeaconChain {
   readonly producedBlockRoot: Map<RootHex, ExecutionPayload | null>;
   readonly shufflingCache: ShufflingCache;
   readonly producedBlindedBlockRoot: Set<RootHex>;
+  // Cache for serialized objects
+  readonly serializedCache: SerializedCache;
+
   readonly opts: IChainOptions;
 
   /** Stop beacon chain processing */

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -31,6 +31,7 @@ import {IExecutionBuilder, IExecutionEngine} from "../execution/index.js";
 import {Metrics} from "../metrics/metrics.js";
 import {BufferPool} from "../util/bufferPool.js";
 import {IClock} from "../util/clock.js";
+import {SerializedCache} from "../util/serializedCache.js";
 import {CheckpointBalancesCache} from "./balancesCache.js";
 import {BeaconProposerCache, ProposerPreparationData} from "./beaconProposerCache.js";
 import {BlockInput, ImportBlockOpts} from "./blocks/types.js";
@@ -59,7 +60,6 @@ import {SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof.js";
 import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
 import {SeenBlockAttesters} from "./seenCache/seenBlockAttesters.js";
 import {ShufflingCache} from "./shufflingCache.js";
-import {SerializedCache} from "../util/serializedCache.js";
 
 export {BlockType, type AssembledBlockType};
 export {type ProposerPreparationData};

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -15,6 +15,7 @@ import {
   getBlockInput,
   getBlockInputBlobs,
 } from "../blocks/types.js";
+import {SerializedCache} from "../../util/serializedCache.js";
 
 export enum BlockInputAvailabilitySource {
   GOSSIP = "gossip",
@@ -22,13 +23,12 @@ export enum BlockInputAvailabilitySource {
 }
 
 type GossipedBlockInput =
-  | {type: GossipedInputType.block; signedBlock: SignedBeaconBlock; blockBytes: Uint8Array | null}
-  | {type: GossipedInputType.blob; blobSidecar: deneb.BlobSidecar; blobBytes: Uint8Array | null};
+  | {type: GossipedInputType.block; signedBlock: SignedBeaconBlock}
+  | {type: GossipedInputType.blob; blobSidecar: deneb.BlobSidecar};
 
 type BlockInputCacheType = {
   fork: ForkName;
   block?: SignedBeaconBlock;
-  blockBytes?: Uint8Array | null;
   cachedData?: CachedData;
   // block promise and its callback cached for delayed resolution
   blockInputPromise: Promise<BlockInput>;
@@ -77,16 +77,15 @@ export class SeenGossipBlockInput {
     let fork: ForkName;
 
     if (gossipedInput.type === GossipedInputType.block) {
-      const {signedBlock, blockBytes} = gossipedInput;
+      const {signedBlock} = gossipedInput;
       fork = config.getForkName(signedBlock.message.slot);
 
       blockHex = toRootHex(config.getForkTypes(signedBlock.message.slot).BeaconBlock.hashTreeRoot(signedBlock.message));
       blockCache = this.blockInputCache.get(blockHex) ?? getEmptyBlockInputCacheEntry(fork);
 
       blockCache.block = signedBlock;
-      blockCache.blockBytes = blockBytes;
     } else {
-      const {blobSidecar, blobBytes} = gossipedInput;
+      const {blobSidecar} = gossipedInput;
       const blockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(blobSidecar.signedBlockHeader.message);
       fork = config.getForkName(blobSidecar.signedBlockHeader.message.slot);
 
@@ -96,8 +95,6 @@ export class SeenGossipBlockInput {
       // TODO: freetheblobs check if its the same blob or a duplicate and throw/take actions
       blockCache.cachedData?.blobsCache.set(blobSidecar.index, {
         blobSidecar,
-        // easily splice out the unsigned message as blob is a fixed length type
-        blobBytes: blobBytes?.slice(0, BLOBSIDECAR_FIXED_SIZE) ?? null,
       });
     }
 
@@ -105,12 +102,12 @@ export class SeenGossipBlockInput {
       this.blockInputCache.set(blockHex, blockCache);
     }
 
-    const {block: signedBlock, blockBytes, blockInputPromise, resolveBlockInput, cachedData} = blockCache;
+    const {block: signedBlock, blockInputPromise, resolveBlockInput, cachedData} = blockCache;
 
     if (signedBlock !== undefined) {
       if (!isForkBlobs(fork)) {
         return {
-          blockInput: getBlockInput.preData(config, signedBlock, BlockSource.gossip, blockBytes ?? null),
+          blockInput: getBlockInput.preData(config, signedBlock, BlockSource.gossip),
           blockInputMeta: {pending: null, haveBlobs: 0, expectedBlobs: 0},
         };
       }
@@ -136,13 +133,7 @@ export class SeenGossipBlockInput {
         const blockData = {...allBlobs, blobsSource: BlobsSource.gossip, fork: cachedData.fork};
         resolveAvailability(blockData);
         metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
-        const blockInput = getBlockInput.availableData(
-          config,
-          signedBlock,
-          BlockSource.gossip,
-          blockBytes ?? null,
-          blockData
-        );
+        const blockInput = getBlockInput.availableData(config, signedBlock, BlockSource.gossip, blockData);
 
         resolveBlockInput(blockInput);
         return {
@@ -151,13 +142,7 @@ export class SeenGossipBlockInput {
         };
       }
 
-      const blockInput = getBlockInput.dataPromise(
-        config,
-        signedBlock,
-        BlockSource.gossip,
-        blockBytes ?? null,
-        cachedData
-      );
+      const blockInput = getBlockInput.dataPromise(config, signedBlock, BlockSource.gossip, cachedData);
 
       resolveBlockInput(blockInput);
       return {

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -4,6 +4,7 @@ import {RootHex, SignedBeaconBlock, deneb, ssz} from "@lodestar/types";
 import {pruneSetToMax, toRootHex} from "@lodestar/utils";
 
 import {Metrics} from "../../metrics/index.js";
+import {SerializedCache} from "../../util/serializedCache.js";
 import {
   BlobsSource,
   BlockInput,
@@ -15,7 +16,6 @@ import {
   getBlockInput,
   getBlockInputBlobs,
 } from "../blocks/types.js";
-import {SerializedCache} from "../../util/serializedCache.js";
 
 export enum BlockInputAvailabilitySource {
   GOSSIP = "gossip",

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -93,9 +93,7 @@ export class SeenGossipBlockInput {
       blockCache = this.blockInputCache.get(blockHex) ?? getEmptyBlockInputCacheEntry(fork);
 
       // TODO: freetheblobs check if its the same blob or a duplicate and throw/take actions
-      blockCache.cachedData?.blobsCache.set(blobSidecar.index, {
-        blobSidecar,
-      });
+      blockCache.cachedData?.blobsCache.set(blobSidecar.index, blobSidecar);
     }
 
     if (!this.blockInputCache.has(blockHex)) {

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -345,6 +345,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
 
       const signedBlock = sszDeserialize(topic, serializedData);
       const blockInput = await validateBeaconBlock(signedBlock, topic.fork, peerIdStr, seenTimestampSec);
+      chain.serializedCache.set(signedBlock, serializedData);
       handleValidBeaconBlock(blockInput, peerIdStr, seenTimestampSec);
     },
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -115,7 +115,6 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
 
   async function validateBeaconBlock(
     signedBlock: SignedBeaconBlock,
-    blockBytes: Uint8Array,
     fork: ForkName,
     peerIdStr: string,
     seenTimestampSec: number
@@ -132,7 +131,6 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       {
         type: GossipedInputType.block,
         signedBlock,
-        blockBytes,
       },
       metrics
     );
@@ -189,7 +187,6 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
 
   async function validateBeaconBlob(
     blobSidecar: deneb.BlobSidecar,
-    blobBytes: Uint8Array,
     subnet: SubnetID,
     peerIdStr: string,
     seenTimestampSec: number
@@ -208,7 +205,6 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       {
         type: GossipedInputType.blob,
         blobSidecar,
-        blobBytes,
       },
       metrics
     );
@@ -348,13 +344,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       const {serializedData} = gossipData;
 
       const signedBlock = sszDeserialize(topic, serializedData);
-      const blockInput = await validateBeaconBlock(
-        signedBlock,
-        serializedData,
-        topic.fork,
-        peerIdStr,
-        seenTimestampSec
-      );
+      const blockInput = await validateBeaconBlock(signedBlock, topic.fork, peerIdStr, seenTimestampSec);
       handleValidBeaconBlock(blockInput, peerIdStr, seenTimestampSec);
     },
 
@@ -372,13 +362,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       if (config.getForkSeq(blobSlot) < ForkSeq.deneb) {
         throw new GossipActionError(GossipAction.REJECT, {code: "PRE_DENEB_BLOCK"});
       }
-      const blockInput = await validateBeaconBlob(
-        blobSidecar,
-        serializedData,
-        topic.subnet,
-        peerIdStr,
-        seenTimestampSec
-      );
+      const blockInput = await validateBeaconBlob(blobSidecar, topic.subnet, peerIdStr, seenTimestampSec);
       if (blockInput.block !== null) {
         // we can just queue up the blockInput in the processor, but block gossip handler would have already
         // queued it up.

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -100,7 +100,6 @@ export function matchBlockWithBlobs(
         fork: config.getForkName(block.data.message.slot),
         blobs: blobSidecars,
         blobsSource,
-        blobsBytes: Array.from({length: blobKzgCommitmentsLen}, () => null),
       } as BlockInputDataBlobs;
 
       // TODO DENEB: instead of null, pass payload in bytes

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -33,7 +33,7 @@ export async function beaconBlocksMaybeBlobsByRange(
   // Note: Assumes all blocks in the same epoch
   if (config.getForkSeq(startSlot) < ForkSeq.deneb) {
     const blocks = await network.sendBeaconBlocksByRange(peerId, request);
-    return blocks.map((block) => getBlockInput.preData(config, block.data, BlockSource.byRange, block.bytes));
+    return blocks.map((block) => getBlockInput.preData(config, block.data, BlockSource.byRange));
   }
 
   // From Deneb
@@ -49,7 +49,7 @@ export async function beaconBlocksMaybeBlobsByRange(
 
   // Data is out of range, only request blocks
   const blocks = await network.sendBeaconBlocksByRange(peerId, request);
-  return blocks.map((block) => getBlockInput.outOfRangeData(config, block.data, BlockSource.byRange, block.bytes));
+  return blocks.map((block) => getBlockInput.outOfRangeData(config, block.data, BlockSource.byRange));
 }
 
 // Assumes that the blobs are in the same sequence as blocks, doesn't require block to be sorted
@@ -74,7 +74,7 @@ export function matchBlockWithBlobs(
   for (let i = 0; i < allBlocks.length; i++) {
     const block = allBlocks[i];
     if (config.getForkSeq(block.data.message.slot) < ForkSeq.deneb) {
-      blockInputs.push(getBlockInput.preData(config, block.data, blockSource, block.bytes));
+      blockInputs.push(getBlockInput.preData(config, block.data, blockSource));
     } else {
       const blobSidecars: deneb.BlobSidecar[] = [];
 
@@ -104,7 +104,7 @@ export function matchBlockWithBlobs(
       } as BlockInputDataBlobs;
 
       // TODO DENEB: instead of null, pass payload in bytes
-      blockInputs.push(getBlockInput.availableData(config, block.data, blockSource, null, blockData));
+      blockInputs.push(getBlockInput.availableData(config, block.data, blockSource, blockData));
     }
   }
 

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -135,7 +135,7 @@ export async function unavailableBeaconBlobsByRoot(
           const {blob, proof: kzgProof} = catchedBlobAndProof;
           const kzgCommitmentInclusionProof = computeInclusionProof(fork, block.message.body, index);
           const blobSidecar = {index, blob, kzgCommitment, kzgProof, signedBlockHeader, kzgCommitmentInclusionProof};
-          blobsCache.set(blobSidecar.index, {blobSidecar});
+          blobsCache.set(blobSidecar.index, blobSidecar);
         }
       } else if (blockTriedBefore) {
         // only retry it from network
@@ -176,7 +176,7 @@ export async function unavailableBeaconBlobsByRoot(
         // add them in cache so that its reflected in all the blockInputs that carry this
         // for e.g. a blockInput that might be awaiting blobs promise fullfillment in
         // verifyBlocksDataAvailability
-        blobsCache.set(blobSidecar.index, {blobSidecar});
+        blobsCache.set(blobSidecar.index, blobSidecar);
       } else {
         metrics?.blockInputFetchStats.dataPromiseBlobsDelayedGossipAvailable.inc();
         metrics?.blockInputFetchStats.dataPromiseBlobsDeplayedGossipAvailableSavedGetBlobsCompute.inc();
@@ -239,7 +239,7 @@ export async function unavailableBeaconBlobsByRoot(
   // for e.g. a blockInput that might be awaiting blobs promise fullfillment in
   // verifyBlocksDataAvailability
   for (const blobSidecar of networkResBlobSidecars) {
-    blobsCache.set(blobSidecar.index, {blobSidecar});
+    blobsCache.set(blobSidecar.index, blobSidecar);
   }
 
   // check and see if all blobs are now available and in that case resolve availability

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -82,17 +82,15 @@ export async function unavailableBeaconBlobsByRoot(
   // resolve the block if thats unavailable
   let block: SignedBeaconBlock,
     blobsCache: NullBlockInput["cachedData"]["blobsCache"],
-    blockBytes: Uint8Array | null,
     resolveAvailability: NullBlockInput["cachedData"]["resolveAvailability"],
     cachedData: NullBlockInput["cachedData"];
   if (unavailableBlockInput.block === null) {
     const allBlocks = await network.sendBeaconBlocksByRoot(peerId, [fromHex(unavailableBlockInput.blockRootHex)]);
     block = allBlocks[0].data;
-    blockBytes = allBlocks[0].bytes;
     cachedData = unavailableBlockInput.cachedData;
     ({blobsCache, resolveAvailability} = cachedData);
   } else {
-    ({block, cachedData, blockBytes} = unavailableBlockInput);
+    ({block, cachedData} = unavailableBlockInput);
     ({blobsCache, resolveAvailability} = cachedData);
   }
 
@@ -137,7 +135,7 @@ export async function unavailableBeaconBlobsByRoot(
           const {blob, proof: kzgProof} = catchedBlobAndProof;
           const kzgCommitmentInclusionProof = computeInclusionProof(fork, block.message.body, index);
           const blobSidecar = {index, blob, kzgCommitment, kzgProof, signedBlockHeader, kzgCommitmentInclusionProof};
-          blobsCache.set(blobSidecar.index, {blobSidecar, blobBytes: null});
+          blobsCache.set(blobSidecar.index, {blobSidecar});
         }
       } else if (blockTriedBefore) {
         // only retry it from network
@@ -178,7 +176,7 @@ export async function unavailableBeaconBlobsByRoot(
         // add them in cache so that its reflected in all the blockInputs that carry this
         // for e.g. a blockInput that might be awaiting blobs promise fullfillment in
         // verifyBlocksDataAvailability
-        blobsCache.set(blobSidecar.index, {blobSidecar, blobBytes: null});
+        blobsCache.set(blobSidecar.index, {blobSidecar});
       } else {
         metrics?.blockInputFetchStats.dataPromiseBlobsDelayedGossipAvailable.inc();
         metrics?.blockInputFetchStats.dataPromiseBlobsDeplayedGossipAvailableSavedGetBlobsCompute.inc();
@@ -241,7 +239,7 @@ export async function unavailableBeaconBlobsByRoot(
   // for e.g. a blockInput that might be awaiting blobs promise fullfillment in
   // verifyBlocksDataAvailability
   for (const blobSidecar of networkResBlobSidecars) {
-    blobsCache.set(blobSidecar.index, {blobSidecar, blobBytes: null});
+    blobsCache.set(blobSidecar.index, {blobSidecar});
   }
 
   // check and see if all blobs are now available and in that case resolve availability
@@ -263,5 +261,5 @@ export async function unavailableBeaconBlobsByRoot(
     metrics?.blockInputFetchStats.totalDataPromiseBlockInputsRetriedAvailableFromNetwork.inc();
   }
 
-  return getBlockInput.availableData(config, block, BlockSource.byRoot, blockBytes, blockData);
+  return getBlockInput.availableData(config, block, BlockSource.byRoot, blockData);
 }

--- a/packages/beacon-node/src/util/serializedCache.ts
+++ b/packages/beacon-node/src/util/serializedCache.ts
@@ -1,0 +1,21 @@
+/**
+ * A cache to store the serialized version of an object
+ *
+ * This is a thin wrapper around WeakMap
+ */
+export class SerializedCache {
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+  map: WeakMap<any, Uint8Array> = new WeakMap();
+
+  get<T>(obj: T): Uint8Array | undefined {
+    return this.map.get(obj);
+  }
+
+  set<T>(obj: T, serialized: Uint8Array): void {
+    this.map.set(obj, serialized);
+  }
+
+  clear(): void {
+    this.map = new WeakMap();
+  }
+}

--- a/packages/beacon-node/src/util/serializedCache.ts
+++ b/packages/beacon-node/src/util/serializedCache.ts
@@ -4,14 +4,13 @@
  * This is a thin wrapper around WeakMap
  */
 export class SerializedCache {
-  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-  map: WeakMap<any, Uint8Array> = new WeakMap();
+  map: WeakMap<object, Uint8Array> = new WeakMap();
 
-  get<T>(obj: T): Uint8Array | undefined {
+  get(obj: object): Uint8Array | undefined {
     return this.map.get(obj);
   }
 
-  set<T>(obj: T, serialized: Uint8Array): void {
+  set(obj: object, serialized: Uint8Array): void {
     this.map.set(obj, serialized);
   }
 

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -89,7 +89,6 @@ describe("data serialization through worker boundary", () => {
         type: BlockInputType.preData,
         block: ssz.capella.SignedBeaconBlock.defaultValue(),
         source: BlockSource.gossip,
-        blockBytes: Uint8Array.from(ZERO_HASH),
       },
       peer,
     },
@@ -265,7 +264,6 @@ function getEmptyBlockInput(): BlockInput {
     type: BlockInputType.dataPromise,
     block: ssz.deneb.SignedBeaconBlock.defaultValue(),
     source: BlockSource.gossip,
-    blockBytes: Uint8Array.from(ZERO_HASH),
     cachedData,
   };
 }

--- a/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
@@ -121,7 +121,7 @@ describe("sync / unknown block sync", () => {
       await connected;
       loggerNodeA.info("Node A connected to Node B");
 
-      const headInput = getBlockInput.preData(config, head, BlockSource.gossip, null);
+      const headInput = getBlockInput.preData(config, head, BlockSource.gossip);
 
       switch (event) {
         case NetworkEvent.unknownBlockParent:

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -105,9 +105,7 @@ describe.skip("verify+import blocks - range sync perf test", () => {
       return chain;
     },
     fn: async (chain) => {
-      const blocksImport = blocks.value.map((block) =>
-        getBlockInput.preData(chain.config, block, BlockSource.byRange, null)
-      );
+      const blocksImport = blocks.value.map((block) => getBlockInput.preData(chain.config, block, BlockSource.byRange));
 
       await chain.processChainSegment(blocksImport, {
         // Only skip importing attestations for finalized sync. For head sync attestation are valuable.

--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -223,14 +223,13 @@ const forkChoiceTest =
                     };
                   });
 
-                  blockImport = getBlockInput.availableData(config, signedBlock, BlockSource.gossip, null, {
+                  blockImport = getBlockInput.availableData(config, signedBlock, BlockSource.gossip, {
                     fork: ForkName.deneb,
                     blobs: blobSidecars,
-                    blobsBytes: [null],
                     blobsSource: BlobsSource.gossip,
                   });
                 } else {
-                  blockImport = getBlockInput.preData(config, signedBlock, BlockSource.gossip, null);
+                  blockImport = getBlockInput.preData(config, signedBlock, BlockSource.gossip);
                 }
 
                 await chain.processBlock(blockImport, {

--- a/packages/beacon-node/test/unit/chain/blocks/verifyBlocksSanityChecks.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/verifyBlocksSanityChecks.test.ts
@@ -126,7 +126,7 @@ function verifyBlocksSanityChecks(
 ): {relevantBlocks: SignedBeaconBlock[]; parentSlots: Slot[]; parentBlock: ProtoBlock | null} {
   const {relevantBlocks, parentSlots, parentBlock} = verifyBlocksImportSanityChecks(
     modules,
-    blocks.map((block) => getBlockInput.preData(config, block, BlockSource.byRange, null)),
+    blocks.map((block) => getBlockInput.preData(config, block, BlockSource.byRange)),
     opts
   );
   return {

--- a/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
@@ -109,7 +109,6 @@ describe("SeenGossipBlockInput", () => {
               {
                 type: GossipedInputType.block,
                 signedBlock,
-                blockBytes: null,
               },
               null
             );
@@ -131,7 +130,6 @@ describe("SeenGossipBlockInput", () => {
               {
                 type: GossipedInputType.blob,
                 blobSidecar,
-                blobBytes: null,
               },
               null
             );

--- a/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
@@ -100,11 +100,10 @@ describe("beaconBlocksMaybeBlobsByRange", () => {
 
       const expectedResponse = blocksWithBlobs.map(([block, blobSidecars]) => {
         const blobs = blobSidecars !== undefined ? blobSidecars : [];
-        return getBlockInput.availableData(config, block, BlockSource.byRange, null, {
+        return getBlockInput.availableData(config, block, BlockSource.byRange, {
           fork: ForkName.electra,
           blobs,
           blobsSource: BlobsSource.byRange,
-          blobsBytes: blobs.map(() => null),
         });
       });
 

--- a/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
+++ b/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
@@ -177,7 +177,7 @@ describe("unavailableBeaconBlobsByRoot", () => {
       blobsBytes: [null, null, null, null, null],
       blobsSource: BlobsSource.byRoot,
     };
-    const resolvedBlobs = getBlockInput.availableData(config, signedBlock, BlockSource.byRoot, null, blockData);
+    const resolvedBlobs = getBlockInput.availableData(config, signedBlock, BlockSource.byRoot, blockData);
 
     const engineReqIdentifiers = [...blobscommitmentsandproofs.blobVersionedHashes];
     // versionedHashes: 1,2,4
@@ -191,7 +191,6 @@ describe("unavailableBeaconBlobsByRoot", () => {
 type BlockInputCacheType = {
   fork: ForkName;
   block?: SignedBeaconBlock;
-  blockBytes?: Uint8Array | null;
   cachedData?: CachedData;
   // block promise and its callback cached for delayed resolution
   blockInputPromise: Promise<BlockInput>;

--- a/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
+++ b/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
@@ -174,7 +174,6 @@ describe("unavailableBeaconBlobsByRoot", () => {
     const blockData = {
       fork: ForkName.deneb as ForkBlobs,
       blobs: allBlobs,
-      blobsBytes: [null, null, null, null, null],
       blobsSource: BlobsSource.byRoot,
     };
     const resolvedBlobs = getBlockInput.availableData(config, signedBlock, BlockSource.byRoot, blockData);

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -12,7 +12,7 @@ describe("sync / range / batch", () => {
   const startEpoch = 0;
   const peer = validPeerIdStr;
   const blocksDownloaded = [
-    getBlockInput.preData(config, ssz.phase0.SignedBeaconBlock.defaultValue(), BlockSource.byRange, null),
+    getBlockInput.preData(config, ssz.phase0.SignedBeaconBlock.defaultValue(), BlockSource.byRange),
   ];
 
   it("Should return correct blockByRangeRequest", () => {

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -89,8 +89,7 @@ describe("sync / range / chain", () => {
                 message: generateEmptyBlock(i),
                 signature: shouldReject ? REJECT_BLOCK : ACCEPT_BLOCK,
               },
-              BlockSource.byRange,
-              null
+              BlockSource.byRange
             )
           );
         }
@@ -134,8 +133,7 @@ describe("sync / range / chain", () => {
               message: generateEmptyBlock(i),
               signature: ACCEPT_BLOCK,
             },
-            BlockSource.byRange,
-            null
+            BlockSource.byRange
           )
         );
       }

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -193,7 +193,7 @@ describe("sync by UnknownBlockSync", () => {
       syncService.subscribeToNetwork();
       if (event === NetworkEvent.unknownBlockParent) {
         network.events?.emit(NetworkEvent.unknownBlockParent, {
-          blockInput: getBlockInput.preData(config, blockC, BlockSource.gossip, null),
+          blockInput: getBlockInput.preData(config, blockC, BlockSource.gossip),
           peer,
         });
       } else {


### PR DESCRIPTION
**Motivation**

- Part of an effort to begin simplifying our block import process
- Investigating the code, it appears we are storing serialized data alongside the deserialized data.
- We do this so that we don't pay for reserialization
- This cached serialized data is currently only used for blocks, to avoid reserializatoin when storing to disk
- Passing optional serialized data everywhere is cumbersome and introduces cognitive burden
- It can be accomplished via a WeakMap instead

**Description**
- Use WeakMap to store block serialized bytes
  - add to cache after gossip validation
- blobBytes were not used anywhere before, this PR doesn't reintroduce them