### PR TITLE
chore: use MIN_GENESIS_ACTIVE_VALIDATOR_COUNT from mainnet in hoodi network config

### DIFF
--- a/packages/config/src/chainConfig/networks/hoodi.ts
+++ b/packages/config/src/chainConfig/networks/hoodi.ts
@@ -12,7 +12,6 @@ export const hoodiChainConfig: ChainConfig = {
 
   // Genesis
   // ---------------------------------------------------------------
-  MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 1000000,
   // 2025-Mar-17 12:00:00 PM UTC
   MIN_GENESIS_TIME: 1742212800,
   GENESIS_DELAY: 600,


### PR DESCRIPTION
This value will be updated by https://github.com/eth-clients/hoodi/pull/5, this should be part of our next rc but it's a inconsequential change as both `MIN_GENESIS_ACTIVE_VALIDATOR_COUNT` values `1000000` vs. `16384` are already fulfilled by genesis state so "waiting for genesis validators" will not happen.

this is the code I am talking about
https://github.com/ChainSafe/lodestar/blob/f55be17bd3158f207402648da278db9560be7e91/packages/beacon-node/src/chain/genesis/genesis.ts#L140