### PR TITLE
feat: no double proof check on columns

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -120,14 +120,14 @@ async function maybeValidateBlobs(
 
         // if the blob sidecars have been individually verified then we can skip kzg proof check
         // but other checks to match blobs with block data still need to be performed
+        //
+        // TODO(@matthewkeil) this needs to be removed in BlockInput refactor.  should not be an option to
+        //    not verify during gossip so should never be necessary during block import
         const skipProofsCheck = opts.validBlobSidecars === BlobSidecarValidation.Individual;
         await validateBlobSidecars(blockSlot, beaconBlockRoot, blobKzgCommitments, blobs, {skipProofsCheck});
       } else if (isForkPostFulu(blockData.fork)) {
         const {dataColumns} = blockData as BlockInputDataColumns;
-        const skipProofsCheck = opts.validBlobSidecars === BlobSidecarValidation.Individual;
-        await validateDataColumnsSidecars(blockSlot, beaconBlockRoot, blobKzgCommitments, dataColumns, chain.metrics, {
-          skipProofsCheck,
-        });
+        validateDataColumnsSidecars(blockSlot, beaconBlockRoot, blobKzgCommitments, dataColumns);
       }
 
       const availableBlockInput = getBlockInput.availableData(

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -180,7 +180,7 @@ export function validateDataColumnsSidecars(
   blockRoot: Root,
   blockKzgCommitments: deneb.BlobKzgCommitments,
   dataColumnSidecars: fulu.DataColumnSidecars
-): Promise<void> {
+): void {
   for (let sidecarsIndex = 0; sidecarsIndex < dataColumnSidecars.length; sidecarsIndex++) {
     const columnSidecar = dataColumnSidecars[sidecarsIndex];
     const {index: columnIndex, column, kzgCommitments, kzgProofs} = columnSidecar;

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -175,19 +175,12 @@ export async function validateGossipDataColumnSidecar(
   }
 }
 
-export async function validateDataColumnsSidecars(
+export function validateDataColumnsSidecars(
   blockSlot: Slot,
   blockRoot: Root,
   blockKzgCommitments: deneb.BlobKzgCommitments,
-  dataColumnSidecars: fulu.DataColumnSidecars,
-  metrics: Metrics | null,
-  opts: {skipProofsCheck: boolean} = {skipProofsCheck: false}
+  dataColumnSidecars: fulu.DataColumnSidecars
 ): Promise<void> {
-  const commitmentBytes: Uint8Array[] = [];
-  const cellIndices: number[] = [];
-  const cells: Uint8Array[] = [];
-  const proofBytes: Uint8Array[] = [];
-
   for (let sidecarsIndex = 0; sidecarsIndex < dataColumnSidecars.length; sidecarsIndex++) {
     const columnSidecar = dataColumnSidecars[sidecarsIndex];
     const {index: columnIndex, column, kzgCommitments, kzgProofs} = columnSidecar;
@@ -219,29 +212,6 @@ export async function validateDataColumnsSidecars(
         `Invalid data sidecar array lengths for columnIndex=${columnIndex} in slot=${blockSlot} blockRoot=${toHex(blockRoot)}`
       );
     }
-
-    commitmentBytes.push(...kzgCommitments);
-    cellIndices.push(...Array.from({length: column.length}, () => columnIndex));
-    cells.push(...column);
-    proofBytes.push(...kzgProofs);
-  }
-
-  if (opts.skipProofsCheck) {
-    return;
-  }
-
-  let valid: boolean;
-  try {
-    const timer = metrics?.peerDas.kzgVerificationDataColumnBatchTime.startTimer();
-    valid = await kzg.asyncVerifyCellKzgProofBatch(commitmentBytes, cellIndices, cells, proofBytes);
-    timer?.();
-  } catch (err) {
-    (err as Error).message = `Error in verifyCellKzgProofBatch for slot=${blockSlot} blockRoot=${toHex(blockRoot)}`;
-    throw err;
-  }
-
-  if (!valid) {
-    throw new Error(`Invalid data column sidecars in slot=${blockSlot} blockRoot=${toHex(blockRoot)}`);
   }
 }
 
@@ -289,13 +259,15 @@ export async function verifyDataColumnSidecarKzgProofs(
 ): Promise<void> {
   let valid: boolean;
   try {
-    valid = await kzg.verifyCellKzgProofBatch(commitments, cellIndices, cells, proofs);
+    // TODO(fulu): this was an async function with the sync kzg method.  prob should be full async
+    //    but should double check gossip validation times to see if it should stay main thread (full sync)
+    valid = await kzg.asyncVerifyCellKzgProofBatch(commitments, cellIndices, cells, proofs);
   } catch (e) {
-    (e as Error).message = `Error on verifyCellKzgProofBatch: ${(e as Error).message}`;
+    (e as Error).message = `Error on asyncVerifyCellKzgProofBatch: ${(e as Error).message}`;
     throw e;
   }
   if (!valid) {
-    throw Error("Invalid verifyCellKzgProofBatch");
+    throw Error("Invalid asyncVerifyCellKzgProofBatch");
   }
 }
 

--- a/packages/beacon-node/test/unit/util/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/util/dataColumn.test.ts
@@ -172,9 +172,7 @@ describe("data column sidecars", () => {
     expect(columnSidecars.length).toEqual(NUMBER_OF_COLUMNS);
     expect(columnSidecars[0].column.length).toEqual(blobs.length);
 
-    await expect(
-      validateDataColumnsSidecars(slot, blockRoot, kzgCommitments, columnSidecars, null)
-    ).resolves.toBeUndefined();
+    expect(validateDataColumnsSidecars(slot, blockRoot, kzgCommitments, columnSidecars)).toBeUndefined();
   });
 
   it("fail for no blob commitments in validateDataColumnsSidecars", async () => {
@@ -212,7 +210,7 @@ describe("data column sidecars", () => {
     expect(columnSidecars.length).toEqual(NUMBER_OF_COLUMNS);
     expect(columnSidecars[0].column.length).toEqual(blobs.length);
 
-    await expect(validateDataColumnsSidecars(slot, blockRoot, [], columnSidecars, null)).rejects.toThrow(
+    expect(validateDataColumnsSidecars(slot, blockRoot, [], columnSidecars)).toThrow(
       `Invalid data column sidecar slot=${slot}`
     );
   });


### PR DESCRIPTION
**Motivation**

Currently we are double checking the kzg proof for data columns.  They are checked once for gossip validation and then again in `is_data_available` spec function (`verifyBlocksDataAvailability`) before block import.   

Should not do the second validation.  Only need to check that the commitments that are included in the sidecar byte-wise match the commitments in the block.  

We already pair the data to the block via the root of the `SignedBlockHeader` of the sidecar and the root of the block, ~~so as long as the individual commitments are byte-wise matched we have reasonable certainty that the proofs are valid at both steps of the process.~~ and we check the inclusion proofs so we know that they are contained in the blinded part of the `BlockHeader` at gossip time.

The only thing that needs to be handled in `is_data_available` is to verify that all columns that need to be sampled are present. Also need to add the validation checks to req/resp so columnSidecars received via that are also good.

I also noticed that in the gossip validation function the proof check was using the synchronous version but the wrapper function was an `async function`.  Switched it over to full async.  Need to double check that this does not negatively impact the gossip validation times.  Otherwise should move back to a full synchronous verification.  BLS is currently async as is the regen so should be the correct move.  Made a TODO to check though before final release