### PR TITLE
fix: track rate limited errors

### DIFF
--- a/packages/beacon-node/src/network/reqresp/score.ts
+++ b/packages/beacon-node/src/network/reqresp/score.ts
@@ -63,5 +63,6 @@ export function onOutgoingReqRespError(e: RequestError, method: ReqRespMethod): 
     }
   }
 
+  // other errors like RequestErrorCode.REQUEST_RATE_LIMITED could come from ourself, not the peer so we should not penalize them
   return null;
 }

--- a/packages/beacon-node/src/network/reqresp/score.ts
+++ b/packages/beacon-node/src/network/reqresp/score.ts
@@ -42,6 +42,8 @@ export function onOutgoingReqRespError(e: RequestError, method: ReqRespMethod): 
     case RequestErrorCode.RESP_TIMEOUT:
       switch (method) {
         case ReqRespMethod.Ping:
+        case ReqRespMethod.Status:
+        case ReqRespMethod.Metadata:
           return PeerAction.LowToleranceError;
         case ReqRespMethod.BeaconBlocksByRange:
         case ReqRespMethod.BeaconBlocksByRoot:

--- a/packages/beacon-node/src/network/reqresp/score.ts
+++ b/packages/beacon-node/src/network/reqresp/score.ts
@@ -65,6 +65,6 @@ export function onOutgoingReqRespError(e: RequestError, method: ReqRespMethod): 
     }
   }
 
-  // other errors like RequestErrorCode.REQUEST_RATE_LIMITED could come from ourself, not the peer so we should not penalize them
+  // other errors like RequestErrorCode.RESP_RATE_LIMITED could come from ourself, not the peer so we should not penalize them
   return null;
 }

--- a/packages/reqresp/src/ReqResp.ts
+++ b/packages/reqresp/src/ReqResp.ts
@@ -181,6 +181,7 @@ export class ReqResp {
         if (e.type.code === RequestErrorCode.DIAL_ERROR || e.type.code === RequestErrorCode.DIAL_TIMEOUT) {
           this.metrics?.dialErrors.inc();
         }
+        this.metrics?.outgoingErrorReasons.inc({reason: e.type.code});
 
         this.onOutgoingRequestError(peerId, method, e);
       }

--- a/packages/reqresp/src/metrics.ts
+++ b/packages/reqresp/src/metrics.ts
@@ -1,4 +1,5 @@
 import {MetricsRegister} from "@lodestar/utils";
+import {RequestErrorCode} from "./request/errors.js";
 
 export type Metrics = ReturnType<typeof getMetrics>;
 
