### PR TITLE
chore: fix tsconfig for type check for lightclient bundle

### DIFF
--- a/packages/light-client/tsconfig.json
+++ b/packages/light-client/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src", "test"],
-  "exclude": ["src/index.browser.ts", "test/unit/webEsmBundle.browser.test.ts"]
+  // These files to be excluded in case we run `check-types` before `build:bundle`
+  "exclude": ["test/unit/webEsmBundle.browser.test.ts", "test/browser/webEsmBundle.browser.test.ts"]
 }


### PR DESCRIPTION
**Motivation**

Make sure `chekc-type` script works without any error.

**Description**

- Update the tsconfig to exclude the browser bundle test
- This file was created as symlink to unit to run browser tests in specific packages


**Steps to test or reproduce**

Run all tests