### PR TITLE
fix: update PeerDAS log level

### DIFF
--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -220,7 +220,7 @@ export class SeenGossipBlockInput {
             // TODO: (@matthewkeil) add metrics collection point here
           })
           .catch((error) => {
-            this.logger.error("Error getting data columns from execution", {blockHex}, error);
+            this.logger.debug("Error getting data columns from execution", {blockHex}, error);
           });
       });
     }
@@ -356,7 +356,7 @@ export class SeenGossipBlockInput {
               dataColumns: dataColumnsCache.size,
             };
             const recoverResult = await recoverDataColumnSidecars(dataColumnsCache, this.clock, metrics).catch((e) => {
-              this.logger.error("Error recovering data column sidecars", logCtx, e);
+              this.logger.debug("Error recovering data column sidecars", logCtx, e);
               return RecoverResult.Failed;
             });
             metrics?.recoverDataColumnSidecars.reconstructionResult.inc({result: recoverResult});

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -220,7 +220,7 @@ export class SeenGossipBlockInput {
             // TODO: (@matthewkeil) add metrics collection point here
           })
           .catch((error) => {
-            this.logger.debug("Error getting data columns from execution", {blockHex}, error);
+            this.logger.warn("Error getting data columns from execution", {blockHex}, error);
           });
       });
     }
