### PR TITLE
chore: bump CL spec version to beta.1

### DIFF
--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -14,7 +14,7 @@ import {DownloadTestsOptions} from "@lodestar/spec-test-util/downloadTests";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: DownloadTestsOptions = {
-  specVersion: "v1.5.0-beta.0",
+  specVersion: "v1.5.0-beta.1",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-spec-tests",

--- a/packages/params/test/e2e/ensure-config-is-synced.test.ts
+++ b/packages/params/test/e2e/ensure-config-is-synced.test.ts
@@ -8,7 +8,7 @@ import {loadConfigYaml} from "../yaml.js";
 // Not e2e, but slow. Run with e2e tests
 
 /** https://github.com/ethereum/consensus-specs/releases */
-const specConfigCommit = "v1.5.0-beta.0";
+const specConfigCommit = "v1.5.0-beta.1";
 /**
  * Fields that we filter from local config when doing comparison.
  * Ideally this should be empty as it is not spec compliant


### PR DESCRIPTION
Run against latest spec, there are a bunch of good new test cases (eg. https://github.com/ethereum/consensus-specs/pull/4090)