### PR TITLE
feat: model ListValidatorType for batch hash

### DIFF
--- a/.benchrc.yaml
+++ b/.benchrc.yaml
@@ -9,3 +9,5 @@ triggerGC: false
 sort: true
 convergence: linear
 averageCalculation: clean-outliers
+setupFiles:
+  - ./setHasher.mjs

--- a/packages/state-transition/test/perf/hashing.test.ts
+++ b/packages/state-transition/test/perf/hashing.test.ts
@@ -78,11 +78,11 @@ describe("BeaconState hashTreeRoot", () => {
       beforeEach: () => {
         const state = stateOg.clone();
         fn(state);
-        state.commit();
         return state;
       },
       fn: (state) => {
-        state.hashTreeRoot();
+        // commit() is inside hashTreeRoot(), count it here so that we can compare to batchHashTreeRoot()
+        state.balances.hashTreeRoot();
       },
     });
   }
@@ -99,7 +99,8 @@ describe("BeaconState hashTreeRoot", () => {
         return state;
       },
       fn: (state) => {
-        state.batchHashTreeRoot(hc);
+        // commit() is inside batchHashTreeRoot()
+        state.balances.batchHashTreeRoot(hc);
       },
     });
   }

--- a/packages/state-transition/test/perf/hashing.test.ts
+++ b/packages/state-transition/test/perf/hashing.test.ts
@@ -1,4 +1,5 @@
 import {beforeAll, bench, describe} from "@chainsafe/benchmark";
+import {HashComputationGroup} from "@chainsafe/persistent-merkle-tree";
 import {unshuffleList} from "@chainsafe/swap-or-not-shuffle";
 import {SHUFFLE_ROUND_COUNT} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
@@ -82,6 +83,23 @@ describe("BeaconState hashTreeRoot", () => {
       },
       fn: (state) => {
         state.hashTreeRoot();
+      },
+    });
+  }
+
+  const hc = new HashComputationGroup();
+
+  for (const {id, noTrack, fn} of testCases) {
+    bench<typeof stateOg, typeof stateOg>({
+      id: `BeaconState.batchHashTreeRoot - ${id}`,
+      noThreshold: noTrack,
+      beforeEach: () => {
+        const state = stateOg.clone();
+        fn(state);
+        return state;
+      },
+      fn: (state) => {
+        state.batchHashTreeRoot(hc);
       },
     });
   }

--- a/packages/state-transition/test/perf/hashing.test.ts
+++ b/packages/state-transition/test/perf/hashing.test.ts
@@ -71,22 +71,6 @@ describe("BeaconState hashTreeRoot", () => {
     });
   }
 
-  for (const {id, noTrack, fn} of testCases) {
-    bench<typeof stateOg, typeof stateOg>({
-      id: `BeaconState.hashTreeRoot - ${id}`,
-      noThreshold: noTrack,
-      beforeEach: () => {
-        const state = stateOg.clone();
-        fn(state);
-        return state;
-      },
-      fn: (state) => {
-        // commit() is inside hashTreeRoot(), count it here so that we can compare to batchHashTreeRoot()
-        state.balances.hashTreeRoot();
-      },
-    });
-  }
-
   const hc = new HashComputationGroup();
 
   for (const {id, noTrack, fn} of testCases) {
@@ -101,6 +85,22 @@ describe("BeaconState hashTreeRoot", () => {
       fn: (state) => {
         // commit() is inside batchHashTreeRoot()
         state.balances.batchHashTreeRoot(hc);
+      },
+    });
+  }
+
+  for (const {id, noTrack, fn} of testCases) {
+    bench<typeof stateOg, typeof stateOg>({
+      id: `BeaconState.hashTreeRoot - ${id}`,
+      noThreshold: noTrack,
+      beforeEach: () => {
+        const state = stateOg.clone();
+        fn(state);
+        return state;
+      },
+      fn: (state) => {
+        // commit() is inside hashTreeRoot(), count it here so that we can compare to batchHashTreeRoot()
+        state.balances.hashTreeRoot();
       },
     });
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -74,6 +74,9 @@
     "@lodestar/params": "^1.28.1",
     "ethereum-cryptography": "^2.0.0"
   },
