### PR TITLE
chore: update the logs during identify

### DIFF
--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -728,6 +728,14 @@ export class PeerManager {
       void this.requestStatus(remotePeer, this.statusCache.get());
     }
 
+    if (evt.detail.status !== "open") {
+      this.logger.debug("Peer disconnected before identification", {
+        peerId: peerData.peerId.toString(),
+        status: evt.detail.status,
+      });
+      return;
+    }
+
     this.libp2p.services.identify
       .identify(evt.detail)
       .then((result) => {

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -694,7 +694,9 @@ export class PeerManager {
    */
   private onLibp2pPeerConnect = async (evt: CustomEvent<Connection>): Promise<void> => {
     const {direction, status, remotePeer} = evt.detail;
-    this.logger.verbose("peer connected", {peer: prettyPrintPeerId(remotePeer), direction, status});
+    const remotePeerStr = remotePeer.toString();
+    const remotePeerPrettyStr = prettyPrintPeerId(remotePeer);
+    this.logger.verbose("peer connected", {peer: remotePeerPrettyStr, direction, status});
     // NOTE: The peerConnect event is not emitted here here, but after asserting peer relevance
     this.metrics?.peerConnectedEvent.inc({direction, status});
 
@@ -720,11 +722,11 @@ export class PeerManager {
       agentClient: null,
       encodingPreference: null,
     };
-    this.connectedPeers.set(remotePeer.toString(), peerData);
+    this.connectedPeers.set(remotePeerStr, peerData);
 
     if (evt.detail.status !== "open") {
       this.logger.debug("Peer disconnected before identification", {
-        peerId: peerData.peerId.toString(),
+        peerId: remotePeerPrettyStr,
         status: evt.detail.status,
       });
       return;
@@ -747,9 +749,9 @@ export class PeerManager {
       })
       .catch((err) => {
         if (evt.detail.status !== "open") {
-          this.logger.debug("Peer disconnected during the identification", {peerId: peerData.peerId.toString()}, err);
+          this.logger.debug("Peer disconnected during the identification", {peerId: remotePeerStr});
         } else {
-          this.logger.debug("Error setting agentVersion for the peer", {peerId: peerData.peerId.toString()}, err);
+          this.logger.debug("Error setting agentVersion for the peer", {peerId: remotePeerStr}, err);
         }
       });
   };

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -725,7 +725,7 @@ export class PeerManager {
     this.connectedPeers.set(remotePeerStr, peerData);
 
     if (evt.detail.status !== "open") {
-      this.logger.debug("Peer disconnected before identification", {
+      this.logger.debug("Peer disconnected before identify protocol initiated", {
         peerId: remotePeerPrettyStr,
         status: evt.detail.status,
       });
@@ -749,7 +749,7 @@ export class PeerManager {
       })
       .catch((err) => {
         if (evt.detail.status !== "open") {
-          this.logger.debug("Peer disconnected during the identification", {peerId: remotePeerStr});
+          this.logger.debug("Peer disconnected during identify protocol", {peerId: remotePeerStr}, err);
         } else {
           this.logger.debug("Error setting agentVersion for the peer", {peerId: remotePeerStr}, err);
         }

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -722,18 +722,18 @@ export class PeerManager {
     };
     this.connectedPeers.set(remotePeer.toString(), peerData);
 
-    if (direction === "outbound") {
-      // this.pingAndStatusTimeouts();
-      void this.requestPing(remotePeer);
-      void this.requestStatus(remotePeer, this.statusCache.get());
-    }
-
     if (evt.detail.status !== "open") {
       this.logger.debug("Peer disconnected before identification", {
         peerId: peerData.peerId.toString(),
         status: evt.detail.status,
       });
       return;
+    }
+
+    if (direction === "outbound") {
+      // this.pingAndStatusTimeouts();
+      void this.requestPing(remotePeer);
+      void this.requestStatus(remotePeer, this.statusCache.get());
     }
 
     this.libp2p.services.identify

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -697,11 +697,6 @@ export class PeerManager {
     this.logger.verbose("peer connected", {peer: prettyPrintPeerId(remotePeer), direction, status});
     // NOTE: The peerConnect event is not emitted here here, but after asserting peer relevance
     this.metrics?.peerConnectedEvent.inc({direction, status});
-    // libp2p may emit closed connection, we don't want to handle it
-    // see https://github.com/libp2p/js-libp2p/issues/1565
-    if (this.connectedPeers.has(remotePeer.toString()) || status !== "open") {
-      return;
-    }
 
     // On connection:
     // - Outbound connections: send a STATUS and PING request
@@ -743,7 +738,11 @@ export class PeerManager {
         }
       })
       .catch((err) => {
-        this.logger.debug("Error setting agentVersion for the peer", {peerId: peerData.peerId.toString()}, err);
+        if (evt.detail.status !== "open") {
+          this.logger.debug("Peer disconnected during the identification", {peerId: peerData.peerId.toString()}, err);
+        } else {
+          this.logger.debug("Error setting agentVersion for the peer", {peerId: peerData.peerId.toString()}, err);
+        }
       });
   };
 

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -700,6 +700,14 @@ export class PeerManager {
     // NOTE: The peerConnect event is not emitted here here, but after asserting peer relevance
     this.metrics?.peerConnectedEvent.inc({direction, status});
 
+    if (evt.detail.status !== "open") {
+      this.logger.debug("Peer disconnected before identify protocol initiated", {
+        peerId: remotePeerPrettyStr,
+        status: evt.detail.status,
+      });
+      return;
+    }
+
     // On connection:
     // - Outbound connections: send a STATUS and PING request
     // - Inbound connections: expect to be STATUS'd, schedule STATUS and PING for latter
@@ -723,14 +731,6 @@ export class PeerManager {
       encodingPreference: null,
     };
     this.connectedPeers.set(remotePeerStr, peerData);
-
-    if (evt.detail.status !== "open") {
-      this.logger.debug("Peer disconnected before identify protocol initiated", {
-        peerId: remotePeerPrettyStr,
-        status: evt.detail.status,
-      });
-      return;
-    }
 
     if (direction === "outbound") {
       // this.pingAndStatusTimeouts();

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -749,9 +749,9 @@ export class PeerManager {
       })
       .catch((err) => {
         if (evt.detail.status !== "open") {
-          this.logger.debug("Peer disconnected during identify protocol", {peerId: remotePeerStr}, err);
+          this.logger.debug("Peer disconnected during identify protocol", {peerId: remotePeerPrettyStr}, err);
         } else {
-          this.logger.debug("Error setting agentVersion for the peer", {peerId: remotePeerStr}, err);
+          this.logger.debug("Error setting agentVersion for the peer", {peerId: remotePeerPrettyStr}, err);
         }
       });
   };


### PR DESCRIPTION
**Motivation**

We observed a lot of `UnexpectedEOFError: unexpected end of input` errors and observed that a lot of these happens after the remote connection is reset. 

**Description**

We observe the logs as following: 

1. Remote connects to us (inbound).
2. Handshake completes (TLS/noise + mplex).
3. Remote starts an identify stream 
4. For whatever reason (protocol mismatch, scoring policy, buggy client, etc.), the remote resets the TCP connection before we finish responding
5. We then attempt to open our own identify substream → underlying TCP is gone → UnexpectedEOFError.


```
025-08-07T06:46:49.366Z libp2p:tcp:socket successfully upgraded inbound connection\n
Aug-07 06:46:49.367[network]       \u001b[36mverbose\u001b[39m: peer connected peer=16...53V6e5, direction=inbound, status=open\n
2025-08-07T06:46:49.367Z libp2p:connection-manager:connection-pruner checking max connections limit 101/300\n
2025-08-07T06:46:49.368Z libp2p:mplex new initiator stream 0\n
2025-08-07T06:46:49.369Z libp2p:tcp:listener inbound connection upgraded /ip4/142.132.132.226/tcp/4101\n
2025-08-07T06:46:49.369Z libp2p:mplex new receiver stream 0\n
2025-08-07T06:46:49.370Z libp2p:mplex new receiver stream 1\n
2025-08-07T06:46:49.370Z libp2p:connection:inbound:4jujk31754549209366 incoming stream opened on /ipfs/id/1.0.0\n
2025-08-07T06:46:49.374Z libp2p:mplex receiver stream with id 0 and protocol /ipfs/id/1.0.0 ended\n
2025-08-07T06:46:49.374Z libp2p:tcp:socket:error inbound socket error - Error: write ECONNRESET\n
    at afterWriteDispatched (node:internal/stream_base_commons:159:15)\n
    at writeGeneric (node:internal/stream_base_commons:150:3)\n
    at Socket._writeGeneric (node:net:966:11)\n
    at Socket._write (node:net:978:8)\n
    at writeOrBuffer (node:internal/streams/writable:572:12)\n
    at _write (node:internal/streams/writable:501:10)\n
    at Writable.write (node:internal/streams/writable:510:10)\n
    at file:///usr/app/node_modules/stream-to-it/dist/src/sink.js:77:31\n
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n
    at async sink (file:///usr/app/node_modules/@libp2p/tcp/dist/src/socket-to-conn.js:87:17)\n
2025-08-07T06:46:49.374Z libp2p:connection:inbound:4jujk31754549209366 closing connection to /ip4/142.132.132.226/tcp/4101/p2p/16Uiu2HAmG63tyrvS3dQCaSRWqwyuqLfi6ewA8vNJ2UZT4k53V6e5\n
2025-08-07T06:46:49.375Z libp2p:mplex initiator stream with id 0 and protocol undefined ended\n
2025-08-07T06:46:49.375Z libp2p:mplex receiver stream with id 1 and protocol undefined ended\n
2025-08-07T06:46:49.375Z libp2p:connection:inbound:4jujk31754549209366:error could not create new outbound stream on connection from /ip4/142.132.132.226/tcp/4101 for protocols [ '/ipfs/id/1.0.0' ] - UnexpectedEOFError: unexpected end of input\n
    at Object.read (file:///usr/app/node_modules/it-byte-stream/dist/src/index.js:60:27)\n
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n
    at async Object.read (file:///usr/app/node_modules/it-length-prefixed-stream/dist/src/index.js:45:37)\n
    at async read (file:///usr/app/node_modules/@libp2p/multistream-select/dist/src/multistream.js:21:17)\n
    at async Module.readString (file:///usr/app/node_modules/@libp2p/multistream-select/dist/src/multistream.js:32:17)\n
    at async Module.select (file:///usr/app/node_modules/@libp2p/multistream-select/dist/src/select.js:72:20)\n
    at async ConnectionImpl.newStream [as _newStream] (file:///usr/app/node_modules/libp2p/dist/src/upgrader.js:353:50)\n
    at async ConnectionImpl.newStream (file:///usr/app/node_modules/libp2p/dist/src/connection/index.js:95:24)\n
    at async Identify._identify (file:///usr/app/node_modules/@libp2p/identify/dist/src/identify.js:50:22)\n
    at async Identify.identify (file:///usr/app/node_modules/@libp2p/identify/dist/src/identify.js:67:25)\n
```

By running these filters on the logs 

```bash
awk '
BEGIN {
  window_size = 10
}
{
  lines[NR] = $0
}
END {
  for (i = 1; i <= NR; i++) {
    if (lines[i] ~ /ECONNRESET/) {
      hasEOF = 0
      for (j = i+1; j <= i+window_size && j <= NR; j++) {
        if (lines[j] ~ /UnexpectedEOFError: unexpected end of input/) {
          hasEOF = 1
          break
        }
      }
      if (hasEOF)
        both++
      else
        newlineOnly++
    }
  }
  print "End of Input  + ECONNRESET: " both
  print "End of Input only: " newlineOnly
}' *.log *.log.*
```

Got the result as 

```
End of Input + ECONNRESET: 12362
End of Input only: 174931
```

For one peer we observed that much overlapping of these errors. That's too much noise, if we clear these up then we can focus on some real errors. 

**Steps to test or reproduce**

Test in devnet. 