### PR TITLE
feat: add endpoint to retrieve data column sidecars

### DIFF
--- a/packages/api/test/unit/beacon/testData/debug.ts
+++ b/packages/api/test/unit/beacon/testData/debug.ts
@@ -76,4 +76,11 @@ export const testData: GenericServerTestCases<Endpoints> = {
       meta: {executionOptimistic: true, finalized: false, version: ForkName.electra},
     },
   },
+  getDebugDataColumnSidecars: {
+    args: {blockId: "head", indices: [0]},
+    res: {
+      data: [ssz.fulu.DataColumnSidecar.defaultValue()],
+      meta: {executionOptimistic: true, finalized: false, version: ForkName.fulu},
+    },
+  },
 };


### PR DESCRIPTION
**Motivation**

- https://github.com/ethereum/beacon-APIs/pull/537

**Description**

Add `GET /eth/v1/debug/beacon/data_column_sidecars/{block_id}` endpoint to retrieve data column sidecars
