### PR TITLE
fix: add bucketId to abstract_prefixed_repo

### DIFF
--- a/packages/db/src/abstractPrefixedRepository.ts
+++ b/packages/db/src/abstractPrefixedRepository.ts
@@ -134,6 +134,7 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
       const prefixedKeys = await this.db.keys({
         gte: this.wrapKey(this.getMinKeyRaw(p)),
         lte: this.wrapKey(this.getMaxKeyRaw(p)),
+        bucketId: this.bucketId,
       });
       keys.push(prefixedKeys);
     }
@@ -146,6 +147,7 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
       for await (const vb of this.db.valuesStream({
         gte: this.wrapKey(this.getMinKeyRaw(p)),
         lte: this.wrapKey(this.getMaxKeyRaw(p)),
+        bucketId: this.bucketId,
       })) {
         yield this.decodeValue(vb);
       }
@@ -168,6 +170,7 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
       for await (const {key, value} of this.db.entriesStream({
         gte: this.wrapKey(this.getMinKeyRaw(p)),
         lte: this.wrapKey(this.getMaxKeyRaw(p)),
+        bucketId: this.bucketId,
       })) {
         const {prefix, id} = this.decodeKeyRaw(this.unwrapKey(key));
 
@@ -196,6 +199,7 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
       for await (const {key, value} of this.db.entriesStream({
         gte: this.wrapKey(this.getMinKeyRaw(v)),
         lte: this.wrapKey(this.getMaxKeyRaw(v)),
+        bucketId: this.bucketId,
       })) {
         const {prefix, id} = this.decodeKeyRaw(this.unwrapKey(key));
 
@@ -213,6 +217,7 @@ export abstract class PrefixedRepository<P, I extends Id, T> {
       for await (const {key, value} of this.db.entriesStream({
         gte: this.wrapKey(this.getMinKeyRaw(v)),
         lt: this.wrapKey(this.getMaxKeyRaw(v)),
+        bucketId: this.bucketId,
       })) {
         const {prefix, id} = this.decodeKeyRaw(this.unwrapKey(key));
 


### PR DESCRIPTION
**Motivation**

- there are a lot of "unknown" read/write requests tracked in #8334

**Description**

- add bucketId to abstractPrefixedRepository.ts where it's missed

part of #8334