### PR TITLE
fix: ignore `statuses` filter in validators api if `null` is passed

### DIFF
--- a/packages/api/src/beacon/routes/beacon/state.ts
+++ b/packages/api/src/beacon/routes/beacon/state.ts
@@ -476,7 +476,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         parseReqJson: ({params, body = {}}) => ({
           stateId: params.state_id,
           validatorIds: fromValidatorIdsStr(body.ids),
-          statuses: body.statuses,
+          statuses: body.statuses ?? undefined,
         }),
         schema: {
           params: {state_id: Schema.StringRequired},


### PR DESCRIPTION
**Motivation**

- Closes https://github.com/ChainSafe/lodestar/issues/7969

**Description**

We need to ignore `statuses` field if it's set to `null` based on note in beacon-api spec
> Either or both may be `null` to signal that no filtering on that attribute is desired.

I am not exactly sure why that note is there, I think the intend was to clarify how to handle the case if the field is omitted, and not if it's explicitly set to `null` as the schema itself only allows type to be `array`.

In any case, this is simple for us to handle, we can just convert the `null` value to `undefined` during request parsing and handle it the same way as if it was omitted in downstream code.
