### PR TITLE
Update GitHub Actions in CI Workflows 

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -27,7 +27,7 @@ jobs:
             arch: arm64
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install arm64 specifics
         if: matrix.arch == 'arm64'
         run: |-

--- a/.github/workflows/build-debug-node.yml
+++ b/.github/workflows/build-debug-node.yml
@@ -18,7 +18,7 @@ jobs:
         run: apt-get install python3 g++ make python3-pip
 
       - name: Download Node.js source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with: 
           repository: 'nodejs/node'
           ref: 'v${{ github.event.inputs.version }}'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
           echo "Deploying ref: $DEPLOY_REF"
 
       # Checkout the correct ref being deployed
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.DEPLOY_REF }}
 

--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and run Kurtosis
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up Docker Buildx

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4
@@ -109,7 +109,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     needs: npm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish-nextfork.yml
+++ b/.github/workflows/publish-nextfork.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v4
@@ -112,7 +112,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     needs: npm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
     needs: [tag, binaries]
     if: needs.tag.outputs.is_rc == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Needs full depth for changelog generation
 

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -61,7 +61,7 @@ jobs:
     needs: [tag, binaries]
     if: needs.tag.outputs.is_stable == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Needs full depth for changelog generation
 
@@ -128,7 +128,7 @@ jobs:
     needs: [tag, npm]
     if: needs.tag.outputs.is_stable == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: scripts/await-release.sh ${{ needs.tag.outputs.tag }} latest 900
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU

--- a/.github/workflows/test-bun.yml
+++ b/.github/workflows/test-bun.yml
@@ -17,7 +17,7 @@ jobs:
     name: Unit Tests (Bun)
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test-sim-merge.yml
+++ b/.github/workflows/test-sim-merge.yml
@@ -26,7 +26,7 @@ jobs:
     name: Sim merge tests
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/setup-and-build"
         with:
           node: 22

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/setup-and-build"
         with:
           node: 22
@@ -39,7 +39,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/setup-and-build"
         with:
           node: 22
@@ -97,7 +97,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/setup-and-build"
         with:
           node: 22
@@ -126,7 +126,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/setup-and-build"
         with:
           node: 22
@@ -155,7 +155,7 @@ jobs:
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/setup-and-build"
         with:
           node: 22

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         node: [22]
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}
@@ -44,7 +44,7 @@ jobs:
       matrix:
         node: [22]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}
@@ -73,7 +73,7 @@ jobs:
       matrix:
         node: [22]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: "./.github/actions/setup-and-build"
         with:
@@ -94,7 +94,7 @@ jobs:
       matrix:
         node: [22]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}
@@ -134,7 +134,7 @@ jobs:
         node: [22]
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: "./.github/actions/setup-and-build"
         with:
@@ -171,7 +171,7 @@ jobs:
         node: [22]
     steps:
       # <common-build> - Uses YAML anchors in the future
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}
@@ -194,7 +194,7 @@ jobs:
       matrix:
         node: [22]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: "./.github/actions/setup-and-build"
         with:
           node: ${{ matrix.node }}


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0