### PR TITLE
chore: remove error stacktrace from peer disconnected during identify protocol logs

### DIFF
--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -751,7 +751,7 @@ export class PeerManager {
       })
       .catch((err) => {
         if (evt.detail.status !== "open") {
-          this.logger.debug("Peer disconnected during identify protocol", {peerId: remotePeerPrettyStr}, err);
+          this.logger.debug("Peer disconnected during identify protocol", {peerId: remotePeerPrettyStr});
         } else {
           this.logger.debug("Error setting agentVersion for the peer", {peerId: remotePeerPrettyStr}, err);
         }

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -751,7 +751,10 @@ export class PeerManager {
       })
       .catch((err) => {
         if (evt.detail.status !== "open") {
-          this.logger.debug("Peer disconnected during identify protocol", {peerId: remotePeerPrettyStr});
+          this.logger.debug("Peer disconnected during identify protocol", {
+            peerId: remotePeerPrettyStr,
+            error: (err as Error).message,
+          });
         } else {
           this.logger.debug("Error setting agentVersion for the peer", {peerId: remotePeerPrettyStr}, err);
         }


### PR DESCRIPTION
**Motivation**

This log is way too verbose on devnet-3 right now
```
devops@lodestar-reth-1 ➜  ~ docker logs beacon 2>&1 | grep "Peer disconnected during identify protocol" | wc -l
113256
```

As suggested in https://github.com/ChainSafe/lodestar/pull/8188#discussion_r2269948281 we should observe the error for a bit and it seems to be only `unexpected end of input` which is not very useful.

**Description**


Remove error stacktrace from peer disconnected during identify protocol logs

~~Alternative could be to add message to context or concat to the message, open to any of these if we still think including the error message is valuable.~~ went with still printing out the error message