### PR TITLE
docs: add python distutils to faqs

### DIFF
--- a/docs/pages/faqs.md
+++ b/docs/pages/faqs.md
@@ -7,13 +7,14 @@ This section of the documentation will cover common questions and common encount
 ### Python Distutils
 
 :::note "MacOS: ModuleNotFoundError: No module named 'distutils'"
-When using the `yarn` command, some MacOS users may experience this error if they are running Python 3.12+. The `distutils` module has been removed from the standard Python library via PEP 632 which deprecates and eliminates `distutils` in favor of other tools like `setuptools`. 
+When using the `yarn` command, some MacOS users may experience this error if they are running Python 3.12+. The `distutils` module has been removed from the standard Python library via PEP 632 which deprecates and eliminates `distutils` in favor of other tools like `setuptools`.
 
 For MacOS, there is no direct equivalent package to Linux's `python3-distutils`. Therefore, the solution is to install the `python-setuptools` package via Homebrew: `brew install python-setuptools`
 
 :::
 
 ### Yarn Package Manager
+
 :::note "Package manager issues"
 
 Lodestar relies on [Corepack](https://nodejs.org/api/corepack.html) and associated `packageManager` value to manage its package manager version.

--- a/docs/pages/faqs.md
+++ b/docs/pages/faqs.md
@@ -2,8 +2,18 @@
 
 This section of the documentation will cover common questions and common encounters by users and developers.
 
-## Tooling
+## Developer Tooling
 
+### Python Distutils
+
+:::note "MacOS: ModuleNotFoundError: No module named 'distutils'"
+When using the `yarn` command, some MacOS users may experience this error if they are running Python 3.12+. The `distutils` module has been removed from the standard Python library via PEP 632 which deprecates and eliminates `distutils` in favor of other tools like `setuptools`. 
+
+For MacOS, there is no direct equivalent package to Linux's `python3-distutils`. Therefore, the solution is to install the `python-setuptools` package via Homebrew: `brew install python-setuptools`
+
+:::
+
+### Yarn Package Manager
 :::note "Package manager issues"
 
 Lodestar relies on [Corepack](https://nodejs.org/api/corepack.html) and associated `packageManager` value to manage its package manager version.


### PR DESCRIPTION
**Motivation**

Adding resolution for MacOS users running Python 3.12+ where `distutils` module was removed from standard Python library. If developers experience this error, they can refer to the FAQs.

**Description**

This PR persists the brew command to resolve the issue.
