### PR TITLE
feat: track BlockInputSync result

### DIFF
--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -4,7 +4,7 @@ import {StrictEventEmitter} from "strict-event-emitter-types";
 import {routes} from "@lodestar/api";
 import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
-import {RootHex, deneb, fulu, phase0} from "@lodestar/types";
+import {RootOptionalSlot, deneb, fulu, phase0} from "@lodestar/types";
 import {PeerIdStr} from "../util/peerId.js";
 import {BlockInputSource, IBlockInput} from "./blocks/blockInput/types.js";
 
@@ -77,7 +77,7 @@ type ApiEvents = {[K in routes.events.EventType]: (data: routes.events.EventData
 
 export type ChainEventData = {
   [ChainEvent.unknownParent]: {blockInput: IBlockInput; peer: PeerIdStr; source: BlockInputSource};
-  [ChainEvent.unknownBlockRoot]: {rootHex: RootHex; peer?: PeerIdStr; source: BlockInputSource};
+  [ChainEvent.unknownBlockRoot]: {rootSlot: RootOptionalSlot; peer?: PeerIdStr; source: BlockInputSource};
   [ChainEvent.incompleteBlockInput]: {blockInput: IBlockInput; peer: PeerIdStr; source: BlockInputSource};
 };
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -568,6 +568,23 @@ export function createLodestarMetrics(
         help: "Total number of blocks whose data availability was resolved",
         labelNames: ["source"],
       }),
+      fetchBegin: register.histogram({
+        name: "lodestar_sync_unknown_block_fetch_begin_since_slot_start_seconds",
+        help: "Time into the slot when the block was fetched",
+        buckets: [0, 1, 2, 4],
+      }),
+      // we may not have slot in case of failure, so track fetch time from start to done (either success or failure)
+      fetchTimeSec: register.histogram<{result: string}>({
+        name: "lodestar_sync_unknown_block_fetch_time_seconds",
+        help: "Fetch time from start to done (either success or failure)",
+        labelNames: ["result"],
+        buckets: [0, 1, 2, 4, 8],
+      }),
+      fetchPeers: register.gauge<{result: string}>({
+        name: "lodestar_sync_unknown_block_fetch_peers_count",
+        help: "Number of peers that node fetched from",
+        labelNames: ["result"],
+      }),
       downloadByRoot: {
         success: register.gauge({
           name: "lodestar_sync_unknown_block_download_by_root_success_total",

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -231,13 +231,14 @@ export class NetworkProcessor {
     return queue.getAll();
   }
 
-  searchUnknownSlotRoot({slot, root}: SlotRootHex, source: BlockInputSource, peer?: PeerIdStr): void {
+  searchUnknownSlotRoot(slotRoot: SlotRootHex, source: BlockInputSource, peer?: PeerIdStr): void {
+    const {slot, root} = slotRoot;
     if (this.chain.seenBlock(root) || this.unknownRootsBySlot.getOrDefault(slot).has(root)) {
       return;
     }
     // Search for the unknown block
     this.unknownRootsBySlot.getOrDefault(slot).add(root);
-    this.chain.emitter.emit(ChainEvent.unknownBlockRoot, {rootHex: root, peer, source});
+    this.chain.emitter.emit(ChainEvent.unknownBlockRoot, {rootSlot: slotRoot, peer, source});
   }
 
   private onPendingGossipsubMessage(message: PendingGossipsubMessage): void {

--- a/packages/beacon-node/src/sync/types.ts
+++ b/packages/beacon-node/src/sync/types.ts
@@ -37,6 +37,8 @@ export type PendingBlockInput = {
 export type PendingRootHex = {
   status: PendingBlockInputStatus.pending | PendingBlockInputStatus.fetching;
   rootHex: RootHex;
+  // optional because we may not know the slot of parent_unknown event
+  slot?: Slot;
   timeAddedSec: number;
   timeSyncedSec?: number;
   peerIdStrings: Set<string>;

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -1,6 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkSeq, INTERVALS_PER_SLOT} from "@lodestar/params";
-import {RootHex} from "@lodestar/types";
+import {RootHex, Slot} from "@lodestar/types";
 import {sleep, Logger, prettyBytes, prettyPrintIndices, pruneSetToMax} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource, IBlockInput} from "../chain/blocks/blockInput/types.js";
@@ -31,6 +31,14 @@ import {RequestError} from "@lodestar/reqresp";
 const MAX_ATTEMPTS_PER_BLOCK = 5;
 const MAX_KNOWN_BAD_BLOCKS = 500;
 const MAX_PENDING_BLOCKS = 100;
+
+enum FetchResult {
+  SuccessResolved = "success_resolved",
+  SuccessMissingParent = "success_missing_parent",
+  SuccessLate = "success_late",
+  FailureTriedAllPeers = "failure_tried_all_peers",
+  FailureMaxAttempts = "failure_max_attempts",
+}
 
 /**
  * BlockInputSync is a class that handles ReqResp to find blocks and data related to a specific blockRoot.  The
@@ -138,7 +146,8 @@ export class BlockInputSync {
    */
   private onUnknownBlockRoot = (data: ChainEventData[ChainEvent.unknownBlockRoot]): void => {
     try {
-      this.addByRootHex(data.rootHex, data.peer);
+      const {root, slot} = data.rootSlot;
+      this.addByRootHex(root, slot, data.peer);
       this.triggerUnknownBlockSearch();
       this.metrics?.blockInputSync.requests.inc({type: PendingBlockType.UNKNOWN_BLOCK_ROOT});
       this.metrics?.blockInputSync.source.inc({source: data.source});
@@ -166,7 +175,8 @@ export class BlockInputSync {
    */
   private onUnknownParent = (data: ChainEventData[ChainEvent.unknownParent]): void => {
     try {
-      this.addByRootHex(data.blockInput.parentRootHex, data.peer);
+      // we don't know the slot of parent, hence make it undefined
+      this.addByRootHex(data.blockInput.parentRootHex, undefined, data.peer);
       this.addByBlockInput(data.blockInput, data.peer);
       this.triggerUnknownBlockSearch();
       this.metrics?.blockInputSync.requests.inc({type: PendingBlockType.UNKNOWN_PARENT});
@@ -176,11 +186,12 @@ export class BlockInputSync {
     }
   };
 
-  private addByRootHex = (rootHex: RootHex, peerIdStr?: PeerIdStr): void => {
+  private addByRootHex = (rootHex: RootHex, slot?: Slot, peerIdStr?: PeerIdStr): void => {
     let pendingBlock = this.pendingBlocks.get(rootHex);
     if (!pendingBlock) {
       pendingBlock = {
         status: PendingBlockInputStatus.pending,
+        slot,
         rootHex: rootHex,
         peerIdStrings: new Set(),
         timeAddedSec: Date.now() / 1000,
@@ -351,7 +362,7 @@ export class BlockInputSync {
         });
         this.removeAndDownScoreAllDescendants(block);
       } else {
-        this.onUnknownBlockRoot({rootHex: pending.blockInput.parentRootHex, source: BlockInputSource.byRoot});
+        this.onUnknownBlockRoot({rootSlot: {root: pending.blockInput.parentRootHex}, source: BlockInputSource.byRoot});
       }
     } else {
       this.metrics?.blockInputSync.downloadedBlocksError.inc();
@@ -487,6 +498,12 @@ export class BlockInputSync {
         ? new Set(this.network.custodyConfig.sampledColumns)
         : null;
 
+    const fetchStartSec = Date.now() / 1000;
+    let slot = isPendingBlockInput(cacheItem) ? cacheItem.blockInput.slot : cacheItem.slot;
+    if (slot !== undefined) {
+      this.metrics?.blockInputSync.fetchBegin.observe(this.chain.clock.secFromSlot(slot, fetchStartSec));
+    }
+
     let i = 0;
     while (i++ < this.getMaxDownloadAttempts()) {
       const pendingColumns =
@@ -501,6 +518,11 @@ export class BlockInputSync {
         if (pendingColumns) {
           message += ` with needed columns=${prettyPrintIndices(Array.from(pendingColumns))}`;
         }
+        this.metrics?.blockInputSync.fetchTimeSec.observe(
+          {result: FetchResult.FailureTriedAllPeers},
+          Date.now() / 1000 - fetchStartSec
+        );
+        this.metrics?.blockInputSync.fetchPeers.set({result: FetchResult.FailureTriedAllPeers}, i);
         throw Error(message);
       }
       const {peerId, client: peerClient} = peerMeta;
@@ -517,7 +539,13 @@ export class BlockInputSync {
           cacheItem,
         });
         cacheItem = downloadResult.result;
-        const logCtx = {slot: cacheItem.blockInput.slot, rootHex, peerId, peerClient};
+        if (slot === undefined) {
+          slot = cacheItem.blockInput.slot;
+          // we were not able to observe the time into slot when starting the fetch, do it now
+          this.metrics?.blockInputSync.fetchBegin.observe(this.chain.clock.secFromSlot(slot, fetchStartSec));
+        }
+
+        const logCtx = {slot, rootHex, peerId, peerClient};
         this.logger.verbose("BlockInputSync.fetchBlockInput: successful download", logCtx);
         this.metrics?.blockInputSync.downloadByRoot.success.inc();
         const warnings = downloadResult.warnings;
@@ -553,9 +581,17 @@ export class BlockInputSync {
       this.pendingBlocks.set(getBlockInputSyncCacheItemRootHex(cacheItem), cacheItem);
 
       if (cacheItem.status === PendingBlockInputStatus.downloaded) {
+        // download was successful, no need to go with another peer, return
+        const result = this.chain.forkChoice.hasBlockHex(cacheItem.blockInput.blockRootHex)
+          ? FetchResult.SuccessLate
+          : this.chain.forkChoice.hasBlockHex(cacheItem.blockInput.parentRootHex)
+            ? FetchResult.SuccessResolved
+            : FetchResult.SuccessMissingParent;
+        this.metrics?.blockInputSync.fetchTimeSec.observe({result}, Date.now() / 1000 - fetchStartSec);
+        this.metrics?.blockInputSync.fetchPeers.set({result}, i);
         return cacheItem;
       }
-    }
+    } // end while loop over peers
 
     let message = `Error fetching BlockInput with blockRoot=${prettyBytes(rootHex)} after ${i} attempts.`;
     if (!isPendingBlockInput(cacheItem)) {
@@ -575,6 +611,12 @@ export class BlockInputSync {
         }
       }
     }
+
+    this.metrics?.blockInputSync.fetchTimeSec.observe(
+      {result: FetchResult.FailureMaxAttempts},
+      Date.now() / 1000 - fetchStartSec
+    );
+    this.metrics?.blockInputSync.fetchPeers.set({result: FetchResult.FailureMaxAttempts}, i - 1);
 
     throw Error(message);
   }

--- a/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
@@ -171,7 +171,7 @@ describe("sync / unknown block sync for fulu", () => {
           break;
         case ChainEvent.unknownBlockRoot:
           bn2.chain.emitter.emit(ChainEvent.unknownBlockRoot, {
-            rootHex: headSummary.blockRoot,
+            rootSlot: {root: headSummary.blockRoot},
             peer: bn2.network.peerId.toString(),
             source: BlockInputSource.gossip,
           });

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -215,7 +215,7 @@ describe.skip(
           });
         } else {
           chain.emitter?.emit(ChainEvent.unknownBlockRoot, {
-            rootHex: blockRootHexC,
+            rootSlot: {root: blockRootHexC},
             peer,
             source: BlockInputSource.gossip,
           });

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -42,6 +42,7 @@ export type WithOptionalBytes<T> = {
 
 export type SlotRootHex = {slot: Slot; root: RootHex};
 export type SlotOptionalRoot = {slot: Slot; root?: RootHex};
+export type RootOptionalSlot = {root: RootHex; slot?: Slot};
 
 type TypesByFork = {
   [ForkName.phase0]: {


### PR DESCRIPTION
**Motivation**

- we want to know how UnknownBlock helps us

**Description**

- track fetch time into slot
- track total fetch time
- track fetch result and fetched peers with different labels following this enum:
```typescript
enum FetchResult {
  SuccessResolved = "success_resolved",
  SuccessMissingParent = "success_missing_parent",
  SuccessLate = "success_late",
  FailureTriedAllPeers = "failure_tried_all_peers",
  FailureMaxAttempts = "failure_max_attempts",
}
```

Closes #8403
