### PR TITLE
fix: parent slot of produced block

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -550,6 +550,7 @@ export function getValidatorApi(
     const {blockRoot: parentBlockRootHex, slot: parentSlot} = chain.getProposerHead(slot);
     const parentBlockRoot = fromHex(parentBlockRootHex);
     notOnOutOfRangeData(parentBlockRoot);
+    metrics?.blockProductionSlotDelta.set(slot - parentSlot);
 
     const fork = config.getForkName(slot);
     // set some sensible opts
@@ -588,6 +589,8 @@ export function getValidatorApi(
 
     const loggerContext = {
       slot,
+      parentSlot,
+      parentBlockRoot: parentBlockRootHex,
       fork,
       builderSelection,
       isBuilderEnabled,

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -405,9 +405,11 @@ export function getValidatorApi(
     {
       commonBlockBody,
       parentBlockRoot,
+      parentSlot,
     }: Omit<routes.validator.ExtraProduceBlockOpts, "builderSelection"> & {
       commonBlockBody: CommonBlockBody;
       parentBlockRoot: Root;
+      parentSlot: Slot;
     }
   ): Promise<ProduceBlindedBlockRes> {
     const version = config.getForkName(slot);
@@ -432,6 +434,7 @@ export function getValidatorApi(
       const {block, executionPayloadValue, consensusBlockValue} = await chain.produceBlindedBlock({
         slot,
         parentBlockRoot,
+        parentSlot,
         randaoReveal,
         graffiti,
         commonBlockBody,
@@ -467,9 +470,11 @@ export function getValidatorApi(
       strictFeeRecipientCheck,
       commonBlockBody,
       parentBlockRoot,
+      parentSlot,
     }: Omit<routes.validator.ExtraProduceBlockOpts, "builderSelection"> & {
       commonBlockBody: CommonBlockBody;
       parentBlockRoot: Root;
+      parentSlot: Slot;
     }
   ): Promise<ProduceBlockOrContentsRes & {shouldOverrideBuilder?: boolean}> {
     const source = ProducedBlockSource.engine;
@@ -481,6 +486,7 @@ export function getValidatorApi(
       const {block, executionPayloadValue, consensusBlockValue, shouldOverrideBuilder} = await chain.produceBlock({
         slot,
         parentBlockRoot,
+        parentSlot,
         randaoReveal,
         graffiti,
         feeRecipient,
@@ -541,7 +547,8 @@ export function getValidatorApi(
     notWhileSyncing();
     await waitForSlot(slot); // Must never request for a future slot > currentSlot
 
-    const parentBlockRoot = fromHex(chain.getProposerHead(slot).blockRoot);
+    const {blockRoot: parentBlockRootHex, slot: parentSlot} = chain.getProposerHead(slot);
+    const parentBlockRoot = fromHex(parentBlockRootHex);
     notOnOutOfRangeData(parentBlockRoot);
 
     const fork = config.getForkName(slot);
@@ -594,6 +601,7 @@ export function getValidatorApi(
     const commonBlockBody = await chain.produceCommonBlockBody({
       slot,
       parentBlockRoot,
+      parentSlot,
       randaoReveal,
       graffiti: graffitiBytes,
     });
@@ -620,6 +628,7 @@ export function getValidatorApi(
           strictFeeRecipientCheck: false,
           commonBlockBody,
           parentBlockRoot,
+          parentSlot,
         })
       : Promise.reject(new Error("Builder disabled"));
 
@@ -629,6 +638,7 @@ export function getValidatorApi(
           strictFeeRecipientCheck,
           commonBlockBody,
           parentBlockRoot,
+          parentSlot,
         }).then((engineBlock) => {
           // Once the engine returns a block, in the event of either:
           // - suspected builder censorship

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -660,10 +660,7 @@ export class BeaconChain implements IBeaconChain {
     // TODO: To avoid breaking changes for metric define this attribute
     const blockType = BlockType.Full;
 
-    return produceCommonBlockBody.call(this, blockType, state, {
-      ...blockAttributes,
-      parentSlot: slot - 1,
-    });
+    return produceCommonBlockBody.call(this, blockType, state, blockAttributes);
   }
 
   produceBlock(blockAttributes: BlockAttributes & {commonBlockBody?: CommonBlockBody}): Promise<{
@@ -692,6 +689,7 @@ export class BeaconChain implements IBeaconChain {
       feeRecipient,
       commonBlockBody,
       parentBlockRoot,
+      parentSlot,
     }: BlockAttributes & {commonBlockBody?: CommonBlockBody}
   ): Promise<{
     block: AssembledBlockType<T>;
@@ -717,7 +715,7 @@ export class BeaconChain implements IBeaconChain {
         graffiti,
         slot,
         feeRecipient,
-        parentSlot: slot - 1,
+        parentSlot,
         parentBlockRoot,
         proposerIndex,
         proposerPubKey,

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -77,6 +77,7 @@ export type BlockAttributes = {
   graffiti: Bytes32;
   slot: Slot;
   parentBlockRoot: Root;
+  parentSlot: Slot;
   feeRecipient?: string;
 };
 
@@ -105,7 +106,6 @@ export async function produceBlockBody<T extends BlockType>(
   blockType: T,
   currentState: CachedBeaconStateAllForks,
   blockAttr: BlockAttributes & {
-    parentSlot: Slot;
     proposerIndex: ValidatorIndex;
     proposerPubKey: BLSPubkey;
     commonBlockBody?: CommonBlockBody;

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -126,6 +126,7 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       buckets: [1, 2, 3, 5, 7, 10, 20, 30, 50, 100],
     }),
 
+    // TODO: wrap to blockProduction
     blockProductionTime: register.histogram<{source: ProducedBlockSource}>({
       name: "beacon_block_production_seconds",
       help: "Full runtime of block production",
@@ -170,6 +171,10 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
       help: "Consensus block value denominated in ETH of produced blocks",
       buckets: [0.001, 0.005, 0.01, 0.03, 0.05, 0.07, 0.1],
       labelNames: ["source"],
+    }),
+    blockProductionSlotDelta: register.gauge({
+      name: "beacon_block_production_slot_delta",
+      help: "Slot delta of produced slot compared to parent slot",
     }),
     blockProductionExecutionPayloadValue: register.histogram<{source: ProducedBlockSource}>({
       name: "beacon_block_production_execution_payload_value",

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -185,7 +185,9 @@ describe("api/validator - produceBlockV3", () => {
     const graffiti = "a".repeat(32);
     const feeRecipient = "0xcccccccccccccccccccccccccccccccccccccccc";
 
-    modules.chain.getProposerHead.mockReturnValue(generateProtoBlock({blockRoot: toHexString(parentBlockRoot)}));
+    modules.chain.getProposerHead.mockReturnValue(
+      generateProtoBlock({blockRoot: toHexString(parentBlockRoot), slot: currentSlot - 1})
+    );
     modules.chain.recomputeForkChoiceHead.mockReturnValue(
       generateProtoBlock({blockRoot: toHexString(parentBlockRoot)})
     );
@@ -203,6 +205,7 @@ describe("api/validator - produceBlockV3", () => {
       graffiti: toGraffitiBytes(graffiti),
       slot,
       parentBlockRoot,
+      parentSlot: currentSlot - 1,
       feeRecipient,
     });
 
@@ -214,6 +217,7 @@ describe("api/validator - produceBlockV3", () => {
       graffiti: toGraffitiBytes(graffiti),
       slot,
       parentBlockRoot,
+      parentSlot: currentSlot - 1,
       feeRecipient: undefined,
     });
   });


### PR DESCRIPTION
**Motivation**

- we currently hard code parent slot as `producedSlot - 1` which is incorrect in reorg scenario, see https://github.com/ChainSafe/lodestar/issues/7299#issuecomment-2947771570

**Description**

- parent slot is slot of head before we produce block
- cascade this value to other flows when producing block
- add metric: track slot delta compared to parent slot
- add logs

part of #7299

