### PR TITLE
chore: add blob schedule to each network config

### DIFF
--- a/packages/config/src/chainConfig/networks/chiado.ts
+++ b/packages/config/src/chainConfig/networks/chiado.ts
@@ -43,4 +43,12 @@ export const chiadoChainConfig: ChainConfig = {
   // Fulu
   FULU_FORK_VERSION: b("0x0600006f"),
   FULU_FORK_EPOCH: Infinity,
+
+  // Blob Scheduling
+  BLOB_SCHEDULE: [
+    // Deneb
+    {EPOCH: 516608, MAX_BLOBS_PER_BLOCK: 2},
+    // Electra
+    {EPOCH: 948224, MAX_BLOBS_PER_BLOCK: 2},
+  ],
 };

--- a/packages/config/src/chainConfig/networks/ephemery.ts
+++ b/packages/config/src/chainConfig/networks/ephemery.ts
@@ -51,6 +51,15 @@ const baseChainConfig: ChainConfig = {
   DEPOSIT_CONTRACT_ADDRESS: b("0x4242424242424242424242424242424242424242"),
 
   ETH1_FOLLOW_DISTANCE: 12,
+
+  // Blob Scheduling
+  // ---------------------------------------------------------------
+  BLOB_SCHEDULE: [
+    // Deneb
+    {EPOCH: 0, MAX_BLOBS_PER_BLOCK: 6},
+    // Electra
+    {EPOCH: 10, MAX_BLOBS_PER_BLOCK: 9},
+  ],
 };
 
 // Reset interval (7 days) in milliseconds, based on ephemery-genesis values.env:

--- a/packages/config/src/chainConfig/networks/holesky.ts
+++ b/packages/config/src/chainConfig/networks/holesky.ts
@@ -48,4 +48,13 @@ export const holeskyChainConfig: ChainConfig = {
   DEPOSIT_CHAIN_ID: 17000,
   DEPOSIT_NETWORK_ID: 17000,
   DEPOSIT_CONTRACT_ADDRESS: b("0x4242424242424242424242424242424242424242"),
+
+  // Blob Scheduling
+  // ---------------------------------------------------------------
+  BLOB_SCHEDULE: [
+    // Deneb
+    {EPOCH: 29696, MAX_BLOBS_PER_BLOCK: 6},
+    // Electra
+    {EPOCH: 115968, MAX_BLOBS_PER_BLOCK: 9},
+  ],
 };

--- a/packages/config/src/chainConfig/networks/hoodi.ts
+++ b/packages/config/src/chainConfig/networks/hoodi.ts
@@ -48,4 +48,13 @@ export const hoodiChainConfig: ChainConfig = {
   // ---------------------------------------------------------------
   DEPOSIT_CHAIN_ID: 560048,
   DEPOSIT_NETWORK_ID: 560048,
+
+  // Blob Scheduling
+  // ---------------------------------------------------------------
+  BLOB_SCHEDULE: [
+    // Deneb
+    {EPOCH: 0, MAX_BLOBS_PER_BLOCK: 6},
+    // Electra
+    {EPOCH: 2048, MAX_BLOBS_PER_BLOCK: 9},
+  ],
 };

--- a/packages/config/src/chainConfig/networks/sepolia.ts
+++ b/packages/config/src/chainConfig/networks/sepolia.ts
@@ -45,4 +45,13 @@ export const sepoliaChainConfig: ChainConfig = {
   DEPOSIT_CHAIN_ID: 11155111,
   DEPOSIT_NETWORK_ID: 11155111,
   DEPOSIT_CONTRACT_ADDRESS: b("0x7f02C3E3c98b133055B8B348B2Ac625669Ed295D"),
+
+  // Blob Scheduling
+  // ---------------------------------------------------------------
+  BLOB_SCHEDULE: [
+    // Deneb
+    {EPOCH: 132608, MAX_BLOBS_PER_BLOCK: 6},
+    // Electra
+    {EPOCH: 222464, MAX_BLOBS_PER_BLOCK: 9},
+  ],
 };


### PR DESCRIPTION
**Motivation**

Follow up to https://github.com/ChainSafe/lodestar/pull/7729, we need to configure blob schedule for each network. This will become relevant once we fully backport blob schedule to deneb and electra.

**Description**

Add blob schedule to each network config
