### PR TITLE
chore: update @actions/cache to latest version (v4)

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -21,7 +21,7 @@ runs:
       run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
 
     - name: Restore build
-      uses: actions/cache/restore@4
+      uses: actions/cache/restore@v4
       id: cache-build-restore
       with:
         path: |
@@ -55,7 +55,7 @@ runs:
       run: yarn check-bundle
 
     - name: Cache build artifacts
-      uses: actions/cache@4
+      uses: actions/cache@v4
       with:
         path: |
           node_modules

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -21,7 +21,7 @@ runs:
       run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
 
     - name: Restore build
-      uses: actions/cache/restore@main
+      uses: actions/cache/restore@4
       id: cache-build-restore
       with:
         path: |
@@ -55,7 +55,7 @@ runs:
       run: yarn check-bundle
 
     - name: Cache build artifacts
-      uses: actions/cache@main
+      uses: actions/cache@4
       with:
         path: |
           node_modules

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -21,7 +21,7 @@ runs:
       run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
 
     - name: Restore build
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@main
       id: cache-build-restore
       with:
         path: |
@@ -55,7 +55,7 @@ runs:
       run: yarn check-bundle
 
     - name: Cache build artifacts
-      uses: actions/cache@master
+      uses: actions/cache@main
       with:
         path: |
           node_modules

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,7 +40,7 @@ jobs:
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
       - name: Restore dependencies
-        uses: actions/cache@4
+        uses: actions/cache@v4
         id: cache-deps
         with:
           path: |
@@ -57,7 +57,7 @@ jobs:
 
       # Restore performance downloaded states
       - name: Restore performance state cache
