### PR TITLE
feat: support fetching historical data from all state apis

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -9,12 +9,18 @@ import {
   computeStartSlotAtEpoch,
   getCurrentEpoch,
   getRandaoMix,
+  loadState,
 } from "@lodestar/state-transition";
 import {getValidatorStatus} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {ApiError} from "../../errors.js";
 import {ApiModules} from "../../types.js";
-import {filterStateValidatorsByStatus, getStateResponse, getStateValidatorIndex, toValidatorResponse} from "./utils.js";
+import {
+  filterStateValidatorsByStatus,
+  getStateResponseWithRegen,
+  getStateValidatorIndex,
+  toValidatorResponse,
+} from "./utils.js";
 
 export function getBeaconStateApi({
   chain,
@@ -23,7 +29,13 @@ export function getBeaconStateApi({
   async function getState(
     stateId: routes.beacon.StateId
   ): Promise<{state: BeaconStateAllForks; executionOptimistic: boolean; finalized: boolean}> {
-    return getStateResponse(chain, stateId);
+    const {state, executionOptimistic, finalized} = await getStateResponseWithRegen(chain, stateId);
+
+    return {
+      state: state instanceof Uint8Array ? loadState(config, chain.getHeadState(), state).state : state,
+      executionOptimistic,
+      finalized,
+    };
   }
 
   return {
@@ -73,7 +85,7 @@ export function getBeaconStateApi({
     },
 
     async getStateValidators({stateId, validatorIds = [], statuses = []}) {
-      const {state, executionOptimistic, finalized} = await getStateResponse(chain, stateId);
+      const {state, executionOptimistic, finalized} = await getState(stateId);
       const currentEpoch = getCurrentEpoch(state);
       const {validators, balances} = state; // Get the validators sub tree once for all the loop
       const {pubkey2index} = chain.getHeadState().epochCtx;
@@ -130,7 +142,7 @@ export function getBeaconStateApi({
     },
 
     async postStateValidatorIdentities({stateId, validatorIds = []}) {
-      const {state, executionOptimistic, finalized} = await getStateResponse(chain, stateId);
+      const {state, executionOptimistic, finalized} = await getState(stateId);
       const {pubkey2index} = chain.getHeadState().epochCtx;
 
       let validatorIdentities: routes.beacon.ValidatorIdentities;
@@ -161,7 +173,7 @@ export function getBeaconStateApi({
     },
 
     async getStateValidator({stateId, validatorId}) {
-      const {state, executionOptimistic, finalized} = await getStateResponse(chain, stateId);
+      const {state, executionOptimistic, finalized} = await getState(stateId);
       const {pubkey2index} = chain.getHeadState().epochCtx;
 
       const resp = getStateValidatorIndex(validatorId, state, pubkey2index);
@@ -182,7 +194,7 @@ export function getBeaconStateApi({
     },
 
     async getStateValidatorBalances({stateId, validatorIds = []}) {
-      const {state, executionOptimistic, finalized} = await getStateResponse(chain, stateId);
+      const {state, executionOptimistic, finalized} = await getState(stateId);
 
       if (validatorIds.length) {
         const headState = chain.getHeadState();
@@ -223,7 +235,7 @@ export function getBeaconStateApi({
     },
 
     async getEpochCommittees({stateId, ...filters}) {
-      const {state, executionOptimistic, finalized} = await getStateResponse(chain, stateId);
+      const {state, executionOptimistic, finalized} = await getState(stateId);
 
       const stateCached = state as CachedBeaconStateAltair;
       if (stateCached.epochCtx === undefined) {
@@ -272,7 +284,7 @@ export function getBeaconStateApi({
      */
     async getEpochSyncCommittees({stateId, epoch}) {
       // TODO: Should pick a state with the provided epoch too
-      const {state, executionOptimistic, finalized} = await getStateResponse(chain, stateId);
+      const {state, executionOptimistic, finalized} = await getState(stateId);
 
       // TODO: If possible compute the syncCommittees in advance of the fork and expose them here.
       // So the validators can prepare and potentially attest the first block. Not critical tho, it's very unlikely


### PR DESCRIPTION
**Motivation**

Similar to https://github.com/ChainSafe/lodestar/pull/7779, we already support fetching historical state from some apis, don't see a strong reason not to support it on all state api as it's really not great UX if you can query data from one api but then another one just tells you "not found"

**Description**

Support fetching historical data from all state apis


