### PR TITLE
feat: replace fork with boundary in reqresp's outgoing chunk

### DIFF
--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -297,7 +297,7 @@ export class ReqRespBeaconNode extends ReqResp {
     yield {
       data: ssz.phase0.Status.serialize(this.statusCache.get()),
       // Status topic is fork-agnostic
-      fork: ForkName.phase0,
+      boundary: {fork: ForkName.phase0},
     };
   }
 
@@ -308,7 +308,7 @@ export class ReqRespBeaconNode extends ReqResp {
     yield {
       data: ssz.phase0.Goodbye.serialize(BigInt(0)),
       // Goodbye topic is fork-agnostic
-      fork: ForkName.phase0,
+      boundary: {fork: ForkName.phase0},
     };
   }
 
@@ -318,7 +318,7 @@ export class ReqRespBeaconNode extends ReqResp {
     yield {
       data: ssz.phase0.Ping.serialize(this.metadataController.seqNumber),
       // Ping topic is fork-agnostic
-      fork: ForkName.phase0,
+      boundary: {fork: ForkName.phase0},
     };
   }
 
@@ -332,7 +332,7 @@ export class ReqRespBeaconNode extends ReqResp {
 
     yield {
       data: type.serialize(metadata),
-      fork,
+      boundary: {fork},
     };
   }
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -26,7 +26,7 @@ export async function* onBeaconBlocksByRange(
     for await (const {key, value} of finalized.binaryEntriesStream({gte: startSlot, lt: endSlot})) {
       yield {
         data: value,
-        fork: chain.config.getForkName(finalized.decodeKey(key)),
+        boundary: {fork: chain.config.getForkName(finalized.decodeKey(key))},
       };
     }
   }
