### PR TITLE
feat: add getBlobs endpoint

### DIFF
--- a/packages/api/src/beacon/routes/beacon/block.ts
+++ b/packages/api/src/beacon/routes/beacon/block.ts
@@ -220,6 +220,24 @@ export type Endpoints = {
     deneb.BlobSidecars,
     ExecutionOptimisticFinalizedAndVersionMeta
   >;
+
+  /**
+   * Get blobs
+   * Retrieves blobs for a given block id.
+   */
+  getBlobs: Endpoint<
+    "GET",
+    BlockArgs & {
+      /**
+       * Array of indices for blobs to request for in the specified block.
+       * Returns all blobs in the block if not specified.
+       */
+      indices?: number[];
+    },
+    {params: {block_id: string}; query: {indices?: number[]}},
+    deneb.Blobs,
+    ExecutionOptimisticAndFinalizedMeta
+  >;
 };
 
 // biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -549,6 +567,19 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
       resp: {
         data: ssz.deneb.BlobSidecars,
         meta: ExecutionOptimisticFinalizedAndVersionCodec,
+      },
+    },
+    getBlobs: {
+      url: "/eth/v1/beacon/blobs/{block_id}",
+      method: "GET",
+      req: {
+        writeReq: ({blockId, indices}) => ({params: {block_id: blockId.toString()}, query: {indices}}),
+        parseReq: ({params, query}) => ({blockId: params.block_id, indices: query.indices}),
+        schema: {params: {block_id: Schema.StringRequired}, query: {indices: Schema.UintArray}},
+      },
+      resp: {
+        data: ssz.deneb.Blobs,
+        meta: ExecutionOptimisticAndFinalizedCodec,
       },
     },
   };

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -97,6 +97,13 @@ export const testData: GenericServerTestCases<Endpoints> = {
       meta: {executionOptimistic: true, finalized: false, version: ForkName.electra},
     },
   },
+  getBlobs: {
+    args: {blockId: "head", indices: [0]},
+    res: {
+      data: [ssz.deneb.Blob.defaultValue()],
+      meta: {executionOptimistic: true, finalized: false},
+    },
+  },
 
   // pool
 

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -5,6 +5,7 @@ import {
   ForkPostBellatrix,
   SLOTS_PER_HISTORICAL_ROOT,
   isForkPostBellatrix,
+  isForkPostDeneb,
   isForkPostElectra,
   isForkPostFulu,
 } from "@lodestar/params";
@@ -44,7 +45,12 @@ import {BlockError, BlockErrorCode, BlockGossipError} from "../../../../chain/er
 import {validateGossipBlock} from "../../../../chain/validation/block.js";
 import {OpSource} from "../../../../chain/validatorMonitor.js";
 import {NetworkEvent} from "../../../../network/index.js";
-import {computeBlobSidecars, computeDataColumnSidecars, kzgCommitmentToVersionedHash} from "../../../../util/blobs.js";
+import {
+  blobsFromDataColumnSidecars,
+  computeBlobSidecars,
+  computeDataColumnSidecars,
+  kzgCommitmentToVersionedHash,
+} from "../../../../util/blobs.js";
 import {isOptimisticBlock} from "../../../../util/forkChoice.js";
 import {promiseAllMaybeAsync} from "../../../../util/promises.js";
 import {ApiModules} from "../../types.js";
