### PR TITLE
fix: ensure loaded state is typed as `Uint8Array`

### DIFF
--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -104,7 +104,9 @@ export async function initBeaconState(
   //   i)  used directly as the anchor state
   //   ii) used to load and verify a weak subjectivity state,
   const lastDbSlot = await db.stateArchive.lastKey();
-  const stateBytes = lastDbSlot !== null ? await db.stateArchive.getBinary(lastDbSlot) : null;
+  let stateBytes = lastDbSlot !== null ? await db.stateArchive.getBinary(lastDbSlot) : null;
+  // Convert to `Uint8Array` to avoid unexpected behavior such as `Buffer.prototype.slice` not copying memory
+  stateBytes = stateBytes ? new Uint8Array(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength) : null;
   let lastDbState: BeaconStateAllForks | null = null;
   let lastDbValidatorsBytes: Uint8Array | null = null;
   let lastDbStateWithBytes: StateWithBytes | null = null;
@@ -181,7 +183,9 @@ export async function initBeaconState(
 
   const genesisStateFile = args.genesisStateFile || getGenesisFileUrl(args.network || defaultNetwork);
   if (genesisStateFile && !args.forceGenesis) {
-    const stateBytes = await downloadOrLoadFile(genesisStateFile);
+    let stateBytes = await downloadOrLoadFile(genesisStateFile);
+    // Convert to `Uint8Array` to avoid unexpected behavior such as `Buffer.prototype.slice` not copying memory
+    stateBytes = new Uint8Array(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength);
     const anchorState = getStateTypeFromBytes(chainForkConfig, stateBytes).deserializeToViewDU(stateBytes);
     const config = createBeaconConfig(chainForkConfig, anchorState.genesisValidatorsRoot);
     const wssCheck = isWithinWeakSubjectivityPeriod(config, anchorState, getCheckpointFromState(anchorState));


### PR DESCRIPTION
**Motivation**

This is related to
- https://github.com/ChainSafe/lodestar/issues/7487
- https://github.com/ChainSafe/lodestar/pull/7478

and adds a additional safety measure to avoid issues related to `Buffer`, specifically we wanna avoid unexpected behavior such as `Buffer.prototype.slice` not copying memory.

**Description**

This changes ensures loaded state is `typeof Uint8Array` by converting loaded bytes. This operation is pretty much free based on benchmarks in https://github.com/ChainSafe/lodestar/issues/6688 as it does not copy the underlying memory, just updates the view.

```
Buffer utils
✔ Buffer.from - copy                  7.286412 ops/s    137.2418 ms/op   x1.024         38 runs   5.82 s
✔ Buffer.from - no copy                1117318 ops/s    895.0000 ns/op   x0.982     723013 runs   1.11 s
✔ Buffer.from - no copy with offset    1179245 ops/s    848.0000 ns/op        -    2699558 runs   3.85 s
```
