### PR TITLE
feat: add QUIC support

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -100,6 +100,7 @@
     "@chainsafe/enr": "^5.0.0",
     "@chainsafe/libp2p-gossipsub": "^14.1.1",
     "@chainsafe/libp2p-noise": "^16.1.0",
+    "@chainsafe/libp2p-quic": "^1.1.1",
     "@chainsafe/persistent-merkle-tree": "^1.1.0",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/pubkey-index-map": "2.0.0",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -100,7 +100,7 @@
     "@chainsafe/enr": "^5.0.0",
     "@chainsafe/libp2p-gossipsub": "^14.1.1",
     "@chainsafe/libp2p-noise": "^16.1.0",
-    "@chainsafe/libp2p-quic": "^1.1.1",
+    "@chainsafe/libp2p-quic": "https://github.com/chainsafe/js-libp2p-quic/raw/lodestar-test/package.tgz",
     "@chainsafe/persistent-merkle-tree": "^1.1.0",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/pubkey-index-map": "2.0.0",

--- a/packages/beacon-node/src/network/discv5/worker.ts
+++ b/packages/beacon-node/src/network/discv5/worker.ts
@@ -75,6 +75,8 @@ const onDiscovered = (enr: ENR): void => {
     subject.next(enr.toObject());
   }
 };
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore wtf?
 discv5.addListener("discovered", onDiscovered);
 
 // Discv5 will now begin accepting request/responses
@@ -91,6 +93,8 @@ const module: Discv5WorkerApi = {
     return discv5.kadValues().map((enr) => enr.toObject());
   },
   async discoverKadValues(): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore wtf?
     discv5.kadValues().map(onDiscovered);
   },
   async findRandomNode(): Promise<ENRData[]> {

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -1,5 +1,6 @@
 import {ENR} from "@chainsafe/enr";
 import {noise} from "@chainsafe/libp2p-noise";
+import {quic} from "@chainsafe/libp2p-quic";
 import {bootstrap} from "@libp2p/bootstrap";
 import {identify} from "@libp2p/identify";
 import {PrivateKey} from "@libp2p/interface";
@@ -72,6 +73,16 @@ export async function createNodeJsLibp2p(
     connectionEncrypters: [noise()],
     // Reject connections when the server's connection count gets high
     transports: [
+      networkOpts.disableQuic
+        ? undefined
+        : quic({
+            handshakeTimeout: 5_000,
+            maxIdleTimeout: 10_000,
+            keepAliveInterval: 5_000,
+            maxConcurrentStreamLimit: 256,
+            maxStreamData: 10_000_000,
+            maxConnectionData: 15_000_000,
+          }),
       tcp({
         maxConnections: networkOpts.maxPeers,
         // socket option: the maximum length of the queue of pending connections
@@ -83,7 +94,7 @@ export async function createNodeJsLibp2p(
           listenBelow: networkOpts.maxPeers ?? Infinity,
         },
       }),
-    ],
+    ].filter(Boolean),
     streamMuxers: [mplex({maxInboundStreams: 256})],
     peerDiscovery,
     metrics: nodeJsLibp2pOpts.metrics

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -8,7 +8,7 @@ import {mdns} from "@libp2p/mdns";
 import {mplex} from "@libp2p/mplex";
 import {prometheusMetrics} from "@libp2p/prometheus-metrics";
 import {tcp} from "@libp2p/tcp";
-import {createLibp2p} from "libp2p";
+import {createLibp2p, Libp2pInit} from "libp2p";
 import {Registry} from "prom-client";
 import {Libp2p, LodestarComponents} from "../interface.js";
 import {NetworkOptions, defaultNetworkOptions} from "../options.js";
@@ -63,6 +63,33 @@ export async function createNodeJsLibp2p(
       peerDiscovery.push(mdns());
     }
   }
