### PR TITLE
fix: don't log proposer boost reorg logs during sync

### DIFF
--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -285,8 +285,6 @@ export type ImportBlockOpts = {
   seenTimestampSec?: number;
   /** Set to true if persist block right at verification time */
   eagerPersistBlock?: boolean;
-  /** Set to true if the importing block is from gossip */
-  isGossipBlock?: boolean;
 };
 
 /**

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -386,7 +386,6 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         seenTimestampSec,
         // gossip block is validated, we want to process it asap
         eagerPersistBlock: true,
-        isGossipBlock: true,
       })
       .then(() => {
         // Returns the delay between the start of `block.slot` and `current time`


### PR DESCRIPTION
**Motivation**

We currently print proposer boost reorg related logs `Strong block detected ...` during sync but it's not relevant there as `shouldOverrideForkChoiceUpdate` will never return true if `block.slot < currentSlot`.

There is also an edge we currently don't handle since we only run proposer reorg checks if block is received through gossip but in theory (although unlikely in practice) we can also receive the block via req/resp (close to 0% on mainnet).

**Description**

- only run proposer boost reorg check if `block.slot >= currentSlot`
- do not emit logs if no checks are run, eg. during sync there is no reason to emit logs
- remove `isGossipBlock` flag to also check if receive block via req/resp, this also means we run the checks if receive block from api meaning we a previous proposer, we could additional check if we are previous proposer cache if we wanna handle that case explicitly