### PR TITLE
fix: reject execution requests with empty data

### DIFF
--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -504,6 +504,12 @@ export function deserializeExecutionRequests(serialized: ExecutionRequestsRpc): 
 
     const requests = prefixedRequests.slice(2);
 
+    if (requests.length === 0) {
+      throw Error(
+        `Request with empty data must be excluded from execution requests currentRequestType=${currentRequestType}`
+      );
+    }
+
     if (prevRequestType !== undefined && prevRequestType >= currentRequestType) {
       throw Error(
         `Current request type must be larger than previous request type prevRequestType=${prevRequestType} currentRequestType=${currentRequestType}`

--- a/packages/beacon-node/test/unit/execution/engine/types.test.ts
+++ b/packages/beacon-node/test/unit/execution/engine/types.test.ts
@@ -127,5 +127,11 @@ describe("execution / engine / types", () => {
 
       expect(() => deserializeExecutionRequests(serializedWrongPrefix)).toThrow();
     });
+
+    it("should throw an error if execution request has no data", () => {
+      const serializedNoData = [serializedRequests[0], "0x01", serializedRequests[2]];
+
+      expect(() => deserializeExecutionRequests(serializedNoData)).toThrow();
+    });
   });
 });


### PR DESCRIPTION
The specification of [engine_getPayloadV4](https://github.com/ethereum/execution-apis/blob/40088597b8b4f48c45184da002e27ffc3c37641f/src/engine/prague.md?plain=1#L82) says execution requests with empty data must be excluded. 

For example, if there is no deposit request but withdrawals and consolidations to be sent, then the execution requests array must be 
```
["0x01......", "0x02....."]
```
instead of 
```
["0x00", "0x01....", "0x02....."]
```

This PR add a check to reject any execution request with just the execution type and no empty data
