### PR TITLE
fix: add electra to cached blob data fork check

### DIFF
--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -177,8 +177,8 @@ export class SeenGossipBlockInput {
 
       blockHex = toHexString(blockRoot);
       blockCache = this.blockInputCache.get(blockHex) ?? getEmptyBlockInputCacheEntry(fork, ++this.globalCacheId);
-      if (blockCache.cachedData?.fork !== ForkName.deneb) {
-        throw Error(`blob data at non deneb fork=${blockCache.fork}`);
+      if (blockCache.cachedData?.fork !== ForkName.deneb && blockCache.cachedData?.fork !== ForkName.electra) {
+        throw Error(`blob data at non deneb/electra fork=${blockCache.fork}`);
       }
 
       // TODO: freetheblobs check if its the same blob or a duplicate and throw/take actions


### PR DESCRIPTION
There are a bunch of these errors pre-fulu because the fork check is only considering deneb
```
Jun-24 13:55:52.337[network]         [34mdebug[39m: Gossip validation blob_sidecar threw a non-GossipActionError - blob data at non deneb fork=electra
Error: blob data at non deneb fork=electra
    at SeenGossipBlockInput.getGossipBlockInput (file:///usr/app/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts:181:15)
    at validateBeaconBlob (file:///usr/app/packages/beacon-node/src/network/processor/gossipHandlers.ts:213:69)
    at Object.blob_sidecar (file:///usr/app/packages/beacon-node/src/network/processor/gossipHandlers.ts:492:32)
    at NetworkProcessor.gossipValidatorFn (file:///usr/app/packages/beacon-node/src/network/processor/gossipValidatorFn.ts:106:54)
    at NetworkProcessor.processPendingGossipsubMessage (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:431:22)
    at NetworkProcessor.executeWork (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:388:16)
    at NetworkProcessor.pushPendingGossipsubMessageToQueue (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:302:10)
    at NetworkProcessor.onPendingGossipsubMessage (file:///usr/app/packages/beacon-node/src/network/processor/index.ts:290:10)
    at NetworkEventBus.emit (node:events:518:28)
    at Worker.<anonymous> (file:///usr/app/packages/beacon-node/src/util/workerEvents.ts:93:14)
```