### PR TITLE
feat: use local checkpoint state for holesky-rescue

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -216,15 +216,20 @@ export async function importBlock(
     // Set head state as strong reference
     this.regen.updateHeadState(newHead, postState);
 
-    this.emitter.emit(routes.events.EventType.head, {
-      block: newHead.blockRoot,
-      epochTransition: computeStartSlotAtEpoch(computeEpochAtSlot(newHead.slot)) === newHead.slot,
-      slot: newHead.slot,
-      state: newHead.stateRoot,
-      previousDutyDependentRoot: this.forkChoice.getDependentRoot(newHead, EpochDifference.previous),
-      currentDutyDependentRoot: this.forkChoice.getDependentRoot(newHead, EpochDifference.current),
-      executionOptimistic: isOptimisticBlock(newHead),
-    });
+    try {
+      this.emitter.emit(routes.events.EventType.head, {
+        block: newHead.blockRoot,
+        epochTransition: computeStartSlotAtEpoch(computeEpochAtSlot(newHead.slot)) === newHead.slot,
+        slot: newHead.slot,
+        state: newHead.stateRoot,
+        previousDutyDependentRoot: this.forkChoice.getDependentRoot(newHead, EpochDifference.previous),
+        currentDutyDependentRoot: this.forkChoice.getDependentRoot(newHead, EpochDifference.current),
+        executionOptimistic: isOptimisticBlock(newHead),
+      });
+    } catch (e) {
+      // holesky-rescue: getDependentRoot may fail with error: "No block for root"
+      this.logger.debug("Error emitting head event", {slot: newHead.slot, root: newHead.blockRoot}, e as Error);
+    }
 
     const delaySec = this.clock.secFromSlot(newHead.slot);
     this.logger.verbose("New chain head", {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -191,6 +191,7 @@ export class BeaconChain implements IBeaconChain {
       clock,
       metrics,
       anchorState,
+      isAnchorStateFinalized,
       eth1,
       executionEngine,
       executionBuilder,
@@ -205,6 +206,7 @@ export class BeaconChain implements IBeaconChain {
       clock?: IClock;
       metrics: Metrics | null;
       anchorState: BeaconStateAllForks;
+      isAnchorStateFinalized: boolean;
       eth1: IEth1ForBlockProduction;
       executionEngine: IExecutionEngine;
       executionBuilder?: IExecutionBuilder;
@@ -324,6 +326,7 @@ export class BeaconChain implements IBeaconChain {
       emitter,
       clock.currentSlot,
       cachedState,
+      isAnchorStateFinalized,
       opts,
       this.justifiedBalancesGetter.bind(this),
       logger

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -149,10 +149,13 @@ export function initializeForkChoiceFromUnfinalizedState(
   const {blockHeader} = computeAnchorCheckpoint(config, unFinalizedState);
   const finalizedCheckpoint = unFinalizedState.finalizedCheckpoint.toValue();
   const justifiedCheckpoint = unFinalizedState.currentJustifiedCheckpoint.toValue();
+  const headRoot = toRootHex(ssz.phase0.BeaconBlockHeader.hashTreeRoot(blockHeader));
 
   const logCtx = {
     currentSlot: currentSlot,
     stateSlot: unFinalizedState.slot,
+    headSlot: blockHeader.slot,
+    headRoot: headRoot,
     finalizedEpoch: finalizedCheckpoint.epoch,
     finalizedRoot: toRootHex(finalizedCheckpoint.root),
     justifiedEpoch: justifiedCheckpoint.epoch,
@@ -173,8 +176,6 @@ export function initializeForkChoiceFromUnfinalizedState(
       onFinalized: (cp) => emitter.emit(ChainEvent.forkChoiceFinalized, cp),
     }
   );
-
-  const headRoot = toRootHex(ssz.phase0.BeaconBlockHeader.hashTreeRoot(blockHeader));
 
   // this is the same to the finalized state
   const headBlock: ProtoBlock = {

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -22,10 +22,9 @@ import {
 import {Slot, ssz} from "@lodestar/types";
 
 import {Logger, toRootHex} from "@lodestar/utils";
-import {GENESIS_SLOT, ZERO_HASH, ZERO_HASH_HEX} from "../../constants/index.js";
+import {GENESIS_SLOT, ZERO_HASH_HEX} from "../../constants/index.js";
 import {ChainEventEmitter} from "../emitter.js";
 import {ChainEvent} from "../emitter.js";
-import { log } from "node:console";
 
 export type ForkChoiceOpts = RawForkChoiceOpts & {
   // for testing only

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -6,19 +6,23 @@ import {
   ForkChoiceStore,
   JustifiedBalancesGetter,
   ProtoArray,
+  ProtoBlock,
   ForkChoiceOpts as RawForkChoiceOpts,
 } from "@lodestar/fork-choice";
 import {
   CachedBeaconStateAllForks,
   computeAnchorCheckpoint,
+  computeEpochAtSlot,
+  computeStartSlotAtEpoch,
+  getBlockRootAtSlot,
   getEffectiveBalanceIncrementsZeroInactive,
   isExecutionStateType,
   isMergeTransitionComplete,
 } from "@lodestar/state-transition";
-import {Slot} from "@lodestar/types";
+import {Slot, ssz} from "@lodestar/types";
 
 import {Logger, toRootHex} from "@lodestar/utils";
-import {GENESIS_SLOT} from "../../constants/index.js";
+import {GENESIS_SLOT, ZERO_HASH, ZERO_HASH_HEX} from "../../constants/index.js";
 import {ChainEventEmitter} from "../emitter.js";
 import {ChainEvent} from "../emitter.js";
 
@@ -45,11 +49,25 @@ export function initializeForkChoice(
   justifiedBalancesGetter: JustifiedBalancesGetter,
   logger?: Logger
 ): ForkChoice {
-  const {blockHeader, checkpoint} = computeAnchorCheckpoint(config, state);
-  // in case of non-finalized anchor state, finalized checkpoint must not be itself
-  const finalizedCheckpoint = isFinalizedState ? {...checkpoint} : state.finalizedCheckpoint.toValue();
+  return isFinalizedState
+    ? initializeForkChoiceFromFinalizedState(config, emitter, currentSlot, state, opts, justifiedBalancesGetter, logger)
+    : initializeForkChoiceFromUnfinalizedState(config, emitter, currentSlot, state, opts, justifiedBalancesGetter, logger);
+}
 
-  // in case of non-finalized anchor state, we assume justified checkpoint is itself to grow the protoarray from there
+/**
+ * Initialized forkchoice from a finalized state.
+ */
+export function initializeForkChoiceFromFinalizedState(
+  config: ChainForkConfig,
+  emitter: ChainEventEmitter,
+  currentSlot: Slot,
+  state: CachedBeaconStateAllForks,
+  opts: ForkChoiceOpts,
+  justifiedBalancesGetter: JustifiedBalancesGetter,
+  logger?: Logger
+): ForkChoice {
+  const {blockHeader, checkpoint} = computeAnchorCheckpoint(config, state);
+  const finalizedCheckpoint = {...checkpoint};
   const justifiedCheckpoint = {
     ...checkpoint,
     // If not genesis epoch, justified checkpoint epoch must be set to finalized checkpoint epoch + 1
@@ -109,6 +127,110 @@ export function initializeForkChoice(
       },
       currentSlot
     ),
+    opts,
+    logger
+  );
+}
+
+/**
+ * Initialized forkchoice from an unfinalized state.
+ */
+export function initializeForkChoiceFromUnfinalizedState(
+  config: ChainForkConfig,
+  emitter: ChainEventEmitter,
+  currentSlot: Slot,
+  unFinalizedState: CachedBeaconStateAllForks,
+  opts: ForkChoiceOpts,
+  justifiedBalancesGetter: JustifiedBalancesGetter,
+  logger?: Logger
+): ForkChoice {
+  const {blockHeader} = computeAnchorCheckpoint(config, unFinalizedState);
+  const finalizedCheckpoint = unFinalizedState.finalizedCheckpoint.toValue();
+  const justifiedCheckpoint = unFinalizedState.currentJustifiedCheckpoint.toValue();
+
+  // this is not the justified state, but there is no other ways to get justified balances
+  const justifiedBalances = getEffectiveBalanceIncrementsZeroInactive(unFinalizedState);
+  const store = new ForkChoiceStore(
+    currentSlot,
+    justifiedCheckpoint,
+    finalizedCheckpoint,
+    justifiedBalances,
+    justifiedBalancesGetter,
+    {
+      onJustified: (cp) => emitter.emit(ChainEvent.forkChoiceJustified, cp),
+      onFinalized: (cp) => emitter.emit(ChainEvent.forkChoiceFinalized, cp),
+    }
+  );
+
+  const headRoot = toRootHex(ssz.phase0.BeaconBlockHeader.hashTreeRoot(blockHeader));
+
+  // this is the same to the finalized state
+  const headBlock: ProtoBlock = {
+    slot: blockHeader.slot,
+    parentRoot: toRootHex(blockHeader.parentRoot),
+    stateRoot: toRootHex(blockHeader.stateRoot),
+    blockRoot: headRoot,
+    targetRoot: headRoot,
+    timeliness: true, // Optimisitcally assume is timely
+
+    justifiedEpoch: justifiedCheckpoint.epoch,
+    justifiedRoot: toRootHex(justifiedCheckpoint.root),
+    finalizedEpoch: finalizedCheckpoint.epoch,
+    finalizedRoot: toRootHex(finalizedCheckpoint.root),
+    unrealizedJustifiedEpoch: justifiedCheckpoint.epoch,
+    unrealizedJustifiedRoot: toRootHex(justifiedCheckpoint.root),
+    unrealizedFinalizedEpoch: finalizedCheckpoint.epoch,
+    unrealizedFinalizedRoot: toRootHex(finalizedCheckpoint.root),
+
+    ...(isExecutionStateType(unFinalizedState) && isMergeTransitionComplete(unFinalizedState)
+      ? {
+          executionPayloadBlockHash: toRootHex(unFinalizedState.latestExecutionPayloadHeader.blockHash),
+          executionPayloadNumber: unFinalizedState.latestExecutionPayloadHeader.blockNumber,
+          executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,
+        }
+      : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),
+
+    dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+  };
+
+  const parentSlot = blockHeader.slot - 1;
+  const parentEpoch = computeEpochAtSlot(parentSlot);
+  // parent of head block
+  const parentBlock: ProtoBlock = {
+    ...headBlock,
+    slot: parentSlot,
+    // link this to the dummy justified block
+    parentRoot: toRootHex(justifiedCheckpoint.root),
+    // dummy data, we're not able to regen state before headBlock
+    stateRoot: ZERO_HASH_HEX,
+    blockRoot: headBlock.parentRoot,
+    targetRoot: toRootHex(getBlockRootAtSlot(unFinalizedState, computeStartSlotAtEpoch(parentEpoch))),
+  };
+
+  const justifiedBlock: ProtoBlock = {
+    ...headBlock,
+    slot: computeStartSlotAtEpoch(justifiedCheckpoint.epoch),
+    // link this to the finalized root so that getAncestors can find the finalized block
+    parentRoot: toRootHex(finalizedCheckpoint.root),
+    // dummy data, we're not able to regen state before headBlock
+    stateRoot: ZERO_HASH_HEX,
+    blockRoot: toRootHex(justifiedCheckpoint.root),
+    // same to blockRoot
+    targetRoot: toRootHex(justifiedCheckpoint.root)
+  };
+
+  const protoArray = ProtoArray.initialize(justifiedBlock, currentSlot);
+  protoArray.onBlock(parentBlock, currentSlot);
+  protoArray.onBlock(headBlock, currentSlot);
+
+  // forkchoiceConstructor is only used for some test cases
+  // production code use ForkChoice constructor directly
+  const forkchoiceConstructor = opts.forkchoiceConstructor ?? ForkChoice;
+
+  return new forkchoiceConstructor(
+    config,
+    store,
+    protoArray,
     opts,
     logger
   );

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -46,14 +46,17 @@ export function initializeForkChoice(
   logger?: Logger
 ): ForkChoice {
   const {blockHeader, checkpoint} = computeAnchorCheckpoint(config, state);
-  const finalizedCheckpoint = isFinalizedState ? {...checkpoint} : state.finalizedCheckpoint;
+  // in case of non-finalized anchor state, finalized checkpoint must not be itself
+  const finalizedCheckpoint = isFinalizedState ? {...checkpoint} : state.finalizedCheckpoint.toValue();
+
+  // in case of non-finalized anchor state, we assume justified checkpoint is itself to grow the protoarray from there
   const justifiedCheckpoint = {
-    ...finalizedCheckpoint,
+    ...checkpoint,
     // If not genesis epoch, justified checkpoint epoch must be set to finalized checkpoint epoch + 1
     // So that we don't allow the chain to initially justify with a block that isn't also finalizing the anchor state.
     // If that happens, we will create an invalid head state,
     // with the head not matching the fork choice justified and finalized epochs.
-    epoch: finalizedCheckpoint.epoch === 0 ? finalizedCheckpoint.epoch : finalizedCheckpoint.epoch + 1,
+    epoch: checkpoint.epoch === 0 ? checkpoint.epoch : checkpoint.epoch + 1,
   };
 
   const justifiedBalances = getEffectiveBalanceIncrementsZeroInactive(state);

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -25,6 +25,7 @@ import {Logger, toRootHex} from "@lodestar/utils";
 import {GENESIS_SLOT, ZERO_HASH, ZERO_HASH_HEX} from "../../constants/index.js";
 import {ChainEventEmitter} from "../emitter.js";
 import {ChainEvent} from "../emitter.js";
+import { log } from "node:console";
 
 export type ForkChoiceOpts = RawForkChoiceOpts & {
   // for testing only
@@ -144,9 +145,20 @@ export function initializeForkChoiceFromUnfinalizedState(
   justifiedBalancesGetter: JustifiedBalancesGetter,
   logger?: Logger
 ): ForkChoice {
+
   const {blockHeader} = computeAnchorCheckpoint(config, unFinalizedState);
   const finalizedCheckpoint = unFinalizedState.finalizedCheckpoint.toValue();
   const justifiedCheckpoint = unFinalizedState.currentJustifiedCheckpoint.toValue();
+
+  const logCtx = {
+    currentSlot: currentSlot,
+    stateSlot: unFinalizedState.slot,
+    finalizedEpoch: finalizedCheckpoint.epoch,
+    finalizedRoot: toRootHex(finalizedCheckpoint.root),
+    justifiedEpoch: justifiedCheckpoint.epoch,
+    justifiedRoot: toRootHex(justifiedCheckpoint.root),
+  };
+  logger?.warn("Initializing fork choice from unfinalized state", logCtx);
 
   // this is not the justified state, but there is no other ways to get justified balances
   const justifiedBalances = getEffectiveBalanceIncrementsZeroInactive(unFinalizedState);
@@ -219,9 +231,24 @@ export function initializeForkChoiceFromUnfinalizedState(
     targetRoot: toRootHex(justifiedCheckpoint.root)
   };
 
-  const protoArray = ProtoArray.initialize(justifiedBlock, currentSlot);
+  const finalizedBlock: ProtoBlock = {
+    ...headBlock,
+    slot: computeStartSlotAtEpoch(finalizedCheckpoint.epoch),
+    // we don't care parent of finalized block
+    parentRoot: ZERO_HASH_HEX,
+    // dummy data, we're not able to regen state before headBlock
+    stateRoot: ZERO_HASH_HEX,
+    blockRoot: toRootHex(finalizedCheckpoint.root),
+    // same to blockRoot
+    targetRoot: toRootHex(finalizedCheckpoint.root)
+  };
+
+  const protoArray = ProtoArray.initialize(finalizedBlock, currentSlot);
+  protoArray.onBlock(justifiedBlock, currentSlot);
   protoArray.onBlock(parentBlock, currentSlot);
   protoArray.onBlock(headBlock, currentSlot);
+
+  logger?.info("Initialized protoArray successfully", {...logCtx, length: protoArray.length()});
 
   // forkchoiceConstructor is only used for some test cases
   // production code use ForkChoice constructor directly

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -40,19 +40,20 @@ export function initializeForkChoice(
   emitter: ChainEventEmitter,
   currentSlot: Slot,
   state: CachedBeaconStateAllForks,
+  isFinalizedState: boolean,
   opts: ForkChoiceOpts,
   justifiedBalancesGetter: JustifiedBalancesGetter,
   logger?: Logger
 ): ForkChoice {
   const {blockHeader, checkpoint} = computeAnchorCheckpoint(config, state);
-  const finalizedCheckpoint = {...checkpoint};
+  const finalizedCheckpoint = isFinalizedState ? {...checkpoint} : state.finalizedCheckpoint;
   const justifiedCheckpoint = {
-    ...checkpoint,
+    ...finalizedCheckpoint,
     // If not genesis epoch, justified checkpoint epoch must be set to finalized checkpoint epoch + 1
     // So that we don't allow the chain to initially justify with a block that isn't also finalizing the anchor state.
     // If that happens, we will create an invalid head state,
     // with the head not matching the fork choice justified and finalized epochs.
-    epoch: checkpoint.epoch === 0 ? checkpoint.epoch : checkpoint.epoch + 1,
+    epoch: finalizedCheckpoint.epoch === 0 ? finalizedCheckpoint.epoch : finalizedCheckpoint.epoch + 1,
   };
 
   const justifiedBalances = getEffectiveBalanceIncrementsZeroInactive(state);

--- a/packages/beacon-node/src/chain/stateCache/datastore/db.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/db.ts
@@ -106,7 +106,7 @@ export async function getLatestSafeDatastoreKey(allKeys: DatastoreKey[], readFn:
       continue;
     }
 
-    if (epoch !== SLOTS_PER_EPOCH * lastProcessedSlot) {
+    if (lastProcessedSlot !== SLOTS_PER_EPOCH * epoch) {
       // should not happen after above checks, but just to be safe
       continue;
     }

--- a/packages/beacon-node/src/chain/stateCache/datastore/db.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/db.ts
@@ -48,11 +48,11 @@ export function checkpointToDatastoreKey(cp: phase0.Checkpoint): DatastoreKey {
 /**
  * Get the latest safe checkpoint state the node can use to boot from
  *   - it should be the checkpoint state that's unique in its epoch
- *   - its last processed block slot should be at epoch boundary
- *   - last processed block slot should be equal to state slot
- *   - last processed block slot should be equal to epoch * SLOTS_PER_EPOCH
+ *   - its last processed block slot should be at epoch boundary or last slot of previous epoch
+ *   - state slot should be at epoch boundary
+ *   - state slot should be equal to epoch * SLOTS_PER_EPOCH
  *
- * return the serialzied data of Current Root Checkpoint State (CRCP) which is added when we import block slot 0 of epoch n
+ * return the serialzied data of Current Root Checkpoint State (CRCS) or Previous Root Checkpoint State (PRCS)
  *
  */
 export async function getLatestSafeDatastoreKey(allKeys: DatastoreKey[], readFn: (key: DatastoreKey) => Promise<Uint8Array | null>): Promise<Uint8Array | null> {
@@ -96,17 +96,17 @@ export async function getLatestSafeDatastoreKey(allKeys: DatastoreKey[], readFn:
       continue;
     }
 
-    if (lastProcessedSlot !== stateSlot) {
-      // not Current Root Checkpoint State (CRCP), skip
+    if (lastProcessedSlot !== stateSlot && lastProcessedSlot !== stateSlot - 1) {
+      // not CRCS or PRCS, skip
       continue;
     }
 
-    if (lastProcessedSlot % SLOTS_PER_EPOCH !== 0) {
-      // not Current Root Checkpoint State (CRCP), skip
+    if (stateSlot % SLOTS_PER_EPOCH !== 0) {
+      // not at epoch boundary, skip
       continue;
     }
 
-    if (lastProcessedSlot !== SLOTS_PER_EPOCH * epoch) {
+    if (stateSlot !== SLOTS_PER_EPOCH * epoch) {
       // should not happen after above checks, but just to be safe
       continue;
     }

--- a/packages/beacon-node/src/chain/stateCache/datastore/db.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/db.ts
@@ -23,11 +23,11 @@ export class DbCPStateDatastore implements CPStateDatastore {
     return this.db.checkpointState.getBinary(serializedCheckpoint);
   }
 
-  async readLatest(): Promise<Uint8Array | null> {
+  async readLatestSafe(): Promise<Uint8Array | null> {
     const allKeys = await this.readKeys();
     if (allKeys.length === 0) return null;
 
-    const latest = getLatestDatastoreKey(allKeys);
+    const latest = getLatestSafeDatastoreKey(allKeys);
 
     if (latest == null) {
       return null;
@@ -52,7 +52,7 @@ export function checkpointToDatastoreKey(cp: phase0.Checkpoint): DatastoreKey {
 /**
  * Get the latest checkpoint state that is unique in its epoch
  */
-export function getLatestDatastoreKey(allKeys: DatastoreKey[]): DatastoreKey | null {
+export function getLatestSafeDatastoreKey(allKeys: DatastoreKey[]): DatastoreKey | null {
   const checkpointsByEpoch = new MapDef<Epoch, DatastoreKey[]>(() => []);
     for (const key of allKeys) {
       const cp = datastoreKeyToCheckpoint(key);

--- a/packages/beacon-node/src/chain/stateCache/datastore/db.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/db.ts
@@ -1,6 +1,7 @@
-import {phase0, ssz} from "@lodestar/types";
+import {Epoch, phase0, ssz} from "@lodestar/types";
 import {IBeaconDb} from "../../../db/interface.js";
 import {CPStateDatastore, DatastoreKey} from "./types.js";
+import {MapDef} from "@lodestar/utils";
 
 /**
  * Implementation of CPStateDatastore using db.
@@ -25,14 +26,11 @@ export class DbCPStateDatastore implements CPStateDatastore {
   async readLatest(): Promise<Uint8Array | null> {
     const allKeys = await this.readKeys();
     if (allKeys.length === 0) return null;
-    let latest: DatastoreKey = allKeys[0];
-    let latestEpoch = datastoreKeyToCheckpoint(latest).epoch;
-    for (const key of allKeys) {
-      const cp = datastoreKeyToCheckpoint(key);
-      if (cp.epoch > latestEpoch) {
-        latest = key;
-        latestEpoch = cp.epoch;
-      }
+
+    const latest = getLatestDatastoreKey(allKeys);
+
+    if (latest == null) {
+      return null;
     }
 
     return this.read(latest);
@@ -49,4 +47,27 @@ export function datastoreKeyToCheckpoint(key: DatastoreKey): phase0.Checkpoint {
 
 export function checkpointToDatastoreKey(cp: phase0.Checkpoint): DatastoreKey {
   return ssz.phase0.Checkpoint.serialize(cp);
+}
+
+/**
+ * Get the latest checkpoint state that is unique in its epoch
+ */
+export function getLatestDatastoreKey(allKeys: DatastoreKey[]): DatastoreKey | null {
+  const checkpointsByEpoch = new MapDef<Epoch, DatastoreKey[]>(() => []);
+    for (const key of allKeys) {
+      const cp = datastoreKeyToCheckpoint(key);
+      checkpointsByEpoch.getOrDefault(cp.epoch).push(key);
+    }
+
+    let latest: DatastoreKey | null = null;
+    let latestEpoch = 0;
+    for (const [epoch, keys] of checkpointsByEpoch.entries()) {
+      // filter out epochs with only 1 checkpoint
+      if (keys.length === 1 && epoch > latestEpoch) {
+        latest = keys[0];
+        latestEpoch = epoch;
+      }
+    }
+
+    return latest;
 }

--- a/packages/beacon-node/src/chain/stateCache/datastore/db.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/db.ts
@@ -22,6 +22,22 @@ export class DbCPStateDatastore implements CPStateDatastore {
     return this.db.checkpointState.getBinary(serializedCheckpoint);
   }
 
+  async readLatest(): Promise<Uint8Array | null> {
+    const allKeys = await this.readKeys();
+    if (allKeys.length === 0) return null;
+    let latest: DatastoreKey = allKeys[0];
+    let latestEpoch = datastoreKeyToCheckpoint(latest).epoch;
+    for (const key of allKeys) {
+      const cp = datastoreKeyToCheckpoint(key);
+      if (cp.epoch > latestEpoch) {
+        latest = key;
+        latestEpoch = cp.epoch;
+      }
+    }
+
+    return this.read(latest);
+  }
+
   async readKeys(): Promise<DatastoreKey[]> {
     return this.db.checkpointState.keys();
   }

--- a/packages/beacon-node/src/chain/stateCache/datastore/db.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/db.ts
@@ -1,7 +1,9 @@
 import {Epoch, phase0, ssz} from "@lodestar/types";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {IBeaconDb} from "../../../db/interface.js";
 import {CPStateDatastore, DatastoreKey} from "./types.js";
 import {MapDef} from "@lodestar/utils";
+import {getLastProcessedSlotFromBeaconStateSerialized, getSlotFromBeaconStateSerialized} from "../../../util/sszBytes.js";
 
 /**
  * Implementation of CPStateDatastore using db.
@@ -27,13 +29,7 @@ export class DbCPStateDatastore implements CPStateDatastore {
     const allKeys = await this.readKeys();
     if (allKeys.length === 0) return null;
 
-    const latest = getLatestSafeDatastoreKey(allKeys);
-
-    if (latest == null) {
-      return null;
-    }
-
-    return this.read(latest);
+    return getLatestSafeDatastoreKey(allKeys, this.read.bind(this));
   }
 
   async readKeys(): Promise<DatastoreKey[]> {
@@ -50,24 +46,73 @@ export function checkpointToDatastoreKey(cp: phase0.Checkpoint): DatastoreKey {
 }
 
 /**
- * Get the latest checkpoint state that is unique in its epoch
+ * Get the latest safe checkpoint state the node can use to boot from
+ *   - it should be the checkpoint state that's unique in its epoch
+ *   - its last processed block slot should be at epoch boundary
+ *   - last processed block slot should be equal to state slot
+ *   - last processed block slot should be equal to epoch * SLOTS_PER_EPOCH
+ *
+ * return the serialzied data of Current Root Checkpoint State (CRCP) which is added when we import block slot 0 of epoch n
+ *
  */
-export function getLatestSafeDatastoreKey(allKeys: DatastoreKey[]): DatastoreKey | null {
+export async function getLatestSafeDatastoreKey(allKeys: DatastoreKey[], readFn: (key: DatastoreKey) => Promise<Uint8Array | null>): Promise<Uint8Array | null> {
   const checkpointsByEpoch = new MapDef<Epoch, DatastoreKey[]>(() => []);
-    for (const key of allKeys) {
-      const cp = datastoreKeyToCheckpoint(key);
-      checkpointsByEpoch.getOrDefault(cp.epoch).push(key);
+  for (const key of allKeys) {
+    const cp = datastoreKeyToCheckpoint(key);
+    checkpointsByEpoch.getOrDefault(cp.epoch).push(key);
+  }
+
+  const dataStoreKeyByEpoch: Map<Epoch, DatastoreKey> = new Map();
+  for (const [epoch, keys] of checkpointsByEpoch.entries()) {
+    // filter out epochs with only 1 checkpoint
+    if (keys.length === 1) {
+      dataStoreKeyByEpoch.set(epoch, keys[0]);
+    }
+  }
+
+  const epochsDesc = Array.from(dataStoreKeyByEpoch.keys()).sort((a, b) => b - a);
+  for (const epoch of epochsDesc) {
+    const datastoreKey = dataStoreKeyByEpoch.get(epoch);
+    if (datastoreKey == null) {
+      // should not happen
+      continue;
     }
 
-    let latest: DatastoreKey | null = null;
-    let latestEpoch = 0;
-    for (const [epoch, keys] of checkpointsByEpoch.entries()) {
-      // filter out epochs with only 1 checkpoint
-      if (keys.length === 1 && epoch > latestEpoch) {
-        latest = keys[0];
-        latestEpoch = epoch;
-      }
+    const stateBytes = await readFn(datastoreKey);
+    if (stateBytes == null) {
+      // should not happen
+      continue;
     }
 
-    return latest;
+    const lastProcessedSlot = getLastProcessedSlotFromBeaconStateSerialized(stateBytes);
+    if (lastProcessedSlot == null) {
+      // cannot extract last processed slot from serialized state, skip
+      continue;
+    }
+
+    const stateSlot = getSlotFromBeaconStateSerialized(stateBytes);
+    if (stateSlot == null) {
+      // cannot extract slot from serialized state, skip
+      continue;
+    }
+
+    if (lastProcessedSlot !== stateSlot) {
+      // not Current Root Checkpoint State (CRCP), skip
+      continue;
+    }
+
+    if (lastProcessedSlot % SLOTS_PER_EPOCH !== 0) {
+      // not Current Root Checkpoint State (CRCP), skip
+      continue;
+    }
+
+    if (epoch !== SLOTS_PER_EPOCH * lastProcessedSlot) {
+      // should not happen after above checks, but just to be safe
+      continue;
+    }
+
+    return stateBytes;
+  }
+
+  return null;
 }

--- a/packages/beacon-node/src/chain/stateCache/datastore/file.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/file.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import {phase0, ssz} from "@lodestar/types";
 import {fromHex, toHex} from "@lodestar/utils";
-import {ensureDir, readFile, readFileNames, removeFile, writeIfNotExist} from "../../../util/file.js";
+import {ensureDir, getLastModifiedFile, readFile, readFileNames, removeFile, writeIfNotExist} from "../../../util/file.js";
 import {CPStateDatastore, DatastoreKey} from "./types.js";
 
 const CHECKPOINT_STATES_FOLDER = "checkpoint_states";
@@ -41,6 +41,13 @@ export class FileCPStateDatastore implements CPStateDatastore {
 
   async read(serializedCheckpoint: DatastoreKey): Promise<Uint8Array | null> {
     const filePath = path.join(this.folderPath, toHex(serializedCheckpoint));
+    return readFile(filePath);
+  }
+
+  async readLatest(): Promise<Uint8Array | null> {
+    const fileName = await getLastModifiedFile(this.folderPath);
+    if (!fileName) return null;
+    const filePath = path.join(this.folderPath, fileName);
     return readFile(filePath);
   }
 

--- a/packages/beacon-node/src/chain/stateCache/datastore/file.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/file.ts
@@ -1,8 +1,9 @@
 import path from "node:path";
 import {phase0, ssz} from "@lodestar/types";
 import {fromHex, toHex} from "@lodestar/utils";
-import {ensureDir, getLastModifiedFile, readFile, readFileNames, removeFile, writeIfNotExist} from "../../../util/file.js";
+import {ensureDir, readFile, readFileNames, removeFile, writeIfNotExist} from "../../../util/file.js";
 import {CPStateDatastore, DatastoreKey} from "./types.js";
+import {getLatestDatastoreKey} from "./db.js";
 
 const CHECKPOINT_STATES_FOLDER = "checkpoint_states";
 const CHECKPOINT_FILE_NAME_LENGTH = 82;
@@ -45,9 +46,15 @@ export class FileCPStateDatastore implements CPStateDatastore {
   }
 
   async readLatest(): Promise<Uint8Array | null> {
-    const fileName = await getLastModifiedFile(this.folderPath);
-    if (!fileName) return null;
-    const filePath = path.join(this.folderPath, fileName);
+    const fileNames = await readFileNames(this.folderPath);
+    const datastoreKeys = fileNames.map((fileName) => fromHex(fileName));
+    const latest = getLatestDatastoreKey(datastoreKeys);
+
+    if (latest == null) {
+      return null;
+    }
+
+    const filePath = path.join(this.folderPath, toHex(latest));
     return readFile(filePath);
   }
 

--- a/packages/beacon-node/src/chain/stateCache/datastore/file.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/file.ts
@@ -46,16 +46,10 @@ export class FileCPStateDatastore implements CPStateDatastore {
   }
 
   async readLatestSafe(): Promise<Uint8Array | null> {
-    const fileNames = await readFileNames(this.folderPath);
-    const datastoreKeys = fileNames.map((fileName) => fromHex(fileName));
-    const latest = getLatestSafeDatastoreKey(datastoreKeys);
+    const allKeys = await this.readKeys();
+    if (allKeys.length === 0) return null;
 
-    if (latest == null) {
-      return null;
-    }
-
-    const filePath = path.join(this.folderPath, toHex(latest));
-    return readFile(filePath);
+    return getLatestSafeDatastoreKey(allKeys, this.read.bind(this));
   }
 
   async readKeys(): Promise<DatastoreKey[]> {

--- a/packages/beacon-node/src/chain/stateCache/datastore/file.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/file.ts
@@ -3,7 +3,7 @@ import {phase0, ssz} from "@lodestar/types";
 import {fromHex, toHex} from "@lodestar/utils";
 import {ensureDir, readFile, readFileNames, removeFile, writeIfNotExist} from "../../../util/file.js";
 import {CPStateDatastore, DatastoreKey} from "./types.js";
-import {getLatestDatastoreKey} from "./db.js";
+import {getLatestSafeDatastoreKey} from "./db.js";
 
 const CHECKPOINT_STATES_FOLDER = "checkpoint_states";
 const CHECKPOINT_FILE_NAME_LENGTH = 82;
@@ -45,10 +45,10 @@ export class FileCPStateDatastore implements CPStateDatastore {
     return readFile(filePath);
   }
 
-  async readLatest(): Promise<Uint8Array | null> {
+  async readLatestSafe(): Promise<Uint8Array | null> {
     const fileNames = await readFileNames(this.folderPath);
     const datastoreKeys = fileNames.map((fileName) => fromHex(fileName));
-    const latest = getLatestDatastoreKey(datastoreKeys);
+    const latest = getLatestSafeDatastoreKey(datastoreKeys);
 
     if (latest == null) {
       return null;

--- a/packages/beacon-node/src/chain/stateCache/datastore/types.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/types.ts
@@ -8,6 +8,8 @@ export interface CPStateDatastore {
   write: (cpKey: phase0.Checkpoint, stateBytes: Uint8Array) => Promise<DatastoreKey>;
   remove: (key: DatastoreKey) => Promise<void>;
   read: (key: DatastoreKey) => Promise<Uint8Array | null>;
+  // read latest checkpoint state that can be loaded to start a beacon node from
+  // it should be the checkpoint state that's unique in its epoch
   readLatest: () => Promise<Uint8Array | null>;
   readKeys: () => Promise<DatastoreKey[]>;
   init?: () => Promise<void>;

--- a/packages/beacon-node/src/chain/stateCache/datastore/types.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/types.ts
@@ -8,6 +8,7 @@ export interface CPStateDatastore {
   write: (cpKey: phase0.Checkpoint, stateBytes: Uint8Array) => Promise<DatastoreKey>;
   remove: (key: DatastoreKey) => Promise<void>;
   read: (key: DatastoreKey) => Promise<Uint8Array | null>;
+  readLatest: () => Promise<Uint8Array | null>;
   readKeys: () => Promise<DatastoreKey[]>;
   init?: () => Promise<void>;
 }

--- a/packages/beacon-node/src/chain/stateCache/datastore/types.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/types.ts
@@ -8,8 +8,6 @@ export interface CPStateDatastore {
   write: (cpKey: phase0.Checkpoint, stateBytes: Uint8Array) => Promise<DatastoreKey>;
   remove: (key: DatastoreKey) => Promise<void>;
   read: (key: DatastoreKey) => Promise<Uint8Array | null>;
-  // read latest checkpoint state that can be loaded to start a beacon node from
-  // it should be the checkpoint state that's unique in its epoch
   readLatestSafe: () => Promise<Uint8Array | null>;
   readKeys: () => Promise<DatastoreKey[]>;
   init?: () => Promise<void>;

--- a/packages/beacon-node/src/chain/stateCache/datastore/types.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/types.ts
@@ -10,7 +10,7 @@ export interface CPStateDatastore {
   read: (key: DatastoreKey) => Promise<Uint8Array | null>;
   // read latest checkpoint state that can be loaded to start a beacon node from
   // it should be the checkpoint state that's unique in its epoch
-  readLatest: () => Promise<Uint8Array | null>;
+  readLatestSafe: () => Promise<Uint8Array | null>;
   readKeys: () => Promise<DatastoreKey[]>;
   init?: () => Promise<void>;
 }

--- a/packages/beacon-node/src/index.ts
+++ b/packages/beacon-node/src/index.ts
@@ -21,4 +21,5 @@ export type {RestApiServerOpts, RestApiServerModules, RestApiServerMetrics} from
 
 // Export type util for CLI - TEMP move to lodestar-types eventually
 export {getStateTypeFromBytes, getStateSlotFromBytes} from "./util/multifork.js";
-export {checkpointToDatastoreKey} from "./chain/stateCache/datastore/db.js";
+export {DbCPStateDatastore} from "./chain/stateCache/datastore/db.js";
+export {FileCPStateDatastore} from "./chain/stateCache/datastore/file.js";

--- a/packages/beacon-node/src/index.ts
+++ b/packages/beacon-node/src/index.ts
@@ -21,3 +21,4 @@ export type {RestApiServerOpts, RestApiServerModules, RestApiServerMetrics} from
 
 // Export type util for CLI - TEMP move to lodestar-types eventually
 export {getStateTypeFromBytes, getStateSlotFromBytes} from "./util/multifork.js";
+export {checkpointToDatastoreKey} from "./chain/stateCache/datastore/db.js";

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -18,7 +18,9 @@ export async function* onBeaconBlocksByRange(
 
   const finalized = db.blockArchive;
   const unfinalized = db.block;
-  const finalizedSlot = chain.forkChoice.getFinalizedBlock().slot;
+  // in the case of initilizing from a non-finalized state, we don't have the finalized block so this api does not work
+  // chain.forkChoice.getFinalizeBlock().slot
+  const finalizedSlot = chain.forkChoice.getFinalizedBlockSlot();
 
   // Finalized range of blocks
   if (startSlot <= finalizedSlot) {

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -55,6 +55,7 @@ export type BeaconNodeInitModules = {
   dataDir: string;
   peerStoreDir?: string;
   anchorState: BeaconStateAllForks;
+  isAnchorStateFinalized: boolean;
   wsCheckpoint?: phase0.Checkpoint;
   metricsRegistries?: Registry[];
 };
@@ -153,6 +154,7 @@ export class BeaconNode {
     dataDir,
     peerStoreDir,
     anchorState,
+    isAnchorStateFinalized,
     wsCheckpoint,
     metricsRegistries = [],
   }: BeaconNodeInitModules): Promise<T> {
@@ -232,6 +234,7 @@ export class BeaconNode {
       processShutdownCallback,
       metrics,
       anchorState,
+      isAnchorStateFinalized,
       eth1: initializeEth1ForBlockProduction(opts.eth1, {
         config,
         db,

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -195,7 +195,10 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       // Should only be used for debugging or testing
       for (const block of blocks) await this.chain.processBlock(block, flags);
     } else {
-      await this.chain.processChainSegment(blocks, flags);
+      // await this.chain.processChainSegment(blocks, flags);
+      // with holesky-rescue, if we start from unfinalized state then head will not always exactly at epoch boundary
+      // and we don't have all blocks processed up to head so processChainSegment may fail
+      await this.chain.processChainSegment(blocks.filter((block) => block.block.message.slot > this.chain.forkChoice.getHead().slot), flags);
     }
   };
 

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -120,6 +120,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       startEpoch,
       targetSlot: target.slot,
       targetRoot: toRootHex(target.root),
+      localHeadSlot: localStatus.headSlot,
     });
 
     // If the peer existed in any other chain, remove it.

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -113,7 +113,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
    */
   addPeer(peerId: PeerIdStr, localStatus: phase0.Status, peerStatus: phase0.Status): void {
     // Compute if we should do a Finalized or Head sync with this peer
-    const {syncType, startEpoch, target} = getRangeSyncTarget(localStatus, peerStatus, this.chain.forkChoice);
+    const {syncType, startEpoch, target} = getRangeSyncTarget(localStatus, peerStatus, this.chain);
     this.logger.debug("Sync peer joined", {
       peer: peerId,
       syncType,

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -195,10 +195,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       // Should only be used for debugging or testing
       for (const block of blocks) await this.chain.processBlock(block, flags);
     } else {
-      // await this.chain.processChainSegment(blocks, flags);
-      // with holesky-rescue, if we start from unfinalized state then head will not always exactly at epoch boundary
-      // and we don't have all blocks processed up to head so processChainSegment may fail
-      await this.chain.processChainSegment(blocks.filter((block) => block.block.message.slot > this.chain.forkChoice.getHead().slot), flags);
+      await this.chain.processChainSegment(blocks, flags);
     }
   };
 

--- a/packages/beacon-node/src/sync/utils/remoteSyncType.ts
+++ b/packages/beacon-node/src/sync/utils/remoteSyncType.ts
@@ -137,10 +137,7 @@ export function getRangeSyncTarget(
     // earlier finalized chain from reaching here).
     // startEpoch: Math.min(computeEpochAtSlot(local.headSlot), remote.finalizedEpoch),
     // for holesky-rescue, we don't want to sync from finalizedEpoch which is too far away (115967)
-    // at start up if headSlot is not at the start of an epoch, we should sync from the next epoch
-    // otherwise get BLOCK_ERROR_PARENT_UNKNOWN
-    // that's not great when node is synced but UnknownBlockSync should help us
-    startEpoch: local.headSlot % 32 === 0 ? computeEpochAtSlot(local.headSlot) : computeEpochAtSlot(local.headSlot) + 1,
+    startEpoch: computeEpochAtSlot(local.headSlot),
     target: {
       slot: remote.headSlot,
       root: remote.headRoot,

--- a/packages/beacon-node/src/sync/utils/remoteSyncType.ts
+++ b/packages/beacon-node/src/sync/utils/remoteSyncType.ts
@@ -137,7 +137,10 @@ export function getRangeSyncTarget(
     // earlier finalized chain from reaching here).
     // startEpoch: Math.min(computeEpochAtSlot(local.headSlot), remote.finalizedEpoch),
     // for holesky-rescue, we don't want to sync from finalizedEpoch which is too far away (115967)
-    startEpoch: computeEpochAtSlot(local.headSlot),
+    // at start up if headSlot is not at the start of an epoch, we should sync from the next epoch
+    // otherwise get BLOCK_ERROR_PARENT_UNKNOWN
+    // that's not great when node is synced but UnknownBlockSync should help us
+    startEpoch: local.headSlot % 32 === 0 ? computeEpochAtSlot(local.headSlot) : computeEpochAtSlot(local.headSlot) + 1,
     target: {
       slot: remote.headSlot,
       root: remote.headRoot,

--- a/packages/beacon-node/src/sync/utils/remoteSyncType.ts
+++ b/packages/beacon-node/src/sync/utils/remoteSyncType.ts
@@ -135,7 +135,9 @@ export function getRangeSyncTarget(
     syncType: RangeSyncType.Head,
     // The new peer has the same finalized (earlier filters should prevent a peer with an
     // earlier finalized chain from reaching here).
-    startEpoch: Math.min(computeEpochAtSlot(local.headSlot), remote.finalizedEpoch),
+    // startEpoch: Math.min(computeEpochAtSlot(local.headSlot), remote.finalizedEpoch),
+    // for holesky-rescue, we don't want to sync from finalizedEpoch which is too far away (115967)
+    startEpoch: computeEpochAtSlot(local.headSlot),
     target: {
       slot: remote.headSlot,
       root: remote.headRoot,

--- a/packages/beacon-node/src/sync/utils/remoteSyncType.ts
+++ b/packages/beacon-node/src/sync/utils/remoteSyncType.ts
@@ -2,6 +2,7 @@ import {IForkChoice} from "@lodestar/fork-choice";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Slot, phase0} from "@lodestar/types";
 import {ChainTarget} from "../range/utils/index.js";
+import {IBeaconChain} from "../../chain/interface.js";
 
 /** The type of peer relative to our current state */
 export enum PeerSyncType {
@@ -103,8 +104,11 @@ export function getRangeSyncType(local: phase0.Status, remote: phase0.Status, fo
 export function getRangeSyncTarget(
   local: phase0.Status,
   remote: phase0.Status,
-  forkChoice: IForkChoice
+  chain: IBeaconChain
 ): {syncType: RangeSyncType; startEpoch: Slot; target: ChainTarget} {
+  const forkChoice = chain.forkChoice;
+
+  // finalized sync
   if (remote.finalizedEpoch > local.finalizedEpoch && !forkChoice.hasBlock(remote.finalizedRoot)) {
     return {
       // If  RangeSyncType.Finalized, the range of blocks fetchable from startEpoch and target must allow to switch
@@ -131,13 +135,20 @@ export function getRangeSyncTarget(
       },
     };
   }
+
+  // we don't want to sync from epoch < minEpoch
+  // if we boot from a finalized checkpoint state, we don't want to sync before anchorStateLatestBlockSlot
+  // if we boot from an unfinalized checkpoint state, anchorStateLatestBlockSlot is trusted and we also don't want to sync before it too
+  const minEpoch = Math.max(remote.finalizedEpoch, computeEpochAtSlot(chain.anchorStateLatestBlockSlot));
+
+  // head sync
   return {
     syncType: RangeSyncType.Head,
     // The new peer has the same finalized (earlier filters should prevent a peer with an
     // earlier finalized chain from reaching here).
     // startEpoch: Math.min(computeEpochAtSlot(local.headSlot), remote.finalizedEpoch),
     // for holesky-rescue, we don't want to sync from finalizedEpoch which is too far away (115967)
-    startEpoch: computeEpochAtSlot(local.headSlot),
+    startEpoch: Math.min(computeEpochAtSlot(local.headSlot), minEpoch),
     target: {
       slot: remote.headSlot,
       root: remote.headRoot,

--- a/packages/beacon-node/src/util/file.ts
+++ b/packages/beacon-node/src/util/file.ts
@@ -64,7 +64,7 @@ export async function getLastModifiedFile(folderPath: string): Promise<string | 
     // Check if it's a file (not a directory)
     if (stats.isFile() && stats.mtimeMs > lastModifiedTime) {
       lastModifiedTime = stats.mtimeMs;
-      lastModifiedFile = filePath;
+      lastModifiedFile = file;
     }
   }
 

--- a/packages/beacon-node/src/util/file.ts
+++ b/packages/beacon-node/src/util/file.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import {promisify} from "node:util";
 
 /** Ensure a directory exists */
@@ -49,4 +50,23 @@ export async function readFileNames(folderPath: string): Promise<string[]> {
   } catch (_) {
     return [];
   }
+}
+
+export async function getLastModifiedFile(folderPath: string): Promise<string | null> {
+  const files = fs.readdirSync(folderPath);
+  let lastModifiedFile = null;
+  let lastModifiedTime = 0;
+
+  // Iterate over each file and check its modification time
+  for (const file of files) {
+    const filePath = path.join(folderPath, file);
+    const stats = fs.statSync(filePath);
+    // Check if it's a file (not a directory)
+    if (stats.isFile() && stats.mtimeMs > lastModifiedTime) {
+      lastModifiedTime = stats.mtimeMs;
+      lastModifiedFile = filePath;
+    }
+  }
+
+  return lastModifiedFile;
 }

--- a/packages/beacon-node/src/util/file.ts
+++ b/packages/beacon-node/src/util/file.ts
@@ -53,6 +53,10 @@ export async function readFileNames(folderPath: string): Promise<string[]> {
 }
 
 export async function getLastModifiedFile(folderPath: string): Promise<string | null> {
+  if (!fs.existsSync(folderPath)) {
+    return null;
+  }
+
   const files = fs.readdirSync(folderPath);
   let lastModifiedFile = null;
   let lastModifiedTime = 0;

--- a/packages/beacon-node/src/util/file.ts
+++ b/packages/beacon-node/src/util/file.ts
@@ -52,25 +52,3 @@ export async function readFileNames(folderPath: string): Promise<string[]> {
   }
 }
 
-export async function getLastModifiedFile(folderPath: string): Promise<string | null> {
-  if (!fs.existsSync(folderPath)) {
-    return null;
-  }
-
-  const files = fs.readdirSync(folderPath);
-  let lastModifiedFile = null;
-  let lastModifiedTime = 0;
-
-  // Iterate over each file and check its modification time
-  for (const file of files) {
-    const filePath = path.join(folderPath, file);
-    const stats = fs.statSync(filePath);
-    // Check if it's a file (not a directory)
-    if (stats.isFile() && stats.mtimeMs > lastModifiedTime) {
-      lastModifiedTime = stats.mtimeMs;
-      lastModifiedFile = file;
-    }
-  }
-
-  return lastModifiedFile;
-}

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -396,6 +396,36 @@ export function getSlotFromBlobSidecarSerialized(data: Uint8Array): Slot | null 
 }
 
 /**
+ * BeaconState of all forks (up until Electra, check with new forks)
+ * class BeaconState(Container):
+ *   genesis_time: uint64                    - 8 bytes
+ *   genesis_validators_root: Root           - 32 bytes
+ *   slot: Slot                              - 8 bytes
+ *   fork: Fork                              - 16 bytes
+ *   latest_block_header: BeaconBlockHeader  - fixed size
+ *     slot: Slot                            - 8 bytes
+ *
+ */
+
+const BLOCK_HEADER_SLOT_BYTES_POSITION_IN_BEACON_STATE = 8 + 32 + 8 + 16;
+export function getLastProcessedSlotFromBeaconStateSerialized(data: Uint8Array): Slot | null {
+  if (data.length < BLOCK_HEADER_SLOT_BYTES_POSITION_IN_BEACON_STATE + SLOT_SIZE) {
+    return null;
+  }
+
+  return getSlotFromOffset(data, BLOCK_HEADER_SLOT_BYTES_POSITION_IN_BEACON_STATE);
+}
+
+const SLOT_BYTES_POSITION_IN_BEACON_STATE = 8 + 32;
+export function getSlotFromBeaconStateSerialized(data: Uint8Array): Slot | null {
+  if (data.length < SLOT_BYTES_POSITION_IN_BEACON_STATE) {
+    return null;
+  }
+
+  return getSlotFromOffset(data, SLOT_BYTES_POSITION_IN_BEACON_STATE);
+}
+
+/**
  * Read only the first 4 bytes of Slot, max value is 4,294,967,295 will be reached 1634 years after genesis
  *
  * If the high bytes are not zero, return null

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -28,9 +28,11 @@ import {
   getBlockRootFromSingleAttestationSerialized,
   getCommitteeBitsFromSignedAggregateAndProofElectra,
   getCommitteeIndexFromSingleAttestationSerialized,
+  getLastProcessedSlotFromBeaconStateSerialized,
   getSignatureFromAttestationSerialized,
   getSignatureFromSingleAttestationSerialized,
   getSlotFromAttestationSerialized,
+  getSlotFromBeaconStateSerialized,
   getSlotFromBlobSidecarSerialized,
   getSlotFromSignedAggregateAndProofSerialized,
   getSlotFromSignedBeaconBlockSerialized,
@@ -315,6 +317,38 @@ describe("BlobSidecar SSZ serialized picking", () => {
     const invalidSlotDataSizes = [0, 20, 38];
     for (const size of invalidSlotDataSizes) {
       expect(getSlotFromBlobSidecarSerialized(Buffer.alloc(size))).toBeNull();
+    }
+  });
+});
+
+describe("BeaconState ssz serialized picking", () => {
+  it("getLastProcessedSlotFromBeaconStateSerialized", () => {
+    const slot = 1_000_000;
+    const state = ssz.phase0.BeaconState.defaultValue();
+    state.latestBlockHeader.slot = slot;
+    const bytes = ssz.phase0.BeaconState.serialize(state);
+    expect(getLastProcessedSlotFromBeaconStateSerialized(bytes)).toBe(slot);
+  });
+
+  it("getLastProcessedSlotFromBeaconStateSerialized - invalid data", () => {
+    const invalidSlotDataSizes = [0, 50, 60];
+    for (const size of invalidSlotDataSizes) {
+      expect(getLastProcessedSlotFromBeaconStateSerialized(Buffer.alloc(size))).toBeNull();
+    }
+  });
+
+  it("getSlotFromBeaconStateSerialized", () => {
+    const slot = 1_000_000;
+    const state = ssz.phase0.BeaconState.defaultValue();
+    state.slot = slot;
+    const bytes = ssz.phase0.BeaconState.serialize(state);
+    expect(getSlotFromBeaconStateSerialized(bytes)).toBe(slot);
+  });
+
+  it("getSlotFromBeaconStateSerialized - invalid data", () => {
+    const invalidSlotDataSizes = [0, 20, 39];
+    for (const size of invalidSlotDataSizes) {
+      expect(getSlotFromBeaconStateSerialized(Buffer.alloc(size))).toBeNull();
     }
   });
 });

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -70,7 +70,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
 
   // BeaconNode setup
   try {
-    const {anchorState, wsCheckpoint} = await initBeaconState(
+    const {anchorState, isFinalized, wsCheckpoint} = await initBeaconState(
       options,
       args,
       config,
@@ -89,6 +89,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       dataDir: beaconPaths.dataDir,
       peerStoreDir: beaconPaths.peerStoreDir,
       anchorState,
+      isAnchorStateFinalized: isFinalized,
       wsCheckpoint,
     });
 

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -145,7 +145,9 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
           // See https://github.com/ChainSafe/lodestar/issues/5642
           process.exit(0);
         } catch (e) {
-          logger.error("Error closing beacon node", {}, e as Error);
+          // for holesky-rescue, if we start from unfinalized state, we don't have checkpoint state so there is this error
+          // "No state in cache for finalized checkpoint state epoch #115967"
+          logger.warn("Error closing beacon node", {}, e as Error);
           // Make sure db is always closed gracefully
           await db.close();
           // Must explicitly exit process due to potential active handles

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -73,6 +73,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
     const {anchorState, isFinalized, wsCheckpoint} = await initBeaconState(
       options,
       args,
+      beaconPaths.dataDir,
       config,
       db,
       logger,

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -36,6 +36,7 @@ async function initAndVerifyWeakSubjectivityState(
   logger: Logger,
   dbStateBytes: StateWithBytes,
   wsStateBytes: StateWithBytes,
+  isWsStateFinalized: boolean,
   wsCheckpoint: Checkpoint,
   opts: {ignoreWeakSubjectivityCheck?: boolean} = {}
 ): Promise<{anchorState: BeaconStateAllForks; wsCheckpoint: Checkpoint}> {
@@ -72,10 +73,12 @@ async function initAndVerifyWeakSubjectivityState(
     throw wssCheck.err;
   }
 
-  await checkAndPersistAnchorState(config, db, logger, anchorState.state, anchorState.stateBytes, {
-    isWithinWeakSubjectivityPeriod,
-    isCheckpointState,
-  });
+  if (isWsStateFinalized) {
+    await checkAndPersistAnchorState(config, db, logger, anchorState.state, anchorState.stateBytes, {
+      isWithinWeakSubjectivityPeriod,
+      isCheckpointState,
+    });
+  }
 
   // Return the latest anchorState but still return original wsCheckpoint to validate in backfill
   return {anchorState: anchorState.state, wsCheckpoint};
@@ -235,6 +238,9 @@ export async function initBeaconState(
   return {anchorState, isFinalized};
 }
 
+/**
+ * Starting from Feb 2025, reading a user provided state or local checkpoint state is consider non-finalized.
+ */
 async function readWSState(
   lastDbStateBytes: StateWithBytes | null,
   lastDbValidatorsBytes: Uint8Array | null,
@@ -261,7 +267,8 @@ async function readWSState(
   const wsStateBytes = {state: wsState, stateBytes};
   const store = lastDbStateBytes ?? wsStateBytes;
   const checkpoint = wssCheckpoint ? getCheckpointFromArg(wssCheckpoint) : getCheckpointFromState(wsState);
-  return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsStateBytes, checkpoint, {
+  const isFinalized = false;
+  return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsStateBytes, isFinalized, checkpoint, {
     ignoreWeakSubjectivityCheck,
   });
 }
@@ -297,7 +304,9 @@ async function fetchWSStateFromBeaconApi(
   const config = createBeaconConfig(chainForkConfig, wsState.genesisValidatorsRoot);
   const wsStateWithBytes = {state: wsState, stateBytes: wsStateBytes};
   const store = lastDbStateBytes ?? wsStateWithBytes;
-  return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsStateWithBytes, wsCheckpoint, {
+  // a fetched ws state is trusted to be finalized
+  const isFinalized = true;
+  return initAndVerifyWeakSubjectivityState(config, db, logger, store, wsStateWithBytes, isFinalized, wsCheckpoint, {
     ignoreWeakSubjectivityCheck: wssOpts.ignoreWeakSubjectivityCheck,
   });
 }

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -212,6 +212,7 @@ export async function initBeaconState(
   }
 
   if (args.checkpointSyncUrl) {
+    isFinalized = false;
     const stateAndCp = await fetchWSStateFromBeaconApi(
       lastDbStateWithBytes,
       lastDbValidatorsBytes,

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -1,8 +1,9 @@
 import {
+  DbCPStateDatastore,
+  FileCPStateDatastore,
   IBeaconDb,
   IBeaconNodeOptions,
   checkAndPersistAnchorState,
-  checkpointToDatastoreKey,
   getStateTypeFromBytes,
   initStateFromEth1,
 } from "@lodestar/beacon-node";
@@ -162,24 +163,23 @@ export async function initBeaconState(
   }
 
   // See if we can sync state using checkpoint sync args or else start from genesis
-  if (args.checkpointState || args.wssCheckpoint) {
+  if (args.checkpointState || args.lastPersistedCheckpointState) {
     let localCpState: Uint8Array | null = null;
     isFinalized = false;
     if (args.checkpointState) {
       // local file checkpoint state specified via wssCheckpoint could be loaded here
       logger.info("Finding local checkpoint state from file", {path: args.checkpointState});
       localCpState = await downloadOrLoadFile(args.checkpointState);
-      logger.info("Found local checkpoint state from file", {path: args.checkpointState});
-    } else if (args.wssCheckpoint) {
-      // local db checkpoint state specified via wssCheckpoint could be loaded here
-      const wssCheckpoint = getCheckpointFromArg(args.wssCheckpoint);
-      const persistedCpKey = checkpointToDatastoreKey(wssCheckpoint);
-      logger.verbose("Finding local checkpoint state from db", {checkpoint: args.wssCheckpoint});
-      localCpState = await db.checkpointState.getBinary(persistedCpKey);
+      logger.info("Found local checkpoint state from file", {path: args.checkpointState, size: formatBytes(localCpState.length)});
+    } else if (args.lastPersistedCheckpointState) {
+      // find the last persisted checkpoint state to load
+      const cpDataStore = args["chain.nHistoricalStatesFileDataStore"] ? new FileCPStateDatastore() : new DbCPStateDatastore(db);
+      logger.verbose(`Finding last persisted checkpoint state from ${cpDataStore.constructor.name}`);
+      localCpState = await cpDataStore.readLatest();
       if (localCpState === null) {
-        logger.verbose("Checkpoint state not found in db", {checkpoint: args.wssCheckpoint});
+        logger.verbose("Last persisted checkpoint state not found");
       } else {
-        logger.info("Found local checkpoint state from db", {checkpoint: args.wssCheckpoint});
+        logger.info("Found last persisted checkpoint state", {size: formatBytes(localCpState.length)});
       }
     }
 

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -2,6 +2,7 @@ import {
   IBeaconDb,
   IBeaconNodeOptions,
   checkAndPersistAnchorState,
+  checkpointToDatastoreKey,
   getStateTypeFromBytes,
   initStateFromEth1,
 } from "@lodestar/beacon-node";
@@ -151,19 +152,40 @@ export async function initBeaconState(
   }
 
   // See if we can sync state using checkpoint sync args or else start from genesis
-  if (args.checkpointState) {
-    return readWSState(
-      lastDbStateWithBytes,
-      lastDbValidatorsBytes,
-      {
-        checkpointState: args.checkpointState,
-        wssCheckpoint: args.wssCheckpoint,
-        ignoreWeakSubjectivityCheck: args.ignoreWeakSubjectivityCheck,
-      },
-      chainForkConfig,
-      db,
-      logger
-    );
+  if (args.checkpointState || args.wssCheckpoint) {
+    let localCpState: Uint8Array | null = null;
+    if (args.checkpointState) {
+      // local file checkpoint state specified via wssCheckpoint could be loaded here
+      logger.info("Loading local checkpoint state from file", {path: args.checkpointState});
+      localCpState = await downloadOrLoadFile(args.checkpointState);
+      logger.info("Loaded local checkpoint state from file", {path: args.checkpointState});
+    } else if (args.wssCheckpoint) {
+      // local db checkpoint state specified via wssCheckpoint could be loaded here
+      const wssCheckpoint = getCheckpointFromArg(args.wssCheckpoint);
+      const persistedCpKey = checkpointToDatastoreKey(wssCheckpoint);
+      logger.verbose("Loading local checkpoint state from db", {checkpoint: args.wssCheckpoint});
+      localCpState = await db.checkpointState.getBinary(persistedCpKey);
+      if (localCpState === null) {
+        logger.verbose("Checkpoint state not found in db", {checkpoint: args.wssCheckpoint});
+      } else {
+        logger.info("Loaded local checkpoint state from db", {checkpoint: args.wssCheckpoint});
+      }
+    }
+
+    if (localCpState !== null) {
+      return readWSState(
+        lastDbStateWithBytes,
+        lastDbValidatorsBytes,
+        {
+          checkpointState: localCpState,
+          wssCheckpoint: args.wssCheckpoint,
+          ignoreWeakSubjectivityCheck: args.ignoreWeakSubjectivityCheck,
+        },
+        chainForkConfig,
+        db,
+        logger
+      );
+    }
   }
 
   if (args.checkpointSyncUrl) {
@@ -204,7 +226,7 @@ export async function initBeaconState(
 async function readWSState(
   lastDbStateBytes: StateWithBytes | null,
   lastDbValidatorsBytes: Uint8Array | null,
-  wssOpts: {checkpointState: string; wssCheckpoint?: string; ignoreWeakSubjectivityCheck?: boolean},
+  wssOpts: {checkpointState: Uint8Array; wssCheckpoint?: string; ignoreWeakSubjectivityCheck?: boolean},
   chainForkConfig: ChainForkConfig,
   db: IBeaconDb,
   logger: Logger
@@ -212,10 +234,10 @@ async function readWSState(
   // weak subjectivity sync from a provided state file:
   // if a weak subjectivity checkpoint has been provided, it is used for additional verification
   // otherwise, the state itself is used for verification (not bad, because the trusted state has been explicitly provided)
-  const {checkpointState, wssCheckpoint, ignoreWeakSubjectivityCheck} = wssOpts;
+  const {wssCheckpoint, ignoreWeakSubjectivityCheck} = wssOpts;
   const lastDbState = lastDbStateBytes?.state ?? null;
 
-  const stateBytes = await downloadOrLoadFile(checkpointState);
+  const stateBytes = wssOpts.checkpointState;
   let wsState: BeaconStateAllForks;
   if (lastDbState && lastDbValidatorsBytes) {
     // use lastDbState to load wsState if possible to share the same state tree

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -205,14 +205,16 @@ export async function initBeaconState(
       const lastProcessedSlot = stateAndCp.anchorState.latestBlockHeader.slot;
       const {epoch, root} = computeAnchorCheckpoint(chainForkConfig, stateAndCp.anchorState).checkpoint;
 
-      logger.info("Loaded checkpoint state", {stateSlot: stateAndCp.anchorState.slot, lastProcessedSlot, root: toRootHex(root), epoch});
+      logger.info("Loaded checkpoint state", {stateSlot: stateAndCp.anchorState.slot, lastProcessedSlot, root: toRootHex(root), epoch, isFinalized});
 
       return {...stateAndCp, isFinalized};
     }
   }
 
   if (args.checkpointSyncUrl) {
-    isFinalized = false;
+    isFinalized = true;
+    logger.info("Found checkpoint sync url", {isFinalized});
+    // the real url is logged in fetchWSStateFromBeaconApi to hide username/password
     const stateAndCp = await fetchWSStateFromBeaconApi(
       lastDbStateWithBytes,
       lastDbValidatorsBytes,
@@ -226,15 +228,22 @@ export async function initBeaconState(
       logger
     );
 
+    const {epoch, root} = computeAnchorCheckpoint(chainForkConfig, stateAndCp.anchorState).checkpoint;
+    logger.info("Loaded downloaded state from checkpointSyncUrl", {stateSlot: stateAndCp.anchorState.slot, root: toRootHex(root), epoch, isFinalized});
+
     return {...stateAndCp, isFinalized};
   }
 
   const genesisStateFile = args.genesisStateFile || getGenesisFileUrl(args.network || defaultNetwork);
   if (genesisStateFile && !args.forceGenesis) {
+    isFinalized = true;
+    logger.info("Fetching genesis state", {isFinalized, genesisStateFile});
     let stateBytes = await downloadOrLoadFile(genesisStateFile);
+    logger.info("Fetched genesis state", {size: formatBytes(stateBytes.length)});
     // Convert to `Uint8Array` to avoid unexpected behavior such as `Buffer.prototype.slice` not copying memory
     stateBytes = new Uint8Array(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength);
     const anchorState = getStateTypeFromBytes(chainForkConfig, stateBytes).deserializeToViewDU(stateBytes);
+    logger.info("Loaded genesis state", {stateSlot: anchorState.slot, root: toRootHex(anchorState.hashTreeRoot()), isFinalized});
     const config = createBeaconConfig(chainForkConfig, anchorState.genesisValidatorsRoot);
     const wssCheck = isWithinWeakSubjectivityPeriod(config, anchorState, getCheckpointFromState(anchorState));
     await checkAndPersistAnchorState(config, db, logger, anchorState, stateBytes, {

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -166,12 +166,8 @@ export async function initBeaconState(
   if (args.checkpointState || args.lastPersistedCheckpointState) {
     let localCpState: Uint8Array | null = null;
     isFinalized = false;
-    if (args.checkpointState) {
-      // local file checkpoint state specified via wssCheckpoint could be loaded here
-      logger.info("Finding local checkpoint state from file", {path: args.checkpointState});
-      localCpState = await downloadOrLoadFile(args.checkpointState);
-      logger.info("Found local checkpoint state from file", {path: args.checkpointState, size: formatBytes(localCpState.length)});
-    } else if (args.lastPersistedCheckpointState) {
+    // prioritize lastPersistedCheckpointState over checkpointState
+    if (args.lastPersistedCheckpointState) {
       // find the last persisted checkpoint state to load
       const cpDataStore = args["chain.nHistoricalStatesFileDataStore"] ? new FileCPStateDatastore() : new DbCPStateDatastore(db);
       logger.verbose(`Finding last persisted checkpoint state from ${cpDataStore.constructor.name}`);
@@ -181,6 +177,11 @@ export async function initBeaconState(
       } else {
         logger.info("Found last persisted checkpoint state", {size: formatBytes(localCpState.length)});
       }
+    } else if (args.checkpointState) {
+      // local file checkpoint state specified via wssCheckpoint could be loaded here
+      logger.info("Finding local checkpoint state from file", {path: args.checkpointState});
+      localCpState = await downloadOrLoadFile(args.checkpointState);
+      logger.info("Found local checkpoint state from file", {path: args.checkpointState, size: formatBytes(localCpState.length)});
     }
 
     if (localCpState !== null) {

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -89,6 +89,10 @@ async function initAndVerifyWeakSubjectivityState(
  * 2. restore from db
  * 3. restore from genesis state (possibly downloaded via URL)
  * 4. create genesis state from eth1
+ *
+ * The returned anchorState could be finalized or not.
+ * - if we load from a local checkpoint state, or local file, it is supposed to be not finalized
+ * - it's finalized if from archived db, checkpointSyncUrl
  */
 export async function initBeaconState(
   options: IBeaconNodeOptions,
@@ -97,7 +101,7 @@ export async function initBeaconState(
   db: IBeaconDb,
   logger: Logger,
   signal: AbortSignal
-): Promise<{anchorState: BeaconStateAllForks; wsCheckpoint?: Checkpoint}> {
+): Promise<{anchorState: BeaconStateAllForks; isFinalized: boolean ; wsCheckpoint?: Checkpoint}> {
   if (args.forceCheckpointSync && !(args.checkpointState || args.checkpointSyncUrl)) {
     throw new Error("Forced checkpoint sync without specifying a checkpointState or checkpointSyncUrl");
   }
@@ -118,6 +122,9 @@ export async function initBeaconState(
     lastDbValidatorsBytes = validatorsBytes;
     lastDbStateWithBytes = {state, stateBytes: stateBytes};
   }
+
+  // by default, we only load finalized state
+  let isFinalized = true;
 
   if (lastDbState) {
     const config = createBeaconConfig(chainForkConfig, lastDbState.genesisValidatorsRoot);
@@ -146,7 +153,7 @@ export async function initBeaconState(
           isWithinWeakSubjectivityPeriod: wssCheck,
           isCheckpointState: false,
         });
-        return {anchorState: lastDbState};
+        return {anchorState: lastDbState, isFinalized};
       }
     }
   }
@@ -154,6 +161,7 @@ export async function initBeaconState(
   // See if we can sync state using checkpoint sync args or else start from genesis
   if (args.checkpointState || args.wssCheckpoint) {
     let localCpState: Uint8Array | null = null;
+    isFinalized = false;
     if (args.checkpointState) {
       // local file checkpoint state specified via wssCheckpoint could be loaded here
       logger.info("Loading local checkpoint state from file", {path: args.checkpointState});
@@ -173,7 +181,7 @@ export async function initBeaconState(
     }
 
     if (localCpState !== null) {
-      return readWSState(
+      const stateAndCp = await readWSState(
         lastDbStateWithBytes,
         lastDbValidatorsBytes,
         {
@@ -185,11 +193,13 @@ export async function initBeaconState(
         db,
         logger
       );
+
+      return {...stateAndCp, isFinalized};
     }
   }
 
   if (args.checkpointSyncUrl) {
-    return fetchWSStateFromBeaconApi(
+    const stateAndCp = await fetchWSStateFromBeaconApi(
       lastDbStateWithBytes,
       lastDbValidatorsBytes,
       {
@@ -201,6 +211,8 @@ export async function initBeaconState(
       db,
       logger
     );
+
+    return {...stateAndCp, isFinalized};
   }
 
   const genesisStateFile = args.genesisStateFile || getGenesisFileUrl(args.network || defaultNetwork);
@@ -215,12 +227,12 @@ export async function initBeaconState(
       isWithinWeakSubjectivityPeriod: wssCheck,
       isCheckpointState: true,
     });
-    return {anchorState};
+    return {anchorState , isFinalized};
   }
 
   // Only place we will not bother checking isWithinWeakSubjectivityPeriod as forceGenesis passed by user
   const anchorState = await initStateFromEth1({config: chainForkConfig, db, logger, opts: options.eth1, signal});
-  return {anchorState};
+  return {anchorState, isFinalized};
 }
 
 async function readWSState(

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -172,7 +172,7 @@ export async function initBeaconState(
       // find the last persisted checkpoint state to load
       const cpDataStore = args["chain.nHistoricalStatesFileDataStore"] ? new FileCPStateDatastore(dataDir) : new DbCPStateDatastore(db);
       logger.verbose(`Finding last persisted checkpoint state from ${cpDataStore.constructor.name}`);
-      localCpState = await cpDataStore.readLatest();
+      localCpState = await cpDataStore.readLatestSafe();
       if (localCpState === null) {
         logger.verbose("Last persisted checkpoint state not found");
       } else {

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -101,6 +101,7 @@ async function initAndVerifyWeakSubjectivityState(
 export async function initBeaconState(
   options: IBeaconNodeOptions,
   args: BeaconArgs & GlobalArgs,
+  dataDir: string,
   chainForkConfig: ChainForkConfig,
   db: IBeaconDb,
   logger: Logger,
@@ -169,7 +170,7 @@ export async function initBeaconState(
     // prioritize lastPersistedCheckpointState over checkpointState
     if (args.lastPersistedCheckpointState) {
       // find the last persisted checkpoint state to load
-      const cpDataStore = args["chain.nHistoricalStatesFileDataStore"] ? new FileCPStateDatastore() : new DbCPStateDatastore(db);
+      const cpDataStore = args["chain.nHistoricalStatesFileDataStore"] ? new FileCPStateDatastore(dataDir) : new DbCPStateDatastore(db);
       logger.verbose(`Finding last persisted checkpoint state from ${cpDataStore.constructor.name}`);
       localCpState = await cpDataStore.readLatest();
       if (localCpState === null) {

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -178,7 +178,9 @@ export async function initBeaconState(
       } else {
         logger.info("Found last persisted checkpoint state", {size: formatBytes(localCpState.length)});
       }
-    } else if (args.checkpointState) {
+    }
+
+    if (localCpState == null && args.checkpointState) {
       // local file checkpoint state specified via wssCheckpoint could be loaded here
       logger.info("Finding local checkpoint state from file", {path: args.checkpointState});
       localCpState = await downloadOrLoadFile(args.checkpointState);

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -167,19 +167,19 @@ export async function initBeaconState(
     isFinalized = false;
     if (args.checkpointState) {
       // local file checkpoint state specified via wssCheckpoint could be loaded here
-      logger.info("Loading local checkpoint state from file", {path: args.checkpointState});
+      logger.info("Finding local checkpoint state from file", {path: args.checkpointState});
       localCpState = await downloadOrLoadFile(args.checkpointState);
-      logger.info("Loaded local checkpoint state from file", {path: args.checkpointState});
+      logger.info("Found local checkpoint state from file", {path: args.checkpointState});
     } else if (args.wssCheckpoint) {
       // local db checkpoint state specified via wssCheckpoint could be loaded here
       const wssCheckpoint = getCheckpointFromArg(args.wssCheckpoint);
       const persistedCpKey = checkpointToDatastoreKey(wssCheckpoint);
-      logger.verbose("Loading local checkpoint state from db", {checkpoint: args.wssCheckpoint});
+      logger.verbose("Finding local checkpoint state from db", {checkpoint: args.wssCheckpoint});
       localCpState = await db.checkpointState.getBinary(persistedCpKey);
       if (localCpState === null) {
         logger.verbose("Checkpoint state not found in db", {checkpoint: args.wssCheckpoint});
       } else {
-        logger.info("Loaded local checkpoint state from db", {checkpoint: args.wssCheckpoint});
+        logger.info("Found local checkpoint state from db", {checkpoint: args.wssCheckpoint});
       }
     }
 
@@ -196,6 +196,8 @@ export async function initBeaconState(
         db,
         logger
       );
+
+      logger.info("Loaded checkpoint state", {slot: stateAndCp.anchorState.slot});
 
       return {...stateAndCp, isFinalized};
     }

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -10,6 +10,7 @@ import {
 import {BeaconConfig, ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {
   BeaconStateAllForks,
+  computeAnchorCheckpoint,
   ensureWithinWeakSubjectivityPeriod,
   isWithinWeakSubjectivityPeriod,
   loadState,
@@ -17,7 +18,7 @@ import {
 } from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {Checkpoint} from "@lodestar/types/phase0";
-import {Logger, formatBytes} from "@lodestar/utils";
+import {Logger, formatBytes, toRootHex} from "@lodestar/utils";
 
 import {
   fetchWeakSubjectivityState,
@@ -201,7 +202,10 @@ export async function initBeaconState(
         logger
       );
 
-      logger.info("Loaded checkpoint state", {slot: stateAndCp.anchorState.slot});
+      const lastProcessedSlot = stateAndCp.anchorState.latestBlockHeader.slot;
+      const {epoch, root} = computeAnchorCheckpoint(chainForkConfig, stateAndCp.anchorState).checkpoint;
+
+      logger.info("Loaded checkpoint state", {stateSlot: stateAndCp.anchorState.slot, lastProcessedSlot, root: toRootHex(root), epoch});
 
       return {...stateAndCp, isFinalized};
     }

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -58,15 +58,15 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
   },
 
   checkpointState: {
-    description: "Checkpoint state file path to start syncing from",
+    description: "Checkpoint state file path or url to start syncing from",
     type: "string",
     group: "weak subjectivity",
   },
 
   lastPersistedCheckpointState: {
-    description: "Set the last persisted checkpoint state to start syncing from",
+    description: "Use the last safe persisted checkpoint state to start syncing from",
     type: "boolean",
-    // this save sync time for holesky-rescue
+    // this saves sync time for holesky-rescue
     default: true,
     group: "weak subjectivity",
   },

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -10,6 +10,7 @@ type BeaconExtraArgs = {
   bootnodesFile?: string;
   checkpointSyncUrl?: string;
   checkpointState?: string;
+  lastPersistedCheckpointState?: boolean;
   wssCheckpoint?: string;
   forceCheckpointSync?: boolean;
   ignoreWeakSubjectivityCheck?: boolean;
@@ -57,8 +58,14 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
   },
 
   checkpointState: {
-    description: "Set a checkpoint state to start syncing from",
+    description: "Checkpoint state file path to start syncing from",
     type: "string",
+    group: "weak subjectivity",
+  },
+
+  lastPersistedCheckpointState: {
+    description: "Set the last persisted checkpoint state to start syncing from",
+    type: "boolean",
     group: "weak subjectivity",
   },
 

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -10,7 +10,7 @@ type BeaconExtraArgs = {
   bootnodesFile?: string;
   checkpointSyncUrl?: string;
   checkpointState?: string;
-  lastPersistedCheckpointState?: boolean;
+  lastPersistedCheckpointState: boolean;
   wssCheckpoint?: string;
   forceCheckpointSync?: boolean;
   ignoreWeakSubjectivityCheck?: boolean;
@@ -66,6 +66,8 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
   lastPersistedCheckpointState: {
     description: "Set the last persisted checkpoint state to start syncing from",
     type: "boolean",
+    // this save sync time for holesky-rescue
+    default: true,
     group: "weak subjectivity",
   },
 

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -535,20 +535,18 @@ export class ForkChoice implements IForkChoice {
     }
 
     // Check block is a descendant of the finalized block at the checkpoint finalized slot.
-    // in holesky-rescue, if we start from non-finalized state, we'll get FORKCHOICE_ERROR_UNKNOWN_ANCESTOR
-    // because we don't have block at the finalized slot
-    // const blockAncestorRoot = this.getAncestor(parentRootHex, finalizedSlot);
-    // const finalizedRoot = this.fcStore.finalizedCheckpoint.rootHex;
-    // if (blockAncestorRoot !== finalizedRoot) {
-    //   throw new ForkChoiceError({
-    //     code: ForkChoiceErrorCode.INVALID_BLOCK,
-    //     err: {
-    //       code: InvalidBlockCode.NOT_FINALIZED_DESCENDANT,
-    //       finalizedRoot,
-    //       blockAncestor: blockAncestorRoot,
-    //     },
-    //   });
-    // }
+    const blockAncestorRoot = this.getAncestor(parentRootHex, finalizedSlot);
+    const finalizedRoot = this.fcStore.finalizedCheckpoint.rootHex;
+    if (blockAncestorRoot !== finalizedRoot) {
+      throw new ForkChoiceError({
+        code: ForkChoiceErrorCode.INVALID_BLOCK,
+        err: {
+          code: InvalidBlockCode.NOT_FINALIZED_DESCENDANT,
+          finalizedRoot,
+          blockAncestor: blockAncestorRoot,
+        },
+      });
+    }
 
     const blockRoot = this.config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block);
     const blockRootHex = toRootHex(blockRoot);

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -535,18 +535,20 @@ export class ForkChoice implements IForkChoice {
     }
 
     // Check block is a descendant of the finalized block at the checkpoint finalized slot.
-    const blockAncestorRoot = this.getAncestor(parentRootHex, finalizedSlot);
-    const finalizedRoot = this.fcStore.finalizedCheckpoint.rootHex;
-    if (blockAncestorRoot !== finalizedRoot) {
-      throw new ForkChoiceError({
-        code: ForkChoiceErrorCode.INVALID_BLOCK,
-        err: {
-          code: InvalidBlockCode.NOT_FINALIZED_DESCENDANT,
-          finalizedRoot,
-          blockAncestor: blockAncestorRoot,
-        },
-      });
-    }
+    // in holesky-rescue, if we start from non-finalized state, we'll get FORKCHOICE_ERROR_UNKNOWN_ANCESTOR
+    // because we don't have block at the finalized slot
+    // const blockAncestorRoot = this.getAncestor(parentRootHex, finalizedSlot);
+    // const finalizedRoot = this.fcStore.finalizedCheckpoint.rootHex;
+    // if (blockAncestorRoot !== finalizedRoot) {
+    //   throw new ForkChoiceError({
+    //     code: ForkChoiceErrorCode.INVALID_BLOCK,
+    //     err: {
+    //       code: InvalidBlockCode.NOT_FINALIZED_DESCENDANT,
+    //       finalizedRoot,
+    //       blockAncestor: blockAncestorRoot,
+    //     },
+    //   });
+    // }
 
     const blockRoot = this.config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block);
     const blockRootHex = toRootHex(blockRoot);

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -870,6 +870,11 @@ export class ForkChoice implements IForkChoice {
     return block;
   }
 
+  getFinalizedBlockSlot(): Slot {
+    const finalizedEpoch = this.fcStore.finalizedCheckpoint.epoch;
+    return computeStartSlotAtEpoch(finalizedEpoch);
+  }
+
   /**
    * Returns true if the `descendantRoot` has an ancestor with `ancestorRoot`.
    *

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -202,6 +202,7 @@ export interface IForkChoice {
   getBlock(blockRoot: Root): ProtoBlock | null;
   getBlockHex(blockRoot: RootHex): ProtoBlock | null;
   getFinalizedBlock(): ProtoBlock;
+  getFinalizedBlockSlot(): Slot;
   getJustifiedBlock(): ProtoBlock;
   /**
    * Returns true if the `descendantRoot` has an ancestor with `ancestorRoot`.


### PR DESCRIPTION
**Motivation**

- we already have local checkpoint states in either db or file, this PR use one of them to save syncing time the next time the node is restarted
- see https://github.com/ChainSafe/lodestar/issues/7504#issuecomment-2689547378

**Description**

2 new init unfinalized state options:

- new `--lastPersistedCheckpointState`, true by default to load from the last safe persisted checkpoint state. And the last safe persisted checkpoint state is considered unfinalized
- use `--checkpointState` option: this is old option and support finalized state only, this PR supports booting from unfinalized state similar to `--lastPersistedCheckpointState` ==> to quickly sync a new node, we can use this option. Then remove it and the next time node will use `--lastPersistedCheckpointState` option by default
- we can configure one of our nodes with `chain.nHistoricalStatesFileDataStore = true`
- then feed other nodes with a persisted "safe checkpoint state" from there in `~/checkpoint_states` folder

- a persisted checkpoint state is consider to be safe to boot if
  - it should be the checkpoint state that's unique in its epoch
   - its last processed block slot should be at epoch boundary or last slot of previous epoch
   - state slot should be at epoch boundary
   - state slot should be equal to epoch * SLOTS_PER_EPOCH

other options to boot from `stateArchived` or `checkpointSyncUrl` are considered finalized states including `wssCheckpoint`. It's not possible to use `wssCheckpoint` option with unfinalized state for now.

**TODO**
- this is for `holesky-rescue`, consider supporting this for `unstable` branch too
- update document in that case