### PR TITLE
fix: reject a consolidation request coming from a validator with BLS withdrawal credentials

### DIFF
--- a/packages/state-transition/src/block/processConsolidationRequest.ts
+++ b/packages/state-transition/src/block/processConsolidationRequest.ts
@@ -7,7 +7,7 @@ import {
   hasCompoundingWithdrawalCredential,
   hasExecutionWithdrawalCredential,
   isPubkeyKnown,
-  switchToCompoundingValidator
+  switchToCompoundingValidator,
 } from "../util/electra.js";
 import {computeConsolidationEpochAndUpdateChurn} from "../util/epoch.js";
 import {getConsolidationChurnLimit, getPendingBalanceToWithdraw, isActiveValidator} from "../util/validator.js";
@@ -59,6 +59,7 @@ export function processConsolidationRequest(
     return;
   }
 
+  // Verify source withdrawal credentials
   const hasCorrectCredential = hasExecutionWithdrawalCredential(sourceValidator.withdrawalCredentials);
   const isCorrectSourceAddress = Buffer.compare(sourceWithdrawalAddress, sourceAddress) === 0;
   if (!(hasCorrectCredential && isCorrectSourceAddress)) {

--- a/packages/state-transition/src/block/processConsolidationRequest.ts
+++ b/packages/state-transition/src/block/processConsolidationRequest.ts
@@ -3,7 +3,12 @@ import {electra, ssz} from "@lodestar/types";
 
 import {CachedBeaconStateElectra} from "../types.js";
 import {hasEth1WithdrawalCredential} from "../util/capella.js";
-import {hasCompoundingWithdrawalCredential, isPubkeyKnown, switchToCompoundingValidator} from "../util/electra.js";
+import {
+  hasCompoundingWithdrawalCredential,
+  hasExecutionWithdrawalCredential,
+  isPubkeyKnown,
+  switchToCompoundingValidator
+} from "../util/electra.js";
 import {computeConsolidationEpochAndUpdateChurn} from "../util/epoch.js";
 import {getConsolidationChurnLimit, getPendingBalanceToWithdraw, isActiveValidator} from "../util/validator.js";
 
@@ -54,7 +59,9 @@ export function processConsolidationRequest(
     return;
   }
 
-  if (Buffer.compare(sourceWithdrawalAddress, sourceAddress) !== 0) {
+  const hasCorrectCredential = hasExecutionWithdrawalCredential(sourceValidator.withdrawalCredentials);
+  const isCorrectSourceAddress = Buffer.compare(sourceWithdrawalAddress, sourceAddress) === 0;
+  if (!(hasCorrectCredential && isCorrectSourceAddress)) {
     return;
   }
 

--- a/packages/state-transition/test/unit/block/processConsolidationRequest.test.ts
+++ b/packages/state-transition/test/unit/block/processConsolidationRequest.test.ts
@@ -1,0 +1,61 @@
+import {processConsolidationRequest} from "../../../src/block";
+import {describe, expect, it} from "vitest";
+import {ssz} from "@lodestar/types";
+import {
+  BLS_WITHDRAWAL_PREFIX, COMPOUNDING_WITHDRAWAL_PREFIX,
+  FAR_FUTURE_EPOCH,
+  MAX_EFFECTIVE_BALANCE,
+  SLOTS_PER_EPOCH,
+  SYNC_COMMITTEE_SIZE
+} from "@lodestar/params";
+import {generateValidators} from "../../utils/validator.js";
+import {generateCachedElectraState} from "../../../../beacon-node/test/utils/state.js";
+import bls from "@chainsafe/blst";
+import {digest} from "@chainsafe/as-sha256";
+
+describe.only("processConsolidationRequest", () => {
+  it.only("rejects BLS withdrawal credentials", () => {
+    const electraForkEpoch = 400000;
+    const currentEpoch = electraForkEpoch + 10;
+    const currentSlot = SLOTS_PER_EPOCH * currentEpoch;
+
+    const activationEpoch = electraForkEpoch - 10000;
+    const exitEpoch = FAR_FUTURE_EPOCH;
+
+    const validatorOpts = {
+      activationEpoch,
+      activation: activationEpoch,
+      effectiveBalance: MAX_EFFECTIVE_BALANCE,
+      withdrawableEpoch: FAR_FUTURE_EPOCH,
+      exitEpoch,
+      exit: exitEpoch,
+    };
+    const validators = generateValidators(SYNC_COMMITTEE_SIZE, validatorOpts);
+    for (let i = 0; i < SYNC_COMMITTEE_SIZE; i++) {
+      const buffer = Buffer.alloc(32, 0);
+      buffer.writeInt16BE(i + 1, 30); // Offset to ensure the SK is less than the order
+      const sk = bls.SecretKey.fromBytes(buffer);
+      validators[i].pubkey = sk.toPublicKey().toBytes();
+    }
+
+    let [sourceValidator, targetValidator] = [validators[0], validators[1]];
+    sourceValidator.withdrawalCredentials = digest(sourceValidator.pubkey);
+    sourceValidator.withdrawalCredentials[0] = BLS_WITHDRAWAL_PREFIX;
+    targetValidator.withdrawalCredentials = digest(targetValidator.pubkey);
+    targetValidator.withdrawalCredentials[0] = COMPOUNDING_WITHDRAWAL_PREFIX;
+
+    let state = generateCachedElectraState({slot: currentSlot + 1, validators}, electraForkEpoch);
+    state.epochCtx.totalActiveBalanceIncrements = 123456789;
+    const request = ssz.electra.ConsolidationRequest.defaultValue();
+
+    request.sourcePubkey = sourceValidator.pubkey;
+    request.targetPubkey = targetValidator.pubkey;
+    request.sourceAddress = digest(sourceValidator.pubkey).slice(12);
+
+    expect(state.pendingConsolidations.length).eq(0);
+
+    processConsolidationRequest(state, request);
+
+    expect(state.pendingConsolidations.length).eq(0);
+  })
+});

--- a/packages/state-transition/test/unit/block/processConsolidationRequest.test.ts
+++ b/packages/state-transition/test/unit/block/processConsolidationRequest.test.ts
@@ -1,36 +1,30 @@
-import {processConsolidationRequest} from "../../../src/block";
-import {describe, expect, it} from "vitest";
-import {ssz} from "@lodestar/types";
-import {
-  BLS_WITHDRAWAL_PREFIX, COMPOUNDING_WITHDRAWAL_PREFIX,
-  FAR_FUTURE_EPOCH,
-  MAX_EFFECTIVE_BALANCE,
-  SLOTS_PER_EPOCH,
-  SYNC_COMMITTEE_SIZE
-} from "@lodestar/params";
-import {generateValidators} from "../../utils/validator.js";
-import {generateCachedElectraState} from "../../../../beacon-node/test/utils/state.js";
-import bls from "@chainsafe/blst";
 import {digest} from "@chainsafe/as-sha256";
+import bls from "@chainsafe/blst";
+import {
+  BLS_WITHDRAWAL_PREFIX,
+  COMPOUNDING_WITHDRAWAL_PREFIX,
+  FAR_FUTURE_EPOCH,
+  SLOTS_PER_EPOCH,
+  SYNC_COMMITTEE_SIZE,
+} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
+import {describe, expect, it} from "vitest";
+import {generateCachedElectraState} from "../../../../beacon-node/test/utils/state.js";
+import {processConsolidationRequest} from "../../../src/block/processConsolidationRequest.js";
+import {generateValidators} from "../../utils/validator.js";
 
-describe.only("processConsolidationRequest", () => {
-  it.only("rejects BLS withdrawal credentials", () => {
+describe("processConsolidationRequest", () => {
+  it("rejects BLS withdrawal credentials", () => {
     const electraForkEpoch = 400000;
     const currentEpoch = electraForkEpoch + 10;
     const currentSlot = SLOTS_PER_EPOCH * currentEpoch;
 
-    const activationEpoch = electraForkEpoch - 10000;
-    const exitEpoch = FAR_FUTURE_EPOCH;
-
-    const validatorOpts = {
-      activationEpoch,
-      activation: activationEpoch,
-      effectiveBalance: MAX_EFFECTIVE_BALANCE,
+    const validators = generateValidators(SYNC_COMMITTEE_SIZE, {
+      activation: electraForkEpoch - 10000,
       withdrawableEpoch: FAR_FUTURE_EPOCH,
-      exitEpoch,
-      exit: exitEpoch,
-    };
-    const validators = generateValidators(SYNC_COMMITTEE_SIZE, validatorOpts);
+      exit: FAR_FUTURE_EPOCH,
+    });
+
     for (let i = 0; i < SYNC_COMMITTEE_SIZE; i++) {
       const buffer = Buffer.alloc(32, 0);
       buffer.writeInt16BE(i + 1, 30); // Offset to ensure the SK is less than the order
@@ -38,18 +32,21 @@ describe.only("processConsolidationRequest", () => {
       validators[i].pubkey = sk.toPublicKey().toBytes();
     }
 
-    let [sourceValidator, targetValidator] = [validators[0], validators[1]];
+    const [sourceValidator, targetValidator] = [validators[0], validators[1]];
     sourceValidator.withdrawalCredentials = digest(sourceValidator.pubkey);
     sourceValidator.withdrawalCredentials[0] = BLS_WITHDRAWAL_PREFIX;
     targetValidator.withdrawalCredentials = digest(targetValidator.pubkey);
     targetValidator.withdrawalCredentials[0] = COMPOUNDING_WITHDRAWAL_PREFIX;
 
-    let state = generateCachedElectraState({slot: currentSlot + 1, validators}, electraForkEpoch);
+    const state = generateCachedElectraState({slot: currentSlot + 1, validators}, electraForkEpoch);
     state.epochCtx.totalActiveBalanceIncrements = 123456789;
-    const request = ssz.electra.ConsolidationRequest.defaultValue();
 
+    const request = ssz.electra.ConsolidationRequest.defaultValue();
     request.sourcePubkey = sourceValidator.pubkey;
     request.targetPubkey = targetValidator.pubkey;
+    // An attacker could create a new validator with BLS withdrawal credentials where the last twenty
+    // bytes of the BLS pubkey are hardcoded to an address that they control. To be clear, the source
+    // address field in consolidation requests cannot be set to an arbitrary value.
     request.sourceAddress = digest(sourceValidator.pubkey).slice(12);
 
     expect(state.pendingConsolidations.length).eq(0);
@@ -57,5 +54,5 @@ describe.only("processConsolidationRequest", () => {
     processConsolidationRequest(state, request);
 
     expect(state.pendingConsolidations.length).eq(0);
-  })
+  });
 });


### PR DESCRIPTION
**Motivation**

<!-- Why is this PR exists? What are the goals of the pull request? -->

In order to comply with the consensus-specs of Electra, when processing a consolidation request we should check that the source validator does not have withdrawal credentials with a BLS prefix.

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

The prefix of the withdrawal credentials of the source validator that is targeted by the consolidation request should either be `ETH1_ADDRESS_WITHDRAWAL_PREFIX` or `COMPOUNDING_WITHDRAWAL_PREFIX`.
The relevant function is [`process_consolidation_request`](https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#new-process_consolidation_request) and as expected verifies the prefix of the withdrawal credentials of the source validator:
```python
    # Verify source withdrawal credentials
    has_correct_credential = has_execution_withdrawal_credential(source_validator)
    is_correct_source_address = (
        source_validator.withdrawal_credentials[12:] == consolidation_request.source_address
    )
    if not (has_correct_credential and is_correct_source_address):
        return
```
Currently, a validator could create a deposit transaction with BLS withdrawal credentials ending with an eth1 that they control in order to make the consolidation request from this address later.
Since Lodestar will process this request and will add the request, it will have a different state root from other clients, effectively performing a chain split as showcased by the failing test at the first commit.