### PR TITLE
feat: print out blob parameters if BPO fork is activated

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -182,7 +182,7 @@ export async function verifyBlocksInEpoch(
         if (toBlobParameters.maxBlobsPerBlock !== fromBlobParameters.maxBlobsPerBlock) {
           const {epoch, maxBlobsPerBlock} = toBlobParameters;
 
-          this.logger.info("Activating Blob Parameter Only (BPO) fork", {epoch, maxBlobsPerBlock});
+          this.logger.info("Activating BPO fork", {epoch, maxBlobsPerBlock});
         }
       }
     }

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -173,9 +173,17 @@ export async function verifyBlocksInEpoch(
 
           default:
         }
-      } else if (isForkPostFulu(toForkBoundary.fork) && toForkBoundary.epoch !== fromForkBoundary.epoch) {
-        const {epoch, maxBlobsPerBlock} = this.config.getBlobParameters(toForkBoundary.epoch);
-        this.logger.info("Activating Blob Parameter Only (BPO) fork", {epoch, maxBlobsPerBlock});
+      }
+
+      if (isForkPostFulu(fromForkBoundary.fork)) {
+        const fromBlobParameters = this.config.getBlobParameters(fromForkBoundary.epoch);
+        const toBlobParameters = this.config.getBlobParameters(toForkBoundary.epoch);
+
+        if (toBlobParameters.maxBlobsPerBlock !== fromBlobParameters.maxBlobsPerBlock) {
+          const {epoch, maxBlobsPerBlock} = toBlobParameters;
+
+          this.logger.info("Activating Blob Parameter Only (BPO) fork", {epoch, maxBlobsPerBlock});
+        }
       }
     }
 

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -179,7 +179,7 @@ export async function verifyBlocksInEpoch(
         const fromBlobParameters = this.config.getBlobParameters(fromForkBoundary.epoch);
         const toBlobParameters = this.config.getBlobParameters(toForkBoundary.epoch);
 
-        if (toBlobParameters.maxBlobsPerBlock !== fromBlobParameters.maxBlobsPerBlock) {
+        if (toBlobParameters.epoch !== fromBlobParameters.epoch) {
           const {epoch, maxBlobsPerBlock} = toBlobParameters;
 
           this.logger.info("Activating BPO fork", {epoch, maxBlobsPerBlock});

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -1,6 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
-import {ForkName} from "@lodestar/params";
+import {ForkName, isForkPostFulu} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   DataAvailabilityStatus,
@@ -145,12 +145,12 @@ export async function verifyBlocksInEpoch(
         logOnPowBlock(this.logger, this.config, segmentExecStatus.mergeBlockFound);
       }
 
-      const fromFork = this.config.getForkName(parentBlock.slot);
-      const toFork = this.config.getForkName(lastBlock.message.slot);
+      const fromForkBoundary = this.config.getForkBoundaryAtEpoch(computeEpochAtSlot(parentBlock.slot));
+      const toForkBoundary = this.config.getForkBoundaryAtEpoch(computeEpochAtSlot(lastBlock.message.slot));
 
       // If transition through toFork, note won't happen if ${toFork}_EPOCH = 0, will log double on re-org
-      if (toFork !== fromFork) {
-        switch (toFork) {
+      if (toForkBoundary.fork !== fromForkBoundary.fork) {
+        switch (toForkBoundary.fork) {
           case ForkName.capella:
             this.logger.info(CAPELLA_OWL_BANNER);
             this.logger.info("Activating withdrawals", {epoch: this.config.CAPELLA_FORK_EPOCH});
@@ -173,6 +173,9 @@ export async function verifyBlocksInEpoch(
 
           default:
         }
+      } else if (isForkPostFulu(toForkBoundary.fork) && toForkBoundary.epoch !== fromForkBoundary.epoch) {
+        const {epoch, maxBlobsPerBlock} = this.config.getBlobParameters(toForkBoundary.epoch);
+        this.logger.info("Activating Blob Parameter Only (BPO) fork", {epoch, maxBlobsPerBlock});
       }
     }
 


### PR DESCRIPTION
**Motivation**

We currently don't print out the current blob limit anywhere but it would be good to know for debugging and just to inform the user if a BPO is activated and what are the new blob parameters.

**Description**

Print out blob parameters if BPO fork is activated