### PR TITLE
feat: eip-6110 deprecate eth1 data poll

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -6,6 +6,7 @@ import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock, UpdateHeadO
 import {ForkSeq, GENESIS_SLOT, SLOTS_PER_EPOCH, isForkPostElectra} from "@lodestar/params";
 import {
   BeaconStateAllForks,
+  BeaconStateElectra,
   CachedBeaconStateAllForks,
   EffectiveBalanceIncrements,
   EpochShuffling,
@@ -351,10 +352,13 @@ export class BeaconChain implements IBeaconChain {
 
     this.archiver = new Archiver(db, this, logger, signal, opts, metrics);
 
-    // Stop polling eth1 data if anchor state is in Electra
-    const anchorStateFork = this.config.getForkName(cachedState.slot);
+    // Stop polling eth1 data if anchor state is in Electra AND deposit_requests_start_index is reached
+    const anchorStateFork = this.config.getForkName(anchorState.slot);
     if (isForkPostElectra(anchorStateFork)) {
-      this.eth1.stopPollingEth1Data();
+      const {eth1DepositIndex, depositRequestsStartIndex} = anchorState as BeaconStateElectra;
+      if (eth1DepositIndex === Number(depositRequestsStartIndex)) {
+        this.eth1.stopPollingEth1Data();
+      }
     }
 
     // always run PrepareNextSlotScheduler except for fork_choice spec tests

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -3,7 +3,7 @@ import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
 import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
-import {ForkSeq, GENESIS_SLOT, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkSeq, GENESIS_SLOT, SLOTS_PER_EPOCH, isForkPostElectra} from "@lodestar/params";
 import {
   BeaconStateAllForks,
   CachedBeaconStateAllForks,
@@ -350,6 +350,13 @@ export class BeaconChain implements IBeaconChain {
     this.serializedCache = new SerializedCache();
 
     this.archiver = new Archiver(db, this, logger, signal, opts, metrics);
+
+    // Stop polling eth1 data if anchor state is in Electra
+    const anchorStateFork = this.config.getForkName(cachedState.slot);
+    if (isForkPostElectra(anchorStateFork)) {
+      this.eth1.stopPollingEth1Data();
+    }
+
     // always run PrepareNextSlotScheduler except for fork_choice spec tests
     if (!opts?.disablePrepareNextSlot) {
       new PrepareNextSlotScheduler(this, this.config, metrics, this.logger, signal);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1143,16 +1143,6 @@ export class BeaconChain implements IBeaconChain {
     if (headState === null) {
       this.logger.verbose("Head state is null");
     }
-
-    // TODO-Electra: Deprecating eth1Data poll requires a check on a finalized checkpoint state.
-    // Will resolve this later
-    // if (cpEpoch >= (this.config.ELECTRA_FORK_EPOCH ?? Infinity)) {
-    //   // finalizedState can be safely casted to Electra state since cp is already post-Electra
-    //   if (finalizedState.eth1DepositIndex >= (finalizedState as CachedBeaconStateElectra).depositRequestsStartIndex) {
-    //     // Signal eth1 to stop polling eth1Data
-    //     this.eth1.stopPollingEth1Data();
-    //   }
-    // }
   }
 
   async updateBeaconProposerData(epoch: Epoch, proposers: ProposerPreparationData[]): Promise<void> {

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -249,16 +249,18 @@ export class PrepareNextSlotScheduler {
    * Stop eth1 data polling after eth1DepositIndex has reached depositRequestsStartIndex in Electra as described in EIP-6110
    */
   stopEth1Polling(): void {
-    // Only continue if eth1 is still polling. State regen is expensive
-    if (this.chain.eth1.isPollingEth1Data()) {
+    const clockSlot = this.chain.clock.currentSlot;
+    const clockFork = this.config.getForkName(clockSlot);
+    // Only continue if eth1 is still polling and clock is in Electra. State regen is expensive
+    if (this.chain.eth1.isPollingEth1Data() && isForkPostElectra(clockFork)) {
       const finalizedCheckpoint = this.chain.forkChoice.getFinalizedCheckpoint();
-      const fork = this.config.getForkInfoAtEpoch(finalizedCheckpoint.epoch).name;
+      const checkpointFork = this.config.getForkInfoAtEpoch(finalizedCheckpoint.epoch).name;
 
-      if (isForkPostElectra(fork)) {
+      if (isForkPostElectra(checkpointFork)) {
         const finalizedState = this.chain.getStateByCheckpoint(finalizedCheckpoint)?.state;
         if (
           finalizedState !== undefined &&
-          finalizedState.eth1DepositIndex >= (finalizedState as BeaconStateElectra).depositRequestsStartIndex
+          finalizedState.eth1DepositIndex === Number((finalizedState as BeaconStateElectra).depositRequestsStartIndex)
         ) {
           // Signal eth1 to stop polling eth1Data
           this.chain.eth1.stopPollingEth1Data();

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -1,11 +1,14 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkExecution, ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkExecution, ForkSeq, SLOTS_PER_EPOCH, isForkPostElectra} from "@lodestar/params";
 import {
+  BeaconStateElectra,
   CachedBeaconStateAllForks,
   CachedBeaconStateExecutions,
   StateHashTreeRootSource,
+  computeEndSlotAtEpoch,
   computeEpochAtSlot,
+  computeStartSlotAtEpoch,
   computeTimeAtSlot,
   isExecutionStateType,
 } from "@lodestar/state-transition";
@@ -214,6 +217,7 @@ export class PrepareNextSlotScheduler {
           this.metrics?.precomputeNextEpochTransition.waste.inc();
         }
         this.metrics?.precomputeNextEpochTransition.hits.set(previousHits ?? 0);
+        this.stopEth1Polling();
         this.logger.verbose("Completed PrepareNextSlotScheduler epoch transition", {
           nextEpoch,
           headSlot,
@@ -239,5 +243,27 @@ export class PrepareNextSlotScheduler {
     });
     state.hashTreeRoot();
     hashTreeRootTimer?.();
+  }
+
+  /**
+   * Stop eth1 data polling after eth1DepositIndex has reached depositRequestsStartIndex in Electra as described in EIP-6110
+   */
+  stopEth1Polling(): void {
+    // Only continue if eth1 is still polling. State regen is expensive
+    if (this.chain.eth1.isPollingEth1Data()) {
+      const finalizedCheckpoint = this.chain.forkChoice.getFinalizedCheckpoint();
+      const fork = this.config.getForkInfoAtEpoch(finalizedCheckpoint.epoch).name;
+
+      if (isForkPostElectra(fork)) {
+        const finalizedState = this.chain.getStateByCheckpoint(finalizedCheckpoint)?.state;
+        if (
+          finalizedState !== undefined &&
+          finalizedState.eth1DepositIndex >= (finalizedState as BeaconStateElectra).depositRequestsStartIndex
+        ) {
+          // Signal eth1 to stop polling eth1Data
+          this.chain.eth1.stopPollingEth1Data();
+        }
+      }
+    }
   }
 }

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -216,10 +216,8 @@ export class PrepareNextSlotScheduler {
         }
         this.metrics?.precomputeNextEpochTransition.hits.set(previousHits ?? 0);
 
-        if (isForkPostElectra(this.config.getForkName(clockSlot))) {
-          // Check if we can stop polling eth1 data
-          this.stopEth1Polling();
-        }
+        // Check if we can stop polling eth1 data
+        this.stopEth1Polling();
 
         this.logger.verbose("Completed PrepareNextSlotScheduler epoch transition", {
           nextEpoch,
@@ -252,17 +250,21 @@ export class PrepareNextSlotScheduler {
    * Stop eth1 data polling after eth1_deposit_index has reached deposit_requests_start_index in Electra as described in EIP-6110
    */
   stopEth1Polling(): void {
-    // Only continue if eth1 is still polling. State regen is expensive
+    // Only continue if eth1 is still polling and finalized checkpoint is in Electra. State regen is expensive
     if (this.chain.eth1.isPollingEth1Data()) {
       const finalizedCheckpoint = this.chain.forkChoice.getFinalizedCheckpoint();
-      const finalizedState = this.chain.getStateByCheckpoint(finalizedCheckpoint)?.state;
+      const checkpointFork = this.config.getForkInfoAtEpoch(finalizedCheckpoint.epoch).name;
 
-      if (
-        finalizedState !== undefined &&
-        finalizedState.eth1DepositIndex === Number((finalizedState as BeaconStateElectra).depositRequestsStartIndex)
-      ) {
-        // Signal eth1 to stop polling eth1Data
-        this.chain.eth1.stopPollingEth1Data();
+      if (isForkPostElectra(checkpointFork)) {
+        const finalizedState = this.chain.getStateByCheckpoint(finalizedCheckpoint)?.state;
+
+        if (
+          finalizedState !== undefined &&
+          finalizedState.eth1DepositIndex === Number((finalizedState as BeaconStateElectra).depositRequestsStartIndex)
+        ) {
+          // Signal eth1 to stop polling eth1Data
+          this.chain.eth1.stopPollingEth1Data();
+        }
       }
     }
   }

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -6,9 +6,7 @@ import {
   CachedBeaconStateAllForks,
   CachedBeaconStateExecutions,
   StateHashTreeRootSource,
-  computeEndSlotAtEpoch,
   computeEpochAtSlot,
-  computeStartSlotAtEpoch,
   computeTimeAtSlot,
   isExecutionStateType,
 } from "@lodestar/state-transition";
@@ -217,7 +215,12 @@ export class PrepareNextSlotScheduler {
           this.metrics?.precomputeNextEpochTransition.waste.inc();
         }
         this.metrics?.precomputeNextEpochTransition.hits.set(previousHits ?? 0);
-        this.stopEth1Polling();
+
+        if (isForkPostElectra(this.config.getForkName(clockSlot))) {
+          // Check if we can stop polling eth1 data
+          this.stopEth1Polling();
+        }
+
         this.logger.verbose("Completed PrepareNextSlotScheduler epoch transition", {
           nextEpoch,
           headSlot,
@@ -246,25 +249,20 @@ export class PrepareNextSlotScheduler {
   }
 
   /**
-   * Stop eth1 data polling after eth1DepositIndex has reached depositRequestsStartIndex in Electra as described in EIP-6110
+   * Stop eth1 data polling after eth1_deposit_index has reached deposit_requests_start_index in Electra as described in EIP-6110
    */
   stopEth1Polling(): void {
-    const clockSlot = this.chain.clock.currentSlot;
-    const clockFork = this.config.getForkName(clockSlot);
-    // Only continue if eth1 is still polling and clock is in Electra. State regen is expensive
-    if (this.chain.eth1.isPollingEth1Data() && isForkPostElectra(clockFork)) {
+    // Only continue if eth1 is still polling. State regen is expensive
+    if (this.chain.eth1.isPollingEth1Data()) {
       const finalizedCheckpoint = this.chain.forkChoice.getFinalizedCheckpoint();
-      const checkpointFork = this.config.getForkInfoAtEpoch(finalizedCheckpoint.epoch).name;
+      const finalizedState = this.chain.getStateByCheckpoint(finalizedCheckpoint)?.state;
 
-      if (isForkPostElectra(checkpointFork)) {
-        const finalizedState = this.chain.getStateByCheckpoint(finalizedCheckpoint)?.state;
-        if (
-          finalizedState !== undefined &&
-          finalizedState.eth1DepositIndex === Number((finalizedState as BeaconStateElectra).depositRequestsStartIndex)
-        ) {
-          // Signal eth1 to stop polling eth1Data
-          this.chain.eth1.stopPollingEth1Data();
-        }
+      if (
+        finalizedState !== undefined &&
+        finalizedState.eth1DepositIndex === Number((finalizedState as BeaconStateElectra).depositRequestsStartIndex)
+      ) {
+        // Signal eth1 to stop polling eth1Data
+        this.chain.eth1.stopPollingEth1Data();
       }
     }
   }

--- a/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
@@ -88,7 +88,6 @@ export class Eth1DepositDataTracker {
     this.depositsCache = new Eth1DepositsCache(opts, config, db);
     this.eth1DataCache = new Eth1DataCache(config, db);
     this.eth1FollowDistance = config.ETH1_FOLLOW_DISTANCE;
-    // TODO Electra: fix scenario where node starts post-Electra and `stopPolling` will always be false
     this.stopPolling = false;
 
     this.forcedEth1DataVote = opts.forcedEth1DataVote
@@ -118,7 +117,10 @@ export class Eth1DepositDataTracker {
     }
   }
 
-  // TODO Electra: Figure out how an elegant way to stop eth1data polling
+  isPollingEth1Data(): boolean {
+    return !this.stopPolling;
+  }
+
   stopPollingEth1Data(): void {
     this.stopPolling = true;
   }

--- a/packages/beacon-node/src/eth1/index.ts
+++ b/packages/beacon-node/src/eth1/index.ts
@@ -105,6 +105,10 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
     this.eth1MergeBlockTracker.startPollingMergeBlock();
   }
 
+  isPollingEth1Data(): boolean | undefined {
+    return this.eth1DepositDataTracker?.isPollingEth1Data();
+  }
+
   stopPollingEth1Data(): void {
     this.eth1DepositDataTracker?.stopPollingEth1Data();
   }
@@ -137,6 +141,10 @@ export class Eth1ForBlockProductionDisabled implements IEth1ForBlockProduction {
 
   getTDProgress(): TDProgress | null {
     return null;
+  }
+
+  isPollingEth1Data(): boolean | undefined {
+    return;
   }
 
   startPollingMergeBlock(): void {

--- a/packages/beacon-node/src/eth1/index.ts
+++ b/packages/beacon-node/src/eth1/index.ts
@@ -105,8 +105,8 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
     this.eth1MergeBlockTracker.startPollingMergeBlock();
   }
 
-  isPollingEth1Data(): boolean | undefined {
-    return this.eth1DepositDataTracker?.isPollingEth1Data();
+  isPollingEth1Data(): boolean {
+    return this.eth1DepositDataTracker?.isPollingEth1Data() ?? false;
   }
 
   stopPollingEth1Data(): void {

--- a/packages/beacon-node/src/eth1/index.ts
+++ b/packages/beacon-node/src/eth1/index.ts
@@ -143,8 +143,8 @@ export class Eth1ForBlockProductionDisabled implements IEth1ForBlockProduction {
     return null;
   }
 
-  isPollingEth1Data(): boolean | undefined {
-    return;
+  isPollingEth1Data(): boolean {
+    return false;
   }
 
   startPollingMergeBlock(): void {

--- a/packages/beacon-node/src/eth1/interface.ts
+++ b/packages/beacon-node/src/eth1/interface.ts
@@ -63,7 +63,7 @@ export interface IEth1ForBlockProduction {
    */
   startPollingMergeBlock(): void;
 
-  isPollingEth1Data(): boolean | undefined;
+  isPollingEth1Data(): boolean;
 
   /**
    * Should stop polling eth1Data after a Electra block is finalized AND deposit_requests_start_index is reached

--- a/packages/beacon-node/src/eth1/interface.ts
+++ b/packages/beacon-node/src/eth1/interface.ts
@@ -63,6 +63,8 @@ export interface IEth1ForBlockProduction {
    */
   startPollingMergeBlock(): void;
 
+  isPollingEth1Data(): boolean | undefined;
+
   /**
    * Should stop polling eth1Data after a Electra block is finalized AND deposit_requests_start_index is reached
    */

--- a/packages/beacon-node/src/eth1/utils/eth1Vote.ts
+++ b/packages/beacon-node/src/eth1/utils/eth1Vote.ts
@@ -1,6 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {EPOCHS_PER_ETH1_VOTING_PERIOD, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {BeaconStateAllForks, computeTimeAtSlot} from "@lodestar/state-transition";
+import {EPOCHS_PER_ETH1_VOTING_PERIOD, isForkPostElectra, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {BeaconStateAllForks, BeaconStateElectra, computeTimeAtSlot} from "@lodestar/state-transition";
 import {RootHex, phase0} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 
@@ -15,6 +15,15 @@ export async function getEth1VotesToConsider(
   state: BeaconStateAllForks,
   eth1DataGetter: Eth1DataGetter
 ): Promise<phase0.Eth1Data[]> {
+
+  const fork = config.getForkInfo(state.slot).name;
+  if (isForkPostElectra(fork)) {
+    const {eth1DepositIndex, depositRequestsStartIndex} = (state as BeaconStateElectra);
+    if (eth1DepositIndex === Number(depositRequestsStartIndex)) {
+      return state.eth1DataVotes.getAllReadonly();
+    }
+  }
+
   const periodStart = votingPeriodStartTime(config, state);
   const {SECONDS_PER_ETH1_BLOCK, ETH1_FOLLOW_DISTANCE} = config;
 

--- a/packages/beacon-node/src/eth1/utils/eth1Vote.ts
+++ b/packages/beacon-node/src/eth1/utils/eth1Vote.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {EPOCHS_PER_ETH1_VOTING_PERIOD, isForkPostElectra, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {EPOCHS_PER_ETH1_VOTING_PERIOD, SLOTS_PER_EPOCH, isForkPostElectra} from "@lodestar/params";
 import {BeaconStateAllForks, BeaconStateElectra, computeTimeAtSlot} from "@lodestar/state-transition";
 import {RootHex, phase0} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
@@ -15,10 +15,9 @@ export async function getEth1VotesToConsider(
   state: BeaconStateAllForks,
   eth1DataGetter: Eth1DataGetter
 ): Promise<phase0.Eth1Data[]> {
-
   const fork = config.getForkInfo(state.slot).name;
   if (isForkPostElectra(fork)) {
-    const {eth1DepositIndex, depositRequestsStartIndex} = (state as BeaconStateElectra);
+    const {eth1DepositIndex, depositRequestsStartIndex} = state as BeaconStateElectra;
     if (eth1DepositIndex === Number(depositRequestsStartIndex)) {
       return state.eth1DataVotes.getAllReadonly();
     }

--- a/packages/beacon-node/src/eth1/utils/eth1Vote.ts
+++ b/packages/beacon-node/src/eth1/utils/eth1Vote.ts
@@ -15,7 +15,7 @@ export async function getEth1VotesToConsider(
   state: BeaconStateAllForks,
   eth1DataGetter: Eth1DataGetter
 ): Promise<phase0.Eth1Data[]> {
-  const fork = config.getForkInfo(state.slot).name;
+  const fork = config.getForkName(state.slot);
   if (isForkPostElectra(fork)) {
     const {eth1DepositIndex, depositRequestsStartIndex} = state as BeaconStateElectra;
     if (eth1DepositIndex === Number(depositRequestsStartIndex)) {


### PR DESCRIPTION
Eth1 data poll is not needed anymore in Pectra after all eth1 deposits are processed. 

Introduce mechanism to stop the polling.

Note in the case of Lodestar starting up in Electra, Eth1 data poll may run for 1 epoch but no data will actually get polled and then `PrepareNextSlotScheduler.stopEth1Polling()` will stop it.

Part of #6341 