### PR TITLE
test: update web3signer e2e tests to electra

### DIFF
--- a/packages/test-utils/src/externalSigner.ts
+++ b/packages/test-utils/src/externalSigner.ts
@@ -4,10 +4,10 @@ import {ForkSeq} from "@lodestar/params";
 import {GenericContainer, StartedTestContainer, Wait} from "testcontainers";
 import {dirSync as tmpDirSync} from "tmp";
 
-const web3signerVersion = "24.2.0";
+const web3signerVersion = "25.4.1";
 
 /** Till what version is the web3signer image updated for signature verification */
-const supportedForkSeq = ForkSeq.deneb;
+const supportedForkSeq = ForkSeq.electra;
 
 export type StartedExternalSigner = {
   container: StartedTestContainer;


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/7794

**Description**

- enable electra signature tests
- update web3signer to version [25.4.1](https://github.com/Consensys/web3signer/releases/tag/25.4.1)