@@ -356,7 +356,7 @@ export class SeenGossipBlockInput {
               dataColumns: dataColumnsCache.size,
             };
             const recoverResult = await recoverDataColumnSidecars(dataColumnsCache, this.clock, metrics).catch((e) => {
-              this.logger.debug("Error recovering data column sidecars", logCtx, e);
+              this.logger.error("Error recovering data column sidecars", logCtx, e);
               return RecoverResult.Failed;
             });
             metrics?.recoverDataColumnSidecars.reconstructionResult.inc({result: recoverResult});

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -397,7 +397,7 @@ export class PeerDiscovery {
     const syncnetsBytes = enr.kvs.get(ENRKey.syncnets); // 4 bits
     const custodyGroupCountBytes = enr.kvs.get(ENRKey.cgc); // 64 bits
     if (custodyGroupCountBytes === undefined) {
-      this.logger.warn("peer discovered with no cgc assuming 4", exportENRToJSON(enr));
+      this.logger.debug("peer discovered with no cgc assuming 4", exportENRToJSON(enr));
     }
 
     // Use faster version than ssz's implementation that leverages pre-cached.
@@ -428,7 +428,7 @@ export class PeerDiscovery {
     custodySubnetCount?: number
   ): DiscoveredPeerStatus {
     const nodeId = computeNodeId(peerId);
-    this.logger.warn("handleDiscoveredPeer", {nodeId: toHexString(nodeId), peerId: peerId.toString()});
+    this.logger.debug("handleDiscoveredPeer", {nodeId: toHexString(nodeId), peerId: peerId.toString()});
     try {
       // Check if peer is not banned or disconnected
       if (this.peerRpcScores.getScoreState(peerId) !== ScoreState.Healthy) {

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -397,7 +397,7 @@ export class PeerDiscovery {
     const syncnetsBytes = enr.kvs.get(ENRKey.syncnets); // 4 bits
     const custodyGroupCountBytes = enr.kvs.get(ENRKey.cgc); // 64 bits
     if (custodyGroupCountBytes === undefined) {
-      this.logger.debug("peer discovered with no cgc assuming 4", exportENRToJSON(enr));
+      this.logger.warn("peer discovered with no cgc assuming 4", exportENRToJSON(enr));
     }
 
     // Use faster version than ssz's implementation that leverages pre-cached.

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -482,7 +482,6 @@ export class PeerManager {
   private async requestMetadata(peer: PeerId): Promise<void> {
     const peerIdStr = peer.toString();
     try {
-      this.logger.debug("requestMetadata", {peer: prettyPrintPeerIdStr(peerIdStr)});
       this.onMetadata(peer, await this.reqResp.sendMetadata(peer));
     } catch (e) {
       this.logger.verbose("invalid requestMetadata response", {peer: prettyPrintPeerIdStr(peerIdStr)}, e as Error);
@@ -493,7 +492,6 @@ export class PeerManager {
   private async requestPing(peer: PeerId): Promise<void> {
     const peerIdStr = peer.toString();
     try {
-      this.logger.debug("requestPing", {peer: peer.toString()});
       this.onPing(peer, await this.reqResp.sendPing(peer));
 
       // If peer replies a PING request also update lastReceivedMsg

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -456,7 +456,7 @@ export class PeerManager {
       const hasAllColumns = matchingSubnetsNum === sampleSubnets.length;
       const clientAgent = peerData?.agentClient ?? ClientKind.Unknown;
 
-      this.logger.debug(`onStatus ${custodyGroupCount === undefined ? "undefined custody count assuming 4" : ""}`, {
+      this.logger.debug("onStatus", {
         nodeId: toHexString(nodeId),
         myNodeId: toHexString(this.nodeId),
         peerId: peer.toString(),

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -316,7 +316,7 @@ export class PeerManager {
   private onPing(peer: PeerId, seqNumber: phase0.Ping): void {
     // if the sequence number is unknown update the peer's metadata
     const metadata = this.connectedPeers.get(peer.toString())?.metadata;
-    this.logger.warn("onPing", {
+    this.logger.debug("onPing", {
       seqNumber,
       metaSeqNumber: metadata?.seqNumber,
       cond: !metadata || metadata.seqNumber < seqNumber,
@@ -333,7 +333,7 @@ export class PeerManager {
     // Store metadata always in case the peer updates attnets but not the sequence number
     // Trust that the peer always sends the latest metadata (From Lighthouse)
     const peerData = this.connectedPeers.get(peer.toString());
-    this.logger.warn("onMetadata", {
+    this.logger.debug("onMetadata", {
       peer: peer.toString(),
       peerData: peerData !== undefined,
       custodyGroupCount: (metadata as Partial<fulu.Metadata>).custodyGroupCount,
@@ -456,7 +456,7 @@ export class PeerManager {
       const hasAllColumns = matchingSubnetsNum === sampleSubnets.length;
       const clientAgent = peerData?.agentClient ?? ClientKind.Unknown;
 
-      this.logger.warn(`onStatus ${custodyGroupCount === undefined ? "undefined custody count assuming 4" : ""}`, {
+      this.logger.debug(`onStatus ${custodyGroupCount === undefined ? "undefined custody count assuming 4" : ""}`, {
         nodeId: toHexString(nodeId),
         myNodeId: toHexString(this.nodeId),
         peerId: peer.toString(),
@@ -482,7 +482,7 @@ export class PeerManager {
   private async requestMetadata(peer: PeerId): Promise<void> {
     const peerIdStr = peer.toString();
     try {
-      this.logger.warn("requestMetadata", {peer: prettyPrintPeerIdStr(peerIdStr)});
+      this.logger.debug("requestMetadata", {peer: prettyPrintPeerIdStr(peerIdStr)});
       this.onMetadata(peer, await this.reqResp.sendMetadata(peer));
     } catch (e) {
       this.logger.verbose("invalid requestMetadata response", {peer: prettyPrintPeerIdStr(peerIdStr)}, e as Error);
@@ -493,7 +493,7 @@ export class PeerManager {
   private async requestPing(peer: PeerId): Promise<void> {
     const peerIdStr = peer.toString();
     try {
-      this.logger.warn("requestPing", {peer: peer.toString()});
+      this.logger.debug("requestPing", {peer: peer.toString()});
       this.onPing(peer, await this.reqResp.sendPing(peer));
 
       // If peer replies a PING request also update lastReceivedMsg


### PR DESCRIPTION
**Motivation**

Some logs in the PeerDAS branch are inappropriate.

**Description**

This PR changes inappropriate PeerDAS log levels from `warn` and `error` to `debug` level.

Closes #8107

**Steps to test or reproduce**

Run beacon node locally using `./scripts/dev/node*.sh` with --logLevel `info` and `debug` and check the logs.