### PR TITLE
fix: handle case if engine or builder is pending with the other disabled

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -686,6 +686,14 @@ export function getValidatorApi(
       throw Error("Builder and engine both failed to produce the block within timeout");
     }
 
+    if (builder.status === "pending" && !isEngineEnabled) {
+      throw Error("Builder failed to produce the block within timeout");
+    }
+
+    if (engine.status === "pending" && !isBuilderEnabled) {
+      throw Error("Engine failed to produce the block within timeout");
+    }
+
     if (isEngineEnabled) {
       if (engine.status === "rejected") {
         logger.warn(


### PR DESCRIPTION
**Motivation**

During FOCIL testing noticed that we can reach the "unreachable" error
https://github.com/ChainSafe/lodestar/blob/3859afe8fe8882ff530dc422926fb05141bd563a/packages/beacon-node/src/api/impl/validator/index.ts#L840

It looks like we didn't consider the case where only  builder or engine is enabled and the response is stuck pending.

**Description**

Handle case if engine or builder is pending with the other disabled


