### PR TITLE
feat: avoid rate limit syncing

### DIFF
--- a/packages/beacon-node/src/sync/constants.ts
+++ b/packages/beacon-node/src/sync/constants.ts
@@ -51,3 +51,16 @@ export const EPOCHS_PER_BATCH = 1;
  * TODO: When switching branches usually all batches in AwaitingProcessing are dropped, could it be optimized?
  */
 export const BATCH_BUFFER_SIZE = Math.ceil(10 / EPOCHS_PER_BATCH);
+
+/**
+ * Maximum number of concurrent requests to perform with a SyncChain.
+ * This is according to the spec https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
+ */
+export const MAX_CONCURRENT_REQUESTS = 2;
+
+/**
+ * Maximum number of epochs to download ahead when syncing.
+ * In fulu, to fully process a batch we may need to download columns from multiple peers
+ * so having this constant too big is a waste of resources and peers may rate limit us.
+ */
+export const MAX_LOOK_AHEAD_EPOCHS = 2;

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -11,7 +11,7 @@ import {CustodyConfig} from "../../util/dataColumns.js";
 import {ItTrigger} from "../../util/itTrigger.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {wrapError} from "../../util/wrapError.js";
-import {BATCH_BUFFER_SIZE, EPOCHS_PER_BATCH} from "../constants.js";
+import {BATCH_BUFFER_SIZE, EPOCHS_PER_BATCH, MAX_LOOK_AHEAD_EPOCHS} from "../constants.js";
 import {RangeSyncType} from "../utils/remoteSyncType.js";
 import {Batch, BatchError, BatchErrorCode, BatchMetadata, BatchStatus} from "./batch.js";
 import {
@@ -406,6 +406,16 @@ export class SyncChain {
       return batch.state.status === BatchStatus.Downloading || batch.state.status === BatchStatus.AwaitingProcessing;
     });
     if (batchesInBuffer.length > BATCH_BUFFER_SIZE) {
+      return null;
+    }
+
+    // if last processed epoch is n, we don't want to request batches with epoch > n + MAX_LOOK_AHEAD_EPOCHS
+    // we should have enough batches to process in the buffer: n + 1, ..., n + MAX_LOOK_AHEAD_EPOCHS
+    // let's focus on redownloading these batches first because it may have to reach different peers to get enough sampled columns
+    if (
+      batches.length > 0 &&
+      Math.max(...batches.map((b) => b.startEpoch)) >= this.lastEpochWithProcessBlocks + MAX_LOOK_AHEAD_EPOCHS
+    ) {
       return null;
     }
 

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -594,6 +594,10 @@ export class SyncChain {
     }
 
     this.lastEpochWithProcessBlocks = newLastEpochWithProcessBlocks;
+    this.logger.verbose("Advanced chain", {
+      id: this.logId,
+      lastEpochWithProcessBlocks: this.lastEpochWithProcessBlocks,
+    });
   }
 
   private scrapeMetrics(metrics: Metrics): void {

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -66,7 +66,17 @@ export class ChainPeersBalancer {
       ({columns}) => -1 * columns // prefer peers with the most columns
     );
 
-    return sortedBestPeers.length > 0 ? sortedBestPeers[0].syncInfo : undefined;
+    if (sortedBestPeers.length > 0) {
+      const bestPeer = sortedBestPeers[0];
+      // we will use this peer for batch in SyncChain right after this call
+      this.activeRequestsByPeer.set(
+        bestPeer.syncInfo.peerId,
+        (this.activeRequestsByPeer.get(bestPeer.syncInfo.peerId) ?? 0) + 1
+      );
+      return bestPeer.syncInfo;
+    }
+
+    return undefined;
   }
 
   /**

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -3,6 +3,7 @@ import {CustodyConfig} from "../../../util/dataColumns.js";
 import {PeerIdStr} from "../../../util/peerId.js";
 import {shuffle} from "../../../util/shuffle.js";
 import {sortBy} from "../../../util/sortBy.js";
+import {MAX_CONCURRENT_REQUESTS} from "../../constants.js";
 import {Batch, BatchStatus} from "../batch.js";
 import {ChainTarget} from "./chainTarget.js";
 
@@ -11,12 +12,6 @@ export type PeerSyncInfo = PeerSyncMeta & {
 };
 
 type PeerInfoColumn = {syncInfo: PeerSyncInfo; columns: number; hasEarliestAvailableSlots: boolean};
-
-/**
- * Maximum number of concurrent requests to perform with a SyncChain.
- * This is according to the spec https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
- */
-const MAX_CONCURRENT_REQUESTS = 2;
 
 /**
  * Balance and organize peers to perform requests with a SyncChain

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -115,7 +115,7 @@ export class ChainPeersBalancer {
         continue;
       }
 
-      if (!noActiveRequest && activeRequest >= this.maxConcurrentRequests) {
+      if (activeRequest >= this.maxConcurrentRequests) {
         // consumer wants to find peer with no more than MAX_CONCURRENT_REQUESTS active requests
         continue;
       }

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -13,6 +13,12 @@ export type PeerSyncInfo = PeerSyncMeta & {
 type PeerInfoColumn = {syncInfo: PeerSyncInfo; columns: number; hasEarliestAvailableSlots: boolean};
 
 /**
+ * Maximum number of concurrent requests to perform with a SyncChain.
+ * This is according to the spec https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
+ */
+const MAX_CONCURRENT_REQUESTS = 2;
+
+/**
  * Balance and organize peers to perform requests with a SyncChain
  * Shuffles peers only once on instantiation
  */
