### PR TITLE
chore: fix spec and e2e tests for peerDAS

### DIFF
--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -67,6 +67,7 @@ export const defaultSkipOpts: SkipOpts = {
     /^capella\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^deneb\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^electra\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
+    /^fulu\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^.+\/light_client\/data_collection\/.*/,
   ],
   skippedTests: [],

--- a/packages/params/test/e2e/ensure-config-is-synced.test.ts
+++ b/packages/params/test/e2e/ensure-config-is-synced.test.ts
@@ -53,15 +53,12 @@ function assertCorrectPreset(localPreset: BeaconPreset, remotePreset: BeaconPres
 
 async function downloadRemoteConfig(preset: "mainnet" | "minimal", commit: string): Promise<BeaconPreset> {
   const downloadedParams = await Promise.all(
-    Object.values(ForkName)
-      // TODO Fulu: check against remote presets
-      .filter((forkName) => forkName !== ForkName.fulu)
-      .map((forkName) =>
-        axios({
-          url: `https://raw.githubusercontent.com/ethereum/consensus-specs/${commit}/presets/${preset}/${forkName}.yaml`,
-          timeout: 30 * 1000,
-        }).then((response) => loadConfigYaml(response.data))
-      )
+    Object.values(ForkName).map((forkName) =>
+      axios({
+        url: `https://raw.githubusercontent.com/ethereum/consensus-specs/${commit}/presets/${preset}/${forkName}.yaml`,
+        timeout: 30 * 1000,
+      }).then((response) => loadConfigYaml(response.data))
+    )
   );
 
   // Merge all the fetched yamls for the different forks


### PR DESCRIPTION
**Motivation**

Fixes an error in the spec test, as well as an error in the e2e tests. This might not fix all the e2e test issues, but I still need to get my e2e environment set up locally.

**Description**

* Continues skipping the test for single_merkle_proof. This is removed for fulu in 1.5.0-beta4 tests, but might as well fix it for now
* Allows the params e2e tests to run on Fulu -- everything is implemented there anyway