### PR TITLE
chore: update builder api spec tests to run against v0.5.0

### DIFF
--- a/packages/api/test/unit/builder/builder.test.ts
+++ b/packages/api/test/unit/builder/builder.test.ts
@@ -10,9 +10,6 @@ describe("builder", () => {
   runGenericServerTest<Endpoints>(
     createChainForkConfig({
       ...defaultChainConfig,
-      ALTAIR_FORK_EPOCH: 0,
-      BELLATRIX_FORK_EPOCH: 0,
-      DENEB_FORK_EPOCH: 0,
       ELECTRA_FORK_EPOCH: 0,
     }),
     getClient,

--- a/packages/api/test/unit/builder/builder.test.ts
+++ b/packages/api/test/unit/builder/builder.test.ts
@@ -8,10 +8,7 @@ import {testData} from "./testData.js";
 
 describe("builder", () => {
   runGenericServerTest<Endpoints>(
-    createChainForkConfig({
-      ...defaultChainConfig,
-      ELECTRA_FORK_EPOCH: 0,
-    }),
+    createChainForkConfig({...defaultChainConfig, ELECTRA_FORK_EPOCH: 0}),
     getClient,
     getRoutes,
     testData

--- a/packages/api/test/unit/builder/builder.test.ts
+++ b/packages/api/test/unit/builder/builder.test.ts
@@ -13,6 +13,7 @@ describe("builder", () => {
       ALTAIR_FORK_EPOCH: 0,
       BELLATRIX_FORK_EPOCH: 0,
       DENEB_FORK_EPOCH: 0,
+      ELECTRA_FORK_EPOCH: 0,
     }),
     getClient,
     getRoutes,

--- a/packages/api/test/unit/builder/oapiSpec.test.ts
+++ b/packages/api/test/unit/builder/oapiSpec.test.ts
@@ -21,12 +21,7 @@ const openApiFile: OpenApiFile = {
   version: RegExp(/.*/),
 };
 
-const definitions = getDefinitions(
-  createChainForkConfig({
-    ...defaultChainConfig,
-    ELECTRA_FORK_EPOCH: 0,
-  })
-);
+const definitions = getDefinitions(createChainForkConfig({...defaultChainConfig, ELECTRA_FORK_EPOCH: 0}));
 
 const openApiJson = await fetchOpenApiSpec(openApiFile);
 runTestCheckAgainstSpec(openApiJson, definitions, testData);

--- a/packages/api/test/unit/builder/oapiSpec.test.ts
+++ b/packages/api/test/unit/builder/oapiSpec.test.ts
@@ -24,10 +24,6 @@ const openApiFile: OpenApiFile = {
 const definitions = getDefinitions(
   createChainForkConfig({
     ...defaultChainConfig,
-    ALTAIR_FORK_EPOCH: 0,
-    BELLATRIX_FORK_EPOCH: 0,
-    CAPELLA_FORK_EPOCH: 0,
-    DENEB_FORK_EPOCH: 0,
     ELECTRA_FORK_EPOCH: 0,
   })
 );

--- a/packages/api/test/unit/builder/oapiSpec.test.ts
+++ b/packages/api/test/unit/builder/oapiSpec.test.ts
@@ -12,7 +12,7 @@ import {testData} from "./testData.js";
 // Solutions: https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const version = "v0.2.0";
+const version = "v0.5.0";
 const openApiFile: OpenApiFile = {
   url: `https://github.com/ethereum/builder-specs/releases/download/${version}/builder-oapi.json`,
   filepath: path.join(__dirname, "../../../oapi-schemas/builder-oapi.json"),
@@ -22,7 +22,14 @@ const openApiFile: OpenApiFile = {
 };
 
 const definitions = getDefinitions(
-  createChainForkConfig({...defaultChainConfig, ALTAIR_FORK_EPOCH: 0, BELLATRIX_FORK_EPOCH: 0})
+  createChainForkConfig({
+    ...defaultChainConfig,
+    ALTAIR_FORK_EPOCH: 0,
+    BELLATRIX_FORK_EPOCH: 0,
+    CAPELLA_FORK_EPOCH: 0,
+    DENEB_FORK_EPOCH: 0,
+    ELECTRA_FORK_EPOCH: 0,
+  })
 );
 
 const openApiJson = await fetchOpenApiSpec(openApiFile);

--- a/packages/api/test/unit/builder/testData.ts
+++ b/packages/api/test/unit/builder/testData.ts
@@ -20,10 +20,10 @@ export const testData: GenericServerTestCases<Endpoints> = {
   },
   getHeader: {
     args: {slot: 1, parentHash: root, proposerPubkey: fromHexString(pubkeyRand)},
-    res: {data: ssz.bellatrix.SignedBuilderBid.defaultValue(), meta: {version: ForkName.bellatrix}},
+    res: {data: ssz.electra.SignedBuilderBid.defaultValue(), meta: {version: ForkName.electra}},
   },
   submitBlindedBlock: {
-    args: {signedBlindedBlock: {data: ssz.deneb.SignedBlindedBeaconBlock.defaultValue()}},
-    res: {data: ssz.bellatrix.ExecutionPayload.defaultValue(), meta: {version: ForkName.bellatrix}},
+    args: {signedBlindedBlock: {data: ssz.electra.SignedBlindedBeaconBlock.defaultValue()}},
+    res: {data: ssz.deneb.ExecutionPayloadAndBlobsBundle.defaultValue(), meta: {version: ForkName.electra}},
   },
 };

--- a/packages/api/test/utils/checkAgainstSpec.ts
+++ b/packages/api/test/utils/checkAgainstSpec.ts
@@ -16,7 +16,7 @@ ajv.addKeyword({
   errors: false,
 });
 
-ajv.addFormat("hex", /^0x[a-fA-F0-9]+$/);
+ajv.addFormat("hex", /^0x[a-fA-F0-9]*$/);
 
 /**
  * A set of properties that will be ignored during tests execution.


### PR DESCRIPTION
**Motivation**

Make sure we test against the latest spec, it has been a while since this has been updated.

**Description**

- run openapi tests against latest builder api spec
- activate most recent fork (electra) in fork schedule

Part of https://github.com/ChainSafe/lodestar/issues/6987
