### PR TITLE
chore: fix strict equality check for type validation

### DIFF
--- a/scripts/generate_changelog.mjs
+++ b/scripts/generate_changelog.mjs
@@ -102,7 +102,7 @@ for (const commitHash of commitHashes.trim().split("\n")) {
   // Sort commits by type and scope
   // - assign each commit to section based on type
   // - group commits by scope within each section
-  if (sections[type] != null) {
+  if (sections[type] !== undefined) {
     if (scope) {
       if (sections[type].commitsByScope[scope] == null) {
         sections[type].commitsByScope[scope] = [];


### PR DESCRIPTION
**Motivation**  
The original condition `!= null` could lead to unintended behavior due to type coercion. Switching to a strict check (`!== undefined`) ensures more predictable results and improves code clarity.

**Description**  
Updated the type validation check from `if (sections[type] != null)` to `if (sections[type] !== undefined)`. This enhances readability and prevents potential issues caused by type coercion.

**Steps to test or reproduce**  
1. Review the code where `sections[type]` is checked.
2. Confirm that the check is now using strict equality (`!== undefined`).
3. Test the application to ensure there are no side effects or errors introduced by this change.