### PR TITLE
chore: upgrade Node.js version in devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,7 @@
 {
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	// Upgrade the container to Node 22
-	// https://github.com/ChainSafe/lodestar/issues/6742
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bullseye",
 	"features": {
 		"ghcr.io/devcontainers/features/python:1": {}
 	}


### PR DESCRIPTION
**Description**
Upgrade devcontainer to use node 22, matching node version in `package.json`.
Closes #6742
