### PR TITLE
chore: fix typos across Lodestar codebase (comments, identifiers, docs)

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -58,7 +58,7 @@ export async function verifyBlocksDataAvailability(
     if (signal.aborted) {
       throw new ErrorAborted("verifyBlocksDataAvailability");
     }
-    // Validate status of only not yet finalized blocks, we don't need yet to propogate the status
+    // Validate status of only not yet finalized blocks, we don't need yet to propagate the status
     // as it is not used upstream anywhere
     const {dataAvailabilityStatus, availableBlockInput} = await maybeValidateBlobs(chain, blockInput, signal, opts);
     dataAvailabilityStatuses.push(dataAvailabilityStatus);

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -208,7 +208,7 @@ export class SeenGossipBlockInput {
         dataColumnBytes: dataColumnBytes?.slice(0, dataColumnBytes.length) ?? null,
       });
     } else {
-      // somehow helps resolve typescript that all types have been exausted
+      // somehow helps resolve typescript that all types have been exhausted
       throw Error("Invalid gossipedInput type");
     }
 

--- a/packages/beacon-node/src/execution/engine/payloadIdCache.ts
+++ b/packages/beacon-node/src/execution/engine/payloadIdCache.ts
@@ -3,7 +3,7 @@ import {pruneSetToMax} from "@lodestar/utils";
 import {DATA, QUANTITY} from "../../eth1/provider/utils.js";
 import {PayloadAttributesRpc} from "./types.js";
 