-        uses: actions/cache@4
+        uses: actions/cache@v4
         with:
           path: packages/state-transition/test-cache
           key: perf-states-${{ hashFiles('packages/state-transition/test/perf/params.ts') }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,7 +40,7 @@ jobs:
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
       - name: Restore dependencies
-        uses: actions/cache@master
+        uses: actions/cache@main
         id: cache-deps
         with:
           path: |
@@ -57,7 +57,7 @@ jobs:
 
       # Restore performance downloaded states
       - name: Restore performance state cache
-        uses: actions/cache@master
+        uses: actions/cache@main
         with:
           path: packages/state-transition/test-cache
           key: perf-states-${{ hashFiles('packages/state-transition/test/perf/params.ts') }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,7 +40,7 @@ jobs:
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
       - name: Restore dependencies
-        uses: actions/cache@main
+        uses: actions/cache@4
         id: cache-deps
         with:
           path: |
@@ -57,7 +57,7 @@ jobs:
 
       # Restore performance downloaded states
       - name: Restore performance state cache
-        uses: actions/cache@main
+        uses: actions/cache@4
         with:
           path: packages/state-transition/test-cache
           key: perf-states-${{ hashFiles('packages/state-transition/test/perf/params.ts') }}

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -21,7 +21,7 @@ jobs:
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
       - name: Restore dependencies
-        uses: actions/cache@master
+        uses: actions/cache@main
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -21,7 +21,7 @@ jobs:
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
       - name: Restore dependencies
-        uses: actions/cache@main
+        uses: actions/cache@4
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -21,7 +21,7 @@ jobs:
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
       - name: Restore dependencies
-        uses: actions/cache@4
+        uses: actions/cache@v4
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
 
       - name: Restore dependencies
-        uses: actions/cache@master
+        uses: actions/cache@main
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
 
       - name: Restore dependencies
-        uses: actions/cache@main
+        uses: actions/cache@4
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
 
       - name: Restore dependencies
-        uses: actions/cache@4
+        uses: actions/cache@v4
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -28,7 +28,7 @@ jobs:
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
       - name: Restore dependencies
-        uses: actions/cache@4
+        uses: actions/cache@v4
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -28,7 +28,7 @@ jobs:
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
       - name: Restore dependencies
-        uses: actions/cache@main
+        uses: actions/cache@4
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -28,7 +28,7 @@ jobs:
         id: node
         run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
       - name: Restore dependencies
-        uses: actions/cache@master
+        uses: actions/cache@main
         id: cache-deps
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
 
       # Cache validator slashing protection data tests
       - name: Restore spec tests cache
-        uses: actions/cache@master
+        uses: actions/cache@main
         with:
           path: packages/validator/spec-tests
           key: spec-test-data-${{ hashFiles('packages/validator/test/spec/params.ts') }}
@@ -201,7 +201,7 @@ jobs:
 
       # Download spec tests with cache
       - name: Restore spec tests cache
-        uses: actions/cache@master
+        uses: actions/cache@main
         with:
           path: packages/beacon-node/spec-tests
           key: spec-test-data-${{ hashFiles('packages/beacon-node/test/spec/specTestVersioning.ts') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
 
       # Cache validator slashing protection data tests
       - name: Restore spec tests cache
-        uses: actions/cache@main
+        uses: actions/cache@4
         with:
           path: packages/validator/spec-tests
           key: spec-test-data-${{ hashFiles('packages/validator/test/spec/params.ts') }}
@@ -201,7 +201,7 @@ jobs:
 
       # Download spec tests with cache
       - name: Restore spec tests cache
-        uses: actions/cache@main
+        uses: actions/cache@4
         env:
           ACTIONS_STEP_DEBUG: true
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,11 +202,15 @@ jobs:
       # Download spec tests with cache
       - name: Restore spec tests cache
         uses: actions/cache@main
+        env:
+          ACTIONS_STEP_DEBUG: true
         with:
           path: packages/beacon-node/spec-tests
           key: spec-test-data-${{ hashFiles('packages/beacon-node/test/spec/specTestVersioning.ts') }}
       - name: Download spec tests
         run: yarn download-spec-tests
+        env:
+          ACTIONS_STEP_DEBUG: true
       # Run them in different steps to quickly identifying which command failed
       # Otherwise just doing `yarn test:spec` you can't tell which specific suite failed
       # many of the suites have identical names for minimal and mainnet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
 
       # Cache validator slashing protection data tests
       - name: Restore spec tests cache
-        uses: actions/cache@4
+        uses: actions/cache@v4
         with:
           path: packages/validator/spec-tests
           key: spec-test-data-${{ hashFiles('packages/validator/test/spec/params.ts') }}
@@ -201,16 +201,12 @@ jobs:
 
       # Download spec tests with cache
       - name: Restore spec tests cache
-        uses: actions/cache@4
-        env:
-          ACTIONS_STEP_DEBUG: true
+        uses: actions/cache@v4
         with:
           path: packages/beacon-node/spec-tests
           key: spec-test-data-${{ hashFiles('packages/beacon-node/test/spec/specTestVersioning.ts') }}
       - name: Download spec tests
         run: yarn download-spec-tests
-        env:
-          ACTIONS_STEP_DEBUG: true
       # Run them in different steps to quickly identifying which command failed
       # Otherwise just doing `yarn test:spec` you can't tell which specific suite failed
       # many of the suites have identical names for minimal and mainnet

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "release:publish": "lerna publish from-package --yes --no-verify-access"
   },
   "devDependencies": {
-    "@actions/core": "^1.10.1",
+    "@actions/core": "^1.11.1",
     "@chainsafe/benchmark": "^1.2.3",
     "@chainsafe/biomejs-config": "^0.1.2",
     "@biomejs/biome": "^1.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,14 +19,6 @@
     semver "^6.3.1"
     twirp-ts "^2.5.0"
 
-"@actions/core@^1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.10.1.tgz#61108e7ac40acae95ee36da074fa5850ca4ced8a"
-  integrity sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==
-  dependencies:
-    "@actions/http-client" "^2.0.1"
-    uuid "^8.3.2"
-
 "@actions/core@^1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.11.1.tgz#ae683aac5112438021588030efb53b1adb86f172"


### PR DESCRIPTION
**Motivation**

Use latest version of `@actions/cache`, older releases will soon no longer work, see [important changes](https://github.com/marketplace/actions/cache#%EF%B8%8F-important-changes)