### PR TITLE
fix: use persistent-merkle-tree v1.1.0

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -70,7 +70,7 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/persistent-merkle-tree": "^1.0.1",
+    "@chainsafe/persistent-merkle-tree": "^1.1.0",
     "@chainsafe/ssz": "^1.2.0",
     "@lodestar/config": "^1.28.1",
     "@lodestar/params": "^1.28.1",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -94,14 +94,14 @@
     "check-readme": "typescript-docs-verifier"
   },
   "dependencies": {
-    "@chainsafe/as-sha256": "^1.0.0",
+    "@chainsafe/as-sha256": "^1.1.0",
     "@chainsafe/blst": "^2.1.0",
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",
     "@chainsafe/libp2p-gossipsub": "^13.0.0",
     "@chainsafe/libp2p-identify": "^1.0.0",
     "@chainsafe/libp2p-noise": "^15.0.0",
-    "@chainsafe/persistent-merkle-tree": "^1.0.1",
+    "@chainsafe/persistent-merkle-tree": "^1.1.0",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/pubkey-index-map": "2.0.0",
     "@chainsafe/ssz": "^1.2.0",

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -1,6 +1,7 @@
 import {setMaxListeners} from "node:events";
 import {Registry} from "prom-client";
 
+import {hasher} from "@chainsafe/persistent-merkle-tree";
 import {PeerId} from "@libp2p/interface";
 import {BeaconApiMethods} from "@lodestar/api/beacon/server";
 import {BeaconConfig} from "@lodestar/config";
@@ -154,6 +155,10 @@ export class BeaconNode {
     wsCheckpoint,
     metricsRegistries = [],
   }: BeaconNodeInitModules): Promise<T> {
+    if (hasher.name !== "hashtree") {
+      throw Error(`Loaded incorrect hasher ${hasher.name}, expected hashtree`);
+    }
+
     const controller = new AbortController();
     // We set infinity to prevent MaxListenersExceededWarning which get logged when listeners > 10
     // Since it is perfectly fine to have listeners > 10

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -1,3 +1,5 @@
+import {setHasher} from "@chainsafe/persistent-merkle-tree";
+import {hasher} from "@chainsafe/persistent-merkle-tree/hasher/hashtree";
 import {PeerId} from "@libp2p/interface";
 import {createSecp256k1PeerId} from "@libp2p/peer-id-factory";
 import {ChainConfig, createBeaconConfig, createChainForkConfig} from "@lodestar/config";
@@ -32,6 +34,7 @@ export async function getDevBeaconNode(
     wsCheckpoint?: phase0.Checkpoint;
   } & InteropStateOpts
 ): Promise<BeaconNode> {
+  setHasher(hasher);
   const {params, validatorCount = 8, peerStoreDir} = opts;
   let {options = {}, logger, peerId} = opts;
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "@chainsafe/blst": "^2.1.0",
     "@chainsafe/discv5": "^9.0.0",
     "@chainsafe/enr": "^3.0.0",
-    "@chainsafe/persistent-merkle-tree": "^1.0.1",
+    "@chainsafe/persistent-merkle-tree": "^1.1.0",
     "@chainsafe/ssz": "^1.2.0",
     "@chainsafe/threads": "^1.11.1",
     "@libp2p/crypto": "^4.1.0",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -72,7 +72,7 @@
   "dependencies": {
     "@chainsafe/bls": "7.1.3",
     "@chainsafe/blst": "^0.2.0",
-    "@chainsafe/persistent-merkle-tree": "^1.0.1",
+    "@chainsafe/persistent-merkle-tree": "^1.1.0",
     "@chainsafe/ssz": "^1.2.0",
     "@lodestar/api": "^1.28.1",
     "@lodestar/config": "^1.28.1",
@@ -82,7 +82,7 @@
     "mitt": "^3.0.0"
   },
   "devDependencies": {
-    "@chainsafe/as-sha256": "^1.0.0",
+    "@chainsafe/as-sha256": "^1.1.0",
     "@types/qs": "^6.9.7",
     "fastify": "^5.2.1",
     "qs": "^6.11.1",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -58,9 +58,9 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/as-sha256": "^1.0.0",
+    "@chainsafe/as-sha256": "^1.1.0",
     "@chainsafe/blst": "^2.1.0",
-    "@chainsafe/persistent-merkle-tree": "^1.0.1",
+    "@chainsafe/persistent-merkle-tree": "^1.1.0",
     "@chainsafe/persistent-ts": "^1.0.0",
     "@chainsafe/pubkey-index-map": "2.0.0",
     "@chainsafe/ssz": "^1.2.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -36,7 +36,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@chainsafe/as-sha256": "^1.0.0",
+    "@chainsafe/as-sha256": "^1.1.0",
     "any-signal": "3.0.1",
     "bigint-buffer": "^1.1.5",
     "case": "^1.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -439,7 +439,7 @@
   resolved "https://registry.yarnpkg.com/@chainsafe/as-chacha20poly1305/-/as-chacha20poly1305-0.1.0.tgz#7da6f8796f9b42dac6e830a086d964f1f9189e09"
   integrity sha512-BpNcL8/lji/GM3+vZ/bgRWqJ1q5kwvTFmGPk7pxm/QQZDbaMI98waOHjEymTjq2JmdD/INdNBFOVSyJofXg7ew==
 
-"@chainsafe/as-sha256@1.1.0":
+"@chainsafe/as-sha256@1.1.0", "@chainsafe/as-sha256@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-1.1.0.tgz#949082ab96e0b266484f01f59a71930761afc6c4"
   integrity sha512-pLlxYtfYy2YW5GN+7d946UAjBOS9VOFulkfFN6Z+84ZhMP0Ey8XsCG21CZTczwq1C8J7/4z8LGzmrAtmQ37VCQ==
@@ -448,11 +448,6 @@
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.4.1.tgz#cfc0737e25f8c206767bdb6703e7943e5d44513e"
   integrity sha512-IqeeGwQihK6Y2EYLFofqs2eY2ep1I2MvQXHzOAI+5iQN51OZlUkrLgyAugu2x86xZewDk5xas7lNczkzFzF62w==
-
-"@chainsafe/as-sha256@^1.0.0", "@chainsafe/as-sha256@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-1.0.1.tgz#9fa9ab73c9748c1160ec5125059bd9f4f9185f68"
-  integrity sha512-4Y/kQm0LsJ6QRtGcMq6gOdQP+fZhWDfIV2eIqP6oFJZBWYGmdh3wm8YbrXDPLJO87X2Fu6koRLdUS00O3k14Hw==
 
 "@chainsafe/benchmark@^1.2.3":
   version "1.2.3"
@@ -701,7 +696,7 @@
   dependencies:
     "@chainsafe/is-ip" "^2.0.1"
 
-"@chainsafe/persistent-merkle-tree@1.1.0":
+"@chainsafe/persistent-merkle-tree@1.1.0", "@chainsafe/persistent-merkle-tree@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-1.1.0.tgz#d10d9e926f2c5751d02a188b8fb6823821572aca"
   integrity sha512-UIcKEGkEGghTXbFTvKqIiN2iljg2f6c2Y8GxdQEyle5UI6YIB8d3ACYTkAhrHSB4YsNlG9pc/A0NGJw/3Hf9wQ==
@@ -716,15 +711,6 @@
   integrity sha512-gcENLemRR13+1MED2NeZBMA7FRS0xQPM7L2vhMqvKkjqtFT4YfjSVADq5U0iLuQLhFUJEMVuA8fbv5v+TN6O9A==
   dependencies:
     "@chainsafe/as-sha256" "^0.4.1"
-    "@noble/hashes" "^1.3.0"
-
-"@chainsafe/persistent-merkle-tree@^1.0.1":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-1.0.2.tgz#e6154d3f6a2046c06f0ff64ac5634b72057959f3"
-  integrity sha512-9yPy1T8VIsN5pogFjMOW7bUATyoQShoKRu/7YUpHb8bkAeMk+5jUHA9FY3rWdGTApnAQnCQNbVcg+VCJfZt8cg==
-  dependencies:
-    "@chainsafe/as-sha256" "^1.0.1"
-    "@chainsafe/hashtree" "1.0.1"
     "@noble/hashes" "^1.3.0"
 
 "@chainsafe/persistent-ts@^1.0.0":


### PR DESCRIPTION
**Motivation**

- fix misused noble as a hasher, see https://github.com/ChainSafe/lodestar/pull/7608#issuecomment-2750007795

**Description**

- use the latest `persistent-merkle-tree` and `as-sha256` everywhere
- this is a prerequisite for #7620
- also confirm the correct hasher in beacon-node