### PR TITLE
feat: introduce finalProcessEpoch()

### DIFF
--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -126,14 +126,14 @@ export class EpochCache {
 
   /**
    * Indexes of the block proposers for the current epoch.
+   * For pre-fulu, this is computed and cached from the current shuffling.
+   * For post-fulu, this is copied from the state.proposerLookahead.
    *
    * 32 x Number
    */
-  // TODO FULU: This is no longer needed since EIP-7917
   proposers: ValidatorIndex[];
 
   /** Proposers for previous epoch, initialized to null in first epoch */
-  // TODO FULU: This is no longer needed since EIP-7917. Need to find a way to deal with
   // getProposerDuties requests with previous epoch
   proposersPrevEpoch: ValidatorIndex[] | null;
 
@@ -141,8 +141,10 @@ export class EpochCache {
    * The next proposer seed is only used in the getBeaconProposersNextEpoch call. It cannot be moved into
    * getBeaconProposersNextEpoch because it needs state as input and all data needed by getBeaconProposersNextEpoch
    * should be in the epoch context.
+   *
+   * For pre-fulu, this is lazily computed from the next epoch's shuffling.
+   * For post-fulu, this is copied from the state.proposerLookahead.
    */
-  // TODO FULU: This is no longer needed since EIP-7917
   proposersNextEpoch: ProposersDeferred;
 
   /**
@@ -618,7 +620,7 @@ export class EpochCache {
    * Steps for afterProcessEpoch
    * 1) update previous/current/next values of cached items
    *
-   * Note that this method should be called before `upgradeState*()`
+   * At fork boundary, this runs pre-fork logic and it happens before `upgradeState*` is called.
    */
   afterProcessEpoch(state: CachedBeaconStateAllForks, epochTransitionCache: EpochTransitionCache): void {
     // Because the slot was incremented before entering this function the "next epoch" is actually the "current epoch"
@@ -632,7 +634,6 @@ export class EpochCache {
     // move current to previous
     this.previousShuffling = this.currentShuffling;
     this.previousDecisionRoot = this.currentDecisionRoot;
-    this.proposersPrevEpoch = this.proposers;
 
     // move next to current or calculate upcoming
     this.currentDecisionRoot = this.nextDecisionRoot;
@@ -742,12 +743,14 @@ export class EpochCache {
   }
 
   /**
-   * Call after afterProcessEpoch() and upgradeState*() to finalize the epoch cache.
+   * At fork boundary, this runs post-fork logic and it happens after `upgradeState*` is called.
    */
   finalProcessEpoch(state: CachedBeaconStateAllForks): void {
     // this.epoch was updated at the end of afterProcessEpoch()
     const upcomingEpoch = this.epoch;
     const epochAfterUpcoming = upcomingEpoch + 1;
+
+    this.proposersPrevEpoch = this.proposers;
     if (this.epoch >= this.config.FULU_FORK_EPOCH) {
       // Populate proposer cache with lookahead from state
       const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
@@ -830,8 +833,10 @@ export class EpochCache {
     return (committeesSinceEpochStart + committeeIndex) % ATTESTATION_SUBNET_COUNT;
   }
 
-  // TODO FULU: Read from state.proposer_lookahead instead.
-  // See https://github.com/ethereum/consensus-specs/blob/e9266b2145c09b63ba0039a9f477cfe8a629c78b/specs/fulu/beacon-chain.md#modified-get_beacon_proposer_index
+  /**
+   * Read from proposers instead of state.proposer_lookahead because we set it in `finalProcessEpoch()`
+   * See https://github.com/ethereum/consensus-specs/blob/e9266b2145c09b63ba0039a9f477cfe8a629c78b/specs/fulu/beacon-chain.md#modified-get_beacon_proposer_index
+   */
   getBeaconProposer(slot: Slot): ValidatorIndex {
     const epoch = computeEpochAtSlot(slot);
     if (epoch !== this.currentShuffling.epoch) {
@@ -889,9 +894,9 @@ export class EpochCache {
    * balances are sampled to adjust the probability of the next selection (32 per epoch on average). So to invalidate
    * the prediction the effective of one of those 32 samples should change and change the random_byte inequality.
    */
-  // TODO Fulu: We can't do lazy compute anymore post EIP-7917. Since we need them to compute state.proposerLookahead
   getBeaconProposersNextEpoch(): ValidatorIndex[] {
     if (!this.proposersNextEpoch.computed) {
+      // this is lazily computed pre-fulu
       const indexes = computeProposers(
         this.config.getForkSeqAtEpoch(this.nextEpoch),
         this.proposersNextEpoch.seed,
@@ -901,6 +906,7 @@ export class EpochCache {
       this.proposersNextEpoch = {computed: true, indexes};
     }
 
+    // this is eagerly computed post-fulu
     return this.proposersNextEpoch.indexes;
   }
 

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -617,6 +617,8 @@ export class EpochCache {
    *
    * Steps for afterProcessEpoch
    * 1) update previous/current/next values of cached items
+   *
+   * Note that this method should be called before `upgradeState*()`
    */
   afterProcessEpoch(state: CachedBeaconStateAllForks, epochTransitionCache: EpochTransitionCache): void {
     // Because the slot was incremented before entering this function the "next epoch" is actually the "current epoch"
@@ -649,34 +651,6 @@ export class EpochCache {
         // allow for this case during testing where the ShufflingCache is not present, may affect perf testing
         // so should be taken into account when structuring tests.  Should not affect unit or other tests though
         computeEpochShuffling(state, this.nextActiveIndices, upcomingEpoch);
-    }
-    if (this.epoch >= this.config.FULU_FORK_EPOCH) {
-      // Populate proposer cache with lookahead from state
-      const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
-      this.proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);
-
-      if (proposerLookahead.length >= SLOTS_PER_EPOCH * 2) {
-        this.proposersNextEpoch = {
-          computed: true,
-          indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
-        };
-      } else {
-        // This should not happen unless MIN_SEED_LOOKAHEAD is set to 0
-        // this ensures things don't break if the proposer lookahead is not long enough
-        this.proposersNextEpoch = {computed: false, seed: getSeed(state, epochAfterUpcoming, DOMAIN_BEACON_PROPOSER)};
-      }
-    } else {
-      // Need to calculate proposers pre-fulu
-      const upcomingProposerSeed = getSeed(state, upcomingEpoch, DOMAIN_BEACON_PROPOSER);
-      // next epoch was moved to current epoch so use current here
-      this.proposers = computeProposers(
-        this.config.getForkSeqAtEpoch(upcomingEpoch),
-        upcomingProposerSeed,
-        this.currentShuffling,
-        this.effectiveBalanceIncrements
-      );
-      // Only pre-compute the seed since it's very cheap. Do the expensive computeProposers() call only on demand.
-      this.proposersNextEpoch = {computed: false, seed: getSeed(state, epochAfterUpcoming, DOMAIN_BEACON_PROPOSER)};
     }
 
     // handle next values
@@ -765,6 +739,43 @@ export class EpochCache {
     // ```
     this.epoch = computeEpochAtSlot(state.slot);
     this.syncPeriod = computeSyncPeriodAtEpoch(this.epoch);
+  }
+
+  /**
+   * Call after afterProcessEpoch() and upgradeState*() to finalize the epoch cache.
+   */
+  finalProcessEpoch(state: CachedBeaconStateAllForks): void {
+    // this.epoch was updated at the end of afterProcessEpoch()
+    const upcomingEpoch = this.epoch;
+    const epochAfterUpcoming = upcomingEpoch + 1;
+    if (this.epoch >= this.config.FULU_FORK_EPOCH) {
+      // Populate proposer cache with lookahead from state
+      const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
+      this.proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);
+
+      if (proposerLookahead.length >= SLOTS_PER_EPOCH * 2) {
+        this.proposersNextEpoch = {
+          computed: true,
+          indexes: proposerLookahead.slice(SLOTS_PER_EPOCH, SLOTS_PER_EPOCH * 2),
+        };
+      } else {
+        // This should not happen unless MIN_SEED_LOOKAHEAD is set to 0
+        // this ensures things don't break if the proposer lookahead is not long enough
+        this.proposersNextEpoch = {computed: false, seed: getSeed(state, epochAfterUpcoming, DOMAIN_BEACON_PROPOSER)};
+      }
+    } else {
+      // Need to calculate proposers pre-fulu
+      const upcomingProposerSeed = getSeed(state, upcomingEpoch, DOMAIN_BEACON_PROPOSER);
+      // next epoch was moved to current epoch so use current here
+      this.proposers = computeProposers(
+        this.config.getForkSeqAtEpoch(upcomingEpoch),
+        upcomingProposerSeed,
+        this.currentShuffling,
+        this.effectiveBalanceIncrements
+      );
+      // Only pre-compute the seed since it's very cheap. Do the expensive computeProposers() call only on demand.
+      this.proposersNextEpoch = {computed: false, seed: getSeed(state, epochAfterUpcoming, DOMAIN_BEACON_PROPOSER)};
+    }
   }
 
   beforeEpochTransition(): void {

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -134,7 +134,6 @@ export class EpochCache {
   proposers: ValidatorIndex[];
 
   /** Proposers for previous epoch, initialized to null in first epoch */
-  // getProposerDuties requests with previous epoch
   proposersPrevEpoch: ValidatorIndex[] | null;
 
   /**

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -751,7 +751,7 @@ export class EpochCache {
     const epochAfterUpcoming = upcomingEpoch + 1;
 
     this.proposersPrevEpoch = this.proposers;
-    if (this.epoch >= this.config.FULU_FORK_EPOCH) {
+    if (upcomingEpoch >= this.config.FULU_FORK_EPOCH) {
       // Populate proposer cache with lookahead from state
       const proposerLookahead = (state as CachedBeaconStateFulu).proposerLookahead.getAll();
       this.proposers = proposerLookahead.slice(0, SLOTS_PER_EPOCH);

--- a/packages/state-transition/src/epoch/index.ts
+++ b/packages/state-transition/src/epoch/index.ts
@@ -65,6 +65,7 @@ const maxSafeValidators = Math.floor(Number.MAX_SAFE_INTEGER / MAX_EFFECTIVE_BAL
 export enum EpochTransitionStep {
   beforeProcessEpoch = "beforeProcessEpoch",
   afterProcessEpoch = "afterProcessEpoch",
+  finalProcessEpoch = "finalProcessEpoch",
   processJustificationAndFinalization = "processJustificationAndFinalization",
   processInactivityUpdates = "processInactivityUpdates",
   processRegistryUpdates = "processRegistryUpdates",

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -248,15 +248,8 @@ function processSlotsWithTransientCache(
 
       {
         const timer = metrics?.epochTransitionStepTime.startTimer({step: EpochTransitionStep.afterProcessEpoch});
+        // this should be called before `upgradeState*()` below to prepare data for it
         postState.epochCtx.afterProcessEpoch(postState, epochTransitionCache);
-        timer?.();
-      }
-
-      // Running commit here is not strictly necessary. The cost of running commit twice (here + after process block)
-      // Should be negligible but gives better metrics to differentiate the cost of it for block and epoch proc.
-      {
-        const timer = metrics?.epochTransitionCommitTime.startTimer();
-        postState.commit();
         timer?.();
       }
 
@@ -282,6 +275,21 @@ function processSlotsWithTransientCache(
       }
       if (stateEpoch === config.FULU_FORK_EPOCH) {
         postState = upgradeStateToFulu(postState as CachedBeaconStateElectra) as CachedBeaconStateAllForks;
+      }
+
+      {
+        const timer = metrics?.epochTransitionStepTime.startTimer({step: EpochTransitionStep.finalProcessEpoch});
+        // last step to prepare epoch data that depends on the upgraded state, for example proposerLookAhead of BeaconStateFulu
+        postState.epochCtx.finalProcessEpoch(postState);
+        timer?.();
+      }
+
+      // Running commit here is not strictly necessary. The cost of running commit twice (here + after process block)
+      // Should be negligible but gives better metrics to differentiate the cost of it for block and epoch proc.
+      {
+        const timer = metrics?.epochTransitionCommitTime.startTimer();
+        postState.commit();
+        timer?.();
       }
     } else {
       postState.slot++;

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -253,9 +253,6 @@ function processSlotsWithTransientCache(
         timer?.();
       }
 
-      // Note: time only on success. Include beforeProcessEpoch, processEpoch, afterProcessEpoch, commit
-      epochTransitionTimer?.();
-
       // Upgrade state if exactly at epoch boundary
       const stateEpoch = computeEpochAtSlot(postState.slot);
       if (stateEpoch === config.ALTAIR_FORK_EPOCH) {
@@ -279,7 +276,7 @@ function processSlotsWithTransientCache(
 
       {
         const timer = metrics?.epochTransitionStepTime.startTimer({step: EpochTransitionStep.finalProcessEpoch});
-        // last step to prepare epoch data that depends on the upgraded state, for example proposerLookAhead of BeaconStateFulu
+        // last step to prepare epoch data that depends on the upgraded state, for example proposerLookahead of BeaconStateFulu
         postState.epochCtx.finalProcessEpoch(postState);
         timer?.();
       }
@@ -291,6 +288,9 @@ function processSlotsWithTransientCache(
         postState.commit();
         timer?.();
       }
+
+      // Note: time only on success. Include beforeProcessEpoch, processEpoch, afterProcessEpoch, upgradeState*, finalProcessEpoch, commit
+      epochTransitionTimer?.();
     } else {
       postState.slot++;
     }


### PR DESCRIPTION
**Motivation**

~~as found in #8082, there is cyclic dependency between `afterProcessEpoch` and `upgradeState*` like `upgradeStateToElectra`~~

this PR improves a couple of things:

- to prepare for the future: future contributor can just decide where to put logic at and it's straightforward to them. Cyclic dependency does not happen here because the logic of computing proposers is unchanged for fulu, but it may happen for other fields in the future
- at fork boundary, (epoch 0 of fulu), we implicitly run pre-fork logic, only run post-fork logic from epoch 1 and it's not great. In epoch transition we should make everything explicit to make it easier to maintain
- performance: we compute proposers for current epoch and next epoch twice at epoch 0 of fulu

**Description**

- implement finalProcessEpoch(), this is to compute epoch data that depends on `upgradeState*`
- call this after `upgradeState*()`
