### PR TITLE
chore: add peerDAS custody group count metric

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -267,7 +267,7 @@ export class BeaconChain implements IBeaconChain {
     this.seenContributionAndProof = new SeenContributionAndProof(metrics);
     this.seenAttestationDatas = new SeenAttestationDatas(metrics, this.opts?.attDataCacheSlotDistance);
     const nodeId = computeNodeIdFromPrivateKey(privateKey);
-    this.custodyConfig = new CustodyConfig(nodeId, config);
+    this.custodyConfig = new CustodyConfig(nodeId, config, metrics);
     this.seenGossipBlockInput = new SeenGossipBlockInput(this.custodyConfig, this.executionEngine, emitter, logger);
 
     this.beaconProposerCache = new BeaconProposerCache(opts);

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -361,6 +361,10 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
         help: "Runtime of batched data column kzg verification",
         buckets: [0.002, 0.004, 0.006, 0.008, 0.01, 0.012, 0.015, 0.02, 0.03, 0.05, 0.07],
       }),
+      custodyGroupCount: register.gauge({
+        name: "beacon_custody_groups",
+        help: "Total number of custody groups within a node",
+      }),
     },
 
     // Non-spec'ed

--- a/packages/beacon-node/src/network/networkConfig.ts
+++ b/packages/beacon-node/src/network/networkConfig.ts
@@ -15,7 +15,7 @@ export class NetworkConfig {
   constructor(peerId: PeerId, config: BeaconConfig) {
     this.nodeId = computeNodeId(peerId);
     this.config = config;
-    this.custodyConfig = new CustodyConfig(this.nodeId, config);
+    this.custodyConfig = new CustodyConfig(this.nodeId, config, null);
   }
 
   getConfig(): BeaconConfig {

--- a/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
@@ -41,7 +41,7 @@ describe("SeenGossipBlockInput", () => {
   const emitter = new ChainEventEmitter();
 
   const seenGossipBlockInput = new SeenGossipBlockInput(
-    new CustodyConfig(nodeId, config),
+    new CustodyConfig(nodeId, config, null),
     executionEngine,
     emitter,
     testLogger("seenGossipBlockInput")

--- a/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
@@ -109,7 +109,7 @@ describe.skip("beaconBlocksMaybeBlobsByRange", () => {
         });
       });
 
-      const custodyConfig = new CustodyConfig(new Uint8Array(32), config);
+      const custodyConfig = new CustodyConfig(new Uint8Array(32), config, null);
       custodyConfig.sampledColumns = [2, 4, 6, 8];
 
       const network = {

--- a/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
+++ b/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
@@ -218,7 +218,7 @@ describe("unavailableBeaconBlobsByRoot", () => {
     const network = {
       sendBeaconBlocksByRoot: vi.fn(),
       sendBlobSidecarsByRoot: vi.fn(),
-      custodyConfig: new CustodyConfig(computeNodeId(getValidPeerId()), config),
+      custodyConfig: new CustodyConfig(computeNodeId(getValidPeerId()), config, null),
     };
 
     const peerId = "mockPeerId";

--- a/packages/beacon-node/test/unit/util/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/util/dataColumn.test.ts
@@ -117,7 +117,7 @@ describe("CustodyConfig", () => {
   });
 
   it("custody columns present in sampled columns", () => {
-    const custodyConfig = new CustodyConfig(nodeId, config);
+    const custodyConfig = new CustodyConfig(nodeId, config, null);
     const {custodyColumns} = custodyConfig;
     const sampledColumns = custodyConfig.sampledColumns;
 
@@ -130,7 +130,7 @@ describe("CustodyConfig", () => {
 
   describe("updateCustodyRequirement", () => {
     it("should update target and sampled but not advertised", () => {
-      const custodyConfig = new CustodyConfig(nodeId, config);
+      const custodyConfig = new CustodyConfig(nodeId, config, null);
 
       expect(custodyConfig.sampledGroupCount).toBe(8);
       expect(custodyConfig.targetCustodyGroupCount).toBe(4);
@@ -144,7 +144,7 @@ describe("CustodyConfig", () => {
     });
 
     it("should update advertised but not target or sampled", () => {
-      const custodyConfig = new CustodyConfig(nodeId, config);
+      const custodyConfig = new CustodyConfig(nodeId, config, null);
 
       expect(custodyConfig.sampledGroupCount).toBe(8);
       expect(custodyConfig.targetCustodyGroupCount).toBe(4);


### PR DESCRIPTION
**Motivation**

Add peerDAS custody group count metric to align with the [peerDAS beacon metrics specs](https://github.com/ethereum/beacon-metrics/pull/14):

**Description**

- `beacon_custody_groups`

**Steps to test or reproduce**
Utilize peerDAS kurtosis dashboard.
