### PR TITLE
chore: update peerDAS kzg library to v0.8

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -103,7 +103,7 @@
     "@chainsafe/pubkey-index-map": "^3.0.0",
     "@chainsafe/ssz": "^1.2.1",
     "@chainsafe/threads": "^1.11.2",
-    "@crate-crypto/node-eth-kzg": "^0.7.1",
+    "@crate-crypto/node-eth-kzg": "0.8.0",
     "@ethersproject/abi": "^5.7.0",
     "@fastify/bearer-auth": "^10.0.1",
     "@fastify/cors": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -848,47 +848,47 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@crate-crypto/node-eth-kzg-darwin-arm64@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg-darwin-arm64/-/node-eth-kzg-darwin-arm64-0.7.1.tgz#1fd9fcc58051a7de306ffc1328b80c0da521fa7e"
-  integrity sha512-t0VJCpkz1wYlCnm7USrRtiAS+j74C0xnEuqy+nOLmFIG/zEjHy0QW5/t42mfMo+wgejhhtG0iT/x0efgC6eNyA==
+"@crate-crypto/node-eth-kzg-darwin-arm64@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg-darwin-arm64/-/node-eth-kzg-darwin-arm64-0.8.0.tgz#d1581b70eae95dc17c3bfc381eb01d91bc00cf9f"
+  integrity sha512-O3UloqPV40wWEgHmVQO475W2En7cZPa0fs2hnWBBpkyHr6G0rXw9a+TEXX6lJm7r8ZMlny7oU2ge/xo2Lu1SBA==
 
-"@crate-crypto/node-eth-kzg-darwin-x64@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg-darwin-x64/-/node-eth-kzg-darwin-x64-0.7.1.tgz#e1514e51061cd69b8c7dd85cdd02ce60b9ce9e48"
-  integrity sha512-0fQfHPEMO94cpFaeCU57tDSCLoQh6W9jX7WoC6XUhrlCwgmlvb7k6qk2+S+0U/kaSaNTr+/ISD+9a4oCZlnG3Q==
+"@crate-crypto/node-eth-kzg-darwin-x64@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg-darwin-x64/-/node-eth-kzg-darwin-x64-0.8.0.tgz#dd5fd9e997ffdb692bdf266f9ba8a7e3edc99568"
+  integrity sha512-wk84+ugYI+HhPm0NIysutPT7wuS1zPirpPccRJI4IhPg3tE+pVLH4BMPR3t7M63BLqLdhnD+Ky+kYWzpxgG7iQ==
 
-"@crate-crypto/node-eth-kzg-linux-arm64-gnu@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg-linux-arm64-gnu/-/node-eth-kzg-linux-arm64-gnu-0.7.1.tgz#5c70d17483be6780615f83282c2dbf4b200e4a2d"
-  integrity sha512-SDH6mvQpHnCHFpStUJdeuOayO13v437Sdf9iq6ThSyHypAiMv1YUYPs9IrBRzNoKN8yESZJyHsPzLWtskbpQZA==
+"@crate-crypto/node-eth-kzg-linux-arm64-gnu@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg-linux-arm64-gnu/-/node-eth-kzg-linux-arm64-gnu-0.8.0.tgz#3a2b3a269462a1cf1993d41b7b26411e3fdcd035"
+  integrity sha512-eVgrcOcKxS1y2lwypja5UsNqNM5xYjHQeNsOBbG6c3MEoCD5pCVrMVTABXHJX4HsUHfOBLqbmwABi6Aqt2eHPA==
 
-"@crate-crypto/node-eth-kzg-linux-x64-gnu@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg-linux-x64-gnu/-/node-eth-kzg-linux-x64-gnu-0.7.1.tgz#a355a5b306300fc2f0afc2b9871ba2b8b12718c2"
-  integrity sha512-w0klnqWdA55TSTl21dsj3vVjpvByamFN9JEF83T2Q/YFANo0ki9rlAG+f3Ki0OtROjJzUNJQoHmcjl7+BAhP8Q==
+"@crate-crypto/node-eth-kzg-linux-x64-gnu@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg-linux-x64-gnu/-/node-eth-kzg-linux-x64-gnu-0.8.0.tgz#e0e99f04f8e58411c532a7ca2f838af9ce138c42"
+  integrity sha512-PNEG96jwoKbErAqHEYIHZe1n/60LPz2MdUELnyHrXUbvUoLZzk3eZLTzNv/WlaT1xVocF9P4S4XwCoHaQNFY7g==
 
