### PR TITLE
feat: add metric to track consensus block value

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -439,6 +439,7 @@ export function getValidatorApi(
 
       metrics?.blockProductionSuccess.inc({source});
       metrics?.blockProductionNumAggregated.observe({source}, block.body.attestations.length);
+      metrics?.blockProductionConsensusBlockValue.observe({source}, Number(formatWeiToEth(consensusBlockValue)));
       metrics?.blockProductionExecutionPayloadValue.observe({source}, Number(formatWeiToEth(executionPayloadValue)));
       logger.verbose("Produced blinded block", {
         slot,
@@ -495,6 +496,7 @@ export function getValidatorApi(
 
       metrics?.blockProductionSuccess.inc({source});
       metrics?.blockProductionNumAggregated.observe({source}, block.body.attestations.length);
+      metrics?.blockProductionConsensusBlockValue.observe({source}, Number(formatWeiToEth(consensusBlockValue)));
       metrics?.blockProductionExecutionPayloadValue.observe({source}, Number(formatWeiToEth(executionPayloadValue)));
       logger.verbose("Produced execution block", {
         slot,

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -165,6 +165,12 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       buckets: [1, 2, 4, 6, 8],
       labelNames: ["source"],
     }),
+    blockProductionConsensusBlockValue: register.histogram<{source: ProducedBlockSource}>({
+      name: "beacon_block_production_consensus_block_value",
+      help: "Consensus block value denominated in ETH of produced blocks",
+      buckets: [0.001, 0.005, 0.01, 0.03, 0.05, 0.07, 0.1],
+      labelNames: ["source"],
+    }),
     blockProductionExecutionPayloadValue: register.histogram<{source: ProducedBlockSource}>({
       name: "beacon_block_production_execution_payload_value",
       help: "Execution payload value denominated in ETH of produced blocks",


### PR DESCRIPTION
**Motivation**

We don't track this anywhere but it's a pretty easy way to figure out the quality of our produced blocks.

**Description**

Add metric `beacon_block_production_consensus_block_value` to track consensus block value