### PR TITLE
fix: skip custody groups computation if all groups are custodied

### DIFF
--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -192,7 +192,12 @@ export function computeColumnsForCustodyGroup(custodyIndex: CustodyIndex): Colum
  */
 export function getCustodyGroups(nodeId: NodeId, custodyGroupCount: number): CustodyIndex[] {
   if (custodyGroupCount > NUMBER_OF_CUSTODY_GROUPS) {
-    custodyGroupCount = NUMBER_OF_CUSTODY_GROUPS;
+    throw Error(`Invalid custody group count ${custodyGroupCount} > ${NUMBER_OF_CUSTODY_GROUPS}`);
+  }
+
+  // Skip computation if all groups are custodied
+  if (custodyGroupCount === NUMBER_OF_CUSTODY_GROUPS) {
+    return Array.from({length: NUMBER_OF_CUSTODY_GROUPS}, (_, i) => i);
   }
 
   const custodyGroups: CustodyIndex[] = [];


### PR DESCRIPTION
**Motivation**

Slight optimization from https://github.com/ethereum/consensus-specs/pull/4459 to skip custody groups computation if we custody all groups.

**Description**

- throw error (instead of hidding a bug) if `custodyGroupCount > NUMBER_OF_CUSTODY_GROUPS`
- skip computation if all groups are custodied