### PR TITLE
chore: add `Uint8Array` type check to `bytesToBigInt`

### DIFF
--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -42,6 +42,10 @@ export function bigIntToBytes(value: bigint, length: number, endianness: Endiann
 }
 
 export function bytesToBigInt(value: Uint8Array, endianness: Endianness = "le"): bigint {
+  if (!(value instanceof Uint8Array)) {
+    throw new TypeError("expected a Uint8Array");
+  }
+
   if (endianness === "le") {
     return toBigIntLE(value as Buffer);
   }


### PR DESCRIPTION
**Motivation**

There is vulnerability in `toBigIntLE()` from `bigint-buffer` package if you pass it `null` or `undefined` that would cause a crash.

```
node: ../src/bigint-buffer.c:49: toBigInt: Assertion `status == napi_ok' failed.
Aborted (core dumped)
```

However, I don't see any case in our code where this would happen or be an issue but since we export this function separately for anyone to use, it makes sense to add a sanity check that ensures it just throws an error instead of crashing.

The last release of [bigint-buffer](https://www.npmjs.com/package/bigint-buffer) was 6 years ago, I don't expect a fix to be published for this, we might wanna look into replacing the package at some point.

**Description**

Add `Uint8Array` type check to `bytesToBigInt`

References
- https://security.snyk.io/vuln/SNYK-JS-BIGINTBUFFER-3364597
- https://nvd.nist.gov/vuln/detail/CVE-2025-3194
- https://github.com/ChainSafe/lodestar/security/dependabot/213
- https://www.npmjs.com/package/bigint-buffer

