### PR TITLE
feat: increase default gas limit to 45M

### DIFF
--- a/docs/pages/run/validator-management/proposer-config.md
+++ b/docs/pages/run/validator-management/proposer-config.md
@@ -15,7 +15,7 @@ proposer_config:
     strict_fee_recipient_check: false
     fee_recipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     builder:
-      gas_limit: "36000000"
+      gas_limit: "45000000"
       selection: "executionalways"
       boost_factor: "0"
   "0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d":
@@ -29,7 +29,7 @@ default_config:
   strict_fee_recipient_check: true
   fee_recipient: "0xcccccccccccccccccccccccccccccccccccccccc"
   builder:
-    gas_limit: "36000000"
+    gas_limit: "45000000"
     selection: "default"
     boost_factor: "90"
 ```

--- a/packages/api/test/unit/keymanager/testData.ts
+++ b/packages/api/test/unit/keymanager/testData.ts
@@ -12,7 +12,7 @@ import {GenericServerTestCases} from "../../utils/genericServerTest.js";
 const pubkeyRand = "0x84105a985058fc8740a48bf1ede9d223ef09e8c6b1735ba0a55cf4a9ff2ff92376b778798365e488dab07a652eb04576";
 const ethaddressRand = "0xabcf8e0d4e9587369b2301d0790347320302cc09";
 const graffitiRandUtf8 = "636861696e736166652f6c6f64657374";
-const gasLimitRand = 36_000_000;
+const gasLimitRand = 45_000_000;
 const builderBoostFactorRand = BigInt(100);
 
 export const testData: GenericServerTestCases<Endpoints> = {

--- a/packages/beacon-node/test/sim/electra-interop.test.ts
+++ b/packages/beacon-node/test/sim/electra-interop.test.ts
@@ -156,7 +156,7 @@ describe("executionEngine / ExecutionEngineHttp", () => {
         256
       ),
       prevRandao: dataToBytes("0x0000000000000000000000000000000000000000000000000000000000000000", 32),
-      gasLimit: 36000000,
+      gasLimit: 45000000,
       gasUsed: 84714,
       timestamp: 16,
       extraData: dataToBytes("0x", 0),

--- a/packages/cli/test/e2e/propserConfigfromKeymanager.test.ts
+++ b/packages/cli/test/e2e/propserConfigfromKeymanager.test.ts
@@ -16,13 +16,13 @@ describe("import keystores from api, test DefaultProposerConfig", () => {
 
   const defaultOptions = {
     suggestedFeeRecipient: "0x0000000000000000000000000000000000000000",
-    gasLimit: 36_000_000,
+    gasLimit: 45_000_000,
     graffiti: "aaaa",
   };
 
   const updatedOptions = {
     suggestedFeeRecipient: "0xcccccccccccccccccccccccccccccccccccccccc",
-    gasLimit: 40_000_000,
+    gasLimit: 50_000_000,
     graffiti: "bbbb",
   };
 

--- a/packages/cli/test/unit/validator/parseProposerConfig.test.ts
+++ b/packages/cli/test/unit/validator/parseProposerConfig.test.ts
@@ -14,7 +14,7 @@ const testValue = {
       strictFeeRecipientCheck: true,
       feeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       builder: {
-        gasLimit: 36000000,
+        gasLimit: 45000000,
         selection: undefined,
         boostFactor: undefined,
       },
@@ -35,7 +35,7 @@ const testValue = {
     strictFeeRecipientCheck: true,
     feeRecipient: "0xcccccccccccccccccccccccccccccccccccccccc",
     builder: {
-      gasLimit: 36000000,
+      gasLimit: 45000000,
       selection: routes.validator.BuilderSelection.MaxProfit,
       boostFactor: BigInt(50),
     },

--- a/packages/cli/test/unit/validator/proposerConfigs/invalidData.yaml
+++ b/packages/cli/test/unit/validator/proposerConfigs/invalidData.yaml
@@ -5,7 +5,7 @@ proposer_config:
     fee_recipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     builder:
       enabled: true
-      gas_limit: "36000000"
+      gas_limit: "45000000"
   "0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d":
     fee_recipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     builder:
@@ -17,4 +17,4 @@ default_config:
   fee_recipient: "0xcccccccccccccccccccccccccccccccccccccccc"
   builder:
     enabled: true
-    gas_limit: "36000000"
+    gas_limit: "45000000"

--- a/packages/cli/test/unit/validator/proposerConfigs/validData.yaml
+++ b/packages/cli/test/unit/validator/proposerConfigs/validData.yaml
@@ -4,7 +4,7 @@ proposer_config:
     strict_fee_recipient_check: true
     fee_recipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     builder:
-      gas_limit: "36000000"
+      gas_limit: "45000000"
   "0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d":
     fee_recipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     builder:
@@ -16,6 +16,6 @@ default_config:
   strict_fee_recipient_check: "true"
   fee_recipient: "0xcccccccccccccccccccccccccccccccccccccccc"
   builder:
-    gas_limit: "36000000"
+    gas_limit: "45000000"
     selection: "maxprofit"
     boost_factor: "50"

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -131,7 +131,7 @@ type ValidatorData = ProposerConfig & {
 
 export const defaultOptions = {
   suggestedFeeRecipient: "0x0000000000000000000000000000000000000000",
-  defaultGasLimit: 36_000_000,
+  defaultGasLimit: 45_000_000,
   builderSelection: routes.validator.BuilderSelection.ExecutionOnly,
   builderAliasSelection: routes.validator.BuilderSelection.Default,
   builderBoostFactor: BigInt(100),

--- a/packages/validator/test/unit/validatorStore.test.ts
+++ b/packages/validator/test/unit/validatorStore.test.ts
@@ -26,7 +26,7 @@ describe("ValidatorStore", () => {
           strictFeeRecipientCheck: true,
           feeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
           builder: {
-            gasLimit: 36000000,
+            gasLimit: 45000000,
             selection: routes.validator.BuilderSelection.ExecutionOnly,
           },
         },


### PR DESCRIPTION
**Motivation**

From https://x.com/vdWijden/status/1939234101631856969
> Over the last couple of days, all major  [@ethereum](https://x.com/ethereum) clients signalled that they consider a move to 45M gas per block safe.

We should make it easy for users and just bump the default. 45M seems like a reasonable increase for now.

**Description**

Increase default gas limit to 45M

Same as https://github.com/ChainSafe/lodestar/pull/7304