### PR TITLE
chore: add panel to track aggregate cache misses

### DIFF
--- a/dashboards/lodestar_block_production.json
+++ b/dashboards/lodestar_block_production.json
@@ -2441,6 +2441,89 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 90
+      },
+      "id": 564,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(lodestar_oppool_attestation_pool_get_aggregate_cache_misses_total[$rate_interval])",
+          "instant": false,
+          "legendFormat": "cache misses",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Aggregate cache misses",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,


### PR DESCRIPTION
**Motivation**

- to confirm https://github.com/ChainSafe/lodestar/issues/7548 is no longer an issue

**Description**

Add grafana panel for metric added in https://github.com/ChainSafe/lodestar/pull/7667 to track aggregate cache misses.

More recently (last 30 days), it does no longer seem to be an issue. I checked multiple nodes on different networks and not a single aggregate cache miss.

![image](https://github.com/user-attachments/assets/a9ad48ad-7171-4f57-8956-b223daf4d420)

I found few cases on hoodi nodes but those are already more than a month ago.

![image](https://github.com/user-attachments/assets/5ecd1fdd-36fb-4ce5-992e-ac27bd4ed2e3)


