### PR TITLE
fix: use PRE_ELECTRA_SINGLE_ATTESTATION_COMMITTEE_INDEX for pre-electra

### DIFF
--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -502,7 +502,9 @@ async function validateAttestationNoSignatureCheck(
     attDataRootHex = toRootHex(ssz.phase0.AttestationData.hashTreeRoot(attData));
     if (attDataKey) {
       // for pre-electra, committee index key is 0. See SeenAttestationDatas.add() documentation
-      const committeeIndexKey = isForkPostElectra(fork) ? committeeIndex : PRE_ELECTRA_SINGLE_ATTESTATION_COMMITTEE_INDEX;
+      const committeeIndexKey = isForkPostElectra(fork)
+        ? committeeIndex
+        : PRE_ELECTRA_SINGLE_ATTESTATION_COMMITTEE_INDEX;
       chain.seenAttestationDatas.add(attSlot, committeeIndexKey, attDataKey, {
         committeeValidatorIndices,
         committeeIndex,

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -501,9 +501,11 @@ async function validateAttestationNoSignatureCheck(
     // add cached attestation data before verifying signature
     attDataRootHex = toRootHex(ssz.phase0.AttestationData.hashTreeRoot(attData));
     if (attDataKey) {
-      chain.seenAttestationDatas.add(attSlot, committeeIndex, attDataKey, {
+      // for pre-electra, committee index key is 0. See SeenAttestationDatas.add() documentation
+      const committeeIndexKey = isForkPostElectra(fork) ? committeeIndex : PRE_ELECTRA_SINGLE_ATTESTATION_COMMITTEE_INDEX;
+      chain.seenAttestationDatas.add(attSlot, committeeIndexKey, attDataKey, {
         committeeValidatorIndices,
-        committeeIndex: isForkPostElectra(fork) ? committeeIndex : PRE_ELECTRA_SINGLE_ATTESTATION_COMMITTEE_INDEX,
+        committeeIndex,
         signingRoot: signatureSet.signingRoot,
         subnet: expectedSubnet,
         // precompute this to be used in forkchoice

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -503,7 +503,7 @@ async function validateAttestationNoSignatureCheck(
     if (attDataKey) {
       chain.seenAttestationDatas.add(attSlot, committeeIndex, attDataKey, {
         committeeValidatorIndices,
-        committeeIndex,
+        committeeIndex: isForkPostElectra(fork) ? committeeIndex : PRE_ELECTRA_SINGLE_ATTESTATION_COMMITTEE_INDEX,
         signingRoot: signatureSet.signingRoot,
         subnet: expectedSubnet,
         // precompute this to be used in forkchoice


### PR DESCRIPTION
**Motivation**

- see gossip attestation validation performance regression in #7588 since v1.26.0

**Description**

- SeenAttestationData specified that we must use `PRE_ELECTRA_SINGLE_ATTESTATION_COMMITTEE_INDEX` in its add() function see https://github.com/ChainSafe/lodestar/blob/6f2a8498433c934b1be73894e0bd1edd758c47f5/packages/beacon-node/src/chain/seenCache/seenAttestationData.ts#L78 and also get() function
- in gossip attestation validation code, we correctly specify `PRE_ELECTRA_SINGLE_ATTESTATION_COMMITTEE_INDEX` for get() function but did not do for add() function

Closes #7588
