### PR TITLE
fix: restore chain.archiveBlobEpochs cli flag

### DIFF
--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -285,6 +285,8 @@ Will double processing times. Use only for debugging purposes.",
   },
 
   "chain.archiveDataEpochs": {
+    // TODO: remove this alias after Lodestar 2.0
+    alias: "chain.archiveBlobEpochs",
     description:
       "Number of epochs to retain finalized blobs/columns (minimum of MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS/MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS)",
     type: "number",

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -285,7 +285,6 @@ Will double processing times. Use only for debugging purposes.",
   },
 
   "chain.archiveDataEpochs": {
-    // TODO: remove this alias after Lodestar 2.0
     alias: "chain.archiveBlobEpochs",
     description:
       "Number of epochs to retain finalized blobs/columns (minimum of MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS/MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS)",


### PR DESCRIPTION
**Motivation**

- https://github.com/ChainSafe/lodestar/pull/6353#discussion_r2257787139

**Description**

- add alias to old (pre-peerDAS) cli flag