### PR TITLE
feat: more metrics for SyncContributionAndProofPool

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1314,7 +1314,8 @@ export function getValidatorApi(
             );
             const insertOutcome = chain.syncContributionAndProofPool.add(
               contributionAndProof.message,
-              syncCommitteeParticipantIndices.length
+              syncCommitteeParticipantIndices.length,
+              true
             );
             metrics?.opPool.syncContributionAndProofPool.apiInsertOutcome.inc({insertOutcome});
             await network.publishContributionAndProof(contributionAndProof);

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1312,10 +1312,11 @@ export function getValidatorApi(
               contributionAndProof,
               true // skip known participants check
             );
-            chain.syncContributionAndProofPool.add(
+            const insertOutcome = chain.syncContributionAndProofPool.add(
               contributionAndProof.message,
               syncCommitteeParticipantIndices.length
             );
+            metrics?.opPool.syncContributionAndProofPool.apiInsertOutcome.inc({insertOutcome});
             await network.publishContributionAndProof(contributionAndProof);
           } catch (e) {
             const logCtx = {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1095,7 +1095,6 @@ export class BeaconChain implements IBeaconChain {
     metrics.opPool.proposerSlashingPoolSize.set(this.opPool.proposerSlashingsSize);
     metrics.opPool.voluntaryExitPoolSize.set(this.opPool.voluntaryExitsSize);
     metrics.opPool.syncCommitteeMessagePoolSize.set(this.syncCommitteeMessagePool.size);
-    // metrics.opPool.syncContributionAndProofPool.size.set(this.syncContributionAndProofPool.size);
     // syncContributionAndProofPool tracks metrics on its own
     metrics.opPool.blsToExecutionChangePoolSize.set(this.opPool.blsToExecutionChangeSize);
     metrics.chain.blacklistedBlocks.set(this.blacklistedBlocks.size);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1094,7 +1094,7 @@ export class BeaconChain implements IBeaconChain {
     metrics.opPool.proposerSlashingPoolSize.set(this.opPool.proposerSlashingsSize);
     metrics.opPool.voluntaryExitPoolSize.set(this.opPool.voluntaryExitsSize);
     metrics.opPool.syncCommitteeMessagePoolSize.set(this.syncCommitteeMessagePool.size);
-    metrics.opPool.syncContributionAndProofPoolSize.set(this.syncContributionAndProofPool.size);
+    metrics.opPool.syncContributionAndProofPool.size.set(this.syncContributionAndProofPool.size);
     metrics.opPool.blsToExecutionChangePoolSize.set(this.opPool.blsToExecutionChangeSize);
     metrics.chain.blacklistedBlocks.set(this.blacklistedBlocks.size);
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -252,7 +252,7 @@ export class BeaconChain implements IBeaconChain {
       preAggregateCutOffTime,
       this.opts?.preaggregateSlotDistance
     );
-    this.syncContributionAndProofPool = new SyncContributionAndProofPool(clock, metrics);
+    this.syncContributionAndProofPool = new SyncContributionAndProofPool(clock, metrics, logger);
 
     this.seenAggregatedAttestations = new SeenAggregatedAttestations(metrics);
     this.seenContributionAndProof = new SeenContributionAndProof(metrics);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -252,7 +252,7 @@ export class BeaconChain implements IBeaconChain {
       preAggregateCutOffTime,
       this.opts?.preaggregateSlotDistance
     );
-    this.syncContributionAndProofPool = new SyncContributionAndProofPool(clock);
+    this.syncContributionAndProofPool = new SyncContributionAndProofPool(clock, metrics);
 
     this.seenAggregatedAttestations = new SeenAggregatedAttestations(metrics);
     this.seenContributionAndProof = new SeenContributionAndProof(metrics);
@@ -1095,7 +1095,8 @@ export class BeaconChain implements IBeaconChain {
     metrics.opPool.proposerSlashingPoolSize.set(this.opPool.proposerSlashingsSize);
     metrics.opPool.voluntaryExitPoolSize.set(this.opPool.voluntaryExitsSize);
     metrics.opPool.syncCommitteeMessagePoolSize.set(this.syncCommitteeMessagePool.size);
-    metrics.opPool.syncContributionAndProofPool.size.set(this.syncContributionAndProofPool.size);
+    // metrics.opPool.syncContributionAndProofPool.size.set(this.syncContributionAndProofPool.size);
+    // syncContributionAndProofPool tracks metrics on its own
     metrics.opPool.blsToExecutionChangePoolSize.set(this.opPool.blsToExecutionChangeSize);
     metrics.chain.blacklistedBlocks.set(this.blacklistedBlocks.size);
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -141,7 +141,7 @@ export class BeaconChain implements IBeaconChain {
   readonly attestationPool: AttestationPool;
   readonly aggregatedAttestationPool: AggregatedAttestationPool;
   readonly syncCommitteeMessagePool: SyncCommitteeMessagePool;
-  readonly syncContributionAndProofPool = new SyncContributionAndProofPool();
+  readonly syncContributionAndProofPool;
   readonly opPool = new OpPool();
 
   // Gossip seen cache
@@ -252,6 +252,7 @@ export class BeaconChain implements IBeaconChain {
       preAggregateCutOffTime,
       this.opts?.preaggregateSlotDistance
     );
+    this.syncContributionAndProofPool = new SyncContributionAndProofPool(clock);
 
     this.seenAggregatedAttestations = new SeenAggregatedAttestations(metrics);
     this.seenContributionAndProof = new SeenContributionAndProof(metrics);

--- a/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
@@ -4,11 +4,11 @@ import {SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params"
 import {G2_POINT_AT_INFINITY} from "@lodestar/state-transition";
 import {Root, Slot, SubnetID, altair, ssz} from "@lodestar/types";
 import {MapDef, toRootHex} from "@lodestar/utils";
+import {MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../constants/constants.js";
+import {Metrics} from "../../metrics/metrics.js";
+import {IClock} from "../../util/clock.js";
 import {InsertOutcome, OpPoolError, OpPoolErrorCode} from "./types.js";
 import {pruneBySlot, signatureFromBytesNoCheck} from "./utils.js";
-import { IClock } from "../../util/clock.js";
-import { MAXIMUM_GOSSIP_CLOCK_DISPARITY } from "../../constants/constants.js";
-import { Metrics } from "../../metrics/metrics.js";
 
 /**
  * SyncCommittee aggregates are only useful for the next block they have signed.
@@ -50,7 +50,10 @@ export class SyncContributionAndProofPool {
 
   private lowestPermissibleSlot = 0;
 
-  constructor(private readonly clock: IClock, private readonly metrics: Metrics | null = null) {
+  constructor(
+    private readonly clock: IClock,
+    private readonly metrics: Metrics | null = null
+  ) {
     // Param guarantee for optimizations below that merge syncSubcommitteeBits as bytes
     if (SYNC_COMMITTEE_SUBNET_SIZE % 8 !== 0) {
       throw Error("SYNC_COMMITTEE_SUBNET_SIZE must be multiple of 8");
@@ -72,7 +75,11 @@ export class SyncContributionAndProofPool {
   /**
    * Only call this once we pass all validation.
    */
-  add(contributionAndProof: altair.ContributionAndProof, syncCommitteeParticipants: number, priority?: boolean): InsertOutcome {
+  add(
+    contributionAndProof: altair.ContributionAndProof,
+    syncCommitteeParticipants: number,
+    priority?: boolean
+  ): InsertOutcome {
     const {contribution} = contributionAndProof;
     const {slot, beaconBlockRoot} = contribution;
     const rootHex = toRootHex(beaconBlockRoot);
@@ -196,7 +203,10 @@ export function contributionToFast(
  * Aggregate best contributions of each subnet into SyncAggregate
  * @returns SyncAggregate to be included in block body.
  */
-export function aggregate(bestContributionBySubnet: Map<number, SyncContributionFast>, metrics: Metrics | null = null): altair.SyncAggregate {
+export function aggregate(
+  bestContributionBySubnet: Map<number, SyncContributionFast>,
+  metrics: Metrics | null = null
+): altair.SyncAggregate {
   // check for empty/undefined bestContributionBySubnet earlier
   const syncCommitteeBits = BitArray.fromBitLen(SYNC_COMMITTEE_SIZE);
 

--- a/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
@@ -95,7 +95,7 @@ export class SyncContributionAndProofPool {
   }
 
   /**
-   * This is for the block factory, the same to process_sync_committee_contributions in the spec.
+   * This is for producing blocks, the same to process_sync_committee_contributions in the spec.
    */
   getAggregate(slot: Slot, prevBlockRoot: Root): altair.SyncAggregate {
     const bestContributionBySubnet = this.bestContributionBySubnetRootBySlot.get(slot)?.get(toRootHex(prevBlockRoot));

--- a/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
@@ -50,7 +50,7 @@ export class SyncContributionAndProofPool {
 
   private lowestPermissibleSlot = 0;
 
-  constructor(private readonly clock: IClock, metrics: Metrics | null = null) {
+  constructor(private readonly clock: IClock, private readonly metrics: Metrics | null = null) {
     // Param guarantee for optimizations below that merge syncSubcommitteeBits as bytes
     if (SYNC_COMMITTEE_SUBNET_SIZE % 8 !== 0) {
       throw Error("SYNC_COMMITTEE_SUBNET_SIZE must be multiple of 8");
@@ -108,9 +108,14 @@ export class SyncContributionAndProofPool {
    * This is for producing blocks, the same to process_sync_committee_contributions in the spec.
    */
   getAggregate(slot: Slot, prevBlockRoot: Root): altair.SyncAggregate {
-    const bestContributionBySubnet = this.bestContributionBySubnetRootBySlot.get(slot)?.get(toRootHex(prevBlockRoot));
-    if (!bestContributionBySubnet || bestContributionBySubnet.size === 0) {
-      // TODO: Add metric for missing SyncAggregate
+    const opPoolMetrics = this.metrics?.opPool.syncContributionAndProofPool;
+    const bestContributionBySubnetByRoot = this.bestContributionBySubnetRootBySlot.get(slot) ?? new Map();
+    opPoolMetrics?.getAggregateRoots.set(bestContributionBySubnetByRoot.size);
+    const bestContributionBySubnet = bestContributionBySubnetByRoot.get(toRootHex(prevBlockRoot)) ?? new Map();
+    opPoolMetrics?.getAggregateSubnets.set(bestContributionBySubnet.size);
+
+    if (bestContributionBySubnet.size === 0) {
+      opPoolMetrics?.getAggregateReturnsEmpty.inc();
       // Must return signature as G2_POINT_AT_INFINITY when participating bits are empty
       // https://github.com/ethereum/consensus-specs/blob/30f2a076377264677e27324a8c3c78c590ae5e20/specs/altair/bls.md#eth2_fast_aggregate_verify
       return {
@@ -119,7 +124,7 @@ export class SyncContributionAndProofPool {
       };
     }
 
-    return aggregate(bestContributionBySubnet);
+    return aggregate(bestContributionBySubnet, this.metrics);
   }
 
   /**
@@ -191,12 +196,14 @@ export function contributionToFast(
  * Aggregate best contributions of each subnet into SyncAggregate
  * @returns SyncAggregate to be included in block body.
  */
-export function aggregate(bestContributionBySubnet: Map<number, SyncContributionFast>): altair.SyncAggregate {
+export function aggregate(bestContributionBySubnet: Map<number, SyncContributionFast>, metrics: Metrics | null = null): altair.SyncAggregate {
   // check for empty/undefined bestContributionBySubnet earlier
   const syncCommitteeBits = BitArray.fromBitLen(SYNC_COMMITTEE_SIZE);
 
   const signatures: Signature[] = [];
+  let participationCount = 0;
   for (const [subnet, bestContribution] of bestContributionBySubnet.entries()) {
+    participationCount += bestContribution.numParticipants;
     const byteOffset = subnet * SYNC_COMMITTEE_SUBNET_BYTES;
 
     for (let i = 0; i < SYNC_COMMITTEE_SUBNET_BYTES; i++) {
@@ -205,6 +212,8 @@ export function aggregate(bestContributionBySubnet: Map<number, SyncContribution
 
     signatures.push(signatureFromBytesNoCheck(bestContribution.syncSubcommitteeSignature));
   }
+
+  metrics?.opPool.syncContributionAndProofPool.getAggregateParticipations.set(participationCount);
   return {
     syncCommitteeBits,
     syncCommitteeSignature: aggregateSignatures(signatures).toBytes(),

--- a/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
@@ -6,6 +6,8 @@ import {Root, Slot, SubnetID, altair, ssz} from "@lodestar/types";
 import {MapDef, toRootHex} from "@lodestar/utils";
 import {InsertOutcome, OpPoolError, OpPoolErrorCode} from "./types.js";
 import {pruneBySlot, signatureFromBytesNoCheck} from "./utils.js";
+import { IClock } from "../../util/clock.js";
+import { MAXIMUM_GOSSIP_CLOCK_DISPARITY } from "../../constants/constants.js";
 
 /**
  * SyncCommittee aggregates are only useful for the next block they have signed.
@@ -47,7 +49,7 @@ export class SyncContributionAndProofPool {
 
   private lowestPermissibleSlot = 0;
 
-  constructor() {
+  constructor(private readonly clock: IClock) {
     // Param guarantee for optimizations below that merge syncSubcommitteeBits as bytes
     if (SYNC_COMMITTEE_SUBNET_SIZE % 8 !== 0) {
       throw Error("SYNC_COMMITTEE_SUBNET_SIZE must be multiple of 8");
@@ -68,7 +70,7 @@ export class SyncContributionAndProofPool {
   /**
    * Only call this once we pass all validation.
    */
-  add(contributionAndProof: altair.ContributionAndProof, syncCommitteeParticipants: number): InsertOutcome {
+  add(contributionAndProof: altair.ContributionAndProof, syncCommitteeParticipants: number, priority?: boolean): InsertOutcome {
     const {contribution} = contributionAndProof;
     const {slot, beaconBlockRoot} = contribution;
     const rootHex = toRootHex(beaconBlockRoot);
@@ -76,6 +78,12 @@ export class SyncContributionAndProofPool {
     // Reject if too old.
     if (slot < this.lowestPermissibleSlot) {
       return InsertOutcome.Old;
+    }
+
+    // Reject ContributionAndProofs of previous slots
+    // for api ContributionAndProofs, we allow them to be added to the pool
+    if (!priority && slot < this.clock.slotWithPastTolerance(MAXIMUM_GOSSIP_CLOCK_DISPARITY)) {
+      return InsertOutcome.Late;
     }
 
     // Limit object per slot

--- a/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
@@ -3,7 +3,7 @@ import {BitArray} from "@chainsafe/ssz";
 import {SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
 import {G2_POINT_AT_INFINITY} from "@lodestar/state-transition";
 import {Root, Slot, SubnetID, altair, ssz} from "@lodestar/types";
-import {MapDef, toRootHex} from "@lodestar/utils";
+import {Logger, MapDef, toRootHex} from "@lodestar/utils";
 import {MAXIMUM_GOSSIP_CLOCK_DISPARITY} from "../../constants/constants.js";
 import {Metrics} from "../../metrics/metrics.js";
 import {IClock} from "../../util/clock.js";
@@ -52,7 +52,8 @@ export class SyncContributionAndProofPool {
 
   constructor(
     private readonly clock: IClock,
-    private readonly metrics: Metrics | null = null
+    private readonly metrics: Metrics | null = null,
+    private logger: Logger | null = null
   ) {
     // Param guarantee for optimizations below that merge syncSubcommitteeBits as bytes
     if (SYNC_COMMITTEE_SUBNET_SIZE % 8 !== 0) {
@@ -118,11 +119,19 @@ export class SyncContributionAndProofPool {
     const opPoolMetrics = this.metrics?.opPool.syncContributionAndProofPool;
     const bestContributionBySubnetByRoot = this.bestContributionBySubnetRootBySlot.get(slot) ?? new Map();
     opPoolMetrics?.getAggregateRoots.set(bestContributionBySubnetByRoot.size);
-    const bestContributionBySubnet = bestContributionBySubnetByRoot.get(toRootHex(prevBlockRoot)) ?? new Map();
+    const prevBlockRootHex = toRootHex(prevBlockRoot);
+    const bestContributionBySubnet = bestContributionBySubnetByRoot.get(prevBlockRootHex) ?? new Map();
     opPoolMetrics?.getAggregateSubnets.set(bestContributionBySubnet.size);
 
     if (bestContributionBySubnet.size === 0) {
       opPoolMetrics?.getAggregateReturnsEmpty.inc();
+      // this may happen, see https://github.com/ChainSafe/lodestar/issues/7299
+      const availableRoots = Array.from(bestContributionBySubnetByRoot.keys()).join(",");
+      this.logger?.warn("SyncContributionAndProofPool.getAggregate: no contributions for root", {
+        slot,
+        root: bestContributionBySubnet,
+        availableRoots,
+      });
       // Must return signature as G2_POINT_AT_INFINITY when participating bits are empty
       // https://github.com/ethereum/consensus-specs/blob/30f2a076377264677e27324a8c3c78c590ae5e20/specs/altair/bls.md#eth2_fast_aggregate_verify
       return {

--- a/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
@@ -8,6 +8,7 @@ import {InsertOutcome, OpPoolError, OpPoolErrorCode} from "./types.js";
 import {pruneBySlot, signatureFromBytesNoCheck} from "./utils.js";
 import { IClock } from "../../util/clock.js";
 import { MAXIMUM_GOSSIP_CLOCK_DISPARITY } from "../../constants/constants.js";
+import { Metrics } from "../../metrics/metrics.js";
 
 /**
  * SyncCommittee aggregates are only useful for the next block they have signed.
@@ -49,11 +50,12 @@ export class SyncContributionAndProofPool {
 
   private lowestPermissibleSlot = 0;
 
-  constructor(private readonly clock: IClock) {
+  constructor(private readonly clock: IClock, metrics: Metrics | null = null) {
     // Param guarantee for optimizations below that merge syncSubcommitteeBits as bytes
     if (SYNC_COMMITTEE_SUBNET_SIZE % 8 !== 0) {
       throw Error("SYNC_COMMITTEE_SUBNET_SIZE must be multiple of 8");
     }
+    metrics?.opPool.syncContributionAndProofPool.size.addCollect(() => this.onScrapeMetrics(metrics));
   }
 
   /** Returns current count of unique SyncContributionFast by block root and subnet */
@@ -128,6 +130,24 @@ export class SyncContributionAndProofPool {
   prune(headSlot: Slot): void {
     pruneBySlot(this.bestContributionBySubnetRootBySlot, headSlot, SLOTS_RETAINED);
     this.lowestPermissibleSlot = Math.max(headSlot - SLOTS_RETAINED, 0);
+  }
+
+  private onScrapeMetrics(metrics: Metrics): void {
+    const poolMetrics = metrics.opPool.syncContributionAndProofPool;
+    poolMetrics.size.set(this.size);
+    const previousSlot = this.clock.currentSlot - 1;
+    const contributionBySubnetByBlockRoot = this.bestContributionBySubnetRootBySlot.get(previousSlot) ?? new Map();
+    poolMetrics.blockRootsPerSlot.set(contributionBySubnetByBlockRoot.size);
+    let index = 0;
+    for (const contributionsBySubnet of contributionBySubnetByBlockRoot.values()) {
+      let participationCount = 0;
+      for (const contribution of contributionsBySubnet.values()) {
+        participationCount += contribution.numParticipants;
+      }
+      poolMetrics.subnetsByBlockRoot.set({index}, contributionsBySubnet.size);
+      poolMetrics.participationsByBlockRoot.set({index}, participationCount);
+      index++;
+    }
   }
 }
 

--- a/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
@@ -120,7 +120,7 @@ export class SyncContributionAndProofPool {
     const bestContributionBySubnetByRoot = this.bestContributionBySubnetRootBySlot.getOrDefault(slot);
     opPoolMetrics?.getAggregateRoots.set(bestContributionBySubnetByRoot.size);
     const prevBlockRootHex = toRootHex(prevBlockRoot);
-    const bestContributionBySubnet = bestContributionBySubnetByRoot.get(prevBlockRootHex) ?? new Map();
+    const bestContributionBySubnet = bestContributionBySubnetByRoot.getOrDefault(prevBlockRootHex);
     opPoolMetrics?.getAggregateSubnets.set(bestContributionBySubnet.size);
 
     if (bestContributionBySubnet.size === 0) {
@@ -157,7 +157,7 @@ export class SyncContributionAndProofPool {
     const poolMetrics = metrics.opPool.syncContributionAndProofPool;
     poolMetrics.size.set(this.size);
     const previousSlot = this.clock.currentSlot - 1;
-    const contributionBySubnetByBlockRoot = this.bestContributionBySubnetRootBySlot.get(previousSlot) ?? new Map();
+    const contributionBySubnetByBlockRoot = this.bestContributionBySubnetRootBySlot.getOrDefault(previousSlot);
     poolMetrics.blockRootsPerSlot.set(contributionBySubnetByBlockRoot.size);
     let index = 0;
     for (const contributionsBySubnet of contributionBySubnetByBlockRoot.values()) {

--- a/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
@@ -166,7 +166,7 @@ export class SyncContributionAndProofPool {
         participationCount += contribution.numParticipants;
       }
       poolMetrics.subnetsByBlockRoot.set({index}, contributionsBySubnet.size);
-      poolMetrics.participationsByBlockRoot.set({index}, participationCount);
+      poolMetrics.participantsByBlockRoot.set({index}, participationCount);
       index++;
     }
   }
@@ -232,7 +232,7 @@ export function aggregate(
     signatures.push(signatureFromBytesNoCheck(bestContribution.syncSubcommitteeSignature));
   }
 
-  metrics?.opPool.syncContributionAndProofPool.getAggregateParticipations.set(participationCount);
+  metrics?.opPool.syncContributionAndProofPool.getAggregateParticipants.set(participationCount);
   return {
     syncCommitteeBits,
     syncCommitteeSignature: aggregateSignatures(signatures).toBytes(),

--- a/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
@@ -117,7 +117,7 @@ export class SyncContributionAndProofPool {
    */
   getAggregate(slot: Slot, prevBlockRoot: Root): altair.SyncAggregate {
     const opPoolMetrics = this.metrics?.opPool.syncContributionAndProofPool;
-    const bestContributionBySubnetByRoot = this.bestContributionBySubnetRootBySlot.get(slot) ?? new Map();
+    const bestContributionBySubnetByRoot = this.bestContributionBySubnetRootBySlot.getOrDefault(slot);
     opPoolMetrics?.getAggregateRoots.set(bestContributionBySubnetByRoot.size);
     const prevBlockRootHex = toRootHex(prevBlockRoot);
     const bestContributionBySubnet = bestContributionBySubnetByRoot.get(prevBlockRootHex) ?? new Map();

--- a/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
@@ -129,7 +129,7 @@ export class SyncContributionAndProofPool {
       const availableRoots = Array.from(bestContributionBySubnetByRoot.keys()).join(",");
       this.logger?.warn("SyncContributionAndProofPool.getAggregate: no contributions for root", {
         slot,
-        root: bestContributionBySubnet,
+        root: prevBlockRootHex,
         availableRoots,
       });
       // Must return signature as G2_POINT_AT_INFINITY when participating bits are empty

--- a/packages/beacon-node/src/chain/opPools/types.ts
+++ b/packages/beacon-node/src/chain/opPools/types.ts
@@ -13,7 +13,7 @@ export enum InsertOutcome {
   Old = "Old",
   /** The pool has reached its limit. No changes were made. */
   ReachLimit = "ReachLimit",
-  /** Attestation comes to the pool at > 2/3 of slot. No changes were made */
+  /** Messages don't bring any value, for example attestations come to the pool at > 2/3 of slot. No changes were made */
   Late = "Late",
   /** The data is know, and the new participants have been added to the aggregated signature */
   Aggregated = "Aggregated",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -936,6 +936,20 @@ export function createLodestarMetrics(
           help: "Total number of InsertOutcome as a result of adding a ContributionAndProof from api into the pool",
           labelNames: ["insertOutcome"],
         }),
+        blockRootsPerSlot: register.gauge({
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_block_roots_per_slot_total",
+          help: "Total number of block roots per slot in SyncContributionAndProofPool",
+        }),
+        subnetsByBlockRoot: register.gauge<{index: number}>({
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_subnets_by_block_root_total",
+          help: "Total number of subnets per block root in SyncContributionAndProofPool",
+          labelNames: ["index"],
+        }),
+        participationsByBlockRoot: register.gauge<{index: number}>({
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_participations_by_block_root_total",
+          help: "Total number of participations per block root in SyncContributionAndProofPool",
+          labelNames: ["index"],
+        }),
       }
     },
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -921,10 +921,22 @@ export function createLodestarMetrics(
         help: "Total number of InsertOutcome as a result of adding a SyncCommitteeMessage to pool",
         labelNames: ["insertOutcome"],
       }),
-      syncContributionAndProofPoolSize: register.gauge({
-        name: "lodestar_oppool_sync_contribution_and_proof_pool_pool_size",
-        help: "Current size of the SyncContributionAndProofPool unique by slot subnet and block root",
-      }),
+      syncContributionAndProofPool: {
+        size: register.gauge({
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_pool_size",
+          help: "Current size of the SyncContributionAndProofPool unique by slot subnet and block root",
+        }),
+        gossipInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_gossip_insert_outcome_total",
+          help: "Total number of InsertOutcome as a result of adding a ContributionAndProof from gossip into the pool",
+          labelNames: ["insertOutcome"],
+        }),
+        apiInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_api_insert_outcome_total",
+          help: "Total number of InsertOutcome as a result of adding a ContributionAndProof from api into the pool",
+          labelNames: ["insertOutcome"],
+        }),
+      }
     },
 
     chain: {

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -945,9 +945,9 @@ export function createLodestarMetrics(
           help: "Total number of subnets per block root in SyncContributionAndProofPool",
           labelNames: ["index"],
         }),
-        participationsByBlockRoot: register.gauge<{index: number}>({
-          name: "lodestar_oppool_sync_contribution_and_proof_pool_participations_by_block_root_total",
-          help: "Total number of participations per block root in SyncContributionAndProofPool",
+        participantsByBlockRoot: register.gauge<{index: number}>({
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_participants_by_block_root_total",
+          help: "Total number of participants per block root in SyncContributionAndProofPool",
           labelNames: ["index"],
         }),
         getAggregateRoots: register.gauge({
@@ -958,9 +958,9 @@ export function createLodestarMetrics(
           name: "lodestar_oppool_sync_contribution_and_proof_pool_get_aggregate_subnets_total",
           help: "Total number of subnets in SyncContributionAndProofPool.getAggregate(slot, root)",
         }),
-        getAggregateParticipations: register.gauge({
-          name: "lodestar_oppool_sync_contribution_and_proof_pool_get_aggregate_participations_total",
-          help: "Total number of participations in SyncContributionAndProofPool.getAggregate(slot, root)",
+        getAggregateParticipants: register.gauge({
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_get_aggregate_participants_total",
+          help: "Total number of participants in SyncContributionAndProofPool.getAggregate(slot, root)",
         }),
         getAggregateReturnsEmpty: register.gauge({
           name: "lodestar_oppool_sync_contribution_and_proof_pool_get_aggregate_returns_empty_total",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -966,7 +966,7 @@ export function createLodestarMetrics(
           name: "lodestar_oppool_sync_contribution_and_proof_pool_get_aggregate_returns_empty_total",
           help: "Total number of empty returns in SyncContributionAndProofPool.getAggregate(slot, root)",
         }),
-      }
+      },
     },
 
     chain: {

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -923,7 +923,7 @@ export function createLodestarMetrics(
       }),
       syncContributionAndProofPool: {
         size: register.gauge({
-          name: "lodestar_oppool_sync_contribution_and_proof_pool_pool_size",
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_size",
           help: "Current size of the SyncContributionAndProofPool unique by slot subnet and block root",
         }),
         gossipInsertOutcome: register.counter<{insertOutcome: InsertOutcome}>({

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -950,6 +950,22 @@ export function createLodestarMetrics(
           help: "Total number of participations per block root in SyncContributionAndProofPool",
           labelNames: ["index"],
         }),
+        getAggregateRoots: register.gauge({
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_get_aggregate_roots_total",
+          help: "Total number of block roots in SyncContributionAndProofPool.getAggregate(slot)",
+        }),
+        getAggregateSubnets: register.gauge({
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_get_aggregate_subnets_total",
+          help: "Total number of subnets in SyncContributionAndProofPool.getAggregate(slot, root)",
+        }),
+        getAggregateParticipations: register.gauge({
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_get_aggregate_participations_total",
+          help: "Total number of participations in SyncContributionAndProofPool.getAggregate(slot, root)",
+        }),
+        getAggregateReturnsEmpty: register.gauge({
+          name: "lodestar_oppool_sync_contribution_and_proof_pool_get_aggregate_returns_empty_total",
+          help: "Total number of empty returns in SyncContributionAndProofPool.getAggregate(slot, root)",
+        }),
       }
     },
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -538,9 +538,11 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         syncCommitteeParticipantIndices
       );
       try {
-        const insertOutcome = chain.syncContributionAndProofPool.add(contributionAndProof.message, syncCommitteeParticipantIndices.length);
+        const insertOutcome = chain.syncContributionAndProofPool.add(
+          contributionAndProof.message,
+          syncCommitteeParticipantIndices.length
+        );
         metrics?.opPool.syncContributionAndProofPool.gossipInsertOutcome.inc({insertOutcome});
-
       } catch (e) {
         logger.error("Error adding to contributionAndProof pool", {}, e as Error);
       }

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -537,9 +537,10 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         contributionAndProof.message,
         syncCommitteeParticipantIndices
       );
-
       try {
-        chain.syncContributionAndProofPool.add(contributionAndProof.message, syncCommitteeParticipantIndices.length);
+        const insertOutcome = chain.syncContributionAndProofPool.add(contributionAndProof.message, syncCommitteeParticipantIndices.length);
+        metrics?.opPool.syncContributionAndProofPool.gossipInsertOutcome.inc({insertOutcome});
+
       } catch (e) {
         logger.error("Error adding to contributionAndProof pool", {}, e as Error);
       }

--- a/packages/beacon-node/test/mocks/clock.ts
+++ b/packages/beacon-node/test/mocks/clock.ts
@@ -74,6 +74,7 @@ export function getMockedClock(): Mocked<IClock> {
     },
     currentSlotWithGossipDisparity: undefined,
     isCurrentSlotGivenGossipDisparity: vi.fn(),
+    slotWithPastTolerance: vi.fn(),
     secFromSlot: vi.fn(),
   } as unknown as Mocked<IClock>;
 }

--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -113,58 +113,63 @@ vi.mock("../../src/chain/opPools/index.js", async (importActual) => {
 vi.mock("../../src/chain/chain.js", async (importActual) => {
   const mod = await importActual<typeof import("../../src/chain/chain.js")>();
 
-  const BeaconChain = vi.fn().mockImplementation(({clock: clockParam, genesisTime, config}: MockedBeaconChainOptions) => {
-    const logger = getMockedLogger();
-    const clock = clockParam === "real" ? new Clock({config, genesisTime, signal: new AbortController().signal}) : getMockedClock();
+  const BeaconChain = vi
+    .fn()
+    .mockImplementation(({clock: clockParam, genesisTime, config}: MockedBeaconChainOptions) => {
+      const logger = getMockedLogger();
+      const clock =
+        clockParam === "real"
+          ? new Clock({config, genesisTime, signal: new AbortController().signal})
+          : getMockedClock();
 
-    return {
-      config,
-      opts: {},
-      genesisTime,
-      clock,
-      forkChoice: getMockedForkChoice(),
-      executionEngine: {
-        notifyForkchoiceUpdate: vi.fn(),
-        getPayload: vi.fn(),
-        getClientVersion: vi.fn(),
-      },
-      executionBuilder: {},
-      // @ts-expect-error
-      eth1: new Eth1ForBlockProduction(),
-      opPool: new OpPool(),
-      aggregatedAttestationPool: new AggregatedAttestationPool(config),
-      syncContributionAndProofPool: new SyncContributionAndProofPool(clock),
-      // @ts-expect-error
-      beaconProposerCache: new BeaconProposerCache(),
-      shufflingCache: new ShufflingCache(),
-      pubkey2index: new PubkeyIndexMap(),
-      index2pubkey: [],
-      produceCommonBlockBody: vi.fn(),
-      getProposerHead: vi.fn(),
-      produceBlock: vi.fn(),
-      produceBlindedBlock: vi.fn(),
-      getCanonicalBlockAtSlot: vi.fn(),
-      recomputeForkChoiceHead: vi.fn(),
-      predictProposerHead: vi.fn(),
-      getHeadStateAtCurrentEpoch: vi.fn(),
-      getHeadState: vi.fn(),
-      getStateBySlot: vi.fn(),
-      updateBuilderStatus: vi.fn(),
-      processBlock: vi.fn(),
-      regenStateForAttestationVerification: vi.fn(),
-      close: vi.fn(),
-      logger,
-      regen: new QueuedStateRegenerator({} as any),
-      lightClientServer: new LightClientServer({} as any, {} as any),
-      bls: {
-        verifySignatureSets: vi.fn().mockResolvedValue(true),
-        verifySignatureSetsSameMessage: vi.fn().mockResolvedValue([true]),
-        close: vi.fn().mockResolvedValue(true),
-        canAcceptWork: vi.fn().mockReturnValue(true),
-      },
-      emitter: new ChainEventEmitter(),
-    };
-  });
+      return {
+        config,
+        opts: {},
+        genesisTime,
+        clock,
+        forkChoice: getMockedForkChoice(),
+        executionEngine: {
+          notifyForkchoiceUpdate: vi.fn(),
+          getPayload: vi.fn(),
+          getClientVersion: vi.fn(),
+        },
+        executionBuilder: {},
+        // @ts-expect-error
+        eth1: new Eth1ForBlockProduction(),
+        opPool: new OpPool(),
+        aggregatedAttestationPool: new AggregatedAttestationPool(config),
+        syncContributionAndProofPool: new SyncContributionAndProofPool(clock),
+        // @ts-expect-error
+        beaconProposerCache: new BeaconProposerCache(),
+        shufflingCache: new ShufflingCache(),
+        pubkey2index: new PubkeyIndexMap(),
+        index2pubkey: [],
+        produceCommonBlockBody: vi.fn(),
+        getProposerHead: vi.fn(),
+        produceBlock: vi.fn(),
+        produceBlindedBlock: vi.fn(),
+        getCanonicalBlockAtSlot: vi.fn(),
+        recomputeForkChoiceHead: vi.fn(),
+        predictProposerHead: vi.fn(),
+        getHeadStateAtCurrentEpoch: vi.fn(),
+        getHeadState: vi.fn(),
+        getStateBySlot: vi.fn(),
+        updateBuilderStatus: vi.fn(),
+        processBlock: vi.fn(),
+        regenStateForAttestationVerification: vi.fn(),
+        close: vi.fn(),
+        logger,
+        regen: new QueuedStateRegenerator({} as any),
+        lightClientServer: new LightClientServer({} as any, {} as any),
+        bls: {
+          verifySignatureSets: vi.fn().mockResolvedValue(true),
+          verifySignatureSetsSameMessage: vi.fn().mockResolvedValue([true]),
+          close: vi.fn().mockResolvedValue(true),
+          canAcceptWork: vi.fn().mockReturnValue(true),
+        },
+        emitter: new ChainEventEmitter(),
+      };
+    });
 
   return {
     ...mod,

--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -113,15 +113,15 @@ vi.mock("../../src/chain/opPools/index.js", async (importActual) => {
 vi.mock("../../src/chain/chain.js", async (importActual) => {
   const mod = await importActual<typeof import("../../src/chain/chain.js")>();
 
-  const BeaconChain = vi.fn().mockImplementation(({clock, genesisTime, config}: MockedBeaconChainOptions) => {
+  const BeaconChain = vi.fn().mockImplementation(({clock: clockParam, genesisTime, config}: MockedBeaconChainOptions) => {
     const logger = getMockedLogger();
+    const clock = clockParam === "real" ? new Clock({config, genesisTime, signal: new AbortController().signal}) : getMockedClock();
 
     return {
       config,
       opts: {},
       genesisTime,
-      clock:
-        clock === "real" ? new Clock({config, genesisTime, signal: new AbortController().signal}) : getMockedClock(),
+      clock,
       forkChoice: getMockedForkChoice(),
       executionEngine: {
         notifyForkchoiceUpdate: vi.fn(),
@@ -133,7 +133,7 @@ vi.mock("../../src/chain/chain.js", async (importActual) => {
       eth1: new Eth1ForBlockProduction(),
       opPool: new OpPool(),
       aggregatedAttestationPool: new AggregatedAttestationPool(config),
-      syncContributionAndProofPool: new SyncContributionAndProofPool(),
+      syncContributionAndProofPool: new SyncContributionAndProofPool(clock),
       // @ts-expect-error
       beaconProposerCache: new BeaconProposerCache(),
       shufflingCache: new ShufflingCache(),

--- a/packages/beacon-node/test/unit/chain/opPools/syncCommitteeContribution.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/syncCommitteeContribution.test.ts
@@ -12,9 +12,9 @@ import {
 } from "../../../../src/chain/opPools/syncContributionAndProofPool.js";
 import {InsertOutcome} from "../../../../src/chain/opPools/types.js";
 import {EMPTY_SIGNATURE} from "../../../../src/constants/index.js";
+import {getMockedClock} from "../../../mocks/clock.js";
 import {renderBitArray} from "../../../utils/render.js";
 import {VALID_BLS_SIGNATURE_RAND} from "../../../utils/typeGenerator.js";
-import { getMockedClock } from "../../../mocks/clock.js";
 
 describe("chain / opPools / SyncContributionAndProofPool", () => {
   let cache: SyncContributionAndProofPool;

--- a/packages/beacon-node/test/unit/chain/opPools/syncCommitteeContribution.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/syncCommitteeContribution.test.ts
@@ -3,7 +3,7 @@ import {BitArray} from "@chainsafe/ssz";
 import {SYNC_COMMITTEE_SIZE, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
 import {newFilledArray} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
-import {beforeAll, beforeEach, describe, expect, it} from "vitest";
+import {beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {
   SyncContributionAndProofPool,
   SyncContributionFast,
@@ -14,6 +14,7 @@ import {InsertOutcome} from "../../../../src/chain/opPools/types.js";
 import {EMPTY_SIGNATURE} from "../../../../src/constants/index.js";
 import {renderBitArray} from "../../../utils/render.js";
 import {VALID_BLS_SIGNATURE_RAND} from "../../../utils/typeGenerator.js";
+import { getMockedClock } from "../../../mocks/clock.js";
 
 describe("chain / opPools / SyncContributionAndProofPool", () => {
   let cache: SyncContributionAndProofPool;
@@ -24,9 +25,11 @@ describe("chain / opPools / SyncContributionAndProofPool", () => {
   contributionAndProof.contribution.slot = slot;
   contributionAndProof.contribution.beaconBlockRoot = beaconBlockRoot;
   contributionAndProof.contribution.signature = VALID_BLS_SIGNATURE_RAND;
+  const clockStub = getMockedClock();
 
   beforeEach(() => {
-    cache = new SyncContributionAndProofPool();
+    vi.spyOn(clockStub, "slotWithPastTolerance").mockReturnValue(slot);
+    cache = new SyncContributionAndProofPool(clockStub);
     cache.add(contributionAndProof, syncCommitteeParticipants);
   });
 
@@ -41,6 +44,15 @@ describe("chain / opPools / SyncContributionAndProofPool", () => {
     expect(ssz.altair.SyncAggregate.equals(aggregate, ssz.altair.SyncAggregate.defaultValue())).toBe(false);
     // TODO Test it's correct. Modify the contributions above so they have 1 bit set to true
     expect(aggregate.syncCommitteeBits.bitLen).toBe(512);
+  });
+
+  it("should reject SyncCommitteeContribution of previous slots", () => {
+    const newContributionAndProof = ssz.altair.ContributionAndProof.defaultValue();
+    // previous slot
+    newContributionAndProof.contribution.slot = slot - 1;
+    expect(cache.add(newContributionAndProof, syncCommitteeParticipants)).toEqual(InsertOutcome.Late);
+    // but a priority ContributionAndProof should work
+    expect(cache.add(newContributionAndProof, syncCommitteeParticipants, true)).toEqual(InsertOutcome.NewData);
   });
 });
 


### PR DESCRIPTION
**Motivation**

- to investigate empty SyncAggregate when producing blocks, see #7299

**Description**

- Do not accept messages of old slots because they are not useful. It's tracked in InsertOutcome and could be the reason we produce empty SyncAggregate
- Track InsertOutcome from api and gossip
- More metrics at each previous slot:
  - number of block roots
  - number of subnets at each block root
  - number of participations at each block root
- More metrics for `getAggregate()`:
  - number of block roots
  - number of subnets
  - number of participations
  - empty SyncAggregate

part of #7299