### PR TITLE
fix: add eip7805 fork to getMaxBlobsPerBlock

### DIFF
--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -178,6 +178,7 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       const fork = this.getForkInfoAtEpoch(epoch).name;
 
       switch (fork) {
+        case ForkName.eip7805:
         case ForkName.electra:
           return config.MAX_BLOBS_PER_BLOCK_ELECTRA;
         case ForkName.deneb:


### PR DESCRIPTION
**Motivation**

FOCIL image failed in Kurtosis after switching to eip-7805 fork (slot 32):
```
[cl-1-lodestar-geth] Error: getBlobParameters is not available pre-fulu epoch=1
```
The error was triggered by `getBlobParameters()` and `getMaxBlobsPerBlock()` functions.
 
**Description**

Added `ForkName.eip7805` into `getMaxBlobsPerBlock()`. Now switching the forks works well in kurtosis.

**Steps to test or reproduce**

Kurtosis config file:
```
participants:
  - el_type: geth
    el_image: jihoonsg/geth-focil:4a583f4
    cl_type: lodestar
    cl_image: sibkatya/lodestar:focil-fork-fix
    count: 2
network_params:
  genesis_delay: 20
  electra_fork_epoch: 0
  eip7805_fork_epoch: 1
  seconds_per_slot: 6
  num_validator_keys_per_node: 256
snooper_enabled: true
additional_services:
  - dora
  - tx_fuzz
  - spamoor
  - prometheus_grafana
port_publisher:
  additional_services:
    enabled: true
    public_port_start: 65500
spamoor_params:
  spammers:
    - scenario: eoatx
      config:
        throughput: 100
    - scenario: uniswap-swaps
      config:
        throughput: 100
    - scenario: blob-combined
      config:
        throughput: 5
```