### PR TITLE
fix: only announce columns if fulu is scheduled in config

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1226,7 +1226,7 @@ export class BeaconChain implements IBeaconChain {
           //
           // TODO(fulu): If target group count increases, we should wait to update the advertised group until we've
           // backfilled the new groups.
-          if (this.config.getForkSeq(slot) < ForkSeq.fulu) {
+          if (this.config.FULU_FORK_EPOCH !== Infinity && this.config.getForkSeq(slot) < ForkSeq.fulu) {
             this.custodyConfig.updateAdvertisedCustodyGroupCount(targetCustodyGroupCount);
             this.emitter.emit(ChainEvent.updateAdvertisedGroupCount, this.custodyConfig.advertisedCustodyGroupCount);
           }


### PR DESCRIPTION
**Motivation**

Follow-up PR to https://github.com/ChainSafe/lodestar/pull/7943.

As per spec
> This new field MUST be added once `FULU_FORK_EPOCH` is assigned any value other than `FAR_FUTURE_EPOCH`.

we should only announce these if fulu is scheduled in config

**Description**

Only announce columns if fulu is scheduled in config


