### PR TITLE
fix: enable attestation grouping for DVs

### DIFF
--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -241,7 +241,7 @@ export class Validator {
       config,
       {
         afterBlockDelaySlotFraction: opts.afterBlockDelaySlotFraction,
-        disableAttestationGrouping: opts.disableAttestationGrouping || opts.distributed,
+        disableAttestationGrouping: opts.disableAttestationGrouping,
         distributedAggregationSelection: opts.distributed,
       }
     );


### PR DESCRIPTION
**Motivation**

Fix for DVs post-electra.

**Description**

Previously from Obol we have required to disable the optimization of Lodestar that skipped asking for a `committee_index`, because we needed it for DVs. However, post-electra the `committee_index` should be 0 per the spec.