### PR TITLE
chore: drop support for nodejs v20.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "engines": {
-    "node": ">=20.1.0 <21 || >=22 <23"
+    "node": ">=22 <23"
   },
   "packageManager": "yarn@1.22.22+sha256.c17d3797fb9a9115bf375e31bfd30058cac6bc9c3b8807a3d8cb2094794b51ca",
   "workspaces": [


### PR DESCRIPTION
We are not actively testing against node 20.x, it's better to not have users run Lodestar on this node version anymore as they might encounter unknown issue we don't catch during our testing.