### PR TITLE
test: error from sim test is swallowed in `tableReporter`

### DIFF
--- a/packages/cli/test/utils/crucible/utils/index.ts
+++ b/packages/cli/test/utils/crucible/utils/index.ts
@@ -154,7 +154,11 @@ export const arrayGroupBy = <T>(
 ): Record<string, T[]> =>
   array.reduce(
     (acc, value, index, array) => {
-      acc[predicate(value, index, array)]?.push(value);
+      const key = predicate(value, index, array);
+      if (!acc[key]) {
+        acc[key] = [];
+      }
+      acc[key].push(value);
       return acc;
     },
     {} as {[key: string]: T[]}


### PR DESCRIPTION
Errors from sim tests are swallowed because `TableReporter.summary()` is not working as intended eg. https://github.com/ChainSafe/lodestar/actions/runs/17056864174/job/48356128796?pr=8091

`arrayGroupBy` will always output empty object because `acc[predicate(value, index, array)]` is always undefined and the bucket is never initialized.

