### PR TITLE
fix: deduplicate slots to delete archived DatacolumnSidecars

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -174,20 +174,28 @@ export async function archiveBlocks(
       );
       const dataColumnSidecarsMinEpoch = currentEpoch - dataColumnSidecarsArchiveWindow;
       if (dataColumnSidecarsMinEpoch >= config.FULU_FORK_EPOCH) {
-        const slotsToDelete = (
-          await db.dataColumnSidecarArchive.keys({
-            lt: db.dataColumnSidecarArchive.getMaxKeyRaw(computeStartSlotAtEpoch(dataColumnSidecarsMinEpoch)),
-          })
-        ).map((p) => p.prefix);
+        const prefixedKeys = await db.dataColumnSidecarArchive.keys({
+          lt: db.dataColumnSidecarArchive.getMaxKeyRaw(computeStartSlotAtEpoch(dataColumnSidecarsMinEpoch)),
+        });
+        // for each slot there could be multiple dataColumnSidecar, so we need to deduplicate it
+        const slots = new Set<Slot>();
+        for (const {prefix} of prefixedKeys) {
+          slots.add(prefix);
+        }
 
+        const slotsToDelete = [...slots].sort((a, b) => a - b);
         if (slotsToDelete.length > 0) {
           await db.dataColumnSidecarArchive.deleteMany(slotsToDelete);
-          logger.verbose(`dataColumnSidecars prune: batchDelete range ${slotsToDelete[0]}..${slotsToDelete.at(-1)}`);
+          logger.verbose(
+            `dataColumnSidecars prune: slot range ${slotsToDelete[0]}..${slotsToDelete.at(-1)}, slots: ${slotsToDelete.length}, sidecars: ${prefixedKeys.length}`
+          );
         } else {
           logger.verbose(`dataColumnSidecars prune: no entries before epoch ${dataColumnSidecarsMinEpoch}`);
         }
       } else {
-        logger.verbose(`dataColumnSidecars pruning skipped: ${dataColumnSidecarsMinEpoch} is before fulu fork epoch`);
+        logger.verbose(
+          `dataColumnSidecars pruning skipped: ${dataColumnSidecarsMinEpoch} is before fulu fork epoch ${config.FULU_FORK_EPOCH}`
+        );
       }
     } else {
       logger.verbose("dataColumnSidecars pruning skipped: archiveDataEpochs set to Infinity");

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -181,9 +181,7 @@ export async function archiveBlocks(
         const slotsToDelete = [...new Set(prefixedKeys.map(({prefix}) => prefix))].sort((a, b) => a - b);
         if (slotsToDelete.length > 0) {
           await db.dataColumnSidecarArchive.deleteMany(slotsToDelete);
-          logger.verbose(
-            `dataColumnSidecars prune: slot range ${slotsToDelete[0]}..${slotsToDelete.at(-1)}, slots: ${slotsToDelete.length}, sidecars: ${prefixedKeys.length}`
-          );
+          `dataColumnSidecars prune slotRange=${prettyPrintIndices(slotsToDelete)}, numOfSlots=${slotsToDelete.length} totalNumOfSidecars=${prefixedKeys.length}`;
         } else {
           logger.verbose(`dataColumnSidecars prune: no entries before epoch ${dataColumnSidecarsMinEpoch}`);
         }
@@ -430,4 +428,7 @@ export function getNonCheckpointBlocks<T extends {slot: Slot}>(blocks: T[]): T[]
   }
 
   return nonCheckpointBlocks;
+}
+function prettyPrintIndices(slotsToDelete: number[]) {
+  throw new Error("Function not implemented.");
 }

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -178,12 +178,7 @@ export async function archiveBlocks(
           lt: db.dataColumnSidecarArchive.getMaxKeyRaw(computeStartSlotAtEpoch(dataColumnSidecarsMinEpoch)),
         });
         // for each slot there could be multiple dataColumnSidecar, so we need to deduplicate it
-        const slots = new Set<Slot>();
-        for (const {prefix} of prefixedKeys) {
-          slots.add(prefix);
-        }
-
-        const slotsToDelete = [...slots].sort((a, b) => a - b);
+        const slotsToDelete = [...new Set(prefixedKeys.map(({prefix}) => prefix))].sort((a, b) => a - b);
         if (slotsToDelete.length > 0) {
           await db.dataColumnSidecarArchive.deleteMany(slotsToDelete);
           logger.verbose(

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -5,7 +5,7 @@ import {IForkChoice} from "@lodestar/fork-choice";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot} from "@lodestar/types";
-import {Logger, fromHex, toRootHex} from "@lodestar/utils";
+import {Logger, fromHex, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {IBeaconDb} from "../../../db/index.js";
 import {BlockArchiveBatchPutBinaryItem} from "../../../db/repositories/index.js";
 import {ensureDir, writeIfNotExist} from "../../../util/file.js";
@@ -428,7 +428,4 @@ export function getNonCheckpointBlocks<T extends {slot: Slot}>(blocks: T[]): T[]
   }
 
   return nonCheckpointBlocks;
-}
-function prettyPrintIndices(slotsToDelete: number[]) {
-  throw new Error("Function not implemented.");
 }


### PR DESCRIPTION
**Motivation**

- fix `archiveBlocks.ts`: duplicate slots when delete DataColumnSidecars

**Description**

- deduplicate them
- improve logs
