### PR TITLE
chore: use number for cell indices

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/validateBlobsAndKzgCommitments.ts
+++ b/packages/beacon-node/src/chain/produceBlock/validateBlobsAndKzgCommitments.ts
@@ -47,7 +47,7 @@ export async function validateBlobsAndKzgCommitments(
 
   const commitmentBytes = blobsBundle.commitments.flatMap((commitment) => Array(CELLS_PER_EXT_BLOB).fill(commitment));
   const cellIndices = Array.from({length: blobsBundle.blobs.length}).flatMap(() =>
-    Array.from({length: CELLS_PER_EXT_BLOB}, (_, i) => BigInt(i))
+    Array.from({length: CELLS_PER_EXT_BLOB}, (_, i) => i)
   );
   const proofBytes = blobsBundle.proofs.flat();
 

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -142,7 +142,7 @@ export async function validateGossipDataColumnSidecar(
   try {
     await verifyDataColumnSidecarKzgProofs(
       dataColumnSidecar.kzgCommitments,
-      Array.from({length: dataColumnSidecar.column.length}, () => BigInt(dataColumnSidecar.index)),
+      Array.from({length: dataColumnSidecar.column.length}, () => dataColumnSidecar.index),
       dataColumnSidecar.column,
       dataColumnSidecar.kzgProofs
     );
@@ -184,7 +184,7 @@ export async function validateDataColumnsSidecars(
   opts: {skipProofsCheck: boolean} = {skipProofsCheck: false}
 ): Promise<void> {
   const commitmentBytes: Uint8Array[] = [];
-  const cellIndices: bigint[] = [];
+  const cellIndices: number[] = [];
   const cells: Uint8Array[] = [];
   const proofBytes: Uint8Array[] = [];
 
@@ -221,7 +221,7 @@ export async function validateDataColumnsSidecars(
     }
 
     commitmentBytes.push(...kzgCommitments);
-    cellIndices.push(...Array.from({length: column.length}, () => BigInt(columnIndex)));
+    cellIndices.push(...Array.from({length: column.length}, () => columnIndex));
     cells.push(...column);
     proofBytes.push(...kzgProofs);
   }
@@ -283,7 +283,7 @@ export function verifyDataColumnSidecar(dataColumnSidecar: fulu.DataColumnSideca
  */
 export async function verifyDataColumnSidecarKzgProofs(
   commitments: Uint8Array[],
-  cellIndices: bigint[],
+  cellIndices: number[],
   cells: Uint8Array[],
   proofs: Uint8Array[]
 ): Promise<void> {

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -148,10 +148,10 @@ export async function recoverDataColumnSidecars(
   // https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/das-core.md#recover_matrix
   const cellsAndProofs = await Promise.all(
     blobProofs.map((_, blobIndex) => {
-      const cellIndices: bigint[] = [];
+      const cellIndices: number[] = [];
       const cells: Uint8Array[] = [];
       for (const [columnIndex, dataColumn] of partialSidecars.entries()) {
-        cellIndices.push(BigInt(columnIndex));
+        cellIndices.push(columnIndex);
         cells.push(dataColumn.column[blobIndex]);
       }
       // recovered cells and proofs are of the same row/blob, their length should be NUMBER_OF_COLUMNS


### PR DESCRIPTION
**Motivation**

- https://github.com/ChainSafe/lodestar/pull/6353#discussion_r2255273049
- 
**Description**

- As of crate-crypto/node-eth-kzg 0.8.0, it supports using `number` to represent cell indices. No need for bigint conversion.
- Use `number` where we can