### PR TITLE
fix: avx check in conditional

### DIFF
--- a/packages/cli/src/applyPreset.ts
+++ b/packages/cli/src/applyPreset.ts
@@ -7,12 +7,13 @@ import CpuFeatures from "cpu-features";
 // without setting this first, persistent-merkle-tree will use noble instead
 const cpuFeatures = CpuFeatures();
 if (
-  cpuFeatures.arch === "x86" &&
-  !(
-    (cpuFeatures.flags.avx512f && cpuFeatures.flags.avx512vl) ||
-    (cpuFeatures.flags.avx2 && cpuFeatures.flags.bmi2) ||
-    (cpuFeatures.flags.avx && cpuFeatures.flags.sha)
-  )
+  (cpuFeatures.arch === "x86" &&
+    !(
+      (cpuFeatures.flags.avx512f && cpuFeatures.flags.avx512vl) ||
+      (cpuFeatures.flags.avx2 && cpuFeatures.flags.bmi2) ||
+      (cpuFeatures.flags.avx && cpuFeatures.flags.sha)
+    )) ||
+  (cpuFeatures.arch === "aarch64" && !cpuFeatures.flags.sha2)
 ) {
   console.log(
     "Hashtree hasher is preferred but the CPU architecture does not support AVX, AVX2 or the correct AVX512 instruction sets. Falling back to as-sha256 hasher instead."

--- a/packages/cli/src/applyPreset.ts
+++ b/packages/cli/src/applyPreset.ts
@@ -8,7 +8,11 @@ import CpuFeatures from "cpu-features";
 const cpuFeatures = CpuFeatures();
 if (
   cpuFeatures.arch === "x86" &&
-  !(cpuFeatures.flags.avx || cpuFeatures.flags.avx2 || cpuFeatures.flags.avx512f || cpuFeatures.flags.avx512vl)
+  !(
+    (cpuFeatures.flags.avx512f && cpuFeatures.flags.avx512vl) ||
+    (cpuFeatures.flags.avx2 && cpuFeatures.flags.bmi2) ||
+    (cpuFeatures.flags.avx && cpuFeatures.flags.sha)
+  )
 ) {
   console.log(
     "Hashtree hasher is preferred but the CPU architecture does not support AVX, AVX2 or the correct AVX512 instruction sets. Falling back to as-sha256 hasher instead."

--- a/packages/prover/src/cli/applyPreset.ts
+++ b/packages/prover/src/cli/applyPreset.ts
@@ -8,7 +8,11 @@ import CpuFeatures from "cpu-features";
 const cpuFeatures = CpuFeatures();
 if (
   cpuFeatures.arch === "x86" &&
-  !(cpuFeatures.flags.avx || cpuFeatures.flags.avx2 || cpuFeatures.flags.avx512f || cpuFeatures.flags.avx512vl)
+  !(
+    (cpuFeatures.flags.avx512f && cpuFeatures.flags.avx512vl) ||
+    (cpuFeatures.flags.avx2 && cpuFeatures.flags.bmi2) ||
+    (cpuFeatures.flags.avx && cpuFeatures.flags.sha)
+  )
 ) {
   // biome-ignore lint/suspicious/noConsole: let consumer know that the default hasher is not supported
   console.log(

--- a/packages/prover/src/cli/applyPreset.ts
+++ b/packages/prover/src/cli/applyPreset.ts
@@ -7,12 +7,13 @@ import CpuFeatures from "cpu-features";
 // without setting this first, persistent-merkle-tree will use noble instead
 const cpuFeatures = CpuFeatures();
 if (
-  cpuFeatures.arch === "x86" &&
-  !(
-    (cpuFeatures.flags.avx512f && cpuFeatures.flags.avx512vl) ||
-    (cpuFeatures.flags.avx2 && cpuFeatures.flags.bmi2) ||
-    (cpuFeatures.flags.avx && cpuFeatures.flags.sha)
-  )
+  (cpuFeatures.arch === "x86" &&
+    !(
+      (cpuFeatures.flags.avx512f && cpuFeatures.flags.avx512vl) ||
+      (cpuFeatures.flags.avx2 && cpuFeatures.flags.bmi2) ||
+      (cpuFeatures.flags.avx && cpuFeatures.flags.sha)
+    )) ||
+  (cpuFeatures.arch === "aarch64" && !cpuFeatures.flags.sha2)
 ) {
   // biome-ignore lint/suspicious/noConsole: let consumer know that the default hasher is not supported
   console.log(


### PR DESCRIPTION
**Motivation**

Fix check for AVX conditional.  Needs to follow what was done in:
https://github.com/OffchainLabs/hashtree/blob/main/bindings_amd64.go

Original PR just looked at the hashtree bindings here:
https://github.com/OffchainLabs/hashtree/blob/main/src/hashtree.c#L42