+  const transports: Libp2pInit["transports"] = [
+    // TCP is always enabled
+    tcp({
+      // Reject connections when the server's connection count gets high
+      maxConnections: networkOpts.maxPeers,
+      // socket option: the maximum length of the queue of pending connections
+      // https://nodejs.org/dist/latest-v18.x/docs/api/net.html#serverlisten
+      // it's not safe if we increase this number
+      backlog: 5,
+      closeServerOnMaxConnections: {
+        closeAbove: networkOpts.maxPeers ?? Infinity,
+        listenBelow: networkOpts.maxPeers ?? Infinity,
+      },
+    }),
+  ];
+  if (!networkOpts.disableQuic) {
+    transports.unshift(
+      quic({
+        handshakeTimeout: 5_000,
+        maxIdleTimeout: 10_000,
+        keepAliveInterval: 5_000,
+        maxConcurrentStreamLimit: 256,
+        maxStreamData: 10_000_000,
+        maxConnectionData: 15_000_000,
+      })
+    );
+  }
 
   return createLibp2p({
     privateKey,
@@ -71,30 +98,7 @@ export async function createNodeJsLibp2p(
       announce: [],
     },
     connectionEncrypters: [noise()],
-    // Reject connections when the server's connection count gets high
-    transports: [
-      networkOpts.disableQuic
-        ? undefined
-        : quic({
-            handshakeTimeout: 5_000,
-            maxIdleTimeout: 10_000,
-            keepAliveInterval: 5_000,
-            maxConcurrentStreamLimit: 256,
-            maxStreamData: 10_000_000,
-            maxConnectionData: 15_000_000,
-          }),
-      tcp({
-        maxConnections: networkOpts.maxPeers,
-        // socket option: the maximum length of the queue of pending connections
-        // https://nodejs.org/dist/latest-v18.x/docs/api/net.html#serverlisten
-        // it's not safe if we increase this number
-        backlog: 5,
-        closeServerOnMaxConnections: {
-          closeAbove: networkOpts.maxPeers ?? Infinity,
-          listenBelow: networkOpts.maxPeers ?? Infinity,
-        },
-      }),
-    ].filter(Boolean),
+    transports,
     streamMuxers: [mplex({maxInboundStreams: 256})],
     peerDiscovery,
     metrics: nodeJsLibp2pOpts.metrics

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -8,6 +8,7 @@ import {getCurrentAndNextFork} from "./forks.js";
 
 export enum ENRKey {
   tcp = "tcp",
+  quic = "quic",
   eth2 = "eth2",
   attnets = "attnets",
   syncnets = "syncnets",

--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -23,12 +23,14 @@ export interface NetworkOptions
   useWorker?: boolean;
   maxYoungGenerationSizeMb?: number;
   disableLightClientServer?: boolean;
+  disableQuic?: boolean;
 }
 
 export const defaultNetworkOptions: NetworkOptions = {
   maxPeers: 110, // Allow some room above targetPeers for new inbound peers
   targetPeers: 100,
-  localMultiaddrs: ["/ip4/0.0.0.0/tcp/9000"],
+  // this default is never used, in practice, it is always overridden by the cli
+  localMultiaddrs: ["/ip4/0.0.0.0/tcp/9000", "/ip4/0.0.0.0/udp/9001/quic-v1"],
   bootMultiaddrs: [],
   /** disabled by default */
   discv5: null,
@@ -42,4 +44,6 @@ export const defaultNetworkOptions: NetworkOptions = {
   slotsToSubscribeBeforeAggregatorDuty: 2,
   // This will enable the light client server by default
   disableLightClientServer: false,
+  // enable quic by default
+  disableQuic: false,
 };

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -485,6 +485,8 @@ export class PeerDiscovery {
       this.logger.debug("peer multiaddrs", {
         peer: peerIdShort,
         mus: (await this.libp2p.peerStore.get(peerId)).addresses.map((a) => a.multiaddr.toString()).join(", "),
+        muTcp: JSON.stringify(multiaddrTCP),
+        muQuic: JSON.stringify(multiaddrQUIC),
       });
     }
   }

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -76,6 +76,7 @@ export type SubnetDiscvQueryMs = {
 type CachedENR = {
   peerId: PeerId;
   multiaddrTCP: Multiaddr;
+  multiaddrQUIC?: Multiaddr;
   subnets: Record<SubnetType, boolean[]>;
   addedUnixMs: number;
 };
@@ -310,9 +311,16 @@ export class PeerDiscovery {
       return;
     }
 
+    // There is at least one multiaddr
+    // We assume its the tcp multiaddr, we also assume that there may be an additional quic multiaddr
+    // In practice this will only be challenged for mdns discovered peers
+    // TODO: make this smarter
+    const multiaddrTCP = multiaddrs[0];
+    const multiaddrQUIC = multiaddrs[1];
+
     const attnets = zeroAttnets;
     const syncnets = zeroSyncnets;
-    const status = this.handleDiscoveredPeer(id, multiaddrs[0], attnets, syncnets);
+    const status = this.handleDiscoveredPeer(id, multiaddrTCP, multiaddrQUIC, attnets, syncnets);
     this.logger.debug("Discovered peer via libp2p", {peer: prettyPrintPeerId(id), status});
     this.metrics?.discovery.discoveredStatus.inc({status});
   };
@@ -343,7 +351,10 @@ export class PeerDiscovery {
     const attnets = attnetsBytes ? deserializeEnrSubnets(attnetsBytes, ATTESTATION_SUBNET_COUNT) : zeroAttnets;
     const syncnets = syncnetsBytes ? deserializeEnrSubnets(syncnetsBytes, SYNC_COMMITTEE_SUBNET_COUNT) : zeroSyncnets;
 
-    const status = this.handleDiscoveredPeer(peerId, multiaddrTCP, attnets, syncnets);
+    // quic multiaddr is optional
+    const multiaddrQUIC = enr.getLocationMultiaddr(ENRKey.quic);
+
+    const status = this.handleDiscoveredPeer(peerId, multiaddrTCP, multiaddrQUIC, attnets, syncnets);
     this.logger.debug("Discovered peer via discv5", {peer: prettyPrintPeerId(peerId), status});
     this.metrics?.discovery.discoveredStatus.inc({status});
   };
@@ -354,6 +365,7 @@ export class PeerDiscovery {
   private handleDiscoveredPeer(
     peerId: PeerId,
     multiaddrTCP: Multiaddr,
+    multiaddrQUIC: Multiaddr | undefined,
     attnets: boolean[],
     syncnets: boolean[]
   ): DiscoveredPeerStatus {
@@ -381,6 +393,7 @@ export class PeerDiscovery {
       const cachedPeer: CachedENR = {
         peerId,
         multiaddrTCP,
+        multiaddrQUIC,
         subnets: {attnets, syncnets},
         addedUnixMs: Date.now(),
       };
@@ -444,13 +457,15 @@ export class PeerDiscovery {
     // are not successful.
     this.peersToConnect = Math.max(this.peersToConnect - 1, 0);
 
-    const {peerId, multiaddrTCP} = cachedPeer;
+    const {peerId, multiaddrTCP, multiaddrQUIC} = cachedPeer;
 
     // Must add the multiaddrs array to the address book before dialing
     // https://github.com/libp2p/js-libp2p/blob/aec8e3d3bb1b245051b60c2a890550d262d5b062/src/index.js#L638
-    await this.libp2p.peerStore.merge(peerId, {multiaddrs: [multiaddrTCP]});
+    await this.libp2p.peerStore.merge(peerId, {
+      multiaddrs: [multiaddrQUIC, multiaddrTCP].filter(Boolean) as Multiaddr[],
+    });
 
-    // Note: PeerDiscovery adds the multiaddrTCP beforehand
+    // Note: PeerDiscovery adds the multiaddrs beforehand
     const peerIdShort = prettyPrintPeerId(peerId);
     this.logger.debug("Dialing discovered peer", {peer: peerIdShort});
 

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -461,9 +461,8 @@ export class PeerDiscovery {
 
     // Must add the multiaddrs array to the address book before dialing
     // https://github.com/libp2p/js-libp2p/blob/aec8e3d3bb1b245051b60c2a890550d262d5b062/src/index.js#L638
-    const p = await this.libp2p.peerStore.merge(peerId, {
-      multiaddrs: [multiaddrQUIC, multiaddrTCP].filter(Boolean) as Multiaddr[],
-    });
+    const multiaddrs = [multiaddrQUIC, multiaddrTCP].filter(Boolean) as Multiaddr[];
+    const p = await this.libp2p.peerStore.merge(peerId, {multiaddrs});
 
     // Note: PeerDiscovery adds the multiaddrs beforehand
     const peerIdShort = prettyPrintPeerId(peerId);
@@ -484,6 +483,7 @@ export class PeerDiscovery {
       this.logger.debug("Error dialing discovered peer", {peer: peerIdShort}, e as Error);
       this.logger.debug("peer multiaddrs", {
         peer: peerIdShort,
+        mus: JSON.stringify(multiaddrs),
         musBefore: JSON.stringify(p.addresses),
         musAfter: JSON.stringify((await this.libp2p.peerStore.get(peerId)).addresses),
         muTcp: JSON.stringify(multiaddrTCP),

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -461,7 +461,7 @@ export class PeerDiscovery {
 
     // Must add the multiaddrs array to the address book before dialing
     // https://github.com/libp2p/js-libp2p/blob/aec8e3d3bb1b245051b60c2a890550d262d5b062/src/index.js#L638
-    await this.libp2p.peerStore.merge(peerId, {
+    const p = await this.libp2p.peerStore.merge(peerId, {
       multiaddrs: [multiaddrQUIC, multiaddrTCP].filter(Boolean) as Multiaddr[],
     });
 
@@ -484,7 +484,8 @@ export class PeerDiscovery {
       this.logger.debug("Error dialing discovered peer", {peer: peerIdShort}, e as Error);
       this.logger.debug("peer multiaddrs", {
         peer: peerIdShort,
-        mus: (await this.libp2p.peerStore.get(peerId)).addresses.map((a) => a.multiaddr.toString()).join(", "),
+        musBefore: JSON.stringify(p.addresses),
+        musAfter: JSON.stringify((await this.libp2p.peerStore.get(peerId)).addresses),
         muTcp: JSON.stringify(multiaddrTCP),
         muQuic: JSON.stringify(multiaddrQUIC),
       });

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -482,6 +482,10 @@ export class PeerDiscovery {
       timer?.({status: "error"});
       formatLibp2pDialError(e as Error);
       this.logger.debug("Error dialing discovered peer", {peer: peerIdShort}, e as Error);
+      this.logger.debug("peer multiaddrs", {
+        peer: peerIdShort,
+        mus: (await this.libp2p.peerStore.get(peerId)).addresses.map((a) => a.multiaddr.toString()).join(", "),
+      });
     }
   }
 

--- a/packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts
+++ b/packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts
@@ -56,7 +56,7 @@ export function isLocalMultiAddr(multiaddr: Multiaddr | undefined): boolean {
 /**
  * Only update the enr if the value has changed
  */
-function maybeUpdateEnr<T extends "ip" | "tcp" | "udp" | "ip6" | "tcp6" | "udp6">(
+function maybeUpdateEnr<T extends "ip" | "tcp" | "udp" | "quic" | "ip6" | "tcp6" | "udp6" | "quic6">(
   enr: SignableENR,
   key: T,
   value: SignableENR[T] | undefined
@@ -73,7 +73,7 @@ export function overwriteEnrWithCliArgs(
   opts?: {newEnr?: boolean; bootnode?: boolean}
 ): void {
   const preSeq = enr.seq;
-  const {port, discoveryPort, port6, discoveryPort6} = parseListenArgs(args);
+  const {port, discoveryPort, quicPort, port6, discoveryPort6, quicPort6} = parseListenArgs(args);
   maybeUpdateEnr(enr, "ip", args["enr.ip"] ?? enr.ip);
   maybeUpdateEnr(enr, "ip6", args["enr.ip6"] ?? enr.ip6);
   maybeUpdateEnr(enr, "udp", args["enr.udp"] ?? discoveryPort ?? enr.udp);
@@ -81,6 +81,8 @@ export function overwriteEnrWithCliArgs(
   if (!opts?.bootnode) {
     maybeUpdateEnr(enr, "tcp", args["enr.tcp"] ?? port ?? enr.tcp);
     maybeUpdateEnr(enr, "tcp6", args["enr.tcp6"] ?? port6 ?? enr.tcp6);
+    maybeUpdateEnr(enr, "quic", args["enr.quic"] ?? quicPort);
+    maybeUpdateEnr(enr, "quic6", args["enr.quic6"] ?? quicPort6);
   }
 
   function testMultiaddrForLocal(mu: Multiaddr, ip4: boolean): void {

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -148,10 +148,12 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
 type ENRArgs = {
   "enr.ip"?: string;
   "enr.tcp"?: number;
-  "enr.ip6"?: string;
   "enr.udp"?: number;
+  "enr.quic"?: number;
+  "enr.ip6"?: string;
   "enr.tcp6"?: number;
   "enr.udp6"?: number;
+  "enr.quic6"?: number;
   nat?: boolean;
 };
 
@@ -171,6 +173,11 @@ const enrOptions: CliCommandOptions<ENRArgs> = {
     type: "number",
     group: "enr",
   },
+  "enr.quic": {
+    description: "Override ENR QUIC entry",
+    type: "number",
+    group: "enr",
+  },
   "enr.ip6": {
     description: "Override ENR IPv6 entry",
     type: "string",
@@ -183,6 +190,11 @@ const enrOptions: CliCommandOptions<ENRArgs> = {
   },
   "enr.udp6": {
     description: "Override ENR (IPv6-specific) UDP entry",
+    type: "number",
+    group: "enr",
+  },
+  "enr.quic6": {
+    description: "Override ENR (IPv6-specific) QUIC entry",
     type: "number",
     group: "enr",
   },

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -6,21 +6,26 @@ import {YargsError} from "../../util/index.js";
 
 export const defaultListenAddress = "0.0.0.0";
 export const defaultP2pPort = 9000;
+export const defaultQuicPort = 9001;
 export const defaultP2pPort6 = 9090;
+export const defaultQuicPort6 = 9091;
 
 export type NetworkArgs = {
   discv5?: boolean;
   listenAddress?: string;
   port?: number;
   discoveryPort?: number;
+  quicPort?: number;
   listenAddress6?: string;
   port6?: number;
   discoveryPort6?: number;
+  quicPort6?: number;
   bootnodes?: string[];
   targetPeers?: number;
   subscribeAllSubnets?: boolean;
   slotsToSubscribeBeforeAggregatorDuty?: number;
   disablePeerScoring?: boolean;
+  disableQuic?: boolean;
   mdns?: boolean;
   "network.maxPeers"?: number;
   "network.connectToDiscv5Bootnodes"?: boolean;
@@ -63,42 +68,55 @@ export function parseListenArgs(args: NetworkArgs) {
   const listenAddress = args.listenAddress ?? (args.listenAddress6 ? undefined : defaultListenAddress);
   const port = listenAddress ? (args.port ?? defaultP2pPort) : undefined;
   const discoveryPort = listenAddress ? (args.discoveryPort ?? args.port ?? defaultP2pPort) : undefined;
+  const quicPort = listenAddress ? (args.quicPort ?? (port !== undefined ? port + 1 : defaultQuicPort)) : undefined;
 
   // Only use listenAddress6 if it is explicitly set
   const listenAddress6 = args.listenAddress6;
   const port6 = listenAddress6 ? (args.port6 ?? defaultP2pPort6) : undefined;
   const discoveryPort6 = listenAddress6 ? (args.discoveryPort6 ?? args.port6 ?? defaultP2pPort6) : undefined;
+  const quicPort6 = listenAddress6
+    ? (args.quicPort6 ?? (port6 !== undefined ? port6 + 1 : defaultQuicPort6))
+    : undefined;
 
-  return {listenAddress, port, discoveryPort, listenAddress6, port6, discoveryPort6};
+  return {listenAddress, port, discoveryPort, quicPort, listenAddress6, port6, discoveryPort6, quicPort6};
 }
 
 export function parseArgs(args: NetworkArgs): IBeaconNodeOptions["network"] {
-  const {listenAddress, port, discoveryPort, listenAddress6, port6, discoveryPort6} = parseListenArgs(args);
+  const {listenAddress, port, discoveryPort, quicPort, listenAddress6, port6, discoveryPort6, quicPort6} =
+    parseListenArgs(args);
   // validate ip, ip6, ports
   const muArgs = {
     listenAddress: listenAddress ? `/ip4/${listenAddress}` : undefined,
     port: listenAddress ? `/tcp/${port}` : undefined,
     discoveryPort: listenAddress ? `/udp/${discoveryPort}` : undefined,
+    quicPort: listenAddress ? `/udp/${quicPort}/quic-v1` : undefined,
     listenAddress6: listenAddress6 ? `/ip6/${listenAddress6}` : undefined,
     port6: listenAddress6 ? `/tcp/${port6}` : undefined,
     discoveryPort6: listenAddress6 ? `/udp/${discoveryPort6}` : undefined,
+    quicPort6: listenAddress ? `/udp/${quicPort6}/quic-v1` : undefined,
   };
 
   for (const key of [
     "listenAddress",
     "port",
     "discoveryPort",
+    "quicPort",
     "listenAddress6",
     "port6",
     "discoveryPort6",
+    "quicPort6",
   ] as (keyof typeof muArgs)[]) {
     validateMultiaddrArg(muArgs, key);
   }
 
+  const disableQuic = args.disableQuic;
+
   const bindMu = listenAddress ? `${muArgs.listenAddress}${muArgs.discoveryPort}` : undefined;
   const localMu = listenAddress ? `${muArgs.listenAddress}${muArgs.port}` : undefined;
+  const quicMu = listenAddress && !disableQuic ? `${muArgs.listenAddress}${muArgs.quicPort}` : undefined;
   const bindMu6 = listenAddress6 ? `${muArgs.listenAddress6}${muArgs.discoveryPort6}` : undefined;
   const localMu6 = listenAddress6 ? `${muArgs.listenAddress6}${muArgs.port6}` : undefined;
+  const quicMu6 = listenAddress6 && !disableQuic ? `${muArgs.listenAddress6}${muArgs.quicPort6}` : undefined;
 
   const targetPeers = args.targetPeers;
   const maxPeers = args["network.maxPeers"] ?? (targetPeers !== undefined ? Math.floor(targetPeers * 1.1) : undefined);
@@ -134,11 +152,12 @@ export function parseArgs(args: NetworkArgs): IBeaconNodeOptions["network"] {
       : null,
     maxPeers: maxPeers ?? defaultOptions.network.maxPeers,
     targetPeers: targetPeers ?? defaultOptions.network.targetPeers,
-    localMultiaddrs: [localMu, localMu6].filter(Boolean) as string[],
+    localMultiaddrs: [quicMu, quicMu6, localMu, localMu6].filter(Boolean) as string[],
     subscribeAllSubnets: args.subscribeAllSubnets,
     slotsToSubscribeBeforeAggregatorDuty:
       args.slotsToSubscribeBeforeAggregatorDuty ?? defaultOptions.network.slotsToSubscribeBeforeAggregatorDuty,
     disablePeerScoring: args.disablePeerScoring,
+    disableQuic,
     connectToDiscv5Bootnodes: args["network.connectToDiscv5Bootnodes"],
     discv5FirstQueryDelayMs: args["network.discv5FirstQueryDelayMs"],
     dontSendGossipAttestationsToForkchoice: args["network.dontSendGossipAttestationsToForkchoice"],
@@ -187,6 +206,13 @@ export const options: CliCommandOptions<NetworkArgs> = {
     group: "network",
   },
 
+  quicPort: {
+    description: "The UDP port that QUIC will listen on. Defaults to `port` + 1",
+    type: "number",
+    defaultDescription: String(defaultQuicPort),
+    group: "network",
+  },
+
   listenAddress6: {
     type: "string",
     description: "The IPv6 address to listen for p2p UDP and TCP connections",
@@ -205,6 +231,13 @@ export const options: CliCommandOptions<NetworkArgs> = {
     description: "The UDP port that discovery will listen on. Defaults to `port6`",
     type: "number",
     defaultDescription: "`port6`",
+    group: "network",
+  },
+
+  quicPort6: {
+    description: "The UDP port that QUIC will listen on. Defaults to `port6` + 1",
+    type: "number",
+    defaultDescription: String(defaultQuicPort6),
     group: "network",
   },
 
@@ -245,6 +278,13 @@ export const options: CliCommandOptions<NetworkArgs> = {
     type: "boolean",
     description: "Disable peer scoring, used for testing on devnets",
     defaultDescription: String(defaultOptions.network.disablePeerScoring === true),
+    group: "network",
+  },
+
+  disableQuic: {
+    type: "boolean",
+    description: "Disable QUIC transport",
+    defaultDescription: String(defaultOptions.network.disableQuic === true),
     group: "network",
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,45 +676,9 @@
     uint8arrays "^5.0.0"
     wherearewe "^2.0.1"
 
-"@chainsafe/libp2p-quic-darwin-arm64@1.1.1":
+"@chainsafe/libp2p-quic@https://github.com/chainsafe/js-libp2p-quic/raw/lodestar-test/package.tgz":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-darwin-arm64/-/libp2p-quic-darwin-arm64-1.1.1.tgz#a84873b0b40ec16ab2fde96b22d0da4fcf345561"
-  integrity sha512-2INg6niu0u3GtKIsHC3gzEaufg/3ZgFvSeqIjuF+u5eXGIcTo1uare228icWC5/hn/DwQ83l6WafoMkuguSakA==
-
-"@chainsafe/libp2p-quic-darwin-x64@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-darwin-x64/-/libp2p-quic-darwin-x64-1.1.1.tgz#757d8a2fbba18d98070158e571b187b9d848b85d"
-  integrity sha512-xHU6GqjI7/4daslX04VIjTrVxyb/O3Yc1hH2dubtEmqnpJEM5+7qf03MBK/ddNhbAqzC0b7QuU/ecEgtqjHsRA==
-
-"@chainsafe/libp2p-quic-linux-arm64-gnu@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-linux-arm64-gnu/-/libp2p-quic-linux-arm64-gnu-1.1.1.tgz#a6805dac5bc5057825ee141e7d4093acd52c87ff"
-  integrity sha512-HmjZ/2cb8xvkUBn1hPFkwl5s6m3hwkCiEE9ITlu/3UPajALpk4vrLjeoKDHV6M3c+ohIMauyKVqV50EEl6VM4Q==
-
-"@chainsafe/libp2p-quic-linux-arm64-musl@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-linux-arm64-musl/-/libp2p-quic-linux-arm64-musl-1.1.1.tgz#41c1bfef51a61bba0d0869b41cd8d02b59ec0299"
-  integrity sha512-G7R4WhzDriLNpVRWPIlsyRUUDIik+4SJoX+ZKQ6T54r+wyJTght6coA1rJANjkXWa8wKK0b5iIQol1SZEGH3Jg==
-
-"@chainsafe/libp2p-quic-linux-x64-gnu@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-linux-x64-gnu/-/libp2p-quic-linux-x64-gnu-1.1.1.tgz#4583dab95304f5bed09ce18ad619e81e09192de6"
-  integrity sha512-ARZbIj+ueD/LTCwB7CLMtokNZkqu640gi9YIuhHqEqenLZ75FbpJpYnqY/Jx+vdK/+gV0NyRZ395o4pH1W5SXQ==
-
-"@chainsafe/libp2p-quic-linux-x64-musl@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-linux-x64-musl/-/libp2p-quic-linux-x64-musl-1.1.1.tgz#7f123d15d24bfb87afee74cb0e4f42fdc1efb417"
-  integrity sha512-lsBlcYlukwTDupe9SxI7hmhhSlZfBhGWXlb4gRqd+xcBptadX15lPhJDBi6P9T2CMwsAIoZNLDZhMqPf8RL5fw==
-
-"@chainsafe/libp2p-quic-win32-x64-msvc@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-win32-x64-msvc/-/libp2p-quic-win32-x64-msvc-1.1.1.tgz#622638c05d82ba6db8e7d169a685fefa2d38b34d"
-  integrity sha512-5O5ffgtzD8fpb6LeP4/clscOdWk17JXrjfMTlp9zUtTa+0vcAzBT8RtWzv12Vaqf9PPsTp+dUQ5595LWMcZVEA==
-
-"@chainsafe/libp2p-quic@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic/-/libp2p-quic-1.1.1.tgz#9bf77218f8961911eb31cf690bdf3e8ce5edec5d"
-  integrity sha512-fnL6n82ngQ1qzcuI/bdVshHU/GumO4azloP3RG1z6hkmcro8gdVDAYgmP47rXOQUf2GlczwKyI2epIPMRVwDhg==
+  resolved "https://github.com/chainsafe/js-libp2p-quic/raw/lodestar-test/package.tgz#954c5e1d9c14b0de5ad8fd1b6c036143bb8c9ff8"
   dependencies:
     "@libp2p/crypto" "^5.0.12"
     "@libp2p/interface" "^2.6.0"
@@ -723,14 +687,6 @@
     "@multiformats/multiaddr-matcher" "^1.6.0"
     it-stream-types "^2.0.2"
     uint8arraylist "^2.4.8"
-  optionalDependencies:
-    "@chainsafe/libp2p-quic-darwin-arm64" "1.1.1"
-    "@chainsafe/libp2p-quic-darwin-x64" "1.1.1"
-    "@chainsafe/libp2p-quic-linux-arm64-gnu" "1.1.1"
-    "@chainsafe/libp2p-quic-linux-arm64-musl" "1.1.1"
-    "@chainsafe/libp2p-quic-linux-x64-gnu" "1.1.1"
-    "@chainsafe/libp2p-quic-linux-x64-musl" "1.1.1"
-    "@chainsafe/libp2p-quic-win32-x64-msvc" "1.1.1"
 
 "@chainsafe/netmask@^2.0.0":
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,6 +676,62 @@
     uint8arrays "^5.0.0"
     wherearewe "^2.0.1"
 
+"@chainsafe/libp2p-quic-darwin-arm64@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-darwin-arm64/-/libp2p-quic-darwin-arm64-1.1.1.tgz#a84873b0b40ec16ab2fde96b22d0da4fcf345561"
+  integrity sha512-2INg6niu0u3GtKIsHC3gzEaufg/3ZgFvSeqIjuF+u5eXGIcTo1uare228icWC5/hn/DwQ83l6WafoMkuguSakA==
+
+"@chainsafe/libp2p-quic-darwin-x64@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-darwin-x64/-/libp2p-quic-darwin-x64-1.1.1.tgz#757d8a2fbba18d98070158e571b187b9d848b85d"
+  integrity sha512-xHU6GqjI7/4daslX04VIjTrVxyb/O3Yc1hH2dubtEmqnpJEM5+7qf03MBK/ddNhbAqzC0b7QuU/ecEgtqjHsRA==
+
+"@chainsafe/libp2p-quic-linux-arm64-gnu@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-linux-arm64-gnu/-/libp2p-quic-linux-arm64-gnu-1.1.1.tgz#a6805dac5bc5057825ee141e7d4093acd52c87ff"
+  integrity sha512-HmjZ/2cb8xvkUBn1hPFkwl5s6m3hwkCiEE9ITlu/3UPajALpk4vrLjeoKDHV6M3c+ohIMauyKVqV50EEl6VM4Q==
+
+"@chainsafe/libp2p-quic-linux-arm64-musl@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-linux-arm64-musl/-/libp2p-quic-linux-arm64-musl-1.1.1.tgz#41c1bfef51a61bba0d0869b41cd8d02b59ec0299"
+  integrity sha512-G7R4WhzDriLNpVRWPIlsyRUUDIik+4SJoX+ZKQ6T54r+wyJTght6coA1rJANjkXWa8wKK0b5iIQol1SZEGH3Jg==
+
+"@chainsafe/libp2p-quic-linux-x64-gnu@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-linux-x64-gnu/-/libp2p-quic-linux-x64-gnu-1.1.1.tgz#4583dab95304f5bed09ce18ad619e81e09192de6"
+  integrity sha512-ARZbIj+ueD/LTCwB7CLMtokNZkqu640gi9YIuhHqEqenLZ75FbpJpYnqY/Jx+vdK/+gV0NyRZ395o4pH1W5SXQ==
+
+"@chainsafe/libp2p-quic-linux-x64-musl@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-linux-x64-musl/-/libp2p-quic-linux-x64-musl-1.1.1.tgz#7f123d15d24bfb87afee74cb0e4f42fdc1efb417"
+  integrity sha512-lsBlcYlukwTDupe9SxI7hmhhSlZfBhGWXlb4gRqd+xcBptadX15lPhJDBi6P9T2CMwsAIoZNLDZhMqPf8RL5fw==
+
+"@chainsafe/libp2p-quic-win32-x64-msvc@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic-win32-x64-msvc/-/libp2p-quic-win32-x64-msvc-1.1.1.tgz#622638c05d82ba6db8e7d169a685fefa2d38b34d"
+  integrity sha512-5O5ffgtzD8fpb6LeP4/clscOdWk17JXrjfMTlp9zUtTa+0vcAzBT8RtWzv12Vaqf9PPsTp+dUQ5595LWMcZVEA==
+
+"@chainsafe/libp2p-quic@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/libp2p-quic/-/libp2p-quic-1.1.1.tgz#9bf77218f8961911eb31cf690bdf3e8ce5edec5d"
+  integrity sha512-fnL6n82ngQ1qzcuI/bdVshHU/GumO4azloP3RG1z6hkmcro8gdVDAYgmP47rXOQUf2GlczwKyI2epIPMRVwDhg==
+  dependencies:
+    "@libp2p/crypto" "^5.0.12"
+    "@libp2p/interface" "^2.6.0"
+    "@libp2p/utils" "^6.5.8"
+    "@multiformats/multiaddr" "^12.4.0"
+    "@multiformats/multiaddr-matcher" "^1.6.0"
+    it-stream-types "^2.0.2"
+    uint8arraylist "^2.4.8"
+  optionalDependencies:
+    "@chainsafe/libp2p-quic-darwin-arm64" "1.1.1"
+    "@chainsafe/libp2p-quic-darwin-x64" "1.1.1"
+    "@chainsafe/libp2p-quic-linux-arm64-gnu" "1.1.1"
+    "@chainsafe/libp2p-quic-linux-arm64-musl" "1.1.1"
+    "@chainsafe/libp2p-quic-linux-x64-gnu" "1.1.1"
+    "@chainsafe/libp2p-quic-linux-x64-musl" "1.1.1"
+    "@chainsafe/libp2p-quic-win32-x64-msvc" "1.1.1"
+
 "@chainsafe/netmask@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@chainsafe/netmask/-/netmask-2.0.0.tgz#0d4a75f47919f65011da4327a3845c9661f1038a"
@@ -1821,7 +1877,7 @@
     "@multiformats/mafmt" "^12.1.6"
     "@multiformats/multiaddr" "^12.3.3"
 
-"@libp2p/crypto@^5.0.0", "@libp2p/crypto@^5.0.1", "@libp2p/crypto@^5.0.15":
+"@libp2p/crypto@^5.0.0", "@libp2p/crypto@^5.0.1", "@libp2p/crypto@^5.0.12", "@libp2p/crypto@^5.0.15":
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/@libp2p/crypto/-/crypto-5.0.15.tgz#ed4b75247ea1661417564d8dd30faf58e4199ecb"
   integrity sha512-28xYMOn3fs8flsNgCVVxp27gEmDTtZHbz+qEVv3v7cWfGRipaVhNXFV9tQJHWXHQ8mN8v/PQvgcfCcWu5jkrTg==
@@ -1864,7 +1920,7 @@
     "@multiformats/multiaddr" "^12.3.3"
     progress-events "^1.0.1"
 
-"@libp2p/interface@^2.0.0", "@libp2p/interface@^2.0.1", "@libp2p/interface@^2.7.0":
+"@libp2p/interface@^2.0.0", "@libp2p/interface@^2.0.1", "@libp2p/interface@^2.6.0", "@libp2p/interface@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@libp2p/interface/-/interface-2.7.0.tgz#05dc0c13901f3a681484ec6f1a41f164b6228f41"
   integrity sha512-lWmfIGzbSaw//yoEWWJh8dXNDGSCwUyXwC7P1Q6jCFWNoEtCaB1pvwOGBtri7Db/aNFZryMzN5covoq5ulldnA==
@@ -2030,7 +2086,7 @@
     race-event "^1.3.0"
     stream-to-it "^1.0.1"
 
-"@libp2p/utils@^6.6.0":
+"@libp2p/utils@^6.5.8", "@libp2p/utils@^6.6.0":
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/@libp2p/utils/-/utils-6.6.0.tgz#ed4859c603dcb8d16b29b6a14e55048df6c35049"
   integrity sha512-QjS1+r+jInOxULjdATBc1N/gorUWUoJqEKxpqTcB2wOwCipzB58RYR3n3QPeoRHj1mVMhZujE1dTbmK/Nafhqg==
@@ -2146,7 +2202,7 @@
     "@multiformats/multiaddr" "^12.0.0"
     multiformats "^13.0.0"
 
-"@multiformats/multiaddr@^12.0.0", "@multiformats/multiaddr@^12.1.10", "@multiformats/multiaddr@^12.1.14", "@multiformats/multiaddr@^12.1.3", "@multiformats/multiaddr@^12.3.3", "@multiformats/multiaddr@^12.3.5":
+"@multiformats/multiaddr@^12.0.0", "@multiformats/multiaddr@^12.1.10", "@multiformats/multiaddr@^12.1.14", "@multiformats/multiaddr@^12.1.3", "@multiformats/multiaddr@^12.3.3", "@multiformats/multiaddr@^12.3.5", "@multiformats/multiaddr@^12.4.0":
   version "12.4.0"
   resolved "https://registry.yarnpkg.com/@multiformats/multiaddr/-/multiaddr-12.4.0.tgz#13fca8d68805fe0d0569bdd7d4dce41497503d31"
   integrity sha512-FL7yBTLijJ5JkO044BGb2msf+uJLrwpD6jD6TkXlbjA9N12+18HT40jvd4o5vL4LOJMc86dPX6tGtk/uI9kYKg==
@@ -12618,7 +12674,14 @@ undici-types@~6.19.2:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
-undici@^5.12.0, undici@^5.25.4:
+undici@^5.12.0:
+  version "5.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.29.0.tgz#419595449ae3f2cdcba3580a2e8903399bd1f5a3"
+  integrity sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
+
+undici@^5.25.4:
   version "5.28.5"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.5.tgz#b2b94b6bf8f1d919bc5a6f31f2c01deb02e54d4b"
   integrity sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==


### PR DESCRIPTION
**Motivation**

TODO

**Description**

- Add QUIC support
- Add `quicPort`, `quicPort6`, `disableQuic` cli flags
- By default, use port 9001 for QUIC, if `port` is specified, use `port + 1`
- Advertise QUIC support in ENR
- Prefer QUIC over TCP for dialing discovered peers