### PR TITLE
refactor: deduplicate DataAvailabilityStatus enum

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1,7 +1,7 @@
 import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
-import {DataAvailabilityStatus, ExecutionStatus} from "@lodestar/fork-choice";
+import {ExecutionStatus} from "@lodestar/fork-choice";
 import {
   ForkPostBellatrix,
   ForkPostDeneb,
@@ -17,6 +17,7 @@ import {
 } from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
+  DataAvailabilityStatus,
   attesterShufflingDecisionRoot,
   beaconBlockToBlinded,
   calculateCommitteeAssignments,

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -393,7 +393,7 @@ export function getValidatorApi(
       throw new ApiError(404, `Block not in forkChoice, beaconBlockRoot=${toRootHex(beaconBlockRoot)}`);
     }
 
-    if (protoBeaconBlock.dataAvailabilityStatus === DataAvailabilityStatus.outOfRange)
+    if (protoBeaconBlock.dataAvailabilityStatus === DataAvailabilityStatus.OutOfRange)
       throw new NodeIsSyncing("Block's data is out of range and not validated");
   }
 

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -392,7 +392,7 @@ export function getValidatorApi(
       throw new ApiError(404, `Block not in forkChoice, beaconBlockRoot=${toRootHex(beaconBlockRoot)}`);
     }
 
-    if (protoBeaconBlock.dataAvailabilityStatus === DataAvailabilityStatus.OutOfRange)
+    if (protoBeaconBlock.dataAvailabilityStatus === DataAvailabilityStatus.outOfRange)
       throw new NodeIsSyncing("Block's data is out of range and not validated");
   }
 

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
@@ -3,7 +3,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {
   BeaconStateAllForks,
   CachedBeaconStateAllForks,
-  DataAvailableStatus,
+  DataAvailabilityStatus,
   ExecutionPayloadStatus,
   createCachedBeaconState,
   stateTransition,
@@ -86,7 +86,7 @@ export async function getHistoricalState(
           verifySignatures: false,
           verifyStateRoot: false,
           executionPayloadStatus: ExecutionPayloadStatus.valid,
-          dataAvailableStatus: DataAvailableStatus.available,
+          dataAvailabilityStatus: DataAvailabilityStatus.available,
         },
         metrics
       );

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
@@ -86,7 +86,7 @@ export async function getHistoricalState(
           verifySignatures: false,
           verifyStateRoot: false,
           executionPayloadStatus: ExecutionPayloadStatus.valid,
-          dataAvailabilityStatus: DataAvailabilityStatus.available,
+          dataAvailabilityStatus: DataAvailabilityStatus.Available,
         },
         metrics
       );

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -1,7 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {DataAvailabilityStatus, MaybeValidExecutionStatus} from "@lodestar/fork-choice";
+import {MaybeValidExecutionStatus} from "@lodestar/fork-choice";
 import {ForkPostDeneb, ForkSeq} from "@lodestar/params";
