### PR TITLE
fix: apply correct count limit in blob sidecars by range

### DIFF
--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
@@ -1,5 +1,4 @@
-import {BeaconConfig} from "@lodestar/config";
-import {BLOBSIDECAR_FIXED_SIZE, GENESIS_SLOT} from "@lodestar/params";
+import {BLOBSIDECAR_FIXED_SIZE, GENESIS_SLOT, MAX_REQUEST_BLOCKS_DENEB} from "@lodestar/params";
 import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Slot, deneb} from "@lodestar/types";
@@ -14,7 +13,7 @@ export async function* onBlobSidecarsByRange(
   db: IBeaconDb
 ): AsyncIterable<ResponseOutgoing> {
   // Non-finalized range of blobs
-  const {startSlot, count} = validateBlobSidecarsByRangeRequest(chain.config, request);
+  const {startSlot, count} = validateBlobSidecarsByRangeRequest(request);
   const endSlot = startSlot + count;
 
   const finalized = db.blobSidecarsArchive;
@@ -92,7 +91,6 @@ export function* iterateBlobBytesFromWrapper(
 }
 
 export function validateBlobSidecarsByRangeRequest(
-  config: BeaconConfig,
   request: deneb.BlobSidecarsByRangeRequest
 ): deneb.BlobSidecarsByRangeRequest {
   const {startSlot} = request;
@@ -106,10 +104,8 @@ export function validateBlobSidecarsByRangeRequest(
     throw new ResponseError(RespStatus.INVALID_REQUEST, "startSlot < genesis");
   }
 
-  const maxRequestBlobSidecars = config.getMaxRequestBlobSidecars(config.getForkName(startSlot));
-
-  if (count > maxRequestBlobSidecars) {
-    count = maxRequestBlobSidecars;
+  if (count > MAX_REQUEST_BLOCKS_DENEB) {
+    count = MAX_REQUEST_BLOCKS_DENEB;
   }
 
   return {startSlot, count};


### PR DESCRIPTION
**Motivation**

The `count` determines the end slot of the by range request.
https://github.com/ChainSafe/lodestar/blob/55f161e1da1088a78145206b54ba5ba239356e40/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts#L18

This means we query a maximum of `startSlot + count` blocks and return `MAX_BLOBS_PER_BLOCK_*` blobs for each of those blocks we got the theoretical maximum response size of `MAX_REQUEST_BLOB_SIDECARS_*`.

If we use `MAX_REQUEST_BLOB_SIDECARS` to limit the count the theoretical maximum would be significantly higher.

**Description**

Apply correct count limit (`MAX_REQUEST_BLOCKS_DENEB`) in blob sidecars by range