### PR TITLE
chore: log error due to execution payload in `verifyBlocksInEpoch`

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -194,6 +194,8 @@ export async function verifyBlocksInEpoch(
           numBlobs,
         });
       }
+    } else {
+      this.logger.verbose("Block executions aborted due to execution payload", segmentExecStatus.execAborted.execError);
     }
 
     return {postStates, dataAvailabilityStatuses, proposerBalanceDeltas, segmentExecStatus, availableBlockInputs};

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -195,7 +195,11 @@ export async function verifyBlocksInEpoch(
         });
       }
     } else {
-      this.logger.verbose("Block executions aborted due to execution payload", segmentExecStatus.execAborted.execError);
+      this.logger.verbose(
+        "Block verification aborted due to execution payload",
+        {},
+        segmentExecStatus.execAborted.execError
+      );
     }
 
     return {postStates, dataAvailabilityStatuses, proposerBalanceDeltas, segmentExecStatus, availableBlockInputs};


### PR DESCRIPTION
Cherry picked from #7511 since the PR is still undergoing testings.


`verifyBlocksInEpoch()` calls `verifyBlockExecutionPayload()` and the latter function returns `BlockError` in the event there is issue verifying execution payload. However this error is swallowed and not logged anywhere.

Add verbose log to expose this error