### PR TITLE
chore: add fork-choice and engine focil metrics

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -15,6 +15,7 @@ import {
   INTERVALS_PER_SLOT,
   MAX_SEED_LOOKAHEAD,
   SLOTS_PER_EPOCH,
+  isForkPostEip7805,
 } from "@lodestar/params";
 import {
   CachedBeaconStateAltair,
@@ -86,6 +87,7 @@ export async function importBlock(
   const blockDelaySec = (fullyVerifiedBlock.seenTimestampSec - postState.genesisTime) % this.config.SECONDS_PER_SLOT;
   const recvToValLatency = Date.now() / 1000 - (opts.seenTimestampSec ?? Date.now() / 1000);
   const fork = this.config.getForkSeq(blockSlot);
+  const forkName = this.config.getForkName(blockSlot);
 
   // this is just a type assertion since blockinput with dataPromise type will not end up here
   if (blockInput.type === BlockInputType.dataPromise) {
@@ -397,6 +399,7 @@ export async function importBlock(
     const safeBlockHash = this.forkChoice.getJustifiedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
     const finalizedBlockHash = this.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
     if (headBlockHash !== ZERO_HASH_HEX) {
+      const requestStartTime = Date.now() / 1000;
       this.executionEngine
         .notifyForkchoiceUpdate(
           this.config.getForkName(this.forkChoice.getHead().slot),
@@ -409,6 +412,11 @@ export async function importBlock(
             this.logger.error("Error pushing notifyForkchoiceUpdate()", {headBlockHash, finalizedBlockHash}, e);
           }
         });
+      if (isForkPostEip7805(forkName)) {
+        const requestDurationTime = Date.now() / 1000 - requestStartTime;
+        this.metrics?.eip7805.forkchoiceUpdatedV4RequestsDuration.observe(requestDurationTime);
+        this.metrics?.eip7805.forkchoiceUpdatedV4Requests.inc();
+      }
     }
   }
 

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -15,7 +15,6 @@ import {
   INTERVALS_PER_SLOT,
   MAX_SEED_LOOKAHEAD,
   SLOTS_PER_EPOCH,
-  isForkPostEip7805,
 } from "@lodestar/params";
 import {
   CachedBeaconStateAltair,
@@ -87,7 +86,6 @@ export async function importBlock(
   const blockDelaySec = (fullyVerifiedBlock.seenTimestampSec - postState.genesisTime) % this.config.SECONDS_PER_SLOT;
   const recvToValLatency = Date.now() / 1000 - (opts.seenTimestampSec ?? Date.now() / 1000);
   const fork = this.config.getForkSeq(blockSlot);
-  const forkName = this.config.getForkName(blockSlot);
 
   // this is just a type assertion since blockinput with dataPromise type will not end up here
   if (blockInput.type === BlockInputType.dataPromise) {
@@ -399,7 +397,6 @@ export async function importBlock(
     const safeBlockHash = this.forkChoice.getJustifiedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
     const finalizedBlockHash = this.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
     if (headBlockHash !== ZERO_HASH_HEX) {
-      const requestStartTime = Date.now() / 1000;
       this.executionEngine
         .notifyForkchoiceUpdate(
           this.config.getForkName(this.forkChoice.getHead().slot),
@@ -412,11 +409,6 @@ export async function importBlock(
             this.logger.error("Error pushing notifyForkchoiceUpdate()", {headBlockHash, finalizedBlockHash}, e);
           }
         });
-      if (isForkPostEip7805(forkName)) {
-        const requestDurationTime = Date.now() / 1000 - requestStartTime;
-        this.metrics?.eip7805.forkchoiceUpdatedV4RequestsDuration.observe(requestDurationTime);
-        this.metrics?.eip7805.forkchoiceUpdatedV4Requests.inc();
-      }
     }
   }
 

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -317,6 +317,9 @@ export async function verifyBlockExecutionPayload(
     executionRequests,
     ilTransactions
   );
+  if (ilTransactions) {
+    chain.metrics?.eip7805.inclusionListTransactionsSentToPayload.inc(ilTransactions.length);
+  }
   chain.logger.debug("Receive engine api newPayload result", {...logCtx, status: execResult.status});
 
   chain.metrics?.engineNotifyNewPayloadResult.inc({result: execResult.status});
@@ -386,6 +389,7 @@ export async function verifyBlockExecutionPayload(
         chain.config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message)
       );
       chain.forkChoice.addInclusionListUnsatisfiedBlock(blockRoot);
+      chain.metrics?.forkChoice.unsatisfiedInclusionListBlocks.inc();
 
       const execError = new BlockError(block, {
         code: BlockErrorCode.EXECUTION_ENGINE_ERROR,

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -568,7 +568,6 @@ export async function prepareExecutionPayload(
       feeRecipient: suggestedFeeRecipient,
     });
 
-    const requestStartTime = Date.now() / 1000;
     payloadId = await chain.executionEngine.notifyForkchoiceUpdate(
       fork,
       toRootHex(parentHash),
@@ -576,11 +575,6 @@ export async function prepareExecutionPayload(
       finalizedBlockHash,
       attributes
     );
-    if (ForkSeq[fork] >= ForkSeq.eip7805) {
-      const requestDurationTime = Date.now() / 1000 - requestStartTime;
-      chain.metrics?.eip7805.forkchoiceUpdatedV4RequestsDuration.observe(requestDurationTime);
-      chain.metrics?.eip7805.forkchoiceUpdatedV4Requests.inc();
-    }
     logger.verbose("Prepared payload id from execution engine", {payloadId});
   }
 

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -55,6 +55,7 @@ import {
   PayloadId,
   getExpectedGasLimit,
 } from "../../execution/index.js";
+import {Metrics} from "../../metrics/metrics.js";
 import {fromGraffitiBytes} from "../../util/graffiti.js";
 import {kzg} from "../../util/kzg.js";
 import type {BeaconChain} from "../chain.js";
@@ -514,6 +515,7 @@ export async function prepareExecutionPayload(
     eth1: IEth1ForBlockProduction;
     executionEngine: IExecutionEngine;
     config: ChainForkConfig;
+    metrics: Metrics | null;
   },
   logger: Logger,
   fork: ForkPostBellatrix,
@@ -566,6 +568,7 @@ export async function prepareExecutionPayload(
       feeRecipient: suggestedFeeRecipient,
     });
 
+    const requestStartTime = Date.now() / 1000;
     payloadId = await chain.executionEngine.notifyForkchoiceUpdate(
       fork,
       toRootHex(parentHash),
@@ -573,6 +576,11 @@ export async function prepareExecutionPayload(
       finalizedBlockHash,
       attributes
     );
+    if (ForkSeq[fork] >= ForkSeq.eip7805) {
+      const requestDurationTime = Date.now() / 1000 - requestStartTime;
+      chain.metrics?.eip7805.forkchoiceUpdatedV4RequestsDuration.observe(requestDurationTime);
+      chain.metrics?.eip7805.forkchoiceUpdatedV4Requests.inc();
+    }
     logger.verbose("Prepared payload id from execution engine", {payloadId});
   }
 

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -124,7 +124,6 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
         help: "Duration of engine_getInclusionListV1 requests",
         buckets: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.5],
       }),
