### PR TITLE
fix: use correct subnet when validating gossip attestations

### DIFF
--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -86,6 +86,7 @@ export type GossipAttestation = {
   attSlot: Slot;
   // for indexed gossip queue we have attDataBase64
   attDataBase64: SeenAttDataKey;
+  subnet: SubnetID;
 };
 
 export type Step0Result = AttestationValidationResult & {
@@ -103,7 +104,6 @@ export async function validateGossipAttestationsSameAttData(
   fork: ForkName,
   chain: IBeaconChain,
   attestationOrBytesArr: GossipAttestation[],
-  subnet: SubnetID,
   // for unit test, consumers do not need to pass this
   step0ValidationFn = validateAttestationNoSignatureCheck
 ): Promise<BatchResult> {
@@ -117,6 +117,7 @@ export async function validateGossipAttestationsSameAttData(
   // for unseen AttestationData, the 1st call will be cached and the rest will be fast
   const step0ResultOrErrors: Result<Step0Result>[] = [];
   for (const attestationOrBytes of attestationOrBytesArr) {
+    const {subnet} = attestationOrBytes;
     const resultOrError = await wrapError(step0ValidationFn(fork, chain, attestationOrBytes, subnet));
     step0ResultOrErrors.push(resultOrError);
   }

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -615,18 +615,18 @@ function getBatchHandlers(modules: ValidatorFnsModules, options: GossipHandlerOp
         return results;
       }
       // all attestations should have same attestation data as filtered by network processor
-      const {subnet, fork} = gossipHandlerParams[0].topic;
+      const {fork} = gossipHandlerParams[0].topic;
       const validationParams = gossipHandlerParams.map((param) => ({
         attestation: null,
         serializedData: param.gossipData.serializedData,
         attSlot: param.gossipData.msgSlot,
         attDataBase64: param.gossipData.indexed,
+        subnet: param.topic.subnet,
       })) as GossipAttestation[];
       const {results: validationResults, batchableBls} = await validateGossipAttestationsSameAttData(
         fork,
         chain,
-        validationParams,
-        subnet
+        validationParams
       );
       for (const [i, validationResult] of validationResults.entries()) {
         if (validationResult.err) {
@@ -647,6 +647,7 @@ function getBatchHandlers(modules: ValidatorFnsModules, options: GossipHandlerOp
         } = validationResult.result;
         metrics?.registerGossipUnaggregatedAttestation(gossipHandlerParams[i].seenTimestampSec, indexedAttestation);
 
+        const {subnet} = validationResult.result;
         try {
           // Node may be subscribe to extra subnets (long-lived random subnets). For those, validate the messages
           // but don't add to attestation pool, to save CPU and RAM

--- a/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
+++ b/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
@@ -29,9 +29,8 @@ export function getGossipValidatorBatchFn(
   const {logger, metrics} = modules;
 
   return async function gossipValidatorBatchFn(messageInfos: GossipMessageInfo[]) {
-    // all messageInfos have same topic
-    const {topic} = messageInfos[0];
-    const type = topic.type;
+    // all messageInfos have same topic type
+    const type = messageInfos[0].topic.type;
     try {
       const results = await (gossipHandlers[type] as BatchGossipHandlerFn)(
         messageInfos.map((messageInfo) => ({
@@ -40,7 +39,7 @@ export function getGossipValidatorBatchFn(
             msgSlot: messageInfo.msgSlot,
             indexed: messageInfo.indexed,
           },
-          topic,
+          topic: messageInfo.topic,
           peerIdStr: messageInfo.propagationSource,
           seenTimestampSec: messageInfo.seenTimestampSec,
         }))

--- a/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
+++ b/packages/beacon-node/test/perf/chain/validation/attestation.test.ts
@@ -49,6 +49,7 @@ describe("validate gossip attestation", () => {
         serializedData,
         attSlot,
         attDataBase64: getAttDataFromAttestationSerialized(serializedData) as string,
+        subnet: subnet0,
       };
     });
 
@@ -56,7 +57,7 @@ describe("validate gossip attestation", () => {
       id: `batch validate gossip attestation - vc ${vc} - chunk ${chunkSize}`,
       beforeEach: () => chain.seenAttesters["validatorIndexesByEpoch"].clear(),
       fn: async () => {
-        await validateGossipAttestationsSameAttData(fork, chain, attestationOrBytesArr, subnet0);
+        await validateGossipAttestationsSameAttData(fork, chain, attestationOrBytesArr);
       },
       runsFactor: chunkSize,
     });

--- a/packages/beacon-node/test/unit/chain/validation/attestation/validateAttestation.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation/validateAttestation.test.ts
@@ -54,8 +54,7 @@ describe("validateAttestation", () => {
     const {chain, subnet} = getValidData();
     await expectGossipError(
       chain,
-      {attestation: null, serializedData: Buffer.alloc(0), attSlot: 0, attDataBase64: "invalid"},
-      subnet,
+      {attestation: null, serializedData: Buffer.alloc(0), attSlot: 0, attDataBase64: "invalid", subnet},
       GossipErrorCode.INVALID_SERIALIZED_BYTES_ERROR_CODE
     );
   });
@@ -75,8 +74,8 @@ describe("validateAttestation", () => {
         serializedData,
         attSlot: attestation.data.slot,
         attDataBase64: getAttDataFromAttestationSerialized(serializedData) as string,
+        subnet,
       },
-      subnet,
       AttestationErrorCode.BAD_TARGET_EPOCH
     );
   });
@@ -94,8 +93,8 @@ describe("validateAttestation", () => {
         serializedData,
         attSlot: attestation.data.slot,
         attDataBase64: getAttDataFromAttestationSerialized(serializedData) as string,
+        subnet,
       },
-      subnet,
       AttestationErrorCode.PAST_SLOT
     );
   });
@@ -113,8 +112,8 @@ describe("validateAttestation", () => {
         serializedData,
         attSlot: attestation.data.slot,
         attDataBase64: getAttDataFromAttestationSerialized(serializedData) as string,
+        subnet,
       },
-      subnet,
       AttestationErrorCode.FUTURE_SLOT
     );
   });
@@ -138,8 +137,8 @@ describe("validateAttestation", () => {
         serializedData,
         attSlot: attestation.data.slot,
         attDataBase64: getAttDataFromAttestationSerialized(serializedData) as string,
+        subnet,
       },
-      subnet,
       AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
     );
   });
@@ -158,8 +157,8 @@ describe("validateAttestation", () => {
         serializedData,
         attSlot: attestation.data.slot,
         attDataBase64: getAttDataFromAttestationSerialized(serializedData) as string,
+        subnet,
       },
-      subnet,
       AttestationErrorCode.NOT_EXACTLY_ONE_AGGREGATION_BIT_SET
     );
   });
