### PR TITLE
fix: make the runner script posix compliant

### DIFF
--- a/lodestar
+++ b/lodestar
@@ -4,6 +4,6 @@
 #
 # ./lodestar.sh beacon --network mainnet
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_DIR=$(cd "$(dirname -- "$0")" >/dev/null 2>&1 && pwd -P)
 
 exec node --trace-deprecation --max-old-space-size=8192 "$SCRIPT_DIR/packages/cli/bin/lodestar.js" "$@"


### PR DESCRIPTION
**Motivation**

Fix an issue identified while running script on the Linux. It was not present on the Mac. 

**Description**

- The `/#!/usr/bin/env sh` descriptor on top of the file result differently on Mac and other machines, enforcing the script to be treated in a particular shell script. 
- On mac it's set to `bash`, but was not compliant with some versions of the Linux. 
- Use the POSIX style output redirect so script is compliant on most OS.

**Steps to test or reproduce**

- Try to run it locally