### PR TITLE
chore: typos in comments

### DIFF
--- a/packages/state-transition/src/block/processDeposit.ts
+++ b/packages/state-transition/src/block/processDeposit.ts
@@ -19,7 +19,7 @@ import {computeDomain, computeSigningRoot, getMaxEffectiveBalance, increaseBalan
 
 /**
  * Process a Deposit operation. Potentially adds a new validator to the registry. Mutates the validators and balances
- * trees, pushing contigious values at the end.
+ * trees, pushing contiguous values at the end.
  *
  * PERF: Work depends on number of Deposit per block. On regular networks the average is 0 / block.
  */
@@ -147,7 +147,7 @@ export function isValidDepositSignature(
   amount: number,
   depositSignature: Uint8Array
 ): boolean {
-  // verify the deposit signature (proof of posession) which is not checked by the deposit contract
+  // verify the deposit signature (proof of possession) which is not checked by the deposit contract
   const depositMessage = {
     pubkey,
     withdrawalCredentials,

--- a/packages/state-transition/src/epoch/processInactivityUpdates.ts
+++ b/packages/state-transition/src/epoch/processInactivityUpdates.ts
@@ -11,7 +11,7 @@ const inactivityScoresArr = new Array<number>();
 /**
  * Mutates `inactivityScores` from pre-calculated validator flags.
  *
- * PERF: Cost = iterate over an array of size $VALIDATOR_COUNT + 'proportional' to how many validtors are inactive or
+ * PERF: Cost = iterate over an array of size $VALIDATOR_COUNT + 'proportional' to how many validators are inactive or
  * have been inactive in the past, i.e. that require an update to their inactivityScore. Worst case = all validators
  * need to update their non-zero `inactivityScore`.
  *


### PR DESCRIPTION


### **Description:**

Corrected a few minor typos in code comments.

- In `packages/state-transition/src/block/processDeposit.ts`:
    - `contigious` → `contiguous`
    - `posession` → `possession`
- In `packages/state-transition/src/epoch/processInactivityUpdates.ts`:
    - `validtors` → `validators`