### PR TITLE
fix: ensure we only receive SSZ checkpoint states if REST API is queried

### DIFF
--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -107,7 +107,7 @@ export async function initBeaconState(
   db: IBeaconDb,
   logger: Logger,
   signal: AbortSignal
-): Promise<{anchorState: BeaconStateAllForks; isFinalized: boolean ; wsCheckpoint?: Checkpoint}> {
+): Promise<{anchorState: BeaconStateAllForks; isFinalized: boolean; wsCheckpoint?: Checkpoint}> {
   if (args.forceCheckpointSync && !(args.checkpointState || args.checkpointSyncUrl)) {
     throw new Error("Forced checkpoint sync without specifying a checkpointState or checkpointSyncUrl");
   }
@@ -168,10 +168,12 @@ export async function initBeaconState(
   if (args.checkpointState || args.lastPersistedCheckpointState) {
     let localCpState: Uint8Array | null = null;
     isFinalized = false;
-    // prioritize lastPersistedCheckpointState over checkpointState
-    if (args.lastPersistedCheckpointState) {
+    // prioritize lastPersistedCheckpointState over checkpointState, unless forceCheckpointSync is set
+    if (args.lastPersistedCheckpointState && !args.forceCheckpointSync) {
       // find the last persisted checkpoint state to load
-      const cpDataStore = args["chain.nHistoricalStatesFileDataStore"] ? new FileCPStateDatastore(dataDir) : new DbCPStateDatastore(db);
+      const cpDataStore = args["chain.nHistoricalStatesFileDataStore"]
+        ? new FileCPStateDatastore(dataDir)
+        : new DbCPStateDatastore(db);
       logger.verbose(`Finding last persisted checkpoint state from ${cpDataStore.constructor.name}`);
       localCpState = await cpDataStore.readLatestSafe();
       if (localCpState === null) {
@@ -183,9 +185,11 @@ export async function initBeaconState(
 
     if (localCpState == null && args.checkpointState) {
       // local file checkpoint state specified via wssCheckpoint could be loaded here
-      logger.info("Finding local checkpoint state from file", {path: args.checkpointState});
+      logger.info("Fetching checkpoint state", {checkpointState: args.checkpointState});
       localCpState = await downloadOrLoadFile(args.checkpointState);
-      logger.info("Found local checkpoint state from file", {path: args.checkpointState, size: formatBytes(localCpState.length)});
+      logger.info("Fetched checkpoint state", {
+        size: formatBytes(localCpState.length),
+      });
     }
 
     if (localCpState !== null) {
@@ -205,7 +209,13 @@ export async function initBeaconState(
       const lastProcessedSlot = stateAndCp.anchorState.latestBlockHeader.slot;
       const {epoch, root} = computeAnchorCheckpoint(chainForkConfig, stateAndCp.anchorState).checkpoint;
 
-      logger.info("Loaded checkpoint state", {stateSlot: stateAndCp.anchorState.slot, lastProcessedSlot, root: toRootHex(root), epoch, isFinalized});
+      logger.info("Loaded checkpoint state", {
+        stateSlot: stateAndCp.anchorState.slot,
+        lastProcessedSlot,
+        root: toRootHex(root),
+        epoch,
+        isFinalized,
+      });
 
       return {...stateAndCp, isFinalized};
     }
@@ -229,7 +239,12 @@ export async function initBeaconState(
     );
 
     const {epoch, root} = computeAnchorCheckpoint(chainForkConfig, stateAndCp.anchorState).checkpoint;
-    logger.info("Loaded downloaded state from checkpointSyncUrl", {stateSlot: stateAndCp.anchorState.slot, root: toRootHex(root), epoch, isFinalized});
+    logger.info("Loaded downloaded state from checkpointSyncUrl", {
+      stateSlot: stateAndCp.anchorState.slot,
+      root: toRootHex(root),
+      epoch,
+      isFinalized,
+    });
 
     return {...stateAndCp, isFinalized};
   }
@@ -237,20 +252,24 @@ export async function initBeaconState(
   const genesisStateFile = args.genesisStateFile || getGenesisFileUrl(args.network || defaultNetwork);
   if (genesisStateFile && !args.forceGenesis) {
     isFinalized = true;
-    logger.info("Fetching genesis state", {isFinalized, genesisStateFile});
+    logger.info("Fetching genesis state", {genesisStateFile, isFinalized});
     let stateBytes = await downloadOrLoadFile(genesisStateFile);
     logger.info("Fetched genesis state", {size: formatBytes(stateBytes.length)});
     // Convert to `Uint8Array` to avoid unexpected behavior such as `Buffer.prototype.slice` not copying memory
     stateBytes = new Uint8Array(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength);
     const anchorState = getStateTypeFromBytes(chainForkConfig, stateBytes).deserializeToViewDU(stateBytes);
-    logger.info("Loaded genesis state", {stateSlot: anchorState.slot, root: toRootHex(anchorState.hashTreeRoot()), isFinalized});
+    logger.info("Loaded genesis state", {
+      stateSlot: anchorState.slot,
+      root: toRootHex(anchorState.hashTreeRoot()),
+      isFinalized,
+    });
     const config = createBeaconConfig(chainForkConfig, anchorState.genesisValidatorsRoot);
     const wssCheck = isWithinWeakSubjectivityPeriod(config, anchorState, getCheckpointFromState(anchorState));
     await checkAndPersistAnchorState(config, db, logger, anchorState, stateBytes, {
       isWithinWeakSubjectivityPeriod: wssCheck,
       isCheckpointState: true,
     });
-    return {anchorState , isFinalized};
+    return {anchorState, isFinalized};
   }
 
   // Only place we will not bother checking isWithinWeakSubjectivityPeriod as forceGenesis passed by user

--- a/packages/cli/src/util/file.ts
+++ b/packages/cli/src/util/file.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import stream from "node:stream";
 import {promisify} from "node:util";
+import {HttpHeader, MediaType} from "@lodestar/api";
 import got from "got";
 import yaml from "js-yaml";
 const {load, dump, FAILSAFE_SCHEMA, Type} = yaml;
@@ -138,7 +139,11 @@ export async function downloadFile(pathDest: string, url: string): Promise<void>
  */
 export async function downloadOrLoadFile(pathOrUrl: string): Promise<Uint8Array> {
   if (isUrl(pathOrUrl)) {
-    const res = await got.get(pathOrUrl, {encoding: "binary"});
+    const res = await got.get(pathOrUrl, {
+      encoding: "binary",
+      // Ensure we only receive SSZ responses if REST API is queried
+      headers: {[HttpHeader.Accept]: MediaType.ssz},
+    });
     return res.rawBody;
   }
   return fs.promises.readFile(pathOrUrl);


### PR DESCRIPTION
We have added a new api in https://github.com/ChainSafe/lodestar/pull/7541 to serve latest checkpoint states. However the problem is that `--checkpointState` right now assumes that we receive a ssz-serialized state bytes, so we also need to ensure that the REST API only returns SSZ responses by applying the correct Accept header.


This PR includes the following changes
- Ensure we only receive SSZ responses if REST API is queried
- Consider `--forceCheckpointSync` flag and if set always prioritze remote checkpoint from `--checkpointState` over latest safe checkpoint in db
- Minor tweaks to logs to make it easier to understand what the node is doing
- Misc formatting changes