### PR TITLE
fix: broken links in docs

### DIFF
--- a/docs/pages/run/beacon-management/starting-a-node.md
+++ b/docs/pages/run/beacon-management/starting-a-node.md
@@ -36,7 +36,7 @@ When starting up a Lodestar beacon node in any configuration, ensure you add the
 Use the `--authrpc.jwtsecret /path/to/jwtsecret.hex` flag to configure the secret. Use their documentation [here](https://geth.ethereum.org/docs/getting-started#start-geth).
 
 **For Nethermind:**
-Use the `--JsonRpc.JwtSecretFile /path/to/jwtsecret.hex` flag to configure the secret. Use their documentation [here](https://docs.nethermind.io/get-started/consensus-clients/#configuring-json-rpc-interface).
+Use the `--JsonRpc.JwtSecretFile /path/to/jwtsecret.hex` flag to configure the secret. Use their documentation [here](https://docs.nethermind.io/get-started/running-node/consensus-clients#configuring-json-rpc-interface).
 
 **For Besu:**
 Use the `--engine-jwt-secret=/path/to/jwtsecret.hex` flag to configure the secret. Use their documentation [here](https://besu.hyperledger.org/public-networks/how-to/use-besu-api/authenticate#2-create-the-jwt).

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -757,7 +757,7 @@ export class BeaconChain implements IBeaconChain {
   }
 
   /**
-   * https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/validator.md#sidecar
+   * https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/validator.md#sidecar
    * def get_blobs_sidecar(block: BeaconBlock, blobs: Sequence[Blob]) -> BlobSidecars:
    *   return BlobSidecars(
    *       beacon_block_root=hash_tree_root(block),

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -290,7 +290,7 @@ export async function produceBlockBody<T extends BlockType>(
       // are pre-merge. We don't care the same for builder segment as the execution block
       // will takeover if the builder flow was activated and errors
       try {
-        // https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/validator.md#constructing-the-beaconblockbody
+        // https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/validator.md#constructing-the-beaconblockbody
         const prepareRes = await prepareExecutionPayload(
           this,
           this.logger,

--- a/packages/types/src/deneb/sszTypes.ts
+++ b/packages/types/src/deneb/sszTypes.ts
@@ -18,10 +18,10 @@ const {UintNum64, Slot, Root, BLSSignature, UintBn64, UintBn256, Bytes32, Bytes4
   primitiveSsz;
 
 // Polynomial commitments
-// https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md
 
 // Custom types
-// https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/polynomial-commitments.md#custom-types
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#custom-types
 export const G1Point = Bytes48;
 export const G2Point = Bytes96;
 export const BLSFieldElement = Bytes32;
@@ -31,7 +31,7 @@ export const KZGProof = Bytes48;
 // Beacon chain
 
 // Custom types
-// https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/beacon-chain.md#custom-types
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/beacon-chain.md#custom-types
 
 export const Blob = new ByteVectorType(BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB);
 export const Blobs = new ListCompositeType(Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK);
@@ -62,7 +62,7 @@ export const BlobIdentifier = new ContainerType(
 );
 
 // Beacon Chain types
-// https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/beacon-chain.md#containers
+// https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/beacon-chain.md#containers
 
 export const ExecutionPayload = new ContainerType(
   {


### PR DESCRIPTION
**Motivation**

Hi! While working with the documentation and code, outdated or incorrect links to specifications and documentation were identified. This could lead to confusion and make it harder for new developers to understand the code. This PR fixes these links to ensure the information is up-to-date and accurate.

**Description**

This PR fixes several broken links in the documentation and code comments. Specifically:

1. In the `starting-a-node.md` file, the link to the Nethermind documentation has been updated.
2. In the `chain.ts` file, the link to the Deneb specification has been updated.
3. In the `produceBlockBody.ts` file, the link to the Deneb specification has been updated.
4. In the `sszTypes.ts` file, the links to the Deneb specifications have been updated.
