### PR TITLE
feat: validate blob schedule on startup

### DIFF
--- a/packages/config/src/chainConfig/json.ts
+++ b/packages/config/src/chainConfig/json.ts
@@ -1,4 +1,5 @@
 import {fromHex, toHex} from "@lodestar/utils";
+import {validateBlobSchedule} from "../utils/validateBlobSchedule.js";
 import {
   BlobSchedule,
   BlobScheduleEntry,
@@ -168,5 +169,6 @@ export function deserializeBlobSchedule(input: unknown): BlobSchedule {
     return out;
   });
 
+  validateBlobSchedule(blobSchedule);
   return blobSchedule;
 }

--- a/packages/config/src/chainConfig/json.ts
+++ b/packages/config/src/chainConfig/json.ts
@@ -170,5 +170,6 @@ export function deserializeBlobSchedule(input: unknown): BlobSchedule {
   });
 
   validateBlobSchedule(blobSchedule);
+
   return blobSchedule;
 }

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -149,12 +149,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       }
 
       // Sort by epoch in descending order to find the latest applicable value
-      const blobSchedule = [...config.BLOB_SCHEDULE].sort((a, b) => {
-        if (a.EPOCH !== b.EPOCH) {
-          return b.EPOCH - a.EPOCH;
-        }
-        return b.MAX_BLOBS_PER_BLOCK - a.MAX_BLOBS_PER_BLOCK;
-      });
+      const blobSchedule = [...config.BLOB_SCHEDULE].sort((a, b) => b.EPOCH - a.EPOCH);
 
       for (const entry of blobSchedule) {
         if (epoch >= entry.EPOCH) {

--- a/packages/config/src/utils/validateBlobSchedule.ts
+++ b/packages/config/src/utils/validateBlobSchedule.ts
@@ -12,16 +12,18 @@ export function validateBlobSchedule(blobSchedule: BlobSchedule): void {
     if (previousEpoch !== undefined) {
       if (entry.EPOCH < previousEpoch) {
         throw Error(
-          `Blob schedule entries must be in ascending order by EPOCH, ${entry.EPOCH} < ${previousEpoch} at index ${i}`
+          `Invalid BLOB_SCHEDULE expected entries to be sorted by EPOCH in ascending order, ${entry.EPOCH} < ${previousEpoch} at index ${i}`
         );
       }
       if (entry.EPOCH === previousEpoch) {
-        throw Error(`Duplicate entries found for epoch ${entry.EPOCH} at ${i - 1} and ${i}`);
+        throw Error(
+          `Invalid BLOB_SCHEDULE[${i}] entry with the same epoch value ${entry.EPOCH} as previous BLOB_SCHEDULE[${i - 1}] entry`
+        );
       }
     }
     if (entry.MAX_BLOBS_PER_BLOCK > MAX_BLOB_COMMITMENTS_PER_BLOCK) {
       throw Error(
-        `Max blobs value exceeds error at ${i}. Value ${entry.MAX_BLOBS_PER_BLOCK} limit ${MAX_BLOB_COMMITMENTS_PER_BLOCK}`
+        `Invalid BLOB_SCHEDULE[${i}].MAX_BLOBS_PER_BLOCK value ${entry.MAX_BLOBS_PER_BLOCK} exceeds limit ${MAX_BLOB_COMMITMENTS_PER_BLOCK}`
       );
     }
 

--- a/packages/config/src/utils/validateBlobSchedule.ts
+++ b/packages/config/src/utils/validateBlobSchedule.ts
@@ -8,7 +8,7 @@ export function validateBlobSchedule(blobSchedule: BlobSchedule): void {
 
   let previousEpoch: number | undefined;
 
-  blobSchedule.forEach((entry, i) => {
+  for (const [i, entry] of blobSchedule.entries()) {
     if (previousEpoch !== undefined) {
       if (entry.EPOCH < previousEpoch) {
         throw Error(
@@ -26,5 +26,5 @@ export function validateBlobSchedule(blobSchedule: BlobSchedule): void {
     }
 
     previousEpoch = entry.EPOCH;
-  });
+  }
 }

--- a/packages/config/src/utils/validateBlobSchedule.ts
+++ b/packages/config/src/utils/validateBlobSchedule.ts
@@ -1,0 +1,30 @@
+import {MAX_BLOB_COMMITMENTS_PER_BLOCK} from "@lodestar/params";
+import {BlobSchedule} from "../chainConfig/types.js";
+
+export function validateBlobSchedule(blobSchedule: BlobSchedule): void {
+  if (blobSchedule.length === 0) {
+    return;
+  }
+
+  let previousEpoch: number | undefined;
+
+  blobSchedule.forEach((entry, i) => {
+    if (previousEpoch !== undefined) {
+      if (entry.EPOCH < previousEpoch) {
+        throw Error(
+          `Blob schedule entries must be in ascending order by EPOCH, ${entry.EPOCH} < ${previousEpoch} at index ${i}`
+        );
+      }
+      if (entry.EPOCH === previousEpoch) {
+        throw Error(`Duplicate entries found for epoch ${entry.EPOCH} at ${i - 1} and ${i}`);
+      }
+    }
+    if (entry.MAX_BLOBS_PER_BLOCK > MAX_BLOB_COMMITMENTS_PER_BLOCK) {
+      throw Error(
+        `Max blobs value exceeds error at ${i}. Value ${entry.MAX_BLOBS_PER_BLOCK} limit ${MAX_BLOB_COMMITMENTS_PER_BLOCK}`
+      );
+    }
+
+    previousEpoch = entry.EPOCH;
+  });
+}

--- a/packages/config/test/unit/json.test.ts
+++ b/packages/config/test/unit/json.test.ts
@@ -1,3 +1,4 @@
+import {MAX_BLOB_COMMITMENTS_PER_BLOCK} from "@lodestar/params";
 import {describe, expect, it} from "vitest";
 import {chainConfig} from "../../src/default.js";
 import {BlobSchedule, chainConfigFromJson, chainConfigToJson} from "../../src/index.js";
@@ -13,9 +14,8 @@ describe("chainConfig JSON", () => {
   it("Custom blob schedule", () => {
     const blobSchedule: BlobSchedule = [
       {EPOCH: 0, MAX_BLOBS_PER_BLOCK: 10},
-      {EPOCH: 10, MAX_BLOBS_PER_BLOCK: Infinity},
+      {EPOCH: 10, MAX_BLOBS_PER_BLOCK: 15},
       {EPOCH: Infinity, MAX_BLOBS_PER_BLOCK: 20},
-      {EPOCH: Infinity, MAX_BLOBS_PER_BLOCK: Infinity},
     ];
     const configWithCustomBlobSchedule = {...chainConfig, BLOB_SCHEDULE: blobSchedule};
 
@@ -23,5 +23,42 @@ describe("chainConfig JSON", () => {
     const chainConfigRes = chainConfigFromJson(json);
 
     expect(chainConfigRes).toEqual(configWithCustomBlobSchedule);
+  });
+
+  it("Blob schedule max blobs exceed limit", () => {
+    const blobSchedule: BlobSchedule = [{EPOCH: 0, MAX_BLOBS_PER_BLOCK: MAX_BLOB_COMMITMENTS_PER_BLOCK + 1}];
+    const configWithCustomBlobSchedule = {...chainConfig, BLOB_SCHEDULE: blobSchedule};
+
+    const json = chainConfigToJson(configWithCustomBlobSchedule);
+
+    expect(() => chainConfigFromJson(json)).toThrow();
+  });
+
+  it("Blob schedule in wrong order", () => {
+    const blobSchedule: BlobSchedule = [
+      {EPOCH: 20, MAX_BLOBS_PER_BLOCK: 20},
+      {EPOCH: 10, MAX_BLOBS_PER_BLOCK: 15},
+      {EPOCH: 0, MAX_BLOBS_PER_BLOCK: 10},
+    ];
+
+    const configWithCustomBlobSchedule = {...chainConfig, BLOB_SCHEDULE: blobSchedule};
+
+    const json = chainConfigToJson(configWithCustomBlobSchedule);
+
+    expect(() => chainConfigFromJson(json)).toThrow();
+  });
+
+  it("Blob schedule duplicated epoch entries", () => {
+    const blobSchedule: BlobSchedule = [
+      {EPOCH: 0, MAX_BLOBS_PER_BLOCK: 10},
+      {EPOCH: 10, MAX_BLOBS_PER_BLOCK: 15},
+      {EPOCH: 10, MAX_BLOBS_PER_BLOCK: 20},
+    ];
+
+    const configWithCustomBlobSchedule = {...chainConfig, BLOB_SCHEDULE: blobSchedule};
+
+    const json = chainConfigToJson(configWithCustomBlobSchedule);
+
+    expect(() => chainConfigFromJson(json)).toThrow();
   });
 });

--- a/packages/config/test/unit/json.test.ts
+++ b/packages/config/test/unit/json.test.ts
@@ -25,7 +25,7 @@ describe("chainConfig JSON", () => {
     expect(chainConfigRes).toEqual(configWithCustomBlobSchedule);
   });
 
-  it("Blob schedule max blobs exceed limit", () => {
+  it("Blob schedule max blobs exceeds limit", () => {
     const blobSchedule: BlobSchedule = [{EPOCH: 0, MAX_BLOBS_PER_BLOCK: MAX_BLOB_COMMITMENTS_PER_BLOCK + 1}];
     const configWithCustomBlobSchedule = {...chainConfig, BLOB_SCHEDULE: blobSchedule};
 
@@ -48,7 +48,7 @@ describe("chainConfig JSON", () => {
     expect(() => chainConfigFromJson(json)).toThrow();
   });
 
-  it("Blob schedule duplicated epoch entries", () => {
+  it("Blob schedule entries with the same epoch value", () => {
     const blobSchedule: BlobSchedule = [
       {EPOCH: 0, MAX_BLOBS_PER_BLOCK: 10},
       {EPOCH: 10, MAX_BLOBS_PER_BLOCK: 15},


### PR DESCRIPTION
We should validate the correctness of blob schedule in addition to its format when parsing it.


Relevant spec ethereum/consensus-specs#4370