### PR TITLE
feat: pass `skipRandaoVerification` to `processRandao` correctly

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -624,8 +624,7 @@ export function getValidatorApi(
           commonBlockBody,
           parentBlockRoot,
           skipRandaoVerification,
-        }
-      )
+        })
       : Promise.reject(new Error("Builder disabled"));
 
     const enginePromise = isEngineEnabled

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -405,9 +405,11 @@ export function getValidatorApi(
     {
       commonBlockBody,
       parentBlockRoot,
+      skipRandaoVerification,
     }: Omit<routes.validator.ExtraProduceBlockOpts, "builderSelection"> & {
       commonBlockBody: CommonBlockBody;
       parentBlockRoot: Root;
+      skipRandaoVerification?: boolean;
     }
   ): Promise<ProduceBlindedBlockRes> {
     const version = config.getForkName(slot);
@@ -435,6 +437,7 @@ export function getValidatorApi(
         randaoReveal,
         graffiti,
         commonBlockBody,
+        skipRandaoVerification,
       });
 
       metrics?.blockProductionSuccess.inc({source});
@@ -466,9 +469,11 @@ export function getValidatorApi(
       strictFeeRecipientCheck,
       commonBlockBody,
       parentBlockRoot,
+      skipRandaoVerification,
     }: Omit<routes.validator.ExtraProduceBlockOpts, "builderSelection"> & {
       commonBlockBody: CommonBlockBody;
       parentBlockRoot: Root;
+      skipRandaoVerification?: boolean;
     }
   ): Promise<ProduceBlockOrContentsRes & {shouldOverrideBuilder?: boolean}> {
     const source = ProducedBlockSource.engine;
@@ -484,6 +489,7 @@ export function getValidatorApi(
         graffiti,
         feeRecipient,
         commonBlockBody,
+        skipRandaoVerification,
       });
       const version = config.getForkName(block.slot);
       if (strictFeeRecipientCheck && feeRecipient && isForkPostBellatrix(version)) {
@@ -531,8 +537,7 @@ export function getValidatorApi(
     slot: Slot,
     randaoReveal: BLSSignature,
     graffiti?: string,
-    // TODO deneb: skip randao verification
-    _skipRandaoVerification?: boolean,
+    skipRandaoVerification?: boolean,
     builderBoostFactor?: bigint,
     {feeRecipient, builderSelection, strictFeeRecipientCheck}: routes.validator.ExtraProduceBlockOpts = {}
   ): Promise<ProduceFullOrBlindedBlockOrContentsRes> {
@@ -618,7 +623,9 @@ export function getValidatorApi(
           strictFeeRecipientCheck: false,
           commonBlockBody,
           parentBlockRoot,
-        })
+          skipRandaoVerification,
+        }
+      )
       : Promise.reject(new Error("Builder disabled"));
 
     const enginePromise = isEngineEnabled
@@ -627,6 +634,7 @@ export function getValidatorApi(
           strictFeeRecipientCheck,
           commonBlockBody,
           parentBlockRoot,
+          skipRandaoVerification,
         }).then((engineBlock) => {
           // Once the engine returns a block, in the event of either:
           // - suspected builder censorship

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -681,7 +681,8 @@ export class BeaconChain implements IBeaconChain {
       feeRecipient,
       commonBlockBody,
       parentBlockRoot,
-    }: BlockAttributes & {commonBlockBody?: CommonBlockBody}
+      skipRandaoVerification,
+    }: BlockAttributes & {commonBlockBody?: CommonBlockBody; skipRandaoVerification?: boolean}
   ): Promise<{
     block: AssembledBlockType<T>;
     executionPayloadValue: Wei;
@@ -735,7 +736,7 @@ export class BeaconChain implements IBeaconChain {
       body,
     } as AssembledBlockType<T>;
 
-    const {newStateRoot, proposerReward} = computeNewStateRoot(this.metrics, state, block);
+    const {newStateRoot, proposerReward} = computeNewStateRoot(this.metrics, state, block, skipRandaoVerification);
     block.stateRoot = newStateRoot;
     const blockRoot =
       blockType === BlockType.Full

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -197,13 +197,13 @@ export interface IBeaconChain {
   getContents(beaconBlock: deneb.BeaconBlock): deneb.Contents;
 
   produceCommonBlockBody(blockAttributes: BlockAttributes): Promise<CommonBlockBody>;
-  produceBlock(blockAttributes: BlockAttributes & {commonBlockBody?: CommonBlockBody}): Promise<{
+  produceBlock(blockAttributes: BlockAttributes & {commonBlockBody?: CommonBlockBody; skipRandaoVerification?: boolean}): Promise<{
     block: BeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Wei;
     shouldOverrideBuilder?: boolean;
   }>;
-  produceBlindedBlock(blockAttributes: BlockAttributes & {commonBlockBody?: CommonBlockBody}): Promise<{
+  produceBlindedBlock(blockAttributes: BlockAttributes & {commonBlockBody?: CommonBlockBody; skipRandaoVerification?: boolean}): Promise<{
     block: BlindedBeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Wei;

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -197,13 +197,17 @@ export interface IBeaconChain {
   getContents(beaconBlock: deneb.BeaconBlock): deneb.Contents;
 
   produceCommonBlockBody(blockAttributes: BlockAttributes): Promise<CommonBlockBody>;
-  produceBlock(blockAttributes: BlockAttributes & {commonBlockBody?: CommonBlockBody; skipRandaoVerification?: boolean}): Promise<{
+  produceBlock(
+    blockAttributes: BlockAttributes & {commonBlockBody?: CommonBlockBody; skipRandaoVerification?: boolean}
+  ): Promise<{
     block: BeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Wei;
     shouldOverrideBuilder?: boolean;
   }>;
-  produceBlindedBlock(blockAttributes: BlockAttributes & {commonBlockBody?: CommonBlockBody; skipRandaoVerification?: boolean}): Promise<{
+  produceBlindedBlock(
+    blockAttributes: BlockAttributes & {commonBlockBody?: CommonBlockBody; skipRandaoVerification?: boolean}
+  ): Promise<{
     block: BlindedBeaconBlock;
     executionPayloadValue: Wei;
     consensusBlockValue: Wei;

--- a/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
+++ b/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
@@ -17,7 +17,8 @@ import {Metrics} from "../../metrics/index.js";
 export function computeNewStateRoot(
   metrics: Metrics | null,
   state: CachedBeaconStateAllForks,
-  block: BeaconBlock | BlindedBeaconBlock
+  block: BeaconBlock | BlindedBeaconBlock,
+  skipRandaoVerification?: boolean
 ): {newStateRoot: Root; proposerReward: Gwei} {
   // Set signature to zero to re-use stateTransition() function which requires the SignedBeaconBlock type
   const blockEmptySig = {message: block, signature: ZERO_HASH};
@@ -35,7 +36,7 @@ export function computeNewStateRoot(
       // verifyProposer: false   | as the block signature is zero-ed
       verifyProposer: false,
       // verifySignatures: false | since the data to assemble the block is trusted
-      verifySignatures: false,
+      verifySignatures: skipRandaoVerification ?? false,
       // Preserve cache in source state, since the resulting state is not added to the state cache
       dontTransferCache: true,
     },


### PR DESCRIPTION
**Motivation**

Allow the block production API to skip RANDAO verification of the block.

**Description**

While skipping RANDAO verification was already implemented, it was not actually used. In other words, the block production endpoint accept such query param, but it didn't pass it to `processRandao` (the function that verifies RANDAO) correctly.

Fix the issue by passing the `skipRandaoVerification` to `processRandao` via some intermediate functions that are called in the process.

Closes #4638