-"@crate-crypto/node-eth-kzg-win32-arm64-msvc@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg-win32-arm64-msvc/-/node-eth-kzg-win32-arm64-msvc-0.7.1.tgz#2b153424b7643983e8d3fb151fa115510889fea4"
-  integrity sha512-cmfoFHwuaD5+Iy003BxDroACiOFEYsfaZHUohHorv+tIGg02NIA5cBtOcWbAkmAGbnhNNA3853v+2AHqbQ/6Eg==
+"@crate-crypto/node-eth-kzg-win32-arm64-msvc@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg-win32-arm64-msvc/-/node-eth-kzg-win32-arm64-msvc-0.8.0.tgz#cdb11f6b3da36e72214f8773ec919fd024e6e96d"
+  integrity sha512-GQbInTzcH678PLyqhV9BVIxPBMr8eMxDatd3aPGJOmTD/JVUPvxuVR9wB8BbEafKePXx8i+clsih7HX6+ZlCqg==
 
-"@crate-crypto/node-eth-kzg-win32-x64-msvc@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg-win32-x64-msvc/-/node-eth-kzg-win32-x64-msvc-0.7.1.tgz#712c215667b27819ff7071b897939e4c73c2243c"
-  integrity sha512-3CVmBK8AQJuyrBP907AXDDMAmR4Q8lgeN+hz7JRQRsJpmbO5hazRPZP2zaNOcisYENzN3i2btmiNJvDXwEAGew==
+"@crate-crypto/node-eth-kzg-win32-x64-msvc@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg-win32-x64-msvc/-/node-eth-kzg-win32-x64-msvc-0.8.0.tgz#cf1544d8190474f49701368c86b4e7bf8cee28ef"
+  integrity sha512-1WANeqBEg6XQ3U6WY4bqtZlsK3kRFZMC4vXJgC10QV+QViFLrOs09fK7KEQPdPQTRoQAfXJiu1g0yVoj1UIqKg==
 
-"@crate-crypto/node-eth-kzg@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg/-/node-eth-kzg-0.7.1.tgz#b157803aefa6c598fad7329b9d2a73142ded79a5"
-  integrity sha512-JEAqTVtWc+POsRFJh6sR4IRsVK9YuCZ3loHq7jfDDh0k4O5xhoArjJUymP6Fp3g4x9/PcGds/528t+qXHEjhhQ==
+"@crate-crypto/node-eth-kzg@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@crate-crypto/node-eth-kzg/-/node-eth-kzg-0.8.0.tgz#b05f232a8d8c7e452348c481e9b74b68c9d99633"
+  integrity sha512-4O6RLpmzeiMZUPbuKsZ5PffIRBjodQjvhh9xVcmVlTRB8BBMXtCmdJe6MafGMTKum5mD3imce2Wwk0QVb0Ectw==
   optionalDependencies:
-    "@crate-crypto/node-eth-kzg-darwin-arm64" "0.7.1"
-    "@crate-crypto/node-eth-kzg-darwin-x64" "0.7.1"
-    "@crate-crypto/node-eth-kzg-linux-arm64-gnu" "0.7.1"
-    "@crate-crypto/node-eth-kzg-linux-x64-gnu" "0.7.1"
-    "@crate-crypto/node-eth-kzg-win32-arm64-msvc" "0.7.1"
-    "@crate-crypto/node-eth-kzg-win32-x64-msvc" "0.7.1"
+    "@crate-crypto/node-eth-kzg-darwin-arm64" "0.8.0"
+    "@crate-crypto/node-eth-kzg-darwin-x64" "0.8.0"
+    "@crate-crypto/node-eth-kzg-linux-arm64-gnu" "0.8.0"
+    "@crate-crypto/node-eth-kzg-linux-x64-gnu" "0.8.0"
+    "@crate-crypto/node-eth-kzg-win32-arm64-msvc" "0.8.0"
+    "@crate-crypto/node-eth-kzg-win32-x64-msvc" "0.8.0"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"


### PR DESCRIPTION
**Motivation**

This version enables the portable flag for the underlying blst library.
