### PR TITLE
fix: peerdas-devnet-6

### DIFF
--- a/packages/config/src/chainConfig/configs/mainnet.ts
+++ b/packages/config/src/chainConfig/configs/mainnet.ts
@@ -126,4 +126,5 @@ export const chainConfig: ChainConfig = {
   SAMPLES_PER_SLOT: 8,
   CUSTODY_REQUIREMENT: 4,
   NODE_CUSTODY_REQUIREMENT: 1,
+  MAX_BLOBS_PER_BLOCK_FULU: 12,
 };

--- a/packages/config/src/chainConfig/configs/minimal.ts
+++ b/packages/config/src/chainConfig/configs/minimal.ts
@@ -122,4 +122,5 @@ export const chainConfig: ChainConfig = {
   SAMPLES_PER_SLOT: 8,
   CUSTODY_REQUIREMENT: 4,
   NODE_CUSTODY_REQUIREMENT: 1,
+  MAX_BLOBS_PER_BLOCK_FULU: 12,
 };

--- a/packages/config/src/chainConfig/types.ts
+++ b/packages/config/src/chainConfig/types.ts
@@ -86,6 +86,7 @@ export type ChainConfig = {
   SAMPLES_PER_SLOT: number;
   CUSTODY_REQUIREMENT: number;
   NODE_CUSTODY_REQUIREMENT: number;
+  MAX_BLOBS_PER_BLOCK_FULU: number;
 };
 
 export const chainConfigTypes: SpecTypes<ChainConfig> = {
@@ -164,6 +165,7 @@ export const chainConfigTypes: SpecTypes<ChainConfig> = {
   SAMPLES_PER_SLOT: "number",
   CUSTODY_REQUIREMENT: "number",
   NODE_CUSTODY_REQUIREMENT: "number",
+  MAX_BLOBS_PER_BLOCK_FULU: "number",
 };
 
 /** Allows values in a Spec file */

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -139,7 +139,14 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       return sszTypesFor(forkName);
     },
     getMaxBlobsPerBlock(fork: ForkName): number {
-      return isForkPostElectra(fork) ? config.MAX_BLOBS_PER_BLOCK_ELECTRA : config.MAX_BLOBS_PER_BLOCK;
+      switch (fork) {
+        case ForkName.fulu:
+          return config.MAX_BLOBS_PER_BLOCK_FULU;
+        case ForkName.electra:
+          return config.MAX_BLOBS_PER_BLOCK_ELECTRA;
+        default:
+          return config.MAX_BLOBS_PER_BLOCK;
+      }
     },
     getMaxRequestBlobSidecars(fork: ForkName): number {
       return isForkPostElectra(fork) ? config.MAX_REQUEST_BLOB_SIDECARS_ELECTRA : config.MAX_REQUEST_BLOB_SIDECARS;

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -256,5 +256,6 @@ function getSpecCriticalParams(localConfig: ChainConfig): Record<keyof ConfigWit
     SAMPLES_PER_SLOT: fuluForkRelevant,
     CUSTODY_REQUIREMENT: fuluForkRelevant,
     NODE_CUSTODY_REQUIREMENT: false,
+    MAX_BLOBS_PER_BLOCK_FULU: fuluForkRelevant,
   };
 }


### PR DESCRIPTION
**Motivation**

- lodestar does not work on peerdas-devnet-6

```
verbose: Batch process error id=Finalized, startEpoch=20, status=Processing, code=BLOCK_ERROR_BEACON_CHAIN_ERROR, error=blobKzgCommitmentsLen of 12 exceeds limit=9
```

**Description**

- add and use MAX_BLOBS_PER_BLOCK_FULU
