### PR TITLE
chore: change ByteArrayEquals to Buffer.compare()

### DIFF
--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -3,7 +3,6 @@ import {BlobIndex, ColumnIndex, SignedBeaconBlock, Slot, deneb, fulu} from "@lod
 import {fromHex, prettyBytes, toHex, withTimeout} from "@lodestar/utils";
 import {VersionedHashes} from "../../../execution/index.js";
 import {kzgCommitmentToVersionedHash} from "../../../util/blobs.js";
-import {byteArrayEquals} from "../../../util/bytes.js";
 import {BlockInputError, BlockInputErrorCode} from "./errors.js";
 import {
   AddBlob,
@@ -486,7 +485,7 @@ export class BlockInputBlobs extends AbstractBlockInput<ForkBlobsDA, deneb.BlobS
 }
 
 function blockAndBlobArePaired(block: SignedBeaconBlock<ForkBlobsDA>, blobSidecar: deneb.BlobSidecar): boolean {
-  return byteArrayEquals(block.message.body.blobKzgCommitments[blobSidecar.index], blobSidecar.kzgCommitment);
+  return Buffer.compare(block.message.body.blobKzgCommitments[blobSidecar.index], blobSidecar.kzgCommitment) === 0;
 }
 
 function assertBlockAndBlobArePaired(
@@ -778,7 +777,7 @@ function blockAndColumnArePaired(
   return (
     block.message.body.blobKzgCommitments.length === columnSidecar.kzgCommitments.length &&
     block.message.body.blobKzgCommitments.every((commitment, index) =>
-      byteArrayEquals(commitment, columnSidecar.kzgCommitments[index])
+      Buffer.compare(commitment, columnSidecar.kzgCommitments[index]) === 0
     )
   );
 }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -7,7 +7,6 @@ import {
 } from "@lodestar/state-transition";
 import {ErrorAborted, Logger} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
-import {byteArrayEquals} from "../../util/bytes.js";
 import {nextEventLoop} from "../../util/eventLoop.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
 import {BlockProcessOpts} from "../options.js";
@@ -69,7 +68,7 @@ export async function verifyBlocksStateTransitionOnly(
     hashTreeRootTimer?.();
 
     // Check state root matches
-    if (!byteArrayEquals(block.message.stateRoot, stateRoot)) {
+    if (Buffer.compare(block.message.stateRoot, stateRoot) !== 0) {
       throw new BlockError(block, {
         code: BlockErrorCode.INVALID_STATE_ROOT,
         root: postState.hashTreeRoot(),

--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -50,7 +50,6 @@ import {ZERO_HASH} from "../../constants/index.js";
 import {IBeaconDb} from "../../db/index.js";
 import {NUM_WITNESS, NUM_WITNESS_ELECTRA} from "../../db/repositories/lightclientSyncCommitteeWitness.js";
 import {Metrics} from "../../metrics/index.js";
-import {byteArrayEquals} from "../../util/bytes.js";
 import {ChainEventEmitter} from "../emitter.js";
 import {LightClientServerError, LightClientServerErrorCode} from "../errors/lightClientError.js";
 import {
@@ -443,7 +442,7 @@ export class LightClientServer {
       // If finalizedCheckpoint is zeroed, consider not finalized (ignore) since there won't exist a
       // finalized header for that root
       finalizedCheckpoint.epoch !== 0 &&
-      !byteArrayEquals(finalizedCheckpoint.root, ZERO_HASH);
+      Buffer.compare(finalizedCheckpoint.root, ZERO_HASH) !== 0;
 
     this.prevHeadData.set(
       blockRootHex,

--- a/packages/beacon-node/src/chain/validation/blobSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -13,7 +13,6 @@ import {
 import {BlobIndex, Root, Slot, SubnetID, deneb, ssz} from "@lodestar/types";
 import {toRootHex, verifyMerkleBranch} from "@lodestar/utils";
 
-import {byteArrayEquals} from "../../util/bytes.js";
 import {ckzg} from "../../util/kzg.js";
 import {BlobSidecarErrorCode, BlobSidecarGossipError} from "../errors/blobSidecarError.js";
 import {GossipAction} from "../errors/gossipValidation.js";
@@ -199,9 +198,9 @@ export function validateBlobSidecars(
       const blobBlockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(blobBlockHeader);
       if (
         blobBlockHeader.slot !== blockSlot ||
-        !byteArrayEquals(blobBlockRoot, blockRoot) ||
+        Buffer.compare(blobBlockRoot, blockRoot) !== 0 ||
         blobSidecar.index !== index ||
-        !byteArrayEquals(expectedKzgCommitments[index], blobSidecar.kzgCommitment)
+        Buffer.compare(expectedKzgCommitments[index], blobSidecar.kzgCommitment) !== 0
       ) {
         throw new Error(
           `Invalid blob with slot=${blobBlockHeader.slot} blobBlockRoot=${toRootHex(blobBlockRoot)} index=${

--- a/packages/beacon-node/src/eth1/eth1DepositsCache.ts
+++ b/packages/beacon-node/src/eth1/eth1DepositsCache.ts
@@ -1,4 +1,3 @@
-import {byteArrayEquals} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {FilterOptions} from "@lodestar/db";
 import {phase0, ssz} from "@lodestar/types";
@@ -81,7 +80,7 @@ export class Eth1DepositsCache {
             throw new Eth1Error({code: Eth1ErrorCode.MISSING_DEPOSIT_LOG, newIndex, lastLogIndex});
           }
           const serializedEvent = ssz.phase0.DepositEvent.serialize(depositEvent);
-          if (!byteArrayEquals(prevDBSerializedEvent, serializedEvent)) {
+          if (Buffer.compare(prevDBSerializedEvent, serializedEvent) !== 0) {
             throw new Eth1Error({code: Eth1ErrorCode.DUPLICATE_DISTINCT_LOG, newIndex, lastLogIndex});
           }
         }

--- a/packages/beacon-node/src/sync/backfill/backfill.ts
+++ b/packages/beacon-node/src/sync/backfill/backfill.ts
@@ -11,7 +11,6 @@ import {GENESIS_SLOT, ZERO_HASH} from "../../constants/index.js";
 import {IBeaconDb} from "../../db/index.js";
 import {Metrics} from "../../metrics/metrics.js";
 import {INetwork, NetworkEvent, NetworkEventData, PeerAction} from "../../network/index.js";
-import {byteArrayEquals} from "../../util/bytes.js";
 import {ItTrigger} from "../../util/itTrigger.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {shuffleOne} from "../../util/shuffle.js";
@@ -335,7 +334,7 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
 
         if (this.syncAnchor.lastBackSyncedBlock.slot === this.prevFinalizedCheckpointBlock.slot) {
           // Okay! we backfilled successfully till prevFinalizedCheckpointBlock
-          if (!byteArrayEquals(this.syncAnchor.lastBackSyncedBlock.root, this.prevFinalizedCheckpointBlock.root)) {
+          if (Buffer.compare(this.syncAnchor.lastBackSyncedBlock.root, this.prevFinalizedCheckpointBlock.root) !== 0) {
             this.logger.error(
               `Invalid root synced at a previous finalized or wsCheckpoint, slot=${
                 this.prevFinalizedCheckpointBlock.slot
@@ -375,7 +374,7 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
         }
 
         if (this.syncAnchor.lastBackSyncedBlock.slot === GENESIS_SLOT) {
-          if (!byteArrayEquals(this.syncAnchor.lastBackSyncedBlock.block.message.parentRoot, ZERO_HASH)) {
+          if (Buffer.compare(this.syncAnchor.lastBackSyncedBlock.block.message.parentRoot, ZERO_HASH) !== 0) {
             Error(
               `Invalid Gensis Block with non zero parentRoot=${toRootHex(
                 this.syncAnchor.lastBackSyncedBlock.block.message.parentRoot
@@ -693,7 +692,7 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
       if (anchorBlock.message.slot === this.prevFinalizedCheckpointBlock.slot) {
         if (
           !isPrevFinWsConfirmedAnchorParent &&
-          !byteArrayEquals(anchorBlockRoot, this.prevFinalizedCheckpointBlock.root)
+          Buffer.compare(anchorBlockRoot, this.prevFinalizedCheckpointBlock.root) !== 0
         ) {
           throw Error(
             `Invalid root for prevFinalizedCheckpointBlock at slot=${

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -13,7 +13,6 @@ import {
   beaconBlocksMaybeBlobsByRoot,
   unavailableBeaconBlobsByRoot,
 } from "../network/reqresp/beaconBlocksMaybeBlobsByRoot.js";
-import {byteArrayEquals} from "../util/bytes.js";
 import {PeerIdStr} from "../util/peerId.js";
 import {shuffle} from "../util/shuffle.js";
 import {Result, wrapError} from "../util/wrapError.js";
@@ -483,7 +482,7 @@ export class UnknownBlockSync {
         // Verify block root is correct
         const block = blockInput.block.message;
         const receivedBlockRoot = this.config.getForkTypes(block.slot).BeaconBlock.hashTreeRoot(block);
-        if (!byteArrayEquals(receivedBlockRoot, blockRoot)) {
+        if (Buffer.compare(receivedBlockRoot, blockRoot) !== 0) {
           throw Error(`Wrong block received by peer, got ${toRootHex(receivedBlockRoot)} expected ${blockRootHex}`);
         }
 
@@ -552,7 +551,7 @@ export class UnknownBlockSync {
         const block = blockInput.block.message;
         const receivedBlockRoot = this.config.getForkTypes(block.slot).BeaconBlock.hashTreeRoot(block);
 
-        if (!byteArrayEquals(receivedBlockRoot, blockRoot)) {
+        if (Buffer.compare(receivedBlockRoot, blockRoot) !== 0) {
           throw Error(`Wrong block received by peer, got ${toRootHex(receivedBlockRoot)} expected ${blockRootHex}`);
         }
         if (unavailableBlockInput.block === null) {

--- a/packages/beacon-node/test/unit/util/bytes.test.ts
+++ b/packages/beacon-node/test/unit/util/bytes.test.ts
@@ -1,7 +1,6 @@
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {describe, expect, it} from "vitest";
 
-import {byteArrayEquals} from "../../../src/util/bytes.js";
 
 /** Reference implementation of byteArrayConcat */
 function byteArrayConcat(bytesArr: Uint8Array[]): Uint8Array {
@@ -24,7 +23,7 @@ describe("util / bytes", () => {
     }
   });
 
-  describe("byteArrayEquals", () => {
+  describe("Buffer.compare()", () => {
     const testCases: {hex1: string; hex2: string; isEqual: boolean}[] = [
       {hex1: "0x00", hex2: "0x00", isEqual: true},
       {hex1: "0x00", hex2: "0x01", isEqual: false},
@@ -34,7 +33,7 @@ describe("util / bytes", () => {
 
     for (const {hex1, hex2, isEqual} of testCases) {
       it(`${hex1} == ${hex2} -> ${isEqual}`, () => {
-        expect(byteArrayEquals(fromHexString(hex1), fromHexString(hex2))).toBe(isEqual);
+        expect(Buffer.compare(fromHexString(hex1), fromHexString(hex2)) === 0).toBe(isEqual);
       });
     }
   });

--- a/packages/light-client/src/spec/utils.ts
+++ b/packages/light-client/src/spec/utils.ts
@@ -1,4 +1,4 @@
-import {BitArray, byteArrayEquals} from "@chainsafe/ssz";
+import {BitArray} from "@chainsafe/ssz";
 
 import {ChainForkConfig} from "@lodestar/config";
 import {
@@ -63,7 +63,7 @@ export function isSyncCommitteeUpdate(update: LightClientUpdate): boolean {
     // Fast return for when constructing full LightClientUpdate from partial updates
     update.nextSyncCommitteeBranch !==
       getZeroSyncCommitteeBranch(isElectraLightClientUpdate(update) ? ForkName.electra : ForkName.altair) &&
-    update.nextSyncCommitteeBranch.some((branch) => !byteArrayEquals(branch, ZERO_HASH))
+    update.nextSyncCommitteeBranch.some((branch) => Buffer.compare(branch, ZERO_HASH) === 0)
   );
 }
 
@@ -72,18 +72,18 @@ export function isFinalityUpdate(update: LightClientUpdate): boolean {
     // Fast return for when constructing full LightClientUpdate from partial updates
     update.finalityBranch !==
       getZeroFinalityBranch(isElectraLightClientUpdate(update) ? ForkName.electra : ForkName.altair) &&
-    update.finalityBranch.some((branch) => !byteArrayEquals(branch, ZERO_HASH))
+    update.finalityBranch.some((branch) => Buffer.compare(branch, ZERO_HASH)!== 0)
   );
 }
 
 export function isZeroedHeader(header: BeaconBlockHeader): boolean {
   // Fast return for when constructing full LightClientUpdate from partial updates
-  return header === ZERO_HEADER || byteArrayEquals(header.bodyRoot, ZERO_HASH);
+  return header === ZERO_HEADER || Buffer.compare(header.bodyRoot, ZERO_HASH) === 0;
 }
 
 export function isZeroedSyncCommittee(syncCommittee: SyncCommittee): boolean {
   // Fast return for when constructing full LightClientUpdate from partial updates
-  return syncCommittee === ZERO_SYNC_COMMITTEE || byteArrayEquals(syncCommittee.pubkeys[0], ZERO_PUBKEY);
+  return syncCommittee === ZERO_SYNC_COMMITTEE || Buffer.compare(syncCommittee.pubkeys[0], ZERO_PUBKEY) === 0;
 }
 
 export function upgradeLightClientHeader(

--- a/packages/light-client/src/spec/validateLightClientBootstrap.ts
+++ b/packages/light-client/src/spec/validateLightClientBootstrap.ts
@@ -1,4 +1,3 @@
-import {byteArrayEquals} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {isForkPostElectra} from "@lodestar/params";
 import {LightClientBootstrap, Root, ssz} from "@lodestar/types";
@@ -23,7 +22,7 @@ export function validateLightClientBootstrap(
     throw Error("Bootstrap Header is not Valid Light Client Header");
   }
 
-  if (!byteArrayEquals(headerRoot, trustedBlockRoot)) {
+  if (Buffer.compare(headerRoot, trustedBlockRoot)!== 0) {
     throw Error(`bootstrap header root ${toHex(headerRoot)} != trusted root ${toHex(trustedBlockRoot)}`);
   }
 

--- a/packages/light-client/src/utils/verifyMerkleBranch.ts
+++ b/packages/light-client/src/utils/verifyMerkleBranch.ts
@@ -1,5 +1,4 @@
 import {hasher} from "@chainsafe/persistent-merkle-tree";
-import {byteArrayEquals} from "@chainsafe/ssz";
 
 export const SYNC_COMMITTEES_DEPTH = 4;
 export const SYNC_COMMITTEES_INDEX = 11;
@@ -25,5 +24,5 @@ export function isValidMerkleBranch(
       value = hasher.digest64(value, proof[i]);
     }
   }
-  return byteArrayEquals(value, root);
+  return Buffer.compare(value, root) === 0;
 }

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -1,4 +1,3 @@
-import {byteArrayEquals} from "@chainsafe/ssz";
 import {Attestation, Epoch, phase0} from "@lodestar/types";
 import {intSqrt} from "@lodestar/utils";
 
@@ -166,11 +165,11 @@ export function getAttestationParticipationStatus(
     );
   }
 
-  const isMatchingTarget = byteArrayEquals(data.target.root, rootCache.getBlockRoot(data.target.epoch));
+  const isMatchingTarget = Buffer.compare(data.target.root, rootCache.getBlockRoot(data.target.epoch)) === 0;
 
   // a timely head is only be set if the target is _also_ matching
   const isMatchingHead =
-    isMatchingTarget && byteArrayEquals(data.beaconBlockRoot, rootCache.getBlockRootAtSlot(data.slot));
+    isMatchingTarget && Buffer.compare(data.beaconBlockRoot, rootCache.getBlockRootAtSlot(data.slot)) === 0;
 
   let flags = 0;
   if (isMatchingSource && inclusionDelay <= SLOTS_PER_EPOCH_SQRT) flags |= TIMELY_SOURCE;
@@ -181,5 +180,5 @@ export function getAttestationParticipationStatus(
 }
 
 export function checkpointValueEquals(cp1: phase0.Checkpoint, cp2: phase0.Checkpoint): boolean {
-  return cp1.epoch === cp2.epoch && byteArrayEquals(cp1.root, cp2.root);
+  return cp1.epoch === cp2.epoch && Buffer.compare(cp1.root, cp2.root) === 0;
 }

--- a/packages/state-transition/src/block/processBlockHeader.ts
+++ b/packages/state-transition/src/block/processBlockHeader.ts
@@ -1,4 +1,3 @@
-import {byteArrayEquals} from "@chainsafe/ssz";
 import {BeaconBlock, BlindedBeaconBlock, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {ZERO_HASH} from "../constants/index.js";
@@ -31,7 +30,7 @@ export function processBlockHeader(state: CachedBeaconStateAllForks, block: Beac
   }
 
   // verify that the parent matches
-  if (!byteArrayEquals(block.parentRoot, ssz.phase0.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader))) {
+  if (Buffer.compare(block.parentRoot, ssz.phase0.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader)) === 0) {
     throw new Error(
       `Block parent root ${toRootHex(block.parentRoot)} does not match state latest block, block slot=${slot}`
     );

--- a/packages/state-transition/src/block/processBlsToExecutionChange.ts
+++ b/packages/state-transition/src/block/processBlsToExecutionChange.ts
@@ -1,5 +1,4 @@
 import {digest} from "@chainsafe/as-sha256";
-import {byteArrayEquals} from "@chainsafe/ssz";
 import {BLS_WITHDRAWAL_PREFIX, ETH1_ADDRESS_WITHDRAWAL_PREFIX} from "@lodestar/params";
 import {capella} from "@lodestar/types";
 import {toHex} from "@lodestar/utils";
@@ -57,7 +56,7 @@ export function isValidBlsToExecutionChange(
   const digestCredentials = digest(addressChange.fromBlsPubkey);
   // Set the BLS_WITHDRAWAL_PREFIX on the digestCredentials for direct match
   digestCredentials[0] = BLS_WITHDRAWAL_PREFIX;
-  if (!byteArrayEquals(withdrawalCredentials, digestCredentials)) {
+  if (Buffer.compare(withdrawalCredentials, digestCredentials) !== 0) {
     return {
       valid: false,
       error: Error(

--- a/packages/state-transition/src/block/processExecutionPayload.ts
+++ b/packages/state-transition/src/block/processExecutionPayload.ts
@@ -1,4 +1,3 @@
-import {byteArrayEquals} from "@chainsafe/ssz";
 import {ForkName, ForkSeq, isForkPostDeneb} from "@lodestar/params";
 import {BeaconBlockBody, BlindedBeaconBlockBody, deneb, isExecutionPayload} from "@lodestar/types";
 import {toHex, toRootHex} from "@lodestar/utils";
@@ -23,7 +22,7 @@ export function processExecutionPayload(
   // with respect to the previous execution payload header
   if (isMergeTransitionComplete(state)) {
     const {latestExecutionPayloadHeader} = state;
-    if (!byteArrayEquals(payload.parentHash, latestExecutionPayloadHeader.blockHash)) {
+    if (Buffer.compare(payload.parentHash, latestExecutionPayloadHeader.blockHash) !== 0) {
       throw Error(
         `Invalid execution payload parentHash ${toRootHex(payload.parentHash)} latest blockHash ${toRootHex(
           latestExecutionPayloadHeader.blockHash
@@ -34,7 +33,7 @@ export function processExecutionPayload(
 
   // Verify random
   const expectedRandom = getRandaoMix(state, state.epochCtx.epoch);
-  if (!byteArrayEquals(payload.prevRandao, expectedRandom)) {
+  if (Buffer.compare(payload.prevRandao, expectedRandom) !== 0) {
     throw Error(`Invalid execution payload random ${toHex(payload.prevRandao)} expected=${toHex(expectedRandom)}`);
   }
 

--- a/packages/state-transition/src/block/processSyncCommittee.ts
+++ b/packages/state-transition/src/block/processSyncCommittee.ts
@@ -1,4 +1,3 @@
-import {byteArrayEquals} from "@chainsafe/ssz";
 import {DOMAIN_SYNC_COMMITTEE, SYNC_COMMITTEE_SIZE} from "@lodestar/params";
 import {altair, ssz} from "@lodestar/types";
 import {G2_POINT_AT_INFINITY} from "../constants/index.js";
@@ -94,7 +93,7 @@ export function getSyncCommitteeSignatureSet(
   if (participantIndices.length === 0) {
     // Must set signature as G2_POINT_AT_INFINITY when participating bits are empty
     // https://github.com/ethereum/eth2.0-specs/blob/30f2a076377264677e27324a8c3c78c590ae5e20/specs/altair/bls.md#eth2_fast_aggregate_verify
-    if (byteArrayEquals(signature, G2_POINT_AT_INFINITY)) {
+    if (Buffer.compare(signature, G2_POINT_AT_INFINITY) !== 0) {
       return null;
     }
     throw Error("Empty sync committee signature is not infinity");

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -1,4 +1,3 @@
-import {byteArrayEquals} from "@chainsafe/ssz";
 import {
   FAR_FUTURE_EPOCH,
   ForkSeq,
@@ -32,7 +31,7 @@ export function processWithdrawals(
   if (isCapellaPayloadHeader(payload)) {
     const expectedWithdrawalsRoot = ssz.capella.Withdrawals.hashTreeRoot(expectedWithdrawals);
     const actualWithdrawalsRoot = payload.withdrawalsRoot;
-    if (!byteArrayEquals(expectedWithdrawalsRoot, actualWithdrawalsRoot)) {
+    if (Buffer.compare(expectedWithdrawalsRoot, actualWithdrawalsRoot) !== 0) {
       throw Error(
         `Invalid withdrawalsRoot of executionPayloadHeader, expected=${toRootHex(
           expectedWithdrawalsRoot

--- a/packages/state-transition/src/epoch/processPendingAttestations.ts
+++ b/packages/state-transition/src/epoch/processPendingAttestations.ts
@@ -1,4 +1,3 @@
-import {byteArrayEquals} from "@chainsafe/ssz";
 import {Epoch, phase0} from "@lodestar/types";
 import {CachedBeaconStatePhase0} from "../types.js";
 import {computeStartSlotAtEpoch, getBlockRootAtSlot} from "../util/index.js";
@@ -31,9 +30,6 @@ export function processPendingAttestations(
     return;
   }
 
-  // Prevent frequent object get of external CommonJS dependencies
-  const byteArrayEqualsFn = byteArrayEquals;
-
   const actualTargetBlockRoot = getBlockRootAtSlot(state, computeStartSlotAtEpoch(epoch));
 
   for (const att of attestations) {
@@ -47,9 +43,9 @@ export function processPendingAttestations(
     const inclusionDelay = att.inclusionDelay;
     const proposerIndex = att.proposerIndex;
     const attSlot = attData.slot;
-    const attVotedTargetRoot = byteArrayEqualsFn(attData.target.root, actualTargetBlockRoot);
+    const attVotedTargetRoot = Buffer.compare(attData.target.root, actualTargetBlockRoot) === 0;
     const attVotedHeadRoot =
-      attSlot < stateSlot && byteArrayEqualsFn(attData.beaconBlockRoot, getBlockRootAtSlot(state, attSlot));
+      attSlot < stateSlot && Buffer.compare(attData.beaconBlockRoot, getBlockRootAtSlot(state, attSlot)) === 0;
     const committee = epochCtx.getBeaconCommittee(attSlot, attData.index);
     const participants = att.aggregationBits.intersectValues(committee);
 

--- a/packages/state-transition/src/slot/index.ts
+++ b/packages/state-transition/src/slot/index.ts
@@ -1,4 +1,3 @@
-import {byteArrayEquals} from "@chainsafe/ssz";
 import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {ZERO_HASH} from "../constants/index.js";
 import {CachedBeaconStateAllForks} from "../types.js";
@@ -20,7 +19,7 @@ export function processSlot(state: CachedBeaconStateAllForks): void {
   state.stateRoots.set(state.slot % SLOTS_PER_HISTORICAL_ROOT, previousStateRoot);
 
   // Cache latest block header state root
-  if (byteArrayEquals(state.latestBlockHeader.stateRoot, ZERO_HASH)) {
+  if (Buffer.compare(state.latestBlockHeader.stateRoot, ZERO_HASH) === 0) {
     state.latestBlockHeader.stateRoot = previousStateRoot;
   }
 

--- a/packages/state-transition/src/util/execution.ts
+++ b/packages/state-transition/src/util/execution.ts
@@ -36,7 +36,7 @@ export function isExecutionEnabled(state: BeaconStateExecutions, block: BeaconBl
   const payload = getFullOrBlindedPayload(block);
   // Note: spec says to check all payload is zero-ed. However a state-root cannot be zero for any non-empty payload
   // TODO: Consider comparing with the payload root if this assumption is not correct.
-  // return !byteArrayEquals(payload.stateRoot, ZERO_HASH);
+  // return Buffer.compare(payload.stateRoot, ZERO_HASH) !== 0;
 
   // UPDATE: stateRoot comparision should have been enough with zero hash, but spec tests were failing
   // Revisit this later to fix specs and make this efficient

--- a/packages/state-transition/test/perf/misc/byteArrayEquals.test.ts
+++ b/packages/state-transition/test/perf/misc/byteArrayEquals.test.ts
@@ -1,6 +1,5 @@
 import crypto from "node:crypto";
 import {bench, describe} from "@chainsafe/benchmark";
-import {byteArrayEquals} from "@chainsafe/ssz";
 import {generateState} from "../../utils/state.js";
 import {generateValidators} from "../../utils/validator.js";
 
@@ -35,10 +34,10 @@ describe("compare Uint8Array using byteArrayEquals() vs Buffer.compare()", () =>
       const bytes = stateBytes.subarray(0, length);
       const bytes2 = bytes.slice();
       bench({
-        id: `byteArrayEquals ${length}`,
+        id: `Buffer.compare ${length}`,
         fn: () => {
           for (let i = 0; i < runsFactor; i++) {
-            byteArrayEquals(bytes, bytes2);
+            Buffer.compare(bytes, bytes2) === 0;
           }
         },
         runsFactor,
@@ -63,10 +62,10 @@ describe("compare Uint8Array using byteArrayEquals() vs Buffer.compare()", () =>
       const bytes2 = bytes.slice();
       bytes2[bytes2.length - 1] = (bytes2.at(-1) as number) + 1;
       bench({
-        id: `byteArrayEquals ${length} - diff last byte`,
+        id: `Buffer.compare ${length} - diff last byte`,
         fn: () => {
           for (let i = 0; i < runsFactor; i++) {
-            byteArrayEquals(bytes, bytes2);
+            Buffer.compare(bytes, bytes2) === 0;
           }
         },
         runsFactor,
@@ -91,10 +90,10 @@ describe("compare Uint8Array using byteArrayEquals() vs Buffer.compare()", () =>
       const bytes2 = crypto.randomBytes(length);
 
       bench({
-        id: `byteArrayEquals ${length} - random bytes`,
+        id: `Buffer.compare ${length} - random bytes`,
         fn: () => {
           for (let i = 0; i < runsFactor; i++) {
-            byteArrayEquals(bytes, bytes2);
+            Buffer.compare(bytes, bytes2) === 0;
           }
         },
         runsFactor,

--- a/packages/state-transition/test/perf/misc/rootEquals.test.ts
+++ b/packages/state-transition/test/perf/misc/rootEquals.test.ts
@@ -1,5 +1,5 @@
 import {bench, describe, setBenchOpts} from "@chainsafe/benchmark";
-import {byteArrayEquals, fromHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {ssz} from "@lodestar/types";
 
 // As of Sep 2023
@@ -27,10 +27,10 @@ describe("root equals", () => {
   });
 
   bench({
-    id: "byteArrayEquals",
+    id: "Buffer.compare",
     fn: () => {
       for (let i = 0; i < runsFactor; i++) {
-        byteArrayEquals(rootTree, stateRoot);
+        Buffer.compare(rootTree, stateRoot) === 0;
       }
     },
     runsFactor,

--- a/packages/state-transition/test/perf/misc/rootEquals.test.ts
+++ b/packages/state-transition/test/perf/misc/rootEquals.test.ts
@@ -27,7 +27,7 @@ describe("root equals", () => {
   });
 
   bench({
-    id: "Buffer.compare",
+    id: "byteArrayEquals",
     fn: () => {
       for (let i = 0; i < runsFactor; i++) {
         Buffer.compare(rootTree, stateRoot) === 0;

--- a/packages/state-transition/test/perf/misc/rootEquals.test.ts
+++ b/packages/state-transition/test/perf/misc/rootEquals.test.ts
@@ -1,5 +1,5 @@
 import {bench, describe, setBenchOpts} from "@chainsafe/benchmark";
-import {fromHexString} from "@chainsafe/ssz";
+import {byteArrayEquals, fromHexString} from "@chainsafe/ssz";
 import {ssz} from "@lodestar/types";
 
 // As of Sep 2023
@@ -30,7 +30,7 @@ describe("root equals", () => {
     id: "byteArrayEquals",
     fn: () => {
       for (let i = 0; i < runsFactor; i++) {
-        Buffer.compare(rootTree, stateRoot) === 0;
+        byteArrayEquals(rootTree, stateRoot);
       }
     },
     runsFactor,


### PR DESCRIPTION
**Motivation**
The goal of this pull request is to improve the performance of byte array comparisons within the codebase by replacing the use of byteArrayEquals() with Node.js’s built-in Buffer.compare(). This change is motivated by significant performance gains observed in benchmark tests, especially for larger data sets, such as mainnet Ethereum state objects.

<!-- Why is this PR exists? What are the goals of the pull request? -->

Description

This PR replaces instances of byteArrayEquals() with Buffer.compare() for comparing byte arrays. Benchmark results demonstrate substantial improvements in speed:

For 32-byte arrays (commonly used for root equality checks), Buffer.compare() is over 2x faster than byteArrayEquals().

For large arrays (~100 MB), Buffer.compare() is approximately 22x faster.



Closes #5955
```sh
git checkout <Buffer_compare>
# Run benchmark or existing test suite to ensure no regressions
npm test
# Optionally run performance benchmarks
node benchmarks/compareBenchmark.js
```

