### PR TITLE
feat: implement PeerBalancer for UnknownBlockSync

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -548,6 +548,20 @@ export function createLodestarMetrics(
         help: "Total number of blocks whose data availability was resolved",
         labelNames: ["source"],
       }),
+      peerBalancer: {
+        peersMetaCount: register.gauge({
+          name: "lodestar_sync_unknown_block_peer_balancer_peers_meta_count",
+          help: "Count of peers meta in UnknownBlockSync peer balancer",
+        }),
+        peersActiveRequestCount: register.gauge({
+          name: "lodestar_sync_unknown_block_peer_balancer_peers_active_request_count",
+          help: "Count of peers active requests in UnknownBlockSync peer balancer",
+        }),
+        totalActiveRequests: register.gauge({
+          name: "lodestar_sync_unknown_block_peer_balancer_total_active_requests",
+          help: "Total active requests in UnknownBlockSync peer balancer",
+        }),
+      },
     },
 
     // Gossip sync committee

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -40,6 +40,10 @@ import {
 const MAX_ENGINE_GETBLOBS_CACHE = 32 * 16;
 const MAX_UNAVAILABLE_RETRY_CACHE = 32;
 
+/**
+ * Request beacon blocks by root, and blobs or data columns if available.
+ * return BlockInput[] along with pendingDataColumns (null for prefulu forks for postfulu where data is available)
+ */
 export async function beaconBlocksMaybeBlobsByRoot(
   config: ChainForkConfig,
   network: INetwork,
@@ -220,10 +224,6 @@ export async function unavailableBeaconBlobsByRoot(
     block = allBlocks[0].data;
     cachedData = unavailableBlockInput.cachedData;
     unavailableBlockInput = getBlockInput.dataPromise(config, block, BlockSource.byRoot, cachedData);
-    // console.log(
-    //   "downloaded sendBeaconBlocksByRoot",
-    //   ssz.fulu.SignedBeaconBlock.toJson(block as fulu.SignedBeaconBlock)
-    // );
   } else {
     ({block, cachedData} = unavailableBlockInput);
   }

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, ForkSeq, INTERVALS_PER_SLOT, NUMBER_OF_COLUMNS} from "@lodestar/params";
+import {ForkName, ForkSeq, INTERVALS_PER_SLOT} from "@lodestar/params";
 import {ColumnIndex, Root, RootHex, deneb} from "@lodestar/types";
 import {BlobAndProof} from "@lodestar/types/deneb";
 import {Logger, fromHex, pruneSetToMax, toRootHex} from "@lodestar/utils";
@@ -22,7 +22,7 @@ import {shuffle} from "../util/shuffle.js";
 import {sortBy} from "../util/sortBy.js";
 import {Result, wrapError} from "../util/wrapError.js";
 import {MAX_CONCURRENT_REQUESTS} from "./constants.js";
-import {PendingBlock, PendingBlockStatus, PendingBlockType, UnknownBlock} from "./interface.js";
+import {PendingBlock, PendingBlockStatus, PendingBlockType} from "./interface.js";
 import {SyncOptions} from "./options.js";
 import {getAllDescendantBlocks, getDescendantBlocks, getUnknownAndAncestorBlocks} from "./utils/pendingBlocksTree.js";
 

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -1,22 +1,27 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, INTERVALS_PER_SLOT, NUMBER_OF_COLUMNS} from "@lodestar/params";
+import {ForkName, ForkSeq, INTERVALS_PER_SLOT, NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {ColumnIndex, Root, RootHex, deneb} from "@lodestar/types";
 import {BlobAndProof} from "@lodestar/types/deneb";
 import {Logger, fromHex, pruneSetToMax, toRootHex} from "@lodestar/utils";
 import {sleep} from "@lodestar/utils";
-import {BlockInput, BlockInputType, CachedDataColumns, NullBlockInput} from "../chain/blocks/types.js";
+import {BlockInput, BlockInputType, CachedData, CachedDataColumns, NullBlockInput} from "../chain/blocks/types.js";
 import {BlockError, BlockErrorCode} from "../chain/errors/index.js";
 import {IBeaconChain} from "../chain/index.js";
 import {Metrics} from "../metrics/index.js";
 import {INetwork, NetworkEvent, NetworkEventData} from "../network/index.js";
+import {PeerSyncMeta} from "../network/peers/peersData.js";
+import {PartialDownload} from "../network/reqresp/beaconBlocksMaybeBlobsByRange.js";
 import {
   beaconBlocksMaybeBlobsByRoot,
   unavailableBeaconBlobsByRoot,
 } from "../network/reqresp/beaconBlocksMaybeBlobsByRoot.js";
 import {byteArrayEquals} from "../util/bytes.js";
+import {CustodyConfig} from "../util/dataColumns.js";
 import {PeerIdStr} from "../util/peerId.js";
 import {shuffle} from "../util/shuffle.js";
+import {sortBy} from "../util/sortBy.js";
 import {Result, wrapError} from "../util/wrapError.js";
+import {MAX_CONCURRENT_REQUESTS} from "./constants.js";
 import {PendingBlock, PendingBlockStatus, PendingBlockType, UnknownBlock} from "./interface.js";
 import {SyncOptions} from "./options.js";
 import {getAllDescendantBlocks, getDescendantBlocks, getUnknownAndAncestorBlocks} from "./utils/pendingBlocksTree.js";
@@ -37,6 +42,7 @@ export class UnknownBlockSync {
 
   private engineGetBlobsCache = new Map<RootHex, BlobAndProof | null>();
   private blockInputsRetryTrackerCache = new Set<RootHex>();
+  private peerBalancer: UnknownBlockPeerBalancer;
 
   constructor(
     private readonly config: ChainForkConfig,
@@ -48,14 +54,18 @@ export class UnknownBlockSync {
   ) {
     this.maxPendingBlocks = opts?.maxPendingBlocks ?? MAX_PENDING_BLOCKS;
     this.proposerBoostSecWindow = this.config.SECONDS_PER_SLOT / INTERVALS_PER_SLOT;
+    this.peerBalancer = new UnknownBlockPeerBalancer(this.network.custodyConfig);
 
     if (metrics) {
-      metrics.syncUnknownBlock.pendingBlocks.addCollect(() =>
-        metrics.syncUnknownBlock.pendingBlocks.set(this.pendingBlocks.size)
-      );
-      metrics.syncUnknownBlock.knownBadBlocks.addCollect(() =>
-        metrics.syncUnknownBlock.knownBadBlocks.set(this.knownBadBlocks.size)
-      );
+      metrics.syncUnknownBlock.pendingBlocks.addCollect(() => {
+        metrics.syncUnknownBlock.pendingBlocks.set(this.pendingBlocks.size);
+        metrics.syncUnknownBlock.knownBadBlocks.set(this.knownBadBlocks.size);
+        metrics.syncUnknownBlock.peerBalancer.peersMetaCount.set(this.peerBalancer.getPeersMetaCount());
+        metrics.syncUnknownBlock.peerBalancer.peersActiveRequestCount.set(
+          this.peerBalancer.getPeersActiveRequestCount()
+        );
+        metrics.syncUnknownBlock.peerBalancer.totalActiveRequests.set(this.peerBalancer.getTotalActiveRequests());
+      });
     }
   }
 
@@ -67,7 +77,8 @@ export class UnknownBlockSync {
         this.network.events.on(NetworkEvent.unknownBlock, this.onUnknownBlock);
         this.network.events.on(NetworkEvent.unknownBlockInput, this.onUnknownBlockInput);
         this.network.events.on(NetworkEvent.unknownBlockParent, this.onUnknownParent);
-        this.network.events.on(NetworkEvent.peerConnected, this.triggerUnknownBlockSearch);
+        this.network.events.on(NetworkEvent.peerConnected, this.onPeerConnected);
+        this.network.events.on(NetworkEvent.peerDisconnected, this.onPeerDisconnected);
         this.subscribedToNetworkEvents = true;
       }
     } else {
@@ -80,7 +91,8 @@ export class UnknownBlockSync {
     this.network.events.off(NetworkEvent.unknownBlock, this.onUnknownBlock);
     this.network.events.off(NetworkEvent.unknownBlockInput, this.onUnknownBlockInput);
     this.network.events.off(NetworkEvent.unknownBlockParent, this.onUnknownParent);
-    this.network.events.off(NetworkEvent.peerConnected, this.triggerUnknownBlockSearch);
+    this.network.events.off(NetworkEvent.peerConnected, this.onPeerConnected);
+    this.network.events.off(NetworkEvent.peerDisconnected, this.onPeerDisconnected);
     this.subscribedToNetworkEvents = false;
   }
 
@@ -238,6 +250,22 @@ export class UnknownBlockSync {
     return unknownBlockType;
   }
 
+  private onPeerConnected = (data: NetworkEventData[NetworkEvent.peerConnected]): void => {
+    try {
+      const peerId = data.peer;
+      const peerSyncMeta = this.network.getConnectedPeerSyncMeta(peerId);
+      this.peerBalancer.onPeerConnected(data.peer, peerSyncMeta);
+      this.triggerUnknownBlockSearch();
+    } catch (e) {
+      this.logger.debug("Error handling peerConnected event", {}, e as Error);
+    }
+  };
+
+  private onPeerDisconnected = (data: NetworkEventData[NetworkEvent.peerDisconnected]): void => {
+    const peerId = data.peer;
+    this.peerBalancer.onPeerDisconnected(peerId);
+  };
+
   /**
    * Gather tip parent blocks with unknown parent and do a search for all of them
    */
@@ -280,13 +308,13 @@ export class UnknownBlockSync {
 
     // most of the time there is exactly 1 unknown block
     for (const block of unknowns) {
-      this.downloadBlock(block, connectedPeers).catch((e) => {
+      this.downloadBlock(block).catch((e) => {
         this.logger.debug("Unexpected error - downloadBlock", {root: block.blockRootHex}, e);
       });
     }
   };
 
-  private async downloadBlock(block: PendingBlock, allPeers: PeerIdStr[]): Promise<void> {
+  private async downloadBlock(block: PendingBlock): Promise<void> {
     if (block.status !== PendingBlockStatus.pending) {
       return;
     }
@@ -304,55 +332,11 @@ export class UnknownBlockSync {
     block.status = PendingBlockStatus.fetching;
 
     let res: Result<{blockInput: BlockInput; peerIdStr: string}>;
-    let connectedPeers: string[];
     if (block.blockInput === null) {
-      connectedPeers = allPeers;
       // we only have block root, and nothing else
-      res = await wrapError(this.fetchUnknownBlockRoot(fromHex(block.blockRootHex), connectedPeers));
+      res = await wrapError(this.fetchUnknownBlockRoot(fromHex(block.blockRootHex)));
     } else {
-      const {cachedData} = block.blockInput;
-      if (cachedData.fork === ForkName.fulu) {
-        const {dataColumnsCache} = cachedData as CachedDataColumns;
-        const sampledColumns = this.network.custodyConfig.sampledColumns;
-        const neededColumns = sampledColumns.reduce((acc, elem) => {
-          if (dataColumnsCache.get(elem) === undefined) {
-            acc.push(elem);
-          }
-          return acc;
-        }, [] as number[]);
-
-        connectedPeers =
-          neededColumns.length <= 0
-            ? allPeers
-            : allPeers.filter((peer) => {
-                const {custodyGroups: peerColumns} = this.network.getConnectedPeerSyncMeta(peer);
-                const columns = peerColumns.reduce((acc, elem) => {
-                  if (neededColumns.includes(elem)) {
-                    acc.push(elem);
-                  }
-                  return acc;
-                }, [] as number[]);
-                return columns.length > 0;
-              });
-        if (connectedPeers.length > 0) {
-          this.logger.debug("Filtered peers to those having relevant columns for downloading data", {
-            ...logCtx,
-            allPeers: allPeers.length,
-            connectedPeers: connectedPeers.length,
-          });
-        } else {
-          this.logger.debug("Skipping download as no filtered peers having relevant data", {
-            ...logCtx,
-            allPeers: allPeers.length,
-            connectedPeers: connectedPeers.length,
-            neededColumns: neededColumns.join(" "),
-          });
-          return;
-        }
-      } else {
-        connectedPeers = allPeers;
-      }
-      res = await wrapError(this.fetchUnavailableBlockInput(block.blockInput, connectedPeers));
+      res = await wrapError(this.fetchUnavailableBlockInput(block.blockInput));
     }
 
     if (res.err) this.metrics?.syncUnknownBlock.downloadedBlocksError.inc();
@@ -360,74 +344,57 @@ export class UnknownBlockSync {
 
     if (!res.err) {
       const {blockInput, peerIdStr} = res.result;
+      // fetchUnknownBlockRoot and fetchUnavailableBlockInput should return available data BlockInput, throw error if not
       if (blockInput.type === BlockInputType.dataPromise) {
         // if there were any peers who would have had the missing datacolumns, it would have resulted in err
-        block = {
-          ...block,
-          blockInput,
-          unknownBlockType: PendingBlockType.UNKNOWN_DATA,
-        } as UnknownBlock;
-        block.blockInput = blockInput;
-        this.pendingBlocks.set(block.blockRootHex, block);
-        block.status = PendingBlockStatus.pending;
-        // parentSlot > finalizedSlot, continue downloading parent of parent
-        block.downloadAttempts += this.config.CUSTODY_REQUIREMENT / NUMBER_OF_COLUMNS;
-        const errorData = {root: block.blockRootHex, attempts: block.downloadAttempts, unknownBlockType};
-        if (block.downloadAttempts > MAX_ATTEMPTS_PER_BLOCK) {
-          // Give up on this block and assume it does not exist, penalizing all peers as if it was a bad block
-          this.logger.debug("Ignoring unknown block after many failed downloads", errorData);
-          this.removeAndDownscoreAllDescendants(block);
-        } else {
-          // Try again when a new peer connects, its status changes, or a new unknownBlockParent event happens
-          this.logger.debug("Error downloading full unknown block", errorData);
-        }
-      } else {
-        block = {
-          ...block,
-          status: PendingBlockStatus.downloaded,
-          blockInput,
-          parentBlockRootHex: toRootHex(blockInput.block.message.parentRoot),
-        };
-        this.pendingBlocks.set(block.blockRootHex, block);
-        const blockSlot = blockInput.block.message.slot;
-        const finalizedSlot = this.chain.forkChoice.getFinalizedBlock().slot;
-        const delaySec = Date.now() / 1000 - (this.chain.genesisTime + blockSlot * this.config.SECONDS_PER_SLOT);
-        this.metrics?.syncUnknownBlock.elapsedTimeTillReceived.observe(delaySec);
+        throw Error(`Expected BlockInput to be available, got dataPromise for ${block.blockRootHex}`);
+      }
 
-        const parentInForkchoice = this.chain.forkChoice.hasBlock(blockInput.block.message.parentRoot);
-        this.logger.verbose("Downloaded unknown block", {
-          root: block.blockRootHex,
-          pendingBlocks: this.pendingBlocks.size,
-          parentInForkchoice,
-          blockInputType: blockInput.type,
+      block = {
+        ...block,
+        status: PendingBlockStatus.downloaded,
+        blockInput,
+        parentBlockRootHex: toRootHex(blockInput.block.message.parentRoot),
+      };
+      this.pendingBlocks.set(block.blockRootHex, block);
+      const blockSlot = blockInput.block.message.slot;
+      const finalizedSlot = this.chain.forkChoice.getFinalizedBlock().slot;
+      const delaySec = Date.now() / 1000 - (this.chain.genesisTime + blockSlot * this.config.SECONDS_PER_SLOT);
+      this.metrics?.syncUnknownBlock.elapsedTimeTillReceived.observe(delaySec);
+
+      const parentInForkchoice = this.chain.forkChoice.hasBlock(blockInput.block.message.parentRoot);
+      this.logger.verbose("Downloaded unknown block", {
+        root: block.blockRootHex,
+        pendingBlocks: this.pendingBlocks.size,
+        parentInForkchoice,
+        blockInputType: blockInput.type,
+        unknownBlockType,
+      });
+
+      if (parentInForkchoice) {
+        // Bingo! Process block. Add to pending blocks anyway for recycle the cache that prevents duplicate processing
+        this.processBlock(block).catch((e) => {
+          this.logger.debug("Unexpected error - process newly downloaded block", {}, e);
+        });
+      } else if (blockSlot <= finalizedSlot) {
+        // the common ancestor of the downloading chain and canonical chain should be at least the finalized slot and
+        // we should found it through forkchoice. If not, we should penalize all peers sending us this block chain
+        // 0 - 1 - ... - n - finalizedSlot
+        //                \
+        //                parent 1 - parent 2 - ... - unknownParent block
+        const blockRoot = this.config.getForkTypes(blockSlot).BeaconBlock.hashTreeRoot(blockInput.block.message);
+        this.logger.debug("Downloaded block is before finalized slot", {
+          finalizedSlot,
+          blockSlot,
+          parentRoot: toRootHex(blockRoot),
           unknownBlockType,
         });
-
-        if (parentInForkchoice) {
-          // Bingo! Process block. Add to pending blocks anyway for recycle the cache that prevents duplicate processing
-          this.processBlock(block).catch((e) => {
-            this.logger.debug("Unexpected error - process newly downloaded block", {}, e);
-          });
-        } else if (blockSlot <= finalizedSlot) {
-          // the common ancestor of the downloading chain and canonical chain should be at least the finalized slot and
-          // we should found it through forkchoice. If not, we should penalize all peers sending us this block chain
-          // 0 - 1 - ... - n - finalizedSlot
-          //                \
-          //                parent 1 - parent 2 - ... - unknownParent block
-          const blockRoot = this.config.getForkTypes(blockSlot).BeaconBlock.hashTreeRoot(blockInput.block.message);
-          this.logger.debug("Downloaded block is before finalized slot", {
-            finalizedSlot,
-            blockSlot,
-            parentRoot: toRootHex(blockRoot),
-            unknownBlockType,
-          });
-          this.removeAndDownscoreAllDescendants(block);
-        } else {
-          this.onUnknownParent({blockInput, peer: peerIdStr});
-        }
+        this.removeAndDownscoreAllDescendants(block);
+      } else {
+        this.onUnknownParent({blockInput, peer: peerIdStr});
       }
     } else {
-      // this allows to retry the download of the block
+      // block download has error, this allows to retry the download of the block
       block.status = PendingBlockStatus.pending;
       // parentSlot > finalizedSlot, continue downloading parent of parent
       block.downloadAttempts++;
@@ -459,7 +426,7 @@ export class UnknownBlockSync {
           return;
         }
         // if the download is a success we'll call `processBlock()` for this block
-        await this.downloadBlock(pendingBlock, connectedPeers);
+        await this.downloadBlock(pendingBlock);
       }
       return;
     }
@@ -557,49 +524,34 @@ export class UnknownBlockSync {
    *   - from deneb, fetch all missing blobs
    *   - from peerDAS, fetch sampled colmns
    * TODO: this means we only have block root, and nothing else. Consider to reflect this in the function name
-   * Will attempt a max of `MAX_ATTEMPTS_PER_BLOCK` on different peers if connectPeers.length > MAX_ATTEMPTS_PER_BLOCK.
+   * prefulu, will attempt a max of `MAX_ATTEMPTS_PER_BLOCK` on different peers, postfulu we may attempt more as defined in `getMaxDownloadAttempts()` function
    * Also verifies the received block root + returns the peer that provided the block for future downscoring.
    */
-  private async fetchUnknownBlockRoot(
-    blockRoot: Root,
-    connectedPeers: PeerIdStr[]
-  ): Promise<{blockInput: BlockInput; peerIdStr: string}> {
-    const shuffledPeers = shuffle(connectedPeers);
+  private async fetchUnknownBlockRoot(blockRoot: Root): Promise<{blockInput: BlockInput; peerIdStr: string}> {
     const blockRootHex = toRootHex(blockRoot);
 
+    const requestedPeers = new Set<PeerIdStr>();
+    let partialDownload: PartialDownload | null = null;
+    const defaultPendingColumns =
+      this.config.getForkSeq(this.chain.clock.currentSlot) >= ForkSeq.fulu
+        ? new Set(this.network.custodyConfig.sampleGroups)
+        : null;
     let lastError: Error | null = null;
-    let partialDownload = null;
-    let fetchedPeerId = null;
-    for (let i = 0; i < MAX_ATTEMPTS_PER_BLOCK; i++) {
-      const peerId = shuffledPeers[i % shuffledPeers.length];
-      const {custodyGroups: peerColumns, client: peerClient} = this.network.getConnectedPeerSyncMeta(peerId);
-      if (partialDownload !== null) {
-        const [prevBlockInput] = partialDownload.blocks;
-        if (prevBlockInput === undefined || prevBlockInput.type !== BlockInputType.dataPromise) {
-          throw Error(`prevBlockInput=${prevBlockInput?.type} in partialDownload`);
-        }
-        const {cachedData} = prevBlockInput;
-        if (cachedData.fork === ForkName.fulu) {
-          const {dataColumnsCache} = cachedData as CachedDataColumns;
-          const sampledColumns = this.network.custodyConfig.sampledColumns;
-          const neededColumns = sampledColumns.reduce((acc, elem) => {
-            if (dataColumnsCache.get(elem) === undefined) {
-              acc.push(elem);
-            }
-            return acc;
-          }, [] as number[]);
-          const columns = peerColumns.reduce((acc, elem) => {
-            if (neededColumns.includes(elem)) {
-              acc.push(elem);
-            }
-            return acc;
-          }, [] as number[]);
-
-          if (columns.length === 0) {
-            continue;
-          }
-        }
+    let i = 0;
+    while (i++ < this.getMaxDownloadAttempts()) {
+      // pendingDataColumns is null prefulu
+      const peer = this.peerBalancer.bestPeerForPendingColumns(
+        partialDownload ? new Set(partialDownload.pendingDataColumns) : defaultPendingColumns,
+        requestedPeers
+      );
+      if (peer === null) {
+        // no more peer with needed columns to try, throw error
+        throw Error(
+          `Error fetching UnknownBlockRoot after ${i}: cannot find peer with needed columns ${partialDownload?.pendingDataColumns.join(", ")}`
+        );
       }
+      const {peerId, client: peerClient} = peer;
+      requestedPeers.add(peerId);
 
       try {
         const {
@@ -623,11 +575,10 @@ export class UnknownBlockSync {
 
         if (pendingDataColumns !== null) {
           partialDownload = {blocks: [blockInput], pendingDataColumns};
-          fetchedPeerId = peerId;
           continue;
         }
 
-        // Verify block root is correct
+        // data is available, verify block root is correct
         const block = blockInput.block.message;
         const receivedBlockRoot = this.config.getForkTypes(block.slot).BeaconBlock.hashTreeRoot(block);
         if (!byteArrayEquals(receivedBlockRoot, blockRoot)) {
@@ -638,21 +589,18 @@ export class UnknownBlockSync {
       } catch (e) {
         this.logger.debug("Error fetching UnknownBlockRoot", {attempt: i, blockRootHex, peer: peerId}, e as Error);
         lastError = e as Error;
+      } finally {
+        this.peerBalancer.onRequestCompleted(peerId);
       }
     }
 
     if (lastError) {
-      lastError.message = `Error fetching UnknownBlockRoot after ${MAX_ATTEMPTS_PER_BLOCK} attempts: ${lastError.message}`;
+      lastError.message = `Error fetching UnknownBlockRoot after ${i} attempts: ${lastError.message}`;
       throw lastError;
     }
-    if (partialDownload !== null && fetchedPeerId !== null) {
-      const {
-        blocks: [blockInput],
-      } = partialDownload;
-      return {blockInput, peerIdStr: fetchedPeerId};
-    }
+
     throw Error(
-      `Error fetching UnknownBlockRoot after ${MAX_ATTEMPTS_PER_BLOCK}: unknown error because either partialDownload is null=${partialDownload === null} or fetchedPeerId is null=${fetchedPeerId === null} `
+      `Error fetching UnknownBlockRoot after ${i}: cannot download all blobs or data columns for block ${blockRootHex}`
     );
   }
 
@@ -660,18 +608,15 @@ export class UnknownBlockSync {
    * We have partial block input:
    * - we have block but not have all blobs (deneb) or needed columns (fulu)
    * - we don't have block and have some blobs (deneb) or some columns (fulu)
-   * Fetches missing blobs for the blockinput, in future can also pull block is thats also missing
-   * along with the blobs (i.e. only some blobs are available)
+   * Fetches missing block/data columns/block for the blockinput. This function returns either preData or availableData BlockInput.
    */
   private async fetchUnavailableBlockInput(
-    unavailableBlockInput: BlockInput | NullBlockInput,
-    connectedPeers: PeerIdStr[]
+    unavailableBlockInput: BlockInput | NullBlockInput
   ): Promise<{blockInput: BlockInput; peerIdStr: string}> {
     if (unavailableBlockInput.block !== null && unavailableBlockInput.type !== BlockInputType.dataPromise) {
       return {blockInput: unavailableBlockInput, peerIdStr: ""};
     }
 
-    const shuffledPeers = shuffle(connectedPeers);
     let blockRootHex: RootHex;
     let blobKzgCommitmentsLen: number | undefined;
     let blockRoot: Uint8Array;
@@ -700,31 +645,17 @@ export class UnknownBlockSync {
     }
 
     let lastError: Error | null = null;
-    for (let i = 0; i < MAX_ATTEMPTS_PER_BLOCK; i++) {
-      const peerId = shuffledPeers[i % shuffledPeers.length];
-      const {custodyGroups: peerColumns, client: peerClient} = this.network.getConnectedPeerSyncMeta(peerId);
-      if (unavailableBlockInput.block !== null) {
-        const {cachedData} = unavailableBlockInput;
-        if (cachedData.fork === ForkName.fulu) {
-          const {dataColumnsCache} = cachedData as CachedDataColumns;
-          const neededColumns = sampledColumns.reduce((acc, elem) => {
-            if (dataColumnsCache.get(elem) === undefined) {
-              acc.push(elem);
-            }
-            return acc;
-          }, [] as number[]);
-          const columns = peerColumns.reduce((acc, elem) => {
-            if (neededColumns.includes(elem)) {
-              acc.push(elem);
-            }
-            return acc;
-          }, [] as number[]);
-
-          if (columns.length === 0) {
-            continue;
-          }
-        }
+    let i = 0;
+    const requestedPeers = new Set<PeerIdStr>();
+    while (i++ < this.getMaxDownloadAttempts()) {
+      const bestPeer = this.peerBalancer.bestPeerForBlockInput(unavailableBlockInput, requestedPeers);
+      if (bestPeer === null) {
+        // no more peer to try, throw error
+        throw Error(
+          `Error fetching UnavailableBlockInput after ${i}: cannot find peer with needed columns ${sampledColumns.join(", ")}`
+        );
       }
+      const {peerId, client: peerClient} = bestPeer;
 
       try {
         const blockInput = await unavailableBeaconBlobsByRoot(
@@ -743,18 +674,13 @@ export class UnknownBlockSync {
           }
         );
 
-        // Peer does not have the block, try with next peer
-        if (blockInput === undefined) {
-          continue;
-        }
-
         if (unavailableBlockInput.block !== null && blockInput.type === BlockInputType.dataPromise) {
           // all datacolumns were not downloaded we can continue with other peers
           // as unavailableBlockInput.block's dataColumnsCache would be updated
           continue;
         }
 
-        // Verify block root is correct
+        // data is available, verify block root is correct
         const block = blockInput.block.message;
         const receivedBlockRoot = this.config.getForkTypes(block.slot).BeaconBlock.hashTreeRoot(block);
 
@@ -771,15 +697,17 @@ export class UnknownBlockSync {
       } catch (e) {
         this.logger.debug("Error fetching UnavailableBlockInput", {attempt: i, blockRootHex, peer: peerId}, e as Error);
         lastError = e as Error;
+      } finally {
+        this.peerBalancer.onRequestCompleted(peerId);
       }
     }
 
     if (lastError) {
-      lastError.message = `Error fetching UnavailableBlockInput after ${MAX_ATTEMPTS_PER_BLOCK} attempts: ${lastError.message}`;
+      lastError.message = `Error fetching UnavailableBlockInput after ${i} attempts: ${lastError.message}`;
       throw lastError;
     }
 
-    throw Error(`Error fetching UnavailableBlockInput after ${MAX_ATTEMPTS_PER_BLOCK}: unknown error`);
+    throw Error(`Error fetching UnavailableBlockInput after ${i}: unknown error`);
   }
 
   /**
@@ -824,5 +752,232 @@ export class UnknownBlockSync {
     }
 
     return badPendingBlocks;
+  }
+
+  private getMaxDownloadAttempts(): number {
+    if (this.config.getForkSeq(this.chain.clock.currentSlot) < ForkSeq.fulu) {
+      return MAX_ATTEMPTS_PER_BLOCK;
+    }
+
+    // TODO: I consider max 20 downloads per block for a supernode is enough for devnets
+    // review this computation for public testnets or mainnet
+    return Math.min(
+      20,
+      (MAX_ATTEMPTS_PER_BLOCK * this.network.custodyConfig.sampleGroups.length) / this.config.SAMPLES_PER_SLOT
+    );
+  }
+}
+
+/**
+ * Class to track active byRoots requests and balance them across eligible peers.
+ */
+export class UnknownBlockPeerBalancer {
+  private readonly peersMeta: Map<PeerIdStr, PeerSyncMeta>;
+  private readonly activeRequests: Map<PeerIdStr, number>;
+  private readonly custodyConfig: CustodyConfig;
+
+  constructor(custodyConfig: CustodyConfig) {
+    this.peersMeta = new Map();
+    this.activeRequests = new Map();
+    this.custodyConfig = custodyConfig;
+  }
+
+  onPeerConnected(peerId: PeerIdStr, syncMeta: PeerSyncMeta): void {
+    if (!this.peersMeta.has(peerId)) {
+      this.peersMeta.set(peerId, syncMeta);
+    }
+
+    if (!this.activeRequests.has(peerId)) {
+      this.activeRequests.set(peerId, 0);
+    }
+  }
+
+  onPeerDisconnected(peerId: PeerIdStr): void {
+    this.peersMeta.delete(peerId);
+    this.activeRequests.delete(peerId);
+  }
+
+  /**
+   * called from fetchUnknownBlockRoot() where we only have block root and nothing else
+   * excludedPeers are the peers that we requested already so we don't want to try again
+   * pendingColumns is empty for prefulu, or the 1st time we we download a block by root
+   */
+  bestPeerForPendingColumns(pendingColumns: Set<number> | null, excludedPeers: Set<PeerIdStr>): PeerSyncMeta | null {
+    const eligiblePeers = this.filterPeers(pendingColumns, excludedPeers);
+    if (eligiblePeers.length === 0) {
+      return null;
+    }
+
+    const sortedEligiblePeers = sortBy(
+      shuffle(eligiblePeers),
+      // prefer peers with least active req
+      (peerId) => this.activeRequests.get(peerId) ?? 0
+    );
+
+    const bestPeerId = sortedEligiblePeers[0];
+    this.onRequest(bestPeerId);
+    return this.peersMeta.get(bestPeerId) ?? null;
+  }
+
+  /**
+   * called from fetchUnavailableBlockInput() where we have either BlockInput or NullBlockInput
+   * excludedPeers are the peers that we requested already so we don't want to try again
+   */
+  bestPeerForBlockInput(
+    unavailableBlockInput: BlockInput | NullBlockInput,
+    excludedPeers: Set<PeerIdStr>
+  ): PeerSyncMeta | null {
+    let cachedData: CachedData | undefined = undefined;
+    if (unavailableBlockInput.block === null) {
+      // NullBlockInput
+      cachedData = unavailableBlockInput.cachedData;
+    } else {
+      // BlockInput
+      if (unavailableBlockInput.type !== BlockInputType.dataPromise) {
+        throw Error(
+          `bestPeerForBlockInput called with BlockInput type ${unavailableBlockInput.type}, expected dataPromise`
+        );
+      }
+      cachedData = unavailableBlockInput.cachedData;
+    }
+
+    const eligiblePeers: PeerIdStr[] = [];
+
+    if (cachedData.fork === ForkName.fulu) {
+      // cached data is CachedDataColumns
+      const {dataColumnsCache} = cachedData;
+      const pendingDataColumns: Set<number> = new Set();
+      for (const column of this.custodyConfig.sampledColumns) {
+        if (!dataColumnsCache.has(column)) {
+          pendingDataColumns.add(column);
+        }
+      }
+      if (pendingDataColumns.size === 0) {
+        // no pending columns, we can return null
+        return null;
+      }
+      eligiblePeers.push(...this.filterPeers(pendingDataColumns, excludedPeers));
+    } else {
+      // prefulu
+      const pendingDataColumns = null;
+      eligiblePeers.push(...this.filterPeers(pendingDataColumns, excludedPeers));
+    }
+
+    if (eligiblePeers.length === 0) {
+      return null;
+    }
+
+    const sortedEligiblePeers = sortBy(
+      shuffle(eligiblePeers),
+      // prefer peers with least active req
+      (peerId) => this.activeRequests.get(peerId) ?? 0
+    );
+
+    const bestPeerId = sortedEligiblePeers[0];
+    this.onRequest(bestPeerId);
+    return this.peersMeta.get(bestPeerId) ?? null;
+  }
+
+  /**
+   * Consumers don't need to call this method directly, it is called internally by bestPeer*() methods
+   * make this public for testing
+   */
+  onRequest(peerId: PeerIdStr): void {
+    if (this.activeRequests.has(peerId)) {
+      this.activeRequests.set(peerId, (this.activeRequests.get(peerId) ?? 0) + 1);
+    } else {
+      this.activeRequests.set(peerId, 1);
+    }
+  }
+
+  /**
+   * Consumers should call this method when a request is completed for a peer.
+   */
+  onRequestCompleted(peerId: PeerIdStr): void {
+    if (this.activeRequests.has(peerId)) {
+      const count = this.activeRequests.get(peerId) ?? 0;
+      this.activeRequests.set(peerId, Math.max(0, count - 1));
+    }
+  }
+
+  /**
+   * For testing only
+   */
+  getActiveRequest(peerId: PeerIdStr): number {
+    return this.activeRequests.get(peerId) ?? 0;
+  }
+
+  getPeersMetaCount(): number {
+    return this.peersMeta.size;
+  }
+
+  getPeersActiveRequestCount(): number {
+    return this.activeRequests.size;
+  }
+
+  getTotalActiveRequests(): number {
+    let totalActiveRequests = 0;
+    for (const count of this.activeRequests.values()) {
+      totalActiveRequests += count;
+    }
+    return totalActiveRequests;
+  }
+
+  // pendingDataColumns could be null for prefulu
+  private filterPeers(pendingDataColumns: Set<number> | null, excludedPeers: Set<PeerIdStr>): PeerIdStr[] {
+    let maxColumnCount = 0;
+    const considerPeers: {peerId: PeerIdStr; columnCount: number}[] = [];
+    for (const [peerId, syncMeta] of this.peersMeta.entries()) {
+      if (excludedPeers.has(peerId)) {
+        // this peer is requested already
+        continue;
+      }
+
+      const activeRequests = this.activeRequests.get(peerId) ?? 0;
+      if (activeRequests >= MAX_CONCURRENT_REQUESTS) {
+        // should return peer with no more than MAX_CONCURRENT_REQUESTS active requests
+        continue;
+      }
+
+      if (pendingDataColumns === null || pendingDataColumns.size === 0) {
+        // prefulu, no pending columns
+        considerPeers.push({peerId, columnCount: 0});
+        continue;
+      }
+
+      // postfulu, find peers that have custody columns that we need
+      const {custodyGroups: peerColumns} = syncMeta;
+      // check if the peer has all needed columns
+      const neededColumns = this.custodyConfig.sampledColumns.reduce((acc, elem) => {
+        if (pendingDataColumns.has(elem)) {
+          acc.push(elem);
+        }
+        return acc;
+      }, [] as number[]);
+
+      // get match
+      const columns = peerColumns.reduce((acc, elem) => {
+        if (neededColumns.includes(elem)) {
+          acc.push(elem);
+        }
+        return acc;
+      }, [] as number[]);
+
+      if (columns.length > 0) {
+        if (columns.length > maxColumnCount) {
+          maxColumnCount = columns.length;
+        }
+        considerPeers.push({peerId, columnCount: columns.length});
+      }
+    } // end for
+
+    const eligiblePeers: PeerIdStr[] = [];
+    for (const {peerId, columnCount} of considerPeers) {
+      if (columnCount === maxColumnCount) {
+        eligiblePeers.push(peerId);
+      }
+    }
+
+    return eligiblePeers;
   }
 }

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -60,10 +60,8 @@ export class UnknownBlockSync {
       metrics.syncUnknownBlock.pendingBlocks.addCollect(() => {
         metrics.syncUnknownBlock.pendingBlocks.set(this.pendingBlocks.size);
         metrics.syncUnknownBlock.knownBadBlocks.set(this.knownBadBlocks.size);
-        metrics.syncUnknownBlock.peerBalancer.peersMetaCount.set(this.peerBalancer.getPeersMetaCount());
-        metrics.syncUnknownBlock.peerBalancer.peersActiveRequestCount.set(
-          this.peerBalancer.getPeersActiveRequestCount()
-        );
+        metrics.syncUnknownBlock.peerBalancer.peersMetaCount.set(this.peerBalancer.peersMeta.size);
+        metrics.syncUnknownBlock.peerBalancer.peersActiveRequestCount.set(this.peerBalancer.activeRequests.size);
         metrics.syncUnknownBlock.peerBalancer.totalActiveRequests.set(this.peerBalancer.getTotalActiveRequests());
       });
     }
@@ -530,7 +528,7 @@ export class UnknownBlockSync {
   private async fetchUnknownBlockRoot(blockRoot: Root): Promise<{blockInput: BlockInput; peerIdStr: string}> {
     const blockRootHex = toRootHex(blockRoot);
 
-    const requestedPeers = new Set<PeerIdStr>();
+    const excludedPeers = new Set<PeerIdStr>();
     let partialDownload: PartialDownload | null = null;
     const defaultPendingColumns =
       this.config.getForkSeq(this.chain.clock.currentSlot) >= ForkSeq.fulu
@@ -542,7 +540,7 @@ export class UnknownBlockSync {
       // pendingDataColumns is null prefulu
       const peer = this.peerBalancer.bestPeerForPendingColumns(
         partialDownload ? new Set(partialDownload.pendingDataColumns) : defaultPendingColumns,
-        requestedPeers
+        excludedPeers
       );
       if (peer === null) {
         // no more peer with needed columns to try, throw error
@@ -551,7 +549,7 @@ export class UnknownBlockSync {
         );
       }
       const {peerId, client: peerClient} = peer;
-      requestedPeers.add(peerId);
+      excludedPeers.add(peerId);
 
       try {
         const {
@@ -646,9 +644,9 @@ export class UnknownBlockSync {
 
     let lastError: Error | null = null;
     let i = 0;
-    const requestedPeers = new Set<PeerIdStr>();
+    const excludedPeers = new Set<PeerIdStr>();
     while (i++ < this.getMaxDownloadAttempts()) {
-      const bestPeer = this.peerBalancer.bestPeerForBlockInput(unavailableBlockInput, requestedPeers);
+      const bestPeer = this.peerBalancer.bestPeerForBlockInput(unavailableBlockInput, excludedPeers);
       if (bestPeer === null) {
         // no more peer to try, throw error
         throw Error(
@@ -656,6 +654,7 @@ export class UnknownBlockSync {
         );
       }
       const {peerId, client: peerClient} = bestPeer;
+      excludedPeers.add(peerId);
 
       try {
         const blockInput = await unavailableBeaconBlobsByRoot(
@@ -772,8 +771,8 @@ export class UnknownBlockSync {
  * Class to track active byRoots requests and balance them across eligible peers.
  */
 export class UnknownBlockPeerBalancer {
-  private readonly peersMeta: Map<PeerIdStr, PeerSyncMeta>;
-  private readonly activeRequests: Map<PeerIdStr, number>;
+  readonly peersMeta: Map<PeerIdStr, PeerSyncMeta>;
+  readonly activeRequests: Map<PeerIdStr, number>;
   private readonly custodyConfig: CustodyConfig;
 
   constructor(custodyConfig: CustodyConfig) {
@@ -782,10 +781,9 @@ export class UnknownBlockPeerBalancer {
     this.custodyConfig = custodyConfig;
   }
 
+  /** Trigger on each peer re-status */
   onPeerConnected(peerId: PeerIdStr, syncMeta: PeerSyncMeta): void {
-    if (!this.peersMeta.has(peerId)) {
-      this.peersMeta.set(peerId, syncMeta);
-    }
+    this.peersMeta.set(peerId, syncMeta);
 
     if (!this.activeRequests.has(peerId)) {
       this.activeRequests.set(peerId, 0);
@@ -883,36 +881,14 @@ export class UnknownBlockPeerBalancer {
    * make this public for testing
    */
   onRequest(peerId: PeerIdStr): void {
-    if (this.activeRequests.has(peerId)) {
-      this.activeRequests.set(peerId, (this.activeRequests.get(peerId) ?? 0) + 1);
-    } else {
-      this.activeRequests.set(peerId, 1);
-    }
+    this.activeRequests.set(peerId, (this.activeRequests.get(peerId) ?? 0) + 1);
   }
 
   /**
    * Consumers should call this method when a request is completed for a peer.
    */
   onRequestCompleted(peerId: PeerIdStr): void {
-    if (this.activeRequests.has(peerId)) {
-      const count = this.activeRequests.get(peerId) ?? 0;
-      this.activeRequests.set(peerId, Math.max(0, count - 1));
-    }
-  }
-
-  /**
-   * For testing only
-   */
-  getActiveRequest(peerId: PeerIdStr): number {
-    return this.activeRequests.get(peerId) ?? 0;
-  }
-
-  getPeersMetaCount(): number {
-    return this.peersMeta.size;
-  }
-
-  getPeersActiveRequestCount(): number {
-    return this.activeRequests.size;
+    this.activeRequests.set(peerId, Math.max(0, (this.activeRequests.get(peerId) ?? 1) - 1));
   }
 
   getTotalActiveRequests(): number {
@@ -929,7 +905,7 @@ export class UnknownBlockPeerBalancer {
     const considerPeers: {peerId: PeerIdStr; columnCount: number}[] = [];
     for (const [peerId, syncMeta] of this.peersMeta.entries()) {
       if (excludedPeers.has(peerId)) {
-        // this peer is requested already
+        // made request to this peer already
         continue;
       }
 
@@ -948,16 +924,9 @@ export class UnknownBlockPeerBalancer {
       // postfulu, find peers that have custody columns that we need
       const {custodyGroups: peerColumns} = syncMeta;
       // check if the peer has all needed columns
-      const neededColumns = this.custodyConfig.sampledColumns.reduce((acc, elem) => {
-        if (pendingDataColumns.has(elem)) {
-          acc.push(elem);
-        }
-        return acc;
-      }, [] as number[]);
-
       // get match
       const columns = peerColumns.reduce((acc, elem) => {
-        if (neededColumns.includes(elem)) {
+        if (pendingDataColumns.has(elem)) {
           acc.push(elem);
         }
         return acc;

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -3,21 +3,32 @@ import {toHexString} from "@chainsafe/ssz";
 import {createChainForkConfig} from "@lodestar/config";
 import {config as minimalConfig} from "@lodestar/config/default";
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
+import {ForkName} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {notNullish, sleep} from "@lodestar/utils";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
-import {BlockSource, getBlockInput} from "../../../src/chain/blocks/types.js";
+import {
+  BlockInput,
+  BlockInputDataColumns,
+  BlockInputType,
+  BlockSource,
+  CachedDataColumns,
+  getBlockInput,
+} from "../../../src/chain/blocks/types.js";
 import {BlockError, BlockErrorCode} from "../../../src/chain/errors/blockError.js";
 import {IBeaconChain} from "../../../src/chain/index.js";
 import {SeenBlockProposers} from "../../../src/chain/seenCache/seenBlockProposers.js";
 import {ZERO_HASH} from "../../../src/constants/constants.js";
 import {INetwork, NetworkEvent, NetworkEventBus, PeerAction} from "../../../src/network/index.js";
+import {PeerSyncMeta} from "../../../src/network/peers/peersData.js";
 import {defaultSyncOptions} from "../../../src/sync/options.js";
-import {UnknownBlockSync} from "../../../src/sync/unknownBlock.js";
+import {UnknownBlockPeerBalancer, UnknownBlockSync} from "../../../src/sync/unknownBlock.js";
+import {CustodyConfig} from "../../../src/util/dataColumns.js";
+import {PeerIdStr} from "../../../src/util/peerId.js";
 import {ClockStopped} from "../../mocks/clock.js";
 import {MockedBeaconChain, getMockedBeaconChain} from "../../mocks/mockedBeaconChain.js";
 import {testLogger} from "../../utils/logger.js";
-import {getRandPeerIdStr} from "../../utils/peer.js";
+import {getRandPeerIdStr, getRandPeerSyncMeta} from "../../utils/peer.js";
 
 describe.skip(
   "sync by UnknownBlockSync",
@@ -297,5 +308,125 @@ describe("UnknownBlockSync", () => {
         }
       });
     }
+  });
+});
+
+describe("UnknownBlockPeerBalancer", async () => {
+  const custodyConfig = {sampledColumns: [0, 1, 2, 3]} as CustodyConfig;
+  const peer0 = await getRandPeerSyncMeta("peer-0");
+  const peer1 = await getRandPeerSyncMeta("peer-1");
+  const peer2 = await getRandPeerSyncMeta("peer-2");
+  const peer3 = await getRandPeerSyncMeta("peer-3");
+  const peers = [peer0, peer1, peer2, peer3];
+  const peersMeta = new Map<string, PeerSyncMeta>(peers.map((p) => [p.peerId, p]));
+
+  // column 0 and 1 are downloaded
+  // column 2 and 3 are pending
+  const testCases: {
+    custodyGroups: number[][];
+    excludedPeers: PeerIdStr[];
+    activeRequests: number[];
+    bestPeer: PeerSyncMeta | null;
+  }[] = [
+    {
+      // test excludedPeers condition
+      // peers[2] and peers[3] are eligible
+      // peers[2] is excluded because it's requested
+      custodyGroups: [[0], [1], [2], [3]],
+      excludedPeers: [peers[2].peerId],
+      activeRequests: [0, 0, 0, 0],
+      bestPeer: peers[3],
+    },
+    {
+      // test activeRequest condition
+      // peers[2] and peers[3] have custody groups
+      // peers[3] has 2 active requests so it's not eligible
+      custodyGroups: [[0], [1], [2], [3]],
+      excludedPeers: [],
+      activeRequests: [0, 0, 0, 2],
+      bestPeer: peers[2],
+    },
+    {
+      // test all conditions
+      // peers[0] and peers[1] does not have pending columns
+      // peers[2] is excluded because it's requested
+      // peers[3] has 2 active requests so it's not eligible
+      custodyGroups: [[0], [1], [2], [3]],
+      excludedPeers: [peers[2].peerId],
+      activeRequests: [0, 0, 0, 2],
+      bestPeer: null,
+    },
+  ];
+
+  let peerBalancer: UnknownBlockPeerBalancer;
+  beforeEach(() => {
+    peerBalancer = new UnknownBlockPeerBalancer(custodyConfig);
+    for (const [peerId, peerMeta] of peersMeta.entries()) {
+      peerBalancer.onPeerConnected(peerId, peerMeta);
+    }
+  });
+
+  for (const [testCaseIndex, {custodyGroups, excludedPeers, activeRequests, bestPeer}] of testCases.entries()) {
+    for (const [i, groups] of custodyGroups.entries()) {
+      peers[i].custodyGroups = groups;
+    }
+
+    const signedBlock = ssz.fulu.SignedBeaconBlock.defaultValue();
+    const cachedData: CachedDataColumns = {
+      cacheId: 2025,
+      fork: ForkName.fulu,
+      availabilityPromise: Promise.resolve({} as unknown as BlockInputDataColumns),
+      resolveAvailability: () => {},
+      dataColumnsCache: new Map([
+        [0, {dataColumn: ssz.fulu.DataColumnSidecar.defaultValue(), dataColumnBytes: null}],
+        [1, {dataColumn: ssz.fulu.DataColumnSidecar.defaultValue(), dataColumnBytes: null}],
+      ]),
+      calledRecover: false,
+    };
+    const blockInput: BlockInput = {
+      block: signedBlock,
+      source: BlockSource.gossip,
+      type: BlockInputType.dataPromise,
+      cachedData,
+    };
+
+    it(`bestPeerForBlockInput - test case ${testCaseIndex}`, () => {
+      for (const [i, activeRequest] of activeRequests.entries()) {
+        for (let j = 0; j < activeRequest; j++) {
+          peerBalancer.onRequest(peers[i].peerId);
+        }
+      }
+      const peer = peerBalancer.bestPeerForBlockInput(blockInput, new Set(excludedPeers));
+      if (bestPeer) {
+        expect(peer).toEqual(bestPeer);
+      } else {
+        expect(peer).toBeNull();
+      }
+    });
+
+    it(`bestPeerForPendingColumns - test case ${testCaseIndex}`, () => {
+      for (const [i, activeRequest] of activeRequests.entries()) {
+        for (let j = 0; j < activeRequest; j++) {
+          peerBalancer.onRequest(peers[i].peerId);
+        }
+      }
+      const peer = peerBalancer.bestPeerForPendingColumns(new Set([2, 3]), new Set(excludedPeers));
+      if (bestPeer) {
+        expect(peer).toEqual(bestPeer);
+      } else {
+        expect(peer).toBeNull();
+      }
+    });
+  } // end for testCases
+
+  it("onRequest and onRequestCompleted", () => {
+    peerBalancer.onRequest(peers[0].peerId);
+    expect(peerBalancer.getActiveRequest(peers[0].peerId)).toBe(1);
+    peerBalancer.onRequest(peers[0].peerId);
+    expect(peerBalancer.getActiveRequest(peers[0].peerId)).toBe(2);
+    peerBalancer.onRequestCompleted(peers[0].peerId);
+    expect(peerBalancer.getActiveRequest(peers[0].peerId)).toBe(1);
+    peerBalancer.onRequestCompleted(peers[0].peerId);
+    expect(peerBalancer.getActiveRequest(peers[0].peerId)).toBe(0);
   });
 });

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -421,12 +421,12 @@ describe("UnknownBlockPeerBalancer", async () => {
 
   it("onRequest and onRequestCompleted", () => {
     peerBalancer.onRequest(peers[0].peerId);
-    expect(peerBalancer.getActiveRequest(peers[0].peerId)).toBe(1);
+    expect(peerBalancer.activeRequests.get(peers[0].peerId)).toBe(1);
     peerBalancer.onRequest(peers[0].peerId);
-    expect(peerBalancer.getActiveRequest(peers[0].peerId)).toBe(2);
+    expect(peerBalancer.activeRequests.get(peers[0].peerId)).toBe(2);
     peerBalancer.onRequestCompleted(peers[0].peerId);
-    expect(peerBalancer.getActiveRequest(peers[0].peerId)).toBe(1);
+    expect(peerBalancer.activeRequests.get(peers[0].peerId)).toBe(1);
     peerBalancer.onRequestCompleted(peers[0].peerId);
-    expect(peerBalancer.getActiveRequest(peers[0].peerId)).toBe(0);
+    expect(peerBalancer.activeRequests.get(peers[0].peerId)).toBe(0);
   });
 });


### PR DESCRIPTION
**Motivation**

- fix unstable `UnknownBlockSync` issues

**Description**

- implement PeerBalancer for `UnknownBlockSync`, that will help us avoid rate limiting errors
- consume PeerBalancer, simplify the code of `downloadBlock()` and related functions
- implement fork-aware `getMaxDownloadAttempts()`
- fix #8194


Closes #8182
Closes #8194

**Steps to test or reproduce**

- [x] passed UnknownBlockSync e2e tests
- [x] passed UnknownBlockSync sim tests
