### PR TITLE
fix: update getBlobsV2 request duration metric

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -380,9 +380,9 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
         name: "beacon_engine_getBlobsV2_responses_total",
         help: "Total number of engine_getBlobsV2 successful responses received",
       }),
-      getBlobsV2Runtime: register.histogram({
+      getBlobsV2RequestDuration: register.histogram({
         name: "beacon_engine_getBlobsV2_request_duration_seconds",
-        help: "Full runtime of engine_getBlobsV2 requests",
+        help: "Duration of engine_getBlobsV2 requests",
         buckets: [0.01, 0.05, 0.1, 0.5, 1, 2.5, 5, 7.5],
       }),
       custodyGroupCount: register.gauge({

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -371,7 +371,7 @@ export async function getDataColumnsFromExecution(
 
   // Get blobs from execution engine
   metrics?.peerDas.getBlobsV2Requests.inc();
-  const timer = metrics?.peerDas.getBlobsV2Runtime.startTimer();
+  const timer = metrics?.peerDas.getBlobsV2RequestDuration.startTimer();
   const blobs = await executionEngine.getBlobs(blockCache.fork, versionedHashes);
   timer?.();
 


### PR DESCRIPTION
**Motivation**

Fixes #7854.

**Description**

Fix the description and the variable name of `beacon_engine_getBlobsV2_request_duration_seconds` metric.