### PR TITLE
chore: add git to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 FROM --platform=${BUILDPLATFORM:-amd64} node:22-slim AS build_src
 ARG COMMIT
 WORKDIR /usr/app
-RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY . .
 
@@ -23,7 +23,7 @@ RUN cd packages/cli && GIT_COMMIT=${COMMIT} yarn write-git-data
 # Note: This step is redundant for the host arch
 FROM node:22-slim AS build_deps
 WORKDIR /usr/app
-RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build_src /usr/app .
 


### PR DESCRIPTION
**Motivation**

The docker build no longer works since https://github.com/ChainSafe/lodestar/pull/8462


see [most recent job run](https://github.com/ChainSafe/lodestar/actions/runs/18008927165/job/51241364972)
```
#13 [linux/amd64 build_src 5/6] RUN yarn install --non-interactive --frozen-lockfile &&   yarn build &&   yarn install --non-interactive --frozen-lockfile --production
#13 ERROR: process "/bin/sh -c yarn install --non-interactive --frozen-lockfile &&   yarn build &&   yarn install --non-interactive --frozen-lockfile --production" did not complete successfully: exit code: 1

#15 [linux/arm64 build_deps 3/6] RUN apt-get update && apt-get install -y g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
#15 67.27 Preparing to unpack .../54-libfreetype6_2.12.1+dfsg-5+deb12u4_arm64.deb ...
#15 67.27 Unpacking libfreetype6:arm64 (2.12.1+dfsg-5+deb12u4) ...
#15 CANCELED
------
 > [linux/amd64 build_src 5/6] RUN yarn install --non-interactive --frozen-lockfile &&   yarn build &&   yarn install --non-interactive --frozen-lockfile --production:
0.219 yarn install v1.22.22
0.317 [1/5] Validating package.json...
0.336 [2/5] Resolving packages...
0.646 [3/5] Fetching packages...
28.83 error Couldn't find the binary git
28.83 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------
Dockerfile:11
--------------------
  10 |     
  11 | >>> RUN yarn install --non-interactive --frozen-lockfile && \
  12 | >>>   yarn build && \
  13 | >>>   yarn install --non-interactive --frozen-lockfile --production
  14 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c yarn install --non-interactive --frozen-lockfile &&   yarn build &&   yarn install --non-interactive --frozen-lockfile --production" did not complete successfully: exit code: 1
Error: Process completed with exit code 1.
```

We need to add `git` to be able to install `@lodestar/bun`

**Description**

Add `git` to Dockerfile to be able to install dependencies that reference a github repository

eg. `@lodestar/bun`
```jsonc
"@lodestar/bun": "git+https://github.com/ChainSafe/lodestar-bun.git
```
