### PR TITLE
chore: remove now unused tar dependency

### DIFF
--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -65,11 +65,7 @@
     "@lodestar/utils": "^1.29.0",
     "rimraf": "^4.4.1",
     "snappyjs": "^0.7.0",
-    "tar": "^6.1.13",
     "vitest": "^3.0.6"
-  },
-  "devDependencies": {
-    "@types/tar": "^6.1.4"
   },
   "peerDependencies": {
     "vitest": "^3.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12103,7 +12103,7 @@ tar@6.1.11:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-tar@^6.0.2, tar@^6.1.11, tar@^6.1.13, tar@^6.1.2:
+tar@^6.0.2, tar@^6.1.11, tar@^6.1.2:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.1.tgz#717549c541bc3c2af15751bea94b1dd068d4b03a"
   integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==


### PR DESCRIPTION
`tar` dependency is no longer used since https://github.com/ChainSafe/lodestar/pull/7816, might as well get rid of it
