### PR TITLE
chore: revert skipping one benchmark

### DIFF
--- a/packages/state-transition/test/perf/util/loadState/findModifiedValidators.test.ts
+++ b/packages/state-transition/test/perf/util/loadState/findModifiedValidators.test.ts
@@ -60,9 +60,7 @@ describe("find modified validators by different ways", () => {
           ? "no difference"
           : expectedModifiedValidators.length + " modified validators";
 
-      // TODO: Diagnose why this benchmark failing after upgrade
-      // https://github.com/ChainSafe/lodestar/issues/7380
-      bench.skip({
+      bench({
         id: `${prefix} - ${testCaseName}`,
         beforeEach: () => {
           const clonedState = state.clone();


### PR DESCRIPTION
**Motivation**

Revert changes to the benchmark, so all tests are included. 

**Description**

- Revert changes to the benchmark skip

**Steps to test or reproduce**

- Run all tests

Closes https://github.com/ChainSafe/lodestar/issues/7380