### PR TITLE
fix: add blocks to all BatchState

### DIFF
--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -55,8 +55,8 @@ export type BatchState =
   | AwaitingDownloadState
   | {status: BatchStatus.Downloading; peer: PeerIdStr; blocks: IBlockInput[]}
   | DownloadSuccessState
-  | {status: BatchStatus.Processing; attempt: Attempt}
-  | {status: BatchStatus.AwaitingValidation; attempt: Attempt};
+  | {status: BatchStatus.Processing; blocks: IBlockInput[]; attempt: Attempt}
+  | {status: BatchStatus.AwaitingValidation; blocks: IBlockInput[]; attempt: Attempt};
 
 export type BatchMetadata = {
   startEpoch: Epoch;
@@ -249,11 +249,6 @@ export class Batch {
   }
 
   getBlocks(): IBlockInput[] {
-    switch (this.state.status) {
-      case BatchStatus.AwaitingValidation:
-      case BatchStatus.Processing:
-        return [];
-    }
     return this.state.blocks;
   }
 
@@ -339,7 +334,7 @@ export class Batch {
     // that the data came from will be handled by the Attempt that goes for processing
     const peers = this.goodPeers;
     this.goodPeers = [];
-    this.state = {status: BatchStatus.Processing, attempt: {peers, hash}};
+    this.state = {status: BatchStatus.Processing, blocks, attempt: {peers, hash}};
     return blocks;
   }
 
@@ -351,7 +346,7 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.Processing));
     }
 
-    this.state = {status: BatchStatus.AwaitingValidation, attempt: this.state.attempt};
+    this.state = {status: BatchStatus.AwaitingValidation, blocks: this.state.blocks, attempt: this.state.attempt};
   }
 
   /**


### PR DESCRIPTION
**Motivation**

- there is OOM error in https://github.com/ChainSafe/lodestar/issues/8331#issuecomment-3274347065
- after latest fixes by @matthewkeil I found that we cannot get blocks after debug
<img width="1227" height="138" alt="Screenshot 2025-09-11 at 09 34 44" src="https://github.com/user-attachments/assets/cc3c162f-b726-4e79-946d-ed57317a3f61" />

the reason is at `AwaitingValidation` state there is no blocks at all


**Description**

- add blocks to all BatchState and transfer it over life cycle

Closes #8331

**Test result on devnet node 0**
- this shows that memory is stable now, also the "cache size" metric

<img width="1685" height="620" alt="Screenshot 2025-09-11 at 10 12 13" src="https://github.com/user-attachments/assets/6e4c2b6a-87e3-4256-bfbe-85bb88194b45" />