@@ -57,7 +57,7 @@ export async function* onBeaconBlocksByRange(
 
         yield {
           data: blockBytes,
-          fork: chain.config.getForkName(block.slot),
+          boundary: {fork: chain.config.getForkName(block.slot)},
         };
       }
 

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRoot.ts
@@ -40,7 +40,7 @@ export async function* onBeaconBlocksByRoot(
 
       yield {
         data: blockBytes,
-        fork: chain.config.getForkName(slot),
+        boundary: {fork: chain.config.getForkName(slot)},
       };
     }
   }

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
@@ -85,7 +85,7 @@ export function* iterateBlobBytesFromWrapper(
     }
     yield {
       data: blobSideCarBytes,
-      fork: chain.config.getForkName(blockSlot),
+      boundary: {fork: chain.config.getForkName(blockSlot)},
     };
   }
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRoot.ts
@@ -55,7 +55,7 @@ export async function* onBlobSidecarsByRoot(
 
     yield {
       data: blobSidecarBytes,
-      fork: chain.config.getForkName(block.slot),
+      boundary: {fork: chain.config.getForkName(block.slot)},
     };
   }
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientBootstrap.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientBootstrap.ts
@@ -19,7 +19,7 @@ export async function* onLightClientBootstrap(requestBody: Root, chain: IBeaconC
     const type = responseSszTypeByMethod[ReqRespMethod.LightClientBootstrap](fork, 0);
     yield {
       data: type.serialize(bootstrap),
-      fork,
+      boundary: {fork},
     };
   } catch (e) {
     if ((e as LightClientServerError).type?.code === LightClientServerErrorCode.RESOURCE_UNAVAILABLE) {

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientFinalityUpdate.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientFinalityUpdate.ts
@@ -15,6 +15,6 @@ export async function* onLightClientFinalityUpdate(chain: IBeaconChain): AsyncIt
   const type = responseSszTypeByMethod[ReqRespMethod.LightClientFinalityUpdate](fork, 0);
   yield {
     data: type.serialize(update),
-    fork,
+    boundary: {fork},
   };
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientOptimisticUpdate.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientOptimisticUpdate.ts
@@ -15,6 +15,6 @@ export async function* onLightClientOptimisticUpdate(chain: IBeaconChain): Async
   const type = responseSszTypeByMethod[ReqRespMethod.LightClientOptimisticUpdate](fork, 0);
   yield {
     data: type.serialize(update),
-    fork,
+    boundary: {fork},
   };
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientUpdatesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientUpdatesByRange.ts
@@ -26,7 +26,7 @@ export async function* onLightClientUpdatesByRange(
 
       yield {
         data: type.serialize(update),
-        fork,
+        boundary: {fork},
       };
     } catch (e) {
       if ((e as LightClientServerError).type?.code === LightClientServerErrorCode.RESOURCE_UNAVAILABLE) {

--- a/packages/beacon-node/src/network/reqresp/handlers/status.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/status.ts
@@ -8,6 +8,6 @@ export async function* onStatus(chain: IBeaconChain): AsyncIterable<ResponseOutg
   yield {
     data: ssz.phase0.Status.serialize(status),
     // Status topic is fork-agnostic
-    fork: ForkName.phase0,
+    boundary: {fork: ForkName.phase0},
   };
 }

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -47,7 +47,7 @@ describe("data serialization through worker boundary", () => {
     [ReqRespBridgeEvent.outgoingResponse]: {
       type: IteratorEventType.next,
       id: 0,
-      item: {data: bytes, fork: ForkName.altair},
+      item: {data: bytes, boundary: {fork: ForkName.altair}},
     },
     [ReqRespBridgeEvent.incomingRequest]: {id: 0, callArgs: {method, req: {data: bytes, version: 1}, peerId}},
     [ReqRespBridgeEvent.incomingResponse]: {

--- a/packages/beacon-node/test/e2e/network/reqresp.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqresp.test.ts
@@ -115,7 +115,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
           if (method === ReqRespMethod.LightClientBootstrap) {
             yield {
               data: ssz.altair.LightClientBootstrap.serialize(expectedValue),
-              fork: ForkName.altair,
+              boundary: {fork: ForkName.altair},
             };
           }
         }
@@ -136,7 +136,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
           if (method === ReqRespMethod.LightClientOptimisticUpdate) {
             yield {
               data: ssz.altair.LightClientOptimisticUpdate.serialize(expectedValue),
-              fork: ForkName.altair,
+              boundary: {fork: ForkName.altair},
             };
           }
         }
@@ -157,7 +157,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
           if (method === ReqRespMethod.LightClientFinalityUpdate) {
             yield {
               data: ssz.altair.LightClientFinalityUpdate.serialize(expectedValue),
-              fork: ForkName.altair,
+              boundary: {fork: ForkName.altair},
             };
           }
         }
@@ -177,7 +177,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
       update.signatureSlot = slot;
       lightClientUpdates.push({
         data: ssz.altair.LightClientUpdate.serialize(update),
-        fork: ForkName.altair,
+        boundary: {fork: ForkName.altair},
       });
     }
 
@@ -332,6 +332,6 @@ function getEmptyEncodedPayloadSignedBeaconBlock(config: ChainForkConfig): Respo
 function wrapBlockAsEncodedPayload(config: ChainForkConfig, block: SignedBeaconBlock): ResponseOutgoing {
   return {
     data: config.getForkTypes(block.message.slot).SignedBeaconBlock.serialize(block),
-    fork: config.getForkName(block.message.slot),
+    boundary: {fork: config.getForkName(block.message.slot)},
   };
 }

--- a/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
@@ -130,7 +130,7 @@ describe("reqresp encoder", () => {
             data: ssz.altair.LightClientOptimisticUpdate.serialize(
               ssz.altair.LightClientOptimisticUpdate.defaultValue()
             ),
-            fork: ForkName.phase0, // Aware that phase0 does not makes sense here, but it's just to pick a fork digest
+            boundary: {fork: ForkName.phase0}, // Aware that phase0 does not makes sense here, but it's just to pick a fork digest
           };
         }
     );

--- a/packages/reqresp/README.md
+++ b/packages/reqresp/README.md
@@ -32,7 +32,7 @@ async function getReqResp(libp2p: Libp2p, logger: Logger): Promise<void> {
     handler: async function* (req) {
       yield {
         data: req.data,
-        fork: ForkName.phase0,
+        boundary: {fork: ForkName.phase0},
       };
     },
   };

--- a/packages/reqresp/src/encoders/responseEncode.ts
+++ b/packages/reqresp/src/encoders/responseEncode.ts
@@ -76,6 +76,6 @@ function getContextBytes(contextBytes: ContextBytesFactory, chunk: ResponseOutgo
 
     // Yield a fixed-width 4 byte chunk, set to the `ForkDigest`
     case ContextBytesType.ForkDigest:
-      return contextBytes.forkDigestContext.forkName2ForkDigest(chunk.fork) as Buffer;
+      return contextBytes.forkDigestContext.forkName2ForkDigest(chunk.boundary.fork) as Buffer;
   }
 }

