### PR TITLE
feat: remove advertised custody

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1254,16 +1254,6 @@ export class BeaconChain implements IBeaconChain {
           this.custodyConfig.updateTargetCustodyGroupCount(targetCustodyGroupCount);
           this.logger.verbose(`Updated targetCustodyGroupCount=${this.custodyConfig.targetCustodyGroupCount}`);
           this.emitter.emit(ChainEvent.updateTargetGroupCount, this.custodyConfig.targetCustodyGroupCount);
-
-          // Need to update advertised custody prior to fulu transition so that we can serve columns we have for
-          // validators that are attached prior to the fork transition.
-          //
-          // TODO(fulu): If target group count increases, we should wait to update the advertised group until we've
-          // backfilled the new groups.
-          if (this.config.FULU_FORK_EPOCH !== Infinity && this.config.getForkSeq(slot) < ForkSeq.fulu) {
-            this.custodyConfig.updateAdvertisedCustodyGroupCount(targetCustodyGroupCount);
-            this.emitter.emit(ChainEvent.updateAdvertisedGroupCount, this.custodyConfig.advertisedCustodyGroupCount);
-          }
         }
       }
     }

--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -39,10 +39,6 @@ export enum ChainEvent {
    */
   updateTargetGroupCount = "updateTargetGroupCount",
   /**
-   * This event signals that the chain is ready to advertise the given group count to the network.
-   */
-  updateAdvertisedGroupCount = "updateAdvertisedGroupCount",
-  /**
    * This event signals that data columns have been fetched from the execution engine
    * and are ready to be published.
    */
@@ -66,7 +62,6 @@ export type IChainEvents = ApiEvents & {
   [ChainEvent.forkChoiceFinalized]: (checkpoint: CheckpointWithHex) => void;
 
   [ChainEvent.updateTargetGroupCount]: (targetGroupCount: number) => void;
-  [ChainEvent.updateAdvertisedGroupCount]: (advertisedGroupCount: number) => void;
 
   [ChainEvent.publishDataColumns]: (sidecars: fulu.DataColumnSidecar[]) => void;
 

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -362,10 +362,6 @@ export class NetworkCore implements INetworkCore {
 
   async setTargetGroupCount(count: number): Promise<void> {
     this.networkConfig.setTargetGroupCount(count);
-  }
-
-  async setAdvertisedGroupCount(count: number): Promise<void> {
-    this.networkConfig.setAdvertisedGroupCount(count);
     this.metadata.custodyGroupCount = count;
   }
 

--- a/packages/beacon-node/src/network/core/networkCoreWorker.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorker.ts
@@ -141,7 +141,6 @@ const libp2pWorkerApi: NetworkWorkerApi = {
   publishGossip: (topic, data, opts) => core.publishGossip(topic, data, opts),
 
   setTargetGroupCount: (count) => core.setTargetGroupCount(count),
-  setAdvertisedGroupCount: (count) => core.setAdvertisedGroupCount(count),
 
   // Debug
 

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -222,9 +222,6 @@ export class WorkerNetworkCore implements INetworkCore {
   setTargetGroupCount(count: number): Promise<void> {
     return this.getApi().setTargetGroupCount(count);
   }
-  setAdvertisedGroupCount(count: number): Promise<void> {
-    return this.getApi().setAdvertisedGroupCount(count);
-  }
 
   // Debug
 

--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -56,7 +56,6 @@ export interface INetworkCore extends INetworkCorePublic {
   updateStatus(status: Status): Promise<void>;
 
   setTargetGroupCount(count: number): Promise<void>;
-  setAdvertisedGroupCount(count: number): Promise<void>;
   /** Opens stream to handle ReqResp outgoing request */
   sendReqRespRequest(data: OutgoingRequestArgs): AsyncIterable<ResponseIncoming>;
   /** Publish gossip message to peers */
@@ -105,7 +104,6 @@ export type NetworkWorkerApi = INetworkCorePublic & {
   updateStatus(status: Status): Promise<void>;
 
   setTargetGroupCount(count: number): Promise<void>;
-  setAdvertisedGroupCount(count: number): Promise<void>;
 
   // sendReqRespRequest - implemented via events
   publishGossip(topic: string, data: Uint8Array, opts?: PublishOpts): Promise<number>;

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -44,7 +44,7 @@ export class MetadataController {
     this.onSetValue = modules.onSetValue;
     this._metadata = opts.metadata ?? {
       ...ssz.fulu.Metadata.defaultValue(),
-      custodyGroupCount: modules.networkConfig.getCustodyConfig().advertisedCustodyGroupCount,
+      custodyGroupCount: modules.networkConfig.getCustodyConfig().targetCustodyGroupCount,
     };
   }
 

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -137,7 +137,6 @@ export class Network implements INetwork {
       this.onLightClientOptimisticUpdate(data)
     );
     this.chain.emitter.on(ChainEvent.updateTargetGroupCount, this.onTargetGroupCountUpdated);
-    this.chain.emitter.on(ChainEvent.updateAdvertisedGroupCount, this.onAdvertisedGroupCountUpdated);
     this.chain.emitter.on(ChainEvent.publishDataColumns, this.onPublishDataColumns);
     this.chain.emitter.on(ChainEvent.updateStatus, this.onUpdateStatus);
   }
@@ -231,7 +230,6 @@ export class Network implements INetwork {
     this.chain.emitter.off(routes.events.EventType.lightClientFinalityUpdate, this.onLightClientFinalityUpdate);
     this.chain.emitter.off(routes.events.EventType.lightClientOptimisticUpdate, this.onLightClientOptimisticUpdate);
     this.chain.emitter.off(ChainEvent.updateTargetGroupCount, this.onTargetGroupCountUpdated);
-    this.chain.emitter.off(ChainEvent.updateAdvertisedGroupCount, this.onAdvertisedGroupCountUpdated);
     this.chain.emitter.off(ChainEvent.publishDataColumns, this.onPublishDataColumns);
     await this.core.close();
 
@@ -741,10 +739,6 @@ export class Network implements INetwork {
 
   private onTargetGroupCountUpdated = (count: number): void => {
     this.core.setTargetGroupCount(count);
-  };
-
-  private onAdvertisedGroupCountUpdated = (count: number): void => {
-    this.core.setAdvertisedGroupCount(count);
   };
 
   private onPublishDataColumns = (sidecars: fulu.DataColumnSidecar[]): Promise<number[]> => {

--- a/packages/beacon-node/src/network/networkConfig.ts
+++ b/packages/beacon-node/src/network/networkConfig.ts
@@ -36,8 +36,4 @@ export class NetworkConfig {
   setTargetGroupCount(count: number): void {
     this.custodyConfig.updateTargetCustodyGroupCount(count);
   }
-
-  setAdvertisedGroupCount(count: number): void {
-    this.custodyConfig.updateAdvertisedCustodyGroupCount(count);
-  }
 }

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -63,11 +63,6 @@ export class CustodyConfig {
   custodyColumnsIndex: Uint8Array;
 
   /**
-   * The number of custody groups the node will advertise to the network
-   */
-  advertisedCustodyGroupCount: number;
-
-  /**
    * The number of custody groups the node will sample
    */
   sampledGroupCount: number;
@@ -102,8 +97,7 @@ export class CustodyConfig {
     this.targetCustodyGroupCount = Math.max(config.CUSTODY_REQUIREMENT, config.NODE_CUSTODY_REQUIREMENT);
     this.custodyColumns = getDataColumns(this.nodeId, this.targetCustodyGroupCount);
     this.custodyColumnsIndex = this.getCustodyColumnsIndex(this.custodyColumns);
-    this.advertisedCustodyGroupCount = this.targetCustodyGroupCount;
-    this.metrics?.peerDas.custodyGroupCount.set(this.advertisedCustodyGroupCount);
+    this.metrics?.peerDas.custodyGroupCount.set(this.targetCustodyGroupCount);
     this.sampledGroupCount = Math.max(this.targetCustodyGroupCount, this.config.SAMPLES_PER_SLOT);
     this.sampleGroups = getCustodyGroups(this.nodeId, this.sampledGroupCount);
     this.sampledColumns = getDataColumns(this.nodeId, this.sampledGroupCount);
@@ -120,11 +114,7 @@ export class CustodyConfig {
     this.sampleGroups = getCustodyGroups(this.nodeId, this.sampledGroupCount);
     this.sampledColumns = getDataColumns(this.nodeId, this.sampledGroupCount);
     this.sampledSubnets = this.sampledColumns.map(computeSubnetForDataColumn);
-  }
-
-  updateAdvertisedCustodyGroupCount(advertisedCustodyGroupCount: number) {
-    this.advertisedCustodyGroupCount = advertisedCustodyGroupCount;
-    this.metrics?.peerDas.custodyGroupCount.set(this.advertisedCustodyGroupCount);
+    this.metrics?.peerDas.custodyGroupCount.set(this.targetCustodyGroupCount);
   }
 
   private getCustodyColumnsIndex(custodyColumns: ColumnIndex[]): Uint8Array {

--- a/packages/beacon-node/test/unit/util/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/util/dataColumn.test.ts
@@ -133,27 +133,11 @@ describe("CustodyConfig", () => {
 
       expect(custodyConfig.sampledGroupCount).toBe(8);
       expect(custodyConfig.targetCustodyGroupCount).toBe(4);
-      expect(custodyConfig.advertisedCustodyGroupCount).toBe(4);
 
       custodyConfig.updateTargetCustodyGroupCount(6);
 
       expect(custodyConfig.sampledGroupCount).toBe(8);
       expect(custodyConfig.targetCustodyGroupCount).toBe(6);
-      expect(custodyConfig.advertisedCustodyGroupCount).toBe(4);
-    });
-
-    it("should update advertised but not target or sampled", () => {
-      const custodyConfig = new CustodyConfig(nodeId, config, null);
-
-      expect(custodyConfig.sampledGroupCount).toBe(8);
-      expect(custodyConfig.targetCustodyGroupCount).toBe(4);
-      expect(custodyConfig.advertisedCustodyGroupCount).toBe(4);
-
-      custodyConfig.updateAdvertisedCustodyGroupCount(3);
-
-      expect(custodyConfig.sampledGroupCount).toBe(8);
-      expect(custodyConfig.targetCustodyGroupCount).toBe(4);
-      expect(custodyConfig.advertisedCustodyGroupCount).toBe(3);
     });
   });
 });


### PR DESCRIPTION
**Motivation**

Remove idea of "advertised custody" completely.  Only use target custody and let `earliestAvailableSlot` gate what requests can be made