### PR TITLE
fix: correct validateBlockDataColumnSidecars result mapping

### DIFF
--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -583,7 +583,7 @@ export async function validateColumnsByRangeResponse(
         blockRoot,
         blockKzgCommitments.length,
         blockColumnSidecars
-      ).then(() => ({blockRoot, columnSidecars}))
+      ).then(() => ({blockRoot, columnSidecars: blockColumnSidecars}))
     );
   }
 


### PR DESCRIPTION
**Motivation**

- fix error:
```
Sep-05 02:41:30.219[sync]          verbose: Batch download error id=Finalized-0, startEpoch=9778, status=Downloading, peer=16...BQ8fLQ, code=BLOCK_INPUT_ERROR_MISMATCHED_ROOT_HEX, blockInputRoot=0xd82f91624089fd14bf59552d3c921706487efa390c6126c983755b4ba1b6c642, mismatchedRoot=0x10a38f5d4ac083fdbfff507a2e1dfc5777685cca22b2af983676408429449313, source=req_resp_by_range, peerId=16Uiu2HAmFsDPzqKFfMuiDTBiRBNALSao7RF2p56TaD4FneBQ8fLQ
Error: Column BeaconBlockHeader blockRootHex does not match BlockInput.blockRootHex
    at BlockInputColumns.addColumn (file:///usr/src/lodestar/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts:734:13)
    at cacheByRangeResponses (file:///usr/src/lodestar/packages/beacon-node/src/sync/utils/downloadByRange.ts:163:16)
    at SyncChain.RangeSync.downloadByRange (file:///usr/src/lodestar/packages/beacon-node/src/sync/range/range.ts:212:20)
    at wrapError (file:///usr/src/lodestar/packages/beacon-node/src/util/wrapError.ts:18:32)
    at SyncChain.sendBatch (file:///usr/src/lodestar/packages/beacon-node/src/sync/range/chain.ts:451:19)
```

**Description**

- correct the mapping of result (use wrong variable)

closes #8327