### PR TITLE
fix: no peer expiry from peerstore

### DIFF
--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -107,6 +107,7 @@ export async function createNodeJsLibp2p(
       enabled: false,
     },
     // for our purposes, we don't want peer store data to expire
+    // see https://github.com/libp2p/js-libp2p/pull/3019
     peerStore: {
       maxAddressAge: Infinity,
       maxPeerAge: Infinity,

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -106,6 +106,11 @@ export async function createNodeJsLibp2p(
     connectionMonitor: {
       enabled: false,
     },
+    // for our purposes, we don't want peer store data to expire
+    peerStore: {
+      maxAddressAge: Infinity,
+      maxPeerAge: Infinity,
+    },
     datastore,
     services: {
       identify: identify({


### PR DESCRIPTION
**Motivation**

See https://discord.com/channels/593655374469660673/1353810292202799154/1362013907668963439

**Description**

- set peerstore expiry options to Infinity, practically disabling the feature

Closes #7702