### PR TITLE
feat: improve the db storage for data column sidecar 

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -653,9 +653,9 @@ export function getBeaconBlockApi({
           );
         }
 
-        let {dataColumnSidecars} = (await db.dataColumnSidecars.get(blockRoot)) ?? {};
+        let dataColumnSidecars = await db.dataColumnSidecar.values(blockRoot);
         if (!dataColumnSidecars) {
-          ({dataColumnSidecars} = (await db.dataColumnSidecarsArchive.get(block.message.slot)) ?? {});
+          dataColumnSidecars = await db.dataColumnSidecarArchive.values(block.message.slot);
         }
 
         if (!dataColumnSidecars) {

--- a/packages/beacon-node/src/api/impl/debug/index.ts
+++ b/packages/beacon-node/src/api/impl/debug/index.ts
@@ -96,9 +96,9 @@ export function getDebugApi({
       const {block, executionOptimistic, finalized} = await getBlockResponse(chain, blockId);
       const blockRoot = config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
 
-      let {dataColumnSidecars} = (await db.dataColumnSidecars.get(blockRoot)) ?? {};
+      let dataColumnSidecars = await db.dataColumnSidecar.values(blockRoot);
       if (!dataColumnSidecars) {
-        ({dataColumnSidecars} = (await db.dataColumnSidecarsArchive.get(block.message.slot)) ?? {});
+        dataColumnSidecars = await db.dataColumnSidecarArchive.values(block.message.slot);
       }
 
       if (!dataColumnSidecars) {

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -299,6 +299,7 @@ async function migrateBlobSidecarsFromHotToColdDb(
   return migratedWrappedBlobSidecars;
 }
 
+// TODO: This function can be simplified further by reducing layers of promises in a loop
 async function migrateDataColumnSidecarsFromHotToColdDb(
   config: ChainForkConfig,
   db: IBeaconDb,
@@ -320,9 +321,9 @@ async function migrateDataColumnSidecarsFromHotToColdDb(
       const blockEpoch = computeEpochAtSlot(blockSlot);
 
       if (
-        config.getForkSeq(blockSlot) >= ForkSeq.fulu &&
+        config.getForkSeq(blockSlot) < ForkSeq.fulu ||
         // if block is out of ${config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS}, skip this step
-        blockEpoch >= currentEpoch - config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS
+        blockEpoch < currentEpoch - config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS
       ) {
         continue;
       }

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -137,7 +137,7 @@ export async function archiveBlocks(
     }
 
     if (finalizedPostFulu) {
-      await db.dataColumnSidecars.batchDelete(nonCanonicalBlockRoots);
+      await db.dataColumnSidecar.deleteMany(nonCanonicalBlockRoots);
       logger.verbose("Deleted non canonical dataColumnSidecars from hot DB");
     }
   }
@@ -173,11 +173,14 @@ export async function archiveBlocks(
       );
       const dataColumnSidecarsMinEpoch = currentEpoch - dataColumnSidecarsArchiveWindow;
       if (dataColumnSidecarsMinEpoch >= config.FULU_FORK_EPOCH) {
-        const slotsToDelete = await db.dataColumnSidecarsArchive.keys({
-          lt: computeStartSlotAtEpoch(dataColumnSidecarsMinEpoch),
-        });
+        const slotsToDelete = (
+          await db.dataColumnSidecarArchive.keys({
+            lt: db.dataColumnSidecarArchive.getMaxKeyRaw(computeStartSlotAtEpoch(dataColumnSidecarsMinEpoch)),
+          })
+        ).map((p) => p.prefix);
+
         if (slotsToDelete.length > 0) {
-          await db.dataColumnSidecarsArchive.batchDelete(slotsToDelete);
+          await db.dataColumnSidecarArchive.deleteMany(slotsToDelete);
           logger.verbose(`dataColumnSidecars prune: batchDelete range ${slotsToDelete[0]}..${slotsToDelete.at(-1)}`);
         } else {
           logger.verbose(`dataColumnSidecars prune: no entries before epoch ${dataColumnSidecarsMinEpoch}`);
@@ -309,34 +312,38 @@ async function migrateDataColumnSidecarsFromHotToColdDb(
 
     // processCanonicalBlocks
     if (canonicalBlocks.length === 0) break;
+    const promises = [];
 
     // load Buffer instead of ssz deserialized to improve performance
-    const canonicalDataColumnSidecarsEntries: KeyValue<Slot, Uint8Array>[] = await Promise.all(
-      canonicalBlocks
-        .filter((block) => {
-          const blockSlot = block.slot;
-          const blockEpoch = computeEpochAtSlot(blockSlot);
-          return (
-            config.getForkSeq(blockSlot) >= ForkSeq.fulu &&
-            // if block is out of ${config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS}, skip this step
-            blockEpoch >= currentEpoch - config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS
-          );
-        })
-        .map(async (block) => {
-          const bytes = await db.dataColumnSidecars.getBinary(block.root);
-          if (!bytes) {
-            throw Error(`No dataColumnSidecars found for slot ${block.slot} root ${toHex(block.root)}`);
-          }
-          return {key: block.slot, value: bytes};
-        })
-    );
+    for (const block of canonicalBlocks) {
+      const blockSlot = block.slot;
+      const blockEpoch = computeEpochAtSlot(blockSlot);
+
+      if (
+        config.getForkSeq(blockSlot) >= ForkSeq.fulu &&
+        // if block is out of ${config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS}, skip this step
+        blockEpoch >= currentEpoch - config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS
+      ) {
+        continue;
+      }
+
+      const dataColumnSidecarBytes = await db.dataColumnSidecar.valuesBinary(block.root);
+      if (!dataColumnSidecarBytes) {
+        throw Error(`No dataColumnSidecars found for slot ${block.slot} root ${toHex(block.root)}`);
+      }
+      promises.push(
+        db.dataColumnSidecarArchive.putManyBinary(
+          block.slot,
+          dataColumnSidecarBytes.map((p) => ({key: p.id, value: p.value}))
+        )
+      );
+      migratedWrappedDataColumns += dataColumnSidecarBytes.length;
+    }
+
+    promises.push(db.dataColumnSidecar.deleteMany(canonicalBlocks.map((block) => block.root)));
 
     // put to blockArchive db and delete block db
-    await Promise.all([
-      db.dataColumnSidecarsArchive.batchPutBinary(canonicalDataColumnSidecarsEntries),
-      db.dataColumnSidecars.batchDelete(canonicalBlocks.map((block) => block.root)),
-    ]);
-    migratedWrappedDataColumns += canonicalDataColumnSidecarsEntries.length;
+    await Promise.all(promises);
   }
 
   return migratedWrappedDataColumns;

--- a/packages/beacon-node/src/db/beacon.ts
+++ b/packages/beacon-node/src/db/beacon.ts
@@ -12,8 +12,8 @@ import {
   BlockArchiveRepository,
   BlockRepository,
   CheckpointHeaderRepository,
-  DataColumnSidecarsArchiveRepository,
-  DataColumnSidecarsRepository,
+  DataColumnSidecarArchiveRepository,
+  DataColumnSidecarRepository,
   DepositDataRootRepository,
   DepositEventRepository,
   Eth1DataRepository,
@@ -36,8 +36,8 @@ export class BeaconDb implements IBeaconDb {
 
   blobSidecars: BlobSidecarsRepository;
   blobSidecarsArchive: BlobSidecarsArchiveRepository;
-  dataColumnSidecars: DataColumnSidecarsRepository;
-  dataColumnSidecarsArchive: DataColumnSidecarsArchiveRepository;
+  dataColumnSidecar: DataColumnSidecarRepository;
+  dataColumnSidecarArchive: DataColumnSidecarArchiveRepository;
 
   stateArchive: StateArchiveRepository;
   checkpointState: CheckpointStateRepository;
@@ -71,8 +71,8 @@ export class BeaconDb implements IBeaconDb {
 
     this.blobSidecars = new BlobSidecarsRepository(config, db);
     this.blobSidecarsArchive = new BlobSidecarsArchiveRepository(config, db);
-    this.dataColumnSidecars = new DataColumnSidecarsRepository(config, db);
-    this.dataColumnSidecarsArchive = new DataColumnSidecarsArchiveRepository(config, db);
+    this.dataColumnSidecar = new DataColumnSidecarRepository(config, db);
+    this.dataColumnSidecarArchive = new DataColumnSidecarArchiveRepository(config, db);
 
     this.stateArchive = new StateArchiveRepository(config, db);
     this.checkpointState = new CheckpointStateRepository(config, db);

--- a/packages/beacon-node/src/db/interface.ts
+++ b/packages/beacon-node/src/db/interface.ts
@@ -10,8 +10,8 @@ import {
   BlockArchiveRepository,
   BlockRepository,
   CheckpointHeaderRepository,
-  DataColumnSidecarsArchiveRepository,
-  DataColumnSidecarsRepository,
+  DataColumnSidecarArchiveRepository,
+  DataColumnSidecarRepository,
   DepositDataRootRepository,
   DepositEventRepository,
   Eth1DataRepository,
@@ -36,8 +36,8 @@ export interface IBeaconDb {
 
   blobSidecars: BlobSidecarsRepository;
   blobSidecarsArchive: BlobSidecarsArchiveRepository;
-  dataColumnSidecars: DataColumnSidecarsRepository;
-  dataColumnSidecarsArchive: DataColumnSidecarsArchiveRepository;
+  dataColumnSidecar: DataColumnSidecarRepository;
+  dataColumnSidecarArchive: DataColumnSidecarArchiveRepository;
 
   // finalized states
   stateArchive: StateArchiveRepository;

--- a/packages/beacon-node/src/db/repositories/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/db/repositories/dataColumnSidecar.ts
@@ -1,4 +1,3 @@
-import {ByteArray} from "@chainsafe/ssz/lib/type/byteArray.js";
 import {ChainForkConfig} from "@lodestar/config";
 import {Db, PrefixedRepository} from "@lodestar/db";
 import {NUMBER_OF_COLUMNS} from "@lodestar/params";

--- a/packages/beacon-node/src/db/repositories/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/db/repositories/dataColumnSidecar.ts
@@ -1,3 +1,4 @@
+import {ByteArray} from "@chainsafe/ssz/lib/type/byteArray.js";
 import {ChainForkConfig} from "@lodestar/config";
 import {Db, PrefixedRepository} from "@lodestar/db";
 import {NUMBER_OF_COLUMNS} from "@lodestar/params";
@@ -26,21 +27,22 @@ export class DataColumnSidecarRepository extends PrefixedRepository<BlockRoot, C
     return value.index;
   }
 
-  protected encodeKeyRaw(prefix: BlockRoot, id: ColumnIndex): Uint8Array {
+  encodeKeyRaw(prefix: BlockRoot, id: ColumnIndex): Uint8Array {
     return Buffer.concat([prefix, intToBytes(id, 4)]);
   }
 
-  protected decodeKeyRaw(raw: Uint8Array): {prefix: BlockRoot; id: ColumnIndex} {
+  decodeKeyRaw(raw: Uint8Array): {prefix: BlockRoot; id: ColumnIndex} {
     return {
       prefix: raw.slice(0, 32) as BlockRoot,
       id: bytesToInt(raw.slice(32, 36)) as ColumnIndex,
     };
   }
 
-  protected rangeForPrefixRaw(prefix: BlockRoot): {gte: Uint8Array; lt: Uint8Array} {
-    return {
-      gte: Buffer.concat([prefix, intToBytes(0, 4)]),
-      lt: Buffer.concat([prefix, intToBytes(NUMBER_OF_COLUMNS, 4)]),
-    };
+  getMaxKeyRaw(prefix: BlockRoot): Uint8Array {
+    return Buffer.concat([prefix, intToBytes(NUMBER_OF_COLUMNS, 4)]);
+  }
+
+  getMinKeyRaw(prefix: BlockRoot): Uint8Array {
+    return Buffer.concat([prefix, intToBytes(0, 4)]);
   }
 }

--- a/packages/beacon-node/src/db/repositories/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/db/repositories/dataColumnSidecar.ts
@@ -13,7 +13,7 @@ type BlockRoot = Root;
  *
  * Indexed data by `blockRoot` + `columnIndex`
  */
-export class DataColumnSidecarsRepository extends PrefixedRepository<BlockRoot, ColumnIndex, fulu.DataColumnSidecar> {
+export class DataColumnSidecarRepository extends PrefixedRepository<BlockRoot, ColumnIndex, fulu.DataColumnSidecar> {
   constructor(config: ChainForkConfig, db: Db) {
     const bucket = Bucket.allForks_dataColumnSidecars;
     super(config, db, bucket, ssz.fulu.DataColumnSidecar, getBucketNameByValue(bucket));

--- a/packages/beacon-node/src/db/repositories/dataColumnSidecarArchive.ts
+++ b/packages/beacon-node/src/db/repositories/dataColumnSidecarArchive.ts
@@ -11,7 +11,7 @@ import {Bucket, getBucketNameByValue} from "../buckets.js";
  *
  * Indexed data by `slot` + `columnIndex`
  */
-export class DataColumnSidecarsArchiveRepository extends PrefixedRepository<Slot, ColumnIndex, fulu.DataColumnSidecar> {
+export class DataColumnSidecarArchiveRepository extends PrefixedRepository<Slot, ColumnIndex, fulu.DataColumnSidecar> {
   constructor(config: ChainForkConfig, db: Db) {
     const bucket = Bucket.allForks_dataColumnSidecars;
     super(config, db, bucket, ssz.fulu.DataColumnSidecar, getBucketNameByValue(bucket));

--- a/packages/beacon-node/src/db/repositories/dataColumnSidecarArchive.ts
+++ b/packages/beacon-node/src/db/repositories/dataColumnSidecarArchive.ts
@@ -24,21 +24,22 @@ export class DataColumnSidecarArchiveRepository extends PrefixedRepository<Slot,
     return value.index;
   }
 
-  protected encodeKeyRaw(prefix: Slot, id: ColumnIndex): Uint8Array {
+  encodeKeyRaw(prefix: Slot, id: ColumnIndex): Uint8Array {
     return Buffer.concat([intToBytes(prefix, 4), intToBytes(id, 4)]);
   }
 
-  protected decodeKeyRaw(raw: Uint8Array): {prefix: Slot; id: ColumnIndex} {
+  decodeKeyRaw(raw: Uint8Array): {prefix: Slot; id: ColumnIndex} {
     return {
       prefix: bytesToInt(raw.slice(0, 4)) as Slot,
       id: bytesToInt(raw.slice(4, 8)) as ColumnIndex,
     };
   }
 
-  protected rangeForPrefixRaw(prefix: Slot): {gte: Uint8Array; lt: Uint8Array} {
-    return {
-      gte: Buffer.concat([intToBytes(prefix, 4), intToBytes(0, 4)]),
-      lt: Buffer.concat([intToBytes(prefix, 4), intToBytes(NUMBER_OF_COLUMNS, 4)]),
-    };
+  getMaxKeyRaw(prefix: Slot): Uint8Array {
+    return Buffer.concat([intToBytes(prefix, 4), intToBytes(NUMBER_OF_COLUMNS, 4)]);
+  }
+
+  getMinKeyRaw(prefix: Slot): Uint8Array {
+    return Buffer.concat([intToBytes(prefix, 4), intToBytes(0, 4)]);
   }
 }

--- a/packages/beacon-node/src/db/repositories/dataColumnSidecars.ts
+++ b/packages/beacon-node/src/db/repositories/dataColumnSidecars.ts
@@ -1,49 +1,46 @@
-import {ByteVectorType, ContainerType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {Db, Repository} from "@lodestar/db";
+import {Db, PrefixedRepository} from "@lodestar/db";
 import {NUMBER_OF_COLUMNS} from "@lodestar/params";
-import {ssz} from "@lodestar/types";
-
+import {ColumnIndex, Root, fulu, ssz} from "@lodestar/types";
+import {bytesToInt, intToBytes} from "@lodestar/utils";
 import {Bucket, getBucketNameByValue} from "../buckets.js";
 
-export const dataColumnSidecarsWrapperSsz = new ContainerType(
-  {
-    blockRoot: ssz.Root,
-    slot: ssz.Slot,
-    dataColumnsLen: ssz.Uint8,
-    dataColumnsSize: ssz.UintNum64,
-    // // each byte[i] tells what index (1 based) the column i is stored, 0 means not custodied
-    // max value to represent will be 128 which can be represented in a byte
-    dataColumnsIndex: new ByteVectorType(NUMBER_OF_COLUMNS),
-    dataColumnSidecars: ssz.fulu.DataColumnSidecars,
-  },
-  {typeName: "DataColumnSidecarsWrapper", jsonCase: "eth2"}
-);
-
-export type DataColumnSidecarsWrapper = ValueOf<typeof dataColumnSidecarsWrapperSsz>;
-export const BLOCK_ROOT_IN_WRAPPER_INDEX = 0;
-export const BLOCK_SLOT_IN_WRAPPER_INDEX = 32;
-export const NUM_COLUMNS_IN_WRAPPER_INDEX = 40;
-export const COLUMN_SIZE_IN_WRAPPER_INDEX = 41;
-export const CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX = 49;
-export const DATA_COLUMN_SIDECARS_IN_WRAPPER_INDEX = CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX + NUMBER_OF_COLUMNS + 4;
+type BlockRoot = Root;
 
 /**
- * dataColumnSidecarsWrapper by block root (= hash_tree_root(SignedBeaconBlock.message))
+ * DataColumnSidecarsRepository
+ * Used to store `unfinalized` DataColumnSidecars
  *
- * Used to store unfinalized DataColumnSidecars
+ * Indexed data by `blockRoot` + `columnIndex`
  */
-export class DataColumnSidecarsRepository extends Repository<Uint8Array, DataColumnSidecarsWrapper> {
+export class DataColumnSidecarsRepository extends PrefixedRepository<BlockRoot, ColumnIndex, fulu.DataColumnSidecar> {
   constructor(config: ChainForkConfig, db: Db) {
     const bucket = Bucket.allForks_dataColumnSidecars;
-    super(config, db, bucket, dataColumnSidecarsWrapperSsz, getBucketNameByValue(bucket));
+    super(config, db, bucket, ssz.fulu.DataColumnSidecar, getBucketNameByValue(bucket));
   }
 
   /**
    * Id is hashTreeRoot of unsigned BeaconBlock
    */
-  getId(value: DataColumnSidecarsWrapper): Uint8Array {
-    const {blockRoot} = value;
-    return blockRoot;
+  getId(value: fulu.DataColumnSidecar): ColumnIndex {
+    return value.index;
+  }
+
+  protected encodeKeyRaw(prefix: BlockRoot, id: ColumnIndex): Uint8Array {
+    return Buffer.concat([prefix, intToBytes(id, 4)]);
+  }
+
+  protected decodeKeyRaw(raw: Uint8Array): {prefix: BlockRoot; id: ColumnIndex} {
+    return {
+      prefix: raw.slice(0, 32) as BlockRoot,
+      id: bytesToInt(raw.slice(32, 36)) as ColumnIndex,
+    };
+  }
+
+  protected rangeForPrefixRaw(prefix: BlockRoot): {gte: Uint8Array; lt: Uint8Array} {
+    return {
+      gte: Buffer.concat([prefix, intToBytes(0, 4)]),
+      lt: Buffer.concat([prefix, intToBytes(NUMBER_OF_COLUMNS, 4)]),
+    };
   }
 }

--- a/packages/beacon-node/src/db/repositories/dataColumnSidecarsArchive.ts
+++ b/packages/beacon-node/src/db/repositories/dataColumnSidecarsArchive.ts
@@ -1,28 +1,44 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Db, Repository} from "@lodestar/db";
-import {Slot} from "@lodestar/types";
-import {bytesToInt} from "@lodestar/utils";
+import {Db, PrefixedRepository} from "@lodestar/db";
+import {NUMBER_OF_COLUMNS} from "@lodestar/params";
+import {ColumnIndex, Slot, fulu, ssz} from "@lodestar/types";
+import {bytesToInt, intToBytes} from "@lodestar/utils";
 import {Bucket, getBucketNameByValue} from "../buckets.js";
-import {DataColumnSidecarsWrapper, dataColumnSidecarsWrapperSsz} from "./dataColumnSidecars.js";
 
 /**
- * dataColumnSidecarsWrapper by slot
+ * DataColumnSidecarsRepository
+ * Used to store `finalized` DataColumnSidecars
  *
- * Used to store finalized DataColumnSidecars
+ * Indexed data by `slot` + `columnIndex`
  */
-export class DataColumnSidecarsArchiveRepository extends Repository<Slot, DataColumnSidecarsWrapper> {
+export class DataColumnSidecarsArchiveRepository extends PrefixedRepository<Slot, ColumnIndex, fulu.DataColumnSidecar> {
   constructor(config: ChainForkConfig, db: Db) {
-    const bucket = Bucket.allForks_dataColumnSidecarsArchive;
-    super(config, db, bucket, dataColumnSidecarsWrapperSsz, getBucketNameByValue(bucket));
+    const bucket = Bucket.allForks_dataColumnSidecars;
+    super(config, db, bucket, ssz.fulu.DataColumnSidecar, getBucketNameByValue(bucket));
   }
 
-  // Handle key as slot
-
-  getId(value: DataColumnSidecarsWrapper): Slot {
-    return value.slot;
+  /**
+   * Id is hashTreeRoot of unsigned BeaconBlock
+   */
+  getId(value: fulu.DataColumnSidecar): ColumnIndex {
+    return value.index;
   }
 
-  decodeKey(data: Uint8Array): number {
-    return bytesToInt(super.decodeKey(data) as unknown as Uint8Array, "be");
+  protected encodeKeyRaw(prefix: Slot, id: ColumnIndex): Uint8Array {
+    return Buffer.concat([intToBytes(prefix, 4), intToBytes(id, 4)]);
+  }
+
+  protected decodeKeyRaw(raw: Uint8Array): {prefix: Slot; id: ColumnIndex} {
+    return {
+      prefix: bytesToInt(raw.slice(0, 4)) as Slot,
+      id: bytesToInt(raw.slice(4, 8)) as ColumnIndex,
+    };
+  }
+
+  protected rangeForPrefixRaw(prefix: Slot): {gte: Uint8Array; lt: Uint8Array} {
+    return {
+      gte: Buffer.concat([intToBytes(prefix, 4), intToBytes(0, 4)]),
+      lt: Buffer.concat([intToBytes(prefix, 4), intToBytes(NUMBER_OF_COLUMNS, 4)]),
+    };
   }
 }

--- a/packages/beacon-node/src/db/repositories/index.ts
+++ b/packages/beacon-node/src/db/repositories/index.ts
@@ -1,7 +1,7 @@
 export {BlobSidecarsRepository} from "./blobSidecars.js";
 export {BlobSidecarsArchiveRepository} from "./blobSidecarsArchive.js";
-export {DataColumnSidecarsRepository} from "./dataColumnSidecars.js";
-export {DataColumnSidecarsArchiveRepository} from "./dataColumnSidecarsArchive.js";
+export {DataColumnSidecarRepository} from "./dataColumnSidecar.js";
+export {DataColumnSidecarArchiveRepository} from "./dataColumnSidecarArchive.js";
 
 export {BlockRepository} from "./block.js";
 export {BlockArchiveRepository} from "./blockArchive.js";

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
@@ -1,16 +1,10 @@
-import {GENESIS_SLOT, MAX_REQUEST_BLOCKS_DENEB, NUMBER_OF_COLUMNS} from "@lodestar/params";
+import {GENESIS_SLOT, MAX_REQUEST_BLOCKS_DENEB} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
-import {ColumnIndex, Slot, fulu, ssz} from "@lodestar/types";
+import {fulu} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
 import {IBeaconDb} from "../../../db/index.js";
-import {
-  COLUMN_SIZE_IN_WRAPPER_INDEX,
-  CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX,
-  DATA_COLUMN_SIDECARS_IN_WRAPPER_INDEX,
-  NUM_COLUMNS_IN_WRAPPER_INDEX,
-} from "../../../db/repositories/dataColumnSidecar.js";
 
 export async function* onDataColumnSidecarsByRange(
   request: fulu.DataColumnSidecarsByRangeRequest,
@@ -21,22 +15,26 @@ export async function* onDataColumnSidecarsByRange(
   const {startSlot, count, columns} = validateDataColumnSidecarsByRangeRequest(request);
   const endSlot = startSlot + count;
 
-  const finalized = db.dataColumnSidecarsArchive;
-  const unfinalized = db.dataColumnSidecars;
+  const finalized = db.dataColumnSidecarArchive;
+  const unfinalized = db.dataColumnSidecar;
   const finalizedSlot = chain.forkChoice.getFinalizedBlock().slot;
 
   // Finalized range of columns
   if (startSlot <= finalizedSlot) {
-    for await (const {key, value: dataColumnSideCarsBytesWrapped} of finalized.binaryEntriesStream({
-      gte: startSlot,
-      lt: endSlot,
-    })) {
-      yield* iterateDataColumnBytesFromWrapper(
-        chain,
-        dataColumnSideCarsBytesWrapped,
-        finalized.decodeKey(key),
-        columns
-      );
+    for (let slot = startSlot; slot < endSlot; slot++) {
+      for (const {id: columnIndex, value: dataColumnSidecarBytes} of await finalized.getManyBinary(slot, columns)) {
+        if (!dataColumnSidecarBytes) {
+          throw new ResponseError(
+            RespStatus.SERVER_ERROR,
+            `No finalized dataColumnSidecar found for slot=${slot}, index=${columnIndex}`
+          );
+        }
+
+        yield {
+          data: dataColumnSidecarBytes,
+          boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(slot)),
+        };
+      }
     }
   }
 
@@ -55,13 +53,22 @@ export async function* onDataColumnSidecarsByRange(
         // at the time of the start of the request. Spec is clear the chain of columns must be consistent, but on
         // re-org there's no need to abort the request
         // Spec: https://github.com/ethereum/consensus-specs/blob/ad36024441cf910d428d03f87f331fbbd2b3e5f1/specs/fulu/p2p-interface.md#L425-L429
+        for (const {id: columnIndex, value: dataColumnSidecarBytes} of await unfinalized.getManyBinary(
+          fromHex(block.blockRoot),
+          columns
+        )) {
+          if (!dataColumnSidecarBytes) {
+            throw new ResponseError(
+              RespStatus.SERVER_ERROR,
+              `No unfinalized dataColumnSidecar found for root=${block.blockRoot}, index=${columnIndex}`
+            );
+          }
 
-        const dataColumnSidecarsBytesWrapped = await unfinalized.getBinary(fromHex(block.blockRoot));
-        if (!dataColumnSidecarsBytesWrapped) {
-          // Handle the same to onBeaconBlocksByRange
-          throw new ResponseError(RespStatus.SERVER_ERROR, `No item for root ${block.blockRoot} slot ${block.slot}`);
+          yield {
+            data: dataColumnSidecarBytes,
+            boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(block.slot)),
+          };
         }
-        yield* iterateDataColumnBytesFromWrapper(chain, dataColumnSidecarsBytesWrapped, block.slot, columns);
       }
 
       // If block is after endSlot, stop iterating
@@ -69,61 +76,6 @@ export async function* onDataColumnSidecarsByRange(
         break;
       }
     }
-  }
-}
-
-export function* iterateDataColumnBytesFromWrapper(
-  chain: IBeaconChain,
-  dataColumnSidecarsBytesWrapped: Uint8Array,
-  blockSlot: Slot,
-  columns: ColumnIndex[]
-): Iterable<ResponseOutgoing> {
-  const retrivedColumnsLen = ssz.Uint8.deserialize(
-    dataColumnSidecarsBytesWrapped.slice(NUM_COLUMNS_IN_WRAPPER_INDEX, COLUMN_SIZE_IN_WRAPPER_INDEX)
-  );
-  const retrievedColumnsSizeBytes = dataColumnSidecarsBytesWrapped.slice(
-    COLUMN_SIZE_IN_WRAPPER_INDEX,
-    CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX
-  );
-  const columnsSize = ssz.UintNum64.deserialize(retrievedColumnsSizeBytes);
-  const dataColumnsIndex = dataColumnSidecarsBytesWrapped.slice(
-    CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX,
-    CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX + NUMBER_OF_COLUMNS
-  );
-  const allDataColumnSidecarsBytes = dataColumnSidecarsBytesWrapped.slice(
-    DATA_COLUMN_SIDECARS_IN_WRAPPER_INDEX + 4 * retrivedColumnsLen
-  );
-
-  const columnsLen = allDataColumnSidecarsBytes.length / columnsSize;
-
-  // no columns possibly no blobs
-  if (columnsLen === 0) {
-    return;
-  }
-
-  for (const index of columns) {
-    // get the index at which the column is
-    const dataIndex = (dataColumnsIndex[index] ?? 0) - 1;
-    if (dataIndex < 0) {
-      throw new ResponseError(
-        RespStatus.SERVER_ERROR,
-        `dataColumnSidecar index=${index} dataIndex=${dataIndex} not custodied`
-      );
-    }
-    const dataColumnSidecarBytes = allDataColumnSidecarsBytes.slice(
-      dataIndex * columnsSize,
-      (dataIndex + 1) * columnsSize
-    );
-    if (dataColumnSidecarBytes.length !== columnsSize) {
-      throw new ResponseError(
-        RespStatus.SERVER_ERROR,
-        `Invalid dataColumnSidecar index=${index} dataIndex=${dataIndex} bytes length=${dataColumnSidecarBytes.length} expected=${columnsSize} for slot ${blockSlot} blobsLen=${columnsLen}`
-      );
-    }
-    yield {
-      data: dataColumnSidecarBytes,
-      boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(blockSlot)),
-    };
   }
 }
 

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
@@ -10,7 +10,7 @@ import {
   CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX,
   DATA_COLUMN_SIDECARS_IN_WRAPPER_INDEX,
   NUM_COLUMNS_IN_WRAPPER_INDEX,
-} from "../../../db/repositories/dataColumnSidecars.js";
+} from "../../../db/repositories/dataColumnSidecar.js";
 
 export async function* onDataColumnSidecarsByRange(
   request: fulu.DataColumnSidecarsByRangeRequest,

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
@@ -22,11 +22,13 @@ export async function* onDataColumnSidecarsByRange(
   // Finalized range of columns
   if (startSlot <= finalizedSlot) {
     for (let slot = startSlot; slot < endSlot; slot++) {
-      for (const {id: columnIndex, value: dataColumnSidecarBytes} of await finalized.getManyBinary(slot, columns)) {
+      const dataColumnSidecars = await finalized.getManyBinary(slot, columns);
+
+      for (const [index, dataColumnSidecarBytes] of dataColumnSidecars.entries()) {
         if (!dataColumnSidecarBytes) {
           throw new ResponseError(
             RespStatus.SERVER_ERROR,
-            `No finalized dataColumnSidecar found for slot=${slot}, index=${columnIndex}`
+            `No finalized dataColumnSidecar found for slot=${slot}, index=${columns[index]}`
           );
         }
 
@@ -53,14 +55,12 @@ export async function* onDataColumnSidecarsByRange(
         // at the time of the start of the request. Spec is clear the chain of columns must be consistent, but on
         // re-org there's no need to abort the request
         // Spec: https://github.com/ethereum/consensus-specs/blob/ad36024441cf910d428d03f87f331fbbd2b3e5f1/specs/fulu/p2p-interface.md#L425-L429
-        for (const {id: columnIndex, value: dataColumnSidecarBytes} of await unfinalized.getManyBinary(
-          fromHex(block.blockRoot),
-          columns
-        )) {
+        const dataColumnSidecars = await unfinalized.getManyBinary(fromHex(block.blockRoot), columns);
+        for (const [index, dataColumnSidecarBytes] of dataColumnSidecars.entries()) {
           if (!dataColumnSidecarBytes) {
             throw new ResponseError(
               RespStatus.SERVER_ERROR,
-              `No unfinalized dataColumnSidecar found for root=${block.blockRoot}, index=${columnIndex}`
+              `No unfinalized dataColumnSidecar found for root=${block.blockRoot}, index=${columns[index]}`
             );
           }
 

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRoot.ts
@@ -1,16 +1,9 @@
-import {NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
-import {fulu, ssz} from "@lodestar/types";
+import {fulu} from "@lodestar/types";
 import {fromHex, toHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
 import {IBeaconDb} from "../../../db/index.js";
-import {
-  COLUMN_SIZE_IN_WRAPPER_INDEX,
-  CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX,
-  DATA_COLUMN_SIDECARS_IN_WRAPPER_INDEX,
-  NUM_COLUMNS_IN_WRAPPER_INDEX,
-} from "../../../db/repositories/dataColumnSidecar.js";
 
 export async function* onDataColumnSidecarsByRoot(
   requestBody: fulu.DataColumnSidecarsByRootRequest,
@@ -40,47 +33,18 @@ export async function* onDataColumnSidecarsByRoot(
       continue;
     }
 
-    const dataColumnSidecarsBytesWrapped = await db.dataColumnSidecars.getBinary(fromHex(block.blockRoot));
-    if (!dataColumnSidecarsBytesWrapped) {
-      // Handle the same to onBeaconBlocksByRange
-      throw new ResponseError(RespStatus.SERVER_ERROR, `No item for root ${block.blockRoot} slot ${block.slot}`);
+    const dataColumns = await db.dataColumnSidecar.getManyBinary(fromHex(block.blockRoot), columns);
+    if (!dataColumns) {
+      throw new ResponseError(RespStatus.SERVER_ERROR, `No item for root=${block.blockRoot}, slot=${block.slot}`);
     }
 
-    const retrivedColumnsLen = ssz.Uint8.deserialize(
-      dataColumnSidecarsBytesWrapped.slice(NUM_COLUMNS_IN_WRAPPER_INDEX, COLUMN_SIZE_IN_WRAPPER_INDEX)
-    );
-    const retrievedColumnsSizeBytes = dataColumnSidecarsBytesWrapped.slice(
-      COLUMN_SIZE_IN_WRAPPER_INDEX,
-      CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX
-    );
-    const columnsSize = ssz.UintNum64.deserialize(retrievedColumnsSizeBytes);
-    const dataColumnSidecarsBytes = dataColumnSidecarsBytesWrapped.slice(
-      DATA_COLUMN_SIDECARS_IN_WRAPPER_INDEX + 4 * retrivedColumnsLen
-    );
-
-    const dataColumnsIndex = dataColumnSidecarsBytesWrapped.slice(
-      CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX,
-      CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX + NUMBER_OF_COLUMNS
-    );
-
-    for (const index of columns) {
-      const dataIndex = (dataColumnsIndex[index] ?? 0) - 1;
-      if (dataIndex < 0) {
-        throw new ResponseError(RespStatus.SERVER_ERROR, `dataColumnSidecar index=${index} not custodied`);
-      }
-
-      const dataColumnSidecarBytes = dataColumnSidecarsBytes.slice(
-        dataIndex * columnsSize,
-        (dataIndex + 1) * columnsSize
-      );
-      if (dataColumnSidecarBytes.length !== columnsSize) {
-        throw Error(
-          `Inconsistent state, dataColumnSidecar blockRoot=${blockRootHex} index=${index} dataColumnSidecarBytes=${dataColumnSidecarBytes.length} expected=${columnsSize}`
-        );
+    for (const {id: columnIndex, value: dataColumnBytes} of dataColumns) {
+      if (columnIndex < 0 || !dataColumnBytes) {
+        throw new ResponseError(RespStatus.SERVER_ERROR, `dataColumnSidecar index=${columnIndex} not custodied`);
       }
 
       yield {
-        data: dataColumnSidecarBytes,
+        data: dataColumnBytes,
         boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(block.slot)),
       };
     }

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRoot.ts
@@ -38,9 +38,9 @@ export async function* onDataColumnSidecarsByRoot(
       throw new ResponseError(RespStatus.SERVER_ERROR, `No item for root=${block.blockRoot}, slot=${block.slot}`);
     }
 
-    for (const {id: columnIndex, value: dataColumnBytes} of dataColumns) {
-      if (columnIndex < 0 || !dataColumnBytes) {
-        throw new ResponseError(RespStatus.SERVER_ERROR, `dataColumnSidecar index=${columnIndex} not custodied`);
+    for (const [index, dataColumnBytes] of dataColumns.entries()) {
+      if (!dataColumnBytes) {
+        throw new ResponseError(RespStatus.SERVER_ERROR, `dataColumnSidecar index=${columns[index]} not custodied`);
       }
 
       yield {

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRoot.ts
@@ -10,7 +10,7 @@ import {
   CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX,
   DATA_COLUMN_SIDECARS_IN_WRAPPER_INDEX,
   NUM_COLUMNS_IN_WRAPPER_INDEX,
-} from "../../../db/repositories/dataColumnSidecars.js";
+} from "../../../db/repositories/dataColumnSidecar.js";
 
 export async function* onDataColumnSidecarsByRoot(
   requestBody: fulu.DataColumnSidecarsByRootRequest,

--- a/packages/beacon-node/test/mocks/mockedBeaconDb.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconDb.ts
@@ -8,8 +8,8 @@ import {
   BlobSidecarsRepository,
   BlockArchiveRepository,
   BlockRepository,
-  DataColumnSidecarsArchiveRepository,
-  DataColumnSidecarsRepository,
+  DataColumnSidecarArchiveRepository,
+  DataColumnSidecarRepository,
   DepositDataRootRepository,
   DepositEventRepository,
   Eth1DataRepository,
@@ -25,8 +25,8 @@ export type MockedBeaconDb = Mocked<BeaconDb> & {
   blobSidecars: Mocked<BlobSidecarsRepository>;
   blobSidecarsArchive: Mocked<BlobSidecarsArchiveRepository>;
 
-  dataColumnSidecars: Mocked<DataColumnSidecarsRepository>;
-  dataColumnSidecarsArchive: Mocked<DataColumnSidecarsArchiveRepository>;
+  dataColumnSidecar: Mocked<DataColumnSidecarRepository>;
+  dataColumnSidecarArchive: Mocked<DataColumnSidecarArchiveRepository>;
 
   stateArchive: Mocked<StateArchiveRepository>;
 
@@ -63,8 +63,8 @@ vi.mock("../../src/db/index.js", async (importActual) => {
       blobSidecars: vi.mocked(new BlobSidecarsRepository({} as any, {} as any)),
       blobSidecarsArchive: vi.mocked(new BlobSidecarsArchiveRepository({} as any, {} as any)),
 
-      dataColumnSidecars: vi.mocked(new DataColumnSidecarsRepository({} as any, {} as any)),
-      dataColumnSidecarsArchive: vi.mocked(new DataColumnSidecarsArchiveRepository({} as any, {} as any)),
+      dataColumnSidecar: vi.mocked(new DataColumnSidecarRepository({} as any, {} as any)),
+      dataColumnSidecarArchive: vi.mocked(new DataColumnSidecarArchiveRepository({} as any, {} as any)),
     };
   });
 

--- a/packages/beacon-node/test/unit/db/api/repositories/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repositories/dataColumn.test.ts
@@ -12,7 +12,7 @@ import {
   DataColumnSidecarsRepository,
   NUM_COLUMNS_IN_WRAPPER_INDEX,
   dataColumnSidecarsWrapperSsz,
-} from "../../../../../src/db/repositories/dataColumnSidecars.js";
+} from "../../../../../src/db/repositories/dataColumnSidecar.js";
 import {getDataColumnSidecarsFromBlock} from "../../../../../src/util/dataColumns.js";
 import {kzg} from "../../../../../src/util/kzg.js";
 import {testLogger} from "../../../../utils/logger.js";

--- a/packages/beacon-node/test/unit/db/api/repositories/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repositories/dataColumn.test.ts
@@ -1,18 +1,10 @@
 import {createChainForkConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db";
-import {NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
 import {rimraf} from "rimraf";
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
-
-import {
-  COLUMN_SIZE_IN_WRAPPER_INDEX,
-  CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX,
-  DATA_COLUMN_SIDECARS_IN_WRAPPER_INDEX,
-  DataColumnSidecarsRepository,
-  NUM_COLUMNS_IN_WRAPPER_INDEX,
-  dataColumnSidecarsWrapperSsz,
-} from "../../../../../src/db/repositories/dataColumnSidecar.js";
+import {DataColumnSidecarRepository} from "../../../../../src/db/repositories/dataColumnSidecar.js";
 import {getDataColumnSidecarsFromBlock} from "../../../../../src/util/dataColumns.js";
 import {kzg} from "../../../../../src/util/kzg.js";
 import {testLogger} from "../../../../utils/logger.js";
@@ -26,22 +18,48 @@ const config = createChainForkConfig({
 });
 describe("block archive repository", () => {
   const testDir = "./.tmp";
-  let dataColumnRepo: DataColumnSidecarsRepository;
+  let dataColumnRepo: DataColumnSidecarRepository;
   let db: LevelDbController;
 
   beforeEach(async () => {
     db = await LevelDbController.create({name: testDir}, {logger: testLogger()});
-    dataColumnRepo = new DataColumnSidecarsRepository(config, db);
+    dataColumnRepo = new DataColumnSidecarRepository(config, db);
   });
+
   afterEach(async () => {
     await db.close();
     rimraf.sync(testDir);
   });
 
-  it("should get block by parent root", async () => {
+  it("should get data column sidecars by parent root", async () => {
     const dataColumn = ssz.fulu.DataColumnSidecar.defaultValue();
     const blockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(dataColumn.signedBlockHeader.message);
-    const slot = dataColumn.signedBlockHeader.message.slot;
+    const blob = ssz.deneb.Blob.defaultValue();
+    const commitment = kzg.blobToKzgCommitment(blob);
+    const signedBlock = ssz.fulu.SignedBeaconBlock.defaultValue();
+    const blobs = [blob, blob, blob];
+    const commitments = [commitment, commitment, commitment];
+    signedBlock.message.body.blobKzgCommitments = commitments;
+    const cellsAndProofs = blobs.map((b) => kzg.computeCellsAndKzgProofs(b));
+
+    const allDataColumnSidecars = getDataColumnSidecarsFromBlock(config, signedBlock, cellsAndProofs);
+    for (let j = 0; j < allDataColumnSidecars.length; j++) {
+      allDataColumnSidecars[j].index = j;
+    }
+
+    const dataColumnSidecars = allDataColumnSidecars.slice(0, 7);
+    const dataColumnsLen = dataColumnSidecars.length;
+
+    await dataColumnRepo.putMany(blockRoot, dataColumnSidecars);
+    const retrievedDataColumnSidecars = await dataColumnRepo.values(blockRoot);
+
+    expect(retrievedDataColumnSidecars).toHaveLength(dataColumnsLen);
+    expect(retrievedDataColumnSidecars.map((c) => c.index)).toEqual(dataColumnSidecars.map((c) => c.index));
+  });
+
+  it("should get data column sidecars by matching bytes", async () => {
+    const dataColumn = ssz.fulu.DataColumnSidecar.defaultValue();
+    const blockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(dataColumn.signedBlockHeader.message);
     const blob = ssz.deneb.Blob.defaultValue();
     const commitment = kzg.blobToKzgCommitment(blob);
     const signedBlock = ssz.fulu.SignedBeaconBlock.defaultValue();
@@ -63,51 +81,17 @@ describe("block archive repository", () => {
 
     const dataColumnSidecars = allDataColumnSidecars.slice(0, 7);
     const dataColumnsLen = dataColumnSidecars.length;
-    const dataColumnsIndex = Array.from({length: NUMBER_OF_COLUMNS}, (_v, _i) => 0);
+
+    await dataColumnRepo.putMany(blockRoot, dataColumnSidecars);
+    const retrievedDataColumnSidecarBytes = await dataColumnRepo.valuesBinary(blockRoot);
+
+    expect(retrievedDataColumnSidecarBytes).toHaveLength(dataColumnsLen);
+
     for (let i = 0; i < dataColumnsLen; i++) {
-      dataColumnsIndex[i] = i + 1;
-    }
-    dataColumnsIndex[127] = 19;
-
-    const writeData = {
-      blockRoot,
-      slot,
-      dataColumnsLen,
-      dataColumnsSize: columnsSize,
-      dataColumnsIndex: Uint8Array.from(dataColumnsIndex),
-      dataColumnSidecars,
-    };
-
-    await dataColumnRepo.add(writeData);
-    const retrievedBinary = await dataColumnRepo.getBinary(blockRoot);
-    if (!retrievedBinary) throw Error("get by root returned null");
-
-    const retrieved = dataColumnSidecarsWrapperSsz.deserialize(retrievedBinary);
-    expect(dataColumnSidecarsWrapperSsz.equals(retrieved, writeData)).toBe(true);
-
-    const retrivedColumnsLen = ssz.Uint8.deserialize(
-      retrievedBinary.slice(NUM_COLUMNS_IN_WRAPPER_INDEX, COLUMN_SIZE_IN_WRAPPER_INDEX)
-    );
-    expect(retrivedColumnsLen === dataColumnsLen).toBe(true);
-
-    const retrievedColumnsSizeBytes = retrievedBinary.slice(
-      COLUMN_SIZE_IN_WRAPPER_INDEX,
-      CUSTODY_COLUMNS_IN_IN_WRAPPER_INDEX
-    );
-
-    const retrievedColumnsSize = ssz.UintNum64.deserialize(retrievedColumnsSizeBytes);
-    expect(retrievedColumnsSize === columnsSize).toBe(true);
-    const dataColumnSidecarsBytes = retrievedBinary.slice(
-      DATA_COLUMN_SIDECARS_IN_WRAPPER_INDEX + 4 * retrivedColumnsLen
-    );
-    // console.log({dataColumnSidecarsBytes: dataColumnSidecarsBytes.length, computeLen: dataColumnSidecarsBytes.length/columnsSize, dataColumnsLen, dataColumnSidecars: dataColumnSidecars.length, retrievedColumnsSize, columnsSize, allDataColumnSidecars: allDataColumnSidecars.length, lastIndex, DATA_COLUMN_SIDECARS_IN_WRAPPER_INDEX, retrivedColumnsLen})
-    expect(dataColumnSidecarsBytes.length === columnsSize * dataColumnsLen).toBe(true);
-
-    for (let j = 0; j < dataColumnsLen; j++) {
-      const dataColumnBytes = dataColumnSidecarsBytes.slice(j * columnsSize, (j + 1) * columnsSize);
-      const retrivedDataColumnSidecar = ssz.fulu.DataColumnSidecar.deserialize(dataColumnBytes);
-      const index = retrivedDataColumnSidecar.index;
-      expect(j === index).toBe(true);
+      expect(retrievedDataColumnSidecarBytes[i].value.byteLength).toEqual(columnsSize);
+      expect(toHex(retrievedDataColumnSidecarBytes[i].value)).toEqual(
+        toHex(ssz.fulu.DataColumnSidecar.serialize(dataColumnSidecars[i]))
+      );
     }
   });
 });

--- a/packages/db/src/abstractPrefixedRepository.ts
+++ b/packages/db/src/abstractPrefixedRepository.ts
@@ -40,8 +40,12 @@ export abstract class PrefixedRepository<I extends Id, P, T> {
     return this.type.deserialize(data);
   }
 
-  private wrapKey(raw: Uint8Array): Uint8Array {
+  protected wrapKey(raw: Uint8Array): Uint8Array {
     return encodeKey(this.bucket, raw);
+  }
+
+  protected unwrapKey(key: Uint8Array): Uint8Array {
+    return key.slice(BUCKET_LENGTH);
   }
 
   // The Id can be inferred from the value
@@ -194,7 +198,7 @@ export abstract class PrefixedRepository<I extends Id, P, T> {
     for (const v of Array.isArray(prefix) ? prefix : [prefix]) {
       const {gte, lt} = this.rangeForPrefixRaw(v);
       for await (const {key, value} of this.db.entriesStream({gte: this.wrapKey(gte), lt: this.wrapKey(lt)})) {
-        const {prefix, id} = this.decodeKeyRaw(key.slice(BUCKET_LENGTH));
+        const {prefix, id} = this.decodeKeyRaw(this.unwrapKey(key));
 
         yield {
           prefix,
@@ -209,7 +213,7 @@ export abstract class PrefixedRepository<I extends Id, P, T> {
     for (const v of Array.isArray(prefix) ? prefix : [prefix]) {
       const {gte, lt} = this.rangeForPrefixRaw(v);
       for await (const {key, value} of this.db.entriesStream({gte: this.wrapKey(gte), lt: this.wrapKey(lt)})) {
-        const {prefix, id} = this.decodeKeyRaw(key.slice(BUCKET_LENGTH));
+        const {prefix, id} = this.decodeKeyRaw(this.unwrapKey(key));
 
         yield {
           prefix,

--- a/packages/db/src/abstractPrefixedRepository.ts
+++ b/packages/db/src/abstractPrefixedRepository.ts
@@ -1,0 +1,222 @@
+import {Type} from "@chainsafe/ssz";
+import {ChainForkConfig} from "@lodestar/config";
+import {BUCKET_LENGTH} from "./const.js";
+import {KeyValue} from "./controller/index.js";
+import {Db, DbReqOpts} from "./controller/interface.js";
+import {encodeKey} from "./util.js";
+
+type Id = Uint8Array | string | number | bigint;
+
+/**
+ * Repository is a high level kv storage
+ * This abstract repository is designed in a way to store items with different prefixed
+ * Specially when those prefixed data is not available in the object to be stored
+ *
+ * By default, SSZ-encoded values,
+ */
+export abstract class PrefixedRepository<I extends Id, P, T> {
+  private readonly dbReqOpts: DbReqOpts;
+
+  protected constructor(
+    protected config: ChainForkConfig,
+    protected db: Db,
+    protected bucket: number,
+    protected type: Type<T>,
+    private readonly bucketId: string
+  ) {
+    this.dbReqOpts = {bucketId: this.bucketId};
+  }
+
+  protected abstract encodeKeyRaw(prefix: P, id: I): Uint8Array;
+  protected abstract decodeKeyRaw(raw: Uint8Array): {prefix: P; id: I};
+  /** Compute [gte, lt) raw range for a given prefix (bucket-local). */
+  protected abstract rangeForPrefixRaw(prefix: P): {gte: Uint8Array; lt: Uint8Array};
+
+  protected encodeValue(value: T): Uint8Array {
+    return this.type.serialize(value);
+  }
+
+  protected decodeValue(data: Uint8Array): T {
+    return this.type.deserialize(data);
+  }
+
+  private wrapKey(raw: Uint8Array): Uint8Array {
+    return encodeKey(this.bucket, raw);
+  }
+
+  // The Id can be inferred from the value
+  getId(value: T): I {
+    return this.type.hashTreeRoot(value) as I;
+  }
+
+  async get(prefix: P, id: I): Promise<T | null> {
+    const key = this.wrapKey(this.encodeKeyRaw(prefix, id));
+    const v = await this.db.get(key, this.dbReqOpts);
+    return v ? this.decodeValue(v) : null;
+  }
+
+  async getMany(prefix: P, ids: I[]): Promise<{id: I; value: T | null}[]> {
+    const keys = [];
+    for (const id of ids) {
+      keys.push(this.wrapKey(this.encodeKeyRaw(prefix, id)));
+    }
+    const result = await this.db.getMany(keys, this.dbReqOpts);
+    const values = [];
+
+    if (!result) {
+      for (const id of ids) {
+        values.push({id, value: null});
+      }
+      return values;
+    }
+
+    for (const {key, value} of result) {
+      const id = this.decodeKeyRaw(key).id;
+      values.push({id, value: value ? this.decodeValue(value) : null});
+    }
+    return values;
+  }
+
+  async getManyBinary(prefix: P, ids: I[]): Promise<{id: I; value: Uint8Array | null}[]> {
+    const keys = [];
+    for (const id of ids) {
+      keys.push(this.wrapKey(this.encodeKeyRaw(prefix, id)));
+    }
+    const result = await this.db.getMany(keys, this.dbReqOpts);
+    const values = [];
+
+    if (!result) {
+      for (const id of ids) {
+        values.push({id, value: null});
+      }
+      return values;
+    }
+
+    for (const {key, value} of result) {
+      const id = this.decodeKeyRaw(key).id;
+      values.push({id, value});
+    }
+    return values;
+  }
+
+  async getBinary(prefix: P, id: I): Promise<Uint8Array | null> {
+    const key = this.wrapKey(this.encodeKeyRaw(prefix, id));
+    return await this.db.get(key, this.dbReqOpts);
+  }
+
+  async put(prefix: P, object: T): Promise<void> {
+    const id = this.getId(object);
+    const key = this.wrapKey(this.encodeKeyRaw(prefix, id));
+    await this.db.put(key, this.encodeValue(object), this.dbReqOpts);
+  }
+
+  async putMany(prefix: P, object: T[]): Promise<void> {
+    const batch: KeyValue<Uint8Array, Uint8Array>[] = [];
+    for (const item of object) {
+      const id = this.getId(item);
+      const key = this.wrapKey(this.encodeKeyRaw(prefix, id));
+      batch.push({key, value: this.encodeValue(item)});
+    }
+    this.db.batchPut(batch, this.dbReqOpts);
+  }
+
+  async putBinary(prefix: P, id: I, bytes: Uint8Array): Promise<void> {
+    const key = this.wrapKey(this.encodeKeyRaw(prefix, id));
+    await this.db.put(key, bytes, this.dbReqOpts);
+  }
+
+  async putManyBinary(prefix: P, items: KeyValue<I, Uint8Array>[]): Promise<void> {
+    const batch: KeyValue<Uint8Array, Uint8Array>[] = [];
+    for (const {key, value} of items) {
+      batch.push({key: this.wrapKey(this.encodeKeyRaw(prefix, key)), value: value});
+    }
+    this.db.batchPut(batch, this.dbReqOpts);
+  }
+
+  async delete(prefix: P, id: I): Promise<void> {
+    const key = this.wrapKey(this.encodeKeyRaw(prefix, id));
+    await this.db.delete(key, this.dbReqOpts);
+  }
+
+  async deleteMany(prefix: P | P[]): Promise<void> {
+    const keys: Uint8Array[][] = [];
+
+    for (const p of Array.isArray(prefix) ? prefix : [prefix]) {
+      const {gte, lt} = this.rangeForPrefixRaw(p);
+      const prefixedKeys = await this.db.keys({gte: this.wrapKey(gte), lt: this.wrapKey(lt)});
+      keys.push(prefixedKeys);
+    }
+
+    await this.db.batchDelete(keys.flat(), this.dbReqOpts);
+  }
+
+  async *valuesStream(prefix: P | P[]): AsyncIterable<T> {
+    for (const p of Array.isArray(prefix) ? prefix : [prefix]) {
+      const {gte, lt} = this.rangeForPrefixRaw(p);
+      for await (const vb of this.db.valuesStream({gte: this.wrapKey(gte), lt: this.wrapKey(lt)})) {
+        yield this.decodeValue(vb);
+      }
+    }
+  }
+
+  /**
+   * Non iterative version of `valuesStream`.
+   */
+  async values(prefix: P | P[]): Promise<T[]> {
+    const result: T[] = [];
+    for await (const value of this.valuesStream(prefix)) {
+      result.push(value);
+    }
+    return result;
+  }
+
+  async *valuesStreamBinary(prefix: P | P[]): AsyncIterable<Uint8Array> {
+    for (const p of Array.isArray(prefix) ? prefix : [prefix]) {
+      const {gte, lt} = this.rangeForPrefixRaw(p);
+      for await (const vb of this.db.valuesStream({gte: this.wrapKey(gte), lt: this.wrapKey(lt)})) {
+        yield vb;
+      }
+    }
+  }
+
+  /**
+   * Non iterative version of `valuesStreamBinary`.
+   */
+  async valuesBinary(prefix: P | P[]): Promise<Uint8Array[]> {
+    const result = [];
+    for await (const value of this.valuesStreamBinary(prefix)) {
+      result.push(value);
+    }
+    return result;
+  }
+
+  async *entriesStream(prefix: P | P[]): AsyncIterable<{prefix: P; id: I; value: T}> {
+    for (const v of Array.isArray(prefix) ? prefix : [prefix]) {
+      const {gte, lt} = this.rangeForPrefixRaw(v);
+      for await (const {key, value} of this.db.entriesStream({gte: this.wrapKey(gte), lt: this.wrapKey(lt)})) {
+        const {prefix, id} = this.decodeKeyRaw(key.slice(BUCKET_LENGTH));
+
+        yield {
+          prefix,
+          id,
+          value: this.decodeValue(value),
+        };
+      }
+    }
+  }
+
+  async *entriesStreamBinary(prefix: P | P[]): AsyncIterable<{prefix: P; id: I; value: Uint8Array}> {
+    for (const v of Array.isArray(prefix) ? prefix : [prefix]) {
+      const {gte, lt} = this.rangeForPrefixRaw(v);
+      for await (const {key, value} of this.db.entriesStream({gte: this.wrapKey(gte), lt: this.wrapKey(lt)})) {
+        const {prefix, id} = this.decodeKeyRaw(key.slice(BUCKET_LENGTH));
+
+        yield {
+          prefix,
+          id: id,
+          value,
+        };
+      }
+    }
+  }
+}

--- a/packages/db/src/abstractPrefixedRepository.ts
+++ b/packages/db/src/abstractPrefixedRepository.ts
@@ -65,7 +65,7 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
     return v ? this.decodeValue(v) : null;
   }
 
-  async getMany(prefix: P, ids: I[]): Promise<(T | null)[]> {
+  async getMany(prefix: P, ids: I[]): Promise<(T | undefined)[]> {
     const keys = [];
     for (const id of ids) {
       keys.push(this.wrapKey(this.encodeKeyRaw(prefix, id)));
@@ -74,13 +74,13 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
 
     const result = [];
     for (const value of values) {
-      result.push(value ? this.decodeValue(value) : null);
+      result.push(value ? this.decodeValue(value) : undefined);
     }
 
     return result;
   }
 
-  async getManyBinary(prefix: P, ids: I[]): Promise<(Uint8Array | null)[]> {
+  async getManyBinary(prefix: P, ids: I[]): Promise<(Uint8Array | undefined)[]> {
     const keys = [];
     for (const id of ids) {
       keys.push(this.wrapKey(this.encodeKeyRaw(prefix, id)));

--- a/packages/db/src/abstractPrefixedRepository.ts
+++ b/packages/db/src/abstractPrefixedRepository.ts
@@ -65,48 +65,27 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
     return v ? this.decodeValue(v) : null;
   }
 
-  async getMany(prefix: P, ids: I[]): Promise<{id: I; value: T | null}[]> {
+  async getMany(prefix: P, ids: I[]): Promise<(T | null)[]> {
     const keys = [];
     for (const id of ids) {
       keys.push(this.wrapKey(this.encodeKeyRaw(prefix, id)));
     }
-    const result = await this.db.getMany(keys, this.dbReqOpts);
-    const values = [];
+    const values = await this.db.getMany(keys, this.dbReqOpts);
 
-    if (!result) {
-      for (const id of ids) {
-        values.push({id, value: null});
-      }
-      return values;
+    const result = [];
+    for (const value of values) {
+      result.push(value ? this.decodeValue(value) : null);
     }
 
-    for (const {key, value} of result) {
-      const id = this.decodeKeyRaw(key).id;
-      values.push({id, value: value ? this.decodeValue(value) : null});
-    }
-    return values;
+    return result;
   }
 
-  async getManyBinary(prefix: P, ids: I[]): Promise<{id: I; value: Uint8Array | null}[]> {
+  async getManyBinary(prefix: P, ids: I[]): Promise<(Uint8Array | null)[]> {
     const keys = [];
     for (const id of ids) {
       keys.push(this.wrapKey(this.encodeKeyRaw(prefix, id)));
     }
-    const result = await this.db.getMany(keys, this.dbReqOpts);
-    const values = [];
-
-    if (!result) {
-      for (const id of ids) {
-        values.push({id, value: null});
-      }
-      return values;
-    }
-
-    for (const {key, value} of result) {
-      const id = this.decodeKeyRaw(key).id;
-      values.push({id, value});
-    }
-    return values;
+    return await this.db.getMany(keys, this.dbReqOpts);
   }
 
   async getBinary(prefix: P, id: I): Promise<Uint8Array | null> {

--- a/packages/db/src/abstractPrefixedRepository.ts
+++ b/packages/db/src/abstractPrefixedRepository.ts
@@ -2,7 +2,7 @@ import {Type} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {BUCKET_LENGTH} from "./const.js";
 import {KeyValue} from "./controller/index.js";
-import {Db, DbReqOpts} from "./controller/interface.js";
+import {Db, DbReqOpts, FilterOptions} from "./controller/interface.js";
 import {encodeKey} from "./util.js";
 
 type Id = Uint8Array | string | number | bigint;
@@ -27,10 +27,16 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
     this.dbReqOpts = {bucketId: this.bucketId};
   }
 
-  protected abstract encodeKeyRaw(prefix: P, id: I): Uint8Array;
-  protected abstract decodeKeyRaw(raw: Uint8Array): {prefix: P; id: I};
-  /** Compute [gte, lt) raw range for a given prefix (bucket-local). */
-  protected abstract rangeForPrefixRaw(prefix: P): {gte: Uint8Array; lt: Uint8Array};
+  abstract encodeKeyRaw(prefix: P, id: I): Uint8Array;
+  abstract decodeKeyRaw(raw: Uint8Array): {prefix: P; id: I};
+  /**
+   * Max key is inclusive
+   * */
+  abstract getMaxKeyRaw(prefix: P): Uint8Array;
+  /**
+   * Min key is inclusive
+   * */
+  abstract getMinKeyRaw(prefix: P): Uint8Array;
 
   protected encodeValue(value: T): Uint8Array {
     return this.type.serialize(value);
@@ -146,8 +152,10 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
     const keys: Uint8Array[][] = [];
 
     for (const p of Array.isArray(prefix) ? prefix : [prefix]) {
-      const {gte, lt} = this.rangeForPrefixRaw(p);
-      const prefixedKeys = await this.db.keys({gte: this.wrapKey(gte), lt: this.wrapKey(lt)});
+      const prefixedKeys = await this.db.keys({
+        gte: this.wrapKey(this.getMinKeyRaw(p)),
+        lte: this.wrapKey(this.getMaxKeyRaw(p)),
+      });
       keys.push(prefixedKeys);
     }
 
@@ -156,8 +164,10 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
 
   async *valuesStream(prefix: P | P[]): AsyncIterable<T> {
     for (const p of Array.isArray(prefix) ? prefix : [prefix]) {
-      const {gte, lt} = this.rangeForPrefixRaw(p);
-      for await (const vb of this.db.valuesStream({gte: this.wrapKey(gte), lt: this.wrapKey(lt)})) {
+      for await (const vb of this.db.valuesStream({
+        gte: this.wrapKey(this.getMinKeyRaw(p)),
+        lte: this.wrapKey(this.getMaxKeyRaw(p)),
+      })) {
         yield this.decodeValue(vb);
       }
     }
@@ -174,11 +184,16 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
     return result;
   }
 
-  async *valuesStreamBinary(prefix: P | P[]): AsyncIterable<Uint8Array> {
+  async *valuesStreamBinary(prefix: P | P[]): AsyncIterable<{prefix: P; id: I; value: Uint8Array}> {
     for (const p of Array.isArray(prefix) ? prefix : [prefix]) {
-      const {gte, lt} = this.rangeForPrefixRaw(p);
-      for await (const vb of this.db.valuesStream({gte: this.wrapKey(gte), lt: this.wrapKey(lt)})) {
-        yield vb;
+      for await (const {key, value} of this.db.entriesStream({
+        gte: this.wrapKey(this.getMinKeyRaw(p)),
+        lte: this.wrapKey(this.getMaxKeyRaw(p)),
+      })) {
+        yield {
+          ...this.decodeKeyRaw(key),
+          value,
+        };
       }
     }
   }
@@ -186,7 +201,7 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
   /**
    * Non iterative version of `valuesStreamBinary`.
    */
-  async valuesBinary(prefix: P | P[]): Promise<Uint8Array[]> {
+  async valuesBinary(prefix: P | P[]): Promise<{prefix: P; id: I; value: Uint8Array}[]> {
     const result = [];
     for await (const value of this.valuesStreamBinary(prefix)) {
       result.push(value);
@@ -196,8 +211,10 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
 
   async *entriesStream(prefix: P | P[]): AsyncIterable<{prefix: P; id: I; value: T}> {
     for (const v of Array.isArray(prefix) ? prefix : [prefix]) {
-      const {gte, lt} = this.rangeForPrefixRaw(v);
-      for await (const {key, value} of this.db.entriesStream({gte: this.wrapKey(gte), lt: this.wrapKey(lt)})) {
+      for await (const {key, value} of this.db.entriesStream({
+        gte: this.wrapKey(this.getMinKeyRaw(v)),
+        lte: this.wrapKey(this.getMaxKeyRaw(v)),
+      })) {
         const {prefix, id} = this.decodeKeyRaw(this.unwrapKey(key));
 
         yield {
@@ -211,8 +228,10 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
 
   async *entriesStreamBinary(prefix: P | P[]): AsyncIterable<{prefix: P; id: I; value: Uint8Array}> {
     for (const v of Array.isArray(prefix) ? prefix : [prefix]) {
-      const {gte, lt} = this.rangeForPrefixRaw(v);
-      for await (const {key, value} of this.db.entriesStream({gte: this.wrapKey(gte), lt: this.wrapKey(lt)})) {
+      for await (const {key, value} of this.db.entriesStream({
+        gte: this.wrapKey(this.getMinKeyRaw(v)),
+        lt: this.wrapKey(this.getMaxKeyRaw(v)),
+      })) {
         const {prefix, id} = this.decodeKeyRaw(this.unwrapKey(key));
 
         yield {
@@ -222,5 +241,31 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
         };
       }
     }
+  }
+
+  async keys(opts?: FilterOptions<Uint8Array>): Promise<{prefix: P; id: I}[]> {
+    const optsBuff: FilterOptions<Uint8Array> = {
+      bucketId: this.bucketId,
+    };
+
+    // Set at least one min key
+    if (opts?.lt !== undefined) {
+      optsBuff.lt = this.wrapKey(opts.lt);
+    } else if (opts?.lte !== undefined) {
+      optsBuff.lte = this.wrapKey(opts.lte);
+    }
+
+    // Set at least on max key
+    if (opts?.gt !== undefined) {
+      optsBuff.gt = this.wrapKey(opts.gt);
+    } else if (opts?.gte !== undefined) {
+      optsBuff.gte = this.wrapKey(opts.gte);
+    }
+
+    if (opts?.reverse !== undefined) optsBuff.reverse = opts.reverse;
+    if (opts?.limit !== undefined) optsBuff.limit = opts.limit;
+
+    const data = await this.db.keys(optsBuff);
+    return (data ?? []).map((data) => this.decodeKeyRaw(data));
   }
 }

--- a/packages/db/src/abstractPrefixedRepository.ts
+++ b/packages/db/src/abstractPrefixedRepository.ts
@@ -14,7 +14,7 @@ type Id = Uint8Array | string | number | bigint;
  *
  * By default, SSZ-encoded values,
  */
-export abstract class PrefixedRepository<I extends Id, P, T> {
+export abstract class PrefixedRepository<P, I extends Id, T> {
   private readonly dbReqOpts: DbReqOpts;
 
   protected constructor(

--- a/packages/db/src/abstractPrefixedRepository.ts
+++ b/packages/db/src/abstractPrefixedRepository.ts
@@ -93,20 +93,20 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
     return await this.db.get(key, this.dbReqOpts);
   }
 
-  async put(prefix: P, object: T): Promise<void> {
-    const id = this.getId(object);
+  async put(prefix: P, item: T): Promise<void> {
+    const id = this.getId(item);
     const key = this.wrapKey(this.encodeKeyRaw(prefix, id));
-    await this.db.put(key, this.encodeValue(object), this.dbReqOpts);
+    await this.db.put(key, this.encodeValue(item), this.dbReqOpts);
   }
 
-  async putMany(prefix: P, object: T[]): Promise<void> {
+  async putMany(prefix: P, items: T[]): Promise<void> {
     const batch: KeyValue<Uint8Array, Uint8Array>[] = [];
-    for (const item of object) {
+    for (const item of items) {
       const id = this.getId(item);
       const key = this.wrapKey(this.encodeKeyRaw(prefix, id));
       batch.push({key, value: this.encodeValue(item)});
     }
-    this.db.batchPut(batch, this.dbReqOpts);
+    await this.db.batchPut(batch, this.dbReqOpts);
   }
 
   async putBinary(prefix: P, id: I, bytes: Uint8Array): Promise<void> {
@@ -119,7 +119,7 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
     for (const {key, value} of items) {
       batch.push({key: this.wrapKey(this.encodeKeyRaw(prefix, key)), value: value});
     }
-    this.db.batchPut(batch, this.dbReqOpts);
+    await this.db.batchPut(batch, this.dbReqOpts);
   }
 
   async delete(prefix: P, id: I): Promise<void> {

--- a/packages/db/src/controller/interface.ts
+++ b/packages/db/src/controller/interface.ts
@@ -39,6 +39,8 @@ export interface DatabaseController<K, V> {
   // Core API
 
   get(key: K, opts?: DbReqOpts): Promise<V | null>;
+  getMany(key: K[], opts?: DbReqOpts): Promise<KeyValue<K, V | null>[] | null>;
+
   put(key: K, value: V, opts?: DbReqOpts): Promise<void>;
   delete(key: K, opts?: DbReqOpts): Promise<void>;
 

--- a/packages/db/src/controller/interface.ts
+++ b/packages/db/src/controller/interface.ts
@@ -39,7 +39,7 @@ export interface DatabaseController<K, V> {
   // Core API
 
   get(key: K, opts?: DbReqOpts): Promise<V | null>;
-  getMany(key: K[], opts?: DbReqOpts): Promise<(V | null)[]>;
+  getMany(key: K[], opts?: DbReqOpts): Promise<(V | undefined)[]>;
 
   put(key: K, value: V, opts?: DbReqOpts): Promise<void>;
   delete(key: K, opts?: DbReqOpts): Promise<void>;

--- a/packages/db/src/controller/interface.ts
+++ b/packages/db/src/controller/interface.ts
@@ -39,7 +39,7 @@ export interface DatabaseController<K, V> {
   // Core API
 
   get(key: K, opts?: DbReqOpts): Promise<V | null>;
-  getMany(key: K[], opts?: DbReqOpts): Promise<KeyValue<K, V | null>[] | null>;
+  getMany(key: K[], opts?: DbReqOpts): Promise<(V | null)[]>;
 
   put(key: K, value: V, opts?: DbReqOpts): Promise<void>;
   delete(key: K, opts?: DbReqOpts): Promise<void>;

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -103,26 +103,16 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
     }
   }
 
-  // https://github.com/Level/abstract-level?tab=readme-ov-file#dbgetmanykeys-options
-  async getMany(keys: Uint8Array[], opts?: DbReqOpts): Promise<KeyValue<Uint8Array, Uint8Array | null>[] | null> {
-    try {
-      this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
-      this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
-      const values = await this.db.getMany(keys);
-      const result: KeyValue<Uint8Array, Uint8Array | null>[] = [];
-      for (const [index, key] of keys.entries()) {
-        result.push({
-          key,
-          value: values[index] ?? null, // If the value is not found, return null
-        });
-      }
-      return result;
-    } catch (e) {
-      if ((e as LevelDbError).code === "LEVEL_NOT_FOUND") {
-        return null;
-      }
-      throw e;
-    }
+  /**
+   * Return the multiple items in the order of the given keys
+   * Will return `null` for the keys which does not exists
+   *
+   * https://github.com/Level/abstract-level?tab=readme-ov-file#dbgetmanykeys-options
+   */
+  async getMany(keys: Uint8Array[], opts?: DbReqOpts): Promise<(Uint8Array | null)[]> {
+    this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
+    return await this.db.getMany(keys);
   }
 
   put(key: Uint8Array, value: Uint8Array, opts?: DbReqOpts): Promise<void> {

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -109,7 +109,7 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
    *
    * https://github.com/Level/abstract-level?tab=readme-ov-file#dbgetmanykeys-options
    */
-  async getMany(keys: Uint8Array[], opts?: DbReqOpts): Promise<(Uint8Array | null)[]> {
+  async getMany(keys: Uint8Array[], opts?: DbReqOpts): Promise<(Uint8Array | undefined)[]> {
     this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
     this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
     return await this.db.getMany(keys);

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -103,6 +103,28 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
     }
   }
 
+  // https://github.com/Level/abstract-level?tab=readme-ov-file#dbgetmanykeys-options
+  async getMany(keys: Uint8Array[], opts?: DbReqOpts): Promise<KeyValue<Uint8Array, Uint8Array | null>[] | null> {
+    try {
+      this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
+      this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
+      const values = await this.db.getMany(keys);
+      const result: KeyValue<Uint8Array, Uint8Array | null>[] = [];
+      for (const [index, key] of keys.entries()) {
+        result.push({
+          key,
+          value: values[index] ?? null, // If the value is not found, return null
+        });
+      }
+      return result;
+    } catch (e) {
+      if ((e as LevelDbError).code === "LEVEL_NOT_FOUND") {
+        return null;
+      }
+      throw e;
+    }
+  }
+
   put(key: Uint8Array, value: Uint8Array, opts?: DbReqOpts): Promise<void> {
     this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
     this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./abstractRepository.js";
+export * from "./abstractPrefixedRepository.js";
 export * from "./controller/index.js";
 export * from "./const.js";
 export * from "./util.js";

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -32,6 +32,26 @@ describe("LevelDB controller", () => {
     expect(await db.get(key)).toBe(null);
   });
 
+  it("test getMany", async () => {
+    const key1 = Buffer.from("test 1");
+    const value1 = Buffer.from("some value 1");
+    await db.put(key1, value1);
+
+    const key2 = Buffer.from("test 2");
+    const value2 = Buffer.from("some value 2");
+    await db.put(key2, value2);
+
+    await expect(db.getMany([key1, key2])).resolves.toEqual([
+      {key: key1, value: value1},
+      {key: key2, value: value2},
+    ]);
+    await db.delete(key1);
+    await expect(db.getMany([key1, key2])).resolves.toEqual([
+      {key: key1, value: null},
+      {key: key2, value: value2},
+    ]);
+  });
+
   it("test batchPut", async () => {
     const k1 = Buffer.from("test1");
     const k2 = Buffer.from("test2");

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -41,15 +41,9 @@ describe("LevelDB controller", () => {
     const value2 = Buffer.from("some value 2");
     await db.put(key2, value2);
 
-    await expect(db.getMany([key1, key2])).resolves.toEqual([
-      {key: key1, value: value1},
-      {key: key2, value: value2},
-    ]);
+    await expect(db.getMany([key1, key2])).resolves.toEqual([value1, value2]);
     await db.delete(key1);
-    await expect(db.getMany([key1, key2])).resolves.toEqual([
-      {key: key1, value: null},
-      {key: key2, value: value2},
-    ]);
+    await expect(db.getMany([key1, key2])).resolves.toEqual([undefined, value2]);
   });
 
   it("test batchPut", async () => {


### PR DESCRIPTION
**Motivation**

Reduce the storage usage by removing duplicate information from dataColumnSidecar storage. 

Closes #8114

**Description**

- Implement a custom db repository 
- Add multiple entries for `DataColumnSidecars`, one entry per sidecar
- Use the streaming values to build the `DataColumnSidecars` from individual sidcar. 

**Steps to test or reproduce**

- Run all tests 

**Notes for reviewers**

The usage of attributes `dataColumnsLen` and `dataColumnsSize` and `dataColumnIndex ` was mostly been used 1) either to build data to store 2) or for log messages. I believe with the new implementation we don't need the use of those attributes any more. There are two usages where we might need extra logic to to calculate `dataColumnsLen`, but that's still not necessary. 

- `packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts#writeBlockInputToDb`
- `packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts#removeEagerlyPersistedBlockInputs` 

Now the `DataColumnsSidecar` is stored individually and not the full collection as singe key: 

1. Finalized are stored as key `slot || columnIndex` 
2. Unfinalized are stored as key `blockRoot || columnIndex`

This will make it easy to access individual column for a slot and transmit on network when needed. 
