### PR TITLE
fix: allow for sparse blobs in blob validation

### DIFF
--- a/packages/beacon-node/src/chain/errors/blobSidecarError.ts
+++ b/packages/beacon-node/src/chain/errors/blobSidecarError.ts
@@ -22,8 +22,6 @@ export enum BlobSidecarErrorCode {
   INCORRECT_SIDECAR_COUNT = "BLOBS_SIDECAR_ERROR_INCORRECT_SIDECAR_COUNT",
   /** Sidecar doesn't match block */
   INCORRECT_BLOCK = "BLOBS_SIDECAR_ERROR_INCORRECT_BLOCK",
-  /** Sidecar index is not as expected */
-  INCORRECT_INDEX = "BLOBS_SIDECAR_ERROR_INCORRECT_INDEX",
   /** Sidecars proofs not valid */
   INVALID_KZG_PROOF_BATCH = "BLOBS_SIDECAR_ERROR_INVALID_KZG_PROOF_BATCH",
 
@@ -48,7 +46,6 @@ export type BlobSidecarErrorType =
   | {code: BlobSidecarErrorCode.INVALID_KZG_PROOF; blobIdx: number}
   | {code: BlobSidecarErrorCode.INCORRECT_SIDECAR_COUNT; slot: number; expected: number; actual: number}
   | {code: BlobSidecarErrorCode.INCORRECT_BLOCK; slot: number; blobIdx: number; expected: string; actual: string}
-  | {code: BlobSidecarErrorCode.INCORRECT_INDEX; slot: number; expected: number; actual: number}
   | {code: BlobSidecarErrorCode.INVALID_KZG_PROOF_BATCH; slot: number; reason: string}
   | {code: BlobSidecarErrorCode.FUTURE_SLOT; blockSlot: Slot; currentSlot: Slot}
   | {code: BlobSidecarErrorCode.WOULD_REVERT_FINALIZED_SLOT; blockSlot: Slot; finalizedSlot: Slot}

--- a/packages/beacon-node/src/chain/validation/blobSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -173,7 +173,7 @@ export async function validateGossipBlobSidecar(
 }
 
 /**
- * Validate all blob sidecars in a block
+ * Validate some blob sidecars in a block
  *
  * Requires the block to be known to the node
  */
@@ -183,17 +183,17 @@ export async function validateBlockBlobSidecars(
   blockBlobCount: number,
   blobSidecars: deneb.BlobSidecars
 ): Promise<void> {
-  if (blockBlobCount !== blobSidecars.length) {
+  if (blobSidecars.length === 0) {
+    return;
+  }
+
+  if (blockBlobCount === 0) {
     throw new BlobSidecarValidationError({
       code: BlobSidecarErrorCode.INCORRECT_SIDECAR_COUNT,
       slot: blockSlot,
       expected: blockBlobCount,
       actual: blobSidecars.length,
     });
-  }
-
-  if (blobSidecars.length === 0) {
-    return;
   }
 
   // Hash the first sidecar block header and compare the rest via (cheaper) equality
@@ -215,25 +215,14 @@ export async function validateBlockBlobSidecars(
   const commitments = [];
   const blobs = [];
   const proofs = [];
-  for (let i = 0; i < blobSidecars.length; i++) {
-    const blobSidecar = blobSidecars[i];
-    if (blobSidecar.index !== i) {
-      throw new BlobSidecarValidationError(
-        {
-          code: BlobSidecarErrorCode.INCORRECT_INDEX,
-          slot: blockSlot,
-          expected: i,
-          actual: blobSidecar.index,
-        },
-        "BlobSidecar index out of order"
-      );
-    }
+  for (const blobSidecar of blobSidecars) {
+    const blobIdx = blobSidecar.index;
     if (!ssz.phase0.BeaconBlockHeader.equals(blobSidecar.signedBlockHeader.message, firstSidecarBlockHeader)) {
       throw new BlobSidecarValidationError(
         {
           code: BlobSidecarErrorCode.INCORRECT_BLOCK,
           slot: blockSlot,
-          blobIdx: i,
+          blobIdx,
           expected: toRootHex(blockRoot),
           actual: "unknown - compared via equality",
         },
@@ -246,7 +235,7 @@ export async function validateBlockBlobSidecars(
         {
           code: BlobSidecarErrorCode.INCLUSION_PROOF_INVALID,
           slot: blockSlot,
-          blobIdx: i,
+          blobIdx,
         },
         "BlobSidecar inclusion proof invalid"
       );

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -474,7 +474,6 @@ export class SyncChain {
           case DownloadByRangeErrorCode.OUT_OF_ORDER_BLOCKS:
           case DownloadByRangeErrorCode.OUT_OF_RANGE_BLOCKS:
           case DownloadByRangeErrorCode.PARENT_ROOT_MISMATCH:
-          case BlobSidecarErrorCode.INCORRECT_INDEX:
           case BlobSidecarErrorCode.INCLUSION_PROOF_INVALID:
           case BlobSidecarErrorCode.INVALID_KZG_PROOF_BATCH:
           case DataColumnSidecarErrorCode.INCORRECT_KZG_COMMITMENTS_COUNT:

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -510,7 +510,7 @@ export async function validateBlobsByRangeResponse(
 
     validateSidecarsPromises.push(
       validateBlockBlobSidecars(block.message.slot, blockRoot, blockKzgCommitments.length, blockBlobSidecars).then(
-        () => ({blockRoot, blobSidecars})
+        () => ({blockRoot, blobSidecars: blockBlobSidecars})
       )
     );
   }

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -496,6 +496,18 @@ export async function validateBlobsByRangeResponse(
     const blockBlobSidecars = blobSidecars.slice(blobSidecarIndex, blobSidecarIndex + blockKzgCommitments.length);
     blobSidecarIndex += blockKzgCommitments.length;
 
+    for (let i = 0; i < blockBlobSidecars.length; i++) {
+      if (blockBlobSidecars[i].index !== i) {
+        throw new DownloadByRangeError(
+          {
+            code: DownloadByRangeErrorCode.OUT_OF_ORDER_BLOBS,
+            slot: block.message.slot,
+          },
+          "Blob sidecars not in order or do not match expected indexes in BlobSidecarsByRange response"
+        );
+      }
+    }
+
     validateSidecarsPromises.push(
       validateBlockBlobSidecars(block.message.slot, blockRoot, blockKzgCommitments.length, blockBlobSidecars).then(
         () => ({blockRoot, blobSidecars})
@@ -670,6 +682,7 @@ export enum DownloadByRangeErrorCode {
   OUT_OF_ORDER_BLOCKS = "DOWNLOAD_BY_RANGE_OUT_OF_ORDER_BLOCKS",
 
   MISSING_BLOBS = "DOWNLOAD_BY_RANGE_ERROR_MISSING_BLOBS",
+  OUT_OF_ORDER_BLOBS = "DOWNLOAD_BY_RANGE_ERROR_OUT_OF_ORDER_BLOBS",
   EXTRA_BLOBS = "DOWNLOAD_BY_RANGE_ERROR_EXTRA_BLOBS",
 
   MISSING_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_MISSING_COLUMNS",
@@ -732,6 +745,10 @@ export type DownloadByRangeErrorType =
       code: DownloadByRangeErrorCode.MISSING_BLOBS;
       expected: number;
       actual: number;
+    }
+  | {
+      code: DownloadByRangeErrorCode.OUT_OF_ORDER_BLOBS;
+      slot: number;
     }
   | {
       code: DownloadByRangeErrorCode.EXTRA_BLOBS;


### PR DESCRIPTION
** Description **

- blobs validation function required _all_ blobs to be present
- that doesn't hold true during by-root where some blobs may have been received via gossip
- check that all block blobs exist at the higher level when all blobs must be present (by range sync)
- various muddling with error cases