### PR TITLE
fix: don't send validator registrations pre-genesis

### DIFF
--- a/packages/validator/src/services/prepareBeaconProposer.ts
+++ b/packages/validator/src/services/prepareBeaconProposer.ts
@@ -1,6 +1,6 @@
 import {ApiClient, routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {GENESIS_EPOCH, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Epoch, bellatrix} from "@lodestar/types";
 
 import {Metrics} from "../metrics.js";
@@ -71,6 +71,11 @@ export function pollBuilderValidatorRegistration(
   _metrics: Metrics | null
 ): void {
   async function registerValidator(epoch: Epoch): Promise<void> {
+    // Don't send validator registrations pre-genesis as mev-boost-relay will reject
+    // those registrations anyways if timestamp is before genesis time and we wanna
+    // avoid caching and re-sending them in subsequent requests
+    if (epoch < GENESIS_EPOCH) return;
+
     // Before bellatrix we don't need to update this data on bn/builder
     if (epoch < config.BELLATRIX_FORK_EPOCH - 1) return;
     const slot = epoch * SLOTS_PER_EPOCH;


### PR DESCRIPTION
**Motivation**

There was an [issue on fusaka-devnet-3 builder flow](https://discord.com/channels/595666850260713488/1399324773758140426) due to failed validator registrations. The problem was that we already sent validator registrations pre-genesis and unless the registration data (fee recipient and gas limit) changes we will keep sending the cached registration data (as per https://github.com/ChainSafe/lodestar/pull/4447) which reuses the previous timestamp. Why this is problematic is because mev-relay will reject those registrations if [timestamp is before genesis time](https://github.com/flashbots/mev-boost-relay/blob/344d5b67d5940b2bd4e462d790858dd05a445fdc/services/api/service.go#L2903) so it will keep rejecting them until we restart the validator client or change registration data to clear the cache.

**Description**

Don't send validator registrations pre-genesis, ie. only start sending and caching them once we are in epoch 0. This matches the behavior of Prysm (see https://github.com/OffchainLabs/prysm/pull/12847) which has been there for a while. The only downside I can see is that in epoch 0 we might not be able to produce builder blocks in the first few slots but that is really only relevant for devnets or local kurtosis runs but either way since mev-relay rejects the registrations anyways there is not much we can do in that case.
