### PR TITLE
chore: proposer lookahead follow-up changes

### DIFF
--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -650,7 +650,7 @@ export class EpochCache {
         // so should be taken into account when structuring tests.  Should not affect unit or other tests though
         computeEpochShuffling(state, this.nextActiveIndices, upcomingEpoch);
     }
-    if (upcomingEpoch >= this.config.FULU_FORK_EPOCH) {
+    if (this.epoch >= this.config.FULU_FORK_EPOCH) {
       // Populate proposer cache with lookahead from state
       const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
       this.proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);

--- a/packages/state-transition/src/epoch/index.ts
+++ b/packages/state-transition/src/epoch/index.ts
@@ -189,6 +189,10 @@ export function processEpoch(
   }
 
   if (fork >= ForkSeq.fulu) {
+    const timer = metrics?.epochTransitionStepTime.startTimer({
+      step: EpochTransitionStep.processProposerLookahead,
+    });
     processProposerLookahead(fork, state as CachedBeaconStateFulu);
+    timer?.();
   }
 }


### PR DESCRIPTION
**Motivation**

Bring proposer lookahead fixes to unstable branch, does not include shuffling calculation changes from https://github.com/ChainSafe/lodestar/pull/7945 yet.

**Description**

- only use proposer lookahead from state if epoch is post fulu
- track epoch transition step time for proposer lookahead


Related https://github.com/ChainSafe/lodestar/pull/7902