### PR TITLE
feat: track new seen attesters per block

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
@@ -123,13 +123,17 @@ if (metricsRegister) {
       name: "lodestar_historical_state_stfn_post_state_validators_nodes_populated_miss_total",
       help: "Total count state.validators nodesPopulated is false on stfn for post state",
     }),
-    newSeenAttesters: metricsRegister.gauge({
-      name: "lodestar_historical_state_stfn_new_seen_attesters_count",
+    newSeenAttestersPerBlock: metricsRegister.gauge({
+      name: "lodestar_historical_state_stfn_new_seen_attesters_per_block_total",
       help: "Count of new seen attesters in epoch transition",
     }),
-    newSeenAttestersEffectiveBalance: metricsRegister.gauge({
-      name: "lodestar_historical_state_stfn_new_seen_attesters_effective_balance_total",
+    newSeenAttestersEffectiveBalancePerBlock: metricsRegister.gauge({
+      name: "lodestar_historical_state_stfn_new_seen_attesters_effective_balance_per_block_total",
       help: "Total effective balance increment of new seen attesters per block",
+    }),
+    attestationsPerBlock: metricsRegister.gauge({
+      name: "lodestar_historical_state_stfn_attestations_per_block_total",
+      help: "Count of attestations per block",
     }),
     registerValidatorStatuses: () => {},
 

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
@@ -123,6 +123,14 @@ if (metricsRegister) {
       name: "lodestar_historical_state_stfn_post_state_validators_nodes_populated_miss_total",
       help: "Total count state.validators nodesPopulated is false on stfn for post state",
     }),
+    newSeenAttesters: metricsRegister.gauge({
+      name: "lodestar_historical_state_stfn_new_seen_attesters_count",
+      help: "Count of new seen attesters in epoch transition",
+    }),
+    newSeenAttestersEffectiveBalance: metricsRegister.gauge({
+      name: "lodestar_historical_state_stfn_new_seen_attesters_effective_balance_total",
+      help: "Total effective balance increment of new seen attesters per block",
+    }),
     registerValidatorStatuses: () => {},
 
     // historical state regen metrics

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -387,13 +387,17 @@ export function createLodestarMetrics(
       name: "lodestar_stfn_post_state_validators_nodes_populated_miss_total",
       help: "Total count state.validators nodesPopulated is false on stfn for post state",
     }),
-    newSeenAttesters: register.gauge({
+    newSeenAttestersPerBlock: register.gauge({
       name: "lodestar_stfn_new_seen_attesters_per_block_total",
       help: "Total count of new seen attesters per block",
     }),
-    newSeenAttestersEffectiveBalance: register.gauge({
-      name: "lodestar_stfn_new_seen_attesters_effective_balance_total",
+    newSeenAttestersEffectiveBalancePerBlock: register.gauge({
+      name: "lodestar_stfn_new_seen_attesters_effective_balance_per_block_total",
       help: "Total effective balance increment of new seen attesters per block",
+    }),
+    attestationsPerBlock: register.gauge({
+      name: "lodestar_stfn_attestations_per_block_total",
+      help: "Total count of attestations per block",
     }),
 
     // BLS verifier thread pool and queue

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -387,6 +387,14 @@ export function createLodestarMetrics(
       name: "lodestar_stfn_post_state_validators_nodes_populated_miss_total",
       help: "Total count state.validators nodesPopulated is false on stfn for post state",
     }),
+    newSeenAttesters: register.gauge({
+      name: "lodestar_stfn_new_seen_attesters_per_block__total",
+      help: "Total count of new seen attesters per block",
+    }),
+    newSeenAttestersEffectiveBalance: register.gauge({
+      name: "lodestar_stfn_new_seen_attesters_effective_balance_total",
+      help: "Total effective balance increment of new seen attesters per block",
+    }),
 
     // BLS verifier thread pool and queue
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -388,7 +388,7 @@ export function createLodestarMetrics(
       help: "Total count state.validators nodesPopulated is false on stfn for post state",
     }),
     newSeenAttesters: register.gauge({
-      name: "lodestar_stfn_new_seen_attesters_per_block__total",
+      name: "lodestar_stfn_new_seen_attesters_per_block_total",
       help: "Total count of new seen attesters per block",
     }),
     newSeenAttestersEffectiveBalance: register.gauge({

--- a/packages/state-transition/src/block/index.ts
+++ b/packages/state-transition/src/block/index.ts
@@ -1,5 +1,6 @@
 import {ForkSeq} from "@lodestar/params";
 import {BeaconBlock, BlindedBeaconBlock, altair, capella} from "@lodestar/types";
+import {BeaconStateTransitionMetrics} from "../metrics.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateBellatrix, CachedBeaconStateCapella} from "../types.js";
 import {getFullOrBlindedPayload, isExecutionEnabled} from "../util/execution.js";
 import {BlockExternalData, DataAvailableStatus} from "./externalData.js";
@@ -33,7 +34,8 @@ export function processBlock(
   state: CachedBeaconStateAllForks,
   block: BeaconBlock | BlindedBeaconBlock,
   externalData: BlockExternalData & ProcessBlockOpts,
-  opts?: ProcessBlockOpts
+  opts?: ProcessBlockOpts,
+  metrics?: BeaconStateTransitionMetrics | null
 ): void {
   const {verifySignatures = true} = opts ?? {};
 
@@ -58,7 +60,7 @@ export function processBlock(
 
   processRandao(state, block, verifySignatures);
   processEth1Data(state, block.body.eth1Data);
-  processOperations(fork, state, block.body, opts);
+  processOperations(fork, state, block.body, opts, metrics);
   if (fork >= ForkSeq.altair) {
     processSyncAggregate(state, block as altair.BeaconBlock, verifySignatures);
   }

--- a/packages/state-transition/src/block/processAttestations.ts
+++ b/packages/state-transition/src/block/processAttestations.ts
@@ -1,5 +1,6 @@
 import {ForkSeq} from "@lodestar/params";
 import {Attestation} from "@lodestar/types";
+import {BeaconStateTransitionMetrics} from "../metrics.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateAltair, CachedBeaconStatePhase0} from "../types.js";
 import {processAttestationPhase0} from "./processAttestationPhase0.js";
 import {processAttestationsAltair} from "./processAttestationsAltair.js";
@@ -11,13 +12,14 @@ export function processAttestations(
   fork: ForkSeq,
   state: CachedBeaconStateAllForks,
   attestations: Attestation[],
-  verifySignatures = true
+  verifySignatures = true,
+  metrics?: BeaconStateTransitionMetrics | null
 ): void {
   if (fork === ForkSeq.phase0) {
     for (const attestation of attestations) {
       processAttestationPhase0(state as CachedBeaconStatePhase0, attestation, verifySignatures);
     }
   } else {
-    processAttestationsAltair(fork, state as CachedBeaconStateAltair, attestations, verifySignatures);
+    processAttestationsAltair(fork, state as CachedBeaconStateAltair, attestations, verifySignatures, metrics);
   }
 }

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -130,8 +130,9 @@ export function processAttestationsAltair(
     proposerReward += Math.floor(proposerRewardNumerator / PROPOSER_REWARD_DOMINATOR);
   }
 
-  metrics?.newSeenAttesters.set(newSeenAttesters);
-  metrics?.newSeenAttestersEffectiveBalance.set(newSeenAttestersEffectiveBalance);
+  metrics?.newSeenAttestersPerBlock.set(newSeenAttesters);
+  metrics?.newSeenAttestersEffectiveBalancePerBlock.set(newSeenAttestersEffectiveBalance);
+  metrics?.attestationsPerBlock.set(attestations.length);
 
   increaseBalance(state, epochCtx.getBeaconProposer(state.slot), proposerReward);
   state.proposerRewards.attestations = proposerReward;

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -15,6 +15,7 @@ import {
   TIMELY_TARGET_WEIGHT,
   WEIGHT_DENOMINATOR,
 } from "@lodestar/params";
+import {BeaconStateTransitionMetrics} from "../metrics.js";
 import {getAttestationWithIndicesSignatureSet} from "../signatureSets/indexedAttestation.js";
 import {CachedBeaconStateAltair} from "../types.js";
 import {increaseBalance, verifySignatureSet} from "../util/index.js";
@@ -33,7 +34,8 @@ export function processAttestationsAltair(
   fork: ForkSeq,
   state: CachedBeaconStateAltair,
   attestations: Attestation[],
-  verifySignature = true
+  verifySignature = true,
+  metrics?: BeaconStateTransitionMetrics | null
 ): void {
   const {epochCtx} = state;
   const {effectiveBalanceIncrements} = epochCtx;
@@ -43,6 +45,8 @@ export function processAttestationsAltair(
 
   // Process all attestations first and then increase the balance of the proposer once
   let proposerReward = 0;
+  let newSeenAttesters = 0;
+  let newSeenAttestersEffectiveBalance = 0;
   for (const attestation of attestations) {
     const data = attestation.data;
 
@@ -76,19 +80,23 @@ export function processAttestationsAltair(
     // In epoch processing, this participation info is used to calculate balance updates
     let totalBalanceIncrementsWithWeight = 0;
     const validators = state.validators;
-    for (const index of attestingIndices) {
-      const flags = epochParticipation.get(index);
+    for (const validatorIndex of attestingIndices) {
+      const flags = epochParticipation.get(validatorIndex);
 
       // For normal block, > 90% of attestations belong to current epoch
       // At epoch boundary, 100% of attestations belong to previous epoch
       // so we want to update the participation flag tree in batch
 
       // Note ParticipationFlags type uses option {setBitwiseOR: true}, .set() does a |= operation
-      epochParticipation.set(index, flagsAttestation);
+      epochParticipation.set(validatorIndex, flagsAttestation);
       // epochParticipation.setStatus(index, newStatus);
 
       // Returns flags that are NOT set before (~ bitwise NOT) AND are set after
       const flagsNewSet = ~flags & flagsAttestation;
+      if (flagsNewSet !== 0) {
+        newSeenAttesters++;
+        newSeenAttestersEffectiveBalance += effectiveBalanceIncrements[validatorIndex];
+      }
 
       // Spec:
       // baseReward = state.validators[index].effectiveBalance / EFFECTIVE_BALANCE_INCREMENT * baseRewardPerIncrement;
@@ -99,18 +107,18 @@ export function processAttestationsAltair(
       if ((flagsNewSet & TIMELY_HEAD) === TIMELY_HEAD) totalWeight += TIMELY_HEAD_WEIGHT;
 
       if (totalWeight > 0) {
-        totalBalanceIncrementsWithWeight += effectiveBalanceIncrements[index] * totalWeight;
+        totalBalanceIncrementsWithWeight += effectiveBalanceIncrements[validatorIndex] * totalWeight;
       }
 
       // TODO: describe issue. Compute progressive target balances
       // When processing each attestation, increase the cummulative target balance. Only applies post-altair
       if ((flagsNewSet & TIMELY_TARGET) === TIMELY_TARGET) {
-        const validator = validators.getReadonly(index);
+        const validator = validators.getReadonly(validatorIndex);
         if (!validator.slashed) {
           if (inCurrentEpoch) {
-            epochCtx.currentTargetUnslashedBalanceIncrements += effectiveBalanceIncrements[index];
+            epochCtx.currentTargetUnslashedBalanceIncrements += effectiveBalanceIncrements[validatorIndex];
           } else {
-            epochCtx.previousTargetUnslashedBalanceIncrements += effectiveBalanceIncrements[index];
+            epochCtx.previousTargetUnslashedBalanceIncrements += effectiveBalanceIncrements[validatorIndex];
           }
         }
       }
@@ -121,6 +129,9 @@ export function processAttestationsAltair(
     const proposerRewardNumerator = totalIncrements * state.epochCtx.baseRewardPerIncrement;
     proposerReward += Math.floor(proposerRewardNumerator / PROPOSER_REWARD_DOMINATOR);
   }
+
+  metrics?.newSeenAttesters.set(newSeenAttesters);
+  metrics?.newSeenAttestersEffectiveBalance.set(newSeenAttestersEffectiveBalance);
 
   increaseBalance(state, epochCtx.getBeaconProposer(state.slot), proposerReward);
   state.proposerRewards.attestations = proposerReward;

--- a/packages/state-transition/src/block/processOperations.ts
+++ b/packages/state-transition/src/block/processOperations.ts
@@ -1,6 +1,7 @@
 import {ForkSeq} from "@lodestar/params";
 import {BeaconBlockBody, capella, electra} from "@lodestar/types";
 
+import {BeaconStateTransitionMetrics} from "../metrics.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateCapella, CachedBeaconStateElectra} from "../types.js";
 import {getEth1DepositCount} from "../util/deposit.js";
 import {processAttestations} from "./processAttestations.js";
@@ -30,7 +31,8 @@ export function processOperations(
   fork: ForkSeq,
   state: CachedBeaconStateAllForks,
   body: BeaconBlockBody,
-  opts: ProcessBlockOpts = {verifySignatures: true}
+  opts: ProcessBlockOpts = {verifySignatures: true},
+  metrics?: BeaconStateTransitionMetrics | null
 ): void {
   // verify that outstanding deposits are processed up to the maximum number of deposits
   const maxDeposits = getEth1DepositCount(state);
@@ -47,7 +49,7 @@ export function processOperations(
     processAttesterSlashing(fork, state, attesterSlashing, opts.verifySignatures);
   }
 
-  processAttestations(fork, state, body.attestations, opts.verifySignatures);
+  processAttestations(fork, state, body.attestations, opts.verifySignatures, metrics);
 
   for (const deposit of body.deposits) {
     processDeposit(fork, state, deposit);

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -21,8 +21,9 @@ export type BeaconStateTransitionMetrics = {
   postStateBalancesNodesPopulatedHit: Gauge;
   postStateValidatorsNodesPopulatedMiss: Gauge;
   postStateValidatorsNodesPopulatedHit: Gauge;
-  newSeenAttesters: Gauge;
-  newSeenAttestersEffectiveBalance: Gauge;
+  newSeenAttestersPerBlock: Gauge;
+  newSeenAttestersEffectiveBalancePerBlock: Gauge;
+  attestationsPerBlock: Gauge;
   registerValidatorStatuses: (
     currentEpoch: Epoch,
     inclusionDelays: number[],

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -21,6 +21,8 @@ export type BeaconStateTransitionMetrics = {
   postStateBalancesNodesPopulatedHit: Gauge;
   postStateValidatorsNodesPopulatedMiss: Gauge;
   postStateValidatorsNodesPopulatedHit: Gauge;
+  newSeenAttesters: Gauge;
+  newSeenAttestersEffectiveBalance: Gauge;
   registerValidatorStatuses: (
     currentEpoch: Epoch,
     inclusionDelays: number[],

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -103,7 +103,7 @@ export function stateTransition(
   // Note: time only on success
   const processBlockTimer = metrics?.processBlockTime.startTimer();
 
-  processBlock(fork, postState, block, options, options);
+  processBlock(fork, postState, block, options, options, metrics);
 
   const processBlockCommitTimer = metrics?.processBlockCommitTime.startTimer();
   postState.commit();


### PR DESCRIPTION
**Motivation**

- track on chain new seen attesters and total effective balance increment of them per block
- see https://github.com/ChainSafe/lodestar/pull/7646#issuecomment-2774348407

**Description**

- at every block processing, when process attestations we track it