+  "devDependencies": {
+    "@lodestar/utils": "^1.28.1"
+  },
   "keywords": [
     "ethereum",
     "eth-consensus",

--- a/packages/types/src/phase0/listValidator.ts
+++ b/packages/types/src/phase0/listValidator.ts
@@ -1,0 +1,15 @@
+import {Node} from "@chainsafe/persistent-merkle-tree";
+import {ListCompositeTreeViewDU, ListCompositeType} from "@chainsafe/ssz";
+import {ValidatorNodeStructType} from "./validator.js";
+import {ListValidatorTreeViewDU} from "./viewDU/listValidator.js";
+
+export class ListValidatorType extends ListCompositeType<ValidatorNodeStructType> {
+  constructor(limit: number) {
+    super(new ValidatorNodeStructType(), limit);
+  }
+
+  getViewDU(node: Node, cache?: unknown): ListCompositeTreeViewDU<ValidatorNodeStructType> {
+    // biome-ignore lint/suspicious/noExplicitAny: ssz api
+    return new ListValidatorTreeViewDU(this, node, cache as any);
+  }
+}

--- a/packages/types/src/phase0/sszTypes.ts
+++ b/packages/types/src/phase0/sszTypes.ts
@@ -28,6 +28,7 @@ import {
   VALIDATOR_REGISTRY_LIMIT,
 } from "@lodestar/params";
 import * as primitiveSsz from "../primitive/sszTypes.js";
+import {ListValidatorType} from "./listValidator.js";
 import {ValidatorNodeStruct} from "./validator.js";
 
 const {
@@ -228,7 +229,7 @@ export const HistoricalBatchRoots = new ContainerType(
 export const Validator = ValidatorNodeStruct;
 
 // Export as stand-alone for direct tree optimizations
-export const Validators = new ListCompositeType(ValidatorNodeStruct, VALIDATOR_REGISTRY_LIMIT);
+export const Validators = new ListValidatorType(VALIDATOR_REGISTRY_LIMIT);
 // this ListUintNum64Type is used to cache Leaf Nodes of BeaconState.balances after epoch transition
 export const Balances = new ListUintNum64Type(VALIDATOR_REGISTRY_LIMIT);
 export const RandaoMixes = new VectorCompositeType(Bytes32, EPOCHS_PER_HISTORICAL_VECTOR);

--- a/packages/types/src/phase0/validator.ts
+++ b/packages/types/src/phase0/validator.ts
@@ -14,6 +14,7 @@ const UINT32_SIZE = 4;
 const PUBKEY_SIZE = 48;
 const WITHDRAWAL_CREDENTIALS_SIZE = 32;
 const SLASHED_SIZE = 1;
+const CHUNK_SIZE = 32;
 
 export const ValidatorType = {
   pubkey: BLSPubkey,
@@ -59,6 +60,60 @@ export class ValidatorNodeStructType extends ContainerNodeStructType<typeof Vali
 
     return offset;
   }
+
+  // TODO: consider improving value_toTree
+}
+
+export const ValidatorNodeStruct = new ValidatorNodeStructType();
+
+/**
+ * Write to level3 and level4 bytes to compute merkle root. Note that this is to compute
+ * merkle root and it's different from serialization (which is more compressed).
+ * pub0 + pub1 are at level4, they will be hashed to 1st chunked of level 3
+ * then use 8 chunks of level 3 to compute the root hash.
+ *           reserved     withdr     eff        sla        actElig    act        exit       with
+ * level 3 |----------|----------|----------|----------|----------|----------|----------|----------|
+ *
+ *            pub0       pub1
+ * level4  |----------|----------|
+ *
+ */
+export function validatorToChunkBytes(
+  level3: ByteViews,
+  level4: Uint8Array,
+  value: ValueOfFields<typeof ValidatorType>
+): void {
+  const {
+    pubkey,
+    withdrawalCredentials,
+    effectiveBalance,
+    slashed,
+    activationEligibilityEpoch,
+    activationEpoch,
+    exitEpoch,
+    withdrawableEpoch,
+  } = value;
+  const {uint8Array: outputLevel3, dataView} = level3;
+
+  // pubkey = 48 bytes which is 2 * CHUNK_SIZE
+  level4.set(pubkey, 0);
+  let offset = CHUNK_SIZE;
+  outputLevel3.set(withdrawalCredentials, offset);
+  offset += CHUNK_SIZE;
+  // effectiveBalance is UintNum64
+  dataView.setUint32(offset, effectiveBalance & 0xffffffff, true);
+  dataView.setUint32(offset + 4, (effectiveBalance / NUMBER_2_POW_32) & 0xffffffff, true);
+
+  offset += CHUNK_SIZE;
+  dataView.setUint32(offset, slashed ? 1 : 0, true);
+  offset += CHUNK_SIZE;
+  writeEpochInf(dataView, offset, activationEligibilityEpoch);
+  offset += CHUNK_SIZE;
+  writeEpochInf(dataView, offset, activationEpoch);
+  offset += CHUNK_SIZE;
+  writeEpochInf(dataView, offset, exitEpoch);
+  offset += CHUNK_SIZE;
+  writeEpochInf(dataView, offset, withdrawableEpoch);
 }
 
 function writeEpochInf(dataView: DataView, offset: number, value: number): number {
@@ -75,4 +130,3 @@ function writeEpochInf(dataView: DataView, offset: number, value: number): numbe
   }
   return offset;
 }
-export const ValidatorNodeStruct = new ValidatorNodeStructType();

--- a/packages/types/src/phase0/viewDU/listValidator.ts
+++ b/packages/types/src/phase0/viewDU/listValidator.ts
@@ -1,0 +1,180 @@
+import {byteArrayIntoHashObject} from "@chainsafe/as-sha256";
+import {HashComputationLevel, Node, digestNLevel, setNodesAtDepth} from "@chainsafe/persistent-merkle-tree";
+import {
+  ArrayCompositeTreeViewDUCache,
+  ByteViews,
+  ContainerNodeStructTreeViewDU,
+  ListCompositeTreeViewDU,
+  ListCompositeType,
+} from "@chainsafe/ssz";
+import {ValidatorIndex} from "../../types.js";
+import {ValidatorNodeStructType, ValidatorType, validatorToChunkBytes} from "../validator.js";
+
+/**
+ * hashtree has a MAX_SIZE of 1024 bytes = 32 chunks
+ * Given a level3 of validators have 8 chunks, we can hash 4 validators at a time
+ */
+const PARALLEL_FACTOR = 4;
+/**
+ * Allocate memory once for batch hash validators.
+ */
+// each level 3 of validator has 8 chunks, each chunk has 32 bytes
+const batchLevel3Bytes = new Uint8Array(PARALLEL_FACTOR * 8 * 32);
+const level3ByteViewsArr: ByteViews[] = [];
+for (let i = 0; i < PARALLEL_FACTOR; i++) {
+  const uint8Array = batchLevel3Bytes.subarray(i * 8 * 32, (i + 1) * 8 * 32);
+  const dataView = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
+  level3ByteViewsArr.push({uint8Array, dataView});
+}
+// each level 4 of validator has 2 chunks for pubkey, each chunk has 32 bytes
+const batchLevel4Bytes = new Uint8Array(PARALLEL_FACTOR * 2 * 32);
+const level4BytesArr: Uint8Array[] = [];
+for (let i = 0; i < PARALLEL_FACTOR; i++) {
+  level4BytesArr.push(batchLevel4Bytes.subarray(i * 2 * 32, (i + 1) * 2 * 32));
+}
+const pubkeyRoots: Uint8Array[] = [];
+for (let i = 0; i < PARALLEL_FACTOR; i++) {
+  pubkeyRoots.push(batchLevel4Bytes.subarray(i * 32, (i + 1) * 32));
+}
+
+const validatorRoots: Uint8Array[] = [];
+for (let i = 0; i < PARALLEL_FACTOR; i++) {
+  validatorRoots.push(batchLevel3Bytes.subarray(i * 32, (i + 1) * 32));
+}
+const validatorRoot = new Uint8Array(32);
+
+/**
+ * Similar to ListCompositeTreeViewDU with some differences:
+ * - if called without params, it's from hashTreeRoot() api call, no need to compute root
+ * - otherwise it's from batchHashTreeRoot() call, compute validator roots in batch
+ */
+export class ListValidatorTreeViewDU extends ListCompositeTreeViewDU<ValidatorNodeStructType> {
+  constructor(
+    readonly type: ListCompositeType<ValidatorNodeStructType>,
+    protected _rootNode: Node,
+    cache?: ArrayCompositeTreeViewDUCache
+  ) {
+    super(type, _rootNode, cache);
+  }
+
+  commit(hcOffset = 0, hcByLevel: HashComputationLevel[] | null = null): void {
+    if (hcByLevel === null) {
+      // this is not from batchHashTreeRoot() call, go with regular flow
+      super.commit();
+      return;
+    }
+
+    const isOldRootHashed = this._rootNode.h0 !== null;
+    if (this.viewsChanged.size === 0) {
+      if (!isOldRootHashed && hcByLevel !== null) {
+        // not possible to get HashComputations due to BranchNodeStruct
+        this._rootNode.root;
+      }
+      return;
+    }
+
+    // TODO - batch: remove this type cast
+    const viewsChanged = this.viewsChanged as unknown as Map<
+      number,
+      ContainerNodeStructTreeViewDU<typeof ValidatorType>
+    >;
+
+    const indicesChanged: number[] = [];
+    for (const [index, viewChanged] of viewsChanged) {
+      // should not have any params here in order not to compute root
+      viewChanged.commit();
+      // Set new node in nodes array to ensure data represented in the tree and fast nodes access is equal
+      this.nodes[index] = viewChanged.node;
+      // `validators.get(i)` was called but it may not modify any property, do not need to compute root
+      if (viewChanged.node.h0 === null) {
+        indicesChanged.push(index);
+      }
+    }
+
+    // these validators don't have roots, we compute roots in batch
+    const sortedIndicesChanged = indicesChanged.sort((a, b) => a - b);
+    const nodesChanged: {index: ValidatorIndex; node: Node}[] = new Array(sortedIndicesChanged.length);
+    for (const [i, validatorIndex] of sortedIndicesChanged.entries()) {
+      nodesChanged[i] = {index: validatorIndex, node: this.nodes[validatorIndex]};
+    }
+    doBatchHashTreeRootValidators(sortedIndicesChanged, viewsChanged);
+
+    // do the remaining commit step the same to parent (ArrayCompositeTreeViewDU)
+    const indexes = nodesChanged.map((entry) => entry.index);
+    const nodes = nodesChanged.map((entry) => entry.node);
+    const chunksNode = this.type.tree_getChunksNode(this._rootNode);
+    const offsetThis = hcOffset + this.type.tree_chunksNodeOffset();
+    const byLevelThis = hcByLevel != null && isOldRootHashed ? hcByLevel : null;
+    const newChunksNode = setNodesAtDepth(chunksNode, this.type.chunkDepth, indexes, nodes, offsetThis, byLevelThis);
+
+    this._rootNode = this.type.tree_setChunksNode(
+      this._rootNode,
+      newChunksNode,
+      this.dirtyLength ? this._length : null,
+      hcOffset,
+      hcByLevel
+    );
+
+    if (!isOldRootHashed && hcByLevel !== null) {
+      // should never happen, handle just in case
+      // not possible to get HashComputations due to BranchNodeStruct
+      this._rootNode.root;
+    }
+
+    this.viewsChanged.clear();
+    this.dirtyLength = false;
+  }
+}
+
+export function doBatchHashTreeRootValidators(
+  indices: ValidatorIndex[],
+  validators: Map<ValidatorIndex, ContainerNodeStructTreeViewDU<typeof ValidatorType>>
+): void {
+  const endBatch = indices.length - (indices.length % PARALLEL_FACTOR);
+
+  // commit every 16 validators in batch
+  for (let i = 0; i < endBatch; i++) {
+    if (i % PARALLEL_FACTOR === 0) {
+      batchLevel3Bytes.fill(0);
+      batchLevel4Bytes.fill(0);
+    }
+    const indexInBatch = i % PARALLEL_FACTOR;
+    const viewIndex = indices[i];
+    const validator = validators.get(viewIndex);
+    if (validator) {
+      validatorToChunkBytes(level3ByteViewsArr[indexInBatch], level4BytesArr[indexInBatch], validator.value);
+    }
+
+    if (indexInBatch === PARALLEL_FACTOR - 1) {
+      // hash level 4, this is populated to pubkeyRoots
+      digestNLevel(batchLevel4Bytes, 1);
+      for (let j = 0; j < PARALLEL_FACTOR; j++) {
+        level3ByteViewsArr[j].uint8Array.set(pubkeyRoots[j], 0);
+      }
+      // hash level 3, this is populated to validatorRoots
+      digestNLevel(batchLevel3Bytes, 3);
+      // commit all validators in this batch
+      for (let j = PARALLEL_FACTOR - 1; j >= 0; j--) {
+        const viewIndex = indices[i - j];
+        const indexInBatch = (i - j) % PARALLEL_FACTOR;
+        const viewChanged = validators.get(viewIndex);
+        if (viewChanged) {
+          const branchNodeStruct = viewChanged.node;
+          byteArrayIntoHashObject(validatorRoots[indexInBatch], 0, branchNodeStruct);
+        }
+      }
+    }
+  }
+
+  // commit the remaining validators, we can do in batch too but don't want to create new Uint8Array views
+  // it's not much different to commit one by one
+  for (let i = endBatch; i < indices.length; i++) {
+    const viewIndex = indices[i];
+    const viewChanged = validators.get(viewIndex);
+    if (viewChanged) {
+      // compute root for each validator
+      viewChanged.type.hashTreeRootInto(viewChanged.value, validatorRoot, 0);
+      byteArrayIntoHashObject(validatorRoot, 0, viewChanged.node);
+    }
+  }
+}

--- a/packages/types/test/perf/beaconState.test.ts
+++ b/packages/types/test/perf/beaconState.test.ts
@@ -1,0 +1,225 @@
+import {bench, describe, setBenchOpts} from "@chainsafe/benchmark";
+import {HashComputationGroup, HashComputationLevel, executeHashComputations} from "@chainsafe/persistent-merkle-tree";
+import {BitArray, CompositeViewDU} from "@chainsafe/ssz";
+import {
+  EPOCHS_PER_ETH1_VOTING_PERIOD,
+  EPOCHS_PER_HISTORICAL_VECTOR,
+  SLOTS_PER_EPOCH,
+  SLOTS_PER_HISTORICAL_ROOT,
+} from "@lodestar/params";
+import {toRootHex} from "@lodestar/utils";
+import {BeaconState} from "../../src/altair/sszTypes.js";
+
+const vc = 200_000;
+const numModified = vc / 2;
+// every time we change vc, need to change this value accordingly
+const expectedRoot = "0x365bba57add6804e7688dbac8793792bb2b4a61eb368cfb0c04860c3db02c313";
+
+/**
+ * This simulates a BeaconState being modified after an epoch transition in lodestar
+ * The fresh tree batch hash bechmark is in packages/persistent-merkle-tree/test/perf/node.test.ts
+ * Note that this benchmark is not very stable because we cannot apply runsFactor as once commit() we
+ * cannot compute HashComputationGroup again.
+ * Increasing number of validators could be OOM since we have to create BeaconState every time
+ */
+describe(`BeaconState ViewDU partially modified tree vc=${vc} numModified=${numModified}`, () => {
+  setBenchOpts({
+    minMs: 20_000,
+  });
+
+  const hc = new HashComputationGroup();
+  bench({
+    id: `BeaconState ViewDU batchHashTreeRoot vc=${vc} mod=${numModified}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      // commit() step is inside hashTreeRoot(), reuse HashComputationGroup
+      if (toRootHex(state.batchHashTreeRoot(hc)) !== expectedRoot) {
+        throw new Error(
+          `batchHashTreeRoot ${toRootHex(state.batchHashTreeRoot(hc))} does not match expectedRoot ${expectedRoot}`
+        );
+      }
+      state.batchHashTreeRoot(hc);
+    },
+  });
+
+  bench({
+    id: `BeaconState ViewDU batchHashTreeRoot - commit step vc=${vc} mod=${numModified}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.commit(0, []);
+    },
+  });
+
+  bench({
+    id: `BeaconState ViewDU batchHashTreeRoot - hash step vc=${vc} mod=${numModified}`,
+    beforeEach: () => {
+      const state = createPartiallyModifiedDenebState();
+      const hcByLevel: HashComputationLevel[] = [];
+      state.commit(0, hcByLevel);
+      return hcByLevel;
+    },
+    fn: (hcByLevel) => {
+      executeHashComputations(hcByLevel);
+    },
+  });
+
+  bench({
+    id: `BeaconState ViewDU hashTreeRoot() vc=${vc} mod=${numModified}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.hashTreeRoot();
+      if (toRootHex(state.node.root) !== expectedRoot) {
+        throw new Error(`hashTreeRoot ${toRootHex(state.node.root)} does not match expectedRoot ${expectedRoot}`);
+      }
+    },
+  });
+
+  bench({
+    id: `BeaconState ViewDU hashTreeRoot - commit step vc=${vc} mod=${numModified}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.commit();
+    },
+  });
+
+  bench({
+    id: `BeaconState ViewDU hashTreeRoot - validator tree creation vc=${numModified} mod=${numModified}`,
+    beforeEach: () => {
+      const state = createPartiallyModifiedDenebState();
+      state.commit();
+      return state;
+    },
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      const validators = state.validators;
+      for (let i = 0; i < numModified; i++) {
+        validators.getReadonly(i).node.left;
+      }
+    },
+  });
+});
+
+let originalState: CompositeViewDU<typeof BeaconState> | null = null;
+function createPartiallyModifiedDenebState(): CompositeViewDU<typeof BeaconState> {
+  if (originalState === null) {
+    originalState = createState(vc);
+    // cache all roots
+    // the original state is huge, do not call hashTreeRoot() here
+    originalState.commit();
+    originalState.node.root;
+  }
+
+  const state = originalState.clone();
+  state.slot++;
+  state.latestBlockHeader = BeaconState.fields.latestBlockHeader.toViewDU({
+    slot: 1000,
+    proposerIndex: 1,
+    parentRoot: Buffer.alloc(32, 0xac),
+    stateRoot: Buffer.alloc(32, 0xed),
+    bodyRoot: Buffer.alloc(32, 0x32),
+  });
+  state.blockRoots.set(0, Buffer.alloc(32, 0x01));
+  state.stateRoots.set(0, Buffer.alloc(32, 0x01));
+  state.historicalRoots.set(0, Buffer.alloc(32, 0x01));
+  for (let i = 0; i < numModified; i++) {
+    state.validators.get(i).effectiveBalance += 1e9;
+  }
+  // all balances are modified as in epoch transition
+  state.balances = BeaconState.fields.balances.toViewDU(Array.from({length: vc}, () => 32e9));
+  // remaining validators are accessed with no modification
+  for (let i = numModified; i < vc; i++) {
+    state.validators.get(i);
+  }
+
+  state.eth1Data = BeaconState.fields.eth1Data.toViewDU({
+    depositRoot: Buffer.alloc(32, 0x02),
+    depositCount: 1000,
+    blockHash: Buffer.alloc(32, 0x03),
+  });
+  state.eth1DataVotes.set(0, state.eth1Data);
+  state.eth1DepositIndex++;
+  state.randaoMixes.set(0, Buffer.alloc(32, 0x02));
+  state.slashings.set(0, 1e9);
+
+  state.justificationBits = BeaconState.fields.justificationBits.toViewDU(
+    BitArray.fromBoolArray([true, false, true, true])
+  );
+  state.previousJustifiedCheckpoint = BeaconState.fields.previousJustifiedCheckpoint.toViewDU({
+    epoch: 1000,
+    root: Buffer.alloc(32, 0x01),
+  });
+  state.currentJustifiedCheckpoint = BeaconState.fields.currentJustifiedCheckpoint.toViewDU({
+    epoch: 1000,
+    root: Buffer.alloc(32, 0x01),
+  });
+  state.finalizedCheckpoint = BeaconState.fields.finalizedCheckpoint.toViewDU({
+    epoch: 1000,
+    root: Buffer.alloc(32, 0x01),
+  });
+  return state;
+}
+
+function createState(vc: number): CompositeViewDU<typeof BeaconState> {
+  const state = BeaconState.defaultViewDU();
+  state.genesisTime = 1e9;
+  state.genesisValidatorsRoot = Buffer.alloc(32, 1);
+  state.slot = 1_000_000;
+  state.fork = BeaconState.fields.fork.toViewDU({
+    epoch: 1000,
+    previousVersion: Buffer.alloc(4, 0x03),
+    currentVersion: Buffer.alloc(4, 0x04),
+  });
+  state.latestBlockHeader = BeaconState.fields.latestBlockHeader.toViewDU({
+    slot: 1000,
+    proposerIndex: 1,
+    parentRoot: Buffer.alloc(32, 0xac),
+    stateRoot: Buffer.alloc(32, 0xed),
+    bodyRoot: Buffer.alloc(32, 0x32),
+  });
+  state.blockRoots = BeaconState.fields.blockRoots.toViewDU(
+    Array.from({length: 1_000_000}, () => Buffer.alloc(32, 0x01))
+  );
+  state.stateRoots = BeaconState.fields.stateRoots.toViewDU(
+    Array.from({length: 1_000_000}, () => Buffer.alloc(32, 0x01))
+  );
+  state.historicalRoots = BeaconState.fields.historicalRoots.toViewDU(
+    Array.from({length: 1_000_000}, () => Buffer.alloc(32, 0x01))
+  );
+
+  state.eth1DataVotes = BeaconState.fields.eth1DataVotes.toViewDU(
+    Array.from({length: EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH}, () => {
+      return {
+        depositRoot: Buffer.alloc(32, 0x04),
+        depositCount: 1000,
+        blockHash: Buffer.alloc(32, 0x05),
+      };
+    })
+  );
+  state.eth1DepositIndex = 1000;
+  const validators = Array.from({length: vc}, () => {
+    return {
+      pubkey: Buffer.alloc(48, 0xaa),
+      withdrawalCredentials: Buffer.alloc(32, 0xbb),
+      effectiveBalance: 32e9,
+      slashed: false,
+      activationEligibilityEpoch: 1_000_000,
+      activationEpoch: 2_000_000,
+      exitEpoch: 3_000_000,
+      withdrawableEpoch: 4_000_000,
+    };
+  });
+  state.validators = BeaconState.fields.validators.toViewDU(validators);
+  state.balances = BeaconState.fields.balances.toViewDU(Array.from({length: vc}, () => 32e9));
+  // randomMixes
+  state.randaoMixes = BeaconState.fields.randaoMixes.toViewDU(
+    Array.from({length: EPOCHS_PER_HISTORICAL_VECTOR}, () => Buffer.alloc(32, 0x01))
+  );
+  // slashings
+  state.slashings = BeaconState.fields.slashings.toViewDU(Array.from({length: SLOTS_PER_HISTORICAL_ROOT}, () => 1e9));
+  state.previousEpochParticipation = BeaconState.fields.previousEpochParticipation.toViewDU(
+    Array.from({length: vc}, () => 7)
+  );
+  state.currentEpochParticipation = BeaconState.fields.previousEpochParticipation.toViewDU(
+    Array.from({length: vc}, () => 7)
+  );
+  return state;
+}

