### PR TITLE
fix: only subscribe to sampled subnets

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -278,7 +278,25 @@ export function getBeaconBlockApi({
             throw e;
           }),
     ];
-    await promiseAllMaybeAsync<number | void>(publishPromises);
+    const sentPeersArr = await promiseAllMaybeAsync<number | void>(publishPromises);
+
+    if (isForkPostFulu(fork)) {
+      // sent peers per topic are logged in network.publishGossip(), here we only track metrics for it
+      // starting from fulu, we have to push to 128 subnets so need to make sure we have enough sent peers per topic
+      // + 1 because we publish to beacon_block first
+      if (sentPeersArr.length < dataColumnSidecars.length + 1) {
+        // should not happen
+        throw Error(
+          `Not enough sent peers per data column subnet, sentPeersArr.length=${sentPeersArr.length}, expected at least ${dataColumnSidecars.length + 1}`
+        );
+      }
+
+      for (let i = 0; i < dataColumnSidecars.length; i++) {
+        // + 1 because we publish to beacon_block first
+        const sentPeers = sentPeersArr[i + 1] as number;
+        metrics?.dataColumns.sentPeersPerSubnet.observe(sentPeers);
+      }
+    }
 
     if (chain.emitter.listenerCount(routes.events.EventType.blockGossip)) {
       chain.emitter.emit(routes.events.EventType.blockGossip, {slot, block: blockRoot});

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -287,6 +287,7 @@ export function getBeaconBlockApi({
       for (let i = 0; i < dataColumnSidecars.length; i++) {
         // + 1 because we publish to beacon_block first
         const sentPeers = sentPeersArr[i + 1] as number;
+        // sent peers could be 0 as we set `allowPublishToZeroTopicPeers=true` in network.publishDataColumnSidecar() api
         metrics?.dataColumns.sentPeersPerSubnet.observe(sentPeers);
       }
     }

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -284,13 +284,6 @@ export function getBeaconBlockApi({
       // sent peers per topic are logged in network.publishGossip(), here we only track metrics for it
       // starting from fulu, we have to push to 128 subnets so need to make sure we have enough sent peers per topic
       // + 1 because we publish to beacon_block first
-      if (sentPeersArr.length < dataColumnSidecars.length + 1) {
-        // should not happen
-        throw Error(
-          `Not enough sent peers per data column subnet, sentPeersArr.length=${sentPeersArr.length}, expected at least ${dataColumnSidecars.length + 1}`
-        );
-      }
-
       for (let i = 0; i < dataColumnSidecars.length; i++) {
         // + 1 because we publish to beacon_block first
         const sentPeers = sentPeersArr[i + 1] as number;

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -756,6 +756,12 @@ export function createLodestarMetrics(
         labelNames: ["source"],
         buckets: [1, 2, 3, 4, 6, 12],
       }),
+      sentPeersPerSubnet: register.histogram({
+        name: "lodestar_data_column_sent_peers_per_subnet",
+        help: "Number of peers node sent per subnet when publishing DataColumnSidecars",
+        // given TARGET_GROUP_PEERS_PER_SUBNET = 4, we expect sending to 4 peers per subnet
+        buckets: [1, 2, 3, 4],
+      }),
     },
     importBlock: {
       persistBlockNoSerializedDataCount: register.gauge({

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -18,6 +18,7 @@ import {Discv5Worker} from "../discv5/index.js";
 import {NetworkEventBus} from "../events.js";
 import {FORK_EPOCH_LOOKAHEAD, getActiveForkBoundaries} from "../forks.js";
 import {Eth2Gossipsub, getCoreTopicsAtFork} from "../gossip/index.js";
+import {getDataColumnSidecarTopics} from "../gossip/topic.js";
 import {Libp2p} from "../interface.js";
 import {createNodeJsLibp2p} from "../libp2p/index.js";
 import {MetadataController} from "../metadata.js";
@@ -369,9 +370,24 @@ export class NetworkCore implements INetworkCore {
     return recipients.length;
   }
 
+  /**
+   * Handler of ChainEvent.updateTargetCustodyGroupCount event
+   * Updates the target custody group count in the network config and metadata.
+   * Also subscribes to new data_column_sidecar subnet topics for the new custody group count.
+   */
   async setTargetGroupCount(count: number): Promise<void> {
     this.networkConfig.custodyConfig.updateTargetCustodyGroupCount(count);
     this.metadata.custodyGroupCount = count;
+    // cannot call subscribeGossipCoreTopics() because we subsribed to core topics already
+    // we only need to subscribe to more data_column_sidecar topics
+    const dataColumnSubnetTopics = getDataColumnSidecarTopics(this.networkConfig);
+    const activeBoundaries = getActiveForkBoundaries(this.config, this.clock.currentEpoch);
+    for (const boundary of activeBoundaries) {
+      for (const topic of dataColumnSubnetTopics) {
+        // there are existing subscriptions for old subnets, in that case gossipsub will just ignore
+        this.gossip.subscribeTopic({...topic, boundary});
+      }
+    }
   }
 
   // REST API queries

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -186,7 +186,7 @@ export class NetworkCore implements INetworkCore {
     );
 
     const gossip = new Eth2Gossipsub(opts, {
-      config,
+      networkConfig,
       libp2p,
       logger,
       metricsRegister: metricsRegistry,
@@ -342,7 +342,7 @@ export class NetworkCore implements INetworkCore {
     }
 
     for (const boundary of getActiveForkBoundaries(this.config, this.clock.currentEpoch)) {
-      this.subscribeCoreTopicsAtBoundary(this.config, boundary);
+      this.subscribeCoreTopicsAtBoundary(this.networkConfig, boundary);
     }
   }
 
@@ -351,7 +351,7 @@ export class NetworkCore implements INetworkCore {
    */
   async unsubscribeGossipCoreTopics(): Promise<void> {
     for (const boundary of this.forkBoundariesByEpoch.values()) {
-      this.unsubscribeCoreTopicsAtBoundary(this.config, boundary);
+      this.unsubscribeCoreTopicsAtBoundary(this.networkConfig, boundary);
     }
   }
 
@@ -508,7 +508,7 @@ export class NetworkCore implements INetworkCore {
           if (epoch === nextBoundaryEpoch - FORK_EPOCH_LOOKAHEAD) {
             // Don't subscribe to new fork boundary if the node is not subscribed to any topic
             if (await this.isSubscribedToGossipCoreTopics()) {
-              this.subscribeCoreTopicsAtBoundary(this.config, nextBoundary);
+              this.subscribeCoreTopicsAtBoundary(this.networkConfig, nextBoundary);
               this.logger.info("Subscribing gossip topics for next fork boundary", nextBoundary);
             } else {
               this.logger.info("Skipping subscribing gossip topics for next fork boundary", nextBoundary);
@@ -527,7 +527,7 @@ export class NetworkCore implements INetworkCore {
           // After fork boundary transition
           if (epoch === nextBoundaryEpoch + FORK_EPOCH_LOOKAHEAD) {
             this.logger.info("Unsubscribing gossip topics of previous fork boundary", prevBoundary);
-            this.unsubscribeCoreTopicsAtBoundary(this.config, prevBoundary);
+            this.unsubscribeCoreTopicsAtBoundary(this.networkConfig, prevBoundary);
             this.attnetsService.unsubscribeSubnetsPrevBoundary(prevBoundary);
             this.syncnetsService.unsubscribeSubnetsPrevBoundary(prevBoundary);
           }
@@ -538,12 +538,12 @@ export class NetworkCore implements INetworkCore {
     }
   };
 
-  private subscribeCoreTopicsAtBoundary(config: BeaconConfig, boundary: ForkBoundary): void {
+  private subscribeCoreTopicsAtBoundary(networkConfig: NetworkConfig, boundary: ForkBoundary): void {
     if (this.forkBoundariesByEpoch.has(boundary.epoch)) return;
     this.forkBoundariesByEpoch.set(boundary.epoch, boundary);
     const {subscribeAllSubnets, disableLightClientServer} = this.opts;
 
-    for (const topic of getCoreTopicsAtFork(config, boundary.fork, {
+    for (const topic of getCoreTopicsAtFork(networkConfig, boundary.fork, {
       subscribeAllSubnets,
       disableLightClientServer,
     })) {
@@ -551,12 +551,12 @@ export class NetworkCore implements INetworkCore {
     }
   }
 
-  private unsubscribeCoreTopicsAtBoundary(config: BeaconConfig, boundary: ForkBoundary): void {
+  private unsubscribeCoreTopicsAtBoundary(networkConfig: NetworkConfig, boundary: ForkBoundary): void {
     if (!this.forkBoundariesByEpoch.has(boundary.epoch)) return;
     this.forkBoundariesByEpoch.delete(boundary.epoch);
     const {subscribeAllSubnets, disableLightClientServer} = this.opts;
 
-    for (const topic of getCoreTopicsAtFork(config, boundary.fork, {
+    for (const topic of getCoreTopicsAtFork(networkConfig, boundary.fork, {
       subscribeAllSubnets,
       disableLightClientServer,
     })) {

--- a/packages/beacon-node/src/network/gossip/scoringParameters.ts
+++ b/packages/beacon-node/src/network/gossip/scoringParameters.ts
@@ -8,7 +8,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {ATTESTATION_SUBNET_COUNT, SLOTS_PER_EPOCH, TARGET_AGGREGATORS_PER_COMMITTEE} from "@lodestar/params";
 import {computeCommitteeCount} from "@lodestar/state-transition";
 import {getActiveForkBoundaries} from "../forks.js";
-import {Eth2Context, Eth2GossipsubModules} from "./gossipsub.js";
+import {Eth2Context} from "./gossipsub.js";
 import {GossipType} from "./interface.js";
 import {stringifyGossipTopic} from "./topic.js";
 
@@ -80,7 +80,7 @@ type TopicScoreInput = {
 export function computeGossipPeerScoreParams({
   config,
   eth2Context,
-}: Pick<Eth2GossipsubModules, "config" | "eth2Context">): Partial<PeerScoreParams> {
+}: {config: BeaconConfig; eth2Context: Eth2Context}): Partial<PeerScoreParams> {
   const decayIntervalMs = config.SECONDS_PER_SLOT * 1000;
   const decayToZero = 0.01;
   const epochDurationMs = config.SECONDS_PER_SLOT * SLOTS_PER_EPOCH * 1000;

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -243,7 +243,6 @@ export function getCoreTopicsAtFork(
 
   // After fulu also track data_column_sidecar_{index}
   if (ForkSeq[fork] >= ForkSeq.fulu) {
-    // TODO: @matthewkeil check if this needs to be updated for custody groups
     const subnets = networkConfig.custodyConfig.sampledSubnets;
     for (const subnet of subnets) {
       topics.push({type: GossipType.data_column_sidecar, subnet});

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -1,7 +1,6 @@
-import {ChainConfig, ForkDigestContext} from "@lodestar/config";
+import {ForkDigestContext} from "@lodestar/config";
 import {
   ATTESTATION_SUBNET_COUNT,
-  DATA_COLUMN_SIDECAR_SUBNET_COUNT,
   ForkName,
   ForkSeq,
   SYNC_COMMITTEE_SUBNET_COUNT,
@@ -11,6 +10,7 @@ import {
 import {Attestation, SingleAttestation, ssz, sszTypesFor} from "@lodestar/types";
 
 import {GossipAction, GossipActionError, GossipErrorCode} from "../../chain/errors/gossipValidation.js";
+import {NetworkConfig} from "../networkConfig.js";
 import {DEFAULT_ENCODING} from "./constants.js";
 import {GossipEncoding, GossipTopic, GossipTopicTypeMap, GossipType, SSZTypeOfGossipTopic} from "./interface.js";
 
@@ -228,7 +228,7 @@ export function parseGossipTopic(forkDigestContext: ForkDigestContext, topicStr:
  * De-duplicate logic to pick fork topics between subscribeCoreTopicsAtFork and unsubscribeCoreTopicsAtFork
  */
 export function getCoreTopicsAtFork(
-  config: ChainConfig,
+  networkConfig: NetworkConfig,
   fork: ForkName,
   opts: {subscribeAllSubnets?: boolean; disableLightClientServer?: boolean}
 ): GossipTopicTypeMap[keyof GossipTopicTypeMap][] {
@@ -244,13 +244,15 @@ export function getCoreTopicsAtFork(
   // After fulu also track data_column_sidecar_{index}
   if (ForkSeq[fork] >= ForkSeq.fulu) {
     // TODO: @matthewkeil check if this needs to be updated for custody groups
-    for (let subnet = 0; subnet < DATA_COLUMN_SIDECAR_SUBNET_COUNT; subnet++) {
+    const subnets = networkConfig.custodyConfig.sampledSubnets;
+    for (const subnet of subnets) {
       topics.push({type: GossipType.data_column_sidecar, subnet});
     }
   }
 
   // After Deneb also track blob_sidecar_{subnet_id}
   if (ForkSeq[fork] >= ForkSeq.deneb) {
+    const {config} = networkConfig;
     const subnetCount = isForkPostElectra(fork)
       ? config.BLOB_SIDECAR_SUBNET_COUNT_ELECTRA
       : config.BLOB_SIDECAR_SUBNET_COUNT;

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -243,10 +243,7 @@ export function getCoreTopicsAtFork(
 
   // After fulu also track data_column_sidecar_{index}
   if (ForkSeq[fork] >= ForkSeq.fulu) {
-    const subnets = networkConfig.custodyConfig.sampledSubnets;
-    for (const subnet of subnets) {
-      topics.push({type: GossipType.data_column_sidecar, subnet});
-    }
+    topics.push(...getDataColumnSidecarTopics(networkConfig));
   }
 
   // After Deneb also track blob_sidecar_{subnet_id}
@@ -284,6 +281,22 @@ export function getCoreTopicsAtFork(
         topics.push({type: GossipType.sync_committee, subnet});
       }
     }
+  }
+
+  return topics;
+}
+
+/**
+ * Pick data column subnets to subscribe to post-fulu.
+ */
+export function getDataColumnSidecarTopics(
+  networkConfig: NetworkConfig
+): GossipTopicTypeMap[keyof GossipTopicTypeMap][] {
+  const topics: GossipTopicTypeMap[keyof GossipTopicTypeMap][] = [];
+
+  const subnets = networkConfig.custodyConfig.sampledSubnets;
+  for (const subnet of subnets) {
+    topics.push({type: GossipType.data_column_sidecar, subnet});
   }
 
   return topics;

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -362,6 +362,11 @@ export class Network implements INetwork {
       dataColumnSidecar,
       {
         ignoreDuplicatePublishError: true,
+        // we ensure having all topic peers via prioritizePeers() function
+        // in the worse case, if there is 0 peer on the topic, the overall publish operation could be still a success
+        // because supernode will rebuild and publish missing data column sidecars for us
+        // hence we want to track sent peers as 0 instead of an error
+        allowPublishToZeroTopicPeers: true,
       }
     );
   }


### PR DESCRIPTION
**Motivation**

- right now we always subscribe to all column subnets which is not necessary because we only need columns that we custody/sample
- that's why I see 128 logs like this per slot, and this could degrade performance. We only need 8 per slot

```
 debug: Received gossip dataColumn slot=198378, root=0x9945…49af, curentSlot=198378, peerId=16Uiu2HAm2J4ZRFnf7qWvu8VBRFT66E5XFWnRTwYTahB2oRJom5ji, delaySec=1.5910000801086426, gossipIndex=113, columnIndex=113, pending=data_column, haveColumns=31, expectedColumns=8, recvToValLatency=0.0009999275207519531, recvToValidation=0.0009999275207519531, validationTime=0
```

**Description**

- only subscribe to custody/sampling subnets
- track sent peers per data column subnet when publishing blocks

**Test result**
- tested successfully on a devnet node

- Resolves https://github.com/ChainSafe/lodestar/issues/8098