### PR TITLE
Fix Hyperledger Besu CLI Documentation Link

### DIFF
--- a/docs/pages/run/getting-started/quick-start-custom-guide.md
+++ b/docs/pages/run/getting-started/quick-start-custom-guide.md
@@ -284,7 +284,7 @@ The following are links to client documentation for CLI commands:
 
 - [**Lodestar CLI Commands**](https://chainsafe.github.io/lodestar/reference/cli/)
 - [**Nethermind CLI Commands**](https://docs.nethermind.io/fundamentals/configuration#command-line-options)
-- [**Besu CLI Commands**](https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/)
+- [**Besu CLI Commands**](https://besu.hyperledger.org/stable/private-networks/reference/cli/options)
 - [**Go Ethereum CLI commands**](https://geth.ethereum.org/docs/interface/command-line-options)
 - [**Erigon CLI commands**](https://github.com/ledgerwatch/erigon#beacon-chain)
 - [**Reth CLI commands**](https://reth.rs/cli/reth.html)


### PR DESCRIPTION
The change updates the Hyperledger Besu CLI documentation link from the non-working URL https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/ to the working URL https://besu.hyperledger.org/stable/private-networks/reference/cli/options.