### PR TITLE
feat: track number of peers per data column subnet topic

### DIFF
--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -3,13 +3,7 @@ import {MetricsRegister, TopicLabel, TopicStrToLabel} from "@chainsafe/libp2p-go
 import {PeerScoreParams} from "@chainsafe/libp2p-gossipsub/score";
 import {SignaturePolicy, TopicStr} from "@chainsafe/libp2p-gossipsub/types";
 import {BeaconConfig, ForkBoundary} from "@lodestar/config";
-import {
-  ATTESTATION_SUBNET_COUNT,
-  ForkName,
-  NUMBER_OF_COLUMNS,
-  SLOTS_PER_EPOCH,
-  SYNC_COMMITTEE_SUBNET_COUNT,
-} from "@lodestar/params";
+import {ATTESTATION_SUBNET_COUNT, SLOTS_PER_EPOCH, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
 import {SubnetID} from "@lodestar/types";
 import {Logger, Map2d, Map2dArr} from "@lodestar/utils";
 import {GOSSIP_MAX_SIZE, GOSSIP_MAX_SIZE_BELLATRIX} from "../../constants/network.js";
@@ -158,7 +152,7 @@ export class Eth2Gossipsub extends GossipSub {
 
     if (metricsRegister) {
       const metrics = createEth2GossipsubMetrics(metricsRegister);
-      metrics.gossipMesh.peersByType.addCollect(() => this.onScrapeLodestarMetrics(metrics));
+      metrics.gossipMesh.peersByType.addCollect(() => this.onScrapeLodestarMetrics(metrics, networkConfig));
     }
 
     this.addEventListener("gossipsub:message", this.onGossipsubMessage.bind(this));
@@ -192,7 +186,7 @@ export class Eth2Gossipsub extends GossipSub {
     this.unsubscribe(topicStr);
   }
 
-  private onScrapeLodestarMetrics(metrics: Eth2GossipsubMetrics): void {
+  private onScrapeLodestarMetrics(metrics: Eth2GossipsubMetrics, networkConfig: NetworkConfig): void {
     const mesh = this.mesh;
     // biome-ignore lint/complexity/useLiteralKeys: `topics` is a private attribute
     const topics = this["topics"] as Map<string, Set<string>>;
@@ -265,7 +259,7 @@ export class Eth2Gossipsub extends GossipSub {
         }
       }
       for (const [boundary, peersByDataColumnSubnet] of peersByDataColumnSubnetByBoundary.map) {
-        for (let subnet = 0; subnet < NUMBER_OF_COLUMNS; subnet++) {
+        for (const subnet of networkConfig.custodyConfig.sampleGroups) {
           metricsGossip.peersByDataColumnSubnet.set({boundary, subnet}, peersByDataColumnSubnet[subnet] ?? 0);
         }
       }

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -3,7 +3,13 @@ import {MetricsRegister, TopicLabel, TopicStrToLabel} from "@chainsafe/libp2p-go
 import {PeerScoreParams} from "@chainsafe/libp2p-gossipsub/score";
 import {SignaturePolicy, TopicStr} from "@chainsafe/libp2p-gossipsub/types";
 import {BeaconConfig, ForkBoundary} from "@lodestar/config";
-import {ATTESTATION_SUBNET_COUNT, ForkName, SLOTS_PER_EPOCH, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
+import {
+  ATTESTATION_SUBNET_COUNT,
+  ForkName,
+  NUMBER_OF_COLUMNS,
+  SLOTS_PER_EPOCH,
+  SYNC_COMMITTEE_SUBNET_COUNT,
+} from "@lodestar/params";
 import {SubnetID} from "@lodestar/types";
 import {Logger, Map2d, Map2dArr} from "@lodestar/utils";
 import {GOSSIP_MAX_SIZE, GOSSIP_MAX_SIZE_BELLATRIX} from "../../constants/network.js";
@@ -200,9 +206,10 @@ export class Eth2Gossipsub extends GossipSub {
       {peersMap: topics, metricsGossip: metrics.gossipTopic, type: "topics"},
     ]) {
       // Pre-aggregate results by fork so we can fill the remaining metrics with 0
-      const peersByTypeByFork = new Map2d<ForkBoundaryLabel, GossipType, number>();
-      const peersByBeaconAttSubnetByFork = new Map2dArr<ForkBoundaryLabel, number>();
-      const peersByBeaconSyncSubnetByFork = new Map2dArr<ForkBoundaryLabel, number>();
+      const peersByTypeByBoundary = new Map2d<ForkBoundaryLabel, GossipType, number>();
+      const peersByBeaconAttSubnetByBoundary = new Map2dArr<ForkBoundaryLabel, number>();
+      const peersByBeaconSyncSubnetByBoundary = new Map2dArr<ForkBoundaryLabel, number>();
+      const peersByDataColumnSubnetByBoundary = new Map2dArr<ForkBoundaryLabel, number>();
 
       // loop through all mesh entries, count each set size
       for (const [topicString, peers] of peersMap) {
@@ -215,11 +222,13 @@ export class Eth2Gossipsub extends GossipSub {
         if (topic !== undefined) {
           const boundary = getForkBoundaryLabel(topic.boundary);
           if (topic.type === GossipType.beacon_attestation) {
-            peersByBeaconAttSubnetByFork.set(boundary, topic.subnet, peers.size);
+            peersByBeaconAttSubnetByBoundary.set(boundary, topic.subnet, peers.size);
           } else if (topic.type === GossipType.sync_committee) {
-            peersByBeaconSyncSubnetByFork.set(boundary, topic.subnet, peers.size);
+            peersByBeaconSyncSubnetByBoundary.set(boundary, topic.subnet, peers.size);
+          } else if (topic.type === GossipType.data_column_sidecar) {
+            peersByDataColumnSubnetByBoundary.set(boundary, topic.subnet, peers.size);
           } else {
-            peersByTypeByFork.set(boundary, topic.type, peers.size);
+            peersByTypeByBoundary.set(boundary, topic.type, peers.size);
           }
         }
 
@@ -236,12 +245,12 @@ export class Eth2Gossipsub extends GossipSub {
 
       // beacon attestation mesh gets counted separately so we can track mesh peers by subnet
       // zero out all gossip type & subnet choices, so the dashboard will register them
-      for (const [boundary, peersByType] of peersByTypeByFork.map) {
+      for (const [boundary, peersByType] of peersByTypeByBoundary.map) {
         for (const type of Object.values(GossipType)) {
           metricsGossip.peersByType.set({boundary, type}, peersByType.get(type) ?? 0);
         }
       }
-      for (const [boundary, peersByBeaconAttSubnet] of peersByBeaconAttSubnetByFork.map) {
+      for (const [boundary, peersByBeaconAttSubnet] of peersByBeaconAttSubnetByBoundary.map) {
         for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
           metricsGossip.peersByBeaconAttestationSubnet.set(
             {boundary, subnet: attSubnetLabel(subnet)},
@@ -249,10 +258,15 @@ export class Eth2Gossipsub extends GossipSub {
           );
         }
       }
-      for (const [boundary, peersByBeaconSyncSubnet] of peersByBeaconSyncSubnetByFork.map) {
+      for (const [boundary, peersByBeaconSyncSubnet] of peersByBeaconSyncSubnetByBoundary.map) {
         for (let subnet = 0; subnet < SYNC_COMMITTEE_SUBNET_COUNT; subnet++) {
           // SYNC_COMMITTEE_SUBNET_COUNT is < 9, no need to prepend a 0 to the label
           metricsGossip.peersBySyncCommitteeSubnet.set({boundary, subnet}, peersByBeaconSyncSubnet[subnet] ?? 0);
+        }
+      }
+      for (const [boundary, peersByDataColumnSubnet] of peersByDataColumnSubnetByBoundary.map) {
+        for (let subnet = 0; subnet < NUMBER_OF_COLUMNS; subnet++) {
+          metricsGossip.peersByDataColumnSubnet.set({boundary, subnet}, peersByDataColumnSubnet[subnet] ?? 0);
         }
       }
     }

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -2,7 +2,7 @@ import {GossipSub, GossipsubEvents} from "@chainsafe/libp2p-gossipsub";
 import {MetricsRegister, TopicLabel, TopicStrToLabel} from "@chainsafe/libp2p-gossipsub/metrics";
 import {PeerScoreParams} from "@chainsafe/libp2p-gossipsub/score";
 import {SignaturePolicy, TopicStr} from "@chainsafe/libp2p-gossipsub/types";
-import {BeaconConfig} from "@lodestar/config";
+import {BeaconConfig, ForkBoundary} from "@lodestar/config";
 import {ATTESTATION_SUBNET_COUNT, ForkName, SLOTS_PER_EPOCH, SYNC_COMMITTEE_SUBNET_COUNT} from "@lodestar/params";
 import {SubnetID} from "@lodestar/types";
 import {Logger, Map2d, Map2dArr} from "@lodestar/utils";
@@ -57,6 +57,8 @@ export type Eth2GossipsubOpts = {
   skipParamsLog?: boolean;
   disableLightClientServer?: boolean;
 };
+
+export type ForkBoundaryLabel = string;
 
 /**
  * Wrapper around js-libp2p-gossipsub with the following extensions:
@@ -198,10 +200,9 @@ export class Eth2Gossipsub extends GossipSub {
       {peersMap: topics, metricsGossip: metrics.gossipTopic, type: "topics"},
     ]) {
       // Pre-aggregate results by fork so we can fill the remaining metrics with 0
-      const peersByTypeByFork = new Map2d<ForkName, GossipType, number>();
-      // TODO: This shouldnt be by fork, but by boundary
-      const peersByBeaconAttSubnetByFork = new Map2dArr<ForkName, number>();
-      const peersByBeaconSyncSubnetByFork = new Map2dArr<ForkName, number>();
+      const peersByTypeByFork = new Map2d<ForkBoundaryLabel, GossipType, number>();
+      const peersByBeaconAttSubnetByFork = new Map2dArr<ForkBoundaryLabel, number>();
+      const peersByBeaconSyncSubnetByFork = new Map2dArr<ForkBoundaryLabel, number>();
 
       // loop through all mesh entries, count each set size
       for (const [topicString, peers] of peersMap) {
@@ -212,13 +213,13 @@ export class Eth2Gossipsub extends GossipSub {
         // for example in prater: /eth2/82f4a72b/optimistic_light_client_update_v0/ssz_snappy
         const topic = this.gossipTopicCache.getKnownTopic(topicString);
         if (topic !== undefined) {
-          const {fork} = topic.boundary;
+          const boundary = getForkBoundaryLabel(topic.boundary);
           if (topic.type === GossipType.beacon_attestation) {
-            peersByBeaconAttSubnetByFork.set(fork, topic.subnet, peers.size);
+            peersByBeaconAttSubnetByFork.set(boundary, topic.subnet, peers.size);
           } else if (topic.type === GossipType.sync_committee) {
-            peersByBeaconSyncSubnetByFork.set(fork, topic.subnet, peers.size);
+            peersByBeaconSyncSubnetByFork.set(boundary, topic.subnet, peers.size);
           } else {
-            peersByTypeByFork.set(fork, topic.type, peers.size);
+            peersByTypeByFork.set(boundary, topic.type, peers.size);
           }
         }
 
@@ -235,23 +236,23 @@ export class Eth2Gossipsub extends GossipSub {
 
       // beacon attestation mesh gets counted separately so we can track mesh peers by subnet
       // zero out all gossip type & subnet choices, so the dashboard will register them
-      for (const [fork, peersByType] of peersByTypeByFork.map) {
+      for (const [boundary, peersByType] of peersByTypeByFork.map) {
         for (const type of Object.values(GossipType)) {
-          metricsGossip.peersByType.set({fork, type}, peersByType.get(type) ?? 0);
+          metricsGossip.peersByType.set({boundary, type}, peersByType.get(type) ?? 0);
         }
       }
-      for (const [fork, peersByBeaconAttSubnet] of peersByBeaconAttSubnetByFork.map) {
+      for (const [boundary, peersByBeaconAttSubnet] of peersByBeaconAttSubnetByFork.map) {
         for (let subnet = 0; subnet < ATTESTATION_SUBNET_COUNT; subnet++) {
           metricsGossip.peersByBeaconAttestationSubnet.set(
-            {fork, subnet: attSubnetLabel(subnet)},
+            {boundary, subnet: attSubnetLabel(subnet)},
             peersByBeaconAttSubnet[subnet] ?? 0
           );
         }
       }
-      for (const [fork, peersByBeaconSyncSubnet] of peersByBeaconSyncSubnetByFork.map) {
+      for (const [boundary, peersByBeaconSyncSubnet] of peersByBeaconSyncSubnetByFork.map) {
         for (let subnet = 0; subnet < SYNC_COMMITTEE_SUBNET_COUNT; subnet++) {
           // SYNC_COMMITTEE_SUBNET_COUNT is < 9, no need to prepend a 0 to the label
-          metricsGossip.peersBySyncCommitteeSubnet.set({fork, subnet}, peersByBeaconSyncSubnet[subnet] ?? 0);
+          metricsGossip.peersBySyncCommitteeSubnet.set({boundary, subnet}, peersByBeaconSyncSubnet[subnet] ?? 0);
         }
       }
     }
@@ -359,4 +360,17 @@ function getMetricsTopicStrToLabel(
   }
 
   return metricsTopicStrToLabel;
+}
+
+// Topics of the same ForkBoundary should have the same ForkBoundary object
+// we don't want to create a new string for every topic
+const boundaryLabelMap = new Map<ForkBoundary, ForkBoundaryLabel>();
+function getForkBoundaryLabel(boundary: ForkBoundary): ForkBoundaryLabel {
+  let label = boundaryLabelMap.get(boundary);
+  if (label === undefined) {
+    label = `${boundary.fork}_${boundary.epoch}`;
+    boundaryLabelMap.set(boundary, label);
+  }
+
+  return label;
 }

--- a/packages/beacon-node/src/network/gossip/metrics.ts
+++ b/packages/beacon-node/src/network/gossip/metrics.ts
@@ -40,6 +40,11 @@ export function createEth2GossipsubMetrics(register: RegistryMetricCreator) {
         help: "Number of connected mesh peers per sync committee subnet",
         labelNames: ["subnet", "boundary"],
       }),
+      peersByDataColumnSubnet: register.gauge<{subnet: SubnetID; boundary: ForkBoundaryLabel}>({
+        name: "lodestar_gossip_mesh_peers_by_data_column_subnet_count",
+        help: "Number of connected mesh peers per data column subnet",
+        labelNames: ["subnet", "boundary"],
+      }),
     },
     gossipTopic: {
       peersByType: register.gauge<{type: GossipType; boundary: ForkBoundaryLabel}>({
@@ -55,6 +60,11 @@ export function createEth2GossipsubMetrics(register: RegistryMetricCreator) {
       peersBySyncCommitteeSubnet: register.gauge<{subnet: SubnetID; boundary: ForkBoundaryLabel}>({
         name: "lodestar_gossip_topic_peers_by_sync_committee_subnet_count",
         help: "Number of connected topic peers per sync committee subnet",
+        labelNames: ["subnet", "boundary"],
+      }),
+      peersByDataColumnSubnet: register.gauge<{subnet: SubnetID; boundary: ForkBoundaryLabel}>({
+        name: "lodestar_gossip_topic_peers_by_data_column_subnet_count",
+        help: "Number of connected topic peers per data column subnet",
         labelNames: ["subnet", "boundary"],
       }),
     },

--- a/packages/beacon-node/src/network/gossip/metrics.ts
+++ b/packages/beacon-node/src/network/gossip/metrics.ts
@@ -1,4 +1,3 @@
-import {ForkName} from "@lodestar/params";
 import {SubnetID} from "@lodestar/types";
 import {RegistryMetricCreator} from "../../metrics/index.js";
 import {ForkBoundaryLabel} from "./gossipsub.js";

--- a/packages/beacon-node/src/network/gossip/metrics.ts
+++ b/packages/beacon-node/src/network/gossip/metrics.ts
@@ -1,6 +1,7 @@
 import {ForkName} from "@lodestar/params";
 import {SubnetID} from "@lodestar/types";
 import {RegistryMetricCreator} from "../../metrics/index.js";
+import {ForkBoundaryLabel} from "./gossipsub.js";
 import {GossipType} from "./interface.js";
 
 export type Eth2GossipsubMetrics = ReturnType<typeof createEth2GossipsubMetrics>;
@@ -24,37 +25,37 @@ export function createEth2GossipsubMetrics(register: RegistryMetricCreator) {
       }),
     },
     gossipMesh: {
-      peersByType: register.gauge<{type: GossipType; fork: ForkName}>({
+      peersByType: register.gauge<{type: GossipType; boundary: ForkBoundaryLabel}>({
         name: "lodestar_gossip_mesh_peers_by_type_count",
         help: "Number of connected mesh peers per gossip type",
-        labelNames: ["type", "fork"],
+        labelNames: ["type", "boundary"],
       }),
-      peersByBeaconAttestationSubnet: register.gauge<{subnet: string; fork: ForkName}>({
+      peersByBeaconAttestationSubnet: register.gauge<{subnet: string; boundary: ForkBoundaryLabel}>({
         name: "lodestar_gossip_mesh_peers_by_beacon_attestation_subnet_count",
         help: "Number of connected mesh peers per beacon attestation subnet",
-        labelNames: ["subnet", "fork"],
+        labelNames: ["subnet", "boundary"],
       }),
-      peersBySyncCommitteeSubnet: register.gauge<{subnet: SubnetID; fork: ForkName}>({
+      peersBySyncCommitteeSubnet: register.gauge<{subnet: SubnetID; boundary: ForkBoundaryLabel}>({
         name: "lodestar_gossip_mesh_peers_by_sync_committee_subnet_count",
         help: "Number of connected mesh peers per sync committee subnet",
-        labelNames: ["subnet", "fork"],
+        labelNames: ["subnet", "boundary"],
       }),
     },
     gossipTopic: {
-      peersByType: register.gauge<{type: GossipType; fork: ForkName}>({
+      peersByType: register.gauge<{type: GossipType; boundary: ForkBoundaryLabel}>({
         name: "lodestar_gossip_topic_peers_by_type_count",
         help: "Number of connected topic peers per gossip type",
-        labelNames: ["type", "fork"],
+        labelNames: ["type", "boundary"],
       }),
-      peersByBeaconAttestationSubnet: register.gauge<{subnet: string; fork: ForkName}>({
+      peersByBeaconAttestationSubnet: register.gauge<{subnet: string; boundary: ForkBoundaryLabel}>({
         name: "lodestar_gossip_topic_peers_by_beacon_attestation_subnet_count",
         help: "Number of connected topic peers per beacon attestation subnet",
-        labelNames: ["subnet", "fork"],
+        labelNames: ["subnet", "boundary"],
       }),
-      peersBySyncCommitteeSubnet: register.gauge<{subnet: SubnetID; fork: ForkName}>({
+      peersBySyncCommitteeSubnet: register.gauge<{subnet: SubnetID; boundary: ForkBoundaryLabel}>({
         name: "lodestar_gossip_topic_peers_by_sync_committee_subnet_count",
         help: "Number of connected topic peers per sync committee subnet",
-        labelNames: ["subnet", "fork"],
+        labelNames: ["subnet", "boundary"],
       }),
     },
   };


### PR DESCRIPTION
**Motivation**

- starting from fulu, we need to track number of peers per data column subnet

**Description**

- track it in gossipsub
- also track peers and topics by fork boundary, not fork name
- will need to render this on the main Grafana dashboard after this PR
