### PR TITLE
feat: add lodestar-bun and bun leveldb binding

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         run: scripts/assert_no_yarn_warnings.sh
 
       - name: Lint yarn lockfile
-        run: npx lockfile-lint --path yarn.lock --allowed-hosts npm yarn --validate-https
+        run: npx lockfile-lint --path yarn.lock --allowed-hosts npm yarn github.com --allowed-schemes "https:" "git+https:"
 
       - name: Lint Code
         run: yarn lint

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@biomejs/biome": "^2.2.0",
     "@chainsafe/benchmark": "^1.2.3",
     "@chainsafe/biomejs-config": "^1.0.0",
-    "@types/node": "^20.12.8",
+    "@types/node": "^22.18.6",
     "@types/react": "^19.1.12",
     "@vitest/browser": "3.0.9",
     "@vitest/coverage-v8": "3.0.9",

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
@@ -2,7 +2,7 @@ import worker from "node:worker_threads";
 import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {Transfer, expose} from "@chainsafe/threads/worker";
 import {chainConfigFromJson, createBeaconConfig} from "@lodestar/config";
-import {LevelDbController} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {getNodeLogger} from "@lodestar/logger/node";
 import {BeaconDb} from "../../../db/index.js";
 import {RegistryMetricCreator, collectNodeJSMetrics} from "../../../metrics/index.js";

--- a/packages/beacon-node/test/e2e/eth1/eth1ForBlockProduction.test.ts
+++ b/packages/beacon-node/test/e2e/eth1/eth1ForBlockProduction.test.ts
@@ -1,6 +1,7 @@
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
-import {KeyValue, LevelDbController} from "@lodestar/db";
+import {KeyValue} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {phase0, ssz} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {BeaconDb} from "../../../src/db/index.js";

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -2,7 +2,7 @@ import {generateKeyPair} from "@libp2p/crypto/keys";
 import {afterAll, beforeAll, bench, describe} from "@chainsafe/benchmark";
 import {fromHexString} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
-import {LevelDbController} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY} from "@lodestar/params";
 import {CachedBeaconStateAltair} from "@lodestar/state-transition";
 import {defaultOptions as defaultValidatorOptions} from "@lodestar/validator";

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -1,7 +1,7 @@
 import {generateKeyPair} from "@libp2p/crypto/keys";
 import {afterAll, beforeAll, bench, describe, setBenchOpts} from "@chainsafe/benchmark";
 import {config} from "@lodestar/config/default";
-import {LevelDbController} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {sleep, toHex} from "@lodestar/utils";
 import {defaultOptions as defaultValidatorOptions} from "@lodestar/validator";

--- a/packages/beacon-node/test/unit/db/api/repositories/blockArchive.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repositories/blockArchive.test.ts
@@ -1,7 +1,8 @@
 import {rimraf} from "rimraf";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {config} from "@lodestar/config/default";
-import {LevelDbController, encodeKey} from "@lodestar/db";
+import {encodeKey} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {ssz} from "@lodestar/types";
 import {intToBytes} from "@lodestar/utils";
 import {Bucket, getBucketNameByValue} from "../../../../../src/db/buckets.js";

--- a/packages/beacon-node/test/unit/db/api/repositories/dataColumn.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repositories/dataColumn.test.ts
@@ -1,7 +1,7 @@
 import {rimraf} from "rimraf";
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
 import {createChainForkConfig} from "@lodestar/config";
-import {LevelDbController} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {Root, fulu, ssz} from "@lodestar/types";
 import {fromAsync, toHex} from "@lodestar/utils";

