### PR TITLE
fix: model AttesterSlashing without bigint

### DIFF
--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -375,7 +375,7 @@ export class Network implements INetwork {
   }
 
   async publishAttesterSlashing(attesterSlashing: AttesterSlashing): Promise<number> {
-    const fork = this.config.getForkName(Number(attesterSlashing.attestation1.data.slot as bigint));
+    const fork = this.config.getForkName(attesterSlashing.attestation1.data.slot);
     return this.publishGossip<GossipType.attester_slashing>(
       {type: GossipType.attester_slashing, fork},
       attesterSlashing

--- a/packages/flare/src/cmds/selfSlashAttester.ts
+++ b/packages/flare/src/cmds/selfSlashAttester.ts
@@ -49,7 +49,7 @@ export const selfSlashAttester: CliCommand<SelfSlashArgs, Record<never, never>, 
 export async function selfSlashAttesterHandler(args: SelfSlashArgs): Promise<void> {
   const sksAll = deriveSecretKeys(args);
 
-  const slot = BigInt(args.slot); // Throws if not valid
+  const slot = Number(args.slot); // Throws if not valid
   const batchSize = parseInt(args.batchSize);
 
   if (Number.isNaN(batchSize)) throw Error(`Invalid arg batchSize ${args.batchSize}`);
@@ -102,31 +102,31 @@ export async function selfSlashAttesterHandler(args: SelfSlashArgs): Promise<voi
 
     // Trigers a double vote, same target epoch different data (beaconBlockRoot)
     // TODO: Allow to create double-votes
-    const data1: phase0.AttestationDataBigint = {
+    const data1: phase0.AttestationData = {
       slot,
-      index: BigInt(0),
+      index: 0,
       beaconBlockRoot: rootA,
-      source: {epoch: BigInt(0), root: rootA},
-      target: {epoch: BigInt(0), root: rootB},
+      source: {epoch: 0, root: rootA},
+      target: {epoch: 0, root: rootB},
     };
-    const data2: phase0.AttestationDataBigint = {
+    const data2: phase0.AttestationData = {
       slot,
-      index: BigInt(0),
+      index: 0,
       beaconBlockRoot: rootB,
-      source: {epoch: BigInt(0), root: rootA},
-      target: {epoch: BigInt(0), root: rootB},
+      source: {epoch: 0, root: rootA},
+      target: {epoch: 0, root: rootB},
     };
 
     const attesterSlashing: AttesterSlashing = {
       attestation1: {
         attestingIndices,
         data: data1,
-        signature: signAttestationDataBigint(config, sks, data1),
+        signature: signAttestationData(config, sks, data1),
       },
       attestation2: {
         attestingIndices,
         data: data2,
-        signature: signAttestationDataBigint(config, sks, data2),
+        signature: signAttestationData(config, sks, data2),
       },
     };
 
@@ -138,14 +138,14 @@ export async function selfSlashAttesterHandler(args: SelfSlashArgs): Promise<voi
   }
 }
 
-function signAttestationDataBigint(
+function signAttestationData(
   config: BeaconConfig,
   sks: SecretKey[],
-  data: phase0.AttestationDataBigint
+  data: phase0.AttestationData
 ): Uint8Array {
-  const slot = Number(data.slot as bigint);
+  const slot = Number(data.slot);
   const proposerDomain = config.getDomain(slot, DOMAIN_BEACON_ATTESTER);
-  const signingRoot = computeSigningRoot(ssz.phase0.AttestationDataBigint, data, proposerDomain);
+  const signingRoot = computeSigningRoot(ssz.phase0.AttestationData, data, proposerDomain);
 
   const sigs = sks.map((sk) => sk.sign(signingRoot));
   return aggregateSignatures(sigs).toBytes();

--- a/packages/state-transition/src/block/processAttesterSlashing.ts
+++ b/packages/state-transition/src/block/processAttesterSlashing.ts
@@ -3,7 +3,7 @@ import {AttesterSlashing} from "@lodestar/types";
 
 import {CachedBeaconStateAllForks} from "../types.js";
 import {getAttesterSlashableIndices, isSlashableAttestationData, isSlashableValidator} from "../util/index.js";
-import {isValidIndexedAttestationBigint} from "./isValidIndexedAttestation.js";
+import {isValidIndexedAttestation, isValidIndexedAttestationBigint} from "./isValidIndexedAttestation.js";
 import {slashValidator} from "./slashValidator.js";
 
 /**
@@ -53,7 +53,7 @@ export function assertValidAttesterSlashing(
   // be higher than the clock and the slashing would still be valid. Same applies to attestation data index, which
   // can be any arbitrary value. Must use bigint variants to hash correctly to all possible values
   for (const [i, attestation] of [attestation1, attestation2].entries()) {
-    if (!isValidIndexedAttestationBigint(state, attestation, verifySignatures)) {
+    if (!isValidIndexedAttestation(state, attestation, verifySignatures)) {
       throw new Error(`AttesterSlashing attestation${i} is invalid`);
     }
   }

--- a/packages/state-transition/src/signatureSets/attesterSlashings.ts
+++ b/packages/state-transition/src/signatureSets/attesterSlashings.ts
@@ -2,6 +2,7 @@ import {DOMAIN_BEACON_ATTESTER} from "@lodestar/params";
 import {AttesterSlashing, IndexedAttestationBigint, SignedBeaconBlock, ssz} from "@lodestar/types";
 import {CachedBeaconStateAllForks} from "../types.js";
 import {ISignatureSet, SignatureSetType, computeSigningRoot, computeStartSlotAtEpoch} from "../util/index.js";
+import { getIndexedAttestationSignatureSet } from "./indexedAttestation.js";
 
 /** Get signature sets from all AttesterSlashing objects in a block */
 export function getAttesterSlashingsSignatureSets(
@@ -19,7 +20,7 @@ export function getAttesterSlashingSignatureSets(
   attesterSlashing: AttesterSlashing
 ): ISignatureSet[] {
   return [attesterSlashing.attestation1, attesterSlashing.attestation2].map((attestation) =>
-    getIndexedAttestationBigintSignatureSet(state, attestation)
+    getIndexedAttestationSignatureSet(state, attestation)
   );
 }
 

--- a/packages/state-transition/src/util/attestation.ts
+++ b/packages/state-transition/src/util/attestation.ts
@@ -5,12 +5,12 @@ import {AttesterSlashing, Slot, ValidatorIndex, phase0, ssz} from "@lodestar/typ
  * Check if [[data1]] and [[data2]] are slashable according to Casper FFG rules.
  */
 export function isSlashableAttestationData(
-  data1: phase0.AttestationDataBigint,
-  data2: phase0.AttestationDataBigint
+  data1: phase0.AttestationData,
+  data2: phase0.AttestationData
 ): boolean {
   return (
     // Double vote
-    (!ssz.phase0.AttestationDataBigint.equals(data1, data2) && data1.target.epoch === data2.target.epoch) ||
+    (!ssz.phase0.AttestationData.equals(data1, data2) && data1.target.epoch === data2.target.epoch) ||
     // Surround vote
     (data1.source.epoch < data2.source.epoch && data2.target.epoch < data1.target.epoch)
   );

--- a/packages/types/src/electra/sszTypes.ts
+++ b/packages/types/src/electra/sszTypes.ts
@@ -100,8 +100,8 @@ export const IndexedAttestationBigint = new ContainerType(
 
 export const AttesterSlashing = new ContainerType(
   {
-    attestation1: IndexedAttestationBigint, // Modified in ELECTRA
-    attestation2: IndexedAttestationBigint, // Modified in ELECTRA
+    attestation1: IndexedAttestation, // Modified in ELECTRA
+    attestation2: IndexedAttestation, // Modified in ELECTRA
   },
   {typeName: "AttesterSlashing", jsonCase: "eth2"}
 );

--- a/packages/types/src/phase0/sszTypes.ts
+++ b/packages/types/src/phase0/sszTypes.ts
@@ -323,8 +323,8 @@ export const AttesterSlashing = new ContainerType(
     // In state transition, AttesterSlashing attestations are only partially validated. Their slot and epoch could
     // be higher than the clock and the slashing would still be valid. Same applies to attestation data index, which
     // can be any arbitrary value. Must use bigint variants to hash correctly to all possible values
-    attestation1: IndexedAttestationBigint,
-    attestation2: IndexedAttestationBigint,
+    attestation1: IndexedAttestation,
+    attestation2: IndexedAttestation,
   },
   {typeName: "AttesterSlashing", jsonCase: "eth2"}
 );


### PR DESCRIPTION
**Motivation**

- @nflaig 's node was down due to OOM, could be because of processing a bunch of AttesterSlashing
- in the past we used to have memory issue with it, see https://github.com/ChainSafe/lodestar/issues/6112

**Description**

-  model AttesterSlashing without BigInt
