### PR TITLE
fix: use CheckpointBalancesCache to help update cgc

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1241,7 +1241,7 @@ export class BeaconChain implements IBeaconChain {
     const effectiveBalanceIncrements = this.checkpointBalancesCache.get(finalizedCheckpoint);
     if (effectiveBalanceIncrements) {
       effectiveBalances = validatorIndices.map(
-        (index) => effectiveBalanceIncrements[index] * EFFECTIVE_BALANCE_INCREMENT
+        (index) => (effectiveBalanceIncrements[index] ?? 0) * EFFECTIVE_BALANCE_INCREMENT
       );
     } else {
       // If there's no cached effective balances, get the state from disk and parse them out
@@ -1263,7 +1263,7 @@ export class BeaconChain implements IBeaconChain {
       if (stateOrBytes instanceof Uint8Array) {
         effectiveBalances = getEffectiveBalancesFromStateBytes(this.config, stateOrBytes, validatorIndices);
       } else {
-        effectiveBalances = validatorIndices.map((index) => stateOrBytes.validators.get(index).effectiveBalance);
+        effectiveBalances = validatorIndices.map((index) => stateOrBytes.validators.get(index).effectiveBalance ?? 0);
       }
     }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -17,6 +17,7 @@ import {
   computeStartSlotAtEpoch,
   createCachedBeaconState,
   getEffectiveBalanceIncrementsZeroInactive,
+  getEffectiveBalancesFromStateBytes,
   isCachedBeaconState,
   processSlots,
 } from "@lodestar/state-transition";
@@ -1232,24 +1233,39 @@ export class BeaconChain implements IBeaconChain {
       return;
     }
 
+    // Validators attached to the node
+    const validatorIndices = this.beaconProposerCache.getValidatorIndices();
+
     // Update custody requirement based on finalized state
-    // Fetch effective balances from the finalized checkpoint
+    let effectiveBalances: number[];
     const effectiveBalanceIncrements = this.checkpointBalancesCache.get(finalizedCheckpoint);
-    if (!effectiveBalanceIncrements) {
-      this.logger.warn("No cached finalized effective balances to update target custody group count", {
+    if (effectiveBalanceIncrements) {
+      effectiveBalances = validatorIndices.map(
+        (index) => effectiveBalanceIncrements[index] * EFFECTIVE_BALANCE_INCREMENT
+      );
+    } else {
+      // If there's no cached effective balances, get the state from disk and parse them out
+      this.logger.debug("No cached finalized effective balances to update target custody group count", {
         finalizedEpoch: finalizedCheckpoint.epoch,
         finalizedRoot: finalizedCheckpoint.rootHex,
       });
-      return;
+
+      const stateOrBytes = (await this.getStateOrBytesByCheckpoint(finalizedCheckpoint))?.state;
+      if (!stateOrBytes) {
+        // If even the state is not available, we cannot update the custody group count
+        this.logger.debug("No finalized state or bytes available to update target custody group count", {
+          finalizedEpoch: finalizedCheckpoint.epoch,
+          finalizedRoot: finalizedCheckpoint.rootHex,
+        });
+        return;
+      }
+
+      if (stateOrBytes instanceof Uint8Array) {
+        effectiveBalances = getEffectiveBalancesFromStateBytes(this.config, stateOrBytes, validatorIndices);
+      } else {
+        effectiveBalances = validatorIndices.map((index) => stateOrBytes.validators.get(index).effectiveBalance);
+      }
     }
-
-    // Validators attached to the node
-    const validatorIndices = this.beaconProposerCache.getValidatorIndices();
-    this.justifiedBalancesGetter;
-
-    const effectiveBalances = validatorIndices.map(
-      (index) => effectiveBalanceIncrements[index] * EFFECTIVE_BALANCE_INCREMENT
-    );
 
     const targetCustodyGroupCount = getValidatorsCustodyRequirement(this.config, effectiveBalances);
     // Only update if target is increased

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -3,7 +3,7 @@ import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
 import {CheckpointWithHex, ExecutionStatus, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
-import {GENESIS_SLOT, SLOTS_PER_EPOCH, isForkPostElectra} from "@lodestar/params";
+import {EFFECTIVE_BALANCE_INCREMENT, GENESIS_SLOT, SLOTS_PER_EPOCH, isForkPostElectra} from "@lodestar/params";
 import {
   BeaconStateAllForks,
   BeaconStateElectra,
@@ -40,7 +40,6 @@ import {ProcessShutdownCallback} from "@lodestar/validator";
 
 import {PrivateKey} from "@libp2p/interface";
 import {LoggerNode} from "@lodestar/logger/node";
-import {getEffectiveBalancesFromStateBytes} from "@lodestar/state-transition";
 import {GENESIS_EPOCH, ZERO_HASH} from "../constants/index.js";
 import {IBeaconDb} from "../db/index.js";
 import {IEth1ForBlockProduction} from "../eth1/index.js";
@@ -1234,23 +1233,23 @@ export class BeaconChain implements IBeaconChain {
     }
 
     // Update custody requirement based on finalized state
-    const stateOrBytes = (await this.getStateOrBytesByCheckpoint(finalizedCheckpoint))?.state;
-
-    if (!stateOrBytes) {
-      throw Error(
-        `No finalized state for epoch ${finalizedCheckpoint.epoch} and root ${finalizedCheckpoint.rootHex} to update target custody group count`
-      );
+    // Fetch effective balances from the finalized checkpoint
+    const effectiveBalanceIncrements = this.checkpointBalancesCache.get(finalizedCheckpoint);
+    if (!effectiveBalanceIncrements) {
+      this.logger.warn("No cached finalized effective balances to update target custody group count", {
+        finalizedEpoch: finalizedCheckpoint.epoch,
+        finalizedRoot: finalizedCheckpoint.rootHex,
+      });
+      return;
     }
 
     // Validators attached to the node
     const validatorIndices = this.beaconProposerCache.getValidatorIndices();
+    this.justifiedBalancesGetter;
 
-    let effectiveBalances: number[];
-    if (stateOrBytes instanceof Uint8Array) {
-      effectiveBalances = getEffectiveBalancesFromStateBytes(this.config, stateOrBytes, validatorIndices);
-    } else {
-      effectiveBalances = validatorIndices.map((index) => stateOrBytes.validators.get(index).effectiveBalance);
-    }
+    const effectiveBalances = validatorIndices.map(
+      (index) => effectiveBalanceIncrements[index] * EFFECTIVE_BALANCE_INCREMENT
+    );
 
     const targetCustodyGroupCount = getValidatorsCustodyRequirement(this.config, effectiveBalances);
     // Only update if target is increased


### PR DESCRIPTION
**Motivation**

- Resolve https://github.com/ChainSafe/lodestar/issues/8136

**Description**

- use `CheckpointBalancesCache` to help update cgc. This prevents the much more expensive state lookup.
- In extremely forky scenarios, the finalized balances won't be found in the cache. In that case, use the strategy from before (fetch state from disk, parse out the effective balances)
- If neither case works don't throw, rather return. This allows the rest of the important onForkChoiceFinalized work to continue