### PR TITLE
chore: bump CL spec to v1.5.0-beta.4

### DIFF
--- a/packages/beacon-node/test/e2e/api/impl/config.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/config.test.ts
@@ -12,6 +12,8 @@ const CONSTANT_NAMES_SKIP_LIST = new Set([
   "PARTICIPATION_FLAG_WEIGHTS",
   // TODO Fulu: remove skipped constant
   "MAX_BLOBS_PER_BLOCK_FULU",
+  "VALIDATOR_CUSTODY_REQUIREMENT",
+  "BALANCE_PER_ADDITIONAL_CUSTODY_GROUP",
 ]);
 
 describe("api / impl / config", () => {

--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -14,7 +14,7 @@ import {DownloadTestsOptions} from "@lodestar/spec-test-util/downloadTests";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: DownloadTestsOptions = {
-  specVersion: "v1.5.0-beta.3",
+  specVersion: "v1.5.0-beta.4",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-spec-tests",

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -58,7 +58,7 @@ const coveredTestRunners = [
 // ],
 // ```
 export const defaultSkipOpts: SkipOpts = {
-  skippedForks: ["eip7594", "fulu"],
+  skippedForks: ["eip7594", "fulu", "eip7732"],
   // TODO: capella
   // BeaconBlockBody proof in lightclient is the new addition in v1.3.0-rc.2-hotfix
   // Skip them for now to enable subsequently

--- a/packages/params/test/e2e/ensure-config-is-synced.test.ts
+++ b/packages/params/test/e2e/ensure-config-is-synced.test.ts
@@ -8,7 +8,7 @@ import {loadConfigYaml} from "../yaml.js";
 // Not e2e, but slow. Run with e2e tests
 
 /** https://github.com/ethereum/consensus-specs/releases */
-const specConfigCommit = "v1.5.0-beta.3";
+const specConfigCommit = "v1.5.0-beta.4";
 /**
  * Fields that we filter from local config when doing comparison.
  * Ideally this should be empty as it is not spec compliant


### PR DESCRIPTION
Run against latest spec tests from [v1.5.0-beta.4](https://github.com/ethereum/consensus-specs/releases/tag/v1.5.0-beta.4)
