### PR TITLE
fix: use state slot instead of clock slot before gathering electra metrics

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1118,9 +1118,11 @@ export class BeaconChain implements IBeaconChain {
     metrics.forkChoice.nodes.set(forkChoiceMetrics.nodes);
     metrics.forkChoice.indices.set(forkChoiceMetrics.indices);
 
-    const fork = this.config.getForkName(this.clock.currentSlot);
+    const headState = this.getHeadState();
+    const fork = this.config.getForkName(headState.slot);
+
     if (isForkPostElectra(fork)) {
-      const headStateElectra = this.getHeadState() as BeaconStateElectra;
+      const headStateElectra = headState as BeaconStateElectra;
       metrics.pendingDeposits.set(headStateElectra.pendingDeposits.length);
       metrics.pendingPartialWithdrawals.set(headStateElectra.pendingPartialWithdrawals.length);
       metrics.pendingConsolidations.set(headStateElectra.pendingConsolidations.length);


### PR DESCRIPTION
**Motivation**

During sync we might not yet be in electra, hence `pendingDeposits` is undefined and we mistakenly use clock slot to determine if we should collect electra metrics but it should be based on state slot.

```
$ curl localhost:8008/metrics

TypeError: Cannot read properties of undefined (reading 'length')
    at BeaconChain.onScrapeMetrics (file:///usr/app/packages/beacon-node/src/chain/chain.ts:1123:68)
    at file:///usr/app/packages/beacon-node/src/chain/chain.ts:395:47
    at GaugeExtra.collect (file:///usr/app/packages/beacon-node/src/metrics/utils/gauge.ts:19:7)
    at GaugeExtra.get (/usr/app/node_modules/prom-client/lib/gauge.js:110:19)
    at RegistryMetricCreator.getMetricsAsString (/usr/app/node_modules/prom-client/lib/registry.js:35:21)
    at /usr/app/node_modules/prom-client/lib/registry.js:91:16
    at Array.map (<anonymous>)
    at RegistryMetricCreator.metrics (/usr/app/node_modules/prom-client/lib/registry.js:87:45)
    at Server.onRequest (file:///usr/app/packages/beacon-node/src/metrics/server/http.ts:47:64)
```

**Description**

 Use state slot instead of clock slot before gathering electra metrcis
