### PR TITLE
fix: initialize metadata controller with persisted enr cgc

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -240,8 +240,9 @@ export class NetworkCore implements INetworkCore {
     // biome-ignore lint/complexity/useLiteralKeys: `discovery` is a private attribute
     discv5 = peerManager["discovery"]?.discv5;
 
+    // Initialize metadata controller with initial ENR
     // Initialize ENR with clock's fork
-    metadata.upstreamValues(clock.currentEpoch);
+    metadata.init(clock.currentEpoch, (await discv5?.enr())?.toENR());
 
     return new NetworkCore({
       libp2p,

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -61,7 +61,7 @@ export class MetadataController {
 
     // First synchronize the metadata with the current ENR values
     if (enrSeq) this._metadata.seqNumber = enrSeq;
-    if (!enrCgc || enrCgc < this._metadata.custodyGroupCount) {
+    if (enrCgc === undefined || enrCgc < this._metadata.custodyGroupCount) {
       this.onSetValue(ENRKey.cgc, serializeCgc(this._metadata.custodyGroupCount));
     } else {
       this._metadata.custodyGroupCount = enrCgc;

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -59,9 +59,13 @@ export class MetadataController {
     const enrCgcRaw = enr?.kvs.get(ENRKey.cgc);
     const enrCgc = enrCgcRaw ? deserializeCgc(enrCgcRaw) : undefined;
 
-    // First update the metadata with the current ENR values
+    // First synchronize the metadata with the current ENR values
     if (enrSeq) this._metadata.seqNumber = enrSeq;
-    if (enrCgc) this._metadata.custodyGroupCount = enrCgc;
+    if (!enrCgc || enrCgc < this._metadata.custodyGroupCount) {
+      this.onSetValue(ENRKey.cgc, serializeCgc(this._metadata.custodyGroupCount));
+    } else {
+      this._metadata.custodyGroupCount = enrCgc;
+    }
 
     // Then update the metadata (and ENR) based on the current clock epoch
 

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -1,11 +1,10 @@
+import {ENR} from "@chainsafe/enr";
 import {BitArray} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {ForkSeq} from "@lodestar/params";
-import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, fulu, phase0, ssz} from "@lodestar/types";
 import {Logger, toHex} from "@lodestar/utils";
 import {FAR_FUTURE_EPOCH} from "../constants/index.js";
-import {serializeCgc} from "../util/metadata.js";
+import {deserializeCgc, serializeCgc} from "../util/metadata.js";
 import {getCurrentAndNextForkBoundary} from "./forks.js";
 import {NetworkConfig} from "./networkConfig.js";
 
@@ -22,9 +21,7 @@ export enum SubnetType {
   syncnets = "syncnets",
 }
 
-export type MetadataOpts = {
-  metadata?: fulu.Metadata;
-};
+export type MetadataOpts = Record<string, never>;
 
 export type MetadataModules = {
   networkConfig: NetworkConfig;
@@ -43,32 +40,33 @@ export class MetadataController {
   private logger: Logger;
   private _metadata: fulu.Metadata;
 
-  constructor(opts: MetadataOpts, modules: MetadataModules) {
+  constructor(_: MetadataOpts, modules: MetadataModules) {
     this.networkConfig = modules.networkConfig;
     this.logger = modules.logger;
     this.onSetValue = modules.onSetValue;
-    this._metadata = opts.metadata ?? {
+    this._metadata = {
       ...ssz.fulu.Metadata.defaultValue(),
       custodyGroupCount: modules.networkConfig.getCustodyConfig().targetCustodyGroupCount,
     };
   }
 
-  upstreamValues(currentEpoch: Epoch): void {
+  /**
+   * Initialize metadata controller with initial ENR
+   * Initialize ENR with clock's fork
+   */
+  init(currentEpoch: Epoch, enr?: ENR): void {
+    const enrSeq = enr?.seq;
+    const enrCgcRaw = enr?.kvs.get(ENRKey.cgc);
+    const enrCgc = enrCgcRaw ? deserializeCgc(enrCgcRaw) : undefined;
+
+    // First update the metadata with the current ENR values
+    if (enrSeq) this._metadata.seqNumber = enrSeq;
+    if (enrCgc) this._metadata.custodyGroupCount = enrCgc;
+
+    // Then update the metadata (and ENR) based on the current clock epoch
+
     // updateEth2Field() MUST be called with clock epoch
     this.updateEth2Field(currentEpoch);
-
-    this.onSetValue(ENRKey.attnets, ssz.phase0.AttestationSubnets.serialize(this._metadata.attnets));
-
-    const config = this.networkConfig.getConfig();
-
-    if (config.getForkSeq(computeStartSlotAtEpoch(currentEpoch)) >= ForkSeq.altair) {
-      // Only persist syncnets if altair fork is already activated. If currentFork is altair but head is phase0
-      // adding syncnets to the ENR is not a problem, we will just have a useless field for a few hours.
-      this.onSetValue(ENRKey.syncnets, ssz.phase0.AttestationSubnets.serialize(this._metadata.syncnets));
-    }
-
-    // Set CGC regardless of fork. It may be useful to clients before Fulu, and will be ignored otherwise.
-    this.onSetValue(ENRKey.cgc, serializeCgc(this._metadata.custodyGroupCount));
   }
 
   get seqNumber(): bigint {

--- a/packages/beacon-node/src/util/metadata.ts
+++ b/packages/beacon-node/src/util/metadata.ts
@@ -1,4 +1,4 @@
-import {intToBytes} from "@lodestar/utils";
+import {bytesToInt, intToBytes} from "@lodestar/utils";
 import {ClientCode, ClientVersion} from "../execution/index.js";
 
 export function getLodestarClientVersion(info?: {version?: string; commit?: string}): ClientVersion {
@@ -15,4 +15,8 @@ export function getLodestarClientVersion(info?: {version?: string; commit?: stri
  */
 export function serializeCgc(cgc: number): Uint8Array {
   return intToBytes(cgc, Math.ceil(Math.log2(cgc + 1) / 8), "be");
+}
+
+export function deserializeCgc(cgc: Uint8Array): number {
+  return bytesToInt(cgc, "be");
 }

--- a/packages/beacon-node/test/unit/network/metadata.test.ts
+++ b/packages/beacon-node/test/unit/network/metadata.test.ts
@@ -48,7 +48,7 @@ describe("network / metadata", () => {
       const networkConfig = new NetworkConfig(getValidPeerId(), config);
       const metadata = new MetadataController({}, {onSetValue, networkConfig, logger});
 
-      metadata.upstreamValues(0);
+      metadata.init(0);
 
       expect(onSetValue).toHaveBeenCalledWith(ENRKey.cgc, expect.anything());
     });


### PR DESCRIPTION
**Motivation**

- Resolves https://github.com/ChainSafe/lodestar/issues/8097

**Description**

- Convert `MetadataController#upstreamValues(e: Epoch)` to `MetadataController#init(e: Epoch, ee?: ENR)`
- Use persisted ENR to initialize the metadata controller's `seqNumber` and `cgc`
- Remove the ability of `MetadataController` to be constructed with a `metadata` opt -- we aren't using it and it creates ambiguities that are not needed. Now `MetadataController` is always constructed with default values, and `init` is called with a persisted or newly-created ENR.
- Remove the ENR updates to `attnets`, `syncnets` on initialization.