### PR TITLE
feat: lazy load pending partial withdrawal in getPendingBalanceToWithdraw

### DIFF
--- a/packages/state-transition/src/util/validator.ts
+++ b/packages/state-transition/src/util/validator.ts
@@ -83,11 +83,15 @@ export function getMaxEffectiveBalance(withdrawalCredentials: Uint8Array): numbe
 }
 
 export function getPendingBalanceToWithdraw(state: CachedBeaconStateElectra, validatorIndex: ValidatorIndex): number {
-  let total = 0;
+  const pendingPartialWithdrawalsLength = state.pendingPartialWithdrawals.length;
 
+  if (pendingPartialWithdrawalsLength === 0) {
+    return 0;
+  }
+
+  let total = 0;
   let chunkStartIndex = 0;
   const chunkSize = 100;
-  const pendingPartialWithdrawalsLength = state.pendingPartialWithdrawals.length;
 
   while (chunkStartIndex < pendingPartialWithdrawalsLength) {
     const pendingPartialWIthdrawalChunk = state.pendingPartialWithdrawals.getReadonlyByRange(

--- a/packages/state-transition/src/util/validator.ts
+++ b/packages/state-transition/src/util/validator.ts
@@ -84,10 +84,25 @@ export function getMaxEffectiveBalance(withdrawalCredentials: Uint8Array): numbe
 
 export function getPendingBalanceToWithdraw(state: CachedBeaconStateElectra, validatorIndex: ValidatorIndex): number {
   let total = 0;
-  for (const item of state.pendingPartialWithdrawals.getAllReadonly()) {
-    if (item.validatorIndex === validatorIndex) {
-      total += Number(item.amount);
+
+  let chunkStartIndex = 0;
+  const chunkSize = 100;
+  const pendingPartialWithdrawalsLength = state.pendingPartialWithdrawals.length;
+
+  while (chunkStartIndex < pendingPartialWithdrawalsLength) {
+    const pendingPartialWIthdrawalChunk = state.pendingPartialWithdrawals.getReadonlyByRange(
+      chunkStartIndex,
+      chunkSize
+    );
+
+    for (const pendingPartialWithdrawal of pendingPartialWIthdrawalChunk) {
+      if (pendingPartialWithdrawal.validatorIndex === validatorIndex) {
+        total += Number(pendingPartialWithdrawal.amount);
+      }
     }
+
+    chunkStartIndex += chunkSize;
   }
+
   return total;
 }


### PR DESCRIPTION
`getPendingBalanceToWithdraw` is calling `state.pendingPartialWithdrawals.getAllReadonly()` which could lead to performance issue if it is large. 

Calling `getReadonlyByRange` instead, but we should explore if a pending balance cache is useful for callers of `getPendingBalanceToWithdraw`.

Related to #7566