### PR TITLE
chore: use typescript gc-stats import

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -65,7 +65,7 @@
   },
   "imports": {
     "#prometheus-gc-stats-wrapper": {
-      "bun": "./lib/bun-wrappers/prometheus-gc-stats.js",
+      "bun": "./src/bun-wrappers/prometheus-gc-stats.ts",
       "default": "@chainsafe/prometheus-gc-stats"
     }
   },


### PR DESCRIPTION
**Motivation**

- #7280 

**Description**

- Bun _does_ support imports, I was mistaken to say it didn't. The issue I ran into was that the referenced file did not exist!
- Use the typescript directly