### PR TITLE
chore: remove per committee attestation routine

### DIFF
--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -167,7 +167,6 @@ export async function validatorHandler(args: IValidatorCliArgs & GlobalArgs): Pr
       doppelgangerProtection,
       afterBlockDelaySlotFraction: args.afterBlockDelaySlotFraction,
       scAfterBlockDelaySlotFraction: args.scAfterBlockDelaySlotFraction,
-      disableAttestationGrouping: args.disableAttestationGrouping,
       valProposerConfig,
       distributed: args.distributed,
       broadcastValidation: parseBroadcastValidation(args.broadcastValidation),

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -223,7 +223,6 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
     type: "number",
   },
 
-
   proposerSettingsFile: {
     description:
       "A yaml file to specify detailed default and per validator public key customized proposer configs. PS: This feature and its format is in alpha and subject to change",

--- a/packages/cli/src/cmds/validator/options.ts
+++ b/packages/cli/src/cmds/validator/options.ts
@@ -38,7 +38,6 @@ export type IValidatorCliArgs = AccountValidatorArgs &
     graffiti?: string;
     afterBlockDelaySlotFraction?: number;
     scAfterBlockDelaySlotFraction?: number;
-    disableAttestationGrouping?: boolean;
     suggestedFeeRecipient?: string;
     proposerSettingsFile?: string;
     strictFeeRecipientCheck?: boolean;
@@ -224,12 +223,6 @@ export const validatorOptions: CliCommandOptions<IValidatorCliArgs> = {
     type: "number",
   },
 
-  disableAttestationGrouping: {
-    hidden: true,
-    description:
-      "Disables attestation service grouping optimization, attestation tasks will be executed per committee instead of just once for all committees.",
-    type: "boolean",
-  },
 
   proposerSettingsFile: {
     description:

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -16,7 +16,6 @@ import {ValidatorStore} from "./validatorStore.js";
 
 export type AttestationServiceOpts = {
   afterBlockDelaySlotFraction?: number;
-  disableAttestationGrouping?: boolean;
   distributedAggregationSelection?: boolean;
 };
 
@@ -93,54 +92,14 @@ export class AttestationService {
     await Promise.race([sleep(this.clock.msToSlot(slot + 1 / 3), signal), this.emitter.waitForBlockSlot(slot)]);
     this.metrics?.attesterStepCallProduceAttestation.observe(this.clock.secFromSlot(slot + 1 / 3));
 
-    if (this.opts?.disableAttestationGrouping) {
-      // Attestation service grouping optimization must be disabled in a distributed validator cluster as
-      // middleware clients such as Charon (https://github.com/ObolNetwork/charon) expect the actual committee index
-      // to be sent to produceAttestationData endpoint. This is required because the middleware client itself
-      // calls produceAttestationData on the beacon node for each validator and there is a slight chance that
-      // the `beacon_block_root` (LMD GHOST vote) changes between calls which would cause a conflict between
-      // attestations submitted by Lodestar and other VCs in the cluster, resulting in aggregation failure.
-      // See https://github.com/ChainSafe/lodestar/issues/5103 for further details and references.
-      const dutiesByCommitteeIndex = groupAttDutiesByCommitteeIndex(duties);
-      await Promise.all(
-        Array.from(dutiesByCommitteeIndex.entries()).map(([index, duties]) =>
-          this.runAttestationTasksPerCommittee(duties, slot, index, signal).catch((e) => {
-            this.logger.error("Error on committee attestation routine", {slot, index}, e);
-          })
-        )
-      );
-    } else {
-      // Beacon node's endpoint produceAttestationData return data is not dependent on committeeIndex.
-      // Produce a single attestation for all committees and submit unaggregated attestations in one go.
-      try {
-        await this.runAttestationTasksGrouped(duties, slot, signal);
-      } catch (e) {
-        this.logger.error("Error on attestation routine", {slot}, e as Error);
-      }
+    // Beacon node's endpoint produceAttestationData return data is not dependent on committeeIndex.
+    // Produce a single attestation for all committees and submit unaggregated attestations in one go.
+    try {
+      await this.runAttestationTasksGrouped(duties, slot, signal);
+    } catch (e) {
+      this.logger.error("Error on attestation routine", {slot}, e as Error);
     }
   };
-
-  private async runAttestationTasksPerCommittee(
-    dutiesSameCommittee: AttDutyAndProof[],
-    slot: Slot,
-    index: number,
-    signal: AbortSignal
-  ): Promise<void> {
-    // Produce attestation with actual committee index
-    const attestation = await this.produceAttestation(index, slot);
-
-    // Step 1. Sign `Attestation` for each validator. Then publish all `Attestations` in one go
-    await this.signAndPublishAttestations(slot, attestation, dutiesSameCommittee);
-
-    // Step 2. after all attestations are submitted, make an aggregate.
-    // First, wait until the `aggregation_production_instant` (2/3rds of the way through the slot)
-    await sleep(this.clock.msToSlot(slot + 2 / 3), signal);
-    this.metrics?.attesterStepCallProduceAggregate.observe(this.clock.secFromSlot(slot + 2 / 3));
-
-    // Then download, sign and publish a `SignedAggregateAndProof` for each
-    // validator that is elected to aggregate for this `slot` and `committeeIndex`.
-    await this.produceAndPublishAggregates(attestation, index, dutiesSameCommittee);
-  }
 
   private async runAttestationTasksGrouped(
     dutiesAll: AttDutyAndProof[],
@@ -176,8 +135,6 @@ export class AttestationService {
    * Beacon node's endpoint produceAttestationData return data is not dependent on committeeIndex.
    * For a validator client with many validators this allows to do a single call for all committees
    * in a slot, saving resources in both the vc and beacon node
-   *
-   * Note: the actual committeeIndex must be passed in if attestation grouping is disabled
    */
   private async produceAttestation(committeeIndex: number, slot: Slot): Promise<phase0.AttestationData> {
     // Produce one attestation data per slot and committeeIndex
@@ -230,15 +187,10 @@ export class AttestationService {
     this.metrics?.attesterStepCallPublishAttestation.observe(this.clock.secFromSlot(slot + 1 / 3));
 
     // Step 2. Publish all `Attestations` in one go
-    const logCtx = {
-      slot,
-      // log index if attestations are published per committee
-      ...(this.opts?.disableAttestationGrouping && {index: attestationNoCommittee.index}),
-    };
     try {
       (await this.api.beacon.submitPoolAttestationsV2({signedAttestations})).assertOk();
       this.logger.info("Published attestations", {
-        ...logCtx,
+        slot,
         head: prettyBytes(headRootHex),
         count: signedAttestations.length,
       });
@@ -246,7 +198,7 @@ export class AttestationService {
     } catch (e) {
       // Note: metric counts only 1 since we don't know how many signedAttestations are invalid
       this.metrics?.attestaterError.inc({error: "publish"});
-      this.logger.error("Error publishing attestations", logCtx, e as Error);
+      this.logger.error("Error publishing attestations", {slot}, e as Error);
     }
   }
 

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -95,40 +95,32 @@ export class AttestationService {
     // Beacon node's endpoint produceAttestationData return data is not dependent on committeeIndex.
     // Produce a single attestation for all committees and submit unaggregated attestations in one go.
     try {
-      await this.runAttestationTasksGrouped(duties, slot, signal);
+      // Produce a single attestation for all committees, and clone mutate before signing
+      const attestationNoCommittee = await this.produceAttestation(0, slot);
+
+      // Step 1. Mutate, and sign `Attestation` for each validator. Then publish all `Attestations` in one go
+      await this.signAndPublishAttestations(slot, attestationNoCommittee, duties);
+
+      // Step 2. after all attestations are submitted, make an aggregate.
+      // First, wait until the `aggregation_production_instant` (2/3rds of the way through the slot)
+      await sleep(this.clock.msToSlot(slot + 2 / 3), signal);
+      this.metrics?.attesterStepCallProduceAggregate.observe(this.clock.secFromSlot(slot + 2 / 3));
+
+      const dutiesByCommitteeIndex = groupAttDutiesByCommitteeIndex(duties);
+      const isPostElectra = this.config.getForkSeq(slot) >= ForkSeq.electra;
+
+      // Then download, sign and publish a `SignedAggregateAndProof` for each
+      // validator that is elected to aggregate for this `slot` and `committeeIndex`.
+      await Promise.all(
+        Array.from(dutiesByCommitteeIndex.entries()).map(([index, dutiesSameCommittee]) => {
+          const attestationData: phase0.AttestationData = {...attestationNoCommittee, index: isPostElectra ? 0 : index};
+          return this.produceAndPublishAggregates(attestationData, index, dutiesSameCommittee);
+        })
+      );
     } catch (e) {
       this.logger.error("Error on attestation routine", {slot}, e as Error);
     }
   };
-
-  private async runAttestationTasksGrouped(
-    dutiesAll: AttDutyAndProof[],
-    slot: Slot,
-    signal: AbortSignal
-  ): Promise<void> {
-    // Produce a single attestation for all committees, and clone mutate before signing
-    const attestationNoCommittee = await this.produceAttestation(0, slot);
-
-    // Step 1. Mutate, and sign `Attestation` for each validator. Then publish all `Attestations` in one go
-    await this.signAndPublishAttestations(slot, attestationNoCommittee, dutiesAll);
-
-    // Step 2. after all attestations are submitted, make an aggregate.
-    // First, wait until the `aggregation_production_instant` (2/3rds of the way through the slot)
-    await sleep(this.clock.msToSlot(slot + 2 / 3), signal);
-    this.metrics?.attesterStepCallProduceAggregate.observe(this.clock.secFromSlot(slot + 2 / 3));
-
-    const dutiesByCommitteeIndex = groupAttDutiesByCommitteeIndex(dutiesAll);
-    const isPostElectra = this.config.getForkSeq(slot) >= ForkSeq.electra;
-
-    // Then download, sign and publish a `SignedAggregateAndProof` for each
-    // validator that is elected to aggregate for this `slot` and `committeeIndex`.
-    await Promise.all(
-      Array.from(dutiesByCommitteeIndex.entries()).map(([index, dutiesSameCommittee]) => {
-        const attestationData: phase0.AttestationData = {...attestationNoCommittee, index: isPostElectra ? 0 : index};
-        return this.produceAndPublishAggregates(attestationData, index, dutiesSameCommittee);
-      })
-    );
-  }
 
   /**
    * Performs the first step of the attesting process: downloading one `Attestation` object.

--- a/packages/validator/src/validator.ts
+++ b/packages/validator/src/validator.ts
@@ -56,7 +56,6 @@ export type ValidatorOptions = {
   abortController: AbortController;
   afterBlockDelaySlotFraction?: number;
   scAfterBlockDelaySlotFraction?: number;
-  disableAttestationGrouping?: boolean;
   doppelgangerProtection?: boolean;
   closed?: boolean;
   valProposerConfig?: ValidatorProposerConfig;
@@ -241,7 +240,6 @@ export class Validator {
       config,
       {
         afterBlockDelaySlotFraction: opts.afterBlockDelaySlotFraction,
-        disableAttestationGrouping: opts.disableAttestationGrouping,
         distributedAggregationSelection: opts.distributed,
       }
     );

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -63,8 +63,6 @@ describe("AttestationService", () => {
   const testContexts: [string, AttestationServiceOpts, Partial<ChainConfig>][] = [
     ["With default configuration", {}, {}],
     ["With default configuration post-electra", {}, electraConfig],
-    ["With attestation grouping disabled", {disableAttestationGrouping: true}, {}],
-    ["With attestation grouping disabled post-electra", {disableAttestationGrouping: true}, electraConfig],
     ["With distributed aggregation selection enabled", {distributedAggregationSelection: true}, {}],
   ];
 


### PR DESCRIPTION
**Motivation**

This code is no longer relevant for post-elecra and was previously only used to be compatible with Charon DVT middleware, see previous PR https://github.com/ChainSafe/lodestar/pull/5258 for reference.

**Description**

Remove per committee attestation routine

Closes https://github.com/ChainSafe/lodestar/issues/7981
