### PR TITLE
chore: add organize imports to VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.biome": "explicit",
+    "source.organizeImports.biome": "explicit"
   },
   "[javascript]": {
     "editor.defaultFormatter": "biomejs.biome"


### PR DESCRIPTION
**Motivation**

The VS Code settings file has linting and formatting enabled on save, but not organizing imports. I think enabling this would help fix some Biome errors before they're caught in CI. 

<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**

Adds `"source.organizeImports.biome": "explicit"` to `.vscode/settings.json`

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
