### PR TITLE
feat: add ColumnReconstructionTracker

### DIFF
--- a/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
+++ b/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
@@ -1,0 +1,72 @@
+import {Logger, sleep} from "@lodestar/utils";
+import {ChainEventEmitter} from "./emitter.js";
+import {Metrics} from "../metrics/metrics.js";
+import {ChainForkConfig} from "@lodestar/config";
+import {BlockInputColumns} from "./blocks/blockInput/index.js";
+import {recoverDataColumnSidecars} from "../util/dataColumns.js";
+
+/**
+ * Minimum time to wait before attempting reconstruction
+ */
+const RECONSTRUCTION_DELAY_MIN_MS = 800;
+
+/**
+ * Maximum time to wait before attempting reconstruction
+ */
+const RECONSTRUCTION_DELAY_MAX_MS = 1200;
+
+export type ColumnRecontructionTrackerInit = {
+  logger: Logger;
+  emitter: ChainEventEmitter;
+  metrics: Metrics | null;
+  config: ChainForkConfig;
+};
+
+/**
+ * Tracks column reconstruction attempts to avoid duplicate and multiple in-flight calls
+ */
+export class ColumnReconstructionTracker {
+  logger: Logger;
+  emitter: ChainEventEmitter;
+  metrics: Metrics | null;
+  config: ChainForkConfig;
+
+  /**
+   * Track last attempted block root
+   *
+   * This is sufficient to avoid duplicate calls since we only call this
+   * function when we see a new data column sidecar from gossip.
+   */
+  lastBlockRootHex: string | null = null;
+  /** Track if a reconstruction attempt is in-flight */
+  running = false;
+
+  constructor(init: ColumnRecontructionTrackerInit) {
+    this.logger = init.logger;
+    this.emitter = init.emitter;
+    this.metrics = init.metrics;
+    this.config = init.config;
+  }
+
+  triggerColumnReconstruction(blockInput: BlockInputColumns): void {
+    if (this.running) {
+      return;
+    }
+
+    if (this.lastBlockRootHex === blockInput.blockRootHex) {
+      return;
+    }
+
+    // We don't care about the outcome of this call,
+    // just that it has been triggered for this block root.
+    this.running = true;
+    this.lastBlockRootHex = blockInput.blockRootHex;
+    const delay =
+      RECONSTRUCTION_DELAY_MIN_MS + Math.random() * (RECONSTRUCTION_DELAY_MAX_MS - RECONSTRUCTION_DELAY_MIN_MS);
+    sleep(delay).then(() => {
+      recoverDataColumnSidecars(blockInput, this.emitter, this.metrics).finally(() => {
+        this.running = false;
+      });
+    });
+  }
+}

--- a/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
+++ b/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
@@ -15,7 +15,7 @@ const RECONSTRUCTION_DELAY_MIN_MS = 800;
  */
 const RECONSTRUCTION_DELAY_MAX_MS = 1200;
 
