### PR TITLE
feat: make committee_index optional for post-electra produce attestation data calls

### DIFF
--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -369,11 +369,11 @@ export type Endpoints = {
     "GET",
     {
       /** The committee index for which an attestation data should be created */
-      committeeIndex: CommitteeIndex;
+      committeeIndex?: CommitteeIndex;
       /** The slot for which an attestation data should be created */
       slot: Slot;
     },
-    {query: {slot: number; committee_index: number}},
+    {query: {slot: number; committee_index?: number}},
     phase0.AttestationData,
     EmptyMeta
   >;
@@ -792,7 +792,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         writeReq: ({committeeIndex, slot}) => ({query: {slot, committee_index: committeeIndex}}),
         parseReq: ({query}) => ({committeeIndex: query.committee_index, slot: query.slot}),
         schema: {
-          query: {slot: Schema.UintRequired, committee_index: Schema.UintRequired},
+          query: {slot: Schema.UintRequired, committee_index: Schema.Uint},
         },
       },
       resp: {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -33,6 +33,7 @@ import {
   BeaconBlock,
   BlindedBeaconBlock,
   BlockContents,
+  CommitteeIndex,
   Epoch,
   ProducedBlockSource,
   Root,
@@ -923,6 +924,16 @@ export function getValidatorApi(
       const headBlockRoot = fromHex(headBlockRootHex);
       const fork = config.getForkName(slot);
 
+      let index: CommitteeIndex;
+      if (isForkPostElectra(fork)) {
+        index = 0;
+      } else {
+        if (committeeIndex === undefined) {
+          throw new ApiError(400, `Committee index must be provided for pre-electra fork=${fork}`);
+        }
+        index = committeeIndex;
+      }
+
       const beaconBlockRoot =
         slot >= headSlot
           ? // When attesting to the head slot or later, always use the head of the chain.
@@ -953,7 +964,7 @@ export function getValidatorApi(
       return {
         data: {
           slot,
-          index: isForkPostElectra(fork) ? 0 : committeeIndex,
+          index,
           beaconBlockRoot,
           source: attEpochState.currentJustifiedCheckpoint,
           target: {epoch: attEpoch, root: targetRoot},


### PR DESCRIPTION
**Motivation**

We already ignore `committee_index` in post-electra produce attestation data calls and always set it to 0 in returned `AttestationData`, however we can be less strict on the beacon node side and only reject api calls that do not provide the committee index pre-electra.

**Description**

This changes the way we enforce that `committee_index` is provided by caller, it moves the check from static schema validation to fork-based validation which allows us to handle requests without the committee index for post-electra.

The validator client will still pass the committee index in any case as per spec this is a required property as of right now. However, there was some discussion around this in https://github.com/ethereum/beacon-APIs/pull/511 and a long-term plan could be to make the `committee_index` optional post-electra on the spec as well but first beacon nodes need to be more relaxed on how they enforce the parameter requirement.