### PR TITLE
fix: peerDAS - Fix name of `custody_group_count` in Fulu metadata

### DIFF
--- a/packages/api/src/beacon/routes/node.ts
+++ b/packages/api/src/beacon/routes/node.ts
@@ -1,6 +1,6 @@
 import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {ssz, stringType} from "@lodestar/types";
+import {ssz, stringType, fulu} from "@lodestar/types";
 import {
   ArrayOf,
   EmptyArgs,
@@ -24,8 +24,9 @@ export const NetworkIdentityType = new ContainerType(
     enr: stringType,
     p2pAddresses: ArrayOf(stringType),
     discoveryAddresses: ArrayOf(stringType),
+    // TODO Fulu: replace with `ssz.fulu.Metadata` once `custody_group_count` is more widely supported
     /** Based on Ethereum Consensus [Metadata object](https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#metadata) */
-    metadata: ssz.fulu.Metadata,
+    metadata: ssz.altair.Metadata,
   },
   {jsonCase: "eth2"}
 );
@@ -56,7 +57,9 @@ export const SyncingStatusType = new ContainerType(
   {jsonCase: "eth2"}
 );
 
-export type NetworkIdentity = ValueOf<typeof NetworkIdentityType>;
+export type NetworkIdentity = ValueOf<typeof NetworkIdentityType> & {
+  metadata: Partial<fulu.Metadata>;
+};
 
 export type PeerState = "disconnected" | "connecting" | "connected" | "disconnecting";
 export type PeerDirection = "inbound" | "outbound";
@@ -190,7 +193,23 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       req: EmptyRequestCodec,
       resp: {
         onlySupport: WireFormat.json,
-        data: NetworkIdentityType,
+        // TODO Fulu: clean this up
+        data: {
+          ...JsonOnlyResponseCodec.data,
+          toJson: (data) => {
+            const json = NetworkIdentityType.toJson(data);
+            (json as {metadata: {custody_group_count: number | undefined}}).metadata.custody_group_count =
+              data.metadata.custodyGroupCount;
+            return json;
+          },
+          fromJson: (json) => {
+            const data = NetworkIdentityType.fromJson(json);
+            (data.metadata as Partial<fulu.Metadata>).custodyGroupCount = (
+              json as {metadata: {custody_group_count: number | undefined}}
+            ).metadata.custody_group_count;
+            return data;
+          },
+        },
         meta: EmptyMetaCodec,
       },
     },

--- a/packages/api/src/beacon/routes/node.ts
+++ b/packages/api/src/beacon/routes/node.ts
@@ -1,6 +1,6 @@
 import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {ssz, stringType, fulu} from "@lodestar/types";
+import {fulu, ssz, stringType} from "@lodestar/types";
 import {
   ArrayOf,
   EmptyArgs,

--- a/packages/api/src/beacon/routes/node.ts
+++ b/packages/api/src/beacon/routes/node.ts
@@ -25,7 +25,7 @@ export const NetworkIdentityType = new ContainerType(
     p2pAddresses: ArrayOf(stringType),
     discoveryAddresses: ArrayOf(stringType),
     /** Based on Ethereum Consensus [Metadata object](https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#metadata) */
-    metadata: ssz.altair.Metadata,
+    metadata: ssz.fulu.Metadata,
   },
   {jsonCase: "eth2"}
 );

