### PR TITLE
fix: beaconBlocksMaybeBlobsByRoot() to handle single block root

### DIFF
--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -54,12 +54,11 @@ export async function beaconBlocksMaybeBlobsByRoot(
     ? partialDownload.blocks.map((blockInput) => ({data: blockInput.block}))
     : await network.sendBeaconBlocksByRoot(peerId, [root]);
 
-  if (partialDownload !== null) {
+  if (partialDownload === null) {
     logger?.debug("beaconBlocksMaybeBlobsByRoot response", {slot: block.data.message.slot, peerClient});
+  } else {
+    logger?.debug("beaconBlocksMaybeBlobsByRoot partialDownload", {slot: block.data.message.slot, peerClient});
   }
-
-  const blobsDataBlocks = [];
-  const dataColumnsDataBlocks = [];
 
   const {custodyConfig} = network;
   const neededColumns = partialDownload ? partialDownload.pendingDataColumns : custodyConfig.sampledColumns;
@@ -85,26 +84,14 @@ export async function beaconBlocksMaybeBlobsByRoot(
   if (ForkSeq[fork] < ForkSeq.deneb) {
     blockInput = getBlockInput.preData(config, block.data, BlockSource.byRoot)
   } else if (fork === ForkName.deneb || fork === ForkName.electra) {
-    blobsDataBlocks.push(block);
+    // deneb and electra
     const blobKzgCommitmentsLen = (block.data.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length;
     logger?.debug("beaconBlocksMaybeBlobsByRoot", {blobKzgCommitmentsLen, peerClient});
     for (let index = 0; index < blobKzgCommitmentsLen; index++) {
       // try see if the blob is available locally
       blobIdentifiers.push({blockRoot, index});
     }
-  } else if (fork === ForkName.fulu) {
-    dataColumnsDataBlocks.push(block);
-    const blobKzgCommitmentsLen = (block.data.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length;
-    const custodyColumnIndexes = blobKzgCommitmentsLen > 0 ? columns : [];
-    for (const columnIndex of custodyColumnIndexes) {
-      dataColumnIdentifiers.push({blockRoot, index: columnIndex});
-    }
-  } else {
-    throw Error(`Invalid fork=${fork} in beaconBlocksMaybeBlobsByRoot`);
-  }
 
-  if (blobsDataBlocks.length > 0) {
-    // deneb and electra
     let allBlobSidecars: deneb.BlobSidecar[];
     if (blobIdentifiers.length > 0) {
       allBlobSidecars = await network.sendBlobSidecarsByRoot(peerId, blobIdentifiers);
@@ -126,10 +113,28 @@ export async function beaconBlocksMaybeBlobsByRoot(
       throw Error(`Expected exactly one blockInputWithBlobs slot=${slot}`);
     }
     blockInput = blockInputWithBlobs[0];
-  }
-
-  if (dataColumnsDataBlocks.length > 0) {
+  } else if (fork === ForkName.fulu) {
     // fulu
+    const blobKzgCommitmentsLen = (block.data.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length;
+    logger?.verbose("beaconBlocksMaybeBlobsByRoot", {blobKzgCommitmentsLen, peerClient, requestedColumns: columns.join(",")});
+
+    if (blobKzgCommitmentsLen === 0) {
+      // no blobs, return empty data columns
+      const blockData = {
+        fork: config.getForkName(slot),
+        dataColumns: [],
+        dataColumnsBytes: [],
+        dataColumnsSource: DataColumnsSource.byRoot,
+      } as BlockInputDataColumns;
+
+      logger?.debug("beaconBlocksMaybeBlobsByRoot: dataColumnsSidecar empty", {slot, peerClient});
+      return {block: getBlockInput.availableData(config, block.data, BlockSource.byRoot, blockData), pendingDataColumns: null};
+    }
+
+    for (const columnIndex of columns) {
+      dataColumnIdentifiers.push({blockRoot, index: columnIndex});
+    }
+
     let dataColumnSidecars: fulu.DataColumnSidecar[];
     logger?.debug("beaconBlocksMaybeBlobsByRoot: dataColumnsSidecars partialDownload", {
       ...(partialDownload
@@ -231,6 +236,8 @@ export async function beaconBlocksMaybeBlobsByRoot(
       logger?.verbose("beaconBlocksMaybeBlobsByRoot: still missing data columns for block", logCtx);
       blockInput = getBlockInput.dataPromise(config, block.data, BlockSource.byRoot, cachedData);
     }
+  } else {
+    throw Error(`Invalid fork=${fork} in beaconBlocksMaybeBlobsByRoot`);
   }
 
   if (blockInput == null) {
@@ -578,7 +585,7 @@ export async function unavailableBeaconBlobsByRootPostFulu(
       fork: cachedData.fork,
       dataColumns: [],
       dataColumnsBytes: [],
-      dataColumnsSource: DataColumnsSource.gossip,
+      dataColumnsSource: DataColumnsSource.byRoot,
     } as BlockInputDataColumns;
 
     resolveAvailability(blockData);

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -63,6 +63,7 @@ export async function beaconBlocksMaybeBlobsByRoot(
 
   const {custodyConfig} = network;
   const neededColumns = partialDownload ? partialDownload.pendingDataColumns : custodyConfig.sampledColumns;
+  let pendingDataColumns = neededColumns;
   const peerColumns = network.getConnectedPeerCustody(peerId);
 
   // get match
@@ -72,7 +73,6 @@ export async function beaconBlocksMaybeBlobsByRoot(
     }
     return acc;
   }, [] as number[]);
-  let pendingDataColumns = null;
 
   const blobIdentifiers: deneb.BlobIdentifier[] = [];
   const dataColumnIdentifiers: fulu.DataColumnIdentifier[] = [];
@@ -136,17 +136,30 @@ export async function beaconBlocksMaybeBlobsByRoot(
         ? {blocks: partialDownload.blocks.length, pendingDataColumns: partialDownload.pendingDataColumns.join(" ")}
         : {blocks: null, pendingDataColumns: null}),
       dataColumnIdentifiers: dataColumnIdentifiers.map((did) => did.index).join(" "),
+      slot,
       peerClient,
     });
     if (dataColumnIdentifiers.length > 0) {
       dataColumnSidecars = await network.sendDataColumnSidecarsByRoot(peerId, dataColumnIdentifiers);
     } else {
       // peer doesn't have columns we need, return. Consumer should try another peer
+      logger?.verbose("beaconBlocksMaybeBlobsByRoot: peer doesn't have columns we need",
+        {
+          slot,
+          peerClient,
+          pendingDataColumns: pendingDataColumns.join(","),
+          partialDownload: partialDownload !== null,
+        });
       if (partialDownload !== null) {
-        logger?.verbose("beaconBlocksMaybeBlobsByRoot: peer doesn't have columns we need", {slot, peerClient});
         return {block: partialDownload.blocks[0], pendingDataColumns};
+      } else {
+        // biome-ignore lint/style/noNonNullAssertion: checked below for validity
+        const cachedData = getEmptyBlockInputCacheEntry(config.getForkName(block.data.message.slot), -1).cachedData!;
+        if (cachedData === undefined) {
+          throw Error("beaconBlocksMaybeBlobsByRoot: Invalid cachedData=undefined from getEmptyBlockInputCacheEntry");
+        }
+        return {block: getBlockInput.dataPromise(config, block.data, BlockSource.byRoot, cachedData), pendingDataColumns};
       }
-      dataColumnSidecars = [];
     }
 
     // the same to matchBlockWithDataColumns() without expecting requested data columns = responded data columns
@@ -194,6 +207,7 @@ export async function beaconBlocksMaybeBlobsByRoot(
       slot: slot,
       requestedColumns: columns.join(","),
       respondedColumns: dataColumnSidecars.map((dcs) => dcs.index).join(","),
+      pendingDataColumns: pendingDataColumns.join(","),
       peerClient,
     };
 

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -2,7 +2,7 @@ import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkName, ForkSeq} from "@lodestar/params";
 import {signedBlockToSignedHeader} from "@lodestar/state-transition";
-import {RootHex, SignedBeaconBlock, deneb, fulu, phase0, ssz} from "@lodestar/types";
+import {Root, RootHex, SignedBeaconBlock, deneb, fulu, phase0, ssz} from "@lodestar/types";
 import {BlobAndProof} from "@lodestar/types/deneb";
 import {fromHex} from "@lodestar/utils";
 import {Logger} from "@lodestar/utils";
@@ -14,6 +14,7 @@ import {
   BlockInputType,
   BlockSource,
   CachedBlobs,
+  CachedData,
   CachedDataColumns,
   DataColumnsSource,
   NullBlockInput,
@@ -21,7 +22,7 @@ import {
   getBlockInputBlobs,
   getBlockInputDataColumns,
 } from "../../chain/blocks/types.js";
-import {BlockInputAvailabilitySource} from "../../chain/seenCache/seenGossipBlockInput.js";
+import {BlockInputAvailabilitySource, getEmptyBlockInputCacheEntry} from "../../chain/seenCache/seenGossipBlockInput.js";
 import {IExecutionEngine} from "../../execution/index.js";
 import {Metrics} from "../../metrics/index.js";
 import {computeInclusionProof, kzgCommitmentToVersionedHash} from "../../util/blobs.js";
@@ -33,21 +34,29 @@ import {PartialDownload, matchBlockWithBlobs, matchBlockWithDataColumns} from ".
 const MAX_ENGINE_GETBLOBS_CACHE = 32 * 16;
 const MAX_UNAVAILABLE_RETRY_CACHE = 32;
 
+/**
+ * Given a block root, fetch all block along with its data (blobs or data columns) from a peer
+ * - for deneb and electra, fetch blobs in 1 round
+ * - for fulu, fetch data columns in multiple rounds
+ *   - round 0: only have the root, partialDownload = null
+ *   - round 1 onwards: partialDownload contains the block and pending data columns
+ */
 export async function beaconBlocksMaybeBlobsByRoot(
   config: ChainForkConfig,
   network: INetwork,
   peerId: PeerIdStr,
-  request: phase0.BeaconBlocksByRootRequest,
+  root: Root,
   partialDownload: null | PartialDownload,
   peerClient: string,
   logger?: Logger
-): Promise<{blocks: BlockInput[]; pendingDataColumns: null | number[]}> {
-  // console.log("beaconBlocksMaybeBlobsByRoot", request);
-  const allBlocks = partialDownload
+): Promise<{block: BlockInput; pendingDataColumns: null | number[]}> {
+  const [block] = partialDownload
     ? partialDownload.blocks.map((blockInput) => ({data: blockInput.block}))
-    : await network.sendBeaconBlocksByRoot(peerId, request);
+    : await network.sendBeaconBlocksByRoot(peerId, [root]);
 
-  logger?.debug("beaconBlocksMaybeBlobsByRoot response", {allBlocks: allBlocks.length, peerClient});
+  if (partialDownload !== null) {
+    logger?.debug("beaconBlocksMaybeBlobsByRoot response", {slot: block.data.message.slot, peerClient});
+  }
 
   const preDataBlocks = [];
   const blobsDataBlocks = [];
@@ -69,41 +78,35 @@ export async function beaconBlocksMaybeBlobsByRoot(
   const blobIdentifiers: deneb.BlobIdentifier[] = [];
   const dataColumnIdentifiers: fulu.DataColumnIdentifier[] = [];
 
-  let prevFork = null;
-  for (const block of allBlocks) {
-    const slot = block.data.message.slot;
-    const blockRoot = config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block.data.message);
-    const fork = config.getForkName(slot);
-    if (fork !== (prevFork ?? fork)) {
-      throw Error("beaconBlocksMaybeBlobsByRoot only accepts requests of same fork");
-    }
-    prevFork = fork;
+  const slot = block.data.message.slot;
+  const blockRoot = config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block.data.message);
+  const fork = config.getForkName(slot);
 
-    if (ForkSeq[fork] < ForkSeq.deneb) {
-      preDataBlocks.push(block);
-    } else if (fork === ForkName.deneb || fork === ForkName.electra) {
-      blobsDataBlocks.push(block);
-      const blobKzgCommitmentsLen = (block.data.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length;
-      logger?.debug("beaconBlocksMaybeBlobsByRoot", {blobKzgCommitmentsLen, peerClient});
-      for (let index = 0; index < blobKzgCommitmentsLen; index++) {
-        // try see if the blob is available locally
-        blobIdentifiers.push({blockRoot, index});
-      }
-    } else if (fork === ForkName.fulu) {
-      dataColumnsDataBlocks.push(block);
-      const blobKzgCommitmentsLen = (block.data.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length;
-      const custodyColumnIndexes = blobKzgCommitmentsLen > 0 ? columns : [];
-      for (const columnIndex of custodyColumnIndexes) {
-        dataColumnIdentifiers.push({blockRoot, index: columnIndex});
-      }
-    } else {
-      throw Error(`Invalid fork=${fork} in beaconBlocksMaybeBlobsByRoot`);
+  if (ForkSeq[fork] < ForkSeq.deneb) {
+    preDataBlocks.push(block);
+  } else if (fork === ForkName.deneb || fork === ForkName.electra) {
+    blobsDataBlocks.push(block);
+    const blobKzgCommitmentsLen = (block.data.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length;
+    logger?.debug("beaconBlocksMaybeBlobsByRoot", {blobKzgCommitmentsLen, peerClient});
+    for (let index = 0; index < blobKzgCommitmentsLen; index++) {
+      // try see if the blob is available locally
+      blobIdentifiers.push({blockRoot, index});
     }
+  } else if (fork === ForkName.fulu) {
+    dataColumnsDataBlocks.push(block);
+    const blobKzgCommitmentsLen = (block.data.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length;
+    const custodyColumnIndexes = blobKzgCommitmentsLen > 0 ? columns : [];
+    for (const columnIndex of custodyColumnIndexes) {
+      dataColumnIdentifiers.push({blockRoot, index: columnIndex});
+    }
+  } else {
+    throw Error(`Invalid fork=${fork} in beaconBlocksMaybeBlobsByRoot`);
   }
 
-  let blockInputs = preDataBlocks.map((block) => getBlockInput.preData(config, block.data, BlockSource.byRoot));
+  let blockInput = getBlockInput.preData(config, block.data, BlockSource.byRoot);
 
   if (blobsDataBlocks.length > 0) {
+    // deneb and electra
     let allBlobSidecars: deneb.BlobSidecar[];
     if (blobIdentifiers.length > 0) {
       allBlobSidecars = await network.sendBlobSidecarsByRoot(peerId, blobIdentifiers);
@@ -115,25 +118,22 @@ export async function beaconBlocksMaybeBlobsByRoot(
     // and here it should be infinity since all bobs should match
     const blockInputWithBlobs = matchBlockWithBlobs(
       config,
-      allBlocks,
+      [block],
       allBlobSidecars,
       Infinity,
       BlockSource.byRoot,
       BlobsSource.byRoot
     );
-    blockInputs = [...blockInputs, ...blockInputWithBlobs];
+    if (blockInputWithBlobs.length !== 1) {
+      throw Error(`Expected exactly one blockInputWithBlobs slot=${slot}`);
+    }
+    blockInput = blockInputWithBlobs[0];
   }
 
   if (dataColumnsDataBlocks.length > 0) {
-    pendingDataColumns = neededColumns.reduce((acc, elem) => {
-      if (!columns.includes(elem)) {
-        acc.push(elem);
-      }
-      return acc;
-    }, [] as number[]);
-
-    let allDataColumnsSidecars: fulu.DataColumnSidecar[];
-    logger?.debug("allDataColumnsSidecars partialDownload", {
+    // fulu
+    let dataColumnSidecars: fulu.DataColumnSidecar[];
+    logger?.debug("beaconBlocksMaybeBlobsByRoot: dataColumnsSidecars partialDownload", {
       ...(partialDownload
         ? {blocks: partialDownload.blocks.length, pendingDataColumns: partialDownload.pendingDataColumns.join(" ")}
         : {blocks: null, pendingDataColumns: null}),
@@ -141,39 +141,88 @@ export async function beaconBlocksMaybeBlobsByRoot(
       peerClient,
     });
     if (dataColumnIdentifiers.length > 0) {
-      allDataColumnsSidecars = await network.sendDataColumnSidecarsByRoot(peerId, dataColumnIdentifiers);
+      dataColumnSidecars = await network.sendDataColumnSidecarsByRoot(peerId, dataColumnIdentifiers);
     } else {
+      // peer doesn't have columns we need, return. Consumer should try another peer
       if (partialDownload !== null) {
-        return partialDownload;
+        logger?.verbose("beaconBlocksMaybeBlobsByRoot: peer doesn't have columns we need", {slot, peerClient});
+        return {block: partialDownload.blocks[0], pendingDataColumns};
       }
-      allDataColumnsSidecars = [];
+      dataColumnSidecars = [];
     }
 
-    // The last arg is to provide slot to which all blobs should be exausted in matching
-    // and here it should be infinity since all bobs should match
-    // TODO: should not call matchBlockWithDataColumns() because it's supposed for range sync
-    // in that function, peers should return all requested data columns, this function runs at gossip time
-    // and it should not expect that
-    const blockInputWithBlobs = matchBlockWithDataColumns(
-      network,
-      peerId,
-      config,
-      custodyConfig,
-      columns,
-      allBlocks,
-      allDataColumnsSidecars,
-      Infinity,
-      BlockSource.byRoot,
-      DataColumnsSource.byRoot,
-      partialDownload,
+    // the same to matchBlockWithDataColumns() without expecting requested data columns = responded data columns
+    // because at gossip time peer may not have enough column to return
+    let cachedData: CachedData;
+    if (partialDownload !== null) {
+      const prevBlockInput = partialDownload.blocks[0];
+      if (prevBlockInput == null) {
+        throw Error("beaconBlocksMaybeBlobsByRoot: prevBlockInput=null in partialDownload");
+      }
+
+      if (prevBlockInput.type !== BlockInputType.dataPromise) {
+        throw Error(`beaconBlocksMaybeBlobsByRoot: prevBlockInput.type=${prevBlockInput.type} in prevPartialDownload`);
+      }
+      cachedData = prevBlockInput.cachedData;
+    } else {
+      // biome-ignore lint/style/noNonNullAssertion: checked below for validity
+      cachedData = getEmptyBlockInputCacheEntry(config.getForkName(block.data.message.slot), -1).cachedData!;
+      if (cachedData === undefined) {
+        throw Error("beaconBlocksMaybeBlobsByRoot: Invalid cachedData=undefined from getEmptyBlockInputCacheEntry");
+      }
+    }
+
+    if (cachedData.fork !== ForkName.fulu) {
+      throw Error("Invalid fork for cachedData on dataColumns");
+    }
+
+    const dataColumnsCache = (cachedData as CachedDataColumns).dataColumnsCache;
+    for (const dataColumnSidecar of dataColumnSidecars) {
+      dataColumnsCache.set(dataColumnSidecar.index, {
+        dataColumn: dataColumnSidecar,
+        // TODO: req/resp should return bytes here
+        dataColumnBytes: null,
+      });
+    }
+
+    pendingDataColumns = custodyConfig.sampledColumns.reduce((acc, elem) => {
+      if (dataColumnsCache.get(elem) === undefined) {
+        acc.push(elem);
+      }
+      return acc;
+    }, [] as number[]);
+
+    const logCtx = {
+      slot: slot,
+      requestedColumns: columns.join(","),
+      respondedColumns: dataColumnSidecars.map((dcs) => dcs.index).join(","),
       peerClient,
-      logger
-    );
-    blockInputs = [...blockInputs, ...blockInputWithBlobs];
+    };
+
+    if (pendingDataColumns.length === 0) {
+      const {dataColumns, dataColumnsBytes} = getBlockInputDataColumns(
+        dataColumnsCache,
+        custodyConfig.sampledColumns
+      );
+
+      const blockData = {
+        fork: config.getForkName(slot),
+        dataColumns,
+        dataColumnsBytes,
+        dataColumnsSource: DataColumnsSource.byRoot,
+      } as BlockInputDataColumns;
+
+      logger?.verbose("beaconBlocksMaybeBlobsByRoot: fetched all data columns", logCtx);
+      blockInput = getBlockInput.availableData(config, block.data, BlockSource.byRoot, blockData);
+    } else {
+      // Consumer need to try with another peer
+      logger?.verbose("beaconBlocksMaybeBlobsByRoot: still missing data columns for block", logCtx);
+      blockInput = getBlockInput.dataPromise(config, block.data, BlockSource.byRoot, cachedData);
+    }
   }
 
   return {
-    blocks: blockInputs,
+    block: blockInput,
     pendingDataColumns: pendingDataColumns && pendingDataColumns.length > 0 ? pendingDataColumns : null,
   };
 }
@@ -203,10 +252,6 @@ export async function unavailableBeaconBlobsByRoot(
     block = allBlocks[0].data;
     cachedData = unavailableBlockInput.cachedData;
     unavailableBlockInput = getBlockInput.dataPromise(config, block, BlockSource.byRoot, cachedData);
-    // console.log(
-    //   "downloaded sendBeaconBlocksByRoot",
-    //   ssz.fulu.SignedBeaconBlock.toJson(block as fulu.SignedBeaconBlock)
-    // );
   } else {
     ({block, cachedData} = unavailableBlockInput);
   }

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -58,7 +58,6 @@ export async function beaconBlocksMaybeBlobsByRoot(
     logger?.debug("beaconBlocksMaybeBlobsByRoot response", {slot: block.data.message.slot, peerClient});
   }
 
-  const preDataBlocks = [];
   const blobsDataBlocks = [];
   const dataColumnsDataBlocks = [];
 
@@ -82,8 +81,9 @@ export async function beaconBlocksMaybeBlobsByRoot(
   const blockRoot = config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block.data.message);
   const fork = config.getForkName(slot);
 
+  let blockInput: BlockInput | null = null;
   if (ForkSeq[fork] < ForkSeq.deneb) {
-    preDataBlocks.push(block);
+    blockInput = getBlockInput.preData(config, block.data, BlockSource.byRoot)
   } else if (fork === ForkName.deneb || fork === ForkName.electra) {
     blobsDataBlocks.push(block);
     const blobKzgCommitmentsLen = (block.data.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length;
@@ -102,8 +102,6 @@ export async function beaconBlocksMaybeBlobsByRoot(
   } else {
     throw Error(`Invalid fork=${fork} in beaconBlocksMaybeBlobsByRoot`);
   }
-
-  let blockInput = getBlockInput.preData(config, block.data, BlockSource.byRoot);
 
   if (blobsDataBlocks.length > 0) {
     // deneb and electra
@@ -219,6 +217,10 @@ export async function beaconBlocksMaybeBlobsByRoot(
       logger?.verbose("beaconBlocksMaybeBlobsByRoot: still missing data columns for block", logCtx);
       blockInput = getBlockInput.dataPromise(config, block.data, BlockSource.byRoot, cachedData);
     }
+  }
+
+  if (blockInput == null) {
+    throw Error("beaconBlocksMaybeBlobsByRoot: blockInput=null");
   }
 
   return {

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -553,8 +553,7 @@ export class UnknownBlockSync {
     let lastError: Error | null = null;
     let partialDownload = null;
     let fetchedPeerId = null;
-    // TODO: should it be loop through MAX_ATTEMPTS_PER_BLOCK instead?
-    for (let i = 0; i < 1; i++) {
+    for (let i = 0; i < MAX_ATTEMPTS_PER_BLOCK; i++) {
       const peer = shuffledPeers[i % shuffledPeers.length];
       if (partialDownload !== null) {
         const [prevBlockInput] = partialDownload.blocks;

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -583,13 +583,13 @@ export class UnknownBlockSync {
       try {
         const peerClient = this.network.getConnectedPeerClientAgent(peer);
         const {
-          blocks: [blockInput],
+          block: blockInput,
           pendingDataColumns,
         } = await beaconBlocksMaybeBlobsByRoot(
           this.config,
           this.network,
           peer,
-          [blockRoot],
+          blockRoot,
           partialDownload,
           peerClient,
           this.logger

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -350,6 +350,11 @@ export class UnknownBlockSync {
 
     if (!res.err) {
       const {blockInput, peerIdStr} = res.result;
+      this.logger.verbose("Downloaded unknown block root", {
+        ...logCtx,
+        peer: peerIdStr,
+        blockInputType: blockInput.type,
+      });
       if (blockInput.type === BlockInputType.dataPromise) {
         // if there were any peers who would have had the missing datacolumns, it would have resulted in err
         block = {


### PR DESCRIPTION
**Motivation**

- fix this mismatch error at synced time same to #7467
```
^[[39m: matchBlockWithDataColumns2 dataColumnIndexes=11 15, reque        stedColumnsPresent=false, slot=38584, peerClient=Lighthouse-cgc:128
2609158 Feb-12 18:58:44.857[sync]            ^[[34mdebug^[[39m: Missing or mismatching dataColumnSidecars from peerId=16U        iu2HAmJyaVGkRGR9ACqompkoge8T2x4KFH4KbzDkh7zz6uN2JX for blockSlot=38584 with numColumns=8 dataColumnSidecars=2 req        uestedColumnsPresent=false received dataColumnIndexes=11 15 requested=11 15 65 71 72 73 83 108 allBlocks=1, allDa        taColumnSidecars=2, peerId=16Uiu2HAmJyaVGkRGR9ACqompkoge8T2x4KFH4KbzDkh7zz6uN2JX, nodeId=0x70a752f736fd0254c715ae        31a3b64d9f3e011c1ca38e7f828d6d7f7bdf4391aa, blobKzgCommitmentsLen=6, peerClient=Lighthouse-cgc:128
```

- this is the logic inside `beaconBlocksMaybeBlobsByRoot()`

**Description**

- at gossip time, `beaconBlocksMaybeBlobsByRoot()` call range sync's `matchBlockWithDataColumns()` which is a mistake because we should not expect peer has enough columns for us at gossip time. Spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/p2p-interface.md#datacolumnsidecarsbyroot-v1
- instead of that, just get as much columns as we can and return data promise at that time
- more details: bring `matchBlockWithDataColumns()` logic without matching code
- also this `beaconBlocksMaybeBlobsByRoot()`  should not support multiple roots because:
  - consumer only need 1 root
  - from fulu, for each block peer may has different data for it at gossip time

