### PR TITLE
fix: small fixes and e2e test fix

### DIFF
--- a/packages/beacon-node/src/network/events.ts
+++ b/packages/beacon-node/src/network/events.ts
@@ -25,7 +25,7 @@ export type NetworkEventData = {
   [NetworkEvent.peerConnected]: {
     peer: PeerIdStr;
     status: Status;
-    custodyGroups: CustodyIndex[];
+    custodyColumns: CustodyIndex[];
     clientAgent: string;
   };
   [NetworkEvent.peerDisconnected]: {peer: PeerIdStr};

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -731,17 +731,17 @@ export class Network implements INetwork {
   };
 
   private onPeerConnected = (data: NetworkEventData[NetworkEvent.peerConnected]): void => {
-    const {peer, clientAgent, custodyGroups, status} = data;
+    const {peer, clientAgent, custodyColumns, status} = data;
     const earliestAvailableSlot = (status as fulu.Status).earliestAvailableSlot;
     this.logger.verbose("onPeerConnected", {
       peer,
       clientAgent,
-      custodyGroups: prettyPrintIndices(custodyGroups),
+      custodyColumns: prettyPrintIndices(custodyColumns),
       earliestAvailableSlot: earliestAvailableSlot ?? "pre-fulu",
     });
     this.connectedPeersSyncMeta.set(peer, {
       client: clientAgent,
-      custodyGroups,
+      custodyColumns,
       earliestAvailableSlot, // can be undefined pre-fulu
     });
   };

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -7,7 +7,7 @@ import {Metadata, Status, altair, fulu, phase0} from "@lodestar/types";
 import {prettyPrintIndices, toHex, withTimeout} from "@lodestar/utils";
 import {GOODBYE_KNOWN_CODES, GoodByeReasonCode, Libp2pEvent} from "../../constants/index.js";
 import {IClock} from "../../util/clock.js";
-import {computeColumnsForCustodyGroup, getCustodyGroups, getDataColumns} from "../../util/dataColumns.js";
+import {computeColumnsForCustodyGroup, getCustodyGroups} from "../../util/dataColumns.js";
 import {NetworkCoreMetrics} from "../core/metrics.js";
 import {LodestarDiscv5Opts} from "../discv5/types.js";
 import {INetworkEventBus, NetworkEvent, NetworkEventData} from "../events.js";
@@ -443,11 +443,12 @@ export class PeerManager {
       const custodyGroupCount = peerData?.metadata?.custodyGroupCount ?? this.config.CUSTODY_REQUIREMENT;
       const custodyGroups =
         peerData?.metadata?.custodyGroups ?? getCustodyGroups(this.config, nodeId, custodyGroupCount);
-      const custodyColumns = custodyGroups.flatMap((g) => computeColumnsForCustodyGroup(this.config, g));
-      const dataColumns = getDataColumns(this.config, nodeId, custodyGroupCount);
+      const custodyColumns = custodyGroups
+        .flatMap((g) => computeColumnsForCustodyGroup(this.config, g))
+        .sort((a, b) => a - b);
 
       const sampleSubnets = this.networkConfig.custodyConfig.sampledSubnets;
-      const matchingSubnetsNum = sampleSubnets.reduce((acc, elem) => acc + (dataColumns.includes(elem) ? 1 : 0), 0);
+      const matchingSubnetsNum = sampleSubnets.reduce((acc, elem) => acc + (custodyColumns.includes(elem) ? 1 : 0), 0);
       const hasAllColumns = matchingSubnetsNum === sampleSubnets.length;
       const clientAgent = peerData?.agentClient ?? ClientKind.Unknown;
 
@@ -457,7 +458,6 @@ export class PeerManager {
         peerId: peer.toString(),
         custodyGroupCount,
         hasAllColumns,
-        dataColumns: prettyPrintIndices(dataColumns),
         matchingSubnetsNum,
         custodyGroups: prettyPrintIndices(custodyGroups),
         custodyColumns: prettyPrintIndices(custodyColumns),

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -7,7 +7,7 @@ import {Metadata, Status, altair, fulu, phase0} from "@lodestar/types";
 import {prettyPrintIndices, toHex, withTimeout} from "@lodestar/utils";
 import {GOODBYE_KNOWN_CODES, GoodByeReasonCode, Libp2pEvent} from "../../constants/index.js";
 import {IClock} from "../../util/clock.js";
-import {getCustodyGroups, getDataColumns} from "../../util/dataColumns.js";
+import {computeColumnsForCustodyGroup, getCustodyGroups, getDataColumns} from "../../util/dataColumns.js";
 import {NetworkCoreMetrics} from "../core/metrics.js";
 import {LodestarDiscv5Opts} from "../discv5/types.js";
 import {INetworkEventBus, NetworkEvent, NetworkEventData} from "../events.js";
@@ -443,6 +443,7 @@ export class PeerManager {
       const custodyGroupCount = peerData?.metadata?.custodyGroupCount ?? this.config.CUSTODY_REQUIREMENT;
       const custodyGroups =
         peerData?.metadata?.custodyGroups ?? getCustodyGroups(this.config, nodeId, custodyGroupCount);
+      const custodyColumns = custodyGroups.flatMap((g) => computeColumnsForCustodyGroup(this.config, g));
       const dataColumns = getDataColumns(this.config, nodeId, custodyGroupCount);
 
       const sampleSubnets = this.networkConfig.custodyConfig.sampledSubnets;
@@ -459,6 +460,7 @@ export class PeerManager {
         dataColumns: prettyPrintIndices(dataColumns),
         matchingSubnetsNum,
         custodyGroups: prettyPrintIndices(custodyGroups),
+        custodyColumns: prettyPrintIndices(custodyColumns),
         mySampleSubnets: prettyPrintIndices(sampleSubnets),
         clientAgent,
       });
@@ -467,7 +469,7 @@ export class PeerManager {
         peer: peer.toString(),
         status,
         clientAgent,
-        custodyGroups,
+        custodyColumns,
       });
     }
   }

