### PR TITLE
fix: use async variant of verifyCellKzgProofBatch

### DIFF
--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -289,7 +289,7 @@ export async function verifyDataColumnSidecarKzgProofs(
 ): Promise<void> {
   let valid: boolean;
   try {
-    valid = await kzg.verifyCellKzgProofBatch(commitments, cellIndices, cells, proofs);
+    valid = await kzg.asyncVerifyCellKzgProofBatch(commitments, cellIndices, cells, proofs);
   } catch (e) {
     (e as Error).message = `Error on verifyCellKzgProofBatch: ${(e as Error).message}`;
     throw e;

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -291,7 +291,7 @@ export async function verifyDataColumnSidecarKzgProofs(
   try {
     valid = await kzg.asyncVerifyCellKzgProofBatch(commitments, cellIndices, cells, proofs);
   } catch (e) {
-    (e as Error).message = `Error on verifyCellKzgProofBatch: ${(e as Error).message}`;
+    (e as Error).message = `Error on asyncVerifyCellKzgProofBatch: ${(e as Error).message}`;
     throw e;
   }
   if (!valid) {


### PR DESCRIPTION
**Motivation**

Seems like an oversight in https://github.com/ChainSafe/lodestar/pull/7936, we added an `await` but didn't actually switch to using the `async` variant of `verifyCellKzgProofBatch`.

**Description**

Use `asyncVerifyCellKzgProofBatch` instead of `verifyCellKzgProofBatch`. I am pretty sure having a useless `await` was caught before by eslint.. but I guess not by biome.

