### PR TITLE
fix: increment seq_number on metadata cgc changes

### DIFF
--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -98,6 +98,7 @@ export class MetadataController {
       return;
     }
     this.onSetValue(ENRKey.cgc, serializeCgc(custodyGroupCount));
+    this._metadata.seqNumber++;
     this._metadata.custodyGroupCount = custodyGroupCount;
   }
 

--- a/packages/beacon-node/test/unit/network/metadata.test.ts
+++ b/packages/beacon-node/test/unit/network/metadata.test.ts
@@ -57,5 +57,24 @@ describe("network / metadata", () => {
       metadata.custodyGroupCount = 128;
       expect(onSetValue).toHaveBeenCalledWith(ENRKey.cgc, serializeCgc(128));
     });
+
+    it("should increment seqNumber when cgc is updated", () => {
+      const onSetValue = vi.fn();
+      const networkConfig = new NetworkConfig(getValidPeerId(), config);
+      const metadata = new MetadataController({}, {onSetValue, networkConfig});
+      const initialSeqNumber = metadata.seqNumber;
+      metadata.custodyGroupCount = 128;
+      expect(metadata.seqNumber).toBe(initialSeqNumber + 1n);
+    });
+
+    it("should not increment seqNumber when cgc is set to the same value", () => {
+      const onSetValue = vi.fn();
+      const networkConfig = new NetworkConfig(getValidPeerId(), config);
+      const metadata = new MetadataController({}, {onSetValue, networkConfig});
+      metadata.custodyGroupCount = 128;
+      const initialSeqNumber = metadata.seqNumber;
+      metadata.custodyGroupCount = 128;
+      expect(metadata.seqNumber).toBe(initialSeqNumber);
+    });
   });
 });


### PR DESCRIPTION
**Motivation**

phase0 spec states that `seq_number` should be incremented by 1 whenever any other field in metadata changes: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#metadata

**Description**

increment seq_number when the metadata cgc field changes

