### PR TITLE
feat: fromHexInto() api

### DIFF
--- a/packages/utils/src/bytes/browser.ts
+++ b/packages/utils/src/bytes/browser.ts
@@ -60,6 +60,9 @@ export function fromHex(hex: string): Uint8Array {
   const byteLen = hex.length / 2;
   const bytes = new Uint8Array(byteLen);
   for (let i = 0; i < byteLen; i++) {
+    // "a".charCodeAt(0) = 97 => delta = 87
+    // "A".charCodeAt(0) = 65 => delta = 55
+    // "0".charCodeAt(0) = 48
     const charCode2i = hex.charCodeAt(i * 2);
     const byte2i = charCode2i >= 97 ? charCode2i - 87 : charCode2i >= 65 ? charCode2i - 55 : charCode2i - 48;
     const charCode2i1 = hex.charCodeAt(i * 2 + 1);

--- a/packages/utils/src/bytes/browser.ts
+++ b/packages/utils/src/bytes/browser.ts
@@ -60,13 +60,8 @@ export function fromHex(hex: string): Uint8Array {
   const byteLen = hex.length / 2;
   const bytes = new Uint8Array(byteLen);
   for (let i = 0; i < byteLen; i++) {
-    // "a".charCodeAt(0) = 97 => delta = 87
-    // "A".charCodeAt(0) = 65 => delta = 55
-    // "0".charCodeAt(0) = 48
-    const charCode2i = hex.charCodeAt(i * 2);
-    const byte2i = charCode2i >= 97 ? charCode2i - 87 : charCode2i >= 65 ? charCode2i - 55 : charCode2i - 48;
-    const charCode2i1 = hex.charCodeAt(i * 2 + 1);
-    const byte2i1 = charCode2i1 >= 97 ? charCode2i1 - 87 : charCode2i1 >= 65 ? charCode2i1 - 55 : charCode2i1 - 48;
+    const byte2i = charCodeToByte(hex.charCodeAt(i * 2));
+    const byte2i1 = charCodeToByte(hex.charCodeAt(i * 2 + 1));
     bytes[i] = (byte2i << 4) | byte2i1;
   }
   return bytes;
@@ -82,13 +77,8 @@ export function fromHexInto(hex: string, buffer: Uint8Array): void {
   }
 
   for (let i = 0; i < buffer.length; i++) {
-    // "a".charCodeAt(0) = 97 => delta = 87
-    // "A".charCodeAt(0) = 65 => delta = 55
-    // "0".charCodeAt(0) = 48
-    const charCode2i = hex.charCodeAt(i * 2);
-    const byte2i = charCode2i >= 97 ? charCode2i - 87 : charCode2i >= 65 ? charCode2i - 55 : charCode2i - 48;
-    const charCode2i1 = hex.charCodeAt(i * 2 + 1);
-    const byte2i1 = charCode2i1 >= 97 ? charCode2i1 - 87 : charCode2i1 >= 65 ? charCode2i1 - 55 : charCode2i1 - 48;
+    const byte2i = charCodeToByte(hex.charCodeAt(i * 2));
+    const byte2i1 = charCodeToByte(hex.charCodeAt(i * 2 + 1));
     buffer[i] = (byte2i << 4) | byte2i1;
   }
 }
@@ -111,4 +101,23 @@ function bytesIntoCharCodes(bytes: Uint8Array, charCodes: number[]): void {
     charCodes[2 + 2 * i] = first < 10 ? first + 48 : first + 87;
     charCodes[2 + 2 * i + 1] = second < 10 ? second + 48 : second + 87;
   }
+}
+
+function charCodeToByte(charCode: number): number {
+  // "a".charCodeAt(0) = 97, "f".charCodeAt(0) = 102 => delta = 87
+  if (charCode >= 97 && charCode <= 102) {
+    return charCode - 87;
+  }
+
+  // "A".charCodeAt(0) = 65, "F".charCodeAt(0) = 70 => delta = 55
+  if (charCode >= 65 && charCode <= 70) {
+    return charCode - 55;
+  }
+
+  // "0".charCodeAt(0) = 48, "9".charCodeAt(0) = 57 => delta = 48
+  if (charCode >= 48 && charCode <= 57) {
+    return charCode - 48;
+  }
+
+  throw new Error(`Invalid hex character code: ${charCode}`);
 }

--- a/packages/utils/src/bytes/browser.ts
+++ b/packages/utils/src/bytes/browser.ts
@@ -66,6 +66,21 @@ export function fromHex(hex: string): Uint8Array {
   return bytes;
 }
 
+export function fromHexInto(hex: string, buffer: Uint8Array): void {
+  if (hex.startsWith("0x")) {
+    hex = hex.slice(2);
+  }
+
+  if (hex.length !== buffer.length * 2) {
+    throw new Error(`hex string length ${hex.length} must be exactly double the buffer length ${buffer.length}`);
+  }
+
+  for (let i = 0; i < buffer.length; i++) {
+    const byte = parseInt(hex.slice(i * 2, (i + 1) * 2), 16);
+    buffer[i] = byte;
+  }
+}
+
 /**
  * Populate charCodes from bytes. Note that charCodes index 0 and 1 ("0x") are not populated.
  */

--- a/packages/utils/src/bytes/browser.ts
+++ b/packages/utils/src/bytes/browser.ts
@@ -60,8 +60,11 @@ export function fromHex(hex: string): Uint8Array {
   const byteLen = hex.length / 2;
   const bytes = new Uint8Array(byteLen);
   for (let i = 0; i < byteLen; i++) {
-    const byte = parseInt(hex.slice(i * 2, (i + 1) * 2), 16);
-    bytes[i] = byte;
+    const charCode2i = hex.charCodeAt(i * 2);
+    const byte2i = charCode2i >= 97 ? charCode2i - 87 : charCode2i >= 65 ? charCode2i - 55 : charCode2i - 48;
+    const charCode2i1 = hex.charCodeAt(i * 2 + 1);
+    const byte2i1 = charCode2i1 >= 97 ? charCode2i1 - 87 : charCode2i1 >= 65 ? charCode2i1 - 55 : charCode2i1 - 48;
+    bytes[i] = (byte2i << 4) | byte2i1;
   }
   return bytes;
 }
@@ -76,8 +79,14 @@ export function fromHexInto(hex: string, buffer: Uint8Array): void {
   }
 
   for (let i = 0; i < buffer.length; i++) {
-    const byte = parseInt(hex.slice(i * 2, (i + 1) * 2), 16);
-    buffer[i] = byte;
+    // "a".charCodeAt(0) = 97 => delta = 87
+    // "A".charCodeAt(0) = 65 => delta = 55
+    // "0".charCodeAt(0) = 48
+    const charCode2i = hex.charCodeAt(i * 2);
+    const byte2i = charCode2i >= 97 ? charCode2i - 87 : charCode2i >= 65 ? charCode2i - 55 : charCode2i - 48;
+    const charCode2i1 = hex.charCodeAt(i * 2 + 1);
+    const byte2i1 = charCode2i1 >= 97 ? charCode2i1 - 87 : charCode2i1 >= 65 ? charCode2i1 - 55 : charCode2i1 - 48;
+    buffer[i] = (byte2i << 4) | byte2i1;
   }
 }
 

