### PR TITLE
chore: add bun exports to packages

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,27 +15,35 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     },
     "./server": {
+      "bun": "./src/server/index.ts",
       "import": "./lib/server/index.js"
     },
     "./beacon": {
+      "bun": "./src/beacon/index.ts",
       "import": "./lib/beacon/index.js"
     },
     "./beacon/server": {
+      "bun": "./src/beacon/server/index.ts",
       "import": "./lib/beacon/server/index.js"
     },
     "./builder": {
+      "bun": "./src/builder/index.ts",
       "import": "./lib/builder/index.js"
     },
     "./builder/server": {
+      "bun": "./src/builder/server/index.ts",
       "import": "./lib/builder/server/index.js"
     },
     "./keymanager": {
+      "bun": "./src/keymanager/index.ts",
       "import": "./lib/keymanager/index.js"
     },
     "./keymanager/server": {
+      "bun": "./src/keymanager/server/index.ts",
       "import": "./lib/keymanager/server/index.js"
     }
   },

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -15,39 +15,51 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     },
     "./api": {
+      "bun": "./src/api/index.ts",
       "import": "./lib/api/index.js"
     },
     "./chain": {
+      "bun": "./src/chain/index.ts",
       "import": "./lib/chain/index.js"
     },
     "./constants": {
+      "bun": "./src/constants/index.ts",
       "import": "./lib/constants/index.js"
     },
     "./db": {
+      "bun": "./src/db/index.ts",
       "import": "./lib/db/index.js"
     },
     "./eth1": {
+      "bun": "./src/eth1/index.ts",
       "import": "./lib/eth1/index.js"
     },
     "./metrics": {
+      "bun": "./src/metrics/index.ts",
       "import": "./lib/metrics/index.js"
     },
     "./monitoring": {
+      "bun": "./src/monitoring/index.ts",
       "import": "./lib/monitoring/index.js"
     },
     "./network": {
+      "bun": "./src/network/index.ts",
       "import": "./lib/network/index.js"
     },
     "./node": {
+      "bun": "./src/node/index.ts",
       "import": "./lib/node/index.js"
     },
     "./sync": {
+      "bun": "./src/sync/index.ts",
       "import": "./lib/sync/index.js"
     },
     "./util": {
+      "bun": "./src/util/index.ts",
       "import": "./lib/util/index.js"
     }
   },

--- a/packages/cli/bin/lodestar.ts
+++ b/packages/cli/bin/lodestar.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env bun
+
+await import("../src/index.js");

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -11,15 +11,19 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     },
     "./default": {
+      "bun": "./src/default.ts",
       "import": "./lib/default.js"
     },
     "./networks": {
+      "bun": "./src/networks.ts",
       "import": "./lib/networks.js"
     },
     "./configs": {
+      "bun": "./src/configs.ts",
       "import": "./lib/configs.js"
     }
   },

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,7 +12,12 @@
     "url": "https://github.com/ChainSafe/lodestar/issues"
   },
   "type": "module",
-  "exports": "./lib/index.js",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "import": "./lib/index.js"
+    }
+  },
   "types": "./lib/index.d.ts",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/flare/package.json
+++ b/packages/flare/package.json
@@ -11,6 +11,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     }
   },

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -13,7 +13,12 @@
   },
   "version": "1.34.1",
   "type": "module",
-  "exports": "./lib/index.js",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "import": "./lib/index.js"
+    }
+  },
   "types": "./lib/index.d.ts",
   "files": [
     "lib/**/*.d.ts",

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -15,18 +15,23 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     },
     "./utils": {
+      "bun": "./src/utils/index.ts",
       "import": "./lib/utils/index.js"
     },
     "./validation": {
+      "bun": "./src/validation.ts",
       "import": "./lib/validation.js"
     },
     "./spec": {
+      "bun": "./src/spec/index.ts",
       "import": "./lib/spec/index.js"
     },
     "./transport": {
+      "bun": "./src/transport/index.ts",
       "import": "./lib/transport/index.js"
     }
   },

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -15,18 +15,23 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     },
     "./browser": {
+      "bun": "./src/browser.ts",
       "import": "./lib/browser.js"
     },
     "./env": {
+      "bun": "./src/env.ts",
       "import": "./lib/env.js"
     },
     "./node": {
+      "bun": "./src/node.ts",
       "import": "./lib/node.js"
     },
     "./empty": {
+      "bun": "./src/empty.ts",
       "import": "./lib/empty.js"
     }
   },

