### PR TITLE
feat: add Electra state pending consolidations endpoint

### DIFF
--- a/packages/api/src/beacon/routes/beacon/state.ts
+++ b/packages/api/src/beacon/routes/beacon/state.ts
@@ -295,6 +295,19 @@ export type Endpoints = {
     electra.PendingPartialWithdrawals,
     ExecutionOptimisticFinalizedAndVersionMeta
   >;
+
+  /**
+   * Get State Pending Consolidations
+   *
+   * Returns pending consolidations for state with given 'stateId'.
+   */
+  getPendingConsolidations: Endpoint<
+    "GET",
+    StateArgs,
+    {params: {state_id: string}},
+    electra.PendingConsolidations,
+    ExecutionOptimisticFinalizedAndVersionMeta
+  >;
 };
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -527,6 +540,15 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       req: stateIdOnlyReq,
       resp: {
         data: ssz.electra.PendingPartialWithdrawals,
+        meta: ExecutionOptimisticFinalizedAndVersionCodec,
+      },
+    },
+    getPendingConsolidations: {
+      url: "/eth/v1/beacon/states/{state_id}/pending_consolidations",
+      method: "GET",
+      req: stateIdOnlyReq,
+      resp: {
+        data: ssz.electra.PendingConsolidations,
         meta: ExecutionOptimisticFinalizedAndVersionCodec,
       },
     },

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -20,7 +20,7 @@ import {testData as validatorTestData} from "./testData/validator.js";
 // Solutions: https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const version = "v3.0.0";
+const version = "v3.1.0";
 const openApiFile: OpenApiFile = {
   url: `https://github.com/ethereum/beacon-APIs/releases/download/${version}/beacon-node-oapi.json`,
   filepath: path.join(__dirname, "../../../oapi-schemas/beacon-node-oapi.json"),

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -238,6 +238,13 @@ export const testData: GenericServerTestCases<Endpoints> = {
       meta: {executionOptimistic: true, finalized: false, version: ForkName.electra},
     },
   },
+  getPendingConsolidations: {
+    args: {stateId: "head"},
+    res: {
+      data: [ssz.electra.PendingConsolidation.defaultValue()],
+      meta: {executionOptimistic: true, finalized: false, version: ForkName.electra},
+    },
+  },
 
   // rewards
 

--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -329,5 +329,21 @@ export function getBeaconStateApi({
         meta: {executionOptimistic, finalized, version: fork},
       };
     },
+
+    async getPendingConsolidations({stateId}, context) {
+      const {state, executionOptimistic, finalized} = await getState(stateId);
+      const fork = config.getForkName(state.slot);
+
+      if (!isForkPostElectra(fork)) {
+        throw new ApiError(400, `Cannot retrieve pending consolidations for pre-electra state fork=${fork}`);
+      }
+
+      const {pendingConsolidations} = state as BeaconStateElectra;
+
+      return {
+        data: context?.returnBytes ? pendingConsolidations.serialize() : pendingConsolidations.toValue(),
+        meta: {executionOptimistic, finalized, version: fork},
+      };
+    },
   };
 }


### PR DESCRIPTION
**Motivation**

Electra `getPendingConsolidations` endpoint implemented: https://github.com/ethereum/beacon-APIs/pull/512

**Description**

- `GET /eth/v1/beacon/states/{state_id}/pending_consolidations added`

Closes https://github.com/ChainSafe/lodestar/issues/7575