--- a/packages/beacon-node/src/network/peers/peersData.ts
+++ b/packages/beacon-node/src/network/peers/peersData.ts
@@ -9,7 +9,7 @@ type Metadata = fulu.Metadata & {custodyGroups: CustodyIndex[]; samplingGroups: 
 export type PeerSyncMeta = {
   peerId: PeerIdStr;
   client: string;
-  custodyGroups: CustodyIndex[];
+  custodyColumns: CustodyIndex[];
   earliestAvailableSlot?: Slot;
 };
 

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -233,7 +233,7 @@ export class Batch {
       return this.requests;
     }
 
-    const peerColumns = new Set(peer.custodyGroups ?? []);
+    const peerColumns = new Set(peer.custodyColumns ?? []);
     const requestedColumns = columnsRequest.columns.filter((c) => peerColumns.has(c));
     if (requestedColumns.length === columnsRequest.columns.length) {
       return this.requests;

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -676,8 +676,8 @@ export class SyncChain {
 
     const peersByColumnIndex = new Map<number, number>();
     for (const [columnIndex, column] of this.custodyConfig.sampledColumns.entries()) {
-      for (const {custodyGroups} of peersSyncMeta.values()) {
-        if (custodyGroups.includes(column)) {
+      for (const {custodyColumns} of peersSyncMeta.values()) {
+        if (custodyColumns.includes(column)) {
           peersByColumnIndex.set(columnIndex, (peersByColumnIndex.get(columnIndex) ?? 0) + 1);
         }
       }

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -163,7 +163,7 @@ export class ChainPeersBalancer {
         continue;
       }
 
-      const columns = peer.custodyGroups.reduce((acc, elem) => {
+      const columns = peer.custodyColumns.reduce((acc, elem) => {
         if (requestColumns.includes(elem)) {
           acc.push(elem);
         }

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -26,7 +26,7 @@ import {
 } from "./types.js";
 import {DownloadByRootError, downloadByRoot} from "./utils/downloadByRoot.js";
 import {getAllDescendantBlocks, getDescendantBlocks, getUnknownAndAncestorBlocks} from "./utils/pendingBlocksTree.js";
-import {RequestError} from "@lodestar/reqresp";
+import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
 
 const MAX_ATTEMPTS_PER_BLOCK = 5;
 const MAX_KNOWN_BAD_BLOCKS = 500;
@@ -526,7 +526,6 @@ export class BlockInputSync {
         throw Error(message);
       }
       const {peerId, client: peerClient} = peerMeta;
-      excludedPeers.add(peerId);
 
       cacheItem.peerIdStrings.add(peerId);
 
@@ -567,12 +566,23 @@ export class BlockInputSync {
         if (e instanceof DownloadByRootError) {
           const errorCode = e.type.code;
           downloadByRootMetrics?.error.inc({code: errorCode, client: peerClient});
+          excludedPeers.add(peerId);
         } else if (e instanceof RequestError) {
           // should look into req_resp metrics in this case
           downloadByRootMetrics?.error.inc({code: "req_resp", client: peerClient});
+          switch (e.type.code) {
+            case RequestErrorCode.REQUEST_RATE_LIMITED:
+            case RequestErrorCode.REQUEST_TIMEOUT:
+              // do not exclude peer for these errors
+              break;
+            default:
+              excludedPeers.add(peerId);
+              break;
+          }
         } else {
           // investigate if this happens
           downloadByRootMetrics?.error.inc({code: "unknown", client: peerClient});
+          excludedPeers.add(peerId);
         }
       } finally {
         this.peerBalancer.onRequestCompleted(peerId);
@@ -812,7 +822,7 @@ export class UnknownBlockPeerBalancer {
       }
 
       // postfulu, find peers that have custody columns that we need
-      const {custodyGroups: peerColumns} = syncMeta;
+      const {custodyColumns: peerColumns} = syncMeta;
       // check if the peer has all needed columns
       // get match
       const columns = peerColumns.reduce((acc, elem) => {

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -341,7 +341,7 @@ export async function fetchAndValidateColumns({
   }
 
   const blockRootHex = toRootHex(blockRoot);
-  const peerColumns = new Set(peerMeta.custodyGroups ?? []);
+  const peerColumns = new Set(peerMeta.custodyColumns ?? []);
   const requestedColumns = missing.filter((c) => peerColumns.has(c));
   const columnSidecars = await network.sendDataColumnSidecarsByRoot(peerIdStr, [
     {blockRoot, columns: requestedColumns},

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -72,7 +72,7 @@ describe("data serialization through worker boundary", () => {
 
   // Defining tests in this notation ensures that any event data is tested and probably safe to send
   const networkEventData = filterByUsedEvents<NetworkEventData>(networkEventDirection, {
-    [NetworkEvent.peerConnected]: {peer, status: statusZero, custodyGroups: [1, 2, 3, 4], clientAgent: "CLIENT_AGENT"},
+    [NetworkEvent.peerConnected]: {peer, status: statusZero, custodyColumns: [1, 2, 3, 4], clientAgent: "CLIENT_AGENT"},
     [NetworkEvent.peerDisconnected]: {peer},
     [NetworkEvent.reqRespRequest]: {
       request: {method: ReqRespMethod.Status, body: statusZero},

--- a/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
@@ -5,7 +5,7 @@ import {ChainConfig} from "@lodestar/config";
 import {TimestampFormatCode} from "@lodestar/logger";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {afterEach, describe, it, vi} from "vitest";
-import {BlockInputPreData} from "../../../src/chain/blocks/blockInput/blockInput.js";
+import {BlockInputColumns} from "../../../src/chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource} from "../../../src/chain/blocks/blockInput/types.js";
 import {ChainEvent} from "../../../src/chain/emitter.js";
 import {BlockError, BlockErrorCode} from "../../../src/chain/errors/index.js";
@@ -15,6 +15,7 @@ import {LogLevel, TestLoggerOpts, testLogger} from "../../utils/logger.js";
 import {connect, onPeerConnect} from "../../utils/network.js";
 import {getDevBeaconNode} from "../../utils/node/beacon.js";
 import {getAndInitDevValidators} from "../../utils/node/validator.js";
+import {fulu} from "@lodestar/types";
 
 describe("sync / unknown block sync for fulu", () => {
   vi.setConfig({testTimeout: 40_000});
@@ -100,10 +101,10 @@ describe("sync / unknown block sync for fulu", () => {
         testLoggerOpts,
       });
 
-      afterEachCallbacks.push(() => Promise.all(validators.map((v) => v.close())));
+      afterEachCallbacks.push(() => Promise.all(validators.map((v) => v.close().catch(() => {}))));
 
       // stop bn after validators
-      afterEachCallbacks.push(() => bn.close());
+      afterEachCallbacks.push(() => bn.close().catch(() => {}));
 
       // wait until the 2nd slot of fulu
       await waitForEvent<EventData[EventType.head]>(
@@ -127,7 +128,7 @@ describe("sync / unknown block sync for fulu", () => {
         eth1BlockHash: Uint8Array.from(INTEROP_BLOCK_HASH),
       });
 
-      afterEachCallbacks.push(() => bn2.close());
+      afterEachCallbacks.push(() => bn2.close().catch(() => {}));
 
       const headSummary = bn.chain.forkChoice.getHead();
       const head = await bn.db.block.get(fromHexString(headSummary.blockRoot));
@@ -144,13 +145,15 @@ describe("sync / unknown block sync for fulu", () => {
       await connected;
       loggerNodeA.info("Node A connected to Node B");
 
-      const headInput = BlockInputPreData.createFromBlock({
-        block: head,
+      const headInput = BlockInputColumns.createFromBlock({
+        block: head as fulu.SignedBeaconBlock,
         blockRootHex: headSummary.blockRoot,
         source: BlockInputSource.gossip,
         seenTimestampSec: Math.floor(Date.now() / 1000),
         forkName: bn.chain.config.getForkName(head.message.slot),
         daOutOfRange: false,
+        sampledColumns: bn2.network.custodyConfig.sampledColumns,
+        custodyColumns: bn2.network.custodyConfig.custodyColumns,
       });
 
       switch (event) {

--- a/packages/beacon-node/test/unit/db/api/repositories/blockArchive.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repositories/blockArchive.test.ts
@@ -10,7 +10,7 @@ import {BlockArchiveRepository} from "../../../../../src/db/repositories/index.j
 import {testLogger} from "../../../../utils/logger.js";
 
 describe("block archive repository", () => {
-  const testDir = "./.tmp";
+  const testDir = "./.tmp_block_archive_unit_test";
   let blockArchive: BlockArchiveRepository;
   let db: LevelDbController;
 

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -74,7 +74,7 @@ describe("sync / range / chain", () => {
     return {
       peerId,
       client: "CLIENT_AGENT",
-      custodyGroups: [],
+      custodyColumns: [],
     };
   };
   const pruneBlockInputs: SyncChainFns["pruneBlockInputs"] = (_) => {};

--- a/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
@@ -136,7 +136,7 @@ describe("sync / range / peerBalancer", () => {
 
         const peerInfos: PeerSyncInfo[] = peers.map((p) => ({
           ...p,
-          custodyGroups: columnsByPeer.get(p.peerId)?.custodyColumns ?? [],
+          custodyColumns: columnsByPeer.get(p.peerId)?.custodyColumns ?? [],
           target: targetByPeer.get(p.peerId) ?? ({slot: 0, root: ZERO_HASH} as ChainTarget),
           earliestAvailableSlot: earliestAvailableSlotByPeers.get(p.peerId) ?? undefined,
         }));
@@ -296,7 +296,7 @@ describe("sync / range / peerBalancer", () => {
 
         const peerInfos: PeerSyncInfo[] = peers.map((p) => ({
           ...p,
-          custodyGroups: columnsByPeer.get(p.peerId)?.custodyColumns ?? [],
+          custodyColumns: columnsByPeer.get(p.peerId)?.custodyColumns ?? [],
           target: targetByPeer.get(p.peerId) ?? {slot: 0, root: ZERO_HASH},
           earliestAvailableSlot: earliestAvailableSlotByPeers.get(p.peerId) ?? undefined,
         }));

--- a/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/utils/peerBalancer.test.ts
@@ -194,14 +194,14 @@ describe("sync / range / peerBalancer", () => {
         {
           peerId: peer2.peerId,
           client: peer2.client,
-          custodyGroups: [0, 1, 2, 3],
+          custodyColumns: [0, 1, 2, 3],
           target: {slot: blocksRequest.startSlot + blocksRequest.count - 1, root: ZERO_HASH},
           earliestAvailableSlot: 0,
         },
         {
           peerId: peer3.peerId,
           client: peer3.client,
-          custodyGroups: [0, 1, 2, 3],
+          custodyColumns: [0, 1, 2, 3],
           target: {slot: blocksRequest.startSlot + blocksRequest.count - 2, root: ZERO_HASH},
           earliestAvailableSlot: 0,
         },

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -373,7 +373,7 @@ describe("UnknownBlockPeerBalancer", async () => {
 
   for (const [testCaseIndex, {custodyGroups, excludedPeers, activeRequests, bestPeer}] of testCases.entries()) {
     for (const [i, groups] of custodyGroups.entries()) {
-      peers[i].custodyGroups = groups;
+      peers[i].custodyColumns = groups;
     }
 
     const signedBlock = ssz.fulu.SignedBeaconBlock.defaultValue();

--- a/packages/beacon-node/test/unit/sync/utils/downloadByRoot.test.ts
+++ b/packages/beacon-node/test/unit/sync/utils/downloadByRoot.test.ts
@@ -28,7 +28,7 @@ describe("downloadByRoot.ts", () => {
   const peerMeta: PeerSyncMeta = {
     peerId: peerIdStr,
     client: "N/A",
-    custodyGroups: Array.from({length: NUMBER_OF_COLUMNS}, (_, i) => i),
+    custodyColumns: Array.from({length: NUMBER_OF_COLUMNS}, (_, i) => i),
     earliestAvailableSlot: 0,
   };
   let network: INetwork;

--- a/packages/beacon-node/test/utils/peer.ts
+++ b/packages/beacon-node/test/utils/peer.ts
@@ -21,7 +21,7 @@ export async function getRandPeerSyncMeta(peerId?: string): Promise<PeerSyncMeta
   return {
     peerId: peerId ?? (await getRandPeerIdStr()),
     client: "PEER_CLIENT",
-    custodyGroups: [],
+    custodyColumns: [],
     earliestAvailableSlot: 0,
   };
 }


### PR DESCRIPTION
**Motivation**

- merging #8200 within sight

**Description**

- replace `custodyGroups` with `custodyColumns` where we're tracking per-peer
  - code was wrongly comparing groups and columns, but this wasn't causing bugged behavior given the current configuration
- in BlockInputSync (unknown sync), don't unilaterally exclude a peer after fetching data from it. Instead only exclude the peer upon (most) errors
- in unknown block sync e2e test, create the proper type of block input (BlockInputColumns). Using the wrong class causes the block input to fail to process