### PR TITLE
feat: audit versioned hashes

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -332,6 +332,7 @@ export function getBeaconBlockApi({
       }
     } else if (isBlockInputBlobs(blockForImport) && chain.emitter.listenerCount(routes.events.EventType.blobSidecar)) {
       const blobSidecars = blockForImport.getBlobs();
+      const versionedHashes = blockForImport.getVersionedHashes();
 
       for (const blobSidecar of blobSidecars) {
         const {index, kzgCommitment} = blobSidecar;
@@ -340,7 +341,7 @@ export function getBeaconBlockApi({
           slot,
           index,
           kzgCommitment: toHex(kzgCommitment),
-          versionedHash: toHex(kzgCommitmentToVersionedHash(kzgCommitment)),
+          versionedHash: toHex(versionedHashes[index]),
         });
       }
     }

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -40,7 +40,7 @@ import {writeBlockInputToDb} from "./writeBlockInputToDb.js";
 export async function verifyBlocksInEpoch(
   this: BeaconChain,
   parentBlock: ProtoBlock,
-  blocksInput: IBlockInput[],
+  blocksInputs: IBlockInput[],
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<{
   postStates: CachedBeaconStateAllForks[];
@@ -48,7 +48,7 @@ export async function verifyBlocksInEpoch(
   segmentExecStatus: SegmentExecStatus;
   dataAvailabilityStatuses: DataAvailabilityStatus[];
 }> {
-  const blocks = blocksInput.map((blockInput) => blockInput.getBlock());
+  const blocks = blocksInputs.map((blockInput) => blockInput.getBlock());
   const lastBlock = blocks.at(-1);
   if (!lastBlock) {
     throw Error("Empty partiallyVerifiedBlocks");
@@ -101,7 +101,7 @@ export async function verifyBlocksInEpoch(
     ] = await Promise.all([
       // Execution payloads
       opts.skipVerifyExecutionPayload !== true
-        ? verifyBlocksExecutionPayload(this, parentBlock, blocks, preState0, abortController.signal, opts)
+        ? verifyBlocksExecutionPayload(this, parentBlock, blocksInputs, preState0, abortController.signal, opts)
         : Promise.resolve({
             execAborted: null,
             executionStatuses: blocks.map((_blk) => ExecutionStatus.Syncing),
@@ -109,13 +109,13 @@ export async function verifyBlocksInEpoch(
           } as SegmentExecStatus),
 
       // data availability for the blobs
-      verifyBlocksDataAvailability(blocksInput, abortController.signal),
+      verifyBlocksDataAvailability(blocksInputs, abortController.signal),
 
       // Run state transition only
       // TODO: Ensure it yields to allow flushing to workers and engine API
       verifyBlocksStateTransitionOnly(
         preState0,
-        blocksInput,
+        blocksInputs,
         // hack availability for state transition eval as availability is separately determined
         blocks.map(() => DataAvailabilityStatus.Available),
         this.logger,
@@ -134,7 +134,7 @@ export async function verifyBlocksInEpoch(
       // rarely invalid blocks we'll batch all I/O operation here to reduce the overhead if there's
       // an error, we'll remove blocks not in forkchoice
       opts.verifyOnly !== true && opts.eagerPersistBlock
-        ? writeBlockInputToDb.call(this, blocksInput)
+        ? writeBlockInputToDb.call(this, blocksInputs)
         : Promise.resolve(),
     ]);
 
@@ -190,10 +190,10 @@ export async function verifyBlocksInEpoch(
     if (segmentExecStatus.execAborted === null) {
       const {executionStatuses, executionTime} = segmentExecStatus;
       if (
-        blocksInput.length === 1 &&
+        blocksInputs.length === 1 &&
         // gossip blocks have seenTimestampSec
         opts.seenTimestampSec !== undefined &&
-        blocksInput[0].type !== DAType.PreData &&
+        blocksInputs[0].type !== DAType.PreData &&
         executionStatuses[0] === ExecutionStatus.Valid
       ) {
         // Find the max time when the block was actually verified
@@ -202,7 +202,7 @@ export async function verifyBlocksInEpoch(
         this.metrics?.gossipBlock.receivedToFullyVerifiedTime.observe(recvTofullyVerifedTime);
 
         const verifiedToBlobsAvailabiltyTime = Math.max(availableTime - fullyVerifiedTime, 0) / 1000;
-        const block = blocksInput[0].getBlock() as deneb.SignedBeaconBlock;
+        const block = blocksInputs[0].getBlock() as deneb.SignedBeaconBlock;
         const numBlobs = block.message.body.blobKzgCommitments.length;
 
         this.metrics?.gossipBlock.verifiedToBlobsAvailabiltyTime.observe({numBlobs}, verifiedToBlobsAvailabiltyTime);
@@ -210,7 +210,7 @@ export async function verifyBlocksInEpoch(
           slot: block.message.slot,
           recvTofullyVerifedTime,
           verifiedToBlobsAvailabiltyTime,
-          type: blocksInput[0].type,
+          type: blocksInputs[0].type,
           numBlobs,
         });
       }

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -40,7 +40,7 @@ import {writeBlockInputToDb} from "./writeBlockInputToDb.js";
 export async function verifyBlocksInEpoch(
   this: BeaconChain,
   parentBlock: ProtoBlock,
-  blocksInputs: IBlockInput[],
+  blockInputs: IBlockInput[],
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<{
   postStates: CachedBeaconStateAllForks[];
@@ -48,7 +48,7 @@ export async function verifyBlocksInEpoch(
   segmentExecStatus: SegmentExecStatus;
   dataAvailabilityStatuses: DataAvailabilityStatus[];
 }> {
-  const blocks = blocksInputs.map((blockInput) => blockInput.getBlock());
+  const blocks = blockInputs.map((blockInput) => blockInput.getBlock());
   const lastBlock = blocks.at(-1);
   if (!lastBlock) {
     throw Error("Empty partiallyVerifiedBlocks");
@@ -101,7 +101,7 @@ export async function verifyBlocksInEpoch(
     ] = await Promise.all([
       // Execution payloads
       opts.skipVerifyExecutionPayload !== true
-        ? verifyBlocksExecutionPayload(this, parentBlock, blocksInputs, preState0, abortController.signal, opts)
+        ? verifyBlocksExecutionPayload(this, parentBlock, blockInputs, preState0, abortController.signal, opts)
         : Promise.resolve({
             execAborted: null,
             executionStatuses: blocks.map((_blk) => ExecutionStatus.Syncing),
@@ -109,13 +109,13 @@ export async function verifyBlocksInEpoch(
           } as SegmentExecStatus),
 
       // data availability for the blobs
-      verifyBlocksDataAvailability(blocksInputs, abortController.signal),
+      verifyBlocksDataAvailability(blockInputs, abortController.signal),
 
       // Run state transition only
       // TODO: Ensure it yields to allow flushing to workers and engine API
       verifyBlocksStateTransitionOnly(
         preState0,
-        blocksInputs,
+        blockInputs,
         // hack availability for state transition eval as availability is separately determined
         blocks.map(() => DataAvailabilityStatus.Available),
         this.logger,
@@ -134,7 +134,7 @@ export async function verifyBlocksInEpoch(
       // rarely invalid blocks we'll batch all I/O operation here to reduce the overhead if there's
       // an error, we'll remove blocks not in forkchoice
       opts.verifyOnly !== true && opts.eagerPersistBlock
-        ? writeBlockInputToDb.call(this, blocksInputs)
+        ? writeBlockInputToDb.call(this, blockInputs)
         : Promise.resolve(),
     ]);
 
@@ -190,10 +190,10 @@ export async function verifyBlocksInEpoch(
     if (segmentExecStatus.execAborted === null) {
       const {executionStatuses, executionTime} = segmentExecStatus;
       if (
-        blocksInputs.length === 1 &&
+        blockInputs.length === 1 &&
         // gossip blocks have seenTimestampSec
         opts.seenTimestampSec !== undefined &&
-        blocksInputs[0].type !== DAType.PreData &&
+        blockInputs[0].type !== DAType.PreData &&
         executionStatuses[0] === ExecutionStatus.Valid
       ) {
         // Find the max time when the block was actually verified
@@ -202,7 +202,7 @@ export async function verifyBlocksInEpoch(
         this.metrics?.gossipBlock.receivedToFullyVerifiedTime.observe(recvTofullyVerifedTime);
 
         const verifiedToBlobsAvailabiltyTime = Math.max(availableTime - fullyVerifiedTime, 0) / 1000;
-        const block = blocksInputs[0].getBlock() as deneb.SignedBeaconBlock;
+        const block = blockInputs[0].getBlock() as deneb.SignedBeaconBlock;
         const numBlobs = block.message.body.blobKzgCommitments.length;
 
         this.metrics?.gossipBlock.verifiedToBlobsAvailabiltyTime.observe({numBlobs}, verifiedToBlobsAvailabiltyTime);
@@ -210,7 +210,7 @@ export async function verifyBlocksInEpoch(
           slot: block.message.slot,
           recvTofullyVerifedTime,
           verifiedToBlobsAvailabiltyTime,
-          type: blocksInputs[0].type,
+          type: blockInputs[0].type,
           numBlobs,
         });
       }

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -79,6 +79,7 @@ import {sszDeserialize} from "../gossip/topic.js";
 import {INetwork} from "../interface.js";
 import {PeerAction} from "../peers/index.js";
 import {AggregatorTracker} from "./aggregatorTracker.js";
+import {VersionedHashes} from "../../execution/index.js";
 
 /**
  * Gossip handler options as part of network options
@@ -233,12 +234,19 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       metrics?.gossipBlob.validationTime.observe(validationTime);
 
       if (chain.emitter.listenerCount(routes.events.EventType.blobSidecar)) {
+        let versionedHash: Uint8Array;
+        if (blockInput.hasBlock()) {
+          // if block hasn't arrived yet then this will throw and need to calculate the versionedHash as a 1-off
+          versionedHash = blockInput.getVersionedHashes()[blobSidecar.index];
+        } else {
+          versionedHash = kzgCommitmentToVersionedHash(blobSidecar.kzgCommitment);
+        }
         chain.emitter.emit(routes.events.EventType.blobSidecar, {
           blockRoot: blockRootHex,
           slot,
           index: blobSidecar.index,
           kzgCommitment: toHex(blobSidecar.kzgCommitment),
-          versionedHash: toHex(kzgCommitmentToVersionedHash(blobSidecar.kzgCommitment)),
+          versionedHash: toHex(versionedHash),
         });
       }
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -79,7 +79,6 @@ import {sszDeserialize} from "../gossip/topic.js";
 import {INetwork} from "../interface.js";
 import {PeerAction} from "../peers/index.js";
 import {AggregatorTracker} from "./aggregatorTracker.js";
-import {VersionedHashes} from "../../execution/index.js";
 
 /**
  * Gossip handler options as part of network options

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -1,15 +1,14 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPostDeneb, ForkPostFulu, ForkPreFulu, isForkPostDeneb, isForkPostFulu} from "@lodestar/params";
-import {SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
+import {BlobIndex, ColumnIndex, SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
 import {LodestarError, fromHex, prettyBytes, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
-import {BlobMeta, BlockInputSource, IBlockInput, MissingColumnMeta} from "../../chain/blocks/blockInput/types.js";
+import {BlockInputSource, IBlockInput} from "../../chain/blocks/blockInput/types.js";
 import {SeenBlockInput} from "../../chain/seenCache/seenGossipBlockInput.js";
 import {validateBlockBlobSidecars} from "../../chain/validation/blobSidecar.js";
 import {validateBlockDataColumnSidecars} from "../../chain/validation/dataColumnSidecar.js";
 import {INetwork} from "../../network/interface.js";
 import {prettyPrintPeerIdStr} from "../../network/util.js";
-import {kzgCommitmentToVersionedHash} from "../../util/blobs.js";
 import {byteArrayEquals} from "../../util/bytes.js";
 import {
   BlockInputSyncCacheItem,
@@ -38,13 +37,14 @@ export type FetchByRootAndValidateBlockProps = Omit<FetchByRootCoreProps, "peerM
 export type FetchByRootAndValidateBlobsProps = FetchByRootAndValidateBlockProps & {
   forkName: ForkPreFulu;
   block: SignedBeaconBlock<ForkPostDeneb>;
-  blobMeta: BlobMeta[];
+  blockRoot: Uint8Array;
+  missing: BlobIndex[];
 };
 export type FetchByRootAndValidateColumnsProps = FetchByRootCoreProps & {
   blockRoot: Uint8Array;
   forkName: ForkPostFulu;
   block: SignedBeaconBlock<ForkPostFulu>;
-  columnMeta: MissingColumnMeta;
+  missing: ColumnIndex[];
 };
 export type FetchByRootResponses = {
   block: SignedBeaconBlock;
@@ -201,7 +201,7 @@ export async function fetchByRoot({
           forkName: forkName as ForkPreFulu,
           block: block as SignedBeaconBlock<ForkPostDeneb>,
           blockRoot,
-          blobMeta: cacheItem.blockInput.getMissingBlobMeta(),
+          missing: cacheItem.blockInput.getMissingBlobMeta().map(({index}) => index),
         });
       }
       if (isBlockInputColumns(cacheItem.blockInput)) {
@@ -212,7 +212,7 @@ export async function fetchByRoot({
           forkName: forkName as ForkPostFulu,
           block: block as SignedBeaconBlock<ForkPostFulu>,
           blockRoot,
-          columnMeta: cacheItem.blockInput.getMissingSampledColumnMeta(),
+          missing: cacheItem.blockInput.getMissingSampledColumnMeta().missing,
         });
       }
     }
@@ -232,12 +232,7 @@ export async function fetchByRoot({
         forkName,
         blockRoot,
         block: block as SignedBeaconBlock<ForkPostFulu>,
-        columnMeta: {
-          missing: network.custodyConfig.sampledColumns,
-          versionedHashes: (block as SignedBeaconBlock<ForkPostFulu>).message.body.blobKzgCommitments.map((c) =>
-            kzgCommitmentToVersionedHash(c)
-          ),
-        },
+        missing: network.custodyConfig.sampledColumns,
       });
     } else if (isForkPostDeneb(forkName)) {
       const commitments = (block as SignedBeaconBlock<ForkPostDeneb>).message.body.blobKzgCommitments;
@@ -249,11 +244,7 @@ export async function fetchByRoot({
         forkName: forkName as ForkPreFulu,
         blockRoot,
         block: block as SignedBeaconBlock<ForkPostDeneb>,
-        blobMeta: Array.from({length: blobCount}, (_, i) => ({
-          index: i,
-          blockRoot,
-          versionedHash: kzgCommitmentToVersionedHash(commitments[i]),
-        })),
+        missing: Array.from({length: blobCount}, (_, i) => i),
       });
     }
   }
@@ -303,15 +294,16 @@ export async function fetchAndValidateBlobs({
   peerIdStr,
   blockRoot,
   block,
-  blobMeta,
+  missing,
 }: FetchByRootAndValidateBlobsProps): Promise<deneb.BlobSidecars> {
   const blobSidecars: deneb.BlobSidecars = await fetchBlobsByRoot({
     network,
     peerIdStr,
-    blobMeta,
+    blockRoot,
+    missing,
   });
 
-  await validateBlockBlobSidecars(block.message.slot, blockRoot, blobMeta.length, blobSidecars);
+  await validateBlockBlobSidecars(block.message.slot, blockRoot, missing.length, blobSidecars);
 
   return blobSidecars;
 }
@@ -319,14 +311,15 @@ export async function fetchAndValidateBlobs({
 export async function fetchBlobsByRoot({
   network,
   peerIdStr,
-  blobMeta,
+  blockRoot,
+  missing,
   indicesInPossession = [],
-}: Pick<FetchByRootAndValidateBlobsProps, "network" | "peerIdStr" | "blobMeta"> & {
+}: Pick<FetchByRootAndValidateBlobsProps, "network" | "peerIdStr" | "blockRoot" | "missing"> & {
   indicesInPossession?: number[];
 }): Promise<deneb.BlobSidecars> {
-  const blobsRequest = blobMeta
-    .filter(({index}) => !indicesInPossession.includes(index))
-    .map(({blockRoot, index}) => ({blockRoot, index}));
+  const blobsRequest = missing
+    .filter((index) => !indicesInPossession.includes(index))
+    .map((index) => ({blockRoot, index}));
   if (!blobsRequest.length) {
     return [];
   }
@@ -338,7 +331,7 @@ export async function fetchAndValidateColumns({
   peerMeta,
   block,
   blockRoot,
-  columnMeta,
+  missing,
 }: FetchByRootAndValidateColumnsProps): Promise<WarnResult<fulu.DataColumnSidecars, DownloadByRootError>> {
   const {peerId: peerIdStr} = peerMeta;
   const slot = block.message.slot;
@@ -349,7 +342,7 @@ export async function fetchAndValidateColumns({
 
   const blockRootHex = toRootHex(blockRoot);
   const peerColumns = new Set(peerMeta.custodyGroups ?? []);
-  const requestedColumns = columnMeta.missing.filter((c) => peerColumns.has(c));
+  const requestedColumns = missing.filter((c) => peerColumns.has(c));
   const columnSidecars = await network.sendDataColumnSidecarsByRoot(peerIdStr, [
     {blockRoot, columns: requestedColumns},
   ]);
@@ -413,18 +406,18 @@ export async function fetchColumnsByRoot({
   network,
   peerMeta,
   blockRoot,
-  columnMeta,
+  missing,
 }: Pick<
   FetchByRootAndValidateColumnsProps,
-  "network" | "peerMeta" | "blockRoot" | "columnMeta"
+  "network" | "peerMeta" | "blockRoot" | "missing"
 >): Promise<fulu.DataColumnSidecars> {
-  return await network.sendDataColumnSidecarsByRoot(peerMeta.peerId, [{blockRoot, columns: columnMeta.missing}]);
+  return await network.sendDataColumnSidecarsByRoot(peerMeta.peerId, [{blockRoot, columns: missing}]);
 }
 
 // TODO(fulu) not in use, remove?
 export type ValidateColumnSidecarsProps = Pick<
   FetchByRootAndValidateColumnsProps,
-  "config" | "peerMeta" | "blockRoot" | "columnMeta"
+  "config" | "peerMeta" | "blockRoot" | "missing"
 > & {
   slot: number;
   blobCount: number;
@@ -438,11 +431,11 @@ export async function validateColumnSidecars({
   slot,
   blockRoot,
   blobCount,
-  columnMeta,
+  missing,
   needed = [],
   needToPublish = [],
 }: ValidateColumnSidecarsProps): Promise<void> {
-  const requestedIndices = columnMeta.missing;
+  const requestedIndices = missing;
   const extraIndices: number[] = [];
   for (const columnSidecar of needed) {
     if (!requestedIndices.includes(columnSidecar.index)) {

--- a/packages/beacon-node/test/unit/sync/utils/downloadByRoot.test.ts
+++ b/packages/beacon-node/test/unit/sync/utils/downloadByRoot.test.ts
@@ -1,8 +1,8 @@
 import {randomBytes} from "node:crypto";
 import {ForkName, NUMBER_OF_COLUMNS} from "@lodestar/params";
-import {ssz} from "@lodestar/types";
+import {BlobIndex, ColumnIndex, ssz} from "@lodestar/types";
 import {afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
-import {BlobMeta, MissingColumnMeta} from "../../../../src/chain/blocks/blockInput/types.js";
+import {BlobMeta} from "../../../../src/chain/blocks/blockInput/types.js";
 import {BlobSidecarValidationError} from "../../../../src/chain/errors/blobSidecarError.js";
 import {INetwork} from "../../../../src/network/index.js";
 import {
@@ -13,7 +13,6 @@ import {
   fetchBlobsByRoot,
   fetchColumnsByRoot,
 } from "../../../../src/sync/utils/downloadByRoot.js";
-import {kzgCommitmentToVersionedHash} from "../../../../src/util/blobs.js";
 import {ROOT_SIZE} from "../../../../src/util/sszBytes.js";
 import {
   config,
@@ -94,15 +93,11 @@ describe("downloadByRoot.ts", () => {
   describe("fetchAndValidateBlobs", () => {
     const forkName = ForkName.deneb;
     let denebBlockWithBlobs: ReturnType<typeof generateBlockWithBlobSidecars>;
-    let blobMeta: BlobMeta[];
+    let missing: BlobIndex[];
 
     beforeEach(() => {
       denebBlockWithBlobs = generateBlockWithBlobSidecars({forkName, count: 6});
-      blobMeta = denebBlockWithBlobs.versionedHashes.map((versionedHash, index) => ({
-        index,
-        blockRoot: denebBlockWithBlobs.blockRoot,
-        versionedHash,
-      }));
+      missing = denebBlockWithBlobs.blobSidecars.map(({index}) => index);
     });
 
     afterEach(() => {
@@ -122,7 +117,7 @@ describe("downloadByRoot.ts", () => {
         peerIdStr,
         blockRoot: denebBlockWithBlobs.blockRoot,
         block: denebBlockWithBlobs.block,
-        blobMeta,
+        missing,
       });
 
       expect(response).toEqual(denebBlockWithBlobs.blobSidecars);
@@ -147,12 +142,12 @@ describe("downloadByRoot.ts", () => {
         peerIdStr,
         blockRoot: denebBlockWithBlobs.blockRoot,
         block: denebBlockWithBlobs.block,
-        blobMeta,
+        missing,
       });
 
       expect(sendBlobSidecarsByRootMock).toHaveBeenCalledExactlyOnceWith(
         peerIdStr,
-        denebBlockWithBlobs.blobSidecars.map(({index}) => ({blockRoot: denebBlockWithBlobs.blockRoot, index}))
+        missing.map((index) => ({blockRoot: denebBlockWithBlobs.blockRoot, index}))
       );
 
       const returnedIndices = response.map((b) => b.index);
@@ -175,7 +170,7 @@ describe("downloadByRoot.ts", () => {
           peerIdStr,
           blockRoot: requestedBlockRoot,
           block: denebBlockWithBlobs.block,
-          blobMeta,
+          missing,
         })
       ).rejects.toThrow(BlobSidecarValidationError);
     });
@@ -184,11 +179,13 @@ describe("downloadByRoot.ts", () => {
   describe("fetchBlobsByRoot", () => {
     let denebBlockWithColumns: ReturnType<typeof generateBlockWithBlobSidecars>;
     let blockRoot: Uint8Array;
+    let missing: BlobIndex[];
     let blobMeta: BlobMeta[];
     beforeAll(() => {
       denebBlockWithColumns = generateBlockWithBlobSidecars({forkName: ForkName.deneb, count: 6});
       blockRoot = denebBlockWithColumns.blockRoot;
-      blobMeta = denebBlockWithColumns.blobSidecars.map((_, index) => ({blockRoot, index}) as BlobMeta);
+      missing = denebBlockWithColumns.blobSidecars.map(({index}) => index);
+      blobMeta = missing.map((index) => ({blockRoot, index}) as BlobMeta);
       network = {
         sendBlobSidecarsByRoot: vi.fn(() => denebBlockWithColumns.blobSidecars),
       } as unknown as INetwork;
@@ -201,7 +198,8 @@ describe("downloadByRoot.ts", () => {
       const response = await fetchBlobsByRoot({
         network,
         peerIdStr,
-        blobMeta,
+        blockRoot,
+        missing,
       });
       expect(response).toEqual(denebBlockWithColumns.blobSidecars);
       expect(network.sendBlobSidecarsByRoot).toHaveBeenCalledOnce();
@@ -212,7 +210,8 @@ describe("downloadByRoot.ts", () => {
       await fetchBlobsByRoot({
         network,
         peerIdStr,
-        blobMeta,
+        blockRoot,
+        missing,
         // biome-ignore lint/style/noNonNullAssertion: its there
         indicesInPossession: [0, denebBlockWithColumns.blobSidecars.at(-1)?.index!],
       });
@@ -224,7 +223,8 @@ describe("downloadByRoot.ts", () => {
       const response = await fetchBlobsByRoot({
         network,
         peerIdStr,
-        blobMeta,
+        blockRoot,
+        missing,
         indicesInPossession: blobMeta.map(({index}) => index),
       });
       expect(response).toEqual([]);
@@ -235,18 +235,11 @@ describe("downloadByRoot.ts", () => {
   describe("fetchAndValidateColumns", () => {
     const forkName = ForkName.fulu;
     let fuluBlockWithColumns: ReturnType<typeof generateBlockWithColumnSidecars>;
-    let columnMeta: MissingColumnMeta;
-    let versionedHashes: Uint8Array[];
+    let missing: ColumnIndex[];
 
     beforeEach(() => {
       fuluBlockWithColumns = generateBlockWithColumnSidecars({forkName, returnBlobs: true});
-      versionedHashes = fuluBlockWithColumns.block.message.body.blobKzgCommitments.map((c) =>
-        kzgCommitmentToVersionedHash(c)
-      );
-      columnMeta = {
-        missing: [0, 1, 2, 3, 4, 5, 6, 7], // Sample a subset of columns
-        versionedHashes,
-      };
+      missing = [0, 1, 2, 3, 4, 5, 6, 7]; // Sample a subset of columns
     });
 
     afterEach(() => {
@@ -254,13 +247,13 @@ describe("downloadByRoot.ts", () => {
     });
 
     it("should successfully fetch columns from network only", async () => {
-      const neededColumns = fuluBlockWithColumns.columnSidecars.filter((c) => columnMeta.missing.includes(c.index));
+      const neededColumns = fuluBlockWithColumns.columnSidecars.filter((c) => missing.includes(c.index));
       const sendDataColumnSidecarsByRootMock = vi.fn(() => Promise.resolve(neededColumns));
       network = {
         sendDataColumnSidecarsByRoot: sendDataColumnSidecarsByRootMock,
         custodyConfig: {
           custodyColumns: [0, 1, 2, 3, 4, 5],
-          sampledColumns: columnMeta.missing,
+          sampledColumns: missing,
         },
         logger: {
           error: vi.fn(),
@@ -274,13 +267,13 @@ describe("downloadByRoot.ts", () => {
         peerMeta,
         blockRoot: fuluBlockWithColumns.blockRoot,
         block: fuluBlockWithColumns.block,
-        columnMeta,
+        missing,
       });
 
       expect(sendDataColumnSidecarsByRootMock).toHaveBeenCalledExactlyOnceWith(peerIdStr, [
-        {blockRoot: fuluBlockWithColumns.blockRoot, columns: columnMeta.missing},
+        {blockRoot: fuluBlockWithColumns.blockRoot, columns: missing},
       ]);
-      expect(response.result.map((c) => c.index)).toEqual(columnMeta.missing);
+      expect(response.result.map((c) => c.index)).toEqual(missing);
     });
 
     it("should throw error if column validation fails", async () => {
@@ -315,10 +308,7 @@ describe("downloadByRoot.ts", () => {
           peerMeta,
           blockRoot: fuluBlockWithColumns.blockRoot,
           block: fuluBlockWithColumns.block,
-          columnMeta: {
-            missing: [0, 1, 2, 3, 4, 5],
-            versionedHashes,
-          },
+          missing: [0, 1, 2, 3, 4, 5],
         })
       ).rejects.toThrow(DataColumnSidecarValidationError);
     });
@@ -342,10 +332,7 @@ describe("downloadByRoot.ts", () => {
         network,
         peerMeta,
         blockRoot,
-        columnMeta: {
-          missing,
-          versionedHashes: [],
-        },
+        missing,
       });
       expect(response).toEqual(fuluBlockWithColumns.columnSidecars);
       expect(network.sendDataColumnSidecarsByRoot).toHaveBeenCalledOnce();


### PR DESCRIPTION
**Motivation**

Audit usage of kzgCommitmentToVersionedHash to make sure we are not recomputing anywhere unnecessarily.  Is a heavy operation and in most cases has already been computed and cached on the BlockInput

Updated `verifyBlocksExecutionPayload`, `verifyBlockExecutionPayload` and `getSegmentErrorResponse` to use `IBlockInput` so that the cached versionedHashes could be consumed instead of recalculating them