### PR TITLE
chore: run beacon api spec tests against v4.0.0-alpha.0

### DIFF
--- a/packages/api/src/beacon/routes/node.ts
+++ b/packages/api/src/beacon/routes/node.ts
@@ -198,15 +198,18 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
           ...JsonOnlyResponseCodec.data,
           toJson: (data) => {
             const json = NetworkIdentityType.toJson(data);
-            (json as {metadata: {custody_group_count: number | undefined}}).metadata.custody_group_count =
-              data.metadata.custodyGroupCount;
+            const {custodyGroupCount} = data.metadata;
+            (json as {metadata: {custody_group_count: string | undefined}}).metadata.custody_group_count =
+              custodyGroupCount !== undefined ? String(custodyGroupCount) : undefined;
             return json;
           },
           fromJson: (json) => {
             const data = NetworkIdentityType.fromJson(json);
-            (data.metadata as Partial<fulu.Metadata>).custodyGroupCount = (
-              json as {metadata: {custody_group_count: number | undefined}}
-            ).metadata.custody_group_count;
+            const {
+              metadata: {custody_group_count},
+            } = json as {metadata: {custody_group_count: string | undefined}};
+            (data.metadata as Partial<fulu.Metadata>).custodyGroupCount =
+              custody_group_count !== undefined ? parseInt(custody_group_count) : undefined;
             return data;
           },
         },

--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -20,7 +20,7 @@ import {testData as validatorTestData} from "./testData/validator.js";
 // Solutions: https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const version = "v3.1.0";
+const version = "v4.0.0-alpha.0";
 const openApiFile: OpenApiFile = {
   url: `https://github.com/ethereum/beacon-APIs/releases/download/${version}/beacon-node-oapi.json`,
   filepath: path.join(__dirname, "../../../oapi-schemas/beacon-node-oapi.json"),


### PR DESCRIPTION
Run against latest release https://github.com/ethereum/beacon-APIs/releases/tag/v4.0.0-alpha.0
