### PR TITLE
feat: implement recover_matrix for peerDAS

### DIFF
--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -90,6 +90,7 @@ export type CachedDataColumns = CachedDataItem &
   ForkDataColumnsInfo &
   Availability<BlockInputDataColumns> & {
     dataColumnsCache: DataColumnsCacheMap;
+    calledRecover: boolean;
   };
 
 /**

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -268,7 +268,13 @@ export class BeaconChain implements IBeaconChain {
     this.seenAttestationDatas = new SeenAttestationDatas(metrics, this.opts?.attDataCacheSlotDistance);
     const nodeId = computeNodeIdFromPrivateKey(privateKey);
     this.custodyConfig = new CustodyConfig(nodeId, config);
-    this.seenGossipBlockInput = new SeenGossipBlockInput(this.custodyConfig, this.executionEngine, emitter, logger);
+    this.seenGossipBlockInput = new SeenGossipBlockInput(
+      this.custodyConfig,
+      this.executionEngine,
+      emitter,
+      clock,
+      logger
+    );
 
     this.beaconProposerCache = new BeaconProposerCache(opts);
     this.checkpointBalancesCache = new CheckpointBalancesCache();

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -30,7 +30,7 @@ import {
   getBlockInputBlobs,
   getBlockInputDataColumns,
 } from "../blocks/types.js";
-import {ChainEventEmitter} from "../emitter.js";
+import {ChainEvent, ChainEventEmitter} from "../emitter.js";
 import {DataColumnSidecarErrorCode, DataColumnSidecarGossipError} from "../errors/dataColumnSidecarError.js";
 import {GossipAction} from "../errors/gossipValidation.js";
 
@@ -344,7 +344,7 @@ export class SeenGossipBlockInput {
               dataColumns: dataColumnsCache.size,
             };
             if (dataColumnRecover == null) {
-              this.logger.debug("No data column recover configured, skipping recovery", logCtx);
+              this.logger.debug("No data column recover configured, skipping recover", logCtx);
               return;
             }
             const shouldResolve = await recoverDataColumnSidecars(
@@ -355,6 +355,16 @@ export class SeenGossipBlockInput {
             );
             if (shouldResolve) {
               resolveAvailabilityAndBlockInput(BlockInputAvailabilitySource.RECOVERED);
+              // Publish columns if and only if subscribed to them
+              const sampledColumns = this.custodyConfig.sampledColumns.map((columnIndex) => {
+                const dataColumn = dataColumnsCache.get(columnIndex)?.dataColumn;
+                if (!dataColumn) {
+                  throw Error(`After recover, missing data column for index=${columnIndex} in cache`);
+                }
+                return dataColumn;
+              });
+
+              this.emitter.emit(ChainEvent.publishDataColumns, sampledColumns);
               this.logger.verbose("Recovered data column sidecars and resolved availability", logCtx);
             } else {
               if (shouldResolve === false) {

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -315,10 +315,6 @@ export class SeenGossipBlockInput {
         const recovered = recoverDataColumnSidecars(dataColumnsCache);
         if (hasSampledDataColumns(this.custodyConfig, dataColumnsCache)) {
           const allDataColumns = getBlockInputDataColumns(dataColumnsCache, this.custodyConfig.sampledColumns);
-          // TODO(das): should not use syncUnknownBlock metrics here
-          metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({
-            source: recovered ? BlockInputAvailabilitySource.RECOVERED : BlockInputAvailabilitySource.GOSSIP,
-          });
           const {dataColumns} = allDataColumns;
           const blockData: BlockInputDataColumns = {
             fork: cachedData.fork,
@@ -326,7 +322,9 @@ export class SeenGossipBlockInput {
             dataColumnsSource: DataColumnsSource.gossip,
           };
           resolveAvailability(blockData);
-          metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
+          // TODO(das): should not use syncUnknownBlock metrics here
+          const source = recovered ? BlockInputAvailabilitySource.RECOVERED : BlockInputAvailabilitySource.GOSSIP;
+          metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source});
 
           const blockInput = getBlockInput.availableData(config, signedBlock, BlockSource.gossip, blockData);
 

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -6,6 +6,8 @@ import {Logger, pruneSetToMax} from "@lodestar/utils";
 
 import {IExecutionEngine} from "../../execution/index.js";
 import {Metrics} from "../../metrics/index.js";
+import {DataColumnRecover} from "../../network/dataColumn/index.js";
+import {IClock} from "../../util/clock.js";
 import {
   CustodyConfig,
   getDataColumnsFromExecution,
@@ -91,6 +93,7 @@ export class SeenGossipBlockInput {
   private readonly blockInputCache = new Map<RootHex, BlockInputCacheType>();
   private readonly custodyConfig: CustodyConfig;
   private readonly executionEngine: IExecutionEngine;
+  private readonly clock: IClock;
   private readonly emitter: ChainEventEmitter;
   private readonly logger: Logger;
 
@@ -98,10 +101,12 @@ export class SeenGossipBlockInput {
     custodyConfig: CustodyConfig,
     executionEngine: IExecutionEngine,
     emitter: ChainEventEmitter,
+    clock: IClock,
     logger: Logger
   ) {
     this.custodyConfig = custodyConfig;
     this.executionEngine = executionEngine;
+    this.clock = clock;
     this.emitter = emitter;
     this.logger = logger;
   }
@@ -146,6 +151,7 @@ export class SeenGossipBlockInput {
   getGossipBlockInput(
     config: ChainForkConfig,
     gossipedInput: GossipedBlockInput,
+    dataColumnRecover: DataColumnRecover | null,
     metrics: Metrics | null
   ): GossipBlockInputResponse {
     let blockHex: RootHex;
@@ -312,10 +318,8 @@ export class SeenGossipBlockInput {
           };
         }
 
-        const recovered = recoverDataColumnSidecars(dataColumnsCache, metrics);
-        if (hasSampledDataColumns(this.custodyConfig, dataColumnsCache)) {
+        const resolveAvailabilityAndBlockInput = (source: BlockInputAvailabilitySource) => {
           const allDataColumns = getBlockInputDataColumns(dataColumnsCache, this.custodyConfig.sampledColumns);
-          const {dataColumns} = allDataColumns;
           const blockData: BlockInputDataColumns = {
             fork: cachedData.fork,
             ...allDataColumns,
@@ -323,12 +327,48 @@ export class SeenGossipBlockInput {
           };
           resolveAvailability(blockData);
           // TODO(das): should not use syncUnknownBlock metrics here
-          const source = recovered ? BlockInputAvailabilitySource.RECOVERED : BlockInputAvailabilitySource.GOSSIP;
           metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source});
 
           const blockInput = getBlockInput.availableData(config, signedBlock, BlockSource.gossip, blockData);
-
           resolveBlockInput(blockInput);
+          return blockInput;
+        };
+
+        // const recovered = recoverDataColumnSidecars(dataColumnsCache, metrics);
+        if (dataColumnsCache.size >= NUMBER_OF_COLUMNS / 2) {
+          callInNextEventLoop(async () => {
+            const logCtx = {
+              blockHex,
+              slot,
+              dataColumns: dataColumnsCache.size,
+            };
+            if (dataColumnRecover == null) {
+              this.logger.debug("No data column recover configured, skipping recovery", logCtx);
+              return;
+            }
+            const shouldResolve = await recoverDataColumnSidecars(
+              dataColumnsCache,
+              dataColumnRecover,
+              this.clock,
+              metrics
+            );
+            if (shouldResolve) {
+              resolveAvailabilityAndBlockInput(BlockInputAvailabilitySource.RECOVERED);
+              this.logger.verbose("Recovered data column sidecars and resolved availability", logCtx);
+            } else {
+              if (shouldResolve === false) {
+                this.logger.verbose("Recovered data column sidecars but it's late to resolve availability", logCtx);
+              } else {
+                // shouldResolve is null
+                this.logger.verbose("Failed or did not attempt to recover data column sidecars", logCtx);
+              }
+            }
+          });
+        }
+        if (hasSampledDataColumns(this.custodyConfig, dataColumnsCache)) {
+          const blockInput = resolveAvailabilityAndBlockInput(BlockInputAvailabilitySource.GOSSIP);
+          const allDataColumns = getBlockInputDataColumns(dataColumnsCache, this.custodyConfig.sampledColumns);
+          const {dataColumns} = allDataColumns;
           return {
             blockInput,
             blockInputMeta: {

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -312,7 +312,7 @@ export class SeenGossipBlockInput {
           };
         }
 
-        const recovered = recoverDataColumnSidecars(dataColumnsCache);
+        const recovered = recoverDataColumnSidecars(dataColumnsCache, metrics);
         if (hasSampledDataColumns(this.custodyConfig, dataColumnsCache)) {
           const allDataColumns = getBlockInputDataColumns(dataColumnsCache, this.custodyConfig.sampledColumns);
           const {dataColumns} = allDataColumns;

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -6,7 +6,12 @@ import {Logger, pruneSetToMax} from "@lodestar/utils";
 
 import {IExecutionEngine} from "../../execution/index.js";
 import {Metrics} from "../../metrics/index.js";
-import {CustodyConfig, getDataColumnsFromExecution, hasSampledDataColumns} from "../../util/dataColumns.js";
+import {
+  CustodyConfig,
+  getDataColumnsFromExecution,
+  hasSampledDataColumns,
+  recoverDataColumnSidecars,
+} from "../../util/dataColumns.js";
 import {callInNextEventLoop} from "../../util/eventLoop.js";
 import {
   BlobsSource,
@@ -29,6 +34,7 @@ import {GossipAction} from "../errors/gossipValidation.js";
 
 export enum BlockInputAvailabilitySource {
   GOSSIP = "gossip",
+  RECOVERED = "recovered",
   UNKNOWN_SYNC = "unknown_sync",
 }
 
@@ -306,9 +312,13 @@ export class SeenGossipBlockInput {
           };
         }
 
+        const recovered = recoverDataColumnSidecars(dataColumnsCache);
         if (hasSampledDataColumns(this.custodyConfig, dataColumnsCache)) {
           const allDataColumns = getBlockInputDataColumns(dataColumnsCache, this.custodyConfig.sampledColumns);
-          metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({source: BlockInputAvailabilitySource.GOSSIP});
+          // TODO(das): should not use syncUnknownBlock metrics here
+          metrics?.syncUnknownBlock.resolveAvailabilitySource.inc({
+            source: recovered ? BlockInputAvailabilitySource.RECOVERED : BlockInputAvailabilitySource.GOSSIP,
+          });
           const {dataColumns} = allDataColumns;
           const blockData: BlockInputDataColumns = {
             fork: cachedData.fork,

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -285,7 +285,7 @@ export class SeenGossipBlockInput {
       }
 
       if (cachedData.fork === ForkName.fulu) {
-        const {dataColumnsCache, resolveAvailability} = cachedData as CachedDataColumns;
+        const {dataColumnsCache, resolveAvailability, calledRecover} = cachedData as CachedDataColumns;
 
         // block is available, check if all blobs have shown up
         const {slot} = signedBlock.message;
@@ -334,8 +334,9 @@ export class SeenGossipBlockInput {
           return blockInput;
         };
 
-        // const recovered = recoverDataColumnSidecars(dataColumnsCache, metrics);
-        if (dataColumnsCache.size >= NUMBER_OF_COLUMNS / 2) {
+        if (dataColumnsCache.size >= NUMBER_OF_COLUMNS / 2 && !calledRecover) {
+          // should call once per slot
+          cachedData.calledRecover = true;
           callInNextEventLoop(async () => {
             const logCtx = {
               blockHex,
@@ -506,6 +507,7 @@ export function getEmptyBlockInputCacheEntry(fork: ForkName, globalCacheId: numb
       availabilityPromise,
       resolveAvailability,
       cacheId: ++globalCacheId,
+      calledRecover: false,
     };
     return {fork, blockInputPromise, resolveBlockInput, cachedData};
   }

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -726,7 +726,7 @@ export function createLodestarMetrics(
       recoverTime: register.histogram({
         name: "lodestar_recover_data_column_sidecar_recover_time_seconds",
         help: "Time elapsed to recover data column sidecar",
-        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
+        buckets: [1, 2, 4, 6, 8],
       }),
       result: register.gauge<{result: RecoverResult}>({
         name: "lodestar_recover_data_column_sidecar_recover_result_total",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -716,6 +716,17 @@ export function createLodestarMetrics(
         buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
       }),
     },
+    gossipDataColumnSidecar: {
+      recoverTime: register.histogram({
+        name: "lodestar_gossip_data_column_sidecar_recover_time_seconds",
+        help: "Time elapsed to recover data column sidecar",
+        buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
+      }),
+      recoverFailed: register.gauge({
+        name: "lodestar_gossip_data_column_sidecar_recover_failed_total",
+        help: "Total count of failed recoveries of data column sidecars",
+      }),
+    },
     importBlock: {
       persistBlockNoSerializedDataCount: register.gauge({
         name: "lodestar_import_block_persist_block_no_serialized_data_count",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -20,6 +20,7 @@ import {BackfillSyncMethod} from "../../sync/backfill/backfill.js";
 import {PendingBlockType} from "../../sync/index.js";
 import {PeerSyncType, RangeSyncType} from "../../sync/utils/remoteSyncType.js";
 import {AllocSource} from "../../util/bufferPool.js";
+import {RecoverResult} from "../../util/dataColumns.js";
 import {LodestarMetadata} from "../options.js";
 import {RegistryMetricCreator} from "../utils/registryMetricCreator.js";
 
@@ -716,15 +717,21 @@ export function createLodestarMetrics(
         buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
       }),
     },
-    gossipDataColumnSidecar: {
+    recoverDataColumnSidecars: {
+      secFromSlot: register.histogram({
+        name: "lodestar_recover_data_column_sidecar_recover_timer_from_slot",
+        help: "Time elapsed between block slot time and the time data column sidecar recovered",
+        buckets: [2, 4, 6, 8, 10, 12],
+      }),
       recoverTime: register.histogram({
-        name: "lodestar_gossip_data_column_sidecar_recover_time_seconds",
+        name: "lodestar_recover_data_column_sidecar_recover_time_seconds",
         help: "Time elapsed to recover data column sidecar",
         buckets: [0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 4],
       }),
-      recoverFailed: register.gauge({
-        name: "lodestar_gossip_data_column_sidecar_recover_failed_total",
-        help: "Total count of failed recoveries of data column sidecars",
+      result: register.gauge<{result: RecoverResult}>({
+        name: "lodestar_recover_data_column_sidecar_recover_result_total",
+        help: "Total count of recover result of data column sidecars",
+        labelNames: ["result"],
       }),
     },
     importBlock: {

--- a/packages/beacon-node/src/network/dataColumn/index.ts
+++ b/packages/beacon-node/src/network/dataColumn/index.ts
@@ -1,0 +1,67 @@
+import path from "node:path";
+import {ModuleThread, Thread, spawn} from "@chainsafe/threads";
+import {LoggerNode} from "@lodestar/logger/node";
+import {fulu} from "@lodestar/types";
+import {
+  DataColumnRecoverInitModules,
+  DataColumnRecoverModules,
+  DataColumnRecoverWorkerApi,
+  DataColumnWorkerData,
+} from "./types.js";
+
+// Worker constructor consider the path relative to the current working directory
+const WORKER_DIR = process.env.NODE_ENV === "test" ? "../../../../lib/network/dataColumn" : "./";
+
+export class DataColumnRecover implements DataColumnRecoverWorkerApi {
+  private readonly api: ModuleThread<DataColumnRecoverWorkerApi>;
+  private readonly logger: LoggerNode;
+
+  constructor(modules: DataColumnRecoverModules) {
+    this.api = modules.api;
+    this.logger = modules.logger;
+    modules.signal?.addEventListener("abort", () => this.close(), {once: true});
+  }
+
+  static async init(modules: DataColumnRecoverInitModules): Promise<DataColumnRecover> {
+    const workerData: DataColumnWorkerData = {
+      loggerOpts: modules.logger.toOpts(),
+      metrics: Boolean(modules.metrics),
+    };
+    const worker = new Worker(path.join(WORKER_DIR, "worker.js"), {
+      workerData,
+    } as ConstructorParameters<typeof Worker>[1]);
+
+    const api = await spawn<DataColumnRecoverWorkerApi>(worker, {
+      // A Lodestar Node may do very expensive task at start blocking the event loop and causing
+      // the initialization to timeout. The number below is big enough to almost disable the timeout
+      timeout: 5 * 60 * 1000,
+    });
+
+    return new DataColumnRecover({...modules, api});
+  }
+
+  async recoverDataColumnSidecars(
+    partialSidecars: Map<number, fulu.DataColumnSidecar>
+  ): Promise<fulu.DataColumnSidecars | null> {
+    return this.api.recoverDataColumnSidecars(partialSidecars);
+  }
+
+  async close(): Promise<void> {
+    await this.api.close();
+    this.logger.debug("Terminating data column recover worker");
+    await Thread.terminate(this.api);
+    this.logger.debug("Terminated data column recover worker");
+  }
+
+  async scrapeMetrics(): Promise<string> {
+    return this.api.scrapeMetrics();
+  }
+
+  async writeProfile(durationMs: number, dirpath: string): Promise<string> {
+    return this.api.writeProfile(durationMs, dirpath);
+  }
+
+  async writeHeapSnapshot(prefix: string, dirpath: string): Promise<string> {
+    return this.api.writeHeapSnapshot(prefix, dirpath);
+  }
+}

--- a/packages/beacon-node/src/network/dataColumn/index.ts
+++ b/packages/beacon-node/src/network/dataColumn/index.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import {ModuleThread, Thread, spawn} from "@chainsafe/threads";
+import {ModuleThread, Worker, Thread, spawn} from "@chainsafe/threads";
 import {LoggerNode} from "@lodestar/logger/node";
 import {fulu} from "@lodestar/types";
 import {

--- a/packages/beacon-node/src/network/dataColumn/index.ts
+++ b/packages/beacon-node/src/network/dataColumn/index.ts
@@ -19,7 +19,6 @@ export class DataColumnRecover implements DataColumnRecoverWorkerApi {
   constructor(modules: DataColumnRecoverModules) {
     this.api = modules.api;
     this.logger = modules.logger;
-    modules.signal?.addEventListener("abort", () => this.close(), {once: true});
   }
 
   static async init(modules: DataColumnRecoverInitModules): Promise<DataColumnRecover> {

--- a/packages/beacon-node/src/network/dataColumn/index.ts
+++ b/packages/beacon-node/src/network/dataColumn/index.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import {ModuleThread, Worker, Thread, spawn} from "@chainsafe/threads";
+import {ModuleThread, Thread, Worker, spawn} from "@chainsafe/threads";
 import {LoggerNode} from "@lodestar/logger/node";
 import {fulu} from "@lodestar/types";
 import {
@@ -42,7 +42,14 @@ export class DataColumnRecover implements DataColumnRecoverWorkerApi {
   async recoverDataColumnSidecars(
     partialSidecars: Map<number, fulu.DataColumnSidecar>
   ): Promise<fulu.DataColumnSidecars | null> {
-    return this.api.recoverDataColumnSidecars(partialSidecars);
+    this.logger.verbose("Recovering data column sidecars", {partialSidecars: partialSidecars.size});
+    const result = await this.api.recoverDataColumnSidecars(partialSidecars);
+    if (result == null) {
+      this.logger.warn("Failed to recover data column sidecars");
+    } else {
+      this.logger.verbose("Recovered data column sidecars", {fullSidecars: result.length});
+    }
+    return result;
   }
 
   async close(): Promise<void> {

--- a/packages/beacon-node/src/network/dataColumn/index.ts
+++ b/packages/beacon-node/src/network/dataColumn/index.ts
@@ -25,6 +25,8 @@ export class DataColumnRecover implements DataColumnRecoverWorkerApi {
     const workerData: DataColumnWorkerData = {
       loggerOpts: modules.logger.toOpts(),
       metrics: Boolean(modules.metrics),
+      trustedSetupPrecompute: modules.trustedSetupPrecompute,
+      trustedSetup: modules.trustedSetup,
     };
     const worker = new Worker(path.join(WORKER_DIR, "worker.js"), {
       workerData,

--- a/packages/beacon-node/src/network/dataColumn/index.ts
+++ b/packages/beacon-node/src/network/dataColumn/index.ts
@@ -44,14 +44,7 @@ export class DataColumnRecover implements DataColumnRecoverWorkerApi {
   async recoverDataColumnSidecars(
     partialSidecars: Map<number, fulu.DataColumnSidecar>
   ): Promise<fulu.DataColumnSidecars | null> {
-    this.logger.verbose("Recovering data column sidecars", {partialSidecars: partialSidecars.size});
-    const result = await this.api.recoverDataColumnSidecars(partialSidecars);
-    if (result == null) {
-      this.logger.warn("Failed to recover data column sidecars");
-    } else {
-      this.logger.verbose("Recovered data column sidecars", {fullSidecars: result.length});
-    }
-    return result;
+    return this.api.recoverDataColumnSidecars(partialSidecars);
   }
 
   async close(): Promise<void> {

--- a/packages/beacon-node/src/network/dataColumn/types.ts
+++ b/packages/beacon-node/src/network/dataColumn/types.ts
@@ -6,7 +6,6 @@ import {Metrics} from "../../metrics/index.js";
 export type DataColumnRecoverInitModules = {
   logger: LoggerNode;
   metrics: Metrics | null;
-  signal?: AbortSignal;
 };
 
 export type DataColumnRecoverModules = DataColumnRecoverInitModules & {

--- a/packages/beacon-node/src/network/dataColumn/types.ts
+++ b/packages/beacon-node/src/network/dataColumn/types.ts
@@ -1,0 +1,42 @@
+import {ModuleThread} from "@chainsafe/threads";
+import {LoggerNode, LoggerNodeOpts} from "@lodestar/logger/node";
+import {fulu} from "@lodestar/types";
+import {Metrics} from "../../metrics/index.js";
+
+export type DataColumnRecoverInitModules = {
+  logger: LoggerNode;
+  metrics: Metrics | null;
+  signal?: AbortSignal;
+};
+
+export type DataColumnRecoverModules = DataColumnRecoverInitModules & {
+  api: ModuleThread<DataColumnRecoverWorkerApi>;
+};
+
+/**
+ * data_column worker constructor data
+ */
+export interface DataColumnWorkerData {
+  metrics: boolean;
+  loggerOpts: LoggerNodeOpts;
+}
+
+/**
+ * API exposed by the data_column worker
+ */
+export type DataColumnRecoverWorkerApi = {
+  /** See https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/das-core.md#recover_matrix */
+  recoverDataColumnSidecars(
+    partialSidecars: Map<number, fulu.DataColumnSidecar>
+  ): Promise<fulu.DataColumnSidecars | null>;
+
+  close(): Promise<void>;
+
+  /** Prometheus metrics string */
+  scrapeMetrics(): Promise<string>;
+
+  /** write profile to disc */
+  writeProfile(durationMs: number, dirpath: string): Promise<string>;
+  /** write heap snapshot to disc */
+  writeHeapSnapshot(prefix: string, dirpath: string): Promise<string>;
+};

