### PR TITLE
feat(cli): add --saveToFile option to voluntary-exit for exporting signed exits to file

### DIFF
--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -21,6 +21,7 @@ type VoluntaryExitArgs = {
   exitEpoch?: number;
   pubkeys?: string[];
   yes?: boolean;
+  saveToFile?: string;
 };
 
 export const voluntaryExit: CliCommand<VoluntaryExitArgs, IValidatorCliArgs & GlobalArgs> = {
@@ -65,9 +66,14 @@ If no `pubkeys` are provided, it will exit all validators that have been importe
       description: "Skip confirmation prompt",
       type: "boolean",
     },
+
+    saveToFile: {
+      description: "Path to file where signed voluntary exit(s) will be saved as JSON instead of being published to the network.",
+      type: "string",
+    },
   },
 
-  handler: async (args) => {
+  handler: async (args: VoluntaryExitArgs & IValidatorCliArgs & GlobalArgs) => {
     // Fetch genesisValidatorsRoot always from beacon node
     // Do not use known networks cache, it defaults to mainnet for devnets
     const {config: chainForkConfig, network} = getBeaconConfigFromArgs(args);
@@ -111,13 +117,19 @@ ${validatorsToExit.map((v) => `${v.pubkey} ${v.index} ${v.status}`).join("\n")}`
     }
 
     const alreadySubmitted = [];
+    const signedExits = [];
     for (const [i, validatorToExit] of validatorsToExit.entries()) {
-      const {err} = await wrapError(processVoluntaryExit({config, client}, exitEpoch, validatorToExit));
+      const {result, err} = await wrapError(signAndMaybeSubmitVoluntaryExit({config, client}, exitEpoch, validatorToExit, !args.saveToFile));
       const {pubkey, index} = validatorToExit;
       if (err === null) {
-        console.log(`Submitted voluntary exit for ${pubkey} (${index}) ${i + 1}/${signersToExit.length}`);
+        if (args.saveToFile) {
+          signedExits.push(result.signedVoluntaryExit);
+          console.log(`Prepared signed voluntary exit for ${pubkey} (${index}) ${i + 1}/${signersToExit.length}`);
+        } else {
+          console.log(`Submitted voluntary exit for ${pubkey} (${index}) ${i + 1}/${signersToExit.length}`);
+        }
       } else {
-        if (err.message.includes("ALREADY_EXISTS")) {
+        if (err.message && err.message.includes("ALREADY_EXISTS")) {
           alreadySubmitted.push(validatorToExit);
         } else {
           console.log(
@@ -125,6 +137,13 @@ ${validatorsToExit.map((v) => `${v.pubkey} ${v.index} ${v.status}`).join("\n")}`
           );
         }
       }
