### PR TITLE
chore: remove node_modules from actions cache

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -20,6 +20,11 @@ runs:
       shell: bash
       run: echo "v8CppApiVersion=$(node --print "process.versions.modules")" >> $GITHUB_OUTPUT
 
+    - name: Create cache key
+      id: build-cache
+      shell: bash
+      run: echo "key=build-cache-${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node }}-${{ github.sha }}" >> $GITHUB_OUTPUT
+
     - name: Restore build
       uses: actions/cache/restore@v4
       id: cache-build-restore
@@ -28,7 +33,7 @@ runs:
           lib/
           packages/*/lib
           packages/*/.git-data.json
-        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node }}-${{ github.sha }}
+        key: ${{ steps.build-cache.outputs.key }}
 
     - name: Install & build
       shell: bash
@@ -50,9 +55,7 @@ runs:
       uses: actions/cache@master
       with:
         path: |
-          node_modules
-          packages/*/node_modules
           lib/
           packages/*/lib
           packages/*/.git-data.json
-        key: ${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node }}-${{ github.sha }}
+        key: ${{ steps.build-cache.outputs.key }}

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Create cache key
       id: build-cache
       shell: bash
-      # This build cache will be per github commits and reused among different jobs on same PRs
+      # This build cache will be reused among different jobs for the same commit
       run: echo "key=build-cache-${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
     - name: Restore build

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -25,22 +25,14 @@ runs:
       id: cache-build-restore
       with:
         path: |
-          node_modules
-          packages/*/node_modules
           lib/
           packages/*/lib
           packages/*/.git-data.json
         key: ${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node }}-${{ github.sha }}
 
     - name: Install & build
-      if: steps.cache-build-restore.outputs.cache-hit != 'true'
       shell: bash
       run: yarn install --frozen-lockfile && yarn build
-
-    - name: Build
-      if: steps.cache-build-restore.outputs.cache-hit == 'true'
-      shell: bash
-      run: yarn build
 
     - name: Check Build
       shell: bash

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -13,6 +13,8 @@ runs:
       with:
         node-version: ${{inputs.node}}
         check-latest: true
+        # The hash of yarn.lock file will be used as cache key
+        # So unless our dependencies change, we can reuse the cache
         cache: yarn
 
     - name: Node.js version
@@ -23,6 +25,7 @@ runs:
     - name: Create cache key
       id: build-cache
       shell: bash
+      # This build cache will be per github commits and reused among different jobs on same PRs
       run: echo "key=build-cache-${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
     - name: Restore build


### PR DESCRIPTION
**Motivation**

- looking at our actions cache usage, trying to improve usage of the 10GB total capacity

**Description**

- It looks like we were caching both:
  - yarn global cache
  - node_modules

- Remove node_modules from the cache since the yarn global cache should suffice