### PR TITLE
fix: add disconnectThreshold for e2e tests

### DIFF
--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -77,6 +77,9 @@ export async function getDevBeaconNode(
         network: {
           discv5: null,
           localMultiaddrs: options.network?.localMultiaddrs || ["/ip4/127.0.0.1/tcp/0"],
+          // Increase of following value is just to circumvent the following error in e2e tests
+          // > libp2p:mplex rate limit hit when receiving messages
+          disconnectThreshold: 255,
           targetPeers: defaultNetworkOptions.targetPeers,
           maxPeers: defaultNetworkOptions.maxPeers,
         },


### PR DESCRIPTION
**Motivation**

- make e2e tests stable
- peers get disconnected in e2e tests

**Description**

- I was not able to run `finalizeSync.test.ts` e2e tests in `mkeil/refactor-block-input-on-unstable` until I found this option added since #7762
- sometimes I found same issue with `unknownBlockSync.test.ts` e2e test, suppose it will help that test too since it uses same utils
