### PR TITLE
feat: relaxed data column response handler

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -506,6 +506,11 @@ export function createLodestarMetrics(
           help: "Total number of errored downloadByRange calls",
           labelNames: ["code", "client"],
         }),
+        warn: register.gauge<{code: string; client: string}>({
+          name: "lodestar_sync_range_download_by_range_warn_total",
+          help: "Total number of warned downloadByRange calls",
+          labelNames: ["code", "client"],
+        }),
       },
     },
 
@@ -571,6 +576,11 @@ export function createLodestarMetrics(
         error: register.gauge<{code: string; client: string}>({
           name: "lodestar_sync_unknown_block_download_by_root_error_total",
           help: "Total number of errored downloadByRoot calls",
+          labelNames: ["code", "client"],
+        }),
+        warn: register.gauge<{code: string; client: string}>({
+          name: "lodestar_sync_unknown_block_download_by_root_warn_total",
+          help: "Total number of warned downloadByRoot calls",
           labelNames: ["code", "client"],
         }),
       },

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -508,7 +508,7 @@ export function createLodestarMetrics(
         }),
         warn: register.gauge<{code: string; client: string}>({
           name: "lodestar_sync_range_download_by_range_warn_total",
-          help: "Total number of warned downloadByRange calls",
+          help: "Total number of downloadByRange call warnings",
           labelNames: ["code", "client"],
         }),
       },
