### PR TITLE
feat: always persist states and block if invalid state root

### DIFF
--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -128,13 +128,15 @@ export async function processBlocks(
         const {signedBlock} = err;
         const blockSlot = signedBlock.message.slot;
         const {preState, postState} = err.type;
-        const forkTypes = this.config.getForkTypes(blockSlot);
-        const invalidRoot = toRootHex(postState.hashTreeRoot());
-
-        const suffix = `slot_${blockSlot}_invalid_state_root_${invalidRoot}`;
-        this.persistInvalidSszValue(forkTypes.SignedBeaconBlock, signedBlock, suffix);
-        this.persistInvalidSszView(preState, `${suffix}_preState`);
-        this.persistInvalidSszView(postState, `${suffix}_postState`);
+        const preRoot = preState.hashTreeRoot();
+        const postRoot = postState.hashTreeRoot();
+        this.persistInvalidStateRoot(preState, postState, signedBlock).catch((e) => {
+          this.logger.error(
+            "Error persisting invalid state root objects",
+            {slot: blockSlot, preStateRoot: toRootHex(preRoot), postStateRoot: toRootHex(postRoot)},
+            e
+          );
+        });
       }
     }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -873,6 +873,36 @@ export class BeaconChain implements IBeaconChain {
     }
   }
 
+  /**
+   * Invalid state root error is critical and it causes the node to stale most of the time so we want to always
+   * persist preState, postState and block for further investigation.
+   */
+  async persistInvalidStateRoot(
+    preState: CachedBeaconStateAllForks,
+    postState: CachedBeaconStateAllForks,
+    block: SignedBeaconBlock
+  ): Promise<void> {
+    const blockSlot = block.message.slot;
+    const blockType = this.config.getForkTypes(blockSlot).SignedBeaconBlock;
+    const postStateRoot = postState.hashTreeRoot();
+    const suffix = `slot_${blockSlot}_invalid_state_root_${toRootHex(postStateRoot)}`;
+    await Promise.all([
+      this.persistSszObject("SignedBeaconBlock", blockType.serialize(block), blockType.hashTreeRoot(block), suffix),
+      this.persistSszObject(
+        `preState_${preState.type.typeName}_${preState.slot}`,
+        preState.serialize(),
+        preState.hashTreeRoot(),
+        suffix
+      ),
+      this.persistSszObject(
+        `postState_${postState.type.typeName}_${postState.slot}`,
+        postState.serialize(),
+        postState.hashTreeRoot(),
+        suffix
+      ),
+    ]);
+  }
+
   persistInvalidSszValue<T>(type: Type<T>, sszObject: T, suffix?: string): void {
     if (this.opts.persistInvalidSszObjects) {
       void this.persistSszObject(type.typeName, type.serialize(sszObject), type.hashTreeRoot(sszObject), suffix);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -885,20 +885,25 @@ export class BeaconChain implements IBeaconChain {
     const blockSlot = block.message.slot;
     const blockType = this.config.getForkTypes(blockSlot).SignedBeaconBlock;
     const postStateRoot = postState.hashTreeRoot();
-    const suffix = `slot_${blockSlot}_invalid_state_root_${toRootHex(postStateRoot)}`;
+    const logStr = `slot_${blockSlot}_invalid_state_root_${toRootHex(postStateRoot)}`;
     await Promise.all([
-      this.persistSszObject("SignedBeaconBlock", blockType.serialize(block), blockType.hashTreeRoot(block), suffix),
       this.persistSszObject(
-        `preState_${preState.type.typeName}_${preState.slot}`,
-        preState.serialize(),
-        preState.hashTreeRoot(),
-        suffix
+        `SignedBeaconBlock_slot_${blockSlot}`,
+        blockType.serialize(block),
+        blockType.hashTreeRoot(block),
+        `${logStr}_block`
       ),
       this.persistSszObject(
-        `postState_${postState.type.typeName}_${postState.slot}`,
+        `preState_slot_${preState.slot}_${preState.type.typeName}`,
+        preState.serialize(),
+        preState.hashTreeRoot(),
+        `${logStr}_pre_state`
+      ),
+      this.persistSszObject(
+        `postState_slot_${postState.slot}_${postState.type.typeName}`,
         postState.serialize(),
         postState.hashTreeRoot(),
-        suffix
+        `${logStr}_post_state`
       ),
     ]);
   }
@@ -1052,19 +1057,14 @@ export class BeaconChain implements IBeaconChain {
     return {state: blockState, stateId: "block_state_any_epoch", shouldWarn: true};
   }
 
-  private async persistSszObject(
-    typeName: string,
-    bytes: Uint8Array,
-    root: Uint8Array,
-    suffix?: string
-  ): Promise<void> {
+  private async persistSszObject(prefix: string, bytes: Uint8Array, root: Uint8Array, logStr?: string): Promise<void> {
     const now = new Date();
     // yyyy-MM-dd
     const dateStr = now.toISOString().split("T")[0];
 
     // by default store to lodestar_archive of current dir
     const dirpath = path.join(this.opts.persistInvalidSszObjectsDir ?? "invalid_ssz_objects", dateStr);
-    const filepath = path.join(dirpath, `${typeName}_${toRootHex(root)}.ssz`);
+    const filepath = path.join(dirpath, `${prefix}_${toRootHex(root)}.ssz`);
 
     await ensureDir(dirpath);
 
@@ -1072,7 +1072,7 @@ export class BeaconChain implements IBeaconChain {
     // remove date suffixes in file name, and check duplicate to avoid redundant persistence
     await writeIfNotExist(filepath, bytes);
 
-    this.logger.debug("Persisted invalid ssz object", {id: suffix, filepath});
+    this.logger.debug("Persisted invalid ssz object", {id: logStr, filepath});
   }
 
   private onScrapeMetrics(metrics: Metrics): void {

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -222,6 +222,11 @@ export interface IBeaconChain {
   updateBeaconProposerData(epoch: Epoch, proposers: ProposerPreparationData[]): Promise<void>;
 
   persistBlock(data: BeaconBlock | BlindedBeaconBlock, suffix?: string): void;
+  persistInvalidStateRoot(
+    preState: CachedBeaconStateAllForks,
+    postState: CachedBeaconStateAllForks,
+    block: SignedBeaconBlock
+  ): Promise<void>;
   persistInvalidSszValue<T>(type: Type<T>, sszObject: T | Uint8Array, suffix?: string): void;
   persistInvalidSszBytes(type: string, sszBytes: Uint8Array, suffix?: string): void;
   /** Persist bad items to persistInvalidSszObjectsDir dir, for example invalid state, attestations etc. */


### PR DESCRIPTION
**Motivation**

- on devnets, "invalid state root" may happen and there is no way to investigate if we don't have preState, postState and signedBlock
- in that case, the node usually stale

**Description**

- always persist preState, postState and signedBlock when there is "invalid state root" issue
- this should not affect mainnet's performance
