### PR TITLE
fix: checkpoint file datastore on docker

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -185,6 +185,7 @@ export class BeaconChain implements IBeaconChain {
     {
       config,
       db,
+      dataDir,
       logger,
       processShutdownCallback,
       clock,
@@ -197,6 +198,7 @@ export class BeaconChain implements IBeaconChain {
     }: {
       config: BeaconConfig;
       db: IBeaconDb;
+      dataDir: string;
       logger: Logger;
       processShutdownCallback: ProcessShutdownCallback;
       /** Used for testing to supply fake clock */
@@ -305,7 +307,7 @@ export class BeaconChain implements IBeaconChain {
             bufferPool: this.bufferPool,
             datastore: fileDataStore
               ? // debug option if we want to investigate any issues with the DB
-                new FileCPStateDatastore()
+                new FileCPStateDatastore(dataDir)
               : // production option
                 new DbCPStateDatastore(this.db),
           },

--- a/packages/beacon-node/src/chain/stateCache/datastore/file.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/file.ts
@@ -13,9 +13,10 @@ const CHECKPOINT_FILE_NAME_LENGTH = 82;
 export class FileCPStateDatastore implements CPStateDatastore {
   private readonly folderPath: string;
 
-  constructor(parentDir = ".") {
-    // by default use the beacon folder `/beacon/checkpoint_states`
-    this.folderPath = path.join(parentDir, CHECKPOINT_STATES_FOLDER);
+  constructor(dataDir: string) {
+    // service deployment: `/beacon/checkpoint_states`
+    // docker deployment: `/data/checkpoint_states`
+    this.folderPath = path.join(dataDir, CHECKPOINT_STATES_FOLDER);
   }
 
   async init(): Promise<void> {

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -52,6 +52,7 @@ export type BeaconNodeInitModules = {
   logger: LoggerNode;
   processShutdownCallback: ProcessShutdownCallback;
   peerId: PeerId;
+  dataDir: string;
   peerStoreDir?: string;
   anchorState: BeaconStateAllForks;
   wsCheckpoint?: phase0.Checkpoint;
@@ -149,6 +150,7 @@ export class BeaconNode {
     logger,
     processShutdownCallback,
     peerId,
+    dataDir,
     peerStoreDir,
     anchorState,
     wsCheckpoint,
@@ -224,6 +226,7 @@ export class BeaconNode {
     const chain = new BeaconChain(opts.chain, {
       config,
       clock,
+      dataDir,
       db,
       logger: logger.child({module: LoggerModule.chain}),
       processShutdownCallback,

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -86,6 +86,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       logger,
       processShutdownCallback,
       peerId,
+      dataDir: beaconPaths.dataDir,
       peerStoreDir: beaconPaths.peerStoreDir,
       anchorState,
       wsCheckpoint,


### PR DESCRIPTION
**Motivation**

Got this error on docker if we configure `chain.nHistoricalStatesFileDataStore` on docker deployment

```
Mar-04 00:09:16.845[chain]           debug: Error processing past epoch epoch=116037, slot=3713472, root=0xcc01573089444f764834fcfc0485b023e9d361177deb4e965d6f56c35b9e72b7 - ENOENT: no such file or directory, open 'checkpoint_states/0x45c5010000000000cc01573089444f764834fcfc0485b023e9d361177deb4e965d6f56c35b9e72b7'
Error: ENOENT: no such file or directory, open 'checkpoint_states/0x45c5010000000000cc01573089444f764834fcfc0485b023e9d361177deb4e965d6f56c35b9e72b7'
```

**Description**

On Docker, need the cwd is different from data folder, need to pass `dataDir` option to BeaconChain so that we can use it to store checkpoint files
