### PR TITLE
fix: head sync failed due to retrying with a more up-to-date peer

### DIFF
--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -28,12 +28,15 @@ import {
 } from "../../chain/blocks/types.js";
 import {getEmptyBlockInputCacheEntry} from "../../chain/seenCache/seenGossipBlockInput.js";
 import {Metrics} from "../../metrics/index.js";
+import {RangeSyncType} from "../../sync/utils/remoteSyncType.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {INetwork} from "../interface.js";
 import {PeerSyncMeta} from "../peers/peersData.js";
 import {PeerAction} from "../peers/score/interface.js";
 
 export type PartialDownload = null | {blocks: BlockInput[]; pendingDataColumns: number[]};
+export const SyncSourceByRoot = "ByRoot" as const;
+export type SyncSource = RangeSyncType | typeof SyncSourceByRoot;
 
 /**
  * Download blocks and blobs (prefulu) or data columns (fulu) by range.
@@ -48,6 +51,7 @@ export async function beaconBlocksMaybeBlobsByRange(
   request: phase0.BeaconBlocksByRangeRequest,
   currentEpoch: Epoch,
   partialDownload: PartialDownload,
+  syncSource: SyncSource,
   metrics: Metrics | null,
   logger?: Logger
 ): Promise<{blocks: BlockInput[]; pendingDataColumns: null | number[]}> {
@@ -181,6 +185,7 @@ export async function beaconBlocksMaybeBlobsByRange(
       DataColumnsSource.byRange,
       partialDownload,
       peerClient,
+      syncSource,
       metrics,
       logger
     );
@@ -298,6 +303,7 @@ export function matchBlockWithDataColumns(
   dataColumnsSource: DataColumnsSource,
   prevPartialDownload: null | PartialDownload,
   peerClient: string,
+  syncSource: SyncSource,
   metrics: Metrics | null,
   logger?: Logger
 ): BlockInput[] {
@@ -341,7 +347,10 @@ export function matchBlockWithDataColumns(
     });
     if (blobKzgCommitmentsLen === 0) {
       if (dataColumnSidecars.length > 0) {
-        network.reportPeer(peerId, PeerAction.LowToleranceError, "Missing or mismatching dataColumnSidecars");
+        // only penalize peer with Finalized range sync or "ByRoot" sync source
+        if (syncSource !== RangeSyncType.Head) {
+          network.reportPeer(peerId, PeerAction.LowToleranceError, "Missing or mismatching dataColumnSidecars");
+        }
         throw Error(
           `Missing or mismatching dataColumnSidecars from peerId=${peerId} for blockSlot=${block.data.message.slot} with blobKzgCommitmentsLen=0 dataColumnSidecars=${dataColumnSidecars.length}>0`
         );
@@ -380,7 +389,10 @@ export function matchBlockWithDataColumns(
             peerClient,
           }
         );
-        network.reportPeer(peerId, PeerAction.LowToleranceError, "Missing or mismatching dataColumnSidecars");
+        // only penalize peer with Finalized range sync or "ByRoot" sync source
+        if (syncSource !== RangeSyncType.Head) {
+          network.reportPeer(peerId, PeerAction.LowToleranceError, "Missing or mismatching dataColumnSidecars");
+        }
         throw Error(
           `Missing or mismatching dataColumnSidecars from peerId=${peerId} for blockSlot=${block.data.message.slot} blobKzgCommitmentsLen=${blobKzgCommitmentsLen} with numColumns=${sampledColumns.length} dataColumnSidecars=${dataColumnSidecars.length} requestedColumnsPresent=${requestedColumnsPresent} received dataColumnIndexes=${dataColumnIndexes.join(" ")} requested=${requestedColumns.join(" ")}`
         );
@@ -441,7 +453,10 @@ export function matchBlockWithDataColumns(
     // If there are no data columns, the data columns request can give 1 block outside the requested range
     allDataColumnSidecars[dataColumnSideCarIndex].signedBlockHeader.message.slot <= endSlot
   ) {
-    network.reportPeer(peerId, PeerAction.LowToleranceError, "Unmatched dataColumnSidecars");
+    // only penalize peer with Finalized range sync or "ByRoot" sync source
+    if (syncSource !== RangeSyncType.Head) {
+      network.reportPeer(peerId, PeerAction.LowToleranceError, "Unmatched dataColumnSidecars");
+    }
     throw Error(
       `Unmatched dataColumnSidecars, blocks=${allBlocks.length}, blobs=${
         allDataColumnSidecars.length

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -108,7 +108,8 @@ export async function beaconBlocksMaybeBlobsByRange(
         allBlobSidecars,
         endSlot,
         BlockSource.byRange,
-        BlobsSource.byRange
+        BlobsSource.byRange,
+        syncSource
       );
       return {blocks, pendingDataColumns: null};
     }
@@ -224,7 +225,8 @@ export function matchBlockWithBlobs(
   allBlobSidecars: deneb.BlobSidecar[],
   endSlot: Slot,
   blockSource: BlockSource,
-  blobsSource: BlobsSource
+  blobsSource: BlobsSource,
+  syncSource: SyncSource
 ): BlockInput[] {
   const blockInputs: BlockInput[] = [];
   let blobSideCarIndex = 0;
@@ -243,12 +245,27 @@ export function matchBlockWithBlobs(
     } else {
       const blobSidecars: deneb.BlobSidecar[] = [];
 
-      let blobSidecar: deneb.BlobSidecar;
-      while (
-        // biome-ignore lint/suspicious/noAssignInExpressions: <explanation>
-        (blobSidecar = allBlobSidecars[blobSideCarIndex])?.signedBlockHeader.message.slot === block.data.message.slot
-      ) {
-        blobSidecars.push(blobSidecar);
+      const blockRoot = config.getForkTypes(block.data.message.slot).BeaconBlock.hashTreeRoot(block.data.message);
+      const matchBlob = (blobSidecar?: deneb.BlobSidecar): boolean => {
+        if (blobSidecar === undefined) {
+          return false;
+        }
+
+        if (syncSource === RangeSyncType.Head || syncSource === SyncSourceByRoot) {
+          return (
+            Buffer.compare(
+              ssz.phase0.BeaconBlockHeader.hashTreeRoot(blobSidecar.signedBlockHeader.message),
+              blockRoot
+            ) === 0
+          );
+        }
+
+        // For finalized range sync, we can just match by slot
+        return blobSidecar.signedBlockHeader.message.slot === block.data.message.slot;
+      };
+
+      while (matchBlob(allBlobSidecars[blobSideCarIndex])) {
+        blobSidecars.push(allBlobSidecars[blobSideCarIndex]);
         lastMatchedSlot = block.data.message.slot;
         blobSideCarIndex++;
       }
@@ -327,7 +344,25 @@ export function matchBlockWithDataColumns(
       throw Error(`Invalid block forkSeq=${forkSeq} < ForSeq.fulu for matchBlockWithDataColumns`);
     }
     const dataColumnSidecars: fulu.DataColumnSidecar[] = [];
-    while (allDataColumnSidecars[dataColumnSideCarIndex]?.signedBlockHeader.message.slot === block.data.message.slot) {
+    const blockRoot = config.getForkTypes(block.data.message.slot).BeaconBlock.hashTreeRoot(block.data.message);
+    const matchDataColumnSidecar = (dataColumnSidecar?: fulu.DataColumnSidecar): boolean => {
+      if (dataColumnSidecar === undefined) {
+        return false;
+      }
+
+      if (syncSource === RangeSyncType.Head || syncSource === SyncSourceByRoot) {
+        return (
+          Buffer.compare(
+            ssz.phase0.BeaconBlockHeader.hashTreeRoot(dataColumnSidecar.signedBlockHeader.message),
+            blockRoot
+          ) === 0
+        );
+      }
+
+      // For finalized range sync, we can just match by slot
+      return dataColumnSidecar.signedBlockHeader.message.slot === block.data.message.slot;
+    };
+    while (matchDataColumnSidecar(allDataColumnSidecars[dataColumnSideCarIndex])) {
       dataColumnSidecars.push(allDataColumnSidecars[dataColumnSideCarIndex]);
       lastMatchedSlot = block.data.message.slot;
       dataColumnSideCarIndex++;

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -446,24 +446,22 @@ export function matchBlockWithDataColumns(
     }
   }
 
-  // If there are still unconsumed blobs this means that the response was inconsistent
-  // and matching was wrong and hence we should throw error
+  // for head sync, there could be unconsumed data column sidecars because the retried peers may have higher head
   if (
     allDataColumnSidecars[dataColumnSideCarIndex] !== undefined &&
     // If there are no data columns, the data columns request can give 1 block outside the requested range
-    allDataColumnSidecars[dataColumnSideCarIndex].signedBlockHeader.message.slot <= endSlot
-  ) {
+    allDataColumnSidecars[dataColumnSideCarIndex].signedBlockHeader.message.slot <= endSlot &&
     // only penalize peer with Finalized range sync or "ByRoot" sync source
-    if (syncSource !== RangeSyncType.Head) {
-      network.reportPeer(peerId, PeerAction.LowToleranceError, "Unmatched dataColumnSidecars");
-    }
+    syncSource !== RangeSyncType.Head
+  ) {
+    network.reportPeer(peerId, PeerAction.LowToleranceError, "Unmatched dataColumnSidecars");
     throw Error(
       `Unmatched dataColumnSidecars, blocks=${allBlocks.length}, blobs=${
         allDataColumnSidecars.length
       } lastMatchedSlot=${lastMatchedSlot}, pending dataColumnSidecars slots=${allDataColumnSidecars
         .slice(dataColumnSideCarIndex)
         .map((blb) => blb.signedBlockHeader.message.slot)
-        .join(" ")}`
+        .join(" ")} endSlot=${endSlot}, peerId=${peerId}, peerClient=${peerClient}`
     );
   }
   logger?.debug("matched BlockWithDataColumns", {

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -130,7 +130,8 @@ export async function beaconBlocksMaybeBlobsByRoot(
       allBlobSidecars,
       Infinity,
       BlockSource.byRoot,
-      BlobsSource.byRoot
+      BlobsSource.byRoot,
+      SyncSourceByRoot
     );
     blockInputs = [...blockInputs, ...blockInputWithBlobs];
   }

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -29,7 +29,12 @@ import {computeInclusionProof, kzgCommitmentToVersionedHash} from "../../util/bl
 import {getDataColumnsFromExecution} from "../../util/dataColumns.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {INetwork} from "../interface.js";
-import {PartialDownload, matchBlockWithBlobs, matchBlockWithDataColumns} from "./beaconBlocksMaybeBlobsByRange.js";
+import {
+  PartialDownload,
+  SyncSourceByRoot,
+  matchBlockWithBlobs,
+  matchBlockWithDataColumns,
+} from "./beaconBlocksMaybeBlobsByRange.js";
 
 // keep 1 epoch of stuff, assmume 16 blobs
 const MAX_ENGINE_GETBLOBS_CACHE = 32 * 16;
@@ -175,6 +180,7 @@ export async function beaconBlocksMaybeBlobsByRoot(
       DataColumnsSource.byRoot,
       partialDownload,
       peerClient,
+      SyncSourceByRoot,
       metrics,
       logger
     );

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -44,7 +44,8 @@ export type SyncChainFns = {
   downloadBeaconBlocksByRange: (
     peer: PeerSyncMeta,
     request: phase0.BeaconBlocksByRangeRequest,
-    partialDownload: PartialDownload
+    partialDownload: PartialDownload,
+    syncType: RangeSyncType
   ) => Promise<{blocks: BlockInput[]; pendingDataColumns: null | number[]}>;
   /** Report peer for negative actions. Decouples from the full network instance */
   reportPeer: (peer: PeerIdStr, action: PeerAction, actionName: string) => void;
