### PR TITLE
chore: use native fetch / tar to download / extract spec tests

### DIFF
--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -63,7 +63,6 @@
   ],
   "dependencies": {
     "@lodestar/utils": "^1.29.0",
-    "axios": "^1.3.4",
     "rimraf": "^4.4.1",
     "snappyjs": "^0.7.0",
     "tar": "^6.1.13",

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -80,13 +80,15 @@ export async function downloadGenericSpecTests<TestNames extends string>(
             throw new Error("Response body is null");
           }
 
-          const totalSize = res.headers.get("content-length") as string;
+          const totalSize = res.headers.get("content-length");
           log(`Downloading ${url} - ${totalSize} bytes`);
 
           await pipeline(res.body as NodeReadableStream, fs.createWriteStream(tarball));
           log(`Downloaded ${url} - ${fs.statSync(tarball).size} bytes`);
 
-          await promisify(exec)(`tar -xzf ${tarball} -C ${outputDir}`);
+          await promisify(exec)(`tar -xzf ${tarball} -C ${outputDir} --warning=no-unknown-keyword`, {
+            maxBuffer: 1000 * 1024 * 1024,
+          });
           log(`Extracted  ${tarball} to ${outputDir}`);
 
           fs.unlinkSync(tarball);

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -86,10 +86,13 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           await pipeline(res.body as NodeReadableStream, fs.createWriteStream(tarball));
           log(`Downloaded ${url} - ${fs.statSync(tarball).size} bytes`);
 
-          await promisify(exec)(`tar -xzf ${tarball} -C ${outputDir} --warning=no-unknown-keyword`, {
-            maxBuffer: 1000 * 1024 * 1024,
-          });
-          log(`Extracted  ${tarball} to ${outputDir}`);
+          await promisify(exec)(
+            `tar -xzf ${tarball} -C ${outputDir} --warning=no-unknown-keyword "--exclude=._*" "--exclude=*/._*"`,
+            {
+              maxBuffer: 1000 * 1024 * 1024,
+            }
+          );
+          log(`Extracted ${tarball} to ${outputDir}`);
 
           fs.unlinkSync(tarball);
         },

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -67,10 +67,7 @@ export async function downloadGenericSpecTests<TestNames extends string>(
 
       await retry(
         async () => {
-          const controller = new AbortController();
-          const timeout = setTimeout(() => controller.abort(), 30 * 60 * 1000);
-
-          const res = await fetch(url, {signal: controller.signal}).finally(() => clearTimeout(timeout));
+          const res = await fetch(url, {signal: AbortSignal.timeout(30 * 60 * 1000)});
 
           if (!res.ok) {
             throw new Error(`Failed to download file from ${url}: ${res.status} ${res.statusText}`);

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -85,13 +85,9 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           log(`Downloaded ${url} - ${fs.statSync(tarball).size} bytes`);
 
           // extract tar into output directory
-          await promisify(execFile)(
-            "tar",
-            ["-xzf", tarball, "-C", outputDir, "--warning=no-unknown-keyword", "--exclude=._*", "--exclude=*/._*"],
-            {
-              maxBuffer: 1000 * 1024 * 1024, // 1 GB
-            }
-          );
+          await promisify(execFile)("tar", ["-xzf", tarball, "-C", outputDir, "--exclude=._*", "--exclude=*/._*"], {
+            maxBuffer: 1000 * 1024 * 1024, // 1 GB
+          });
           log(`Extracted ${tarball} to ${outputDir}`);
 
           fs.unlinkSync(tarball);

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -1,8 +1,9 @@
-import {spawn} from "node:child_process";
+import {exec} from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import {pipeline} from "node:stream/promises";
 import {ReadableStream as NodeReadableStream} from "node:stream/web";
+import {promisify} from "node:util";
 import {fetch, retry} from "@lodestar/utils";
 import {rimraf} from "rimraf";
 
@@ -85,13 +86,8 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           await pipeline(res.body as NodeReadableStream, fs.createWriteStream(tarball));
           log(`Downloaded ${url} - ${fs.statSync(tarball).size} bytes`);
 
-          await new Promise<void>((resolve, reject) => {
-            const extractor = spawn("tar", ["-xzf", tarball, "-C", outputDir], {stdio: "inherit"});
-            extractor.on("error", reject);
-            extractor.on("close", (code) =>
-              code === 0 ? (log(`Extracted  ${tarball}`), resolve()) : reject(new Error(`tar exited with code ${code}`))
-            );
-          });
+          await promisify(exec)(`tar -xzf ${tarball} -C ${outputDir}`);
+          log(`Extracted  ${tarball} to ${outputDir}`);
 
           fs.unlinkSync(tarball);
         },

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -83,9 +83,10 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           log(`Downloading ${url} - ${totalSize} bytes`);
 
           await pipeline(res.body as NodeReadableStream, fs.createWriteStream(tarball));
+          log(`Downloaded ${url} - ${fs.statSync(tarball).size} bytes`);
 
           await extractTar({file: tarball, cwd: outputDir});
-          log(`Downloaded  ${url}`);
+          log(`Extracted  ${url}`);
 
           fs.unlinkSync(tarball);
         },

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -1,9 +1,8 @@
-import {exec} from "node:child_process";
+import {spawn} from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import {pipeline} from "node:stream/promises";
 import {ReadableStream as NodeReadableStream} from "node:stream/web";
-import {promisify} from "node:util";
 import {fetch, retry} from "@lodestar/utils";
 import {rimraf} from "rimraf";
 
@@ -86,8 +85,13 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           await pipeline(res.body as NodeReadableStream, fs.createWriteStream(tarball));
           log(`Downloaded ${url} - ${fs.statSync(tarball).size} bytes`);
 
-          await promisify(exec)(`tar -xzf ${tarball} -C ${outputDir}`);
-          log(`Extracted  ${tarball} to ${outputDir}`);
+          await new Promise<void>((resolve, reject) => {
+            const extractor = spawn("tar", ["-xzf", tarball, "-C", outputDir], {stdio: "inherit"});
+            extractor.on("error", reject);
+            extractor.on("close", (code) =>
+              code === 0 ? (log(`Extracted  ${tarball}`), resolve()) : reject(new Error(`tar exited with code ${code}`))
+            );
+          });
 
           fs.unlinkSync(tarball);
         },

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -83,6 +83,7 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           await pipeline(res.body as NodeReadableStream, fs.createWriteStream(tarball));
           log(`Downloaded ${url} - ${fs.statSync(tarball).size} bytes`);
 
+          // extract tar into output directory
           await promisify(execFile)(
             "tar",
             ["-xzf", tarball, "-C", outputDir, "--warning=no-unknown-keyword", "--exclude=._*", "--exclude=*/._*"],
@@ -101,6 +102,8 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           },
         }
       );
