### PR TITLE
chore: bump CL spec to v1.5.0-beta.3

### DIFF
--- a/packages/beacon-node/test/spec/presets/ssz_static.test.ts
+++ b/packages/beacon-node/test/spec/presets/ssz_static.test.ts
@@ -41,6 +41,7 @@ const sszStatic =
     if (skippedTypes?.includes(typeName)) {
       return;
     }
+    console.log(fork);
 
     /* eslint-disable @typescript-eslint/strict-boolean-expressions */
     const sszType =
@@ -80,7 +81,7 @@ const sszStatic =
 specTestIterator(path.join(ethereumConsensusSpecsTests.outputDir, "tests", ACTIVE_PRESET), {
   ssz_static: {
     type: RunnerType.custom,
-    // starting from v1.4.0-beta.6, there is "whisk" fork in ssz_static tests but we ignore them
-    fn: sszStatic("whisk"),
+    // starting from v1.5.0-beta.3, there is "eip7441" fork in ssz_static tests but we ignore them
+    fn: sszStatic("eip7441"),
   },
 });

--- a/packages/beacon-node/test/spec/presets/ssz_static.test.ts
+++ b/packages/beacon-node/test/spec/presets/ssz_static.test.ts
@@ -41,7 +41,6 @@ const sszStatic =
     if (skippedTypes?.includes(typeName)) {
       return;
     }
-    console.log(fork);
 
     /* eslint-disable @typescript-eslint/strict-boolean-expressions */
     const sszType =

--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -14,7 +14,7 @@ import {DownloadTestsOptions} from "@lodestar/spec-test-util/downloadTests";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: DownloadTestsOptions = {
-  specVersion: "v1.5.0-beta.2",
+  specVersion: "v1.5.0-beta.3",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-spec-tests",

--- a/packages/params/test/e2e/ensure-config-is-synced.test.ts
+++ b/packages/params/test/e2e/ensure-config-is-synced.test.ts
@@ -8,7 +8,7 @@ import {loadConfigYaml} from "../yaml.js";
 // Not e2e, but slow. Run with e2e tests
 
 /** https://github.com/ethereum/consensus-specs/releases */
-const specConfigCommit = "v1.5.0-beta.2";
+const specConfigCommit = "v1.5.0-beta.3";
 /**
  * Fields that we filter from local config when doing comparison.
  * Ideally this should be empty as it is not spec compliant


### PR DESCRIPTION
Run against latest spec tests from [v1.5.0-beta.3](https://github.com/ethereum/consensus-specs/releases/tag/v1.5.0-beta.3)