@@ -449,7 +450,9 @@ export class SyncChain {
       const partialDownload = batch.startDownloading(peer.peerId);
 
       // wrapError ensures to never call both batch success() and batch error()
-      const res = await wrapError(this.downloadBeaconBlocksByRange(peer, batch.request, partialDownload));
+      const res = await wrapError(
+        this.downloadBeaconBlocksByRange(peer, batch.request, partialDownload, this.syncType)
+      );
 
       if (!res.err) {
         const downloadSuccessOutput = batch.downloadingSuccess(res.result);

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -203,7 +203,8 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
   private downloadBeaconBlocksByRange: SyncChainFns["downloadBeaconBlocksByRange"] = async (
     peer,
     request,
-    partialDownload
+    partialDownload,
+    syncType: RangeSyncType
   ) => {
     return beaconBlocksMaybeBlobsByRange(
       this.config,
@@ -212,6 +213,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       request,
       this.chain.clock.currentEpoch,
       partialDownload,
+      syncType,
       this.metrics,
       this.logger
     );

--- a/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/beaconBlocksMaybeBlobsByRange.test.ts
@@ -7,6 +7,7 @@ import {BlobsSource, BlockSource, getBlockInput} from "../../../src/chain/blocks
 import {ZERO_HASH} from "../../../src/constants/constants.js";
 import {INetwork} from "../../../src/network/interface.js";
 import {beaconBlocksMaybeBlobsByRange} from "../../../src/network/reqresp/index.js";
+import {RangeSyncType} from "../../../src/sync/utils/remoteSyncType.js";
 import {CustodyConfig} from "../../../src/util/dataColumns.js";
 
 describe.skip("beaconBlocksMaybeBlobsByRange", () => {
@@ -126,6 +127,7 @@ describe.skip("beaconBlocksMaybeBlobsByRange", () => {
         rangeRequest,
         0,
         null,
+        RangeSyncType.Finalized,
         null
       );
       expect(response).toEqual(expectedResponse);

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -216,9 +216,9 @@ function logSyncChainFns(logger: Logger, fns: SyncChainFns): SyncChainFns {
       logger.debug("mock processChainSegment", {blocks: blocks.map((b) => b.block.message.slot).join(",")});
       return fns.processChainSegment(blocks, syncType);
     },
-    downloadBeaconBlocksByRange(peer, request, _partialDownload) {
+    downloadBeaconBlocksByRange(peer, request, _partialDownload, syncType) {
       logger.debug("mock downloadBeaconBlocksByRange", request);
-      return fns.downloadBeaconBlocksByRange(peer, request, _partialDownload);
+      return fns.downloadBeaconBlocksByRange(peer, request, _partialDownload, syncType);
     },
     getConnectedPeerSyncMeta(peerId) {
       logger.debug("mock getConnectedPeerSyncMeta", peerId);


### PR DESCRIPTION
**Motivation**

- fix multiple issues of head sync
  - #8192
  - #8202

**Description**

- define `SyncSource` enum
- based on that do corresponding actions for each sync source
- do not penalize peer for head sync

Closes #8192
Closes #8202