-import {CachedBeaconStateAllForks, computeEpochAtSlot} from "@lodestar/state-transition";
+import {CachedBeaconStateAllForks, DataAvailabilityStatus, computeEpochAtSlot} from "@lodestar/state-transition";
 import {RootHex, SignedBeaconBlock, Slot, deneb} from "@lodestar/types";
 
 export enum BlockInputType {

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -116,7 +116,7 @@ export async function verifyBlocksInEpoch(
         preState0,
         blocksInput,
         // hack availability for state transition eval as availability is separately determined
-        blocks.map(() => DataAvailabilityStatus.available),
+        blocks.map(() => DataAvailabilityStatus.Available),
         this.logger,
         this.metrics,
         abortController.signal,

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -1,9 +1,9 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {DataAvailabilityStatus, ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
+import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
-  DataAvailableStatus,
+  DataAvailabilityStatus,
   computeEpochAtSlot,
   isStateValidatorsNodesPopulated,
 } from "@lodestar/state-transition";
@@ -116,7 +116,7 @@ export async function verifyBlocksInEpoch(
         preState0,
         blocksInput,
         // hack availability for state transition eval as availability is separately determined
-        blocks.map(() => DataAvailableStatus.available),
+        blocks.map(() => DataAvailabilityStatus.available),
         this.logger,
         this.metrics,
         abortController.signal,

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -1,6 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {DataAvailabilityStatus} from "@lodestar/fork-choice";
-import {computeTimeAtSlot} from "@lodestar/state-transition";
+import {DataAvailabilityStatus, computeTimeAtSlot} from "@lodestar/state-transition";
 import {UintNum64, deneb} from "@lodestar/types";
 import {ErrorAborted, Logger} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -87,7 +87,7 @@ async function maybeValidateBlobs(
     // biome-ignore lint/suspicious/noFallthroughSwitchClause: We need fall-through behavior here
     case BlockInputType.availableData:
       if (opts.validBlobSidecars === BlobSidecarValidation.Full) {
-        return {dataAvailabilityStatus: DataAvailabilityStatus.Available, availableBlockInput: blockInput};
+        return {dataAvailabilityStatus: DataAvailabilityStatus.available, availableBlockInput: blockInput};
       }
 
     case BlockInputType.dataPromise: {
@@ -115,7 +115,7 @@ async function maybeValidateBlobs(
         blockInput.source,
         blobsData
       );
-      return {dataAvailabilityStatus: DataAvailabilityStatus.Available, availableBlockInput: availableBlockInput};
+      return {dataAvailabilityStatus: DataAvailabilityStatus.available, availableBlockInput: availableBlockInput};
     }
   }
 }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -79,7 +79,7 @@ async function maybeValidateBlobs(
 ): Promise<{dataAvailabilityStatus: DataAvailabilityStatus; availableBlockInput: BlockInput}> {
   switch (blockInput.type) {
     case BlockInputType.preData:
-      return {dataAvailabilityStatus: DataAvailabilityStatus.PreData, availableBlockInput: blockInput};
+      return {dataAvailabilityStatus: DataAvailabilityStatus.preData, availableBlockInput: blockInput};
 
     case BlockInputType.outOfRangeData:
       return {dataAvailabilityStatus: DataAvailabilityStatus.OutOfRange, availableBlockInput: blockInput};

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -78,7 +78,7 @@ async function maybeValidateBlobs(
 ): Promise<{dataAvailabilityStatus: DataAvailabilityStatus; availableBlockInput: BlockInput}> {
   switch (blockInput.type) {
     case BlockInputType.preData:
-      return {dataAvailabilityStatus: DataAvailabilityStatus.preData, availableBlockInput: blockInput};
+      return {dataAvailabilityStatus: DataAvailabilityStatus.PreData, availableBlockInput: blockInput};
 
     case BlockInputType.outOfRangeData:
       return {dataAvailabilityStatus: DataAvailabilityStatus.outOfRange, availableBlockInput: blockInput};

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -81,7 +81,7 @@ async function maybeValidateBlobs(
       return {dataAvailabilityStatus: DataAvailabilityStatus.PreData, availableBlockInput: blockInput};
 
     case BlockInputType.outOfRangeData:
-      return {dataAvailabilityStatus: DataAvailabilityStatus.outOfRange, availableBlockInput: blockInput};
+      return {dataAvailabilityStatus: DataAvailabilityStatus.OutOfRange, availableBlockInput: blockInput};
 
     // biome-ignore lint/suspicious/noFallthroughSwitchClause: We need fall-through behavior here
     case BlockInputType.availableData:

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -82,7 +82,7 @@ async function maybeValidateBlobs(
       return {dataAvailabilityStatus: DataAvailabilityStatus.preData, availableBlockInput: blockInput};
 
     case BlockInputType.outOfRangeData:
-      return {dataAvailabilityStatus: DataAvailabilityStatus.OutOfRange, availableBlockInput: blockInput};
+      return {dataAvailabilityStatus: DataAvailabilityStatus.outOfRange, availableBlockInput: blockInput};
 
     // biome-ignore lint/suspicious/noFallthroughSwitchClause: We need fall-through behavior here
     case BlockInputType.availableData:

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -86,7 +86,7 @@ async function maybeValidateBlobs(
     // biome-ignore lint/suspicious/noFallthroughSwitchClause: We need fall-through behavior here
     case BlockInputType.availableData:
       if (opts.validBlobSidecars === BlobSidecarValidation.Full) {
-        return {dataAvailabilityStatus: DataAvailabilityStatus.available, availableBlockInput: blockInput};
+        return {dataAvailabilityStatus: DataAvailabilityStatus.Available, availableBlockInput: blockInput};
       }
 
     case BlockInputType.dataPromise: {
@@ -114,7 +114,7 @@ async function maybeValidateBlobs(
         blockInput.source,
         blobsData
       );
-      return {dataAvailabilityStatus: DataAvailabilityStatus.available, availableBlockInput: availableBlockInput};
+      return {dataAvailabilityStatus: DataAvailabilityStatus.Available, availableBlockInput: availableBlockInput};
     }
   }
 }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -1,6 +1,6 @@
 import {
   CachedBeaconStateAllForks,
-  DataAvailableStatus,
+  DataAvailabilityStatus,
   ExecutionPayloadStatus,
   StateHashTreeRootSource,
   stateTransition,
@@ -24,7 +24,7 @@ import {BlockInput, ImportBlockOpts} from "./types.js";
 export async function verifyBlocksStateTransitionOnly(
   preState0: CachedBeaconStateAllForks,
   blocks: BlockInput[],
-  dataAvailabilityStatuses: DataAvailableStatus[],
+  dataAvailabilityStatuses: DataAvailabilityStatus[],
   logger: Logger,
   metrics: Metrics | null,
   signal: AbortSignal,
@@ -38,7 +38,7 @@ export async function verifyBlocksStateTransitionOnly(
     const {validProposerSignature, validSignatures} = opts;
     const {block} = blocks[i];
     const preState = i === 0 ? preState0 : postStates[i - 1];
-    const dataAvailableStatus = dataAvailabilityStatuses[i];
+    const dataAvailabilityStatus = dataAvailabilityStatuses[i];
 
     // STFN - per_slot_processing() + per_block_processing()
     // NOTE: `regen.getPreState()` should have dialed forward the state already caching checkpoint states
@@ -50,7 +50,7 @@ export async function verifyBlocksStateTransitionOnly(
         // NOTE: Assume valid for now while sending payload to execution engine in parallel
         // Latter verifyBlocksInEpoch() will make sure that payload is indeed valid
         executionPayloadStatus: ExecutionPayloadStatus.valid,
-        dataAvailableStatus,
+        dataAvailabilityStatus,
         // false because it's verified below with better error typing
         verifyStateRoot: false,
         // if block is trusted don't verify proposer or op signature

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -1,6 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {
-  DataAvailabilityStatus,
   ExecutionStatus,
   ForkChoice,
   ForkChoiceStore,
@@ -10,6 +9,7 @@ import {
 } from "@lodestar/fork-choice";
 import {
   CachedBeaconStateAllForks,
+  DataAvailabilityStatus,
   computeAnchorCheckpoint,
   getEffectiveBalanceIncrementsZeroInactive,
   isExecutionStateType,

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -101,7 +101,7 @@ export function initializeForkChoice(
             }
           : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),
 
-        dataAvailabilityStatus: DataAvailabilityStatus.preData,
+        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
       },
       currentSlot
     ),

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -101,7 +101,7 @@ export function initializeForkChoice(
             }
           : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),
 
-        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+        dataAvailabilityStatus: DataAvailabilityStatus.preData,
       },
       currentSlot
     ),

--- a/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
+++ b/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
@@ -29,7 +29,7 @@ export function computeNewStateRoot(
       // ExecutionPayloadStatus.valid: Assume payload valid, it has been produced by a trusted EL
       executionPayloadStatus: ExecutionPayloadStatus.valid,
       // DataAvailabilityStatus.available: Assume the blobs to be available, have just been produced by trusted EL
-      dataAvailabilityStatus: DataAvailabilityStatus.available,
+      dataAvailabilityStatus: DataAvailabilityStatus.Available,
       // verifyStateRoot: false  | the root in the block is zero-ed, it's being computed here
       verifyStateRoot: false,
       // verifyProposer: false   | as the block signature is zero-ed

--- a/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
+++ b/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
@@ -1,6 +1,6 @@
 import {
   CachedBeaconStateAllForks,
-  DataAvailableStatus,
+  DataAvailabilityStatus,
   ExecutionPayloadStatus,
   StateHashTreeRootSource,
   stateTransition,
@@ -28,8 +28,8 @@ export function computeNewStateRoot(
     {
       // ExecutionPayloadStatus.valid: Assume payload valid, it has been produced by a trusted EL
       executionPayloadStatus: ExecutionPayloadStatus.valid,
-      // DataAvailableStatus.available: Assume the blobs to be available, have just been produced by trusted EL
-      dataAvailableStatus: DataAvailableStatus.available,
+      // DataAvailabilityStatus.available: Assume the blobs to be available, have just been produced by trusted EL
+      dataAvailabilityStatus: DataAvailabilityStatus.available,
       // verifyStateRoot: false  | the root in the block is zero-ed, it's being computed here
       verifyStateRoot: false,
       // verifyProposer: false   | as the block signature is zero-ed

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -3,7 +3,7 @@ import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
-  DataAvailableStatus,
+  DataAvailabilityStatus,
   ExecutionPayloadStatus,
   StateHashTreeRootSource,
   computeEpochAtSlot,
@@ -259,7 +259,7 @@ export class StateRegenerator implements IStateRegeneratorInternal {
           {
             // Replay previously imported blocks, assume valid and available
             executionPayloadStatus: ExecutionPayloadStatus.valid,
-            dataAvailableStatus: DataAvailableStatus.available,
+            dataAvailabilityStatus: DataAvailabilityStatus.available,
             verifyStateRoot: false,
             verifyProposer: false,
             verifySignatures: false,

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -259,7 +259,7 @@ export class StateRegenerator implements IStateRegeneratorInternal {
           {
             // Replay previously imported blocks, assume valid and available
             executionPayloadStatus: ExecutionPayloadStatus.valid,
-            dataAvailabilityStatus: DataAvailabilityStatus.available,
+            dataAvailabilityStatus: DataAvailabilityStatus.Available,
             verifyStateRoot: false,
             verifyProposer: false,
             verifySignatures: false,

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -1,6 +1,7 @@
 import {beforeAll, bench, describe} from "@chainsafe/benchmark";
 import {BitArray, toHexString} from "@chainsafe/ssz";
-import {DataAvailabilityStatus, ExecutionStatus, ForkChoice, IForkChoiceStore, ProtoArray} from "@lodestar/fork-choice";
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
+import {ExecutionStatus, ForkChoice, IForkChoiceStore, ProtoArray} from "@lodestar/fork-choice";
 import {HISTORICAL_ROOTS_LIMIT, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
   CachedBeaconStateAltair,

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -66,7 +66,7 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
           executionStatus: ExecutionStatus.PreMerge,
 
           timeliness: false,
-          dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+          dataAvailabilityStatus: DataAvailabilityStatus.preData,
         },
         originalState.slot
       );
@@ -91,7 +91,7 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
             executionPayloadBlockHash: null,
             executionStatus: ExecutionStatus.PreMerge,
             timeliness: false,
-            dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+            dataAvailabilityStatus: DataAvailabilityStatus.preData,
           },
           slot
         );

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -1,8 +1,8 @@
 import {beforeAll, bench, describe} from "@chainsafe/benchmark";
 import {BitArray, toHexString} from "@chainsafe/ssz";
-import {DataAvailabilityStatus} from "@lodestar/state-transition";
 import {ExecutionStatus, ForkChoice, IForkChoiceStore, ProtoArray} from "@lodestar/fork-choice";
 import {HISTORICAL_ROOTS_LIMIT, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
 import {
   CachedBeaconStateAltair,
   computeAnchorCheckpoint,

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -67,7 +67,7 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
           executionStatus: ExecutionStatus.PreMerge,
 
           timeliness: false,
-          dataAvailabilityStatus: DataAvailabilityStatus.preData,
+          dataAvailabilityStatus: DataAvailabilityStatus.PreData,
         },
         originalState.slot
       );
@@ -92,7 +92,7 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
             executionPayloadBlockHash: null,
             executionStatus: ExecutionStatus.PreMerge,
             timeliness: false,
-            dataAvailabilityStatus: DataAvailabilityStatus.preData,
+            dataAvailabilityStatus: DataAvailabilityStatus.PreData,
           },
           slot
         );

--- a/packages/beacon-node/test/spec/presets/finality.test.ts
+++ b/packages/beacon-node/test/spec/presets/finality.test.ts
@@ -26,7 +26,7 @@ const finality: TestRunnerFn<FinalityTestCase, BeaconStateAllForks> = (fork) => 
         state = stateTransition(state, signedBlock, {
           // Should assume payload valid and blob data available for this test
           executionPayloadStatus: ExecutionPayloadStatus.valid,
-          dataAvailabilityStatus: DataAvailabilityStatus.available,
+          dataAvailabilityStatus: DataAvailabilityStatus.Available,
           verifyStateRoot: false,
           verifyProposer: verify,
           verifySignatures: verify,

--- a/packages/beacon-node/test/spec/presets/finality.test.ts
+++ b/packages/beacon-node/test/spec/presets/finality.test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import {ACTIVE_PRESET, ForkName} from "@lodestar/params";
 import {
   BeaconStateAllForks,
-  DataAvailableStatus,
+  DataAvailabilityStatus,
   ExecutionPayloadStatus,
   stateTransition,
 } from "@lodestar/state-transition";
@@ -26,7 +26,7 @@ const finality: TestRunnerFn<FinalityTestCase, BeaconStateAllForks> = (fork) => 
         state = stateTransition(state, signedBlock, {
           // Should assume payload valid and blob data available for this test
           executionPayloadStatus: ExecutionPayloadStatus.valid,
-          dataAvailableStatus: DataAvailableStatus.available,
+          dataAvailabilityStatus: DataAvailabilityStatus.available,
           verifyStateRoot: false,
           verifyProposer: verify,
           verifySignatures: verify,

--- a/packages/beacon-node/test/spec/presets/sanity.test.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.test.ts
@@ -3,7 +3,7 @@ import {ACTIVE_PRESET, ForkName} from "@lodestar/params";
 import {InputType} from "@lodestar/spec-test-util";
 import {
   BeaconStateAllForks,
-  DataAvailableStatus,
+  DataAvailabilityStatus,
   ExecutionPayloadStatus,
   processSlots,
   stateTransition,
@@ -67,7 +67,7 @@ const sanityBlocks: TestRunnerFn<SanityBlocksTestCase, BeaconStateAllForks> = (f
         wrappedState = stateTransition(wrappedState, signedBlock, {
           // Assume valid and available for this test
           executionPayloadStatus: ExecutionPayloadStatus.valid,
-          dataAvailableStatus: DataAvailableStatus.available,
+          dataAvailabilityStatus: DataAvailabilityStatus.available,
           verifyStateRoot: verify,
           verifyProposer: verify,
           verifySignatures: verify,

--- a/packages/beacon-node/test/spec/presets/sanity.test.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.test.ts
@@ -67,7 +67,7 @@ const sanityBlocks: TestRunnerFn<SanityBlocksTestCase, BeaconStateAllForks> = (f
         wrappedState = stateTransition(wrappedState, signedBlock, {
           // Assume valid and available for this test
           executionPayloadStatus: ExecutionPayloadStatus.valid,
-          dataAvailabilityStatus: DataAvailabilityStatus.available,
+          dataAvailabilityStatus: DataAvailabilityStatus.Available,
           verifyStateRoot: verify,
           verifyProposer: verify,
           verifySignatures: verify,

--- a/packages/beacon-node/test/spec/presets/transition.test.ts
+++ b/packages/beacon-node/test/spec/presets/transition.test.ts
@@ -4,7 +4,7 @@ import {config} from "@lodestar/config/default";
 import {ACTIVE_PRESET, ForkName} from "@lodestar/params";
 import {
   BeaconStateAllForks,
-  DataAvailableStatus,
+  DataAvailabilityStatus,
   ExecutionPayloadStatus,
   stateTransition,
 } from "@lodestar/state-transition";
@@ -57,7 +57,7 @@ const transition =
           state = stateTransition(state, signedBlock, {
             // Assume valid and available for this test
             executionPayloadStatus: ExecutionPayloadStatus.valid,
-            dataAvailableStatus: DataAvailableStatus.available,
+            dataAvailabilityStatus: DataAvailabilityStatus.available,
             verifyStateRoot: true,
             verifyProposer: false,
             verifySignatures: false,

--- a/packages/beacon-node/test/spec/presets/transition.test.ts
+++ b/packages/beacon-node/test/spec/presets/transition.test.ts
@@ -57,7 +57,7 @@ const transition =
           state = stateTransition(state, signedBlock, {
             // Assume valid and available for this test
             executionPayloadStatus: ExecutionPayloadStatus.valid,
-            dataAvailabilityStatus: DataAvailabilityStatus.available,
+            dataAvailabilityStatus: DataAvailabilityStatus.Available,
             verifyStateRoot: true,
             verifyProposer: false,
             verifySignatures: false,

--- a/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -1,14 +1,16 @@
 import {toHexString} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
-import {CheckpointWithHex, DataAvailabilityStatus, ExecutionStatus, ForkChoice} from "@lodestar/fork-choice";
+import {CheckpointWithHex, ExecutionStatus, ForkChoice} from "@lodestar/fork-choice";
 import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
+  DataAvailabilityStatus,
   computeAnchorCheckpoint,
   computeEpochAtSlot,
   getEffectiveBalanceIncrementsZeroed,
+  getTemporaryBlockHeader,
+  processSlots,
 } from "@lodestar/state-transition";
-import {getTemporaryBlockHeader, processSlots} from "@lodestar/state-transition";
 import {IndexedAttestation, Slot, ValidatorIndex, phase0, ssz} from "@lodestar/types";
 import {beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {ChainEventEmitter, initializeForkChoice} from "../../../../src/chain/index.js";

--- a/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -47,7 +47,7 @@ describe("LodestarForkChoice", () => {
   justifiedBalances[1] = 2;
   justifiedBalances[2] = 3;
   const executionStatus = ExecutionStatus.PreMerge;
-  const dataAvailabilityStatus = DataAvailabilityStatus.PreData;
+  const dataAvailabilityStatus = DataAvailabilityStatus.preData;
   const blockDelaySec = 0;
 
   const hashBlock = (block: phase0.BeaconBlock): string => toHexString(ssz.phase0.BeaconBlock.hashTreeRoot(block));

--- a/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -49,7 +49,7 @@ describe("LodestarForkChoice", () => {
   justifiedBalances[1] = 2;
   justifiedBalances[2] = 3;
   const executionStatus = ExecutionStatus.PreMerge;
-  const dataAvailabilityStatus = DataAvailabilityStatus.preData;
+  const dataAvailabilityStatus = DataAvailabilityStatus.PreData;
   const blockDelaySec = 0;
 
   const hashBlock = (block: phase0.BeaconBlock): string => toHexString(ssz.phase0.BeaconBlock.hashTreeRoot(block));

--- a/packages/beacon-node/test/unit/chain/rewards/blockRewards.test.ts
+++ b/packages/beacon-node/test/unit/chain/rewards/blockRewards.test.ts
@@ -1,7 +1,7 @@
 import {SYNC_COMMITTEE_SIZE} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
-  DataAvailableStatus,
+  DataAvailabilityStatus,
   ExecutionPayloadStatus,
   stateTransition,
 } from "@lodestar/state-transition";
@@ -114,7 +114,7 @@ describe("chain / rewards / blockRewards", () => {
 
       const postState = stateTransition(state as CachedBeaconStateAllForks, block, {
         executionPayloadStatus: ExecutionPayloadStatus.valid,
-        dataAvailableStatus: DataAvailableStatus.available,
+        dataAvailabilityStatus: DataAvailabilityStatus.available,
         verifyProposer: false,
         verifySignatures: false,
         verifyStateRoot: false,
@@ -142,7 +142,7 @@ describe("chain / rewards / blockRewards", () => {
 
     const postState = stateTransition(preState as CachedBeaconStateAllForks, block, {
       executionPayloadStatus: ExecutionPayloadStatus.valid,
-      dataAvailableStatus: DataAvailableStatus.available,
+      dataAvailabilityStatus: DataAvailabilityStatus.available,
       verifyProposer: false,
       verifySignatures: false,
       verifyStateRoot: false,

--- a/packages/beacon-node/test/unit/chain/rewards/blockRewards.test.ts
+++ b/packages/beacon-node/test/unit/chain/rewards/blockRewards.test.ts
@@ -114,7 +114,7 @@ describe("chain / rewards / blockRewards", () => {
 
       const postState = stateTransition(state as CachedBeaconStateAllForks, block, {
         executionPayloadStatus: ExecutionPayloadStatus.valid,
-        dataAvailabilityStatus: DataAvailabilityStatus.available,
+        dataAvailabilityStatus: DataAvailabilityStatus.Available,
         verifyProposer: false,
         verifySignatures: false,
         verifyStateRoot: false,
@@ -142,7 +142,7 @@ describe("chain / rewards / blockRewards", () => {
 
     const postState = stateTransition(preState as CachedBeaconStateAllForks, block, {
       executionPayloadStatus: ExecutionPayloadStatus.valid,
-      dataAvailabilityStatus: DataAvailabilityStatus.available,
+      dataAvailabilityStatus: DataAvailabilityStatus.Available,
       verifyProposer: false,
       verifySignatures: false,
       verifyStateRoot: false,

--- a/packages/beacon-node/test/utils/state.ts
+++ b/packages/beacon-node/test/utils/state.ts
@@ -10,11 +10,12 @@ import {
   CachedBeaconStateAllForks,
   CachedBeaconStateBellatrix,
   CachedBeaconStateElectra,
+  DataAvailabilityStatus,
   createCachedBeaconState,
 } from "@lodestar/state-transition";
 import {BeaconState, altair, bellatrix, electra, ssz} from "@lodestar/types";
 
-import {DataAvailabilityStatus, ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
+import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {ZERO_HASH_HEX} from "../../src/constants/constants.js";
 import {getConfig} from "./config.js";
 import {generateValidator, generateValidators} from "./validator.js";

--- a/packages/beacon-node/test/utils/state.ts
+++ b/packages/beacon-node/test/utils/state.ts
@@ -179,5 +179,5 @@ export const zeroProtoBlock: ProtoBlock = {
   timeliness: false,
 
   ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-  dataAvailabilityStatus: DataAvailabilityStatus.preData,
+  dataAvailabilityStatus: DataAvailabilityStatus.PreData,
 };

--- a/packages/beacon-node/test/utils/state.ts
+++ b/packages/beacon-node/test/utils/state.ts
@@ -178,5 +178,5 @@ export const zeroProtoBlock: ProtoBlock = {
   timeliness: false,
 
   ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-  dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+  dataAvailabilityStatus: DataAvailabilityStatus.preData,
 };

--- a/packages/beacon-node/test/utils/typeGenerator.ts
+++ b/packages/beacon-node/test/utils/typeGenerator.ts
@@ -1,7 +1,6 @@
-import {DataAvailabilityStatus, ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
-import {Slot} from "@lodestar/types";
-import {phase0} from "@lodestar/types";
-import {ssz} from "@lodestar/types";
+import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
+import {Slot, phase0, ssz} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {ZERO_HASH_HEX} from "../../src/constants/index.js";
 

--- a/packages/beacon-node/test/utils/typeGenerator.ts
+++ b/packages/beacon-node/test/utils/typeGenerator.ts
@@ -42,7 +42,7 @@ export function generateProtoBlock(overrides: Partial<ProtoBlock> = {}): ProtoBl
     timeliness: false,
 
     ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-    dataAvailabilityStatus: DataAvailabilityStatus.preData,
+    dataAvailabilityStatus: DataAvailabilityStatus.PreData,
     ...overrides,
   } as ProtoBlock;
 }

--- a/packages/beacon-node/test/utils/typeGenerator.ts
+++ b/packages/beacon-node/test/utils/typeGenerator.ts
@@ -43,7 +43,7 @@ export function generateProtoBlock(overrides: Partial<ProtoBlock> = {}): ProtoBl
     timeliness: false,
 
     ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-    dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+    dataAvailabilityStatus: DataAvailabilityStatus.preData,
     ...overrides,
   } as ProtoBlock;
 }

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -1,7 +1,12 @@
 import {BitArray, toHexString} from "@chainsafe/ssz";
-import {DataAvailabilityStatus, ExecutionStatus, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
+import {ExecutionStatus, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {DOMAIN_BEACON_ATTESTER} from "@lodestar/params";
-import {computeEpochAtSlot, computeSigningRoot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {
+  DataAvailabilityStatus,
+  computeEpochAtSlot,
+  computeSigningRoot,
+  computeStartSlotAtEpoch,
+} from "@lodestar/state-transition";
 import {Slot, SubnetID, phase0, ssz} from "@lodestar/types";
 import {
   generateTestCachedBeaconStateOnlyValidators,

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -72,7 +72,7 @@ export function getAttestationValidData(opts: AttestationValidDataOpts): {
     timeliness: false,
 
     ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-    dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+    dataAvailabilityStatus: DataAvailabilityStatus.preData,
   };
 
   const shufflingCache = new ShufflingCache(null, null, {}, [

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -77,7 +77,7 @@ export function getAttestationValidData(opts: AttestationValidDataOpts): {
     timeliness: false,
 
     ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-    dataAvailabilityStatus: DataAvailabilityStatus.preData,
+    dataAvailabilityStatus: DataAvailabilityStatus.PreData,
   };
 
   const shufflingCache = new ShufflingCache(null, null, {}, [

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -2,6 +2,7 @@ import {ChainConfig, ChainForkConfig} from "@lodestar/config";
 import {INTERVALS_PER_SLOT, SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
+  DataAvailabilityStatus,
   EffectiveBalanceIncrements,
   ZERO_HASH,
   computeEpochAtSlot,
@@ -31,7 +32,6 @@ import {Logger, MapDef, fromHex, toRootHex} from "@lodestar/utils";
 import {computeDeltas} from "../protoArray/computeDeltas.js";
 import {ProtoArrayError, ProtoArrayErrorCode} from "../protoArray/errors.js";
 import {
-  DataAvailabilityStatus,
   ExecutionStatus,
   HEX_ZERO_HASH,
   LVHExecResponse,

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1126,10 +1126,10 @@ export class ForkChoice implements IForkChoice {
     return executionStatus;
   }
 
-  private getPreMergeDataStatus(dataAvailabilityStatus: DataAvailabilityStatus): DataAvailabilityStatus.PreData {
-    if (dataAvailabilityStatus !== DataAvailabilityStatus.PreData)
+  private getPreMergeDataStatus(dataAvailabilityStatus: DataAvailabilityStatus): DataAvailabilityStatus.preData {
+    if (dataAvailabilityStatus !== DataAvailabilityStatus.preData)
       throw Error(
-        `Invalid pre-merge data status: expected: ${DataAvailabilityStatus.PreData}, got ${dataAvailabilityStatus}`
+        `Invalid pre-merge data status: expected: ${DataAvailabilityStatus.preData}, got ${dataAvailabilityStatus}`
       );
     return dataAvailabilityStatus;
   }

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1126,10 +1126,10 @@ export class ForkChoice implements IForkChoice {
     return executionStatus;
   }
 
-  private getPreMergeDataStatus(dataAvailabilityStatus: DataAvailabilityStatus): DataAvailabilityStatus.preData {
-    if (dataAvailabilityStatus !== DataAvailabilityStatus.preData)
+  private getPreMergeDataStatus(dataAvailabilityStatus: DataAvailabilityStatus): DataAvailabilityStatus.PreData {
+    if (dataAvailabilityStatus !== DataAvailabilityStatus.PreData)
       throw Error(
-        `Invalid pre-merge data status: expected: ${DataAvailabilityStatus.preData}, got ${dataAvailabilityStatus}`
+        `Invalid pre-merge data status: expected: ${DataAvailabilityStatus.PreData}, got ${dataAvailabilityStatus}`
       );
     return dataAvailabilityStatus;
   }

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -1,4 +1,4 @@
-import {EffectiveBalanceIncrements} from "@lodestar/state-transition";
+import {DataAvailabilityStatus, EffectiveBalanceIncrements} from "@lodestar/state-transition";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {
   AttesterSlashing,
@@ -10,13 +10,7 @@ import {
   Slot,
   ValidatorIndex,
 } from "@lodestar/types";
-import {
-  DataAvailabilityStatus,
-  LVHExecResponse,
-  MaybeValidExecutionStatus,
-  ProtoBlock,
-  ProtoNode,
-} from "../protoArray/interface.js";
+import {LVHExecResponse, MaybeValidExecutionStatus, ProtoBlock, ProtoNode} from "../protoArray/interface.js";
 import {UpdateAndGetHeadOpt} from "./forkChoice.js";
 import {CheckpointWithHex} from "./store.js";
 

--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -7,7 +7,6 @@ export type {
   LVHValidResponse,
   LVHInvalidResponse,
 } from "./protoArray/interface.js";
-export {DataAvailabilityStatus} from "./protoArray/interface.js";
 export {ExecutionStatus} from "./protoArray/interface.js";
 
 export {ForkChoice, type ForkChoiceOpts, UpdateHeadOpt, assertValidTerminalPowBlock} from "./forkChoice/forkChoice.js";

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -1,3 +1,4 @@
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot, UintNum64} from "@lodestar/types";
 
 // RootHex is a root as a hex string
@@ -34,13 +35,6 @@ export type LVHInvalidResponse = {
 export type LVHExecResponse = LVHValidResponse | LVHInvalidResponse;
 
 export type MaybeValidExecutionStatus = Exclude<ExecutionStatus, ExecutionStatus.Invalid>;
-
-export enum DataAvailabilityStatus {
-  preData = "PreData",
-  /* validator activities can't be performed on out of range data */
-  OutOfRange = "OutOfRange",
-  available = "Available",
-}
 
 export type BlockExtraMeta =
   | {

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -36,7 +36,7 @@ export type LVHExecResponse = LVHValidResponse | LVHInvalidResponse;
 export type MaybeValidExecutionStatus = Exclude<ExecutionStatus, ExecutionStatus.Invalid>;
 
 export enum DataAvailabilityStatus {
-  PreData = "PreData",
+  preData = "PreData",
   /* validator activities can't be performed on out of range data */
   OutOfRange = "OutOfRange",
   Available = "Available",
@@ -52,7 +52,7 @@ export type BlockExtraMeta =
   | {
       executionPayloadBlockHash: null;
       executionStatus: ExecutionStatus.PreMerge;
-      dataAvailabilityStatus: DataAvailabilityStatus.PreData;
+      dataAvailabilityStatus: DataAvailabilityStatus.preData;
     };
 
 /**

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -39,7 +39,7 @@ export enum DataAvailabilityStatus {
   preData = "PreData",
   /* validator activities can't be performed on out of range data */
   OutOfRange = "OutOfRange",
-  Available = "Available",
+  available = "Available",
 }
 
 export type BlockExtraMeta =

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -46,7 +46,7 @@ export type BlockExtraMeta =
   | {
       executionPayloadBlockHash: null;
       executionStatus: ExecutionStatus.PreMerge;
-      dataAvailabilityStatus: DataAvailabilityStatus.preData;
+      dataAvailabilityStatus: DataAvailabilityStatus.PreData;
     };
 
 /**

--- a/packages/fork-choice/test/perf/forkChoice/util.ts
+++ b/packages/fork-choice/test/perf/forkChoice/util.ts
@@ -1,14 +1,8 @@
 import {fromHexString} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
 import {computeTotalBalance} from "../../../src/forkChoice/store.js";
-import {
-  DataAvailabilityStatus,
-  ExecutionStatus,
-  ForkChoice,
-  IForkChoiceStore,
-  ProtoArray,
-  ProtoBlock,
-} from "../../../src/index.js";
+import {ExecutionStatus, ForkChoice, IForkChoiceStore, ProtoArray, ProtoBlock} from "../../../src/index.js";
 
 const genesisSlot = 0;
 const genesisEpoch = 0;

--- a/packages/fork-choice/test/perf/forkChoice/util.ts
+++ b/packages/fork-choice/test/perf/forkChoice/util.ts
@@ -30,7 +30,7 @@ export function initializeForkChoice(opts: Opts): ForkChoice {
 
       executionPayloadBlockHash: null,
       executionStatus: ExecutionStatus.PreMerge,
-      dataAvailabilityStatus: DataAvailabilityStatus.preData,
+      dataAvailabilityStatus: DataAvailabilityStatus.PreData,
     } as Omit<ProtoBlock, "targetRoot">,
     genesisSlot
   );
@@ -79,7 +79,7 @@ export function initializeForkChoice(opts: Opts): ForkChoice {
       executionStatus: ExecutionStatus.PreMerge,
 
       timeliness: false,
-      dataAvailabilityStatus: DataAvailabilityStatus.preData,
+      dataAvailabilityStatus: DataAvailabilityStatus.PreData,
     };
 
     protoArr.onBlock(block, block.slot);

--- a/packages/fork-choice/test/perf/forkChoice/util.ts
+++ b/packages/fork-choice/test/perf/forkChoice/util.ts
@@ -36,7 +36,7 @@ export function initializeForkChoice(opts: Opts): ForkChoice {
 
       executionPayloadBlockHash: null,
       executionStatus: ExecutionStatus.PreMerge,
-      dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+      dataAvailabilityStatus: DataAvailabilityStatus.preData,
     } as Omit<ProtoBlock, "targetRoot">,
     genesisSlot
   );
@@ -85,7 +85,7 @@ export function initializeForkChoice(opts: Opts): ForkChoice {
       executionStatus: ExecutionStatus.PreMerge,
 
       timeliness: false,
-      dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+      dataAvailabilityStatus: DataAvailabilityStatus.preData,
     };
 
     protoArr.onBlock(block, block.slot);

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -1,12 +1,11 @@
 import {fromHexString} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {DataAvailabilityStatus, computeEpochAtSlot} from "@lodestar/state-transition";
 import {RootHex, Slot} from "@lodestar/types";
 import {toHex} from "@lodestar/utils";
 import {beforeAll, beforeEach, describe, expect, it} from "vitest";
 import {
-  DataAvailabilityStatus,
   EpochDifference,
   ExecutionStatus,
   ForkChoice,

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -40,7 +40,7 @@ describe("Forkchoice", () => {
 
         executionPayloadBlockHash: null,
         executionStatus: ExecutionStatus.PreMerge,
-        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+        dataAvailabilityStatus: DataAvailabilityStatus.preData,
       } as Omit<ProtoBlock, "targetRoot">,
       genesisSlot
     );
@@ -103,7 +103,7 @@ describe("Forkchoice", () => {
       executionStatus: ExecutionStatus.PreMerge,
 
       timeliness: false,
-      dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+      dataAvailabilityStatus: DataAvailabilityStatus.preData,
     };
   };
 

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -39,7 +39,7 @@ describe("Forkchoice", () => {
 
         executionPayloadBlockHash: null,
         executionStatus: ExecutionStatus.PreMerge,
-        dataAvailabilityStatus: DataAvailabilityStatus.preData,
+        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
       } as Omit<ProtoBlock, "targetRoot">,
       genesisSlot
     );
@@ -102,7 +102,7 @@ describe("Forkchoice", () => {
       executionStatus: ExecutionStatus.PreMerge,
 
       timeliness: false,
-      dataAvailabilityStatus: DataAvailabilityStatus.preData,
+      dataAvailabilityStatus: DataAvailabilityStatus.PreData,
     };
   };
 

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -1,18 +1,12 @@
 import {fromHexString} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
 import {INTERVALS_PER_SLOT, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
 import {Slot} from "@lodestar/types";
 import {toHex} from "@lodestar/utils";
 import {beforeEach, describe, expect, it} from "vitest";
 import {NotReorgedReason} from "../../../src/forkChoice/interface.js";
-import {
-  DataAvailabilityStatus,
-  ExecutionStatus,
-  ForkChoice,
-  IForkChoiceStore,
-  ProtoArray,
-  ProtoBlock,
-} from "../../../src/index.js";
+import {ExecutionStatus, ForkChoice, IForkChoiceStore, ProtoArray, ProtoBlock} from "../../../src/index.js";
 import {getBlockRoot, getStateRoot} from "../../utils/index.js";
 
 type ProtoBlockWithWeight = ProtoBlock & {weight: number}; // weight of the block itself

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -46,7 +46,7 @@ describe("Forkchoice / GetProposerHead", () => {
     executionStatus: ExecutionStatus.PreMerge,
 
     timeliness: false,
-    dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+    dataAvailabilityStatus: DataAvailabilityStatus.preData,
   };
 
   const baseHeadBlock: ProtoBlockWithWeight = {
@@ -71,7 +71,7 @@ describe("Forkchoice / GetProposerHead", () => {
     timeliness: false,
 
     weight: 29,
-    dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+    dataAvailabilityStatus: DataAvailabilityStatus.preData,
   };
 
   const baseParentHeadBlock: ProtoBlockWithWeight = {
@@ -95,7 +95,7 @@ describe("Forkchoice / GetProposerHead", () => {
 
     timeliness: false,
     weight: 212, // 240 - 29 + 1
-    dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+    dataAvailabilityStatus: DataAvailabilityStatus.preData,
   };
 
   const fcStore: IForkChoiceStore = {

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -40,7 +40,7 @@ describe("Forkchoice / GetProposerHead", () => {
     executionStatus: ExecutionStatus.PreMerge,
 
     timeliness: false,
-    dataAvailabilityStatus: DataAvailabilityStatus.preData,
+    dataAvailabilityStatus: DataAvailabilityStatus.PreData,
   };
 
   const baseHeadBlock: ProtoBlockWithWeight = {
@@ -65,7 +65,7 @@ describe("Forkchoice / GetProposerHead", () => {
     timeliness: false,
 
     weight: 29,
-    dataAvailabilityStatus: DataAvailabilityStatus.preData,
+    dataAvailabilityStatus: DataAvailabilityStatus.PreData,
   };
 
   const baseParentHeadBlock: ProtoBlockWithWeight = {
@@ -89,7 +89,7 @@ describe("Forkchoice / GetProposerHead", () => {
 
     timeliness: false,
     weight: 212, // 240 - 29 + 1
-    dataAvailabilityStatus: DataAvailabilityStatus.preData,
+    dataAvailabilityStatus: DataAvailabilityStatus.PreData,
   };
 
   const fcStore: IForkChoiceStore = {

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "vitest";
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
 import {
   BlockExtraMeta,
   ExecutionStatus,
@@ -7,7 +8,6 @@ import {
   ProtoBlock,
 } from "../../../src/index.js";
 import {LVHExecErrorCode} from "../../../src/protoArray/errors.js";
-import {DataAvailabilityStatus} from "../../../src/protoArray/interface.js";
 
 type ValidationTestCase = {
   root: string;

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -1,5 +1,5 @@
-import {describe, expect, it} from "vitest";
 import {DataAvailabilityStatus} from "@lodestar/state-transition";
+import {describe, expect, it} from "vitest";
 import {
   BlockExtraMeta,
   ExecutionStatus,

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -85,13 +85,13 @@ function setupForkChoice(): ProtoArray {
         ? {
             executionPayloadBlockHash: null,
             executionStatus: ExecutionStatus.PreMerge,
-            dataAvailabilityStatus: DataAvailabilityStatus.preData,
+            dataAvailabilityStatus: DataAvailabilityStatus.PreData,
           }
         : {
             executionPayloadBlockHash: block.root,
             executionPayloadNumber: block.slot,
             executionStatus: block.executionStatus,
-            dataAvailabilityStatus: DataAvailabilityStatus.preData,
+            dataAvailabilityStatus: DataAvailabilityStatus.PreData,
           }
     ) as BlockExtraMeta;
     fc.onBlock(

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -85,13 +85,13 @@ function setupForkChoice(): ProtoArray {
         ? {
             executionPayloadBlockHash: null,
             executionStatus: ExecutionStatus.PreMerge,
-            dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+            dataAvailabilityStatus: DataAvailabilityStatus.preData,
           }
         : {
             executionPayloadBlockHash: block.root,
             executionPayloadNumber: block.slot,
             executionStatus: block.executionStatus,
-            dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+            dataAvailabilityStatus: DataAvailabilityStatus.preData,
           }
     ) as BlockExtraMeta;
     fc.onBlock(

--- a/packages/fork-choice/test/unit/protoArray/getCommonAncestor.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/getCommonAncestor.test.ts
@@ -1,5 +1,6 @@
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
 import {describe, expect, it} from "vitest";
-import {DataAvailabilityStatus, ExecutionStatus, ProtoArray} from "../../../src/index.js";
+import {ExecutionStatus, ProtoArray} from "../../../src/index.js";
 
 describe("getCommonAncestor", () => {
   const blocks: {slot: number; root: string; parent: string}[] = [

--- a/packages/fork-choice/test/unit/protoArray/getCommonAncestor.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/getCommonAncestor.test.ts
@@ -44,7 +44,7 @@ describe("getCommonAncestor", () => {
       timeliness: false,
 
       ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-      dataAvailabilityStatus: DataAvailabilityStatus.preData,
+      dataAvailabilityStatus: DataAvailabilityStatus.PreData,
     },
     0
   );
@@ -70,7 +70,7 @@ describe("getCommonAncestor", () => {
         timeliness: false,
 
         ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-        dataAvailabilityStatus: DataAvailabilityStatus.preData,
+        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
       },
       block.slot
     );

--- a/packages/fork-choice/test/unit/protoArray/getCommonAncestor.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/getCommonAncestor.test.ts
@@ -43,7 +43,7 @@ describe("getCommonAncestor", () => {
       timeliness: false,
 
       ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-      dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+      dataAvailabilityStatus: DataAvailabilityStatus.preData,
     },
     0
   );
@@ -69,7 +69,7 @@ describe("getCommonAncestor", () => {
         timeliness: false,
 
         ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+        dataAvailabilityStatus: DataAvailabilityStatus.preData,
       },
       block.slot
     );

--- a/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
@@ -1,7 +1,7 @@
+import {DataAvailabilityStatus} from "@lodestar/state-transition";
 import {RootHex} from "@lodestar/types";
 import {describe, expect, it} from "vitest";
-
-import {DataAvailabilityStatus, ExecutionStatus, ProtoArray} from "../../../src/index.js";
+import {ExecutionStatus, ProtoArray} from "../../../src/index.js";
 
 describe("ProtoArray", () => {
   it("finalized descendant", () => {

--- a/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
@@ -33,7 +33,7 @@ describe("ProtoArray", () => {
         timeliness: false,
 
         ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-        dataAvailabilityStatus: DataAvailabilityStatus.preData,
+        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
       },
       genesisSlot
     );
@@ -59,7 +59,7 @@ describe("ProtoArray", () => {
         timeliness: false,
 
         ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-        dataAvailabilityStatus: DataAvailabilityStatus.preData,
+        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
       },
       genesisSlot + 1
     );
@@ -85,7 +85,7 @@ describe("ProtoArray", () => {
         timeliness: false,
 
         ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-        dataAvailabilityStatus: DataAvailabilityStatus.preData,
+        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
       },
       genesisSlot + 1
     );

--- a/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
@@ -33,7 +33,7 @@ describe("ProtoArray", () => {
         timeliness: false,
 
         ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+        dataAvailabilityStatus: DataAvailabilityStatus.preData,
       },
       genesisSlot
     );
@@ -59,7 +59,7 @@ describe("ProtoArray", () => {
         timeliness: false,
 
         ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+        dataAvailabilityStatus: DataAvailabilityStatus.preData,
       },
       genesisSlot + 1
     );
@@ -85,7 +85,7 @@ describe("ProtoArray", () => {
         timeliness: false,
 
         ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
-        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+        dataAvailabilityStatus: DataAvailabilityStatus.preData,
       },
       genesisSlot + 1
     );

--- a/packages/state-transition/src/block/externalData.ts
+++ b/packages/state-transition/src/block/externalData.ts
@@ -13,13 +13,14 @@ export enum ExecutionPayloadStatus {
   valid = "valid",
 }
 
-export enum DataAvailableStatus {
-  preDeneb = "preDeneb",
-  notAvailable = "notAvailable",
+export enum DataAvailabilityStatus {
+  preData = "preData",
+  /* validator activities can't be performed on out of range data */
+  outOfRange = "outOfRange",
   available = "available",
 }
 
 export interface BlockExternalData {
   executionPayloadStatus: ExecutionPayloadStatus;
-  dataAvailableStatus: DataAvailableStatus;
+  dataAvailabilityStatus: DataAvailabilityStatus;
 }

--- a/packages/state-transition/src/block/externalData.ts
+++ b/packages/state-transition/src/block/externalData.ts
@@ -17,7 +17,7 @@ export enum DataAvailabilityStatus {
   PreData = "PreData",
   /* validator activities can't be performed on out of range data */
   OutOfRange = "OutOfRange",
-  available = "Available",
+  Available = "Available",
 }
 
 export interface BlockExternalData {

--- a/packages/state-transition/src/block/externalData.ts
+++ b/packages/state-transition/src/block/externalData.ts
@@ -14,10 +14,10 @@ export enum ExecutionPayloadStatus {
 }
 
 export enum DataAvailabilityStatus {
-  PreData = "preData",
+  PreData = "PreData",
   /* validator activities can't be performed on out of range data */
-  OutOfRange = "outOfRange",
-  available = "available",
+  OutOfRange = "OutOfRange",
+  available = "Available",
 }
 
 export interface BlockExternalData {

--- a/packages/state-transition/src/block/externalData.ts
+++ b/packages/state-transition/src/block/externalData.ts
@@ -14,9 +14,9 @@ export enum ExecutionPayloadStatus {
 }
 
 export enum DataAvailabilityStatus {
-  preData = "preData",
+  PreData = "preData",
   /* validator activities can't be performed on out of range data */
-  outOfRange = "outOfRange",
+  OutOfRange = "outOfRange",
   available = "available",
 }
 

--- a/packages/state-transition/src/block/index.ts
+++ b/packages/state-transition/src/block/index.ts
@@ -70,7 +70,7 @@ export function processBlock(
     // Only throw preDeneb so beacon can also sync/process blocks optimistically
     // and let forkChoice handle it
     if (externalData.dataAvailabilityStatus === DataAvailabilityStatus.preData) {
-      throw Error("dataAvailableStatus preDeneb");
+      throw Error("dataAvailabilityStatus preDeneb");
     }
   }
 }

--- a/packages/state-transition/src/block/index.ts
+++ b/packages/state-transition/src/block/index.ts
@@ -3,7 +3,7 @@ import {BeaconBlock, BlindedBeaconBlock, altair, capella} from "@lodestar/types"
 import {BeaconStateTransitionMetrics} from "../metrics.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateBellatrix, CachedBeaconStateCapella} from "../types.js";
 import {getFullOrBlindedPayload, isExecutionEnabled} from "../util/execution.js";
-import {BlockExternalData, DataAvailableStatus} from "./externalData.js";
+import {BlockExternalData, DataAvailabilityStatus} from "./externalData.js";
 import {processBlobKzgCommitments} from "./processBlobKzgCommitments.js";
 import {processBlockHeader} from "./processBlockHeader.js";
 import {processEth1Data} from "./processEth1Data.js";
@@ -69,7 +69,7 @@ export function processBlock(
     processBlobKzgCommitments(externalData);
     // Only throw preDeneb so beacon can also sync/process blocks optimistically
     // and let forkChoice handle it
-    if (externalData.dataAvailableStatus === DataAvailableStatus.preDeneb) {
+    if (externalData.dataAvailabilityStatus === DataAvailabilityStatus.preData) {
       throw Error("dataAvailableStatus preDeneb");
     }
   }

--- a/packages/state-transition/src/block/index.ts
+++ b/packages/state-transition/src/block/index.ts
@@ -67,10 +67,10 @@ export function processBlock(
 
   if (fork >= ForkSeq.deneb) {
     processBlobKzgCommitments(externalData);
-    // Only throw preDeneb so beacon can also sync/process blocks optimistically
+    // Only throw PreData so beacon can also sync/process blocks optimistically
     // and let forkChoice handle it
     if (externalData.dataAvailabilityStatus === DataAvailabilityStatus.PreData) {
-      throw Error("dataAvailabilityStatus preDeneb");
+      throw Error("dataAvailabilityStatus.PreData");
     }
   }
 }

--- a/packages/state-transition/src/block/index.ts
+++ b/packages/state-transition/src/block/index.ts
@@ -69,7 +69,7 @@ export function processBlock(
     processBlobKzgCommitments(externalData);
     // Only throw preDeneb so beacon can also sync/process blocks optimistically
     // and let forkChoice handle it
-    if (externalData.dataAvailabilityStatus === DataAvailabilityStatus.preData) {
+    if (externalData.dataAvailabilityStatus === DataAvailabilityStatus.PreData) {
       throw Error("dataAvailabilityStatus preDeneb");
     }
   }

--- a/packages/state-transition/src/block/processExecutionPayload.ts
+++ b/packages/state-transition/src/block/processExecutionPayload.ts
@@ -15,7 +15,7 @@ export function processExecutionPayload(
   fork: ForkSeq,
   state: CachedBeaconStateBellatrix | CachedBeaconStateCapella,
   body: BeaconBlockBody | BlindedBeaconBlockBody,
-  externalData: Omit<BlockExternalData, "dataAvailableStatus">
+  externalData: Omit<BlockExternalData, "dataAvailabilityStatus">
 ): void {
   const payload = getFullOrBlindedPayloadFromBody(body);
   const forkName = ForkName[ForkSeq[fork] as ForkName];

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -57,7 +57,11 @@ export {isValidVoluntaryExit} from "./block/processVoluntaryExit.js";
 export {isValidBlsToExecutionChange} from "./block/processBlsToExecutionChange.js";
 export {assertValidProposerSlashing} from "./block/processProposerSlashing.js";
 export {assertValidAttesterSlashing} from "./block/processAttesterSlashing.js";
-export {ExecutionPayloadStatus, DataAvailableStatus, type BlockExternalData} from "./block/externalData.js";
+export {
+  ExecutionPayloadStatus,
+  DataAvailabilityStatus,
+  type BlockExternalData,
+} from "./block/externalData.js";
 
 // BeaconChain, to prepare new blocks
 export {becomesNewEth1Data} from "./block/processEth1Data.js";

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -69,7 +69,7 @@ export function stateTransition(
   options: StateTransitionOpts = {
     // Assume default to be valid and available
     executionPayloadStatus: ExecutionPayloadStatus.valid,
-    dataAvailabilityStatus: DataAvailabilityStatus.available,
+    dataAvailabilityStatus: DataAvailabilityStatus.Available,
   },
   metrics?: BeaconStateTransitionMetrics | null
 ): CachedBeaconStateAllForks {

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -1,7 +1,7 @@
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {SignedBeaconBlock, SignedBlindedBeaconBlock, Slot, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
-import {BlockExternalData, DataAvailableStatus, ExecutionPayloadStatus} from "./block/externalData.js";
+import {BlockExternalData, DataAvailabilityStatus, ExecutionPayloadStatus} from "./block/externalData.js";
 import {processBlock} from "./block/index.js";
 import {ProcessBlockOpts} from "./block/types.js";
 import {EpochTransitionCache, EpochTransitionCacheOpts, beforeProcessEpoch} from "./cache/epochTransitionCache.js";
@@ -69,7 +69,7 @@ export function stateTransition(
   options: StateTransitionOpts = {
     // Assume default to be valid and available
     executionPayloadStatus: ExecutionPayloadStatus.valid,
-    dataAvailableStatus: DataAvailableStatus.available,
+    dataAvailabilityStatus: DataAvailabilityStatus.available,
   },
   metrics?: BeaconStateTransitionMetrics | null
 ): CachedBeaconStateAllForks {

--- a/packages/state-transition/test/perf/block/processBlockAltair.test.ts
+++ b/packages/state-transition/test/perf/block/processBlockAltair.test.ts
@@ -126,7 +126,7 @@ describe("altair processBlock", () => {
         fn: ({state, block}) => {
           const postState = stateTransition(state, block, {
             executionPayloadStatus: ExecutionPayloadStatus.valid,
-            dataAvailableStatus: DataAvailableStatus.available,
+            dataAvailabilityStatus: DataAvailableStatus.available,
             verifyProposer: false,
             verifySignatures: false,
             verifyStateRoot: false,

--- a/packages/state-transition/test/perf/block/processBlockAltair.test.ts
+++ b/packages/state-transition/test/perf/block/processBlockAltair.test.ts
@@ -126,7 +126,7 @@ describe("altair processBlock", () => {
         fn: ({state, block}) => {
           const postState = stateTransition(state, block, {
             executionPayloadStatus: ExecutionPayloadStatus.valid,
-            dataAvailabilityStatus: DataAvailabilityStatus.available,
+            dataAvailabilityStatus: DataAvailabilityStatus.Available,
             verifyProposer: false,
             verifySignatures: false,
             verifyStateRoot: false,

--- a/packages/state-transition/test/perf/block/processBlockAltair.test.ts
+++ b/packages/state-transition/test/perf/block/processBlockAltair.test.ts
@@ -12,7 +12,7 @@ import {
 import {ssz} from "@lodestar/types";
 import {
   CachedBeaconStateAltair,
-  DataAvailableStatus,
+  DataAvailabilityStatus,
   ExecutionPayloadStatus,
   stateTransition,
 } from "../../../src/index.js";
@@ -126,7 +126,7 @@ describe("altair processBlock", () => {
         fn: ({state, block}) => {
           const postState = stateTransition(state, block, {
             executionPayloadStatus: ExecutionPayloadStatus.valid,
-            dataAvailabilityStatus: DataAvailableStatus.available,
+            dataAvailabilityStatus: DataAvailabilityStatus.available,
             verifyProposer: false,
             verifySignatures: false,
             verifyStateRoot: false,

--- a/packages/state-transition/test/perf/block/processBlockPhase0.test.ts
+++ b/packages/state-transition/test/perf/block/processBlockPhase0.test.ts
@@ -8,7 +8,7 @@ import {
   MAX_VOLUNTARY_EXITS,
   PresetName,
 } from "@lodestar/params";
-import {DataAvailableStatus, ExecutionPayloadStatus, stateTransition} from "../../../src/index.js";
+import {DataAvailabilityStatus, ExecutionPayloadStatus, stateTransition} from "../../../src/index.js";
 import {StateBlock} from "../types.js";
 import {generatePerfTestCachedStatePhase0, perfStateId} from "../util.js";
 import {BlockOpts, getBlockPhase0} from "./util.js";
@@ -110,7 +110,7 @@ describe("phase0 processBlock", () => {
       fn: ({state, block}) => {
         stateTransition(state, block, {
           executionPayloadStatus: ExecutionPayloadStatus.valid,
-          dataAvailabilityStatus: DataAvailableStatus.available,
+          dataAvailabilityStatus: DataAvailabilityStatus.available,
           verifyProposer: false,
           verifySignatures: false,
           verifyStateRoot: false,

--- a/packages/state-transition/test/perf/block/processBlockPhase0.test.ts
+++ b/packages/state-transition/test/perf/block/processBlockPhase0.test.ts
@@ -110,7 +110,7 @@ describe("phase0 processBlock", () => {
       fn: ({state, block}) => {
         stateTransition(state, block, {
           executionPayloadStatus: ExecutionPayloadStatus.valid,
-          dataAvailableStatus: DataAvailableStatus.available,
+          dataAvailabilityStatus: DataAvailableStatus.available,
           verifyProposer: false,
           verifySignatures: false,
           verifyStateRoot: false,

--- a/packages/state-transition/test/perf/block/processBlockPhase0.test.ts
+++ b/packages/state-transition/test/perf/block/processBlockPhase0.test.ts
@@ -110,7 +110,7 @@ describe("phase0 processBlock", () => {
       fn: ({state, block}) => {
         stateTransition(state, block, {
           executionPayloadStatus: ExecutionPayloadStatus.valid,
-          dataAvailabilityStatus: DataAvailabilityStatus.available,
+          dataAvailabilityStatus: DataAvailabilityStatus.Available,
           verifyProposer: false,
           verifySignatures: false,
           verifyStateRoot: false,


### PR DESCRIPTION
**Motivation**

There were two copies of the DataAvailabilityStatus enum.  One in state-transition and the other in fork-choice.  Both did essentially the same thing.  Refactor to use only the one.

The is prep work for the BlockInput refactor.

PR 0 of ??
