### PR TITLE
fix: do not throw error for non-hashtree hashers

### DIFF
--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -161,7 +161,7 @@ export class BeaconNode {
     metricsRegistries = [],
   }: BeaconNodeInitModules): Promise<T> {
     if (hasher.name !== "hashtree") {
-      logger.warn("hashtree is not supported, using hasher", {hasher: hasher.name});
+      logger.warn(`hashtree is not supported, using hasher ${hasher.name}`);
     }
 
     const controller = new AbortController();

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -161,7 +161,7 @@ export class BeaconNode {
     metricsRegistries = [],
   }: BeaconNodeInitModules): Promise<T> {
     if (hasher.name !== "hashtree") {
-      throw Error(`Loaded incorrect hasher ${hasher.name}, expected hashtree`);
+      logger.warn("hashtree is not supported, using hasher", {hasher: hasher.name});
     }
 
     const controller = new AbortController();

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -38,7 +38,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
   const {config, options, beaconPaths, network, version, commit, privateKey, logger} = await beaconHandlerInit(args);
 
   if (hasher.name !== "hashtree") {
-    logger.warn("hashtree is not supported, using hasher", {hasher: hasher.name});
+    logger.warn(`hashtree is not supported, using hasher ${hasher.name}`);
   }
 
   const heapSizeLimit = getHeapStatistics().heap_size_limit;

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -38,7 +38,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
   const {config, options, beaconPaths, network, version, commit, privateKey, logger} = await beaconHandlerInit(args);
 
   if (hasher.name !== "hashtree") {
-    throw Error(`Loaded incorrect hasher ${hasher.name}, expected hashtree`);
+    logger.warn("hashtree is not supported, using hasher", {hasher: hasher.name});
   }
 
   const heapSizeLimit = getHeapStatistics().heap_size_limit;


### PR DESCRIPTION
**Motivation**

- do not throw error for as-sha256 hasher, an addition to #7887

**Description**

- `log.warn` instead of throwing error

may want @KatyaRyazantseva to give it a try on her laptop