### PR TITLE
chore: update gnosis `MAX_BLOBS_PER_BLOCK` to match upstream config

### DIFF
--- a/packages/config/src/chainConfig/networks/gnosis.ts
+++ b/packages/config/src/chainConfig/networks/gnosis.ts
@@ -58,6 +58,9 @@ export const gnosisChainConfig: ChainConfig = {
   FULU_FORK_VERSION: b("0x06000064"),
   FULU_FORK_EPOCH: Infinity,
 
+  // Deneb
+  MAX_BLOBS_PER_BLOCK: 2,
+
   // Electra
   // 2**6 * 10**9 (= 64,000,000,000)
   MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT: 64000000000,


### PR DESCRIPTION
**Motivation**

This can cause interop issues if Lodestar is used with other clients (https://github.com/ChainSafe/lodestar/issues/7764). It's not an actual problem otherwise anymore. This value was never correct but the problem was not that we didn't update it correctly but rather Gnosis team decided to change this value on the fly while the hard fork (Deneb) was already live on the network but due to the fact that blob count is limited by EL as well this was never an issue and won't be now because we use `MAX_BLOBS_PER_BLOCK_ELECTRA` but in theory this could have caused a consensus split if clients use different values (which they did).

**Description**

Update gnosis `MAX_BLOBS_PER_BLOCK` to [match upstream config](https://github.com/gnosischain/configs/blob/d447a94bbe1bafbef4fe5a2fbb2e5469e7b494bb/mainnet/config.yaml#L140)

Closes https://github.com/ChainSafe/lodestar/issues/7765
