### PR TITLE
feat: increase target peers by default to 200

### DIFF
--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -46,8 +46,8 @@ export interface NetworkOptions
 }
 
 export const defaultNetworkOptions: NetworkOptions = {
-  maxPeers: 110, // Allow some room above targetPeers for new inbound peers
-  targetPeers: 100,
+  maxPeers: 210, // Allow some room above targetPeers for new inbound peers
+  targetPeers: 200,
   localMultiaddrs: ["/ip4/0.0.0.0/tcp/9000"],
   bootMultiaddrs: [],
   /** disabled by default */


### PR DESCRIPTION
**Motivation**

As discussed on https://github.com/ChainSafe/lodestar/discussions/8236#discussioncomment-14221640, we made a decision to increase peer counts to maximize peer diversity in anticipation of Fusaka, which may help with PeerDAS functionalities.

**Description**

This PR increases the maxPeers from 110 to 210 and targetPeers from 100 to 200. The overhead of bandwidth and computational resources are minimal (even at 300 peers) and holding up well as seen in https://github.com/ChainSafe/lodestar/discussions/8236#discussioncomment-14221689 and from Discord discussions here:  https://discord.com/channels/593655374469660673/1197575814494035968/1409883390995337226

Bandwidth data from @nflaig 's node:

<img width="660" height="666" alt="image" src="https://github.com/user-attachments/assets/dc5be828-2a46-4f85-82b0-70ee271445f7" />