@@ -25,6 +26,11 @@ export function getMetrics(register: MetricsRegister) {
       name: "beacon_reqresp_outgoing_requests_error_total",
       help: "Counts total failed requests done per method",
       labelNames: ["method"],
+    }),
+    outgoingErrorReasons: register.gauge<{reason: RequestErrorCode}>({
+      name: "beacon_reqresp_outgoing_requests_error_reason_total",
+      help: "Count total outgoing request errors by reason",
+      labelNames: ["reason"],
     }),
     incomingRequests: register.gauge<{method: string}>({
       name: "beacon_reqresp_incoming_requests_total",

--- a/packages/reqresp/src/request/errors.ts
+++ b/packages/reqresp/src/request/errors.ts
@@ -31,6 +31,8 @@ export enum RequestErrorCode {
   RESP_TIMEOUT = "REQUEST_ERROR_RESP_TIMEOUT",
   /** Request rate limited */
   REQUEST_RATE_LIMITED = "REQUEST_ERROR_RATE_LIMITED",
+  /** Response rate limited */
+  RESP_RATE_LIMITED = "RESPONSE_ERROR_RATE_LIMITED",
   /** For malformed SSZ (metadata) responses */
   SSZ_OVER_MAX_SIZE = "SSZ_SNAPPY_ERROR_OVER_SSZ_MAX_SIZE",
 }
@@ -49,6 +51,7 @@ type RequestErrorType =
   | {code: RequestErrorCode.TTFB_TIMEOUT}
   | {code: RequestErrorCode.RESP_TIMEOUT}
   | {code: RequestErrorCode.REQUEST_RATE_LIMITED}
+  | {code: RequestErrorCode.RESP_RATE_LIMITED}
   | {code: RequestErrorCode.SSZ_OVER_MAX_SIZE};
 
 export const REQUEST_ERROR_CLASS_NAME = "RequestError";
@@ -77,7 +80,7 @@ export function responseStatusErrorToRequestError(e: ResponseError): RequestErro
   // refer to https://github.com/ChainSafe/lodestar/issues/8065#issuecomment-3157266196
   const errorMessageLowercase = errorMessage.toLowerCase();
   if (errorMessageLowercase.includes("rate limit")) {
-    return {code: RequestErrorCode.REQUEST_RATE_LIMITED};
+    return {code: RequestErrorCode.RESP_RATE_LIMITED};
   }
 
   // Grandine may return this without standard RespStatus, see https://github.com/ChainSafe/lodestar/issues/8110

--- a/packages/reqresp/src/request/errors.ts
+++ b/packages/reqresp/src/request/errors.ts
@@ -73,6 +73,13 @@ export class RequestError extends LodestarError<RequestErrorType> {
  */
 export function responseStatusErrorToRequestError(e: ResponseError): RequestErrorType {
   const {errorMessage, status} = e;
+  // rate limited error from clients have different status, for example: lighthouse responds with 139, teku responds with 1
+  // but all of them has "rate limit" in the error message
+  // refer to https://github.com/ChainSafe/lodestar/issues/8065#issuecomment-3157266196
+  if (errorMessage.toLowerCase().includes("rate limit")) {
+    return {code: RequestErrorCode.REQUEST_RATE_LIMITED};
+  }
+
   switch (status) {
     case RespStatus.INVALID_REQUEST:
       return {code: RequestErrorCode.INVALID_REQUEST, errorMessage};

--- a/packages/reqresp/src/request/errors.ts
+++ b/packages/reqresp/src/request/errors.ts
@@ -45,7 +45,6 @@ type RequestErrorType =
   | {code: RequestErrorCode.DIAL_ERROR; error: Error}
   | {code: RequestErrorCode.REQUEST_TIMEOUT}
   | {code: RequestErrorCode.REQUEST_ERROR; error: Error}
-  | {code: RequestErrorCode.RESPONSE_TIMEOUT}
   | {code: RequestErrorCode.EMPTY_RESPONSE}
   | {code: RequestErrorCode.TTFB_TIMEOUT}
   | {code: RequestErrorCode.RESP_TIMEOUT}
@@ -76,8 +75,14 @@ export function responseStatusErrorToRequestError(e: ResponseError): RequestErro
   // rate limited error from clients have different status, for example: lighthouse responds with 139, teku responds with 1
   // but all of them has "rate limit" in the error message
   // refer to https://github.com/ChainSafe/lodestar/issues/8065#issuecomment-3157266196
-  if (errorMessage.toLowerCase().includes("rate limit")) {
+  const errorMessageLowercase = errorMessage.toLowerCase();
+  if (errorMessageLowercase.includes("rate limit")) {
     return {code: RequestErrorCode.REQUEST_RATE_LIMITED};
+  }
+
+  // Grandine may return this without standard RespStatus, see https://github.com/ChainSafe/lodestar/issues/8110
+  if (errorMessageLowercase.includes("wait ")) {
+    return {code: RequestErrorCode.RESP_TIMEOUT};
   }
 
   switch (status) {

--- a/packages/reqresp/test/unit/utils/errorMessage.test.ts
+++ b/packages/reqresp/test/unit/utils/errorMessage.test.ts
@@ -1,7 +1,6 @@
 import {Uint8ArrayList} from "uint8arraylist";
 import {describe, expect, it} from "vitest";
 import {Encoding} from "../../../src/types.js";
-import {BufferedSource} from "../../../src/utils/bufferedSource.js";
 import {decodeErrorMessage, encodeErrorMessage} from "../../../src/utils/errorMessage.js";
 
 describe("encode and decode error message", () => {

--- a/packages/reqresp/test/unit/utils/errorMessage.test.ts
+++ b/packages/reqresp/test/unit/utils/errorMessage.test.ts
@@ -22,6 +22,15 @@ describe("encode and decode error message", () => {
       name: "NA - rate limited",
       errorMessage: "rate limited",
     },
+    // see https://github.com/ChainSafe/lodestar/issues/8110
+    {
+      name: "NA - Wait n seconds",
+      errorMessage: "Wait 2.816488536s",
+    },
+    {
+      name: "Lodestar - Timeout",
+      errorMessage: "Timeout",
+    },
   ];
   for (const {name, errorMessage} of testCases) {
     it(name, async () => {

--- a/packages/reqresp/test/unit/utils/errorMessage.test.ts
+++ b/packages/reqresp/test/unit/utils/errorMessage.test.ts
@@ -1,0 +1,40 @@
+import {Uint8ArrayList} from "uint8arraylist";
+import {describe, expect, it} from "vitest";
+import {Encoding} from "../../../src/types.js";
+import {BufferedSource} from "../../../src/utils/bufferedSource.js";
+import {decodeErrorMessage, encodeErrorMessage} from "../../../src/utils/errorMessage.js";
+
+describe("encode and decode error message", () => {
+  // refer to https://github.com/ChainSafe/lodestar/issues/8065#issuecomment-3157266196
+  const testCases: {name: string; errorMessage: string}[] = [
+    {
+      name: "Lighthouse - rate limited",
+      errorMessage: "Rate limited. There are already 2 active requests with the same protocol",
+    },
+    {
+      name: "Prysm - rate limited",
+      errorMessage: "rate limited",
+    },
+    {
+      name: "Teku - rate limited",
+      errorMessage: "Peer has been rate limited",
+    },
+    {
+      name: "NA - rate limited",
+      errorMessage: "rate limited",
+    },
+  ];
+  for (const {name, errorMessage} of testCases) {
+    it(name, async () => {
+      const buffers = await encodeErrorMessage(errorMessage, Encoding.SSZ_SNAPPY);
+      const accu: Uint8ArrayList = new Uint8ArrayList();
+      for await (const buffer of buffers) {
+        accu.append(buffer);
+      }
+
+      const encodedMessage = accu.subarray(0);
+      const decodedErrorMessage = await decodeErrorMessage(encodedMessage);
+      expect(decodedErrorMessage).toBe(errorMessage);
+    });
+  }
+});


### PR DESCRIPTION
**Motivation**

- when we end request to peers, they may respond with rate limit error and we don't track it
- this is a prerequisite for rate limit prevention that I'll implement later. We want to make sure `REQUEST_RATE_LIMITED` does not happen in that branch

**Description**

- fix the malformed extracted error message, see the unit test
- throw `REQUEST_RATE_LIMITED` if message contains "rate limit", see rate limited error messages of all clients [here](https://github.com/ChainSafe/lodestar/issues/8065#issuecomment-3157266196)
- new metric to track out going error by reason

Closes #8065
Closes #8110

**Test on dev nodes**

<img width="1506" height="358" alt="Screenshot 2025-08-06 at 15 52 46" src="https://github.com/user-attachments/assets/9c8f2d4a-ef34-458d-81a9-85880b1624ac" />
