### PR TITLE
feat: add endpoint to retrieve proposer lookahead from state

### DIFF
--- a/packages/api/src/beacon/routes/beacon/state.ts
+++ b/packages/api/src/beacon/routes/beacon/state.ts
@@ -1,7 +1,18 @@
 import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {MAX_VALIDATORS_PER_COMMITTEE} from "@lodestar/params";
-import {CommitteeIndex, Epoch, RootHex, Slot, StringType, ValidatorStatus, electra, phase0, ssz} from "@lodestar/types";
+import {
+  CommitteeIndex,
+  Epoch,
+  RootHex,
+  Slot,
+  StringType,
+  ValidatorStatus,
+  electra,
+  fulu,
+  phase0,
+  ssz,
+} from "@lodestar/types";
 import {ArrayOf, JsonOnlyReq} from "../../../utils/codecs.js";
 import {Endpoint, RequestCodec, RouteDefinitions, Schema} from "../../../utils/index.js";
 import {
@@ -308,6 +319,19 @@ export type Endpoints = {
     electra.PendingConsolidations,
     ExecutionOptimisticFinalizedAndVersionMeta
   >;
+
+  /**
+   * Get State Proposer Lookahead
+   *
+   * Returns proposer lookahead for state with given 'stateId'.
+   */
+  getProposerLookahead: Endpoint<
+    "GET",
+    StateArgs,
+    {params: {state_id: string}},
+    fulu.ProposerLookahead,
+    ExecutionOptimisticFinalizedAndVersionMeta
+  >;
 };
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -549,6 +573,15 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
       req: stateIdOnlyReq,
       resp: {
         data: ssz.electra.PendingConsolidations,
+        meta: ExecutionOptimisticFinalizedAndVersionCodec,
+      },
+    },
+    getProposerLookahead: {
+      url: "/eth/v1/beacon/states/{state_id}/proposer_lookahead",
+      method: "GET",
+      req: stateIdOnlyReq,
+      resp: {
+        data: ssz.fulu.ProposerLookahead,
         meta: ExecutionOptimisticFinalizedAndVersionCodec,
       },
     },

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -245,6 +245,13 @@ export const testData: GenericServerTestCases<Endpoints> = {
       meta: {executionOptimistic: true, finalized: false, version: ForkName.electra},
     },
   },
+  getProposerLookahead: {
+    args: {stateId: "head"},
+    res: {
+      data: ssz.fulu.ProposerLookahead.defaultValue(),
+      meta: {executionOptimistic: true, finalized: false, version: ForkName.fulu},
+    },
+  },
 
   // rewards
 

--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -1,9 +1,10 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
-import {EPOCHS_PER_HISTORICAL_VECTOR, isForkPostElectra} from "@lodestar/params";
+import {EPOCHS_PER_HISTORICAL_VECTOR, isForkPostElectra, isForkPostFulu} from "@lodestar/params";
 import {
   BeaconStateAllForks,
   BeaconStateElectra,
+  BeaconStateFulu,
   CachedBeaconStateAltair,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
@@ -363,6 +364,22 @@ export function getBeaconStateApi({
 
       return {
         data: context?.returnBytes ? pendingConsolidations.serialize() : pendingConsolidations.toValue(),
+        meta: {executionOptimistic, finalized, version: fork},
+      };
+    },
+
+    async getProposerLookahead({stateId}, context) {
+      const {state, executionOptimistic, finalized} = await getState(stateId);
+      const fork = config.getForkName(state.slot);
+
+      if (!isForkPostFulu(fork)) {
+        throw new ApiError(400, `Cannot retrieve proposer lookahead for pre-fulu state fork=${fork}`);
+      }
+
+      const {proposerLookahead} = state as BeaconStateFulu;
+
+      return {
+        data: context?.returnBytes ? proposerLookahead.serialize() : proposerLookahead.toValue(),
         meta: {executionOptimistic, finalized, version: fork},
       };
     },


### PR DESCRIPTION
**Motivation**

- https://github.com/ethereum/beacon-APIs/pull/539

**Description**

Add `GET /eth/v1/beacon/states/{state_id}/proposer_lookahead` endpoint to retrieve proposer lookahead from state