+    }
+
+    if (args.saveToFile && signedExits.length > 0) {
+      // Write all signed voluntary exits to the specified file as a JSON array
+      const {writeFile} = await import("../../util/file.js");
+      writeFile(args.saveToFile, signedExits);
+      console.log(`Saved ${signedExits.length} signed voluntary exit(s) to file: ${args.saveToFile}`);
     }
 
     if (alreadySubmitted.length > 0) {
@@ -137,11 +156,12 @@ ${validatorsToExit.map((v) => `${v.pubkey} ${v.index} ${v.status}`).join("\n")}`
   },
 };
 
-async function processVoluntaryExit(
+async function signAndMaybeSubmitVoluntaryExit(
   {config, client}: {config: BeaconConfig; client: ApiClient},
   exitEpoch: Epoch,
-  validatorToExit: {index: ValidatorIndex; signer: Signer; pubkey: string}
-): Promise<void> {
+  validatorToExit: {index: ValidatorIndex; signer: Signer; pubkey: string},
+  shouldSubmit: boolean
+): Promise<{signedVoluntaryExit: phase0.SignedVoluntaryExit; err: Error | null}> {
   const {index, signer, pubkey} = validatorToExit;
   const slot = computeStartSlotAtEpoch(exitEpoch);
   const domain = config.getDomainForVoluntaryExit(slot);
@@ -162,7 +182,7 @@ async function processVoluntaryExit(
       break;
     }
     default:
-      throw new YargsError(`Unexpected signer type for ${pubkey}`);
+      return {signedVoluntaryExit: null as any, err: new YargsError(`Unexpected signer type for ${pubkey}`)};
   }
 
   const signedVoluntaryExit: phase0.SignedVoluntaryExit = {
@@ -170,7 +190,16 @@ async function processVoluntaryExit(
     signature: signature.toBytes(),
   };
 
-  (await client.beacon.submitPoolVoluntaryExit({signedVoluntaryExit})).assertOk();
+  if (shouldSubmit) {
+    try {
+      (await client.beacon.submitPoolVoluntaryExit({signedVoluntaryExit})).assertOk();
+      return {signedVoluntaryExit, err: null};
+    } catch (err) {
+      return {signedVoluntaryExit, err: err as Error};
+    }
+  } else {
+    return {signedVoluntaryExit, err: null};
+  }
 }
 
 type SignerPubkey = {signer: Signer; pubkey: string};

--- a/packages/cli/src/cmds/validator/voluntaryExit.ts
+++ b/packages/cli/src/cmds/validator/voluntaryExit.ts
@@ -119,22 +119,29 @@ ${validatorsToExit.map((v) => `${v.pubkey} ${v.index} ${v.status}`).join("\n")}`
     const alreadySubmitted = [];
     const signedExits = [];
     for (const [i, validatorToExit] of validatorsToExit.entries()) {
-      const {result, err} = await wrapError(signAndMaybeSubmitVoluntaryExit({config, client}, exitEpoch, validatorToExit, !args.saveToFile));
-      const {pubkey, index} = validatorToExit;
-      if (err === null) {
-        if (args.saveToFile) {
-          signedExits.push(result.signedVoluntaryExit);
-          console.log(`Prepared signed voluntary exit for ${pubkey} (${index}) ${i + 1}/${signersToExit.length}`);
-        } else {
-          console.log(`Submitted voluntary exit for ${pubkey} (${index}) ${i + 1}/${signersToExit.length}`);
-        }
+      const v: {index: ValidatorIndex; signer: Signer; pubkey: string} = validatorToExit;
+      let signedVoluntaryExit: phase0.SignedVoluntaryExit;
+      try {
+        signedVoluntaryExit = await signVoluntaryExit(config, exitEpoch, v);
+      } catch (err) {
+        console.log(`Signing voluntary exit errored for ${v.pubkey} (${v.index}): ${err instanceof Error ? err.message : err}`);
+        continue;
+      }
+      if (args.saveToFile) {
+        signedExits.push(signedVoluntaryExit);
+        console.log(`Prepared signed voluntary exit for ${v.pubkey} (${v.index}) ${i + 1}/${signersToExit.length}`);
       } else {
-        if (err.message && err.message.includes("ALREADY_EXISTS")) {
-          alreadySubmitted.push(validatorToExit);
-        } else {
-          console.log(
-            `Voluntary exit errored for ${pubkey} (${index}) ${i + 1}/${signersToExit.length}: ${err.message}`
-          );
+        try {
+          (await client.beacon.submitPoolVoluntaryExit({signedVoluntaryExit})).assertOk();
+          console.log(`Submitted voluntary exit for ${v.pubkey} (${v.index}) ${i + 1}/${signersToExit.length}`);
+        } catch (err: any) {
+          if (err && err.message && err.message.includes("ALREADY_EXISTS")) {
+            alreadySubmitted.push(v);
+          } else {
+            console.log(
+              `Voluntary exit errored for ${v.pubkey} (${v.index}) ${i + 1}/${signersToExit.length}: ${err && err.message ? err.message : err}`
+            );
+          }
         }
       }
     }
@@ -156,12 +163,11 @@ ${validatorsToExit.map((v) => `${v.pubkey} ${v.index} ${v.status}`).join("\n")}`
   },
 };
 
-async function signAndMaybeSubmitVoluntaryExit(
-  {config, client}: {config: BeaconConfig; client: ApiClient},
+async function signVoluntaryExit(
+  config: BeaconConfig,
   exitEpoch: Epoch,
-  validatorToExit: {index: ValidatorIndex; signer: Signer; pubkey: string},
-  shouldSubmit: boolean
-): Promise<{signedVoluntaryExit: phase0.SignedVoluntaryExit; err: Error | null}> {
+  validatorToExit: {index: ValidatorIndex; signer: Signer; pubkey: string}
+): Promise<phase0.SignedVoluntaryExit> {
   const {index, signer, pubkey} = validatorToExit;
   const slot = computeStartSlotAtEpoch(exitEpoch);
   const domain = config.getDomainForVoluntaryExit(slot);
@@ -182,24 +188,13 @@ async function signAndMaybeSubmitVoluntaryExit(
       break;
     }
     default:
-      return {signedVoluntaryExit: null as any, err: new YargsError(`Unexpected signer type for ${pubkey}`)};
+      throw new YargsError(`Unexpected signer type for ${pubkey}`);
   }
 
-  const signedVoluntaryExit: phase0.SignedVoluntaryExit = {
+  return {
     message: voluntaryExit,
     signature: signature.toBytes(),
   };
-
-  if (shouldSubmit) {
-    try {
-      (await client.beacon.submitPoolVoluntaryExit({signedVoluntaryExit})).assertOk();
-      return {signedVoluntaryExit, err: null};
-    } catch (err) {
-      return {signedVoluntaryExit, err: err as Error};
-    }
-  } else {
-    return {signedVoluntaryExit, err: null};
-  }
 }
 
 type SignerPubkey = {signer: Signer; pubkey: string};


### PR DESCRIPTION
**Motivation**

This PR adds the ability to export signed voluntary exit messages to a file instead of immediately broadcasting them to the network. With EIP-7044, signed voluntary exits are perpetually valid, so it is useful for operators to be able to prepare and store these messages for later submission or manual broadcast. This feature matches similar functionality recently added to Teku and is requested by the community.

**Description**

- Adds a --saveToFile option to the validator voluntary-exit CLI command.
- When specified, the command generates and signs voluntary exit messages for the selected validators and saves them as a JSON array to the given file path, instead of submitting them to the beacon node.
- The exported file is compatible with the beacon API POST endpoint for voluntary exits.
- If the option is not provided, the command behaves as before and submits the signed exits to the beacon node.
- This enables validators to prepare EIP-7044-compliant voluntary exit messages for later use.

Closes #6632 

**Steps to test or reproduce**

git checkout <feature_branch>
lodestar validator voluntary-exit --network <network> --pubkeys <pubkey1> --saveToFile ./exits.json
# Check that ./exits.json contains the signed voluntary exit(s)
