### PR TITLE
chore: revert back to previous `getPendingBalanceToWithdraw` implementation

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@chainsafe/persistent-merkle-tree": "^1.0.1",
-    "@chainsafe/ssz": "^1.0.1",
+    "@chainsafe/ssz": "^1.0.2",
     "@lodestar/config": "^1.25.0",
     "@lodestar/params": "^1.25.0",
     "@lodestar/types": "^1.25.0",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -104,7 +104,7 @@
     "@chainsafe/persistent-merkle-tree": "^1.0.1",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/pubkey-index-map": "2.0.0",
-    "@chainsafe/ssz": "^1.0.1",
+    "@chainsafe/ssz": "^1.0.2",
     "@chainsafe/threads": "^1.11.1",
     "@ethersproject/abi": "^5.7.0",
     "@fastify/bearer-auth": "^10.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",
     "@chainsafe/persistent-merkle-tree": "^1.0.1",
-    "@chainsafe/ssz": "^1.0.1",
+    "@chainsafe/ssz": "^1.0.2",
     "@chainsafe/threads": "^1.11.1",
     "@libp2p/crypto": "^4.1.0",
     "@libp2p/peer-id": "^4.1.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -64,7 +64,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/ssz": "^1.0.1",
+    "@chainsafe/ssz": "^1.0.2",
     "@lodestar/params": "^1.25.0",
     "@lodestar/types": "^1.25.0",
     "@lodestar/utils": "^1.25.0"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -35,7 +35,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^1.0.1",
+    "@chainsafe/ssz": "^1.0.2",
     "@lodestar/config": "^1.25.0",
     "@lodestar/utils": "^1.25.0",
     "classic-level": "^1.4.1",

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -36,7 +36,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^1.0.1",
+    "@chainsafe/ssz": "^1.0.2",
     "@lodestar/config": "^1.25.0",
     "@lodestar/params": "^1.25.0",
     "@lodestar/state-transition": "^1.25.0",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -76,7 +76,7 @@
     "@chainsafe/bls": "7.1.3",
     "@chainsafe/blst": "^0.2.0",
     "@chainsafe/persistent-merkle-tree": "^1.0.1",
-    "@chainsafe/ssz": "^1.0.1",
+    "@chainsafe/ssz": "^1.0.2",
     "@lodestar/api": "^1.25.0",
     "@lodestar/config": "^1.25.0",
     "@lodestar/params": "^1.25.0",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -63,7 +63,7 @@
     "@chainsafe/persistent-merkle-tree": "^1.0.1",
     "@chainsafe/persistent-ts": "^1.0.0",
     "@chainsafe/pubkey-index-map": "2.0.0",
-    "@chainsafe/ssz": "^1.0.1",
+    "@chainsafe/ssz": "^1.0.2",
     "@chainsafe/swap-or-not-shuffle": "^0.0.2",
     "@lodestar/config": "^1.25.0",
     "@lodestar/params": "^1.25.0",

--- a/packages/state-transition/src/util/validator.ts
+++ b/packages/state-transition/src/util/validator.ts
@@ -84,8 +84,7 @@ export function getMaxEffectiveBalance(withdrawalCredentials: Uint8Array): numbe
 
 export function getPendingBalanceToWithdraw(state: CachedBeaconStateElectra, validatorIndex: ValidatorIndex): number {
   let total = 0;
-  for (let i = 0; i < state.pendingPartialWithdrawals.length; i++) {
-    const item = state.pendingPartialWithdrawals.get(i);
+  for (const item of state.pendingPartialWithdrawals.getAllReadonly()) {
     if (item.validatorIndex === validatorIndex) {
       total += Number(item.amount);
     }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -73,7 +73,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/ssz": "^1.0.1",
+    "@chainsafe/ssz": "^1.0.2",
     "@lodestar/params": "^1.25.0",
     "ethereum-cryptography": "^2.0.0"
   },

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "@chainsafe/blst": "^2.1.0",
-    "@chainsafe/ssz": "^1.0.1",
+    "@chainsafe/ssz": "^1.0.2",
     "@lodestar/api": "^1.25.0",
     "@lodestar/config": "^1.25.0",
     "@lodestar/db": "^1.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,10 +758,10 @@
     "@chainsafe/as-sha256" "^0.4.1"
     "@chainsafe/persistent-merkle-tree" "^0.6.1"
 
-"@chainsafe/ssz@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-1.0.1.tgz#dd1373cb4387fdd869d377f0fc5460edf422bd78"
-  integrity sha512-+QugG2Wbw3zWmCSIYsjAGoJXmT899ecdfI9OJVG6e3A6pPMJHH4EgENzXYy02ZUDhHXNhJ5c9pA4dElGfT7b4Q==
+"@chainsafe/ssz@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-1.0.2.tgz#af09775ac1f14c19a75bfd45279f71dce67545a1"
+  integrity sha512-T/hiLYRJoM0NkTgTc6XLIL5Nobc/poNqFnJ/8GlvG08czCcri5l8H5DF/6RKdL+1a++LRZCdtHElMaFryszkww==
   dependencies:
     "@chainsafe/as-sha256" "1.0.0"
     "@chainsafe/persistent-merkle-tree" "1.0.1"


### PR DESCRIPTION
Since https://github.com/ChainSafe/ssz/pull/456 it's possible to use `getAllReadonly()` with uncommited changes. This PR essential reverts changes done in https://github.com/ChainSafe/lodestar/pull/7375 as it causes more memory allocation which is not ideal. 