### PR TITLE
feat: use dual-stack by default

### DIFF
--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -48,7 +48,7 @@ export interface NetworkOptions
 export const defaultNetworkOptions: NetworkOptions = {
   maxPeers: 210, // Allow some room above targetPeers for new inbound peers
   targetPeers: 200,
-  localMultiaddrs: ["/ip4/0.0.0.0/tcp/9000"],
+  localMultiaddrs: ["/ip4/0.0.0.0/tcp/9000", "/ip6/::/tcp/9000"],
   bootMultiaddrs: [],
   /** disabled by default */
   discv5: null,

--- a/packages/cli/src/cmds/bootnode/options.ts
+++ b/packages/cli/src/cmds/bootnode/options.ts
@@ -1,6 +1,6 @@
 import {CliCommandOptions, CliOptionDefinition} from "@lodestar/utils";
 import {MetricsArgs, options as metricsOptions} from "../../options/beaconNodeOptions/metrics.js";
-import {defaultListenAddress, defaultP2pPort} from "../../options/beaconNodeOptions/network.js";
+import {defaultListenAddress, defaultListenAddress6, defaultP2pPort} from "../../options/beaconNodeOptions/network.js";
 import {LogArgs, logOptions} from "../../options/logOptions.js";
 
 type BootnodeExtraArgs = {
@@ -37,6 +37,7 @@ export const bootnodeExtraOptions: CliCommandOptions<BootnodeExtraArgs> = {
   listenAddress6: {
     type: "string",
     description: "The IPv6 address to listen for discv5 connections",
+    defaultDescription: defaultListenAddress6,
     group: "network",
   },
 

--- a/packages/cli/src/options/beaconNodeOptions/network.ts
+++ b/packages/cli/src/options/beaconNodeOptions/network.ts
@@ -5,6 +5,7 @@ import {multiaddr} from "@multiformats/multiaddr";
 import {YargsError} from "../../util/index.js";
 
 export const defaultListenAddress = "0.0.0.0";
+export const defaultListenAddress6 = "::";
 export const defaultP2pPort = 9000;
 
 export type NetworkArgs = {
@@ -64,8 +65,9 @@ export function parseListenArgs(args: NetworkArgs) {
   const port = listenAddress ? (args.port ?? defaultP2pPort) : undefined;
   const discoveryPort = listenAddress ? (args.discoveryPort ?? args.port ?? defaultP2pPort) : undefined;
 
-  // Only use listenAddress6 if it is explicitly set
-  const listenAddress6 = args.listenAddress6;
+  // If listenAddress6 is explicitly set, use it
+  // If listenAddress is not set, use defaultListenAddress6
+  const listenAddress6 = args.listenAddress6 ?? (args.listenAddress ? undefined : defaultListenAddress6);
   const port6 = listenAddress6 ? (args.port6 ?? defaultP2pPort) : undefined;
   const discoveryPort6 = listenAddress6 ? (args.discoveryPort6 ?? args.port6 ?? defaultP2pPort) : undefined;
 
@@ -191,6 +193,7 @@ export const options: CliCommandOptions<NetworkArgs> = {
   listenAddress6: {
     type: "string",
     description: "The IPv6 address to listen for p2p UDP and TCP connections",
+    defaultDescription: defaultListenAddress6,
     group: "network",
   },
 


### PR DESCRIPTION
**Motivation**

To further increase the number of IPv6 nodes on the network it would help if we use dual-stack by default.

**Description**

Use dual-stack by default
- if no `listenAddress` is specified then enable IPv4 and IPv6
- if only `listenAddress` is configured then only enable IPv4
- if only `listenAddress6` is configured then only enable IPv6
- if both `listenAddress` and `listenAddress6` are configured enable both

Information about other clients can be found here https://ipv6eth.info/