### PR TITLE
fix: new error code NOT_ENOUGH_SIDECARS_RECEIVED

### DIFF
--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -346,6 +346,21 @@ export async function fetchAndValidateColumns({
   const columnSidecars = await network.sendDataColumnSidecarsByRoot(peerIdStr, [
     {blockRoot, columns: requestedColumns},
   ]);
+
+  // sanity check if peer returned correct number of columnSidecars
+  if (columnSidecars.length < requestedColumns.length) {
+    throw new DownloadByRootError(
+      {
+        code: DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED,
+        peer: prettyPrintPeerIdStr(peerIdStr),
+        blockRoot: prettyBytes(blockRoot),
+        invalidIndex: requestedColumns.length - columnSidecars.length,
+      },
+      "Did not receive enough columnSidecars"
+    );
+  }
+
+  // check each returned columnSidecar
   for (let i = 0; i < requestedColumns.length; i++) {
     const columnSidecar = columnSidecars[i];
     if (columnSidecar.index !== requestedColumns[i]) {
@@ -419,6 +434,7 @@ export async function validateColumnSidecars({
 export enum DownloadByRootErrorCode {
   MISMATCH_BLOCK_ROOT = "DOWNLOAD_BY_ROOT_ERROR_MISMATCH_BLOCK_ROOT",
   EXTRA_SIDECAR_RECEIVED = "DOWNLOAD_BY_ROOT_ERROR_EXTRA_SIDECAR_RECEIVED",
+  NOT_ENOUGH_SIDECARS_RECEIVED = "DOWNLOAD_BY_ROOT_ERROR_NOT_ENOUGH_SIDECARS_RECEIVED",
   INVALID_INCLUSION_PROOF = "DOWNLOAD_BY_ROOT_ERROR_INVALID_INCLUSION_PROOF",
   INVALID_KZG_PROOF = "DOWNLOAD_BY_ROOT_ERROR_INVALID_KZG_PROOF",
   MISSING_BLOCK_RESPONSE = "DOWNLOAD_BY_ROOT_ERROR_MISSING_BLOCK_RESPONSE",
@@ -435,6 +451,12 @@ export type DownloadByRootErrorType =
     }
   | {
       code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED;
+      peer: string;
+      blockRoot: string;
+      invalidIndex: number;
+    }
+  | {
+      code: DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED;
       peer: string;
       blockRoot: string;
       invalidIndex: number;

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -1,7 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPostDeneb, ForkPostFulu, ForkPreFulu, isForkPostDeneb, isForkPostFulu} from "@lodestar/params";
 import {SignedBeaconBlock, deneb, fulu} from "@lodestar/types";
-import {LodestarError, fromHex, prettyBytes, toRootHex} from "@lodestar/utils";
+import {LodestarError, fromHex, prettyBytes, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {BlobMeta, BlockInputSource, IBlockInput, MissingColumnMeta} from "../../chain/blocks/blockInput/types.js";
 import {SeenBlockInput} from "../../chain/seenCache/seenGossipBlockInput.js";
@@ -349,14 +349,15 @@ export async function fetchAndValidateColumns({
 
   // sanity check if peer returned correct number of columnSidecars
   if (columnSidecars.length < requestedColumns.length) {
+    const returnedColumns = new Set(columnSidecars.map((c) => c.index));
     throw new DownloadByRootError(
       {
         code: DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED,
         peer: prettyPrintPeerIdStr(peerIdStr),
         blockRoot: prettyBytes(blockRoot),
-        invalidIndex: requestedColumns.length - columnSidecars.length,
+        missingIndices: prettyPrintIndices(requestedColumns.filter(c => !returnedColumns.has(c))),
       },
-      "Did not receive enough columnSidecars"
+      "Did not receive all of the requested columnSidecars"
     );
   }
 
@@ -459,7 +460,7 @@ export type DownloadByRootErrorType =
       code: DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED;
       peer: string;
       blockRoot: string;
-      invalidIndex: number;
+      missingIndices: string;
     }
   | {
       code: DownloadByRootErrorCode.INVALID_INCLUSION_PROOF;


### PR DESCRIPTION
**Motivation**

- when not enough sidecars received, we throwed `DOWNLOAD_BY_ROOT_ERROR_EXTRA_SIDECAR_RECEIVED`

**Description**

- define and use the new `NOT_ENOUGH_SIDECARS_RECEIVED` error instead

Closes #8350
