### PR TITLE
fix: set FULU_FORK_EPOCH to Infinity in sepolia network config

### DIFF
--- a/packages/config/src/chainConfig/networks/sepolia.ts
+++ b/packages/config/src/chainConfig/networks/sepolia.ts
@@ -38,7 +38,7 @@ export const sepoliaChainConfig: ChainConfig = {
   ELECTRA_FORK_EPOCH: 222464,
   // Fulu
   FULU_FORK_VERSION: b("0x90000075"),
-  FULU_FORK_EPOCH: 222464,
+  FULU_FORK_EPOCH: Infinity,
 
   // Deposit contract
   // ---------------------------------------------------------------


### PR DESCRIPTION
We accidentally scheduled fulu on sepolia in https://github.com/ChainSafe/lodestar/pull/7479, it uses the same fork epoch as electra. This means our unstable branch is not able to sync the network right now.