--- a/packages/api/test/unit/beacon/testData/node.ts
+++ b/packages/api/test/unit/beacon/testData/node.ts
@@ -20,7 +20,7 @@ export const testData: GenericServerTestCases<Endpoints> = {
         enr: "enr",
         p2pAddresses: ["p2pAddresses"],
         discoveryAddresses: ["discoveryAddresses"],
-        metadata: ssz.altair.Metadata.defaultValue(),
+        metadata: ssz.fulu.Metadata.defaultValue(),
       },
     },
   },

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -365,7 +365,7 @@ export class NetworkCore implements INetworkCore {
 
   async setAdvertisedGroupCount(count: number): Promise<void> {
     this.networkConfig.setAdvertisedGroupCount(count);
-    this.metadata.cgc = count;
+    this.metadata.custodyGroupCount = count;
   }
 
   // REST API queries

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -44,7 +44,7 @@ export class MetadataController {
     this.onSetValue = modules.onSetValue;
     this._metadata = opts.metadata ?? {
       ...ssz.fulu.Metadata.defaultValue(),
-      cgc: modules.networkConfig.getCustodyConfig().advertisedCustodyGroupCount,
+      custodyGroupCount: modules.networkConfig.getCustodyConfig().advertisedCustodyGroupCount,
     };
   }
 
@@ -63,7 +63,7 @@ export class MetadataController {
     }
 
     // Set CGC regardless of fork. It may be useful to clients before Fulu, and will be ignored otherwise.
-    this.onSetValue(ENRKey.cgc, serializeCgc(this._metadata.cgc));
+    this.onSetValue(ENRKey.cgc, serializeCgc(this._metadata.custodyGroupCount));
   }
 
   get seqNumber(): bigint {
@@ -89,16 +89,16 @@ export class MetadataController {
     this._metadata.attnets = attnets;
   }
 
-  get cgc(): number {
-    return this._metadata.cgc;
+  get custodyGroupCount(): number {
+    return this._metadata.custodyGroupCount;
   }
 
-  set cgc(cgc: number) {
-    if (cgc === this._metadata.cgc) {
+  set custodyGroupCount(custodyGroupCount: number) {
+    if (custodyGroupCount === this._metadata.custodyGroupCount) {
       return;
     }
-    this.onSetValue(ENRKey.cgc, serializeCgc(cgc));
-    this._metadata.cgc = cgc;
+    this.onSetValue(ENRKey.cgc, serializeCgc(custodyGroupCount));
+    this._metadata.custodyGroupCount = custodyGroupCount;
   }
 
   /** Consumers that need the phase0.Metadata type can just ignore the .syncnets property */

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -173,7 +173,7 @@ describe("data serialization through worker boundary", () => {
       enr: "test-enr",
       p2pAddresses: ["/ip4/1.2.3.4/tcp/0"],
       discoveryAddresses: ["/ip4/1.2.3.4/tcp/0"],
-      metadata: ssz.altair.Metadata.defaultValue(),
+      metadata: ssz.fulu.Metadata.defaultValue(),
     },
     subscribeGossipCoreTopics: null,
     unsubscribeGossipCoreTopics: null,

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -188,13 +188,13 @@ describe("network / peers / PeerManager", () => {
 
     // Simulate peer1 returning a PING and STATUS message
     const remoteStatus = statusCache.get();
-    const cgc = config.CUSTODY_REQUIREMENT;
+    const custodyGroupCount = config.CUSTODY_REQUIREMENT;
     const remoteMetadata: NonNullable<ReturnType<PeerManager["connectedPeers"]["get"]>>["metadata"] = {
       seqNumber: BigInt(1),
       attnets: getAttnets(),
       syncnets: getSyncnets(),
-      cgc,
-      custodyGroups: getCustodyGroups(computeNodeId(peerId1), cgc),
+      custodyGroupCount,
+      custodyGroups: getCustodyGroups(computeNodeId(peerId1), custodyGroupCount),
     };
     reqResp.sendPing.mockResolvedValue(remoteMetadata.seqNumber);
     reqResp.sendStatus.mockResolvedValue(remoteStatus);

--- a/packages/beacon-node/test/unit/network/metadata.test.ts
+++ b/packages/beacon-node/test/unit/network/metadata.test.ts
@@ -54,7 +54,7 @@ describe("network / metadata", () => {
       const onSetValue = vi.fn();
       const networkConfig = new NetworkConfig(getValidPeerId(), config);
       const metadata = new MetadataController({}, {onSetValue, networkConfig});
-      metadata.cgc = 128;
+      metadata.custodyGroupCount = 128;
       expect(onSetValue).toHaveBeenCalledWith(ENRKey.cgc, serializeCgc(128));
     });
   });

--- a/packages/types/src/fulu/sszTypes.ts
+++ b/packages/types/src/fulu/sszTypes.ts
@@ -22,7 +22,7 @@ export const Blob = denebSsz.Blob;
 export const Metadata = new ContainerType(
   {
     ...altariSsz.Metadata.fields,
-    cgc: UintNum64,
+    custodyGroupCount: UintNum64,
   },
   {typeName: "Metadata", jsonCase: "eth2"}
 );


### PR DESCRIPTION
**Motivation**

I was updating the beacon API to include custody group count when I noticed that the metadata field should be named `custody_group_count`, not `cgc` (unlike the ENR).

* https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/p2p-interface.md#metadata
* https://github.com/ethereum/beacon-APIs/blob/2b1d7b5ac4756881bd29e7adacc9b7032343d981/types/p2p.yaml#L39

<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**

* Updated `/eth/v1/node/identity` to return Fulu metadata
* Renamed `cgc` to `custodyGroupCount` in Metadata