### PR TITLE
feat: audit peer sync meta update handling

### DIFF
--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -733,7 +733,7 @@ export class Network implements INetwork {
     const {peer, clientAgent, custodyColumns, status} = data;
     const earliestAvailableSlot = (status as fulu.Status).earliestAvailableSlot;
     this.logger.verbose("onPeerConnected", {
-      peer,
+      peer: prettyPrintPeerIdStr(peer),
       clientAgent,
       custodyColumns: prettyPrintIndices(custodyColumns),
       earliestAvailableSlot: earliestAvailableSlot ?? "pre-fulu",

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -17,7 +17,7 @@ import {SubnetType} from "../metadata.js";
 import {NetworkConfig} from "../networkConfig.js";
 import {ReqRespMethod} from "../reqresp/ReqRespBeaconNode.js";
 import {StatusCache} from "../statusCache.js";
-import {NodeId, SubnetsService, computeNodeId} from "../subnets/index.js";
+import {SubnetsService, computeNodeId} from "../subnets/index.js";
 import {getConnection, getConnectionsMap, prettyPrintPeerId, prettyPrintPeerIdStr} from "../util.js";
 import {ClientKind, getKnownClientFromAgentVersion} from "./client.js";
 import {PeerDiscovery, SubnetDiscvQueryMs} from "./discover.js";
@@ -140,7 +140,6 @@ enum RelevantPeerStatus {
  * - Disconnect peers if over target peers
  */
 export class PeerManager {
-  private nodeId: NodeId;
   private readonly libp2p: Libp2p;
   private readonly logger: LoggerNode;
   private readonly metrics: NetworkCoreMetrics | null;
@@ -182,7 +181,6 @@ export class PeerManager {
     this.connectedPeers = modules.peersData.connectedPeers;
     this.opts = opts;
     this.discovery = discovery;
-    this.nodeId = networkConfig.nodeId;
 
     const {metrics} = modules;
     if (metrics) {

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -318,8 +318,8 @@ export class PeerManager {
     if (!metadata || metadata.seqNumber < seqNumber) {
       // re-status happens at end of requestMetadata to keep peer info up to date
       void this.requestMetadata(peer);
-    } else {
-      // if metadata didn't change just re-status to check for earliestAvailableSlot updates
+    } else if (this.clock.currentEpoch > this.config.FULU_FORK_EPOCH) {
+      // if metadata didn't change just re-status when post-fulu to check for earliestAvailableSlot updates
       void this.requestStatus(peer, this.statusCache.get());
     }
   }
@@ -362,9 +362,13 @@ export class PeerManager {
         custodyGroups,
         samplingGroups,
       };
-      // always call requestStatus to make sure earliestAvailableSlot is up to date. also peerConnected event will trigger
-      // sending updates to the cached sync meta
-      void this.requestStatus(peer, this.statusCache.get());
+
+      if (oldMetadata === null || this.clock.currentEpoch > this.config.FULU_FORK_EPOCH) {
+        // status peer if there was no existing metadata or always re-status post-fulu to make sure
+        // earliestAvailableSlot is up to date. The peerConnected event will trigger at end of response handling to
+        // send updates to the cached sync meta on main thread
+        void this.requestStatus(peer, this.statusCache.get());
+      }
     }
   }
 

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -318,7 +318,11 @@ export class PeerManager {
     // if the sequence number is unknown update the peer's metadata
     const metadata = this.connectedPeers.get(peer.toString())?.metadata;
     if (!metadata || metadata.seqNumber < seqNumber) {
+      // re-status happens at end of requestMetadata to keep peer info up to date
       void this.requestMetadata(peer);
+    } else {
+      // if metadata didn't change just re-status to check for earliestAvailableSlot updates
+      void this.requestStatus(peer, this.statusCache.get());
     }
   }
 
@@ -357,14 +361,12 @@ export class PeerManager {
           (metadata as Partial<fulu.Metadata>).custodyGroupCount ??
           // TODO: spec says that Clients MAY reject peers with a value less than CUSTODY_REQUIREMENT
           this.config.CUSTODY_REQUIREMENT,
-        // TODO(fulu): this should be columns not groups.  need to change everywhere. we consume columns and should
-        //      cache that instead so if groups->columns ever changes from 1-1 we only need to update that here
         custodyGroups,
         samplingGroups,
       };
-      if (oldMetadata === null || oldMetadata.custodyGroupCount !== peerData.metadata.custodyGroupCount) {
-        void this.requestStatus(peer, this.statusCache.get());
-      }
+      // always call requestStatus to make sure earliestAvailableSlot is up to date. also peerConnected event will trigger
+      // sending updates to the cached sync meta
+      void this.requestStatus(peer, this.statusCache.get());
     }
   }
 
@@ -454,15 +456,12 @@ export class PeerManager {
 
       this.logger.debug("onStatus", {
         nodeId: toHex(nodeId),
-        myNodeId: toHex(this.nodeId),
         peerId: peer.toString(),
+        clientAgent,
         custodyGroupCount,
         hasAllColumns,
         matchingSubnetsNum,
-        custodyGroups: prettyPrintIndices(custodyGroups),
         custodyColumns: prettyPrintIndices(custodyColumns),
-        mySampleSubnets: prettyPrintIndices(sampleSubnets),
-        clientAgent,
       });
 
       this.networkEventBus.emit(NetworkEvent.peerConnected, {

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -115,13 +115,13 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
   addPeer(peerId: PeerIdStr, localStatus: Status, peerStatus: Status): void {
     // Compute if we should do a Finalized or Head sync with this peer
     const {syncType, startEpoch, target} = getRangeSyncTarget(localStatus, peerStatus, this.chain.forkChoice);
-    this.logger.debug("Sync peer joined", {
+    this.logger.debug("RangeSync.addPeer", {
       peer: peerId,
       syncType,
       startEpoch,
       targetSlot: target.slot,
       targetRoot: toRootHex(target.root),
-      earliestAvailableSlot: (peerStatus as fulu.Status).earliestAvailableSlot ?? Infinity,
+      earliestAvailableSlot: (peerStatus as fulu.Status).earliestAvailableSlot ?? "pre-fulu",
     });
 
     // If the peer existed in any other chain, remove it.

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -1,7 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkSeq, INTERVALS_PER_SLOT} from "@lodestar/params";
 import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
-import {RootHex, Slot} from "@lodestar/types";
+import {RootHex, Slot, fulu} from "@lodestar/types";
 import {Logger, prettyBytes, prettyPrintIndices, pruneSetToMax, sleep} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource, IBlockInput} from "../chain/blocks/blockInput/types.js";
@@ -248,9 +248,19 @@ export class BlockInputSync {
 
   private onPeerConnected = (data: NetworkEventData[NetworkEvent.peerConnected]): void => {
     try {
-      const peerId = data.peer;
-      const peerSyncMeta = this.network.getConnectedPeerSyncMeta(peerId);
-      this.peerBalancer.onPeerConnected(data.peer, peerSyncMeta);
+      const earliestAvailableSlot = (data.status as fulu.Status).earliestAvailableSlot; // could be undefined pre-fulu
+      this.logger.verbose("BlockInputSync.onPeerConnected", {
+        peer: prettyPrintPeerIdStr(data.peer),
+        clientAgent: data.clientAgent,
+        custodyColumns: prettyPrintIndices(data.custodyColumns),
+        earliestAvailableSlot: earliestAvailableSlot ?? "pre-fulu",
+      });
+      this.peerBalancer.onPeerConnected(data.peer, {
+        peerId: data.peer,
+        client: data.clientAgent,
+        custodyColumns: data.custodyColumns,
+        earliestAvailableSlot,
+      });
       this.triggerUnknownBlockSearch();
     } catch (e) {
       this.logger.debug("Error handling peerConnected event", {}, e as Error);

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -256,7 +256,6 @@ export class BlockInputSync {
         earliestAvailableSlot: earliestAvailableSlot ?? "pre-fulu",
       });
       this.peerBalancer.onPeerConnected(data.peer, {
-        peerId: data.peer,
         client: data.clientAgent,
         custodyColumns: data.custodyColumns,
         earliestAvailableSlot,
@@ -721,7 +720,7 @@ export class BlockInputSync {
  * Class to track active byRoots requests and balance them across eligible peers.
  */
 export class UnknownBlockPeerBalancer {
-  readonly peersMeta: Map<PeerIdStr, PeerSyncMeta>;
+  readonly peersMeta: Map<PeerIdStr, Omit<PeerSyncMeta, "peerId">>;
   readonly activeRequests: Map<PeerIdStr, number>;
 
   constructor() {
@@ -730,7 +729,7 @@ export class UnknownBlockPeerBalancer {
   }
 
   /** Trigger on each peer re-status */
-  onPeerConnected(peerId: PeerIdStr, syncMeta: PeerSyncMeta): void {
+  onPeerConnected(peerId: PeerIdStr, syncMeta: Omit<PeerSyncMeta, "peerId">): void {
     this.peersMeta.set(peerId, syncMeta);
 
     if (!this.activeRequests.has(peerId)) {
@@ -761,8 +760,12 @@ export class UnknownBlockPeerBalancer {
     );
 
     const bestPeerId = sortedEligiblePeers[0];
+    const peerMeta = this.peersMeta.get(bestPeerId);
+    if (!peerMeta) {
+      return null;
+    }
     this.onRequest(bestPeerId);
-    return this.peersMeta.get(bestPeerId) ?? null;
+    return {peerId: bestPeerId, ...peerMeta};
   }
 
   /**
@@ -792,8 +795,12 @@ export class UnknownBlockPeerBalancer {
     );
 
     const bestPeerId = sortedEligiblePeers[0];
+    const peerMeta = this.peersMeta.get(bestPeerId);
+    if (!peerMeta) {
+      return null;
+    }
     this.onRequest(bestPeerId);
-    return this.peersMeta.get(bestPeerId) ?? null;
+    return {peerId: bestPeerId, ...peerMeta};
   }
 
   /**


### PR DESCRIPTION
**Motivation**

resolves #8424 

Post-Fulu the status and metadata changes both affect how sync peers are selected.  Wanted to make sure that the most up-to-date information was passed to the main thread so sync has current meta.

Also cleaned up a few of the log entries as they relate to the flow/display of SyncMeta

**NOTE** Need to triple check that the updates of Status do not affect range sync as it will be updating the head/target for peers which may change the calculation for where we should sync towards.  Need to deploy to a feat group and monitor that there are no adverse affects.
