### PR TITLE
fix: DataColumSidecars recoverTime buckets

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -799,8 +799,7 @@ export function createLodestarMetrics(
       recoverTime: register.histogram({
         name: "lodestar_recover_data_column_sidecar_recover_time_seconds",
         help: "Time elapsed to recover data column sidecar",
-        // this data comes from 20 blobs in `fusaka-devnet-1`, need to reevaluate in the future
-        buckets: [0.4, 0.6, 0.8, 1.0, 1.2],
+        buckets: [0.5, 1.0, 1.5, 2],
       }),
       custodyBeforeReconstruction: register.gauge({
         name: "lodestar_data_columns_in_custody_before_reconstruction",


### PR DESCRIPTION
**Motivation**

- the data columns `recoverTime` could be more than 2s, we should reflect that in our metrics

**Description**

- this shows that we should only consider it as a back up way to make sure all data available, not a way to speed up the import process
<img width="1507" height="700" alt="Screenshot 2025-09-18 at 14 47 40" src="https://github.com/user-attachments/assets/52696e3d-a379-4b57-af2c-323b9db08f33" />


