### PR TITLE
fix: processState to handle processPastEpoch

### DIFF
--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -476,8 +476,13 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     for (const lowestEpoch of persistEpochs) {
       try {
         // getBlockRootAtSlot() may fail, see https://github.com/ChainSafe/lodestar/issues/7495
+        if (state.slot < computeStartSlotAtEpoch(lowestEpoch)) {
+          // there is no checkpoint states of epochs newer than this state
+          break;
+        }
         // usually there is only 0 or 1 epoch to persist in this loop
         persistCount += await this.processPastEpoch(blockRootHex, state, lowestEpoch);
+        this.logger.verbose("Processed past epoch", {epoch: lowestEpoch, slot: blockSlot, root: blockRootHex});
       } catch (e) {
         this.logger.debug(
           "Error processing past epoch",

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -474,14 +474,17 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
 
     const persistEpochs = sortedEpochs.slice(0, sortedEpochs.length - this.maxEpochsInMemory);
     for (const lowestEpoch of persistEpochs) {
-      if (state.slot < computeStartSlotAtEpoch(lowestEpoch)) {
-        // there is no checkpoint states of epochs newer than this state
-        // otherwise get "Can only get block root in the past" error from getBlockRootAtSlot() api below
-        // see https://github.com/ChainSafe/lodestar/issues/7495
-        break;
+      try {
+        // getBlockRootAtSlot() may fail, see https://github.com/ChainSafe/lodestar/issues/7495
+        // usually there is only 0 or 1 epoch to persist in this loop
+        persistCount += await this.processPastEpoch(blockRootHex, state, lowestEpoch);
+      } catch (e) {
+        this.logger.debug(
+          "Error processing past epoch",
+          {epoch: lowestEpoch, slot: blockSlot, root: blockRootHex},
+          e as Error
+        );
       }
-      // usually there is only 0 or 1 epoch to persist in this loop
-      persistCount += await this.processPastEpoch(blockRootHex, state, lowestEpoch);
     }
 
     if (persistCount > 0) {


### PR DESCRIPTION
**Motivation**

- avoid OOM when node getting close to head in holesky 

**Description**

- the fix in https://github.com/ChainSafe/lodestar/pull/7497 was not enough since `getBlockRootAtSlot()` may fail at both side

Closes #7495
