### PR TITLE
fix: properly handle fetching data columns from api if block has no blobs

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -656,19 +656,23 @@ export function getBeaconBlockApi({
           );
         }
 
-        let dataColumnSidecars = await db.dataColumnSidecar.values(blockRoot);
-        if (dataColumnSidecars.length === 0) {
-          dataColumnSidecars = await db.dataColumnSidecarArchive.values(block.message.slot);
-        }
+        if ((block.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length > 0) {
+          let dataColumnSidecars = await db.dataColumnSidecar.values(blockRoot);
+          if (dataColumnSidecars.length === 0) {
+            dataColumnSidecars = await db.dataColumnSidecarArchive.values(block.message.slot);
+          }
 
-        if (dataColumnSidecars.length === 0) {
-          throw new ApiError(
-            404,
-            `dataColumnSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`
-          );
-        }
+          if (dataColumnSidecars.length === 0) {
+            throw new ApiError(
+              404,
+              `dataColumnSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`
+            );
+          }
 
-        blobs = await reconstructBlobs(dataColumnSidecars);
+          blobs = await reconstructBlobs(dataColumnSidecars);
+        } else {
+          blobs = [];
+        }
       } else if (isForkPostDeneb(fork)) {
         let {blobSidecars} = (await db.blobSidecars.get(blockRoot)) ?? {};
         if (!blobSidecars) {

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -656,7 +656,9 @@ export function getBeaconBlockApi({
           );
         }
 
-        if ((block.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length > 0) {
+        const blobCount = (block.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length;
+
+        if (blobCount > 0) {
           let dataColumnSidecars = await db.dataColumnSidecar.values(blockRoot);
           if (dataColumnSidecars.length === 0) {
             dataColumnSidecars = await db.dataColumnSidecarArchive.values(block.message.slot);
@@ -665,7 +667,7 @@ export function getBeaconBlockApi({
           if (dataColumnSidecars.length === 0) {
             throw new ApiError(
               404,
-              `dataColumnSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`
+              `dataColumnSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)} blobs=${blobCount}`
             );
           }
 

--- a/packages/beacon-node/src/api/impl/debug/index.ts
+++ b/packages/beacon-node/src/api/impl/debug/index.ts
@@ -1,8 +1,8 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {ExecutionStatus} from "@lodestar/fork-choice";
-import {ZERO_HASH_HEX} from "@lodestar/params";
-import {BeaconState} from "@lodestar/types";
+import {isForkPostFulu, ZERO_HASH_HEX} from "@lodestar/params";
+import {BeaconState, deneb, fulu, sszTypesFor} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {isOptimisticBlock} from "../../../util/forkChoice.js";
 import {getStateSlotFromBytes} from "../../../util/multifork.js";
@@ -94,16 +94,23 @@ export function getDebugApi({
       assertUniqueItems(indices, "Duplicate indices provided");
 
       const {block, executionOptimistic, finalized} = await getBlockResponse(chain, blockId);
-      const blockRoot = config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
+      const fork = config.getForkName(block.message.slot);
+      const blockRoot = sszTypesFor(fork).BeaconBlock.hashTreeRoot(block.message);
 
-      let dataColumnSidecars = await db.dataColumnSidecar.values(blockRoot);
+      let dataColumnSidecars: fulu.DataColumnSidecars;
 
-      if (dataColumnSidecars.length === 0) {
-        dataColumnSidecars = await db.dataColumnSidecarArchive.values(block.message.slot);
-      }
+      if (isForkPostFulu(fork) && (block.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length > 0) {
+        dataColumnSidecars = await db.dataColumnSidecar.values(blockRoot);
 
-      if (dataColumnSidecars.length === 0) {
-        throw Error(`dataColumnSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`);
+        if (dataColumnSidecars.length === 0) {
+          dataColumnSidecars = await db.dataColumnSidecarArchive.values(block.message.slot);
+        }
+
+        if (dataColumnSidecars.length === 0) {
+          throw Error(`dataColumnSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`);
+        }
+      } else {
+        dataColumnSidecars = [];
       }
 
       return {
@@ -111,7 +118,7 @@ export function getDebugApi({
         meta: {
           executionOptimistic,
           finalized,
-          version: config.getForkName(block.message.slot),
+          version: fork,
         },
       };
     },

--- a/packages/beacon-node/src/api/impl/debug/index.ts
+++ b/packages/beacon-node/src/api/impl/debug/index.ts
@@ -101,7 +101,6 @@ export function getDebugApi({
 
       if (isForkPostFulu(fork) && (block.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length > 0) {
         dataColumnSidecars = await db.dataColumnSidecar.values(blockRoot);
-
         if (dataColumnSidecars.length === 0) {
           dataColumnSidecars = await db.dataColumnSidecarArchive.values(block.message.slot);
         }

--- a/packages/beacon-node/src/api/impl/debug/index.ts
+++ b/packages/beacon-node/src/api/impl/debug/index.ts
@@ -1,7 +1,7 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {ExecutionStatus} from "@lodestar/fork-choice";
-import {isForkPostFulu, ZERO_HASH_HEX} from "@lodestar/params";
+import {isForkPostDeneb, isForkPostFulu, ZERO_HASH_HEX} from "@lodestar/params";
 import {BeaconState, deneb, fulu, sszTypesFor} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {isOptimisticBlock} from "../../../util/forkChoice.js";
@@ -99,14 +99,20 @@ export function getDebugApi({
 
       let dataColumnSidecars: fulu.DataColumnSidecars;
 
-      if (isForkPostFulu(fork) && (block.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length > 0) {
+      const blobCount = isForkPostDeneb(fork)
+        ? (block.message.body as deneb.BeaconBlockBody).blobKzgCommitments.length
+        : 0;
+
+      if (isForkPostFulu(fork) && blobCount > 0) {
         dataColumnSidecars = await db.dataColumnSidecar.values(blockRoot);
         if (dataColumnSidecars.length === 0) {
           dataColumnSidecars = await db.dataColumnSidecarArchive.values(block.message.slot);
         }
 
         if (dataColumnSidecars.length === 0) {
-          throw Error(`dataColumnSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)}`);
+          throw Error(
+            `dataColumnSidecars not found in db for slot=${block.message.slot} root=${toRootHex(blockRoot)} blobs=${blobCount}`
+          );
         }
       } else {
         dataColumnSidecars = [];


### PR DESCRIPTION
**Motivation**

Restores previous behavior before https://github.com/ChainSafe/lodestar/pull/8251, if there is a block that has no blobs we shouldn't throw an error and instead just return no data columns. Only throw an error if there should be data columns in db (by checking if block has kzg commitments) but we don't have them.

**Description**

Only query data columns from db if block has at least one `blobKzgCommitments`
