### PR TITLE
fix: call `afterProcessEpoch` after upgrading state to next fork

### DIFF
--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -246,14 +246,6 @@ function processSlotsWithTransientCache(
 
       postState.slot++;
 
-      // Running commit here is not strictly necessary. The cost of running commit twice (here + after process block)
-      // Should be negligible but gives better metrics to differentiate the cost of it for block and epoch proc.
-      {
-        const timer = metrics?.epochTransitionCommitTime.startTimer();
-        postState.commit();
-        timer?.();
-      }
-
       // Upgrade state if exactly at epoch boundary
       const stateEpoch = computeEpochAtSlot(postState.slot);
       if (stateEpoch === config.ALTAIR_FORK_EPOCH) {
@@ -278,6 +270,14 @@ function processSlotsWithTransientCache(
       {
         const timer = metrics?.epochTransitionStepTime.startTimer({step: EpochTransitionStep.afterProcessEpoch});
         postState.epochCtx.afterProcessEpoch(postState, epochTransitionCache);
+        timer?.();
+      }
+
+      // Running commit here is not strictly necessary. The cost of running commit twice (here + after process block)
+      // Should be negligible but gives better metrics to differentiate the cost of it for block and epoch proc.
+      {
+        const timer = metrics?.epochTransitionCommitTime.startTimer();
+        postState.commit();
         timer?.();
       }
 

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -246,12 +246,6 @@ function processSlotsWithTransientCache(
 
       postState.slot++;
 
-      {
-        const timer = metrics?.epochTransitionStepTime.startTimer({step: EpochTransitionStep.afterProcessEpoch});
-        postState.epochCtx.afterProcessEpoch(postState, epochTransitionCache);
-        timer?.();
-      }
-
       // Running commit here is not strictly necessary. The cost of running commit twice (here + after process block)
       // Should be negligible but gives better metrics to differentiate the cost of it for block and epoch proc.
       {
@@ -259,9 +253,6 @@ function processSlotsWithTransientCache(
         postState.commit();
         timer?.();
       }
-
-      // Note: time only on success. Include beforeProcessEpoch, processEpoch, afterProcessEpoch, commit
-      epochTransitionTimer?.();
 
       // Upgrade state if exactly at epoch boundary
       const stateEpoch = computeEpochAtSlot(postState.slot);
@@ -283,6 +274,15 @@ function processSlotsWithTransientCache(
       if (stateEpoch === config.FULU_FORK_EPOCH) {
         postState = upgradeStateToFulu(postState as CachedBeaconStateElectra) as CachedBeaconStateAllForks;
       }
+
+      {
+        const timer = metrics?.epochTransitionStepTime.startTimer({step: EpochTransitionStep.afterProcessEpoch});
+        postState.epochCtx.afterProcessEpoch(postState, epochTransitionCache);
+        timer?.();
+      }
+
+      // Note: time only on success. Include beforeProcessEpoch, processEpoch, afterProcessEpoch, commit
+      epochTransitionTimer?.();
     } else {
       postState.slot++;
     }


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/pull/7988#pullrequestreview-3049726981
> as discussed, the last issue I found with this work is proposers not assigned for the 1st fulu epoch

**Description**

Call `afterProcessEpoch` after upgrading state to next fork, mostly relevant for fulu to call it after `upgradeStateToFulu`
