### PR TITLE
fix: sort cell indices before calling `recoverCellsAndKzgProofs`

### DIFF
--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -88,6 +88,10 @@ export async function dataColumnMatrixRecovery(
   }
 
   const firstDataColumn = partialSidecarsSorted[0];
+  if (firstDataColumn == null) {
+    // should not happen because we check the size of the cache before this
+    throw new Error("No data column found in cache to recover from");
+  }
   const blobCount = firstDataColumn.kzgCommitments.length;
 
   const fullColumns: Array<Uint8Array[]> = Array.from(

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -87,11 +87,7 @@ export async function dataColumnMatrixRecovery(
     return partialSidecarsSorted;
   }
 
-  const firstDataColumn = partialSidecarsSorted.length > 0 ? partialSidecarsSorted[0] : null;
-  if (firstDataColumn == null) {
-    // should not happen because we check the size of the cache before this
-    throw new Error("No data column found in cache to recover from");
-  }
+  const firstDataColumn = partialSidecarsSorted[0];
   const blobCount = firstDataColumn.kzgCommitments.length;
 
   const fullColumns: Array<Uint8Array[]> = Array.from(
@@ -104,8 +100,8 @@ export async function dataColumnMatrixRecovery(
     blobProofs.map((_, blobIndex) => {
       const cellIndices: number[] = [];
       const cells: Uint8Array[] = [];
-      for (const [columnIndex, dataColumn] of partialSidecarsSorted.entries()) {
-        cellIndices.push(columnIndex);
+      for (const dataColumn of partialSidecarsSorted) {
+        cellIndices.push(dataColumn.index);
         cells.push(dataColumn.column[blobIndex]);
       }
       // recovered cells and proofs are of the same row/blob, their length should be NUMBER_OF_COLUMNS

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -79,12 +79,15 @@ export async function dataColumnMatrixRecovery(
     return null;
   }
 
+  // Sort data columns by index in ascending order before passing for kzg operations
+  const partialSidecarsSorted = [...partialSidecars.values()].sort((a, b) => a.index - b.index);
+
   if (columnCount === NUMBER_OF_COLUMNS) {
     // full columns, no need to recover
-    return Array.from(partialSidecars.values());
+    return partialSidecarsSorted;
   }
 
-  const firstDataColumn = partialSidecars.values().next().value;
+  const firstDataColumn = partialSidecarsSorted.length > 0 ? partialSidecarsSorted[0] : null;
   if (firstDataColumn == null) {
     // should not happen because we check the size of the cache before this
     throw new Error("No data column found in cache to recover from");
@@ -101,7 +104,7 @@ export async function dataColumnMatrixRecovery(
     blobProofs.map((_, blobIndex) => {
       const cellIndices: number[] = [];
       const cells: Uint8Array[] = [];
-      for (const [columnIndex, dataColumn] of partialSidecars.entries()) {
+      for (const [columnIndex, dataColumn] of partialSidecarsSorted.entries()) {
         cellIndices.push(columnIndex);
         cells.push(dataColumn.column[blobIndex]);
       }

--- a/packages/beacon-node/src/util/blobs.ts
+++ b/packages/beacon-node/src/util/blobs.ts
@@ -79,13 +79,13 @@ export async function dataColumnMatrixRecovery(
     return null;
   }
 
-  // Sort data columns by index in ascending order before passing for kzg operations
-  const partialSidecarsSorted = [...partialSidecars.values()].sort((a, b) => a.index - b.index);
-
   if (columnCount === NUMBER_OF_COLUMNS) {
     // full columns, no need to recover
-    return partialSidecarsSorted;
+    return Array.from(partialSidecars.values());
   }
+
+  // Sort data columns by index in ascending order before passing for kzg operations
+  const partialSidecarsSorted = Array.from(partialSidecars.values()).sort((a, b) => a.index - b.index);
 
   const firstDataColumn = partialSidecarsSorted[0];
   if (firstDataColumn == null) {

--- a/packages/beacon-node/test/spec/general/kzg.ts
+++ b/packages/beacon-node/test/spec/general/kzg.ts
@@ -169,6 +169,9 @@ type RecoverCellsAndKzgProofsInput = {
   cells: string[];
 };
 function recoverCellsAndKzgProofs(input: RecoverCellsAndKzgProofsInput): [string[], string[]] | null {
+  const isSorted = input.cell_indices.every((val, i, arr) => i === 0 || arr[i - 1] < val);
+  // If cell indices are not in ascending order, they are deemed invalid and cannot pass it to kzg
+  if (!isSorted) return null;
   const cellIndices = input.cell_indices.map(BigInt);
   const cells = input.cells.map(fromHexString);
   try {

--- a/packages/beacon-node/test/spec/general/kzg.ts
+++ b/packages/beacon-node/test/spec/general/kzg.ts
@@ -171,6 +171,8 @@ type RecoverCellsAndKzgProofsInput = {
 function recoverCellsAndKzgProofs(input: RecoverCellsAndKzgProofsInput): [string[], string[]] | null {
   const isSorted = input.cell_indices.every((val, i, arr) => i === 0 || arr[i - 1] < val);
   // If cell indices are not in ascending order, they are deemed invalid and cannot pass it to kzg
+  // Though in practice, we sort them before passing to kzg, here we follow the spec test case expectation
+  // See https://github.com/ChainSafe/lodestar/pull/8450/files#r2372830108 for context
   if (!isSorted) return null;
   const cellIndices = input.cell_indices.map(BigInt);
   const cells = input.cells.map(fromHexString);


### PR DESCRIPTION
For context please view https://discord.com/channels/593655374469660673/1229813597501395028/1419794786121945141 .

The latest spec requires cell indices to be sorted in [`recover_cells_and_kzg_proofs `](https://github.com/jtraglia/consensus-specs/blob/340d23358a0cdb4f4b547226dadd36d1cf775f20/specs/fulu/polynomial-commitments-sampling.md?plain=1#L805) so we need to sort them before passing it to kzg. 