### PR TITLE
test: run against stable lighthouse release in sim tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,7 +4,7 @@
 GETH_DOCKER_IMAGE=ethereum/client-go:v1.13.14
 # Use either image or local binary for the testing
 GETH_BINARY_DIR=
-LIGHTHOUSE_DOCKER_IMAGE=sigp/lighthouse:latest-amd64-unstable
+LIGHTHOUSE_DOCKER_IMAGE=sigp/lighthouse:latest
 
 # We can't upgrade nethermind further due to genesis hash mismatch with the geth
 # https://github.com/NethermindEth/nethermind/issues/6683

--- a/.env.test
+++ b/.env.test
@@ -4,7 +4,7 @@
 GETH_DOCKER_IMAGE=ethereum/client-go:v1.13.14
 # Use either image or local binary for the testing
 GETH_BINARY_DIR=
-LIGHTHOUSE_DOCKER_IMAGE=sigp/lighthouse:latest
+LIGHTHOUSE_DOCKER_IMAGE=sigp/lighthouse:v7.0.1
 
 # We can't upgrade nethermind further due to genesis hash mismatch with the geth
 # https://github.com/NethermindEth/nethermind/issues/6683


### PR DESCRIPTION
**Motivation**

[Sim tests are failing](https://github.com/ChainSafe/lodestar/actions/runs/15706086864/job/44325974978) likely due to https://github.com/sigp/lighthouse/pull/7444. It might be that Lighthouse drops support for pre-electra altogether so we need to see how to make that work with our multi fork sim tests.

**Description**

Run against stable lighthouse release in sim tests
