### PR TITLE
fix: correct leveldb metrics

### DIFF
--- a/packages/db/src/controller/level.ts
+++ b/packages/db/src/controller/level.ts
@@ -189,9 +189,9 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
 
   /** Capture metrics for db.iterator, db.keys, db.values .all() calls */
   private async metricsAll<T>(promise: Promise<T[]>, bucket: string): Promise<T[]> {
-    this.metrics?.dbWriteReq.inc({bucket}, 1);
+    this.metrics?.dbReadReq.inc({bucket}, 1);
     const items = await promise;
-    this.metrics?.dbWriteItems.inc({bucket}, items.length);
+    this.metrics?.dbReadItems.inc({bucket}, items.length);
     return items;
   }
 
@@ -201,7 +201,7 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
     getValue: (item: T) => K,
     bucket: string
   ): AsyncIterable<K> {
-    this.metrics?.dbWriteReq.inc({bucket}, 1);
+    this.metrics?.dbReadReq.inc({bucket}, 1);
 
     let itemsRead = 0;
 
@@ -212,7 +212,7 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
       yield getValue(item);
     }
 
-    this.metrics?.dbWriteItems.inc({bucket}, itemsRead);
+    this.metrics?.dbReadItems.inc({bucket}, itemsRead);
   }
 
   /** Start interval to capture metric for db size */


### PR DESCRIPTION
**Motivation**

- misuse `dbRead*` vs `dbWrite*` which leads to incorrect metric

**Description**

- this PR should ideally be with `unstable` target branch, however leaving here so that we can investigate #8334 easier
- we will merge this to unstable later anyway


part of #8334
