### PR TITLE
fix: peer count per sampling group - peerDAS

### DIFF
--- a/packages/beacon-node/src/network/core/metrics.ts
+++ b/packages/beacon-node/src/network/core/metrics.ts
@@ -111,10 +111,10 @@ export function createNetworkCoreMetrics(register: RegistryMetricCreator) {
       help: "network.reportPeer count by reason",
       labelNames: ["reason"],
     }),
-    peerCountPerSamplingGroup: register.gauge<{group: CustodyIndex}>({
+    peerCountPerSamplingGroup: register.gauge<{groupIndex: number}>({
       name: "lodestar_peer_count_per_sampling_group",
       help: "Current count of peers per sampling group",
-      labelNames: ["group"],
+      labelNames: ["groupIndex"],
     }),
     peerManager: {
       heartbeatDuration: register.histogram({

--- a/packages/beacon-node/src/network/peers/utils/prioritizePeers.ts
+++ b/packages/beacon-node/src/network/peers/utils/prioritizePeers.ts
@@ -241,13 +241,15 @@ function requestSubnetPeers(
     }
   }
 
+  let groupIndex = 0;
   for (const group of samplingGroups ?? []) {
     const peersInGroup = peersPerGroup.get(group) ?? 0;
-    metrics?.peerCountPerSamplingGroup.set({group}, peersInGroup);
+    metrics?.peerCountPerSamplingGroup.set({groupIndex}, peersInGroup);
     if (peersInGroup < targetGroupPeers) {
       // We need more peers
       groupQueries.set(group, targetGroupPeers - peersInGroup);
     }
+    groupIndex++;
   }
 
   return {attnetQueries, syncnetQueries, groupQueries, dutiesByPeer};


### PR DESCRIPTION
**Motivation**

- it's not a good idea to track peer count per sampling group because when the node is restarted we have different sampling groups, then the metric will also track sampling groups of prior times. It looks like:

<img width="1262" alt="Screenshot 2025-04-18 at 15 42 20" src="https://github.com/user-attachments/assets/da816d46-d8be-4d55-9222-22c2d6b3935a" />


**Description**

- track by group index instead so it's consistently from 0 to 7. If we want to know specific groups, it's available in the log, just search for `requestedColumns`, for example
