### PR TITLE
chore: unhide `--chain.archiveStateEpochFrequency` flag

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -205,7 +205,6 @@ Will double processing times. Use only for debugging purposes.",
   },
 
   "chain.archiveStateEpochFrequency": {
-    hidden: true,
     description: "Minimum number of epochs between archived states",
     default: defaultOptions.chain.archiveStateEpochFrequency,
     type: "number",


### PR DESCRIPTION
Closes https://github.com/ChainSafe/lodestar/issues/6908, this flag is widely used already and people are aware of the trade-offs, ie. increased storage but works well enough for their use cases.