--- a/packages/types/test/perf/beaconState.test.ts
+++ b/packages/types/test/perf/beaconState.test.ts
@@ -11,9 +11,11 @@ import {toRootHex} from "@lodestar/utils";
 import {BeaconState} from "../../src/altair/sszTypes.js";
 
 const vc = 200_000;
-const numModified = vc / 2;
-// every time we change vc, need to change this value accordingly
-const expectedRoot = "0x365bba57add6804e7688dbac8793792bb2b4a61eb368cfb0c04860c3db02c313";
+
+const testCases: {numModified: number; expectedRoot: string}[] = [
+  {numModified: 0, expectedRoot: "0x77f8e77943e88926d1c4021e6f5672a3664158999f9be3f349d9e1eb32f1e331"},
+  {numModified: vc / 2, expectedRoot: "0x365bba57add6804e7688dbac8793792bb2b4a61eb368cfb0c04860c3db02c313"},
+];
 
 /**
  * This simulates a BeaconState being modified after an epoch transition in lodestar
@@ -22,84 +24,87 @@ const expectedRoot = "0x365bba57add6804e7688dbac8793792bb2b4a61eb368cfb0c04860c3
  * cannot compute HashComputationGroup again.
  * Increasing number of validators could be OOM since we have to create BeaconState every time
  */
