### PR TITLE
feat: log when publishing to 0 data column peers

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -296,7 +296,7 @@ export function getBeaconBlockApi({
       }
       if (columnsPublishedWithZeroPeers > 0) {
         chain.logger.warn("Published data columns to 0 peers, increased risk of reorg", {
-          slot: signedBlock.message.slot,
+          slot,
           blockRoot,
           columns: columnsPublishedWithZeroPeers,
         });

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -281,6 +281,7 @@ export function getBeaconBlockApi({
     const sentPeersArr = await promiseAllMaybeAsync<number | void>(publishPromises);
 
     if (isForkPostFulu(fork)) {
+      let columnsPublishedWithZeroPeers = 0;
       // sent peers per topic are logged in network.publishGossip(), here we only track metrics for it
       // starting from fulu, we have to push to 128 subnets so need to make sure we have enough sent peers per topic
       // + 1 because we publish to beacon_block first
@@ -289,6 +290,14 @@ export function getBeaconBlockApi({
         const sentPeers = sentPeersArr[i + 1] as number;
         // sent peers could be 0 as we set `allowPublishToZeroTopicPeers=true` in network.publishDataColumnSidecar() api
         metrics?.dataColumns.sentPeersPerSubnet.observe(sentPeers);
+        if (sentPeers === 0) {
+          columnsPublishedWithZeroPeers++;
+        }
+      }
+      if (columnsPublishedWithZeroPeers > 0) {
+        chain.logger.warn("Published data columns with 0 peers, increased risk of reorg", {
+          columns: columnsPublishedWithZeroPeers,
+        });
       }
     }
 

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -296,6 +296,8 @@ export function getBeaconBlockApi({
       }
       if (columnsPublishedWithZeroPeers > 0) {
         chain.logger.warn("Published data columns with 0 peers, increased risk of reorg", {
+          slot: signedBlock.message.slot,
+          blockRoot,
           columns: columnsPublishedWithZeroPeers,
         });
       }

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -295,7 +295,7 @@ export function getBeaconBlockApi({
         }
       }
       if (columnsPublishedWithZeroPeers > 0) {
-        chain.logger.warn("Published data columns with 0 peers, increased risk of reorg", {
+        chain.logger.warn("Published data columns to 0 peers, increased risk of reorg", {
           slot: signedBlock.message.slot,
           blockRoot,
           columns: columnsPublishedWithZeroPeers,


### PR DESCRIPTION
**Motivation**

- followup to #8181 

**Description**

- If any columns were published to 0 peers, print a warning that the block may be reorged