### PR TITLE
fix: peerDAS - support MetadataV3 before fulu

### DIFF
--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -226,9 +226,10 @@ export class ReqRespBeaconNode extends ReqResp {
       [protocols.Ping(fork, this.config), this.onPing.bind(this)],
       [protocols.Status(fork, this.config), this.onStatus.bind(this)],
       [protocols.Goodbye(fork, this.config), this.onGoodbye.bind(this)],
-      // Support V2 methods as soon as implemented (for altair)
+      // Support V3 methods as soon as implemented (for fulu)
+      // Follows pattern for altair:
       // Ref https://github.com/ethereum/consensus-specs/blob/v1.2.0/specs/altair/p2p-interface.md#transitioning-from-v1-to-v2
-      [protocols.MetadataV2(fork, this.config), this.onMetadata.bind(this)],
+      [protocols.MetadataV3(fork, this.config), this.onMetadata.bind(this)],
       [protocols.BeaconBlocksByRangeV2(fork, this.config), this.getHandler(ReqRespMethod.BeaconBlocksByRange)],
       [protocols.BeaconBlocksByRootV2(fork, this.config), this.getHandler(ReqRespMethod.BeaconBlocksByRoot)],
     ];
@@ -240,6 +241,11 @@ export class ReqRespBeaconNode extends ReqResp {
         [protocols.BeaconBlocksByRange(fork, this.config), this.getHandler(ReqRespMethod.BeaconBlocksByRange)],
         [protocols.BeaconBlocksByRoot(fork, this.config), this.getHandler(ReqRespMethod.BeaconBlocksByRoot)]
       );
+    }
+
+    if (ForkSeq[fork] < ForkSeq.fulu) {
+      // Unregister MetadataV2 at the fork boundary, so only declare for pre-fulu
+      protocolsAtFork.push([protocols.MetadataV2(fork, this.config), this.onMetadata.bind(this)]);
     }
 
     if (ForkSeq[fork] >= ForkSeq.altair && !this.disableLightClientServer) {
@@ -270,7 +276,6 @@ export class ReqRespBeaconNode extends ReqResp {
 
     if (ForkSeq[fork] >= ForkSeq.fulu) {
       protocolsAtFork.push(
-        [protocols.MetadataV3(fork, this.config), this.onMetadata.bind(this)],
         [
           protocols.DataColumnSidecarsByRoot(fork, this.config),
           this.getHandler(ReqRespMethod.DataColumnSidecarsByRoot),


### PR DESCRIPTION
**Motivation**

Running a cluster of three nodes in Kurtosis, was seeing this error before the Fulu fork:

```
[cl-1-lodestar-geth] Error: Request to send to protocol /eth2/beacon_chain/req/metadata/3/ssz_snappy but it has not been declared
[cl-1-lodestar-geth]     at ReqRespBeaconNode.sendRequest (file:///usr/app/packages/reqresp/lib/ReqResp.js:104:23)
```

The error is because the client is attempting to send Metadatav3 requests. There's a check in the sender that prevents sending messages to versions that the client hasn't registered, and Metadatav3 is not registered until the fork.

[The Fulu spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/p2p-interface.md#getmetadata-v3) says to follow the same semantics as Altair, which allows registering the new metadata endpoint before the fork.

I think that's a good idea anyway, to allow clients to prioritize peers pre-fork based on their expected custody groups.

**Description**

* Updates MetadataV3 to always be registered
* Updates MetadataV2 to unregister at Fulu fork, like MetadataV1 does at Altair

