### PR TITLE
fix: use prettyPrintIndices for logging

### DIFF
--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -1,6 +1,6 @@
 import {ForkName, isForkPostDeneb, isForkPostFulu} from "@lodestar/params";
 import {fulu} from "@lodestar/types";
-import {toHex, toRootHex} from "@lodestar/utils";
+import {prettyPrintIndices, toHex, toRootHex} from "@lodestar/utils";
 import {BeaconChain} from "../chain.js";
 import {BlockInput, BlockInputBlobs, BlockInputDataColumns, BlockInputType} from "./types.js";
 
@@ -82,7 +82,7 @@ export async function writeBlockInputToDb(this: BeaconChain, blocksInput: BlockI
   await Promise.all(fnPromises);
   this.logger.debug("Persisted blocksInput to db", {
     blocksInput: blocksInput.length,
-    slots: blocksInput.map((blockInput) => blockInput.block.message.slot).join(" "),
+    slots: prettyPrintIndices(blocksInput.map((blockInput) => blockInput.block.message.slot)),
   });
 }
 

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -457,7 +457,7 @@ export class PeerManager {
         dataColumns: prettyPrintIndices(dataColumns),
         matchingSubnetsNum,
         custodyGroups: prettyPrintIndices(custodyGroups),
-        mySampleSubnets: sampleSubnets.join(" "),
+        mySampleSubnets: prettyPrintIndices(sampleSubnets),
         clientAgent,
       });
 

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -377,7 +377,7 @@ export function matchBlockWithDataColumns(
       neededColumns: prettyPrintIndices(neededColumns),
       requestedColumns: prettyPrintIndices(requestedColumns),
       slot: block.data.message.slot,
-      dataColumnsSlots: dataColumnSidecars.map((dcm) => dcm.signedBlockHeader.message.slot).join(" "),
+      dataColumnsSlots: prettyPrintIndices(dataColumnSidecars.map((dcm) => dcm.signedBlockHeader.message.slot)),
       peerClient,
     });
     if (blobKzgCommitmentsLen === 0) {
@@ -501,7 +501,8 @@ export function matchBlockWithDataColumns(
   }
   logger?.debug("matched BlockWithDataColumns", {
     peerClient,
-    blockInputs: blockInputs.map((bInpt) => `${bInpt.block.message.slot}=${bInpt.type}`).join(" "),
+    slots: prettyPrintIndices(blockInputs.map((b) => Number(b.block.message.slot))),
+    types: blockInputs.map((b) => b.type).join(" "),
   });
   return blockInputs;
 }

--- a/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/beaconBlocksMaybeBlobsByRange.ts
@@ -12,7 +12,7 @@ import {
   phase0,
   ssz,
 } from "@lodestar/types";
-import {Logger} from "@lodestar/utils";
+import {Logger, prettyPrintIndices} from "@lodestar/utils";
 import {
   BlobsSource,
   BlockInput,
@@ -161,7 +161,7 @@ export async function beaconBlocksMaybeBlobsByRange(
       [`allDataColumnSidecars(${allDataColumnSidecars.length})`]: allDataColumnSidecars
         .map((dCol) => `${dCol.signedBlockHeader.message.slot}:${dCol.index}`)
         .join(" "),
-      peerColumns: peerColumns.join(" "),
+      peerColumns: prettyPrintIndices(peerColumns),
       peerId,
       peerClient,
       prevPartialDownload: !!partialDownload,
@@ -374,8 +374,8 @@ export function matchBlockWithDataColumns(
       blobKzgCommitmentsLen,
       dataColumnSidecars: dataColumnSidecars.length,
       shouldHaveAllData,
-      neededColumns: neededColumns.join(" "),
-      requestedColumns: requestedColumns.join(" "),
+      neededColumns: prettyPrintIndices(neededColumns),
+      requestedColumns: prettyPrintIndices(requestedColumns),
       slot: block.data.message.slot,
       dataColumnsSlots: dataColumnSidecars.map((dcm) => dcm.signedBlockHeader.message.slot).join(" "),
       peerClient,
@@ -407,7 +407,7 @@ export function matchBlockWithDataColumns(
       );
 
       logger?.debug("matchBlockWithDataColumns2", {
-        dataColumnIndexes: dataColumnIndexes.join(" "),
+        dataColumnIndexes: prettyPrintIndices(dataColumnIndexes),
         requestedColumnsPresent,
         slot: block.data.message.slot,
         peerClient,


### PR DESCRIPTION
**Motivation**
We want to use `prettyPrintIndices` consistently for logging subnet indices.

**Description**
Replaced `sampleSubnets.join(" ")` with `prettyPrintIndices(sampleSubnets)` 
to improve readability and consistency with other log fields.

Closes #8292

**Steps to test or reproduce**
```sh
git checkout maishivamhoo123/prettyPrintIndices-fresh
npm run test
