### PR TITLE
fix: advance pre state's slot used in rewards endpoints

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -18,6 +18,7 @@ import {
   createCachedBeaconState,
   getEffectiveBalanceIncrementsZeroInactive,
   isCachedBeaconState,
+  processSlots,
 } from "@lodestar/state-transition";
 import {
   BeaconBlock,
@@ -1230,11 +1231,13 @@ export class BeaconChain implements IBeaconChain {
   }
 
   async getBlockRewards(block: BeaconBlock | BlindedBeaconBlock): Promise<BlockRewards> {
-    const preState = this.regen.getPreStateSync(block);
+    let preState = this.regen.getPreStateSync(block);
 
     if (preState === null) {
       throw Error(`Pre-state is unavailable given block's parent root ${toRootHex(block.parentRoot)}`);
     }
+
+    preState = processSlots(preState, block.slot); // Dial preState's slot to block.slot
 
     const postState = this.regen.getStateSync(toRootHex(block.stateRoot)) ?? undefined;
 
@@ -1271,11 +1274,13 @@ export class BeaconChain implements IBeaconChain {
     block: BeaconBlock | BlindedBeaconBlock,
     validatorIds?: (ValidatorIndex | string)[]
   ): Promise<SyncCommitteeRewards> {
-    const preState = this.regen.getPreStateSync(block);
+    let preState = this.regen.getPreStateSync(block);
 
     if (preState === null) {
       throw Error(`Pre-state is unavailable given block's parent root ${toRootHex(block.parentRoot)}`);
     }
+
+    preState = processSlots(preState, block.slot); // Dial preState's slot to block.slot
 
     return computeSyncCommitteeRewards(block, preState.clone(), validatorIds);
   }


### PR DESCRIPTION
Currently `getBlockRewards` uses a pre state that has slot of parent block. 

This is not right because `validateAttestation` checks block attestations' slot with `preState.slot = block.parent.slot`

```
  if (!(data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= slot && isTimelyTarget(fork, slot - data.slot))) {
    throw new Error(
      "Attestation slot not within inclusion window: " +
        `slot=${data.slot} window=${data.slot + MIN_ATTESTATION_INCLUSION_DELAY}..${data.slot + SLOTS_PER_EPOCH}`
    );
  }
```

We need to advance pre state's slot to `block.slot` before proceed with the calculation.

Also updates `preState` in `getSyncCommitteeRewards` for the sake of consistency albeit no functional difference.