### PR TITLE
fix: bug for skipping download no relevant peers

### DIFF
--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -309,16 +309,19 @@ export class UnknownBlockSync {
           return acc;
         }, [] as number[]);
 
-        connectedPeers = allPeers.filter((peer) => {
-          const peerColumns = this.network.getConnectedPeerCustody(peer);
-          const columns = peerColumns.reduce((acc, elem) => {
-            if (neededColumns.includes(elem)) {
-              acc.push(elem);
-            }
-            return acc;
-          }, [] as number[]);
-          return columns.length > 0;
-        });
+        connectedPeers =
+          neededColumns.length <= 0
+            ? allPeers
+            : allPeers.filter((peer) => {
+                const peerColumns = this.network.getConnectedPeerCustody(peer);
+                const columns = peerColumns.reduce((acc, elem) => {
+                  if (neededColumns.includes(elem)) {
+                    acc.push(elem);
+                  }
+                  return acc;
+                }, [] as number[]);
+                return columns.length > 0;
+              });
         if (connectedPeers.length > 0) {
           this.logger.debug("Filtered peers to those having relevant columns for downloading data", {
             allPeers: allPeers.length,


### PR DESCRIPTION
**Motivation**

Fix bug on peerDAS branch for:
```
Skipping download as no filtered peers having relevant da        ta allPeers=17, connectedPeers=0, neededColumns=
```

