### PR TITLE
fix: duplicated block attestations

### DIFF
--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -394,7 +394,7 @@ export class AggregatedAttestationPool {
         }
       }
     }
-    const sortedConsolidationsByScore = [...consolidations.entries()]
+    const sortedConsolidationsByScore = Array.from(consolidations.entries())
       .sort((a, b) => b[1] - a[1])
       .map(([consolidation, _]) => consolidation)
       .slice(0, MAX_ATTESTATIONS_ELECTRA);

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -50,7 +50,6 @@ export type AttestationsConsolidation = {
   byCommittee: Map<CommitteeIndex, AttestationNonParticipant>;
   attData: phase0.AttestationData;
   totalNotSeenCount: number;
-  score: number;
 };
 
 /**
@@ -307,7 +306,7 @@ export class AggregatedAttestationPool {
     const validateAttestationDataFn = getValidateAttestationDataFn(forkChoice, state);
 
     const slots = Array.from(this.attestationGroupByIndexByDataHexBySlot.keys()).sort((a, b) => b - a);
-    const consolidations: AttestationsConsolidation[] = [];
+    const consolidations = new Map<AttestationsConsolidation, number>();
     let minScore = Number.MAX_SAFE_INTEGER;
     let slotCount = 0;
     slot: for (const slot of slots) {
@@ -344,7 +343,7 @@ export class AggregatedAttestationPool {
 
           if (
             slotCount > 2 &&
-            consolidations.length >= MAX_ATTESTATIONS_ELECTRA &&
+            consolidations.size >= MAX_ATTESTATIONS_ELECTRA &&
             notSeenAttestingIndices.size / slotDelta < minScore
           ) {
             // after 2 slots, there are a good chance that we have 2 * MAX_ATTESTATIONS_ELECTRA attestations and break the for loop early
@@ -373,8 +372,6 @@ export class AggregatedAttestationPool {
                 byCommittee: new Map(),
                 attData: attestationNonParticipation.attestation.data,
                 totalNotSeenCount: 0,
-                // only update score after we have full data
-                score: 0,
               };
             }
             sameAttDataCons[i].byCommittee.set(committeeIndex, attestationNonParticipation);
@@ -385,19 +382,22 @@ export class AggregatedAttestationPool {
             if (score < minScore) {
               minScore = score;
             }
-            consolidations.push({...consolidation, score});
+
+            consolidations.set(consolidation, score);
+
             // Stop accumulating attestations there are enough that may have good scoring
-            if (consolidations.length >= MAX_ATTESTATIONS_ELECTRA * 2) {
+            if (consolidations.size >= MAX_ATTESTATIONS_ELECTRA * 2) {
               break slot;
             }
           }
         }
       }
     }
-
-    const sortedConsolidationsByScore = consolidations
-      .sort((a, b) => b.score - a.score)
+    const sortedConsolidationsByScore = [...consolidations.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([consolidation, _]) => consolidation)
       .slice(0, MAX_ATTESTATIONS_ELECTRA);
+
     // on chain aggregation is expensive, only do it after all
     return sortedConsolidationsByScore.map(aggregateConsolidation);
   }

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -306,6 +306,7 @@ export class AggregatedAttestationPool {
     const validateAttestationDataFn = getValidateAttestationDataFn(forkChoice, state);
 
     const slots = Array.from(this.attestationGroupByIndexByDataHexBySlot.keys()).sort((a, b) => b - a);
+    // Track score of each `AttestationsConsolidation`
     const consolidations = new Map<AttestationsConsolidation, number>();
     let minScore = Number.MAX_SAFE_INTEGER;
     let slotCount = 0;

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -374,7 +374,7 @@ describe("aggregateConsolidation", () => {
       const consolidation: AttestationsConsolidation = {
         byCommittee: new Map(),
         attData: attData,
-        totalNotSeenCount: 0
+        totalNotSeenCount: 0,
       };
       // to simplify, instead of signing the signingRoot, just sign the attData root
       const sigArr = skArr.map((sk) => sk.sign(ssz.phase0.AttestationData.hashTreeRoot(attData)));

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -374,8 +374,7 @@ describe("aggregateConsolidation", () => {
       const consolidation: AttestationsConsolidation = {
         byCommittee: new Map(),
         attData: attData,
-        totalNotSeenCount: 0,
-        score: 0,
+        totalNotSeenCount: 0
       };
       // to simplify, instead of signing the signingRoot, just sign the attData root
       const sigArr = skArr.map((sk) => sk.sign(ssz.phase0.AttestationData.hashTreeRoot(attData)));


### PR DESCRIPTION
### Background
Raise by Teku team on discord https://discord.com/channels/595666850260713488/1338793076491026486/1338793635386228756,

Lodestar will generate duplicated attestations and include them in the block body when proposing. 

For example https://dora.pectra-devnet-6.ethpandaops.io/slot/54933 has 6 copies of the same attestation with signature `0xae6b928e4866d5a43ae6d4ced869e3aa53f38617d42da5862c76e9a928942783a108e4e281d208766b8a9b2adb286aff0e0af7c14f24d1b013f4ccb47c000a11c256112fab37945d2e5bb3671b997a23b1d57d67d3fe69835ecc06f1f57b1210 `.

This is due to `getAttestationsForBlockElectra` putting multiple copies of the same attestations in `consolidations` when there are attestations coming from different committees with the same attestation data.

The above attestation having 6 copies because the attestation contains 6 committees (0, 2, 3, 6, 7 and 12).

### Proposal

Remove `AttestationsConsolidation.score` and convert `consolidations` to a `Map<AttestationsConsolidation, number>()` to track the score while eliminating duplicates. 