@@ -20,11 +26,21 @@ export class ChainPeersBalancer {
   private peers: PeerSyncInfo[];
   private activeRequestsByPeer = new Map<PeerIdStr, number>();
   private readonly custodyConfig: CustodyConfig;
+  private readonly maxConcurrentRequests: number;
 
-  // TODO: @matthewkeil check if this needs to be updated for custody groups
-  constructor(peers: PeerSyncInfo[], batches: Batch[], custodyConfig: CustodyConfig) {
+  /**
+   * No need to specify `maxConcurrentRequests` for production code
+   * It is used for testing purposes to limit the number of concurrent requests
+   */
+  constructor(
+    peers: PeerSyncInfo[],
+    batches: Batch[],
+    custodyConfig: CustodyConfig,
+    maxConcurrentRequests = MAX_CONCURRENT_REQUESTS
+  ) {
     this.peers = shuffle(peers);
     this.custodyConfig = custodyConfig;
+    this.maxConcurrentRequests = maxConcurrentRequests;
 
     // Compute activeRequestsByPeer from all batches internal states
     for (const batch of batches) {
@@ -82,14 +98,20 @@ export class ChainPeersBalancer {
     return undefined;
   }
 
-  private filterPeers(batch: Batch, requestColumns: number[], checkActiveRequest: boolean): PeerInfoColumn[] {
+  private filterPeers(batch: Batch, requestColumns: number[], noActiveRequest: boolean): PeerInfoColumn[] {
     const eligiblePeers: PeerInfoColumn[] = [];
 
     for (const peer of this.peers) {
       const {earliestAvailableSlot, custodyGroups, target, peerId} = peer;
 
       const activeRequest = this.activeRequestsByPeer.get(peerId) ?? 0;
-      if (checkActiveRequest && activeRequest > 0) {
+      if (noActiveRequest && activeRequest > 0) {
+        // consumer wants to find peer with no active request, but this peer has active request
+        continue;
+      }
+
+      if (!noActiveRequest && activeRequest >= this.maxConcurrentRequests) {
+        // consumer wants to find peer with no more than MAX_CONCURRENT_REQUESTS active requests
         continue;
       }
 

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -28,10 +28,13 @@ describe("sync / range / chain", () => {
       targetEpoch: 16,
     },
     {
-      id: "Simulate sync with a very long range of skipped slots",
+      // due to BATCH_BUFFER_SIZE and MAX_LOOK_AHEAD_EPOCHS, lodestar cannot deal with unlimited skipped slots
+      // having a test with 2 epochs of skipped slots is enough to test the logic
+      // this hasn't happened in any networks as of Aug 2025
+      id: "Simulate sync with 2 epochs of skipped slots",
       startEpoch: 0,
       targetEpoch: 16,
-      skippedSlots: new Set(linspace(3 * SLOTS_PER_EPOCH, 10 * SLOTS_PER_EPOCH)),
+      skippedSlots: new Set(linspace(3 * SLOTS_PER_EPOCH, 4 * SLOTS_PER_EPOCH)),
     },
     {
       id: "Simulate sync with multiple ranges of bad blocks",


### PR DESCRIPTION
**Motivation**

- we got a lot of rate limited response from peers during syncing
- we should be able to control which peers to connect to based on tracked active requests in PeerBalancer

**Description**

- enforce no more than MAX_CONCURRENT_REQUESTS per peer in sync
- limit number of epochs downloaded ahead


part of #8033

**Test results on fusaka-devnet-3**
was able to sync `fusaka-devnet-3` 2 times using this branch along with #8150

<img width="851" height="346" alt="Screenshot 2025-08-09 at 14 45 32" src="https://github.com/user-attachments/assets/1f3afca0-13a6-4f7a-9c18-51d03cc34793" />

