### PR TITLE
feat: update `getHistoricalSummaries` endpoint include version+slot

### DIFF
--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -5,19 +5,19 @@ import {
   ArrayOf,
   EmptyArgs,
   EmptyMeta,
-  EmptyMetaCodec,
   EmptyRequest,
   EmptyRequestCodec,
   EmptyResponseCodec,
   EmptyResponseData,
   JsonOnlyResponseCodec,
-  WithVersion,
 } from "../../utils/codecs.js";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
+import {
+  ExecutionOptimisticFinalizedAndVersionCodec,
+  ExecutionOptimisticFinalizedAndVersionMeta,
+} from "../../utils/metadata.js";
 import {StateArgs} from "./beacon/state.js";
 import {FilterGetPeers, NodePeer, PeerDirection, PeerState} from "./node.js";
-import { ExecutionOptimisticFinalizedAndVersionCodec, ExecutionOptimisticFinalizedAndVersionMeta } from "../../utils/metadata.js";
-import { isForkPostElectra } from "@lodestar/params";
 
 export type SyncChainDebugState = {
   targetRoot: string | null;
@@ -83,7 +83,7 @@ export type BlacklistedBlock = {root: RootHex; slot: Slot | null};
 export type LodestarThreadType = "main" | "network" | "discv5";
 
 const HistoricalSummariesResponseType = new ContainerType(
-{
+  {
     slot: ssz.Slot,
     historicalSummaries: ssz.capella.HistoricalSummaries,
     proof: ArrayOf(ssz.Bytes8),

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -410,7 +410,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       resp: JsonOnlyResponseCodec,
     },
     getHistoricalSummaries: {
-      url: "/eth/v1/lodestar/{state_id}/historical_summaries",
+      url: "/eth/v1/lodestar/states/{state_id}/historical_summaries",
       method: "GET",
       req: {
         writeReq: ({stateId}) => ({params: {state_id: stateId.toString()}}),

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -11,10 +11,13 @@ import {
   EmptyResponseCodec,
   EmptyResponseData,
   JsonOnlyResponseCodec,
+  WithVersion,
 } from "../../utils/codecs.js";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {StateArgs} from "./beacon/state.js";
 import {FilterGetPeers, NodePeer, PeerDirection, PeerState} from "./node.js";
+import { ExecutionOptimisticFinalizedAndVersionCodec, ExecutionOptimisticFinalizedAndVersionMeta } from "../../utils/metadata.js";
+import { isForkPostElectra } from "@lodestar/params";
 
 export type SyncChainDebugState = {
   targetRoot: string | null;
@@ -80,7 +83,8 @@ export type BlacklistedBlock = {root: RootHex; slot: Slot | null};
 export type LodestarThreadType = "main" | "network" | "discv5";
 
 const HistoricalSummariesResponseType = new ContainerType(
-  {
+{
+    slot: ssz.Slot,
     historicalSummaries: ssz.capella.HistoricalSummaries,
     proof: ArrayOf(ssz.Bytes8),
   },
@@ -245,7 +249,7 @@ export type Endpoints = {
     StateArgs,
     {params: {state_id: string}},
     HistoricalSummariesResponse,
-    EmptyMeta
+    ExecutionOptimisticFinalizedAndVersionMeta
   >;
 
   /** Dump Discv5 Kad values */
@@ -406,7 +410,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       resp: JsonOnlyResponseCodec,
     },
     getHistoricalSummaries: {
-      url: "/eth/v1/lodestar/historical_summaries/{state_id}",
+      url: "/eth/v1/lodestar/{state_id}/historical_summaries",
       method: "GET",
       req: {
         writeReq: ({stateId}) => ({params: {state_id: stateId.toString()}}),
@@ -417,7 +421,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       },
       resp: {
         data: HistoricalSummariesResponseType,
-        meta: EmptyMetaCodec,
+        meta: ExecutionOptimisticFinalizedAndVersionCodec,
       },
     },
     discv5GetKadValues: {

--- a/packages/api/test/unit-mainnet/beacon/genericServerTest/lodestar.test.ts
+++ b/packages/api/test/unit-mainnet/beacon/genericServerTest/lodestar.test.ts
@@ -1,6 +1,7 @@
 import {config} from "@lodestar/config/default";
+import {ForkName} from "@lodestar/params";
 import {FastifyInstance} from "fastify";
-import {afterAll, beforeAll, describe, expect, it, vi} from "vitest";
+import {afterAll, beforeAll, describe, expect, it} from "vitest";
 import {getClient} from "../../../../src/beacon/client/lodestar.js";
 import {Endpoints, getDefinitions} from "../../../../src/beacon/routes/lodestar.js";
 import {getRoutes} from "../../../../src/beacon/server/lodestar.js";
@@ -9,7 +10,6 @@ import {AnyEndpoint} from "../../../../src/utils/codecs.js";
 import {FastifyRoute} from "../../../../src/utils/server/index.js";
 import {WireFormat} from "../../../../src/utils/wireFormat.js";
 import {getMockApi, getTestServer} from "../../../utils/utils.js";
-import { ForkName } from "@lodestar/params";
 
 describe("beacon / lodestar", () => {
   describe("get HistoricalSummaries as json", () => {
@@ -31,7 +31,7 @@ describe("beacon / lodestar", () => {
     });
 
     it("getHistoricalSummaries", async () => {
-        mockApi.getHistoricalSummaries.mockResolvedValue({
+      mockApi.getHistoricalSummaries.mockResolvedValue({
         data: {
           slot: 0,
           historicalSummaries: [],

--- a/packages/api/test/unit-mainnet/beacon/genericServerTest/lodestar.test.ts
+++ b/packages/api/test/unit-mainnet/beacon/genericServerTest/lodestar.test.ts
@@ -9,6 +9,7 @@ import {AnyEndpoint} from "../../../../src/utils/codecs.js";
 import {FastifyRoute} from "../../../../src/utils/server/index.js";
 import {WireFormat} from "../../../../src/utils/wireFormat.js";
 import {getMockApi, getTestServer} from "../../../utils/utils.js";
+import { ForkName } from "@lodestar/params";
 
 describe("beacon / lodestar", () => {
   describe("get HistoricalSummaries as json", () => {
@@ -30,11 +31,13 @@ describe("beacon / lodestar", () => {
     });
 
     it("getHistoricalSummaries", async () => {
-      mockApi.getHistoricalSummaries.mockResolvedValue({
+        mockApi.getHistoricalSummaries.mockResolvedValue({
         data: {
+          slot: 0,
           historicalSummaries: [],
           proof: [],
         },
+        meta: {version: ForkName.electra, executionOptimistic: false, finalized: false},
       });
 
       const httpClient = new HttpClient({baseUrl});

--- a/packages/api/test/unit-mainnet/beacon/genericServerTest/lodestar.test.ts
+++ b/packages/api/test/unit-mainnet/beacon/genericServerTest/lodestar.test.ts
@@ -48,6 +48,7 @@ describe("beacon / lodestar", () => {
       expect(res.ok).toBe(true);
       expect(res.wireFormat()).toBe(WireFormat.json);
       expect(res.json().data).toStrictEqual({
+        slot: "0",
         historical_summaries: [],
         proof: [],
       });

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -210,10 +210,10 @@ export function getLodestarApi({
       const proof = new Tree(stateView.node).getSingleProof(gindex);
 
       return {
-          data: {
-            slot: stateView.slot,
-            historicalSummaries: stateView.historicalSummaries.toValue(),
-            proof: proof,
+        data: {
+          slot: stateView.slot,
+          historicalSummaries: stateView.historicalSummaries.toValue(),
+          proof: proof,
         },
         meta: {executionOptimistic, finalized, version: fork},
       };

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -5,7 +5,7 @@ import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {ChainForkConfig} from "@lodestar/config";
 import {Repository} from "@lodestar/db";
-import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkName, ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {BeaconStateCapella, getLatestWeakSubjectivityCheckpointEpoch, loadState} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {toHex, toRootHex} from "@lodestar/utils";
@@ -195,7 +195,7 @@ export function getLodestarApi({
     },
 
     async getHistoricalSummaries({stateId}) {
-      const {state} = await getStateResponseWithRegen(chain, stateId);
+      const {state, executionOptimistic, finalized} = await getStateResponseWithRegen(chain, stateId);
 
       const stateView = (
         state instanceof Uint8Array ? loadState(config, chain.getHeadState(), state).state : state.clone()
@@ -210,10 +210,12 @@ export function getLodestarApi({
       const proof = new Tree(stateView.node).getSingleProof(gindex);
 
       return {
-        data: {
-          historicalSummaries: stateView.historicalSummaries.toValue(),
-          proof: proof,
+          data: {
+            slot: stateView.slot,
+            historicalSummaries: stateView.historicalSummaries.toValue(),
+            proof: proof,
         },
+        meta: {executionOptimistic, finalized, version: config.getForkName(stateView.slot)},
       };
     },
   };

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -215,7 +215,7 @@ export function getLodestarApi({
             historicalSummaries: stateView.historicalSummaries.toValue(),
             proof: proof,
         },
-        meta: {executionOptimistic, finalized, version: config.getForkName(stateView.slot)},
+        meta: {executionOptimistic, finalized, version: fork},
       };
     },
   };


### PR DESCRIPTION
**Motivation**

This PR is an extension on https://github.com/ChainSafe/lodestar/pull/7245

I was trying to use the endpoint to create a https://github.com/ethereum/portal-network-specs/blob/master/beacon-chain/beacon-network.md#historicalsummaries `HistoricalSummariesWithProof`, but the endpoint didn't return the Fork or the slot as we need the epoch.

**Description**

- I added slot to the `HistoricalSummariesResponseType` type
- I used ExecutionOptimisticFinalizedAndVersionCodec to expose the fork
- I changed `/eth/v1/lodestar/historical_summaries/{state_id}` to `/eth/v1/lodestar/states/{state_id}/historical_summaries` to be more in line with the other state endpoints https://ethereum.github.io/beacon-APIs/#/Beacon
 

 