--- a/packages/params/package.json
+++ b/packages/params/package.json
@@ -11,18 +11,23 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     },
     "./presets/mainnet": {
+      "bun": "./src/presets/mainnet.ts",
       "import": "./lib/presets/mainnet.js"
     },
     "./presets/minimal": {
+      "bun": "./src/presets/minimal.ts",
       "import": "./lib/presets/minimal.js"
     },
     "./presets/gnosis": {
+      "bun": "./src/presets/gnosis.ts",
       "import": "./lib/presets/gnosis.js"
     },
     "./setPreset": {
+      "bun": "./src/setPreset.ts",
       "import": "./lib/setPreset.js"
     }
   },

--- a/packages/prover/package.json
+++ b/packages/prover/package.json
@@ -15,9 +15,11 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     },
     "./browser": {
+      "bun": "./src/browser/index.ts",
       "import": "./lib/browser/index.js"
     }
   },

--- a/packages/reqresp/package.json
+++ b/packages/reqresp/package.json
@@ -15,9 +15,11 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     },
     "./utils": {
+      "bun": "./src/utils/index.ts",
       "import": "./lib/utils/index.js"
     }
   },

--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -11,9 +11,11 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     },
     "./downloadTests": {
+      "bun": "./src/downloadTests.ts",
       "import": "./lib/downloadTests.js"
     }
   },

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -15,15 +15,19 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     },
     "./block": {
+      "bun": "./src/block/index.ts",
       "import": "./lib/block/index.js"
     },
     "./epoch": {
+      "bun": "./src/epoch/index.ts",
       "import": "./lib/epoch/index.js"
     },
     "./slot": {
+      "bun": "./src/slot/index.ts",
       "import": "./lib/slot/index.js"
     }
   },

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -12,9 +12,11 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     },
     "./doubles": {
+      "bun": "./src/doubles.ts",
       "import": "./lib/doubles.js"
     }
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,27 +15,35 @@
   "type": "module",
   "exports": {
     ".": {
+      "bun": "./src/index.ts",
       "import": "./lib/index.js"
     },
     "./altair": {
+      "bun": "./src/altair/index.ts",
       "import": "./lib/altair/index.js"
     },
     "./capella": {
+      "bun": "./src/capella/index.ts",
       "import": "./lib/capella/index.js"
     },
     "./bellatrix": {
+      "bun": "./src/bellatrix/index.ts",
       "import": "./lib/bellatrix/index.js"
     },
     "./deneb": {
+      "bun": "./src/deneb/index.ts",
       "import": "./lib/deneb/index.js"
     },
     "./electra": {
+      "bun": "./src/electra/index.ts",
       "import": "./lib/electra/index.js"
     },
     "./fulu": {
+      "bun": "./src/fulu/index.ts",
       "import": "./lib/fulu/index.js"
     },
     "./phase0": {
+      "bun": "./src/phase0/index.ts",
       "import": "./lib/phase0/index.js"
     }
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,12 @@
   },
   "version": "1.34.1",
   "type": "module",
-  "exports": "./lib/index.js",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "import": "./lib/index.js"
+    }
+  },
   "files": [
     "lib/**/*.d.ts",
     "lib/**/*.js",

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -9,7 +9,12 @@
   },
   "homepage": "https://github.com/ChainSafe/lodestar#readme",
   "type": "module",
-  "exports": "./lib/index.js",
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "import": "./lib/index.js"
+    }
+  },
   "types": "./lib/index.d.ts",
   "files": [
     "lib/**/*.js",


### PR DESCRIPTION
**Motivation**

- #7280 

**Description**

- Add `"bun"` export to all packages that points to the _typescript source_ rather than the transpiled javascript
- Allows for bun to use typescript directly