### PR TITLE
fix: genesis sync in peerDAS

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -224,7 +224,7 @@ async function migrateBlobSidecarsFromHotToColdDb(
           return (
             forkSeq >= ForkSeq.deneb &&
             forkSeq < ForkSeq.fulu &&
-            // if block is out of WS period, its blobs was not downloaded so skip this step
+            // if block is out of ${config.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS}, skip this step
             blockEpoch >= currentEpoch - config.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
           );
         })

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -70,7 +70,12 @@ export async function archiveBlocks(
     }
 
     if (finalizedPostFulu) {
-      const migratedEntries = await migrateDataColumnSidecarsFromHotToColdDb(config, db, finalizedCanonicalBlockRoots);
+      const migratedEntries = await migrateDataColumnSidecarsFromHotToColdDb(
+        config,
+        db,
+        finalizedCanonicalBlockRoots,
+        currentEpoch
+      );
       logger.verbose("Migrated dataColumnSidecars from hot DB to cold DB", {migratedEntries});
     }
   }
@@ -251,7 +256,8 @@ async function migrateBlobSidecarsFromHotToColdDb(
 async function migrateDataColumnSidecarsFromHotToColdDb(
   config: ChainForkConfig,
   db: IBeaconDb,
-  blocks: BlockRootSlot[]
+  blocks: BlockRootSlot[],
+  currentEpoch: Epoch
 ): Promise<number> {
   let migratedWrappedDataColumns = 0;
   for (let i = 0; i < blocks.length; i += BLOB_SIDECAR_BATCH_SIZE) {
@@ -264,7 +270,15 @@ async function migrateDataColumnSidecarsFromHotToColdDb(
     // load Buffer instead of ssz deserialized to improve performance
     const canonicalDataColumnSidecarsEntries: KeyValue<Slot, Uint8Array>[] = await Promise.all(
       canonicalBlocks
-        .filter((block) => config.getForkSeq(block.slot) >= ForkSeq.fulu)
+        .filter((block) => {
+          const blockSlot = block.slot;
+          const blockEpoch = computeEpochAtSlot(blockSlot);
+          return (
+            config.getForkSeq(blockSlot) >= ForkSeq.fulu &&
+            // if block is out of ${config.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS}, skip this step
+            blockEpoch >= currentEpoch - config.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
+          );
+        })
         .map(async (block) => {
           const bytes = await db.dataColumnSidecars.getBinary(block.root);
           if (!bytes) {

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -60,7 +60,12 @@ export async function archiveBlocks(
     });
 
     if (finalizedPostDeneb) {
-      const migratedEntries = await migrateBlobSidecarsFromHotToColdDb(config, db, finalizedCanonicalBlockRoots);
+      const migratedEntries = await migrateBlobSidecarsFromHotToColdDb(
+        config,
+        db,
+        finalizedCanonicalBlockRoots,
+        currentEpoch
+      );
       logger.verbose("Migrated blobSidecars from hot DB to cold DB", {migratedEntries});
     }
 
@@ -198,7 +203,8 @@ async function migrateBlocksFromHotToColdDb(db: IBeaconDb, blocks: BlockRootSlot
 async function migrateBlobSidecarsFromHotToColdDb(
   config: ChainForkConfig,
   db: IBeaconDb,
-  blocks: BlockRootSlot[]
+  blocks: BlockRootSlot[],
+  currentEpoch: Epoch
 ): Promise<number> {
   let migratedWrappedBlobSidecars = 0;
   for (let i = 0; i < blocks.length; i += BLOB_SIDECAR_BATCH_SIZE) {
@@ -212,8 +218,15 @@ async function migrateBlobSidecarsFromHotToColdDb(
     const canonicalBlobSidecarsEntries: KeyValue<Slot, Uint8Array>[] = await Promise.all(
       canonicalBlocks
         .filter((block) => {
-          const blkSeq = config.getForkSeq(block.slot);
-          return blkSeq >= ForkSeq.deneb && blkSeq < ForkSeq.fulu;
+          const blockSlot = block.slot;
+          const blockEpoch = computeEpochAtSlot(blockSlot);
+          const forkSeq = config.getForkSeq(blockSlot);
+          return (
+            forkSeq >= ForkSeq.deneb &&
+            forkSeq < ForkSeq.fulu &&
+            // if block is out of WS period, its blobs was not downloaded so skip this step
+            blockEpoch >= currentEpoch - config.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
+          );
         })
         .map(async (block) => {
           const bytes = await db.blobSidecars.getBinary(block.root);

--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -31,6 +31,7 @@ export async function writeBlockInputToDb(this: BeaconChain, blocksInput: BlockI
     this.logger.debug("Persist block to hot DB", {
       slot: block.message.slot,
       root: blockRootHex,
+      inputType: blockInput.type,
     });
 
     if (blockInput.type === BlockInputType.availableData || blockInput.type === BlockInputType.dataPromise) {

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -143,12 +143,15 @@ export async function beaconBlocksMaybeBlobsByRange(
     return {blocks, pendingDataColumns: pendingDataColumns.length > 0 ? pendingDataColumns : null};
   }
 
-  logger?.verbose("Download range is out of WS period, skip Blobs and DataColumnSidecars download", {
-    startSlot,
-    endSlot,
-    startEpoch,
-    currentEpoch,
-  });
+  logger?.verbose(
+    `Download range is out of ${config.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS} epochs, skip Blobs and DataColumnSidecars download`,
+    {
+      startEpoch,
+      startSlot,
+      endSlot,
+      currentEpoch,
+    }
+  );
 
   // Data is out of range, only request blocks
   const blocks = await network.sendBeaconBlocksByRange(peerId, request);

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -143,6 +143,13 @@ export async function beaconBlocksMaybeBlobsByRange(
     return {blocks, pendingDataColumns: pendingDataColumns.length > 0 ? pendingDataColumns : null};
   }
 
+  logger?.verbose("Download range is out of WS period, skip Blobs and DataColumnSidecars download", {
+    startSlot,
+    endSlot,
+    startEpoch,
+    currentEpoch,
+  });
+
   // Data is out of range, only request blocks
   const blocks = await network.sendBeaconBlocksByRange(peerId, request);
   return {


### PR DESCRIPTION
**Motivation**

- right now we cannot sync hoodi using `peerDAS`, this PR fixes it

**Description**

- when `archiveBlocks` if data is out of `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`, no need to archive blobs/data columns
Closes #7754

<img width="1677" alt="Screenshot 2025-04-29 at 09 19 09" src="https://github.com/user-attachments/assets/93b8cb5c-f8ca-42ec-99c2-c81aae3e3004" />
