### PR TITLE
feat: opPool to allow late api attestations

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -123,7 +123,11 @@ export function getBeaconPoolApi({
                 attestation,
                 attDataRootHex,
                 committeeValidatorIndex,
-                committeeSize
+                committeeSize,
+                // api attestation has high priority, we allow them to be added to pool even when it's late
+                // this is to prevent "No aggregated attestation for slot" issue
+                // see https://github.com/ChainSafe/lodestar/issues/7548
+                true
               );
               metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
             }

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -273,7 +273,9 @@ export function getBeaconPoolApi({
               // Sync committee subnet members are just sequential in the order they appear in SyncCommitteeIndexes array
               const subnet = Math.floor(indexInCommittee / SYNC_COMMITTEE_SUBNET_SIZE);
               const indexInSubcommittee = indexInCommittee % SYNC_COMMITTEE_SUBNET_SIZE;
-              chain.syncCommitteeMessagePool.add(subnet, signature, indexInSubcommittee);
+              // same to api attestation, we allow api SyncCommittee to be added to pool even when it's late
+              // see https://github.com/ChainSafe/lodestar/issues/7548
+              chain.syncCommitteeMessagePool.add(subnet, signature, indexInSubcommittee, true);
 
               // Cheap de-duplication code to avoid using a Set. indexesInCommittee is always sorted
               if (subnets.length === 0 || subnets[subnets.length - 1] !== subnet) {

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -104,6 +104,10 @@ export function getBeaconPoolApi({
     async submitPoolAttestationsV2({signedAttestations}) {
       const seenTimestampSec = Date.now() / 1000;
       const failures: FailureList = [];
+      // api attestation has high priority, we allow them to be added to pool even when it's late
+      // this is to prevent "No aggregated attestation for slot" issue
+      // see https://github.com/ChainSafe/lodestar/issues/7548
+      const priority = true;
 
       await Promise.all(
         signedAttestations.map(async (attestation, i) => {
@@ -124,10 +128,7 @@ export function getBeaconPoolApi({
                 attDataRootHex,
                 committeeValidatorIndex,
                 committeeSize,
-                // api attestation has high priority, we allow them to be added to pool even when it's late
-                // this is to prevent "No aggregated attestation for slot" issue
-                // see https://github.com/ChainSafe/lodestar/issues/7548
-                true
+                priority
               );
               metrics?.opPool.attestationPoolInsertOutcome.inc({insertOutcome});
             }
@@ -268,14 +269,15 @@ export function getBeaconPoolApi({
             // The same validator can appear multiple times in the sync committee. It can appear multiple times per
             // subnet even. First compute on which subnet the signature must be broadcasted to.
             const subnets: number[] = [];
+            // same to api attestation, we allow api SyncCommittee to be added to pool even when it's late
+            // see https://github.com/ChainSafe/lodestar/issues/7548
+            const priority = true;
 
             for (const indexInCommittee of indexesInCommittee) {
               // Sync committee subnet members are just sequential in the order they appear in SyncCommitteeIndexes array
               const subnet = Math.floor(indexInCommittee / SYNC_COMMITTEE_SUBNET_SIZE);
               const indexInSubcommittee = indexInCommittee % SYNC_COMMITTEE_SUBNET_SIZE;
-              // same to api attestation, we allow api SyncCommittee to be added to pool even when it's late
-              // see https://github.com/ChainSafe/lodestar/issues/7548
-              chain.syncCommitteeMessagePool.add(subnet, signature, indexInSubcommittee, true);
+              chain.syncCommitteeMessagePool.add(subnet, signature, indexInSubcommittee, priority);
 
               // Cheap de-duplication code to avoid using a Set. indexesInCommittee is always sorted
               if (subnets.length === 0 || subnets[subnets.length - 1] !== subnet) {

--- a/packages/beacon-node/src/chain/opPools/attestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/attestationPool.ts
@@ -111,7 +111,7 @@ export class AttestationPool {
     attDataRootHex: RootHex,
     committeeValidatorIndex: number,
     committeeSize: number,
-    priority?: boolean,
+    priority?: boolean
   ): InsertOutcome {
     const slot = attestation.data.slot;
     const fork = this.config.getForkName(slot);

--- a/packages/beacon-node/src/chain/opPools/attestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/attestationPool.ts
@@ -110,7 +110,8 @@ export class AttestationPool {
     attestation: SingleAttestation,
     attDataRootHex: RootHex,
     committeeValidatorIndex: number,
-    committeeSize: number
+    committeeSize: number,
+    priority?: boolean,
   ): InsertOutcome {
     const slot = attestation.data.slot;
     const fork = this.config.getForkName(slot);
@@ -121,8 +122,9 @@ export class AttestationPool {
       return InsertOutcome.Old;
     }
 
-    // Reject attestations in the current slot but come to this pool very late
-    if (this.clock.secFromSlot(slot) > this.cutOffSecFromSlot) {
+    // Reject gossip attestations in the current slot but come to this pool very late
+    // for api attestations, we allow them to be added to the pool
+    if (!priority && this.clock.secFromSlot(slot) > this.cutOffSecFromSlot) {
       return InsertOutcome.Late;
     }
 

--- a/packages/beacon-node/src/chain/opPools/syncCommitteeMessagePool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncCommitteeMessagePool.ts
@@ -61,7 +61,12 @@ export class SyncCommitteeMessagePool {
   }
 
   // TODO: indexInSubcommittee: number should be indicesInSyncCommittee
-  add(subnet: SubnetID, signature: altair.SyncCommitteeMessage, indexInSubcommittee: number): InsertOutcome {
+  add(
+    subnet: SubnetID,
+    signature: altair.SyncCommitteeMessage,
+    indexInSubcommittee: number,
+    priority?: boolean
+  ): InsertOutcome {
     const {slot, beaconBlockRoot} = signature;
     const rootHex = toRootHex(beaconBlockRoot);
     const lowestPermissibleSlot = this.lowestPermissibleSlot;
@@ -72,7 +77,7 @@ export class SyncCommitteeMessagePool {
     }
 
     // validator gets SyncCommitteeContribution at 2/3 of slot, it's no use to preaggregate later than that time
-    if (this.clock.secFromSlot(slot) > this.cutOffSecFromSlot) {
+    if (!priority && this.clock.secFromSlot(slot) > this.cutOffSecFromSlot) {
       return InsertOutcome.Late;
     }
 


### PR DESCRIPTION
**Motivation**

- api attestations could be late but we should allow them to be added to OpPool in that case see https://github.com/ChainSafe/lodestar/issues/7548#issuecomment-2713221164

**Description**

- add flag to oppool to specify a priority (api) attestation. This is the same to the way we do attestation validation https://github.com/ChainSafe/lodestar/blob/ca29dbb8edad29e1eb5ac2c576059abcb1c82ec7/packages/beacon-node/src/chain/validation/attestation.ts#L209
- same feature for SyncCommittee

part of #7548
