### PR TITLE
chore: revert "fix: wrap libp2p stop call with a timeout (#6062)"

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -8,7 +8,7 @@ import type {LoggerNode} from "@lodestar/logger/node";
 import {ForkName} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {Epoch, phase0} from "@lodestar/types";
-import {fromHex, withTimeout} from "@lodestar/utils";
+import {fromHex} from "@lodestar/utils";
 import {multiaddr} from "@multiformats/multiaddr";
 import {formatNodePeer} from "../../api/impl/node/utils.js";
 import {RegistryMetricCreator} from "../../metrics/index.js";
@@ -266,10 +266,7 @@ export class NetworkCore implements INetworkCore {
     this.logger.debug("network reqResp closed");
     this.attnetsService.close();
     this.syncnetsService.close();
-    // In some cases, `libp2p.stop` never resolves, it is required
-    // to wrap the call with a timeout to allow for a timely shutdown
-    // See https://github.com/ChainSafe/lodestar/issues/6053
-    await withTimeout(async () => this.libp2p.stop(), 5000);
+    await this.libp2p.stop();
     this.logger.debug("network lib2p closed");
 
     this.closed = true;


### PR DESCRIPTION
**Motivation**

https://github.com/ChainSafe/lodestar/issues/6053 is no longer an issue, we can remove the workaround

**Description**

Revert "fix: wrap libp2p stop call with a timeout (#6062)"
