### PR TITLE
feat: only subscribe to sampled subnets

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -178,7 +178,7 @@ export class NetworkCore implements INetworkCore {
     );
 
     const gossip = new Eth2Gossipsub(opts, {
-      config,
+      networkConfig,
       libp2p,
       logger,
       metricsRegister: metricsRegistry,
@@ -331,7 +331,7 @@ export class NetworkCore implements INetworkCore {
     }
 
     for (const fork of getActiveForks(this.config, this.clock.currentEpoch)) {
-      this.subscribeCoreTopicsAtFork(this.config, fork);
+      this.subscribeCoreTopicsAtFork(this.networkConfig, fork);
     }
   }
 
@@ -340,7 +340,7 @@ export class NetworkCore implements INetworkCore {
    */
   async unsubscribeGossipCoreTopics(): Promise<void> {
     for (const fork of this.subscribedForks.values()) {
-      this.unsubscribeCoreTopicsAtFork(this.config, fork);
+      this.unsubscribeCoreTopicsAtFork(this.networkConfig, fork);
     }
   }
 
@@ -496,7 +496,7 @@ export class NetworkCore implements INetworkCore {
           if (epoch === forkEpoch - FORK_EPOCH_LOOKAHEAD) {
             // Don't subscribe to new fork if the node is not subscribed to any topic
             if (await this.isSubscribedToGossipCoreTopics()) {
-              this.subscribeCoreTopicsAtFork(this.config, nextFork);
+              this.subscribeCoreTopicsAtFork(this.networkConfig, nextFork);
               this.logger.info("Subscribing gossip topics before fork", {nextFork});
             } else {
               this.logger.info("Skipping subscribing gossip topics before fork", {nextFork});
@@ -515,7 +515,7 @@ export class NetworkCore implements INetworkCore {
           // After fork transition
           if (epoch === forkEpoch + FORK_EPOCH_LOOKAHEAD) {
             this.logger.info("Unsubscribing gossip topics from prev fork", {prevFork});
-            this.unsubscribeCoreTopicsAtFork(this.config, prevFork);
+            this.unsubscribeCoreTopicsAtFork(this.networkConfig, prevFork);
             this.attnetsService.unsubscribeSubnetsFromPrevFork(prevFork);
             this.syncnetsService.unsubscribeSubnetsFromPrevFork(prevFork);
           }
@@ -526,12 +526,12 @@ export class NetworkCore implements INetworkCore {
     }
   };
 
-  private subscribeCoreTopicsAtFork(config: BeaconConfig, fork: ForkName): void {
+  private subscribeCoreTopicsAtFork(networkConfig: NetworkConfig, fork: ForkName): void {
     if (this.subscribedForks.has(fork)) return;
     this.subscribedForks.add(fork);
     const {subscribeAllSubnets, disableLightClientServer} = this.opts;
 
-    for (const topic of getCoreTopicsAtFork(config, fork, {
+    for (const topic of getCoreTopicsAtFork(networkConfig, fork, {
       subscribeAllSubnets,
       disableLightClientServer,
     })) {
@@ -539,12 +539,12 @@ export class NetworkCore implements INetworkCore {
     }
   }
 
-  private unsubscribeCoreTopicsAtFork(config: BeaconConfig, fork: ForkName): void {
+  private unsubscribeCoreTopicsAtFork(networkConfig: NetworkConfig, fork: ForkName): void {
     if (!this.subscribedForks.has(fork)) return;
     this.subscribedForks.delete(fork);
     const {subscribeAllSubnets, disableLightClientServer} = this.opts;
 
-    for (const topic of getCoreTopicsAtFork(config, fork, {
+    for (const topic of getCoreTopicsAtFork(networkConfig, fork, {
       subscribeAllSubnets,
       disableLightClientServer,
     })) {

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -19,6 +19,7 @@ import {GossipTopic, GossipType} from "./interface.js";
 import {Eth2GossipsubMetrics, createEth2GossipsubMetrics} from "./metrics.js";
 import {GossipTopicCache, getCoreTopicsAtFork, stringifyGossipTopic} from "./topic.js";
 
+import {NetworkConfig} from "../networkConfig.js";
 import {
   GOSSIP_D,
   GOSSIP_D_HIGH,
@@ -39,7 +40,7 @@ export type Eth2Context = {
 };
 
 export type Eth2GossipsubModules = {
-  config: BeaconConfig;
+  networkConfig: NetworkConfig;
   libp2p: Libp2p;
   logger: Logger;
   metricsRegister: RegistryMetricCreator | null;
@@ -84,10 +85,11 @@ export class Eth2Gossipsub extends GossipSub {
 
   constructor(opts: Eth2GossipsubOpts, modules: Eth2GossipsubModules) {
     const {allowPublishToZeroPeers, gossipsubD, gossipsubDLow, gossipsubDHigh} = opts;
-    const gossipTopicCache = new GossipTopicCache(modules.config);
+    const {networkConfig, logger, metricsRegister, peersData, events} = modules;
+    const config = networkConfig.getConfig();
+    const gossipTopicCache = new GossipTopicCache(config);
 
-    const scoreParams = computeGossipPeerScoreParams(modules);
-    const {config, logger, metricsRegister, peersData, events} = modules;
+    const scoreParams = computeGossipPeerScoreParams({config, eth2Context: modules.eth2Context});
 
     // Gossipsub parameters defined here:
     // https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#the-gossip-domain-gossipsub
@@ -126,7 +128,7 @@ export class Eth2Gossipsub extends GossipSub {
       ),
       metricsRegister: metricsRegister as MetricsRegister | null,
       metricsTopicStrToLabel: metricsRegister
-        ? getMetricsTopicStrToLabel(config, {disableLightClientServer: opts.disableLightClientServer ?? false})
+        ? getMetricsTopicStrToLabel(networkConfig, {disableLightClientServer: opts.disableLightClientServer ?? false})
         : undefined,
       asyncValidation: true,
 
@@ -330,11 +332,15 @@ function attSubnetLabel(subnet: SubnetID): string {
   return `0${subnet}`;
 }
 
-function getMetricsTopicStrToLabel(config: BeaconConfig, opts: {disableLightClientServer: boolean}): TopicStrToLabel {
+function getMetricsTopicStrToLabel(
+  networkConfig: NetworkConfig,
+  opts: {disableLightClientServer: boolean}
+): TopicStrToLabel {
   const metricsTopicStrToLabel = new Map<TopicStr, TopicLabel>();
+  const config = networkConfig.getConfig();
 
   for (const {name: fork} of config.forksAscendingEpochOrder) {
-    const topics = getCoreTopicsAtFork(config, fork, {
+    const topics = getCoreTopicsAtFork(networkConfig, fork, {
       subscribeAllSubnets: true,
       disableLightClientServer: opts.disableLightClientServer,
     });

--- a/packages/beacon-node/src/network/gossip/scoringParameters.ts
+++ b/packages/beacon-node/src/network/gossip/scoringParameters.ts
@@ -80,7 +80,7 @@ type TopicScoreInput = {
 export function computeGossipPeerScoreParams({
   config,
   eth2Context,
-}: Pick<Eth2GossipsubModules, "config" | "eth2Context">): Partial<PeerScoreParams> {
+}: {config: BeaconConfig; eth2Context: Eth2Context}): Partial<PeerScoreParams> {
   const decayIntervalMs = config.SECONDS_PER_SLOT * 1000;
   const decayToZero = 0.01;
   const epochDurationMs = config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH * 1000;

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -11,6 +11,7 @@ import {
 import {Attestation, SingleAttestation, ssz, sszTypesFor} from "@lodestar/types";
 
 import {GossipAction, GossipActionError, GossipErrorCode} from "../../chain/errors/gossipValidation.js";
+import {NetworkConfig} from "../networkConfig.js";
 import {DEFAULT_ENCODING} from "./constants.js";
 import {GossipEncoding, GossipTopic, GossipTopicTypeMap, GossipType, SSZTypeOfGossipTopic} from "./interface.js";
 
@@ -227,7 +228,7 @@ export function parseGossipTopic(forkDigestContext: ForkDigestContext, topicStr:
  * De-duplicate logic to pick fork topics between subscribeCoreTopicsAtFork and unsubscribeCoreTopicsAtFork
  */
 export function getCoreTopicsAtFork(
-  config: ChainConfig,
+  networkConfig: NetworkConfig,
   fork: ForkName,
   opts: {subscribeAllSubnets?: boolean; disableLightClientServer?: boolean}
 ): GossipTopicTypeMap[keyof GossipTopicTypeMap][] {
@@ -243,13 +244,15 @@ export function getCoreTopicsAtFork(
   // After fulu also track data_column_sidecar_{index}
   if (ForkSeq[fork] >= ForkSeq.fulu) {
     // TODO: @matthewkeil check if this needs to be updated for custody groups
-    for (let subnet = 0; subnet < DATA_COLUMN_SIDECAR_SUBNET_COUNT; subnet++) {
+    const subnets = networkConfig.getCustodyConfig().sampledSubnets;
+    for (const subnet of subnets) {
       topics.push({type: GossipType.data_column_sidecar, subnet});
     }
   }
 
   // After Deneb also track blob_sidecar_{subnet_id}
   if (ForkSeq[fork] >= ForkSeq.deneb) {
+    const config = networkConfig.getConfig();
     const subnetCount = isForkPostElectra(fork)
       ? config.BLOB_SIDECAR_SUBNET_COUNT_ELECTRA
       : config.BLOB_SIDECAR_SUBNET_COUNT;


### PR DESCRIPTION
**Motivation**

- right now we always subscribe to all column subnets which is not necessary because we only need columns that we custody/sample
- that's why I see 128 logs like this per slot, and this could degrade performance. We only need 8 per slot

```
 debug: Received gossip dataColumn slot=198378, root=0x9945…49af, curentSlot=198378, peerId=16Uiu2HAm2J4ZRFnf7qWvu8VBRFT66E5XFWnRTwYTahB2oRJom5ji, delaySec=1.5910000801086426, gossipIndex=113, columnIndex=113, pending=data_column, haveColumns=31, expectedColumns=8, recvToValLatency=0.0009999275207519531, recvToValidation=0.0009999275207519531, validationTime=0
```

**Description**

- only subscribe to custody/sampling subnets