--- a/packages/utils/src/bytes/index.ts
+++ b/packages/utils/src/bytes/index.ts
@@ -7,7 +7,6 @@ import {
 } from "./browser.js";
 import {
   fromHex as nodeFromHex,
-  fromHexInto as nodeFromHexInto,
   toHex as nodeToHex,
   toPubkeyHex as nodeToPubkeyHex,
   toRootHex as nodeToRootHex,
@@ -17,14 +16,14 @@ let toHex = browserToHex;
 let toRootHex = browserToRootHex;
 let toPubkeyHex = browserToPubkeyHex;
 let fromHex = browserFromHex;
-let fromHexInto = browserFromHexInto;
+// there is no fromHexInto for NodeJs as the performance of browserFromHexInto is >100x faster
+const fromHexInto = browserFromHexInto;
 
 if (typeof Buffer !== "undefined") {
   toHex = nodeToHex;
   toRootHex = nodeToRootHex;
   toPubkeyHex = nodeToPubkeyHex;
   fromHex = nodeFromHex;
-  fromHexInto = nodeFromHexInto;
 }
 
 export {toHex, toRootHex, toPubkeyHex, fromHex, fromHexInto};

--- a/packages/utils/src/bytes/index.ts
+++ b/packages/utils/src/bytes/index.ts
@@ -1,11 +1,13 @@
 import {
   fromHex as browserFromHex,
+  fromHexInto as browserFromHexInto,
   toHex as browserToHex,
   toPubkeyHex as browserToPubkeyHex,
   toRootHex as browserToRootHex,
 } from "./browser.js";
 import {
   fromHex as nodeFromHex,
+  fromHexInto as nodeFromHexInto,
   toHex as nodeToHex,
   toPubkeyHex as nodeToPubkeyHex,
   toRootHex as nodeToRootHex,
@@ -15,12 +17,14 @@ let toHex = browserToHex;
 let toRootHex = browserToRootHex;
 let toPubkeyHex = browserToPubkeyHex;
 let fromHex = browserFromHex;
+let fromHexInto = browserFromHexInto;
 
 if (typeof Buffer !== "undefined") {
   toHex = nodeToHex;
   toRootHex = nodeToRootHex;
   toPubkeyHex = nodeToPubkeyHex;
   fromHex = nodeFromHex;
+  fromHexInto = nodeFromHexInto;
 }
 
-export {toHex, toRootHex, toPubkeyHex, fromHex};
+export {toHex, toRootHex, toPubkeyHex, fromHex, fromHexInto};

--- a/packages/utils/src/bytes/nodejs.ts
+++ b/packages/utils/src/bytes/nodejs.ts
@@ -62,20 +62,4 @@ export function fromHex(hex: string): Uint8Array {
   return new Uint8Array(b.buffer, b.byteOffset, b.length);
 }
 
-export function fromHexInto(hex: string, buffer: Uint8Array): void {
-  // fallback to browser impl for non-Buffer inputs
-  if (!(buffer instanceof Buffer)) {
-    _fromHexInto(hex, buffer);
-    return;
-  }
-
-  if (hex.startsWith("0x")) {
-    hex = hex.slice(2);
-  }
-
-  if (hex.length !== buffer.length * 2) {
-    throw new Error(`hex string length ${hex.length} must be exactly double the buffer length ${buffer.length}`);
-  }
-
-  buffer.write(hex, "hex");
-}
+/// the performance of fromHexInto using a preallocated buffer is very bad compared to browser so I moved it to the benchmark

--- a/packages/utils/src/bytes/nodejs.ts
+++ b/packages/utils/src/bytes/nodejs.ts
@@ -1,3 +1,5 @@
+import {fromHexInto as _fromHexInto} from "./browser.js";
+
 export function toHex(buffer: Uint8Array | Parameters<typeof Buffer.from>[0]): string {
   if (Buffer.isBuffer(buffer)) {
     return "0x" + buffer.toString("hex");
@@ -58,4 +60,22 @@ export function fromHex(hex: string): Uint8Array {
 
   const b = Buffer.from(hex, "hex");
   return new Uint8Array(b.buffer, b.byteOffset, b.length);
+}
+
+export function fromHexInto(hex: string, buffer: Uint8Array): void {
+  // fallback to browser impl for non-Buffer inputs
+  if (!(buffer instanceof Buffer)) {
+    _fromHexInto(hex, buffer);
+    return;
+  }
+
+  if (hex.startsWith("0x")) {
+    hex = hex.slice(2);
+  }
+
+  if (hex.length !== buffer.length * 2) {
+    throw new Error(`hex string length ${hex.length} must be exactly double the buffer length ${buffer.length}`);
+  }
+
+  buffer.write(hex, "hex");
 }

--- a/packages/utils/test/perf/bytes.test.ts
+++ b/packages/utils/test/perf/bytes.test.ts
@@ -1,11 +1,17 @@
 import {bench, describe} from "@chainsafe/benchmark";
 import {toHexString} from "../../src/bytes.js";
-import {toHex as browserToHex, toRootHex as browserToRootHex} from "../../src/bytes/browser.js";
-import {toHex, toRootHex} from "../../src/bytes/nodejs.js";
+import {
+  fromHex as browserFromHex,
+  fromHexInto as browserFromHexInto,
+  toHex as browserToHex,
+  toRootHex as browserToRootHex,
+} from "../../src/bytes/browser.js";
+import {fromHex, fromHexInto, toHex, toRootHex} from "../../src/bytes/nodejs.js";
 
 describe("bytes utils", () => {
   const runsFactor = 1000;
   const blockRoot = new Uint8Array(Array.from({length: 32}, (_, i) => i));
+  const rootHex = toRootHex(blockRoot);
 
   bench({
     id: "nodejs block root to RootHex using toHex",
@@ -25,6 +31,25 @@ describe("bytes utils", () => {
       }
     },
     runsFactor,
+  });
+
+  bench({
+    id: "nodejs fromhex",
+    fn: () => {
+      for (let i = 0; i < runsFactor; i++) {
+        fromHex(rootHex);
+      }
+    },
+  });
+
+  const buffer = Buffer.alloc(32);
+  bench({
+    id: "nodejs fromHexInto",
+    fn: () => {
+      for (let i = 0; i < runsFactor; i++) {
+        fromHexInto(rootHex, buffer);
+      }
+    },
   });
 
   bench({
@@ -55,5 +80,25 @@ describe("bytes utils", () => {
       }
     },
     runsFactor,
+  });
+
+  const buf = new Uint8Array(32);
+  bench({
+    id: "browser fromHexInto",
+    fn: () => {
+      for (let i = 0; i < runsFactor; i++) {
+        browserFromHexInto(rootHex, buf);
+      }
+    },
+    runsFactor,
+  });
+
+  bench({
+    id: "browser fromHex",
+    fn: () => {
+      for (let i = 0; i < runsFactor; i++) {
+        browserFromHex(rootHex);
+      }
+    },
   });
 });

--- a/packages/utils/test/perf/bytes.test.ts
+++ b/packages/utils/test/perf/bytes.test.ts
@@ -11,7 +11,10 @@ import {fromHex, fromHexInto, toHex, toRootHex} from "../../src/bytes/nodejs.js"
 describe("bytes utils", () => {
   const runsFactor = 1000;
   const blockRoot = new Uint8Array(Array.from({length: 32}, (_, i) => i));
-  const rootHex = toRootHex(blockRoot);
+  // FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT = 4096 * 32 = 131072
+  const BLOB_LEN = 131072;
+  const blob = new Uint8Array(BLOB_LEN);
+  const blobHex = toHex(blob);
 
   bench({
     id: "nodejs block root to RootHex using toHex",
@@ -34,20 +37,20 @@ describe("bytes utils", () => {
   });
 
   bench({
-    id: "nodejs fromhex",
+    id: "nodejs fromhex(blob)",
     fn: () => {
       for (let i = 0; i < runsFactor; i++) {
-        fromHex(rootHex);
+        fromHex(blobHex);
       }
     },
   });
 
-  const buffer = Buffer.alloc(32);
+  const buffer = Buffer.alloc(BLOB_LEN);
   bench({
-    id: "nodejs fromHexInto",
+    id: "nodejs fromHexInto(blob)",
     fn: () => {
       for (let i = 0; i < runsFactor; i++) {
-        fromHexInto(rootHex, buffer);
+        fromHexInto(blobHex, buffer);
       }
     },
   });
@@ -82,22 +85,22 @@ describe("bytes utils", () => {
     runsFactor,
   });
 
-  const buf = new Uint8Array(32);
+  const buf = new Uint8Array(BLOB_LEN);
   bench({
-    id: "browser fromHexInto",
+    id: "browser fromHexInto(blob)",
     fn: () => {
       for (let i = 0; i < runsFactor; i++) {
-        browserFromHexInto(rootHex, buf);
+        browserFromHexInto(blobHex, buf);
       }
     },
     runsFactor,
   });
 
   bench({
-    id: "browser fromHex",
+    id: "browser fromHex(blob)",
     fn: () => {
       for (let i = 0; i < runsFactor; i++) {
-        browserFromHex(rootHex);
+        browserFromHex(blobHex);
       }
     },
   });

--- a/packages/utils/test/perf/bytes.test.ts
+++ b/packages/utils/test/perf/bytes.test.ts
@@ -14,6 +14,9 @@ describe("bytes utils", () => {
   // FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT = 4096 * 32 = 131072
   const BLOB_LEN = 131072;
   const blob = new Uint8Array(BLOB_LEN);
+  for (let i = 0; i < blob.length; i++) {
+    blob[i] = i % 256;
+  }
   const blobHex = toHex(blob);
 
   bench({

--- a/packages/utils/test/perf/bytes.test.ts
+++ b/packages/utils/test/perf/bytes.test.ts
@@ -6,7 +6,7 @@ import {
   toHex as browserToHex,
   toRootHex as browserToRootHex,
 } from "../../src/bytes/browser.js";
-import {fromHex, fromHexInto, toHex, toRootHex} from "../../src/bytes/nodejs.js";
+import {fromHex, toHex, toRootHex} from "../../src/bytes/nodejs.js";
 
 describe("bytes utils", () => {
   const runsFactor = 1000;
@@ -50,7 +50,7 @@ describe("bytes utils", () => {
     id: "nodejs fromHexInto(blob)",
     fn: () => {
       for (let i = 0; i < runsFactor; i++) {
-        fromHexInto(blobHex, buffer);
+        nodeJsFromHexInto(blobHex, buffer);
       }
     },
   });
@@ -105,3 +105,20 @@ describe("bytes utils", () => {
     },
   });
 });
+
+/**
+ * this function is so slow compared to browser's implementation we only maintain it here to compare performance
+ *   - nodejs fromHexInto(blob)                                            3.562495 ops/s    280.7022 ms/op        -         10 runs   3.50 s
+ *   - browser fromHexInto(blob)                                           535.0952 ops/s    1.868826 ms/op        -         10 runs   20.8 s
+ */
+function nodeJsFromHexInto(hex: string, buffer: Buffer): void {
+  if (hex.startsWith("0x")) {
+    hex = hex.slice(2);
+  }
+
+  if (hex.length !== buffer.length * 2) {
+    throw new Error(`hex string length ${hex.length} must be exactly double the buffer length ${buffer.length}`);
+  }
+
+  buffer.write(hex, "hex");
+}

--- a/packages/utils/test/unit/bytes.test.ts
+++ b/packages/utils/test/unit/bytes.test.ts
@@ -3,6 +3,7 @@ import {
   bytesToInt,
   formatBytes,
   fromHex,
+  fromHexInto,
   intToBytes,
   toHex,
   toHexString,
@@ -108,7 +109,7 @@ describe("toPubkeyHex", () => {
   }
 });
 
-describe("fromHex", () => {
+describe("fromHex and fromHexInto", () => {
   const testCases: {input: string; output: Buffer | Uint8Array}[] = [
     {
       input: "0x48656c6c6f2c20576f726c6421",
@@ -124,6 +125,14 @@ describe("fromHex", () => {
   for (const {input, output} of testCases) {
     it(`should convert hex string ${input} to Uint8Array`, () => {
       expect(fromHex(input)).toEqual(output);
+    });
+  }
+
+  for (const {input, output} of testCases) {
+    it(`should convert hex string ${input} into provided buffer`, () => {
+      const buffer = typeof Buffer !== "undefined" ? Buffer.alloc(output.length) : new Uint8Array(output.length);
+      fromHexInto(input, buffer);
+      expect(toHex(buffer)).toBe(toHex(output));
     });
   }
 });

--- a/packages/utils/test/unit/bytes.test.ts
+++ b/packages/utils/test/unit/bytes.test.ts
@@ -116,7 +116,17 @@ describe("fromHex and fromHexInto", () => {
       output: new Uint8Array([72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33]),
     },
     {
+      // same but with upper case
+      input: "0x48656C6C6F2C20576F726C6421",
+      output: new Uint8Array([72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33]),
+    },
+    {
       input: "48656c6c6f2c20576f726c6421",
+      output: new Uint8Array([72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33]),
+    },
+    {
+      // same but with upper case
+      input: "48656C6C6F2C20576F726C6421",
       output: new Uint8Array([72, 101, 108, 108, 111, 44, 32, 87, 111, 114, 108, 100, 33]),
     },
     {input: "0x", output: new Uint8Array([])},

--- a/packages/utils/test/unit/bytes.test.ts
+++ b/packages/utils/test/unit/bytes.test.ts
@@ -140,7 +140,7 @@ describe("fromHex and fromHexInto", () => {
 
   for (const {input, output} of testCases) {
     it(`should convert hex string ${input} into provided buffer`, () => {
-      const buffer = typeof Buffer !== "undefined" ? Buffer.alloc(output.length) : new Uint8Array(output.length);
+      const buffer = new Uint8Array(output.length);
       fromHexInto(input, buffer);
       expect(toHex(buffer)).toBe(toHex(output));
     });


### PR DESCRIPTION
**Motivation**

- improve the time to deserialize hex, especially for getBlobsV2() where each blob is 131kb
- if the benchmark is correct, we can expect the time to deserialize blob hex from `332.6842 ms/op` to more or less 2ms
- will apply it for getBlobsV2() in the next PR by preallocate some memory and reuse it for all slots

**Description**

- implement `fromHexInto()` using `String.charCodeAt()` for browser and use that for NodeJs as well
- the Buffer/NodeJS implementation is too bad that I only maintain it in the benchmark

**Test result on a regular lodestar node**
- `browser fromHexInto(blob)` is 1000x faster than `browser fromHex(blob)` and >100x faster than `nodejs fromHexInto(blob) `

```
packages/utils/test/perf/bytes.test.ts
  bytes utils
    ✔ nodejs block root to RootHex using toHex                             2817687 ops/s    354.9010 ns/op        -       1324 runs  0.897 s
    ✔ nodejs block root to RootHex using toRootHex                         4369044 ops/s    228.8830 ns/op        -       1793 runs  0.902 s
    ✔ nodejs fromhex(blob)                                                3.005854 ops/s    332.6842 ms/op        -         10 runs   4.18 s
    ✔ nodejs fromHexInto(blob)                                            3.617654 ops/s    276.4222 ms/op        -         10 runs   3.36 s
    ✔ browser block root to RootHex using the deprecated toHexString       1656696 ops/s    603.6110 ns/op        -        963 runs   1.34 s
    ✔ browser block root to RootHex using toHex                            2060611 ops/s    485.2930 ns/op        -        424 runs  0.812 s
    ✔ browser block root to RootHex using toRootHex                        2320476 ops/s    430.9460 ns/op        -        889 runs  0.841 s
    ✔ browser fromHexInto(blob)                                           503.7166 ops/s    1.985243 ms/op        -         10 runs   21.9 s
    ✔ browser fromHex(blob)                                              0.5095370 ops/s    1.962566  s/op        -         10 runs   21.7 s
```
