### PR TITLE
feat: improve blacklisted blocks feature

### DIFF
--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -75,6 +75,8 @@ export type LodestarNodePeer = NodePeer & {
   agentVersion: string;
 };
 
+export type BlacklistedBlock = {root: RootHex; slot: Slot | null};
+
 export type LodestarThreadType = "main" | "network" | "discv5";
 
 const HistoricalSummariesResponseType = new ContainerType(
@@ -224,6 +226,16 @@ export type Endpoints = {
     {query: {state?: PeerState[]; direction?: PeerDirection[]}},
     LodestarNodePeer[],
     {count: number}
+  >;
+
+  /** Returns root/slot of blacklisted blocks */
+  getBlacklistedBlocks: Endpoint<
+    // ⏎
+    "GET",
+    EmptyArgs,
+    EmptyRequest,
+    BlacklistedBlock[],
+    EmptyMeta
   >;
 
   /** Returns historical summaries and proof for a given state ID */
@@ -385,6 +397,12 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         parseReq: ({query}) => ({state: query.state, direction: query.direction}),
         schema: {query: {state: Schema.StringArray, direction: Schema.StringArray}},
       },
+      resp: JsonOnlyResponseCodec,
+    },
+    getBlacklistedBlocks: {
+      url: "/eth/v1/lodestar/blacklisted_blocks",
+      method: "GET",
+      req: EmptyRequestCodec,
       resp: JsonOnlyResponseCodec,
     },
     getHistoricalSummaries: {

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -167,6 +167,12 @@ export function getLodestarApi({
       };
     },
 
+    async getBlacklistedBlocks() {
+      return {
+        data: Array.from(chain.blacklistedBlocks.entries()).map(([root, slot]) => ({root, slot})),
+      };
+    },
+
     async discv5GetKadValues() {
       return {
         data: await network.dumpDiscv5KadValues(),

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -168,7 +168,7 @@ export class BeaconChain implements IBeaconChain {
   // actual publish
   readonly producedBlockRoot = new Map<RootHex, ExecutionPayload | null>();
   readonly producedBlindedBlockRoot = new Set<RootHex>();
-  readonly blacklistedBlocks: Set<RootHex>;
+  readonly blacklistedBlocks: Map<RootHex, Slot | null>;
 
   readonly serializedCache: SerializedCache;
 
@@ -233,7 +233,7 @@ export class BeaconChain implements IBeaconChain {
 
     if (!clock) clock = new Clock({config, genesisTime: this.genesisTime, signal});
 
-    this.blacklistedBlocks = new Set(opts.blacklistedBlocks ?? []);
+    this.blacklistedBlocks = new Map((opts.blacklistedBlocks ?? []).map((hex) => [hex, null]));
     const preAggregateCutOffTime = (2 / 3) * this.config.SECONDS_PER_SLOT;
     this.attestationPool = new AttestationPool(
       config,

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -129,7 +129,7 @@ export interface IBeaconChain {
   readonly producedBlockRoot: Map<RootHex, ExecutionPayload | null>;
   readonly shufflingCache: ShufflingCache;
   readonly producedBlindedBlockRoot: Set<RootHex>;
-  readonly blacklistedBlocks: Set<RootHex>;
+  readonly blacklistedBlocks: Map<RootHex, Slot | null>;
   // Cache for serialized objects
   readonly serializedCache: SerializedCache;
 

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -41,6 +41,7 @@ describe("produceBlockBody", () => {
       {
         config: state.config,
         db,
+        dataDir: ".",
         logger,
         processShutdownCallback: () => {},
         metrics: null,

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -90,6 +90,7 @@ describe.skip("verify+import blocks - range sync perf test", () => {
         {
           config: state.config,
           db,
+          dataDir: ".",
           logger,
           processShutdownCallback: () => {},
           metrics: null,

--- a/packages/beacon-node/test/utils/networkWithMockDb.ts
+++ b/packages/beacon-node/test/utils/networkWithMockDb.ts
@@ -60,6 +60,7 @@ export async function getNetworkForTest(
     {
       config: beaconConfig,
       db,
+      dataDir: ".",
       logger,
       processShutdownCallback: () => {},
       // set genesis time so that we are at ALTAIR_FORK_EPOCH

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -112,6 +112,7 @@ export const options: CliCommandOptions<ChainArgs> = {
   "chain.blacklistedBlocks": {
     hidden: true,
     type: "array",
+    string: true,
     description:
       "Comma-separated list of 0x-prefixed root hex's for blocks that should not be allowed through processing",
     group: "chain",


### PR DESCRIPTION
Follow up on https://github.com/ChainSafe/lodestar/pull/7498 to improve the blacklisted blocks feature
- adds new endpoint `/eth/v1/lodestar/blacklisted_blocks` to return root/slot of blacklisted blocks
- updates blacklisted blocks store on chain to use `Map` to also keep track of slot
- proper parsing of root hex values passed through CLI flag to make sure those are handled as `string` and not `number`
- add unit test to sanity check implementation + various type issue fixed not caught due to previous tsconfig issue