-export type ColumnRecontructionTrackerInit = {
+export type ColumnReconstructionTrackerInit = {
   logger: Logger;
   emitter: ChainEventEmitter;
   metrics: Metrics | null;
@@ -41,7 +41,7 @@ export class ColumnReconstructionTracker {
   /** Track if a reconstruction attempt is in-flight */
   running = false;
 
-  constructor(init: ColumnRecontructionTrackerInit) {
+  constructor(init: ColumnReconstructionTrackerInit) {
     this.logger = init.logger;
     this.emitter = init.emitter;
     this.metrics = init.metrics;

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -101,6 +101,7 @@ import {InMemoryCheckpointStateCache} from "./stateCache/inMemoryCheckpointsCach
 import {PersistentCheckpointStateCache} from "./stateCache/persistentCheckpointsCache.js";
 import {ValidatorMonitor} from "./validatorMonitor.js";
 import {GetBlobsTracker} from "./GetBlobsTracker.js";
+import {ColumnReconstructionTracker} from "./ColumnReconstructionTracker.js";
 
 /**
  * The maximum number of cached produced results to keep in memory.
@@ -175,6 +176,7 @@ export class BeaconChain implements IBeaconChain {
   readonly serializedCache: SerializedCache;
 
   readonly getBlobsTracker: GetBlobsTracker;
+  readonly columnReconstructionTracker: ColumnReconstructionTracker;
 
   readonly opts: IChainOptions;
 
@@ -400,6 +402,12 @@ export class BeaconChain implements IBeaconChain {
     this.getBlobsTracker = new GetBlobsTracker({
       logger,
       executionEngine: this.executionEngine,
+      emitter,
+      metrics,
+      config,
+    });
+    this.columnReconstructionTracker = new ColumnReconstructionTracker({
+      logger,
       emitter,
       metrics,
       config,

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -64,6 +64,7 @@ import {SeenBlockInput} from "./seenCache/seenGossipBlockInput.js";
 import {ShufflingCache} from "./shufflingCache.js";
 import {ValidatorMonitor} from "./validatorMonitor.js";
 import {GetBlobsTracker} from "./GetBlobsTracker.js";
+import {ColumnReconstructionTracker} from "./ColumnReconstructionTracker.js";
 
 export {BlockType, type AssembledBlockType};
 export {type ProposerPreparationData};
@@ -142,6 +143,7 @@ export interface IBeaconChain {
   readonly serializedCache: SerializedCache;
 
   readonly getBlobsTracker: GetBlobsTracker;
+  readonly columnReconstructionTracker: ColumnReconstructionTracker;
 
   readonly opts: IChainOptions;
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -769,11 +769,6 @@ export function createLodestarMetrics(
       }),
     },
     recoverDataColumnSidecars: {
-      elapsedTimeTillReconstructed: register.histogram({
-        name: "lodestar_data_column_sidecar_elapsed_time_till_reconstructed_seconds",
-        help: "Time elapsed between block slot time and the time data column sidecar reconstructed",
-        buckets: [2, 4, 6, 8, 10, 12],
-      }),
       recoverTime: register.histogram({
         name: "lodestar_recover_data_column_sidecar_recover_time_seconds",
         help: "Time elapsed to recover data column sidecar",

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -22,7 +22,13 @@ import {
   sszTypesFor,
 } from "@lodestar/types";
 import {LogLevel, Logger, prettyBytes, toHex, toRootHex} from "@lodestar/utils";
-import {BlockInput, BlockInputSource, IBlockInput, isBlockInputColumns} from "../../chain/blocks/blockInput/index.js";
+import {
+  BlockInput,
+  BlockInputColumns,
+  BlockInputSource,
+  IBlockInput,
+  isBlockInputColumns,
+} from "../../chain/blocks/blockInput/index.js";
 import {BlobSidecarValidation} from "../../chain/blocks/types.js";
 import {ChainEvent} from "../../chain/emitter.js";
 import {
@@ -73,8 +79,6 @@ import {sszDeserialize} from "../gossip/topic.js";
 import {INetwork} from "../interface.js";
 import {PeerAction} from "../peers/index.js";
 import {AggregatorTracker} from "./aggregatorTracker.js";
-import {DataColumnReconstructionError, recoverDataColumnSidecars} from "../../util/dataColumns.js";
-import {callInNextEventLoop} from "../../util/eventLoop.js";
 
 /**
  * Gossip handler options as part of network options
@@ -282,7 +286,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
     gossipSubnet: SubnetID,
     peerIdStr: string,
     seenTimestampSec: number
-  ): Promise<BlockInput> {
+  ): Promise<BlockInputColumns> {
     metrics?.peerDas.dataColumnSidecarProcessingRequests.inc();
     const dataColumnBlockHeader = dataColumnSidecar.signedBlockHeader.message;
     const slot = dataColumnBlockHeader.slot;
@@ -315,27 +319,6 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         seenTimestampSec,
         peerIdStr,
       });
-
-      // only triggers reconstruction on the 64th column to deduplicate the expensive request
-      if (blockInput.columnCount === NUMBER_OF_COLUMNS / 2) {
-        // do not await to block gossip handler
-        callInNextEventLoop(() => {
-          recoverDataColumnSidecars(blockInput, chain.clock, metrics).catch((err) => {
-            if (err instanceof DataColumnReconstructionError) {
-              metrics?.recoverDataColumnSidecars.reconstructionResult.inc({
-                result: err.type.code,
-              });
-            }
-            logger.debug(
-              "Error recovering column sidecars",
-              {
-                blockRoot: blockRootHex,
-              },
-              err
-            );
-          });
-        });
-      }
 
       const recvToValidation = Date.now() / 1000 - seenTimestampSec;
       const validationTime = recvToValidation - recvToValLatency;
@@ -578,6 +561,10 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         });
         // immediately attempt fetch of data columns from execution engine
         chain.getBlobsTracker.triggerGetBlobs(blockInput);
+        // if we've received at least half of the columns, trigger reconstruction of the rest
+        if (blockInput.columnCount >= NUMBER_OF_COLUMNS / 2) {
+          chain.columnReconstructionTracker.triggerColumnReconstruction(blockInput);
+        }
       }
     },
 

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -20,8 +20,8 @@ import {kzg} from "./kzg.js";
 import {dataColumnMatrixRecovery} from "./blobs.js";
 import {BlockInputColumns} from "../chain/blocks/blockInput/blockInput.js";
 import {Metrics} from "../metrics/metrics.js";
-import {IClock} from "./clock.js";
 import {BlockInputSource} from "../chain/blocks/blockInput/types.js";
+import {ChainEvent, ChainEventEmitter} from "../chain/emitter.js";
 
 export enum RecoverResult {
   // the recover is not attempted because we have less than `NUMBER_OF_COLUMNS / 2` columns
@@ -342,14 +342,17 @@ export function getDataColumnSidecarsFromColumnSidecar(
  */
 export async function recoverDataColumnSidecars(
   blockInput: BlockInputColumns,
-  clock: IClock,
+  emitter: ChainEventEmitter,
   metrics: Metrics | null
 ): Promise<void> {
   const existingColumns = blockInput.getAllColumns();
   const columnCount = existingColumns.length;
   if (columnCount >= NUMBER_OF_COLUMNS) {
     // We have all columns
-    throw new DataColumnReconstructionError({code: DataColumnReconstructionCode.NotAttemptedAlreadyFull});
+    metrics?.recoverDataColumnSidecars.reconstructionResult.inc({
+      result: DataColumnReconstructionCode.NotAttemptedAlreadyFull,
+    });
+    return;
   }
 
   if (columnCount < NUMBER_OF_COLUMNS / 2) {
@@ -378,19 +381,20 @@ export async function recoverDataColumnSidecars(
     );
   }
 
-  const firstDataColumn = existingColumns.at(0);
-  if (firstDataColumn) {
-    const slot = firstDataColumn.signedBlockHeader.message.slot;
-    const secFromSlot = clock.secFromSlot(slot);
-    metrics?.recoverDataColumnSidecars.elapsedTimeTillReconstructed.observe(secFromSlot);
-  }
-
   if (blockInput.getAllColumns().length === NUMBER_OF_COLUMNS) {
     // either gossip or getBlobsV2 resolved availability while we were recovering
     throw new DataColumnReconstructionError({code: DataColumnReconstructionCode.ReceivedAllDuringReconstruction});
   }
 
-  // We successfully recovered the data columns, update the cache
+  // Once the node obtains a column through reconstruction,
+  // the node MUST expose the new column as if it had received it over the network.
+  // If the node is subscribed to the subnet corresponding to the column,
+  // it MUST send the reconstructed DataColumnSidecar to its topic mesh neighbors.
+  // If instead the node is not subscribed to the corresponding subnet,
+  // it SHOULD still expose the availability of the DataColumnSidecar as part of the gossip emission process.
+  // After exposing the reconstructed DataColumnSidecar to the network,
+  // the node MAY delete the DataColumnSidecar if it is not part of the node's custody requirement.
+  const sidecarsToPublish = [];
   for (const columnSidecar of fullSidecars) {
     if (!blockInput.hasColumn(columnSidecar.index)) {
       blockInput.addColumn({
@@ -399,8 +403,10 @@ export async function recoverDataColumnSidecars(
         seenTimestampSec: Date.now(),
         source: BlockInputSource.recovery,
       });
+      sidecarsToPublish.push(columnSidecar);
     }
   }
+  emitter.emit(ChainEvent.publishDataColumns, sidecarsToPublish);
 
   metrics?.recoverDataColumnSidecars.reconstructionResult.inc({result: DataColumnReconstructionCode.Success});
 }
@@ -415,7 +421,6 @@ export enum DataColumnReconstructionCode {
 
 type DataColumnReconstructionErrorType = {
   code:
-    | DataColumnReconstructionCode.NotAttemptedAlreadyFull
     | DataColumnReconstructionCode.NotAttemptedHaveLessThanHalf
     | DataColumnReconstructionCode.ReceivedAllDuringReconstruction
     | DataColumnReconstructionCode.ReconstructionFailed;

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -357,7 +357,10 @@ export async function recoverDataColumnSidecars(
 
   if (columnCount < NUMBER_OF_COLUMNS / 2) {
     // We don't have enough columns to recover
-    throw new DataColumnReconstructionError({code: DataColumnReconstructionCode.NotAttemptedHaveLessThanHalf});
+    metrics?.recoverDataColumnSidecars.reconstructionResult.inc({
+      result: DataColumnReconstructionCode.NotAttemptedHaveLessThanHalf,
+    });
+    return;
   }
 
   metrics?.recoverDataColumnSidecars.custodyBeforeReconstruction.set(columnCount);
@@ -372,18 +375,21 @@ export async function recoverDataColumnSidecars(
 
   const timer = metrics?.recoverDataColumnSidecars.recoverTime.startTimer();
   // if this function throws, we catch at the consumer side
-  const fullSidecars = await dataColumnMatrixRecovery(partialSidecars);
+  const fullSidecars = await dataColumnMatrixRecovery(partialSidecars).catch(() => null);
   timer?.();
   if (fullSidecars == null) {
-    throw new DataColumnReconstructionError(
-      {code: DataColumnReconstructionCode.ReconstructionFailed},
-      "No sidecars rebuilt via dataColumnMatrixRecovery"
-    );
+    metrics?.recoverDataColumnSidecars.reconstructionResult.inc({
+      result: DataColumnReconstructionCode.ReconstructionFailed,
+    });
+    return;
   }
 
   if (blockInput.getAllColumns().length === NUMBER_OF_COLUMNS) {
     // either gossip or getBlobsV2 resolved availability while we were recovering
-    throw new DataColumnReconstructionError({code: DataColumnReconstructionCode.ReceivedAllDuringReconstruction});
+    metrics?.recoverDataColumnSidecars.reconstructionResult.inc({
+      result: DataColumnReconstructionCode.ReceivedAllDuringReconstruction,
+    });
+    return;
   }
 
   // Once the node obtains a column through reconstruction,


### PR DESCRIPTION
**Motivation**

- investigation of block input metrics

**Description**

- Add ColumnReconstructionTracker (to avoid duplicate and multiple in-flight calls)
- Add delay before reconstruction (configurable via file constants)
- Publish all newly seen columns from reconstruction
- Track in metrics when reconstruction is skipped due to having all columns