### PR TITLE
fix: do not attempt to reconstruct builder blocks

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -360,7 +360,7 @@ export function getBeaconBlockApi({
 
     // Either the payload/blobs are cached from i) engine locally or ii) they are from the builder
     const producedResult = chain.blockProductionCache.get(blockRoot);
-    if (producedResult !== undefined) {
+    if (producedResult !== undefined && producedResult.type !== BlockType.Blinded) {
       const source = ProducedBlockSource.engine;
       chain.logger.debug("Reconstructing the full signed block contents", {slot, blockRoot, source});
 

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -43,7 +43,12 @@ import {
 import {verifyBlocksInEpoch} from "../../../../chain/blocks/verifyBlock.js";
 import {BeaconChain} from "../../../../chain/chain.js";
 import {BlockError, BlockErrorCode, BlockGossipError} from "../../../../chain/errors/index.js";
-import {ProduceFullBellatrix, ProduceFullDeneb, ProduceFullFulu} from "../../../../chain/produceBlock/index.js";
+import {
+  BlockType,
+  ProduceFullBellatrix,
+  ProduceFullDeneb,
+  ProduceFullFulu,
+} from "../../../../chain/produceBlock/index.js";
 import {validateGossipBlock} from "../../../../chain/validation/block.js";
 import {OpSource} from "../../../../chain/validatorMonitor.js";
 import {NetworkEvent} from "../../../../network/index.js";


### PR DESCRIPTION
**Motivation**

We fail to publish builder blocks as we attempt to reconstruct the full block

```
Sep-03 21:52:48.755[api]              info: Selected builder block reason=block_value, slot=304614, parentSlot=304613, parentBlockRoot=0x17a2824216119eef2d74aae47c7473c727e4ef67e02214b10b209c115c4ef10b, fork=fulu, builderSelection=default, isBuilderEnabled=true, isEngineEnabled=true, strictFeeRecipientCheck=false, builderBoostFactor=90, engineDurationMs=162, engineExecutionPayloadValue=0.00932 ETH, engineConsensusBlockValue=0.00071 ETH, engineBlockTotalValue=0.01003 ETH, builderDurationMs=746, builderExecutionPayloadValue=1.01245 ETH, builderConsensusBlockValue=0.00071 ETH, builderBlockTotalValue=1.01317 ETH
Sep-03 21:52:48.756[rest]            debug: Res req-2qfu produceBlockV3 - 200
Sep-03 21:52:48.764[rest]            debug: Req req-2qfw 172.18.0.4 publishBlindedBlockV2
Sep-03 21:52:48.765[rest]            debug: Exec req-2qfw 172.18.0.4 publishBlindedBlockV2
Sep-03 21:52:48.766[chain]           debug: Reconstructing the full signed block contents slot=304614, blockRoot=0xb2d3e029598895fd59a37eb89a120d9dd422c861077872117739c39cc2594442, source=engine
Sep-03 21:52:48.766[rest]            error: Req req-2qfw publishBlindedBlockV2 error - Missing executionPayload to reconstruct post-bellatrix full block
Error: Missing executionPayload to reconstruct post-bellatrix full block
    at signedBlindedBlockToFull (file:///usr/app/packages/state-transition/src/util/blindedBlock.ts:92:11)
    at reconstructSignedBlockContents (file:///usr/app/packages/state-transition/src/util/blindedBlock.ts:132:23)
    at publishBlindedBlock (file:///usr/app/packages/beacon-node/src/api/impl/beacon/blocks/index.ts:367:35)
```
```
Sep-03 21:52:48.768[]                error: Error proposing block slot=304614, validator=0xa12e…8dda - publishBlindedBlockV2 failed with status 500: Missing executionPayload to reconstruct post-bellatrix full block - Failed to publish block
Error: publishBlindedBlockV2 failed with status 500: Missing executionPayload to reconstruct post-bellatrix full block - Failed to publish block
    at ApiResponse.error (file:///usr/app/packages/api/src/utils/client/response.ts:165:12)
    at ApiResponse.assertOk (file:///usr/app/packages/api/src/utils/client/response.ts:156:18)
    at BlockProposingService.publishBlockWrapper (file:///usr/app/packages/validator/src/services/block.ts:176:9)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at BlockProposingService.createAndPublishBlock (file:///usr/app/packages/validator/src/services/block.ts:153:7)
    at async Promise.all (index 0)
```

**Description**

Do not attempt to reconstruct builder blocks by checking not only for `producedResult` but also the block type, in case of `BlockType.Blinded` we don't have the execution payload/blobs to reconstruct the full block which results in the error above.
