### PR TITLE
fix: do not register validator statuses for epoch -1

### DIFF
--- a/packages/beacon-node/src/metrics/validatorMonitor.ts
+++ b/packages/beacon-node/src/metrics/validatorMonitor.ts
@@ -306,6 +306,11 @@ export function createValidatorMonitor(
       lastRegisteredStatusEpoch = currentEpoch;
       const previousEpoch = currentEpoch - 1;
 
+      // There won't be any validator activity in epoch -1
+      if (previousEpoch === -1) {
+        return;
+      }
+
       for (const [index, monitoredValidator] of validators.entries()) {
         // We subtract two from the state of the epoch that generated these summaries.
         //


### PR DESCRIPTION
**Motivation**

Follow up on https://github.com/ChainSafe/lodestar/pull/6791 to skip validator monitor updates for epoch -1.

This will cause wrong failed attestation reports
```
Failed attestation in previous epoch validator=468, prevEpoch=-1, isPrevSourceAttester=false, isPrevHeadAttester=false, isPrevTargetAttester=false, inclusionDistance=null
```

**Description**

Do not register validator statuses for epoch -1
