### PR TITLE
refactor: decouple pre and post deneb calculation in verifyPropagationSlotRange

### DIFF
--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -572,18 +572,18 @@ export function verifyPropagationSlotRange(fork: ForkName, chain: IBeaconChain, 
     });
   }
 
-  const earliestPermissibleSlot = Math.max(
-    // slot with past tolerance of MAXIMUM_GOSSIP_CLOCK_DISPARITY_SEC
-    // ATTESTATION_PROPAGATION_SLOT_RANGE = SLOTS_PER_EPOCH
-    chain.clock.slotWithPastTolerance(MAXIMUM_GOSSIP_CLOCK_DISPARITY_SEC) - SLOTS_PER_EPOCH,
-    0
-  );
-
   // Post deneb the attestations are valid for current as well as previous epoch
   // while pre deneb they are valid for ATTESTATION_PROPAGATION_SLOT_RANGE
   //
   // see: https://github.com/ethereum/consensus-specs/pull/3360
   if (ForkSeq[fork] < ForkSeq.deneb) {
+    const earliestPermissibleSlot = Math.max(
+      // slot with past tolerance of MAXIMUM_GOSSIP_CLOCK_DISPARITY_SEC
+      // ATTESTATION_PROPAGATION_SLOT_RANGE = SLOTS_PER_EPOCH
+      chain.clock.slotWithPastTolerance(MAXIMUM_GOSSIP_CLOCK_DISPARITY_SEC) - SLOTS_PER_EPOCH,
+      0
+    );
+
     if (attestationSlot < earliestPermissibleSlot) {
       throw new AttestationError(GossipAction.IGNORE, {
         code: AttestationErrorCode.PAST_SLOT,
@@ -605,7 +605,9 @@ export function verifyPropagationSlotRange(fork: ForkName, chain: IBeaconChain, 
     }
 
     // lower bound for previous epoch is same as epoch of earliestPermissibleSlot
-    const earliestPermissiblePreviousEpoch = computeEpochAtSlot(earliestPermissibleSlot);
+    const currentEpochWithPastTolerance = computeEpochAtSlot(chain.clock.slotWithPastTolerance(MAXIMUM_GOSSIP_CLOCK_DISPARITY_SEC));
+
+    const earliestPermissiblePreviousEpoch = Math.max(currentEpochWithPastTolerance - 1, 0);
     if (attestationEpoch < earliestPermissiblePreviousEpoch) {
       throw new AttestationError(GossipAction.IGNORE, {
         code: AttestationErrorCode.PAST_EPOCH,

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -605,7 +605,9 @@ export function verifyPropagationSlotRange(fork: ForkName, chain: IBeaconChain, 
     }
 
     // lower bound for previous epoch is same as epoch of earliestPermissibleSlot
-    const currentEpochWithPastTolerance = computeEpochAtSlot(chain.clock.slotWithPastTolerance(MAXIMUM_GOSSIP_CLOCK_DISPARITY_SEC));
+    const currentEpochWithPastTolerance = computeEpochAtSlot(
+      chain.clock.slotWithPastTolerance(MAXIMUM_GOSSIP_CLOCK_DISPARITY_SEC)
+    );
 
     const earliestPermissiblePreviousEpoch = Math.max(currentEpochWithPastTolerance - 1, 0);
     if (attestationEpoch < earliestPermissiblePreviousEpoch) {


### PR DESCRIPTION
In post-deneb, we don't use `earliestPermissibleSlot` anymore when checking attestation's slot but checking the slot's epoch.

Because in post-deneb, we moved from
```
[IGNORE] aggregate.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots 
(with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) 
-- i.e. aggregate.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= aggregate.data.slot
```
to 
```
[IGNORE] the epoch of aggregate.data.slot is either the current or previous epoch 
(with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) 
-- i.e. compute_epoch_at_slot(aggregate.data.slot) in (get_previous_epoch(state), get_current_epoch(state))
```


In our current code, we mix pre-deneb calculation ie. `earliestPermissibleSlot` into post-deneb calculation:
```const earliestPermissiblePreviousEpoch = computeEpochAtSlot(earliestPermissibleSlot);```
We should separate the two calculations to make it more readable