### PR TITLE
Update options.ts

### DIFF
--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -315,7 +315,7 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
   },
 
   doppelgangerProtection: {
-    alias: ["doppelgangerProtectionEnabled"],
+    alias: ["doppelgangerProtection"],
     description: "Enables Doppelganger protection",
     default: false,
     type: "boolean",


### PR DESCRIPTION
This PR updates the alias for the doppelgangerProtection option from "doppelgangerProtectionEnabled" to "doppelgangerProtection" to maintain consistency in the CLI options naming convention.