--- a/packages/beacon-node/src/network/dataColumn/types.ts
+++ b/packages/beacon-node/src/network/dataColumn/types.ts
@@ -6,6 +6,16 @@ import {Metrics} from "../../metrics/index.js";
 export type DataColumnRecoverInitModules = {
   logger: LoggerNode;
   metrics: Metrics | null;
+  /*
+   * This is the window size for the windowed multiplication in proof
+   * generation. The larger wbits is, the faster the MSM will be, but the
+   * size of the precomputed table will grow exponentially. With 8 bits, the
+   * tables are 96 MiB; with 9 bits, the tables are 192 MiB and so forth.
+   * From our testing, there are diminishing returns after 8 bits.
+   */
+  trustedSetupPrecompute?: number;
+  /** Option to load a custom kzg trusted setup in txt format */
+  trustedSetup?: string;
 };
 
 export type DataColumnRecoverModules = DataColumnRecoverInitModules & {
@@ -18,6 +28,16 @@ export type DataColumnRecoverModules = DataColumnRecoverInitModules & {
 export interface DataColumnWorkerData {
   metrics: boolean;
   loggerOpts: LoggerNodeOpts;
+  /*
+   * This is the window size for the windowed multiplication in proof
+   * generation. The larger wbits is, the faster the MSM will be, but the
+   * size of the precomputed table will grow exponentially. With 8 bits, the
+   * tables are 96 MiB; with 9 bits, the tables are 192 MiB and so forth.
+   * From our testing, there are diminishing returns after 8 bits.
+   */
+  trustedSetupPrecompute?: number;
+  /** Option to load a custom kzg trusted setup in txt format */
+  trustedSetup?: string;
 }
 
 /**

--- a/packages/beacon-node/src/network/dataColumn/worker.ts
+++ b/packages/beacon-node/src/network/dataColumn/worker.ts
@@ -7,13 +7,20 @@ import {fulu} from "@lodestar/types";
 import {Gauge, Histogram} from "@lodestar/utils";
 import {RegistryMetricCreator, collectNodeJSMetrics} from "../../metrics/index.js";
 import {recoverDataColumnSidecars} from "../../util/blobs.js";
+import {initCKZG, loadEthereumTrustedSetup} from "../../util/kzg.js";
 import {profileNodeJS, writeHeapSnapshot} from "../../util/profile.js";
 import {DataColumnRecoverWorkerApi, DataColumnWorkerData} from "./types.js";
 
 const workerData = worker.workerData as DataColumnWorkerData;
+const {loggerOpts, trustedSetupPrecompute, trustedSetup} = workerData;
 
-const logger = getNodeLogger(workerData.loggerOpts);
+const logger = getNodeLogger(loggerOpts);
 const abortController = new AbortController();
+
+await initCKZG();
+loadEthereumTrustedSetup(trustedSetupPrecompute, trustedSetup);
+
+logger.info("data_column worker thread: loaded c-kzg trusted setup the same to main thread");
 
 // Set up metrics
 let metricsRegistry: RegistryMetricCreator | undefined;

--- a/packages/beacon-node/src/network/dataColumn/worker.ts
+++ b/packages/beacon-node/src/network/dataColumn/worker.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import worker from "node:worker_threads";
+import {expose} from "@chainsafe/threads";
+import {getNodeLogger} from "@lodestar/logger/node";
+import {fulu} from "@lodestar/types";
+import {Gauge, Histogram} from "@lodestar/utils";
+import {RegistryMetricCreator, collectNodeJSMetrics} from "../../metrics/index.js";
+import {recoverDataColumnSidecars} from "../../util/blobs.js";
+import {profileNodeJS, writeHeapSnapshot} from "../../util/profile.js";
+import {DataColumnRecoverWorkerApi, DataColumnWorkerData} from "./types.js";
+
+const workerData = worker.workerData as DataColumnWorkerData;
+
+const logger = getNodeLogger(workerData.loggerOpts);
+const abortController = new AbortController();
+
+// Set up metrics
+let metricsRegistry: RegistryMetricCreator | undefined;
+let recoverTime: Histogram | undefined;
+let recoverFailed: Gauge | undefined;
+let partialDataColumnCount: Gauge | undefined;
+let closeMetrics: () => void | undefined;
+if (workerData.metrics) {
+  metricsRegistry = new RegistryMetricCreator();
+  closeMetrics = collectNodeJSMetrics(metricsRegistry, "data_column_worker_");
+  abortController.signal.addEventListener("abort", closeMetrics, {once: true});
+  recoverTime = metricsRegistry.histogram({
+    name: "lodestar_data_column_sidecar_recover_time_seconds",
+    help: "Time elapsed to recover data column sidecar",
+    buckets: [1, 2, 3, 4, 8],
+  });
+  recoverFailed = metricsRegistry.gauge({
+    name: "lodestar_data_column_sidecar_recover_failed_total",
+    help: "Total count of failed recoveries of data column sidecars",
+  });
+  partialDataColumnCount = metricsRegistry.gauge({
+    name: "lodestar_data_column_partial_data_column_count",
+    help: "Total partial data columns per call",
+  });
+}
+
+const module: DataColumnRecoverWorkerApi = {
+  recoverDataColumnSidecars: (
+    partialSidecars: Map<number, fulu.DataColumnSidecar>
+  ): Promise<fulu.DataColumnSidecars | null> => {
+    partialDataColumnCount?.set(partialSidecars.size);
+    const timer = recoverTime?.startTimer();
+    const result = recoverDataColumnSidecars(partialSidecars);
+    timer?.();
+    if (result == null) {
+      recoverFailed?.inc();
+    }
+    return Promise.resolve(result);
+  },
+  async close() {
+    abortController.abort();
+  },
+  async scrapeMetrics(): Promise<string> {
+    return (await metricsRegistry?.metrics()) ?? "";
+  },
+  writeProfile: async (durationMs: number, dirpath: string) => {
+    const profile = await profileNodeJS(durationMs);
+    const filePath = path.join(dirpath, `data_column_recover_thread_${new Date().toISOString()}.cpuprofile`);
+    fs.writeFileSync(filePath, profile);
+    return filePath;
+  },
+  writeHeapSnapshot: async (prefix: string, dirpath: string) => {
+    return writeHeapSnapshot(prefix, dirpath);
+  },
+};
+
+expose(module);
+
+logger.info("data_column worker started");

--- a/packages/beacon-node/src/network/dataColumn/worker.ts
+++ b/packages/beacon-node/src/network/dataColumn/worker.ts
@@ -35,7 +35,7 @@ if (workerData.metrics) {
     help: "Total count of failed recoveries of data column sidecars",
   });
   partialDataColumnCount = metricsRegistry.gauge({
-    name: "lodestar_data_column_partial_data_column_count",
+    name: "lodestar_data_column_sidecar_recover_partial_data_column_count",
     help: "Total partial data columns per call",
   });
 }

--- a/packages/beacon-node/src/network/dataColumn/worker.ts
+++ b/packages/beacon-node/src/network/dataColumn/worker.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import worker from "node:worker_threads";
-import {expose} from "@chainsafe/threads";
+import {expose} from "@chainsafe/threads/worker";
 import {getNodeLogger} from "@lodestar/logger/node";
 import {fulu} from "@lodestar/types";
 import {Gauge, Histogram} from "@lodestar/utils";

--- a/packages/beacon-node/src/network/dataColumn/worker.ts
+++ b/packages/beacon-node/src/network/dataColumn/worker.ts
@@ -51,12 +51,18 @@ const module: DataColumnRecoverWorkerApi = {
   recoverDataColumnSidecars: (
     partialSidecars: Map<number, fulu.DataColumnSidecar>
   ): Promise<fulu.DataColumnSidecars | null> => {
+    logger.verbose("data_column_recover worker: recovering data column sidecars", {
+      partialSidecars: partialSidecars.size,
+    });
     partialDataColumnCount?.set(partialSidecars.size);
     const timer = recoverTime?.startTimer();
     const result = recoverDataColumnSidecars(partialSidecars);
     timer?.();
     if (result == null) {
+      logger.debug("data_column_recover worker: failed to recover data column sidecars");
       recoverFailed?.inc();
+    } else {
+      logger.verbose("data_column_recover worker: recovered data column sidecars", {fullSidecars: result.length});
     }
     return Promise.resolve(result);
   },

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -204,6 +204,8 @@ export class Network implements INetwork {
       dataColumnRecover = await DataColumnRecover.init({
         logger,
         metrics,
+        trustedSetupPrecompute: chain.opts.trustedSetupPrecompute,
+        trustedSetup: chain.opts.trustedSetup,
       });
       logger.verbose("DataColumnRecover worker initialized", {
         sampledColumns: chain.custodyConfig.sampledColumns.length,

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -39,6 +39,7 @@ import {PeerIdStr, peerIdToString} from "../util/peerId.js";
 import {promiseAllMaybeAsync} from "../util/promises.js";
 import {BlobSidecarsByRootRequest} from "../util/types.js";
 import {INetworkCore, NetworkCore, WorkerNetworkCore} from "./core/index.js";
+import {DataColumnRecover} from "./dataColumn/index.js";
 import {INetworkEventBus, NetworkEvent, NetworkEventBus, NetworkEventData} from "./events.js";
 import {getActiveForks} from "./forks.js";
 import {GossipHandlers, GossipTopicMap, GossipType, GossipTypeMap} from "./gossip/index.js";
@@ -69,6 +70,7 @@ type NetworkModules = {
   aggregatorTracker: AggregatorTracker;
   networkProcessor: NetworkProcessor;
   core: INetworkCore;
+  dataColumnRecover: DataColumnRecover | null;
 };
 
 export type NetworkInitModules = {
@@ -110,6 +112,7 @@ export class Network implements INetwork {
   private readonly networkProcessor: NetworkProcessor;
   private readonly core: INetworkCore;
   private readonly aggregatorTracker: AggregatorTracker;
+  private readonly dataColumnRecover: DataColumnRecover | null;
 
   private subscribedToCoreTopics = false;
   private connectedPeers = new Map<PeerIdStr, ColumnIndex[]>();
@@ -127,6 +130,7 @@ export class Network implements INetwork {
     this.networkProcessor = modules.networkProcessor;
     this.core = modules.core;
     this.aggregatorTracker = modules.aggregatorTracker;
+    this.dataColumnRecover = modules.dataColumnRecover;
 
     this.events.on(NetworkEvent.peerConnected, this.onPeerConnected);
     this.events.on(NetworkEvent.peerDisconnected, this.onPeerDisconnected);
@@ -195,8 +199,23 @@ export class Network implements INetwork {
           activeValidatorCount,
         });
 
+    let dataColumnRecover: DataColumnRecover | null = null;
+    if (chain.custodyConfig.sampledColumns.length > NUMBER_OF_COLUMNS / 2) {
+      dataColumnRecover = await DataColumnRecover.init({
+        logger,
+        metrics,
+      });
+      logger.verbose("DataColumnRecover worker initialized", {
+        sampledColumns: chain.custodyConfig.sampledColumns.length,
+      });
+    } else {
+      logger.verbose("DataColumnRecover worker not initialized", {
+        sampledColumns: chain.custodyConfig.sampledColumns.length,
+      });
+    }
+
     const networkProcessor = new NetworkProcessor(
-      {chain, db, config, logger, metrics, events, gossipHandlers, core, aggregatorTracker},
+      {chain, db, config, logger, metrics, events, gossipHandlers, core, aggregatorTracker, dataColumnRecover},
       opts
     );
 
@@ -214,6 +233,7 @@ export class Network implements INetwork {
       aggregatorTracker,
       networkProcessor,
       core,
+      dataColumnRecover,
     });
   }
 
@@ -233,6 +253,8 @@ export class Network implements INetwork {
     this.chain.emitter.off(ChainEvent.updateTargetGroupCount, this.onTargetGroupCountUpdated);
     this.chain.emitter.off(ChainEvent.updateAdvertisedGroupCount, this.onAdvertisedGroupCountUpdated);
     this.chain.emitter.off(ChainEvent.publishDataColumns, this.onPublishDataColumns);
+    await this.dataColumnRecover?.close();
+    this.logger.debug("data column recover worker closed");
     await this.core.close();
 
     // Used only for sleep() statements

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -263,7 +263,13 @@ export class Network implements INetwork {
   }
 
   async scrapeMetrics(): Promise<string> {
-    return this.core.scrapeMetrics();
+    const coreMetrics = await this.core.scrapeMetrics();
+    if (this.dataColumnRecover) {
+      const dataColumnRecoverMetrics = await this.dataColumnRecover.scrapeMetrics();
+      return `${coreMetrics}\n\n${dataColumnRecoverMetrics}`;
+    }
+
+    return coreMetrics;
   }
 
   /**

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -59,6 +59,7 @@ import {validateLightClientOptimisticUpdate} from "../../chain/validation/lightC
 import {OpSource} from "../../chain/validatorMonitor.js";
 import {Metrics} from "../../metrics/index.js";
 import {INetworkCore} from "../core/index.js";
+import {DataColumnRecover} from "../dataColumn/index.js";
 import {NetworkEvent, NetworkEventBus} from "../events.js";
 import {
   BatchGossipHandlers,
@@ -88,6 +89,7 @@ export type ValidatorFnsModules = {
   events: NetworkEventBus;
   aggregatorTracker: AggregatorTracker;
   core: INetworkCore;
+  dataColumnRecover: DataColumnRecover | null;
 };
 
 const MAX_UNKNOWN_BLOCK_ROOT_RETRIES = 1;
@@ -116,7 +118,7 @@ export function getGossipHandlers(modules: ValidatorFnsModules, options: GossipH
  * We only have a choice to do batch validation for beacon_attestation topic.
  */
 function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHandlerOpts): SequentialGossipHandlers {
-  const {chain, config, metrics, events, logger, core} = modules;
+  const {chain, config, metrics, events, logger, core, dataColumnRecover} = modules;
 
   async function validateBeaconBlock(
     signedBlock: SignedBeaconBlock,
@@ -138,6 +140,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         type: GossipedInputType.block,
         signedBlock,
       },
+      dataColumnRecover,
       metrics
     );
     const blockInput = blockInputRes.blockInput;
@@ -214,6 +217,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         type: GossipedInputType.blob,
         blobSidecar,
       },
