### PR TITLE
fix: handle empty partial download - peerDAS

### DIFF
--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -106,7 +106,7 @@ export async function beaconBlocksMaybeBlobsByRange(
     const dataColumnRequest = {...request, columns};
     const [allBlocks, allDataColumnSidecars] = await Promise.all([
       // TODO-das: investigate why partialDownload blocks is empty here
-      (partialDownload && partialDownload.blocks.length > 0)
+      partialDownload && partialDownload.blocks.length > 0
         ? partialDownload.blocks.map((blockInput) => ({data: blockInput.block}))
         : network.sendBeaconBlocksByRange(peerId, request),
       columns.length === 0 ? [] : network.sendDataColumnSidecarsByRange(peerId, dataColumnRequest),

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -105,7 +105,8 @@ export async function beaconBlocksMaybeBlobsByRange(
 
     const dataColumnRequest = {...request, columns};
     const [allBlocks, allDataColumnSidecars] = await Promise.all([
-      partialDownload
+      // TODO-das: not sure why partialDownload blocks is empty here
+      (partialDownload && partialDownload.blocks.length > 0)
         ? partialDownload.blocks.map((blockInput) => ({data: blockInput.block}))
         : network.sendBeaconBlocksByRange(peerId, request),
       columns.length === 0 ? [] : network.sendDataColumnSidecarsByRange(peerId, dataColumnRequest),

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -105,7 +105,7 @@ export async function beaconBlocksMaybeBlobsByRange(
 
     const dataColumnRequest = {...request, columns};
     const [allBlocks, allDataColumnSidecars] = await Promise.all([
-      // TODO-das: not sure why partialDownload blocks is empty here
+      // TODO-das: investigate why partialDownload blocks is empty here
       (partialDownload && partialDownload.blocks.length > 0)
         ? partialDownload.blocks.map((blockInput) => ({data: blockInput.block}))
         : network.sendBeaconBlocksByRange(peerId, request),
@@ -325,7 +325,8 @@ export function matchBlockWithDataColumns(
       }
 
       let cachedData: CachedData;
-      if (prevPartialDownload !== null) {
+      // TODO-das: investigate why partialDownload blocks is empty here
+      if (prevPartialDownload !== null && prevPartialDownload.blocks.length > 0) {
         const prevBlockInput = prevPartialDownload.blocks[i];
         if (prevBlockInput.type !== BlockInputType.dataPromise) {
           throw Error(`prevBlockInput.type=${prevBlockInput.type} in prevPartialDownload`);

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -124,7 +124,7 @@ export class Batch {
       return blocks;
     }
 
-    this.state = {status: BatchStatus.AwaitingDownload, partialDownload: {blocks, pendingDataColumns}};
+    this.state = {status: BatchStatus.AwaitingDownload, partialDownload: blocks.length === 0 ? null : {blocks, pendingDataColumns}};
     return null;
   }
 

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -124,7 +124,10 @@ export class Batch {
       return blocks;
     }
 
-    this.state = {status: BatchStatus.AwaitingDownload, partialDownload: blocks.length === 0 ? null : {blocks, pendingDataColumns}};
+    this.state = {
+      status: BatchStatus.AwaitingDownload,
+      partialDownload: blocks.length === 0 ? null : {blocks, pendingDataColumns},
+    };
     return null;
   }
 


### PR DESCRIPTION
**Motivation**

Not able to sync due to the following errors:
```
Apr-18 07:57:45.931[sync]          ^[[36mverbose^[[39m: Batch download error id=Head, startEpoch=1798, status=Downloading, peer=16...YqJeis - Cannot read properties of undefined (reading 'type')
TypeError: Cannot read properties of undefined (reading 'type')
    at matchBlockWithDataColumns (file:///usr/src/lodestar/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts:330:28)
    at beaconBlocksMaybeBlobsByRange (file:///usr/src/lodestar/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts:127:20)
    at wrapError (file:///usr/src/lodestar/packages/beacon-node/src/util/wrapError.ts:18:32)
    at SyncChain.sendBatch (file:///usr/src/lodestar/packages/beacon-node/src/sync/range/chain.ts:410:19)
```

```
Apr-18 08:13:42.983[sync]          verbose: Batch download error id=Head, startEpoch=1800, status=Downloading, peer=16...T4qw69 - Unmatched blobSidecars, blocks=0, blobs=96 lastMatchedSlot=-1, pending blobSidecars slots=57602 57602 57602 57602 57602 57602 57602 57602 57608 57608 57608 57608 57608 57608 57608 57608 57609 57609 57609 57609 57609 57609 57609 57609 57610 57610 57610 57610 57610 57610 57610 57610 57612 57612 57612 57612 57612 57612 57612 57612 57615 57615 57615 57615 57615 57615 57615 57615 57616 57616 57616 57616 57616 57616 57616 57616 57617 57617 57617 57617 57617 57617 57617 57617 57620 57620 57620 57620 57620 57620 57620 57620 57625 57625 57625 57625 57625 57625 57625 57625 57627 57627 57627 57627 57627 57627 57627 57627 57631 57631 57631 57631 57631 57631 57631 57631
```

it happens so many times that prevent my node to sync
```
grep -e "Batch download error id=Head" -rn beacon-2025-04-18.log | grep "blocks=0" | wc -l
9408
```

**Description**

- handle `partialDownload` containing 0 blocks