### PR TITLE
fix: update logs if block not found while handling unavailable data columns

### DIFF
--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -142,6 +142,8 @@ export interface IBeaconChain {
 
   readonly opts: IChainOptions;
 
+  readonly earliestAvailableSlot: Slot;
+
   /** Start the processing of chain and load state from disk and related actions */
   init(): Promise<void>;
   /** Stop beacon chain processing */

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -85,6 +85,7 @@ export enum FindHeadFnName {
 export interface IBeaconChain {
   readonly genesisTime: UintNum64;
   readonly genesisValidatorsRoot: Root;
+  readonly earliestAvailableSlot: Slot;
   readonly eth1: IEth1ForBlockProduction;
   readonly executionEngine: IExecutionEngine;
   readonly executionBuilder?: IExecutionBuilder;
@@ -141,8 +142,6 @@ export interface IBeaconChain {
   readonly serializedCache: SerializedCache;
 
   readonly opts: IChainOptions;
-
-  readonly earliestAvailableSlot: Slot;
 
   /** Start the processing of chain and load state from disk and related actions */
   init(): Promise<void>;

--- a/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
+++ b/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
@@ -1,7 +1,7 @@
 import {LogData} from "@lodestar/logger";
 import {RespStatus, ResponseError} from "@lodestar/reqresp";
 import {ColumnIndex, Slot} from "@lodestar/types";
-import {prettyBytes, prettyPrintIndices} from "@lodestar/utils";
+import {prettyBytes, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/interface.js";
 import {IBeaconDb} from "../../../db/interface.js";
 import {getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized} from "../../../util/sszBytes.js";
@@ -27,10 +27,10 @@ export async function handleColumnSidecarUnavailability({
   availableColumns: ColumnIndex[];
 }): Promise<void> {
   const logData: LogData = {
+    slot,
     unavailableColumnIndices: prettyPrintIndices(unavailableColumnIndices),
     requestedColumns: prettyPrintIndices(requestedColumns),
     availableColumns: prettyPrintIndices(availableColumns),
-    slot,
   };
   if (blockRoot) {
     logData.blockRoot = prettyBytes(blockRoot);
@@ -40,8 +40,9 @@ export async function handleColumnSidecarUnavailability({
 
   const blockBytes = blockRoot ? await db.block.getBinary(blockRoot) : await db.blockArchive.getBinary(slot);
   if (!blockBytes) {
-    chain.logger.error(
-      `Expected ${blockRoot ? "unfinalized" : "finalized"} block not found while handling unavailable dataColumnSidecar`
+    chain.logger.verbose(
+      `Expected ${blockRoot ? "unfinalized" : "finalized"} block not found while handling unavailable dataColumnSidecar`,
+      {slot, blockRoot: blockRoot ? toRootHex(blockRoot) : "unknown"}
     );
     return;
   }
@@ -57,7 +58,7 @@ export async function handleColumnSidecarUnavailability({
   metrics?.dataColumns.missingCustodyColumns.inc(unavailableColumnIndices.length);
   chain.logger.verbose("dataColumnSidecar requested and within custody but not available", {
     unavailableColumnIndices: prettyPrintIndices(unavailableColumnIndices),
-    blockRoot: blockRoot ? prettyBytes(blockRoot) : "unknown blockRoot",
+    blockRoot: blockRoot ? prettyBytes(blockRoot) : "unknown",
   });
 }
 

--- a/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
+++ b/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
@@ -42,7 +42,11 @@ export async function handleColumnSidecarUnavailability({
   if (!blockBytes) {
     chain.logger.verbose(
       `Expected ${blockRoot ? "unfinalized" : "finalized"} block not found while handling unavailable dataColumnSidecar`,
-      {slot, blockRoot: blockRoot ? toRootHex(blockRoot) : "unknown"}
+      {
+        slot,
+        blockRoot: blockRoot ? toRootHex(blockRoot) : "unknown",
+        earliestAvailableSlot: chain.earliestAvailableSlot,
+      }
     );
     return;
   }

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -334,7 +334,7 @@ describe("getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized", () => {
     FULU_FORK_EPOCH: 15,
   });
 
-  it("should return blob count pre electra", async () => {
+  it("should return 0 blob count pre deneb", async () => {
     const slot = 1;
     const block = config.getForkTypes(slot).SignedBeaconBlock.defaultValue();
     block.message.slot = slot;


### PR DESCRIPTION
**Motivation**

Don't spam the logs with uninformative errors


**Description**

Update logs if block not found while handling unavailable data columns
- move log from `error` to `verbose` as it's network related log and to avoid spam
- make log actually useful by adding context like slot and block root

Closes https://github.com/ChainSafe/lodestar/issues/8333