### PR TITLE
feat: update dataColumnSidecarsByRoot to new spec

### DIFF
--- a/packages/types/src/fulu/sszTypes.ts
+++ b/packages/types/src/fulu/sszTypes.ts
@@ -5,6 +5,7 @@ import {
   FIELD_ELEMENTS_PER_EXT_BLOB,
   KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH,
   MAX_BLOB_COMMITMENTS_PER_BLOCK,
+  MAX_REQUEST_BLOCKS_DENEB,
   MAX_REQUEST_DATA_COLUMN_SIDECARS,
   NUMBER_OF_COLUMNS,
 } from "@lodestar/params";
@@ -64,17 +65,17 @@ export const MatrixEntry = new ContainerType(
 // ReqResp types
 // =============
 
-export const DataColumnIdentifier = new ContainerType(
+export const DataColumnsByRootIdentifier = new ContainerType(
   {
     blockRoot: Root,
-    index: ColumnIndex,
+    columns: new ListBasicType(ColumnIndex, NUMBER_OF_COLUMNS),
   },
-  {typeName: "DataColumnIdentifier", jsonCase: "eth2"}
+  {typeName: "DataColumnsByRootIdentifier", jsonCase: "eth2"}
 );
 
 export const DataColumnSidecarsByRootRequest = new ListCompositeType(
-  DataColumnIdentifier,
-  MAX_REQUEST_DATA_COLUMN_SIDECARS
+  DataColumnsByRootIdentifier,
+  MAX_REQUEST_BLOCKS_DENEB
 );
 
 export const DataColumnSidecarsByRangeRequest = new ContainerType(

--- a/packages/types/src/fulu/types.ts
+++ b/packages/types/src/fulu/types.ts
@@ -14,7 +14,7 @@ export type DataColumnSidecar = ValueOf<typeof ssz.DataColumnSidecar>;
 export type DataColumnSidecars = ValueOf<typeof ssz.DataColumnSidecars>;
 export type MatrixEntry = ValueOf<typeof ssz.MatrixEntry>;
 
-export type DataColumnIdentifier = ValueOf<typeof ssz.DataColumnIdentifier>;
+export type DataColumnsByRootIdentifier = ValueOf<typeof ssz.DataColumnsByRootIdentifier>;
 export type DataColumnSidecarsByRootRequest = ValueOf<typeof ssz.DataColumnSidecarsByRootRequest>;
 export type DataColumnSidecarsByRangeRequest = ValueOf<typeof ssz.DataColumnSidecarsByRangeRequest>;
 


### PR DESCRIPTION
**Motivation**

The request format for DataColumnSidecarsByRoot was updated to group the columns by blockRoot: https://github.com/ethereum/consensus-specs/pull/4284

Ready for review, but leaving in draft because although it's in the spec for devnet-7, I don't think other clients have merged their PRs yet https://notes.ethereum.org/@ethpandaops/peerdas-devnet-7

**Description**

* Changes DataColumnsByRootRequest from `{blockRoot: string, column: number}` to {blockRoot: string, columns: number[]}` (see spec above for actual ssz types)
