### PR TITLE
fix: change hoodi's SECONDS_PER_ETH1_BLOCK config from 14s to 12s.

### DIFF
--- a/packages/config/src/chainConfig/networks/hoodi.ts
+++ b/packages/config/src/chainConfig/networks/hoodi.ts
@@ -41,7 +41,7 @@ export const hoodiChainConfig: ChainConfig = {
 
   // Time parameters
   // ---------------------------------------------------------------
-  // 12 Update from older mainnet default of 14
+  // 12 (update from older mainnet default of 14)
   SECONDS_PER_ETH1_BLOCK: 12,
 
   // Deposit contract

--- a/packages/config/src/chainConfig/networks/hoodi.ts
+++ b/packages/config/src/chainConfig/networks/hoodi.ts
@@ -39,6 +39,11 @@ export const hoodiChainConfig: ChainConfig = {
   FULU_FORK_VERSION: b("0x70000910"),
   FULU_FORK_EPOCH: Infinity,
 
+  // Time parameters
+  // ---------------------------------------------------------------
+  // 12 Update from older mainnet default of 14
+  SECONDS_PER_ETH1_BLOCK: 12,
+
   // Deposit contract
   // ---------------------------------------------------------------
   DEPOSIT_CHAIN_ID: 560048,


### PR DESCRIPTION
**Motivation**

Lodestar VC does not start with other BNs on Hoodi because of mismatching local and remote specs. 

![lodestarestartingr](https://github.com/user-attachments/assets/61e40278-174c-404b-8d66-e5549b594778)


**Description**

The hoodi spec has changed the `SECONDS_PER_ETH1_BLOCKS:` value to 12 https://github.com/eth-clients/hoodi/blob/main/metadata/config.yaml#L53 while in lodestar, it [pulls the mainnet spec](https://github.com/ChainSafe/lodestar/blob/unstable/packages/config/src/chainConfig/networks/hoodi.ts#L9) which is still 14. 


**Steps to test or reproduce**

```sh
# Curl a config endpoint on a hoodi BN and observe that the SECONDS_PER_ETH1_BLOCK == 12 not the expected 14. 
wget -qO- http://localhost:4000/eth/v1/config/spec
```
> ... "SECONDS_PER_ETH1_BLOCK":"12" ...

It might be appropriate to update the mainnet or minimal spec at some point if the plan is to change it at Pectra. For now I put the change in hoodi.ts
