### PR TITLE
feat: holesky-resuce - get persisted checkpoint state api

### DIFF
--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -247,7 +247,7 @@ export type Endpoints = {
   getPersistedCheckpointState: Endpoint<
     "GET",
     {
-      /** The checkpoint in `<root>:<epoch>` format to be returned instead of the last safe checkpoint state */
+      /** The checkpoint in `<root>:<epoch>` format to be returned instead of the latest safe checkpoint state */
       checkpointId?: string;
     },
     {query: {checkpoint_id?: string}},

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -1,6 +1,6 @@
-import {ContainerType, ValueOf} from "@chainsafe/ssz";
+import {ContainerType, Type, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {Epoch, RootHex, Slot, ssz} from "@lodestar/types";
+import {BeaconState, Epoch, RootHex, Slot, ssz} from "@lodestar/types";
 import {
   ArrayOf,
   EmptyArgs,
@@ -11,8 +11,10 @@ import {
   EmptyResponseCodec,
   EmptyResponseData,
   JsonOnlyResponseCodec,
+  WithVersion,
 } from "../../utils/codecs.js";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
+import {VersionCodec, VersionMeta} from "../../utils/metadata.js";
 import {StateArgs} from "./beacon/state.js";
 import {FilterGetPeers, NodePeer, PeerDirection, PeerState} from "./node.js";
 
@@ -242,6 +244,15 @@ export type Endpoints = {
     EmptyMeta
   >;
 
+  getPersistedCheckpointState: Endpoint<
+    // ⏎
+    "GET",
+    {checkpointId?: string},
+    {params: {checkpoint_id?: string}},
+    BeaconState,
+    VersionMeta
+  >;
+
   /** Dump Discv5 Kad values */
   discv5GetKadValues: Endpoint<
     // ⏎
@@ -406,6 +417,25 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       resp: {
         data: HistoricalSummariesResponseType,
         meta: EmptyMetaCodec,
+      },
+    },
+    getPersistedCheckpointState: {
+      url: "/eth/v1/lodestar/persisted_checkpoint_state/{checkpoint_id}",
+      method: "GET",
+      req: {
+        writeReq: ({checkpointId}) => ({params: {checkpoint_id: checkpointId}}),
+        parseReq: ({params}) => ({checkpointId: params.checkpoint_id}),
+        schema: {
+          params: {checkpoint_id: Schema.String},
+        },
+      },
+      resp: {
+        data: WithVersion((fork) => ssz[fork].BeaconState as Type<BeaconState>),
+        meta: VersionCodec,
+      },
+      init: {
+        // Default timeout is not sufficient to download state
+        timeoutMs: 5 * 60 * 1000,
       },
     },
     discv5GetKadValues: {

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -245,10 +245,12 @@ export type Endpoints = {
   >;
 
   getPersistedCheckpointState: Endpoint<
-    // ⏎
     "GET",
-    {checkpointId?: string},
-    {params: {checkpoint_id?: string}},
+    {
+      /** The checkpoint in `<root>:<epoch>` format to be returned instead of the last safe checkpoint state */
+      checkpointId?: string;
+    },
+    {query: {checkpoint_id?: string}},
     BeaconState,
     VersionMeta
   >;
@@ -420,13 +422,13 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       },
     },
     getPersistedCheckpointState: {
-      url: "/eth/v1/lodestar/persisted_checkpoint_state/{checkpoint_id}",
+      url: "/eth/v1/lodestar/persisted_checkpoint_state",
       method: "GET",
       req: {
-        writeReq: ({checkpointId}) => ({params: {checkpoint_id: checkpointId}}),
-        parseReq: ({params}) => ({checkpointId: params.checkpoint_id}),
+        writeReq: ({checkpointId}) => ({query: {checkpoint_id: checkpointId}}),
+        parseReq: ({query}) => ({checkpointId: query.checkpoint_id}),
         schema: {
-          params: {checkpoint_id: Schema.String},
+          query: {checkpoint_id: Schema.String},
         },
       },
       resp: {

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -7,12 +7,14 @@ import {ChainForkConfig} from "@lodestar/config";
 import {Repository} from "@lodestar/db";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {BeaconStateCapella, getLatestWeakSubjectivityCheckpointEpoch, loadState} from "@lodestar/state-transition";
-import {ssz} from "@lodestar/types";
-import {toHex, toRootHex} from "@lodestar/utils";
+import {Epoch, RootHex, ssz} from "@lodestar/types";
+import {Checkpoint} from "@lodestar/types/phase0";
+import {fromHex, toHex, toRootHex} from "@lodestar/utils";
 import {BeaconChain} from "../../../chain/index.js";
 import {QueuedStateRegenerator, RegenRequest} from "../../../chain/regen/index.js";
 import {IBeaconDb} from "../../../db/interface.js";
 import {GossipType} from "../../../network/index.js";
+import {getStateSlotFromBytes} from "../../../util/multifork.js";
 import {profileNodeJS, writeHeapSnapshot} from "../../../util/profile.js";
 import {getStateResponseWithRegen} from "../beacon/state/utils.js";
 import {ApiModules} from "../types.js";
@@ -212,6 +214,23 @@ export function getLodestarApi({
         },
       };
     },
+
+    // the optional checkpoint is in root:epoch format
+    async getPersistedCheckpointState({checkpointId}) {
+      const checkpoint = checkpointId ? getCheckpointFromArg(checkpointId) : undefined;
+      const stateBytes = await chain.getPersistedCheckpointState(checkpoint);
+      if (stateBytes === null) {
+        throw new Error(`Checkpoint state not found for id ${checkpointId}`);
+      }
+
+      const slot = getStateSlotFromBytes(stateBytes);
+      return {
+        data: stateBytes,
+        meta: {
+          version: config.getForkName(slot),
+        },
+      };
+    },
   };
 }
 
@@ -239,6 +258,19 @@ function regenRequestToJson(config: ChainForkConfig, regenRequest: RegenRequest)
         root: regenRequest.args[0],
       };
   }
