### PR TITLE
feat: track on chain proposer rewards per block

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
@@ -129,7 +129,7 @@ export function createHistoricalStateTransitionMetrics(
       help: "Count of attestations per block",
     }),
     proposerRewards: metricsRegister.gauge<{type: ProposerRewardType}>({
-      name: "lodestar_historical_statestfn_proposer_rewards_total",
+      name: "lodestar_historical_state_stfn_proposer_rewards_total",
       help: "Proposer reward by type per block",
       labelNames: ["type"],
     }),

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/metrics.ts
@@ -1,6 +1,7 @@
 import {
   BeaconStateTransitionMetrics,
   EpochTransitionStep,
+  ProposerRewardType,
   StateCloneSource,
   StateHashTreeRootSource,
 } from "@lodestar/state-transition";
@@ -126,6 +127,11 @@ export function createHistoricalStateTransitionMetrics(
     attestationsPerBlock: metricsRegister.gauge({
       name: "lodestar_historical_state_stfn_attestations_per_block_total",
       help: "Count of attestations per block",
+    }),
+    proposerRewards: metricsRegister.gauge<{type: ProposerRewardType}>({
+      name: "lodestar_historical_statestfn_proposer_rewards_total",
+      help: "Proposer reward by type per block",
+      labelNames: ["type"],
     }),
   };
 }

--- a/packages/state-transition/src/block/index.ts
+++ b/packages/state-transition/src/block/index.ts
@@ -12,7 +12,7 @@ import {processOperations} from "./processOperations.js";
 import {processRandao} from "./processRandao.js";
 import {processSyncAggregate} from "./processSyncCommittee.js";
 import {processWithdrawals} from "./processWithdrawals.js";
-import {ProcessBlockOpts} from "./types.js";
+import {ProcessBlockOpts, ProposerRewardType} from "./types.js";
 
 // Spec tests
 export {
@@ -73,4 +73,9 @@ export function processBlock(
       throw Error("dataAvailabilityStatus.PreData");
     }
   }
+
+  const rewards = state.proposerRewards;
+  metrics?.proposerRewards.set({type: ProposerRewardType.attestation}, rewards.attestations);
+  metrics?.proposerRewards.set({type: ProposerRewardType.syncAggregate}, rewards.syncAggregate);
+  metrics?.proposerRewards.set({type: ProposerRewardType.slashing}, rewards.slashing);
 }

--- a/packages/state-transition/src/block/types.ts
+++ b/packages/state-transition/src/block/types.ts
@@ -1,3 +1,9 @@
 export interface ProcessBlockOpts {
   verifySignatures?: boolean;
 }
+
+export enum ProposerRewardType {
+  attestation = "attestation",
+  syncAggregate = "sync_aggregate",
+  slashing = "slashing",
+}

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -71,3 +71,5 @@ export {becomesNewEth1Data} from "./block/processEth1Data.js";
 export {getExpectedWithdrawals} from "./block/processWithdrawals.js";
 
 export {getAttestationParticipationStatus, processAttestationsAltair} from "./block/processAttestationsAltair.js";
+
+export {ProposerRewardType} from "./block/types.js";

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -1,4 +1,5 @@
 import {MetricsRegister} from "@lodestar/utils";
+import {ProposerRewardType} from "./block/types.js";
 import {EpochTransitionStep} from "./epoch/index.js";
 import {StateCloneSource, StateHashTreeRootSource} from "./stateTransition.js";
 import {CachedBeaconStateAllForks} from "./types.js";
@@ -111,6 +112,11 @@ export function getMetrics(register: MetricsRegister) {
     attestationsPerBlock: register.gauge({
       name: "lodestar_stfn_attestations_per_block_total",
       help: "Total count of attestations per block",
+    }),
+    proposerRewards: register.gauge<{type: ProposerRewardType}>({
+      name: "lodestar_stfn_proposer_rewards_total",
+      help: "Proposer reward by type per block",
+      labelNames: ["type"],
     }),
   };
 }


### PR DESCRIPTION
**Motivation**

- we already track produced block consensus value in #7921
- this will track on chain data so that we can improve later if needed

cc @nflaig 