### PR TITLE
feat: persist orphaned blocks to disk

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
+++ b/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
@@ -184,7 +184,9 @@ export class ArchiveStore {
         this.logger,
         finalized,
         this.chain.clock.currentEpoch,
-        this.archiveBlobEpochs
+        this.archiveBlobEpochs,
+        this.chain.opts.persistOrphanedBlocks,
+        this.chain.opts.persistOrphanedBlocksDir
       );
       if (this.opts.pruneHistory) {
         await pruneHistory(

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -97,19 +97,14 @@ export async function archiveBlocks(
         nonCanonicalBlockRoots.map(async (root, index) => {
           const block = finalizedNonCanonicalBlocks[index];
           const blockBytes = await db.block.getBinary(root);
+          const logCtx = {slot: block.slot, root: block.blockRoot};
           if (blockBytes) {
             await persistOrphanedBlock(block.slot, block.blockRoot, blockBytes, {
               persistOrphanedBlocksDir: persistOrphanedBlocksDir ?? "orphaned_blocks",
             });
-            logger.verbose("Persisted orphaned block", {
-              slot: block.slot,
-              root: block.blockRoot,
-            });
+            logger.verbose("Persisted orphaned block", logCtx);
           } else {
-            logger.warn("Tried to persist orphaned block but no block found", {
-              slot: block.slot,
-              root: block.blockRoot,
-            });
+            logger.warn("Tried to persist orphaned block but no block found", logCtx);
           }
         })
       );

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {ChainForkConfig} from "@lodestar/config";
 import {KeyValue} from "@lodestar/db";
 import {IForkChoice} from "@lodestar/fork-choice";
@@ -7,6 +8,8 @@ import {Epoch, RootHex, Slot} from "@lodestar/types";
 import {Logger, fromHex, toRootHex} from "@lodestar/utils";
 import {IBeaconDb} from "../../../db/index.js";
 import {BlockArchiveBatchPutBinaryItem} from "../../../db/repositories/index.js";
+import {ensureDir, writeIfNotExist} from "../../../util/file.js";
+import {BlockRootHex} from "../../../util/sszBytes.js";
 import {LightClientServer} from "../../lightClient/index.js";
 
 // Process in chunks to avoid OOM
@@ -17,6 +20,23 @@ const BLOB_SIDECAR_BATCH_SIZE = 32;
 
 type BlockRootSlot = {slot: Slot; root: Uint8Array};
 type CheckpointHex = {epoch: Epoch; rootHex: RootHex};
+
+/**
+ * Persist orphaned block to disk
+ */
+async function persistOrphanedBlock(
+  slot: Slot,
+  blockRoot: BlockRootHex,
+  bytes: Uint8Array,
+  opts: {
+    persistOrphanedBlocksDir: string;
+  }
+) {
+  const dirpath = path.join(opts.persistOrphanedBlocksDir ?? "orphaned_blocks");
+  const filepath = path.join(dirpath, `${slot}_${blockRoot}.ssz`);
+  await ensureDir(dirpath);
+  await writeIfNotExist(filepath, bytes);
+}
 
 /**
  * Archives finalized blocks from active bucket to archive bucket.
@@ -35,7 +55,9 @@ export async function archiveBlocks(
   logger: Logger,
   finalizedCheckpoint: CheckpointHex,
   currentEpoch: Epoch,
-  archiveBlobEpochs?: number
+  archiveBlobEpochs?: number,
+  persistOrphanedBlocks?: boolean,
+  persistOrphanedBlocksDir?: string
 ): Promise<void> {
   // Use fork choice to determine the blocks to archive and delete
   // getAllAncestorBlocks response includes the finalized block, so it's also moved to the cold db
@@ -69,6 +91,30 @@ export async function archiveBlocks(
 
   const nonCanonicalBlockRoots = finalizedNonCanonicalBlocks.map((summary) => fromHex(summary.blockRoot));
   if (nonCanonicalBlockRoots.length > 0) {
+    if (persistOrphanedBlocks) {
+      // Persist orphaned blocks to disk before deleting them from hot db
+      await Promise.all(
+        nonCanonicalBlockRoots.map(async (root, index) => {
+          const block = finalizedNonCanonicalBlocks[index];
+          const blockBytes = await db.block.getBinary(root);
+          if (blockBytes) {
+            await persistOrphanedBlock(block.slot, block.blockRoot, blockBytes, {
+              persistOrphanedBlocksDir: persistOrphanedBlocksDir ?? "orphaned_blocks",
+            });
+            logger.verbose("Persisted orphaned block", {
+              slot: block.slot,
+              root: block.blockRoot,
+            });
+          } else {
+            logger.warn("Tried to persist orphaned block but no block found", {
+              slot: block.slot,
+              root: block.blockRoot,
+            });
+          }
+        })
+      );
+    }
+
     await db.block.batchDelete(nonCanonicalBlockRoots);
     logger.verbose("Deleted non canonical blocks from hot DB", {
       slots: finalizedNonCanonicalBlocks.map((summary) => summary.slot).join(","),

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -28,6 +28,8 @@ export type IChainOptions = BlockProcessOpts &
     persistProducedBlocks?: boolean;
     persistInvalidSszObjects?: boolean;
     persistInvalidSszObjectsDir?: string;
+    persistOrphanedBlocks?: boolean;
+    persistOrphanedBlocksDir?: string;
     skipCreateStateCacheIfAvailable?: boolean;
     suggestedFeeRecipient: string;
     maxSkipSlots?: number;

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -177,6 +177,7 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
     chain: {
       validatorMonitorLogs: args.validatorMonitorLogs,
       persistInvalidSszObjectsDir: beaconPaths.persistInvalidSszObjectsDir,
+      persistOrphanedBlocksDir: beaconPaths.persistOrphanedBlocksDir,
     },
   });
   // Add metrics metadata to show versioning + network info in Prometheus + Grafana

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -23,6 +23,7 @@ type BeaconExtraArgs = {
   validatorMonitorLogs?: boolean;
   attachToGlobalThis?: boolean;
   disableLightClientServer?: boolean;
+  persistOrphanedBlocksDir?: string;
 };
 
 export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
@@ -142,6 +143,13 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
   disableLightClientServer: {
     description: "Disable light client server.",
     type: "boolean",
+  },
+
+  persistOrphanedBlocksDir: {
+    description: "Enable and specify a directory to persist orphaned blocks",
+    defaultDescription: defaultBeaconPaths.persistOrphanedBlocksDir,
+    hidden: true,
+    type: "string",
   },
 };
 

--- a/packages/cli/src/cmds/beacon/options.ts
+++ b/packages/cli/src/cmds/beacon/options.ts
@@ -17,13 +17,13 @@ type BeaconExtraArgs = {
   dbDir?: string;
   persistInvalidSszObjectsDir?: string;
   persistInvalidSszObjectsRetentionHours?: number;
+  persistOrphanedBlocksDir?: string;
   peerStoreDir?: string;
   persistNetworkIdentity?: boolean;
   private?: boolean;
   validatorMonitorLogs?: boolean;
   attachToGlobalThis?: boolean;
   disableLightClientServer?: boolean;
-  persistOrphanedBlocksDir?: string;
 };
 
 export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
@@ -111,6 +111,13 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
     type: "number",
   },
 
+  persistOrphanedBlocksDir: {
+    description: "Enable and specify a directory to persist orphaned blocks",
+    defaultDescription: defaultBeaconPaths.persistOrphanedBlocksDir,
+    hidden: true,
+    type: "string",
+  },
+
   peerStoreDir: {
     hidden: true,
     description: "Peer store directory",
@@ -143,13 +150,6 @@ export const beaconExtraOptions: CliCommandOptions<BeaconExtraArgs> = {
   disableLightClientServer: {
     description: "Disable light client server.",
     type: "boolean",
-  },
-
-  persistOrphanedBlocksDir: {
-    description: "Enable and specify a directory to persist orphaned blocks",
-    defaultDescription: defaultBeaconPaths.persistOrphanedBlocksDir,
-    hidden: true,
-    type: "string",
   },
 };
 

--- a/packages/cli/src/cmds/beacon/paths.ts
+++ b/packages/cli/src/cmds/beacon/paths.ts
@@ -7,6 +7,7 @@ export type BeaconPathsPartial = Partial<{
   peerStoreDir: string;
   dbDir: string;
   persistInvalidSszObjectsDir: string;
+  persistOrphanedBlocksDir?: string;
 }>;
 
 export type BeaconPaths = {
@@ -14,6 +15,7 @@ export type BeaconPaths = {
   peerStoreDir: string;
   dbDir: string;
   persistInvalidSszObjectsDir: string;
+  persistOrphanedBlocksDir: string;
 };
 
 /**
@@ -42,6 +44,7 @@ export function getBeaconPaths(
   const dbDir = args.dbDir ?? path.join(beaconDir, "chain-db");
   const persistInvalidSszObjectsDir = args.persistInvalidSszObjectsDir ?? path.join(beaconDir, "invalidSszObjects");
   const peerStoreDir = args.peerStoreDir ?? path.join(beaconDir, "peerstore");
+  const persistOrphanedBlocksDir = args.persistOrphanedBlocksDir ?? path.join(beaconDir, "orphaned_blocks");
 
   return {
     ...globalPaths,
@@ -49,6 +52,7 @@ export function getBeaconPaths(
     dbDir,
     persistInvalidSszObjectsDir,
     peerStoreDir,
+    persistOrphanedBlocksDir,
   };
 }
 

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -164,7 +164,7 @@ Will double processing times. Use only for debugging purposes.",
   "chain.persistOrphanedBlocks": {
     hidden: true,
     type: "boolean",
-    description: "Whether to persist orphaned blocks ",
+    description: "Whether to persist orphaned blocks",
     group: "chain",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -15,6 +15,7 @@ export type ChainArgs = {
   // No need to define chain.persistInvalidSszObjects as part of ChainArgs
   // as this is defined as part of BeaconPaths
   // "chain.persistInvalidSszObjectsDir": string;
+  "chain.persistOrphanedBlocks"?: boolean;
   "chain.proposerBoost"?: boolean;
   "chain.proposerBoostReorg"?: boolean;
   "chain.disableImportExecutionFcU"?: boolean;
@@ -52,6 +53,9 @@ export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
     persistInvalidSszObjects: args["chain.persistInvalidSszObjects"],
     // biome-ignore lint/suspicious/noExplicitAny: <explanation>
     persistInvalidSszObjectsDir: undefined as any,
+    persistOrphanedBlocks: args["chain.persistOrphanedBlocks"],
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    persistOrphanedBlocksDir: undefined as any,
     proposerBoost: args["chain.proposerBoost"],
     proposerBoostReorg: args["chain.proposerBoostReorg"],
     disableImportExecutionFcU: args["chain.disableImportExecutionFcU"],
@@ -154,6 +158,13 @@ Will double processing times. Use only for debugging purposes.",
     hidden: true,
     type: "boolean",
     description: "Persist invalid ssz objects or not for debugging purpose",
+    group: "chain",
+  },
+
+  "chain.persistOrphanedBlocks": {
+    hidden: true,
+    type: "boolean",
+    description: "Whether to persist orphaned blocks ",
     group: "chain",
   },
 


### PR DESCRIPTION
**Description**
Add two new options to persist orphaned blocks to disk:
- chain.persistOrphanedBlocks
- chain.persistOrphanedBlocksDir

Closes #4066

Please note that I couldn't test it because it requires running a node receiving blocks that become orphaned after a while, and it's beyond my current understanding of the repo.
