### PR TITLE
refactor: cleanup block production

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -573,7 +573,7 @@ export function getValidatorApi(
       );
     }
 
-    const graffitiBuffer = toGraffitiBuffer(
+    const graffitiBytes = toGraffitiBuffer(
       graffiti ?? getDefaultGraffiti(getLodestarClientVersion(opts), chain.executionEngine.clientVersion, opts)
     );
 
@@ -593,9 +593,7 @@ export function getValidatorApi(
       slot,
       parentBlockRoot,
       randaoReveal,
-      graffiti: toGraffitiBuffer(
-        graffiti ?? getDefaultGraffiti(getLodestarClientVersion(opts), chain.executionEngine.clientVersion, opts)
-      ),
+      graffiti: graffitiBytes,
     });
     logger.debug("Produced common block body", loggerContext);
 
@@ -614,7 +612,7 @@ export function getValidatorApi(
     // Start calls for building execution and builder blocks
 
     const builderPromise = isBuilderEnabled
-      ? produceBuilderBlindedBlock(slot, randaoReveal, graffitiBuffer, {
+      ? produceBuilderBlindedBlock(slot, randaoReveal, graffitiBytes, {
           feeRecipient,
           // can't do fee recipient checks as builder bid doesn't return feeRecipient as of now
           strictFeeRecipientCheck: false,
@@ -624,7 +622,7 @@ export function getValidatorApi(
       : Promise.reject(new Error("Builder disabled"));
 
     const enginePromise = isEngineEnabled
-      ? produceEngineFullBlockOrContents(slot, randaoReveal, graffitiBuffer, {
+      ? produceEngineFullBlockOrContents(slot, randaoReveal, graffitiBytes, {
           feeRecipient,
           strictFeeRecipientCheck,
           commonBlockBody,

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -76,7 +76,7 @@ import {validateGossipFnRetryUnknownRoot} from "../../../network/processor/gossi
 import {CommitteeSubscription} from "../../../network/subnets/index.js";
 import {SyncState} from "../../../sync/index.js";
 import {isOptimisticBlock} from "../../../util/forkChoice.js";
-import {getDefaultGraffiti, toGraffitiBuffer} from "../../../util/graffiti.js";
+import {getDefaultGraffiti, toGraffitiBytes} from "../../../util/graffiti.js";
 import {getLodestarClientVersion} from "../../../util/metadata.js";
 import {ApiOptions} from "../../options.js";
 import {getStateResponseWithRegen} from "../beacon/state/utils.js";
@@ -573,7 +573,7 @@ export function getValidatorApi(
       );
     }
 
-    const graffitiBytes = toGraffitiBuffer(
+    const graffitiBytes = toGraffitiBytes(
       graffiti ?? getDefaultGraffiti(getLodestarClientVersion(opts), chain.executionEngine.clientVersion, opts)
     );
 

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -34,6 +34,7 @@ import {
   BeaconBlock,
   BlindedBeaconBlock,
   BlockContents,
+  Bytes32,
   CommitteeIndex,
   Epoch,
   ProducedBlockSource,
@@ -399,7 +400,7 @@ export function getValidatorApi(
   async function produceBuilderBlindedBlock(
     slot: Slot,
     randaoReveal: BLSSignature,
-    graffiti: Buffer,
+    graffiti: Bytes32,
     // as of now fee recipient checks can not be performed because builder does not return bid recipient
     {
       commonBlockBody,
@@ -459,7 +460,7 @@ export function getValidatorApi(
   async function produceEngineFullBlockOrContents(
     slot: Slot,
     randaoReveal: BLSSignature,
-    graffiti: Buffer,
+    graffiti: Bytes32,
     {
       feeRecipient,
       strictFeeRecipientCheck,

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -399,25 +399,15 @@ export function getValidatorApi(
   async function produceBuilderBlindedBlock(
     slot: Slot,
     randaoReveal: BLSSignature,
-    graffiti?: string,
+    graffiti: Buffer,
     // as of now fee recipient checks can not be performed because builder does not return bid recipient
     {
-      skipHeadChecksAndUpdate,
       commonBlockBody,
-      parentBlockRoot: inParentBlockRoot,
-    }: Omit<routes.validator.ExtraProduceBlockOpts, "builderSelection"> &
-      (
-        | {
-            skipHeadChecksAndUpdate: true;
-            commonBlockBody: CommonBlockBody;
-            parentBlockRoot: Root;
-          }
-        | {
-            skipHeadChecksAndUpdate?: false | undefined;
-            commonBlockBody?: undefined;
-            parentBlockRoot?: undefined;
-          }
-      ) = {}
+      parentBlockRoot,
+    }: Omit<routes.validator.ExtraProduceBlockOpts, "builderSelection"> & {
+      commonBlockBody: CommonBlockBody;
+      parentBlockRoot: Root;
+    }
   ): Promise<ProduceBlindedBlockRes> {
     const version = config.getForkName(slot);
     if (!isForkPostBellatrix(version)) {
@@ -435,17 +425,6 @@ export function getValidatorApi(
       throw Error("Execution builder disabled");
     }
 
-    let parentBlockRoot: Root;
-    if (skipHeadChecksAndUpdate !== true) {
-      notWhileSyncing();
-      await waitForSlot(slot); // Must never request for a future slot > currentSlot
-
-      parentBlockRoot = fromHex(chain.getProposerHead(slot).blockRoot);
-    } else {
-      parentBlockRoot = inParentBlockRoot;
-    }
-    notOnOutOfRangeData(parentBlockRoot);
-
     let timer: undefined | ((opts: {source: ProducedBlockSource}) => number);
     try {
       timer = metrics?.blockProductionTime.startTimer();
@@ -453,9 +432,7 @@ export function getValidatorApi(
         slot,
         parentBlockRoot,
         randaoReveal,
-        graffiti: toGraffitiBuffer(
-          graffiti ?? getDefaultGraffiti(getLodestarClientVersion(opts), chain.executionEngine.clientVersion, opts)
-        ),
+        graffiti,
         commonBlockBody,
       });
 
@@ -482,36 +459,19 @@ export function getValidatorApi(
   async function produceEngineFullBlockOrContents(
     slot: Slot,
     randaoReveal: BLSSignature,
-    graffiti?: string,
+    graffiti: Buffer,
     {
       feeRecipient,
       strictFeeRecipientCheck,
-      skipHeadChecksAndUpdate,
       commonBlockBody,
-      parentBlockRoot: inParentBlockRoot,
-    }: Omit<routes.validator.ExtraProduceBlockOpts, "builderSelection"> &
-      (
-        | {
-            skipHeadChecksAndUpdate: true;
-            commonBlockBody: CommonBlockBody;
-            parentBlockRoot: Root;
-          }
-        | {skipHeadChecksAndUpdate?: false | undefined; commonBlockBody?: undefined; parentBlockRoot?: undefined}
-      ) = {}
+      parentBlockRoot,
+    }: Omit<routes.validator.ExtraProduceBlockOpts, "builderSelection"> & {
+      commonBlockBody: CommonBlockBody;
+      parentBlockRoot: Root;
+    }
   ): Promise<ProduceBlockOrContentsRes & {shouldOverrideBuilder?: boolean}> {
     const source = ProducedBlockSource.engine;
     metrics?.blockProductionRequests.inc({source});
-
-    let parentBlockRoot: Root;
-    if (skipHeadChecksAndUpdate !== true) {
-      notWhileSyncing();
-      await waitForSlot(slot); // Must never request for a future slot > currentSlot
-
-      parentBlockRoot = fromHex(chain.getProposerHead(slot).blockRoot);
-    } else {
-      parentBlockRoot = inParentBlockRoot;
-    }
-    notOnOutOfRangeData(parentBlockRoot);
 
     let timer: undefined | ((opts: {source: ProducedBlockSource}) => number);
     try {
@@ -520,9 +480,7 @@ export function getValidatorApi(
         slot,
         parentBlockRoot,
         randaoReveal,
-        graffiti: toGraffitiBuffer(
-          graffiti ?? getDefaultGraffiti(getLodestarClientVersion(opts), chain.executionEngine.clientVersion, opts)
-        ),
+        graffiti,
         feeRecipient,
         commonBlockBody,
       });
@@ -614,6 +572,10 @@ export function getValidatorApi(
       );
     }
 
+    const graffitiBuffer = toGraffitiBuffer(
+      graffiti ?? getDefaultGraffiti(getLodestarClientVersion(opts), chain.executionEngine.clientVersion, opts)
+    );
+
     const loggerContext = {
       slot,
       fork,
@@ -651,23 +613,19 @@ export function getValidatorApi(
     // Start calls for building execution and builder blocks
 
     const builderPromise = isBuilderEnabled
-      ? produceBuilderBlindedBlock(slot, randaoReveal, graffiti, {
+      ? produceBuilderBlindedBlock(slot, randaoReveal, graffitiBuffer, {
           feeRecipient,
           // can't do fee recipient checks as builder bid doesn't return feeRecipient as of now
           strictFeeRecipientCheck: false,
-          // skip checking and recomputing head in these individual produce calls
-          skipHeadChecksAndUpdate: true,
           commonBlockBody,
           parentBlockRoot,
         })
       : Promise.reject(new Error("Builder disabled"));
 
     const enginePromise = isEngineEnabled
-      ? produceEngineFullBlockOrContents(slot, randaoReveal, graffiti, {
+      ? produceEngineFullBlockOrContents(slot, randaoReveal, graffitiBuffer, {
           feeRecipient,
           strictFeeRecipientCheck,
-          // skip checking and recomputing head in these individual produce calls
-          skipHeadChecksAndUpdate: true,
           commonBlockBody,
           parentBlockRoot,
         }).then((engineBlock) => {

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -43,7 +43,7 @@ import {
   PayloadId,
   getExpectedGasLimit,
 } from "../../execution/index.js";
-import {fromGraffitiBuffer} from "../../util/graffiti.js";
+import {fromGraffitiBytes} from "../../util/graffiti.js";
 import type {BeaconChain} from "../chain.js";
 import {CommonBlockBody} from "../interface.js";
 import {validateBlobsAndKzgCommitments} from "./validateBlobsAndKzgCommitments.js";
@@ -161,7 +161,7 @@ export async function produceBlockBody<T extends BlockType>(
   } = blockBody;
 
   Object.assign(logMeta, {
-    graffiti: fromGraffitiBuffer(graffiti),
+    graffiti: fromGraffitiBytes(graffiti),
     attestations: attestations.length,
     deposits: deposits.length,
     voluntaryExits: voluntaryExits.length,

--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -1,17 +1,18 @@
+import {Bytes32} from "@lodestar/types";
 import {GRAFFITI_SIZE} from "../constants/index.js";
 import {ClientVersion} from "../execution/index.js";
 
 /**
  * Parses a graffiti UTF8 string and returns a 32 bytes buffer right padded with zeros
  */
-export function toGraffitiBuffer(graffiti: string): Buffer {
+export function toGraffitiBytes(graffiti: string): Bytes32 {
   return Buffer.concat([Buffer.from(graffiti, "utf8"), Buffer.alloc(GRAFFITI_SIZE, 0)], GRAFFITI_SIZE);
 }
 
 /**
  * Converts a graffiti from 32 bytes buffer back to a UTF-8 string
  */
-export function fromGraffitiBuffer(graffiti: Uint8Array): string {
+export function fromGraffitiBytes(graffiti: Uint8Array): string {
   return Buffer.from(graffiti.buffer, graffiti.byteOffset, graffiti.byteLength)
     .toString("utf8")
     .replaceAll("\u0000", "");

--- a/packages/beacon-node/src/util/graffiti.ts
+++ b/packages/beacon-node/src/util/graffiti.ts
@@ -12,7 +12,7 @@ export function toGraffitiBytes(graffiti: string): Bytes32 {
 /**
  * Converts a graffiti from 32 bytes buffer back to a UTF-8 string
  */
-export function fromGraffitiBytes(graffiti: Uint8Array): string {
+export function fromGraffitiBytes(graffiti: Bytes32): string {
   return Buffer.from(graffiti.buffer, graffiti.byteOffset, graffiti.byteLength)
     .toString("utf8")
     .replaceAll("\u0000", "");

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -13,7 +13,7 @@ import {CommonBlockBody} from "../../../../../src/chain/interface.js";
 import {BlockType, produceBlockBody} from "../../../../../src/chain/produceBlock/index.js";
 import {PayloadIdCache} from "../../../../../src/execution/index.js";
 import {SyncState} from "../../../../../src/sync/interface.js";
-import {toGraffitiBuffer} from "../../../../../src/util/graffiti.js";
+import {toGraffitiBytes} from "../../../../../src/util/graffiti.js";
 import {ApiTestModules, getApiTestModules} from "../../../../utils/api.js";
 import {generateCachedBellatrixState, zeroProtoBlock} from "../../../../utils/state.js";
 import {generateProtoBlock} from "../../../../utils/typeGenerator.js";
@@ -200,7 +200,7 @@ describe("api/validator - produceBlockV3", () => {
     await api.produceBlockV3({slot, randaoReveal, graffiti, feeRecipient});
     expect(modules.chain.produceBlock).toBeCalledWith({
       randaoReveal,
-      graffiti: toGraffitiBuffer(graffiti),
+      graffiti: toGraffitiBytes(graffiti),
       slot,
       parentBlockRoot,
       feeRecipient,
@@ -211,7 +211,7 @@ describe("api/validator - produceBlockV3", () => {
     await api.produceBlockV3({slot, randaoReveal, graffiti});
     expect(modules.chain.produceBlock).toBeCalledWith({
       randaoReveal,
-      graffiti: toGraffitiBuffer(graffiti),
+      graffiti: toGraffitiBytes(graffiti),
       slot,
       parentBlockRoot,
       feeRecipient: undefined,
@@ -253,7 +253,7 @@ describe("api/validator - produceBlockV3", () => {
     // use fee recipient passed in produceBlockBody call for payload gen in engine notifyForkchoiceUpdate
     await produceBlockBody.call(modules.chain as unknown as BeaconChain, BlockType.Full, state, {
       randaoReveal,
-      graffiti: toGraffitiBuffer(graffiti),
+      graffiti: toGraffitiBytes(graffiti),
       slot,
       feeRecipient,
       parentSlot: slot - 1,
@@ -278,7 +278,7 @@ describe("api/validator - produceBlockV3", () => {
     modules.chain["beaconProposerCache"].getOrDefault.mockReturnValue("0x fee recipient address");
     await produceBlockBody.call(modules.chain as unknown as BeaconChain, BlockType.Full, state, {
       randaoReveal,
-      graffiti: toGraffitiBuffer(graffiti),
+      graffiti: toGraffitiBytes(graffiti),
       slot,
       parentSlot: slot - 1,
       parentBlockRoot: fromHexString(ZERO_HASH_HEX),

--- a/packages/beacon-node/test/unit/util/graffiti.test.ts
+++ b/packages/beacon-node/test/unit/util/graffiti.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from "vitest";
 import {ClientCode} from "../../../src/execution/index.js";
-import {getDefaultGraffiti, toGraffitiBuffer} from "../../../src/util/graffiti.js";
+import {getDefaultGraffiti, toGraffitiBytes} from "../../../src/util/graffiti.js";
 
 describe("Graffiti helper", () => {
   describe("toGraffitiBuffer", () => {
@@ -23,7 +23,7 @@ describe("Graffiti helper", () => {
     ];
     for (const {input, result} of cases) {
       it(`Convert graffiti UTF8 ${input} to Buffer`, () => {
-        expect(toGraffitiBuffer(input).toString("hex")).toBe(result);
+        expect(Buffer.from(toGraffitiBytes(input)).toString("hex")).toBe(result);
       });
     }
   });


### PR DESCRIPTION
**Motivation**

Remove unused code. 

**Description**

The functions `produceBuilderBlindedBlock` and `produceEngineFullBlockOrContents` is only used inside `produceEngineOrBuilderBlock`. And we already have all logic for `notOnOutOfRangeData` in there, so no need to duplciate that logic. 


**Steps to test or reproduce**

Run all tests