### PR TITLE
fix: handle empty pending deposit case in `processPendingDeposits`

### DIFF
--- a/packages/state-transition/src/epoch/processPendingDeposits.ts
+++ b/packages/state-transition/src/epoch/processPendingDeposits.ts
@@ -29,6 +29,13 @@ export function processPendingDeposits(state: CachedBeaconStateElectra, cache: E
   // TODO: is this a good number?
   const chunk = 100;
   const pendingDepositsLength = state.pendingDeposits.length;
+
+  if (pendingDepositsLength === 0) {
+    // Need to handle length = 0 case because state.pendingDeposits.getReadonlyByRange will throw error
+    state.depositBalanceToConsume = 0n;
+    return;
+  }
+
   outer: while (startIndex < pendingDepositsLength) {
     const deposits = state.pendingDeposits.getReadonlyByRange(startIndex, chunk);
 


### PR DESCRIPTION
With the change introduced in #7566 , `getReadonlyByRange()` in `processPendingDeposits` will always return error if `state.pendingDeposits` is empty.

Adding a check to ensure we don't call `getReadonlyByRange()` if empty.