### PR TITLE
fix: peerDAS - missing file extensions in networkConfig

### DIFF
--- a/packages/beacon-node/src/network/networkConfig.ts
+++ b/packages/beacon-node/src/network/networkConfig.ts
@@ -1,6 +1,6 @@
 import {BeaconConfig} from "@lodestar/config";
-import {NodeId, computeNodeId} from "./subnets";
-import {CustodyConfig, computeCustodyConfig} from "../util/dataColumns";
+import {NodeId, computeNodeId} from "./subnets/interface.js";
+import {CustodyConfig, computeCustodyConfig} from "../util/dataColumns.js";
 import {PeerId} from "@libp2p/interface";
 
 /**


### PR DESCRIPTION
**Motivation**

The Docker build isn't working on `peerDAS` because of missing file extensions -- this PR adds them in.

**Description**

* Adds `.js` file extensions to imports in `networkConfig.ts`