### PR TITLE
fix: update publish block/column order

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -257,15 +257,26 @@ export function getBeaconBlockApi({
     chain.logger.info("Publishing block", valLogMeta);
     const publishPromises = [
       // Send the block, regardless of whether or not it is valid. The API
-      // specification is very clear that this is the desired behaviour.
+      // specification is very clear that this is the desired behavior.
       //
       // i) Publish blobs and block before importing so that network can see them asap
-      // ii) publish blobs first because
-      //     a) by the times nodes see block, they might decide to pull blobs
-      //     b) they might require more hops to reach recipients in peerDAS kind of setup where
-      //        blobs might need to hop between nodes because of partial subnet subscription
-      () => network.publishBeaconBlock(signedBlock) as Promise<unknown>,
+      //
+      // For blobs and columns the publish order is reversed do to networking considerations. When data
+      // is sharded across the network there is additional latency for it to reasonably propagate.
+      //
+      // ii) DENEB/ELECTRA publish block first because
+      //     a) as soon as node sees block they can start processing it while large blobs are in transit
+      //     b) getting block first allows nodes to use getBlobs from local ELs and save
+      //        import latency and hopefully bandwidth
+      //
+      // ii) POST-FULU publish columns first because
+      //     a) by the times nodes see block, they might decide to pull sidecars
+      //     b) they might require more hops to reach recipients under data sharding where sidecars
+      //        might need to distribute to more nodes for sufficient availability because of
+      //        partial subnet subscription
+      //
       ...dataColumnSidecars.map((dataColumnSidecar) => () => network.publishDataColumnSidecar(dataColumnSidecar)),
+      () => network.publishBeaconBlock(signedBlock) as Promise<unknown>,
       ...blobSidecars.map((blobSidecar) => () => network.publishBlobSidecar(blobSidecar)),
       () =>
         // there is no rush to persist block since we published it to gossip anyway

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -260,23 +260,13 @@ export function getBeaconBlockApi({
       // specification is very clear that this is the desired behavior.
       //
       // - Publish blobs and block before importing so that network can see them asap
-      //
-      // For blobs and columns the publish order is reversed do to networking considerations. When data
-      // is sharded across the network there is additional latency for it to reasonably propagate.
-      //
-      // - DENEB/ELECTRA publish block first because
-      //     a) as soon as node sees block they can start processing it while large blobs are in transit
+      // - Publish block first because
+      //     a) as soon as node sees block they can start processing it while data is in transit
       //     b) getting block first allows nodes to use getBlobs from local ELs and save
       //        import latency and hopefully bandwidth
       //
-      // - POST-FULU publish columns first because
-      //     a) by the times nodes see block, they might decide to pull sidecars
-      //     b) they might require more hops to reach recipients under data sharding where sidecars
-      //        might need to distribute to more nodes for sufficient availability because of
-      //        partial subnet subscription
-      //
-      ...dataColumnSidecars.map((dataColumnSidecar) => () => network.publishDataColumnSidecar(dataColumnSidecar)),
       () => network.publishBeaconBlock(signedBlock),
+      ...dataColumnSidecars.map((dataColumnSidecar) => () => network.publishDataColumnSidecar(dataColumnSidecar)),
       ...blobSidecars.map((blobSidecar) => () => network.publishBlobSidecar(blobSidecar)),
       () =>
         // there is no rush to persist block since we published it to gossip anyway

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -276,7 +276,7 @@ export function getBeaconBlockApi({
       //        partial subnet subscription
       //
       ...dataColumnSidecars.map((dataColumnSidecar) => () => network.publishDataColumnSidecar(dataColumnSidecar)),
-      () => network.publishBeaconBlock(signedBlock) as Promise<unknown>,
+      () => network.publishBeaconBlock(signedBlock),
       ...blobSidecars.map((blobSidecar) => () => network.publishBlobSidecar(blobSidecar)),
       () =>
         // there is no rush to persist block since we published it to gossip anyway
@@ -292,7 +292,7 @@ export function getBeaconBlockApi({
             throw e;
           }),
     ];
-    await promiseAllMaybeAsync(publishPromises);
+    await promiseAllMaybeAsync<number | void>(publishPromises);
 
     if (chain.emitter.listenerCount(routes.events.EventType.blockGossip)) {
       chain.emitter.emit(routes.events.EventType.blockGossip, {slot, block: blockRoot});

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -259,17 +259,17 @@ export function getBeaconBlockApi({
       // Send the block, regardless of whether or not it is valid. The API
       // specification is very clear that this is the desired behavior.
       //
-      // i) Publish blobs and block before importing so that network can see them asap
+      // - Publish blobs and block before importing so that network can see them asap
       //
       // For blobs and columns the publish order is reversed do to networking considerations. When data
       // is sharded across the network there is additional latency for it to reasonably propagate.
       //
-      // ii) DENEB/ELECTRA publish block first because
+      // - DENEB/ELECTRA publish block first because
       //     a) as soon as node sees block they can start processing it while large blobs are in transit
       //     b) getting block first allows nodes to use getBlobs from local ELs and save
       //        import latency and hopefully bandwidth
       //
-      // ii) POST-FULU publish columns first because
+      // - POST-FULU publish columns first because
       //     a) by the times nodes see block, they might decide to pull sidecars
       //     b) they might require more hops to reach recipients under data sharding where sidecars
       //        might need to distribute to more nodes for sufficient availability because of


### PR DESCRIPTION
**Motivation**

Addressing peerDAS PR comment 
https://github.com/ChainSafe/lodestar/pull/6353#discussion_r2255208127

Changes order of publish to match comment and likely the best order for a sharded DA network.

Also adds additional information to the comment 