--- a/packages/beacon-node/test/unit/db/api/repository.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repository.test.ts
@@ -8,7 +8,7 @@ import {Bytes32, ssz} from "@lodestar/types";
 import {Bucket} from "../../../../src/db/buckets.js";
 
 vi.mock("@lodestar/db", async (importOriginal) => {
-  const mod = await importOriginal<typeof import("@lodestar/db")>();
+  const mod = await importOriginal<typeof import("@lodestar/db/controller/level")>();
 
   return {
     ...mod,

--- a/packages/beacon-node/test/unit/db/api/repository.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repository.test.ts
@@ -7,7 +7,7 @@ import {LevelDbController} from "@lodestar/db/controller/level";
 import {Bytes32, ssz} from "@lodestar/types";
 import {Bucket} from "../../../../src/db/buckets.js";
 
-vi.mock("@lodestar/db", async (importOriginal) => {
+vi.mock("@lodestar/db/controller/level", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@lodestar/db/controller/level")>();
 
   return {

--- a/packages/beacon-node/test/unit/db/api/repository.test.ts
+++ b/packages/beacon-node/test/unit/db/api/repository.test.ts
@@ -2,7 +2,8 @@ import all from "it-all";
 import {MockedObject, afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {ContainerType} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
-import {Db, LevelDbController, Repository} from "@lodestar/db";
+import {Db, Repository} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {Bytes32, ssz} from "@lodestar/types";
 import {Bucket} from "../../../../src/db/buckets.js";
 

--- a/packages/beacon-node/test/utils/db.ts
+++ b/packages/beacon-node/test/utils/db.ts
@@ -1,6 +1,7 @@
 import childProcess from "node:child_process";
 import {ChainForkConfig} from "@lodestar/config";
-import {FilterOptions, LevelDbController} from "@lodestar/db";
+import {FilterOptions} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {BeaconDb} from "../../src/index.js";
 import {testLogger} from "./logger.js";
 

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -6,7 +6,7 @@ import {setHasher} from "@chainsafe/persistent-merkle-tree";
 import {hasher} from "@chainsafe/persistent-merkle-tree/hasher/hashtree";
 import {ChainConfig, createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {config as minimalConfig} from "@lodestar/config/default";
-import {LevelDbController} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {LoggerNode} from "@lodestar/logger/node";
 import {ForkSeq, GENESIS_SLOT, NUMBER_OF_COLUMNS, SLOTS_PER_EPOCH, ZERO_HASH_HEX} from "@lodestar/params";
 import {BeaconStateAllForks, computeTimeAtSlot} from "@lodestar/state-transition";

--- a/packages/beacon-node/test/utils/node/validator.ts
+++ b/packages/beacon-node/test/utils/node/validator.ts
@@ -3,7 +3,7 @@ import {vi} from "vitest";
 import {SecretKey} from "@chainsafe/blst";
 import {ApiClient, ApiError, ApiResponse, HttpStatusCode} from "@lodestar/api";
 import {BeaconApiMethods} from "@lodestar/api/beacon/server";
-import {LevelDbController} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {interopSecretKey} from "@lodestar/state-transition";
 import {mapValues} from "@lodestar/utils";
 import {Signer, SignerType, SlashingProtection, Validator, ValidatorProposerConfig} from "@lodestar/validator";

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -4,7 +4,7 @@ import {SignableENR} from "@chainsafe/enr";
 import {hasher} from "@chainsafe/persistent-merkle-tree";
 import {BeaconDb, BeaconNode} from "@lodestar/beacon-node";
 import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
-import {LevelDbController} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {LoggerNode, getNodeLogger} from "@lodestar/logger/node";
 import {ACTIVE_PRESET, PresetName} from "@lodestar/params";
 import {ErrorAborted, bytesToInt} from "@lodestar/utils";

--- a/packages/cli/src/cmds/validator/handler.ts
+++ b/packages/cli/src/cmds/validator/handler.ts
@@ -7,7 +7,7 @@ import {
   collectNodeJSMetrics,
   getHttpMetricsServer,
 } from "@lodestar/beacon-node";
-import {LevelDbController} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {getNodeLogger} from "@lodestar/logger/node";
 import {
   ProcessShutdownCallback,

--- a/packages/cli/src/cmds/validator/slashingProtection/utils.ts
+++ b/packages/cli/src/cmds/validator/slashingProtection/utils.ts
@@ -1,6 +1,6 @@
 import {getClient} from "@lodestar/api";
 import {NetworkName, genesisData} from "@lodestar/config/networks";
-import {LevelDbController} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {Root} from "@lodestar/types";
 import {Logger, fromHex} from "@lodestar/utils";
 import {MetaDataRepository, SlashingProtection} from "@lodestar/validator";

--- a/packages/cli/src/util/file.ts
+++ b/packages/cli/src/util/file.ts
@@ -139,7 +139,7 @@ export async function downloadFile(pathDest: string, url: string): Promise<void>
       throw new Error("Response body is null");
     }
 
-    await stream.pipeline(Readable.fromWeb(res.body as NodeReadableStream), fs.createWriteStream(pathDest));
+    await stream.pipeline(Readable.fromWeb(res.body as unknown as NodeReadableStream), fs.createWriteStream(pathDest));
   }
 }
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,6 +16,16 @@
     ".": {
       "bun": "./src/index.ts",
       "import": "./lib/index.js"
+    },
+    "./controller/level": {
+      "bun": "./src/controller/level_bun.ts",
+      "import": "./lib/controller/level.js"
+    }
+  },
+  "imports": {
+    "#controller/level": {
+      "bun": "./src/controller/level_bun.ts",
+      "import": "./src/controller/level.js"
     }
   },
   "types": "./lib/index.d.ts",
@@ -42,6 +52,7 @@
   },
   "dependencies": {
     "@chainsafe/ssz": "^1.2.2",
+    "@lodestar/bun": "git+https://github.com/ChainSafe/lodestar-bun.git",
     "@lodestar/config": "^1.34.1",
     "@lodestar/utils": "^1.34.1",
     "classic-level": "^1.4.1",

--- a/packages/db/src/controller/index.ts
+++ b/packages/db/src/controller/index.ts
@@ -1,3 +1,2 @@
 export type {DatabaseController, Db, DbReqOpts, FilterOptions, KeyValue} from "./interface.js";
-export {LevelDbController} from "./level.js";
 export type {LevelDbControllerMetrics} from "./metrics.js";

--- a/packages/db/src/controller/level_bun.ts
+++ b/packages/db/src/controller/level_bun.ts
@@ -1,0 +1,288 @@
+import {
+  DB,
+  dbBatchDelete,
+  dbBatchPut,
+  dbClose,
+  dbDelete,
+  dbDestroy,
+  dbGet,
+  dbIterator,
+  dbOpen,
+  dbPut,
+  iteratorDestroy,
+  iteratorKey,
+  iteratorNext,
+  iteratorSeek,
+  iteratorSeekToFirst,
+  iteratorValid,
+  iteratorValue,
+} from "@lodestar/bun";
+import {Logger} from "@lodestar/utils";
+import {DatabaseController, DatabaseOptions, DbReqOpts, FilterOptions, KeyValue} from "./interface.js";
+import {LevelDbControllerMetrics} from "./metrics.js";
+
+export type LevelDbControllerModules = {
+  logger: Logger;
+  metrics?: LevelDbControllerMetrics | null;
+};
+
+export enum Status {
+  started = "started",
+  closed = "closed",
+}
+
+const BUCKET_ID_UNKNOWN = "unknown";
+
+export class LevelDbController implements DatabaseController<Uint8Array, Uint8Array> {
+  private status = Status.started;
+
+  constructor(
+    private readonly db: DB,
+    private metrics: LevelDbControllerMetrics | null
+  ) {}
+
+  static async create(options: DatabaseOptions, {metrics}: LevelDbControllerModules): Promise<LevelDbController> {
+    const db = dbOpen(options.name, {create_if_missing: true});
+    return new LevelDbController(db, metrics ?? null);
+  }
+
+  static async destroy(location: string): Promise<void> {
+    dbDestroy(location);
+  }
+
+  async close(): Promise<void> {
+    if (this.status === Status.closed) {
+      return;
+    }
+    this.status = Status.closed;
+
+    dbClose(this.db);
+  }
+
+  setMetrics(metrics: LevelDbControllerMetrics): void {
+    if (this.metrics !== null) {
+      throw new Error("Metrics already set");
+    }
+    this.metrics = metrics;
+  }
+
+  async get(key: Uint8Array, opts?: DbReqOpts): Promise<Uint8Array | null> {
+    this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+
+    return dbGet(this.db, key);
+  }
+
+  async getMany(keys: Uint8Array[], opts?: DbReqOpts): Promise<(Uint8Array | undefined)[]> {
+    this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
+
+    return keys.map((key) => dbGet(this.db, key) ?? undefined);
+  }
+
+  async put(key: Uint8Array, value: Uint8Array, opts?: DbReqOpts): Promise<void> {
+    this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+
+    dbPut(this.db, key, value);
+  }
+
+  async delete(key: Uint8Array, opts?: DbReqOpts): Promise<void> {
+    this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+
+    dbDelete(this.db, key);
+  }
+
+  async batchPut(items: KeyValue<Uint8Array, Uint8Array>[], opts?: DbReqOpts): Promise<void> {
+    this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, items.length);
+
+    dbBatchPut(this.db, items);
+  }
+
+  async batchDelete(keys: Uint8Array[], opts?: DbReqOpts): Promise<void> {
+    this.metrics?.dbWriteReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    this.metrics?.dbWriteItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
+
+    dbBatchDelete(this.db, keys);
+  }
+
+  keysStream(opts: FilterOptions<Uint8Array> = {}): AsyncIterable<Uint8Array> {
+    const iterator = dbIterator(this.db);
+    if (opts.gt) {
+      iteratorSeek(iterator, opts.gt);
+      iteratorNext(iterator);
+    } else if (opts.gte) {
+      iteratorSeek(iterator, opts.gte);
+    } else {
+      iteratorSeekToFirst(iterator);
+    }
+    const bucket = opts.bucketId ?? BUCKET_ID_UNKNOWN;
+    const metrics = this.metrics;
+    metrics?.dbReadReq.inc({bucket}, 1);
+    let itemsRead = 0;
+    return (async function* () {
+      try {
+        while (iteratorValid(iterator)) {
+          const key = iteratorKey(iterator);
+          if (opts.lt && Buffer.compare(key, opts.lt) >= 0) break;
+          if (opts.lte && Buffer.compare(key, opts.lte) > 0) break;
+          itemsRead++;
+          yield key;
+          iteratorNext(iterator);
+        }
+      } finally {
+        metrics?.dbReadItems.inc({bucket}, itemsRead);
+        iteratorDestroy(iterator);
+      }
+    })();
+  }
+
+  async keys(opts: FilterOptions<Uint8Array> = {}): Promise<Uint8Array[]> {
+    const iterator = dbIterator(this.db);
+    if (opts.gt) {
+      iteratorSeek(iterator, opts.gt);
+      iteratorNext(iterator);
+    } else if (opts.gte) {
+      iteratorSeek(iterator, opts.gte);
+    } else {
+      iteratorSeekToFirst(iterator);
+    }
+    const keys = [];
+    this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    try {
+      while (iteratorValid(iterator)) {
+        const key = iteratorKey(iterator);
+        if (opts.lt && Buffer.compare(key, opts.lt) >= 0) break;
+        if (opts.lte && Buffer.compare(key, opts.lte) > 0) break;
+        keys.push(key);
+        iteratorNext(iterator);
+      }
+      return keys;
+    } finally {
+      this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
+      iteratorDestroy(iterator);
+    }
+  }
+
+  valuesStream(opts: FilterOptions<Uint8Array> = {}): AsyncIterable<Uint8Array> {
+    const iterator = dbIterator(this.db);
+    if (opts.gt) {
+      iteratorSeek(iterator, opts.gt);
+      iteratorNext(iterator);
+    } else if (opts.gte) {
+      iteratorSeek(iterator, opts.gte);
+    } else {
+      iteratorSeekToFirst(iterator);
+    }
+    const bucket = opts.bucketId ?? BUCKET_ID_UNKNOWN;
+    const metrics = this.metrics;
+    metrics?.dbReadReq.inc({bucket}, 1);
+    let itemsRead = 0;
+    return (async function* () {
+      try {
+        while (iteratorValid(iterator)) {
+          const key = iteratorKey(iterator);
+          if (opts.lt && Buffer.compare(key, opts.lt) >= 0) break;
+          if (opts.lte && Buffer.compare(key, opts.lte) > 0) break;
+          itemsRead++;
+          const value = iteratorValue(iterator);
+          yield value;
+          iteratorNext(iterator);
+        }
+      } finally {
+        metrics?.dbReadItems.inc({bucket}, itemsRead);
+        iteratorDestroy(iterator);
+      }
+    })();
+  }
+
+  async values(opts: FilterOptions<Uint8Array> = {}): Promise<Uint8Array[]> {
+    const iterator = dbIterator(this.db);
+    if (opts.gt) {
+      iteratorSeek(iterator, opts.gt);
+      iteratorNext(iterator);
+    } else if (opts.gte) {
+      iteratorSeek(iterator, opts.gte);
+    } else {
+      iteratorSeekToFirst(iterator);
+    }
+    const values = [];
+    this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    try {
+      while (iteratorValid(iterator)) {
+        const key = iteratorKey(iterator);
+        if (opts.lt && Buffer.compare(key, opts.lt) >= 0) break;
+        if (opts.lte && Buffer.compare(key, opts.lte) > 0) break;
+        const value = iteratorValue(iterator);
+        values.push(value);
+        iteratorNext(iterator);
+      }
+      return values;
+    } finally {
+      this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, values.length);
+      iteratorDestroy(iterator);
+    }
+  }
+
+  entriesStream(opts: FilterOptions<Uint8Array> = {}): AsyncIterable<KeyValue<Uint8Array, Uint8Array>> {
+    const iterator = dbIterator(this.db);
+    if (opts.gt) {
+      iteratorSeek(iterator, opts.gt);
+      iteratorNext(iterator);
+    } else if (opts.gte) {
+      iteratorSeek(iterator, opts.gte);
+    } else {
+      iteratorSeekToFirst(iterator);
+    }
+    const bucket = opts.bucketId ?? BUCKET_ID_UNKNOWN;
+    const metrics = this.metrics;
+    metrics?.dbReadReq.inc({bucket}, 1);
+    let itemsRead = 0;
+    return (async function* () {
+      try {
+        while (iteratorValid(iterator)) {
+          const key = iteratorKey(iterator);
+          if (opts.lt && Buffer.compare(key, opts.lt) >= 0) break;
+          if (opts.lte && Buffer.compare(key, opts.lte) > 0) break;
+          itemsRead++;
+          const value = iteratorValue(iterator);
+          yield {key, value};
+          iteratorNext(iterator);
+        }
+      } finally {
+        metrics?.dbReadItems.inc({bucket}, itemsRead);
+        iteratorDestroy(iterator);
+      }
+    })();
+  }
+
+  async entries(opts: FilterOptions<Uint8Array> = {}): Promise<KeyValue<Uint8Array, Uint8Array>[]> {
+    const iterator = dbIterator(this.db);
+    if (opts.gt) {
+      iteratorSeek(iterator, opts.gt);
+      iteratorNext(iterator);
+    } else if (opts.gte) {
+      iteratorSeek(iterator, opts.gte);
+    } else {
+      iteratorSeekToFirst(iterator);
+    }
+    const entries = [];
+    this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    try {
+      while (iteratorValid(iterator)) {
+        const key = iteratorKey(iterator);
+        if (opts.lt && Buffer.compare(key, opts.lt) >= 0) break;
+        if (opts.lte && Buffer.compare(key, opts.lte) > 0) break;
+        const value = iteratorValue(iterator);
+        entries.push({key, value});
+        iteratorNext(iterator);
+      }
+      return entries;
+    } finally {
+      this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, entries.length);
+      iteratorDestroy(iterator);
+    }
+  }
+}

--- a/packages/db/test/e2e/abstractPrefixedRepository.test.ts
+++ b/packages/db/test/e2e/abstractPrefixedRepository.test.ts
@@ -1,15 +1,10 @@
 /** biome-ignore-all lint/style/noNonNullAssertion: values all exist */
 
 import {afterAll, beforeAll, beforeEach, describe, expect, it} from "vitest";
+import {LevelDbController} from "#controller/level";
 import {getEnvLogger} from "@lodestar/logger/env";
 import {fromAsync} from "@lodestar/utils";
-import {
-  type Db,
-  LevelDbController,
-  PrefixedRepository,
-  decodeNumberForDbKey,
-  encodeNumberForDbKey,
-} from "../../src/index.js";
+import {type Db, PrefixedRepository, decodeNumberForDbKey, encodeNumberForDbKey} from "../../src/index.js";
 
 type Slot = number;
 type Column = number;

--- a/packages/db/test/e2e/abstractRepository.test.ts
+++ b/packages/db/test/e2e/abstractRepository.test.ts
@@ -1,8 +1,9 @@
 /** biome-ignore-all lint/style/noNonNullAssertion: values all exist */
 
 import {afterAll, beforeAll, beforeEach, describe, expect, it} from "vitest";
+import {LevelDbController} from "#controller/level";
 import {getEnvLogger} from "@lodestar/logger/env";
-import {BUCKET_LENGTH, type Db, LevelDbController, Repository, encodeKey} from "../../src/index.js";
+import {BUCKET_LENGTH, type Db, Repository, encodeKey} from "../../src/index.js";
 
 // Minimal fake SSZ-like type for string values
 const fakeType = {

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -2,8 +2,8 @@ import {execSync} from "node:child_process";
 import os from "node:os";
 import all from "it-all";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
+import {LevelDbController} from "#controller/level";
 import {getEnvLogger} from "@lodestar/logger/env";
-import {LevelDbController} from "../../../src/controller/index.js";
 
 describe("LevelDB controller", () => {
   const dbLocation = "./.__testdb";

--- a/packages/db/tsconfig.build.json
+++ b/packages/db/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.build.json",
   "include": ["src"],
+  "exclude": ["src/controller/level_bun.ts"],
   "compilerOptions": {
     "outDir": "lib"
   }

--- a/packages/db/tsconfig.build.json
+++ b/packages/db/tsconfig.build.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.build.json",
   "include": ["src"],
-  "exclude": ["src/controller/level_bun.ts"],
   "compilerOptions": {
     "outDir": "lib"
   }

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src", "test"],
-  "exclude": ["src/controller/level_bun.ts"],
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "lib"

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src", "test"],
+  "exclude": ["src/controller/level_bun.ts"],
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "lib"
   }
 }

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -81,7 +81,7 @@ export async function downloadGenericSpecTests<TestNames extends string>(
           log(`Downloading ${url} - ${totalSize} bytes`);
 
           // stream download to local .tar.gz file
-          await pipeline(res.body as NodeReadableStream, fs.createWriteStream(tarball));
+          await pipeline(res.body as unknown as NodeReadableStream, fs.createWriteStream(tarball));
           log(`Downloaded ${url} - ${fs.statSync(tarball).size} bytes`);
 
           // extract tar into output directory

--- a/packages/validator/test/spec/index.test.ts
+++ b/packages/validator/test/spec/index.test.ts
@@ -1,6 +1,6 @@
 import {rimraf} from "rimraf";
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
-import {LevelDbController} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {
   InvalidAttestationError,
   InvalidBlockError,

--- a/packages/validator/test/spec/spec.test.ts
+++ b/packages/validator/test/spec/spec.test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import {rimraf} from "rimraf";
 import {afterAll, beforeAll, beforeEach, describe, expect, it} from "vitest";
 import {fromHexString} from "@chainsafe/ssz";
-import {LevelDbController} from "@lodestar/db";
+import {LevelDbController} from "@lodestar/db/controller/level";
 import {ZERO_HASH} from "@lodestar/state-transition";
 import {
   InterchangeError,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -26,6 +26,7 @@
     "incremental": true,
     "preserveWatchOutput": true,
     "noUncheckedSideEffectImports": true,    
+    "rewriteRelativeImportExtensions": true,
     // TODO: Investigate following errors:
     // - Cannot find module 'rollup/parseAst' or its corresponding type declarations
     "skipLibCheck": true,

--- a/types/bun/index.d.ts
+++ b/types/bun/index.d.ts
@@ -1,7 +1,7 @@
 
 // We have to override Bun types to disallow mutating global types provide by NodeJS
 // This breaks our CI build process
-// <reference path="../../node_modules/bun-types/globals.d.ts" />
+/// <reference path="../../node_modules/bun-types/globals.d.ts" />
 
 /// <reference path="../../node_modules/bun-types/s3.d.ts" />
 /// <reference path="../../node_modules/bun-types/fetch.d.ts" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,10 +550,10 @@
     "@chainsafe/blst-linux-x64-musl" "2.2.0"
     "@chainsafe/blst-win32-x64-msvc" "2.2.0"
 
-"@chainsafe/bun-ffi-z@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@chainsafe/bun-ffi-z/-/bun-ffi-z-1.1.1.tgz#ca9d4b83c2d83780639c3d5a965dacbcb1ff0957"
-  integrity sha512-RSJhdS8Ytj3NuEvwshAFRI/y9/GbD1IhVuYEjVt0u16Hw2owDvVUVAgiN4/g8WWcFMhs8i5a4VXiFzK25fARSA==
+"@chainsafe/bun-ffi-z@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chainsafe/bun-ffi-z/-/bun-ffi-z-1.1.3.tgz#152a06a9cde8e0050ac400703ec5c438fcbcd221"
+  integrity sha512-KlhcVDUYdcAI7KRy4UTQvxMtaFGpSodHizNy/1aHFaC+sjCKBoTTaVdQhbcVF1Jy3O12WK7ZzTlljpKgEvma+Q==
 
 "@chainsafe/discv5@^11.0.4":
   version "11.0.4"
@@ -2140,9 +2140,9 @@
 
 "@lodestar/bun@git+https://github.com/ChainSafe/lodestar-bun.git":
   version "0.1.0"
-  resolved "git+https://github.com/ChainSafe/lodestar-bun.git#fb40c72ff6c3150f3fe0e015b33da880cac47004"
+  resolved "git+https://github.com/ChainSafe/lodestar-bun.git#368dfa6e112171231d23edbc34e55ad53054442e"
   dependencies:
-    "@chainsafe/bun-ffi-z" "^1.1.1"
+    "@chainsafe/bun-ffi-z" "^1.1.3"
 
 "@lukeed/ms@^2.0.2":
   version "2.0.2"
@@ -3525,12 +3525,12 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/node@^20.12.8":
-  version "20.16.11"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.16.11.tgz#9b544c3e716b1577ac12e70f9145193f32750b33"
-  integrity sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==
+"@types/node@^22.18.6":
+  version "22.18.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.18.6.tgz#38172ef0b65e09d1a4fc715eb09a7d5decfdc748"
+  integrity sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==
   dependencies:
-    undici-types "~6.19.2"
+    undici-types "~6.21.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -12538,6 +12538,11 @@ undici-types@~6.19.2:
   version "6.19.8"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 undici@^5.12.0:
   version "5.29.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -550,6 +550,11 @@
     "@chainsafe/blst-linux-x64-musl" "2.2.0"
     "@chainsafe/blst-win32-x64-msvc" "2.2.0"
 
+"@chainsafe/bun-ffi-z@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/bun-ffi-z/-/bun-ffi-z-1.1.1.tgz#ca9d4b83c2d83780639c3d5a965dacbcb1ff0957"
+  integrity sha512-RSJhdS8Ytj3NuEvwshAFRI/y9/GbD1IhVuYEjVt0u16Hw2owDvVUVAgiN4/g8WWcFMhs8i5a4VXiFzK25fARSA==
+
 "@chainsafe/discv5@^11.0.4":
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@chainsafe/discv5/-/discv5-11.0.4.tgz#77da0bef913ded936d97ca23a078de2034f2c94f"
@@ -2132,6 +2137,12 @@
     race-signal "^1.1.3"
     uint8arraylist "^2.4.8"
     uint8arrays "^5.1.0"
+
+"@lodestar/bun@git+https://github.com/ChainSafe/lodestar-bun.git":
+  version "0.1.0"
+  resolved "git+https://github.com/ChainSafe/lodestar-bun.git#fb40c72ff6c3150f3fe0e015b33da880cac47004"
+  dependencies:
+    "@chainsafe/bun-ffi-z" "^1.1.1"
 
 "@lukeed/ms@^2.0.2":
   version "2.0.2"


### PR DESCRIPTION
**Motivation**

- #7280 

**Description**

- update `@types/node` to the latest node v22 version
- add `@lodestar/bun` dependency using git+https (for now! so that we don't have to republish a bazillion times)
  - keep in mind that this requires a manual build/rebuild of the so (via `cd node_modules/@lodestar/bun && zig build`)
- Add a bun-specific `LevelDbController` which uses [`@lodestar/bun`](https://github.com/ChainSafe/lodestar-bun)
- Only expose the leveldb controller via a subpath export (and for tests, as a custom import, like in #8320 )
- add bun bun global override types