### PR TITLE
fix: add special handling for blob schedule when asserting equal params

### DIFF
--- a/packages/config/src/chainConfig/index.ts
+++ b/packages/config/src/chainConfig/index.ts
@@ -2,7 +2,7 @@ import {ACTIVE_PRESET} from "@lodestar/params";
 import {defaultChainConfig} from "./default.js";
 import {ChainConfig} from "./types.js";
 
-export {chainConfigToJson, chainConfigFromJson, specValuesToJson} from "./json.js";
+export {chainConfigToJson, chainConfigFromJson, specValuesToJson, deserializeBlobSchedule} from "./json.js";
 export * from "./types.js";
 export * from "./default.js";
 

--- a/packages/config/src/chainConfig/json.ts
+++ b/packages/config/src/chainConfig/json.ts
@@ -1,5 +1,6 @@
 import {fromHex, toHex} from "@lodestar/utils";
 import {
+  BlobSchedule,
   BlobScheduleEntry,
   ChainConfig,
   SpecJson,
@@ -103,45 +104,7 @@ export function serializeSpecValue(
 
 export function deserializeSpecValue(valueStr: unknown, typeName: SpecValueTypeName, keyName: string): SpecValue {
   if (typeName === "blob_schedule") {
-    if (!Array.isArray(valueStr)) {
-      throw Error(`Invalid BLOB_SCHEDULE value ${valueStr} expected array`);
-    }
-
-    const blobSchedule = valueStr.map((entry, i) => {
-      if (typeof entry !== "object" || entry === null) {
-        throw Error(`Invalid BLOB_SCHEDULE[${i}] entry ${entry} expected object`);
-      }
-
-      const out = {} as BlobScheduleEntry;
-
-      for (const key of ["EPOCH", "MAX_BLOBS_PER_BLOCK"] as Array<keyof BlobScheduleEntry>) {
-        const value = entry[key];
-
-        if (value === undefined) {
-          throw Error(`Invalid BLOB_SCHEDULE[${i}] entry ${JSON.stringify(entry)} missing ${key}`);
-        }
-
-        if (typeof value !== "string") {
-          throw Error(`Invalid BLOB_SCHEDULE[${i}].${key} value ${value} expected string`);
-        }
-
-        if (value === MAX_UINT64_JSON) {
-          out[key] = Infinity;
-        } else {
-          const parsed = parseInt(value, 10);
-
-          if (Number.isNaN(parsed)) {
-            throw Error(`Invalid BLOB_SCHEDULE[${i}].${key} value ${value} expected number`);
-          }
-
-          out[key] = parsed;
-        }
-      }
-
-      return out;
-    });
-
-    return blobSchedule;
+    return deserializeBlobSchedule(valueStr);
   }
 
   if (typeof valueStr !== "string") {
@@ -164,4 +127,46 @@ export function deserializeSpecValue(valueStr: unknown, typeName: SpecValueTypeN
     case "string":
       return valueStr;
   }
+}
+
+export function deserializeBlobSchedule(value: unknown): BlobSchedule {
+  if (!Array.isArray(value)) {
+    throw Error(`Invalid BLOB_SCHEDULE value ${value} expected array`);
+  }
+
+  const blobSchedule = value.map((entry, i) => {
+    if (typeof entry !== "object" || entry === null) {
+      throw Error(`Invalid BLOB_SCHEDULE[${i}] entry ${entry} expected object`);
+    }
+
+    const out = {} as BlobScheduleEntry;
+
+    for (const key of ["EPOCH", "MAX_BLOBS_PER_BLOCK"] as Array<keyof BlobScheduleEntry>) {
+      const value = entry[key];
+
+      if (value === undefined) {
+        throw Error(`Invalid BLOB_SCHEDULE[${i}] entry ${JSON.stringify(entry)} missing ${key}`);
+      }
+
+      if (typeof value !== "string") {
+        throw Error(`Invalid BLOB_SCHEDULE[${i}].${key} value ${value} expected string`);
+      }
+
+      if (value === MAX_UINT64_JSON) {
+        out[key] = Infinity;
+      } else {
+        const parsed = parseInt(value, 10);
+
+        if (Number.isNaN(parsed)) {
+          throw Error(`Invalid BLOB_SCHEDULE[${i}].${key} value ${value} expected number`);
+        }
+
+        out[key] = parsed;
+      }
+    }
+
+    return out;
+  });
+
+  return blobSchedule;
 }

--- a/packages/config/src/chainConfig/json.ts
+++ b/packages/config/src/chainConfig/json.ts
@@ -129,12 +129,12 @@ export function deserializeSpecValue(valueStr: unknown, typeName: SpecValueTypeN
   }
 }
 
-export function deserializeBlobSchedule(value: unknown): BlobSchedule {
-  if (!Array.isArray(value)) {
-    throw Error(`Invalid BLOB_SCHEDULE value ${value} expected array`);
+export function deserializeBlobSchedule(input: unknown): BlobSchedule {
+  if (!Array.isArray(input)) {
+    throw Error(`Invalid BLOB_SCHEDULE value ${input} expected array`);
   }
 
-  const blobSchedule = value.map((entry, i) => {
+  const blobSchedule = input.map((entry, i) => {
     if (typeof entry !== "object" || entry === null) {
       throw Error(`Invalid BLOB_SCHEDULE[${i}] entry ${entry} expected object`);
     }

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -1,4 +1,4 @@
-import {ChainConfig, SpecJson, chainConfigToJson} from "@lodestar/config";
+import {BlobScheduleEntry, ChainConfig, SpecJson, chainConfigToJson, deserializeBlobSchedule} from "@lodestar/config";
 import {BeaconPreset, activePreset, presetToJson} from "@lodestar/params";
 
 export class NotEqualParamsError extends Error {}
@@ -49,6 +49,36 @@ export function assertEqualParams(localConfig: ChainConfig, externalSpecJson: Sp
       // to detect spec discrepancies in all cases.
       externalSpecJson[key] === undefined
     ) {
+      continue;
+    }
+
+    if (key === "BLOB_SCHEDULE") {
+      const localBlobSchedule = deserializeBlobSchedule(localSpecJson[key]).sort((a, b) => a.EPOCH - b.EPOCH);
+      const remoteBlobSchedule = deserializeBlobSchedule(externalSpecJson[key]).sort((a, b) => a.EPOCH - b.EPOCH);
+
+      if (localBlobSchedule.length !== remoteBlobSchedule.length) {
+        errors.push(`BLOB_SCHEDULE different length: ${localBlobSchedule.length} != ${remoteBlobSchedule.length}`);
+
+        // Skip per entry comparison
+        continue;
+      }
+
+      const len = Math.min(localBlobSchedule.length, remoteBlobSchedule.length);
+      for (let i = 0; i < len; i++) {
+        const localEntry = localBlobSchedule[i];
+        const remoteEntry = remoteBlobSchedule[i];
+
+        for (const entryKey of ["EPOCH", "MAX_BLOBS_PER_BLOCK"] as Array<keyof BlobScheduleEntry>) {
+          const localValue = String(localEntry[entryKey]);
+          const remoteValue = String(remoteEntry[entryKey]);
+
+          if (localValue !== remoteValue) {
+            errors.push(`BLOB_SCHEDULE[${i}].${entryKey} different value: ${localValue} != ${remoteValue}`);
+          }
+        }
+      }
+
+      // Skip generic string comparison
       continue;
     }
 

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -63,8 +63,7 @@ export function assertEqualParams(localConfig: ChainConfig, externalSpecJson: Sp
         continue;
       }
 
-      const len = Math.min(localBlobSchedule.length, remoteBlobSchedule.length);
-      for (let i = 0; i < len; i++) {
+      for (let i = 0; i < localBlobSchedule.length; i++) {
         const localEntry = localBlobSchedule[i];
         const remoteEntry = remoteBlobSchedule[i];
 


### PR DESCRIPTION
**Motivation**

Follow up to https://github.com/ChainSafe/lodestar/pull/7729, we need to handle blob schedule separately from generic string comparison of values, otherwise what we compare are shallow stringified arrays. It does not validate the object properties and on length mismatch we just get the following error

```
✖ Error: Local and remote configs are different
BLOB_SCHEDULE different value: [object object] != [object object],[object object]
```

**Description**

Add special handling for blob schedule when asserting equal params
- deserialize and sort blob schedules
- compare length of local and remote blob schedule
- then check each entry by comparing `EPOCH` and `MAX_BLOBS_PER_BLOCK`