### PR TITLE
fix: erigon getblobsv2 bug in response

### DIFF
--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -555,8 +555,9 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         return (response as EngineApiRpcReturnTypes[typeof method]).map(deserializeBlobAndProofs);
       case "engine_getBlobsV2": {
         const castResponse = response as EngineApiRpcReturnTypes[typeof method];
-        // TODO: Spec says to return null if any blob is not found, but reth and nethermind return empty arrays as of peerdas-devnet-6
-        if (castResponse === null || castResponse.length === 0) return null;
+        // TODO(fulu): Spec says to return null if any blob is not found, but reth and nethermind return empty arrays as of peerdas-devnet-6
+        // TODO(fulu): Erigon returns array with `null` values
+        if (castResponse === null || castResponse.length === 0 || castResponse?.includes(null)) return null;
         return castResponse.map(deserializeBlobAndProofsV2);
       }
     }

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -557,7 +557,8 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         const castResponse = response as EngineApiRpcReturnTypes[typeof method];
         // TODO(fulu): Spec says to return null if any blob is not found, but reth and nethermind return empty arrays as of peerdas-devnet-6
         // TODO(fulu): Erigon returns array with `null` values
-        if (castResponse === null || castResponse.length === 0 || castResponse?.includes(null)) return null;
+        // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+        if (castResponse === null || castResponse.length === 0 || castResponse?.includes(null as any)) return null;
         return castResponse.map(deserializeBlobAndProofsV2);
       }
     }


### PR DESCRIPTION
**Motivation**

Found a bug in the logs while looking for an issue on fusaka-devnet-0.  Bug exists for Erigon response to getBlobsV2.


```sh
Jun-04 09:20:00.603[chain]           error: Error getting data columns from execution blockHex=0xd5311b3a4eee9727d8f9c493533ef610f18d12764984d6878d6842ef9261359b - Cannot read properties of null (reading 'blob')
TypeError: Cannot read properties of null (reading 'blob')
    at deserializeBlobAndProofsV2 (file:///usr/app/packages/beacon-node/src/execution/engine/types.ts:578:28)
    at Array.map (<anonymous>)
    at ExecutionEngineHttp.getBlobs (file:///usr/app/packages/beacon-node/src/execution/engine/http.ts:560:29)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at getDataColumnsFromExecution (file:///usr/app/packages/beacon-node/src/util/dataColumns.ts:366:17)
```