### PR TITLE
fix: do not create data column sidecars if block has no blobs

### DIFF
--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -183,6 +183,11 @@ export async function validateDataColumnsSidecars(
   metrics: Metrics | null,
   opts: {skipProofsCheck: boolean} = {skipProofsCheck: false}
 ): Promise<void> {
+  // Skip verification if there are no data columns
+  if (dataColumnSidecars.length === 0) {
+    return;
+  }
+
   const commitmentBytes: Uint8Array[] = [];
   const cellIndices: number[] = [];
   const cells: Uint8Array[] = [];

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -309,6 +309,12 @@ export function getDataColumnSidecarsFromBlock(
   cellsAndKzgProofs: {cells: Uint8Array[]; proofs: Uint8Array[]}[]
 ): fulu.DataColumnSidecars {
   const blobKzgCommitments = signedBlock.message.body.blobKzgCommitments;
+
+  // No need to create data column sidecars if there are no blobs
+  if (blobKzgCommitments.length === 0) {
+    return [];
+  }
+
   const fork = config.getForkName(signedBlock.message.slot);
   const signedBlockHeader = signedBlockToSignedHeader(config, signedBlock);
 


### PR DESCRIPTION
**Motivation**

Fix block production if block has 0 blobs

**Description**

Do not create data column sidecars if there block has no blobs and return early in data column validation if there are no data column sidecars to validate.


Closes https://github.com/ChainSafe/lodestar/issues/8276
