### PR TITLE
feat: track oppool insert outcome for api attestation separately

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -125,7 +125,7 @@ export function getBeaconPoolApi({
                 committeeValidatorIndex,
                 committeeSize
               );
-              metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
+              metrics?.opPool.attestationPoolApiInsertOutcome.inc({insertOutcome});
             }
 
             if (isForkPostElectra(fork)) {

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -855,9 +855,14 @@ export function createLodestarMetrics(
         name: "lodestar_oppool_attestation_pool_size",
         help: "Current size of the AttestationPool = total attestations unique by data and slot",
       }),
-      attestationPoolInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
+      attestationPoolGossipInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
         name: "lodestar_attestation_pool_insert_outcome_total",
-        help: "Total number of InsertOutcome as a result of adding an attestation in a pool",
+        help: "Total number of InsertOutcome as a result of adding a gossip attestation in a pool",
+        labelNames: ["insertOutcome"],
+      }),
+      attestationPoolApiInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
+        name: "lodestar_attestation_pool_api_insert_outcome_total",
+        help: "Total number of InsertOutcome as a result of adding an attestation from api in a pool",
         labelNames: ["insertOutcome"],
       }),
       attesterSlashingPoolSize: register.gauge({

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -658,7 +658,7 @@ function getBatchHandlers(modules: ValidatorFnsModules, options: GossipHandlerOp
               committeeValidatorIndex,
               committeeSize
             );
-            metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
+            metrics?.opPool.attestationPoolGossipInsertOutcome.inc({insertOutcome});
           }
         } catch (e) {
           logger.error("Error adding unaggregated attestation to pool", {subnet}, e as Error);


### PR DESCRIPTION
**Motivation**

We want to know when inserting api attestation to oppool, what's the insert outcome? see #7548

**Description**

- clone `lodestar_attestation_pool_insert_outcome_total` to `lodestar_attestation_pool_api_insert_outcome_total` and use it in oppool api
- the old metric is used for gossip attestations only

part of #7548
