### PR TITLE
chore: throw error if ssz types for fork are not defined

### DIFF
--- a/packages/types/src/sszTypes.ts
+++ b/packages/types/src/sszTypes.ts
@@ -64,7 +64,11 @@ export function sszTypesFor<F extends ForkName, K extends keyof SSZTypesByFork[F
   fork: F,
   typeName?: K
 ): SSZTypesFor<F, K> {
-  return (
-    typeName === undefined ? typesByFork[fork] : typesByFork[fork][typeName as keyof SSZTypesByFork[F]]
-  ) as SSZTypesFor<F, K>;
+  const sszTypes = typesByFork[fork];
+
+  if (sszTypes === undefined) {
+    throw Error(`SSZ types for fork ${fork} are not defined`);
+  }
+
+  return (typeName === undefined ? sszTypes : sszTypes[typeName as keyof SSZTypesByFork[F]]) as SSZTypesFor<F, K>;
 }


### PR DESCRIPTION
**Motivation**

This makes debugging of ssz static spec tests easier as we print out the fork that is causing issues. Also as per type this function does not return `void` but in practice it happens due to missing check.

**Description**

Throw error if ssz types for fork are not defined
