### PR TITLE
Fix typo in BlobSidecarValidation comments: "recieved" → "received"

### DIFF
--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -147,10 +147,10 @@ export enum AttestationImportOpt {
 }
 
 export enum BlobSidecarValidation {
-  /** When recieved in gossip the blobs are individually verified before import */
+  /** When received in gossip the blobs are individually verified before import */
   Individual,
   /**
-   * Blobs when recieved in req/resp can be fully verified before import
+   * Blobs when received in req/resp can be fully verified before import
    * but currently used in spec tests where blobs come without proofs and assumed
    * to be valid
    */


### PR DESCRIPTION
Corrects spelling error in comments for BlobSidecarValidation enum in packages/beacon-node/src/chain/blocks/types.ts