### PR TITLE
fix: review EIP-7045

### DIFF
--- a/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
@@ -13,11 +13,11 @@ import {MapDef} from "@lodestar/utils";
 // - `compute_epoch_at_slot(attestation.data.slot) in (get_previous_epoch(state), get_current_epoch(state))`
 //
 // When factored in MAXIMUM_GOSSIP_CLOCK_DISPARITY, it is possible we keep 3 epochs of SeenAttesters:
-// previous, current and future epoch. This constant is solely used to calculate `lowestPermissableEpoch`
+// previous, current and future epoch. This constant is solely used to calculate `lowestPermissibleEpoch`
 // which prunes anything older than it.
 //
-// assuming we're at epoch 100 while all other nodes at epoch 99, they all accept attestations at epoch 98, 99. If MAX_RETAINED_EPOCH = 2 then our lowestPermissableEpoch is 98 which is fine
-// assuming we're at epoch 99 while all other nodes at epoch 100, they all accept attestations at epoch 99, 100. If MAX_RETAINED_EPOCH = 2 then lowestPermissableEpoch is 97 which is more than enough
+// assuming we're at epoch 100 while all other nodes at epoch 99, they all accept attestations at epoch 98, 99. If MAX_RETAINED_EPOCH = 2 then our lowestPermissibleEpoch is 98 which is fine
+// assuming we're at epoch 99 while all other nodes at epoch 100, they all accept attestations at epoch 99, 100. If MAX_RETAINED_EPOCH = 2 then lowestPermissibleEpoch is 97 which is more than enough
 const EPOCH_LOOKBACK_LIMIT = 2;
 
 /**

--- a/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
@@ -1,7 +1,7 @@
 import {Epoch, ValidatorIndex} from "@lodestar/types";
 import {MapDef} from "@lodestar/utils";
 
-// How many *non future* epoch we intend to keep for SeenAttesters.
+// How many *non future* epochs we intend to keep for SeenAttesters.
 // Pre and post deneb specs require us to accept attestations from current and
 // previous epoch.
 //

--- a/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
@@ -18,6 +18,7 @@ import {MapDef} from "@lodestar/utils";
 //
 // Assuming we're at epoch 100 while all other nodes at epoch 99, they all accept attestations at epoch 98, 99.
 // If MAX_RETAINED_EPOCH = 2 then our lowestPermissibleEpoch is 98 which is fine
+//
 // Assuming we're at epoch 99 while all other nodes at epoch 100, they all accept attestations at epoch 99, 100.
 // If MAX_RETAINED_EPOCH = 2 then lowestPermissibleEpoch is 97 which is more than enough
 const EPOCH_LOOKBACK_LIMIT = 2;

--- a/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
@@ -16,8 +16,10 @@ import {MapDef} from "@lodestar/utils";
 // previous, current and future epoch. This constant is solely used to calculate `lowestPermissibleEpoch`
 // which prunes anything older than it.
 //
-// assuming we're at epoch 100 while all other nodes at epoch 99, they all accept attestations at epoch 98, 99. If MAX_RETAINED_EPOCH = 2 then our lowestPermissibleEpoch is 98 which is fine
-// assuming we're at epoch 99 while all other nodes at epoch 100, they all accept attestations at epoch 99, 100. If MAX_RETAINED_EPOCH = 2 then lowestPermissibleEpoch is 97 which is more than enough
+// Assuming we're at epoch 100 while all other nodes at epoch 99, they all accept attestations at epoch 98, 99. 
+// If MAX_RETAINED_EPOCH = 2 then our lowestPermissibleEpoch is 98 which is fine
+// Assuming we're at epoch 99 while all other nodes at epoch 100, they all accept attestations at epoch 99, 100.
+// If MAX_RETAINED_EPOCH = 2 then lowestPermissibleEpoch is 97 which is more than enough
 const EPOCH_LOOKBACK_LIMIT = 2;
 
 /**

--- a/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
@@ -1,18 +1,24 @@
 import {Epoch, ValidatorIndex} from "@lodestar/types";
 import {MapDef} from "@lodestar/utils";
 
-// The next, current and previous epochs. We require the next epoch due to the
-// `MAXIMUM_GOSSIP_CLOCK_DISPARITY`. We require the previous epoch since the
-// specification delcares:
+// How many *non future* epoch we intend to keep for SeenAttesters.
+// Pre and post deneb specs require us to accept attestations from current and
+// previous epoch.
 //
-// ```
-// aggregate.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE
-//      >= current_slot >= aggregate.data.slot
-// ```
+// Pre-deneb:
+// - `attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot`
 //
-// This means that during the current epoch we will always accept an attestation
-// from at least one slot in the previous epoch.
-const MAX_EPOCHS = 3;
+// Post-deneb:
+// - `attestation.data.slot <= current_slot`
+// - `compute_epoch_at_slot(attestation.data.slot) in (get_previous_epoch(state), get_current_epoch(state))`
+//
+// When factored in MAXIMUM_GOSSIP_CLOCK_DISPARITY, it is possible we keep 3 epochs of SeenAttesters:
+// previous, current and future epoch. This constant is solely used to calculate `lowestPermissableEpoch`
+// which prunes anything older than it.
+//
+// assuming we're at epoch 100 while all other nodes at epoch 99, they all accept attestations at epoch 98, 99. If MAX_RETAINED_EPOCH = 2 then our lowestPermissableEpoch is 98 which is fine
+// assuming we're at epoch 99 while all other nodes at epoch 100, they all accept attestations at epoch 99, 100. If MAX_RETAINED_EPOCH = 2 then lowestPermissableEpoch is 97 which is more than enough
+const EPOCH_LOOKBACK_LIMIT = 2;
 
 /**
  * Keeps a cache to filter unaggregated attestations from the same validator in the same epoch.
@@ -34,7 +40,7 @@ export class SeenAttesters {
   }
 
   prune(currentEpoch: Epoch): void {
-    this.lowestPermissibleEpoch = Math.max(currentEpoch - MAX_EPOCHS, 0);
+    this.lowestPermissibleEpoch = Math.max(currentEpoch - EPOCH_LOOKBACK_LIMIT, 0);
     for (const epoch of this.validatorIndexesByEpoch.keys()) {
       if (epoch < this.lowestPermissibleEpoch) {
         this.validatorIndexesByEpoch.delete(epoch);

--- a/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenAttesters.ts
@@ -16,7 +16,7 @@ import {MapDef} from "@lodestar/utils";
 // previous, current and future epoch. This constant is solely used to calculate `lowestPermissibleEpoch`
 // which prunes anything older than it.
 //
-// Assuming we're at epoch 100 while all other nodes at epoch 99, they all accept attestations at epoch 98, 99. 
+// Assuming we're at epoch 100 while all other nodes at epoch 99, they all accept attestations at epoch 98, 99.
 // If MAX_RETAINED_EPOCH = 2 then our lowestPermissibleEpoch is 98 which is fine
 // Assuming we're at epoch 99 while all other nodes at epoch 100, they all accept attestations at epoch 99, 100.
 // If MAX_RETAINED_EPOCH = 2 then lowestPermissibleEpoch is 97 which is more than enough

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -104,9 +104,17 @@ async function validateAggregateAndProof(
       throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.BAD_TARGET_EPOCH});
     }
 
+    // Pre-deneb:
     // [IGNORE] aggregate.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
     // -- i.e. aggregate.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= aggregate.data.slot
     // (a client MAY queue future aggregates for processing at the appropriate slot).
+    // Post-deneb:
+    // [IGNORE] `aggregate.data.slot` is equal to or earlier than the `current_slot` (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance)
+    // -- i.e. `aggregate.data.slot <= current_slot`
+    //   (a client MAY queue future aggregates for processing at the appropriate slot).
+    // [IGNORE] the epoch of `aggregate.data.slot` is either the current or previous epoch
+    //   (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance)
+    // -- i.e. `compute_epoch_at_slot(aggregate.data.slot) in (get_previous_epoch(state), get_current_epoch(state))`
     verifyPropagationSlotRange(fork, chain, attSlot);
   }
 

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -320,9 +320,17 @@ async function validateAttestationNoSignatureCheck(
       });
     }
 
+    // Pre-deneb:
     // [IGNORE] attestation.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots (within a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
     //  -- i.e. attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot
     // (a client MAY queue future attestations for processing at the appropriate slot).
+    // Post-deneb:
+    // [IGNORE] `attestation.data.slot` is equal to or earlier than the `current_slot` (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance)
+    // -- i.e. `attestation.data.slot <= current_slot`
+    //   (a client MAY queue future attestation for processing at the appropriate slot).
+    // [IGNORE] the epoch of `attestation.data.slot` is either the current or previous epoch
+    //   (with a `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance)
+    // -- i.e. `compute_epoch_at_slot(attestation.data.slot) in (get_previous_epoch(state), get_current_epoch(state))`
     verifyPropagationSlotRange(fork, chain, attestationOrCache.attestation.data.slot);
   }
 

--- a/packages/state-transition/src/block/processAttestationPhase0.ts
+++ b/packages/state-transition/src/block/processAttestationPhase0.ts
@@ -3,7 +3,7 @@ import {Attestation, Slot, electra, phase0, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {assert} from "@lodestar/utils";
 import {CachedBeaconStateAllForks, CachedBeaconStatePhase0} from "../types.js";
-import {computeEpochAtSlot} from "../util/index.js";
+import {computeEndSlotAtEpoch, computeEpochAtSlot} from "../util/index.js";
 import {isValidIndexedAttestation} from "./index.js";
 
 /**
@@ -78,9 +78,11 @@ export function validateAttestation(fork: ForkSeq, state: CachedBeaconStateAllFo
 
   // post deneb, the attestations are valid till end of next epoch
   if (!(data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= slot && isTimelyTarget(fork, slot - data.slot))) {
+    const windowStart = data.slot + MIN_ATTESTATION_INCLUSION_DELAY;
+    const windowEnd = fork >= ForkSeq.deneb ? computeEndSlotAtEpoch(computedEpoch + 1) : data.slot + SLOTS_PER_EPOCH;
+
     throw new Error(
-      "Attestation slot not within inclusion window: " +
-        `slot=${data.slot} window=${data.slot + MIN_ATTESTATION_INCLUSION_DELAY}..${data.slot + SLOTS_PER_EPOCH}`
+      "Attestation slot not within inclusion window: " + `slot=${data.slot} window=${windowStart}..${windowEnd}`
     );
   }
 

--- a/packages/state-transition/src/block/processAttestationPhase0.ts
+++ b/packages/state-transition/src/block/processAttestationPhase0.ts
@@ -82,7 +82,7 @@ export function validateAttestation(fork: ForkSeq, state: CachedBeaconStateAllFo
     const windowEnd = fork >= ForkSeq.deneb ? computeEndSlotAtEpoch(computedEpoch + 1) : data.slot + SLOTS_PER_EPOCH;
 
     throw new Error(
-      "Attestation slot not within inclusion window: " + `slot=${data.slot} window=${windowStart}..${windowEnd}`
+      `Attestation slot not within inclusion window: slot=${data.slot} window=${windowStart}..${windowEnd}`
     );
   }
 


### PR DESCRIPTION
- Update code comments to describe EIP-7045 attestations
- Rename `MAX_EPOCHS` and `MAX_EPOCHS_IN_CACHE` in `seenAttesters` and `seenAggregateAndProof` to `EPOCH_LOOKBACK_LIMIT` for more accurate naming
- Set `EPOCH_LOOKBACK_LIMIT` in `seenAttesters` to 2. 


See EIP-7045 review discord thread for more context [here](https://discord.com/channels/593655374469660673/1357685167422050427)