### PR TITLE
fix: only use proposer lookahead from state if epoch is post fulu

### DIFF
--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -650,7 +650,7 @@ export class EpochCache {
         // so should be taken into account when structuring tests.  Should not affect unit or other tests though
         computeEpochShuffling(state, this.nextActiveIndices, upcomingEpoch);
     }
-    if (upcomingEpoch >= this.config.FULU_FORK_EPOCH) {
+    if (this.epoch >= this.config.FULU_FORK_EPOCH) {
       // Populate proposer cache with lookahead from state
       const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
       this.proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);


### PR DESCRIPTION
Need to make sure we only run this if state is upgraded to fulu

Currently it causes spec tests to fail
```
 FAIL   spec-minimal  test/spec/presets/transition.test.ts > fulu/transition/core/pyspec_tests > fulu/transition/core/pyspec_tests/transition_with_voluntary_exit_right_before_fork
TypeError: Cannot read properties of undefined (reading 'getAll')
 ❯ EpochCache.afterProcessEpoch ../state-transition/src/cache/epochCache.ts:655:84
 ❯ processSlotsWithTransientCache ../state-transition/src/stateTransition.ts:251:28
 ❯ stateTransition ../state-transition/src/stateTransition.ts:109:15
 ❯ testFunction test/spec/presets/transition.test.ts:57:19
     55|         for (let i = 0; i < meta.blocks_count; i++) {
```