### PR TITLE
fix: ensure new withdrawalCredentials in switchToCompoundingValidator()

### DIFF
--- a/packages/state-transition/src/util/electra.ts
+++ b/packages/state-transition/src/util/electra.ts
@@ -20,7 +20,11 @@ export function switchToCompoundingValidator(state: CachedBeaconStateElectra, in
   // directly modifying the byte leads to ssz missing the modification resulting into
   // wrong root compute, although slicing can be avoided but anyway this is not going
   // to be a hot path so its better to clean slice and avoid side effects
-  const newWithdrawalCredentials = validator.withdrawalCredentials.slice();
+  const newWithdrawalCredentials = Uint8Array.prototype.slice.call(
+    validator.withdrawalCredentials,
+    0,
+    validator.withdrawalCredentials.length
+  );
   newWithdrawalCredentials[0] = COMPOUNDING_WITHDRAWAL_PREFIX;
   validator.withdrawalCredentials = newWithdrawalCredentials;
   queueExcessActiveBalance(state, index);


### PR DESCRIPTION
**Motivation**

- got this issue in Gnosis

Tested this but on first consolidation same target and source validator it apparently worked fine. However, the erigon-lodestar validator node that proposed the consolidation request transaction rejected all peers and forked. It is stuck on this slot: [link](http://45.79.201.144:8083/slot/68121)


Lodestar shows these errors:
```
Feb-17 07:11:09.621[chain]           debug: Block error slot=68121, code=BLOCK_ERROR_INVALID_STATE_ROOT, slot=68121, root=0xb8362da32e9ba60bb4e76aa3dae3cf3722404f97be7d674a1ba2d61140bae2f0, expectedRoot=0xb3e18d8a01cb01ac43a0e2fc4d11f6f9298d74ed51ed8520f0597001e4499516
Error: BLOCK_ERROR_INVALID_STATE_ROOT
    at verifyBlocksStateTransitionOnly (file:///usr/app/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts:71:13)
    at BeaconChain.verifyBlocksInEpoch (file:///usr/app/packages/beacon-node/src/chain/blocks/verifyBlock.ts:114:7)
    at BeaconChain.processBlocks (file:///usr/app/packages/beacon-node/src/chain/blocks/index.ts:74:7)
    at JobItemQueue.runJob (file:///usr/app/packages/beacon-node/src/util/queue/itemQueue.ts:102:22)
Feb-17 07:11:09.622[sync]          verbose: Batch process error id=Finalized, startEpoch=4257, status=Processing, code=BLOCK_ERROR_INVALID_STATE_ROOT, slot=68121, root=0xb8362da32e9ba60bb4e76aa3dae3cf3722404f97be7d674a1ba2d61140bae2f0, expectedRoot=0xb3e18d8a01cb01ac43a0e2fc4d11f6f9298d74ed51ed8520f0597001e4499516
Error: BLOCK_ERROR_INVALID_STATE_ROOT
    at verifyBlocksStateTransitionOnly (file:///usr/app/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts:71:13)
    at BeaconChain.verifyBlocksInEpoch (file:///usr/app/packages/beacon-node/src/chain/blocks/verifyBlock.ts:114:7)
    at BeaconChain.processBlocks (file:///usr/app/packages/beacon-node/src/chain/blocks/index.ts:74:7)
    at JobItemQueue.runJob (file:///usr/app/packages/beacon-node/src/util/queue/itemQueue.ts:102:22)
```

The rest of the nodes are working the fine, even nethermind-lodestar, and the validator seems to have updated to 0x02 withdrawal credentials type. [link](http://45.79.201.144:8083/validator/2000)

closes #7487

**Description**

- although it's not proved to fix the issue, we should ensure we always create a new `withdrawalCredentials` by enforcing the use of `Uint8Array.slice()`, just in case backed data is a Buffer
- the similar "Invalid state root" was found in the past due to this code place, as noted in the comment
- this pattern was used in a lot of places anyway

**Update**
just found this

```typescript
describe("Buffer", () => {
  it("slice", () => {
    const buffer = Buffer.alloc(32, 1);
    const sliced = Uint8Array.prototype.slice.call(buffer, 0, buffer.length);
    sliced[0] = 2;
    expect(sliced[0]).toBe(2);
    expect(buffer[0]).toBe(1);
    expect(sliced instanceof Buffer).toBe(false);
  });
});
```

```
- Expected
+ Received

- false
+ true
```

even we used this pattern a lot `Uint8Array.prototype.slice.call` in ssz to deserialize state it still return a Buffer
when we deserialize state from leveldb, the state bytes there is really the Buffer
that's one possibilities how this issue happened


**Conclusion**

The state root mismatch happens because the proposer calls `stateTransition` twice for the same block, first time when [computeNewStateRoot](https://github.com/ChainSafe/lodestar/blob/9a2cf748d3a2d63180fdfca6a948731e976b75d8/packages/beacon-node/src/chain/chain.ts#L726) is called and second time when processing / importing the block when it is publishing.

Based on these observations it seems like the condition is that
- lodestar needs to be proposer of block
- the block needs to contain consolidation request switching validator to compounding
- the validator being switched needs to be part of state that was loaded from the db / genesis ssz file