### PR TITLE
chore: hide --chain.pruneHistory until feature is more stable

### DIFF
--- a/docs/pages/run/beacon-management/data-retention.md
+++ b/docs/pages/run/beacon-management/data-retention.md
@@ -53,6 +53,6 @@ Logs can also become quite large so please check out the section on [log managem
 
 There is really only one flag that is needed to manage the data for Lodestar, [`--dataDir`](./beacon-cli#--datadir). Other than that handling log management is really the heart of the data management story. Beacon node data is what it is. Depending on the execution client that is chosen, there may be flags to help with data storage growth but that is outside the scope of this document.
 
-### Pruning history
+<!-- ### Pruning history
 
-For validators seeking to store the least amount of data possible, and store no historical data, use [`--chain.pruneHistory`](./beacon-cli#--chainprunehistory). This flag will configure the beacon node to continually prune all old blocks (older than `config.MIN_EPOCHS_FOR_BLOCK_REQUESTS`) and all prior finalized states.
+For validators seeking to store the least amount of data possible, and store no historical data, use [`--chain.pruneHistory`](./beacon-cli#--chainprunehistory). This flag will configure the beacon node to continually prune all old blocks (older than `config.MIN_EPOCHS_FOR_BLOCK_REQUESTS`) and all prior finalized states. -->

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -288,6 +288,7 @@ Will double processing times. Use only for debugging purposes.",
   },
 
   "chain.pruneHistory": {
+    hidden: true,
     description: "Prune historical blocks and state",
     type: "boolean",
     default: defaultOptions.chain.pruneHistory,


### PR DESCRIPTION
As discussed we should hide the flag introduced in https://github.com/ChainSafe/lodestar/pull/7427 for now until the feature becomes more stable.

Also commented out the docs section for now.