### PR TITLE
fix: misleading comment in MAX_BATCH_PROCESSING_ATTEMPTS

### DIFF
--- a/packages/beacon-node/src/sync/constants.ts
+++ b/packages/beacon-node/src/sync/constants.ts
@@ -12,7 +12,7 @@ export const MAX_BATCH_DOWNLOAD_ATTEMPTS = 20;
 
 /**
  * Consider batch faulty after downloading and processing this number of times
- * as in https://github.com/ChainSafe/lodestar/issues/8147 we cannot proceed the sync chain if a peer return 0 blocks without error
+ * for example a peer may send us a non-canonical chain segment or not returning all blocks
  * in that case we should throw error and `RangeSync` should remove that error chain and add a new one.
  **/
 export const MAX_BATCH_PROCESSING_ATTEMPTS = 0;


### PR DESCRIPTION
**Motivation**

- fix comment of MAX_BATCH_PROCESSING_ATTEMPTS to avoid the misunderstanding of the issue

**Description**

- when peer returning 0 blocks we already throw error and retry with another peer, see https://github.com/ChainSafe/lodestar/pull/8150/files#r2268384293

Closes #8176

cc @wemeetagain @matthewkeil 