### PR TITLE
fix: detect weak head when predicting proposer head

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -829,9 +829,9 @@ export class BeaconChain implements IBeaconChain {
     const timer = this.metrics?.forkChoice.findHead.startTimer({caller});
 
     try {
-      return this.forkChoice.updateAndGetHead({mode: UpdateHeadOpt.GetCanonicialHead}).head;
+      return this.forkChoice.updateAndGetHead({mode: UpdateHeadOpt.GetCanonicalHead}).head;
     } catch (e) {
-      this.metrics?.forkChoice.errors.inc({entrypoint: UpdateHeadOpt.GetCanonicialHead});
+      this.metrics?.forkChoice.errors.inc({entrypoint: UpdateHeadOpt.GetCanonicalHead});
       throw e;
     } finally {
       timer?.();

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -136,7 +136,7 @@ export class PrepareNextSlotScheduler {
 
           // If we predict we can reorg, update prepareState with proposer head block
           if (proposerHeadRoot !== headRoot || proposerHeadSlot !== headSlot) {
-            this.logger.verbose("Weak head detected. May build on this block instead:", {
+            this.logger.verbose("Weak head detected. May build on parent block instead", {
               proposerHeadSlot,
               proposerHeadRoot,
               headSlot,

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -128,7 +128,7 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
         name: "beacon_fork_choice_indices_count",
         help: "Current count of indices in fork choice data structures",
       }),
-      notReorgedReason: register.gauge<{reason: NotReorgedReason}>({
+      notReorgedReason: register.counter<{reason: NotReorgedReason}>({
         name: "beacon_fork_choice_not_reorged_reason_total",
         help: "Reason why the current head is not re-orged out",
         labelNames: ["reason"],


### PR DESCRIPTION
**Motivation**

There was a regression in https://github.com/ChainSafe/lodestar/pull/7810 which caused us to not detect weak head when predicting proposer head.

**Description**

This PR addresses the issue to correctly detect weak head when predicting proposer head and updates few logs / misc changes while reviewing the code.

I tested this on Kurtosis by artificially delaying some blocks. Let's look at the example of proposer for slot 54 which re-orged out the late block from slot 53.

The block was received after 4 seconds into the slot via gossip
```
Received gossip block slot=53, root=0x77cc…92e1, currentSlot=53, peerId=16Uiu2HAmQ8AL3EKjxSs7V6AG1CA4xMXvWXnVEZ6jybSShxCX48Fy, delaySec=4.1579999923706055, pending=null, haveBlobs=0, expectedBlobs=0, recvToValLatency=0.003000020980834961
```
We correctly determined during block import that it's a weak block and skipped fcu call
```
Block is weak. Should override forkchoice update blockRoot=0x77cc3e39bc0c843f25c9556141f30e16901516a49dfb956fdc68e9c6f98592e1, slot=53
Weak block detected. Skip fcu call in importBlock blockRoot=0x77cc3e39bc0c843f25c9556141f30e16901516a49dfb956fdc68e9c6f98592e1, slot=53
```
When preparing next slot, we predicted that next block will be built on parent (at start of next slot)
```
Current head is weak. Predicting next block to be built on parent of head. slot=53, weakHead=0x77cc3e39bc0c843f25c9556141f30e16901516a49dfb956fdc68e9c6f98592e1, proposerHead=0xfe8dfdd3ebc9715bbf9fac23d14024cf9dc29bfe78d352a9ea7eeea5f8cd25f1
```
Which turned out to be the case and we re-orged out the weak head
```
Performing single-slot reorg to remove current weak head slot=54, proposerHead=0xfe8dfdd3ebc9715bbf9fac23d14024cf9dc29bfe78d352a9ea7eeea5f8cd25f1, weakHead=0x77cc3e39bc0c843f25c9556141f30e16901516a49dfb956fdc68e9c6f98592e1
```
The node (and other nodes) detected and accepted the re-org as part of canonical chain
```
Chain reorg depth=2, epoch=1, slot=54, newHeadBlock=0x39be0f98e895e91bf245535becb2ef8d631abe9be6602cce87473d94719099d0, oldHeadBlock=0x77cc3e39bc0c843f25c9556141f30e16901516a49dfb956fdc68e9c6f98592e1, newHeadState=0x5afc8b88b1b805797ea1a37b86f956fb5560bf8bbfe3ed4a449f4cae1851cb6d, oldHeadState=0x2d79bf2fb26881b4efa41bedeae8181fb7f430ddaec839175baeb26a3250045c, executionOptimistic=false
```

<img width="726" height="503" alt="image" src="https://github.com/user-attachments/assets/7298fe6f-cb4c-4de7-b5ce-f322bcfc7ca0" />
