### PR TITLE
feat: validate data column sidecar in batch

### DIFF
--- a/packages/beacon-node/src/chain/regen/interface.ts
+++ b/packages/beacon-node/src/chain/regen/interface.ts
@@ -10,6 +10,7 @@ export enum RegenCaller {
   produceBlock = "produceBlock",
   validateGossipBlock = "validateGossipBlock",
   validateGossipBlob = "validateGossipBlob",
+  validateGossipDataColumn = "validateGossipDataColumn",
   precomputeEpoch = "precomputeEpoch",
   predictProposerHead = "predictProposerHead",
   produceAttestationData = "produceAttestationData",

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -11,55 +11,105 @@ import {computeStartSlotAtEpoch, getBlockHeaderProposerSignatureSet} from "@lode
 import {Metrics} from "../../metrics/metrics.js";
 import {byteArrayEquals} from "../../util/bytes.js";
 import {kzg} from "../../util/kzg.js";
+import {Result} from "../../util/wrapError.js";
 import {DataColumnSidecarErrorCode, DataColumnSidecarGossipError} from "../errors/dataColumnSidecarError.js";
 import {GossipAction} from "../errors/gossipValidation.js";
 import {IBeaconChain} from "../interface.js";
 import {RegenCaller} from "../regen/interface.js";
 
-// SPEC FUNCTION
+export type GossipDataColumnSidecar = {
+  sidecar: fulu.DataColumnSidecar;
+  subnet: SubnetID;
+};
+
+export enum VerificationDataColumnBatchSource {
+  Gossip = "gossip",
+  VerifyBlock = "verify_block",
+}
+
+// The spec function to verify an individual DataColumnSidecar
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/p2p-interface.md#data_column_sidecar_subnet_id
-export async function validateGossipDataColumnSidecar(
+// here we do it in batch to:
+// - efficiently verify proofs
+// - verify inclusion proof once
+// - verify signatures once
+export async function validateGossipDataColumnSidecarSameBlock(
   chain: IBeaconChain,
-  dataColumnSidecar: fulu.DataColumnSidecar,
-  gossipSubnet: SubnetID,
-  metrics: Metrics | null
-): Promise<void> {
-  const blockHeader = dataColumnSidecar.signedBlockHeader.message;
+  sidecars: GossipDataColumnSidecar[]
+): Promise<Result<void>[]> {
+  // there is always at least one sidecar as checked in gossip handler
+  const results: Result<void>[] = new Array<Result<void>>(sidecars.length);
 
-  // 1) [REJECT] The sidecar is valid as verified by verify_data_column_sidecar
-  verifyDataColumnSidecar(dataColumnSidecar);
+  // all sidecars are from the same block thanks to the IndexedGossipQueueMinSize
+  const signedBlockHeader = sidecars[0].sidecar.signedBlockHeader;
+  const blockHeader = signedBlockHeader.message;
+  const sidecarSlot = blockHeader.slot;
+  const clockSlot = chain.clock.currentSlot;
 
-  // 2) [REJECT] The sidecar is for the correct subnet -- i.e. compute_subnet_for_data_column_sidecar(sidecar.index) == subnet_id
-  if (computeSubnetForDataColumnSidecar(dataColumnSidecar) !== gossipSubnet) {
-    throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
-      code: DataColumnSidecarErrorCode.INVALID_SUBNET,
-      columnIdx: dataColumnSidecar.index,
-      gossipSubnet: gossipSubnet,
-    });
+  chain.metrics?.gossipDataColumnSidecar.sidecarSlotToClockSlot.observe(clockSlot - sidecarSlot);
+  if (sidecars.length === 1) {
+    chain.metrics?.gossipDataColumnSidecar.nonBatchCount.inc();
+  } else if (sidecars.length > 1) {
+    chain.metrics?.gossipDataColumnSidecar.batchHistogram.observe(sidecars.length);
+  } else {
+    // should not happen, consumer checked there is at least one sidecar already
+    throw new Error("validateGossipDataColumnSidecarSameBlock called with no sidecars");
+  }
+
+  for (const [i, {sidecar, subnet}] of sidecars.entries()) {
+    // 1) [REJECT] The sidecar is valid as verified by verify_data_column_sidecar
+    verifyDataColumnSidecar(sidecar);
+
+    // 2) [REJECT] The sidecar is for the correct subnet -- i.e. compute_subnet_for_data_column_sidecar(sidecar.index) == subnet_id
+    if (computeSubnetForDataColumnSidecar(sidecar) !== subnet) {
+      results[i] = {
+        err: new DataColumnSidecarGossipError(GossipAction.REJECT, {
+          code: DataColumnSidecarErrorCode.INVALID_SUBNET,
+          columnIdx: sidecar.index,
+          gossipSubnet: subnet,
+        }),
+      };
+    }
   }
 
   // 3) [IGNORE] The sidecar is not from a future slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
   //             -- i.e. validate that sidecar.slot <= current_slot (a client MAY queue future blocks
   //             for processing at the appropriate slot).
   const currentSlotWithGossipDisparity = chain.clock.currentSlotWithGossipDisparity;
-  if (currentSlotWithGossipDisparity < blockHeader.slot) {
-    throw new DataColumnSidecarGossipError(GossipAction.IGNORE, {
-      code: DataColumnSidecarErrorCode.FUTURE_SLOT,
-      currentSlot: currentSlotWithGossipDisparity,
-      blockSlot: blockHeader.slot,
-    });
+  if (currentSlotWithGossipDisparity < sidecarSlot) {
+    for (let i = 0; i < sidecars.length; i++) {
+      if (results[i] === undefined) {
+        results[i] = {
+          err: new DataColumnSidecarGossipError(GossipAction.IGNORE, {
+            code: DataColumnSidecarErrorCode.FUTURE_SLOT,
+            currentSlot: currentSlotWithGossipDisparity,
+            blockSlot: sidecarSlot,
+          }),
+        };
+      }
+    }
+
+    return results;
   }
 
   // 4) [IGNORE] The sidecar is from a slot greater than the latest finalized slot -- i.e. validate that
   //             sidecar.slot > compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
   const finalizedCheckpoint = chain.forkChoice.getFinalizedCheckpoint();
   const finalizedSlot = computeStartSlotAtEpoch(finalizedCheckpoint.epoch);
-  if (blockHeader.slot <= finalizedSlot) {
-    throw new DataColumnSidecarGossipError(GossipAction.IGNORE, {
-      code: DataColumnSidecarErrorCode.WOULD_REVERT_FINALIZED_SLOT,
-      blockSlot: blockHeader.slot,
-      finalizedSlot,
-    });
+  if (sidecarSlot <= finalizedSlot) {
+    for (let i = 0; i < sidecars.length; i++) {
+      if (results[i] === undefined) {
+        results[i] = {
+          err: new DataColumnSidecarGossipError(GossipAction.IGNORE, {
+            code: DataColumnSidecarErrorCode.WOULD_REVERT_FINALIZED_SLOT,
+            blockSlot: sidecarSlot,
+            finalizedSlot,
+          }),
+        };
+      }
+    }
+
+    return results;
   }
 
   // 6) [IGNORE] The sidecar's block's parent (defined by block_header.parent_root) has been seen (via gossip
@@ -77,19 +127,35 @@ export async function validateGossipDataColumnSidecar(
     //    descend from the finalized root.
     // (Non-Lighthouse): Since we prune all blocks non-descendant from finalized checking the `db.block` database won't be useful to guard
     // against known bad fork blocks, so we throw PARENT_UNKNOWN for cases (1) and (2)
-    throw new DataColumnSidecarGossipError(GossipAction.IGNORE, {
-      code: DataColumnSidecarErrorCode.PARENT_UNKNOWN,
-      parentRoot,
-    });
+    for (let i = 0; i < sidecars.length; i++) {
+      if (results[i] === undefined) {
+        results[i] = {
+          err: new DataColumnSidecarGossipError(GossipAction.IGNORE, {
+            code: DataColumnSidecarErrorCode.PARENT_UNKNOWN,
+            parentRoot,
+          }),
+        };
+      }
+    }
+
+    return results;
   }
 
   // 8) [REJECT] The sidecar is from a higher slot than the sidecar's block's parent
-  if (parentBlock.slot >= blockHeader.slot) {
-    throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
-      code: DataColumnSidecarErrorCode.NOT_LATER_THAN_PARENT,
-      parentSlot: parentBlock.slot,
-      slot: blockHeader.slot,
-    });
+  if (parentBlock.slot >= sidecarSlot) {
+    for (let i = 0; i < sidecars.length; i++) {
+      if (results[i] === undefined) {
+        results[i] = {
+          err: new DataColumnSidecarGossipError(GossipAction.REJECT, {
+            code: DataColumnSidecarErrorCode.NOT_LATER_THAN_PARENT,
+            parentSlot: parentBlock.slot,
+            slot: sidecarSlot,
+          }),
+        };
+      }
+    }
+
+    return results;
   }
 
   // getBlockSlotState also checks for whether the current finalized checkpoint is an ancestor of the block.
@@ -97,7 +163,7 @@ export async function validateGossipDataColumnSidecar(
   // this is something we should change this in the future to make the code airtight to the spec.
   // 7) [REJECT] The sidecar's block's parent passes validation.
   const blockState = await chain.regen
-    .getBlockSlotState(parentRoot, blockHeader.slot, {dontTransferCache: true}, RegenCaller.validateGossipBlock)
+    .getBlockSlotState(parentRoot, sidecarSlot, {dontTransferCache: true}, RegenCaller.validateGossipBlock)
     .catch(() => {
       throw new DataColumnSidecarGossipError(GossipAction.IGNORE, {
         code: DataColumnSidecarErrorCode.PARENT_UNKNOWN,
@@ -106,16 +172,24 @@ export async function validateGossipDataColumnSidecar(
     });
 
   // 5) [REJECT] The proposer signature of sidecar.signed_block_header, is valid with respect to the block_header.proposer_index pubkey.
-  const signatureSet = getBlockHeaderProposerSignatureSet(blockState, dataColumnSidecar.signedBlockHeader);
-  // Don't batch so verification is not delayed
+  const signatureSet = getBlockHeaderProposerSignatureSet(blockState, signedBlockHeader);
   if (
+    // TODO-das: verify this once per block for all DataColumnSidecars using the new BlockInput
     !(await chain.bls.verifySignatureSets([signatureSet], {
-      verifyOnMainThread: blockHeader.slot > chain.forkChoice.getHead().slot,
+      verifyOnMainThread: sidecarSlot > chain.forkChoice.getHead().slot,
     }))
   ) {
-    throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
-      code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
-    });
+    for (let i = 0; i < sidecars.length; i++) {
+      if (results[i] === undefined) {
+        results[i] = {
+          err: new DataColumnSidecarGossipError(GossipAction.REJECT, {
+            code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
+          }),
+        };
+      }
+    }
+
+    return results;
   }
 
   // 9) [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
@@ -125,33 +199,100 @@ export async function validateGossipDataColumnSidecar(
 
   // 10) [REJECT] The sidecar's kzg_commitments field inclusion proof is valid as verified by
   //              verify_data_column_sidecar_inclusion_proof
-  //              TODO: Can cache result on (commitments, proof, header) in the future
-  const timer = metrics?.peerDas.dataColumnSidecarInclusionProofVerificationTime.startTimer();
-  const valid = verifyDataColumnSidecarInclusionProof(dataColumnSidecar);
-  timer?.();
+  //              TODO (fulu): verify once using the new BlockInput if same inclusion proof
+  let verifiedInclusionProof: fulu.DataColumnSidecar | null = null;
+  for (const [i, {sidecar}] of sidecars.entries()) {
+    if (results[i] !== undefined) {
+      // already rejected or ignored
+      continue;
+    }
 
-  if (!valid) {
-    throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
-      code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID,
-      slot: dataColumnSidecar.signedBlockHeader.message.slot,
-      columnIdx: dataColumnSidecar.index,
-    });
+    if (verifiedInclusionProof == null) {
+      const timer = chain.metrics?.peerDas.dataColumnSidecarInclusionProofVerificationTime.startTimer();
+      if (verifyDataColumnSidecarInclusionProof(sidecar)) {
+        verifiedInclusionProof = sidecar;
+      } else {
+        results[i] = {
+          err: new DataColumnSidecarGossipError(GossipAction.REJECT, {
+            code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID,
+            slot: sidecar.signedBlockHeader.message.slot,
+            columnIdx: sidecar.index,
+          }),
+        };
+      }
+      timer?.();
+    } else {
+      if (isSameInclusionProof(verifiedInclusionProof, sidecar)) {
+        // already verified
+        continue;
+      }
+
+      results[i] = {
+        err: new DataColumnSidecarGossipError(GossipAction.REJECT, {
+          code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID,
+          slot: sidecar.signedBlockHeader.message.slot,
+          columnIdx: sidecar.index,
+        }),
+      };
+    }
   }
 
   // 11) [REJECT] The sidecar's column data is valid as verified by verify_data_column_sidecar_kzg_proofs
-  try {
-    await verifyDataColumnSidecarKzgProofs(
-      dataColumnSidecar.kzgCommitments,
-      Array.from({length: dataColumnSidecar.column.length}, () => BigInt(dataColumnSidecar.index)),
-      dataColumnSidecar.column,
-      dataColumnSidecar.kzgProofs
-    );
-  } catch {
-    throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
-      code: DataColumnSidecarErrorCode.INVALID_KZG_PROOF,
-      slot: blockHeader.slot,
-      columnIdx: dataColumnSidecar.index,
-    });
+  const commitmentBytes: Uint8Array[] = [];
+  const cellIndices: bigint[] = [];
+  const cells: Uint8Array[] = [];
+  const proofBytes: Uint8Array[] = [];
+  for (const [i, {sidecar}] of sidecars.entries()) {
+    if (results[i] !== undefined) {
+      // already rejected or ignored
+      continue;
+    }
+    const {column, index: columnIndex, kzgProofs} = sidecar;
+
+    commitmentBytes.push(...sidecar.kzgCommitments);
+    cellIndices.push(...Array.from({length: column.length}, () => BigInt(columnIndex)));
+    cells.push(...column);
+    proofBytes.push(...kzgProofs);
+  }
+
+  if (commitmentBytes.length > 0 && cells.length > 0 && cells.length > 0 && proofBytes.length > 0) {
+    let valid: boolean;
+    try {
+      const timer = chain.metrics?.peerDas.kzgVerificationDataColumnBatchTime.startTimer({
+        source: VerificationDataColumnBatchSource.Gossip,
+      });
+      valid = await kzg.asyncVerifyCellKzgProofBatch(commitmentBytes, cellIndices, cells, proofBytes);
+      timer?.();
+    } catch (_e) {
+      valid = false;
+    }
+
+    if (!valid) {
+      for (const [i, {sidecar}] of sidecars.entries()) {
+        if (results[i] !== undefined) {
+          // already rejected or ignored
+          continue;
+        }
+        chain.metrics?.peerDas.kzgVerificationDataColumnBatchReverify.inc();
+
+        try {
+          verifyDataColumnSidecarKzgProofs(
+            sidecar.kzgCommitments,
+            Array.from({length: sidecar.column.length}, () => BigInt(sidecar.index)),
+            sidecar.column,
+            sidecar.kzgProofs
+          );
+        } catch (_e) {
+          results[i] = {
+            err: new DataColumnSidecarGossipError(GossipAction.REJECT, {
+              code: DataColumnSidecarErrorCode.INVALID_KZG_PROOF,
+              slot: sidecarSlot,
+              columnIdx: sidecar.index,
+            }),
+          };
+        }
+      }
+    }
   }
 
   // 12) [IGNORE] The sidecar is the first sidecar for the tuple (block_header.slot, block_header.proposer_index,
@@ -164,15 +305,26 @@ export async function validateGossipDataColumnSidecar(
   //              while proposers for the block's branch are calculated -- in such a case do not REJECT, instead IGNORE
   //              this message.
   const proposerIndex = blockHeader.proposerIndex;
-  const expectedProposerIndex = blockState.epochCtx.getBeaconProposer(blockHeader.slot);
+  const expectedProposerIndex = blockState.epochCtx.getBeaconProposer(sidecarSlot);
 
   if (proposerIndex !== expectedProposerIndex) {
-    throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
-      code: DataColumnSidecarErrorCode.INCORRECT_PROPOSER,
-      actualProposerIndex: proposerIndex,
-      expectedProposerIndex,
-    });
+    for (let i = 0; i < sidecars.length; i++) {
+      if (results[i] !== undefined) {
+        // already rejected or ignored
+        continue;
+      }
+
+      results[i] = {
+        err: new DataColumnSidecarGossipError(GossipAction.REJECT, {
+          code: DataColumnSidecarErrorCode.INCORRECT_PROPOSER,
+          actualProposerIndex: proposerIndex,
+          expectedProposerIndex,
+        }),
+      };
+    }
   }
+
+  return results;
 }
 
 export async function validateDataColumnsSidecars(
@@ -232,7 +384,9 @@ export async function validateDataColumnsSidecars(
 
   let valid: boolean;
   try {
-    const timer = metrics?.peerDas.kzgVerificationDataColumnBatchTime.startTimer();
+    const timer = metrics?.peerDas.kzgVerificationDataColumnBatchTime.startTimer({
+      source: VerificationDataColumnBatchSource.VerifyBlock,
+    });
     valid = await kzg.asyncVerifyCellKzgProofBatch(commitmentBytes, cellIndices, cells, proofBytes);
     timer?.();
   } catch (err) {
@@ -319,4 +473,33 @@ export function verifyDataColumnSidecarInclusionProof(dataColumnSidecar: fulu.Da
  */
 export function computeSubnetForDataColumnSidecar(columnSidecar: fulu.DataColumnSidecar): SubnetID {
   return columnSidecar.index % DATA_COLUMN_SIDECAR_SUBNET_COUNT;
+}
+
+/**
+ * Check if a DataColumnSidecar inclusion proof is the same to a verified DataColumnSidecar so that we don't have to call
+ * verifyDataColumnSidecarInclusionProof() again.
+ */
+function isSameInclusionProof(verified: fulu.DataColumnSidecar, toCheck: fulu.DataColumnSidecar): boolean {
+  if (toCheck.kzgCommitments.length !== verified.kzgCommitments.length) {
+    return false;
+  }
+
+  if (toCheck.kzgCommitmentsInclusionProof.length !== verified.kzgCommitmentsInclusionProof.length) {
+    return false;
+  }
+
+  for (let i = 0; i < toCheck.kzgCommitments.length; i++) {
+    if (Buffer.compare(toCheck.kzgCommitments[i], verified.kzgCommitments[i]) !== 0) {
+      return false;
+    }
+  }
+
+  for (let i = 0; i < toCheck.kzgCommitmentsInclusionProof.length; i++) {
+    if (Buffer.compare(toCheck.kzgCommitmentsInclusionProof[i], verified.kzgCommitmentsInclusionProof[i]) !== 0) {
+      return false;
+    }
+  }
+
+  // signedBlockHeader should be the same thanks to IndexedGossipQueueMinSize
+  return true;
 }

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -3,6 +3,7 @@ import {NotReorgedReason} from "@lodestar/fork-choice";
 import {ProducedBlockSource} from "@lodestar/types";
 import {BlockSelectionResult} from "../../api/impl/validator/index.js";
 import {BlockProductionStep, PayloadPreparationType} from "../../chain/produceBlock/index.js";
+import {type VerificationDataColumnBatchSource} from "../../chain/validation/dataColumnSidecar.js";
 import {RegistryMetricCreator} from "../utils/registryMetricCreator.js";
 
 export type BeaconMetrics = ReturnType<typeof createBeaconMetrics>;
@@ -386,10 +387,11 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
         help: "Time taken to verify data_column sidecar inclusion proof",
         buckets: [0.002, 0.004, 0.006, 0.008, 0.01, 0.05, 1, 2],
       }),
-      kzgVerificationDataColumnBatchTime: register.histogram({
+      kzgVerificationDataColumnBatchTime: register.histogram<{source: VerificationDataColumnBatchSource}>({
         name: "beacon_kzg_verification_data_column_batch_seconds",
         help: "Runtime of batched data column kzg verification",
         buckets: [0.025, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1, 2, 5],
+        labelNames: ["source"],
       }),
       getBlobsV2Requests: register.counter({
         name: "beacon_engine_getBlobsV2_requests_total",
@@ -407,6 +409,10 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       custodyGroupCount: register.gauge({
         name: "beacon_custody_groups",
         help: "Total number of custody groups within a node",
+      }),
+      kzgVerificationDataColumnBatchReverify: register.gauge({
+        name: "beacon_kzg_verification_data_column_batch_reverify_total",
+        help: "Count of re-verifications of data column kzg proofs",
       }),
     },
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1,7 +1,7 @@
 import {BlockInputSource} from "../../chain/blocks/blockInput/index.js";
 import {BlobsSource, BlockSource} from "../../chain/blocks/types.js";
 import {JobQueueItemType} from "../../chain/bls/index.js";
-import {AttestationErrorCode, BlockErrorCode} from "../../chain/errors/index.js";
+import {AttestationErrorCode, BlockErrorCode, DataColumnSidecarErrorCode} from "../../chain/errors/index.js";
 import {
   type InvalidAttestationData,
   ScannedSlotsTerminationReason,
@@ -86,16 +86,17 @@ export function createLodestarMetrics(
         help: "Current count of jobs being run on network processor for topic",
         labelNames: ["topic"],
       }),
-      // this metric links to the beacon_attestation topic only as this is the only topics that are batch
-      keyAge: register.histogram({
+      keyAge: register.histogram<{topic: GossipType}>({
         name: "lodestar_gossip_validation_queue_key_age_seconds",
         help: "Age of the first item of each key in the indexed queues in seconds",
         buckets: [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 5],
+        labelNames: ["topic"],
       }),
-      queueTime: register.histogram({
+      queueTime: register.histogram<{topic: GossipType}>({
         name: "lodestar_gossip_validation_queue_time_seconds",
         help: "Total time an item stays in queue until it is processed in seconds",
         buckets: [0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 5],
+        labelNames: ["topic"],
       }),
     },
 
@@ -128,6 +129,16 @@ export function createLodestarMetrics(
       gossipAttestationRejectByReason: register.gauge<{reason: AttestationErrorCode}>({
         name: "lodestar_gossip_attestation_reject_by_reason_total",
         help: "Count of total gossip attestation reject by reason",
+        labelNames: ["reason"],
+      }),
+      gossipDataColumnSidecarIgnoreByReason: register.gauge<{reason: DataColumnSidecarErrorCode}>({
+        name: "lodestar_gossip_data_column_sidecar_ignore_by_reason_total",
+        help: "Count of total gossip data column sidecar ignore by reason",
+        labelNames: ["reason"],
+      }),
+      gossipDataColumnSidecarRejectByReason: register.gauge<{reason: DataColumnSidecarErrorCode}>({
+        name: "lodestar_gossip_data_column_sidecar_reject_by_reason_total",
+        help: "Count of total gossip data column sidecar reject by reason",
         labelNames: ["reason"],
       }),
       executeWorkCalls: register.gauge({
@@ -603,6 +614,23 @@ export function createLodestarMetrics(
       attestationNonBatchCount: register.gauge({
         name: "lodestar_gossip_attestation_verified_non_batch_count",
         help: "Count of attestations NOT verified in batch",
+      }),
+    },
+
+    gossipDataColumnSidecar: {
+      sidecarSlotToClockSlot: register.histogram({
+        name: "lodestar_gossip_data_column_sidecar_sidecar_slot_to_clock_slot",
+        help: "Slot distance between clock slot and sidecar slot",
+        buckets: [0, 1, 2, 4],
+      }),
+      batchHistogram: register.histogram({
+        name: "lodestar_gossip_data_column_sidecar_verified_in_batch_histogram",
+        help: "Number of data column sidecars verified in batch",
+        buckets: [2, 4, 8, 16, 32],
+      }),
+      nonBatchCount: register.gauge({
+        name: "lodestar_gossip_data_column_sidecar_verified_non_batch_count",
+        help: "Count of data column sidecars NOT verified in batch",
       }),
     },
 

--- a/packages/beacon-node/src/network/gossip/interface.ts
+++ b/packages/beacon-node/src/network/gossip/interface.ts
@@ -18,8 +18,8 @@ import {
 } from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Libp2p} from "libp2p";
-import {AttestationError, AttestationErrorType} from "../../chain/errors/attestationError.js";
-import {GossipActionError} from "../../chain/errors/gossipValidation.js";
+import {AttestationError} from "../../chain/errors/attestationError.js";
+import {DataColumnSidecarGossipError} from "../../chain/errors/dataColumnSidecarError.js";
 import {IBeaconChain} from "../../chain/index.js";
 import {JobItemQueue} from "../../util/queue/index.js";
 import {SubscribeBoundary} from "../core/types.js";
@@ -40,8 +40,8 @@ export enum GossipType {
   bls_to_execution_change = "bls_to_execution_change",
 }
 
-export type SequentialGossipType = Exclude<GossipType, GossipType.beacon_attestation>;
-export type BatchGossipType = GossipType.beacon_attestation;
+export type BatchGossipType = GossipType.beacon_attestation | GossipType.data_column_sidecar;
+export type SequentialGossipType = Exclude<GossipType, BatchGossipType>;
 
 export enum GossipEncoding {
   ssz_snappy = "ssz_snappy",
@@ -147,8 +147,8 @@ export type GossipModules = {
  *
  * js-libp2p-gossipsub expects validation functions that look like this
  */
-export type GossipMessageInfo = {
-  topic: GossipTopic;
+export type GossipMessageInfo<T extends GossipType> = {
+  topic: GossipTopicMap[T];
   msg: Message;
   propagationSource: PeerIdStr;
   seenTimestampSec: number;
@@ -156,9 +156,13 @@ export type GossipMessageInfo = {
   indexed?: string;
 };
 
-export type GossipValidatorFn = (messageInfo: GossipMessageInfo) => Promise<TopicValidatorResult>;
+export type SequentialGossipMessageInfo<T extends SequentialGossipType = SequentialGossipType> = GossipMessageInfo<T>;
 
-export type GossipValidatorBatchFn = (messageInfos: GossipMessageInfo[]) => Promise<TopicValidatorResult[]>;
+export type BatchGossipMessageInfo<T extends BatchGossipType = BatchGossipType> = GossipMessageInfo<T>;
+
+export type GossipValidatorFn = (messageInfo: SequentialGossipMessageInfo) => Promise<TopicValidatorResult>;
+
+export type GossipValidatorBatchFn = (messageInfos: BatchGossipMessageInfo[]) => Promise<TopicValidatorResult[]>;
 
 export type ValidatorFnsByType = {[K in GossipType]: GossipValidatorFn};
 
@@ -172,16 +176,7 @@ export type GossipData = {
   indexed?: string;
 };
 
-export type GossipHandlerParam = {
-  gossipData: GossipData;
-  topic: GossipTopicMap[GossipType];
-  peerIdStr: string;
-  seenTimestampSec: number;
-};
-
-export type GossipHandlerFn = (gossipHandlerParam: GossipHandlerParam) => Promise<void>;
-
-export type BatchGossipHandlerFn = (gossipHandlerParam: GossipHandlerParam[]) => Promise<(null | AttestationError)[]>;
+export type GossipHandlerFn = (gossipHandlerParam: GossipHandlerParamGeneric<SequentialGossipType>) => Promise<void>;
 
 export type GossipHandlerParamGeneric<T extends GossipType> = {
   gossipData: GossipData;
@@ -190,11 +185,11 @@ export type GossipHandlerParamGeneric<T extends GossipType> = {
   seenTimestampSec: number;
 };
 
-export type GossipHandlers = {
-  [K in GossipType]: SequentialGossipHandler<K> | BatchGossipHandler<K>;
-};
+export type BatchGossipHandlerParamGeneric<T extends BatchGossipType> = GossipHandlerParamGeneric<T>;
 
-export type SequentialGossipHandler<K extends GossipType> = (
+export type GossipHandlers = SequentialGossipHandlers & BatchGossipHandlers;
+
+export type SequentialGossipHandler<K extends SequentialGossipType> = (
   gossipHandlerParam: GossipHandlerParamGeneric<K>
 ) => Promise<void>;
 
@@ -206,9 +201,14 @@ export type BatchGossipHandlers = {
   [K in BatchGossipType]: BatchGossipHandler<K>;
 };
 
-export type BatchGossipHandler<K extends GossipType> = (
-  gossipHandlerParams: GossipHandlerParamGeneric<K>[]
-) => Promise<(null | GossipActionError<AttestationErrorType>)[]>;
+export type BatchGossipActionErrorGeneric = {
+  [GossipType.beacon_attestation]: AttestationError;
+  [GossipType.data_column_sidecar]: DataColumnSidecarGossipError;
+};
+
+export type BatchGossipHandler<K extends BatchGossipType> = (
+  gossipHandlerParams: BatchGossipHandlerParamGeneric<K>[]
+) => Promise<(null | BatchGossipActionErrorGeneric[K])[]>;
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
 export type ResolvedType<F extends (...args: any) => Promise<any>> = F extends (...args: any) => Promise<infer T>

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -10,7 +10,6 @@ import {
   SubnetID,
   UintNum64,
   deneb,
-  fulu,
   ssz,
   sszTypesFor,
 } from "@lodestar/types";
@@ -38,7 +37,7 @@ import {
 } from "../../chain/errors/index.js";
 import {IBeaconChain} from "../../chain/interface.js";
 import {validateGossipBlobSidecar} from "../../chain/validation/blobSidecar.js";
-import {validateGossipDataColumnSidecar} from "../../chain/validation/dataColumnSidecar.js";
+import {validateGossipDataColumnSidecarSameBlock} from "../../chain/validation/dataColumnSidecar.js";
 import {
   AggregateAndProofValidationResult,
   GossipAttestation,
@@ -58,6 +57,7 @@ import {validateLightClientOptimisticUpdate} from "../../chain/validation/lightC
 import {OpSource} from "../../chain/validatorMonitor.js";
 import {Metrics} from "../../metrics/index.js";
 import {kzgCommitmentToVersionedHash} from "../../util/blobs.js";
+import {PeerIdStr} from "../../util/peerId.js";
 import {INetworkCore} from "../core/index.js";
 import {NetworkEvent, NetworkEventBus} from "../events.js";
 import {
@@ -272,80 +272,6 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
     }
   }
 
-  async function validateBeaconDataColumn(
-    dataColumnSidecar: fulu.DataColumnSidecar,
-    dataColumnBytes: Uint8Array,
-    gossipSubnet: SubnetID,
-    peerIdStr: string,
-    seenTimestampSec: number
-  ): Promise<BlockInput | NullBlockInput> {
-    metrics?.peerDas.dataColumnSidecarProcessingRequests.inc();
-    const verificationTimer = metrics?.peerDas.dataColumnSidecarGossipVerificationTime.startTimer();
-
-    const dataColumnBlockHeader = dataColumnSidecar.signedBlockHeader.message;
-    const slot = dataColumnBlockHeader.slot;
-    const blockRootHex = toRootHex(ssz.phase0.BeaconBlockHeader.hashTreeRoot(dataColumnBlockHeader));
-    const blockShortHex = prettyBytes(blockRootHex);
-
-    const delaySec = chain.clock.secFromSlot(slot, seenTimestampSec);
-    const recvToValLatency = Date.now() / 1000 - seenTimestampSec;
-
-    try {
-      await validateGossipDataColumnSidecar(chain, dataColumnSidecar, gossipSubnet, metrics);
-      const {blockInput, blockInputMeta} = chain.seenGossipBlockInput.getGossipBlockInput(
-        config,
-        {
-          type: GossipedInputType.dataColumn,
-          dataColumnSidecar,
-          dataColumnBytes,
-        },
-        metrics
-      );
-
-      const recvToValidation = Date.now() / 1000 - seenTimestampSec;
-      const validationTime = recvToValidation - recvToValLatency;
-
-      metrics?.peerDas.dataColumnSidecarProcessingSuccesses.inc();
-      metrics?.gossipBlob.recvToValidation.observe(recvToValidation);
-      metrics?.gossipBlob.validationTime.observe(validationTime);
-
-      chain.emitter.emit(routes.events.EventType.dataColumnSidecar, {
-        blockRoot: blockRootHex,
-        slot,
-        index: dataColumnSidecar.index,
-        kzgCommitments: dataColumnSidecar.kzgCommitments.map(toHex),
-      });
-
-      logger.debug("Received gossip dataColumn", {
-        slot: slot,
-        root: blockShortHex,
-        currentSlot: chain.clock.currentSlot,
-        peerId: peerIdStr,
-        delaySec,
-        gossipSubnet,
-        columnIndex: dataColumnSidecar.index,
-        ...blockInputMeta,
-        recvToValLatency,
-        recvToValidation,
-        validationTime,
-      });
-
-      return blockInput;
-    } catch (e) {
-      if (e instanceof DataColumnSidecarGossipError && e.action === GossipAction.REJECT) {
-        chain.persistInvalidSszValue(
-          ssz.fulu.DataColumnSidecar,
-          dataColumnSidecar,
-          `gossip_reject_slot_${slot}_index_${dataColumnSidecar.index}`
-        );
-      }
-
-      throw e;
-    } finally {
-      verificationTimer?.();
-    }
-  }
-
   function handleValidBeaconBlock(blockInput: BlockInput, peerIdStr: string, seenTimestampSec: number): void {
     const signedBlock = blockInput.block;
 
@@ -552,84 +478,6 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
             "Block corresponding to blob not available till BLOCK_AVAILABILITY_CUTOFF_MS adding to unknownBlockInput",
             {blobSlot, index}
           );
-          events.emit(NetworkEvent.unknownBlockInput, {blockInput, peer: peerIdStr});
-        }
-      }
-    },
-
-    [GossipType.data_column_sidecar]: async ({
-      gossipData,
-      topic,
-      peerIdStr,
-      seenTimestampSec,
-    }: GossipHandlerParamGeneric<GossipType.data_column_sidecar>) => {
-      const {serializedData} = gossipData;
-      const dataColumnSidecar = sszDeserialize(topic, serializedData);
-      const blobSlot = dataColumnSidecar.signedBlockHeader.message.slot;
-      const index = dataColumnSidecar.index;
-
-      if (config.getForkSeq(blobSlot) < ForkSeq.deneb) {
-        throw new GossipActionError(GossipAction.REJECT, {code: "PRE_DENEB_BLOCK"});
-      }
-      const blockInput = await validateBeaconDataColumn(
-        dataColumnSidecar,
-        serializedData,
-        topic.subnet,
-        peerIdStr,
-        seenTimestampSec
-      );
-      if (blockInput.block !== null) {
-        if (blockInput.type === BlockInputType.dataPromise) {
-          chain.logger.debug("Block corresponding to blob is available but waiting for data availability", {
-            blobSlot,
-            index,
-          });
-          await raceWithCutoff(
-            chain,
-            blobSlot,
-            blockInput.cachedData.availabilityPromise as Promise<BlockInputAvailableData>,
-            BLOCK_AVAILABILITY_CUTOFF_MS
-          ).catch((_e) => {
-            chain.logger.debug("Block under processing not yet fully available adding to unknownBlockInput", {
-              blobSlot,
-            });
-            events.emit(NetworkEvent.unknownBlockInput, {blockInput, peer: peerIdStr});
-          });
-        }
-      } else {
-        // wait for the block to arrive till some cutoff else emit unknownBlockInput event
-        chain.logger.debug("Block not yet available, racing with cutoff", {blobSlot, index});
-        const normalBlockInput = await raceWithCutoff(
-          chain,
-          blobSlot,
-          blockInput.blockInputPromise,
-          BLOCK_AVAILABILITY_CUTOFF_MS
-        ).catch((_e) => {
-          return null;
-        });
-
-        if (normalBlockInput !== null) {
-          if (normalBlockInput.type === BlockInputType.dataPromise) {
-            chain.logger.debug("Block corresponding to blob is now available but waiting for data availability", {
-              blobSlot,
-              index,
-            });
-            await raceWithCutoff(
-              chain,
-              blobSlot,
-              normalBlockInput.cachedData.availabilityPromise as Promise<BlockInputAvailableData>,
-              BLOCK_AVAILABILITY_CUTOFF_MS
-            ).catch((_e) => {
-              chain.logger.debug("Block under processing not yet fully available adding to unknownBlockInput", {
-                blobSlot,
-              });
-              events.emit(NetworkEvent.unknownBlockInput, {blockInput: normalBlockInput, peer: peerIdStr});
-            });
-          } else {
-            chain.logger.debug("Block corresponding to blob is now available for processing", {blobSlot, index});
-          }
-        } else {
-          chain.logger.debug("Block not available till BLOCK_AVAILABILITY_CUTOFF_MS", {blobSlot, index});
           events.emit(NetworkEvent.unknownBlockInput, {blockInput, peer: peerIdStr});
         }
       }
@@ -847,7 +695,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
  * For now, only beacon_attestation topic is batched.
  */
 function getBatchHandlers(modules: ValidatorFnsModules, options: GossipHandlerOpts): BatchGossipHandlers {
-  const {chain, metrics, logger, aggregatorTracker} = modules;
+  const {chain, config, metrics, events, logger, aggregatorTracker} = modules;
   return {
     [GossipType.beacon_attestation]: async (
       gossipHandlerParams: GossipHandlerParamGeneric<GossipType.beacon_attestation>[]
@@ -940,6 +788,144 @@ function getBatchHandlers(modules: ValidatorFnsModules, options: GossipHandlerOp
         metrics?.gossipAttestation.attestationBatchHistogram.observe(attestationCount);
       } else {
         metrics?.gossipAttestation.attestationNonBatchCount.inc(attestationCount);
+      }
+
+      return results;
+    },
+    [GossipType.data_column_sidecar]: async (
+      gossipHandlerParams: GossipHandlerParamGeneric<GossipType.data_column_sidecar>[]
+    ): Promise<(null | DataColumnSidecarGossipError)[]> => {
+      const sidecarCount = gossipHandlerParams.length;
+      const results = new Array<null | DataColumnSidecarGossipError>(sidecarCount);
+      if (sidecarCount === 0) {
+        return results;
+      }
+      const slot = gossipHandlerParams[0].gossipData.msgSlot;
+      if (slot == null) {
+        // should not happen
+        throw new Error(`Gossip data column sidecar slot is null, slot: ${slot}`);
+      }
+
+      const validationParams = gossipHandlerParams.map((param) => ({
+        sidecar: sszDeserialize(param.topic, param.gossipData.serializedData),
+        subnet: param.topic.subnet,
+        peerIdStr: param.peerIdStr,
+        bytes: param.gossipData.serializedData,
+        seenTimestampSec: param.seenTimestampSec,
+      }));
+      const blockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(
+        validationParams[0].sidecar.signedBlockHeader.message
+      );
+      const blockHex = prettyBytes(blockRoot);
+      const validationResults = await validateGossipDataColumnSidecarSameBlock(chain, validationParams);
+
+      let last: {blockInput: BlockInput | NullBlockInput; peerIdStr: PeerIdStr} | null = null;
+      for (const [i, validationResult] of validationResults.entries()) {
+        if (validationResult?.err) {
+          results[i] = validationResult.err as DataColumnSidecarGossipError;
+          continue;
+        }
+
+        // no error
+        results[i] = null;
+        // handler
+        const {sidecar, bytes, seenTimestampSec, subnet, peerIdStr} = validationParams[i];
+        const delaySec = chain.clock.secFromSlot(slot, seenTimestampSec);
+        const recvToValLatency = Date.now() / 1000 - seenTimestampSec;
+        const recvToValidation = Date.now() / 1000 - seenTimestampSec;
+        const validationTime = recvToValidation - recvToValLatency;
+        metrics?.peerDas.dataColumnSidecarProcessingSuccesses.inc();
+        metrics?.gossipBlob.recvToValidation.observe(recvToValidation);
+        metrics?.gossipBlob.validationTime.observe(validationTime);
+        const blockInputAndMeta = chain.seenGossipBlockInput.getGossipBlockInput(
+          config,
+          {
+            type: GossipedInputType.dataColumn,
+            dataColumnSidecar: sidecar,
+            dataColumnBytes: bytes,
+          },
+          metrics
+        );
+        const {blockInputMeta} = blockInputAndMeta;
+        last = {blockInput: blockInputAndMeta.blockInput, peerIdStr};
+
+        // this will be logged multiple times for this batch but it's not much per slot and we can confirm if they're validated in batch there
+        logger.debug("Received gossip dataColumn", {
+          slot: slot,
+          root: blockHex,
+          curentSlot: chain.clock.currentSlot,
+          sideCars: sidecarCount,
+          peerId: peerIdStr,
+          delaySec,
+          subnet,
+          columnIndex: sidecar.index,
+          ...blockInputMeta,
+          recvToValLatency,
+          recvToValidation,
+          validationTime,
+        });
+      }
+
+      if (last == null) {
+        // no sidecar is validated
+        return results;
+      }
+
+      const {blockInput, peerIdStr} = last;
+
+      // previously we handle valid block input for every sidecar, but for batch processing we handle only the last one
+      if (blockInput.block !== null) {
+        if (blockInput.type === BlockInputType.dataPromise) {
+          chain.logger.debug("Block corresponding to blob is available but waiting for data availability", {
+            slot,
+          });
+          await raceWithCutoff(
+            chain,
+            slot,
+            blockInput.cachedData.availabilityPromise as Promise<BlockInputAvailableData>,
+            BLOCK_AVAILABILITY_CUTOFF_MS
+          ).catch((_e) => {
+            chain.logger.debug("Block under processing not yet fully available adding to unknownBlockInput", {
+              slot,
+            });
+            events.emit(NetworkEvent.unknownBlockInput, {blockInput, peer: peerIdStr});
+          });
+        }
+      } else {
+        // wait for the block to arrive till some cutoff else emit unknownBlockInput event
+        chain.logger.debug("Block not yet available, racing with cutoff", {slot});
+        const normalBlockInput = await raceWithCutoff(
+          chain,
+          slot,
+          blockInput.blockInputPromise,
+          BLOCK_AVAILABILITY_CUTOFF_MS
+        ).catch((_e) => {
+          return null;
+        });
+
+        if (normalBlockInput !== null) {
+          if (normalBlockInput.type === BlockInputType.dataPromise) {
+            chain.logger.debug("Block corresponding to blob is now available but waiting for data availability", {
+              slot,
+            });
+            await raceWithCutoff(
+              chain,
+              slot,
+              normalBlockInput.cachedData.availabilityPromise as Promise<BlockInputAvailableData>,
+              BLOCK_AVAILABILITY_CUTOFF_MS
+            ).catch((_e) => {
+              chain.logger.debug("Block under processing not yet fully available adding to unknownBlockInput", {
+                slot,
+              });
+              events.emit(NetworkEvent.unknownBlockInput, {blockInput: normalBlockInput, peer: peerIdStr});
+            });
+          } else {
+            chain.logger.debug("Block corresponding to blob is now available for processing", {slot});
+          }
+        } else {
+          chain.logger.debug("Block not available till BLOCK_AVAILABILITY_CUTOFF_MS", {slot});
+          events.emit(NetworkEvent.unknownBlockInput, {blockInput, peer: peerIdStr});
+        }
       }
 
       return results;

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -837,20 +837,7 @@ function getBatchHandlers(modules: ValidatorFnsModules, options: GossipHandlerOp
         metrics?.peerDas.dataColumnSidecarProcessingSuccesses.inc();
         metrics?.gossipBlob.recvToValidation.observe(recvToValidation);
         metrics?.gossipBlob.validationTime.observe(validationTime);
-        const blockInputAndMeta = chain.seenGossipBlockInput.getGossipBlockInput(
-          config,
-          {
-            type: GossipedInputType.dataColumn,
-            dataColumnSidecar: sidecar,
-            dataColumnBytes: bytes,
-          },
-          metrics
-        );
-        const {blockInputMeta} = blockInputAndMeta;
-        last = {blockInput: blockInputAndMeta.blockInput, peerIdStr};
-
-        // this will be logged multiple times for this batch but it's not much per slot and we can confirm if they're validated in batch there
-        logger.debug("Received gossip dataColumn", {
+        const logCtx = {
           slot: slot,
           root: blockHex,
           curentSlot: chain.clock.currentSlot,
@@ -859,11 +846,34 @@ function getBatchHandlers(modules: ValidatorFnsModules, options: GossipHandlerOp
           delaySec,
           subnet,
           columnIndex: sidecar.index,
-          ...blockInputMeta,
           recvToValLatency,
           recvToValidation,
           validationTime,
-        });
+        };
+        try {
+          const blockInputAndMeta = chain.seenGossipBlockInput.getGossipBlockInput(
+            config,
+            {
+              type: GossipedInputType.dataColumn,
+              dataColumnSidecar: sidecar,
+              dataColumnBytes: bytes,
+            },
+            metrics
+          );
+          const {blockInputMeta} = blockInputAndMeta;
+          last = {blockInput: blockInputAndMeta.blockInput, peerIdStr};
+
+          // this will be logged multiple times for this batch but it's not much per slot and we can confirm if they're validated in batch there
+          logger.verbose("Received gossip dataColumn", {
+            ...logCtx,
+            ...blockInputMeta,
+          });
+        } catch (e) {
+          logger.debug("Error adding data column sidecar to gossip block input", logCtx, e as Error);
+          // there could be error like DataColumnSidecarErrorCode.ALREADY_KNOWN when calling getGossipBlockInput
+          results[i] = e as DataColumnSidecarGossipError;
+          // last statement, no need continue;
+        }
       }
 
       if (last == null) {

--- a/packages/beacon-node/src/network/processor/gossipQueues/index.ts
+++ b/packages/beacon-node/src/network/processor/gossipQueues/index.ts
@@ -1,5 +1,5 @@
 import {mapValues} from "@lodestar/utils";
-import {getBeaconAttestationGossipIndex} from "../../../util/sszBytes.js";
+import {getBeaconAttestationGossipIndex, getDataColumnSidecarIndex} from "../../../util/sszBytes.js";
 import {BatchGossipType, GossipType, SequentialGossipType} from "../../gossip/interface.js";
 import {PendingGossipsubMessage} from "../types.js";
 import {IndexedGossipQueueMinSize} from "./indexed.js";
@@ -18,6 +18,19 @@ const MAX_GOSSIP_ATTESTATION_BATCH_SIZE = 128;
 export const MIN_SIGNATURE_SETS_TO_BATCH_VERIFY = 32;
 
 /**
+ * As tested in `fulu-devnet-0` we can batch up to 16 data column sidecars per slot.
+ * This constant is opinionated, may need to be adjusted in the future.
+ */
+const MIN_DATA_COLUMN_SIDECAR_BATCH_SIZE = 16;
+
+/**
+ * With DATA_COLUMN_SIDECAR_SUBNET_COUNT = 128, it can take at least 2 trips to verify all of them per slot for
+ * a node subscribing to all data column subnets.
+ * This constant is opinionated, may need to be adjusted in the future.
+ */
+const MAX_DATA_COLUMN_SIDECAR_BATCH_SIZE = 64;
+
+/**
  * Numbers from https://github.com/sigp/lighthouse/blob/b34a79dc0b02e04441ba01fd0f304d1e203d877d/beacon_node/network/src/beacon_processor/mod.rs#L69
  */
 const linearGossipQueueOpts: {
@@ -27,11 +40,6 @@ const linearGossipQueueOpts: {
   [GossipType.beacon_block]: {maxLength: 1024, type: QueueType.FIFO, dropOpts: {type: DropType.count, count: 1}},
   // gossip length for blob is beacon block length * max blobs per block = 4096
   [GossipType.blob_sidecar]: {
-    maxLength: 4096,
-    type: QueueType.FIFO,
-    dropOpts: {type: DropType.count, count: 1},
-  },
-  [GossipType.data_column_sidecar]: {
     maxLength: 4096,
     type: QueueType.FIFO,
     dropOpts: {type: DropType.count, count: 1},
@@ -81,6 +89,16 @@ const indexedGossipQueueOpts: {
     },
     minChunkSize: MIN_SIGNATURE_SETS_TO_BATCH_VERIFY,
     maxChunkSize: MAX_GOSSIP_ATTESTATION_BATCH_SIZE,
+  },
+  [GossipType.data_column_sidecar]: {
+    // with max DATA_COLUMN_SIDECAR_SUBNET_COUNT = 128 items per slot, it's really bad to see more than 5x128 items in the queue
+    // drop them if we have more than 640 items in the queue will signal the node is overloaded
+    maxLength: 640,
+    indexFn: (item: PendingGossipsubMessage) => {
+      return getDataColumnSidecarIndex(item.msg.data);
+    },
+    minChunkSize: MIN_DATA_COLUMN_SIDECAR_BATCH_SIZE,
+    maxChunkSize: MAX_DATA_COLUMN_SIDECAR_BATCH_SIZE,
   },
 };
 

--- a/packages/beacon-node/src/network/processor/gossipQueues/indexed.ts
+++ b/packages/beacon-node/src/network/processor/gossipQueues/indexed.ts
@@ -14,7 +14,7 @@ type QueueItem<T> = {
  * Starting from peerDAS, we also use this queue for data_column_sidecar topic
  * without using this queue, total job time + job wait time is almost 500ms in fulu-devnet-0 so the constant still makes sense.
  */
-const MINIMUM_WAIT_TIME_MS = 50;
+export const MINIMUM_WAIT_TIME_MS = 50;
 
 /**
  * This implementation tries to get the most items with same key:

--- a/packages/beacon-node/src/network/processor/gossipQueues/indexed.ts
+++ b/packages/beacon-node/src/network/processor/gossipQueues/indexed.ts
@@ -9,8 +9,10 @@ type QueueItem<T> = {
 
 /**
  * Enforce minimum wait time for each key. On a mainnet node, wait time for beacon_attestation
- * is more than 500ms, it's worth to take 1/10 of that to help batch more items.
+ * is more than 500ms without using this queue, it's worth to take 1/10 of that to help batch more items.
  * This is only needed for key item < minChunkSize.
+ * Starting from peerDAS, we also use this queue for data_column_sidecar topic
+ * without using this queue, total job time + job wait time is almost 500ms in fulu-devnet-0 so the constant still makes sense.
  */
 const MINIMUM_WAIT_TIME_MS = 50;
 
@@ -25,7 +27,7 @@ const MINIMUM_WAIT_TIME_MS = 50;
  *   - On next pick the last key with minChunksize
  *     - if there is no key with minChunkSize, pop the last item of the last key
  *
- * This is a special gossip queue for beacon_attestation topic
+ * This is a special gossip queue for beacon_attestation and data_column_sidecar topic
  */
 export class IndexedGossipQueueMinSize<T extends {indexed?: string; queueAddedMs?: number}> implements GossipQueue<T> {
   private _length = 0;

--- a/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
+++ b/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
@@ -1,13 +1,20 @@
 import {TopicValidatorResult} from "@libp2p/interface";
 import {ChainForkConfig} from "@lodestar/config";
 import {Logger} from "@lodestar/utils";
-import {AttestationError, GossipAction, GossipActionError} from "../../chain/errors/index.js";
+import {
+  AttestationErrorCode,
+  DataColumnSidecarGossipError,
+  GossipAction,
+  GossipActionError,
+} from "../../chain/errors/index.js";
 import {Metrics} from "../../metrics/index.js";
 import {
-  BatchGossipHandlerFn,
+  BatchGossipHandlers,
+  BatchGossipMessageInfo,
+  BatchGossipType,
   GossipHandlerFn,
   GossipHandlers,
-  GossipMessageInfo,
+  GossipType,
   GossipValidatorBatchFn,
   GossipValidatorFn,
 } from "../gossip/interface.js";
@@ -23,16 +30,17 @@ export type ValidatorFnModules = {
  * with the same attestation data
  */
 export function getGossipValidatorBatchFn(
-  gossipHandlers: GossipHandlers,
+  gossipHandlers: BatchGossipHandlers,
   modules: ValidatorFnModules
 ): GossipValidatorBatchFn {
   const {logger, metrics} = modules;
 
-  return async function gossipValidatorBatchFn(messageInfos: GossipMessageInfo[]) {
+  return async function gossipValidatorBatchFn<T extends BatchGossipType>(messageInfos: BatchGossipMessageInfo<T>[]) {
     // all messageInfos have same topic type
-    const type = messageInfos[0].topic.type;
+    const type = messageInfos[0].topic.type as T;
+    const handler = gossipHandlers[type];
     try {
-      const results = await (gossipHandlers[type] as BatchGossipHandlerFn)(
+      const results = await handler(
         messageInfos.map((messageInfo) => ({
           gossipData: {
             serializedData: messageInfo.msg.data,
@@ -50,8 +58,8 @@ export function getGossipValidatorBatchFn(
           return TopicValidatorResult.Accept;
         }
 
-        if (!(e instanceof AttestationError)) {
-          logger.debug(`Gossip batch validation ${type} threw a non-AttestationError`, {}, e as Error);
+        if (!(e instanceof GossipActionError)) {
+          logger.debug(`Gossip batch validation ${type} threw a non-GossipActionError`, {}, e as Error);
           metrics?.networkProcessor.gossipValidationIgnore.inc({topic: type});
           return TopicValidatorResult.Ignore;
         }
@@ -59,13 +67,37 @@ export function getGossipValidatorBatchFn(
         switch (e.action) {
           case GossipAction.IGNORE:
             metrics?.networkProcessor.gossipValidationIgnore.inc({topic: type});
-            // only beacon_attestation topic is validated in batch
-            metrics?.networkProcessor.gossipAttestationIgnoreByReason.inc({reason: e.type.code});
+            switch (type) {
+              case GossipType.beacon_attestation:
+                metrics?.networkProcessor.gossipAttestationIgnoreByReason.inc({
+                  reason: e.type.code as AttestationErrorCode,
+                });
+                break;
+              case GossipType.data_column_sidecar:
+                if (e instanceof DataColumnSidecarGossipError) {
+                  metrics?.networkProcessor.gossipDataColumnSidecarIgnoreByReason.inc({reason: e.type.code});
+                }
+                break;
+              default:
+                throw new Error(`Unexpected batch gossip type ${type} for IGNORE action`);
+            }
             return TopicValidatorResult.Ignore;
           case GossipAction.REJECT:
             metrics?.networkProcessor.gossipValidationReject.inc({topic: type});
-            // only beacon_attestation topic is validated in batch
-            metrics?.networkProcessor.gossipAttestationRejectByReason.inc({reason: e.type.code});
+            switch (type) {
+              case GossipType.beacon_attestation:
+                metrics?.networkProcessor.gossipAttestationRejectByReason.inc({
+                  reason: e.type.code as AttestationErrorCode,
+                });
+                break;
+              case GossipType.data_column_sidecar:
+                if (e instanceof DataColumnSidecarGossipError) {
+                  metrics?.networkProcessor.gossipDataColumnSidecarRejectByReason.inc({reason: e.type.code});
+                }
+                break;
+              default:
+                throw new Error(`Unexpected batch gossip type ${type} for REJECT action`);
+            }
             logger.debug(`Gossip validation ${type} rejected`, {}, e);
             return TopicValidatorResult.Reject;
         }

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -23,6 +23,7 @@ import {
 import {createExtractBlockSlotRootFns} from "./extractSlotRootFns.js";
 import {GossipHandlerOpts, ValidatorFnsModules, getGossipHandlers} from "./gossipHandlers.js";
 import {createGossipQueues} from "./gossipQueues/index.js";
+import {MINIMUM_WAIT_TIME_MS} from "./gossipQueues/indexed.js";
 import {ValidatorFnModules, getGossipValidatorBatchFn, getGossipValidatorFn} from "./gossipValidatorFn.js";
 import {PendingGossipsubMessage} from "./types.js";
 
@@ -158,6 +159,7 @@ export class NetworkProcessor {
   private readonly awaitingGossipsubMessagesByRootBySlot: MapDef<Slot, MapDef<RootHex, Set<PendingGossipsubMessage>>>;
   private unknownBlockGossipsubMessagesCount = 0;
   private unknownRootsBySlot = new MapDef<Slot, Set<RootHex>>(() => new Set());
+  private nextTickTimeout: NodeJS.Timeout | null = null;
 
   constructor(
     modules: NetworkProcessorModules,
@@ -302,8 +304,20 @@ export class NetworkProcessor {
       this.metrics?.gossipValidationQueue.droppedJobs.inc({topic: message.topic.type}, droppedCount);
     }
 
+    if (this.nextTickTimeout != null) {
+      clearTimeout(this.nextTickTimeout);
+    }
+
     // Tentatively perform work
     this.executeWork();
+
+    // we know there could messages in the queue that could be processed in the next `MINIMUM_WAIT_TIME_MS`
+    // this is to prevent the last message not being processed
+    this.nextTickTimeout = setTimeout(() => {
+      this.nextTickTimeout = null;
+      this.executeWork();
+      // +1 to make sure all messages get executed
+    }, MINIMUM_WAIT_TIME_MS + 1);
   }
 
   private async onBlockProcessed({

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -13,11 +13,12 @@ import {callInNextEventLoop} from "../../util/eventLoop.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {NetworkEvent, NetworkEventBus} from "../events.js";
 import {
+  BatchGossipMessageInfo,
   GossipHandlers,
-  GossipMessageInfo,
   GossipType,
   GossipValidatorBatchFn,
   GossipValidatorFn,
+  SequentialGossipMessageInfo,
 } from "../gossip/interface.js";
 import {createExtractBlockSlotRootFns} from "./extractSlotRootFns.js";
 import {GossipHandlerOpts, ValidatorFnsModules, getGossipHandlers} from "./gossipHandlers.js";
@@ -195,10 +196,13 @@ export class NetworkProcessor {
           metrics.gossipValidationQueue.concurrency.set({topic}, this.gossipTopicConcurrency[topic]);
         }
         metrics.reprocessGossipAttestations.countPerSlot.set(this.unknownBlockGossipsubMessagesCount);
-        // specific metric for beacon_attestation topic
+        // specific metric for beacon_attestation topic and data_column_sidecar topic
         metrics.gossipValidationQueue.keyAge.reset();
         for (const ageMs of this.gossipQueues.beacon_attestation.getDataAgeMs()) {
-          metrics.gossipValidationQueue.keyAge.observe(ageMs / 1000);
+          metrics.gossipValidationQueue.keyAge.observe({topic: GossipType.beacon_attestation}, ageMs / 1000);
+        }
+        for (const ageMs of this.gossipQueues.data_column_sidecar.getDataAgeMs()) {
+          metrics.gossipValidationQueue.keyAge.observe({topic: GossipType.data_column_sidecar}, ageMs / 1000);
         }
       });
     }
@@ -414,7 +418,10 @@ export class NetworkProcessor {
       for (const msg of messageOrArray) {
         msg.startProcessUnixSec = nowSec;
         if (msg.queueAddedMs !== undefined) {
-          this.metrics?.gossipValidationQueue.queueTime.observe(nowSec - msg.queueAddedMs / 1000);
+          this.metrics?.gossipValidationQueue.queueTime.observe(
+            {topic: msg.topic.type},
+            nowSec - msg.queueAddedMs / 1000
+          );
         }
       }
     } else {
@@ -423,12 +430,14 @@ export class NetworkProcessor {
     }
 
     const acceptanceArr = Array.isArray(messageOrArray)
-      ? // for beacon_attestation topic, process attestations with same attestation data
-        // we always have msgSlot in beaccon_attestation topic so the type conversion is safe
-        await this.gossipValidatorBatchFn(messageOrArray as GossipMessageInfo[])
+      ? // for beacon_attestation and data_column_sidecar topics
+        await this.gossipValidatorBatchFn(messageOrArray as BatchGossipMessageInfo[])
       : [
           // for other topics
-          await this.gossipValidatorFn({...messageOrArray, msgSlot: messageOrArray.msgSlot ?? null}),
+          await this.gossipValidatorFn({
+            ...messageOrArray,
+            msgSlot: messageOrArray.msgSlot ?? null,
+          } as SequentialGossipMessageInfo),
         ];
 
     if (Array.isArray(messageOrArray)) {

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -406,13 +406,36 @@ export function getSlotFromBlobSidecarSerialized(data: Uint8Array): Slot | null 
   }
  */
 
-const SLOT_BYTES_POSITION_IN_SIGNED_DATA_COLUMN_SIDECAR = 20;
-export function getSlotFromDataColumnSidecarSerialized(data: Uint8Array): Slot | null {
-  if (data.length < SLOT_BYTES_POSITION_IN_SIGNED_DATA_COLUMN_SIDECAR + SLOT_SIZE) {
+// slot = 8 bytes, proposerIndex = 8 bytes, parentRoot = 32 bytes, stateRoot = 32 bytes, bodyRoot = 32 bytes
+// signature = 96 bytes
+const SIGNED_BEACON_BLOCK_HEADER_SIZE = 208;
+const signBlockHeaderBuf = Buffer.alloc(SIGNED_BEACON_BLOCK_HEADER_SIZE);
+// index = 8 bytes, column = 4 bytes, kzgCommitments = bytes, kzgProofs = 4 bytes;
+const DATA_COLUMN_SIDECAR_BLOCK_HEADER_OFFSET = 20;
+type SignedBeaconHeaderBase64 = string;
+
+export function getDataColumnSidecarIndex(data: Uint8Array): SignedBeaconHeaderBase64 | null {
+  if (data.length < DATA_COLUMN_SIDECAR_BLOCK_HEADER_OFFSET + SIGNED_BEACON_BLOCK_HEADER_SIZE) {
     return null;
   }
 
-  return getSlotFromOffset(data, SLOT_BYTES_POSITION_IN_SIGNED_DATA_COLUMN_SIDECAR);
+  signBlockHeaderBuf.set(
+    data.subarray(
+      DATA_COLUMN_SIDECAR_BLOCK_HEADER_OFFSET,
+      DATA_COLUMN_SIDECAR_BLOCK_HEADER_OFFSET + SIGNED_BEACON_BLOCK_HEADER_SIZE
+    )
+  );
+
+  // base64 is a bit efficient than hex
+  return signBlockHeaderBuf.toString("base64");
+}
+
+export function getSlotFromDataColumnSidecarSerialized(data: Uint8Array): Slot | null {
+  if (data.length < DATA_COLUMN_SIDECAR_BLOCK_HEADER_OFFSET + SLOT_SIZE) {
+    return null;
+  }
+
+  return getSlotFromOffset(data, DATA_COLUMN_SIDECAR_BLOCK_HEADER_OFFSET);
 }
 
 /**

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -28,10 +28,12 @@ import {
   getBlockRootFromSingleAttestationSerialized,
   getCommitteeBitsFromSignedAggregateAndProofElectra,
   getCommitteeIndexFromSingleAttestationSerialized,
+  getDataColumnSidecarIndex,
   getSignatureFromAttestationSerialized,
   getSignatureFromSingleAttestationSerialized,
   getSlotFromAttestationSerialized,
   getSlotFromBlobSidecarSerialized,
+  getSlotFromDataColumnSidecarSerialized,
   getSlotFromSignedAggregateAndProofSerialized,
   getSlotFromSignedBeaconBlockSerialized,
   getSlotFromSingleAttestationSerialized,
@@ -319,6 +321,49 @@ describe("BlobSidecar SSZ serialized picking", () => {
   });
 });
 
+describe("DataColumnSidecar SSZ serialized picking", () => {
+  const slot = 1_000_000;
+  const proposerIndex = 123;
+  const parentRoot = new Uint8Array(32).fill(0x01);
+  const stateRoot = new Uint8Array(32).fill(0x02);
+  const bodyRoot = new Uint8Array(32).fill(0x03);
+  const testCases = [
+    ssz.fulu.DataColumnSidecar.defaultValue(),
+    dataColumnSidecarFromValues(slot, proposerIndex, parentRoot, stateRoot, bodyRoot),
+  ];
+
+  it("getSlotFromDataColumnSidecarSerialized", () => {
+    for (const dataColumnSidecar of testCases) {
+      const bytes = ssz.fulu.DataColumnSidecar.serialize(dataColumnSidecar);
+      expect(getSlotFromDataColumnSidecarSerialized(bytes)).toBe(dataColumnSidecar.signedBlockHeader.message.slot);
+    }
+  });
+
+  it("getSlotFromDataColumnSidecarSerialized - invalid data", () => {
+    const invalidDataSizes = [0, 20];
+    for (const size of invalidDataSizes) {
+      expect(getSlotFromDataColumnSidecarSerialized(Buffer.alloc(size))).toBeNull();
+    }
+  });
+
+  it("getDataColumnSidecarIndexStr", () => {
+    for (const dataColumnSidecar of testCases) {
+      const bytes = ssz.fulu.DataColumnSidecar.serialize(dataColumnSidecar);
+      const indexStr = Buffer.from(
+        ssz.phase0.SignedBeaconBlockHeader.serialize(dataColumnSidecar.signedBlockHeader)
+      ).toString("base64");
+      expect(getDataColumnSidecarIndex(bytes)).toBe(indexStr);
+    }
+  });
+
+  it("getDataColumnSidecarIndexStr - invalid data", () => {
+    const invalidDataSizes = [0, 20, 40];
+    for (const size of invalidDataSizes) {
+      expect(getDataColumnSidecarIndex(Buffer.alloc(size))).toBeNull();
+    }
+  });
+});
+
 function phase0SingleAttestationFromValues(
   slot: Slot,
   blockRoot: RootHex,
@@ -390,4 +435,28 @@ function blobSidecarFromValues(slot: Slot): deneb.BlobSidecar {
   const blobSidecar = ssz.deneb.BlobSidecar.defaultValue();
   blobSidecar.signedBlockHeader.message.slot = slot;
   return blobSidecar;
+}
+
+function dataColumnSidecarFromValues(
+  slot: Slot,
+  proposerIndex?: number,
+  parentRoot?: Uint8Array,
+  stateRoot?: Uint8Array,
+  bodyRoot?: Uint8Array
+) {
+  const dataColumnSidecar = ssz.fulu.DataColumnSidecar.defaultValue();
+  dataColumnSidecar.signedBlockHeader.message.slot = slot;
+  if (proposerIndex !== undefined) {
+    dataColumnSidecar.signedBlockHeader.message.proposerIndex = proposerIndex;
+  }
+  if (parentRoot !== undefined) {
+    dataColumnSidecar.signedBlockHeader.message.parentRoot = parentRoot;
+  }
+  if (stateRoot !== undefined) {
+    dataColumnSidecar.signedBlockHeader.message.stateRoot = stateRoot;
+  }
+  if (bodyRoot !== undefined) {
+    dataColumnSidecar.signedBlockHeader.message.bodyRoot = bodyRoot;
+  }
+  return dataColumnSidecar;
 }


### PR DESCRIPTION
**Motivation**

- it's not efficient to verify each DataColumnSidecar gossip message separately

**Description**

use the IndexedGossipQueue that's already works for `beacon_attestation` for `data_column_sidecar`
- key by `BeaconBlockHeader` base64
- main benefit is to do `ckzg.verifyCellKzgProofBatch()` in batch
- verify inclusion proof once per batch, in the future we should do it once per block with new BlockInput
- verify signature once per batch, in the future we should do it once per block with new BlockInput

**Test result with fusaka-devnet-0**
- for job time it's 3x-4x faster, saves us ~250ms
<img width="1055" alt="Screenshot 2025-06-04 at 10 50 49" src="https://github.com/user-attachments/assets/dbeeaf2e-075e-406d-8ac7-f8442a965017" />

- it's takes ~35ms more for wait time, but it's really worth it

<img width="864" alt="Screenshot 2025-06-04 at 10 51 37" src="https://github.com/user-attachments/assets/51d3d4af-9887-40bc-a232-71bf1e80ef7f" />

- it also helps us save time to interact with EL. I guess if we can do async we can reduce this time more

<img width="862" alt="Screenshot 2025-06-04 at 10 52 29" src="https://github.com/user-attachments/assets/28b0f8c0-e576-4d42-b91d-e61e73df975b" />

