### PR TITLE
fix: update cgc during genesis and use finalized state

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1237,6 +1237,8 @@ export class BeaconChain implements IBeaconChain {
     this.logger.verbose("Fork choice finalized", {epoch: cp.epoch, root: cp.rootHex});
     this.seenBlockProposers.prune(computeStartSlotAtEpoch(cp.epoch));
 
+    this.updateValidatorsCustodyRequirement(cp);
+
     // TODO: Improve using regen here
     const {blockRoot, stateRoot, slot} = this.forkChoice.getHead();
     const headState = this.regen.getStateSync(stateRoot);
@@ -1252,8 +1254,6 @@ export class BeaconChain implements IBeaconChain {
     if (headState === null) {
       this.logger.verbose("Head state is null");
     }
-
-    this.updateValidatorsCustodyRequirement(cp);
   }
 
   async updateBeaconProposerData(epoch: Epoch, proposers: ProposerPreparationData[]): Promise<void> {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -44,7 +44,7 @@ import {ProcessShutdownCallback} from "@lodestar/validator";
 
 import {PrivateKey} from "@libp2p/interface";
 import {LoggerNode} from "@lodestar/logger/node";
-import {getValidatorsFromStateBytes} from "@lodestar/state-transition";
+import {getEffectiveBalancesFromStateBytes} from "@lodestar/state-transition";
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants/index.js";
 import {IBeaconDb} from "../db/index.js";
 import {IEth1ForBlockProduction} from "../eth1/index.js";
@@ -1292,13 +1292,18 @@ export class BeaconChain implements IBeaconChain {
       );
     }
 
-    const stateValidators =
-      stateOrBytes instanceof Uint8Array
-        ? getValidatorsFromStateBytes(this.config, stateOrBytes)
-        : stateOrBytes.validators;
-
+    // Validators attached to the node
     const validatorIndices = this.beaconProposerCache.getValidatorIndices();
-    const effectiveBalances = validatorIndices.map((index) => stateValidators.get(index).effectiveBalance);
+
+    let effectiveBalances: number[];
+    if (stateOrBytes instanceof Uint8Array) {
+      effectiveBalances = Array.from(
+        getEffectiveBalancesFromStateBytes(this.config, stateOrBytes, validatorIndices).values()
+      );
+    } else {
+      effectiveBalances = validatorIndices.map((index) => stateOrBytes.validators.get(index).effectiveBalance);
+    }
+
     const targetCustodyGroupCount = getValidatorsCustodyRequirement(this.config, effectiveBalances);
     // Only update if target is increased
     if (targetCustodyGroupCount > this.custodyConfig.targetCustodyGroupCount) {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -605,7 +605,7 @@ export class BeaconChain implements IBeaconChain {
 
   getStateByCheckpoint(
     checkpoint: CheckpointWithHex
-  ): {state: BeaconStateAllForks; executionOptimistic: boolean; finalized: boolean} | null {
+  ): {state: CachedBeaconStateAllForks; executionOptimistic: boolean; finalized: boolean} | null {
     // finalized or justified checkpoint states maynot be available with PersistentCheckpointStateCache, use getCheckpointStateOrBytes() api to get Uint8Array
     const cachedStateCtx = this.regen.getCheckpointStateSync(checkpoint);
     if (cachedStateCtx) {
@@ -1222,6 +1222,31 @@ export class BeaconChain implements IBeaconChain {
         this.eth1.startPollingMergeBlock();
       }
     }
+
+    // Disable dynamic custody updates for supernodes since they must maintain custody
+    // of all custody groups regardless of validator effective balances
+    if (!this.opts.supernode) {
+      const finalizedCheckpoint = this.forkChoice.getFinalizedCheckpoint();
+      const finalizedState = this.getStateByCheckpoint(finalizedCheckpoint)?.state;
+
+      if (finalizedState) {
+        // Update custody requirement based on finalized state
+        const validatorIndices = this.beaconProposerCache.getValidatorIndices();
+        const targetCustodyGroupCount = getValidatorsCustodyRequirement(finalizedState, validatorIndices, this.config);
+        // Only update if target is increased
+        if (targetCustodyGroupCount > this.custodyConfig.targetCustodyGroupCount) {
+          this.custodyConfig.updateTargetCustodyGroupCount(targetCustodyGroupCount);
+          this.logger.verbose("Updated target custody group count", {epoch, targetCustodyGroupCount});
+          this.emitter.emit(ChainEvent.updateTargetGroupCount, targetCustodyGroupCount);
+        }
+      } else {
+        this.logger.debug("No finalized state in cache to update target custody group count", {
+          epoch,
+          finalizedEpoch: finalizedCheckpoint.epoch,
+          finalizedRoot: finalizedCheckpoint.rootHex,
+        });
+      }
+    }
   }
 
   protected onNewHead(head: ProtoBlock): void {
@@ -1247,20 +1272,6 @@ export class BeaconChain implements IBeaconChain {
 
     if (headState) {
       this.opPool.pruneAll(headBlock, headState);
-
-      // Disable dynamic custody updates for supernodes since they must maintain custody
-      // of all custody groups regardless of validator effective balances
-      if (!this.opts.supernode) {
-        // Update custody requirement based on finalized state
-        const validatorIndices = this.beaconProposerCache.getValidatorIndices();
-        const targetCustodyGroupCount = getValidatorsCustodyRequirement(headState, validatorIndices, this.config);
-        // only update if target is increased
-        if (targetCustodyGroupCount > this.custodyConfig.targetCustodyGroupCount) {
-          this.custodyConfig.updateTargetCustodyGroupCount(targetCustodyGroupCount);
-          this.logger.verbose(`Updated targetCustodyGroupCount=${this.custodyConfig.targetCustodyGroupCount}`);
-          this.emitter.emit(ChainEvent.updateTargetGroupCount, this.custodyConfig.targetCustodyGroupCount);
-        }
-      }
     }
 
     if (headState === null) {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -44,6 +44,7 @@ import {ProcessShutdownCallback} from "@lodestar/validator";
 
 import {PrivateKey} from "@libp2p/interface";
 import {LoggerNode} from "@lodestar/logger/node";
+import {getValidatorsFromStateBytes} from "@lodestar/state-transition";
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants/index.js";
 import {IBeaconDb} from "../db/index.js";
 import {IEth1ForBlockProduction} from "../eth1/index.js";
@@ -605,7 +606,7 @@ export class BeaconChain implements IBeaconChain {
 
   getStateByCheckpoint(
     checkpoint: CheckpointWithHex
-  ): {state: CachedBeaconStateAllForks; executionOptimistic: boolean; finalized: boolean} | null {
+  ): {state: BeaconStateAllForks; executionOptimistic: boolean; finalized: boolean} | null {
     // finalized or justified checkpoint states maynot be available with PersistentCheckpointStateCache, use getCheckpointStateOrBytes() api to get Uint8Array
     const cachedStateCtx = this.regen.getCheckpointStateSync(checkpoint);
     if (cachedStateCtx) {
@@ -1237,7 +1238,8 @@ export class BeaconChain implements IBeaconChain {
     this.logger.verbose("Fork choice finalized", {epoch: cp.epoch, root: cp.rootHex});
     this.seenBlockProposers.prune(computeStartSlotAtEpoch(cp.epoch));
 
-    this.updateValidatorsCustodyRequirement(cp);
+    // Update validator custody to account for effective balance changes
+    await this.updateValidatorsCustodyRequirement(cp);
 
     // TODO: Improve using regen here
     const {blockRoot, stateRoot, slot} = this.forkChoice.getHead();
@@ -1268,38 +1270,42 @@ export class BeaconChain implements IBeaconChain {
     // Only update validator custody if we discovered new validators
     if (newValidatorCount > previousValidatorCount) {
       const finalizedCheckpoint = this.forkChoice.getFinalizedCheckpoint();
-      this.updateValidatorsCustodyRequirement(finalizedCheckpoint);
+      await this.updateValidatorsCustodyRequirement(finalizedCheckpoint);
     }
   }
 
-  private updateValidatorsCustodyRequirement(finalizedCheckpoint: CheckpointWithHex): void {
+  private async updateValidatorsCustodyRequirement(finalizedCheckpoint: CheckpointWithHex): Promise<void> {
     if (this.opts.supernode) {
       // Disable dynamic custody updates for supernodes since they must maintain custody
       // of all custody groups regardless of validator effective balances
       return;
     }
 
-    const finalizedState = this.getStateByCheckpoint(finalizedCheckpoint)?.state;
+    // Update custody requirement based on finalized state
+    const stateOrBytes = (await this.getStateOrBytesByCheckpoint(finalizedCheckpoint))?.state;
 
-    if (finalizedState) {
-      // Update custody requirement based on finalized state
-      const validatorIndices = this.beaconProposerCache.getValidatorIndices();
-      const targetCustodyGroupCount = getValidatorsCustodyRequirement(finalizedState, validatorIndices, this.config);
-      // Only update if target is increased
-      if (targetCustodyGroupCount > this.custodyConfig.targetCustodyGroupCount) {
-        this.custodyConfig.updateTargetCustodyGroupCount(targetCustodyGroupCount);
-        this.logger.verbose("Updated target custody group count", {
-          finalizedEpoch: finalizedCheckpoint.epoch,
-          validatorCount: validatorIndices.length,
-          targetCustodyGroupCount,
-        });
-        this.emitter.emit(ChainEvent.updateTargetGroupCount, targetCustodyGroupCount);
-      }
-    } else {
-      this.logger.debug("No finalized state in cache to update target custody group count", {
+    if (!stateOrBytes) {
+      throw Error(
+        `No finalized state for epoch ${finalizedCheckpoint.epoch} and root ${finalizedCheckpoint.rootHex} to update target custody group count`
+      );
+    }
+
+    const stateValidators =
+      stateOrBytes instanceof Uint8Array
+        ? getValidatorsFromStateBytes(this.config, stateOrBytes)
+        : stateOrBytes.validators;
+
+    const validatorIndices = this.beaconProposerCache.getValidatorIndices();
+    const targetCustodyGroupCount = getValidatorsCustodyRequirement(this.config, stateValidators, validatorIndices);
+    // Only update if target is increased
+    if (targetCustodyGroupCount > this.custodyConfig.targetCustodyGroupCount) {
+      this.custodyConfig.updateTargetCustodyGroupCount(targetCustodyGroupCount);
+      this.logger.verbose("Updated target custody group count", {
         finalizedEpoch: finalizedCheckpoint.epoch,
-        finalizedRoot: finalizedCheckpoint.rootHex,
+        validatorCount: validatorIndices.length,
+        targetCustodyGroupCount,
       });
+      this.emitter.emit(ChainEvent.updateTargetGroupCount, targetCustodyGroupCount);
     }
   }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1298,7 +1298,8 @@ export class BeaconChain implements IBeaconChain {
         : stateOrBytes.validators;
 
     const validatorIndices = this.beaconProposerCache.getValidatorIndices();
-    const targetCustodyGroupCount = getValidatorsCustodyRequirement(this.config, stateValidators, validatorIndices);
+    const effectiveBalances = validatorIndices.map((index) => stateValidators.get(index).effectiveBalance);
+    const targetCustodyGroupCount = getValidatorsCustodyRequirement(this.config, effectiveBalances);
     // Only update if target is increased
     if (targetCustodyGroupCount > this.custodyConfig.targetCustodyGroupCount) {
       this.custodyConfig.updateTargetCustodyGroupCount(targetCustodyGroupCount);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1222,31 +1222,6 @@ export class BeaconChain implements IBeaconChain {
         this.eth1.startPollingMergeBlock();
       }
     }
-
-    // Disable dynamic custody updates for supernodes since they must maintain custody
-    // of all custody groups regardless of validator effective balances
-    if (!this.opts.supernode) {
-      const finalizedCheckpoint = this.forkChoice.getFinalizedCheckpoint();
-      const finalizedState = this.getStateByCheckpoint(finalizedCheckpoint)?.state;
-
-      if (finalizedState) {
-        // Update custody requirement based on finalized state
-        const validatorIndices = this.beaconProposerCache.getValidatorIndices();
-        const targetCustodyGroupCount = getValidatorsCustodyRequirement(finalizedState, validatorIndices, this.config);
-        // Only update if target is increased
-        if (targetCustodyGroupCount > this.custodyConfig.targetCustodyGroupCount) {
-          this.custodyConfig.updateTargetCustodyGroupCount(targetCustodyGroupCount);
-          this.logger.verbose("Updated target custody group count", {epoch, targetCustodyGroupCount});
-          this.emitter.emit(ChainEvent.updateTargetGroupCount, targetCustodyGroupCount);
-        }
-      } else {
-        this.logger.debug("No finalized state in cache to update target custody group count", {
-          epoch,
-          finalizedEpoch: finalizedCheckpoint.epoch,
-          finalizedRoot: finalizedCheckpoint.rootHex,
-        });
-      }
-    }
   }
 
   protected onNewHead(head: ProtoBlock): void {
@@ -1277,11 +1252,54 @@ export class BeaconChain implements IBeaconChain {
     if (headState === null) {
       this.logger.verbose("Head state is null");
     }
+
+    this.updateValidatorsCustodyRequirement(cp);
   }
 
   async updateBeaconProposerData(epoch: Epoch, proposers: ProposerPreparationData[]): Promise<void> {
+    const previousValidatorCount = this.beaconProposerCache.getValidatorIndices().length;
+
     for (const proposer of proposers) {
       this.beaconProposerCache.add(epoch, proposer);
+    }
+
+    const newValidatorCount = this.beaconProposerCache.getValidatorIndices().length;
+
+    // Only update validator custody if we discovered new validators
+    if (newValidatorCount > previousValidatorCount) {
+      const finalizedCheckpoint = this.forkChoice.getFinalizedCheckpoint();
+      this.updateValidatorsCustodyRequirement(finalizedCheckpoint);
+    }
+  }
+
+  private updateValidatorsCustodyRequirement(finalizedCheckpoint: CheckpointWithHex): void {
+    if (this.opts.supernode) {
+      // Disable dynamic custody updates for supernodes since they must maintain custody
+      // of all custody groups regardless of validator effective balances
+      return;
+    }
+
+    const finalizedState = this.getStateByCheckpoint(finalizedCheckpoint)?.state;
+
+    if (finalizedState) {
+      // Update custody requirement based on finalized state
+      const validatorIndices = this.beaconProposerCache.getValidatorIndices();
+      const targetCustodyGroupCount = getValidatorsCustodyRequirement(finalizedState, validatorIndices, this.config);
+      // Only update if target is increased
+      if (targetCustodyGroupCount > this.custodyConfig.targetCustodyGroupCount) {
+        this.custodyConfig.updateTargetCustodyGroupCount(targetCustodyGroupCount);
+        this.logger.verbose("Updated target custody group count", {
+          finalizedEpoch: finalizedCheckpoint.epoch,
+          validatorCount: validatorIndices.length,
+          targetCustodyGroupCount,
+        });
+        this.emitter.emit(ChainEvent.updateTargetGroupCount, targetCustodyGroupCount);
+      }
+    } else {
+      this.logger.debug("No finalized state in cache to update target custody group count", {
+        finalizedEpoch: finalizedCheckpoint.epoch,
+        finalizedRoot: finalizedCheckpoint.rootHex,
+      });
     }
   }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1297,9 +1297,7 @@ export class BeaconChain implements IBeaconChain {
 
     let effectiveBalances: number[];
     if (stateOrBytes instanceof Uint8Array) {
-      effectiveBalances = Array.from(
-        getEffectiveBalancesFromStateBytes(this.config, stateOrBytes, validatorIndices).values()
-      );
+      effectiveBalances = getEffectiveBalancesFromStateBytes(this.config, stateOrBytes, validatorIndices);
     } else {
       effectiveBalances = validatorIndices.map((index) => stateOrBytes.validators.get(index).effectiveBalance);
     }

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1311,7 +1311,7 @@ export class BeaconChain implements IBeaconChain {
         validatorCount: validatorIndices.length,
         targetCustodyGroupCount,
       });
-      this.emitter.emit(ChainEvent.updateTargetGroupCount, targetCustodyGroupCount);
+      this.emitter.emit(ChainEvent.updateTargetCustodyGroupCount, targetCustodyGroupCount);
     }
   }
 

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -103,6 +103,7 @@ export class MetadataController {
       return;
     }
     this.onSetValue(ENRKey.cgc, serializeCgc(custodyGroupCount));
+    this.logger.debug("Updated cgc field in ENR", {custodyGroupCount});
     this._metadata.seqNumber++;
     this._metadata.custodyGroupCount = custodyGroupCount;
   }

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -1,5 +1,4 @@
 import {digest} from "@chainsafe/as-sha256";
-import {ListCompositeTreeViewDU} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {
   DATA_COLUMN_SIDECAR_SUBNET_COUNT,
@@ -8,7 +7,7 @@ import {
   NUMBER_OF_CUSTODY_GROUPS,
 } from "@lodestar/params";
 import {signedBlockToSignedHeader} from "@lodestar/state-transition";
-import {ColumnIndex, CustodyIndex, SignedBeaconBlockHeader, ValidatorIndex, deneb, fulu} from "@lodestar/types";
+import {ColumnIndex, CustodyIndex, SignedBeaconBlockHeader, deneb, fulu} from "@lodestar/types";
 import {ssz} from "@lodestar/types";
 import {bytesToBigInt} from "@lodestar/utils";
 import {

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -144,17 +144,13 @@ function computeSubnetForDataColumn(columnIndex: ColumnIndex): number {
  * SPEC FUNCTION
  * https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.3/specs/fulu/validator.md#validator-custody
  */
-export function getValidatorsCustodyRequirement(
-  config: ChainForkConfig,
-  stateValidators: ListCompositeTreeViewDU<typeof ssz.phase0.Validator>,
-  validatorIndices: ValidatorIndex[]
-): number {
-  if (validatorIndices.length === 0) {
+export function getValidatorsCustodyRequirement(config: ChainForkConfig, effectiveBalances: number[]): number {
+  if (effectiveBalances.length === 0) {
     return config.CUSTODY_REQUIREMENT;
   }
 
-  const totalNodeEffectiveBalance = validatorIndices.reduce((total, validatorIndex) => {
-    return total + stateValidators.get(validatorIndex).effectiveBalance;
+  const totalNodeEffectiveBalance = effectiveBalances.reduce((total, effectiveBalance) => {
+    return total + effectiveBalance;
   }, 0);
 
   // Must custody one group for every BALANCE_PER_ADDITIONAL_CUSTODY_GROUP of effective balance

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -1,13 +1,13 @@
 import {digest} from "@chainsafe/as-sha256";
+import {ListCompositeTreeViewDU} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {
   DATA_COLUMN_SIDECAR_SUBNET_COUNT,
-  EFFECTIVE_BALANCE_INCREMENT,
   ForkName,
   NUMBER_OF_COLUMNS,
   NUMBER_OF_CUSTODY_GROUPS,
 } from "@lodestar/params";
-import {CachedBeaconStateAllForks, signedBlockToSignedHeader} from "@lodestar/state-transition";
+import {signedBlockToSignedHeader} from "@lodestar/state-transition";
 import {ColumnIndex, CustodyIndex, SignedBeaconBlockHeader, ValidatorIndex, deneb, fulu} from "@lodestar/types";
 import {ssz} from "@lodestar/types";
 import {bytesToBigInt} from "@lodestar/utils";
@@ -142,19 +142,19 @@ function computeSubnetForDataColumn(columnIndex: ColumnIndex): number {
  * Calculate the number of custody groups the node should subscribe to based on the node's effective balance
  *
  * SPEC FUNCTION
- * https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/validator.md#validator-custody
+ * https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.3/specs/fulu/validator.md#validator-custody
  */
 export function getValidatorsCustodyRequirement(
-  state: CachedBeaconStateAllForks,
-  validatorIndices: ValidatorIndex[],
-  config: ChainForkConfig
+  config: ChainForkConfig,
+  stateValidators: ListCompositeTreeViewDU<typeof ssz.phase0.Validator>,
+  validatorIndices: ValidatorIndex[]
 ): number {
   if (validatorIndices.length === 0) {
     return config.CUSTODY_REQUIREMENT;
   }
 
   const totalNodeEffectiveBalance = validatorIndices.reduce((total, validatorIndex) => {
-    return total + state.epochCtx.effectiveBalanceIncrements[validatorIndex] * EFFECTIVE_BALANCE_INCREMENT;
+    return total + stateValidators.get(validatorIndex).effectiveBalance;
   }, 0);
 
   // Must custody one group for every BALANCE_PER_ADDITIONAL_CUSTODY_GROUP of effective balance

--- a/packages/beacon-node/test/unit/util/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/util/dataColumn.test.ts
@@ -1,9 +1,8 @@
-import {ListCompositeTreeViewDU, fromHexString} from "@chainsafe/ssz";
+import {fromHexString} from "@chainsafe/ssz";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {ChainForkConfig} from "@lodestar/config";
 import {NUMBER_OF_COLUMNS, NUMBER_OF_CUSTODY_GROUPS} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
-import {ValidatorIndex} from "@lodestar/types";
 import {bigIntToBytes} from "@lodestar/utils";
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
 
@@ -15,19 +14,9 @@ import {getMockedBeaconChain} from "../../mocks/mockedBeaconChain.js";
 import {generateRandomBlob, transactionForKzgCommitment} from "../../utils/kzg.js";
 
 describe("getValidatorsCustodyRequirement", () => {
-  let stateValidators: ListCompositeTreeViewDU<typeof ssz.phase0.Validator>;
   let config: ChainForkConfig;
 
   beforeEach(() => {
-    const defaultValidator = ssz.phase0.Validator.defaultValue();
-
-    stateValidators = ssz.phase0.Validators.toViewDU(
-      Array.from({length: NUMBER_OF_CUSTODY_GROUPS + 1}, () => ({
-        ...defaultValidator,
-        effectiveBalance: 32000000000, // Each validator has 32 ETH (1 increment)
-      }))
-    );
-
     config = createChainForkConfig({
       ...defaultChainConfig,
       ALTAIR_FORK_EPOCH: 0,
@@ -43,28 +32,28 @@ describe("getValidatorsCustodyRequirement", () => {
   });
 
   it("should return minimum requirement when total balance is below the balance per additional custody group", () => {
-    const validatorIndices: ValidatorIndex[] = [0, 1]; // 2 validators with 32 ETH each = 64 ETH total
-    const result = getValidatorsCustodyRequirement(config, stateValidators, validatorIndices);
+    const effectiveBalances = [32000000000, 32000000000]; // 2 validators with 32 ETH each = 64 ETH total
+    const result = getValidatorsCustodyRequirement(config, effectiveBalances);
     expect(result).toBe(config.VALIDATOR_CUSTODY_REQUIREMENT);
   });
 
   it("should calculate correct number of groups based on total balance", () => {
     // Create a state with 10 validators with 32 ETH each = 320 ETH total
-    const validatorIndices: ValidatorIndex[] = Array.from({length: 10}, (_, i) => i);
-    const result = getValidatorsCustodyRequirement(config, stateValidators, validatorIndices);
+    const effectiveBalances = Array.from({length: 10}, () => 32000000000);
+    const result = getValidatorsCustodyRequirement(config, effectiveBalances);
     expect(result).toBe(10);
   });
 
   it("should cap at maximum number of custody groups", () => {
     // Create a state with enough validators to exceed max groups
-    const validatorIndices: ValidatorIndex[] = Array.from({length: NUMBER_OF_CUSTODY_GROUPS + 1}, (_, i) => i);
-    const result = getValidatorsCustodyRequirement(config, stateValidators, validatorIndices);
+    const effectiveBalances = Array.from({length: NUMBER_OF_CUSTODY_GROUPS + 1}, () => 32000000000);
+    const result = getValidatorsCustodyRequirement(config, effectiveBalances);
     expect(result).toBe(NUMBER_OF_CUSTODY_GROUPS);
   });
 
   it("should handle zero validators", () => {
-    const validatorIndices: ValidatorIndex[] = [];
-    const result = getValidatorsCustodyRequirement(config, stateValidators, validatorIndices);
+    const effectiveBalances: number[] = [];
+    const result = getValidatorsCustodyRequirement(config, effectiveBalances);
     expect(result).toBe(config.CUSTODY_REQUIREMENT);
   });
 });

--- a/packages/beacon-node/test/unit/util/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/util/dataColumn.test.ts
@@ -19,7 +19,6 @@ describe("getValidatorsCustodyRequirement", () => {
   let config: ChainForkConfig;
 
   beforeEach(() => {
-    // Create a mock state validators
     const defaultValidator = ssz.phase0.Validator.defaultValue();
 
     stateValidators = ssz.phase0.Validators.toViewDU(
@@ -29,7 +28,6 @@ describe("getValidatorsCustodyRequirement", () => {
       }))
     );
 
-    // Create a proper config using createChainForkConfig
     config = createChainForkConfig({
       ...defaultChainConfig,
       ALTAIR_FORK_EPOCH: 0,

--- a/packages/beacon-node/test/unit/util/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/util/dataColumn.test.ts
@@ -1,8 +1,7 @@
-import {fromHexString} from "@chainsafe/ssz";
+import {ListCompositeTreeViewDU, fromHexString} from "@chainsafe/ssz";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {ChainForkConfig} from "@lodestar/config";
 import {NUMBER_OF_COLUMNS, NUMBER_OF_CUSTODY_GROUPS} from "@lodestar/params";
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {ValidatorIndex} from "@lodestar/types";
 import {bigIntToBytes} from "@lodestar/utils";
@@ -16,16 +15,19 @@ import {getMockedBeaconChain} from "../../mocks/mockedBeaconChain.js";
 import {generateRandomBlob, transactionForKzgCommitment} from "../../utils/kzg.js";
 
 describe("getValidatorsCustodyRequirement", () => {
-  let state: CachedBeaconStateAllForks;
+  let stateValidators: ListCompositeTreeViewDU<typeof ssz.phase0.Validator>;
   let config: ChainForkConfig;
 
   beforeEach(() => {
-    // Create a mock state with validators effective balance increments
-    state = {
-      epochCtx: {
-        effectiveBalanceIncrements: new Uint8Array(NUMBER_OF_CUSTODY_GROUPS + 1).fill(32), // Each validator has 32 ETH (1 increment)
-      },
-    } as unknown as CachedBeaconStateAllForks;
+    // Create a mock state validators
+    const defaultValidator = ssz.phase0.Validator.defaultValue();
+
+    stateValidators = ssz.phase0.Validators.toViewDU(
+      Array.from({length: NUMBER_OF_CUSTODY_GROUPS + 1}, () => ({
+        ...defaultValidator,
+        effectiveBalance: 32000000000, // Each validator has 32 ETH (1 increment)
+      }))
+    );
 
     // Create a proper config using createChainForkConfig
     config = createChainForkConfig({
@@ -44,30 +46,27 @@ describe("getValidatorsCustodyRequirement", () => {
 
   it("should return minimum requirement when total balance is below the balance per additional custody group", () => {
     const validatorIndices: ValidatorIndex[] = [0, 1]; // 2 validators with 32 ETH each = 64 ETH total
-    const result = getValidatorsCustodyRequirement(state, validatorIndices, config);
+    const result = getValidatorsCustodyRequirement(config, stateValidators, validatorIndices);
     expect(result).toBe(config.VALIDATOR_CUSTODY_REQUIREMENT);
   });
 
   it("should calculate correct number of groups based on total balance", () => {
     // Create a state with 10 validators with 32 ETH each = 320 ETH total
-    const validatorIndices: ValidatorIndex[] = Array.from({length: 10}, (_, i) => i as ValidatorIndex);
-    const result = getValidatorsCustodyRequirement(state, validatorIndices, config);
+    const validatorIndices: ValidatorIndex[] = Array.from({length: 10}, (_, i) => i);
+    const result = getValidatorsCustodyRequirement(config, stateValidators, validatorIndices);
     expect(result).toBe(10);
   });
 
   it("should cap at maximum number of custody groups", () => {
     // Create a state with enough validators to exceed max groups
-    const validatorIndices: ValidatorIndex[] = Array.from(
-      {length: NUMBER_OF_CUSTODY_GROUPS + 1},
-      (_, i) => i as ValidatorIndex
-    );
-    const result = getValidatorsCustodyRequirement(state, validatorIndices, config);
+    const validatorIndices: ValidatorIndex[] = Array.from({length: NUMBER_OF_CUSTODY_GROUPS + 1}, (_, i) => i);
+    const result = getValidatorsCustodyRequirement(config, stateValidators, validatorIndices);
     expect(result).toBe(NUMBER_OF_CUSTODY_GROUPS);
   });
 
   it("should handle zero validators", () => {
     const validatorIndices: ValidatorIndex[] = [];
-    const result = getValidatorsCustodyRequirement(state, validatorIndices, config);
+    const result = getValidatorsCustodyRequirement(config, stateValidators, validatorIndices);
     expect(result).toBe(config.CUSTODY_REQUIREMENT);
   });
 });

--- a/packages/state-transition/src/util/loadState/index.ts
+++ b/packages/state-transition/src/util/loadState/index.ts
@@ -1,2 +1,2 @@
 export {loadState, loadStateAndValidators} from "./loadState.js";
-export {getValidatorsFromStateBytes} from "./loadValidator.js";
+export {getEffectiveBalancesFromStateBytes} from "./loadValidator.js";

--- a/packages/state-transition/src/util/loadState/index.ts
+++ b/packages/state-transition/src/util/loadState/index.ts
@@ -1,1 +1,2 @@
 export {loadState, loadStateAndValidators} from "./loadState.js";
+export {getValidatorsFromStateBytes} from "./loadValidator.js";

--- a/packages/state-transition/src/util/loadState/loadValidator.ts
+++ b/packages/state-transition/src/util/loadState/loadValidator.ts
@@ -51,7 +51,7 @@ export function getEffectiveBalancesFromStateBytes(
   config: ChainForkConfig,
   stateBytes: Uint8Array,
   validatorIndices: ValidatorIndex[]
-): Map<ValidatorIndex, number> {
+): number[] {
   // stateType could be any types, casting just to make typescript happy
   const stateType = getStateTypeFromBytes(config, stateBytes) as typeof ssz.phase0.BeaconState;
   const stateView = new DataView(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength);
@@ -62,7 +62,7 @@ export function getEffectiveBalancesFromStateBytes(
   const validatorsBytes = stateBytes.subarray(validatorsRange.start, validatorsRange.end);
   const validatorSize = ssz.phase0.Validator.fixedSize as number;
 
-  const effectiveBalances = new Map<ValidatorIndex, number>();
+  const effectiveBalances: number[] = [];
 
   for (const index of validatorIndices) {
     const validatorBytes = validatorsBytes.subarray(index * validatorSize, (index + 1) * validatorSize);
@@ -70,7 +70,7 @@ export function getEffectiveBalancesFromStateBytes(
       throw Error(`Validator index ${index} out of range`);
     }
     const validator = ssz.phase0.Validator.deserialize(validatorBytes);
-    effectiveBalances.set(index, validator.effectiveBalance);
+    effectiveBalances.push(validator.effectiveBalance);
   }
 
   return effectiveBalances;

--- a/packages/state-transition/src/util/loadState/loadValidator.ts
+++ b/packages/state-transition/src/util/loadState/loadValidator.ts
@@ -1,5 +1,7 @@
-import {CompositeViewDU} from "@chainsafe/ssz";
+import {CompositeViewDU, ListCompositeTreeViewDU} from "@chainsafe/ssz";
+import {ChainForkConfig} from "@lodestar/config";
 import {deserializeContainerIgnoreFields, ssz} from "@lodestar/types";
+import {getStateTypeFromBytes} from "../sszBytes.js";
 
 /**
  * Load validator from bytes given a seed validator.
@@ -40,4 +42,22 @@ function getSameFields(
   }
 
   return ignoredFields;
+}
+
+/**
+ * Extract and deserialize validators from state bytes
+ */
+export function getValidatorsFromStateBytes(
+  config: ChainForkConfig,
+  stateBytes: Uint8Array
+): ListCompositeTreeViewDU<typeof ssz.phase0.Validator> {
+  // stateType could be any types, casting just to make typescript happy
+  const stateType = getStateTypeFromBytes(config, stateBytes) as typeof ssz.phase0.BeaconState;
+  const dataView = new DataView(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength);
+  const fieldRanges = stateType.getFieldRanges(dataView, 0, stateBytes.length);
+  const allFields = Object.keys(stateType.fields);
+  const validatorFieldIndex = allFields.indexOf("validators");
+  const validatorRange = fieldRanges[validatorFieldIndex];
+  const validatorsBytes = stateBytes.subarray(validatorRange.start, validatorRange.end);
+  return ssz.phase0.Validators.deserializeToViewDU(validatorsBytes);
 }

--- a/packages/state-transition/src/util/loadState/loadValidator.ts
+++ b/packages/state-transition/src/util/loadState/loadValidator.ts
@@ -1,6 +1,6 @@
-import {CompositeViewDU, ListCompositeTreeViewDU} from "@chainsafe/ssz";
+import {CompositeViewDU} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {deserializeContainerIgnoreFields, ssz} from "@lodestar/types";
+import {ValidatorIndex, deserializeContainerIgnoreFields, ssz} from "@lodestar/types";
 import {getStateTypeFromBytes} from "../sszBytes.js";
 
 /**
@@ -45,19 +45,33 @@ function getSameFields(
 }
 
 /**
- * Extract and deserialize validators from state bytes
+ * Extract and deserialize validator effective balances from state bytes
  */
-export function getValidatorsFromStateBytes(
+export function getEffectiveBalancesFromStateBytes(
   config: ChainForkConfig,
-  stateBytes: Uint8Array
-): ListCompositeTreeViewDU<typeof ssz.phase0.Validator> {
+  stateBytes: Uint8Array,
+  validatorIndices: ValidatorIndex[]
+): Map<ValidatorIndex, number> {
   // stateType could be any types, casting just to make typescript happy
   const stateType = getStateTypeFromBytes(config, stateBytes) as typeof ssz.phase0.BeaconState;
-  const dataView = new DataView(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength);
-  const fieldRanges = stateType.getFieldRanges(dataView, 0, stateBytes.length);
-  const allFields = Object.keys(stateType.fields);
-  const validatorFieldIndex = allFields.indexOf("validators");
-  const validatorRange = fieldRanges[validatorFieldIndex];
-  const validatorsBytes = stateBytes.subarray(validatorRange.start, validatorRange.end);
-  return ssz.phase0.Validators.deserializeToViewDU(validatorsBytes);
+  const stateView = new DataView(stateBytes.buffer, stateBytes.byteOffset, stateBytes.byteLength);
+  const stateFieldRanges = stateType.getFieldRanges(stateView, 0, stateBytes.length);
+  const stateFields = Object.keys(stateType.fields);
+  const validatorsFieldIndex = stateFields.indexOf("validators");
+  const validatorsRange = stateFieldRanges[validatorsFieldIndex];
+  const validatorsBytes = stateBytes.subarray(validatorsRange.start, validatorsRange.end);
+  const validatorSize = ssz.phase0.Validator.fixedSize as number;
+
+  const effectiveBalances = new Map<ValidatorIndex, number>();
+
+  for (const index of validatorIndices) {
+    const validatorBytes = validatorsBytes.subarray(index * validatorSize, (index + 1) * validatorSize);
+    if (validatorBytes.byteLength === 0) {
+      throw Error(`Validator index ${index} out of range`);
+    }
+    const validator = ssz.phase0.Validator.deserialize(validatorBytes);
+    effectiveBalances.set(index, validator.effectiveBalance);
+  }
+
+  return effectiveBalances;
 }

--- a/packages/state-transition/test/unit/util/loadState/loadValidator.test.ts
+++ b/packages/state-transition/test/unit/util/loadState/loadValidator.test.ts
@@ -127,19 +127,15 @@ describe("getEffectiveBalancesFromStateBytes", () => {
   it("should get the effective balance of a single validator", () => {
     const validatorIndices = [1];
     const effectiveBalances = getEffectiveBalancesFromStateBytes(config, stateBytes, validatorIndices);
-    expect(effectiveBalances.size).toBe(1);
-    expect(effectiveBalances.get(1)).toBe(balance);
+    expect(effectiveBalances.length).toBe(1);
+    expect(effectiveBalances[0]).toBe(balance);
   });
 
   it("should get the effective balances of multiple validators", () => {
     const validatorIndices = [1, 5, 9];
     const effectiveBalances = getEffectiveBalancesFromStateBytes(config, stateBytes, validatorIndices);
-    expect(effectiveBalances.size).toBe(3);
-    expect(Array.from(effectiveBalances.entries())).toEqual([
-      [1, balance],
-      [5, balance],
-      [9, balance],
-    ]);
+    expect(effectiveBalances.length).toBe(3);
+    expect(effectiveBalances).toEqual(Array.from({length: validatorIndices.length}, () => balance));
   });
 
   it("should throw an error if validator index is out of range", () => {

--- a/packages/state-transition/test/unit/util/loadState/loadValidator.test.ts
+++ b/packages/state-transition/test/unit/util/loadState/loadValidator.test.ts
@@ -1,7 +1,10 @@
 import {CompositeViewDU} from "@chainsafe/ssz";
+import {config} from "@lodestar/config/default";
 import {phase0, ssz} from "@lodestar/types";
 import {describe, expect, it} from "vitest";
-import {loadValidator} from "../../../../src/util/loadState/loadValidator.js";
+import {getEffectiveBalancesFromStateBytes, loadValidator} from "../../../../src/util/loadState/loadValidator.js";
+import {generateState} from "../../../utils/state.js";
+import {generateValidators} from "../../../utils/validator.js";
 
 describe("loadValidator", () => {
   const validatorValue: phase0.Validator = {
@@ -111,5 +114,36 @@ describe("loadValidator", () => {
     const loadedValidator = loadValidator(validator, newValidatorBytes);
     expect(Buffer.compare(loadedValidator.hashTreeRoot(), newValidator.hashTreeRoot())).toBe(0);
     expect(Buffer.compare(loadedValidator.serialize(), newValidator.serialize())).toBe(0);
+  });
+});
+
+describe("getEffectiveBalancesFromStateBytes", () => {
+  const numValidators = 10;
+  const balance = 32000000000;
+  const validators = generateValidators(numValidators, {balance});
+  const state = generateState({validators: validators});
+  const stateBytes = state.serialize();
+
+  it("should get the effective balance of a single validator", () => {
+    const validatorIndices = [1];
+    const effectiveBalances = getEffectiveBalancesFromStateBytes(config, stateBytes, validatorIndices);
+    expect(effectiveBalances.size).toBe(1);
+    expect(effectiveBalances.get(1)).toBe(balance);
+  });
+
+  it("should get the effective balances of multiple validators", () => {
+    const validatorIndices = [1, 5, 9];
+    const effectiveBalances = getEffectiveBalancesFromStateBytes(config, stateBytes, validatorIndices);
+    expect(effectiveBalances.size).toBe(3);
+    expect(Array.from(effectiveBalances.entries())).toEqual([
+      [1, balance],
+      [5, balance],
+      [9, balance],
+    ]);
+  });
+
+  it("should throw an error if validator index is out of range", () => {
+    const validatorIndices = [numValidators];
+    expect(() => getEffectiveBalancesFromStateBytes(config, stateBytes, validatorIndices)).toThrowError();
   });
 });


### PR DESCRIPTION
**Motivation**

- Closes https://github.com/ChainSafe/lodestar/issues/8093

**Description**

- update validator custody group count (cgc) in the following cases:
  - during registration if number of attached validators is increased, this ensures we update during (or before) genesis
  - `onForkChoiceFinalized`to account for effective balance changes of attached validators
- use finalized state instead of head state as per [spec](https://github.com/ethereum/consensus-specs/blob/01454a2afc442a32644df45deb8f81687e461785/specs/fulu/validator.md?plain=1#L115) 

