### PR TITLE
fix: emit listenerCount events only when count > 0

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -308,7 +308,7 @@ export function getBeaconBlockApi({
       }
     }
 
-    if (chain.emitter.listenerCount(routes.events.EventType.blockGossip)) {
+    if (chain.emitter.listenerCount(routes.events.EventType.blockGossip) > 0) {
       chain.emitter.emit(routes.events.EventType.blockGossip, {slot, block: blockRoot});
     }
 
@@ -317,7 +317,7 @@ export function getBeaconBlockApi({
         const {dataColumns} = blockForImport.blockData as BlockInputDataColumns;
         metrics?.dataColumns.bySource.inc({source: DataColumnsSource.api}, dataColumns.length);
 
-        if (chain.emitter.listenerCount(routes.events.EventType.dataColumnSidecar)) {
+        if (chain.emitter.listenerCount(routes.events.EventType.dataColumnSidecar) > 0) {
           for (const dataColumnSidecar of dataColumns) {
             chain.emitter.emit(routes.events.EventType.dataColumnSidecar, {
               blockRoot,
@@ -329,7 +329,7 @@ export function getBeaconBlockApi({
         }
       } else if (
         isForkPostDeneb(blockForImport.blockData.fork) &&
-        chain.emitter.listenerCount(routes.events.EventType.blobSidecar)
+        chain.emitter.listenerCount(routes.events.EventType.blobSidecar) > 0
       ) {
         const {blobs} = blockForImport.blockData as BlockInputBlobs;
 

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -464,34 +464,34 @@ export async function importBlock(
     // We want to import block asap so call all event handler in the next event loop
     callInNextEventLoop(() => {
       // NOTE: Skip emitting if there are no listeners from the API
-      if (this.emitter.listenerCount(routes.events.EventType.block)) {
+      if (this.emitter.listenerCount(routes.events.EventType.block) > 0) {
         this.emitter.emit(routes.events.EventType.block, {
           block: blockRootHex,
           slot: blockSlot,
           executionOptimistic: blockSummary != null && isOptimisticBlock(blockSummary),
         });
       }
-      if (this.emitter.listenerCount(routes.events.EventType.voluntaryExit)) {
+      if (this.emitter.listenerCount(routes.events.EventType.voluntaryExit) > 0) {
         for (const voluntaryExit of block.message.body.voluntaryExits) {
           this.emitter.emit(routes.events.EventType.voluntaryExit, voluntaryExit);
         }
       }
-      if (this.emitter.listenerCount(routes.events.EventType.blsToExecutionChange)) {
+      if (this.emitter.listenerCount(routes.events.EventType.blsToExecutionChange) > 0) {
         for (const blsToExecutionChange of (block.message as capella.BeaconBlock).body.blsToExecutionChanges ?? []) {
           this.emitter.emit(routes.events.EventType.blsToExecutionChange, blsToExecutionChange);
         }
       }
-      if (this.emitter.listenerCount(routes.events.EventType.attestation)) {
+      if (this.emitter.listenerCount(routes.events.EventType.attestation) > 0) {
         for (const attestation of block.message.body.attestations) {
           this.emitter.emit(routes.events.EventType.attestation, attestation);
         }
       }
-      if (this.emitter.listenerCount(routes.events.EventType.attesterSlashing)) {
+      if (this.emitter.listenerCount(routes.events.EventType.attesterSlashing) > 0) {
         for (const attesterSlashing of block.message.body.attesterSlashings) {
           this.emitter.emit(routes.events.EventType.attesterSlashing, attesterSlashing);
         }
       }
-      if (this.emitter.listenerCount(routes.events.EventType.proposerSlashing)) {
+      if (this.emitter.listenerCount(routes.events.EventType.proposerSlashing) > 0) {
         for (const proposerSlashing of block.message.body.proposerSlashings) {
           this.emitter.emit(routes.events.EventType.proposerSlashing, proposerSlashing);
         }

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -176,7 +176,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
 
       logger.debug("Validated gossip block", {...logCtx, recvToValidation, validationTime});
 
-      if (chain.emitter.listenerCount(routes.events.EventType.blockGossip)) {
+      if (chain.emitter.listenerCount(routes.events.EventType.blockGossip) > 0) {
         chain.emitter.emit(routes.events.EventType.blockGossip, {slot, block: blockRootHex});
       }
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -229,7 +229,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       metrics?.gossipBlob.recvToValidation.observe(recvToValidation);
       metrics?.gossipBlob.validationTime.observe(validationTime);
 
-      if (chain.emitter.listenerCount(routes.events.EventType.blobSidecar)) {
+      if (chain.emitter.listenerCount(routes.events.EventType.blobSidecar) > 0) {
         chain.emitter.emit(routes.events.EventType.blobSidecar, {
           blockRoot: blockRootHex,
           slot,

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -368,7 +368,7 @@ export async function unavailableBeaconBlobsByRootPreFulu(
         // verifyBlocksDataAvailability
         cachedData.blobsCache.set(blobSidecar.index, blobSidecar);
 
-        if (emitter.listenerCount(routes.events.EventType.blobSidecar)) {
+        if (emitter.(routes.events.EventType.blobSidecar)>0) {
           emitter.emit(routes.events.EventType.blobSidecar, {
             blockRoot: blockRootHex,
             slot,
@@ -441,7 +441,7 @@ export async function unavailableBeaconBlobsByRootPreFulu(
   for (const blobSidecar of networkResBlobSidecars) {
     cachedData.blobsCache.set(blobSidecar.index, blobSidecar);
 
-    if (emitter.listenerCount(routes.events.EventType.blobSidecar)) {
+    if (emitter.(routes.events.EventType.blobSidecar)>0) {
       emitter.emit(routes.events.EventType.blobSidecar, {
         blockRoot: blockRootHex,
         slot,

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -368,7 +368,7 @@ export async function unavailableBeaconBlobsByRootPreFulu(
         // verifyBlocksDataAvailability
         cachedData.blobsCache.set(blobSidecar.index, blobSidecar);
 
-        if (emitter.(routes.events.EventType.blobSidecar)>0) {
+        if (emitter.listenerCount(routes.events.EventType.blobSidecar) > 0) {
           emitter.emit(routes.events.EventType.blobSidecar, {
             blockRoot: blockRootHex,
             slot,
@@ -441,7 +441,7 @@ export async function unavailableBeaconBlobsByRootPreFulu(
   for (const blobSidecar of networkResBlobSidecars) {
     cachedData.blobsCache.set(blobSidecar.index, blobSidecar);
 
-    if (emitter.(routes.events.EventType.blobSidecar)>0) {
+    if (emitter.listenerCount(routes.events.EventType.blobSidecar) > 0) {
       emitter.emit(routes.events.EventType.blobSidecar, {
         blockRoot: blockRootHex,
         slot,


### PR DESCRIPTION
**Motivation**
Prevent emitting when listenerCount is zero to avoid noisy, misleading events and unnecessary downstream processing.
<!-- Why is this PR exists? What are the goals of the pull request? -->

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->
Adjusted conditionals so emit is triggered strictly when listenerCount > 0
<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number
#7996

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
