### PR TITLE
chore: make NetworkConfig a simple object

### DIFF
--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -49,7 +49,7 @@ export class MetadataController {
     this.onSetValue = modules.onSetValue;
     this._metadata = opts.metadata ?? {
       ...ssz.fulu.Metadata.defaultValue(),
-      custodyGroupCount: modules.networkConfig.getCustodyConfig().targetCustodyGroupCount,
+      custodyGroupCount: modules.networkConfig.custodyConfig.targetCustodyGroupCount,
     };
   }
 
@@ -59,7 +59,7 @@ export class MetadataController {
 
     this.onSetValue(ENRKey.attnets, ssz.phase0.AttestationSubnets.serialize(this._metadata.attnets));
 
-    const config = this.networkConfig.getConfig();
+    const config = this.networkConfig.config;
 
     if (config.getForkSeq(computeStartSlotAtEpoch(currentEpoch)) >= ForkSeq.altair) {
       // Only persist syncnets if altair fork is already activated. If currentFork is altair but head is phase0
@@ -125,7 +125,7 @@ export class MetadataController {
    *    Current Clock implementation ensures no race conditions, epoch is correct if re-fetched
    */
   updateEth2Field(epoch: Epoch): void {
-    const config = this.networkConfig.getConfig();
+    const config = this.networkConfig.config;
     const enrForkId = getENRForkID(config, epoch);
     const {forkDigest, nextForkVersion, nextForkEpoch} = enrForkId;
     this.onSetValue(ENRKey.eth2, ssz.phase0.ENRForkID.serialize(enrForkId));

--- a/packages/beacon-node/src/network/networkConfig.ts
+++ b/packages/beacon-node/src/network/networkConfig.ts
@@ -1,43 +1,12 @@
-import {PeerId} from "@libp2p/interface";
 import {BeaconConfig} from "@lodestar/config";
 import {CustodyConfig} from "../util/dataColumns.js";
-import {NodeId, computeNodeId} from "./subnets/interface.js";
-
-export type NetworkConfigOpts = {
-  supernode?: boolean;
-};
+import {NodeId} from "./subnets/interface.js";
 
 /**
  * Store shared data for different modules in the network stack.
- * TODO: consider moving similar shared data, for example PeersData, under NetworkConfig.
  */
-export class NetworkConfig {
-  private readonly nodeId: NodeId;
-  private readonly config: BeaconConfig;
-  private readonly custodyConfig: CustodyConfig;
-
-  constructor(peerId: PeerId, config: BeaconConfig, opts: NetworkConfigOpts = {}) {
-    this.nodeId = computeNodeId(peerId);
-    this.config = config;
-    this.custodyConfig = new CustodyConfig(this.nodeId, config, null, opts);
-  }
-
-  getConfig(): BeaconConfig {
-    return this.config;
-  }
-
-  getNodeId(): NodeId {
-    return this.nodeId;
-  }
-
-  /**
-   * Consumer should never mutate returned CustodyConfig
-   */
-  getCustodyConfig(): CustodyConfig {
-    return this.custodyConfig;
-  }
-
-  setTargetGroupCount(count: number): void {
-    this.custodyConfig.updateTargetCustodyGroupCount(count);
-  }
-}
+export type NetworkConfig = {
+  readonly nodeId: NodeId;
+  readonly config: BeaconConfig;
+  readonly custodyConfig: CustodyConfig;
+};

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -131,7 +131,7 @@ export class PeerDiscovery {
     this.peerRpcScores = peerRpcScores;
     this.metrics = metrics;
     this.logger = logger;
-    this.config = networkConfig.getConfig();
+    this.config = networkConfig.config;
     this.discv5 = discv5;
     this.groupRequests = new Map();
 
@@ -190,7 +190,7 @@ export class PeerDiscovery {
       privateKey: modules.privateKey,
       metrics: modules.metrics ?? undefined,
       logger: modules.logger,
-      config: modules.networkConfig.getConfig(),
+      config: modules.networkConfig.config,
       genesisTime: modules.clock.genesisTime,
     });
 

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -176,13 +176,13 @@ export class PeerManager {
     this.statusCache = modules.statusCache;
     this.clock = modules.clock;
     this.networkConfig = networkConfig;
-    this.config = networkConfig.getConfig();
+    this.config = networkConfig.config;
     this.peerRpcScores = modules.peerRpcScores;
     this.networkEventBus = modules.events;
     this.connectedPeers = modules.peersData.connectedPeers;
     this.opts = opts;
     this.discovery = discovery;
-    this.nodeId = networkConfig.getNodeId();
+    this.nodeId = networkConfig.nodeId;
 
     const {metrics} = modules;
     if (metrics) {
@@ -450,7 +450,7 @@ export class PeerManager {
       // on metadata, we should have custodyGroupss
       const peerCustodyGroups = peerData?.metadata?.custodyGroups ?? getCustodyGroups(nodeId, peerCustodyGroupCount);
 
-      const sampleSubnets = this.networkConfig.getCustodyConfig().sampledSubnets;
+      const sampleSubnets = this.networkConfig.custodyConfig.sampledSubnets;
       const matchingSubnetsNum = sampleSubnets.reduce((acc, elem) => acc + (dataColumns.includes(elem) ? 1 : 0), 0);
       const hasAllColumns = matchingSubnetsNum === sampleSubnets.length;
       const clientAgent = peerData?.agentClient ?? ClientKind.Unknown;
@@ -578,7 +578,7 @@ export class PeerManager {
       this.attnetsService.getActiveSubnets(),
       this.syncnetsService.getActiveSubnets(),
       // ignore samplingGroups for pre-fulu forks
-      forkSeq >= ForkSeq.fulu ? this.networkConfig.getCustodyConfig().sampleGroups : undefined,
+      forkSeq >= ForkSeq.fulu ? this.networkConfig.custodyConfig.sampleGroups : undefined,
       {
         ...this.opts,
         status,

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -13,7 +13,7 @@ import {
   ResponseOutgoing,
 } from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
-import {Metadata, Status, phase0, ssz, sszTypesFor} from "@lodestar/types";
+import {Metadata, Status, phase0, ssz} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Libp2p} from "libp2p";
 import {callInNextEventLoop} from "../../util/eventLoop.js";

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -14,7 +14,7 @@ import {ReqRespMethod} from "../../../../src/network/reqresp/ReqRespBeaconNode.j
 import {LocalStatusCache} from "../../../../src/network/statusCache.js";
 import {IAttnetsService, computeNodeId} from "../../../../src/network/subnets/index.js";
 import {Clock} from "../../../../src/util/clock.js";
-import {getCustodyGroups} from "../../../../src/util/dataColumns.js";
+import {CustodyConfig, getCustodyGroups} from "../../../../src/util/dataColumns.js";
 import {waitForEvent} from "../../../utils/events/resolver.js";
 import {testLogger} from "../../../utils/logger.js";
 import {createNode} from "../../../utils/network.js";
@@ -45,7 +45,12 @@ describe("network / peers / PeerManager", () => {
       },
     });
     const beaconConfig = createBeaconConfig(config, state.genesisValidatorsRoot);
-    const networkConfig = new NetworkConfig(peerId1, beaconConfig);
+    const nodeId = computeNodeId(peerId1);
+    const networkConfig: NetworkConfig = {
+      nodeId,
+      config: beaconConfig,
+      custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+    };
     const controller = new AbortController();
     const clock = new Clock({config: beaconConfig, genesisTime: 0, signal: controller.signal});
     const status = ssz.phase0.Status.defaultValue();

--- a/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
@@ -25,6 +25,8 @@ import {NetworkConfig} from "../../../src/network/networkConfig.js";
 import {PeersData} from "../../../src/network/peers/peersData.js";
 import {GetReqRespHandlerFn} from "../../../src/network/reqresp/types.js";
 import {LocalStatusCache} from "../../../src/network/statusCache.js";
+import {computeNodeId} from "../../../src/network/subnets/index.js";
+import {CustodyConfig} from "../../../src/util/dataColumns.js";
 import {testLogger} from "../../utils/logger.js";
 
 describe("reqresp encoder", () => {
@@ -65,7 +67,12 @@ describe("reqresp encoder", () => {
 
     const config = createBeaconConfig({}, ZERO_HASH);
     const peerId = peerIdFromPrivateKey(privateKey);
-    const networkConfig = new NetworkConfig(peerId, config);
+    const nodeId = computeNodeId(peerId);
+    const networkConfig: NetworkConfig = {
+      nodeId,
+      config,
+      custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+    };
     const logger = testLogger();
     const modules: ReqRespBeaconNodeModules = {
       libp2p,

--- a/packages/beacon-node/test/unit/network/metadata.test.ts
+++ b/packages/beacon-node/test/unit/network/metadata.test.ts
@@ -5,6 +5,8 @@ import {toHex} from "@lodestar/utils";
 import {describe, expect, it, vi} from "vitest";
 import {ENRKey, MetadataController, getENRForkID} from "../../../src/network/metadata.js";
 import {NetworkConfig} from "../../../src/network/networkConfig.js";
+import {computeNodeId} from "../../../src/network/subnets/index.js";
+import {CustodyConfig} from "../../../src/util/dataColumns.js";
 import {serializeCgc} from "../../../src/util/metadata.js";
 import {config} from "../../utils/config.js";
 import {testLogger} from "../../utils/logger.js";
@@ -45,7 +47,12 @@ describe("network / metadata", () => {
         }),
         ZERO_HASH
       );
-      const networkConfig = new NetworkConfig(getValidPeerId(), config);
+      const nodeId = computeNodeId(getValidPeerId());
+      const networkConfig: NetworkConfig = {
+        nodeId,
+        config,
+        custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+      };
       const metadata = new MetadataController({}, {onSetValue, networkConfig, logger});
 
       metadata.upstreamValues(0);
@@ -55,7 +62,12 @@ describe("network / metadata", () => {
 
     it("should call onSetValue with the correct cgc", () => {
       const onSetValue = vi.fn();
-      const networkConfig = new NetworkConfig(getValidPeerId(), config);
+      const nodeId = computeNodeId(getValidPeerId());
+      const networkConfig: NetworkConfig = {
+        nodeId,
+        config,
+        custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+      };
       const metadata = new MetadataController({}, {onSetValue, networkConfig, logger});
       metadata.custodyGroupCount = 128;
       expect(onSetValue).toHaveBeenCalledWith(ENRKey.cgc, serializeCgc(128));
@@ -63,7 +75,12 @@ describe("network / metadata", () => {
 
     it("should increment seqNumber when cgc is updated", () => {
       const onSetValue = vi.fn();
-      const networkConfig = new NetworkConfig(getValidPeerId(), config);
+      const nodeId = computeNodeId(getValidPeerId());
+      const networkConfig: NetworkConfig = {
+        nodeId,
+        config,
+        custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+      };
       const metadata = new MetadataController({}, {onSetValue, networkConfig, logger});
       const initialSeqNumber = metadata.seqNumber;
       metadata.custodyGroupCount = 128;
@@ -72,7 +89,12 @@ describe("network / metadata", () => {
 
     it("should not increment seqNumber when cgc is set to the same value", () => {
       const onSetValue = vi.fn();
-      const networkConfig = new NetworkConfig(getValidPeerId(), config);
+      const nodeId = computeNodeId(getValidPeerId());
+      const networkConfig: NetworkConfig = {
+        nodeId,
+        config,
+        custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+      };
       const metadata = new MetadataController({}, {onSetValue, networkConfig, logger});
       metadata.custodyGroupCount = 128;
       const initialSeqNumber = metadata.seqNumber;

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -18,8 +18,8 @@ import {NetworkConfig} from "../../../../src/network/networkConfig.js";
 import {AttnetsService} from "../../../../src/network/subnets/attnetsService.js";
 import {CommitteeSubscription} from "../../../../src/network/subnets/interface.js";
 import {Clock, IClock} from "../../../../src/util/clock.js";
+import {CustodyConfig} from "../../../../src/util/dataColumns.js";
 import {testLogger} from "../../../utils/logger.js";
-import {getValidPeerId} from "../../../utils/peer.js";
 
 vi.mock("../../../../src/network/gossip/gossipsub.js");
 
@@ -31,7 +31,11 @@ describe("AttnetsService", () => {
   );
   const ALTAIR_FORK_EPOCH = 100;
   const config = createBeaconConfig({ALTAIR_FORK_EPOCH}, ZERO_HASH);
-  const networkConfig = new NetworkConfig(getValidPeerId(), config);
+  const networkConfig: NetworkConfig = {
+    nodeId,
+    config,
+    custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+  };
   // const {SECONDS_PER_SLOT} = config;
   let service: AttnetsService;
   let gossipStub: MockedObject<Eth2Gossipsub>;


### PR DESCRIPTION
**Motivation**

- https://github.com/ChainSafe/lodestar/pull/6353#discussion_r2257722059

**Description**

- make `NetworkConfig` a simple object, fix consumers
- fix stray import breaking `yarn check-types`