### PR TITLE
chore: remove workarounds no longer needed

### DIFF
--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -138,18 +138,6 @@ export class RestApiServer {
       const operationId = getOperationId(req);
       this.logger.debug(`Req ${req.id} ${req.ip} ${operationId}`);
       metrics?.requests.inc({operationId});
-
-      // Workaround to fix compatibility with go-eth2-client
-      // See https://github.com/attestantio/go-eth2-client/issues/144
-      if (
-        // go-eth2-client supports handling SSZ data in response for these endpoints
-        !["produceBlockV3", "getBlockV2", "getStateV2"].includes(operationId) &&
-        // Only Vouch seems to override default header
-        ["go-eth2-client", "Go-http-client", "Vouch"].includes(req.headers["user-agent"]?.split("/")[0] ?? "")
-      ) {
-        // Override Accept header to force server to return JSON
-        req.headers.accept = "application/json";
-      }
     });
 
     server.addHook("preHandler", async (req, _res) => {

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import {ENR} from "@chainsafe/enr";
-import {HttpHeader, MediaType, WireFormat, getClient} from "@lodestar/api";
+import {WireFormat, getClient} from "@lodestar/api";
 import {getStateSlotFromBytes} from "@lodestar/beacon-node";
 import {ChainConfig, ChainForkConfig} from "@lodestar/config";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -10,7 +10,7 @@ import {
   getLatestBlockRoot,
   loadState,
 } from "@lodestar/state-transition";
-import {Slot} from "@lodestar/types";
+import {Slot, sszTypesFor} from "@lodestar/types";
 import {Checkpoint} from "@lodestar/types/phase0";
 import {Logger, callFnWhenAwait, formatBytes, fromHex} from "@lodestar/utils";
 import {fetch} from "@lodestar/utils";
@@ -173,38 +173,26 @@ export async function fetchWeakSubjectivityState(
     }
 
     // getStateV2 should be available for all forks including phase0
-    const getStatePromise = api.debug.getStateV2(
-      {stateId},
-      {
-        responseWireFormat: WireFormat.ssz,
-        headers: {
-          // Set Accept header explicitly to fix Checkpointz incompatibility
-          // See https://github.com/ethpandaops/checkpointz/issues/165
-          [HttpHeader.Accept]: MediaType.ssz,
-        },
-      }
-    );
+    const getStatePromise = api.debug.getStateV2({stateId}, {responseWireFormat: WireFormat.ssz});
 
-    const wsStateBytes = await callFnWhenAwait(
+    const {wsStateBytes, fork} = await callFnWhenAwait(
       getStatePromise,
       () => logger.info("Download in progress, please wait..."),
       GET_STATE_LOG_INTERVAL
     ).then((res) => {
-      return res.ssz();
+      return {wsStateBytes: res.ssz(), fork: res.meta().version};
     });
 
     const wsSlot = getStateSlotFromBytes(wsStateBytes);
     const logData = {stateId, size: formatBytes(wsStateBytes.length)};
     logger.info("Download completed", typeof stateId === "number" ? logData : {...logData, slot: wsSlot});
-    // It should not be required to get fork type from bytes but Checkpointz does not return
-    // Eth-Consensus-Version header, see https://github.com/ethpandaops/checkpointz/issues/164
+
     let wsState: BeaconStateAllForks;
     if (lastDbState && lastDbValidatorsBytes) {
       // use lastDbState to load wsState if possible to share the same state tree
       wsState = loadState(config, lastDbState, wsStateBytes, lastDbValidatorsBytes).state;
     } else {
-      const stateType = config.getForkTypes(wsSlot).BeaconState;
-      wsState = stateType.deserializeToViewDU(wsStateBytes);
+      wsState = sszTypesFor(fork).BeaconState.deserializeToViewDU(wsStateBytes);
     }
 
     return {


### PR DESCRIPTION
**Motivation**

Part of https://github.com/ChainSafe/lodestar/issues/7682, we can safely remove these workarounds in our next release as we can be sure all dependent software has been updated after Pectra hard fork on mainnet.

**Description**

- Remove workaround for go-eth2-client, reverts https://github.com/ChainSafe/lodestar/pull/6953
- Remove workaround fetching state from checkpointz, partially reverts https://github.com/ChainSafe/lodestar/pull/6874 