-describe(`BeaconState ViewDU partially modified tree vc=${vc} numModified=${numModified}`, () => {
-  setBenchOpts({
-    minMs: 20_000,
-  });
 
-  const hc = new HashComputationGroup();
-  bench({
-    id: `BeaconState ViewDU batchHashTreeRoot vc=${vc} mod=${numModified}`,
-    beforeEach: () => createPartiallyModifiedDenebState(),
-    fn: (state: CompositeViewDU<typeof BeaconState>) => {
-      // commit() step is inside hashTreeRoot(), reuse HashComputationGroup
-      if (toRootHex(state.batchHashTreeRoot(hc)) !== expectedRoot) {
-        throw new Error(
-          `batchHashTreeRoot ${toRootHex(state.batchHashTreeRoot(hc))} does not match expectedRoot ${expectedRoot}`
-        );
-      }
-      state.batchHashTreeRoot(hc);
-    },
-  });
+for (const {numModified, expectedRoot} of testCases) {
+  describe(`BeaconState ViewDU partially modified tree vc=${vc} numModified=${numModified}`, () => {
+    setBenchOpts({
+      minMs: 20_000,
+    });
 
-  bench({
-    id: `BeaconState ViewDU batchHashTreeRoot - commit step vc=${vc} mod=${numModified}`,
-    beforeEach: () => createPartiallyModifiedDenebState(),
-    fn: (state: CompositeViewDU<typeof BeaconState>) => {
-      state.commit(0, []);
-    },
-  });
+    const hc = new HashComputationGroup();
+    bench({
+      id: `BeaconState ViewDU batchHashTreeRoot vc=${vc} mod=${numModified}`,
+      beforeEach: () => createPartiallyModifiedDenebState(numModified),
+      fn: (state: CompositeViewDU<typeof BeaconState>) => {
+        // commit() step is inside hashTreeRoot(), reuse HashComputationGroup
+        if (toRootHex(state.batchHashTreeRoot(hc)) !== expectedRoot) {
+          throw new Error(
+            `batchHashTreeRoot ${toRootHex(state.batchHashTreeRoot(hc))} does not match expectedRoot ${expectedRoot}`
+          );
+        }
+        state.batchHashTreeRoot(hc);
+      },
+    });
 
-  bench({
-    id: `BeaconState ViewDU batchHashTreeRoot - hash step vc=${vc} mod=${numModified}`,
-    beforeEach: () => {
-      const state = createPartiallyModifiedDenebState();
-      const hcByLevel: HashComputationLevel[] = [];
-      state.commit(0, hcByLevel);
-      return hcByLevel;
-    },
-    fn: (hcByLevel) => {
-      executeHashComputations(hcByLevel);
-    },
-  });
+    bench({
+      id: `BeaconState ViewDU batchHashTreeRoot - commit step vc=${vc} mod=${numModified}`,
+      beforeEach: () => createPartiallyModifiedDenebState(numModified),
+      fn: (state: CompositeViewDU<typeof BeaconState>) => {
+        state.commit(0, []);
+      },
+    });
 
-  bench({
-    id: `BeaconState ViewDU hashTreeRoot() vc=${vc} mod=${numModified}`,
-    beforeEach: () => createPartiallyModifiedDenebState(),
-    fn: (state: CompositeViewDU<typeof BeaconState>) => {
-      state.hashTreeRoot();
-      if (toRootHex(state.node.root) !== expectedRoot) {
-        throw new Error(`hashTreeRoot ${toRootHex(state.node.root)} does not match expectedRoot ${expectedRoot}`);
-      }
-    },
-  });
+    bench({
+      id: `BeaconState ViewDU batchHashTreeRoot - hash step vc=${vc} mod=${numModified}`,
+      beforeEach: () => {
+        const state = createPartiallyModifiedDenebState(numModified);
+        const hcByLevel: HashComputationLevel[] = [];
+        state.commit(0, hcByLevel);
+        return hcByLevel;
+      },
+      fn: (hcByLevel) => {
+        executeHashComputations(hcByLevel);
+      },
+    });
 
-  bench({
-    id: `BeaconState ViewDU hashTreeRoot - commit step vc=${vc} mod=${numModified}`,
-    beforeEach: () => createPartiallyModifiedDenebState(),
-    fn: (state: CompositeViewDU<typeof BeaconState>) => {
-      state.commit();
-    },
-  });
+    bench({
+      id: `BeaconState ViewDU hashTreeRoot() vc=${vc} mod=${numModified}`,
+      beforeEach: () => createPartiallyModifiedDenebState(numModified),
+      fn: (state: CompositeViewDU<typeof BeaconState>) => {
+        state.hashTreeRoot();
+        if (toRootHex(state.node.root) !== expectedRoot) {
+          throw new Error(`hashTreeRoot ${toRootHex(state.node.root)} does not match expectedRoot ${expectedRoot}`);
+        }
+      },
+    });
 
-  bench({
-    id: `BeaconState ViewDU hashTreeRoot - validator tree creation vc=${numModified} mod=${numModified}`,
-    beforeEach: () => {
-      const state = createPartiallyModifiedDenebState();
-      state.commit();
-      return state;
-    },
-    fn: (state: CompositeViewDU<typeof BeaconState>) => {
-      const validators = state.validators;
-      for (let i = 0; i < numModified; i++) {
-        validators.getReadonly(i).node.left;
-      }
-    },
+    bench({
+      id: `BeaconState ViewDU hashTreeRoot - commit step vc=${vc} mod=${numModified}`,
+      beforeEach: () => createPartiallyModifiedDenebState(numModified),
+      fn: (state: CompositeViewDU<typeof BeaconState>) => {
+        state.commit();
+      },
+    });
+
+    bench({
+      id: `BeaconState ViewDU hashTreeRoot - validator tree creation vc=${numModified} mod=${numModified}`,
+      beforeEach: () => {
+        const state = createPartiallyModifiedDenebState(numModified);
+        state.commit();
+        return state;
+      },
+      fn: (state: CompositeViewDU<typeof BeaconState>) => {
+        const validators = state.validators;
+        for (let i = 0; i < numModified; i++) {
+          validators.getReadonly(i).node.left;
+        }
+      },
+    });
   });
-});
+}
 
 let originalState: CompositeViewDU<typeof BeaconState> | null = null;
-function createPartiallyModifiedDenebState(): CompositeViewDU<typeof BeaconState> {
+function createPartiallyModifiedDenebState(numModified: number): CompositeViewDU<typeof BeaconState> {
   if (originalState === null) {
     originalState = createState(vc);
     // cache all roots

--- a/setHasher.mjs
+++ b/setHasher.mjs
@@ -1,0 +1,7 @@
+// Set the hasher to hashtree
+// Used to run benchmarks with with visibility into hashtree performance, useful for Lodestar
+import {setHasher} from "@chainsafe/persistent-merkle-tree";
+import {hasher} from "@chainsafe/persistent-merkle-tree/hasher/hashtree";
+setHasher(hasher);
+
+export {};


### PR DESCRIPTION
**Motivation**

- model ListValidatorType for batch hash BeaconState (which will come next)

**Description**

- model ssz Type and ViewDU for ListValidator which will be consumed in #7620
- ListValidatorTreeViewDU is designed to be backward compatible, when commit() has no param
- this is same to ssz v1.2.0, just clone them here https://github.com/ChainSafe/ssz/blob/ssz-v1.2.0/packages/ssz/test/lodestarTypes/phase0/viewDU/listValidator.ts

prerequisite for #7620