### PR TITLE
fix: findSeedStateToReload

### DIFF
--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -524,6 +524,8 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     const maxEpoch = Math.max(...Array.from(this.epochIndex.keys()));
     const reloadedCpSlot = computeStartSlotAtEpoch(reloadedCp.epoch);
     let firstState: CachedBeaconStateAllForks | null = null;
+    const logCtx = {cpEpoch: reloadedCp.epoch, cpRoot: reloadedCp.rootHex};
+
     // no need to check epochs before `maxEpoch - this.maxEpochsInMemory + 1` before they are all persisted
     for (let epoch = maxEpoch - this.maxEpochsInMemory + 1; epoch <= maxEpoch; epoch++) {
       // if there's at least 1 state in memory in an epoch, just return the 1st one
@@ -550,22 +552,20 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
               reloadedCpSlot < state.slot &&
               toRootHex(getBlockRootAtSlot(state, reloadedCpSlot)) === reloadedCp.rootHex
             ) {
+              this.logger.verbose("Reload: use block state as seed state", {stateSlot: state.slot, ...logCtx});
               return state;
             }
           } catch (e) {
             // getBlockRootAtSlot may throw error
-            this.logger.debug(
-              "Error finding seed state to reload",
-              {epoch, root: rootHex, reloadedEpoch: reloadedCp.epoch, reloadedRoot: reloadedCp.rootHex},
-              e as Error
-            );
+            this.logger.debug("Error finding seed state to reload", {epoch, root: rootHex, ...logCtx}, e as Error);
           }
         }
       }
     }
 
+    // fallback to using the default seed state from block state cache
     const seedBlockState = this.blockStateCache.getSeedState();
-    this.logger.verbose("Reload: use block state as seed state", {slot: seedBlockState.slot});
+    this.logger.verbose("Reload: use default block state as seed state", {stateSlot: seedBlockState.slot, ...logCtx});
     return seedBlockState;
   }
 

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -544,12 +544,21 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
             firstState = state;
           }
 
-          // amongst states of the same epoch, choose the one with the same view of reloadedCp
-          if (
-            reloadedCpSlot < state.slot &&
-            toRootHex(getBlockRootAtSlot(state, reloadedCpSlot)) === reloadedCp.rootHex
-          ) {
-            return state;
+          try {
+            // amongst states of the same epoch, choose the one with the same view of reloadedCp
+            if (
+              reloadedCpSlot < state.slot &&
+              toRootHex(getBlockRootAtSlot(state, reloadedCpSlot)) === reloadedCp.rootHex
+            ) {
+              return state;
+            }
+          } catch (e) {
+            // getBlockRootAtSlot may throw error
+            this.logger.debug(
+              "Error finding seed state to reload",
+              {epoch, root: rootHex, reloadedEpoch: reloadedCp.epoch, reloadedRoot: reloadedCp.rootHex},
+              e as Error
+            );
           }
         }
       }


### PR DESCRIPTION
**Motivation**

- got this error on one of nodes running holesky-rescue #7501 branch
```
Error get or reload state epoch=115971, rootHex=0x2d58d27886354a292f7247215a84b1ed0a1a714465eca800df8dd2255275eb16 - Cannot get block root more than 8192 in the past
Error: Cannot get block root more than 8192 in the past
    at getBlockRootAtSlot (file:///usr/app/packages/state-transition/src/util/blockRoot.ts:24:11)
    at PersistentCheckpointStateCache.findSeedStateToReload (file:///usr/app/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts:550:23)
    at PersistentCheckpointStateCache.getOrReload (file:///usr/app/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts:182:28)
    at PersistentCheckpointStateCache.getOrReloadLatest (file:///usr/app/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts:361:31)
    at StateRegenerator.getState (file:///usr/app/packages/beacon-node/src/chain/regen/regen.ts:186:11)
    at JobItemQueue.QueuedStateRegenerator.jobQueueProcessor [as itemProcessor] (file:///usr/app/packages/beacon-node/src/chain/regen/queued.ts:302:18)
    at JobItemQueue.runJob (file:///usr/app/packages/beacon-node/src/util/queue/itemQueue.ts:102:22)
```



**Description**

- when the state to reload is ~256 epochs in the past the `getBlockRootAtSlot` will fail
- in that case, let's just catch the error and use the default `seedBlockState` handled below
