### PR TITLE
feat: sort packed attestations by total effective balance

### DIFF
--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -694,7 +694,6 @@ export class MatchingDataAttestationGroup {
     const isPostElectra = isForkPostElectra(fork);
 
     let maxNewSeenEffectiveBalance = 0;
-    let newSeenAttesters = 0;
     let mostValuableAttestation: AttestationNonParticipant | null = null;
     for (const {attestation} of this.attestations) {
       if (
@@ -712,6 +711,7 @@ export class MatchingDataAttestationGroup {
 
       // we prioritize total effective balance over attester count
       let newSeenEffectiveBalance = 0;
+      let newSeenAttesters = 0;
       const {aggregationBits} = attestation;
       for (const notSeenIndex of notSeenAttestingIndices) {
         if (aggregationBits.get(notSeenIndex)) {

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -57,7 +57,8 @@ export type AttestationsConsolidation = {
   totalNewSeenEffectiveBalance: number;
   newSeenAttesters: number;
   notSeenAttesters: number;
-  committeeMembers: number;
+  // total number of committee members across all committees in this consolidation
+  crossCommitteeMembers: number;
 };
 
 /**
@@ -96,9 +97,11 @@ const MAX_ATTESTATIONS_PER_GROUP = 3;
 
 /**
  * For electra, there is on chain aggregation of attestations across committees, so we can just pick up to 8
- * attestations per group, sort by scores get get first 8.
- * The new algorithm is improved to get most valuable attestation helped not to get not-useful attestations anyway.
+ * attestations per group, sort by scores to get first 8.
+ * The new algorithm helps not to inlclude useless attestations so we usually cannot get up to 8.
  * The more consolidations we have per block, the less likely we have to scan all slots in the pool.
+ * This is max attestations returned per group, it does not make sense to have this number greater than MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA
+ * and MAX_ATTESTATIONS_ELECTRA.
  */
 const MAX_ATTESTATIONS_PER_GROUP_ELECTRA = Math.min(
   MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA,
@@ -344,11 +347,15 @@ export class AggregatedAttestationPool {
       }
 
       const epoch = computeEpochAtSlot(slot);
+      if (epoch < statePrevEpoch) {
+        // we process slot in desc order, this means next slot is not eligible, we should stop
+        stopReason = ScannedSlotsTerminationReason.SlotBeforePreviousEpoch;
+        break;
+      }
+
       // validateAttestation condition: Attestation target epoch not in previous or current epoch
       if (!(epoch === stateEpoch || epoch === statePrevEpoch)) {
-        // we process slot in desc order, this means slot is out of current or previous epoch, we should stop
-        stopReason = ScannedSlotsTerminationReason.SlotBeforePreviousEpoch;
-        break; // Invalid attestations
+        continue; // Invalid attestations
       }
 
       // validateAttestation condition: Attestation slot not within inclusion window
@@ -409,7 +416,7 @@ export class AggregatedAttestationPool {
                 totalNewSeenEffectiveBalance: 0,
                 newSeenAttesters: 0,
                 notSeenAttesters: 0,
-                committeeMembers: 0,
+                crossCommitteeMembers: 0,
               };
             }
             const sameAttDataCon = sameAttDataCons[i];
@@ -419,7 +426,7 @@ export class AggregatedAttestationPool {
               sameAttDataCon.totalNewSeenEffectiveBalance += attestationNonParticipation.newSeenEffectiveBalance;
               sameAttDataCon.newSeenAttesters += attestationNonParticipation.newSeenAttesters;
               sameAttDataCon.notSeenAttesters += attestationNonParticipation.notSeenAttendingIndices.size;
-              sameAttDataCon.committeeMembers += attestationGroup.committee.length;
+              sameAttDataCon.crossCommitteeMembers += attestationGroup.committee.length;
             }
           }
         } // all committees are processed
@@ -456,7 +463,7 @@ export class AggregatedAttestationPool {
       // record metrics of packed attestations
       const committeeCount = consolidation.byCommittee.size;
       packedAttestationsMetrics?.committeeBits.set({index: i}, committeeCount);
-      packedAttestationsMetrics?.committeeMembers.set({index: i}, consolidation.committeeMembers);
+      packedAttestationsMetrics?.crossCommitteeMembers.set({index: i}, consolidation.crossCommitteeMembers);
       packedAttestationsMetrics?.nonParticipation.set({index: i}, consolidation.notSeenAttesters);
       packedAttestationsMetrics?.inclusionDistance.set({index: i}, stateSlot - packedAttestations[i].data.slot);
       packedAttestationsMetrics?.newSeenAttesters.set({index: i}, consolidation.newSeenAttesters);
@@ -644,7 +651,7 @@ export class MatchingDataAttestationGroup {
 
   /**
    * Get AttestationNonParticipant for this groups of same attestation data.
-   * @param notSeenCommitteeMembers not seen attestting indices, i.e. indices in the same committee
+   * @param notSeenCommitteeMembers not seen attesting indices, i.e. indices in the same committee
    * @returns an array of AttestationNonParticipant
    */
   getAttestationsForBlock(
@@ -678,9 +685,9 @@ export class MatchingDataAttestationGroup {
   }
 
   /**
-   * Most valuable attestation is attestation has the most effective balance of not seen validators.
+   * Select the attestation with the highest total effective balance of not seen validators.
    */
-  getMostValuableAttestation(
+  private getMostValuableAttestation(
     fork: ForkName,
     effectiveBalanceIncrements: EffectiveBalanceIncrements,
     notSeenAttestingIndices: Set<number>,

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -57,7 +57,7 @@ export type AttestationsConsolidation = {
   totalNewSeenEffectiveBalance: number;
   newSeenAttesters: number;
   notSeenAttesters: number;
-  committeeSize: number;
+  committeeMembers: number;
 };
 
 /**
@@ -409,13 +409,18 @@ export class AggregatedAttestationPool {
                 totalNewSeenEffectiveBalance: 0,
                 newSeenAttesters: 0,
                 notSeenAttesters: 0,
-                committeeSize: attestationGroup.committee.length,
+                committeeMembers: 0,
               };
             }
-            sameAttDataCons[i].byCommittee.set(committeeIndex, attestationNonParticipation);
-            sameAttDataCons[i].totalNewSeenEffectiveBalance += attestationNonParticipation.newSeenEffectiveBalance;
-            sameAttDataCons[i].newSeenAttesters += attestationNonParticipation.newSeenAttesters;
-            sameAttDataCons[i].notSeenAttesters += attestationNonParticipation.notSeenAttendingIndices.size;
+            const sameAttDataCon = sameAttDataCons[i];
+            // committeeIndex was from a map so it should be unique, but just in case
+            if (!sameAttDataCon.byCommittee.has(committeeIndex)) {
+              sameAttDataCon.byCommittee.set(committeeIndex, attestationNonParticipation);
+              sameAttDataCon.totalNewSeenEffectiveBalance += attestationNonParticipation.newSeenEffectiveBalance;
+              sameAttDataCon.newSeenAttesters += attestationNonParticipation.newSeenAttesters;
+              sameAttDataCon.notSeenAttesters += attestationNonParticipation.notSeenAttendingIndices.size;
+              sameAttDataCon.committeeMembers += attestationGroup.committee.length;
+            }
           }
         } // all committees are processed
 
@@ -451,7 +456,7 @@ export class AggregatedAttestationPool {
       // record metrics of packed attestations
       const committeeCount = consolidation.byCommittee.size;
       packedAttestationsMetrics?.committeeBits.set({index: i}, committeeCount);
-      packedAttestationsMetrics?.committeeMembers.set({index: i}, consolidation.committeeSize * committeeCount);
+      packedAttestationsMetrics?.committeeMembers.set({index: i}, consolidation.committeeMembers);
       packedAttestationsMetrics?.nonParticipation.set({index: i}, consolidation.notSeenAttesters);
       packedAttestationsMetrics?.inclusionDistance.set({index: i}, stateSlot - packedAttestations[i].data.slot);
       packedAttestationsMetrics?.newSeenAttesters.set({index: i}, consolidation.newSeenAttesters);
@@ -705,7 +710,7 @@ export class MatchingDataAttestationGroup {
 
       const notSeen = new Set<number>();
 
-      // from electra, we prioritize total effective balance over attester count
+      // we prioritize total effective balance over attester count
       let newSeenEffectiveBalance = 0;
       const {aggregationBits} = attestation;
       for (const notSeenIndex of notSeenAttestingIndices) {

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -17,6 +17,7 @@ import {
   CachedBeaconStateAllForks,
   CachedBeaconStateAltair,
   CachedBeaconStatePhase0,
+  EffectiveBalanceIncrements,
   computeEpochAtSlot,
   computeSlotsSinceEpochStart,
   computeStartSlotAtEpoch,
@@ -53,7 +54,10 @@ type AttestationWithScore = {attestation: Attestation; score: number};
 export type AttestationsConsolidation = {
   byCommittee: Map<CommitteeIndex, AttestationNonParticipant>;
   attData: phase0.AttestationData;
-  totalNotSeenCount: number;
+  totalNewSeenEffectiveBalance: number;
+  newSeenAttesters: number;
+  notSeenAttesters: number;
+  committeeSize: number;
 };
 
 /**
@@ -73,6 +77,15 @@ type ValidateAttestationDataFn = (attData: phase0.AttestationData) => boolean;
 const MAX_RETAINED_ATTESTATIONS_PER_GROUP = 4;
 
 /**
+ * This is the same to MAX_RETAINED_ATTESTATIONS_PER_GROUP but for electra
+ * As monitored in hoodi, max attestations per group could be up to > 10. But in electra we can
+ * consolidate attestations across committees, so we can just pick up to 8 attestations per group.
+ * Also the MatchingDataAttestationGroup.getAttestationsForBlock() is improved not to have to scan each
+ * committee member for previous slot.
+ */
+const MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA = 8;
+
+/**
  * Pre-electra, each slot has 64 committees, and each block has 128 attestations max so in average
  * we get 2 attestation per groups.
  * Starting from Jan 2024, we have a performance issue getting attestations for a block. Based on the
@@ -82,11 +95,21 @@ const MAX_RETAINED_ATTESTATIONS_PER_GROUP = 4;
 const MAX_ATTESTATIONS_PER_GROUP = 3;
 
 /**
- * For electra, each block has up to 8 aggregated attestations, assuming there are 3 for the "best"
- * attestation data, there are still 5 for other attestation data so this constant is still good.
- * We should separate to 2 constant based on conditions of different networks
+ * For electra, there is on chain aggregation of attestations across committees, so we can just pick up to 8
+ * attestations per group, sort by scores get get first 8.
+ * The new algorithm is improved to get most valuable attestation helped not to get not-useful attestations anyway.
+ * The more consolidations we have per block, the less likely we have to scan all slots in the pool.
  */
-const MAX_ATTESTATIONS_PER_GROUP_ELECTRA = 3;
+const MAX_ATTESTATIONS_PER_GROUP_ELECTRA = Math.min(
+  MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA,
+  MAX_ATTESTATIONS_ELECTRA
+);
+
+export enum ScannedSlotsTerminationReason {
+  MaxConsolidationReached = "max_consolidation_reached",
+  ScannedAllSlots = "scanned_all_slots",
+  SlotBeforePreviousEpoch = "slot_before_previous_epoch",
+}
 
 /**
  * Maintain a pool of aggregated attestations. Attestations can be retrieved for inclusion in a block
@@ -151,7 +174,7 @@ export class AggregatedAttestationPool {
     assert.notNull(committeeIndex, "Committee index should not be null in aggregated attestation pool");
     let attestationGroup = attestationGroupByIndex.get(committeeIndex);
     if (!attestationGroup) {
-      attestationGroup = new MatchingDataAttestationGroup(committee, attestation.data);
+      attestationGroup = new MatchingDataAttestationGroup(this.config, committee, attestation.data);
       attestationGroupByIndex.set(committeeIndex, attestationGroup);
     }
 
@@ -257,11 +280,13 @@ export class AggregatedAttestationPool {
           // These properties should not change after being validate in gossip
           // IF they have to be validated, do it only with one attestation per group since same data
           // The committeeCountPerSlot can be precomputed once per slot
-          for (const {attestation, notSeenAttesterCount} of attestationGroup.getAttestationsForBlock(
+          for (const {attestation, newSeenEffectiveBalance} of attestationGroup.getAttestationsForBlock(
             fork,
-            notSeenAttestingIndices
+            state.epochCtx.effectiveBalanceIncrements,
+            notSeenAttestingIndices,
+            MAX_ATTESTATIONS_PER_GROUP
           )) {
-            const score = notSeenAttesterCount / slotDelta;
+            const score = newSeenEffectiveBalance / slotDelta;
             if (score < minScore) {
               minScore = score;
             }
@@ -309,6 +334,8 @@ export class AggregatedAttestationPool {
     const slots = Array.from(this.attestationGroupByIndexByDataHexBySlot.keys()).sort((a, b) => b - a);
     // Track score of each `AttestationsConsolidation`
     const consolidations = new Map<AttestationsConsolidation, number>();
+    let scannedSlots = 0;
+    let stopReason: ScannedSlotsTerminationReason | null = null;
     slot: for (const slot of slots) {
       const attestationGroupByIndexByDataHash = this.attestationGroupByIndexByDataHexBySlot.get(slot);
       // should not happen
@@ -319,15 +346,19 @@ export class AggregatedAttestationPool {
       const epoch = computeEpochAtSlot(slot);
       // validateAttestation condition: Attestation target epoch not in previous or current epoch
       if (!(epoch === stateEpoch || epoch === statePrevEpoch)) {
-        continue; // Invalid attestations
+        // we process slot in desc order, this means slot is out of current or previous epoch, we should stop
+        stopReason = ScannedSlotsTerminationReason.SlotBeforePreviousEpoch;
+        break; // Invalid attestations
       }
+
       // validateAttestation condition: Attestation slot not within inclusion window
       if (!(slot + MIN_ATTESTATION_INCLUSION_DELAY <= stateSlot)) {
+        // this should not happen and slot is decreased so no need to track in metric
         continue; // Invalid attestations
       }
 
       const slotDelta = stateSlot - slot;
-      // CommitteeIndex    0           1            2    ...   Consolidationn (sameAttDataCons)
+      // CommitteeIndex    0           1            2    ...   Consolidation (sameAttDataCons)
       // Attestations    att00  ---   att10  ---  att20  ---   0 (att 00 10 20)
       //                 att01  ---     -    ---  att21  ---   1 (att 01 __ 21)
       //                   -    ---     -    ---  att22  ---   2 (att __ __ 22)
@@ -336,16 +367,19 @@ export class AggregatedAttestationPool {
         const sameAttDataCons: AttestationsConsolidation[] = [];
         const allAttestationGroups = Array.from(attestationGroupByIndex.values());
         if (allAttestationGroups.length === 0) {
+          this.metrics?.opPool.aggregatedAttestationPool.packedAttestations.emptyAttestationData.inc();
           continue;
         }
 
         if (!validateAttestationDataFn(allAttestationGroups[0].data)) {
+          this.metrics?.opPool.aggregatedAttestationPool.packedAttestations.invalidAttestationData.inc();
           continue;
         }
 
         for (const [committeeIndex, attestationGroup] of attestationGroupByIndex.entries()) {
           const notSeenAttestingIndices = notSeenValidatorsFn(epoch, slot, committeeIndex);
           if (notSeenAttestingIndices === null || notSeenAttestingIndices.size === 0) {
+            this.metrics?.opPool.aggregatedAttestationPool.packedAttestations.seenCommittees.inc();
             continue;
           }
 
@@ -359,40 +393,78 @@ export class AggregatedAttestationPool {
           // These properties should not change after being validate in gossip
           // IF they have to be validated, do it only with one attestation per group since same data
           // The committeeCountPerSlot can be precomputed once per slot
-          for (const [i, attestationNonParticipation] of attestationGroup
-            .getAttestationsForBlock(fork, notSeenAttestingIndices)
-            .entries()) {
+          const attestationsSameGroup = attestationGroup.getAttestationsForBlock(
+            fork,
+            state.epochCtx.effectiveBalanceIncrements,
+            notSeenAttestingIndices,
+            MAX_ATTESTATIONS_PER_GROUP_ELECTRA
+          );
+
+          for (const [i, attestationNonParticipation] of attestationsSameGroup.entries()) {
+            // sameAttDataCons shares the same index for different committees so we use index `i` here
             if (sameAttDataCons[i] === undefined) {
               sameAttDataCons[i] = {
                 byCommittee: new Map(),
                 attData: attestationNonParticipation.attestation.data,
-                totalNotSeenCount: 0,
+                totalNewSeenEffectiveBalance: 0,
+                newSeenAttesters: 0,
+                notSeenAttesters: 0,
+                committeeSize: attestationGroup.committee.length,
               };
             }
             sameAttDataCons[i].byCommittee.set(committeeIndex, attestationNonParticipation);
-            sameAttDataCons[i].totalNotSeenCount += attestationNonParticipation.notSeenAttesterCount;
+            sameAttDataCons[i].totalNewSeenEffectiveBalance += attestationNonParticipation.newSeenEffectiveBalance;
+            sameAttDataCons[i].newSeenAttesters += attestationNonParticipation.newSeenAttesters;
+            sameAttDataCons[i].notSeenAttesters += attestationNonParticipation.notSeenAttendingIndices.size;
           }
         } // all committees are processed
 
         // after all committees are processed, we have a list of sameAttDataCons
         for (const consolidation of sameAttDataCons) {
-          const score = consolidation.totalNotSeenCount / slotDelta;
+          const score = consolidation.totalNewSeenEffectiveBalance / slotDelta;
           consolidations.set(consolidation, score);
-
           // Stop accumulating attestations there are enough that may have good scoring
           if (consolidations.size >= MAX_ATTESTATIONS_ELECTRA * 2) {
+            stopReason = ScannedSlotsTerminationReason.MaxConsolidationReached;
             break slot;
           }
         }
       }
+
+      // finished processing a slot
+      scannedSlots++;
     }
+
+    this.metrics?.opPool.aggregatedAttestationPool.packedAttestations.totalConsolidations.set(consolidations.size);
+
     const sortedConsolidationsByScore = Array.from(consolidations.entries())
       .sort((a, b) => b[1] - a[1])
       .map(([consolidation, _]) => consolidation)
       .slice(0, MAX_ATTESTATIONS_ELECTRA);
 
     // on chain aggregation is expensive, only do it after all
-    return sortedConsolidationsByScore.map(aggregateConsolidation);
+    const packedAttestationsMetrics = this.metrics?.opPool.aggregatedAttestationPool.packedAttestations;
+    const packedAttestations: electra.Attestation[] = new Array(sortedConsolidationsByScore.length);
+    for (const [i, consolidation] of sortedConsolidationsByScore.entries()) {
+      packedAttestations[i] = aggregateConsolidation(consolidation);
+
+      // record metrics of packed attestations
+      const committeeCount = consolidation.byCommittee.size;
+      packedAttestationsMetrics?.committeeBits.set({index: i}, committeeCount);
+      packedAttestationsMetrics?.committeeMembers.set({index: i}, consolidation.committeeSize * committeeCount);
+      packedAttestationsMetrics?.nonParticipation.set({index: i}, consolidation.notSeenAttesters);
+      packedAttestationsMetrics?.inclusionDistance.set({index: i}, stateSlot - packedAttestations[i].data.slot);
+      packedAttestationsMetrics?.newSeenAttesters.set({index: i}, consolidation.newSeenAttesters);
+      packedAttestationsMetrics?.totalEffectiveBalance.set({index: i}, consolidation.totalNewSeenEffectiveBalance);
+    }
+
+    if (stopReason === null) {
+      stopReason = ScannedSlotsTerminationReason.ScannedAllSlots;
+    }
+    packedAttestationsMetrics?.scannedSlots.set({reason: stopReason}, scannedSlots);
+    packedAttestationsMetrics?.totalSlots.set(slots.length);
+
+    return packedAttestations;
   }
 
   /**
@@ -483,9 +555,12 @@ interface AttestationWithIndex {
 
 type AttestationNonParticipant = {
   attestation: Attestation;
-  // this is <= attestingIndices.count since some attesters may be seen by the chain
+  // this was `notSeenAttesterCount` in pre-electra
+  // since electra, we prioritize total effective balance over attester count
   // this is only updated and used in removeBySeenValidators function
-  notSeenAttesterCount: number;
+  newSeenEffectiveBalance: number;
+  newSeenAttesters: number;
+  notSeenAttendingIndices: Set<number>;
 };
 
 /**
@@ -498,7 +573,7 @@ export class MatchingDataAttestationGroup {
   private readonly attestations: AttestationWithIndex[] = [];
 
   constructor(
-    // TODO: no need committee here
+    private readonly config: ChainForkConfig,
     readonly committee: Uint32Array,
     readonly data: phase0.AttestationData
   ) {}
@@ -547,13 +622,16 @@ export class MatchingDataAttestationGroup {
 
     this.attestations.push(attestation);
 
+    const maxRetained = isForkPostElectra(this.config.getForkName(this.data.slot))
+      ? MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA
+      : MAX_RETAINED_ATTESTATIONS_PER_GROUP;
+
     // Remove the attestations with less participation
-    if (this.attestations.length > MAX_RETAINED_ATTESTATIONS_PER_GROUP) {
+    if (this.attestations.length > maxRetained) {
+      // ideally we should sort by effective balance but there is no state/effectiveBalance here
+      // it's rare to see > 8 attestations per group in electra anyway
       this.attestations.sort((a, b) => b.trueBitsCount - a.trueBitsCount);
-      this.attestations.splice(
-        MAX_RETAINED_ATTESTATIONS_PER_GROUP,
-        this.attestations.length - MAX_RETAINED_ATTESTATIONS_PER_GROUP
-      );
+      this.attestations.splice(maxRetained, this.attestations.length - maxRetained);
     }
 
     return InsertOutcome.NewData;
@@ -561,12 +639,58 @@ export class MatchingDataAttestationGroup {
 
   /**
    * Get AttestationNonParticipant for this groups of same attestation data.
-   * @param notSeenAttestingIndices not seen attestting indices, i.e. indices in the same committee
+   * @param notSeenCommitteeMembers not seen attestting indices, i.e. indices in the same committee
    * @returns an array of AttestationNonParticipant
    */
-  getAttestationsForBlock(fork: ForkName, notSeenAttestingIndices: Set<number>): AttestationNonParticipant[] {
+  getAttestationsForBlock(
+    fork: ForkName,
+    effectiveBalanceIncrements: EffectiveBalanceIncrements,
+    notSeenAttestingIndices: Set<number>,
+    maxAttestation: number
+  ): AttestationNonParticipant[] {
     const attestations: AttestationNonParticipant[] = [];
+    const excluded = new Set<Attestation>();
+    for (let i = 0; i < maxAttestation; i++) {
+      const mostValuableAttestation = this.getMostValuableAttestation(
+        fork,
+        effectiveBalanceIncrements,
+        notSeenAttestingIndices,
+        excluded
+      );
+
+      if (mostValuableAttestation === null) {
+        // stop looking for attestation because all attesters are seen or no attestation has missing attesters
+        break;
+      }
+
+      attestations.push(mostValuableAttestation);
+      excluded.add(mostValuableAttestation.attestation);
+      // this will narrow down the notSeenAttestingIndices for the next iteration
+      notSeenAttestingIndices = mostValuableAttestation.notSeenAttendingIndices;
+    }
+
+    return attestations;
+  }
+
+  /**
+   * Most valuable attestation is attestation has the most effective balance of not seen validators.
+   */
+  getMostValuableAttestation(
+    fork: ForkName,
+    effectiveBalanceIncrements: EffectiveBalanceIncrements,
+    notSeenAttestingIndices: Set<number>,
+    excluded: Set<Attestation>
+  ): AttestationNonParticipant | null {
+    if (notSeenAttestingIndices.size === 0) {
+      // no more attesters to consider
+      return null;
+    }
+
     const isPostElectra = isForkPostElectra(fork);
+
+    let maxNewSeenEffectiveBalance = 0;
+    let newSeenAttesters = 0;
+    let mostValuableAttestation: AttestationNonParticipant | null = null;
     for (const {attestation} of this.attestations) {
       if (
         (isPostElectra && !isElectraAttestation(attestation)) ||
@@ -575,25 +699,36 @@ export class MatchingDataAttestationGroup {
         continue;
       }
 
-      let notSeenAttesterCount = 0;
+      if (excluded.has(attestation)) {
+        continue;
+      }
+
+      const notSeen = new Set<number>();
+
+      // from electra, we prioritize total effective balance over attester count
+      let newSeenEffectiveBalance = 0;
       const {aggregationBits} = attestation;
       for (const notSeenIndex of notSeenAttestingIndices) {
         if (aggregationBits.get(notSeenIndex)) {
-          notSeenAttesterCount++;
+          newSeenEffectiveBalance += effectiveBalanceIncrements[this.committee[notSeenIndex]];
+          newSeenAttesters++;
+        } else {
+          notSeen.add(notSeenIndex);
         }
       }
 
-      if (notSeenAttesterCount > 0) {
-        attestations.push({attestation, notSeenAttesterCount});
+      if (newSeenEffectiveBalance > maxNewSeenEffectiveBalance) {
+        maxNewSeenEffectiveBalance = newSeenEffectiveBalance;
+        mostValuableAttestation = {
+          attestation,
+          newSeenEffectiveBalance,
+          newSeenAttesters,
+          notSeenAttendingIndices: notSeen,
+        };
       }
     }
 
-    const maxAttestation = isPostElectra ? MAX_ATTESTATIONS_PER_GROUP_ELECTRA : MAX_ATTESTATIONS_PER_GROUP;
-    if (attestations.length <= maxAttestation) {
-      return attestations;
-    }
-
-    return attestations.sort((a, b) => b.notSeenAttesterCount - a.notSeenAttesterCount).slice(0, maxAttestation);
+    return mostValuableAttestation;
   }
 
   /** Get attestations for API. */
@@ -644,13 +779,14 @@ export function aggregateConsolidation({byCommittee, attData}: AttestationsConso
  * has already attested or not.
  */
 export function getNotSeenValidatorsFn(state: CachedBeaconStateAllForks): GetNotSeenValidatorsFn {
-  if (state.config.getForkName(state.slot) === ForkName.phase0) {
+  const stateSlot = state.slot;
+  if (state.config.getForkName(stateSlot) === ForkName.phase0) {
     // Get attestations to be included in a phase0 block.
     // As we are close to altair, this is not really important, it's mainly for e2e.
     // The performance is not great due to the different BeaconState data structure to altair.
     // check for phase0 block already
     const phase0State = state as CachedBeaconStatePhase0;
-    const stateEpoch = computeEpochAtSlot(state.slot);
+    const stateEpoch = computeEpochAtSlot(stateSlot);
 
     const previousEpochParticipants = extractParticipationPhase0(
       phase0State.previousEpochAttestations.getAllReadonly(),
@@ -687,7 +823,7 @@ export function getNotSeenValidatorsFn(state: CachedBeaconStateAllForks): GetNot
   const altairState = state as CachedBeaconStateAltair;
   const previousParticipation = altairState.previousEpochParticipation.getAll();
   const currentParticipation = altairState.currentEpochParticipation.getAll();
-  const stateEpoch = computeEpochAtSlot(state.slot);
+  const stateEpoch = computeEpochAtSlot(stateSlot);
   // this function could be called multiple times with same slot + committeeIndex
   const cachedNotSeenValidators = new Map<string, Set<number>>();
 
@@ -709,7 +845,8 @@ export function getNotSeenValidatorsFn(state: CachedBeaconStateAllForks): GetNot
     notSeenAttestingIndices = new Set<number>();
     for (const [i, validatorIndex] of committee.entries()) {
       // no need to check flagIsTimelySource as if validator is not seen, it's participation status is 0
-      if (participationStatus[validatorIndex] === 0) {
+      // attestations for the previous slot are not included in the state, so we don't need to check for them
+      if (slot === stateSlot - 1 || participationStatus[validatorIndex] === 0) {
         notSeenAttestingIndices.add(i);
       }
     }
@@ -753,7 +890,7 @@ export function getValidateAttestationDataFn(
   forkChoice: IForkChoice,
   state: CachedBeaconStateAllForks
 ): ValidateAttestationDataFn {
-  const cachedValidatedAttestationData = new Map<RootHex, boolean>();
+  const cachedValidatedAttestationData = new Map<string, boolean>();
   const {previousJustifiedCheckpoint, currentJustifiedCheckpoint} = state;
   const stateEpoch = state.epochCtx.epoch;
   return (attData: phase0.AttestationData) => {
@@ -768,7 +905,9 @@ export function getValidateAttestationDataFn(
       return false;
     }
 
-    if (!ssz.phase0.Checkpoint.equals(attData.source, justifiedCheckpoint)) return false;
+    if (!ssz.phase0.Checkpoint.equals(attData.source, justifiedCheckpoint)) {
+      return false;
+    }
 
     // Shuffling can't have changed if we're in the first few epochs
     // Also we can't look back 2 epochs if target epoch is 1 or less

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -477,7 +477,7 @@ export class AggregatedAttestationPool {
 
       // record metrics of packed attestations
       const committeeCount = consolidation.byCommittee.size;
-      packedAttestationsMetrics?.committeeBits.set({index: i}, committeeCount);
+      packedAttestationsMetrics?.committeeCount.set({index: i}, committeeCount);
       packedAttestationsMetrics?.totalAttesters.set({index: i}, consolidation.totalAttesters);
       packedAttestationsMetrics?.nonParticipation.set({index: i}, consolidation.notSeenAttesters);
       packedAttestationsMetrics?.inclusionDistance.set({index: i}, stateSlot - packedAttestations[i].data.slot);

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -283,12 +283,13 @@ export class AggregatedAttestationPool {
           // These properties should not change after being validate in gossip
           // IF they have to be validated, do it only with one attestation per group since same data
           // The committeeCountPerSlot can be precomputed once per slot
-          for (const {attestation, newSeenEffectiveBalance} of attestationGroup.getAttestationsForBlock(
+          const getAttestationsResult = attestationGroup.getAttestationsForBlock(
             fork,
             state.epochCtx.effectiveBalanceIncrements,
             notSeenCommitteeMembers,
             MAX_ATTESTATIONS_PER_GROUP
-          )) {
+          );
+          for (const {attestation, newSeenEffectiveBalance} of getAttestationsResult.result) {
             const score = newSeenEffectiveBalance / slotDelta;
             if (score < minScore) {
               minScore = score;
@@ -364,7 +365,9 @@ export class AggregatedAttestationPool {
         continue; // Invalid attestations
       }
 
-      const slotDelta = stateSlot - slot;
+      const inclusionDistance = stateSlot - slot;
+      let returnedAttestationsPerSlot = 0;
+      let totalAttestationsPerSlot = 0;
       // CommitteeIndex    0           1            2    ...   Consolidation (sameAttDataCons)
       // Attestations    att00  ---   att10  ---  att20  ---   0 (att 00 10 20)
       //                 att01  ---     -    ---  att21  ---   1 (att 01 __ 21)
@@ -400,12 +403,15 @@ export class AggregatedAttestationPool {
           // These properties should not change after being validate in gossip
           // IF they have to be validated, do it only with one attestation per group since same data
           // The committeeCountPerSlot can be precomputed once per slot
-          const attestationsSameGroup = attestationGroup.getAttestationsForBlock(
+          const getAttestationGroupResult = attestationGroup.getAttestationsForBlock(
             fork,
             state.epochCtx.effectiveBalanceIncrements,
             notSeenCommitteeMembers,
             MAX_ATTESTATIONS_PER_GROUP_ELECTRA
           );
+          const attestationsSameGroup = getAttestationGroupResult.result;
+          returnedAttestationsPerSlot += attestationsSameGroup.length;
+          totalAttestationsPerSlot += getAttestationGroupResult.totalAttestations;
 
           for (const [i, attestationNonParticipation] of attestationsSameGroup.entries()) {
             // sameAttDataCons shares the same index for different committees so we use index `i` here
@@ -431,9 +437,18 @@ export class AggregatedAttestationPool {
           }
         } // all committees are processed
 
+        this.metrics?.opPool.aggregatedAttestationPool.packedAttestations.returnedAttestations.set(
+          {inclusionDistance},
+          returnedAttestationsPerSlot
+        );
+        this.metrics?.opPool.aggregatedAttestationPool.packedAttestations.scannedAttestations.set(
+          {inclusionDistance},
+          totalAttestationsPerSlot
+        );
+
         // after all committees are processed, we have a list of sameAttDataCons
         for (const consolidation of sameAttDataCons) {
-          const score = consolidation.totalNewSeenEffectiveBalance / slotDelta;
+          const score = consolidation.totalNewSeenEffectiveBalance / inclusionDistance;
           consolidations.set(consolidation, score);
           // Stop accumulating attestations there are enough that may have good scoring
           if (consolidations.size >= MAX_ATTESTATIONS_ELECTRA * 2) {
@@ -575,6 +590,11 @@ type AttestationNonParticipant = {
   notSeenCommitteeMembers: Set<number>;
 };
 
+type GetAttestationsGroupResult = {
+  result: AttestationNonParticipant[];
+  totalAttestations: number;
+};
+
 /**
  * Maintain a pool of AggregatedAttestation which all share the same AttestationData.
  * Preaggregate into smallest number of attestations.
@@ -659,7 +679,7 @@ export class MatchingDataAttestationGroup {
     effectiveBalanceIncrements: EffectiveBalanceIncrements,
     notSeenCommitteeMembers: Set<number>,
     maxAttestation: number
-  ): AttestationNonParticipant[] {
+  ): GetAttestationsGroupResult {
     const attestations: AttestationNonParticipant[] = [];
     const excluded = new Set<Attestation>();
     for (let i = 0; i < maxAttestation; i++) {
@@ -684,7 +704,7 @@ export class MatchingDataAttestationGroup {
       notSeenCommitteeMembers = mostValuableAttestation.notSeenCommitteeMembers;
     }
 
-    return attestations;
+    return {result: attestations, totalAttestations: this.attestations.length};
   }
 
   /**

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -57,12 +57,12 @@ export type AttestationsConsolidation = {
   totalNewSeenEffectiveBalance: number;
   newSeenAttesters: number;
   notSeenAttesters: number;
-  // total number of attesters across all committees in this consolidation
+  /** total number of attesters across all committees in this consolidation */
   totalAttesters: number;
 };
 
 /**
- * This function returns not seen participation for a given epoch and slot and committe index.
+ * This function returns not seen participation for a given epoch and slot and committee index.
  * Return null if all validators are seen or no info to check.
  */
 type GetNotSeenValidatorsFn = (epoch: Epoch, slot: Slot, committeeIndex: number) => Set<number> | null;
@@ -78,8 +78,8 @@ type ValidateAttestationDataFn = (attData: phase0.AttestationData) => boolean;
 const MAX_RETAINED_ATTESTATIONS_PER_GROUP = 4;
 
 /**
- * This is the same to MAX_RETAINED_ATTESTATIONS_PER_GROUP but for electra
- * As monitored in hoodi, max attestations per group could be up to > 10. But in electra we can
+ * This is the same to MAX_RETAINED_ATTESTATIONS_PER_GROUP but for electra.
+ * As monitored in hoodi, max attestations per group could be up to > 10. But since electra we can
  * consolidate attestations across committees, so we can just pick up to 8 attestations per group.
  * Also the MatchingDataAttestationGroup.getAttestationsForBlock() is improved not to have to scan each
  * committee member for previous slot.
@@ -252,7 +252,7 @@ export class AggregatedAttestationPool {
         continue; // Invalid attestations
       }
 
-      const slotDelta = stateSlot - slot;
+      const inclusionDistance = stateSlot - slot;
       for (const attestationGroupByIndex of attestationGroupByIndexByDataHash.values()) {
         for (const [committeeIndex, attestationGroup] of attestationGroupByIndex.entries()) {
           const notSeenCommitteeMembers = notSeenValidatorsFn(epoch, slot, committeeIndex);
@@ -263,7 +263,7 @@ export class AggregatedAttestationPool {
           if (
             slotCount > 2 &&
             attestationsByScore.length >= MAX_ATTESTATIONS &&
-            notSeenCommitteeMembers.size / slotDelta < minScore
+            notSeenCommitteeMembers.size / inclusionDistance < minScore
           ) {
             // after 2 slots, there are a good chance that we have 2 * MAX_ATTESTATIONS attestations and break the for loop early
             // if not, we may have to scan all slots in the pool
@@ -290,7 +290,7 @@ export class AggregatedAttestationPool {
             MAX_ATTESTATIONS_PER_GROUP
           );
           for (const {attestation, newSeenEffectiveBalance} of getAttestationsResult.result) {
-            const score = newSeenEffectiveBalance / slotDelta;
+            const score = newSeenEffectiveBalance / inclusionDistance;
             if (score < minScore) {
               minScore = score;
             }
@@ -361,7 +361,7 @@ export class AggregatedAttestationPool {
 
       // validateAttestation condition: Attestation slot not within inclusion window
       if (!(slot + MIN_ATTESTATION_INCLUSION_DELAY <= stateSlot)) {
-        // this should not happen and slot is decreased so no need to track in metric
+        // this should not happen as slot is decreased so no need to track in metric
         continue; // Invalid attestations
       }
 
@@ -476,8 +476,7 @@ export class AggregatedAttestationPool {
       packedAttestations[i] = aggregateConsolidation(consolidation);
 
       // record metrics of packed attestations
-      const committeeCount = consolidation.byCommittee.size;
-      packedAttestationsMetrics?.committeeCount.set({index: i}, committeeCount);
+      packedAttestationsMetrics?.committeeCount.set({index: i}, consolidation.byCommittee.size);
       packedAttestationsMetrics?.totalAttesters.set({index: i}, consolidation.totalAttesters);
       packedAttestationsMetrics?.nonParticipation.set({index: i}, consolidation.notSeenAttesters);
       packedAttestationsMetrics?.inclusionDistance.set({index: i}, stateSlot - packedAttestations[i].data.slot);
@@ -584,6 +583,7 @@ type AttestationNonParticipant = {
   attestation: Attestation;
   // this was `notSeenAttesterCount` in pre-electra
   // since electra, we prioritize total effective balance over attester count
+  // as attestation value can vary significantly between validators due to EIP-7251
   // this is only updated and used in removeBySeenValidators function
   newSeenEffectiveBalance: number;
   newSeenAttesters: number;

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -255,15 +255,15 @@ export class AggregatedAttestationPool {
       const slotDelta = stateSlot - slot;
       for (const attestationGroupByIndex of attestationGroupByIndexByDataHash.values()) {
         for (const [committeeIndex, attestationGroup] of attestationGroupByIndex.entries()) {
-          const notSeenAttestingIndices = notSeenValidatorsFn(epoch, slot, committeeIndex);
-          if (notSeenAttestingIndices === null || notSeenAttestingIndices.size === 0) {
+          const notSeenCommitteeMembers = notSeenValidatorsFn(epoch, slot, committeeIndex);
+          if (notSeenCommitteeMembers === null || notSeenCommitteeMembers.size === 0) {
             continue;
           }
 
           if (
             slotCount > 2 &&
             attestationsByScore.length >= MAX_ATTESTATIONS &&
-            notSeenAttestingIndices.size / slotDelta < minScore
+            notSeenCommitteeMembers.size / slotDelta < minScore
           ) {
             // after 2 slots, there are a good chance that we have 2 * MAX_ATTESTATIONS attestations and break the for loop early
             // if not, we may have to scan all slots in the pool
@@ -286,7 +286,7 @@ export class AggregatedAttestationPool {
           for (const {attestation, newSeenEffectiveBalance} of attestationGroup.getAttestationsForBlock(
             fork,
             state.epochCtx.effectiveBalanceIncrements,
-            notSeenAttestingIndices,
+            notSeenCommitteeMembers,
             MAX_ATTESTATIONS_PER_GROUP
           )) {
             const score = newSeenEffectiveBalance / slotDelta;
@@ -384,8 +384,8 @@ export class AggregatedAttestationPool {
         }
 
         for (const [committeeIndex, attestationGroup] of attestationGroupByIndex.entries()) {
-          const notSeenAttestingIndices = notSeenValidatorsFn(epoch, slot, committeeIndex);
-          if (notSeenAttestingIndices === null || notSeenAttestingIndices.size === 0) {
+          const notSeenCommitteeMembers = notSeenValidatorsFn(epoch, slot, committeeIndex);
+          if (notSeenCommitteeMembers === null || notSeenCommitteeMembers.size === 0) {
             this.metrics?.opPool.aggregatedAttestationPool.packedAttestations.seenCommittees.inc();
             continue;
           }
@@ -403,7 +403,7 @@ export class AggregatedAttestationPool {
           const attestationsSameGroup = attestationGroup.getAttestationsForBlock(
             fork,
             state.epochCtx.effectiveBalanceIncrements,
-            notSeenAttestingIndices,
+            notSeenCommitteeMembers,
             MAX_ATTESTATIONS_PER_GROUP_ELECTRA
           );
 
@@ -425,7 +425,7 @@ export class AggregatedAttestationPool {
               sameAttDataCon.byCommittee.set(committeeIndex, attestationNonParticipation);
               sameAttDataCon.totalNewSeenEffectiveBalance += attestationNonParticipation.newSeenEffectiveBalance;
               sameAttDataCon.newSeenAttesters += attestationNonParticipation.newSeenAttesters;
-              sameAttDataCon.notSeenAttesters += attestationNonParticipation.notSeenAttestingIndices.size;
+              sameAttDataCon.notSeenAttesters += attestationNonParticipation.notSeenCommitteeMembers.size;
               sameAttDataCon.totalAttesters += attestationGroup.committee.length;
             }
           }
@@ -572,7 +572,7 @@ type AttestationNonParticipant = {
   // this is only updated and used in removeBySeenValidators function
   newSeenEffectiveBalance: number;
   newSeenAttesters: number;
-  notSeenAttestingIndices: Set<number>;
+  notSeenCommitteeMembers: Set<number>;
 };
 
 /**
@@ -651,13 +651,13 @@ export class MatchingDataAttestationGroup {
 
   /**
    * Get AttestationNonParticipant for this groups of same attestation data.
-   * @param notSeenCommitteeMembers not seen attesting indices, i.e. indices in the same committee
+   * @param notSeenCommitteeMembers not seen committee members, i.e. indices in the same committee (starting from 0 till (committee.size - 1))
    * @returns an array of AttestationNonParticipant
    */
   getAttestationsForBlock(
     fork: ForkName,
     effectiveBalanceIncrements: EffectiveBalanceIncrements,
-    notSeenAttestingIndices: Set<number>,
+    notSeenCommitteeMembers: Set<number>,
     maxAttestation: number
   ): AttestationNonParticipant[] {
     const attestations: AttestationNonParticipant[] = [];
@@ -666,7 +666,7 @@ export class MatchingDataAttestationGroup {
       const mostValuableAttestation = this.getMostValuableAttestation(
         fork,
         effectiveBalanceIncrements,
-        notSeenAttestingIndices,
+        notSeenCommitteeMembers,
         excluded
       );
 
@@ -677,11 +677,11 @@ export class MatchingDataAttestationGroup {
 
       attestations.push(mostValuableAttestation);
       excluded.add(mostValuableAttestation.attestation);
-      // this will narrow down the notSeenAttestingIndices for the next iteration
+      // this will narrow down the notSeenCommitteeMembers for the next iteration
       // so usually it will not take much time, however it could take more time during
       // non-finality of the network when there is low participation, but in this case
       // we pre-aggregate aggregated attestations and bound the total attestations per group
-      notSeenAttestingIndices = mostValuableAttestation.notSeenAttestingIndices;
+      notSeenCommitteeMembers = mostValuableAttestation.notSeenCommitteeMembers;
     }
 
     return attestations;
@@ -693,10 +693,10 @@ export class MatchingDataAttestationGroup {
   private getMostValuableAttestation(
     fork: ForkName,
     effectiveBalanceIncrements: EffectiveBalanceIncrements,
-    notSeenAttestingIndices: Set<number>,
+    notSeenCommitteeMembers: Set<number>,
     excluded: Set<Attestation>
   ): AttestationNonParticipant | null {
-    if (notSeenAttestingIndices.size === 0) {
+    if (notSeenCommitteeMembers.size === 0) {
       // no more attesters to consider
       return null;
     }
@@ -723,7 +723,7 @@ export class MatchingDataAttestationGroup {
       let newSeenEffectiveBalance = 0;
       let newSeenAttesters = 0;
       const {aggregationBits} = attestation;
-      for (const notSeenIndex of notSeenAttestingIndices) {
+      for (const notSeenIndex of notSeenCommitteeMembers) {
         if (aggregationBits.get(notSeenIndex)) {
           newSeenEffectiveBalance += effectiveBalanceIncrements[this.committee[notSeenIndex]];
           newSeenAttesters++;
@@ -738,7 +738,7 @@ export class MatchingDataAttestationGroup {
           attestation,
           newSeenEffectiveBalance,
           newSeenAttesters,
-          notSeenAttestingIndices: notSeen,
+          notSeenCommitteeMembers: notSeen,
         };
       }
     }
@@ -820,13 +820,13 @@ export function getNotSeenValidatorsFn(state: CachedBeaconStateAllForks): GetNot
       }
       const committee = state.epochCtx.getBeaconCommittee(slot, committeeIndex);
 
-      const notSeenAttestingIndices = new Set<number>();
+      const notSeenCommitteeMembers = new Set<number>();
       for (const [i, validatorIndex] of committee.entries()) {
         if (!participants.has(validatorIndex)) {
-          notSeenAttestingIndices.add(i);
+          notSeenCommitteeMembers.add(i);
         }
       }
-      return notSeenAttestingIndices.size === 0 ? null : notSeenAttestingIndices;
+      return notSeenCommitteeMembers.size === 0 ? null : notSeenCommitteeMembers;
     };
   }
 
@@ -850,24 +850,24 @@ export function getNotSeenValidatorsFn(state: CachedBeaconStateAllForks): GetNot
       return null;
     }
     const cacheKey = slot + "_" + committeeIndex;
-    let notSeenAttestingIndices = cachedNotSeenValidators.get(cacheKey);
-    if (notSeenAttestingIndices != null) {
+    let notSeenCommitteeMembers = cachedNotSeenValidators.get(cacheKey);
+    if (notSeenCommitteeMembers != null) {
       // if all validators are seen then return null, we don't need to check for any attestations of same committee again
-      return notSeenAttestingIndices.size === 0 ? null : notSeenAttestingIndices;
+      return notSeenCommitteeMembers.size === 0 ? null : notSeenCommitteeMembers;
     }
 
     const committee = state.epochCtx.getBeaconCommittee(slot, committeeIndex);
-    notSeenAttestingIndices = new Set<number>();
+    notSeenCommitteeMembers = new Set<number>();
     for (const [i, validatorIndex] of committee.entries()) {
       // no need to check flagIsTimelySource as if validator is not seen, it's participation status is 0
       // attestations for the previous slot are not included in the state, so we don't need to check for them
       if (slot === stateSlot - 1 || participationStatus[validatorIndex] === 0) {
-        notSeenAttestingIndices.add(i);
+        notSeenCommitteeMembers.add(i);
       }
     }
-    cachedNotSeenValidators.set(cacheKey, notSeenAttestingIndices);
+    cachedNotSeenValidators.set(cacheKey, notSeenCommitteeMembers);
     // if all validators are seen then return null, we don't need to check for any attestations of same committee again
-    return notSeenAttestingIndices.size === 0 ? null : notSeenAttestingIndices;
+    return notSeenCommitteeMembers.size === 0 ? null : notSeenCommitteeMembers;
   };
 }
 

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -57,8 +57,8 @@ export type AttestationsConsolidation = {
   totalNewSeenEffectiveBalance: number;
   newSeenAttesters: number;
   notSeenAttesters: number;
-  // total number of committee members across all committees in this consolidation
-  crossCommitteeMembers: number;
+  // total number of attesters across all committees in this consolidation
+  totalAttesters: number;
 };
 
 /**
@@ -98,10 +98,10 @@ const MAX_ATTESTATIONS_PER_GROUP = 3;
 /**
  * For electra, there is on chain aggregation of attestations across committees, so we can just pick up to 8
  * attestations per group, sort by scores to get first 8.
- * The new algorithm helps not to inlclude useless attestations so we usually cannot get up to 8.
+ * The new algorithm helps not to include useless attestations so we usually cannot get up to 8.
  * The more consolidations we have per block, the less likely we have to scan all slots in the pool.
- * This is max attestations returned per group, it does not make sense to have this number greater than MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA
- * and MAX_ATTESTATIONS_ELECTRA.
+ * This is max attestations returned per group, it does not make sense to have this number greater
+ * than MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA or MAX_ATTESTATIONS_ELECTRA.
  */
 const MAX_ATTESTATIONS_PER_GROUP_ELECTRA = Math.min(
   MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA,
@@ -116,7 +116,7 @@ export enum ScannedSlotsTerminationReason {
 
 /**
  * Maintain a pool of aggregated attestations. Attestations can be retrieved for inclusion in a block
- * or api. The returned attestations are aggregated to maximise the number of validators that can be
+ * or api. The returned attestations are aggregated to maximize the number of validators that can be
  * included.
  * Note that we want to remove attestations with attesters that were included in the chain.
  */
@@ -416,7 +416,7 @@ export class AggregatedAttestationPool {
                 totalNewSeenEffectiveBalance: 0,
                 newSeenAttesters: 0,
                 notSeenAttesters: 0,
-                crossCommitteeMembers: 0,
+                totalAttesters: 0,
               };
             }
             const sameAttDataCon = sameAttDataCons[i];
@@ -426,7 +426,7 @@ export class AggregatedAttestationPool {
               sameAttDataCon.totalNewSeenEffectiveBalance += attestationNonParticipation.newSeenEffectiveBalance;
               sameAttDataCon.newSeenAttesters += attestationNonParticipation.newSeenAttesters;
               sameAttDataCon.notSeenAttesters += attestationNonParticipation.notSeenAttestingIndices.size;
-              sameAttDataCon.crossCommitteeMembers += attestationGroup.committee.length;
+              sameAttDataCon.totalAttesters += attestationGroup.committee.length;
             }
           }
         } // all committees are processed
@@ -463,7 +463,7 @@ export class AggregatedAttestationPool {
       // record metrics of packed attestations
       const committeeCount = consolidation.byCommittee.size;
       packedAttestationsMetrics?.committeeBits.set({index: i}, committeeCount);
-      packedAttestationsMetrics?.crossCommitteeMembers.set({index: i}, consolidation.crossCommitteeMembers);
+      packedAttestationsMetrics?.totalAttesters.set({index: i}, consolidation.totalAttesters);
       packedAttestationsMetrics?.nonParticipation.set({index: i}, consolidation.notSeenAttesters);
       packedAttestationsMetrics?.inclusionDistance.set({index: i}, stateSlot - packedAttestations[i].data.slot);
       packedAttestationsMetrics?.newSeenAttesters.set({index: i}, consolidation.newSeenAttesters);
@@ -474,7 +474,7 @@ export class AggregatedAttestationPool {
       stopReason = ScannedSlotsTerminationReason.ScannedAllSlots;
     }
     packedAttestationsMetrics?.scannedSlots.set({reason: stopReason}, scannedSlots);
-    packedAttestationsMetrics?.totalSlots.set(slots.length);
+    packedAttestationsMetrics?.poolSlots.set(slots.length);
 
     return packedAttestations;
   }
@@ -678,6 +678,9 @@ export class MatchingDataAttestationGroup {
       attestations.push(mostValuableAttestation);
       excluded.add(mostValuableAttestation.attestation);
       // this will narrow down the notSeenAttestingIndices for the next iteration
+      // so usually it will not take much time , however it could take time for during
+      // non-finality of the network when there is too few participation, but in that case
+      // we pre-aggregate aggregated attestations and bound the total attestations per group
       notSeenAttestingIndices = mostValuableAttestation.notSeenAttestingIndices;
     }
 

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -425,7 +425,7 @@ export class AggregatedAttestationPool {
               sameAttDataCon.byCommittee.set(committeeIndex, attestationNonParticipation);
               sameAttDataCon.totalNewSeenEffectiveBalance += attestationNonParticipation.newSeenEffectiveBalance;
               sameAttDataCon.newSeenAttesters += attestationNonParticipation.newSeenAttesters;
-              sameAttDataCon.notSeenAttesters += attestationNonParticipation.notSeenAttendingIndices.size;
+              sameAttDataCon.notSeenAttesters += attestationNonParticipation.notSeenAttestingIndices.size;
               sameAttDataCon.crossCommitteeMembers += attestationGroup.committee.length;
             }
           }
@@ -572,7 +572,7 @@ type AttestationNonParticipant = {
   // this is only updated and used in removeBySeenValidators function
   newSeenEffectiveBalance: number;
   newSeenAttesters: number;
-  notSeenAttendingIndices: Set<number>;
+  notSeenAttestingIndices: Set<number>;
 };
 
 /**
@@ -678,7 +678,7 @@ export class MatchingDataAttestationGroup {
       attestations.push(mostValuableAttestation);
       excluded.add(mostValuableAttestation.attestation);
       // this will narrow down the notSeenAttestingIndices for the next iteration
-      notSeenAttestingIndices = mostValuableAttestation.notSeenAttendingIndices;
+      notSeenAttestingIndices = mostValuableAttestation.notSeenAttestingIndices;
     }
 
     return attestations;
@@ -735,7 +735,7 @@ export class MatchingDataAttestationGroup {
           attestation,
           newSeenEffectiveBalance,
           newSeenAttesters,
-          notSeenAttendingIndices: notSeen,
+          notSeenAttestingIndices: notSeen,
         };
       }
     }

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -678,8 +678,8 @@ export class MatchingDataAttestationGroup {
       attestations.push(mostValuableAttestation);
       excluded.add(mostValuableAttestation.attestation);
       // this will narrow down the notSeenAttestingIndices for the next iteration
-      // so usually it will not take much time , however it could take time for during
-      // non-finality of the network when there is too few participation, but in that case
+      // so usually it will not take much time, however it could take more time during
+      // non-finality of the network when there is low participation, but in this case
       // we pre-aggregate aggregated attestations and bound the total attestations per group
       notSeenAttestingIndices = mostValuableAttestation.notSeenAttestingIndices;
     }

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -928,7 +928,7 @@ export function createLodestarMetrics(
             labelNames: ["index"],
           }),
           inclusionDistance: register.gauge<{index: number}>({
-            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_slot_delta_total",
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_inclusion_distance_total",
             help: "How far the packed attestation ${index} slot is from the block slot",
             labelNames: ["index"],
           }),

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -3,6 +3,7 @@ import {BeaconState} from "@lodestar/types";
 import {BlobsSource, BlockSource} from "../../chain/blocks/types.js";
 import {JobQueueItemType} from "../../chain/bls/index.js";
 import {AttestationErrorCode, BlockErrorCode} from "../../chain/errors/index.js";
+import {ScannedSlotsTerminationReason} from "../../chain/opPools/aggregatedAttestationPool.js";
 import {InsertOutcome} from "../../chain/opPools/types.js";
 import {RegenCaller, RegenFnName} from "../../chain/regen/interface.js";
 import {ReprocessStatus} from "../../chain/reprocess.js";
@@ -900,6 +901,63 @@ export function createLodestarMetrics(
           help: "Total number of InsertOutcome as a result of adding an aggregated attestation from api in the pool",
           labelNames: ["insertOutcome"],
         }),
+        packedAttestations: {
+          committeeBits: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_committee_bits_total",
+            help: "Total number of committee bits in packed attestation ${index}",
+            labelNames: ["index"],
+          }),
+          committeeMembers: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_committee_members_total",
+            help: "Total number of committee members in packed attestation ${index}",
+            labelNames: ["index"],
+          }),
+          nonParticipation: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_non_participation_total",
+            help: "Total number of not seen attesters in packed attestation ${index}",
+            labelNames: ["index"],
+          }),
+          newSeenAttesters: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_new_seen_attesters_total",
+            help: "Total number of new seen attesters in packed attestation ${index}",
+            labelNames: ["index"],
+          }),
+          totalEffectiveBalance: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_total_effective_balance",
+            help: "Total effective balance of new seen attesters in packed attestation ${index}",
+            labelNames: ["index"],
+          }),
+          inclusionDistance: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_slot_delta_total",
+            help: "How far the packed attestations ${index} from the block slot",
+            labelNames: ["index"],
+          }),
+          scannedSlots: register.gauge<{reason: ScannedSlotsTerminationReason}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_scanned_slots_total",
+            help: "Total number of scanned slots to produce packed attestations",
+            labelNames: ["reason"],
+          }),
+          totalSlots: register.gauge({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_total_slots_total",
+            help: "Total number of slots in pool when producing packed attestations",
+          }),
+          totalConsolidations: register.gauge({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_total_consolidations_total",
+            help: "Total number of consolidations before truncate",
+          }),
+          emptyAttestationData: register.gauge({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_empty_attestation_data_total",
+            help: "Total number of attestation data with no group when producing packed attestation",
+          }),
+          invalidAttestationData: register.gauge({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_invalid_attestation_data_total",
+            help: "Total number of invalid attestation data when producing packed attestation",
+          }),
+          seenCommittees: register.gauge({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_seen_committees_total",
+            help: "Total number of committees that all members are seen when producing packed attestations",
+          }),
+        },
       },
       attestationPool: {
         size: register.gauge({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -937,6 +937,16 @@ export function createLodestarMetrics(
             help: "Total number of scanned slots to produce packed attestations",
             labelNames: ["reason"],
           }),
+          scannedAttestations: register.gauge<{inclusionDistance: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_scanned_attestations_total",
+            help: "Total number of scanned attestations per scanned slot to produce packed attestations",
+            labelNames: ["inclusionDistance"],
+          }),
+          returnedAttestations: register.gauge<{inclusionDistance: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_returned_attestations_total",
+            help: "Total number of returned attestations per scanned slot to produce packed attestations",
+            labelNames: ["inclusionDistance"],
+          }),
           poolSlots: register.gauge({
             name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_pool_slots_total",
             help: "Total number of slots in pool when producing packed attestations",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -907,9 +907,9 @@ export function createLodestarMetrics(
             help: "Total number of committee bits in packed attestation ${index}",
             labelNames: ["index"],
           }),
-          committeeMembers: register.gauge<{index: number}>({
-            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_committee_members_total",
-            help: "Total number of committee members in packed attestation ${index}",
+          crossCommitteeMembers: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_cross_committee_members_total",
+            help: "Total number of committee members across committees in packed attestation ${index}",
             labelNames: ["index"],
           }),
           nonParticipation: register.gauge<{index: number}>({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -902,9 +902,9 @@ export function createLodestarMetrics(
           labelNames: ["insertOutcome"],
         }),
         packedAttestations: {
-          committeeBits: register.gauge<{index: number}>({
-            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_committee_bits_total",
-            help: "Total number of committee bits in packed attestation ${index}",
+          committeeCount: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_committee_count",
+            help: "Total number of committees in packed attestation ${index}",
             labelNames: ["index"],
           }),
           totalAttesters: register.gauge<{index: number}>({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -907,9 +907,9 @@ export function createLodestarMetrics(
             help: "Total number of committee bits in packed attestation ${index}",
             labelNames: ["index"],
           }),
-          crossCommitteeMembers: register.gauge<{index: number}>({
-            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_cross_committee_members_total",
-            help: "Total number of committee members across committees in packed attestation ${index}",
+          totalAttesters: register.gauge<{index: number}>({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_attesters_total",
+            help: "Total number of attesters in packed attestation ${index}",
             labelNames: ["index"],
           }),
           nonParticipation: register.gauge<{index: number}>({
@@ -929,7 +929,7 @@ export function createLodestarMetrics(
           }),
           inclusionDistance: register.gauge<{index: number}>({
             name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_slot_delta_total",
-            help: "How far the packed attestations ${index} from the block slot",
+            help: "How far the packed attestation ${index} slot is from the block slot",
             labelNames: ["index"],
           }),
           scannedSlots: register.gauge<{reason: ScannedSlotsTerminationReason}>({
@@ -937,8 +937,8 @@ export function createLodestarMetrics(
             help: "Total number of scanned slots to produce packed attestations",
             labelNames: ["reason"],
           }),
-          totalSlots: register.gauge({
-            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_total_slots_total",
+          poolSlots: register.gauge({
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_pool_slots_total",
             help: "Total number of slots in pool when producing packed attestations",
           }),
           totalConsolidations: register.gauge({
@@ -955,7 +955,7 @@ export function createLodestarMetrics(
           }),
           seenCommittees: register.gauge({
             name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_seen_committees_total",
-            help: "Total number of committees that all members are seen when producing packed attestations",
+            help: "Total number of committees for which all members are seen when producing packed attestations",
           }),
         },
       },

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -703,7 +703,7 @@ describe("aggregateConsolidation", () => {
         byCommittee: new Map(),
         attData: attData,
         totalNewSeenEffectiveBalance: 0,
-        committeeMembers: 32,
+        crossCommitteeMembers: 32,
         newSeenAttesters: 0,
         notSeenAttesters: 0,
       };

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -631,7 +631,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
         effectiveBalanceIncrements,
         notSeenCommitteeMembers,
         maxAttestations
-      );
+      ).result;
 
       for (const [
         i,

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -491,7 +491,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           notSeenAttestingIndices: new Set([]),
           returnedIndex: 0,
         },
-        // not valueable because seen attestations are all included in attestation 0
+        // not valuable because seen attestations are all included in attestation 0
         {
           bits: [0b00000011],
           newSeenEffectiveBalance: 0,
@@ -703,7 +703,7 @@ describe("aggregateConsolidation", () => {
         byCommittee: new Map(),
         attData: attData,
         totalNewSeenEffectiveBalance: 0,
-        crossCommitteeMembers: 32,
+        totalAttesters: 32,
         newSeenAttesters: 0,
         notSeenAttesters: 0,
       };
@@ -712,13 +712,13 @@ describe("aggregateConsolidation", () => {
       const attestationSeed = ssz.electra.Attestation.defaultValue();
       for (let i = 0; i < committeeIndices.length; i++) {
         const committeeIndex = committeeIndices[i];
-        const commiteeBits = BitArray.fromBoolArray(
+        const committeeBits = BitArray.fromBoolArray(
           Array.from({length: MAX_COMMITTEES_PER_SLOT}, (_, i) => i === committeeIndex)
         );
         const aggAttestation = {
           ...attestationSeed,
           aggregationBits: new BitArray(new Uint8Array(aggregationBitsArr[i]), 3),
-          committeeBits: commiteeBits,
+          committeeBits,
           signature: sigArr[i].toBytes(),
         };
         consolidation.byCommittee.set(committeeIndex, {

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -215,15 +215,17 @@ describe("AggregatedAttestationPool - get packed attestations - Electra", () => 
 
   const testCases: {
     name: string;
-    // item is is for committee i, which contains array of attester indices that's not seen (seen by default)
+    // item i is for committee i, which contains array of attester indices that's not seen (seen by default)
     notSeenInStateByCommittee: number[][];
     // item i is for committee i, each item is number[][] which is the indices of validators not seen by the committee
     // each item i also decides how many attestations added to the pool for that committee
     attParticipationByCommittee: number[][][];
     // expected committeeBits of packed attestations, item 0 is for returned attestation 0, ...
     packedCommitteeBits: number[][];
-    // expected aggregationBits of packed attestations: item 0 is for returned attestation 0, ...
-    packedAggregationBits: number[];
+    // expected length of aggregationBits of packed attestations: item 0 is for returned attestation 0, ...
+    packedAggregationBitsLen: number[];
+    // expected backed Uint8Array of aggreationBits of packed attestations: item 0 is for returned attestation 0, ...
+    packedAggregationBitsUint8Array: Uint8Array[];
   }[] = [
     {
       name: "Full participation",
@@ -237,7 +239,10 @@ describe("AggregatedAttestationPool - get packed attestations - Electra", () => 
       attParticipationByCommittee: [[[]], [[]], [[]], [[]]],
       // 1 full packed attestation
       packedCommitteeBits: [[0, 1, 2, 3]],
-      packedAggregationBits: [committeeLength * 4],
+      packedAggregationBitsLen: [committeeLength * 4],
+      packedAggregationBitsUint8Array: [
+        new Uint8Array([255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]),
+      ],
     },
     {
       name: "Full participation but all are seen in the state",
@@ -246,7 +251,8 @@ describe("AggregatedAttestationPool - get packed attestations - Electra", () => 
       attParticipationByCommittee: [[[]], [[]], [[]], [[]]],
       // no packed attestation
       packedCommitteeBits: [],
-      packedAggregationBits: [],
+      packedAggregationBitsLen: [],
+      packedAggregationBitsUint8Array: [],
     },
     {
       name: "Committee 1 and 2 has 2 versions of aggregationBits",
@@ -265,7 +271,11 @@ describe("AggregatedAttestationPool - get packed attestations - Electra", () => 
         [0, 1, 2, 3],
         [1, 2],
       ],
-      packedAggregationBits: [committeeLength * 4, committeeLength * 2],
+      packedAggregationBitsLen: [committeeLength * 4, committeeLength * 2],
+      packedAggregationBitsUint8Array: [
+        new Uint8Array([255, 255, 255, 255, 0b11111110, 255, 255, 255, 0b11111101, 255, 255, 255, 255, 255, 255, 255]),
+        new Uint8Array([0b11111101, 255, 255, 255, 0b11111011, 255, 255, 255]),
+      ],
     },
     {
       // same to above but no-participation validators are all seen in the state so only 1 attestation is returned
@@ -280,9 +290,11 @@ describe("AggregatedAttestationPool - get packed attestations - Electra", () => 
       // committee 2 has 2 attestations, one with no participation validator 1, one with no participation validator 2
       // committee 0 and 3 has 1 attestation each, and all validators are seen
       attParticipationByCommittee: [[[]], [[0], [1]], [[1], [2]], [[]]],
-      // 2nd packed attestation only has 2 committees: 1 and 2
       packedCommitteeBits: [[0, 1, 2, 3]],
-      packedAggregationBits: [committeeLength * 4],
+      packedAggregationBitsLen: [committeeLength * 4],
+      packedAggregationBitsUint8Array: [
+        new Uint8Array([255, 255, 255, 255, 0b11111110, 255, 255, 255, 0b11111011, 255, 255, 255, 255, 255, 255, 255]),
+      ],
     },
     {
       name: "Only committee 1 has 2 versions of aggregationBits",
@@ -298,7 +310,11 @@ describe("AggregatedAttestationPool - get packed attestations - Electra", () => 
       // 2nd packed attestation only has 1 committeee
       packedCommitteeBits: [[0, 1, 2, 3], [1]],
       // 2nd packed attestation only has 1 committee
-      packedAggregationBits: [committeeLength * 4, committeeLength],
+      packedAggregationBitsLen: [committeeLength * 4, committeeLength],
+      packedAggregationBitsUint8Array: [
+        new Uint8Array([255, 255, 255, 255, 0b11111110, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]),
+        new Uint8Array([0b11111101, 255, 255, 255]),
+      ],
     },
   ];
 
@@ -307,7 +323,8 @@ describe("AggregatedAttestationPool - get packed attestations - Electra", () => 
     notSeenInStateByCommittee,
     attParticipationByCommittee,
     packedCommitteeBits,
-    packedAggregationBits,
+    packedAggregationBitsLen,
+    packedAggregationBitsUint8Array,
   } of testCases) {
     it(name, () => {
       // this is related to NotSeenValidatorsFn, all validators are seen by default
@@ -353,12 +370,13 @@ describe("AggregatedAttestationPool - get packed attestations - Electra", () => 
 
       const blockAttestations = pool.getAttestationsForBlock(fork, forkchoiceStub, electraState);
       // make sure test data is correct
-      expect(packedCommitteeBits.length).toBe(packedAggregationBits.length);
+      expect(packedCommitteeBits.length).toBe(packedAggregationBitsLen.length);
       expect(blockAttestations.length).toBe(packedCommitteeBits.length);
       for (let attIndex = 0; attIndex < blockAttestations.length; attIndex++) {
         const returnedAttestation = blockAttestations[attIndex] as Attestation<ForkPostElectra>;
         expect(returnedAttestation.committeeBits.getTrueBitIndexes()).toStrictEqual(packedCommitteeBits[attIndex]);
-        expect(returnedAttestation.aggregationBits.bitLen).toStrictEqual(packedAggregationBits[attIndex]);
+        expect(returnedAttestation.aggregationBits.bitLen).toStrictEqual(packedAggregationBitsLen[attIndex]);
+        expect(returnedAttestation.aggregationBits.uint8Array).toStrictEqual(packedAggregationBitsUint8Array[attIndex]);
       }
     });
   }
@@ -451,6 +469,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       newSeenEffectiveBalance: number;
       newSeenAttesters: number;
       notSeenCommitteeMembers: Set<number> | null;
+      // this comes from the find() api, -1 means not found
       returnedIndex: number;
     }[];
   }[] = [

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -450,7 +450,8 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
     attestationsToAdd: {
       bits: number[];
       newSeenEffectiveBalance: number;
-      notSeenAttesters: number;
+      newSeenAttesters: number;
+      notSeenAttendingIndices: Set<number> | null;
       returnedIndex: number;
     }[];
   }[] = [
@@ -461,8 +462,20 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b00000000],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], newSeenEffectiveBalance: 0, notSeenAttesters: 0, returnedIndex: -1},
-        {bits: [0b00000011], newSeenEffectiveBalance: 0, notSeenAttesters: 0, returnedIndex: -1},
+        {
+          bits: [0b11111110],
+          newSeenEffectiveBalance: 0,
+          newSeenAttesters: 0,
+          notSeenAttendingIndices: null,
+          returnedIndex: -1,
+        },
+        {
+          bits: [0b00000011],
+          newSeenEffectiveBalance: 0,
+          newSeenAttesters: 0,
+          notSeenAttendingIndices: null,
+          returnedIndex: -1,
+        },
       ],
     },
     {
@@ -471,9 +484,21 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b00001110],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], newSeenEffectiveBalance: 3 * 32, notSeenAttesters: 3, returnedIndex: 0},
+        {
+          bits: [0b11111110],
+          newSeenEffectiveBalance: 3 * 32,
+          newSeenAttesters: 3,
+          notSeenAttendingIndices: new Set([]),
+          returnedIndex: 0,
+        },
         // not valueable because seen attestations are all included in attestation 0
-        {bits: [0b00000011], newSeenEffectiveBalance: 0, notSeenAttesters: 0, returnedIndex: -1},
+        {
+          bits: [0b00000011],
+          newSeenEffectiveBalance: 0,
+          newSeenAttesters: 0,
+          notSeenAttendingIndices: null,
+          returnedIndex: -1,
+        },
       ],
     },
     {
@@ -482,8 +507,20 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b00001110],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111010], newSeenEffectiveBalance: 2 * 32, notSeenAttesters: 2, returnedIndex: 0},
-        {bits: [0b10000101], newSeenEffectiveBalance: 1 * 32, notSeenAttesters: 1, returnedIndex: 1},
+        {
+          bits: [0b11111010],
+          newSeenEffectiveBalance: 2 * 32,
+          newSeenAttesters: 2,
+          notSeenAttendingIndices: new Set([2]),
+          returnedIndex: 0,
+        },
+        {
+          bits: [0b10000101],
+          newSeenEffectiveBalance: 1 * 32,
+          newSeenAttesters: 1,
+          notSeenAttendingIndices: new Set(),
+          returnedIndex: 1,
+        },
       ],
     },
     {
@@ -492,11 +529,29 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       effectiveBalanceIncrements: new Uint16Array([32, 2048, 32, 32, 32, 32, 32, 32]),
       attestationsToAdd: [
         // newSeenEffectiveBalance is not 6 * 32 considering the 1st included attestation
-        {bits: [0b11111001], newSeenEffectiveBalance: 4 * 32, notSeenAttesters: 4, returnedIndex: 1},
+        {
+          bits: [0b11111001],
+          newSeenEffectiveBalance: 4 * 32,
+          newSeenAttesters: 4,
+          notSeenAttendingIndices: new Set([2]),
+          returnedIndex: 1,
+        },
         // although this has less not seen attesters, it has bigger effective balance so returned index is 0
-        {bits: [0b10000011], newSeenEffectiveBalance: 2048 + 2 * 32, notSeenAttesters: 3, returnedIndex: 0},
+        {
+          bits: [0b10000011],
+          newSeenEffectiveBalance: 2048 + 2 * 32,
+          newSeenAttesters: 3,
+          notSeenAttendingIndices: new Set([2, 3, 4, 5, 6]),
+          returnedIndex: 0,
+        },
         // maxAttestation is only 2
-        {bits: [0b00001101], newSeenEffectiveBalance: 0, notSeenAttesters: 0, returnedIndex: -1},
+        {
+          bits: [0b00001101],
+          newSeenEffectiveBalance: 0,
+          newSeenAttesters: 0,
+          notSeenAttendingIndices: null,
+          returnedIndex: -1,
+        },
       ],
     },
     {
@@ -505,9 +560,21 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       notSeenAttestingBits: [0b11111111],
       effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b00111110], newSeenEffectiveBalance: 5 * 32, notSeenAttesters: 5, returnedIndex: 0},
+        {
+          bits: [0b00111110],
+          newSeenEffectiveBalance: 5 * 32,
+          newSeenAttesters: 5,
+          notSeenAttendingIndices: new Set([0, 6, 7]),
+          returnedIndex: 0,
+        },
         // newSeenEffectiveBalance is not 3 * 32 considering the 1st included attestation already include attester 1
-        {bits: [0b01000011], newSeenEffectiveBalance: 2 * 32, notSeenAttesters: 2, returnedIndex: 1},
+        {
+          bits: [0b01000011],
+          newSeenEffectiveBalance: 2 * 32,
+          newSeenAttesters: 2,
+          notSeenAttendingIndices: new Set([7]),
+          returnedIndex: 1,
+        },
       ],
     },
   ];
@@ -548,13 +615,18 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
         maxAttestations
       );
 
-      for (const [i, {newSeenEffectiveBalance, returnedIndex}] of attestationsToAdd.entries()) {
+      for (const [
+        i,
+        {newSeenEffectiveBalance, newSeenAttesters, notSeenAttendingIndices, returnedIndex},
+      ] of attestationsToAdd.entries()) {
         const attestationIndex = attestationsForBlock.findIndex((a) => a.attestation === attestations[i]);
         expect(attestationIndex).toBe(returnedIndex);
         const attestation = attestationsForBlock[attestationIndex];
         // If notSeenAttesterCount === 0 the attestation is not returned
         if (returnedIndex !== -1) {
           expect(attestation ? attestation.newSeenEffectiveBalance : 0).toBe(newSeenEffectiveBalance);
+          expect(attestation ? attestation.newSeenAttesters : 0).toBe(newSeenAttesters);
+          expect(attestation ? attestation.notSeenAttendingIndices : 0).toStrictEqual(notSeenAttendingIndices);
         }
       }
     });
@@ -631,7 +703,7 @@ describe("aggregateConsolidation", () => {
         byCommittee: new Map(),
         attData: attData,
         totalNewSeenEffectiveBalance: 0,
-        committeeSize: 32,
+        committeeMembers: 32,
         newSeenAttesters: 0,
         notSeenAttesters: 0,
       };

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -7,7 +7,6 @@ import {
   ForkPostElectra,
   MAX_COMMITTEES_PER_SLOT,
   MAX_EFFECTIVE_BALANCE,
-  MAX_VALIDATORS_PER_COMMITTEE,
   SLOTS_PER_EPOCH,
 } from "@lodestar/params";
 import {CachedBeaconStateAllForks, CachedBeaconStateElectra, newFilledArray} from "@lodestar/state-transition";

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -451,7 +451,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       bits: number[];
       newSeenEffectiveBalance: number;
       newSeenAttesters: number;
-      notSeenAttendingIndices: Set<number> | null;
+      notSeenAttestingIndices: Set<number> | null;
       returnedIndex: number;
     }[];
   }[] = [
@@ -466,14 +466,14 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b11111110],
           newSeenEffectiveBalance: 0,
           newSeenAttesters: 0,
-          notSeenAttendingIndices: null,
+          notSeenAttestingIndices: null,
           returnedIndex: -1,
         },
         {
           bits: [0b00000011],
           newSeenEffectiveBalance: 0,
           newSeenAttesters: 0,
-          notSeenAttendingIndices: null,
+          notSeenAttestingIndices: null,
           returnedIndex: -1,
         },
       ],
@@ -488,7 +488,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b11111110],
           newSeenEffectiveBalance: 3 * 32,
           newSeenAttesters: 3,
-          notSeenAttendingIndices: new Set([]),
+          notSeenAttestingIndices: new Set([]),
           returnedIndex: 0,
         },
         // not valueable because seen attestations are all included in attestation 0
@@ -496,7 +496,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b00000011],
           newSeenEffectiveBalance: 0,
           newSeenAttesters: 0,
-          notSeenAttendingIndices: null,
+          notSeenAttestingIndices: null,
           returnedIndex: -1,
         },
       ],
@@ -511,14 +511,14 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b11111010],
           newSeenEffectiveBalance: 2 * 32,
           newSeenAttesters: 2,
-          notSeenAttendingIndices: new Set([2]),
+          notSeenAttestingIndices: new Set([2]),
           returnedIndex: 0,
         },
         {
           bits: [0b10000101],
           newSeenEffectiveBalance: 1 * 32,
           newSeenAttesters: 1,
-          notSeenAttendingIndices: new Set(),
+          notSeenAttestingIndices: new Set(),
           returnedIndex: 1,
         },
       ],
@@ -533,7 +533,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b11111001],
           newSeenEffectiveBalance: 4 * 32,
           newSeenAttesters: 4,
-          notSeenAttendingIndices: new Set([2]),
+          notSeenAttestingIndices: new Set([2]),
           returnedIndex: 1,
         },
         // although this has less not seen attesters, it has bigger effective balance so returned index is 0
@@ -541,7 +541,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b10000011],
           newSeenEffectiveBalance: 2048 + 2 * 32,
           newSeenAttesters: 3,
-          notSeenAttendingIndices: new Set([2, 3, 4, 5, 6]),
+          notSeenAttestingIndices: new Set([2, 3, 4, 5, 6]),
           returnedIndex: 0,
         },
         // maxAttestation is only 2
@@ -549,7 +549,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b00001101],
           newSeenEffectiveBalance: 0,
           newSeenAttesters: 0,
-          notSeenAttendingIndices: null,
+          notSeenAttestingIndices: null,
           returnedIndex: -1,
         },
       ],
@@ -564,7 +564,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b00111110],
           newSeenEffectiveBalance: 5 * 32,
           newSeenAttesters: 5,
-          notSeenAttendingIndices: new Set([0, 6, 7]),
+          notSeenAttestingIndices: new Set([0, 6, 7]),
           returnedIndex: 0,
         },
         // newSeenEffectiveBalance is not 3 * 32 considering the 1st included attestation already include attester 1
@@ -572,7 +572,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b01000011],
           newSeenEffectiveBalance: 2 * 32,
           newSeenAttesters: 2,
-          notSeenAttendingIndices: new Set([7]),
+          notSeenAttestingIndices: new Set([7]),
           returnedIndex: 1,
         },
       ],
@@ -617,7 +617,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
 
       for (const [
         i,
-        {newSeenEffectiveBalance, newSeenAttesters, notSeenAttendingIndices, returnedIndex},
+        {newSeenEffectiveBalance, newSeenAttesters, notSeenAttestingIndices: notSeenAttendingIndices, returnedIndex},
       ] of attestationsToAdd.entries()) {
         const attestationIndex = attestationsForBlock.findIndex((a) => a.attestation === attestations[i]);
         expect(attestationIndex).toBe(returnedIndex);
@@ -626,7 +626,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
         if (returnedIndex !== -1) {
           expect(attestation ? attestation.newSeenEffectiveBalance : 0).toBe(newSeenEffectiveBalance);
           expect(attestation ? attestation.newSeenAttesters : 0).toBe(newSeenAttesters);
-          expect(attestation ? attestation.notSeenAttendingIndices : 0).toStrictEqual(notSeenAttendingIndices);
+          expect(attestation ? attestation.notSeenAttestingIndices : 0).toStrictEqual(notSeenAttendingIndices);
         }
       }
     });
@@ -724,7 +724,7 @@ describe("aggregateConsolidation", () => {
         consolidation.byCommittee.set(committeeIndex, {
           attestation: aggAttestation,
           newSeenEffectiveBalance: aggregationBitsArr[i].filter((item) => item).length * 32,
-          notSeenAttendingIndices: new Set(),
+          notSeenAttestingIndices: new Set(),
           newSeenAttesters: 0,
         });
       }

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -224,7 +224,7 @@ describe("AggregatedAttestationPool - get packed attestations - Electra", () => 
     packedCommitteeBits: number[][];
     // expected length of aggregationBits of packed attestations: item 0 is for returned attestation 0, ...
     packedAggregationBitsLen: number[];
-    // expected backed Uint8Array of aggreationBits of packed attestations: item 0 is for returned attestation 0, ...
+    // expected backed Uint8Array of aggregationBits of packed attestations: item 0 is for returned attestation 0, ...
     packedAggregationBitsUint8Array: Uint8Array[];
   }[] = [
     {
@@ -307,7 +307,7 @@ describe("AggregatedAttestationPool - get packed attestations - Electra", () => 
       // committee 1 has 2 attestations, one with no participation validator 0, one with no participation validator 1
       // other committees have 1 attestation each, and all validators are seen
       attParticipationByCommittee: [[[]], [[0], [1]], [[]], [[]]],
-      // 2nd packed attestation only has 1 committeee
+      // 2nd packed attestation only has 1 committee
       packedCommitteeBits: [[0, 1, 2, 3], [1]],
       // 2nd packed attestation only has 1 committee
       packedAggregationBitsLen: [committeeLength * 4, committeeLength],
@@ -349,8 +349,8 @@ describe("AggregatedAttestationPool - get packed attestations - Electra", () => 
         const committeeIndex = committeeIndices[i];
         const committeeBits = BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, committeeIndex);
         // same committee, each is by attestation
-        const notSeenValidatorsByAttationIndex = attParticipationByCommittee[i];
-        for (const notSeenValidators of notSeenValidatorsByAttationIndex) {
+        const notSeenValidatorsByAttestationIndex = attParticipationByCommittee[i];
+        for (const notSeenValidators of notSeenValidatorsByAttestationIndex) {
           const aggregationBits = new BitArray(new Uint8Array(committeeLength / 8).fill(255), committeeLength);
           for (const index of notSeenValidators) {
             aggregationBits.set(index, false);

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@lodestar/params";
 import {CachedBeaconStateAllForks, CachedBeaconStateElectra, newFilledArray} from "@lodestar/state-transition";
 import {CachedBeaconStateAltair} from "@lodestar/state-transition/src/types.js";
-import {Attestation, phase0, ssz} from "@lodestar/types";
+import {Attestation, electra, phase0, ssz} from "@lodestar/types";
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {
   AggregatedAttestationPool,
@@ -48,7 +48,8 @@ describe("AggregatedAttestationPool - Altair", () => {
 
   const committeeIndex = 0;
   const attestation = ssz.phase0.Attestation.defaultValue();
-  attestation.data.slot = currentSlot;
+  // state slot is (currentSlot + 1) so if set attestation slot to currentSlot, it will be included in the block
+  attestation.data.slot = currentSlot - 1;
   attestation.data.index = committeeIndex;
   attestation.data.target.epoch = currentEpoch;
   const attDataRootHex = toHexString(ssz.phase0.AttestationData.hashTreeRoot(attestation.data));
@@ -64,7 +65,7 @@ describe("AggregatedAttestationPool - Altair", () => {
   const committeeLength = 4;
   const validators = generateValidators(vc, validatorOpts);
   const originalState = generateCachedAltairState({slot: currentSlot + 1, validators}, altairForkEpoch);
-  const committee = originalState.epochCtx.getBeaconCommittee(currentSlot, committeeIndex);
+  const committee = originalState.epochCtx.getBeaconCommittee(currentSlot - 1, committeeIndex);
   expect(committee.length).toEqual(committeeLength);
   // 0 and 1 in committee are fully participated
   const epochParticipation = newFilledArray(vc, 0b111);
@@ -98,15 +99,10 @@ describe("AggregatedAttestationPool - Altair", () => {
     // previousEpochParticipation and currentEpochParticipation is created inside generateCachedState
     // 0 and 1 are fully participated
     const notSeenValidatorFn = getNotSeenValidatorsFn(altairState);
-    const participation = notSeenValidatorFn(currentEpoch, currentSlot, committeeIndex);
     // seen attesting indices are 0, 1 => not seen are 2, 3
-    expect(participation).toEqual(
-      // {
-      // validatorIndices: [null, null, committee[2], committee[3]],
-      // attestingIndices: new Set([2, 3]),
-      // }
-      new Set([2, 3])
-    );
+    expect(notSeenValidatorFn(currentEpoch, currentSlot - 1, committeeIndex)).toEqual(new Set([2, 3]));
+    // attestations in current slot are always included (since altairState.slot = currentSlot + 1)
+    expect(notSeenValidatorFn(currentEpoch, currentSlot, committeeIndex)).toEqual(new Set([0, 1, 2, 3]));
   });
 
   // previousEpochParticipation and currentEpochParticipation is created inside generateCachedState
@@ -160,7 +156,7 @@ describe("AggregatedAttestationPool - Altair", () => {
   });
 });
 
-describe("AggregatedAttestationPool - Electra", () => {
+describe("AggregatedAttestationPool - get packed attestations - Electra", () => {
   let pool: AggregatedAttestationPool;
   const fork = ForkName.electra;
   const electraForkEpoch = 2020;
@@ -177,7 +173,9 @@ describe("AggregatedAttestationPool - Electra", () => {
 
   const committeeIndices = [0, 1, 2, 3];
   const attestation = ssz.electra.Attestation.defaultValue();
-  attestation.data.slot = currentSlot;
+  // it will always include attestations for stateSlot - 1 which is currentSlot
+  // so we want attestation slot to be less than that to test epochParticipation
+  attestation.data.slot = currentSlot - 1;
   attestation.data.index = 0; // Must be zero post-electra
   attestation.data.target.epoch = currentEpoch;
   attestation.signature = validSignature;
@@ -196,17 +194,11 @@ describe("AggregatedAttestationPool - Electra", () => {
   const originalState = generateCachedElectraState({slot: currentSlot + 1, validators}, electraForkEpoch);
   expect(originalState.epochCtx.getCommitteeCountPerSlot(currentEpoch)).toEqual(committeeIndices.length);
 
-  const committees = originalState.epochCtx.getBeaconCommittees(currentSlot, committeeIndices);
-
-  const epochParticipation = newFilledArray(vc, 0b000);
+  const committees = originalState.epochCtx.getBeaconCommittees(attestation.data.slot, committeeIndices);
   for (const committee of committees) {
     expect(committee.length).toEqual(committeeLength);
   }
 
-  (originalState as CachedBeaconStateElectra).previousEpochParticipation =
-    ssz.altair.EpochParticipation.toViewDU(epochParticipation);
-  (originalState as CachedBeaconStateElectra).currentEpochParticipation =
-    ssz.altair.EpochParticipation.toViewDU(epochParticipation);
   originalState.commit();
   let electraState: CachedBeaconStateAllForks;
 
@@ -222,66 +214,162 @@ describe("AggregatedAttestationPool - Electra", () => {
     vi.clearAllMocks();
   });
 
-  it("Multiple attestations with same attestation data different committee", () => {
-    // Attestation from committee 0
-    const committeeBits0 = BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, 0);
+  const testCases: {
+    name: string;
+    // item is is for committee i, which contains array of attester indices that's not seen (seen by default)
+    notSeenInStateByCommittee: number[][];
+    // item i is for committee i, each item is number[][] which is the indices of validators not seen by the committee
+    // each item i also decides how many attestations added to the pool for that committee
+    attParticipationByCommittee: number[][][];
+    // expected committeeBits of packed attestations, item 0 is for returned attestation 0, ...
+    packedCommitteeBits: number[][];
+    // expected aggregationBits of packed attestations: item 0 is for returned attestation 0, ...
+    packedAggregationBits: number[];
+  }[] = [
+    {
+      name: "Full participation",
+      notSeenInStateByCommittee: [
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+      ],
+      // each committee has exactly 1 full attestations
+      attParticipationByCommittee: [[[]], [[]], [[]], [[]]],
+      // 1 full packed attestation
+      packedCommitteeBits: [[0, 1, 2, 3]],
+      packedAggregationBits: [committeeLength * 4],
+    },
+    {
+      name: "Full participation but all are seen in the state",
+      notSeenInStateByCommittee: [[], [], [], []],
+      // each committee has exactly 1 full attestations
+      attParticipationByCommittee: [[[]], [[]], [[]], [[]]],
+      // no packed attestation
+      packedCommitteeBits: [],
+      packedAggregationBits: [],
+    },
+    {
+      name: "Committee 1 and 2 has 2 versions of aggregationBits",
+      notSeenInStateByCommittee: [
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+      ],
+      // committee 1 has 2 attestations, one with no participation validator 0, one with no participation validator 1
+      // committee 2 has 2 attestations, one with no participation validator 1, one with no participation validator 2
+      // committee 0 and 3 has 1 attestation each, and all validators are seen
+      attParticipationByCommittee: [[[]], [[0], [1]], [[1], [2]], [[]]],
+      // 2nd packed attestation only has 2 committees: 1 and 2
+      packedCommitteeBits: [
+        [0, 1, 2, 3],
+        [1, 2],
+      ],
+      packedAggregationBits: [committeeLength * 4, committeeLength * 2],
+    },
+    {
+      // same to above but no-participation validators are all seen in the state so only 1 attestation is returned
+      name: "Committee 1 and 2 has 2 versions of aggregationBits - only 1 attestation is included",
+      notSeenInStateByCommittee: [
+        [0, 1, 2, 3],
+        [2, 3],
+        [0, 1],
+        [0, 1, 2, 3],
+      ],
+      // committee 1 has 2 attestations, one with no participation validator 0, one with no participation validator 1
+      // committee 2 has 2 attestations, one with no participation validator 1, one with no participation validator 2
+      // committee 0 and 3 has 1 attestation each, and all validators are seen
+      attParticipationByCommittee: [[[]], [[0], [1]], [[1], [2]], [[]]],
+      // 2nd packed attestation only has 2 committees: 1 and 2
+      packedCommitteeBits: [[0, 1, 2, 3]],
+      packedAggregationBits: [committeeLength * 4],
+    },
+    {
+      name: "Only committee 1 has 2 versions of aggregationBits",
+      notSeenInStateByCommittee: [
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+        [0, 1, 2, 3],
+      ],
+      // committee 1 has 2 attestations, one with no participation validator 0, one with no participation validator 1
+      // other committees have 1 attestation each, and all validators are seen
+      attParticipationByCommittee: [[[]], [[0], [1]], [[]], [[]]],
+      // 2nd packed attestation only has 1 committeee
+      packedCommitteeBits: [[0, 1, 2, 3], [1]],
+      // 2nd packed attestation only has 1 committee
+      packedAggregationBits: [committeeLength * 4, committeeLength],
+    },
+  ];
 
-    const attestation0: Attestation<ForkPostElectra> = {
-      ...attestation,
-      aggregationBits: new BitArray(new Uint8Array(committeeLength / 8).fill(1), committeeLength),
-      committeeBits: committeeBits0,
-    };
+  for (const {
+    name,
+    notSeenInStateByCommittee,
+    attParticipationByCommittee,
+    packedCommitteeBits,
+    packedAggregationBits,
+  } of testCases) {
+    it(name, () => {
+      // this is related to NotSeenValidatorsFn, all validators are seen by default
+      const epochParticipation = newFilledArray(vc, 0b111);
+      for (let i = 0; i < committeeIndices.length; i++) {
+        const committeeIndex = committeeIndices[i];
+        const notSeenValidators = notSeenInStateByCommittee[i];
+        const committee = committees[committeeIndex];
+        for (const notSeenValidator of notSeenValidators) {
+          const validatorIndex = committee[notSeenValidator];
+          epochParticipation[validatorIndex] = 0b000;
+        }
+      }
 
-    // Attestation from committee 1
-    const committeeBits1 = BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, 1);
+      (electraState as CachedBeaconStateElectra).previousEpochParticipation =
+        ssz.altair.EpochParticipation.toViewDU(epochParticipation);
+      (electraState as CachedBeaconStateElectra).currentEpochParticipation =
+        ssz.altair.EpochParticipation.toViewDU(epochParticipation);
+      electraState.commit();
 
-    const attestation1: Attestation<ForkPostElectra> = {
-      ...attestation,
-      aggregationBits: new BitArray(new Uint8Array(committeeLength / 8).fill(1), committeeLength),
-      committeeBits: committeeBits1,
-    };
-    // Attestation from committee 2
-    const committeeBits2 = BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, 2);
+      for (let i = 0; i < committeeIndices.length; i++) {
+        const committeeIndex = committeeIndices[i];
+        const committeeBits = BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, committeeIndex);
+        // same committee, each is by attestation
+        const notSeenValidatorsByAttationIndex = attParticipationByCommittee[i];
+        for (const notSeenValidators of notSeenValidatorsByAttationIndex) {
+          const aggregationBits = new BitArray(new Uint8Array(committeeLength / 8).fill(255), committeeLength);
+          for (const index of notSeenValidators) {
+            aggregationBits.set(index, false);
+          }
+          const attestationi: Attestation<ForkPostElectra> = {
+            ...attestation,
+            aggregationBits,
+            committeeBits,
+          };
 
-    const attestation2: Attestation<ForkPostElectra> = {
-      ...attestation,
-      aggregationBits: new BitArray(new Uint8Array(committeeLength / 8).fill(1), committeeLength),
-      committeeBits: committeeBits2,
-    };
+          pool.add(attestationi, attDataRootHex, aggregationBits.getTrueBitIndexes().length, committees[i]);
+        }
+      }
 
-    // Attestation from committee 3
-    const committeeBits3 = BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, 3);
+      forkchoiceStub.getBlockHex.mockReturnValue(generateProtoBlock());
+      forkchoiceStub.getDependentRoot.mockReturnValue(ZERO_HASH_HEX);
 
-    const attestation3: Attestation<ForkPostElectra> = {
-      ...attestation,
-      aggregationBits: new BitArray(new Uint8Array(committeeLength / 8).fill(1), committeeLength),
-      committeeBits: committeeBits3,
-    };
-
-    pool.add(attestation0, attDataRootHex, attestation0.aggregationBits.getTrueBitIndexes().length, committees[0]);
-
-    pool.add(attestation1, attDataRootHex, attestation1.aggregationBits.getTrueBitIndexes().length, committees[1]);
-
-    pool.add(attestation2, attDataRootHex, attestation2.aggregationBits.getTrueBitIndexes().length, committees[2]);
-
-    pool.add(attestation3, attDataRootHex, attestation3.aggregationBits.getTrueBitIndexes().length, committees[3]);
-
-    forkchoiceStub.getBlockHex.mockReturnValue(generateProtoBlock());
-    forkchoiceStub.getDependentRoot.mockReturnValue(ZERO_HASH_HEX);
-
-    const blockAttestations = pool.getAttestationsForBlock(fork, forkchoiceStub, electraState);
-
-    expect(blockAttestations.length).toBe(1); // Expect attestations from committee 0, 1, 2 and 3 to be aggregated into one
-    expect((blockAttestations[0] as Attestation<ForkPostElectra>).committeeBits.getTrueBitIndexes()).toStrictEqual(
-      committeeIndices
-    );
-    expect((blockAttestations[0] as Attestation<ForkPostElectra>).aggregationBits.bitLen).toStrictEqual(
-      committeeLength * 4
-    );
-  });
+      const blockAttestations = pool.getAttestationsForBlock(fork, forkchoiceStub, electraState);
+      // make sure test data is correct
+      expect(packedCommitteeBits.length).toBe(packedAggregationBits.length);
+      expect(blockAttestations.length).toBe(packedCommitteeBits.length);
+      for (let attIndex = 0; attIndex < blockAttestations.length; attIndex++) {
+        const returnedAttestation = blockAttestations[attIndex] as Attestation<ForkPostElectra>;
+        expect(returnedAttestation.committeeBits.getTrueBitIndexes()).toStrictEqual(packedCommitteeBits[attIndex]);
+        expect(returnedAttestation.aggregationBits.bitLen).toStrictEqual(packedAggregationBits[attIndex]);
+      }
+    });
+  }
 });
 
 describe("MatchingDataAttestationGroup.add()", () => {
+  const config = createChainForkConfig({
+    ...defaultChainConfig,
+  });
+
   const testCases: {id: string; attestationsToAdd: {bits: number[]; res: InsertOutcome; isKept: boolean}[]}[] = [
     {
       id: "2 intersecting",
@@ -320,7 +408,7 @@ describe("MatchingDataAttestationGroup.add()", () => {
 
   for (const {id, attestationsToAdd} of testCases) {
     it(id, () => {
-      const attestationGroup = new MatchingDataAttestationGroup(committee, attestationData);
+      const attestationGroup = new MatchingDataAttestationGroup(config, committee, attestationData);
 
       const attestations = attestationsToAdd.map(
         ({bits}): phase0.Attestation => ({
@@ -350,37 +438,76 @@ describe("MatchingDataAttestationGroup.add()", () => {
 });
 
 describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
+  const config = createChainForkConfig({
+    ...defaultChainConfig,
+  });
+
+  const maxAttestations = 2;
   const testCases: {
     id: string;
     notSeenAttestingBits: number[];
-    attestationsToAdd: {bits: number[]; notSeenAttesterCount: number}[];
+    effectiveBalanceIncrements: Uint16Array;
+    attestationsToAdd: {
+      bits: number[];
+      newSeenEffectiveBalance: number;
+      notSeenAttesters: number;
+      returnedIndex: number;
+    }[];
   }[] = [
     // Note: attestationsToAdd MUST intersect in order to not be aggregated and distort the results
     {
       id: "All have attested",
       // same to seenAttestingBits: [0b11111111],
       notSeenAttestingBits: [0b00000000],
+      effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], notSeenAttesterCount: 0},
-        {bits: [0b00000011], notSeenAttesterCount: 0},
+        {bits: [0b11111110], newSeenEffectiveBalance: 0, notSeenAttesters: 0, returnedIndex: -1},
+        {bits: [0b00000011], newSeenEffectiveBalance: 0, notSeenAttesters: 0, returnedIndex: -1},
       ],
     },
     {
-      id: "Some have attested",
+      id: "Same effective balance - 2nd attestation is not valuable",
       // same to seenAttestingBits: [0b11110001]
       notSeenAttestingBits: [0b00001110],
+      effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], notSeenAttesterCount: 3},
-        {bits: [0b00000011], notSeenAttesterCount: 1},
+        {bits: [0b11111110], newSeenEffectiveBalance: 3 * 32, notSeenAttesters: 3, returnedIndex: 0},
+        // not valueable because seen attestations are all included in attestation 0
+        {bits: [0b00000011], newSeenEffectiveBalance: 0, notSeenAttesters: 0, returnedIndex: -1},
+      ],
+    },
+    {
+      id: "Same effective balance - include both",
+      // same to seenAttestingBits: [0b11110001]
+      notSeenAttestingBits: [0b00001110],
+      effectiveBalanceIncrements: new Uint16Array(8).fill(32),
+      attestationsToAdd: [
+        {bits: [0b11111010], newSeenEffectiveBalance: 2 * 32, notSeenAttesters: 2, returnedIndex: 0},
+        {bits: [0b10000101], newSeenEffectiveBalance: 1 * 32, notSeenAttesters: 1, returnedIndex: 1},
+      ],
+    },
+    {
+      id: "Prioritize bigger effective balance",
+      notSeenAttestingBits: [0b11111111],
+      effectiveBalanceIncrements: new Uint16Array([32, 2048, 32, 32, 32, 32, 32, 32]),
+      attestationsToAdd: [
+        // newSeenEffectiveBalance is not 6 * 32 considering the 1st included attestation
+        {bits: [0b11111001], newSeenEffectiveBalance: 4 * 32, notSeenAttesters: 4, returnedIndex: 1},
+        // although this has less not seen attesters, it has bigger effective balance so returned index is 0
+        {bits: [0b10000011], newSeenEffectiveBalance: 2048 + 2 * 32, notSeenAttesters: 3, returnedIndex: 0},
+        // maxAttestation is only 2
+        {bits: [0b00001101], newSeenEffectiveBalance: 0, notSeenAttesters: 0, returnedIndex: -1},
       ],
     },
     {
       id: "Non have attested",
       // same to seenAttestingBits: [0b00000000],
       notSeenAttestingBits: [0b11111111],
+      effectiveBalanceIncrements: new Uint16Array(8).fill(32),
       attestationsToAdd: [
-        {bits: [0b11111110], notSeenAttesterCount: 7},
-        {bits: [0b00000011], notSeenAttesterCount: 2},
+        {bits: [0b00111110], newSeenEffectiveBalance: 5 * 32, notSeenAttesters: 5, returnedIndex: 0},
+        // newSeenEffectiveBalance is not 3 * 32 considering the 1st included attestation already include attester 1
+        {bits: [0b01000011], newSeenEffectiveBalance: 2 * 32, notSeenAttesters: 2, returnedIndex: 1},
       ],
     },
   ];
@@ -388,15 +515,17 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
   const attestationData = ssz.phase0.AttestationData.defaultValue();
   const committee = Uint32Array.from(linspace(0, 7));
 
-  for (const {id, notSeenAttestingBits, attestationsToAdd} of testCases) {
+  for (const {id, notSeenAttestingBits, effectiveBalanceIncrements, attestationsToAdd} of testCases) {
+    // these are for electra attestations but it should work the same way to pre-electra
     it(id, () => {
-      const attestationGroup = new MatchingDataAttestationGroup(committee, attestationData);
+      const attestationGroup = new MatchingDataAttestationGroup(config, committee, attestationData);
 
       const attestations = attestationsToAdd.map(
-        ({bits}): phase0.Attestation => ({
+        ({bits}): electra.Attestation => ({
           data: attestationData,
           aggregationBits: new BitArray(new Uint8Array(bits), 8),
           signature: validSignature,
+          committeeBits: BitArray.fromSingleBit(MAX_COMMITTEES_PER_SLOT, 0),
         })
       );
 
@@ -405,7 +534,6 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       }
 
       const notSeenAggBits = new BitArray(new Uint8Array(notSeenAttestingBits), 8);
-      // const notSeenValidatorIndices: (ValidatorIndex | null)[] = [];
       const notSeenAttestingIndices = new Set<number>();
       for (let i = 0; i < committee.length; i++) {
         // notSeenValidatorIndices.push(notSeenAggBits.get(i) ? committee[i] : null);
@@ -414,15 +542,20 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
         }
       }
       const attestationsForBlock = attestationGroup.getAttestationsForBlock(
-        ForkName.phase0,
-        // notSeenValidatorIndices,
-        notSeenAttestingIndices
+        ForkName.electra,
+        effectiveBalanceIncrements,
+        notSeenAttestingIndices,
+        maxAttestations
       );
 
-      for (const [i, {notSeenAttesterCount}] of attestationsToAdd.entries()) {
-        const attestation = attestationsForBlock.find((a) => a.attestation === attestations[i]);
+      for (const [i, {newSeenEffectiveBalance, returnedIndex}] of attestationsToAdd.entries()) {
+        const attestationIndex = attestationsForBlock.findIndex((a) => a.attestation === attestations[i]);
+        expect(attestationIndex).toBe(returnedIndex);
+        const attestation = attestationsForBlock[attestationIndex];
         // If notSeenAttesterCount === 0 the attestation is not returned
-        expect(attestation ? attestation.notSeenAttesterCount : 0).toBe(notSeenAttesterCount);
+        if (returnedIndex !== -1) {
+          expect(attestation ? attestation.newSeenEffectiveBalance : 0).toBe(newSeenEffectiveBalance);
+        }
       }
     });
   }
@@ -497,7 +630,10 @@ describe("aggregateConsolidation", () => {
       const consolidation: AttestationsConsolidation = {
         byCommittee: new Map(),
         attData: attData,
-        totalNotSeenCount: 0,
+        totalNewSeenEffectiveBalance: 0,
+        committeeSize: 32,
+        newSeenAttesters: 0,
+        notSeenAttesters: 0,
       };
       // to simplify, instead of signing the signingRoot, just sign the attData root
       const sigArr = skArr.map((sk) => sk.sign(ssz.phase0.AttestationData.hashTreeRoot(attData)));
@@ -515,7 +651,9 @@ describe("aggregateConsolidation", () => {
         };
         consolidation.byCommittee.set(committeeIndex, {
           attestation: aggAttestation,
-          notSeenAttesterCount: aggregationBitsArr[i].filter((item) => item).length,
+          newSeenEffectiveBalance: aggregationBitsArr[i].filter((item) => item).length * 32,
+          notSeenAttendingIndices: new Set(),
+          newSeenAttesters: 0,
         });
       }
 

--- a/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/aggregatedAttestationPool.test.ts
@@ -450,7 +450,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       bits: number[];
       newSeenEffectiveBalance: number;
       newSeenAttesters: number;
-      notSeenAttestingIndices: Set<number> | null;
+      notSeenCommitteeMembers: Set<number> | null;
       returnedIndex: number;
     }[];
   }[] = [
@@ -465,14 +465,14 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b11111110],
           newSeenEffectiveBalance: 0,
           newSeenAttesters: 0,
-          notSeenAttestingIndices: null,
+          notSeenCommitteeMembers: null,
           returnedIndex: -1,
         },
         {
           bits: [0b00000011],
           newSeenEffectiveBalance: 0,
           newSeenAttesters: 0,
-          notSeenAttestingIndices: null,
+          notSeenCommitteeMembers: null,
           returnedIndex: -1,
         },
       ],
@@ -487,7 +487,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b11111110],
           newSeenEffectiveBalance: 3 * 32,
           newSeenAttesters: 3,
-          notSeenAttestingIndices: new Set([]),
+          notSeenCommitteeMembers: new Set([]),
           returnedIndex: 0,
         },
         // not valuable because seen attestations are all included in attestation 0
@@ -495,7 +495,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b00000011],
           newSeenEffectiveBalance: 0,
           newSeenAttesters: 0,
-          notSeenAttestingIndices: null,
+          notSeenCommitteeMembers: null,
           returnedIndex: -1,
         },
       ],
@@ -510,14 +510,14 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b11111010],
           newSeenEffectiveBalance: 2 * 32,
           newSeenAttesters: 2,
-          notSeenAttestingIndices: new Set([2]),
+          notSeenCommitteeMembers: new Set([2]),
           returnedIndex: 0,
         },
         {
           bits: [0b10000101],
           newSeenEffectiveBalance: 1 * 32,
           newSeenAttesters: 1,
-          notSeenAttestingIndices: new Set(),
+          notSeenCommitteeMembers: new Set(),
           returnedIndex: 1,
         },
       ],
@@ -532,7 +532,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b11111001],
           newSeenEffectiveBalance: 4 * 32,
           newSeenAttesters: 4,
-          notSeenAttestingIndices: new Set([2]),
+          notSeenCommitteeMembers: new Set([2]),
           returnedIndex: 1,
         },
         // although this has less not seen attesters, it has bigger effective balance so returned index is 0
@@ -540,7 +540,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b10000011],
           newSeenEffectiveBalance: 2048 + 2 * 32,
           newSeenAttesters: 3,
-          notSeenAttestingIndices: new Set([2, 3, 4, 5, 6]),
+          notSeenCommitteeMembers: new Set([2, 3, 4, 5, 6]),
           returnedIndex: 0,
         },
         // maxAttestation is only 2
@@ -548,7 +548,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b00001101],
           newSeenEffectiveBalance: 0,
           newSeenAttesters: 0,
-          notSeenAttestingIndices: null,
+          notSeenCommitteeMembers: null,
           returnedIndex: -1,
         },
       ],
@@ -563,7 +563,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b00111110],
           newSeenEffectiveBalance: 5 * 32,
           newSeenAttesters: 5,
-          notSeenAttestingIndices: new Set([0, 6, 7]),
+          notSeenCommitteeMembers: new Set([0, 6, 7]),
           returnedIndex: 0,
         },
         // newSeenEffectiveBalance is not 3 * 32 considering the 1st included attestation already include attester 1
@@ -571,7 +571,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
           bits: [0b01000011],
           newSeenEffectiveBalance: 2 * 32,
           newSeenAttesters: 2,
-          notSeenAttestingIndices: new Set([7]),
+          notSeenCommitteeMembers: new Set([7]),
           returnedIndex: 1,
         },
       ],
@@ -600,23 +600,23 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
       }
 
       const notSeenAggBits = new BitArray(new Uint8Array(notSeenAttestingBits), 8);
-      const notSeenAttestingIndices = new Set<number>();
+      const notSeenCommitteeMembers = new Set<number>();
       for (let i = 0; i < committee.length; i++) {
         // notSeenValidatorIndices.push(notSeenAggBits.get(i) ? committee[i] : null);
         if (notSeenAggBits.get(i)) {
-          notSeenAttestingIndices.add(i);
+          notSeenCommitteeMembers.add(i);
         }
       }
       const attestationsForBlock = attestationGroup.getAttestationsForBlock(
         ForkName.electra,
         effectiveBalanceIncrements,
-        notSeenAttestingIndices,
+        notSeenCommitteeMembers,
         maxAttestations
       );
 
       for (const [
         i,
-        {newSeenEffectiveBalance, newSeenAttesters, notSeenAttestingIndices: notSeenAttendingIndices, returnedIndex},
+        {newSeenEffectiveBalance, newSeenAttesters, notSeenCommitteeMembers: notSeenAttendingIndices, returnedIndex},
       ] of attestationsToAdd.entries()) {
         const attestationIndex = attestationsForBlock.findIndex((a) => a.attestation === attestations[i]);
         expect(attestationIndex).toBe(returnedIndex);
@@ -625,7 +625,7 @@ describe("MatchingDataAttestationGroup.getAttestationsForBlock", () => {
         if (returnedIndex !== -1) {
           expect(attestation ? attestation.newSeenEffectiveBalance : 0).toBe(newSeenEffectiveBalance);
           expect(attestation ? attestation.newSeenAttesters : 0).toBe(newSeenAttesters);
-          expect(attestation ? attestation.notSeenAttestingIndices : 0).toStrictEqual(notSeenAttendingIndices);
+          expect(attestation ? attestation.notSeenCommitteeMembers : 0).toStrictEqual(notSeenAttendingIndices);
         }
       }
     });
@@ -723,7 +723,7 @@ describe("aggregateConsolidation", () => {
         consolidation.byCommittee.set(committeeIndex, {
           attestation: aggAttestation,
           newSeenEffectiveBalance: aggregationBitsArr[i].filter((item) => item).length * 32,
-          notSeenAttestingIndices: new Set(),
+          notSeenCommitteeMembers: new Set(),
           newSeenAttesters: 0,
         });
       }


### PR DESCRIPTION
**Motivation**

- packed attestations are currently sorted by new seen attesters, should be by effective balance
- not enough metrics when producing packed attestations

**Description**

- for electra, retain up to 8 attestations per group. When getting attestations, we also get up to 8 of them (instead of 3)
- track packed attestations by new seen effective balance
- reevaluate every attestation after an attestation is included, see `getMostValuableAttestation()`. This means there is no useless attestations included
- add a lot of metrics:
  - committee bits for each packed attestation
  - total committee members of each packed attestation
  - non-participation of each packed attestation
  - distance from block slot to attestation slot for each packed attestation
  - total effective balance for each packed attestations
  - scanned slots and termination reason
  - scanned attestations per scanned slot
  - returned attestations per scanned slot
  - total slots in pool at the time of producing block
  - total consolidations

Closes #7544

**Testing**

- see some metrics here https://github.com/ChainSafe/lodestar/pull/7646#issuecomment-2771932411
- performance are the same on hoodi prod node

<img width="846" alt="Screenshot 2025-04-08 at 16 09 17" src="https://github.com/user-attachments/assets/7ffb3bcb-7774-4383-b2e7-da1065ff8f97" />

