### PR TITLE
feat: adjust aggregate participation buckets and track aggregate cache misses

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -130,7 +130,7 @@ export function getBeaconPoolApi({
                 committeeSize,
                 priority
               );
-              metrics?.opPool.attestationPoolApiInsertOutcome.inc({insertOutcome});
+              metrics?.opPool.attestationPool.apiInsertOutcome.inc({insertOutcome});
             }
 
             if (isForkPostElectra(fork)) {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1248,7 +1248,7 @@ export function getValidatorApi(
       await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
       const dataRootHex = toRootHex(attestationDataRoot);
-      const aggregate = chain.attestationPool.getAggregate(slot, null, dataRootHex);
+      const aggregate = chain.attestationPool.getAggregate(slot, dataRootHex, null);
       const fork = chain.config.getForkName(slot);
 
       if (isForkPostElectra(fork)) {
@@ -1275,12 +1275,12 @@ export function getValidatorApi(
       await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
       const dataRootHex = toRootHex(attestationDataRoot);
-      const aggregate = chain.attestationPool.getAggregate(slot, committeeIndex, dataRootHex);
+      const aggregate = chain.attestationPool.getAggregate(slot, dataRootHex, committeeIndex);
 
       if (!aggregate) {
         throw new ApiError(
           404,
-          `No aggregated attestation for slot=${slot}, committeeIndex=${committeeIndex}, dataRoot=${dataRootHex}`
+          `No aggregated attestation for slot=${slot}, dataRoot=${dataRootHex}, committeeIndex=${committeeIndex}`
         );
       }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -373,7 +373,7 @@ export class BeaconChain implements IBeaconChain {
     }
 
     if (metrics) {
-      metrics.opPool.attestationPoolSize.addCollect(() => this.onScrapeMetrics(metrics));
+      metrics.clockSlot.addCollect(() => this.onScrapeMetrics(metrics));
     }
 
     // Event handlers. emitter is created internally and dropped on close(). Not need to .removeListener()
@@ -1077,7 +1077,7 @@ export class BeaconChain implements IBeaconChain {
 
   private onScrapeMetrics(metrics: Metrics): void {
     // aggregatedAttestationPool tracks metrics on its own
-    metrics.opPool.attestationPoolSize.set(this.attestationPool.getAttestationCount());
+    metrics.opPool.attestationPool.poolSize.set(this.attestationPool.getAttestationCount());
     metrics.opPool.attesterSlashingPoolSize.set(this.opPool.attesterSlashingsSize);
     metrics.opPool.proposerSlashingPoolSize.set(this.opPool.proposerSlashingsSize);
     metrics.opPool.voluntaryExitPoolSize.set(this.opPool.voluntaryExitsSize);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1078,7 +1078,7 @@ export class BeaconChain implements IBeaconChain {
 
   private onScrapeMetrics(metrics: Metrics): void {
     // aggregatedAttestationPool tracks metrics on its own
-    metrics.opPool.attestationPool.poolSize.set(this.attestationPool.getAttestationCount());
+    metrics.opPool.attestationPool.size.set(this.attestationPool.getAttestationCount());
     metrics.opPool.attesterSlashingPoolSize.set(this.opPool.attesterSlashingsSize);
     metrics.opPool.proposerSlashingPoolSize.set(this.opPool.proposerSlashingsSize);
     metrics.opPool.voluntaryExitPoolSize.set(this.opPool.voluntaryExitsSize);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -237,7 +237,8 @@ export class BeaconChain implements IBeaconChain {
       config,
       clock,
       preAggregateCutOffTime,
-      this.opts?.preaggregateSlotDistance
+      this.opts?.preaggregateSlotDistance,
+      metrics
     );
     this.aggregatedAttestationPool = new AggregatedAttestationPool(this.config, metrics);
     this.syncCommitteeMessagePool = new SyncCommitteeMessagePool(

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -424,8 +424,8 @@ export class AggregatedAttestationPool {
     return attestations;
   }
 
-  private onScrapeMetrics({opPool}: Metrics): void {
-    const metrics = opPool.aggregatedAttestationPool;
+  private onScrapeMetrics(metrics: Metrics): void {
+    const aggregatedAttestationPoolMetrics = metrics.opPool.aggregatedAttestationPool;
     const allSlots = Array.from(this.attestationGroupByIndexByDataHexBySlot.keys());
 
     // always record the previous slot because the current slot may not be finished yet, we may receive more attestations
@@ -439,7 +439,7 @@ export class AggregatedAttestationPool {
 
       const groupByIndexByDataHex = this.attestationGroupByIndexByDataHexBySlot.get(previousSlot);
       if (groupByIndexByDataHex != null) {
-        metrics.attDataPerSlot.set(groupByIndexByDataHex.size);
+        aggregatedAttestationPoolMetrics.attDataPerSlot.set(groupByIndexByDataHex.size);
 
         let maxAttestations = 0;
         let committeeCount = 0;
@@ -447,12 +447,12 @@ export class AggregatedAttestationPool {
           for (const group of groupByIndex.values()) {
             const attestationCount = group.getAttestationCount();
             maxAttestations = Math.max(maxAttestations, attestationCount);
-            metrics.attestationsPerCommittee.observe(attestationCount);
+            aggregatedAttestationPoolMetrics.attestationsPerCommittee.observe(attestationCount);
             committeeCount += 1;
           }
         }
-        metrics.maxAttestationsPerCommittee.set(maxAttestations);
-        metrics.committeesPerSlot.set(committeeCount);
+        aggregatedAttestationPoolMetrics.maxAttestationsPerCommittee.set(maxAttestations);
+        aggregatedAttestationPoolMetrics.committeesPerSlot.set(committeeCount);
       }
     }
 
@@ -467,8 +467,8 @@ export class AggregatedAttestationPool {
       }
     }
 
-    metrics.poolSize.set(attestationCount);
-    metrics.poolUniqueData.set(attestationDataCount);
+    aggregatedAttestationPoolMetrics.size.set(attestationCount);
+    aggregatedAttestationPoolMetrics.uniqueData.set(attestationDataCount);
   }
 }
 

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -1,7 +1,7 @@
 import {Signature, aggregateSignatures} from "@chainsafe/blst";
 import {BitArray} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {EpochDifference, IForkChoice} from "@lodestar/fork-choice";
+import {IForkChoice} from "@lodestar/fork-choice";
 import {
   ForkName,
   ForkSeq,

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -270,7 +270,7 @@ export function createLodestarMetrics(
         name: "lodestar_produced_aggregate_participants",
         help: "API impl produced aggregates histogram of participants",
         // We care more about tracking low quality aggregates with low participation
-        // Max committee sizes are: 0.5e6 vc: 244, 1e6 vc: 488, 1.1e6 vc: 537
+        // Max committee sizes are: 1e6 vc: 488, 1.1e6 vc: 537
         buckets: [1, 5, 25, 50, 100, 200, 300, 400, 500, 600],
       }),
       producedSyncContributionParticipants: register.histogram({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -270,7 +270,7 @@ export function createLodestarMetrics(
         name: "lodestar_produced_aggregate_participants",
         help: "API impl produced aggregates histogram of participants",
         // We care more about tracking low quality aggregates with low participation
-        // Max committee sizes are: 1e6 vc: 488, 1.1e6 vc: 537
+        // Max committee sizes are: 1e6 vc: 488, 1.1e6 vc: 537, 1.4e6 vc: 683
         buckets: [1, 5, 25, 50, 100, 200, 300, 400, 500, 600],
       }),
       producedSyncContributionParticipants: register.histogram({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -863,11 +863,11 @@ export function createLodestarMetrics(
 
     opPool: {
       aggregatedAttestationPool: {
-        poolSize: register.gauge({
+        size: register.gauge({
           name: "lodestar_oppool_aggregated_attestation_pool_size",
           help: "Current size of the AggregatedAttestationPool = total attestations",
         }),
-        poolUniqueData: register.gauge({
+        uniqueData: register.gauge({
           name: "lodestar_oppool_aggregated_attestation_pool_unique_data_count",
           help: "Current size of the AggregatedAttestationPool = total attestations unique by data",
         }),
@@ -891,22 +891,22 @@ export function createLodestarMetrics(
         }),
       },
       attestationPool: {
-        poolSize: register.gauge({
+        size: register.gauge({
           name: "lodestar_oppool_attestation_pool_size",
           help: "Current size of the AttestationPool = total attestations unique by data and slot",
         }),
         gossipInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
-          name: "lodestar_attestation_pool_insert_outcome_total",
+          name: "lodestar_oppool_attestation_pool_gossip_insert_outcome_total",
           help: "Total number of InsertOutcome as a result of adding a gossip attestation in a pool",
           labelNames: ["insertOutcome"],
         }),
         apiInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
-          name: "lodestar_attestation_pool_api_insert_outcome_total",
+          name: "lodestar_oppool_attestation_pool_api_insert_outcome_total",
           help: "Total number of InsertOutcome as a result of adding an attestation from api in a pool",
           labelNames: ["insertOutcome"],
         }),
         getAggregateCacheMisses: register.counter({
-          name: "lodestar_attestation_pool_get_aggregate_cache_misses_total",
+          name: "lodestar_oppool_attestation_pool_get_aggregate_cache_misses_total",
           help: "Total number of getAggregate calls with no aggregate for slot, attestation data root, and committee index",
         }),
       },

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -270,8 +270,8 @@ export function createLodestarMetrics(
         name: "lodestar_produced_aggregate_participants",
         help: "API impl produced aggregates histogram of participants",
         // We care more about tracking low quality aggregates with low participation
-        // Max committee sizes are: 0.5e6 vc: 244, 1e6 vc: 488
-        buckets: [1, 5, 20, 50, 100, 200, 400],
+        // Max committee sizes are: 0.5e6 vc: 244, 1e6 vc: 488, 1.1e6 vc: 537
+        buckets: [1, 5, 25, 50, 100, 200, 300, 400, 500, 600],
       }),
       producedSyncContributionParticipants: register.histogram({
         name: "lodestar_produced_sync_contribution_participants",
@@ -890,20 +890,26 @@ export function createLodestarMetrics(
           buckets: [0, 2, 4, 8],
         }),
       },
-      attestationPoolSize: register.gauge({
-        name: "lodestar_oppool_attestation_pool_size",
-        help: "Current size of the AttestationPool = total attestations unique by data and slot",
-      }),
-      attestationPoolGossipInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
-        name: "lodestar_attestation_pool_insert_outcome_total",
-        help: "Total number of InsertOutcome as a result of adding a gossip attestation in a pool",
-        labelNames: ["insertOutcome"],
-      }),
-      attestationPoolApiInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
-        name: "lodestar_attestation_pool_api_insert_outcome_total",
-        help: "Total number of InsertOutcome as a result of adding an attestation from api in a pool",
-        labelNames: ["insertOutcome"],
-      }),
+      attestationPool: {
+        poolSize: register.gauge({
+          name: "lodestar_oppool_attestation_pool_size",
+          help: "Current size of the AttestationPool = total attestations unique by data and slot",
+        }),
+        gossipInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
+          name: "lodestar_attestation_pool_insert_outcome_total",
+          help: "Total number of InsertOutcome as a result of adding a gossip attestation in a pool",
+          labelNames: ["insertOutcome"],
+        }),
+        apiInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
+          name: "lodestar_attestation_pool_api_insert_outcome_total",
+          help: "Total number of InsertOutcome as a result of adding an attestation from api in a pool",
+          labelNames: ["insertOutcome"],
+        }),
+        getAggregateCacheMisses: register.counter({
+          name: "lodestar_attestation_pool_get_aggregate_cache_misses_total",
+          help: "Total number of getAggregate calls with no aggregate for slot, attestation data root, and committee index",
+        }),
+      },
       attesterSlashingPoolSize: register.gauge({
         name: "lodestar_oppool_attester_slashing_pool_size",
         help: "Current size of the AttesterSlashingPool",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -269,9 +269,10 @@ export function createLodestarMetrics(
       producedAggregateParticipants: register.histogram({
         name: "lodestar_produced_aggregate_participants",
         help: "API impl produced aggregates histogram of participants",
-        // We care more about tracking low quality aggregates with low participation
+        // We expect most aggregates to have 400-600 participants depending on the
+        // validator count of the network, anything lower than that is not acceptable
         // Max committee sizes are: 1e6 vc: 488, 1.1e6 vc: 537, 1.4e6 vc: 683
-        buckets: [1, 5, 25, 50, 100, 200, 300, 400, 500, 600],
+        buckets: [1, 25, 50, 100, 250, 400, 500, 600],
       }),
       producedSyncContributionParticipants: register.histogram({
         name: "lodestar_produced_sync_contribution_participants",

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -659,7 +659,7 @@ function getBatchHandlers(modules: ValidatorFnsModules, options: GossipHandlerOp
               committeeValidatorIndex,
               committeeSize
             );
-            metrics?.opPool.attestationPoolGossipInsertOutcome.inc({insertOutcome});
+            metrics?.opPool.attestationPool.gossipInsertOutcome.inc({insertOutcome});
           }
         } catch (e) {
           logger.error("Error adding unaggregated attestation to pool", {subnet}, e as Error);

--- a/packages/beacon-node/test/unit/chain/opPools/attestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/attestationPool.test.ts
@@ -73,7 +73,7 @@ describe("AttestationPool", () => {
     );
 
     expect(outcome).equal(InsertOutcome.NewData);
-    expect(pool.getAggregate(electraAttestationData.slot, committeeIndex, attDataRootHex)).toEqual(electraAttestation);
+    expect(pool.getAggregate(electraAttestationData.slot, attDataRootHex, committeeIndex)).toEqual(electraAttestation);
   });
 
   it("add correct phase0 attestation", () => {
@@ -82,10 +82,10 @@ describe("AttestationPool", () => {
     const outcome = pool.add(committeeIndex, phase0Attestation, attDataRootHex, committeeValidatorIndex, committeeSize);
 
     expect(outcome).equal(InsertOutcome.NewData);
-    expect(pool.getAggregate(phase0AttestationData.slot, committeeIndex, attDataRootHex)).toEqual(phase0Attestation);
-    expect(pool.getAggregate(phase0AttestationData.slot, 10, attDataRootHex)).toEqual(phase0Attestation);
-    expect(pool.getAggregate(phase0AttestationData.slot, 42, attDataRootHex)).toEqual(phase0Attestation);
-    expect(pool.getAggregate(phase0AttestationData.slot, null, attDataRootHex)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, attDataRootHex, committeeIndex)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, attDataRootHex, 10)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, attDataRootHex, 42)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, attDataRootHex, null)).toEqual(phase0Attestation);
   });
 
   it("add electra attestation without committee index", () => {
@@ -95,7 +95,7 @@ describe("AttestationPool", () => {
     expect(() =>
       pool.add(committeeIndex, electraSingleAttestation, attDataRootHex, committeeValidatorIndex, committeeSize)
     ).toThrow();
-    expect(pool.getAggregate(electraAttestationData.slot, committeeIndex, attDataRootHex)).toBeNull();
+    expect(pool.getAggregate(electraAttestationData.slot, attDataRootHex, committeeIndex)).toBeNull();
   });
 
   it("add phase0 attestation with committee index", () => {
@@ -104,10 +104,10 @@ describe("AttestationPool", () => {
     const outcome = pool.add(committeeIndex, phase0Attestation, attDataRootHex, committeeValidatorIndex, committeeSize);
 
     expect(outcome).equal(InsertOutcome.NewData);
-    expect(pool.getAggregate(phase0AttestationData.slot, committeeIndex, attDataRootHex)).toEqual(phase0Attestation);
-    expect(pool.getAggregate(phase0AttestationData.slot, 123, attDataRootHex)).toEqual(phase0Attestation);
-    expect(pool.getAggregate(phase0AttestationData.slot, 456, attDataRootHex)).toEqual(phase0Attestation);
-    expect(pool.getAggregate(phase0AttestationData.slot, null, attDataRootHex)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, attDataRootHex, committeeIndex)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, attDataRootHex, 123)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, attDataRootHex, 456)).toEqual(phase0Attestation);
+    expect(pool.getAggregate(phase0AttestationData.slot, attDataRootHex, null)).toEqual(phase0Attestation);
   });
 
   it("add electra attestation with phase0 slot", () => {

--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -131,7 +131,7 @@ export function getMetrics(register: MetricsRegisterExtra, gitData: LodestarGitD
     numParticipantsInAggregate: register.histogram({
       name: "vc_attestation_service_participants_in_aggregate_total",
       help: "Number of attestations in the published AggregatedAttestation",
-      buckets: [0, 50, 200, 500],
+      buckets: [1, 5, 25, 50, 100, 200, 300, 400, 500, 600],
     }),
 
     attestaterError: register.gauge<{error: "produce" | "sign" | "publish"}>({

--- a/packages/validator/src/metrics.ts
+++ b/packages/validator/src/metrics.ts
@@ -131,7 +131,7 @@ export function getMetrics(register: MetricsRegisterExtra, gitData: LodestarGitD
     numParticipantsInAggregate: register.histogram({
       name: "vc_attestation_service_participants_in_aggregate_total",
       help: "Number of attestations in the published AggregatedAttestation",
-      buckets: [1, 5, 25, 50, 100, 200, 300, 400, 500, 600],
+      buckets: [1, 25, 50, 100, 250, 400, 500, 600],
     }),
 
     attestaterError: register.gauge<{error: "produce" | "sign" | "publish"}>({


### PR DESCRIPTION
**Motivation**

- we lack a metrics to track get aggregate cache misses and [need to use logs](https://github.com/ChainSafe/lodestar/issues/7548#issuecomment-2716881021) to determine it which is not ideal 
- aggregate participation metric buckets lack granularity and just show `+Inf` which make the metric less useful since most / all aggregates fall into this category
- allows to better investigate https://github.com/ChainSafe/lodestar/issues/7548

**Description**

- adjust aggregate participation metric buckets to get more meaningful data
- add metrics to track get aggregate cache misses, ie. total number of `getAggregate` calls with no aggregate for slot, attestation data root, and committee index
- slight refactoring to group attestation pool metrics similar to https://github.com/ChainSafe/lodestar/pull/7656
- reorder function parameters and logs to better map to how data is stored internally in attestation pool cache

We mostly have dashboard panels for those already but will add few more in a separate PR.
