### PR TITLE
chore: fix lints, types and unit tests in peerDAS

### DIFF
--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -1,6 +1,6 @@
 import type {ChainForkConfig} from "@lodestar/config";
 import type {DataAvailabilityStatus, MaybeValidExecutionStatus} from "@lodestar/fork-choice";
-import {type ForkPostDeneb, ForkSeq, ForkPreFulu, ForkPostFulu} from "@lodestar/params";
+import {type ForkPostDeneb, ForkPostFulu, ForkPreFulu, ForkSeq} from "@lodestar/params";
 import {type CachedBeaconStateAllForks, computeEpochAtSlot} from "@lodestar/state-transition";
 import type {ColumnIndex, RootHex, SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
 

--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -4,7 +4,7 @@ import {StrictEventEmitter} from "strict-event-emitter-types";
 import {routes} from "@lodestar/api";
 import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
-import {phase0, fulu} from "@lodestar/types";
+import {fulu, phase0} from "@lodestar/types";
 
 /**
  * Important chain events that occur during normal chain operation.

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -31,6 +31,7 @@ import {IExecutionBuilder, IExecutionEngine} from "../execution/index.js";
 import {Metrics} from "../metrics/metrics.js";
 import {BufferPool} from "../util/bufferPool.js";
 import {IClock} from "../util/clock.js";
+import {CustodyConfig} from "../util/dataColumns.js";
 import {SerializedCache} from "../util/serializedCache.js";
 import {IArchiveStore} from "./archiveStore/interface.js";
 import {CheckpointBalancesCache} from "./balancesCache.js";
@@ -61,7 +62,6 @@ import {SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof.js";
 import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
 import {SeenBlockAttesters} from "./seenCache/seenBlockAttesters.js";
 import {ShufflingCache} from "./shufflingCache.js";
-import {CustodyConfig} from "../util/dataColumns.js";
 
 export {BlockType, type AssembledBlockType};
 export {type ProposerPreparationData};

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -7,12 +7,12 @@ import {
 import {Root, Slot, deneb, fulu, ssz} from "@lodestar/types";
 import {toHex, verifyMerkleBranch} from "@lodestar/utils";
 
+import {Metrics} from "../../metrics/metrics.js";
 import {byteArrayEquals} from "../../util/bytes.js";
 import {ckzg} from "../../util/kzg.js";
 import {DataColumnSidecarErrorCode, DataColumnSidecarGossipError} from "../errors/dataColumnSidecarError.js";
 import {GossipAction} from "../errors/gossipValidation.js";
 import {IBeaconChain} from "../interface.js";
-import {Metrics} from "../../metrics/metrics.js";
 
 export async function validateGossipDataColumnSidecar(
   chain: IBeaconChain,

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -21,6 +21,7 @@ import {Eth2Gossipsub, getCoreTopicsAtFork} from "../gossip/index.js";
 import {Libp2p} from "../interface.js";
 import {createNodeJsLibp2p} from "../libp2p/index.js";
 import {MetadataController} from "../metadata.js";
+import {NetworkConfig} from "../networkConfig.js";
 import {NetworkOptions} from "../options.js";
 import {PeerAction, PeerRpcScoreStore, PeerScoreStats} from "../peers/index.js";
 import {PeerManager} from "../peers/peerManager.js";
@@ -34,7 +35,6 @@ import {SyncnetsService} from "../subnets/syncnetsService.js";
 import {getConnectionsMap} from "../util.js";
 import {NetworkCoreMetrics, createNetworkCoreMetrics} from "./metrics.js";
 import {INetworkCore, MultiaddrStr, PeerIdStr} from "./types.js";
-import {NetworkConfig} from "../networkConfig.js";
 
 type Mods = {
   libp2p: Libp2p;

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -34,6 +34,7 @@ import {Metrics, RegistryMetricCreator} from "../metrics/index.js";
 import {IClock} from "../util/clock.js";
 import {CustodyConfig} from "../util/dataColumns.js";
 import {PeerIdStr, peerIdToString} from "../util/peerId.js";
+import {promiseAllMaybeAsync} from "../util/promises.js";
 import {BlobSidecarsByRootRequest} from "../util/types.js";
 import {INetworkCore, NetworkCore, WorkerNetworkCore} from "./core/index.js";
 import {INetworkEventBus, NetworkEvent, NetworkEventBus, NetworkEventData} from "./events.js";
@@ -55,7 +56,6 @@ import {
 import {collectSequentialBlocksInRange} from "./reqresp/utils/collectSequentialBlocksInRange.js";
 import {CommitteeSubscription, NodeId} from "./subnets/index.js";
 import {isPublishToZeroPeersError} from "./util.js";
-import {promiseAllMaybeAsync} from "../util/promises.js";
 
 type NetworkModules = {
   opts: NetworkOptions;

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -8,19 +8,19 @@ import {CustodyIndex, SubnetID} from "@lodestar/types";
 import {pruneSetToMax, sleep} from "@lodestar/utils";
 import {bytesToInt} from "@lodestar/utils";
 import {Multiaddr} from "@multiformats/multiaddr";
+import {IClock} from "../../util/clock.js";
 import {getCustodyGroups, getDataColumns} from "../../util/dataColumns.js";
 import {NetworkCoreMetrics} from "../core/metrics.js";
 import {Discv5Worker} from "../discv5/index.js";
 import {LodestarDiscv5Opts} from "../discv5/types.js";
 import {Libp2p} from "../interface.js";
 import {ENRKey, SubnetType} from "../metadata.js";
+import {NetworkConfig} from "../networkConfig.js";
 import {NodeId, computeNodeId} from "../subnets/interface.js";
 import {getConnectionsMap, prettyPrintPeerId} from "../util.js";
 import {IPeerRpcScoreStore, ScoreState} from "./score/index.js";
 import {deserializeEnrSubnets, zeroAttnets, zeroSyncnets} from "./utils/enrSubnetsDeserialize.js";
 import {type GroupQueries} from "./utils/prioritizePeers.js";
-import {IClock} from "../../util/clock.js";
-import {NetworkConfig} from "../networkConfig.js";
 
 /** Max number of cached ENRs after discovering a good peer */
 const MAX_CACHED_ENRS = 100;
@@ -253,7 +253,7 @@ export class PeerDiscovery {
       group: for (const [group, maxPeersToConnect] of groupRequests) {
         let cachedENRsInGroup = 0;
         for (const cachedENR of cachedENRsReverse) {
-          if (cachedENR.peerCustodyGroups && cachedENR.peerCustodyGroups.includes(group)) {
+          if (cachedENR.peerCustodyGroups?.includes(group)) {
             cachedENRsToDial.set(cachedENR.peerId.toString(), cachedENR);
 
             if (++cachedENRsInGroup >= maxPeersToConnect) {

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -14,23 +14,23 @@ import {INetworkEventBus, NetworkEvent, NetworkEventData} from "../events.js";
 import {Eth2Gossipsub} from "../gossip/gossipsub.js";
 import {Libp2p} from "../interface.js";
 import {SubnetType} from "../metadata.js";
+import {NetworkConfig} from "../networkConfig.js";
 import {ReqRespMethod} from "../reqresp/ReqRespBeaconNode.js";
 import {StatusCache} from "../statusCache.js";
 import {NodeId, SubnetsService, computeNodeId} from "../subnets/index.js";
 import {getConnection, getConnectionsMap, prettyPrintPeerId} from "../util.js";
 import {ClientKind, getKnownClientFromAgentVersion} from "./client.js";
 import {PeerDiscovery, SubnetDiscvQueryMs} from "./discover.js";
+import {PeerData, PeersData} from "./peersData.js";
 import {IPeerRpcScoreStore, PeerAction, PeerScoreStats, ScoreState, updateGossipsubScores} from "./score/index.js";
-import {PeersData, PeerData} from "./peersData.js";
 import {
+  PrioritizePeersOpts,
   assertPeerRelevance,
   getConnectedPeerIds,
   hasSomeConnectedPeer,
   prioritizePeers,
   renderIrrelevantPeerType,
-  PrioritizePeersOpts,
 } from "./utils/index.js";
-import {NetworkConfig} from "../networkConfig.js";
 
 /** heartbeat performs regular updates such as updating reputations and performing discovery requests */
 const HEARTBEAT_INTERVAL_MS = 30 * 1000;

--- a/packages/beacon-node/src/network/peers/utils/prioritizePeers.ts
+++ b/packages/beacon-node/src/network/peers/utils/prioritizePeers.ts
@@ -91,7 +91,7 @@ export function prioritizePeers(
   }[],
   activeAttnets: RequestedSubnet[],
   activeSyncnets: RequestedSubnet[],
-  samplingGroups: CustodyIndex[] = [],
+  samplingGroups: CustodyIndex[] | undefined,
   opts: PrioritizePeersOpts,
   metrics: NetworkCoreMetrics | null
 ): {
@@ -162,7 +162,7 @@ function requestSubnetPeers(
   connectedPeers: PeerInfo[],
   activeAttnets: RequestedSubnet[],
   activeSyncnets: RequestedSubnet[],
-  samplingGroups: CustodyIndex[] = [],
+  samplingGroups: CustodyIndex[] | undefined,
   opts: PrioritizePeersOpts,
   metrics: NetworkCoreMetrics | null
 ): {
@@ -241,7 +241,7 @@ function requestSubnetPeers(
     }
   }
 
-  for (const group of samplingGroups) {
+  for (const group of samplingGroups ?? []) {
     const peersInGroup = peersPerGroup.get(group) ?? 0;
     metrics?.peerCountPerSamplingGroup.set({group}, peersInGroup);
     if (peersInGroup < targetGroupPeers) {

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -260,12 +260,8 @@ export function matchBlockWithDataColumns(
       throw Error(`Invalid block forkSeq=${forkSeq} < ForSeq.fulu for matchBlockWithDataColumns`);
     }
     const dataColumnSidecars: fulu.DataColumnSidecar[] = [];
-    let dataColumnSidecar: fulu.DataColumnSidecar;
-    while (
-      (dataColumnSidecar = allDataColumnSidecars[dataColumnSideCarIndex])?.signedBlockHeader.message.slot ===
-      block.data.message.slot
-    ) {
-      dataColumnSidecars.push(dataColumnSidecar);
+    while (allDataColumnSidecars[dataColumnSideCarIndex]?.signedBlockHeader.message.slot === block.data.message.slot) {
+      dataColumnSidecars.push(allDataColumnSidecars[dataColumnSideCarIndex]);
       lastMatchedSlot = block.data.message.slot;
       dataColumnSideCarIndex++;
     }

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -180,7 +180,7 @@ export class BeaconNode {
         config,
         anchorState,
         logger.child({module: LoggerModule.vmon}),
-        metricsRegistries,
+        metricsRegistries
       );
       initBeaconMetrics(metrics, anchorState);
       // Since the db is instantiated before this, metrics must be injected manually afterwards

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -3,8 +3,8 @@ import {Tree} from "@chainsafe/persistent-merkle-tree";
 import {ChainForkConfig} from "@lodestar/config";
 import {
   ForkAll,
-  ForkPostDeneb,
   ForkName,
+  ForkPostDeneb,
   KZG_COMMITMENTS_GINDEX,
   KZG_COMMITMENT_GINDEX0,
   NUMBER_OF_COLUMNS,

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -151,6 +151,8 @@ describe("data serialization through worker boundary", () => {
     scrapeMetrics: [],
     writeProfile: [0, ""],
     writeDiscv5Profile: [0, ""],
+    setTargetGroupCount: [4],
+    setAdvertisedGroupCount: [4],
   };
 
   const lodestarPeer: routes.lodestar.LodestarNodePeer = {
@@ -214,6 +216,8 @@ describe("data serialization through worker boundary", () => {
     scrapeMetrics: "test-metrics",
     writeProfile: "",
     writeDiscv5Profile: "",
+    setAdvertisedGroupCount: null,
+    setTargetGroupCount: null,
   };
 
   type TestCase = {id: string; data: unknown; shouldFail?: boolean};

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -7,11 +7,12 @@ import {altair, phase0, ssz} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {afterEach, describe, expect, it, vi} from "vitest";
 import {Eth2Gossipsub, NetworkEvent, NetworkEventBus, getConnectionsMap} from "../../../../src/network/index.js";
+import {NetworkConfig} from "../../../../src/network/networkConfig.js";
 import {IReqRespBeaconNodePeerManager, PeerManager, PeerRpcScoreStore} from "../../../../src/network/peers/index.js";
 import {PeersData} from "../../../../src/network/peers/peersData.js";
 import {ReqRespMethod} from "../../../../src/network/reqresp/ReqRespBeaconNode.js";
 import {LocalStatusCache} from "../../../../src/network/statusCache.js";
-import {IAttnetsService, computeNodeId} from "../../../../src/network/subnets/index.js";
+import {IAttnetsService} from "../../../../src/network/subnets/index.js";
 import {Clock} from "../../../../src/util/clock.js";
 import {waitForEvent} from "../../../utils/events/resolver.js";
 import {testLogger} from "../../../utils/logger.js";
@@ -43,6 +44,7 @@ describe("network / peers / PeerManager", () => {
       },
     });
     const beaconConfig = createBeaconConfig(config, state.genesisValidatorsRoot);
+    const networkConfig = new NetworkConfig(peerId1, beaconConfig);
     const controller = new AbortController();
     const clock = new Clock({config: beaconConfig, genesisTime: 0, signal: controller.signal});
     const status = ssz.phase0.Status.defaultValue();
@@ -74,17 +76,17 @@ describe("network / peers / PeerManager", () => {
         metrics: null,
         clock,
         statusCache,
-        config: beaconConfig,
+        networkConfig,
         peerRpcScores,
         events: networkEventBus,
         attnetsService: mockSubnetsService,
         syncnetsService: mockSubnetsService,
         gossip: {getScore: () => 0, scoreParams: {decayInterval: 1000}} as unknown as Eth2Gossipsub,
         peersData: new PeersData(),
-        nodeId: computeNodeId(peerId1),
       },
       {
         targetPeers: 30,
+        targetGroupPeers: 6,
         maxPeers: 50,
         discv5: null,
         discv5FirstQueryDelayMs: 0,

--- a/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
@@ -17,6 +17,7 @@ import {
   ReqRespBeaconNodeModules,
 } from "../../../src/network/index.js";
 import {MetadataController} from "../../../src/network/metadata.js";
+import {NetworkConfig} from "../../../src/network/networkConfig.js";
 import {PeersData} from "../../../src/network/peers/peersData.js";
 import {GetReqRespHandlerFn} from "../../../src/network/reqresp/types.js";
 import {LocalStatusCache} from "../../../src/network/statusCache.js";
@@ -59,6 +60,7 @@ describe("reqresp encoder", () => {
       };
 
     const config = createBeaconConfig({}, ZERO_HASH);
+    const networkConfig = new NetworkConfig(libp2p.peerId, config);
     const modules: ReqRespBeaconNodeModules = {
       libp2p,
       peersData: new PeersData(),
@@ -66,7 +68,7 @@ describe("reqresp encoder", () => {
       config,
       metrics: null,
       getHandler: getHandler ?? getHandlerNoop,
-      metadata: new MetadataController({}, {config, onSetValue: () => null}),
+      metadata: new MetadataController({}, {networkConfig, onSetValue: () => null}),
       peerRpcScores: new PeerRpcScoreStore(),
       events: new NetworkEventBus(),
       statusCache: new LocalStatusCache(ssz.phase0.Status.defaultValue()),

--- a/packages/beacon-node/test/perf/network/peers/util/prioritizePeers.test.ts
+++ b/packages/beacon-node/test/perf/network/peers/util/prioritizePeers.test.ts
@@ -101,6 +101,7 @@ describe("prioritizePeers", () => {
             Array.from({length: Math.floor(syncnetPercentage * SYNC_COMMITTEE_SUBNET_COUNT)}, (_, i) => i)
           ),
           score: lowestScore + ((highestScore - lowestScore) * i) / defaultNetworkOptions.maxPeers,
+          custodyGroups: [],
         }));
 
         const attnets: RequestedSubnet[] = [];
@@ -112,10 +113,10 @@ describe("prioritizePeers", () => {
         for (let i = 0; i < requestedSyncNets.count; i++) {
           syncnets.push({subnet: requestedSyncNets.start + i, toSlot: 1_000_000});
         }
-        return {connectedPeers, attnets, syncnets};
+        return {connectedPeers, attnets, syncnets, samplingGroups: []};
       },
-      fn: ({connectedPeers, attnets, syncnets}) => {
-        prioritizePeers(connectedPeers, attnets, syncnets, defaultNetworkOptions);
+      fn: ({connectedPeers, attnets, syncnets, samplingGroups}) => {
+        prioritizePeers(connectedPeers, attnets, syncnets, samplingGroups, defaultNetworkOptions, null);
       },
     });
   }

--- a/packages/beacon-node/test/unit/chain/lightclient/upgradeLightClientHeader.test.ts
+++ b/packages/beacon-node/test/unit/chain/lightclient/upgradeLightClientHeader.test.ts
@@ -43,14 +43,8 @@ describe("UpgradeLightClientHeader", () => {
     };
   });
 
-  // Since fulu is not implemented for loop is till deneb (Object.values(ForkName).length-1)
-  // Once fulu is implemnted run for loop till Object.values(ForkName).length
-
-  // for (let i = ForkSeq.altair; i < Object.values(ForkName).length; i++) {
-  //   for (let j = i + 1; j < Object.values(ForkName).length; j++) {
-
-  for (let i = ForkSeq.altair; i < Object.values(ForkName).length - 1; i++) {
-    for (let j = i + 1; j < Object.values(ForkName).length - 1; j++) {
+  for (let i = ForkSeq.altair; i < Object.values(ForkName).length; i++) {
+    for (let j = i + 1; j < Object.values(ForkName).length; j++) {
       const fromFork = ForkName[ForkSeq[i] as ForkName];
       const toFork = ForkName[ForkSeq[j] as ForkName];
 
@@ -64,27 +58,7 @@ describe("UpgradeLightClientHeader", () => {
     }
   }
 
-  // for fulu not implemented
   for (let i = ForkSeq.altair; i < Object.values(ForkName).length; i++) {
-    const fromFork = ForkName[ForkSeq[i] as ForkName];
-    const toFork = ForkName["fulu"];
-
-    it(`Throw error ${fromFork}=>${toFork}`, () => {
-      lcHeaderByFork[fromFork].beacon.slot = testSlots[fromFork];
-      lcHeaderByFork[toFork].beacon.slot = testSlots[fromFork];
-
-      expect(() => {
-        upgradeLightClientHeader(config, toFork, lcHeaderByFork[fromFork]);
-      }).toThrow("Not Implemented");
-    });
-  }
-
-  // Since fulu is not implemented for loop is till deneb (Object.values(ForkName).length-1)
-  // Once fulu is implemnted run for loop till Object.values(ForkName).length
-
-  // for (let i = ForkSeq.altair; i < Object.values(ForkName).length; i++) {
-
-  for (let i = ForkSeq.altair; i < Object.values(ForkName).length - 1; i++) {
     for (let j = i; j > 0; j--) {
       const fromFork = ForkName[ForkSeq[i] as ForkName];
       const toFork = ForkName[ForkSeq[j] as ForkName];

--- a/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
@@ -2,16 +2,16 @@ import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lo
 import {ssz} from "@lodestar/types";
 import {describe, expect, it} from "vitest";
 
+import {ZERO_HASH_HEX} from "@lodestar/params";
 import {BlockInput, BlockInputType, GossipedInputType} from "../../../../src/chain/blocks/types.js";
+import {ChainEventEmitter} from "../../../../src/chain/emitter.js";
 import {
   BlockInputMetaPendingBlockWithBlobs,
   SeenGossipBlockInput,
 } from "../../../../src/chain/seenCache/seenGossipBlockInput.js";
-import {ExecutionEngineMockBackend} from "../../../../src/execution/engine/mock.js";
-import {ZERO_HASH_HEX} from "@lodestar/params";
 import {getExecutionEngineFromBackend} from "../../../../src/execution/engine/index.js";
+import {ExecutionEngineMockBackend} from "../../../../src/execution/engine/mock.js";
 import {testLogger} from "../../../utils/logger.js";
-import {ChainEventEmitter} from "../../../../src/chain/emitter.js";
 
 describe("SeenGossipBlockInput", () => {
   const chainConfig = createChainForkConfig({

--- a/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
@@ -11,7 +11,10 @@ import {
 } from "../../../../src/chain/seenCache/seenGossipBlockInput.js";
 import {getExecutionEngineFromBackend} from "../../../../src/execution/engine/index.js";
 import {ExecutionEngineMockBackend} from "../../../../src/execution/engine/mock.js";
+import {computeNodeId} from "../../../../src/network/subnets/index.js";
+import {CustodyConfig} from "../../../../src/util/dataColumns.js";
 import {testLogger} from "../../../utils/logger.js";
+import {getValidPeerId} from "../../../utils/peer.js";
 
 describe("SeenGossipBlockInput", () => {
   const chainConfig = createChainForkConfig({
@@ -22,6 +25,7 @@ describe("SeenGossipBlockInput", () => {
   });
   const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
   const config = createBeaconConfig(chainConfig, genesisValidatorsRoot);
+  const nodeId = computeNodeId(getValidPeerId());
 
   // Execution engine
   const executionEngineBackend = new ExecutionEngineMockBackend({
@@ -36,18 +40,7 @@ describe("SeenGossipBlockInput", () => {
 
   const emitter = new ChainEventEmitter();
 
-  const seenGossipBlockInput = new SeenGossipBlockInput(
-    {
-      sampledColumns: [],
-      custodyColumns: [],
-      custodyColumnsIndex: Uint8Array.from([1, 2, 3]),
-      custodyColumnsLen: 0,
-      sampleGroups: [],
-      sampledSubnets: [],
-    },
-    executionEngine,
-    emitter
-  );
+  const seenGossipBlockInput = new SeenGossipBlockInput(new CustodyConfig(nodeId, config), executionEngine, emitter);
 
   // array of numBlobs, events where events are array of
   // [block|blob11|blob2, pd | bp | null | error string reflecting the expected result]

--- a/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
@@ -7,8 +7,8 @@ import {BlobsSource, BlockSource, getBlockInput} from "../../../src/chain/blocks
 import {ZERO_HASH} from "../../../src/constants/constants.js";
 import {INetwork} from "../../../src/network/interface.js";
 import {beaconBlocksMaybeBlobsByRange} from "../../../src/network/reqresp/index.js";
-import {initCKZG, loadEthereumTrustedSetup} from "../../../src/util/kzg.js";
 import {CustodyConfig} from "../../../src/util/dataColumns.js";
+import {initCKZG, loadEthereumTrustedSetup} from "../../../src/util/kzg.js";
 
 describe.skip("beaconBlocksMaybeBlobsByRange", () => {
   beforeAll(async () => {

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -13,10 +13,12 @@ import {bigIntToBytes} from "@lodestar/utils";
 import {MockedObject, afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {Eth2Gossipsub} from "../../../../src/network/gossip/gossipsub.js";
 import {MetadataController} from "../../../../src/network/metadata.js";
+import {NetworkConfig} from "../../../../src/network/networkConfig.js";
 import {AttnetsService} from "../../../../src/network/subnets/attnetsService.js";
 import {CommitteeSubscription} from "../../../../src/network/subnets/interface.js";
 import {Clock, IClock} from "../../../../src/util/clock.js";
 import {testLogger} from "../../../utils/logger.js";
+import {getValidPeerId} from "../../../utils/peer.js";
 
 vi.mock("../../../../src/network/gossip/gossipsub.js");
 
@@ -28,6 +30,7 @@ describe("AttnetsService", () => {
   );
   const ALTAIR_FORK_EPOCH = 100;
   const config = createBeaconConfig({ALTAIR_FORK_EPOCH}, ZERO_HASH);
+  const networkConfig = new NetworkConfig(getValidPeerId(), config);
   // const {SECONDS_PER_SLOT} = config;
   let service: AttnetsService;
   let gossipStub: MockedObject<Eth2Gossipsub>;
@@ -51,7 +54,7 @@ describe("AttnetsService", () => {
 
     // load getCurrentSlot first, vscode not able to debug without this
     getCurrentSlot(config, Math.floor(Date.now() / 1000));
-    metadata = new MetadataController({}, {config, onSetValue: () => null});
+    metadata = new MetadataController({}, {networkConfig, onSetValue: () => null});
     service = new AttnetsService(config, clock, gossipStub, metadata, logger, null, nodeId, {
       slotsToSubscribeBeforeAggregatorDuty: 2,
     });

--- a/packages/beacon-node/test/unit/sync/range/utils/batches.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/utils/batches.test.ts
@@ -227,7 +227,7 @@ describe("sync / range / batches", () => {
     batch.startDownloading(peer);
     if (status === BatchStatus.Downloading) return batch;
 
-    batch.downloadingSuccess({blocks: [], pendingDataColumns: []});
+    batch.downloadingSuccess({blocks: [], pendingDataColumns: null});
     if (status === BatchStatus.AwaitingProcessing) return batch;
 
     batch.startProcessing();

--- a/packages/beacon-node/test/unit/util/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/util/dataColumn.test.ts
@@ -1,11 +1,11 @@
 import {fromHexString} from "@chainsafe/ssz";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
-import {NUMBER_OF_COLUMNS, NUMBER_OF_CUSTODY_GROUPS} from "@lodestar/params";
-import {ssz} from "@lodestar/types";
-import {bigIntToBytes} from "@lodestar/utils";
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {ChainForkConfig} from "@lodestar/config";
+import {NUMBER_OF_COLUMNS, NUMBER_OF_CUSTODY_GROUPS} from "@lodestar/params";
+import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {ssz} from "@lodestar/types";
 import {ValidatorIndex} from "@lodestar/types";
+import {bigIntToBytes} from "@lodestar/utils";
 /* eslint-disable @typescript-eslint/naming-convention */
 import {afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
 
@@ -74,18 +74,10 @@ describe("getValidatorsCustodyRequirement", () => {
 });
 
 describe("CustodyConfig", () => {
-  let state: CachedBeaconStateAllForks;
   let config: ChainForkConfig;
   const nodeId = fromHexString("cdbee32dc3c50e9711d22be5565c7e44ff6108af663b2dc5abd2df573d2fa83f");
 
   beforeEach(() => {
-    // Create a mock state with validators effective balance increments
-    state = {
-      epochCtx: {
-        effectiveBalanceIncrements: new Uint8Array(NUMBER_OF_CUSTODY_GROUPS + 1).fill(32), // Each validator has 32 ETH (1 increment)
-      },
-    } as unknown as CachedBeaconStateAllForks;
-
     // Create a proper config using createChainForkConfig
     config = createChainForkConfig({
       ...defaultChainConfig,

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -189,7 +189,7 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
   }
 
   const logger = initLogger(args, beaconPaths.dataDir, config);
-  const {peerId, enr, nodeId} = await initPeerIdAndEnr(config, args, beaconPaths.beaconDir, logger);
+  const {peerId, enr, nodeId} = await initPeerIdAndEnr(args, beaconPaths.beaconDir, logger);
 
   if (args.discv5 !== false) {
     // Inject ENR to beacon options

--- a/packages/cli/src/cmds/bootnode/handler.ts
+++ b/packages/cli/src/cmds/bootnode/handler.ts
@@ -180,7 +180,7 @@ export async function bootnodeHandlerInit(args: BootnodeArgs & GlobalArgs) {
   );
 
   const logger = initLogger(args, beaconPaths.dataDir, config, "bootnode.log");
-  const {peerId, enr} = await initPeerIdAndEnr(config, args as unknown as BeaconArgs, bootnodeDir, logger, true);
+  const {peerId, enr} = await initPeerIdAndEnr(args as unknown as BeaconArgs, bootnodeDir, logger, true);
 
   return {discv5Args, metricsArgs, bootnodeDir, network, version, commit, peerId, enr, logger};
 }

--- a/packages/cli/test/unit/cmds/beacon.test.ts
+++ b/packages/cli/test/unit/cmds/beacon.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import {ENR, SignableENR, createPrivateKeyFromPeerId} from "@chainsafe/enr";
 import {createFromJSON, createSecp256k1PeerId} from "@libp2p/peer-id-factory";
-import {chainConfigToJson, createChainForkConfig} from "@lodestar/config";
+import {chainConfigToJson} from "@lodestar/config";
 import {chainConfig} from "@lodestar/config/default";
 import {LogLevel} from "@lodestar/utils";
 import {multiaddr} from "@multiformats/multiaddr";
@@ -13,8 +13,6 @@ import {BeaconArgs} from "../../../src/cmds/beacon/options.js";
 import {exportToJSON} from "../../../src/config/peerId.js";
 import {GlobalArgs} from "../../../src/options/globalOptions.js";
 import {testFilesDir, testLogger} from "../../utils.js";
-
-const chainForkConfig = createChainForkConfig(chainConfig);
 
 describe("cmds / beacon / args handler", () => {
   // Make tests faster skipping a network call
@@ -120,13 +118,11 @@ describe("Test isLocalMultiAddr", () => {
 describe("initPeerIdAndEnr", () => {
   it("should not reuse peer id, persistNetworkIdentity=false", async () => {
     const {peerId: peerId1} = await initPeerIdAndEnr(
-      chainForkConfig,
       {persistNetworkIdentity: false} as BeaconArgs,
       testFilesDir,
       testLogger()
     );
     const {peerId: peerId2} = await initPeerIdAndEnr(
-      chainForkConfig,
       {persistNetworkIdentity: false} as BeaconArgs,
       testFilesDir,
       testLogger()
@@ -137,13 +133,11 @@ describe("initPeerIdAndEnr", () => {
 
   it("should reuse peer id, persistNetworkIdentity=true", async () => {
     const {peerId: peerId1} = await initPeerIdAndEnr(
-      chainForkConfig,
       {persistNetworkIdentity: true} as BeaconArgs,
       testFilesDir,
       testLogger()
     );
     const {peerId: peerId2} = await initPeerIdAndEnr(
-      chainForkConfig,
       {persistNetworkIdentity: true} as BeaconArgs,
       testFilesDir,
       testLogger()
@@ -157,7 +151,6 @@ describe("initPeerIdAndEnr", () => {
     const peerId1Str = "wrong peer id file content";
     fs.writeFileSync(peerIdFile, peerId1Str);
     const {peerId: peerId2} = await initPeerIdAndEnr(
-      chainForkConfig,
       {persistNetworkIdentity: true} as BeaconArgs,
       testFilesDir,
       testLogger()
@@ -173,7 +166,7 @@ describe("initPeerIdAndEnr", () => {
     const invalidEnr = "wrong enr file content";
     fs.writeFileSync(enrFilePath, invalidEnr);
 
-    await initPeerIdAndEnr(chainForkConfig, {persistNetworkIdentity: true} as BeaconArgs, testFilesDir, testLogger());
+    await initPeerIdAndEnr({persistNetworkIdentity: true} as BeaconArgs, testFilesDir, testLogger());
 
     const validEnr = fs.readFileSync(enrFilePath, "utf-8");
 
@@ -187,12 +180,7 @@ describe("initPeerIdAndEnr", () => {
     const otherEnrStr = otherEnr.encodeTxt();
     fs.writeFileSync(enrFilePath, otherEnrStr);
 
-    const {enr} = await initPeerIdAndEnr(
-      chainForkConfig,
-      {persistNetworkIdentity: true} as BeaconArgs,
-      testFilesDir,
-      testLogger()
-    );
+    const {enr} = await initPeerIdAndEnr({persistNetworkIdentity: true} as BeaconArgs, testFilesDir, testLogger());
 
     expect(enr.nodeId).not.toBe(otherEnr);
   });

--- a/packages/cli/test/unit/cmds/initPeerIdAndEnr.test.ts
+++ b/packages/cli/test/unit/cmds/initPeerIdAndEnr.test.ts
@@ -1,13 +1,9 @@
 import fs from "node:fs";
-import {createChainForkConfig} from "@lodestar/config";
-import {chainConfig} from "@lodestar/config/default";
 import tmp from "tmp";
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
 import {initPeerIdAndEnr} from "../../../src/cmds/beacon/initPeerIdAndEnr.js";
 import {BeaconArgs} from "../../../src/cmds/beacon/options.js";
 import {testLogger} from "../../utils.js";
-
-const chainForkConfig = createChainForkConfig(chainConfig);
 
 describe("initPeerIdAndEnr", () => {
   let tmpDir: tmp.DirResult;
@@ -22,7 +18,6 @@ describe("initPeerIdAndEnr", () => {
 
   it("first time should create a new enr and peer id", async () => {
     const {enr, peerId} = await initPeerIdAndEnr(
-      chainForkConfig,
       {persistNetworkIdentity: true} as unknown as BeaconArgs,
       tmpDir.name,
       testLogger(),
@@ -35,9 +30,8 @@ describe("initPeerIdAndEnr", () => {
     expect(enr.tcp6).toBeUndefined();
   });
 
-  it("second time should use ths existing enr and peer id", async () => {
+  it("second time should use the existing enr and peer id", async () => {
     const run1 = await initPeerIdAndEnr(
-      chainForkConfig,
       {persistNetworkIdentity: true} as unknown as BeaconArgs,
       tmpDir.name,
       testLogger(),
@@ -45,7 +39,6 @@ describe("initPeerIdAndEnr", () => {
     );
 
     const run2 = await initPeerIdAndEnr(
-      chainForkConfig,
       {persistNetworkIdentity: true} as unknown as BeaconArgs,
       tmpDir.name,
       testLogger(),

--- a/packages/params/test/unit/forkName.test.ts
+++ b/packages/params/test/unit/forkName.test.ts
@@ -2,13 +2,13 @@ import {describe, expect, it} from "vitest";
 import {
   ForkName,
   forkAll,
+  forkBlobs,
   forkPostAltair,
   forkPostBellatrix,
   forkPostCapella,
   forkPostDeneb,
   highestFork,
   lowestFork,
-  forkBlobs,
 } from "../../src/forkName.js";
 
 describe("forkName", () => {


### PR DESCRIPTION
**Motivation**

It'd be nice to get tests and lints passing on the peerDAS branch, both to get it ready to merge into unstable and so we can check PRs into the peerDAS branch.

**Description**

The only intended functional change is to `initPeerIdAndEnr`, will add a comment on that change. It might be easier to review commit by commit, to more easily view the lint fixes separately from the unit test fixes.

