### PR TITLE
feat: prune persisted cp states

### DIFF
--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -14,8 +14,10 @@ import {MapTracker} from "./mapMetrics.js";
 import {BlockStateCache, CacheItemType, CheckpointHex, CheckpointStateCache} from "./types.js";
 
 export type PersistentCheckpointStateCacheOpts = {
-  /** Keep max n states in memory, persist the rest to disk */
+  /** Keep max n state epochs in memory, persist the rest to disk */
   maxCPStateEpochsInMemory?: number;
+  /** Keep max n state epochs on disk */
+  maxCPStateEpochsOnDisk?: number;
 };
 
 type PersistentCheckpointStateCacheModules = {
@@ -54,6 +56,12 @@ type LoadedStateBytesData = {persistedKey: DatastoreKey; stateBytes: Uint8Array}
  * may not be available in memory, and stay on disk instead.
  */
 export const DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY = 3;
+
+/**
+ * During nft state of Holesky in Feb 2025, lodestar stores ~250MB per epoch and it's not sustainable to keep all states on disk.
+ * It's not likely to have reorgs that go back to 10 epochs ago, so we only keep 10 epochs on disk.
+ */
+export const DEFAULT_MAX_CP_STATE_ON_DISK = 10;
 
 /**
  * An implementation of CheckpointStateCache that keep up to n epoch checkpoint states in memory and persist the rest to disk
@@ -98,6 +106,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   private preComputedCheckpoint: string | null = null;
   private preComputedCheckpointHits: number | null = null;
   private readonly maxEpochsInMemory: number;
+  private readonly maxEpochsOnDisk: number;
   private readonly datastore: CPStateDatastore;
   private readonly blockStateCache: BlockStateCache;
   private readonly bufferPool?: BufferPool | null;
@@ -133,10 +142,16 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     this.logger = logger;
     this.clock = clock;
     this.signal = signal;
+
     if (opts.maxCPStateEpochsInMemory !== undefined && opts.maxCPStateEpochsInMemory < 0) {
       throw new Error("maxEpochsInMemory must be >= 0");
     }
+    if (opts.maxCPStateEpochsOnDisk !== undefined && opts.maxCPStateEpochsOnDisk < 0) {
+      throw new Error("maxCPStateEpochsOnDisk must be >= 0");
+    }
+
     this.maxEpochsInMemory = opts.maxCPStateEpochsInMemory ?? DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY;
+    this.maxEpochsOnDisk = opts.maxCPStateEpochsOnDisk ?? DEFAULT_MAX_CP_STATE_ON_DISK;
     // Specify different datastore for testing
     this.datastore = datastore;
     this.blockStateCache = blockStateCache;
@@ -318,6 +333,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       this.logger.verbose("Added checkpoint state to memory", {epoch: cp.epoch, rootHex: cpHex.rootHex});
     }
     this.epochIndex.getOrDefault(cp.epoch).add(cpHex.rootHex);
+    this.prunePersistedStates();
   }
 
   /**
@@ -750,11 +766,36 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       this.cache.delete(key);
     }
     this.epochIndex.delete(epoch);
-    this.logger.verbose("Pruned finalized checkpoints states for epoch", {
+    this.logger.verbose("Pruned checkpoints state for epoch", {
       epoch,
       persistCount,
       rootHexes: Array.from(rootHexes).join(","),
     });
+  }
+
+  /**
+   * Prune persisted checkpoint states from disk.
+   * Note that this should handle all possible errors and not throw.
+   */
+  private prunePersistedStates(): void {
+    //                epochsOnDisk                                   epochsInMemory
+    // |----------------------------------------------------------|----------------------|
+    const maxTrackedEpochs = this.maxEpochsOnDisk + this.maxEpochsInMemory;
+    if (this.epochIndex.size <= maxTrackedEpochs) {
+      return;
+    }
+
+    const sortedEpochs = Array.from(this.epochIndex.keys()).sort((a, b) => a - b);
+    const pruneEpochs = sortedEpochs.slice(0, sortedEpochs.length - maxTrackedEpochs);
+    for (const epoch of pruneEpochs) {
+      this.deleteAllEpochItems(epoch).catch((e) =>
+        this.logger.debug(
+          "Error delete all epoch items",
+          {epoch, maxCPStateEpochsOnDisk: this.maxEpochsOnDisk, maxEpochsInMemory: this.maxEpochsInMemory},
+          e as Error
+        )
+      );
+    }
   }
 
   /**

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -33,6 +33,7 @@ export type ChainArgs = {
   "chain.nHistoricalStatesFileDataStore"?: boolean;
   "chain.maxBlockStates"?: number;
   "chain.maxCPStateEpochsInMemory"?: number;
+  "chain.maxCPStateEpochsOnDisk"?: number;
 
   "chain.pruneHistory"?: boolean;
 };
@@ -70,6 +71,7 @@ export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
       args["chain.nHistoricalStatesFileDataStore"] ?? defaultOptions.chain.nHistoricalStatesFileDataStore,
     maxBlockStates: args["chain.maxBlockStates"] ?? defaultOptions.chain.maxBlockStates,
     maxCPStateEpochsInMemory: args["chain.maxCPStateEpochsInMemory"] ?? defaultOptions.chain.maxCPStateEpochsInMemory,
+    maxCPStateEpochsOnDisk: args["chain.maxCPStateEpochsOnDisk"] ?? defaultOptions.chain.maxCPStateEpochsOnDisk,
     pruneHistory: args["chain.pruneHistory"],
   };
 }
@@ -284,6 +286,14 @@ Will double processing times. Use only for debugging purposes.",
     description: "Max epochs to cache checkpoint states in memory, used for PersistentCheckpointStateCache",
     type: "number",
     default: defaultOptions.chain.maxCPStateEpochsInMemory,
+    group: "chain",
+  },
+
+  "chain.maxCPStateEpochsOnDisk": {
+    hidden: true,
+    description: "Max epochs to cache checkpoint states on disk, used for PersistentCheckpointStateCache",
+    type: "number",
+    default: defaultOptions.chain.maxCPStateEpochsOnDisk,
     group: "chain",
   },
 

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -43,6 +43,7 @@ describe("options / beaconNodeOptions", () => {
       "chain.nHistoricalStatesFileDataStore": true,
       "chain.maxBlockStates": 100,
       "chain.maxCPStateEpochsInMemory": 100,
+      "chain.maxCPStateEpochsOnDisk": 1000,
       "chain.stateArchiveMode": StateArchiveMode.Frequency,
       emitPayloadAttributes: false,
 
@@ -153,6 +154,7 @@ describe("options / beaconNodeOptions", () => {
         nHistoricalStatesFileDataStore: true,
         maxBlockStates: 100,
         maxCPStateEpochsInMemory: 100,
+        maxCPStateEpochsOnDisk: 1000,
       },
       eth1: {
         enabled: true,


### PR DESCRIPTION
**Motivation**

- as of Holesky Feb 2025, it takes 250MB per checkpoint states and more than 56GB per day which is not sustainable
- see https://github.com/ChainSafe/lodestar/issues/7504#issuecomment-2689547378

**Description**

- delete persisted checkpoint state in add() function, by default only store max 10 persisted checkpoint state

- see https://github.com/ChainSafe/lodestar/issues/7504#issuecomment-2689547378
