### PR TITLE
fix: update schemas to enforce unique array values in beacon routes

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -544,7 +544,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       req: {
         writeReq: ({blockId, indices}) => ({params: {block_id: blockId.toString()}, query: {indices}}),
         parseReq: ({params, query}) => ({blockId: params.block_id, indices: query.indices}),
-        schema: {params: {block_id: Schema.StringRequired}, query: {indices: Schema.UintArray}},
+        schema: {params: {block_id: Schema.StringRequired}, query: {indices: Schema.UintArrayUnique}},
       },
       resp: {
         data: ssz.deneb.BlobSidecars,

--- a/packages/api/src/beacon/routes/beacon/rewards.ts
+++ b/packages/api/src/beacon/routes/beacon/rewards.ts
@@ -183,7 +183,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         }),
         schema: {
           params: {epoch: Schema.UintRequired},
-          body: Schema.UintOrStringArray,
+          body: Schema.UintOrStringArrayUnique,
         },
       }),
       resp: {
@@ -205,7 +205,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         }),
         schema: {
           params: {block_id: Schema.StringRequired},
-          body: Schema.UintOrStringArray,
+          body: Schema.UintOrStringArrayUnique,
         },
       }),
       resp: {

--- a/packages/api/src/beacon/routes/beacon/state.ts
+++ b/packages/api/src/beacon/routes/beacon/state.ts
@@ -429,7 +429,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         parseReq: ({params, query}) => ({stateId: params.state_id, validatorIds: query.id, statuses: query.status}),
         schema: {
           params: {state_id: Schema.StringRequired},
-          query: {id: Schema.UintOrStringArray, status: Schema.StringArray},
+          query: {id: Schema.UintOrStringArrayUnique, status: Schema.StringArrayUnique},
         },
       },
       resp: {
@@ -479,7 +479,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         }),
         schema: {
           params: {state_id: Schema.StringRequired},
-          body: Schema.UintOrStringArray,
+          body: Schema.UintOrStringArrayUnique,
         },
       }),
       resp: {
@@ -495,7 +495,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         parseReq: ({params, query}) => ({stateId: params.state_id, validatorIds: query.id}),
         schema: {
           params: {state_id: Schema.StringRequired},
-          query: {id: Schema.UintOrStringArray},
+          query: {id: Schema.UintOrStringArrayUnique},
         },
       },
       resp: {
@@ -517,7 +517,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         }),
         schema: {
           params: {state_id: Schema.StringRequired},
-          body: Schema.UintOrStringArray,
+          body: Schema.UintOrStringArrayUnique,
         },
       }),
       resp: {

--- a/packages/api/src/utils/schema.ts
+++ b/packages/api/src/utils/schema.ts
@@ -24,12 +24,15 @@ export enum Schema {
   Uint,
   UintRequired,
   UintArray,
+  UintArrayUnique,
   String,
   StringRequired,
   StringArray,
+  StringArrayUnique,
   StringArrayRequired,
   UintOrStringRequired,
   UintOrStringArray,
+  UintOrStringArrayUnique,
   Object,
   ObjectArray,
   AnyArray,
@@ -47,6 +50,8 @@ function getJsonSchemaItem(schema: Schema): JsonSchema {
 
     case Schema.UintArray:
       return {type: "array", items: {type: "integer", minimum: 0}};
+    case Schema.UintArrayUnique:
+      return {type: "array", uniqueItems: true, items: {type: "integer", minimum: 0}};
 
     case Schema.String:
     case Schema.StringRequired:
@@ -55,11 +60,15 @@ function getJsonSchemaItem(schema: Schema): JsonSchema {
     case Schema.StringArray:
     case Schema.StringArrayRequired:
       return {type: "array", items: {type: "string"}};
+    case Schema.StringArrayUnique:
+      return {type: "array", uniqueItems: true, items: {type: "string"}};
 
     case Schema.UintOrStringRequired:
       return {anyOf: [{type: "string"}, {type: "integer"}]};
     case Schema.UintOrStringArray:
       return {type: "array", items: {anyOf: [{type: "string"}, {type: "integer"}]}};
+    case Schema.UintOrStringArrayUnique:
+      return {type: "array", uniqueItems: true, items: {anyOf: [{type: "string"}, {type: "integer"}]}};
 
     case Schema.Object:
       return {type: "object"};

--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -138,6 +138,27 @@ export function getBeaconStateApi({
     },
 
     async postStateValidators(args, context) {
+      /**
+       * Uniqueness is checked at the schema level, but because the schema
+       * definition for the body of this endpoint is marked as `Schema.Object`
+       * we have to check it at the implementation level. Check the schema
+       * definition for more details.
+       * https://github.com/ChainSafe/lodestar/blob/ac2653dd8b767a24f9b1580977f8f560b1e3352d/packages/api/src/beacon/routes/beacon/state.ts#L459
+       */
+      const {validatorIds = [], statuses = []} = args;
+      const containsDuplicateStatuses = new Set(statuses).size !== statuses.length;
+      const containsDuplicateValidatorIds = new Set(validatorIds).size !== validatorIds.length;
+
+      if (containsDuplicateStatuses || containsDuplicateValidatorIds) {
+        const message =
+          containsDuplicateStatuses && containsDuplicateValidatorIds
+            ? "Duplicate validator IDs and statuses provided"
+            : containsDuplicateStatuses
+              ? "Duplicate statuses provided"
+              : "Duplicate validator IDs provided";
+        throw new ApiError(400, message);
+      }
+
       return this.getStateValidators(args, context);
     },
 


### PR DESCRIPTION
**Motivation**

Make sure array inputs to some Beacon APIs are unique, based on [Beacon APIs spec](https://github.com/ethereum/beacon-APIs).

**Description**

Modify Beacon routes request schemas to use unique version of Schema types for better data integrity.

This change enhances the robustness of the API by ensuring that duplicate entries are not processed, aligning with schema definitions from Beacon API spec.

Closes #5271

**Steps to test or reproduce**
- Run a dev environment via `lodestar dev`
- Test the API with duplicate input (=query, body, etc.)
- Assert that a response with 400 status code is returned