--- a/packages/reqresp/src/types.ts
+++ b/packages/reqresp/src/types.ts
@@ -6,6 +6,8 @@ import {RateLimiterQuota} from "./rate_limiter/rateLimiterGRCA.js";
 
 export const protocolPrefix = "/eth2/beacon_chain/req";
 
+export type SubscribeBoundary = {fork: ForkName};
+
 /**
  * Available request/response encoding strategies:
  * https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#encoding-strategies
@@ -27,7 +29,11 @@ export type ResponseIncoming = {
 
 export type ResponseOutgoing = {
   data: Uint8Array;
-  fork: ForkName;
+  /**
+   * Reason why outgoing needs boundary but incoming only needs fork is because we can deserialize incoming data
+   * with only fork info, but for outgoing we also need to compute fork digest, which requires boundary.
+   */
+  boundary: SubscribeBoundary;
 };
 
 /**

--- a/packages/reqresp/test/fixtures/encodingStrategies.ts
+++ b/packages/reqresp/test/fixtures/encodingStrategies.ts
@@ -34,7 +34,7 @@ export const goerliShadowForkBlock13249: SszSnappyTestBlockData = {
   type: ssz.bellatrix.SignedBeaconBlock,
   payload: {
     data: fs.readFileSync(path.join(__dirname, "/goerliShadowForkBlock.13249/serialized.ssz")),
-    fork: ForkName.altair,
+    boundary: {fork: ForkName.altair},
   },
   streamedBody: fs.readFileSync(path.join(__dirname, "/goerliShadowForkBlock.13249/streamed.snappy")),
 };

--- a/packages/reqresp/test/fixtures/protocols.ts
+++ b/packages/reqresp/test/fixtures/protocols.ts
@@ -40,7 +40,7 @@ export const numberToStringProtocol: Protocol = {
   handler: async function* handler(req) {
     yield {
       data: Buffer.from(req.data.toString(), "utf8"),
-      fork: ForkName.phase0,
+      boundary: {fork: ForkName.phase0},
     };
   },
 };

--- a/packages/reqresp/test/unit/response/index.test.ts
+++ b/packages/reqresp/test/unit/response/index.test.ts
@@ -21,8 +21,9 @@ const testCases: {
   {
     id: "Yield two chunks, then throw",
     protocol: pingProtocol(async function* () {
-      yield sszSnappyPing.binaryPayload;
-      yield sszSnappyPing.binaryPayload;
+      const payload = sszSnappyPing.binaryPayload;
+      yield {...payload, boundary: {fork: payload.fork}};
+      yield {...payload, boundary: {fork: payload.fork}};
       throw new LodestarError({code: "TEST_ERROR"});
     }),
     requestChunks: sszSnappyPing.chunks, // Request Ping: BigInt(1)

--- a/packages/reqresp/test/utils/response.ts
+++ b/packages/reqresp/test/utils/response.ts
@@ -8,7 +8,11 @@ import {arrToSource} from "../utils/index.js";
 export async function* responseEncode(responseChunks: ResponseChunk[], protocol: Protocol): AsyncIterable<Buffer> {
   for (const chunk of responseChunks) {
     if (chunk.status === RespStatus.SUCCESS) {
-      yield* pipe(arrToSource([chunk.payload]), responseEncodeSuccess(protocol, {onChunk: () => {}}));
+      const payload = chunk.payload;
+      yield* pipe(
+        arrToSource([{...payload, boundary: {fork: payload.fork}}]),
+        responseEncodeSuccess(protocol, {onChunk: () => {}})
+      );
     } else {
       yield* responseEncodeError(protocol, chunk.status, chunk.errorMessage);
     }


### PR DESCRIPTION
Replace `ResponseOutgoing.fork` with `ResponseOutgoing.boundary`

Extracted from #7954 for easier review