### PR TITLE
fix: emit unknownParent event

### DIFF
--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -177,13 +177,9 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       return blockInput;
     } catch (e) {
       if (e instanceof BlockGossipError) {
-        // TODO(fulu): check that this is the only error that should trigger resolution of the block and all others
-        //    cause the block to get thrown away
-        // Don't trigger this yet if full block and blobs haven't arrived yet
         if (e.type.code === BlockErrorCode.PARENT_UNKNOWN && blockInput) {
           logger.debug("Gossip block has error", {slot, root: blockShortHex, code: e.type.code});
-          // TODO(fulu): should this be unknownParent event?
-          chain.emitter.emit(ChainEvent.incompleteBlockInput, {
+          chain.emitter.emit(ChainEvent.unknownParent, {
             blockInput,
             peer: peerIdStr,
             source: BlockInputSource.gossip,

--- a/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/unknownBlockSync.test.ts
@@ -56,7 +56,10 @@ describe("sync / unknown block sync for fulu", () => {
       id: "should do an unknown block sync from another BN",
       event: ChainEvent.unknownBlockRoot,
     },
-    // TODO: new event postfulu for unknownBlockInput
+    {
+      id: "should do an incompleteBlockInput sync from another BN",
+      event: ChainEvent.incompleteBlockInput,
+    },
   ];
 
   for (const {id, event} of testCases) {
@@ -174,6 +177,13 @@ describe("sync / unknown block sync for fulu", () => {
         case ChainEvent.unknownBlockRoot:
           bn2.chain.emitter.emit(ChainEvent.unknownBlockRoot, {
             rootSlot: {root: headSummary.blockRoot},
+            peer: bn2.network.peerId.toString(),
+            source: BlockInputSource.gossip,
+          });
+          break;
+        case ChainEvent.incompleteBlockInput:
+          bn2.chain.emitter.emit(ChainEvent.incompleteBlockInput, {
+            blockInput: headInput,
             peer: bn2.network.peerId.toString(),
             source: BlockInputSource.gossip,
           });


### PR DESCRIPTION
**Motivation**

- when validating a gossip block and got a `PARENT_UNKNOWN` error, we should emit `unknownParent` event instead of `incompleteBlockInput` event

**Description**

- do that in gosssip handler
- add `ChainEvent.incompleteBlockInput` test to unknownBlockSync e2e test

Closes #8415
Closes #8417