### PR TITLE
fix: increase MAX_BATCH_PROCESSING_ATTEMPTS

### DIFF
--- a/packages/beacon-node/src/sync/constants.ts
+++ b/packages/beacon-node/src/sync/constants.ts
@@ -5,7 +5,10 @@ export const PARALLEL_HEAD_CHAINS = 2;
 export const MIN_FINALIZED_CHAIN_VALIDATED_EPOCHS = 10;
 
 /** The number of times to retry a batch before it is considered failed. */
-export const MAX_BATCH_DOWNLOAD_ATTEMPTS = 5;
+// export const MAX_BATCH_DOWNLOAD_ATTEMPTS = 5;
+// this constant is increased a lot for peerDAS because we may have many failed download due to rate limit not implemented yet
+// TODO: change it back to 5 when this issue is implemented https://github.com/ChainSafe/lodestar/issues/8033
+export const MAX_BATCH_DOWNLOAD_ATTEMPTS = 20;
 
 /** Consider batch faulty after downloading and processing this number of times */
 export const MAX_BATCH_PROCESSING_ATTEMPTS = 3;

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -439,8 +439,9 @@ export class SyncChain {
       const res = await wrapError(this.downloadBeaconBlocksByRange(peer, batch.request, partialDownload));
 
       if (!res.err) {
-        const blocks = batch.downloadingSuccess(res.result);
-        if (blocks !== null) {
+        const downloadSuccessOutput = batch.downloadingSuccess(res.result);
+        if (downloadSuccessOutput.status === BatchStatus.AwaitingProcessing) {
+          const blocks = downloadSuccessOutput.blocks;
           let hasPostDenebBlocks = false;
           const blobs = blocks.reduce((acc, blockInput) => {
             hasPostDenebBlocks ||= blockInput.type === BlockInputType.availableData;
@@ -474,7 +475,7 @@ export class SyncChain {
           });
           this.triggerBatchProcessor();
         } else {
-          const pendingDataColumns = res.result.pendingDataColumns?.join(",");
+          const pendingDataColumns = downloadSuccessOutput.pendingDataColumns.join(",");
           this.logger.debug("Partially downloaded batch", {
             id: this.logId,
             ...batch.getMetadata(),

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -82,6 +82,10 @@ export enum SyncChainStatus {
   Error = "Error",
 }
 
+// this global chain id is used to identify the chain over time, increase it every time a new chain is created
+// a chain type could be Finalized or Head, so it should be appended with this id to make the log unique
+let nextChainId = 0;
+
 /**
  * Dynamic target sync chain. Peers with multiple targets but with the same syncType are added
  * through the `addPeer()` hook.
@@ -145,7 +149,7 @@ export class SyncChain {
     this.custodyConfig = modules.custodyConfig;
     this.logger = modules.logger;
     this.metrics = modules.metrics;
-    this.logId = `${syncType}`;
+    this.logId = `${syncType}-${nextChainId++}`;
 
     if (this.metrics != null) {
       this.metrics.syncRange.headSyncPeers.addCollect(() => this.scrapeMetrics(this.metrics as Metrics));


### PR DESCRIPTION
**Motivation**

- there are hiccup when syncing
- it shows weird log: we downloaded some columns but then it appears again in the same batch, see https://github.com/ChainSafe/lodestar/issues/8036#issue-3207822752

**Description**

- improve chain log id by tracking a global `nextChainId`
- increase `MAX_BATCH_DOWNLOAD_ATTEMPTS` to 20 as we didn't implement rate limit prevention at client side. This should help us sync faster on devnets
- ensure the `pendingDataColumns` is decreased over time, this is a nice to have as we should download 1 single batch at a time
Closes #8036

**Testing**

- was able to sync with `te/fusaka_devnet_2_increase_MAX_BATCH_PROCESSING_ATTEMPT` branch

<img width="1561" alt="Screenshot 2025-07-07 at 16 00 31" src="https://github.com/user-attachments/assets/d356de29-9282-4eb2-b607-154f0457e3dc" />

- log is improved with the new id:

```
verbose: SyncChain Error id=Head-10, code=BATCH_ERROR_MAX_DOWNLOAD_ATTEMPTS, startEpoch=2463, status=Downloading
```
