### PR TITLE
feat: add EIP-7917 deterministic proposer lookahead

### DIFF
--- a/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
+++ b/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
@@ -4,6 +4,7 @@ import {
   BeaconStateAllForks,
   CachedBeaconStateAllForks,
   CachedBeaconStateAltair,
+  CachedBeaconStateFulu,
   EpochTransitionCache,
   beforeProcessEpoch,
 } from "@lodestar/state-transition";
@@ -46,6 +47,10 @@ const epochTransitionFns: Record<string, EpochTransitionFn> = {
   historical_summaries_update: epochFns.processHistoricalSummariesUpdate as EpochTransitionFn,
   pending_deposits: epochFns.processPendingDeposits as EpochTransitionFn,
   pending_consolidations: epochFns.processPendingConsolidations as EpochTransitionFn,
+  process_proposer_lookahead: (state, _) => {
+    const fork = state.config.getForkSeq(state.slot);
+    epochFns.processProposerLookahead(fork, state as CachedBeaconStateFulu);
+  },
 };
 
 /**

--- a/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
+++ b/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
@@ -47,7 +47,7 @@ const epochTransitionFns: Record<string, EpochTransitionFn> = {
   historical_summaries_update: epochFns.processHistoricalSummariesUpdate as EpochTransitionFn,
   pending_deposits: epochFns.processPendingDeposits as EpochTransitionFn,
   pending_consolidations: epochFns.processPendingConsolidations as EpochTransitionFn,
-  process_proposer_lookahead: (state, _) => {
+  proposer_lookahead: (state, _) => {
     const fork = state.config.getForkSeq(state.slot);
     epochFns.processProposerLookahead(fork, state as CachedBeaconStateFulu);
   },

--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -14,7 +14,7 @@ import {DownloadTestsOptions} from "@lodestar/spec-test-util/downloadTests";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: DownloadTestsOptions = {
-  specVersion: "v1.5.0",
+  specVersion: "v1.6.0-alpha.1",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-spec-tests",

--- a/packages/params/test/e2e/ensure-config-is-synced.test.ts
+++ b/packages/params/test/e2e/ensure-config-is-synced.test.ts
@@ -8,7 +8,7 @@ import {loadConfigYaml} from "../yaml.js";
 // Not e2e, but slow. Run with e2e tests
 
 /** https://github.com/ethereum/consensus-specs/releases */
-const specConfigCommit = "v1.5.0";
+const specConfigCommit = "v1.6.0-alpha.1";
 /**
  * Fields that we filter from local config when doing comparison.
  * Ideally this should be empty as it is not spec compliant

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -129,9 +129,12 @@ export class EpochCache {
    *
    * 32 x Number
    */
+  // TODO FULU: This is no longer needed since EIP-7917
   proposers: ValidatorIndex[];
 
   /** Proposers for previous epoch, initialized to null in first epoch */
+  // TODO FULU: This is no longer needed since EIP-7917. Need to find a way to deal with
+  // getProposerDuties requests with previous epoch
   proposersPrevEpoch: ValidatorIndex[] | null;
 
   /**
@@ -139,6 +142,7 @@ export class EpochCache {
    * getBeaconProposersNextEpoch because it needs state as input and all data needed by getBeaconProposersNextEpoch
    * should be in the epoch context.
    */
+  // TODO FULU: This is no longer needed since EIP-7917
   proposersNextEpoch: ProposersDeferred;
 
   /**
@@ -848,6 +852,7 @@ export class EpochCache {
    * balances are sampled to adjust the probability of the next selection (32 per epoch on average). So to invalidate
    * the prediction the effective of one of those 32 samples should change and change the random_byte inequality.
    */
