### PR TITLE
fix: remove getAttestationsForBlockPreElectra

### DIFF
--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -5,7 +5,6 @@ import {IForkChoice} from "@lodestar/fork-choice";
 import {
   ForkName,
   ForkSeq,
-  MAX_ATTESTATIONS,
   MAX_ATTESTATIONS_ELECTRA,
   MAX_COMMITTEES_PER_SLOT,
   MIN_ATTESTATION_INCLUSION_DELAY,
@@ -45,8 +44,6 @@ type DataRootHex = string;
 
 type CommitteeIndex = number;
 
-// for pre-electra
-type AttestationWithScore = {attestation: Attestation; score: number};
 /**
  * for electra, this is to consolidate aggregated attestations of the same attestation data into a single attestation to be included in block
  * note that this is local definition in this file and it's NOT validator consolidation
@@ -100,15 +97,6 @@ const MAX_RETAINED_ATTESTATIONS_PER_GROUP = 4;
  * committee member for previous slot.
  */
 const MAX_RETAINED_ATTESTATIONS_PER_GROUP_ELECTRA = 8;
-
-/**
- * Pre-electra, each slot has 64 committees, and each block has 128 attestations max so in average
- * we get 2 attestation per groups.
- * Starting from Jan 2024, we have a performance issue getting attestations for a block. Based on the
- * fact that lot of groups will have only 1 full participation attestation, increase this number
- * a bit higher than average. This also help decrease number of slots to search for attestations.
- */
-const MAX_ATTESTATIONS_PER_GROUP = 3;
 
 /**
  * For electra, there is on chain aggregation of attestations across committees, so we can just pick up to 8
@@ -217,122 +205,12 @@ export class AggregatedAttestationPool {
   }
 
   getAttestationsForBlock(fork: ForkName, forkChoice: IForkChoice, state: CachedBeaconStateAllForks): Attestation[] {
+    // since Jul 2025, only support electra
     const forkSeq = ForkSeq[fork];
-    return forkSeq >= ForkSeq.electra
-      ? this.getAttestationsForBlockElectra(fork, forkChoice, state)
-      : this.getAttestationsForBlockPreElectra(fork, forkChoice, state);
-  }
-
-  /**
-   * Get attestations to be included in a block pre-electra. Returns up to $MAX_ATTESTATIONS items
-   */
-  getAttestationsForBlockPreElectra(
-    fork: ForkName,
-    forkChoice: IForkChoice,
-    state: CachedBeaconStateAllForks
-  ): phase0.Attestation[] {
-    const stateSlot = state.slot;
-    const stateEpoch = state.epochCtx.epoch;
-    const statePrevEpoch = stateEpoch - 1;
-
-    const notSeenValidatorsFn = getNotSeenValidatorsFn(state);
-    const validateAttestationDataFn = getValidateAttestationDataFn(forkChoice, state);
-
-    const attestationsByScore: AttestationWithScore[] = [];
-
-    const slots = Array.from(this.attestationGroupByIndexByDataHexBySlot.keys()).sort((a, b) => b - a);
-    let minScore = Number.MAX_SAFE_INTEGER;
-    let slotCount = 0;
-    slot: for (const slot of slots) {
-      slotCount++;
-      const attestationGroupByIndexByDataHash = this.attestationGroupByIndexByDataHexBySlot.get(slot);
-      // should not happen
-      if (!attestationGroupByIndexByDataHash) {
-        throw Error(`No aggregated attestation pool for slot=${slot}`);
-      }
-
-      const epoch = computeEpochAtSlot(slot);
-      // validateAttestation condition: Attestation target epoch not in previous or current epoch
-      if (!(epoch === stateEpoch || epoch === statePrevEpoch)) {
-        continue; // Invalid attestations
-      }
-      // validateAttestation condition: Attestation slot not within inclusion window
-      if (
-        !(
-          slot + MIN_ATTESTATION_INCLUSION_DELAY <= stateSlot &&
-          // Post deneb, attestations are valid for current and previous epoch
-          (ForkSeq[fork] >= ForkSeq.deneb || stateSlot <= slot + SLOTS_PER_EPOCH)
-        )
-      ) {
-        continue; // Invalid attestations
-      }
-
-      const inclusionDistance = stateSlot - slot;
-      for (const attestationGroupByIndex of attestationGroupByIndexByDataHash.values()) {
-        for (const [committeeIndex, attestationGroup] of attestationGroupByIndex.entries()) {
-          const notSeenCommitteeMembers = notSeenValidatorsFn(epoch, slot, committeeIndex);
-          if (notSeenCommitteeMembers === null || notSeenCommitteeMembers.size === 0) {
-            continue;
-          }
-
-          if (
-            slotCount > 2 &&
-            attestationsByScore.length >= MAX_ATTESTATIONS &&
-            notSeenCommitteeMembers.size / inclusionDistance < minScore
-          ) {
-            // after 2 slots, there are a good chance that we have 2 * MAX_ATTESTATIONS attestations and break the for loop early
-            // if not, we may have to scan all slots in the pool
-            // if we have enough attestations and the max possible score is lower than scores of `attestationsByScore`, we should skip
-            // otherwise it takes time to check attestation, add it and remove it later after the sort by score
-            continue;
-          }
-
-          if (validateAttestationDataFn(attestationGroup.data) !== null) {
-            continue;
-          }
-
-          // TODO: Is it necessary to validateAttestation for:
-          // - Attestation committee index not within current committee count
-          // - Attestation aggregation bits length does not match committee length
-          //
-          // These properties should not change after being validate in gossip
-          // IF they have to be validated, do it only with one attestation per group since same data
-          // The committeeCountPerSlot can be precomputed once per slot
-          const getAttestationsResult = attestationGroup.getAttestationsForBlock(
-            fork,
-            state.epochCtx.effectiveBalanceIncrements,
-            notSeenCommitteeMembers,
-            MAX_ATTESTATIONS_PER_GROUP
-          );
-          for (const {attestation, newSeenEffectiveBalance} of getAttestationsResult.result) {
-            const score = newSeenEffectiveBalance / inclusionDistance;
-            if (score < minScore) {
-              minScore = score;
-            }
-            attestationsByScore.push({
-              attestation,
-              score,
-            });
-          }
-
-          // Stop accumulating attestations there are enough that may have good scoring
-          if (attestationsByScore.length >= MAX_ATTESTATIONS * 2) {
-            break slot;
-          }
-        }
-      }
+    if (forkSeq < ForkSeq.electra) {
+      throw Error(`Not support producing block for fork ${fork} slot ${state.slot}`);
     }
-
-    const sortedAttestationsByScore = attestationsByScore.sort((a, b) => b.score - a.score);
-    const attestationsForBlock: phase0.Attestation[] = [];
-    for (const [i, attestationWithScore] of sortedAttestationsByScore.entries()) {
-      if (i >= MAX_ATTESTATIONS) {
-        break;
-      }
-      // attestations could be modified in this op pool, so we need to clone for block
-      attestationsForBlock.push(ssz.phase0.Attestation.clone(attestationWithScore.attestation));
-    }
-    return attestationsForBlock;
+    return this.getAttestationsForBlockElectra(fork, forkChoice, state);
   }
 
   /**


### PR DESCRIPTION
**Motivation**

- to reduce the maintenance cost for flows we don't use anymore

**Description**

- stop support producing blocks pre-electra

part of #8028