### PR TITLE
chore: fix broken panels due to missing historical state worker metrics

### DIFF
--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -178,7 +178,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(sum(nodejs_heap_size_total_bytes) + sum(discv5_worker_nodejs_heap_size_total_bytes) + sum(network_worker_nodejs_heap_size_total_bytes) + sum(lodestar_historical_state_worker_nodejs_heap_size_total_bytes))\nor\n(sum(nodejs_heap_size_total_bytes) + sum(discv5_worker_nodejs_heap_size_total_bytes) + sum(lodestar_historical_state_worker_nodejs_heap_size_total_bytes))",
+          "expr": "(sum(nodejs_heap_size_total_bytes) + sum(discv5_worker_nodejs_heap_size_total_bytes) + sum(network_worker_nodejs_heap_size_total_bytes) + sum(lodestar_historical_state_worker_nodejs_heap_size_total_bytes or vector(0)))\nor\n(sum(nodejs_heap_size_total_bytes) + sum(discv5_worker_nodejs_heap_size_total_bytes) + sum(lodestar_historical_state_worker_nodejs_heap_size_total_bytes or vector(0)))",
           "hide": false,
           "interval": "",
           "legendFormat": "node allocated heap",
@@ -192,7 +192,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(sum(nodejs_heap_size_used_bytes) + sum(discv5_worker_nodejs_heap_size_used_bytes) + sum(network_worker_nodejs_heap_size_used_bytes) + sum(lodestar_historical_state_worker_nodejs_heap_size_used_bytes)) \nor\n(sum(nodejs_heap_size_used_bytes) + sum(discv5_worker_nodejs_heap_size_used_bytes) + sum(lodestar_historical_state_worker_nodejs_heap_size_used_bytes)) ",
+          "expr": "(sum(nodejs_heap_size_used_bytes) + sum(discv5_worker_nodejs_heap_size_used_bytes) + sum(network_worker_nodejs_heap_size_used_bytes) + sum(lodestar_historical_state_worker_nodejs_heap_size_used_bytes or vector(0))) \nor\n(sum(nodejs_heap_size_used_bytes) + sum(discv5_worker_nodejs_heap_size_used_bytes) + sum(lodestar_historical_state_worker_nodejs_heap_size_used_bytes or vector(0))) ",
           "hide": false,
           "interval": "",
           "legendFormat": "node used heap",
@@ -206,7 +206,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(sum(nodejs_external_memory_bytes) + sum(discv5_worker_nodejs_external_memory_bytes) + sum(network_worker_nodejs_external_memory_bytes) + sum(lodestar_historical_state_worker_nodejs_external_memory_bytes))\nor\n(sum(nodejs_external_memory_bytes) + sum(discv5_worker_nodejs_external_memory_bytes) + sum(lodestar_historical_state_worker_nodejs_external_memory_bytes))",
+          "expr": "(sum(nodejs_external_memory_bytes) + sum(discv5_worker_nodejs_external_memory_bytes) + sum(network_worker_nodejs_external_memory_bytes) + sum(lodestar_historical_state_worker_nodejs_external_memory_bytes or vector(0)))\nor\n(sum(nodejs_external_memory_bytes) + sum(discv5_worker_nodejs_external_memory_bytes) + sum(lodestar_historical_state_worker_nodejs_external_memory_bytes or vector(0)))",
           "hide": false,
           "interval": "",
           "legendFormat": "node external memory",
@@ -307,7 +307,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(nodejs_external_memory_bytes{job=~\"$beacon_job|beacon\"} + discv5_worker_nodejs_external_memory_bytes{job=~\"$beacon_job|beacon\"} + network_worker_nodejs_external_memory_bytes{job=~\"$beacon_job|beacon\"} + lodestar_historical_state_worker_nodejs_external_memory_bytes{job=~\"$beacon_job|beacon\"})\nor\n(nodejs_external_memory_bytes{job=~\"$beacon_job|beacon\"} + discv5_worker_nodejs_external_memory_bytes{job=~\"$beacon_job|beacon\"} + lodestar_historical_state_worker_nodejs_external_memory_bytes{job=~\"$beacon_job|beacon\"})",
+          "expr": "(sum(nodejs_external_memory_bytes{job=~\"$beacon_job|beacon\"}) + sum(discv5_worker_nodejs_external_memory_bytes{job=~\"$beacon_job|beacon\"}) + sum(network_worker_nodejs_external_memory_bytes{job=~\"$beacon_job|beacon\"}) + sum(lodestar_historical_state_worker_nodejs_external_memory_bytes{job=~\"$beacon_job|beacon\"} or vector(0)))\nor\nsum(nodejs_external_memory_bytes{job=~\"$validator_job|validator\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "external_memory",
@@ -1196,7 +1196,7 @@
           "refId": "C"
         }
       ],
-      "title": "HIstorical State Worker Thread - GC pause time rate + reclaimed bytes",
+      "title": "Historical State Worker Thread - GC pause time rate + reclaimed bytes",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
**Motivation**

Since https://github.com/ChainSafe/lodestar/pull/7799, the historical state worker is only enabled if `--serveHistoricalState` flag is set which means that metrics might not exist. This is not a problem for dedicated panels / dashboard for the historical state worker / regen but it shouldn't break other metric panels that include the metrics as part of a sum.

**Description**


Fix broken panels by adding `or vector(0)` to `lodestar_historical_state_worker_*` metrics to handle the case if those metrics are missing due to historical state work being disabled