### PR TITLE
chore: do not create map entry if prev block root does not exist

### DIFF
--- a/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/syncContributionAndProofPool.ts
@@ -120,7 +120,7 @@ export class SyncContributionAndProofPool {
     const bestContributionBySubnetByRoot = this.bestContributionBySubnetRootBySlot.getOrDefault(slot);
     opPoolMetrics?.getAggregateRoots.set(bestContributionBySubnetByRoot.size);
     const prevBlockRootHex = toRootHex(prevBlockRoot);
-    const bestContributionBySubnet = bestContributionBySubnetByRoot.getOrDefault(prevBlockRootHex);
+    const bestContributionBySubnet = bestContributionBySubnetByRoot.get(prevBlockRootHex) ?? new Map();
     opPoolMetrics?.getAggregateSubnets.set(bestContributionBySubnet.size);
 
     if (bestContributionBySubnet.size === 0) {


### PR DESCRIPTION
Need to create empty `Map` as `getOrDefault` will create an entry for `prevBlockRootHex` which would then be part of `availableRoots` in the logs which is not intended

```
Jun-05 03:09:11.223[chain]            [33mwarn[39m: SyncContributionAndProofPool.getAggregate: no contributions for root slot=11855743, root=0xa98916bfe94196f46bc73be9766aff6abedf05794b4214cd3d0643fa91b0a6a0, availableRoots=0x91624667f40cdfe572102e9ff1937674adf2f92a5b17631b45bca80fb163a2be,0xa98916bfe94196f46bc73be9766aff6abedf05794b4214cd3d0643fa91b0a6a0
```