### PR TITLE
chore: restore dashboard variable names and inputs during download

### DIFF
--- a/scripts/lint-grafana-dashboard.mjs
+++ b/scripts/lint-grafana-dashboard.mjs
@@ -111,7 +111,10 @@ export function lintGrafanaDashboard(json) {
           type: "constant",
           value: "beacon",
         });
-        item.current.text = item.current.value = item.query = "${VAR_BEACON_JOB}";
+        if (item.current) {
+          item.current.text = item.current.value = "${VAR_BEACON_JOB}";
+        }
+        item.query = "${VAR_BEACON_JOB}";
       } else if (item.query === "${VAR_VALIDATOR_JOB}" || item.query === "validator") {
         inputs.push({
           description: "",
@@ -120,7 +123,10 @@ export function lintGrafanaDashboard(json) {
           type: "constant",
           value: "validator",
         });
-        item.current.text = item.current.value = item.query = "${VAR_VALIDATOR_JOB}";
+        if (item.current) {
+          item.current.text = item.current.value = "${VAR_VALIDATOR_JOB}";
+        }
+        item.query = "${VAR_VALIDATOR_JOB}";
       }
     }
   }

--- a/scripts/lint-grafana-dashboard.mjs
+++ b/scripts/lint-grafana-dashboard.mjs
@@ -72,6 +72,7 @@ import fs from "node:fs";
  * @typedef {Object} TemplatingListItem
  * @property {string} name
  * @property {string} query
+ * @property {{text: string; value: string}} current
  */
 
 const variableNameDatasource = "DS_PROMETHEUS";
@@ -102,7 +103,7 @@ export function lintGrafanaDashboard(json) {
   // Add job names to __inputs if used by dashboard
   if (json.templating && json.templating.list) {
     for (const item of json.templating.list) {
-      if (item.query === "${VAR_BEACON_JOB}") {
+      if (item.query === "${VAR_BEACON_JOB}" || item.query === "beacon") {
         inputs.push({
           description: "",
           label: "Beacon node job name",
@@ -110,7 +111,8 @@ export function lintGrafanaDashboard(json) {
           type: "constant",
           value: "beacon",
         });
-      } else if (item.query === "${VAR_VALIDATOR_JOB}") {
+        item.current.text = item.current.value = item.query = "${VAR_BEACON_JOB}";
+      } else if (item.query === "${VAR_VALIDATOR_JOB}" || item.query === "validator") {
         inputs.push({
           description: "",
           label: "Validator client job name",
@@ -118,6 +120,7 @@ export function lintGrafanaDashboard(json) {
           type: "constant",
           value: "validator",
         });
+        item.current.text = item.current.value = item.query = "${VAR_VALIDATOR_JOB}";
       }
     }
   }


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/7840, it seems that newer versions of grafana replace variables with values picked during manual import. This means if an external contributor that edits a dashboard and follows our steps in contribution guideline it will still keep the hard coded values and requires to manually revert them, which is not a big deal but we should still make sure that external contributor have as close to seamless experience when contributing to dashboard as we do using the cloud instance with provisioned dashboards.

**Description**

Restore dashboard variable names and inputs during download

