### PR TITLE
feat: peerDAS - fetch blobs from EL in unknownBlock

### DIFF
--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -164,7 +164,7 @@ export class SeenGossipBlockInput {
     if (!this.blockInputCache.has(blockHex)) {
       this.blockInputCache.set(blockHex, blockCache);
       callInNextEventLoop(() => {
-        this.reconstructColumns(config, blockHex);
+        getDataColumnsFromExecution(config, this.custodyConfig, this.executionEngine, this.emitter, blockCache);
       });
     }
 
@@ -263,7 +263,7 @@ export class SeenGossipBlockInput {
           };
         }
 
-        if (this.hasSampledDataColumns(dataColumnsCache)) {
+        if (hasSampledDataColumns(this.custodyConfig, dataColumnsCache)) {
           const allDataColumns = getBlockInputDataColumns(dataColumnsCache, this.custodyConfig.sampledColumns);
           metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
           const {dataColumns} = allDataColumns;
@@ -361,111 +361,116 @@ export class SeenGossipBlockInput {
     //   blockInputMeta: {pending: GossipedInputType.block, haveBlobs: blobsCache.size, expectedBlobs: null},
     // };
   }
+}
 
-  private hasSampledDataColumns(dataColumnCache: DataColumnsCacheMap): boolean {
-    return (
-      dataColumnCache.size >= this.custodyConfig.sampledColumns.length &&
-      this.custodyConfig.sampledColumns.reduce((acc, columnIndex) => acc && dataColumnCache.has(columnIndex), true)
-    );
+function hasSampledDataColumns(custodyConfig: CustodyConfig, dataColumnCache: DataColumnsCacheMap): boolean {
+  return (
+    dataColumnCache.size >= custodyConfig.sampledColumns.length &&
+    custodyConfig.sampledColumns.reduce((acc, columnIndex) => acc && dataColumnCache.has(columnIndex), true)
+  );
+}
+
+export async function getDataColumnsFromExecution(
+  config: ChainForkConfig,
+  custodyConfig: CustodyConfig,
+  executionEngine: IExecutionEngine,
+  emitter: ChainEventEmitter,
+  blockCache: BlockInputCacheType
+): Promise<boolean> {
+  if (blockCache.fork !== ForkName.fulu) {
+    return false;
   }
 
-  private async reconstructColumns(config: ChainForkConfig, blockRoot: RootHex) {
-    const blockCache = this.blockInputCache.get(blockRoot);
-    if (blockCache === undefined || blockCache.fork !== ForkName.fulu) {
-      return;
-    }
-
-    if (!blockCache.cachedData) {
-      // this condition should never get hit... just a sanity check
-      throw new Error("invalid blockCache");
-    }
-
-    // If already have all columns, exit
-    if (
-      blockCache.cachedData.fork !== ForkName.fulu ||
-      this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache)
-    ) {
-      return;
-    }
-
-    let commitments: undefined | Uint8Array[];
-    if (blockCache.block) {
-      const block = blockCache.block as fulu.SignedBeaconBlock;
-      commitments = block.message.body.blobKzgCommitments;
-    } else {
-      const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
-      commitments = firstSidecar?.dataColumn.kzgCommitments;
-    }
-
-    if (!commitments) {
-      throw new Error("blockInputCache missing both block and cachedData");
-    }
-
-    // Process KZG commitments into versioned hashes
-    const versionedHashes: Uint8Array[] = commitments.map(kzgCommitmentToVersionedHash);
-
-    // Return if block has no blobs
-    if (versionedHashes.length === 0) {
-      return;
-    }
-
-    // Get blobs from execution engine
-    const blobs = await this.executionEngine.getBlobs(blockCache.fork, versionedHashes);
-
-    // Execution engine was unable to find one or more blobs
-    if (blobs === null) {
-      return;
-    }
-
-    // Return if we received all data columns while waiting for getBlobs
-    if (this.hasSampledDataColumns(blockCache.cachedData.dataColumnsCache)) {
-      return;
-    }
-
-    let dataColumnSidecars: fulu.DataColumnSidecars;
-    const cellsAndProofs = getCellsAndProofs(blobs);
-    if (blockCache.block) {
-      dataColumnSidecars = getDataColumnSidecarsFromBlock(
-        config,
-        blockCache.block as fulu.SignedBeaconBlock,
-        cellsAndProofs
-      );
-    } else {
-      const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
-      if (!firstSidecar) {
-        throw new Error("blockInputCache missing both block and data column sidecar");
-      }
-      dataColumnSidecars = getDataColumnSidecarsFromColumnSidecar(firstSidecar.dataColumn, cellsAndProofs);
-    }
-
-    // Publish columns if and only if subscribed to them
-    const sampledColumns = this.custodyConfig.sampledColumns.map((columnIndex) => dataColumnSidecars[columnIndex]);
-
-    this.emitter.emit(ChainEvent.publishDataColumns, sampledColumns);
-
-    for (const column of sampledColumns) {
-      blockCache.cachedData.dataColumnsCache.set(column.index, {dataColumn: column, dataColumnBytes: null});
-    }
-
-    const allDataColumns = getBlockInputDataColumns(
-      blockCache.cachedData.dataColumnsCache,
-      this.custodyConfig.sampledColumns
-    );
-    // TODO: Add metrics
-    // metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
-    const blockData: BlockInputDataColumns = {
-      fork: blockCache.cachedData.fork,
-      ...allDataColumns,
-      dataColumnsSource: DataColumnsSource.gossip,
-    };
-    blockCache.cachedData.resolveAvailability(blockData);
-
-    if (blockCache.block !== undefined) {
-      const blockInput = getBlockInput.availableData(config, blockCache.block, BlockSource.gossip, blockData);
-
-      blockCache.resolveBlockInput(blockInput);
-    }
+  if (!blockCache.cachedData) {
+    // this condition should never get hit... just a sanity check
+    throw new Error("invalid blockCache");
   }
+
+  if (blockCache.cachedData.fork !== ForkName.fulu) {
+    return false;
+  }
+
+  // If already have all columns, exit
+  if (hasSampledDataColumns(custodyConfig, blockCache.cachedData.dataColumnsCache)) {
+    return true;
+  }
+
+  let commitments: undefined | Uint8Array[];
+  if (blockCache.block) {
+    const block = blockCache.block as fulu.SignedBeaconBlock;
+    commitments = block.message.body.blobKzgCommitments;
+  } else {
+    const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
+    commitments = firstSidecar?.dataColumn.kzgCommitments;
+  }
+
+  if (!commitments) {
+    throw new Error("blockInputCache missing both block and cachedData");
+  }
+
+  // Return if block has no blobs
+  if (commitments.length === 0) {
+    return true;
+  }
+
+  // Process KZG commitments into versioned hashes
+  const versionedHashes: Uint8Array[] = commitments.map(kzgCommitmentToVersionedHash);
+
+  // Get blobs from execution engine
+  const blobs = await executionEngine.getBlobs(blockCache.fork, versionedHashes);
+
+  // Execution engine was unable to find one or more blobs
+  if (blobs === null) {
+    return false;
+  }
+
+  // Return if we received all data columns while waiting for getBlobs
+  if (hasSampledDataColumns(custodyConfig, blockCache.cachedData.dataColumnsCache)) {
+    return true;
+  }
+
+  let dataColumnSidecars: fulu.DataColumnSidecars;
+  const cellsAndProofs = getCellsAndProofs(blobs);
+  if (blockCache.block) {
+    dataColumnSidecars = getDataColumnSidecarsFromBlock(
+      config,
+      blockCache.block as fulu.SignedBeaconBlock,
+      cellsAndProofs
+    );
+  } else {
+    const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
+    if (!firstSidecar) {
+      throw new Error("blockInputCache missing both block and data column sidecar");
+    }
+    dataColumnSidecars = getDataColumnSidecarsFromColumnSidecar(firstSidecar.dataColumn, cellsAndProofs);
+  }
+
+  // Publish columns if and only if subscribed to them
+  const sampledColumns = custodyConfig.sampledColumns.map((columnIndex) => dataColumnSidecars[columnIndex]);
+
+  emitter.emit(ChainEvent.publishDataColumns, sampledColumns);
+
+  for (const column of sampledColumns) {
+    blockCache.cachedData.dataColumnsCache.set(column.index, {dataColumn: column, dataColumnBytes: null});
+  }
+
+  const allDataColumns = getBlockInputDataColumns(blockCache.cachedData.dataColumnsCache, custodyConfig.sampledColumns);
+  // TODO: Add metrics
+  // metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
+  const blockData: BlockInputDataColumns = {
+    fork: blockCache.cachedData.fork,
+    ...allDataColumns,
+    dataColumnsSource: DataColumnsSource.gossip,
+  };
+  blockCache.cachedData.resolveAvailability(blockData);
+
+  if (blockCache.block !== undefined) {
+    const blockInput = getBlockInput.availableData(config, blockCache.block, BlockSource.gossip, blockData);
+
+    blockCache.resolveBlockInput(blockInput);
+  }
+
+  return true;
 }
 
 export function getEmptyBlockInputCacheEntry(fork: ForkName, globalCacheId: number): BlockInputCacheType {

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -6,13 +6,7 @@ import {pruneSetToMax} from "@lodestar/utils";
 
 import {IExecutionEngine} from "../../execution/index.js";
 import {Metrics} from "../../metrics/index.js";
-import {kzgCommitmentToVersionedHash} from "../../util/blobs.js";
-import {
-  CustodyConfig,
-  getCellsAndProofs,
-  getDataColumnSidecarsFromBlock,
-  getDataColumnSidecarsFromColumnSidecar,
-} from "../../util/dataColumns.js";
+import {CustodyConfig, getDataColumnsFromExecution, hasSampledDataColumns} from "../../util/dataColumns.js";
 import {callInNextEventLoop} from "../../util/eventLoop.js";
 import {
   BlobsSource,
@@ -22,7 +16,6 @@ import {
   BlockSource,
   CachedData,
   CachedDataColumns,
-  DataColumnsCacheMap,
   DataColumnsSource,
   GossipedInputType,
   NullBlockInput,
@@ -30,7 +23,7 @@ import {
   getBlockInputBlobs,
   getBlockInputDataColumns,
 } from "../blocks/types.js";
-import {ChainEvent, ChainEventEmitter} from "../emitter.js";
+import {ChainEventEmitter} from "../emitter.js";
 
 export enum BlockInputAvailabilitySource {
   GOSSIP = "gossip",
@@ -46,7 +39,7 @@ type GossipedBlockInput =
       dataColumnBytes: Uint8Array | null;
     };
 
-type BlockInputCacheType = {
+export type BlockInputCacheType = {
   fork: ForkName;
   block?: SignedBeaconBlock;
   cachedData?: CachedData;
@@ -164,7 +157,13 @@ export class SeenGossipBlockInput {
     if (!this.blockInputCache.has(blockHex)) {
       this.blockInputCache.set(blockHex, blockCache);
       callInNextEventLoop(() => {
-        getDataColumnsFromExecution(config, this.custodyConfig, this.executionEngine, this.emitter, blockCache);
+        getDataColumnsFromExecution(config, this.custodyConfig, this.executionEngine, this.emitter, blockCache)
+          .then((_success) => {
+            // TODO: (@matthewkeil) add metrics collection point here
+          })
+          .catch(() => {
+            // need to handle these errors so they don't percolate as uncaught and crash the node
+          });
       });
     }
 
@@ -361,116 +360,6 @@ export class SeenGossipBlockInput {
     //   blockInputMeta: {pending: GossipedInputType.block, haveBlobs: blobsCache.size, expectedBlobs: null},
     // };
   }
-}
-
-function hasSampledDataColumns(custodyConfig: CustodyConfig, dataColumnCache: DataColumnsCacheMap): boolean {
-  return (
-    dataColumnCache.size >= custodyConfig.sampledColumns.length &&
-    custodyConfig.sampledColumns.reduce((acc, columnIndex) => acc && dataColumnCache.has(columnIndex), true)
-  );
-}
-
-export async function getDataColumnsFromExecution(
-  config: ChainForkConfig,
-  custodyConfig: CustodyConfig,
-  executionEngine: IExecutionEngine,
-  emitter: ChainEventEmitter,
-  blockCache: BlockInputCacheType
-): Promise<boolean> {
-  if (blockCache.fork !== ForkName.fulu) {
-    return false;
-  }
-
-  if (!blockCache.cachedData) {
-    // this condition should never get hit... just a sanity check
-    throw new Error("invalid blockCache");
-  }
-
-  if (blockCache.cachedData.fork !== ForkName.fulu) {
-    return false;
-  }
-
-  // If already have all columns, exit
-  if (hasSampledDataColumns(custodyConfig, blockCache.cachedData.dataColumnsCache)) {
-    return true;
-  }
-
-  let commitments: undefined | Uint8Array[];
-  if (blockCache.block) {
-    const block = blockCache.block as fulu.SignedBeaconBlock;
-    commitments = block.message.body.blobKzgCommitments;
-  } else {
-    const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
-    commitments = firstSidecar?.dataColumn.kzgCommitments;
-  }
-
-  if (!commitments) {
-    throw new Error("blockInputCache missing both block and cachedData");
-  }
-
-  // Return if block has no blobs
-  if (commitments.length === 0) {
-    return true;
-  }
-
-  // Process KZG commitments into versioned hashes
-  const versionedHashes: Uint8Array[] = commitments.map(kzgCommitmentToVersionedHash);
-
-  // Get blobs from execution engine
-  const blobs = await executionEngine.getBlobs(blockCache.fork, versionedHashes);
-
-  // Execution engine was unable to find one or more blobs
-  if (blobs === null) {
-    return false;
-  }
-
-  // Return if we received all data columns while waiting for getBlobs
-  if (hasSampledDataColumns(custodyConfig, blockCache.cachedData.dataColumnsCache)) {
-    return true;
-  }
-
-  let dataColumnSidecars: fulu.DataColumnSidecars;
-  const cellsAndProofs = getCellsAndProofs(blobs);
-  if (blockCache.block) {
-    dataColumnSidecars = getDataColumnSidecarsFromBlock(
-      config,
-      blockCache.block as fulu.SignedBeaconBlock,
-      cellsAndProofs
-    );
-  } else {
-    const firstSidecar = blockCache.cachedData.dataColumnsCache.values().next().value;
-    if (!firstSidecar) {
-      throw new Error("blockInputCache missing both block and data column sidecar");
-    }
-    dataColumnSidecars = getDataColumnSidecarsFromColumnSidecar(firstSidecar.dataColumn, cellsAndProofs);
-  }
-
-  // Publish columns if and only if subscribed to them
-  const sampledColumns = custodyConfig.sampledColumns.map((columnIndex) => dataColumnSidecars[columnIndex]);
-
-  emitter.emit(ChainEvent.publishDataColumns, sampledColumns);
-
-  for (const column of sampledColumns) {
-    blockCache.cachedData.dataColumnsCache.set(column.index, {dataColumn: column, dataColumnBytes: null});
-  }
-
-  const allDataColumns = getBlockInputDataColumns(blockCache.cachedData.dataColumnsCache, custodyConfig.sampledColumns);
-  // TODO: Add metrics
-  // metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
-  const blockData: BlockInputDataColumns = {
-    fork: blockCache.cachedData.fork,
-    ...allDataColumns,
-    dataColumnsSource: DataColumnsSource.gossip,
-  };
-  blockCache.cachedData.resolveAvailability(blockData);
-
-  if (blockCache.block !== undefined) {
-    const blockInput = getBlockInput.availableData(config, blockCache.block, BlockSource.gossip, blockData);
-
-    blockCache.resolveBlockInput(blockInput);
-  }
-
-  return true;
 }
 
 export function getEmptyBlockInputCacheEntry(fork: ForkName, globalCacheId: number): BlockInputCacheType {

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -2,7 +2,7 @@ import {toHexString} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkName, NUMBER_OF_COLUMNS, isForkPostDeneb} from "@lodestar/params";
 import {RootHex, SignedBeaconBlock, deneb, fulu, ssz} from "@lodestar/types";
-import {pruneSetToMax} from "@lodestar/utils";
+import {Logger, pruneSetToMax} from "@lodestar/utils";
 
 import {IExecutionEngine} from "../../execution/index.js";
 import {Metrics} from "../../metrics/index.js";
@@ -84,11 +84,18 @@ export class SeenGossipBlockInput {
   private readonly custodyConfig: CustodyConfig;
   private readonly executionEngine: IExecutionEngine;
   private readonly emitter: ChainEventEmitter;
+  private readonly logger: Logger;
 
-  constructor(custodyConfig: CustodyConfig, executionEngine: IExecutionEngine, emitter: ChainEventEmitter) {
+  constructor(
+    custodyConfig: CustodyConfig,
+    executionEngine: IExecutionEngine,
+    emitter: ChainEventEmitter,
+    logger: Logger
+  ) {
     this.custodyConfig = custodyConfig;
     this.executionEngine = executionEngine;
     this.emitter = emitter;
+    this.logger = logger;
   }
   globalCacheId = 0;
 
@@ -161,8 +168,8 @@ export class SeenGossipBlockInput {
           .then((_success) => {
             // TODO: (@matthewkeil) add metrics collection point here
           })
-          .catch(() => {
-            // need to handle these errors so they don't percolate as uncaught and crash the node
+          .catch((error) => {
+            this.logger.error("Error getting data columns from execution", {blockHex}, error);
           });
       });
     }

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -22,10 +22,11 @@ import {
   getBlockInputDataColumns,
 } from "../../chain/blocks/types.js";
 import {ChainEventEmitter} from "../../chain/emitter.js";
-import {BlockInputAvailabilitySource, getDataColumnsFromExecution} from "../../chain/seenCache/seenGossipBlockInput.js";
+import {BlockInputAvailabilitySource} from "../../chain/seenCache/seenGossipBlockInput.js";
 import {IExecutionEngine} from "../../execution/index.js";
 import {Metrics} from "../../metrics/index.js";
 import {computeInclusionProof, kzgCommitmentToVersionedHash} from "../../util/blobs.js";
+import {getDataColumnsFromExecution} from "../../util/dataColumns.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {INetwork} from "../interface.js";
 import {PartialDownload, matchBlockWithBlobs, matchBlockWithDataColumns} from "./beaconBlocksMaybeBlobsByRange.js";

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -1,4 +1,4 @@
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {toHexString} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkName, ForkSeq} from "@lodestar/params";
 import {signedBlockToSignedHeader} from "@lodestar/state-transition";
@@ -21,7 +21,8 @@ import {
   getBlockInputBlobs,
   getBlockInputDataColumns,
 } from "../../chain/blocks/types.js";
-import {BlockInputAvailabilitySource} from "../../chain/seenCache/seenGossipBlockInput.js";
+import {ChainEventEmitter} from "../../chain/emitter.js";
+import {BlockInputAvailabilitySource, getDataColumnsFromExecution} from "../../chain/seenCache/seenGossipBlockInput.js";
 import {IExecutionEngine} from "../../execution/index.js";
 import {Metrics} from "../../metrics/index.js";
 import {computeInclusionProof, kzgCommitmentToVersionedHash} from "../../util/blobs.js";
@@ -188,6 +189,7 @@ export async function unavailableBeaconBlobsByRoot(
     logger?: Logger;
     metrics?: Metrics | null;
     executionEngine: IExecutionEngine;
+    emitter: ChainEventEmitter;
     engineGetBlobsCache?: Map<RootHex, BlobAndProof | null>;
     blockInputsRetryTrackerCache?: Set<RootHex>;
   }
@@ -235,6 +237,8 @@ export async function unavailableBeaconBlobsByRoot(
     cachedData,
     {
       metrics: opts.metrics,
+      executionEngine: opts.executionEngine,
+      emitter: opts.emitter,
       logger: opts.logger,
     }
   );
@@ -455,6 +459,8 @@ export async function unavailableBeaconBlobsByRootPostFulu(
   cachedData: NullBlockInput["cachedData"],
   opts: {
     metrics?: Metrics | null;
+    executionEngine: IExecutionEngine;
+    emitter: ChainEventEmitter;
     logger?: Logger;
   }
 ): Promise<BlockInput> {
@@ -510,8 +516,8 @@ export async function unavailableBeaconBlobsByRootPostFulu(
   const slot = block.message.slot;
   const blockRoot = config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block.message);
 
-  const blobKzgCommitmentsLen = (block.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length;
-  if (blobKzgCommitmentsLen === 0) {
+  const blobKzgCommitments = (block.message.body as deneb.BeaconBlockBody).blobKzgCommitments;
+  if (blobKzgCommitments.length === 0) {
     const blockData = {
       fork: cachedData.fork,
       dataColumns: [],
@@ -532,47 +538,73 @@ export async function unavailableBeaconBlobsByRootPostFulu(
     return acc;
   }, [] as number[]);
 
-  const peerColumns = network.getConnectedPeerCustody(peerId);
+  let resolveBlockInput: ((block: BlockInput) => void) | null = null;
+  const blockInputPromise = new Promise<BlockInput>((resolveCB) => {
+    resolveBlockInput = resolveCB;
+  });
+  if (resolveBlockInput === null) {
+    throw Error("Promise Constructor was not executed immediately");
+  }
 
-  // get match
-  const columns = peerColumns.reduce((acc, elem) => {
-    if (neededColumns.includes(elem)) {
-      acc.push(elem);
+  const gotColumnsFromExecution = await getDataColumnsFromExecution(
+    config,
+    network.custodyConfig,
+    opts.executionEngine,
+    opts.emitter,
+    {
+      fork: config.getForkName(block.message.slot),
+      block: block,
+      cachedData: cachedData,
+      blockInputPromise,
+      resolveBlockInput,
     }
-    return acc;
-  }, [] as number[]);
+  );
 
-  // this peer can't help fetching columns for this block
-  if (unavailableBlockInput.block !== null && columns.length === 0 && neededColumns.length > 0) {
-    return unavailableBlockInput;
-  }
+  if (!gotColumnsFromExecution) {
+    const peerColumns = network.getConnectedPeerCustody(peerId);
 
-  for (const columnIndex of columns) {
-    dataColumnIdentifiers.push({blockRoot, index: columnIndex});
-  }
+    // get match
+    const columns = peerColumns.reduce((acc, elem) => {
+      if (neededColumns.includes(elem)) {
+        acc.push(elem);
+      }
+      return acc;
+    }, [] as number[]);
 
-  let allDataColumnSidecars: fulu.DataColumnSidecar[];
-  if (dataColumnIdentifiers.length > 0) {
-    allDataColumnSidecars = await network.sendDataColumnSidecarsByRoot(peerId, dataColumnIdentifiers);
-  } else {
-    allDataColumnSidecars = [];
-  }
+    // this peer can't help fetching columns for this block
+    if (unavailableBlockInput.block !== null && columns.length === 0 && neededColumns.length > 0) {
+      return unavailableBlockInput;
+    }
 
-  const logCtx = {
-    slot: block.message.slot,
-    requestedColumns: columns.join(","),
-    respondedColumns: allDataColumnSidecars.map((dcs) => dcs.index).join(","),
-    peerClient,
-  };
+    for (const columnIndex of columns) {
+      dataColumnIdentifiers.push({blockRoot, index: columnIndex});
+    }
 
-  // the same to matchBlockWithDataColumns() without expecting requested data columns = responded data columns
-  // because at gossip time peer may not have enough column to return
-  for (const dataColumnSidecar of allDataColumnSidecars) {
-    dataColumnsCache.set(dataColumnSidecar.index, {
-      dataColumn: dataColumnSidecar,
-      // TODO: req/resp should return bytes here
-      dataColumnBytes: null,
-    });
+    let allDataColumnSidecars: fulu.DataColumnSidecar[];
+    if (dataColumnIdentifiers.length > 0) {
+      allDataColumnSidecars = await network.sendDataColumnSidecarsByRoot(peerId, dataColumnIdentifiers);
+    } else {
+      allDataColumnSidecars = [];
+    }
+
+    const logCtx = {
+      slot: block.message.slot,
+      requestedColumns: columns.join(","),
+      respondedColumns: allDataColumnSidecars.map((dcs) => dcs.index).join(","),
+      peerClient,
+    };
+
+    opts.logger?.verbose("unavailableBeaconBlobsByRootPostFulu: Requested data columns from peer", logCtx);
+
+    // the same to matchBlockWithDataColumns() without expecting requested data columns = responded data columns
+    // because at gossip time peer may not have enough column to return
+    for (const dataColumnSidecar of allDataColumnSidecars) {
+      dataColumnsCache.set(dataColumnSidecar.index, {
+        dataColumn: dataColumnSidecar,
+        // TODO: req/resp should return bytes here
+        dataColumnBytes: null,
+      });
+    }
   }
 
   // reevaluate needeColumns and resolve availability if possible
@@ -582,6 +614,12 @@ export async function unavailableBeaconBlobsByRootPostFulu(
     }
     return acc;
   }, [] as number[]);
+
+  const logCtx = {
+    slot: block.message.slot,
+    neededColumns: neededColumns.join(","),
+    sampledColumns: sampledColumns.join(","),
+  };
 
   if (neededColumns.length === 0) {
     const {dataColumns, dataColumnsBytes} = getBlockInputDataColumns(
@@ -603,7 +641,6 @@ export async function unavailableBeaconBlobsByRootPostFulu(
     );
     return getBlockInput.availableData(config, block, BlockSource.byRoot, blockData);
   }
-
   opts.logger?.verbose("unavailableBeaconBlobsByRootPostFulu: Still missing data columns for block", logCtx);
   return getBlockInput.dataPromise(config, block, BlockSource.byRoot, cachedData);
 }

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -717,6 +717,7 @@ export class UnknownBlockSync {
             metrics: this.metrics,
             logger: this.logger,
             executionEngine: this.chain.executionEngine,
+            emitter: this.chain.emitter,
             blockInputsRetryTrackerCache: this.blockInputsRetryTrackerCache,
             engineGetBlobsCache: this.engineGetBlobsCache,
           }

--- a/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
+++ b/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
@@ -8,24 +8,36 @@ import {
   isForkPostDeneb,
 } from "@lodestar/params";
 import {signedBlockToSignedHeader} from "@lodestar/state-transition";
-import {SignedBeaconBlock, deneb, ssz} from "@lodestar/types";
+import {SignedBeaconBlock, Uint8, deneb, ssz} from "@lodestar/types";
+import {BlobAndProofV2} from "@lodestar/types/lib/fulu/types.js";
 import {beforeAll, describe, expect, it, vi} from "vitest";
 import {
   BlobsSource,
   BlockInput,
   BlockInputAvailableData,
   BlockInputBlobs,
+  BlockInputDataColumns,
   BlockInputType,
   BlockSource,
   CachedData,
+  DataColumnsSource,
   getBlockInput,
 } from "../../../src/chain/blocks/types.js";
+import {ChainEventEmitter} from "../../../src/chain/emitter.js";
+import {getEmptyBlockInputCacheEntry} from "../../../src/chain/seenCache/seenGossipBlockInput.js";
 import {IExecutionEngine} from "../../../src/execution/index.js";
 import {INetwork} from "../../../src/network/interface.js";
 import {unavailableBeaconBlobsByRoot} from "../../../src/network/reqresp/index.js";
-import {computeInclusionProof, kzgCommitmentToVersionedHash} from "../../../src/util/blobs.js";
+import {computeNodeId} from "../../../src/network/subnets/index.js";
+import {
+  computeInclusionProof,
+  computeKzgCommitmentsInclusionProof,
+  kzgCommitmentToVersionedHash,
+} from "../../../src/util/blobs.js";
+import {CustodyConfig, getCellsAndProofs, getDataColumnSidecars} from "../../../src/util/dataColumns.js";
 import {ckzg} from "../../../src/util/kzg.js";
 import {initCKZG, loadEthereumTrustedSetup} from "../../../src/util/kzg.js";
+import {getValidPeerId} from "../../utils/peer.js";
 
 describe("unavailableBeaconBlobsByRoot", () => {
   beforeAll(async () => {
@@ -33,204 +45,251 @@ describe("unavailableBeaconBlobsByRoot", () => {
     loadEthereumTrustedSetup();
   });
 
-  /* eslint-disable @typescript-eslint/naming-convention */
-  const chainConfig = createChainForkConfig({
-    ...defaultChainConfig,
-    ALTAIR_FORK_EPOCH: 0,
-    BELLATRIX_FORK_EPOCH: 0,
-    CAPELLA_FORK_EPOCH: 0,
-    DENEB_FORK_EPOCH: 0,
-  });
-  const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
-  const config = createBeaconConfig(chainConfig, genesisValidatorsRoot);
-
-  const executionEngine = {
-    getBlobs: vi.fn(),
-  };
-
-  const network = {
-    sendBeaconBlocksByRoot: vi.fn(),
-    sendBlobSidecarsByRoot: vi.fn(),
-  };
-
-  const peerId = "mockPeerId";
-  const engineGetBlobsCache = new Map();
-
-  it("should successfully resolve all blobs from engine and network", async () => {
-    // Simulate a block 1 with 5 blobs
-    const signedBlock = ssz.deneb.SignedBeaconBlock.defaultValue();
-    signedBlock.message.slot = 1;
-    const blobscommitmentsandproofs = generateBlobs(5);
-    signedBlock.message.body.blobKzgCommitments.push(...blobscommitmentsandproofs.kzgCommitments);
-    const blockheader = signedBlockToSignedHeader(config, signedBlock);
-
-    const unavailableBlockInput = {
-      block: signedBlock,
-      source: BlockSource.gossip,
-      blockBytes: null,
-      type: BlockInputType.dataPromise,
-      cachedData: getEmptyBlockInputCacheEntry(ForkName.deneb).cachedData,
-    } as BlockInput;
-
-    // total of 5 blobs
-    //  blob 0. not in cache & to resolved by getBlobs
-    //  blob 1. not in cache & to resolved by getBlobs
-    //  blob 2. to be found in engineGetBlobsCache
-    //  blob 3. null cached earlier so should directly go to network query and skip engine query
-    //  blob 4. to hit getBlobs first with null response and then go to the network query
-    //
-    //  engineGetBlobsCache caches 2 fully, and null for 3
-    //  getBlobs should see 0,1,4 and return first two non null and last null
-    //  network should see 3,4
-
-    engineGetBlobsCache.set(toHexString(blobscommitmentsandproofs.blobVersionedHashes[2]), {
-      blob: blobscommitmentsandproofs.blobs[2],
-      proof: blobscommitmentsandproofs.kzgProofs[2],
+  describe("blobs", () => {
+    const chainConfig = createChainForkConfig({
+      ...defaultChainConfig,
+      ALTAIR_FORK_EPOCH: 0,
+      BELLATRIX_FORK_EPOCH: 0,
+      CAPELLA_FORK_EPOCH: 0,
+      DENEB_FORK_EPOCH: 0,
     });
-    engineGetBlobsCache.set(toHexString(blobscommitmentsandproofs.blobVersionedHashes[3]), null);
+    const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
+    const config = createBeaconConfig(chainConfig, genesisValidatorsRoot);
 
-    // Mock execution engine to return 2 blobs
-    executionEngine.getBlobs.mockResolvedValueOnce([
-      {
-        blob: blobscommitmentsandproofs.blobs[0],
-        proof: blobscommitmentsandproofs.kzgProofs[0],
-      },
-      {
-        blob: blobscommitmentsandproofs.blobs[1],
-        proof: blobscommitmentsandproofs.kzgProofs[1],
-      },
-      null,
-    ]);
-
-    // Mock network to return 2 blobs
-    network.sendBlobSidecarsByRoot.mockResolvedValueOnce([
-      {
-        index: 3,
-        blob: blobscommitmentsandproofs.blobs[3],
-        kzgCommitment: blobscommitmentsandproofs.kzgCommitments[3],
-        kzgProof: blobscommitmentsandproofs.kzgProofs[3],
-        signedBlockHeader: blockheader,
-        kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 3),
-      },
-      {
-        index: 4,
-        blob: blobscommitmentsandproofs.blobs[4],
-        kzgCommitment: blobscommitmentsandproofs.kzgCommitments[4],
-        kzgProof: blobscommitmentsandproofs.kzgProofs[4],
-        signedBlockHeader: blockheader,
-        kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 4),
-      },
-    ]);
-
-    const result = await unavailableBeaconBlobsByRoot(
-      config,
-      network as unknown as INetwork,
-      peerId,
-      "peerClient",
-      unavailableBlockInput,
-      {
-        executionEngine: executionEngine as unknown as IExecutionEngine,
-        engineGetBlobsCache,
-      }
-    );
-
-    // Check if all blobs are aggregated
-    const allBlobs = [
-      {
-        index: 0,
-        blob: blobscommitmentsandproofs.blobs[0],
-        kzgCommitment: blobscommitmentsandproofs.kzgCommitments[0],
-        kzgProof: blobscommitmentsandproofs.kzgProofs[0],
-        signedBlockHeader: blockheader,
-        kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 0),
-      },
-      {
-        index: 1,
-        blob: blobscommitmentsandproofs.blobs[1],
-        kzgCommitment: blobscommitmentsandproofs.kzgCommitments[1],
-        kzgProof: blobscommitmentsandproofs.kzgProofs[1],
-        signedBlockHeader: blockheader,
-        kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 1),
-      },
-      {
-        index: 2,
-        blob: blobscommitmentsandproofs.blobs[2],
-        kzgCommitment: blobscommitmentsandproofs.kzgCommitments[2],
-        kzgProof: blobscommitmentsandproofs.kzgProofs[2],
-        signedBlockHeader: blockheader,
-        kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 2),
-      },
-      {
-        index: 3,
-        blob: blobscommitmentsandproofs.blobs[3],
-        kzgCommitment: blobscommitmentsandproofs.kzgCommitments[3],
-        kzgProof: blobscommitmentsandproofs.kzgProofs[3],
-        signedBlockHeader: blockheader,
-        kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 3),
-      },
-      {
-        index: 4,
-        blob: blobscommitmentsandproofs.blobs[4],
-        kzgCommitment: blobscommitmentsandproofs.kzgCommitments[4],
-        kzgProof: blobscommitmentsandproofs.kzgProofs[4],
-        signedBlockHeader: blockheader,
-        kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 4),
-      },
-    ];
-
-    const blockData: BlockInputAvailableData = {
-      fork: ForkName.deneb,
-      blobs: allBlobs,
-      blobsSource: BlobsSource.byRoot,
+    const executionEngine = {
+      getBlobs: vi.fn(),
     };
-    const resolvedBlobs = getBlockInput.availableData(config, signedBlock, BlockSource.byRoot, blockData);
 
-    const engineReqIdentifiers = [...blobscommitmentsandproofs.blobVersionedHashes];
-    // versionedHashes: 1,2,4
-    engineReqIdentifiers.splice(2, 2);
-    expect(result).toBeDefined();
-    expect(executionEngine.getBlobs).toHaveBeenCalledWith("deneb", engineReqIdentifiers);
-    expect(result).toEqual(resolvedBlobs);
+    const network = {
+      sendBeaconBlocksByRoot: vi.fn(),
+      sendBlobSidecarsByRoot: vi.fn(),
+    };
+
+    const peerId = "mockPeerId";
+    const engineGetBlobsCache = new Map();
+
+    it("should successfully resolve all blobs from engine and network", async () => {
+      // Simulate a block 1 with 5 blobs
+      const signedBlock = ssz.deneb.SignedBeaconBlock.defaultValue();
+      signedBlock.message.slot = 1;
+      const blobscommitmentsandproofs = generateBlobs(5);
+      signedBlock.message.body.blobKzgCommitments.push(...blobscommitmentsandproofs.kzgCommitments);
+      const blockheader = signedBlockToSignedHeader(config, signedBlock);
+
+      const unavailableBlockInput = {
+        block: signedBlock,
+        source: BlockSource.gossip,
+        blockBytes: null,
+        type: BlockInputType.dataPromise,
+        cachedData: getEmptyBlockInputCacheEntry(ForkName.deneb, 1).cachedData,
+      } as BlockInput;
+
+      // total of 5 blobs
+      //  blob 0. not in cache & to resolved by getBlobs
+      //  blob 1. not in cache & to resolved by getBlobs
+      //  blob 2. to be found in engineGetBlobsCache
+      //  blob 3. null cached earlier so should directly go to network query and skip engine query
+      //  blob 4. to hit getBlobs first with null response and then go to the network query
+      //
+      //  engineGetBlobsCache caches 2 fully, and null for 3
+      //  getBlobs should see 0,1,4 and return first two non null and last null
+      //  network should see 3,4
+
+      engineGetBlobsCache.set(toHexString(blobscommitmentsandproofs.blobVersionedHashes[2]), {
+        blob: blobscommitmentsandproofs.blobs[2],
+        proof: blobscommitmentsandproofs.kzgProofs[2],
+      });
+      engineGetBlobsCache.set(toHexString(blobscommitmentsandproofs.blobVersionedHashes[3]), null);
+
+      // Mock execution engine to return 2 blobs
+      executionEngine.getBlobs.mockResolvedValueOnce([
+        {
+          blob: blobscommitmentsandproofs.blobs[0],
+          proof: blobscommitmentsandproofs.kzgProofs[0],
+        },
+        {
+          blob: blobscommitmentsandproofs.blobs[1],
+          proof: blobscommitmentsandproofs.kzgProofs[1],
+        },
+        null,
+      ]);
+
+      // Mock network to return 2 blobs
+      network.sendBlobSidecarsByRoot.mockResolvedValueOnce([
+        {
+          index: 3,
+          blob: blobscommitmentsandproofs.blobs[3],
+          kzgCommitment: blobscommitmentsandproofs.kzgCommitments[3],
+          kzgProof: blobscommitmentsandproofs.kzgProofs[3],
+          signedBlockHeader: blockheader,
+          kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 3),
+        },
+        {
+          index: 4,
+          blob: blobscommitmentsandproofs.blobs[4],
+          kzgCommitment: blobscommitmentsandproofs.kzgCommitments[4],
+          kzgProof: blobscommitmentsandproofs.kzgProofs[4],
+          signedBlockHeader: blockheader,
+          kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 4),
+        },
+      ]);
+
+      const result = await unavailableBeaconBlobsByRoot(
+        config,
+        network as unknown as INetwork,
+        peerId,
+        "peerClient",
+        unavailableBlockInput,
+        {
+          executionEngine: executionEngine as unknown as IExecutionEngine,
+          emitter: new ChainEventEmitter(),
+          engineGetBlobsCache,
+        }
+      );
+
+      // Check if all blobs are aggregated
+      const allBlobs = [
+        {
+          index: 0,
+          blob: blobscommitmentsandproofs.blobs[0],
+          kzgCommitment: blobscommitmentsandproofs.kzgCommitments[0],
+          kzgProof: blobscommitmentsandproofs.kzgProofs[0],
+          signedBlockHeader: blockheader,
+          kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 0),
+        },
+        {
+          index: 1,
+          blob: blobscommitmentsandproofs.blobs[1],
+          kzgCommitment: blobscommitmentsandproofs.kzgCommitments[1],
+          kzgProof: blobscommitmentsandproofs.kzgProofs[1],
+          signedBlockHeader: blockheader,
+          kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 1),
+        },
+        {
+          index: 2,
+          blob: blobscommitmentsandproofs.blobs[2],
+          kzgCommitment: blobscommitmentsandproofs.kzgCommitments[2],
+          kzgProof: blobscommitmentsandproofs.kzgProofs[2],
+          signedBlockHeader: blockheader,
+          kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 2),
+        },
+        {
+          index: 3,
+          blob: blobscommitmentsandproofs.blobs[3],
+          kzgCommitment: blobscommitmentsandproofs.kzgCommitments[3],
+          kzgProof: blobscommitmentsandproofs.kzgProofs[3],
+          signedBlockHeader: blockheader,
+          kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 3),
+        },
+        {
+          index: 4,
+          blob: blobscommitmentsandproofs.blobs[4],
+          kzgCommitment: blobscommitmentsandproofs.kzgCommitments[4],
+          kzgProof: blobscommitmentsandproofs.kzgProofs[4],
+          signedBlockHeader: blockheader,
+          kzgCommitmentInclusionProof: computeInclusionProof(ForkName.deneb, signedBlock.message.body, 4),
+        },
+      ];
+
+      const blockData: BlockInputAvailableData = {
+        fork: ForkName.deneb,
+        blobs: allBlobs,
+        blobsSource: BlobsSource.byRoot,
+      };
+      const resolvedBlobs = getBlockInput.availableData(config, signedBlock, BlockSource.byRoot, blockData);
+
+      const engineReqIdentifiers = [...blobscommitmentsandproofs.blobVersionedHashes];
+      // versionedHashes: 1,2,4
+      engineReqIdentifiers.splice(2, 2);
+      expect(result).toBeDefined();
+      expect(executionEngine.getBlobs).toHaveBeenCalledWith("deneb", engineReqIdentifiers);
+      expect(result).toEqual(resolvedBlobs);
+    });
+  });
+
+  describe("data columns", () => {
+    const chainConfig = createChainForkConfig({
+      ...defaultChainConfig,
+      ALTAIR_FORK_EPOCH: 0,
+      BELLATRIX_FORK_EPOCH: 0,
+      CAPELLA_FORK_EPOCH: 0,
+      DENEB_FORK_EPOCH: 0,
+      ELECTRA_FORK_EPOCH: 0,
+      FULU_FORK_EPOCH: 0,
+    });
+    const genesisValidatorsRoot = Buffer.alloc(32, 0xaa);
+    const config = createBeaconConfig(chainConfig, genesisValidatorsRoot);
+
+    const executionEngine = {
+      getBlobs: vi.fn(),
+    };
+
+    const network = {
+      sendBeaconBlocksByRoot: vi.fn(),
+      sendBlobSidecarsByRoot: vi.fn(),
+      custodyConfig: new CustodyConfig(computeNodeId(getValidPeerId()), config),
+    };
+
+    const peerId = "mockPeerId";
+    const engineGetBlobsCache = new Map();
+
+    it("should successfully resolve all data columns from engine", async () => {
+      // Simulate a block 1 with 3 blobs
+      const signedBlock = ssz.fulu.SignedBeaconBlock.defaultValue();
+      signedBlock.message.slot = 1;
+      const blobscommitmentsandproofs = generateBlobsWithCellProofs(3);
+      signedBlock.message.body.blobKzgCommitments.push(...blobscommitmentsandproofs.map((b) => b.kzgCommitment));
+      const blockheader = signedBlockToSignedHeader(config, signedBlock);
+
+      const unavailableBlockInput: BlockInput = {
+        block: signedBlock,
+        source: BlockSource.gossip,
+        type: BlockInputType.dataPromise,
+        cachedData: getEmptyBlockInputCacheEntry(ForkName.fulu, 1).cachedData as CachedData,
+      };
+
+      const blobAndProof: BlobAndProofV2[] = blobscommitmentsandproofs.map((b) => ({
+        blob: b.blob,
+        proofs: b.cellsAndProofs[1],
+      }));
+
+      // Mock execution engine to return all blobs
+      executionEngine.getBlobs.mockImplementationOnce(
+        (): Promise<BlobAndProofV2[] | null> => Promise.resolve(blobAndProof)
+      );
+
+      const result = await unavailableBeaconBlobsByRoot(
+        config,
+        network as unknown as INetwork,
+        peerId,
+        "peerClient",
+        unavailableBlockInput,
+        {
+          executionEngine: executionEngine as unknown as IExecutionEngine,
+          emitter: new ChainEventEmitter(),
+          engineGetBlobsCache,
+        }
+      );
+
+      const sampledSidecars = getDataColumnSidecars(
+        blockheader,
+        blobscommitmentsandproofs.map((b) => b.kzgCommitment),
+        computeKzgCommitmentsInclusionProof(ForkName.fulu, signedBlock.message.body),
+        blobscommitmentsandproofs.map((b) => b.cellsAndProofs)
+      ).filter((s) => network.custodyConfig.sampledColumns.includes(s.index));
+
+      expect(executionEngine.getBlobs).toHaveBeenCalledWith(
+        ForkName.fulu,
+        blobscommitmentsandproofs.map((b) => kzgCommitmentToVersionedHash(b.kzgCommitment))
+      );
+      expect(result.type).toEqual(BlockInputType.availableData);
+      if (result.type !== BlockInputType.availableData) throw new Error("Should not get here");
+      expect(result.blockData.fork).toEqual(ForkName.fulu);
+      if (result.blockData.fork !== ForkName.fulu) throw new Error("Should not get here");
+      expect(result.blockData.dataColumns).toEqual(sampledSidecars);
+    });
   });
 });
-
-type BlockInputCacheType = {
-  fork: ForkName;
-  block?: SignedBeaconBlock;
-  cachedData?: CachedData;
-  // block promise and its callback cached for delayed resolution
-  blockInputPromise: Promise<BlockInput>;
-  resolveBlockInput: (blockInput: BlockInput) => void;
-};
-
-function getEmptyBlockInputCacheEntry(fork: ForkName): BlockInputCacheType {
-  // Capture both the promise and its callbacks for blockInput and final availability
-  // It is not spec'ed but in tests in Firefox and NodeJS the promise constructor is run immediately
-  let resolveBlockInput: ((block: BlockInput) => void) | null = null;
-  const blockInputPromise = new Promise<BlockInput>((resolveCB) => {
-    resolveBlockInput = resolveCB;
-  });
-  if (resolveBlockInput === null) {
-    throw Error("Promise Constructor was not executed immediately");
-  }
-
-  if (fork === ForkName.deneb || fork === ForkName.electra) {
-    let resolveAvailability: ((blobs: BlockInputBlobs) => void) | null = null;
-    const availabilityPromise = new Promise<BlockInputBlobs>((resolveCB) => {
-      resolveAvailability = resolveCB;
-    });
-
-    if (resolveAvailability === null) {
-      throw Error("Promise Constructor was not executed immediately");
-    }
-
-    const blobsCache = new Map();
-    const cachedData: CachedData = {fork, blobsCache, availabilityPromise, resolveAvailability, cacheId: 18};
-    return {fork, blockInputPromise, resolveBlockInput, cachedData};
-  }
-
-  return {fork, blockInputPromise, resolveBlockInput};
-}
 
 function generateBlobs(count: number): {
   blobs: Uint8Array[];
@@ -249,6 +308,18 @@ function generateBlobs(count: number): {
     blobVersionedHashes: versionedHash.map((hash) => hash),
     kzgProofs,
   };
+}
+
+function generateBlobsWithCellProofs(
+  count: number
+): {blob: Uint8Array; cellsAndProofs: [Uint8Array[], Uint8Array[]]; kzgCommitment: Uint8Array}[] {
+  const blobs = Array.from({length: count}, (_, index) => generateRandomBlob(index));
+
+  return blobs.map((blob) => ({
+    blob,
+    cellsAndProofs: ckzg.computeCellsAndKzgProofs(blob),
+    kzgCommitment: ckzg.blobToKzgCommitment(blob),
+  }));
 }
 
 function generateRandomBlob(index: number): deneb.Blob {


### PR DESCRIPTION
**Motivation**

We're currently fetching blobs from the EL as soon as the first block/data column is received, per spec. However, we also should fetch blobs in `unavailableBeaconBlobsByRoot`, like we do in deneb/electra (this gets called about 2.5s into the slot). I added that in this PR, as well as a test.

Note that getBlobsV2 will be called prior to every peer reqresp attempted -- as far as I can tell, the behavior is the same behavior with getBlobsV1.

**Description**

* Made `reconstructColumns` a generalized function: `getDataColumnsFromExecution`
* Added a test that mocks blobs returned from the EL