### PR TITLE
chore: remove `getMaxRequestBlobSidecars` helper from config object

### DIFF
--- a/packages/beacon-node/src/network/reqresp/rateLimit.ts
+++ b/packages/beacon-node/src/network/reqresp/rateLimit.ts
@@ -1,5 +1,5 @@
 import {BeaconConfig} from "@lodestar/config";
-import {ForkName, MAX_REQUEST_LIGHT_CLIENT_UPDATES, isForkPostDeneb} from "@lodestar/params";
+import {ForkName, MAX_REQUEST_LIGHT_CLIENT_UPDATES, isForkPostDeneb, isForkPostElectra} from "@lodestar/params";
 import {InboundRateLimitQuota} from "@lodestar/reqresp";
 import {ReqRespMethod, RequestBodyByMethod, requestSszTypeByMethod} from "./types.js";
 
@@ -42,12 +42,18 @@ export const rateLimitQuotas: (fork: ForkName, config: BeaconConfig) => Record<R
   },
   [ReqRespMethod.BlobSidecarsByRange]: {
     // Rationale: MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK
-    byPeer: {quota: config.getMaxRequestBlobSidecars(fork), quotaTimeMs: 10_000},
+    byPeer: {
+      quota: isForkPostElectra(fork) ? config.MAX_REQUEST_BLOB_SIDECARS_ELECTRA : config.MAX_REQUEST_BLOB_SIDECARS,
+      quotaTimeMs: 10_000,
+    },
     getRequestCount: getRequestCountFn(fork, config, ReqRespMethod.BlobSidecarsByRange, (req) => req.count),
   },
   [ReqRespMethod.BlobSidecarsByRoot]: {
     // Rationale: quota of BeaconBlocksByRoot * MAX_BLOBS_PER_BLOCK
-    byPeer: {quota: config.getMaxRequestBlobSidecars(fork), quotaTimeMs: 10_000},
+    byPeer: {
+      quota: isForkPostElectra(fork) ? config.MAX_REQUEST_BLOB_SIDECARS_ELECTRA : config.MAX_REQUEST_BLOB_SIDECARS,
+      quotaTimeMs: 10_000,
+    },
     getRequestCount: getRequestCountFn(fork, config, ReqRespMethod.BlobSidecarsByRoot, (req) => req.length),
   },
   [ReqRespMethod.DataColumnSidecarsByRange]: {

--- a/packages/beacon-node/src/util/types.ts
+++ b/packages/beacon-node/src/util/types.ts
@@ -1,6 +1,6 @@
 import {ContainerType, ListCompositeType, ValueOf} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {ForkName, isForkPostDeneb} from "@lodestar/params";
+import {ForkName, isForkPostDeneb, isForkPostElectra} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 
 // Misc SSZ types used only in the beacon-node package, no need to upstream to types
@@ -20,7 +20,10 @@ export const BeaconBlocksByRootRequestType = (fork: ForkName, config: BeaconConf
 export type BeaconBlocksByRootRequest = ValueOf<ReturnType<typeof BeaconBlocksByRootRequestType>>;
 
 export const BlobSidecarsByRootRequestType = (fork: ForkName, config: BeaconConfig) =>
-  new ListCompositeType(ssz.deneb.BlobIdentifier, config.getMaxRequestBlobSidecars(fork));
+  new ListCompositeType(
+    ssz.deneb.BlobIdentifier,
+    isForkPostElectra(fork) ? config.MAX_REQUEST_BLOB_SIDECARS_ELECTRA : config.MAX_REQUEST_BLOB_SIDECARS
+  );
 export type BlobSidecarsByRootRequest = ValueOf<ReturnType<typeof BlobSidecarsByRootRequestType>>;
 
 export const DataColumnSidecarsByRootRequestType = (config: BeaconConfig) =>

--- a/packages/config/src/forkConfig/index.ts
+++ b/packages/config/src/forkConfig/index.ts
@@ -10,7 +10,6 @@ import {
   isForkPostAltair,
   isForkPostBellatrix,
   isForkPostDeneb,
-  isForkPostElectra,
 } from "@lodestar/params";
 import {Epoch, SSZTypesFor, Slot, Version, sszTypesFor} from "@lodestar/types";
 import {ChainConfig} from "../chainConfig/index.js";
@@ -199,9 +198,6 @@ export function createForkConfig(config: ChainConfig): ForkConfig {
       }
 
       return {epoch: config.ELECTRA_FORK_EPOCH, maxBlobsPerBlock: config.MAX_BLOBS_PER_BLOCK_ELECTRA};
-    },
-    getMaxRequestBlobSidecars(fork: ForkName): number {
-      return isForkPostElectra(fork) ? config.MAX_REQUEST_BLOB_SIDECARS_ELECTRA : config.MAX_REQUEST_BLOB_SIDECARS;
     },
   };
 }

--- a/packages/config/src/forkConfig/types.ts
+++ b/packages/config/src/forkConfig/types.ts
@@ -56,6 +56,4 @@ export type ForkConfig = {
   getMaxBlobsPerBlock(epoch: Epoch): number;
   /** Get blob parameters at a given epoch */
   getBlobParameters(epoch: Epoch): BlobParameters;
-  /** Get max request blob sidecars by hard-fork */
-  getMaxRequestBlobSidecars(fork: ForkName): number;
 };


### PR DESCRIPTION
The `getMaxRequestBlobSidecars` helper is only relevant for deneb and electra and we no longer will have to update the conditional. It shouldn't be part of config object as it will be legacy code once fulu is activated.