### PR TITLE
feat: track libp2p streams

### DIFF
--- a/packages/reqresp/src/metrics.ts
+++ b/packages/reqresp/src/metrics.ts
@@ -15,12 +15,12 @@ export function getMetrics(register: MetricsRegisterExtra) {
       help: "Counts total requests done per method",
       labelNames: ["method"],
     }),
-    outgoingOpennedStreams: register.gauge<{method: string}>({
+    outgoingOpenedStreams: register.counter<{method: string}>({
       name: "beacon_reqresp_outgoing_opened_streams_total",
       help: "Counts total opened streams per method",
       labelNames: ["method"],
     }),
-    outgoingClosedStreams: register.gauge<{method: string}>({
+    outgoingClosedStreams: register.counter<{method: string}>({
       name: "beacon_reqresp_outgoing_closed_streams_total",
       help: "Counts total closed streams per method",
       labelNames: ["method"],
@@ -47,12 +47,12 @@ export function getMetrics(register: MetricsRegisterExtra) {
       help: "Counts total responses handled per method",
       labelNames: ["method"],
     }),
-    incomingOpennedStreams: register.gauge<{method: string}>({
+    incomingOpenedStreams: register.counter<{method: string}>({
       name: "beacon_reqresp_incoming_opened_streams_total",
       help: "Counts total incoming opened streams per method",
       labelNames: ["method"],
     }),
-    incomingClosedStreams: register.gauge<{method: string}>({
+    incomingClosedStreams: register.counter<{method: string}>({
       name: "beacon_reqresp_incoming_closed_streams_total",
       help: "Counts total incoming closed streams per method",
       labelNames: ["method"],

--- a/packages/reqresp/src/metrics.ts
+++ b/packages/reqresp/src/metrics.ts
@@ -15,6 +15,16 @@ export function getMetrics(register: MetricsRegisterExtra) {
       help: "Counts total requests done per method",
       labelNames: ["method"],
     }),
+    outgoingOpennedStreams: register.gauge<{method: string}>({
+      name: "beacon_reqresp_outgoing_opened_streams_total",
+      help: "Counts total opened streams per method",
+      labelNames: ["method"],
+    }),
+    outgoingClosedStreams: register.gauge<{method: string}>({
+      name: "beacon_reqresp_outgoing_closed_streams_total",
+      help: "Counts total closed streams per method",
+      labelNames: ["method"],
+    }),
     outgoingRequestRoundtripTime: register.histogram<{method: string}>({
       name: "beacon_reqresp_outgoing_request_roundtrip_time_seconds",
       help: "Histogram of outgoing requests round-trip time",
@@ -35,6 +45,16 @@ export function getMetrics(register: MetricsRegisterExtra) {
     incomingRequests: register.gauge<{method: string}>({
       name: "beacon_reqresp_incoming_requests_total",
       help: "Counts total responses handled per method",
+      labelNames: ["method"],
+    }),
+    incomingOpennedStreams: register.gauge<{method: string}>({
+      name: "beacon_reqresp_incoming_opened_streams_total",
+      help: "Counts total incoming opened streams per method",
+      labelNames: ["method"],
+    }),
+    incomingClosedStreams: register.gauge<{method: string}>({
+      name: "beacon_reqresp_incoming_closed_streams_total",
+      help: "Counts total incoming closed streams per method",
       labelNames: ["method"],
     }),
     incomingRequestHandlerTime: register.histogram<{method: string}>({

--- a/packages/reqresp/src/request/index.ts
+++ b/packages/reqresp/src/request/index.ts
@@ -110,7 +110,7 @@ export async function* sendRequest(
       throw new RequestError({code: RequestErrorCode.DIAL_ERROR, error: e});
     });
 
-    metrics?.outgoingOpennedStreams?.inc({method});
+    metrics?.outgoingOpenedStreams?.inc({method});
 
     // TODO: Does the TTFB timer start on opening stream or after receiving request
     const timerTTFB = metrics?.outgoingResponseTTFB.startTimer({method});

--- a/packages/reqresp/src/request/index.ts
+++ b/packages/reqresp/src/request/index.ts
@@ -110,6 +110,8 @@ export async function* sendRequest(
       throw new RequestError({code: RequestErrorCode.DIAL_ERROR, error: e});
     });
 
+    metrics?.outgoingOpennedStreams?.inc({method});
+
     // TODO: Does the TTFB timer start on opening stream or after receiving request
     const timerTTFB = metrics?.outgoingResponseTTFB.startTimer({method});
 
@@ -209,6 +211,8 @@ export async function* sendRequest(
       // `stream.close()` libp2p-mplex will .end() the source (it-pushable instance)
       // If collectResponses() exhausts the source, it-pushable.end() can be safely called multiple times
       await stream.close();
+      metrics?.outgoingClosedStreams?.inc({method});
+      logger.verbose("Req  stream closed", logCtx);
     }
   } catch (e) {
     logger.verbose("Req  error", logCtx, e as Error);

--- a/packages/reqresp/src/response/index.ts
+++ b/packages/reqresp/src/response/index.ts
@@ -65,6 +65,7 @@ export async function handleRequest({
     peer: prettyPrintPeerId(peerId),
     requestId,
   };
+  metrics?.incomingOpennedStreams.inc({method: protocol.method});
 
   let responseError: Error | null = null;
   await pipe(
@@ -129,6 +130,7 @@ export async function handleRequest({
   // If `requestDecode()` throws the stream.source must be closed manually
   // To ensure the stream.source it-pushable instance is always closed, stream.close() is called always
   await stream.close();
+  metrics?.incomingClosedStreams.inc({method: protocol.method});
 
   // TODO: It may happen that stream.sink returns before returning stream.source first,
   // so you never see "Resp received request" in the logs and the response ends without

--- a/packages/reqresp/src/response/index.ts
+++ b/packages/reqresp/src/response/index.ts
@@ -65,7 +65,7 @@ export async function handleRequest({
     peer: prettyPrintPeerId(peerId),
     requestId,
   };
-  metrics?.incomingOpennedStreams.inc({method: protocol.method});
+  metrics?.incomingOpenedStreams.inc({method: protocol.method});
 
   let responseError: Error | null = null;
   await pipe(


### PR DESCRIPTION
**Motivation**

- as shown in #8301, there could be leaked streams which cause the connection to be closed
- it's good to know number of streams opened vs closed so that we know if we have leaked streams on a running nodes

**Description**

- track incoming/outgoing streams opened/closed by methods

**Test**
it already showed that when we handle streams, number of streams closed successfully is less than number of streams opened
<img width="1529" height="658" alt="Screenshot 2025-09-02 at 15 57 25" src="https://github.com/user-attachments/assets/7472b95e-34af-4707-8af5-d1591e085dba" />

