### PR TITLE
chore: add panels for IDONTWANT metrics to gossipsub dashboard

### DIFF
--- a/dashboards/lodestar_debug_gossipsub.json
+++ b/dashboards/lodestar_debug_gossipsub.json
@@ -7185,6 +7185,236 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 278
+      },
+      "id": 508,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(gossipsub_idontwant_rcv_msgids_total[$rate_interval])",
+          "interval": "",
+          "legendFormat": "rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "IDONTWANT received",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "cps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "rate"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "percentunit"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "share of received"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "count"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 278
+      },
+      "id": 509,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(gossipsub_idontwant_rcv_dont_have_msgids_total[$rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "rate",
+          "range": true,
+          "refId": "count"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(rate(gossipsub_idontwant_rcv_dont_have_msgids_total[$rate_interval]))\n/\nsum(rate(gossipsub_idontwant_rcv_msgids_total[$rate_interval]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "share of received",
+          "range": true,
+          "refId": "rate"
+        }
+      ],
+      "title": "IDONTWANT received we don't have",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "datasource": {
         "type": "prometheus",
@@ -7194,7 +7424,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 278
+        "y": 286
       },
       "id": 429,
       "panels": [],
@@ -7261,7 +7491,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 279
+        "y": 287
       },
       "id": 385,
       "options": {
@@ -7368,7 +7598,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 279
+        "y": 287
       },
       "id": 391,
       "options": {
@@ -7463,7 +7693,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 287
+        "y": 295
       },
       "id": 436,
       "options": {
@@ -7547,7 +7777,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 287
+        "y": 295
       },
       "id": 437,
       "options": {
@@ -7646,7 +7876,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 295
+        "y": 303
       },
       "id": 440,
       "options": {
@@ -7753,7 +7983,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 295
+        "y": 303
       },
       "id": 441,
       "options": {
@@ -7818,7 +8048,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 303
+        "y": 311
       },
       "id": 409,
       "panels": [],
@@ -7839,7 +8069,7 @@
         "h": 4,
         "w": 24,
         "x": 0,
-        "y": 304
+        "y": 312
       },
       "id": 423,
       "options": {
@@ -7905,7 +8135,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 308
+        "y": 316
       },
       "id": 396,
       "options": {
@@ -7999,7 +8229,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 308
+        "y": 316
       },
       "id": 397,
       "options": {
@@ -8093,7 +8323,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 316
+        "y": 324
       },
       "id": 398,
       "options": {
@@ -8187,7 +8417,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 316
+        "y": 324
       },
       "id": 399,
       "options": {
@@ -8281,7 +8511,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 324
+        "y": 332
       },
       "id": 401,
       "options": {
@@ -8375,7 +8605,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 324
+        "y": 332
       },
       "id": 402,
       "options": {
@@ -8469,7 +8699,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 332
+        "y": 340
       },
       "id": 403,
       "options": {
@@ -8563,7 +8793,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 332
+        "y": 340
       },
       "id": 404,
       "options": {
@@ -8657,7 +8887,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 340
+        "y": 348
       },
       "id": 405,
       "options": {
@@ -8751,7 +8981,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 340
+        "y": 348
       },
       "id": 406,
       "options": {
@@ -8845,7 +9075,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 348
+        "y": 356
       },
       "id": 400,
       "options": {
@@ -8939,7 +9169,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 348
+        "y": 356
       },
       "id": 407,
       "options": {

--- a/dashboards/lodestar_debug_gossipsub.json
+++ b/dashboards/lodestar_debug_gossipsub.json
@@ -7258,9 +7258,9 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "rate(gossipsub_idontwant_rcv_msgids_total[$rate_interval])",
+          "expr": "rate(gossipsub_rpc_sent_idontwant_total[$rate_interval])",
           "interval": "",
-          "legendFormat": "received",
+          "legendFormat": "sent",
           "range": true,
           "refId": "A"
         },
@@ -7270,15 +7270,15 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(gossipsub_rpc_sent_idontwant_total[$rate_interval])",
+          "expr": "rate(gossipsub_idontwant_rcv_msgids_total[$rate_interval])",
           "hide": false,
           "instant": false,
-          "legendFormat": "sent",
+          "legendFormat": "received",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "IDONTWANT messages",
+      "title": "IDONTWANT sent / received",
       "type": "timeseries"
     },
     {

--- a/dashboards/lodestar_debug_gossipsub.json
+++ b/dashboards/lodestar_debug_gossipsub.json
@@ -7260,12 +7260,25 @@
           "exemplar": false,
           "expr": "rate(gossipsub_idontwant_rcv_msgids_total[$rate_interval])",
           "interval": "",
-          "legendFormat": "rate",
+          "legendFormat": "received",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(gossipsub_rpc_sent_idontwant_total[$rate_interval])",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "sent",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "IDONTWANT received",
+      "title": "IDONTWANT messages",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
**Motivation**

We enabled `IDONTWANT` a while ago but haven't added panels for it yet.

**Description**

Add panels for `IDONTWANT` metrics to gossipsub dashboard

![image](https://github.com/user-attachments/assets/8c39f565-81aa-4ba7-8171-e52cc296da65)


Related https://github.com/ChainSafe/js-libp2p-gossipsub/pull/498