### PR TITLE
feat: store more SingleAttestation slots

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -69,6 +69,7 @@ import {
 import {ChainEvent, CheckpointHex, CommonBlockBody} from "../../../chain/index.js";
 import {SCHEDULER_LOOKAHEAD_FACTOR} from "../../../chain/prepareNextSlot.js";
 import {RegenCaller} from "../../../chain/regen/index.js";
+import {AggregationInfo} from "../../../chain/seenCache/seenAggregateAndProof.js";
 import {validateApiAggregateAndProof} from "../../../chain/validation/index.js";
 import {validateSyncCommitteeGossipContributionAndProof} from "../../../chain/validation/syncCommitteeContributionAndProof.js";
 import {ZERO_HASH} from "../../../constants/index.js";
@@ -1273,23 +1274,30 @@ export function getValidatorApi(
           try {
             // TODO: Validate in batch
             const validateFn = () => validateApiAggregateAndProof(fork, chain, signedAggregateAndProof);
-            const {slot, beaconBlockRoot} = signedAggregateAndProof.message.aggregate.data;
+            const {slot, beaconBlockRoot, target} = signedAggregateAndProof.message.aggregate.data;
             // when a validator is configured with multiple beacon node urls, this attestation may come from another beacon node
             // and the block hasn't been in our forkchoice since we haven't seen / processing that block
             // see https://github.com/ChainSafe/lodestar/issues/5098
-            const {indexedAttestation, committeeIndices, attDataRootHex} = await validateGossipFnRetryUnknownRoot(
-              validateFn,
-              network,
-              chain,
-              slot,
-              beaconBlockRoot
-            );
+            const {indexedAttestation, committeeIndices, attDataRootHex, committeeIndex} =
+              await validateGossipFnRetryUnknownRoot(validateFn, network, chain, slot, beaconBlockRoot);
 
             const insertOutcome = chain.aggregatedAttestationPool.add(
               signedAggregateAndProof.message.aggregate,
               attDataRootHex,
               indexedAttestation.attestingIndices.length,
               committeeIndices
+            );
+            const aggregationInto: AggregationInfo = {
+              aggregationBits: signedAggregateAndProof.message.aggregate.aggregationBits,
+              trueBitCount: indexedAttestation.attestingIndices.length,
+            };
+            chain.addSeenAgregatedAttestation(
+              slot,
+              target.epoch,
+              committeeIndex,
+              attDataRootHex,
+              aggregationInto,
+              false
             );
             metrics?.opPool.aggregatedAttestationPool.apiInsertOutcome.inc({insertOutcome});
 

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -523,6 +523,8 @@ export function addAttestationPostElectra(
       const aggregationBits = BitArray.fromBoolArray(aggregationBools.slice(offset, offset + committee.length));
       const trueBitCount = aggregationBits.getTrueBitIndexes().length;
       offset += committee.length;
+      // no need to add to SingleAttestationPool because this block could be reorged
+      // it will also slow down the block import process
       this.seenAggregatedAttestations.add(
         target.epoch,
         committeeIndices[i],

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -24,6 +24,7 @@ import {
   BeaconBlock,
   BlindedBeaconBlock,
   BlindedBeaconBlockBody,
+  CommitteeIndex,
   Epoch,
   ExecutionPayload,
   Root,
@@ -95,7 +96,7 @@ import {
   SeenSyncCommitteeMessages,
 } from "./seenCache/index.js";
 import {SeenGossipBlockInput} from "./seenCache/index.js";
-import {SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof.js";
+import {AggregationInfo, SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof.js";
 import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
 import {SeenBlockAttesters} from "./seenCache/seenBlockAttesters.js";
 import {SeenBlockInputCache} from "./seenCache/seenBlockInput.js";
@@ -993,6 +994,18 @@ export class BeaconChain implements IBeaconChain {
 
     // should always be the current epoch of the active context so no need to await a result from the ShufflingCache
     return state.epochCtx.getShufflingAtEpoch(attEpoch);
+  }
+
+  addSeenAgregatedAttestation(
+    slot: Slot,
+    targetEpoch: Epoch,
+    committeeIndex: CommitteeIndex,
+    attDataRoot: RootHex,
+    newItem: AggregationInfo,
+    checkIsKnown: boolean
+  ): void {
+    this.seenAggregatedAttestations.add(targetEpoch, committeeIndex, attDataRoot, newItem, checkIsKnown);
+    this.singleAttestationPool.seenAggregatedAttestation(slot, attDataRoot, committeeIndex, newItem.aggregationBits);
   }
 
   /**

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -11,6 +11,7 @@ import {
 import {
   BeaconBlock,
   BlindedBeaconBlock,
+  CommitteeIndex,
   Epoch,
   ExecutionPayload,
   Root,
@@ -58,7 +59,7 @@ import {
   SeenSyncCommitteeMessages,
 } from "./seenCache/index.js";
 import {SeenGossipBlockInput} from "./seenCache/index.js";
-import {SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof.js";
+import {AggregationInfo, SeenAggregatedAttestations} from "./seenCache/seenAggregateAndProof.js";
 import {SeenAttestationDatas} from "./seenCache/seenAttestationData.js";
 import {SeenBlockAttesters} from "./seenCache/seenBlockAttesters.js";
 import {SeenBlockInputCache} from "./seenCache/seenBlockInput.js";
@@ -262,6 +263,15 @@ export interface IBeaconChain {
     blockRef: BeaconBlock | BlindedBeaconBlock,
     validatorIds?: (ValidatorIndex | string)[]
   ): Promise<SyncCommitteeRewards>;
+
+  addSeenAgregatedAttestation(
+    slot: Slot,
+    targetEpoch: Epoch,
+    committeeIndex: CommitteeIndex,
+    attDataRoot: RootHex,
+    newItem: AggregationInfo,
+    checkIsKnown: boolean
+  ): void;
 }
 
 export type SSZObjectType =

--- a/packages/beacon-node/src/chain/opPools/singleAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/singleAttestationPool.ts
@@ -118,6 +118,8 @@ export class SingleAttestationPool {
 
     // remove SingleAttestation for this committee index, we have it in AggregatedAttestationPool
     const singleAttestations = committeeInfo.attestations;
+    // loop through singleAttestations instead of aggregationBits because after the 1st seen aggregated attestation,
+    // there is few/zero SingleAttestations left for the same committee index
     for (const committeeValidatorIndex of singleAttestations.keys()) {
       if (aggregationBits.get(committeeValidatorIndex)) {
         singleAttestations.delete(committeeValidatorIndex);

--- a/packages/beacon-node/src/chain/opPools/singleAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/singleAttestationPool.ts
@@ -1,7 +1,7 @@
 import {Signature, aggregateSignatures} from "@chainsafe/blst";
 import {BitArray} from "@chainsafe/ssz";
-import {ForkPostElectra, MAX_COMMITTEES_PER_SLOT, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {EffectiveBalanceIncrements, computeEpochAtSlot} from "@lodestar/state-transition";
+import {ForkPostElectra, MAX_COMMITTEES_PER_SLOT} from "@lodestar/params";
+import {EffectiveBalanceIncrements, computeEpochAtSlot, computeSlotsSinceEpochStart} from "@lodestar/state-transition";
 import {Attestation, RootHex, SingleAttestation, Slot, phase0} from "@lodestar/types";
 import {MapDef} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
@@ -13,36 +13,6 @@ import {
 } from "./aggregatedAttestationPool.js";
 import {InsertOutcome} from "./types.js";
 import {pruneBySlot, signatureFromBytesNoCheck} from "./utils.js";
-
-/**
- * The number of slots storing SingleAttestation to be included in producing blocks.
- * The beacon node has to subscribe to 2 random (long-lived) subnets plus short-lived subnets for aggregation duties, in avarage it's usually less than 3 per slot.
- * Given a network of 2M active validators, total number of SingleAttestation per slot is up to 2M / 32 / 64 * 3 = 3k
- * Each SingleAttestation includes:
- * - CommitteeIndex: 8 bytes
- * - ValidatorIndex: 8 bytes
- * - AttestationData: this is shared via SeenAttestationDatas so we don't count
- * - Signature: 96 bytes, but NodeJS has some overhead so could be up to 300 bytes
- *
- * So given 3k SingleAttestations per slot, it could cause up to 3k * 316 bytes = 948kB, which is < 1MB per slot.
- * It should not affect beacon node's performance if we store 32MB of SingleAttestation in memory.
- * TODO: only store SingleAttestations when we have proposer duty once proposerLookAhead is implemented in fulu.
- * TODO: monitor on mainnet to see if we need to adject this value
- */
-const MAX_SLOTS_RETAINED = SLOTS_PER_EPOCH;
-
-/**
- * This is mainly for a node subscribing to all subnets, we don't want to spend a lot of memory for this.
- * We store at least 3 recent slots of SingleAttestations to be able to include missing attestations in the next block.
- */
-const MIN_SLOTS_RETAINED = 3;
-
-/**
- * Given an average of 3k SingleAttestations per slot for 2M active validators network, and 32 slots per epoch,
- * we can store up to 100k SingleAttestations in memory.
- * As of Jul 2025, mainnet has ~1.1M active validators so we can store up to 32 slots of SingleAttestations until it reaches 2M active validators.
- */
-const MAX_ATTESTATIONS_RETAINED = 100_000;
 
 /** Hex string of DataRoot `TODO` */
 type DataRootHex = string;
@@ -60,10 +30,8 @@ type CommitteeInfo = {
 /**
  * A pool of `SingleAttestation` that is specially designed to block production.
  *
- * Due to memory constraints, this pool is designed to store attestations for a limited number of slots ranging from 3 to 32
- *   - For a regular node, it is expected to store attestations of 32 recent slots
- *   - For a node subscribing to all subnets, it is expected to store attestations of 3 recent slots
- *
+ * The memory usage of this pool is small because after an aggregated attestation is seen,
+ * all `SingleAttestation` for the same data root and committee index are removed.
  */
 export class SingleAttestationPool {
   /**
@@ -95,10 +63,8 @@ export class SingleAttestationPool {
     committeeSize: number
   ): InsertOutcome {
     const slot = attestation.data.slot;
-    const lowestPermissibleSlot = this.lowestPermissibleSlot;
-
     // Reject any attestations that are too old.
-    if (slot < lowestPermissibleSlot) {
+    if (slot < this.lowestPermissibleSlot) {
       return InsertOutcome.Old;
     }
 
@@ -120,6 +86,43 @@ export class SingleAttestationPool {
 
     committeeInfo.attestations.set(committeeValidatorIndex, attestation);
     return InsertOutcome.NewData;
+  }
+
+  /**
+   * An aggregated attestations was seen, so we remove all SingleAttestations respective to that data
+   * as it's useless for us. In block production it'll prioritize aggregated attestations before reaching this pool.
+   */
+  seenAggregatedAttestation(
+    slot: Slot,
+    attDataRootHex: RootHex,
+    committeeIndex: CommitteeIndex,
+    aggregationBits: BitArray
+  ): void {
+    const committeeByIndexByRoot = this.committeeByIndexByRootBySlot.get(slot);
+    if (committeeByIndexByRoot == null) {
+      // no SingleAttestation for this slot
+      return;
+    }
+
+    const committeeByIndex = committeeByIndexByRoot.get(attDataRootHex);
+    if (committeeByIndex == null) {
+      // no SingleAttestation for this data root
+      return;
+    }
+
+    const committeeInfo = committeeByIndex.get(committeeIndex);
+    if (committeeInfo == null) {
+      // no SingleAttestation for this committee index
+      return;
+    }
+
+    // remove SingleAttestation for this committee index, we have it in AggregatedAttestationPool
+    const singleAttestations = committeeInfo.attestations;
+    for (const committeeValidatorIndex of singleAttestations.keys()) {
+      if (aggregationBits.get(committeeValidatorIndex)) {
+        singleAttestations.delete(committeeValidatorIndex);
+      }
+    }
   }
 
   /**
@@ -264,39 +267,11 @@ export class SingleAttestationPool {
    *     This ensures we have some SingleAttesations for block production while it does not occupy a lot of memory.
    */
   prune(clockSlot: Slot): void {
-    pruneBySlot(this.committeeByIndexByRootBySlot, clockSlot, MAX_SLOTS_RETAINED);
-    this.lowestPermissibleSlot = clockSlot - MAX_SLOTS_RETAINED;
+    // this value is for post-deneb
+    const slotsToRetain = computeSlotsSinceEpochStart(clockSlot, computeEpochAtSlot(clockSlot) - 1);
 
-    // now we have 32 slots, we want to prune slots until we have less than MAX_ATTESTATIONS_RETAINED
-    // this is mainly a concern for beacon node subscribing to all subnets, which may have a lot of attestations
-    const attestationCountBySlot: number[] = [];
-    for (let i = 0; i < MAX_SLOTS_RETAINED; i++) {
-      // i = 0 => slot = clockSlot - 31 (first value)
-      // i = 31 => slot = clockSlot (last value)
-      attestationCountBySlot[i] = this.getAttestationCountAtSlot(clockSlot - (MAX_SLOTS_RETAINED - i) + 1);
-    }
-
-    let totalAttestations = attestationCountBySlot.reduce((sum, count) => sum + count, 0);
-    for (let i = 0; i < MAX_ATTESTATIONS_RETAINED - MIN_SLOTS_RETAINED; i++) {
-      if (
-        totalAttestations < MAX_ATTESTATIONS_RETAINED ||
-        this.committeeByIndexByRootBySlot.size <= MIN_SLOTS_RETAINED
-      ) {
-        // we have not too many attestations or too few slots, no need to prune more
-        // this usually happens for a regular node at i = 0
-        break;
-      }
-
-      // i = 0 => slot = clockSlot - 31 (first value)
-      // i = 28 => slot = clockSlot - 3 (last value)
-      const slot = clockSlot - (MAX_SLOTS_RETAINED - i) + 1;
-
-      // i = 0 => attestationCountIndex = 31
-      // i = 28 => attestationCountIndex = 3
-      const attestationCount = attestationCountBySlot[i];
-      this.committeeByIndexByRootBySlot.delete(slot);
-      totalAttestations -= attestationCount;
-    }
+    pruneBySlot(this.committeeByIndexByRootBySlot, clockSlot, slotsToRetain);
+    this.lowestPermissibleSlot = Math.max(clockSlot - slotsToRetain, 0);
   }
 
   private onScrapeMetrics(metrics: Metrics): void {

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -71,11 +71,11 @@ async function validateAggregateAndProof(
   const attData = aggregate.data;
   const attSlot = attData.slot;
 
-  let attIndex: number | null;
+  let committeeIndex: number | null;
   if (ForkSeq[fork] >= ForkSeq.electra) {
-    attIndex = (aggregate as electra.Attestation).committeeBits.getSingleTrueBit();
+    committeeIndex = (aggregate as electra.Attestation).committeeBits.getSingleTrueBit();
     // [REJECT] len(committee_indices) == 1, where committee_indices = get_committee_indices(aggregate)
-    if (attIndex === null) {
+    if (committeeIndex === null) {
       throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.NOT_EXACTLY_ONE_COMMITTEE_BIT_SET});
     }
     // [REJECT] aggregate.data.index == 0
@@ -83,11 +83,11 @@ async function validateAggregateAndProof(
       throw new AttestationError(GossipAction.REJECT, {code: AttestationErrorCode.NON_ZERO_ATTESTATION_DATA_INDEX});
     }
   } else {
-    attIndex = attData.index;
+    committeeIndex = attData.index;
   }
 
   const seenAttDataKey = serializedData ? getSeenAttDataKeyFromSignedAggregateAndProof(fork, serializedData) : null;
-  const cachedAttData = seenAttDataKey ? chain.seenAttestationDatas.get(attSlot, attIndex, seenAttDataKey) : null;
+  const cachedAttData = seenAttDataKey ? chain.seenAttestationDatas.get(attSlot, committeeIndex, seenAttDataKey) : null;
 
   const attEpoch = computeEpochAtSlot(attSlot);
   const attTarget = attData.target;
@@ -136,7 +136,7 @@ async function validateAggregateAndProof(
     : toRootHex(ssz.phase0.AttestationData.hashTreeRoot(attData));
   if (
     !skipValidationKnownAttesters &&
-    chain.seenAggregatedAttestations.isKnown(targetEpoch, attIndex, attDataRootHex, aggregationBits)
+    chain.seenAggregatedAttestations.isKnown(targetEpoch, committeeIndex, attDataRootHex, aggregationBits)
   ) {
     throw new AttestationError(GossipAction.IGNORE, {
       code: AttestationErrorCode.ATTESTERS_ALREADY_KNOWN,
@@ -177,7 +177,7 @@ async function validateAggregateAndProof(
   // -- i.e. data.index < get_committee_count_per_slot(state, data.target.epoch)
   const committeeIndices = cachedAttData
     ? cachedAttData.committeeValidatorIndices
-    : getCommitteeIndices(shuffling, attSlot, attIndex);
+    : getCommitteeIndices(shuffling, attSlot, committeeIndex);
 
   // [REJECT] The number of aggregation bits matches the committee size
   // -- i.e. `len(aggregation_bits) == len(get_beacon_committee(state, aggregate.data.slot, index))`.
@@ -246,9 +246,10 @@ async function validateAggregateAndProof(
   }
 
   chain.seenAggregators.add(targetEpoch, aggregatorIndex);
-  chain.seenAggregatedAttestations.add(
+  chain.addSeenAgregatedAttestation(
+    attSlot,
     targetEpoch,
-    attIndex,
+    committeeIndex,
     attDataRootHex,
     {aggregationBits, trueBitCount: attestingIndices.length},
     false

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -4,7 +4,7 @@ import {
   createAggregateSignatureSetFromComponents,
   isAggregatorFromCommitteeLength,
 } from "@lodestar/state-transition";
-import {IndexedAttestation, RootHex, SignedAggregateAndProof, electra, ssz} from "@lodestar/types";
+import {CommitteeIndex, IndexedAttestation, RootHex, SignedAggregateAndProof, electra, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../errors/index.js";
 import {IBeaconChain} from "../index.js";
@@ -23,6 +23,7 @@ export type AggregateAndProofValidationResult = {
   indexedAttestation: IndexedAttestation;
   committeeIndices: Uint32Array;
   attDataRootHex: RootHex;
+  committeeIndex: CommitteeIndex;
 };
 
 export async function validateApiAggregateAndProof(
@@ -255,5 +256,5 @@ async function validateAggregateAndProof(
     false
   );
 
-  return {indexedAttestation, committeeIndices, attDataRootHex};
+  return {indexedAttestation, committeeIndex, committeeIndices, attDataRootHex};
 }

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -159,6 +159,7 @@ export function getAttestationValidData(opts: AttestationValidDataOpts): {
     index2pubkey: state.epochCtx.index2pubkey,
     shufflingCache,
     opts: defaultChainOptions,
+    addSeenAgregatedAttestation: () => {},
   } as Partial<IBeaconChain> as IBeaconChain;
 
   return {chain, attestation, subnet, validatorIndex};


### PR DESCRIPTION
**Motivation**

- right now we only store 32 slots of SingleAttestation due to memory concern

**Description**

- store up to 64 slots of SingleAttestation, remove seen votes per seen aggregated attestations
- this also resolves the concern for a node subscribing to all subnets because the memory increased only happened for 1/3 slots
- memory is way smaller and not a concern anymore

