### PR TITLE
refactor: subscribe boundary

### DIFF
--- a/packages/api/src/beacon/routes/lightclient.ts
+++ b/packages/api/src/beacon/routes/lightclient.ts
@@ -1,5 +1,5 @@
 import {ListCompositeType, ValueOf} from "@chainsafe/ssz";
-import {BeaconConfig, ChainForkConfig, createBeaconConfig} from "@lodestar/config";
+import {BeaconConfig, ChainForkConfig, createBeaconConfig, createSubscribeBoundary} from "@lodestar/config";
 import {NetworkName, genesisData} from "@lodestar/config/networks";
 import {ForkName, SLOTS_PER_EPOCH, ZERO_HASH} from "@lodestar/params";
 import {
@@ -133,7 +133,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
             for (const [i, update] of data.entries()) {
               const version = meta.versions[i];
               const epoch = Math.floor(update.attestedHeader.beacon.slot / SLOTS_PER_EPOCH);
-              const boundary = cachedBeaconConfig().getSubscribeBoundary(epoch);
+              const boundary = createSubscribeBoundary(cachedBeaconConfig(), epoch);
               const forkDigest = cachedBeaconConfig().boundary2ForkDigest(boundary);
               const serialized = getPostAltairForkTypes(version).LightClientUpdate.serialize(update);
               const length = ssz.UintNum64.serialize(4 + serialized.length);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
-import {BeaconConfig} from "@lodestar/config";
+import {BeaconConfig, createSubscribeBoundary} from "@lodestar/config";
 import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
 import {ForkSeq, GENESIS_SLOT, SLOTS_PER_EPOCH, isForkPostElectra, isForkPostFulu} from "@lodestar/params";
 import {
@@ -842,7 +842,7 @@ export class BeaconChain implements IBeaconChain {
       // fork_digest: The node's ForkDigest (compute_fork_digest(current_fork_version, genesis_validators_root)) where
       // - current_fork_version is the fork version at the node's current epoch defined by the wall-clock time (not necessarily the epoch to which the node is sync)
       // - genesis_validators_root is the static Root found in state.genesis_validators_root
-      forkDigest: this.config.boundary2ForkDigest(this.config.getSubscribeBoundary(this.clock.currentEpoch)),
+      forkDigest: this.config.boundary2ForkDigest(createSubscribeBoundary(this.config, this.clock.currentEpoch)),
       // finalized_root: state.finalized_checkpoint.root for the state corresponding to the head block (Note this defaults to Root(b'\x00' * 32) for the genesis finalized checkpoint).
       finalizedRoot: finalizedCheckpoint.epoch === GENESIS_EPOCH ? ZERO_HASH : finalizedCheckpoint.root,
       finalizedEpoch: finalizedCheckpoint.epoch,

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -3,7 +3,7 @@ import {PublishOpts} from "@chainsafe/libp2p-gossipsub/types";
 import {Connection, PrivateKey} from "@libp2p/interface";
 import {peerIdFromPrivateKey} from "@libp2p/peer-id";
 import {routes} from "@lodestar/api";
-import {BeaconConfig, SubscribeBoundary, isSubscribeBoundaryPostFulu} from "@lodestar/config";
+import {BeaconConfig, SubscribeBoundary, createSubscribeBoundary} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {Epoch, Status, sszTypesFor} from "@lodestar/types";
@@ -230,7 +230,7 @@ export class NetworkCore implements INetworkCore {
     );
 
     // Network spec decides version changes based on clock fork, not head fork
-    const boundary = config.getSubscribeBoundary(clock.currentEpoch);
+    const boundary = createSubscribeBoundary(config, clock.currentEpoch);
     // Register only ReqResp protocols relevant to clock's epoch
     reqResp.registerProtocolsAtBoundary(boundary);
 
@@ -493,18 +493,16 @@ export class NetworkCore implements INetworkCore {
           const prevBoundary = activeBoundaries[i];
           const nextBoundary = activeBoundaries[i + 1];
 
-          // If EPOCH does not exist, that means next boundary is still pre-fulu
-          const blobScheduleEpoch = isSubscribeBoundaryPostFulu(nextBoundary) ? nextBoundary.EPOCH : -1;
-          const nextBoundaryEpoch = Math.max(this.config.forks[nextBoundary.fork].epoch, blobScheduleEpoch);
+          const nextBoundaryEpoch = nextBoundary.epoch;
 
           // Before subscribe boundary transition
           if (epoch === nextBoundaryEpoch - FORK_EPOCH_LOOKAHEAD) {
             // Don't subscribe to new boundary if the node is not subscribed to any topic
             if (await this.isSubscribedToGossipCoreTopics()) {
               this.subscribeCoreTopicsAtBoundary(this.config, nextBoundary);
-              this.logger.info("Subscribing gossip topics before boundary", nextBoundary);
+              this.logger.info("Subscribing gossip topics before boundary epoch", nextBoundary.epoch);
             } else {
-              this.logger.info("Skipping subscribing gossip topics before boundary", nextBoundary);
+              this.logger.info("Skipping subscribing gossip topics before boundary epoch", nextBoundary.epoch);
             }
             this.attnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
             this.syncnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
@@ -519,7 +517,7 @@ export class NetworkCore implements INetworkCore {
 
           // After boundary transition
           if (epoch === nextBoundaryEpoch + FORK_EPOCH_LOOKAHEAD) {
-            this.logger.info("Unsubscribing gossip topics before boundary", prevBoundary);
+            this.logger.info("Unsubscribing gossip topics before boundary epoch", prevBoundary.epoch);
             this.unsubscribeCoreTopicsAtBoundary(this.config, prevBoundary);
             this.attnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);
             this.syncnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);

--- a/packages/beacon-node/src/network/forks.ts
+++ b/packages/beacon-node/src/network/forks.ts
@@ -1,4 +1,4 @@
-import {ChainForkConfig, SubscribeBoundary, isBlobSchedule} from "@lodestar/config";
+import {ChainForkConfig, SubscribeBoundary, createSubscribeBoundary, isBpo} from "@lodestar/config";
 import {ForkName} from "@lodestar/params";
 import {Epoch} from "@lodestar/types";
 
@@ -56,19 +56,17 @@ export function getActiveForks(config: ChainForkConfig, epoch: Epoch): ForkName[
 
 export function getActiveSubscribeBoundaries(config: ChainForkConfig, epoch: Epoch): SubscribeBoundary[] {
   const activeBoundaries: SubscribeBoundary[] = [];
-  const forkOrBlobScheduleList = config.forkOrBlobScheduleAscendingEpochOrder;
+  const forkOrBlobScheduleList = config.forkOrBpoAscendingEpochOrder;
 
   for (let i = 0; i < forkOrBlobScheduleList.length; i++) {
     const currForkOrBlobSchedule = forkOrBlobScheduleList[i];
     const nextForkOrBlobSchedule = forkOrBlobScheduleList[i + 1];
 
-    const currEpoch = isBlobSchedule(currForkOrBlobSchedule)
-      ? currForkOrBlobSchedule.EPOCH
-      : currForkOrBlobSchedule.epoch;
+    const currEpoch = isBpo(currForkOrBlobSchedule) ? currForkOrBlobSchedule.EPOCH : currForkOrBlobSchedule.epoch;
     const nextEpoch =
       nextForkOrBlobSchedule === undefined
         ? Infinity
-        : isBlobSchedule(nextForkOrBlobSchedule)
+        : isBpo(nextForkOrBlobSchedule)
           ? nextForkOrBlobSchedule.EPOCH
           : nextForkOrBlobSchedule.epoch;
 
@@ -78,7 +76,7 @@ export function getActiveSubscribeBoundaries(config: ChainForkConfig, epoch: Epo
     }
 
     if (epoch >= currEpoch - FORK_EPOCH_LOOKAHEAD && epoch <= nextEpoch + FORK_EPOCH_LOOKAHEAD) {
-      activeBoundaries.push(config.getSubscribeBoundary(currEpoch));
+      activeBoundaries.push(createSubscribeBoundary(config, currEpoch));
     }
   }
 
@@ -95,13 +93,13 @@ export function getCurrentAndNextBoundary(
   // normalize negative epochs to zero
   if (epoch < 0) epoch = 0;
 
-  const schedule = config.forkOrBlobScheduleAscendingEpochOrder;
+  const schedule = config.forkOrBpoAscendingEpochOrder;
   let currIdx = -1;
 
   // find the last schedule whose start‐epoch ≤ our epoch
   for (let i = 0; i < schedule.length; i++) {
     const entry = schedule[i];
-    const e = isBlobSchedule(entry) ? entry.EPOCH : entry.epoch;
+    const e = isBpo(entry) ? entry.EPOCH : entry.epoch;
     if (epoch >= e) currIdx = i;
   }
 
@@ -109,13 +107,13 @@ export function getCurrentAndNextBoundary(
   if (currIdx === -1) currIdx = 0;
 
   const currSchedule = schedule[currIdx];
-  const currEpoch = isBlobSchedule(currSchedule) ? currSchedule.EPOCH : currSchedule.epoch;
-  const currentBoundary = config.getSubscribeBoundary(currEpoch);
+  const currEpoch = isBpo(currSchedule) ? currSchedule.EPOCH : currSchedule.epoch;
+  const currentBoundary = createSubscribeBoundary(config, currEpoch);
 
   // find the next schedule whose epoch > our epoch
   let nextIdx = currIdx + 1;
   let entry = schedule[nextIdx];
-  while (nextIdx < schedule.length && (isBlobSchedule(entry) ? entry.EPOCH : entry.epoch) === currEpoch) {
+  while (nextIdx < schedule.length && (isBpo(entry) ? entry.EPOCH : entry.epoch) === currEpoch) {
     // skip any that have the same epoch
     nextIdx++;
     entry = schedule[nextIdx];
@@ -126,8 +124,8 @@ export function getCurrentAndNextBoundary(
   }
 
   const nextSchedule = schedule[nextIdx];
-  const nextEpoch = isBlobSchedule(nextSchedule) ? nextSchedule.EPOCH : nextSchedule.epoch;
-  const nextBoundary = config.getSubscribeBoundary(nextEpoch);
+  const nextEpoch = isBpo(nextSchedule) ? nextSchedule.EPOCH : nextSchedule.epoch;
+  const nextBoundary = createSubscribeBoundary(config, nextEpoch);
 
   return {currentBoundary, nextBoundary};
 }

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -2,14 +2,8 @@ import {GossipSub, GossipsubEvents} from "@chainsafe/libp2p-gossipsub";
 import {MetricsRegister, TopicLabel, TopicStrToLabel} from "@chainsafe/libp2p-gossipsub/metrics";
 import {PeerScoreParams} from "@chainsafe/libp2p-gossipsub/score";
 import {SignaturePolicy, TopicStr} from "@chainsafe/libp2p-gossipsub/types";
-import {BeaconConfig} from "@lodestar/config";
-import {
-  ATTESTATION_SUBNET_COUNT,
-  ForkName,
-  SLOTS_PER_EPOCH,
-  SYNC_COMMITTEE_SUBNET_COUNT,
-  isForkPostFulu,
-} from "@lodestar/params";
+import {BeaconConfig, createSubscribeBoundary, isBpo} from "@lodestar/config";
+import {ATTESTATION_SUBNET_COUNT, ForkName, SLOTS_PER_EPOCH, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
 import {SubnetID} from "@lodestar/types";
 import {Logger, Map2d, Map2dArr} from "@lodestar/utils";
 
@@ -341,37 +335,19 @@ function attSubnetLabel(subnet: SubnetID): string {
 function getMetricsTopicStrToLabel(config: BeaconConfig, opts: {disableLightClientServer: boolean}): TopicStrToLabel {
   const metricsTopicStrToLabel = new Map<TopicStr, TopicLabel>();
 
-  // Hard forks
-  for (const {name: fork} of config.forksAscendingEpochOrder) {
-    const topics = getCoreTopicsAtFork(config, fork, {
-      subscribeAllSubnets: true,
-      disableLightClientServer: opts.disableLightClientServer,
-    });
-    if (!isForkPostFulu(fork)) {
-      for (const topic of topics) {
-        metricsTopicStrToLabel.set(stringifyGossipTopic(config, {...topic, boundary: {fork}}), topic.type);
-      }
-    } else {
-      // Post fulu fork activations require blob schedule to calculate gossip topic
-      const blobSchedule = config.getBlobParameters(config.forks[fork].epoch);
-      for (const topic of topics) {
-        metricsTopicStrToLabel.set(
-          stringifyGossipTopic(config, {...topic, boundary: {...blobSchedule, fork}}),
-          topic.type
-        );
-      }
-    }
-  }
+  for (const forkOrBpo of config.forkOrBpoAscendingEpochOrder) {
+    const fork = isBpo(forkOrBpo) ? config.getForkInfoAtEpoch(forkOrBpo.EPOCH).name : forkOrBpo.name;
+    const epoch = isBpo(forkOrBpo) ? forkOrBpo.EPOCH : forkOrBpo.epoch;
 
-  // BPO forks
-  for (const entry of config.BLOB_SCHEDULE) {
-    const fork = config.getForkInfoAtEpoch(entry.EPOCH).name;
     const topics = getCoreTopicsAtFork(config, fork, {
       subscribeAllSubnets: true,
       disableLightClientServer: opts.disableLightClientServer,
     });
+
+    const boundary = createSubscribeBoundary(config, epoch);
+
     for (const topic of topics) {
-      metricsTopicStrToLabel.set(stringifyGossipTopic(config, {...topic, boundary: {...entry, fork}}), topic.type);
+      metricsTopicStrToLabel.set(stringifyGossipTopic(config, {...topic, boundary}), topic.type);
     }
   }
 

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -1,4 +1,4 @@
-import {BeaconConfig, ChainConfig} from "@lodestar/config";
+import {BeaconConfig, ChainConfig, createSubscribeBoundary} from "@lodestar/config";
 import {
   ATTESTATION_SUBNET_COUNT,
   DATA_COLUMN_SIDECAR_SUBNET_COUNT,
@@ -181,7 +181,7 @@ export function parseGossipTopic(forkDigestContext: BeaconConfig, topicStr: stri
     const fork = forkDigestContext.forkDigest2ForkName(forkDigestHexNoPrefix);
     // TODO: This epoch is just an approximate. Will update in the next PR
     const epoch = forkDigestContext.forks[fork].epoch;
-    const boundary = forkDigestContext.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(forkDigestContext, epoch);
     const encoding = parseEncodingStr(encodingStr);
 
     // Inline-d the parseGossipTopicType() function since spreading the resulting object x4 the time to parse a topicStr

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -1,5 +1,5 @@
 import {BitArray} from "@chainsafe/ssz";
-import {BeaconConfig, isSubscribeBoundaryPostFulu} from "@lodestar/config";
+import {BeaconConfig, createSubscribeBoundary} from "@lodestar/config";
 import {ForkSeq} from "@lodestar/params";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, fulu, phase0, ssz} from "@lodestar/types";
@@ -125,7 +125,7 @@ export class MetadataController {
     this.onSetValue(ENRKey.eth2, enrForkIdBytes);
     const nextForkDigest =
       enrForkId.nextForkEpoch !== FAR_FUTURE_EPOCH
-        ? config.boundary2ForkDigest(config.getSubscribeBoundary(enrForkId.nextForkEpoch))
+        ? config.boundary2ForkDigest(createSubscribeBoundary(config, enrForkId.nextForkEpoch))
         : ssz.ForkDigest.defaultValue();
     this.onSetValue(ENRKey.nfd, nextForkDigest);
     return enrForkIdBytes;
@@ -143,11 +143,6 @@ export function getENRForkID(config: BeaconConfig, clockEpoch: Epoch): phase0.EN
       ? config.forks[nextBoundary.fork].version
       : config.forks[currentBoundary.fork].version,
     // Next fork epoch
-    nextForkEpoch: nextBoundary
-      ? Math.max(
-          config.forks[nextBoundary.fork].epoch,
-          isSubscribeBoundaryPostFulu(nextBoundary) ? nextBoundary.EPOCH : -1
-        )
-      : FAR_FUTURE_EPOCH,
+    nextForkEpoch: nextBoundary ? nextBoundary.epoch : FAR_FUTURE_EPOCH,
   };
 }

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -3,7 +3,7 @@ import {PublishOpts} from "@chainsafe/libp2p-gossipsub/types";
 import {PeerId, PrivateKey} from "@libp2p/interface";
 import {peerIdFromPrivateKey} from "@libp2p/peer-id";
 import {routes} from "@lodestar/api";
-import {BeaconConfig} from "@lodestar/config";
+import {BeaconConfig, createSubscribeBoundary} from "@lodestar/config";
 import {LoggerNode} from "@lodestar/logger/node";
 import {ForkSeq, NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
@@ -332,7 +332,7 @@ export class Network implements INetwork {
 
   async publishBeaconBlock(signedBlock: SignedBeaconBlock): Promise<number> {
     const epoch = computeEpochAtSlot(signedBlock.message.slot);
-    const boundary = this.config.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(this.config, epoch);
 
     return this.publishGossip<GossipType.beacon_block>({type: GossipType.beacon_block, boundary}, signedBlock, {
       ignoreDuplicatePublishError: true,
@@ -341,7 +341,7 @@ export class Network implements INetwork {
 
   async publishBlobSidecar(blobSidecar: deneb.BlobSidecar): Promise<number> {
     const epoch = computeEpochAtSlot(blobSidecar.signedBlockHeader.message.slot);
-    const boundary = this.config.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(this.config, epoch);
 
     const subnet = blobSidecar.index;
 
@@ -352,7 +352,7 @@ export class Network implements INetwork {
 
   async publishDataColumnSidecar(dataColumnSidecar: fulu.DataColumnSidecar): Promise<number> {
     const epoch = computeEpochAtSlot(dataColumnSidecar.signedBlockHeader.message.slot);
-    const boundary = this.config.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(this.config, epoch);
 
     const subnet = computeSubnetForDataColumnSidecar(dataColumnSidecar);
     return this.publishGossip<GossipType.data_column_sidecar>(
@@ -366,7 +366,7 @@ export class Network implements INetwork {
 
   async publishBeaconAggregateAndProof(aggregateAndProof: SignedAggregateAndProof): Promise<number> {
     const epoch = computeEpochAtSlot(aggregateAndProof.message.aggregate.data.slot);
-    const boundary = this.config.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(this.config, epoch);
 
     return this.publishGossip<GossipType.beacon_aggregate_and_proof>(
       {type: GossipType.beacon_aggregate_and_proof, boundary},
@@ -377,7 +377,7 @@ export class Network implements INetwork {
 
   async publishBeaconAttestation(attestation: SingleAttestation, subnet: SubnetID): Promise<number> {
     const epoch = computeEpochAtSlot(attestation.data.slot);
-    const boundary = this.config.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(this.config, epoch);
 
     return this.publishGossip<GossipType.beacon_attestation>(
       {type: GossipType.beacon_attestation, boundary, subnet},
@@ -388,7 +388,7 @@ export class Network implements INetwork {
 
   async publishVoluntaryExit(voluntaryExit: phase0.SignedVoluntaryExit): Promise<number> {
     const epoch = voluntaryExit.message.epoch;
-    const boundary = this.config.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(this.config, epoch);
 
     return this.publishGossip<GossipType.voluntary_exit>({type: GossipType.voluntary_exit, boundary}, voluntaryExit, {
       ignoreDuplicatePublishError: true,
@@ -418,7 +418,7 @@ export class Network implements INetwork {
 
   async publishProposerSlashing(proposerSlashing: phase0.ProposerSlashing): Promise<number> {
     const epoch = computeEpochAtSlot(Number(proposerSlashing.signedHeader1.message.slot as bigint));
-    const boundary = this.config.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(this.config, epoch);
 
     return this.publishGossip<GossipType.proposer_slashing>(
       {type: GossipType.proposer_slashing, boundary},
@@ -428,7 +428,7 @@ export class Network implements INetwork {
 
   async publishAttesterSlashing(attesterSlashing: AttesterSlashing): Promise<number> {
     const epoch = computeEpochAtSlot(Number(attesterSlashing.attestation1.data.slot as bigint));
-    const boundary = this.config.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(this.config, epoch);
 
     return this.publishGossip<GossipType.attester_slashing>(
       {type: GossipType.attester_slashing, boundary},
@@ -438,7 +438,7 @@ export class Network implements INetwork {
 
   async publishSyncCommitteeSignature(signature: altair.SyncCommitteeMessage, subnet: SubnetID): Promise<number> {
     const epoch = computeEpochAtSlot(signature.slot);
-    const boundary = this.config.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(this.config, epoch);
 
     return this.publishGossip<GossipType.sync_committee>(
       {type: GossipType.sync_committee, boundary, subnet},
@@ -451,7 +451,7 @@ export class Network implements INetwork {
 
   async publishContributionAndProof(contributionAndProof: altair.SignedContributionAndProof): Promise<number> {
     const epoch = computeEpochAtSlot(contributionAndProof.message.contribution.slot);
-    const boundary = this.config.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(this.config, epoch);
 
     return this.publishGossip<GossipType.sync_committee_contribution_and_proof>(
       {type: GossipType.sync_committee_contribution_and_proof, boundary},
@@ -462,7 +462,7 @@ export class Network implements INetwork {
 
   async publishLightClientFinalityUpdate(update: LightClientFinalityUpdate): Promise<number> {
     const epoch = computeEpochAtSlot(update.signatureSlot);
-    const boundary = this.config.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(this.config, epoch);
 
     return this.publishGossip<GossipType.light_client_finality_update>(
       {type: GossipType.light_client_finality_update, boundary},
@@ -472,7 +472,7 @@ export class Network implements INetwork {
 
   async publishLightClientOptimisticUpdate(update: LightClientOptimisticUpdate): Promise<number> {
     const epoch = computeEpochAtSlot(update.signatureSlot);
-    const boundary = this.config.getSubscribeBoundary(epoch);
+    const boundary = createSubscribeBoundary(this.config, epoch);
 
     return this.publishGossip<GossipType.light_client_optimistic_update>(
       {type: GossipType.light_client_optimistic_update, boundary},

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -1,5 +1,5 @@
 import {PeerId} from "@libp2p/interface";
-import {BeaconConfig, SubscribeBoundary} from "@lodestar/config";
+import {BeaconConfig, SubscribeBoundary, createSubscribeBoundary} from "@lodestar/config";
 import {ForkName, ForkSeq} from "@lodestar/params";
 import {
   Encoding,
@@ -331,7 +331,7 @@ export class ReqRespBeaconNode extends ReqResp {
     const status = this.statusCache.get();
     yield {
       data: type.serialize(status as fulu.Status),
-      boundary: this.config.getSubscribeBoundary(computeEpochAtSlot(body.headSlot)),
+      boundary: createSubscribeBoundary(this.config, computeEpochAtSlot(body.headSlot)),
     };
   }
 
@@ -341,8 +341,8 @@ export class ReqRespBeaconNode extends ReqResp {
 
     yield {
       data: ssz.phase0.Goodbye.serialize(BigInt(0)),
-      // Goodbye topic is fork-agnostic
-      boundary: {fork: ForkName.phase0},
+      // Goodbye topic is fork-agnostic.
+      boundary: createSubscribeBoundary(this.config, 0),
     };
   }
 
@@ -352,7 +352,7 @@ export class ReqRespBeaconNode extends ReqResp {
     yield {
       data: ssz.phase0.Ping.serialize(this.metadataController.seqNumber),
       // Ping topic is fork-agnostic
-      boundary: {fork: ForkName.phase0},
+      boundary: createSubscribeBoundary(this.config, 0),
     };
   }
 
@@ -368,7 +368,7 @@ export class ReqRespBeaconNode extends ReqResp {
 
     yield {
       data: type.serialize(metadata),
-      boundary: {fork},
+      boundary: createSubscribeBoundary(this.config, 0),
     };
   }
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -1,4 +1,4 @@
-import {BeaconConfig} from "@lodestar/config";
+import {BeaconConfig, createSubscribeBoundary} from "@lodestar/config";
 import {GENESIS_SLOT, MAX_REQUEST_BLOCKS, MAX_REQUEST_BLOCKS_DENEB, isForkPostDeneb} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
@@ -27,7 +27,7 @@ export async function* onBeaconBlocksByRange(
     for await (const {key, value} of finalized.binaryEntriesStream({gte: startSlot, lt: endSlot})) {
       yield {
         data: value,
-        boundary: chain.config.getSubscribeBoundary(computeEpochAtSlot(finalized.decodeKey(key))),
+        boundary: createSubscribeBoundary(chain.config, computeEpochAtSlot(finalized.decodeKey(key))),
       };
     }
   }
@@ -58,7 +58,7 @@ export async function* onBeaconBlocksByRange(
 
         yield {
           data: blockBytes,
-          boundary: chain.config.getSubscribeBoundary(computeEpochAtSlot(block.slot)),
+          boundary: createSubscribeBoundary(chain.config, computeEpochAtSlot(block.slot)),
         };
       }
 

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRoot.ts
@@ -1,3 +1,4 @@
+import {createSubscribeBoundary} from "@lodestar/config";
 import {ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Slot, phase0} from "@lodestar/types";
@@ -41,7 +42,7 @@ export async function* onBeaconBlocksByRoot(
 
       yield {
         data: blockBytes,
-        boundary: chain.config.getSubscribeBoundary(computeEpochAtSlot(slot)),
+        boundary: createSubscribeBoundary(chain.config, computeEpochAtSlot(slot)),
       };
     }
   }

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
@@ -1,4 +1,4 @@
-import {BeaconConfig} from "@lodestar/config";
+import {BeaconConfig, createSubscribeBoundary} from "@lodestar/config";
 import {BLOBSIDECAR_FIXED_SIZE, GENESIS_SLOT} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
@@ -86,7 +86,7 @@ export function* iterateBlobBytesFromWrapper(
     }
     yield {
       data: blobSideCarBytes,
-      boundary: chain.config.getSubscribeBoundary(computeEpochAtSlot(blockSlot)),
+      boundary: createSubscribeBoundary(chain.config, computeEpochAtSlot(blockSlot)),
     };
   }
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRoot.ts
@@ -1,3 +1,4 @@
+import {createSubscribeBoundary} from "@lodestar/config";
 import {BLOBSIDECAR_FIXED_SIZE} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
@@ -56,7 +57,7 @@ export async function* onBlobSidecarsByRoot(
 
     yield {
       data: blobSidecarBytes,
-      boundary: chain.config.getSubscribeBoundary(computeEpochAtSlot(block.slot)),
+      boundary: createSubscribeBoundary(chain.config, computeEpochAtSlot(block.slot)),
     };
   }
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
@@ -1,3 +1,4 @@
+import {createSubscribeBoundary} from "@lodestar/config";
 import {GENESIS_SLOT, MAX_REQUEST_BLOCKS_DENEB, NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
@@ -138,7 +139,7 @@ export function* iterateDataColumnBytesFromWrapper(
     // console.log(`iterate onDataColumnSidecarsByRange blockSlot=${blockSlot} index=${index} dataIndex=${dataIndex}`);
     yield {
       data: dataColumnSidecarBytes,
-      boundary: chain.config.getSubscribeBoundary(computeEpochAtSlot(blockSlot)),
+      boundary: createSubscribeBoundary(chain.config, computeEpochAtSlot(blockSlot)),
     };
   }
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRoot.ts
@@ -1,3 +1,4 @@
+import {createSubscribeBoundary} from "@lodestar/config";
 import {NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
@@ -89,7 +90,7 @@ export async function* onDataColumnSidecarsByRoot(
 
       yield {
         data: dataColumnSidecarBytes,
-        boundary: chain.config.getSubscribeBoundary(computeEpochAtSlot(block.slot)),
+        boundary: createSubscribeBoundary(chain.config, computeEpochAtSlot(block.slot)),
       };
     }
   }

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientBootstrap.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientBootstrap.ts
@@ -1,3 +1,4 @@
+import {createSubscribeBoundary} from "@lodestar/config";
 import {
   LightClientServerError,
   LightClientServerErrorCode,
@@ -20,7 +21,7 @@ export async function* onLightClientBootstrap(requestBody: Root, chain: IBeaconC
     const type = responseSszTypeByMethod[ReqRespMethod.LightClientBootstrap](fork, 0);
     yield {
       data: type.serialize(bootstrap),
-      boundary: chain.config.getSubscribeBoundary(computeEpochAtSlot(bootstrap.header.beacon.slot)),
+      boundary: createSubscribeBoundary(chain.config, computeEpochAtSlot(bootstrap.header.beacon.slot)),
     };
   } catch (e) {
     if ((e as LightClientServerError).type?.code === LightClientServerErrorCode.RESOURCE_UNAVAILABLE) {

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientFinalityUpdate.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientFinalityUpdate.ts
@@ -1,3 +1,4 @@
+import {createSubscribeBoundary} from "@lodestar/config";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {IBeaconChain} from "../../../chain/index.js";
@@ -16,6 +17,6 @@ export async function* onLightClientFinalityUpdate(chain: IBeaconChain): AsyncIt
   const type = responseSszTypeByMethod[ReqRespMethod.LightClientFinalityUpdate](fork, 0);
   yield {
     data: type.serialize(update),
-    boundary: chain.config.getSubscribeBoundary(computeEpochAtSlot(update.signatureSlot)),
+    boundary: createSubscribeBoundary(chain.config, computeEpochAtSlot(update.signatureSlot)),
   };
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientOptimisticUpdate.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientOptimisticUpdate.ts
@@ -3,6 +3,7 @@ import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {IBeaconChain} from "../../../chain/index.js";
 import {assertLightClientServer} from "../../../node/utils/lightclient.js";
 
+import {createSubscribeBoundary} from "@lodestar/config";
 import {ReqRespMethod, responseSszTypeByMethod} from "../types.js";
 
 export async function* onLightClientOptimisticUpdate(chain: IBeaconChain): AsyncIterable<ResponseOutgoing> {
@@ -17,6 +18,6 @@ export async function* onLightClientOptimisticUpdate(chain: IBeaconChain): Async
   const type = responseSszTypeByMethod[ReqRespMethod.LightClientOptimisticUpdate](fork, 0);
   yield {
     data: type.serialize(update),
-    boundary: chain.config.getSubscribeBoundary(computeEpochAtSlot(update.signatureSlot)),
+    boundary: createSubscribeBoundary(chain.config, computeEpochAtSlot(update.signatureSlot)),
   };
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientUpdatesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientUpdatesByRange.ts
@@ -11,6 +11,7 @@ import {altair} from "@lodestar/types";
 import {IBeaconChain} from "../../../chain/index.js";
 import {assertLightClientServer} from "../../../node/utils/lightclient.js";
 
+import {createSubscribeBoundary} from "@lodestar/config";
 import {ReqRespMethod, responseSszTypeByMethod} from "../types.js";
 
 export async function* onLightClientUpdatesByRange(
@@ -28,7 +29,7 @@ export async function* onLightClientUpdatesByRange(
 
       yield {
         data: type.serialize(update),
-        boundary: chain.config.getSubscribeBoundary(computeEpochAtSlot(update.signatureSlot)),
+        boundary: createSubscribeBoundary(chain.config, computeEpochAtSlot(update.signatureSlot)),
       };
     } catch (e) {
       if ((e as LightClientServerError).type?.code === LightClientServerErrorCode.RESOURCE_UNAVAILABLE) {

--- a/packages/beacon-node/src/network/reqresp/handlers/status.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/status.ts
@@ -1,14 +1,13 @@
-import {ForkName} from "@lodestar/params";
+import {createSubscribeBoundary} from "@lodestar/config";
 import {ResponseOutgoing} from "@lodestar/reqresp";
-import {sszTypesFor} from "@lodestar/types";
+import {ssz} from "@lodestar/types";
 import {IBeaconChain} from "../../../chain/index.js";
 
 export async function* onStatus(chain: IBeaconChain): AsyncIterable<ResponseOutgoing> {
   const status = chain.getStatus();
-  const fork = chain.config.getForkName(chain.clock.currentSlot);
   yield {
-    data: sszTypesFor(fork).Status.serialize(status),
+    data: ssz.phase0.Status.serialize(status),
     // Status topic is fork-agnostic
-    boundary: {fork: ForkName.phase0},
+    boundary: createSubscribeBoundary(chain.config, 0),
   };
 }

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -1,4 +1,4 @@
-import {BeaconConfig, SubscribeBoundary} from "@lodestar/config";
+import {BeaconConfig, SubscribeBoundary, createSubscribeBoundary} from "@lodestar/config";
 import {ATTESTATION_SUBNET_COUNT, EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Epoch, Slot, SubnetID, ssz} from "@lodestar/types";
@@ -134,7 +134,7 @@ export class AttnetsService implements IAttnetsService {
    **/
   subscribeSubnetsAfterBoundary(boundary: SubscribeBoundary): void {
     this.logger.info("Subscribing to long lived attnets after boundary", {
-      ...boundary,
+      boundaryEpoch: boundary.epoch,
       subnets: Array.from(this.longLivedSubscriptions).join(","),
     });
     for (const subnet of this.longLivedSubscriptions) {
@@ -147,7 +147,7 @@ export class AttnetsService implements IAttnetsService {
    * Call  ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork
    **/
   unsubscribeSubnetsBeforeBoundary(boundary: SubscribeBoundary): void {
-    this.logger.info("Unsubscribing to long lived attnets before boundary", {...boundary});
+    this.logger.info("Unsubscribing to long lived attnets before boundary", {boundaryEpoch: boundary.epoch});
     for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
       if (!this.opts.subscribeAllSubnets) {
         this.gossip.unsubscribeTopic({type: gossipType, subnet, boundary});
@@ -219,7 +219,7 @@ export class AttnetsService implements IAttnetsService {
           const topicStr = stringifyGossipTopic(this.config, {
             type: gossipType,
             subnet,
-            boundary: this.config.getSubscribeBoundary(computeEpochAtSlot(dutiedSlot)),
+            boundary: createSubscribeBoundary(this.config, computeEpochAtSlot(dutiedSlot)),
           });
           const numMeshPeers = this.gossip.mesh.get(topicStr)?.size ?? 0;
           if (numMeshPeers >= GOSSIP_D_LOW) {
@@ -369,7 +369,7 @@ export class AttnetsService implements IAttnetsService {
     for (const {subnet} of this.shortLivedSubscriptions.getActiveTtl(currentSlot)) {
       const topicStr = stringifyGossipTopic(this.config, {
         type: gossipType,
-        boundary: this.config.getSubscribeBoundary(computeEpochAtSlot(currentSlot)),
+        boundary: createSubscribeBoundary(this.config, computeEpochAtSlot(currentSlot)),
         subnet,
       });
       const numMeshPeers = this.gossip.mesh.get(topicStr)?.size ?? 0;

--- a/packages/beacon-node/src/network/subnets/syncnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/syncnetsService.ts
@@ -72,7 +72,7 @@ export class SyncnetsService implements SubnetsService {
 
   /** Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork  */
   subscribeSubnetsAfterBoundary(boundary: SubscribeBoundary): void {
-    this.logger.info("Subscribing to random attnets after boundary", boundary);
+    this.logger.info("Subscribing to random attnets after boundary epoch", boundary.epoch);
     for (const subnet of this.subscriptionsCommittee.getAll()) {
       this.gossip.subscribeTopic({type: GossipType.sync_committee, boundary, subnet});
     }
@@ -80,7 +80,7 @@ export class SyncnetsService implements SubnetsService {
 
   /** Call  ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork */
   unsubscribeSubnetsBeforeBoundary(boundary: SubscribeBoundary): void {
-    this.logger.info("Unsubscribing to random attnets before boundary", boundary);
+    this.logger.info("Unsubscribing to random attnets before boundary epoch", boundary.epoch);
     for (let subnet = 0; subnet < SYNC_COMMITTEE_SUBNET_COUNT; subnet++) {
       if (!this.opts?.subscribeAllSubnets) {
         this.gossip.unsubscribeTopic({type: GossipType.sync_committee, boundary, subnet});

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -1,6 +1,8 @@
 import {BitArray} from "@chainsafe/ssz";
 import {TopicValidatorResult} from "@libp2p/interface";
 import {routes} from "@lodestar/api";
+import {createSubscribeBoundary} from "@lodestar/config";
+import {config} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
@@ -47,7 +49,7 @@ describe("data serialization through worker boundary", () => {
     [ReqRespBridgeEvent.outgoingResponse]: {
       type: IteratorEventType.next,
       id: 0,
-      item: {data: bytes, boundary: {fork: ForkName.altair}},
+      item: {data: bytes, boundary: createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH)},
     },
     [ReqRespBridgeEvent.incomingRequest]: {id: 0, callArgs: {method, req: {data: bytes, version: 1}, peerId}},
     [ReqRespBridgeEvent.incomingResponse]: {
@@ -95,7 +97,7 @@ describe("data serialization through worker boundary", () => {
       peer,
     },
     [NetworkEvent.pendingGossipsubMessage]: {
-      topic: {type: GossipType.beacon_block, boundary: {fork: ForkName.altair}},
+      topic: {type: GossipType.beacon_block, boundary: createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH)},
       msg: {
         type: "unsigned",
         topic: "test-topic",

--- a/packages/beacon-node/test/e2e/network/reqresp.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqresp.test.ts
@@ -1,6 +1,5 @@
-import {ChainForkConfig, createChainForkConfig} from "@lodestar/config";
+import {ChainForkConfig, createChainForkConfig, createSubscribeBoundary} from "@lodestar/config";
 import {chainConfig} from "@lodestar/config/default";
-import {ForkName} from "@lodestar/params";
 import {RequestError, RequestErrorCode, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Root, SignedBeaconBlock, altair, phase0, ssz} from "@lodestar/types";
@@ -116,7 +115,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
           if (method === ReqRespMethod.LightClientBootstrap) {
             yield {
               data: ssz.altair.LightClientBootstrap.serialize(expectedValue),
-              boundary: {fork: ForkName.altair},
+              boundary: createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH),
             };
           }
         }
@@ -137,7 +136,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
           if (method === ReqRespMethod.LightClientOptimisticUpdate) {
             yield {
               data: ssz.altair.LightClientOptimisticUpdate.serialize(expectedValue),
-              boundary: {fork: ForkName.altair},
+              boundary: createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH),
             };
           }
         }
@@ -158,7 +157,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
           if (method === ReqRespMethod.LightClientFinalityUpdate) {
             yield {
               data: ssz.altair.LightClientFinalityUpdate.serialize(expectedValue),
-              boundary: {fork: ForkName.altair},
+              boundary: createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH),
             };
           }
         }
@@ -178,7 +177,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
       update.signatureSlot = slot;
       lightClientUpdates.push({
         data: ssz.altair.LightClientUpdate.serialize(update),
-        boundary: {fork: ForkName.altair},
+        boundary: createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH),
       });
     }
 
@@ -333,6 +332,6 @@ function getEmptyEncodedPayloadSignedBeaconBlock(config: ChainForkConfig): Respo
 function wrapBlockAsEncodedPayload(config: ChainForkConfig, block: SignedBeaconBlock): ResponseOutgoing {
   return {
     data: config.getForkTypes(block.message.slot).SignedBeaconBlock.serialize(block),
-    boundary: config.getSubscribeBoundary(computeEpochAtSlot(block.message.slot)),
+    boundary: createSubscribeBoundary(config, computeEpochAtSlot(block.message.slot)),
   };
 }

--- a/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
@@ -4,8 +4,7 @@ import {PrivateKey} from "@libp2p/interface";
 import {mplex} from "@libp2p/mplex";
 import {peerIdFromPrivateKey} from "@libp2p/peer-id";
 import {tcp} from "@libp2p/tcp";
-import {createBeaconConfig} from "@lodestar/config";
-import {ForkName} from "@lodestar/params";
+import {createBeaconConfig, createSubscribeBoundary} from "@lodestar/config";
 import {ssz} from "@lodestar/types";
 import {fromHex, sleep, toHex} from "@lodestar/utils";
 import {Multiaddr, multiaddr} from "@multiformats/multiaddr";
@@ -28,6 +27,7 @@ import {testLogger} from "../../utils/logger.js";
 
 describe("reqresp encoder", () => {
   let port = 60000;
+  const config = createBeaconConfig({}, ZERO_HASH);
 
   const afterEachCallbacks: (() => Promise<void> | void)[] = [];
   afterEach(async () => {
@@ -62,7 +62,6 @@ describe("reqresp encoder", () => {
         throw Error("not implemented");
       };
 
-    const config = createBeaconConfig({}, ZERO_HASH);
     const peerId = peerIdFromPrivateKey(privateKey);
     const networkConfig = new NetworkConfig(peerId, config);
     const modules: ReqRespBeaconNodeModules = {
@@ -107,7 +106,7 @@ describe("reqresp encoder", () => {
 
   it("assert correct handler switch between metadata v2 and v1", async () => {
     const {multiaddr: serverMultiaddr, reqresp} = await getReqResp();
-    reqresp.registerProtocolsAtBoundary({fork: ForkName.phase0});
+    reqresp.registerProtocolsAtBoundary(createSubscribeBoundary(config, 0));
     await sleep(0); // Sleep to resolve register handler promises
 
     reqresp["metadataController"].attnets.set(0, true);
@@ -139,11 +138,11 @@ describe("reqresp encoder", () => {
             data: ssz.altair.LightClientOptimisticUpdate.serialize(
               ssz.altair.LightClientOptimisticUpdate.defaultValue()
             ),
-            boundary: {fork: ForkName.phase0}, // Aware that phase0 does not makes sense here, but it's just to pick a fork digest
+            boundary: createSubscribeBoundary(config, 0), // Aware that phase0 does not makes sense here, but it's just to pick a fork digest
           };
         }
     );
-    reqresp.registerProtocolsAtBoundary({fork: ForkName.altair});
+    reqresp.registerProtocolsAtBoundary(createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH));
     await sleep(0); // Sleep to resolve register handler promises
 
     const {libp2p: dialer} = await getLibp2p();

--- a/packages/beacon-node/test/unit/network/fork.test.ts
+++ b/packages/beacon-node/test/unit/network/fork.test.ts
@@ -84,7 +84,7 @@ function getForkConfig({
     forks,
     forksAscendingEpochOrder,
     forksDescendingEpochOrder,
-    forkOrBlobScheduleAscendingEpochOrder: forksAscendingEpochOrder,
+    forkOrBpoAscendingEpochOrder: forksAscendingEpochOrder,
   } as BeaconConfig;
 }
 

--- a/packages/beacon-node/test/unit/network/gossip/scoringParameters.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/scoringParameters.test.ts
@@ -1,5 +1,5 @@
 import {TopicScoreParams} from "@chainsafe/libp2p-gossipsub/score";
-import {createBeaconConfig} from "@lodestar/config";
+import {createBeaconConfig, createSubscribeBoundary} from "@lodestar/config";
 import {mainnetChainConfig} from "@lodestar/config/configs";
 import {ATTESTATION_SUBNET_COUNT, ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {describe, expect, it} from "vitest";
@@ -69,7 +69,7 @@ describe("computeGossipPeerScoreParams", () => {
   function validateVoluntaryExitTopicParams(topics: Record<string, TopicScoreParams>): void {
     const topicString = stringifyGossipTopic(config, {
       type: GossipType.voluntary_exit,
-      boundary: {fork: ForkName.phase0},
+      boundary: createSubscribeBoundary(config, 0),
     });
     const params = topics[topicString];
     assertMessageRatePenaltiesDisabled(params);
@@ -87,11 +87,11 @@ describe("computeGossipPeerScoreParams", () => {
   function validateSlashingTopicParams(topics: Record<string, TopicScoreParams>): void {
     const attesterSlashingTopicString = stringifyGossipTopic(config, {
       type: GossipType.attester_slashing,
-      boundary: {fork: ForkName.phase0},
+      boundary: createSubscribeBoundary(config, 0),
     });
     const proposerSlashingTopicString = stringifyGossipTopic(config, {
       type: GossipType.proposer_slashing,
-      boundary: {fork: ForkName.phase0},
+      boundary: createSubscribeBoundary(config, 0),
     });
     validateSlashingTopicScoreParams(topics[attesterSlashingTopicString]);
     validateSlashingTopicScoreParams(topics[proposerSlashingTopicString]);
@@ -113,7 +113,7 @@ describe("computeGossipPeerScoreParams", () => {
   function validateAggregateTopicParams(topics: Record<string, TopicScoreParams>, penaltiesActive: boolean): void {
     const topicString = stringifyGossipTopic(config, {
       type: GossipType.beacon_aggregate_and_proof,
-      boundary: {fork: ForkName.phase0},
+      boundary: createSubscribeBoundary(config, 0),
     });
     const params = topics[topicString];
 
@@ -147,7 +147,7 @@ describe("computeGossipPeerScoreParams", () => {
   function validateBlockTopicParams(topics: Record<string, TopicScoreParams>, penaltiesActive: boolean): void {
     const topicString = stringifyGossipTopic(config, {
       type: GossipType.beacon_block,
-      boundary: {fork: ForkName.phase0},
+      boundary: createSubscribeBoundary(config, 0),
     });
     const params = topics[topicString];
 
@@ -185,7 +185,7 @@ describe("computeGossipPeerScoreParams", () => {
     for (let i = 0; i < ATTESTATION_SUBNET_COUNT; i++) {
       const topicString = stringifyGossipTopic(config, {
         type: GossipType.beacon_attestation,
-        boundary: {fork: ForkName.phase0},
+        boundary: createSubscribeBoundary(config, 0),
         subnet: i,
       });
       validateAllAttestationSubnetTopicScoreParams(topics[topicString], penaltiesActive);

--- a/packages/beacon-node/test/unit/network/gossip/topic.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/topic.test.ts
@@ -1,4 +1,4 @@
-import {ForkName, ForkPreFulu} from "@lodestar/params";
+import {createSubscribeBoundary} from "@lodestar/config";
 import {describe, expect, it} from "vitest";
 import {GossipEncoding, GossipTopicMap, GossipType} from "../../../../src/network/gossip/index.js";
 import {parseGossipTopic, stringifyGossipTopic} from "../../../../src/network/gossip/topic.js";
@@ -11,7 +11,7 @@ describe("network / gossip / topic", () => {
   const testCases: {[K in GossipType]: {topic: GossipTopicMap[K]; topicStr: string}[]} = {
     [GossipType.beacon_block]: [
       {
-        topic: {type: GossipType.beacon_block, boundary: {fork: ForkName.phase0}, encoding},
+        topic: {type: GossipType.beacon_block, boundary: createSubscribeBoundary(config, 0), encoding},
         topicStr: "/eth2/f5a5fd42/beacon_block/ssz_snappy",
       },
     ],
@@ -20,7 +20,7 @@ describe("network / gossip / topic", () => {
         topic: {
           type: GossipType.blob_sidecar,
           subnet: 1,
-          boundary: {fork: ForkName.deneb},
+          boundary: createSubscribeBoundary(config, config.DENEB_FORK_EPOCH),
           encoding,
         },
         topicStr: "/eth2/d6e497b8/blob_sidecar_1/ssz_snappy",
@@ -31,7 +31,7 @@ describe("network / gossip / topic", () => {
         topic: {
           type: GossipType.data_column_sidecar,
           subnet: 1,
-          boundary: {fork: ForkName.fulu as ForkPreFulu},
+          boundary: createSubscribeBoundary(config, config.ELECTRA_FORK_EPOCH), // TODO FULU: Make this FULU_FORK_EPOCH
           encoding,
         },
         topicStr: "/eth2/0570c363/data_column_sidecar_1/ssz_snappy",
@@ -41,7 +41,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.beacon_aggregate_and_proof,
-          boundary: {fork: ForkName.phase0},
+          boundary: createSubscribeBoundary(config, 0),
           encoding,
         },
         topicStr: "/eth2/f5a5fd42/beacon_aggregate_and_proof/ssz_snappy",
@@ -51,7 +51,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.beacon_attestation,
-          boundary: {fork: ForkName.phase0},
+          boundary: createSubscribeBoundary(config, 0),
           subnet: 5,
           encoding,
         },
@@ -60,7 +60,7 @@ describe("network / gossip / topic", () => {
     ],
     [GossipType.voluntary_exit]: [
       {
-        topic: {type: GossipType.voluntary_exit, boundary: {fork: ForkName.phase0}, encoding},
+        topic: {type: GossipType.voluntary_exit, boundary: createSubscribeBoundary(config, 0), encoding},
         topicStr: "/eth2/f5a5fd42/voluntary_exit/ssz_snappy",
       },
     ],
@@ -68,7 +68,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.bls_to_execution_change,
-          boundary: {fork: ForkName.capella},
+          boundary: createSubscribeBoundary(config, config.CAPELLA_FORK_EPOCH),
           encoding,
         },
         topicStr: "/eth2/e7b4bb67/bls_to_execution_change/ssz_snappy",
@@ -78,7 +78,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.proposer_slashing,
-          boundary: {fork: ForkName.phase0},
+          boundary: createSubscribeBoundary(config, 0),
           encoding,
         },
         topicStr: "/eth2/f5a5fd42/proposer_slashing/ssz_snappy",
@@ -88,7 +88,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.attester_slashing,
-          boundary: {fork: ForkName.phase0},
+          boundary: createSubscribeBoundary(config, 0),
           encoding,
         },
         topicStr: "/eth2/f5a5fd42/attester_slashing/ssz_snappy",
@@ -98,7 +98,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.sync_committee_contribution_and_proof,
-          boundary: {fork: ForkName.altair},
+          boundary: createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH),
           encoding,
         },
         topicStr: "/eth2/16abab34/sync_committee_contribution_and_proof/ssz_snappy",
@@ -108,7 +108,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.sync_committee,
-          boundary: {fork: ForkName.altair},
+          boundary: createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH),
           subnet: 5,
           encoding,
         },
@@ -119,7 +119,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.light_client_finality_update,
-          boundary: {fork: ForkName.altair},
+          boundary: createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH),
           encoding,
         },
         topicStr: "/eth2/16abab34/light_client_finality_update/ssz_snappy",
@@ -129,7 +129,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.light_client_optimistic_update,
-          boundary: {fork: ForkName.altair},
+          boundary: createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH),
           encoding,
         },
         topicStr: "/eth2/16abab34/light_client_optimistic_update/ssz_snappy",

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -1,4 +1,4 @@
-import {createBeaconConfig} from "@lodestar/config";
+import {createBeaconConfig, createSubscribeBoundary} from "@lodestar/config";
 import {
   ATTESTATION_SUBNET_COUNT,
   EPOCHS_PER_SUBNET_SUBSCRIPTION,
@@ -85,7 +85,7 @@ describe("AttnetsService", () => {
     const secondSubnet = (gossipStub.subscribeTopic.mock.calls[1][0] as unknown as {subnet: SubnetID}).subnet;
     expect(gossipStub.subscribeTopic).toBeCalledTimes(SUBNETS_PER_NODE);
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH * (ALTAIR_FORK_EPOCH - 2) * 1000);
-    service.subscribeSubnetsAfterBoundary({fork: ForkName.altair});
+    service.subscribeSubnetsAfterBoundary(createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH));
     // SUBNETS_PER_NODE = 2 => 2 more calls
     // same subnets were called
     expect(gossipStub.subscribeTopic).toHaveBeenCalledWith(
@@ -97,7 +97,7 @@ describe("AttnetsService", () => {
     expect(gossipStub.subscribeTopic).toBeCalledTimes(2 * SUBNETS_PER_NODE);
     // 2 epochs after the fork
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * 4 * 1000);
-    service.unsubscribeSubnetsBeforeBoundary({fork: ForkName.phase0});
+    service.unsubscribeSubnetsBeforeBoundary(createSubscribeBoundary(config, 0));
     expect(gossipStub.unsubscribeTopic).toHaveBeenCalledWith(
       expect.objectContaining({boundary: {fork: ForkName.phase0}, subnet: firstSubnet})
     );

--- a/packages/beacon-node/test/unit/network/subscribeBoundary.test.ts
+++ b/packages/beacon-node/test/unit/network/subscribeBoundary.test.ts
@@ -1,4 +1,11 @@
-import {BlobSchedule, ChainConfig, ChainForkConfig, SubscribeBoundary, createChainForkConfig} from "@lodestar/config";
+import {
+  BlobSchedule,
+  ChainConfig,
+  ChainForkConfig,
+  SubscribeBoundary,
+  SubscribeBoundaryType,
+  createChainForkConfig,
+} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
 import {describe, expect, it} from "vitest";
@@ -53,9 +60,9 @@ const testScenarios: {
     fulu: Infinity,
     blobSchedule: [] as BlobSchedule,
     testCases: [
-      {epoch: -1, activeBoundaries: [{fork: ForkName.altair}]},
-      {epoch: 0, activeBoundaries: [{fork: ForkName.altair}]},
-      {epoch: 1, activeBoundaries: [{fork: ForkName.altair}]},
+      {epoch: -1, activeBoundaries: [{type: SubscribeBoundaryType.PreFulu, fork: ForkName.altair, epoch: 0}]},
+      {epoch: 0, activeBoundaries: [{type: SubscribeBoundaryType.PreFulu, fork: ForkName.altair, epoch: 0}]},
+      {epoch: 1, activeBoundaries: [{type: SubscribeBoundaryType.PreFulu, fork: ForkName.altair, epoch: 0}]},
     ],
   },
   {
@@ -67,8 +74,14 @@ const testScenarios: {
     fulu: Infinity,
     blobSchedule: [] as BlobSchedule,
     testCases: [
-      {epoch: 50, activeBoundaries: [{fork: ForkName.deneb}, {fork: ForkName.electra}]},
-      {epoch: 55, activeBoundaries: [{fork: ForkName.electra}]},
+      {
+        epoch: 50,
+        activeBoundaries: [
+          {type: SubscribeBoundaryType.PreFulu, fork: ForkName.deneb, epoch: 40},
+          {type: SubscribeBoundaryType.PreFulu, fork: ForkName.electra, epoch: 50},
+        ],
+      },
+      {epoch: 55, activeBoundaries: [{type: SubscribeBoundaryType.PreFulu, fork: ForkName.electra, epoch: 50}]},
     ],
   },
   {
@@ -80,19 +93,35 @@ const testScenarios: {
     fulu: 60,
     blobSchedule: [] as BlobSchedule,
     testCases: [
-      {epoch: 50, activeBoundaries: [{fork: ForkName.deneb}, {fork: ForkName.electra}]},
-      {epoch: 55, activeBoundaries: [{fork: ForkName.electra}]},
+      {
+        epoch: 50,
+        activeBoundaries: [
+          {type: SubscribeBoundaryType.PreFulu, fork: ForkName.deneb, epoch: 40},
+          {type: SubscribeBoundaryType.PreFulu, fork: ForkName.electra, epoch: 50},
+        ],
+      },
+      {epoch: 55, activeBoundaries: [{type: SubscribeBoundaryType.PreFulu, fork: ForkName.electra, epoch: 50}]},
       {
         epoch: 60,
         activeBoundaries: [
-          {fork: ForkName.electra},
-          {fork: ForkName.fulu, EPOCH: 50, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
+          {type: SubscribeBoundaryType.PreFulu, fork: ForkName.electra, epoch: 50},
+          {
+            type: SubscribeBoundaryType.HardFork,
+            fork: ForkName.fulu,
+            epoch: 60,
+            blobSchedule: {EPOCH: 50, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
+          },
         ],
       },
       {
         epoch: 65,
         activeBoundaries: [
-          {fork: ForkName.fulu, EPOCH: 50, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
+          {
+            type: SubscribeBoundaryType.HardFork,
+            fork: ForkName.fulu,
+            epoch: 60,
+            blobSchedule: {EPOCH: 50, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
+          },
         ],
       },
     ],
@@ -110,27 +139,71 @@ const testScenarios: {
       {EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300},
     ],
     testCases: [
-      {epoch: 10, activeBoundaries: [{fork: ForkName.deneb}, {fork: ForkName.electra}]},
-      {epoch: 15, activeBoundaries: [{fork: ForkName.electra}]},
+      {
+        epoch: 10,
+        activeBoundaries: [
+          {type: SubscribeBoundaryType.PreFulu, fork: ForkName.deneb, epoch: 0},
+          {type: SubscribeBoundaryType.PreFulu, fork: ForkName.electra, epoch: 10},
+        ],
+      },
+      {epoch: 15, activeBoundaries: [{type: SubscribeBoundaryType.PreFulu, fork: ForkName.electra, epoch: 10}]},
       {
         epoch: 20,
-        activeBoundaries: [{fork: ForkName.electra}, {fork: ForkName.fulu, EPOCH: 20, MAX_BLOBS_PER_BLOCK: 200}],
+        activeBoundaries: [
+          {type: SubscribeBoundaryType.PreFulu, fork: ForkName.electra, epoch: 10},
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 20,
+            blobSchedule: {EPOCH: 20, MAX_BLOBS_PER_BLOCK: 200},
+          },
+        ],
       },
       {
         epoch: 25,
         activeBoundaries: [
-          {fork: ForkName.fulu, EPOCH: 20, MAX_BLOBS_PER_BLOCK: 200},
-          {fork: ForkName.fulu, EPOCH: 25, MAX_BLOBS_PER_BLOCK: 250},
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 20,
+            blobSchedule: {EPOCH: 20, MAX_BLOBS_PER_BLOCK: 200},
+          },
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 25,
+            blobSchedule: {EPOCH: 25, MAX_BLOBS_PER_BLOCK: 250},
+          },
         ],
       },
       {
         epoch: 30,
         activeBoundaries: [
-          {fork: ForkName.fulu, EPOCH: 25, MAX_BLOBS_PER_BLOCK: 250},
-          {fork: ForkName.fulu, EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300},
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 25,
+            blobSchedule: {EPOCH: 25, MAX_BLOBS_PER_BLOCK: 250},
+          },
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 30,
+            blobSchedule: {EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300},
+          },
         ],
       },
-      {epoch: 33, activeBoundaries: [{fork: ForkName.fulu, EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300}]},
+      {
+        epoch: 33,
+        activeBoundaries: [
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 30,
+            blobSchedule: {EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300},
+          },
+        ],
+      },
     ],
   },
   {
@@ -148,32 +221,82 @@ const testScenarios: {
       {
         epoch: 20,
         activeBoundaries: [
-          {fork: ForkName.electra},
-          {fork: ForkName.fulu, EPOCH: 10, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
+          {type: SubscribeBoundaryType.PreFulu, fork: ForkName.electra, epoch: 10},
+          {
+            type: SubscribeBoundaryType.HardFork,
+            fork: ForkName.fulu,
+            epoch: 20,
+            blobSchedule: {EPOCH: 10, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
+          },
         ],
       },
       {
         epoch: 25,
         activeBoundaries: [
-          {fork: ForkName.fulu, EPOCH: 10, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
+          {
+            type: SubscribeBoundaryType.HardFork,
+            fork: ForkName.fulu,
+            epoch: 20,
+            blobSchedule: {EPOCH: 10, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
+          },
         ],
       },
       {
         epoch: 30,
         activeBoundaries: [
-          {fork: ForkName.fulu, EPOCH: 10, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
-          {fork: ForkName.fulu, EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300},
+          {
+            type: SubscribeBoundaryType.HardFork,
+            fork: ForkName.fulu,
+            epoch: 20,
+            blobSchedule: {EPOCH: 10, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
+          },
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 30,
+            blobSchedule: {EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300},
+          },
         ],
       },
-      {epoch: 35, activeBoundaries: [{fork: ForkName.fulu, EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300}]},
+      {
+        epoch: 35,
+        activeBoundaries: [
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 30,
+            blobSchedule: {EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300},
+          },
+        ],
+      },
       {
         epoch: 40,
         activeBoundaries: [
-          {fork: ForkName.fulu, EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300},
-          {fork: ForkName.fulu, EPOCH: 40, MAX_BLOBS_PER_BLOCK: 400},
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 30,
+            blobSchedule: {EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300},
+          },
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 40,
+            blobSchedule: {EPOCH: 40, MAX_BLOBS_PER_BLOCK: 400},
+          },
         ],
       },
-      {epoch: 45, activeBoundaries: [{fork: ForkName.fulu, EPOCH: 40, MAX_BLOBS_PER_BLOCK: 400}]},
+      {
+        epoch: 45,
+        activeBoundaries: [
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 40,
+            blobSchedule: {EPOCH: 40, MAX_BLOBS_PER_BLOCK: 400},
+          },
+        ],
+      },
     ],
   },
   {
@@ -191,27 +314,72 @@ const testScenarios: {
       {
         epoch: 20,
         activeBoundaries: [
-          {fork: ForkName.electra},
-          {fork: ForkName.fulu, EPOCH: 10, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
-          {fork: ForkName.fulu, EPOCH: 22, MAX_BLOBS_PER_BLOCK: 220},
+          {type: SubscribeBoundaryType.PreFulu, fork: ForkName.electra, epoch: 10},
+          {
+            type: SubscribeBoundaryType.HardFork,
+            fork: ForkName.fulu,
+            epoch: 20,
+            blobSchedule: {EPOCH: 10, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
+          },
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 22,
+            blobSchedule: {EPOCH: 22, MAX_BLOBS_PER_BLOCK: 220},
+          },
         ],
       },
       {
         epoch: 23,
         activeBoundaries: [
-          {fork: ForkName.fulu, EPOCH: 10, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
-          {fork: ForkName.fulu, EPOCH: 22, MAX_BLOBS_PER_BLOCK: 220},
-          {fork: ForkName.fulu, EPOCH: 24, MAX_BLOBS_PER_BLOCK: 240},
+          {
+            type: SubscribeBoundaryType.HardFork,
+            fork: ForkName.fulu,
+            epoch: 20,
+            blobSchedule: {EPOCH: 10, MAX_BLOBS_PER_BLOCK: defaultConfig.MAX_BLOBS_PER_BLOCK_ELECTRA},
+          },
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 22,
+            blobSchedule: {EPOCH: 22, MAX_BLOBS_PER_BLOCK: 220},
+          },
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 24,
+            blobSchedule: {EPOCH: 24, MAX_BLOBS_PER_BLOCK: 240},
+          },
         ],
       },
       {
         epoch: 25,
         activeBoundaries: [
-          {fork: ForkName.fulu, EPOCH: 22, MAX_BLOBS_PER_BLOCK: 220},
-          {fork: ForkName.fulu, EPOCH: 24, MAX_BLOBS_PER_BLOCK: 240},
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 22,
+            blobSchedule: {EPOCH: 22, MAX_BLOBS_PER_BLOCK: 220},
+          },
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 24,
+            blobSchedule: {EPOCH: 24, MAX_BLOBS_PER_BLOCK: 240},
+          },
         ],
       },
-      {epoch: 27, activeBoundaries: [{fork: ForkName.fulu, EPOCH: 24, MAX_BLOBS_PER_BLOCK: 240}]},
+      {
+        epoch: 27,
+        activeBoundaries: [
+          {
+            type: SubscribeBoundaryType.BpoFork,
+            fork: ForkName.fulu,
+            epoch: 24,
+            blobSchedule: {EPOCH: 24, MAX_BLOBS_PER_BLOCK: 240},
+          },
+        ],
+      },
     ],
   },
 ];

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -11,11 +11,9 @@ import {
   isForkPostBellatrix,
   isForkPostDeneb,
   isForkPostElectra,
-  isForkPostFulu,
 } from "@lodestar/params";
 import {Epoch, SSZTypesFor, Slot, Version, sszTypesFor} from "@lodestar/types";
 import {BlobScheduleEntry, ChainConfig} from "../chainConfig/index.js";
-import {SubscribeBoundary} from "../genesisConfig/types.js";
 import {ForkConfig, ForkInfo} from "./types.js";
 
 export * from "./types.js";
@@ -89,21 +87,19 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
 
   const blobScheduleDescendingEpochOrder = [...config.BLOB_SCHEDULE].sort((a, b) => b.EPOCH - a.EPOCH);
 
-  const forkOrBlobScheduleByEpoch = new Map<Epoch, ForkInfo | BlobScheduleEntry>();
+  const forkOrBpoByEpoch = new Map<Epoch, ForkInfo | BlobScheduleEntry>();
   for (const fork of forksAscendingEpochOrder) {
-    forkOrBlobScheduleByEpoch.set(fork.epoch, fork);
+    forkOrBpoByEpoch.set(fork.epoch, fork);
   }
   for (const entry of blobScheduleDescendingEpochOrder) {
-    forkOrBlobScheduleByEpoch.set(entry.EPOCH, entry);
+    forkOrBpoByEpoch.set(entry.EPOCH, entry);
   }
 
   return {
     forks,
     forksAscendingEpochOrder,
     forksDescendingEpochOrder,
-    forkOrBlobScheduleAscendingEpochOrder: [...forkOrBlobScheduleByEpoch.entries()]
-      .sort(([k1], [k2]) => k1 - k2)
-      .map(([, v]) => v),
+    forkOrBpoAscendingEpochOrder: [...forkOrBpoByEpoch.entries()].sort(([k1], [k2]) => k1 - k2).map(([, v]) => v),
 
     // Fork convenience methods
     getForkInfo(slot: Slot): ForkInfo {
@@ -178,16 +174,6 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       }
 
       return {EPOCH: config.ELECTRA_FORK_EPOCH, MAX_BLOBS_PER_BLOCK: config.MAX_BLOBS_PER_BLOCK_ELECTRA};
-    },
-    getSubscribeBoundary(epoch: Epoch): SubscribeBoundary {
-      const fork = this.getForkInfoAtEpoch(epoch).name;
-
-      if (isForkPostFulu(fork)) {
-        const blobSchedule = this.getBlobParameters(epoch);
-        return {...blobSchedule, fork};
-      }
-
-      return {fork};
     },
     getMaxRequestBlobSidecars(fork: ForkName): number {
       return isForkPostElectra(fork) ? config.MAX_REQUEST_BLOB_SIDECARS_ELECTRA : config.MAX_REQUEST_BLOB_SIDECARS;

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -1,7 +1,6 @@
 import {ForkAll, ForkName, ForkPostAltair, ForkPostBellatrix, ForkPostDeneb, ForkSeq} from "@lodestar/params";
 import {Epoch, SSZTypesFor, Slot, Version} from "@lodestar/types";
 import {BlobScheduleEntry} from "../chainConfig/types.js";
-import {SubscribeBoundary} from "../genesisConfig/types.js";
 
 export type ForkInfo = {
   name: ForkName;
@@ -20,7 +19,7 @@ export type ForkConfig = {
   forks: {[K in ForkName]: ForkInfo};
   forksAscendingEpochOrder: ForkInfo[];
   forksDescendingEpochOrder: ForkInfo[];
-  forkOrBlobScheduleAscendingEpochOrder: (ForkInfo | BlobScheduleEntry)[];
+  forkOrBpoAscendingEpochOrder: (ForkInfo | BlobScheduleEntry)[];
 
   /** Get the hard-fork info for the active fork at `slot` */
   getForkInfo(slot: Slot): ForkInfo;
@@ -46,14 +45,10 @@ export type ForkConfig = {
   getMaxBlobsPerBlock(epoch: Epoch): number;
   /** Get blob schedule entry at a given epoch */
   getBlobParameters(epoch: Epoch): BlobScheduleEntry;
-  /** Get subscribe boundary at a given epoch */
-  getSubscribeBoundary(epoch: Epoch): SubscribeBoundary;
   /** Get max request blob sidecars by hard-fork */
   getMaxRequestBlobSidecars(fork: ForkName): number;
 };
 
-export function isBlobSchedule(
-  forkOrBlobSchedule: ForkConfig["forkOrBlobScheduleAscendingEpochOrder"][number]
-): forkOrBlobSchedule is BlobScheduleEntry {
-  return "EPOCH" in forkOrBlobSchedule;
+export function isBpo(forkOrBpo: ForkConfig["forkOrBpoAscendingEpochOrder"][number]): forkOrBpo is BlobScheduleEntry {
+  return "EPOCH" in forkOrBpo;
 }

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -3,11 +3,12 @@ import {DOMAIN_VOLUNTARY_EXIT, ForkName, ForkSeq, SLOTS_PER_EPOCH} from "@lodest
 import {DomainType, Epoch, ForkDigest, Root, Slot, Version, phase0, ssz} from "@lodestar/types";
 import {intToBytes, strip0xPrefix, toHex} from "@lodestar/utils";
 import {ChainForkConfig} from "../beaconConfig.js";
-import {BlobScheduleEntry, ForkInfo, isBlobSchedule} from "../index.js";
+import {BlobScheduleEntry, ForkInfo, isBpo} from "../index.js";
 import {xor} from "../utils/bytes.js";
-import {CachedGenesis, ForkDigestHex, SubscribeBoundary, isSubscribeBoundaryPostFulu} from "./types.js";
+import {createSubscribeBoundary} from "./network.js";
+import {CachedGenesis, ForkDigestHex, SubscribeBoundary} from "./types.js";
 export type {ForkDigestContext, SubscribeBoundary} from "./types.js";
-export {isSubscribeBoundaryPostFulu} from "./types.js";
+export {createSubscribeBoundary, SubscribeBoundaryType} from "./network.js";
 
 export function createCachedGenesis(chainForkConfig: ChainForkConfig, genesisValidatorsRoot: Root): CachedGenesis {
   const domainCache = new Map<ForkName, Map<DomainType, Uint8Array>>();
@@ -19,19 +20,17 @@ export function createCachedGenesis(chainForkConfig: ChainForkConfig, genesisVal
   /** Map of ForkDigest in hex format without prefix: `0011aabb` */
   const epochByForkDigest = new Map<ForkDigestHex, Epoch>();
 
-  const forkOrBlobScheduleList = chainForkConfig.forkOrBlobScheduleAscendingEpochOrder;
+  const forkOrBlobScheduleList = chainForkConfig.forkOrBpoAscendingEpochOrder;
 
   for (let i = 0; i < forkOrBlobScheduleList.length; i++) {
     const currForkOrBlobSchedule = forkOrBlobScheduleList[i];
     const nextForkOrBlobSchedule = forkOrBlobScheduleList[i + 1];
 
-    const currEpoch = isBlobSchedule(currForkOrBlobSchedule)
-      ? currForkOrBlobSchedule.EPOCH
-      : currForkOrBlobSchedule.epoch;
+    const currEpoch = isBpo(currForkOrBlobSchedule) ? currForkOrBlobSchedule.EPOCH : currForkOrBlobSchedule.epoch;
     const nextEpoch =
       nextForkOrBlobSchedule === undefined
         ? Infinity
-        : isBlobSchedule(nextForkOrBlobSchedule)
+        : isBpo(nextForkOrBlobSchedule)
           ? nextForkOrBlobSchedule.EPOCH
           : nextForkOrBlobSchedule.epoch;
 
@@ -40,13 +39,9 @@ export function createCachedGenesis(chainForkConfig: ChainForkConfig, genesisVal
       continue;
     }
 
-    const boundary = chainForkConfig.getSubscribeBoundary(currEpoch);
+    const boundary = createSubscribeBoundary(chainForkConfig, currEpoch);
     const fork = chainForkConfig.forks[boundary.fork];
-    const forkDigest = computeForkDigest(
-      fork,
-      genesisValidatorsRoot,
-      isSubscribeBoundaryPostFulu(boundary) ? {...boundary} : undefined
-    );
+    const forkDigest = computeForkDigest(fork, genesisValidatorsRoot, boundary.blobSchedule);
     const forkDigestHex = toHexStringNoPrefix(forkDigest);
     epochByForkDigest.set(forkDigestHex, currEpoch);
     forkDigestByEpoch.set(currEpoch, forkDigest);
@@ -139,25 +134,17 @@ export function createCachedGenesis(chainForkConfig: ChainForkConfig, genesisVal
     },
 
     boundary2ForkDigest(boundary: SubscribeBoundary): ForkDigest {
-      const epoch = Math.max(
-        chainForkConfig.forks[boundary.fork].epoch,
-        isSubscribeBoundaryPostFulu(boundary) ? boundary.EPOCH : -1
-      );
-      const forkDigest = forkDigestByEpoch.get(epoch);
+      const forkDigest = forkDigestByEpoch.get(boundary.epoch);
       if (!forkDigest) {
-        throw Error(`No precomputed forkDigest for ${epoch}`);
+        throw Error(`No precomputed forkDigest for ${boundary.epoch}`);
       }
       return forkDigest;
     },
 
     boundary2ForkDigestHex(boundary: SubscribeBoundary): ForkDigestHex {
-      const epoch = Math.max(
-        chainForkConfig.forks[boundary.fork].epoch,
-        isSubscribeBoundaryPostFulu(boundary) ? boundary.EPOCH : -1
-      );
-      const forkDigestHex = forkDigestHexByEpoch.get(epoch);
+      const forkDigestHex = forkDigestHexByEpoch.get(boundary.epoch);
       if (!forkDigestHex) {
-        throw Error(`No precomputed forkDigest for ${epoch}`);
+        throw Error(`No precomputed forkDigest for ${boundary.epoch}`);
       }
       return toHexStringNoPrefix(forkDigestHex);
     },

--- a/packages/config/src/genesisConfig/network.ts
+++ b/packages/config/src/genesisConfig/network.ts
@@ -1,0 +1,78 @@
+import {ForkName, isForkPostFulu} from "@lodestar/params";
+import {Epoch} from "@lodestar/types";
+import {BlobScheduleEntry} from "../chainConfig/index.js";
+import {ForkConfig} from "../forkConfig/index.js";
+
+export enum SubscribeBoundaryType {
+  PreFulu,
+  HardFork,
+  BpoFork,
+}
+/**
+ * Get the epoch of the boundary. We need this function because
+ * 1) There is no epoch stored in boundary pre-fulu
+ * 2) Post-fulu, `EPOCH` is not an accurate indicator of boundary's epoch. If a boundary refers
+ *  to a hard fork, it is possible that its blob schedule's EPOCH still refers to the previous
+ *  fork. But if a boundary refers to a BPO fork, then `EPOCH` is accurate
+ */
+
+/**
+ * If boundary is a hard fork, we want to take fork epoch, and blob schedule's epoch will
+ * only be less than or equal fork epoch. If boundary is BPO, we want to take blob schdule
+ * epoch, and it will only be greater or equal to fork epoch. Either case we take max of
+ * fork epoch and blob schedule epoch.
+ */
+
+type SubscribeBoundaryPreFulu = {
+  readonly type: SubscribeBoundaryType.PreFulu;
+  readonly fork: ForkName;
+  readonly epoch: Epoch;
+  readonly blobSchedule?: undefined;
+};
+
+type SubscribeBoundaryPostFulu = {
+  readonly type: SubscribeBoundaryType.HardFork | SubscribeBoundaryType.BpoFork;
+  readonly fork: ForkName;
+  readonly epoch: Epoch;
+  readonly blobSchedule: BlobScheduleEntry;
+};
+
+/**
+ * Boundary of network subscription. We subscribe/unsubscribe during hard fork and bpo fork transitions.
+ * There are 3 types of boundary:
+ *  1) Pre-fulu hard fork - defined by hard fork name only
+ *  2) Post-fulu bpo fork - defined by blob parameters (aka BlobScheduleEntry) and name of hard fork it is in
+ *  3) Post-fulu hard fork - defined by hard fork's name, along with the blob parameters it should use
+ *    (aka ForkConfig.getBlobParameters(*_FORK_EPOCH))
+ *
+ * TODO: We can actually make `type SubscribeBoundary = Epoch` and rely on the callers to decode it
+ * as fork or blob schedule as needed. However it takes some sizable refactor give every callers access
+ * to beacon config
+ */
+export type SubscribeBoundary = SubscribeBoundaryPreFulu | SubscribeBoundaryPostFulu;
+
+export function createSubscribeBoundary(config: ForkConfig, epoch: Epoch): SubscribeBoundary {
+  const fork = config.getForkInfoAtEpoch(epoch).name;
+  const forkEpoch = config.forks[fork].epoch;
+
+  if (isForkPostFulu(fork)) {
+    const blobSchedule = config.getBlobParameters(epoch);
+    const boundaryEpoch = Math.max(forkEpoch, blobSchedule.EPOCH);
+    const type =
+      boundaryEpoch === forkEpoch && forkEpoch !== blobSchedule.EPOCH
+        ? SubscribeBoundaryType.HardFork
+        : SubscribeBoundaryType.BpoFork;
+
+    return {
+      fork,
+      epoch: boundaryEpoch,
+      type,
+      blobSchedule,
+    };
+  }
+  return {
+    fork,
+    epoch: forkEpoch,
+    type: SubscribeBoundaryType.PreFulu,
+  };
+}

--- a/packages/config/src/genesisConfig/types.ts
+++ b/packages/config/src/genesisConfig/types.ts
@@ -1,15 +1,9 @@
-import {ForkName, ForkPostFulu, ForkPreFulu} from "@lodestar/params";
+import {ForkName} from "@lodestar/params";
 import {DomainType, ForkDigest, Root, Slot} from "@lodestar/types";
-import {BlobScheduleEntry} from "../chainConfig/types.js";
+import {SubscribeBoundary} from "./network.js";
 
 export type ForkDigestHex = string;
-// Boundary of network subscription. We subscribe/unsubscribe during fork and blob schedule transitions
-// TODO: We can actually make `type SubscribeBoundary = Epoch` and rely on the callers to decode it
-// as fork or blob schedule as needed. However it takes some sizable refactor give every callers access
-// to beacon config
-type SubscribeBoundaryPreFulu = {fork: ForkPreFulu};
-type SubscribeBoundaryPostFulu = {fork: ForkPostFulu} & BlobScheduleEntry;
-export type SubscribeBoundary = SubscribeBoundaryPreFulu | SubscribeBoundaryPostFulu;
+export {type SubscribeBoundary} from "./network.js";
 
 export type ForkDigestContext = {
   forkDigest2ForkName(forkDigest: ForkDigest | ForkDigestHex): ForkName;
@@ -33,8 +27,4 @@ export interface CachedGenesis extends ForkDigestContext {
   getDomainForVoluntaryExit(stateSlot: Slot, messageSlot?: Slot): Uint8Array;
 
   readonly genesisValidatorsRoot: Root;
-}
-
-export function isSubscribeBoundaryPostFulu(boundary: SubscribeBoundary): boundary is SubscribeBoundaryPostFulu {
-  return "EPOCH" in boundary;
 }

--- a/packages/config/test/unit/forkDigest.test.ts
+++ b/packages/config/test/unit/forkDigest.test.ts
@@ -1,8 +1,13 @@
 import {ForkName} from "@lodestar/params";
 import {fromHex as b, toHex} from "@lodestar/utils";
 import {describe, expect, it} from "vitest";
-import {isSubscribeBoundaryPostFulu} from "../../src/genesisConfig/types.js";
-import {ForkInfo, computeForkDigest, createCachedGenesis, createChainForkConfig} from "../../src/index.js";
+import {
+  ForkInfo,
+  computeForkDigest,
+  createCachedGenesis,
+  createChainForkConfig,
+  createSubscribeBoundary,
+} from "../../src/index.js";
 
 // Test cases copied from https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.2/tests/core/pyspec/eth2spec/test/fulu/validator/test_compute_fork_digest.py
 // TODO FULU: Add Electra scenarios to test cases when they are available in the spec repo
@@ -85,14 +90,8 @@ describe("fork digest", () => {
       const {epoch, forkVersion, expectedForkDigest} = testCase;
       it(`should match fork digest at epoch ${epoch}`, () => {
         const fork: ForkInfo = {...config.forks[ForkName.fulu], version: forkVersion};
-        const boundary = config.getSubscribeBoundary(epoch);
-        const forkDigest = toHex(
-          computeForkDigest(
-            fork,
-            genesisValidatorRoot,
-            isSubscribeBoundaryPostFulu(boundary) ? {...boundary} : undefined
-          )
-        );
+        const boundary = createSubscribeBoundary(config, epoch);
+        const forkDigest = toHex(computeForkDigest(fork, genesisValidatorRoot, boundary.blobSchedule));
 
         expect(forkDigest.slice(2)).toBe(expectedForkDigest);
       });
@@ -118,7 +117,7 @@ describe("fork digest", () => {
     for (const testCase of testCases) {
       const {epoch, expectedForkDigest} = testCase;
       it(`should match fork digest at epoch ${epoch}`, () => {
-        const boundary = config.getSubscribeBoundary(epoch);
+        const boundary = createSubscribeBoundary(config, epoch);
         const forkDigestHex = cachedGenesis.boundary2ForkDigestHex(boundary);
 
         expect(forkDigestHex).toBe(expectedForkDigest);

--- a/packages/reqresp/test/fixtures/encoders.ts
+++ b/packages/reqresp/test/fixtures/encoders.ts
@@ -1,4 +1,4 @@
-import {ForkName} from "@lodestar/params";
+import {createSubscribeBoundary} from "@lodestar/config";
 import {LodestarError} from "@lodestar/utils";
 import {SszSnappyError, SszSnappyErrorCode} from "../../src/encodingStrategies/sszSnappy/index.js";
 import {ResponseError} from "../../src/index.js";
@@ -135,7 +135,7 @@ export const responseEncodersTestCases: {
       // <result>
       Buffer.from([RespStatus.SUCCESS]),
       // <context-bytes>
-      beaconConfig.boundary2ForkDigest({fork: ForkName.phase0}),
+      beaconConfig.boundary2ForkDigest(createSubscribeBoundary(beaconConfig, 0)),
       // <encoding-dependent-header> | <encoded-payload>
       ...sszSnappySignedBeaconBlockPhase0.chunks,
     ],
@@ -148,7 +148,7 @@ export const responseEncodersTestCases: {
       // <result>
       Buffer.from([RespStatus.SUCCESS]),
       // <context-bytes>
-      beaconConfig.boundary2ForkDigest({fork: ForkName.altair}),
+      beaconConfig.boundary2ForkDigest(createSubscribeBoundary(beaconConfig, beaconConfig.ALTAIR_FORK_EPOCH)),
       // <encoding-dependent-header> | <encoded-payload>
       ...sszSnappySignedBeaconBlockAltair.chunks,
     ],
@@ -212,11 +212,11 @@ export const responseEncodersTestCases: {
     chunks: [
       // Chunk 0 - success block in phase0 with context bytes
       Buffer.from([RespStatus.SUCCESS]),
-      beaconConfig.boundary2ForkDigest({fork: ForkName.phase0}),
+      beaconConfig.boundary2ForkDigest(createSubscribeBoundary(beaconConfig, 0)),
       ...sszSnappySignedBeaconBlockPhase0.chunks,
       // Chunk 1 - success block in altair with context bytes
       Buffer.from([RespStatus.SUCCESS]),
-      beaconConfig.boundary2ForkDigest({fork: ForkName.altair}),
+      beaconConfig.boundary2ForkDigest(createSubscribeBoundary(beaconConfig, beaconConfig.ALTAIR_FORK_EPOCH)),
       ...sszSnappySignedBeaconBlockAltair.chunks,
     ],
   },
@@ -247,7 +247,7 @@ export const responseEncodersErrorTestCases: {
       // <result>
       Buffer.from([RespStatus.SUCCESS]),
       // <context-bytes>
-      beaconConfig.boundary2ForkDigest({fork: ForkName.altair}),
+      beaconConfig.boundary2ForkDigest(createSubscribeBoundary(beaconConfig, beaconConfig.ALTAIR_FORK_EPOCH)),
       // <encoding-dependent-header> | <encoded-payload>
       ...sszSnappySignedBeaconBlockAltair.chunks,
     ],

--- a/packages/reqresp/test/fixtures/encodingStrategies.ts
+++ b/packages/reqresp/test/fixtures/encodingStrategies.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import {fileURLToPath} from "node:url";
-import {ForkName} from "@lodestar/params";
+import {createSubscribeBoundary} from "@lodestar/config";
+import {config} from "@lodestar/config/default";
 import {ssz} from "@lodestar/types";
 import {encode as varintEncode} from "uint8-varint";
 import {SszSnappyErrorCode} from "../../src/encodingStrategies/sszSnappy/errors.js";
@@ -34,7 +35,7 @@ export const goerliShadowForkBlock13249: SszSnappyTestBlockData = {
   type: ssz.bellatrix.SignedBeaconBlock,
   payload: {
     data: fs.readFileSync(path.join(__dirname, "/goerliShadowForkBlock.13249/serialized.ssz")),
-    boundary: {fork: ForkName.altair},
+    boundary: createSubscribeBoundary(config, config.ALTAIR_FORK_EPOCH),
   },
   streamedBody: fs.readFileSync(path.join(__dirname, "/goerliShadowForkBlock.13249/streamed.snappy")),
 };

--- a/packages/reqresp/test/fixtures/protocols.ts
+++ b/packages/reqresp/test/fixtures/protocols.ts
@@ -1,5 +1,5 @@
 import {ContainerType, ListBasicType, UintNumberType, ValueOf} from "@chainsafe/ssz";
-import {ForkName} from "@lodestar/params";
+import {createSubscribeBoundary} from "@lodestar/config";
 import {ssz} from "@lodestar/types";
 import {ContextBytesType, DialOnlyProtocol, Encoding, Protocol, ProtocolHandler} from "../../src/types.js";
 import {getEmptyHandler} from "./messages.js";
@@ -40,7 +40,7 @@ export const numberToStringProtocol: Protocol = {
   handler: async function* handler(req) {
     yield {
       data: Buffer.from(req.data.toString(), "utf8"),
-      boundary: {fork: ForkName.phase0},
+      boundary: createSubscribeBoundary(beaconConfig, 0),
     };
   },
 };

--- a/packages/reqresp/test/unit/response/index.test.ts
+++ b/packages/reqresp/test/unit/response/index.test.ts
@@ -1,7 +1,7 @@
 import {PeerId} from "@libp2p/interface";
+import {createSubscribeBoundary} from "@lodestar/config";
 import {config} from "@lodestar/config/default.js";
 import {getEmptyLogger} from "@lodestar/logger/empty";
-import {isForkPostFulu} from "@lodestar/params";
 import {LodestarError, fromHex} from "@lodestar/utils";
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
 import {Protocol, RespStatus} from "../../../src/index.js";
@@ -27,15 +27,11 @@ const testCases: {
       const fork = payload.fork;
       yield {
         ...payload,
-        boundary: isForkPostFulu(fork)
-          ? {fork, EPOCH: config.ELECTRA_FORK_EPOCH, MAX_BLOBS_PER_BLOCK: config.MAX_BLOBS_PER_BLOCK_ELECTRA}
-          : {fork},
+        boundary: createSubscribeBoundary(config, config.forks[fork].epoch),
       };
       yield {
         ...payload,
-        boundary: isForkPostFulu(fork)
-          ? {fork, EPOCH: config.ELECTRA_FORK_EPOCH, MAX_BLOBS_PER_BLOCK: config.MAX_BLOBS_PER_BLOCK_ELECTRA}
-          : {fork},
+        boundary: createSubscribeBoundary(config, config.forks[fork].epoch),
       };
       throw new LodestarError({code: "TEST_ERROR"});
     }),

--- a/packages/reqresp/test/utils/response.ts
+++ b/packages/reqresp/test/utils/response.ts
@@ -1,5 +1,5 @@
+import {createSubscribeBoundary} from "@lodestar/config";
 import {config} from "@lodestar/config/default.js";
-import {isForkPostFulu} from "@lodestar/params";
 import {pipe} from "it-pipe";
 import {responseEncodeError, responseEncodeSuccess} from "../../src/encoders/responseEncode.js";
 import {RespStatus} from "../../src/interface.js";
@@ -16,9 +16,7 @@ export async function* responseEncode(responseChunks: ResponseChunk[], protocol:
         arrToSource([
           {
             ...payload,
-            boundary: isForkPostFulu(fork)
-              ? {fork, EPOCH: config.ELECTRA_FORK_EPOCH, MAX_BLOBS_PER_BLOCK: config.MAX_BLOBS_PER_BLOCK_ELECTRA}
-              : {fork},
+            boundary: createSubscribeBoundary(config, config.forks[fork].epoch),
           },
         ]),
         responseEncodeSuccess(protocol, {onChunk: () => {}})


### PR DESCRIPTION
The code around subscribe boundary is confusing. There are several factors that lead to this:
- `SubscribeBoundary.EPOCH` is not an indicator of the boundary's epoch, but it is from the hard fork/bpo fork's blob schedule that it uses when computing fork digest.
- The word "blob schedule" is used too liberally that refers to 1) `BlobSchedule` aka `BlobScheduleEntry[]` 2) `BlobScheduleEntry` 3) BPO fork 4) blob parameters
- Words like "blob parameters" and "BPO fork" are not used in our codebase. 
- Lack of helper functions eg. creating a `SubscribeBoundary` object, and attempt to get the actual boundary's epoch.

This PR draft attempts to solve these issues:
- Defining `epoch` in `SubscribeBoundary` that actual indicates the boundary epoch. See `packages/config/src/genesisConfig/network.ts`
- Add a factory method to create `SubscribeBoundary` object, that encapsulates boundary epoch calculation and retrieval of blob parameters that are needed to create a subscribe boundary. See `packages/config/src/genesisConfig/network.ts`.
- Use BPO fork wording instead of blob schedule when a blob schedule is used to define a BPO fork. eg. blob schedule in `ForkConfig.forkOrBpoAscendingEpochOrder`. 