### PR TITLE
refactor: rename related to sync committee indices

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1210,12 +1210,12 @@ export function getValidatorApi(
       const pubkeys = getPubkeysForIndices(state.validators, indices);
       // Ensures `epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD <= current_epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD + 1`
       const syncCommitteeCache = state.epochCtx.getIndexedSyncCommitteeAtEpoch(epoch);
-      const syncCommitteeValidatorIndexMap = syncCommitteeCache.validatorIndexMap;
+      const validatorSyncCommitteeIndexMap = syncCommitteeCache.validatorIndexMap;
 
       const duties: routes.validator.SyncDuty[] = [];
       for (let i = 0, len = indices.length; i < len; i++) {
         const validatorIndex = indices[i];
-        const validatorSyncCommitteeIndices = syncCommitteeValidatorIndexMap.get(validatorIndex);
+        const validatorSyncCommitteeIndices = validatorSyncCommitteeIndexMap.get(validatorIndex);
         if (validatorSyncCommitteeIndices) {
           duties.push({
             pubkey: pubkeys[i],

--- a/packages/beacon-node/src/chain/rewards/syncCommitteeRewards.ts
+++ b/packages/beacon-node/src/chain/rewards/syncCommitteeRewards.ts
@@ -20,8 +20,8 @@ export async function computeSyncCommitteeRewards(
   const preStateAltair = preState as CachedBeaconStateAltair;
   const {index2pubkey} = preStateAltair.epochCtx;
 
-  // Bound committeeIndices in case it goes beyond SYNC_COMMITTEE_SIZE just to be safe
-  const committeeIndices = preStateAltair.epochCtx.currentSyncCommitteeIndexed.validatorIndices.slice(
+  // Bound syncCommitteeValidatorIndices in case it goes beyond SYNC_COMMITTEE_SIZE just to be safe
+  const syncCommitteeValidatorIndices = preStateAltair.epochCtx.currentSyncCommitteeIndexed.validatorIndices.slice(
     0,
     SYNC_COMMITTEE_SIZE
   );
@@ -30,11 +30,11 @@ export async function computeSyncCommitteeRewards(
 
   // Use balance of each committee as starting point such that we cap the penalty to avoid balance dropping below 0
   const balances: Map<ValidatorIndex, BalanceRecord> = new Map();
-  for (const i of committeeIndices) {
+  for (const i of syncCommitteeValidatorIndices) {
     balances.set(i, {val: preStateAltair.balances.get(i)});
   }
 
-  for (const i of committeeIndices) {
+  for (const i of syncCommitteeValidatorIndices) {
     const balanceRecord = balances.get(i) as BalanceRecord;
     if (syncCommitteeBits.get(i)) {
       // Positive rewards for participants

--- a/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -114,6 +114,9 @@ function getContributionIndices(
 
   const syncCommittee = state.epochCtx.getIndexedSyncCommittee(contribution.slot);
   // The bits in contribution.aggregationBits select validatorIndexes in the subcommittee starting at startIndex
-  const subcommitteeIndices = syncCommittee.validatorIndices.slice(startIndex, startIndex + SYNC_COMMITTEE_SUBNET_SIZE);
-  return contribution.aggregationBits.intersectValues(subcommitteeIndices);
+  const subcommitteeValidatorIndices = syncCommittee.validatorIndices.slice(
+    startIndex,
+    startIndex + SYNC_COMMITTEE_SUBNET_SIZE
+  );
+  return contribution.aggregationBits.intersectValues(subcommitteeValidatorIndices);
 }

--- a/packages/state-transition/src/cache/syncCommitteeCache.ts
+++ b/packages/state-transition/src/cache/syncCommitteeCache.ts
@@ -33,7 +33,7 @@ export class SyncCommitteeCacheEmpty implements SyncCommitteeCache {
 export function getSyncCommitteeCache(validatorIndices: Uint32Array): SyncCommitteeCache {
   return {
     validatorIndices,
-    validatorIndexMap: computeValidatorSyncComitteeIndexMap(validatorIndices),
+    validatorIndexMap: computeValidatorSyncCommitteeIndexMap(validatorIndices),
   };
 }
 
@@ -42,7 +42,7 @@ export function computeSyncCommitteeCache(
   pubkey2index: PubkeyIndexMap
 ): SyncCommitteeCache {
   const validatorIndices = computeSyncCommitteeValidatorIndices(syncCommittee, pubkey2index);
-  const validatorIndexMap = computeValidatorSyncComitteeIndexMap(validatorIndices);
+  const validatorIndexMap = computeValidatorSyncCommitteeIndexMap(validatorIndices);
   return {
     validatorIndices,
     validatorIndexMap,
@@ -54,7 +54,7 @@ export function computeSyncCommitteeCache(
  * Helps reduce work necessary to verify a validatorIndex belongs in a sync committee and which.
  * This is similar to compute_subnets_for_sync_committee in https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.5/specs/altair/validator.md
  */
-export function computeValidatorSyncComitteeIndexMap(
+export function computeValidatorSyncCommitteeIndexMap(
   validatorIndices: ArrayLike<ValidatorIndex>
 ): ValidatorSyncCommitteeIndexMap {
   const map = new Map<ValidatorIndex, number[]>();

--- a/packages/state-transition/src/cache/syncCommitteeCache.ts
+++ b/packages/state-transition/src/cache/syncCommitteeCache.ts
@@ -3,7 +3,7 @@ import {CompositeViewDU} from "@chainsafe/ssz";
 import {ValidatorIndex, ssz} from "@lodestar/types";
 import {toPubkeyHex} from "@lodestar/utils";
 
-type SyncComitteeValidatorIndexMap = Map<ValidatorIndex, number[]>;
+type ValidatorSyncCommitteeIndexMap = Map<ValidatorIndex, number[]>;
 
 export type SyncCommitteeCache = {
   /**
@@ -14,8 +14,9 @@ export type SyncCommitteeCache = {
   /**
    * Update freq: every ~ 27h.
    * Memory cost: Map of Number -> Number with 512 entries.
+   * Note: it stores the position indices in sync committee for each sync committee validator
    */
-  validatorIndexMap: SyncComitteeValidatorIndexMap;
+  validatorIndexMap: ValidatorSyncCommitteeIndexMap;
 };
 
 /** Placeholder object for pre-altair fork */
@@ -24,7 +25,7 @@ export class SyncCommitteeCacheEmpty implements SyncCommitteeCache {
     throw Error("Empty SyncCommitteeCache");
   }
 
-  get validatorIndexMap(): SyncComitteeValidatorIndexMap {
+  get validatorIndexMap(): ValidatorSyncCommitteeIndexMap {
     throw Error("Empty SyncCommitteeCache");
   }
 }
@@ -32,7 +33,7 @@ export class SyncCommitteeCacheEmpty implements SyncCommitteeCache {
 export function getSyncCommitteeCache(validatorIndices: Uint32Array): SyncCommitteeCache {
   return {
     validatorIndices,
-    validatorIndexMap: computeSyncComitteeMap(validatorIndices),
+    validatorIndexMap: computeValidatorSyncComitteeIndexMap(validatorIndices),
   };
 }
 
@@ -40,8 +41,8 @@ export function computeSyncCommitteeCache(
   syncCommittee: CompositeViewDU<typeof ssz.altair.SyncCommittee>,
   pubkey2index: PubkeyIndexMap
 ): SyncCommitteeCache {
-  const validatorIndices = computeSyncCommitteeIndices(syncCommittee, pubkey2index);
-  const validatorIndexMap = computeSyncComitteeMap(validatorIndices);
+  const validatorIndices = computeSyncCommitteeValidatorIndices(syncCommittee, pubkey2index);
+  const validatorIndexMap = computeValidatorSyncComitteeIndexMap(validatorIndices);
   return {
     validatorIndices,
     validatorIndexMap,
@@ -49,15 +50,17 @@ export function computeSyncCommitteeCache(
 }
 
 /**
- * Compute all index in sync committee for all validatorIndexes in `syncCommitteeIndexes`.
+ * Compute all position index in sync committee for all validatorIndexes in `syncCommitteeIndexes`.
  * Helps reduce work necessary to verify a validatorIndex belongs in a sync committee and which.
  * This is similar to compute_subnets_for_sync_committee in https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.5/specs/altair/validator.md
  */
-export function computeSyncComitteeMap(syncCommitteeIndexes: ArrayLike<ValidatorIndex>): SyncComitteeValidatorIndexMap {
+export function computeValidatorSyncComitteeIndexMap(
+  validatorIndices: ArrayLike<ValidatorIndex>
+): ValidatorSyncCommitteeIndexMap {
   const map = new Map<ValidatorIndex, number[]>();
 
-  for (let i = 0, len = syncCommitteeIndexes.length; i < len; i++) {
-    const validatorIndex = syncCommitteeIndexes[i];
+  for (let i = 0, len = validatorIndices.length; i < len; i++) {
+    const validatorIndex = validatorIndices[i];
     let indexes = map.get(validatorIndex);
     if (!indexes) {
       indexes = [];
@@ -74,7 +77,7 @@ export function computeSyncComitteeMap(syncCommitteeIndexes: ArrayLike<Validator
 /**
  * Extract validator indices from current and next sync committee
  */
-function computeSyncCommitteeIndices(
+function computeSyncCommitteeValidatorIndices(
   syncCommittee: CompositeViewDU<typeof ssz.altair.SyncCommittee>,
   pubkey2index: PubkeyIndexMap
 ): Uint32Array {

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -180,7 +180,7 @@ export function naiveGetNextSyncCommitteeIndices(
   activeValidatorIndices: ArrayLike<ValidatorIndex>,
   effectiveBalanceIncrements: EffectiveBalanceIncrements
 ): ValidatorIndex[] {
-  const syncCommitteeIndices = [];
+  const syncCommitteeValidatorIndices = [];
 
   if (fork >= ForkSeq.electra) {
     const MAX_RANDOM_VALUE = 2 ** 16 - 1;
@@ -191,7 +191,7 @@ export function naiveGetNextSyncCommitteeIndices(
     const seed = getSeed(state, epoch, DOMAIN_SYNC_COMMITTEE);
 
     let i = 0;
-    while (syncCommitteeIndices.length < SYNC_COMMITTEE_SIZE) {
+    while (syncCommitteeValidatorIndices.length < SYNC_COMMITTEE_SIZE) {
       const shuffledIndex = computeShuffledIndex(i % activeValidatorCount, activeValidatorCount, seed);
       const candidateIndex = activeValidatorIndices[shuffledIndex];
       const randomBytes = digest(Buffer.concat([seed, intToBytes(Math.floor(i / 16), 8, "le")]));
@@ -200,7 +200,7 @@ export function naiveGetNextSyncCommitteeIndices(
 
       const effectiveBalanceIncrement = effectiveBalanceIncrements[candidateIndex];
       if (effectiveBalanceIncrement * MAX_RANDOM_VALUE >= MAX_EFFECTIVE_BALANCE_INCREMENT * randomValue) {
-        syncCommitteeIndices.push(candidateIndex);
+        syncCommitteeValidatorIndices.push(candidateIndex);
       }
 
       i += 1;
@@ -214,21 +214,21 @@ export function naiveGetNextSyncCommitteeIndices(
     const seed = getSeed(state, epoch, DOMAIN_SYNC_COMMITTEE);
 
     let i = 0;
-    while (syncCommitteeIndices.length < SYNC_COMMITTEE_SIZE) {
+    while (syncCommitteeValidatorIndices.length < SYNC_COMMITTEE_SIZE) {
       const shuffledIndex = computeShuffledIndex(i % activeValidatorCount, activeValidatorCount, seed);
       const candidateIndex = activeValidatorIndices[shuffledIndex];
       const randomByte = digest(Buffer.concat([seed, intToBytes(Math.floor(i / 32), 8, "le")]))[i % 32];
 
       const effectiveBalanceIncrement = effectiveBalanceIncrements[candidateIndex];
       if (effectiveBalanceIncrement * MAX_RANDOM_BYTE >= MAX_EFFECTIVE_BALANCE_INCREMENT * randomByte) {
-        syncCommitteeIndices.push(candidateIndex);
+        syncCommitteeValidatorIndices.push(candidateIndex);
       }
 
       i += 1;
     }
   }
 
-  return syncCommitteeIndices;
+  return syncCommitteeValidatorIndices;
 }
 
 /**


### PR DESCRIPTION
Follow up on #7687 , we will want to apply similar naming convention to sync committee when it comes to indices.

- `validatorSyncCommitteeIndices` should be the position indices in the sync committee
- `syncCommitteeValidatorIndices` should be the validator indices (eg. 1063664) of the sync committee members