@@ -182,8 +181,8 @@ describe("validateAttestation", () => {
         serializedData,
         attSlot: attestation.data.slot,
         attDataBase64: getAttDataFromAttestationSerialized(serializedData) as string,
+        subnet,
       },
-      subnet,
       AttestationErrorCode.UNKNOWN_OR_PREFINALIZED_BEACON_BLOCK_ROOT
     );
   });
@@ -202,8 +201,8 @@ describe("validateAttestation", () => {
         serializedData,
         attSlot: attestation.data.slot,
         attDataBase64: getAttDataFromAttestationSerialized(serializedData) as string,
+        subnet,
       },
-      subnet,
       AttestationErrorCode.INVALID_TARGET_ROOT
     );
   });
@@ -229,8 +228,8 @@ describe("validateAttestation", () => {
         serializedData,
         attSlot: attestation.data.slot,
         attDataBase64: getAttDataFromAttestationSerialized(serializedData) as string,
+        subnet,
       },
-      subnet,
       AttestationErrorCode.WRONG_NUMBER_OF_AGGREGATION_BITS
     );
   });
@@ -248,8 +247,8 @@ describe("validateAttestation", () => {
         serializedData,
         attSlot: attestation.data.slot,
         attDataBase64: getAttDataFromAttestationSerialized(serializedData) as string,
+        subnet: invalidSubnet,
       },
-      invalidSubnet,
       AttestationErrorCode.INVALID_SUBNET_ID
     );
   });
@@ -268,8 +267,8 @@ describe("validateAttestation", () => {
         serializedData,
         attSlot: attestation.data.slot,
         attDataBase64: getAttDataFromAttestationSerialized(serializedData) as string,
+        subnet,
       },
-      subnet,
       AttestationErrorCode.ATTESTATION_ALREADY_KNOWN
     );
   });
@@ -290,8 +289,8 @@ describe("validateAttestation", () => {
         serializedData,
         attSlot: attestation.data.slot,
         attDataBase64: getAttDataFromAttestationSerialized(serializedData) as string,
+        subnet,
       },
-      subnet,
       AttestationErrorCode.INVALID_SIGNATURE
     );
   });
@@ -309,11 +308,10 @@ describe("validateAttestation", () => {
   async function expectGossipError(
     chain: IBeaconChain,
     attestationOrBytes: GossipAttestation,
-    subnet: SubnetID,
     errorCode: string
   ): Promise<void> {
     const fork = chain.config.getForkName(stateSlot);
-    const {results} = await validateGossipAttestationsSameAttData(fork, chain, [attestationOrBytes], subnet);
+    const {results} = await validateGossipAttestationsSameAttData(fork, chain, [attestationOrBytes]);
     expect(results.length).toEqual(1);
     expect((results[0].err as LodestarError<{code: string}>).type.code).toEqual(errorCode);
   }

--- a/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
@@ -113,7 +113,7 @@ describe("validateGossipAttestationsSameAttData", () => {
         callIndex++;
         return result;
       };
-      await validateGossipAttestationsSameAttData(ForkName.phase0, chain, new Array(5).fill({}), 0, phase0ValidationFn);
+      await validateGossipAttestationsSameAttData(ForkName.phase0, chain, new Array(5).fill({}), phase0ValidationFn);
       for (let validatorIndex = 0; validatorIndex < phase0Result.length; validatorIndex++) {
         if (seenAttesters.includes(validatorIndex)) {
           expect(chain.seenAttesters.isKnown(0, validatorIndex)).toBe(true);


### PR DESCRIPTION
Apply same fix from https://github.com/ChainSafe/lodestar/pull/7543 to unstable branch