### PR TITLE
Fixed Grammar Issues and Corrected Release Version Reference

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ Lodestar uses a modified version of gitflow to manage releases. [Gitflow](https:
 
 ## Stable release
 
-### When to a release
+### When to release
 
 Lodestar does not have a fixed schedule for releases. Instead, they are published as the developers see fit.
 
@@ -74,7 +74,7 @@ If there is a bug discovered during the testing period which significantly impac
 For example: After 3-5 days of testing, is performance equal to or better than latest stable?
 
 - **Yes**: Continue to the next release step
-- **No**: If it a small issue fixable quickly (hotfix)?
+- **No**: If it is a small issue fixable quickly (hotfix)?
   - **Yes**: Merge fix(es) to `unstable`, push the fix(es) to `rc/v1.1.0` branch, go to step 2, incrementing the rc version
   - **No**: abort the release. Close the `chore: v1.1.0 release` PR, delete the branch, and start the whole release process over.
 
@@ -173,7 +173,7 @@ For example: After modified hotfix testing period, is the original bug resolved?
 - **Yes**: Continue to the next release step
 - **No**: If it a small issue fixable quickly with another hotfix?
   - **Yes**: Merge fix(es) to `unstable`, push the fix(es) to `rc/v1.1.1` hotfix branch, go to step 2, incrementing the rc version
-  - **No**: Abort the release. Close the `chore: v1.1.v release` PR, delete the branch, and start the whole release process over.
+  - **No**: Abort the release. Close the `chore: v1.1.1 release` PR, delete the branch, and start the whole release process over.
 
 ### 4. Merge hotfix release candidate
 


### PR DESCRIPTION
### 1.Fixed Incorrect Heading

Before: ### When to a release
After: ### When to release
Explanation: The original heading contained incorrect grammar ("When to a release"). The corrected version, "When to release," is grammatically correct.
### 2.Clarified Hotfix Decision Criteria

Before: - **No**: If it a small issue fixable quickly (hotfix)?
After: - **No**: If it is a small issue fixable quickly (hotfix)?
Explanation: Fixed grammatical error ("If it a" → "If it is a"), making the sentence clearer.

### 3.Fixed an incorrect version with a typo: v1.1.v was replaced with v1.1.1.
Explanation:
The documentation incorrectly referenced rc/v1.1.v instead of the correct rc/v1.1.1. This fix removes the typo and ensures the correct release candidate version is specified.