@@ -610,26 +616,38 @@ export function getBeaconBlockApi({
 
       const {block, executionOptimistic, finalized} = await getBlockResponse(chain, blockId);
       const fork = config.getForkName(block.message.slot);
-
-      if (isForkPostFulu(fork)) {
-        throw Error("TODO");
-      }
-
       const blockRoot = sszTypesFor(fork).BeaconBlock.hashTreeRoot(block.message);
 
-      let {blobSidecars} = (await db.blobSidecars.get(blockRoot)) ?? {};
-      if (!blobSidecars) {
-        ({blobSidecars} = (await db.blobSidecarsArchive.get(block.message.slot)) ?? {});
-      }
+      let blobs: deneb.Blobs;
 
-      if (!blobSidecars) {
-        throw Error(`blobSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`);
-      }
+      if (isForkPostFulu(fork)) {
+        let {dataColumnSidecars} = (await db.dataColumnSidecars.get(blockRoot)) ?? {};
+        if (!dataColumnSidecars) {
+          ({dataColumnSidecars} = (await db.dataColumnSidecarsArchive.get(block.message.slot)) ?? {});
+        }
 
-      blobSidecars = indices ? blobSidecars.filter(({index}) => indices.includes(index)) : blobSidecars;
+        if (!dataColumnSidecars) {
+          throw Error(`dataColumnSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`);
+        }
+
+        blobs = blobsFromDataColumnSidecars(dataColumnSidecars);
+      } else if (isForkPostDeneb(fork)) {
+        let {blobSidecars} = (await db.blobSidecars.get(blockRoot)) ?? {};
+        if (!blobSidecars) {
+          ({blobSidecars} = (await db.blobSidecarsArchive.get(block.message.slot)) ?? {});
+        }
+
+        if (!blobSidecars) {
+          throw Error(`blobSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`);
+        }
+
+        blobs = blobSidecars.sort((a, b) => a.index - b.index).map(({blob}) => blob);
+      } else {
+        blobs = [];
+      }
 
       return {
-        data: blobSidecars.map(({blob}) => blob),
+        data: indices ? blobs.filter((_, i) => indices.includes(i)) : blobs,
         meta: {
           executionOptimistic,
           finalized,

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -578,7 +578,13 @@ export function getBeaconBlockApi({
       assertUniqueItems(indices, "Duplicate indices provided");
 
       const {block, executionOptimistic, finalized} = await getBlockResponse(chain, blockId);
-      const blockRoot = config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
+      const fork = config.getForkName(block.message.slot);
+
+      if (isForkPostFulu(fork)) {
+        throw new ApiError(400, `Use getBlobs to retrieve blobs for post-fulu fork=${fork}`);
+      }
+
+      const blockRoot = sszTypesFor(fork).BeaconBlock.hashTreeRoot(block.message);
 
       let {blobSidecars} = (await db.blobSidecars.get(blockRoot)) ?? {};
       if (!blobSidecars) {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -632,7 +632,10 @@ export function getBeaconBlockApi({
         }
 
         if (!dataColumnSidecars) {
-          throw Error(`dataColumnSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`);
+          throw new ApiError(
+            404,
+            `dataColumnSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`
+          );
         }
 
         blobs = blobsFromDataColumnSidecars(dataColumnSidecars);
@@ -643,7 +646,10 @@ export function getBeaconBlockApi({
         }
 
         if (!blobSidecars) {
-          throw Error(`blobSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`);
+          throw new ApiError(
+            404,
+            `blobSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`
+          );
         }
 
         blobs = blobSidecars.sort((a, b) => a.index - b.index).map(({blob}) => blob);

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -622,8 +622,11 @@ export function getBeaconBlockApi({
       let blobs: deneb.Blobs;
 
       if (isForkPostFulu(fork)) {
-        if (chain.custodyConfig.targetCustodyGroupCount !== NUMBER_OF_COLUMNS) {
-          throw Error(`Must custody all ${NUMBER_OF_COLUMNS} data columns to be able to serve blobs`);
+        const {targetCustodyGroupCount} = chain.custodyConfig;
+        if (targetCustodyGroupCount < NUMBER_OF_COLUMNS / 2) {
+          throw Error(
+            `Custody group count of ${targetCustodyGroupCount} is not sufficient to serve blobs, must custody at least ${NUMBER_OF_COLUMNS / 2} data columns`
+          );
         }
 
         let {dataColumnSidecars} = (await db.dataColumnSidecars.get(blockRoot)) ?? {};
@@ -638,7 +641,7 @@ export function getBeaconBlockApi({
           );
         }
 
-        blobs = reconstructBlobs(dataColumnSidecars);
+        blobs = await reconstructBlobs(dataColumnSidecars);
       } else if (isForkPostDeneb(fork)) {
         let {blobSidecars} = (await db.blobSidecars.get(blockRoot)) ?? {};
         if (!blobSidecars) {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -23,6 +23,7 @@ import {
   deneb,
   fulu,
   isSignedBlockContents,
+  sszTypesFor,
 } from "@lodestar/types";
 import {fromHex, sleep, toHex, toRootHex} from "@lodestar/utils";
 import {
@@ -594,6 +595,38 @@ export function getBeaconBlockApi({
           executionOptimistic,
           finalized,
           version: config.getForkName(block.message.slot),
+        },
+      };
+    },
+
+    async getBlobs({blockId, indices}) {
+      assertUniqueItems(indices, "Duplicate indices provided");
+
+      const {block, executionOptimistic, finalized} = await getBlockResponse(chain, blockId);
+      const fork = config.getForkName(block.message.slot);
+
+      if (isForkPostFulu(fork)) {
+        throw Error("TODO");
+      }
+
+      const blockRoot = sszTypesFor(fork).BeaconBlock.hashTreeRoot(block.message);
+
+      let {blobSidecars} = (await db.blobSidecars.get(blockRoot)) ?? {};
+      if (!blobSidecars) {
+        ({blobSidecars} = (await db.blobSidecarsArchive.get(block.message.slot)) ?? {});
+      }
+
+      if (!blobSidecars) {
+        throw Error(`blobSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`);
+      }
+
+      blobSidecars = indices ? blobSidecars.filter(({index}) => indices.includes(index)) : blobSidecars;
+
+      return {
+        data: blobSidecars.map(({blob}) => blob),
+        meta: {
+          executionOptimistic,
+          finalized,
         },
       };
     },

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -47,10 +47,10 @@ import {validateGossipBlock} from "../../../../chain/validation/block.js";
 import {OpSource} from "../../../../chain/validatorMonitor.js";
 import {NetworkEvent} from "../../../../network/index.js";
 import {
-  blobsFromDataColumnSidecars,
   computeBlobSidecars,
   computeDataColumnSidecars,
   kzgCommitmentToVersionedHash,
+  reconstructBlobs,
 } from "../../../../util/blobs.js";
 import {isOptimisticBlock} from "../../../../util/forkChoice.js";
 import {promiseAllMaybeAsync} from "../../../../util/promises.js";
@@ -638,7 +638,7 @@ export function getBeaconBlockApi({
           );
         }
 
-        blobs = blobsFromDataColumnSidecars(dataColumnSidecars);
+        blobs = reconstructBlobs(dataColumnSidecars);
       } else if (isForkPostDeneb(fork)) {
         let {blobSidecars} = (await db.blobSidecars.get(blockRoot)) ?? {};
         if (!blobSidecars) {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -3,6 +3,7 @@ import {ApiError, ApplicationMethods} from "@lodestar/api/server";
 import {
   ForkName,
   ForkPostBellatrix,
+  NUMBER_OF_COLUMNS,
   SLOTS_PER_HISTORICAL_ROOT,
   isForkPostBellatrix,
   isForkPostDeneb,
@@ -621,6 +622,10 @@ export function getBeaconBlockApi({
       let blobs: deneb.Blobs;
 
       if (isForkPostFulu(fork)) {
+        if (chain.custodyConfig.custodyColumns.length !== NUMBER_OF_COLUMNS) {
+          throw Error(`Must custody all ${NUMBER_OF_COLUMNS} data columns to be able to serve blobs`);
+        }
+
         let {dataColumnSidecars} = (await db.dataColumnSidecars.get(blockRoot)) ?? {};
         if (!dataColumnSidecars) {
           ({dataColumnSidecars} = (await db.dataColumnSidecarsArchive.get(block.message.slot)) ?? {});

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -622,7 +622,7 @@ export function getBeaconBlockApi({
       let blobs: deneb.Blobs;
 
       if (isForkPostFulu(fork)) {
-        if (chain.custodyConfig.custodyColumns.length !== NUMBER_OF_COLUMNS) {
+        if (chain.custodyConfig.targetCustodyGroupCount !== NUMBER_OF_COLUMNS) {
           throw Error(`Must custody all ${NUMBER_OF_COLUMNS} data columns to be able to serve blobs`);
         }
 

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -194,6 +194,7 @@ export async function recoverDataColumnSidecars(
  * Reconstruct blobs from a complete set of data columns
  */
 export function blobsFromDataColumnSidecars(sidecars: fulu.DataColumnSidecars): deneb.Blobs {
+  //  Must have all columns otherwise call `recoverDataColumnSidecars` first
   if (sidecars.length !== NUMBER_OF_COLUMNS) {
     throw Error(`Expected ${NUMBER_OF_COLUMNS} data columns to reconstruct blobs, received ${sidecars.length}`);
   }
@@ -202,6 +203,7 @@ export function blobsFromDataColumnSidecars(sidecars: fulu.DataColumnSidecars): 
 
   const ordered = sidecars.slice().sort((a, b) => a.index - b.index);
   for (let row = 0; row < blobCount; row++) {
+    // 128 cells that make up one "extended blob" row
     const cells = ordered.map((col) => col.column[row]);
     blobs[row] = cellsToBlob(cells);
   }
@@ -209,6 +211,11 @@ export function blobsFromDataColumnSidecars(sidecars: fulu.DataColumnSidecars): 
   return blobs;
 }
 
+/**
+ * Concatenate the systematic half (columns 0‑63) of a row of cells into
+ * the original 131072 byte blob. The parity half (64‑127) is ignored as
+ * it is only needed for erasure‑coding recovery when columns are missing.
+ */
 function cellsToBlob(cells: fulu.Cell[]): deneb.Blob {
   if (cells.length !== NUMBER_OF_COLUMNS) {
     throw Error(`Expected ${NUMBER_OF_COLUMNS} cells to reconstruct blob, received ${cells.length}`);
@@ -216,7 +223,9 @@ function cellsToBlob(cells: fulu.Cell[]): deneb.Blob {
 
   const blob = new Uint8Array(BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB);
 
-  for (const [i, cell] of cells.entries()) {
+  // Only the first 64 cells hold the original bytes
+  for (let i = 0; i < NUMBER_OF_COLUMNS / 2; i++) {
+    const cell = cells[i];
     if (cell.length !== BYTES_PER_CELL) {
       throw Error(`Cell ${i} has incorrect byte size ${cell.length} != ${BYTES_PER_CELL}`);
     }

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -2,6 +2,9 @@ import {digest as sha256Digest} from "@chainsafe/as-sha256";
 import {Tree} from "@chainsafe/persistent-merkle-tree";
 import {ChainForkConfig} from "@lodestar/config";
 import {
+  BYTES_PER_CELL,
+  BYTES_PER_FIELD_ELEMENT,
+  FIELD_ELEMENTS_PER_BLOB,
   ForkAll,
   ForkName,
   KZG_COMMITMENTS_GINDEX,
@@ -207,12 +210,19 @@ export function blobsFromDataColumnSidecars(sidecars: fulu.DataColumnSidecars): 
 }
 
 function cellsToBlob(cells: fulu.Cell[]): deneb.Blob {
-  const len = cells.reduce((n, c) => n + c.length, 0);
-  const blob = new Uint8Array(len);
-  let off = 0;
-  for (const c of cells) {
-    blob.set(c, off);
-    off += c.length;
+  if (cells.length !== NUMBER_OF_COLUMNS) {
+    throw Error(`Expected ${NUMBER_OF_COLUMNS} cells to reconstruct blob, received ${cells.length}`);
   }
+
+  const blob = new Uint8Array(BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB);
+
+  for (const [i, cell] of cells.entries()) {
+    if (cell.length !== BYTES_PER_CELL) {
+      throw Error(`Cell ${i} has incorrect byte size ${cell.length} != ${BYTES_PER_CELL}`);
+    }
+
+    blob.set(cell, i * BYTES_PER_CELL);
+  }
+
   return blob;
 }

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -192,7 +192,7 @@ export async function recoverDataColumnSidecars(
  */
 export function blobsFromDataColumnSidecars(sidecars: fulu.DataColumnSidecars): deneb.Blobs {
   if (sidecars.length !== NUMBER_OF_COLUMNS) {
-    throw Error(`Expected ${NUMBER_OF_COLUMNS} columns to reconstruct blobs, received ${sidecars.length}`);
+    throw Error(`Expected ${NUMBER_OF_COLUMNS} data columns to reconstruct blobs, received ${sidecars.length}`);
   }
   const blobCount = sidecars[0].column.length;
   const blobs: deneb.Blobs = new Array(blobCount);

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -193,7 +193,7 @@ export async function recoverDataColumnSidecars(
 /**
  * Reconstruct blobs from a complete set of data columns
  */
-export function blobsFromDataColumnSidecars(sidecars: fulu.DataColumnSidecars): deneb.Blobs {
+export function reconstructBlobs(sidecars: fulu.DataColumnSidecars): deneb.Blobs {
   //  Must have all columns otherwise call `recoverDataColumnSidecars` first
   if (sidecars.length !== NUMBER_OF_COLUMNS) {
     throw Error(`Expected ${NUMBER_OF_COLUMNS} data columns to reconstruct blobs, received ${sidecars.length}`);

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -186,3 +186,33 @@ export async function recoverDataColumnSidecars(
 
   return result;
 }
+
+/**
+ * Reconstruct blobs from a complete set of data columns
+ */
+export function blobsFromDataColumnSidecars(sidecars: fulu.DataColumnSidecars): deneb.Blobs {
+  if (sidecars.length !== NUMBER_OF_COLUMNS) {
+    throw Error(`Expected ${NUMBER_OF_COLUMNS} columns to reconstruct blobs, received ${sidecars.length}`);
+  }
+  const blobCount = sidecars[0].column.length;
+  const blobs: deneb.Blobs = new Array(blobCount);
+
+  const ordered = sidecars.slice().sort((a, b) => a.index - b.index);
+  for (let row = 0; row < blobCount; row++) {
+    const cells = ordered.map((col) => col.column[row]);
+    blobs[row] = cellsToBlob(cells);
+  }
+
+  return blobs;
+}
+
+function cellsToBlob(cells: fulu.Cell[]): deneb.Blob {
+  const len = cells.reduce((n, c) => n + c.length, 0);
+  const blob = new Uint8Array(len);
+  let off = 0;
+  for (const c of cells) {
+    blob.set(c, off);
+    off += c.length;
+  }
+  return blob;
+}

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -192,17 +192,35 @@ export async function recoverDataColumnSidecars(
 }
 
 /**
- * Reconstruct blobs from a complete set of data columns
+ * Reconstruct blobs from a set of data columns, at least 50%+ of all the columns
+ * must be provided to allow to reconstruct the full data matrix
  */
-export function reconstructBlobs(sidecars: fulu.DataColumnSidecars): deneb.Blobs {
-  //  Must have all columns otherwise call `recoverDataColumnSidecars` first
-  if (sidecars.length !== NUMBER_OF_COLUMNS) {
-    throw Error(`Expected ${NUMBER_OF_COLUMNS} data columns to reconstruct blobs, received ${sidecars.length}`);
+export async function reconstructBlobs(sidecars: fulu.DataColumnSidecars): Promise<deneb.Blobs> {
+  if (sidecars.length < NUMBER_OF_COLUMNS / 2) {
+    throw Error(
+      `Expected at least ${NUMBER_OF_COLUMNS / 2} data columns to reconstruct blobs, received ${sidecars.length}`
+    );
   }
-  const blobCount = sidecars[0].column.length;
+
+  let fullSidecars: fulu.DataColumnSidecars;
+
+  if (sidecars.length === NUMBER_OF_COLUMNS) {
+    // Full columns, no need to recover
+    fullSidecars = sidecars;
+  } else {
+    const sidecarsByIndex = new Map<number, fulu.DataColumnSidecar>(sidecars.map((sc) => [sc.index, sc]));
+    const recoveredSidecars = await recoverDataColumnSidecars(sidecarsByIndex);
+    if (recoveredSidecars === null) {
+      // Should not happen because we check the column count above
+      throw Error("Failed to reconstruct the full data matrix");
+    }
+    fullSidecars = recoveredSidecars;
+  }
+
+  const blobCount = fullSidecars[0].column.length;
   const blobs: deneb.Blobs = new Array(blobCount);
 
-  const ordered = sidecars.slice().sort((a, b) => a.index - b.index);
+  const ordered = fullSidecars.slice().sort((a, b) => a.index - b.index);
   for (let row = 0; row < blobCount; row++) {
     // 128 cells that make up one "extended blob" row
     const cells = ordered.map((col) => col.column[row]);

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -4,6 +4,7 @@ import {ChainForkConfig} from "@lodestar/config";
 import {
   BYTES_PER_CELL,
   BYTES_PER_FIELD_ELEMENT,
+  CELLS_PER_EXT_BLOB,
   FIELD_ELEMENTS_PER_BLOB,
   ForkAll,
   ForkName,
@@ -217,14 +218,14 @@ export function reconstructBlobs(sidecars: fulu.DataColumnSidecars): deneb.Blobs
  * it is only needed for erasure‑coding recovery when columns are missing.
  */
 function cellsToBlob(cells: fulu.Cell[]): deneb.Blob {
-  if (cells.length !== NUMBER_OF_COLUMNS) {
-    throw Error(`Expected ${NUMBER_OF_COLUMNS} cells to reconstruct blob, received ${cells.length}`);
+  if (cells.length !== CELLS_PER_EXT_BLOB) {
+    throw Error(`Expected ${CELLS_PER_EXT_BLOB} cells to reconstruct blob, received ${cells.length}`);
   }
 
   const blob = new Uint8Array(BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB);
 
   // Only the first 64 cells hold the original bytes
-  for (let i = 0; i < NUMBER_OF_COLUMNS / 2; i++) {
+  for (let i = 0; i < CELLS_PER_EXT_BLOB / 2; i++) {
     const cell = cells[i];
     if (cell.length !== BYTES_PER_CELL) {
       throw Error(`Cell ${i} has incorrect byte size ${cell.length} != ${BYTES_PER_CELL}`);

--- a/packages/beacon-node/test/unit/util/blobs.test.ts
+++ b/packages/beacon-node/test/unit/util/blobs.test.ts
@@ -113,32 +113,48 @@ describe("reconstructBlobs", () => {
     FULU_FORK_EPOCH: 0,
   });
 
-  it("should reconstruct blobs from a complete set of data columns", () => {
-    // Generate test data
-    const blobs = [generateRandomBlob(), generateRandomBlob()];
+  // Generate test data
+  const blobs = [generateRandomBlob(), generateRandomBlob()];
 
-    // Compute commitments, cells, and proofs for each blob
-    const kzgCommitments: deneb.KZGCommitment[] = [];
-    const cells: fulu.Cell[][] = [];
-    const kzgProofs: deneb.KZGProof[] = [];
-    for (const blob of blobs) {
-      kzgCommitments.push(kzg.blobToKzgCommitment(blob));
+  // Compute commitments, cells, and proofs for each blob
+  const kzgCommitments: deneb.KZGCommitment[] = [];
+  const cells: fulu.Cell[][] = [];
+  const kzgProofs: deneb.KZGProof[] = [];
+  for (const blob of blobs) {
+    kzgCommitments.push(kzg.blobToKzgCommitment(blob));
 
-      const {cells: blobCells, proofs} = kzg.computeCellsAndKzgProofs(blob);
-      cells.push(blobCells);
-      kzgProofs.push(...proofs);
-    }
+    const {cells: blobCells, proofs} = kzg.computeCellsAndKzgProofs(blob);
+    cells.push(blobCells);
+    kzgProofs.push(...proofs);
+  }
 
-    // Create a test block with the commitments
-    const signedBeaconBlock = ssz.fulu.SignedBeaconBlock.defaultValue();
-    signedBeaconBlock.message.body.blobKzgCommitments = kzgCommitments;
+  // Create a test block with the commitments
+  const signedBeaconBlock = ssz.fulu.SignedBeaconBlock.defaultValue();
+  signedBeaconBlock.message.body.blobKzgCommitments = kzgCommitments;
 
-    // Compute sidecars without providing cells
-    const sidecars = computeDataColumnSidecars(config, signedBeaconBlock, {
-      blobs,
-      kzgProofs,
-    });
+  // Compute sidecars without providing cells
+  const sidecars = computeDataColumnSidecars(config, signedBeaconBlock, {
+    blobs,
+    kzgProofs,
+  });
 
-    expect(reconstructBlobs(sidecars)).toEqual(blobs);
+  it("should reconstruct blobs from a complete set of data columns", async () => {
+    expect(await reconstructBlobs(sidecars)).toEqual(blobs);
+  });
+
+  it("should reconstruct blobs from at least half of the data columns ", async () => {
+    // random shuffle + take first 64
+    const randomHalf = sidecars
+      .slice()
+      .sort(() => Math.random() - 0.5)
+      .slice(0, NUMBER_OF_COLUMNS / 2);
+
+    expect(await reconstructBlobs(randomHalf)).toEqual(blobs);
+  });
+
+  it("should throw if less than half of the data columns are provided", async () => {
+    const lessThanHalf = sidecars.slice(0, NUMBER_OF_COLUMNS / 2 - 10);
+
+    await expect(reconstructBlobs(lessThanHalf)).rejects.toThrow();
   });
 });

--- a/packages/beacon-node/test/unit/util/blobs.test.ts
+++ b/packages/beacon-node/test/unit/util/blobs.test.ts
@@ -142,7 +142,7 @@ describe("reconstructBlobs", () => {
     expect(await reconstructBlobs(sidecars)).toEqual(blobs);
   });
 
-  it("should reconstruct blobs from at least half of the data columns ", async () => {
+  it("should reconstruct blobs from at least half of the data columns", async () => {
     // random shuffle + take first 64
     const randomHalf = sidecars
       .slice()

--- a/packages/beacon-node/test/unit/util/blobs.test.ts
+++ b/packages/beacon-node/test/unit/util/blobs.test.ts
@@ -2,7 +2,7 @@ import {createChainForkConfig} from "@lodestar/config";
 import {NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {deneb, fulu, ssz} from "@lodestar/types";
 import {describe, expect, it} from "vitest";
-import {computeDataColumnSidecars} from "../../../src/util/blobs.js";
+import {computeDataColumnSidecars, reconstructBlobs} from "../../../src/util/blobs.js";
 import {kzg} from "../../../src/util/kzg.js";
 import {generateRandomBlob} from "../../utils/kzg.js";
 
@@ -100,5 +100,45 @@ describe("computeDataColumnSidecars", () => {
         kzgProofs,
       })
     ).toThrow("Invalid block with missing blobKzgCommitments for computeBlobSidecars");
+  });
+});
+
+describe("reconstructBlobs", () => {
+  const config = createChainForkConfig({
+    ALTAIR_FORK_EPOCH: 0,
+    BELLATRIX_FORK_EPOCH: 0,
+    CAPELLA_FORK_EPOCH: 0,
+    DENEB_FORK_EPOCH: 0,
+    ELECTRA_FORK_EPOCH: 0,
+    FULU_FORK_EPOCH: 0,
+  });
+
+  it("should reconstruct blobs from a complete set of data columns", () => {
+    // Generate test data
+    const blobs = [generateRandomBlob(), generateRandomBlob()];
+
+    // Compute commitments, cells, and proofs for each blob
+    const kzgCommitments: deneb.KZGCommitment[] = [];
+    const cells: fulu.Cell[][] = [];
+    const kzgProofs: deneb.KZGProof[] = [];
+    for (const blob of blobs) {
+      kzgCommitments.push(kzg.blobToKzgCommitment(blob));
+
+      const {cells: blobCells, proofs} = kzg.computeCellsAndKzgProofs(blob);
+      cells.push(blobCells);
+      kzgProofs.push(...proofs);
+    }
+
+    // Create a test block with the commitments
+    const signedBeaconBlock = ssz.fulu.SignedBeaconBlock.defaultValue();
+    signedBeaconBlock.message.body.blobKzgCommitments = kzgCommitments;
+
+    // Compute sidecars without providing cells
+    const sidecars = computeDataColumnSidecars(config, signedBeaconBlock, {
+      blobs,
+      kzgProofs,
+    });
+
+    expect(reconstructBlobs(sidecars)).toEqual(blobs);
   });
 });


### PR DESCRIPTION
**Motivation**

- https://github.com/ethereum/beacon-APIs/pull/546

**Description**

Add `GET /eth/v1/beacon/blobs/{block_id}` endpoint to retrieve blobs
- pre-fulu we can just return data stored in db
- post-fulu we need to reconstruct the blobs from stored data column sidecars


