### PR TITLE
chore: remove parent beacon block root from execution payload rpc type

### DIFF
--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -181,7 +181,6 @@ export type ExecutionPayloadRpc = {
   withdrawals?: WithdrawalRpc[]; // Capella hardfork
   blobGasUsed?: QUANTITY; // DENEB
   excessBlobGas?: QUANTITY; // DENEB
-  parentBeaconBlockRoot?: QUANTITY; // DENEB
 };
 
 export type WithdrawalRpc = {


### PR DESCRIPTION
Noticed the type isn't correct as [ExecutionPayloadV3](https://github.com/ethereum/execution-apis/blob/9a7b40cc08eaf45ef98d746ad4e8b77eabe35637/src/engine/cancun.md?plain=1#L41-L61) doesn't contain `parentBeaconBlockRoot` as it's passed as part of payload attributes.