### PR TITLE
feat: schedule fulu and BPOs on sepolia and hoodi

### DIFF
--- a/packages/config/src/chainConfig/networks/hoodi.ts
+++ b/packages/config/src/chainConfig/networks/hoodi.ts
@@ -37,7 +37,7 @@ export const hoodiChainConfig: ChainConfig = {
   ELECTRA_FORK_EPOCH: 2048,
   // Fulu
   FULU_FORK_VERSION: b("0x70000910"),
-  FULU_FORK_EPOCH: Infinity,
+  FULU_FORK_EPOCH: 50688,
 
   // Time parameters
   // ---------------------------------------------------------------
@@ -51,5 +51,14 @@ export const hoodiChainConfig: ChainConfig = {
 
   // Blob Scheduling
   // ---------------------------------------------------------------
-  BLOB_SCHEDULE: [],
+  BLOB_SCHEDULE: [
+    {
+      EPOCH: 52480,
+      MAX_BLOBS_PER_BLOCK: 15,
+    },
+    {
+      EPOCH: 54016,
+      MAX_BLOBS_PER_BLOCK: 21,
+    },
+  ],
 };

--- a/packages/config/src/chainConfig/networks/sepolia.ts
+++ b/packages/config/src/chainConfig/networks/sepolia.ts
@@ -38,7 +38,7 @@ export const sepoliaChainConfig: ChainConfig = {
   ELECTRA_FORK_EPOCH: 222464,
   // Fulu
   FULU_FORK_VERSION: b("0x90000075"),
-  FULU_FORK_EPOCH: Infinity,
+  FULU_FORK_EPOCH: 272640,
 
   // Deposit contract
   // ---------------------------------------------------------------
@@ -48,5 +48,14 @@ export const sepoliaChainConfig: ChainConfig = {
 
   // Blob Scheduling
   // ---------------------------------------------------------------
-  BLOB_SCHEDULE: [],
+  BLOB_SCHEDULE: [
+    {
+      EPOCH: 274176,
+      MAX_BLOBS_PER_BLOCK: 15,
+    },
+    {
+      EPOCH: 275712,
+      MAX_BLOBS_PER_BLOCK: 21,
+    },
+  ],
 };


### PR DESCRIPTION
**Motivation**

This PR schedules Fulu fork and BPO1 and BPO2 on remaining testnets Sepolia and Hoodi.

**Description**

Updates network configs for Fulu fork
Includes BPO1 and BPO2 configs
For both Sepolia and Hoodi

As defined in Sepolia: https://github.com/eth-clients/sepolia/pull/111
As defined in Hoodi: https://github.com/eth-clients/hoodi/pull/21

Wait for confirmation of these remaining testnets configs before merging.
