### PR TITLE
feat: add flag to disable optimistic sync

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -194,6 +194,8 @@ export async function verifyBlocksInEpoch(
           numBlobs,
         });
       }
+    } else {
+      this.logger.verbose("Block executions aborted due to execution payload", segmentExecStatus.execAborted.execError);
     }
 
     return {postStates, dataAvailabilityStatuses, proposerBalanceDeltas, segmentExecStatus, availableBlockInputs};

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -145,6 +145,8 @@ export async function verifyBlocksExecutionPayload(
 
   const currentSlot = chain.clock.currentSlot;
   const safeSlotsToImportOptimistically = opts.safeSlotsToImportOptimistically ?? SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY;
+  // In the case optimisic sync is disabled, it does not matter what `isOptimisticallySafe` is since we will reject
+  // any syncing blocks in `verifyBlockExecutionPayload`.
   let isOptimisticallySafe =
     parentBlock.executionStatus !== ExecutionStatus.PreMerge ||
     lastBlock.message.slot + safeSlotsToImportOptimistically < currentSlot;
@@ -343,6 +345,15 @@ export async function verifyBlockExecutionPayload(
     // Accepted and Syncing have the same treatment, as final validation of block is pending
     case ExecutionPayloadStatus.ACCEPTED:
     case ExecutionPayloadStatus.SYNCING: {
+      if (opts.disableOptimisticSync) {
+        // Optimistic sync is disabled, skip importing this block
+        const execError = new BlockError(block, {
+          code: BlockErrorCode.EXECUTION_ENGINE_ERROR,
+          execStatus: ExecutionPayloadStatus.OPTIMISTIC_SYNC_DISABLED,
+          errorMessage: `attempt to import ${execResult.status} payload when optimistic sync is disabled`,
+        });
+        return {executionStatus: null, execError} as VerifyBlockExecutionResponse;
+      }
       // Check if the entire segment was deemed safe or, this block specifically itself if not in
       // the safeSlotsToImportOptimistically window of current slot, then we can import else
       // we need to throw and not import his block

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -78,6 +78,9 @@ export type BlockProcessOpts = {
   skipVerifyExecutionPayload?: boolean;
   /** Used to specify to skip block signatures validation */
   skipVerifyBlockSignatures?: boolean;
+
+  /** Will not import beacon blocks when execution client is syncing if true */
+  disableOptimisticSync?: boolean;
 };
 
 export type PoolOpts = {

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -28,6 +28,8 @@ export enum ExecutionPayloadStatus {
   UNAVAILABLE = "UNAVAILABLE",
   /** EL replied with SYNCING or ACCEPTED when its not safe to import optimistic blocks */
   UNSAFE_OPTIMISTIC_STATUS = "UNSAFE_OPTIMISTIC_STATUS",
+  /** EL replied with SYNCING or ACCEPTED when optimistic sync is disabled */
+  OPTIMISTIC_SYNC_DISABLED = "OPTIMISTIC_SYNC_DISABLED",
 }
 
 export enum ExecutionEngineState {

--- a/packages/beacon-node/src/execution/engine/utils.ts
+++ b/packages/beacon-node/src/execution/engine/utils.ts
@@ -56,7 +56,6 @@ export const HTTP_FATAL_ERROR_CODES = ["ECONNREFUSED", "ENOTFOUND", "EAI_AGAIN"]
 export const HTTP_CONNECTION_ERROR_CODES = ["ECONNRESET", "ECONNABORTED"];
 
 function getExecutionEngineStateForPayloadStatus(payloadStatus: ExecutionPayloadStatus): ExecutionEngineState {
-  // TODO Opt
   switch (payloadStatus) {
     case ExecutionPayloadStatus.ACCEPTED:
     case ExecutionPayloadStatus.VALID:

--- a/packages/beacon-node/src/execution/engine/utils.ts
+++ b/packages/beacon-node/src/execution/engine/utils.ts
@@ -56,6 +56,7 @@ export const HTTP_FATAL_ERROR_CODES = ["ECONNREFUSED", "ENOTFOUND", "EAI_AGAIN"]
 export const HTTP_CONNECTION_ERROR_CODES = ["ECONNRESET", "ECONNABORTED"];
 
 function getExecutionEngineStateForPayloadStatus(payloadStatus: ExecutionPayloadStatus): ExecutionEngineState {
+  // TODO Opt
   switch (payloadStatus) {
     case ExecutionPayloadStatus.ACCEPTED:
     case ExecutionPayloadStatus.VALID:
@@ -66,6 +67,7 @@ function getExecutionEngineStateForPayloadStatus(payloadStatus: ExecutionPayload
     case ExecutionPayloadStatus.INVALID:
     case ExecutionPayloadStatus.SYNCING:
     case ExecutionPayloadStatus.INVALID_BLOCK_HASH:
+    case ExecutionPayloadStatus.OPTIMISTIC_SYNC_DISABLED:
       return ExecutionEngineState.SYNCING;
 
     case ExecutionPayloadStatus.UNAVAILABLE:

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -35,6 +35,7 @@ export type ChainArgs = {
   "chain.maxCPStateEpochsInMemory"?: number;
 
   "chain.pruneHistory"?: boolean;
+  "chain.disableOptimisticSync"?: boolean;
 };
 
 export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
@@ -71,6 +72,7 @@ export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
     maxBlockStates: args["chain.maxBlockStates"] ?? defaultOptions.chain.maxBlockStates,
     maxCPStateEpochsInMemory: args["chain.maxCPStateEpochsInMemory"] ?? defaultOptions.chain.maxCPStateEpochsInMemory,
     pruneHistory: args["chain.pruneHistory"],
+    disableOptimisticSync: args["chain.disableOptimisticSync"],
   };
 }
 
@@ -292,6 +294,14 @@ Will double processing times. Use only for debugging purposes.",
     description: "Prune historical blocks and state",
     type: "boolean",
     default: defaultOptions.chain.pruneHistory,
+    group: "chain",
+  },
+
+  "chain.disableOptimisticSync": {
+    hidden: true,
+    description: "Will not import beacon blocks when execution client is syncing if true",
+    type: "boolean",
+    default: defaultOptions.chain.disableOptimisticSync,
     group: "chain",
   },
 };


### PR DESCRIPTION
Add flag to disable optimistic sync

### Test Evidence

Run devnet-7 with full-sync Besu and `--chain.disableOptimisticSync` on Lodestar. 
See logs: https://gist.github.com/ensi321/fdf0a87ca3761e2bd1238f803f0dd053

Explanation:
The latest EL block at the time was 33401. 
Period 1: From start until `00:42:45` Besu did a backward sync until it synced to 33401.
Period 2: From `00:42:45` to `00:43:58` it was syncing from initial finalized cp to head.
Period 3: From `00:43:58` to end it was following the chain. 

Lodestar did not import any block during period 1, only started syncing in period 2 and fully synced in period 3.
