### PR TITLE
feat: improve range sync in fulu

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -486,6 +486,16 @@ export function createLodestarMetrics(
         name: "lodestar_sync_chain_highest_target_slot_completed",
         help: "Highest target slot completed by a sync chain",
       }),
+      headSyncPeers: register.gauge<{columnIndex: number}>({
+        name: "lodestar_sync_head_sync_peers_count",
+        help: "Count of head sync peers by group index",
+        labelNames: ["columnIndex"],
+      }),
+      finalizedSyncPeers: register.gauge<{columnIndex: number}>({
+        name: "lodestar_sync_finalized_sync_peers_count",
+        help: "Count of finalized sync peers by group index",
+        labelNames: ["columnIndex"],
+      }),
     },
 
     syncUnknownBlock: {

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -1,4 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
+import {ForkSeq} from "@lodestar/params";
 import {Epoch, RootHex, phase0} from "@lodestar/types";
 import {LodestarError} from "@lodestar/utils";
 import {BlockInput} from "../../chain/blocks/types.js";
@@ -211,6 +212,10 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.AwaitingValidation));
     }
     return this.state.attempt;
+  }
+
+  isFulu(): boolean {
+    return this.config.getForkSeq(this.request.startSlot) >= ForkSeq.fulu;
   }
 
   private onExecutionEngineError(attempt: Attempt): void {

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -3,9 +3,11 @@ import {ForkName} from "@lodestar/params";
 import {Epoch, Root, Slot, phase0} from "@lodestar/types";
 import {ErrorAborted, Logger, toRootHex} from "@lodestar/utils";
 import {BlockInput, BlockInputDataColumns, BlockInputType} from "../../chain/blocks/types.js";
+import {Metrics} from "../../metrics/metrics.js";
 import {PeerAction, prettyPrintPeerIdStr} from "../../network/index.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
 import {PartialDownload} from "../../network/reqresp/beaconBlocksMaybeBlobsByRange.js";
+import {CustodyConfig} from "../../util/dataColumns.js";
 import {ItTrigger} from "../../util/itTrigger.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {wrapError} from "../../util/wrapError.js";
@@ -14,8 +16,9 @@ import {RangeSyncType} from "../utils/remoteSyncType.js";
 import {Batch, BatchError, BatchErrorCode, BatchMetadata, BatchStatus} from "./batch.js";
 import {
   ChainPeersBalancer,
+  PeerSyncInfo,
   batchStartEpochIsAfterSlot,
-  computeMostCommonTarget,
+  computeHighestTarget,
   getBatchSlotRange,
   getNextBatchToProcess,
   isSyncChainDone,
@@ -26,7 +29,9 @@ import {
 
 export type SyncChainModules = {
   config: ChainForkConfig;
+  custodyConfig: CustodyConfig;
   logger: Logger;
+  metrics: Metrics | null;
 };
 
 export type SyncChainFns = {
@@ -118,6 +123,8 @@ export class SyncChain {
 
   private readonly logger: Logger;
   private readonly config: ChainForkConfig;
+  private readonly custodyConfig: CustodyConfig;
+  private readonly metrics: Metrics | null;
 
   constructor(
     initialBatchEpoch: Epoch,
@@ -135,8 +142,14 @@ export class SyncChain {
     this.reportPeer = fns.reportPeer;
     this.getConnectedPeerSyncMeta = fns.getConnectedPeerSyncMeta;
     this.config = modules.config;
+    this.custodyConfig = modules.custodyConfig;
     this.logger = modules.logger;
+    this.metrics = modules.metrics;
     this.logId = `${syncType}`;
+
+    if (this.metrics != null) {
+      this.metrics.syncRange.headSyncPeers.addCollect(() => this.scrapeMetrics(this.metrics as Metrics));
+    }
 
     // Trigger event on parent class
     this.sync().then(
@@ -257,7 +270,7 @@ export class SyncChain {
   private computeTarget(): void {
     if (this.peerset.size > 0) {
       const targets = Array.from(this.peerset.values());
-      this.target = computeMostCommonTarget(targets);
+      this.target = computeHighestTarget(targets);
     }
   }
 
@@ -340,12 +353,12 @@ export class SyncChain {
       return;
     }
 
-    const peersSyncMeta: PeerSyncMeta[] = [];
-    for (const peerId of this.peerset.keys()) {
-      peersSyncMeta.push(this.getConnectedPeerSyncMeta(peerId));
+    const peersSyncInfo: PeerSyncInfo[] = [];
+    for (const [peerId, target] of this.peerset.entries()) {
+      peersSyncInfo.push({...this.getConnectedPeerSyncMeta(peerId), target});
     }
 
-    const peerBalancer = new ChainPeersBalancer(peersSyncMeta, toArr(this.batches));
+    const peerBalancer = new ChainPeersBalancer(peersSyncInfo, toArr(this.batches), this.custodyConfig);
 
     // Retry download of existing batches
     for (const batch of this.batches.values()) {
@@ -360,12 +373,15 @@ export class SyncChain {
     }
 
     // find the next pending batch and request it from the peer
-    for (const peer of peerBalancer.idlePeers()) {
-      const batch = this.includeNextBatch();
-      if (!batch) {
+    let batch = this.includeNextBatch();
+    while (batch != null) {
+      const peer = peerBalancer.idlePeerForBatch(batch);
+      if (!peer) {
+        // if there is no peer available, we stop requesting batches because next batches will have greater startEpoch with the same sampling groups
         break;
       }
       void this.sendBatch(batch, peer);
+      batch = this.includeNextBatch();
     }
   }
 
@@ -547,6 +563,32 @@ export class SyncChain {
     }
 
     this.lastEpochWithProcessBlocks = newLastEpochWithProcessBlocks;
+  }
+
+  private scrapeMetrics(metrics: Metrics): void {
+    const syncPeersMetric =
+      this.syncType === RangeSyncType.Finalized
+        ? metrics.syncRange.finalizedSyncPeers
+        : metrics.syncRange.headSyncPeers;
+
+    const peersSyncMeta = new Map<PeerIdStr, PeerSyncMeta>();
+    for (const peerId of this.peerset.keys()) {
+      peersSyncMeta.set(peerId, this.getConnectedPeerSyncMeta(peerId));
+    }
+
+    const peersByColumnIndex = new Map<number, number>();
+    for (const [columnIndex, column] of this.custodyConfig.sampledColumns.entries()) {
+      for (const {custodyGroups} of peersSyncMeta.values()) {
+        if (custodyGroups.includes(column)) {
+          peersByColumnIndex.set(columnIndex, (peersByColumnIndex.get(columnIndex) ?? 0) + 1);
+        }
+      }
+    }
+
+    for (let columnIndex = 0; columnIndex < this.custodyConfig.sampledColumns.length; columnIndex++) {
+      const peerCount = peersByColumnIndex.get(columnIndex) ?? 0;
+      syncPeersMetric.set({columnIndex}, peerCount);
+    }
   }
 }
 

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -355,7 +355,11 @@ export class SyncChain {
 
     const peersSyncInfo: PeerSyncInfo[] = [];
     for (const [peerId, target] of this.peerset.entries()) {
-      peersSyncInfo.push({...this.getConnectedPeerSyncMeta(peerId), target});
+      try {
+        peersSyncInfo.push({...this.getConnectedPeerSyncMeta(peerId), target});
+      } catch (e) {
+        this.logger.debug("Failed to get peer sync meta", {peerId}, e as Error);
+      }
     }
 
     const peerBalancer = new ChainPeersBalancer(peersSyncInfo, toArr(this.batches), this.custodyConfig);
@@ -573,7 +577,11 @@ export class SyncChain {
 
     const peersSyncMeta = new Map<PeerIdStr, PeerSyncMeta>();
     for (const peerId of this.peerset.keys()) {
-      peersSyncMeta.set(peerId, this.getConnectedPeerSyncMeta(peerId));
+      try {
+        peersSyncMeta.set(peerId, this.getConnectedPeerSyncMeta(peerId));
+      } catch (_) {
+        // ignore for metric as peer could be disconnected
+      }
     }
 
     const peersByColumnIndex = new Map<number, number>();

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -249,7 +249,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
           getConnectedPeerSyncMeta: this.getConnectedPeerSyncMeta,
           onEnd: this.onSyncChainEnd,
         },
-        {config: this.config, logger: this.logger}
+        {config: this.config, logger: this.logger, custodyConfig: this.chain.custodyConfig, metrics: this.metrics}
       );
       this.chains.set(syncType, syncChain);
 
@@ -259,6 +259,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
         firstEpoch: syncChain.firstBatchEpoch,
         targetSlot: syncChain.target.slot,
         targetRoot: toRootHex(syncChain.target.root),
+        peer,
       });
     }
 

--- a/packages/beacon-node/src/sync/range/utils/chainTarget.ts
+++ b/packages/beacon-node/src/sync/range/utils/chainTarget.ts
@@ -10,7 +10,35 @@ export type ChainTarget = {
   root: Root;
 };
 
-export function computeMostCommonTarget(targets: ChainTarget[]): ChainTarget {
+/**
+ * Previously we use computeMostCommonTarget to compute the target for a chain.
+ * Starting from fulu, we use computeHighestTarget to compute the target for a chain.
+ */
+export function computeHighestTarget(targets: ChainTarget[]): ChainTarget {
+  if (targets.length === 0) {
+    throw Error("Must provide at least one target");
+  }
+
+  let highestSlot = -1;
+  let highestTargets: ChainTarget[] = [];
+  for (const target of targets) {
+    if (target.slot > highestSlot) {
+      highestSlot = target.slot;
+      highestTargets = [target];
+    } else if (target.slot === highestSlot) {
+      highestTargets.push(target);
+    }
+    // ignore if target.slot < highestSlot
+  }
+
+  if (highestTargets.length === 1) {
+    return highestTargets[0];
+  }
+
+  return computeMostCommonTarget(highestTargets);
+}
+
+function computeMostCommonTarget(targets: ChainTarget[]): ChainTarget {
   if (targets.length === 0) {
     throw Error("Must provide at least one target");
   }

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -55,7 +55,7 @@ export class ChainPeersBalancer {
       ({columns}) => -1 * columns // prefer peers with the most columns
     );
 
-    return sortedBestPeers[0].syncInfo;
+    return sortedBestPeers.length > 0 ? sortedBestPeers[0].syncInfo : undefined;
   }
 
   /**

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -10,7 +10,7 @@ export type PeerSyncInfo = PeerSyncMeta & {
   target: ChainTarget;
 };
 
-type PeerInfoColumn = {syncInfo: PeerSyncInfo; columns: number};
+type PeerInfoColumn = {syncInfo: PeerSyncInfo; columns: number; hasEarliestAvailableSlots: boolean};
 
 /**
  * Balance and organize peers to perform requests with a SyncChain
@@ -49,9 +49,10 @@ export class ChainPeersBalancer {
     const failedPeers = new Set(batch.getFailedPeers());
     const sortedBestPeers = sortBy(
       eligiblePeers,
-      ({syncInfo}) => (failedPeers.has(syncInfo.peerId) ? 1 : 0), // Sort by no failed first = 0
-      ({syncInfo}) => this.activeRequestsByPeer.get(syncInfo.peerId) ?? 0, // Sort by least active req
-      ({columns}) => -1 * columns // Sort by most columns we need
+      ({syncInfo}) => (failedPeers.has(syncInfo.peerId) ? 1 : 0), // prefer peers without failed requests
+      ({syncInfo}) => this.activeRequestsByPeer.get(syncInfo.peerId) ?? 0, // prefer peers with least active req
+      ({hasEarliestAvailableSlots}) => (hasEarliestAvailableSlots ? 0 : 1), // prefer peers with earliestAvailableSlots defined
+      ({columns}) => -1 * columns // prefer peers with the most columns
     );
 
     return sortedBestPeers[0].syncInfo;
@@ -63,12 +64,19 @@ export class ChainPeersBalancer {
   idlePeerForBatch(batch: Batch): PeerSyncInfo | undefined {
     const eligiblePeers = this.filterPeers(batch, this.custodyConfig.sampledColumns, true);
 
-    // pick idle peer that has the most columns we need, for pre-fulu they are always 0
-    const mostColumnsPeer = eligiblePeers.sort((a, b) => b.columns - a.columns)[0];
-    if (mostColumnsPeer != null) {
+    // pick idle peer that has (for pre-fulu they are the same)
+    // - earliestAvailableSlot defined
+    // - the most columns we need
+    const sortedBestPeers = sortBy(
+      eligiblePeers,
+      ({hasEarliestAvailableSlots}) => (hasEarliestAvailableSlots ? 0 : 1), // prefer peers with earliestAvailableSlots defined
+      ({columns}) => -1 * columns // prefer peers with most columns we need
+    );
+    const bestPeer = sortedBestPeers[0];
+    if (bestPeer != null) {
       // we will use this peer for batch in SyncChain right after this call
-      this.activeRequestsByPeer.set(mostColumnsPeer.syncInfo.peerId, 1);
-      return mostColumnsPeer.syncInfo;
+      this.activeRequestsByPeer.set(bestPeer.syncInfo.peerId, 1);
+      return bestPeer.syncInfo;
     }
 
     return undefined;
@@ -90,13 +98,13 @@ export class ChainPeersBalancer {
       }
 
       if (!batch.isFulu()) {
-        // pre-fulu logic
-        eligiblePeers.push({syncInfo: peer, columns: 0});
+        // pre-fulu logic, we don't care columns and earliestAvailableSlot
+        eligiblePeers.push({syncInfo: peer, columns: 0, hasEarliestAvailableSlots: false});
         continue;
       }
 
-      // TODO(fulu): this is a bug and is prioritizing peers that do not announce
-      //     an earliestAvailableSlot. Need to refactor this logic
+      // for devnet, we optimistically assume peers without earliestAvailableSlot, but don't prioritize them
+      // TODO(fulu): consider do not accept these peers
       const earliestSlot = earliestAvailableSlot ?? 0;
       const peerColumns = custodyGroups;
 
@@ -112,7 +120,11 @@ export class ChainPeersBalancer {
       }, [] as number[]);
 
       if (columns.length > 0) {
-        eligiblePeers.push({syncInfo: peer, columns: columns.length});
+        eligiblePeers.push({
+          syncInfo: peer,
+          columns: columns.length,
+          hasEarliestAvailableSlots: earliestAvailableSlot != null,
+        });
       }
     }
 

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -1,20 +1,28 @@
 import {PeerSyncMeta} from "../../../network/peers/peersData.js";
+import {CustodyConfig} from "../../../util/dataColumns.js";
 import {PeerIdStr} from "../../../util/peerId.js";
 import {shuffle} from "../../../util/shuffle.js";
 import {sortBy} from "../../../util/sortBy.js";
 import {Batch, BatchStatus} from "../batch.js";
+import {ChainTarget} from "./chainTarget.js";
+
+export type PeerSyncInfo = PeerSyncMeta & {
+  target: ChainTarget;
+};
 
 /**
  * Balance and organize peers to perform requests with a SyncChain
  * Shuffles peers only once on instantiation
  */
 export class ChainPeersBalancer {
-  private peers: PeerSyncMeta[];
+  private peers: PeerSyncInfo[];
   private activeRequestsByPeer = new Map<PeerIdStr, number>();
+  private readonly custodyConfig: CustodyConfig;
 
   // TODO: @matthewkeil check if this needs to be updated for custody groups
-  constructor(peers: PeerSyncMeta[], batches: Batch[]) {
+  constructor(peers: PeerSyncInfo[], batches: Batch[], custodyConfig: CustodyConfig) {
     this.peers = shuffle(peers);
+    this.custodyConfig = custodyConfig;
 
     // Compute activeRequestsByPeer from all batches internal states
     for (const batch of batches) {
@@ -36,22 +44,30 @@ export class ChainPeersBalancer {
 
     const failedPeers = new Set(batch.getFailedPeers());
     const sortedBestPeers = sortBy(
-      this.peers.filter(({earliestAvailableSlot, custodyGroups}) => {
+      this.peers.filter(({earliestAvailableSlot, custodyGroups, target}) => {
+        if (!batch.isFulu()) {
+          return true;
+        }
+
         // TODO(fulu): this is a bug and is prioritizing peers that do not announce
         //     an earliestAvailableSlot. Need to refactor this logic
         const earliestSlot = earliestAvailableSlot ?? 0;
-        const peerColumns = custodyGroups ?? [];
+        const peerColumns = custodyGroups;
 
         if (earliestSlot > batch.request.startSlot) {
           return false;
         }
 
-        if (partialDownload === null) {
-          return true;
+        if (target.slot < batch.request.startSlot) {
+          return false;
         }
 
+        const pendingDataColumns = partialDownload
+          ? partialDownload.pendingDataColumns
+          : this.custodyConfig.sampledColumns;
+
         const columns = peerColumns.reduce((acc, elem) => {
-          if (partialDownload.pendingDataColumns.includes(elem)) {
+          if (pendingDataColumns.includes(elem)) {
             acc.push(elem);
           }
           return acc;
@@ -67,12 +83,55 @@ export class ChainPeersBalancer {
   }
 
   /**
-   * Return peers with 0 or no active requests
+   * Return peers with 0 or no active requests that has a higher target slot than this batch and has columns we need.
    */
-  idlePeers(): PeerSyncMeta[] {
-    return this.peers.filter(({peerId}) => {
+  idlePeerForBatch(batch: Batch): PeerSyncInfo | undefined {
+    const eligiblePeers: {peerInfo: PeerSyncInfo; columns: number}[] = [];
+    for (const peerInfo of this.peers) {
+      const {peerId, custodyGroups, target, earliestAvailableSlot} = peerInfo;
       const activeRequests = this.activeRequestsByPeer.get(peerId);
-      return activeRequests === undefined || activeRequests === 0;
-    });
+      if (activeRequests != null && activeRequests > 0) {
+        continue;
+      }
+
+      // TODO(fulu): this is a bug and is prioritizing peers that do not announce
+      //     an earliestAvailableSlot. Need to refactor this logic
+      const earliestSlot = earliestAvailableSlot ?? 0;
+      if (earliestSlot > batch.request.startSlot) {
+        continue;
+      }
+
+      if (target.slot < batch.request.startSlot) {
+        continue;
+      }
+
+      if (!batch.isFulu()) {
+        eligiblePeers.push({peerInfo, columns: 0});
+        continue;
+      }
+
+      // fulu specific logic
+      const peerColumns = custodyGroups;
+      const columns = peerColumns.reduce((acc, elem) => {
+        if (this.custodyConfig.sampledColumns.includes(elem)) {
+          acc.push(elem);
+        }
+        return acc;
+      }, [] as number[]);
+
+      if (columns.length > 0) {
+        eligiblePeers.push({peerInfo, columns: columns.length});
+      }
+    }
+
+    // pick idle peer that has the most columns we need, for pre-fulu they are always 0
+    const mostColumnsPeer = eligiblePeers.sort((a, b) => b.columns - a.columns)[0];
+    if (mostColumnsPeer != null) {
+      // we will use this peer for batch in SyncChain right after this call
+      this.activeRequestsByPeer.set(mostColumnsPeer.peerInfo.peerId, 1);
+      return mostColumnsPeer.peerInfo;
+    }
+
+    return undefined;
   }
 }

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -43,43 +43,51 @@ export class ChainPeersBalancer {
     const {partialDownload} = batch.state;
 
     const failedPeers = new Set(batch.getFailedPeers());
+    const eligiblePeers: {syncInfo: PeerSyncInfo; columns: number}[] = [];
+    for (const peer of this.peers) {
+      const {earliestAvailableSlot, custodyGroups, target} = peer;
+      if (!batch.isFulu()) {
+        eligiblePeers.push({syncInfo: peer, columns: 0});
+        continue;
+      }
+
+      // TODO(fulu): this is a bug and is prioritizing peers that do not announce
+      //     an earliestAvailableSlot. Need to refactor this logic
+      const earliestSlot = earliestAvailableSlot ?? 0;
+      const peerColumns = custodyGroups;
+
+      if (earliestSlot > batch.request.startSlot) {
+        continue;
+      }
+
+      if (target.slot < batch.request.startSlot) {
+        continue;
+      }
+
+      const pendingDataColumns = partialDownload
+        ? partialDownload.pendingDataColumns
+        : this.custodyConfig.sampledColumns;
+
+      const columns = peerColumns.reduce((acc, elem) => {
+        if (pendingDataColumns.includes(elem)) {
+          acc.push(elem);
+        }
+        return acc;
+      }, [] as number[]);
+
+      if (columns.length > 0) {
+        eligiblePeers.push({syncInfo: peer, columns: columns.length});
+      }
+    }
+
     const sortedBestPeers = sortBy(
-      this.peers.filter(({earliestAvailableSlot, custodyGroups, target}) => {
-        if (!batch.isFulu()) {
-          return true;
-        }
-
-        // TODO(fulu): this is a bug and is prioritizing peers that do not announce
-        //     an earliestAvailableSlot. Need to refactor this logic
-        const earliestSlot = earliestAvailableSlot ?? 0;
-        const peerColumns = custodyGroups;
-
-        if (earliestSlot > batch.request.startSlot) {
-          return false;
-        }
-
-        if (target.slot < batch.request.startSlot) {
-          return false;
-        }
-
-        const pendingDataColumns = partialDownload
-          ? partialDownload.pendingDataColumns
-          : this.custodyConfig.sampledColumns;
-
-        const columns = peerColumns.reduce((acc, elem) => {
-          if (pendingDataColumns.includes(elem)) {
-            acc.push(elem);
-          }
-          return acc;
-        }, [] as number[]);
-
-        return columns.length > 0;
-      }),
-      ({peerId}) => (failedPeers.has(peerId) ? 1 : 0), // Sort by no failed first = 0
-      ({peerId}) => this.activeRequestsByPeer.get(peerId) ?? 0 // Sort by least active req
+      eligiblePeers,
+      ({syncInfo}) => (failedPeers.has(syncInfo.peerId) ? 1 : 0), // Sort by no failed first = 0
+      ({syncInfo}) => this.activeRequestsByPeer.get(syncInfo.peerId) ?? 0, // Sort by least active req
+      ({columns}) => -1 * columns // Sort by most columns we need
     );
 
-    return sortedBestPeers[0];
+    return sortedBestPeers[0].syncInfo;
   }
 
   /**

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -10,6 +10,8 @@ export type PeerSyncInfo = PeerSyncMeta & {
   target: ChainTarget;
 };
 
+type PeerInfoColumn = {syncInfo: PeerSyncInfo; columns: number};
+
 /**
  * Balance and organize peers to perform requests with a SyncChain
  * Shuffles peers only once on instantiation
@@ -41,45 +43,10 @@ export class ChainPeersBalancer {
       return;
     }
     const {partialDownload} = batch.state;
+    const pendingDataColumns = partialDownload?.pendingDataColumns ?? this.custodyConfig.sampledColumns;
+    const eligiblePeers = this.filterPeers(batch, pendingDataColumns, false);
 
     const failedPeers = new Set(batch.getFailedPeers());
-    const eligiblePeers: {syncInfo: PeerSyncInfo; columns: number}[] = [];
-    for (const peer of this.peers) {
-      const {earliestAvailableSlot, custodyGroups, target} = peer;
-      if (!batch.isFulu()) {
-        eligiblePeers.push({syncInfo: peer, columns: 0});
-        continue;
-      }
-
-      // TODO(fulu): this is a bug and is prioritizing peers that do not announce
-      //     an earliestAvailableSlot. Need to refactor this logic
-      const earliestSlot = earliestAvailableSlot ?? 0;
-      const peerColumns = custodyGroups;
-
-      if (earliestSlot > batch.request.startSlot) {
-        continue;
-      }
-
-      if (target.slot < batch.request.startSlot) {
-        continue;
-      }
-
-      const pendingDataColumns = partialDownload
-        ? partialDownload.pendingDataColumns
-        : this.custodyConfig.sampledColumns;
-
-      const columns = peerColumns.reduce((acc, elem) => {
-        if (pendingDataColumns.includes(elem)) {
-          acc.push(elem);
-        }
-        return acc;
-      }, [] as number[]);
-
-      if (columns.length > 0) {
-        eligiblePeers.push({syncInfo: peer, columns: columns.length});
-      }
-    }
-
     const sortedBestPeers = sortBy(
       eligiblePeers,
       ({syncInfo}) => (failedPeers.has(syncInfo.peerId) ? 1 : 0), // Sort by no failed first = 0
@@ -94,18 +61,27 @@ export class ChainPeersBalancer {
    * Return peers with 0 or no active requests that has a higher target slot than this batch and has columns we need.
    */
   idlePeerForBatch(batch: Batch): PeerSyncInfo | undefined {
-    const eligiblePeers: {peerInfo: PeerSyncInfo; columns: number}[] = [];
-    for (const peerInfo of this.peers) {
-      const {peerId, custodyGroups, target, earliestAvailableSlot} = peerInfo;
-      const activeRequests = this.activeRequestsByPeer.get(peerId);
-      if (activeRequests != null && activeRequests > 0) {
-        continue;
-      }
+    const eligiblePeers = this.filterPeers(batch, this.custodyConfig.sampledColumns, true);
 
-      // TODO(fulu): this is a bug and is prioritizing peers that do not announce
-      //     an earliestAvailableSlot. Need to refactor this logic
-      const earliestSlot = earliestAvailableSlot ?? 0;
-      if (earliestSlot > batch.request.startSlot) {
+    // pick idle peer that has the most columns we need, for pre-fulu they are always 0
+    const mostColumnsPeer = eligiblePeers.sort((a, b) => b.columns - a.columns)[0];
+    if (mostColumnsPeer != null) {
+      // we will use this peer for batch in SyncChain right after this call
+      this.activeRequestsByPeer.set(mostColumnsPeer.syncInfo.peerId, 1);
+      return mostColumnsPeer.syncInfo;
+    }
+
+    return undefined;
+  }
+
+  private filterPeers(batch: Batch, requestColumns: number[], checkActiveRequest: boolean): PeerInfoColumn[] {
+    const eligiblePeers: PeerInfoColumn[] = [];
+
+    for (const peer of this.peers) {
+      const {earliestAvailableSlot, custodyGroups, target, peerId} = peer;
+
+      const activeRequest = this.activeRequestsByPeer.get(peerId) ?? 0;
+      if (checkActiveRequest && activeRequest > 0) {
         continue;
       }
 
@@ -114,32 +90,32 @@ export class ChainPeersBalancer {
       }
 
       if (!batch.isFulu()) {
-        eligiblePeers.push({peerInfo, columns: 0});
+        // pre-fulu logic
+        eligiblePeers.push({syncInfo: peer, columns: 0});
         continue;
       }
 
-      // fulu specific logic
+      // TODO(fulu): this is a bug and is prioritizing peers that do not announce
+      //     an earliestAvailableSlot. Need to refactor this logic
+      const earliestSlot = earliestAvailableSlot ?? 0;
       const peerColumns = custodyGroups;
+
+      if (earliestSlot > batch.request.startSlot) {
+        continue;
+      }
+
       const columns = peerColumns.reduce((acc, elem) => {
-        if (this.custodyConfig.sampledColumns.includes(elem)) {
+        if (requestColumns.includes(elem)) {
           acc.push(elem);
         }
         return acc;
       }, [] as number[]);
 
       if (columns.length > 0) {
-        eligiblePeers.push({peerInfo, columns: columns.length});
+        eligiblePeers.push({syncInfo: peer, columns: columns.length});
       }
     }
 
-    // pick idle peer that has the most columns we need, for pre-fulu they are always 0
-    const mostColumnsPeer = eligiblePeers.sort((a, b) => b.columns - a.columns)[0];
-    if (mostColumnsPeer != null) {
-      // we will use this peer for batch in SyncChain right after this call
-      this.activeRequestsByPeer.set(mostColumnsPeer.peerInfo.peerId, 1);
-      return mostColumnsPeer.peerInfo;
-    }
-
-    return undefined;
+    return eligiblePeers;
   }
 }

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -1,3 +1,4 @@
+import {fromHexString} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
@@ -8,6 +9,7 @@ import {BlockInput, BlockSource, getBlockInput} from "../../../../src/chain/bloc
 import {ZERO_HASH} from "../../../../src/constants/index.js";
 import {ChainTarget, SyncChain, SyncChainFns} from "../../../../src/sync/range/chain.js";
 import {RangeSyncType} from "../../../../src/sync/utils/remoteSyncType.js";
+import {CustodyConfig} from "../../../../src/util/dataColumns.js";
 import {linspace} from "../../../../src/util/numpy.js";
 import {testLogger} from "../../../utils/logger.js";
 import {validPeerIdStr} from "../../../utils/peer.js";
@@ -56,6 +58,8 @@ describe("sync / range / chain", () => {
   const REJECT_BLOCK = Buffer.alloc(96, 1);
   const zeroBlockBody = ssz.phase0.BeaconBlockBody.defaultValue();
   const interval: NodeJS.Timeout | null = null;
+  const nodeId = fromHexString("cdbee32dc3c50e9711d22be5565c7e44ff6108af663b2dc5abd2df573d2fa83f");
+  const custodyConfig = new CustodyConfig(nodeId, config, null);
 
   const reportPeer: SyncChainFns["reportPeer"] = () => {};
   const getConnectedPeerSyncMeta: SyncChainFns["getConnectedPeerSyncMeta"] = (peerId) => {
@@ -123,7 +127,7 @@ describe("sync / range / chain", () => {
             reportPeer,
             onEnd,
           }),
-          {config, logger}
+          {config, logger, custodyConfig, metrics: null}
         );
 
         const peers = [peer];
@@ -177,7 +181,7 @@ describe("sync / range / chain", () => {
           getConnectedPeerSyncMeta,
           onEnd,
         }),
-        {config, logger}
+        {config, logger, custodyConfig, metrics: null}
       );
 
       // Add peers after some time

--- a/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
@@ -1,57 +1,190 @@
-import {config} from "@lodestar/config/default";
+import {createChainForkConfig} from "@lodestar/config";
+import {chainConfig} from "@lodestar/config/default";
+import {ZERO_HASH} from "@lodestar/params";
+import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {describe, expect, it} from "vitest";
+import {PeerSyncMeta} from "../../../../../src/network/peers/peersData.js";
 import {Batch} from "../../../../../src/sync/range/batch.js";
-import {ChainPeersBalancer} from "../../../../../src/sync/range/utils/peerBalancer.js";
+import {ChainTarget} from "../../../../../src/sync/range/chain.js";
+import {ChainPeersBalancer, PeerSyncInfo} from "../../../../../src/sync/range/utils/peerBalancer.js";
+import {CustodyConfig} from "../../../../../src/util/dataColumns.js";
+import {PeerIdStr} from "../../../../../src/util/peerId.js";
 import {getRandPeerSyncMeta} from "../../../../utils/peer.js";
 
 describe("sync / range / peerBalancer", () => {
-  it("bestPeerToRetryBatch", async () => {
-    // Run N times to make sure results are consistent with different shufflings
-    for (let i = 0; i < 5; i++) {
-      const peer1 = await getRandPeerSyncMeta();
-      const peer2 = await getRandPeerSyncMeta();
-      const peer3 = await getRandPeerSyncMeta();
-      const batch0 = new Batch(0, config);
-      const batch1 = new Batch(1, config);
+  const custodyConfig = {sampledColumns: [0, 1, 2, 3]} as CustodyConfig;
 
-      // Batch zero has a failedDownloadAttempt with peer0
-      batch0.startDownloading(peer1.peerId);
-      batch0.downloadingError();
+  describe("bestPeerToRetryBatch", async () => {
+    const peer1 = await getRandPeerSyncMeta();
+    const peer2 = await getRandPeerSyncMeta();
+    const peer3 = await getRandPeerSyncMeta();
+    const peers = [peer1, peer2, peer3];
 
-      // peer2 is busy downloading batch1
-      batch1.startDownloading(peer2.peerId);
+    const testCases: {isFulu: boolean; custodyColumns: number[][]; targetEpochs: number[]; expected: PeerIdStr}[] = [
+      {
+        isFulu: true,
+        // peer3 is free and has full custody columns and has the greater target epoch
+        custodyColumns: [[], [0, 1, 2, 3], [0, 1, 2, 3]],
+        targetEpochs: [1, 2, 3],
+        expected: peer3.peerId,
+      },
+      {
+        isFulu: true,
+        // peer3 is free and has partial custody columns (0) and has the greater target epoch
+        custodyColumns: [[], [0, 1, 2, 3], [0]],
+        targetEpochs: [1, 2, 3],
+        expected: peer3.peerId,
+      },
+      {
+        isFulu: true,
+        // peer3 is free and has partial custody columns (3) and has the greater target epoch
+        custodyColumns: [[], [0, 1, 2, 3], [3]],
+        targetEpochs: [1, 2, 3],
+        expected: peer3.peerId,
+      },
+      {
+        isFulu: true,
+        // peer3 is free and has full custody columns, but don't have greater target epoch
+        custodyColumns: [[], [0, 1, 2, 3], [0, 1, 2, 3]],
+        targetEpochs: [1, 2, 0],
+        expected: peer2.peerId,
+      },
+      {
+        isFulu: true,
+        // peer3 is free but don't have any custody columns, have greater target epoch
+        custodyColumns: [[], [0, 1, 2, 3], [4, 5, 6, 7]],
+        targetEpochs: [1, 2, 3],
+        expected: peer2.peerId,
+      },
+      {
+        isFulu: false,
+        // pre-fulu, same to the the above, pick peer3 because it's free
+        custodyColumns: [[], [0, 1, 2, 3], [4, 5, 6, 7]],
+        targetEpochs: [1, 2, 3],
+        expected: peer3.peerId,
+      },
+    ];
+    for (const [i, {isFulu, custodyColumns, targetEpochs, expected}] of testCases.entries()) {
+      it(`test case ${i}`, async () => {
+        const columnsByPeer = new Map<PeerIdStr, {custodyColumns: number[]}>();
+        for (const [i, custody] of custodyColumns.entries()) {
+          columnsByPeer.set(peers[i].peerId, {custodyColumns: custody});
+        }
 
-      const peerBalancer = new ChainPeersBalancer([peer1, peer2, peer3], [batch0, batch1]);
+        const targetByPeer = new Map<PeerIdStr, ChainTarget>();
+        for (const [i, targetEpoch] of targetEpochs.entries()) {
+          targetByPeer.set(peers[i].peerId, {slot: computeStartSlotAtEpoch(targetEpoch), root: ZERO_HASH});
+        }
 
-      expect(peerBalancer.bestPeerToRetryBatch(batch0)?.peerId).toBe(peer3.peerId);
+        const peerInfos: PeerSyncInfo[] = peers.map((p) => ({
+          ...p,
+          custodyGroups: columnsByPeer.get(p.peerId)?.custodyColumns ?? [],
+          target: targetByPeer.get(p.peerId) ?? ({slot: 0, root: ZERO_HASH} as ChainTarget),
+        }));
 
-      batch0.startDownloading(peer3.peerId);
-      batch0.downloadingError();
-      expect(peerBalancer.bestPeerToRetryBatch(batch0)?.peerId).toBe(peer2.peerId);
+        const config = isFulu
+          ? createChainForkConfig({...chainConfig, FULU_FORK_EPOCH: 0})
+          : createChainForkConfig(chainConfig);
+
+        const batch0 = new Batch(1, config);
+        const batch1 = new Batch(2, config);
+
+        // Batch zero has a failedDownloadAttempt with peer1
+        batch0.startDownloading(peer1.peerId);
+        batch0.downloadingError();
+
+        // peer2 is busy downloading batch1
+        batch1.startDownloading(peer2.peerId);
+
+        const peerBalancer = new ChainPeersBalancer(peerInfos, [batch0, batch1], custodyConfig);
+        expect(peerBalancer.bestPeerToRetryBatch(batch0)?.peerId).toBe(expected);
+      });
     }
   });
 
-  it("idlePeers", async () => {
-    // Run N times to make sure results are consistent with different shufflings
-    for (let i = 0; i < 5; i++) {
-      const peer1 = await getRandPeerSyncMeta();
-      const peer2 = await getRandPeerSyncMeta();
-      const peer3 = await getRandPeerSyncMeta();
-      const peer4 = await getRandPeerSyncMeta();
-      const batch0 = new Batch(0, config);
-      const batch1 = new Batch(1, config);
+  describe("idlePeerForBatch", async () => {
+    const peer1 = await getRandPeerSyncMeta();
+    const peer2 = await getRandPeerSyncMeta();
+    const peer3 = await getRandPeerSyncMeta();
+    const peer4 = await getRandPeerSyncMeta();
+    const peers = [peer1, peer2, peer3, peer4];
 
-      // peer1 and peer2 are busy downloading
-      batch0.startDownloading(peer1.peerId);
-      batch1.startDownloading(peer2.peerId);
+    const testCases: {
+      isFulu: boolean;
+      custodyColumns: number[][];
+      targetEpochs: number[];
+      expected: string | undefined;
+    }[] = [
+      {
+        isFulu: true,
+        // peer3 and peer4 are free and have greater target epoch, pick peer3 because it has more custody columns
+        custodyColumns: [[], [], [0, 1, 2, 3], [0]],
+        targetEpochs: [1, 2, 4, 4],
+        expected: peer3.peerId,
+      },
+      {
+        isFulu: true,
+        // peer3 and peer4 are free, peer3 does not have greater epoch, peer4 has full custody columns, pick peer4
+        custodyColumns: [[], [], [0, 1, 2, 3], [0, 1, 2, 3]],
+        targetEpochs: [1, 2, 2, 4],
+        expected: peer4.peerId,
+      },
+      {
+        isFulu: true,
+        // peer3 and peer4 are free, peer3 does not have greater epoch, peer4 has partial custody columns, pick peer4
+        custodyColumns: [[], [], [0, 1, 2, 3], [3]],
+        targetEpochs: [1, 2, 2, 4],
+        expected: peer4.peerId,
+      },
+      {
+        isFulu: true,
+        // peer3 and peer4 are free, peer3 does not have greater epoch, peer4 does not have custody columns we need, pick nothing
+        custodyColumns: [[], [], [0, 1, 2, 3], []],
+        targetEpochs: [1, 2, 2, 4],
+        expected: undefined,
+      },
+      {
+        isFulu: false,
+        // pre-fulu, same to the above, pick peer4 because we don't care about custody columns
+        custodyColumns: [[], [], [0, 1, 2, 3], []],
+        targetEpochs: [1, 2, 2, 4],
+        expected: peer4.peerId,
+      },
+    ];
 
-      const peerBalancer = new ChainPeersBalancer([peer1, peer2, peer3, peer4], [batch0, batch1]);
+    for (const [i, {isFulu, custodyColumns, targetEpochs, expected}] of testCases.entries()) {
+      it(`test case ${i}`, async () => {
+        const columnsByPeer = new Map<PeerIdStr, {custodyColumns: number[]}>();
+        for (const [i, custody] of custodyColumns.entries()) {
+          columnsByPeer.set(peers[i].peerId, {custodyColumns: custody});
+        }
 
-      const idlePeers = peerBalancer.idlePeers();
+        const targetByPeer = new Map<PeerIdStr, ChainTarget>();
+        for (const [i, targetEpoch] of targetEpochs.entries()) {
+          targetByPeer.set(peers[i].peerId, {slot: computeStartSlotAtEpoch(targetEpoch), root: ZERO_HASH});
+        }
 
-      const idlePeersIds = idlePeers.map((p) => p.peerId.toString()).sort();
-      const expectedIds = [peer3, peer4].map((p) => p.peerId.toString()).sort();
-      expect(idlePeersIds).toEqual(expectedIds);
+        const peerInfos: PeerSyncInfo[] = peers.map((p) => ({
+          ...p,
+          custodyGroups: columnsByPeer.get(p.peerId)?.custodyColumns ?? [],
+          target: targetByPeer.get(p.peerId) ?? {slot: 0, root: ZERO_HASH},
+        }));
+
+        const config = isFulu
+          ? createChainForkConfig({...chainConfig, FULU_FORK_EPOCH: 0})
+          : createChainForkConfig(chainConfig);
+
+        const batch0 = new Batch(1, config);
+        const batch1 = new Batch(2, config);
+        // peer1 and peer2 are busy downloading
+        batch0.startDownloading(peer1.peerId);
+        batch1.startDownloading(peer2.peerId);
+
+        const newBatch = new Batch(3, config);
+        const peerBalancer = new ChainPeersBalancer(peerInfos, [batch0, batch1], custodyConfig);
+        const idlePeer = peerBalancer.idlePeerForBatch(newBatch);
+        expect(idlePeer?.peerId).toBe(expected);
+      });
     }
   });
 });

--- a/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
@@ -3,7 +3,6 @@ import {chainConfig} from "@lodestar/config/default";
 import {ZERO_HASH} from "@lodestar/params";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {describe, expect, it} from "vitest";
-import {PeerSyncMeta} from "../../../../../src/network/peers/peersData.js";
 import {Batch} from "../../../../../src/sync/range/batch.js";
 import {ChainTarget} from "../../../../../src/sync/range/chain.js";
 import {ChainPeersBalancer, PeerSyncInfo} from "../../../../../src/sync/range/utils/peerBalancer.js";

--- a/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
@@ -21,7 +21,13 @@ describe("sync / range / peerBalancer", () => {
     const peer4 = await getRandPeerSyncMeta("peer-4");
     const peers = [peer1, peer2, peer3, peer4];
 
-    const testCases: {isFulu: boolean; custodyColumns: number[][]; targetEpochs: number[]; expected: PeerIdStr}[] = [
+    const testCases: {
+      isFulu: boolean;
+      custodyColumns: number[][];
+      targetEpochs: number[];
+      earliestAvailableSlots: (number | undefined | null)[];
+      expected: PeerIdStr;
+    }[] = [
       {
         isFulu: true,
         // peer3 and peer 4 are free and has some/all custody columns and has the greater target epoch
@@ -29,6 +35,7 @@ describe("sync / range / peerBalancer", () => {
         // test column sort condition
         custodyColumns: [[], [0, 1], [0, 1, 2, 3]],
         targetEpochs: [1, 2, 3, 4],
+        earliestAvailableSlots: [0, 0, 0, 0],
         expected: peer3.peerId,
       },
       {
@@ -38,6 +45,7 @@ describe("sync / range / peerBalancer", () => {
         // test target epoch condition
         custodyColumns: [[], [0, 1, 2, 3], [0], [100]],
         targetEpochs: [1, 2, 3, 4],
+        earliestAvailableSlots: [0, 0, 0, 0],
         expected: peer3.peerId,
       },
       {
@@ -47,28 +55,48 @@ describe("sync / range / peerBalancer", () => {
         // test target epoch condition
         custodyColumns: [[], [0, 1, 2, 3], [0, 1, 2, 3], [100]],
         targetEpochs: [1, 2, 0, 4],
+        earliestAvailableSlots: [0, 0, 0, 0],
         expected: peer2.peerId,
       },
       {
         isFulu: true,
-        // peer3 is free but don't have any custody columns, have greater target epoch
+        // peer3 is free but don't have any custody columns
         // peer 4 has unrelated custody column
         // test custody columns condition
         custodyColumns: [[], [0, 1, 2, 3], [4, 5, 6, 7], [100]],
         targetEpochs: [1, 2, 3, 4],
+        earliestAvailableSlots: [0, 0, 0, 0],
         expected: peer2.peerId,
       },
       {
+        isFulu: true,
+        // peer3 and peer4 are free but peer4 has more clumns
+        // test custody columns condition
+        custodyColumns: [[], [0, 1, 2, 3], [2, 3, 4, 5], [1, 2, 3, 4]],
+        targetEpochs: [1, 2, 3, 4],
+        earliestAvailableSlots: [0, 0, 0, 0],
+        expected: peer4.peerId,
+      },
+      {
+        isFulu: true,
+        // peer3 is free and has all columns but pick peer4 because it has earliestAvailableSlot
+        // test earliestAvailableSlots condition
+        custodyColumns: [[], [0, 1, 2, 3], [0, 1, 2, 3], [0]],
+        targetEpochs: [1, 2, 3, 4],
+        earliestAvailableSlots: [0, 0, undefined, 0],
+        expected: peer4.peerId,
+      },
+      {
         isFulu: false,
-        // pre-fulu, same to the the above, pick peer3 because it's free
-        // this test case could pick either peer3 or peer4
+        // pre-fulu, same to the the above, pick peer3 because has good target epoch
         // test pre-fulu condition
         custodyColumns: [[], [0, 1, 2, 3], [4, 5, 6, 7], [100]],
-        targetEpochs: [1, 2, 3],
+        targetEpochs: [1, 2, 3, 0],
+        earliestAvailableSlots: [null, null, null, null],
         expected: peer3.peerId,
       },
     ];
-    for (const [i, {isFulu, custodyColumns, targetEpochs, expected}] of testCases.entries()) {
+    for (const [i, {isFulu, custodyColumns, targetEpochs, earliestAvailableSlots, expected}] of testCases.entries()) {
       it(`test case ${i}`, async () => {
         const columnsByPeer = new Map<PeerIdStr, {custodyColumns: number[]}>();
         for (const [i, custody] of custodyColumns.entries()) {
@@ -80,10 +108,16 @@ describe("sync / range / peerBalancer", () => {
           targetByPeer.set(peers[i].peerId, {slot: computeStartSlotAtEpoch(targetEpoch), root: ZERO_HASH});
         }
 
+        const earliestAvailableSlotByPeers = new Map<PeerIdStr, number | undefined | null>();
+        for (const [i, earliestAvailableSlot] of earliestAvailableSlots.entries()) {
+          earliestAvailableSlotByPeers.set(peers[i].peerId, earliestAvailableSlot);
+        }
+
         const peerInfos: PeerSyncInfo[] = peers.map((p) => ({
           ...p,
           custodyGroups: columnsByPeer.get(p.peerId)?.custodyColumns ?? [],
           target: targetByPeer.get(p.peerId) ?? ({slot: 0, root: ZERO_HASH} as ChainTarget),
+          earliestAvailableSlot: earliestAvailableSlotByPeers.get(p.peerId) ?? undefined,
         }));
 
         const config = isFulu
@@ -117,6 +151,7 @@ describe("sync / range / peerBalancer", () => {
       isFulu: boolean;
       custodyColumns: number[][];
       targetEpochs: number[];
+      earliestAvailableSlots: (number | undefined | null)[];
       expected: string | undefined;
     }[] = [
       {
@@ -124,13 +159,23 @@ describe("sync / range / peerBalancer", () => {
         // peer3 and peer4 are free and have greater target epoch, pick peer3 because it has more custody columns
         custodyColumns: [[], [], [0, 1, 2, 3], [0]],
         targetEpochs: [1, 2, 4, 4],
+        earliestAvailableSlots: [0, 0, 0, 0],
         expected: peer3.peerId,
+      },
+      {
+        isFulu: true,
+        // peer3 and peer4 are free and have greater target epoch, pick peer4 because it available slots
+        custodyColumns: [[], [], [0, 1, 2, 3], [0]],
+        targetEpochs: [1, 2, 4, 4],
+        earliestAvailableSlots: [0, 0, undefined, 0],
+        expected: peer4.peerId,
       },
       {
         isFulu: true,
         // peer3 and peer4 are free, peer3 does not have greater epoch, peer4 has full custody columns, pick peer4
         custodyColumns: [[], [], [0, 1, 2, 3], [0, 1, 2, 3]],
         targetEpochs: [1, 2, 2, 4],
+        earliestAvailableSlots: [0, 0, 0, 0],
         expected: peer4.peerId,
       },
       {
@@ -138,6 +183,7 @@ describe("sync / range / peerBalancer", () => {
         // peer3 and peer4 are free, peer3 does not have greater epoch, peer4 has partial custody columns, pick peer4
         custodyColumns: [[], [], [0, 1, 2, 3], [3]],
         targetEpochs: [1, 2, 2, 4],
+        earliestAvailableSlots: [0, 0, 0, 0],
         expected: peer4.peerId,
       },
       {
@@ -145,6 +191,7 @@ describe("sync / range / peerBalancer", () => {
         // peer3 and peer4 are free, peer3 does not have greater epoch, peer4 does not have custody columns we need, pick nothing
         custodyColumns: [[], [], [0, 1, 2, 3], []],
         targetEpochs: [1, 2, 2, 4],
+        earliestAvailableSlots: [0, 0, 0, 0],
         expected: undefined,
       },
       {
@@ -152,11 +199,12 @@ describe("sync / range / peerBalancer", () => {
         // pre-fulu, same to the above, pick peer4 because we don't care about custody columns
         custodyColumns: [[], [], [0, 1, 2, 3], []],
         targetEpochs: [1, 2, 2, 4],
+        earliestAvailableSlots: [undefined, undefined, undefined, undefined],
         expected: peer4.peerId,
       },
     ];
 
-    for (const [i, {isFulu, custodyColumns, targetEpochs, expected}] of testCases.entries()) {
+    for (const [i, {isFulu, custodyColumns, targetEpochs, earliestAvailableSlots, expected}] of testCases.entries()) {
       it(`test case ${i}`, async () => {
         const columnsByPeer = new Map<PeerIdStr, {custodyColumns: number[]}>();
         for (const [i, custody] of custodyColumns.entries()) {
@@ -168,10 +216,16 @@ describe("sync / range / peerBalancer", () => {
           targetByPeer.set(peers[i].peerId, {slot: computeStartSlotAtEpoch(targetEpoch), root: ZERO_HASH});
         }
 
+        const earliestAvailableSlotByPeers = new Map<PeerIdStr, number | undefined | null>();
+        for (const [i, earliestAvailableSlot] of earliestAvailableSlots.entries()) {
+          earliestAvailableSlotByPeers.set(peers[i].peerId, earliestAvailableSlot);
+        }
+
         const peerInfos: PeerSyncInfo[] = peers.map((p) => ({
           ...p,
           custodyGroups: columnsByPeer.get(p.peerId)?.custodyColumns ?? [],
           target: targetByPeer.get(p.peerId) ?? {slot: 0, root: ZERO_HASH},
+          earliestAvailableSlot: earliestAvailableSlotByPeers.get(p.peerId) ?? undefined,
         }));
 
         const config = isFulu

--- a/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
@@ -15,51 +15,55 @@ describe("sync / range / peerBalancer", () => {
   const custodyConfig = {sampledColumns: [0, 1, 2, 3]} as CustodyConfig;
 
   describe("bestPeerToRetryBatch", async () => {
-    const peer1 = await getRandPeerSyncMeta();
-    const peer2 = await getRandPeerSyncMeta();
-    const peer3 = await getRandPeerSyncMeta();
-    const peers = [peer1, peer2, peer3];
+    const peer1 = await getRandPeerSyncMeta("peer-1");
+    const peer2 = await getRandPeerSyncMeta("peer-2");
+    const peer3 = await getRandPeerSyncMeta("peer-3");
+    const peer4 = await getRandPeerSyncMeta("peer-4");
+    const peers = [peer1, peer2, peer3, peer4];
 
     const testCases: {isFulu: boolean; custodyColumns: number[][]; targetEpochs: number[]; expected: PeerIdStr}[] = [
       {
         isFulu: true,
-        // peer3 is free and has full custody columns and has the greater target epoch
-        custodyColumns: [[], [0, 1, 2, 3], [0, 1, 2, 3]],
-        targetEpochs: [1, 2, 3],
+        // peer3 and peer 4 are free and has some/all custody columns and has the greater target epoch
+        // pick peer4 because it has more custody columns
+        // test column sort condition
+        custodyColumns: [[], [0, 1], [0, 1, 2, 3]],
+        targetEpochs: [1, 2, 3, 4],
         expected: peer3.peerId,
       },
       {
         isFulu: true,
         // peer3 is free and has partial custody columns (0) and has the greater target epoch
-        custodyColumns: [[], [0, 1, 2, 3], [0]],
-        targetEpochs: [1, 2, 3],
-        expected: peer3.peerId,
-      },
-      {
-        isFulu: true,
-        // peer3 is free and has partial custody columns (3) and has the greater target epoch
-        custodyColumns: [[], [0, 1, 2, 3], [3]],
-        targetEpochs: [1, 2, 3],
+        // peer 4 has unrelated custody column
+        // test target epoch condition
+        custodyColumns: [[], [0, 1, 2, 3], [0], [100]],
+        targetEpochs: [1, 2, 3, 4],
         expected: peer3.peerId,
       },
       {
         isFulu: true,
         // peer3 is free and has full custody columns, but don't have greater target epoch
-        custodyColumns: [[], [0, 1, 2, 3], [0, 1, 2, 3]],
-        targetEpochs: [1, 2, 0],
+        // peer 4 has unrelated custody column
+        // test target epoch condition
+        custodyColumns: [[], [0, 1, 2, 3], [0, 1, 2, 3], [100]],
+        targetEpochs: [1, 2, 0, 4],
         expected: peer2.peerId,
       },
       {
         isFulu: true,
         // peer3 is free but don't have any custody columns, have greater target epoch
-        custodyColumns: [[], [0, 1, 2, 3], [4, 5, 6, 7]],
-        targetEpochs: [1, 2, 3],
+        // peer 4 has unrelated custody column
+        // test custody columns condition
+        custodyColumns: [[], [0, 1, 2, 3], [4, 5, 6, 7], [100]],
+        targetEpochs: [1, 2, 3, 4],
         expected: peer2.peerId,
       },
       {
         isFulu: false,
         // pre-fulu, same to the the above, pick peer3 because it's free
-        custodyColumns: [[], [0, 1, 2, 3], [4, 5, 6, 7]],
+        // this test case could pick either peer3 or peer4
+        // test pre-fulu condition
+        custodyColumns: [[], [0, 1, 2, 3], [4, 5, 6, 7], [100]],
         targetEpochs: [1, 2, 3],
         expected: peer3.peerId,
       },
@@ -103,10 +107,10 @@ describe("sync / range / peerBalancer", () => {
   });
 
   describe("idlePeerForBatch", async () => {
-    const peer1 = await getRandPeerSyncMeta();
-    const peer2 = await getRandPeerSyncMeta();
-    const peer3 = await getRandPeerSyncMeta();
-    const peer4 = await getRandPeerSyncMeta();
+    const peer1 = await getRandPeerSyncMeta("peer-1");
+    const peer2 = await getRandPeerSyncMeta("peer-2");
+    const peer3 = await getRandPeerSyncMeta("peer-3");
+    const peer4 = await getRandPeerSyncMeta("peer-4");
     const peers = [peer1, peer2, peer3, peer4];
 
     const testCases: {

--- a/packages/beacon-node/test/utils/peer.ts
+++ b/packages/beacon-node/test/utils/peer.ts
@@ -17,9 +17,9 @@ export async function getRandPeerIdStr(): Promise<string> {
   return peerIdToString(peerIdFromPrivateKey(await generateKeyPair("secp256k1")));
 }
 
-export async function getRandPeerSyncMeta(): Promise<PeerSyncMeta> {
+export async function getRandPeerSyncMeta(peerId?: string): Promise<PeerSyncMeta> {
   return {
-    peerId: await getRandPeerIdStr(),
+    peerId: peerId ?? (await getRandPeerIdStr()),
     client: "PEER_CLIENT",
     custodyGroups: [],
     earliestAvailableSlot: 0,


### PR DESCRIPTION
**Motivation**

- stablize range sync and add metrics to it

**Description**

- should not do a range sync with peer that has lower target slot than the one in batch
- post fulu, we care about custody columns to pick a good peers
- post fulu, we prefer peers with earliest_available_slot defined
- switch from the most common target to highest target, see [this](https://discord.com/channels/593655374469660673/1229813597501395028/1364874368219611196) for more context
- more metrics: how many peers per column in SyncChain
- more unit tests for PeerBalancer

**Testing**

- [x] synced from a stopped mainnet node
- [ ] waiting for `peerdas-devnet-7` to test