### PR TITLE
fix: support dual stack on same port

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -94,7 +94,7 @@
   "dependencies": {
     "@chainsafe/as-sha256": "^1.2.0",
     "@chainsafe/blst": "^2.2.0",
-    "@chainsafe/discv5": "^11.0.0",
+    "@chainsafe/discv5": "^11.0.3",
     "@chainsafe/enr": "^5.0.0",
     "@chainsafe/libp2p-gossipsub": "^14.1.1",
     "@chainsafe/libp2p-noise": "^16.1.0",

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -95,7 +95,7 @@
     "@chainsafe/as-sha256": "^1.2.0",
     "@chainsafe/blst": "^2.2.0",
     "@chainsafe/discv5": "^11.0.3",
-    "@chainsafe/enr": "^5.0.0",
+    "@chainsafe/enr": "^5.0.1",
     "@chainsafe/libp2p-gossipsub": "^14.1.1",
     "@chainsafe/libp2p-noise": "^16.1.0",
     "@chainsafe/persistent-merkle-tree": "^1.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "@chainsafe/bls-keygen": "^0.4.0",
     "@chainsafe/bls-keystore": "^3.1.0",
     "@chainsafe/blst": "^2.2.0",
-    "@chainsafe/discv5": "^11.0.0",
+    "@chainsafe/discv5": "^11.0.3",
     "@chainsafe/enr": "^5.0.0",
     "@chainsafe/persistent-merkle-tree": "^1.2.0",
     "@chainsafe/ssz": "^1.2.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,7 +55,7 @@
     "@chainsafe/bls-keystore": "^3.1.0",
     "@chainsafe/blst": "^2.2.0",
     "@chainsafe/discv5": "^11.0.3",
-    "@chainsafe/enr": "^5.0.0",
+    "@chainsafe/enr": "^5.0.1",
     "@chainsafe/persistent-merkle-tree": "^1.2.0",
     "@chainsafe/ssz": "^1.2.1",
     "@chainsafe/threads": "^1.11.2",

--- a/packages/cli/src/cmds/bootnode/options.ts
+++ b/packages/cli/src/cmds/bootnode/options.ts
@@ -1,6 +1,6 @@
 import {CliCommandOptions, CliOptionDefinition} from "@lodestar/utils";
 import {MetricsArgs, options as metricsOptions} from "../../options/beaconNodeOptions/metrics.js";
-import {defaultListenAddress, defaultP2pPort, defaultP2pPort6} from "../../options/beaconNodeOptions/network.js";
+import {defaultListenAddress, defaultP2pPort} from "../../options/beaconNodeOptions/network.js";
 import {LogArgs, logOptions} from "../../options/logOptions.js";
 
 type BootnodeExtraArgs = {
@@ -44,7 +44,7 @@ export const bootnodeExtraOptions: CliCommandOptions<BootnodeExtraArgs> = {
     alias: "discoveryPort6",
     description: "The UDP port to listen on",
     type: "number",
-    defaultDescription: String(defaultP2pPort6),
+    defaultDescription: String(defaultP2pPort),
     group: "network",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -6,7 +6,6 @@ import {YargsError} from "../../util/index.js";
 
 export const defaultListenAddress = "0.0.0.0";
 export const defaultP2pPort = 9000;
-export const defaultP2pPort6 = 9090;
 
 export type NetworkArgs = {
   discv5?: boolean;
@@ -67,8 +66,8 @@ export function parseListenArgs(args: NetworkArgs) {
 
   // Only use listenAddress6 if it is explicitly set
   const listenAddress6 = args.listenAddress6;
-  const port6 = listenAddress6 ? (args.port6 ?? defaultP2pPort6) : undefined;
-  const discoveryPort6 = listenAddress6 ? (args.discoveryPort6 ?? args.port6 ?? defaultP2pPort6) : undefined;
+  const port6 = listenAddress6 ? (args.port6 ?? defaultP2pPort) : undefined;
+  const discoveryPort6 = listenAddress6 ? (args.discoveryPort6 ?? args.port6 ?? defaultP2pPort) : undefined;
 
   return {listenAddress, port, discoveryPort, listenAddress6, port6, discoveryPort6};
 }
@@ -199,7 +198,7 @@ export const options: CliCommandOptions<NetworkArgs> = {
     description: "The TCP/UDP port to listen on. The UDP port can be modified by the --discoveryPort6 flag.",
     type: "number",
     // TODO: Derive from BeaconNode defaults
-    defaultDescription: String(defaultP2pPort6),
+    defaultDescription: String(defaultP2pPort),
     group: "network",
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,20 +566,6 @@
     lru-cache "^10.1.0"
     strict-event-emitter-types "^2.0.0"
 
-"@chainsafe/enr@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/enr/-/enr-5.0.0.tgz#0486d6d3ba9cb8c4a6e2190921b2dd33ec60bb7b"
-  integrity sha512-xqWBsdFFHy/sLqddsyCT4BH/5PFheyK8Grho27tmiwg/a95nANYANsqXXUP8/HbgCx3F5VDl0/xFacV3Ik7kDA==
-  dependencies:
-    "@ethereumjs/rlp" "^5.0.2"
-    "@libp2p/crypto" "^5.0.1"
-    "@libp2p/interface" "^2.0.1"
-    "@libp2p/peer-id" "^5.0.1"
-    "@multiformats/multiaddr" "^12.1.10"
-    "@scure/base" "^1.2.1"
-    ethereum-cryptography "^2.2.0"
-    uint8-varint "^2.0.2"
-
 "@chainsafe/enr@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@chainsafe/enr/-/enr-5.0.1.tgz#ac7622ee381475110239af75073969fad1faf412"

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,12 +550,12 @@
     "@chainsafe/blst-linux-x64-musl" "2.2.0"
     "@chainsafe/blst-win32-x64-msvc" "2.2.0"
 
-"@chainsafe/discv5@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/discv5/-/discv5-11.0.0.tgz#346a11ad25f552d29e8b1956b539e08d14bde361"
-  integrity sha512-g/x79Y5b7g6CrNuWazSzXTtnNguC0Sl8xkf9CPMlZ0BrsXmXPzwTp3zgtAiuJcG9x7zDUSDFOejrb4iFcJ0/FQ==
+"@chainsafe/discv5@^11.0.3":
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/@chainsafe/discv5/-/discv5-11.0.3.tgz#0f53d2f8a7f015bf2c0c8d897c01e8cb5466c916"
+  integrity sha512-bDvpiHfg7th/YGoOx7+W6x/28kfE/Cob7uE0XWpyPMQ0RTmJmzMYMfT1eulg5unlggALABvKgsct/gQDQT/hFw==
   dependencies:
-    "@chainsafe/enr" "^5.0.0"
+    "@chainsafe/enr" "^5.0.1"
     "@ethereumjs/rlp" "^5.0.2"
     "@libp2p/crypto" "^5.0.1"
     "@libp2p/interface" "^2.0.1"
@@ -570,6 +570,20 @@
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@chainsafe/enr/-/enr-5.0.0.tgz#0486d6d3ba9cb8c4a6e2190921b2dd33ec60bb7b"
   integrity sha512-xqWBsdFFHy/sLqddsyCT4BH/5PFheyK8Grho27tmiwg/a95nANYANsqXXUP8/HbgCx3F5VDl0/xFacV3Ik7kDA==
+  dependencies:
+    "@ethereumjs/rlp" "^5.0.2"
+    "@libp2p/crypto" "^5.0.1"
+    "@libp2p/interface" "^2.0.1"
+    "@libp2p/peer-id" "^5.0.1"
+    "@multiformats/multiaddr" "^12.1.10"
+    "@scure/base" "^1.2.1"
+    ethereum-cryptography "^2.2.0"
+    uint8-varint "^2.0.2"
+
+"@chainsafe/enr@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/enr/-/enr-5.0.1.tgz#ac7622ee381475110239af75073969fad1faf412"
+  integrity sha512-RP5XxJOSYt0f775ne6NqlaG33Qia+IaMjWlP7PlWagz6SOpXlfbm+vaqHx3by6lKPb9aW4UQtO+fiRxz85XwaQ==
   dependencies:
     "@ethereumjs/rlp" "^5.0.2"
     "@libp2p/crypto" "^5.0.1"


### PR DESCRIPTION
**Motivation**

- Resolve https://github.com/ChainSafe/lodestar/issues/7116
- Resolve https://github.com/ChainSafe/lodestar/issues/6531

**Description**

- Update discv5 dependency (https://github.com/ChainSafe/discv5/pull/316)
- default to using the same port for ipv4 and ipv6