### PR TITLE
feat: modify fork digest to distinguish BPO forks

### DIFF
--- a/packages/api/src/beacon/routes/lightclient.ts
+++ b/packages/api/src/beacon/routes/lightclient.ts
@@ -1,7 +1,7 @@
 import {ListCompositeType, ValueOf} from "@chainsafe/ssz";
 import {BeaconConfig, ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {NetworkName, genesisData} from "@lodestar/config/networks";
-import {ForkName, ZERO_HASH} from "@lodestar/params";
+import {ForkName, SLOTS_PER_EPOCH, ZERO_HASH} from "@lodestar/params";
 import {
   LightClientBootstrap,
   LightClientFinalityUpdate,
@@ -132,7 +132,8 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
             const chunks: Uint8Array[] = [];
             for (const [i, update] of data.entries()) {
               const version = meta.versions[i];
-              const forkDigest = cachedBeaconConfig().forkName2ForkDigest(version);
+              const epoch = Math.floor(update.attestedHeader.beacon.slot / SLOTS_PER_EPOCH);
+              const forkDigest = cachedBeaconConfig().epoch2ForkDigest(epoch);
               const serialized = getPostAltairForkTypes(version).LightClientUpdate.serialize(update);
               const length = ssz.UintNum64.serialize(4 + serialized.length);
               chunks.push(length, forkDigest, serialized);
@@ -145,7 +146,7 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
             while (offset < data.length) {
               const length = ssz.UintNum64.deserialize(data.subarray(offset, offset + 8));
               const forkDigest = ssz.ForkDigest.deserialize(data.subarray(offset + 8, offset + 12));
-              const version = cachedBeaconConfig().forkDigest2ForkName(forkDigest);
+              const {fork: version} = cachedBeaconConfig().forkDigest2ForkBoundary(forkDigest);
               updates.push(
                 getPostAltairForkTypes(version).LightClientUpdate.deserialize(
                   data.subarray(offset + 12, offset + 8 + length)

--- a/packages/api/src/beacon/routes/lightclient.ts
+++ b/packages/api/src/beacon/routes/lightclient.ts
@@ -132,8 +132,9 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
             const chunks: Uint8Array[] = [];
             for (const [i, update] of data.entries()) {
               const version = meta.versions[i];
+              const config = cachedBeaconConfig();
               const epoch = Math.floor(update.attestedHeader.beacon.slot / SLOTS_PER_EPOCH);
-              const forkDigest = cachedBeaconConfig().epoch2ForkDigest(epoch);
+              const forkDigest = config.forkBoundary2ForkDigest(config.getForkBoundaryAtEpoch(epoch));
               const serialized = getPostAltairForkTypes(version).LightClientUpdate.serialize(update);
               const length = ssz.UintNum64.serialize(4 + serialized.length);
               chunks.push(length, forkDigest, serialized);

--- a/packages/api/test/unit/beacon/genericServerTest/lightclient.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/lightclient.test.ts
@@ -8,7 +8,14 @@ import {testData} from "../testData/lightclient.js";
 
 describe("beacon / lightclient", () => {
   runGenericServerTest<Endpoints>(
-    createChainForkConfig({...defaultChainConfig, ELECTRA_FORK_EPOCH: 0}),
+    createChainForkConfig({
+      ...defaultChainConfig,
+      ALTAIR_FORK_EPOCH: 0,
+      BELLATRIX_FORK_EPOCH: 0,
+      CAPELLA_FORK_EPOCH: 0,
+      DENEB_FORK_EPOCH: 0,
+      ELECTRA_FORK_EPOCH: 0,
+    }),
     getClient,
     getRoutes,
     testData

--- a/packages/api/test/unit/beacon/genericServerTest/lightclient.test.ts
+++ b/packages/api/test/unit/beacon/genericServerTest/lightclient.test.ts
@@ -8,14 +8,7 @@ import {testData} from "../testData/lightclient.js";
 
 describe("beacon / lightclient", () => {
   runGenericServerTest<Endpoints>(
-    createChainForkConfig({
-      ...defaultChainConfig,
-      ALTAIR_FORK_EPOCH: 0,
-      BELLATRIX_FORK_EPOCH: 0,
-      CAPELLA_FORK_EPOCH: 0,
-      DENEB_FORK_EPOCH: 0,
-      ELECTRA_FORK_EPOCH: 0,
-    }),
+    createChainForkConfig({...defaultChainConfig, ELECTRA_FORK_EPOCH: 0}),
     getClient,
     getRoutes,
     testData

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -808,11 +808,12 @@ export class BeaconChain implements IBeaconChain {
   getStatus(): phase0.Status {
     const head = this.forkChoice.getHead();
     const finalizedCheckpoint = this.forkChoice.getFinalizedCheckpoint();
+    const boundary = this.config.getForkBoundaryAtEpoch(this.clock.currentEpoch);
     return {
       // fork_digest: The node's ForkDigest (compute_fork_digest(current_fork_version, genesis_validators_root)) where
       // - current_fork_version is the fork version at the node's current epoch defined by the wall-clock time (not necessarily the epoch to which the node is sync)
       // - genesis_validators_root is the static Root found in state.genesis_validators_root
-      forkDigest: this.config.epoch2ForkDigest(this.clock.currentEpoch),
+      forkDigest: this.config.forkBoundary2ForkDigest(boundary),
       // finalized_root: state.finalized_checkpoint.root for the state corresponding to the head block (Note this defaults to Root(b'\x00' * 32) for the genesis finalized checkpoint).
       finalizedRoot: finalizedCheckpoint.epoch === GENESIS_EPOCH ? ZERO_HASH : finalizedCheckpoint.root,
       finalizedEpoch: finalizedCheckpoint.epoch,

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -813,6 +813,7 @@ export class BeaconChain implements IBeaconChain {
       // fork_digest: The node's ForkDigest (compute_fork_digest(current_fork_version, genesis_validators_root)) where
       // - current_fork_version is the fork version at the node's current epoch defined by the wall-clock time (not necessarily the epoch to which the node is sync)
       // - genesis_validators_root is the static Root found in state.genesis_validators_root
+      // - epoch of fork boundary is used to get blob parameters of current Blob Parameter Only (BPO) fork
       forkDigest: this.config.forkBoundary2ForkDigest(boundary),
       // finalized_root: state.finalized_checkpoint.root for the state corresponding to the head block (Note this defaults to Root(b'\x00' * 32) for the genesis finalized checkpoint).
       finalizedRoot: finalizedCheckpoint.epoch === GENESIS_EPOCH ? ZERO_HASH : finalizedCheckpoint.root,

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -812,7 +812,7 @@ export class BeaconChain implements IBeaconChain {
       // fork_digest: The node's ForkDigest (compute_fork_digest(current_fork_version, genesis_validators_root)) where
       // - current_fork_version is the fork version at the node's current epoch defined by the wall-clock time (not necessarily the epoch to which the node is sync)
       // - genesis_validators_root is the static Root found in state.genesis_validators_root
-      forkDigest: this.config.forkName2ForkDigest(this.config.getForkName(this.clock.currentSlot)),
+      forkDigest: this.config.epoch2ForkDigest(this.clock.currentEpoch),
       // finalized_root: state.finalized_checkpoint.root for the state corresponding to the head block (Note this defaults to Root(b'\x00' * 32) for the genesis finalized checkpoint).
       finalizedRoot: finalizedCheckpoint.epoch === GENESIS_EPOCH ? ZERO_HASH : finalizedCheckpoint.root,
       finalizedEpoch: finalizedCheckpoint.epoch,

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -114,7 +114,7 @@ export async function validateGossipBlock(
   // [REJECT] The length of KZG commitments is less than or equal to the limitation defined in Consensus Layer -- i.e. validate that len(body.signed_beacon_block.message.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
   if (isForkPostDeneb(fork)) {
     const blobKzgCommitmentsLen = (block as deneb.BeaconBlock).body.blobKzgCommitments.length;
-    const maxBlobsPerBlock = chain.config.getMaxBlobsPerBlock(computeEpochAtSlot(blockSlot));
+    const maxBlobsPerBlock = config.getMaxBlobsPerBlock(computeEpochAtSlot(blockSlot));
     if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
       throw new BlockGossipError(GossipAction.REJECT, {
         code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS,

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -457,7 +457,7 @@ export class NetworkCore implements INetworkCore {
    */
   private onEpoch = async (epoch: Epoch): Promise<void> => {
     try {
-      // Compute prev and next fork shifted, so next fork is still next at forkEpoch + FORK_EPOCH_LOOKAHEAD
+      // Compute prev and next fork boundary shifted, so next boundary is still next at forkEpoch + FORK_EPOCH_LOOKAHEAD
       const activeBoundaries = getActiveForkBoundaries(this.config, epoch);
       for (let i = 0; i < activeBoundaries.length; i++) {
         // Only when a new fork boundary is scheduled post this one

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -468,15 +468,15 @@ export class NetworkCore implements INetworkCore {
 
           // Before fork boundary transition
           if (epoch === nextBoundaryEpoch - FORK_EPOCH_LOOKAHEAD) {
-            // Don't subscribe to new boundary if the node is not subscribed to any topic
+            // Don't subscribe to new fork boundary if the node is not subscribed to any topic
             if (await this.isSubscribedToGossipCoreTopics()) {
               this.subscribeCoreTopicsAtBoundary(this.config, nextBoundary);
-              this.logger.info("Subscribing gossip topics before fork boundary", nextBoundary);
+              this.logger.info("Subscribing gossip topics for next fork boundary", nextBoundary);
             } else {
-              this.logger.info("Skipping subscribing gossip topics before fork boundary", nextBoundary);
+              this.logger.info("Skipping subscribing gossip topics for next fork boundary", nextBoundary);
             }
-            this.attnetsService.subscribeSubnetsBeforeBoundary(nextBoundary);
-            this.syncnetsService.subscribeSubnetsBeforeBoundary(nextBoundary);
+            this.attnetsService.subscribeSubnetsForNextBoundary(nextBoundary);
+            this.syncnetsService.subscribeSubnetsForNextBoundary(nextBoundary);
           }
 
           // On fork boundary transition

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -479,14 +479,14 @@ export class NetworkCore implements INetworkCore {
             this.syncnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
           }
 
-          // On boundary transition
+          // On fork boundary transition
           if (epoch === nextBoundaryEpoch) {
             // updateEth2Field() MUST be called with clock epoch, onEpoch event is emitted in response to clock events
             this.metadata.updateEth2Field(epoch);
             this.reqResp.registerProtocolsAtBoundary(nextBoundary);
           }
 
-          // After boundary transition
+          // After fork boundary transition
           if (epoch === nextBoundaryEpoch + FORK_EPOCH_LOOKAHEAD) {
             this.logger.info("Unsubscribing gossip topics before fork boundary", prevBoundary);
             this.unsubscribeCoreTopicsAtBoundary(this.config, prevBoundary);

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -475,8 +475,8 @@ export class NetworkCore implements INetworkCore {
             } else {
               this.logger.info("Skipping subscribing gossip topics before fork boundary", nextBoundary);
             }
-            this.attnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
-            this.syncnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
+            this.attnetsService.subscribeSubnetsBeforeBoundary(nextBoundary);
+            this.syncnetsService.subscribeSubnetsBeforeBoundary(nextBoundary);
           }
 
           // On fork boundary transition
@@ -488,10 +488,10 @@ export class NetworkCore implements INetworkCore {
 
           // After fork boundary transition
           if (epoch === nextBoundaryEpoch + FORK_EPOCH_LOOKAHEAD) {
-            this.logger.info("Unsubscribing gossip topics before fork boundary", prevBoundary);
+            this.logger.info("Unsubscribing gossip topics from previous fork boundary", prevBoundary);
             this.unsubscribeCoreTopicsAtBoundary(this.config, prevBoundary);
-            this.attnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);
-            this.syncnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);
+            this.attnetsService.unsubscribeSubnetsFromPrevBoundary(prevBoundary);
+            this.syncnetsService.unsubscribeSubnetsFromPrevBoundary(prevBoundary);
           }
         }
       }

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -475,8 +475,8 @@ export class NetworkCore implements INetworkCore {
             } else {
               this.logger.info("Skipping subscribing gossip topics for next fork boundary", nextBoundary);
             }
-            this.attnetsService.subscribeSubnetsForNextBoundary(nextBoundary);
-            this.syncnetsService.subscribeSubnetsForNextBoundary(nextBoundary);
+            this.attnetsService.subscribeSubnetsNextBoundary(nextBoundary);
+            this.syncnetsService.subscribeSubnetsNextBoundary(nextBoundary);
           }
 
           // On fork boundary transition
@@ -488,10 +488,10 @@ export class NetworkCore implements INetworkCore {
 
           // After fork boundary transition
           if (epoch === nextBoundaryEpoch + FORK_EPOCH_LOOKAHEAD) {
-            this.logger.info("Unsubscribing gossip topics from previous fork boundary", prevBoundary);
+            this.logger.info("Unsubscribing gossip topics of previous fork boundary", prevBoundary);
             this.unsubscribeCoreTopicsAtBoundary(this.config, prevBoundary);
-            this.attnetsService.unsubscribeSubnetsFromPrevBoundary(prevBoundary);
-            this.syncnetsService.unsubscribeSubnetsFromPrevBoundary(prevBoundary);
+            this.attnetsService.unsubscribeSubnetsPrevBoundary(prevBoundary);
+            this.syncnetsService.unsubscribeSubnetsPrevBoundary(prevBoundary);
           }
         }
       }

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -465,30 +465,15 @@ export class NetworkCore implements INetworkCore {
           const prevBoundary = activeBoundaries[i];
           const nextBoundary = activeBoundaries[i + 1];
           const nextBoundaryEpoch = nextBoundary.epoch;
-          const isBpoForkBoundary = prevBoundary.fork === nextBoundary.fork;
 
           // Before fork boundary transition
           if (epoch === nextBoundaryEpoch - FORK_EPOCH_LOOKAHEAD) {
-            // Don't subscribe to new fork boundary if the node is not subscribed to any topic
+            // Don't subscribe to new boundary if the node is not subscribed to any topic
             if (await this.isSubscribedToGossipCoreTopics()) {
               this.subscribeCoreTopicsAtBoundary(this.config, nextBoundary);
-              if (isBpoForkBoundary) {
-                this.logger.info(
-                  "Subscribing gossip topics before BPO fork boundary",
-                  this.config.getBlobParameters(nextBoundaryEpoch)
-                );
-              } else {
-                this.logger.info("Subscribing gossip topics before fork boundary", nextBoundary);
-              }
+              this.logger.info("Subscribing gossip topics before fork boundary", nextBoundary);
             } else {
-              if (isBpoForkBoundary) {
-                this.logger.info(
-                  "Skipping subscribing gossip topics before BPO fork boundary",
-                  this.config.getBlobParameters(nextBoundaryEpoch)
-                );
-              } else {
-                this.logger.info("Skipping subscribing gossip topics before fork boundary", nextBoundary);
-              }
+              this.logger.info("Skipping subscribing gossip topics before fork boundary", nextBoundary);
             }
             this.attnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
             this.syncnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
@@ -503,14 +488,7 @@ export class NetworkCore implements INetworkCore {
 
           // After fork boundary transition
           if (epoch === nextBoundaryEpoch + FORK_EPOCH_LOOKAHEAD) {
-            if (isBpoForkBoundary) {
-              this.logger.info(
-                "Unsubscribing gossip topics of previous BPO fork boundary",
-                this.config.getBlobParameters(prevBoundary.epoch)
-              );
-            } else {
-              this.logger.info("Unsubscribing gossip topics of previous fork boundary", prevBoundary);
-            }
+            this.logger.info("Unsubscribing gossip topics before fork boundary", prevBoundary);
             this.unsubscribeCoreTopicsAtBoundary(this.config, prevBoundary);
             this.attnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);
             this.syncnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -453,20 +453,20 @@ export class NetworkCore implements INetworkCore {
   }
 
   /**
-   * Handle subscriptions through subscribe boundary transitions, @see FORK_EPOCH_LOOKAHEAD
+   * Handle subscriptions through fork boundary transitions, @see FORK_EPOCH_LOOKAHEAD
    */
   private onEpoch = async (epoch: Epoch): Promise<void> => {
     try {
       // Compute prev and next fork shifted, so next fork is still next at forkEpoch + FORK_EPOCH_LOOKAHEAD
       const activeBoundaries = getActiveForkBoundaries(this.config, epoch);
       for (let i = 0; i < activeBoundaries.length; i++) {
-        // Only when a new subscribe boundary is scheduled post this one
+        // Only when a new fork boundary is scheduled post this one
         if (activeBoundaries[i + 1] !== undefined) {
           const prevBoundary = activeBoundaries[i];
           const nextBoundary = activeBoundaries[i + 1];
           const nextBoundaryEpoch = nextBoundary.epoch;
 
-          // Before subscribe boundary transition
+          // Before fork boundary transition
           if (epoch === nextBoundaryEpoch - FORK_EPOCH_LOOKAHEAD) {
             // Don't subscribe to new boundary if the node is not subscribed to any topic
             if (await this.isSubscribedToGossipCoreTopics()) {

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -464,7 +464,7 @@ export class NetworkCore implements INetworkCore {
         if (activeBoundaries[i + 1] !== undefined) {
           const prevBoundary = activeBoundaries[i];
           const nextBoundary = activeBoundaries[i + 1];
-          const nextBoundaryEpoch = this.config.forks[nextBoundary.fork].epoch;
+          const nextBoundaryEpoch = nextBoundary.epoch;
 
           // Before subscribe boundary transition
           if (epoch === nextBoundaryEpoch - FORK_EPOCH_LOOKAHEAD) {

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -3,7 +3,7 @@ import {PeerScoreStatsDump} from "@chainsafe/libp2p-gossipsub/dist/src/score/pee
 import {PublishOpts} from "@chainsafe/libp2p-gossipsub/types";
 import {Connection, PrivateKey} from "@libp2p/interface";
 import {routes} from "@lodestar/api";
-import {BeaconConfig} from "@lodestar/config";
+import {BeaconConfig, ForkBoundary} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {Epoch, phase0, ssz, sszTypesFor} from "@lodestar/types";
@@ -15,7 +15,7 @@ import {ClockEvent, IClock} from "../../util/clock.js";
 import {PeerIdStr, peerIdFromString, peerIdToString} from "../../util/peerId.js";
 import {Discv5Worker} from "../discv5/index.js";
 import {NetworkEventBus} from "../events.js";
-import {FORK_EPOCH_LOOKAHEAD, getActiveSubscribeBoundaries} from "../forks.js";
+import {FORK_EPOCH_LOOKAHEAD, getActiveForkBoundaries} from "../forks.js";
 import {Eth2Gossipsub, getCoreTopicsAtFork} from "../gossip/index.js";
 import {Libp2p} from "../interface.js";
 import {createNodeJsLibp2p} from "../libp2p/index.js";
@@ -32,7 +32,7 @@ import {CommitteeSubscription, IAttnetsService} from "../subnets/interface.js";
 import {SyncnetsService} from "../subnets/syncnetsService.js";
 import {getConnectionsMap} from "../util.js";
 import {NetworkCoreMetrics, createNetworkCoreMetrics} from "./metrics.js";
-import {INetworkCore, MultiaddrStr, SubscribeBoundary} from "./types.js";
+import {INetworkCore, MultiaddrStr} from "./types.js";
 
 type Mods = {
   libp2p: Libp2p;
@@ -100,7 +100,7 @@ export class NetworkCore implements INetworkCore {
   private readonly opts: NetworkOptions;
 
   // Internal state
-  private readonly subscribedBoundariesByEpoch = new Map<Epoch, SubscribeBoundary>();
+  private readonly forkBoundariesByEpoch = new Map<Epoch, ForkBoundary>();
   private closed = false;
 
   constructor(modules: Mods) {
@@ -217,11 +217,11 @@ export class NetworkCore implements INetworkCore {
       opts
     );
 
-    // Network spec decides version changes based on clock fork, not head fork
-    const forkCurrentSlot = config.getForkName(clock.currentSlot);
+    // Network spec decides version changes based on clock epoch, not head epoch
+    const boundary = config.getForkBoundaryAtEpoch(clock.currentEpoch);
 
-    // Register only ReqResp protocols relevant to clock's fork
-    reqResp.registerProtocolsAtBoundary({fork: forkCurrentSlot});
+    // Register only ReqResp protocols relevant to clock's epoch
+    reqResp.registerProtocolsAtBoundary(boundary);
 
     // Bind discv5's ENR to local metadata
     // biome-ignore lint/complexity/useLiteralKeys: `discovery` is a private attribute
@@ -313,7 +313,7 @@ export class NetworkCore implements INetworkCore {
       this.logger.info("Subscribed gossip core topics");
     }
 
-    for (const boundary of getActiveSubscribeBoundaries(this.config, this.clock.currentEpoch)) {
+    for (const boundary of getActiveForkBoundaries(this.config, this.clock.currentEpoch)) {
       this.subscribeCoreTopicsAtBoundary(this.config, boundary);
     }
   }
@@ -322,13 +322,13 @@ export class NetworkCore implements INetworkCore {
    * Unsubscribe from all gossip events. Safe to call multiple times
    */
   async unsubscribeGossipCoreTopics(): Promise<void> {
-    for (const boundary of this.subscribedBoundariesByEpoch.values()) {
+    for (const boundary of this.forkBoundariesByEpoch.values()) {
       this.unsubscribeCoreTopicsAtBoundary(this.config, boundary);
     }
   }
 
   async isSubscribedToGossipCoreTopics(): Promise<boolean> {
-    return this.subscribedBoundariesByEpoch.size > 0;
+    return this.forkBoundariesByEpoch.size > 0;
   }
 
   sendReqRespRequest(data: OutgoingRequestArgs): AsyncIterable<ResponseIncoming> {
@@ -458,7 +458,7 @@ export class NetworkCore implements INetworkCore {
   private onEpoch = async (epoch: Epoch): Promise<void> => {
     try {
       // Compute prev and next fork shifted, so next fork is still next at forkEpoch + FORK_EPOCH_LOOKAHEAD
-      const activeBoundaries = getActiveSubscribeBoundaries(this.config, epoch);
+      const activeBoundaries = getActiveForkBoundaries(this.config, epoch);
       for (let i = 0; i < activeBoundaries.length; i++) {
         // Only when a new subscribe boundary is scheduled post this one
         if (activeBoundaries[i + 1] !== undefined) {
@@ -471,9 +471,9 @@ export class NetworkCore implements INetworkCore {
             // Don't subscribe to new boundary if the node is not subscribed to any topic
             if (await this.isSubscribedToGossipCoreTopics()) {
               this.subscribeCoreTopicsAtBoundary(this.config, nextBoundary);
-              this.logger.info("Subscribing gossip topics before boundary", nextBoundary);
+              this.logger.info("Subscribing gossip topics before fork boundary", nextBoundary);
             } else {
-              this.logger.info("Skipping subscribing gossip topics before boundary", nextBoundary);
+              this.logger.info("Skipping subscribing gossip topics before fork boundary", nextBoundary);
             }
             this.attnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
             this.syncnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
@@ -488,7 +488,7 @@ export class NetworkCore implements INetworkCore {
 
           // After boundary transition
           if (epoch === nextBoundaryEpoch + FORK_EPOCH_LOOKAHEAD) {
-            this.logger.info("Unsubscribing gossip topics before boundary", prevBoundary);
+            this.logger.info("Unsubscribing gossip topics before fork boundary", prevBoundary);
             this.unsubscribeCoreTopicsAtBoundary(this.config, prevBoundary);
             this.attnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);
             this.syncnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);
@@ -500,10 +500,9 @@ export class NetworkCore implements INetworkCore {
     }
   };
 
-  private subscribeCoreTopicsAtBoundary(config: BeaconConfig, boundary: SubscribeBoundary): void {
-    const epoch = config.forks[boundary.fork].epoch;
-    if (this.subscribedBoundariesByEpoch.has(epoch)) return;
-    this.subscribedBoundariesByEpoch.set(epoch, boundary);
+  private subscribeCoreTopicsAtBoundary(config: BeaconConfig, boundary: ForkBoundary): void {
+    if (this.forkBoundariesByEpoch.has(boundary.epoch)) return;
+    this.forkBoundariesByEpoch.set(boundary.epoch, boundary);
     const {subscribeAllSubnets, disableLightClientServer} = this.opts;
 
     for (const topic of getCoreTopicsAtFork(config, boundary.fork, {
@@ -514,10 +513,9 @@ export class NetworkCore implements INetworkCore {
     }
   }
 
-  private unsubscribeCoreTopicsAtBoundary(config: BeaconConfig, boundary: SubscribeBoundary): void {
-    const epoch = config.forks[boundary.fork].epoch;
-    if (!this.subscribedBoundariesByEpoch.has(epoch)) return;
-    this.subscribedBoundariesByEpoch.delete(epoch);
+  private unsubscribeCoreTopicsAtBoundary(config: BeaconConfig, boundary: ForkBoundary): void {
+    if (!this.forkBoundariesByEpoch.has(boundary.epoch)) return;
+    this.forkBoundariesByEpoch.delete(boundary.epoch);
     const {subscribeAllSubnets, disableLightClientServer} = this.opts;
 
     for (const topic of getCoreTopicsAtFork(config, boundary.fork, {

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -465,15 +465,30 @@ export class NetworkCore implements INetworkCore {
           const prevBoundary = activeBoundaries[i];
           const nextBoundary = activeBoundaries[i + 1];
           const nextBoundaryEpoch = nextBoundary.epoch;
+          const isBpoForkBoundary = prevBoundary.fork === nextBoundary.fork;
 
           // Before fork boundary transition
           if (epoch === nextBoundaryEpoch - FORK_EPOCH_LOOKAHEAD) {
-            // Don't subscribe to new boundary if the node is not subscribed to any topic
+            // Don't subscribe to new fork boundary if the node is not subscribed to any topic
             if (await this.isSubscribedToGossipCoreTopics()) {
               this.subscribeCoreTopicsAtBoundary(this.config, nextBoundary);
-              this.logger.info("Subscribing gossip topics before fork boundary", nextBoundary);
+              if (isBpoForkBoundary) {
+                this.logger.info(
+                  "Subscribing gossip topics before BPO fork boundary",
+                  this.config.getBlobParameters(nextBoundaryEpoch)
+                );
+              } else {
+                this.logger.info("Subscribing gossip topics before fork boundary", nextBoundary);
+              }
             } else {
-              this.logger.info("Skipping subscribing gossip topics before fork boundary", nextBoundary);
+              if (isBpoForkBoundary) {
+                this.logger.info(
+                  "Skipping subscribing gossip topics before BPO fork boundary",
+                  this.config.getBlobParameters(nextBoundaryEpoch)
+                );
+              } else {
+                this.logger.info("Skipping subscribing gossip topics before fork boundary", nextBoundary);
+              }
             }
             this.attnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
             this.syncnetsService.subscribeSubnetsAfterBoundary(nextBoundary);
@@ -488,7 +503,14 @@ export class NetworkCore implements INetworkCore {
 
           // After fork boundary transition
           if (epoch === nextBoundaryEpoch + FORK_EPOCH_LOOKAHEAD) {
-            this.logger.info("Unsubscribing gossip topics before fork boundary", prevBoundary);
+            if (isBpoForkBoundary) {
+              this.logger.info(
+                "Unsubscribing gossip topics of previous BPO fork boundary",
+                this.config.getBlobParameters(prevBoundary.epoch)
+              );
+            } else {
+              this.logger.info("Unsubscribing gossip topics of previous fork boundary", prevBoundary);
+            }
             this.unsubscribeCoreTopicsAtBoundary(this.config, prevBoundary);
             this.attnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);
             this.syncnetsService.unsubscribeSubnetsBeforeBoundary(prevBoundary);

--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -3,7 +3,6 @@ import {PublishOpts} from "@chainsafe/libp2p-gossipsub/types";
 import {routes} from "@lodestar/api";
 import {SpecJson} from "@lodestar/config";
 import {LoggerNodeOpts} from "@lodestar/logger/node";
-import {ForkName} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
 import {phase0} from "@lodestar/types";
 import {PeerIdStr} from "../../util/peerId.js";
@@ -13,8 +12,6 @@ import {OutgoingRequestArgs} from "../reqresp/types.js";
 import {CommitteeSubscription} from "../subnets/interface.js";
 
 export type MultiaddrStr = string;
-/* Boundary of network subscription. We subscribe/unsubscribe during fork transition */
-export type SubscribeBoundary = {fork: ForkName};
 
 // Interface shared by main Network class, and all backends
 export interface INetworkCorePublic {

--- a/packages/beacon-node/src/network/discv5/utils.ts
+++ b/packages/beacon-node/src/network/discv5/utils.ts
@@ -29,7 +29,7 @@ export function enrRelevance(enr: ENR, config: BeaconConfig, clock: IClock): ENR
   // Fast de-serialization without SSZ
   const forkDigest = eth2.slice(0, 4);
   // Check if forkDigest matches any of our known forks.
-  const forkName = config.forkDigest2ForkNameOption(forkDigest);
+  const {fork: forkName} = config.forkDigest2ForkBoundaryOption(forkDigest) ?? {};
   if (forkName == null) {
     return ENRRelevance.unknown_forkDigest;
   }

--- a/packages/beacon-node/src/network/discv5/utils.ts
+++ b/packages/beacon-node/src/network/discv5/utils.ts
@@ -30,7 +30,7 @@ export function enrRelevance(enr: ENR, config: BeaconConfig, clock: IClock): ENR
   const forkDigest = eth2.slice(0, 4);
   // Check if forkDigest matches any of our known forks.
   const {fork: forkName} = config.forkDigest2ForkBoundaryOption(forkDigest) ?? {};
-  if (forkName == null) {
+  if (forkName === undefined) {
     return ENRRelevance.unknown_forkDigest;
   }
 

--- a/packages/beacon-node/src/network/forks.ts
+++ b/packages/beacon-node/src/network/forks.ts
@@ -1,7 +1,5 @@
-import {ChainForkConfig, ForkInfo} from "@lodestar/config";
-import {ForkName} from "@lodestar/params";
+import {ChainForkConfig, ForkBoundary} from "@lodestar/config";
 import {Epoch} from "@lodestar/types";
-import {SubscribeBoundary} from "./core/types.js";
 
 /**
  * Subscribe topics to the new fork N epochs before the fork. Remove all subscriptions N epochs after the fork
@@ -31,69 +29,66 @@ import {SubscribeBoundary} from "./core/types.js";
 export const FORK_EPOCH_LOOKAHEAD = 2;
 
 /**
- * Return the list of `ForkName`s meant to be active at `epoch`
- * @see FORK_EPOCH_LOOKAHEAD for details on when forks are considered 'active'
+ * Return the list of `ForkBoundary`s meant to be active at `epoch`
+ * @see FORK_EPOCH_LOOKAHEAD for details on when fork boundaries are considered 'active'
  */
-export function getActiveForks(config: ChainForkConfig, epoch: Epoch): ForkName[] {
-  const activeForks: ForkName[] = [];
-  const forks = config.forksAscendingEpochOrder;
+export function getActiveForkBoundaries(config: ChainForkConfig, epoch: Epoch): ForkBoundary[] {
+  const activeBoundaries: ForkBoundary[] = [];
+  const {forkBoundariesAscendingEpochOrder} = config;
 
-  for (let i = 0; i < forks.length; i++) {
-    const currForkEpoch = forks[i].epoch;
-    const nextForkEpoch = i >= forks.length - 1 ? Infinity : forks[i + 1].epoch;
+  for (let i = 0; i < forkBoundariesAscendingEpochOrder.length; i++) {
+    const currentForkBoundary = forkBoundariesAscendingEpochOrder[i];
+    const nextForkBoundary = forkBoundariesAscendingEpochOrder[i + 1];
 
-    // Edge case: If multiple forks start at the same epoch, only consider the latest one
-    if (currForkEpoch === nextForkEpoch) {
+    const currEpoch = currentForkBoundary.epoch;
+    const nextEpoch = nextForkBoundary !== undefined ? nextForkBoundary.epoch : Infinity;
+
+    // If multiple forks/blob schedules start at the same epoch, only consider the latest one
+    if (currEpoch === nextEpoch) {
       continue;
     }
 
-    if (epoch >= currForkEpoch - FORK_EPOCH_LOOKAHEAD && epoch <= nextForkEpoch + FORK_EPOCH_LOOKAHEAD) {
-      activeForks.push(forks[i].name);
+    if (epoch >= currEpoch - FORK_EPOCH_LOOKAHEAD && epoch <= nextEpoch + FORK_EPOCH_LOOKAHEAD) {
+      activeBoundaries.push(currentForkBoundary);
     }
   }
 
-  return activeForks;
-}
-
-export function getActiveSubscribeBoundaries(config: ChainForkConfig, epoch: Epoch): SubscribeBoundary[] {
-  const activeForks = getActiveForks(config, epoch);
-
-  return activeForks.map((fork) => ({fork}));
+  return activeBoundaries;
 }
 
 /**
- * Return the currentFork and nextFork given a fork schedule and `epoch`
+ * Return the currentBoundary and nextBoundary given a fork/blob schedule and `epoch`
  */
-export function getCurrentAndNextFork(
+export function getCurrentAndNextForkBoundary(
   config: ChainForkConfig,
   epoch: Epoch
-): {currentFork: ForkInfo; nextFork: ForkInfo | undefined} {
+): {currentBoundary: ForkBoundary; nextBoundary: ForkBoundary | undefined} {
   if (epoch < 0) {
     epoch = 0;
   }
 
-  // NOTE: forks are sorted by ascending epoch, phase0 first
-  const forks = config.forksAscendingEpochOrder;
-  let currentForkIdx = -1;
+  // NOTE: fork boundaries are sorted by ascending epoch
+  const boundaries = config.forkBoundariesAscendingEpochOrder;
+  let currentBoundaryIdx = -1;
   // findLastIndex
-  for (let i = 0; i < forks.length; i++) {
-    if (epoch >= forks[i].epoch) currentForkIdx = i;
+  for (let i = 0; i < boundaries.length; i++) {
+    if (epoch >= boundaries[i].epoch) currentBoundaryIdx = i;
   }
 
-  let nextForkIdx = currentForkIdx + 1;
-  const hasNextFork = forks[nextForkIdx] !== undefined && forks[nextForkIdx].epoch !== Infinity;
-  // Keep moving the needle of nextForkIdx if there the higher fork also exists on same epoch
-  // for e.g. altair and bellatrix are on same epoch 6, next fork should be bellatrix
-  if (hasNextFork) {
-    for (let i = nextForkIdx + 1; i < forks.length; i++) {
-      // If the fork's epoch is same as nextForkIdx (which is not equal to infinity),
-      // update nextForkIdx to the same
-      if (forks[i].epoch === forks[nextForkIdx].epoch) nextForkIdx = i;
+  let nextBoundaryIdx = currentBoundaryIdx + 1;
+  const hasNextBoundary = boundaries[nextBoundaryIdx] !== undefined && boundaries[nextBoundaryIdx].epoch !== Infinity;
+  // Keep moving the needle of nextBoundaryIdx if there the higher boundary also exists on same epoch
+  // for e.g. altair and bellatrix are on same epoch 6, next boundary should be bellatrix
+  if (hasNextBoundary) {
+    for (let i = nextBoundaryIdx + 1; i < boundaries.length; i++) {
+      // If the boundary's epoch is same as nextBoundaryIdx (which is not equal to infinity),
+      // update nextBoundaryIdx to the same
+      if (boundaries[i].epoch === boundaries[nextBoundaryIdx].epoch) nextBoundaryIdx = i;
     }
   }
 
   return {
-    currentFork: forks[currentForkIdx] || forks[0],
-    nextFork: hasNextFork ? forks[nextForkIdx] : undefined,
+    currentBoundary: boundaries[currentBoundaryIdx] || boundaries[0],
+    nextBoundary: hasNextBoundary ? boundaries[nextBoundaryIdx] : undefined,
   };
 }

--- a/packages/beacon-node/src/network/forks.ts
+++ b/packages/beacon-node/src/network/forks.ts
@@ -43,7 +43,7 @@ export function getActiveForkBoundaries(config: ChainForkConfig, epoch: Epoch): 
     const currEpoch = currentForkBoundary.epoch;
     const nextEpoch = nextForkBoundary !== undefined ? nextForkBoundary.epoch : Infinity;
 
-    // If multiple forks/blob schedules start at the same epoch, only consider the latest one
+    // Edge case: If multiple fork boundaries start at the same epoch, only consider the latest one
     if (currEpoch === nextEpoch) {
       continue;
     }

--- a/packages/beacon-node/src/network/forks.ts
+++ b/packages/beacon-node/src/network/forks.ts
@@ -57,7 +57,7 @@ export function getActiveForkBoundaries(config: ChainForkConfig, epoch: Epoch): 
 }
 
 /**
- * Return the currentBoundary and nextBoundary given a fork/blob schedule and `epoch`
+ * Return the currentBoundary and nextBoundary given a fork/BPO schedule and `epoch`
  */
 export function getCurrentAndNextForkBoundary(
   config: ChainForkConfig,

--- a/packages/beacon-node/src/network/forks.ts
+++ b/packages/beacon-node/src/network/forks.ts
@@ -40,15 +40,15 @@ export function getActiveForkBoundaries(config: ChainForkConfig, epoch: Epoch): 
     const currentForkBoundary = forkBoundariesAscendingEpochOrder[i];
     const nextForkBoundary = forkBoundariesAscendingEpochOrder[i + 1];
 
-    const currEpoch = currentForkBoundary.epoch;
+    const currentEpoch = currentForkBoundary.epoch;
     const nextEpoch = nextForkBoundary !== undefined ? nextForkBoundary.epoch : Infinity;
 
     // Edge case: If multiple fork boundaries start at the same epoch, only consider the latest one
-    if (currEpoch === nextEpoch) {
+    if (currentEpoch === nextEpoch) {
       continue;
     }
 
-    if (epoch >= currEpoch - FORK_EPOCH_LOOKAHEAD && epoch <= nextEpoch + FORK_EPOCH_LOOKAHEAD) {
+    if (epoch >= currentEpoch - FORK_EPOCH_LOOKAHEAD && epoch <= nextEpoch + FORK_EPOCH_LOOKAHEAD) {
       activeBoundaries.push(currentForkBoundary);
     }
   }

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -335,13 +335,13 @@ function attSubnetLabel(subnet: SubnetID): string {
 function getMetricsTopicStrToLabel(config: BeaconConfig, opts: {disableLightClientServer: boolean}): TopicStrToLabel {
   const metricsTopicStrToLabel = new Map<TopicStr, TopicLabel>();
 
-  for (const {name: fork} of config.forksAscendingEpochOrder) {
-    const topics = getCoreTopicsAtFork(config, fork, {
+  for (const boundary of config.forkBoundariesAscendingEpochOrder) {
+    const topics = getCoreTopicsAtFork(config, boundary.fork, {
       subscribeAllSubnets: true,
       disableLightClientServer: opts.disableLightClientServer,
     });
     for (const topic of topics) {
-      metricsTopicStrToLabel.set(stringifyGossipTopic(config, {...topic, boundary: {fork}}), topic.type);
+      metricsTopicStrToLabel.set(stringifyGossipTopic(config, {...topic, boundary}), topic.type);
     }
   }
   return metricsTopicStrToLabel;

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -334,15 +334,25 @@ function attSubnetLabel(subnet: SubnetID): string {
 
 function getMetricsTopicStrToLabel(config: BeaconConfig, opts: {disableLightClientServer: boolean}): TopicStrToLabel {
   const metricsTopicStrToLabel = new Map<TopicStr, TopicLabel>();
+  const {forkBoundariesAscendingEpochOrder} = config;
 
-  for (const boundary of config.forkBoundariesAscendingEpochOrder) {
-    const topics = getCoreTopicsAtFork(config, boundary.fork, {
+  for (let i = 0; i < forkBoundariesAscendingEpochOrder.length; i++) {
+    const currentForkBoundary = forkBoundariesAscendingEpochOrder[i];
+    const nextForkBoundary = forkBoundariesAscendingEpochOrder[i + 1];
+
+    // Edge case: If multiple fork boundaries start at the same epoch, only consider the latest one
+    if (nextForkBoundary && currentForkBoundary.epoch === nextForkBoundary.epoch) {
+      continue;
+    }
+
+    const topics = getCoreTopicsAtFork(config, currentForkBoundary.fork, {
       subscribeAllSubnets: true,
       disableLightClientServer: opts.disableLightClientServer,
     });
     for (const topic of topics) {
-      metricsTopicStrToLabel.set(stringifyGossipTopic(config, {...topic, boundary}), topic.type);
+      metricsTopicStrToLabel.set(stringifyGossipTopic(config, {...topic, boundary: currentForkBoundary}), topic.type);
     }
   }
+
   return metricsTopicStrToLabel;
 }

--- a/packages/beacon-node/src/network/gossip/interface.ts
+++ b/packages/beacon-node/src/network/gossip/interface.ts
@@ -1,6 +1,6 @@
 import {PeerIdStr} from "@chainsafe/libp2p-gossipsub/types";
 import {Message, TopicValidatorResult} from "@libp2p/interface";
-import {BeaconConfig} from "@lodestar/config";
+import {BeaconConfig, ForkBoundary} from "@lodestar/config";
 import {
   AttesterSlashing,
   LightClientFinalityUpdate,
@@ -21,7 +21,6 @@ import {AttestationError, AttestationErrorType} from "../../chain/errors/attesta
 import {GossipActionError} from "../../chain/errors/gossipValidation.js";
 import {IBeaconChain} from "../../chain/index.js";
 import {JobItemQueue} from "../../util/queue/index.js";
-import {SubscribeBoundary} from "../core/types.js";
 
 export enum GossipType {
   beacon_block = "beacon_block",
@@ -50,7 +49,7 @@ export enum GossipEncoding {
  */
 export interface IGossipTopic {
   type: GossipType;
-  boundary: SubscribeBoundary;
+  boundary: ForkBoundary;
   encoding?: GossipEncoding;
 }
 

--- a/packages/beacon-node/src/network/gossip/scoringParameters.ts
+++ b/packages/beacon-node/src/network/gossip/scoringParameters.ts
@@ -7,7 +7,7 @@ import {
 import {BeaconConfig} from "@lodestar/config";
 import {ATTESTATION_SUBNET_COUNT, SLOTS_PER_EPOCH, TARGET_AGGREGATORS_PER_COMMITTEE} from "@lodestar/params";
 import {computeCommitteeCount} from "@lodestar/state-transition";
-import {getActiveSubscribeBoundaries} from "../forks.js";
+import {getActiveForkBoundaries} from "../forks.js";
 import {Eth2Context, Eth2GossipsubModules} from "./gossipsub.js";
 import {GossipType} from "./interface.js";
 import {stringifyGossipTopic} from "./topic.js";
@@ -123,7 +123,7 @@ function getAllTopicsScoreParams(
   const {epochDurationMs, slotDurationMs} = precomputedParams;
   const epoch = eth2Context.currentEpoch;
   const topicsParams: Record<string, TopicScoreParams> = {};
-  const boundaries = getActiveSubscribeBoundaries(config, epoch);
+  const boundaries = getActiveForkBoundaries(config, epoch);
   const beaconAttestationSubnetWeight = 1 / ATTESTATION_SUBNET_COUNT;
   for (const boundary of boundaries) {
     //first all fixed topics

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -49,7 +49,7 @@ export class GossipTopicCache implements IGossipTopicCache {
  * Stringify a GossipTopic into a spec-ed formated topic string
  */
 export function stringifyGossipTopic(forkDigestContext: ForkDigestContext, topic: GossipTopic): string {
-  const forkDigestHexNoPrefix = forkDigestContext.epoch2ForkDigestHex(topic.boundary.epoch);
+  const forkDigestHexNoPrefix = forkDigestContext.forkBoundary2ForkDigestHex(topic.boundary);
   const topicType = stringifyGossipTopicType(topic);
   const encoding = topic.encoding ?? DEFAULT_ENCODING;
   return `/eth2/${forkDigestHexNoPrefix}/${topicType}/${encoding}`;

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -49,7 +49,7 @@ export class GossipTopicCache implements IGossipTopicCache {
  * Stringify a GossipTopic into a spec-ed formated topic string
  */
 export function stringifyGossipTopic(forkDigestContext: ForkDigestContext, topic: GossipTopic): string {
-  const forkDigestHexNoPrefix = forkDigestContext.forkName2ForkDigestHex(topic.boundary.fork);
+  const forkDigestHexNoPrefix = forkDigestContext.epoch2ForkDigestHex(topic.boundary.epoch);
   const topicType = stringifyGossipTopicType(topic);
   const encoding = topic.encoding ?? DEFAULT_ENCODING;
   return `/eth2/${forkDigestHexNoPrefix}/${topicType}/${encoding}`;
@@ -172,7 +172,7 @@ export function parseGossipTopic(forkDigestContext: ForkDigestContext, topicStr:
 
     const [, forkDigestHexNoPrefix, gossipTypeStr, encodingStr] = matches;
 
-    const fork = forkDigestContext.forkDigest2ForkName(forkDigestHexNoPrefix);
+    const boundary = forkDigestContext.forkDigest2ForkBoundary(forkDigestHexNoPrefix);
     const encoding = parseEncodingStr(encodingStr);
 
     // Inline-d the parseGossipTopicType() function since spreading the resulting object x4 the time to parse a topicStr
@@ -186,7 +186,7 @@ export function parseGossipTopic(forkDigestContext: ForkDigestContext, topicStr:
       case GossipType.light_client_finality_update:
       case GossipType.light_client_optimistic_update:
       case GossipType.bls_to_execution_change:
-        return {type: gossipTypeStr, boundary: {fork}, encoding};
+        return {type: gossipTypeStr, boundary, encoding};
     }
 
     for (const gossipType of [GossipType.beacon_attestation as const, GossipType.sync_committee as const]) {
@@ -194,7 +194,7 @@ export function parseGossipTopic(forkDigestContext: ForkDigestContext, topicStr:
         const subnetStr = gossipTypeStr.slice(gossipType.length + 1); // +1 for '_' concatenating the topic name and the subnet
         const subnet = parseInt(subnetStr, 10);
         if (Number.isNaN(subnet)) throw Error(`Subnet ${subnetStr} is not a number`);
-        return {type: gossipType, subnet, boundary: {fork}, encoding};
+        return {type: gossipType, subnet, boundary, encoding};
       }
     }
 
@@ -202,7 +202,7 @@ export function parseGossipTopic(forkDigestContext: ForkDigestContext, topicStr:
       const subnetStr = gossipTypeStr.slice(GossipType.blob_sidecar.length + 1); // +1 for '_' concatenating the topic name and the subnet
       const subnet = parseInt(subnetStr, 10);
       if (Number.isNaN(subnet)) throw Error(`subnet ${subnetStr} is not a number`);
-      return {type: GossipType.blob_sidecar, subnet, boundary: {fork}, encoding};
+      return {type: GossipType.blob_sidecar, subnet, boundary, encoding};
     }
 
     throw Error(`Unknown gossip type ${gossipTypeStr}`);

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -4,7 +4,7 @@ import {ForkSeq} from "@lodestar/params";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, altair, phase0, ssz} from "@lodestar/types";
 import {FAR_FUTURE_EPOCH} from "../constants/index.js";
-import {getCurrentAndNextFork} from "./forks.js";
+import {getCurrentAndNextForkBoundary} from "./forks.js";
 
 export enum ENRKey {
   tcp = "tcp",
@@ -102,14 +102,16 @@ export class MetadataController {
 }
 
 export function getENRForkID(config: BeaconConfig, clockEpoch: Epoch): phase0.ENRForkID {
-  const {currentFork, nextFork} = getCurrentAndNextFork(config, clockEpoch);
+  const {currentBoundary, nextBoundary} = getCurrentAndNextForkBoundary(config, clockEpoch);
 
   return {
     // Current fork digest
-    forkDigest: config.forkName2ForkDigest(currentFork.name),
-    // next planned fork versin
-    nextForkVersion: nextFork ? nextFork.version : currentFork.version,
-    // next fork epoch
-    nextForkEpoch: nextFork ? nextFork.epoch : FAR_FUTURE_EPOCH,
+    forkDigest: config.epoch2ForkDigest(currentBoundary.epoch),
+    // Next planned fork version
+    nextForkVersion: nextBoundary
+      ? config.forks[nextBoundary.fork].version
+      : config.forks[currentBoundary.fork].version,
+    // Next fork epoch
+    nextForkEpoch: nextBoundary ? nextBoundary.epoch : FAR_FUTURE_EPOCH,
   };
 }

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -106,7 +106,7 @@ export function getENRForkID(config: BeaconConfig, clockEpoch: Epoch): phase0.EN
 
   return {
     // Current fork digest
-    forkDigest: config.epoch2ForkDigest(currentBoundary.epoch),
+    forkDigest: config.forkBoundary2ForkDigest(currentBoundary),
     // Next planned fork version
     nextForkVersion: nextBoundary
       ? config.forks[nextBoundary.fork].version

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -1,5 +1,5 @@
 import {PeerId} from "@libp2p/interface";
-import {BeaconConfig} from "@lodestar/config";
+import {BeaconConfig, ForkBoundary} from "@lodestar/config";
 import {ForkName, ForkSeq} from "@lodestar/params";
 import {
   Encoding,
@@ -17,7 +17,6 @@ import {Logger} from "@lodestar/utils";
 import {Libp2p} from "libp2p";
 import {callInNextEventLoop} from "../../util/eventLoop.js";
 import {NetworkCoreMetrics} from "../core/metrics.js";
-import {SubscribeBoundary} from "../core/types.js";
 import {INetworkEventBus, NetworkEvent} from "../events.js";
 import {MetadataController} from "../metadata.js";
 import {PeersData} from "../peers/peersData.js";
@@ -120,7 +119,7 @@ export class ReqRespBeaconNode extends ReqResp {
   // pruneOnPeerDisconnect(peerId: PeerId): void {
   //   this.rateLimiter.prune(peerId);
 
-  registerProtocolsAtBoundary(boundary: SubscribeBoundary): void {
+  registerProtocolsAtBoundary(boundary: ForkBoundary): void {
     this.currentRegisteredFork = ForkSeq[boundary.fork];
 
     const mustSubscribeProtocols = this.getProtocolsAtBoundary(boundary);
@@ -218,8 +217,8 @@ export class ReqRespBeaconNode extends ReqResp {
    * Returns the list of protocols that must be subscribed during a specific fork.
    * Any protocol not in this list must be un-subscribed.
    */
-  private getProtocolsAtBoundary(boundary: SubscribeBoundary): [ProtocolNoHandler, ProtocolHandler][] {
-    const fork = boundary.fork;
+  private getProtocolsAtBoundary(boundary: ForkBoundary): [ProtocolNoHandler, ProtocolHandler][] {
+    const {fork} = boundary;
     const protocolsAtFork: [ProtocolNoHandler, ProtocolHandler][] = [
       [protocols.Ping(fork, this.config), this.onPing.bind(this)],
       [protocols.Status(fork, this.config), this.onStatus.bind(this)],
@@ -297,7 +296,7 @@ export class ReqRespBeaconNode extends ReqResp {
     yield {
       data: ssz.phase0.Status.serialize(this.statusCache.get()),
       // Status topic is fork-agnostic
-      boundary: {fork: ForkName.phase0},
+      boundary: {fork: ForkName.phase0, epoch: 0},
     };
   }
 
@@ -308,7 +307,7 @@ export class ReqRespBeaconNode extends ReqResp {
     yield {
       data: ssz.phase0.Goodbye.serialize(BigInt(0)),
       // Goodbye topic is fork-agnostic
-      boundary: {fork: ForkName.phase0},
+      boundary: {fork: ForkName.phase0, epoch: 0},
     };
   }
 
@@ -318,7 +317,7 @@ export class ReqRespBeaconNode extends ReqResp {
     yield {
       data: ssz.phase0.Ping.serialize(this.metadataController.seqNumber),
       // Ping topic is fork-agnostic
-      boundary: {fork: ForkName.phase0},
+      boundary: {fork: ForkName.phase0, epoch: 0},
     };
   }
 
@@ -332,7 +331,7 @@ export class ReqRespBeaconNode extends ReqResp {
 
     yield {
       data: type.serialize(metadata),
-      boundary: {fork},
+      boundary: {fork, epoch: 0},
     };
   }
 }

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -1,6 +1,6 @@
 import {PeerId} from "@libp2p/interface";
 import {BeaconConfig, ForkBoundary} from "@lodestar/config";
-import {ForkName, ForkSeq} from "@lodestar/params";
+import {ForkName, ForkSeq, GENESIS_EPOCH} from "@lodestar/params";
 import {
   Encoding,
   ProtocolDescriptor,
@@ -307,7 +307,7 @@ export class ReqRespBeaconNode extends ReqResp {
     yield {
       data: ssz.phase0.Goodbye.serialize(BigInt(0)),
       // Goodbye topic is fork-agnostic
-      boundary: {fork: ForkName.phase0, epoch: 0},
+      boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
     };
   }
 
@@ -317,7 +317,7 @@ export class ReqRespBeaconNode extends ReqResp {
     yield {
       data: ssz.phase0.Ping.serialize(this.metadataController.seqNumber),
       // Ping topic is fork-agnostic
-      boundary: {fork: ForkName.phase0, epoch: 0},
+      boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
     };
   }
 

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -296,7 +296,7 @@ export class ReqRespBeaconNode extends ReqResp {
     yield {
       data: ssz.phase0.Status.serialize(this.statusCache.get()),
       // Status topic is fork-agnostic
-      boundary: {fork: ForkName.phase0, epoch: 0},
+      boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
     };
   }
 

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -327,11 +327,12 @@ export class ReqRespBeaconNode extends ReqResp {
     const metadata = this.metadataController.json;
     // Metadata topic is fork-agnostic
     const fork = ForkName.phase0;
+    const epoch = GENESIS_EPOCH;
     const type = responseSszTypeByMethod[ReqRespMethod.Metadata](fork, req.version);
 
     yield {
       data: type.serialize(metadata),
-      boundary: {fork, epoch: 0},
+      boundary: {fork, epoch},
     };
   }
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -1,6 +1,7 @@
 import {BeaconConfig} from "@lodestar/config";
 import {GENESIS_SLOT, MAX_REQUEST_BLOCKS, MAX_REQUEST_BLOCKS_DENEB, isForkPostDeneb} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {deneb, phase0} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
@@ -26,7 +27,7 @@ export async function* onBeaconBlocksByRange(
     for await (const {key, value} of finalized.binaryEntriesStream({gte: startSlot, lt: endSlot})) {
       yield {
         data: value,
-        boundary: {fork: chain.config.getForkName(finalized.decodeKey(key))},
+        boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(finalized.decodeKey(key))),
       };
     }
   }
@@ -57,7 +58,7 @@ export async function* onBeaconBlocksByRange(
 
         yield {
           data: blockBytes,
-          boundary: {fork: chain.config.getForkName(block.slot)},
+          boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(block.slot)),
         };
       }
 

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRoot.ts
@@ -1,4 +1,5 @@
 import {ResponseOutgoing} from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Slot, phase0} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
@@ -40,7 +41,7 @@ export async function* onBeaconBlocksByRoot(
 
       yield {
         data: blockBytes,
-        boundary: {fork: chain.config.getForkName(slot)},
+        boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(slot)),
       };
     }
   }

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
@@ -1,6 +1,7 @@
 import {BeaconConfig} from "@lodestar/config";
 import {BLOBSIDECAR_FIXED_SIZE, GENESIS_SLOT} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Slot, deneb} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
@@ -85,7 +86,7 @@ export function* iterateBlobBytesFromWrapper(
     }
     yield {
       data: blobSideCarBytes,
-      boundary: {fork: chain.config.getForkName(blockSlot)},
+      boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(blockSlot)),
     };
   }
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRoot.ts
@@ -1,5 +1,6 @@
 import {BLOBSIDECAR_FIXED_SIZE} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {RootHex} from "@lodestar/types";
 import {fromHex, toRootHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
@@ -55,7 +56,7 @@ export async function* onBlobSidecarsByRoot(
 
     yield {
       data: blobSidecarBytes,
-      boundary: {fork: chain.config.getForkName(block.slot)},
+      boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(block.slot)),
     };
   }
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientFinalityUpdate.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientFinalityUpdate.ts
@@ -1,4 +1,5 @@
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {IBeaconChain} from "../../../chain/index.js";
 import {assertLightClientServer} from "../../../node/utils/lightclient.js";
 import {ReqRespMethod, responseSszTypeByMethod} from "../types.js";
@@ -11,10 +12,10 @@ export async function* onLightClientFinalityUpdate(chain: IBeaconChain): AsyncIt
     throw new ResponseError(RespStatus.RESOURCE_UNAVAILABLE, "No latest finality update available");
   }
 
-  const fork = chain.config.getForkName(update.signatureSlot);
-  const type = responseSszTypeByMethod[ReqRespMethod.LightClientFinalityUpdate](fork, 0);
+  const boundary = chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(update.signatureSlot));
+  const type = responseSszTypeByMethod[ReqRespMethod.LightClientFinalityUpdate](boundary.fork, 0);
   yield {
     data: type.serialize(update),
-    boundary: {fork},
+    boundary,
   };
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientOptimisticUpdate.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientOptimisticUpdate.ts
@@ -1,4 +1,5 @@
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {IBeaconChain} from "../../../chain/index.js";
 import {assertLightClientServer} from "../../../node/utils/lightclient.js";
 import {ReqRespMethod, responseSszTypeByMethod} from "../types.js";
@@ -11,10 +12,10 @@ export async function* onLightClientOptimisticUpdate(chain: IBeaconChain): Async
     throw new ResponseError(RespStatus.RESOURCE_UNAVAILABLE, "No latest optimistic update available");
   }
 
-  const fork = chain.config.getForkName(update.signatureSlot);
-  const type = responseSszTypeByMethod[ReqRespMethod.LightClientOptimisticUpdate](fork, 0);
+  const boundary = chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(update.signatureSlot));
+  const type = responseSszTypeByMethod[ReqRespMethod.LightClientOptimisticUpdate](boundary.fork, 0);
   yield {
     data: type.serialize(update),
-    boundary: {fork},
+    boundary,
   };
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientUpdatesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientUpdatesByRange.ts
@@ -6,6 +6,7 @@ import {
   ResponseError,
   ResponseOutgoing,
 } from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {altair} from "@lodestar/types";
 import {IBeaconChain} from "../../../chain/index.js";
 import {assertLightClientServer} from "../../../node/utils/lightclient.js";
@@ -21,12 +22,12 @@ export async function* onLightClientUpdatesByRange(
   for (let period = requestBody.startPeriod; period < requestBody.startPeriod + count; period++) {
     try {
       const update = await chain.lightClientServer.getUpdate(period);
-      const fork = chain.config.getForkName(update.signatureSlot);
-      const type = responseSszTypeByMethod[ReqRespMethod.LightClientUpdatesByRange](fork, 0);
+      const boundary = chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(update.signatureSlot));
+      const type = responseSszTypeByMethod[ReqRespMethod.LightClientUpdatesByRange](boundary.fork, 0);
 
       yield {
         data: type.serialize(update),
-        boundary: {fork},
+        boundary,
       };
     } catch (e) {
       if ((e as LightClientServerError).type?.code === LightClientServerErrorCode.RESOURCE_UNAVAILABLE) {

--- a/packages/beacon-node/src/network/reqresp/handlers/status.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/status.ts
@@ -8,6 +8,6 @@ export async function* onStatus(chain: IBeaconChain): AsyncIterable<ResponseOutg
   yield {
     data: ssz.phase0.Status.serialize(status),
     // Status topic is fork-agnostic
-    boundary: {fork: ForkName.phase0, epoch: 0},
+    boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
   };
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/status.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/status.ts
@@ -8,6 +8,6 @@ export async function* onStatus(chain: IBeaconChain): AsyncIterable<ResponseOutg
   yield {
     data: ssz.phase0.Status.serialize(status),
     // Status topic is fork-agnostic
-    boundary: {fork: ForkName.phase0},
+    boundary: {fork: ForkName.phase0, epoch: 0},
   };
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/status.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/status.ts
@@ -1,4 +1,4 @@
-import {ForkName} from "@lodestar/params";
+import {ForkName, GENESIS_EPOCH} from "@lodestar/params";
 import {ResponseOutgoing} from "@lodestar/reqresp";
 import {ssz} from "@lodestar/types";
 import {IBeaconChain} from "../../../chain/index.js";

--- a/packages/beacon-node/src/network/reqresp/protocols.ts
+++ b/packages/beacon-node/src/network/reqresp/protocols.ts
@@ -1,4 +1,4 @@
-import {BeaconConfig, ForkDigestContext} from "@lodestar/config";
+import {BeaconConfig} from "@lodestar/config";
 import {ForkName} from "@lodestar/params";
 import {ContextBytesFactory, ContextBytesType, Encoding} from "@lodestar/reqresp";
 import {rateLimitQuotas} from "./rateLimit.js";
@@ -112,11 +112,11 @@ function toProtocol(protocol: ProtocolSummary) {
   });
 }
 
-function toContextBytes(type: ContextBytesType, config: ForkDigestContext): ContextBytesFactory {
+function toContextBytes(type: ContextBytesType, config: BeaconConfig): ContextBytesFactory {
   switch (type) {
     case ContextBytesType.Empty:
       return {type: ContextBytesType.Empty};
     case ContextBytesType.ForkDigest:
-      return {type: ContextBytesType.ForkDigest, forkDigestContext: config};
+      return {type: ContextBytesType.ForkDigest, config};
   }
 }

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -132,7 +132,7 @@ export class AttnetsService implements IAttnetsService {
    * TODO-dll: clarify how many epochs before the fork we should subscribe to the new fork
    * Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork
    **/
-  subscribeSubnetsForNextBoundary(boundary: ForkBoundary): void {
+  subscribeSubnetsNextBoundary(boundary: ForkBoundary): void {
     this.logger.info("Subscribing to long lived attnets for next fork boundary", {
       ...boundary,
       subnets: Array.from(this.longLivedSubscriptions).join(","),
@@ -146,8 +146,8 @@ export class AttnetsService implements IAttnetsService {
    * TODO-dll: clarify how many epochs after the fork we should unsubscribe to the new fork
    * Call  ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork
    **/
-  unsubscribeSubnetsFromPrevBoundary(boundary: ForkBoundary): void {
-    this.logger.info("Unsubscribing to long lived attnets from previous fork boundary", boundary);
+  unsubscribeSubnetsPrevBoundary(boundary: ForkBoundary): void {
+    this.logger.info("Unsubscribing from long lived attnets of previous fork boundary", boundary);
     for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
       if (!this.opts.subscribeAllSubnets) {
         this.gossip.unsubscribeTopic({type: gossipType, subnet, boundary});

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -1,11 +1,11 @@
-import {BeaconConfig} from "@lodestar/config";
+import {BeaconConfig, ForkBoundary} from "@lodestar/config";
 import {ATTESTATION_SUBNET_COUNT, EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Epoch, Slot, SubnetID, ssz} from "@lodestar/types";
 import {Logger, MapDef} from "@lodestar/utils";
 import {ClockEvent, IClock} from "../../util/clock.js";
 import {NetworkCoreMetrics} from "../core/metrics.js";
-import {SubscribeBoundary} from "../core/types.js";
-import {getActiveSubscribeBoundaries} from "../forks.js";
+import {getActiveForkBoundaries} from "../forks.js";
 import {GossipType} from "../gossip/index.js";
 import {GOSSIP_D_LOW} from "../gossip/scoringParameters.js";
 import {stringifyGossipTopic} from "../gossip/topic.js";
@@ -132,8 +132,8 @@ export class AttnetsService implements IAttnetsService {
    * TODO-dll: clarify how many epochs before the fork we should subscribe to the new fork
    * Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork
    **/
-  subscribeSubnetsAfterBoundary(boundary: SubscribeBoundary): void {
-    this.logger.info("Subscribing to long lived attnets after boundary", {
+  subscribeSubnetsAfterBoundary(boundary: ForkBoundary): void {
+    this.logger.info("Subscribing to long lived attnets after fork boundary", {
       ...boundary,
       subnets: Array.from(this.longLivedSubscriptions).join(","),
     });
@@ -146,8 +146,8 @@ export class AttnetsService implements IAttnetsService {
    * TODO-dll: clarify how many epochs after the fork we should unsubscribe to the new fork
    * Call  ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork
    **/
-  unsubscribeSubnetsBeforeBoundary(boundary: SubscribeBoundary): void {
-    this.logger.info("Unsubscribing to long lived attnets before boundary", {...boundary});
+  unsubscribeSubnetsBeforeBoundary(boundary: ForkBoundary): void {
+    this.logger.info("Unsubscribing to long lived attnets before fork boundary", {...boundary});
     for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
       if (!this.opts.subscribeAllSubnets) {
         this.gossip.unsubscribeTopic({type: gossipType, subnet, boundary});
@@ -218,7 +218,7 @@ export class AttnetsService implements IAttnetsService {
         if (timeToFormMesh === null) {
           const topicStr = stringifyGossipTopic(this.config, {
             type: gossipType,
-            boundary: {fork: this.config.getForkName(dutiedSlot)},
+            boundary: this.config.getForkBoundaryAtEpoch(computeEpochAtSlot(dutiedSlot)),
             subnet,
           });
           const numMeshPeers = this.gossip.mesh.get(topicStr)?.size ?? 0;
@@ -329,7 +329,7 @@ export class AttnetsService implements IAttnetsService {
    * shortLivedSubscriptions or longLivedSubscriptions should be updated right AFTER this called
    **/
   private subscribeToSubnets(subnets: number[], src: SubnetSource): void {
-    const boundaries = getActiveSubscribeBoundaries(this.config, this.clock.currentEpoch);
+    const boundaries = getActiveForkBoundaries(this.config, this.clock.currentEpoch);
 
     for (const subnet of subnets) {
       if (!this.shortLivedSubscriptions.has(subnet) && !this.longLivedSubscriptions.has(subnet)) {
@@ -349,7 +349,7 @@ export class AttnetsService implements IAttnetsService {
     // No need to unsubscribeTopic(). Return early to prevent repetitive extra work
     if (this.opts.subscribeAllSubnets) return;
 
-    const boundaries = getActiveSubscribeBoundaries(this.config, this.clock.currentEpoch);
+    const boundaries = getActiveForkBoundaries(this.config, this.clock.currentEpoch);
 
     for (const subnet of subnets) {
       if (!this.shortLivedSubscriptions.isActiveAtSlot(subnet, slot) && !this.longLivedSubscriptions.has(subnet)) {
@@ -369,7 +369,7 @@ export class AttnetsService implements IAttnetsService {
     for (const {subnet} of this.shortLivedSubscriptions.getActiveTtl(currentSlot)) {
       const topicStr = stringifyGossipTopic(this.config, {
         type: gossipType,
-        boundary: {fork: this.config.getForkName(currentSlot)},
+        boundary: this.config.getForkBoundaryAtEpoch(this.clock.currentEpoch),
         subnet,
       });
       const numMeshPeers = this.gossip.mesh.get(topicStr)?.size ?? 0;

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -132,8 +132,8 @@ export class AttnetsService implements IAttnetsService {
    * TODO-dll: clarify how many epochs before the fork we should subscribe to the new fork
    * Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork
    **/
-  subscribeSubnetsBeforeBoundary(boundary: ForkBoundary): void {
-    this.logger.info("Subscribing to long lived attnets before fork boundary", {
+  subscribeSubnetsForNextBoundary(boundary: ForkBoundary): void {
+    this.logger.info("Subscribing to long lived attnets for next fork boundary", {
       ...boundary,
       subnets: Array.from(this.longLivedSubscriptions).join(","),
     });

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -132,8 +132,8 @@ export class AttnetsService implements IAttnetsService {
    * TODO-dll: clarify how many epochs before the fork we should subscribe to the new fork
    * Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork
    **/
-  subscribeSubnetsAfterBoundary(boundary: ForkBoundary): void {
-    this.logger.info("Subscribing to long lived attnets after fork boundary", {
+  subscribeSubnetsBeforeBoundary(boundary: ForkBoundary): void {
+    this.logger.info("Subscribing to long lived attnets before fork boundary", {
       ...boundary,
       subnets: Array.from(this.longLivedSubscriptions).join(","),
     });
@@ -146,8 +146,8 @@ export class AttnetsService implements IAttnetsService {
    * TODO-dll: clarify how many epochs after the fork we should unsubscribe to the new fork
    * Call  ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork
    **/
-  unsubscribeSubnetsBeforeBoundary(boundary: ForkBoundary): void {
-    this.logger.info("Unsubscribing to long lived attnets before fork boundary", {...boundary});
+  unsubscribeSubnetsFromPrevBoundary(boundary: ForkBoundary): void {
+    this.logger.info("Unsubscribing to long lived attnets from previous fork boundary", boundary);
     for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
       if (!this.opts.subscribeAllSubnets) {
         this.gossip.unsubscribeTopic({type: gossipType, subnet, boundary});

--- a/packages/beacon-node/src/network/subnets/interface.ts
+++ b/packages/beacon-node/src/network/subnets/interface.ts
@@ -15,7 +15,7 @@ export type SubnetsService = {
   close(): void;
   addCommitteeSubscriptions(subscriptions: CommitteeSubscription[]): void;
   getActiveSubnets(): RequestedSubnet[];
-  subscribeSubnetsBeforeBoundary(boundary: ForkBoundary): void;
+  subscribeSubnetsForNextBoundary(boundary: ForkBoundary): void;
   unsubscribeSubnetsFromPrevBoundary(boundary: ForkBoundary): void;
 };
 

--- a/packages/beacon-node/src/network/subnets/interface.ts
+++ b/packages/beacon-node/src/network/subnets/interface.ts
@@ -15,8 +15,8 @@ export type SubnetsService = {
   close(): void;
   addCommitteeSubscriptions(subscriptions: CommitteeSubscription[]): void;
   getActiveSubnets(): RequestedSubnet[];
-  subscribeSubnetsForNextBoundary(boundary: ForkBoundary): void;
-  unsubscribeSubnetsFromPrevBoundary(boundary: ForkBoundary): void;
+  subscribeSubnetsNextBoundary(boundary: ForkBoundary): void;
+  unsubscribeSubnetsPrevBoundary(boundary: ForkBoundary): void;
 };
 
 export interface IAttnetsService extends SubnetsService {

--- a/packages/beacon-node/src/network/subnets/interface.ts
+++ b/packages/beacon-node/src/network/subnets/interface.ts
@@ -1,5 +1,5 @@
+import {ForkBoundary} from "@lodestar/config";
 import {Bytes32, Slot, SubnetID, ValidatorIndex} from "@lodestar/types";
-import {SubscribeBoundary} from "../core/types.js";
 import {GossipTopic} from "../gossip/interface.js";
 import {RequestedSubnet} from "../peers/utils/index.js";
 
@@ -15,8 +15,8 @@ export type SubnetsService = {
   close(): void;
   addCommitteeSubscriptions(subscriptions: CommitteeSubscription[]): void;
   getActiveSubnets(): RequestedSubnet[];
-  subscribeSubnetsAfterBoundary(boundary: SubscribeBoundary): void;
-  unsubscribeSubnetsBeforeBoundary(prevFork: SubscribeBoundary): void;
+  subscribeSubnetsAfterBoundary(boundary: ForkBoundary): void;
+  unsubscribeSubnetsBeforeBoundary(prevFork: ForkBoundary): void;
 };
 
 export interface IAttnetsService extends SubnetsService {

--- a/packages/beacon-node/src/network/subnets/interface.ts
+++ b/packages/beacon-node/src/network/subnets/interface.ts
@@ -15,8 +15,8 @@ export type SubnetsService = {
   close(): void;
   addCommitteeSubscriptions(subscriptions: CommitteeSubscription[]): void;
   getActiveSubnets(): RequestedSubnet[];
-  subscribeSubnetsAfterBoundary(boundary: ForkBoundary): void;
-  unsubscribeSubnetsBeforeBoundary(prevFork: ForkBoundary): void;
+  subscribeSubnetsBeforeBoundary(boundary: ForkBoundary): void;
+  unsubscribeSubnetsFromPrevBoundary(boundary: ForkBoundary): void;
 };
 
 export interface IAttnetsService extends SubnetsService {

--- a/packages/beacon-node/src/network/subnets/syncnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/syncnetsService.ts
@@ -73,7 +73,7 @@ export class SyncnetsService implements SubnetsService {
   }
 
   /** Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork  */
-  subscribeSubnetsForNextBoundary(boundary: ForkBoundary): void {
+  subscribeSubnetsNextBoundary(boundary: ForkBoundary): void {
     this.logger.info("Subscribing to random attnets for next fork boundary", boundary);
     for (const subnet of this.subscriptionsCommittee.getAll()) {
       this.gossip.subscribeTopic({type: gossipType, boundary, subnet});
@@ -81,8 +81,8 @@ export class SyncnetsService implements SubnetsService {
   }
 
   /** Call  ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork */
-  unsubscribeSubnetsFromPrevBoundary(boundary: ForkBoundary): void {
-    this.logger.info("Unsubscribing to random attnets from previous fork boundary", boundary);
+  unsubscribeSubnetsPrevBoundary(boundary: ForkBoundary): void {
+    this.logger.info("Unsubscribing from random attnets of previous fork boundary", boundary);
     for (let subnet = 0; subnet < SYNC_COMMITTEE_SUBNET_COUNT; subnet++) {
       if (!this.opts?.subscribeAllSubnets) {
         this.gossip.unsubscribeTopic({type: gossipType, boundary, subnet});

--- a/packages/beacon-node/src/network/subnets/syncnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/syncnetsService.ts
@@ -1,12 +1,11 @@
-import {BeaconConfig} from "@lodestar/config";
+import {BeaconConfig, ForkBoundary} from "@lodestar/config";
 import {SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, ssz} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {ClockEvent, IClock} from "../../util/clock.js";
 import {NetworkCoreMetrics} from "../core/metrics.js";
-import {SubscribeBoundary} from "../core/types.js";
-import {getActiveSubscribeBoundaries} from "../forks.js";
+import {getActiveForkBoundaries} from "../forks.js";
 import {GossipType} from "../gossip/index.js";
 import {MetadataController} from "../metadata.js";
 import {RequestedSubnet, SubnetMap} from "../peers/utils/index.js";
@@ -74,19 +73,19 @@ export class SyncnetsService implements SubnetsService {
   }
 
   /** Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork  */
-  subscribeSubnetsAfterBoundary(boundary: SubscribeBoundary): void {
+  subscribeSubnetsAfterBoundary(boundary: ForkBoundary): void {
     this.logger.info("Subscribing to random attnets after boundary", boundary);
     for (const subnet of this.subscriptionsCommittee.getAll()) {
-      this.gossip.subscribeTopic({type: gossipType, boundary: {fork: boundary.fork}, subnet});
+      this.gossip.subscribeTopic({type: gossipType, boundary, subnet});
     }
   }
 
   /** Call  ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork */
-  unsubscribeSubnetsBeforeBoundary(boundary: SubscribeBoundary): void {
+  unsubscribeSubnetsBeforeBoundary(boundary: ForkBoundary): void {
     this.logger.info("Unsubscribing to random attnets before boundary", boundary);
     for (let subnet = 0; subnet < SYNC_COMMITTEE_SUBNET_COUNT; subnet++) {
       if (!this.opts?.subscribeAllSubnets) {
-        this.gossip.unsubscribeTopic({type: gossipType, boundary: {fork: boundary.fork}, subnet});
+        this.gossip.unsubscribeTopic({type: gossipType, boundary, subnet});
       }
     }
   }
@@ -119,7 +118,7 @@ export class SyncnetsService implements SubnetsService {
 
   /** Tigger a gossip subcription only if not already subscribed */
   private subscribeToSubnets(subnets: number[]): void {
-    const boundaries = getActiveSubscribeBoundaries(this.config, this.clock.currentEpoch);
+    const boundaries = getActiveForkBoundaries(this.config, this.clock.currentEpoch);
     for (const subnet of subnets) {
       if (!this.subscriptionsCommittee.has(subnet)) {
         for (const boundary of boundaries) {
@@ -132,7 +131,7 @@ export class SyncnetsService implements SubnetsService {
 
   /** Trigger a gossip un-subscrition only if no-one is still subscribed */
   private unsubscribeSubnets(subnets: number[]): void {
-    const boundaries = getActiveSubscribeBoundaries(this.config, this.clock.currentEpoch);
+    const boundaries = getActiveForkBoundaries(this.config, this.clock.currentEpoch);
     for (const subnet of subnets) {
       // No need to check if active in subscriptionsCommittee since we only have a single SubnetMap
       if (!this.opts?.subscribeAllSubnets) {

--- a/packages/beacon-node/src/network/subnets/syncnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/syncnetsService.ts
@@ -73,16 +73,16 @@ export class SyncnetsService implements SubnetsService {
   }
 
   /** Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork  */
-  subscribeSubnetsAfterBoundary(boundary: ForkBoundary): void {
-    this.logger.info("Subscribing to random attnets after fork boundary", boundary);
+  subscribeSubnetsBeforeBoundary(boundary: ForkBoundary): void {
+    this.logger.info("Subscribing to random attnets before fork boundary", boundary);
     for (const subnet of this.subscriptionsCommittee.getAll()) {
       this.gossip.subscribeTopic({type: gossipType, boundary, subnet});
     }
   }
 
   /** Call  ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork */
-  unsubscribeSubnetsBeforeBoundary(boundary: ForkBoundary): void {
-    this.logger.info("Unsubscribing to random attnets before fork boundary", boundary);
+  unsubscribeSubnetsFromPrevBoundary(boundary: ForkBoundary): void {
+    this.logger.info("Unsubscribing to random attnets from previous fork boundary", boundary);
     for (let subnet = 0; subnet < SYNC_COMMITTEE_SUBNET_COUNT; subnet++) {
       if (!this.opts?.subscribeAllSubnets) {
         this.gossip.unsubscribeTopic({type: gossipType, boundary, subnet});

--- a/packages/beacon-node/src/network/subnets/syncnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/syncnetsService.ts
@@ -74,7 +74,7 @@ export class SyncnetsService implements SubnetsService {
 
   /** Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork  */
   subscribeSubnetsAfterBoundary(boundary: ForkBoundary): void {
-    this.logger.info("Subscribing to random attnets after boundary", boundary);
+    this.logger.info("Subscribing to random attnets after fork boundary", boundary);
     for (const subnet of this.subscriptionsCommittee.getAll()) {
       this.gossip.subscribeTopic({type: gossipType, boundary, subnet});
     }
@@ -82,7 +82,7 @@ export class SyncnetsService implements SubnetsService {
 
   /** Call  ONLY ONCE: Two epochs after the fork, un-subscribe all subnets from the old fork */
   unsubscribeSubnetsBeforeBoundary(boundary: ForkBoundary): void {
-    this.logger.info("Unsubscribing to random attnets before boundary", boundary);
+    this.logger.info("Unsubscribing to random attnets before fork boundary", boundary);
     for (let subnet = 0; subnet < SYNC_COMMITTEE_SUBNET_COUNT; subnet++) {
       if (!this.opts?.subscribeAllSubnets) {
         this.gossip.unsubscribeTopic({type: gossipType, boundary, subnet});

--- a/packages/beacon-node/src/network/subnets/syncnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/syncnetsService.ts
@@ -73,8 +73,8 @@ export class SyncnetsService implements SubnetsService {
   }
 
   /** Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork  */
-  subscribeSubnetsBeforeBoundary(boundary: ForkBoundary): void {
-    this.logger.info("Subscribing to random attnets before fork boundary", boundary);
+  subscribeSubnetsForNextBoundary(boundary: ForkBoundary): void {
+    this.logger.info("Subscribing to random attnets for next fork boundary", boundary);
     for (const subnet of this.subscriptionsCommittee.getAll()) {
       this.gossip.subscribeTopic({type: gossipType, boundary, subnet});
     }

--- a/packages/beacon-node/src/network/subscribeBoundary.ts
+++ b/packages/beacon-node/src/network/subscribeBoundary.ts
@@ -1,7 +1,0 @@
-import {BeaconConfig} from "@lodestar/config";
-import {Epoch} from "@lodestar/types";
-import {SubscribeBoundary} from "./core/types.js";
-
-export function getSubscribeBoundary(config: BeaconConfig, epoch: Epoch): SubscribeBoundary {
-  return {fork: config.getForkInfoAtEpoch(epoch).name};
-}

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -1,7 +1,7 @@
 import {BitArray} from "@chainsafe/ssz";
 import {TopicValidatorResult} from "@libp2p/interface";
 import {routes} from "@lodestar/api";
-import {config} from "@lodestar/config/default.js";
+import {config} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -1,6 +1,7 @@
 import {BitArray} from "@chainsafe/ssz";
 import {TopicValidatorResult} from "@libp2p/interface";
 import {routes} from "@lodestar/api";
+import {config} from "@lodestar/config/default.js";
 import {ForkName} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
@@ -47,7 +48,7 @@ describe("data serialization through worker boundary", () => {
     [ReqRespBridgeEvent.outgoingResponse]: {
       type: IteratorEventType.next,
       id: 0,
-      item: {data: bytes, boundary: {fork: ForkName.altair}},
+      item: {data: bytes, boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH}},
     },
     [ReqRespBridgeEvent.incomingRequest]: {id: 0, callArgs: {method, req: {data: bytes, version: 1}, peerId}},
     [ReqRespBridgeEvent.incomingResponse]: {
@@ -95,7 +96,7 @@ describe("data serialization through worker boundary", () => {
       peer,
     },
     [NetworkEvent.pendingGossipsubMessage]: {
-      topic: {type: GossipType.beacon_block, boundary: {fork: ForkName.altair}},
+      topic: {type: GossipType.beacon_block, boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH}},
       msg: {
         type: "unsigned",
         topic: "test-topic",

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -63,8 +63,8 @@ describe("network / peers / PeerManager", () => {
       shouldProcess: () => true,
       addCommitteeSubscriptions: () => {},
       close: () => {},
-      subscribeSubnetsForNextBoundary: () => {},
-      unsubscribeSubnetsFromPrevBoundary: () => {},
+      subscribeSubnetsNextBoundary: () => {},
+      unsubscribeSubnetsPrevBoundary: () => {},
     };
 
     const peerManager = new PeerManager(

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -63,8 +63,8 @@ describe("network / peers / PeerManager", () => {
       shouldProcess: () => true,
       addCommitteeSubscriptions: () => {},
       close: () => {},
-      subscribeSubnetsAfterBoundary: () => {},
-      unsubscribeSubnetsBeforeBoundary: () => {},
+      subscribeSubnetsBeforeBoundary: () => {},
+      unsubscribeSubnetsFromPrevBoundary: () => {},
     };
 
     const peerManager = new PeerManager(

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -63,7 +63,7 @@ describe("network / peers / PeerManager", () => {
       shouldProcess: () => true,
       addCommitteeSubscriptions: () => {},
       close: () => {},
-      subscribeSubnetsBeforeBoundary: () => {},
+      subscribeSubnetsForNextBoundary: () => {},
       unsubscribeSubnetsFromPrevBoundary: () => {},
     };
 

--- a/packages/beacon-node/test/e2e/network/reqresp.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqresp.test.ts
@@ -2,6 +2,7 @@ import {ChainForkConfig, createChainForkConfig} from "@lodestar/config";
 import {chainConfig} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
 import {RequestError, RequestErrorCode, ResponseOutgoing} from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Root, SignedBeaconBlock, altair, phase0, ssz} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
@@ -115,7 +116,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
           if (method === ReqRespMethod.LightClientBootstrap) {
             yield {
               data: ssz.altair.LightClientBootstrap.serialize(expectedValue),
-              boundary: {fork: ForkName.altair},
+              boundary: {fork: ForkName.altair, epoch: 0},
             };
           }
         }
@@ -136,7 +137,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
           if (method === ReqRespMethod.LightClientOptimisticUpdate) {
             yield {
               data: ssz.altair.LightClientOptimisticUpdate.serialize(expectedValue),
-              boundary: {fork: ForkName.altair},
+              boundary: {fork: ForkName.altair, epoch: 0},
             };
           }
         }
@@ -157,7 +158,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
           if (method === ReqRespMethod.LightClientFinalityUpdate) {
             yield {
               data: ssz.altair.LightClientFinalityUpdate.serialize(expectedValue),
-              boundary: {fork: ForkName.altair},
+              boundary: {fork: ForkName.altair, epoch: 0},
             };
           }
         }
@@ -177,7 +178,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
       update.signatureSlot = slot;
       lightClientUpdates.push({
         data: ssz.altair.LightClientUpdate.serialize(update),
-        boundary: {fork: ForkName.altair},
+        boundary: {fork: ForkName.altair, epoch: 0},
       });
     }
 
@@ -332,6 +333,6 @@ function getEmptyEncodedPayloadSignedBeaconBlock(config: ChainForkConfig): Respo
 function wrapBlockAsEncodedPayload(config: ChainForkConfig, block: SignedBeaconBlock): ResponseOutgoing {
   return {
     data: config.getForkTypes(block.message.slot).SignedBeaconBlock.serialize(block),
-    boundary: {fork: config.getForkName(block.message.slot)},
+    boundary: config.getForkBoundaryAtEpoch(computeEpochAtSlot(block.message.slot)),
   };
 }

--- a/packages/beacon-node/test/e2e/network/reqresp.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqresp.test.ts
@@ -116,7 +116,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
           if (method === ReqRespMethod.LightClientBootstrap) {
             yield {
               data: ssz.altair.LightClientBootstrap.serialize(expectedValue),
-              boundary: {fork: ForkName.altair, epoch: 0},
+              boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH},
             };
           }
         }
@@ -137,7 +137,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
           if (method === ReqRespMethod.LightClientOptimisticUpdate) {
             yield {
               data: ssz.altair.LightClientOptimisticUpdate.serialize(expectedValue),
-              boundary: {fork: ForkName.altair, epoch: 0},
+              boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH},
             };
           }
         }
@@ -158,7 +158,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
           if (method === ReqRespMethod.LightClientFinalityUpdate) {
             yield {
               data: ssz.altair.LightClientFinalityUpdate.serialize(expectedValue),
-              boundary: {fork: ForkName.altair, epoch: 0},
+              boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH},
             };
           }
         }
@@ -178,7 +178,7 @@ function runTests({useWorker}: {useWorker: boolean}): void {
       update.signatureSlot = slot;
       lightClientUpdates.push({
         data: ssz.altair.LightClientUpdate.serialize(update),
-        boundary: {fork: ForkName.altair, epoch: 0},
+        boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH},
       });
     }
 

--- a/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
@@ -2,6 +2,7 @@ import {noise} from "@chainsafe/libp2p-noise";
 import {mplex} from "@libp2p/mplex";
 import {tcp} from "@libp2p/tcp";
 import {createBeaconConfig} from "@lodestar/config";
+import {config} from "@lodestar/config/default.js";
 import {ForkName} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {fromHex, sleep, toHex} from "@lodestar/utils";
@@ -99,7 +100,7 @@ describe("reqresp encoder", () => {
 
   it("assert correct handler switch between metadata v2 and v1", async () => {
     const {multiaddr: serverMultiaddr, reqresp} = await getReqResp();
-    reqresp.registerProtocolsAtBoundary({fork: ForkName.phase0});
+    reqresp.registerProtocolsAtBoundary({fork: ForkName.phase0, epoch: 0});
     await sleep(0); // Sleep to resolve register handler promises
 
     reqresp["metadataController"].attnets.set(0, true);
@@ -130,11 +131,11 @@ describe("reqresp encoder", () => {
             data: ssz.altair.LightClientOptimisticUpdate.serialize(
               ssz.altair.LightClientOptimisticUpdate.defaultValue()
             ),
-            boundary: {fork: ForkName.phase0}, // Aware that phase0 does not makes sense here, but it's just to pick a fork digest
+            boundary: {fork: ForkName.phase0, epoch: 0}, // Aware that phase0 does not makes sense here, but it's just to pick a fork digest
           };
         }
     );
-    reqresp.registerProtocolsAtBoundary({fork: ForkName.altair});
+    reqresp.registerProtocolsAtBoundary({fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH});
     await sleep(0); // Sleep to resolve register handler promises
 
     const {libp2p: dialer} = await getLibp2p();

--- a/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
@@ -3,7 +3,7 @@ import {mplex} from "@libp2p/mplex";
 import {tcp} from "@libp2p/tcp";
 import {createBeaconConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
-import {ForkName} from "@lodestar/params";
+import {ForkName, GENESIS_EPOCH} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {fromHex, sleep, toHex} from "@lodestar/utils";
 import {Multiaddr, multiaddr} from "@multiformats/multiaddr";
@@ -100,7 +100,7 @@ describe("reqresp encoder", () => {
 
   it("assert correct handler switch between metadata v2 and v1", async () => {
     const {multiaddr: serverMultiaddr, reqresp} = await getReqResp();
-    reqresp.registerProtocolsAtBoundary({fork: ForkName.phase0, epoch: 0});
+    reqresp.registerProtocolsAtBoundary({fork: ForkName.phase0, epoch: GENESIS_EPOCH});
     await sleep(0); // Sleep to resolve register handler promises
 
     reqresp["metadataController"].attnets.set(0, true);
@@ -131,7 +131,7 @@ describe("reqresp encoder", () => {
             data: ssz.altair.LightClientOptimisticUpdate.serialize(
               ssz.altair.LightClientOptimisticUpdate.defaultValue()
             ),
-            boundary: {fork: ForkName.phase0, epoch: 0}, // Aware that phase0 does not makes sense here, but it's just to pick a fork digest
+            boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH}, // Aware that phase0 does not makes sense here, but it's just to pick a fork digest
           };
         }
     );

--- a/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
@@ -2,7 +2,7 @@ import {noise} from "@chainsafe/libp2p-noise";
 import {mplex} from "@libp2p/mplex";
 import {tcp} from "@libp2p/tcp";
 import {createBeaconConfig} from "@lodestar/config";
-import {config} from "@lodestar/config/default.js";
+import {config} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {fromHex, sleep, toHex} from "@lodestar/utils";

--- a/packages/beacon-node/test/spec/presets/light_client/sync.ts
+++ b/packages/beacon-node/test/spec/presets/light_client/sync.ts
@@ -196,7 +196,13 @@ function pickConfigForkEpochs(config: Partial<ChainConfig>): Partial<ChainConfig
   const configOnlyFork: Record<string, number> = {};
   for (const key of Object.keys(config) as (keyof ChainConfig)[]) {
     if (key.endsWith("_FORK_EPOCH")) {
-      configOnlyFork[key] = config[key] as number;
+      const value = config[key];
+      // Overwrite 2^64 to Infinity
+      if (typeof value === "bigint" && value > BigInt(Number.MAX_SAFE_INTEGER)) {
+        configOnlyFork[key] = Infinity;
+      } else {
+        configOnlyFork[key] = Number(value);
+      }
     }
   }
   return configOnlyFork;

--- a/packages/beacon-node/test/unit/network/fork.test.ts
+++ b/packages/beacon-node/test/unit/network/fork.test.ts
@@ -1,7 +1,7 @@
 import {BeaconConfig, ForkInfo} from "@lodestar/config";
 import {ForkName, ForkSeq} from "@lodestar/params";
 import {describe, expect, it} from "vitest";
-import {getActiveForks, getCurrentAndNextFork} from "../../../src/network/forks.js";
+import {getCurrentAndNextForkBoundary} from "../../../src/network/forks.js";
 
 function getForkConfig({
   phase0,
@@ -80,7 +80,12 @@ function getForkConfig({
   };
   const forksAscendingEpochOrder = Object.values(forks);
   const forksDescendingEpochOrder = Object.values(forks).reverse();
-  return {forks, forksAscendingEpochOrder, forksDescendingEpochOrder} as BeaconConfig;
+  return {
+    forks,
+    forksAscendingEpochOrder,
+    forksDescendingEpochOrder,
+    forkBoundariesAscendingEpochOrder: forksAscendingEpochOrder.map(({name, epoch}) => ({fork: name, epoch})),
+  } as BeaconConfig;
 }
 
 const testScenarios = [
@@ -165,11 +170,13 @@ for (const testScenario of testScenarios) {
         currentFork,
         nextFork,
       })}, getActiveForks: ${activeForks.join(",")}`, () => {
-        expect(getCurrentAndNextFork(forkConfig, epoch)).toEqual({
-          currentFork: forks[currentFork as ForkName],
-          nextFork: (nextFork && forks[nextFork as ForkName]) ?? undefined,
+        const currentForkInfo = forks[currentFork as ForkName];
+        const nextForkInfo = (nextFork && forks[nextFork as ForkName]) ?? undefined;
+
+        expect(getCurrentAndNextForkBoundary(forkConfig, epoch)).toEqual({
+          currentBoundary: {fork: currentForkInfo.name, epoch: currentForkInfo.epoch},
+          nextBoundary: nextForkInfo ? {fork: nextForkInfo.name, epoch: nextForkInfo.epoch} : undefined,
         });
-        expect(getActiveForks(forkConfig, epoch)).toEqual(activeForks);
       });
     }
   });

--- a/packages/beacon-node/test/unit/network/fork.test.ts
+++ b/packages/beacon-node/test/unit/network/fork.test.ts
@@ -169,7 +169,7 @@ for (const testScenario of testScenarios) {
       it(` on epoch ${epoch} should return ${JSON.stringify({
         currentFork,
         nextFork,
-      })}, getActiveForks: ${activeForks.join(",")}`, () => {
+      })}, activeForks: ${activeForks.join(",")}`, () => {
         const currentForkInfo = forks[currentFork as ForkName];
         const nextForkInfo = (nextFork && forks[nextFork as ForkName]) ?? undefined;
 

--- a/packages/beacon-node/test/unit/network/forkBoundary.test.ts
+++ b/packages/beacon-node/test/unit/network/forkBoundary.test.ts
@@ -1,0 +1,248 @@
+import {BlobSchedule, ChainConfig, ChainForkConfig, ForkBoundary, createChainForkConfig} from "@lodestar/config";
+import {config as defaultConfig} from "@lodestar/config/default";
+import {ForkName} from "@lodestar/params";
+import {describe, expect, it} from "vitest";
+import {getActiveForkBoundaries} from "../../../src/network/forks.js";
+
+function getForkConfig({
+  altair,
+  bellatrix,
+  capella,
+  deneb,
+  electra,
+  fulu,
+  blobSchedule,
+}: {
+  altair: number;
+  bellatrix: number;
+  capella: number;
+  deneb: number;
+  electra: number;
+  fulu: number;
+  blobSchedule: BlobSchedule;
+}): ChainForkConfig {
+  const forkEpochs: Partial<ChainConfig> = {
+    ALTAIR_FORK_EPOCH: altair,
+    BELLATRIX_FORK_EPOCH: bellatrix,
+    CAPELLA_FORK_EPOCH: capella,
+    DENEB_FORK_EPOCH: deneb,
+    ELECTRA_FORK_EPOCH: electra,
+    FULU_FORK_EPOCH: fulu,
+    BLOB_SCHEDULE: blobSchedule,
+  };
+
+  return createChainForkConfig({...defaultConfig, ...forkEpochs});
+}
+
+const testScenarios: {
+  altair: number;
+  bellatrix: number;
+  capella: number;
+  deneb: number;
+  electra: number;
+  fulu: number;
+  blobSchedule: BlobSchedule;
+  testCases: {epoch: number; activeBoundaries: ForkBoundary[]}[];
+}[] = [
+  {
+    altair: 0,
+    bellatrix: Infinity,
+    capella: Infinity,
+    deneb: Infinity,
+    electra: Infinity,
+    fulu: Infinity,
+    blobSchedule: [],
+    testCases: [
+      {epoch: -1, activeBoundaries: [{fork: ForkName.altair, epoch: 0}]},
+      {epoch: 0, activeBoundaries: [{fork: ForkName.altair, epoch: 0}]},
+      {epoch: 1, activeBoundaries: [{fork: ForkName.altair, epoch: 0}]},
+    ],
+  },
+  {
+    altair: 10,
+    bellatrix: 20,
+    capella: 30,
+    deneb: 40,
+    electra: 50,
+    fulu: Infinity,
+    blobSchedule: [],
+    testCases: [
+      {
+        epoch: 50,
+        activeBoundaries: [
+          {fork: ForkName.deneb, epoch: 40},
+          {fork: ForkName.electra, epoch: 50},
+        ],
+      },
+      {epoch: 55, activeBoundaries: [{fork: ForkName.electra, epoch: 50}]},
+    ],
+  },
+  {
+    altair: 10,
+    bellatrix: 20,
+    capella: 30,
+    deneb: 40,
+    electra: 50,
+    fulu: 60,
+    blobSchedule: [],
+    testCases: [
+      {
+        epoch: 50,
+        activeBoundaries: [
+          {fork: ForkName.deneb, epoch: 40},
+          {fork: ForkName.electra, epoch: 50},
+        ],
+      },
+      {epoch: 55, activeBoundaries: [{fork: ForkName.electra, epoch: 50}]},
+      {
+        epoch: 60,
+        activeBoundaries: [
+          {fork: ForkName.electra, epoch: 50},
+          {fork: ForkName.fulu, epoch: 60},
+        ],
+      },
+      {
+        epoch: 65,
+        activeBoundaries: [{fork: ForkName.fulu, epoch: 60}],
+      },
+    ],
+  },
+  {
+    altair: 0,
+    bellatrix: 0,
+    capella: 0,
+    deneb: 0,
+    electra: 10,
+    fulu: 20,
+    blobSchedule: [
+      {EPOCH: 20, MAX_BLOBS_PER_BLOCK: 200},
+      {EPOCH: 25, MAX_BLOBS_PER_BLOCK: 250},
+      {EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300},
+    ],
+    testCases: [
+      {
+        epoch: 10,
+        activeBoundaries: [
+          {fork: ForkName.deneb, epoch: 0},
+          {fork: ForkName.electra, epoch: 10},
+        ],
+      },
+      {epoch: 15, activeBoundaries: [{fork: ForkName.electra, epoch: 10}]},
+      {
+        epoch: 20,
+        activeBoundaries: [
+          {fork: ForkName.electra, epoch: 10},
+          {fork: ForkName.fulu, epoch: 20},
+        ],
+      },
+      {
+        epoch: 25,
+        activeBoundaries: [
+          {fork: ForkName.fulu, epoch: 20},
+          {fork: ForkName.fulu, epoch: 25},
+        ],
+      },
+      {
+        epoch: 30,
+        activeBoundaries: [
+          {fork: ForkName.fulu, epoch: 25},
+          {fork: ForkName.fulu, epoch: 30},
+        ],
+      },
+      {epoch: 33, activeBoundaries: [{fork: ForkName.fulu, epoch: 30}]},
+    ],
+  },
+  {
+    altair: 0,
+    bellatrix: 0,
+    capella: 0,
+    deneb: 0,
+    electra: 10,
+    fulu: 20,
+    blobSchedule: [
+      {EPOCH: 30, MAX_BLOBS_PER_BLOCK: 300},
+      {EPOCH: 40, MAX_BLOBS_PER_BLOCK: 400},
+    ],
+    testCases: [
+      {
+        epoch: 20,
+        activeBoundaries: [
+          {fork: ForkName.electra, epoch: 10},
+          {fork: ForkName.fulu, epoch: 20},
+        ],
+      },
+      {
+        epoch: 25,
+        activeBoundaries: [{fork: ForkName.fulu, epoch: 20}],
+      },
+      {
+        epoch: 30,
+        activeBoundaries: [
+          {fork: ForkName.fulu, epoch: 20},
+          {fork: ForkName.fulu, epoch: 30},
+        ],
+      },
+      {epoch: 35, activeBoundaries: [{fork: ForkName.fulu, epoch: 30}]},
+      {
+        epoch: 40,
+        activeBoundaries: [
+          {fork: ForkName.fulu, epoch: 30},
+          {fork: ForkName.fulu, epoch: 40},
+        ],
+      },
+      {epoch: 45, activeBoundaries: [{fork: ForkName.fulu, epoch: 40}]},
+    ],
+  },
+  {
+    altair: 0,
+    bellatrix: 0,
+    capella: 0,
+    deneb: 0,
+    electra: 10,
+    fulu: 20,
+    blobSchedule: [
+      {EPOCH: 22, MAX_BLOBS_PER_BLOCK: 220},
+      {EPOCH: 24, MAX_BLOBS_PER_BLOCK: 240},
+    ],
+    testCases: [
+      {
+        epoch: 20,
+        activeBoundaries: [
+          {fork: ForkName.electra, epoch: 10},
+          {fork: ForkName.fulu, epoch: 20},
+          {fork: ForkName.fulu, epoch: 22},
+        ],
+      },
+      {
+        epoch: 23,
+        activeBoundaries: [
+          {fork: ForkName.fulu, epoch: 20},
+          {fork: ForkName.fulu, epoch: 22},
+          {fork: ForkName.fulu, epoch: 24},
+        ],
+      },
+      {
+        epoch: 25,
+        activeBoundaries: [
+          {fork: ForkName.fulu, epoch: 22},
+          {fork: ForkName.fulu, epoch: 24},
+        ],
+      },
+      {epoch: 27, activeBoundaries: [{fork: ForkName.fulu, epoch: 24}]},
+    ],
+  },
+];
+
+for (const testScenario of testScenarios) {
+  const {altair, bellatrix, capella, deneb, electra, fulu, blobSchedule, testCases} = testScenario;
+
+  describe("network / forks / getActiveForkBoundaries", () => {
+    const forkConfig = getForkConfig({altair, bellatrix, capella, deneb, electra, fulu, blobSchedule});
+    for (const testCase of testCases) {
+      const {epoch, activeBoundaries} = testCase;
+      it(` on epoch ${epoch} should return ${JSON.stringify(activeBoundaries)}`, () => {
+        expect(getActiveForkBoundaries(forkConfig, epoch)).toEqual(activeBoundaries);
+      });
+    }
+  });
+}

--- a/packages/beacon-node/test/unit/network/gossip/scoringParameters.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/scoringParameters.test.ts
@@ -15,8 +15,8 @@ import {GossipType} from "../../../../src/network/index.js";
 describe("computeGossipPeerScoreParams", () => {
   const config = createBeaconConfig(mainnetChainConfig, ZERO_HASH);
   // Cheap stub on new BeaconConfig instance
-  config.forkName2ForkDigest = () => Buffer.alloc(4, 1);
-  config.forkDigest2ForkName = () => ForkName.phase0;
+  config.epoch2ForkDigest = () => Buffer.alloc(4, 1);
+  config.forkDigest2ForkBoundary = () => ({fork: ForkName.phase0, epoch: 0});
 
   const TOLERANCE = 0.00005;
 
@@ -69,7 +69,7 @@ describe("computeGossipPeerScoreParams", () => {
   function validateVoluntaryExitTopicParams(topics: Record<string, TopicScoreParams>): void {
     const topicString = stringifyGossipTopic(config, {
       type: GossipType.voluntary_exit,
-      boundary: {fork: ForkName.phase0},
+      boundary: {fork: ForkName.phase0, epoch: 0},
     });
     const params = topics[topicString];
     assertMessageRatePenaltiesDisabled(params);
@@ -87,11 +87,11 @@ describe("computeGossipPeerScoreParams", () => {
   function validateSlashingTopicParams(topics: Record<string, TopicScoreParams>): void {
     const attesterSlashingTopicString = stringifyGossipTopic(config, {
       type: GossipType.attester_slashing,
-      boundary: {fork: ForkName.phase0},
+      boundary: {fork: ForkName.phase0, epoch: 0},
     });
     const proposerSlashingTopicString = stringifyGossipTopic(config, {
       type: GossipType.proposer_slashing,
-      boundary: {fork: ForkName.phase0},
+      boundary: {fork: ForkName.phase0, epoch: 0},
     });
     validateSlashingTopicScoreParams(topics[attesterSlashingTopicString]);
     validateSlashingTopicScoreParams(topics[proposerSlashingTopicString]);
@@ -113,7 +113,7 @@ describe("computeGossipPeerScoreParams", () => {
   function validateAggregateTopicParams(topics: Record<string, TopicScoreParams>, penaltiesActive: boolean): void {
     const topicString = stringifyGossipTopic(config, {
       type: GossipType.beacon_aggregate_and_proof,
-      boundary: {fork: ForkName.phase0},
+      boundary: {fork: ForkName.phase0, epoch: 0},
     });
     const params = topics[topicString];
 
@@ -147,7 +147,7 @@ describe("computeGossipPeerScoreParams", () => {
   function validateBlockTopicParams(topics: Record<string, TopicScoreParams>, penaltiesActive: boolean): void {
     const topicString = stringifyGossipTopic(config, {
       type: GossipType.beacon_block,
-      boundary: {fork: ForkName.phase0},
+      boundary: {fork: ForkName.phase0, epoch: 0},
     });
     const params = topics[topicString];
 
@@ -185,7 +185,7 @@ describe("computeGossipPeerScoreParams", () => {
     for (let i = 0; i < ATTESTATION_SUBNET_COUNT; i++) {
       const topicString = stringifyGossipTopic(config, {
         type: GossipType.beacon_attestation,
-        boundary: {fork: ForkName.phase0},
+        boundary: {fork: ForkName.phase0, epoch: 0},
         subnet: i,
       });
       validateAllAttestationSubnetTopicScoreParams(topics[topicString], penaltiesActive);

--- a/packages/beacon-node/test/unit/network/gossip/scoringParameters.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/scoringParameters.test.ts
@@ -15,7 +15,7 @@ import {GossipType} from "../../../../src/network/index.js";
 describe("computeGossipPeerScoreParams", () => {
   const config = createBeaconConfig(mainnetChainConfig, ZERO_HASH);
   // Cheap stub on new BeaconConfig instance
-  config.epoch2ForkDigest = () => Buffer.alloc(4, 1);
+  config.forkBoundary2ForkDigest = () => Buffer.alloc(4, 1);
   config.forkDigest2ForkBoundary = () => ({fork: ForkName.phase0, epoch: 0});
 
   const TOLERANCE = 0.00005;

--- a/packages/beacon-node/test/unit/network/gossip/scoringParameters.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/scoringParameters.test.ts
@@ -1,7 +1,7 @@
 import {TopicScoreParams} from "@chainsafe/libp2p-gossipsub/score";
 import {createBeaconConfig} from "@lodestar/config";
 import {mainnetChainConfig} from "@lodestar/config/configs";
-import {ATTESTATION_SUBNET_COUNT, ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ATTESTATION_SUBNET_COUNT, ForkName, GENESIS_EPOCH, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {describe, expect, it} from "vitest";
 import {ZERO_HASH} from "../../../../src/constants/index.js";
 import {computeGossipPeerScoreParams, gossipScoreThresholds} from "../../../../src/network/gossip/scoringParameters.js";
@@ -16,7 +16,7 @@ describe("computeGossipPeerScoreParams", () => {
   const config = createBeaconConfig(mainnetChainConfig, ZERO_HASH);
   // Cheap stub on new BeaconConfig instance
   config.forkBoundary2ForkDigest = () => Buffer.alloc(4, 1);
-  config.forkDigest2ForkBoundary = () => ({fork: ForkName.phase0, epoch: 0});
+  config.forkDigest2ForkBoundary = () => ({fork: ForkName.phase0, epoch: GENESIS_EPOCH});
 
   const TOLERANCE = 0.00005;
 
@@ -69,7 +69,7 @@ describe("computeGossipPeerScoreParams", () => {
   function validateVoluntaryExitTopicParams(topics: Record<string, TopicScoreParams>): void {
     const topicString = stringifyGossipTopic(config, {
       type: GossipType.voluntary_exit,
-      boundary: {fork: ForkName.phase0, epoch: 0},
+      boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
     });
     const params = topics[topicString];
     assertMessageRatePenaltiesDisabled(params);
@@ -87,11 +87,11 @@ describe("computeGossipPeerScoreParams", () => {
   function validateSlashingTopicParams(topics: Record<string, TopicScoreParams>): void {
     const attesterSlashingTopicString = stringifyGossipTopic(config, {
       type: GossipType.attester_slashing,
-      boundary: {fork: ForkName.phase0, epoch: 0},
+      boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
     });
     const proposerSlashingTopicString = stringifyGossipTopic(config, {
       type: GossipType.proposer_slashing,
-      boundary: {fork: ForkName.phase0, epoch: 0},
+      boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
     });
     validateSlashingTopicScoreParams(topics[attesterSlashingTopicString]);
     validateSlashingTopicScoreParams(topics[proposerSlashingTopicString]);
@@ -113,7 +113,7 @@ describe("computeGossipPeerScoreParams", () => {
   function validateAggregateTopicParams(topics: Record<string, TopicScoreParams>, penaltiesActive: boolean): void {
     const topicString = stringifyGossipTopic(config, {
       type: GossipType.beacon_aggregate_and_proof,
-      boundary: {fork: ForkName.phase0, epoch: 0},
+      boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
     });
     const params = topics[topicString];
 
@@ -147,7 +147,7 @@ describe("computeGossipPeerScoreParams", () => {
   function validateBlockTopicParams(topics: Record<string, TopicScoreParams>, penaltiesActive: boolean): void {
     const topicString = stringifyGossipTopic(config, {
       type: GossipType.beacon_block,
-      boundary: {fork: ForkName.phase0, epoch: 0},
+      boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
     });
     const params = topics[topicString];
 
@@ -185,7 +185,7 @@ describe("computeGossipPeerScoreParams", () => {
     for (let i = 0; i < ATTESTATION_SUBNET_COUNT; i++) {
       const topicString = stringifyGossipTopic(config, {
         type: GossipType.beacon_attestation,
-        boundary: {fork: ForkName.phase0, epoch: 0},
+        boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
         subnet: i,
       });
       validateAllAttestationSubnetTopicScoreParams(topics[topicString], penaltiesActive);

--- a/packages/beacon-node/test/unit/network/gossip/topic.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/topic.test.ts
@@ -1,4 +1,4 @@
-import {ForkName} from "@lodestar/params";
+import {ForkName, GENESIS_EPOCH} from "@lodestar/params";
 import {describe, expect, it} from "vitest";
 import {GossipEncoding, GossipTopicMap, GossipType} from "../../../../src/network/gossip/index.js";
 import {parseGossipTopic, stringifyGossipTopic} from "../../../../src/network/gossip/topic.js";
@@ -11,7 +11,7 @@ describe("network / gossip / topic", () => {
   const testCases: {[K in GossipType]: {topic: GossipTopicMap[K]; topicStr: string}[]} = {
     [GossipType.beacon_block]: [
       {
-        topic: {type: GossipType.beacon_block, boundary: {fork: ForkName.phase0, epoch: 0}, encoding},
+        topic: {type: GossipType.beacon_block, boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH}, encoding},
         topicStr: "/eth2/f5a5fd42/beacon_block/ssz_snappy",
       },
     ],
@@ -30,7 +30,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.beacon_aggregate_and_proof,
-          boundary: {fork: ForkName.phase0, epoch: 0},
+          boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
           encoding,
         },
         topicStr: "/eth2/f5a5fd42/beacon_aggregate_and_proof/ssz_snappy",
@@ -40,7 +40,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.beacon_attestation,
-          boundary: {fork: ForkName.phase0, epoch: 0},
+          boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
           subnet: 5,
           encoding,
         },
@@ -49,7 +49,7 @@ describe("network / gossip / topic", () => {
     ],
     [GossipType.voluntary_exit]: [
       {
-        topic: {type: GossipType.voluntary_exit, boundary: {fork: ForkName.phase0, epoch: 0}, encoding},
+        topic: {type: GossipType.voluntary_exit, boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH}, encoding},
         topicStr: "/eth2/f5a5fd42/voluntary_exit/ssz_snappy",
       },
     ],
@@ -67,7 +67,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.proposer_slashing,
-          boundary: {fork: ForkName.phase0, epoch: 0},
+          boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
           encoding,
         },
         topicStr: "/eth2/f5a5fd42/proposer_slashing/ssz_snappy",
@@ -77,7 +77,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.attester_slashing,
-          boundary: {fork: ForkName.phase0, epoch: 0},
+          boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
           encoding,
         },
         topicStr: "/eth2/f5a5fd42/attester_slashing/ssz_snappy",

--- a/packages/beacon-node/test/unit/network/gossip/topic.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/topic.test.ts
@@ -11,7 +11,7 @@ describe("network / gossip / topic", () => {
   const testCases: {[K in GossipType]: {topic: GossipTopicMap[K]; topicStr: string}[]} = {
     [GossipType.beacon_block]: [
       {
-        topic: {type: GossipType.beacon_block, boundary: {fork: ForkName.phase0}, encoding},
+        topic: {type: GossipType.beacon_block, boundary: {fork: ForkName.phase0, epoch: 0}, encoding},
         topicStr: "/eth2/f5a5fd42/beacon_block/ssz_snappy",
       },
     ],
@@ -20,7 +20,7 @@ describe("network / gossip / topic", () => {
         topic: {
           type: GossipType.blob_sidecar,
           subnet: 1,
-          boundary: {fork: ForkName.deneb},
+          boundary: {fork: ForkName.deneb, epoch: config.DENEB_FORK_EPOCH},
           encoding,
         },
         topicStr: "/eth2/d6e497b8/blob_sidecar_1/ssz_snappy",
@@ -30,7 +30,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.beacon_aggregate_and_proof,
-          boundary: {fork: ForkName.phase0},
+          boundary: {fork: ForkName.phase0, epoch: 0},
           encoding,
         },
         topicStr: "/eth2/f5a5fd42/beacon_aggregate_and_proof/ssz_snappy",
@@ -40,7 +40,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.beacon_attestation,
-          boundary: {fork: ForkName.phase0},
+          boundary: {fork: ForkName.phase0, epoch: 0},
           subnet: 5,
           encoding,
         },
@@ -49,7 +49,7 @@ describe("network / gossip / topic", () => {
     ],
     [GossipType.voluntary_exit]: [
       {
-        topic: {type: GossipType.voluntary_exit, boundary: {fork: ForkName.phase0}, encoding},
+        topic: {type: GossipType.voluntary_exit, boundary: {fork: ForkName.phase0, epoch: 0}, encoding},
         topicStr: "/eth2/f5a5fd42/voluntary_exit/ssz_snappy",
       },
     ],
@@ -57,7 +57,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.bls_to_execution_change,
-          boundary: {fork: ForkName.capella},
+          boundary: {fork: ForkName.capella, epoch: config.CAPELLA_FORK_EPOCH},
           encoding,
         },
         topicStr: "/eth2/e7b4bb67/bls_to_execution_change/ssz_snappy",
@@ -67,7 +67,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.proposer_slashing,
-          boundary: {fork: ForkName.phase0},
+          boundary: {fork: ForkName.phase0, epoch: 0},
           encoding,
         },
         topicStr: "/eth2/f5a5fd42/proposer_slashing/ssz_snappy",
@@ -77,7 +77,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.attester_slashing,
-          boundary: {fork: ForkName.phase0},
+          boundary: {fork: ForkName.phase0, epoch: 0},
           encoding,
         },
         topicStr: "/eth2/f5a5fd42/attester_slashing/ssz_snappy",
@@ -87,7 +87,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.sync_committee_contribution_and_proof,
-          boundary: {fork: ForkName.altair},
+          boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH},
           encoding,
         },
         topicStr: "/eth2/16abab34/sync_committee_contribution_and_proof/ssz_snappy",
@@ -97,7 +97,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.sync_committee,
-          boundary: {fork: ForkName.altair},
+          boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH},
           subnet: 5,
           encoding,
         },
@@ -108,7 +108,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.light_client_finality_update,
-          boundary: {fork: ForkName.altair},
+          boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH},
           encoding,
         },
         topicStr: "/eth2/16abab34/light_client_finality_update/ssz_snappy",
@@ -118,7 +118,7 @@ describe("network / gossip / topic", () => {
       {
         topic: {
           type: GossipType.light_client_optimistic_update,
-          boundary: {fork: ForkName.altair},
+          boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH},
           encoding,
         },
         topicStr: "/eth2/16abab34/light_client_optimistic_update/ssz_snappy",

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -82,7 +82,7 @@ describe("AttnetsService", () => {
     const secondSubnet = (gossipStub.subscribeTopic.mock.calls[1][0] as unknown as {subnet: SubnetID}).subnet;
     expect(gossipStub.subscribeTopic).toBeCalledTimes(SUBNETS_PER_NODE);
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH * (ALTAIR_FORK_EPOCH - 2) * 1000);
-    service.subscribeSubnetsAfterBoundary({fork: ForkName.altair});
+    service.subscribeSubnetsAfterBoundary({fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH});
     // SUBNETS_PER_NODE = 2 => 2 more calls
     // same subnets were called
     expect(gossipStub.subscribeTopic).toHaveBeenCalledWith(
@@ -94,7 +94,7 @@ describe("AttnetsService", () => {
     expect(gossipStub.subscribeTopic).toBeCalledTimes(2 * SUBNETS_PER_NODE);
     // 2 epochs after the fork
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * 4 * 1000);
-    service.unsubscribeSubnetsBeforeBoundary({fork: ForkName.phase0});
+    service.unsubscribeSubnetsBeforeBoundary({fork: ForkName.phase0, epoch: 0});
     expect(gossipStub.unsubscribeTopic).toHaveBeenCalledWith(
       expect.objectContaining({boundary: {fork: ForkName.phase0}, subnet: firstSubnet})
     );

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -3,6 +3,7 @@ import {
   ATTESTATION_SUBNET_COUNT,
   EPOCHS_PER_SUBNET_SUBSCRIPTION,
   ForkName,
+  GENESIS_EPOCH,
   SLOTS_PER_EPOCH,
   SUBNETS_PER_NODE,
 } from "@lodestar/params";
@@ -76,7 +77,7 @@ describe("AttnetsService", () => {
 
   it("should subscribe to new fork 2 epochs before ALTAIR_FORK_EPOCH", () => {
     expect(gossipStub.subscribeTopic).toBeCalledWith(
-      expect.objectContaining({boundary: {fork: ForkName.phase0, epoch: 0}})
+      expect.objectContaining({boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH}})
     );
     expect(gossipStub.subscribeTopic).not.toBeCalledWith({
       boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH},
@@ -101,12 +102,12 @@ describe("AttnetsService", () => {
     expect(gossipStub.subscribeTopic).toBeCalledTimes(2 * SUBNETS_PER_NODE);
     // 2 epochs after the fork
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * 4 * 1000);
-    service.unsubscribeSubnetsPrevBoundary({fork: ForkName.phase0, epoch: 0});
+    service.unsubscribeSubnetsPrevBoundary({fork: ForkName.phase0, epoch: GENESIS_EPOCH});
     expect(gossipStub.unsubscribeTopic).toHaveBeenCalledWith(
-      expect.objectContaining({boundary: {fork: ForkName.phase0, epoch: 0}, subnet: firstSubnet})
+      expect.objectContaining({boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH}, subnet: firstSubnet})
     );
     expect(gossipStub.unsubscribeTopic).toHaveBeenCalledWith(
-      expect.objectContaining({boundary: {fork: ForkName.phase0, epoch: 0}, subnet: secondSubnet})
+      expect.objectContaining({boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH}, subnet: secondSubnet})
     );
     expect(gossipStub.unsubscribeTopic).toBeCalledTimes(ATTESTATION_SUBNET_COUNT);
   });

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -75,8 +75,12 @@ describe("AttnetsService", () => {
   });
 
   it("should subscribe to new fork 2 epochs before ALTAIR_FORK_EPOCH", () => {
-    expect(gossipStub.subscribeTopic).toBeCalledWith(expect.objectContaining({boundary: {fork: ForkName.phase0}}));
-    expect(gossipStub.subscribeTopic).not.toBeCalledWith({boundary: {fork: ForkName.altair}});
+    expect(gossipStub.subscribeTopic).toBeCalledWith(
+      expect.objectContaining({boundary: {fork: ForkName.phase0, epoch: 0}})
+    );
+    expect(gossipStub.subscribeTopic).not.toBeCalledWith({
+      boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH},
+    });
     expect(gossipStub.subscribeTopic).toBeCalledTimes(2);
     const firstSubnet = (gossipStub.subscribeTopic.mock.calls[0][0] as unknown as {subnet: SubnetID}).subnet;
     const secondSubnet = (gossipStub.subscribeTopic.mock.calls[1][0] as unknown as {subnet: SubnetID}).subnet;
@@ -86,20 +90,23 @@ describe("AttnetsService", () => {
     // SUBNETS_PER_NODE = 2 => 2 more calls
     // same subnets were called
     expect(gossipStub.subscribeTopic).toHaveBeenCalledWith(
-      expect.objectContaining({boundary: {fork: ForkName.altair}, subnet: firstSubnet})
+      expect.objectContaining({boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH}, subnet: firstSubnet})
     );
     expect(gossipStub.subscribeTopic).toHaveBeenCalledWith(
-      expect.objectContaining({boundary: {fork: ForkName.altair}, subnet: secondSubnet})
+      expect.objectContaining({
+        boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH},
+        subnet: secondSubnet,
+      })
     );
     expect(gossipStub.subscribeTopic).toBeCalledTimes(2 * SUBNETS_PER_NODE);
     // 2 epochs after the fork
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * 4 * 1000);
     service.unsubscribeSubnetsBeforeBoundary({fork: ForkName.phase0, epoch: 0});
     expect(gossipStub.unsubscribeTopic).toHaveBeenCalledWith(
-      expect.objectContaining({boundary: {fork: ForkName.phase0}, subnet: firstSubnet})
+      expect.objectContaining({boundary: {fork: ForkName.phase0, epoch: 0}, subnet: firstSubnet})
     );
     expect(gossipStub.unsubscribeTopic).toHaveBeenCalledWith(
-      expect.objectContaining({boundary: {fork: ForkName.phase0}, subnet: secondSubnet})
+      expect.objectContaining({boundary: {fork: ForkName.phase0, epoch: 0}, subnet: secondSubnet})
     );
     expect(gossipStub.unsubscribeTopic).toBeCalledTimes(ATTESTATION_SUBNET_COUNT);
   });

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -86,7 +86,7 @@ describe("AttnetsService", () => {
     const secondSubnet = (gossipStub.subscribeTopic.mock.calls[1][0] as unknown as {subnet: SubnetID}).subnet;
     expect(gossipStub.subscribeTopic).toBeCalledTimes(SUBNETS_PER_NODE);
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH * (ALTAIR_FORK_EPOCH - 2) * 1000);
-    service.subscribeSubnetsAfterBoundary({fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH});
+    service.subscribeSubnetsBeforeBoundary({fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH});
     // SUBNETS_PER_NODE = 2 => 2 more calls
     // same subnets were called
     expect(gossipStub.subscribeTopic).toHaveBeenCalledWith(
@@ -101,7 +101,7 @@ describe("AttnetsService", () => {
     expect(gossipStub.subscribeTopic).toBeCalledTimes(2 * SUBNETS_PER_NODE);
     // 2 epochs after the fork
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * 4 * 1000);
-    service.unsubscribeSubnetsBeforeBoundary({fork: ForkName.phase0, epoch: 0});
+    service.unsubscribeSubnetsFromPrevBoundary({fork: ForkName.phase0, epoch: 0});
     expect(gossipStub.unsubscribeTopic).toHaveBeenCalledWith(
       expect.objectContaining({boundary: {fork: ForkName.phase0, epoch: 0}, subnet: firstSubnet})
     );

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -86,7 +86,7 @@ describe("AttnetsService", () => {
     const secondSubnet = (gossipStub.subscribeTopic.mock.calls[1][0] as unknown as {subnet: SubnetID}).subnet;
     expect(gossipStub.subscribeTopic).toBeCalledTimes(SUBNETS_PER_NODE);
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH * (ALTAIR_FORK_EPOCH - 2) * 1000);
-    service.subscribeSubnetsBeforeBoundary({fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH});
+    service.subscribeSubnetsForNextBoundary({fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH});
     // SUBNETS_PER_NODE = 2 => 2 more calls
     // same subnets were called
     expect(gossipStub.subscribeTopic).toHaveBeenCalledWith(

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -86,7 +86,7 @@ describe("AttnetsService", () => {
     const secondSubnet = (gossipStub.subscribeTopic.mock.calls[1][0] as unknown as {subnet: SubnetID}).subnet;
     expect(gossipStub.subscribeTopic).toBeCalledTimes(SUBNETS_PER_NODE);
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH * (ALTAIR_FORK_EPOCH - 2) * 1000);
-    service.subscribeSubnetsForNextBoundary({fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH});
+    service.subscribeSubnetsNextBoundary({fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH});
     // SUBNETS_PER_NODE = 2 => 2 more calls
     // same subnets were called
     expect(gossipStub.subscribeTopic).toHaveBeenCalledWith(
@@ -101,7 +101,7 @@ describe("AttnetsService", () => {
     expect(gossipStub.subscribeTopic).toBeCalledTimes(2 * SUBNETS_PER_NODE);
     // 2 epochs after the fork
     vi.advanceTimersByTime(config.SECONDS_PER_SLOT * 4 * 1000);
-    service.unsubscribeSubnetsFromPrevBoundary({fork: ForkName.phase0, epoch: 0});
+    service.unsubscribeSubnetsPrevBoundary({fork: ForkName.phase0, epoch: 0});
     expect(gossipStub.unsubscribeTopic).toHaveBeenCalledWith(
       expect.objectContaining({boundary: {fork: ForkName.phase0, epoch: 0}, subnet: firstSubnet})
     );

--- a/packages/beacon-node/test/unit/network/util.test.ts
+++ b/packages/beacon-node/test/unit/network/util.test.ts
@@ -1,35 +1,35 @@
 import {config} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
 import {afterEach, describe, expect, it} from "vitest";
-import {getCurrentAndNextFork} from "../../../src/network/forks.js";
+import {getCurrentAndNextForkBoundary} from "../../../src/network/forks.js";
 import {getDiscv5Multiaddrs} from "../../../src/network/libp2p/index.js";
 
-describe("getCurrentAndNextFork", () => {
-  const altairEpoch = config.forks.altair.epoch;
+describe("getCurrentAndNextForkBoundary", () => {
+  const altairEpoch = config.forkBoundariesAscendingEpochOrder[1].epoch;
   afterEach(() => {
-    config.forks.altair.epoch = altairEpoch;
+    config.forkBoundariesAscendingEpochOrder[1].epoch = altairEpoch;
   });
 
-  it("should return no next fork if altair epoch is infinity", () => {
-    config.forks.altair.epoch = Infinity;
-    const {currentFork, nextFork} = getCurrentAndNextFork(config, 0);
-    expect(currentFork.name).toBe(ForkName.phase0);
-    expect(nextFork).toBeUndefined();
+  it("should return no next fork boundary if altair epoch is infinity", () => {
+    config.forkBoundariesAscendingEpochOrder[1].epoch = Infinity;
+    const {currentBoundary, nextBoundary} = getCurrentAndNextForkBoundary(config, 0);
+    expect(currentBoundary.fork).toBe(ForkName.phase0);
+    expect(nextBoundary).toBeUndefined();
   });
 
-  it("should return altair as next fork and then bellatrix", () => {
-    config.forks.altair.epoch = 1000;
-    let forks = getCurrentAndNextFork(config, 0);
-    expect(forks.currentFork.name).toBe(ForkName.phase0);
-    if (forks.nextFork) {
-      expect(forks.nextFork.name).toBe(ForkName.altair);
+  it("should return altair as next fork boundary and then bellatrix", () => {
+    config.forkBoundariesAscendingEpochOrder[1].epoch = 1000;
+    let boundaries = getCurrentAndNextForkBoundary(config, 0);
+    expect(boundaries.currentBoundary.fork).toBe(ForkName.phase0);
+    if (boundaries.nextBoundary) {
+      expect(boundaries.nextBoundary.fork).toBe(ForkName.altair);
     } else {
       expect.fail("No next fork");
     }
 
-    forks = getCurrentAndNextFork(config, 1000);
-    expect(forks.currentFork.name).toBe(ForkName.altair);
-    expect(forks.nextFork?.name).toBe(ForkName.bellatrix);
+    boundaries = getCurrentAndNextForkBoundary(config, 1000);
+    expect(boundaries.currentBoundary.fork).toBe(ForkName.altair);
+    expect(boundaries.nextBoundary?.fork).toBe(ForkName.bellatrix);
   });
 });
 

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -125,7 +125,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       for (const boundary of forkBoundariesDescendingEpochOrder) {
         if (epoch >= boundary.epoch) return boundary;
       }
-      return {fork: phase0.name, epoch: GENESIS_EPOCH};
+      throw Error("Unreachable as phase0 is scheduled at epoch 0");
     },
     getForkName(slot: Slot): ForkName {
       return this.getForkInfo(slot).name;

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -13,8 +13,8 @@ import {
   isForkPostElectra,
 } from "@lodestar/params";
 import {Epoch, SSZTypesFor, Slot, Version, sszTypesFor} from "@lodestar/types";
-import {ChainConfig} from "../chainConfig/index.js";
-import {ForkConfig, ForkInfo} from "./types.js";
+import {BlobScheduleEntry, ChainConfig} from "../chainConfig/index.js";
+import {ForkBoundary, ForkConfig, ForkInfo} from "./types.js";
 
 export * from "./types.js";
 
@@ -85,10 +85,27 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
   const forksAscendingEpochOrder = Object.values(forks);
   const forksDescendingEpochOrder = Object.values(forks).reverse();
 
+  const blobScheduleDescendingEpochOrder = [...config.BLOB_SCHEDULE].sort((a, b) => b.EPOCH - a.EPOCH);
+
+  const forkBoundariesAscendingEpochOrder: ForkBoundary[] = [
+    ...forksAscendingEpochOrder.map((fork) => ({
+      fork: fork.name,
+      epoch: fork.epoch,
+    })),
+    ...config.BLOB_SCHEDULE.map((entry) => ({
+      fork: forksDescendingEpochOrder.find((f) => entry.EPOCH >= f.epoch)?.name ?? phase0.name,
+      epoch: entry.EPOCH,
+    })),
+  ].sort((a, b) => a.epoch - b.epoch);
+
+  const forkBoundariesDescendingEpochOrder = [...forkBoundariesAscendingEpochOrder].reverse();
+
   return {
     forks,
     forksAscendingEpochOrder,
     forksDescendingEpochOrder,
+    forkBoundariesAscendingEpochOrder,
+    forkBoundariesDescendingEpochOrder,
 
     // Fork convenience methods
     getForkInfo(slot: Slot): ForkInfo {
@@ -101,6 +118,13 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
         if (epoch >= fork.epoch) return fork;
       }
       return phase0;
+    },
+    getForkBoundaryAtEpoch(epoch: Epoch): ForkBoundary {
+      // NOTE: boundaries must be sorted by descending epoch, latest boundary first
+      for (const boundary of forkBoundariesDescendingEpochOrder) {
+        if (epoch >= boundary.epoch) return boundary;
+      }
+      return {fork: phase0.name, epoch: 0};
     },
     getForkName(slot: Slot): ForkName {
       return this.getForkInfo(slot).name;
@@ -148,16 +172,21 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
           return config.MAX_BLOBS_PER_BLOCK;
       }
 
-      // Sort by epoch in descending order to find the latest applicable value
-      const blobSchedule = [...config.BLOB_SCHEDULE].sort((a, b) => b.EPOCH - a.EPOCH);
+      return this.getBlobParameters(epoch).MAX_BLOBS_PER_BLOCK;
+    },
+    getBlobParameters(epoch: Epoch): BlobScheduleEntry {
+      if (epoch < config.FULU_FORK_EPOCH) {
+        throw Error(`getBlobParameters is not available pre-fulu epoch=${epoch}`);
+      }
 
-      for (const entry of blobSchedule) {
+      // Find the latest applicable value from blob schedule
+      for (const entry of blobScheduleDescendingEpochOrder) {
         if (epoch >= entry.EPOCH) {
-          return entry.MAX_BLOBS_PER_BLOCK;
+          return entry;
         }
       }
 
-      return config.MAX_BLOBS_PER_BLOCK_ELECTRA;
+      return {EPOCH: config.ELECTRA_FORK_EPOCH, MAX_BLOBS_PER_BLOCK: config.MAX_BLOBS_PER_BLOCK_ELECTRA};
     },
     getMaxRequestBlobSidecars(fork: ForkName): number {
       return isForkPostElectra(fork) ? config.MAX_REQUEST_BLOB_SIDECARS_ELECTRA : config.MAX_REQUEST_BLOB_SIDECARS;

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -164,7 +164,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       return sszTypesFor(forkName);
     },
     getMaxBlobsPerBlock(epoch: Epoch): number {
-      const {fork} = this.getForkBoundaryAtEpoch(epoch);
+      const fork = this.getForkInfoAtEpoch(epoch).name;
 
       switch (fork) {
         case ForkName.electra:

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -96,7 +96,10 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       fork: forksDescendingEpochOrder.find((f) => entry.EPOCH >= f.epoch)?.name ?? phase0.name,
       epoch: entry.EPOCH,
     })),
-  ].sort((a, b) => a.epoch - b.epoch);
+  ]
+    // Remove unscheduled fork boundaries
+    .filter(({epoch}) => epoch !== Infinity)
+    .sort((a, b) => a.epoch - b.epoch);
 
   const forkBoundariesDescendingEpochOrder = [...forkBoundariesAscendingEpochOrder].reverse();
 

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -88,10 +88,12 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
   const blobScheduleDescendingEpochOrder = [...config.BLOB_SCHEDULE].sort((a, b) => b.EPOCH - a.EPOCH);
 
   const forkBoundariesAscendingEpochOrder: ForkBoundary[] = [
+    // Normal hard-forks (phase0, altair, etc.)
     ...forksAscendingEpochOrder.map((fork) => ({
       fork: fork.name,
       epoch: fork.epoch,
     })),
+    // Blob Parameter Only (BPO) forks
     ...config.BLOB_SCHEDULE.map((entry) => ({
       fork: forksDescendingEpochOrder.find((f) => entry.EPOCH >= f.epoch)?.name ?? phase0.name,
       epoch: entry.EPOCH,

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -122,6 +122,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       return forks[this.getForkBoundaryAtEpoch(epoch).fork];
     },
     getForkBoundaryAtEpoch(epoch: Epoch): ForkBoundary {
+      if (epoch < 0) epoch = 0;
       // NOTE: fork boundaries must be sorted by descending epoch, latest first
       for (const boundary of forkBoundariesDescendingEpochOrder) {
         if (epoch >= boundary.epoch) return boundary;

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -119,12 +119,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       return this.getForkInfoAtEpoch(epoch);
     },
     getForkInfoAtEpoch(epoch: Epoch): ForkInfo {
-      if (epoch < 0) epoch = 0;
-      // NOTE: forks must be sorted by descending epoch, latest fork first
-      for (const fork of forksDescendingEpochOrder) {
-        if (epoch >= fork.epoch) return fork;
-      }
-      return phase0;
+      return forks[this.getForkBoundaryAtEpoch(epoch).fork];
     },
     getForkBoundaryAtEpoch(epoch: Epoch): ForkBoundary {
       if (epoch < 0) epoch = 0;

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -94,6 +94,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       epoch: fork.epoch,
     })),
     // Blob Parameter Only (BPO) forks
+    // Note: Must be appended after normal hard-forks to have precedence if scheduled at the same epoch
     ...config.BLOB_SCHEDULE.map((entry) => ({
       fork: forksDescendingEpochOrder.find((f) => entry.EPOCH >= f.epoch)?.name ?? phase0.name,
       epoch: entry.EPOCH,

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -122,7 +122,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       return forks[this.getForkBoundaryAtEpoch(epoch).fork];
     },
     getForkBoundaryAtEpoch(epoch: Epoch): ForkBoundary {
-      // NOTE: fork boundaries must be sorted by descending epoch, latest boundary first
+      // NOTE: fork boundaries must be sorted by descending epoch, latest first
       for (const boundary of forkBoundariesDescendingEpochOrder) {
         if (epoch >= boundary.epoch) return boundary;
       }

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -13,8 +13,8 @@ import {
   isForkPostElectra,
 } from "@lodestar/params";
 import {Epoch, SSZTypesFor, Slot, Version, sszTypesFor} from "@lodestar/types";
-import {BlobScheduleEntry, ChainConfig} from "../chainConfig/index.js";
-import {ForkBoundary, ForkConfig, ForkInfo} from "./types.js";
+import {ChainConfig} from "../chainConfig/index.js";
+import {BlobParameters, ForkBoundary, ForkConfig, ForkInfo} from "./types.js";
 
 export * from "./types.js";
 
@@ -176,9 +176,9 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
           return config.MAX_BLOBS_PER_BLOCK;
       }
 
-      return this.getBlobParameters(epoch).MAX_BLOBS_PER_BLOCK;
+      return this.getBlobParameters(epoch).maxBlobsPerBlock;
     },
-    getBlobParameters(epoch: Epoch): BlobScheduleEntry {
+    getBlobParameters(epoch: Epoch): BlobParameters {
       if (epoch < config.FULU_FORK_EPOCH) {
         throw Error(`getBlobParameters is not available pre-fulu epoch=${epoch}`);
       }
@@ -186,11 +186,11 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       // Find the latest applicable value from blob schedule
       for (const entry of blobScheduleDescendingEpochOrder) {
         if (epoch >= entry.EPOCH) {
-          return entry;
+          return {epoch: entry.EPOCH, maxBlobsPerBlock: entry.MAX_BLOBS_PER_BLOCK};
         }
       }
 
-      return {EPOCH: config.ELECTRA_FORK_EPOCH, MAX_BLOBS_PER_BLOCK: config.MAX_BLOBS_PER_BLOCK_ELECTRA};
+      return {epoch: config.ELECTRA_FORK_EPOCH, maxBlobsPerBlock: config.MAX_BLOBS_PER_BLOCK_ELECTRA};
     },
     getMaxRequestBlobSidecars(fork: ForkName): number {
       return isForkPostElectra(fork) ? config.MAX_REQUEST_BLOB_SIDECARS_ELECTRA : config.MAX_REQUEST_BLOB_SIDECARS;

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -99,6 +99,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
   ]
     // Remove unscheduled fork boundaries
     .filter(({epoch}) => epoch !== Infinity)
+    // Sort by epoch in ascending order
     .sort((a, b) => a.epoch - b.epoch);
 
   const forkBoundariesDescendingEpochOrder = [...forkBoundariesAscendingEpochOrder].reverse();
@@ -123,7 +124,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       return phase0;
     },
     getForkBoundaryAtEpoch(epoch: Epoch): ForkBoundary {
-      // NOTE: boundaries must be sorted by descending epoch, latest boundary first
+      // NOTE: fork boundaries must be sorted by descending epoch, latest boundary first
       for (const boundary of forkBoundariesDescendingEpochOrder) {
         if (epoch >= boundary.epoch) return boundary;
       }

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -117,11 +117,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       return this.getForkInfoAtEpoch(epoch);
     },
     getForkInfoAtEpoch(epoch: Epoch): ForkInfo {
-      // NOTE: forks must be sorted by descending epoch, latest fork first
-      for (const fork of forksDescendingEpochOrder) {
-        if (epoch >= fork.epoch) return fork;
-      }
-      return phase0;
+      return forks[this.getForkBoundaryAtEpoch(epoch).fork];
     },
     getForkBoundaryAtEpoch(epoch: Epoch): ForkBoundary {
       // NOTE: fork boundaries must be sorted by descending epoch, latest boundary first

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -99,8 +99,6 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       epoch: entry.EPOCH,
     })),
   ]
-    // Remove unscheduled fork boundaries
-    .filter(({epoch}) => epoch !== Infinity)
     // Sort by epoch in ascending order
     .sort((a, b) => a.epoch - b.epoch);
 

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -167,7 +167,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       return sszTypesFor(forkName);
     },
     getMaxBlobsPerBlock(epoch: Epoch): number {
-      const fork = this.getForkInfoAtEpoch(epoch).name;
+      const {fork} = this.getForkBoundaryAtEpoch(epoch);
 
       switch (fork) {
         case ForkName.electra:

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -119,7 +119,12 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       return this.getForkInfoAtEpoch(epoch);
     },
     getForkInfoAtEpoch(epoch: Epoch): ForkInfo {
-      return forks[this.getForkBoundaryAtEpoch(epoch).fork];
+      if (epoch < 0) epoch = 0;
+      // NOTE: forks must be sorted by descending epoch, latest fork first
+      for (const fork of forksDescendingEpochOrder) {
+        if (epoch >= fork.epoch) return fork;
+      }
+      return phase0;
     },
     getForkBoundaryAtEpoch(epoch: Epoch): ForkBoundary {
       if (epoch < 0) epoch = 0;

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -124,7 +124,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       for (const boundary of forkBoundariesDescendingEpochOrder) {
         if (epoch >= boundary.epoch) return boundary;
       }
-      return {fork: phase0.name, epoch: 0};
+      return {fork: phase0.name, epoch: GENESIS_EPOCH};
     },
     getForkName(slot: Slot): ForkName {
       return this.getForkInfo(slot).name;

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -100,6 +100,8 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       epoch: entry.EPOCH,
     })),
   ]
+    // Remove unscheduled fork boundaries
+    .filter(({epoch}) => epoch !== Infinity)
     // Sort by epoch in ascending order
     .sort((a, b) => a.epoch - b.epoch);
 

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -1,5 +1,6 @@
 import {ForkAll, ForkName, ForkPostAltair, ForkPostBellatrix, ForkPostDeneb, ForkSeq} from "@lodestar/params";
 import {Epoch, SSZTypesFor, Slot, Version} from "@lodestar/types";
+import {BlobScheduleEntry} from "../chainConfig/types.js";
 
 export type ForkInfo = {
   name: ForkName;
@@ -10,6 +11,9 @@ export type ForkInfo = {
   prevForkName: ForkName;
 };
 
+/** TODO: */
+export type ForkBoundary = {fork: ForkName; epoch: Epoch};
+
 /**
  * Fork schedule and helper methods
  */
@@ -18,11 +22,15 @@ export type ForkConfig = {
   forks: {[K in ForkName]: ForkInfo};
   forksAscendingEpochOrder: ForkInfo[];
   forksDescendingEpochOrder: ForkInfo[];
+  forkBoundariesAscendingEpochOrder: ForkBoundary[];
+  forkBoundariesDescendingEpochOrder: ForkBoundary[];
 
   /** Get the hard-fork info for the active fork at `slot` */
   getForkInfo(slot: Slot): ForkInfo;
   /** Get the hard-fork info for the active fork at `epoch` */
   getForkInfoAtEpoch(epoch: Epoch): ForkInfo;
+  /** Get the active fork boundary at a given `epoch` */
+  getForkBoundaryAtEpoch(epoch: Epoch): ForkBoundary;
   /** Get the hard-fork name at a given slot */
   getForkName(slot: Slot): ForkName;
   /** Get the hard-fork sequence number at a given slot */
@@ -41,6 +49,8 @@ export type ForkConfig = {
   getPostDenebForkTypes(slot: Slot): SSZTypesFor<ForkPostDeneb>;
   /** Get max blobs per block at a given epoch */
   getMaxBlobsPerBlock(epoch: Epoch): number;
+  /** Get blob schedule entry at a given epoch */
+  getBlobParameters(epoch: Epoch): BlobScheduleEntry;
   /** Get max request blob sidecars by hard-fork */
   getMaxRequestBlobSidecars(fork: ForkName): number;
 };

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -1,6 +1,5 @@
 import {ForkAll, ForkName, ForkPostAltair, ForkPostBellatrix, ForkPostDeneb, ForkSeq} from "@lodestar/params";
-import {Epoch, SSZTypesFor, Slot, Version} from "@lodestar/types";
-import {BlobScheduleEntry} from "../chainConfig/types.js";
+import {Epoch, SSZTypesFor, Slot, UintNum64, Version} from "@lodestar/types";
 
 export type ForkInfo = {
   name: ForkName;
@@ -13,6 +12,8 @@ export type ForkInfo = {
 
 /** TODO: */
 export type ForkBoundary = {fork: ForkName; epoch: Epoch};
+
+export type BlobParameters = {epoch: Epoch; maxBlobsPerBlock: UintNum64};
 
 /**
  * Fork schedule and helper methods
@@ -49,8 +50,8 @@ export type ForkConfig = {
   getPostDenebForkTypes(slot: Slot): SSZTypesFor<ForkPostDeneb>;
   /** Get max blobs per block at a given epoch */
   getMaxBlobsPerBlock(epoch: Epoch): number;
-  /** Get blob schedule entry at a given epoch */
-  getBlobParameters(epoch: Epoch): BlobScheduleEntry;
+  /** Get blob parameters at a given epoch */
+  getBlobParameters(epoch: Epoch): BlobParameters;
   /** Get max request blob sidecars by hard-fork */
   getMaxRequestBlobSidecars(fork: ForkName): number;
 };

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -10,7 +10,11 @@ export type ForkInfo = {
   prevForkName: ForkName;
 };
 
-/** TODO: */
+/**
+ * Fork boundaries include both normal hard-forks (phase0, altair, etc.)
+ * and Blob Parameter Only (BPO) forks and are used to un-/subscribe to gossip topics
+ * and compute the fork digest.
+ */
 export type ForkBoundary = {fork: ForkName; epoch: Epoch};
 
 export type BlobParameters = {epoch: Epoch; maxBlobsPerBlock: UintNum64};

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -13,7 +13,7 @@ export type ForkInfo = {
 /**
  * Fork boundaries include both normal hard-forks (phase0, altair, etc.)
  * and Blob Parameter Only (BPO) forks and are used to un-/subscribe to gossip topics
- * and compute the fork digest.
+ * and compute the fork digest primarily for domain separation on the p2p layer.
  */
 export type ForkBoundary = {fork: ForkName; epoch: Epoch};
 

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -161,7 +161,7 @@ function toHexStringNoPrefix(hex: string | Uint8Array): string {
 }
 
 export function computeForkDigest(config: ChainForkConfig, genesisValidatorsRoot: Root, epoch: Epoch): ForkDigest {
-  const currentFork = config.forks[config.getForkBoundaryAtEpoch(epoch).fork];
+  const currentFork = config.getForkInfoAtEpoch(epoch);
   const baseDigest = computeForkDataRoot(currentFork.version, genesisValidatorsRoot);
 
   if (currentFork.seq < ForkSeq.fulu) {

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -24,7 +24,7 @@ export function createCachedGenesis(chainForkConfig: ChainForkConfig, genesisVal
     const currentEpoch = currentForkBoundary.epoch;
     const nextEpoch = nextForkBoundary !== undefined ? nextForkBoundary.epoch : Infinity;
 
-    // If multiple forks/blob schedules start at the same epoch, only consider the latest one
+    // Edge case: If multiple fork boundaries start at the same epoch, only consider the latest one
     if (currentEpoch === nextEpoch) {
       continue;
     }

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -123,20 +123,18 @@ export function createCachedGenesis(chainForkConfig: ChainForkConfig, genesisVal
       return chainForkConfig.getForkBoundaryAtEpoch(epoch);
     },
 
-    epoch2ForkDigest(epoch: Epoch): ForkDigest {
-      const boundary = chainForkConfig.getForkBoundaryAtEpoch(epoch);
+    forkBoundary2ForkDigest(boundary: ForkBoundary): ForkDigest {
       const forkDigest = forkDigestByEpoch.get(boundary.epoch);
       if (!forkDigest) {
-        throw Error(`No precomputed forkDigest for ${epoch}`);
+        throw Error(`No precomputed forkDigest for ${boundary.epoch}`);
       }
       return forkDigest;
     },
 
-    epoch2ForkDigestHex(epoch: Epoch): ForkDigestHex {
-      const boundary = chainForkConfig.getForkBoundaryAtEpoch(epoch);
+    forkBoundary2ForkDigestHex(boundary: ForkBoundary): ForkDigestHex {
       const forkDigestHex = forkDigestHexByEpoch.get(boundary.epoch);
       if (!forkDigestHex) {
-        throw Error(`No precomputed forkDigest for ${epoch}`);
+        throw Error(`No precomputed forkDigest for ${boundary.epoch}`);
       }
       return toHexStringNoPrefix(forkDigestHex);
     },

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -1,24 +1,45 @@
-import {DOMAIN_VOLUNTARY_EXIT, ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {DomainType, ForkDigest, Root, Slot, Version, phase0, ssz} from "@lodestar/types";
-import {strip0xPrefix, toHex} from "@lodestar/utils";
+import {digest} from "@chainsafe/as-sha256";
+import {DOMAIN_VOLUNTARY_EXIT, ForkName, ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {DomainType, Epoch, ForkDigest, Root, Slot, Version, phase0, ssz} from "@lodestar/types";
+import {intToBytes, strip0xPrefix, toHex} from "@lodestar/utils";
 import {ChainForkConfig} from "../beaconConfig.js";
+import {ForkBoundary} from "../forkConfig/types.js";
+import {xor} from "../utils/bytes.js";
 import {CachedGenesis, ForkDigestHex} from "./types.js";
 export type {ForkDigestContext} from "./types.js";
 
 export function createCachedGenesis(chainForkConfig: ChainForkConfig, genesisValidatorsRoot: Root): CachedGenesis {
   const domainCache = new Map<ForkName, Map<DomainType, Uint8Array>>();
 
-  const forkDigestByForkName = new Map<ForkName, ForkDigest>();
-  const forkDigestHexByForkName = new Map<ForkName, ForkDigestHex>();
+  const forkDigestByEpoch = new Map<Epoch, ForkDigest>();
+  const forkDigestHexByEpoch = new Map<Epoch, ForkDigestHex>();
   /** Map of ForkDigest in hex format without prefix: `0011aabb` */
-  const forkNameByForkDigest = new Map<ForkDigestHex, ForkName>();
+  const epochByForkDigest = new Map<ForkDigestHex, Epoch>();
 
-  for (const fork of Object.values(chainForkConfig.forks)) {
-    const forkDigest = computeForkDigest(fork.version, genesisValidatorsRoot);
+  const {forkBoundariesAscendingEpochOrder} = chainForkConfig;
+
+  for (let i = 0; i < forkBoundariesAscendingEpochOrder.length; i++) {
+    const currentForkBoundary = forkBoundariesAscendingEpochOrder[i];
+    const nextForkBoundary = forkBoundariesAscendingEpochOrder[i + 1];
+
+    const currentEpoch = currentForkBoundary.epoch;
+
+    // Skip unscheduled fork boundaries
+    if (currentEpoch === Infinity) continue;
+
+    const nextEpoch = nextForkBoundary !== undefined ? nextForkBoundary.epoch : Infinity;
+
+    // If multiple forks/blob schedules start at the same epoch, only consider the latest one
+    if (currentEpoch === nextEpoch) {
+      continue;
+    }
+
+    const forkDigest = computeForkDigest(chainForkConfig, genesisValidatorsRoot, currentEpoch);
     const forkDigestHex = toHexStringNoPrefix(forkDigest);
-    forkNameByForkDigest.set(forkDigestHex, fork.name);
-    forkDigestByForkName.set(fork.name, forkDigest);
-    forkDigestHexByForkName.set(fork.name, forkDigestHex);
+
+    epochByForkDigest.set(forkDigestHex, currentEpoch);
+    forkDigestByEpoch.set(currentEpoch, forkDigest);
+    forkDigestHexByEpoch.set(currentEpoch, forkDigestHex);
   }
 
   return {
@@ -86,36 +107,40 @@ export function createCachedGenesis(chainForkConfig: ChainForkConfig, genesisVal
       return domain;
     },
 
-    forkDigest2ForkName(forkDigest: ForkDigest | ForkDigestHex): ForkName {
+    forkDigest2ForkBoundary(forkDigest: ForkDigest | ForkDigestHex): ForkBoundary {
       const forkDigestHex = toHexStringNoPrefix(forkDigest);
-      const forkName = forkNameByForkDigest.get(forkDigestHex);
-      if (forkName == null) {
+      const epoch = epochByForkDigest.get(forkDigestHex);
+      if (epoch == null) {
         throw Error(`Unknown forkDigest ${forkDigestHex}`);
       }
-      return forkName;
+
+      return chainForkConfig.getForkBoundaryAtEpoch(epoch);
     },
 
-    forkDigest2ForkNameOption(forkDigest: ForkDigest | ForkDigestHex): ForkName | null {
+    forkDigest2ForkBoundaryOption(forkDigest: ForkDigest | ForkDigestHex): ForkBoundary | null {
       const forkDigestHex = toHexStringNoPrefix(forkDigest);
-      const forkName = forkNameByForkDigest.get(forkDigestHex);
-      if (forkName == null) {
+      const epoch = epochByForkDigest.get(forkDigestHex);
+      if (epoch == null) {
         return null;
       }
-      return forkName;
+
+      return chainForkConfig.getForkBoundaryAtEpoch(epoch);
     },
 
-    forkName2ForkDigest(forkName: ForkName): ForkDigest {
-      const forkDigest = forkDigestByForkName.get(forkName);
+    epoch2ForkDigest(epoch: Epoch): ForkDigest {
+      const boundary = chainForkConfig.getForkBoundaryAtEpoch(epoch);
+      const forkDigest = forkDigestByEpoch.get(boundary.epoch);
       if (!forkDigest) {
-        throw Error(`No precomputed forkDigest for ${forkName}`);
+        throw Error(`No precomputed forkDigest for ${epoch}`);
       }
       return forkDigest;
     },
 
-    forkName2ForkDigestHex(forkName: ForkName): ForkDigestHex {
-      const forkDigestHex = forkDigestHexByForkName.get(forkName);
+    epoch2ForkDigestHex(epoch: Epoch): ForkDigestHex {
+      const boundary = chainForkConfig.getForkBoundaryAtEpoch(epoch);
+      const forkDigestHex = forkDigestHexByEpoch.get(boundary.epoch);
       if (!forkDigestHex) {
-        throw Error(`No precomputed forkDigest for ${forkName}`);
+        throw Error(`No precomputed forkDigest for ${epoch}`);
       }
       return toHexStringNoPrefix(forkDigestHex);
     },
@@ -142,6 +167,23 @@ function toHexStringNoPrefix(hex: string | Uint8Array): string {
   return strip0xPrefix(typeof hex === "string" ? hex : toHex(hex));
 }
 
-function computeForkDigest(currentVersion: Version, genesisValidatorsRoot: Root): ForkDigest {
-  return computeForkDataRoot(currentVersion, genesisValidatorsRoot).slice(0, 4);
+export function computeForkDigest(config: ChainForkConfig, genesisValidatorsRoot: Root, epoch: Epoch): ForkDigest {
+  const currentFork = config.getForkInfoAtEpoch(epoch);
+  const baseDigest = computeForkDataRoot(currentFork.version, genesisValidatorsRoot);
+
+  if (currentFork.seq < ForkSeq.fulu) {
+    return baseDigest.slice(0, 4);
+  }
+
+  const blobParameters = config.getBlobParameters(epoch);
+
+  return xor(
+    baseDigest,
+    digest(
+      Buffer.concat([
+        intToBytes(blobParameters.EPOCH, 8, "le"),
+        intToBytes(blobParameters.MAX_BLOBS_PER_BLOCK, 8, "le"),
+      ])
+    )
+  ).slice(0, 4);
 }

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -23,10 +23,6 @@ export function createCachedGenesis(chainForkConfig: ChainForkConfig, genesisVal
     const nextForkBoundary = forkBoundariesAscendingEpochOrder[i + 1];
 
     const currentEpoch = currentForkBoundary.epoch;
-
-    // Skip unscheduled fork boundaries
-    if (currentEpoch === Infinity) continue;
-
     const nextEpoch = nextForkBoundary !== undefined ? nextForkBoundary.epoch : Infinity;
 
     // If multiple forks/blob schedules start at the same epoch, only consider the latest one

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -1,10 +1,9 @@
 import {digest} from "@chainsafe/as-sha256";
 import {DOMAIN_VOLUNTARY_EXIT, ForkName, ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {DomainType, Epoch, ForkDigest, Root, Slot, Version, phase0, ssz} from "@lodestar/types";
-import {intToBytes, strip0xPrefix, toHex} from "@lodestar/utils";
+import {intToBytes, strip0xPrefix, toHex, xor} from "@lodestar/utils";
 import {ChainForkConfig} from "../beaconConfig.js";
 import {ForkBoundary} from "../forkConfig/types.js";
-import {xor} from "../utils/bytes.js";
 import {CachedGenesis, ForkDigestHex} from "./types.js";
 export type {ForkDigestContext} from "./types.js";
 

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -161,7 +161,7 @@ function toHexStringNoPrefix(hex: string | Uint8Array): string {
 }
 
 export function computeForkDigest(config: ChainForkConfig, genesisValidatorsRoot: Root, epoch: Epoch): ForkDigest {
-  const currentFork = config.getForkInfoAtEpoch(epoch);
+  const currentFork = config.forks[config.getForkBoundaryAtEpoch(epoch).fork];
   const baseDigest = computeForkDataRoot(currentFork.version, genesisValidatorsRoot);
 
   if (currentFork.seq < ForkSeq.fulu) {

--- a/packages/config/src/genesisConfig/index.ts
+++ b/packages/config/src/genesisConfig/index.ts
@@ -173,10 +173,7 @@ export function computeForkDigest(config: ChainForkConfig, genesisValidatorsRoot
   return xor(
     baseDigest,
     digest(
-      Buffer.concat([
-        intToBytes(blobParameters.EPOCH, 8, "le"),
-        intToBytes(blobParameters.MAX_BLOBS_PER_BLOCK, 8, "le"),
-      ])
+      Buffer.concat([intToBytes(blobParameters.epoch, 8, "le"), intToBytes(blobParameters.maxBlobsPerBlock, 8, "le")])
     )
   ).slice(0, 4);
 }

--- a/packages/config/src/genesisConfig/types.ts
+++ b/packages/config/src/genesisConfig/types.ts
@@ -1,13 +1,14 @@
 import {ForkName} from "@lodestar/params";
-import {DomainType, ForkDigest, Root, Slot} from "@lodestar/types";
+import {DomainType, Epoch, ForkDigest, Root, Slot} from "@lodestar/types";
+import {ForkBoundary} from "../forkConfig/types.js";
 
 export type ForkDigestHex = string;
 
 export type ForkDigestContext = {
-  forkDigest2ForkName(forkDigest: ForkDigest | ForkDigestHex): ForkName;
-  forkDigest2ForkNameOption(forkDigest: ForkDigest | ForkDigestHex): ForkName | null;
-  forkName2ForkDigest(forkName: ForkName): ForkDigest;
-  forkName2ForkDigestHex(forkName: ForkName): ForkDigestHex;
+  forkDigest2ForkBoundary(forkDigest: ForkDigest | ForkDigestHex): ForkBoundary;
+  forkDigest2ForkBoundaryOption(forkDigest: ForkDigest | ForkDigestHex): ForkBoundary | null;
+  epoch2ForkDigest(epoch: Epoch): ForkDigest;
+  epoch2ForkDigestHex(epoch: Epoch): ForkDigestHex;
 };
 
 export interface CachedGenesis extends ForkDigestContext {

--- a/packages/config/src/genesisConfig/types.ts
+++ b/packages/config/src/genesisConfig/types.ts
@@ -1,5 +1,5 @@
 import {ForkName} from "@lodestar/params";
-import {DomainType, Epoch, ForkDigest, Root, Slot} from "@lodestar/types";
+import {DomainType, ForkDigest, Root, Slot} from "@lodestar/types";
 import {ForkBoundary} from "../forkConfig/types.js";
 
 export type ForkDigestHex = string;
@@ -7,8 +7,8 @@ export type ForkDigestHex = string;
 export type ForkDigestContext = {
   forkDigest2ForkBoundary(forkDigest: ForkDigest | ForkDigestHex): ForkBoundary;
   forkDigest2ForkBoundaryOption(forkDigest: ForkDigest | ForkDigestHex): ForkBoundary | null;
-  epoch2ForkDigest(epoch: Epoch): ForkDigest;
-  epoch2ForkDigestHex(epoch: Epoch): ForkDigestHex;
+  forkBoundary2ForkDigest(boundary: ForkBoundary): ForkDigest;
+  forkBoundary2ForkDigestHex(boundary: ForkBoundary): ForkDigestHex;
 };
 
 export interface CachedGenesis extends ForkDigestContext {

--- a/packages/config/src/utils/bytes.ts
+++ b/packages/config/src/utils/bytes.ts
@@ -1,7 +1,0 @@
-export function xor(a: Uint8Array, b: Uint8Array): Uint8Array {
-  const length = Math.min(a.length, b.length);
-  for (let i = 0; i < length; i++) {
-    a[i] = a[i] ^ b[i];
-  }
-  return a;
-}

--- a/packages/config/src/utils/bytes.ts
+++ b/packages/config/src/utils/bytes.ts
@@ -1,0 +1,7 @@
+export function xor(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const length = Math.min(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    a[i] = a[i] ^ b[i];
+  }
+  return a;
+}

--- a/packages/config/test/unit/forkDigest.test.ts
+++ b/packages/config/test/unit/forkDigest.test.ts
@@ -1,0 +1,110 @@
+import {fromHex as b, toHex} from "@lodestar/utils";
+import {describe, expect, it} from "vitest";
+import {computeForkDigest, createCachedGenesis, createChainForkConfig} from "../../src/index.js";
+
+// Test cases copied from https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.2/tests/core/pyspec/eth2spec/test/fulu/validator/test_compute_fork_digest.py
+// TODO FULU: Add Electra scenarios to test cases when they are available in the spec repo
+describe("fork digest", () => {
+  const genesisValidatorRoot = Buffer.alloc(32, 0);
+  const config = createChainForkConfig({
+    ALTAIR_FORK_EPOCH: 0,
+    BELLATRIX_FORK_EPOCH: 0,
+    CAPELLA_FORK_EPOCH: 0,
+    DENEB_FORK_EPOCH: 0,
+    ELECTRA_FORK_EPOCH: 9,
+    FULU_FORK_EPOCH: 100,
+    BLOB_SCHEDULE: [
+      {EPOCH: 9, MAX_BLOBS_PER_BLOCK: 9},
+      {EPOCH: 100, MAX_BLOBS_PER_BLOCK: 100},
+      {EPOCH: 150, MAX_BLOBS_PER_BLOCK: 175},
+      {EPOCH: 200, MAX_BLOBS_PER_BLOCK: 200},
+      {EPOCH: 250, MAX_BLOBS_PER_BLOCK: 275},
+      {EPOCH: 300, MAX_BLOBS_PER_BLOCK: 300},
+    ],
+    FULU_FORK_VERSION: b("0x06000000"),
+  });
+
+  describe("computeForkDigest", () => {
+    const testCases = [
+      {
+        epoch: 100,
+        expectedForkDigest: "df67557b",
+      },
+      {
+        epoch: 101,
+        expectedForkDigest: "df67557b",
+      },
+      {
+        epoch: 150,
+        expectedForkDigest: "8ab38b59",
+      },
+      {
+        epoch: 199,
+        expectedForkDigest: "8ab38b59",
+      },
+      {
+        epoch: 200,
+        expectedForkDigest: "d9b81438",
+      },
+      {
+        epoch: 201,
+        expectedForkDigest: "d9b81438",
+      },
+      {
+        epoch: 250,
+        expectedForkDigest: "4ef32a62",
+      },
+      {
+        epoch: 299,
+        expectedForkDigest: "4ef32a62",
+      },
+      {
+        epoch: 300,
+        expectedForkDigest: "ca100d64",
+      },
+      {
+        epoch: 301,
+        expectedForkDigest: "ca100d64",
+      },
+    ];
+
+    for (const testCase of testCases) {
+      const {epoch, expectedForkDigest} = testCase;
+      it(`should match fork digest at epoch ${epoch}`, () => {
+        const forkDigest = toHex(computeForkDigest(config, genesisValidatorRoot, epoch));
+
+        expect(forkDigest.slice(2)).toBe(expectedForkDigest);
+      });
+    }
+  });
+
+  describe("createCachedGenesis", () => {
+    const cachedGenesis = createCachedGenesis(config, genesisValidatorRoot);
+
+    const testCases = [
+      {epoch: 100, expectedForkDigest: "df67557b"},
+      {epoch: 101, expectedForkDigest: "df67557b"},
+      {epoch: 150, expectedForkDigest: "8ab38b59"},
+      {epoch: 199, expectedForkDigest: "8ab38b59"},
+      {epoch: 200, expectedForkDigest: "d9b81438"},
+      {epoch: 201, expectedForkDigest: "d9b81438"},
+      {epoch: 250, expectedForkDigest: "4ef32a62"},
+      {epoch: 299, expectedForkDigest: "4ef32a62"},
+      {epoch: 300, expectedForkDigest: "ca100d64"},
+      {epoch: 301, expectedForkDigest: "ca100d64"},
+    ];
+
+    for (const testCase of testCases) {
+      const {epoch, expectedForkDigest} = testCase;
+      it(`should match fork digest at epoch ${epoch}`, () => {
+        const forkDigestHex = cachedGenesis.epoch2ForkDigestHex(epoch);
+
+        expect(forkDigestHex).toBe(expectedForkDigest);
+
+        const boundary = config.getForkBoundaryAtEpoch(epoch);
+
+        expect(boundary).toBe(cachedGenesis.forkDigest2ForkBoundary(expectedForkDigest));
+      });
+    }
+  });
+});

--- a/packages/config/test/unit/forkDigest.test.ts
+++ b/packages/config/test/unit/forkDigest.test.ts
@@ -97,12 +97,10 @@ describe("fork digest", () => {
     for (const testCase of testCases) {
       const {epoch, expectedForkDigest} = testCase;
       it(`should match fork digest at epoch ${epoch}`, () => {
-        const forkDigestHex = cachedGenesis.epoch2ForkDigestHex(epoch);
+        const boundary = config.getForkBoundaryAtEpoch(epoch);
+        const forkDigestHex = cachedGenesis.forkBoundary2ForkDigestHex(boundary);
 
         expect(forkDigestHex).toBe(expectedForkDigest);
-
-        const boundary = config.getForkBoundaryAtEpoch(epoch);
-
         expect(boundary).toBe(cachedGenesis.forkDigest2ForkBoundary(expectedForkDigest));
       });
     }

--- a/packages/reqresp/README.md
+++ b/packages/reqresp/README.md
@@ -32,7 +32,7 @@ async function getReqResp(libp2p: Libp2p, logger: Logger): Promise<void> {
     handler: async function* (req) {
       yield {
         data: req.data,
-        boundary: {fork: ForkName.phase0, epoch: 0},
+        boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
       };
     },
   };

--- a/packages/reqresp/README.md
+++ b/packages/reqresp/README.md
@@ -32,7 +32,7 @@ async function getReqResp(libp2p: Libp2p, logger: Logger): Promise<void> {
     handler: async function* (req) {
       yield {
         data: req.data,
-        boundary: {fork: ForkName.phase0},
+        boundary: {fork: ForkName.phase0, epoch: 0},
       };
     },
   };

--- a/packages/reqresp/README.md
+++ b/packages/reqresp/README.md
@@ -15,7 +15,7 @@ Typescript implementation of the [Ethereum Consensus Req/Resp protocol](https://
 import {Libp2p} from "libp2p";
 import {ssz} from "@lodestar/types";
 import {ReqResp, ContextBytesType, Protocol, Encoding} from "@lodestar/reqresp";
-import {ForkName} from "@lodestar/params";
+import {ForkName, GENESIS_EPOCH} from "@lodestar/params";
 import {Logger} from "@lodestar/utils";
 
 async function getReqResp(libp2p: Libp2p, logger: Logger): Promise<void> {

--- a/packages/reqresp/src/encoders/responseDecode.ts
+++ b/packages/reqresp/src/encoders/responseDecode.ts
@@ -147,7 +147,7 @@ export async function readContextBytes(
 
     case ContextBytesType.ForkDigest: {
       const forkDigest = await readContextBytesForkDigest(bufferedSource);
-      return contextBytes.forkDigestContext.forkDigest2ForkName(forkDigest);
+      return contextBytes.config.forkDigest2ForkBoundary(forkDigest).fork;
     }
   }
 }

--- a/packages/reqresp/src/encoders/responseEncode.ts
+++ b/packages/reqresp/src/encoders/responseEncode.ts
@@ -76,6 +76,6 @@ function getContextBytes(contextBytes: ContextBytesFactory, chunk: ResponseOutgo
 
     // Yield a fixed-width 4 byte chunk, set to the `ForkDigest`
     case ContextBytesType.ForkDigest:
-      return contextBytes.config.epoch2ForkDigest(chunk.boundary.epoch);
+      return contextBytes.config.forkBoundary2ForkDigest(chunk.boundary);
   }
 }

--- a/packages/reqresp/src/encoders/responseEncode.ts
+++ b/packages/reqresp/src/encoders/responseEncode.ts
@@ -76,6 +76,6 @@ function getContextBytes(contextBytes: ContextBytesFactory, chunk: ResponseOutgo
 
     // Yield a fixed-width 4 byte chunk, set to the `ForkDigest`
     case ContextBytesType.ForkDigest:
-      return contextBytes.forkDigestContext.forkName2ForkDigest(chunk.boundary.fork) as Buffer;
+      return contextBytes.config.epoch2ForkDigest(chunk.boundary.epoch);
   }
 }

--- a/packages/reqresp/src/types.ts
+++ b/packages/reqresp/src/types.ts
@@ -6,8 +6,6 @@ import {RateLimiterQuota} from "./rate_limiter/rateLimiterGRCA.js";
 
 export const protocolPrefix = "/eth2/beacon_chain/req";
 
-export type SubscribeBoundary = {fork: ForkName};
-
 /**
  * Available request/response encoding strategies:
  * https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#encoding-strategies
@@ -30,8 +28,8 @@ export type ResponseIncoming = {
 export type ResponseOutgoing = {
   data: Uint8Array;
   /**
-   * Reason why outgoing needs boundary but incoming only needs fork is because we can deserialize incoming data
-   * with only fork info, but for outgoing we also need to compute fork digest, which requires boundary.
+   * Reason why outgoing needs fork boundary but incoming only needs fork is because we can deserialize incoming data
+   * with only fork info, but for outgoing we also need to compute fork digest, which requires fork boundary.
    */
   boundary: ForkBoundary;
 };

--- a/packages/reqresp/src/types.ts
+++ b/packages/reqresp/src/types.ts
@@ -1,5 +1,5 @@
 import {PeerId} from "@libp2p/interface";
-import {BeaconConfig, ForkDigestContext} from "@lodestar/config";
+import {BeaconConfig, ForkBoundary} from "@lodestar/config";
 import {ForkName} from "@lodestar/params";
 import {LodestarError} from "@lodestar/utils";
 import {RateLimiterQuota} from "./rate_limiter/rateLimiterGRCA.js";
@@ -33,7 +33,7 @@ export type ResponseOutgoing = {
    * Reason why outgoing needs boundary but incoming only needs fork is because we can deserialize incoming data
    * with only fork info, but for outgoing we also need to compute fork digest, which requires boundary.
    */
-  boundary: SubscribeBoundary;
+  boundary: ForkBoundary;
 };
 
 /**
@@ -135,7 +135,7 @@ export type HandlerTypeFromMessage<T> = T extends ProtocolGenerator ? ProtocolHa
 
 export type ContextBytesFactory =
   | {type: ContextBytesType.Empty}
-  | {type: ContextBytesType.ForkDigest; forkDigestContext: ForkDigestContext};
+  | {type: ContextBytesType.ForkDigest; config: BeaconConfig};
 
 export type ContextBytes = {type: ContextBytesType.Empty} | {type: ContextBytesType.ForkDigest; fork: ForkName};
 

--- a/packages/reqresp/test/fixtures/encoders.ts
+++ b/packages/reqresp/test/fixtures/encoders.ts
@@ -134,7 +134,7 @@ export const responseEncodersTestCases: {
       // <result>
       Buffer.from([RespStatus.SUCCESS]),
       // <context-bytes>
-      beaconConfig.epoch2ForkDigest(0),
+      beaconConfig.forkBoundary2ForkDigest(beaconConfig.getForkBoundaryAtEpoch(0)),
       // <encoding-dependent-header> | <encoded-payload>
       ...sszSnappySignedBeaconBlockPhase0.chunks,
     ],
@@ -147,7 +147,7 @@ export const responseEncodersTestCases: {
       // <result>
       Buffer.from([RespStatus.SUCCESS]),
       // <context-bytes>
-      beaconConfig.epoch2ForkDigest(beaconConfig.ALTAIR_FORK_EPOCH),
+      beaconConfig.forkBoundary2ForkDigest(beaconConfig.getForkBoundaryAtEpoch(beaconConfig.ALTAIR_FORK_EPOCH)),
       // <encoding-dependent-header> | <encoded-payload>
       ...sszSnappySignedBeaconBlockAltair.chunks,
     ],
@@ -211,11 +211,11 @@ export const responseEncodersTestCases: {
     chunks: [
       // Chunk 0 - success block in phase0 with context bytes
       Buffer.from([RespStatus.SUCCESS]),
-      beaconConfig.epoch2ForkDigest(0),
+      beaconConfig.forkBoundary2ForkDigest(beaconConfig.getForkBoundaryAtEpoch(0)),
       ...sszSnappySignedBeaconBlockPhase0.chunks,
       // Chunk 1 - success block in altair with context bytes
       Buffer.from([RespStatus.SUCCESS]),
-      beaconConfig.epoch2ForkDigest(beaconConfig.ALTAIR_FORK_EPOCH),
+      beaconConfig.forkBoundary2ForkDigest(beaconConfig.getForkBoundaryAtEpoch(beaconConfig.ALTAIR_FORK_EPOCH)),
       ...sszSnappySignedBeaconBlockAltair.chunks,
     ],
   },
@@ -246,7 +246,7 @@ export const responseEncodersErrorTestCases: {
       // <result>
       Buffer.from([RespStatus.SUCCESS]),
       // <context-bytes>
-      beaconConfig.epoch2ForkDigest(beaconConfig.ALTAIR_FORK_EPOCH),
+      beaconConfig.forkBoundary2ForkDigest(beaconConfig.getForkBoundaryAtEpoch(beaconConfig.ALTAIR_FORK_EPOCH)),
       // <encoding-dependent-header> | <encoded-payload>
       ...sszSnappySignedBeaconBlockAltair.chunks,
     ],

--- a/packages/reqresp/test/fixtures/encoders.ts
+++ b/packages/reqresp/test/fixtures/encoders.ts
@@ -1,4 +1,3 @@
-import {ForkName} from "@lodestar/params";
 import {LodestarError} from "@lodestar/utils";
 import {SszSnappyError, SszSnappyErrorCode} from "../../src/encodingStrategies/sszSnappy/index.js";
 import {ResponseError} from "../../src/index.js";
@@ -135,7 +134,7 @@ export const responseEncodersTestCases: {
       // <result>
       Buffer.from([RespStatus.SUCCESS]),
       // <context-bytes>
-      beaconConfig.forkName2ForkDigest(ForkName.phase0),
+      beaconConfig.epoch2ForkDigest(0),
       // <encoding-dependent-header> | <encoded-payload>
       ...sszSnappySignedBeaconBlockPhase0.chunks,
     ],
@@ -148,7 +147,7 @@ export const responseEncodersTestCases: {
       // <result>
       Buffer.from([RespStatus.SUCCESS]),
       // <context-bytes>
-      beaconConfig.forkName2ForkDigest(ForkName.altair),
+      beaconConfig.epoch2ForkDigest(beaconConfig.ALTAIR_FORK_EPOCH),
       // <encoding-dependent-header> | <encoded-payload>
       ...sszSnappySignedBeaconBlockAltair.chunks,
     ],
@@ -212,11 +211,11 @@ export const responseEncodersTestCases: {
     chunks: [
       // Chunk 0 - success block in phase0 with context bytes
       Buffer.from([RespStatus.SUCCESS]),
-      beaconConfig.forkName2ForkDigest(ForkName.phase0),
+      beaconConfig.epoch2ForkDigest(0),
       ...sszSnappySignedBeaconBlockPhase0.chunks,
       // Chunk 1 - success block in altair with context bytes
       Buffer.from([RespStatus.SUCCESS]),
-      beaconConfig.forkName2ForkDigest(ForkName.altair),
+      beaconConfig.epoch2ForkDigest(beaconConfig.ALTAIR_FORK_EPOCH),
       ...sszSnappySignedBeaconBlockAltair.chunks,
     ],
   },
@@ -247,7 +246,7 @@ export const responseEncodersErrorTestCases: {
       // <result>
       Buffer.from([RespStatus.SUCCESS]),
       // <context-bytes>
-      beaconConfig.forkName2ForkDigest(ForkName.altair),
+      beaconConfig.epoch2ForkDigest(beaconConfig.ALTAIR_FORK_EPOCH),
       // <encoding-dependent-header> | <encoded-payload>
       ...sszSnappySignedBeaconBlockAltair.chunks,
     ],

--- a/packages/reqresp/test/fixtures/encodingStrategies.ts
+++ b/packages/reqresp/test/fixtures/encodingStrategies.ts
@@ -34,7 +34,7 @@ export const goerliShadowForkBlock13249: SszSnappyTestBlockData = {
   type: ssz.bellatrix.SignedBeaconBlock,
   payload: {
     data: fs.readFileSync(path.join(__dirname, "/goerliShadowForkBlock.13249/serialized.ssz")),
-    boundary: {fork: ForkName.altair},
+    boundary: {fork: ForkName.altair, epoch: 36660},
   },
   streamedBody: fs.readFileSync(path.join(__dirname, "/goerliShadowForkBlock.13249/streamed.snappy")),
 };

--- a/packages/reqresp/test/fixtures/protocols.ts
+++ b/packages/reqresp/test/fixtures/protocols.ts
@@ -1,5 +1,5 @@
 import {ContainerType, ListBasicType, UintNumberType, ValueOf} from "@chainsafe/ssz";
-import {ForkName} from "@lodestar/params";
+import {ForkName, GENESIS_EPOCH} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {ContextBytesType, DialOnlyProtocol, Encoding, Protocol, ProtocolHandler} from "../../src/types.js";
 import {getEmptyHandler} from "./messages.js";
@@ -40,7 +40,7 @@ export const numberToStringProtocol: Protocol = {
   handler: async function* handler(req) {
     yield {
       data: Buffer.from(req.data.toString(), "utf8"),
-      boundary: {fork: ForkName.phase0, epoch: 0},
+      boundary: {fork: ForkName.phase0, epoch: GENESIS_EPOCH},
     };
   },
 };

--- a/packages/reqresp/test/fixtures/protocols.ts
+++ b/packages/reqresp/test/fixtures/protocols.ts
@@ -40,7 +40,7 @@ export const numberToStringProtocol: Protocol = {
   handler: async function* handler(req) {
     yield {
       data: Buffer.from(req.data.toString(), "utf8"),
-      boundary: {fork: ForkName.phase0},
+      boundary: {fork: ForkName.phase0, epoch: 0},
     };
   },
 };
@@ -71,7 +71,7 @@ export function customProtocol(opts: ProtocolOptions): Protocol {
     responseSizes: () => ({minSize: 0, maxSize: Infinity}),
     contextBytes:
       opts.contextBytesType === ContextBytesType.ForkDigest
-        ? {type: ContextBytesType.ForkDigest, forkDigestContext: beaconConfig}
+        ? {type: ContextBytesType.ForkDigest, config: beaconConfig}
         : {type: ContextBytesType.Empty},
     method: "req/test",
     version: opts.version ?? 1,

--- a/packages/reqresp/test/unit/response/index.test.ts
+++ b/packages/reqresp/test/unit/response/index.test.ts
@@ -1,5 +1,5 @@
 import {PeerId} from "@libp2p/interface";
-import {config} from "@lodestar/config/default.js";
+import {config} from "@lodestar/config/default";
 import {getEmptyLogger} from "@lodestar/logger/empty";
 import {LodestarError, fromHex} from "@lodestar/utils";
 import {afterEach, beforeEach, describe, expect, it} from "vitest";

--- a/packages/reqresp/test/unit/response/index.test.ts
+++ b/packages/reqresp/test/unit/response/index.test.ts
@@ -1,4 +1,5 @@
 import {PeerId} from "@libp2p/interface";
+import {config} from "@lodestar/config/default.js";
 import {getEmptyLogger} from "@lodestar/logger/empty";
 import {LodestarError, fromHex} from "@lodestar/utils";
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
@@ -22,8 +23,9 @@ const testCases: {
     id: "Yield two chunks, then throw",
     protocol: pingProtocol(async function* () {
       const payload = sszSnappyPing.binaryPayload;
-      yield {...payload, boundary: {fork: payload.fork}};
-      yield {...payload, boundary: {fork: payload.fork}};
+      const boundary = {fork: payload.fork, epoch: config.forks[payload.fork].epoch};
+      yield {...payload, boundary};
+      yield {...payload, boundary};
       throw new LodestarError({code: "TEST_ERROR"});
     }),
     requestChunks: sszSnappyPing.chunks, // Request Ping: BigInt(1)

--- a/packages/reqresp/test/unit/response/index.test.ts
+++ b/packages/reqresp/test/unit/response/index.test.ts
@@ -23,7 +23,8 @@ const testCases: {
     id: "Yield two chunks, then throw",
     protocol: pingProtocol(async function* () {
       const payload = sszSnappyPing.binaryPayload;
-      const boundary = {fork: payload.fork, epoch: config.forks[payload.fork].epoch};
+      const epoch = config.forks[payload.fork].epoch;
+      const boundary = config.getForkBoundaryAtEpoch(epoch);
       yield {...payload, boundary};
       yield {...payload, boundary};
       throw new LodestarError({code: "TEST_ERROR"});

--- a/packages/reqresp/test/utils/response.ts
+++ b/packages/reqresp/test/utils/response.ts
@@ -1,4 +1,4 @@
-import {config} from "@lodestar/config/default.js";
+import {config} from "@lodestar/config/default";
 import {pipe} from "it-pipe";
 import {responseEncodeError, responseEncodeSuccess} from "../../src/encoders/responseEncode.js";
 import {RespStatus} from "../../src/interface.js";

--- a/packages/reqresp/test/utils/response.ts
+++ b/packages/reqresp/test/utils/response.ts
@@ -1,9 +1,9 @@
-import {config} from "@lodestar/config/default";
 import {pipe} from "it-pipe";
 import {responseEncodeError, responseEncodeSuccess} from "../../src/encoders/responseEncode.js";
 import {RespStatus} from "../../src/interface.js";
 import {Protocol} from "../../src/types.js";
 import {ResponseChunk} from "../fixtures/encoders.js";
+import {beaconConfig} from "../fixtures/messages.js";
 import {arrToSource} from "../utils/index.js";
 
 export async function* responseEncode(responseChunks: ResponseChunk[], protocol: Protocol): AsyncIterable<Buffer> {
@@ -11,7 +11,9 @@ export async function* responseEncode(responseChunks: ResponseChunk[], protocol:
     if (chunk.status === RespStatus.SUCCESS) {
       const payload = chunk.payload;
       yield* pipe(
-        arrToSource([{...payload, boundary: {fork: payload.fork, epoch: config.forks[payload.fork].epoch}}]),
+        arrToSource([
+          {...payload, boundary: beaconConfig.getForkBoundaryAtEpoch(beaconConfig.forks[payload.fork].epoch)},
+        ]),
         responseEncodeSuccess(protocol, {onChunk: () => {}})
       );
     } else {

--- a/packages/reqresp/test/utils/response.ts
+++ b/packages/reqresp/test/utils/response.ts
@@ -1,3 +1,4 @@
+import {config} from "@lodestar/config/default.js";
 import {pipe} from "it-pipe";
 import {responseEncodeError, responseEncodeSuccess} from "../../src/encoders/responseEncode.js";
 import {RespStatus} from "../../src/interface.js";
@@ -10,7 +11,7 @@ export async function* responseEncode(responseChunks: ResponseChunk[], protocol:
     if (chunk.status === RespStatus.SUCCESS) {
       const payload = chunk.payload;
       yield* pipe(
-        arrToSource([{...payload, boundary: {fork: payload.fork}}]),
+        arrToSource([{...payload, boundary: {fork: payload.fork, epoch: config.forks[payload.fork].epoch}}]),
         responseEncodeSuccess(protocol, {onChunk: () => {}})
       );
     } else {

--- a/packages/state-transition/src/block/processRandao.ts
+++ b/packages/state-transition/src/block/processRandao.ts
@@ -1,6 +1,7 @@
 import {digest} from "@chainsafe/as-sha256";
 import {EPOCHS_PER_HISTORICAL_VECTOR} from "@lodestar/params";
 import {BeaconBlock} from "@lodestar/types";
+import {xor} from "@lodestar/utils";
 import {verifyRandaoSignature} from "../signatureSets/index.js";
 import {CachedBeaconStateAllForks} from "../types.js";
 import {getRandaoMix} from "../util/index.js";
@@ -23,12 +24,4 @@ export function processRandao(state: CachedBeaconStateAllForks, block: BeaconBlo
   // mix in RANDAO reveal
   const randaoMix = xor(getRandaoMix(state, epoch), digest(randaoReveal));
   state.randaoMixes.set(epoch % EPOCHS_PER_HISTORICAL_VECTOR, randaoMix);
-}
-
-function xor(a: Uint8Array, b: Uint8Array): Uint8Array {
-  const length = Math.min(a.length, b.length);
-  for (let i = 0; i < length; i++) {
-    a[i] = a[i] ^ b[i];
-  }
-  return a;
 }

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -74,3 +74,11 @@ export function formatBytes(bytes: number): string {
 
   return `${formattedSize} ${units[i]}`;
 }
+
+export function xor(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const length = Math.min(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    a[i] = a[i] ^ b[i];
+  }
+  return a;
+}


### PR DESCRIPTION
**Motivation**

- https://github.com/ethereum/consensus-specs/pull/4354

**Description**

- add concept of fork boundaries (`ForkBoundary`) which include both normal hard-forks (phase0, altair, etc.) and Blob Parameter Only (BPO) forks and are used to un-/subscribe to gossip topics and compute the fork digest primarily for domain separation on the p2p layer
- mix in blob parameters (`BlobParameters`) when computing fork digest (`computeForkDigest`) post-fulu
- update ENR fork id (`ENRForkID`) to consider fork boundaries (next fork digest (`nfd`) will be updated in https://github.com/ChainSafe/lodestar/pull/8023)
- cache pre-computed fork digests by epoch instead of fork name in genesis config cache

