### PR TITLE
fix: request columns by peer custodied columns

### DIFF
--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -10,6 +10,7 @@ import {PeerIdStr} from "../../util/peerId.js";
 import {MAX_BATCH_DOWNLOAD_ATTEMPTS, MAX_BATCH_PROCESSING_ATTEMPTS} from "../constants.js";
 import {DownloadByRangeRequests} from "../utils/downloadByRange.js";
 import {getBatchSlotRange, hashBlocks} from "./utils/index.js";
+import {PeerSyncMeta} from "../../network/peers/peersData.js";
 
 /**
  * Current state of a batch
@@ -205,6 +206,35 @@ export class Batch {
     }
 
     return requests;
+  }
+
+  /**
+   * Post-fulu we should only get columns that peer has advertised
+   */
+  getRequestsForPeer(peer: PeerSyncMeta): DownloadByRangeRequests {
+    if (!isForkPostFulu(this.forkName)) {
+      return this.requests;
+    }
+
+    // post-fulu we need to ensure that we only request columns that the peer has advertised
+    const {columnsRequest} = this.requests;
+    if (columnsRequest == null) {
+      return this.requests;
+    }
+
+    const peerColumns = new Set(peer.custodyGroups ?? []);
+    const requestedColumns = columnsRequest.columns.filter((c) => peerColumns.has(c));
+    if (requestedColumns.length === columnsRequest.columns.length) {
+      return this.requests;
+    }
+
+    return {
+      ...this.requests,
+      columnsRequest: {
+        ...columnsRequest,
+        columns: requestedColumns,
+      },
+    };
   }
 
   /**

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -207,7 +207,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       logger: this.logger,
       peerIdStr: peer.peerId,
       batchBlocks,
-      ...batch.requests,
+      ...batch.getRequestsForPeer(peer),
     });
     const cached = cacheByRangeResponses({
       cache: this.chain.seenBlockInputCache,

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -494,8 +494,8 @@ export class BlockInputSync {
           ? new Set(cacheItem.blockInput.getMissingSampledColumnMeta().missing)
           : defaultPendingColumns;
       // pendingDataColumns is null pre-fulu
-      const peer = this.peerBalancer.bestPeerForPendingColumns(pendingColumns, excludedPeers);
-      if (peer === null) {
+      const peerMeta = this.peerBalancer.bestPeerForPendingColumns(pendingColumns, excludedPeers);
+      if (peerMeta === null) {
         // no more peer with needed columns to try, throw error
         let message = `Error fetching UnknownBlockRoot after ${i}: cannot find peer`;
         if (pendingColumns) {
@@ -503,7 +503,7 @@ export class BlockInputSync {
         }
         throw Error(message);
       }
-      const {peerId, client: peerClient} = peer;
+      const {peerId, client: peerClient} = peerMeta;
       excludedPeers.add(peerId);
 
       cacheItem.peerIdStrings.add(peerId);
@@ -514,7 +514,7 @@ export class BlockInputSync {
           network: this.network,
           seenCache: this.chain.seenGossipBlockInput,
           executionEngine: this.chain.executionEngine,
-          peerIdStr: peerId,
+          peerMeta,
           cacheItem,
         });
       } catch (e) {

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -583,7 +583,7 @@ export async function validateColumnsByRangeResponse(
         blockRoot,
         blockKzgCommitments.length,
         blockColumnSidecars
-      ).then(() => ({blockRoot, columnSidecars}))
+      ).then(() => ({blockRoot, columnSidecars: blockColumnSidecars}))
     );
   }
 

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -14,7 +14,6 @@ import {prettyPrintPeerIdStr} from "../../network/util.js";
 import {computePreFuluKzgCommitmentsInclusionProof, kzgCommitmentToVersionedHash} from "../../util/blobs.js";
 import {byteArrayEquals} from "../../util/bytes.js";
 import {getCellsAndProofs, getDataColumnSidecarsFromBlock} from "../../util/dataColumns.js";
-import {PeerIdStr} from "../../util/peerId.js";
 import {
   BlockInputSyncCacheItem,
   PendingBlockInput,
@@ -22,25 +21,31 @@ import {
   getBlockInputSyncCacheItemRootHex,
   isPendingBlockInput,
 } from "../types.js";
+import {PeerSyncMeta} from "../../network/peers/peersData.js";
+import {PeerIdStr} from "../../util/peerId.js";
 
 export type FetchByRootCoreProps = {
   config: ChainForkConfig;
   network: INetwork;
-  peerIdStr: PeerIdStr;
+  peerMeta: PeerSyncMeta;
 };
 export type FetchByRootProps = FetchByRootCoreProps & {
   cacheItem: BlockInputSyncCacheItem;
   executionEngine: IExecutionEngine;
   blockRoot: Uint8Array;
 };
-export type FetchByRootAndValidateBlockProps = FetchByRootCoreProps & {blockRoot: Uint8Array};
+export type FetchByRootAndValidateBlockProps = Omit<FetchByRootCoreProps, "peerMeta"> & {
+  peerIdStr: PeerIdStr;
+  blockRoot: Uint8Array;
+};
 export type FetchByRootAndValidateBlobsProps = FetchByRootAndValidateBlockProps & {
   executionEngine: IExecutionEngine;
   forkName: ForkPreFulu;
   block: SignedBeaconBlock<ForkPostDeneb>;
   blobMeta: BlobMeta[];
 };
-export type FetchByRootAndValidateColumnsProps = FetchByRootAndValidateBlockProps & {
+export type FetchByRootAndValidateColumnsProps = FetchByRootCoreProps & {
+  blockRoot: Uint8Array;
   executionEngine: IExecutionEngine;
   forkName: ForkPostFulu;
   block: SignedBeaconBlock<ForkPostFulu>;
@@ -62,11 +67,12 @@ export async function downloadByRoot({
   seenCache,
   network,
   executionEngine,
-  peerIdStr,
+  peerMeta,
   cacheItem,
 }: DownloadByRootProps): Promise<PendingBlockInput> {
   const rootHex = getBlockInputSyncCacheItemRootHex(cacheItem);
   const blockRoot = fromHex(rootHex);
+  const {peerId: peerIdStr} = peerMeta;
 
   const {block, blobSidecars, columnSidecars} = await fetchByRoot({
     config,
@@ -74,7 +80,7 @@ export async function downloadByRoot({
     executionEngine,
     cacheItem,
     blockRoot,
-    peerIdStr,
+    peerMeta,
   });
 
   let blockInput: IBlockInput;
@@ -127,13 +133,17 @@ export async function downloadByRoot({
       });
     }
     for (const columnSidecar of columnSidecars) {
-      blockInput.addColumn({
-        columnSidecar,
-        blockRootHex: rootHex,
-        seenTimestampSec: Date.now(),
-        source: BlockInputSource.byRoot,
-        peerIdStr,
-      });
+      blockInput.addColumn(
+        {
+          columnSidecar,
+          blockRootHex: rootHex,
+          seenTimestampSec: Date.now(),
+          source: BlockInputSource.byRoot,
+          peerIdStr,
+        },
+        // the same DataColumnSidecar may be added by gossip while waiting for fetchByRoot
+        {throwOnDuplicateAdd: false}
+      );
     }
   }
 
@@ -159,13 +169,14 @@ export async function fetchByRoot({
   config,
   network,
   executionEngine,
-  peerIdStr,
+  peerMeta,
   blockRoot,
   cacheItem,
 }: FetchByRootProps): Promise<FetchByRootResponses> {
   let block: SignedBeaconBlock;
   let blobSidecars: deneb.BlobSidecars | undefined;
   let columnSidecars: fulu.DataColumnSidecars | undefined;
+  const {peerId: peerIdStr} = peerMeta;
 
   if (isPendingBlockInput(cacheItem)) {
     if (cacheItem.blockInput.hasBlock()) {
@@ -198,7 +209,7 @@ export async function fetchByRoot({
           config,
           network,
           executionEngine,
-          peerIdStr,
+          peerMeta,
           forkName: forkName as ForkPostFulu,
           block: block as SignedBeaconBlock<ForkPostFulu>,
           blockRoot,
@@ -219,7 +230,7 @@ export async function fetchByRoot({
         config,
         network,
         executionEngine,
-        peerIdStr,
+        peerMeta,
         forkName,
         blockRoot,
         block: block as SignedBeaconBlock<ForkPostFulu>,
@@ -399,13 +410,18 @@ export async function fetchAndValidateColumns({
   network,
   executionEngine,
   forkName,
-  peerIdStr,
+  peerMeta,
   block,
   blockRoot,
   columnMeta,
 }: FetchByRootAndValidateColumnsProps): Promise<fulu.DataColumnSidecars> {
+  const {peerId: peerIdStr} = peerMeta;
   const slot = block.message.slot;
   const blobCount = block.message.body.blobKzgCommitments.length;
+  if (blobCount === 0) {
+    return [];
+  }
+
   const blobsV2ColumnSidecars = await fetchGetBlobsV2AndBuildSidecars({
     config,
     executionEngine,
@@ -448,12 +464,14 @@ export async function fetchAndValidateColumns({
     return needed;
   }
 
+  const peerColumns = new Set(peerMeta.custodyGroups ?? []);
+  const requestedColumns = columnMeta.missing.filter((c) => peerColumns.has(c));
   const columnSidecars = await network.sendDataColumnSidecarsByRoot(peerIdStr, [
-    {blockRoot, columns: columnMeta.missing},
+    {blockRoot, columns: requestedColumns},
   ]);
-  for (let i = 0; i < columnMeta.missing.length; i++) {
+  for (let i = 0; i < requestedColumns.length; i++) {
     const columnSidecar = columnSidecars[i];
-    if (columnSidecar.index !== columnMeta.missing[i]) {
+    if (columnSidecar.index !== requestedColumns[i]) {
       throw new DownloadByRootError(
         {
           code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED,
@@ -489,29 +507,33 @@ export async function fetchGetBlobsV2AndBuildSidecars({
   return getDataColumnSidecarsFromBlock(config, block, cellsAndProofs);
 }
 
+// TODO(fulu) not in use, remove?
 export async function fetchColumnsByRoot({
   network,
-  peerIdStr,
+  peerMeta,
   blockRoot,
   columnMeta,
 }: Pick<
   FetchByRootAndValidateColumnsProps,
-  "network" | "peerIdStr" | "blockRoot" | "columnMeta"
+  "network" | "peerMeta" | "blockRoot" | "columnMeta"
 >): Promise<fulu.DataColumnSidecars> {
-  return await network.sendDataColumnSidecarsByRoot(peerIdStr, [{blockRoot, columns: columnMeta.missing}]);
+  return await network.sendDataColumnSidecarsByRoot(peerMeta.peerId, [{blockRoot, columns: columnMeta.missing}]);
 }
 
+// TODO(fulu) not in use, remove?
 export type ValidateColumnSidecarsProps = Pick<
   FetchByRootAndValidateColumnsProps,
-  "config" | "peerIdStr" | "blockRoot" | "columnMeta"
+  "config" | "peerMeta" | "blockRoot" | "columnMeta"
 > & {
   slot: number;
   blobCount: number;
   needed?: fulu.DataColumnSidecars;
   needToPublish?: fulu.DataColumnSidecars;
 };
+
+// TODO(fulu) not in use, remove?
 export async function validateColumnSidecars({
-  peerIdStr,
+  peerMeta,
   slot,
   blockRoot,
   blobCount,
@@ -525,7 +547,7 @@ export async function validateColumnSidecars({
       throw new DownloadByRootError(
         {
           code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED,
-          peer: prettyPrintPeerIdStr(peerIdStr),
+          peer: prettyPrintPeerIdStr(peerMeta.peerId),
           blockRoot: prettyBytes(blockRoot),
           invalidIndex: columnSidecar.index,
         },

--- a/packages/beacon-node/test/unit/sync/utils/downloadByRoot.test.ts
+++ b/packages/beacon-node/test/unit/sync/utils/downloadByRoot.test.ts
@@ -31,9 +31,16 @@ import {
   generateBlockWithBlobSidecars,
   generateBlockWithColumnSidecars,
 } from "../../../utils/blocksAndData.js";
+import {PeerSyncMeta} from "../../../../src/network/peers/peersData.js";
 
 describe("downloadByRoot.ts", () => {
   const peerIdStr = "1234567890abcdef1234567890abcdef";
+  const peerMeta: PeerSyncMeta = {
+    peerId: peerIdStr,
+    client: "N/A",
+    custodyGroups: Array.from({length: NUMBER_OF_COLUMNS}, (_, i) => i),
+    earliestAvailableSlot: 0,
+  };
   let network: INetwork;
   let executionEngine: IExecutionEngine;
 
@@ -519,7 +526,7 @@ describe("downloadByRoot.ts", () => {
         network,
         executionEngine,
         forkName,
-        peerIdStr,
+        peerMeta,
         blockRoot: fuluBlockWithColumns.blockRoot,
         block: fuluBlockWithColumns.block,
         columnMeta,
@@ -563,7 +570,7 @@ describe("downloadByRoot.ts", () => {
         network,
         executionEngine,
         forkName,
-        peerIdStr,
+        peerMeta,
         blockRoot: fuluBlockWithColumns.blockRoot,
         block: fuluBlockWithColumns.block,
         columnMeta: testColumnMeta,
@@ -603,7 +610,7 @@ describe("downloadByRoot.ts", () => {
         network,
         executionEngine,
         forkName,
-        peerIdStr,
+        peerMeta,
         blockRoot: fuluBlockWithColumns.blockRoot,
         block: fuluBlockWithColumns.block,
         columnMeta: testColumnMeta,
@@ -639,7 +646,7 @@ describe("downloadByRoot.ts", () => {
         network,
         executionEngine,
         forkName,
-        peerIdStr,
+        peerMeta,
         blockRoot: fuluBlockWithColumns.blockRoot,
         block: fuluBlockWithColumns.block,
         columnMeta,
@@ -679,7 +686,7 @@ describe("downloadByRoot.ts", () => {
         network,
         executionEngine,
         forkName,
-        peerIdStr,
+        peerMeta,
         blockRoot: fuluBlockWithColumns.blockRoot,
         block: fuluBlockWithColumns.block,
         columnMeta,
@@ -736,7 +743,7 @@ describe("downloadByRoot.ts", () => {
           network,
           executionEngine,
           forkName,
-          peerIdStr,
+          peerMeta,
           blockRoot: fuluBlockWithColumns.blockRoot,
           block: fuluBlockWithColumns.block,
           columnMeta: {
@@ -773,7 +780,7 @@ describe("downloadByRoot.ts", () => {
         network,
         executionEngine,
         forkName,
-        peerIdStr,
+        peerMeta,
         blockRoot: fuluBlockWithColumns.blockRoot,
         block: fuluBlockWithColumns.block,
         columnMeta: {
@@ -947,7 +954,7 @@ describe("downloadByRoot.ts", () => {
       const missing = fuluBlockWithColumns.columnSidecars.map((c) => c.index);
       const response = await fetchColumnsByRoot({
         network,
-        peerIdStr,
+        peerMeta,
         blockRoot,
         columnMeta: {
           missing,


### PR DESCRIPTION
**Motivation**

- before we send `beacon_data_columns_by_root` or `beacon_data_columns_by_range` to peer, we need to filter by peers' custofied columns
- otherwise, will get error
```
Sep-05 03:05:17.827[sync]            debug: Error downloading in BlockInputSync.fetchBlockInput attempt=3, rootHex=0xe81f474d8bd7f94e891f664165f7ea3af9841ff3b7a17a20f9bc54647f5b0480, peer=16Uiu2HAm3k5Npu6EaYWxiEvzsdLseEkjVyoVhvbxWEuyqdBgBBbq, peerClient=Grandine, code=DOWNLOAD_BY_ROOT_ERROR_EXTRA_SIDECAR_RECEIVED, peer=16...BgBBbq, blockRoot=0xe81f…0480, invalidIndex=126
Error: Received a columnSidecar that was not requested
    at fetchAndValidateColumns (file:///usr/src/lodestar/packages/beacon-node/src/sync/utils/downloadByRoot.ts:457:13)
    at fetchByRoot (file:///usr/src/lodestar/packages/beacon-node/src/sync/utils/downloadByRoot.ts:197:26)
    at downloadByRoot (file:///usr/src/lodestar/packages/beacon-node/src/sync/utils/downloadByRoot.ts:71:49)
    at BlockInputSync.fetchBlockInput (file:///usr/src/lodestar/packages/beacon-node/src/sync/unknownBlock.ts:512:21)
    at wrapError (file:///usr/src/lodestar/packages/beacon-node/src/util/wrapError.ts:18:32)
    at BlockInputSync.downloadBlock (file:///usr/src/lodestar/packages/beacon-node/src/sync/unknownBlock.ts:319:17)
```

**Description**

- fix for `downloadByRange` and `downloadByRoot` flows

Closes #8329
