### PR TITLE
chore: use multi fork type for IndexedAttestation

### DIFF
--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -4,7 +4,7 @@ import {
   createAggregateSignatureSetFromComponents,
   isAggregatorFromCommitteeLength,
 } from "@lodestar/state-transition";
-import {IndexedAttestation, RootHex, SignedAggregateAndProof, electra, phase0, ssz} from "@lodestar/types";
+import {IndexedAttestation, RootHex, SignedAggregateAndProof, electra, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors/index.js";
 import {IBeaconChain} from "../index.js";
@@ -178,15 +178,11 @@ async function validateAggregateAndProof(
   }
   const attestingIndices = aggregate.aggregationBits.intersectValues(committeeIndices);
 
-  const indexedAttestationContent: IndexedAttestation = {
+  const indexedAttestation: IndexedAttestation = {
     attestingIndices,
     data: attData,
     signature: aggregate.signature,
   };
-  const indexedAttestation =
-    ForkSeq[fork] >= ForkSeq.electra
-      ? (indexedAttestationContent as electra.IndexedAttestation)
-      : (indexedAttestationContent as phase0.IndexedAttestation);
 
   // TODO: Check this before regen
   // [REJECT] The attestation has participants -- that is,

--- a/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -9,7 +9,7 @@ import {
   getEffectiveBalanceIncrementsZeroed,
 } from "@lodestar/state-transition";
 import {getTemporaryBlockHeader, processSlots} from "@lodestar/state-transition";
-import {Slot, ValidatorIndex, phase0, ssz} from "@lodestar/types";
+import {IndexedAttestation, Slot, ValidatorIndex, phase0, ssz} from "@lodestar/types";
 import {beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {ChainEventEmitter, initializeForkChoice} from "../../../../src/chain/index.js";
 import {createCachedBeaconStateTest} from "../../../utils/cachedBeaconState.js";
@@ -418,7 +418,7 @@ function createIndexedAttestation(
   target: phase0.SignedBeaconBlock,
   block: phase0.SignedBeaconBlock,
   validatorIndex: ValidatorIndex
-): phase0.IndexedAttestation {
+): IndexedAttestation {
   return {
     attestingIndices: [validatorIndex],
     data: {

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -13,7 +13,18 @@ import {
   isExecutionStateType,
 } from "@lodestar/state-transition";
 import {computeUnrealizedCheckpoints} from "@lodestar/state-transition/epoch";
-import {BeaconBlock, Epoch, Root, RootHex, Slot, ValidatorIndex, bellatrix, phase0, ssz} from "@lodestar/types";
+import {
+  BeaconBlock,
+  Epoch,
+  IndexedAttestation,
+  Root,
+  RootHex,
+  Slot,
+  ValidatorIndex,
+  bellatrix,
+  phase0,
+  ssz,
+} from "@lodestar/types";
 import {Logger, MapDef, fromHex, toRootHex} from "@lodestar/utils";
 
 import {computeDeltas} from "../protoArray/computeDeltas.js";
@@ -686,7 +697,7 @@ export class ForkChoice implements IForkChoice {
    * The supplied `attestation` **must** pass the `in_valid_indexed_attestation` function as it
    * will not be run here.
    */
-  onAttestation(attestation: phase0.IndexedAttestation, attDataRoot: string, forceImport?: boolean): void {
+  onAttestation(attestation: IndexedAttestation, attDataRoot: string, forceImport?: boolean): void {
     // Ignore any attestations to the zero hash.
     //
     // This is an edge case that results from the spec aliasing the zero hash to the genesis
@@ -1199,7 +1210,7 @@ export class ForkChoice implements IForkChoice {
    * https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/fork-choice.md#validate_on_attestation
    */
   private validateOnAttestation(
-    indexedAttestation: phase0.IndexedAttestation,
+    indexedAttestation: IndexedAttestation,
     slot: Slot,
     blockRootHex: string,
     targetEpoch: Epoch,

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -1,5 +1,5 @@
 import {ForkSeq, MAX_COMMITTEES_PER_SLOT, MAX_VALIDATORS_PER_COMMITTEE} from "@lodestar/params";
-import {phase0} from "@lodestar/types";
+import {IndexedAttestation, IndexedAttestationBigint} from "@lodestar/types";
 import {getIndexedAttestationBigintSignatureSet, getIndexedAttestationSignatureSet} from "../signatureSets/index.js";
 import {CachedBeaconStateAllForks} from "../types.js";
 import {verifySignatureSet} from "../util/index.js";
@@ -9,7 +9,7 @@ import {verifySignatureSet} from "../util/index.js";
  */
 export function isValidIndexedAttestation(
   state: CachedBeaconStateAllForks,
-  indexedAttestation: phase0.IndexedAttestation,
+  indexedAttestation: IndexedAttestation,
   verifySignature: boolean
 ): boolean {
   if (!isValidIndexedAttestationIndices(state, indexedAttestation.attestingIndices)) {
@@ -24,7 +24,7 @@ export function isValidIndexedAttestation(
 
 export function isValidIndexedAttestationBigint(
   state: CachedBeaconStateAllForks,
-  indexedAttestation: phase0.IndexedAttestationBigint,
+  indexedAttestation: IndexedAttestationBigint,
   verifySignature: boolean
 ): boolean {
   if (!isValidIndexedAttestationIndices(state, indexedAttestation.attestingIndices)) {

--- a/packages/state-transition/src/signatureSets/indexedAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedAttestation.ts
@@ -1,5 +1,5 @@
 import {DOMAIN_BEACON_ATTESTER} from "@lodestar/params";
-import {SignedBeaconBlock, phase0, ssz} from "@lodestar/types";
+import {IndexedAttestation, SignedBeaconBlock, phase0, ssz} from "@lodestar/types";
 import {CachedBeaconStateAllForks} from "../types.js";
 import {
   ISignatureSet,
@@ -32,7 +32,7 @@ export function getAttestationWithIndicesSignatureSet(
 
 export function getIndexedAttestationSignatureSet(
   state: CachedBeaconStateAllForks,
-  indexedAttestation: phase0.IndexedAttestation
+  indexedAttestation: IndexedAttestation
 ): ISignatureSet {
   return getAttestationWithIndicesSignatureSet(state, indexedAttestation, indexedAttestation.attestingIndices);
 }

--- a/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
+++ b/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
@@ -1,6 +1,6 @@
 import {config} from "@lodestar/config/default";
 import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE} from "@lodestar/params";
-import {phase0, ssz} from "@lodestar/types";
+import {IndexedAttestation, ssz} from "@lodestar/types";
 import {describe, expect, it} from "vitest";
 import {isValidIndexedAttestation} from "../../../src/block/isValidIndexedAttestation.js";
 import {EMPTY_SIGNATURE} from "../../../src/index.js";
@@ -40,7 +40,7 @@ describe("validate indexed attestation", () => {
     attestationData.source.epoch = 0;
     attestationData.target.epoch = 1;
 
-    const indexedAttestation: phase0.IndexedAttestation = {
+    const indexedAttestation: IndexedAttestation = {
       attestingIndices: indices,
       data: attestationData,
       signature: EMPTY_SIGNATURE,


### PR DESCRIPTION
Just some cleanup to use multi fork type for `IndexedAttestation` if a function should handle both phase0 and electra.
