### PR TITLE
feat: reduce peer score if they send mismatch DataColumnSidecars

### DIFF
--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -405,7 +405,7 @@ export function matchBlockWithDataColumns(
     throw Error(
       `Unmatched dataColumnSidecars, blocks=${allBlocks.length}, blobs=${
         allDataColumnSidecars.length
-      } lastMatchedSlot=${lastMatchedSlot}, pending blobSidecars slots=${allDataColumnSidecars
+      } lastMatchedSlot=${lastMatchedSlot}, pending dataColumnSidecars slots=${allDataColumnSidecars
         .slice(dataColumnSideCarIndex)
         .map((blb) => blb.signedBlockHeader.message.slot)
         .join(" ")}`

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -21,6 +21,7 @@ import {Metrics} from "../../metrics/index.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {INetwork, WithOptionalBytes} from "../interface.js";
 import {PeerSyncMeta} from "../peers/peersData.js";
+import {PeerAction} from "../peers/score/interface.js";
 
 export type PartialDownload = null | {blocks: BlockInput[]; pendingDataColumns: number[]};
 export async function beaconBlocksMaybeBlobsByRange(
@@ -245,7 +246,7 @@ export function matchBlockWithBlobs(
 }
 
 export function matchBlockWithDataColumns(
-  _network: INetwork,
+  network: INetwork,
   peerId: PeerIdStr,
   config: ChainForkConfig,
   sampledColumns: ColumnIndex[],
@@ -300,6 +301,7 @@ export function matchBlockWithDataColumns(
     });
     if (blobKzgCommitmentsLen === 0) {
       if (dataColumnSidecars.length > 0) {
+        network.reportPeer(peerId, PeerAction.LowToleranceError, "Missing or mismatching dataColumnSidecars");
         throw Error(
           `Missing or mismatching dataColumnSidecars from peerId=${peerId} for blockSlot=${block.data.message.slot} with blobKzgCommitmentsLen=0 dataColumnSidecars=${dataColumnSidecars.length}>0`
         );
@@ -338,6 +340,7 @@ export function matchBlockWithDataColumns(
             peerClient,
           }
         );
+        network.reportPeer(peerId, PeerAction.LowToleranceError, "Missing or mismatching dataColumnSidecars");
         throw Error(
           `Missing or mismatching dataColumnSidecars from peerId=${peerId} for blockSlot=${block.data.message.slot} blobKzgCommitmentsLen=${blobKzgCommitmentsLen} with numColumns=${sampledColumns.length} dataColumnSidecars=${dataColumnSidecars.length} requestedColumnsPresent=${requestedColumnsPresent} received dataColumnIndexes=${dataColumnIndexes.join(" ")} requested=${requestedColumns.join(" ")}`
         );
@@ -398,8 +401,9 @@ export function matchBlockWithDataColumns(
     // If there are no data columns, the data columns request can give 1 block outside the requested range
     allDataColumnSidecars[dataColumnSideCarIndex].signedBlockHeader.message.slot <= endSlot
   ) {
+    network.reportPeer(peerId, PeerAction.LowToleranceError, "Unmatched dataColumnSidecars");
     throw Error(
-      `Unmatched blobSidecars, blocks=${allBlocks.length}, blobs=${
+      `Unmatched dataColumnSidecars, blocks=${allBlocks.length}, blobs=${
         allDataColumnSidecars.length
       } lastMatchedSlot=${lastMatchedSlot}, pending blobSidecars slots=${allDataColumnSidecars
         .slice(dataColumnSideCarIndex)


### PR DESCRIPTION
**Motivation**

- some peers consistently sent mismatched DataColumnSidecars, we should gradually reduce peer score and eventually disconnect it

**Description**

- reduce peer score by using `network.reportPeer()` api

Closes #8133