### PR TITLE
refactor: group beacon metrics, move chain metrics to chain domain

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,13 +10,13 @@
     "editor.defaultFormatter": "biomejs.biome"
   },
   "[typescript]": {
-    "editor.defaultFormatter": "biomejs.biome"
+    "editor.defaultFormatter": "vscode.typescript-language-features"
   },
   "[json]": {
     "editor.defaultFormatter": "biomejs.biome" 
   },
   "[jsonc]": {
-    "editor.defaultFormatter": "biomejs.biome" 
+    "editor.defaultFormatter": "vscode.json-language-features" 
   },
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -424,7 +424,7 @@ export function getValidatorApi(
     }
 
     const source = ProducedBlockSource.builder;
-    metrics?.blockProductionRequests.inc({source});
+    metrics?.api.blockProductionRequests.inc({source});
 
     // Error early for builder if builder flow not active
     if (!chain.executionBuilder) {
@@ -447,7 +447,7 @@ export function getValidatorApi(
 
     let timer: undefined | ((opts: {source: ProducedBlockSource}) => number);
     try {
-      timer = metrics?.blockProductionTime.startTimer();
+      timer = metrics?.api.blockProductionTime.startTimer();
       const {block, executionPayloadValue, consensusBlockValue} = await chain.produceBlindedBlock({
         slot,
         parentBlockRoot,
@@ -458,9 +458,12 @@ export function getValidatorApi(
         commonBlockBody,
       });
 
-      metrics?.blockProductionSuccess.inc({source});
-      metrics?.blockProductionNumAggregated.observe({source}, block.body.attestations.length);
-      metrics?.blockProductionExecutionPayloadValue.observe({source}, Number(formatWeiToEth(executionPayloadValue)));
+      metrics?.api.blockProductionSuccess.inc({source});
+      metrics?.api.blockProductionNumAggregated.observe({source}, block.body.attestations.length);
+      metrics?.api.blockProductionExecutionPayloadValue.observe(
+        {source},
+        Number(formatWeiToEth(executionPayloadValue))
+      );
       logger.verbose("Produced blinded block", {
         slot,
         executionPayloadValue,
@@ -499,7 +502,7 @@ export function getValidatorApi(
       ) = {}
   ): Promise<ProduceBlockOrContentsRes & {shouldOverrideBuilder?: boolean}> {
     const source = ProducedBlockSource.engine;
-    metrics?.blockProductionRequests.inc({source});
+    metrics?.api.blockProductionRequests.inc({source});
 
     let parentBlockRoot: Root;
     if (skipHeadChecksAndUpdate !== true) {
@@ -514,7 +517,7 @@ export function getValidatorApi(
 
     let timer: undefined | ((opts: {source: ProducedBlockSource}) => number);
     try {
-      timer = metrics?.blockProductionTime.startTimer();
+      timer = metrics?.api.blockProductionTime.startTimer();
       const {block, executionPayloadValue, consensusBlockValue, shouldOverrideBuilder} = await chain.produceBlock({
         slot,
         parentBlockRoot,
@@ -533,9 +536,12 @@ export function getValidatorApi(
         }
       }
 
-      metrics?.blockProductionSuccess.inc({source});
-      metrics?.blockProductionNumAggregated.observe({source}, block.body.attestations.length);
-      metrics?.blockProductionExecutionPayloadValue.observe({source}, Number(formatWeiToEth(executionPayloadValue)));
+      metrics?.api.blockProductionSuccess.inc({source});
+      metrics?.api.blockProductionNumAggregated.observe({source}, block.body.attestations.length);
+      metrics?.api.blockProductionExecutionPayloadValue.observe(
+        {source},
+        Number(formatWeiToEth(executionPayloadValue))
+      );
       logger.verbose("Produced execution block", {
         slot,
         executionPayloadValue,
@@ -753,7 +759,7 @@ export function getValidatorApi(
         ...getBlockValueLogInfo(engine.value),
       });
 
-      metrics?.blockProductionSelectionResults.inc({
+      metrics?.api.blockProductionSelectionResults.inc({
         source: ProducedBlockSource.engine,
         reason: EngineBlockSelectionReason.BuilderCensorship,
       });
@@ -776,7 +782,7 @@ export function getValidatorApi(
         ...getBlockValueLogInfo(builder.value),
       });
 
-      metrics?.blockProductionSelectionResults.inc({
+      metrics?.api.blockProductionSelectionResults.inc({
         source: ProducedBlockSource.builder,
         reason,
       });
@@ -803,7 +809,7 @@ export function getValidatorApi(
         ...getBlockValueLogInfo(engine.value),
       });
 
-      metrics?.blockProductionSelectionResults.inc({
+      metrics?.api.blockProductionSelectionResults.inc({
         source: ProducedBlockSource.engine,
         reason,
       });
@@ -820,7 +826,7 @@ export function getValidatorApi(
       });
       const executionPayloadSource = result.source;
 
-      metrics?.blockProductionSelectionResults.inc(result);
+      metrics?.api.blockProductionSelectionResults.inc(result);
 
       logger.info(`Selected ${executionPayloadSource} block`, {
         reason: result.reason,

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -234,7 +234,7 @@ export async function importBlock(
     });
 
     if (this.metrics) {
-      this.metrics.headSlot.set(newHead.slot);
+      this.metrics.beaconMetricsSpecsInterop.headSlot.set(newHead.slot);
       // Only track "recent" blocks. Otherwise sync can distort this metrics heavily.
       // We want to track recent blocks coming from gossip, unknown block sync, and API.
       if (delaySec < SLOTS_PER_EPOCH * this.config.SECONDS_PER_SLOT) {
@@ -267,7 +267,7 @@ export async function importBlock(
       this.emitter.emit(routes.events.EventType.chainReorg, forkChoiceReorgEventData);
       this.logger.verbose("Chain reorg", forkChoiceReorgEventData);
 
-      this.metrics?.forkChoice.reorg.inc();
+      this.metrics?.beaconMetricsSpecsInterop.reorgEventsTotal.inc();
       this.metrics?.forkChoice.reorgDistance.observe(ancestorResult.depth);
     }
 
@@ -347,8 +347,8 @@ export async function importBlock(
     this.logger.verbose("Checkpoint processed", toCheckpointHex(cp));
 
     const activeValidatorsCount = checkpointState.epochCtx.currentShuffling.activeIndices.length;
-    this.metrics?.currentActiveValidators.set(activeValidatorsCount);
-    this.metrics?.currentValidators.set({status: "active"}, activeValidatorsCount);
+    this.metrics?.beaconMetricsSpecsInterop.currentActiveValidators.set(activeValidatorsCount);
+    // this.metrics?.currentValidators.set({status: "active"}, activeValidatorsCount);
 
     const parentBlockSummary = this.forkChoice.getBlock(checkpointState.latestBlockHeader.parentRoot);
 
@@ -358,8 +358,10 @@ export async function importBlock(
       const preJustifiedEpoch = parentBlockSummary.justifiedEpoch;
       if (justifiedEpoch > preJustifiedEpoch) {
         this.logger.verbose("Checkpoint justified", toCheckpointHex(justifiedCheckpoint));
-        this.metrics?.previousJustifiedEpoch.set(checkpointState.previousJustifiedCheckpoint.epoch);
-        this.metrics?.currentJustifiedEpoch.set(justifiedCheckpoint.epoch);
+        this.metrics?.beaconMetricsSpecsInterop.previousJustifiedEpoch.set(
+          checkpointState.previousJustifiedCheckpoint.epoch
+        );
+        this.metrics?.beaconMetricsSpecsInterop.currentJustifiedEpoch.set(justifiedCheckpoint.epoch);
       }
       const finalizedCheckpoint = checkpointState.finalizedCheckpoint;
       const finalizedEpoch = finalizedCheckpoint.epoch;
@@ -372,7 +374,7 @@ export async function importBlock(
           executionOptimistic: false,
         });
         this.logger.verbose("Checkpoint finalized", toCheckpointHex(finalizedCheckpoint));
-        this.metrics?.finalizedEpoch.set(finalizedCheckpoint.epoch);
+        this.metrics?.beaconMetricsSpecsInterop.finalizedEpoch.set(finalizedCheckpoint.epoch);
       }
     }
   }
@@ -435,7 +437,7 @@ export async function importBlock(
   }
 
   // Register stat metrics about the block after importing it
-  this.metrics?.parentBlockDistance.observe(blockSlot - parentBlockSlot);
+  this.metrics?.importedBlock.parentBlockDistance.observe(blockSlot - parentBlockSlot);
   this.metrics?.proposerBalanceDeltaAny.observe(fullyVerifiedBlock.proposerBalanceDelta);
   this.metrics?.registerImportedBlock(block.message, fullyVerifiedBlock);
   if (this.config.getForkSeq(blockSlot) >= ForkSeq.altair) {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -735,11 +735,13 @@ export class BeaconChain implements IBeaconChain {
     if (blockType === BlockType.Full) {
       this.logger.debug("Setting executionPayload cache for produced block", {blockRootHex, slot, blockType});
       this.producedBlockRoot.set(blockRootHex, (block as bellatrix.BeaconBlock).body.executionPayload ?? null);
-      this.metrics?.blockProductionCaches.producedBlockRoot.set(this.producedBlockRoot.size);
+      this.metrics?.blockProduction.blockProductionCaches.producedBlockRoot.set(this.producedBlockRoot.size);
     } else {
       this.logger.debug("Tracking the produced blinded block", {blockRootHex, slot, blockType});
       this.producedBlindedBlockRoot.add(blockRootHex);
-      this.metrics?.blockProductionCaches.producedBlindedBlockRoot.set(this.producedBlindedBlockRoot.size);
+      this.metrics?.blockProduction.blockProductionCaches.producedBlindedBlockRoot.set(
+        this.producedBlindedBlockRoot.size
+      );
     }
 
     // Cache for latter broadcasting
@@ -750,7 +752,7 @@ export class BeaconChain implements IBeaconChain {
       // body is of full type here
       const {blockHash, contents} = blobs;
       this.producedContentsCache.set(blockHash, contents);
-      this.metrics?.blockProductionCaches.producedContentsCache.set(this.producedContentsCache.size);
+      this.metrics?.blockProduction.blockProductionCaches.producedContentsCache.set(this.producedContentsCache.size);
     }
 
     return {block, executionPayloadValue, consensusBlockValue: gweiToWei(proposerReward), shouldOverrideBuilder};
@@ -1105,7 +1107,7 @@ export class BeaconChain implements IBeaconChain {
     }
 
     this.forkChoice.updateTime(slot);
-    this.metrics?.clockSlot.set(slot);
+    this.metrics?.clock.clockSlot.set(slot);
 
     this.attestationPool.prune(slot);
     this.aggregatedAttestationPool.prune(slot);
@@ -1116,14 +1118,16 @@ export class BeaconChain implements IBeaconChain {
 
     // Prune old cached block production artifacts, those are only useful on their slot
     pruneSetToMax(this.producedBlockRoot, this.opts.maxCachedProducedRoots ?? DEFAULT_MAX_CACHED_PRODUCED_ROOTS);
-    this.metrics?.blockProductionCaches.producedBlockRoot.set(this.producedBlockRoot.size);
+    this.metrics?.blockProduction.blockProductionCaches.producedBlockRoot.set(this.producedBlockRoot.size);
 
     pruneSetToMax(this.producedBlindedBlockRoot, this.opts.maxCachedProducedRoots ?? DEFAULT_MAX_CACHED_PRODUCED_ROOTS);
-    this.metrics?.blockProductionCaches.producedBlindedBlockRoot.set(this.producedBlindedBlockRoot.size);
+    this.metrics?.blockProduction.blockProductionCaches.producedBlindedBlockRoot.set(
+      this.producedBlindedBlockRoot.size
+    );
 
     if (this.config.getForkSeq(slot) >= ForkSeq.deneb) {
       pruneSetToMax(this.producedContentsCache, this.opts.maxCachedProducedRoots ?? DEFAULT_MAX_CACHED_PRODUCED_ROOTS);
-      this.metrics?.blockProductionCaches.producedContentsCache.set(this.producedContentsCache.size);
+      this.metrics?.blockProduction.blockProductionCaches.producedContentsCache.set(this.producedContentsCache.size);
     }
 
     const metrics = this.metrics;
@@ -1138,7 +1142,7 @@ export class BeaconChain implements IBeaconChain {
   }
 
   private onClockEpoch(epoch: Epoch): void {
-    this.metrics?.clockEpoch.set(epoch);
+    this.metrics?.clock.clockEpoch.set(epoch);
 
     this.seenAttesters.prune(epoch);
     this.seenAggregators.prune(epoch);

--- a/packages/beacon-node/src/chain/initState.ts
+++ b/packages/beacon-node/src/chain/initState.ts
@@ -197,8 +197,8 @@ export async function checkAndPersistAnchorState(
 }
 
 export function initBeaconMetrics(metrics: Metrics, state: BeaconStateAllForks): void {
-  metrics.headSlot.set(state.slot);
-  metrics.previousJustifiedEpoch.set(state.previousJustifiedCheckpoint.epoch);
-  metrics.currentJustifiedEpoch.set(state.currentJustifiedCheckpoint.epoch);
-  metrics.finalizedEpoch.set(state.finalizedCheckpoint.epoch);
+  metrics.beaconMetricsSpecsInterop.headSlot.set(state.slot);
+  metrics.beaconMetricsSpecsInterop.previousJustifiedEpoch.set(state.previousJustifiedCheckpoint.epoch);
+  metrics.beaconMetricsSpecsInterop.currentJustifiedEpoch.set(state.currentJustifiedCheckpoint.epoch);
+  metrics.beaconMetricsSpecsInterop.finalizedEpoch.set(state.finalizedCheckpoint.epoch);
 }

--- a/packages/beacon-node/src/chain/metrics.ts
+++ b/packages/beacon-node/src/chain/metrics.ts
@@ -1,0 +1,150 @@
+import { UpdateHeadOpt } from "@lodestar/fork-choice";
+import { NotReorgedReason } from "@lodestar/fork-choice/lib/forkChoice/interface.js";
+import { PayloadPreparationType } from "./produceBlock/index.js";
+import { RegistryMetricCreator } from "../metrics/utils/registryMetricCreator.js";
+import { BlockProductionStep } from "./produceBlock/index.js";
+
+export type ChainMetrics = ReturnType<typeof createChainMetrics>;
+
+export function createChainMetrics(register: RegistryMetricCreator) {
+  return {
+    forkChoice: {
+      findHead: register.histogram<{ caller: string }>({
+        name: "beacon_fork_choice_find_head_seconds",
+        help: "Time taken to find head in seconds",
+        buckets: [0.1, 1, 10],
+        labelNames: ["caller"],
+      }),
+      requests: register.gauge({
+        name: "beacon_fork_choice_requests_total",
+        help: "Count of occasions where fork choice has tried to find a head",
+      }),
+      errors: register.gauge<{ entrypoint: UpdateHeadOpt }>({
+        name: "beacon_fork_choice_errors_total",
+        help: "Count of occasions where fork choice has returned an error when trying to find a head",
+        labelNames: ["entrypoint"],
+      }),
+      changedHead: register.gauge({
+        name: "beacon_fork_choice_changed_head_total",
+        help: "Count of occasions fork choice has found a new head",
+      }),
+      // duplicates beacon_reorgs_total from metrics specs
+      reorg: register.gauge({
+        name: "beacon_fork_choice_reorg_total",
+        help: "Count of occasions fork choice has switched to a different chain",
+      }),
+      reorgDistance: register.histogram({
+        name: "beacon_fork_choice_reorg_distance",
+        help: "Histogram of re-org distance",
+        // We need high resolution in the low range, since re-orgs are a rare but critical event.
+        // Add buckets up to 100 to capture high depth re-orgs. Above 100 things are going really bad.
+        buckets: [1, 2, 3, 5, 7, 10, 20, 30, 50, 100],
+      }),
+      votes: register.gauge({
+        name: "beacon_fork_choice_votes_count",
+        help: "Current count of votes in fork choice data structures",
+      }),
+      queuedAttestations: register.gauge({
+        name: "beacon_fork_choice_queued_attestations_count",
+        help: "Count of queued_attestations in fork choice per slot",
+      }),
+      validatedAttestationDatas: register.gauge({
+        name: "beacon_fork_choice_validated_attestation_datas_count",
+        help: "Current count of validatedAttestationDatas in fork choice data structures",
+      }),
+      balancesLength: register.gauge({
+        name: "beacon_fork_choice_balances_length",
+        help: "Current length of balances in fork choice data structures",
+      }),
+      nodes: register.gauge({
+        name: "beacon_fork_choice_nodes_count",
+        help: "Current count of nodes in fork choice data structures",
+      }),
+      indices: register.gauge({
+        name: "beacon_fork_choice_indices_count",
+        help: "Current count of indices in fork choice data structures",
+      }),
+      notReorgedReason: register.gauge<{ reason: NotReorgedReason }>({
+        name: "beacon_fork_choice_not_reorged_reason_total",
+        help: "Reason why the current head is not re-orged out",
+        labelNames: ["reason"],
+      }),
+    },
+    importedBlock: {
+      parentBlockDistance: register.histogram({
+        name: "beacon_imported_block_parent_distance",
+        help: "Histogram of distance to parent block of valid imported blocks",
+        buckets: [1, 2, 3, 5, 7, 10, 20, 30, 50, 100],
+      }),
+    },
+    blockProduction: {
+      executionBlockProductionTimeSteps: register.histogram<{ step: BlockProductionStep }>({
+        name: "beacon_block_production_execution_steps_seconds",
+        help: "Detailed steps runtime of execution block production",
+        buckets: [0.01, 0.1, 0.2, 0.5, 1],
+        labelNames: ["step"],
+      }),
+      builderBlockProductionTimeSteps: register.histogram<{ step: BlockProductionStep }>({
+        name: "beacon_block_production_builder_steps_seconds",
+        help: "Detailed steps runtime of builder block production",
+        buckets: [0.01, 0.1, 0.2, 0.5, 1],
+        labelNames: ["step"],
+      }),
+      blockProductionCaches: {
+        producedBlockRoot: register.gauge({
+          name: "beacon_blockroot_produced_cache_total",
+          help: "Count of cached produced block roots",
+        }),
+        producedBlindedBlockRoot: register.gauge({
+          name: "beacon_blinded_blockroot_produced_cache_total",
+          help: "Count of cached produced blinded block roots",
+        }),
+        producedContentsCache: register.gauge({
+          name: "beacon_contents_produced_cache_total",
+          help: "Count of cached produced blob contents",
+        }),
+      },
+    },
+    clock: {
+      clockSlot: register.gauge({
+        name: "beacon_clock_slot",
+        help: "Current clock slot",
+      }),
+      clockEpoch: register.gauge({
+        name: "beacon_clock_epoch",
+        help: "Current clock epoch",
+      }),
+    },
+    prepareNextSlot: {
+      weakHeadDetected: register.gauge({
+        name: "beacon_weak_head_detected_total",
+        help: "Detected current head block is weak. May reorg it out when proposing next slot. See proposer boost reorg for more",
+      }),
+    },
+    blockPayload: {
+      // not used on the dashboard
+      payloadAdvancePrepTime: register.histogram({
+        name: "beacon_block_payload_prepare_time",
+        help: "Time for preparing payload in advance",
+        buckets: [0.1, 1, 3, 5, 10],
+      }),
+      // not used on the dashboard
+      payloadFetchedTime: register.histogram<{ prepType: PayloadPreparationType }>({
+        name: "beacon_block_payload_fetched_time",
+        help: "Time to fetch the payload from EL",
+        labelNames: ["prepType"],
+      }),
+      // not used on the dashboard
+      emptyPayloads: register.gauge<{ prepType: PayloadPreparationType }>({
+        name: "beacon_block_payload_empty_total",
+        help: "Count of payload with empty transactions",
+        labelNames: ["prepType"],
+      }),
+      // not used on the dashboard
+      payloadFetchErrors: register.gauge({
+        name: "beacon_block_payload_errors_total",
+        help: "Count of errors while fetching payloads",
+      }),
+    },
+  };
+}

--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -199,8 +199,8 @@ export class OpPool {
 
     const stepsMetrics =
       blockType === BlockType.Full
-        ? metrics?.executionBlockProductionTimeSteps
-        : metrics?.builderBlockProductionTimeSteps;
+        ? metrics?.blockProduction.executionBlockProductionTimeSteps
+        : metrics?.blockProduction.builderBlockProductionTimeSteps;
 
     const endProposerSlashing = stepsMetrics?.startTimer();
     for (const proposerSlashing of this.proposerSlashings.values()) {

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -1,6 +1,6 @@
-import {routes} from "@lodestar/api";
-import {ChainForkConfig} from "@lodestar/config";
-import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH, isForkPostElectra} from "@lodestar/params";
+import { routes } from "@lodestar/api";
+import { ChainForkConfig } from "@lodestar/config";
+import { ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH, isForkPostElectra } from "@lodestar/params";
 import {
   BeaconStateElectra,
   CachedBeaconStateAllForks,
@@ -10,16 +10,16 @@ import {
   computeTimeAtSlot,
   isExecutionStateType,
 } from "@lodestar/state-transition";
-import {Slot} from "@lodestar/types";
-import {Logger, fromHex, isErrorAborted, sleep} from "@lodestar/utils";
-import {GENESIS_SLOT, ZERO_HASH_HEX} from "../constants/constants.js";
-import {Metrics} from "../metrics/index.js";
-import {ClockEvent} from "../util/clock.js";
-import {isQueueErrorAborted} from "../util/queue/index.js";
-import {ForkchoiceCaller} from "./forkChoice/index.js";
-import {IBeaconChain} from "./interface.js";
-import {getPayloadAttributesForSSE, prepareExecutionPayload} from "./produceBlock/produceBlockBody.js";
-import {RegenCaller} from "./regen/index.js";
+import { Slot } from "@lodestar/types";
+import { Logger, fromHex, isErrorAborted, sleep } from "@lodestar/utils";
+import { GENESIS_SLOT, ZERO_HASH_HEX } from "../constants/constants.js";
+import { Metrics } from "../metrics/index.js";
+import { ClockEvent } from "../util/clock.js";
+import { isQueueErrorAborted } from "../util/queue/index.js";
+import { ForkchoiceCaller } from "./forkChoice/index.js";
+import { IBeaconChain } from "./interface.js";
+import { getPayloadAttributesForSSE, prepareExecutionPayload } from "./produceBlock/produceBlockBody.js";
+import { RegenCaller } from "./regen/index.js";
 
 /* With 12s slot times, this scheduler will run 4s before the start of each slot (`12 / 3 = 4`). */
 export const SCHEDULER_LOOKAHEAD_FACTOR = 3;
@@ -52,7 +52,7 @@ export class PrepareNextSlotScheduler {
       () => {
         this.chain.clock.off(ClockEvent.slot, this.prepareForNextSlot);
       },
-      {once: true}
+      { once: true }
     );
   }
 
@@ -79,14 +79,14 @@ export class PrepareNextSlotScheduler {
       await sleep(slotMs - slotMs / SCHEDULER_LOOKAHEAD_FACTOR, this.signal);
 
       // calling updateHead() here before we produce a block to reduce reorg possibility
-      const {slot: headSlot, blockRoot: headRoot} = this.chain.recomputeForkChoiceHead(
+      const { slot: headSlot, blockRoot: headRoot } = this.chain.recomputeForkChoiceHead(
         ForkchoiceCaller.prepareNextSlot
       );
 
       // PS: previously this was comparing slots, but that gave no leway on the skipped
       // slots on epoch bounday. Making it more fluid.
       if (prepareSlot - headSlot > PREPARE_EPOCH_LIMIT * SLOTS_PER_EPOCH) {
-        this.metrics?.precomputeNextEpochTransition.count.inc({result: "skip"}, 1);
+        this.metrics?.precomputeNextEpochTransition.count.inc({ result: "skip" }, 1);
         this.logger.debug("Skipping PrepareNextSlotScheduler - head slot is too behind current slot", {
           nextEpoch,
           headSlot,
@@ -120,7 +120,7 @@ export class PrepareNextSlotScheduler {
         // beforeProcessEpoch and should theoretically be ready immediately after the synchronous epoch transition finished and the
         // event loop is free.  In long periods of non-finality too many forks will cause the shufflingCache to throw an error for
         // too many queued shufflings so only run async during normal epoch transition. See issue ChainSafe/lodestar#7244
-        {dontTransferCache: !isEpochTransition, asyncShufflingCalculation: true},
+        { dontTransferCache: !isEpochTransition, asyncShufflingCalculation: true },
         RegenCaller.precomputeEpoch
       );
 
@@ -132,7 +132,7 @@ export class PrepareNextSlotScheduler {
 
         if (feeRecipient) {
           // If we are proposing next slot, we need to predict if we can proposer-boost-reorg or not
-          const {slot: proposerHeadSlot, blockRoot: proposerHeadRoot} = this.chain.predictProposerHead(clockSlot);
+          const { slot: proposerHeadSlot, blockRoot: proposerHeadRoot } = this.chain.predictProposerHead(clockSlot);
 
           // If we predict we can reorg, update prepareState with proposer head block
           if (proposerHeadRoot !== headRoot || proposerHeadSlot !== headSlot) {
@@ -142,11 +142,11 @@ export class PrepareNextSlotScheduler {
               headSlot,
               headRoot,
             });
-            this.metrics?.weakHeadDetected.inc();
+            this.metrics?.prepareNextSlot.weakHeadDetected.inc();
             updatedPrepareState = (await this.chain.regen.getBlockSlotState(
               proposerHeadRoot,
               prepareSlot,
-              {dontTransferCache: !isEpochTransition},
+              { dontTransferCache: !isEpochTransition },
               RegenCaller.predictProposerHead
             )) as CachedBeaconStateExecutions;
             updatedHeadRoot = proposerHeadRoot;
@@ -156,7 +156,7 @@ export class PrepareNextSlotScheduler {
           this.chain.updateBuilderStatus(clockSlot);
           if (this.chain.executionBuilder?.status) {
             this.chain.executionBuilder.checkStatus().catch((e) => {
-              this.logger.error("Builder disabled as the check status api failed", {prepareSlot}, e as Error);
+              this.logger.error("Builder disabled as the check status api failed", { prepareSlot }, e as Error);
             });
           }
 
@@ -199,7 +199,7 @@ export class PrepareNextSlotScheduler {
             // feeRecipient, so just pass zero hash for now till a real use case arises
             feeRecipient: "0x0000000000000000000000000000000000000000000000000000000000000000",
           });
-          this.chain.emitter.emit(routes.events.EventType.payloadAttributes, {data, version: fork});
+          this.chain.emitter.emit(routes.events.EventType.payloadAttributes, { data, version: fork });
         }
       } else {
         this.computeStateHashTreeRoot(prepareState, isEpochTransition);
@@ -209,7 +209,7 @@ export class PrepareNextSlotScheduler {
       //  + when gossip block comes, we need to validate and run state transition
       //  + if next slot is a skipped slot, it'd help getting target checkpoint state faster to validate attestations
       if (isEpochTransition) {
-        this.metrics?.precomputeNextEpochTransition.count.inc({result: "success"}, 1);
+        this.metrics?.precomputeNextEpochTransition.count.inc({ result: "success" }, 1);
         const previousHits = this.chain.regen.updatePreComputedCheckpoint(headRoot, nextEpoch);
         if (previousHits === 0) {
           this.metrics?.precomputeNextEpochTransition.waste.inc();
@@ -230,8 +230,8 @@ export class PrepareNextSlotScheduler {
       }
     } catch (e) {
       if (!isErrorAborted(e) && !isQueueErrorAborted(e)) {
-        this.metrics?.precomputeNextEpochTransition.count.inc({result: "error"}, 1);
-        this.logger.error("Failed to run prepareForNextSlot", {nextEpoch, isEpochTransition, prepareSlot}, e as Error);
+        this.metrics?.precomputeNextEpochTransition.count.inc({ result: "error" }, 1);
+        this.logger.error("Failed to run prepareForNextSlot", { nextEpoch, isEpochTransition, prepareSlot }, e as Error);
       }
     }
   };

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -1,5 +1,5 @@
-import {ChainForkConfig} from "@lodestar/config";
-import {ForkPostBellatrix, ForkSeq, isForkPostAltair, isForkPostBellatrix} from "@lodestar/params";
+import { ChainForkConfig } from "@lodestar/config";
+import { ForkPostBellatrix, ForkSeq, isForkPostAltair, isForkPostBellatrix } from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   CachedBeaconStateBellatrix,
@@ -32,10 +32,10 @@ import {
   ssz,
   sszTypesFor,
 } from "@lodestar/types";
-import {Logger, sleep, toHex, toPubkeyHex, toRootHex} from "@lodestar/utils";
-import {ZERO_HASH, ZERO_HASH_HEX} from "../../constants/index.js";
-import {IEth1ForBlockProduction} from "../../eth1/index.js";
-import {numToQuantity} from "../../eth1/provider/utils.js";
+import { Logger, sleep, toHex, toPubkeyHex, toRootHex } from "@lodestar/utils";
+import { ZERO_HASH, ZERO_HASH_HEX } from "../../constants/index.js";
+import { IEth1ForBlockProduction } from "../../eth1/index.js";
+import { numToQuantity } from "../../eth1/provider/utils.js";
 import {
   IExecutionBuilder,
   IExecutionEngine,
@@ -43,10 +43,10 @@ import {
   PayloadId,
   getExpectedGasLimit,
 } from "../../execution/index.js";
-import {fromGraffitiBuffer} from "../../util/graffiti.js";
-import type {BeaconChain} from "../chain.js";
-import {CommonBlockBody} from "../interface.js";
-import {validateBlobsAndKzgCommitments} from "./validateBlobsAndKzgCommitments.js";
+import { fromGraffitiBuffer } from "../../util/graffiti.js";
+import type { BeaconChain } from "../chain.js";
+import { CommonBlockBody } from "../interface.js";
+import { validateBlobsAndKzgCommitments } from "./validateBlobsAndKzgCommitments.js";
 
 // Time to provide the EL to generate a payload from new payload id
 const PAYLOAD_GENERATION_TIME_MS = 500;
@@ -96,9 +96,9 @@ export enum BlobsResultType {
 }
 
 export type BlobsResult =
-  | {type: BlobsResultType.preDeneb}
-  | {type: BlobsResultType.produced; contents: deneb.Contents; blockHash: RootHex}
-  | {type: BlobsResultType.blinded};
+  | { type: BlobsResultType.preDeneb }
+  | { type: BlobsResultType.produced; contents: deneb.Contents; blockHash: RootHex }
+  | { type: BlobsResultType.blinded };
 
 export async function produceBlockBody<T extends BlockType>(
   this: BeaconChain,
@@ -142,8 +142,8 @@ export async function produceBlockBody<T extends BlockType>(
   this.logger.verbose("Producing beacon block body", logMeta);
   const stepsMetrics =
     blockType === BlockType.Full
-      ? this.metrics?.executionBlockProductionTimeSteps
-      : this.metrics?.builderBlockProductionTimeSteps;
+      ? this.metrics?.blockProduction.executionBlockProductionTimeSteps
+      : this.metrics?.blockProduction.builderBlockProductionTimeSteps;
 
   const blockBody = commonBlockBody
     ? Object.assign({}, commonBlockBody)
@@ -186,7 +186,7 @@ export async function produceBlockBody<T extends BlockType>(
         ? "cached"
         : "default";
 
-    Object.assign(logMeta, {feeRecipientType, feeRecipient});
+    Object.assign(logMeta, { feeRecipientType, feeRecipient });
 
     if (blockType === BlockType.Blinded) {
       if (!this.executionBuilder) throw Error("Execution Builder not available");
@@ -221,7 +221,7 @@ export async function produceBlockBody<T extends BlockType>(
 
       const fetchedTime = Date.now() / 1000 - computeTimeAtSlot(this.config, blockSlot, this.genesisTime);
       const prepType = PayloadPreparationType.Blinded;
-      this.metrics?.blockPayload.payloadFetchedTime.observe({prepType}, fetchedTime);
+      this.metrics?.blockPayload.payloadFetchedTime.observe({ prepType }, fetchedTime);
       this.logger.verbose("Fetched execution payload header from builder", {
         slot: blockSlot,
         executionPayloadValue,
@@ -263,20 +263,20 @@ export async function produceBlockBody<T extends BlockType>(
       }
 
       if (ForkSeq[fork] >= ForkSeq.deneb) {
-        const {blobKzgCommitments} = builderRes;
+        const { blobKzgCommitments } = builderRes;
         if (blobKzgCommitments === undefined) {
           throw Error(`Invalid builder getHeader response for fork=${fork}, missing blobKzgCommitments`);
         }
 
         (blockBody as deneb.BlindedBeaconBlockBody).blobKzgCommitments = blobKzgCommitments;
-        blobsResult = {type: BlobsResultType.blinded};
-        Object.assign(logMeta, {blobs: blobKzgCommitments.length});
+        blobsResult = { type: BlobsResultType.blinded };
+        Object.assign(logMeta, { blobs: blobKzgCommitments.length });
       } else {
-        blobsResult = {type: BlobsResultType.preDeneb};
+        blobsResult = { type: BlobsResultType.preDeneb };
       }
 
       if (ForkSeq[fork] >= ForkSeq.electra) {
-        const {executionRequests} = builderRes;
+        const { executionRequests } = builderRes;
         if (executionRequests === undefined) {
           throw Error(`Invalid builder getHeader response for fork=${fork}, missing executionRequests`);
         }
@@ -305,11 +305,11 @@ export async function produceBlockBody<T extends BlockType>(
         if (prepareRes.isPremerge) {
           (blockBody as BeaconBlockBody<ForkPostBellatrix>).executionPayload =
             sszTypesFor(fork).ExecutionPayload.defaultValue();
-          blobsResult = {type: BlobsResultType.preDeneb};
+          blobsResult = { type: BlobsResultType.preDeneb };
           executionPayloadValue = BigInt(0);
         } else {
-          const {prepType, payloadId} = prepareRes;
-          Object.assign(logMeta, {executionPayloadPrepType: prepType});
+          const { prepType, payloadId } = prepareRes;
+          Object.assign(logMeta, { executionPayloadPrepType: prepType });
 
           if (prepType !== PayloadPreparationType.Cached) {
             // Wait for 500ms to allow EL to add some txs to the payload
@@ -321,15 +321,15 @@ export async function produceBlockBody<T extends BlockType>(
           }
 
           const engineRes = await this.executionEngine.getPayload(fork, payloadId);
-          const {executionPayload, blobsBundle, executionRequests} = engineRes;
+          const { executionPayload, blobsBundle, executionRequests } = engineRes;
           shouldOverrideBuilder = engineRes.shouldOverrideBuilder;
 
           (blockBody as BeaconBlockBody<ForkPostBellatrix>).executionPayload = executionPayload;
           executionPayloadValue = engineRes.executionPayloadValue;
-          Object.assign(logMeta, {transactions: executionPayload.transactions.length, shouldOverrideBuilder});
+          Object.assign(logMeta, { transactions: executionPayload.transactions.length, shouldOverrideBuilder });
 
           const fetchedTime = Date.now() / 1000 - computeTimeAtSlot(this.config, blockSlot, this.genesisTime);
-          this.metrics?.blockPayload.payloadFetchedTime.observe({prepType}, fetchedTime);
+          this.metrics?.blockPayload.payloadFetchedTime.observe({ prepType }, fetchedTime);
           this.logger.verbose("Fetched execution payload from engine", {
             slot: blockSlot,
             executionPayloadValue,
@@ -339,7 +339,7 @@ export async function produceBlockBody<T extends BlockType>(
             executionHeadBlockHash: toRootHex(engineRes.executionPayload.blockHash),
           });
           if (executionPayload.transactions.length === 0) {
-            this.metrics?.blockPayload.emptyPayloads.inc({prepType});
+            this.metrics?.blockPayload.emptyPayloads.inc({ prepType });
           }
 
           if (ForkSeq[fork] >= ForkSeq.deneb) {
@@ -353,12 +353,12 @@ export async function produceBlockBody<T extends BlockType>(
 
             (blockBody as deneb.BeaconBlockBody).blobKzgCommitments = blobsBundle.commitments;
             const blockHash = toRootHex(executionPayload.blockHash);
-            const contents = {kzgProofs: blobsBundle.proofs, blobs: blobsBundle.blobs};
-            blobsResult = {type: BlobsResultType.produced, contents, blockHash};
+            const contents = { kzgProofs: blobsBundle.proofs, blobs: blobsBundle.blobs };
+            blobsResult = { type: BlobsResultType.produced, contents, blockHash };
 
-            Object.assign(logMeta, {blobs: blobsBundle.commitments.length});
+            Object.assign(logMeta, { blobs: blobsBundle.commitments.length });
           } else {
-            blobsResult = {type: BlobsResultType.preDeneb};
+            blobsResult = { type: BlobsResultType.preDeneb };
           }
 
           if (ForkSeq[fork] >= ForkSeq.electra) {
@@ -381,7 +381,7 @@ export async function produceBlockBody<T extends BlockType>(
           );
           (blockBody as BeaconBlockBody<ForkPostBellatrix>).executionPayload =
             sszTypesFor(fork).ExecutionPayload.defaultValue();
-          blobsResult = {type: BlobsResultType.preDeneb};
+          blobsResult = { type: BlobsResultType.preDeneb };
           executionPayloadValue = BigInt(0);
         } else {
           // since merge transition is complete, we need a valid payload even if with an
@@ -391,7 +391,7 @@ export async function produceBlockBody<T extends BlockType>(
       }
     }
   } else {
-    blobsResult = {type: BlobsResultType.preDeneb};
+    blobsResult = { type: BlobsResultType.preDeneb };
     executionPayloadValue = BigInt(0);
   }
   endExecutionPayload?.({
@@ -411,10 +411,10 @@ export async function produceBlockBody<T extends BlockType>(
     }
   }
 
-  Object.assign(logMeta, {executionPayloadValue});
+  Object.assign(logMeta, { executionPayloadValue });
   this.logger.verbose("Produced beacon block body", logMeta);
 
-  return {body: blockBody as AssembledBodyType<T>, blobs: blobsResult, executionPayloadValue, shouldOverrideBuilder};
+  return { body: blockBody as AssembledBodyType<T>, blobs: blobsResult, executionPayloadValue, shouldOverrideBuilder };
 }
 
 /**
@@ -437,14 +437,14 @@ export async function prepareExecutionPayload(
   finalizedBlockHash: RootHex,
   state: CachedBeaconStateExecutions,
   suggestedFeeRecipient: string
-): Promise<{isPremerge: true} | {isPremerge: false; prepType: PayloadPreparationType; payloadId: PayloadId}> {
+): Promise<{ isPremerge: true } | { isPremerge: false; prepType: PayloadPreparationType; payloadId: PayloadId }> {
   const parentHashRes = await getExecutionPayloadParentHash(chain, state);
   if (parentHashRes.isPremerge) {
     // Return null only if the execution is pre-merge
-    return {isPremerge: true};
+    return { isPremerge: true };
   }
 
-  const {parentHash} = parentHashRes;
+  const { parentHash } = parentHashRes;
   const timestamp = computeTimeAtSlot(chain.config, state.slot, state.genesisTime);
   const prevRandao = getRandaoMix(state, state.epochCtx.epoch);
 
@@ -468,7 +468,7 @@ export async function prepareExecutionPayload(
   } else {
     // If there was a payload assigned to this timestamp, it would imply that there some sort
     // of payload reorg, i.e. head, fee recipient or any other fcu param changed
-    if (chain.executionEngine.payloadIdCache.hasPayload({timestamp: numToQuantity(timestamp)})) {
+    if (chain.executionEngine.payloadIdCache.hasPayload({ timestamp: numToQuantity(timestamp) })) {
       prepType = PayloadPreparationType.Reorged;
     } else {
       prepType = PayloadPreparationType.Fresh;
@@ -488,7 +488,7 @@ export async function prepareExecutionPayload(
       finalizedBlockHash,
       attributes
     );
-    logger.verbose("Prepared payload id from execution engine", {payloadId});
+    logger.verbose("Prepared payload id from execution engine", { payloadId });
   }
 
   // Should never happen, notifyForkchoiceUpdate() with payload attributes always
@@ -500,7 +500,7 @@ export async function prepareExecutionPayload(
   // We are only returning payloadId here because prepareExecutionPayload is also called from
   // prepareNextSlot, which is an advance call to execution engine to start building payload
   // Actual payload isn't produced till getPayload is called.
-  return {isPremerge: false, payloadId, prepType};
+  return { isPremerge: false, payloadId, prepType };
 }
 
 async function prepareExecutionPayloadHeader(
@@ -527,7 +527,7 @@ async function prepareExecutionPayloadHeader(
     throw Error("Execution builder disabled pre-merge");
   }
 
-  const {parentHash} = parentHashRes;
+  const { parentHash } = parentHashRes;
   return chain.executionBuilder.getHeader(fork, state.slot, parentHash, proposerPubKey);
 }
 
@@ -537,12 +537,12 @@ export async function getExecutionPayloadParentHash(
     config: ChainForkConfig;
   },
   state: CachedBeaconStateExecutions
-): Promise<{isPremerge: true} | {isPremerge: false; parentHash: Root}> {
+): Promise<{ isPremerge: true } | { isPremerge: false; parentHash: Root }> {
   // Use different POW block hash parent for block production based on merge status.
   // Returned value of null == using an empty ExecutionPayload value
   if (isMergeTransitionComplete(state)) {
     // Post-merge, normal payload
-    return {isPremerge: false, parentHash: state.latestExecutionPayloadHeader.blockHash};
+    return { isPremerge: false, parentHash: state.latestExecutionPayloadHeader.blockHash };
   }
 
   if (
@@ -550,8 +550,7 @@ export async function getExecutionPayloadParentHash(
     getCurrentEpoch(state) < chain.config.TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
   ) {
     throw new Error(
-      `InvalidMergeTBH epoch: expected >= ${
-        chain.config.TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
+      `InvalidMergeTBH epoch: expected >= ${chain.config.TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
       }, actual: ${getCurrentEpoch(state)}`
     );
   }
@@ -559,10 +558,10 @@ export async function getExecutionPayloadParentHash(
   const terminalPowBlockHash = await chain.eth1.getTerminalPowBlock();
   if (terminalPowBlockHash === null) {
     // Pre-merge, no prepare payload call is needed
-    return {isPremerge: true};
+    return { isPremerge: true };
   }
   // Signify merge via producing on top of the last PoW block
-  return {isPremerge: false, parentHash: terminalPowBlockHash};
+  return { isPremerge: false, parentHash: terminalPowBlockHash };
 }
 
 export async function getPayloadAttributesForSSE(
@@ -576,12 +575,12 @@ export async function getPayloadAttributesForSSE(
     prepareSlot,
     parentBlockRoot,
     feeRecipient,
-  }: {prepareState: CachedBeaconStateExecutions; prepareSlot: Slot; parentBlockRoot: Root; feeRecipient: string}
+  }: { prepareState: CachedBeaconStateExecutions; prepareSlot: Slot; parentBlockRoot: Root; feeRecipient: string }
 ): Promise<SSEPayloadAttributes> {
   const parentHashRes = await getExecutionPayloadParentHash(chain, prepareState);
 
   if (!parentHashRes.isPremerge) {
-    const {parentHash} = parentHashRes;
+    const { parentHash } = parentHashRes;
     const payloadAttributes = preparePayloadAttributes(fork, chain, {
       prepareState,
       prepareSlot,
@@ -659,8 +658,8 @@ export async function produceCommonBlockBody<T extends BlockType>(
 ): Promise<CommonBlockBody> {
   const stepsMetrics =
     blockType === BlockType.Full
-      ? this.metrics?.executionBlockProductionTimeSteps
-      : this.metrics?.builderBlockProductionTimeSteps;
+      ? this.metrics?.blockProduction.executionBlockProductionTimeSteps
+      : this.metrics?.blockProduction.builderBlockProductionTimeSteps;
 
   const fork = currentState.config.getForkName(slot);
 
@@ -685,7 +684,7 @@ export async function produceCommonBlockBody<T extends BlockType>(
   });
 
   const endEth1DataAndDeposits = stepsMetrics?.startTimer();
-  const {eth1Data, deposits} = await this.eth1.getEth1DataAndDeposits(currentState);
+  const { eth1Data, deposits } = await this.eth1.getEth1DataAndDeposits(currentState);
   endEth1DataAndDeposits?.({
     step: BlockProductionStep.eth1DataAndDeposits,
   });

--- a/packages/beacon-node/src/metrics/metrics.ts
+++ b/packages/beacon-node/src/metrics/metrics.ts
@@ -2,6 +2,7 @@ import {ChainForkConfig} from "@lodestar/config";
 import {BeaconStateAllForks, getCurrentSlot} from "@lodestar/state-transition";
 import {Logger} from "@lodestar/utils";
 import {Metric, Registry} from "prom-client";
+import {ChainMetrics, createChainMetrics} from "../chain/chainMetrics.js";
 import {BeaconMetrics, createBeaconMetrics} from "./metrics/beacon.js";
 import {LodestarMetrics, createLodestarMetrics} from "./metrics/lodestar.js";
 import {collectNodeJSMetrics} from "./nodeJsMetrics.js";
@@ -11,6 +12,7 @@ import {ValidatorMonitor, createValidatorMonitor} from "./validatorMonitor.js";
 
 export type Metrics = BeaconMetrics &
   LodestarMetrics &
+  ChainMetrics &
   ValidatorMonitor & {register: RegistryMetricCreator; close: () => void};
 
 export function createMetrics(
@@ -23,6 +25,7 @@ export function createMetrics(
   const register = new RegistryMetricCreator();
   const beacon = createBeaconMetrics(register);
   const lodestar = createLodestarMetrics(register, opts.metadata, anchorState);
+  const chainMetrics = createChainMetrics(register);
 
   const genesisTime = anchorState.genesisTime;
   const validatorMonitor = createValidatorMonitor(lodestar, config, genesisTime, logger, opts);
@@ -47,6 +50,7 @@ export function createMetrics(
   return {
     ...beacon,
     ...lodestar,
+    ...chainMetrics,
     ...validatorMonitor,
     register,
     close,

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -1,13 +1,6 @@
-import {UpdateHeadOpt} from "@lodestar/fork-choice";
-import {NotReorgedReason} from "@lodestar/fork-choice/lib/forkChoice/interface.js";
-import {ProducedBlockSource} from "@lodestar/types";
-import {
-  BlockSelectionResult,
-  BuilderBlockSelectionReason,
-  EngineBlockSelectionReason,
-} from "../../api/impl/validator/index.js";
-import {BlockProductionStep, PayloadPreparationType} from "../../chain/produceBlock/index.js";
-import {RegistryMetricCreator} from "../utils/registryMetricCreator.js";
+import { ProducedBlockSource } from "@lodestar/types";
+import { BlockSelectionResult } from "../../api/impl/validator/index.js";
+import { RegistryMetricCreator } from "../utils/registryMetricCreator.js";
 
 export type BeaconMetrics = ReturnType<typeof createBeaconMetrics>;
 
@@ -21,198 +14,90 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
     // From https://github.com/ethereum/beacon-metrics/blob/master/metrics.md
     // Interop-metrics
 
-    headSlot: register.gauge({
-      name: "beacon_head_slot",
-      help: "slot of the head block of the beacon chain",
-    }),
-    finalizedEpoch: register.gauge({
-      name: "beacon_finalized_epoch",
-      help: "current finalized epoch",
-    }),
-    currentJustifiedEpoch: register.gauge({
-      name: "beacon_current_justified_epoch",
-      help: "current justified epoch",
-    }),
-    previousJustifiedEpoch: register.gauge({
-      name: "beacon_previous_justified_epoch",
-      help: "previous justified epoch",
-    }),
-    currentActiveValidators: register.gauge({
-      name: "beacon_current_active_validators",
-      help: "number of active validators in current epoch",
-    }),
-    reorgEventsTotal: register.gauge({
-      name: "beacon_reorgs_total",
-      help: "number of chain reorganizations",
-    }),
-    processedDepositsTotal: register.gauge({
-      name: "beacon_processed_deposits_total",
-      help: "number of total deposits included on chain",
-    }),
-
+    beaconMetricsSpecsInterop: {
+      headSlot: register.gauge({
+        name: "beacon_head_slot",
+        help: "slot of the head block of the beacon chain",
+      }),
+      finalizedEpoch: register.gauge({
+        name: "beacon_finalized_epoch",
+        help: "current finalized epoch",
+      }),
+      currentJustifiedEpoch: register.gauge({
+        name: "beacon_current_justified_epoch",
+        help: "current justified epoch",
+      }),
+      previousJustifiedEpoch: register.gauge({
+        name: "beacon_previous_justified_epoch",
+        help: "previous justified epoch",
+      }),
+      currentActiveValidators: register.gauge({
+        name: "beacon_current_active_validators",
+        help: "number of active validators in current epoch",
+      }),
+      // duplicates reorg from metrics.forkChoice
+      reorgEventsTotal: register.gauge({
+        name: "beacon_reorgs_total",
+        help: "number of chain reorganizations",
+      }),
+      processedDepositsTotal: register.gauge({
+        name: "beacon_processed_deposits_total",
+        help: "number of total deposits included on chain",
+      }),
+    },
     // From https://github.com/ethereum/beacon-metrics/blob/master/metrics.md
     // Additional Metrics
     // TODO: Implement
 
-    currentValidators: register.gauge<{status: string}>({
-      name: "beacon_current_validators",
-      labelNames: ["status"],
-      help: "number of validators in current epoch",
-    }),
+    // currentValidators: register.gauge<{status: string}>({
+    //   name: "beacon_current_validators",
+    //   labelNames: ["status"],
+    //   help: "number of validators in current epoch",
+    // }),
 
     // Non-spec'ed
 
-    forkChoice: {
-      findHead: register.histogram<{caller: string}>({
-        name: "beacon_fork_choice_find_head_seconds",
-        help: "Time taken to find head in seconds",
-        buckets: [0.1, 1, 10],
-        labelNames: ["caller"],
+    // validator api
+    api: {
+      blockProductionTime: register.histogram<{ source: ProducedBlockSource }>({
+        name: "beacon_block_production_seconds",
+        help: "Full runtime of block production",
+        buckets: [0.1, 1, 2, 4, 10],
+        labelNames: ["source"],
       }),
-      requests: register.gauge({
-        name: "beacon_fork_choice_requests_total",
-        help: "Count of occasions where fork choice has tried to find a head",
+      blockProductionRequests: register.gauge<{ source: ProducedBlockSource }>({
+        name: "beacon_block_production_requests_total",
+        help: "Count of all block production requests",
+        labelNames: ["source"],
       }),
-      errors: register.gauge<{entrypoint: UpdateHeadOpt}>({
-        name: "beacon_fork_choice_errors_total",
-        help: "Count of occasions where fork choice has returned an error when trying to find a head",
-        labelNames: ["entrypoint"],
+      blockProductionSuccess: register.gauge<{ source: ProducedBlockSource }>({
+        name: "beacon_block_production_successes_total",
+        help: "Count of blocks successfully produced",
+        labelNames: ["source"],
       }),
-      changedHead: register.gauge({
-        name: "beacon_fork_choice_changed_head_total",
-        help: "Count of occasions fork choice has found a new head",
+      // not used on the dashboard
+      blockProductionSelectionResults: register.gauge<BlockSelectionResult>({
+        name: "beacon_block_production_selection_results_total",
+        help: "Count of all block production selection results",
+        labelNames: ["source", "reason"],
       }),
-      reorg: register.gauge({
-        name: "beacon_fork_choice_reorg_total",
-        help: "Count of occasions fork choice has switched to a different chain",
+      // not used on the dashboard
+      blockProductionNumAggregated: register.histogram<{ source: ProducedBlockSource }>({
+        name: "beacon_block_production_num_aggregated_total",
+        help: "Count of all aggregated attestations in our produced block",
+        buckets: [32, 64, 96, 128],
+        labelNames: ["source"],
       }),
-      reorgDistance: register.histogram({
-        name: "beacon_fork_choice_reorg_distance",
-        help: "Histogram of re-org distance",
-        // We need high resolution in the low range, since re-orgs are a rare but critical event.
-        // Add buckets up to 100 to capture high depth re-orgs. Above 100 things are going really bad.
-        buckets: [1, 2, 3, 5, 7, 10, 20, 30, 50, 100],
-      }),
-      votes: register.gauge({
-        name: "beacon_fork_choice_votes_count",
-        help: "Current count of votes in fork choice data structures",
-      }),
-      queuedAttestations: register.gauge({
-        name: "beacon_fork_choice_queued_attestations_count",
-        help: "Count of queued_attestations in fork choice per slot",
-      }),
-      validatedAttestationDatas: register.gauge({
-        name: "beacon_fork_choice_validated_attestation_datas_count",
-        help: "Current count of validatedAttestationDatas in fork choice data structures",
-      }),
-      balancesLength: register.gauge({
-        name: "beacon_fork_choice_balances_length",
-        help: "Current length of balances in fork choice data structures",
-      }),
-      nodes: register.gauge({
-        name: "beacon_fork_choice_nodes_count",
-        help: "Current count of nodes in fork choice data structures",
-      }),
-      indices: register.gauge({
-        name: "beacon_fork_choice_indices_count",
-        help: "Current count of indices in fork choice data structures",
-      }),
-      notReorgedReason: register.gauge<{reason: NotReorgedReason}>({
-        name: "beacon_fork_choice_not_reorged_reason_total",
-        help: "Reason why the current head is not re-orged out",
-        labelNames: ["reason"],
+      // not used on the dashboard
+      blockProductionExecutionPayloadValue: register.histogram<{ source: ProducedBlockSource }>({
+        name: "beacon_block_production_execution_payload_value",
+        help: "Execution payload value denominated in ETH of produced blocks",
+        buckets: [0.001, 0.005, 0.01, 0.03, 0.05, 0.07, 0.1, 0.3, 0.5, 1],
+        labelNames: ["source"],
       }),
     },
 
-    parentBlockDistance: register.histogram({
-      name: "beacon_imported_block_parent_distance",
-      help: "Histogram of distance to parent block of valid imported blocks",
-      buckets: [1, 2, 3, 5, 7, 10, 20, 30, 50, 100],
-    }),
-
-    blockProductionTime: register.histogram<{source: ProducedBlockSource}>({
-      name: "beacon_block_production_seconds",
-      help: "Full runtime of block production",
-      buckets: [0.1, 1, 2, 4, 10],
-      labelNames: ["source"],
-    }),
-    executionBlockProductionTimeSteps: register.histogram<{step: BlockProductionStep}>({
-      name: "beacon_block_production_execution_steps_seconds",
-      help: "Detailed steps runtime of execution block production",
-      buckets: [0.01, 0.1, 0.2, 0.5, 1],
-      labelNames: ["step"],
-    }),
-    builderBlockProductionTimeSteps: register.histogram<{step: BlockProductionStep}>({
-      name: "beacon_block_production_builder_steps_seconds",
-      help: "Detailed steps runtime of builder block production",
-      buckets: [0.01, 0.1, 0.2, 0.5, 1],
-      labelNames: ["step"],
-    }),
-    blockProductionRequests: register.gauge<{source: ProducedBlockSource}>({
-      name: "beacon_block_production_requests_total",
-      help: "Count of all block production requests",
-      labelNames: ["source"],
-    }),
-    blockProductionSuccess: register.gauge<{source: ProducedBlockSource}>({
-      name: "beacon_block_production_successes_total",
-      help: "Count of blocks successfully produced",
-      labelNames: ["source"],
-    }),
-    blockProductionSelectionResults: register.gauge<BlockSelectionResult>({
-      name: "beacon_block_production_selection_results_total",
-      help: "Count of all block production selection results",
-      labelNames: ["source", "reason"],
-    }),
-    blockProductionNumAggregated: register.histogram<{source: ProducedBlockSource}>({
-      name: "beacon_block_production_num_aggregated_total",
-      help: "Count of all aggregated attestations in our produced block",
-      buckets: [32, 64, 96, 128],
-      labelNames: ["source"],
-    }),
-    blockProductionExecutionPayloadValue: register.histogram<{source: ProducedBlockSource}>({
-      name: "beacon_block_production_execution_payload_value",
-      help: "Execution payload value denominated in ETH of produced blocks",
-      buckets: [0.001, 0.005, 0.01, 0.03, 0.05, 0.07, 0.1, 0.3, 0.5, 1],
-      labelNames: ["source"],
-    }),
-
-    blockProductionCaches: {
-      producedBlockRoot: register.gauge({
-        name: "beacon_blockroot_produced_cache_total",
-        help: "Count of cached produced block roots",
-      }),
-      producedBlindedBlockRoot: register.gauge({
-        name: "beacon_blinded_blockroot_produced_cache_total",
-        help: "Count of cached produced blinded block roots",
-      }),
-      producedContentsCache: register.gauge({
-        name: "beacon_contents_produced_cache_total",
-        help: "Count of cached produced blob contents",
-      }),
-    },
-
-    blockPayload: {
-      payloadAdvancePrepTime: register.histogram({
-        name: "beacon_block_payload_prepare_time",
-        help: "Time for preparing payload in advance",
-        buckets: [0.1, 1, 3, 5, 10],
-      }),
-      payloadFetchedTime: register.histogram<{prepType: PayloadPreparationType}>({
-        name: "beacon_block_payload_fetched_time",
-        help: "Time to fetch the payload from EL",
-        labelNames: ["prepType"],
-      }),
-      emptyPayloads: register.gauge<{prepType: PayloadPreparationType}>({
-        name: "beacon_block_payload_empty_total",
-        help: "Count of payload with empty transactions",
-        labelNames: ["prepType"],
-      }),
-      payloadFetchErrors: register.gauge({
-        name: "beacon_block_payload_errors_total",
-        help: "Count of errors while fetching payloads",
-      }),
-    },
-
+    // network
     blockInputFetchStats: {
       // of already available blocks which didn't have to go through blobs pull
       totalDataAvailableBlockInputBlobs: register.gauge({
@@ -338,20 +223,5 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
         help: "datapromise retry tracker cache pruned count",
       }),
     },
-
-    // Non-spec'ed
-    clockSlot: register.gauge({
-      name: "beacon_clock_slot",
-      help: "Current clock slot",
-    }),
-    clockEpoch: register.gauge({
-      name: "beacon_clock_epoch",
-      help: "Current clock epoch",
-    }),
-
-    weakHeadDetected: register.gauge({
-      name: "beacon_weak_head_detected_total",
-      help: "Detected current head block is weak. May reorg it out when proposing next slot. See proposer boost reorg for more",
-    }),
   };
 }


### PR DESCRIPTION
**Motivation**

Organize and update metrics as part of the effort to resolve #7098.

**Description**

- Group beacon metrics.
- Create ChainMetrics type in chain domain and move related metrics into it.

Partially closes #7098

**Steps to test or reproduce**

- Check chain related dashboards.
