### PR TITLE
feat: implement mock Eth1ForBlockProduction

### DIFF
--- a/packages/beacon-node/src/eth1/disabled.ts
+++ b/packages/beacon-node/src/eth1/disabled.ts
@@ -1,0 +1,45 @@
+import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {Root} from "@lodestar/types";
+import {Eth1DataAndDeposits, IEth1ForBlockProduction, PowMergeBlock, TDProgress} from "./interface.js";
+
+/**
+ * Disabled version of Eth1ForBlockProduction
+ * May produce invalid blocks by not adding new deposits and voting for the same eth1Data
+ */
+export class Eth1ForBlockProductionDisabled implements IEth1ForBlockProduction {
+  /**
+   * Returns same eth1Data as in state and no deposits
+   * May produce invalid blocks if deposits have to be added
+   */
+  async getEth1DataAndDeposits(state: CachedBeaconStateAllForks): Promise<Eth1DataAndDeposits> {
+    return {eth1Data: state.eth1Data, deposits: []};
+  }
+
+  /**
+   * Will miss the oportunity to propose the merge block but will still produce valid blocks
+   */
+  async getTerminalPowBlock(): Promise<Root | null> {
+    return null;
+  }
+
+  /** Will not be able to validate the merge block */
+  async getPowBlock(_powBlockHash: string): Promise<PowMergeBlock | null> {
+    throw Error("eth1 must be enabled to verify merge block");
+  }
+
+  getTDProgress(): TDProgress | null {
+    return null;
+  }
+
+  isPollingEth1Data(): boolean {
+    return false;
+  }
+
+  startPollingMergeBlock(): void {
+    // Ignore
+  }
+
+  stopPollingEth1Data(): void {
+    // Ignore
+  }
+}

--- a/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
+++ b/packages/beacon-node/src/eth1/eth1DepositDataTracker.ts
@@ -13,7 +13,7 @@ import {Metrics} from "../metrics/index.js";
 import {Eth1DataCache} from "./eth1DataCache.js";
 import {Eth1DepositsCache} from "./eth1DepositsCache.js";
 import {Eth1DataAndDeposits, EthJsonRpcBlockRaw, IEth1Provider} from "./interface.js";
-import {Eth1Options} from "./options.js";
+import {Eth1HttpOptions} from "./options.js";
 import {parseEth1Block} from "./provider/eth1Provider.js";
 import {HttpRpcError} from "./provider/jsonRpcHttpClient.js";
 import {isJsonRpcTruncatedError} from "./provider/utils.js";
@@ -76,7 +76,7 @@ export class Eth1DepositDataTracker {
   private stopPolling: boolean;
 
   constructor(
-    opts: Eth1Options,
+    opts: Eth1HttpOptions,
     {config, db, metrics, logger, signal}: Eth1DepositDataTrackerModules,
     private readonly eth1Provider: IEth1Provider
   ) {
@@ -108,13 +108,11 @@ export class Eth1DepositDataTracker {
       });
     }
 
