### PR TITLE
fix: track getBlobsV2 calls via GetBlobsTracker

### DIFF
--- a/packages/beacon-node/src/chain/GetBlobsTracker.ts
+++ b/packages/beacon-node/src/chain/GetBlobsTracker.ts
@@ -1,0 +1,72 @@
+import {Logger} from "@lodestar/utils";
+import {IExecutionEngine} from "../execution/index.js";
+import {ChainEventEmitter} from "./emitter.js";
+import {Metrics} from "../metrics/metrics.js";
+import {ChainForkConfig} from "@lodestar/config";
+import {IBlockInput} from "./blocks/blockInput/index.js";
+import {getDataColumnSidecarsFromExecution} from "../util/execution.js";
+
+export type GetBlobsTrackerInit = {
+  logger: Logger;
+  executionEngine: IExecutionEngine;
+  emitter: ChainEventEmitter;
+  metrics: Metrics | null;
+  config: ChainForkConfig;
+};
+
+/**
+ * Tracks getBlobsV2 calls to the execution engine to avoid duplicate and multiple in-flight calls
+ */
+export class GetBlobsTracker {
+  logger: Logger;
+  executionEngine: IExecutionEngine;
+  emitter: ChainEventEmitter;
+  metrics: Metrics | null;
+  config: ChainForkConfig;
+
+  /**
+   * Track last attempted block root
+   *
+   * This is sufficient to avoid duplicate calls since we only call this
+   * function when we see a new block or data column sidecar from gossip.
+   */
+  lastBlockRootHex: string | null = null;
+  /** Track if a getBlobsV2 call is in-flight */
+  running = false;
+  // Preallocate buffers for getBlobsV2 RPC calls
+  // See https://github.com/ChainSafe/lodestar/pull/8282 for context
+  blobAndProofBuffers: Uint8Array[] = [];
+
+  constructor(init: GetBlobsTrackerInit) {
+    this.logger = init.logger;
+    this.executionEngine = init.executionEngine;
+    this.emitter = init.emitter;
+    this.metrics = init.metrics;
+    this.config = init.config;
+  }
+
+  triggerGetBlobs(blockInput: IBlockInput): void {
+    if (this.running) {
+      return;
+    }
+
+    if (this.lastBlockRootHex === blockInput.blockRootHex) {
+      return;
+    }
+
+    // We don't care about the outcome of this call,
+    // just that it has been triggered for this block root.
+    this.running = true;
+    this.lastBlockRootHex = blockInput.blockRootHex;
+    getDataColumnSidecarsFromExecution(
+      this.config,
+      this.executionEngine,
+      this.emitter,
+      blockInput,
+      this.metrics,
+      this.blobAndProofBuffers
+    ).finally(() => {
+      this.running = false;
+    });
+  }
+}

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -100,6 +100,7 @@ import {FIFOBlockStateCache} from "./stateCache/fifoBlockStateCache.js";
 import {InMemoryCheckpointStateCache} from "./stateCache/inMemoryCheckpointsCache.js";
 import {PersistentCheckpointStateCache} from "./stateCache/persistentCheckpointsCache.js";
 import {ValidatorMonitor} from "./validatorMonitor.js";
