### PR TITLE
chore: remove unknown casting on getLibP2PError

### DIFF
--- a/packages/beacon-node/src/network/libp2p/error.ts
+++ b/packages/beacon-node/src/network/libp2p/error.ts
@@ -51,5 +51,6 @@ export enum Libp2pError {
 }
 
 export function getLibp2pError(error: Error): Libp2pError {
-  return Libp2pError[(error as unknown as {name: string}).name as keyof typeof Libp2pError] ?? Libp2pError.OtherError;
+  const errorName = error.name as keyof typeof Libp2pError;
+  return Libp2pError[errorName] ?? Libp2pError.OtherError;
 }


### PR DESCRIPTION
Motivation
This PR removes needles casting of error to unknown when indexing the LibP2P  error's objects, improving code readability

1. remove casting of error to unknown as the name property is defined in standard Error

Other option
another good option is to remove type casting  all together by defining a type guard util. as follows

```ts
// Type guard to check if a string is a key of Libp2pError
function isLibp2pErrorKey(name: string): name is keyof typeof Libp2pError {
  return Object.keys(Libp2pError).includes(name);
}

export function getLibp2pError(error: Error): Libp2pError {
  return isLibp2pErrorKey(error.name) ? Libp2pError[error.name] : Libp2pError.OtherError;
}
```

this approach is more verbose but it removes casting all together which is better as avoiding type casting in any scenario is always favourable. perhaps this fn would be useful in combination with the use of getLibP2P  error elsewhere in the codebase.

however. for the purposes of this scenario, the extra verbosity may not be needed since accessing an object with a key that is not present is ok as it will just return u defined and this extra type guard is not critical. (be that casting string to a type that its not guaranteed to be is not correct)

so for this reason my inital commit only removes the unneeded casting to unknown and then to `({ name: string }).name`