+      dataColumnRecover,
       metrics
     );
 
@@ -285,6 +289,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         dataColumnSidecar,
         dataColumnBytes,
       },
+      dataColumnRecover,
       metrics
     );
 

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -11,6 +11,7 @@ import {Metrics} from "../../metrics/metrics.js";
 import {ClockEvent} from "../../util/clock.js";
 import {callInNextEventLoop} from "../../util/eventLoop.js";
 import {PeerIdStr} from "../../util/peerId.js";
+import {DataColumnRecover} from "../dataColumn/index.js";
 import {NetworkEvent, NetworkEventBus} from "../events.js";
 import {
   GossipHandlers,
@@ -34,6 +35,7 @@ export type NetworkProcessorModules = ValidatorFnsModules &
     events: NetworkEventBus;
     logger: Logger;
     metrics: Metrics | null;
+    dataColumnRecover: DataColumnRecover | null;
     // Optionally pass custom GossipHandlers, for testing
     gossipHandlers?: GossipHandlers;
   };

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -2,7 +2,6 @@ import {digest as sha256Digest} from "@chainsafe/as-sha256";
 import {Tree} from "@chainsafe/persistent-merkle-tree";
 import {ChainForkConfig} from "@lodestar/config";
 import {
-  DATA_COLUMN_SIDECAR_SUBNET_COUNT,
   ForkAll,
   ForkName,
   KZG_COMMITMENTS_GINDEX,

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -2,6 +2,7 @@ import {digest as sha256Digest} from "@chainsafe/as-sha256";
 import {Tree} from "@chainsafe/persistent-merkle-tree";
 import {ChainForkConfig} from "@lodestar/config";
 import {
+  DATA_COLUMN_SIDECAR_SUBNET_COUNT,
   ForkAll,
   ForkName,
   KZG_COMMITMENTS_GINDEX,
@@ -109,4 +110,83 @@ export function computeDataColumnSidecars(
       kzgCommitmentsInclusionProof,
     };
   });
