### PR TITLE
chore: add electra fork constants to unscheduled networks

### DIFF
--- a/packages/config/src/chainConfig/networks/chiado.ts
+++ b/packages/config/src/chainConfig/networks/chiado.ts
@@ -37,4 +37,7 @@ export const chiadoChainConfig: ChainConfig = {
   // Deneb
   DENEB_FORK_VERSION: b("0x0400006f"),
   DENEB_FORK_EPOCH: 516608, // Wed Jan 31 2024 18:15:40 GMT+0000
+  // Electra
+  ELECTRA_FORK_VERSION: b("0x0500006f"),
+  ELECTRA_FORK_EPOCH: Infinity,
 };

--- a/packages/config/src/chainConfig/networks/ephemery.ts
+++ b/packages/config/src/chainConfig/networks/ephemery.ts
@@ -37,6 +37,9 @@ const baseChainConfig: ChainConfig = {
   // Deneb
   DENEB_FORK_VERSION: b("0x5000101b"),
   DENEB_FORK_EPOCH: 5,
+  // Electra
+  ELECTRA_FORK_VERSION: b("0x6000101b"),
+  ELECTRA_FORK_EPOCH: Infinity,
 
   // Deposit contract
   // ---------------------------------------------------------------

--- a/packages/config/src/chainConfig/networks/gnosis.ts
+++ b/packages/config/src/chainConfig/networks/gnosis.ts
@@ -51,4 +51,7 @@ export const gnosisChainConfig: ChainConfig = {
   // Deneb
   DENEB_FORK_VERSION: b("0x04000064"),
   DENEB_FORK_EPOCH: 889856, // 2024-03-11T18:30:20.000Z
+  // Electra
+  ELECTRA_FORK_VERSION: b("0x05000064"),
+  ELECTRA_FORK_EPOCH: Infinity,
 };


### PR DESCRIPTION
This avoids an issue we had previously where configs that extend mainnet preset would inherit wrong parameters. This just ensures this cannot happen in case we those will be forked after mainnet.
