### PR TITLE
fix: default to as-sha256 if no chip support for AVX

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -74,6 +74,7 @@
     "@lodestar/utils": "^1.30.0",
     "@lodestar/validator": "^1.30.0",
     "@multiformats/multiaddr": "^12.1.3",
+    "cpu-features": "^0.0.10",
     "deepmerge": "^4.3.1",
     "ethers": "^6.7.0",
     "find-up": "^6.3.0",
@@ -88,6 +89,7 @@
   },
   "devDependencies": {
     "@lodestar/test-utils": "^1.30.0",
+    "@types/cpu-features": "^0.0.3",
     "@types/debug": "^4.1.7",
     "@types/inquirer": "^9.0.3",
     "@types/proper-lockfile": "^4.1.4",

--- a/packages/cli/src/applyPreset.ts
+++ b/packages/cli/src/applyPreset.ts
@@ -1,9 +1,22 @@
 // MUST import this file first before anything and not import any Lodestar code.
 import {setHasher} from "@chainsafe/persistent-merkle-tree";
-import {hasher} from "@chainsafe/persistent-merkle-tree/hasher/hashtree";
+import {hasher as asSha256Hasher} from "@chainsafe/persistent-merkle-tree/hasher/as-sha256";
+import {hasher as hashtreeHasher} from "@chainsafe/persistent-merkle-tree/hasher/hashtree";
+import CpuFeatures from "cpu-features";
 
 // without setting this first, persistent-merkle-tree will use noble instead
-setHasher(hasher);
+const cpuFeatures = CpuFeatures();
+if (
+  cpuFeatures.arch === "x86" &&
+  !(cpuFeatures.flags.avx || cpuFeatures.flags.avx2 || cpuFeatures.flags.avx512f || cpuFeatures.flags.avx512vl)
+) {
+  console.log(
+    "Hashtree hasher is preferred but the CPU architecture does not support AVX, AVX2 or the correct AVX512 instruction sets. Falling back to as-sha256 hasher instead."
+  );
+  setHasher(asSha256Hasher);
+} else {
+  setHasher(hashtreeHasher);
+}
 
 //
 // ## Rationale

--- a/packages/prover/src/cli/applyPreset.ts
+++ b/packages/prover/src/cli/applyPreset.ts
@@ -1,10 +1,23 @@
 // MUST import this file first before anything and not import any Lodestar code.
-
 import {setHasher} from "@chainsafe/persistent-merkle-tree";
-import {hasher} from "@chainsafe/persistent-merkle-tree/hasher/hashtree";
+import {hasher as asSha256Hasher} from "@chainsafe/persistent-merkle-tree/hasher/as-sha256";
+import {hasher as hashtreeHasher} from "@chainsafe/persistent-merkle-tree/hasher/hashtree";
+import CpuFeatures from "cpu-features";
 
 // without setting this first, persistent-merkle-tree will use noble instead
-setHasher(hasher);
+const cpuFeatures = CpuFeatures();
+if (
+  cpuFeatures.arch === "x86" &&
+  !(cpuFeatures.flags.avx || cpuFeatures.flags.avx2 || cpuFeatures.flags.avx512f || cpuFeatures.flags.avx512vl)
+) {
+  // biome-ignore lint/suspicious/noConsole: let consumer know that the default hasher is not supported
+  console.log(
+    "Hashtree hasher is preferred but the CPU architecture does not support AVX, AVX2 or the correct AVX512 instruction sets. Falling back to as-sha256 hasher instead."
+  );
+  setHasher(asSha256Hasher);
+} else {
+  setHasher(hashtreeHasher);
+}
 
 //
 // ## Rationale

--- a/yarn.lock
+++ b/yarn.lock
@@ -3357,6 +3357,11 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
   integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
 
+"@types/cpu-features@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/cpu-features/-/cpu-features-0.0.3.tgz#a2bec076eb5dc95e0a6c23d1f8d389be4109b309"
+  integrity sha512-W/Ep+LDZoxMbCcH7LHRB3RN+TY4gbHl3u4uRq4XsxOh1gnpf5Lkwy5xWTBKSaJYQuMLW2XPAmRWA5Ucsy2EGVQ==
+
 "@types/datastore-level@^3.0.0":
   version "3.0.0"
   resolved "https://registry.npmjs.org/@types/datastore-level/-/datastore-level-3.0.0.tgz"
@@ -5379,6 +5384,14 @@ cosmiconfig@^8.2.0:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
     path-type "^4.0.0"
+
+cpu-features@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cpu-features/-/cpu-features-0.0.10.tgz#9aae536db2710c7254d7ed67cb3cbc7d29ad79c5"
+  integrity sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==
+  dependencies:
+    buildcheck "~0.0.6"
+    nan "^2.19.0"
 
 cpu-features@~0.0.4:
   version "0.0.8"


### PR DESCRIPTION
**Motivation**

A crash was reported by several parties running Lodestar on a VPS.  The problem was tracked down to no AVX support on the host which causes OffchainLabs/hashtree to crash.  The go binding do a similar check, at the bindings level, and revert to a non-assembly SHA256 lib.  This PR does the same.  Checks the hardware for the supported AVX types and returns `as-sha256` hasher from the `hashtree` hasher so there is no crash.


https://github.com/OffchainLabs/hashtree/blob/67979dccfc99b02b488ed8f5fddee9f09aea411e/src/hashtree.c#L53-L67