### PR TITLE
fix: handle NullBlockInput full data columns in UnknownBlockPeerBalancer

### DIFF
--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -850,10 +850,7 @@ export class UnknownBlockPeerBalancer {
           pendingDataColumns.add(column);
         }
       }
-      if (pendingDataColumns.size === 0) {
-        // no pending columns, we can return null
-        return null;
-      }
+      // there could be no pending column in case of NullBlockInput
       eligiblePeers.push(...this.filterPeers(pendingDataColumns, excludedPeers));
     } else {
       // prefulu


### PR DESCRIPTION
**Motivation**

- fix an edge case of #8219 when we have NullBlockInput with full data column found by @matthewkeil 
- see https://github.com/ChainSafe/lodestar/blob/e675be7c4038c9bc2b57be70af429f1302ea9dc0/packages/beacon-node/src/sync/blockInputSync.ts#L720

**Description**

- in that case, just return whatever peer as handled in `filterPeers()` function already
- reproduced and fixed in the new unit test