+  // TODO Fulu: We can't do lazy compute anymore post EIP-7917. Since we need them to compute state.proposerLookahead
   getBeaconProposersNextEpoch(): ValidatorIndex[] {
     if (!this.proposersNextEpoch.computed) {
       const indexes = computeProposers(

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -441,7 +441,7 @@ export class EpochCache {
     const currentProposerSeed = getSeed(state, currentEpoch, DOMAIN_BEACON_PROPOSER);
 
     let proposers: number[];
-    if ((state as CachedBeaconStateFulu).proposerLookahead !== undefined) {
+    if (currentEpoch >= config.FULU_FORK_EPOCH) {
       // Overwrite proposers with state.proposerLookahead
       proposers = (state as CachedBeaconStateFulu).proposerLookahead.getAll().slice(0, SLOTS_PER_EPOCH);
     } else {
@@ -626,7 +626,6 @@ export class EpochCache {
     // epochAfterUpcoming for the same reason to help minimize confusion.
     const upcomingEpoch = this.nextEpoch;
     const epochAfterUpcoming = upcomingEpoch + 1;
-    const isForkPostFulu = (state as CachedBeaconStateFulu).proposerLookahead !== undefined;
 
     // move current to previous
     this.previousShuffling = this.currentShuffling;
@@ -651,7 +650,7 @@ export class EpochCache {
         // so should be taken into account when structuring tests.  Should not affect unit or other tests though
         computeEpochShuffling(state, this.nextActiveIndices, upcomingEpoch);
     }
-    if (isForkPostFulu) {
+    if (upcomingEpoch >= this.config.FULU_FORK_EPOCH) {
       // Populate proposer cache with lookahead from state
       const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
       this.proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -795,6 +795,8 @@ export class EpochCache {
     return (committeesSinceEpochStart + committeeIndex) % ATTESTATION_SUBNET_COUNT;
   }
 
+  // TODO FULU: Read from state.proposer_lookahead instead.
+  // See https://github.com/ethereum/consensus-specs/blob/e9266b2145c09b63ba0039a9f477cfe8a629c78b/specs/fulu/beacon-chain.md#modified-get_beacon_proposer_index
   getBeaconProposer(slot: Slot): ValidatorIndex {
     const epoch = computeEpochAtSlot(slot);
     if (epoch !== this.currentShuffling.epoch) {

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -52,7 +52,7 @@ import {sumTargetUnslashedBalanceIncrements} from "../util/targetUnslashedBalanc
 import {EffectiveBalanceIncrements, getEffectiveBalanceIncrementsWithLen} from "./effectiveBalanceIncrements.js";
 import {EpochTransitionCache} from "./epochTransitionCache.js";
 import {Index2PubkeyCache, syncPubkeys} from "./pubkeyCache.js";
-import {CachedBeaconStateAllForks} from "./stateCache.js";
+import {CachedBeaconStateAllForks, CachedBeaconStateFulu} from "./stateCache.js";
 import {
   SyncCommitteeCache,
   SyncCommitteeCacheEmpty,
@@ -440,16 +440,23 @@ export class EpochCache {
 
     const currentProposerSeed = getSeed(state, currentEpoch, DOMAIN_BEACON_PROPOSER);
 
-    // Allow to create CachedBeaconState for empty states, or no active validators
-    const proposers =
-      currentShuffling.activeIndices.length > 0
-        ? computeProposers(
-            config.getForkSeqAtEpoch(currentEpoch),
-            currentProposerSeed,
-            currentShuffling,
-            effectiveBalanceIncrements
-          )
-        : [];
+    let proposers: number[];
+    if ((state as CachedBeaconStateFulu).proposerLookahead !== undefined) {
+      // Overwrite proposers with state.proposerLookahead
+      proposers = (state as CachedBeaconStateFulu).proposerLookahead.getAll().slice(0, SLOTS_PER_EPOCH);
+    } else {
+      // We need to calculate Pre-fulu
+      // Allow to create CachedBeaconState for empty states, or no active validators
+      proposers =
+        currentShuffling.activeIndices.length > 0
+          ? computeProposers(
+              config.getForkSeqAtEpoch(currentEpoch),
+              currentProposerSeed,
+              currentShuffling,
+              effectiveBalanceIncrements
+            )
+          : [];
+    }
 
     const proposersNextEpoch: ProposersDeferred = {
       computed: false,
@@ -619,6 +626,7 @@ export class EpochCache {
     // epochAfterUpcoming for the same reason to help minimize confusion.
     const upcomingEpoch = this.nextEpoch;
     const epochAfterUpcoming = upcomingEpoch + 1;
+    const isForkPostFulu = (state as CachedBeaconStateFulu).proposerLookahead !== undefined;
 
     // move current to previous
     this.previousShuffling = this.currentShuffling;
@@ -643,14 +651,34 @@ export class EpochCache {
         // so should be taken into account when structuring tests.  Should not affect unit or other tests though
         computeEpochShuffling(state, this.nextActiveIndices, upcomingEpoch);
     }
-    const upcomingProposerSeed = getSeed(state, upcomingEpoch, DOMAIN_BEACON_PROPOSER);
-    // next epoch was moved to current epoch so use current here
-    this.proposers = computeProposers(
-      this.config.getForkSeqAtEpoch(upcomingEpoch),
-      upcomingProposerSeed,
-      this.currentShuffling,
-      this.effectiveBalanceIncrements
-    );
+    if (isForkPostFulu) {
+      // Populate proposer cache with lookahead from state
+      const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
+      this.proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);
+
+      if (proposerLookahead.length >= SLOTS_PER_EPOCH * 2) {
+        this.proposersNextEpoch = {
+          computed: true,
+          indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
+        };
+      } else {
+        // This should not happen unless MIN_SEED_LOOKAHEAD is set to 0
+        // this ensures things don't break if the proposer lookahead is not long enough
+        this.proposersNextEpoch = {computed: false, seed: getSeed(state, epochAfterUpcoming, DOMAIN_BEACON_PROPOSER)};
+      }
+    } else {
+      // Need to calculate proposers pre-fulu
+      const upcomingProposerSeed = getSeed(state, upcomingEpoch, DOMAIN_BEACON_PROPOSER);
+      // next epoch was moved to current epoch so use current here
+      this.proposers = computeProposers(
+        this.config.getForkSeqAtEpoch(upcomingEpoch),
+        upcomingProposerSeed,
+        this.currentShuffling,
+        this.effectiveBalanceIncrements
+      );
+      // Only pre-compute the seed since it's very cheap. Do the expensive computeProposers() call only on demand.
+      this.proposersNextEpoch = {computed: false, seed: getSeed(state, epochAfterUpcoming, DOMAIN_BEACON_PROPOSER)};
+    }
 
     // handle next values
     this.nextDecisionRoot = epochTransitionCache.nextShufflingDecisionRoot;
@@ -689,9 +717,6 @@ export class EpochCache {
       // Only for testing. shufflingCache should always be available in prod
       this.nextShuffling = computeEpochShuffling(state, this.nextActiveIndices, epochAfterUpcoming);
     }
-
-    // Only pre-compute the seed since it's very cheap. Do the expensive computeProposers() call only on demand.
-    this.proposersNextEpoch = {computed: false, seed: getSeed(state, epochAfterUpcoming, DOMAIN_BEACON_PROPOSER)};
 
     // TODO: DEDUPLICATE from createEpochCache
     //

--- a/packages/state-transition/src/epoch/index.ts
+++ b/packages/state-transition/src/epoch/index.ts
@@ -187,6 +187,7 @@ export function processEpoch(
       timer?.();
     }
   }
+
   if (fork >= ForkSeq.fulu) {
     processProposerLookahead(fork, state as CachedBeaconStateFulu);
   }

--- a/packages/state-transition/src/epoch/index.ts
+++ b/packages/state-transition/src/epoch/index.ts
@@ -11,6 +11,7 @@ import {
   CachedBeaconStateAltair,
   CachedBeaconStateCapella,
   CachedBeaconStateElectra,
+  CachedBeaconStateFulu,
   CachedBeaconStatePhase0,
   EpochTransitionCache,
 } from "../types.js";
@@ -186,5 +187,7 @@ export function processEpoch(
       timer?.();
     }
   }
-  // TODO FULU: Add processProposerLookahead here
+  if (fork >= ForkSeq.fulu) {
+    processProposerLookahead(fork, state as CachedBeaconStateFulu);
+  }
 }

--- a/packages/state-transition/src/epoch/index.ts
+++ b/packages/state-transition/src/epoch/index.ts
@@ -25,13 +25,13 @@ import {processParticipationFlagUpdates} from "./processParticipationFlagUpdates
 import {processParticipationRecordUpdates} from "./processParticipationRecordUpdates.js";
 import {processPendingConsolidations} from "./processPendingConsolidations.js";
 import {processPendingDeposits} from "./processPendingDeposits.js";
+import {processProposerLookahead} from "./processProposerLookahead.js";
 import {processRandaoMixesReset} from "./processRandaoMixesReset.js";
 import {processRegistryUpdates} from "./processRegistryUpdates.js";
 import {processRewardsAndPenalties} from "./processRewardsAndPenalties.js";
 import {processSlashings} from "./processSlashings.js";
 import {processSlashingsReset} from "./processSlashingsReset.js";
 import {processSyncCommitteeUpdates} from "./processSyncCommitteeUpdates.js";
-import {processProposerLookahead} from "./processProposerLookahead.js";
 
 // For spec tests
 export {getRewardsAndPenalties} from "./processRewardsAndPenalties.js";

--- a/packages/state-transition/src/epoch/index.ts
+++ b/packages/state-transition/src/epoch/index.ts
@@ -30,6 +30,7 @@ import {processRewardsAndPenalties} from "./processRewardsAndPenalties.js";
 import {processSlashings} from "./processSlashings.js";
 import {processSlashingsReset} from "./processSlashingsReset.js";
 import {processSyncCommitteeUpdates} from "./processSyncCommitteeUpdates.js";
+import {processProposerLookahead} from "./processProposerLookahead.js";
 
 // For spec tests
 export {getRewardsAndPenalties} from "./processRewardsAndPenalties.js";
@@ -50,6 +51,7 @@ export {
   processHistoricalSummariesUpdate,
   processPendingDeposits,
   processPendingConsolidations,
+  processProposerLookahead,
 };
 
 export {computeUnrealizedCheckpoints} from "./computeUnrealizedCheckpoints.js";
@@ -72,6 +74,7 @@ export enum EpochTransitionStep {
   processSyncCommitteeUpdates = "processSyncCommitteeUpdates",
   processPendingDeposits = "processPendingDeposits",
   processPendingConsolidations = "processPendingConsolidations",
+  processProposerLookahead = "processProposerLookahead",
 }
 
 export function processEpoch(
@@ -183,4 +186,5 @@ export function processEpoch(
       timer?.();
     }
   }
+  // TODO FULU: Add processProposerLookahead here
 }

--- a/packages/state-transition/src/epoch/processProposerLookahead.ts
+++ b/packages/state-transition/src/epoch/processProposerLookahead.ts
@@ -6,8 +6,8 @@ import {computeProposerIndices} from "../util/seed.js";
 /**
  * This function updates the `proposer_lookahead` field in the beacon state
  * by shifting out proposer indices from the earliest epoch and appending new
- * proposer indices for the latest epoch. With `MIN_SEED_LOOKAHEAD` set to `1`, 
- * this means that at the start of epoch `N`, the proposer lookahead for epoch 
+ * proposer indices for the latest epoch. With `MIN_SEED_LOOKAHEAD` set to `1`,
+ * this means that at the start of epoch `N`, the proposer lookahead for epoch
  * `N+1` will be computed and included in the beacon state's lookahead.
  */
 export function processProposerLookahead(fork: ForkSeq, state: CachedBeaconStateFulu): void {
@@ -17,6 +17,8 @@ export function processProposerLookahead(fork: ForkSeq, state: CachedBeaconState
   // Fill in the last epoch with new proposer indices
   const lastEpochProposerLookahead = computeProposerIndices(fork, state, state.epochCtx.epoch + MIN_SEED_LOOKAHEAD + 1);
 
-  state.proposerLookahead = ssz.fulu.ProposerLookahead.toViewDU([...remainingProposerLookahead, ...lastEpochProposerLookahead]);
-
+  state.proposerLookahead = ssz.fulu.ProposerLookahead.toViewDU([
+    ...remainingProposerLookahead,
+    ...lastEpochProposerLookahead,
+  ]);
 }

--- a/packages/state-transition/src/epoch/processProposerLookahead.ts
+++ b/packages/state-transition/src/epoch/processProposerLookahead.ts
@@ -1,0 +1,15 @@
+import {aggregateSerializedPublicKeys} from "@chainsafe/blst";
+import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, ForkSeq} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
+import {CachedBeaconStateAltair} from "../types.js";
+import {getNextSyncCommitteeIndices} from "../util/seed.js";
+
+/**
+ * Rotate nextSyncCommittee to currentSyncCommittee if sync committee period is over.
+ *
+ * PERF: Once every `EPOCHS_PER_SYNC_COMMITTEE_PERIOD`, do an expensive operation to compute the next committee.
+ * Calculating the next sync committee has a proportional cost to $VALIDATOR_COUNT
+ */
+// TODO Fulu: Implement this
+export function processProposerLookahead(fork: ForkSeq, state: CachedBeaconStateAltair): void {
+}

--- a/packages/state-transition/src/epoch/processProposerLookahead.ts
+++ b/packages/state-transition/src/epoch/processProposerLookahead.ts
@@ -1,15 +1,22 @@
-import {aggregateSerializedPublicKeys} from "@chainsafe/blst";
-import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, ForkSeq} from "@lodestar/params";
+import {ForkSeq, MIN_SEED_LOOKAHEAD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
-import {CachedBeaconStateAltair} from "../types.js";
-import {getNextSyncCommitteeIndices} from "../util/seed.js";
+import {CachedBeaconStateFulu} from "../types.js";
+import {computeProposerIndices} from "../util/seed.js";
 
 /**
- * Rotate nextSyncCommittee to currentSyncCommittee if sync committee period is over.
- *
- * PERF: Once every `EPOCHS_PER_SYNC_COMMITTEE_PERIOD`, do an expensive operation to compute the next committee.
- * Calculating the next sync committee has a proportional cost to $VALIDATOR_COUNT
+ * This function updates the `proposer_lookahead` field in the beacon state
+ * by shifting out proposer indices from the earliest epoch and appending new
+ * proposer indices for the latest epoch. With `MIN_SEED_LOOKAHEAD` set to `1`, 
+ * this means that at the start of epoch `N`, the proposer lookahead for epoch 
+ * `N+1` will be computed and included in the beacon state's lookahead.
  */
-// TODO Fulu: Implement this
-export function processProposerLookahead(fork: ForkSeq, state: CachedBeaconStateAltair): void {
+export function processProposerLookahead(fork: ForkSeq, state: CachedBeaconStateFulu): void {
+  // Shift out proposers in the first epoch
+  const remainingProposerLookahead = state.proposerLookahead.getAll().slice(SLOTS_PER_EPOCH);
+
+  // Fill in the last epoch with new proposer indices
+  const lastEpochProposerLookahead = computeProposerIndices(fork, state, state.epochCtx.epoch + MIN_SEED_LOOKAHEAD + 1);
+
+  state.proposerLookahead = ssz.fulu.ProposerLookahead.toViewDU([...remainingProposerLookahead, ...lastEpochProposerLookahead]);
+
 }

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -12,6 +12,7 @@ export type {
   CachedBeaconStateCapella,
   CachedBeaconStateDeneb,
   CachedBeaconStateElectra,
+  CachedBeaconStateFulu,
   CachedBeaconStateAllForks,
   CachedBeaconStateExecutions,
   // Non-cached states
@@ -21,6 +22,7 @@ export type {
   BeaconStateCapella,
   BeaconStateDeneb,
   BeaconStateElectra,
+  BeaconStateFulu,
   BeaconStateAllForks,
   BeaconStateExecutions,
 } from "./types.js";

--- a/packages/state-transition/src/slot/upgradeStateToFulu.ts
+++ b/packages/state-transition/src/slot/upgradeStateToFulu.ts
@@ -1,6 +1,7 @@
 import {ssz} from "@lodestar/types";
 import {getCachedBeaconState} from "../cache/stateCache.js";
 import {CachedBeaconStateElectra, CachedBeaconStateFulu} from "../types.js";
+import { initializeProposerLookahead } from "../util/fulu.js";
 
 /**
  * Upgrade a state from Electra to Fulu.
@@ -18,7 +19,8 @@ export function upgradeStateToFulu(stateElectra: CachedBeaconStateElectra): Cach
     currentVersion: config.FULU_FORK_VERSION,
     epoch: stateElectra.epochCtx.epoch,
   });
-  // TODO FULU: Populate proposer_lookahead here
+
+  stateFulu.proposerLookahead = ssz.fulu.ProposerLookahead.toViewDU(initializeProposerLookahead(stateElectra));
 
   stateFulu.commit();
   // Clear cache to ensure the cache of capella fields is not used by new deneb fields

--- a/packages/state-transition/src/slot/upgradeStateToFulu.ts
+++ b/packages/state-transition/src/slot/upgradeStateToFulu.ts
@@ -18,6 +18,7 @@ export function upgradeStateToFulu(stateElectra: CachedBeaconStateElectra): Cach
     currentVersion: config.FULU_FORK_VERSION,
     epoch: stateElectra.epochCtx.epoch,
   });
+  // TODO FULU: Populate proposer_lookahead here
 
   stateFulu.commit();
   // Clear cache to ensure the cache of capella fields is not used by new deneb fields

--- a/packages/state-transition/src/slot/upgradeStateToFulu.ts
+++ b/packages/state-transition/src/slot/upgradeStateToFulu.ts
@@ -1,7 +1,7 @@
 import {ssz} from "@lodestar/types";
 import {getCachedBeaconState} from "../cache/stateCache.js";
 import {CachedBeaconStateElectra, CachedBeaconStateFulu} from "../types.js";
-import { initializeProposerLookahead } from "../util/fulu.js";
+import {initializeProposerLookahead} from "../util/fulu.js";
 
 /**
  * Upgrade a state from Electra to Fulu.

--- a/packages/state-transition/src/util/fulu.ts
+++ b/packages/state-transition/src/util/fulu.ts
@@ -1,21 +1,19 @@
 import {ForkSeq, MIN_SEED_LOOKAHEAD} from "@lodestar/params";
 import {ValidatorIndex} from "@lodestar/types";
 import {CachedBeaconStateElectra} from "../types.js";
-import { computeProposerIndices } from "./seed.js";
-
+import {computeProposerIndices} from "./seed.js";
 
 /**
  * Return the proposer indices for the full available lookahead starting from current epoch.
  * Used to initialize the ``proposer_lookahead`` field in the beacon state at genesis and after forks.
  */
 export function initializeProposerLookahead(state: CachedBeaconStateElectra): ValidatorIndex[] {
-
   const currentEpoch = state.epochCtx.epoch;
 
   let lookahead: ValidatorIndex[] = [];
 
   for (let i = 0; i < MIN_SEED_LOOKAHEAD + 1; i++) {
-    lookahead = [...lookahead, ...computeProposerIndices(ForkSeq.fulu, state, currentEpoch + i)]
+    lookahead = [...lookahead, ...computeProposerIndices(ForkSeq.fulu, state, currentEpoch + i)];
   }
 
   return lookahead;

--- a/packages/state-transition/src/util/fulu.ts
+++ b/packages/state-transition/src/util/fulu.ts
@@ -5,15 +5,15 @@ import {computeProposerIndices} from "./seed.js";
 
 /**
  * Return the proposer indices for the full available lookahead starting from current epoch.
- * Used to initialize the ``proposer_lookahead`` field in the beacon state at genesis and after forks.
+ * Used to initialize the `proposer_lookahead` field in the beacon state at genesis and after forks.
  */
 export function initializeProposerLookahead(state: CachedBeaconStateElectra): ValidatorIndex[] {
   const currentEpoch = state.epochCtx.epoch;
 
-  let lookahead: ValidatorIndex[] = [];
+  const lookahead: ValidatorIndex[] = [];
 
   for (let i = 0; i < MIN_SEED_LOOKAHEAD + 1; i++) {
-    lookahead = [...lookahead, ...computeProposerIndices(ForkSeq.fulu, state, currentEpoch + i)];
+    lookahead.push(...computeProposerIndices(ForkSeq.fulu, state, currentEpoch + i));
   }
 
   return lookahead;

--- a/packages/state-transition/src/util/fulu.ts
+++ b/packages/state-transition/src/util/fulu.ts
@@ -1,0 +1,11 @@
+import {COMPOUNDING_WITHDRAWAL_PREFIX, GENESIS_SLOT, MIN_ACTIVATION_BALANCE} from "@lodestar/params";
+import {ValidatorIndex, ssz} from "@lodestar/types";
+import {G2_POINT_AT_INFINITY} from "../constants/constants.js";
+import {CachedBeaconStateElectra, CachedBeaconStateFulu} from "../types.js";
+import {hasEth1WithdrawalCredential} from "./capella.js";
+
+
+// TODO FULU: Impelment this
+export function initializeProposerLookahead(state: CachedBeaconStateFulu): void {
+
+}

--- a/packages/state-transition/src/util/fulu.ts
+++ b/packages/state-transition/src/util/fulu.ts
@@ -1,11 +1,22 @@
-import {COMPOUNDING_WITHDRAWAL_PREFIX, GENESIS_SLOT, MIN_ACTIVATION_BALANCE} from "@lodestar/params";
-import {ValidatorIndex, ssz} from "@lodestar/types";
-import {G2_POINT_AT_INFINITY} from "../constants/constants.js";
-import {CachedBeaconStateElectra, CachedBeaconStateFulu} from "../types.js";
-import {hasEth1WithdrawalCredential} from "./capella.js";
+import {ForkSeq, MIN_SEED_LOOKAHEAD} from "@lodestar/params";
+import {ValidatorIndex} from "@lodestar/types";
+import {CachedBeaconStateElectra} from "../types.js";
+import { computeProposerIndices } from "./seed.js";
 
 
-// TODO FULU: Impelment this
-export function initializeProposerLookahead(state: CachedBeaconStateFulu): void {
+/**
+ * Return the proposer indices for the full available lookahead starting from current epoch.
+ * Used to initialize the ``proposer_lookahead`` field in the beacon state at genesis and after forks.
+ */
+export function initializeProposerLookahead(state: CachedBeaconStateElectra): ValidatorIndex[] {
 
+  const currentEpoch = state.epochCtx.epoch;
+
+  let lookahead: ValidatorIndex[] = [];
+
+  for (let i = 0; i < MIN_SEED_LOOKAHEAD + 1; i++) {
+    lookahead = [...lookahead, ...computeProposerIndices(ForkSeq.fulu, state, currentEpoch + i)]
+  }
+
+  return lookahead;
 }

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -4,6 +4,7 @@ import {
   computeSyncCommitteeIndices as nativeComputeSyncCommitteeIndices,
 } from "@chainsafe/swap-or-not-shuffle";
 import {
+  DOMAIN_BEACON_PROPOSER,
   DOMAIN_SYNC_COMMITTEE,
   EFFECTIVE_BALANCE_INCREMENT,
   EPOCHS_PER_HISTORICAL_VECTOR,
@@ -18,14 +19,13 @@ import {
 import {Bytes32, DomainType, Epoch, ValidatorIndex} from "@lodestar/types";
 import {assert, bytesToBigInt, bytesToInt, intToBytes} from "@lodestar/utils";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";
-import {BeaconStateAllForks} from "../types.js";
+import {BeaconStateAllForks, CachedBeaconStateAllForks} from "../types.js";
 import {computeStartSlotAtEpoch} from "./epoch.js";
 import {computeEpochAtSlot} from "./epoch.js";
 
 /**
  * Compute proposer indices for an epoch
  */
-// TODO fulu: Updated this
 export function computeProposers(
   fork: ForkSeq,
   epochSeed: Uint8Array,
@@ -134,6 +134,29 @@ export function computeProposerIndex(
     EFFECTIVE_BALANCE_INCREMENT,
     SHUFFLE_ROUND_COUNT
   );
+}
+
+/**
+ * Return the proposer indices for the given ``epoch``.
+ * A more generic version of `computeProposers`
+ */
+export function computeProposerIndices(fork: ForkSeq, state: CachedBeaconStateAllForks, epoch: Epoch): ValidatorIndex[] {
+  const startSlot = computeStartSlotAtEpoch(epoch);
+  const proposers = [];
+  const epochSeed = getSeed(state, epoch, DOMAIN_BEACON_PROPOSER); 
+  const shuffling = state.epochCtx.getShufflingAtEpoch(epoch);
+
+  for (let slot = startSlot; slot < startSlot + SLOTS_PER_EPOCH; slot++) {
+    proposers.push(
+      computeProposerIndex(
+        fork,
+        state.epochCtx.effectiveBalanceIncrements,
+        shuffling.activeIndices,
+        digest(Buffer.concat([epochSeed, intToBytes(slot, 8)]))
+      )
+    );
+  }
+  return proposers;
 }
 
 /**

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -22,8 +22,8 @@ import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "../types.js";
 import {computeStartSlotAtEpoch} from "./epoch.js";
 import {computeEpochAtSlot} from "./epoch.js";
-import { computeEpochShuffling, EpochShuffling } from "./epochShuffling.js";
-import { getActiveValidatorIndices } from "./validator.js";
+import {EpochShuffling, computeEpochShuffling} from "./epochShuffling.js";
+import {getActiveValidatorIndices} from "./validator.js";
 
 /**
  * Compute proposer indices for an epoch
@@ -150,13 +150,17 @@ export function computeProposerIndices(
   const startSlot = computeStartSlotAtEpoch(epoch);
   const proposers = [];
   const epochSeed = getSeed(state, epoch, DOMAIN_BEACON_PROPOSER);
-  // TODO FULU: Compute shuffling if shuffling cache miss is a temporary workaround. 
+  // TODO FULU: Compute shuffling if shuffling cache miss is a temporary workaround.
   // EpochCache needs to cache shuffling for nextEpoch + 1 too.
   let shuffling: EpochShuffling;
   try {
     shuffling = state.epochCtx.getShufflingAtEpoch(epoch);
   } catch (e) {
-    state.epochCtx.shufflingCache?.logger?.verbose(`Shuffling cache miss for epoch ${epoch}. Current epoch ${state.epochCtx.epoch}, computing shuffling...`, {}, e as Error);
+    state.epochCtx.shufflingCache?.logger?.verbose(
+      `Shuffling cache miss for epoch ${epoch}. Current epoch ${state.epochCtx.epoch}, computing shuffling...`,
+      {},
+      e as Error
+    );
     state.commit();
     shuffling = computeEpochShuffling(state, getActiveValidatorIndices(state, epoch), epoch);
   }

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -140,10 +140,14 @@ export function computeProposerIndex(
  * Return the proposer indices for the given ``epoch``.
  * A more generic version of `computeProposers`
  */
-export function computeProposerIndices(fork: ForkSeq, state: CachedBeaconStateAllForks, epoch: Epoch): ValidatorIndex[] {
+export function computeProposerIndices(
+  fork: ForkSeq,
+  state: CachedBeaconStateAllForks,
+  epoch: Epoch
+): ValidatorIndex[] {
   const startSlot = computeStartSlotAtEpoch(epoch);
   const proposers = [];
-  const epochSeed = getSeed(state, epoch, DOMAIN_BEACON_PROPOSER); 
+  const epochSeed = getSeed(state, epoch, DOMAIN_BEACON_PROPOSER);
   const shuffling = state.epochCtx.getShufflingAtEpoch(epoch);
 
   for (let slot = startSlot; slot < startSlot + SLOTS_PER_EPOCH; slot++) {

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -22,7 +22,7 @@ import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "../types.js";
 import {computeStartSlotAtEpoch} from "./epoch.js";
 import {computeEpochAtSlot} from "./epoch.js";
-import { computeEpochShuffling } from "./epochShuffling.js";
+import { computeEpochShuffling, EpochShuffling } from "./epochShuffling.js";
 import { getActiveValidatorIndices } from "./validator.js";
 
 /**
@@ -152,7 +152,14 @@ export function computeProposerIndices(
   const epochSeed = getSeed(state, epoch, DOMAIN_BEACON_PROPOSER);
   // TODO FULU: Compute shuffling if shuffling cache miss is a temporary workaround. 
   // EpochCache needs to cache shuffling for nextEpoch + 1 too.
-  const shuffling = state.epochCtx.getShufflingAtEpoch(epoch) ?? computeEpochShuffling(state, getActiveValidatorIndices(state, epoch), epoch);
+  let shuffling: EpochShuffling;
+  try {
+    shuffling = state.epochCtx.getShufflingAtEpoch(epoch);
+  } catch (e) {
+    state.epochCtx.shufflingCache?.logger?.verbose(`Shuffling cache miss for epoch ${epoch}. Current epoch ${state.epochCtx.epoch}, computing shuffling...`, {}, e as Error);
+    state.commit();
+    shuffling = computeEpochShuffling(state, getActiveValidatorIndices(state, epoch), epoch);
+  }
 
   for (let slot = startSlot; slot < startSlot + SLOTS_PER_EPOCH; slot++) {
     proposers.push(

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -139,7 +139,7 @@ export function computeProposerIndex(
 }
 
 /**
- * Return the proposer indices for the given ``epoch``.
+ * Return the proposer indices for the given `epoch`.
  * A more generic version of `computeProposers`
  */
 export function computeProposerIndices(

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -22,6 +22,8 @@ import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "../types.js";
 import {computeStartSlotAtEpoch} from "./epoch.js";
 import {computeEpochAtSlot} from "./epoch.js";
+import { computeEpochShuffling } from "./epochShuffling.js";
+import { getActiveValidatorIndices } from "./validator.js";
 
 /**
  * Compute proposer indices for an epoch
@@ -148,7 +150,9 @@ export function computeProposerIndices(
   const startSlot = computeStartSlotAtEpoch(epoch);
   const proposers = [];
   const epochSeed = getSeed(state, epoch, DOMAIN_BEACON_PROPOSER);
-  const shuffling = state.epochCtx.getShufflingAtEpoch(epoch);
+  // TODO FULU: Compute shuffling if shuffling cache miss is a temporary workaround. 
+  // EpochCache needs to cache shuffling for nextEpoch + 1 too.
+  const shuffling = state.epochCtx.getShufflingAtEpoch(epoch) ?? computeEpochShuffling(state, getActiveValidatorIndices(state, epoch), epoch);
 
   for (let slot = startSlot; slot < startSlot + SLOTS_PER_EPOCH; slot++) {
     proposers.push(

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -25,6 +25,7 @@ import {computeEpochAtSlot} from "./epoch.js";
 /**
  * Compute proposer indices for an epoch
  */
+// TODO fulu: Updated this
 export function computeProposers(
   fork: ForkSeq,
   epochSeed: Uint8Array,

--- a/packages/types/src/fulu/sszTypes.ts
+++ b/packages/types/src/fulu/sszTypes.ts
@@ -86,7 +86,10 @@ export const DataColumnSidecarsByRangeRequest = new ContainerType(
   {typeName: "DataColumnSidecarsByRangeRequest", jsonCase: "eth2"}
 );
 
-export const BeaconState = new ContainerType({
-  ...electraSsz.BeaconState.fields,
-  proposerLookahead: ProposerLookahead, // New in FULU:EIP7917
-});
+export const BeaconState = new ContainerType(
+  {
+    ...electraSsz.BeaconState.fields,
+    proposerLookahead: ProposerLookahead, // New in FULU:EIP7917
+  },
+  {typeName: "BeaconState", jsonCase: "eth2"}
+);

--- a/packages/types/src/fulu/sszTypes.ts
+++ b/packages/types/src/fulu/sszTypes.ts
@@ -22,9 +22,8 @@ import {ssz as denebSsz} from "../deneb/index.js";
 import {ssz as electraSsz} from "../electra/index.js";
 import {ssz as phase0Ssz} from "../phase0/index.js";
 import {ssz as primitiveSsz} from "../primitive/index.js";
-import {ValidatorIndex} from "../sszTypes.js";
 
-const {Root, ColumnIndex, RowIndex, Bytes32, Slot, UintNum64} = primitiveSsz;
+const {Root, ColumnIndex, RowIndex, Bytes32, Slot, UintNum64, ValidatorIndex} = primitiveSsz;
 
 export const Metadata = new ContainerType(
   {

--- a/packages/types/src/fulu/sszTypes.ts
+++ b/packages/types/src/fulu/sszTypes.ts
@@ -1,4 +1,11 @@
-import {ByteVectorType, ContainerType, ListBasicType, ListCompositeType, VectorBasicType, VectorCompositeType} from "@chainsafe/ssz";
+import {
+  ByteVectorType,
+  ContainerType,
+  ListBasicType,
+  ListCompositeType,
+  VectorBasicType,
+  VectorCompositeType,
+} from "@chainsafe/ssz";
 import {
   BYTES_PER_FIELD_ELEMENT,
   FIELD_ELEMENTS_PER_CELL,
@@ -15,7 +22,7 @@ import {ssz as denebSsz} from "../deneb/index.js";
 import {ssz as electraSsz} from "../electra/index.js";
 import {ssz as phase0Ssz} from "../phase0/index.js";
 import {ssz as primitiveSsz} from "../primitive/index.js";
-import { ValidatorIndex } from "../sszTypes.js";
+import {ValidatorIndex} from "../sszTypes.js";
 
 const {Root, ColumnIndex, RowIndex, Bytes32, Slot, UintNum64} = primitiveSsz;
 
@@ -79,9 +86,7 @@ export const DataColumnSidecarsByRangeRequest = new ContainerType(
   {typeName: "DataColumnSidecarsByRangeRequest", jsonCase: "eth2"}
 );
 
-export const BeaconState = new ContainerType (
-  {
-    ...electraSsz.BeaconState.fields,
-    proposerLookahead: ProposerLookahead // New in FULU:EIP7917
-  }
-)
+export const BeaconState = new ContainerType({
+  ...electraSsz.BeaconState.fields,
+  proposerLookahead: ProposerLookahead, // New in FULU:EIP7917
+});

--- a/packages/types/src/fulu/sszTypes.ts
+++ b/packages/types/src/fulu/sszTypes.ts
@@ -31,6 +31,7 @@ export const Cell = new ByteVectorType(BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_
 export const DataColumn = new ListCompositeType(Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK);
 export const ExtendedMatrix = new ListCompositeType(Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK * NUMBER_OF_COLUMNS);
 export const KzgCommitmentsInclusionProof = new VectorCompositeType(Bytes32, KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH);
+export const ProposerLookahead = new VectorBasicType(ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH);
 
 export const DataColumnSidecar = new ContainerType(
   {
@@ -81,6 +82,6 @@ export const DataColumnSidecarsByRangeRequest = new ContainerType(
 export const BeaconState = new ContainerType (
   {
     ...electraSsz.BeaconState.fields,
-    proposerLookahead: new VectorBasicType(ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH) // New in FULU:EIP7917
+    proposerLookahead: ProposerLookahead // New in FULU:EIP7917
   }
 )

--- a/packages/types/src/fulu/sszTypes.ts
+++ b/packages/types/src/fulu/sszTypes.ts
@@ -5,13 +5,17 @@ import {
   KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH,
   MAX_BLOB_COMMITMENTS_PER_BLOCK,
   MAX_REQUEST_DATA_COLUMN_SIDECARS,
+  MIN_SEED_LOOKAHEAD,
   NUMBER_OF_COLUMNS,
+  SLOTS_PER_EPOCH,
 } from "@lodestar/params";
 
 import {ssz as altairSsz} from "../altair/index.js";
 import {ssz as denebSsz} from "../deneb/index.js";
+import {ssz as electraSsz} from "../electra/index.js";
 import {ssz as phase0Ssz} from "../phase0/index.js";
 import {ssz as primitiveSsz} from "../primitive/index.js";
+import { ValidatorIndex } from "../sszTypes.js";
 
 const {Root, ColumnIndex, RowIndex, Bytes32, Slot, UintNum64} = primitiveSsz;
 
@@ -73,3 +77,10 @@ export const DataColumnSidecarsByRangeRequest = new ContainerType(
   },
   {typeName: "DataColumnSidecarsByRangeRequest", jsonCase: "eth2"}
 );
+
+export const BeaconState = new ContainerType (
+  {
+    ...electraSsz.BeaconState.fields,
+    proposerLookahead: new ListBasicType(ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH) // New in FULU:EIP7917
+  }
+)

--- a/packages/types/src/fulu/sszTypes.ts
+++ b/packages/types/src/fulu/sszTypes.ts
@@ -1,4 +1,4 @@
-import {ByteVectorType, ContainerType, ListBasicType, ListCompositeType, VectorCompositeType} from "@chainsafe/ssz";
+import {ByteVectorType, ContainerType, ListBasicType, ListCompositeType, VectorBasicType, VectorCompositeType} from "@chainsafe/ssz";
 import {
   BYTES_PER_FIELD_ELEMENT,
   FIELD_ELEMENTS_PER_CELL,
@@ -81,6 +81,6 @@ export const DataColumnSidecarsByRangeRequest = new ContainerType(
 export const BeaconState = new ContainerType (
   {
     ...electraSsz.BeaconState.fields,
-    proposerLookahead: new ListBasicType(ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH) // New in FULU:EIP7917
+    proposerLookahead: new VectorBasicType(ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH) // New in FULU:EIP7917
   }
 )

--- a/packages/types/src/fulu/types.ts
+++ b/packages/types/src/fulu/types.ts
@@ -14,3 +14,5 @@ export type MatrixEntry = ValueOf<typeof ssz.MatrixEntry>;
 export type DataColumnIdentifier = ValueOf<typeof ssz.DataColumnIdentifier>;
 export type DataColumnSidecarsByRootRequest = ValueOf<typeof ssz.DataColumnSidecarsByRootRequest>;
 export type DataColumnSidecarsByRangeRequest = ValueOf<typeof ssz.DataColumnSidecarsByRangeRequest>;
+
+export type ProposerLookahead = ValueOf<typeof ssz.ProposerLookahead>;

--- a/packages/types/src/fulu/types.ts
+++ b/packages/types/src/fulu/types.ts
@@ -15,4 +15,5 @@ export type DataColumnIdentifier = ValueOf<typeof ssz.DataColumnIdentifier>;
 export type DataColumnSidecarsByRootRequest = ValueOf<typeof ssz.DataColumnSidecarsByRootRequest>;
 export type DataColumnSidecarsByRangeRequest = ValueOf<typeof ssz.DataColumnSidecarsByRangeRequest>;
 
+export type BeaconState = ValueOf<typeof ssz.BeaconState>;
 export type ProposerLookahead = ValueOf<typeof ssz.ProposerLookahead>;

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -234,7 +234,7 @@ type TypesByFork = {
     SignedBeaconBlockHeader: phase0.SignedBeaconBlockHeader;
     BeaconBlock: electra.BeaconBlock;
     BeaconBlockBody: electra.BeaconBlockBody;
-    BeaconState: electra.BeaconState;
+    BeaconState: fulu.BeaconState;
     SignedBeaconBlock: electra.SignedBeaconBlock;
     Metadata: fulu.Metadata;
     LightClientHeader: deneb.LightClientHeader;


### PR DESCRIPTION
This is the first implementation of EIP-7917. 

We will want to have a plan deprecate proposer caches in `EpochCache` since Fulu beacon state will carry those information. This will be addressed in a later PR. 

Pending spec release for spec test

Spec PR ethereum/consensus-specs#4190