### PR TITLE
chore: use v2 attestation apis even pre-electra

### DIFF
--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -1,6 +1,6 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkPreElectra, ForkSeq} from "@lodestar/params";
+import {ForkSeq} from "@lodestar/params";
 import {computeEpochAtSlot, isAggregatorFromCommitteeLength} from "@lodestar/state-transition";
 import {BLSSignature, SignedAggregateAndProof, SingleAttestation, Slot, phase0, ssz} from "@lodestar/types";
 import {prettyBytes, sleep, toRootHex} from "@lodestar/utils";

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -196,11 +196,10 @@ export class AttestationService {
     const signedAttestations: SingleAttestation[] = [];
     const headRootHex = toRootHex(attestationNoCommittee.beaconBlockRoot);
     const currentEpoch = computeEpochAtSlot(slot);
-    const isPostElectra = currentEpoch >= this.config.ELECTRA_FORK_EPOCH;
 
     await Promise.all(
       duties.map(async ({duty}) => {
-        const index = isPostElectra ? 0 : duty.committeeIndex;
+        const index = currentEpoch >= this.config.ELECTRA_FORK_EPOCH ? 0 : duty.committeeIndex;
         const attestationData: phase0.AttestationData = {...attestationNoCommittee, index};
         const logCtxValidator = {slot, index, head: headRootHex, validatorIndex: duty.validatorIndex};
 
@@ -236,15 +235,7 @@ export class AttestationService {
       ...(this.opts?.disableAttestationGrouping && {index: attestationNoCommittee.index}),
     };
     try {
-      if (isPostElectra) {
-        (await this.api.beacon.submitPoolAttestationsV2({signedAttestations})).assertOk();
-      } else {
-        (
-          await this.api.beacon.submitPoolAttestations({
-            signedAttestations: signedAttestations as SingleAttestation<ForkPreElectra>[],
-          })
-        ).assertOk();
-      }
+      (await this.api.beacon.submitPoolAttestationsV2({signedAttestations})).assertOk();
       this.logger.info("Published attestations", {
         ...logCtx,
         head: prettyBytes(headRootHex),
@@ -274,7 +265,6 @@ export class AttestationService {
     duties: AttDutyAndProof[]
   ): Promise<void> {
     const logCtx = {slot: attestation.slot, index: committeeIndex};
-    const isPostElectra = this.config.getForkSeq(attestation.slot) >= ForkSeq.electra;
 
     // No validator is aggregator, skip
     if (duties.every(({selectionProof}) => selectionProof === null)) {
@@ -282,17 +272,13 @@ export class AttestationService {
     }
 
     this.logger.verbose("Aggregating attestations", logCtx);
-    const res = isPostElectra
-      ? await this.api.validator.getAggregatedAttestationV2({
-          attestationDataRoot: ssz.phase0.AttestationData.hashTreeRoot(attestation),
-          slot: attestation.slot,
-          committeeIndex,
-        })
-      : await this.api.validator.getAggregatedAttestation({
-          attestationDataRoot: ssz.phase0.AttestationData.hashTreeRoot(attestation),
-          slot: attestation.slot,
-        });
-    const aggregate = res.value();
+    const aggregate = (
+      await this.api.validator.getAggregatedAttestationV2({
+        attestationDataRoot: ssz.phase0.AttestationData.hashTreeRoot(attestation),
+        slot: attestation.slot,
+        committeeIndex,
+      })
+    ).value();
     const participants = aggregate.aggregationBits.getTrueBitIndexes().length;
     this.metrics?.numParticipantsInAggregate.observe(participants);
 
@@ -319,11 +305,7 @@ export class AttestationService {
 
     if (signedAggregateAndProofs.length > 0) {
       try {
-        if (isPostElectra) {
-          (await this.api.validator.publishAggregateAndProofsV2({signedAggregateAndProofs})).assertOk();
-        } else {
-          (await this.api.validator.publishAggregateAndProofs({signedAggregateAndProofs})).assertOk();
-        }
+        (await this.api.validator.publishAggregateAndProofsV2({signedAggregateAndProofs})).assertOk();
         this.logger.info("Published aggregateAndProofs", {
           ...logCtx,
           participants,

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -196,10 +196,11 @@ export class AttestationService {
     const signedAttestations: SingleAttestation[] = [];
     const headRootHex = toRootHex(attestationNoCommittee.beaconBlockRoot);
     const currentEpoch = computeEpochAtSlot(slot);
+    const isPostElectra = this.config.getForkSeq(slot) >= ForkSeq.electra;
 
     await Promise.all(
       duties.map(async ({duty}) => {
-        const index = this.config.getForkSeq(slot) >= ForkSeq.electra ? 0 : duty.committeeIndex;
+        const index = isPostElectra ? 0 : duty.committeeIndex;
         const attestationData: phase0.AttestationData = {...attestationNoCommittee, index};
         const logCtxValidator = {slot, index, head: headRootHex, validatorIndex: duty.validatorIndex};
 

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -199,7 +199,7 @@ export class AttestationService {
 
     await Promise.all(
       duties.map(async ({duty}) => {
-        const index = currentEpoch >= this.config.ELECTRA_FORK_EPOCH ? 0 : duty.committeeIndex;
+        const index = this.config.getForkSeq(slot) >= ForkSeq.electra ? 0 : duty.committeeIndex;
         const attestationData: phase0.AttestationData = {...attestationNoCommittee, index};
         const logCtxValidator = {slot, index, head: headRootHex, validatorIndex: duty.validatorIndex};
 

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -119,17 +119,11 @@ describe("AttestationService", () => {
 
         // Mock beacon's attestation and aggregates endpoints
         api.validator.produceAttestationData.mockResolvedValue(mockApiResponse({data: singleAttestation.data}));
-        if (isPostElectra) {
-          api.validator.getAggregatedAttestationV2.mockResolvedValue(
-            mockApiResponse({data: aggregatedAttestation, meta: {version: ForkName.electra}})
-          );
-          api.beacon.submitPoolAttestationsV2.mockResolvedValue(mockApiResponse({}));
-          api.validator.publishAggregateAndProofsV2.mockResolvedValue(mockApiResponse({}));
-        } else {
-          api.validator.getAggregatedAttestation.mockResolvedValue(mockApiResponse({data: aggregatedAttestation}));
-          api.beacon.submitPoolAttestations.mockResolvedValue(mockApiResponse({}));
-          api.validator.publishAggregateAndProofs.mockResolvedValue(mockApiResponse({}));
-        }
+        api.validator.getAggregatedAttestationV2.mockResolvedValue(
+          mockApiResponse({data: aggregatedAttestation, meta: {version: ForkName.electra}})
+        );
+        api.beacon.submitPoolAttestationsV2.mockResolvedValue(mockApiResponse({}));
+        api.validator.publishAggregateAndProofsV2.mockResolvedValue(mockApiResponse({}));
 
         if (opts.distributedAggregationSelection) {
           // Mock distributed validator middleware client selections endpoint
@@ -170,27 +164,15 @@ describe("AttestationService", () => {
           expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledWith({subscriptions: [subscription]});
         }
 
-        if (isPostElectra) {
-          // Must submit the attestation received through produceAttestationData()
-          expect(api.beacon.submitPoolAttestationsV2).toHaveBeenCalledOnce();
-          expect(api.beacon.submitPoolAttestationsV2).toHaveBeenCalledWith({signedAttestations: [singleAttestation]});
+        // Must submit the attestation received through produceAttestationData()
+        expect(api.beacon.submitPoolAttestationsV2).toHaveBeenCalledOnce();
+        expect(api.beacon.submitPoolAttestationsV2).toHaveBeenCalledWith({signedAttestations: [singleAttestation]});
 
-          // Must submit the aggregate received through getAggregatedAttestationV2() then createAndSignAggregateAndProof()
-          expect(api.validator.publishAggregateAndProofsV2).toHaveBeenCalledOnce();
-          expect(api.validator.publishAggregateAndProofsV2).toHaveBeenCalledWith({
-            signedAggregateAndProofs: [aggregateAndProof],
-          });
-        } else {
-          // Must submit the attestation received through produceAttestationData()
-          expect(api.beacon.submitPoolAttestations).toHaveBeenCalledOnce();
-          expect(api.beacon.submitPoolAttestations).toHaveBeenCalledWith({signedAttestations: [singleAttestation]});
-
-          // Must submit the aggregate received through getAggregatedAttestation() then createAndSignAggregateAndProof()
-          expect(api.validator.publishAggregateAndProofs).toHaveBeenCalledOnce();
-          expect(api.validator.publishAggregateAndProofs).toHaveBeenCalledWith({
-            signedAggregateAndProofs: [aggregateAndProof],
-          });
-        }
+        // Must submit the aggregate received through getAggregatedAttestationV2() then createAndSignAggregateAndProof()
+        expect(api.validator.publishAggregateAndProofsV2).toHaveBeenCalledOnce();
+        expect(api.validator.publishAggregateAndProofsV2).toHaveBeenCalledWith({
+          signedAggregateAndProofs: [aggregateAndProof],
+        });
       });
     });
   }


### PR DESCRIPTION
**Motivation**

There is no reason to use v1 attestation apis other than clients not implementing them yet but after Pectra hard fork on mainnet we know that all node operators have updated their software and v2 attestation apis are available, and since those are fork-aware / backward compatible we can even use them pre-electra (although there isn't really a network that runs on Deneb after May 7th).

**Description**

Use v2 attestation apis even pre-electra

Part of https://github.com/ChainSafe/lodestar/issues/7412 and https://github.com/ChainSafe/lodestar/issues/7682