### PR TITLE
fix: do not pick out-of-date peer to retry head sync

### DIFF
--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -365,7 +365,7 @@ export class SyncChain {
       }
     }
 
-    const peerBalancer = new ChainPeersBalancer(peersSyncInfo, toArr(this.batches), this.custodyConfig);
+    const peerBalancer = new ChainPeersBalancer(peersSyncInfo, toArr(this.batches), this.custodyConfig, this.syncType);
 
     // Retry download of existing batches
     for (const batch of this.batches.values()) {


### PR DESCRIPTION
**Motivation**

- blocks were downloaded for a batch, but its a partial download because peer does not have all column node needs, and need a retry
- we did not have a condition to pick peers that's more up to date than the previous one and it caused #8193

**Description**

- if head sync and post fulu, do not pick out-of-date peer compared to the previous partial download

Closes #8193