### PR TITLE
fix: stop verifying `SECONDS_PER_ETH1_BLOCK` on validator startup

### DIFF
--- a/packages/validator/src/util/params.ts
+++ b/packages/validator/src/util/params.ts
@@ -147,7 +147,7 @@ function getSpecCriticalParams(localConfig: ChainConfig): Record<keyof ConfigWit
 
     // Time parameters
     SECONDS_PER_SLOT: true,
-    SECONDS_PER_ETH1_BLOCK: true,
+    SECONDS_PER_ETH1_BLOCK: false, // Legacy
     MIN_VALIDATOR_WITHDRAWABILITY_DELAY: true,
     SHARD_COMMITTEE_PERIOD: true,
     ETH1_FOLLOW_DISTANCE: true,


### PR DESCRIPTION
**Motivation**

See https://github.com/ChainSafe/lodestar/issues/8395 for rationale. 

**Description**

Stop verifying `SECONDS_PER_ETH1_BLOCK` on validator startup to avoid potential interop issues with other clients.

Closes https://github.com/ChainSafe/lodestar/issues/8395