### PR TITLE
chore: adjust buckets to track number of attestations in our blocks

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -162,7 +162,7 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
     blockProductionNumAggregated: register.histogram<{source: ProducedBlockSource}>({
       name: "beacon_block_production_num_aggregated_total",
       help: "Count of all aggregated attestations in our produced block",
-      buckets: [1, 2, 4, 8],
+      buckets: [1, 2, 4, 6, 8],
       labelNames: ["source"],
     }),
     blockProductionExecutionPayloadValue: register.histogram<{source: ProducedBlockSource}>({

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -162,7 +162,7 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
     blockProductionNumAggregated: register.histogram<{source: ProducedBlockSource}>({
       name: "beacon_block_production_num_aggregated_total",
       help: "Count of all aggregated attestations in our produced block",
-      buckets: [32, 64, 96, 128],
+      buckets: [1, 2, 4, 8],
       labelNames: ["source"],
     }),
     blockProductionExecutionPayloadValue: register.histogram<{source: ProducedBlockSource}>({


### PR DESCRIPTION
The current buckets `[32, 64, 96, 128]` are no longer meaningful post-electra since we can only include max. 8 attestations per block and as I don't think we need this metric from now until electra goes live on mainnet we should adjust it already to give us more meaningful data for electra networks, like hoodi or holesky.