### PR TITLE
feat: broken status get peers

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -5,8 +5,9 @@ import {peerIdFromPrivateKey} from "@libp2p/peer-id";
 import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
+import {isForkPostFulu} from "@lodestar/params";
 import {ResponseIncoming} from "@lodestar/reqresp";
-import {Epoch, Status, sszTypesFor} from "@lodestar/types";
+import {Epoch, Status, fulu, sszTypesFor} from "@lodestar/types";
 import {multiaddr} from "@multiformats/multiaddr";
 import {formatNodePeer} from "../../api/impl/node/utils.js";
 import {RegistryMetricCreator} from "../../metrics/index.js";
@@ -415,6 +416,10 @@ export class NetworkCore implements INetworkCore {
   private _dumpPeer(peerIdStr: string, connections: Connection[]): routes.lodestar.LodestarNodePeer {
     const peerData = this.peersData.connectedPeers.get(peerIdStr);
     const fork = this.config.getForkName(this.clock.currentSlot);
+    if (isForkPostFulu(fork) && peerData?.status) {
+      (peerData.status as fulu.Status).earliestAvailableSlot =
+        (peerData.status as fulu.Status).earliestAvailableSlot ?? 0;
+    }
     return {
       ...formatNodePeer(peerIdStr, connections),
       status: peerData?.status ? sszTypesFor(fork).Status.toJson(peerData.status) : null,


### PR DESCRIPTION
**Motivation**

fixes #8007

peers that survive across fork boundary have old status in peer manager and ssz.toJson fails if the value is undefined


**Duplicate PR as #8021 but merges to `peerDAS` branch**