### PR TITLE
fix: type checks for build config

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -24,9 +24,7 @@
     "declarationMap": true,
     "incremental": true,
     "preserveWatchOutput": true,
-    "noUncheckedSideEffectImports": true,
-    "noCheck": true,
-
+    "noUncheckedSideEffectImports": true,    
     // TODO: Investigate following errors:
     // - Cannot find module 'rollup/parseAst' or its corresponding type declarations
     "skipLibCheck": true,


### PR DESCRIPTION
**Motivation**

It is commonly practice that if code builds fine, it works fine. 


**Description**

- Having type checking and other checks disabled for the build step causing confusing in dev experience
- Revert the **noCheck** from the build tsconfig. 


**Steps to test or reproduce**

- Run all tests