@@ -580,7 +580,7 @@ export function createLodestarMetrics(
         }),
         warn: register.gauge<{code: string; client: string}>({
           name: "lodestar_sync_unknown_block_download_by_root_warn_total",
-          help: "Total number of warned downloadByRoot calls",
+          help: "Total number of downloadByRoot call warnings",
           labelNames: ["code", "client"],
         }),
       },

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -509,19 +509,19 @@ export class SyncChain {
         );
         batch.downloadingError(peer.peerId); // Throws after MAX_DOWNLOAD_ATTEMPTS
       } else {
-        const {warn: warns, result} = res.result;
+        const {warnings, result} = res.result;
         const downloadSuccessOutput = batch.downloadingSuccess(peer.peerId, result);
         const logMeta: Record<string, number> = {
           blockCount: downloadSuccessOutput.blocks.length,
         };
 
-        if (warns && warns.length > 0) {
-          for (const warn of warns) {
-            this.metrics?.syncRange.downloadByRange.warn.inc({client: peer.client, code: warn.type.code});
+        if (warnings && warnings.length > 0) {
+          for (const warning of warnings) {
+            this.metrics?.syncRange.downloadByRange.warn.inc({client: peer.client, code: warning.type.code});
             this.logger.debug(
               "Batch downloaded with warning",
               {id: this.logId, epoch: batch.startEpoch, ...logMeta, peer: prettyPrintPeerIdStr(peer.peerId)},
-              warn
+              warning
             );
           }
         } else {

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -509,6 +509,12 @@ export class SyncChain {
         );
         batch.downloadingError(peer.peerId); // Throws after MAX_DOWNLOAD_ATTEMPTS
       } else {
+        this.logger.verbose("Batch download success", {
+          id: this.logId,
+          ...batch.getMetadata(),
+          peer: prettyPrintPeerIdStr(peer.peerId),
+        });
+        this.metrics?.syncRange.downloadByRange.success.inc();
         const {warnings, result} = res.result;
         const downloadSuccessOutput = batch.downloadingSuccess(peer.peerId, result);
         const logMeta: Record<string, number> = {
@@ -524,8 +530,6 @@ export class SyncChain {
               warning
             );
           }
-        } else {
-          this.metrics?.syncRange.downloadByRange.success.inc();
         }
 
         for (const block of downloadSuccessOutput.blocks) {

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -12,9 +12,9 @@ import {PeerSyncMeta} from "../../network/peers/peersData.js";
 import {CustodyConfig} from "../../util/dataColumns.js";
 import {ItTrigger} from "../../util/itTrigger.js";
 import {PeerIdStr} from "../../util/peerId.js";
-import {wrapError} from "../../util/wrapError.js";
+import {WarnResult, wrapError} from "../../util/wrapError.js";
 import {BATCH_BUFFER_SIZE, EPOCHS_PER_BATCH, MAX_LOOK_AHEAD_EPOCHS} from "../constants.js";
-import {DownloadByRangeErrorCode} from "../utils/downloadByRange.js";
+import {DownloadByRangeError, DownloadByRangeErrorCode} from "../utils/downloadByRange.js";
 import {RangeSyncType} from "../utils/remoteSyncType.js";
 import {Batch, BatchError, BatchErrorCode, BatchMetadata, BatchStatus} from "./batch.js";
 import {
@@ -46,7 +46,11 @@ export type SyncChainFns = {
    */
   processChainSegment: (blocks: IBlockInput[], syncType: RangeSyncType) => Promise<void>;
   /** Must download blocks, and validate their range */
-  downloadByRange: (peer: PeerSyncMeta, batch: Batch, syncType: RangeSyncType) => Promise<IBlockInput[]>;
+  downloadByRange: (
+    peer: PeerSyncMeta,
+    batch: Batch,
+    syncType: RangeSyncType
+  ) => Promise<WarnResult<IBlockInput[], DownloadByRangeError>>;
   /** Report peer for negative actions. Decouples from the full network instance */
   reportPeer: (peer: PeerIdStr, action: PeerAction, actionName: string) => void;
   /** Gets current peer custodyColumns and earliestAvailableSlot */
@@ -505,11 +509,25 @@ export class SyncChain {
         );
         batch.downloadingError(peer.peerId); // Throws after MAX_DOWNLOAD_ATTEMPTS
       } else {
-        this.metrics?.syncRange.downloadByRange.success.inc();
-        const downloadSuccessOutput = batch.downloadingSuccess(peer.peerId, res.result);
+        const {warn: warns, result} = res.result;
+        const downloadSuccessOutput = batch.downloadingSuccess(peer.peerId, result);
         const logMeta: Record<string, number> = {
           blockCount: downloadSuccessOutput.blocks.length,
         };
+
+        if (warns && warns.length > 0) {
+          for (const warn of warns) {
+            this.metrics?.syncRange.downloadByRange.warn.inc({client: peer.client, code: warn.type.code});
+            this.logger.debug(
+              "Batch downloaded with warning",
+              {id: this.logId, epoch: batch.startEpoch, ...logMeta, peer: prettyPrintPeerIdStr(peer.peerId)},
+              warn
+            );
+          }
+        } else {
+          this.metrics?.syncRange.downloadByRange.success.inc();
+        }
+
         for (const block of downloadSuccessOutput.blocks) {
           if (isBlockInputBlobs(block)) {
             const blockLogMeta = block.getLogMeta();

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -202,7 +202,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
 
   private downloadByRange: SyncChainFns["downloadByRange"] = async (peer, batch) => {
     const batchBlocks = batch.getBlocks();
-    const responses = await downloadByRange({
+    const {result, warn} = await downloadByRange({
       config: this.config,
       network: this.network,
       logger: this.logger,
@@ -213,10 +213,10 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
     const cached = cacheByRangeResponses({
       cache: this.chain.seenBlockInputCache,
       peerIdStr: peer.peerId,
-      responses,
+      responses: result,
       batchBlocks,
     });
-    return cached;
+    return {result: cached, warn};
   };
 
   private pruneBlockInputs: SyncChainFns["pruneBlockInputs"] = (blocks: IBlockInput[]) => {

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -202,7 +202,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
 
   private downloadByRange: SyncChainFns["downloadByRange"] = async (peer, batch) => {
     const batchBlocks = batch.getBlocks();
-    const {result, warn} = await downloadByRange({
+    const {result, warnings} = await downloadByRange({
       config: this.config,
       network: this.network,
       logger: this.logger,
@@ -216,7 +216,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       responses: result,
       batchBlocks,
     });
-    return {result: cached, warn};
+    return {result: cached, warnings};
   };
 
   private pruneBlockInputs: SyncChainFns["pruneBlockInputs"] = (blocks: IBlockInput[]) => {

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -307,9 +307,9 @@ export class BlockInputSync {
 
     const rootHex = getBlockInputSyncCacheItemRootHex(block);
     const logCtx = {
-      blockRoot: prettyBytes(rootHex),
-      pendingBlocks: this.pendingBlocks.size,
       slot: getBlockInputSyncCacheItemSlot(block),
+      blockRoot: rootHex,
+      pendingBlocks: this.pendingBlocks.size,
     };
 
     this.logger.verbose("BlockInputSync.downloadBlock()", logCtx);
@@ -328,16 +328,17 @@ export class BlockInputSync {
       this.metrics?.blockInputSync.elapsedTimeTillReceived.observe(delaySec);
 
       const parentInForkChoice = this.chain.forkChoice.hasBlockHex(pending.blockInput.parentRootHex);
-      this.logger.verbose("Downloaded unknown block", {
-        blockRoot: rootHex,
-        pendingBlocks: this.pendingBlocks.size,
+      const logCtx2 = {
+        ...logCtx,
+        slot: blockSlot,
         parentInForkChoice,
-      });
+      };
+      this.logger.verbose("Downloaded unknown block", logCtx2);
 
       if (parentInForkChoice) {
         // Bingo! Process block. Add to pending blocks anyway for recycle the cache that prevents duplicate processing
         this.processBlock(pending).catch((e) => {
-          this.logger.debug("Unexpected error - process newly downloaded block", {}, e);
+          this.logger.debug("Unexpected error - process newly downloaded block", logCtx2, e);
         });
       } else if (blockSlot <= finalizedSlot) {
         // the common ancestor of the downloading chain and canonical chain should be at least the finalized slot and
@@ -346,9 +347,8 @@ export class BlockInputSync {
         //                \
         //                parent 1 - parent 2 - ... - unknownParent block
         this.logger.debug("Downloaded block is before finalized slot", {
+          ...logCtx2,
           finalizedSlot,
-          blockSlot,
-          blockRoot: pending.blockInput.blockRootHex,
         });
         this.removeAndDownScoreAllDescendants(block);
       } else {
@@ -356,7 +356,7 @@ export class BlockInputSync {
       }
     } else {
       this.metrics?.blockInputSync.downloadedBlocksError.inc();
-      this.logger.debug("Ignoring unknown block root after many failed downloads", {blockRoot: rootHex}, res.err);
+      this.logger.debug("Ignoring unknown block root after many failed downloads", logCtx, res.err);
       this.removeAndDownScoreAllDescendants(block);
     }
   }
@@ -510,14 +510,26 @@ export class BlockInputSync {
       cacheItem.peerIdStrings.add(peerId);
 
       try {
-        cacheItem = await downloadByRoot({
+        const downloadResult = await downloadByRoot({
           config: this.config,
           network: this.network,
           seenCache: this.chain.seenBlockInputCache,
           peerMeta,
           cacheItem,
         });
-        this.metrics?.blockInputSync.downloadByRoot.success.inc();
+        cacheItem = downloadResult.result;
+        const logCtx = {slot: cacheItem.blockInput.slot, rootHex, peerId, peerClient};
+        const warns = downloadResult.warn;
+        if (warns) {
+          for (const warn of warns) {
+            this.logger.debug("BlockInputSync.fetchBlockInput: downloaded with warn", logCtx, warn);
+            this.metrics?.blockInputSync.downloadByRoot.warn.inc({code: warn.type.code, client: peerClient});
+          }
+          // TODO: penalize peer?
+        } else {
+          this.logger.verbose("BlockInputSync.fetchBlockInput: successful download", logCtx);
+          this.metrics?.blockInputSync.downloadByRoot.success.inc();
+        }
       } catch (e) {
         this.logger.debug(
           "Error downloading in BlockInputSync.fetchBlockInput",
@@ -525,6 +537,7 @@ export class BlockInputSync {
           e as Error
         );
         const downloadByRootMetrics = this.metrics?.blockInputSync.downloadByRoot;
+        // TODO: penalize peer?
         if (e instanceof DownloadByRootError) {
           const errorCode = e.type.code;
           downloadByRootMetrics?.error.inc({code: errorCode, client: peerClient});

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -519,6 +519,8 @@ export class BlockInputSync {
         });
         cacheItem = downloadResult.result;
         const logCtx = {slot: cacheItem.blockInput.slot, rootHex, peerId, peerClient};
+        this.logger.verbose("BlockInputSync.fetchBlockInput: successful download", logCtx);
+        this.metrics?.blockInputSync.downloadByRoot.success.inc();
         const warnings = downloadResult.warnings;
         if (warnings) {
           for (const warning of warnings) {
@@ -526,9 +528,6 @@ export class BlockInputSync {
             this.metrics?.blockInputSync.downloadByRoot.warn.inc({code: warning.type.code, client: peerClient});
           }
           // TODO: penalize peer?
-        } else {
-          this.logger.verbose("BlockInputSync.fetchBlockInput: successful download", logCtx);
-          this.metrics?.blockInputSync.downloadByRoot.success.inc();
         }
       } catch (e) {
         this.logger.debug(

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -519,11 +519,11 @@ export class BlockInputSync {
         });
         cacheItem = downloadResult.result;
         const logCtx = {slot: cacheItem.blockInput.slot, rootHex, peerId, peerClient};
-        const warns = downloadResult.warn;
-        if (warns) {
-          for (const warn of warns) {
-            this.logger.debug("BlockInputSync.fetchBlockInput: downloaded with warn", logCtx, warn);
-            this.metrics?.blockInputSync.downloadByRoot.warn.inc({code: warn.type.code, client: peerClient});
+        const warnings = downloadResult.warnings;
+        if (warnings) {
+          for (const warning of warnings) {
+            this.logger.debug("BlockInputSync.fetchBlockInput: downloaded with warning", logCtx, warning);
+            this.metrics?.blockInputSync.downloadByRoot.warn.inc({code: warning.type.code, client: peerClient});
           }
           // TODO: penalize peer?
         } else {

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -1,7 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPostDeneb, ForkPostFulu} from "@lodestar/params";
 import {SignedBeaconBlock, Slot, deneb, fulu, phase0} from "@lodestar/types";
-import {LodestarError, Logger, fromHex, prettyBytes, toRootHex} from "@lodestar/utils";
+import {LodestarError, Logger, fromHex, prettyBytes, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {
   BlockInputSource,
   DAType,
@@ -15,6 +15,7 @@ import {validateBlockDataColumnSidecars} from "../../chain/validation/dataColumn
 import {INetwork} from "../../network/index.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {DownloadByRootErrorCode} from "./downloadByRoot.js";
+import {WarnResult} from "../../util/wrapError.js";
 
 export type DownloadByRangeRequests = {
   blocksRequest?: phase0.BeaconBlocksByRangeRequest;
@@ -184,7 +185,7 @@ export async function downloadByRange({
   blocksRequest,
   blobsRequest,
   columnsRequest,
-}: Omit<DownloadAndCacheByRangeProps, "cache">): Promise<ValidatedResponses> {
+}: Omit<DownloadAndCacheByRangeProps, "cache">): Promise<WarnResult<ValidatedResponses, DownloadByRangeError>> {
   let response: DownloadByRangeResponses;
   try {
     response = await requestByRange({
@@ -282,7 +283,7 @@ export async function validateResponses({
   DownloadByRangeResponses & {
     config: ChainForkConfig;
     batchBlocks?: IBlockInput[];
-  }): Promise<ValidatedResponses> {
+  }): Promise<WarnResult<ValidatedResponses, DownloadByRangeError>> {
   // Blocks are always required for blob/column validation
   // If a blocksRequest is provided, blocks have just been downloaded
   // If no blocksRequest is provided, batchBlocks must have been provided from cache
@@ -297,6 +298,7 @@ export async function validateResponses({
   }
 
   const validatedResponses: ValidatedResponses = {};
+  let warn: DownloadByRangeError[] | null = null;
 
   if (blocksRequest) {
     validatedResponses.validatedBlocks = validateBlockByRangeResponse(config, blocksRequest, blocks ?? []);
@@ -304,7 +306,7 @@ export async function validateResponses({
 
   const dataRequest = blobsRequest ?? columnsRequest;
   if (!dataRequest) {
-    return validatedResponses;
+    return {result: validatedResponses, warn: null};
   }
 
   const dataRequestBlocks = getBlocksForDataValidation(
@@ -348,14 +350,16 @@ export async function validateResponses({
       );
     }
 
-    validatedResponses.validatedColumnSidecars = await validateColumnsByRangeResponse(
+    const validatedColumnSidecarsResult = await validateColumnsByRangeResponse(
       columnsRequest,
       dataRequestBlocks,
       columnSidecars
     );
+    validatedResponses.validatedColumnSidecars = validatedColumnSidecarsResult.result;
+    warn = validatedColumnSidecarsResult.warn;
   }
 
-  return validatedResponses;
+  return {result: validatedResponses, warn};
 }
 
 /**
@@ -526,7 +530,7 @@ export async function validateColumnsByRangeResponse(
   request: fulu.DataColumnSidecarsByRangeRequest,
   dataRequestBlocks: ValidatedBlock[],
   columnSidecars: fulu.DataColumnSidecars
-): Promise<ValidatedColumnSidecars[]> {
+): Promise<WarnResult<ValidatedColumnSidecars[], DownloadByRangeError>> {
   // Expected column count considering currently-validated batch blocks
   const expectedColumnCount = dataRequestBlocks.reduce((acc, {block}) => {
     return (block as SignedBeaconBlock<ForkPostDeneb>).message.body.blobKzgCommitments.length > 0
@@ -543,74 +547,84 @@ export async function validateColumnsByRangeResponse(
   const maxColumnCount = expectedColumnCount + possiblyMissingBlocks * request.columns.length;
 
   if (columnSidecars.length > maxColumnCount) {
+    // this never happens on devnet, so throw error for now
     throw new DownloadByRangeError(
       {
-        code: DownloadByRangeErrorCode.EXTRA_COLUMNS,
+        code: DownloadByRangeErrorCode.OVER_COLUMNS,
         max: maxColumnCount,
         actual: columnSidecars.length,
       },
       "Extra data columns received in DataColumnSidecarsByRange response"
     );
   }
-  if (columnSidecars.length < expectedColumnCount) {
-    throw new DownloadByRangeError(
-      {
-        code: DownloadByRangeErrorCode.MISSING_COLUMNS,
-        expected: expectedColumnCount,
-        actual: columnSidecars.length,
-      },
-      "Missing data columns in DataColumnSidecarsByRange response"
-    );
-  }
 
+  const warn: DownloadByRangeError[] = [];
+  // no need to check for columnSidecars.length  vs expectedColumnCount here, will be checked per-block below
+  const requestedColumns = new Set(request.columns);
   const validateSidecarsPromises: Promise<ValidatedColumnSidecars>[] = [];
   for (let blockIndex = 0, columnSidecarIndex = 0; blockIndex < dataRequestBlocks.length; blockIndex++) {
     const {block, blockRoot} = dataRequestBlocks[blockIndex];
+    const slot = block.message.slot;
+    const blockRootHex = toRootHex(blockRoot);
     const blockKzgCommitments = (block as SignedBeaconBlock<ForkPostFulu>).message.body.blobKzgCommitments;
     const expectedColumns = blockKzgCommitments.length ? request.columns.length : 0;
 
     if (expectedColumns === 0) {
       continue;
     }
-    const blockColumnSidecars = columnSidecars.slice(columnSidecarIndex, columnSidecarIndex + expectedColumns);
-    columnSidecarIndex += expectedColumns;
-
-    // Validate that all requested columns are present and in order
-    if (blockColumnSidecars.length !== expectedColumns) {
-      throw new DownloadByRangeError(
-        {
-          code: DownloadByRangeErrorCode.MISSING_COLUMNS,
-          expected: expectedColumns,
-          actual: blockColumnSidecars.length,
-        },
-        "Missing data columns in DataColumnSidecarsByRange response"
-      );
+    const blockColumnSidecars: fulu.DataColumnSidecar[] = [];
+    while (columnSidecarIndex < columnSidecars.length) {
+      const columnSidecar = columnSidecars[columnSidecarIndex];
+      if (columnSidecar.signedBlockHeader.message.slot !== block.message.slot) {
+        // We've reached columns for the next block
+        break;
+      }
+      blockColumnSidecars.push(columnSidecar);
+      columnSidecarIndex++;
     }
-    for (let i = 0; i < blockColumnSidecars.length; i++) {
-      if (blockColumnSidecars[i].index !== request.columns[i]) {
-        throw new DownloadByRangeError(
+
+    const returnedColumns = new Set(blockColumnSidecars.map((c) => c.index));
+    const missingIndices = request.columns.filter((i) => !returnedColumns.has(i));
+    if (missingIndices.length > 0) {
+      warn.push(
+        new DownloadByRangeError(
           {
             code: DownloadByRangeErrorCode.MISSING_COLUMNS,
-            expected: expectedColumns,
-            actual: blockColumnSidecars.length,
+            slot,
+            blockRoot: blockRootHex,
+            missingIndices: prettyPrintIndices(missingIndices),
           },
-          "Data columns not in order or do not match requested columns in DataColumnSidecarsByRange response"
-        );
-      }
+          "Missing data columns in DataColumnSidecarsByRange response"
+        )
+      );
+    }
+
+    const extraIndices = [...returnedColumns].filter((i) => !requestedColumns.has(i));
+    if (extraIndices.length) {
+      warn.push(
+        new DownloadByRangeError(
+          {
+            code: DownloadByRangeErrorCode.EXTRA_COLUMNS,
+            slot,
+            blockRoot: blockRootHex,
+            invalidIndices: prettyPrintIndices(extraIndices),
+          },
+          "Data column in not in requested columns in DataColumnSidecarsByRange response"
+        )
+      );
     }
 
     validateSidecarsPromises.push(
-      validateBlockDataColumnSidecars(
-        block.message.slot,
+      validateBlockDataColumnSidecars(slot, blockRoot, blockKzgCommitments.length, blockColumnSidecars).then(() => ({
         blockRoot,
-        blockKzgCommitments.length,
-        blockColumnSidecars
-      ).then(() => ({blockRoot, columnSidecars: blockColumnSidecars}))
+        columnSidecars: blockColumnSidecars,
+      }))
     );
   }
 
   // Await all sidecar validations in parallel
-  return Promise.all(validateSidecarsPromises);
+  const result = await Promise.all(validateSidecarsPromises);
+  return {result, warn: warn.length ? warn : null};
 }
 
 /**
@@ -696,6 +710,7 @@ export enum DownloadByRangeErrorCode {
   EXTRA_BLOBS = "DOWNLOAD_BY_RANGE_ERROR_EXTRA_BLOBS",
 
   MISSING_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_MISSING_COLUMNS",
+  OVER_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_OVER_COLUMNS",
   EXTRA_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_EXTRA_COLUMNS",
 
   /** Cached block input type mismatches new data */
@@ -766,14 +781,21 @@ export type DownloadByRangeErrorType =
       actual: number;
     }
   | {
-      code: DownloadByRangeErrorCode.MISSING_COLUMNS;
-      expected: number;
+      code: DownloadByRangeErrorCode.OVER_COLUMNS;
+      max: number;
       actual: number;
     }
   | {
+      code: DownloadByRangeErrorCode.MISSING_COLUMNS;
+      slot: Slot;
+      blockRoot: string;
+      missingIndices: string;
+    }
+  | {
       code: DownloadByRangeErrorCode.EXTRA_COLUMNS;
-      max: number;
-      actual: number;
+      slot: Slot;
+      blockRoot: string;
+      invalidIndices: string;
     }
   | {
       code: DownloadByRangeErrorCode.MISMATCH_BLOCK_INPUT_TYPE;

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -298,7 +298,7 @@ export async function validateResponses({
   }
 
   const validatedResponses: ValidatedResponses = {};
-  let warn: DownloadByRangeError[] | null = null;
+  let warnings: DownloadByRangeError[] | null = null;
 
   if (blocksRequest) {
     validatedResponses.validatedBlocks = validateBlockByRangeResponse(config, blocksRequest, blocks ?? []);
@@ -306,7 +306,7 @@ export async function validateResponses({
 
   const dataRequest = blobsRequest ?? columnsRequest;
   if (!dataRequest) {
-    return {result: validatedResponses, warn: null};
+    return {result: validatedResponses, warnings: null};
   }
 
   const dataRequestBlocks = getBlocksForDataValidation(
@@ -356,10 +356,10 @@ export async function validateResponses({
       columnSidecars
     );
     validatedResponses.validatedColumnSidecars = validatedColumnSidecarsResult.result;
-    warn = validatedColumnSidecarsResult.warn;
+    warnings = validatedColumnSidecarsResult.warnings;
   }
 
-  return {result: validatedResponses, warn};
+  return {result: validatedResponses, warnings};
 }
 
 /**
@@ -558,7 +558,7 @@ export async function validateColumnsByRangeResponse(
     );
   }
 
-  const warn: DownloadByRangeError[] = [];
+  const warnings: DownloadByRangeError[] = [];
   // no need to check for columnSidecars.length  vs expectedColumnCount here, will be checked per-block below
   const requestedColumns = new Set(request.columns);
   const validateSidecarsPromises: Promise<ValidatedColumnSidecars>[] = [];
@@ -586,7 +586,7 @@ export async function validateColumnsByRangeResponse(
     const returnedColumns = new Set(blockColumnSidecars.map((c) => c.index));
     const missingIndices = request.columns.filter((i) => !returnedColumns.has(i));
     if (missingIndices.length > 0) {
-      warn.push(
+      warnings.push(
         new DownloadByRangeError(
           {
             code: DownloadByRangeErrorCode.MISSING_COLUMNS,
@@ -601,7 +601,7 @@ export async function validateColumnsByRangeResponse(
 
     const extraIndices = [...returnedColumns].filter((i) => !requestedColumns.has(i));
     if (extraIndices.length > 0) {
-      warn.push(
+      warnings.push(
         new DownloadByRangeError(
           {
             code: DownloadByRangeErrorCode.EXTRA_COLUMNS,
@@ -624,7 +624,7 @@ export async function validateColumnsByRangeResponse(
 
   // Await all sidecar validations in parallel
   const result = await Promise.all(validateSidecarsPromises);
-  return {result, warn: warn.length ? warn : null};
+  return {result, warnings: warnings.length ? warnings : null};
 }
 
 /**

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -600,7 +600,7 @@ export async function validateColumnsByRangeResponse(
     }
 
     const extraIndices = [...returnedColumns].filter((i) => !requestedColumns.has(i));
-    if (extraIndices.length) {
+    if (extraIndices.length > 0) {
       warn.push(
         new DownloadByRangeError(
           {

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -69,7 +69,7 @@ export async function downloadByRoot({
 
   const {
     result: {block, blobSidecars, columnSidecars},
-    warn,
+    warnings: warn,
   } = await fetchByRoot({
     config,
     network,
@@ -163,7 +163,7 @@ export async function downloadByRoot({
       timeAddedSec: cacheItem.timeAddedSec,
       peerIdStrings: cacheItem.peerIdStrings,
     },
-    warn,
+    warnings: warn,
   };
 }
 
@@ -264,7 +264,7 @@ export async function fetchByRoot({
       blobSidecars,
       columnSidecars: columnSidecarResult?.result,
     },
-    warn: columnSidecarResult?.warn ?? null,
+    warnings: columnSidecarResult?.warnings ?? null,
   };
 }
 
@@ -344,7 +344,7 @@ export async function fetchAndValidateColumns({
   const slot = block.message.slot;
   const blobCount = block.message.body.blobKzgCommitments.length;
   if (blobCount === 0) {
-    return {result: [], warn: null};
+    return {result: [], warnings: null};
   }
 
   const blockRootHex = toRootHex(blockRoot);
@@ -354,7 +354,7 @@ export async function fetchAndValidateColumns({
     {blockRoot, columns: requestedColumns},
   ]);
 
-  const warn: DownloadByRootError[] = [];
+  const warnings: DownloadByRootError[] = [];
 
   // it's not acceptable if no sidecar is returned with >0 blobCount
   if (columnSidecars.length === 0) {
@@ -372,7 +372,7 @@ export async function fetchAndValidateColumns({
   const returnedColumnsSet = new Set(returnedColumns);
   const missingIndices = requestedColumns.filter((c) => !returnedColumnsSet.has(c));
   if (missingIndices.length > 0) {
-    warn.push(
+    warnings.push(
       new DownloadByRootError(
         {
           code: DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED,
@@ -389,7 +389,7 @@ export async function fetchAndValidateColumns({
   // check extra returned columnSidecar
   const extraIndices = returnedColumns.filter((c) => !requestedColumnsSet.has(c));
   if (extraIndices.length > 0) {
-    warn.push(
+    warnings.push(
       new DownloadByRootError(
         {
           code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED,
@@ -405,7 +405,7 @@ export async function fetchAndValidateColumns({
 
   await validateBlockDataColumnSidecars(slot, blockRoot, blobCount, columnSidecars);
 
-  return {result: columnSidecars, warn: warn.length > 0 ? warn : null};
+  return {result: columnSidecars, warnings: warnings.length > 0 ? warnings : null};
 }
 
 // TODO(fulu) not in use, remove?

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -1,6 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPostDeneb, ForkPostFulu, ForkPreFulu, isForkPostDeneb, isForkPostFulu} from "@lodestar/params";
-import {SignedBeaconBlock, deneb, fulu} from "@lodestar/types";
+import {SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
 import {LodestarError, fromHex, prettyBytes, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {BlobMeta, BlockInputSource, IBlockInput, MissingColumnMeta} from "../../chain/blocks/blockInput/types.js";
@@ -20,6 +20,7 @@ import {
 } from "../types.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
 import {PeerIdStr} from "../../util/peerId.js";
+import {WarnResult} from "../../util/wrapError.js";
 
 export type FetchByRootCoreProps = {
   config: ChainForkConfig;
@@ -61,12 +62,15 @@ export async function downloadByRoot({
   network,
   peerMeta,
   cacheItem,
-}: DownloadByRootProps): Promise<PendingBlockInput> {
+}: DownloadByRootProps): Promise<WarnResult<PendingBlockInput, DownloadByRootError>> {
   const rootHex = getBlockInputSyncCacheItemRootHex(cacheItem);
   const blockRoot = fromHex(rootHex);
   const {peerId: peerIdStr} = peerMeta;
 
-  const {block, blobSidecars, columnSidecars} = await fetchByRoot({
+  const {
+    result: {block, blobSidecars, columnSidecars},
+    warn,
+  } = await fetchByRoot({
     config,
     network,
     cacheItem,
@@ -152,11 +156,14 @@ export async function downloadByRoot({
   }
 
   return {
-    status,
-    blockInput,
-    timeSyncedSec,
-    timeAddedSec: cacheItem.timeAddedSec,
-    peerIdStrings: cacheItem.peerIdStrings,
+    result: {
+      status,
+      blockInput,
+      timeSyncedSec,
+      timeAddedSec: cacheItem.timeAddedSec,
+      peerIdStrings: cacheItem.peerIdStrings,
+    },
+    warn,
   };
 }
 
@@ -166,10 +173,10 @@ export async function fetchByRoot({
   peerMeta,
   blockRoot,
   cacheItem,
-}: FetchByRootProps): Promise<FetchByRootResponses> {
+}: FetchByRootProps): Promise<WarnResult<FetchByRootResponses, DownloadByRootError>> {
   let block: SignedBeaconBlock;
   let blobSidecars: deneb.BlobSidecars | undefined;
-  let columnSidecars: fulu.DataColumnSidecars | undefined;
+  let columnSidecarResult: WarnResult<fulu.DataColumnSidecars, DownloadByRootError> | undefined;
   const {peerId: peerIdStr} = peerMeta;
 
   if (isPendingBlockInput(cacheItem)) {
@@ -198,7 +205,7 @@ export async function fetchByRoot({
         });
       }
       if (isBlockInputColumns(cacheItem.blockInput)) {
-        columnSidecars = await fetchAndValidateColumns({
+        columnSidecarResult = await fetchAndValidateColumns({
           config,
           network,
           peerMeta,
@@ -218,7 +225,7 @@ export async function fetchByRoot({
     });
     const forkName = config.getForkName(block.message.slot);
     if (isForkPostFulu(forkName)) {
-      columnSidecars = await fetchAndValidateColumns({
+      columnSidecarResult = await fetchAndValidateColumns({
         config,
         network,
         peerMeta,
@@ -252,9 +259,12 @@ export async function fetchByRoot({
   }
 
   return {
-    block,
-    blobSidecars,
-    columnSidecars,
+    result: {
+      block,
+      blobSidecars,
+      columnSidecars: columnSidecarResult?.result,
+    },
+    warn: columnSidecarResult?.warn ?? null,
   };
 }
 
@@ -329,52 +339,73 @@ export async function fetchAndValidateColumns({
   block,
   blockRoot,
   columnMeta,
-}: FetchByRootAndValidateColumnsProps): Promise<fulu.DataColumnSidecars> {
+}: FetchByRootAndValidateColumnsProps): Promise<WarnResult<fulu.DataColumnSidecars, DownloadByRootError>> {
   const {peerId: peerIdStr} = peerMeta;
   const slot = block.message.slot;
   const blobCount = block.message.body.blobKzgCommitments.length;
   if (blobCount === 0) {
-    return [];
+    return {result: [], warn: null};
   }
 
+  const blockRootHex = toRootHex(blockRoot);
   const peerColumns = new Set(peerMeta.custodyGroups ?? []);
   const requestedColumns = columnMeta.missing.filter((c) => peerColumns.has(c));
   const columnSidecars = await network.sendDataColumnSidecarsByRoot(peerIdStr, [
     {blockRoot, columns: requestedColumns},
   ]);
 
-  // sanity check if peer returned correct number of columnSidecars
-  if (columnSidecars.length < requestedColumns.length) {
-    const returnedColumns = new Set(columnSidecars.map((c) => c.index));
-    throw new DownloadByRootError(
-      {
-        code: DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED,
-        peer: prettyPrintPeerIdStr(peerIdStr),
-        blockRoot: prettyBytes(blockRoot),
-        missingIndices: prettyPrintIndices(requestedColumns.filter((c) => !returnedColumns.has(c))),
-      },
-      "Did not receive all of the requested columnSidecars"
+  const warn: DownloadByRootError[] = [];
+
+  // it's not acceptable if no sidecar is returned with >0 blobCount
+  if (columnSidecars.length === 0) {
+    throw new DownloadByRootError({
+      code: DownloadByRootErrorCode.NO_SIDECAR_RECEIVED,
+      peer: prettyPrintPeerIdStr(peerIdStr),
+      slot,
+      blockRoot: blockRootHex,
+    });
+  }
+
+  // it's ok if only some sidecars are returned, we will try to get the rest from other peers
+  const requestedColumnsSet = new Set(requestedColumns);
+  const returnedColumns = columnSidecars.map((c) => c.index);
+  const returnedColumnsSet = new Set(returnedColumns);
+  const missingIndices = requestedColumns.filter((c) => !returnedColumnsSet.has(c));
+  if (missingIndices.length > 0) {
+    warn.push(
+      new DownloadByRootError(
+        {
+          code: DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED,
+          peer: prettyPrintPeerIdStr(peerIdStr),
+          slot,
+          blockRoot: blockRootHex,
+          missingIndices: prettyPrintIndices(missingIndices),
+        },
+        "Did not receive all of the requested columnSidecars"
+      )
     );
   }
 
-  // check each returned columnSidecar
-  for (let i = 0; i < requestedColumns.length; i++) {
-    const columnSidecar = columnSidecars[i];
-    if (columnSidecar.index !== requestedColumns[i]) {
-      throw new DownloadByRootError(
+  // check extra returned columnSidecar
+  const extraIndices = returnedColumns.filter((c) => !requestedColumnsSet.has(c));
+  if (extraIndices.length > 0) {
+    warn.push(
+      new DownloadByRootError(
         {
           code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED,
           peer: prettyPrintPeerIdStr(peerIdStr),
-          blockRoot: prettyBytes(blockRoot),
-          invalidIndex: columnSidecar.index,
+          slot,
+          blockRoot: blockRootHex,
+          invalidIndices: prettyPrintIndices(extraIndices),
         },
-        "Received a columnSidecar that was not requested"
-      );
-    }
+        "Received columnSidecars that were not requested"
+      )
+    );
   }
+
   await validateBlockDataColumnSidecars(slot, blockRoot, blobCount, columnSidecars);
 
-  return columnSidecars;
+  return {result: columnSidecars, warn: warn.length > 0 ? warn : null};
 }
 
 // TODO(fulu) not in use, remove?
@@ -412,18 +443,23 @@ export async function validateColumnSidecars({
   needToPublish = [],
 }: ValidateColumnSidecarsProps): Promise<void> {
   const requestedIndices = columnMeta.missing;
+  const extraIndices: number[] = [];
   for (const columnSidecar of needed) {
     if (!requestedIndices.includes(columnSidecar.index)) {
-      throw new DownloadByRootError(
-        {
-          code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED,
-          peer: prettyPrintPeerIdStr(peerMeta.peerId),
-          blockRoot: prettyBytes(blockRoot),
-          invalidIndex: columnSidecar.index,
-        },
-        "Received a columnSidecar that was not requested"
-      );
+      extraIndices.push(columnSidecar.index);
     }
+  }
+  if (extraIndices.length > 0) {
+    throw new DownloadByRootError(
+      {
+        code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED,
+        peer: prettyPrintPeerIdStr(peerMeta.peerId),
+        slot,
+        blockRoot: prettyBytes(blockRoot),
+        invalidIndices: prettyPrintIndices(extraIndices),
+      },
+      "Received a columnSidecar that was not requested"
+    );
   }
   await validateBlockDataColumnSidecars(slot, blockRoot, blobCount, [...needed, ...needToPublish]);
 }
@@ -431,6 +467,7 @@ export async function validateColumnSidecars({
 export enum DownloadByRootErrorCode {
   MISMATCH_BLOCK_ROOT = "DOWNLOAD_BY_ROOT_ERROR_MISMATCH_BLOCK_ROOT",
   EXTRA_SIDECAR_RECEIVED = "DOWNLOAD_BY_ROOT_ERROR_EXTRA_SIDECAR_RECEIVED",
+  NO_SIDECAR_RECEIVED = "DOWNLOAD_BY_ROOT_ERROR_NO_SIDECAR_RECEIVED",
   NOT_ENOUGH_SIDECARS_RECEIVED = "DOWNLOAD_BY_ROOT_ERROR_NOT_ENOUGH_SIDECARS_RECEIVED",
   INVALID_INCLUSION_PROOF = "DOWNLOAD_BY_ROOT_ERROR_INVALID_INCLUSION_PROOF",
   INVALID_KZG_PROOF = "DOWNLOAD_BY_ROOT_ERROR_INVALID_KZG_PROOF",
@@ -449,12 +486,20 @@ export type DownloadByRootErrorType =
   | {
       code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED;
       peer: string;
+      slot: Slot;
       blockRoot: string;
-      invalidIndex: number;
+      invalidIndices: string;
+    }
+  | {
+      code: DownloadByRootErrorCode.NO_SIDECAR_RECEIVED;
+      peer: string;
+      slot: Slot;
+      blockRoot: string;
     }
   | {
       code: DownloadByRootErrorCode.NOT_ENOUGH_SIDECARS_RECEIVED;
       peer: string;
+      slot: Slot;
       blockRoot: string;
       missingIndices: string;
     }

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -69,7 +69,7 @@ export async function downloadByRoot({
 
   const {
     result: {block, blobSidecars, columnSidecars},
-    warnings: warn,
+    warnings,
   } = await fetchByRoot({
     config,
     network,
@@ -163,7 +163,7 @@ export async function downloadByRoot({
       timeAddedSec: cacheItem.timeAddedSec,
       peerIdStrings: cacheItem.peerIdStrings,
     },
-    warnings: warn,
+    warnings,
   };
 }
 

--- a/packages/beacon-node/src/util/wrapError.ts
+++ b/packages/beacon-node/src/util/wrapError.ts
@@ -24,4 +24,4 @@ export async function wrapError<T>(promise: Promise<T>): Promise<Result<T>> {
 /**
  * Some functions may want to return a result and some warning typed as Error
  */
-export type WarnResult<T, E extends Error> = {result: T; warn: E[] | null};
+export type WarnResult<T, E extends Error> = {result: T; warnings: E[] | null};

--- a/packages/beacon-node/src/util/wrapError.ts
+++ b/packages/beacon-node/src/util/wrapError.ts
@@ -20,3 +20,8 @@ export async function wrapError<T>(promise: Promise<T>): Promise<Result<T>> {
     return {err: err as Error};
   }
 }
+
+/**
+ * Some functions may want to return a result and some warning typed as Error
+ */
+export type WarnResult<T, E extends Error> = {result: T; warn: E[] | null};


### PR DESCRIPTION
**Motivation**

- the DownloadByRoot and DownloadByRange are quite strict: all DataColumnSidecars have to present, and no extra DataColumnSidecars received even they may pass validation
- the reality is that node should not expect that perfection, otherwise we'll never be able to fulfill downloading a BlockInput, see https://github.com/ChainSafe/lodestar/issues/8375#issuecomment-3283482077
- also we may evict downloaded good blocks which cause performance issue

**Description**

- accept DataColumnSidecars response with missing columns or extra columns
- we only have functions to either throw error or return result, introduce a new `WarnResult` which is a result with some warns (typed as Error)

```typescript
export type WarnResult<T, E extends Error> = {result: T; warn: E[] | null};
```

- new `warn` metrics in DownloadByRoot and DownloadByRange to track
- handle respective warned result in `BlockInputSync` and `SyncChain`:
  - log
  - track in the new metrics