+}
+
+/**
+ * If the node obtains 50%+ of all the columns, it SHOULD reconstruct the full data matrix via the recover_matrix helper
+ * See https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/das-core.md#recover_matrix
+ */
+export function recoverDataColumnSidecars(
+  partialSidecars: Map<number, fulu.DataColumnSidecar>
+): fulu.DataColumnSidecars | null {
+  const columnCount = partialSidecars.size;
+  if (columnCount < NUMBER_OF_COLUMNS / 2) {
+    // We don't have enough columns to recover
+    return null;
+  }
+
+  if (columnCount === NUMBER_OF_COLUMNS) {
+    // full columns, no need to recover
+    return Array.from(partialSidecars.values());
+  }
+
+  const firstDataColumn = partialSidecars.values().next().value;
+  if (firstDataColumn == null) {
+    // should not happen because we check the size of the cache before this
+    throw new Error("No data column found in cache to recover from");
+  }
+  const blobCount = firstDataColumn.kzgCommitments.length;
+
+  const fullColumns: Array<Uint8Array[]> = Array.from(
+    {length: NUMBER_OF_COLUMNS},
+    () => new Array<Uint8Array>(blobCount)
+  );
+  const blobProofs: Array<Uint8Array[]> = Array.from({length: blobCount});
+  try {
+    // https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/das-core.md#recover_matrix
+    for (let blobIndex = 0; blobIndex < blobCount; blobIndex++) {
+      const cellIndices: number[] = [];
+      const cells: Uint8Array[] = [];
+      for (const [columnIndex, dataColumn] of partialSidecars.entries()) {
+        cellIndices.push(columnIndex);
+        cells.push(dataColumn.column[blobIndex]);
+      }
+      // recovered cells and proofs are of the same row/blob, their length should be NUMBER_OF_COLUMNS
+      const [recoveredCells, recoveredProofs] = ckzg.recoverCellsAndKzgProofs(cellIndices, cells);
+      if (recoveredCells.length !== NUMBER_OF_COLUMNS || recoveredProofs.length !== NUMBER_OF_COLUMNS) {
+        // recovered cells or proofs is not of the expected length, we cannot recover
+        return null;
+      }
+
+      for (let columnIndex = 0; columnIndex < NUMBER_OF_COLUMNS; columnIndex++) {
+        fullColumns[columnIndex][blobIndex] = recoveredCells[columnIndex];
+      }
+      blobProofs[blobIndex] = recoveredProofs;
+    }
+  } catch (_e) {
+    return null;
+  }
+
+  const result: fulu.DataColumnSidecars = new Array(NUMBER_OF_COLUMNS);
+
+  for (let columnIndex = 0; columnIndex < NUMBER_OF_COLUMNS; columnIndex++) {
+    let sidecar = partialSidecars.get(columnIndex);
+    if (sidecar) {
+      // We already have this column
+      result[columnIndex] = sidecar;
+      continue;
+    }
+
+    sidecar = {
+      index: columnIndex,
+      column: fullColumns[columnIndex],
+      kzgCommitments: firstDataColumn.kzgCommitments,
+      kzgProofs: Array.from({length: blobCount}, (_, rowIndex) => blobProofs[rowIndex][columnIndex]),
+      signedBlockHeader: firstDataColumn.signedBlockHeader,
+      kzgCommitmentsInclusionProof: firstDataColumn.kzgCommitmentsInclusionProof,
+    };
+    result[columnIndex] = sidecar;
+  }
+
+  return result;
 }

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -8,7 +8,7 @@ import {
   NUMBER_OF_CUSTODY_GROUPS,
 } from "@lodestar/params";
 import {CachedBeaconStateAllForks, signedBlockToSignedHeader} from "@lodestar/state-transition";
