### PR TITLE
chore: remove axios from spec-test-utils

### DIFF
--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -63,7 +63,6 @@
   ],
   "dependencies": {
     "@lodestar/utils": "^1.30.0",
-    "axios": "^1.3.4",
     "rimraf": "^4.4.1",
     "snappyjs": "^0.7.0",
     "vitest": "^3.0.6"


### PR DESCRIPTION
**Motivation**

Follow up PR to #7828 which re-included axios dependency when it should remain removed.
