### PR TITLE
refactor: use shorter alias for aggregated attestation pool metrics

### DIFF
--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -425,7 +425,7 @@ export class AggregatedAttestationPool {
   }
 
   private onScrapeMetrics(metrics: Metrics): void {
-    const aggregatedAttestationPoolMetrics = metrics.opPool.aggregatedAttestationPool;
+    const poolMetrics = metrics.opPool.aggregatedAttestationPool;
     const allSlots = Array.from(this.attestationGroupByIndexByDataHexBySlot.keys());
 
     // last item is current slot, we want the previous one, if available.
@@ -438,7 +438,7 @@ export class AggregatedAttestationPool {
     if (previousSlot !== null) {
       const groupByIndexByDataHex = this.attestationGroupByIndexByDataHexBySlot.get(previousSlot);
       if (groupByIndexByDataHex != null) {
-        aggregatedAttestationPoolMetrics.attDataPerSlot.set(groupByIndexByDataHex.size);
+        poolMetrics.attDataPerSlot.set(groupByIndexByDataHex.size);
 
         let maxAttestations = 0;
         let committeeCount = 0;
@@ -447,14 +447,14 @@ export class AggregatedAttestationPool {
           for (const group of groupByIndex.values()) {
             const attestationCountInGroup = group.getAttestationCount();
             maxAttestations = Math.max(maxAttestations, attestationCountInGroup);
-            aggregatedAttestationPoolMetrics.attestationsPerCommittee.observe(attestationCountInGroup);
+            poolMetrics.attestationsPerCommittee.observe(attestationCountInGroup);
             committeeCount += 1;
 
             attestationCount += attestationCountInGroup;
           }
         }
-        aggregatedAttestationPoolMetrics.maxAttestationsPerCommittee.set(maxAttestations);
-        aggregatedAttestationPoolMetrics.committeesPerSlot.set(committeeCount);
+        poolMetrics.maxAttestationsPerCommittee.set(maxAttestations);
+        poolMetrics.committeesPerSlot.set(committeeCount);
       }
     }
 
@@ -471,8 +471,8 @@ export class AggregatedAttestationPool {
       }
     }
 
-    aggregatedAttestationPoolMetrics.size.set(attestationCount);
-    aggregatedAttestationPoolMetrics.uniqueData.set(attestationDataCount);
+    poolMetrics.size.set(attestationCount);
+    poolMetrics.uniqueData.set(attestationDataCount);
   }
 }
 


### PR DESCRIPTION
Just read this part of code again and the long metric variable name makes is a bit to verbose imo, didn't wanna push changes to https://github.com/ChainSafe/lodestar/pull/7673 though