-      // TODO: Katya - add forkchoiceUpdatedV4 metrics after the latest FOCIL spec updates
       forkchoiceUpdatedV4Requests: register.counter({
         name: "beacon_engine_forkchoiceUpdatedV4_requests_total",
         help: "Total number of engine_forkchoiceUpdatedV4 requests sent to the execution client",
@@ -134,7 +133,6 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
         help: "Duration of engine_forkchoiceUpdatedV4 requests",
         buckets: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.5],
       }),
-      // TODO: Katya - add metric after focil refactoring
       inclusionListTransactionsSentToPayload: register.counter({
         name: "beacon_inclusion_list_transactions_sent_to_payload_total",
         help: "Total number of inclusion list transactions sent to payload",

--- a/packages/beacon-node/src/metrics/metrics/beacon.ts
+++ b/packages/beacon-node/src/metrics/metrics/beacon.ts
@@ -124,15 +124,6 @@ export function createBeaconMetrics(register: RegistryMetricCreator) {
         help: "Duration of engine_getInclusionListV1 requests",
         buckets: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.5],
       }),
-      forkchoiceUpdatedV4Requests: register.counter({
-        name: "beacon_engine_forkchoiceUpdatedV4_requests_total",
-        help: "Total number of engine_forkchoiceUpdatedV4 requests sent to the execution client",
-      }),
-      forkchoiceUpdatedV4RequestsDuration: register.histogram({
-        name: "beacon_engine_forkchoiceUpdatedV4_requests_duration_seconds",
-        help: "Duration of engine_forkchoiceUpdatedV4 requests",
-        buckets: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.5],
-      }),
       inclusionListTransactionsSentToPayload: register.counter({
         name: "beacon_inclusion_list_transactions_sent_to_payload_total",
         help: "Total number of inclusion list transactions sent to payload",

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -884,6 +884,7 @@ export class ForkChoice implements IForkChoice {
         const equivocators = this.fcStore.inclusionListEquivocators.get(storeKey) ?? new Set<ValidatorIndex>();
         equivocators.add(validatorIndex);
         this.fcStore.inclusionListEquivocators.set(storeKey, equivocators);
+        this.metrics?.forkChoice.inclusionListsEquivocating.inc();
       }
     } else if (isBeforeFreezeDeadline) {
       const inclusionLists = this.fcStore.inclusionLists.get(storeKey) ?? [];

--- a/packages/fork-choice/src/metrics.ts
+++ b/packages/fork-choice/src/metrics.ts
@@ -66,12 +66,10 @@ export function getForkChoiceMetrics(register: MetricsRegisterExtra) {
         help: "Reason why the current head is not re-orged out",
         labelNames: ["reason"],
       }),
-      // TODO: Katya - add metric after refactoring fork-choice metrics
       inclusionListsEquivocating: register.counter({
         name: "beacon_inclusion_lists_equivocating_total",
         help: "Total number of equivocating inclusion lists",
       }),
-      // TODO: Katya - add metric after implementing FOCIL specs updates
       unsatisfiedInclusionListBlocks: register.counter({
         name: "beacon_inclusion_list_unsatisfied_blocks_total",
         help: "Total number of unsatisfied inclusion list blocks",


### PR DESCRIPTION
**Motivation**

The focil TODO metrics need to be updated after the latest focil updates have been merged.

**Description**
The list of updated metrics:
- beacon_engine_forkchoiceUpdatedV4_requests_total
- beacon_engine_forkchoiceUpdatedV4_requests_duration_seconds
- beacon_inclusion_list_transactions_sent_to_payload_total
- beacon_inclusion_lists_equivocating_total
- beacon_inclusion_list_unsatisfied_blocks_total

**Steps to test or reproduce**

The metrics can be reproduced using the [Kurtosis focil dashboard](https://github.com/ethpandaops/ethereum-package/pull/986/).
