### PR TITLE
fix: bypass LightClientServer reference

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -96,7 +96,6 @@
         "@lodestar/config": "^1.30.0",
         "@lodestar/db": "^1.30.0",
         "@lodestar/fork-choice": "^1.30.0",
-        "@lodestar/light-client": "^1.30.0",
         "@lodestar/logger": "^1.30.0",
         "@lodestar/params": "^1.30.0",
         "@lodestar/reqresp": "^1.30.0",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -121,7 +121,6 @@
     "@lodestar/config": "^1.30.0",
     "@lodestar/db": "^1.30.0",
     "@lodestar/fork-choice": "^1.30.0",
-    "@lodestar/light-client": "^1.30.0",
     "@lodestar/logger": "^1.30.0",
     "@lodestar/params": "^1.30.0",
     "@lodestar/reqresp": "^1.30.0",

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -279,20 +279,20 @@ export async function importBlock(
     // Lightclient server support (only after altair)
     // - Persist state witness
     // - Use block's syncAggregate
-    if (blockEpoch >= this.config.ALTAIR_FORK_EPOCH) {
-      // we want to import block asap so do this in the next event loop
-      callInNextEventLoop(() => {
-        try {
-          this.lightClientServer?.onImportBlockHead(
-            block.message as BeaconBlock<ForkPostAltair>,
-            postState as CachedBeaconStateAltair,
-            parentBlockSlot
-          );
-        } catch (e) {
-          this.logger.verbose("Error lightClientServer.onImportBlock", {slot: blockSlot}, e as Error);
-        }
-      });
-    }
+    // if (blockEpoch >= this.config.ALTAIR_FORK_EPOCH) {
+    //   // we want to import block asap so do this in the next event loop
+    //   callInNextEventLoop(() => {
+    //     try {
+    //       this.lightClientServer?.onImportBlockHead(
+    //         block.message as BeaconBlock<ForkPostAltair>,
+    //         postState as CachedBeaconStateAltair,
+    //         parentBlockSlot
+    //       );
+    //     } catch (e) {
+    //       this.logger.verbose("Error lightClientServer.onImportBlock", {slot: blockSlot}, e as Error);
+    //     }
+    //   });
+    // }
   }
 
   // 6. Queue notifyForkchoiceUpdate to engine api

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -68,7 +68,7 @@ import {
   ProposerPreparationData,
   StateGetOpts,
 } from "./interface.js";
-import {LightClientServer} from "./lightClient/index.js";
+// import {LightClientServer} from "./lightClient/index.js";
 import {
   AggregatedAttestationPool,
   AttestationPool,
@@ -133,7 +133,7 @@ export class BeaconChain implements IBeaconChain {
   readonly clock: IClock;
   readonly emitter: ChainEventEmitter;
   readonly regen: QueuedStateRegenerator;
-  readonly lightClientServer?: LightClientServer;
+  // readonly lightClientServer?: LightClientServer;
   readonly reprocessController: ReprocessController;
   readonly archiveStore: ArchiveStore;
 
@@ -344,9 +344,9 @@ export class BeaconChain implements IBeaconChain {
       signal,
     });
 
-    if (!opts.disableLightClientServer) {
-      this.lightClientServer = new LightClientServer(opts, {config, db, metrics, emitter, logger});
-    }
+    // if (!opts.disableLightClientServer) {
+      // this.lightClientServer = new LightClientServer(opts, {config, db, metrics, emitter, logger});
+    // }
 
     this.reprocessController = new ReprocessController(this.metrics);
 


### PR DESCRIPTION
**Motivation**

- got this error when running `cayman/bun`

```
/.bun/bin/bun: symbol lookup error: lodestar/packages/light-client/node_modules/@chainsafe/blst/prebuild/linux-x64-127-binding.node: undefined symbol: _ZN2v87Context6GlobalEv
```

**Description**

- Bun cannot load napi module @chainsafe/bls since it used the old blst binding there
- Do not reference LightClientServer for now to fix it

was able to run our BeaconNode with this fix