+}
+
+/**
+ * Extract a checkpoint from a string in the format `rootHex:epoch`.
+ * TODO: dedup to cli package
+ */
+export function getCheckpointFromArg(checkpointStr: string): Checkpoint {
+  const checkpointRegex = /^(?:0x)?([0-9a-f]{64}):([0-9]+)$/;
+  const match = checkpointRegex.exec(checkpointStr.toLowerCase());
+  if (!match) {
+    throw new Error(`Could not parse checkpoint string: ${checkpointStr}`);
+  }
+  return {root: fromHex(match[1]), epoch: parseInt(match[2])};
 }
 
 function stringifyKeys(keys: (Uint8Array | number | string)[]): string[] {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -98,11 +98,13 @@ import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
 import {SeenBlockAttesters} from "./seenCache/seenBlockAttesters.js";
 import {ShufflingCache} from "./shufflingCache.js";
 import {BlockStateCacheImpl} from "./stateCache/blockStateCacheImpl.js";
-import {DbCPStateDatastore} from "./stateCache/datastore/db.js";
+import {DbCPStateDatastore, checkpointToDatastoreKey} from "./stateCache/datastore/db.js";
 import {FileCPStateDatastore} from "./stateCache/datastore/file.js";
+import {CPStateDatastore} from "./stateCache/datastore/types.js";
 import {FIFOBlockStateCache} from "./stateCache/fifoBlockStateCache.js";
 import {InMemoryCheckpointStateCache} from "./stateCache/inMemoryCheckpointsCache.js";
 import {PersistentCheckpointStateCache} from "./stateCache/persistentCheckpointsCache.js";
+import {CheckpointStateCache} from "./stateCache/types.js";
 
 /**
  * Arbitrary constants, blobs and payloads should be consumed immediately in the same slot
@@ -177,6 +179,8 @@ export class BeaconChain implements IBeaconChain {
   protected readonly blockProcessor: BlockProcessor;
   protected readonly db: IBeaconDb;
   private readonly archiver: Archiver;
+  // this is only available if nHistoricalStates is enabled
+  private readonly cpStateDatastore?: CPStateDatastore;
   private abortController = new AbortController();
   private processShutdownCallback: ProcessShutdownCallback;
 
@@ -299,23 +303,26 @@ export class BeaconChain implements IBeaconChain {
     this.bufferPool = this.opts.nHistoricalStates
       ? new BufferPool(anchorState.type.tree_serializedSize(anchorState.node), metrics)
       : null;
-    const checkpointStateCache = this.opts.nHistoricalStates
-      ? new PersistentCheckpointStateCache(
-          {
-            metrics,
-            logger,
-            clock,
-            blockStateCache,
-            bufferPool: this.bufferPool,
-            datastore: fileDataStore
-              ? // debug option if we want to investigate any issues with the DB
-                new FileCPStateDatastore(dataDir)
-              : // production option
-                new DbCPStateDatastore(this.db),
-          },
-          this.opts
-        )
-      : new InMemoryCheckpointStateCache({metrics});
+
+    let checkpointStateCache: CheckpointStateCache;
+    this.cpStateDatastore = undefined;
+    if (this.opts.nHistoricalStates) {
+      this.cpStateDatastore = fileDataStore ? new FileCPStateDatastore(dataDir) : new DbCPStateDatastore(this.db);
+      checkpointStateCache = new PersistentCheckpointStateCache(
+        {
+          metrics,
+          logger,
+          clock,
+          blockStateCache,
+          bufferPool: this.bufferPool,
+          datastore: this.cpStateDatastore,
+        },
+        this.opts
+      );
+    } else {
+      checkpointStateCache = new InMemoryCheckpointStateCache({metrics});
+    }
+
     const {checkpoint} = computeAnchorCheckpoint(config, anchorState);
     blockStateCache.add(cachedState);
     blockStateCache.setHeadState(cachedState);
@@ -558,6 +565,20 @@ export class BeaconChain implements IBeaconChain {
 
     const data = await this.db.stateArchive.getByRoot(fromHex(stateRoot));
     return data && {state: data, executionOptimistic: false, finalized: true};
+  }
+
+  async getPersistedCheckpointState(checkpoint?: phase0.Checkpoint): Promise<Uint8Array | null> {
+    if (!this.cpStateDatastore) {
+      throw new Error("n-historical-state flag is not enabled");
+    }
+
+    if (checkpoint == null) {
+      // return the last safe checkpoint state by default
+      return this.cpStateDatastore.readLatestSafe();
+    }
+
+    const persistedKey = checkpointToDatastoreKey(checkpoint);
+    return this.cpStateDatastore.read(persistedKey);
   }
 
   getStateByCheckpoint(

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -164,6 +164,8 @@ export interface IBeaconChain {
     stateRoot: RootHex,
     opts?: StateGetOpts
   ): Promise<{state: BeaconStateAllForks; executionOptimistic: boolean; finalized: boolean} | null>;
+  /** Return serialized bytes of a persisted checkpoint state */
+  getPersistedCheckpointState(checkpoint?: phase0.Checkpoint): Promise<Uint8Array | null>;
   /** Returns a cached state by checkpoint */
   getStateByCheckpoint(
     checkpoint: CheckpointWithHex


### PR DESCRIPTION
**Motivation**

- implement an api to get a node synced asap

**Description**

- new api: `eth/v1/lodestar/persisted_checkpoint_state` to return a state based on an optional `rootHex:epoch` param
- if not specified, return the latest safe checkpoint state
- a node need to specify `--checkpointState` from the previous PR #7509

**Test**
- [x] `curl -H "Accept: application/octet-stream"  http://localhost:9596/eth/v1/lodestar/persisted_checkpoint_state -o latest_checkpoint_state.ssz`
- [x] `curl -H "Accept: application/octet-stream"  http://localhost:9596/eth/v1/lodestar/persisted_checkpoint_state?checkpoint_id=0x4f4d4c1b81141fe77a4a1c6a376dbe64ed9baa8f123664195e4f710c9fc4238d:118936 -o state_epoch_118936.ssz`