### PR TITLE
fix(readme): Correct broken LICENSE link to LICENSE-LGPL  

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ yarn build
 ## Architecture Overview
 
 - :package: This mono-repository contains a suite of Ethereum Consensus packages.
-- :balance_scale: The mono-repository is released under [LGPLv3 license](./LICENSE). Note, that the packages contain their own licenses.
+- :balance_scale: The mono-repository is released under [LGPLv3 license](./LICENSE-LGPL). Note, that the packages contain their own licenses.
 
 | Package                                                     | Version                                                                                                                     | License                                                                                                               | Docs                                                                                      | Description                                                                    |
 | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |


### PR DESCRIPTION

**PR Description:**  
This PR fixes a broken link in the README by updating `LICENSE` to `LICENSE-LGPL`, ensuring the license reference properly links to the actual file.  
