### PR TITLE
feat: stricter builder circuit breaker

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -428,7 +428,7 @@ export function getValidatorApi(
 
     switch (chain.executionBuilder.status) {
       case BuilderStatus.disabled:
-        throw Error("External builder disabled due to failed status checks");
+        throw Error("External builder disabled due to failed status check");
       case BuilderStatus.circuitBreaker:
         throw Error("External builder circuit breaker is activated");
       case BuilderStatus.enabled:

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -72,7 +72,7 @@ import {RegenCaller} from "../../../chain/regen/index.js";
 import {validateApiAggregateAndProof} from "../../../chain/validation/index.js";
 import {validateSyncCommitteeGossipContributionAndProof} from "../../../chain/validation/syncCommitteeContributionAndProof.js";
 import {ZERO_HASH} from "../../../constants/index.js";
-import {NoBidReceived} from "../../../execution/builder/http.js";
+import {BuilderStatus, NoBidReceived} from "../../../execution/builder/http.js";
 import {validateGossipFnRetryUnknownRoot} from "../../../network/processor/gossipHandlers.js";
 import {CommitteeSubscription} from "../../../network/subnets/index.js";
 import {SyncState} from "../../../sync/index.js";
@@ -423,10 +423,17 @@ export function getValidatorApi(
 
     // Error early for builder if builder flow not active
     if (!chain.executionBuilder) {
-      throw Error("Execution builder not set");
+      throw Error("External builder not configured");
     }
-    if (!chain.executionBuilder.status) {
-      throw Error("Execution builder disabled");
+
+    switch (chain.executionBuilder.status) {
+      case BuilderStatus.disabled:
+        throw Error("External builder disabled due to failed status checks");
+      case BuilderStatus.circuitBreaker:
+        throw Error("External builder circuit breaker is activated");
+      case BuilderStatus.enabled:
+        // continue
+        break;
     }
 
     let timer: undefined | ((opts: {source: ProducedBlockSource}) => number);
@@ -1491,7 +1498,7 @@ export function getValidatorApi(
 
     async registerValidator({registrations}) {
       if (!chain.executionBuilder) {
-        throw Error("Execution builder not enabled");
+        throw Error("External builder not configured");
       }
 
       // should only send active or pending validator to builder

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -48,6 +48,7 @@ import {getEffectiveBalancesFromStateBytes} from "@lodestar/state-transition";
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants/index.js";
 import {IBeaconDb} from "../db/index.js";
 import {IEth1ForBlockProduction} from "../eth1/index.js";
+import {BuilderStatus} from "../execution/builder/http.js";
 import {IExecutionBuilder, IExecutionEngine} from "../execution/index.js";
 import {Metrics} from "../metrics/index.js";
 import {computeNodeIdFromPrivateKey} from "../network/subnets/interface.js";
@@ -1328,7 +1329,7 @@ export class BeaconChain implements IBeaconChain {
       const previousStatus = executionBuilder.status;
       const shouldEnable = slotsPresent >= Math.min(faultInspectionWindow - allowedFaults, clockSlot);
 
-      executionBuilder.updateStatus(shouldEnable);
+      executionBuilder.updateStatus(shouldEnable ? BuilderStatus.enabled : BuilderStatus.circuitBreaker);
       // The status changed we should log
       const status = executionBuilder.status;
       const builderLog = {
@@ -1338,9 +1339,9 @@ export class BeaconChain implements IBeaconChain {
         allowedFaults,
       };
       if (status !== previousStatus) {
-        this.logger.info("Execution builder status updated", builderLog);
+        this.logger.info("External builder status updated", builderLog);
       } else {
-        this.logger.verbose("Execution builder status", builderLog);
+        this.logger.verbose("External builder status", builderLog);
       }
     }
   }

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -13,6 +13,7 @@ import {
 import {Slot} from "@lodestar/types";
 import {Logger, fromHex, isErrorAborted, sleep} from "@lodestar/utils";
 import {GENESIS_SLOT, ZERO_HASH_HEX} from "../constants/constants.js";
+import {BuilderStatus} from "../execution/builder/http.js";
 import {Metrics} from "../metrics/index.js";
 import {ClockEvent} from "../util/clock.js";
 import {isQueueErrorAborted} from "../util/queue/index.js";
@@ -154,7 +155,7 @@ export class PrepareNextSlotScheduler {
 
           // Update the builder status, if enabled shoot an api call to check status
           this.chain.updateBuilderStatus(clockSlot);
-          if (this.chain.executionBuilder?.status) {
+          if (this.chain.executionBuilder?.status === BuilderStatus.enabled) {
             this.chain.executionBuilder.checkStatus().catch((e) => {
               this.logger.error("Builder disabled as the check status api failed", {prepareSlot}, e as Error);
             });

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -159,7 +159,7 @@ export async function produceBlockBody<T extends BlockType>(
     Object.assign(logMeta, {feeRecipientType, feeRecipient});
 
     if (blockType === BlockType.Blinded) {
-      if (!this.executionBuilder) throw Error("Execution Builder not available");
+      if (!this.executionBuilder) throw Error("External builder not configured");
       const executionBuilder = this.executionBuilder;
 
       const builderPromise = (async () => {
@@ -567,7 +567,7 @@ async function prepareExecutionPayloadHeader(
 
   const parentHashRes = await getExecutionPayloadParentHash(chain, state);
   if (parentHashRes.isPremerge) {
-    throw Error("Execution builder disabled pre-merge");
+    throw Error("External builder disabled pre-merge");
   }
 
   const {parentHash} = parentHashRes;

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -42,6 +42,23 @@ export const defaultExecutionBuilderHttpOpts: ExecutionBuilderHttpOpts = {
   timeout: 12000,
 };
 
+export enum BuilderStatus {
+  /**
+   * Builder is enabled and operational
+   */
+  enabled = "enabled",
+  /**
+   * Builder is disabled due to failed status checks
+   */
+  disabled = "disabled",
+  /**
+   * Circuit breaker condition that is triggered when the node determines the chain is unhealthy.
+   * When the circuit breaker is fired, proposers **MUST** not utilize the external builder
+   * network and exclusively build locally.
+   */
+  circuitBreaker = "circuit_breaker",
+}
+
 /**
  * Expected error if builder does not provide a bid. Most of the time, this
  * is due to `min-bid` setting on the mev-boost side but in rare cases could
@@ -71,7 +88,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
   readonly registrations: ValidatorRegistrationCache;
   readonly issueLocalFcUWithFeeRecipient?: string;
   // Builder needs to be explicity enabled using updateStatus
-  status = false;
+  status = BuilderStatus.disabled;
   faultInspectionWindow: number;
   allowedFaults: number;
 
@@ -119,21 +136,23 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
     );
     // allowedFaults should be < faultInspectionWindow, limiting them to faultInspectionWindow/2
     this.allowedFaults = Math.min(
-      opts.allowedFaults ?? Math.floor(this.faultInspectionWindow / 2),
-      Math.floor(this.faultInspectionWindow / 2)
+      opts.allowedFaults ?? Math.floor(this.faultInspectionWindow / 4),
+      Math.floor(this.faultInspectionWindow / 4)
     );
   }
 
-  updateStatus(shouldEnable: boolean): void {
-    this.status = shouldEnable;
+  updateStatus(status: BuilderStatus): void {
+    this.status = status;
   }
 
   async checkStatus(): Promise<void> {
     try {
       (await this.api.status()).assertOk();
     } catch (e) {
-      // Disable if the status was enabled
-      this.status = false;
+      if (this.status === BuilderStatus.enabled) {
+        // Disable if the status was enabled
+        this.status = BuilderStatus.disabled;
+      }
       throw e;
     }
   }

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -134,7 +134,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
       opts.faultInspectionWindow ?? SLOTS_PER_EPOCH + Math.floor(Math.random() * SLOTS_PER_EPOCH),
       SLOTS_PER_EPOCH
     );
-    // allowedFaults should be < faultInspectionWindow, limiting them to faultInspectionWindow/2
+    // allowedFaults should be < faultInspectionWindow, limiting them to faultInspectionWindow/4
     this.allowedFaults = Math.min(
       opts.allowedFaults ?? Math.floor(this.faultInspectionWindow / 4),
       Math.floor(this.faultInspectionWindow / 4)

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -126,7 +126,7 @@ export class ExecutionBuilderHttp implements IExecutionBuilder {
      * Beacon clients select randomized values from the following ranges when initializing
      * the circuit breaker (so at boot time and once for each unique boot).
      *
-     * ALLOWED_FAULTS: between 1 and SLOTS_PER_EPOCH // 2
+     * ALLOWED_FAULTS: between 1 and SLOTS_PER_EPOCH // 4
      * FAULT_INSPECTION_WINDOW: between SLOTS_PER_EPOCH and 2 * SLOTS_PER_EPOCH
      *
      */

--- a/packages/beacon-node/src/execution/builder/http.ts
+++ b/packages/beacon-node/src/execution/builder/http.ts
@@ -48,7 +48,7 @@ export enum BuilderStatus {
    */
   enabled = "enabled",
   /**
-   * Builder is disabled due to failed status checks
+   * Builder is disabled due to failed status check
    */
   disabled = "disabled",
   /**

--- a/packages/beacon-node/src/execution/builder/interface.ts
+++ b/packages/beacon-node/src/execution/builder/interface.ts
@@ -14,6 +14,7 @@ import {
   electra,
 } from "@lodestar/types";
 import {ValidatorRegistration} from "./cache.js";
+import {BuilderStatus} from "./http.js";
 
 export interface IExecutionBuilder {
   /**
@@ -22,13 +23,13 @@ export interface IExecutionBuilder {
    * fetch
    */
   readonly issueLocalFcUWithFeeRecipient?: string;
-  status: boolean;
+  status: BuilderStatus;
   /** Window to inspect missed slots for enabling/disabling builder circuit breaker */
   faultInspectionWindow: number;
   /** Number of missed slots allowed in the faultInspectionWindow for builder circuit*/
   allowedFaults: number;
 
-  updateStatus(shouldEnable: boolean): void;
+  updateStatus(status: BuilderStatus): void;
   checkStatus(): Promise<void>;
   registerValidator(epoch: Epoch, registrations: bellatrix.SignedValidatorRegistrationV1[]): Promise<void>;
   getValidatorRegistration(pubkey: BLSPubkey): ValidatorRegistration | undefined;

--- a/packages/beacon-node/test/sim/mergemock.test.ts
+++ b/packages/beacon-node/test/sim/mergemock.test.ts
@@ -11,6 +11,7 @@ import {afterAll, afterEach, describe, it, vi} from "vitest";
 
 import {BeaconRestApiServerOpts} from "../../src/api/index.js";
 import {ZERO_HASH} from "../../src/constants/index.js";
+import {BuilderStatus} from "../../src/execution/builder/http.js";
 import {Eth1Provider} from "../../src/index.js";
 import {ClockEvent} from "../../src/util/clock.js";
 import {TestLoggerOpts, testLogger} from "../utils/logger.js";
@@ -152,7 +153,7 @@ describe("executionEngine / ExecutionEngineHttp", () => {
           url: ethRpcUrl,
           enabled: true,
           issueLocalFcUWithFeeRecipient: feeRecipientMevBoost,
-          allowedFaults: 16,
+          allowedFaults: 8,
           faultInspectionWindow: 32,
         },
         chain: {suggestedFeeRecipient: feeRecipientLocal},
@@ -166,7 +167,7 @@ describe("executionEngine / ExecutionEngineHttp", () => {
       throw Error("executionBuilder should have been initialized");
     }
     // Enable builder by default, else because of circuit breaker we always start it with disabled
-    bn.chain.executionBuilder.updateStatus(true);
+    bn.chain.executionBuilder.updateStatus(BuilderStatus.enabled);
 
     afterEachCallbacks.push(async () => {
       await bn.close();

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -10,6 +10,7 @@ import {getValidatorApi} from "../../../../../src/api/impl/validator/index.js";
 import {defaultApiOptions} from "../../../../../src/api/options.js";
 import {BeaconChain} from "../../../../../src/chain/chain.js";
 import {BlockType, produceBlockBody} from "../../../../../src/chain/produceBlock/index.js";
+import {BuilderStatus} from "../../../../../src/execution/builder/http.js";
 import {PayloadIdCache} from "../../../../../src/execution/index.js";
 import {SyncState} from "../../../../../src/sync/interface.js";
 import {toGraffitiBytes} from "../../../../../src/util/graffiti.js";
@@ -35,7 +36,7 @@ describe("api/validator - produceBlockV3", () => {
     api = getValidatorApi(defaultApiOptions, {...modules, config});
     state = generateCachedBellatrixState();
 
-    modules.chain.executionBuilder.status = true;
+    modules.chain.executionBuilder.status = BuilderStatus.enabled;
   });
 
   afterEach(() => {

--- a/packages/cli/src/options/beaconNodeOptions/builder.ts
+++ b/packages/cli/src/options/beaconNodeOptions/builder.ts
@@ -28,7 +28,7 @@ export function parseArgs(args: ExecutionBuilderArgs): IBeaconNodeOptions["execu
 
 export const options: CliCommandOptions<ExecutionBuilderArgs> = {
   builder: {
-    description: "Enable builder interface",
+    description: "Enable external builder",
     type: "boolean",
     default: defaultExecutionBuilderHttpOpts.enabled,
     group: "builder",

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -63,7 +63,7 @@ describe("options / beaconNodeOptions", () => {
       "builder.url": "http://localhost:8661",
       "builder.timeout": 12000,
       "builder.faultInspectionWindow": 32,
-      "builder.allowedFaults": 16,
+      "builder.allowedFaults": 8,
 
       metrics: true,
       "metrics.port": 8765,
@@ -173,7 +173,7 @@ describe("options / beaconNodeOptions", () => {
         url: "http://localhost:8661",
         timeout: 12000,
         faultInspectionWindow: 32,
-        allowedFaults: 16,
+        allowedFaults: 8,
       },
       metrics: {
         enabled: true,


### PR DESCRIPTION
**Motivation**

- Closes https://github.com/ChainSafe/lodestar/issues/7802

**Description**

- makes builder circuit breaker stricter, from previous 50% of blocks missed down to 25%
- differentiate builder disabled due to failed status check vs. circuit breaker activated
- updating wording in logs/errors `Execution builder` --> `External builder`
