### PR TITLE
fix: Remove redundant strictFeeRecipientCheck from log context

### DIFF
--- a/packages/validator/src/services/block.ts
+++ b/packages/validator/src/services/block.ts
@@ -230,8 +230,6 @@ export class BlockProposingService {
       executionPayloadValue: prettyWeiToEth(meta.executionPayloadValue),
       consensusBlockValue: prettyWeiToEth(meta.consensusBlockValue),
       totalBlockValue: prettyWeiToEth(meta.executionPayloadValue + meta.consensusBlockValue),
-      // TODO PR: should be used in api call instead of adding in log
-      strictFeeRecipientCheck,
       builderSelection,
       api: "produceBlockV3",
     };


### PR DESCRIPTION
**Motivation**

The `strictFeeRecipientCheck` parameter was being passed to the API call but was also redundantly included in the log context with a TODO comment indicating it should be removed.


**Description**

This PR removes the redundant `strictFeeRecipientCheck` parameter from the log context in the `produceBlockWrapper` method of the `BlockProposingService` class. The parameter is already being passed to the API call, so there's no need to include it in the log context as well.

Closes #issue_number

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
