### PR TITLE
feat: ssz v1.2.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@chainsafe/persistent-merkle-tree": "^1.0.1",
-    "@chainsafe/ssz": "^1.0.2",
+    "@chainsafe/ssz": "^1.2.0",
     "@lodestar/config": "^1.28.1",
     "@lodestar/params": "^1.28.1",
     "@lodestar/types": "^1.28.1",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -104,7 +104,7 @@
     "@chainsafe/persistent-merkle-tree": "^1.0.1",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/pubkey-index-map": "2.0.0",
-    "@chainsafe/ssz": "^1.0.2",
+    "@chainsafe/ssz": "^1.2.0",
     "@chainsafe/threads": "^1.11.1",
     "@ethersproject/abi": "^5.7.0",
     "@fastify/bearer-auth": "^10.0.1",

--- a/packages/beacon-node/test/spec/utils/runValidSszTest.ts
+++ b/packages/beacon-node/test/spec/utils/runValidSszTest.ts
@@ -81,13 +81,10 @@ export function runValidSszTest(type: Type<unknown>, testData: ValidTestCaseData
   // 0x0000000000000000000000000000000000000000000000000000000000000000
   if (process.env.RENDER_ROOTS) {
     if (type.isBasic) {
-      console.log("ROOTS Basic", toHexString(type.serialize(testDataValue)));
+      console.log("Chunk Basic", toHexString(type.serialize(testDataValue)));
     } else {
-      const roots = (type as CompositeType<unknown, unknown, unknown>)["getRoots"](testDataValue);
-      console.log(
-        "ROOTS Composite",
-        roots.map((root) => toHexString(root))
-      );
+      const blockBytes = (type as CompositeType<unknown, unknown, unknown>)["getBlocksBytes"](testDataValue);
+      console.log("chunkBytes Composite", toHexString(blockBytes));
     }
   }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",
     "@chainsafe/persistent-merkle-tree": "^1.0.1",
-    "@chainsafe/ssz": "^1.0.2",
+    "@chainsafe/ssz": "^1.2.0",
     "@chainsafe/threads": "^1.11.1",
     "@libp2p/crypto": "^4.1.0",
     "@libp2p/peer-id": "^4.1.0",

--- a/packages/cli/src/applyPreset.ts
+++ b/packages/cli/src/applyPreset.ts
@@ -1,7 +1,6 @@
 // MUST import this file first before anything and not import any Lodestar code.
-
 import {setHasher} from "@chainsafe/persistent-merkle-tree";
-import {hasher} from "@chainsafe/persistent-merkle-tree/hasher/as-sha256";
+import {hasher} from "@chainsafe/persistent-merkle-tree/hasher/hashtree";
 
 // without setting this first, persistent-merkle-tree will use noble instead
 setHasher(hasher);

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -37,8 +37,8 @@ const EIGHT_GB = 8 * 1024 * 1024 * 1024;
 export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void> {
   const {config, options, beaconPaths, network, version, commit, peerId, logger} = await beaconHandlerInit(args);
 
-  if (hasher.name !== "as-sha256") {
-    throw Error(`Loaded incorrect hasher ${hasher.name}, expected as-sha256`);
+  if (hasher.name !== "hashtree") {
+    throw Error(`Loaded incorrect hasher ${hasher.name}, expected hashtree`);
   }
 
   const heapSizeLimit = getHeapStatistics().heap_size_limit;

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -64,7 +64,7 @@
     "blockchain"
   ],
   "dependencies": {
-    "@chainsafe/ssz": "^1.0.2",
+    "@chainsafe/ssz": "^1.2.0",
     "@lodestar/params": "^1.28.1",
     "@lodestar/types": "^1.28.1",
     "@lodestar/utils": "^1.28.1"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -35,7 +35,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^1.0.2",
+    "@chainsafe/ssz": "^1.2.0",
     "@lodestar/config": "^1.28.1",
     "@lodestar/utils": "^1.28.1",
     "classic-level": "^1.4.1",

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -36,7 +36,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^1.0.2",
+    "@chainsafe/ssz": "^1.2.0",
     "@lodestar/config": "^1.28.1",
     "@lodestar/params": "^1.28.1",
     "@lodestar/state-transition": "^1.28.1",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -73,7 +73,7 @@
     "@chainsafe/bls": "7.1.3",
     "@chainsafe/blst": "^0.2.0",
     "@chainsafe/persistent-merkle-tree": "^1.0.1",
-    "@chainsafe/ssz": "^1.0.2",
+    "@chainsafe/ssz": "^1.2.0",
     "@lodestar/api": "^1.28.1",
     "@lodestar/config": "^1.28.1",
     "@lodestar/params": "^1.28.1",

--- a/packages/prover/src/cli/applyPreset.ts
+++ b/packages/prover/src/cli/applyPreset.ts
@@ -1,7 +1,7 @@
 // MUST import this file first before anything and not import any Lodestar code.
 
 import {setHasher} from "@chainsafe/persistent-merkle-tree";
-import {hasher} from "@chainsafe/persistent-merkle-tree/hasher/as-sha256";
+import {hasher} from "@chainsafe/persistent-merkle-tree/hasher/hashtree";
 
 // without setting this first, persistent-merkle-tree will use noble instead
 setHasher(hasher);

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -63,7 +63,7 @@
     "@chainsafe/persistent-merkle-tree": "^1.0.1",
     "@chainsafe/persistent-ts": "^1.0.0",
     "@chainsafe/pubkey-index-map": "2.0.0",
-    "@chainsafe/ssz": "^1.0.2",
+    "@chainsafe/ssz": "^1.2.0",
     "@chainsafe/swap-or-not-shuffle": "^1.2.1",
     "@lodestar/config": "^1.28.1",
     "@lodestar/params": "^1.28.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -70,7 +70,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/ssz": "^1.0.2",
+    "@chainsafe/ssz": "^1.2.0",
     "@lodestar/params": "^1.28.1",
     "ethereum-cryptography": "^2.0.0"
   },

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "@chainsafe/blst": "^2.1.0",
-    "@chainsafe/ssz": "^1.0.2",
+    "@chainsafe/ssz": "^1.2.0",
     "@lodestar/api": "^1.28.1",
     "@lodestar/config": "^1.28.1",
     "@lodestar/db": "^1.28.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -439,6 +439,11 @@
   resolved "https://registry.yarnpkg.com/@chainsafe/as-chacha20poly1305/-/as-chacha20poly1305-0.1.0.tgz#7da6f8796f9b42dac6e830a086d964f1f9189e09"
   integrity sha512-BpNcL8/lji/GM3+vZ/bgRWqJ1q5kwvTFmGPk7pxm/QQZDbaMI98waOHjEymTjq2JmdD/INdNBFOVSyJofXg7ew==
 
+"@chainsafe/as-sha256@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-1.1.0.tgz#949082ab96e0b266484f01f59a71930761afc6c4"
+  integrity sha512-pLlxYtfYy2YW5GN+7d946UAjBOS9VOFulkfFN6Z+84ZhMP0Ey8XsCG21CZTczwq1C8J7/4z8LGzmrAtmQ37VCQ==
+
 "@chainsafe/as-sha256@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.4.1.tgz#cfc0737e25f8c206767bdb6703e7943e5d44513e"
@@ -696,6 +701,15 @@
   dependencies:
     "@chainsafe/is-ip" "^2.0.1"
 
+"@chainsafe/persistent-merkle-tree@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-1.1.0.tgz#d10d9e926f2c5751d02a188b8fb6823821572aca"
+  integrity sha512-UIcKEGkEGghTXbFTvKqIiN2iljg2f6c2Y8GxdQEyle5UI6YIB8d3ACYTkAhrHSB4YsNlG9pc/A0NGJw/3Hf9wQ==
+  dependencies:
+    "@chainsafe/as-sha256" "1.1.0"
+    "@chainsafe/hashtree" "1.0.1"
+    "@noble/hashes" "^1.3.0"
+
 "@chainsafe/persistent-merkle-tree@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.6.1.tgz#37bde25cf6cbe1660ad84311aa73157dc86ec7f2"
@@ -704,7 +718,7 @@
     "@chainsafe/as-sha256" "^0.4.1"
     "@noble/hashes" "^1.3.0"
 
-"@chainsafe/persistent-merkle-tree@^1.0.1", "@chainsafe/persistent-merkle-tree@^1.0.2":
+"@chainsafe/persistent-merkle-tree@^1.0.1":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-1.0.2.tgz#e6154d3f6a2046c06f0ff64ac5634b72057959f3"
   integrity sha512-9yPy1T8VIsN5pogFjMOW7bUATyoQShoKRu/7YUpHb8bkAeMk+5jUHA9FY3rWdGTApnAQnCQNbVcg+VCJfZt8cg==
@@ -767,13 +781,13 @@
     "@chainsafe/as-sha256" "^0.4.1"
     "@chainsafe/persistent-merkle-tree" "^0.6.1"
 
-"@chainsafe/ssz@^1.0.2":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-1.0.3.tgz#c15fede5c1c75bc153b9b0c95e9d4953ecc31a1b"
-  integrity sha512-vmvR2FNpCHKK88E1vi1x2EzMMuYd6HTS9/lS63yX9yU4r4xe3keZ8SHcFmX0tZN+rGGPO52jXLNVWQpJI5uLmw==
+"@chainsafe/ssz@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-1.2.0.tgz#7201cc885460bfd4cf991791070100c3512aba1e"
+  integrity sha512-fsFFBfT5JPCypyzENDg6srd6woNMj0+x6OLR5X1di+IK5mYlxBiAVsH/bYVj/u5DE3nanAgPZOc5KSszoDBRvw==
   dependencies:
-    "@chainsafe/as-sha256" "^1.0.1"
-    "@chainsafe/persistent-merkle-tree" "^1.0.2"
+    "@chainsafe/as-sha256" "1.1.0"
+    "@chainsafe/persistent-merkle-tree" "1.1.0"
 
 "@chainsafe/swap-or-not-shuffle-darwin-arm64@1.2.1":
   version "1.2.1"


### PR DESCRIPTION
**Motivation**

- as v1.28.0 was released, we want to upgrade to ssz v1.2.0 to test the batch hash asap and unblock other works

**Description**

- replace ssz v1.0.2 by v1.2.0
