### PR TITLE
fix: unbreak sim and e2e tests

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -396,19 +396,24 @@ export class NetworkCore implements INetworkCore {
     // biome-ignore lint/complexity/useLiteralKeys: `discovery` is a private attribute
     const enr = await this.peerManager["discovery"]?.discv5.enr();
 
+    // enr.getFullMultiaddr can counterintuitively return undefined near startup if the enr.ip or enr.ip6 is not set.
+    // Eventually, the enr will be updated with the correct ip after discv5 runs for a while.
+
     // Node's addresses on which is listening for discv5 requests.
     // The example provided by the beacon-APIs show a _full_ multiaddr, ie including the peer id, so we include it.
     const discoveryAddresses = [
-      (await enr?.getFullMultiaddr("udp"))?.toString() ?? null,
-      (await enr?.getFullMultiaddr("udp6"))?.toString() ?? null,
+      (await enr?.getFullMultiaddr("udp"))?.toString(),
+      (await enr?.getFullMultiaddr("udp6"))?.toString(),
     ].filter((addr): addr is string => Boolean(addr));
 
     // Node's addresses on which eth2 RPC requests are served.
     const p2pAddresses = [
-      (await enr?.getFullMultiaddr("tcp"))?.toString() ?? null,
-      (await enr?.getFullMultiaddr("tcp6"))?.toString() ?? null,
-      (await enr?.getFullMultiaddr("quic"))?.toString() ?? null,
-      (await enr?.getFullMultiaddr("quic6"))?.toString() ?? null,
+      // It is useful to include listen multiaddrs even if they use public IPs
+      ...this.libp2p.getMultiaddrs(),
+      (await enr?.getFullMultiaddr("tcp"))?.toString(),
+      (await enr?.getFullMultiaddr("tcp6"))?.toString(),
+      (await enr?.getFullMultiaddr("quic"))?.toString(),
+      (await enr?.getFullMultiaddr("quic6"))?.toString(),
     ].filter((addr): addr is string => Boolean(addr));
 
     return {

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -408,8 +408,10 @@ export class NetworkCore implements INetworkCore {
 
     // Node's addresses on which eth2 RPC requests are served.
     const p2pAddresses = [
-      // It is useful to include listen multiaddrs even if they use public IPs
+      // It is useful to include listen multiaddrs even if they likely aren't public IPs
+      // This means that we will always return some multiaddrs
       ...this.libp2p.getMultiaddrs().map((ma) => ma.toString()),
+
       (await enr?.getFullMultiaddr("tcp"))?.toString(),
       (await enr?.getFullMultiaddr("tcp6"))?.toString(),
       (await enr?.getFullMultiaddr("quic"))?.toString(),

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -399,16 +399,16 @@ export class NetworkCore implements INetworkCore {
     // Node's addresses on which is listening for discv5 requests.
     // The example provided by the beacon-APIs show a _full_ multiaddr, ie including the peer id, so we include it.
     const discoveryAddresses = [
-      enr?.getFullMultiaddr("udp")?.toString() ?? null,
-      enr?.getFullMultiaddr("udp6")?.toString() ?? null,
+      (await enr?.getFullMultiaddr("udp"))?.toString() ?? null,
+      (await enr?.getFullMultiaddr("udp6"))?.toString() ?? null,
     ].filter((addr): addr is string => Boolean(addr));
 
     // Node's addresses on which eth2 RPC requests are served.
     const p2pAddresses = [
-      enr?.getFullMultiaddr("tcp")?.toString() ?? null,
-      enr?.getFullMultiaddr("tcp6")?.toString() ?? null,
-      enr?.getFullMultiaddr("quic")?.toString() ?? null,
-      enr?.getFullMultiaddr("quic6")?.toString() ?? null,
+      (await enr?.getFullMultiaddr("tcp"))?.toString() ?? null,
+      (await enr?.getFullMultiaddr("tcp6"))?.toString() ?? null,
+      (await enr?.getFullMultiaddr("quic"))?.toString() ?? null,
+      (await enr?.getFullMultiaddr("quic6"))?.toString() ?? null,
     ].filter((addr): addr is string => Boolean(addr));
 
     return {

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -409,7 +409,7 @@ export class NetworkCore implements INetworkCore {
     // Node's addresses on which eth2 RPC requests are served.
     const p2pAddresses = [
       // It is useful to include listen multiaddrs even if they use public IPs
-      ...this.libp2p.getMultiaddrs(),
+      ...this.libp2p.getMultiaddrs().map((ma) => ma.toString()),
       (await enr?.getFullMultiaddr("tcp"))?.toString(),
       (await enr?.getFullMultiaddr("tcp6"))?.toString(),
       (await enr?.getFullMultiaddr("quic"))?.toString(),


### PR DESCRIPTION
**Motivation**
- Fix bug in #8189 

**Description**

- enr.getFullMultiaddr returns a promise which must be awaited
- enr.getFullMultiaddr will return undefined if enr.ip or enr.ip6 is not set. This will be the case on startup before discv5 runs for a while. Our sim and e2e tests assume that a dialable multiaddr is returned in p2pAddresses, so we include the listenAddresses from libp2p (even though they're likely local IPs)