+import {GetBlobsTracker} from "./GetBlobsTracker.js";
 
 /**
  * The maximum number of cached produced results to keep in memory.
@@ -172,6 +173,8 @@ export class BeaconChain implements IBeaconChain {
   readonly blacklistedBlocks: Map<RootHex, Slot | null>;
 
   readonly serializedCache: SerializedCache;
+
+  readonly getBlobsTracker: GetBlobsTracker;
 
   readonly opts: IChainOptions;
 
@@ -393,6 +396,14 @@ export class BeaconChain implements IBeaconChain {
     this.emitter = emitter;
 
     this.serializedCache = new SerializedCache();
+
+    this.getBlobsTracker = new GetBlobsTracker({
+      logger,
+      executionEngine: this.executionEngine,
+      emitter,
+      metrics,
+      config,
+    });
 
     this.archiveStore = new ArchiveStore(
       {db, chain: this, logger: logger as LoggerNode, metrics},

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -63,6 +63,7 @@ import {SeenBlockAttesters} from "./seenCache/seenBlockAttesters.js";
 import {SeenBlockInput} from "./seenCache/seenGossipBlockInput.js";
 import {ShufflingCache} from "./shufflingCache.js";
 import {ValidatorMonitor} from "./validatorMonitor.js";
+import {GetBlobsTracker} from "./GetBlobsTracker.js";
 
 export {BlockType, type AssembledBlockType};
 export {type ProposerPreparationData};
@@ -139,6 +140,8 @@ export interface IBeaconChain {
   readonly blacklistedBlocks: Map<RootHex, Slot | null>;
   // Cache for serialized objects
   readonly serializedCache: SerializedCache;
+
+  readonly getBlobsTracker: GetBlobsTracker;
 
   readonly opts: IChainOptions;
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -73,7 +73,6 @@ import {sszDeserialize} from "../gossip/topic.js";
 import {INetwork} from "../interface.js";
 import {PeerAction} from "../peers/index.js";
 import {AggregatorTracker} from "./aggregatorTracker.js";
-import {getDataColumnSidecarsFromExecution} from "../../util/execution.js";
 import {DataColumnReconstructionError, recoverDataColumnSidecars} from "../../util/dataColumns.js";
 import {callInNextEventLoop} from "../../util/eventLoop.js";
 
@@ -393,7 +392,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         source: BlockInputSource.gossip,
       });
       // immediately attempt fetch of data columns from execution engine
-      getDataColumnSidecarsFromExecution(config, chain.executionEngine, chain.emitter, blockInput, metrics);
+      chain.getBlobsTracker.triggerGetBlobs(blockInput);
     } else {
       metrics?.blockInputFetchStats.totalDataAvailableBlockInputs.inc();
       metrics?.blockInputFetchStats.totalDataAvailableBlockInputBlobs.inc(
@@ -565,7 +564,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
           });
         });
         // immediately attempt fetch of data columns from execution engine
-        getDataColumnSidecarsFromExecution(config, chain.executionEngine, chain.emitter, blockInput, metrics);
+        chain.getBlobsTracker.triggerGetBlobs(blockInput);
       }
     },
 

--- a/packages/beacon-node/src/util/execution.ts
+++ b/packages/beacon-node/src/util/execution.ts
@@ -13,104 +13,90 @@ import {isBlockInputColumns} from "../chain/blocks/blockInput/blockInput.js";
 import {ForkPostFulu} from "@lodestar/params";
 import {BLOB_AND_PROOF_V2_RPC_BYTES} from "../execution/engine/types.js";
 
-let running = false;
-// Preallocate buffers for getBlobsV2 RPC calls
-// See https://github.com/ChainSafe/lodestar/pull/8282 for context
-const blobAndProofBuffers: Uint8Array[] = [];
-
 /**
  * Post fulu, call getBlobsV2 from execution engine once per slot whenever we see either beacon_block or data_column_sidecar gossip message
- * Only a single call can be in-flight at a time, subsequent calls are ignored
  */
 export async function getDataColumnSidecarsFromExecution(
   config: ChainForkConfig,
   executionEngine: IExecutionEngine,
   emitter: ChainEventEmitter,
   blockInput: IBlockInput,
-  metrics: Metrics | null
+  metrics: Metrics | null,
+  blobAndProofBuffers?: Uint8Array[]
 ): Promise<void> {
-  try {
-    if (running) {
-      return;
-    }
-    running = true;
+  // If its not a column block input, exit
+  if (!isBlockInputColumns(blockInput)) {
+    return;
+  }
 
-    // If its not a column block input, exit
-    if (!isBlockInputColumns(blockInput)) {
-      return;
-    }
+  // If already have all columns, exit
+  if (blockInput.hasAllData()) {
+    return;
+  }
 
-    // If already have all columns, exit
-    if (blockInput.hasAllData()) {
-      return;
-    }
+  const versionedHashes = blockInput.getVersionedHashes();
 
-    const versionedHashes = blockInput.getVersionedHashes();
+  // If there are no blobs in this block, exit
+  if (versionedHashes.length === 0) {
+    return;
+  }
 
-    // If there are no blobs in this block, exit
-    if (versionedHashes.length === 0) {
-      return;
-    }
-
-    // Get blobs from execution engine
-    metrics?.peerDas.getBlobsV2Requests.inc();
-    const timer = metrics?.peerDas.getBlobsV2RequestDuration.startTimer();
-    if (blobAndProofBuffers) {
-      for (let i = 0; i < versionedHashes.length; i++) {
-        if (blobAndProofBuffers[i] === undefined) {
-          blobAndProofBuffers[i] = new Uint8Array(BLOB_AND_PROOF_V2_RPC_BYTES);
-        }
+  // Get blobs from execution engine
+  metrics?.peerDas.getBlobsV2Requests.inc();
+  const timer = metrics?.peerDas.getBlobsV2RequestDuration.startTimer();
+  if (blobAndProofBuffers) {
+    for (let i = 0; i < versionedHashes.length; i++) {
+      if (blobAndProofBuffers[i] === undefined) {
+        blobAndProofBuffers[i] = new Uint8Array(BLOB_AND_PROOF_V2_RPC_BYTES);
       }
     }
-    const blobs = await executionEngine.getBlobs(
-      blockInput.forkName as ForkPostFulu,
-      versionedHashes,
-      blobAndProofBuffers
-    );
-    timer?.();
-
-    // Execution engine was unable to find one or more blobs
-    if (blobs === null) {
-      return;
-    }
-    metrics?.peerDas.getBlobsV2Responses.inc();
-
-    // Return if we received all data columns while waiting for getBlobs
-    if (blockInput.hasAllData()) {
-      return;
-    }
-
-    let dataColumnSidecars: fulu.DataColumnSidecars;
-    const cellsAndProofs = await getCellsAndProofs(blobs);
-    if (blockInput.hasBlock()) {
-      dataColumnSidecars = getDataColumnSidecarsFromBlock(
-        config,
-        blockInput.getBlock() as fulu.SignedBeaconBlock,
-        cellsAndProofs
-      );
-    } else {
-      const firstSidecar = blockInput.getAllColumns()[0];
-      dataColumnSidecars = getDataColumnSidecarsFromColumnSidecar(firstSidecar, cellsAndProofs);
-    }
-
-    // Publish columns if and only if subscribed to them
-    const previouslyMissingColumns = blockInput.getMissingSampledColumnMeta().missing;
-    const sampledColumns = previouslyMissingColumns.map((columnIndex) => dataColumnSidecars[columnIndex]);
-
-    // for columns that we already seen, it will be ignored through `ignoreDuplicatePublishError` gossip option
-    emitter.emit(ChainEvent.publishDataColumns, sampledColumns);
-
-    // add all sampled columns to the block input, even if we didn't sample them
-    const seenTimestampSec = Date.now() / 1000;
-    for (const columnSidecar of sampledColumns) {
-      blockInput.addColumn(
-        {columnSidecar, blockRootHex: blockInput.blockRootHex, source: BlockInputSource.engine, seenTimestampSec},
-        {throwOnDuplicateAdd: false} // columns may have been added while waiting
-      );
-    }
-
-    metrics?.dataColumns.bySource.inc({source: BlockInputSource.engine}, previouslyMissingColumns.length);
-  } finally {
-    running = false;
   }
+  const blobs = await executionEngine.getBlobs(
+    blockInput.forkName as ForkPostFulu,
+    versionedHashes,
+    blobAndProofBuffers
+  );
+  timer?.();
+
+  // Execution engine was unable to find one or more blobs
+  if (blobs === null) {
+    return;
+  }
+  metrics?.peerDas.getBlobsV2Responses.inc();
+
+  // Return if we received all data columns while waiting for getBlobs
+  if (blockInput.hasAllData()) {
+    return;
+  }
+
+  let dataColumnSidecars: fulu.DataColumnSidecars;
+  const cellsAndProofs = await getCellsAndProofs(blobs);
+  if (blockInput.hasBlock()) {
+    dataColumnSidecars = getDataColumnSidecarsFromBlock(
+      config,
+      blockInput.getBlock() as fulu.SignedBeaconBlock,
+      cellsAndProofs
+    );
+  } else {
+    const firstSidecar = blockInput.getAllColumns()[0];
+    dataColumnSidecars = getDataColumnSidecarsFromColumnSidecar(firstSidecar, cellsAndProofs);
+  }
+
+  // Publish columns if and only if subscribed to them
+  const previouslyMissingColumns = blockInput.getMissingSampledColumnMeta().missing;
+  const sampledColumns = previouslyMissingColumns.map((columnIndex) => dataColumnSidecars[columnIndex]);
+
+  // for columns that we already seen, it will be ignored through `ignoreDuplicatePublishError` gossip option
+  emitter.emit(ChainEvent.publishDataColumns, sampledColumns);
+
+  // add all sampled columns to the block input, even if we didn't sample them
+  const seenTimestampSec = Date.now() / 1000;
+  for (const columnSidecar of sampledColumns) {
+    blockInput.addColumn(
+      {columnSidecar, blockRootHex: blockInput.blockRootHex, source: BlockInputSource.engine, seenTimestampSec},
+      {throwOnDuplicateAdd: false} // columns may have been added while waiting
+    );
+  }
+
+  metrics?.dataColumns.bySource.inc({source: BlockInputSource.engine}, previouslyMissingColumns.length);
 }


### PR DESCRIPTION
**Motivation**

- Lots of getBlobsV2 calls, causing bad sidecar validation times
<img width="961" height="313" alt="Screenshot from 2025-09-11 08-38-34" src="https://github.com/user-attachments/assets/2c9d8eb8-1ac3-4b57-8586-7999c7065dc3" />
<img width="961" height="313" alt="Screenshot from 2025-09-11 08-38-40" src="https://github.com/user-attachments/assets/4ee04fd0-5ab4-4b02-b4ef-6d34a959de46" />
<img width="969" height="243" alt="Screenshot from 2025-09-11 08-44-55" src="https://github.com/user-attachments/assets/565880ed-e96f-4df8-bda4-372aa5d14a5b" />
<img width="969" height="243" alt="Screenshot from 2025-09-11 08-45-03" src="https://github.com/user-attachments/assets/cc1111ff-14cd-4597-9be7-79054c375e37" />


**Description**
- Add simple class to track when getBlobsV2 is called and for which block.