### PR TITLE
feat: sort packed attestations by effective balance

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -239,7 +239,7 @@ export class BeaconChain implements IBeaconChain {
       preAggregateCutOffTime,
       this.opts?.preaggregateSlotDistance
     );
-    this.aggregatedAttestationPool = new AggregatedAttestationPool(this.config);
+    this.aggregatedAttestationPool = new AggregatedAttestationPool(this.config, metrics);
     this.syncCommitteeMessagePool = new SyncCommitteeMessagePool(
       clock,
       preAggregateCutOffTime,
@@ -373,7 +373,7 @@ export class BeaconChain implements IBeaconChain {
     }
 
     if (metrics) {
-      metrics.opPool.aggregatedAttestationPoolSize.addCollect(() => this.onScrapeMetrics(metrics));
+      metrics.opPool.attestationPoolSize.addCollect(() => this.onScrapeMetrics(metrics));
     }
 
     // Event handlers. emitter is created internally and dropped on close(). Not need to .removeListener()
@@ -1076,9 +1076,6 @@ export class BeaconChain implements IBeaconChain {
   }
 
   private onScrapeMetrics(metrics: Metrics): void {
-    const {attestationCount, attestationDataCount} = this.aggregatedAttestationPool.getAttestationCount();
-    metrics.opPool.aggregatedAttestationPoolSize.set(attestationCount);
-    metrics.opPool.aggregatedAttestationPoolUniqueData.set(attestationDataCount);
     metrics.opPool.attestationPoolSize.set(this.attestationPool.getAttestationCount());
     metrics.opPool.attesterSlashingPoolSize.set(this.opPool.attesterSlashingsSize);
     metrics.opPool.proposerSlashingPoolSize.set(this.opPool.proposerSlashingsSize);

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -81,11 +81,10 @@ const MAX_RETAINED_ATTESTATIONS_PER_GROUP = 4;
 const MAX_ATTESTATIONS_PER_GROUP = 3;
 
 /**
- * For electra, each block has up to 8 aggregated attestations, assuming there are 3 for the "best"
- * attestation data, there are still 5 for other attestation data so this constant is still good.
- * We should separate to 2 constant based on conditions of different networks
+ * For electra, there is on chain aggregation of attestations across committees, so we can just pick up to 8
+ * attestations per group, sort by scores get get first 8.
  */
-const MAX_ATTESTATIONS_PER_GROUP_ELECTRA = 3;
+const MAX_ATTESTATIONS_PER_GROUP_ELECTRA = MAX_ATTESTATIONS_ELECTRA;
 
 /**
  * Maintain a pool of aggregated attestations. Attestations can be retrieved for inclusion in a block

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -507,14 +507,17 @@ export class AggregatedAttestationPool {
         metrics.opPool.aggregatedAttestationPool.attDataPerSlot.set(groupByIndexByDataHex.size);
 
         let maxAttestations = 0;
+        let committeeCount = 0;
         for (const groupByIndex of groupByIndexByDataHex.values()) {
           for (const group of groupByIndex.values()) {
             const attestationCount = group.getAttestationCount();
             maxAttestations = Math.max(maxAttestations, attestationCount);
             metrics.opPool.aggregatedAttestationPool.attestationsPerCommittee.observe(attestationCount);
+            committeeCount += 1;
           }
         }
         metrics.opPool.aggregatedAttestationPool.maxAttestationsPerCommittee.set(maxAttestations);
+        metrics.opPool.aggregatedAttestationPool.committeesPerSlot.set(committeeCount);
       }
     }
   }
@@ -866,7 +869,9 @@ export function getValidateAttestationDataFn(
       return false;
     }
 
-    if (!ssz.phase0.Checkpoint.equals(attData.source, justifiedCheckpoint)) return false;
+    if (!ssz.phase0.Checkpoint.equals(attData.source, justifiedCheckpoint)) {
+      return false;
+    }
 
     // Shuffling can't have changed if we're in the first few epochs
     // Also we can't look back 2 epochs if target epoch is 1 or less

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -95,6 +95,8 @@ const MAX_ATTESTATIONS_PER_GROUP = 3;
 /**
  * For electra, there is on chain aggregation of attestations across committees, so we can just pick up to 8
  * attestations per group, sort by scores get get first 8.
+ * The new algorithm is improved to get most valuable attestation helped not to get not-useful attestations anyway.
+ * The more consolidations we have per block, the less likely we have to scan all slots in the pool.
  */
 const MAX_ATTESTATIONS_PER_GROUP_ELECTRA = Math.min(
   MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA,

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -34,6 +34,7 @@ import {
   ssz,
 } from "@lodestar/types";
 import {assert, MapDef, toRootHex} from "@lodestar/utils";
+import {Metrics} from "../../metrics/metrics.js";
 import {IntersectResult, intersectUint8Arrays} from "../../util/bitArray.js";
 import {InsertOutcome} from "./types.js";
 import {pruneBySlot, signatureFromBytesNoCheck} from "./utils.js";
@@ -104,21 +105,11 @@ export class AggregatedAttestationPool {
   >(() => new Map<DataRootHex, Map<CommitteeIndex, MatchingDataAttestationGroup>>());
   private lowestPermissibleSlot = 0;
 
-  constructor(private readonly config: ChainForkConfig) {}
-
-  /** For metrics to track size of the pool */
-  getAttestationCount(): {attestationCount: number; attestationDataCount: number} {
-    let attestationCount = 0;
-    let attestationDataCount = 0;
-    for (const attestationGroupByIndexByDataHex of this.attestationGroupByIndexByDataHexBySlot.values()) {
-      for (const attestationGroupByIndex of attestationGroupByIndexByDataHex.values()) {
-        attestationDataCount += attestationGroupByIndex.size;
-        for (const attestationGroup of attestationGroupByIndex.values()) {
-          attestationCount += attestationGroup.getAttestationCount();
-        }
-      }
-    }
-    return {attestationCount, attestationDataCount};
+  constructor(
+    private readonly config: ChainForkConfig,
+    metrics: Metrics | null = null,
+  ) {
+    metrics?.opPool.aggregatedAttestationPool.attDataPerSlot.addCollect(() => this.onScrapeMetrics(metrics));
   }
 
   add(
@@ -440,6 +431,34 @@ export class AggregatedAttestationPool {
       }
     }
     return attestations;
+  }
+
+  private onScrapeMetrics(metrics: Metrics): void {
+    const allSlots = Array.from(this.attestationGroupByIndexByDataHexBySlot.keys());
+    // always record the previous slot because the current slot may not be finished yet, we may receive more attestations
+    if (allSlots.length > 1) {
+      // same to allSlots[allSlots.length - 2];
+      const previousSlot = allSlots.at(-2);
+      if (previousSlot == null) {
+        // only happen right after we start the node
+        return;
+      }
+
+      const groupByIndexByDataHex = this.attestationGroupByIndexByDataHexBySlot.get(previousSlot);
+      if (groupByIndexByDataHex != null) {
+        metrics.opPool.aggregatedAttestationPool.attDataPerSlot.set(groupByIndexByDataHex.size);
+
+        let maxAttestations = 0;
+        for (const groupByIndex of groupByIndexByDataHex.values()) {
+          for (const group of groupByIndex.values()) {
+            const attestationCount = group.getAttestationCount();
+            maxAttestations = Math.max(maxAttestations, attestationCount);
+            metrics.opPool.aggregatedAttestationPool.attestationsPerCommittee.observe(attestationCount);
+          }
+        }
+        metrics.opPool.aggregatedAttestationPool.maxAttestationsPerCommittee.set(maxAttestations);
+      }
+    }
   }
 }
 

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -17,6 +17,7 @@ import {
   CachedBeaconStateAllForks,
   CachedBeaconStateAltair,
   CachedBeaconStatePhase0,
+  EffectiveBalanceIncrements,
   computeEpochAtSlot,
   computeSlotsSinceEpochStart,
   computeStartSlotAtEpoch,
@@ -52,7 +53,7 @@ type AttestationWithScore = {attestation: Attestation; score: number};
 export type AttestationsConsolidation = {
   byCommittee: Map<CommitteeIndex, AttestationNonParticipant>;
   attData: phase0.AttestationData;
-  totalNotSeenCount: number;
+  totalNotSeenEffectiveBalance: number;
 };
 
 /**
@@ -106,7 +107,7 @@ export class AggregatedAttestationPool {
 
   constructor(
     private readonly config: ChainForkConfig,
-    metrics: Metrics | null = null,
+    metrics: Metrics | null = null
   ) {
     metrics?.opPool.aggregatedAttestationPool.attDataPerSlot.addCollect(() => this.onScrapeMetrics(metrics));
   }
@@ -255,11 +256,13 @@ export class AggregatedAttestationPool {
           // These properties should not change after being validate in gossip
           // IF they have to be validated, do it only with one attestation per group since same data
           // The committeeCountPerSlot can be precomputed once per slot
-          for (const {attestation, notSeenAttesterCount} of attestationGroup.getAttestationsForBlock(
+          for (const {attestation, notSeenEffectiveBalance} of attestationGroup.getAttestationsForBlock(
             fork,
-            notSeenAttestingIndices
+            state.epochCtx.effectiveBalanceIncrements,
+            notSeenAttestingIndices,
+            MAX_ATTESTATIONS_PER_GROUP
           )) {
-            const score = notSeenAttesterCount / slotDelta;
+            const score = notSeenEffectiveBalance / slotDelta;
             if (score < minScore) {
               minScore = score;
             }
@@ -341,17 +344,18 @@ export class AggregatedAttestationPool {
             continue;
           }
 
-          if (
-            slotCount > 2 &&
-            consolidations.size >= MAX_ATTESTATIONS_ELECTRA &&
-            notSeenAttestingIndices.size / slotDelta < minScore
-          ) {
-            // after 2 slots, there are a good chance that we have 2 * MAX_ATTESTATIONS_ELECTRA attestations and break the for loop early
-            // if not, we may have to scan all slots in the pool
-            // if we have enough attestations and the max possible score is lower than scores of `attestationsByScore`, we should skip
-            // otherwise it takes time to check attestation, add it and remove it later after the sort by score
-            continue;
-          }
+          // cannot apply this optimization like pre-electra because consolidation needs to be done across committees
+          // if (
+          //   slotCount > 2 &&
+          //   consolidations.size >= MAX_ATTESTATIONS_ELECTRA &&
+          //   notSeenAttestingIndices.size / slotDelta < minScore
+          // ) {
+          //   // after 2 slots, there are a good chance that we have 2 * MAX_ATTESTATIONS_ELECTRA attestations and break the for loop early
+          //   // if not, we may have to scan all slots in the pool
+          //   // if we have enough attestations and the max possible score is lower than scores of `attestationsByScore`, we should skip
+          //   // otherwise it takes time to check attestation, add it and remove it later after the sort by score
+          //   continue;
+          // }
 
           if (!validateAttestationDataFn(attestationGroup.data)) {
             continue;
@@ -365,21 +369,26 @@ export class AggregatedAttestationPool {
           // IF they have to be validated, do it only with one attestation per group since same data
           // The committeeCountPerSlot can be precomputed once per slot
           for (const [i, attestationNonParticipation] of attestationGroup
-            .getAttestationsForBlock(fork, notSeenAttestingIndices)
+            .getAttestationsForBlock(
+              fork,
+              state.epochCtx.effectiveBalanceIncrements,
+              notSeenAttestingIndices,
+              MAX_ATTESTATIONS_PER_GROUP_ELECTRA
+            )
             .entries()) {
             // sameAttDataCons shares the same index for different committees so we use index `i` here
             if (sameAttDataCons[i] === undefined) {
               sameAttDataCons[i] = {
                 byCommittee: new Map(),
                 attData: attestationNonParticipation.attestation.data,
-                totalNotSeenCount: 0,
+                totalNotSeenEffectiveBalance: 0,
               };
             }
             sameAttDataCons[i].byCommittee.set(committeeIndex, attestationNonParticipation);
-            sameAttDataCons[i].totalNotSeenCount += attestationNonParticipation.notSeenAttesterCount;
+            sameAttDataCons[i].totalNotSeenEffectiveBalance += attestationNonParticipation.notSeenEffectiveBalance;
           }
           for (const consolidation of sameAttDataCons) {
-            const score = consolidation.totalNotSeenCount / slotDelta;
+            const score = consolidation.totalNotSeenEffectiveBalance / slotDelta;
             if (score < minScore) {
               minScore = score;
             }
@@ -468,9 +477,10 @@ interface AttestationWithIndex {
 
 type AttestationNonParticipant = {
   attestation: Attestation;
-  // this is <= attestingIndices.count since some attesters may be seen by the chain
+  // this was `notSeenAttesterCount` in pre-electra
+  // since electra, we prioritize total effective balance over attester count
   // this is only updated and used in removeBySeenValidators function
-  notSeenAttesterCount: number;
+  notSeenEffectiveBalance: number;
 };
 
 /**
@@ -483,7 +493,6 @@ export class MatchingDataAttestationGroup {
   private readonly attestations: AttestationWithIndex[] = [];
 
   constructor(
-    // TODO: no need committee here
     readonly committee: Uint32Array,
     readonly data: phase0.AttestationData
   ) {}
@@ -546,10 +555,15 @@ export class MatchingDataAttestationGroup {
 
   /**
    * Get AttestationNonParticipant for this groups of same attestation data.
-   * @param notSeenAttestingIndices not seen attestting indices, i.e. indices in the same committee
+   * @param notSeenCommitteeMembers not seen attestting indices, i.e. indices in the same committee
    * @returns an array of AttestationNonParticipant
    */
-  getAttestationsForBlock(fork: ForkName, notSeenAttestingIndices: Set<number>): AttestationNonParticipant[] {
+  getAttestationsForBlock(
+    fork: ForkName,
+    effectiveBalanceIncrements: EffectiveBalanceIncrements,
+    notSeenAttestingIndices: Set<number>,
+    maxAttestation: number
+  ): AttestationNonParticipant[] {
     const attestations: AttestationNonParticipant[] = [];
     const isPostElectra = isForkPostElectra(fork);
     for (const {attestation} of this.attestations) {
@@ -560,25 +574,25 @@ export class MatchingDataAttestationGroup {
         continue;
       }
 
-      let notSeenAttesterCount = 0;
+      // from electra, we prioritize total effective balance over attester count
+      let notSeenEffectiveBalance = 0;
       const {aggregationBits} = attestation;
       for (const notSeenIndex of notSeenAttestingIndices) {
         if (aggregationBits.get(notSeenIndex)) {
-          notSeenAttesterCount++;
+          notSeenEffectiveBalance += effectiveBalanceIncrements[this.committee[notSeenIndex]];
         }
       }
 
-      if (notSeenAttesterCount > 0) {
-        attestations.push({attestation, notSeenAttesterCount});
+      if (notSeenEffectiveBalance > 0) {
+        attestations.push({attestation, notSeenEffectiveBalance});
       }
     }
 
-    const maxAttestation = isPostElectra ? MAX_ATTESTATIONS_PER_GROUP_ELECTRA : MAX_ATTESTATIONS_PER_GROUP;
     if (attestations.length <= maxAttestation) {
       return attestations;
     }
 
-    return attestations.sort((a, b) => b.notSeenAttesterCount - a.notSeenAttesterCount).slice(0, maxAttestation);
+    return attestations.sort((a, b) => b.notSeenEffectiveBalance - a.notSeenEffectiveBalance).slice(0, maxAttestation);
   }
 
   /** Get attestations for API. */
@@ -738,7 +752,7 @@ export function getValidateAttestationDataFn(
   forkChoice: IForkChoice,
   state: CachedBeaconStateAllForks
 ): ValidateAttestationDataFn {
-  const cachedValidatedAttestationData = new Map<RootHex, boolean>();
+  const cachedValidatedAttestationData = new Map<string, boolean>();
   const {previousJustifiedCheckpoint, currentJustifiedCheckpoint} = state;
   const stateEpoch = state.epochCtx.epoch;
   return (attData: phase0.AttestationData) => {

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -631,12 +631,13 @@ export class MatchingDataAttestationGroup {
     maxAttestation: number
   ): AttestationNonParticipant[] {
     const attestations: AttestationNonParticipant[] = [];
+    const excluded = new Set<Attestation>();
     for (let i = 0; i < maxAttestation; i++) {
       const mostValuableAttestation = this.getMostValuableAttestation(
         fork,
         effectiveBalanceIncrements,
         notSeenAttestingIndices,
-        new Set(attestations.map((a) => a.attestation))
+        excluded
       );
 
       if (mostValuableAttestation === null) {
@@ -645,6 +646,7 @@ export class MatchingDataAttestationGroup {
       }
 
       attestations.push(mostValuableAttestation);
+      excluded.add(mostValuableAttestation.attestation);
       // this will narrow down the notSeenAttestingIndices for the next iteration
       notSeenAttestingIndices = mostValuableAttestation.notSeenAttendingIndices;
     }

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -647,13 +647,14 @@ export function aggregateConsolidation({byCommittee, attData}: AttestationsConso
  * has already attested or not.
  */
 export function getNotSeenValidatorsFn(state: CachedBeaconStateAllForks): GetNotSeenValidatorsFn {
-  if (state.config.getForkName(state.slot) === ForkName.phase0) {
+  const stateSlot = state.slot;
+  if (state.config.getForkName(stateSlot) === ForkName.phase0) {
     // Get attestations to be included in a phase0 block.
     // As we are close to altair, this is not really important, it's mainly for e2e.
     // The performance is not great due to the different BeaconState data structure to altair.
     // check for phase0 block already
     const phase0State = state as CachedBeaconStatePhase0;
-    const stateEpoch = computeEpochAtSlot(state.slot);
+    const stateEpoch = computeEpochAtSlot(stateSlot);
 
     const previousEpochParticipants = extractParticipationPhase0(
       phase0State.previousEpochAttestations.getAllReadonly(),
@@ -690,7 +691,7 @@ export function getNotSeenValidatorsFn(state: CachedBeaconStateAllForks): GetNot
   const altairState = state as CachedBeaconStateAltair;
   const previousParticipation = altairState.previousEpochParticipation.getAll();
   const currentParticipation = altairState.currentEpochParticipation.getAll();
-  const stateEpoch = computeEpochAtSlot(state.slot);
+  const stateEpoch = computeEpochAtSlot(stateSlot);
   // this function could be called multiple times with same slot + committeeIndex
   const cachedNotSeenValidators = new Map<string, Set<number>>();
 
@@ -712,7 +713,8 @@ export function getNotSeenValidatorsFn(state: CachedBeaconStateAllForks): GetNot
     notSeenAttestingIndices = new Set<number>();
     for (const [i, validatorIndex] of committee.entries()) {
       // no need to check flagIsTimelySource as if validator is not seen, it's participation status is 0
-      if (participationStatus[validatorIndex] === 0) {
+      // attestations for the previous slot are not included in the state, so we don't need to check for them
+      if (slot === stateSlot - 1 || participationStatus[validatorIndex] === 0) {
         notSeenAttestingIndices.add(i);
       }
     }

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -456,6 +456,7 @@ export class AggregatedAttestationPool {
       packedAttestationsMetrics?.committeeMembers.set({index: i}, consolidation.committeeSize * committeeCount);
       packedAttestationsMetrics?.nonParticipation.set({index: i}, consolidation.notSeenAttesters);
       packedAttestationsMetrics?.inclusionDistance.set({index: i}, stateSlot - packedAttestations[i].data.slot);
+      packedAttestationsMetrics?.newSeenAttesters.set({index: i}, consolidation.newSeenAttesters);
       packedAttestationsMetrics?.totalEffectiveBalance.set({index: i}, consolidation.totalNewSeenEffectiveBalance);
     }
 

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -53,7 +53,8 @@ type AttestationWithScore = {attestation: Attestation; score: number};
 export type AttestationsConsolidation = {
   byCommittee: Map<CommitteeIndex, AttestationNonParticipant>;
   attData: phase0.AttestationData;
-  totalEffectiveBalance: number;
+  totalNewSeenEffectiveBalance: number;
+  newSeenAttesters: number;
   notSeenAttesters: number;
   committeeSize: number;
 };
@@ -278,7 +279,10 @@ export class AggregatedAttestationPool {
           // These properties should not change after being validate in gossip
           // IF they have to be validated, do it only with one attestation per group since same data
           // The committeeCountPerSlot can be precomputed once per slot
-          for (const {attestation, notSeenEffectiveBalance} of attestationGroup.getAttestationsForBlock(
+          for (const {
+            attestation,
+            newSeenEffectiveBalance: notSeenEffectiveBalance,
+          } of attestationGroup.getAttestationsForBlock(
             fork,
             state.epochCtx.effectiveBalanceIncrements,
             notSeenAttestingIndices,
@@ -404,20 +408,22 @@ export class AggregatedAttestationPool {
               sameAttDataCons[i] = {
                 byCommittee: new Map(),
                 attData: attestationNonParticipation.attestation.data,
-                totalEffectiveBalance: 0,
+                totalNewSeenEffectiveBalance: 0,
+                newSeenAttesters: 0,
                 notSeenAttesters: 0,
                 committeeSize: attestationGroup.committee.length,
               };
             }
             sameAttDataCons[i].byCommittee.set(committeeIndex, attestationNonParticipation);
-            sameAttDataCons[i].totalEffectiveBalance += attestationNonParticipation.notSeenEffectiveBalance;
+            sameAttDataCons[i].totalNewSeenEffectiveBalance += attestationNonParticipation.newSeenEffectiveBalance;
+            sameAttDataCons[i].newSeenAttesters += attestationNonParticipation.newSeenAttesters;
             sameAttDataCons[i].notSeenAttesters += attestationNonParticipation.notSeenAttendingIndices.size;
           }
         } // all committees are processed
 
         // after all committees are processed, we have a list of sameAttDataCons
         for (const consolidation of sameAttDataCons) {
-          const score = consolidation.totalEffectiveBalance / slotDelta;
+          const score = consolidation.totalNewSeenEffectiveBalance / slotDelta;
           consolidations.set(consolidation, score);
           // Stop accumulating attestations there are enough that may have good scoring
           if (consolidations.size >= MAX_ATTESTATIONS_ELECTRA * 2) {
@@ -449,8 +455,8 @@ export class AggregatedAttestationPool {
       packedAttestationsMetrics?.committeeBits.set({index: i}, committeeCount);
       packedAttestationsMetrics?.committeeMembers.set({index: i}, consolidation.committeeSize * committeeCount);
       packedAttestationsMetrics?.nonParticipation.set({index: i}, consolidation.notSeenAttesters);
-      packedAttestationsMetrics?.slotDelta.set({index: i}, stateSlot - packedAttestations[i].data.slot);
-      packedAttestationsMetrics?.totalEffectiveBalance.set({index: i}, consolidation.totalEffectiveBalance);
+      packedAttestationsMetrics?.inclusionDistance.set({index: i}, stateSlot - packedAttestations[i].data.slot);
+      packedAttestationsMetrics?.totalEffectiveBalance.set({index: i}, consolidation.totalNewSeenEffectiveBalance);
     }
 
     if (stopReason === null) {
@@ -533,7 +539,8 @@ type AttestationNonParticipant = {
   // this was `notSeenAttesterCount` in pre-electra
   // since electra, we prioritize total effective balance over attester count
   // this is only updated and used in removeBySeenValidators function
-  notSeenEffectiveBalance: number;
+  newSeenEffectiveBalance: number;
+  newSeenAttesters: number;
   notSeenAttendingIndices: Set<number>;
 };
 
@@ -659,7 +666,8 @@ export class MatchingDataAttestationGroup {
 
     const isPostElectra = isForkPostElectra(fork);
 
-    let maxNotSeenEffectiveBalance = 0;
+    let maxNewSeenEffectiveBalance = 0;
+    let newSeenAttesters = 0;
     let mostValuableAttestation: AttestationNonParticipant | null = null;
     for (const {attestation} of this.attestations) {
       if (
@@ -676,19 +684,25 @@ export class MatchingDataAttestationGroup {
       const notSeen = new Set<number>();
 
       // from electra, we prioritize total effective balance over attester count
-      let notSeenEffectiveBalance = 0;
+      let newSeenEffectiveBalance = 0;
       const {aggregationBits} = attestation;
       for (const notSeenIndex of notSeenAttestingIndices) {
         if (aggregationBits.get(notSeenIndex)) {
-          notSeenEffectiveBalance += effectiveBalanceIncrements[this.committee[notSeenIndex]];
+          newSeenEffectiveBalance += effectiveBalanceIncrements[this.committee[notSeenIndex]];
+          newSeenAttesters++;
         } else {
           notSeen.add(notSeenIndex);
         }
       }
 
-      if (notSeenEffectiveBalance > maxNotSeenEffectiveBalance) {
-        maxNotSeenEffectiveBalance = notSeenEffectiveBalance;
-        mostValuableAttestation = {attestation, notSeenEffectiveBalance, notSeenAttendingIndices: notSeen};
+      if (newSeenEffectiveBalance > maxNewSeenEffectiveBalance) {
+        maxNewSeenEffectiveBalance = newSeenEffectiveBalance;
+        mostValuableAttestation = {
+          attestation,
+          newSeenEffectiveBalance,
+          newSeenAttesters,
+          notSeenAttendingIndices: notSeen,
+        };
       }
     }
 

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -351,6 +351,7 @@ export class AggregatedAttestationPool {
 
       // validateAttestation condition: Attestation slot not within inclusion window
       if (!(slot + MIN_ATTESTATION_INCLUSION_DELAY <= stateSlot)) {
+        // this should not happen and slot is decreased so no need to track in metric
         continue; // Invalid attestations
       }
 
@@ -364,16 +365,19 @@ export class AggregatedAttestationPool {
         const sameAttDataCons: AttestationsConsolidation[] = [];
         const allAttestationGroups = Array.from(attestationGroupByIndex.values());
         if (allAttestationGroups.length === 0) {
+          this.metrics?.opPool.aggregatedAttestationPool.packedAttestations.emptyAttestationData.inc();
           continue;
         }
 
         if (!validateAttestationDataFn(allAttestationGroups[0].data)) {
+          this.metrics?.opPool.aggregatedAttestationPool.packedAttestations.invalidAttestationData.inc();
           continue;
         }
 
         for (const [committeeIndex, attestationGroup] of attestationGroupByIndex.entries()) {
           const notSeenAttestingIndices = notSeenValidatorsFn(epoch, slot, committeeIndex);
           if (notSeenAttestingIndices === null || notSeenAttestingIndices.size === 0) {
+            this.metrics?.opPool.aggregatedAttestationPool.packedAttestations.seenCommittees.inc();
             continue;
           }
 

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -101,6 +101,12 @@ const MAX_ATTESTATIONS_PER_GROUP_ELECTRA = Math.min(
   MAX_ATTESTATIONS_ELECTRA
 );
 
+export enum ScannedSlotsTerminationReason {
+  MaxConsolidationReached = "max_consolidation_reached",
+  ScannedAllSlots = "scanned_all_slots",
+  SlotBeforePreviousEpoch = "slot_before_previous_epoch",
+}
+
 /**
  * Maintain a pool of aggregated attestations. Attestations can be retrieved for inclusion in a block
  * or api. The returned attestations are aggregated to maximise the number of validators that can be
@@ -325,6 +331,7 @@ export class AggregatedAttestationPool {
     // Track score of each `AttestationsConsolidation`
     const consolidations = new Map<AttestationsConsolidation, number>();
     let scannedSlots = 0;
+    let stopReason: ScannedSlotsTerminationReason | null = null;
     slot: for (const slot of slots) {
       const attestationGroupByIndexByDataHash = this.attestationGroupByIndexByDataHexBySlot.get(slot);
       // should not happen
@@ -336,7 +343,8 @@ export class AggregatedAttestationPool {
       // validateAttestation condition: Attestation target epoch not in previous or current epoch
       if (!(epoch === stateEpoch || epoch === statePrevEpoch)) {
         // we process slot in desc order, this means slot is out of current or previous epoch, we should stop
-        break slot; // Invalid attestations
+        stopReason = ScannedSlotsTerminationReason.SlotBeforePreviousEpoch;
+        break; // Invalid attestations
       }
 
       // validateAttestation condition: Attestation slot not within inclusion window
@@ -377,8 +385,7 @@ export class AggregatedAttestationPool {
           // These properties should not change after being validate in gossip
           // IF they have to be validated, do it only with one attestation per group since same data
           // The committeeCountPerSlot can be precomputed once per slot
-          const attestationsSameGroup = attestationGroup
-          .getAttestationsForBlock(
+          const attestationsSameGroup = attestationGroup.getAttestationsForBlock(
             fork,
             state.epochCtx.effectiveBalanceIncrements,
             notSeenAttestingIndices,
@@ -408,6 +415,7 @@ export class AggregatedAttestationPool {
           consolidations.set(consolidation, score);
           // Stop accumulating attestations there are enough that may have good scoring
           if (consolidations.size >= MAX_ATTESTATIONS_ELECTRA * 2) {
+            stopReason = ScannedSlotsTerminationReason.MaxConsolidationReached;
             break slot;
           }
         }
@@ -416,6 +424,8 @@ export class AggregatedAttestationPool {
       // finished processing a slot
       scannedSlots++;
     }
+
+    this.metrics?.opPool.aggregatedAttestationPool.packedAttestations.totalConsolidations.set(consolidations.size);
 
     const sortedConsolidationsByScore = Array.from(consolidations.entries())
       .sort((a, b) => b[1] - a[1])
@@ -437,7 +447,10 @@ export class AggregatedAttestationPool {
       packedAttestationsMetrics?.totalEffectiveBalance.set({index: i}, consolidation.totalEffectiveBalance);
     }
 
-    packedAttestationsMetrics?.scannedSlots.set(scannedSlots);
+    if (stopReason === null) {
+      stopReason = ScannedSlotsTerminationReason.ScannedAllSlots;
+    }
+    packedAttestationsMetrics?.scannedSlots.set({reason: stopReason}, scannedSlots);
     packedAttestationsMetrics?.totalSlots.set(slots.length);
 
     return packedAttestations;
@@ -605,7 +618,7 @@ export class MatchingDataAttestationGroup {
         fork,
         effectiveBalanceIncrements,
         notSeenAttestingIndices,
-        new Set(attestations.map((a) => a.attestation)),
+        new Set(attestations.map((a) => a.attestation))
       );
 
       if (mostValuableAttestation === null) {
@@ -628,7 +641,7 @@ export class MatchingDataAttestationGroup {
     fork: ForkName,
     effectiveBalanceIncrements: EffectiveBalanceIncrements,
     notSeenAttestingIndices: Set<number>,
-    excluded: Set<Attestation>,
+    excluded: Set<Attestation>
   ): AttestationNonParticipant | null {
     if (notSeenAttestingIndices.size === 0) {
       // no more attesters to consider

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -37,6 +37,7 @@ import {
 import {assert, MapDef, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {IntersectResult, intersectUint8Arrays} from "../../util/bitArray.js";
+import {getShufflingDependentRoot} from "../../util/dependentRoot.js";
 import {InsertOutcome} from "./types.js";
 import {pruneBySlot, signatureFromBytesNoCheck} from "./utils.js";
 
@@ -967,7 +968,14 @@ function isValidShuffling(
 
   let attestationDependentRoot: string;
   try {
-    attestationDependentRoot = forkChoice.getDependentRoot(beaconBlock, EpochDifference.previous);
+    // should not use forkChoice.getDependentRoot directly, see https://github.com/ChainSafe/lodestar/issues/7651
+    // attestationDependentRoot = forkChoice.getDependentRoot(beaconBlock, EpochDifference.previous);
+    attestationDependentRoot = getShufflingDependentRoot(
+      forkChoice,
+      targetEpoch,
+      computeEpochAtSlot(beaconBlock.slot),
+      beaconBlock
+    );
   } catch (_) {
     // getDependent root may throw error if the dependent root of attestation data is prior to finalized slot
     // ignore this attestation data in that case since we're not sure it's compatible to the state

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -310,10 +310,7 @@ export class AggregatedAttestationPool {
     const slots = Array.from(this.attestationGroupByIndexByDataHexBySlot.keys()).sort((a, b) => b - a);
     // Track score of each `AttestationsConsolidation`
     const consolidations = new Map<AttestationsConsolidation, number>();
-    let minScore = Number.MAX_SAFE_INTEGER;
-    let slotCount = 0;
     slot: for (const slot of slots) {
-      slotCount++;
       const attestationGroupByIndexByDataHash = this.attestationGroupByIndexByDataHexBySlot.get(slot);
       // should not happen
       if (!attestationGroupByIndexByDataHash) {
@@ -338,28 +335,23 @@ export class AggregatedAttestationPool {
       for (const attestationGroupByIndex of attestationGroupByIndexByDataHash.values()) {
         // sameAttDataCons could be up to MAX_ATTESTATIONS_PER_GROUP_ELECTRA
         const sameAttDataCons: AttestationsConsolidation[] = [];
+        const allAttestationGroups = Array.from(attestationGroupByIndex.values());
+        if (allAttestationGroups.length === 0) {
+          continue;
+        }
+
+        if (!validateAttestationDataFn(allAttestationGroups[0].data)) {
+          continue;
+        }
+
         for (const [committeeIndex, attestationGroup] of attestationGroupByIndex.entries()) {
           const notSeenAttestingIndices = notSeenValidatorsFn(epoch, slot, committeeIndex);
           if (notSeenAttestingIndices === null || notSeenAttestingIndices.size === 0) {
             continue;
           }
 
-          // cannot apply this optimization like pre-electra because consolidation needs to be done across committees
-          // if (
-          //   slotCount > 2 &&
-          //   consolidations.size >= MAX_ATTESTATIONS_ELECTRA &&
-          //   notSeenAttestingIndices.size / slotDelta < minScore
-          // ) {
-          //   // after 2 slots, there are a good chance that we have 2 * MAX_ATTESTATIONS_ELECTRA attestations and break the for loop early
-          //   // if not, we may have to scan all slots in the pool
-          //   // if we have enough attestations and the max possible score is lower than scores of `attestationsByScore`, we should skip
-          //   // otherwise it takes time to check attestation, add it and remove it later after the sort by score
-          //   continue;
-          // }
-
-          if (!validateAttestationDataFn(attestationGroup.data)) {
-            continue;
-          }
+          // cannot apply this optimization like pre-electra because consolidation needs to be done across committees:
+          // "after 2 slots, there are a good chance that we have 2 * MAX_ATTESTATIONS_ELECTRA attestations and break the for loop early"
 
           // TODO: Is it necessary to validateAttestation for:
           // - Attestation committee index not within current committee count
@@ -387,18 +379,15 @@ export class AggregatedAttestationPool {
             sameAttDataCons[i].byCommittee.set(committeeIndex, attestationNonParticipation);
             sameAttDataCons[i].totalNotSeenEffectiveBalance += attestationNonParticipation.notSeenEffectiveBalance;
           }
-          for (const consolidation of sameAttDataCons) {
-            const score = consolidation.totalNotSeenEffectiveBalance / slotDelta;
-            if (score < minScore) {
-              minScore = score;
-            }
+        } // all committees are processed
 
-            consolidations.set(consolidation, score);
-
-            // Stop accumulating attestations there are enough that may have good scoring
-            if (consolidations.size >= MAX_ATTESTATIONS_ELECTRA * 2) {
-              break slot;
-            }
+        // after all committees are processed, we have a list of sameAttDataCons
+        for (const consolidation of sameAttDataCons) {
+          const score = consolidation.totalNotSeenEffectiveBalance / slotDelta;
+          consolidations.set(consolidation, score);
+          // Stop accumulating attestations there are enough that may have good scoring
+          if (consolidations.size >= MAX_ATTESTATIONS_ELECTRA * 2) {
+            break slot;
           }
         }
       }

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -73,6 +73,15 @@ type ValidateAttestationDataFn = (attData: phase0.AttestationData) => boolean;
 const MAX_RETAINED_ATTESTATIONS_PER_GROUP = 4;
 
 /**
+ * This is the same to MAX_RETAINED_ATTESTATIONS_PER_GROUP but for electra
+ * As monitored in hoodi, max attestations per group could be up to > 10. But in electra we can
+ * consolidate attestations across committees, so we can just pick up to 8 attestations per group.
+ * Also the MatchingDataAttestationGroup.getAttestationsForBlock() is improved not to have to scan each
+ * committee member for previous slot.
+ */
+const MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA = 8;
+
+/**
  * Pre-electra, each slot has 64 committees, and each block has 128 attestations max so in average
  * we get 2 attestation per groups.
  * Starting from Jan 2024, we have a performance issue getting attestations for a block. Based on the
@@ -85,7 +94,10 @@ const MAX_ATTESTATIONS_PER_GROUP = 3;
  * For electra, there is on chain aggregation of attestations across committees, so we can just pick up to 8
  * attestations per group, sort by scores get get first 8.
  */
-const MAX_ATTESTATIONS_PER_GROUP_ELECTRA = MAX_ATTESTATIONS_ELECTRA;
+const MAX_ATTESTATIONS_PER_GROUP_ELECTRA = Math.min(
+  MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA,
+  MAX_ATTESTATIONS_ELECTRA
+);
 
 /**
  * Maintain a pool of aggregated attestations. Attestations can be retrieved for inclusion in a block
@@ -150,7 +162,7 @@ export class AggregatedAttestationPool {
     assert.notNull(committeeIndex, "Committee index should not be null in aggregated attestation pool");
     let attestationGroup = attestationGroupByIndex.get(committeeIndex);
     if (!attestationGroup) {
-      attestationGroup = new MatchingDataAttestationGroup(committee, attestation.data);
+      attestationGroup = new MatchingDataAttestationGroup(this.config, committee, attestation.data);
       attestationGroupByIndex.set(committeeIndex, attestationGroup);
     }
 
@@ -482,6 +494,7 @@ export class MatchingDataAttestationGroup {
   private readonly attestations: AttestationWithIndex[] = [];
 
   constructor(
+    private readonly config: ChainForkConfig,
     readonly committee: Uint32Array,
     readonly data: phase0.AttestationData
   ) {}
@@ -530,13 +543,15 @@ export class MatchingDataAttestationGroup {
 
     this.attestations.push(attestation);
 
+    const maxRetained = isForkPostElectra(this.config.getForkName(this.data.slot))
+      ? MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA
+      : MAX_RETAINED_ATTESTATIONS_PER_GROUP;
+
     // Remove the attestations with less participation
-    if (this.attestations.length > MAX_RETAINED_ATTESTATIONS_PER_GROUP) {
+    if (this.attestations.length > maxRetained) {
+      // TODO: for electra, ideally we should sort by effective balance
       this.attestations.sort((a, b) => b.trueBitsCount - a.trueBitsCount);
-      this.attestations.splice(
-        MAX_RETAINED_ATTESTATIONS_PER_GROUP,
-        this.attestations.length - MAX_RETAINED_ATTESTATIONS_PER_GROUP
-      );
+      this.attestations.splice(maxRetained, this.attestations.length - maxRetained);
     }
 
     return InsertOutcome.NewData;

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -338,7 +338,7 @@ export class AggregatedAttestationPool {
       }
 
       const slotDelta = stateSlot - slot;
-      // CommitteeIndex    0           1            2    ...   Consolidation
+      // CommitteeIndex    0           1            2    ...   Consolidation (sameAttDataCons)
       // Attestations    att00  ---   att10  ---  att20  ---   0 (att 00 10 20)
       //                 att01  ---     -    ---  att21  ---   1 (att 01 __ 21)
       //                   -    ---     -    ---  att22  ---   2 (att __ __ 22)
@@ -377,6 +377,7 @@ export class AggregatedAttestationPool {
           for (const [i, attestationNonParticipation] of attestationGroup
             .getAttestationsForBlock(fork, notSeenAttestingIndices)
             .entries()) {
+            // sameAttDataCons shares the same index for different committees so we use index `i` here
             if (sameAttDataCons[i] === undefined) {
               sameAttDataCons[i] = {
                 byCommittee: new Map(),

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -53,7 +53,9 @@ type AttestationWithScore = {attestation: Attestation; score: number};
 export type AttestationsConsolidation = {
   byCommittee: Map<CommitteeIndex, AttestationNonParticipant>;
   attData: phase0.AttestationData;
-  totalNotSeenEffectiveBalance: number;
+  totalEffectiveBalance: number;
+  notSeenAttesters: number;
+  committeeSize: number;
 };
 
 /**
@@ -119,7 +121,7 @@ export class AggregatedAttestationPool {
 
   constructor(
     private readonly config: ChainForkConfig,
-    metrics: Metrics | null = null
+    private readonly metrics: Metrics | null = null
   ) {
     metrics?.opPool.aggregatedAttestationPool.attDataPerSlot.addCollect(() => this.onScrapeMetrics(metrics));
   }
@@ -322,6 +324,7 @@ export class AggregatedAttestationPool {
     const slots = Array.from(this.attestationGroupByIndexByDataHexBySlot.keys()).sort((a, b) => b - a);
     // Track score of each `AttestationsConsolidation`
     const consolidations = new Map<AttestationsConsolidation, number>();
+    let scannedSlots = 0;
     slot: for (const slot of slots) {
       const attestationGroupByIndexByDataHash = this.attestationGroupByIndexByDataHexBySlot.get(slot);
       // should not happen
@@ -372,30 +375,34 @@ export class AggregatedAttestationPool {
           // These properties should not change after being validate in gossip
           // IF they have to be validated, do it only with one attestation per group since same data
           // The committeeCountPerSlot can be precomputed once per slot
-          for (const [i, attestationNonParticipation] of attestationGroup
-            .getAttestationsForBlock(
-              fork,
-              state.epochCtx.effectiveBalanceIncrements,
-              notSeenAttestingIndices,
-              MAX_ATTESTATIONS_PER_GROUP_ELECTRA
-            )
-            .entries()) {
+          const attestationsSameGroup = attestationGroup
+          .getAttestationsForBlock(
+            fork,
+            state.epochCtx.effectiveBalanceIncrements,
+            notSeenAttestingIndices,
+            MAX_ATTESTATIONS_PER_GROUP_ELECTRA
+          );
+
+          for (const [i, attestationNonParticipation] of attestationsSameGroup.entries()) {
             // sameAttDataCons shares the same index for different committees so we use index `i` here
             if (sameAttDataCons[i] === undefined) {
               sameAttDataCons[i] = {
                 byCommittee: new Map(),
                 attData: attestationNonParticipation.attestation.data,
-                totalNotSeenEffectiveBalance: 0,
+                totalEffectiveBalance: 0,
+                notSeenAttesters: 0,
+                committeeSize: attestationGroup.committee.length,
               };
             }
             sameAttDataCons[i].byCommittee.set(committeeIndex, attestationNonParticipation);
-            sameAttDataCons[i].totalNotSeenEffectiveBalance += attestationNonParticipation.notSeenEffectiveBalance;
+            sameAttDataCons[i].totalEffectiveBalance += attestationNonParticipation.notSeenEffectiveBalance;
+            sameAttDataCons[i].notSeenAttesters += attestationNonParticipation.notSeenAttendingIndices.size;
           }
         } // all committees are processed
 
         // after all committees are processed, we have a list of sameAttDataCons
         for (const consolidation of sameAttDataCons) {
-          const score = consolidation.totalNotSeenEffectiveBalance / slotDelta;
+          const score = consolidation.totalEffectiveBalance / slotDelta;
           consolidations.set(consolidation, score);
           // Stop accumulating attestations there are enough that may have good scoring
           if (consolidations.size >= MAX_ATTESTATIONS_ELECTRA * 2) {
@@ -403,14 +410,35 @@ export class AggregatedAttestationPool {
           }
         }
       }
+
+      // finished processing a slot
+      scannedSlots++;
     }
+
     const sortedConsolidationsByScore = Array.from(consolidations.entries())
       .sort((a, b) => b[1] - a[1])
       .map(([consolidation, _]) => consolidation)
       .slice(0, MAX_ATTESTATIONS_ELECTRA);
 
     // on chain aggregation is expensive, only do it after all
-    return sortedConsolidationsByScore.map(aggregateConsolidation);
+    const packedAttestationsMetrics = this.metrics?.opPool.aggregatedAttestationPool.packedAttestations;
+    const packedAttestations: electra.Attestation[] = new Array(sortedConsolidationsByScore.length);
+    for (const [i, consolidation] of sortedConsolidationsByScore.entries()) {
+      packedAttestations[i] = aggregateConsolidation(consolidation);
+
+      // record metrics of packed attestations
+      const committeeCount = consolidation.byCommittee.size;
+      packedAttestationsMetrics?.committeeBits.set({index: i}, committeeCount);
+      packedAttestationsMetrics?.committeeMembers.set({index: i}, consolidation.committeeSize * committeeCount);
+      packedAttestationsMetrics?.nonParticipation.set({index: i}, consolidation.notSeenAttesters);
+      packedAttestationsMetrics?.slotDelta.set({index: i}, stateSlot - packedAttestations[i].data.slot);
+      packedAttestationsMetrics?.totalEffectiveBalance.set({index: i}, consolidation.totalEffectiveBalance);
+    }
+
+    packedAttestationsMetrics?.scannedSlots.set(scannedSlots);
+    packedAttestationsMetrics?.totalSlots.set(slots.length);
+
+    return packedAttestations;
   }
 
   /**
@@ -482,6 +510,7 @@ type AttestationNonParticipant = {
   // since electra, we prioritize total effective balance over attester count
   // this is only updated and used in removeBySeenValidators function
   notSeenEffectiveBalance: number;
+  notSeenAttendingIndices: Set<number>;
 };
 
 /**
@@ -569,7 +598,45 @@ export class MatchingDataAttestationGroup {
     maxAttestation: number
   ): AttestationNonParticipant[] {
     const attestations: AttestationNonParticipant[] = [];
+    for (let i = 0; i < maxAttestation; i++) {
+      const mostValuableAttestation = this.getMostValuableAttestation(
+        fork,
+        effectiveBalanceIncrements,
+        notSeenAttestingIndices,
+        new Set(attestations.map((a) => a.attestation)),
+      );
+
+      if (mostValuableAttestation === null) {
+        // stop looking for attestation because all attesters are seen or no attestation has missing attesters
+        break;
+      }
+
+      attestations.push(mostValuableAttestation);
+      // this will narrow down the notSeenAttestingIndices for the next iteration
+      notSeenAttestingIndices = mostValuableAttestation.notSeenAttendingIndices;
+    }
+
+    return attestations;
+  }
+
+  /**
+   * Most valuable attestation is attestation has the most effective balance of not seen validators.
+   */
+  getMostValuableAttestation(
+    fork: ForkName,
+    effectiveBalanceIncrements: EffectiveBalanceIncrements,
+    notSeenAttestingIndices: Set<number>,
+    excluded: Set<Attestation>,
+  ): AttestationNonParticipant | null {
+    if (notSeenAttestingIndices.size === 0) {
+      // no more attesters to consider
+      return null;
+    }
+
     const isPostElectra = isForkPostElectra(fork);
+
+    let maxNotSeenEffectiveBalance = 0;
+    let mostValuableAttestation: AttestationNonParticipant | null = null;
     for (const {attestation} of this.attestations) {
       if (
         (isPostElectra && !isElectraAttestation(attestation)) ||
@@ -578,25 +645,30 @@ export class MatchingDataAttestationGroup {
         continue;
       }
 
+      if (excluded.has(attestation)) {
+        continue;
+      }
+
+      const notSeen = new Set<number>();
+
       // from electra, we prioritize total effective balance over attester count
       let notSeenEffectiveBalance = 0;
       const {aggregationBits} = attestation;
       for (const notSeenIndex of notSeenAttestingIndices) {
         if (aggregationBits.get(notSeenIndex)) {
           notSeenEffectiveBalance += effectiveBalanceIncrements[this.committee[notSeenIndex]];
+        } else {
+          notSeen.add(notSeenIndex);
         }
       }
 
-      if (notSeenEffectiveBalance > 0) {
-        attestations.push({attestation, notSeenEffectiveBalance});
+      if (notSeenEffectiveBalance > maxNotSeenEffectiveBalance) {
+        maxNotSeenEffectiveBalance = notSeenEffectiveBalance;
+        mostValuableAttestation = {attestation, notSeenEffectiveBalance, notSeenAttendingIndices: notSeen};
       }
     }
 
-    if (attestations.length <= maxAttestation) {
-      return attestations;
-    }
-
-    return attestations.sort((a, b) => b.notSeenEffectiveBalance - a.notSeenEffectiveBalance).slice(0, maxAttestation);
+    return mostValuableAttestation;
   }
 
   /** Get attestations for API. */

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -335,8 +335,10 @@ export class AggregatedAttestationPool {
       const epoch = computeEpochAtSlot(slot);
       // validateAttestation condition: Attestation target epoch not in previous or current epoch
       if (!(epoch === stateEpoch || epoch === statePrevEpoch)) {
-        continue; // Invalid attestations
+        // we process slot in desc order, this means slot is out of current or previous epoch, we should stop
+        break slot; // Invalid attestations
       }
+
       // validateAttestation condition: Attestation slot not within inclusion window
       if (!(slot + MIN_ATTESTATION_INCLUSION_DELAY <= stateSlot)) {
         continue; // Invalid attestations

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -886,14 +886,19 @@ export function createLodestarMetrics(
             help: "Total number of not seen attesters in packed attestation ${index}",
             labelNames: ["index"],
           }),
-          slotDelta: register.gauge<{index: number}>({
-            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_slot_delta_total",
-            help: "How far the packed attestations ${index} from the block slot",
+          newSeenAttesters: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_new_seen_attesters_total",
+            help: "Total number of new seen attesters in packed attestation ${index}",
             labelNames: ["index"],
           }),
           totalEffectiveBalance: register.gauge<{index: number}>({
             name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_total_effective_balance",
-            help: "Total effective balance of attesters in packed attestation ${index}",
+            help: "Total effective balance of new seen attesters in packed attestation ${index}",
+            labelNames: ["index"],
+          }),
+          inclusionDistance: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_slot_delta_total",
+            help: "How far the packed attestations ${index} from the block slot",
             labelNames: ["index"],
           }),
           scannedSlots: register.gauge<{reason: ScannedSlotsTerminationReason}>({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -865,6 +865,41 @@ export function createLodestarMetrics(
           help: "Number of attestations per committee in AggregatedAttestationPool",
           buckets: [0, 2, 4, 8],
         }),
+        packedAttestations: {
+          committeeBits: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_committee_bits_total",
+            help: "Total number of committee bits in packed attestation ${index}",
+            labelNames: ["index"],
+          }),
+          committeeMembers: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_committee_members_total",
+            help: "Total number of committee members in packed attestation ${index}",
+            labelNames: ["index"],
+          }),
+          nonParticipation: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_non_participation_total",
+            help: "Total number of not seen attesters in packed attestation ${index}",
+            labelNames: ["index"],
+          }),
+          slotDelta: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_slot_delta_total",
+            help: "How far the packed attestations ${index} from the block slot",
+            labelNames: ["index"],
+          }),
+          totalEffectiveBalance: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_total_effective_balance",
+            help: "Total effective balance of attesters in packed attestation ${index}",
+            labelNames: ["index"],
+          }),
+          scannedSlots: register.gauge({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_scanned_slots_total",
+            help: "Total number of scanned slots to produce packed attestations",
+          }),
+          totalSlots: register.gauge({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_total_slots_total",
+            help: "Total number of slots in pool when producing packed attestations",
+          })
+        },
       },
       attestationPoolSize: register.gauge({
         name: "lodestar_oppool_attestation_pool_size",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -856,6 +856,10 @@ export function createLodestarMetrics(
           name: "lodestar_oppool_aggregated_attestation_pool_attestation_data_per_slot_total",
           help: "Total number of attestation data per slot in AggregatedAttestationPool",
         }),
+        committeesPerSlot: register.gauge({
+          name: "lodestar_oppool_aggregated_attestation_pool_committees_per_slot_total",
+          help: "Total number of committees per slot in AggregatedAttestationPool",
+        }),
         // max number of attestations per committee will become number of consolidations
         maxAttestationsPerCommittee: register.gauge({
           name: "lodestar_oppool_aggregated_attestation_pool_max_attestations_per_committee",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -863,8 +863,7 @@ export function createLodestarMetrics(
         attestationsPerCommittee: register.histogram({
           name: "lodestar_oppool_aggregated_attestation_pool_attestations_per_committee",
           help: "Number of attestations per committee in AggregatedAttestationPool",
-          // TODO: monitor this on hoodi
-          buckets: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+          buckets: [0, 2, 4, 8],
         }),
       },
       attestationPoolSize: register.gauge({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -3,6 +3,7 @@ import {BeaconState} from "@lodestar/types";
 import {BlobsSource, BlockSource} from "../../chain/blocks/types.js";
 import {JobQueueItemType} from "../../chain/bls/index.js";
 import {AttestationErrorCode, BlockErrorCode} from "../../chain/errors/index.js";
+import {ScannedSlotsTerminationReason} from "../../chain/opPools/aggregatedAttestationPool.js";
 import {InsertOutcome} from "../../chain/opPools/types.js";
 import {RegenCaller, RegenFnName} from "../../chain/regen/interface.js";
 import {ReprocessStatus} from "../../chain/reprocess.js";
@@ -891,14 +892,19 @@ export function createLodestarMetrics(
             help: "Total effective balance of attesters in packed attestation ${index}",
             labelNames: ["index"],
           }),
-          scannedSlots: register.gauge({
+          scannedSlots: register.gauge<{reason: ScannedSlotsTerminationReason}>({
             name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_scanned_slots_total",
             help: "Total number of scanned slots to produce packed attestations",
+            labelNames: ["reason"],
           }),
           totalSlots: register.gauge({
             name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_total_slots_total",
             help: "Total number of slots in pool when producing packed attestations",
-          })
+          }),
+          totalConsolidations: register.gauge({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_total_consolidations_total",
+            help: "Total number of consolidations before truncate",
+          }),
         },
       },
       attestationPoolSize: register.gauge({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -850,17 +850,23 @@ export function createLodestarMetrics(
     },
 
     opPool: {
-      // Note: Current opPool metrics only track current size.
-      //       I don't believe tracking total add() count is relevant since that can be seen with gossip ACCEPTs
-      aggregatedAttestationPoolSize: register.gauge({
-        name: "lodestar_oppool_aggregated_attestation_pool_size",
-        help: "Current size of the AggregatedAttestationPool = total attestations",
-      }),
-      /** This metric helps view how many overlapping attestations we keep per data on average */
-      aggregatedAttestationPoolUniqueData: register.gauge({
-        name: "lodestar_oppool_aggregated_attestation_pool_unique_data_count",
-        help: "Current size of the AggregatedAttestationPool = total attestations unique by data",
-      }),
+      aggregatedAttestationPool: {
+        attDataPerSlot: register.gauge({
+          name: "lodestar_oppool_aggregated_attestation_pool_attestation_data_per_slot_total",
+          help: "Total number of attestation data per slot in AggregatedAttestationPool",
+        }),
+        // max number of attestations per committee will become number of consolidations
+        maxAttestationsPerCommittee: register.gauge({
+          name: "lodestar_oppool_aggregated_attestation_pool_max_attestations_per_committee",
+          help: "Max number of attestations per committee in AggregatedAttestationPool",
+        }),
+        attestationsPerCommittee: register.histogram({
+          name: "lodestar_oppool_aggregated_attestation_pool_attestations_per_committee",
+          help: "Number of attestations per committee in AggregatedAttestationPool",
+          // TODO: monitor this on hoodi
+          buckets: [0, 1, 2, 3, 4, 5, 6, 7, 8],
+        }),
+      },
       attestationPoolSize: register.gauge({
         name: "lodestar_oppool_attestation_pool_size",
         help: "Current size of the AttestationPool = total attestations unique by data and slot",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -905,6 +905,18 @@ export function createLodestarMetrics(
             name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_total_consolidations_total",
             help: "Total number of consolidations before truncate",
           }),
+          emptyAttestationData: register.gauge({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_empty_attestation_data_total",
+            help: "Total number of attestation data with no group when producing packed attestation",
+          }),
+          invalidAttestationData: register.gauge({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_invalid_attestation_data_total",
+            help: "Total number of invalid attestation data when producing packed attestation",
+          }),
+          seenCommittees: register.gauge({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_seen_committees_total",
+            help: "Total number of committees that all members are seen when producing packed attestations",
+          }),
         },
       },
       attestationPoolSize: register.gauge({

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@lodestar/params";
 import {CachedBeaconStateAllForks, CachedBeaconStateElectra, newFilledArray} from "@lodestar/state-transition";
 import {CachedBeaconStateAltair} from "@lodestar/state-transition/src/types.js";
-import {Attestation, phase0, ssz} from "@lodestar/types";
+import {Attestation, electra, phase0, ssz} from "@lodestar/types";
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {
   AggregatedAttestationPool,
@@ -156,7 +156,7 @@ describe("AggregatedAttestationPool - Altair", () => {
   });
 });
 
-describe("AggregatedAttestationPool - Electra", () => {
+describe("AggregatedAttestationPool - get packed attestations - Electra", () => {
   let pool: AggregatedAttestationPool;
   const fork = ForkName.electra;
   const electraForkEpoch = 2020;
@@ -173,7 +173,9 @@ describe("AggregatedAttestationPool - Electra", () => {
 
   const committeeIndices = [0, 1, 2, 3];
   const attestation = ssz.electra.Attestation.defaultValue();
-  attestation.data.slot = currentSlot;
+  // it will always include attestations for stateSlot - 1 which is currentSlot
+  // so we want attestation slot to be less than that to test epochParticipation
+  attestation.data.slot = currentSlot - 1;
   attestation.data.index = 0; // Must be zero post-electra
   attestation.data.target.epoch = currentEpoch;
   attestation.signature = validSignature;
@@ -192,17 +194,11 @@ describe("AggregatedAttestationPool - Electra", () => {
   const originalState = generateCachedElectraState({slot: currentSlot + 1, validators}, electraForkEpoch);
   expect(originalState.epochCtx.getCommitteeCountPerSlot(currentEpoch)).toEqual(committeeIndices.length);
 
-  const committees = originalState.epochCtx.getBeaconCommittees(currentSlot, committeeIndices);
-
-  const epochParticipation = newFilledArray(vc, 0b000);
+  const committees = originalState.epochCtx.getBeaconCommittees(attestation.data.slot, committeeIndices);
   for (const committee of committees) {
     expect(committee.length).toEqual(committeeLength);
   }
 
-  (originalState as CachedBeaconStateElectra).previousEpochParticipation =
-    ssz.altair.EpochParticipation.toViewDU(epochParticipation);
-  (originalState as CachedBeaconStateElectra).currentEpochParticipation =
-    ssz.altair.EpochParticipation.toViewDU(epochParticipation);
   originalState.commit();
   let electraState: CachedBeaconStateAllForks;
 
@@ -218,53 +214,127 @@ describe("AggregatedAttestationPool - Electra", () => {
     vi.clearAllMocks();
   });
 
-  // notSeenByCommittees: item i is for committe i, each item is number[][] which is the indices of validators not seen by the committee
-  // expectedCommitteeBits is by returned attestations: expectedCommitteeBits[0] is for returned attestation 0, ...
-  // expectedAggregationBits is the aggregation bits of the returned attestations: expectedAggregationBits[0] is for returned attestation 0, ...
   const testCases: {
     name: string;
-    notSeenByCommittees: number[][][];
-    expectedCommitteeBits: number[][];
-    expectedAggregationBits: number[];
+    // item is is for committee i, which contains array of attester indices that's not seen (seen by default)
+    notSeenInStateByCommittee: number[][];
+    // item i is for committee i, each item is number[][] which is the indices of validators not seen by the committee
+    // each item i also decides how many attestations added to the pool for that committee
+    attParticipationByCommittee: number[][][];
+    // expected committeeBits of packed attestations, item 0 is for returned attestation 0, ...
+    packedCommitteeBits: number[][];
+    // expected aggregationBits of packed attestations: item 0 is for returned attestation 0, ...
+    packedAggregationBits: number[];
   }[] = [
     {
       name: "Full participation",
-      notSeenByCommittees: [[[]], [[]], [[]], [[]]],
-      expectedCommitteeBits: [[0, 1, 2, 3]],
-      expectedAggregationBits: [committeeLength * 4],
+      notSeenInStateByCommittee: [
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+      ],
+      // each committee has exactly 1 full attestations
+      attParticipationByCommittee: [[[]], [[]], [[]], [[]]],
+      // 1 full packed attestation
+      packedCommitteeBits: [[0, 1, 2, 3]],
+      packedAggregationBits: [committeeLength * 4],
+    },
+    {
+      name: "Full participation but all are seen in the state",
+      notSeenInStateByCommittee: [[], [], [], []],
+      // each committee has exactly 1 full attestations
+      attParticipationByCommittee: [[[]], [[]], [[]], [[]]],
+      // no packed attestation
+      packedCommitteeBits: [],
+      packedAggregationBits: [],
     },
     {
       name: "Committee 1 and 2 has 2 versions of aggregationBits",
-      // committee 1 has 2 attestations, one with not seen validator 0, one with not seen validator 1
-      // committee 2 has 2 attestations, one with not seen validator 1, one with not seen validator 2
-      // other committees have 1 attestation each, and all validators are seen
-      notSeenByCommittees: [[[]], [[0], [1]], [[1], [2]], [[]]],
-      // 2nd consolidation only has 2 committees: 1 and 2
-      expectedCommitteeBits: [
+      notSeenInStateByCommittee: [
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+      ],
+      // committee 1 has 2 attestations, one with no participation validator 0, one with no participation validator 1
+      // committee 2 has 2 attestations, one with no participation validator 1, one with no participation validator 2
+      // committee 0 and 3 has 1 attestation each, and all validators are seen
+      attParticipationByCommittee: [[[]], [[0], [1]], [[1], [2]], [[]]],
+      // 2nd packed attestation only has 2 committees: 1 and 2
+      packedCommitteeBits: [
         [0, 1, 2, 3],
         [1, 2],
       ],
-      expectedAggregationBits: [committeeLength * 4, committeeLength * 2],
+      packedAggregationBits: [committeeLength * 4, committeeLength * 2],
+    },
+    {
+      // same to above but no-participation validators are all seen in the state so only 1 attestation is returned
+      name: "Committee 1 and 2 has 2 versions of aggregationBits - only 1 attestation is included",
+      notSeenInStateByCommittee: [
+        [0, 1, 2, 3],
+        [2, 3],
+        [0, 1],
+        [0, 1, 2, 3],
+      ],
+      // committee 1 has 2 attestations, one with no participation validator 0, one with no participation validator 1
+      // committee 2 has 2 attestations, one with no participation validator 1, one with no participation validator 2
+      // committee 0 and 3 has 1 attestation each, and all validators are seen
+      attParticipationByCommittee: [[[]], [[0], [1]], [[1], [2]], [[]]],
+      // 2nd packed attestation only has 2 committees: 1 and 2
+      packedCommitteeBits: [[0, 1, 2, 3]],
+      packedAggregationBits: [committeeLength * 4],
     },
     {
       name: "Only committee 1 has 2 versions of aggregationBits",
-      // committee 1 has 2 attestations, one with not seen validator 0, one with not seen validator 1
+      notSeenInStateByCommittee: [
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+      ],
+      // committee 1 has 2 attestations, one with no participation validator 0, one with no participation validator 1
       // other committees have 1 attestation each, and all validators are seen
-      notSeenByCommittees: [[[]], [[0], [1]], [[]], [[]]],
-      // 2nd consolidation only has 1 committeee
-      expectedCommitteeBits: [[0, 1, 2, 3], [1]],
-      expectedAggregationBits: [committeeLength * 4, committeeLength],
+      attParticipationByCommittee: [[[]], [[0], [1]], [[]], [[]]],
+      // 2nd packed attestation only has 1 committeee
+      packedCommitteeBits: [[0, 1, 2, 3], [1]],
+      // 2nd packed attestation only has 1 committee
+      packedAggregationBits: [committeeLength * 4, committeeLength],
     },
   ];
 
-  for (const {name, notSeenByCommittees, expectedCommitteeBits, expectedAggregationBits} of testCases) {
+  for (const {
+    name,
+    notSeenInStateByCommittee,
+    attParticipationByCommittee,
+    packedCommitteeBits,
+    packedAggregationBits,
+  } of testCases) {
     it(name, () => {
+      // this is related to NotSeenValidatorsFn, all validators are seen by default
+      const epochParticipation = newFilledArray(vc, 0b111);
+      for (let i = 0; i < committeeIndices.length; i++) {
+        const committeeIndex = committeeIndices[i];
+        const notSeenValidators = notSeenInStateByCommittee[i];
+        const committee = committees[committeeIndex];
+        for (const notSeenValidator of notSeenValidators) {
+          const validatorIndex = committee[notSeenValidator];
+          epochParticipation[validatorIndex] = 0b000;
+        }
+      }
+
+      (electraState as CachedBeaconStateElectra).previousEpochParticipation =
+        ssz.altair.EpochParticipation.toViewDU(epochParticipation);
+      (electraState as CachedBeaconStateElectra).currentEpochParticipation =
+        ssz.altair.EpochParticipation.toViewDU(epochParticipation);
+      electraState.commit();
+
       for (let i = 0; i < committeeIndices.length; i++) {
         const committeeIndex = committeeIndices[i];
         const committeeBits = BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, committeeIndex);
         // same committee, each is by attestation
-        const notSeenValidatorsByAtt = notSeenByCommittees[i];
-        for (const notSeenValidators of notSeenValidatorsByAtt) {
+        const notSeenValidatorsByAttationIndex = attParticipationByCommittee[i];
+        for (const notSeenValidators of notSeenValidatorsByAttationIndex) {
           const aggregationBits = new BitArray(new Uint8Array(committeeLength / 8).fill(255), committeeLength);
           for (const index of notSeenValidators) {
             aggregationBits.set(index, false);
@@ -284,12 +354,12 @@ describe("AggregatedAttestationPool - Electra", () => {
 
       const blockAttestations = pool.getAttestationsForBlock(fork, forkchoiceStub, electraState);
       // make sure test data is correct
-      expect(expectedCommitteeBits.length).toBe(expectedAggregationBits.length);
-      expect(blockAttestations.length).toBe(expectedCommitteeBits.length);
+      expect(packedCommitteeBits.length).toBe(packedAggregationBits.length);
+      expect(blockAttestations.length).toBe(packedCommitteeBits.length);
       for (let attIndex = 0; attIndex < blockAttestations.length; attIndex++) {
         const returnedAttestation = blockAttestations[attIndex] as Attestation<ForkPostElectra>;
-        expect(returnedAttestation.committeeBits.getTrueBitIndexes()).toStrictEqual(expectedCommitteeBits[attIndex]);
-        expect(returnedAttestation.aggregationBits.bitLen).toStrictEqual(expectedAggregationBits[attIndex]);
+        expect(returnedAttestation.committeeBits.getTrueBitIndexes()).toStrictEqual(packedCommitteeBits[attIndex]);
+        expect(returnedAttestation.aggregationBits.bitLen).toStrictEqual(packedAggregationBits[attIndex]);
       }
     });
   }
@@ -377,7 +447,12 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
     id: string;
     notSeenAttestingBits: number[];
     effectiveBalanceIncrements: Uint16Array;
-    attestationsToAdd: {bits: number[]; newSeenEffectiveBalance: number; notSeenAttesters: number; returnedIndex: number}[];
+    attestationsToAdd: {
+      bits: number[];
+      newSeenEffectiveBalance: number;
+      notSeenAttesters: number;
+      returnedIndex: number;
+    }[];
   }[] = [
     // Note: attestationsToAdd MUST intersect in order to not be aggregated and distort the results
     {
@@ -441,15 +516,16 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
   const committee = Uint32Array.from(linspace(0, 7));
 
   for (const {id, notSeenAttestingBits, effectiveBalanceIncrements, attestationsToAdd} of testCases) {
-    // TODO: tests electra
+    // these are for electra attestations but it should work the same way to pre-electra
     it(id, () => {
       const attestationGroup = new MatchingDataAttestationGroup(config, committee, attestationData);
 
       const attestations = attestationsToAdd.map(
-        ({bits}): phase0.Attestation => ({
+        ({bits}): electra.Attestation => ({
           data: attestationData,
           aggregationBits: new BitArray(new Uint8Array(bits), 8),
           signature: validSignature,
+          committeeBits: BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, 0),
         })
       );
 
@@ -466,16 +542,13 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
         }
       }
       const attestationsForBlock = attestationGroup.getAttestationsForBlock(
-        ForkName.phase0,
+        ForkName.electra,
         effectiveBalanceIncrements,
         notSeenAttestingIndices,
         maxAttestations
       );
 
-      for (const [
-        i,
-        {newSeenEffectiveBalance, returnedIndex},
-      ] of attestationsToAdd.entries()) {
+      for (const [i, {newSeenEffectiveBalance, returnedIndex}] of attestationsToAdd.entries()) {
         const attestationIndex = attestationsForBlock.findIndex((a) => a.attestation === attestations[i]);
         expect(attestationIndex).toBe(returnedIndex);
         const attestation = attestationsForBlock[attestationIndex];

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -300,6 +300,10 @@ describe("AggregatedAttestationPool - Electra", () => {
 });
 
 describe("MatchingDataAttestationGroup.add()", () => {
+  const config = createChainForkConfig({
+    ...defaultChainConfig,
+  });
+
   const testCases: {id: string; attestationsToAdd: {bits: number[]; res: InsertOutcome; isKept: boolean}[]}[] = [
     {
       id: "2 intersecting",
@@ -338,7 +342,7 @@ describe("MatchingDataAttestationGroup.add()", () => {
 
   for (const {id, attestationsToAdd} of testCases) {
     it(id, () => {
-      const attestationGroup = new MatchingDataAttestationGroup(committee, attestationData);
+      const attestationGroup = new MatchingDataAttestationGroup(config, committee, attestationData);
 
       const attestations = attestationsToAdd.map(
         ({bits}): phase0.Attestation => ({
@@ -368,6 +372,10 @@ describe("MatchingDataAttestationGroup.add()", () => {
 });
 
 describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
+  const config = createChainForkConfig({
+    ...defaultChainConfig,
+  });
+
   const maxAttestations = 2;
   const testCases: {
     id: string;
@@ -425,7 +433,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
   for (const {id, notSeenAttestingBits, effectiveBalanceIncrements, attestationsToAdd} of testCases) {
     // TODO: tests electra
     it(id, () => {
-      const attestationGroup = new MatchingDataAttestationGroup(committee, attestationData);
+      const attestationGroup = new MatchingDataAttestationGroup(config, committee, attestationData);
 
       const attestations = attestationsToAdd.map(
         ({bits}): phase0.Attestation => ({

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -222,63 +222,81 @@ describe("AggregatedAttestationPool - Electra", () => {
     vi.clearAllMocks();
   });
 
-  it("Multiple attestations with same attestation data different committee", () => {
-    // Attestation from committee 0
-    const committeeBits0 = BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, 0);
+  // notSeenByCommittees: item i is for committe i, each item is number[][] which is the indices of validators not seen by the committee
+  // expectedCommitteeBits is by returned attestations: expectedCommitteeBits[0] is for returned attestation 0, ...
+  // expectedAggregationBits is the aggregation bits of the returned attestations: expectedAggregationBits[0] is for returned attestation 0, ...
+  const testCases: {
+    name: string;
+    notSeenByCommittees: number[][][];
+    expectedCommitteeBits: number[][];
+    expectedAggregationBits: number[];
+  }[] = [
+    {
+      name: "Full participation",
+      notSeenByCommittees: [[[]], [[]], [[]], [[]]],
+      expectedCommitteeBits: [[0, 1, 2, 3]],
+      expectedAggregationBits: [committeeLength * 4],
+    },
+    {
+      name: "Committee 1 and 2 has 2 versions of aggregationBits",
+      // committee 1 has 2 attestations, one with not seen validator 0, one with not seen validator 1
+      // committee 2 has 2 attestations, one with not seen validator 1, one with not seen validator 2
+      // other committees have 1 attestation each, and all validators are seen
+      notSeenByCommittees: [[[]], [[0], [1]], [[1], [2]], [[]]],
+      // 2nd consolidation only has 2 committees: 1 and 2
+      expectedCommitteeBits: [
+        [0, 1, 2, 3],
+        [1, 2],
+      ],
+      expectedAggregationBits: [committeeLength * 4, committeeLength * 2],
+    },
+    {
+      name: "Only committee 1 has 2 versions of aggregationBits",
+      // committee 1 has 2 attestations, one with not seen validator 0, one with not seen validator 1
+      // other committees have 1 attestation each, and all validators are seen
+      notSeenByCommittees: [[[]], [[0], [1]], [[]], [[]]],
+      // 2nd consolidation only has 1 committeee
+      expectedCommitteeBits: [[0, 1, 2, 3], [1]],
+      expectedAggregationBits: [committeeLength * 4, committeeLength],
+    },
+  ];
 
-    const attestation0: Attestation<ForkPostElectra> = {
-      ...attestation,
-      aggregationBits: new BitArray(new Uint8Array(committeeLength / 8).fill(1), committeeLength),
-      committeeBits: committeeBits0,
-    };
+  for (const {name, notSeenByCommittees, expectedCommitteeBits, expectedAggregationBits} of testCases) {
+    it(name, () => {
+      for (let i = 0; i < committeeIndices.length; i++) {
+        const committeeIndex = committeeIndices[i];
+        const committeeBits = BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, committeeIndex);
+        // same committee, each is by attestation
+        const notSeenValidatorsByAtt = notSeenByCommittees[i];
+        for (const notSeenValidators of notSeenValidatorsByAtt) {
+          const aggregationBits = new BitArray(new Uint8Array(committeeLength / 8).fill(255), committeeLength);
+          for (const index of notSeenValidators) {
+            aggregationBits.set(index, false);
+          }
+          const attestationi: Attestation<ForkPostElectra> = {
+            ...attestation,
+            aggregationBits,
+            committeeBits,
+          };
 
-    // Attestation from committee 1
-    const committeeBits1 = BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, 1);
+          pool.add(attestationi, attDataRootHex, aggregationBits.getTrueBitIndexes().length, committees[i]);
+        }
+      }
 
-    const attestation1: Attestation<ForkPostElectra> = {
-      ...attestation,
-      aggregationBits: new BitArray(new Uint8Array(committeeLength / 8).fill(1), committeeLength),
-      committeeBits: committeeBits1,
-    };
-    // Attestation from committee 2
-    const committeeBits2 = BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, 2);
+      forkchoiceStub.getBlockHex.mockReturnValue(generateProtoBlock());
+      forkchoiceStub.getDependentRoot.mockReturnValue(ZERO_HASH_HEX);
 
-    const attestation2: Attestation<ForkPostElectra> = {
-      ...attestation,
-      aggregationBits: new BitArray(new Uint8Array(committeeLength / 8).fill(1), committeeLength),
-      committeeBits: committeeBits2,
-    };
-
-    // Attestation from committee 3
-    const committeeBits3 = BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, 3);
-
-    const attestation3: Attestation<ForkPostElectra> = {
-      ...attestation,
-      aggregationBits: new BitArray(new Uint8Array(committeeLength / 8).fill(1), committeeLength),
-      committeeBits: committeeBits3,
-    };
-
-    pool.add(attestation0, attDataRootHex, attestation0.aggregationBits.getTrueBitIndexes().length, committees[0]);
-
-    pool.add(attestation1, attDataRootHex, attestation1.aggregationBits.getTrueBitIndexes().length, committees[1]);
-
-    pool.add(attestation2, attDataRootHex, attestation2.aggregationBits.getTrueBitIndexes().length, committees[2]);
-
-    pool.add(attestation3, attDataRootHex, attestation3.aggregationBits.getTrueBitIndexes().length, committees[3]);
-
-    forkchoiceStub.getBlockHex.mockReturnValue(generateProtoBlock());
-    forkchoiceStub.getDependentRoot.mockReturnValue(ZERO_HASH_HEX);
-
-    const blockAttestations = pool.getAttestationsForBlock(fork, forkchoiceStub, electraState);
-
-    expect(blockAttestations.length).toBe(1); // Expect attestations from committee 0, 1, 2 and 3 to be aggregated into one
-    expect((blockAttestations[0] as Attestation<ForkPostElectra>).committeeBits.getTrueBitIndexes()).toStrictEqual(
-      committeeIndices
-    );
-    expect((blockAttestations[0] as Attestation<ForkPostElectra>).aggregationBits.bitLen).toStrictEqual(
-      committeeLength * 4
-    );
-  });
+      const blockAttestations = pool.getAttestationsForBlock(fork, forkchoiceStub, electraState);
+      // make sure test data is correct
+      expect(expectedCommitteeBits.length).toBe(expectedAggregationBits.length);
+      expect(blockAttestations.length).toBe(expectedCommitteeBits.length);
+      for (let attIndex = 0; attIndex < blockAttestations.length; attIndex++) {
+        const returnedAttestation = blockAttestations[attIndex] as Attestation<ForkPostElectra>;
+        expect(returnedAttestation.committeeBits.getTrueBitIndexes()).toStrictEqual(expectedCommitteeBits[attIndex]);
+        expect(returnedAttestation.aggregationBits.bitLen).toStrictEqual(expectedAggregationBits[attIndex]);
+      }
+    });
+  }
 });
 
 describe("MatchingDataAttestationGroup.add()", () => {

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -48,7 +48,8 @@ describe("AggregatedAttestationPool - Altair", () => {
 
   const committeeIndex = 0;
   const attestation = ssz.phase0.Attestation.defaultValue();
-  attestation.data.slot = currentSlot;
+  // state slot is (currentSlot + 1) so if set attestation slot to currentSlot, it will be included in the block
+  attestation.data.slot = currentSlot - 1;
   attestation.data.index = committeeIndex;
   attestation.data.target.epoch = currentEpoch;
   const attDataRootHex = toHexString(ssz.phase0.AttestationData.hashTreeRoot(attestation.data));
@@ -64,7 +65,7 @@ describe("AggregatedAttestationPool - Altair", () => {
   const committeeLength = 4;
   const validators = generateValidators(vc, validatorOpts);
   const originalState = generateCachedAltairState({slot: currentSlot + 1, validators}, altairForkEpoch);
-  const committee = originalState.epochCtx.getBeaconCommittee(currentSlot, committeeIndex);
+  const committee = originalState.epochCtx.getBeaconCommittee(currentSlot - 1, committeeIndex);
   expect(committee.length).toEqual(committeeLength);
   // 0 and 1 in committee are fully participated
   const epochParticipation = newFilledArray(vc, 0b111);
@@ -98,15 +99,10 @@ describe("AggregatedAttestationPool - Altair", () => {
     // previousEpochParticipation and currentEpochParticipation is created inside generateCachedState
     // 0 and 1 are fully participated
     const notSeenValidatorFn = getNotSeenValidatorsFn(altairState);
-    const participation = notSeenValidatorFn(currentEpoch, currentSlot, committeeIndex);
     // seen attesting indices are 0, 1 => not seen are 2, 3
-    expect(participation).toEqual(
-      // {
-      // validatorIndices: [null, null, committee[2], committee[3]],
-      // attestingIndices: new Set([2, 3]),
-      // }
-      new Set([2, 3])
-    );
+    expect(notSeenValidatorFn(currentEpoch, currentSlot - 1, committeeIndex)).toEqual(new Set([2, 3]));
+    // attestations in current slot are always included (since altairState.slot = currentSlot + 1)
+    expect(notSeenValidatorFn(currentEpoch, currentSlot, committeeIndex)).toEqual(new Set([0, 1, 2, 3]));
   });
 
   // previousEpochParticipation and currentEpochParticipation is created inside generateCachedState
@@ -562,7 +558,7 @@ describe("aggregateConsolidation", () => {
         };
         consolidation.byCommittee.set(committeeIndex, {
           attestation: aggAttestation,
-          notSeenAttesterCount: aggregationBitsArr[i].filter((item) => item).length,
+          notSeenEffectiveBalance: aggregationBitsArr[i].filter((item) => item).length * 32,
         });
       }
 

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -122,7 +122,7 @@ describe("AggregatedAttestationPool - Altair", () => {
         aggregationBits.getTrueBitIndexes().length,
         committee
       );
-      forkchoiceStub.getBlockHex.mockReturnValue(generateProtoBlock());
+      forkchoiceStub.getBlockHex.mockReturnValue(generateProtoBlock({slot: attestation.data.slot}));
       forkchoiceStub.getDependentRoot.mockReturnValue(ZERO_HASH_HEX);
       if (isReturned) {
         expect(pool.getAttestationsForBlock(fork, forkchoiceStub, altairState).length).toBeGreaterThan(0);
@@ -148,7 +148,7 @@ describe("AggregatedAttestationPool - Altair", () => {
     // all attesters are not seen
     const attestingIndices = [2, 3];
     pool.add(attestation, attDataRootHex, attestingIndices.length, committee);
-    forkchoiceStub.getBlockHex.mockReturnValue(generateProtoBlock());
+    forkchoiceStub.getBlockHex.mockReturnValue(generateProtoBlock({slot: attestation.data.slot}));
     forkchoiceStub.getDependentRoot.mockReturnValue("0xWeird");
     expect(pool.getAttestationsForBlock(fork, forkchoiceStub, altairState)).toEqual([]);
     // "forkchoice should be called to check pivot block"
@@ -472,7 +472,10 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
         maxAttestations
       );
 
-      for (const [i, {newSeenEffectiveBalance: notSeenEffectiveBalance, returnedIndex}] of attestationsToAdd.entries()) {
+      for (const [
+        i,
+        {newSeenEffectiveBalance: notSeenEffectiveBalance, returnedIndex},
+      ] of attestationsToAdd.entries()) {
         const attestationIndex = attestationsForBlock.findIndex((a) => a.attestation === attestations[i]);
         expect(attestationIndex).toBe(returnedIndex);
         const attestation = attestationsForBlock[attestationIndex];

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -391,23 +391,36 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       ],
     },
     {
-      id: "Some have attested - same effective balance",
+      id: "Same effective balance - 2nd attestation is not valuable",
       // same to seenAttestingBits: [0b11110001]
       notSeenAttestingBits: [0b00001110],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
         {bits: [0b11111110], notSeenEffectiveBalance: 3 * 32, returnedIndex: 0},
-        {bits: [0b00000011], notSeenEffectiveBalance: 1 * 32, returnedIndex: 1},
+        // not valueable because seen attestations are all included in attestation 0
+        {bits: [0b00000011], notSeenEffectiveBalance: 1 * 32, returnedIndex: -1},
       ],
     },
     {
-      id: "Some have attested - prioritize bigger effective balance",
+      id: "Same effective balance - include both",
+      // same to seenAttestingBits: [0b11110001]
+      notSeenAttestingBits: [0b00001110],
+      effectiveBalanceIncrements: new Uint16Array(8).fill(32),
+      attestationsToAdd: [
+        {bits: [0b11111010], notSeenEffectiveBalance: 2 * 32, returnedIndex: 0},
+        {bits: [0b10000101], notSeenEffectiveBalance: 1 * 32, returnedIndex: 1},
+      ],
+    },
+    {
+      id: "Prioritize bigger effective balance",
       notSeenAttestingBits: [0b11111111],
       effectiveBalanceIncrements: new Uint16Array([32, 2048, 32, 32, 32, 32, 32, 32]),
       attestationsToAdd: [
-        {bits: [0b11111001], notSeenEffectiveBalance: 6 * 32, returnedIndex: 1},
+        // notSeenEffectiveBalance is not 6 * 32 considering the 1st included attestation
+        {bits: [0b11111001], notSeenEffectiveBalance: 4 * 32, returnedIndex: 1},
         // although this has less not seen attesters, it has bigger effective balance so returned index is 0
         {bits: [0b10000011], notSeenEffectiveBalance: 2048 + 2 * 32, returnedIndex: 0},
+        // maxAttestation is only 2
         {bits: [0b00001101], notSeenEffectiveBalance: 3 * 32, returnedIndex: -1},
       ],
     },
@@ -417,8 +430,9 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b11111111],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], notSeenEffectiveBalance: 7 * 32, returnedIndex: 0},
-        {bits: [0b00000011], notSeenEffectiveBalance: 2 * 32, returnedIndex: 1},
+        {bits: [0b00111110], notSeenEffectiveBalance: 5 * 32, returnedIndex: 0},
+        // notSeenEffectiveBalance is not 3 * 32 considering the 1st included attestation already include attester 1
+        {bits: [0b01000011], notSeenEffectiveBalance: 2 * 32, returnedIndex: 1},
       ],
     },
   ];
@@ -540,7 +554,9 @@ describe("aggregateConsolidation", () => {
       const consolidation: AttestationsConsolidation = {
         byCommittee: new Map(),
         attData: attData,
-        totalNotSeenEffectiveBalance: 0,
+        totalEffectiveBalance: 0,
+        committeeSize: 32,
+        notSeenAttesters: 0,
       };
       // to simplify, instead of signing the signingRoot, just sign the attData root
       const sigArr = skArr.map((sk) => sk.sign(ssz.phase0.AttestationData.hashTreeRoot(attData)));
@@ -559,6 +575,7 @@ describe("aggregateConsolidation", () => {
         consolidation.byCommittee.set(committeeIndex, {
           attestation: aggAttestation,
           notSeenEffectiveBalance: aggregationBitsArr[i].filter((item) => item).length * 32,
+          notSeenAttendingIndices: new Set(),
         });
       }
 

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -368,37 +368,53 @@ describe("MatchingDataAttestationGroup.add()", () => {
 });
 
 describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
+  const maxAttestations = 2;
   const testCases: {
     id: string;
     notSeenAttestingBits: number[];
-    attestationsToAdd: {bits: number[]; notSeenAttesterCount: number}[];
+    effectiveBalanceIncrements: Uint16Array;
+    attestationsToAdd: {bits: number[]; notSeenEffectiveBalance: number; returnedIndex: number}[];
   }[] = [
     // Note: attestationsToAdd MUST intersect in order to not be aggregated and distort the results
     {
       id: "All have attested",
       // same to seenAttestingBits: [0b11111111],
       notSeenAttestingBits: [0b00000000],
+      effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], notSeenAttesterCount: 0},
-        {bits: [0b00000011], notSeenAttesterCount: 0},
+        {bits: [0b11111110], notSeenEffectiveBalance: 0, returnedIndex: -1},
+        {bits: [0b00000011], notSeenEffectiveBalance: 0, returnedIndex: -1},
       ],
     },
     {
-      id: "Some have attested",
+      id: "Some have attested - same effective balance",
       // same to seenAttestingBits: [0b11110001]
       notSeenAttestingBits: [0b00001110],
+      effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], notSeenAttesterCount: 3},
-        {bits: [0b00000011], notSeenAttesterCount: 1},
+        {bits: [0b11111110], notSeenEffectiveBalance: 3 * 32, returnedIndex: 0},
+        {bits: [0b00000011], notSeenEffectiveBalance: 1 * 32, returnedIndex: 1},
+      ],
+    },
+    {
+      id: "Some have attested - prioritize bigger effective balance",
+      notSeenAttestingBits: [0b11111111],
+      effectiveBalanceIncrements: new Uint16Array([32, 2048, 32, 32, 32, 32, 32, 32]),
+      attestationsToAdd: [
+        {bits: [0b11111001], notSeenEffectiveBalance: 6 * 32, returnedIndex: 1},
+        // although this has less not seen attesters, it has bigger effective balance so returned index is 0
+        {bits: [0b10000011], notSeenEffectiveBalance: 2048 + 2 * 32, returnedIndex: 0},
+        {bits: [0b00001101], notSeenEffectiveBalance: 3 * 32, returnedIndex: -1},
       ],
     },
     {
       id: "Non have attested",
       // same to seenAttestingBits: [0b00000000],
       notSeenAttestingBits: [0b11111111],
+      effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], notSeenAttesterCount: 7},
-        {bits: [0b00000011], notSeenAttesterCount: 2},
+        {bits: [0b11111110], notSeenEffectiveBalance: 7 * 32, returnedIndex: 0},
+        {bits: [0b00000011], notSeenEffectiveBalance: 2 * 32, returnedIndex: 1},
       ],
     },
   ];
@@ -406,7 +422,8 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
   const attestationData = ssz.phase0.AttestationData.defaultValue();
   const committee = Uint32Array.from(linspace(0, 7));
 
-  for (const {id, notSeenAttestingBits, attestationsToAdd} of testCases) {
+  for (const {id, notSeenAttestingBits, effectiveBalanceIncrements, attestationsToAdd} of testCases) {
+    // TODO: tests electra
     it(id, () => {
       const attestationGroup = new MatchingDataAttestationGroup(committee, attestationData);
 
@@ -423,7 +440,6 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       }
 
       const notSeenAggBits = new BitArray(new Uint8Array(notSeenAttestingBits), 8);
-      // const notSeenValidatorIndices: (ValidatorIndex | null)[] = [];
       const notSeenAttestingIndices = new Set<number>();
       for (let i = 0; i < committee.length; i++) {
         // notSeenValidatorIndices.push(notSeenAggBits.get(i) ? committee[i] : null);
@@ -433,14 +449,19 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       }
       const attestationsForBlock = attestationGroup.getAttestationsForBlock(
         ForkName.phase0,
-        // notSeenValidatorIndices,
-        notSeenAttestingIndices
+        effectiveBalanceIncrements,
+        notSeenAttestingIndices,
+        maxAttestations
       );
 
-      for (const [i, {notSeenAttesterCount}] of attestationsToAdd.entries()) {
-        const attestation = attestationsForBlock.find((a) => a.attestation === attestations[i]);
+      for (const [i, {notSeenEffectiveBalance, returnedIndex}] of attestationsToAdd.entries()) {
+        const attestationIndex = attestationsForBlock.findIndex((a) => a.attestation === attestations[i]);
+        expect(attestationIndex).toBe(returnedIndex);
+        const attestation = attestationsForBlock[attestationIndex];
         // If notSeenAttesterCount === 0 the attestation is not returned
-        expect(attestation ? attestation.notSeenAttesterCount : 0).toBe(notSeenAttesterCount);
+        if (returnedIndex !== -1) {
+          expect(attestation ? attestation.notSeenEffectiveBalance : 0).toBe(notSeenEffectiveBalance);
+        }
       }
     });
   }
@@ -515,7 +536,7 @@ describe("aggregateConsolidation", () => {
       const consolidation: AttestationsConsolidation = {
         byCommittee: new Map(),
         attData: attData,
-        totalNotSeenCount: 0,
+        totalNotSeenEffectiveBalance: 0,
       };
       // to simplify, instead of signing the signingRoot, just sign the attData root
       const sigArr = skArr.map((sk) => sk.sign(ssz.phase0.AttestationData.hashTreeRoot(attData)));

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -377,7 +377,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
     id: string;
     notSeenAttestingBits: number[];
     effectiveBalanceIncrements: Uint16Array;
-    attestationsToAdd: {bits: number[]; newSeenEffectiveBalance: number; returnedIndex: number}[];
+    attestationsToAdd: {bits: number[]; newSeenEffectiveBalance: number; notSeenAttesters: number; returnedIndex: number}[];
   }[] = [
     // Note: attestationsToAdd MUST intersect in order to not be aggregated and distort the results
     {
@@ -386,8 +386,8 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b00000000],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], newSeenEffectiveBalance: 0, returnedIndex: -1},
-        {bits: [0b00000011], newSeenEffectiveBalance: 0, returnedIndex: -1},
+        {bits: [0b11111110], newSeenEffectiveBalance: 0, notSeenAttesters: 0, returnedIndex: -1},
+        {bits: [0b00000011], newSeenEffectiveBalance: 0, notSeenAttesters: 0, returnedIndex: -1},
       ],
     },
     {
@@ -396,9 +396,9 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b00001110],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], newSeenEffectiveBalance: 3 * 32, returnedIndex: 0},
+        {bits: [0b11111110], newSeenEffectiveBalance: 3 * 32, notSeenAttesters: 3, returnedIndex: 0},
         // not valueable because seen attestations are all included in attestation 0
-        {bits: [0b00000011], newSeenEffectiveBalance: 1 * 32, returnedIndex: -1},
+        {bits: [0b00000011], newSeenEffectiveBalance: 0, notSeenAttesters: 0, returnedIndex: -1},
       ],
     },
     {
@@ -407,8 +407,8 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b00001110],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111010], newSeenEffectiveBalance: 2 * 32, returnedIndex: 0},
-        {bits: [0b10000101], newSeenEffectiveBalance: 1 * 32, returnedIndex: 1},
+        {bits: [0b11111010], newSeenEffectiveBalance: 2 * 32, notSeenAttesters: 2, returnedIndex: 0},
+        {bits: [0b10000101], newSeenEffectiveBalance: 1 * 32, notSeenAttesters: 1, returnedIndex: 1},
       ],
     },
     {
@@ -416,12 +416,12 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b11111111],
       effectiveBalanceIncrements: new Uint16Array([32, 2048, 32, 32, 32, 32, 32, 32]),
       attestationsToAdd: [
-        // notSeenEffectiveBalance is not 6 * 32 considering the 1st included attestation
-        {bits: [0b11111001], newSeenEffectiveBalance: 4 * 32, returnedIndex: 1},
+        // newSeenEffectiveBalance is not 6 * 32 considering the 1st included attestation
+        {bits: [0b11111001], newSeenEffectiveBalance: 4 * 32, notSeenAttesters: 4, returnedIndex: 1},
         // although this has less not seen attesters, it has bigger effective balance so returned index is 0
-        {bits: [0b10000011], newSeenEffectiveBalance: 2048 + 2 * 32, returnedIndex: 0},
+        {bits: [0b10000011], newSeenEffectiveBalance: 2048 + 2 * 32, notSeenAttesters: 3, returnedIndex: 0},
         // maxAttestation is only 2
-        {bits: [0b00001101], newSeenEffectiveBalance: 3 * 32, returnedIndex: -1},
+        {bits: [0b00001101], newSeenEffectiveBalance: 0, notSeenAttesters: 0, returnedIndex: -1},
       ],
     },
     {
@@ -430,9 +430,9 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b11111111],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b00111110], newSeenEffectiveBalance: 5 * 32, returnedIndex: 0},
-        // notSeenEffectiveBalance is not 3 * 32 considering the 1st included attestation already include attester 1
-        {bits: [0b01000011], newSeenEffectiveBalance: 2 * 32, returnedIndex: 1},
+        {bits: [0b00111110], newSeenEffectiveBalance: 5 * 32, notSeenAttesters: 5, returnedIndex: 0},
+        // newSeenEffectiveBalance is not 3 * 32 considering the 1st included attestation already include attester 1
+        {bits: [0b01000011], newSeenEffectiveBalance: 2 * 32, notSeenAttesters: 2, returnedIndex: 1},
       ],
     },
   ];
@@ -474,14 +474,14 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
 
       for (const [
         i,
-        {newSeenEffectiveBalance: notSeenEffectiveBalance, returnedIndex},
+        {newSeenEffectiveBalance, returnedIndex},
       ] of attestationsToAdd.entries()) {
         const attestationIndex = attestationsForBlock.findIndex((a) => a.attestation === attestations[i]);
         expect(attestationIndex).toBe(returnedIndex);
         const attestation = attestationsForBlock[attestationIndex];
         // If notSeenAttesterCount === 0 the attestation is not returned
         if (returnedIndex !== -1) {
-          expect(attestation ? attestation.newSeenEffectiveBalance : 0).toBe(notSeenEffectiveBalance);
+          expect(attestation ? attestation.newSeenEffectiveBalance : 0).toBe(newSeenEffectiveBalance);
         }
       }
     });

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -377,7 +377,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
     id: string;
     notSeenAttestingBits: number[];
     effectiveBalanceIncrements: Uint16Array;
-    attestationsToAdd: {bits: number[]; notSeenEffectiveBalance: number; returnedIndex: number}[];
+    attestationsToAdd: {bits: number[]; newSeenEffectiveBalance: number; returnedIndex: number}[];
   }[] = [
     // Note: attestationsToAdd MUST intersect in order to not be aggregated and distort the results
     {
@@ -386,8 +386,8 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b00000000],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], notSeenEffectiveBalance: 0, returnedIndex: -1},
-        {bits: [0b00000011], notSeenEffectiveBalance: 0, returnedIndex: -1},
+        {bits: [0b11111110], newSeenEffectiveBalance: 0, returnedIndex: -1},
+        {bits: [0b00000011], newSeenEffectiveBalance: 0, returnedIndex: -1},
       ],
     },
     {
@@ -396,9 +396,9 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b00001110],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], notSeenEffectiveBalance: 3 * 32, returnedIndex: 0},
+        {bits: [0b11111110], newSeenEffectiveBalance: 3 * 32, returnedIndex: 0},
         // not valueable because seen attestations are all included in attestation 0
-        {bits: [0b00000011], notSeenEffectiveBalance: 1 * 32, returnedIndex: -1},
+        {bits: [0b00000011], newSeenEffectiveBalance: 1 * 32, returnedIndex: -1},
       ],
     },
     {
@@ -407,8 +407,8 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b00001110],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111010], notSeenEffectiveBalance: 2 * 32, returnedIndex: 0},
-        {bits: [0b10000101], notSeenEffectiveBalance: 1 * 32, returnedIndex: 1},
+        {bits: [0b11111010], newSeenEffectiveBalance: 2 * 32, returnedIndex: 0},
+        {bits: [0b10000101], newSeenEffectiveBalance: 1 * 32, returnedIndex: 1},
       ],
     },
     {
@@ -417,11 +417,11 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       effectiveBalanceIncrements: new Uint16Array([32, 2048, 32, 32, 32, 32, 32, 32]),
       attestationsToAdd: [
         // notSeenEffectiveBalance is not 6 * 32 considering the 1st included attestation
-        {bits: [0b11111001], notSeenEffectiveBalance: 4 * 32, returnedIndex: 1},
+        {bits: [0b11111001], newSeenEffectiveBalance: 4 * 32, returnedIndex: 1},
         // although this has less not seen attesters, it has bigger effective balance so returned index is 0
-        {bits: [0b10000011], notSeenEffectiveBalance: 2048 + 2 * 32, returnedIndex: 0},
+        {bits: [0b10000011], newSeenEffectiveBalance: 2048 + 2 * 32, returnedIndex: 0},
         // maxAttestation is only 2
-        {bits: [0b00001101], notSeenEffectiveBalance: 3 * 32, returnedIndex: -1},
+        {bits: [0b00001101], newSeenEffectiveBalance: 3 * 32, returnedIndex: -1},
       ],
     },
     {
@@ -430,9 +430,9 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b11111111],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b00111110], notSeenEffectiveBalance: 5 * 32, returnedIndex: 0},
+        {bits: [0b00111110], newSeenEffectiveBalance: 5 * 32, returnedIndex: 0},
         // notSeenEffectiveBalance is not 3 * 32 considering the 1st included attestation already include attester 1
-        {bits: [0b01000011], notSeenEffectiveBalance: 2 * 32, returnedIndex: 1},
+        {bits: [0b01000011], newSeenEffectiveBalance: 2 * 32, returnedIndex: 1},
       ],
     },
   ];
@@ -472,13 +472,13 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
         maxAttestations
       );
 
-      for (const [i, {notSeenEffectiveBalance, returnedIndex}] of attestationsToAdd.entries()) {
+      for (const [i, {newSeenEffectiveBalance: notSeenEffectiveBalance, returnedIndex}] of attestationsToAdd.entries()) {
         const attestationIndex = attestationsForBlock.findIndex((a) => a.attestation === attestations[i]);
         expect(attestationIndex).toBe(returnedIndex);
         const attestation = attestationsForBlock[attestationIndex];
         // If notSeenAttesterCount === 0 the attestation is not returned
         if (returnedIndex !== -1) {
-          expect(attestation ? attestation.notSeenEffectiveBalance : 0).toBe(notSeenEffectiveBalance);
+          expect(attestation ? attestation.newSeenEffectiveBalance : 0).toBe(notSeenEffectiveBalance);
         }
       }
     });
@@ -554,8 +554,9 @@ describe("aggregateConsolidation", () => {
       const consolidation: AttestationsConsolidation = {
         byCommittee: new Map(),
         attData: attData,
-        totalEffectiveBalance: 0,
+        totalNewSeenEffectiveBalance: 0,
         committeeSize: 32,
+        newSeenAttesters: 0,
         notSeenAttesters: 0,
       };
       // to simplify, instead of signing the signingRoot, just sign the attData root
@@ -574,8 +575,9 @@ describe("aggregateConsolidation", () => {
         };
         consolidation.byCommittee.set(committeeIndex, {
           attestation: aggAttestation,
-          notSeenEffectiveBalance: aggregationBitsArr[i].filter((item) => item).length * 32,
+          newSeenEffectiveBalance: aggregationBitsArr[i].filter((item) => item).length * 32,
           notSeenAttendingIndices: new Set(),
+          newSeenAttesters: 0,
         });
       }
 


### PR DESCRIPTION
**Motivation**

- right now we sort packed attestations by attester count which is not correct for electra
- the not seen attester count is not correct, it should be reevaluated after the previous attestation is included. This is to prevent useless attestations
- no metrics when producing packed attestations

**Description**

- track packed attestations by not seen effective balance
- reevaluate every attestation after an attestation is included, see `getMostValuableAttestation()`. This means there is no useless attestations included
- add a lot of metrics:
  - committee bits for each packed attestation
  - total committee members of each packed attestation
  - non-participation of each packed attestation
  - distance from block slot to attestation slot for each packed attestation
  - total effective balance for each packed attestations
  - scanned slots and termination reason
  - total slots in pool at the time of producing block
  - total consolidations

Closes #7544

**TODOs**
- [ ] more unit tests for electra
- [ ] add benchmark
- [ ] monitor on hoodi
