### PR TITLE
chore: move peer id file error due to file not found to debug

### DIFF
--- a/packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts
+++ b/packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts
@@ -158,8 +158,12 @@ export async function initPrivateKeyAndEnr(
     // attempt to read stored private key
     try {
       privateKey = readPrivateKey(peerIdFile);
-    } catch (_e) {
-      logger.debug("Unable to read peerIdFile, creating a new peer id");
+    } catch (e) {
+      if ((e as {code: string}).code === "ENOENT") {
+        logger.debug("peerIdFile not found, creating a new peer id", {peerIdFile});
+      } else {
+        logger.warn("Unable to read peerIdFile, creating a new peer id", {peerIdFile}, e as Error);
+      }
       return {...(await newPrivateKeyAndENR()), newEnr: true};
     }
     // attempt to read stored enr

--- a/packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts
+++ b/packages/cli/src/cmds/beacon/initPeerIdAndEnr.ts
@@ -159,7 +159,7 @@ export async function initPrivateKeyAndEnr(
     try {
       privateKey = readPrivateKey(peerIdFile);
     } catch (_e) {
-      logger.warn("Unable to read peerIdFile, creating a new peer id");
+      logger.debug("Unable to read peerIdFile, creating a new peer id");
       return {...(await newPrivateKeyAndENR()), newEnr: true};
     }
     // attempt to read stored enr


### PR DESCRIPTION
**Motivation**

This log is currently always emitted if a user starts the node for the first time or when upgrading to next release since we now have `persistNetworkIdentity` set to `true` by default. Hence I think a warning is not the right log level here.

**Description**

Move peer id file error due to file not found to `debug`

~~Alternative could be to differentiate error, ie. still log errors other than file not found (`ENOENT`) as warn but seems unlikely that if file exists we will fail here.~~ went with this approach now

