### PR TITLE
feat: add imported columns by source metric

### DIFF
--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -799,6 +799,17 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
     return columns;
   }
 
+  getSampledColumnsWithSource(): ColumnWithSource[] {
+    const columns: ColumnWithSource[] = [];
+    for (const index of this.sampledColumns) {
+      const column = this.columnsCache.get(index);
+      if (column) {
+        columns.push(column);
+      }
+    }
+    return columns;
+  }
+
   getSampledColumns(): fulu.DataColumnSidecars {
     const columns: fulu.DataColumnSidecars = [];
     for (const index of this.sampledColumns) {

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -514,13 +514,13 @@ export async function importBlock(
 
   if (isBlockInputColumns(blockInput)) {
     for (const {source} of blockInput.getSampledColumnsWithSource()) {
-      this.metrics?.importBlock.blobsBySource.inc({blobsSource: source});
+      this.metrics?.importBlock.columnsBySource.inc({source});
     }
   }
 
   if (isBlockInputBlobs(blockInput)) {
     for (const {source} of blockInput.getAllBlobsWithSource()) {
-      this.metrics?.importBlock.columnsBySource.inc({source});
+      this.metrics?.importBlock.blobsBySource.inc({blobsSource: source});
     }
   }
 

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -36,7 +36,7 @@ import {ChainEvent, ReorgEventData} from "../emitter.js";
 import {ForkchoiceCaller} from "../forkChoice/index.js";
 import {REPROCESS_MIN_TIME_TO_NEXT_SLOT_SEC} from "../reprocess.js";
 import {toCheckpointHex} from "../stateCache/index.js";
-import {isBlockInputBlobs} from "./blockInput/blockInput.js";
+import {isBlockInputBlobs, isBlockInputColumns} from "./blockInput/blockInput.js";
 import {AttestationImportOpt, FullyVerifiedBlock, ImportBlockOpts} from "./types.js";
 import {getCheckpointFromState} from "./utils/checkpoint.js";
 import {writeBlockInputToDb} from "./writeBlockInputToDb.js";
@@ -512,9 +512,15 @@ export async function importBlock(
     );
   }
 
+  if (isBlockInputColumns(blockInput)) {
+    for (const {source} of blockInput.getSampledColumnsWithSource()) {
+      this.metrics?.importBlock.blobsBySource.inc({blobsSource: source});
+    }
+  }
+
   if (isBlockInputBlobs(blockInput)) {
     for (const {source} of blockInput.getAllBlobsWithSource()) {
-      this.metrics?.importBlock.blobsBySource.inc({blobsSource: source});
+      this.metrics?.importBlock.columnsBySource.inc({source});
     }
   }
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -845,6 +845,11 @@ export function createLodestarMetrics(
         help: "Total number of imported blobs by source",
         labelNames: ["blobsSource"],
       }),
+      columnsBySource: register.gauge<{source: BlockInputSource}>({
+        name: "lodestar_import_columns_by_source_total",
+        help: "Total number of imported columns (sampled columns) by source",
+        labelNames: ["source"],
+      }),
       notOverrideFcuReason: register.counter<{reason: NotReorgedReason}>({
         name: "lodestar_import_block_not_override_fcu_reason_total",
         help: "Reason why the fcu call is not suppressed during block import",


### PR DESCRIPTION
**Motivation**

- Investigation of #8377 

**Description**

- add `BlockInputColumns.getSampledColumnsWithSource` so we can only measure the sources of column sidecars which contributed to our waiting to import blocks
- add `lodestar_import_columns_by_source_total` to track the source of imported column sidecars
