### PR TITLE
fix: import path of networkConfig

### DIFF
--- a/packages/beacon-node/src/network/networkConfig.ts
+++ b/packages/beacon-node/src/network/networkConfig.ts
@@ -1,7 +1,7 @@
-import {BeaconConfig} from "@lodestar/config";
-import {NodeId, computeNodeId} from "./subnets";
-import {CustodyConfig, computeCustodyConfig} from "../util/dataColumns";
 import {PeerId} from "@libp2p/interface";
+import {BeaconConfig} from "@lodestar/config";
+import {CustodyConfig, computeCustodyConfig} from "../util/dataColumns.js";
+import {NodeId, computeNodeId} from "./subnets/interface.js";
 
 /**
  * Store shared data for different modules in the network stack.


### PR DESCRIPTION
**Motivation**

- fix import issue introduced by #7632

```
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '/usr/src/lodestar/packages/beacon-node/lib/network/subnets' is not supported resolving ES modules imported from /usr/src/lodestar/packages/beacon-node/lib/network/networkConfig.js
Apr 13 08:18:20 devnet-ax41-0 beacon_run.sh[2274894]:     at finalizeResolution (node:internal/modules/esm/resolve:254:11)
Apr 13 08:18:20 devnet-ax41-0 beacon_run.sh[2274894]:     at moduleResolve (node:internal/modules/esm/resolve:921:10)
Apr 13 08:18:20 devnet-ax41-0 beacon_run.sh[2274894]:     at defaultResolve (node:internal/modules/esm/resolve:1120:11)
Apr 13 08:18:20 devnet-ax41-0 beacon_run.sh[2274894]:     at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:557:12)
Apr 13 08:18:20 devnet-ax41-0 beacon_run.sh[2274894]:     at ModuleLoader.resolve (node:internal/modules/esm/loader:526:25)
Apr 13 08:18:20 devnet-ax41-0 beacon_run.sh[2274894]:     at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:249:38)
Apr 13 08:18:20 devnet-ax41-0 beacon_run.sh[2274894]:     at ModuleJob._link (node:internal/modules/esm/module_job:126:49) {
Apr 13 08:18:20 devnet-ax41-0 beacon_run.sh[2274894]:   code: 'ERR_UNSUPPORTED_DIR_IMPORT',
Apr 13 08:18:20 devnet-ax41-0 beacon_run.sh[2274894]:   url: 'file:///usr/src/lodestar/packages/beacon-node/lib/network/subnets'
```

**Description**
- should not import folder path, import specific files instead
