### PR TITLE
fix: self rate limiter to handle dead requests

### DIFF
--- a/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
+++ b/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
@@ -1,4 +1,4 @@
-import {MapDef} from "@lodestar/utils";
+import {Logger, MapDef} from "@lodestar/utils";
 
 type PeerIdStr = string;
 type ProtocolID = string;
@@ -12,11 +12,21 @@ export const CHECK_DISCONNECTED_PEERS_INTERVAL_MS = 2 * 60 * 1000;
 const DISCONNECTED_TIMEOUT_MS = 60 * 1000;
 
 /**
+ * Timeout to consider a request is no longer in progress
+ * this is to cover the case where `requestCompleted()` is not called due to unexpected errors
+ * for example https://github.com/ChainSafe/lodestar/issues/8256
+ **/
+export const REQUEST_TIMEOUT_MS = 30 * 1000;
+
+type RequestId = number;
+type RequestIdMs = number;
+
+/**
  * Simple rate limiter that allows a maximum of 2 concurrent requests per protocol per peer.
  * The consumer should either prevent requests from being sent when the limit is reached or handle the case when the request is not allowed.
  */
 export class SelfRateLimiter {
-  private readonly rateLimitersPerPeer: MapDef<PeerIdStr, MapDef<ProtocolID, number>>;
+  private readonly rateLimitersPerPeer: MapDef<PeerIdStr, MapDef<ProtocolID, Map<RequestId, RequestIdMs>>>;
   /**
    * It's not convenient to handle a peer disconnected event so we track the last seen requests by peer.
    * This is the same design to `ReqRespRateLimiter`.
@@ -25,9 +35,9 @@ export class SelfRateLimiter {
   /** Interval to check lastSeenMessagesByPeer */
   private cleanupInterval: NodeJS.Timeout | undefined = undefined;
 
-  constructor() {
-    this.rateLimitersPerPeer = new MapDef<PeerIdStr, MapDef<ProtocolID, number>>(
-      () => new MapDef<ProtocolID, number>(() => 0)
+  constructor(private readonly logger?: Logger) {
+    this.rateLimitersPerPeer = new MapDef<PeerIdStr, MapDef<ProtocolID, Map<RequestId, RequestIdMs>>>(
+      () => new MapDef<ProtocolID, Map<RequestId, RequestIdMs>>(() => new Map())
     );
     this.lastSeenRequestsByPeer = new Map();
   }
@@ -46,15 +56,32 @@ export class SelfRateLimiter {
   /**
    * called before we send a request to a peer.
    */
-  allows(peerId: PeerIdStr, protocolId: ProtocolID): boolean {
+  allows(peerId: PeerIdStr, protocolId: ProtocolID, requestId: RequestId): boolean {
     const peerRateLimiter = this.rateLimitersPerPeer.getOrDefault(peerId);
-    const inProgressRequests = peerRateLimiter.getOrDefault(protocolId);
+    const trackedRequests = peerRateLimiter.getOrDefault(protocolId);
     this.lastSeenRequestsByPeer.set(peerId, Date.now());
+
+    let inProgressRequests = 0;
+    for (const [trackedRequestId, trackedRequestTimeMs] of trackedRequests.entries()) {
+      if (trackedRequestTimeMs + REQUEST_TIMEOUT_MS <= Date.now()) {
+        // request timed out, remove it
+        trackedRequests.delete(trackedRequestId);
+        this.logger?.debug("SelfRateLimiter: request timed out, removing it", {
+          requestId: trackedRequestId,
+          requestTime: trackedRequestTimeMs,
+          peerId,
+          protocolId,
+        });
+      } else {
+        inProgressRequests++;
+      }
+    }
+
     if (inProgressRequests >= MAX_CONCURRENT_REQUESTS) {
       return false;
     }
 
-    peerRateLimiter.set(protocolId, inProgressRequests + 1);
+    trackedRequests.set(requestId, Date.now());
     return true;
   }
 
@@ -62,10 +89,10 @@ export class SelfRateLimiter {
    * called when a request to a peer is completed, regardless of success or failure.
    * This should NOT be called when the request was not allowed
    */
-  requestCompleted(peerId: PeerIdStr, protocolId: ProtocolID): void {
+  requestCompleted(peerId: PeerIdStr, protocolId: ProtocolID, requestId: RequestId): void {
     const peerRateLimiter = this.rateLimitersPerPeer.getOrDefault(peerId);
-    const inProgressRequests = peerRateLimiter.getOrDefault(protocolId);
-    peerRateLimiter.set(protocolId, Math.max(0, inProgressRequests - 1));
+    const trackedRequests = peerRateLimiter.getOrDefault(protocolId);
+    trackedRequests.delete(requestId);
   }
 
   getPeerCount(): number {

--- a/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
+++ b/packages/reqresp/src/rate_limiter/selfRateLimiter.ts
@@ -57,13 +57,14 @@ export class SelfRateLimiter {
    * called before we send a request to a peer.
    */
   allows(peerId: PeerIdStr, protocolId: ProtocolID, requestId: RequestId): boolean {
+    const now = Date.now();
     const peerRateLimiter = this.rateLimitersPerPeer.getOrDefault(peerId);
     const trackedRequests = peerRateLimiter.getOrDefault(protocolId);
-    this.lastSeenRequestsByPeer.set(peerId, Date.now());
+    this.lastSeenRequestsByPeer.set(peerId, now);
 
     let inProgressRequests = 0;
     for (const [trackedRequestId, trackedRequestTimeMs] of trackedRequests.entries()) {
-      if (trackedRequestTimeMs + REQUEST_TIMEOUT_MS <= Date.now()) {
+      if (trackedRequestTimeMs + REQUEST_TIMEOUT_MS <= now) {
         // request timed out, remove it
         trackedRequests.delete(trackedRequestId);
         this.logger?.debug("SelfRateLimiter: request timed out, removing it", {
@@ -81,7 +82,7 @@ export class SelfRateLimiter {
       return false;
     }
 
-    trackedRequests.set(requestId, Date.now());
+    trackedRequests.set(requestId, now);
     return true;
   }
 

--- a/packages/reqresp/test/unit/rate_limiter/selfRateLimiter.test.ts
+++ b/packages/reqresp/test/unit/rate_limiter/selfRateLimiter.test.ts
@@ -1,5 +1,9 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
-import {CHECK_DISCONNECTED_PEERS_INTERVAL_MS, SelfRateLimiter} from "../../../src/rate_limiter/selfRateLimiter.js";
+import {
+  CHECK_DISCONNECTED_PEERS_INTERVAL_MS,
+  REQUEST_TIMEOUT_MS,
+  SelfRateLimiter,
+} from "../../../src/rate_limiter/selfRateLimiter.js";
 
 describe("SelfRateLimiter", () => {
   let selfRateLimiter: SelfRateLimiter;
@@ -16,30 +20,39 @@ describe("SelfRateLimiter", () => {
   });
 
   it("allows requests under the limit", () => {
-    expect(selfRateLimiter.allows("peer1", "protocol1")).toBe(true);
-    expect(selfRateLimiter.allows("peer1", "protocol1")).toBe(true);
+    expect(selfRateLimiter.allows("peer1", "protocol1", 1)).toBe(true);
+    expect(selfRateLimiter.allows("peer1", "protocol1", 2)).toBe(true);
   });
 
   it("blocks requests over the limit", () => {
-    selfRateLimiter.allows("peer1", "protocol1");
-    selfRateLimiter.allows("peer1", "protocol1");
-    expect(selfRateLimiter.allows("peer1", "protocol1")).toBe(false);
+    selfRateLimiter.allows("peer1", "protocol1", 1);
+    selfRateLimiter.allows("peer1", "protocol1", 2);
+    expect(selfRateLimiter.allows("peer1", "protocol1", 3)).toBe(false);
     // but allows a different protocol
-    expect(selfRateLimiter.allows("peer1", "protocol2")).toBe(true);
+    expect(selfRateLimiter.allows("peer1", "protocol2", 4)).toBe(true);
     // allows a different peer
-    expect(selfRateLimiter.allows("peer2", "protocol1")).toBe(true);
+    expect(selfRateLimiter.allows("peer2", "protocol1", 5)).toBe(true);
 
     // allow after request completed
-    selfRateLimiter.requestCompleted("peer1", "protocol1");
-    expect(selfRateLimiter.allows("peer1", "protocol1")).toBe(true);
+    selfRateLimiter.requestCompleted("peer1", "protocol1", 1);
+    expect(selfRateLimiter.allows("peer1", "protocol1", 6)).toBe(true);
+  });
+
+  it("should timeout requests after REQUEST_TIMEOUT_MS", () => {
+    selfRateLimiter.allows("peer1", "protocol1", 1);
+    selfRateLimiter.allows("peer1", "protocol1", 2);
+    expect(selfRateLimiter.allows("peer1", "protocol1", 3)).toBe(false);
+
+    vi.advanceTimersByTime(REQUEST_TIMEOUT_MS);
+    expect(selfRateLimiter.allows("peer1", "protocol1", 4)).toBe(true);
   });
 
   it("should remove disconnected peers after interval", () => {
-    selfRateLimiter.allows("peer1", "protocol1");
-    selfRateLimiter.allows("peer1", "protocol1");
-    expect(selfRateLimiter.allows("peer1", "protocol1")).toBe(false);
+    selfRateLimiter.allows("peer1", "protocol1", 1);
+    selfRateLimiter.allows("peer1", "protocol1", 2);
+    expect(selfRateLimiter.allows("peer1", "protocol1", 3)).toBe(false);
 
     vi.advanceTimersByTime(CHECK_DISCONNECTED_PEERS_INTERVAL_MS + 1);
-    expect(selfRateLimiter.allows("peer1", "protocol1")).toBe(true);
+    expect(selfRateLimiter.allows("peer1", "protocol1", 4)).toBe(true);
   });
 });


### PR DESCRIPTION
**Motivation**

- node slow to sync due to dead requests tracked in self rate limiter

**Description**

- track request ids in self rate limiter
- if it's > 30s, it's considered dead and we remove

Closes #8263

part of #8256

**Test**

- was able to sync fusaka-devnet-3 with no selft rate limited errors
<img width="1677" height="645" alt="Screenshot 2025-08-29 at 20 38 45" src="https://github.com/user-attachments/assets/2388639e-7232-4941-a1bf-4b9ecac55a58" />

