### PR TITLE
fix: improve sync committee updates

### DIFF
--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -374,8 +374,9 @@ export function getComputeShuffledIndexFn(indexCount: number, seed: Bytes32): Co
   // there are possibly SHUFFLE_ROUND_COUNT (90 for mainnet) values for this cache
   // this cache will always hit after the 1st call
   const pivotByIndex: Map<number, number> = new Map();
-  // there are only 256 possible values of position byte, this cache will hit very soon
-  const sourceByPositionByIndex: Map<number, Map<number, Uint8Array>> = new Map();
+  // given 2M active validators, there are 2 M / 256 = 8k possible positionDiv
+  // it means there are at most 8k different sources for each round
+  const sourceByPositionDivByIndex: Map<number, Map<number, Uint8Array>> = new Map();
 
   return (index): number => {
     assert.lt(index, indexCount, "indexCount must be less than index");
@@ -401,16 +402,16 @@ export function getComputeShuffledIndexFn(indexCount: number, seed: Bytes32): Co
 
       // optimized version of the below naive code
       // const source = digest(Buffer.concat([_seed, intToBytes(i, 1), intToBytes(Math.floor(position / 256), 4)]));
-      let sourceByPosition = sourceByPositionByIndex.get(i);
-      if (sourceByPosition == null) {
-        sourceByPosition = new Map<number, Uint8Array>();
-        sourceByPositionByIndex.set(i, sourceByPosition);
+      let sourceByPositionDiv = sourceByPositionDivByIndex.get(i);
+      if (sourceByPositionDiv == null) {
+        sourceByPositionDiv = new Map<number, Uint8Array>();
+        sourceByPositionDivByIndex.set(i, sourceByPositionDiv);
       }
-      const positionByte = Math.floor(position / 256);
-      let source = sourceByPosition.get(positionByte);
+      const positionDiv256 = Math.floor(position / 256);
+      let source = sourceByPositionDiv.get(positionDiv256);
       if (source == null) {
-        source = digest(Buffer.concat([_seed, intToBytes(i, 1), intToBytes(Math.floor(position / 256), 4)]));
-        sourceByPosition.set(positionByte, source);
+        source = digest(Buffer.concat([_seed, intToBytes(i, 1), intToBytes(positionDiv256, 4)]));
+        sourceByPositionDiv.set(positionDiv256, source);
       }
       const byte = source[Math.floor((position % 256) / 8)];
       const bit = (byte >> (position % 8)) % 2;

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -120,6 +120,8 @@ export function computeProposerIndex(
     const shuffledResult = new Map<number, number>();
 
     let i = 0;
+    const cachedHashInput = Buffer.allocUnsafe(32 + 8);
+    cachedHashInput.set(seed, 0);
     let cachedHash: Uint8Array | null = null;
     while (true) {
       // an optimized version of the below naive code
@@ -134,7 +136,8 @@ export function computeProposerIndex(
 
       // compute a new hash every 16 iterations
       if (i % 16 === 0) {
-        cachedHash = digest(Buffer.concat([seed, intToBytes(Math.floor(i / 16), 8, "le")]));
+        cachedHashInput.writeUint32LE(Math.floor(i / 16), 32);
+        cachedHash = digest(cachedHashInput);
       }
 
       if (cachedHash == null) {
@@ -270,6 +273,8 @@ export function getNextSyncCommitteeIndices(
 
     let i = 0;
     let cachedHash: Uint8Array | null = null;
+    const cachedHashInput = Buffer.allocUnsafe(32 + 8);
+    cachedHashInput.set(seed, 0);
     // this simple cache makes sure we don't have to recompute the shuffled index for the next round of activeValidatorCount
     const shuffledResult = new Map<number, number>();
     while (syncCommitteeIndices.length < SYNC_COMMITTEE_SIZE) {
@@ -285,7 +290,8 @@ export function getNextSyncCommitteeIndices(
 
       // compute a new hash every 16 iterations
       if (i % 16 === 0) {
-        cachedHash = digest(Buffer.concat([seed, intToBytes(Math.floor(i / 16), 8, "le")]));
+        cachedHashInput.writeUint32LE(Math.floor(i / 16), 32);
+        cachedHash = digest(cachedHashInput);
       }
 
       if (cachedHash == null) {
@@ -402,7 +408,7 @@ export function getComputeShuffledIndexFn(indexCount: number, seed: Bytes32): Co
         //   bytesToBigInt(digest(Buffer.concat([_seed, intToBytes(i, 1)])).slice(0, 8)) % BigInt(indexCount)
         // );
         pivotBuffer[32] = i % 256;
-        pivot = Number(bytesToBigInt(digest(pivotBuffer).slice(0, 8)) % BigInt(indexCount));
+        pivot = Number(bytesToBigInt(digest(pivotBuffer).subarray(0, 8)) % BigInt(indexCount));
         pivotByIndex.set(i, pivot);
       }
 

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -122,6 +122,7 @@ export function computeProposerIndex(
     let i = 0;
     const cachedHashInput = Buffer.allocUnsafe(32 + 8);
     cachedHashInput.set(seed, 0);
+    cachedHashInput.writeUint32LE(0, 32 + 4);
     let cachedHash: Uint8Array | null = null;
     while (true) {
       // an optimized version of the below naive code
@@ -275,6 +276,7 @@ export function getNextSyncCommitteeIndices(
     let cachedHash: Uint8Array | null = null;
     const cachedHashInput = Buffer.allocUnsafe(32 + 8);
     cachedHashInput.set(seed, 0);
+    cachedHashInput.writeUInt32LE(0, 32 + 4);
     // this simple cache makes sure we don't have to recompute the shuffled index for the next round of activeValidatorCount
     const shuffledResult = new Map<number, number>();
     while (syncCommitteeIndices.length < SYNC_COMMITTEE_SIZE) {

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -377,6 +377,12 @@ export function getComputeShuffledIndexFn(indexCount: number, seed: Bytes32): Co
   // given 2M active validators, there are 2 M / 256 = 8k possible positionDiv
   // it means there are at most 8k different sources for each round
   const sourceByPositionDivByIndex: Map<number, Map<number, Uint8Array>> = new Map();
+  // 32 bytes seed + 1 byte i
+  const pivotBuffer = Buffer.alloc(32 + 1);
+  pivotBuffer.set(seed, 0);
+  // 32 bytes seed + 1 byte i + 4 bytes positionDiv
+  const sourceBuffer = Buffer.alloc(32 + 1 + 4);
+  sourceBuffer.set(seed, 0);
 
   return (index): number => {
     assert.lt(index, indexCount, "indexCount must be less than index");
@@ -391,9 +397,12 @@ export function getComputeShuffledIndexFn(indexCount: number, seed: Bytes32): Co
 
       let pivot = pivotByIndex.get(i);
       if (pivot == null) {
-        pivot = Number(
-          bytesToBigInt(digest(Buffer.concat([_seed, intToBytes(i, 1)])).slice(0, 8)) % BigInt(indexCount)
-        );
+        // naive version always creates a new buffer, we can reuse the buffer
+        // pivot = Number(
+        //   bytesToBigInt(digest(Buffer.concat([_seed, intToBytes(i, 1)])).slice(0, 8)) % BigInt(indexCount)
+        // );
+        pivotBuffer[32] = i % 256;
+        pivot = Number(bytesToBigInt(digest(pivotBuffer).slice(0, 8)) % BigInt(indexCount));
         pivotByIndex.set(i, pivot);
       }
 
@@ -410,7 +419,11 @@ export function getComputeShuffledIndexFn(indexCount: number, seed: Bytes32): Co
       const positionDiv256 = Math.floor(position / 256);
       let source = sourceByPositionDiv.get(positionDiv256);
       if (source == null) {
-        source = digest(Buffer.concat([_seed, intToBytes(i, 1), intToBytes(positionDiv256, 4)]));
+        // naive version always creates a new buffer, we can reuse the buffer
+        // don't want to go through intToBytes() to avoid BigInt
+        sourceBuffer[32] = i % 256;
+        sourceBuffer.writeUint32LE(positionDiv256, 33);
+        source = digest(sourceBuffer);
         sourceByPositionDiv.set(positionDiv256, source);
       }
       const byte = source[Math.floor((position % 256) / 8)];

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -35,6 +35,7 @@ export function computeProposers(
         fork,
         effectiveBalanceIncrements,
         shuffling.activeIndices,
+        // TODO: if we use hashTree, we can precompute the roots for the next n loops
         digest(Buffer.concat([epochSeed, intToBytes(slot, 8)]))
       )
     );
@@ -44,10 +45,11 @@ export function computeProposers(
 
 /**
  * Return from ``indices`` a random index sampled by effective balance.
+ * This is just to make sure lodestar follows the spec, this is not for production.
  *
  * SLOW CODE - 🐢
  */
-export function computeProposerIndex(
+export function naiveComputeProposerIndex(
   fork: ForkSeq,
   effectiveBalanceIncrements: EffectiveBalanceIncrements,
   indices: ArrayLike<ValidatorIndex>,
@@ -76,6 +78,87 @@ export function computeProposerIndex(
       i += 1;
     }
   } else {
+    const MAX_RANDOM_BYTE = 2 ** 8 - 1;
+    const MAX_EFFECTIVE_BALANCE_INCREMENT = MAX_EFFECTIVE_BALANCE / EFFECTIVE_BALANCE_INCREMENT;
+
+    let i = 0;
+    while (true) {
+      const candidateIndex = indices[computeShuffledIndex(i % indices.length, indices.length, seed)];
+      const randomByte = digest(Buffer.concat([seed, intToBytes(Math.floor(i / 32), 8, "le")]))[i % 32];
+
+      const effectiveBalanceIncrement = effectiveBalanceIncrements[candidateIndex];
+      if (effectiveBalanceIncrement * MAX_RANDOM_BYTE >= MAX_EFFECTIVE_BALANCE_INCREMENT * randomByte) {
+        return candidateIndex;
+      }
+
+      i += 1;
+    }
+  }
+}
+
+/**
+ * Optimized version of `naiveComputeProposerIndex`.
+ * It shows > 3x speedup according to the perf test.
+ */
+export function computeProposerIndex(
+  fork: ForkSeq,
+  effectiveBalanceIncrements: EffectiveBalanceIncrements,
+  indices: ArrayLike<ValidatorIndex>,
+  seed: Uint8Array
+): ValidatorIndex {
+  if (indices.length === 0) {
+    throw Error("Validator indices must not be empty");
+  }
+
+  if (fork >= ForkSeq.electra) {
+    // electra, see inline comments for the optimization
+    const MAX_RANDOM_VALUE = 2 ** 16 - 1;
+    const MAX_EFFECTIVE_BALANCE_INCREMENT = MAX_EFFECTIVE_BALANCE_ELECTRA / EFFECTIVE_BALANCE_INCREMENT;
+
+    const shuffledIndexFn = getComputeShuffledIndexFn(indices.length, seed);
+    // this simple cache makes sure we don't have to recompute the shuffled index for the next round of activeValidatorCount
+    const shuffledResult = new Map<number, number>();
+
+    let i = 0;
+    let cachedHash: Uint8Array | null = null;
+    while (true) {
+      // an optimized version of the below naive code
+      // const candidateIndex = indices[computeShuffledIndex(i % indices.length, indices.length, seed)];
+      const index = i % indices.length;
+      let shuffledIndex = shuffledResult.get(index);
+      if (shuffledIndex == null) {
+        shuffledIndex = shuffledIndexFn(index);
+        shuffledResult.set(index, shuffledIndex);
+      }
+      const candidateIndex = indices[shuffledIndex];
+
+      // compute a new hash every 16 iterations
+      if (i % 16 === 0) {
+        cachedHash = digest(Buffer.concat([seed, intToBytes(Math.floor(i / 16), 8, "le")]));
+      }
+
+      if (cachedHash == null) {
+        // there is always a cachedHash, handle this to make the compiler happy
+        throw new Error("cachedHash should not be null");
+      }
+
+      const randomBytes = cachedHash;
+      const offset = (i % 16) * 2;
+      // this is equivalent to bytesToInt(randomBytes.subarray(offset, offset + 2));
+      // but it does not get through BigInt
+      const lowByte = randomBytes[offset];
+      const highByte = randomBytes[offset + 1];
+      const randomValue = lowByte + highByte * 256;
+
+      const effectiveBalanceIncrement = effectiveBalanceIncrements[candidateIndex];
+      if (effectiveBalanceIncrement * MAX_RANDOM_VALUE >= MAX_EFFECTIVE_BALANCE_INCREMENT * randomValue) {
+        return candidateIndex;
+      }
+
+      i += 1;
+    }
+  } else {
+    // preelectra, this function is the same to the naive version
     const MAX_RANDOM_BYTE = 2 ** 8 - 1;
     const MAX_EFFECTIVE_BALANCE_INCREMENT = MAX_EFFECTIVE_BALANCE / EFFECTIVE_BALANCE_INCREMENT;
 
@@ -163,8 +246,9 @@ export function naiveGetNextSyncCommitteeIndices(
 }
 
 /**
- *
  * Optmized version of `naiveGetNextSyncCommitteeIndices`.
+ *
+ * In the worse case scenario, this could be >1000x speedup according to the perf test.
  */
 export function getNextSyncCommitteeIndices(
   fork: ForkSeq,
@@ -175,6 +259,7 @@ export function getNextSyncCommitteeIndices(
   const syncCommitteeIndices = [];
 
   if (fork >= ForkSeq.electra) {
+    // electra, see inline comments for the optimization
     const MAX_RANDOM_VALUE = 2 ** 16 - 1;
     const MAX_EFFECTIVE_BALANCE_INCREMENT = MAX_EFFECTIVE_BALANCE_ELECTRA / EFFECTIVE_BALANCE_INCREMENT;
 

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -95,7 +95,8 @@ export function computeProposerIndex(
 }
 
 /**
- * TODO: NAIVE
+ * Naive version, this is not supposed to be used in production.
+ * See `computeProposerIndex` for the optimized version.
  *
  * Return the sync committee indices for a given state and epoch.
  * Aligns `epoch` to `baseEpoch` so the result is the same with any `epoch` within a sync period.
@@ -104,7 +105,7 @@ export function computeProposerIndex(
  *
  * SLOW CODE - 🐢
  */
-export function getNextSyncCommitteeIndices(
+export function naiveGetNextSyncCommitteeIndices(
   fork: ForkSeq,
   state: BeaconStateAllForks,
   activeValidatorIndices: ArrayLike<ValidatorIndex>,
@@ -162,12 +163,103 @@ export function getNextSyncCommitteeIndices(
 }
 
 /**
+ *
+ * Optmized version of `naiveGetNextSyncCommitteeIndices`.
+ */
+export function getNextSyncCommitteeIndices(
+  fork: ForkSeq,
+  state: BeaconStateAllForks,
+  activeValidatorIndices: ArrayLike<ValidatorIndex>,
+  effectiveBalanceIncrements: EffectiveBalanceIncrements
+): ValidatorIndex[] {
+  const syncCommitteeIndices = [];
+
+  if (fork >= ForkSeq.electra) {
+    const MAX_RANDOM_VALUE = 2 ** 16 - 1;
+    const MAX_EFFECTIVE_BALANCE_INCREMENT = MAX_EFFECTIVE_BALANCE_ELECTRA / EFFECTIVE_BALANCE_INCREMENT;
+
+    const epoch = computeEpochAtSlot(state.slot) + 1;
+    const activeValidatorCount = activeValidatorIndices.length;
+    const seed = getSeed(state, epoch, DOMAIN_SYNC_COMMITTEE);
+    const shuffledIndexFn = getComputeShuffledIndexFn(activeValidatorCount, seed);
+
+    let i = 0;
+    let cachedHash: Uint8Array | null = null;
+    // this simple cache makes sure we don't have to recompute the shuffled index for the next round of activeValidatorCount
+    const shuffledResult = new Map<number, number>();
+    while (syncCommitteeIndices.length < SYNC_COMMITTEE_SIZE) {
+      // optimized version of the below naive code
+      // const shuffledIndex = shuffledIndexFn(i % activeValidatorCount);
+      const index = i % activeValidatorCount;
+      let shuffledIndex = shuffledResult.get(index);
+      if (shuffledIndex == null) {
+        shuffledIndex = shuffledIndexFn(index);
+        shuffledResult.set(index, shuffledIndex);
+      }
+      const candidateIndex = activeValidatorIndices[shuffledIndex];
+
+      // compute a new hash every 16 iterations
+      if (i % 16 === 0) {
+        cachedHash = digest(Buffer.concat([seed, intToBytes(Math.floor(i / 16), 8, "le")]));
+      }
+
+      if (cachedHash == null) {
+        // there is always a cachedHash, handle this to make the compiler happy
+        throw new Error("cachedHash should not be null");
+      }
+
+      const randomBytes = cachedHash;
+      const offset = (i % 16) * 2;
+
+      // this is equivalent to bytesToInt(randomBytes.subarray(offset, offset + 2));
+      // but it does not get through BigInt
+      const lowByte = randomBytes[offset];
+      const highByte = randomBytes[offset + 1];
+      const randomValue = lowByte + highByte * 256;
+
+      const effectiveBalanceIncrement = effectiveBalanceIncrements[candidateIndex];
+      if (effectiveBalanceIncrement * MAX_RANDOM_VALUE >= MAX_EFFECTIVE_BALANCE_INCREMENT * randomValue) {
+        syncCommitteeIndices.push(candidateIndex);
+      }
+
+      i += 1;
+    }
+  } else {
+    // pre-electra, keep the same naive version
+    const MAX_RANDOM_BYTE = 2 ** 8 - 1;
+    const MAX_EFFECTIVE_BALANCE_INCREMENT = MAX_EFFECTIVE_BALANCE / EFFECTIVE_BALANCE_INCREMENT;
+
+    const epoch = computeEpochAtSlot(state.slot) + 1;
+    const activeValidatorCount = activeValidatorIndices.length;
+    const seed = getSeed(state, epoch, DOMAIN_SYNC_COMMITTEE);
+
+    let i = 0;
+    while (syncCommitteeIndices.length < SYNC_COMMITTEE_SIZE) {
+      const shuffledIndex = computeShuffledIndex(i % activeValidatorCount, activeValidatorCount, seed);
+      const candidateIndex = activeValidatorIndices[shuffledIndex];
+      const randomByte = digest(Buffer.concat([seed, intToBytes(Math.floor(i / 32), 8, "le")]))[i % 32];
+
+      const effectiveBalanceIncrement = effectiveBalanceIncrements[candidateIndex];
+      if (effectiveBalanceIncrement * MAX_RANDOM_BYTE >= MAX_EFFECTIVE_BALANCE_INCREMENT * randomByte) {
+        syncCommitteeIndices.push(candidateIndex);
+      }
+
+      i += 1;
+    }
+  }
+
+  return syncCommitteeIndices;
+}
+
+/**
  * Return the shuffled validator index corresponding to ``seed`` (and ``index_count``).
  *
  * Swap or not
  * https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf
  *
  * See the 'generalized domain' algorithm on page 3.
+ * This is the naive implementation just to make sure lodestar follows the spec, this is not for production.
+ * The optimized version is in `getComputeShuffledIndexFn`.
  */
 export function computeShuffledIndex(index: number, indexCount: number, seed: Bytes32): number {
   let permuted = index;
@@ -186,6 +278,61 @@ export function computeShuffledIndex(index: number, indexCount: number, seed: By
     permuted = bit ? flip : permuted;
   }
   return permuted;
+}
+
+type ComputeShuffledIndexFn = (index: number) => number;
+
+/**
+ * An optimized version of `computeShuffledIndex`, this is for production.
+ */
+export function getComputeShuffledIndexFn(indexCount: number, seed: Bytes32): ComputeShuffledIndexFn {
+  // there are possibly SHUFFLE_ROUND_COUNT (90 for mainnet) values for this cache
+  // this cache will always hit after the 1st call
+  const pivotByIndex: Map<number, number> = new Map();
+  // there are only 256 possible values of position byte, this cache will hit very soon
+  const sourceByPositionByIndex: Map<number, Map<number, Uint8Array>> = new Map();
+
+  return (index): number => {
+    assert.lt(index, indexCount, "indexCount must be less than index");
+    assert.lte(indexCount, 2 ** 40, "indexCount too big");
+    let permuted = index;
+    const _seed = seed;
+    for (let i = 0; i < SHUFFLE_ROUND_COUNT; i++) {
+      // optimized version of the below naive code
+      // const pivot = Number(
+      //   bytesToBigInt(digest(Buffer.concat([_seed, intToBytes(i, 1)])).slice(0, 8)) % BigInt(indexCount)
+      // );
+
+      let pivot = pivotByIndex.get(i);
+      if (pivot == null) {
+        pivot = Number(
+          bytesToBigInt(digest(Buffer.concat([_seed, intToBytes(i, 1)])).slice(0, 8)) % BigInt(indexCount)
+        );
+        pivotByIndex.set(i, pivot);
+      }
+
+      const flip = (pivot + indexCount - permuted) % indexCount;
+      const position = Math.max(permuted, flip);
+
+      // optimized version of the below naive code
+      // const source = digest(Buffer.concat([_seed, intToBytes(i, 1), intToBytes(Math.floor(position / 256), 4)]));
+      let sourceByPosition = sourceByPositionByIndex.get(i);
+      if (sourceByPosition == null) {
+        sourceByPosition = new Map<number, Uint8Array>();
+        sourceByPositionByIndex.set(i, sourceByPosition);
+      }
+      const positionByte = Math.floor(position / 256);
+      let source = sourceByPosition.get(positionByte);
+      if (source == null) {
+        source = digest(Buffer.concat([_seed, intToBytes(i, 1), intToBytes(Math.floor(position / 256), 4)]));
+        sourceByPosition.set(positionByte, source);
+      }
+      const byte = source[Math.floor((position % 256) / 8)];
+      const bit = (byte >> (position % 8)) % 2;
+      permuted = bit ? flip : permuted;
+    }
+    return permuted;
+  };
 }
 
 /**

--- a/packages/state-transition/test/perf/util/seed.test.ts
+++ b/packages/state-transition/test/perf/util/seed.test.ts
@@ -74,27 +74,27 @@ describe("getNextSyncCommitteeIndices electra", () => {
 });
 
 describe("computeShuffledIndex", () => {
-  // TODO
-  const vc = 100_000;
   const seed = new Uint8Array(Array.from({length: 32}, (_, i) => i));
 
-  bench({
-    id: `naive computeShuffledIndex ${vc} validators`,
-    fn: () => {
-      for (let i = 0; i < vc; i++) {
-        computeShuffledIndex(i, vc, seed);
-      }
-    },
-  });
+  for (const vc of [100_000, 2_000_000]) {
+    bench({
+      id: `naive computeShuffledIndex ${vc} validators`,
+      fn: () => {
+        for (let i = 0; i < vc; i++) {
+          computeShuffledIndex(i, vc, seed);
+        }
+      },
+    });
 
-  const shuffledIndexFn = getComputeShuffledIndexFn(vc, seed);
+    const shuffledIndexFn = getComputeShuffledIndexFn(vc, seed);
 
-  bench({
-    id: `cached computeShuffledIndex ${vc} validators`,
-    fn: () => {
-      for (let i = 0; i < vc; i++) {
-        shuffledIndexFn(i);
-      }
-    },
-  });
+    bench({
+      id: `cached computeShuffledIndex ${vc} validators`,
+      fn: () => {
+        for (let i = 0; i < vc; i++) {
+          shuffledIndexFn(i);
+        }
+      },
+    });
+  }
 });

--- a/packages/state-transition/test/perf/util/seed.test.ts
+++ b/packages/state-transition/test/perf/util/seed.test.ts
@@ -1,0 +1,61 @@
+import {bench, describe} from "@chainsafe/benchmark";
+import {ForkSeq} from "@lodestar/params";
+import {
+  computeShuffledIndex,
+  getComputeShuffledIndexFn,
+  getNextSyncCommitteeIndices,
+  naiveGetNextSyncCommitteeIndices,
+} from "../../../src/util/seed.js";
+import {generatePerfTestCachedStateAltair} from "../util.js";
+
+describe("getNextSyncCommitteeIndices electra", () => {
+  for (const vc of [1_000, 10_000, 100_000]) {
+    const state = generatePerfTestCachedStateAltair({vc, goBackOneSlot: false});
+    const activeIndices = Array.from({length: state.validators.length}, (_, i) => i);
+    const effectiveBalanceIncrements = new Uint16Array(state.validators.length);
+    for (let i = 0; i < state.validators.length; i++) {
+      // make it the worse case where each validator has 32 ETH effective balance
+      effectiveBalanceIncrements[i] = 32;
+    }
+
+    bench({
+      id: `naiveGetNextSyncCommitteeIndices ${vc} validators`,
+      fn: () => {
+        naiveGetNextSyncCommitteeIndices(ForkSeq.electra, state, activeIndices, effectiveBalanceIncrements);
+      },
+    });
+
+    bench({
+      id: `getNextSyncCommitteeIndices ${vc} validators`,
+      fn: () => {
+        getNextSyncCommitteeIndices(ForkSeq.electra, state, activeIndices, effectiveBalanceIncrements);
+      },
+    });
+  }
+});
+
+describe("computeShuffledIndex", () => {
+  // TODO
+  const vc = 100_000;
+  const seed = new Uint8Array(Array.from({length: 32}, (_, i) => i));
+
+  bench({
+    id: `naive computeShuffledIndex ${vc} validators`,
+    fn: () => {
+      for (let i = 0; i < vc; i++) {
+        computeShuffledIndex(i, vc, seed);
+      }
+    },
+  });
+
+  const shuffledIndexFn = getComputeShuffledIndexFn(vc, seed);
+
+  bench({
+    id: `cached computeShuffledIndex ${vc} validators`,
+    fn: () => {
+      for (let i = 0; i < vc; i++) {
+        shuffledIndexFn(i);
+      }
+    },
+  });
+});

--- a/packages/state-transition/test/perf/util/seed.test.ts
+++ b/packages/state-transition/test/perf/util/seed.test.ts
@@ -1,12 +1,51 @@
 import {bench, describe} from "@chainsafe/benchmark";
 import {ForkSeq} from "@lodestar/params";
+import {fromHex} from "@lodestar/utils";
 import {
+  computeProposerIndex,
   computeShuffledIndex,
   getComputeShuffledIndexFn,
   getNextSyncCommitteeIndices,
+  naiveComputeProposerIndex,
   naiveGetNextSyncCommitteeIndices,
 } from "../../../src/util/seed.js";
 import {generatePerfTestCachedStateAltair} from "../util.js";
+
+// I'm not sure how to populate a good test data for this benchmark
+describe("computeProposerIndex", () => {
+  // it's hard to find a seed that shows differences between naive and optimized version
+  // this was selected after a couple of time I run and try crytpo.randomBytes()
+  const seed = fromHex("0x902199936ba358175ec5eca9825fd0d26fc355d5fd4d37d1b10575a29d4bd5a8");
+
+  const vc = 100_000;
+  const effectiveBalanceIncrements = new Uint16Array(vc);
+  for (let i = 0; i < vc; i++) {
+    // make it the worse case where each validator has 32 ETH effective balance
+    effectiveBalanceIncrements[i] = 32;
+  }
+
+  const activeIndices = Array.from({length: vc}, (_, i) => i);
+  const runsFactor = 100;
+  bench({
+    id: `naive computeProposerIndex ${vc} validators`,
+    fn: () => {
+      for (let i = 0; i < runsFactor; i++) {
+        naiveComputeProposerIndex(ForkSeq.electra, effectiveBalanceIncrements, activeIndices, seed);
+      }
+    },
+    runsFactor,
+  });
+
+  bench({
+    id: `computeProposerIndex ${vc} validators`,
+    fn: () => {
+      for (let i = 0; i < runsFactor; i++) {
+        computeProposerIndex(ForkSeq.electra, effectiveBalanceIncrements, activeIndices, seed);
+      }
+    },
+    runsFactor,
+  });
+});
 
 describe("getNextSyncCommitteeIndices electra", () => {
   for (const vc of [1_000, 10_000, 100_000]) {

--- a/packages/state-transition/test/unit/util/seed.test.ts
+++ b/packages/state-transition/test/unit/util/seed.test.ts
@@ -4,10 +4,12 @@ import {describe, expect, it} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
 import {ForkSeq, GENESIS_EPOCH, GENESIS_SLOT, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
+  computeProposerIndex,
   computeShuffledIndex,
   getComputeShuffledIndexFn,
   getNextSyncCommitteeIndices,
   getRandaoMix,
+  naiveComputeProposerIndex,
   naiveGetNextSyncCommitteeIndices,
 } from "../../../src/util/index.js";
 
@@ -35,6 +37,22 @@ describe("getRandaoMix", () => {
 
     const res = getRandaoMix(state, GENESIS_EPOCH + 1);
     expect(toHexString(res)).toBe(toHexString(randaoMix2));
+  });
+});
+
+describe("computeProposerIndex electra", () => {
+  const seed = crypto.randomBytes(32);
+  const vc = 1000;
+  const activeIndices = Array.from({length: vc}, (_, i) => i);
+  const effectiveBalanceIncrements = new Uint16Array(vc);
+  for (let i = 0; i < vc; i++) {
+    effectiveBalanceIncrements[i] = 32 + 32 * (i % 64);
+  }
+
+  it("should be the same to the naive version", () => {
+    const expected = naiveComputeProposerIndex(ForkSeq.electra, effectiveBalanceIncrements, activeIndices, seed);
+    const result = computeProposerIndex(ForkSeq.electra, effectiveBalanceIncrements, activeIndices, seed);
+    expect(result).toBe(expected);
   });
 });
 

--- a/packages/state-transition/test/unit/util/seed.test.ts
+++ b/packages/state-transition/test/unit/util/seed.test.ts
@@ -1,10 +1,19 @@
+import crypto from "node:crypto";
 import {describe, expect, it} from "vitest";
 
 import {toHexString} from "@chainsafe/ssz";
-import {GENESIS_EPOCH, GENESIS_SLOT, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {getRandaoMix} from "../../../src/util/index.js";
+import {ForkSeq, GENESIS_EPOCH, GENESIS_SLOT, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {
+  computeShuffledIndex,
+  getComputeShuffledIndexFn,
+  getNextSyncCommitteeIndices,
+  getRandaoMix,
+  naiveGetNextSyncCommitteeIndices,
+} from "../../../src/util/index.js";
 
+import {bytesToInt} from "@lodestar/utils";
 import {generateState} from "../../utils/state.js";
+import {generateValidators} from "../../utils/validator.js";
 
 describe("getRandaoMix", () => {
   const randaoMix1 = Buffer.alloc(32, 1);
@@ -26,5 +35,57 @@ describe("getRandaoMix", () => {
 
     const res = getRandaoMix(state, GENESIS_EPOCH + 1);
     expect(toHexString(res)).toBe(toHexString(randaoMix2));
+  });
+});
+
+describe("computeShuffledIndex", () => {
+  const seed = crypto.randomBytes(32);
+  const vc = 1000;
+  const shuffledIndexFn = getComputeShuffledIndexFn(vc, seed);
+  it("should be the same to the naive version", () => {
+    for (let i = 0; i < vc; i++) {
+      const expectedIndex = computeShuffledIndex(i, vc, seed);
+      expect(shuffledIndexFn(i)).toBe(expectedIndex);
+    }
+  });
+});
+
+describe("electra getNextSyncCommitteeIndices", () => {
+  const vc = 1000;
+  const validators = generateValidators(vc);
+  const state = generateState({validators});
+  const activeValidatorIndices = Array.from({length: vc}, (_, i) => i);
+  const effectiveBalanceIncrements = new Uint16Array(vc);
+  for (let i = 0; i < vc; i++) {
+    effectiveBalanceIncrements[i] = 32 + 32 * (i % 64);
+  }
+
+  it("should return the same result as naiveGetNextSyncCommitteeIndices", () => {
+    const expected = naiveGetNextSyncCommitteeIndices(
+      ForkSeq.electra,
+      state,
+      activeValidatorIndices,
+      effectiveBalanceIncrements
+    );
+    const result = getNextSyncCommitteeIndices(
+      ForkSeq.electra,
+      state,
+      activeValidatorIndices,
+      effectiveBalanceIncrements
+    );
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("number from 2 bytes bytesToInt", () => {
+  it("should compute numbers manually from 2 bytes", () => {
+    // this is to be used in getNextSyncCommitteeIndices without getting through BigInt
+    for (let lowByte = 0; lowByte < 256; lowByte++) {
+      for (let highByte = 0; highByte < 256; highByte++) {
+        const bytes = new Uint8Array([lowByte, highByte]);
+        const n = lowByte + highByte * 256;
+        expect(n).toBe(bytesToInt(bytes));
+      }
+    }
   });
 });


### PR DESCRIPTION
**Motivation**

- from electra, `processSyncCommitteeUpdates()` could be >15s according to the devnet

**Description**

- the main fix is in `computeShuffledIndex` where we can cache pivot and source computation there
- some other optimization other than that:
  - only compute hash once every 16 iterations
  - compute int manually instead of using `bytesToInt` in order not to use BigInt
  - cache shuffled index

I guess if we use `hashtree` we can improve more but the diff is a lot already and the main optimization is in `computeShuffledIndex()`, not the hash function. We can consider that in the future.

We can also improve pre-electra but I think it's been not that bad for a long time, so only focus on electra in this PR

Closes #7366

**Tests**

- added unit tests to compare naive version vs the optimized version
- benchmarks on local show >1000x difference for the main concerned function `naiveGetNextSyncCommitteeIndices()` while CI only show >20x difference. This is my local

```
computeProposerIndex
    ✔ naive computeProposerIndex 100000 validators                        31.86491 ops/s    31.38248 ms/op        -         10 runs   34.5 s
    ✔ computeProposerIndex 100000 validators                              106.2267 ops/s    9.413833 ms/op        -         10 runs   10.4 s

  getNextSyncCommitteeIndices electra
    ✔ naiveGetNextSyncCommitteeIndices 1000 validators                   0.2121840 ops/s    4.712890  s/op        -         10 runs   51.7 s
    ✔ getNextSyncCommitteeIndices 1000 validators                         214.9251 ops/s    4.652783 ms/op        -         45 runs  0.714 s
    ✔ naiveGetNextSyncCommitteeIndices 10000 validators                  0.2122278 ops/s    4.711918  s/op        -         10 runs   51.8 s
    ✔ getNextSyncCommitteeIndices 10000 validators                        220.2337 ops/s    4.540632 ms/op        -         46 runs  0.710 s
    ✔ naiveGetNextSyncCommitteeIndices 100000 validators                 0.2117828 ops/s    4.721820  s/op        -         10 runs   52.2 s
    ✔ getNextSyncCommitteeIndices 100000 validators                       204.7383 ops/s    4.884283 ms/op        -         43 runs  0.714 s

  computeShuffledIndex
    ✔ naive computeShuffledIndex 100000 validators                      0.06638498 ops/s    15.06365  s/op        -          3 runs   60.3 s
    ✔ cached computeShuffledIndex 100000 validators                       1.932706 ops/s    517.4092 ms/op        -         10 runs   5.72 s
```
