### PR TITLE
fix: typos and polish comments across state-transition code

### DIFF
--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -111,7 +111,7 @@ export function processAttestationsAltair(
       }
 
       // TODO: describe issue. Compute progressive target balances
-      // When processing each attestation, increase the cummulative target balance. Only applies post-altair
+      // When processing each attestation, increase the cumulative target balance. Only applies post-altair
       if ((flagsNewSet & TIMELY_TARGET) === TIMELY_TARGET) {
         const validator = validators.getReadonly(validatorIndex);
         if (!validator.slashed) {

--- a/packages/state-transition/src/block/processDeposit.ts
+++ b/packages/state-transition/src/block/processDeposit.ts
@@ -19,7 +19,7 @@ import {computeDomain, computeSigningRoot, getMaxEffectiveBalance, increaseBalan
 
 /**
  * Process a Deposit operation. Potentially adds a new validator to the registry. Mutates the validators and balances
- * trees, pushing contigious values at the end.
+ * trees, pushing contiguous values at the end.
  *
  * PERF: Work depends on number of Deposit per block. On regular networks the average is 0 / block.
  */
@@ -147,7 +147,7 @@ export function isValidDepositSignature(
   amount: number,
   depositSignature: Uint8Array
 ): boolean {
-  // verify the deposit signature (proof of posession) which is not checked by the deposit contract
+  // verify the deposit signature (proof of possession) which is not checked by the deposit contract
   const depositMessage = {
     pubkey,
     withdrawalCredentials,

--- a/packages/state-transition/src/block/processEth1Data.ts
+++ b/packages/state-transition/src/block/processEth1Data.ts
@@ -43,7 +43,7 @@ export function becomesNewEth1Data(
     return false;
   }
 
-  // Close to half the EPOCHS_PER_ETH1_VOTING_PERIOD it can be expensive to do so many comparisions.
+  // Close to half the EPOCHS_PER_ETH1_VOTING_PERIOD it can be expensive to do so many comparisons.
   // `eth1DataVotes.getAllReadonly()` navigates the tree once to fetch all the LeafNodes efficiently.
   // Then isEqualEth1DataView compares cached roots (HashObject as of Jan 2022) which is much cheaper
   // than doing structural equality, which requires tree -> value conversions

--- a/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
+++ b/packages/state-transition/src/epoch/processEffectiveBalanceUpdates.ts
@@ -87,7 +87,7 @@ export function processEffectiveBalanceUpdates(
           epochCtx.previousTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;
         }
 
-        // currentTargetUnslashedBalanceIncrements is transfered to previousTargetUnslashedBalanceIncrements in afterEpochTransitionCache
+        // currentTargetUnslashedBalanceIncrements is transferred to previousTargetUnslashedBalanceIncrements in afterEpochTransitionCache
         // at epoch transition of next epoch (in EpochTransitionCache), prevTargetUnslStake is calculated based on newEffectiveBalanceIncrement
         if (!validator.slashed && (currentEpochParticipation.get(i) & TIMELY_TARGET) === TIMELY_TARGET) {
           epochCtx.currentTargetUnslashedBalanceIncrements += deltaEffectiveBalanceIncrement;

--- a/packages/state-transition/src/epoch/processInactivityUpdates.ts
+++ b/packages/state-transition/src/epoch/processInactivityUpdates.ts
@@ -11,7 +11,7 @@ const inactivityScoresArr = new Array<number>();
 /**
  * Mutates `inactivityScores` from pre-calculated validator flags.
  *
- * PERF: Cost = iterate over an array of size $VALIDATOR_COUNT + 'proportional' to how many validtors are inactive or
+ * PERF: Cost = iterate over an array of size $VALIDATOR_COUNT + 'proportional' to how many validators are inactive or
  * have been inactive in the past, i.e. that require an update to their inactivityScore. Worst case = all validators
  * need to update their non-zero `inactivityScore`.
  *

--- a/packages/state-transition/src/slot/upgradeStateToAltair.ts
+++ b/packages/state-transition/src/slot/upgradeStateToAltair.ts
@@ -101,7 +101,7 @@ export function upgradeStateToAltair(statePhase0: CachedBeaconStatePhase0): Cach
   //       currentTargetUnslashedBalanceIncrements is rotated to previousTargetUnslashedBalanceIncrements
   //
   // Here target balance is computed in full, which is slightly less performant than doing so in the loop
-  // above but gurantees consistency with EpochCache.createFromState(). Note execution order below:
+  // above but guarantees consistency with EpochCache.createFromState(). Note execution order below:
   // ```
   // processEpoch()
   // epochCtx.afterProcessEpoch()

--- a/packages/state-transition/src/slot/upgradeStateToDeneb.ts
+++ b/packages/state-transition/src/slot/upgradeStateToDeneb.ts
@@ -22,7 +22,7 @@ export function upgradeStateToDeneb(stateCapella: CachedBeaconStateCapella): Cac
 
   // Since excessBlobGas and blobGasUsed are appened in the end to latestExecutionPayloadHeader so they should
   // be set to defaults and need no assigning, but right now any access to latestExecutionPayloadHeader fails
-  // with LeafNode has no left node. Weirdly its beacuse of addition of the second field as with one field
+  // with LeafNode has no left node. Weirdly its because of addition of the second field as with one field
   // it seems to work.
   //
   // TODO DENEB: Debug and remove the following cloning


### PR DESCRIPTION

Corrects spelling and wording in comments; improves clarity and consistency.