### PR TITLE
feat: track kzg proofs verification time

### DIFF
--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -154,6 +154,7 @@ export async function validateGossipDataColumnSidecar(
     });
   }
 
+  const kzgProofTimer = metrics?.peerDas.dataColumnSidecarKzgProofsVerificationTime.startTimer();
   // 11) [REJECT] The sidecar's column data is valid as verified by verify_data_column_sidecar_kzg_proofs
   try {
     await verifyDataColumnSidecarKzgProofs(
@@ -168,6 +169,8 @@ export async function validateGossipDataColumnSidecar(
       slot: blockHeader.slot,
       columnIdx: dataColumnSidecar.index,
     });
+  } finally {
+    kzgProofTimer?.();
   }
 
   // 12) [IGNORE] The sidecar is the first sidecar for the tuple (block_header.slot, block_header.proposer_index,

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -375,6 +375,11 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
         help: "Time taken to verify data_column sidecar inclusion proof",
         buckets: [0.002, 0.004, 0.006, 0.008, 0.01, 0.05, 1, 2],
       }),
+      dataColumnSidecarKzgProofsVerificationTime: register.histogram({
+        name: "beacon_data_column_sidecar_kzg_proofs_verification_seconds",
+        help: "Time taken to verify data_column sidecar kzg proofs",
+        buckets: [0.01, 0.02, 0.03, 0.04, 0.05, 0.1, 0.2, 0.5, 1],
+      }),
       kzgVerificationDataColumnBatchTime: register.histogram({
         name: "beacon_kzg_verification_data_column_batch_seconds",
         help: "Runtime of batched data column kzg verification",


### PR DESCRIPTION
**Motivation**

- when verifying DataColumnSidecars, we track inclusion proof verification time but not kzg proofs verification time

**Description**

- also track kzg proofs verification time

part of #8260
