### PR TITLE
fix: only check genesis state root if network is specified

### DIFF
--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -190,7 +190,7 @@ export async function initBeaconState(
     const anchorState = getStateTypeFromBytes(chainForkConfig, stateBytes).deserializeToViewDU(stateBytes);
     // Validate genesis state root
     const stateRoot = toRootHex(anchorState.hashTreeRoot());
-    const expectedRoot = getGenesisStateRoot(args.network || defaultNetwork);
+    const expectedRoot = getGenesisStateRoot(args.network);
     if (expectedRoot !== null && stateRoot !== expectedRoot) {
       throw Error(`Genesis state root mismatch expected=${expectedRoot} received=${stateRoot}`);
     }

--- a/packages/cli/src/networks/index.ts
+++ b/packages/cli/src/networks/index.ts
@@ -96,7 +96,10 @@ export function getGenesisFileUrl(network: NetworkName): string | null {
  * For example, this returns null for Ephemery, since its genesis state root
  * changes with each iteration and we don't know the permanent state root.
  */
-export function getGenesisStateRoot(network: NetworkName): string | null {
+export function getGenesisStateRoot(network: NetworkName | undefined): string | null {
+  if (!network) {
+    return null;
+  }
   return getNetworkData(network).genesisStateRoot;
 }
 


### PR DESCRIPTION
**Motivation**

Noticed https://github.com/ChainSafe/lodestar/pull/7841 breaks kurtosis runs as we check against mainnet genesis state root as it's the `defaultNetwork`.

**Description**

Only check genesis state root if network is specified, since this isn't really relevant for mainnet anyways and just new networks that are launched it doesn't really make a difference as in those cases we explicitly need to set `--network` and genesis state root check will be done.