### PR TITLE
feat: run `lodestar` root binary from any directory

### DIFF
--- a/lodestar
+++ b/lodestar
@@ -4,4 +4,6 @@
 #
 # ./lodestar.sh beacon --network mainnet
 
-exec node --trace-deprecation --max-old-space-size=8192 ./packages/cli/bin/lodestar.js "$@"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+exec node --trace-deprecation --max-old-space-size=8192 "$SCRIPT_DIR/packages/cli/bin/lodestar.js" "$@"


### PR DESCRIPTION
**Motivation**

During development need to run the `lodestar` from different directories, current binary wrapper does not allow that. With this change you can now run lodestar from any directory by just running `/path/to/lodestar_repo/lodestar`

**Description**

- Add the bash source script directory support


**Steps to test or reproduce**

- Run it locally