### PR TITLE
fix: validate data_column_sidecar before add to cache

### DIFF
--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -278,18 +278,18 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
     const delaySec = chain.clock.secFromSlot(slot, seenTimestampSec);
     const recvToValLatency = Date.now() / 1000 - seenTimestampSec;
 
-    const {blockInput, blockInputMeta} = chain.seenGossipBlockInput.getGossipBlockInput(
-      config,
-      {
-        type: GossipedInputType.dataColumn,
-        dataColumnSidecar,
-        dataColumnBytes,
-      },
-      metrics
-    );
-
     try {
       await validateGossipDataColumnSidecar(chain, dataColumnSidecar, gossipSubnet, metrics);
+      const {blockInput, blockInputMeta} = chain.seenGossipBlockInput.getGossipBlockInput(
+        config,
+        {
+          type: GossipedInputType.dataColumn,
+          dataColumnSidecar,
+          dataColumnBytes,
+        },
+        metrics
+      );
+
       const recvToValidation = Date.now() / 1000 - seenTimestampSec;
       const validationTime = recvToValidation - recvToValLatency;
 
@@ -320,20 +320,12 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
 
       return blockInput;
     } catch (e) {
-      if (e instanceof DataColumnSidecarGossipError) {
-        // Don't trigger this yet if full block and blobs haven't arrived yet
-        if (e.type.code === DataColumnSidecarErrorCode.PARENT_UNKNOWN && blockInput.block !== null) {
-          logger.debug("Gossip dataColumn has error", {slot, root: blockShortHex, code: e.type.code});
-          events.emit(NetworkEvent.unknownBlockParent, {blockInput, peer: peerIdStr});
-        }
-
-        if (e.action === GossipAction.REJECT) {
-          chain.persistInvalidSszValue(
-            ssz.fulu.DataColumnSidecar,
-            dataColumnSidecar,
-            `gossip_reject_slot_${slot}_index_${dataColumnSidecar.index}`
-          );
-        }
+      if (e instanceof DataColumnSidecarGossipError && e.action === GossipAction.REJECT) {
+        chain.persistInvalidSszValue(
+          ssz.fulu.DataColumnSidecar,
+          dataColumnSidecar,
+          `gossip_reject_slot_${slot}_index_${dataColumnSidecar.index}`
+        );
       }
 
       throw e;

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -31,7 +31,6 @@ import {
   BlockError,
   BlockErrorCode,
   BlockGossipError,
-  DataColumnSidecarErrorCode,
   DataColumnSidecarGossipError,
   GossipAction,
   GossipActionError,


### PR DESCRIPTION
**Motivation**

- I was investigating why current peerDAS has faster processed blocks than batch in #7910
- it turns out we add `data_column_sidecar` to cache before validating it

**Description**

- validate `data_column_sidecar` before adding to cache
- do not emit `PARENT_UNKNOWN` because it's not meaningful there: it requires a block and once we have a gossip block with unknown parent we should have emitted `PAARENT_UNKNOWN` already