### PR TITLE
fix: hasAllData in createFromColumn() api

### DIFF
--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -652,7 +652,8 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
   static createFromColumn(
     props: AddColumn & CreateBlockInputMeta & {sampledColumns: ColumnIndex[]; custodyColumns: ColumnIndex[]}
   ): BlockInputColumns {
-    const hasAllData = props.sampledColumns.length === 0;
+    const hasAllData =
+      props.daOutOfRange || props.columnSidecar.kzgCommitments.length === 0 || props.sampledColumns.length === 0;
     const state: BlockInputColumnsState = {
       hasBlock: false,
       hasAllData,

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
@@ -1,5 +1,5 @@
 import {DataAvailabilityStatus} from "@lodestar/state-transition";
-import {DAType, IBlockInput} from "./blockInput/index.js";
+import {DAData, DAType, IBlockInput} from "./blockInput/index.js";
 
 // we can now wait for full 12 seconds because unavailable block sync will try pulling
 // the blobs from the network anyway after 500ms of seeing the block
@@ -18,7 +18,15 @@ export async function verifyBlocksDataAvailability(
   dataAvailabilityStatuses: DataAvailabilityStatus[];
   availableTime: number;
 }> {
-  await Promise.all(blocks.map((blockInput) => blockInput.waitForAllData(BLOB_AVAILABILITY_TIMEOUT, signal)));
+  const promises: Promise<DAData>[] = [];
+  for (const blockInput of blocks) {
+    // block verification is triggered on a verified gossip block so we only need to wait for all data
+    if (!blockInput.hasAllData()) {
+      promises.push(blockInput.waitForAllData(BLOB_AVAILABILITY_TIMEOUT, signal));
+    }
+  }
+  await Promise.all(promises);
+
   const availableTime = Math.max(0, Math.max(...blocks.map((blockInput) => blockInput.getTimeComplete())));
   const dataAvailabilityStatuses: DataAvailabilityStatus[] = blocks.map((blockInput) => {
     if (blockInput.type === DAType.PreData) {


### PR DESCRIPTION
**Motivation**

- when investigating #8457 I found that we did not set `hashAllColumn()` correctly at the 1st time

**Description**

- correct `hasAllData` when creating IBlockInput from column
- nice to have: in `verifyBlocksDataAvailability`, only wait for all data if not has all data. This is to make it consistent to `writeBlockInputToDb()` where the error did not happen, see https://github.com/ChainSafe/lodestar/issues/8457#issuecomment-3337347372
