### PR TITLE
feat: track gossip attestation ignore/reject reasons

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -2,7 +2,7 @@ import {EpochTransitionStep, StateCloneSource, StateHashTreeRootSource} from "@l
 import {BeaconState} from "@lodestar/types";
 import {BlobsSource, BlockSource} from "../../chain/blocks/types.js";
 import {JobQueueItemType} from "../../chain/bls/index.js";
-import {BlockErrorCode} from "../../chain/errors/index.js";
+import {AttestationErrorCode, BlockErrorCode} from "../../chain/errors/index.js";
 import {InsertOutcome} from "../../chain/opPools/types.js";
 import {RegenCaller, RegenFnName} from "../../chain/regen/interface.js";
 import {ReprocessStatus} from "../../chain/reprocess.js";
@@ -115,6 +115,16 @@ export function createLodestarMetrics(
         name: "lodestar_gossip_validation_error_total",
         help: "Count of total gossip validation errors detailed",
         labelNames: ["topic", "error"],
+      }),
+      gossipAttestationIgnoreByReason: register.gauge<{reason: AttestationErrorCode}>({
+        name: "lodestar_gossip_attestation_ignore_by_reason_total",
+        help: "Count of total gossip attestation ignore by reason",
+        labelNames: ["reason"],
+      }),
+      gossipAttestationRejectByReason: register.gauge<{reason: AttestationErrorCode}>({
+        name: "lodestar_gossip_attestation_reject_by_reason_total",
+        help: "Count of total gossip attestation reject by reason",
+        labelNames: ["reason"],
       }),
       executeWorkCalls: register.gauge({
         name: "lodestar_network_processor_execute_work_calls_total",

--- a/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
+++ b/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
@@ -1,6 +1,6 @@
 import {TopicValidatorResult} from "@libp2p/interface";
 import {ChainForkConfig} from "@lodestar/config";
-import {Logger} from "@lodestar/utils";
+import {GaugeExtra, Logger} from "@lodestar/utils";
 import {AttestationError, GossipAction, GossipActionError} from "../../chain/errors/index.js";
 import {Metrics} from "../../metrics/index.js";
 import {
@@ -8,6 +8,7 @@ import {
   GossipHandlerFn,
   GossipHandlers,
   GossipMessageInfo,
+  GossipType,
   GossipValidatorBatchFn,
   GossipValidatorFn,
 } from "../gossip/interface.js";
@@ -60,10 +61,13 @@ export function getGossipValidatorBatchFn(
         switch (e.action) {
           case GossipAction.IGNORE:
             metrics?.networkProcessor.gossipValidationIgnore.inc({topic: type});
+            // only beacon_attestation topic is validated in batch
+            metrics?.networkProcessor.gossipAttestationIgnoreByReason.inc({reason: e.type.code});
             return TopicValidatorResult.Ignore;
-
           case GossipAction.REJECT:
             metrics?.networkProcessor.gossipValidationReject.inc({topic: type});
+            // only beacon_attestation topic is validated in batch
+            metrics?.networkProcessor.gossipAttestationRejectByReason.inc({reason: e.type.code});
             logger.debug(`Gossip validation ${type} rejected`, {}, e);
             return TopicValidatorResult.Reject;
         }

--- a/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
+++ b/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
@@ -1,6 +1,6 @@
 import {TopicValidatorResult} from "@libp2p/interface";
 import {ChainForkConfig} from "@lodestar/config";
-import {GaugeExtra, Logger} from "@lodestar/utils";
+import {Logger} from "@lodestar/utils";
 import {AttestationError, GossipAction, GossipActionError} from "../../chain/errors/index.js";
 import {Metrics} from "../../metrics/index.js";
 import {
@@ -8,7 +8,6 @@ import {
   GossipHandlerFn,
   GossipHandlers,
   GossipMessageInfo,
-  GossipType,
   GossipValidatorBatchFn,
   GossipValidatorFn,
 } from "../gossip/interface.js";


### PR DESCRIPTION
**Motivation**

we throw different errors when validating gossip but did not collect it in metrics, see https://github.com/ChainSafe/lodestar/issues/7546#issuecomment-2712294165

**Description**

- new metrics to collect gossip attestation errors
- for other topics, we already did it
- need another PR to capture this in Grafana once this is merged