### PR TITLE
feat: update dumpPeer(s) api to support `fulu.Metadata`

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -5,9 +5,9 @@ import {Connection, PrivateKey} from "@libp2p/interface";
 import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
-import {ForkName} from "@lodestar/params";
+import {ForkName, ForkSeq} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
-import {Epoch, phase0, ssz} from "@lodestar/types";
+import {Epoch, phase0, ssz, sszTypesFor} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {multiaddr} from "@multiformats/multiaddr";
 import {formatNodePeer} from "../../api/impl/node/utils.js";
@@ -389,11 +389,12 @@ export class NetworkCore implements INetworkCore {
 
   private _dumpPeer(peerIdStr: string, connections: Connection[]): routes.lodestar.LodestarNodePeer {
     const peerData = this.peersData.connectedPeers.get(peerIdStr);
+    const fork = this.config.getForkName(this.clock.currentSlot);
     return {
       ...formatNodePeer(peerIdStr, connections),
       agentVersion: peerData?.agentVersion ?? "NA",
       status: peerData?.status ? ssz.phase0.Status.toJson(peerData.status) : null,
-      metadata: peerData?.metadata ? ssz.altair.Metadata.toJson(peerData.metadata) : null,
+      metadata: peerData?.metadata ? sszTypesFor(fork).Metadata.toJson(peerData.metadata) : null,
       agentClient: String(peerData?.agentClient ?? "Unknown"),
       lastReceivedMsgUnixTsMs: peerData?.lastReceivedMsgUnixTsMs ?? 0,
       lastStatusUnixTsMs: peerData?.lastStatusUnixTsMs ?? 0,

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -5,7 +5,7 @@ import {Connection, PrivateKey} from "@libp2p/interface";
 import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
-import {ForkName, ForkSeq} from "@lodestar/params";
+import {ForkName} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {Epoch, phase0, ssz, sszTypesFor} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";


### PR DESCRIPTION
Follow up on https://github.com/ChainSafe/lodestar/pull/7508 to support dumping `fulu.Metadata`, ie. we can inspect `custody_group_count` of our connected peers via `GET /eth/v1/lodestar/peers` api.

Closes https://github.com/ChainSafe/lodestar/issues/7790