-// Idealy this only need to be set to the max head reorgs number
+// Ideally this only need to be set to the max head reorgs number
 const MAX_PAYLOAD_IDS = SLOTS_PER_EPOCH;
 
 // An execution engine can produce a payload id anywhere the uint64 range

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -322,7 +322,7 @@ export class NetworkCore implements INetworkCore {
   }
 
   /**
-   * Request att subnets up `toSlot`. Network will ensure to mantain some peers for each
+   * Request att subnets up `toSlot`. Network will ensure to maintain some peers for each
    */
   async prepareBeaconCommitteeSubnets(subscriptions: CommitteeSubscription[]): Promise<void> {
     this.attnetsService.addCommitteeSubscriptions(subscriptions);
@@ -378,7 +378,7 @@ export class NetworkCore implements INetworkCore {
   async setTargetGroupCount(count: number): Promise<void> {
     this.networkConfig.custodyConfig.updateTargetCustodyGroupCount(count);
     this.metadata.custodyGroupCount = count;
-    // cannot call subscribeGossipCoreTopics() because we subsribed to core topics already
+    // cannot call subscribeGossipCoreTopics() because we subscribed to core topics already
     // we only need to subscribe to more data_column_sidecar topics
     const dataColumnSubnetTopics = getDataColumnSidecarTopics(this.networkConfig);
     const activeBoundaries = getActiveForkBoundaries(this.config, this.clock.currentEpoch);

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -47,7 +47,7 @@ export class GossipTopicCache implements IGossipTopicCache {
 }
 
 /**
- * Stringify a GossipTopic into a spec-ed formated topic string
+ * Stringify a GossipTopic into a spec-ed formatted topic string
  */
 export function stringifyGossipTopic(forkDigestContext: ForkDigestContext, topic: GossipTopic): string {
   const forkDigestHexNoPrefix = forkDigestContext.forkBoundary2ForkDigestHex(topic.boundary);
@@ -57,7 +57,7 @@ export function stringifyGossipTopic(forkDigestContext: ForkDigestContext, topic
 }
 
 /**
- * Stringify a GossipTopic into a spec-ed formated partial topic string
+ * Stringify a GossipTopic into a spec-ed formatted partial topic string
  */
 function stringifyGossipTopicType(topic: GossipTopic): string {
   switch (topic.type) {
@@ -144,7 +144,7 @@ export function sszDeserializeAttestation(fork: ForkName, serializedData: Uint8A
 }
 
 /**
- * Deserialize a gossip seralized data into an SingleAttestation object.
+ * Deserialize a gossip serialized data into a SingleAttestation object.
  */
 export function sszDeserializeSingleAttestation(fork: ForkName, serializedData: Uint8Array): SingleAttestation {
   try {

--- a/packages/beacon-node/src/network/processor/gossipQueues/index.ts
+++ b/packages/beacon-node/src/network/processor/gossipQueues/index.ts
@@ -88,7 +88,7 @@ const indexedGossipQueueOpts: {
  * Wraps a GossipValidatorFn with a queue, to limit the processing of gossip objects by type.
  *
  * A queue here is essential to protect against DOS attacks, where a peer may send many messages at once.
- * Queues also protect the node against overloading. If the node gets bussy with an expensive epoch transition,
+ * Queues also protect the node against overloading. If the node gets busy with an expensive epoch transition,
  * it may buffer too many gossip objects causing an Out of memory (OOM) error. With a queue the node will reject
  * new objects to fit its current throughput.
  *

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -184,7 +184,7 @@ export class NetworkProcessor {
       () => new MapDef<RootHex, Set<PendingGossipsubMessage>>(() => new Set())
     );
 
-    // TODO: Implement queues and priorization for ReqResp incoming requests
+    // TODO: Implement queues and prioritization for ReqResp incoming requests
     // Listens to NetworkEvent.reqRespIncomingRequest event
 
     if (metrics) {
@@ -367,7 +367,7 @@ export class NetworkProcessor {
       const reason = this.checkAcceptWork();
 
       for (const topic of executeGossipWorkOrder) {
-        // beacon block is guaranteed to be processed immedately
+        // beacon block is guaranteed to be processed immediately
         // reason !== null means cannot accept work
         if (reason !== null && !executeGossipWorkOrderObj[topic]?.bypassQueue) {
           this.metrics?.networkProcessor.canNotAcceptWork.inc({reason});
@@ -392,7 +392,7 @@ export class NetworkProcessor {
             .catch((e) => this.logger.error("processGossipAttestations must not throw", {}, e));
 
           jobsSubmitted += numMessages;
-          // Attempt to find more work, but check canAcceptWork() again and run executeGossipWorkOrder priorization
+          // Attempt to find more work, but check canAcceptWork() again and run executeGossipWorkOrder prioritization
           continue job_loop;
         }
       }

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -233,7 +233,7 @@ export function matchBlockWithBlobs(
   let lastMatchedSlot = -1;
 
   // Match blobSideCar with the block as some blocks would have no blobs and hence
-  // would be omitted from the response. If there are any inconsitencies in the
+  // would be omitted from the response. If there are any inconsistencies in the
   // response, the validations during import will reject the block and hence this
   // entire segment.
   //
@@ -331,7 +331,7 @@ export function matchBlockWithDataColumns(
   const shouldHaveAllData = neededColumns.reduce((acc, elem) => acc && requestedColumns.includes(elem), true);
 
   // Match dataColumnSideCar with the block as some blocks would have no dataColumns and hence
-  // would be omitted from the response. If there are any inconsitencies in the
+  // would be omitted from the response. If there are any inconsistencies in the
   // response, the validations during import will reject the block and hence this
   // entire segment.
   //

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -36,7 +36,7 @@ import {
   matchBlockWithDataColumns,
 } from "./beaconBlocksMaybeBlobsByRange.js";
 
-// keep 1 epoch of stuff, assmume 16 blobs
+// keep 1 epoch of stuff, assume 16 blobs
 const MAX_ENGINE_GETBLOBS_CACHE = 32 * 16;
 const MAX_UNAVAILABLE_RETRY_CACHE = 32;
 
@@ -122,7 +122,7 @@ export async function beaconBlocksMaybeBlobsByRoot(
       allBlobSidecars = [];
     }
 
-    // The last arg is to provide slot to which all blobs should be exausted in matching
+    // The last arg is to provide slot to which all blobs should be exhausted in matching
     // and here it should be infinity since all bobs should match
     const blockInputWithBlobs = matchBlockWithBlobs(
       config,
@@ -163,7 +163,7 @@ export async function beaconBlocksMaybeBlobsByRoot(
       allDataColumnsSidecars = [];
     }
 
-    // The last arg is to provide slot to which all blobs should be exausted in matching
+    // The last arg is to provide slot to which all blobs should be exhausted in matching
     // and here it should be infinity since all bobs should match
     // TODO: should not call matchBlockWithDataColumns() because it's supposed for range sync
     // in that function, peers should return all requested data columns, this function runs at gossip time

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -35,7 +35,7 @@ export async function* onBeaconBlocksByRange(
   // Non-finalized range of blocks
   if (endSlot > finalizedSlot) {
     const headRoot = chain.forkChoice.getHeadRoot();
-    // TODO DENEB: forkChoice should mantain an array of canonical blocks, and change only on reorg
+    // TODO DENEB: forkChoice should maintain an array of canonical blocks, and change only on reorg
     const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
     // getAllAncestorBlocks response includes the head node, so it's the full chain.
 

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
@@ -35,7 +35,7 @@ export async function* onBlobSidecarsByRange(
   // Non-finalized range of blobs
   if (endSlot > finalizedSlot) {
     const headRoot = chain.forkChoice.getHeadRoot();
-    // TODO DENEB: forkChoice should mantain an array of canonical blocks, and change only on reorg
+    // TODO DENEB: forkChoice should maintain an array of canonical blocks, and change only on reorg
     const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
 
     // Iterate head chain with ascending block numbers

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -30,7 +30,7 @@ type AggregatorDutyInfo = Map<SubnetID, number | null>;
 const NOT_ABLE_TO_FORM_STABLE_MESH_SEC = -1;
 
 /**
- * Manage deleterministic long lived (DLL) subnets and short lived subnets.
+ * Manage deterministic long lived (DLL) subnets and short lived subnets.
  * - PeerManager uses attnetsService to know which peers are required for duties and long lived subscriptions
  * - Network call addCommitteeSubscriptions() from API calls
  * - Gossip handler checks shouldProcess to know if validator is aggregator
@@ -84,7 +84,7 @@ export class AttnetsService implements IAttnetsService {
   }
 
   /**
-   * Get all active subnets for the hearbeat:
+   * Get all active subnets for the heartbeat:
    *   - committeeSubnets so that submitted attestations can be spread to the network
    *  - longLivedSubscriptions because other peers based on this node's ENR for their submitted attestations
    */
@@ -283,7 +283,7 @@ export class AttnetsService implements IAttnetsService {
       this.longLivedSubscriptions.add(subnet);
     }
 
-    // Only tell gossip to unsubsribe last, longLivedSubscriptions has the latest state
+    // Only tell gossip to unsubscribe last, longLivedSubscriptions has the latest state
     this.unsubscribeSubnets(toRemoveSubnets, this.clock.currentSlot, SubnetSource.longLived);
     this.updateMetadata();
   }
@@ -325,7 +325,7 @@ export class AttnetsService implements IAttnetsService {
   }
 
   /**
-   * Trigger a gossip subcription only if not already subscribed
+   * Trigger a gossip subscription only if not already subscribed
    * shortLivedSubscriptions or longLivedSubscriptions should be updated right AFTER this called
    **/
   private subscribeToSubnets(subnets: number[], src: SubnetSource): void {

--- a/packages/beacon-node/src/util/forkName.ts
+++ b/packages/beacon-node/src/util/forkName.ts
@@ -3,7 +3,7 @@ import {ForkName} from "@lodestar/params";
 import {Slot} from "@lodestar/types";
 
 /**
- * Group an array of items by ForkName according to the slot associted to each item
+ * Group an array of items by ForkName according to the slot associated to each item
  */
 export function groupByFork<T>(config: BeaconConfig, items: T[], getSlot: (item: T) => Slot): Map<ForkName, T[]> {
   const itemsByFork = new Map<ForkName, T[]>();

--- a/packages/beacon-node/src/util/promises.ts
+++ b/packages/beacon-node/src/util/promises.ts
@@ -1,5 +1,5 @@
 /**
- * Promise.all() but allows all functions to run even if one throws syncronously
+ * Promise.all() but allows all functions to run even if one throws synchronously
  */
 export function promiseAllMaybeAsync<T>(fns: Array<() => Promise<T>>): Promise<T[]> {
   return Promise.all(

--- a/packages/beacon-node/src/util/timeSeries.ts
+++ b/packages/beacon-node/src/util/timeSeries.ts
@@ -12,7 +12,7 @@ export class TimeSeries {
 
   /** Add TimeSeries entry for value at current time */
   addPoint(value: number, timeSec = Math.floor(Date.now() / 1000)): void {
-    // Substract initial time so x values are not big and cause rounding errors
+    // Subtract initial time so x values are not big and cause rounding errors
     const time = timeSec - this.startTimeSec;
     this.points.push([time, value]);
 
@@ -33,8 +33,8 @@ export class TimeSeries {
    */
   computeY0Point(): number {
     const {m, b} = linearRegression(this.points);
-    // The X cordinate system has been shifted left by startTimeSec, so return the
-    // projection in original coordinated system
+    // The X coordinate system has been shifted left by startTimeSec, so return the
+    // projection in original coordinate system
     return -b / m + this.startTimeSec;
   }
 

--- a/packages/cli/src/cmds/validator/keymanager/persistedKeys.ts
+++ b/packages/cli/src/cmds/validator/keymanager/persistedKeys.ts
@@ -119,14 +119,14 @@ export class PersistedKeysBackend implements IPersistedKeysBackend {
     persistIfDuplicate: boolean;
   }): boolean {
     // Validate Keystore JSON + pubkey format.
-    // Note: while this is currently redundant, it's free to check that format is correct before writting
+    // Note: while this is currently redundant, it's free to check that format is correct before writing
     const keystore = Keystore.parse(keystoreStr);
     const pubkeyHex = getPubkeyHexFromKeystore(keystore);
 
     const {dirpath, keystoreFilepath, passphraseFilepath} = this.getValidatorPaths(pubkeyHex);
 
     // Check if duplicate first.
-    // TODO: Check that the content is actually equal. But not naively, the JSON could be formated differently
+    // TODO: Check that the content is actually equal. But not naively, the JSON could be formatted differently
     if (!persistIfDuplicate && fs.existsSync(keystoreFilepath)) {
       return false;
     }
@@ -188,7 +188,7 @@ export class PersistedKeysBackend implements IPersistedKeysBackend {
     const {definitionFilepath} = this.getDefinitionPaths(pubkey);
 
     // Check if duplicate first.
-    // TODO: Check that the content is actually equal. But not naively, the JSON could be formated differently
+    // TODO: Check that the content is actually equal. But not naively, the JSON could be formatted differently
     if (!persistIfDuplicate && fs.existsSync(definitionFilepath)) {
       return false;
     }
@@ -212,7 +212,7 @@ export class PersistedKeysBackend implements IPersistedKeysBackend {
   }
 
   private getDefinitionPaths(pubkey: PubkeyHex): {definitionFilepath: string} {
-    // TODO: Ensure correct formating 0x prefixed
+    // TODO: Ensure correct formatting 0x prefixed
 
     return {
       definitionFilepath: path.join(this.paths.remoteKeysDir, pubkey),
@@ -225,7 +225,7 @@ export class PersistedKeysBackend implements IPersistedKeysBackend {
     passphraseFilepath: string;
     proposerDirPath: string;
   } {
-    // TODO: Ensure correct formating 0x prefixed
+    // TODO: Ensure correct formatting 0x prefixed
 
     const dirpath = path.join(this.paths.keystoresDir, pubkey);
 

--- a/packages/logger/src/utils/json.ts
+++ b/packages/logger/src/utils/json.ts
@@ -16,7 +16,7 @@ export type LogData =
  * Renders any log Context to JSON up to one level of depth.
  *
  * By limiting recursiveness, it renders limited content while ensuring safer logging.
- * Consumers of the logger should ensure to send pre-formated data if they require nesting.
+ * Consumers of the logger should ensure to send pre-formatted data if they require nesting.
  */
 export function logCtxToJson(arg: unknown, depth = 0, fromError = false): LogData {
   switch (typeof arg) {
@@ -76,7 +76,7 @@ export function logCtxToJson(arg: unknown, depth = 0, fromError = false): LogDat
  * Renders any log Context to a string up to one level of depth.
  *
  * By limiting recursiveness, it renders limited content while ensuring safer logging.
- * Consumers of the logger should ensure to send pre-formated data if they require nesting.
+ * Consumers of the logger should ensure to send pre-formatted data if they require nesting.
  */
 export function logCtxToString(arg: unknown, depth = 0, fromError = false): string {
   switch (typeof arg) {

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -111,7 +111,7 @@ export function processAttestationsAltair(
       }
 
       // TODO: describe issue. Compute progressive target balances
-      // When processing each attestation, increase the cummulative target balance. Only applies post-altair
+      // When processing each attestation, increase the cumulative target balance. Only applies post-altair
       if ((flagsNewSet & TIMELY_TARGET) === TIMELY_TARGET) {
         const validator = validators.getReadonly(validatorIndex);
         if (!validator.slashed) {

--- a/packages/state-transition/src/block/processDeposit.ts
+++ b/packages/state-transition/src/block/processDeposit.ts
@@ -19,7 +19,7 @@ import {computeDomain, computeSigningRoot, getMaxEffectiveBalance, increaseBalan
 
 /**
  * Process a Deposit operation. Potentially adds a new validator to the registry. Mutates the validators and balances
- * trees, pushing contigious values at the end.
+ * trees, pushing contiguous values at the end.
  *
  * PERF: Work depends on number of Deposit per block. On regular networks the average is 0 / block.
  */
@@ -147,7 +147,7 @@ export function isValidDepositSignature(
   amount: number,
   depositSignature: Uint8Array
 ): boolean {
-  // verify the deposit signature (proof of posession) which is not checked by the deposit contract
+  // verify the deposit signature (proof of possession) which is not checked by the deposit contract
   const depositMessage = {
     pubkey,
     withdrawalCredentials,

--- a/packages/state-transition/src/block/processEth1Data.ts
+++ b/packages/state-transition/src/block/processEth1Data.ts
@@ -43,7 +43,7 @@ export function becomesNewEth1Data(
     return false;
   }
 
-  // Close to half the EPOCHS_PER_ETH1_VOTING_PERIOD it can be expensive to do so many comparisions.
+  // Close to half the EPOCHS_PER_ETH1_VOTING_PERIOD it can be expensive to do so many comparisons.
   // `eth1DataVotes.getAllReadonly()` navigates the tree once to fetch all the LeafNodes efficiently.
   // Then isEqualEth1DataView compares cached roots (HashObject as of Jan 2022) which is much cheaper
   // than doing structural equality, which requires tree -> value conversions

--- a/packages/state-transition/src/epoch/getRewardsAndPenalties.ts
+++ b/packages/state-transition/src/epoch/getRewardsAndPenalties.ts
@@ -65,9 +65,9 @@ export function getRewardsAndPenaltiesAltair(
   const {config, epochCtx} = state;
   const fork = config.getForkSeq(state.slot);
 
-  const inactivityPenalityMultiplier =
+  const inactivityPenaltyMultiplier =
     fork === ForkSeq.altair ? INACTIVITY_PENALTY_QUOTIENT_ALTAIR : INACTIVITY_PENALTY_QUOTIENT_BELLATRIX;
-  const penaltyDenominator = config.INACTIVITY_SCORE_BIAS * inactivityPenalityMultiplier;
+  const penaltyDenominator = config.INACTIVITY_SCORE_BIAS * inactivityPenaltyMultiplier;
 
   const {flags} = cache;
   for (let i = 0; i < flags.length; i++) {

--- a/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -87,7 +87,7 @@ export function processEffectiveBalanceUpdates(
           epochCtx.previousTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;
         }
 
-        // currentTargetUnslashedBalanceIncrements is transfered to previousTargetUnslashedBalanceIncrements in afterEpochTransitionCache
+        // currentTargetUnslashedBalanceIncrements is transferred to previousTargetUnslashedBalanceIncrements in afterEpochTransitionCache
         // at epoch transition of next epoch (in EpochTransitionCache), prevTargetUnslStake is calculated based on newEffectiveBalanceIncrement
         if (!validator.slashed && (currentEpochParticipation.get(i) & TIMELY_TARGET) === TIMELY_TARGET) {
           epochCtx.currentTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;

--- a/packages/state-transition/src/slot/upgradeStateToAltair.ts
+++ b/packages/state-transition/src/slot/upgradeStateToAltair.ts
@@ -101,7 +101,7 @@ export function upgradeStateToAltair(statePhase0: CachedBeaconStatePhase0): Cach
   //       currentTargetUnslashedBalanceIncrements is rotated to previousTargetUnslashedBalanceIncrements
   //
   // Here target balance is computed in full, which is slightly less performant than doing so in the loop
-  // above but gurantees consistency with EpochCache.createFromState(). Note execution order below:
+  // above but guarantees consistency with EpochCache.createFromState(). Note execution order below:
   // ```
   // processEpoch()
   // epochCtx.afterProcessEpoch()

--- a/packages/state-transition/src/slot/upgradeStateToDeneb.ts
+++ b/packages/state-transition/src/slot/upgradeStateToDeneb.ts
@@ -22,7 +22,7 @@ export function upgradeStateToDeneb(stateCapella: CachedBeaconStateCapella): Cac
 
   // Since excessBlobGas and blobGasUsed are appended in the end to latestExecutionPayloadHeader so they should
   // be set to defaults and need no assigning, but right now any access to latestExecutionPayloadHeader fails
-  // with LeafNode has no left node. Weirdly it's because of addition of the second field as with one field
+// with LeafNode has no left node. Weirdly it's because of addition of the second field as with one field
   // it seems to work.
   //
   // TODO DENEB: Debug and remove the following cloning

--- a/packages/state-transition/src/slot/upgradeStateToDeneb.ts
+++ b/packages/state-transition/src/slot/upgradeStateToDeneb.ts
@@ -20,9 +20,9 @@ export function upgradeStateToDeneb(stateCapella: CachedBeaconStateCapella): Cac
     epoch: stateCapella.epochCtx.epoch,
   });
 
-  // Since excessBlobGas and blobGasUsed are appened in the end to latestExecutionPayloadHeader so they should
+  // Since excessBlobGas and blobGasUsed are appended in the end to latestExecutionPayloadHeader so they should
   // be set to defaults and need no assigning, but right now any access to latestExecutionPayloadHeader fails
-  // with LeafNode has no left node. Weirdly its beacuse of addition of the second field as with one field
+  // with LeafNode has no left node. Weirdly it's because of addition of the second field as with one field
   // it seems to work.
   //
   // TODO DENEB: Debug and remove the following cloning

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -189,7 +189,7 @@ export function processSlots(
  *
  *   state-transition
  *   ╔══════════════════════════════════════════════════════════════════════════════════╗
- *   ║   beforeProcessEpoch          processEpoch                 afterPRocessEpoch     ║
+ *   ║   beforeProcessEpoch          processEpoch                 afterProcessEpoch     ║
  *   ║  |-------------------------|--------------------|-------------------------------|║
  *   ║                       |                         |     |                          ║
  *   ╚═══════════════════════|═══════════════════════════════|══════════════════════════╝

--- a/packages/state-transition/src/util/blindedBlock.ts
+++ b/packages/state-transition/src/util/blindedBlock.ts
@@ -104,7 +104,7 @@ export function signedBlindedBlockToFull(
     },
   } as SignedBeaconBlock;
 
-  // state transition can't seem to handle executionPayloadHeader presense in merge block
+  // state transition can't seem to handle executionPayloadHeader presence in merge block
   // so just delete the extra field we don't require
   delete (signedBlock.message.body as {executionPayloadHeader?: ExecutionPayloadHeader}).executionPayloadHeader;
   return signedBlock;

--- a/packages/state-transition/src/util/execution.ts
+++ b/packages/state-transition/src/util/execution.ts
@@ -38,7 +38,7 @@ export function isExecutionEnabled(state: BeaconStateExecutions, block: BeaconBl
   // TODO: Consider comparing with the payload root if this assumption is not correct.
   // return !byteArrayEquals(payload.stateRoot, ZERO_HASH);
 
-  // UPDATE: stateRoot comparision should have been enough with zero hash, but spec tests were failing
+  // UPDATE: stateRoot comparison should have been enough with zero hash, but spec tests were failing
   // Revisit this later to fix specs and make this efficient
   return isExecutionPayload(payload)
     ? !ssz.bellatrix.ExecutionPayload.equals(payload, ssz.bellatrix.ExecutionPayload.defaultValue())

--- a/packages/state-transition/src/util/rootCache.ts
+++ b/packages/state-transition/src/util/rootCache.ts
@@ -3,7 +3,7 @@ import {CachedBeaconStateAllForks} from "../types.js";
 import {getBlockRoot, getBlockRootAtSlot} from "./blockRoot.js";
 
 /**
- * Cache to prevent accessing the state tree to fetch block roots repeteadly.
+ * Cache to prevent accessing the state tree to fetch block roots repeatedly.
  * In normal network conditions the same root is read multiple times, specially the target.
  */
 export class RootCache {

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -232,7 +232,7 @@ export function naiveGetNextSyncCommitteeIndices(
 }
 
 /**
- * Optmized version of `naiveGetNextSyncCommitteeIndices`.
+ * Optimized version of `naiveGetNextSyncCommitteeIndices`.
  *
  * In the worse case scenario, this could be >1000x speedup according to the perf test.
  */

--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -22,7 +22,7 @@ type ConfigWithPreset = ChainConfig & BeaconPreset;
  */
 export function assertEqualParams(localConfig: ChainConfig, externalSpecJson: SpecJson): void {
   // Before comparing, add preset which is bundled in api impl config route.
-  // config and preset must be serialized to JSON for safe comparisions.
+  // config and preset must be serialized to JSON for safe comparisons.
   const localSpecJson = {
     ...chainConfigToJson(localConfig),
     ...presetToJson(activePreset),


### PR DESCRIPTION
This PR fixes spelling mistakes, wording inconsistencies, and minor identifier typos across multiple Lodestar packages.  

#### Examples of changes
- **Beacon Node**
  - `propogate` → `propagate`
  - `exausted` → `exhausted`
  - `formated` → `formatted`
  - `seralized` → `serialized`
  - `mantain` → `maintain`
  - `deleterministic` → `deterministic`
  - `hearbeat` → `heartbeat`

- **State Transition**
  - `cummulative` → `cumulative`
  - `contigious` → `contiguous`
  - `posession` → `possession`
  - `comparisions` → `comparisons`
  - `transfered` → `transferred`
  - `gurantees` → `guarantees`
  - `appened` → `appended`
  - `beacuse` → `because`
  - `repeteadly` → `repeatedly`
  - `Optmized` → `Optimized`
  - `comparisions` → `comparisons`

- **Utilities & Logger**
  - `syncronously` → `synchronously`
  - `Substract` → `Subtract`
  - `cordinate` → `coordinate`
  - `formated` → `formatted`
  - `presense` → `presence`

- **Validator / CLI**
  - Fixed typos in `persistedKeys.ts` docstrings (`writting` → `writing`, `formating` → `formatting`).
