### PR TITLE
chore: move single attestation errors to `verbose` log level

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -161,7 +161,7 @@ export function getBeaconPoolApi({
             }
 
             failures.push({index: i, message: (e as Error).message});
-            logger.error(`Error on submitPoolAttestations [${i}]`, logCtx, e as Error);
+            logger.verbose(`Error on submitPoolAttestations [${i}]`, logCtx, e as Error);
             if (e instanceof AttestationError && e.action === GossipAction.REJECT) {
               chain.persistInvalidSszValue(sszTypesFor(fork).SingleAttestation, attestation, "api_reject");
             }
@@ -216,7 +216,7 @@ export function getBeaconPoolApi({
             }
           } catch (e) {
             failures.push({index: i, message: (e as Error).message});
-            logger.error(
+            logger.verbose(
               `Error on submitPoolBLSToExecutionChange [${i}]`,
               {validatorIndex: blsToExecutionChange.message.validatorIndex},
               e as Error
@@ -294,7 +294,7 @@ export function getBeaconPoolApi({
             }
 
             failures.push({index: i, message: (e as Error).message});
-            logger.error(
+            logger.verbose(
               `Error on submitPoolSyncCommitteeSignatures [${i}]`,
               {slot: signature.slot, validatorIndex: signature.validatorIndex},
               e as Error


### PR DESCRIPTION
- Closes https://github.com/ChainSafe/lodestar/issues/8386