### PR TITLE
fix: do not dial identify on dying connections

### DIFF
--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -701,13 +701,11 @@ export class PeerManager {
    * dialed or connecting to us.
    */
   private onLibp2pPeerConnect = async (evt: CustomEvent<Connection>): Promise<void> => {
-    const {direction, status, remotePeer} = evt.detail;
+    const {direction, remotePeer} = evt.detail;
     this.logger.verbose("peer connected", {peer: prettyPrintPeerId(remotePeer), direction, status});
     // NOTE: The peerConnect event is not emitted here here, but after asserting peer relevance
-    this.metrics?.peerConnectedEvent.inc({direction, status});
-    // libp2p may emit closed connection, we don't want to handle it
-    // see https://github.com/libp2p/js-libp2p/issues/1565
-    if (this.connectedPeers.has(remotePeer.toString()) || status !== "open") {
+    this.metrics?.peerConnectedEvent.inc({direction, status: evt.detail.status});
+    if (this.connectedPeers.has(remotePeer.toString())) {
       return;
     }
 
@@ -740,6 +738,10 @@ export class PeerManager {
       void this.requestPing(remotePeer);
       void this.requestStatus(remotePeer, this.statusCache.get());
     }
+
+    // It is observed that client connect and immediately disconnect
+    // We don't need to identify a peer which have connection status `closing` or `closed`
+    if (evt.detail.status !== "open") return;
 
     this.libp2p.services.identify
       .identify(evt.detail)

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -4,7 +4,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {LoggerNode} from "@lodestar/logger/node";
 import {ForkSeq, SLOTS_PER_EPOCH, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
 import {Metadata, Status, altair, fulu, phase0} from "@lodestar/types";
-import {toHex, withTimeout} from "@lodestar/utils";
+import {ErrorAborted, isErrorAborted, toHex, withTimeout} from "@lodestar/utils";
 import {GOODBYE_KNOWN_CODES, GoodByeReasonCode, Libp2pEvent} from "../../constants/index.js";
 import {IClock} from "../../util/clock.js";
 import {getCustodyGroups, getDataColumns} from "../../util/dataColumns.js";
@@ -702,10 +702,13 @@ export class PeerManager {
    */
   private onLibp2pPeerConnect = async (evt: CustomEvent<Connection>): Promise<void> => {
     const {direction, remotePeer} = evt.detail;
-    this.logger.verbose("peer connected", {peer: prettyPrintPeerId(remotePeer), direction, status});
+    const remotePeerIdStr = remotePeer.toString();
+    const remotePeerIdPrettyStr = prettyPrintPeerId(remotePeer);
+    this.logger.verbose("peer connected", {peer: remotePeerIdPrettyStr, direction, status: evt.detail.status});
+
     // NOTE: The peerConnect event is not emitted here here, but after asserting peer relevance
     this.metrics?.peerConnectedEvent.inc({direction, status: evt.detail.status});
-    if (this.connectedPeers.has(remotePeer.toString())) {
+    if (this.connectedPeers.has(remotePeerIdStr)) {
       return;
     }
 
@@ -731,7 +734,7 @@ export class PeerManager {
       agentClient: null,
       encodingPreference: null,
     };
-    this.connectedPeers.set(remotePeer.toString(), peerData);
+    this.connectedPeers.set(remotePeerIdStr, peerData);
 
     if (direction === "outbound") {
       // this.pingAndStatusTimeouts();
@@ -741,20 +744,37 @@ export class PeerManager {
 
     // It is observed that client connect and immediately disconnect
     // We don't need to identify a peer which have connection status `closing` or `closed`
-    if (evt.detail.status !== "open") return;
+    if (evt.detail.status !== "open") {
+      this.logger.debug("Skipping Identify because connection not open", {peerId: remotePeerIdPrettyStr, direction});
+      return;
+    }
 
-    this.libp2p.services.identify
-      .identify(evt.detail)
-      .then((result) => {
-        const agentVersion = result.agentVersion;
-        if (agentVersion) {
-          peerData.agentVersion = agentVersion;
-          peerData.agentClient = getKnownClientFromAgentVersion(agentVersion);
-        }
-      })
-      .catch((err) => {
-        this.logger.debug("Error setting agentVersion for the peer", {peerId: peerData.peerId.toString()}, err);
-      });
+    const identifyController = new AbortController();
+    const earlyAbortMessage = "Abort identify step because peer is disconnected";
+    const onEarlyDisconnect = (disconnectEvt: CustomEvent<Connection>) => {
+      if (disconnectEvt.detail === evt.detail) identifyController.abort(new ErrorAborted(earlyAbortMessage));
+    };
+    this.libp2p.services.components.events.addEventListener(Libp2pEvent.connectionClose, onEarlyDisconnect, {
+      once: true,
+    });
+
+    try {
+      const result = await this.libp2p.services.identify.identify(evt.detail, {signal: identifyController.signal});
+      this.libp2p.services.components.events.removeEventListener(Libp2pEvent.connectionClose, onEarlyDisconnect);
+      const agentVersion = result.agentVersion;
+      if (agentVersion) {
+        peerData.agentVersion = agentVersion;
+        peerData.agentClient = getKnownClientFromAgentVersion(agentVersion);
+      }
+    } catch (err: unknown) {
+      if (isErrorAborted(err) && err.message === earlyAbortMessage) {
+        this.logger.debug("Peer disconnected before identification", {peerId: remotePeerIdPrettyStr, direction});
+      } else {
+        this.logger.debug("Error setting agentVersion for the peer", {peerId: remotePeerIdPrettyStr}, err as Error);
+      }
+    } finally {
+      this.libp2p.services.components.events.removeEventListener(Libp2pEvent.connectionClose, onEarlyDisconnect);
+    }
   };
 
   /**

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -234,4 +234,78 @@ describe("network / peers / PeerManager", () => {
 
     expect(peerManager["connectedPeers"].get(peerId1.toString())?.metadata).toEqual(remoteMetadata);
   });
+
+  describe("safe identification of peers", () => {
+    it("skips identify when connection status is closing", async () => {
+      const {peerManager, libp2p} = await mockModules();
+      const conn = {
+        direction: "inbound",
+        status: "closing",
+        remotePeer: peerId1,
+      } as unknown as Connection;
+      const identifySpy = vi.spyOn(libp2p.services.identify, "identify");
+
+      await peerManager["onLibp2pPeerConnect"](new CustomEvent("evt", {detail: conn}));
+      // identify should not be called; we assert by absence of agentVersion on peerData
+      const pd = peerManager["connectedPeers"].get(peerId1.toString());
+      expect(pd).toBeDefined();
+      expect(pd?.agentVersion).toBeNull();
+      expect(identifySpy).not.toHaveBeenCalled();
+    });
+
+    it("skips identify when connection status is closed", async () => {
+      const {peerManager, libp2p} = await mockModules();
+      const conn = {
+        direction: "inbound",
+        status: "closed",
+        remotePeer: peerId1,
+      } as unknown as Connection;
+      const identifySpy = vi.spyOn(libp2p.services.identify, "identify");
+
+      await peerManager["onLibp2pPeerConnect"](new CustomEvent("evt", {detail: conn}));
+      // identify should not be called; we assert by absence of agentVersion on peerData
+      const pd = peerManager["connectedPeers"].get(peerId1.toString());
+      expect(pd).toBeDefined();
+      expect(pd?.agentVersion).toBeNull();
+      expect(identifySpy).not.toHaveBeenCalled();
+    });
+
+    it("aborts identify on connectionClose for same connection", async () => {
+      const {peerManager, libp2p} = await mockModules();
+
+      const conn = {
+        direction: "inbound",
+        status: "open",
+        remotePeer: peerId1,
+      } as unknown as Connection;
+      const identifySpy = vi.spyOn(libp2p.services.identify, "identify");
+
+      const p = peerManager["onLibp2pPeerConnect"](new CustomEvent("evt", {detail: conn}));
+
+      // fire the close event for the same connection to trigger abort
+      libp2p.services.components.events.dispatchEvent(new CustomEvent("connection:close", {detail: conn}));
+
+      await p;
+
+      expect(identifySpy).toHaveBeenCalledOnce();
+    });
+
+    it("successful identify stores agentVersion", async () => {
+      const {peerManager, libp2p} = await mockModules();
+      const conn = {
+        direction: "outbound",
+        status: "open",
+        remotePeer: peerId1,
+      } as unknown as Connection;
+      const identifySpy = vi
+        .spyOn(libp2p.services.identify, "identify")
+        .mockResolvedValue({agentVersion: "Lighthouse/v4.6.0"} as any);
+
+      await peerManager["onLibp2pPeerConnect"](new CustomEvent("evt", {detail: conn}));
+      const pd = peerManager["connectedPeers"].get(peerId1.toString());
+
+      expect(identifySpy).toHaveBeenCalledOnce();
+      expect(pd?.agentVersion).toBe("Lighthouse/v4.6.0");
+    });
+  });
 });


### PR DESCRIPTION
**Motivation**

We observed a lot of `UnexpectedEOFError: unexpected end of input` errors and observed that a lot of these happens after the remote connection is reset. 

**Description**

We observe the logs as following: 

1. Remote connects to us (inbound).
2. Handshake completes (TLS/noise + mplex).
3. Remote starts an identify stream 
4. For whatever reason (protocol mismatch, scoring policy, buggy client, etc.), the remote resets the TCP connection before we finish responding
5. We then attempt to open our own identify substream → underlying TCP is gone → UnexpectedEOFError.


```
025-08-07T06:46:49.366Z libp2p:tcp:socket successfully upgraded inbound connection\n
Aug-07 06:46:49.367[network]       \u001b[36mverbose\u001b[39m: peer connected peer=16...53V6e5, direction=inbound, status=open\n
2025-08-07T06:46:49.367Z libp2p:connection-manager:connection-pruner checking max connections limit 101/300\n
2025-08-07T06:46:49.368Z libp2p:mplex new initiator stream 0\n
2025-08-07T06:46:49.369Z libp2p:tcp:listener inbound connection upgraded /ip4/142.132.132.226/tcp/4101\n
2025-08-07T06:46:49.369Z libp2p:mplex new receiver stream 0\n
2025-08-07T06:46:49.370Z libp2p:mplex new receiver stream 1\n
2025-08-07T06:46:49.370Z libp2p:connection:inbound:4jujk31754549209366 incoming stream opened on /ipfs/id/1.0.0\n
2025-08-07T06:46:49.374Z libp2p:mplex receiver stream with id 0 and protocol /ipfs/id/1.0.0 ended\n
2025-08-07T06:46:49.374Z libp2p:tcp:socket:error inbound socket error - Error: write ECONNRESET\n
    at afterWriteDispatched (node:internal/stream_base_commons:159:15)\n
    at writeGeneric (node:internal/stream_base_commons:150:3)\n
    at Socket._writeGeneric (node:net:966:11)\n
    at Socket._write (node:net:978:8)\n
    at writeOrBuffer (node:internal/streams/writable:572:12)\n
    at _write (node:internal/streams/writable:501:10)\n
    at Writable.write (node:internal/streams/writable:510:10)\n
    at file:///usr/app/node_modules/stream-to-it/dist/src/sink.js:77:31\n
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n
    at async sink (file:///usr/app/node_modules/@libp2p/tcp/dist/src/socket-to-conn.js:87:17)\n
2025-08-07T06:46:49.374Z libp2p:connection:inbound:4jujk31754549209366 closing connection to /ip4/142.132.132.226/tcp/4101/p2p/16Uiu2HAmG63tyrvS3dQCaSRWqwyuqLfi6ewA8vNJ2UZT4k53V6e5\n
2025-08-07T06:46:49.375Z libp2p:mplex initiator stream with id 0 and protocol undefined ended\n
2025-08-07T06:46:49.375Z libp2p:mplex receiver stream with id 1 and protocol undefined ended\n
2025-08-07T06:46:49.375Z libp2p:connection:inbound:4jujk31754549209366:error could not create new outbound stream on connection from /ip4/142.132.132.226/tcp/4101 for protocols [ '/ipfs/id/1.0.0' ] - UnexpectedEOFError: unexpected end of input\n
    at Object.read (file:///usr/app/node_modules/it-byte-stream/dist/src/index.js:60:27)\n
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n
    at async Object.read (file:///usr/app/node_modules/it-length-prefixed-stream/dist/src/index.js:45:37)\n
    at async read (file:///usr/app/node_modules/@libp2p/multistream-select/dist/src/multistream.js:21:17)\n
    at async Module.readString (file:///usr/app/node_modules/@libp2p/multistream-select/dist/src/multistream.js:32:17)\n
    at async Module.select (file:///usr/app/node_modules/@libp2p/multistream-select/dist/src/select.js:72:20)\n
    at async ConnectionImpl.newStream [as _newStream] (file:///usr/app/node_modules/libp2p/dist/src/upgrader.js:353:50)\n
    at async ConnectionImpl.newStream (file:///usr/app/node_modules/libp2p/dist/src/connection/index.js:95:24)\n
    at async Identify._identify (file:///usr/app/node_modules/@libp2p/identify/dist/src/identify.js:50:22)\n
    at async Identify.identify (file:///usr/app/node_modules/@libp2p/identify/dist/src/identify.js:67:25)\n
```

By running these filters on the logs 

```bash
awk '
BEGIN {
  window_size = 10
}
{
  lines[NR] = $0
}
END {
  for (i = 1; i <= NR; i++) {
    if (lines[i] ~ /ECONNRESET/) {
      hasEOF = 0
      for (j = i+1; j <= i+window_size && j <= NR; j++) {
        if (lines[j] ~ /UnexpectedEOFError: unexpected end of input/) {
          hasEOF = 1
          break
        }
      }
      if (hasEOF)
        both++
      else
        newlineOnly++
    }
  }
  print "End of Input  + ECONNRESET: " both
  print "End of Input only: " newlineOnly
}' *.log *.log.*
```

Got the result as 

```
End of Input + ECONNRESET: 12362
End of Input only: 174931
```

For one peer we observed that much overlapping of these errors. That's too much noise, if we clear these up then we can focus on some real errors. 

**Steps to test or reproduce**

Test in devnet. 