### PR TITLE
chore: bump @chainsafe/threads to v1.11.2

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -102,7 +102,7 @@
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/pubkey-index-map": "^3.0.0",
     "@chainsafe/ssz": "^1.2.0",
-    "@chainsafe/threads": "^1.11.1",
+    "@chainsafe/threads": "^1.11.2",
     "@ethersproject/abi": "^5.7.0",
     "@fastify/bearer-auth": "^10.0.1",
     "@fastify/cors": "^10.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "@chainsafe/enr": "^5.0.0",
     "@chainsafe/persistent-merkle-tree": "^1.1.0",
     "@chainsafe/ssz": "^1.2.0",
-    "@chainsafe/threads": "^1.11.1",
+    "@chainsafe/threads": "^1.11.2",
     "@libp2p/crypto": "^5.0.15",
     "@libp2p/interface": "^2.7.0",
     "@libp2p/peer-id": "^5.1.0",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -69,7 +69,7 @@
     "winston-transport": "^4.5.0"
   },
   "devDependencies": {
-    "@chainsafe/threads": "^1.11.1",
+    "@chainsafe/threads": "^1.11.2",
     "@lodestar/test-utils": "^1.30.0",
     "@types/triple-beam": "^1.3.2",
     "triple-beam": "^1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,10 +831,10 @@
     "@chainsafe/swap-or-not-shuffle-win32-arm64-msvc" "1.2.1"
     "@chainsafe/swap-or-not-shuffle-win32-x64-msvc" "1.2.1"
 
-"@chainsafe/threads@^1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/threads/-/threads-1.11.1.tgz#0b3b8c76f5875043ef6d47aeeb681dc80378f205"
-  integrity sha512-ejkB0eVcM0k2E8n5ZqOGt//ZEWU+c431QS3e/WfjLKxhw/fwZpvYhUOxBA8u3lJmAKLGziIcXjOoTnPwMPhkcQ==
+"@chainsafe/threads@^1.11.2":
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/@chainsafe/threads/-/threads-1.11.2.tgz#fc400efdfec2d246e5054e3521a9066dc2dc45af"
+  integrity sha512-qd5mSYWyIgK+G4LQTLhJhO4IUda4eydYhZsT6AadALFUKs5WrHaFtAf7sLol6JjgWG7wwgznUs7FFyBl0xPmoQ==
   dependencies:
     callsites "^3.1.0"
     debug "^4.2.0"


### PR DESCRIPTION
**Motivation**
- https://github.com/ChainSafe/lodestar/issues/5552 is still an issue

**Description**

- Includes https://github.com/ChainSafe/threads.js/pull/4 to get rid of `MaxListenersExceededWarning`
