### PR TITLE
feat: emit block_gossip event

### DIFF
--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -48,8 +48,10 @@ export enum EventType {
    * Both dependent roots use the genesis block root in the case of underflow.
    */
   head = "head",
-  /** The node has received a valid block (from P2P or API) */
+  /** The node has received a block (from P2P or API) that is successfully imported on the fork-choice `on_block` handler */
   block = "block",
+  /** The node has received a block (from P2P or API) that passes validation rules of the `beacon_block` topic */
+  blockGossip = "block_gossip",
   /** The node has received a valid attestation (from P2P or API) */
   attestation = "attestation",
   /** The node has received a valid SingleAttestation (from P2P or API) */
@@ -81,6 +83,7 @@ export enum EventType {
 export const eventTypes: {[K in EventType]: K} = {
   [EventType.head]: EventType.head,
   [EventType.block]: EventType.block,
+  [EventType.blockGossip]: EventType.blockGossip,
   [EventType.attestation]: EventType.attestation,
   [EventType.singleAttestation]: EventType.singleAttestation,
   [EventType.voluntaryExit]: EventType.voluntaryExit,
@@ -110,6 +113,10 @@ export type EventData = {
     slot: Slot;
     block: RootHex;
     executionOptimistic: boolean;
+  };
+  [EventType.blockGossip]: {
+    slot: Slot;
+    block: RootHex;
   };
   [EventType.attestation]: Attestation;
   [EventType.singleAttestation]: electra.SingleAttestation;
@@ -228,6 +235,13 @@ export function getTypeByEvent(config: ChainForkConfig): {[K in EventType]: Type
         slot: ssz.Slot,
         block: stringType,
         executionOptimistic: ssz.Boolean,
+      },
+      {jsonCase: "eth2"}
+    ),
+    [EventType.blockGossip]: new ContainerType(
+      {
+        slot: ssz.Slot,
+        block: stringType,
       },
       {jsonCase: "eth2"}
     ),

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -75,13 +75,7 @@ const ignoredProperties: Record<string, IgnoredProperty> = {
 const openApiJson = await fetchOpenApiSpec(openApiFile);
 runTestCheckAgainstSpec(openApiJson, definitions, testDatas, ignoredOperations, ignoredProperties);
 
-const ignoredTopics = [
-  /*
-   https://github.com/ChainSafe/lodestar/issues/6470
-   topic block_gossip not implemented
-   */
-  "block_gossip",
-];
+const ignoredTopics: string[] = [];
 
 // eventstream types are defined as comments in the description of "examples".
 // The function runTestCheckAgainstSpec() can't handle those, so the custom code before:

--- a/packages/api/test/unit/beacon/testData/events.ts
+++ b/packages/api/test/unit/beacon/testData/events.ts
@@ -29,6 +29,10 @@ export const eventTestData: EventData = {
     block: "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf",
     executionOptimistic: false,
   },
+  [EventType.blockGossip]: {
+    slot: 10,
+    block: "0x9a2fefd2fdb57f74993c7780ea5b9030d2897b615b89f808011ca5aebed54eaf",
+  },
   [EventType.attestation]: ssz.phase0.Attestation.fromJson({
     aggregation_bits: "0x01",
     signature:

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -198,6 +198,8 @@ export function getBeaconBlockApi({
       }
     }
 
+    chain.emitter.emit(routes.events.EventType.blockGossip, {slot, block: blockRoot});
+
     // Simple implementation of a pending block queue. Keeping the block here recycles the API logic, and keeps the
     // REST request promise without any extra infrastructure.
     const msToBlockSlot =

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -198,8 +198,6 @@ export function getBeaconBlockApi({
       }
     }
 
-    chain.emitter.emit(routes.events.EventType.blockGossip, {slot, block: blockRoot});
-
     // Simple implementation of a pending block queue. Keeping the block here recycles the API logic, and keeps the
     // REST request promise without any extra infrastructure.
     const msToBlockSlot =
@@ -208,6 +206,8 @@ export function getBeaconBlockApi({
       // If block is a bit early, hold it in a promise. Equivalent to a pending queue.
       await sleep(msToBlockSlot);
     }
+
+    chain.emitter.emit(routes.events.EventType.blockGossip, {slot, block: blockRoot});
 
     // TODO: Validate block
     metrics?.registerBeaconBlock(OpSource.api, seenTimestampSec, blockForImport.block.message);


### PR DESCRIPTION
**Motivation**

See https://github.com/ethereum/beacon-APIs/pull/405 and https://github.com/ethereum/beacon-APIs/issues/349 for further details  and rationale for why we want two different block events.

**Description**

Emit `block_gossip` SSE event when receiving a block through gossip or api that passes validation rules of the `beacon_block` topic.

On the api the validation might be skipped if the block was produced locally or a different broadcast validation is requested by the client but by default it will use gossip validation rules.

Closes https://github.com/ChainSafe/lodestar/issues/6470

