### PR TITLE
feat: self rate limiter

### DIFF
--- a/packages/reqresp/src/ReqResp.ts
+++ b/packages/reqresp/src/ReqResp.ts
@@ -1,6 +1,6 @@
 import {setMaxListeners} from "node:events";
 import {Connection, PeerId, Stream} from "@libp2p/interface";
-import {Logger, MetricsRegister} from "@lodestar/utils";
+import {Logger, MetricsRegisterExtra} from "@lodestar/utils";
 import type {Libp2p} from "libp2p";
 import {Metrics, getMetrics} from "./metrics.js";
 import {ReqRespRateLimiter} from "./rate_limiter/ReqRespRateLimiter.js";
@@ -25,7 +25,7 @@ export const DEFAULT_PROTOCOL_PREFIX = "/eth2/beacon_chain/req";
 export interface ReqRespProtocolModules {
   libp2p: Libp2p;
   logger: Logger;
-  metricsRegister: MetricsRegister | null;
+  metricsRegister: MetricsRegisterExtra | null;
 }
 
 export interface ReqRespOpts extends SendRequestOpts, ReqRespRateLimiterOpts {
@@ -71,9 +71,9 @@ export class ReqResp {
     this.rateLimiter = new ReqRespRateLimiter(opts);
     this.selfRateLimiter = new SelfRateLimiter();
 
-    if (this.metrics) {
-      this.metrics.selfRateLimiterPeerCount.set(this.selfRateLimiter.getPeerCount());
-    }
+    this.metrics?.selfRateLimiterPeerCount.addCollect(() => {
+      this.metrics?.selfRateLimiterPeerCount.set(this.selfRateLimiter.getPeerCount());
+    });
   }
 
   /**

--- a/packages/reqresp/src/ReqResp.ts
+++ b/packages/reqresp/src/ReqResp.ts
@@ -175,7 +175,7 @@ export class ReqResp {
       if (!this.selfRateLimiter.allows(peerIdStr, protocolID)) {
         // we technically don't send request in this case but would be nice just to track this in the same `outgoingErrorReasons` metric
         this.metrics?.outgoingErrorReasons.inc({reason: RequestErrorCode.REQUEST_RATE_LIMITED});
-        throw new RequestError({code: RequestErrorCode.REQUEST_RATE_LIMITED});
+        throw new RequestError({code: RequestErrorCode.REQUEST_SELF_RATE_LIMITED});
         // don't call this.onOutgoingRequestError() to penalize peer
       }
 

--- a/packages/reqresp/src/ReqResp.ts
+++ b/packages/reqresp/src/ReqResp.ts
@@ -4,6 +4,7 @@ import {Logger, MetricsRegister} from "@lodestar/utils";
 import type {Libp2p} from "libp2p";
 import {Metrics, getMetrics} from "./metrics.js";
 import {ReqRespRateLimiter} from "./rate_limiter/ReqRespRateLimiter.js";
+import {SelfRateLimiter} from "./rate_limiter/selfRateLimiter.js";
 import {RequestError, RequestErrorCode, SendRequestOpts, sendRequest} from "./request/index.js";
 import {handleRequest} from "./response/index.js";
 import {
@@ -45,8 +46,11 @@ export class ReqResp {
   protected readonly logger: Logger;
   protected readonly metrics: Metrics | null;
 
-  // to not be used by extending class
+  // rate limit requests coming to this node to not be used by extending class
   private readonly rateLimiter: ReqRespRateLimiter;
+  // rate limit requests sending to other peers
+  private readonly selfRateLimiter: SelfRateLimiter;
+
   private controller = new AbortController();
   /** Tracks request and responses in a sequential counter */
   private reqCount = 0;
@@ -65,6 +69,11 @@ export class ReqResp {
     this.metrics = modules.metricsRegister ? getMetrics(modules.metricsRegister) : null;
     this.protocolPrefix = opts.protocolPrefix ?? DEFAULT_PROTOCOL_PREFIX;
     this.rateLimiter = new ReqRespRateLimiter(opts);
+    this.selfRateLimiter = new SelfRateLimiter();
+
+    if (this.metrics) {
+      this.metrics.selfRateLimiterPeerCount.set(this.selfRateLimiter.getPeerCount());
+    }
   }
 
   /**
@@ -128,6 +137,7 @@ export class ReqResp {
   async start(): Promise<void> {
     this.controller = new AbortController();
     this.rateLimiter.start();
+    this.selfRateLimiter.start();
     // We set infinity to prevent MaxListenersExceededWarning which get logged when listeners > 10
     // Since it is perfectly fine to have listeners > 10
     setMaxListeners(Infinity, this.controller.signal);
@@ -135,6 +145,7 @@ export class ReqResp {
 
   async stop(): Promise<void> {
     this.rateLimiter.stop();
+    this.selfRateLimiter.stop();
     this.controller.abort();
   }
 
@@ -146,7 +157,8 @@ export class ReqResp {
     encoding: Encoding,
     body: Uint8Array
   ): AsyncIterable<ResponseIncoming> {
-    const peerClient = this.opts.getPeerLogMetadata?.(peerId.toString());
+    const peerIdStr = peerId.toString();
+    const peerClient = this.opts.getPeerLogMetadata?.(peerIdStr);
     this.metrics?.outgoingRequests.inc({method});
     const timer = this.metrics?.outgoingRequestRoundtripTime.startTimer({method});
 
@@ -159,6 +171,14 @@ export class ReqResp {
       if (!protocol) {
         throw Error(`Request to send to protocol ${protocolID} but it has not been declared`);
       }
+
+      if (!this.selfRateLimiter.allows(peerIdStr, protocolID)) {
+        // we technically don't send request in this case but would be nice just to track this in the same `outgoingErrorReasons` metric
+        this.metrics?.outgoingErrorReasons.inc({reason: RequestErrorCode.REQUEST_RATE_LIMITED});
+        throw new RequestError({code: RequestErrorCode.REQUEST_RATE_LIMITED});
+        // don't call this.onOutgoingRequestError() to penalize peer
+      }
+
       protocols.push(protocol);
       protocolIDs.push(protocolID);
     }
@@ -188,6 +208,9 @@ export class ReqResp {
 
       throw e;
     } finally {
+      for (const protocolID of protocolIDs) {
+        this.selfRateLimiter.requestCompleted(peerIdStr, protocolID);
+      }
       timer?.();
     }
   }

--- a/packages/reqresp/src/metrics.ts
+++ b/packages/reqresp/src/metrics.ts
@@ -67,5 +67,9 @@ export function getMetrics(register: MetricsRegister) {
       name: "beacon_reqresp_dial_errors_total",
       help: "Count total dial errors",
     }),
+    selfRateLimiterPeerCount: register.gauge({
+      name: "beacon_reqresp_self_rate_limiter_peer_count",
+      help: "Count of peers tracked by the self rate limiter",
+    }),
   };
 }

--- a/packages/reqresp/src/metrics.ts
+++ b/packages/reqresp/src/metrics.ts
@@ -1,4 +1,4 @@
-import {MetricsRegister} from "@lodestar/utils";
+import {MetricsRegisterExtra} from "@lodestar/utils";
 import {RequestErrorCode} from "./request/errors.js";
 
 export type Metrics = ReturnType<typeof getMetrics>;
@@ -6,7 +6,7 @@ export type Metrics = ReturnType<typeof getMetrics>;
 /**
  * A collection of metrics used throughout the Gossipsub behaviour.
  */
-export function getMetrics(register: MetricsRegister) {
+export function getMetrics(register: MetricsRegisterExtra) {
   // Using function style instead of class to prevent having to re-declare all MetricsPrometheus types.
 
   return {

--- a/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
+++ b/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
@@ -5,11 +5,11 @@ type ProtocolID = string;
 /** https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md#constants */
 const MAX_CONCURRENT_REQUESTS = 2;
 
-/** Sometimes a peer request comes AFTER libp2p disconnect event, check for such peers every 10 minutes */
-export const CHECK_DISCONNECTED_PEERS_INTERVAL_MS = 10 * 60 * 1000;
+/** Sometimes a peer request comes AFTER libp2p disconnect event, check for such peers every 2 minutes */
+export const CHECK_DISCONNECTED_PEERS_INTERVAL_MS = 2 * 60 * 1000;
 
-/** Peers don't request us for 5 mins are considered disconnected */
-const DISCONNECTED_TIMEOUT_MS = 5 * 60 * 1000;
+/** Given PING_INTERVAL constants of 15s/20s, we consider a peer is disconnected if there is no request in 1 minute */
+const DISCONNECTED_TIMEOUT_MS = 60 * 1000;
 
 /**
  * Simple rate limiter that allows a maximum of 2 concurrent requests per protocol per peer.

--- a/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
+++ b/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
@@ -77,6 +77,7 @@ export class SelfRateLimiter {
     for (const [peerIdStr, lastSeenTime] of this.lastSeenRequestsByPeer.entries()) {
       if (now - lastSeenTime >= DISCONNECTED_TIMEOUT_MS) {
         this.rateLimitersPerPeer.delete(peerIdStr);
+        this.lastSeenRequestsByPeer.delete(peerIdStr);
       }
     }
   }

--- a/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
+++ b/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
@@ -1,0 +1,83 @@
+import {MapDef} from "@lodestar/utils";
+
+type PeerIdStr = string;
+type ProtocolID = string;
+/** https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md#constants */
+const MAX_CONCURRENT_REQUESTS = 2;
+
+/** Sometimes a peer request comes AFTER libp2p disconnect event, check for such peers every 10 minutes */
+export const CHECK_DISCONNECTED_PEERS_INTERVAL_MS = 10 * 60 * 1000;
+
+/** Peers don't request us for 5 mins are considered disconnected */
+const DISCONNECTED_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Simple rate limiter that allows a maximum of 2 concurrent requests per protocol per peer.
+ * The consumer should either prevent requests from being sent when the limit is reached or handle the case when the request is not allowed.
+ */
+export class SelfRateLimiter {
+  private readonly rateLimitersPerPeer: MapDef<PeerIdStr, MapDef<ProtocolID, number>>;
+  /**
+   * It's not convenient to handle a peer disconnected event so we track the last seen requests by peer.
+   * This is the same design to `ReqRespRateLimiter`.
+   **/
+  private lastSeenRequestsByPeer: Map<string, number>;
+  /** Interval to check lastSeenMessagesByPeer */
+  private cleanupInterval: NodeJS.Timeout | undefined = undefined;
+
+  constructor() {
+    this.rateLimitersPerPeer = new MapDef<PeerIdStr, MapDef<ProtocolID, number>>(
+      () => new MapDef<ProtocolID, number>(() => 0)
+    );
+    this.lastSeenRequestsByPeer = new Map();
+  }
+
+  start(): void {
+    this.cleanupInterval = setInterval(this.checkDisconnectedPeers.bind(this), CHECK_DISCONNECTED_PEERS_INTERVAL_MS);
+  }
+
+  stop(): void {
+    if (this.cleanupInterval !== undefined) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = undefined;
+    }
+  }
+
+  /**
+   * called before we send a request to a peer.
+   */
+  allows(peerId: PeerIdStr, protocolId: ProtocolID): boolean {
+    const peerRateLimiter = this.rateLimitersPerPeer.getOrDefault(peerId);
+    const inProgressRequests = peerRateLimiter.getOrDefault(protocolId);
+    this.lastSeenRequestsByPeer.set(peerId, Date.now());
+    if (inProgressRequests >= MAX_CONCURRENT_REQUESTS) {
+      return false;
+    }
+
+    peerRateLimiter.set(protocolId, inProgressRequests + 1);
+    return true;
+  }
+
+  /**
+   * called when a request to a peer is completed, regardless of success or failure.
+   * This should NOT be called when the request was not allowed
+   */
+  requestCompleted(peerId: PeerIdStr, protocolId: ProtocolID): void {
+    const peerRateLimiter = this.rateLimitersPerPeer.getOrDefault(peerId);
+    const inProgressRequests = peerRateLimiter.getOrDefault(protocolId);
+    peerRateLimiter.set(protocolId, Math.max(0, inProgressRequests - 1));
+  }
+
+  getPeerCount(): number {
+    return this.rateLimitersPerPeer.size;
+  }
+
+  private checkDisconnectedPeers(): void {
+    const now = Date.now();
+    for (const [peerIdStr, lastSeenTime] of this.lastSeenRequestsByPeer.entries()) {
+      if (now - lastSeenTime >= DISCONNECTED_TIMEOUT_MS) {
+        this.rateLimitersPerPeer.delete(peerIdStr);
+      }
+    }
+  }
+}

--- a/packages/reqresp/src/request/errors.ts
+++ b/packages/reqresp/src/request/errors.ts
@@ -31,6 +31,8 @@ export enum RequestErrorCode {
   RESP_TIMEOUT = "REQUEST_ERROR_RESP_TIMEOUT",
   /** Request rate limited */
   REQUEST_RATE_LIMITED = "REQUEST_ERROR_RATE_LIMITED",
+  /** Request self rate limited */
+  REQUEST_SELF_RATE_LIMITED = "REQUEST_ERROR_SELF_RATE_LIMITED",
   /** Response rate limited */
   RESP_RATE_LIMITED = "RESPONSE_ERROR_RATE_LIMITED",
   /** For malformed SSZ (metadata) responses */
@@ -51,6 +53,7 @@ type RequestErrorType =
   | {code: RequestErrorCode.TTFB_TIMEOUT}
   | {code: RequestErrorCode.RESP_TIMEOUT}
   | {code: RequestErrorCode.REQUEST_RATE_LIMITED}
+  | {code: RequestErrorCode.REQUEST_SELF_RATE_LIMITED}
   | {code: RequestErrorCode.RESP_RATE_LIMITED}
   | {code: RequestErrorCode.SSZ_OVER_MAX_SIZE};
 

--- a/packages/reqresp/test/unit/rate_limiter/selfRateLimiter.test.ts
+++ b/packages/reqresp/test/unit/rate_limiter/selfRateLimiter.test.ts
@@ -1,0 +1,45 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {CHECK_DISCONNECTED_PEERS_INTERVAL_MS, SelfRateLimiter} from "../../../src/rate_limiter/selfRateLimiter.js";
+
+describe("SelfRateLimiter", () => {
+  let selfRateLimiter: SelfRateLimiter;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    selfRateLimiter = new SelfRateLimiter();
+    selfRateLimiter.start();
+  });
+
+  afterEach(() => {
+    selfRateLimiter.stop();
+    vi.useRealTimers();
+  });
+
+  it("allows requests under the limit", () => {
+    expect(selfRateLimiter.allows("peer1", "protocol1")).toBe(true);
+    expect(selfRateLimiter.allows("peer1", "protocol1")).toBe(true);
+  });
+
+  it("blocks requests over the limit", () => {
+    selfRateLimiter.allows("peer1", "protocol1");
+    selfRateLimiter.allows("peer1", "protocol1");
+    expect(selfRateLimiter.allows("peer1", "protocol1")).toBe(false);
+    // but allows a different protocol
+    expect(selfRateLimiter.allows("peer1", "protocol2")).toBe(true);
+    // allows a different peer
+    expect(selfRateLimiter.allows("peer2", "protocol1")).toBe(true);
+
+    // allow after request completed
+    selfRateLimiter.requestCompleted("peer1", "protocol1");
+    expect(selfRateLimiter.allows("peer1", "protocol1")).toBe(true);
+  });
+
+  it("should remove disconnected peers after interval", () => {
+    selfRateLimiter.allows("peer1", "protocol1");
+    selfRateLimiter.allows("peer1", "protocol1");
+    expect(selfRateLimiter.allows("peer1", "protocol1")).toBe(false);
+
+    vi.advanceTimersByTime(CHECK_DISCONNECTED_PEERS_INTERVAL_MS + 1);
+    expect(selfRateLimiter.allows("peer1", "protocol1")).toBe(true);
+  });
+});


### PR DESCRIPTION
**Motivation**

- per spec, we should not issue more than 2 requests per protocol per peer https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/p2p-interface.md#constants
- we should be able to self detect that and see `REQUEST_ERROR_RATE_LIMITED` instead of sending requests to peer and get `RESPONSE_ERROR_RATE_LIMITED`

**Description**

- Implement SelfRateLimiter
  - before sending out a request, call `selfRateLimiter.allows()`
  - after finishing a request, call `selfRateLimiter.requestCompleted()`
  - check for disconnected peers automatically, similar to `RateLimiterGRCA`
- RangeSync already manage active requests and prevent that from happening, see #8166
- UnknownBlockSync needs to implement the same thing, tracked in #8182

part of #8033
