### PR TITLE
feat: track DownloadByRoot errors on new metrics

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -552,6 +552,62 @@ export function createLodestarMetrics(
         help: "Total number of blocks whose data availability was resolved",
         labelNames: ["source"],
       }),
+      downloadByRoot: {
+        success: register.gauge({
+          name: "lodestar_sync_unknown_block_download_by_root_success_total",
+          help: "Total number of successful downloadByRoot calls",
+        }),
+        error: register.gauge<{code: string}>({
+          name: "lodestar_sync_unknown_block_download_by_root_error_total",
+          help: "Total number of errored downloadByRoot calls",
+          labelNames: ["code"],
+        }),
+        mismatchBlockRootError: register.gauge<{client: string}>({
+          name: "lodestar_sync_unknown_block_download_by_root_mismatch_block_root_error_total",
+          help: "Total number of downloadByRoot calls that returned a mismatched root",
+          labelNames: ["client"],
+        }),
+        extraSidecarReceivedError: register.gauge<{client: string}>({
+          name: "lodestar_sync_unknown_block_download_by_root_extra_sidecar_received_error_total",
+          help: "Total number of downloadByRoot calls that returned an unexpected sidecar",
+          labelNames: ["client"],
+        }),
+        notEnoughSidecarError: register.gauge<{client: string}>({
+          name: "lodestar_sync_unknown_block_download_by_root_not_enough_sidecar_error_total",
+          help: "Total number of downloadByRoot calls that returned not enough sidecars",
+          labelNames: ["client"],
+        }),
+        invalidInclusionProofError: register.gauge<{client: string}>({
+          name: "lodestar_sync_unknown_block_download_by_root_invalid_inclusion_proof_error_total",
+          help: "Total number of downloadByRoot calls that returned an invalid inclusion proof",
+          labelNames: ["client"],
+        }),
+        invalidKzgProofError: register.gauge<{client: string}>({
+          name: "lodestar_sync_unknown_block_download_by_root_invalid_kzg_proof_error_total",
+          help: "Total number of downloadByRoot calls that returned an invalid KZG proof",
+          labelNames: ["client"],
+        }),
+        missingBlockResponseError: register.gauge<{client: string}>({
+          name: "lodestar_sync_unknown_block_download_by_root_missing_block_response_error_total",
+          help: "Total number of downloadByRoot calls that returned a missing block response",
+          labelNames: ["client"],
+        }),
+        missingBlobResponseError: register.gauge<{client: string}>({
+          name: "lodestar_sync_unknown_block_download_by_root_missing_blob_response_error_total",
+          help: "Total number of downloadByRoot calls that returned a missing blob response",
+          labelNames: ["client"],
+        }),
+        missingColumnResponseError: register.gauge<{client: string}>({
+          name: "lodestar_sync_unknown_block_download_by_root_missing_column_response_error_total",
+          help: "Total number of downloadByRoot calls that returned a missing column response",
+          labelNames: ["client"],
+        }),
+        unknownError: register.gauge<{client: string}>({
+          name: "lodestar_sync_unknown_block_download_by_root_unknown_error_total",
+          help: "Total number of downloadByRoot calls that returned an unknown error",
+          labelNames: ["client"],
+        }),
+      },
       peerBalancer: {
         peersMetaCount: register.gauge({
           name: "lodestar_sync_unknown_block_peer_balancer_peers_meta_count",

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -557,55 +557,10 @@ export function createLodestarMetrics(
           name: "lodestar_sync_unknown_block_download_by_root_success_total",
           help: "Total number of successful downloadByRoot calls",
         }),
-        error: register.gauge<{code: string}>({
+        error: register.gauge<{code: string; client: string}>({
           name: "lodestar_sync_unknown_block_download_by_root_error_total",
           help: "Total number of errored downloadByRoot calls",
-          labelNames: ["code"],
-        }),
-        mismatchBlockRootError: register.gauge<{client: string}>({
-          name: "lodestar_sync_unknown_block_download_by_root_mismatch_block_root_error_total",
-          help: "Total number of downloadByRoot calls that returned a mismatched root",
-          labelNames: ["client"],
-        }),
-        extraSidecarReceivedError: register.gauge<{client: string}>({
-          name: "lodestar_sync_unknown_block_download_by_root_extra_sidecar_received_error_total",
-          help: "Total number of downloadByRoot calls that returned an unexpected sidecar",
-          labelNames: ["client"],
-        }),
-        notEnoughSidecarError: register.gauge<{client: string}>({
-          name: "lodestar_sync_unknown_block_download_by_root_not_enough_sidecar_error_total",
-          help: "Total number of downloadByRoot calls that returned not enough sidecars",
-          labelNames: ["client"],
-        }),
-        invalidInclusionProofError: register.gauge<{client: string}>({
-          name: "lodestar_sync_unknown_block_download_by_root_invalid_inclusion_proof_error_total",
-          help: "Total number of downloadByRoot calls that returned an invalid inclusion proof",
-          labelNames: ["client"],
-        }),
-        invalidKzgProofError: register.gauge<{client: string}>({
-          name: "lodestar_sync_unknown_block_download_by_root_invalid_kzg_proof_error_total",
-          help: "Total number of downloadByRoot calls that returned an invalid KZG proof",
-          labelNames: ["client"],
-        }),
-        missingBlockResponseError: register.gauge<{client: string}>({
-          name: "lodestar_sync_unknown_block_download_by_root_missing_block_response_error_total",
-          help: "Total number of downloadByRoot calls that returned a missing block response",
-          labelNames: ["client"],
-        }),
-        missingBlobResponseError: register.gauge<{client: string}>({
-          name: "lodestar_sync_unknown_block_download_by_root_missing_blob_response_error_total",
-          help: "Total number of downloadByRoot calls that returned a missing blob response",
-          labelNames: ["client"],
-        }),
-        missingColumnResponseError: register.gauge<{client: string}>({
-          name: "lodestar_sync_unknown_block_download_by_root_missing_column_response_error_total",
-          help: "Total number of downloadByRoot calls that returned a missing column response",
-          labelNames: ["client"],
-        }),
-        unknownError: register.gauge<{client: string}>({
-          name: "lodestar_sync_unknown_block_download_by_root_unknown_error_total",
-          help: "Total number of downloadByRoot calls that returned an unknown error",
-          labelNames: ["client"],
+          labelNames: ["code", "client"],
         }),
       },
       peerBalancer: {

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -527,30 +527,13 @@ export class BlockInputSync {
         const downloadByRootMetrics = this.metrics?.blockInputSync.downloadByRoot;
         if (e instanceof DownloadByRootError) {
           const errorCode = e.type.code;
-          downloadByRootMetrics?.error.inc({code: errorCode});
-          const metricForCode = {
-            [DownloadByRootErrorCode.MISMATCH_BLOCK_ROOT]: downloadByRootMetrics?.mismatchBlockRootError,
-            [DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED]: downloadByRootMetrics?.extraSidecarReceivedError,
-            [DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED]: downloadByRootMetrics?.notEnoughSidecarError,
-            [DownloadByRootErrorCode.INVALID_INCLUSION_PROOF]: downloadByRootMetrics?.invalidInclusionProofError,
-            [DownloadByRootErrorCode.INVALID_KZG_PROOF]: downloadByRootMetrics?.invalidKzgProofError,
-            [DownloadByRootErrorCode.MISSING_BLOCK_RESPONSE]: downloadByRootMetrics?.missingBlockResponseError,
-            [DownloadByRootErrorCode.MISSING_BLOB_RESPONSE]: downloadByRootMetrics?.missingBlobResponseError,
-            [DownloadByRootErrorCode.MISSING_COLUMN_RESPONSE]: downloadByRootMetrics?.missingColumnResponseError,
-          }[errorCode];
-
-          if (metricForCode) {
-            metricForCode.inc({client: peerClient});
-          } else {
-            // investigate if this happens
-            downloadByRootMetrics?.unknownError.inc({client: peerClient});
-          }
+          downloadByRootMetrics?.error.inc({code: errorCode, client: peerClient});
         } else if (e instanceof RequestError) {
           // should look into req_resp metrics in this case
-          downloadByRootMetrics?.error.inc({code: "req_resp"});
+          downloadByRootMetrics?.error.inc({code: "req_resp", client: peerClient});
         } else {
           // investigate if this happens
-          downloadByRootMetrics?.error.inc({code: "unknown"});
+          downloadByRootMetrics?.error.inc({code: "unknown", client: peerClient});
         }
       } finally {
         this.peerBalancer.onRequestCompleted(peerId);

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -26,8 +26,9 @@ import {
   getBlockInputSyncCacheItemSlot,
   isPendingBlockInput,
 } from "./types.js";
-import {downloadByRoot} from "./utils/downloadByRoot.js";
+import {DownloadByRootError, DownloadByRootErrorCode, downloadByRoot} from "./utils/downloadByRoot.js";
 import {getAllDescendantBlocks, getDescendantBlocks, getUnknownAndAncestorBlocks} from "./utils/pendingBlocksTree.js";
+import {RequestError} from "@lodestar/reqresp";
 
 const MAX_ATTEMPTS_PER_BLOCK = 5;
 const MAX_KNOWN_BAD_BLOCKS = 500;
@@ -516,12 +517,55 @@ export class BlockInputSync {
           peerMeta,
           cacheItem,
         });
+        this.metrics?.blockInputSync.downloadByRoot.success.inc();
       } catch (e) {
         this.logger.debug(
           "Error downloading in BlockInputSync.fetchBlockInput",
           {attempt: i, rootHex, peer: peerId, peerClient},
           e as Error
         );
+        const downloadByRootMetrics = this.metrics?.blockInputSync.downloadByRoot;
+        if (e instanceof DownloadByRootError) {
+          const errorCode = e.type.code;
+          const client = e.type.client;
+          downloadByRootMetrics?.error.inc({code: errorCode});
+          switch(errorCode) {
+            case DownloadByRootErrorCode.MISMATCH_BLOCK_ROOT:
+              downloadByRootMetrics?.mismatchBlockRootError.inc({client});
+              break;
+            case DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED:
+              downloadByRootMetrics?.extraSidecarReceivedError.inc({client});
+              break;
+            case DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED:
+              downloadByRootMetrics?.notEnoughSidecarError.inc({client});
+              break;
+            case DownloadByRootErrorCode.INVALID_INCLUSION_PROOF:
+              downloadByRootMetrics?.invalidInclusionProofError.inc({client});
+              break;
+            case DownloadByRootErrorCode.INVALID_KZG_PROOF:
+              downloadByRootMetrics?.invalidKzgProofError.inc({client});
+              break;
+            case DownloadByRootErrorCode.MISSING_BLOCK_RESPONSE:
+              downloadByRootMetrics?.missingBlockResponseError.inc({client});
+              break;
+            case DownloadByRootErrorCode.MISSING_BLOB_RESPONSE:
+              downloadByRootMetrics?.missingBlobResponseError.inc({client});
+              break;
+            case DownloadByRootErrorCode.MISSING_COLUMN_RESPONSE:
+              downloadByRootMetrics?.missingColumnResponseError.inc({client});
+              break;
+            default:
+              // investigate if this happens
+              downloadByRootMetrics?.unknownError.inc({client});
+              break;
+          }
+        } else if (e instanceof RequestError) {
+          // should look into req_resp metrics in this case
+          downloadByRootMetrics?.error.inc({code: "req_resp"});
+        } else {
+          // investigate if this happens
+          downloadByRootMetrics?.error.inc({code: "unknown"});
+        }
       } finally {
         this.peerBalancer.onRequestCompleted(peerId);
       }

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -529,35 +529,22 @@ export class BlockInputSync {
           const errorCode = e.type.code;
           const client = e.type.client;
           downloadByRootMetrics?.error.inc({code: errorCode});
-          switch(errorCode) {
-            case DownloadByRootErrorCode.MISMATCH_BLOCK_ROOT:
-              downloadByRootMetrics?.mismatchBlockRootError.inc({client});
-              break;
-            case DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED:
-              downloadByRootMetrics?.extraSidecarReceivedError.inc({client});
-              break;
-            case DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED:
-              downloadByRootMetrics?.notEnoughSidecarError.inc({client});
-              break;
-            case DownloadByRootErrorCode.INVALID_INCLUSION_PROOF:
-              downloadByRootMetrics?.invalidInclusionProofError.inc({client});
-              break;
-            case DownloadByRootErrorCode.INVALID_KZG_PROOF:
-              downloadByRootMetrics?.invalidKzgProofError.inc({client});
-              break;
-            case DownloadByRootErrorCode.MISSING_BLOCK_RESPONSE:
-              downloadByRootMetrics?.missingBlockResponseError.inc({client});
-              break;
-            case DownloadByRootErrorCode.MISSING_BLOB_RESPONSE:
-              downloadByRootMetrics?.missingBlobResponseError.inc({client});
-              break;
-            case DownloadByRootErrorCode.MISSING_COLUMN_RESPONSE:
-              downloadByRootMetrics?.missingColumnResponseError.inc({client});
-              break;
-            default:
-              // investigate if this happens
-              downloadByRootMetrics?.unknownError.inc({client});
-              break;
+          const metricForCode = {
+            [DownloadByRootErrorCode.MISMATCH_BLOCK_ROOT]: downloadByRootMetrics?.mismatchBlockRootError,
+            [DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED]: downloadByRootMetrics?.extraSidecarReceivedError,
+            [DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED]: downloadByRootMetrics?.notEnoughSidecarError,
+            [DownloadByRootErrorCode.INVALID_INCLUSION_PROOF]: downloadByRootMetrics?.invalidInclusionProofError,
+            [DownloadByRootErrorCode.INVALID_KZG_PROOF]: downloadByRootMetrics?.invalidKzgProofError,
+            [DownloadByRootErrorCode.MISSING_BLOCK_RESPONSE]: downloadByRootMetrics?.missingBlockResponseError,
+            [DownloadByRootErrorCode.MISSING_BLOB_RESPONSE]: downloadByRootMetrics?.missingBlobResponseError,
+            [DownloadByRootErrorCode.MISSING_COLUMN_RESPONSE]: downloadByRootMetrics?.missingColumnResponseError,
+          }[errorCode];
+
+          if (metricForCode) {
+            metricForCode.inc({client});
+          } else {
+            // investigate if this happens
+            downloadByRootMetrics?.unknownError.inc({client});
           }
         } else if (e instanceof RequestError) {
           // should look into req_resp metrics in this case

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -527,7 +527,6 @@ export class BlockInputSync {
         const downloadByRootMetrics = this.metrics?.blockInputSync.downloadByRoot;
         if (e instanceof DownloadByRootError) {
           const errorCode = e.type.code;
-          const client = e.type.client;
           downloadByRootMetrics?.error.inc({code: errorCode});
           const metricForCode = {
             [DownloadByRootErrorCode.MISMATCH_BLOCK_ROOT]: downloadByRootMetrics?.mismatchBlockRootError,
@@ -541,10 +540,10 @@ export class BlockInputSync {
           }[errorCode];
 
           if (metricForCode) {
-            metricForCode.inc({client});
+            metricForCode.inc({client: peerClient});
           } else {
             // investigate if this happens
-            downloadByRootMetrics?.unknownError.inc({client});
+            downloadByRootMetrics?.unknownError.inc({client: peerClient});
           }
         } else if (e instanceof RequestError) {
           // should look into req_resp metrics in this case

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -62,7 +62,7 @@ export async function downloadByRoot({
 }: DownloadByRootProps): Promise<PendingBlockInput> {
   const rootHex = getBlockInputSyncCacheItemRootHex(cacheItem);
   const blockRoot = fromHex(rootHex);
-  const {peerId: peerIdStr} = peerMeta;
+  const {peerId: peerIdStr, client} = peerMeta;
 
   const {block, blobSidecars, columnSidecars} = await fetchByRoot({
     config,
@@ -103,6 +103,7 @@ export async function downloadByRoot({
         code: DownloadByRootErrorCode.MISSING_BLOB_RESPONSE,
         blockRoot: prettyBytes(rootHex),
         peer: peerIdStr,
+        client,
       });
     }
     for (const blobSidecar of blobSidecars) {
@@ -123,6 +124,7 @@ export async function downloadByRoot({
         code: DownloadByRootErrorCode.MISSING_COLUMN_RESPONSE,
         blockRoot: prettyBytes(rootHex),
         peer: peerIdStr,
+        client,
       });
     }
     for (const columnSidecar of columnSidecars) {
@@ -269,6 +271,7 @@ export async function fetchAndValidateBlock({
     throw new DownloadByRootError({
       code: DownloadByRootErrorCode.MISSING_BLOCK_RESPONSE,
       peer: prettyPrintPeerIdStr(peerIdStr),
+      client,
       blockRoot: prettyBytes(blockRoot),
     });
   }
@@ -485,16 +488,19 @@ export type DownloadByRootErrorType =
   | {
       code: DownloadByRootErrorCode.MISSING_BLOCK_RESPONSE;
       peer: string;
+      client: string;
       blockRoot: string;
     }
   | {
       code: DownloadByRootErrorCode.MISSING_BLOB_RESPONSE;
       peer: string;
+      client: string;
       blockRoot: string;
     }
   | {
       code: DownloadByRootErrorCode.MISSING_COLUMN_RESPONSE;
       peer: string;
+      client: string;
       blockRoot: string;
     };
 

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -19,7 +19,6 @@ import {
   isPendingBlockInput,
 } from "../types.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
-import {PeerIdStr} from "../../util/peerId.js";
 
 export type FetchByRootCoreProps = {
   config: ChainForkConfig;
@@ -30,8 +29,7 @@ export type FetchByRootProps = FetchByRootCoreProps & {
   cacheItem: BlockInputSyncCacheItem;
   blockRoot: Uint8Array;
 };
-export type FetchByRootAndValidateBlockProps = Omit<FetchByRootCoreProps, "peerMeta"> & {
-  peerIdStr: PeerIdStr;
+export type FetchByRootAndValidateBlockProps = FetchByRootCoreProps & {
   blockRoot: Uint8Array;
 };
 export type FetchByRootAndValidateBlobsProps = FetchByRootAndValidateBlockProps & {
@@ -179,7 +177,7 @@ export async function fetchByRoot({
       block = await fetchAndValidateBlock({
         config,
         network,
-        peerIdStr,
+        peerMeta,
         blockRoot,
       });
     }
@@ -190,7 +188,7 @@ export async function fetchByRoot({
         blobSidecars = await fetchAndValidateBlobs({
           config,
           network,
-          peerIdStr,
+          peerMeta,
           forkName: forkName as ForkPreFulu,
           block: block as SignedBeaconBlock<ForkPostDeneb>,
           blockRoot,
@@ -213,7 +211,7 @@ export async function fetchByRoot({
     block = await fetchAndValidateBlock({
       config,
       network,
-      peerIdStr,
+      peerMeta,
       blockRoot,
     });
     const forkName = config.getForkName(block.message.slot);
@@ -238,7 +236,7 @@ export async function fetchByRoot({
       blobSidecars = await fetchAndValidateBlobs({
         config,
         network,
-        peerIdStr,
+        peerMeta,
         forkName: forkName as ForkPreFulu,
         blockRoot,
         block: block as SignedBeaconBlock<ForkPostDeneb>,
@@ -261,9 +259,10 @@ export async function fetchByRoot({
 export async function fetchAndValidateBlock({
   config,
   network,
-  peerIdStr,
+  peerMeta,
   blockRoot,
 }: FetchByRootAndValidateBlockProps): Promise<SignedBeaconBlock> {
+  const {peerId: peerIdStr, client} = peerMeta;
   const response = await network.sendBeaconBlocksByRoot(peerIdStr, [blockRoot]);
   const block = response.at(0)?.data;
   if (!block) {
@@ -279,6 +278,7 @@ export async function fetchAndValidateBlock({
       {
         code: DownloadByRootErrorCode.MISMATCH_BLOCK_ROOT,
         peer: prettyPrintPeerIdStr(peerIdStr),
+        client,
         requestedBlockRoot: prettyBytes(blockRoot),
         receivedBlockRoot: prettyBytes(toRootHex(receivedRoot)),
       },
@@ -292,14 +292,14 @@ export async function fetchAndValidateBlobs({
   config,
   network,
   forkName,
-  peerIdStr,
+  peerMeta,
   blockRoot,
   block,
   blobMeta,
 }: FetchByRootAndValidateBlobsProps): Promise<deneb.BlobSidecars> {
   const blobSidecars: deneb.BlobSidecars = await fetchBlobsByRoot({
       network,
-      peerIdStr,
+      peerMeta,
       blobMeta,
     });
 
@@ -310,12 +310,13 @@ export async function fetchAndValidateBlobs({
 
 export async function fetchBlobsByRoot({
   network,
-  peerIdStr,
+  peerMeta,
   blobMeta,
   indicesInPossession = [],
-}: Pick<FetchByRootAndValidateBlobsProps, "network" | "peerIdStr" | "blobMeta"> & {
+}: Pick<FetchByRootAndValidateBlobsProps, "network" | "peerMeta" | "blobMeta"> & {
   indicesInPossession?: number[];
 }): Promise<deneb.BlobSidecars> {
+  const {peerId: peerIdStr} = peerMeta;
   const blobsRequest = blobMeta
     .filter(({index}) => !indicesInPossession.includes(index))
     .map(({blockRoot, index}) => ({blockRoot, index}));
@@ -334,7 +335,7 @@ export async function fetchAndValidateColumns({
   blockRoot,
   columnMeta,
 }: FetchByRootAndValidateColumnsProps): Promise<fulu.DataColumnSidecars> {
-  const {peerId: peerIdStr} = peerMeta;
+  const {peerId: peerIdStr, client} = peerMeta;
   const slot = block.message.slot;
   const blobCount = block.message.body.blobKzgCommitments.length;
   if (blobCount === 0) {
@@ -354,6 +355,7 @@ export async function fetchAndValidateColumns({
       {
         code: DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED,
         peer: prettyPrintPeerIdStr(peerIdStr),
+        client,
         blockRoot: prettyBytes(blockRoot),
         missingIndices: prettyPrintIndices(requestedColumns.filter(c => !returnedColumns.has(c))),
       },
@@ -369,6 +371,7 @@ export async function fetchAndValidateColumns({
         {
           code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED,
           peer: prettyPrintPeerIdStr(peerIdStr),
+          client,
           blockRoot: prettyBytes(blockRoot),
           invalidIndex: columnSidecar.index,
         },
@@ -422,6 +425,7 @@ export async function validateColumnSidecars({
         {
           code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED,
           peer: prettyPrintPeerIdStr(peerMeta.peerId),
+          client: peerMeta.client,
           blockRoot: prettyBytes(blockRoot),
           invalidIndex: columnSidecar.index,
         },
@@ -447,30 +451,35 @@ export type DownloadByRootErrorType =
   | {
       code: DownloadByRootErrorCode.MISMATCH_BLOCK_ROOT;
       peer: string;
+      client: string;
       requestedBlockRoot: string;
       receivedBlockRoot: string;
     }
   | {
       code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED;
       peer: string;
+      client: string;
       blockRoot: string;
       invalidIndex: number;
     }
   | {
       code: DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED;
       peer: string;
+      client: string;
       blockRoot: string;
       missingIndices: string;
     }
   | {
       code: DownloadByRootErrorCode.INVALID_INCLUSION_PROOF;
       peer: string;
+      client: string;
       blockRoot: string;
       sidecarIndex: number;
     }
   | {
       code: DownloadByRootErrorCode.INVALID_KZG_PROOF;
       peer: string;
+      client: string;
       blockRoot: string;
     }
   | {

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -19,6 +19,7 @@ import {
   isPendingBlockInput,
 } from "../types.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
+import {PeerIdStr} from "../../util/peerId.js";
 
 export type FetchByRootCoreProps = {
   config: ChainForkConfig;
@@ -29,7 +30,8 @@ export type FetchByRootProps = FetchByRootCoreProps & {
   cacheItem: BlockInputSyncCacheItem;
   blockRoot: Uint8Array;
 };
-export type FetchByRootAndValidateBlockProps = FetchByRootCoreProps & {
+export type FetchByRootAndValidateBlockProps = Omit<FetchByRootCoreProps, "peerMeta"> & {
+  peerIdStr: PeerIdStr;
   blockRoot: Uint8Array;
 };
 export type FetchByRootAndValidateBlobsProps = FetchByRootAndValidateBlockProps & {
@@ -62,7 +64,7 @@ export async function downloadByRoot({
 }: DownloadByRootProps): Promise<PendingBlockInput> {
   const rootHex = getBlockInputSyncCacheItemRootHex(cacheItem);
   const blockRoot = fromHex(rootHex);
-  const {peerId: peerIdStr, client} = peerMeta;
+  const {peerId: peerIdStr} = peerMeta;
 
   const {block, blobSidecars, columnSidecars} = await fetchByRoot({
     config,
@@ -103,7 +105,6 @@ export async function downloadByRoot({
         code: DownloadByRootErrorCode.MISSING_BLOB_RESPONSE,
         blockRoot: prettyBytes(rootHex),
         peer: peerIdStr,
-        client,
       });
     }
     for (const blobSidecar of blobSidecars) {
@@ -124,7 +125,6 @@ export async function downloadByRoot({
         code: DownloadByRootErrorCode.MISSING_COLUMN_RESPONSE,
         blockRoot: prettyBytes(rootHex),
         peer: peerIdStr,
-        client,
       });
     }
     for (const columnSidecar of columnSidecars) {
@@ -179,7 +179,7 @@ export async function fetchByRoot({
       block = await fetchAndValidateBlock({
         config,
         network,
-        peerMeta,
+        peerIdStr,
         blockRoot,
       });
     }
@@ -190,7 +190,7 @@ export async function fetchByRoot({
         blobSidecars = await fetchAndValidateBlobs({
           config,
           network,
-          peerMeta,
+          peerIdStr,
           forkName: forkName as ForkPreFulu,
           block: block as SignedBeaconBlock<ForkPostDeneb>,
           blockRoot,
@@ -213,7 +213,7 @@ export async function fetchByRoot({
     block = await fetchAndValidateBlock({
       config,
       network,
-      peerMeta,
+      peerIdStr,
       blockRoot,
     });
     const forkName = config.getForkName(block.message.slot);
@@ -238,7 +238,7 @@ export async function fetchByRoot({
       blobSidecars = await fetchAndValidateBlobs({
         config,
         network,
-        peerMeta,
+        peerIdStr,
         forkName: forkName as ForkPreFulu,
         blockRoot,
         block: block as SignedBeaconBlock<ForkPostDeneb>,
@@ -261,17 +261,15 @@ export async function fetchByRoot({
 export async function fetchAndValidateBlock({
   config,
   network,
-  peerMeta,
+  peerIdStr,
   blockRoot,
 }: FetchByRootAndValidateBlockProps): Promise<SignedBeaconBlock> {
-  const {peerId: peerIdStr, client} = peerMeta;
   const response = await network.sendBeaconBlocksByRoot(peerIdStr, [blockRoot]);
   const block = response.at(0)?.data;
   if (!block) {
     throw new DownloadByRootError({
       code: DownloadByRootErrorCode.MISSING_BLOCK_RESPONSE,
       peer: prettyPrintPeerIdStr(peerIdStr),
-      client,
       blockRoot: prettyBytes(blockRoot),
     });
   }
@@ -281,7 +279,6 @@ export async function fetchAndValidateBlock({
       {
         code: DownloadByRootErrorCode.MISMATCH_BLOCK_ROOT,
         peer: prettyPrintPeerIdStr(peerIdStr),
-        client,
         requestedBlockRoot: prettyBytes(blockRoot),
         receivedBlockRoot: prettyBytes(toRootHex(receivedRoot)),
       },
@@ -295,14 +292,14 @@ export async function fetchAndValidateBlobs({
   config,
   network,
   forkName,
-  peerMeta,
+  peerIdStr,
   blockRoot,
   block,
   blobMeta,
 }: FetchByRootAndValidateBlobsProps): Promise<deneb.BlobSidecars> {
   const blobSidecars: deneb.BlobSidecars = await fetchBlobsByRoot({
       network,
-      peerMeta,
+      peerIdStr,
       blobMeta,
     });
 
@@ -313,13 +310,12 @@ export async function fetchAndValidateBlobs({
 
 export async function fetchBlobsByRoot({
   network,
-  peerMeta,
+  peerIdStr,
   blobMeta,
   indicesInPossession = [],
-}: Pick<FetchByRootAndValidateBlobsProps, "network" | "peerMeta" | "blobMeta"> & {
+}: Pick<FetchByRootAndValidateBlobsProps, "network" | "peerIdStr" | "blobMeta"> & {
   indicesInPossession?: number[];
 }): Promise<deneb.BlobSidecars> {
-  const {peerId: peerIdStr} = peerMeta;
   const blobsRequest = blobMeta
     .filter(({index}) => !indicesInPossession.includes(index))
     .map(({blockRoot, index}) => ({blockRoot, index}));
@@ -338,7 +334,7 @@ export async function fetchAndValidateColumns({
   blockRoot,
   columnMeta,
 }: FetchByRootAndValidateColumnsProps): Promise<fulu.DataColumnSidecars> {
-  const {peerId: peerIdStr, client} = peerMeta;
+  const {peerId: peerIdStr} = peerMeta;
   const slot = block.message.slot;
   const blobCount = block.message.body.blobKzgCommitments.length;
   if (blobCount === 0) {
@@ -358,7 +354,6 @@ export async function fetchAndValidateColumns({
       {
         code: DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED,
         peer: prettyPrintPeerIdStr(peerIdStr),
-        client,
         blockRoot: prettyBytes(blockRoot),
         missingIndices: prettyPrintIndices(requestedColumns.filter(c => !returnedColumns.has(c))),
       },
@@ -374,7 +369,6 @@ export async function fetchAndValidateColumns({
         {
           code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED,
           peer: prettyPrintPeerIdStr(peerIdStr),
-          client,
           blockRoot: prettyBytes(blockRoot),
           invalidIndex: columnSidecar.index,
         },
@@ -428,7 +422,6 @@ export async function validateColumnSidecars({
         {
           code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED,
           peer: prettyPrintPeerIdStr(peerMeta.peerId),
-          client: peerMeta.client,
           blockRoot: prettyBytes(blockRoot),
           invalidIndex: columnSidecar.index,
         },
@@ -454,53 +447,45 @@ export type DownloadByRootErrorType =
   | {
       code: DownloadByRootErrorCode.MISMATCH_BLOCK_ROOT;
       peer: string;
-      client: string;
       requestedBlockRoot: string;
       receivedBlockRoot: string;
     }
   | {
       code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED;
       peer: string;
-      client: string;
       blockRoot: string;
       invalidIndex: number;
     }
   | {
       code: DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED;
       peer: string;
-      client: string;
       blockRoot: string;
       missingIndices: string;
     }
   | {
       code: DownloadByRootErrorCode.INVALID_INCLUSION_PROOF;
       peer: string;
-      client: string;
       blockRoot: string;
       sidecarIndex: number;
     }
   | {
       code: DownloadByRootErrorCode.INVALID_KZG_PROOF;
       peer: string;
-      client: string;
       blockRoot: string;
     }
   | {
       code: DownloadByRootErrorCode.MISSING_BLOCK_RESPONSE;
       peer: string;
-      client: string;
       blockRoot: string;
     }
   | {
       code: DownloadByRootErrorCode.MISSING_BLOB_RESPONSE;
       peer: string;
-      client: string;
       blockRoot: string;
     }
   | {
       code: DownloadByRootErrorCode.MISSING_COLUMN_RESPONSE;
       peer: string;
-      client: string;
       blockRoot: string;
     };
 


### PR DESCRIPTION
**Motivation**

- there are a lot of DownloadByRoot errors happening on the logs that we want to know more about

**Description**

- track errors by code for all clients
- given a specific code, count errors by client

this will give us an overview of which clients have specific issues in order to work with them later
also may want to find mitigate some of them later (will need to monitor metrics)
