### PR TITLE
fix: correct reference to MIN_EPOCHS for data columns

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -275,8 +275,8 @@ async function migrateDataColumnSidecarsFromHotToColdDb(
           const blockEpoch = computeEpochAtSlot(blockSlot);
           return (
             config.getForkSeq(blockSlot) >= ForkSeq.fulu &&
-            // if block is out of ${config.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS}, skip this step
-            blockEpoch >= currentEpoch - config.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
+            // if block is out of ${config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS}, skip this step
+            blockEpoch >= currentEpoch - config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS
           );
         })
         .map(async (block) => {

--- a/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
+++ b/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
@@ -90,7 +90,7 @@ describe("block archiver task", () => {
     const config = createChainForkConfig({
       ...defaultConfig,
       FULU_FORK_EPOCH: 0,
-      MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS: 1,
+      MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS: 2,
     });
     const blockBytes = ssz.fulu.SignedBeaconBlock.serialize(ssz.fulu.SignedBeaconBlock.defaultValue());
     const dataColumnBytes = ssz.fulu.DataColumnSidecar.serialize(ssz.fulu.DataColumnSidecar.defaultValue());

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -277,7 +277,8 @@ Will double processing times. Use only for debugging purposes.",
   },
 
   "chain.archiveDataEpochs": {
-    description: "Number of epochs to retain finalized blobs (minimum of MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS)",
+    description:
+      "Number of epochs to retain finalized blobs (minimum of MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS/MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS)",
     type: "number",
     group: "chain",
   },

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -278,7 +278,7 @@ Will double processing times. Use only for debugging purposes.",
 
   "chain.archiveDataEpochs": {
     description:
-      "Number of epochs to retain finalized blobs (minimum of MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS/MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS)",
+      "Number of epochs to retain finalized blobs/columns (minimum of MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS/MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS)",
     type: "number",
     group: "chain",
   },


### PR DESCRIPTION
**Motivation**

Found a couple more places we should be referencing MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS.

**Description**

* Updated `migrateDataColumnSidecarsFromHotToColdDb ` to reference `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS`
* Updated `chain.archiveDataEpochs` to reference `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS`