-import {ColumnIndex, CustodyIndex, SignedBeaconBlockHeader, Uint8, ValidatorIndex, deneb, fulu} from "@lodestar/types";
+import {ColumnIndex, CustodyIndex, SignedBeaconBlockHeader, ValidatorIndex, deneb, fulu} from "@lodestar/types";
 import {ssz} from "@lodestar/types";
 import {bytesToBigInt} from "@lodestar/utils";
 import {
@@ -23,13 +23,20 @@ import {ChainEvent, ChainEventEmitter} from "../chain/emitter.js";
 import {BlockInputCacheType} from "../chain/seenCache/seenGossipBlockInput.js";
 import {IExecutionEngine} from "../execution/engine/interface.js";
 import {Metrics} from "../metrics/index.js";
+import {DataColumnRecover} from "../network/dataColumn/index.js";
 import {NodeId} from "../network/subnets/index.js";
-import {
-  computeKzgCommitmentsInclusionProof,
-  kzgCommitmentToVersionedHash,
-  recoverDataColumnSidecars as recover,
-} from "./blobs.js";
+import {computeKzgCommitmentsInclusionProof, kzgCommitmentToVersionedHash} from "./blobs.js";
+import {IClock} from "./clock.js";
 import {ckzg} from "./kzg.js";
+
+export enum RecoverResult {
+  // the recover is a success and it helps resolve availability
+  SuccessResolved = "success_resolved",
+  // the redover is a success but it's late, availability is already resolved by either gossip or getBlobsV2
+  SuccessLater = "success_later",
+  // the recover failed
+  Failed = "failed",
+}
 
 export class CustodyConfig {
   /**
@@ -316,38 +323,56 @@ export function getDataColumnSidecarsFromColumnSidecar(
 
 /**
  * If we receive more than half of DATA_COLUMN_SIDECAR_SUBNET_COUNT (64) we should recover all remaining columns
- * If we have less than that, return false and do nothing
- * If we have all columns, return false and do nothing
+ *   - return true if we successfully recovered and it helps resolve availability
+ *   - return false if we successfully recovered but it does not help resolve availability
+ *   - return null if we failed to recover or we don't attempt to recover
  */
-export function recoverDataColumnSidecars(dataColumnCache: DataColumnsCacheMap, metric: Metrics | null): boolean {
+export async function recoverDataColumnSidecars(
+  dataColumnCache: DataColumnsCacheMap,
+  dataColumnRecover: DataColumnRecover,
+  clock: IClock,
+  metric: Metrics | null
+): Promise<boolean | null> {
   const columnCount = dataColumnCache.size;
   if (columnCount >= DATA_COLUMN_SIDECAR_SUBNET_COUNT) {
     // We have all columns
-    return true;
+    return null;
   }
 
   if (columnCount < DATA_COLUMN_SIDECAR_SUBNET_COUNT / 2) {
     // We don't have enough columns to recover
-    return false;
+    return null;
   }
 
-  const timer = metric?.gossipDataColumnSidecar.recoverTime.startTimer();
+  const timer = metric?.recoverDataColumnSidecars.recoverTime.startTimer();
   const partialSidecars = new Map<number, fulu.DataColumnSidecar>();
   for (const [columnIndex, {dataColumn}] of dataColumnCache.entries()) {
     partialSidecars.set(columnIndex, dataColumn);
   }
-  const fullSidecars = recover(partialSidecars);
+  const fullSidecars = await dataColumnRecover?.recoverDataColumnSidecars(partialSidecars);
   if (fullSidecars == null) {
-    const firstDataColumn = dataColumnCache.values().next().value?.dataColumn;
-    if (firstDataColumn == null) {
-      metric?.gossipDataColumnSidecar.recoverFailed.inc();
-      // should not happen because we check the size of the cache before this
-      throw new Error("No data column found in cache to recover from");
-    }
-    throw Error(`Cannot recover sidecar for slot ${firstDataColumn.signedBlockHeader.message.slot}`);
+    metric?.recoverDataColumnSidecars.result.inc({result: RecoverResult.Failed});
+    return null;
+  }
+  timer?.();
+
+  const firstDataColumn = dataColumnCache.values().next().value?.dataColumn;
+  if (firstDataColumn == null) {
+    // should not happen because we check the size of the cache before this
+    throw new Error("No data column found in cache to recover from");
+  }
+  const slot = firstDataColumn.signedBlockHeader.message.slot;
+  const secFromSlot = clock.secFromSlot(slot);
+  metric?.recoverDataColumnSidecars.secFromSlot.observe(secFromSlot);
+
+  if (dataColumnCache.size === NUMBER_OF_COLUMNS) {
+    // either gossip or getBlobsV2 resolved availability while we were recovering
+    metric?.recoverDataColumnSidecars.result.inc({result: RecoverResult.SuccessLater});
+    return false;
   }
 
-  timer?.();
+  // We successfully recovered the data columns, update the cache
+  metric?.recoverDataColumnSidecars.result.inc({result: RecoverResult.SuccessResolved});
 
   for (let columnIndex = 0; columnIndex < DATA_COLUMN_SIDECAR_SUBNET_COUNT; columnIndex++) {
     if (dataColumnCache.has(columnIndex)) {

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -309,6 +309,59 @@ export function getDataColumnSidecarsFromColumnSidecar(
   );
 }
 
+/**
+ * If we receive more than half of DATA_COLUMN_SIDECAR_SUBNET_COUNT (64) we should recover all remaining columns
+ * If we have less than that, return false and do nothing
+ * If we have all columns, return false and do nothing
+ */
+export function recoverDataColumnSidecars(dataColumnCache: DataColumnsCacheMap): boolean {
+  const columnCount = dataColumnCache.size;
+  if (columnCount >= DATA_COLUMN_SIDECAR_SUBNET_COUNT) {
+    // We have all columns
+    return true;
+  }
+
+  if (columnCount < DATA_COLUMN_SIDECAR_SUBNET_COUNT / 2) {
+    // We don't have enough columns to recover
+    return false;
+  }
+
+  // recover uzing c-kzg
+  const cellIndices: number[] = [];
+  const cells: Uint8Array[] = [];
+  for (const [columnIndex, {dataColumn}] of dataColumnCache.entries()) {
+    cellIndices.push(...Array.from({length: dataColumn.kzgCommitments.length}, () => columnIndex));
+    cells.push(...dataColumn.column);
+  }
+
+  const [recoveredCells, recoveredProofs] = ckzg.recoverCellsAndKzgProofs(cellIndices, cells);
+  const firstDataColumn = dataColumnCache.get(cellIndices[0])?.dataColumn;
+  if (firstDataColumn == null) {
+    // should not happen because we check the size of the cache before this
+    throw new Error("No data column found in cache to recover from");
+  }
+  const blobCount = firstDataColumn.kzgCommitments.length;
+  for (let i = 0; i < DATA_COLUMN_SIDECAR_SUBNET_COUNT; i++) {
+    if (dataColumnCache.has(i)) {
+      // We already have this column
+      continue;
+    }
+
+    const columnIndex = i;
+    const dataColumn: fulu.DataColumnSidecar = {
+      index: columnIndex,
+      column: recoveredCells.slice(i * blobCount, (i + 1) * blobCount),
+      kzgCommitments: firstDataColumn.kzgCommitments,
+      kzgProofs: recoveredProofs.slice(i * blobCount, (i + 1) * blobCount),
+      signedBlockHeader: firstDataColumn.signedBlockHeader,
+      kzgCommitmentsInclusionProof: firstDataColumn.kzgCommitmentsInclusionProof,
+    };
+    dataColumnCache.set(columnIndex, {dataColumn, dataColumnBytes: null});
+  }
+
+  return true;
+}
+
 export function hasSampledDataColumns(custodyConfig: CustodyConfig, dataColumnCache: DataColumnsCacheMap): boolean {
   return (
     dataColumnCache.size >= custodyConfig.sampledColumns.length &&

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -8,7 +8,7 @@ import {
   NUMBER_OF_CUSTODY_GROUPS,
 } from "@lodestar/params";
 import {CachedBeaconStateAllForks, signedBlockToSignedHeader} from "@lodestar/state-transition";
-import {ColumnIndex, CustodyIndex, SignedBeaconBlockHeader, ValidatorIndex, deneb, fulu} from "@lodestar/types";
+import {ColumnIndex, CustodyIndex, SignedBeaconBlockHeader, Uint8, ValidatorIndex, deneb, fulu} from "@lodestar/types";
 import {ssz} from "@lodestar/types";
 import {bytesToBigInt} from "@lodestar/utils";
 import {
@@ -22,8 +22,13 @@ import {
 import {ChainEvent, ChainEventEmitter} from "../chain/emitter.js";
 import {BlockInputCacheType} from "../chain/seenCache/seenGossipBlockInput.js";
 import {IExecutionEngine} from "../execution/engine/interface.js";
+import {Metrics} from "../metrics/index.js";
 import {NodeId} from "../network/subnets/index.js";
-import {computeKzgCommitmentsInclusionProof, kzgCommitmentToVersionedHash} from "./blobs.js";
+import {
+  computeKzgCommitmentsInclusionProof,
+  kzgCommitmentToVersionedHash,
+  recoverDataColumnSidecars as recover,
+} from "./blobs.js";
 import {ckzg} from "./kzg.js";
 
 export class CustodyConfig {
@@ -314,7 +319,7 @@ export function getDataColumnSidecarsFromColumnSidecar(
  * If we have less than that, return false and do nothing
  * If we have all columns, return false and do nothing
  */
-export function recoverDataColumnSidecars(dataColumnCache: DataColumnsCacheMap): boolean {
+export function recoverDataColumnSidecars(dataColumnCache: DataColumnsCacheMap, metric: Metrics | null): boolean {
   const columnCount = dataColumnCache.size;
   if (columnCount >= DATA_COLUMN_SIDECAR_SUBNET_COUNT) {
     // We have all columns
@@ -326,37 +331,35 @@ export function recoverDataColumnSidecars(dataColumnCache: DataColumnsCacheMap):
     return false;
   }
 
-  // recover uzing c-kzg
-  const cellIndices: number[] = [];
-  const cells: Uint8Array[] = [];
+  const timer = metric?.gossipDataColumnSidecar.recoverTime.startTimer();
+  const partialSidecars = new Map<number, fulu.DataColumnSidecar>();
   for (const [columnIndex, {dataColumn}] of dataColumnCache.entries()) {
-    cellIndices.push(...Array.from({length: dataColumn.kzgCommitments.length}, () => columnIndex));
-    cells.push(...dataColumn.column);
+    partialSidecars.set(columnIndex, dataColumn);
+  }
+  const fullSidecars = recover(partialSidecars);
+  if (fullSidecars == null) {
+    const firstDataColumn = dataColumnCache.values().next().value?.dataColumn;
+    if (firstDataColumn == null) {
+      metric?.gossipDataColumnSidecar.recoverFailed.inc();
+      // should not happen because we check the size of the cache before this
+      throw new Error("No data column found in cache to recover from");
+    }
+    throw Error(`Cannot recover sidecar for slot ${firstDataColumn.signedBlockHeader.message.slot}`);
   }
 
-  const [recoveredCells, recoveredProofs] = ckzg.recoverCellsAndKzgProofs(cellIndices, cells);
-  const firstDataColumn = dataColumnCache.get(cellIndices[0])?.dataColumn;
-  if (firstDataColumn == null) {
-    // should not happen because we check the size of the cache before this
-    throw new Error("No data column found in cache to recover from");
-  }
-  const blobCount = firstDataColumn.kzgCommitments.length;
-  for (let i = 0; i < DATA_COLUMN_SIDECAR_SUBNET_COUNT; i++) {
-    if (dataColumnCache.has(i)) {
+  timer?.();
+
+  for (let columnIndex = 0; columnIndex < DATA_COLUMN_SIDECAR_SUBNET_COUNT; columnIndex++) {
+    if (dataColumnCache.has(columnIndex)) {
       // We already have this column
       continue;
     }
 
-    const columnIndex = i;
-    const dataColumn: fulu.DataColumnSidecar = {
-      index: columnIndex,
-      column: recoveredCells.slice(i * blobCount, (i + 1) * blobCount),
-      kzgCommitments: firstDataColumn.kzgCommitments,
-      kzgProofs: recoveredProofs.slice(i * blobCount, (i + 1) * blobCount),
-      signedBlockHeader: firstDataColumn.signedBlockHeader,
-      kzgCommitmentsInclusionProof: firstDataColumn.kzgCommitmentsInclusionProof,
-    };
-    dataColumnCache.set(columnIndex, {dataColumn, dataColumnBytes: null});
+    const sidecar = fullSidecars[columnIndex];
+    if (sidecar === undefined) {
+      throw new Error(`full sidecars is undefined at index ${columnIndex}`);
+    }
+    dataColumnCache.set(columnIndex, {dataColumn: sidecar, dataColumnBytes: null});
   }
 
   return true;

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -33,7 +33,7 @@ export enum RecoverResult {
   // the recover is a success and it helps resolve availability
   SuccessResolved = "success_resolved",
   // the redover is a success but it's late, availability is already resolved by either gossip or getBlobsV2
-  SuccessLater = "success_later",
+  SuccessLate = "success_late",
   // the recover failed
   Failed = "failed",
 }
@@ -367,7 +367,7 @@ export async function recoverDataColumnSidecars(
 
   if (dataColumnCache.size === NUMBER_OF_COLUMNS) {
     // either gossip or getBlobsV2 resolved availability while we were recovering
-    metric?.recoverDataColumnSidecars.result.inc({result: RecoverResult.SuccessLater});
+    metric?.recoverDataColumnSidecars.result.inc({result: RecoverResult.SuccessLate});
     return false;
   }
 

--- a/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
@@ -15,6 +15,7 @@ import {computeNodeId} from "../../../../src/network/subnets/index.js";
 import {CustodyConfig} from "../../../../src/util/dataColumns.js";
 import {testLogger} from "../../../utils/logger.js";
 import {getValidPeerId} from "../../../utils/peer.js";
+import { IClock } from "../../../../src/util/clock.js";
 
 describe("SeenGossipBlockInput", () => {
   const chainConfig = createChainForkConfig({
@@ -39,11 +40,14 @@ describe("SeenGossipBlockInput", () => {
   });
 
   const emitter = new ChainEventEmitter();
+  // Not used in this test, but required by the constructor
+  const unusedClock = {} as unknown as IClock;
 
   const seenGossipBlockInput = new SeenGossipBlockInput(
     new CustodyConfig(nodeId, config),
     executionEngine,
     emitter,
+    unusedClock,
     testLogger("seenGossipBlockInput")
   );
 
@@ -141,6 +145,7 @@ describe("SeenGossipBlockInput", () => {
                 type: GossipedInputType.block,
                 signedBlock,
               },
+              null,
               null
             );
 
@@ -162,6 +167,7 @@ describe("SeenGossipBlockInput", () => {
                 type: GossipedInputType.blob,
                 blobSidecar,
               },
+              null,
               null
             );
 

--- a/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
@@ -12,10 +12,10 @@ import {
 import {getExecutionEngineFromBackend} from "../../../../src/execution/engine/index.js";
 import {ExecutionEngineMockBackend} from "../../../../src/execution/engine/mock.js";
 import {computeNodeId} from "../../../../src/network/subnets/index.js";
+import {IClock} from "../../../../src/util/clock.js";
 import {CustodyConfig} from "../../../../src/util/dataColumns.js";
 import {testLogger} from "../../../utils/logger.js";
 import {getValidPeerId} from "../../../utils/peer.js";
-import { IClock } from "../../../../src/util/clock.js";
 
 describe("SeenGossipBlockInput", () => {
   const chainConfig = createChainForkConfig({

--- a/packages/beacon-node/test/unit/util/kzg.test.ts
+++ b/packages/beacon-node/test/unit/util/kzg.test.ts
@@ -1,10 +1,12 @@
 import {createBeaconConfig, createChainForkConfig} from "@lodestar/config";
+import {NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {signedBlockToSignedHeader} from "@lodestar/state-transition";
-import {deneb, ssz} from "@lodestar/types";
+import {deneb, fulu, ssz} from "@lodestar/types";
 import {afterEach, beforeAll, describe, expect, it} from "vitest";
 import {validateBlobSidecars, validateGossipBlobSidecar} from "../../../src/chain/validation/blobSidecar.js";
-import {computeBlobSidecars, computeDataColumnSidecars} from "../../../src/util/blobs.js";
+import {computeBlobSidecars, computeDataColumnSidecars, recoverDataColumnSidecars} from "../../../src/util/blobs.js";
 import {ckzg, initCKZG, loadEthereumTrustedSetup} from "../../../src/util/kzg.js";
+import {shuffle} from "../../../src/util/shuffle.js";
 import {getMockedBeaconChain} from "../../mocks/mockedBeaconChain.js";
 import {getBlobCellAndProofs} from "../../utils/getBlobCellAndProofs.js";
 import {generateRandomBlob, transactionForKzgCommitment} from "../../utils/kzg.js";
@@ -121,5 +123,31 @@ describe("C-KZG", () => {
         )
       ).toBeTruthy();
     });
+
+    const partialSidecars = new Map<number, fulu.DataColumnSidecar>();
+    for (let i = 0; i < NUMBER_OF_COLUMNS; i++) {
+      if (i % 2 === 0) {
+        // skip every second column to simulate partial sidecars
+        continue;
+      }
+      partialSidecars.set(i, sidecars[i]);
+    }
+    const shuffled = shuffle(Array.from(partialSidecars.keys()));
+    const shuffledPartial = new Map<number, fulu.DataColumnSidecar>();
+    for (const columnIndex of shuffled) {
+      const sidecar = partialSidecars.get(columnIndex);
+      if (sidecar) {
+        shuffledPartial.set(columnIndex, sidecar);
+      }
+    }
+
+    const recoveredSidecars = recoverDataColumnSidecars(shuffledPartial);
+    expect(recoveredSidecars !== null).toBeTruthy();
+    if (recoveredSidecars == null) {
+      // should not happen
+      throw new Error("Recovered sidecars should not be null");
+    }
+    expect(recoveredSidecars.length).toBe(NUMBER_OF_COLUMNS);
+    expect(ssz.fulu.DataColumnSidecars.equals(recoveredSidecars, sidecars)).toBeTruthy();
   });
 });


### PR DESCRIPTION
**Motivation**

- for super node, if we don't receive sidecar for a single column subnet, we cannot sync, see #7931
- instead of that, we should recover all sidecars when we receive >= 64 sidecars

**Description**

- with `MAX_BLOBS_PER_BLOCK=20` it takes ~4s to recover all sidecars
- implement `data_column_recover` worker thread, initialized by network
- call it once we have >= 64 data column sidecars in `SeenGossipBlockInput`
- some results from the worker:
  - success_resolved: it's a success recover and it resolve availability for the block
  - success_late: it's a success recover but it's late, it could be resolved either by `getBlobsV2` or `gossip`
  - fail

Closes #7932

**Test on fusaka-devnet-0**
- it takes almost 4s to recover all blobs, recover time from slot is ~5.5s

<img width="1027" alt="Screenshot 2025-06-09 at 15 30 09" src="https://github.com/user-attachments/assets/cbfd8f35-55ae-4e78-810a-f217d4503ace" />

- so most of the time the recovered blobs/sidecars are late. But it's great because it makes sure our super node will not fall out of synced due to missing some sidecars
<img width="857" alt="Screenshot 2025-06-09 at 15 31 41" src="https://github.com/user-attachments/assets/8b471343-0df9-4b38-85bb-636d608afe72" />



