### PR TITLE
feat: track insert outcome of aggregated attestations to oppool

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1320,12 +1320,14 @@ export function getValidatorApi(
               beaconBlockRoot
             );
 
-            chain.aggregatedAttestationPool.add(
+            const insertOutcome = chain.aggregatedAttestationPool.add(
               signedAggregateAndProof.message.aggregate,
               attDataRootHex,
               indexedAttestation.attestingIndices.length,
               committeeIndices
             );
+            metrics?.opPool.aggregatedAttestationPool.apiInsertOutcome.inc({insertOutcome});
+
             const sentPeers = await network.publishBeaconAggregateAndProof(signedAggregateAndProof);
             metrics?.onPoolSubmitAggregatedAttestation(seenTimestampSec, indexedAttestation, sentPeers);
           } catch (e) {

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -913,7 +913,7 @@ export function createLodestarMetrics(
         }),
         apiInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
           name: "lodestar_oppool_attestation_pool_api_insert_outcome_total",
-          help: "Total number of InsertOutcome as a result of adding a single attestation from api in the pool",
+          help: "Total number of InsertOutcome as a result of adding a single attestation from api to the pool",
           labelNames: ["insertOutcome"],
         }),
         getAggregateCacheMisses: register.counter({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -890,6 +890,16 @@ export function createLodestarMetrics(
           help: "Number of attestations per committee in AggregatedAttestationPool",
           buckets: [0, 2, 4, 8],
         }),
+        gossipInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
+          name: "lodestar_oppool_aggregated_attestation_pool_gossip_insert_outcome_total",
+          help: "Total number of InsertOutcome as a result of adding an aggregated attestation from gossip in the pool",
+          labelNames: ["insertOutcome"],
+        }),
+        apiInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
+          name: "lodestar_oppool_aggregated_attestation_pool_api_insert_outcome_total",
+          help: "Total number of InsertOutcome as a result of adding an aggregated attestation from api in the pool",
+          labelNames: ["insertOutcome"],
+        }),
       },
       attestationPool: {
         size: register.gauge({
@@ -898,12 +908,12 @@ export function createLodestarMetrics(
         }),
         gossipInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
           name: "lodestar_oppool_attestation_pool_gossip_insert_outcome_total",
-          help: "Total number of InsertOutcome as a result of adding a gossip attestation in a pool",
+          help: "Total number of InsertOutcome as a result of adding a single attestation from gossip to the pool",
           labelNames: ["insertOutcome"],
         }),
         apiInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
           name: "lodestar_oppool_attestation_pool_api_insert_outcome_total",
-          help: "Total number of InsertOutcome as a result of adding an attestation from api in a pool",
+          help: "Total number of InsertOutcome as a result of adding a single attestation from api in the pool",
           labelNames: ["insertOutcome"],
         }),
         getAggregateCacheMisses: register.counter({

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -431,12 +431,13 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       metrics?.registerGossipAggregatedAttestation(seenTimestampSec, signedAggregateAndProof, indexedAttestation);
       const aggregatedAttestation = signedAggregateAndProof.message.aggregate;
 
-      chain.aggregatedAttestationPool.add(
+      const insertOutcome = chain.aggregatedAttestationPool.add(
         aggregatedAttestation,
         attDataRootHex,
         indexedAttestation.attestingIndices.length,
         committeeIndices
       );
+      metrics?.opPool.aggregatedAttestationPool.gossipInsertOutcome.inc({insertOutcome});
 
       if (!options.dontSendGossipAttestationsToForkchoice) {
         try {


### PR DESCRIPTION
**Motivation**

This information might be useful to diagnose why we might not be packing as many aggregates into a block as we would expect.

Similar reasoning to https://github.com/ChainSafe/lodestar/pull/7550.

**Description**

Adds two metrics to track insert outcome of aggregated attestations to oppool
- `lodestar_oppool_aggregated_attestation_pool_gossip_insert_outcome_total`
- `lodestar_oppool_aggregated_attestation_pool_api_insert_outcome_total`

Dashboard panels come later :)
