### PR TITLE
feat: add genesis state root integrity validation

### DIFF
--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -15,13 +15,14 @@ import {
 } from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {Checkpoint} from "@lodestar/types/phase0";
-import {Logger, formatBytes} from "@lodestar/utils";
+import {Logger, formatBytes, toRootHex} from "@lodestar/utils";
 
 import {
   fetchWeakSubjectivityState,
   getCheckpointFromArg,
   getCheckpointFromState,
   getGenesisFileUrl,
+  getGenesisStateRoot,
 } from "../../networks/index.js";
 import {GlobalArgs, defaultNetwork} from "../../options/globalOptions.js";
 import {downloadOrLoadFile, wrapFnError} from "../../util/index.js";
@@ -187,6 +188,15 @@ export async function initBeaconState(
     // Convert to `Uint8Array` to avoid unexpected behavior such as `Buffer.prototype.slice` not copying memory
     stateBytes = new Uint8Array(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength);
     const anchorState = getStateTypeFromBytes(chainForkConfig, stateBytes).deserializeToViewDU(stateBytes);
+    // Validate genesis state root
+    const stateRoot = toRootHex(anchorState.hashTreeRoot());
+    const expectedRoot = getGenesisStateRoot(args.network || defaultNetwork);
+    if (expectedRoot && stateRoot !== expectedRoot) {
+      logger.error("Genesis state root mismatch", {
+        expected: expectedRoot,
+        found: stateRoot,
+      });
+    }
     const config = createBeaconConfig(chainForkConfig, anchorState.genesisValidatorsRoot);
     const wssCheck = isWithinWeakSubjectivityPeriod(config, anchorState, getCheckpointFromState(anchorState));
     await checkAndPersistAnchorState(config, db, logger, anchorState, stateBytes, {

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -192,7 +192,7 @@ export async function initBeaconState(
     const stateRoot = toRootHex(anchorState.hashTreeRoot());
     const expectedRoot = getGenesisStateRoot(args.network || defaultNetwork);
     if (expectedRoot !== null && stateRoot !== expectedRoot) {
-      throw Error(`Genesis state root mismatch expected=${expectedRoot} received=${stateRoot}`)
+      throw Error(`Genesis state root mismatch expected=${expectedRoot} received=${stateRoot}`);
     }
     const config = createBeaconConfig(chainForkConfig, anchorState.genesisValidatorsRoot);
     const wssCheck = isWithinWeakSubjectivityPeriod(config, anchorState, getCheckpointFromState(anchorState));

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -191,11 +191,11 @@ export async function initBeaconState(
     // Validate genesis state root
     const stateRoot = toRootHex(anchorState.hashTreeRoot());
     const expectedRoot = getGenesisStateRoot(args.network || defaultNetwork);
-    if (expectedRoot && stateRoot !== expectedRoot) {
-      logger.error("Genesis state root mismatch", {
-        expected: expectedRoot,
-        found: stateRoot,
-      });
+    if (expectedRoot !== null && stateRoot !== expectedRoot) {
+      throw new Error(`Genesis state root mismatch, {
+        expected: ${expectedRoot},
+        found: ${stateRoot},
+      }`);
     }
     const config = createBeaconConfig(chainForkConfig, anchorState.genesisValidatorsRoot);
     const wssCheck = isWithinWeakSubjectivityPeriod(config, anchorState, getCheckpointFromState(anchorState));

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -192,10 +192,7 @@ export async function initBeaconState(
     const stateRoot = toRootHex(anchorState.hashTreeRoot());
     const expectedRoot = getGenesisStateRoot(args.network || defaultNetwork);
     if (expectedRoot !== null && stateRoot !== expectedRoot) {
-      throw new Error(`Genesis state root mismatch, {
-        expected: ${expectedRoot},
-        found: ${stateRoot},
-      }`);
+      throw Error(`Genesis state root mismatch expected=${expectedRoot} received=${stateRoot}`)
     }
     const config = createBeaconConfig(chainForkConfig, anchorState.genesisValidatorsRoot);
     const wssCheck = isWithinWeakSubjectivityPeriod(config, anchorState, getCheckpointFromState(anchorState));

--- a/packages/cli/src/networks/chiado.ts
+++ b/packages/cli/src/networks/chiado.ts
@@ -3,6 +3,7 @@ export {chiadoChainConfig as chainConfig} from "@lodestar/config/networks";
 // eth1.providerUrls suggestion: https://rpc.chiado.gnosis.gateway.fm
 export const depositContractDeployBlock = 155435;
 export const genesisFileUrl = "https://raw.githubusercontent.com/gnosischain/configs/main/chiado/genesis.ssz";
+export const genesisStateRoot = null;
 export const bootnodesFileUrl = "https://raw.githubusercontent.com/gnosischain/configs/main/chiado/bootnodes.yaml";
 
 export const bootEnrs = [

--- a/packages/cli/src/networks/chiado.ts
+++ b/packages/cli/src/networks/chiado.ts
@@ -3,7 +3,7 @@ export {chiadoChainConfig as chainConfig} from "@lodestar/config/networks";
 // eth1.providerUrls suggestion: https://rpc.chiado.gnosis.gateway.fm
 export const depositContractDeployBlock = 155435;
 export const genesisFileUrl = "https://raw.githubusercontent.com/gnosischain/configs/main/chiado/genesis.ssz";
-export const genesisStateRoot = null;
+export const genesisStateRoot = "0xa48419160f8f146ecaa53d12a5d6e1e6af414a328afdc56b60d5002bb472a077";
 export const bootnodesFileUrl = "https://raw.githubusercontent.com/gnosischain/configs/main/chiado/bootnodes.yaml";
 
 export const bootEnrs = [

--- a/packages/cli/src/networks/dev.ts
+++ b/packages/cli/src/networks/dev.ts
@@ -22,5 +22,6 @@ export {chainConfig};
 
 export const depositContractDeployBlock = 0;
 export const genesisFileUrl = null;
+export const genesisStateRoot = null;
 export const bootnodesFileUrl = null;
 export const bootEnrs = [];

--- a/packages/cli/src/networks/ephemery.ts
+++ b/packages/cli/src/networks/ephemery.ts
@@ -2,6 +2,7 @@ export {ephemeryChainConfig as chainConfig} from "@lodestar/config/networks";
 
 export const depositContractDeployBlock = 0;
 export const genesisFileUrl = "https://ephemery.dev/latest/genesis.ssz";
+export const genesisStateRoot = null;
 export const bootnodesFileUrl = "https://ephemery.dev/latest/bootstrap_nodes.txt";
 
 // Pick from above file

--- a/packages/cli/src/networks/gnosis.ts
+++ b/packages/cli/src/networks/gnosis.ts
@@ -3,7 +3,7 @@ export {gnosisChainConfig as chainConfig} from "@lodestar/config/networks";
 // eth1.providerUrls suggestion: https://rpc.gnosischain.com
 export const depositContractDeployBlock = 19469077;
 export const genesisFileUrl = "https://raw.githubusercontent.com/gnosischain/configs/main/mainnet/genesis.ssz";
-export const genesisStateRoot = null;
+export const genesisStateRoot = "0x1511578d6de70428bf3529ab92102f21070694cb205443437fae359a7f220537";
 export const bootnodesFileUrl = "https://raw.githubusercontent.com/gnosischain/configs/main/mainnet/bootnodes.yaml";
 
 export const bootEnrs = [

--- a/packages/cli/src/networks/gnosis.ts
+++ b/packages/cli/src/networks/gnosis.ts
@@ -3,6 +3,7 @@ export {gnosisChainConfig as chainConfig} from "@lodestar/config/networks";
 // eth1.providerUrls suggestion: https://rpc.gnosischain.com
 export const depositContractDeployBlock = 19469077;
 export const genesisFileUrl = "https://raw.githubusercontent.com/gnosischain/configs/main/mainnet/genesis.ssz";
+export const genesisStateRoot = null;
 export const bootnodesFileUrl = "https://raw.githubusercontent.com/gnosischain/configs/main/mainnet/bootnodes.yaml";
 
 export const bootEnrs = [

--- a/packages/cli/src/networks/holesky.ts
+++ b/packages/cli/src/networks/holesky.ts
@@ -2,7 +2,7 @@ export {holeskyChainConfig as chainConfig} from "@lodestar/config/networks";
 
 export const depositContractDeployBlock = 0;
 export const genesisFileUrl = "https://media.githubusercontent.com/media/eth-clients/holesky/main/metadata/genesis.ssz";
-export const genesisStateRoot = null;
+export const genesisStateRoot = "0x0ea3f6f9515823b59c863454675fefcd1d8b4f2dbe454db166206a41fda060a0";
 export const bootnodesFileUrl =
   "https://raw.githubusercontent.com/eth-clients/holesky/main/metadata/bootstrap_nodes.yaml";
 

--- a/packages/cli/src/networks/holesky.ts
+++ b/packages/cli/src/networks/holesky.ts
@@ -2,6 +2,7 @@ export {holeskyChainConfig as chainConfig} from "@lodestar/config/networks";
 
 export const depositContractDeployBlock = 0;
 export const genesisFileUrl = "https://media.githubusercontent.com/media/eth-clients/holesky/main/metadata/genesis.ssz";
+export const genesisStateRoot = null;
 export const bootnodesFileUrl =
   "https://raw.githubusercontent.com/eth-clients/holesky/main/metadata/bootstrap_nodes.yaml";
 

--- a/packages/cli/src/networks/hoodi.ts
+++ b/packages/cli/src/networks/hoodi.ts
@@ -2,6 +2,7 @@ export {hoodiChainConfig as chainConfig} from "@lodestar/config/networks";
 
 export const depositContractDeployBlock = 0;
 export const genesisFileUrl = "https://media.githubusercontent.com/media/eth-clients/hoodi/main/metadata/genesis.ssz";
+export const genesisStateRoot = "0x2683ebc120f91f740c7bed4c866672d01e1ba51b4cc360297138";
 export const bootnodesFileUrl =
   "https://raw.githubusercontent.com/eth-clients/hoodi/main/metadata/bootstrap_nodes.yaml";
 

--- a/packages/cli/src/networks/hoodi.ts
+++ b/packages/cli/src/networks/hoodi.ts
@@ -2,7 +2,7 @@ export {hoodiChainConfig as chainConfig} from "@lodestar/config/networks";
 
 export const depositContractDeployBlock = 0;
 export const genesisFileUrl = "https://media.githubusercontent.com/media/eth-clients/hoodi/main/metadata/genesis.ssz";
-export const genesisStateRoot = "0x2683ebc120f91f740c7bed4c866672d01e1ba51b4cc360297138";
+export const genesisStateRoot = "0x2683ebc120f91f740c7bed4c866672d01e1ba51b4cc360297138465ee5df40f0";
 export const bootnodesFileUrl =
   "https://raw.githubusercontent.com/eth-clients/hoodi/main/metadata/bootstrap_nodes.yaml";
 

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -54,6 +54,7 @@ export function getNetworkData(network: NetworkName): {
   chainConfig: ChainConfig;
   depositContractDeployBlock: number;
   genesisFileUrl: string | null;
+  genesisStateRoot: string | null;
   bootnodesFileUrl: string | null;
   bootEnrs: string[];
 } {
@@ -88,6 +89,13 @@ export function getNetworkBeaconParams(network: NetworkName): ChainConfig {
  */
 export function getGenesisFileUrl(network: NetworkName): string | null {
   return getNetworkData(network).genesisFileUrl;
+}
+
+/**
+ * Get expected genesisStateRoot for validation. Returns null if not available
+ */
+export function getGenesisStateRoot(network: NetworkName): string | null {
+  return getNetworkData(network).genesisStateRoot;
 }
 
 /**

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -92,7 +92,8 @@ export function getGenesisFileUrl(network: NetworkName): string | null {
 }
 
 /**
- * Get expected genesisStateRoot for validation. Returns null if not available
+ * Get expected genesisStateRoot for validation. Returns null if not available.
+ * For example, this returns null for Ephemery, since its genesis state root changes with each iteration and we don't know the permanent state root.
  */
 export function getGenesisStateRoot(network: NetworkName): string | null {
   return getNetworkData(network).genesisStateRoot;

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -93,7 +93,8 @@ export function getGenesisFileUrl(network: NetworkName): string | null {
 
 /**
  * Get expected genesisStateRoot for validation. Returns null if not available.
- * For example, this returns null for Ephemery, since its genesis state root changes with each iteration and we don't know the permanent state root.
+ * For example, this returns null for Ephemery, since its genesis state root
+ * changes with each iteration and we don't know the permanent state root.
  */
 export function getGenesisStateRoot(network: NetworkName): string | null {
   return getNetworkData(network).genesisStateRoot;

--- a/packages/cli/src/networks/mainnet.ts
+++ b/packages/cli/src/networks/mainnet.ts
@@ -3,6 +3,7 @@ export {mainnetChainConfig as chainConfig} from "@lodestar/config/networks";
 export const depositContractDeployBlock = 11052984;
 export const genesisFileUrl =
   "https://raw.githubusercontent.com/eth-clients/mainnet/refs/heads/main/metadata/genesis.ssz";
+export const genesisStateRoot = null;
 export const bootnodesFileUrl =
   "https://raw.githubusercontent.com/eth-clients/mainnet/refs/heads/main/metadata/bootstrap_nodes.yaml";
 

--- a/packages/cli/src/networks/mainnet.ts
+++ b/packages/cli/src/networks/mainnet.ts
@@ -3,7 +3,7 @@ export {mainnetChainConfig as chainConfig} from "@lodestar/config/networks";
 export const depositContractDeployBlock = 11052984;
 export const genesisFileUrl =
   "https://raw.githubusercontent.com/eth-clients/mainnet/refs/heads/main/metadata/genesis.ssz";
-export const genesisStateRoot = null;
+export const genesisStateRoot = "0x7e76880eb67bbdc86250aa578958e9d0675e64e714337855204fb5abaaf82c2b";
 export const bootnodesFileUrl =
   "https://raw.githubusercontent.com/eth-clients/mainnet/refs/heads/main/metadata/bootstrap_nodes.yaml";
 

--- a/packages/cli/src/networks/sepolia.ts
+++ b/packages/cli/src/networks/sepolia.ts
@@ -2,6 +2,7 @@ export {sepoliaChainConfig as chainConfig} from "@lodestar/config/networks";
 
 export const depositContractDeployBlock = 1273020;
 export const genesisFileUrl = "https://github.com/eth-clients/sepolia/raw/main/metadata/genesis.ssz";
+export const genesisStateRoot = null;
 export const bootnodesFileUrl =
   "https://raw.githubusercontent.com/eth-clients/sepolia/main/metadata/bootstrap_nodes.yaml";
 

--- a/packages/cli/src/networks/sepolia.ts
+++ b/packages/cli/src/networks/sepolia.ts
@@ -2,7 +2,7 @@ export {sepoliaChainConfig as chainConfig} from "@lodestar/config/networks";
 
 export const depositContractDeployBlock = 1273020;
 export const genesisFileUrl = "https://github.com/eth-clients/sepolia/raw/main/metadata/genesis.ssz";
-export const genesisStateRoot = null;
+export const genesisStateRoot = "0xfb9afe32150fa39f4b346be2519a67e2a4f5efcd50a1dc192c3f6b3d013d2798";
 export const bootnodesFileUrl =
   "https://raw.githubusercontent.com/eth-clients/sepolia/main/metadata/bootstrap_nodes.yaml";
 


### PR DESCRIPTION
#**Motivation**
This PR adds validation of genesis state roots when initializing the beacon node from a downloaded genesis state file. This helps ensure node operators are working with the correct genesis state and can detect potential tampering or misconfigurations. This validation is particularly useful during testnet launches and provides an important security check.

**Description**
Implements validation of genesis state root against expected values in the network configuration.

Changes:
- Added `getGenesisStateRoot()` utility function to retrieve expected roots for networks
- Added `genesisStateRoot` configuration property to all network files (with initial value known only for hoodi testnet)
- Added validation logic that computes the hash tree root of downloaded genesis state and compares against expected `genesisStateRoot`

Closes #7601