### PR TITLE
fix: wait for block and all data

### DIFF
--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -568,7 +568,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
           ...blockInputMeta,
         });
         // do not await here to not delay gossip validation
-        blockInput.waitForAllData(cutoffTimeMs).catch((_e) => {
+        blockInput.waitForBlockAndAllData(cutoffTimeMs).catch((_e) => {
           chain.logger.debug(
             "Waited for data after receiving gossip column. Cut-off reached so attempting to fetch remainder of BlockInput",
             {


### PR DESCRIPTION
**Motivation**

- got a case where all columns came timely while block came very late and we did not trigger `incompleteBlockInput` event

**Description**

- trigger `incompleteBlockInput` in that case

Closes #8405