### PR TITLE
chore: fix packed attestation total effective balance metric name

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -923,7 +923,7 @@ export function createLodestarMetrics(
             labelNames: ["index"],
           }),
           totalEffectiveBalance: register.gauge<{index: number}>({
-            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_total_effective_balance",
+            name: "lodestar_oppool_aggregated_attestation_pool_packed_attestations_effective_balance_total",
             help: "Total effective balance of new seen attesters in packed attestation ${index}",
             labelNames: ["index"],
           }),


### PR DESCRIPTION
`_total` needs to be at the end to follow https://prometheus.io/docs/practices/naming/