### PR TITLE
chore: update 404 block/state error messages to match spec examples

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/utils.ts
@@ -68,7 +68,7 @@ export async function getBlockResponse(
       : await chain.getCanonicalBlockAtSlot(rootOrSlot);
 
   if (!res) {
-    throw new ApiError(404, `No block found for id '${blockId}'`);
+    throw new ApiError(404, `Block not found for id '${blockId}'`);
   }
 
   return res;

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -55,7 +55,7 @@ export async function getStateResponse(
         : chain.getStateByCheckpoint(stateId);
 
   if (!res) {
-    throw new ApiError(404, `No state found for id '${inStateId}'`);
+    throw new ApiError(404, `State not found for id '${inStateId}'`);
   }
 
   return res;
@@ -77,7 +77,7 @@ export async function getStateResponseWithRegen(
         : await chain.getStateOrBytesByCheckpoint(stateId);
 
   if (!res) {
-    throw new ApiError(404, `No state found for id '${inStateId}'`);
+    throw new ApiError(404, `State not found for id '${inStateId}'`);
   }
 
   return res;

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -134,7 +134,7 @@ async function migrateBlocksFromHotToColdDb(db: IBeaconDb, blocks: BlockRootSlot
       canonicalBlocks.map(async (block) => {
         const blockBuffer = await db.block.getBinary(block.root);
         if (!blockBuffer) {
-          throw Error(`No block found for slot ${block.slot} root ${toRootHex(block.root)}`);
+          throw Error(`Block not found for slot ${block.slot} root ${toRootHex(block.root)}`);
         }
         return {
           key: block.slot,


### PR DESCRIPTION
**Motivation**

Obol currently uses the [message to determine if block was missed for slot](https://github.com/ObolNetwork/charon/blob/aa207050f8548db18ce9feafe96a2053f313c411/app/eth2wrap/httpwrap.go#L234) and assumes that clients use the same format as per spec example. While I don't think this is a great approach it's simple enough for us to adjust and doesn't hurt to be closer to spec examples.

And the problem with just using the status code (404) right now is that it can either mean "route not implemented" or "block not found", I guess could consider to standardize error codes for this on the beacon-api spec but likely not worth it due to limited use cases, usually status code is good enough.

**Description**

Update 404 block/state error messages to match spec examples ([state 404 message](https://github.com/ethereum/beacon-APIs/blob/2b1d7b5ac4756881bd29e7adacc9b7032343d981/apis/debug/state.v2.yaml#L56), [block 404 message](https://github.com/ethereum/beacon-APIs/blob/2b1d7b5ac4756881bd29e7adacc9b7032343d981/apis/beacon/blocks/attestations.v2.yaml#L59))

