### PR TITLE
fix: return subcommittee assignments from state sync committees endpoint

### DIFF
--- a/packages/api/src/beacon/routes/beacon/state.ts
+++ b/packages/api/src/beacon/routes/beacon/state.ts
@@ -77,7 +77,6 @@ export const EpochSyncCommitteeResponseType = new ContainerType(
   {
     /** All of the validator indices in the current sync committee */
     validators: ArrayOf(ssz.ValidatorIndex),
-    // TODO: This property will likely be deprecated
     /** Subcommittee slices of the current sync committee */
     validatorAggregates: ArrayOf(ArrayOf(ssz.ValidatorIndex)),
   },

--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -1,6 +1,12 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
-import {EPOCHS_PER_HISTORICAL_VECTOR, isForkPostElectra, isForkPostFulu} from "@lodestar/params";
+import {
+  EPOCHS_PER_HISTORICAL_VECTOR,
+  SYNC_COMMITTEE_SIZE,
+  SYNC_COMMITTEE_SUBNET_COUNT,
+  isForkPostElectra,
+  isForkPostFulu,
+} from "@lodestar/params";
 import {
   BeaconStateAllForks,
   BeaconStateElectra,
@@ -12,7 +18,7 @@ import {
   getRandaoMix,
   loadState,
 } from "@lodestar/state-transition";
-import {getValidatorStatus} from "@lodestar/types";
+import {ValidatorIndex, getValidatorStatus} from "@lodestar/types";
 import {ApiError} from "../../errors.js";
 import {ApiModules} from "../../types.js";
 import {assertUniqueItems} from "../../utils.js";
@@ -305,12 +311,19 @@ export function getBeaconStateApi({
       }
 
       const syncCommitteeCache = stateCached.epochCtx.getIndexedSyncCommitteeAtEpoch(epoch ?? stateEpoch);
+      const validatorIndices = new Array<ValidatorIndex>(...syncCommitteeCache.validatorIndices);
+      const subcommitteeSize = SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT;
+
+      // Subcommittee assignments of the current sync committee
+      const validatorAggregates: ValidatorIndex[][] = [];
+      for (let i = 0; i < validatorIndices.length; i += subcommitteeSize) {
+        validatorAggregates.push(validatorIndices.slice(i, i + subcommitteeSize));
+      }
 
       return {
         data: {
-          validators: new Array(...syncCommitteeCache.validatorIndices),
-          // TODO: This is not used by the validator and will be deprecated soon
-          validatorAggregates: [],
+          validators: validatorIndices,
+          validatorAggregates,
         },
         meta: {executionOptimistic, finalized},
       };

--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -311,12 +311,11 @@ export function getBeaconStateApi({
 
       const syncCommitteeCache = stateCached.epochCtx.getIndexedSyncCommitteeAtEpoch(epoch ?? stateEpoch);
       const validatorIndices = new Array<ValidatorIndex>(...syncCommitteeCache.validatorIndices);
-      const subcommitteeSize = SYNC_COMMITTEE_SUBNET_SIZE;
 
       // Subcommittee assignments of the current sync committee
       const validatorAggregates: ValidatorIndex[][] = [];
-      for (let i = 0; i < validatorIndices.length; i += subcommitteeSize) {
-        validatorAggregates.push(validatorIndices.slice(i, i + subcommitteeSize));
+      for (let i = 0; i < validatorIndices.length; i += SYNC_COMMITTEE_SUBNET_SIZE) {
+        validatorAggregates.push(validatorIndices.slice(i, i + SYNC_COMMITTEE_SUBNET_SIZE));
       }
 
       return {

--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -2,8 +2,7 @@ import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {
   EPOCHS_PER_HISTORICAL_VECTOR,
-  SYNC_COMMITTEE_SIZE,
-  SYNC_COMMITTEE_SUBNET_COUNT,
+  SYNC_COMMITTEE_SUBNET_SIZE,
   isForkPostElectra,
   isForkPostFulu,
 } from "@lodestar/params";
@@ -312,7 +311,7 @@ export function getBeaconStateApi({
 
       const syncCommitteeCache = stateCached.epochCtx.getIndexedSyncCommitteeAtEpoch(epoch ?? stateEpoch);
       const validatorIndices = new Array<ValidatorIndex>(...syncCommitteeCache.validatorIndices);
-      const subcommitteeSize = SYNC_COMMITTEE_SIZE / SYNC_COMMITTEE_SUBNET_COUNT;
+      const subcommitteeSize = SYNC_COMMITTEE_SUBNET_SIZE;
 
       // Subcommittee assignments of the current sync committee
       const validatorAggregates: ValidatorIndex[][] = [];


### PR DESCRIPTION
**Motivation**

Seems like all other clients populate this field and it hasn't been deprecated on the spec side as our code comments might suggest.

**Description**

Return subcommittee assignments from state sync committees endpoint

Closes https://github.com/ChainSafe/lodestar/issues/7903