### PR TITLE
feat: define `SubscribeBoundary`

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -100,7 +100,7 @@ export class NetworkCore implements INetworkCore {
   private readonly opts: NetworkOptions;
 
   // Internal state
-  private readonly subscribedBoundaries = new Set<SubscribeBoundary>();
+  private readonly subscribedBoundariesByEpoch = new Map<Epoch, SubscribeBoundary>();
   private closed = false;
 
   constructor(modules: Mods) {
@@ -322,13 +322,13 @@ export class NetworkCore implements INetworkCore {
    * Unsubscribe from all gossip events. Safe to call multiple times
    */
   async unsubscribeGossipCoreTopics(): Promise<void> {
-    for (const fork of this.subscribedBoundaries.values()) {
-      this.unsubscribeCoreTopicsAtBoundary(this.config, fork);
+    for (const boundary of this.subscribedBoundariesByEpoch.values()) {
+      this.unsubscribeCoreTopicsAtBoundary(this.config, boundary);
     }
   }
 
   async isSubscribedToGossipCoreTopics(): Promise<boolean> {
-    return this.subscribedBoundaries.size > 0;
+    return this.subscribedBoundariesByEpoch.size > 0;
   }
 
   sendReqRespRequest(data: OutgoingRequestArgs): AsyncIterable<ResponseIncoming> {
@@ -501,8 +501,9 @@ export class NetworkCore implements INetworkCore {
   };
 
   private subscribeCoreTopicsAtBoundary(config: BeaconConfig, boundary: SubscribeBoundary): void {
-    if (this.subscribedBoundaries.has(boundary)) return;
-    this.subscribedBoundaries.add(boundary);
+    const epoch = config.forks[boundary.fork].epoch;
+    if (this.subscribedBoundariesByEpoch.has(epoch)) return;
+    this.subscribedBoundariesByEpoch.set(epoch, boundary);
     const {subscribeAllSubnets, disableLightClientServer} = this.opts;
 
     for (const topic of getCoreTopicsAtFork(config, boundary.fork, {
@@ -514,8 +515,9 @@ export class NetworkCore implements INetworkCore {
   }
 
   private unsubscribeCoreTopicsAtBoundary(config: BeaconConfig, boundary: SubscribeBoundary): void {
-    if (!this.subscribedBoundaries.has(boundary)) return;
-    this.subscribedBoundaries.delete(boundary);
+    const epoch = config.forks[boundary.fork].epoch;
+    if (!this.subscribedBoundariesByEpoch.has(epoch)) return;
+    this.subscribedBoundariesByEpoch.delete(epoch);
     const {subscribeAllSubnets, disableLightClientServer} = this.opts;
 
     for (const topic of getCoreTopicsAtFork(config, boundary.fork, {

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -220,10 +220,8 @@ export class NetworkCore implements INetworkCore {
     // Network spec decides version changes based on clock fork, not head fork
     const forkCurrentSlot = config.getForkName(clock.currentSlot);
 
-    const boundary = {fork: forkCurrentSlot};
-
     // Register only ReqResp protocols relevant to clock's fork
-    reqResp.registerProtocolsAtBoundary(boundary);
+    reqResp.registerProtocolsAtBoundary({fork: forkCurrentSlot});
 
     // Bind discv5's ENR to local metadata
     // biome-ignore lint/complexity/useLiteralKeys: `discovery` is a private attribute

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -5,7 +5,6 @@ import {Connection, PrivateKey} from "@libp2p/interface";
 import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
-import {ForkName} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {Epoch, phase0, ssz, sszTypesFor} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
@@ -16,7 +15,7 @@ import {ClockEvent, IClock} from "../../util/clock.js";
 import {PeerIdStr, peerIdFromString, peerIdToString} from "../../util/peerId.js";
 import {Discv5Worker} from "../discv5/index.js";
 import {NetworkEventBus} from "../events.js";
-import {FORK_EPOCH_LOOKAHEAD, getActiveForks} from "../forks.js";
+import {FORK_EPOCH_LOOKAHEAD, getActiveSubscribeBoundaries} from "../forks.js";
 import {Eth2Gossipsub, getCoreTopicsAtFork} from "../gossip/index.js";
 import {Libp2p} from "../interface.js";
 import {createNodeJsLibp2p} from "../libp2p/index.js";
@@ -33,7 +32,7 @@ import {CommitteeSubscription, IAttnetsService} from "../subnets/interface.js";
 import {SyncnetsService} from "../subnets/syncnetsService.js";
 import {getConnectionsMap} from "../util.js";
 import {NetworkCoreMetrics, createNetworkCoreMetrics} from "./metrics.js";
-import {INetworkCore, MultiaddrStr} from "./types.js";
+import {INetworkCore, MultiaddrStr, SubscribeBoundary} from "./types.js";
 
 type Mods = {
   libp2p: Libp2p;
@@ -101,7 +100,7 @@ export class NetworkCore implements INetworkCore {
   private readonly opts: NetworkOptions;
 
   // Internal state
-  private readonly subscribedForks = new Set<ForkName>();
+  private readonly subscribedBoundaries = new Set<SubscribeBoundary>();
   private closed = false;
 
   constructor(modules: Mods) {
@@ -220,8 +219,11 @@ export class NetworkCore implements INetworkCore {
 
     // Network spec decides version changes based on clock fork, not head fork
     const forkCurrentSlot = config.getForkName(clock.currentSlot);
+
+    const boundary = {fork: forkCurrentSlot};
+
     // Register only ReqResp protocols relevant to clock's fork
-    reqResp.registerProtocolsAtFork(forkCurrentSlot);
+    reqResp.registerProtocolsAtBoundary(boundary);
 
     // Bind discv5's ENR to local metadata
     // biome-ignore lint/complexity/useLiteralKeys: `discovery` is a private attribute
@@ -313,8 +315,8 @@ export class NetworkCore implements INetworkCore {
       this.logger.info("Subscribed gossip core topics");
     }
 
-    for (const fork of getActiveForks(this.config, this.clock.currentEpoch)) {
-      this.subscribeCoreTopicsAtFork(this.config, fork);
+    for (const boundary of getActiveSubscribeBoundaries(this.config, this.clock.currentEpoch)) {
+      this.subscribeCoreTopicsAtBoundary(this.config, boundary);
     }
   }
 
@@ -322,13 +324,13 @@ export class NetworkCore implements INetworkCore {
    * Unsubscribe from all gossip events. Safe to call multiple times
    */
   async unsubscribeGossipCoreTopics(): Promise<void> {
-    for (const fork of this.subscribedForks.values()) {
-      this.unsubscribeCoreTopicsAtFork(this.config, fork);
+    for (const fork of this.subscribedBoundaries.values()) {
+      this.unsubscribeCoreTopicsAtBoundary(this.config, fork);
     }
   }
 
   async isSubscribedToGossipCoreTopics(): Promise<boolean> {
-    return this.subscribedForks.size > 0;
+    return this.subscribedBoundaries.size > 0;
   }
 
   sendReqRespRequest(data: OutgoingRequestArgs): AsyncIterable<ResponseIncoming> {
@@ -458,40 +460,40 @@ export class NetworkCore implements INetworkCore {
   private onEpoch = async (epoch: Epoch): Promise<void> => {
     try {
       // Compute prev and next fork shifted, so next fork is still next at forkEpoch + FORK_EPOCH_LOOKAHEAD
-      const activeForks = getActiveForks(this.config, epoch);
-      for (let i = 0; i < activeForks.length; i++) {
+      const activeBoundaries = getActiveSubscribeBoundaries(this.config, epoch);
+      for (let i = 0; i < activeBoundaries.length; i++) {
         // Only when a new fork is scheduled post this one
-        if (activeForks[i + 1] !== undefined) {
-          const prevFork = activeForks[i];
-          const nextFork = activeForks[i + 1];
-          const forkEpoch = this.config.forks[nextFork].epoch;
+        if (activeBoundaries[i + 1] !== undefined) {
+          const prevBoundary = activeBoundaries[i];
+          const nextBoundary = activeBoundaries[i + 1];
+          const nextBoundaryEpoch = this.config.forks[nextBoundary.fork].epoch;
 
           // Before fork transition
-          if (epoch === forkEpoch - FORK_EPOCH_LOOKAHEAD) {
+          if (epoch === nextBoundaryEpoch - FORK_EPOCH_LOOKAHEAD) {
             // Don't subscribe to new fork if the node is not subscribed to any topic
             if (await this.isSubscribedToGossipCoreTopics()) {
-              this.subscribeCoreTopicsAtFork(this.config, nextFork);
-              this.logger.info("Subscribing gossip topics before fork", {nextFork});
+              this.subscribeCoreTopicsAtBoundary(this.config, nextBoundary);
+              this.logger.info("Subscribing gossip topics before boundary", nextBoundary);
             } else {
-              this.logger.info("Skipping subscribing gossip topics before fork", {nextFork});
+              this.logger.info("Skipping subscribing gossip topics before boundary", nextBoundary);
             }
-            this.attnetsService.subscribeSubnetsToNextFork(nextFork);
-            this.syncnetsService.subscribeSubnetsToNextFork(nextFork);
+            this.attnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
+            this.syncnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
           }
 
           // On fork transition
-          if (epoch === forkEpoch) {
+          if (epoch === nextBoundaryEpoch) {
             // updateEth2Field() MUST be called with clock epoch, onEpoch event is emitted in response to clock events
             this.metadata.updateEth2Field(epoch);
-            this.reqResp.registerProtocolsAtFork(nextFork);
+            this.reqResp.registerProtocolsAtBoundary(nextBoundary);
           }
 
           // After fork transition
-          if (epoch === forkEpoch + FORK_EPOCH_LOOKAHEAD) {
-            this.logger.info("Unsubscribing gossip topics from prev fork", {prevFork});
-            this.unsubscribeCoreTopicsAtFork(this.config, prevFork);
-            this.attnetsService.unsubscribeSubnetsFromPrevFork(prevFork);
-            this.syncnetsService.unsubscribeSubnetsFromPrevFork(prevFork);
+          if (epoch === nextBoundaryEpoch + FORK_EPOCH_LOOKAHEAD) {
+            this.logger.info("Unsubscribing gossip topics from prev fork", prevBoundary);
+            this.unsubscribeCoreTopicsAtBoundary(this.config, prevBoundary);
+            this.attnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);
+            this.syncnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);
           }
         }
       }
@@ -500,29 +502,29 @@ export class NetworkCore implements INetworkCore {
     }
   };
 
-  private subscribeCoreTopicsAtFork(config: BeaconConfig, fork: ForkName): void {
-    if (this.subscribedForks.has(fork)) return;
-    this.subscribedForks.add(fork);
+  private subscribeCoreTopicsAtBoundary(config: BeaconConfig, boundary: SubscribeBoundary): void {
+    if (this.subscribedBoundaries.has(boundary)) return;
+    this.subscribedBoundaries.add(boundary);
     const {subscribeAllSubnets, disableLightClientServer} = this.opts;
 
-    for (const topic of getCoreTopicsAtFork(config, fork, {
+    for (const topic of getCoreTopicsAtFork(config, boundary.fork, {
       subscribeAllSubnets,
       disableLightClientServer,
     })) {
-      this.gossip.subscribeTopic({...topic, fork});
+      this.gossip.subscribeTopic({...topic, fork: boundary.fork});
     }
   }
 
-  private unsubscribeCoreTopicsAtFork(config: BeaconConfig, fork: ForkName): void {
-    if (!this.subscribedForks.has(fork)) return;
-    this.subscribedForks.delete(fork);
+  private unsubscribeCoreTopicsAtBoundary(config: BeaconConfig, boundary: SubscribeBoundary): void {
+    if (!this.subscribedBoundaries.has(boundary)) return;
+    this.subscribedBoundaries.delete(boundary);
     const {subscribeAllSubnets, disableLightClientServer} = this.opts;
 
-    for (const topic of getCoreTopicsAtFork(config, fork, {
+    for (const topic of getCoreTopicsAtFork(config, boundary.fork, {
       subscribeAllSubnets,
       disableLightClientServer,
     })) {
-      this.gossip.unsubscribeTopic({...topic, fork});
+      this.gossip.unsubscribeTopic({...topic, fork: boundary.fork});
     }
   }
 }

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -455,22 +455,22 @@ export class NetworkCore implements INetworkCore {
   }
 
   /**
-   * Handle subscriptions through fork transitions, @see FORK_EPOCH_LOOKAHEAD
+   * Handle subscriptions through subscribe boundary transitions, @see FORK_EPOCH_LOOKAHEAD
    */
   private onEpoch = async (epoch: Epoch): Promise<void> => {
     try {
       // Compute prev and next fork shifted, so next fork is still next at forkEpoch + FORK_EPOCH_LOOKAHEAD
       const activeBoundaries = getActiveSubscribeBoundaries(this.config, epoch);
       for (let i = 0; i < activeBoundaries.length; i++) {
-        // Only when a new fork is scheduled post this one
+        // Only when a new subscribe boundary is scheduled post this one
         if (activeBoundaries[i + 1] !== undefined) {
           const prevBoundary = activeBoundaries[i];
           const nextBoundary = activeBoundaries[i + 1];
           const nextBoundaryEpoch = this.config.forks[nextBoundary.fork].epoch;
 
-          // Before fork transition
+          // Before subscribe boundary transition
           if (epoch === nextBoundaryEpoch - FORK_EPOCH_LOOKAHEAD) {
-            // Don't subscribe to new fork if the node is not subscribed to any topic
+            // Don't subscribe to new boundary if the node is not subscribed to any topic
             if (await this.isSubscribedToGossipCoreTopics()) {
               this.subscribeCoreTopicsAtBoundary(this.config, nextBoundary);
               this.logger.info("Subscribing gossip topics before boundary", nextBoundary);
@@ -481,16 +481,16 @@ export class NetworkCore implements INetworkCore {
             this.syncnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
           }
 
-          // On fork transition
+          // On boundary transition
           if (epoch === nextBoundaryEpoch) {
             // updateEth2Field() MUST be called with clock epoch, onEpoch event is emitted in response to clock events
             this.metadata.updateEth2Field(epoch);
             this.reqResp.registerProtocolsAtBoundary(nextBoundary);
           }
 
-          // After fork transition
+          // After boundary transition
           if (epoch === nextBoundaryEpoch + FORK_EPOCH_LOOKAHEAD) {
-            this.logger.info("Unsubscribing gossip topics from prev fork", prevBoundary);
+            this.logger.info("Unsubscribing gossip topics before boundary", prevBoundary);
             this.unsubscribeCoreTopicsAtBoundary(this.config, prevBoundary);
             this.attnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);
             this.syncnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);

--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -13,10 +13,7 @@ import {OutgoingRequestArgs} from "../reqresp/types.js";
 import {CommitteeSubscription} from "../subnets/interface.js";
 
 export type MultiaddrStr = string;
-// Boundary of network subscription. We subscribe/unsubscribe during fork and blob schedule transitions
-// TODO: We can actually make `type SubscribeBoundary = Epoch` and rely on the callers to decode it
-// as fork or blob schedule as needed. However it takes some sizable refactor give every callers access
-// to beacon config
+// Boundary of network subscription. We subscribe/unsubscribe during fork transition
 export type SubscribeBoundary = {fork: ForkName};
 
 // Interface shared by main Network class, and all backends

--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -13,7 +13,7 @@ import {OutgoingRequestArgs} from "../reqresp/types.js";
 import {CommitteeSubscription} from "../subnets/interface.js";
 
 export type MultiaddrStr = string;
-// Boundary of network subscription. We subscribe/unsubscribe during fork transition
+/* Boundary of network subscription. We subscribe/unsubscribe during fork transition */
 export type SubscribeBoundary = {fork: ForkName};
 
 // Interface shared by main Network class, and all backends

--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -3,6 +3,7 @@ import {PublishOpts} from "@chainsafe/libp2p-gossipsub/types";
 import {routes} from "@lodestar/api";
 import {SpecJson} from "@lodestar/config";
 import {LoggerNodeOpts} from "@lodestar/logger/node";
+import {ForkName} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {phase0} from "@lodestar/types";
 import {PeerIdStr} from "../../util/peerId.js";
@@ -12,6 +13,11 @@ import {OutgoingRequestArgs} from "../reqresp/types.js";
 import {CommitteeSubscription} from "../subnets/interface.js";
 
 export type MultiaddrStr = string;
+// Boundary of network subscription. We subscribe/unsubscribe during fork and blob schedule transitions
+// TODO: We can actually make `type SubscribeBoundary = Epoch` and rely on the callers to decode it
+// as fork or blob schedule as needed. However it takes some sizable refactor give every callers access
+// to beacon config
+export type SubscribeBoundary = {fork: ForkName};
 
 // Interface shared by main Network class, and all backends
 export interface INetworkCorePublic {

--- a/packages/beacon-node/src/network/forks.ts
+++ b/packages/beacon-node/src/network/forks.ts
@@ -1,6 +1,7 @@
 import {ChainForkConfig, ForkInfo} from "@lodestar/config";
 import {ForkName} from "@lodestar/params";
 import {Epoch} from "@lodestar/types";
+import {SubscribeBoundary} from "./core/types.js";
 
 /**
  * Subscribe topics to the new fork N epochs before the fork. Remove all subscriptions N epochs after the fork
@@ -52,6 +53,12 @@ export function getActiveForks(config: ChainForkConfig, epoch: Epoch): ForkName[
   }
 
   return activeForks;
+}
+
+export function getActiveSubscribeBoundaries(config: ChainForkConfig, epoch: Epoch): SubscribeBoundary[] {
+  const activeForks = getActiveForks(config, epoch);
+
+  return activeForks.map((fork) => ({fork}));
 }
 
 /**

--- a/packages/beacon-node/src/network/gossip/scoringParameters.ts
+++ b/packages/beacon-node/src/network/gossip/scoringParameters.ts
@@ -7,7 +7,7 @@ import {
 import {BeaconConfig} from "@lodestar/config";
 import {ATTESTATION_SUBNET_COUNT, SLOTS_PER_EPOCH, TARGET_AGGREGATORS_PER_COMMITTEE} from "@lodestar/params";
 import {computeCommitteeCount} from "@lodestar/state-transition";
-import {getActiveForks} from "../forks.js";
+import {getActiveSubscribeBoundaries} from "../forks.js";
 import {Eth2Context, Eth2GossipsubModules} from "./gossipsub.js";
 import {GossipType} from "./interface.js";
 import {stringifyGossipTopic} from "./topic.js";
@@ -123,9 +123,10 @@ function getAllTopicsScoreParams(
   const {epochDurationMs, slotDurationMs} = precomputedParams;
   const epoch = eth2Context.currentEpoch;
   const topicsParams: Record<string, TopicScoreParams> = {};
-  const forks = getActiveForks(config, epoch);
+  const boundaries = getActiveSubscribeBoundaries(config, epoch);
   const beaconAttestationSubnetWeight = 1 / ATTESTATION_SUBNET_COUNT;
-  for (const fork of forks) {
+  for (const boundary of boundaries) {
+    const fork = boundary.fork;
     //first all fixed topics
     topicsParams[
       stringifyGossipTopic(config, {

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -35,7 +35,7 @@ import {PeerIdStr, peerIdToString} from "../util/peerId.js";
 import {BlobSidecarsByRootRequest} from "../util/types.js";
 import {INetworkCore, NetworkCore, WorkerNetworkCore} from "./core/index.js";
 import {INetworkEventBus, NetworkEvent, NetworkEventBus, NetworkEventData} from "./events.js";
-import {getActiveForks} from "./forks.js";
+import {getActiveSubscribeBoundaries} from "./forks.js";
 import {GossipHandlers, GossipTopicMap, GossipType, GossipTypeMap} from "./gossip/index.js";
 import {getGossipSSZType, gossipTopicIgnoreDuplicatePublishError, stringifyGossipTopic} from "./gossip/topic.js";
 import {INetwork} from "./interface.js";
@@ -351,10 +351,12 @@ export class Network implements INetwork {
 
   async publishBlsToExecutionChange(blsToExecutionChange: capella.SignedBLSToExecutionChange): Promise<number> {
     const publishChanges = [];
-    for (const fork of getActiveForks(this.config, this.clock.currentEpoch)) {
-      if (ForkSeq[fork] >= ForkSeq.capella) {
+    for (const boundary of getActiveSubscribeBoundaries(this.config, this.clock.currentEpoch)) {
+      const fork = ForkSeq[boundary.fork];
+
+      if (fork >= ForkSeq.capella) {
         const publishPromise = this.publishGossip<GossipType.bls_to_execution_change>(
-          {type: GossipType.bls_to_execution_change, fork},
+          {type: GossipType.bls_to_execution_change, fork: boundary.fork},
           blsToExecutionChange,
           {ignoreDuplicatePublishError: true}
         );

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -17,6 +17,7 @@ import {Logger} from "@lodestar/utils";
 import {Libp2p} from "libp2p";
 import {callInNextEventLoop} from "../../util/eventLoop.js";
 import {NetworkCoreMetrics} from "../core/metrics.js";
+import {SubscribeBoundary} from "../core/types.js";
 import {INetworkEventBus, NetworkEvent} from "../events.js";
 import {MetadataController} from "../metadata.js";
 import {PeersData} from "../peers/peersData.js";
@@ -119,10 +120,10 @@ export class ReqRespBeaconNode extends ReqResp {
   // pruneOnPeerDisconnect(peerId: PeerId): void {
   //   this.rateLimiter.prune(peerId);
 
-  registerProtocolsAtFork(fork: ForkName): void {
-    this.currentRegisteredFork = ForkSeq[fork];
+  registerProtocolsAtBoundary(boundary: SubscribeBoundary): void {
+    this.currentRegisteredFork = ForkSeq[boundary.fork];
 
-    const mustSubscribeProtocols = this.getProtocolsAtFork(fork);
+    const mustSubscribeProtocols = this.getProtocolsAtBoundary(boundary);
     const mustSubscribeProtocolIDs = new Set(
       mustSubscribeProtocols.map(([protocol]) => this.formatProtocolID(protocol))
     );
@@ -217,7 +218,8 @@ export class ReqRespBeaconNode extends ReqResp {
    * Returns the list of protocols that must be subscribed during a specific fork.
    * Any protocol not in this list must be un-subscribed.
    */
-  private getProtocolsAtFork(fork: ForkName): [ProtocolNoHandler, ProtocolHandler][] {
+  private getProtocolsAtBoundary(boundary: SubscribeBoundary): [ProtocolNoHandler, ProtocolHandler][] {
+    const fork = boundary.fork;
     const protocolsAtFork: [ProtocolNoHandler, ProtocolHandler][] = [
       [protocols.Ping(fork, this.config), this.onPing.bind(this)],
       [protocols.Status(fork, this.config), this.onStatus.bind(this)],

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -1,15 +1,12 @@
 import {BeaconConfig} from "@lodestar/config";
-import {
-  ATTESTATION_SUBNET_COUNT,
-  EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION,
-  ForkName,
-  SLOTS_PER_EPOCH,
-} from "@lodestar/params";
+import {ATTESTATION_SUBNET_COUNT, EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Epoch, Slot, SubnetID, ssz} from "@lodestar/types";
 import {Logger, MapDef} from "@lodestar/utils";
 import {ClockEvent, IClock} from "../../util/clock.js";
 import {NetworkCoreMetrics} from "../core/metrics.js";
-import {getActiveForks} from "../forks.js";
+import {SubscribeBoundary} from "../core/types.js";
+import {getActiveSubscribeBoundaries} from "../forks.js";
 import {GossipType} from "../gossip/index.js";
 import {GOSSIP_D_LOW} from "../gossip/scoringParameters.js";
 import {stringifyGossipTopic} from "../gossip/topic.js";
@@ -136,13 +133,13 @@ export class AttnetsService implements IAttnetsService {
    * TODO-dll: clarify how many epochs before the fork we should subscribe to the new fork
    * Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork
    **/
-  subscribeSubnetsToNextFork(nextFork: ForkName): void {
-    this.logger.info("Subscribing to long lived attnets to next fork", {
-      nextFork,
+  subscribeSubnetsAfterBoundary(boundary: SubscribeBoundary): void {
+    this.logger.info("Subscribing to long lived attnets after boundary", {
+      ...boundary,
       subnets: Array.from(this.longLivedSubscriptions).join(","),
     });
     for (const subnet of this.longLivedSubscriptions) {
-      this.gossip.subscribeTopic({type: gossipType, fork: nextFork, subnet});
+      this.gossip.subscribeTopic({type: gossipType, subnet, fork: boundary.fork});
     }
   }
 
@@ -150,11 +147,11 @@ export class AttnetsService implements IAttnetsService {
    * TODO-dll: clarify how many epochs after the fork we should unsubscribe to the new fork
    * Call  ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork
    **/
-  unsubscribeSubnetsFromPrevFork(prevFork: ForkName): void {
-    this.logger.info("Unsubscribing to long lived attnets from prev fork", {prevFork});
+  unsubscribeSubnetsBeforeBoundary(boundary: SubscribeBoundary): void {
+    this.logger.info("Unsubscribing to long lived attnets before boundary", {...boundary});
     for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
       if (!this.opts.subscribeAllSubnets) {
-        this.gossip.unsubscribeTopic({type: gossipType, fork: prevFork, subnet});
+        this.gossip.unsubscribeTopic({type: gossipType, subnet, fork: boundary.fork});
       }
     }
   }
@@ -333,11 +330,12 @@ export class AttnetsService implements IAttnetsService {
    * shortLivedSubscriptions or longLivedSubscriptions should be updated right AFTER this called
    **/
   private subscribeToSubnets(subnets: number[], src: SubnetSource): void {
-    const forks = getActiveForks(this.config, this.clock.currentEpoch);
+    const boundaries = getActiveSubscribeBoundaries(this.config, this.clock.currentEpoch);
+
     for (const subnet of subnets) {
       if (!this.shortLivedSubscriptions.has(subnet) && !this.longLivedSubscriptions.has(subnet)) {
-        for (const fork of forks) {
-          this.gossip.subscribeTopic({type: gossipType, fork, subnet});
+        for (const boundary of boundaries) {
+          this.gossip.subscribeTopic({type: gossipType, subnet, fork: boundary.fork});
         }
         this.metrics?.attnetsService.subscribeSubnets.inc({subnet, src});
       }
@@ -352,11 +350,12 @@ export class AttnetsService implements IAttnetsService {
     // No need to unsubscribeTopic(). Return early to prevent repetitive extra work
     if (this.opts.subscribeAllSubnets) return;
 
-    const forks = getActiveForks(this.config, this.clock.currentEpoch);
+    const boundaries = getActiveSubscribeBoundaries(this.config, this.clock.currentEpoch);
+
     for (const subnet of subnets) {
       if (!this.shortLivedSubscriptions.isActiveAtSlot(subnet, slot) && !this.longLivedSubscriptions.has(subnet)) {
-        for (const fork of forks) {
-          this.gossip.unsubscribeTopic({type: gossipType, fork, subnet});
+        for (const boundary of boundaries) {
+          this.gossip.unsubscribeTopic({type: gossipType, subnet, fork: boundary.fork});
         }
         this.metrics?.attnetsService.unsubscribeSubnets.inc({subnet, src});
       }
@@ -368,10 +367,13 @@ export class AttnetsService implements IAttnetsService {
     metrics.attnetsService.subscriptionsCommittee.set(this.shortLivedSubscriptions.size);
     // track short lived subnet status, >= 6 (Dlo) means healthy, otherwise unhealthy
     const currentSlot = this.clock.currentSlot;
+    const epoch = computeEpochAtSlot(currentSlot);
+    const fork = this.config.getForkInfoAtEpoch(epoch).name;
+
     for (const {subnet} of this.shortLivedSubscriptions.getActiveTtl(currentSlot)) {
       const topicStr = stringifyGossipTopic(this.config, {
         type: gossipType,
-        fork: this.config.getForkName(currentSlot),
+        fork,
         subnet,
       });
       const numMeshPeers = this.gossip.mesh.get(topicStr)?.size ?? 0;

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -367,13 +367,10 @@ export class AttnetsService implements IAttnetsService {
     metrics.attnetsService.subscriptionsCommittee.set(this.shortLivedSubscriptions.size);
     // track short lived subnet status, >= 6 (Dlo) means healthy, otherwise unhealthy
     const currentSlot = this.clock.currentSlot;
-    const epoch = computeEpochAtSlot(currentSlot);
-    const fork = this.config.getForkInfoAtEpoch(epoch).name;
-
     for (const {subnet} of this.shortLivedSubscriptions.getActiveTtl(currentSlot)) {
       const topicStr = stringifyGossipTopic(this.config, {
         type: gossipType,
-        fork,
+        fork: this.config.getForkName(currentSlot),
         subnet,
       });
       const numMeshPeers = this.gossip.mesh.get(topicStr)?.size ?? 0;

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -1,6 +1,5 @@
 import {BeaconConfig} from "@lodestar/config";
 import {ATTESTATION_SUBNET_COUNT, EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Epoch, Slot, SubnetID, ssz} from "@lodestar/types";
 import {Logger, MapDef} from "@lodestar/utils";
 import {ClockEvent, IClock} from "../../util/clock.js";

--- a/packages/beacon-node/src/network/subnets/interface.ts
+++ b/packages/beacon-node/src/network/subnets/interface.ts
@@ -1,5 +1,5 @@
-import {ForkName} from "@lodestar/params";
 import {Bytes32, Slot, SubnetID, ValidatorIndex} from "@lodestar/types";
+import {SubscribeBoundary} from "../core/types.js";
 import {GossipTopic} from "../gossip/interface.js";
 import {RequestedSubnet} from "../peers/utils/index.js";
 
@@ -15,8 +15,8 @@ export type SubnetsService = {
   close(): void;
   addCommitteeSubscriptions(subscriptions: CommitteeSubscription[]): void;
   getActiveSubnets(): RequestedSubnet[];
-  subscribeSubnetsToNextFork(nextFork: ForkName): void;
-  unsubscribeSubnetsFromPrevFork(prevFork: ForkName): void;
+  subscribeSubnetsAfterBoundary(boundary: SubscribeBoundary): void;
+  unsubscribeSubnetsBeforeBoundary(prevFork: SubscribeBoundary): void;
 };
 
 export interface IAttnetsService extends SubnetsService {

--- a/packages/beacon-node/src/network/subnets/syncnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/syncnetsService.ts
@@ -1,11 +1,12 @@
 import {BeaconConfig} from "@lodestar/config";
-import {ForkName, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
+import {SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, ssz} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {ClockEvent, IClock} from "../../util/clock.js";
 import {NetworkCoreMetrics} from "../core/metrics.js";
-import {getActiveForks} from "../forks.js";
+import {SubscribeBoundary} from "../core/types.js";
+import {getActiveSubscribeBoundaries} from "../forks.js";
 import {GossipType} from "../gossip/index.js";
 import {MetadataController} from "../metadata.js";
 import {RequestedSubnet, SubnetMap} from "../peers/utils/index.js";
@@ -73,19 +74,19 @@ export class SyncnetsService implements SubnetsService {
   }
 
   /** Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork  */
-  subscribeSubnetsToNextFork(nextFork: ForkName): void {
-    this.logger.info("Subscribing to random attnets to next fork", {nextFork});
+  subscribeSubnetsAfterBoundary(boundary: SubscribeBoundary): void {
+    this.logger.info("Subscribing to random attnets after boundary", boundary);
     for (const subnet of this.subscriptionsCommittee.getAll()) {
-      this.gossip.subscribeTopic({type: gossipType, fork: nextFork, subnet});
+      this.gossip.subscribeTopic({type: gossipType, fork: boundary.fork, subnet});
     }
   }
 
   /** Call  ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork */
-  unsubscribeSubnetsFromPrevFork(prevFork: ForkName): void {
-    this.logger.info("Unsubscribing to random attnets from prev fork", {prevFork});
+  unsubscribeSubnetsBeforeBoundary(boundary: SubscribeBoundary): void {
+    this.logger.info("Unsubscribing to random attnets before boundary", boundary);
     for (let subnet = 0; subnet < SYNC_COMMITTEE_SUBNET_COUNT; subnet++) {
       if (!this.opts?.subscribeAllSubnets) {
-        this.gossip.unsubscribeTopic({type: gossipType, fork: prevFork, subnet});
+        this.gossip.unsubscribeTopic({type: gossipType, fork: boundary.fork, subnet});
       }
     }
   }
@@ -118,11 +119,11 @@ export class SyncnetsService implements SubnetsService {
 
   /** Tigger a gossip subcription only if not already subscribed */
   private subscribeToSubnets(subnets: number[]): void {
-    const forks = getActiveForks(this.config, this.clock.currentEpoch);
+    const boundaries = getActiveSubscribeBoundaries(this.config, this.clock.currentEpoch);
     for (const subnet of subnets) {
       if (!this.subscriptionsCommittee.has(subnet)) {
-        for (const fork of forks) {
-          this.gossip.subscribeTopic({type: gossipType, fork, subnet});
+        for (const boundary of boundaries) {
+          this.gossip.subscribeTopic({type: gossipType, fork: boundary.fork, subnet});
         }
         this.metrics?.syncnetsService.subscribeSubnets.inc({subnet});
       }
@@ -131,12 +132,12 @@ export class SyncnetsService implements SubnetsService {
 
   /** Trigger a gossip un-subscrition only if no-one is still subscribed */
   private unsubscribeSubnets(subnets: number[]): void {
-    const forks = getActiveForks(this.config, this.clock.currentEpoch);
+    const boundaries = getActiveSubscribeBoundaries(this.config, this.clock.currentEpoch);
     for (const subnet of subnets) {
       // No need to check if active in subscriptionsCommittee since we only have a single SubnetMap
       if (!this.opts?.subscribeAllSubnets) {
-        for (const fork of forks) {
-          this.gossip.unsubscribeTopic({type: gossipType, fork, subnet});
+        for (const boundary of boundaries) {
+          this.gossip.unsubscribeTopic({type: gossipType, fork: boundary.fork, subnet});
         }
         this.metrics?.syncnetsService.unsubscribeSubnets.inc({subnet});
       }

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -63,8 +63,8 @@ describe("network / peers / PeerManager", () => {
       shouldProcess: () => true,
       addCommitteeSubscriptions: () => {},
       close: () => {},
-      subscribeSubnetsToNextFork: () => {},
-      unsubscribeSubnetsFromPrevFork: () => {},
+      subscribeSubnetsAfterBoundary: () => {},
+      unsubscribeSubnetsBeforeBoundary: () => {},
     };
 
     const peerManager = new PeerManager(

--- a/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
@@ -10,7 +10,6 @@ import all from "it-all";
 import {Libp2p, createLibp2p} from "libp2p";
 import {afterEach, describe, expect, it} from "vitest";
 import {ZERO_HASH} from "../../../src/constants/constants.js";
-import {SubscribeBoundary} from "../../../src/network/core/types.js";
 import {
   NetworkEventBus,
   PeerRpcScoreStore,
@@ -100,8 +99,7 @@ describe("reqresp encoder", () => {
 
   it("assert correct handler switch between metadata v2 and v1", async () => {
     const {multiaddr: serverMultiaddr, reqresp} = await getReqResp();
-    const boundary: SubscribeBoundary = {fork: ForkName.phase0};
-    reqresp.registerProtocolsAtBoundary(boundary);
+    reqresp.registerProtocolsAtBoundary({fork: ForkName.phase0});
     await sleep(0); // Sleep to resolve register handler promises
 
     reqresp["metadataController"].attnets.set(0, true);
@@ -136,8 +134,7 @@ describe("reqresp encoder", () => {
           };
         }
     );
-    const boundary: SubscribeBoundary = {fork: ForkName.altair};
-    reqresp.registerProtocolsAtBoundary(boundary);
+    reqresp.registerProtocolsAtBoundary({fork: ForkName.altair});
     await sleep(0); // Sleep to resolve register handler promises
 
     const {libp2p: dialer} = await getLibp2p();

--- a/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
@@ -136,7 +136,7 @@ describe("reqresp encoder", () => {
           };
         }
     );
-    const boundary: SubscribeBoundary = {fork: ForkName.phase0};
+    const boundary: SubscribeBoundary = {fork: ForkName.altair};
     reqresp.registerProtocolsAtBoundary(boundary);
     await sleep(0); // Sleep to resolve register handler promises
 

--- a/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
@@ -10,6 +10,7 @@ import all from "it-all";
 import {Libp2p, createLibp2p} from "libp2p";
 import {afterEach, describe, expect, it} from "vitest";
 import {ZERO_HASH} from "../../../src/constants/constants.js";
+import {SubscribeBoundary} from "../../../src/network/core/types.js";
 import {
   NetworkEventBus,
   PeerRpcScoreStore,
@@ -99,7 +100,8 @@ describe("reqresp encoder", () => {
 
   it("assert correct handler switch between metadata v2 and v1", async () => {
     const {multiaddr: serverMultiaddr, reqresp} = await getReqResp();
-    reqresp.registerProtocolsAtFork(ForkName.phase0);
+    const boundary: SubscribeBoundary = {fork: ForkName.phase0};
+    reqresp.registerProtocolsAtBoundary(boundary);
     await sleep(0); // Sleep to resolve register handler promises
 
     reqresp["metadataController"].attnets.set(0, true);
@@ -134,7 +136,8 @@ describe("reqresp encoder", () => {
           };
         }
     );
-    reqresp.registerProtocolsAtFork(ForkName.altair);
+    const boundary: SubscribeBoundary = {fork: ForkName.phase0};
+    reqresp.registerProtocolsAtBoundary(boundary);
     await sleep(0); // Sleep to resolve register handler promises
 
     const {libp2p: dialer} = await getLibp2p();

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -82,7 +82,7 @@ describe("AttnetsService", () => {
     const secondSubnet = (gossipStub.subscribeTopic.mock.calls[1][0] as unknown as {subnet: SubnetID}).subnet;
     expect(gossipStub.subscribeTopic).toBeCalledTimes(SUBNETS_PER_NODE);
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH * (ALTAIR_FORK_EPOCH - 2) * 1000);
-    service.subscribeSubnetsToNextFork(ForkName.altair);
+    service.subscribeSubnetsAfterBoundary({fork: ForkName.altair});
     // SUBNETS_PER_NODE = 2 => 2 more calls
     // same subnets were called
     expect(gossipStub.subscribeTopic).toHaveBeenCalledWith(
@@ -94,7 +94,7 @@ describe("AttnetsService", () => {
     expect(gossipStub.subscribeTopic).toBeCalledTimes(2 * SUBNETS_PER_NODE);
     // 2 epochs after the fork
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * 4 * 1000);
-    service.unsubscribeSubnetsFromPrevFork(ForkName.phase0);
+    service.unsubscribeSubnetsBeforeBoundary({fork: ForkName.phase0});
     expect(gossipStub.unsubscribeTopic).toHaveBeenCalledWith(
       expect.objectContaining({fork: ForkName.phase0, subnet: firstSubnet})
     );


### PR DESCRIPTION
- Define `SubscribeBoundary`
- Use notion of boundary instead of fork when we subscribe/unsubscribe during fork boundary


This is extracted from #7954 for easier review