### PR TITLE
fix: track execution engine getBlobs requests

### DIFF
--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -464,7 +464,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     const response = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
-    >({method, params: [blockHashes]});
+    >({method, params: [blockHashes]}, {routeId: "getPayloadBodiesByHash"});
     return response.map(deserializeExecutionPayloadBody);
   }
 
@@ -480,7 +480,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     const response = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
-    >({method, params: [start, count]});
+    >({method, params: [start, count]}, {routeId: "getPayloadBodiesByRange"});
     return response.map(deserializeExecutionPayloadBody);
   }
 
@@ -551,7 +551,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     const response = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
-    >({method, params: [{...clientVersion, commit: `0x${clientVersion.commit}`}]});
+    >({method, params: [{...clientVersion, commit: `0x${clientVersion.commit}`}]}, {routeId: "getClientVersion"});
 
     const clientVersions = response.map((cv) => {
       const code = cv.code in ClientCode ? ClientCode[cv.code as keyof typeof ClientCode] : ClientCode.XX;

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -502,10 +502,13 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     const response = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes["engine_getBlobsV1"],
       EngineApiRpcParamTypes["engine_getBlobsV1"]
-    >({
-      method: "engine_getBlobsV1",
-      params: [versionedHashesHex],
-    }, {routeId: "getBlobsV1"});
+    >(
+      {
+        method: "engine_getBlobsV1",
+        params: [versionedHashesHex],
+      },
+      {routeId: "getBlobsV1"}
+    );
 
     const invalidLength = response.length !== versionedHashesHex.length;
 
@@ -522,10 +525,13 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     const response = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes["engine_getBlobsV2"],
       EngineApiRpcParamTypes["engine_getBlobsV2"]
-    >({
-      method: "engine_getBlobsV2",
-      params: [versionedHashesHex],
-    }, {routeId: "getBlobsV2"});
+    >(
+      {
+        method: "engine_getBlobsV2",
+        params: [versionedHashesHex],
+      },
+      {routeId: "getBlobsV2"}
+    );
 
     // engine_getBlobsV2 does not return partial responses. It returns null if any blob is not found
     const invalidLength = !!response && response.length !== versionedHashesHex.length;

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -505,7 +505,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     >({
       method: "engine_getBlobsV1",
       params: [versionedHashesHex],
-    });
+    }, {routeId: "getBlobsV1"});
 
     const invalidLength = response.length !== versionedHashesHex.length;
 
@@ -525,7 +525,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     >({
       method: "engine_getBlobsV2",
       params: [versionedHashesHex],
-    });
+    }, {routeId: "getBlobsV2"});
 
     // engine_getBlobsV2 does not return partial responses. It returns null if any blob is not found
     const invalidLength = !!response && response.length !== versionedHashesHex.length;

--- a/packages/beacon-node/src/execution/engine/http.ts
+++ b/packages/beacon-node/src/execution/engine/http.ts
@@ -110,6 +110,11 @@ const MAX_VERSIONED_HASHES = 128;
 const notifyNewPayloadOpts: ReqOpts = {routeId: "notifyNewPayload"};
 const forkchoiceUpdatedV1Opts: ReqOpts = {routeId: "forkchoiceUpdated"};
 const getPayloadOpts: ReqOpts = {routeId: "getPayload"};
+const getPayloadBodiesByHashOpts: ReqOpts = {routeId: "getPayloadBodiesByHash"};
+const getPayloadBodiesByRangeOpts: ReqOpts = {routeId: "getPayloadBodiesByRange"};
+const getBlobsV1Opts: ReqOpts = {routeId: "getBlobsV1"};
+const getBlobsV2Opts: ReqOpts = {routeId: "getBlobsV2"};
+const getClientVersionOpts: ReqOpts = {routeId: "getClientVersion"};
 
 /**
  * based on Ethereum JSON-RPC API and inherits the following properties of this standard:
@@ -464,7 +469,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     const response = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
-    >({method, params: [blockHashes]}, {routeId: "getPayloadBodiesByHash"});
+    >({method, params: [blockHashes]}, getPayloadBodiesByHashOpts);
     return response.map(deserializeExecutionPayloadBody);
   }
 
@@ -480,7 +485,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     const response = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
-    >({method, params: [start, count]}, {routeId: "getPayloadBodiesByRange"});
+    >({method, params: [start, count]}, getPayloadBodiesByRangeOpts);
     return response.map(deserializeExecutionPayloadBody);
   }
 
@@ -507,7 +512,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         method: "engine_getBlobsV1",
         params: [versionedHashesHex],
       },
-      {routeId: "getBlobsV1"}
+      getBlobsV1Opts
     );
 
     const invalidLength = response.length !== versionedHashesHex.length;
@@ -530,7 +535,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
         method: "engine_getBlobsV2",
         params: [versionedHashesHex],
       },
-      {routeId: "getBlobsV2"}
+      getBlobsV2Opts
     );
 
     // engine_getBlobsV2 does not return partial responses. It returns null if any blob is not found
@@ -551,7 +556,7 @@ export class ExecutionEngineHttp implements IExecutionEngine {
     const response = await this.rpc.fetchWithRetries<
       EngineApiRpcReturnTypes[typeof method],
       EngineApiRpcParamTypes[typeof method]
-    >({method, params: [{...clientVersion, commit: `0x${clientVersion.commit}`}]}, {routeId: "getClientVersion"});
+    >({method, params: [{...clientVersion, commit: `0x${clientVersion.commit}`}]}, getClientVersionOpts);
 
     const clientVersions = response.map((cv) => {
       const code = cv.code in ClientCode ? ClientCode[cv.code as keyof typeof ClientCode] : ClientCode.XX;


### PR DESCRIPTION
**Motivation**

- we currently track `getBlobs` request as unknown on metric

<img width="1304" height="374" alt="Screenshot 2025-08-27 at 10 39 58" src="https://github.com/user-attachments/assets/721cd695-41e2-4e49-9225-7358acb2a6d4" />


**Description**

- track routeId to show them on our Grafana dashboard

part of #8271