### PR TITLE
fix: update pruning to account for increase of max attestation inclusion slot post-deneb

### DIFF
--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -18,6 +18,7 @@ import {
   CachedBeaconStateAltair,
   CachedBeaconStatePhase0,
   computeEpochAtSlot,
+  computeSlotsSinceEpochStart,
   computeStartSlotAtEpoch,
   getBlockRootAtSlot,
 } from "@lodestar/state-transition";
@@ -174,7 +175,7 @@ export class AggregatedAttestationPool {
 
     const slotsToRetain = isForkPostDeneb(fork)
       ? // Post deneb, attestations from current and previous epoch can be included
-        SLOTS_PER_EPOCH * 2
+        computeSlotsSinceEpochStart(clockSlot, computeEpochAtSlot(clockSlot) - 1)
       : // Before deneb, only retain SLOTS_PER_EPOCH slots
         SLOTS_PER_EPOCH;
 

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -10,6 +10,7 @@ import {
   MAX_COMMITTEES_PER_SLOT,
   MIN_ATTESTATION_INCLUSION_DELAY,
   SLOTS_PER_EPOCH,
+  isForkPostDeneb,
   isForkPostElectra,
 } from "@lodestar/params";
 import {
@@ -169,9 +170,16 @@ export class AggregatedAttestationPool {
 
   /** Remove attestations which are too old to be included in a block. */
   prune(clockSlot: Slot): void {
-    // Only retain SLOTS_PER_EPOCH slots
-    pruneBySlot(this.attestationGroupByIndexByDataHexBySlot, clockSlot, SLOTS_PER_EPOCH);
-    this.lowestPermissibleSlot = Math.max(clockSlot - SLOTS_PER_EPOCH, 0);
+    const fork = this.config.getForkName(clockSlot);
+
+    const slotsToRetain = isForkPostDeneb(fork)
+      ? // Post deneb, attestations from current and previous epoch can be included
+        SLOTS_PER_EPOCH * 2
+      : // Before deneb, only retain SLOTS_PER_EPOCH slots
+        SLOTS_PER_EPOCH;
+
+    pruneBySlot(this.attestationGroupByIndexByDataHexBySlot, clockSlot, slotsToRetain);
+    this.lowestPermissibleSlot = Math.max(clockSlot - slotsToRetain, 0);
   }
 
   getAttestationsForBlock(fork: ForkName, forkChoice: IForkChoice, state: CachedBeaconStateAllForks): Attestation[] {


### PR DESCRIPTION
**Motivation**

[EIP-7045](https://eips.ethereum.org/EIPS/eip-7045) allows to include attestations from current and previous epoch in block, while we already account for increase of max attestation inclusion slot post-deneb when packing the block (https://github.com/ChainSafe/lodestar/pull/6522), we did not update our pruning and as of right now we will remove all attestations older than `clockSlot - SLOTS_PER_EPOCH`.

This is not problematic during healthy network conditions but as EIP-7045 shows this is important, especially during non-finality where those attestations could become critical to include.
> As discussed in the Motivation, extending this max inclusion slot to the end of the next epoch is critical for LMD-GHOST security proofs and confirmation rule.


**Description**

Update pruning to account for increase of max attestation inclusion slot post-deneb, ie. we will retain attestations for current and previous epoch instead of previous behavior which removed attestations older than 32 slots.
