### PR TITLE
fix: not throw error in removeEagerlyPersistedBlockInputs

### DIFF
--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -102,15 +102,7 @@ export async function removeEagerlyPersistedBlockInputs(this: BeaconChain, block
     if (!this.forkChoice.hasBlockHex(blockRootHex)) {
       blockToRemove.push(block);
 
-      if (isBlockInputColumns(blockInput)) {
-        const {custodyColumns} = this.custodyConfig;
-        const dataColumnsLen = custodyColumns.length;
-        const dataColumnSidecars = blockInput.getCustodyColumns();
-        if (dataColumnSidecars.length !== dataColumnsLen) {
-          throw Error(
-            `Invalid dataColumnSidecars=${dataColumnSidecars.length} for custody expected custodyColumnsLen=${dataColumnsLen}`
-          );
-        }
+      if (isBlockInputColumns(blockInput) && blockInput.getCustodyColumns().length > 0) {
         dataColumnsToRemove.push(blockRoot);
       } else if (isBlockInputBlobs(blockInput)) {
         const blobSidecars = blockInput.getBlobs();


### PR DESCRIPTION
**Motivation**

- when we remove an eagerly persisted block input, it's very normal that we did not have any columns persisted
- but right now it threw this error as shown in #8457

```
Sep-23 19:16:55.002[chain]            �[33mwarn�[39m: Error pruning eagerly imported block inputs, DB may grow in size if this error happens frequently slot=30 - Invalid dataColumnSidecars=0 for custody expected custodyColumnsLen=128
Error: Invalid dataColumnSidecars=0 for custody expected custodyColumnsLen=128
```

**Description**

- do not throw error in this case

part of #8457
