### PR TITLE
fix: bump discv5 to 11.0.4

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -94,7 +94,7 @@
   "dependencies": {
     "@chainsafe/as-sha256": "^1.2.0",
     "@chainsafe/blst": "^2.2.0",
-    "@chainsafe/discv5": "^11.0.3",
+    "@chainsafe/discv5": "^11.0.4",
     "@chainsafe/enr": "^5.0.1",
     "@chainsafe/libp2p-gossipsub": "^14.1.1",
     "@chainsafe/libp2p-noise": "^16.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "@chainsafe/bls-keygen": "^0.4.0",
     "@chainsafe/bls-keystore": "^3.1.0",
     "@chainsafe/blst": "^2.2.0",
-    "@chainsafe/discv5": "^11.0.3",
+    "@chainsafe/discv5": "^11.0.4",
     "@chainsafe/enr": "^5.0.1",
     "@chainsafe/persistent-merkle-tree": "^1.2.1",
     "@chainsafe/ssz": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,10 +550,10 @@
     "@chainsafe/blst-linux-x64-musl" "2.2.0"
     "@chainsafe/blst-win32-x64-msvc" "2.2.0"
 
-"@chainsafe/discv5@^11.0.3":
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/@chainsafe/discv5/-/discv5-11.0.3.tgz#0f53d2f8a7f015bf2c0c8d897c01e8cb5466c916"
-  integrity sha512-bDvpiHfg7th/YGoOx7+W6x/28kfE/Cob7uE0XWpyPMQ0RTmJmzMYMfT1eulg5unlggALABvKgsct/gQDQT/hFw==
+"@chainsafe/discv5@^11.0.4":
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/@chainsafe/discv5/-/discv5-11.0.4.tgz#77da0bef913ded936d97ca23a078de2034f2c94f"
+  integrity sha512-8bUqQXlh3+VBO3f3kzvFL0CLOeShZLjUexlmjCyfXfOgwpP1e46F4G6a9tneEEXaU+AMLPMz8uRCwtP/YsESbw==
   dependencies:
     "@chainsafe/enr" "^5.0.1"
     "@ethereumjs/rlp" "^5.0.2"


### PR DESCRIPTION
**Motivation**

Users reported in the v1.34.0 release that changes in the release created an issue when ipv6 and ipv4 ports were the same:

```
✖ Error: Timeout: Did not receive an init message from worker after 300000ms. Make sure the worker calls expose().
```

**Description**

This PR bumps discv5 from 11.0.3 to 11.0.4 which includes the fix to binding ipv4 and ipv6 on the same port in dual stack mode.
See: https://github.com/ChainSafe/discv5/pull/318