### PR TITLE
chore: make buckets required when defining histograms

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -208,6 +208,7 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
         name: "beacon_block_payload_fetched_time",
         help: "Time to fetch the payload from EL",
         labelNames: ["prepType"],
+        buckets: [0.1, 0.2, 0.3, 0.5, 0.7, 1, 2],
       }),
       emptyPayloads: register.gauge<{prepType: PayloadPreparationType}>({
         name: "beacon_block_payload_empty_total",

--- a/packages/utils/src/metrics.ts
+++ b/packages/utils/src/metrics.ts
@@ -44,7 +44,7 @@ export type GaugeConfig<Labels extends LabelsGeneric> = {
 } & (NoLabels extends Labels ? {labelNames?: never} : {labelNames: NonEmptyArray<LabelKeys<Labels>>});
 
 export type HistogramConfig<Labels extends LabelsGeneric> = GaugeConfig<Labels> & {
-  buckets?: number[];
+  buckets: number[];
 };
 
 export type AvgMinMaxConfig<Labels extends LabelsGeneric> = GaugeConfig<Labels>;


### PR DESCRIPTION
**Motivation**

This forces the author of new metrics to set some initial buckets instead of falling back to [prom-client default buckets](https://github.com/siimon/prom-client/blob/c1d76c5d497ef803f6bd90c56c713c3fa811c3e0/lib/histogram.js#L21) which is usually not what we want.

**Description**

Make buckets required when defining histograms
