### PR TITLE
chore: remove stale comment about default max blobs limit

### DIFF
--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -162,7 +162,6 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
         }
       }
 
-      // Only for testing. Should never reach this line on a public network.
       return config.MAX_BLOBS_PER_BLOCK_ELECTRA;
     },
     getMaxRequestBlobSidecars(fork: ForkName): number {


### PR DESCRIPTION
**Motivation**

We are no longer backporting the blob schedule to deneb/electra which means once we reach fulu we will default to `MAX_BLOBS_PER_BLOCK_ELECTRA` if there is no blob schedule entry for the fulu fork epoch which is very likely as we wanna bump blobs a bit later, hence the comment that default / fallback is only used during testing is no longer true.

**Description**

Remove stale comment about default max blobs limit