-    if (opts.enabled) {
-      this.runAutoUpdate().catch((e: Error) => {
-        if (!(e instanceof ErrorAborted)) {
-          this.logger.error("Error on eth1 loop", {}, e);
-        }
-      });
-    }
+    this.runAutoUpdate().catch((e: Error) => {
+      if (!(e instanceof ErrorAborted)) {
+        this.logger.error("Error on eth1 loop", {}, e);
+      }
+    });
   }
 
   isPollingEth1Data(): boolean {

--- a/packages/beacon-node/src/eth1/index.ts
+++ b/packages/beacon-node/src/eth1/index.ts
@@ -52,7 +52,7 @@ export function initializeEth1ForBlockProduction(
       return new Eth1ForBlockProductionDisabled();
 
     case "mock":
-      return new Eth1ForBlockProductionMock(modules.config);
+      return new Eth1ForBlockProductionMock(opts, modules.config);
 
     default:
       return new Eth1ForBlockProduction(opts, {

--- a/packages/beacon-node/src/eth1/index.ts
+++ b/packages/beacon-node/src/eth1/index.ts
@@ -1,10 +1,12 @@
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {Root} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
+import {Eth1ForBlockProductionDisabled} from "./disabled.js";
 import {Eth1DepositDataTracker, Eth1DepositDataTrackerModules} from "./eth1DepositDataTracker.js";
 import {Eth1MergeBlockTracker, Eth1MergeBlockTrackerModules} from "./eth1MergeBlockTracker.js";
 import {Eth1DataAndDeposits, IEth1ForBlockProduction, IEth1Provider, PowMergeBlock, TDProgress} from "./interface.js";
-import {Eth1Options} from "./options.js";
+import {Eth1ForBlockProductionMock} from "./mock.js";
+import {Eth1HttpOptions, Eth1Options} from "./options.js";
 import {Eth1Provider} from "./provider/eth1Provider.js";
 export {Eth1Provider};
 export type {IEth1ForBlockProduction, IEth1Provider};
@@ -45,16 +47,22 @@ export function initializeEth1ForBlockProduction(
   opts: Eth1Options,
   modules: Pick<Eth1DepositDataTrackerModules, "db" | "config" | "metrics" | "logger" | "signal">
 ): IEth1ForBlockProduction {
-  if (opts.enabled) {
-    return new Eth1ForBlockProduction(opts, {
-      config: modules.config,
-      db: modules.db,
-      metrics: modules.metrics,
-      logger: modules.logger,
-      signal: modules.signal,
-    });
+  switch (opts.mode) {
+    case "disabled":
+      return new Eth1ForBlockProductionDisabled();
+
+    case "mock":
+      return new Eth1ForBlockProductionMock(modules.config);
+
+    default:
+      return new Eth1ForBlockProduction(opts, {
+        config: modules.config,
+        db: modules.db,
+        metrics: modules.metrics,
+        logger: modules.logger,
+        signal: modules.signal,
+      });
   }
-  return new Eth1ForBlockProductionDisabled();
 }
 
 export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
@@ -62,7 +70,7 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
   private readonly eth1MergeBlockTracker: Eth1MergeBlockTracker;
 
   constructor(
-    opts: Eth1Options,
+    opts: Eth1HttpOptions,
     modules: Eth1DepositDataTrackerModules & Eth1MergeBlockTrackerModules & {eth1Provider?: IEth1Provider}
   ) {
     const eth1Provider =
@@ -111,47 +119,5 @@ export class Eth1ForBlockProduction implements IEth1ForBlockProduction {
 
   stopPollingEth1Data(): void {
     this.eth1DepositDataTracker?.stopPollingEth1Data();
-  }
-}
-
-/**
- * Disabled version of Eth1ForBlockProduction
- * May produce invalid blocks by not adding new deposits and voting for the same eth1Data
- */
-export class Eth1ForBlockProductionDisabled implements IEth1ForBlockProduction {
-  /**
-   * Returns same eth1Data as in state and no deposits
-   * May produce invalid blocks if deposits have to be added
-   */
-  async getEth1DataAndDeposits(state: CachedBeaconStateAllForks): Promise<Eth1DataAndDeposits> {
-    return {eth1Data: state.eth1Data, deposits: []};
-  }
-
-  /**
-   * Will miss the oportunity to propose the merge block but will still produce valid blocks
-   */
-  async getTerminalPowBlock(): Promise<Root | null> {
-    return null;
-  }
-
-  /** Will not be able to validate the merge block */
-  async getPowBlock(_powBlockHash: string): Promise<PowMergeBlock | null> {
-    throw Error("eth1 must be enabled to verify merge block");
-  }
-
-  getTDProgress(): TDProgress | null {
-    return null;
-  }
-
-  isPollingEth1Data(): boolean {
-    return false;
-  }
-
-  startPollingMergeBlock(): void {
-    // Ignore
-  }
-
-  stopPollingEth1Data(): void {
-    // Ignore
   }
 }

--- a/packages/beacon-node/src/eth1/mock.ts
+++ b/packages/beacon-node/src/eth1/mock.ts
@@ -1,0 +1,86 @@
+import {ChainForkConfig} from "@lodestar/config";
+import {ZERO_HASH_HEX} from "@lodestar/params";
+import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {Root} from "@lodestar/types";
+import {fromHex, toRootHex} from "@lodestar/utils";
+import {Eth1DataAndDeposits, IEth1ForBlockProduction, PowMergeBlock, TDProgress} from "./interface.js";
+
+export const MOCK_TERMINAL_POW_BLOCK_HASH = toRootHex(Buffer.alloc(32, 1));
+export const MOCK_TERMINAL_POW_BLOCK_NUMBER = 1;
+
+/**
+ * Mock version of Eth1ForBlockProduction
+ */
+export class Eth1ForBlockProductionMock implements IEth1ForBlockProduction {
+  private powBlocks: Map<string, PowMergeBlock> = new Map();
+
+  constructor(config?: ChainForkConfig) {
+    const genericBlock: PowMergeBlock = {
+      number: 0,
+      blockHash: ZERO_HASH_HEX,
+      parentHash: ZERO_HASH_HEX,
+      totalDifficulty: BigInt(0),
+    };
+    const terminalPowBlock: PowMergeBlock = {
+      number: MOCK_TERMINAL_POW_BLOCK_NUMBER,
+      blockHash: MOCK_TERMINAL_POW_BLOCK_HASH,
+      parentHash: ZERO_HASH_HEX,
+      totalDifficulty: config?.TERMINAL_TOTAL_DIFFICULTY ?? BigInt(0),
+    };
+    this.powBlocks.set(ZERO_HASH_HEX, genericBlock);
+    this.powBlocks.set(MOCK_TERMINAL_POW_BLOCK_HASH, terminalPowBlock);
+  }
+
+  /**
+   * Returns same eth1Data as in state and no deposits
+   * May produce invalid blocks if deposits have to be added
+   */
+  async getEth1DataAndDeposits(state: CachedBeaconStateAllForks): Promise<Eth1DataAndDeposits> {
+    return {eth1Data: state.eth1Data, deposits: []};
+  }
+
+  /**
+   * Will miss the oportunity to propose the merge block but will still produce valid blocks
+   */
+  async getTerminalPowBlock(): Promise<Root | null> {
+    return fromHex(MOCK_TERMINAL_POW_BLOCK_HASH);
+  }
+
+  /** Will not be able to validate the merge block */
+  async getPowBlock(powBlockHash: string): Promise<PowMergeBlock | null> {
+    let powBlock = this.powBlocks.get(powBlockHash);
+    if (powBlock != null) {
+      return powBlock;
+    }
+    // eth1mock may generate a random pow block hash
+    const lastPowBlock = Array.from(this.powBlocks.values()).at(-1);
+    if (lastPowBlock == null) {
+      // should not happen, we populate at least 2 blocks in constructor
+      throw new Error("No pow blocks available in Eth1ForBlockProductionDisabled");
+    }
+    powBlock = {
+      number: lastPowBlock.number + 1,
+      blockHash: powBlockHash,
+      parentHash: lastPowBlock.blockHash,
+      totalDifficulty: lastPowBlock.totalDifficulty + BigInt(1),
+    };
+    this.powBlocks.set(powBlockHash, powBlock);
+    return powBlock;
+  }
+
+  getTDProgress(): TDProgress | null {
+    return null;
+  }
+
+  isPollingEth1Data(): boolean {
+    return false;
+  }
+
+  startPollingMergeBlock(): void {
+    // Ignore
+  }
+
+  stopPollingEth1Data(): void {
+    // Ignore
+  }
+}

--- a/packages/beacon-node/src/eth1/mock.ts
+++ b/packages/beacon-node/src/eth1/mock.ts
@@ -2,11 +2,9 @@ import {ChainForkConfig} from "@lodestar/config";
 import {ZERO_HASH_HEX} from "@lodestar/params";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {Root} from "@lodestar/types";
-import {fromHex, toRootHex} from "@lodestar/utils";
+import {fromHex} from "@lodestar/utils";
 import {Eth1DataAndDeposits, IEth1ForBlockProduction, PowMergeBlock, TDProgress} from "./interface.js";
-
-export const MOCK_TERMINAL_POW_BLOCK_HASH = toRootHex(Buffer.alloc(32, 1));
-export const MOCK_TERMINAL_POW_BLOCK_NUMBER = 1;
+import {Eth1MockOptions} from "./options.js";
 
 /**
  * Mock version of Eth1ForBlockProduction
@@ -14,7 +12,11 @@ export const MOCK_TERMINAL_POW_BLOCK_NUMBER = 1;
 export class Eth1ForBlockProductionMock implements IEth1ForBlockProduction {
   private powBlocks: Map<string, PowMergeBlock> = new Map();
 
-  constructor(config?: ChainForkConfig) {
+  constructor(
+    private readonly options: Eth1MockOptions,
+    config?: ChainForkConfig
+  ) {
+    const {terminalPowBlockNumber, terminalPowBlockHash} = options;
     const genericBlock: PowMergeBlock = {
       number: 0,
       blockHash: ZERO_HASH_HEX,
@@ -22,13 +24,13 @@ export class Eth1ForBlockProductionMock implements IEth1ForBlockProduction {
       totalDifficulty: BigInt(0),
     };
     const terminalPowBlock: PowMergeBlock = {
-      number: MOCK_TERMINAL_POW_BLOCK_NUMBER,
-      blockHash: MOCK_TERMINAL_POW_BLOCK_HASH,
+      number: terminalPowBlockNumber,
+      blockHash: terminalPowBlockHash,
       parentHash: ZERO_HASH_HEX,
       totalDifficulty: config?.TERMINAL_TOTAL_DIFFICULTY ?? BigInt(0),
     };
     this.powBlocks.set(ZERO_HASH_HEX, genericBlock);
-    this.powBlocks.set(MOCK_TERMINAL_POW_BLOCK_HASH, terminalPowBlock);
+    this.powBlocks.set(terminalPowBlockHash, terminalPowBlock);
   }
 
   /**
@@ -43,7 +45,7 @@ export class Eth1ForBlockProductionMock implements IEth1ForBlockProduction {
    * Will miss the oportunity to propose the merge block but will still produce valid blocks
    */
   async getTerminalPowBlock(): Promise<Root | null> {
-    return fromHex(MOCK_TERMINAL_POW_BLOCK_HASH);
+    return fromHex(this.options.terminalPowBlockHash);
   }
 
   /** Will not be able to validate the merge block */

--- a/packages/beacon-node/src/eth1/options.ts
+++ b/packages/beacon-node/src/eth1/options.ts
@@ -1,5 +1,4 @@
-export type Eth1Options = {
-  enabled?: boolean;
+export type Eth1HttpOptions = {
   disableEth1DepositDataTracker?: boolean;
   providerUrls?: string[];
   /**
@@ -18,10 +17,16 @@ export type Eth1Options = {
   forcedEth1DataVote?: string;
 };
 
+export type Eth1MockOptions = {
+  genesisBlockHash: string;
+  terminalPowBlockHash: string;
+};
+
+export type Eth1Options = ({mode?: "http"} & Eth1HttpOptions) | ({mode: "mock"} & Eth1MockOptions) | {mode: "disabled"};
+
 export const DEFAULT_PROVIDER_URLS = ["http://localhost:8545"];
 
-export const defaultEth1Options: Eth1Options = {
-  enabled: true,
+export const defaultEth1HttpOptions: Eth1HttpOptions = {
   providerUrls: DEFAULT_PROVIDER_URLS,
   depositContractDeployBlock: 0,
   unsafeAllowDepositDataOverwrite: false,

--- a/packages/beacon-node/src/eth1/options.ts
+++ b/packages/beacon-node/src/eth1/options.ts
@@ -18,7 +18,7 @@ export type Eth1HttpOptions = {
 };
 
 export type Eth1MockOptions = {
-  genesisBlockHash: string;
+  terminalPowBlockNumber: number;
   terminalPowBlockHash: string;
 };
 

--- a/packages/beacon-node/src/eth1/provider/eth1Provider.ts
+++ b/packages/beacon-node/src/eth1/provider/eth1Provider.ts
@@ -16,7 +16,7 @@ import {isValidAddress} from "../../util/address.js";
 import {linspace} from "../../util/numpy.js";
 import {Eth1Block, Eth1ProviderState, IEth1Provider} from "../interface.js";
 import {EthJsonRpcBlockRaw} from "../interface.js";
-import {DEFAULT_PROVIDER_URLS, Eth1Options} from "../options.js";
+import {DEFAULT_PROVIDER_URLS, Eth1HttpOptions} from "../options.js";
 import {depositEventTopics, parseDepositLog} from "../utils/depositContract.js";
 import {
   ErrorJsonRpcResponse,
@@ -68,7 +68,10 @@ export class Eth1Provider implements IEth1Provider {
 
   constructor(
     config: Pick<ChainConfig, "DEPOSIT_CONTRACT_ADDRESS">,
-    opts: Pick<Eth1Options, "depositContractDeployBlock" | "providerUrls" | "jwtSecretHex" | "jwtId" | "jwtVersion"> & {
+    opts: Pick<
+      Eth1HttpOptions,
+      "depositContractDeployBlock" | "providerUrls" | "jwtSecretHex" | "jwtId" | "jwtVersion"
+    > & {
       logger?: Logger;
     },
     signal?: AbortSignal,

--- a/packages/beacon-node/src/node/options.ts
+++ b/packages/beacon-node/src/node/options.ts
@@ -2,7 +2,7 @@ import {ApiOptions, defaultApiOptions} from "../api/options.js";
 import {ArchiveMode, DEFAULT_ARCHIVE_MODE, IChainOptions, defaultChainOptions} from "../chain/options.js";
 import {ValidatorMonitorOpts, defaultValidatorMonitorOpts} from "../chain/validatorMonitor.js";
 import {DatabaseOptions, defaultDbOptions} from "../db/options.js";
-import {Eth1Options, defaultEth1Options} from "../eth1/options.js";
+import {Eth1Options, defaultEth1HttpOptions} from "../eth1/options.js";
 import {
   ExecutionBuilderOpts,
   ExecutionEngineOpts,
@@ -19,7 +19,13 @@ import {SyncOptions, defaultSyncOptions} from "../sync/options.js";
 export {allNamespaces} from "../api/rest/index.js";
 
 // Re-export to use as default values in CLI args
-export {defaultExecutionEngineHttpOpts, defaultExecutionBuilderHttpOpts, ArchiveMode, DEFAULT_ARCHIVE_MODE};
+export {
+  defaultEth1HttpOptions,
+  defaultExecutionEngineHttpOpts,
+  defaultExecutionBuilderHttpOpts,
+  ArchiveMode,
+  DEFAULT_ARCHIVE_MODE,
+};
 
 export interface IBeaconNodeOptions {
   api: ApiOptions;
@@ -39,7 +45,7 @@ export const defaultOptions: IBeaconNodeOptions = {
   api: defaultApiOptions,
   chain: defaultChainOptions,
   db: defaultDbOptions,
-  eth1: defaultEth1Options,
+  eth1: defaultEth1HttpOptions,
   executionEngine: defaultExecutionEngineOpts,
   executionBuilder: defaultExecutionBuilderOpts,
   metrics: defaultMetricsOptions,

--- a/packages/beacon-node/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/beacon-node/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -6,7 +6,7 @@ import {afterAll, beforeAll, describe, expect, it} from "vitest";
 import {phase0, ssz} from "@lodestar/types";
 import {BeaconDb} from "../../../src/db/index.js";
 import {Eth1ForBlockProduction} from "../../../src/eth1/index.js";
-import {Eth1Options} from "../../../src/eth1/options.js";
+import {Eth1HttpOptions} from "../../../src/eth1/options.js";
 import {Eth1Provider} from "../../../src/eth1/provider/eth1Provider.js";
 import {getGoerliRpcUrl} from "../../testParams.js";
 import {createCachedBeaconStateTest} from "../../utils/cachedBeaconState.js";
@@ -47,8 +47,7 @@ describe.skip("eth1 / Eth1Provider", () => {
   });
 
   it("Should fetch real Pyrmont eth1 data for block proposing", async () => {
-    const eth1Options: Eth1Options = {
-      enabled: true,
+    const eth1Options: Eth1HttpOptions = {
       providerUrls: [getGoerliRpcUrl()],
       depositContractDeployBlock: medallaTestnetConfig.depositBlock,
       unsafeAllowDepositDataOverwrite: false,

--- a/packages/beacon-node/test/e2e/eth1/eth1MergeBlockTracker.test.ts
+++ b/packages/beacon-node/test/e2e/eth1/eth1MergeBlockTracker.test.ts
@@ -4,7 +4,7 @@ import {sleep} from "@lodestar/utils";
 import {afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
 import {ZERO_HASH} from "../../../src/constants/index.js";
 import {Eth1MergeBlockTracker, StatusCode} from "../../../src/eth1/eth1MergeBlockTracker.js";
-import {Eth1Options} from "../../../src/eth1/options.js";
+import {Eth1HttpOptions} from "../../../src/eth1/options.js";
 import {quantityToBigint} from "../../../src/eth1/provider/utils.js";
 import {Eth1Provider, IEth1Provider} from "../../../src/index.js";
 import {getGoerliRpcUrl} from "../../testParams.js";
@@ -30,10 +30,9 @@ describe.skip("eth1 / Eth1MergeBlockTracker", () => {
   const eth1Config = {DEPOSIT_CONTRACT_ADDRESS: ZERO_HASH};
 
   // Compute lazily since getGoerliRpcUrl() throws if GOERLI_RPC_URL is not set
-  let eth1Options: Eth1Options;
+  let eth1Options: Eth1HttpOptions;
   beforeAll(() => {
     eth1Options = {
-      enabled: true,
       providerUrls: [getGoerliRpcUrl()],
       depositContractDeployBlock: 0,
       unsafeAllowDepositDataOverwrite: false,

--- a/packages/beacon-node/test/e2e/eth1/eth1Provider.test.ts
+++ b/packages/beacon-node/test/e2e/eth1/eth1Provider.test.ts
@@ -1,7 +1,7 @@
 import {fromHexString} from "@chainsafe/ssz";
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
 import {Eth1Block} from "../../../src/eth1/interface.js";
-import {Eth1Options} from "../../../src/eth1/options.js";
+import {Eth1HttpOptions} from "../../../src/eth1/options.js";
 import {Eth1Provider, parseEth1Block} from "../../../src/eth1/provider/eth1Provider.js";
 import {getGoerliRpcUrl} from "../../testParams.js";
 import {getTestnetConfig} from "../../utils/testnet.js";
@@ -19,8 +19,7 @@ describe.skip("eth1 / Eth1Provider", () => {
 
   // Compute lazily since getGoerliRpcUrl() throws if GOERLI_RPC_URL is not set
   function getEth1Provider(): Eth1Provider {
-    const eth1Options: Eth1Options = {
-      enabled: true,
+    const eth1Options: Eth1HttpOptions = {
       providerUrls: [getGoerliRpcUrl()],
       depositContractDeployBlock: 0,
       unsafeAllowDepositDataOverwrite: false,

--- a/packages/beacon-node/test/e2e/eth1/stream.test.ts
+++ b/packages/beacon-node/test/e2e/eth1/stream.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
-import {Eth1Options} from "../../../src/eth1/options.js";
+import {Eth1HttpOptions} from "../../../src/eth1/options.js";
 import {Eth1Provider} from "../../../src/eth1/provider/eth1Provider.js";
 import {getDepositsAndBlockStreamForGenesis, getDepositsStream} from "../../../src/eth1/stream.js";
 import {getGoerliRpcUrl} from "../../testParams.js";
@@ -17,8 +17,7 @@ describe.skip("Eth1 streams", () => {
 
   // Compute lazily since getGoerliRpcUrl() throws if GOERLI_RPC_URL is not set
   function getEth1Provider(): Eth1Provider {
-    const eth1Options: Eth1Options = {
-      enabled: true,
+    const eth1Options: Eth1HttpOptions = {
       providerUrls: [getGoerliRpcUrl()],
       depositContractDeployBlock: 0,
       unsafeAllowDepositDataOverwrite: false,

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -9,7 +9,7 @@ import {defaultOptions as defaultValidatorOptions} from "@lodestar/validator";
 import {generatePerfTestCachedStateAltair} from "../../../../../state-transition/test/perf/util.js";
 import {BeaconChain} from "../../../../src/chain/index.js";
 import {BlockType, produceBlockBody} from "../../../../src/chain/produceBlock/produceBlockBody.js";
-import {Eth1ForBlockProductionDisabled} from "../../../../src/eth1/index.js";
+import {Eth1ForBlockProductionDisabled} from "../../../../src/eth1/disabled.js";
 import {ExecutionEngineDisabled} from "../../../../src/execution/engine/index.js";
 import {ArchiveMode, BeaconDb} from "../../../../src/index.js";
 import {testLogger} from "../../../utils/logger.js";

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -10,7 +10,7 @@ import {beforeValue} from "../../../../state-transition/test/utils/beforeValueBe
 import {getNetworkCachedBlock, getNetworkCachedState} from "../../../../state-transition/test/utils/testFileCache.js";
 import {AttestationImportOpt, BlockSource, getBlockInput} from "../../../src/chain/blocks/types.js";
 import {BeaconChain} from "../../../src/chain/index.js";
-import {Eth1ForBlockProductionDisabled} from "../../../src/eth1/index.js";
+import {Eth1ForBlockProductionDisabled} from "../../../src/eth1/disabled.js";
 import {ExecutionEngineDisabled} from "../../../src/execution/engine/index.js";
 import {ArchiveMode, BeaconDb} from "../../../src/index.js";
 import {linspace} from "../../../src/util/numpy.js";

--- a/packages/beacon-node/test/sim/electra-interop.test.ts
+++ b/packages/beacon-node/test/sim/electra-interop.test.ts
@@ -318,7 +318,7 @@ describe("executionEngine / ExecutionEngineHttp", () => {
         sync: {isSingleNode: true},
         network: {allowPublishToZeroPeers: true, discv5: null},
         // Now eth deposit/merge tracker methods directly available on engine endpoints
-        eth1: {enabled: false, providerUrls: [engineRpcUrl], jwtSecretHex},
+        eth1: {mode: "disabled"},
         executionEngine: {urls: [engineRpcUrl], jwtSecretHex},
         chain: {suggestedFeeRecipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
       },

--- a/packages/beacon-node/test/sim/mergemock.test.ts
+++ b/packages/beacon-node/test/sim/mergemock.test.ts
@@ -147,7 +147,7 @@ describe("executionEngine / ExecutionEngineHttp", () => {
         sync: {isSingleNode: true},
         network: {allowPublishToZeroPeers: true, discv5: null},
         // Now eth deposit/merge tracker methods directly available on engine endpoints
-        eth1: {enabled: false, providerUrls: [engineRpcUrl], jwtSecretHex},
+        eth1: {mode: "disabled"},
         executionEngine: {urls: [engineRpcUrl], jwtSecretHex},
         executionBuilder: {
           url: ethRpcUrl,

--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -37,7 +37,7 @@ import {
   verifyDataColumnSidecarKzgProofs,
 } from "../../../src/chain/validation/dataColumnSidecar.js";
 import {ZERO_HASH_HEX} from "../../../src/constants/constants.js";
-import {Eth1ForBlockProductionDisabled} from "../../../src/eth1/index.js";
+import {Eth1ForBlockProductionDisabled} from "../../../src/eth1/disabled.js";
 import {PowMergeBlock} from "../../../src/eth1/interface.js";
 import {ExecutionPayloadStatus} from "../../../src/execution/engine/interface.js";
 import {ExecutionEngineMockBackend} from "../../../src/execution/engine/mock.js";

--- a/packages/beacon-node/test/unit/eth1/eth1DepositDataTracker.test.ts
+++ b/packages/beacon-node/test/unit/eth1/eth1DepositDataTracker.test.ts
@@ -3,7 +3,7 @@ import {TimeoutError} from "@lodestar/utils";
 import {MockInstance, afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {BeaconDb} from "../../../src/db/beacon.js";
 import {Eth1DepositDataTracker} from "../../../src/eth1/eth1DepositDataTracker.js";
-import {defaultEth1Options} from "../../../src/eth1/options.js";
+import {defaultEth1HttpOptions} from "../../../src/eth1/options.js";
 import {Eth1Provider} from "../../../src/eth1/provider/eth1Provider.js";
 import {getMockedBeaconDb} from "../../mocks/mockedBeaconDb.js";
 import {testLogger} from "../../utils/logger.js";
@@ -12,7 +12,7 @@ describe("Eth1DepositDataTracker", () => {
   const controller = new AbortController();
 
   const logger = testLogger();
-  const opts = {...defaultEth1Options, enabled: false};
+  const opts = {...defaultEth1HttpOptions};
   const signal = controller.signal;
   const eth1Provider = new Eth1Provider(config, opts, signal, null);
   let db: BeaconDb;

--- a/packages/beacon-node/test/utils/networkWithMockDb.ts
+++ b/packages/beacon-node/test/utils/networkWithMockDb.ts
@@ -3,7 +3,7 @@ import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {ssz} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {BeaconChain} from "../../src/chain/chain.js";
-import {Eth1ForBlockProductionDisabled} from "../../src/eth1/index.js";
+import {Eth1ForBlockProductionDisabled} from "../../src/eth1/disabled.js";
 import {ExecutionEngineDisabled} from "../../src/execution/index.js";
 import {ArchiveMode} from "../../src/index.js";
 import {GossipHandlers, Network, NetworkInitModules, getReqRespHandlers} from "../../src/network/index.js";

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -53,7 +53,7 @@ export async function getDevBeaconNode(
       // dev defaults that we wish, especially for the api options
       {
         db: {name: tmpDir.name},
-        eth1: {enabled: false},
+        eth1: {mode: "disabled"},
         api: {rest: {api: ["beacon", "config", "events", "node", "validator"], port: 19596}},
         metrics: {enabled: false},
         network: {

--- a/packages/cli/src/options/beaconNodeOptions/eth1.ts
+++ b/packages/cli/src/options/beaconNodeOptions/eth1.ts
@@ -1,10 +1,12 @@
 import fs from "node:fs";
 import {IBeaconNodeOptions, defaultOptions} from "@lodestar/beacon-node";
+import {defaultEth1HttpOptions} from "@lodestar/beacon-node/lib/eth1/options.js";
 import {CliCommandOptions} from "@lodestar/utils";
 import {extractJwtHexSecret} from "../../util/index.js";
 import {ExecutionEngineArgs} from "./execution.js";
 
 export type Eth1Args = {
+  // cli only support boolean mode for eth1: true means "http" and false means "disabled"
   eth1?: boolean;
   "eth1.providerUrls"?: string[];
   "eth1.depositContractDeployBlock"?: number;
@@ -30,7 +32,7 @@ export function parseArgs(args: Eth1Args & Partial<ExecutionEngineArgs>): IBeaco
   }
 
   return {
-    enabled: args.eth1,
+    mode: args.eth1 ? "http" : "disabled",
     providerUrls,
     jwtSecretHex,
     jwtId,
@@ -45,14 +47,14 @@ export const options: CliCommandOptions<Eth1Args> = {
   eth1: {
     description: "Whether to follow the eth1 chain",
     type: "boolean",
-    defaultDescription: String(defaultOptions.eth1.enabled),
+    defaultDescription: String(defaultOptions.eth1.mode),
     group: "eth1",
   },
 
   "eth1.providerUrls": {
     description:
       "Urls to Eth1 node with enabled rpc. If not explicitly provided and execution endpoint provided via execution.urls, it will use execution.urls. Otherwise will try connecting on the specified default(s)",
-    defaultDescription: defaultOptions.eth1.providerUrls?.join(","),
+    defaultDescription: defaultEth1HttpOptions.providerUrls?.join(","),
     type: "array",
     string: true,
     coerce: (urls: string[]): string[] =>
@@ -65,7 +67,7 @@ export const options: CliCommandOptions<Eth1Args> = {
     hidden: true,
     description: "Block number at which the deposit contract contract was deployed",
     type: "number",
-    defaultDescription: String(defaultOptions.eth1.depositContractDeployBlock),
+    defaultDescription: String(defaultEth1HttpOptions.depositContractDeployBlock),
     group: "eth1",
   },
 
@@ -73,7 +75,7 @@ export const options: CliCommandOptions<Eth1Args> = {
     hidden: true,
     description: "Disable Eth1DepositDataTracker modules",
     type: "boolean",
-    defaultDescription: String(defaultOptions.eth1.disableEth1DepositDataTracker),
+    defaultDescription: String(defaultEth1HttpOptions.disableEth1DepositDataTracker),
     group: "eth1",
   },
 
@@ -82,7 +84,7 @@ export const options: CliCommandOptions<Eth1Args> = {
     description:
       "Allow the deposit tracker to overwrite previously fetched and saved deposit event data. Warning!!! This is an unsafe operation, so enable this flag only if you know what you are doing.",
     type: "boolean",
-    defaultDescription: String(defaultOptions.eth1.unsafeAllowDepositDataOverwrite),
+    defaultDescription: String(defaultEth1HttpOptions.unsafeAllowDepositDataOverwrite),
     group: "eth1",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/eth1.ts
+++ b/packages/cli/src/options/beaconNodeOptions/eth1.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import {IBeaconNodeOptions, defaultOptions} from "@lodestar/beacon-node";
-import {defaultEth1HttpOptions} from "@lodestar/beacon-node/lib/eth1/options.js";
+import {defaultEth1HttpOptions} from "@lodestar/beacon-node";
 import {CliCommandOptions} from "@lodestar/utils";
 import {extractJwtHexSecret} from "../../util/index.js";
 import {ExecutionEngineArgs} from "./execution.js";

--- a/packages/cli/test/unit/cmds/beacon.test.ts
+++ b/packages/cli/test/unit/cmds/beacon.test.ts
@@ -81,10 +81,16 @@ describe("cmds / beacon / args handler", () => {
   it("Set known deposit contract", async () => {
     const {options} = await runBeaconHandlerInit({
       network: "mainnet",
+      eth1: true,
     });
 
+    const {eth1} = options;
+    if (eth1.mode !== "http") {
+      throw Error(`Expected eth1 mode to be 'http', got ${eth1.mode}`);
+    }
+
     // Okay to hardcode, since this value will never change
-    expect(options.eth1.depositContractDeployBlock).toBe(11052984);
+    expect(eth1.depositContractDeployBlock).toBe(11052984);
   });
 
   it("Apply custom network name from config file", async () => {

--- a/packages/cli/test/unit/config/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/config/beaconNodeOptions.test.ts
@@ -12,8 +12,8 @@ describe("config / beaconNodeOptions", () => {
   });
 
   it("Should return added partial options", () => {
-    const initialPartialOptions = {eth1: {enabled: true}};
-    const editedPartialOptions = {eth1: {enabled: false}};
+    const initialPartialOptions = {eth1: {mode: "http" as const}};
+    const editedPartialOptions = {eth1: {mode: "disabled" as const}};
 
     const beaconNodeOptions = new BeaconNodeOptions(initialPartialOptions);
     beaconNodeOptions.set(editedPartialOptions);

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -154,7 +154,7 @@ describe("options / beaconNodeOptions", () => {
         maxCPStateEpochsInMemory: 100,
       },
       eth1: {
-        enabled: true,
+        mode: "http",
         providerUrls: ["http://my.node:8545"],
         depositContractDeployBlock: 1625314,
         disableEth1DepositDataTracker: true,
@@ -245,7 +245,7 @@ describe("options / beaconNodeOptions", () => {
 
     const expectedOptions: RecursivePartial<IBeaconNodeOptions> = {
       eth1: {
-        enabled: true,
+        mode: "http",
         providerUrls: ["http://my.node:8551"],
         jwtSecretHex,
       },


### PR DESCRIPTION
**Motivation**

- implement mock Eth1ForBlockProduction in order to write more e2e tests post-bellatrix (which will come next)

**Description**

- new `Eth1ForBlockProductionMock` in `mock.ts`
- move `Eth1ForBlockProductionDisabled` to `disabled.ts`
- enhance `Eth1Option` with `mode` field: `disabled` | `mock` | `http`. This is the same to ExecutionEngineOptions
- don't want to break cli by still supporting a boolean flag there: true for `http` and `false` for `disable`