### PR TITLE
fix: choose more profitable block only based on execution payload value

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -830,8 +830,8 @@ export function getValidatorApi(
 
     if (engine.status === "fulfilled" && builder.status === "fulfilled") {
       const result = selectBlockProductionSource({
-        builderBlockValue: builder.value.executionPayloadValue + builder.value.consensusBlockValue,
-        engineBlockValue: engine.value.executionPayloadValue + engine.value.consensusBlockValue,
+        builderExecutionPayloadValue: builder.value.executionPayloadValue,
+        engineExecutionPayloadValue: engine.value.executionPayloadValue,
         builderBoostFactor,
         builderSelection,
       });

--- a/packages/beacon-node/src/api/impl/validator/utils.ts
+++ b/packages/beacon-node/src/api/impl/validator/utils.ts
@@ -47,13 +47,13 @@ export function getPubkeysForIndices(
 
 export function selectBlockProductionSource({
   builderSelection,
-  engineBlockValue,
-  builderBlockValue,
+  engineExecutionPayloadValue,
+  builderExecutionPayloadValue,
   builderBoostFactor,
 }: {
   builderSelection: routes.validator.BuilderSelection;
-  engineBlockValue: bigint;
-  builderBlockValue: bigint;
+  engineExecutionPayloadValue: bigint;
+  builderExecutionPayloadValue: bigint;
   builderBoostFactor: bigint;
 }): BlockSelectionResult {
   switch (builderSelection) {
@@ -71,7 +71,7 @@ export function selectBlockProductionSource({
         return {source: ProducedBlockSource.builder, reason: BuilderBlockSelectionReason.BuilderPreferred};
       }
 
-      if (engineBlockValue >= (builderBlockValue * builderBoostFactor) / BigInt(100)) {
+      if (engineExecutionPayloadValue >= (builderExecutionPayloadValue * builderBoostFactor) / BigInt(100)) {
         return {source: ProducedBlockSource.engine, reason: EngineBlockSelectionReason.BlockValue};
       }
 


### PR DESCRIPTION
**Motivation**

Noticed we choose the more profitable block during block building based on total block value. This makes no difference if `builder_boost_factor` is not used (or set to 100) as CL block value is the same for both local and builder block, however in case we have a `builder_boost_factor` configured (default: 90) then it might pick the wrong block.

The [spec](https://github.com/ethereum/beacon-APIs/blob/33b6bb789cc301bab7ec2e865f89073341cea6ba/apis/validator/block.v3.yaml#L39-L68) is pretty clear that we should choose and run the calculation on payload values, not total block value.
> Percentage multiplier to apply to the builder's **payload value** when choosing between a
        builder payload header and payload from the paired execution node.

> if `exec_node_payload_value >= builder_boost_factor * (builder_payload_value // 100)`,
          then return a full (unblinded) block containing the execution node payload.

**Description**

Choose more profitable block only based on execution payload value
