### PR TITLE
feat: refine data column elapsedTimeTillReceived metric

### DIFF
--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -822,10 +822,10 @@ export function createLodestarMetrics(
         help: "Number of received data columns by source",
         labelNames: ["source"],
       }),
-      elapsedTimeTillReceived: register.histogram<{source: BlockInputSource}>({
+      elapsedTimeTillReceived: register.histogram<{receivedOrder: number}>({
         name: "lodestar_data_column_elapsed_time_till_received_seconds",
         help: "Time elapsed between block slot time and the time data column received",
-        labelNames: ["source"],
+        labelNames: ["receivedOrder"],
         buckets: [1, 2, 3, 4, 6, 12],
       }),
       sentPeersPerSubnet: register.histogram({

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -549,14 +549,16 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       const blockInputMeta = blockInput.getLogMeta();
       const {receivedColumns} = blockInputMeta;
       // it's not helpful to track every single column received
-      // instead of that, track 1st, 32th, 64th, and 128th column
-      if (
-        receivedColumns === 1 ||
-        receivedColumns === NUMBER_OF_COLUMNS / 4 ||
-        receivedColumns === NUMBER_OF_COLUMNS / 2 ||
-        receivedColumns === NUMBER_OF_COLUMNS
-      ) {
-        metrics?.dataColumns.elapsedTimeTillReceived.observe({receivedOrder: receivedColumns}, delaySec);
+      // instead of that, track 1st, 8th, 16th 32th, 64th, and 128th column
+      switch (receivedColumns) {
+        case 1:
+        case config.SAMPLES_PER_SLOT:
+        case 2 * config.SAMPLES_PER_SLOT:
+        case NUMBER_OF_COLUMNS / 4:
+        case NUMBER_OF_COLUMNS / 2:
+        case NUMBER_OF_COLUMNS:
+          metrics?.dataColumns.elapsedTimeTillReceived.observe({receivedOrder: receivedColumns}, delaySec);
+          break;
       }
       if (!blockInput.hasBlockAndAllData()) {
         const cutoffTimeMs = getCutoffTimeMs(chain, dataColumnSlot, BLOCK_AVAILABILITY_CUTOFF_MS);

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -539,7 +539,6 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         throw new GossipActionError(GossipAction.REJECT, {code: "PRE_FULU_BLOCK"});
       }
       const delaySec = chain.clock.secFromSlot(dataColumnSlot, seenTimestampSec);
-      metrics?.dataColumns.elapsedTimeTillReceived.observe({source: BlockInputSource.gossip}, delaySec);
       const blockInput = await validateBeaconDataColumn(
         dataColumnSidecar,
         serializedData,
@@ -547,12 +546,24 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         peerIdStr,
         seenTimestampSec
       );
+      const blockInputMeta = blockInput.getLogMeta();
+      const {receivedColumns} = blockInputMeta;
+      // it's not helpful to track every single column received
+      // instead of that, track 1st, 32th, 64th, and 128th column
+      if (
+        receivedColumns === 1 ||
+        receivedColumns === NUMBER_OF_COLUMNS / 4 ||
+        receivedColumns === NUMBER_OF_COLUMNS / 2 ||
+        receivedColumns === NUMBER_OF_COLUMNS
+      ) {
+        metrics?.dataColumns.elapsedTimeTillReceived.observe({receivedOrder: receivedColumns}, delaySec);
+      }
       if (!blockInput.hasBlockAndAllData()) {
         const cutoffTimeMs = getCutoffTimeMs(chain, dataColumnSlot, BLOCK_AVAILABILITY_CUTOFF_MS);
         chain.logger.debug("Received gossip data column, waiting for full data availability", {
           msToWait: cutoffTimeMs,
           dataColumnIndex: index,
-          ...blockInput.getLogMeta(),
+          ...blockInputMeta,
         });
         // do not await here to not delay gossip validation
         blockInput.waitForAllData(cutoffTimeMs).catch((_e) => {
@@ -560,7 +571,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
             "Waited for data after receiving gossip column. Cut-off reached so attempting to fetch remainder of BlockInput",
             {
               dataColumnIndex: index,
-              ...blockInput.getLogMeta(),
+              ...blockInputMeta,
             }
           );
           chain.emitter.emit(ChainEvent.incompleteBlockInput, {


### PR DESCRIPTION
**Motivation**

- elapsed time till processed of devnet-5 is not great after it gets to `MAX_BLOBS_PER_BLOCK` as 72
- when I look into some late processed blocks, it turned out that data columns were received very late, for example the 64th seen columns:

```
Sep-18 08:08:20.167[network]         debug: Received gossip dataColumn slot=55841, blockRoot=0x2a9f…209d, timeCreatedSec=1758182899.816, expectedColumns=128, receivedColumns=64, currentSlot=55841, peerId=16Uiu2HAmSnADzjUiLA41g1J8jKTHqq3tKCP4PVfAa8bHGSrQwKGq, delaySec=8.138000011444092, gossipSubnet=107, columnIndex=107, recvToValLatency=0.003000020980834961, recvToValidation=0.029000043869018555, validationTime=0.026000022888183594
```
- the current `elapsedTimeTillReceived` does not help much because it track all columns

**Description**

- refine `elapsedTimeTillReceived` metric to only track columns at specific orders: 1st, 32th, 64th, 128th
- this will help us investigate late block processed easier postfulu
