### PR TITLE
fix: chain.nHistoricalStatesFileDataStore

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -286,7 +286,7 @@ export class BeaconChain implements IBeaconChain {
     this.pubkey2index = cachedState.epochCtx.pubkey2index;
     this.index2pubkey = cachedState.epochCtx.index2pubkey;
 
-    const fileDataStore = opts.nHistoricalStatesFileDataStore ?? false;
+    const fileDataStore = opts.nHistoricalStatesFileDataStore ?? true;
     const blockStateCache = this.opts.nHistoricalStates
       ? new FIFOBlockStateCache(this.opts, {metrics})
       : new BlockStateCacheImpl({metrics});

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -184,6 +184,7 @@ export class BeaconChain implements IBeaconChain {
     {
       config,
       db,
+      dataDir,
       logger,
       processShutdownCallback,
       clock,
@@ -196,6 +197,7 @@ export class BeaconChain implements IBeaconChain {
     }: {
       config: BeaconConfig;
       db: IBeaconDb;
+      dataDir: string;
       logger: Logger;
       processShutdownCallback: ProcessShutdownCallback;
       /** Used for testing to supply fake clock */
@@ -301,7 +303,7 @@ export class BeaconChain implements IBeaconChain {
             bufferPool: this.bufferPool,
             datastore: fileDataStore
               ? // debug option if we want to investigate any issues with the DB
-                new FileCPStateDatastore()
+                new FileCPStateDatastore(dataDir)
               : // production option
                 new DbCPStateDatastore(this.db),
           },

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -117,7 +117,11 @@ export const defaultChainOptions: IChainOptions = {
   // since this batch attestation work is designed to work with useWorker=true, make this the lowest value
   minSameMessageSignatureSetsToBatch: 2,
   nHistoricalStates: true,
-  nHistoricalStatesFileDataStore: false,
+  // as of Feb 2025, this option turned out to be very useful:
+  //   - it allows to share a persisted checkpoint state to other nodes
+  //   - users can prune the persisted checkpoint state files manually to save disc space
+  //   - it helps debug easier when network is unfinalized
+  nHistoricalStatesFileDataStore: true,
   maxBlockStates: DEFAULT_MAX_BLOCK_STATES,
   maxCPStateEpochsInMemory: DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY,
 };

--- a/packages/beacon-node/src/chain/stateCache/datastore/file.ts
+++ b/packages/beacon-node/src/chain/stateCache/datastore/file.ts
@@ -13,9 +13,10 @@ const CHECKPOINT_FILE_NAME_LENGTH = 82;
 export class FileCPStateDatastore implements CPStateDatastore {
   private readonly folderPath: string;
 
-  constructor(parentDir = ".") {
-    // by default use the beacon folder `/beacon/checkpoint_states`
-    this.folderPath = path.join(parentDir, CHECKPOINT_STATES_FOLDER);
+  constructor(dataDir: string) {
+    // service deployment: `/beacon/checkpoint_states`
+    // docker deployment: `/data/checkpoint_states`
+    this.folderPath = path.join(dataDir, CHECKPOINT_STATES_FOLDER);
   }
 
   async init(): Promise<void> {

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -52,6 +52,7 @@ export type BeaconNodeInitModules = {
   logger: LoggerNode;
   processShutdownCallback: ProcessShutdownCallback;
   peerId: PeerId;
+  dataDir: string;
   peerStoreDir?: string;
   anchorState: BeaconStateAllForks;
   wsCheckpoint?: phase0.Checkpoint;
@@ -149,6 +150,7 @@ export class BeaconNode {
     logger,
     processShutdownCallback,
     peerId,
+    dataDir,
     peerStoreDir,
     anchorState,
     wsCheckpoint,
@@ -224,6 +226,7 @@ export class BeaconNode {
     const chain = new BeaconChain(opts.chain, {
       config,
       clock,
+      dataDir,
       db,
       logger: logger.child({module: LoggerModule.chain}),
       processShutdownCallback,

--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -111,6 +111,7 @@ const forkChoiceTest =
           {
             config: createBeaconConfig(config, state.genesisValidatorsRoot),
             db: getMockedBeaconDb(),
+            dataDir: ".",
             logger,
             processShutdownCallback: () => {},
             clock,

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -94,6 +94,7 @@ export async function getDevBeaconNode(
     logger,
     processShutdownCallback: () => {},
     peerId,
+    dataDir: ".",
     peerStoreDir,
     anchorState,
     wsCheckpoint: opts.wsCheckpoint,

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -86,6 +86,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       logger,
       processShutdownCallback,
       peerId,
+      dataDir: beaconPaths.dataDir,
       peerStoreDir: beaconPaths.peerStoreDir,
       anchorState,
       wsCheckpoint,


### PR DESCRIPTION
**Motivation**

- `chain.nHistoricalStatesFileDataStore: true` does not work in docker. This PR fixes it.

**Description**

- this was from #7525 which was tested in holesky
- turn this option on by default as agreed by @nflaig @philknows 