### PR TITLE
feat: enable proposer boost reorg by default

### DIFF
--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -103,7 +103,7 @@ export const defaultChainOptions: IChainOptions = {
   blacklistedBlocks: [],
   disableBlsBatchVerify: false,
   proposerBoost: true,
-  proposerBoostReorg: false,
+  proposerBoostReorg: true,
   computeUnrealized: true,
   safeSlotsToImportOptimistically: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY,
   suggestedFeeRecipient: defaultValidatorOptions.suggestedFeeRecipient,

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -28,7 +28,7 @@ describe("produceBlockBody", () => {
     chain = new BeaconChain(
       {
         proposerBoost: true,
-        proposerBoostReorg: false,
+        proposerBoostReorg: true,
         computeUnrealized: false,
         safeSlotsToImportOptimistically: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY,
         disableArchiveOnCheckpoint: true,

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -77,7 +77,7 @@ describe.skip("verify+import blocks - range sync perf test", () => {
       const chain = new BeaconChain(
         {
           proposerBoost: true,
-          proposerBoostReorg: false,
+          proposerBoostReorg: true,
           computeUnrealized: false,
           safeSlotsToImportOptimistically: SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY,
           disableArchiveOnCheckpoint: true,


### PR DESCRIPTION
**Motivation**

Based on https://github.com/ChainSafe/lodestar/pull/8079 our proposer boost reorg implementation works as expected. To get more test coverage and observe it on actual networks it makes sense to enable by default.

**Description**

Enable proposer boost reorg by default