### PR TITLE
ci: enable spec tests for validator in the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,7 +207,6 @@ jobs:
           key: spec-test-data-${{ hashFiles('packages/beacon-node/test/spec/specTestVersioning.ts') }}
       - name: Download spec tests
         run: yarn download-spec-tests
-        working-directory: packages/beacon-node
       # Run them in different steps to quickly identifying which command failed
       # Otherwise just doing `yarn test:spec` you can't tell which specific suite failed
       # many of the suites have identical names for minimal and mainnet
@@ -223,3 +222,6 @@ jobs:
       - name: Spec tests mainnet
         run: NODE_OPTIONS='--max-old-space-size=4096' yarn test:spec:mainnet
         working-directory: packages/beacon-node
+      - name: Spec tests validator
+        run: yarn test:spec
+        working-directory: packages/validator


### PR DESCRIPTION
**Motivation**

Test all available suits on the CI

**Description**

Seems that spec tests for the validator package was skipped in the CI unintentionally. Bringing it back.


**Steps to test or reproduce**

Run all tests