+
+      // download tar
     })
   );
 

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -80,6 +80,7 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           const totalSize = res.headers.get("content-length");
           log(`Downloading ${url} - ${totalSize} bytes`);
 
+          // stream download to local .tar.gz file
           await pipeline(res.body as NodeReadableStream, fs.createWriteStream(tarball));
           log(`Downloaded ${url} - ${fs.statSync(tarball).size} bytes`);
 

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -1,10 +1,11 @@
+import {exec} from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import {pipeline} from "node:stream/promises";
 import {ReadableStream as NodeReadableStream} from "node:stream/web";
+import {promisify} from "node:util";
 import {fetch, retry} from "@lodestar/utils";
 import {rimraf} from "rimraf";
-import {x as extractTar} from "tar";
 
 export const defaultSpecTestsRepoUrl = "https://github.com/ethereum/consensus-spec-tests";
 
@@ -85,8 +86,8 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           await pipeline(res.body as NodeReadableStream, fs.createWriteStream(tarball));
           log(`Downloaded ${url} - ${fs.statSync(tarball).size} bytes`);
 
-          await extractTar({file: tarball, cwd: outputDir});
-          log(`Extracted  ${url}`);
+          await promisify(exec)(`tar -xzf ${tarball} -C ${outputDir}`);
+          log(`Extracted  ${tarball} to ${outputDir}`);
 
           fs.unlinkSync(tarball);
         },
@@ -97,8 +98,6 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           },
         }
       );
-
-      // download tar
     })
   );
 

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -1,4 +1,4 @@
-import {exec} from "node:child_process";
+import {execFile} from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import {pipeline} from "node:stream/promises";
@@ -86,10 +86,11 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           await pipeline(res.body as NodeReadableStream, fs.createWriteStream(tarball));
           log(`Downloaded ${url} - ${fs.statSync(tarball).size} bytes`);
 
-          await promisify(exec)(
-            `tar -xzf ${tarball} -C ${outputDir} --warning=no-unknown-keyword "--exclude=._*" "--exclude=*/._*"`,
+          await promisify(execFile)(
+            "tar",
+            ["-xzf", tarball, "-C", outputDir, "--warning=no-unknown-keyword", "--exclude=._*", "--exclude=*/._*"],
             {
-              maxBuffer: 1000 * 1024 * 1024,
+              maxBuffer: 1000 * 1024 * 1024, // 1 GB
             }
           );
           log(`Extracted ${tarball} to ${outputDir}`);

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -1,9 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-import stream from "node:stream";
-import {promisify} from "node:util";
-import {retry} from "@lodestar/utils";
-import axios from "axios";
+import {pipeline} from "node:stream/promises";
+import {ReadableStream as NodeReadableStream} from "node:stream/web";
+import {fetch, retry} from "@lodestar/utils";
 import {rimraf} from "rimraf";
 import {x as extractTar} from "tar";
 
@@ -63,23 +62,32 @@ export async function downloadGenericSpecTests<TestNames extends string>(
   await Promise.all(
     testsToDownload.map(async (test) => {
       const url = `${specTestsRepoUrl ?? defaultSpecTestsRepoUrl}/releases/download/${specVersion}/${test}.tar.gz`;
+      const tarball = path.join(outputDir, `${test}.tar.gz`);
 
       await retry(
         async () => {
-          const {data, headers} = await axios({
-            method: "get",
-            url,
-            responseType: "stream",
-            timeout: 30 * 60 * 1000,
-          });
+          const controller = new AbortController();
+          const timeout = setTimeout(() => controller.abort(), 30 * 60 * 1000);
 
-          const totalSize = headers["content-length"] as string;
+          const res = await fetch(url, {signal: controller.signal}).finally(() => clearTimeout(timeout));
+
+          if (!res.ok) {
+            throw new Error(`Failed to download file from ${url}: ${res.status} ${res.statusText}`);
+          }
+
+          if (!res.body) {
+            throw new Error("Response body is null");
+          }
+
+          const totalSize = res.headers.get("content-length") as string;
           log(`Downloading ${url} - ${totalSize} bytes`);
 
-          // extract tar into output directory
-          await promisify(stream.pipeline)(data, extractTar({cwd: outputDir}));
+          await pipeline(res.body as NodeReadableStream, fs.createWriteStream(tarball));
 
+          await extractTar({file: tarball, cwd: outputDir});
           log(`Downloaded  ${url}`);
+
+          fs.unlinkSync(tarball);
         },
         {
           retries: 3,


### PR DESCRIPTION
Make spec test download a lot faster and avoid random failures due to abort.