### PR TITLE
test: disable DEBUG logs by default when running sim tests

### DIFF
--- a/packages/cli/test/utils/crucible/clients/beacon/lodestar.ts
+++ b/packages/cli/test/utils/crucible/clients/beacon/lodestar.ts
@@ -87,7 +87,7 @@ export const generateLodestarBeaconNode: BeaconNodeGenerator<BeaconClient.Lodest
         command: LODESTAR_BINARY_PATH,
         args: ["beacon", "--rcConfig", rcConfigPath, "--paramsFile", paramsPath],
         env: {
-          DEBUG: process.env.DISABLE_DEBUG_LOGS ? "" : "*,-winston:*",
+          DEBUG: process.env.ENABLE_DEBUG_LOGS ? "*,-winston:*" : "",
         },
       },
       logs: {

--- a/packages/cli/test/utils/crucible/clients/validator/lodestar.ts
+++ b/packages/cli/test/utils/crucible/clients/validator/lodestar.ts
@@ -60,7 +60,7 @@ export const generateLodestarValidatorNode: ValidatorNodeGenerator<ValidatorClie
           path.join(rootDir, "params.json"),
         ],
         env: {
-          DEBUG: process.env.DISABLE_DEBUG_LOGS ? "" : "*,-winston:*",
+          DEBUG: process.env.ENABLE_DEBUG_LOGS ? "*,-winston:*" : "",
         },
       },
       logs: {


### PR DESCRIPTION
**Motivation**

Sim test debug logs are way too verbose by default. We don't run mainnet nodes with `DEBUG` set unless we wanna investigate a specific issue, should take the same approach in sim tests.

**Description**

Disable `DEBUG` logs by default when running sim tests