### PR TITLE
fix: typo in serializeBlobsBundle()

### DIFF
--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -410,7 +410,7 @@ export function serializeBlobsBundle(data: BlobsBundle): BlobsBundleRpc {
   return {
     commitments: data.commitments.map((kzg) => bytesToData(kzg)),
     blobs: data.blobs.map((blob) => bytesToData(blob)),
-    proofs: data.blobs.map((proof) => bytesToData(proof)),
+    proofs: data.proofs.map((proof) => bytesToData(proof)),
   };
 }
 


### PR DESCRIPTION
**Description**

- fix copy/paste issue in serializeBlobsBundle()
- I'm not sure the impact of this, why didn't we catch this in the past? the data type is post-deneb