### PR TITLE
feat: rename pre/post fork designations and fork guards

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -15,7 +15,7 @@ import {
   sszTypesFor,
 } from "@lodestar/types";
 import {EmptyMeta, EmptyResponseCodec, EmptyResponseData, WithVersion} from "../../../utils/codecs.js";
-import {getExecutionForkTypes, toForkName} from "../../../utils/fork.js";
+import {getPostBellatrixForkTypes, toForkName} from "../../../utils/fork.js";
 import {fromHeaders} from "../../../utils/headers.js";
 import {Endpoint, RequestCodec, RouteDefinitions, Schema} from "../../../utils/index.js";
 import {
@@ -445,7 +445,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         writeReqJson: ({signedBlindedBlock}) => {
           const fork = config.getForkName(signedBlindedBlock.message.slot);
           return {
-            body: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.toJson(signedBlindedBlock),
+            body: getPostBellatrixForkTypes(fork).SignedBlindedBeaconBlock.toJson(signedBlindedBlock),
             headers: {
               [MetaHeader.Version]: fork,
             },
@@ -463,13 +463,13 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           }
 
           return {
-            signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body),
+            signedBlindedBlock: getPostBellatrixForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body),
           };
         },
         writeReqSsz: ({signedBlindedBlock}) => {
           const fork = config.getForkName(signedBlindedBlock.message.slot);
           return {
-            body: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.serialize(signedBlindedBlock),
+            body: getPostBellatrixForkTypes(fork).SignedBlindedBeaconBlock.serialize(signedBlindedBlock),
             headers: {
               [MetaHeader.Version]: fork,
             },
@@ -478,7 +478,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqSsz: ({body, headers}) => {
           const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.deserialize(body),
+            signedBlindedBlock: getPostBellatrixForkTypes(fork).SignedBlindedBeaconBlock.deserialize(body),
           };
         },
         schema: {
@@ -498,7 +498,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         writeReqJson: ({signedBlindedBlock, broadcastValidation}) => {
           const fork = config.getForkName(signedBlindedBlock.message.slot);
           return {
-            body: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.toJson(signedBlindedBlock),
+            body: getPostBellatrixForkTypes(fork).SignedBlindedBeaconBlock.toJson(signedBlindedBlock),
             headers: {
               [MetaHeader.Version]: fork,
             },
@@ -508,14 +508,14 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqJson: ({body, headers, query}) => {
           const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body),
+            signedBlindedBlock: getPostBellatrixForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body),
             broadcastValidation: query.broadcast_validation as BroadcastValidation,
           };
         },
         writeReqSsz: ({signedBlindedBlock, broadcastValidation}) => {
           const fork = config.getForkName(signedBlindedBlock.message.slot);
           return {
-            body: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.serialize(signedBlindedBlock),
+            body: getPostBellatrixForkTypes(fork).SignedBlindedBeaconBlock.serialize(signedBlindedBlock),
             headers: {
               [MetaHeader.Version]: fork,
             },
@@ -525,7 +525,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqSsz: ({body, headers, query}) => {
           const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlindedBlock: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.deserialize(body),
+            signedBlindedBlock: getPostBellatrixForkTypes(fork).SignedBlindedBeaconBlock.deserialize(body),
             broadcastValidation: query.broadcast_validation as BroadcastValidation,
           };
         },

--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -1,6 +1,6 @@
 import {ContainerType, ListCompositeType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, ForkPreElectra, ForkPreExecution, isForkBlobs, isForkExecution} from "@lodestar/params";
+import {ForkName, ForkPreElectra, ForkPreExecution, isForkBlobs, isForkPostBellatrix} from "@lodestar/params";
 import {
   BeaconBlockBody,
   RootHex,
@@ -248,7 +248,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       req: blockIdOnlyReq,
       resp: {
         data: WithVersion((fork) =>
-          isForkExecution(fork) ? ssz[fork].SignedBlindedBeaconBlock : ssz[fork].SignedBeaconBlock
+          isForkPostBellatrix(fork) ? ssz[fork].SignedBlindedBeaconBlock : ssz[fork].SignedBeaconBlock
         ),
         meta: ExecutionOptimisticFinalizedAndVersionCodec,
       },

--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -1,6 +1,6 @@
 import {ContainerType, ListCompositeType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, ForkPreElectra, ForkPreBellatrix, isForkPostDeneb, isForkPostBellatrix} from "@lodestar/params";
+import {ForkName, ForkPreBellatrix, ForkPreElectra, isForkPostBellatrix, isForkPostDeneb} from "@lodestar/params";
 import {
   BeaconBlockBody,
   RootHex,

--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -1,6 +1,6 @@
 import {ContainerType, ListCompositeType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, ForkPreElectra, ForkPreBellatrix, isForkBlobs, isForkPostBellatrix} from "@lodestar/params";
+import {ForkName, ForkPreElectra, ForkPreBellatrix, isForkPostDeneb, isForkPostBellatrix} from "@lodestar/params";
 import {
   BeaconBlockBody,
   RootHex,
@@ -313,7 +313,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           const fork = config.getForkName(slot);
 
           return {
-            body: isForkBlobs(fork)
+            body: isForkPostDeneb(fork)
               ? sszTypesFor(fork).SignedBlockContents.toJson(signedBlockOrContents as SignedBlockContents)
               : sszTypesFor(fork).SignedBeaconBlock.toJson(signedBlockOrContents as SignedBeaconBlock),
             headers: {
@@ -336,7 +336,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
             );
           }
           return {
-            signedBlockOrContents: isForkBlobs(forkName)
+            signedBlockOrContents: isForkPostDeneb(forkName)
               ? sszTypesFor(forkName).SignedBlockContents.fromJson(body)
               : ssz[forkName].SignedBeaconBlock.fromJson(body),
           };
@@ -348,7 +348,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           const fork = config.getForkName(slot);
 
           return {
-            body: isForkBlobs(fork)
+            body: isForkPostDeneb(fork)
               ? sszTypesFor(fork).SignedBlockContents.serialize(signedBlockOrContents as SignedBlockContents)
               : sszTypesFor(fork).SignedBeaconBlock.serialize(signedBlockOrContents as SignedBeaconBlock),
             headers: {
@@ -359,7 +359,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqSsz: ({body, headers}) => {
           const forkName = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlockOrContents: isForkBlobs(forkName)
+            signedBlockOrContents: isForkPostDeneb(forkName)
               ? sszTypesFor(forkName).SignedBlockContents.deserialize(body)
               : ssz[forkName].SignedBeaconBlock.deserialize(body),
           };
@@ -384,7 +384,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
             : signedBlockOrContents.message.slot;
           const fork = config.getForkName(slot);
           return {
-            body: isForkBlobs(fork)
+            body: isForkPostDeneb(fork)
               ? sszTypesFor(fork).SignedBlockContents.toJson(signedBlockOrContents as SignedBlockContents)
               : sszTypesFor(fork).SignedBeaconBlock.toJson(signedBlockOrContents as SignedBeaconBlock),
             headers: {
@@ -396,7 +396,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqJson: ({body, headers, query}) => {
           const forkName = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlockOrContents: isForkBlobs(forkName)
+            signedBlockOrContents: isForkPostDeneb(forkName)
               ? sszTypesFor(forkName).SignedBlockContents.fromJson(body)
               : ssz[forkName].SignedBeaconBlock.fromJson(body),
             broadcastValidation: query.broadcast_validation as BroadcastValidation,
@@ -409,7 +409,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           const fork = config.getForkName(slot);
 
           return {
-            body: isForkBlobs(fork)
+            body: isForkPostDeneb(fork)
               ? sszTypesFor(fork).SignedBlockContents.serialize(signedBlockOrContents as SignedBlockContents)
               : sszTypesFor(fork).SignedBeaconBlock.serialize(signedBlockOrContents as SignedBeaconBlock),
             headers: {
@@ -421,7 +421,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqSsz: ({body, headers, query}) => {
           const forkName = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlockOrContents: isForkBlobs(forkName)
+            signedBlockOrContents: isForkPostDeneb(forkName)
               ? sszTypesFor(forkName).SignedBlockContents.deserialize(body)
               : ssz[forkName].SignedBeaconBlock.deserialize(body),
             broadcastValidation: query.broadcast_validation as BroadcastValidation,

--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -1,6 +1,6 @@
 import {ContainerType, ListCompositeType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, ForkPreElectra, ForkPreExecution, isForkBlobs, isForkPostBellatrix} from "@lodestar/params";
+import {ForkName, ForkPreElectra, ForkPreBellatrix, isForkBlobs, isForkPostBellatrix} from "@lodestar/params";
 import {
   BeaconBlockBody,
   RootHex,
@@ -88,7 +88,7 @@ export type Endpoints = {
     "GET",
     BlockArgs,
     {params: {block_id: string}},
-    SignedBlindedBeaconBlock | SignedBeaconBlock<ForkPreExecution>,
+    SignedBlindedBeaconBlock | SignedBeaconBlock<ForkPreBellatrix>,
     ExecutionOptimisticFinalizedAndVersionMeta
   >;
 

--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -21,7 +21,7 @@ import {
 } from "@lodestar/types";
 
 import {EmptyMeta, EmptyResponseCodec, EmptyResponseData} from "../../utils/codecs.js";
-import {getPostBellatrixForkTypes, getPostAltairForkTypes} from "../../utils/fork.js";
+import {getPostAltairForkTypes, getPostBellatrixForkTypes} from "../../utils/fork.js";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {VersionType} from "../../utils/metadata.js";
 

--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -21,7 +21,7 @@ import {
 } from "@lodestar/types";
 
 import {EmptyMeta, EmptyResponseCodec, EmptyResponseData} from "../../utils/codecs.js";
-import {getExecutionForkTypes, getPostAltairForkTypes} from "../../utils/fork.js";
+import {getPostBellatrixForkTypes, getPostAltairForkTypes} from "../../utils/fork.js";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {VersionType} from "../../utils/metadata.js";
 
@@ -296,7 +296,7 @@ export function getTypeByEvent(config: ChainForkConfig): {[K in EventType]: Type
     ),
 
     [EventType.contributionAndProof]: ssz.altair.SignedContributionAndProof,
-    [EventType.payloadAttributes]: WithVersion((fork) => getExecutionForkTypes(fork).SSEPayloadAttributes),
+    [EventType.payloadAttributes]: WithVersion((fork) => getPostBellatrixForkTypes(fork).SSEPayloadAttributes),
     [EventType.blobSidecar]: blobSidecarSSE,
 
     [EventType.lightClientOptimisticUpdate]: WithVersion(

--- a/packages/api/src/beacon/routes/events.ts
+++ b/packages/api/src/beacon/routes/events.ts
@@ -21,7 +21,7 @@ import {
 } from "@lodestar/types";
 
 import {EmptyMeta, EmptyResponseCodec, EmptyResponseData} from "../../utils/codecs.js";
-import {getExecutionForkTypes, getLightClientForkTypes} from "../../utils/fork.js";
+import {getExecutionForkTypes, getPostAltairForkTypes} from "../../utils/fork.js";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {VersionType} from "../../utils/metadata.js";
 
@@ -300,10 +300,10 @@ export function getTypeByEvent(config: ChainForkConfig): {[K in EventType]: Type
     [EventType.blobSidecar]: blobSidecarSSE,
 
     [EventType.lightClientOptimisticUpdate]: WithVersion(
-      (fork) => getLightClientForkTypes(fork).LightClientOptimisticUpdate
+      (fork) => getPostAltairForkTypes(fork).LightClientOptimisticUpdate
     ),
     [EventType.lightClientFinalityUpdate]: WithVersion(
-      (fork) => getLightClientForkTypes(fork).LightClientFinalityUpdate
+      (fork) => getPostAltairForkTypes(fork).LightClientFinalityUpdate
     ),
   };
 }

--- a/packages/api/src/beacon/routes/lightclient.ts
+++ b/packages/api/src/beacon/routes/lightclient.ts
@@ -19,7 +19,7 @@ import {
   EmptyRequestCodec,
   WithVersion,
 } from "../../utils/codecs.js";
-import {getLightClientForkTypes, toForkName} from "../../utils/fork.js";
+import {getPostAltairForkTypes, toForkName} from "../../utils/fork.js";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {MetaHeader, VersionCodec, VersionMeta} from "../../utils/metadata.js";
 
@@ -117,7 +117,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           toJson: (data, meta) => {
             const json: unknown[] = [];
             for (const [i, update] of data.entries()) {
-              json.push(getLightClientForkTypes(meta.versions[i]).LightClientUpdate.toJson(update));
+              json.push(getPostAltairForkTypes(meta.versions[i]).LightClientUpdate.toJson(update));
             }
             return json;
           },
@@ -126,7 +126,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
             const value: LightClientUpdate[] = [];
             for (let i = 0; i < updates.length; i++) {
               const version = meta.versions[i];
-              value.push(getLightClientForkTypes(version).LightClientUpdate.fromJson(updates[i]));
+              value.push(getPostAltairForkTypes(version).LightClientUpdate.fromJson(updates[i]));
             }
             return value;
           },
@@ -135,7 +135,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
             for (const [i, update] of data.entries()) {
               const version = meta.versions[i];
               const forkDigest = cachedBeaconConfig().forkName2ForkDigest(version);
-              const serialized = getLightClientForkTypes(version).LightClientUpdate.serialize(update);
+              const serialized = getPostAltairForkTypes(version).LightClientUpdate.serialize(update);
               const length = ssz.UintNum64.serialize(4 + serialized.length);
               chunks.push(length, forkDigest, serialized);
             }
@@ -149,7 +149,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
               const forkDigest = ssz.ForkDigest.deserialize(data.subarray(offset + 8, offset + 12));
               const version = cachedBeaconConfig().forkDigest2ForkName(forkDigest);
               updates.push(
-                getLightClientForkTypes(version).LightClientUpdate.deserialize(
+                getPostAltairForkTypes(version).LightClientUpdate.deserialize(
                   data.subarray(offset + 12, offset + 8 + length)
                 )
               );
@@ -198,7 +198,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       method: "GET",
       req: EmptyRequestCodec,
       resp: {
-        data: WithVersion((fork) => getLightClientForkTypes(fork).LightClientOptimisticUpdate),
+        data: WithVersion((fork) => getPostAltairForkTypes(fork).LightClientOptimisticUpdate),
         meta: VersionCodec,
       },
     },
@@ -207,7 +207,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       method: "GET",
       req: EmptyRequestCodec,
       resp: {
-        data: WithVersion((fork) => getLightClientForkTypes(fork).LightClientFinalityUpdate),
+        data: WithVersion((fork) => getPostAltairForkTypes(fork).LightClientFinalityUpdate),
         meta: VersionCodec,
       },
     },
@@ -220,7 +220,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         schema: {params: {block_root: Schema.StringRequired}},
       },
       resp: {
-        data: WithVersion((fork) => getLightClientForkTypes(fork).LightClientBootstrap),
+        data: WithVersion((fork) => getPostAltairForkTypes(fork).LightClientBootstrap),
         meta: VersionCodec,
       },
     },

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -1,6 +1,6 @@
 import {ContainerType, Type, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {isForkBlobs, isForkPostElectra} from "@lodestar/params";
+import {isForkPostDeneb, isForkPostElectra} from "@lodestar/params";
 import {
   Attestation,
   BLSSignature,
@@ -652,7 +652,9 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       resp: {
         data: WithVersion(
           (fork) =>
-            (isForkBlobs(fork) ? sszTypesFor(fork).BlockContents : ssz[fork].BeaconBlock) as Type<BeaconBlockOrContents>
+            (isForkPostDeneb(fork)
+              ? sszTypesFor(fork).BlockContents
+              : ssz[fork].BeaconBlock) as Type<BeaconBlockOrContents>
         ),
         meta: VersionCodec,
       },
@@ -714,7 +716,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           ({version, executionPayloadBlinded}) =>
             (executionPayloadBlinded
               ? getPostBellatrixForkTypes(version).BlindedBeaconBlock
-              : isForkBlobs(version)
+              : isForkPostDeneb(version)
                 ? sszTypesFor(version).BlockContents
                 : ssz[version].BeaconBlock) as Type<BeaconBlockOrContents | BlindedBeaconBlock>
         ),

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -30,7 +30,7 @@ import {
   WithMeta,
   WithVersion,
 } from "../../utils/codecs.js";
-import {getExecutionForkTypes, toForkName} from "../../utils/fork.js";
+import {getPostBellatrixForkTypes, toForkName} from "../../utils/fork.js";
 import {fromHeaders} from "../../utils/headers.js";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {
@@ -713,7 +713,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         data: WithMeta(
           ({version, executionPayloadBlinded}) =>
             (executionPayloadBlinded
-              ? getExecutionForkTypes(version).BlindedBeaconBlock
+              ? getPostBellatrixForkTypes(version).BlindedBeaconBlock
               : isForkBlobs(version)
                 ? sszTypesFor(version).BlockContents
                 : ssz[version].BeaconBlock) as Type<BeaconBlockOrContents | BlindedBeaconBlock>
@@ -781,7 +781,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         },
       },
       resp: {
-        data: WithVersion((fork) => getExecutionForkTypes(fork).BlindedBeaconBlock),
+        data: WithVersion((fork) => getPostBellatrixForkTypes(fork).BlindedBeaconBlock),
         meta: VersionCodec,
       },
     },

--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -25,7 +25,7 @@ import {
   JsonOnlyReq,
   WithVersion,
 } from "../utils/codecs.js";
-import {getPostDenebForkTypes, getPostBellatrixForkTypes, toForkName} from "../utils/fork.js";
+import {getPostBellatrixForkTypes, getPostDenebForkTypes, toForkName} from "../utils/fork.js";
 import {fromHeaders} from "../utils/headers.js";
 import {Endpoint, RouteDefinitions, Schema} from "../utils/index.js";
 import {MetaHeader, VersionCodec, VersionMeta} from "../utils/metadata.js";

--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, isForkBlobs} from "@lodestar/params";
+import {ForkName, isForkPostDeneb} from "@lodestar/params";
 import {
   BLSPubkey,
   ExecutionPayload,
@@ -163,7 +163,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       },
       resp: {
         data: WithVersion<ExecutionPayload | ExecutionPayloadAndBlobsBundle, VersionMeta>((fork: ForkName) => {
-          return isForkBlobs(fork)
+          return isForkPostDeneb(fork)
             ? getBlobsForkTypes(fork).ExecutionPayloadAndBlobsBundle
             : getPostBellatrixForkTypes(fork).ExecutionPayload;
         }),

--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -25,7 +25,7 @@ import {
   JsonOnlyReq,
   WithVersion,
 } from "../utils/codecs.js";
-import {getBlobsForkTypes, getPostBellatrixForkTypes, toForkName} from "../utils/fork.js";
+import {getPostDenebForkTypes, getPostBellatrixForkTypes, toForkName} from "../utils/fork.js";
 import {fromHeaders} from "../utils/headers.js";
 import {Endpoint, RouteDefinitions, Schema} from "../utils/index.js";
 import {MetaHeader, VersionCodec, VersionMeta} from "../utils/metadata.js";
@@ -164,7 +164,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       resp: {
         data: WithVersion<ExecutionPayload | ExecutionPayloadAndBlobsBundle, VersionMeta>((fork: ForkName) => {
           return isForkPostDeneb(fork)
-            ? getBlobsForkTypes(fork).ExecutionPayloadAndBlobsBundle
+            ? getPostDenebForkTypes(fork).ExecutionPayloadAndBlobsBundle
             : getPostBellatrixForkTypes(fork).ExecutionPayload;
         }),
         meta: VersionCodec,

--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -25,7 +25,7 @@ import {
   JsonOnlyReq,
   WithVersion,
 } from "../utils/codecs.js";
-import {getBlobsForkTypes, getExecutionForkTypes, toForkName} from "../utils/fork.js";
+import {getBlobsForkTypes, getPostBellatrixForkTypes, toForkName} from "../utils/fork.js";
 import {fromHeaders} from "../utils/headers.js";
 import {Endpoint, RouteDefinitions, Schema} from "../utils/index.js";
 import {MetaHeader, VersionCodec, VersionMeta} from "../utils/metadata.js";
@@ -115,7 +115,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       },
       resp: {
         data: WithVersion<MaybeSignedBuilderBid, VersionMeta>(
-          (fork: ForkName) => getExecutionForkTypes(fork).SignedBuilderBid
+          (fork: ForkName) => getPostBellatrixForkTypes(fork).SignedBuilderBid
         ),
         meta: VersionCodec,
       },
@@ -127,7 +127,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         writeReqJson: ({signedBlindedBlock}) => {
           const fork = config.getForkName(signedBlindedBlock.data.message.slot);
           return {
-            body: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.toJson(signedBlindedBlock.data),
+            body: getPostBellatrixForkTypes(fork).SignedBlindedBeaconBlock.toJson(signedBlindedBlock.data),
             headers: {
               [MetaHeader.Version]: fork,
             },
@@ -136,7 +136,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqJson: ({body, headers}) => {
           const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlindedBlock: {data: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body)},
+            signedBlindedBlock: {data: getPostBellatrixForkTypes(fork).SignedBlindedBeaconBlock.fromJson(body)},
           };
         },
         writeReqSsz: ({signedBlindedBlock}) => {
@@ -144,7 +144,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
           return {
             body:
               signedBlindedBlock.bytes ??
-              getExecutionForkTypes(fork).SignedBlindedBeaconBlock.serialize(signedBlindedBlock.data),
+              getPostBellatrixForkTypes(fork).SignedBlindedBeaconBlock.serialize(signedBlindedBlock.data),
             headers: {
               [MetaHeader.Version]: fork,
             },
@@ -153,7 +153,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqSsz: ({body, headers}) => {
           const fork = toForkName(fromHeaders(headers, MetaHeader.Version));
           return {
-            signedBlindedBlock: {data: getExecutionForkTypes(fork).SignedBlindedBeaconBlock.deserialize(body)},
+            signedBlindedBlock: {data: getPostBellatrixForkTypes(fork).SignedBlindedBeaconBlock.deserialize(body)},
           };
         },
         schema: {
@@ -165,7 +165,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         data: WithVersion<ExecutionPayload | ExecutionPayloadAndBlobsBundle, VersionMeta>((fork: ForkName) => {
           return isForkBlobs(fork)
             ? getBlobsForkTypes(fork).ExecutionPayloadAndBlobsBundle
-            : getExecutionForkTypes(fork).ExecutionPayload;
+            : getPostBellatrixForkTypes(fork).ExecutionPayload;
         }),
         meta: VersionCodec,
       },

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -1,11 +1,11 @@
 import {
-  ForkPostDeneb,
-  ForkPostBellatrix,
-  ForkPostAltair,
   ForkName,
-  isForkPostDeneb,
-  isForkPostBellatrix,
+  ForkPostAltair,
+  ForkPostBellatrix,
+  ForkPostDeneb,
   isForkPostAltair,
+  isForkPostBellatrix,
+  isForkPostDeneb,
 } from "@lodestar/params";
 import {SSZTypesFor, sszTypesFor} from "@lodestar/types";
 

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -1,7 +1,7 @@
 import {
   ForkBlobs,
   ForkExecution,
-  ForkLightClient,
+  ForkPostAltair,
   ForkName,
   isForkBlobs,
   isForkExecution,
@@ -19,7 +19,7 @@ export function toForkName(version: string): ForkName {
   return version as ForkName;
 }
 
-export function getLightClientForkTypes(fork: ForkName): SSZTypesFor<ForkLightClient> {
+export function getLightClientForkTypes(fork: ForkName): SSZTypesFor<ForkPostAltair> {
   if (!isForkPostAltair(fork)) {
     throw Error(`Invalid fork=${fork} for lightclient fork types`);
   }

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -1,5 +1,5 @@
 import {
-  ForkBlobs,
+  ForkPostDeneb,
   ForkPostBellatrix,
   ForkPostAltair,
   ForkName,
@@ -35,7 +35,7 @@ export function getPostBellatrixForkTypes(fork: ForkName): SSZTypesFor<ForkPostB
   return sszTypesFor(fork);
 }
 
-export function getPostDenebForkTypes(fork: ForkName): SSZTypesFor<ForkBlobs> {
+export function getPostDenebForkTypes(fork: ForkName): SSZTypesFor<ForkPostDeneb> {
   if (!isForkPostDeneb(fork)) {
     throw Error(`Invalid fork=${fork} for post deneb fork types`);
   }

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -27,9 +27,9 @@ export function getPostAltairForkTypes(fork: ForkName): SSZTypesFor<ForkPostAlta
   return sszTypesFor(fork);
 }
 
-export function getExecutionForkTypes(fork: ForkName): SSZTypesFor<ForkExecution> {
+export function getPostBellatrixForkTypes(fork: ForkName): SSZTypesFor<ForkExecution> {
   if (!isForkPostBellatrix(fork)) {
-    throw Error(`Invalid fork=${fork} for execution fork types`);
+    throw Error(`Invalid fork=${fork} for post bellatrix fork types`);
   }
 
   return sszTypesFor(fork);

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -3,7 +3,7 @@ import {
   ForkPostBellatrix,
   ForkPostAltair,
   ForkName,
-  isForkBlobs,
+  isForkPostDeneb,
   isForkPostBellatrix,
   isForkPostAltair,
 } from "@lodestar/params";
@@ -36,7 +36,7 @@ export function getPostBellatrixForkTypes(fork: ForkName): SSZTypesFor<ForkPostB
 }
 
 export function getBlobsForkTypes(fork: ForkName): SSZTypesFor<ForkBlobs> {
-  if (!isForkBlobs(fork)) {
+  if (!isForkPostDeneb(fork)) {
     throw Error(`Invalid fork=${fork} for blobs fork types`);
   }
 

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -5,7 +5,7 @@ import {
   ForkName,
   isForkBlobs,
   isForkExecution,
-  isForkLightClient,
+  isForkPostAltair,
 } from "@lodestar/params";
 import {SSZTypesFor, sszTypesFor} from "@lodestar/types";
 
@@ -20,7 +20,7 @@ export function toForkName(version: string): ForkName {
 }
 
 export function getLightClientForkTypes(fork: ForkName): SSZTypesFor<ForkLightClient> {
-  if (!isForkLightClient(fork)) {
+  if (!isForkPostAltair(fork)) {
     throw Error(`Invalid fork=${fork} for lightclient fork types`);
   }
 

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -19,9 +19,9 @@ export function toForkName(version: string): ForkName {
   return version as ForkName;
 }
 
-export function getLightClientForkTypes(fork: ForkName): SSZTypesFor<ForkPostAltair> {
+export function getPostAltairForkTypes(fork: ForkName): SSZTypesFor<ForkPostAltair> {
   if (!isForkPostAltair(fork)) {
-    throw Error(`Invalid fork=${fork} for lightclient fork types`);
+    throw Error(`Invalid fork=${fork} for post altair fork types`);
   }
 
   return sszTypesFor(fork);

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -21,7 +21,7 @@ export function toForkName(version: string): ForkName {
 
 export function getPostAltairForkTypes(fork: ForkName): SSZTypesFor<ForkPostAltair> {
   if (!isForkPostAltair(fork)) {
-    throw Error(`Invalid fork=${fork} for post altair fork types`);
+    throw Error(`Invalid fork=${fork} for post-altair fork types`);
   }
 
   return sszTypesFor(fork);
@@ -29,7 +29,7 @@ export function getPostAltairForkTypes(fork: ForkName): SSZTypesFor<ForkPostAlta
 
 export function getPostBellatrixForkTypes(fork: ForkName): SSZTypesFor<ForkPostBellatrix> {
   if (!isForkPostBellatrix(fork)) {
-    throw Error(`Invalid fork=${fork} for post bellatrix fork types`);
+    throw Error(`Invalid fork=${fork} for post-bellatrix fork types`);
   }
 
   return sszTypesFor(fork);
@@ -37,7 +37,7 @@ export function getPostBellatrixForkTypes(fork: ForkName): SSZTypesFor<ForkPostB
 
 export function getPostDenebForkTypes(fork: ForkName): SSZTypesFor<ForkPostDeneb> {
   if (!isForkPostDeneb(fork)) {
-    throw Error(`Invalid fork=${fork} for post deneb fork types`);
+    throw Error(`Invalid fork=${fork} for post-deneb fork types`);
   }
 
   return sszTypesFor(fork);

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -4,7 +4,7 @@ import {
   ForkPostAltair,
   ForkName,
   isForkBlobs,
-  isForkExecution,
+  isForkPostBellatrix,
   isForkPostAltair,
 } from "@lodestar/params";
 import {SSZTypesFor, sszTypesFor} from "@lodestar/types";
@@ -28,7 +28,7 @@ export function getPostAltairForkTypes(fork: ForkName): SSZTypesFor<ForkPostAlta
 }
 
 export function getExecutionForkTypes(fork: ForkName): SSZTypesFor<ForkExecution> {
-  if (!isForkExecution(fork)) {
+  if (!isForkPostBellatrix(fork)) {
     throw Error(`Invalid fork=${fork} for execution fork types`);
   }
 

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -1,6 +1,6 @@
 import {
   ForkBlobs,
-  ForkExecution,
+  ForkPostBellatrix,
   ForkPostAltair,
   ForkName,
   isForkBlobs,
@@ -27,7 +27,7 @@ export function getPostAltairForkTypes(fork: ForkName): SSZTypesFor<ForkPostAlta
   return sszTypesFor(fork);
 }
 
-export function getPostBellatrixForkTypes(fork: ForkName): SSZTypesFor<ForkExecution> {
+export function getPostBellatrixForkTypes(fork: ForkName): SSZTypesFor<ForkPostBellatrix> {
   if (!isForkPostBellatrix(fork)) {
     throw Error(`Invalid fork=${fork} for post bellatrix fork types`);
   }

--- a/packages/api/src/utils/fork.ts
+++ b/packages/api/src/utils/fork.ts
@@ -35,9 +35,9 @@ export function getPostBellatrixForkTypes(fork: ForkName): SSZTypesFor<ForkPostB
   return sszTypesFor(fork);
 }
 
-export function getBlobsForkTypes(fork: ForkName): SSZTypesFor<ForkBlobs> {
+export function getPostDenebForkTypes(fork: ForkName): SSZTypesFor<ForkBlobs> {
   if (!isForkPostDeneb(fork)) {
-    throw Error(`Invalid fork=${fork} for blobs fork types`);
+    throw Error(`Invalid fork=${fork} for post deneb fork types`);
   }
 
   return sszTypesFor(fork);

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ApiError, ApplicationMethods} from "@lodestar/api/server";
-import {ForkExecution, SLOTS_PER_HISTORICAL_ROOT, isForkPostBellatrix, isForkPostElectra} from "@lodestar/params";
+import {ForkPostBellatrix, SLOTS_PER_HISTORICAL_ROOT, isForkPostBellatrix, isForkPostElectra} from "@lodestar/params";
 import {
   computeEpochAtSlot,
   computeTimeAtSlot,
@@ -393,7 +393,7 @@ export function getBeaconBlockApi({
       const fork = config.getForkName(block.message.slot);
       return {
         data: isForkPostBellatrix(fork)
-          ? signedBeaconBlockToBlinded(config, block as SignedBeaconBlock<ForkExecution>)
+          ? signedBeaconBlockToBlinded(config, block as SignedBeaconBlock<ForkPostBellatrix>)
           : block,
         meta: {
           executionOptimistic,

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -240,7 +240,7 @@ export function getBeaconBlockApi({
     const slot = signedBlindedBlock.message.slot;
     const blockRoot = toRootHex(
       chain.config
-        .getExecutionForkTypes(signedBlindedBlock.message.slot)
+        .getPostBellatrixForkTypes(signedBlindedBlock.message.slot)
         .BlindedBeaconBlock.hashTreeRoot(signedBlindedBlock.message)
     );
 

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ApiError, ApplicationMethods} from "@lodestar/api/server";
-import {ForkExecution, SLOTS_PER_HISTORICAL_ROOT, isForkExecution, isForkPostElectra} from "@lodestar/params";
+import {ForkExecution, SLOTS_PER_HISTORICAL_ROOT, isForkPostBellatrix, isForkPostElectra} from "@lodestar/params";
 import {
   computeEpochAtSlot,
   computeTimeAtSlot,
@@ -392,7 +392,7 @@ export function getBeaconBlockApi({
       const {block, executionOptimistic, finalized} = await getBlockResponse(chain, blockId);
       const fork = config.getForkName(block.message.slot);
       return {
-        data: isForkExecution(fork)
+        data: isForkPostBellatrix(fork)
           ? signedBeaconBlockToBlinded(config, block as SignedBeaconBlock<ForkExecution>)
           : block,
         meta: {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -3,7 +3,7 @@ import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {DataAvailabilityStatus, ExecutionStatus} from "@lodestar/fork-choice";
 import {
-  ForkBlobs,
+  ForkPostDeneb,
   ForkPostBellatrix,
   ForkPreBlobs,
   ForkSeq,
@@ -111,7 +111,7 @@ const BLOCK_PRODUCTION_RACE_TIMEOUT_MS = 12_000;
 
 type ProduceBlockOrContentsRes = {executionPayloadValue: Wei; consensusBlockValue: Wei} & (
   | {data: BeaconBlock<ForkPreBlobs>; version: ForkPreBlobs}
-  | {data: BlockContents; version: ForkBlobs}
+  | {data: BlockContents; version: ForkPostDeneb}
 );
 type ProduceBlindedBlockRes = {executionPayloadValue: Wei; consensusBlockValue: Wei} & {
   data: BlindedBeaconBlock;

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -3,16 +3,16 @@ import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {DataAvailabilityStatus, ExecutionStatus} from "@lodestar/fork-choice";
 import {
-  ForkPostDeneb,
   ForkPostBellatrix,
+  ForkPostDeneb,
   ForkPreDeneb,
   ForkSeq,
   GENESIS_SLOT,
   SLOTS_PER_EPOCH,
   SLOTS_PER_HISTORICAL_ROOT,
   SYNC_COMMITTEE_SUBNET_SIZE,
-  isForkPostDeneb,
   isForkPostBellatrix,
+  isForkPostDeneb,
   isForkPostElectra,
 } from "@lodestar/params";
 import {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -465,7 +465,7 @@ export function getValidatorApi(
         slot,
         executionPayloadValue,
         consensusBlockValue,
-        root: toRootHex(config.getExecutionForkTypes(slot).BlindedBeaconBlock.hashTreeRoot(block)),
+        root: toRootHex(config.getPostBellatrixForkTypes(slot).BlindedBeaconBlock.hashTreeRoot(block)),
       });
 
       if (chain.opts.persistProducedBlocks) {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -5,7 +5,7 @@ import {DataAvailabilityStatus, ExecutionStatus} from "@lodestar/fork-choice";
 import {
   ForkPostDeneb,
   ForkPostBellatrix,
-  ForkPreBlobs,
+  ForkPreDeneb,
   ForkSeq,
   GENESIS_SLOT,
   SLOTS_PER_EPOCH,
@@ -110,7 +110,7 @@ const BLOCK_PRODUCTION_RACE_CUTOFF_MS = 2_500;
 const BLOCK_PRODUCTION_RACE_TIMEOUT_MS = 12_000;
 
 type ProduceBlockOrContentsRes = {executionPayloadValue: Wei; consensusBlockValue: Wei} & (
-  | {data: BeaconBlock<ForkPreBlobs>; version: ForkPreBlobs}
+  | {data: BeaconBlock<ForkPreDeneb>; version: ForkPreDeneb}
   | {data: BlockContents; version: ForkPostDeneb}
 );
 type ProduceBlindedBlockRes = {executionPayloadValue: Wei; consensusBlockValue: Wei} & {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -4,7 +4,7 @@ import {ApplicationMethods} from "@lodestar/api/server";
 import {DataAvailabilityStatus, ExecutionStatus} from "@lodestar/fork-choice";
 import {
   ForkBlobs,
-  ForkExecution,
+  ForkPostBellatrix,
   ForkPreBlobs,
   ForkSeq,
   GENESIS_SLOT,
@@ -115,7 +115,7 @@ type ProduceBlockOrContentsRes = {executionPayloadValue: Wei; consensusBlockValu
 );
 type ProduceBlindedBlockRes = {executionPayloadValue: Wei; consensusBlockValue: Wei} & {
   data: BlindedBeaconBlock;
-  version: ForkExecution;
+  version: ForkPostBellatrix;
 };
 
 type ProduceFullOrBlindedBlockOrContentsRes = {executionPayloadSource: ProducedBlockSource} & (
@@ -872,14 +872,14 @@ export function getValidatorApi(
 
         if (isBlockContents(data)) {
           const {block} = data;
-          const blindedBlock = beaconBlockToBlinded(config, block as BeaconBlock<ForkExecution>);
+          const blindedBlock = beaconBlockToBlinded(config, block as BeaconBlock<ForkPostBellatrix>);
           return {
             data: blindedBlock,
             meta: {...meta, executionPayloadBlinded: true},
           };
         }
 
-        const blindedBlock = beaconBlockToBlinded(config, data as BeaconBlock<ForkExecution>);
+        const blindedBlock = beaconBlockToBlinded(config, data as BeaconBlock<ForkPostBellatrix>);
         return {
           data: blindedBlock,
           meta: {...meta, executionPayloadBlinded: true},
@@ -897,7 +897,7 @@ export function getValidatorApi(
 
       if (isBlockContents(data)) {
         const {block} = data;
-        const blindedBlock = beaconBlockToBlinded(config, block as BeaconBlock<ForkExecution>);
+        const blindedBlock = beaconBlockToBlinded(config, block as BeaconBlock<ForkPostBellatrix>);
         return {data: blindedBlock, meta: {version}};
       }
 
@@ -905,7 +905,7 @@ export function getValidatorApi(
         return {data, meta: {version}};
       }
 
-      const blindedBlock = beaconBlockToBlinded(config, data as BeaconBlock<ForkExecution>);
+      const blindedBlock = beaconBlockToBlinded(config, data as BeaconBlock<ForkPostBellatrix>);
       return {data: blindedBlock, meta: {version}};
     },
 

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -12,7 +12,7 @@ import {
   SLOTS_PER_HISTORICAL_ROOT,
   SYNC_COMMITTEE_SUBNET_SIZE,
   isForkBlobs,
-  isForkExecution,
+  isForkPostBellatrix,
   isForkPostElectra,
 } from "@lodestar/params";
 import {
@@ -419,7 +419,7 @@ export function getValidatorApi(
       ) = {}
   ): Promise<ProduceBlindedBlockRes> {
     const version = config.getForkName(slot);
-    if (!isForkExecution(version)) {
+    if (!isForkPostBellatrix(version)) {
       throw Error(`Invalid fork=${version} for produceBuilderBlindedBlock`);
     }
 
@@ -526,7 +526,7 @@ export function getValidatorApi(
         commonBlockBody,
       });
       const version = config.getForkName(block.slot);
-      if (strictFeeRecipientCheck && feeRecipient && isForkExecution(version)) {
+      if (strictFeeRecipientCheck && feeRecipient && isForkPostBellatrix(version)) {
         const blockFeeRecipient = toHex((block as bellatrix.BeaconBlock).body.executionPayload.feeRecipient);
         if (blockFeeRecipient !== feeRecipient) {
           throw Error(`Invalid feeRecipient set in engine block expected=${feeRecipient} actual=${blockFeeRecipient}`);
@@ -891,7 +891,7 @@ export function getValidatorApi(
 
     async produceBlindedBlock({slot, randaoReveal, graffiti}) {
       const {data, version} = await produceEngineOrBuilderBlock(slot, randaoReveal, graffiti);
-      if (!isForkExecution(version)) {
+      if (!isForkPostBellatrix(version)) {
         throw Error(`Invalid fork=${version} for produceBlindedBlock`);
       }
 

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -11,7 +11,7 @@ import {
   SLOTS_PER_EPOCH,
   SLOTS_PER_HISTORICAL_ROOT,
   SYNC_COMMITTEE_SUBNET_SIZE,
-  isForkBlobs,
+  isForkPostDeneb,
   isForkPostBellatrix,
   isForkPostElectra,
 } from "@lodestar/params";
@@ -545,7 +545,7 @@ export function getValidatorApi(
       if (chain.opts.persistProducedBlocks) {
         void chain.persistBlock(block, "produced_engine_block");
       }
-      if (isForkBlobs(version)) {
+      if (isForkPostDeneb(version)) {
         const blockHash = toRootHex((block as bellatrix.BeaconBlock).body.executionPayload.blockHash);
         const contents = chain.producedContentsCache.get(blockHash);
         if (contents === undefined) {

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {AncestorStatus, EpochDifference, ForkChoiceError, ForkChoiceErrorCode} from "@lodestar/fork-choice";
-import {ForkLightClient, ForkSeq, INTERVALS_PER_SLOT, MAX_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkPostAltair, ForkSeq, INTERVALS_PER_SLOT, MAX_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
   CachedBeaconStateAltair,
   RootCache,
@@ -279,7 +279,7 @@ export async function importBlock(
       callInNextEventLoop(() => {
         try {
           this.lightClientServer?.onImportBlockHead(
-            block.message as BeaconBlock<ForkLightClient>,
+            block.message as BeaconBlock<ForkPostAltair>,
             postState as CachedBeaconStateAltair,
             parentBlockSlot
           );

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -1,6 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {DataAvailabilityStatus, MaybeValidExecutionStatus} from "@lodestar/fork-choice";
-import {ForkBlobs, ForkSeq} from "@lodestar/params";
+import {ForkPostDeneb, ForkSeq} from "@lodestar/params";
 import {CachedBeaconStateAllForks, computeEpochAtSlot} from "@lodestar/state-transition";
 import {RootHex, SignedBeaconBlock, Slot, deneb} from "@lodestar/types";
 
@@ -36,7 +36,7 @@ export enum GossipedInputType {
 
 type BlobsCacheMap = Map<number, deneb.BlobSidecar>;
 
-type ForkBlobsInfo = {fork: ForkBlobs};
+type ForkBlobsInfo = {fork: ForkPostDeneb};
 export type BlockInputBlobs = {blobs: deneb.BlobSidecar[]; blobsSource: BlobsSource};
 export type BlockInputDataBlobs = ForkBlobsInfo & BlockInputBlobs;
 export type BlockInputData = BlockInputDataBlobs;

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -706,7 +706,9 @@ export class BeaconChain implements IBeaconChain {
     const bodyRoot =
       blockType === BlockType.Full
         ? this.config.getForkTypes(slot).BeaconBlockBody.hashTreeRoot(body)
-        : this.config.getExecutionForkTypes(slot).BlindedBeaconBlockBody.hashTreeRoot(body as BlindedBeaconBlockBody);
+        : this.config
+            .getPostBellatrixForkTypes(slot)
+            .BlindedBeaconBlockBody.hashTreeRoot(body as BlindedBeaconBlockBody);
     this.logger.debug("Computing block post state from the produced body", {
       slot,
       bodyRoot: toRootHex(bodyRoot),
@@ -726,7 +728,7 @@ export class BeaconChain implements IBeaconChain {
     const blockRoot =
       blockType === BlockType.Full
         ? this.config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block)
-        : this.config.getExecutionForkTypes(slot).BlindedBeaconBlock.hashTreeRoot(block as BlindedBeaconBlock);
+        : this.config.getPostBellatrixForkTypes(slot).BlindedBeaconBlock.hashTreeRoot(block as BlindedBeaconBlock);
     const blockRootHex = toRootHex(blockRoot);
 
     // track the produced block for consensus broadcast validations
@@ -863,7 +865,7 @@ export class BeaconChain implements IBeaconChain {
   persistBlock(data: BeaconBlock | BlindedBeaconBlock, suffix?: string): void {
     const slot = data.slot;
     if (isBlindedBeaconBlock(data)) {
-      const sszType = this.config.getExecutionForkTypes(slot).BlindedBeaconBlock;
+      const sszType = this.config.getPostBellatrixForkTypes(slot).BlindedBeaconBlock;
       void this.persistSszObject("BlindedBeaconBlock", sszType.serialize(data), sszType.hashTreeRoot(data), suffix);
     } else {
       const sszType = this.config.getForkTypes(slot).BeaconBlock;

--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -8,9 +8,9 @@ import {
   upgradeLightClientHeader,
 } from "@lodestar/light-client/spec";
 import {
-  ForkPostBellatrix,
-  ForkPostAltair,
   ForkName,
+  ForkPostAltair,
+  ForkPostBellatrix,
   ForkSeq,
   MIN_SYNC_COMMITTEE_PARTICIPANTS,
   SYNC_COMMITTEE_SIZE,

--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -9,12 +9,12 @@ import {
 } from "@lodestar/light-client/spec";
 import {
   ForkExecution,
-  ForkLightClient,
+  ForkPostAltair,
   ForkName,
   ForkSeq,
   MIN_SYNC_COMMITTEE_PARTICIPANTS,
   SYNC_COMMITTEE_SIZE,
-  forkLightClient,
+  forkPostAltair,
   highestFork,
   isForkPostElectra,
 } from "@lodestar/params";
@@ -230,7 +230,7 @@ export class LightClientServer {
 
     this.zero = {
       // Assign the hightest fork's default value because it can always be typecasted down to correct fork
-      finalizedHeader: sszTypesFor(highestFork(forkLightClient)).LightClientHeader.defaultValue(),
+      finalizedHeader: sszTypesFor(highestFork(forkPostAltair)).LightClientHeader.defaultValue(),
       // Electra finalityBranch has fixed length of 5 whereas altair has 4. The fifth element will be ignored
       // when serializing as altair LightClientUpdate
       finalityBranch: ssz.electra.LightClientUpdate.fields.finalityBranch.defaultValue(),
@@ -260,7 +260,7 @@ export class LightClientServer {
    * - Use block's syncAggregate
    */
   onImportBlockHead(
-    block: BeaconBlock<ForkLightClient>,
+    block: BeaconBlock<ForkPostAltair>,
     postState: CachedBeaconStateAltair,
     parentBlockSlot: Slot
   ): void {
@@ -391,7 +391,7 @@ export class LightClientServer {
   }
 
   private async persistPostBlockImportData(
-    block: BeaconBlock<ForkLightClient>,
+    block: BeaconBlock<ForkPostAltair>,
     postState: CachedBeaconStateAltair,
     parentBlockSlot: Slot
   ): Promise<void> {
@@ -742,14 +742,14 @@ export function sumBits(bits: BitArray): number {
   return bits.getTrueBitIndexes().length;
 }
 
-export function blockToLightClientHeader(fork: ForkName, block: BeaconBlock<ForkLightClient>): LightClientHeader {
+export function blockToLightClientHeader(fork: ForkName, block: BeaconBlock<ForkPostAltair>): LightClientHeader {
   const blockSlot = block.slot;
   const beacon: phase0.BeaconBlockHeader = {
     slot: blockSlot,
     proposerIndex: block.proposerIndex,
     parentRoot: block.parentRoot,
     stateRoot: block.stateRoot,
-    bodyRoot: (ssz[fork].BeaconBlockBody as SSZTypesFor<ForkLightClient, "BeaconBlockBody">).hashTreeRoot(block.body),
+    bodyRoot: (ssz[fork].BeaconBlockBody as SSZTypesFor<ForkPostAltair, "BeaconBlockBody">).hashTreeRoot(block.body),
   };
   if (ForkSeq[fork] >= ForkSeq.capella) {
     const blockBody = block.body as BeaconBlockBody<ForkExecution>;

--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -8,7 +8,7 @@ import {
   upgradeLightClientHeader,
 } from "@lodestar/light-client/spec";
 import {
-  ForkExecution,
+  ForkPostBellatrix,
   ForkPostAltair,
   ForkName,
   ForkSeq,
@@ -752,12 +752,12 @@ export function blockToLightClientHeader(fork: ForkName, block: BeaconBlock<Fork
     bodyRoot: (ssz[fork].BeaconBlockBody as SSZTypesFor<ForkPostAltair, "BeaconBlockBody">).hashTreeRoot(block.body),
   };
   if (ForkSeq[fork] >= ForkSeq.capella) {
-    const blockBody = block.body as BeaconBlockBody<ForkExecution>;
+    const blockBody = block.body as BeaconBlockBody<ForkPostBellatrix>;
     const execution = executionPayloadToPayloadHeader(ForkSeq[fork], blockBody.executionPayload);
     return {
       beacon,
       execution,
-      executionBranch: getBlockBodyExecutionHeaderProof(fork as ForkExecution, blockBody),
+      executionBranch: getBlockBodyExecutionHeaderProof(fork as ForkPostBellatrix, blockBody),
     } as LightClientHeader;
   }
 

--- a/packages/beacon-node/src/chain/lightClient/proofs.ts
+++ b/packages/beacon-node/src/chain/lightClient/proofs.ts
@@ -3,8 +3,8 @@ import {
   BLOCK_BODY_EXECUTION_PAYLOAD_GINDEX,
   FINALIZED_ROOT_GINDEX,
   FINALIZED_ROOT_GINDEX_ELECTRA,
-  ForkPostBellatrix,
   ForkName,
+  ForkPostBellatrix,
   isForkPostElectra,
 } from "@lodestar/params";
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "@lodestar/state-transition";

--- a/packages/beacon-node/src/chain/lightClient/proofs.ts
+++ b/packages/beacon-node/src/chain/lightClient/proofs.ts
@@ -3,7 +3,7 @@ import {
   BLOCK_BODY_EXECUTION_PAYLOAD_GINDEX,
   FINALIZED_ROOT_GINDEX,
   FINALIZED_ROOT_GINDEX_ELECTRA,
-  ForkExecution,
+  ForkPostBellatrix,
   ForkName,
   isForkPostElectra,
 } from "@lodestar/params";
@@ -78,9 +78,9 @@ export function getFinalizedRootProof(state: CachedBeaconStateAllForks): Uint8Ar
 }
 
 export function getBlockBodyExecutionHeaderProof(
-  fork: ForkExecution,
-  body: BeaconBlockBody<ForkExecution>
+  fork: ForkPostBellatrix,
+  body: BeaconBlockBody<ForkPostBellatrix>
 ): Uint8Array[] {
-  const bodyView = (ssz[fork].BeaconBlockBody as SSZTypesFor<ForkExecution, "BeaconBlockBody">).toView(body);
+  const bodyView = (ssz[fork].BeaconBlockBody as SSZTypesFor<ForkPostBellatrix, "BeaconBlockBody">).toView(body);
   return new Tree(bodyView.node).getSingleProof(BigInt(BLOCK_BODY_EXECUTION_PAYLOAD_GINDEX));
 }

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkExecution, ForkSeq, SLOTS_PER_EPOCH, isForkPostElectra} from "@lodestar/params";
+import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH, isForkPostElectra} from "@lodestar/params";
 import {
   BeaconStateElectra,
   CachedBeaconStateAllForks,
@@ -173,7 +173,7 @@ export class PrepareNextSlotScheduler {
           await prepareExecutionPayload(
             this.chain,
             this.logger,
-            fork as ForkExecution, // State is of execution type
+            fork as ForkPostBellatrix, // State is of execution type
             fromHex(updatedHeadRoot),
             safeBlockHash,
             finalizedBlockHash,
@@ -191,7 +191,7 @@ export class PrepareNextSlotScheduler {
 
         // If emitPayloadAttributes is true emit a SSE payloadAttributes event
         if (this.chain.opts.emitPayloadAttributes === true) {
-          const data = await getPayloadAttributesForSSE(fork as ForkExecution, this.chain, {
+          const data = await getPayloadAttributesForSSE(fork as ForkPostBellatrix, this.chain, {
             prepareState: updatedPrepareState,
             prepareSlot,
             parentBlockRoot: fromHex(headRoot),

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkExecution, ForkSeq, isForkExecution, isForkLightClient} from "@lodestar/params";
+import {ForkExecution, ForkSeq, isForkExecution, isForkPostAltair} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   CachedBeaconStateBellatrix,
@@ -169,7 +169,7 @@ export async function produceBlockBody<T extends BlockType>(
     proposerSlashings: proposerSlashings.length,
   });
 
-  if (isForkLightClient(fork)) {
+  if (isForkPostAltair(fork)) {
     Object.assign(logMeta, {
       syncAggregateParticipants: syncAggregate.syncCommitteeBits.getTrueBitIndexes().length,
     });

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkExecution, ForkSeq, isForkPostBellatrix, isForkPostAltair} from "@lodestar/params";
+import {ForkPostBellatrix, ForkSeq, isForkPostBellatrix, isForkPostAltair} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   CachedBeaconStateBellatrix,
@@ -303,7 +303,7 @@ export async function produceBlockBody<T extends BlockType>(
         );
 
         if (prepareRes.isPremerge) {
-          (blockBody as BeaconBlockBody<ForkExecution>).executionPayload =
+          (blockBody as BeaconBlockBody<ForkPostBellatrix>).executionPayload =
             sszTypesFor(fork).ExecutionPayload.defaultValue();
           blobsResult = {type: BlobsResultType.preDeneb};
           executionPayloadValue = BigInt(0);
@@ -324,7 +324,7 @@ export async function produceBlockBody<T extends BlockType>(
           const {executionPayload, blobsBundle, executionRequests} = engineRes;
           shouldOverrideBuilder = engineRes.shouldOverrideBuilder;
 
-          (blockBody as BeaconBlockBody<ForkExecution>).executionPayload = executionPayload;
+          (blockBody as BeaconBlockBody<ForkPostBellatrix>).executionPayload = executionPayload;
           executionPayloadValue = engineRes.executionPayloadValue;
           Object.assign(logMeta, {transactions: executionPayload.transactions.length, shouldOverrideBuilder});
 
@@ -379,7 +379,7 @@ export async function produceBlockBody<T extends BlockType>(
             {},
             e as Error
           );
-          (blockBody as BeaconBlockBody<ForkExecution>).executionPayload =
+          (blockBody as BeaconBlockBody<ForkPostBellatrix>).executionPayload =
             sszTypesFor(fork).ExecutionPayload.defaultValue();
           blobsResult = {type: BlobsResultType.preDeneb};
           executionPayloadValue = BigInt(0);
@@ -431,7 +431,7 @@ export async function prepareExecutionPayload(
     config: ChainForkConfig;
   },
   logger: Logger,
-  fork: ForkExecution,
+  fork: ForkPostBellatrix,
   parentBlockRoot: Root,
   safeBlockHash: RootHex,
   finalizedBlockHash: RootHex,
@@ -509,7 +509,7 @@ async function prepareExecutionPayloadHeader(
     executionBuilder?: IExecutionBuilder;
     config: ChainForkConfig;
   },
-  fork: ForkExecution,
+  fork: ForkPostBellatrix,
   state: CachedBeaconStateBellatrix,
   proposerPubKey: BLSPubkey
 ): Promise<{
@@ -566,7 +566,7 @@ export async function getExecutionPayloadParentHash(
 }
 
 export async function getPayloadAttributesForSSE(
-  fork: ForkExecution,
+  fork: ForkPostBellatrix,
   chain: {
     eth1: IEth1ForBlockProduction;
     config: ChainForkConfig;
@@ -604,7 +604,7 @@ export async function getPayloadAttributesForSSE(
 }
 
 function preparePayloadAttributes(
-  fork: ForkExecution,
+  fork: ForkPostBellatrix,
   chain: {
     config: ChainForkConfig;
   },

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkExecution, ForkSeq, isForkExecution, isForkPostAltair} from "@lodestar/params";
+import {ForkExecution, ForkSeq, isForkPostBellatrix, isForkPostAltair} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   CachedBeaconStateBellatrix,
@@ -176,7 +176,7 @@ export async function produceBlockBody<T extends BlockType>(
   }
 
   const endExecutionPayload = stepsMetrics?.startTimer();
-  if (isForkExecution(fork)) {
+  if (isForkPostBellatrix(fork)) {
     const safeBlockHash = this.forkChoice.getJustifiedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
     const finalizedBlockHash = this.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
     const feeRecipient = requestedFeeRecipient ?? this.beaconProposerCache.getOrDefault(proposerIndex);

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkPostBellatrix, ForkSeq, isForkPostBellatrix, isForkPostAltair} from "@lodestar/params";
+import {ForkPostBellatrix, ForkSeq, isForkPostAltair, isForkPostBellatrix} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   CachedBeaconStateBellatrix,

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -111,7 +111,7 @@ export class SeenGossipBlockInput {
       }
 
       if (cachedData === undefined || !isForkPostDeneb(cachedData.fork)) {
-        throw Error("Missing or Invalid fork cached Data for post deneb block");
+        throw Error("Missing or Invalid fork cached Data for post-deneb block");
       }
       const {blobsCache, resolveAvailability} = cachedData;
 

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {BLOBSIDECAR_FIXED_SIZE, ForkName, isForkBlobs} from "@lodestar/params";
+import {BLOBSIDECAR_FIXED_SIZE, ForkName, isForkPostDeneb} from "@lodestar/params";
 import {RootHex, SignedBeaconBlock, deneb, ssz} from "@lodestar/types";
 import {pruneSetToMax, toRootHex} from "@lodestar/utils";
 
@@ -103,15 +103,15 @@ export class SeenGossipBlockInput {
     const {block: signedBlock, blockInputPromise, resolveBlockInput, cachedData} = blockCache;
 
     if (signedBlock !== undefined) {
-      if (!isForkBlobs(fork)) {
+      if (!isForkPostDeneb(fork)) {
         return {
           blockInput: getBlockInput.preData(config, signedBlock, BlockSource.gossip),
           blockInputMeta: {pending: null, haveBlobs: 0, expectedBlobs: 0},
         };
       }
 
-      if (cachedData === undefined || !isForkBlobs(cachedData.fork)) {
-        throw Error("Missing or Invalid fork cached Data for deneb+ block");
+      if (cachedData === undefined || !isForkPostDeneb(cachedData.fork)) {
+        throw Error("Missing or Invalid fork cached Data for post deneb block");
       }
       const {blobsCache, resolveAvailability} = cachedData;
 
@@ -181,7 +181,7 @@ function getEmptyBlockInputCacheEntry(fork: ForkName): BlockInputCacheType {
   if (resolveBlockInput === null) {
     throw Error("Promise Constructor was not executed immediately");
   }
-  if (!isForkBlobs(fork)) {
+  if (!isForkPostDeneb(fork)) {
     return {fork, blockInputPromise, resolveBlockInput};
   }
 

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, isForkBlobs} from "@lodestar/params";
+import {ForkName, isForkPostDeneb} from "@lodestar/params";
 import {
   computeStartSlotAtEpoch,
   computeTimeAtSlot,
@@ -111,7 +111,7 @@ export async function validateGossipBlock(
   }
 
   // [REJECT] The length of KZG commitments is less than or equal to the limitation defined in Consensus Layer -- i.e. validate that len(body.signed_beacon_block.message.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
-  if (isForkBlobs(fork)) {
+  if (isForkPostDeneb(fork)) {
     const blobKzgCommitmentsLen = (block as deneb.BeaconBlock).body.blobKzgCommitments.length;
     const maxBlobsPerBlock = chain.config.getMaxBlobsPerBlock(fork);
     if (blobKzgCommitmentsLen > maxBlobsPerBlock) {

--- a/packages/beacon-node/src/chain/validation/lightClientFinalityUpdate.ts
+++ b/packages/beacon-node/src/chain/validation/lightClientFinalityUpdate.ts
@@ -34,7 +34,7 @@ export function validateLightClientFinalityUpdate(
   }
 
   // [IGNORE] The received finality_update matches the locally computed one exactly
-  const sszType = config.getLightClientForkTypes(
+  const sszType = config.getPostAltairForkTypes(
     gossipedFinalityUpdate.attestedHeader.beacon.slot
   ).LightClientFinalityUpdate;
   if (localFinalityUpdate === null || !sszType.equals(gossipedFinalityUpdate, localFinalityUpdate)) {

--- a/packages/beacon-node/src/chain/validation/lightClientOptimisticUpdate.ts
+++ b/packages/beacon-node/src/chain/validation/lightClientOptimisticUpdate.ts
@@ -35,7 +35,7 @@ export function validateLightClientOptimisticUpdate(
   }
 
   // [IGNORE] The received optimistic_update matches the locally computed one exactly
-  const sszType = config.getLightClientForkTypes(
+  const sszType = config.getPostAltairForkTypes(
     gossipedOptimisticUpdate.attestedHeader.beacon.slot
   ).LightClientOptimisticUpdate;
   if (localOptimisticUpdate === null || !sszType.equals(gossipedOptimisticUpdate, localOptimisticUpdate)) {

--- a/packages/beacon-node/src/db/repositories/lightclientBestUpdate.ts
+++ b/packages/beacon-node/src/db/repositories/lightclientBestUpdate.ts
@@ -23,7 +23,7 @@ export class BestLightClientUpdateRepository extends Repository<SyncPeriod, Ligh
     // prefix by attestedHeader's slot bytes
     const slotBytes = ssz.Slot.serialize(value.attestedHeader.beacon.slot);
     const valueBytes = this.config
-      .getLightClientForkTypes(value.attestedHeader.beacon.slot)
+      .getPostAltairForkTypes(value.attestedHeader.beacon.slot)
       .LightClientUpdate.serialize(value);
 
     const prefixedData = new Uint8Array(SLOT_BYTE_COUNT + valueBytes.length);
@@ -36,6 +36,6 @@ export class BestLightClientUpdateRepository extends Repository<SyncPeriod, Ligh
   decodeValue(data: Uint8Array): LightClientUpdate {
     // First slot is written
     const slot = ssz.Slot.deserialize(data.subarray(0, SLOT_BYTE_COUNT));
-    return this.config.getLightClientForkTypes(slot).LightClientUpdate.deserialize(data.subarray(SLOT_BYTE_COUNT));
+    return this.config.getPostAltairForkTypes(slot).LightClientUpdate.deserialize(data.subarray(SLOT_BYTE_COUNT));
   }
 }

--- a/packages/beacon-node/src/db/repositories/lightclientCheckpointHeader.ts
+++ b/packages/beacon-node/src/db/repositories/lightclientCheckpointHeader.ts
@@ -19,7 +19,7 @@ export class CheckpointHeaderRepository extends Repository<Uint8Array, LightClie
 
   // Overrides for multi-fork
   encodeValue(value: LightClientHeader): Uint8Array {
-    return this.config.getLightClientForkTypes(value.beacon.slot).LightClientHeader.serialize(value);
+    return this.config.getPostAltairForkTypes(value.beacon.slot).LightClientHeader.serialize(value);
   }
 
   decodeValue(data: Uint8Array): LightClientHeader {
@@ -27,6 +27,6 @@ export class CheckpointHeaderRepository extends Repository<Uint8Array, LightClie
   }
 
   getId(value: LightClientHeader): Uint8Array {
-    return this.config.getLightClientForkTypes(value.beacon.slot).LightClientHeader.hashTreeRoot(value);
+    return this.config.getPostAltairForkTypes(value.beacon.slot).LightClientHeader.hashTreeRoot(value);
   }
 }

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -2,7 +2,7 @@ import {WireFormat} from "@lodestar/api";
 import {ApiClient as BuilderApi, getClient} from "@lodestar/api/builder";
 import {ChainForkConfig} from "@lodestar/config";
 import {Logger} from "@lodestar/logger";
-import {ForkExecution, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkPostBellatrix, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {parseExecutionPayloadAndBlobsBundle, reconstructFullBlockOrContents} from "@lodestar/state-transition";
 import {
   BLSPubkey,
@@ -152,7 +152,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
   }
 
   async getHeader(
-    _fork: ForkExecution,
+    _fork: ForkPostBellatrix,
     slot: Slot,
     parentHash: Root,
     proposerPubkey: BLSPubkey

--- a/packages/beacon-node/src/execution/builder/interface.ts
+++ b/packages/beacon-node/src/execution/builder/interface.ts
@@ -1,4 +1,4 @@
-import {ForkExecution} from "@lodestar/params";
+import {ForkPostBellatrix} from "@lodestar/params";
 import {
   BLSPubkey,
   Epoch,
@@ -33,7 +33,7 @@ export interface IExecutionBuilder {
   registerValidator(epoch: Epoch, registrations: bellatrix.SignedValidatorRegistrationV1[]): Promise<void>;
   getValidatorRegistration(pubkey: BLSPubkey): ValidatorRegistration | undefined;
   getHeader(
-    fork: ForkExecution,
+    fork: ForkPostBellatrix,
     slot: Slot,
     parentHash: Root,
     proposerPubKey: BLSPubkey

--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -3,7 +3,7 @@ import {
   BLOB_TX_TYPE,
   BYTES_PER_FIELD_ELEMENT,
   FIELD_ELEMENTS_PER_BLOB,
-  ForkExecution,
+  ForkPostBellatrix,
   ForkName,
   ForkSeq,
 } from "@lodestar/params";
@@ -404,7 +404,7 @@ export class ExecutionEngineMockBackend implements JsonRpcBackend {
     return versionedHashes.map((_vh) => null);
   }
 
-  private timestampToFork(timestamp: number): ForkExecution {
+  private timestampToFork(timestamp: number): ForkPostBellatrix {
     if (timestamp > (this.opts.electraForkTimestamp ?? Infinity)) return ForkName.electra;
     if (timestamp > (this.opts.denebForkTimestamp ?? Infinity)) return ForkName.deneb;
     if (timestamp > (this.opts.capellaForkTimestamp ?? Infinity)) return ForkName.capella;

--- a/packages/beacon-node/src/execution/engine/mock.ts
+++ b/packages/beacon-node/src/execution/engine/mock.ts
@@ -3,8 +3,8 @@ import {
   BLOB_TX_TYPE,
   BYTES_PER_FIELD_ELEMENT,
   FIELD_ELEMENTS_PER_BLOB,
-  ForkPostBellatrix,
   ForkName,
+  ForkPostBellatrix,
   ForkSeq,
 } from "@lodestar/params";
 import {RootHex, bellatrix, deneb, ssz} from "@lodestar/types";

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -4,7 +4,7 @@ import {
   ForkName,
   ForkSeq,
   SYNC_COMMITTEE_SUBNET_COUNT,
-  isForkLightClient,
+  isForkPostAltair,
   isForkPostElectra,
 } from "@lodestar/params";
 import {Attestation, SingleAttestation, ssz, sszTypesFor} from "@lodestar/types";
@@ -100,11 +100,11 @@ export function getGossipSSZType(topic: GossipTopic) {
     case GossipType.sync_committee:
       return ssz.altair.SyncCommitteeMessage;
     case GossipType.light_client_optimistic_update:
-      return isForkLightClient(topic.fork)
+      return isForkPostAltair(topic.fork)
         ? sszTypesFor(topic.fork).LightClientOptimisticUpdate
         : ssz.altair.LightClientOptimisticUpdate;
     case GossipType.light_client_finality_update:
-      return isForkLightClient(topic.fork)
+      return isForkPostAltair(topic.fork)
         ? sszTypesFor(topic.fork).LightClientFinalityUpdate
         : ssz.altair.LightClientFinalityUpdate;
     case GossipType.bls_to_execution_change:

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -1,5 +1,5 @@
 import {BeaconConfig} from "@lodestar/config";
-import {GENESIS_SLOT, MAX_REQUEST_BLOCKS, MAX_REQUEST_BLOCKS_DENEB, isForkBlobs} from "@lodestar/params";
+import {GENESIS_SLOT, MAX_REQUEST_BLOCKS, MAX_REQUEST_BLOCKS_DENEB, isForkPostDeneb} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {deneb, phase0} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
@@ -86,7 +86,9 @@ export function validateBeaconBlocksByRangeRequest(
 
   // step > 1 is deprecated, see https://github.com/ethereum/consensus-specs/pull/2856
 
-  const maxRequestBlocks = isForkBlobs(config.getForkName(startSlot)) ? MAX_REQUEST_BLOCKS_DENEB : MAX_REQUEST_BLOCKS;
+  const maxRequestBlocks = isForkPostDeneb(config.getForkName(startSlot))
+    ? MAX_REQUEST_BLOCKS_DENEB
+    : MAX_REQUEST_BLOCKS;
 
   if (count > maxRequestBlocks) {
     count = maxRequestBlocks;

--- a/packages/beacon-node/src/network/reqresp/rateLimit.ts
+++ b/packages/beacon-node/src/network/reqresp/rateLimit.ts
@@ -4,7 +4,7 @@ import {
   MAX_REQUEST_BLOCKS,
   MAX_REQUEST_BLOCKS_DENEB,
   MAX_REQUEST_LIGHT_CLIENT_UPDATES,
-  isForkBlobs,
+  isForkPostDeneb,
 } from "@lodestar/params";
 import {InboundRateLimitQuota} from "@lodestar/reqresp";
 import {ReqRespMethod, RequestBodyByMethod, requestSszTypeByMethod} from "./types.js";
@@ -32,12 +32,12 @@ export const rateLimitQuotas: (fork: ForkName, config: BeaconConfig) => Record<R
   // Do not matter
   [ReqRespMethod.BeaconBlocksByRange]: {
     // Rationale: https://github.com/sigp/lighthouse/blob/bf533c8e42cc73c35730e285c21df8add0195369/beacon_node/lighthouse_network/src/rpc/mod.rs#L118-L130
-    byPeer: {quota: isForkBlobs(fork) ? MAX_REQUEST_BLOCKS_DENEB : MAX_REQUEST_BLOCKS, quotaTimeMs: 10_000},
+    byPeer: {quota: isForkPostDeneb(fork) ? MAX_REQUEST_BLOCKS_DENEB : MAX_REQUEST_BLOCKS, quotaTimeMs: 10_000},
     getRequestCount: getRequestCountFn(fork, config, ReqRespMethod.BeaconBlocksByRange, (req) => req.count),
   },
   [ReqRespMethod.BeaconBlocksByRoot]: {
     // Rationale: https://github.com/sigp/lighthouse/blob/bf533c8e42cc73c35730e285c21df8add0195369/beacon_node/lighthouse_network/src/rpc/mod.rs#L118-L130
-    byPeer: {quota: isForkBlobs(fork) ? MAX_REQUEST_BLOCKS_DENEB : MAX_REQUEST_BLOCKS, quotaTimeMs: 10_000},
+    byPeer: {quota: isForkPostDeneb(fork) ? MAX_REQUEST_BLOCKS_DENEB : MAX_REQUEST_BLOCKS, quotaTimeMs: 10_000},
     getRequestCount: getRequestCountFn(fork, config, ReqRespMethod.BeaconBlocksByRoot, (req) => req.length),
   },
   [ReqRespMethod.BlobSidecarsByRange]: {

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -116,7 +116,6 @@ export const responseSszTypeByMethod: {[K in ReqRespMethod]: ResponseTypeGetter<
     sszTypesFor(onlyPostAltairFork(fork)).LightClientOptimisticUpdate,
 };
 
-// TODO: @matthewkeil perhaps this should move to params/src/forkName with the other guards?
 function onlyPostAltairFork(fork: ForkName): ForkPostAltair {
   if (isForkPostAltair(fork)) {
     return fork;

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -1,6 +1,6 @@
 import {Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {ForkPostAltair, ForkName, isForkPostAltair} from "@lodestar/params";
+import {ForkName, ForkPostAltair, isForkPostAltair} from "@lodestar/params";
 import {Protocol, ProtocolHandler, ReqRespRequest} from "@lodestar/reqresp";
 import {
   LightClientBootstrap,

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -120,7 +120,7 @@ function onlyPostAltairFork(fork: ForkName): ForkPostAltair {
   if (isForkPostAltair(fork)) {
     return fork;
   }
-  throw Error(`Not a post altair fork ${fork}`);
+  throw Error(`Not a post-altair fork ${fork}`);
 }
 
 export type RequestTypedContainer = {

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -1,6 +1,6 @@
 import {Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {ForkLightClient, ForkName, isForkLightClient} from "@lodestar/params";
+import {ForkLightClient, ForkName, isForkPostAltair} from "@lodestar/params";
 import {Protocol, ProtocolHandler, ReqRespRequest} from "@lodestar/reqresp";
 import {
   LightClientBootstrap,
@@ -117,7 +117,7 @@ export const responseSszTypeByMethod: {[K in ReqRespMethod]: ResponseTypeGetter<
 };
 
 function onlyLightclientFork(fork: ForkName): ForkLightClient {
-  if (isForkLightClient(fork)) {
+  if (isForkPostAltair(fork)) {
     return fork;
   }
   throw Error(`Not a lightclient fork ${fork}`);

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -109,18 +109,19 @@ export const responseSszTypeByMethod: {[K in ReqRespMethod]: ResponseTypeGetter<
   [ReqRespMethod.BeaconBlocksByRoot]: blocksResponseType,
   [ReqRespMethod.BlobSidecarsByRange]: () => ssz.deneb.BlobSidecar,
   [ReqRespMethod.BlobSidecarsByRoot]: () => ssz.deneb.BlobSidecar,
-  [ReqRespMethod.LightClientBootstrap]: (fork) => sszTypesFor(onlyLightclientFork(fork)).LightClientBootstrap,
-  [ReqRespMethod.LightClientUpdatesByRange]: (fork) => sszTypesFor(onlyLightclientFork(fork)).LightClientUpdate,
-  [ReqRespMethod.LightClientFinalityUpdate]: (fork) => sszTypesFor(onlyLightclientFork(fork)).LightClientFinalityUpdate,
+  [ReqRespMethod.LightClientBootstrap]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientBootstrap,
+  [ReqRespMethod.LightClientUpdatesByRange]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientUpdate,
+  [ReqRespMethod.LightClientFinalityUpdate]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientFinalityUpdate,
   [ReqRespMethod.LightClientOptimisticUpdate]: (fork) =>
-    sszTypesFor(onlyLightclientFork(fork)).LightClientOptimisticUpdate,
+    sszTypesFor(onlyPostAltairFork(fork)).LightClientOptimisticUpdate,
 };
 
-function onlyLightclientFork(fork: ForkName): ForkPostAltair {
+// TODO: @matthewkeil perhaps this should move to params/src/forkName with the other guards?
+function onlyPostAltairFork(fork: ForkName): ForkPostAltair {
   if (isForkPostAltair(fork)) {
     return fork;
   }
-  throw Error(`Not a lightclient fork ${fork}`);
+  throw Error(`Not a post altair fork ${fork}`);
 }
 
 export type RequestTypedContainer = {

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -1,6 +1,6 @@
 import {Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {ForkLightClient, ForkName, isForkPostAltair} from "@lodestar/params";
+import {ForkPostAltair, ForkName, isForkPostAltair} from "@lodestar/params";
 import {Protocol, ProtocolHandler, ReqRespRequest} from "@lodestar/reqresp";
 import {
   LightClientBootstrap,
@@ -116,7 +116,7 @@ export const responseSszTypeByMethod: {[K in ReqRespMethod]: ResponseTypeGetter<
     sszTypesFor(onlyLightclientFork(fork)).LightClientOptimisticUpdate,
 };
 
-function onlyLightclientFork(fork: ForkName): ForkLightClient {
+function onlyLightclientFork(fork: ForkName): ForkPostAltair {
   if (isForkPostAltair(fork)) {
     return fork;
   }

--- a/packages/beacon-node/src/util/multifork.ts
+++ b/packages/beacon-node/src/util/multifork.ts
@@ -65,5 +65,5 @@ export function getLightClientHeaderTypeFromBytes(
   const slot = bytesToInt(
     bytes.subarray(SLOT_BYTES_POSITION_IN_LIGHTCLIENTHEADER, SLOT_BYTES_POSITION_IN_LIGHTCLIENTHEADER + SLOT_BYTE_COUNT)
   );
-  return config.getLightClientForkTypes(slot).LightClientHeader;
+  return config.getPostAltairForkTypes(slot).LightClientHeader;
 }

--- a/packages/beacon-node/src/util/multifork.ts
+++ b/packages/beacon-node/src/util/multifork.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkAll, ForkLightClient} from "@lodestar/params";
+import {ForkAll, ForkPostAltair} from "@lodestar/params";
 import {SSZTypesFor, Slot} from "@lodestar/types";
 import {bytesToInt} from "@lodestar/utils";
 import {getSlotFromSignedBeaconBlockSerialized} from "./sszBytes.js";
@@ -61,7 +61,7 @@ const SLOT_BYTES_POSITION_IN_LIGHTCLIENTHEADER = 0;
 export function getLightClientHeaderTypeFromBytes(
   config: ChainForkConfig,
   bytes: Buffer | Uint8Array
-): SSZTypesFor<ForkLightClient, "LightClientHeader"> {
+): SSZTypesFor<ForkPostAltair, "LightClientHeader"> {
   const slot = bytesToInt(
     bytes.subarray(SLOT_BYTES_POSITION_IN_LIGHTCLIENTHEADER, SLOT_BYTES_POSITION_IN_LIGHTCLIENTHEADER + SLOT_BYTE_COUNT)
   );

--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import {toHexString} from "@chainsafe/ssz";
 import {createBeaconConfig} from "@lodestar/config";
 import {CheckpointWithHex, ForkChoice} from "@lodestar/fork-choice";
-import {ACTIVE_PRESET, ForkName, ForkSeq, isForkBlobs} from "@lodestar/params";
+import {ACTIVE_PRESET, ForkName, ForkSeq, isForkPostDeneb} from "@lodestar/params";
 import {InputType} from "@lodestar/spec-test-util";
 import {BeaconStateAllForks, isExecutionStateType, signedBlockToSignedHeader} from "@lodestar/state-transition";
 import {
@@ -61,7 +61,7 @@ const forkChoiceTest =
   (fork) => {
     return {
       testFunction: async (testcase) => {
-        if (isForkBlobs(fork)) {
+        if (isForkPostDeneb(fork)) {
           await initCKZG();
           loadEthereumTrustedSetup();
         }

--- a/packages/beacon-node/test/spec/presets/light_client/sync.ts
+++ b/packages/beacon-node/test/spec/presets/light_client/sync.ts
@@ -128,7 +128,7 @@ export const sync: TestRunnerFn<SyncTestCase, void> = (fork) => {
             }
 
             const headerSlot = Number(step.process_update.checks.optimistic_header.slot);
-            const update = config.getLightClientForkTypes(headerSlot).LightClientUpdate.deserialize(updateBytes);
+            const update = config.getPostAltairForkTypes(headerSlot).LightClientUpdate.deserialize(updateBytes);
 
             logger.debug(`LightclientUpdateSummary: ${JSON.stringify(toLightClientUpdateSummary(update))}`);
 

--- a/packages/beacon-node/test/spec/presets/light_client/sync.ts
+++ b/packages/beacon-node/test/spec/presets/light_client/sync.ts
@@ -1,6 +1,6 @@
 import {ChainConfig, createBeaconConfig} from "@lodestar/config";
 import {LightclientSpec, toLightClientUpdateSummary} from "@lodestar/light-client/spec";
-import {isForkLightClient} from "@lodestar/params";
+import {isForkPostAltair} from "@lodestar/params";
 import {InputType} from "@lodestar/spec-test-util";
 import {computeSyncPeriodAtSlot} from "@lodestar/state-transition";
 import {RootHex, Slot, altair, phase0, ssz, sszTypesFor} from "@lodestar/types";
@@ -165,7 +165,7 @@ export const sync: TestRunnerFn<SyncTestCase, void> = (fork) => {
         config: InputType.YAML,
       },
       sszTypes: {
-        bootstrap: isForkLightClient(fork) ? sszTypesFor(fork).LightClientBootstrap : ssz.altair.LightClientBootstrap,
+        bootstrap: isForkPostAltair(fork) ? sszTypesFor(fork).LightClientBootstrap : ssz.altair.LightClientBootstrap,
         // The updates are multifork and need config and step info to be deserialized within the test
         [UPDATE_FILE_NAME]: {typeName: "LightClientUpdate", deserialize: (bytes: Uint8Array) => bytes},
       },

--- a/packages/beacon-node/test/spec/presets/light_client/update_ranking.ts
+++ b/packages/beacon-node/test/spec/presets/light_client/update_ranking.ts
@@ -1,5 +1,5 @@
 import {LightClientUpdateSummary, isBetterUpdate, toLightClientUpdateSummary} from "@lodestar/light-client/spec";
-import {isForkLightClient} from "@lodestar/params";
+import {isForkPostAltair} from "@lodestar/params";
 import {InputType} from "@lodestar/spec-test-util";
 import {LightClientUpdate, altair, ssz, sszTypesFor} from "@lodestar/types";
 import {expect} from "vitest";
@@ -51,7 +51,7 @@ newUpdate = ${renderUpdate(newUpdate)}
         meta: InputType.YAML,
       },
       sszTypes: {
-        [UPDATES_FILE_NAME]: isForkLightClient(fork)
+        [UPDATES_FILE_NAME]: isForkPostAltair(fork)
           ? sszTypesFor(fork).LightClientUpdate
           : ssz.altair.LightClientUpdate,
       },

--- a/packages/beacon-node/test/unit/chain/validation/block.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/block.test.ts
@@ -1,6 +1,6 @@
 import {config} from "@lodestar/config/default";
 import {ProtoBlock} from "@lodestar/fork-choice";
-import {ForkBlobs, ForkName} from "@lodestar/params";
+import {ForkPostDeneb, ForkName} from "@lodestar/params";
 import {SignedBeaconBlock, ssz} from "@lodestar/types";
 import {Mock, Mocked, beforeEach, describe, it, vi} from "vitest";
 import {BlockErrorCode} from "../../../../src/chain/errors/index.js";
@@ -206,7 +206,7 @@ describe("gossip block validation", () => {
     // Force proposer shuffling cache to return correct value
     vi.spyOn(state.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex + 1);
     // Add one extra kzg commitment in the block so it goes over the limit
-    (job as SignedBeaconBlock<ForkBlobs>).message.body.blobKzgCommitments.push(new Uint8Array([0]));
+    (job as SignedBeaconBlock<ForkPostDeneb>).message.body.blobKzgCommitments.push(new Uint8Array([0]));
 
     await expectRejectedWithLodestarError(
       validateGossipBlock(config, chain, job, ForkName.deneb),

--- a/packages/beacon-node/test/unit/chain/validation/block.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/block.test.ts
@@ -1,6 +1,6 @@
 import {config} from "@lodestar/config/default";
 import {ProtoBlock} from "@lodestar/fork-choice";
-import {ForkPostDeneb, ForkName} from "@lodestar/params";
+import {ForkName, ForkPostDeneb} from "@lodestar/params";
 import {SignedBeaconBlock, ssz} from "@lodestar/types";
 import {Mock, Mocked, beforeEach, describe, it, vi} from "vitest";
 import {BlockErrorCode} from "../../../../src/chain/errors/index.js";

--- a/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
+++ b/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
@@ -3,8 +3,8 @@ import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lo
 import {
   BYTES_PER_FIELD_ELEMENT,
   FIELD_ELEMENTS_PER_BLOB,
-  ForkPostDeneb,
   ForkName,
+  ForkPostDeneb,
   isForkPostDeneb,
 } from "@lodestar/params";
 import {signedBlockToSignedHeader} from "@lodestar/state-transition";

--- a/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
+++ b/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
@@ -1,6 +1,6 @@
 import {toHexString} from "@chainsafe/ssz";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
-import {BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB, ForkBlobs, ForkName, isForkBlobs} from "@lodestar/params";
+import {BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB, ForkBlobs, ForkName, isForkPostDeneb} from "@lodestar/params";
 import {signedBlockToSignedHeader} from "@lodestar/state-transition";
 import {SignedBeaconBlock, deneb, ssz} from "@lodestar/types";
 import {beforeAll, describe, expect, it, vi} from "vitest";
@@ -206,7 +206,7 @@ function getEmptyBlockInputCacheEntry(fork: ForkName): BlockInputCacheType {
   if (resolveBlockInput === null) {
     throw Error("Promise Constructor was not executed immediately");
   }
-  if (!isForkBlobs(fork)) {
+  if (!isForkPostDeneb(fork)) {
     return {fork, blockInputPromise, resolveBlockInput};
   }
 

--- a/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
+++ b/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
@@ -1,6 +1,12 @@
 import {toHexString} from "@chainsafe/ssz";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
-import {BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB, ForkBlobs, ForkName, isForkPostDeneb} from "@lodestar/params";
+import {
+  BYTES_PER_FIELD_ELEMENT,
+  FIELD_ELEMENTS_PER_BLOB,
+  ForkPostDeneb,
+  ForkName,
+  isForkPostDeneb,
+} from "@lodestar/params";
 import {signedBlockToSignedHeader} from "@lodestar/state-transition";
 import {SignedBeaconBlock, deneb, ssz} from "@lodestar/types";
 import {beforeAll, describe, expect, it, vi} from "vitest";
@@ -172,7 +178,7 @@ describe("unavailableBeaconBlobsByRoot", () => {
     ];
 
     const blockData = {
-      fork: ForkName.deneb as ForkBlobs,
+      fork: ForkName.deneb as ForkPostDeneb,
       blobs: allBlobs,
       blobsSource: BlobsSource.byRoot,
     };

--- a/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
+++ b/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
@@ -178,7 +178,7 @@ describe("unavailableBeaconBlobsByRoot", () => {
     ];
 
     const blockData = {
-      fork: ForkName.deneb as ForkPostDeneb,
+      fork: ForkName.deneb as const,
       blobs: allBlobs,
       blobsSource: BlobsSource.byRoot,
     };

--- a/packages/cli/test/utils/crucible/utils/syncing.ts
+++ b/packages/cli/test/utils/crucible/utils/syncing.ts
@@ -1,5 +1,5 @@
 import {routes} from "@lodestar/api";
-import {ForkBlobs} from "@lodestar/params";
+import {ForkPostDeneb} from "@lodestar/params";
 import {SignedBeaconBlock, Slot} from "@lodestar/types";
 import {sleep, toHex} from "@lodestar/utils";
 import {BeaconClient, ExecutionClient, NodePair} from "../interfaces.js";
@@ -132,7 +132,7 @@ export async function assertUnknownBlockSync(env: Simulation): Promise<void> {
     (
       await unknownBlockSync.beacon.api.beacon.publishBlockV2({
         signedBlockOrContents: {
-          signedBlock: currentHead as SignedBeaconBlock<ForkBlobs>,
+          signedBlock: currentHead as SignedBeaconBlock<ForkPostDeneb>,
           blobs: currentSidecars.map((b) => b.blob),
           kzgProofs: currentSidecars.map((b) => b.kzgProof),
         },

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -123,10 +123,10 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       }
       return sszTypesFor(forkName);
     },
-    getBlobsForkTypes(slot: Slot): SSZTypesFor<ForkBlobs> {
+    getPostDenebForkTypes(slot: Slot): SSZTypesFor<ForkBlobs> {
       const forkName = this.getForkName(slot);
       if (!isForkPostDeneb(forkName)) {
-        throw Error(`Invalid slot=${slot} fork=${forkName} for blobs fork types`);
+        throw Error(`Invalid slot=${slot} fork=${forkName} for post deneb fork types`);
       }
       return sszTypesFor(forkName);
     },

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -109,10 +109,10 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
     getForkTypes<F extends ForkName = ForkAll>(slot: Slot): SSZTypesFor<F> {
       return sszTypesFor(this.getForkName(slot)) as SSZTypesFor<F>;
     },
-    getExecutionForkTypes(slot: Slot): SSZTypesFor<ForkExecution> {
+    getPostBellatrixForkTypes(slot: Slot): SSZTypesFor<ForkExecution> {
       const forkName = this.getForkName(slot);
       if (!isForkPostBellatrix(forkName)) {
-        throw Error(`Invalid slot=${slot} fork=${forkName} for execution fork types`);
+        throw Error(`Invalid slot=${slot} fork=${forkName} for post bellatrix fork types`);
       }
       return sszTypesFor(forkName);
     },

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -2,7 +2,7 @@ import {
   ForkAll,
   ForkBlobs,
   ForkExecution,
-  ForkLightClient,
+  ForkPostAltair,
   ForkName,
   ForkSeq,
   GENESIS_EPOCH,
@@ -116,7 +116,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       }
       return sszTypesFor(forkName);
     },
-    getLightClientForkTypes(slot: Slot): SSZTypesFor<ForkLightClient> {
+    getLightClientForkTypes(slot: Slot): SSZTypesFor<ForkPostAltair> {
       const forkName = this.getForkName(slot);
       if (!isForkPostAltair(forkName)) {
         throw Error(`Invalid slot=${slot} fork=${forkName} for lightclient fork types`);

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -1,6 +1,6 @@
 import {
   ForkAll,
-  ForkBlobs,
+  ForkPostDeneb,
   ForkPostBellatrix,
   ForkPostAltair,
   ForkName,
@@ -123,7 +123,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       }
       return sszTypesFor(forkName);
     },
-    getPostDenebForkTypes(slot: Slot): SSZTypesFor<ForkBlobs> {
+    getPostDenebForkTypes(slot: Slot): SSZTypesFor<ForkPostDeneb> {
       const forkName = this.getForkName(slot);
       if (!isForkPostDeneb(forkName)) {
         throw Error(`Invalid slot=${slot} fork=${forkName} for post deneb fork types`);

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -7,7 +7,7 @@ import {
   ForkSeq,
   GENESIS_EPOCH,
   SLOTS_PER_EPOCH,
-  isForkBlobs,
+  isForkPostDeneb,
   isForkPostBellatrix,
   isForkPostAltair,
   isForkPostElectra,
@@ -125,7 +125,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
     },
     getBlobsForkTypes(slot: Slot): SSZTypesFor<ForkBlobs> {
       const forkName = this.getForkName(slot);
-      if (!isForkBlobs(forkName)) {
+      if (!isForkPostDeneb(forkName)) {
         throw Error(`Invalid slot=${slot} fork=${forkName} for blobs fork types`);
       }
       return sszTypesFor(forkName);

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -112,21 +112,21 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
     getPostBellatrixForkTypes(slot: Slot): SSZTypesFor<ForkPostBellatrix> {
       const forkName = this.getForkName(slot);
       if (!isForkPostBellatrix(forkName)) {
-        throw Error(`Invalid slot=${slot} fork=${forkName} for post bellatrix fork types`);
+        throw Error(`Invalid slot=${slot} fork=${forkName} for post-bellatrix fork types`);
       }
       return sszTypesFor(forkName);
     },
     getPostAltairForkTypes(slot: Slot): SSZTypesFor<ForkPostAltair> {
       const forkName = this.getForkName(slot);
       if (!isForkPostAltair(forkName)) {
-        throw Error(`Invalid slot=${slot} fork=${forkName} for post altair fork types`);
+        throw Error(`Invalid slot=${slot} fork=${forkName} for post-altair fork types`);
       }
       return sszTypesFor(forkName);
     },
     getPostDenebForkTypes(slot: Slot): SSZTypesFor<ForkPostDeneb> {
       const forkName = this.getForkName(slot);
       if (!isForkPostDeneb(forkName)) {
-        throw Error(`Invalid slot=${slot} fork=${forkName} for post deneb fork types`);
+        throw Error(`Invalid slot=${slot} fork=${forkName} for post-deneb fork types`);
       }
       return sszTypesFor(forkName);
     },

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -1,15 +1,15 @@
 import {
   ForkAll,
-  ForkPostDeneb,
-  ForkPostBellatrix,
-  ForkPostAltair,
   ForkName,
+  ForkPostAltair,
+  ForkPostBellatrix,
+  ForkPostDeneb,
   ForkSeq,
   GENESIS_EPOCH,
   SLOTS_PER_EPOCH,
-  isForkPostDeneb,
-  isForkPostBellatrix,
   isForkPostAltair,
+  isForkPostBellatrix,
+  isForkPostDeneb,
   isForkPostElectra,
 } from "@lodestar/params";
 import {Epoch, SSZTypesFor, Slot, Version, sszTypesFor} from "@lodestar/types";

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -8,7 +8,7 @@ import {
   GENESIS_EPOCH,
   SLOTS_PER_EPOCH,
   isForkBlobs,
-  isForkExecution,
+  isForkPostBellatrix,
   isForkPostAltair,
   isForkPostElectra,
 } from "@lodestar/params";
@@ -111,7 +111,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
     },
     getExecutionForkTypes(slot: Slot): SSZTypesFor<ForkExecution> {
       const forkName = this.getForkName(slot);
-      if (!isForkExecution(forkName)) {
+      if (!isForkPostBellatrix(forkName)) {
         throw Error(`Invalid slot=${slot} fork=${forkName} for execution fork types`);
       }
       return sszTypesFor(forkName);

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -9,7 +9,7 @@ import {
   SLOTS_PER_EPOCH,
   isForkBlobs,
   isForkExecution,
-  isForkLightClient,
+  isForkPostAltair,
   isForkPostElectra,
 } from "@lodestar/params";
 import {Epoch, SSZTypesFor, Slot, Version, sszTypesFor} from "@lodestar/types";
@@ -118,7 +118,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
     },
     getLightClientForkTypes(slot: Slot): SSZTypesFor<ForkLightClient> {
       const forkName = this.getForkName(slot);
-      if (!isForkLightClient(forkName)) {
+      if (!isForkPostAltair(forkName)) {
         throw Error(`Invalid slot=${slot} fork=${forkName} for lightclient fork types`);
       }
       return sszTypesFor(forkName);

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -116,10 +116,10 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       }
       return sszTypesFor(forkName);
     },
-    getLightClientForkTypes(slot: Slot): SSZTypesFor<ForkPostAltair> {
+    getPostAltairForkTypes(slot: Slot): SSZTypesFor<ForkPostAltair> {
       const forkName = this.getForkName(slot);
       if (!isForkPostAltair(forkName)) {
-        throw Error(`Invalid slot=${slot} fork=${forkName} for lightclient fork types`);
+        throw Error(`Invalid slot=${slot} fork=${forkName} for post altair fork types`);
       }
       return sszTypesFor(forkName);
     },

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -1,7 +1,7 @@
 import {
   ForkAll,
   ForkBlobs,
-  ForkExecution,
+  ForkPostBellatrix,
   ForkPostAltair,
   ForkName,
   ForkSeq,
@@ -109,7 +109,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
     getForkTypes<F extends ForkName = ForkAll>(slot: Slot): SSZTypesFor<F> {
       return sszTypesFor(this.getForkName(slot)) as SSZTypesFor<F>;
     },
-    getPostBellatrixForkTypes(slot: Slot): SSZTypesFor<ForkExecution> {
+    getPostBellatrixForkTypes(slot: Slot): SSZTypesFor<ForkPostBellatrix> {
       const forkName = this.getForkName(slot);
       if (!isForkPostBellatrix(forkName)) {
         throw Error(`Invalid slot=${slot} fork=${forkName} for post bellatrix fork types`);

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -1,4 +1,4 @@
-import {ForkAll, ForkBlobs, ForkExecution, ForkPostAltair, ForkName, ForkSeq} from "@lodestar/params";
+import {ForkAll, ForkBlobs, ForkPostBellatrix, ForkPostAltair, ForkName, ForkSeq} from "@lodestar/params";
 import {Epoch, SSZTypesFor, Slot, Version} from "@lodestar/types";
 
 export type ForkInfo = {
@@ -36,7 +36,7 @@ export type ForkConfig = {
   /** Get lightclient SSZ types by hard-fork*/
   getPostAltairForkTypes(slot: Slot): SSZTypesFor<ForkPostAltair>;
   /** Get execution SSZ types by hard-fork*/
-  getPostBellatrixForkTypes(slot: Slot): SSZTypesFor<ForkExecution>;
+  getPostBellatrixForkTypes(slot: Slot): SSZTypesFor<ForkPostBellatrix>;
   /** Get blobs SSZ types by hard-fork*/
   getBlobsForkTypes(slot: Slot): SSZTypesFor<ForkBlobs>;
   /** Get max blobs per block by hard-fork */

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -34,7 +34,7 @@ export type ForkConfig = {
   /** Get SSZ types by hard-fork */
   getForkTypes<F extends ForkName = ForkAll>(slot: Slot): SSZTypesFor<F>;
   /** Get lightclient SSZ types by hard-fork*/
-  getLightClientForkTypes(slot: Slot): SSZTypesFor<ForkPostAltair>;
+  getPostAltairForkTypes(slot: Slot): SSZTypesFor<ForkPostAltair>;
   /** Get execution SSZ types by hard-fork*/
   getExecutionForkTypes(slot: Slot): SSZTypesFor<ForkExecution>;
   /** Get blobs SSZ types by hard-fork*/

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -36,7 +36,7 @@ export type ForkConfig = {
   /** Get lightclient SSZ types by hard-fork*/
   getPostAltairForkTypes(slot: Slot): SSZTypesFor<ForkPostAltair>;
   /** Get execution SSZ types by hard-fork*/
-  getExecutionForkTypes(slot: Slot): SSZTypesFor<ForkExecution>;
+  getPostBellatrixForkTypes(slot: Slot): SSZTypesFor<ForkExecution>;
   /** Get blobs SSZ types by hard-fork*/
   getBlobsForkTypes(slot: Slot): SSZTypesFor<ForkBlobs>;
   /** Get max blobs per block by hard-fork */

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -38,7 +38,7 @@ export type ForkConfig = {
   /** Get execution SSZ types by hard-fork*/
   getPostBellatrixForkTypes(slot: Slot): SSZTypesFor<ForkPostBellatrix>;
   /** Get blobs SSZ types by hard-fork*/
-  getBlobsForkTypes(slot: Slot): SSZTypesFor<ForkBlobs>;
+  getPostDenebForkTypes(slot: Slot): SSZTypesFor<ForkBlobs>;
   /** Get max blobs per block by hard-fork */
   getMaxBlobsPerBlock(fork: ForkName): number;
   /** Get max request blob sidecars by hard-fork */

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -1,4 +1,4 @@
-import {ForkAll, ForkPostDeneb, ForkPostBellatrix, ForkPostAltair, ForkName, ForkSeq} from "@lodestar/params";
+import {ForkAll, ForkName, ForkPostAltair, ForkPostBellatrix, ForkPostDeneb, ForkSeq} from "@lodestar/params";
 import {Epoch, SSZTypesFor, Slot, Version} from "@lodestar/types";
 
 export type ForkInfo = {

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -1,4 +1,4 @@
-import {ForkAll, ForkBlobs, ForkPostBellatrix, ForkPostAltair, ForkName, ForkSeq} from "@lodestar/params";
+import {ForkAll, ForkPostDeneb, ForkPostBellatrix, ForkPostAltair, ForkName, ForkSeq} from "@lodestar/params";
 import {Epoch, SSZTypesFor, Slot, Version} from "@lodestar/types";
 
 export type ForkInfo = {
@@ -38,7 +38,7 @@ export type ForkConfig = {
   /** Get execution SSZ types by hard-fork*/
   getPostBellatrixForkTypes(slot: Slot): SSZTypesFor<ForkPostBellatrix>;
   /** Get blobs SSZ types by hard-fork*/
-  getPostDenebForkTypes(slot: Slot): SSZTypesFor<ForkBlobs>;
+  getPostDenebForkTypes(slot: Slot): SSZTypesFor<ForkPostDeneb>;
   /** Get max blobs per block by hard-fork */
   getMaxBlobsPerBlock(fork: ForkName): number;
   /** Get max request blob sidecars by hard-fork */

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -1,4 +1,4 @@
-import {ForkAll, ForkBlobs, ForkExecution, ForkLightClient, ForkName, ForkSeq} from "@lodestar/params";
+import {ForkAll, ForkBlobs, ForkExecution, ForkPostAltair, ForkName, ForkSeq} from "@lodestar/params";
 import {Epoch, SSZTypesFor, Slot, Version} from "@lodestar/types";
 
 export type ForkInfo = {
@@ -34,7 +34,7 @@ export type ForkConfig = {
   /** Get SSZ types by hard-fork */
   getForkTypes<F extends ForkName = ForkAll>(slot: Slot): SSZTypesFor<F>;
   /** Get lightclient SSZ types by hard-fork*/
-  getLightClientForkTypes(slot: Slot): SSZTypesFor<ForkLightClient>;
+  getLightClientForkTypes(slot: Slot): SSZTypesFor<ForkPostAltair>;
   /** Get execution SSZ types by hard-fork*/
   getExecutionForkTypes(slot: Slot): SSZTypesFor<ForkExecution>;
   /** Get blobs SSZ types by hard-fork*/

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -33,11 +33,11 @@ export type ForkConfig = {
   getForkVersion(slot: Slot): Version;
   /** Get SSZ types by hard-fork */
   getForkTypes<F extends ForkName = ForkAll>(slot: Slot): SSZTypesFor<F>;
-  /** Get lightclient SSZ types by hard-fork*/
+  /** Get post-altair SSZ types by hard-fork*/
   getPostAltairForkTypes(slot: Slot): SSZTypesFor<ForkPostAltair>;
-  /** Get execution SSZ types by hard-fork*/
+  /** Get post-bellatrix SSZ types by hard-fork*/
   getPostBellatrixForkTypes(slot: Slot): SSZTypesFor<ForkPostBellatrix>;
-  /** Get blobs SSZ types by hard-fork*/
+  /** Get post-deneb SSZ types by hard-fork*/
   getPostDenebForkTypes(slot: Slot): SSZTypesFor<ForkPostDeneb>;
   /** Get max blobs per block by hard-fork */
   getMaxBlobsPerBlock(fork: ForkName): number;

--- a/packages/light-client/src/spec/utils.ts
+++ b/packages/light-client/src/spec/utils.ts
@@ -174,7 +174,7 @@ export function isValidLightClientHeader(config: ChainForkConfig, header: LightC
 
   return isValidMerkleBranch(
     config
-      .getExecutionForkTypes(header.beacon.slot)
+      .getPostBellatrixForkTypes(header.beacon.slot)
       .ExecutionPayloadHeader.hashTreeRoot((header as LightClientHeader<ForkName.capella>).execution),
     (header as LightClientHeader<ForkName.capella>).executionBranch,
     EXECUTION_PAYLOAD_DEPTH,

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -94,69 +94,69 @@ export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
   return isForkPostDeneb(fork) && fork !== ForkName.deneb;
 }
 
-/**
+/*
  * Aliases only exported for backwards compatibility. This will be removed in
  * lodestar v2.0.  The types and guards above should be used in all places as
  * they are more correct than using the "main feature" from a fork.
  */
 
 /**
- * @deprecated
+ * @deprecated Use `ForkPostAltair` instead.
  */
 export type ForkLightClient = ForkPostAltair;
 /**
- * @deprecated
+ * @deprecated Use `ForkPreBellatrix` instead.
  */
 export type ForkPreExecution = ForkPreBellatrix;
 /**
- * @deprecated
+ * @deprecated Use `ForkPostBellatrix` instead.
  */
 export type ForkExecution = ForkPostBellatrix;
 /**
- * @deprecated
+ * @deprecated Use `ForkPreCapella` instead.
  */
 export type ForkPreWithdrawals = ForkPreCapella;
 /**
- * @deprecated
+ * @deprecated Use `ForkPostCapella` instead.
  */
 export type ForkWithdrawals = ForkPostCapella;
 /**
- * @deprecated
+ * @deprecated Use `ForkPreDeneb` instead.
  */
 export type ForkPreBlobs = ForkPreDeneb;
 /**
- * @deprecated
+ * @deprecated Use `ForkPostDeneb` instead.
  */
 export type ForkBlobs = ForkPostDeneb;
 /**
- * @deprecated
+ * @deprecated Use `forkPostAltair` instead.
  */
 export const forkLightClient = forkPostAltair;
 /**
- * @deprecated
+ * @deprecated Use `isForkPostAltair` instead.
  */
 export const isForkLightClient = isForkPostAltair;
 /**
- * @deprecated
+ * @deprecated Use `forkPostBellatrix` instead.
  */
 export const forkExecution = forkPostBellatrix;
 /**
- * @deprecated
+ * @deprecated Use `isForkPostBellatrix` instead.
  */
 export const isForkExecution = isForkPostBellatrix;
 /**
- * @deprecated
+ * @deprecated Use `forkPostCapella` instead.
  */
 export const forkWithdrawals = forkPostCapella;
 /**
- * @deprecated
+ * @deprecated Use `isForkPostCapella` instead.
  */
 export const isForkWithdrawals = isForkPostCapella;
 /**
- * @deprecated
+ * @deprecated Use `forkPostDeneb` instead.
  */
 export const forkBlobs = forkPostDeneb;
 /**
- * @deprecated
+ * @deprecated Use `isForkPostDeneb` instead.
  */
 export const isForkBlobs = isForkPostDeneb;

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -99,5 +99,4 @@ export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
  * places where they are more correct than using the "main feature" from a fork.
  */
 export type ForkPreBlobs = ForkPreDeneb;
-export type ForkBlobs = ForkPostDeneb;
 export {forkPostDeneb as forkBlobs};

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -98,7 +98,6 @@ export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
  * Aliases exported for compatibility. Types and guards above should be used in
  * places where they are more correct than using the "main feature" from a fork.
  */
-export type ForkLightClient = ForkPostAltair;
 export type ForkPreExecution = ForkPreBellatrix;
 export type ForkExecution = ForkPostBellatrix;
 export type ForkPreWithdrawals = ForkPreCapella;
@@ -106,8 +105,6 @@ export type ForkWithdrawals = ForkPostCapella;
 export type ForkPreBlobs = ForkPreDeneb;
 export type ForkBlobs = ForkPostDeneb;
 export {
-  forkPostAltair as forkLightClient,
-  isForkPostAltair as isForkLightClient,
   forkPostBellatrix as forkExecution,
   isForkPostBellatrix as isForkExecution,
   forkPostCapella as forkWithdrawals,

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -98,7 +98,6 @@ export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
  * Aliases exported for compatibility. Types and guards above should be used in
  * places where they are more correct than using the "main feature" from a fork.
  */
-export type ForkPreExecution = ForkPreBellatrix;
 export type ForkExecution = ForkPostBellatrix;
 export type ForkPreWithdrawals = ForkPreCapella;
 export type ForkWithdrawals = ForkPostCapella;

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -99,20 +99,64 @@ export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
  * lodestar v2.0.  The types and guards above should be used in all places as
  * they are more correct than using the "main feature" from a fork.
  */
+
+/**
+ * @deprecated
+ */
 export type ForkLightClient = ForkPostAltair;
+/**
+ * @deprecated
+ */
 export type ForkPreExecution = ForkPreBellatrix;
+/**
+ * @deprecated
+ */
 export type ForkExecution = ForkPostBellatrix;
+/**
+ * @deprecated
+ */
 export type ForkPreWithdrawals = ForkPreCapella;
+/**
+ * @deprecated
+ */
 export type ForkWithdrawals = ForkPostCapella;
+/**
+ * @deprecated
+ */
 export type ForkPreBlobs = ForkPreDeneb;
+/**
+ * @deprecated
+ */
 export type ForkBlobs = ForkPostDeneb;
-export {
-  forkPostAltair as forkLightClient,
-  isForkPostAltair as isForkLightClient,
-  forkPostBellatrix as forkExecution,
-  isForkPostBellatrix as isForkExecution,
-  forkPostCapella as forkWithdrawals,
-  isForkPostCapella as isForkWithdrawals,
-  forkPostDeneb as forkBlobs,
-  isForkPostDeneb as isForkBlobs,
-};
+/**
+ * @deprecated
+ */
+export const forkLightClient = forkPostAltair;
+/**
+ * @deprecated
+ */
+export const isForkLightClient = isForkPostAltair;
+/**
+ * @deprecated
+ */
+export const forkExecution = forkPostBellatrix;
+/**
+ * @deprecated
+ */
+export const isForkExecution = isForkPostBellatrix;
+/**
+ * @deprecated
+ */
+export const forkWithdrawals = forkPostCapella;
+/**
+ * @deprecated
+ */
+export const isForkWithdrawals = isForkPostCapella;
+/**
+ * @deprecated
+ */
+export const forkBlobs = forkPostDeneb;
+/**
+ * @deprecated
+ */
+export const isForkBlobs = isForkPostDeneb;

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -98,14 +98,8 @@ export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
  * Aliases exported for compatibility. Types and guards above should be used in
  * places where they are more correct than using the "main feature" from a fork.
  */
-export type ForkExecution = ForkPostBellatrix;
 export type ForkPreWithdrawals = ForkPreCapella;
 export type ForkWithdrawals = ForkPostCapella;
 export type ForkPreBlobs = ForkPreDeneb;
 export type ForkBlobs = ForkPostDeneb;
-export {
-  forkPostCapella as forkWithdrawals,
-  isForkPostCapella as isForkWithdrawals,
-  forkPostDeneb as forkBlobs,
-  isForkPostDeneb as isForkBlobs,
-};
+export {forkPostCapella as forkWithdrawals, forkPostDeneb as forkBlobs, isForkPostDeneb as isForkBlobs};

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -93,3 +93,25 @@ export const forkPostElectra = exclude(forkAll, [
 export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
   return isForkPostDeneb(fork) && fork !== ForkName.deneb;
 }
+
+/**
+ * Aliases exported for compatibility. Types and guards above should be used in
+ * places where they are more correct than using the "main feature" from a fork.
+ */
+export type ForkLightClient = ForkPostAltair;
+export type ForkPreExecution = ForkPreBellatrix;
+export type ForkExecution = ForkPostBellatrix;
+export type ForkPreWithdrawals = ForkPreCapella;
+export type ForkWithdrawals = ForkPostCapella;
+export type ForkPreBlobs = ForkPreDeneb;
+export type ForkBlobs = ForkPostDeneb;
+export {
+  forkPostAltair as forkLightClient,
+  isForkPostAltair as isForkLightClient,
+  forkPostBellatrix as forkExecution,
+  isForkPostBellatrix as isForkExecution,
+  forkPostCapella as forkWithdrawals,
+  isForkPostCapella as isForkWithdrawals,
+  forkPostDeneb as forkBlobs,
+  isForkPostDeneb as isForkBlobs,
+};

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -93,9 +93,3 @@ export const forkPostElectra = exclude(forkAll, [
 export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
   return isForkPostDeneb(fork) && fork !== ForkName.deneb;
 }
-
-/**
- * Aliases exported for compatibility. Types and guards above should be used in
- * places where they are more correct than using the "main feature" from a fork.
- */
-export {forkPostDeneb as forkBlobs};

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -104,7 +104,6 @@ export type ForkWithdrawals = ForkPostCapella;
 export type ForkPreBlobs = ForkPreDeneb;
 export type ForkBlobs = ForkPostDeneb;
 export {
-  forkPostBellatrix as forkExecution,
   forkPostCapella as forkWithdrawals,
   isForkPostCapella as isForkWithdrawals,
   forkPostDeneb as forkBlobs,

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -98,8 +98,6 @@ export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
  * Aliases exported for compatibility. Types and guards above should be used in
  * places where they are more correct than using the "main feature" from a fork.
  */
-export type ForkPreWithdrawals = ForkPreCapella;
-export type ForkWithdrawals = ForkPostCapella;
 export type ForkPreBlobs = ForkPreDeneb;
 export type ForkBlobs = ForkPostDeneb;
-export {forkPostCapella as forkWithdrawals, forkPostDeneb as forkBlobs, isForkPostDeneb as isForkBlobs};
+export {forkPostDeneb as forkBlobs, isForkPostDeneb as isForkBlobs};

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -98,5 +98,4 @@ export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
  * Aliases exported for compatibility. Types and guards above should be used in
  * places where they are more correct than using the "main feature" from a fork.
  */
-export type ForkPreBlobs = ForkPreDeneb;
 export {forkPostDeneb as forkBlobs};

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -105,7 +105,6 @@ export type ForkPreBlobs = ForkPreDeneb;
 export type ForkBlobs = ForkPostDeneb;
 export {
   forkPostBellatrix as forkExecution,
-  isForkPostBellatrix as isForkExecution,
   forkPostCapella as forkWithdrawals,
   isForkPostCapella as isForkWithdrawals,
   forkPostDeneb as forkBlobs,

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -95,8 +95,9 @@ export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
 }
 
 /**
- * Aliases exported for compatibility. Types and guards above should be used in
- * places where they are more correct than using the "main feature" from a fork.
+ * Aliases only exported for backwards compatibility. This will be removed in
+ * lodestar v2.0.  The types and guards above should be used in all places as
+ * they are more correct than using the "main feature" from a fork.
  */
 export type ForkLightClient = ForkPostAltair;
 export type ForkPreExecution = ForkPreBellatrix;

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -53,35 +53,35 @@ export function lowestFork<F extends ForkName>(forkNames: F[]): F {
 export type ForkAll = ForkName;
 export const forkAll = Object.values(ForkName);
 
-export type ForkPreLightClient = ForkName.phase0;
-export type ForkLightClient = Exclude<ForkName, ForkPreLightClient>;
-export const forkLightClient = exclude(forkAll, [ForkName.phase0]);
-export function isForkLightClient(fork: ForkName): fork is ForkLightClient {
+export type ForkPreAltair = ForkName.phase0;
+export type ForkPostAltair = Exclude<ForkName, ForkPreAltair>;
+export const forkPostAltair = exclude(forkAll, [ForkName.phase0]);
+export function isForkPostAltair(fork: ForkName): fork is ForkPostAltair {
   return fork !== ForkName.phase0;
 }
 
-export type ForkPreExecution = ForkPreLightClient | ForkName.altair;
-export type ForkExecution = Exclude<ForkName, ForkPreExecution>;
-export const forkExecution = exclude(forkAll, [ForkName.phase0, ForkName.altair]);
-export function isForkExecution(fork: ForkName): fork is ForkExecution {
-  return isForkLightClient(fork) && fork !== ForkName.altair;
+export type ForkPreBellatrix = ForkPreAltair | ForkName.altair;
+export type ForkPostBellatrix = Exclude<ForkName, ForkPreBellatrix>;
+export const forkPostBellatrix = exclude(forkAll, [ForkName.phase0, ForkName.altair]);
+export function isForkPostBellatrix(fork: ForkName): fork is ForkPostBellatrix {
+  return isForkPostAltair(fork) && fork !== ForkName.altair;
 }
 
-export type ForkPreWithdrawals = ForkPreExecution | ForkName.bellatrix;
-export type ForkWithdrawals = Exclude<ForkName, ForkPreWithdrawals>;
-export const forkWithdrawals = exclude(forkAll, [ForkName.phase0, ForkName.altair, ForkName.bellatrix]);
-export function isForkWithdrawals(fork: ForkName): fork is ForkWithdrawals {
-  return isForkExecution(fork) && fork !== ForkName.bellatrix;
+export type ForkPreCapella = ForkPreBellatrix | ForkName.bellatrix;
+export type ForkPostCapella = Exclude<ForkName, ForkPreCapella>;
+export const forkPostCapella = exclude(forkAll, [ForkName.phase0, ForkName.altair, ForkName.bellatrix]);
+export function isForkPostCapella(fork: ForkName): fork is ForkPostCapella {
+  return isForkPostBellatrix(fork) && fork !== ForkName.bellatrix;
 }
 
-export type ForkPreBlobs = ForkPreWithdrawals | ForkName.capella;
-export type ForkBlobs = Exclude<ForkName, ForkPreBlobs>;
-export const forkBlobs = exclude(forkAll, [ForkName.phase0, ForkName.altair, ForkName.bellatrix, ForkName.capella]);
-export function isForkBlobs(fork: ForkName): fork is ForkBlobs {
-  return isForkWithdrawals(fork) && fork !== ForkName.capella;
+export type ForkPreDeneb = ForkPreCapella | ForkName.capella;
+export type ForkPostDeneb = Exclude<ForkName, ForkPreDeneb>;
+export const forkPostDeneb = exclude(forkAll, [ForkName.phase0, ForkName.altair, ForkName.bellatrix, ForkName.capella]);
+export function isForkPostDeneb(fork: ForkName): fork is ForkPostDeneb {
+  return isForkPostCapella(fork) && fork !== ForkName.capella;
 }
 
-export type ForkPreElectra = ForkPreBlobs | ForkName.deneb;
+export type ForkPreElectra = ForkPreDeneb | ForkName.deneb;
 export type ForkPostElectra = Exclude<ForkName, ForkPreElectra>;
 export const forkPostElectra = exclude(forkAll, [
   ForkName.phase0,
@@ -91,5 +91,27 @@ export const forkPostElectra = exclude(forkAll, [
   ForkName.deneb,
 ]);
 export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
-  return isForkBlobs(fork) && fork !== ForkName.deneb;
+  return isForkPostDeneb(fork) && fork !== ForkName.deneb;
 }
+
+/**
+ * Aliases exported for compatibility. Types and guards above should be used in
+ * places where they are more correct than using the "main feature" from a fork.
+ */
+export type ForkLightClient = ForkPostAltair;
+export type ForkPreExecution = ForkPreBellatrix;
+export type ForkExecution = ForkPostBellatrix;
+export type ForkPreWithdrawals = ForkPreCapella;
+export type ForkWithdrawals = ForkPostCapella;
+export type ForkPreBlobs = ForkPreDeneb;
+export type ForkBlobs = ForkPostDeneb;
+export {
+  forkPostAltair as forkLightClient,
+  isForkPostAltair as isForkLightClient,
+  forkPostBellatrix as forkExecution,
+  isForkPostBellatrix as isForkExecution,
+  forkPostCapella as forkWithdrawals,
+  isForkPostCapella as isForkWithdrawals,
+  forkPostDeneb as forkBlobs,
+  isForkPostDeneb as isForkBlobs,
+};

--- a/packages/params/src/forkName.ts
+++ b/packages/params/src/forkName.ts
@@ -100,4 +100,4 @@ export function isForkPostElectra(fork: ForkName): fork is ForkPostElectra {
  */
 export type ForkPreBlobs = ForkPreDeneb;
 export type ForkBlobs = ForkPostDeneb;
-export {forkPostDeneb as forkBlobs, isForkPostDeneb as isForkBlobs};
+export {forkPostDeneb as forkBlobs};

--- a/packages/params/test/unit/__snapshots__/forkName.test.ts.snap
+++ b/packages/params/test/unit/__snapshots__/forkName.test.ts.snap
@@ -11,7 +11,7 @@ exports[`forkName > should have valid allForks 1`] = `
 ]
 `;
 
-exports[`forkName > should have valid post altair forks 1`] = `
+exports[`forkName > should have valid post-altair forks 1`] = `
 [
   "altair",
   "bellatrix",
@@ -21,7 +21,7 @@ exports[`forkName > should have valid post altair forks 1`] = `
 ]
 `;
 
-exports[`forkName > should have valid post bellatrix forks 1`] = `
+exports[`forkName > should have valid post-bellatrix forks 1`] = `
 [
   "bellatrix",
   "capella",
@@ -30,7 +30,7 @@ exports[`forkName > should have valid post bellatrix forks 1`] = `
 ]
 `;
 
-exports[`forkName > should have valid post capella forks 1`] = `
+exports[`forkName > should have valid post-capella forks 1`] = `
 [
   "capella",
   "deneb",
@@ -38,7 +38,7 @@ exports[`forkName > should have valid post capella forks 1`] = `
 ]
 `;
 
-exports[`forkName > should have valid post deneb forks 1`] = `
+exports[`forkName > should have valid post-deneb forks 1`] = `
 [
   "deneb",
   "electra",

--- a/packages/params/test/unit/__snapshots__/forkName.test.ts.snap
+++ b/packages/params/test/unit/__snapshots__/forkName.test.ts.snap
@@ -11,23 +11,7 @@ exports[`forkName > should have valid allForks 1`] = `
 ]
 `;
 
-exports[`forkName > should have valid blobs forks 1`] = `
-[
-  "deneb",
-  "electra",
-]
-`;
-
-exports[`forkName > should have valid execution forks 1`] = `
-[
-  "bellatrix",
-  "capella",
-  "deneb",
-  "electra",
-]
-`;
-
-exports[`forkName > should have valid lightclient forks 1`] = `
+exports[`forkName > should have valid post altair forks 1`] = `
 [
   "altair",
   "bellatrix",
@@ -37,9 +21,25 @@ exports[`forkName > should have valid lightclient forks 1`] = `
 ]
 `;
 
-exports[`forkName > should have valid withdrawal forks 1`] = `
+exports[`forkName > should have valid post bellatrix forks 1`] = `
+[
+  "bellatrix",
+  "capella",
+  "deneb",
+  "electra",
+]
+`;
+
+exports[`forkName > should have valid post capella forks 1`] = `
 [
   "capella",
+  "deneb",
+  "electra",
+]
+`;
+
+exports[`forkName > should have valid post deneb forks 1`] = `
+[
   "deneb",
   "electra",
 ]

--- a/packages/params/test/unit/forkName.test.ts
+++ b/packages/params/test/unit/forkName.test.ts
@@ -5,7 +5,7 @@ import {
   forkBlobs,
   forkPostBellatrix,
   forkPostAltair,
-  forkWithdrawals,
+  ForkPostCapella,
   highestFork,
   lowestFork,
 } from "../../src/forkName.js";
@@ -23,8 +23,8 @@ describe("forkName", () => {
     expect(forkPostAltair).toMatchSnapshot();
   });
 
-  it("should have valid withdrawal forks", () => {
-    expect(forkWithdrawals).toMatchSnapshot();
+  it("should have valid post capella forks", () => {
+    expect(ForkPostCapella).toMatchSnapshot();
   });
 
   it("should have valid blobs forks", () => {

--- a/packages/params/test/unit/forkName.test.ts
+++ b/packages/params/test/unit/forkName.test.ts
@@ -5,7 +5,7 @@ import {
   forkBlobs,
   forkPostBellatrix,
   forkPostAltair,
-  ForkPostCapella,
+  forkPostCapella,
   highestFork,
   lowestFork,
 } from "../../src/forkName.js";
@@ -24,7 +24,7 @@ describe("forkName", () => {
   });
 
   it("should have valid post capella forks", () => {
-    expect(ForkPostCapella).toMatchSnapshot();
+    expect(forkPostCapella).toMatchSnapshot();
   });
 
   it("should have valid blobs forks", () => {

--- a/packages/params/test/unit/forkName.test.ts
+++ b/packages/params/test/unit/forkName.test.ts
@@ -2,7 +2,7 @@ import {describe, expect, it} from "vitest";
 import {
   ForkName,
   forkAll,
-  forkBlobs,
+  forkPostDeneb,
   forkPostBellatrix,
   forkPostAltair,
   forkPostCapella,
@@ -27,8 +27,8 @@ describe("forkName", () => {
     expect(forkPostCapella).toMatchSnapshot();
   });
 
-  it("should have valid blobs forks", () => {
-    expect(forkBlobs).toMatchSnapshot();
+  it("should have valid post deneb forks", () => {
+    expect(forkPostDeneb).toMatchSnapshot();
   });
 
   describe("highestFork", () => {

--- a/packages/params/test/unit/forkName.test.ts
+++ b/packages/params/test/unit/forkName.test.ts
@@ -2,10 +2,10 @@ import {describe, expect, it} from "vitest";
 import {
   ForkName,
   forkAll,
-  forkPostDeneb,
-  forkPostBellatrix,
   forkPostAltair,
+  forkPostBellatrix,
   forkPostCapella,
+  forkPostDeneb,
   highestFork,
   lowestFork,
 } from "../../src/forkName.js";

--- a/packages/params/test/unit/forkName.test.ts
+++ b/packages/params/test/unit/forkName.test.ts
@@ -4,7 +4,7 @@ import {
   forkAll,
   forkBlobs,
   forkExecution,
-  forkLightClient,
+  forkPostAltair,
   forkWithdrawals,
   highestFork,
   lowestFork,
@@ -19,8 +19,8 @@ describe("forkName", () => {
     expect(forkExecution).toMatchSnapshot();
   });
 
-  it("should have valid lightclient forks", () => {
-    expect(forkLightClient).toMatchSnapshot();
+  it("should have valid post altair forks", () => {
+    expect(forkPostAltair).toMatchSnapshot();
   });
 
   it("should have valid withdrawal forks", () => {

--- a/packages/params/test/unit/forkName.test.ts
+++ b/packages/params/test/unit/forkName.test.ts
@@ -15,19 +15,19 @@ describe("forkName", () => {
     expect(forkAll).toMatchSnapshot();
   });
 
-  it("should have valid post bellatrix forks", () => {
+  it("should have valid post-bellatrix forks", () => {
     expect(forkPostBellatrix).toMatchSnapshot();
   });
 
-  it("should have valid post altair forks", () => {
+  it("should have valid post-altair forks", () => {
     expect(forkPostAltair).toMatchSnapshot();
   });
 
-  it("should have valid post capella forks", () => {
+  it("should have valid post-capella forks", () => {
     expect(forkPostCapella).toMatchSnapshot();
   });
 
-  it("should have valid post deneb forks", () => {
+  it("should have valid post-deneb forks", () => {
     expect(forkPostDeneb).toMatchSnapshot();
   });
 

--- a/packages/params/test/unit/forkName.test.ts
+++ b/packages/params/test/unit/forkName.test.ts
@@ -3,7 +3,7 @@ import {
   ForkName,
   forkAll,
   forkBlobs,
-  forkExecution,
+  forkPostBellatrix,
   forkPostAltair,
   forkWithdrawals,
   highestFork,
@@ -15,8 +15,8 @@ describe("forkName", () => {
     expect(forkAll).toMatchSnapshot();
   });
 
-  it("should have valid execution forks", () => {
-    expect(forkExecution).toMatchSnapshot();
+  it("should have valid post bellatrix forks", () => {
+    expect(forkPostBellatrix).toMatchSnapshot();
   });
 
   it("should have valid post altair forks", () => {

--- a/packages/prover/src/proof_provider/proof_provider.ts
+++ b/packages/prover/src/proof_provider/proof_provider.ts
@@ -177,7 +177,7 @@ export class ProofProvider {
       return;
     }
 
-    const sszType = this.opts.config.getExecutionForkTypes(lcHeader.beacon.slot).ExecutionPayloadHeader;
+    const sszType = this.opts.config.getPostBellatrixForkTypes(lcHeader.beacon.slot).ExecutionPayloadHeader;
     if (
       isForkWithdrawals(fork) &&
       (!("execution" in lcHeader) || sszType.equals(lcHeader.execution, sszType.defaultValue()))

--- a/packages/prover/src/proof_provider/proof_provider.ts
+++ b/packages/prover/src/proof_provider/proof_provider.ts
@@ -3,7 +3,7 @@ import {ChainForkConfig, createChainForkConfig} from "@lodestar/config";
 import {NetworkName, networksChainConfig} from "@lodestar/config/networks";
 import {Lightclient, LightclientEvent, RunStatusCode} from "@lodestar/light-client";
 import {LightClientRestTransport} from "@lodestar/light-client/transport";
-import {ForkName, isForkWithdrawals} from "@lodestar/params";
+import {ForkName, isForkPostCapella} from "@lodestar/params";
 import {ExecutionPayload, LightClientHeader} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {LCTransport, RootProviderInitOptions} from "../interfaces.js";
@@ -173,13 +173,13 @@ export class ProofProvider {
   async processLCHeader(lcHeader: LightClientHeader, finalized = false): Promise<void> {
     const fork = this.opts.config.getForkName(lcHeader.beacon.slot);
 
-    if (!isForkWithdrawals(fork)) {
+    if (!isForkPostCapella(fork)) {
       return;
     }
 
     const sszType = this.opts.config.getPostBellatrixForkTypes(lcHeader.beacon.slot).ExecutionPayloadHeader;
     if (
-      isForkWithdrawals(fork) &&
+      isForkPostCapella(fork) &&
       (!("execution" in lcHeader) || sszType.equals(lcHeader.execution, sszType.defaultValue()))
     ) {
       throw new Error("Execution payload is required for execution fork");

--- a/packages/prover/test/mocks/request_handler.ts
+++ b/packages/prover/test/mocks/request_handler.ts
@@ -107,7 +107,7 @@ export function generateReqHandlerOptionsMock(
   config: ForkConfig
 ): Omit<ELVerifiedRequestHandlerOpts<any>, "payload"> {
   const executionPayload = config
-    .getExecutionForkTypes(parseInt(data.beacon.headers.header.message.slot))
+    .getPostBellatrixForkTypes(parseInt(data.beacon.headers.header.message.slot))
     .ExecutionPayload.fromJson(data.beacon.executionPayload);
 
   const options = {

--- a/packages/state-transition/src/block/processExecutionPayload.ts
+++ b/packages/state-transition/src/block/processExecutionPayload.ts
@@ -1,5 +1,5 @@
 import {byteArrayEquals} from "@chainsafe/ssz";
-import {ForkName, ForkSeq, isForkBlobs} from "@lodestar/params";
+import {ForkName, ForkSeq, isForkPostDeneb} from "@lodestar/params";
 import {BeaconBlockBody, BlindedBeaconBlockBody, deneb, isExecutionPayload} from "@lodestar/types";
 import {toHex, toRootHex} from "@lodestar/utils";
 import {CachedBeaconStateBellatrix, CachedBeaconStateCapella} from "../types.js";
@@ -48,7 +48,7 @@ export function processExecutionPayload(
     throw Error(`Invalid timestamp ${payload.timestamp} genesisTime=${state.genesisTime} slot=${state.slot}`);
   }
 
-  if (isForkBlobs(forkName)) {
+  if (isForkPostDeneb(forkName)) {
     const maxBlobsPerBlock = state.config.getMaxBlobsPerBlock(forkName);
     const blobKzgCommitmentsLen = (body as deneb.BeaconBlockBody).blobKzgCommitments?.length ?? 0;
     if (blobKzgCommitmentsLen > maxBlobsPerBlock) {

--- a/packages/state-transition/src/block/processExecutionPayload.ts
+++ b/packages/state-transition/src/block/processExecutionPayload.ts
@@ -79,6 +79,6 @@ export function processExecutionPayload(
   // TODO Deneb: Types are not happy by default. Since it's a generic type going through ViewDU
   // transformation then into all forks compatible probably some weird intersection incompatibility happens
   state.latestExecutionPayloadHeader = state.config
-    .getExecutionForkTypes(state.slot)
+    .getPostBellatrixForkTypes(state.slot)
     .ExecutionPayloadHeader.toViewDU(payloadHeader) as typeof state.latestExecutionPayloadHeader;
 }

--- a/packages/state-transition/src/cache/types.ts
+++ b/packages/state-transition/src/cache/types.ts
@@ -1,5 +1,5 @@
 import {CompositeViewDU} from "@chainsafe/ssz";
-import {ForkAll, ForkExecution, ForkName} from "@lodestar/params";
+import {ForkAll, ForkPostBellatrix, ForkName} from "@lodestar/params";
 import {Epoch, RootHex, SSZTypesFor} from "@lodestar/types";
 import {EpochShuffling} from "../util/epochShuffling.js";
 
@@ -11,6 +11,6 @@ export type BeaconStateDeneb = CompositeViewDU<SSZTypesFor<ForkName.deneb, "Beac
 export type BeaconStateElectra = CompositeViewDU<SSZTypesFor<ForkName.electra, "BeaconState">>;
 
 export type BeaconStateAllForks = CompositeViewDU<SSZTypesFor<ForkAll, "BeaconState">>;
-export type BeaconStateExecutions = CompositeViewDU<SSZTypesFor<ForkExecution, "BeaconState">>;
+export type BeaconStateExecutions = CompositeViewDU<SSZTypesFor<ForkPostBellatrix, "BeaconState">>;
 
 export type ShufflingGetter = (shufflingEpoch: Epoch, dependentRoot: RootHex) => EpochShuffling | null;

--- a/packages/state-transition/src/cache/types.ts
+++ b/packages/state-transition/src/cache/types.ts
@@ -1,5 +1,5 @@
 import {CompositeViewDU} from "@chainsafe/ssz";
-import {ForkAll, ForkPostBellatrix, ForkName} from "@lodestar/params";
+import {ForkAll, ForkName, ForkPostBellatrix} from "@lodestar/params";
 import {Epoch, RootHex, SSZTypesFor} from "@lodestar/types";
 import {EpochShuffling} from "../util/epochShuffling.js";
 

--- a/packages/state-transition/src/signatureSets/proposer.ts
+++ b/packages/state-transition/src/signatureSets/proposer.ts
@@ -20,7 +20,7 @@ export function getBlockProposerSignatureSet(
   const domain = config.getDomain(state.slot, DOMAIN_BEACON_PROPOSER, signedBlock.message.slot);
 
   const blockType = isBlindedBeaconBlock(signedBlock.message)
-    ? config.getExecutionForkTypes(signedBlock.message.slot).BlindedBeaconBlock
+    ? config.getPostBellatrixForkTypes(signedBlock.message.slot).BlindedBeaconBlock
     : config.getForkTypes(signedBlock.message.slot).BeaconBlock;
 
   return {

--- a/packages/state-transition/src/util/blindedBlock.ts
+++ b/packages/state-transition/src/util/blindedBlock.ts
@@ -26,7 +26,7 @@ export function blindedOrFullBlockHashTreeRoot(
   return isBlindedBeaconBlock(blindedOrFull)
     ? // Blinded
       config
-        .getExecutionForkTypes(blindedOrFull.slot)
+        .getPostBellatrixForkTypes(blindedOrFull.slot)
         .BlindedBeaconBlock.hashTreeRoot(blindedOrFull)
     : // Full
       config
@@ -41,7 +41,7 @@ export function blindedOrFullBlockToHeader(
   const bodyRoot = isBlindedBeaconBlock(blindedOrFull)
     ? // Blinded
       config
-        .getExecutionForkTypes(blindedOrFull.slot)
+        .getPostBellatrixForkTypes(blindedOrFull.slot)
         .BlindedBeaconBlockBody.hashTreeRoot(blindedOrFull.body)
     : // Full
       config

--- a/packages/state-transition/src/util/blindedBlock.ts
+++ b/packages/state-transition/src/util/blindedBlock.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkExecution, ForkSeq} from "@lodestar/params";
+import {ForkPostBellatrix, ForkSeq} from "@lodestar/params";
 import {
   BeaconBlock,
   BeaconBlockHeader,
@@ -57,7 +57,10 @@ export function blindedOrFullBlockToHeader(
   };
 }
 
-export function beaconBlockToBlinded(config: ChainForkConfig, block: BeaconBlock<ForkExecution>): BlindedBeaconBlock {
+export function beaconBlockToBlinded(
+  config: ChainForkConfig,
+  block: BeaconBlock<ForkPostBellatrix>
+): BlindedBeaconBlock {
   const fork = config.getForkName(block.slot);
   const executionPayloadHeader = executionPayloadToPayloadHeader(ForkSeq[fork], block.body.executionPayload);
   const blindedBlock: BlindedBeaconBlock = {...block, body: {...block.body, executionPayloadHeader}};
@@ -66,7 +69,7 @@ export function beaconBlockToBlinded(config: ChainForkConfig, block: BeaconBlock
 
 export function signedBeaconBlockToBlinded(
   config: ChainForkConfig,
-  signedBlock: SignedBeaconBlock<ForkExecution>
+  signedBlock: SignedBeaconBlock<ForkPostBellatrix>
 ): SignedBlindedBeaconBlock {
   return {
     message: beaconBlockToBlinded(config, signedBlock.message),

--- a/packages/state-transition/src/util/execution.ts
+++ b/packages/state-transition/src/util/execution.ts
@@ -1,4 +1,4 @@
-import {ForkPostBellatrix, ForkName, ForkSeq} from "@lodestar/params";
+import {ForkName, ForkPostBellatrix, ForkSeq} from "@lodestar/params";
 import {
   BeaconBlock,
   BeaconBlockBody,

--- a/packages/state-transition/src/util/execution.ts
+++ b/packages/state-transition/src/util/execution.ts
@@ -1,4 +1,4 @@
-import {ForkExecution, ForkName, ForkSeq} from "@lodestar/params";
+import {ForkPostBellatrix, ForkName, ForkSeq} from "@lodestar/params";
 import {
   BeaconBlock,
   BeaconBlockBody,
@@ -99,8 +99,8 @@ export function isExecutionCachedStateType(state: CachedBeaconStateAllForks): st
 }
 
 /** Type guard for ExecutionBlockBody */
-export function isExecutionBlockBodyType(blockBody: BeaconBlockBody): blockBody is BeaconBlockBody<ForkExecution> {
-  return (blockBody as BeaconBlockBody<ForkExecution>).executionPayload !== undefined;
+export function isExecutionBlockBodyType(blockBody: BeaconBlockBody): blockBody is BeaconBlockBody<ForkPostBellatrix> {
+  return (blockBody as BeaconBlockBody<ForkPostBellatrix>).executionPayload !== undefined;
 }
 
 export function getFullOrBlindedPayload(block: BeaconBlock): ExecutionPayload | ExecutionPayloadHeader {

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -1,7 +1,7 @@
 import {
   ForkAll,
   ForkBlobs,
-  ForkExecution,
+  ForkPostBellatrix,
   ForkPostAltair,
   ForkName,
   ForkPostElectra,
@@ -237,14 +237,15 @@ export type BeaconBlockHeader<F extends ForkAll = ForkAll> = TypesByFork[F]["Bea
 export type SignedBeaconBlockHeader<F extends ForkAll = ForkAll> = TypesByFork[F]["SignedBeaconBlockHeader"];
 
 export type BeaconBlock<F extends ForkAll = ForkAll> = TypesByFork[F]["BeaconBlock"];
-export type BlindedBeaconBlock<F extends ForkExecution = ForkExecution> = TypesByFork[F]["BlindedBeaconBlock"];
+export type BlindedBeaconBlock<F extends ForkPostBellatrix = ForkPostBellatrix> = TypesByFork[F]["BlindedBeaconBlock"];
 
 export type SignedBeaconBlock<F extends ForkAll = ForkAll> = TypesByFork[F]["SignedBeaconBlock"];
-export type SignedBlindedBeaconBlock<F extends ForkExecution = ForkExecution> =
+export type SignedBlindedBeaconBlock<F extends ForkPostBellatrix = ForkPostBellatrix> =
   TypesByFork[F]["SignedBlindedBeaconBlock"];
 
 export type BeaconBlockBody<F extends ForkAll = ForkAll> = TypesByFork[F]["BeaconBlockBody"];
-export type BlindedBeaconBlockBody<F extends ForkExecution = ForkExecution> = TypesByFork[F]["BlindedBeaconBlockBody"];
+export type BlindedBeaconBlockBody<F extends ForkPostBellatrix = ForkPostBellatrix> =
+  TypesByFork[F]["BlindedBeaconBlockBody"];
 
 export type BlockContents<F extends ForkBlobs = ForkBlobs> = TypesByFork[F]["BlockContents"];
 export type SignedBlockContents<F extends ForkBlobs = ForkBlobs> = TypesByFork[F]["SignedBlockContents"];
@@ -258,8 +259,9 @@ export type SignedBeaconBlockOrContents<FB extends ForkPreBlobs = ForkPreBlobs, 
   | SignedBeaconBlock<FB>
   | SignedBlockContents<FC>;
 
-export type ExecutionPayload<F extends ForkExecution = ForkExecution> = TypesByFork[F]["ExecutionPayload"];
-export type ExecutionPayloadHeader<F extends ForkExecution = ForkExecution> = TypesByFork[F]["ExecutionPayloadHeader"];
+export type ExecutionPayload<F extends ForkPostBellatrix = ForkPostBellatrix> = TypesByFork[F]["ExecutionPayload"];
+export type ExecutionPayloadHeader<F extends ForkPostBellatrix = ForkPostBellatrix> =
+  TypesByFork[F]["ExecutionPayloadHeader"];
 export type ExecutionRequests<F extends ForkPostElectra = ForkPostElectra> = TypesByFork[F]["ExecutionRequests"];
 
 export type BlobsBundle<F extends ForkBlobs = ForkBlobs> = TypesByFork[F]["BlobsBundle"];
@@ -282,9 +284,10 @@ export type BeaconState<F extends ForkName = ForkAll> = TypesByFork[F]["BeaconSt
 
 export type Metadata<F extends ForkName = ForkAll> = TypesByFork[F]["Metadata"];
 
-export type BuilderBid<F extends ForkExecution = ForkExecution> = TypesByFork[F]["BuilderBid"];
-export type SignedBuilderBid<F extends ForkExecution = ForkExecution> = TypesByFork[F]["SignedBuilderBid"];
-export type SSEPayloadAttributes<F extends ForkExecution = ForkExecution> = TypesByFork[F]["SSEPayloadAttributes"];
+export type BuilderBid<F extends ForkPostBellatrix = ForkPostBellatrix> = TypesByFork[F]["BuilderBid"];
+export type SignedBuilderBid<F extends ForkPostBellatrix = ForkPostBellatrix> = TypesByFork[F]["SignedBuilderBid"];
+export type SSEPayloadAttributes<F extends ForkPostBellatrix = ForkPostBellatrix> =
+  TypesByFork[F]["SSEPayloadAttributes"];
 
 export type Attestation<F extends ForkName = ForkAll> = TypesByFork[F]["Attestation"];
 export type SingleAttestation<F extends ForkName = ForkAll> = TypesByFork[F]["SingleAttestation"];

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -2,7 +2,7 @@ import {
   ForkAll,
   ForkBlobs,
   ForkExecution,
-  ForkLightClient,
+  ForkPostAltair,
   ForkName,
   ForkPostElectra,
   ForkPreBlobs,
@@ -267,16 +267,16 @@ export type Contents<F extends ForkBlobs = ForkBlobs> = TypesByFork[F]["Contents
 export type ExecutionPayloadAndBlobsBundle<F extends ForkBlobs = ForkBlobs> =
   TypesByFork[F]["ExecutionPayloadAndBlobsBundle"];
 
-export type LightClientHeader<F extends ForkLightClient = ForkLightClient> = TypesByFork[F]["LightClientHeader"];
-export type LightClientBootstrap<F extends ForkLightClient = ForkLightClient> = TypesByFork[F]["LightClientBootstrap"];
-export type LightClientUpdate<F extends ForkLightClient = ForkLightClient> = TypesByFork[F]["LightClientUpdate"];
-export type LightClientFinalityUpdate<F extends ForkLightClient = ForkLightClient> =
+export type LightClientHeader<F extends ForkPostAltair = ForkPostAltair> = TypesByFork[F]["LightClientHeader"];
+export type LightClientBootstrap<F extends ForkPostAltair = ForkPostAltair> = TypesByFork[F]["LightClientBootstrap"];
+export type LightClientUpdate<F extends ForkPostAltair = ForkPostAltair> = TypesByFork[F]["LightClientUpdate"];
+export type LightClientFinalityUpdate<F extends ForkPostAltair = ForkPostAltair> =
   TypesByFork[F]["LightClientFinalityUpdate"];
-export type LightClientOptimisticUpdate<F extends ForkLightClient = ForkLightClient> =
+export type LightClientOptimisticUpdate<F extends ForkPostAltair = ForkPostAltair> =
   TypesByFork[F]["LightClientOptimisticUpdate"];
-export type LightClientStore<F extends ForkLightClient = ForkLightClient> = TypesByFork[F]["LightClientStore"];
-export type SyncCommittee<F extends ForkLightClient = ForkLightClient> = TypesByFork[F]["SyncCommittee"];
-export type SyncAggregate<F extends ForkLightClient = ForkLightClient> = TypesByFork[F]["SyncAggregate"];
+export type LightClientStore<F extends ForkPostAltair = ForkPostAltair> = TypesByFork[F]["LightClientStore"];
+export type SyncCommittee<F extends ForkPostAltair = ForkPostAltair> = TypesByFork[F]["SyncCommittee"];
+export type SyncAggregate<F extends ForkPostAltair = ForkPostAltair> = TypesByFork[F]["SyncAggregate"];
 
 export type BeaconState<F extends ForkName = ForkAll> = TypesByFork[F]["BeaconState"];
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -1,9 +1,9 @@
 import {
   ForkAll,
-  ForkPostDeneb,
-  ForkPostBellatrix,
-  ForkPostAltair,
   ForkName,
+  ForkPostAltair,
+  ForkPostBellatrix,
+  ForkPostDeneb,
   ForkPostElectra,
   ForkPreDeneb,
 } from "@lodestar/params";

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -5,7 +5,7 @@ import {
   ForkPostAltair,
   ForkName,
   ForkPostElectra,
-  ForkPreBlobs,
+  ForkPreDeneb,
 } from "@lodestar/params";
 import {ts as altair} from "./altair/index.js";
 import {ts as bellatrix} from "./bellatrix/index.js";
@@ -253,12 +253,12 @@ export type SignedOrUnsignedBlockContents<F extends ForkPostDeneb = ForkPostDene
   | BlockContents<F>
   | SignedBlockContents<F>;
 
-export type BeaconBlockOrContents<FB extends ForkPreBlobs = ForkPreBlobs, FC extends ForkPostDeneb = ForkPostDeneb> =
+export type BeaconBlockOrContents<FB extends ForkPreDeneb = ForkPreDeneb, FC extends ForkPostDeneb = ForkPostDeneb> =
   | BeaconBlock<FB>
   | BlockContents<FC>;
 
 export type SignedBeaconBlockOrContents<
-  FB extends ForkPreBlobs = ForkPreBlobs,
+  FB extends ForkPreDeneb = ForkPreDeneb,
   FC extends ForkPostDeneb = ForkPostDeneb,
 > = SignedBeaconBlock<FB> | SignedBlockContents<FC>;
 

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -1,6 +1,6 @@
 import {
   ForkAll,
-  ForkBlobs,
+  ForkPostDeneb,
   ForkPostBellatrix,
   ForkPostAltair,
   ForkName,
@@ -247,26 +247,29 @@ export type BeaconBlockBody<F extends ForkAll = ForkAll> = TypesByFork[F]["Beaco
 export type BlindedBeaconBlockBody<F extends ForkPostBellatrix = ForkPostBellatrix> =
   TypesByFork[F]["BlindedBeaconBlockBody"];
 
-export type BlockContents<F extends ForkBlobs = ForkBlobs> = TypesByFork[F]["BlockContents"];
-export type SignedBlockContents<F extends ForkBlobs = ForkBlobs> = TypesByFork[F]["SignedBlockContents"];
-export type SignedOrUnsignedBlockContents<F extends ForkBlobs = ForkBlobs> = BlockContents<F> | SignedBlockContents<F>;
+export type BlockContents<F extends ForkPostDeneb = ForkPostDeneb> = TypesByFork[F]["BlockContents"];
+export type SignedBlockContents<F extends ForkPostDeneb = ForkPostDeneb> = TypesByFork[F]["SignedBlockContents"];
+export type SignedOrUnsignedBlockContents<F extends ForkPostDeneb = ForkPostDeneb> =
+  | BlockContents<F>
+  | SignedBlockContents<F>;
 
-export type BeaconBlockOrContents<FB extends ForkPreBlobs = ForkPreBlobs, FC extends ForkBlobs = ForkBlobs> =
+export type BeaconBlockOrContents<FB extends ForkPreBlobs = ForkPreBlobs, FC extends ForkPostDeneb = ForkPostDeneb> =
   | BeaconBlock<FB>
   | BlockContents<FC>;
 
-export type SignedBeaconBlockOrContents<FB extends ForkPreBlobs = ForkPreBlobs, FC extends ForkBlobs = ForkBlobs> =
-  | SignedBeaconBlock<FB>
-  | SignedBlockContents<FC>;
+export type SignedBeaconBlockOrContents<
+  FB extends ForkPreBlobs = ForkPreBlobs,
+  FC extends ForkPostDeneb = ForkPostDeneb,
+> = SignedBeaconBlock<FB> | SignedBlockContents<FC>;
 
 export type ExecutionPayload<F extends ForkPostBellatrix = ForkPostBellatrix> = TypesByFork[F]["ExecutionPayload"];
 export type ExecutionPayloadHeader<F extends ForkPostBellatrix = ForkPostBellatrix> =
   TypesByFork[F]["ExecutionPayloadHeader"];
 export type ExecutionRequests<F extends ForkPostElectra = ForkPostElectra> = TypesByFork[F]["ExecutionRequests"];
 
-export type BlobsBundle<F extends ForkBlobs = ForkBlobs> = TypesByFork[F]["BlobsBundle"];
-export type Contents<F extends ForkBlobs = ForkBlobs> = TypesByFork[F]["Contents"];
-export type ExecutionPayloadAndBlobsBundle<F extends ForkBlobs = ForkBlobs> =
+export type BlobsBundle<F extends ForkPostDeneb = ForkPostDeneb> = TypesByFork[F]["BlobsBundle"];
+export type Contents<F extends ForkPostDeneb = ForkPostDeneb> = TypesByFork[F]["Contents"];
+export type ExecutionPayloadAndBlobsBundle<F extends ForkPostDeneb = ForkPostDeneb> =
   TypesByFork[F]["ExecutionPayloadAndBlobsBundle"];
 
 export type LightClientHeader<F extends ForkPostAltair = ForkPostAltair> = TypesByFork[F]["LightClientHeader"];

--- a/packages/types/src/utils/typeguards.ts
+++ b/packages/types/src/utils/typeguards.ts
@@ -1,4 +1,4 @@
-import {FINALIZED_ROOT_DEPTH_ELECTRA, ForkBlobs, ForkExecution, ForkPostElectra} from "@lodestar/params";
+import {FINALIZED_ROOT_DEPTH_ELECTRA, ForkBlobs, ForkPostBellatrix, ForkPostElectra} from "@lodestar/params";
 import {
   Attestation,
   BeaconBlock,
@@ -19,7 +19,7 @@ import {
   SingleAttestation,
 } from "../types.js";
 
-export function isExecutionPayload<F extends ForkExecution>(
+export function isExecutionPayload<F extends ForkPostBellatrix>(
   payload: ExecutionPayload<F> | ExecutionPayloadHeader<F>
 ): payload is ExecutionPayload<F> {
   // we just check transactionsRoot for determining as it the base field
@@ -27,7 +27,7 @@ export function isExecutionPayload<F extends ForkExecution>(
   return (payload as ExecutionPayload<F>).transactions !== undefined;
 }
 
-export function isExecutionPayloadHeader<F extends ForkExecution>(
+export function isExecutionPayloadHeader<F extends ForkPostBellatrix>(
   payload: ExecutionPayload<F> | ExecutionPayloadHeader<F>
 ): payload is ExecutionPayloadHeader<F> {
   // we just check transactionsRoot for determining as it the base field
@@ -36,24 +36,24 @@ export function isExecutionPayloadHeader<F extends ForkExecution>(
 }
 
 export function isExecutionPayloadAndBlobsBundle<F extends ForkBlobs>(
-  data: ExecutionPayload<ForkExecution> | ExecutionPayloadAndBlobsBundle<F>
+  data: ExecutionPayload<ForkPostBellatrix> | ExecutionPayloadAndBlobsBundle<F>
 ): data is ExecutionPayloadAndBlobsBundle<F> {
   return (data as ExecutionPayloadAndBlobsBundle<ForkBlobs>).blobsBundle !== undefined;
 }
 
-export function isBlindedBeaconBlock<F extends ForkExecution>(
+export function isBlindedBeaconBlock<F extends ForkPostBellatrix>(
   block: BeaconBlockOrContents | SignedBeaconBlockOrContents
 ): block is BlindedBeaconBlock<F> {
   return (block as BeaconBlock).body !== null && isBlindedBeaconBlockBody((block as BeaconBlock).body);
 }
 
-export function isBlindedSignedBeaconBlock<F extends ForkExecution>(
+export function isBlindedSignedBeaconBlock<F extends ForkPostBellatrix>(
   signedBlock: SignedBeaconBlock | SignedBeaconBlockOrContents
 ): signedBlock is SignedBlindedBeaconBlock<F> {
   return (signedBlock as SignedBlindedBeaconBlock<F>).message.body.executionPayloadHeader !== undefined;
 }
 
-export function isBlindedBeaconBlockBody<F extends ForkExecution>(
+export function isBlindedBeaconBlockBody<F extends ForkPostBellatrix>(
   body: BeaconBlockBody | BlindedBeaconBlockBody
 ): body is BlindedBeaconBlockBody<F> {
   return (body as BlindedBeaconBlockBody).executionPayloadHeader !== undefined;

--- a/packages/types/src/utils/typeguards.ts
+++ b/packages/types/src/utils/typeguards.ts
@@ -1,4 +1,4 @@
-import {FINALIZED_ROOT_DEPTH_ELECTRA, ForkBlobs, ForkPostBellatrix, ForkPostElectra} from "@lodestar/params";
+import {FINALIZED_ROOT_DEPTH_ELECTRA, ForkPostDeneb, ForkPostBellatrix, ForkPostElectra} from "@lodestar/params";
 import {
   Attestation,
   BeaconBlock,
@@ -35,10 +35,10 @@ export function isExecutionPayloadHeader<F extends ForkPostBellatrix>(
   return (payload as ExecutionPayloadHeader<F>).transactionsRoot !== undefined;
 }
 
-export function isExecutionPayloadAndBlobsBundle<F extends ForkBlobs>(
+export function isExecutionPayloadAndBlobsBundle<F extends ForkPostDeneb>(
   data: ExecutionPayload<ForkPostBellatrix> | ExecutionPayloadAndBlobsBundle<F>
 ): data is ExecutionPayloadAndBlobsBundle<F> {
-  return (data as ExecutionPayloadAndBlobsBundle<ForkBlobs>).blobsBundle !== undefined;
+  return (data as ExecutionPayloadAndBlobsBundle<ForkPostDeneb>).blobsBundle !== undefined;
 }
 
 export function isBlindedBeaconBlock<F extends ForkPostBellatrix>(
@@ -59,13 +59,13 @@ export function isBlindedBeaconBlockBody<F extends ForkPostBellatrix>(
   return (body as BlindedBeaconBlockBody).executionPayloadHeader !== undefined;
 }
 
-export function isBlockContents<F extends ForkBlobs>(
+export function isBlockContents<F extends ForkPostDeneb>(
   data: BeaconBlockOrContents | SignedBeaconBlockOrContents
 ): data is BlockContents<F> {
   return (data as BlockContents<F>).kzgProofs !== undefined;
 }
 
-export function isSignedBlockContents<F extends ForkBlobs>(
+export function isSignedBlockContents<F extends ForkPostDeneb>(
   data: SignedBeaconBlockOrContents | BeaconBlockOrContents
 ): data is SignedBlockContents<F> {
   return (data as SignedBlockContents<F>).kzgProofs !== undefined;

--- a/packages/types/src/utils/typeguards.ts
+++ b/packages/types/src/utils/typeguards.ts
@@ -1,4 +1,4 @@
-import {FINALIZED_ROOT_DEPTH_ELECTRA, ForkPostDeneb, ForkPostBellatrix, ForkPostElectra} from "@lodestar/params";
+import {FINALIZED_ROOT_DEPTH_ELECTRA, ForkPostBellatrix, ForkPostDeneb, ForkPostElectra} from "@lodestar/params";
 import {
   Attestation,
   BeaconBlock,

--- a/packages/types/test/unit/blinded.test.ts
+++ b/packages/types/test/unit/blinded.test.ts
@@ -1,4 +1,4 @@
-import {ForkName, isForkExecution} from "@lodestar/params";
+import {ForkName, isForkPostBellatrix} from "@lodestar/params";
 import {describe, expect, it} from "vitest";
 import {ssz} from "../../src/index.js";
 
@@ -11,7 +11,7 @@ describe("blinded data structures", () => {
 
     for (const {a, b} of blindedTypes) {
       for (const fork of Object.keys(ssz.sszTypesFor) as ForkName[]) {
-        if (!isForkExecution(fork)) {
+        if (!isForkPostBellatrix(fork)) {
           continue;
         }
 

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -1,6 +1,6 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkBlobs, ForkExecution, ForkName, ForkPreBlobs, ForkSeq} from "@lodestar/params";
+import {ForkBlobs, ForkPostBellatrix, ForkName, ForkPreBlobs, ForkSeq} from "@lodestar/params";
 import {
   BLSPubkey,
   BLSSignature,
@@ -45,7 +45,7 @@ type FullOrBlindedBlockWithContents =
       executionPayloadSource: ProducedBlockSource.engine;
     }
   | {
-      version: ForkExecution;
+      version: ForkPostBellatrix;
       block: BlindedBeaconBlock;
       contents: null;
       executionPayloadBlinded: true;

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -1,6 +1,6 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkPostDeneb, ForkPostBellatrix, ForkName, ForkPreBlobs, ForkSeq} from "@lodestar/params";
+import {ForkPostDeneb, ForkPostBellatrix, ForkName, ForkPreDeneb, ForkSeq} from "@lodestar/params";
 import {
   BLSPubkey,
   BLSSignature,
@@ -28,8 +28,8 @@ import {ValidatorStore} from "./validatorStore.js";
 //  iii) a blinded block post bellatrix
 type FullOrBlindedBlockWithContents =
   | {
-      version: ForkPreBlobs;
-      block: BeaconBlock<ForkPreBlobs>;
+      version: ForkPreDeneb;
+      block: BeaconBlock<ForkPreDeneb>;
       contents: null;
       executionPayloadBlinded: false;
       executionPayloadSource: ProducedBlockSource.engine;

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -1,6 +1,6 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkBlobs, ForkPostBellatrix, ForkName, ForkPreBlobs, ForkSeq} from "@lodestar/params";
+import {ForkPostDeneb, ForkPostBellatrix, ForkName, ForkPreBlobs, ForkSeq} from "@lodestar/params";
 import {
   BLSPubkey,
   BLSSignature,
@@ -35,8 +35,8 @@ type FullOrBlindedBlockWithContents =
       executionPayloadSource: ProducedBlockSource.engine;
     }
   | {
-      version: ForkBlobs;
-      block: BeaconBlock<ForkBlobs>;
+      version: ForkPostDeneb;
+      block: BeaconBlock<ForkPostDeneb>;
       contents: {
         kzgProofs: deneb.KZGProofs;
         blobs: deneb.Blobs;
@@ -194,7 +194,7 @@ export class BlockProposingService {
       } else {
         (
           await this.api.beacon.publishBlockV2({
-            signedBlockOrContents: {...contents, signedBlock: signedBlock as SignedBeaconBlock<ForkBlobs>},
+            signedBlockOrContents: {...contents, signedBlock: signedBlock as SignedBeaconBlock<ForkPostDeneb>},
             ...opts,
           })
         ).assertOk();

--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -1,6 +1,6 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkPostDeneb, ForkPostBellatrix, ForkName, ForkPreDeneb, ForkSeq} from "@lodestar/params";
+import {ForkName, ForkPostBellatrix, ForkPostDeneb, ForkPreDeneb, ForkSeq} from "@lodestar/params";
 import {
   BLSPubkey,
   BLSSignature,

--- a/packages/validator/src/util/externalSignerClient.ts
+++ b/packages/validator/src/util/externalSignerClient.ts
@@ -1,7 +1,7 @@
 import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {fetch} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
-import {ForkPreExecution, ForkSeq} from "@lodestar/params";
+import {ForkPreBellatrix, ForkSeq} from "@lodestar/params";
 import {blindedOrFullBlockToHeader, computeEpochAtSlot} from "@lodestar/state-transition";
 import {
   AggregateAndProof,
@@ -76,7 +76,7 @@ export type SignableMessage =
   | {type: SignableMessageType.AGGREGATE_AND_PROOF; data: phase0.AggregateAndProof}
   | {type: SignableMessageType.AGGREGATE_AND_PROOF_V2; data: AggregateAndProof}
   | {type: SignableMessageType.ATTESTATION; data: phase0.AttestationData}
-  | {type: SignableMessageType.BLOCK_V2; data: BeaconBlock<ForkPreExecution> | BlindedBeaconBlock}
+  | {type: SignableMessageType.BLOCK_V2; data: BeaconBlock<ForkPreBellatrix> | BlindedBeaconBlock}
   | {type: SignableMessageType.DEPOSIT; data: ValueOf<typeof DepositType>}
   | {type: SignableMessageType.RANDAO_REVEAL; data: {epoch: Epoch}}
   | {type: SignableMessageType.VOLUNTARY_EXIT; data: phase0.VoluntaryExit}


### PR DESCRIPTION
**Motivation**

Start of resolution to #7183.  Driven by peerDAS branch.  `isForkBlobs` is not longer semantically correct in `fulu` because that branch does not have blobs, it has columns.  Is the first major feature that was removed so the types/typeguard naming semantics we were using kinda broke.  Updated to reflect pre/post fork instead of post"Feature".

**Description**

Rename pre/post fork names and type guards. 
