### PR TITLE
chore: revise epoch transition metric bucket

### DIFF
--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -107,6 +107,7 @@ export class PrepareNextSlotScheduler {
       const precomputeEpochTransitionTimer = isEpochTransition
         ? this.metrics?.precomputeNextEpochTransition.duration.startTimer()
         : null;
+      const start = Date.now();
       // No need to wait for this or the clock drift
       // Pre Bellatrix: we only do precompute state transition for the last slot of epoch
       // For Bellatrix, we always do the `processSlots()` to prepare payload for the next slot
@@ -228,6 +229,7 @@ export class PrepareNextSlotScheduler {
           headSlot,
           prepareSlot,
           previousHits,
+          durationMs: Date.now() - start,
         });
 
         precomputeEpochTransitionTimer?.();

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1437,7 +1437,7 @@ export function createLodestarMetrics(
       duration: register.histogram({
         name: "lodestar_precompute_next_epoch_transition_duration_seconds",
         help: "Duration of precomputeNextEpochTransition, including epoch transition and hashTreeRoot",
-        buckets: [1, 2, 3, 4, 8],
+        buckets: [0.2, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 10],
       }),
     },
 

--- a/packages/state-transition/src/metrics.ts
+++ b/packages/state-transition/src/metrics.ts
@@ -16,8 +16,8 @@ export function getMetrics(register: MetricsRegister) {
     epochTransitionTime: register.histogram({
       name: "lodestar_stfn_epoch_transition_seconds",
       help: "Time to process a single epoch transition in seconds",
-      // Epoch transitions are 100ms on very fast clients, and average 800ms on heavy networks
-      buckets: [0.01, 0.05, 0.1, 0.2, 0.5, 0.75, 1, 1.25, 1.5, 3, 10],
+      // as of Sep 2025, on mainnet, epoch transition time of lodestar is never less than 0.5s, and it could be up to 3s
+      buckets: [0.2, 0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 10],
     }),
     epochTransitionCommitTime: register.histogram({
       name: "lodestar_stfn_epoch_transition_commit_seconds",


### PR DESCRIPTION
**Motivation**

- we want to know more details about the epoch transition time

**Description**

- revise metric bucket:
  - 0.01, 0.05, 0.1 is unrealistic even with state-transition-z
  - add more realistic buckets: 2, 2.5
  - sync that with `lodestar_precompute_next_epoch_transition_duration_seconds`
- also log epoch transition duration
