### PR TITLE
chore: update `payload_attributes` event test data

### DIFF
--- a/packages/api/test/unit/beacon/oapiSpec.test.ts
+++ b/packages/api/test/unit/beacon/oapiSpec.test.ts
@@ -68,10 +68,7 @@ const ignoredProperties: Record<string, IgnoredProperty> = {
 const openApiJson = await fetchOpenApiSpec(openApiFile);
 runTestCheckAgainstSpec(openApiJson, definitions, testDatas, ignoredOperations, ignoredProperties);
 
-const ignoredTopics: string[] = [
-  // TODO: fix in follow-up PR
-  "payload_attributes",
-];
+const ignoredTopics: string[] = [];
 
 // eventstream types are defined as comments in the description of "examples".
 // The function runTestCheckAgainstSpec() can't handle those, so the custom code before:

--- a/packages/api/test/unit/beacon/testData/events.ts
+++ b/packages/api/test/unit/beacon/testData/events.ts
@@ -235,8 +235,8 @@ export const eventTestData: EventData = {
     }),
   },
   [EventType.payloadAttributes]: {
-    version: ForkName.capella,
-    data: ssz.capella.SSEPayloadAttributes.fromJson({
+    version: ForkName.electra,
+    data: ssz.electra.SSEPayloadAttributes.fromJson({
       proposer_index: "123",
       proposal_slot: "10",
       parent_block_number: "9",
@@ -254,6 +254,7 @@ export const eventTestData: EventData = {
             amount: "15640",
           },
         ],
+        parent_beacon_block_root: "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
       },
     }),
   },

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -7,6 +7,7 @@ import {
   ForkSeq,
   isForkPostAltair,
   isForkPostBellatrix,
+  isForkPostCapella,
 } from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -7,7 +7,6 @@ import {
   ForkSeq,
   isForkPostAltair,
   isForkPostBellatrix,
-  isForkPostCapella,
 } from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,


### PR DESCRIPTION
**Motivation**

This is required to pass spec tests since spec example was updated in https://github.com/ethereum/beacon-APIs/pull/550

**Description**

Update `payload_attributes` event test data

**Note:** we already emit all required fields, no changes needed there
