### PR TITLE
feat: add blacklist for peers where there is a disconnection event (both in/out bound)

### DIFF
--- a/packages/beacon-node/src/network/core/metrics.ts
+++ b/packages/beacon-node/src/network/core/metrics.ts
@@ -1,3 +1,4 @@
+import {Direction} from "@libp2p/interface";
 import {SubnetID} from "@lodestar/types";
 import {RegistryMetricCreator} from "../../metrics/utils/registryMetricCreator.js";
 import {Libp2pError} from "../libp2p/error.js";
@@ -159,6 +160,15 @@ export function createNetworkCoreMetrics(register: RegistryMetricCreator) {
       cachedENRsSize: register.gauge({
         name: "lodestar_discovery_cached_enrs_size",
         help: "Current size of the cachedENRs Set",
+      }),
+      blacklistedPeerIdsSize: register.gauge({
+        name: "lodestar_discovery_blacklisted_peer_ids_size",
+        help: "Current size of the blacklistedPeerIds Map",
+      }),
+      blacklistedPeerDirection: register.gauge<{direction: Direction}>({
+        name: "lodestar_discovery_blacklisted_peer_direction",
+        help: "Whether peer disconnected us or we disconnected them",
+        labelNames: ["direction"],
       }),
       findNodeQueryRequests: register.gauge<{action: string}>({
         name: "lodestar_discovery_find_node_query_requests_total",

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -1,6 +1,6 @@
 import {ENR} from "@chainsafe/enr";
 import {toHexString} from "@chainsafe/ssz";
-import type {PeerId, PeerInfo, PrivateKey} from "@libp2p/interface";
+import type {Direction, PeerId, PeerInfo, PrivateKey} from "@libp2p/interface";
 import {BeaconConfig} from "@lodestar/config";
 import {LoggerNode} from "@lodestar/logger/node";
 import {ATTESTATION_SUBNET_COUNT, ForkSeq, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
@@ -189,6 +189,7 @@ export class PeerDiscovery {
     if (metrics) {
       metrics.discovery.cachedENRsSize.addCollect(() => {
         metrics.discovery.cachedENRsSize.set(this.cachedENRs.size);
+        metrics.discovery.blacklistedPeersSize.set(this.blacklistedPeerIds.size);
         metrics.discovery.peersToConnect.set(this.peersToConnect);
 
         // PeerDAS metrics
@@ -350,7 +351,10 @@ export class PeerDiscovery {
     });
   }
 
-  blacklistPeer(peerIdStr: PeerIdStr): void {
+  blacklistPeer(peerIdStr: PeerIdStr, direction: Direction): void {
+    const cachedENR = this.cachedENRs.get(peerIdStr);
+    this.cachedENRs.delete(peerIdStr);
+
     if (this.blacklistedPeerIds.has(peerIdStr)) {
       this.logger.warn("blacklistPeer called on peer already in blacklistedENRs", {
         peerId: prettyPrintPeerIdStr(peerIdStr),
@@ -358,14 +362,14 @@ export class PeerDiscovery {
       return;
     }
 
-    const cachedENR = this.cachedENRs.get(peerIdStr);
     if (!cachedENR) {
-      this.logger.debug("blacklistedPeer was not in cachedENRs", {peerId: peerIdStr});
+      this.logger.debug("blacklisted peer was not in cachedENRs so will not be redialed", {peerId: peerIdStr});
       return;
     }
 
     this.logger.debug(`adding peer to blacklistedPeers for ${PEER_BLACKLIST_TIMEOUT_MIN} minutes`, {peerId: peerIdStr});
     this.blacklistedPeerIds.set(peerIdStr, Date.now() + PEER_BLACKLIST_TIMEOUT_MS);
+    this.metrics?.discovery.blacklistedPeerDirection.inc({direction});
   }
 
   private onBlacklistPruneInterval = () => {

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -28,6 +28,7 @@ const MAX_CACHED_ENRS = 100;
 /** Max age a cached ENR will be considered for dial */
 const MAX_CACHED_ENR_AGE_MS = 5 * 60 * 1000;
 
+const MAX_BLACKLISTED_PEER_IDS = 200;
 /** Nominal timeout for disconnected or disconnecting peers is one hour */
 const PEER_BLACKLIST_TIMEOUT_MIN = 60;
 const PEER_BLACKLIST_TIMEOUT_MS = PEER_BLACKLIST_TIMEOUT_MIN * 60 * 1000;
@@ -379,6 +380,12 @@ export class PeerDiscovery {
         this.blacklistedPeerIds.delete(peerIdStr);
       }
     }
+
+    pruneSetToMax(this.blacklistedPeerIds, MAX_BLACKLISTED_PEER_IDS, (a, b) => {
+      const t1 = this.blacklistedPeerIds.get(a);
+      const t2 = this.blacklistedPeerIds.get(b);
+      return t2 - t1; // remove oldest first
+    });
   };
 
   /**

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -18,7 +18,7 @@ import {getLibp2pError} from "../libp2p/error.js";
 import {ENRKey, SubnetType} from "../metadata.js";
 import {NetworkConfig} from "../networkConfig.js";
 import {NodeId, computeNodeId} from "../subnets/interface.js";
-import {getConnectionsMap, prettyPrintPeerId} from "../util.js";
+import {getConnectionsMap, prettyPrintPeerId, prettyPrintPeerIdStr} from "../util.js";
 import {IPeerRpcScoreStore, ScoreState} from "./score/index.js";
 import {deserializeEnrSubnets, zeroAttnets, zeroSyncnets} from "./utils/enrSubnetsDeserialize.js";
 import {type GroupQueries} from "./utils/prioritizePeers.js";
@@ -27,6 +27,13 @@ import {type GroupQueries} from "./utils/prioritizePeers.js";
 const MAX_CACHED_ENRS = 100;
 /** Max age a cached ENR will be considered for dial */
 const MAX_CACHED_ENR_AGE_MS = 5 * 60 * 1000;
+
+/** Nominal timeout for disconnected or disconnecting peers is one hour */
+const PEER_BLACKLIST_TIMEOUT_MIN = 60;
+const PEER_BLACKLIST_TIMEOUT_MS = PEER_BLACKLIST_TIMEOUT_MIN * 60 * 1000;
+
+/** Prune blacklist for expired timeouts this often (5min) */
+const PEER_BLACKLIST_PRUNE_INTERVAL_MS = 5 * 60 * 1000;
 
 export type PeerDiscoveryOpts = {
   discv5FirstQueryDelayMs: number;
@@ -65,6 +72,7 @@ export enum DiscoveredPeerStatus {
   cached = "cached",
   dropped = "dropped",
   no_multiaddrs = "no_multiaddrs",
+  blacklisted = "blacklisted",
 }
 
 export enum NotDialReason {
@@ -116,6 +124,8 @@ export class PeerDiscovery {
   private networkConfig: NetworkConfig;
   private config: BeaconConfig;
   private cachedENRs = new Map<PeerIdStr, CachedENR>();
+  private blacklistedPeerIds = new Map<PeerIdStr, number>();
+  private blacklistPruneInterval: NodeJS.Timeout;
   private randomNodeQuery: QueryStatus = {code: QueryStatusCode.NotActive};
   private peersToConnect = 0;
   private subnetRequests: Record<SubnetType, Map<number, SubnetRequestInfo>> = {
@@ -146,6 +156,7 @@ export class PeerDiscovery {
     // TODO-das: remove
     this.nodeId = networkConfig.getNodeId();
     this.groupRequests = new Map();
+    this.blacklistPruneInterval = setInterval(this.onBlacklistPruneInterval, PEER_BLACKLIST_PRUNE_INTERVAL_MS);
 
     this.discv5StartMs = 0;
     this.discv5StartMs = Date.now();
@@ -214,6 +225,7 @@ export class PeerDiscovery {
   async stop(): Promise<void> {
     this.libp2p.removeEventListener("peer:discovery", this.onDiscoveredPeer);
     this.discv5.off("discovered", this.onDiscoveredENR);
+    clearInterval(this.blacklistPruneInterval);
     await this.discv5.close();
   }
 
@@ -338,6 +350,33 @@ export class PeerDiscovery {
     });
   }
 
+  blacklistPeer(peerIdStr: PeerIdStr): void {
+    if (this.blacklistedPeerIds.has(peerIdStr)) {
+      this.logger.warn("blacklistPeer called on peer already in blacklistedENRs", {
+        peerId: prettyPrintPeerIdStr(peerIdStr),
+      });
+      return;
+    }
+
+    const cachedENR = this.cachedENRs.get(peerIdStr);
+    if (!cachedENR) {
+      this.logger.debug("blacklistedPeer was not in cachedENRs", {peerId: peerIdStr});
+      return;
+    }
+
+    this.logger.debug(`adding peer to blacklistedPeers for ${PEER_BLACKLIST_TIMEOUT_MIN} minutes`, {peerId: peerIdStr});
+    this.blacklistedPeerIds.set(peerIdStr, Date.now() + PEER_BLACKLIST_TIMEOUT_MS);
+  }
+
+  private onBlacklistPruneInterval = () => {
+    const currentTimeMs = Date.now();
+    for (const [peerIdStr, endTimeMs] of this.blacklistedPeerIds.entries()) {
+      if (endTimeMs < currentTimeMs) {
+        this.blacklistedPeerIds.delete(peerIdStr);
+      }
+    }
+  };
+
   /**
    * Request discv5 to find peers if there is no query in progress
    */
@@ -442,8 +481,14 @@ export class PeerDiscovery {
     syncnets: boolean[],
     custodySubnetCount?: number
   ): DiscoveredPeerStatus {
+    const peerIdStr = peerId.toString();
+    if (this.blacklistedPeerIds.has(peerIdStr)) {
+      this.logger.warn("blacklisted peer was rediscovered. enforcing cool-off period", {peerId: peerIdStr});
+      return DiscoveredPeerStatus.blacklisted;
+    }
+
     const nodeId = computeNodeId(peerId);
-    this.logger.warn("handleDiscoveredPeer", {nodeId: toHexString(nodeId), peerId: peerId.toString()});
+    this.logger.warn("handleDiscoveredPeer", {nodeId: toHexString(nodeId), peerId: peerIdStr});
     try {
       // Check if peer is not banned or disconnected
       if (this.peerRpcScores.getScoreState(peerId) !== ScoreState.Healthy) {
@@ -486,7 +531,7 @@ export class PeerDiscovery {
       }
 
       // Add to pending good peers with a last seen time
-      this.cachedENRs.set(peerId.toString(), cachedPeer);
+      this.cachedENRs.set(peerIdStr, cachedPeer);
       const dropped = pruneSetToMax(this.cachedENRs, MAX_CACHED_ENRS);
       // If the cache was already full, count the peer as dropped
       return dropped > 0 ? DiscoveredPeerStatus.dropped : DiscoveredPeerStatus.cached;

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -190,7 +190,7 @@ export class PeerDiscovery {
     if (metrics) {
       metrics.discovery.cachedENRsSize.addCollect(() => {
         metrics.discovery.cachedENRsSize.set(this.cachedENRs.size);
-        metrics.discovery.blacklistedPeersSize.set(this.blacklistedPeerIds.size);
+        metrics.discovery.blacklistedPeerIdsSize.set(this.blacklistedPeerIds.size);
         metrics.discovery.peersToConnect.set(this.peersToConnect);
 
         // PeerDAS metrics
@@ -382,8 +382,10 @@ export class PeerDiscovery {
     }
 
     pruneSetToMax(this.blacklistedPeerIds, MAX_BLACKLISTED_PEER_IDS, (a, b) => {
-      const t1 = this.blacklistedPeerIds.get(a);
-      const t2 = this.blacklistedPeerIds.get(b);
+      // biome-ignore lint/style/noNonNullAssertion: pulled from Map so must exist
+      const t1 = this.blacklistedPeerIds.get(a)!;
+      // biome-ignore lint/style/noNonNullAssertion: pulled from Map so must exist
+      const t2 = this.blacklistedPeerIds.get(b)!;
       return t2 - t1; // remove oldest first
     });
   };

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -1,5 +1,5 @@
 import {BitArray, toHexString} from "@chainsafe/ssz";
-import {Connection, PeerId, PrivateKey} from "@libp2p/interface";
+import {Connection, Direction, PeerId, PrivateKey} from "@libp2p/interface";
 import {BeaconConfig} from "@lodestar/config";
 import {LoggerNode} from "@lodestar/logger/node";
 import {ForkSeq, SLOTS_PER_EPOCH, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
@@ -778,8 +778,8 @@ export class PeerManager {
 
     // remove the ping and status timer for the peer
     this.connectedPeers.delete(peerIdStr);
-    this.discovery.blacklistPeer(peerIdStr);
-    this.logger.verbose("a peer disconnected", {peer: prettyPrintPeerIdStr(peerIdStr), direction, status});
+    this.discovery.blacklistPeer(peerIdStr, "inbound");
+    this.logger.verbose("a peer disconnected us", {peer: prettyPrintPeerIdStr(peerIdStr), direction, status});
     this.networkEventBus.emit(NetworkEvent.peerDisconnected, {peer: peerIdStr});
     this.metrics?.peerDisconnectedEvent.inc({direction});
     this.libp2p.peerStore
@@ -796,12 +796,13 @@ export class PeerManager {
   }
 
   private async goodbyeAndDisconnect(peer: PeerId, goodbye: GoodByeReasonCode): Promise<void> {
+    const peerIdStr = peer.toString();
     try {
       const reason = GOODBYE_KNOWN_CODES[goodbye.toString()] || "";
       this.metrics?.peerGoodbyeSent.inc({reason});
-      this.logger.debug("disconnected a peer", {reason, peerId: prettyPrintPeerId(peer)});
+      this.logger.debug("we disconnected a peer", {reason, peerId: prettyPrintPeerIdStr(peerIdStr)});
 
-      const conn = getConnection(this.libp2p, peer.toString());
+      const conn = getConnection(this.libp2p, peerIdStr);
       if (conn && Date.now() - conn.timeline.open > LONG_PEER_CONNECTION_MS) {
         this.metrics?.peerLongConnectionDisconnect.inc({reason});
       }
@@ -809,8 +810,9 @@ export class PeerManager {
       // Wrap with shorter timeout than regular ReqResp requests to speed up shutdown
       await withTimeout(() => this.reqResp.sendGoodbye(peer, BigInt(goodbye)), 1_000);
     } catch (e) {
-      this.logger.verbose("Failed to send goodbye", {peer: prettyPrintPeerId(peer)}, e as Error);
+      this.logger.verbose("Failed to send goodbye", {peer: prettyPrintPeerIdStr(peerIdStr)}, e as Error);
     } finally {
+      this.discovery.blacklistPeer(peerIdStr, "outbound");
       await this.disconnect(peer);
     }
   }

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -778,7 +778,7 @@ export class PeerManager {
 
     // remove the ping and status timer for the peer
     this.connectedPeers.delete(peerIdStr);
-    this.discovery.blacklistPeer(peerIdStr, "inbound");
+    this.discovery?.blacklistPeer(peerIdStr, "inbound");
     this.logger.verbose("a peer disconnected us", {peer: prettyPrintPeerIdStr(peerIdStr), direction, status});
     this.networkEventBus.emit(NetworkEvent.peerDisconnected, {peer: peerIdStr});
     this.metrics?.peerDisconnectedEvent.inc({direction});
@@ -812,7 +812,7 @@ export class PeerManager {
     } catch (e) {
       this.logger.verbose("Failed to send goodbye", {peer: prettyPrintPeerIdStr(peerIdStr)}, e as Error);
     } finally {
-      this.discovery.blacklistPeer(peerIdStr, "outbound");
+      this.discovery?.blacklistPeer(peerIdStr, "outbound");
       await this.disconnect(peer);
     }
   }

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -1,5 +1,5 @@
 import {BitArray, toHexString} from "@chainsafe/ssz";
-import {Connection, Direction, PeerId, PrivateKey} from "@libp2p/interface";
+import {Connection, PeerId, PrivateKey} from "@libp2p/interface";
 import {BeaconConfig} from "@lodestar/config";
 import {LoggerNode} from "@lodestar/logger/node";
 import {ForkSeq, SLOTS_PER_EPOCH, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -18,7 +18,7 @@ import {NetworkConfig} from "../networkConfig.js";
 import {ReqRespMethod} from "../reqresp/ReqRespBeaconNode.js";
 import {StatusCache} from "../statusCache.js";
 import {NodeId, SubnetsService, computeNodeId} from "../subnets/index.js";
-import {getConnection, getConnectionsMap, prettyPrintPeerId} from "../util.js";
+import {getConnection, getConnectionsMap, prettyPrintPeerId, prettyPrintPeerIdStr} from "../util.js";
 import {ClientKind, getKnownClientFromAgentVersion} from "./client.js";
 import {PeerDiscovery, SubnetDiscvQueryMs} from "./discover.js";
 import {PeerData, PeersData} from "./peersData.js";
@@ -774,16 +774,17 @@ export class PeerManager {
    */
   private onLibp2pPeerDisconnect = (evt: CustomEvent<Connection>): void => {
     const {direction, status, remotePeer} = evt.detail;
+    const peerIdStr = remotePeer.toString();
 
     // remove the ping and status timer for the peer
-    this.connectedPeers.delete(remotePeer.toString());
-
-    this.logger.verbose("peer disconnected", {peer: prettyPrintPeerId(remotePeer), direction, status});
-    this.networkEventBus.emit(NetworkEvent.peerDisconnected, {peer: remotePeer.toString()});
+    this.connectedPeers.delete(peerIdStr);
+    this.discovery.blacklistPeer(peerIdStr);
+    this.logger.verbose("a peer disconnected", {peer: prettyPrintPeerIdStr(peerIdStr), direction, status});
+    this.networkEventBus.emit(NetworkEvent.peerDisconnected, {peer: peerIdStr});
     this.metrics?.peerDisconnectedEvent.inc({direction});
     this.libp2p.peerStore
       .merge(remotePeer, {tags: {[PEER_RELEVANT_TAG]: undefined}})
-      .catch((e) => this.logger.verbose("cannot untag peer", {peerId: remotePeer.toString()}, e as Error));
+      .catch((e) => this.logger.verbose("cannot untag peer", {peerId: peerIdStr}, e as Error));
   };
 
   private async disconnect(peer: PeerId): Promise<void> {
@@ -798,7 +799,7 @@ export class PeerManager {
     try {
       const reason = GOODBYE_KNOWN_CODES[goodbye.toString()] || "";
       this.metrics?.peerGoodbyeSent.inc({reason});
-      this.logger.debug("disconnected peer", {reason, peerId: prettyPrintPeerId(peer)});
+      this.logger.debug("disconnected a peer", {reason, peerId: prettyPrintPeerId(peer)});
 
       const conn = getConnection(this.libp2p, peer.toString());
       if (conn && Date.now() - conn.timeline.open > LONG_PEER_CONNECTION_MS) {


### PR DESCRIPTION
**Motivation**

Fixes #8040

During fusaka-devnet-2 an issue was identified.  There is a bug in Nimbus where they disconnect us for bad protocol negotiation from lack of StatusV2 support on their end.  We get disconnected and then we immediately redial the same peer.  See issue #8040.

Adds cool-down period (initially set to 1hr) where the peer will not get redialed.  Also prevents the peer from getting rediscovered during the blacklist period.  After period is over the peer is removed from the blacklist and can be rediscovered.  Debated whether to add the peer back to the `cachedENRs` but thought better not to add a peer that disconnected us or we disconnected to promote other peers getting promoted and connected.  Once the peer is removed from the blacklist they can be rediscovered naturally though.

Add an interval, initially set to 5 minutes, for going through the blacklist to prune entries that have cooled off for the designated period of time.

Added `MAX_BLACKLISTED_PEER_IDS` to prevent the map from getting too large.  Sorts to remove oldest entries first.