### PR TITLE
chore: include peer id in batch download logs

### DIFF
--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -2,7 +2,7 @@ import {ChainForkConfig} from "@lodestar/config";
 import {Epoch, Root, Slot, phase0} from "@lodestar/types";
 import {ErrorAborted, Logger, toRootHex} from "@lodestar/utils";
 import {BlockInput, BlockInputType} from "../../chain/blocks/types.js";
-import {PeerAction, prettyPrintPeerId, prettyPrintPeerIdStr} from "../../network/index.js";
+import {PeerAction, prettyPrintPeerIdStr} from "../../network/index.js";
 import {ItTrigger} from "../../util/itTrigger.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {wrapError} from "../../util/wrapError.js";

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -2,7 +2,7 @@ import {ChainForkConfig} from "@lodestar/config";
 import {Epoch, Root, Slot, phase0} from "@lodestar/types";
 import {ErrorAborted, Logger, toRootHex} from "@lodestar/utils";
 import {BlockInput, BlockInputType} from "../../chain/blocks/types.js";
-import {PeerAction} from "../../network/index.js";
+import {PeerAction, prettyPrintPeerId, prettyPrintPeerIdStr} from "../../network/index.js";
 import {ItTrigger} from "../../util/itTrigger.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {wrapError} from "../../util/wrapError.js";
@@ -410,10 +410,19 @@ export class SyncChain {
         if (hasPostDenebBlocks) {
           Object.assign(downloadInfo, {blobs});
         }
-        this.logger.debug("Downloaded batch", {id: this.logId, ...batch.getMetadata(), ...downloadInfo});
+        this.logger.debug("Downloaded batch", {
+          id: this.logId,
+          ...batch.getMetadata(),
+          ...downloadInfo,
+          peer: prettyPrintPeerIdStr(peer),
+        });
         this.triggerBatchProcessor();
       } else {
-        this.logger.verbose("Batch download error", {id: this.logId, ...batch.getMetadata()}, res.err);
+        this.logger.verbose(
+          "Batch download error",
+          {id: this.logId, ...batch.getMetadata(), peer: prettyPrintPeerIdStr(peer)},
+          res.err
+        );
         batch.downloadingError(); // Throws after MAX_DOWNLOAD_ATTEMPTS
       }
 


### PR DESCRIPTION
**Motivation**

We've seen a lot of batch download errors when trying to sync a node from far back on devnet-5
```
Jan-27 16:07:08.044[sync]          verbose: Batch download error id=Finalized, startEpoch=97, status=Downloading - Missing blobSidecars for blockSlot=3104 with blobKzgCommitmentsLen=9 blobSidecars=6
Error: Missing blobSidecars for blockSlot=3104 with blobKzgCommitmentsLen=9 blobSidecars=6
```
but from the logs it's hard to tell which peer actually sent the invalid response and logs might get mixed up if we request data from multiple peers at the same time.

**Description**

Include peer id in batch download logs. I opted to only include short peer id (eg. `peer=16...UNpy88`) as this should be sufficient to see to which request it belongs and based on that determine the client.
