### PR TITLE
fix: handle full data BlockInput in downloadByRoot

### DIFF
--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -99,7 +99,10 @@ export async function downloadByRoot({
     });
   }
 
-  if (isBlockInputBlobs(blockInput)) {
+  const hasAllData = blockInput.hasBlockAndAllData();
+
+  if (isBlockInputBlobs(blockInput) && !hasAllData) {
+    // blobSidecars could be undefined if gossip resulted in full block+blobs so we don't download any
     if (!blobSidecars) {
       throw new DownloadByRootError({
         code: DownloadByRootErrorCode.MISSING_BLOB_RESPONSE,
@@ -118,7 +121,8 @@ export async function downloadByRoot({
     }
   }
 
-  if (isBlockInputColumns(blockInput)) {
+  if (isBlockInputColumns(blockInput) && !hasAllData) {
+    // columnSidecars could be undefined if gossip resulted in full block+columns so we don't download any
     if (!columnSidecars) {
       throw new DownloadByRootError({
         code: DownloadByRootErrorCode.MISSING_COLUMN_RESPONSE,
@@ -139,7 +143,7 @@ export async function downloadByRoot({
 
   let status: PendingBlockInputStatus;
   let timeSyncedSec: number | undefined;
-  if (blockInput.hasBlockAndAllData()) {
+  if (hasAllData) {
     status = PendingBlockInputStatus.downloaded;
     timeSyncedSec = Date.now() / 1000;
   } else {


### PR DESCRIPTION
**Motivation**

- there are a lot of errors like
```
Sep 05 10:36:05 devnet-ax41-0 beacon_run.sh[581633]: Sep-05 10:36:05.767[sync]            debug: Error downloading in BlockInputSync.fetchBlockInput attempt=13, rootHex=0xbda1d14f56df33ad5f87ad60f639b67750320b324d817d03b3fa72516aa0d7a3, peer=16Uiu2HAmVeQdJYU1cmZHdHD5jyse2kKwLqDFJwZpVv3cuPwUr9yu, peerClient=Nimbus, code=DOWNLOAD_BY_ROOT_ERROR_MISSING_COLUMN_RESPONSE, blockRoot=0xbda1…d7a3, peer=16Uiu2HAmVeQdJYU1cmZHdHD5jyse2kKwLqDFJwZpVv3cuPwUr9yu
Sep 05 10:36:05 devnet-ax41-0 beacon_run.sh[581633]: Error: DOWNLOAD_BY_ROOT_ERROR_MISSING_COLUMN_RESPONSE
Sep 05 10:36:05 devnet-ax41-0 beacon_run.sh[581633]:     at downloadByRoot (file:///usr/src/lodestar/packages/beacon-node/src/sync/utils/downloadByRoot.ts:123:13)
Sep 05 10:36:05 devnet-ax41-0 beacon_run.sh[581633]:     at BlockInputSync.fetchBlockInput (file:///usr/src/lodestar/packages/beacon-node/src/sync/unknownBlock.ts:512:21)
Sep 05 10:36:05 devnet-ax41-0 beacon_run.sh[581633]:     at wrapError (file:///usr/src/lodestar/packages/beacon-node/src/util/wrapError.ts:18:32)
Sep 05 10:36:05 devnet-ax41-0 beacon_run.sh[581633]:     at BlockInputSync.downloadBlock (file:///usr/src/lodestar/packages/beacon-node/src/sync/unknownBlock.ts:319:17)
```

it's because when we see block input has full data, we don't download blobs/data_columns

**Description**

- skip errors in that case

Closes #8338
