### PR TITLE
feat: support single db batch operation

### DIFF
--- a/packages/beacon-node/test/unit/db/api/repository.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repository.test.ts
@@ -21,6 +21,7 @@ vi.mock("@lodestar/db/controller/level", async (importOriginal) => {
         valuesStream: vi.fn(),
         batchDelete: vi.fn(),
         batchPut: vi.fn(),
+        batch: vi.fn(),
       };
     }),
   };

--- a/packages/db/src/abstractPrefixedRepository.ts
+++ b/packages/db/src/abstractPrefixedRepository.ts
@@ -148,7 +148,23 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
     await this.db.batchDelete(keys.flat(), this.dbReqOpts);
   }
 
-  async batch(prefix: P, batch: DbBatch<I, Uint8Array>): Promise<void> {
+  async batch(prefix: P, batch: DbBatch<I, T>): Promise<void> {
+    const batchWithKeys = [];
+    for (const b of batch) {
+      if (b.type === "del") {
+        batchWithKeys.push({type: b.type, key: this.wrapKey(this.encodeKeyRaw(prefix, b.key))});
+      } else {
+        batchWithKeys.push({
+          type: b.type,
+          key: this.wrapKey(this.encodeKeyRaw(prefix, b.key)),
+          value: this.encodeValue(b.value),
+        });
+      }
+    }
+    await this.db.batch(batchWithKeys, this.dbReqOpts);
+  }
+
+  async batchBinary(prefix: P, batch: DbBatch<I, Uint8Array>): Promise<void> {
     const batchWithKeys = [];
     for (const b of batch) {
       batchWithKeys.push({...b, key: this.wrapKey(this.encodeKeyRaw(prefix, b.key))});

--- a/packages/db/src/abstractPrefixedRepository.ts
+++ b/packages/db/src/abstractPrefixedRepository.ts
@@ -2,7 +2,7 @@ import {Type} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {BUCKET_LENGTH} from "./const.js";
 import {KeyValue} from "./controller/index.js";
-import {Db, DbReqOpts, FilterOptions} from "./controller/interface.js";
+import {Db, DbBatch, DbReqOpts, FilterOptions} from "./controller/interface.js";
 import {encodeKey} from "./util.js";
 
 type Id = Uint8Array | string | number | bigint;
@@ -146,6 +146,14 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
     }
 
     await this.db.batchDelete(keys.flat(), this.dbReqOpts);
+  }
+
+  async batch(prefix: P, batch: DbBatch<I, Uint8Array>): Promise<void> {
+    const batchWithKeys = [];
+    for (const b of batch) {
+      batchWithKeys.push({...b, key: this.wrapKey(this.encodeKeyRaw(prefix, b.key))});
+    }
+    await this.db.batch(batchWithKeys, this.dbReqOpts);
   }
 
   async *valuesStream(prefix: P | P[]): AsyncIterable<T> {

--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -2,7 +2,7 @@ import {Type} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {BUCKET_LENGTH} from "./const.js";
 import {FilterOptions, KeyValue} from "./controller/index.js";
-import {Db, DbReqOpts} from "./controller/interface.js";
+import {Db, DbBatch, DbReqOpts} from "./controller/interface.js";
 import {encodeKey as _encodeKey} from "./util.js";
 
 export type Id = Uint8Array | string | number | bigint;
@@ -128,6 +128,14 @@ export abstract class Repository<I extends Id, T> {
       Array.from({length: ids.length}, (_, i) => this.encodeKey(ids[i])),
       this.dbReqOpts
     );
+  }
+
+  async batch(batch: DbBatch<I, T>): Promise<void> {
+    const batchWithKeys = [];
+    for (const b of batch) {
+      batchWithKeys.push({...b, key: this.encodeKey(b.key)});
+    }
+    await this.db.batch(batchWithKeys, this.dbReqOpts);
   }
 
   async batchAdd(values: T[]): Promise<void> {

--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -131,7 +131,19 @@ export abstract class Repository<I extends Id, T> {
   }
 
   async batch(batch: DbBatch<I, T>): Promise<void> {
-    const batchWithKeys = [];
+    const batchWithKeys: DbBatch<Uint8Array, Uint8Array> = [];
+    for (const b of batch) {
+      if (b.type === "del") {
+        batchWithKeys.push({...b, key: this.encodeKey(b.key)});
+      } else {
+        batchWithKeys.push({...b, key: this.encodeKey(b.key), value: this.encodeValue(b.value)});
+      }
+    }
+    await this.db.batch(batchWithKeys, this.dbReqOpts);
+  }
+
+  async batchBinary(batch: DbBatch<I, Uint8Array>): Promise<void> {
+    const batchWithKeys: DbBatch<Uint8Array, Uint8Array> = [];
     for (const b of batch) {
       batchWithKeys.push({...b, key: this.encodeKey(b.key)});
     }

--- a/packages/db/src/controller/index.ts
+++ b/packages/db/src/controller/index.ts
@@ -1,3 +1,11 @@
-export type {DatabaseController, Db, DbReqOpts, FilterOptions, KeyValue} from "./interface.js";
+export type {
+  DatabaseController,
+  Db,
+  DbBatch,
+  DbBatchOperation,
+  DbReqOpts,
+  FilterOptions,
+  KeyValue,
+} from "./interface.js";
 export {LevelDbController} from "./level.js";
 export type {LevelDbControllerMetrics} from "./metrics.js";

--- a/packages/db/src/controller/interface.ts
+++ b/packages/db/src/controller/interface.ts
@@ -28,6 +28,9 @@ export interface KeyValue<K, V> {
   value: V;
 }
 
+export type DbBatchOperation<K, V> = {type: "del"; key: K} | {type: "put"; key: K; value: V};
+export type DbBatch<K, V> = DbBatchOperation<K, V>[];
+
 export interface DatabaseController<K, V> {
   // service start / stop
 
@@ -48,6 +51,7 @@ export interface DatabaseController<K, V> {
 
   batchPut(items: KeyValue<K, V>[], opts?: DbReqOpts): Promise<void>;
   batchDelete(keys: K[], opts?: DbReqOpts): Promise<void>;
+  batch(batch: DbBatch<K, V>, opts?: DbReqOpts): Promise<void>;
 
   // Iterate over entries
 

--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -1,6 +1,6 @@
 import {ClassicLevel} from "classic-level";
 import {Logger} from "@lodestar/utils";
-import {DatabaseController, DatabaseOptions, DbReqOpts, FilterOptions, KeyValue} from "./interface.js";
+import {DatabaseController, DatabaseOptions, DbBatch, DbReqOpts, FilterOptions, KeyValue} from "./interface.js";
 import {LevelDbControllerMetrics} from "./metrics.js";
 
 enum Status {
@@ -141,6 +141,13 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
     this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
 
     return this.db.batch(keys.map((key) => ({type: "del", key: key})));
+  }
+
+  batch(batch: DbBatch<Uint8Array, Uint8Array>, opts?: DbReqOpts): Promise<void> {
+    this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, batch.length);
+
+    return this.db.batch(batch);
   }
 
   keysStream(opts: FilterOptions<Uint8Array> = {}): AsyncIterable<Uint8Array> {

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -82,7 +82,7 @@ describe("LevelDB controller", () => {
     expect((await db.entries()).length).toBe(0);
   });
 
-  it.only("test batch", async () => {
+  it("test batch", async () => {
     const [
       {key: k1, value: v1},
       {key: k2, value: v2},

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -82,6 +82,55 @@ describe("LevelDB controller", () => {
     expect((await db.entries()).length).toBe(0);
   });
 
+  it.only("test batch", async () => {
+    const [
+      {key: k1, value: v1},
+      {key: k2, value: v2},
+      {key: k3, value: v3},
+      {key: k4, value: v4},
+      {key: k5, value: v5},
+    ] = Array.from({length: 5}, (_, i) => ({
+      key: Buffer.from(`test${i}`),
+      value: Buffer.from(`some value ${i}`),
+    }));
+    await db.put(k1, v1);
+    await db.put(k2, v2);
+    await db.put(k3, v3);
+
+    expect(await db.entries()).toEqual([
+      {key: k1, value: v1},
+      {key: k2, value: v2},
+      {key: k3, value: v3},
+    ]);
+
+    await db.batch([
+      {
+        type: "del",
+        key: k1,
+      },
+      {
+        type: "put",
+        key: k4,
+        value: v4,
+      },
+      {
+        type: "del",
+        key: k3,
+      },
+      {
+        type: "put",
+        key: k5,
+        value: v5,
+      },
+    ]);
+
+    expect(await db.entries()).toEqual([
+      {key: k2, value: v2},
+      {key: k4, value: v4},
+      {key: k5, value: v5},
+    ]);
+  });
+
   it("test entries", async () => {
     const k1 = Buffer.from("test1");
     const k2 = Buffer.from("test2");


### PR DESCRIPTION
**Motivation**

Support single db operation to delete/put in a single repository. Will partially covers https://github.com/ChainSafe/lodestar/issues/8244 and enable next step for the across db repositories atomic write. 

**Description**

- Allow bundle `put` and `delete` in a single batch


**Steps to test or reproduce**

- Run all tests