### PR TITLE
fix: consider BPO forks when setting next fork digest and epoch in ENR

### DIFF
--- a/packages/beacon-node/src/network/forks.ts
+++ b/packages/beacon-node/src/network/forks.ts
@@ -86,38 +86,48 @@ export function getActiveSubscribeBoundaries(config: ChainForkConfig, epoch: Epo
 }
 
 /**
- * Return the currentFork and nextFork given a fork schedule and `epoch`
+ * Return the currentBoundary and nextBoundary given a fork/BPO schedule and `epoch`
  */
-export function getCurrentAndNextFork(
+export function getCurrentAndNextBoundary(
   config: ChainForkConfig,
   epoch: Epoch
-): {currentFork: ForkInfo; nextFork: ForkInfo | undefined} {
-  if (epoch < 0) {
-    epoch = 0;
+): {currentBoundary: SubscribeBoundary; nextBoundary?: SubscribeBoundary} {
+  // normalize negative epochs to zero
+  if (epoch < 0) epoch = 0;
+
+  const schedule = config.forkOrBlobScheduleAscendingEpochOrder;
+  let currIdx = -1;
+
+  // find the last schedule whose start‐epoch ≤ our epoch
+  for (let i = 0; i < schedule.length; i++) {
+    const entry = schedule[i];
+    const e = isBlobSchedule(entry) ? entry.EPOCH : entry.epoch;
+    if (epoch >= e) currIdx = i;
   }
 
-  // NOTE: forks are sorted by ascending epoch, phase0 first
-  const forks = config.forksAscendingEpochOrder;
-  let currentForkIdx = -1;
-  // findLastIndex
-  for (let i = 0; i < forks.length; i++) {
-    if (epoch >= forks[i].epoch) currentForkIdx = i;
+  // if we never found one, fall back to the very first
+  if (currIdx === -1) currIdx = 0;
+
+  const currSchedule = schedule[currIdx];
+  const currEpoch = isBlobSchedule(currSchedule) ? currSchedule.EPOCH : currSchedule.epoch;
+  const currentBoundary = config.getSubscribeBoundary(currEpoch);
+
+  // find the next schedule whose epoch > our epoch
+  let nextIdx = currIdx + 1;
+  let entry = schedule[nextIdx];
+  while (nextIdx < schedule.length && (isBlobSchedule(entry) ? entry.EPOCH : entry.epoch) === currEpoch) {
+    // skip any that have the same epoch
+    nextIdx++;
+    entry = schedule[nextIdx];
   }
 
-  let nextForkIdx = currentForkIdx + 1;
-  const hasNextFork = forks[nextForkIdx] !== undefined && forks[nextForkIdx].epoch !== Infinity;
-  // Keep moving the needle of nextForkIdx if there the higher fork also exists on same epoch
-  // for e.g. altair and bellatrix are on same epoch 6, next fork should be bellatrix
-  if (hasNextFork) {
-    for (let i = nextForkIdx + 1; i < forks.length; i++) {
-      // If the fork's epoch is same as nextForkIdx (which is not equal to infinity),
-      // update nextForkIdx to the same
-      if (forks[i].epoch === forks[nextForkIdx].epoch) nextForkIdx = i;
-    }
+  if (nextIdx >= schedule.length) {
+    return {currentBoundary, nextBoundary: undefined};
   }
 
-  return {
-    currentFork: forks[currentForkIdx] || forks[0],
-    nextFork: hasNextFork ? forks[nextForkIdx] : undefined,
-  };
+  const nextSchedule = schedule[nextIdx];
+  const nextEpoch = isBlobSchedule(nextSchedule) ? nextSchedule.EPOCH : nextSchedule.epoch;
+  const nextBoundary = config.getSubscribeBoundary(nextEpoch);
+
+  return {currentBoundary, nextBoundary};
 }

--- a/packages/beacon-node/src/network/forks.ts
+++ b/packages/beacon-node/src/network/forks.ts
@@ -1,4 +1,4 @@
-import {ChainForkConfig, ForkInfo, SubscribeBoundary, isBlobSchedule} from "@lodestar/config";
+import {ChainForkConfig, SubscribeBoundary, isBlobSchedule} from "@lodestar/config";
 import {ForkName} from "@lodestar/params";
 import {Epoch} from "@lodestar/types";
 

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -1,11 +1,11 @@
 import {BitArray} from "@chainsafe/ssz";
-import {BeaconConfig} from "@lodestar/config";
+import {BeaconConfig, isSubscribeBoundaryPostFulu} from "@lodestar/config";
 import {ForkSeq} from "@lodestar/params";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, fulu, phase0, ssz} from "@lodestar/types";
 import {FAR_FUTURE_EPOCH} from "../constants/index.js";
 import {serializeCgc} from "../util/metadata.js";
-import {getCurrentAndNextFork} from "./forks.js";
+import {getCurrentAndNextBoundary} from "./forks.js";
 import {NetworkConfig} from "./networkConfig.js";
 export enum ENRKey {
   tcp = "tcp",
@@ -133,14 +133,21 @@ export class MetadataController {
 }
 
 export function getENRForkID(config: BeaconConfig, clockEpoch: Epoch): phase0.ENRForkID {
-  const {currentFork, nextFork} = getCurrentAndNextFork(config, clockEpoch);
+  const {currentBoundary, nextBoundary} = getCurrentAndNextBoundary(config, clockEpoch);
 
   return {
     // Current fork digest
-    forkDigest: config.boundary2ForkDigest(config.getSubscribeBoundary(clockEpoch)),
-    // next planned fork versin
-    nextForkVersion: nextFork ? nextFork.version : currentFork.version,
-    // next fork epoch
-    nextForkEpoch: nextFork ? nextFork.epoch : FAR_FUTURE_EPOCH,
+    forkDigest: config.boundary2ForkDigest(currentBoundary),
+    // Next fork version
+    nextForkVersion: nextBoundary
+      ? config.forks[nextBoundary.fork].version
+      : config.forks[currentBoundary.fork].version,
+    // Next fork epoch
+    nextForkEpoch: nextBoundary
+      ? Math.max(
+          config.forks[nextBoundary.fork].epoch,
+          isSubscribeBoundaryPostFulu(nextBoundary) ? nextBoundary.EPOCH : -1
+        )
+      : FAR_FUTURE_EPOCH,
   };
 }

--- a/packages/beacon-node/test/unit/network/fork.test.ts
+++ b/packages/beacon-node/test/unit/network/fork.test.ts
@@ -1,7 +1,7 @@
 import {BeaconConfig, ForkInfo} from "@lodestar/config";
 import {ForkName, ForkSeq} from "@lodestar/params";
 import {describe, expect, it} from "vitest";
-import {getCurrentAndNextFork} from "../../../src/network/forks.js";
+import {getCurrentAndNextBoundary} from "../../../src/network/forks.js";
 
 function getForkConfig({
   phase0,
@@ -170,7 +170,7 @@ for (const testScenario of testScenarios) {
         currentFork,
         nextFork,
       })}, getActiveForks: ${activeForks.join(",")}`, () => {
-        expect(getCurrentAndNextFork(forkConfig, epoch)).toEqual({
+        expect(getCurrentAndNextBoundary(forkConfig, epoch)).toEqual({
           currentFork: forks[currentFork as ForkName],
           nextFork: (nextFork && forks[nextFork as ForkName]) ?? undefined,
         });

--- a/packages/beacon-node/test/unit/network/util.test.ts
+++ b/packages/beacon-node/test/unit/network/util.test.ts
@@ -1,10 +1,10 @@
 import {config} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
 import {afterEach, describe, expect, it} from "vitest";
-import {getCurrentAndNextFork} from "../../../src/network/forks.js";
+import {getCurrentAndNextBoundary} from "../../../src/network/forks.js";
 import {getDiscv5Multiaddrs} from "../../../src/network/libp2p/index.js";
 
-describe("getCurrentAndNextFork", () => {
+describe("getCurrentAndNextBoundary", () => {
   const altairEpoch = config.forks.altair.epoch;
   afterEach(() => {
     config.forks.altair.epoch = altairEpoch;
@@ -12,24 +12,24 @@ describe("getCurrentAndNextFork", () => {
 
   it("should return no next fork if altair epoch is infinity", () => {
     config.forks.altair.epoch = Infinity;
-    const {currentFork, nextFork} = getCurrentAndNextFork(config, 0);
-    expect(currentFork.name).toBe(ForkName.phase0);
-    expect(nextFork).toBeUndefined();
+    const {currentBoundary, nextBoundary} = getCurrentAndNextBoundary(config, 0);
+    expect(currentBoundary.fork).toBe(ForkName.phase0);
+    expect(nextBoundary).toBeUndefined();
   });
 
   it("should return altair as next fork and then bellatrix", () => {
     config.forks.altair.epoch = 1000;
-    let forks = getCurrentAndNextFork(config, 0);
-    expect(forks.currentFork.name).toBe(ForkName.phase0);
-    if (forks.nextFork) {
-      expect(forks.nextFork.name).toBe(ForkName.altair);
+    let forks = getCurrentAndNextBoundary(config, 0);
+    expect(forks.currentBoundary.fork).toBe(ForkName.phase0);
+    if (forks.nextBoundary) {
+      expect(forks.nextBoundary.fork).toBe(ForkName.altair);
     } else {
       expect.fail("No next fork");
     }
 
-    forks = getCurrentAndNextFork(config, 1000);
-    expect(forks.currentFork.name).toBe(ForkName.altair);
-    expect(forks.nextFork?.name).toBe(ForkName.bellatrix);
+    forks = getCurrentAndNextBoundary(config, 1000);
+    expect(forks.currentBoundary.fork).toBe(ForkName.altair);
+    expect(forks.nextBoundary?.fork).toBe(ForkName.bellatrix);
   });
 });
 


### PR DESCRIPTION
Follow up to https://github.com/ChainSafe/lodestar/pull/8002 to consider BPO forks when setting next fork digest (nfd) and next fork epoch in ENR. 