### PR TITLE
chore: prepare for spec test v1.6.0-alpha.1

### DIFF
--- a/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
+++ b/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
@@ -46,10 +46,6 @@ const epochTransitionFns: Record<string, EpochTransitionFn> = {
   historical_summaries_update: epochFns.processHistoricalSummariesUpdate as EpochTransitionFn,
   pending_deposits: epochFns.processPendingDeposits as EpochTransitionFn,
   pending_consolidations: epochFns.processPendingConsolidations as EpochTransitionFn,
-  process_proposer_lookahead: (state, _) => {
-    const fork = state.config.getForkSeq(state.slot);
-    epochFns.processProposerLookahead(fork, state as CachedBeaconStateFulu);
-  },
 };
 
 /**

--- a/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
+++ b/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
@@ -46,6 +46,10 @@ const epochTransitionFns: Record<string, EpochTransitionFn> = {
   historical_summaries_update: epochFns.processHistoricalSummariesUpdate as EpochTransitionFn,
   pending_deposits: epochFns.processPendingDeposits as EpochTransitionFn,
   pending_consolidations: epochFns.processPendingConsolidations as EpochTransitionFn,
+  process_proposer_lookahead: (state, _) => {
+    const fork = state.config.getForkSeq(state.slot);
+    epochFns.processProposerLookahead(fork, state as CachedBeaconStateFulu);
+  },
 };
 
 /**
@@ -61,6 +65,7 @@ type EpochTransitionCacheingTestCase = {
  * @param fork
  * @param epochTransitionFns Describe with which function to run each directory of tests
  */
+// TODO FULU: Add verification for preEpoch and postEpoch states too
 const epochProcessing =
   (skipTestNames?: string[]): TestRunnerFn<EpochTransitionCacheingTestCase, BeaconStateAllForks> =>
   (fork, testName) => {
@@ -95,6 +100,8 @@ const epochProcessing =
         sszTypes: {
           pre: ssz[fork].BeaconState,
           post: ssz[fork].BeaconState,
+          preEpoch: ssz[fork].BeaconState,
+          postEpoch: ssz[fork].BeaconState,
         },
         getExpected: (testCase) => testCase.post,
         expectFunc: (_testCase, expected, actual) => {

--- a/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
+++ b/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
@@ -61,7 +61,7 @@ type EpochTransitionCacheingTestCase = {
  * @param fork
  * @param epochTransitionFns Describe with which function to run each directory of tests
  */
-// TODO FULU: Add verification for preEpoch and postEpoch states too
+// TODO FULU: Add verification for pre_epoch and post_epoch states too
 const epochProcessing =
   (skipTestNames?: string[]): TestRunnerFn<EpochTransitionCacheingTestCase, BeaconStateAllForks> =>
   (fork, testName) => {
@@ -96,8 +96,8 @@ const epochProcessing =
         sszTypes: {
           pre: ssz[fork].BeaconState,
           post: ssz[fork].BeaconState,
-          preEpoch: ssz[fork].BeaconState,
-          postEpoch: ssz[fork].BeaconState,
+          pre_epoch: ssz[fork].BeaconState,
+          post_epoch: ssz[fork].BeaconState,
         },
         getExpected: (testCase) => testCase.post,
         expectFunc: (_testCase, expected, actual) => {

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -58,7 +58,7 @@ const coveredTestRunners = [
 // ],
 // ```
 export const defaultSkipOpts: SkipOpts = {
-  skippedForks: ["eip7594", "fulu", "eip7732"],
+  skippedForks: ["eip7594", "fulu", "eip7732", "eip7805"],
   // TODO: capella
   // BeaconBlockBody proof in lightclient is the new addition in v1.3.0-rc.2-hotfix
   // Skip them for now to enable subsequently

--- a/packages/spec-test-util/src/single.ts
+++ b/packages/spec-test-util/src/single.ts
@@ -221,8 +221,6 @@ function deserializeInputFile<TestCase extends {meta?: any}, Result>(
 
     let sszType: SszTypeGeneric | undefined;
     for (const key of Object.keys(sszTypes)) {
-      // Sometimes the inputName is in snake_case, but we want to match camelCase
-      inputName = inputName.replace(/_([a-z])/g, (_, char) => char.toUpperCase());
       // most tests configure with exact match
       // fork_choice tests configure with regex
       if ((key.startsWith("^") && inputName.match(key)) || inputName === key) {

--- a/packages/spec-test-util/src/single.ts
+++ b/packages/spec-test-util/src/single.ts
@@ -221,6 +221,8 @@ function deserializeInputFile<TestCase extends {meta?: any}, Result>(
 
     let sszType: SszTypeGeneric | undefined;
     for (const key of Object.keys(sszTypes)) {
+      // Sometimes the inputName is in snake_case, but we want to match camelCase
+      inputName = inputName.replace(/_([a-z])/g, (_, char) => char.toUpperCase());
       // most tests configure with exact match
       // fork_choice tests configure with regex
       if ((key.startsWith("^") && inputName.match(key)) || inputName === key) {


### PR DESCRIPTION
There are several changes in spec test v1.6.0-alpha.1.
- Introduce eip7805 spec test
- Add `pre_epoch` and `post_epoch` definition in epoch processing.


This PR adds code in preparation for v1.6.0-alpha.1 to minimize changes needs to be made in #7902 


Partially resolve #7918 