### PR TITLE
fix: await builder header response before capturing timing metric

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -185,7 +185,7 @@ export async function produceBlockBody<T extends BlockType>(
           slot: blockSlot,
           proposerPubKey: toHex(proposerPubKey),
         });
-        const headerRes = prepareExecutionPayloadHeader(
+        const headerRes = await prepareExecutionPayloadHeader(
           this,
           fork,
           currentState as CachedBeaconStateBellatrix,


### PR DESCRIPTION
**Motivation**

As noted by @twoeths we don't correctly track time of builder header response

<img width="2630" height="1336" alt="image" src="https://github.com/user-attachments/assets/3d6afaab-0141-4609-bcc2-cb18b6d147e8" />

this is due to the fact that we don't await the promise before capturing the timing metric

**Description**

Add missing `await` to `prepareExecutionPayloadHeader` to correctly capture timing of builder header response. This makes no difference logically as promise would have been awaited later. 
