### PR TITLE
fix: use prettyPrintIndices for mySampleSubnets logging (#8292)

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -308,7 +308,7 @@ export function getBeaconBlockApi({
       }
     }
 
-    if (chain.emitter.listenerCount(routes.events.EventType.blockGossip)) {
+    if (chain.emitter.listenerCount(routes.events.EventType.blockGossip) > 0) {
       chain.emitter.emit(routes.events.EventType.blockGossip, {slot, block: blockRoot});
     }
 
@@ -317,7 +317,7 @@ export function getBeaconBlockApi({
         const {dataColumns} = blockForImport.blockData as BlockInputDataColumns;
         metrics?.dataColumns.bySource.inc({source: DataColumnsSource.api}, dataColumns.length);
 
-        if (chain.emitter.listenerCount(routes.events.EventType.dataColumnSidecar)) {
+        if (chain.emitter.listenerCount(routes.events.EventType.dataColumnSidecar) > 0) {
           for (const dataColumnSidecar of dataColumns) {
             chain.emitter.emit(routes.events.EventType.dataColumnSidecar, {
               blockRoot,
@@ -329,7 +329,7 @@ export function getBeaconBlockApi({
         }
       } else if (
         isForkPostDeneb(blockForImport.blockData.fork) &&
-        chain.emitter.listenerCount(routes.events.EventType.blobSidecar)
+        chain.emitter.listenerCount(routes.events.EventType.blobSidecar) > 0
       ) {
         const {blobs} = blockForImport.blockData as BlockInputBlobs;
 

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -464,34 +464,34 @@ export async function importBlock(
     // We want to import block asap so call all event handler in the next event loop
     callInNextEventLoop(() => {
       // NOTE: Skip emitting if there are no listeners from the API
-      if (this.emitter.listenerCount(routes.events.EventType.block)) {
+      if (this.emitter.listenerCount(routes.events.EventType.block) > 0) {
         this.emitter.emit(routes.events.EventType.block, {
           block: blockRootHex,
           slot: blockSlot,
           executionOptimistic: blockSummary != null && isOptimisticBlock(blockSummary),
         });
       }
-      if (this.emitter.listenerCount(routes.events.EventType.voluntaryExit)) {
+      if (this.emitter.listenerCount(routes.events.EventType.voluntaryExit) > 0) {
         for (const voluntaryExit of block.message.body.voluntaryExits) {
           this.emitter.emit(routes.events.EventType.voluntaryExit, voluntaryExit);
         }
       }
-      if (this.emitter.listenerCount(routes.events.EventType.blsToExecutionChange)) {
+      if (this.emitter.listenerCount(routes.events.EventType.blsToExecutionChange) > 0) {
         for (const blsToExecutionChange of (block.message as capella.BeaconBlock).body.blsToExecutionChanges ?? []) {
           this.emitter.emit(routes.events.EventType.blsToExecutionChange, blsToExecutionChange);
         }
       }
-      if (this.emitter.listenerCount(routes.events.EventType.attestation)) {
+      if (this.emitter.listenerCount(routes.events.EventType.attestation) > 0) {
         for (const attestation of block.message.body.attestations) {
           this.emitter.emit(routes.events.EventType.attestation, attestation);
         }
       }
-      if (this.emitter.listenerCount(routes.events.EventType.attesterSlashing)) {
+      if (this.emitter.listenerCount(routes.events.EventType.attesterSlashing) > 0) {
         for (const attesterSlashing of block.message.body.attesterSlashings) {
           this.emitter.emit(routes.events.EventType.attesterSlashing, attesterSlashing);
         }
       }
-      if (this.emitter.listenerCount(routes.events.EventType.proposerSlashing)) {
+      if (this.emitter.listenerCount(routes.events.EventType.proposerSlashing) > 0) {
         for (const proposerSlashing of block.message.body.proposerSlashings) {
           this.emitter.emit(routes.events.EventType.proposerSlashing, proposerSlashing);
         }

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -457,7 +457,7 @@ export class PeerManager {
         dataColumns: prettyPrintIndices(dataColumns),
         matchingSubnetsNum,
         custodyGroups: prettyPrintIndices(custodyGroups),
-        mySampleSubnets: sampleSubnets.join(" "),
+        mySampleSubnets: prettyPrintIndices(sampleSubnets),
         clientAgent,
       });
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -176,7 +176,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
 
       logger.debug("Validated gossip block", {...logCtx, recvToValidation, validationTime});
 
-      if (chain.emitter.listenerCount(routes.events.EventType.blockGossip)) {
+      if (chain.emitter.listenerCount(routes.events.EventType.blockGossip) > 0) {
         chain.emitter.emit(routes.events.EventType.blockGossip, {slot, block: blockRootHex});
       }
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -229,7 +229,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       metrics?.gossipBlob.recvToValidation.observe(recvToValidation);
       metrics?.gossipBlob.validationTime.observe(validationTime);
 
-      if (chain.emitter.listenerCount(routes.events.EventType.blobSidecar)) {
+      if (chain.emitter.listenerCount(routes.events.EventType.blobSidecar) > 0) {
         chain.emitter.emit(routes.events.EventType.blobSidecar, {
           blockRoot: blockRootHex,
           slot,

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -368,7 +368,7 @@ export async function unavailableBeaconBlobsByRootPreFulu(
         // verifyBlocksDataAvailability
         cachedData.blobsCache.set(blobSidecar.index, blobSidecar);
 
-        if (emitter.listenerCount(routes.events.EventType.blobSidecar)) {
+        if (emitter.(routes.events.EventType.blobSidecar)>0) {
           emitter.emit(routes.events.EventType.blobSidecar, {
             blockRoot: blockRootHex,
             slot,
@@ -441,7 +441,7 @@ export async function unavailableBeaconBlobsByRootPreFulu(
   for (const blobSidecar of networkResBlobSidecars) {
     cachedData.blobsCache.set(blobSidecar.index, blobSidecar);
 
-    if (emitter.listenerCount(routes.events.EventType.blobSidecar)) {
+    if (emitter.(routes.events.EventType.blobSidecar)>0) {
       emitter.emit(routes.events.EventType.blobSidecar, {
         blockRoot: blockRootHex,
         slot,

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRoot.ts
@@ -368,7 +368,7 @@ export async function unavailableBeaconBlobsByRootPreFulu(
         // verifyBlocksDataAvailability
         cachedData.blobsCache.set(blobSidecar.index, blobSidecar);
 
-        if (emitter.(routes.events.EventType.blobSidecar)>0) {
+        if (emitter.listenerCount(routes.events.EventType.blobSidecar) > 0) {
           emitter.emit(routes.events.EventType.blobSidecar, {
             blockRoot: blockRootHex,
             slot,
@@ -441,7 +441,7 @@ export async function unavailableBeaconBlobsByRootPreFulu(
   for (const blobSidecar of networkResBlobSidecars) {
     cachedData.blobsCache.set(blobSidecar.index, blobSidecar);
 
-    if (emitter.(routes.events.EventType.blobSidecar)>0) {
+    if (emitter.listenerCount(routes.events.EventType.blobSidecar) > 0) {
       emitter.emit(routes.events.EventType.blobSidecar, {
         blockRoot: blockRootHex,
         slot,


### PR DESCRIPTION
**Motivation**

This PR ensures we use `prettyPrintIndices` consistently across logging.  
Previously, `mySampleSubnets` was logged as a long space-separated string, making it harder to read.  
Now, it uses the same pretty-printing as `dataColumns` and `custodyGroups`.

**Description**

- Updated logger call in `onStatus` to wrap `mySampleSubnets` with `prettyPrintIndices`.
- Improves log readability and makes output consistent across all subnet index fields.
- No functional logic is changed — only affects debug log formatting.

Closes #8292

**Steps to test or reproduce**

```sh
# Checkout this branch
git checkout  maishivamhoo123/prettyPrintIndices

# Build and run Lodestar
npm run build
./packages/cli/bin/lodestar dev


