### PR TITLE
chore: remove unnecessary BigInt conversion in process deposit request

### DIFF
--- a/packages/state-transition/src/block/processDepositRequest.ts
+++ b/packages/state-transition/src/block/processDepositRequest.ts
@@ -5,7 +5,7 @@ import {CachedBeaconStateElectra} from "../types.js";
 
 export function processDepositRequest(state: CachedBeaconStateElectra, depositRequest: electra.DepositRequest): void {
   if (state.depositRequestsStartIndex === UNSET_DEPOSIT_REQUESTS_START_INDEX) {
-    state.depositRequestsStartIndex = BigInt(depositRequest.index);
+    state.depositRequestsStartIndex = depositRequest.index;
   }
 
   // Create pending deposit


### PR DESCRIPTION
I don't think that matters much but `DepositIndex` is arleady `Bigint` so we don't need to type cast it here.
https://github.com/ChainSafe/lodestar/blob/7ce493932623e63998aea7faea167acaae7ac3ea/packages/types/src/primitive/sszTypes.ts#L54

@twoeths do you think using `BigInt` for deposit index matters? I think it shouldn't but we essentially only had to use it here to pass spec tests, see https://github.com/ChainSafe/lodestar/pull/7344
