### PR TITLE
fix: handle bad response of 0 block from peer

### DIFF
--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -23,6 +23,13 @@ import {INetwork, WithOptionalBytes} from "../interface.js";
 import {PeerSyncMeta} from "../peers/peersData.js";
 
 export type PartialDownload = null | {blocks: BlockInput[]; pendingDataColumns: number[]};
+
+/**
+ * Download blocks and blobs (prefulu) or data columns (fulu) by range.
+ * returns:
+ *  - array of blocks with blobs or data columns
+ *  - pendingDataColumns: null if all data columns are present, or array of column indexes that are missing. Also null for prefulu
+ */
 export async function beaconBlocksMaybeBlobsByRange(
   config: ChainForkConfig,
   network: INetwork,
@@ -182,10 +189,14 @@ export async function beaconBlocksMaybeBlobsByRange(
 
   // Data is out of range, only request blocks
   const blocks = await network.sendBeaconBlocksByRange(peerId, request);
+  if (blocks.length === 0) {
+    throw Error(
+      `peerId=${peerId} peerClient=${peerClient} returned no blocks for BeaconBlocksByRangeRequest ${JSON.stringify(request)}`
+    );
+  }
   return {
     blocks: blocks.map((block) => getBlockInput.outOfRangeData(config, block.data, BlockSource.byRange)),
-    // TODO: (@matthewkeil) this was a merge conflict when rebased on electra. Should this be a null or an empty array?  Should it
-    //       depend on which fork we are in?  Need to revisit
+    // null means all data columns are present
     pendingDataColumns: null,
   };
 }

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -38,7 +38,7 @@ export async function beaconBlocksMaybeBlobsByRange(
   // Range sync satisfies this condition, but double check here for sanity
   const {startSlot, count} = request;
   if (count < 1) {
-    return {blocks: [], pendingDataColumns: null};
+    throw Error(`Invalid count=${count} in BeaconBlocksByRangeRequest`);
   }
   const endSlot = startSlot + count - 1;
 
@@ -55,6 +55,12 @@ export async function beaconBlocksMaybeBlobsByRange(
   // Note: Assumes all blocks in the same epoch
   if (forkSeq < ForkSeq.deneb) {
     const beaconBlocks = await network.sendBeaconBlocksByRange(peerId, request);
+    if (beaconBlocks.length === 0) {
+      throw Error(
+        `peerId=${peerId} peerClient=${peerClient} returned no blocks for BeaconBlocksByRangeRequest ${JSON.stringify(request)}`
+      );
+    }
+
     const blocks = beaconBlocks.map((block) => getBlockInput.preData(config, block.data, BlockSource.byRange));
     return {blocks, pendingDataColumns: null};
   }
@@ -68,6 +74,12 @@ export async function beaconBlocksMaybeBlobsByRange(
         network.sendBlobSidecarsByRange(peerId, request),
       ]);
 
+      if (allBlocks.length === 0) {
+        throw Error(
+          `peerId=${peerId} peerClient=${peerClient} returns no blocks allBlobSidecars=${allBlobSidecars.length} for BeaconBlocksByRangeRequest ${JSON.stringify(request)}`
+        );
+      }
+
       const blocks = matchBlockWithBlobs(
         config,
         allBlocks,
@@ -78,7 +90,8 @@ export async function beaconBlocksMaybeBlobsByRange(
       );
       return {blocks, pendingDataColumns: null};
     }
-    // get columns
+
+    // From fulu, get columns
     const sampledColumns = network.custodyConfig.sampledColumns;
     const neededColumns = partialDownload ? partialDownload.pendingDataColumns : sampledColumns;
 
@@ -130,6 +143,12 @@ export async function beaconBlocksMaybeBlobsByRange(
       peerClient,
       prevPartialDownload: !!partialDownload,
     });
+
+    if (allBlocks.length === 0) {
+      throw Error(
+        `peerId=${peerId} peerClient=${peerClient} returns no blocks dataColumnSidecars=${allDataColumnSidecars.length} for BeaconBlocksByRangeRequest ${JSON.stringify(request)}`
+      );
+    }
 
     const blocks = matchBlockWithDataColumns(
       network,

--- a/packages/beacon-node/src/sync/constants.ts
+++ b/packages/beacon-node/src/sync/constants.ts
@@ -10,8 +10,12 @@ export const MIN_FINALIZED_CHAIN_VALIDATED_EPOCHS = 10;
 // TODO: change it back to 5 when this issue is implemented https://github.com/ChainSafe/lodestar/issues/8033
 export const MAX_BATCH_DOWNLOAD_ATTEMPTS = 20;
 
-/** Consider batch faulty after downloading and processing this number of times */
-export const MAX_BATCH_PROCESSING_ATTEMPTS = 3;
+/**
+ * Consider batch faulty after downloading and processing this number of times
+ * as in https://github.com/ChainSafe/lodestar/issues/8147 we cannot proceed the sync chain if a peer return 0 blocks without error
+ * in that case we should throw error and `RangeSync` should remove that error chain and add a new one.
+ **/
+export const MAX_BATCH_PROCESSING_ATTEMPTS = 0;
 
 /**
  * Number of slots to offset batches.

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -123,6 +123,7 @@ export class Batch {
 
   /**
    * Downloading -> AwaitingProcessing
+   * pendingDataColumns is null when a complete download is done, otherwise it contains the columns that are still pending
    */
   downloadingSuccess(downloadResult: {
     blocks: BlockInput[];

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -51,7 +51,6 @@ export class ChainPeersBalancer {
       eligiblePeers,
       ({syncInfo}) => (failedPeers.has(syncInfo.peerId) ? 1 : 0), // prefer peers without failed requests
       ({syncInfo}) => this.activeRequestsByPeer.get(syncInfo.peerId) ?? 0, // prefer peers with least active req
-      ({hasEarliestAvailableSlots}) => (hasEarliestAvailableSlots ? 0 : 1), // prefer peers with earliestAvailableSlots defined
       ({columns}) => -1 * columns // prefer peers with the most columns
     );
 
@@ -69,7 +68,6 @@ export class ChainPeersBalancer {
     // - the most columns we need
     const sortedBestPeers = sortBy(
       eligiblePeers,
-      ({hasEarliestAvailableSlots}) => (hasEarliestAvailableSlots ? 0 : 1), // prefer peers with earliestAvailableSlots defined
       ({columns}) => -1 * columns // prefer peers with most columns we need
     );
     const bestPeer = sortedBestPeers[0];
@@ -103,15 +101,17 @@ export class ChainPeersBalancer {
         continue;
       }
 
-      // for devnet, we optimistically assume peers without earliestAvailableSlot, but don't prioritize them
-      // TODO(fulu): consider do not accept these peers
-      const earliestSlot = earliestAvailableSlot ?? 0;
-      const peerColumns = custodyGroups;
-
-      if (earliestSlot > batch.request.startSlot) {
+      // we don't accept peers without earliestAvailableSlot because it may return 0 blocks and we get stuck
+      // see https://github.com/ChainSafe/lodestar/issues/8147
+      if (earliestAvailableSlot == null) {
         continue;
       }
 
+      if (earliestAvailableSlot > batch.request.startSlot) {
+        continue;
+      }
+
+      const peerColumns = custodyGroups;
       const columns = peerColumns.reduce((acc, elem) => {
         if (requestColumns.includes(elem)) {
           acc.push(elem);


### PR DESCRIPTION
**Motivation**

- sync chain was stuck because some peers incorrectly response 0 block for a batch when they don't have it, see #8147
  - batch `n` has 0 block so chain does not process anything (and note that this is wrong response from peers, most likely peer started from a `checkpointSyncUrl`
  - batch `n+1` cannot process due to `UNKNOWN_BLOCK_PARENT`
  - then SyncChain stuck
- sometimes other clients throw `ResourceUnavailable` instead, and that's expected in the spec

**Description**
- set `MAX_BATCH_PROCESSING_ATTEMPTS` to 0, ie if we cannot process a batch, we remove that sync chain and RangeSync will automatically add a new one
- do not sync from peers without `earliestAvailableSlot`
- throw error if peers return 0 blocks (peers should have returned `ResourceUnavailable` error in that case according to [the spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#responding-side), we handle just in case. For lodestar, I tracked that in #8149)

Closes #8147

was able to sync `fusaka-devnet-3` 2 times using this branch along with #8166

<img width="851" height="346" alt="Screenshot 2025-08-09 at 14 45 32" src="https://github.com/user-attachments/assets/1f3afca0-13a6-4f7a-9c18-51d03cc34793" />
