### PR TITLE
fix: handle getDependentRoot() error when importing block

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -216,15 +216,20 @@ export async function importBlock(
     // Set head state as strong reference
     this.regen.updateHeadState(newHead, postState);
 
-    this.emitter.emit(routes.events.EventType.head, {
-      block: newHead.blockRoot,
-      epochTransition: computeStartSlotAtEpoch(computeEpochAtSlot(newHead.slot)) === newHead.slot,
-      slot: newHead.slot,
-      state: newHead.stateRoot,
-      previousDutyDependentRoot: this.forkChoice.getDependentRoot(newHead, EpochDifference.previous),
-      currentDutyDependentRoot: this.forkChoice.getDependentRoot(newHead, EpochDifference.current),
-      executionOptimistic: isOptimisticBlock(newHead),
-    });
+    try {
+      this.emitter.emit(routes.events.EventType.head, {
+        block: newHead.blockRoot,
+        epochTransition: computeStartSlotAtEpoch(computeEpochAtSlot(newHead.slot)) === newHead.slot,
+        slot: newHead.slot,
+        state: newHead.stateRoot,
+        previousDutyDependentRoot: this.forkChoice.getDependentRoot(newHead, EpochDifference.previous),
+        currentDutyDependentRoot: this.forkChoice.getDependentRoot(newHead, EpochDifference.current),
+        executionOptimistic: isOptimisticBlock(newHead),
+      });
+    } catch (e) {
+      // getDependentRoot() may fail with error: "No block for root" as we can see in holesky non-finality issue
+      this.logger.debug("Error emitting head event", {slot: newHead.slot, root: newHead.blockRoot}, e as Error);
+    }
 
     const delaySec = this.clock.secFromSlot(newHead.slot);
     this.logger.verbose("New chain head", {


### PR DESCRIPTION
**Motivation**

- when emitting head, `forkchoice.getDependentRoot()` may failed with "No block root" error and break the block import process

**Description**

- handle it with `try/catch`, this was picked from `holesky-rescue` branch https://github.com/ChainSafe/lodestar/pull/7501/files#diff-c21a87c055e2b34c02de2fa28ecc52c53837159f567eef5fb22e80ed55827044R229

