### PR TITLE
chore: refactor custody config initialization

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1322,6 +1322,7 @@ export class BeaconChain implements IBeaconChain {
     // Only update if target is increased
     if (targetCustodyGroupCount > this.custodyConfig.targetCustodyGroupCount) {
       this.custodyConfig.updateTargetCustodyGroupCount(targetCustodyGroupCount);
+      this.metrics?.peerDas.targetCustodyGroupCount.set(targetCustodyGroupCount);
       this.logger.verbose("Updated target custody group count", {
         finalizedEpoch: finalizedCheckpoint.epoch,
         validatorCount: validatorIndices.length,

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -3,7 +3,14 @@ import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
 import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
-import {ForkSeq, GENESIS_SLOT, SLOTS_PER_EPOCH, isForkPostElectra, isForkPostFulu} from "@lodestar/params";
+import {
+  ForkSeq,
+  GENESIS_SLOT,
+  NUMBER_OF_CUSTODY_GROUPS,
+  SLOTS_PER_EPOCH,
+  isForkPostElectra,
+  isForkPostFulu,
+} from "@lodestar/params";
 import {
   BeaconStateAllForks,
   BeaconStateElectra,
@@ -279,7 +286,14 @@ export class BeaconChain implements IBeaconChain {
     this.seenContributionAndProof = new SeenContributionAndProof(metrics);
     this.seenAttestationDatas = new SeenAttestationDatas(metrics, this.opts?.attDataCacheSlotDistance);
     const nodeId = computeNodeIdFromPrivateKey(privateKey);
-    this.custodyConfig = new CustodyConfig(nodeId, config, metrics, this.opts);
+    const initialCustodyGroupCount =
+      (opts.initialCustodyGroupCount ?? opts.supernode) ? NUMBER_OF_CUSTODY_GROUPS : config.CUSTODY_REQUIREMENT;
+    this.metrics?.peerDas.custodyGroupCount.set(initialCustodyGroupCount);
+    this.custodyConfig = new CustodyConfig({
+      nodeId,
+      config,
+      initialCustodyGroupCount,
+    });
     this.seenGossipBlockInput = new SeenGossipBlockInput(
       this.custodyConfig,
       this.executionEngine,
@@ -1255,18 +1269,28 @@ export class BeaconChain implements IBeaconChain {
       if (!this.opts.supernode) {
         // Update custody requirement based on finalized state
         const validatorIndices = this.beaconProposerCache.getValidatorIndices();
-        const targetCustodyGroupCount = getValidatorsCustodyRequirement(headState, validatorIndices, this.config);
-        // only update if target is increased
-        if (targetCustodyGroupCount > this.custodyConfig.targetCustodyGroupCount) {
-          this.custodyConfig.updateTargetCustodyGroupCount(targetCustodyGroupCount);
-          this.logger.verbose(`Updated targetCustodyGroupCount=${this.custodyConfig.targetCustodyGroupCount}`);
-          this.emitter.emit(ChainEvent.updateTargetGroupCount, this.custodyConfig.targetCustodyGroupCount);
-        }
+        this.updateTargetCustodyGroupCount(getValidatorsCustodyRequirement(headState, validatorIndices, this.config));
       }
     }
 
     if (headState === null) {
       this.logger.verbose("Head state is null");
+    }
+  }
+
+  updateTargetCustodyGroupCount(newTarget: number): void {
+    // Only increase targetCustodyGroupCount, never decrease it
+    const oldTarget = this.custodyConfig.targetCustodyGroupCount;
+    if (newTarget > oldTarget) {
+      this.custodyConfig.updateTargetCustodyGroupCount(newTarget);
+      this.metrics?.peerDas.custodyGroupCount.set(newTarget);
+      this.logger.verbose("Updated targetCustodyGroupCount", {oldTarget, newTarget});
+      this.emitter.emit(ChainEvent.updateTargetGroupCount, newTarget);
+    } else {
+      this.logger.verbose("Not updating targetCustodyGroupCount", {
+        currentTarget: oldTarget,
+        attemptedTarget: newTarget,
+      });
     }
   }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -289,7 +289,7 @@ export class BeaconChain implements IBeaconChain {
 
     const nodeId = computeNodeIdFromPrivateKey(privateKey);
     const initialCustodyGroupCount =
-      (opts.initialCustodyGroupCount ?? opts.supernode) ? NUMBER_OF_CUSTODY_GROUPS : config.CUSTODY_REQUIREMENT;
+      opts.initialCustodyGroupCount ?? (opts.supernode ? NUMBER_OF_CUSTODY_GROUPS : config.CUSTODY_REQUIREMENT);
     this.metrics?.peerDas.targetCustodyGroupCount.set(initialCustodyGroupCount);
     this.custodyConfig = new CustodyConfig({
       nodeId,

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -41,6 +41,7 @@ export type IChainOptions = BlockProcessOpts &
     maxCachedProducedRoots?: number;
     /** Subscribe to and custody all data column sidecar subnets */
     supernode?: boolean;
+    initialCustodyGroupCount?: number;
     /*
      * This is the window size for the windowed multiplication in proof
      * generation. The larger wbits is, the faster the MSM will be, but the

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -66,6 +66,7 @@ export type BaseNetworkInit = {
   getReqRespHandler: GetReqRespHandlerFn;
   activeValidatorCount: number;
   initialStatus: Status;
+  initialCustodyGroupCount: number;
 };
 
 /**
@@ -139,6 +140,7 @@ export class NetworkCore implements INetworkCore {
     getReqRespHandler,
     activeValidatorCount,
     initialStatus,
+    initialCustodyGroupCount,
   }: BaseNetworkInit): Promise<NetworkCore> {
     const libp2p = await createNodeJsLibp2p(privateKey, opts, {
       peerStoreDir,
@@ -163,7 +165,7 @@ export class NetworkCore implements INetworkCore {
     const networkConfig: NetworkConfig = {
       nodeId,
       config,
-      custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: opts.supernode}),
+      custodyConfig: new CustodyConfig({nodeId, config, initialCustodyGroupCount}),
     };
     const metadata = new MetadataController({}, {networkConfig, logger, onSetValue: onMetadataSetValue});
 

--- a/packages/beacon-node/src/network/core/networkCoreWorker.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorker.ts
@@ -104,6 +104,7 @@ const core = await NetworkCore.init({
     reqRespBridgeRespCaller.getAsyncIterable({method, req, peerId: peerIdToString(peerId)}),
   activeValidatorCount: workerData.activeValidatorCount,
   initialStatus: workerData.initialStatus,
+  initialCustodyGroupCount: workerData.initialCustodyGroupCount,
 });
 
 wireEventsOnWorkerThread<NetworkEventData>(

--- a/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
+++ b/packages/beacon-node/src/network/core/networkCoreWorkerHandler.ts
@@ -38,6 +38,7 @@ export type WorkerNetworkCoreOpts = NetworkOptions & {
   activeValidatorCount: number;
   genesisTime: number;
   initialStatus: Status;
+  initialCustodyGroupCount: number;
 };
 
 export type WorkerNetworkCoreInitModules = {
@@ -104,7 +105,15 @@ export class WorkerNetworkCore implements INetworkCore {
 
   static async init(modules: WorkerNetworkCoreInitModules): Promise<WorkerNetworkCore> {
     const {opts, config, privateKey} = modules;
-    const {genesisTime, peerStoreDir, activeValidatorCount, localMultiaddrs, metricsEnabled, initialStatus} = opts;
+    const {
+      genesisTime,
+      peerStoreDir,
+      activeValidatorCount,
+      localMultiaddrs,
+      metricsEnabled,
+      initialStatus,
+      initialCustodyGroupCount,
+    } = opts;
 
     const workerData: NetworkWorkerData = {
       opts,
@@ -116,6 +125,7 @@ export class WorkerNetworkCore implements INetworkCore {
       peerStoreDir,
       genesisTime,
       initialStatus,
+      initialCustodyGroupCount,
       activeValidatorCount,
       loggerOpts: modules.logger.toOpts(),
     };

--- a/packages/beacon-node/src/network/core/types.ts
+++ b/packages/beacon-node/src/network/core/types.ts
@@ -80,6 +80,7 @@ export type NetworkWorkerData = {
   genesisTime: number;
   activeValidatorCount: number;
   initialStatus: Status;
+  initialCustodyGroupCount: number;
   privateKeyProto: Uint8Array;
   localMultiaddrs: string[];
   metricsEnabled: boolean;

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -158,6 +158,7 @@ export class Network implements INetwork {
 
     const activeValidatorCount = chain.getHeadState().epochCtx.currentShuffling.activeIndices.length;
     const initialStatus = chain.getStatus();
+    const initialCustodyGroupCount = chain.custodyConfig.targetCustodyGroupCount;
 
     if (opts.useWorker) {
       logger.info("running libp2p instance in worker thread");
@@ -172,6 +173,7 @@ export class Network implements INetwork {
             activeValidatorCount,
             genesisTime: chain.genesisTime,
             initialStatus,
+            initialCustodyGroupCount,
           },
           config,
           privateKey,
@@ -191,6 +193,7 @@ export class Network implements INetwork {
           getReqRespHandler,
           metricsRegistry: metrics ? new RegistryMetricCreator() : null,
           initialStatus,
+          initialCustodyGroupCount,
           activeValidatorCount,
         });
 

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -46,7 +46,9 @@ export enum RecoverResult {
 }
 
 export type CustodyConfigOpts = {
-  supernode?: boolean;
+  nodeId: NodeId;
+  config: ChainForkConfig;
+  initialCustodyGroupCount?: number;
 };
 
 export class CustodyConfig {
@@ -92,16 +94,12 @@ export class CustodyConfig {
   private config: ChainForkConfig;
   private nodeId: NodeId;
 
-  private readonly metrics: Metrics | null;
-
-  constructor(nodeId: NodeId, config: ChainForkConfig, metrics: Metrics | null, opts: CustodyConfigOpts = {}) {
-    this.config = config;
-    this.nodeId = nodeId;
-    this.metrics = metrics;
-    this.targetCustodyGroupCount = opts.supernode ? NUMBER_OF_CUSTODY_GROUPS : config.CUSTODY_REQUIREMENT;
+  constructor(opts: CustodyConfigOpts) {
+    this.config = opts.config;
+    this.nodeId = opts.nodeId;
+    this.targetCustodyGroupCount = opts.initialCustodyGroupCount ?? this.config.CUSTODY_REQUIREMENT;
     this.custodyColumns = getDataColumns(this.nodeId, this.targetCustodyGroupCount);
     this.custodyColumnsIndex = this.getCustodyColumnsIndex(this.custodyColumns);
-    this.metrics?.peerDas.custodyGroupCount.set(this.targetCustodyGroupCount);
     this.sampledGroupCount = Math.max(this.targetCustodyGroupCount, this.config.SAMPLES_PER_SLOT);
     this.sampleGroups = getCustodyGroups(this.nodeId, this.sampledGroupCount);
     this.sampledColumns = getDataColumns(this.nodeId, this.sampledGroupCount);
@@ -118,7 +116,6 @@ export class CustodyConfig {
     this.sampleGroups = getCustodyGroups(this.nodeId, this.sampledGroupCount);
     this.sampledColumns = getDataColumns(this.nodeId, this.sampledGroupCount);
     this.sampledSubnets = this.sampledColumns.map(computeSubnetForDataColumn);
-    this.metrics?.peerDas.custodyGroupCount.set(this.targetCustodyGroupCount);
   }
 
   private getCustodyColumnsIndex(custodyColumns: ColumnIndex[]): Uint8Array {

--- a/packages/beacon-node/src/util/metadata.ts
+++ b/packages/beacon-node/src/util/metadata.ts
@@ -1,4 +1,4 @@
-import {intToBytes} from "@lodestar/utils";
+import {bytesToInt, intToBytes} from "@lodestar/utils";
 import {ClientCode, ClientVersion} from "../execution/index.js";
 
 export function getLodestarClientVersion(info?: {version?: string; commit?: string}): ClientVersion {
@@ -15,4 +15,8 @@ export function getLodestarClientVersion(info?: {version?: string; commit?: stri
  */
 export function serializeCgc(cgc: number): Uint8Array {
   return intToBytes(cgc, Math.ceil(Math.log2(cgc + 1) / 8), "be");
+}
+
+export function deserializeCgc(cgcBytes: Uint8Array): number {
+  return bytesToInt(cgcBytes, "be");
 }

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -49,7 +49,10 @@ describe("network / peers / PeerManager", () => {
     const networkConfig: NetworkConfig = {
       nodeId,
       config: beaconConfig,
-      custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+      custodyConfig: new CustodyConfig({
+        nodeId,
+        config,
+      }),
     };
     const controller = new AbortController();
     const clock = new Clock({config: beaconConfig, genesisTime: 0, signal: controller.signal});

--- a/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
+++ b/packages/beacon-node/test/e2e/network/reqrespEncode.test.ts
@@ -71,7 +71,10 @@ describe("reqresp encoder", () => {
     const networkConfig: NetworkConfig = {
       nodeId,
       config,
-      custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+      custodyConfig: new CustodyConfig({
+        nodeId,
+        config,
+      }),
     };
     const logger = testLogger();
     const modules: ReqRespBeaconNodeModules = {

--- a/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenGossipBlockInput.test.ts
@@ -44,7 +44,7 @@ describe("SeenGossipBlockInput", () => {
   const unusedClock = {} as unknown as IClock;
 
   const seenGossipBlockInput = new SeenGossipBlockInput(
-    new CustodyConfig(nodeId, config, null),
+    new CustodyConfig({nodeId, config}),
     executionEngine,
     emitter,
     unusedClock,

--- a/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
@@ -103,7 +103,10 @@ describe.skip("beaconBlocksMaybeBlobsByRange", () => {
         });
       });
 
-      const custodyConfig = new CustodyConfig(new Uint8Array(32), config, null);
+      const custodyConfig = new CustodyConfig({
+        nodeId: new Uint8Array(32),
+        config,
+      });
       custodyConfig.sampledColumns = [2, 4, 6, 8];
 
       const network = {

--- a/packages/beacon-node/test/unit/network/metadata.test.ts
+++ b/packages/beacon-node/test/unit/network/metadata.test.ts
@@ -51,7 +51,10 @@ describe("network / metadata", () => {
       const networkConfig: NetworkConfig = {
         nodeId,
         config,
-        custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+        custodyConfig: new CustodyConfig({
+          nodeId,
+          config,
+        }),
       };
       const metadata = new MetadataController({}, {onSetValue, networkConfig, logger});
 
@@ -66,7 +69,10 @@ describe("network / metadata", () => {
       const networkConfig: NetworkConfig = {
         nodeId,
         config,
-        custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+        custodyConfig: new CustodyConfig({
+          nodeId,
+          config,
+        }),
       };
       const metadata = new MetadataController({}, {onSetValue, networkConfig, logger});
       metadata.custodyGroupCount = 128;
@@ -79,7 +85,10 @@ describe("network / metadata", () => {
       const networkConfig: NetworkConfig = {
         nodeId,
         config,
-        custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+        custodyConfig: new CustodyConfig({
+          nodeId,
+          config,
+        }),
       };
       const metadata = new MetadataController({}, {onSetValue, networkConfig, logger});
       const initialSeqNumber = metadata.seqNumber;
@@ -93,7 +102,10 @@ describe("network / metadata", () => {
       const networkConfig: NetworkConfig = {
         nodeId,
         config,
-        custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+        custodyConfig: new CustodyConfig({
+          nodeId,
+          config,
+        }),
       };
       const metadata = new MetadataController({}, {onSetValue, networkConfig, logger});
       metadata.custodyGroupCount = 128;

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -34,7 +34,10 @@ describe("AttnetsService", () => {
   const networkConfig: NetworkConfig = {
     nodeId,
     config,
-    custodyConfig: new CustodyConfig(nodeId, config, null, {supernode: false}),
+    custodyConfig: new CustodyConfig({
+      nodeId,
+      config,
+    }),
   };
   // const {SECONDS_PER_SLOT} = config;
   let service: AttnetsService;

--- a/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
+++ b/packages/beacon-node/test/unit/network/unavailableBeaconBlobsByRoot.test.ts
@@ -211,7 +211,10 @@ describe("unavailableBeaconBlobsByRoot", () => {
     const network = {
       sendBeaconBlocksByRoot: vi.fn(),
       sendBlobSidecarsByRoot: vi.fn(),
-      custodyConfig: new CustodyConfig(computeNodeId(getValidPeerId()), config, null),
+      custodyConfig: new CustodyConfig({
+        nodeId: computeNodeId(getValidPeerId()),
+        config,
+      }),
     };
 
     const peerId = "mockPeerId";

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -59,7 +59,10 @@ describe("sync / range / chain", () => {
   const zeroBlockBody = ssz.phase0.BeaconBlockBody.defaultValue();
   const interval: NodeJS.Timeout | null = null;
   const nodeId = fromHexString("cdbee32dc3c50e9711d22be5565c7e44ff6108af663b2dc5abd2df573d2fa83f");
-  const custodyConfig = new CustodyConfig(nodeId, config, null);
+  const custodyConfig = new CustodyConfig({
+    nodeId,
+    config,
+  });
 
   const reportPeer: SyncChainFns["reportPeer"] = () => {};
   const getConnectedPeerSyncMeta: SyncChainFns["getConnectedPeerSyncMeta"] = (peerId) => {

--- a/packages/beacon-node/test/unit/util/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/util/dataColumn.test.ts
@@ -94,7 +94,7 @@ describe("CustodyConfig", () => {
   });
 
   it("custody columns present in sampled columns", () => {
-    const custodyConfig = new CustodyConfig(nodeId, config, null);
+    const custodyConfig = new CustodyConfig({nodeId, config});
     const {custodyColumns} = custodyConfig;
     const sampledColumns = custodyConfig.sampledColumns;
 
@@ -107,7 +107,7 @@ describe("CustodyConfig", () => {
 
   describe("updateCustodyRequirement", () => {
     it("should update target and sampled but not advertised", () => {
-      const custodyConfig = new CustodyConfig(nodeId, config, null);
+      const custodyConfig = new CustodyConfig({nodeId, config});
 
       expect(custodyConfig.sampledGroupCount).toBe(8);
       expect(custodyConfig.targetCustodyGroupCount).toBe(4);

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -212,7 +212,7 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
     beaconNodeOptions.set({network: {discv5: {bootEnrs: [...new Set(bootnodes)]}}});
   }
 
-  beaconNodeOptions.set({chain: {initialCustodyGroupCount: getInitialCGC(args, config, enr)}});
+  beaconNodeOptions.set({chain: {initialCustodyGroupCount: getInitialCustodyGroupCount(args, config, enr)}});
 
   if (args.disableLightClientServer) {
     beaconNodeOptions.set({chain: {disableLightClientServer: true}});
@@ -256,7 +256,7 @@ export function initLogger(
   return logger;
 }
 
-function getInitialCGC(args: BeaconArgs & GlobalArgs, config: ChainForkConfig, enr: SignableENR): number {
+function getInitialCustodyGroupCount(args: BeaconArgs & GlobalArgs, config: ChainForkConfig, enr: SignableENR): number {
   if (args.supernode) {
     return NUMBER_OF_CUSTODY_GROUPS;
   }

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -5,10 +5,11 @@ import {BeaconDb, BeaconNode} from "@lodestar/beacon-node";
 import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db";
 import {LoggerNode, getNodeLogger} from "@lodestar/logger/node";
-import {ACTIVE_PRESET, PresetName} from "@lodestar/params";
-import {ErrorAborted} from "@lodestar/utils";
+import {ACTIVE_PRESET, NUMBER_OF_CUSTODY_GROUPS, PresetName} from "@lodestar/params";
+import {ErrorAborted, bytesToInt} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
 
+import {SignableENR} from "@chainsafe/enr";
 import {BeaconNodeOptions, getBeaconConfigFromArgs} from "../../config/index.js";
 import {getNetworkBootnodes, getNetworkData, isKnownNetworkName, readBootnodes} from "../../networks/index.js";
 import {GlobalArgs, parseBeaconNodeArgs} from "../../options/index.js";
@@ -211,6 +212,8 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
     beaconNodeOptions.set({network: {discv5: {bootEnrs: [...new Set(bootnodes)]}}});
   }
 
+  beaconNodeOptions.set({chain: {initialCustodyGroupCount: getInitialCGC(args, config, enr)}});
+
   if (args.disableLightClientServer) {
     beaconNodeOptions.set({chain: {disableLightClientServer: true}});
   }
@@ -251,4 +254,15 @@ export function initLogger(
   }
 
   return logger;
+}
+
+function getInitialCGC(args: BeaconArgs & GlobalArgs, config: ChainForkConfig, enr: SignableENR): number {
+  if (args.supernode) {
+    return NUMBER_OF_CUSTODY_GROUPS;
+  }
+
+  const enrCgcBytes = enr.kvs.get("cgc");
+  const enrCgc = enrCgcBytes != null ? bytesToInt(enrCgcBytes, "be") : 0;
+
+  return Math.max(enrCgc, config.CUSTODY_REQUIREMENT);
 }


### PR DESCRIPTION
**Motivation**

- https://github.com/ChainSafe/lodestar/issues/8097
- supersedes https://github.com/ChainSafe/lodestar/pull/8112

**Description**

- remove metrics from `CustodyConfig`. Instead, do metrics in `BeaconChain` (set on initialization, set on update)
- add `initialCustodyGroupCount` opt that gets set at the CLI layer by "doing the right thing" - comparing opts.supernode, the stored enr value, and the config value.
- thread `initialCustodyGroupCount` thru the application
- update all `CustodyConfig` construction sites