### PR TITLE
feat: peerDAS - implement distributed blob publishing

### DIFF
--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -1,6 +1,6 @@
 import type {ChainForkConfig} from "@lodestar/config";
 import type {DataAvailabilityStatus, MaybeValidExecutionStatus} from "@lodestar/fork-choice";
-import {type ForkPostDeneb, type ForkName, ForkSeq} from "@lodestar/params";
+import {type ForkPostDeneb, ForkSeq, ForkPreFulu, ForkPostFulu} from "@lodestar/params";
 import {type CachedBeaconStateAllForks, computeEpochAtSlot} from "@lodestar/state-transition";
 import type {ColumnIndex, RootHex, SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
 
@@ -48,7 +48,7 @@ export enum BlobsSource {
   byRoot = "req_resp_by_root",
 }
 type ForkBlobsInfo = {
-  fork: ForkPostDeneb;
+  fork: ForkPostDeneb & ForkPreFulu;
 };
 export type BlockInputBlobs = ForkBlobsInfo & {
   blobs: deneb.BlobSidecars;
@@ -73,7 +73,7 @@ export enum DataColumnsSource {
   byRoot = "req_resp_by_root",
 }
 type ForkDataColumnsInfo = {
-  fork: ForkName.fulu;
+  fork: ForkPostFulu;
 };
 type DataColumnData = {
   dataColumn: fulu.DataColumnSidecar;

--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -49,7 +49,7 @@ export async function writeBlockInputToDb(this: BeaconChain, blocksInput: BlockI
           root: blockRootHex,
         });
       } else {
-        const {custodyConfig} = this.seenGossipBlockInput;
+        const {custodyConfig} = this;
         const {custodyColumnsIndex, custodyColumns} = custodyConfig;
         const blobsLen = (block.message as fulu.BeaconBlock).body.blobKzgCommitments.length;
         let dataColumnsLen: number;
@@ -126,7 +126,7 @@ export async function removeEagerlyPersistedBlockInputs(this: BeaconChain, block
           const blobSidecars = blockData.blobs;
           blobsToRemove.push({blockRoot, slot, blobSidecars});
         } else {
-          const {custodyConfig} = this.seenGossipBlockInput;
+          const {custodyConfig} = this;
           const {custodyColumnsIndex: dataColumnsIndex, custodyColumns} = custodyConfig;
           const dataColumnsLen = custodyColumns.length;
           const dataColumnSidecars = (blockData as BlockInputDataColumns).dataColumns.filter((dataColumnSidecar) =>

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -255,7 +255,7 @@ export class BeaconChain implements IBeaconChain {
     this.seenContributionAndProof = new SeenContributionAndProof(metrics);
     this.seenAttestationDatas = new SeenAttestationDatas(metrics, this.opts?.attDataCacheSlotDistance);
     this.custodyConfig = new CustodyConfig(nodeId, config);
-    this.seenGossipBlockInput = new SeenGossipBlockInput(this.custodyConfig);
+    this.seenGossipBlockInput = new SeenGossipBlockInput(this.custodyConfig, this.executionEngine, emitter);
 
     this.beaconProposerCache = new BeaconProposerCache(opts);
     this.checkpointBalancesCache = new CheckpointBalancesCache();

--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -4,7 +4,7 @@ import {StrictEventEmitter} from "strict-event-emitter-types";
 import {routes} from "@lodestar/api";
 import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
-import {phase0} from "@lodestar/types";
+import {phase0, fulu} from "@lodestar/types";
 
 /**
  * Important chain events that occur during normal chain operation.
@@ -42,6 +42,11 @@ export enum ChainEvent {
    * This event signals that the chain is ready to advertise the given group count to the network.
    */
   updateAdvertisedGroupCount = "updateAdvertisedGroupCount",
+  /**
+   * This event signals that data columns have been fetched from the execution engine
+   * and are ready to be published.
+   */
+  publishDataColumns = "publishDataColumns",
 }
 
 export type HeadEventData = routes.events.EventData[routes.events.EventType.head];
@@ -58,6 +63,8 @@ export type IChainEvents = ApiEvents & {
 
   [ChainEvent.updateTargetGroupCount]: (targetGroupCount: number) => void;
   [ChainEvent.updateAdvertisedGroupCount]: (advertisedGroupCount: number) => void;
+
+  [ChainEvent.publishDataColumns]: (sidecars: fulu.DataColumnSidecar[]) => void;
 };
 
 /**

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -1,21 +1,28 @@
 import {toHexString} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {BLOBSIDECAR_FIXED_SIZE, ForkName, NUMBER_OF_COLUMNS, isForkPostDeneb} from "@lodestar/params";
+import {ForkName, NUMBER_OF_COLUMNS, isForkPostDeneb} from "@lodestar/params";
 import {RootHex, SignedBeaconBlock, deneb, fulu, ssz} from "@lodestar/types";
-import {pruneSetToMax, toRootHex} from "@lodestar/utils";
+import {pruneSetToMax} from "@lodestar/utils";
 
+import {IExecutionEngine} from "../../execution/index.js";
 import {Metrics} from "../../metrics/index.js";
-import {CustodyConfig} from "../../util/dataColumns.js";
-import {SerializedCache} from "../../util/serializedCache.js";
+import {kzgCommitmentToVersionedHash} from "../../util/blobs.js";
+import {
+  CustodyConfig,
+  getCellsAndProofs,
+  getDataColumnSidecarsFromBlock,
+  getDataColumnSidecarsFromColumnSidecar,
+} from "../../util/dataColumns.js";
+import {callInNextEventLoop} from "../../util/eventLoop.js";
 import {
   BlobsSource,
   BlockInput,
   BlockInputBlobs,
   BlockInputDataColumns,
   BlockSource,
-  CachedBlobs,
   CachedData,
   CachedDataColumns,
+  DataColumnsCacheMap,
   DataColumnsSource,
   GossipedInputType,
   NullBlockInput,
@@ -23,6 +30,7 @@ import {
   getBlockInputBlobs,
   getBlockInputDataColumns,
 } from "../blocks/types.js";
+import {ChainEvent, ChainEventEmitter} from "../emitter.js";
 
 export enum BlockInputAvailabilitySource {
   GOSSIP = "gossip",
@@ -79,10 +87,15 @@ const MAX_GOSSIPINPUT_CACHE = 5;
  * block are seen by SeenGossipBlockInput
  */
 export class SeenGossipBlockInput {
-  private blockInputCache = new Map<RootHex, BlockInputCacheType>();
-  custodyConfig: CustodyConfig;
-  constructor(custodyConfig: CustodyConfig) {
+  private readonly blockInputCache = new Map<RootHex, BlockInputCacheType>();
+  private readonly custodyConfig: CustodyConfig;
+  private readonly executionEngine: IExecutionEngine;
+  private readonly emitter: ChainEventEmitter;
+
+  constructor(custodyConfig: CustodyConfig, executionEngine: IExecutionEngine, emitter: ChainEventEmitter) {
     this.custodyConfig = custodyConfig;
+    this.executionEngine = executionEngine;
+    this.emitter = emitter;
   }
   globalCacheId = 0;
 
@@ -138,7 +151,7 @@ export class SeenGossipBlockInput {
       }
 
       // TODO: freetheblobs check if its the same blob or a duplicate and throw/take actions
-      (blockCache.cachedData as CachedDataColumns)?.dataColumnsCache.set(dataColumnSidecar.index, {
+      blockCache.cachedData?.dataColumnsCache.set(dataColumnSidecar.index, {
         dataColumn: dataColumnSidecar,
         // easily splice out the unsigned message as blob is a fixed length type
         dataColumnBytes: dataColumnBytes?.slice(0, dataColumnBytes.length) ?? null,
@@ -150,6 +163,9 @@ export class SeenGossipBlockInput {
 
     if (!this.blockInputCache.has(blockHex)) {
       this.blockInputCache.set(blockHex, blockCache);
+      callInNextEventLoop(() => {
+        this.reconstructColumns(config, blockHex);
+      });
     }
 
     const {block: signedBlock, blockInputPromise, resolveBlockInput, cachedData} = blockCache;
@@ -247,13 +263,8 @@ export class SeenGossipBlockInput {
           };
         }
 
-        const sampledColumns = this.custodyConfig.sampledColumns;
-        const sampledIndexesPresent =
-          dataColumnsCache.size >= sampledColumns.length &&
-          sampledColumns.reduce((acc, columnIndex) => acc && dataColumnsCache.has(columnIndex), true);
-
-        if (sampledIndexesPresent) {
-          const allDataColumns = getBlockInputDataColumns(dataColumnsCache, sampledColumns);
+        if (this.hasSampledDataColumns(dataColumnsCache)) {
+          const allDataColumns = getBlockInputDataColumns(dataColumnsCache, this.custodyConfig.sampledColumns);
           metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
           const {dataColumns} = allDataColumns;
           const blockData: BlockInputDataColumns = {
@@ -272,7 +283,7 @@ export class SeenGossipBlockInput {
             blockInputMeta: {
               pending: null,
               haveColumns: dataColumns.length,
-              expectedColumns: sampledColumns.length,
+              expectedColumns: this.custodyConfig.sampledColumns.length,
             },
           };
         }
@@ -285,7 +296,7 @@ export class SeenGossipBlockInput {
           blockInputMeta: {
             pending: GossipedInputType.dataColumn,
             haveColumns: dataColumnsCache.size,
-            expectedColumns: sampledColumns.length,
+            expectedColumns: this.custodyConfig.sampledColumns.length,
           },
         };
       }
@@ -349,6 +360,100 @@ export class SeenGossipBlockInput {
     //   },
     //   blockInputMeta: {pending: GossipedInputType.block, haveBlobs: blobsCache.size, expectedBlobs: null},
     // };
+  }
+
+  private hasSampledDataColumns(dataColumnCache: DataColumnsCacheMap): boolean {
+    return (
+      dataColumnCache.size >= this.custodyConfig.sampledColumns.length &&
+      this.custodyConfig.sampledColumns.reduce((acc, columnIndex) => acc && dataColumnCache.has(columnIndex), true)
+    );
+  }
+
+  private async reconstructColumns(config: ChainForkConfig, blockRoot: RootHex) {
+    const blockCache = this.blockInputCache.get(blockRoot);
+    if (blockCache === undefined || blockCache.fork !== ForkName.fulu) {
+      return;
+    }
+
+    // If already have all columns, exit
+    if (
+      blockCache.cachedData &&
+      (blockCache.cachedData.fork !== ForkName.fulu ||
+        this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache))
+    ) {
+      return;
+    }
+
+    // Process KZG commitments into versioned hashes
+    let versionedHashes: Uint8Array[];
+
+    if (blockCache.block) {
+      const block = blockCache.block as fulu.SignedBeaconBlock;
+      versionedHashes = block.message.body.blobKzgCommitments.map(kzgCommitmentToVersionedHash);
+    } else if (blockCache.cachedData) {
+      const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
+      if (!firstSidecar) {
+        return;
+      }
+
+      versionedHashes = firstSidecar.dataColumn.kzgCommitments.map(kzgCommitmentToVersionedHash);
+    } else {
+      throw new Error("blockInputCache missing both block and cachedData");
+    }
+
+    // Return if block has no blobs
+    if (versionedHashes.length === 0) {
+      return;
+    }
+
+    // Get blobs from execution engine
+    const blobs = await this.executionEngine.getBlobs(blockCache.fork, versionedHashes);
+
+    // Execution engine was unable to find one or more blobs
+    if (blobs === null) {
+      return;
+    }
+
+    // Return if we received all data columns while waiting for getBlobs
+    if (blockCache.cachedData && this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache)) {
+      return;
+    }
+
+    let dataColumnSidecars: fulu.DataColumnSidecars;
+    const cellsAndProofs = getCellsAndProofs(blobs);
+    if (blockCache.block) {
+      dataColumnSidecars = getDataColumnSidecarsFromBlock(
+        config,
+        blockCache.block as fulu.SignedBeaconBlock,
+        cellsAndProofs
+      );
+    } else if (blockCache.cachedData) {
+      const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
+      if (!firstSidecar) {
+        return;
+      }
+      dataColumnSidecars = getDataColumnSidecarsFromColumnSidecar(firstSidecar.dataColumn, cellsAndProofs);
+    } else {
+      throw new Error("blockInputCache missing both block and cachedData");
+    }
+
+    // Publish columns if and only if subscribed to them
+    const sampledColumns = this.custodyConfig.sampledColumns.map((columnIndex) => dataColumnSidecars[columnIndex]);
+
+    this.emitter.emit(ChainEvent.publishDataColumns, sampledColumns);
+
+    for (const column of sampledColumns) {
+      this.getGossipBlockInput(
+        config,
+        {
+          type: GossipedInputType.dataColumn,
+          dataColumnSidecar: column,
+          dataColumnBytes: null,
+        },
+        // TODO: Pass in metrics. Should this use a different availability source?
+        null
+      );
+    }
   }
 }
 

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -430,7 +430,7 @@ export class SeenGossipBlockInput {
     } else if (blockCache.cachedData) {
       const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
       if (!firstSidecar) {
-        return;
+        throw new Error("blockInputCache missing both block and data column sidecar");
       }
       dataColumnSidecars = getDataColumnSidecarsFromColumnSidecar(firstSidecar.dataColumn, cellsAndProofs);
     } else {

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -371,17 +371,16 @@ export class SeenGossipBlockInput {
 
   private async reconstructColumns(config: ChainForkConfig, blockRoot: RootHex) {
     const blockCache = this.blockInputCache.get(blockRoot);
-    if (
-      blockCache === undefined ||
-      blockCache.fork !== ForkName.fulu ||
-      blockCache.cachedData === undefined ||
-      blockCache.cachedData.fork !== ForkName.fulu
-    ) {
+    if (blockCache === undefined || blockCache.fork !== ForkName.fulu) {
       return;
     }
 
     // If already have all columns, exit
-    if (this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache)) {
+    if (
+      blockCache.cachedData &&
+      (blockCache.cachedData.fork !== ForkName.fulu ||
+        this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache))
+    ) {
       return;
     }
 
@@ -390,7 +389,7 @@ export class SeenGossipBlockInput {
       const block = blockCache.block as fulu.SignedBeaconBlock;
       commitments = block.message.body.blobKzgCommitments;
     } else {
-      const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
+      const firstSidecar = blockCache.cachedData?.dataColumnsCache.values().next().value;
       commitments = firstSidecar?.dataColumn.kzgCommitments;
     }
 
@@ -415,7 +414,7 @@ export class SeenGossipBlockInput {
     }
 
     // Return if we received all data columns while waiting for getBlobs
-    if (this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache)) {
+    if (blockCache.cachedData && this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache)) {
       return;
     }
 
@@ -427,12 +426,14 @@ export class SeenGossipBlockInput {
         blockCache.block as fulu.SignedBeaconBlock,
         cellsAndProofs
       );
-    } else {
+    } else if (blockCache.cachedData) {
       const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
       if (!firstSidecar) {
         throw new Error("blockInputCache missing both block and data column sidecar");
       }
       dataColumnSidecars = getDataColumnSidecarsFromColumnSidecar(firstSidecar.dataColumn, cellsAndProofs);
+    } else {
+      throw new Error("blockInputCache missing both block and cached data");
     }
 
     // Publish columns if and only if subscribed to them
@@ -440,27 +441,29 @@ export class SeenGossipBlockInput {
 
     this.emitter.emit(ChainEvent.publishDataColumns, sampledColumns);
 
-    for (const column of sampledColumns) {
-      blockCache.cachedData.dataColumnsCache.set(column.index, {dataColumn: column, dataColumnBytes: null});
-    }
+    if (blockCache.cachedData) {
+      for (const column of sampledColumns) {
+        blockCache.cachedData.dataColumnsCache.set(column.index, {dataColumn: column, dataColumnBytes: null});
+      }
 
-    if (blockCache.block) {
-      const allDataColumns = getBlockInputDataColumns(
-        blockCache.cachedData.dataColumnsCache,
-        this.custodyConfig.sampledColumns
-      );
-      // TODO: Add metrics
-      // metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
-      const blockData: BlockInputDataColumns = {
-        fork: blockCache.cachedData.fork,
-        ...allDataColumns,
-        dataColumnsSource: DataColumnsSource.gossip,
-      };
-      blockCache.cachedData.resolveAvailability(blockData);
+      if (blockCache.block) {
+        const allDataColumns = getBlockInputDataColumns(
+          blockCache.cachedData.dataColumnsCache,
+          this.custodyConfig.sampledColumns
+        );
+        // TODO: Add metrics
+        // metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
+        const blockData: BlockInputDataColumns = {
+          fork: blockCache.cachedData.fork,
+          ...allDataColumns,
+          dataColumnsSource: DataColumnsSource.gossip,
+        };
+        blockCache.cachedData.resolveAvailability(blockData);
 
-      const blockInput = getBlockInput.availableData(config, blockCache.block, BlockSource.gossip, blockData);
+        const blockInput = getBlockInput.availableData(config, blockCache.block, BlockSource.gossip, blockData);
 
-      blockCache.resolveBlockInput(blockInput);
+        blockCache.resolveBlockInput(blockInput);
+      }
     }
   }
 }

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -393,7 +393,7 @@ export class SeenGossipBlockInput {
     } else if (blockCache.cachedData) {
       const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
       if (!firstSidecar) {
-        return;
+        throw new Error("blockInputCache missing both block and data column sidecar");
       }
 
       versionedHashes = firstSidecar.dataColumn.kzgCommitments.map(kzgCommitmentToVersionedHash);

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -460,7 +460,7 @@ export class SeenGossipBlockInput {
     };
     blockCache.cachedData.resolveAvailability(blockData);
 
-    if (blockCache.block) {
+    if (blockCache.block !== undefined) {
       const blockInput = getBlockInput.availableData(config, blockCache.block, BlockSource.gossip, blockData);
 
       blockCache.resolveBlockInput(blockInput);

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -375,11 +375,15 @@ export class SeenGossipBlockInput {
       return;
     }
 
+    if (!blockCache.cachedData) {
+      // this condition should never get hit... just a sanity check
+      throw new Error("invalid blockCache");
+    }
+
     // If already have all columns, exit
     if (
-      blockCache.cachedData &&
-      (blockCache.cachedData.fork !== ForkName.fulu ||
-        this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache))
+      blockCache.cachedData.fork !== ForkName.fulu ||
+      this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache)
     ) {
       return;
     }
@@ -389,7 +393,7 @@ export class SeenGossipBlockInput {
       const block = blockCache.block as fulu.SignedBeaconBlock;
       commitments = block.message.body.blobKzgCommitments;
     } else {
-      const firstSidecar = blockCache.cachedData?.dataColumnsCache.values().next().value;
+      const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
       commitments = firstSidecar?.dataColumn.kzgCommitments;
     }
 
@@ -414,7 +418,7 @@ export class SeenGossipBlockInput {
     }
 
     // Return if we received all data columns while waiting for getBlobs
-    if (blockCache.cachedData && this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache)) {
+    if (this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache)) {
       return;
     }
 
@@ -426,14 +430,12 @@ export class SeenGossipBlockInput {
         blockCache.block as fulu.SignedBeaconBlock,
         cellsAndProofs
       );
-    } else if (blockCache.cachedData) {
+    } else {
       const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
       if (!firstSidecar) {
         throw new Error("blockInputCache missing both block and data column sidecar");
       }
       dataColumnSidecars = getDataColumnSidecarsFromColumnSidecar(firstSidecar.dataColumn, cellsAndProofs);
-    } else {
-      throw new Error("blockInputCache missing both block and cached data");
     }
 
     // Publish columns if and only if subscribed to them
@@ -441,29 +443,27 @@ export class SeenGossipBlockInput {
 
     this.emitter.emit(ChainEvent.publishDataColumns, sampledColumns);
 
-    if (blockCache.cachedData) {
-      for (const column of sampledColumns) {
-        blockCache.cachedData.dataColumnsCache.set(column.index, {dataColumn: column, dataColumnBytes: null});
-      }
+    for (const column of sampledColumns) {
+      blockCache.cachedData.dataColumnsCache.set(column.index, {dataColumn: column, dataColumnBytes: null});
+    }
 
-      if (blockCache.block) {
-        const allDataColumns = getBlockInputDataColumns(
-          blockCache.cachedData.dataColumnsCache,
-          this.custodyConfig.sampledColumns
-        );
-        // TODO: Add metrics
-        // metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
-        const blockData: BlockInputDataColumns = {
-          fork: blockCache.cachedData.fork,
-          ...allDataColumns,
-          dataColumnsSource: DataColumnsSource.gossip,
-        };
-        blockCache.cachedData.resolveAvailability(blockData);
+    const allDataColumns = getBlockInputDataColumns(
+      blockCache.cachedData.dataColumnsCache,
+      this.custodyConfig.sampledColumns
+    );
+    // TODO: Add metrics
+    // metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
+    const blockData: BlockInputDataColumns = {
+      fork: blockCache.cachedData.fork,
+      ...allDataColumns,
+      dataColumnsSource: DataColumnsSource.gossip,
+    };
+    blockCache.cachedData.resolveAvailability(blockData);
 
-        const blockInput = getBlockInput.availableData(config, blockCache.block, BlockSource.gossip, blockData);
+    if (blockCache.block) {
+      const blockInput = getBlockInput.availableData(config, blockCache.block, BlockSource.gossip, blockData);
 
-        blockCache.resolveBlockInput(blockInput);
-      }
+      blockCache.resolveBlockInput(blockInput);
     }
   }
 }

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -371,16 +371,17 @@ export class SeenGossipBlockInput {
 
   private async reconstructColumns(config: ChainForkConfig, blockRoot: RootHex) {
     const blockCache = this.blockInputCache.get(blockRoot);
-    if (blockCache === undefined || blockCache.fork !== ForkName.fulu) {
+    if (
+      blockCache === undefined ||
+      blockCache.fork !== ForkName.fulu ||
+      blockCache.cachedData === undefined ||
+      blockCache.cachedData.fork !== ForkName.fulu
+    ) {
       return;
     }
 
     // If already have all columns, exit
-    if (
-      blockCache.cachedData &&
-      (blockCache.cachedData.fork !== ForkName.fulu ||
-        this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache))
-    ) {
+    if (this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache)) {
       return;
     }
 
@@ -415,7 +416,7 @@ export class SeenGossipBlockInput {
     }
 
     // Return if we received all data columns while waiting for getBlobs
-    if (blockCache.cachedData && this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache)) {
+    if (this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache)) {
       return;
     }
 
@@ -443,16 +444,26 @@ export class SeenGossipBlockInput {
     this.emitter.emit(ChainEvent.publishDataColumns, sampledColumns);
 
     for (const column of sampledColumns) {
-      this.getGossipBlockInput(
-        config,
-        {
-          type: GossipedInputType.dataColumn,
-          dataColumnSidecar: column,
-          dataColumnBytes: null,
-        },
-        // TODO: Pass in metrics. Should this use a different availability source?
-        null
+      blockCache.cachedData.dataColumnsCache.set(column.index, {dataColumn: column, dataColumnBytes: null});
+    }
+
+    if (blockCache.block) {
+      const allDataColumns = getBlockInputDataColumns(
+        blockCache.cachedData.dataColumnsCache,
+        this.custodyConfig.sampledColumns
       );
+      // TODO: Add metrics
+      // metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
+      const blockData: BlockInputDataColumns = {
+        fork: blockCache.cachedData.fork,
+        ...allDataColumns,
+        dataColumnsSource: DataColumnsSource.gossip,
+      };
+      blockCache.cachedData.resolveAvailability(blockData);
+
+      const blockInput = getBlockInput.availableData(config, blockCache.block, BlockSource.gossip, blockData);
+
+      blockCache.resolveBlockInput(blockInput);
     }
   }
 }

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -385,22 +385,21 @@ export class SeenGossipBlockInput {
       return;
     }
 
-    // Process KZG commitments into versioned hashes
-    let versionedHashes: Uint8Array[];
-
+    let commitments: undefined | Uint8Array[];
     if (blockCache.block) {
       const block = blockCache.block as fulu.SignedBeaconBlock;
-      versionedHashes = block.message.body.blobKzgCommitments.map(kzgCommitmentToVersionedHash);
-    } else if (blockCache.cachedData) {
-      const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
-      if (!firstSidecar) {
-        throw new Error("blockInputCache missing both block and data column sidecar");
-      }
-
-      versionedHashes = firstSidecar.dataColumn.kzgCommitments.map(kzgCommitmentToVersionedHash);
+      commitments = block.message.body.blobKzgCommitments;
     } else {
+      const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
+      commitments = firstSidecar?.dataColumn.kzgCommitments;
+    }
+
+    if (!commitments) {
       throw new Error("blockInputCache missing both block and cachedData");
     }
+
+    // Process KZG commitments into versioned hashes
+    const versionedHashes: Uint8Array[] = commitments.map(kzgCommitmentToVersionedHash);
 
     // Return if block has no blobs
     if (versionedHashes.length === 0) {
@@ -428,14 +427,12 @@ export class SeenGossipBlockInput {
         blockCache.block as fulu.SignedBeaconBlock,
         cellsAndProofs
       );
-    } else if (blockCache.cachedData) {
+    } else {
       const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
       if (!firstSidecar) {
         throw new Error("blockInputCache missing both block and data column sidecar");
       }
       dataColumnSidecars = getDataColumnSidecarsFromColumnSidecar(firstSidecar.dataColumn, cellsAndProofs);
-    } else {
-      throw new Error("blockInputCache missing both block and cachedData");
     }
 
     // Publish columns if and only if subscribed to them

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -6,11 +6,13 @@ import {
   NUMBER_OF_COLUMNS,
   NUMBER_OF_CUSTODY_GROUPS,
 } from "@lodestar/params";
-import {ColumnIndex, CustodyIndex, ValidatorIndex} from "@lodestar/types";
+import {CachedBeaconStateAllForks, signedBlockToSignedHeader} from "@lodestar/state-transition";
+import {ColumnIndex, CustodyIndex, SignedBeaconBlockHeader, ValidatorIndex, deneb, fulu} from "@lodestar/types";
 import {ssz} from "@lodestar/types";
 import {bytesToBigInt} from "@lodestar/utils";
 import {NodeId} from "../network/subnets/index.js";
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {computeKzgCommitmentsInclusionProof} from "./blobs.js";
+import {ckzg} from "./kzg.js";
 
 export class CustodyConfig {
   /**
@@ -191,4 +193,96 @@ export function getDataColumns(nodeId: NodeId, custodyGroupCount: number): Colum
   return getCustodyGroups(nodeId, custodyGroupCount)
     .flatMap(computeColumnsForCustodyGroup)
     .sort((a, b) => a - b);
+}
+
+/**
+ * Computes the cells for each blob and combines them with cell proofs.
+ * Similar to the computeMatrix function described below.
+ *
+ * SPEC FUNCTION (note: spec currently computes proofs, but we already have them)
+ * https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/das-core.md#compute_matrix
+ */
+export function getCellsAndProofs(blobs: fulu.BlobAndProofV2[]): [Uint8Array[], Uint8Array[]][] {
+  return blobs.map((blob) => {
+    const cells = ckzg.computeCells(blob.blob);
+    const proofs = blob.proofs;
+    return [cells, proofs];
+  });
+}
+
+/**
+ * Given a signed block header and the commitments, inclusion proof, cells/proofs associated with
+ * each blob in the block, assemble the sidecars which can be distributed to peers.
+ *
+ * SPEC FUNCTION
+ * https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/validator.md#get_data_column_sidecars
+ */
+export function getDataColumnSidecars(
+  signedBlockHeader: SignedBeaconBlockHeader,
+  kzgCommitments: deneb.KZGCommitment[],
+  kzgCommitmentsInclusionProof: fulu.KzgCommitmentsInclusionProof,
+  cellsAndKzgProofs: [Uint8Array[], Uint8Array[]][]
+): fulu.DataColumnSidecars {
+  if (cellsAndKzgProofs.length !== kzgCommitments.length) {
+    throw Error("Invalid cellsAndKzgProofs length for getDataColumnSidecars");
+  }
+
+  const sidecars: fulu.DataColumnSidecars = [];
+  for (let columnIndex = 0; columnIndex < NUMBER_OF_COLUMNS; columnIndex++) {
+    const columnCells = [];
+    const columnProofs = [];
+    for (const [cells, proofs] of cellsAndKzgProofs) {
+      columnCells.push(cells[columnIndex]);
+      columnProofs.push(proofs[columnIndex]);
+    }
+    sidecars.push({
+      index: columnIndex,
+      column: columnCells,
+      kzgCommitments,
+      kzgProofs: columnProofs,
+      signedBlockHeader,
+      kzgCommitmentsInclusionProof,
+    });
+  }
+  return sidecars;
+}
+
+/**
+ * Given a signed block and the cells/proofs associated with each blob in the
+ * block, assemble the sidecars which can be distributed to peers.
+ *
+ * SPEC FUNCTION
+ * https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/validator.md#get_data_column_sidecars_from_block
+ */
+export function getDataColumnSidecarsFromBlock(
+  config: ChainForkConfig,
+  signedBlock: fulu.SignedBeaconBlock,
+  cellsAndKzgProofs: [Uint8Array[], Uint8Array[]][]
+): fulu.DataColumnSidecars {
+  const blobKzgCommitments = signedBlock.message.body.blobKzgCommitments;
+  const fork = config.getForkName(signedBlock.message.slot);
+  const signedBlockHeader = signedBlockToSignedHeader(config, signedBlock);
+
+  const kzgCommitmentsInclusionProof = computeKzgCommitmentsInclusionProof(fork, signedBlock.message.body);
+
+  return getDataColumnSidecars(signedBlockHeader, blobKzgCommitments, kzgCommitmentsInclusionProof, cellsAndKzgProofs);
+}
+
+/**
+ * Given a DataColumnSidecar and the cells/proofs associated with each blob corresponding
+ * to the commitments it contains, assemble all sidecars for distribution to peers.
+ *
+ * SPEC FUNCTION
+ * https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/validator.md#get_data_column_sidecars_from_column_sidecar
+ */
+export function getDataColumnSidecarsFromColumnSidecar(
+  sidecar: fulu.DataColumnSidecar,
+  cellsAndKzgProofs: [Uint8Array[], Uint8Array[]][]
+): fulu.DataColumnSidecars {
+  return getDataColumnSidecars(
+    sidecar.signedBlockHeader,
+    sidecar.kzgCommitments,
+    sidecar.kzgCommitmentsInclusionProof,
+    cellsAndKzgProofs
+  );
 }

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -202,11 +202,10 @@ export function getDataColumns(nodeId: NodeId, custodyGroupCount: number): Colum
  * SPEC FUNCTION (note: spec currently computes proofs, but we already have them)
  * https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/das-core.md#compute_matrix
  */
-export function getCellsAndProofs(blobs: fulu.BlobAndProofV2[]): [Uint8Array[], Uint8Array[]][] {
-  return blobs.map((blob) => {
-    const cells = ckzg.computeCells(blob.blob);
-    const proofs = blob.proofs;
-    return [cells, proofs];
+export function getCellsAndProofs(blobBundles: fulu.BlobAndProofV2[]): [Uint8Array[], Uint8Array[]][] {
+  return blobBundles.map(({blob, proofs: cellProofs}) => {
+    const cells = ckzg.computeCells(blob);
+    return [cells, cellProofs];
   });
 }
 

--- a/packages/beacon-node/src/util/kzg.ts
+++ b/packages/beacon-node/src/util/kzg.ts
@@ -13,6 +13,7 @@ export let ckzg: {
   verifyKzgProof(commitmentBytes: Uint8Array, zBytes: Uint8Array, yBytes: Uint8Array, proofBytes: Uint8Array): boolean;
   verifyBlobKzgProof(blob: Uint8Array, commitment: Uint8Array, proof: Uint8Array): boolean;
   verifyBlobKzgProofBatch(blobs: Uint8Array[], expectedKzgCommitments: Uint8Array[], kzgProofs: Uint8Array[]): boolean;
+  computeCells(blob: Uint8Array): Uint8Array[];
   computeCellsAndKzgProofs(blob: Uint8Array): [Uint8Array[], Uint8Array[]];
   recoverCellsAndKzgProofs(cellIndices: number[], cells: Uint8Array[]): [Uint8Array[], Uint8Array[]];
   verifyCellKzgProofBatch(
@@ -29,6 +30,7 @@ export let ckzg: {
   verifyKzgProof: ckzgNotLoaded,
   verifyBlobKzgProof: ckzgNotLoaded,
   verifyBlobKzgProofBatch: ckzgNotLoaded,
+  computeCells: ckzgNotLoaded,
   computeCellsAndKzgProofs: ckzgNotLoaded,
   recoverCellsAndKzgProofs: ckzgNotLoaded,
   verifyCellKzgProofBatch: ckzgNotLoaded,


### PR DESCRIPTION
**Motivation**

Add support for [distributed blob publishing](https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/p2p-interface.md#distributed-blob-publishing-using-blobs-retrieved-from-local-execution-layer-client) (When a block or first data column for a block is received, fetch blobs from EL to reconstruct columns, then publish columns to the network).

Depends on #7675 -- the last commit contains changes from this branch.

Fixes #7638

**Description**

* Adds a ColumnReconstructor to Sync that takes a chain and a network
* Adds new chain events for dataColumnGossip and blockGossip
* When either event is fired and it's the first time a block root is seen, call engine_getBlobsV2 to fetch all blobs/cell proofs in the block.
* If received, add them to `seenGossipBlockInput`.

Still TODO: Figure out metrics tracking for this.

