### PR TITLE
feat: add BLOB_SCHEDULE for blob parameter forks

### DIFF
--- a/packages/beacon-node/src/chain/validation/blobSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -5,7 +5,11 @@ import {
   KZG_COMMITMENT_SUBTREE_INDEX0,
   isForkPostElectra,
 } from "@lodestar/params";
-import {computeStartSlotAtEpoch, getBlockHeaderProposerSignatureSet} from "@lodestar/state-transition";
+import {
+  computeEpochAtSlot,
+  computeStartSlotAtEpoch,
+  getBlockHeaderProposerSignatureSet,
+} from "@lodestar/state-transition";
 import {BlobIndex, Root, Slot, SubnetID, deneb, ssz} from "@lodestar/types";
 import {toRootHex, verifyMerkleBranch} from "@lodestar/utils";
 
@@ -25,7 +29,7 @@ export async function validateGossipBlobSidecar(
   const blobSlot = blobSidecar.signedBlockHeader.message.slot;
 
   // [REJECT] The sidecar's index is consistent with `MAX_BLOBS_PER_BLOCK` -- i.e. `blob_sidecar.index < MAX_BLOBS_PER_BLOCK`.
-  const maxBlobsPerBlock = chain.config.getMaxBlobsPerBlock(fork);
+  const maxBlobsPerBlock = chain.config.getMaxBlobsPerBlock(computeEpochAtSlot(blobSlot));
   if (blobSidecar.index >= maxBlobsPerBlock) {
     throw new BlobSidecarGossipError(GossipAction.REJECT, {
       code: BlobSidecarErrorCode.INDEX_TOO_LARGE,

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -1,6 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkName, isForkPostDeneb} from "@lodestar/params";
 import {
+  computeEpochAtSlot,
   computeStartSlotAtEpoch,
   computeTimeAtSlot,
   getBlockProposerSignatureSet,
@@ -113,7 +114,7 @@ export async function validateGossipBlock(
   // [REJECT] The length of KZG commitments is less than or equal to the limitation defined in Consensus Layer -- i.e. validate that len(body.signed_beacon_block.message.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
   if (isForkPostDeneb(fork)) {
     const blobKzgCommitmentsLen = (block as deneb.BeaconBlock).body.blobKzgCommitments.length;
-    const maxBlobsPerBlock = chain.config.getMaxBlobsPerBlock(fork);
+    const maxBlobsPerBlock = config.getMaxBlobsPerBlock(computeEpochAtSlot(blockSlot));
     if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
       throw new BlockGossipError(GossipAction.REJECT, {
         code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS,

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -6,7 +6,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {LoggerNode} from "@lodestar/logger/node";
 import {DATA_COLUMN_SIDECAR_SUBNET_COUNT, ForkSeq, NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
-import {computeStartSlotAtEpoch, computeTimeAtSlot} from "@lodestar/state-transition";
+import {computeEpochAtSlot, computeStartSlotAtEpoch, computeTimeAtSlot} from "@lodestar/state-transition";
 import {
   AttesterSlashing,
   ColumnIndex,
@@ -553,11 +553,11 @@ export class Network implements INetwork {
     peerId: PeerIdStr,
     request: deneb.BlobSidecarsByRangeRequest
   ): Promise<deneb.BlobSidecar[]> {
-    const fork = this.config.getForkName(request.startSlot);
+    const epoch = computeEpochAtSlot(request.startSlot);
     return collectMaxResponseTyped(
       this.sendReqRespRequest(peerId, ReqRespMethod.BlobSidecarsByRange, [Version.V1], request),
       // request's count represent the slots, so the actual max count received could be slots * blobs per slot
-      request.count * this.config.getMaxBlobsPerBlock(fork),
+      request.count * this.config.getMaxBlobsPerBlock(epoch),
       responseSszTypeByMethod[ReqRespMethod.BlobSidecarsByRange]
     );
   }

--- a/packages/beacon-node/test/unit/chain/validation/block.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/block.test.ts
@@ -1,3 +1,4 @@
+import {createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
 import {ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName, ForkPostDeneb} from "@lodestar/params";
@@ -194,6 +195,14 @@ describe("gossip block validation", () => {
   });
 
   it("deneb - TOO_MANY_KZG_COMMITMENTS", async () => {
+    const cfg = createChainForkConfig({
+      ...defaultChainConfig,
+      ALTAIR_FORK_EPOCH: 0,
+      BELLATRIX_FORK_EPOCH: 0,
+      CAPELLA_FORK_EPOCH: 0,
+      DENEB_FORK_EPOCH: 0,
+    });
+
     // Return not known for proposed block
     forkChoice.getBlockHex.mockReturnValueOnce(null);
     // Returned parent block is latter than proposed block
@@ -209,12 +218,20 @@ describe("gossip block validation", () => {
     (job as SignedBeaconBlock<ForkPostDeneb>).message.body.blobKzgCommitments.push(new Uint8Array([0]));
 
     await expectRejectedWithLodestarError(
-      validateGossipBlock(config, chain, job, ForkName.deneb),
+      validateGossipBlock(cfg, chain, job, ForkName.deneb),
       BlockErrorCode.TOO_MANY_KZG_COMMITMENTS
     );
   });
 
   it("deneb - valid", async () => {
+    const cfg = createChainForkConfig({
+      ...defaultChainConfig,
+      ALTAIR_FORK_EPOCH: 0,
+      BELLATRIX_FORK_EPOCH: 0,
+      CAPELLA_FORK_EPOCH: 0,
+      DENEB_FORK_EPOCH: 0,
+    });
+
     // Return not known for proposed block
     forkChoice.getBlockHex.mockReturnValueOnce(null);
     // Returned parent block is latter than proposed block
@@ -228,6 +245,6 @@ describe("gossip block validation", () => {
     vi.spyOn(state.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
     // Keep number of kzg commitments as is so it stays within the limit
 
-    await validateGossipBlock(config, chain, job, ForkName.deneb);
+    await validateGossipBlock(cfg, chain, job, ForkName.deneb);
   });
 });

--- a/packages/config/src/chainConfig/configs/mainnet.ts
+++ b/packages/config/src/chainConfig/configs/mainnet.ts
@@ -128,5 +128,26 @@ export const chainConfig: ChainConfig = {
   NODE_CUSTODY_REQUIREMENT: 1,
   VALIDATOR_CUSTODY_REQUIREMENT: 8,
   BALANCE_PER_ADDITIONAL_CUSTODY_GROUP: 32000000000,
-  MAX_BLOBS_PER_BLOCK_FULU: 12,
+  BLOB_SCHEDULE: [
+    {
+      EPOCH: 269568, // Deneb
+      MAX_BLOBS_PER_BLOCK: 6,
+    },
+    {
+      EPOCH: 364032, // Electra
+      MAX_BLOBS_PER_BLOCK: 9,
+    },
+    {
+      EPOCH: Number.MAX_SAFE_INTEGER, // BP01
+      MAX_BLOBS_PER_BLOCK: 18,
+    },
+    {
+      EPOCH: Number.MAX_SAFE_INTEGER, // BP02
+      MAX_BLOBS_PER_BLOCK: 36,
+    },
+    {
+      EPOCH: Number.MAX_SAFE_INTEGER, // BP03
+      MAX_BLOBS_PER_BLOCK: 72,
+    },
+  ],
 };

--- a/packages/config/src/chainConfig/configs/minimal.ts
+++ b/packages/config/src/chainConfig/configs/minimal.ts
@@ -124,5 +124,18 @@ export const chainConfig: ChainConfig = {
   NODE_CUSTODY_REQUIREMENT: 1,
   VALIDATOR_CUSTODY_REQUIREMENT: 8,
   BALANCE_PER_ADDITIONAL_CUSTODY_GROUP: 32000000000,
-  MAX_BLOBS_PER_BLOCK_FULU: 12,
+  BLOB_SCHEDULE: [
+    {
+      EPOCH: Infinity,
+      MAX_BLOBS_PER_BLOCK: 12, // BP01
+    },
+    {
+      EPOCH: Infinity,
+      MAX_BLOBS_PER_BLOCK: 15, // BP02
+    },
+    {
+      EPOCH: Infinity,
+      MAX_BLOBS_PER_BLOCK: 18, // BP03
+    },
+  ],
 };

--- a/packages/config/src/chainConfig/json.ts
+++ b/packages/config/src/chainConfig/json.ts
@@ -45,6 +45,7 @@ export function toSpecValueTypeName(value: SpecValue): SpecValueTypeName {
   if (typeof value === "number") return "number";
   if (typeof value === "bigint") return "bigint";
   if (typeof value === "string") return "string";
+  if (Array.isArray(value)) return "blobschedule";
   throw Error(`Unknown value type ${value}`);
 }
 
@@ -76,6 +77,20 @@ export function serializeSpecValue(value: SpecValue, typeName: SpecValueTypeName
         throw Error(`Invalid value ${value.toString()} expected string`);
       }
       return value;
+
+    case "blobschedule":
+      if (!Array.isArray(value)) {
+        throw Error(`Invalid value ${value.toString()} expected Array`);
+      }
+      return JSON.stringify(
+        value.map((obj) => {
+          const result: Record<string, string> = {};
+          for (const [key, val] of Object.entries(obj)) {
+            result[key] = serializeSpecValue(val, toSpecValueTypeName(val));
+          }
+          return result;
+        })
+      );
   }
 }
 
@@ -99,5 +114,33 @@ export function deserializeSpecValue(valueStr: unknown, typeName: SpecValueTypeN
 
     case "string":
       return valueStr;
+
+    case "blobschedule": {
+      try {
+        const parsedJson = JSON.parse(valueStr);
+        if (!Array.isArray(parsedJson)) {
+          throw Error(`Invalid ${keyName} value, expected array but got ${typeof parsedJson}`);
+        }
+        return parsedJson.map((item) => {
+          const result: Record<string, SpecValue> = {};
+          for (const [key, val] of Object.entries(item)) {
+            if (typeof val !== "string") {
+              throw Error(`Invalid ${keyName}.${key} value ${val as string}, expected string`);
+            }
+
+            if (key === "EPOCH") {
+              result[key] = parseInt(val, 10);
+            } else if (key === "MAX_BLOBS_PER_BLOCK") {
+              result[key] = parseInt(val, 10);
+            } else {
+              throw new Error("Unexpected key in blob schedule");
+            }
+          }
+          return result;
+        });
+      } catch (e) {
+        throw Error(`Invalid ${keyName} value '${valueStr}', failed to parse as JSON: ${(e as Error).message}`);
+      }
+    }
   }
 }

--- a/packages/config/src/chainConfig/types.ts
+++ b/packages/config/src/chainConfig/types.ts
@@ -88,7 +88,7 @@ export type ChainConfig = {
   NODE_CUSTODY_REQUIREMENT: number;
   VALIDATOR_CUSTODY_REQUIREMENT: number;
   BALANCE_PER_ADDITIONAL_CUSTODY_GROUP: number;
-  MAX_BLOBS_PER_BLOCK_FULU: number;
+  BLOB_SCHEDULE: {EPOCH: number; MAX_BLOBS_PER_BLOCK: number}[];
 };
 
 export const chainConfigTypes: SpecTypes<ChainConfig> = {
@@ -169,11 +169,11 @@ export const chainConfigTypes: SpecTypes<ChainConfig> = {
   NODE_CUSTODY_REQUIREMENT: "number",
   VALIDATOR_CUSTODY_REQUIREMENT: "number",
   BALANCE_PER_ADDITIONAL_CUSTODY_GROUP: "number",
-  MAX_BLOBS_PER_BLOCK_FULU: "number",
+  BLOB_SCHEDULE: "blobschedule",
 };
 
 /** Allows values in a Spec file */
-export type SpecValue = number | bigint | Uint8Array | string;
+export type SpecValue = number | bigint | Uint8Array | string | Array<Record<string, SpecValue>>;
 
 /** Type value name of each spec field. Numbers are ignored since they are the most common */
 export type SpecValueType<V extends SpecValue> = V extends number
@@ -184,7 +184,9 @@ export type SpecValueType<V extends SpecValue> = V extends number
       ? "bytes"
       : V extends string
         ? "string"
-        : never;
+        : V extends Array<Record<string, SpecValue>>
+          ? "blobschedule"
+          : never;
 
 /** All possible type names for a SpecValue */
 export type SpecValueTypeName = SpecValueType<SpecValue>;

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -138,15 +138,29 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       }
       return sszTypesFor(forkName);
     },
-    getMaxBlobsPerBlock(fork: ForkName): number {
-      switch (fork) {
-        case ForkName.fulu:
-          return config.MAX_BLOBS_PER_BLOCK_FULU;
-        case ForkName.electra:
-          return config.MAX_BLOBS_PER_BLOCK_ELECTRA;
-        default:
-          return config.MAX_BLOBS_PER_BLOCK;
+    getMaxBlobsPerBlock(epoch: Epoch): number {
+      if (config.BLOB_SCHEDULE && Array.isArray(config.BLOB_SCHEDULE) && config.BLOB_SCHEDULE.length > 0) {
+        // Find the entry in BLOB_SCHEDULE that applies to the current epoch
+        // Sort in descending order of epochs to find the latest applicable schedule
+        const scheduleEntries = [...config.BLOB_SCHEDULE].sort((a, b) => b.EPOCH - a.EPOCH);
+
+        for (const entry of scheduleEntries) {
+          if (epoch >= entry.EPOCH) {
+            return entry.MAX_BLOBS_PER_BLOCK;
+          }
+        }
       }
+
+      // Fall back to the static configuration if no BLOB_SCHEDULE entry applies
+      // Get the fork name for this epoch
+      const forkInfo = this.getForkInfoAtEpoch(epoch);
+      if (isForkPostElectra(forkInfo.name)) {
+        return config.MAX_BLOBS_PER_BLOCK_ELECTRA;
+      }
+      if (isForkPostDeneb(forkInfo.name)) {
+        return config.MAX_BLOBS_PER_BLOCK;
+      }
+      return 0;
     },
     getMaxRequestBlobSidecars(fork: ForkName): number {
       return isForkPostElectra(fork) ? config.MAX_REQUEST_BLOB_SIDECARS_ELECTRA : config.MAX_REQUEST_BLOB_SIDECARS;

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -39,8 +39,8 @@ export type ForkConfig = {
   getPostBellatrixForkTypes(slot: Slot): SSZTypesFor<ForkPostBellatrix>;
   /** Get post-deneb SSZ types by hard-fork*/
   getPostDenebForkTypes(slot: Slot): SSZTypesFor<ForkPostDeneb>;
-  /** Get max blobs per block by hard-fork */
-  getMaxBlobsPerBlock(fork: ForkName): number;
+  /** Get max blobs per block for a given epoch */
+  getMaxBlobsPerBlock(epoch: Epoch): number;
   /** Get max request blob sidecars by hard-fork */
   getMaxRequestBlobSidecars(fork: ForkName): number;
 };

--- a/packages/state-transition/src/block/processExecutionPayload.ts
+++ b/packages/state-transition/src/block/processExecutionPayload.ts
@@ -8,7 +8,7 @@ import {
   getFullOrBlindedPayloadFromBody,
   isMergeTransitionComplete,
 } from "../util/execution.js";
-import {getRandaoMix} from "../util/index.js";
+import {computeEpochAtSlot, getRandaoMix} from "../util/index.js";
 import {BlockExternalData, ExecutionPayloadStatus} from "./externalData.js";
 
 export function processExecutionPayload(
@@ -49,7 +49,7 @@ export function processExecutionPayload(
   }
 
   if (isForkPostDeneb(forkName)) {
-    const maxBlobsPerBlock = state.config.getMaxBlobsPerBlock(forkName);
+    const maxBlobsPerBlock = state.config.getMaxBlobsPerBlock(computeEpochAtSlot(state.slot));
     const blobKzgCommitmentsLen = (body as deneb.BeaconBlockBody).blobKzgCommitments?.length ?? 0;
     if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
       throw Error(`blobKzgCommitmentsLen of ${blobKzgCommitmentsLen} exceeds limit=${maxBlobsPerBlock}`);

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -258,6 +258,6 @@ function getSpecCriticalParams(localConfig: ChainConfig): Record<keyof ConfigWit
     NODE_CUSTODY_REQUIREMENT: false,
     VALIDATOR_CUSTODY_REQUIREMENT: fuluForkRelevant,
     BALANCE_PER_ADDITIONAL_CUSTODY_GROUP: fuluForkRelevant,
-    MAX_BLOBS_PER_BLOCK_FULU: fuluForkRelevant,
+    BLOB_SCHEDULE: fuluForkRelevant,
   };
 }


### PR DESCRIPTION
**Motivation**

Blob parameter forks ([EIP 7892](https://eips.ethereum.org/EIPS/eip-7892)) are SFI for Fulu and planned for fusaka-devnet-0, so starting a branch for them here based on the [consensus spec PR](https://github.com/ethereum/consensus-specs/pull/4277).

**Description**

* Seems like the toughest part will be expanding the config format to support complex objects. For now I added a unique `blobschedule` type to contain the validation, but could also go down the path of generalizing the serialization.