### PR TITLE
fix: improve error message when validating blobs len

### DIFF
--- a/packages/state-transition/src/block/processExecutionPayload.ts
+++ b/packages/state-transition/src/block/processExecutionPayload.ts
@@ -52,7 +52,7 @@ export function processExecutionPayload(
     const maxBlobsPerBlock = state.config.getMaxBlobsPerBlock(forkName);
     const blobKzgCommitmentsLen = (body as deneb.BeaconBlockBody).blobKzgCommitments?.length ?? 0;
     if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
-      throw Error(`blobKzgCommitmentsLen exceeds limit=${maxBlobsPerBlock}`);
+      throw Error(`blobKzgCommitmentsLen of ${blobKzgCommitmentsLen} exceeds limit=${maxBlobsPerBlock}`);
     }
   }
 


### PR DESCRIPTION
**Motivation**

Get a lot of errors like this when running devnet-6 in our nodes

```

debug: Block error slot=640, code=BLOCK_ERROR_BEACON_CHAIN_ERROR, error=blobKzgCommitmentsLen exceeds limit=9 |  
-- | --
  |   | 2025-04-13 16:03:35.062 | Error: blobKzgCommitmentsLen exceeds limit=9


```

**Description**

- also log the blobKzgCommitmentsLen to give us more information of the error
