### PR TITLE
fix: refactor validateColumnsByRangeResponse

### DIFF
--- a/packages/beacon-node/src/chain/errors/dataColumnSidecarError.ts
+++ b/packages/beacon-node/src/chain/errors/dataColumnSidecarError.ts
@@ -11,10 +11,14 @@ export enum DataColumnSidecarErrorCode {
 
   // Validation errors when validating against an existing block
 
+  /** Block and sidecars header root mismatch */
+  INCORRECT_HEADER_ROOT = "DATA_COLUMN_SIDECAR_ERROR_INCORRECT_HEADER_ROOT",
   /** Block and sidecars data column count mismatch */
   INCORRECT_SIDECAR_COUNT = "DATA_COLUMN_SIDECAR_ERROR_INCORRECT_SIDECAR_COUNT",
   /** Sidecar doesn't match block */
   INCORRECT_BLOCK = "DATA_COLUMN_SIDECAR_ERROR_INCORRECT_BLOCK",
+  /** Sidecar cell count not as expected */
+  INCORRECT_CELL_COUNT = "DATA_COLUMN_SIDECAR_ERROR_INCORRECT_CELL_COUNT",
   /** Sidecar kzg proof count not as expected */
   INCORRECT_KZG_COMMITMENTS_COUNT = "DATA_COLUMN_SIDECAR_ERROR_INCORRECT_KZG_COMMITMENTS_COUNT",
   /** Sidecar kzg proof count not as expected */
@@ -34,42 +38,44 @@ export enum DataColumnSidecarErrorCode {
 }
 
 export type DataColumnSidecarErrorType =
-  | {code: DataColumnSidecarErrorCode.INVALID_INDEX; slot: Slot; columnIdx: number}
-  | {code: DataColumnSidecarErrorCode.NO_COMMITMENTS; slot: Slot; columnIdx: number}
+  | {code: DataColumnSidecarErrorCode.INVALID_INDEX; slot: Slot; columnIndex: number}
+  | {code: DataColumnSidecarErrorCode.NO_COMMITMENTS; slot: Slot; columnIndex: number}
   | {
       code: DataColumnSidecarErrorCode.MISMATCHED_LENGTHS;
       columnLength: number;
       commitmentsLength: number;
       proofsLength: number;
     }
-  | {code: DataColumnSidecarErrorCode.INVALID_SUBNET; columnIdx: number; gossipSubnet: SubnetID}
-  | {code: DataColumnSidecarErrorCode.ALREADY_KNOWN; columnIdx: number; slot: Slot}
+  | {code: DataColumnSidecarErrorCode.INVALID_SUBNET; columnIndex: number; gossipSubnet: SubnetID}
+  | {code: DataColumnSidecarErrorCode.ALREADY_KNOWN; columnIndex: number; slot: Slot}
   | {code: DataColumnSidecarErrorCode.FUTURE_SLOT; blockSlot: Slot; currentSlot: Slot}
   | {code: DataColumnSidecarErrorCode.WOULD_REVERT_FINALIZED_SLOT; blockSlot: Slot; finalizedSlot: Slot}
   | {code: DataColumnSidecarErrorCode.PARENT_UNKNOWN; parentRoot: RootHex}
   | {code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID}
   | {code: DataColumnSidecarErrorCode.NOT_LATER_THAN_PARENT; parentSlot: Slot; slot: Slot}
-  | {code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID; slot: Slot; columnIdx: number}
-  | {code: DataColumnSidecarErrorCode.INVALID_KZG_PROOF; slot: Slot; columnIdx: number}
+  | {code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID; slot: Slot; columnIndex: number}
+  | {code: DataColumnSidecarErrorCode.INVALID_KZG_PROOF; slot: Slot; columnIndex: number}
   | {code: DataColumnSidecarErrorCode.INCORRECT_SIDECAR_COUNT; slot: number; expected: number; actual: number}
   | {
       code: DataColumnSidecarErrorCode.INCORRECT_BLOCK;
       slot: number;
-      columnIdx: number;
+      columnIndex: number;
       expected: string;
       actual: string;
     }
   | {
-      code: DataColumnSidecarErrorCode.INCORRECT_KZG_COMMITMENTS_COUNT;
+      code: DataColumnSidecarErrorCode.INCORRECT_HEADER_ROOT;
       slot: number;
-      columnIdx: number;
-      expected: number;
-      actual: number;
+      expected: string;
+      actual: string;
     }
   | {
-      code: DataColumnSidecarErrorCode.INCORRECT_KZG_PROOF_COUNT;
+      code:
+        | DataColumnSidecarErrorCode.INCORRECT_CELL_COUNT
+        | DataColumnSidecarErrorCode.INCORRECT_KZG_COMMITMENTS_COUNT
+        | DataColumnSidecarErrorCode.INCORRECT_KZG_PROOF_COUNT;
       slot: number;
-      columnIdx: number;
+      columnIndex: number;
       expected: number;
       actual: number;
     }

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -10,7 +10,7 @@ import {
   getBlockHeaderProposerSignatureSet,
 } from "@lodestar/state-transition";
 import {Root, Slot, SubnetID, fulu, ssz} from "@lodestar/types";
-import {prettyBytes, prettyPrintIndices, toRootHex, verifyMerkleBranch} from "@lodestar/utils";
+import {prettyBytes, toRootHex, verifyMerkleBranch} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {kzg} from "../../util/kzg.js";
 import {

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -6,7 +6,7 @@ import {
 } from "@lodestar/params";
 import {computeStartSlotAtEpoch, getBlockHeaderProposerSignatureSet} from "@lodestar/state-transition";
 import {Root, Slot, SubnetID, fulu, ssz} from "@lodestar/types";
-import {toRootHex, verifyMerkleBranch} from "@lodestar/utils";
+import {prettyBytes, toRootHex, verifyMerkleBranch} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {kzg} from "../../util/kzg.js";
 import {
@@ -35,7 +35,7 @@ export async function validateGossipDataColumnSidecar(
   if (computeSubnetForDataColumnSidecar(chain.config, dataColumnSidecar) !== gossipSubnet) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INVALID_SUBNET,
-      columnIdx: dataColumnSidecar.index,
+      columnIndex: dataColumnSidecar.index,
       gossipSubnet: gossipSubnet,
     });
   }
@@ -152,7 +152,7 @@ export async function validateGossipDataColumnSidecar(
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID,
       slot: dataColumnSidecar.signedBlockHeader.message.slot,
-      columnIdx: dataColumnSidecar.index,
+      columnIndex: dataColumnSidecar.index,
     });
   }
 
@@ -169,7 +169,7 @@ export async function validateGossipDataColumnSidecar(
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INVALID_KZG_PROOF,
       slot: blockHeader.slot,
-      columnIdx: dataColumnSidecar.index,
+      columnIndex: dataColumnSidecar.index,
     });
   } finally {
     kzgProofTimer?.();
@@ -189,7 +189,7 @@ function verifyDataColumnSidecar(dataColumnSidecar: fulu.DataColumnSidecar): voi
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.INVALID_INDEX,
       slot: dataColumnSidecar.signedBlockHeader.message.slot,
-      columnIdx: dataColumnSidecar.index,
+      columnIndex: dataColumnSidecar.index,
     });
   }
 
@@ -197,7 +197,7 @@ function verifyDataColumnSidecar(dataColumnSidecar: fulu.DataColumnSidecar): voi
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.NO_COMMITMENTS,
       slot: dataColumnSidecar.signedBlockHeader.message.slot,
-      columnIdx: dataColumnSidecar.index,
+      columnIndex: dataColumnSidecar.index,
     });
   }
 
@@ -261,22 +261,6 @@ export async function validateBlockDataColumnSidecars(
   blockBlobCount: number,
   dataColumnSidecars: fulu.DataColumnSidecars
 ): Promise<void> {
-  if (dataColumnSidecars.length === 0) {
-    return;
-  }
-
-  if (blockBlobCount === 0) {
-    throw new DataColumnSidecarValidationError(
-      {
-        code: DataColumnSidecarErrorCode.INCORRECT_SIDECAR_COUNT,
-        slot: blockSlot,
-        expected: 0,
-        actual: dataColumnSidecars.length,
-      },
-      "Block has no blob commitments but data column sidecars were provided"
-    );
-  }
-
   // Hash the first sidecar block header and compare the rest via (cheaper) equality
   const firstSidecarBlockHeader = dataColumnSidecars[0].signedBlockHeader.message;
   const firstBlockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(firstSidecarBlockHeader);
@@ -285,9 +269,9 @@ export async function validateBlockDataColumnSidecars(
       {
         code: DataColumnSidecarErrorCode.INCORRECT_BLOCK,
         slot: blockSlot,
-        columnIdx: 0,
-        expected: toRootHex(blockRoot),
-        actual: toRootHex(firstBlockRoot),
+        columnIndex: 0,
+        expected: prettyBytes(blockRoot),
+        actual: prettyBytes(firstBlockRoot),
       },
       "DataColumnSidecar doesn't match corresponding block"
     );
@@ -300,33 +284,52 @@ export async function validateBlockDataColumnSidecars(
   for (let i = 0; i < dataColumnSidecars.length; i++) {
     const columnSidecar = dataColumnSidecars[i];
 
+    if (!ssz.phase0.BeaconBlockHeader.equals(firstSidecarBlockHeader, columnSidecar.signedBlockHeader.message)) {
+      throw new DataColumnSidecarValidationError({
+        code: DataColumnSidecarErrorCode.INCORRECT_HEADER_ROOT,
+        slot: blockSlot,
+        expected: prettyBytes(blockRoot),
+        actual: prettyBytes(ssz.phase0.BeaconBlockHeader.hashTreeRoot(columnSidecar.signedBlockHeader.message)),
+      });
+    }
+
     if (columnSidecar.index >= NUMBER_OF_COLUMNS) {
       throw new DataColumnSidecarValidationError(
         {
           code: DataColumnSidecarErrorCode.INVALID_INDEX,
           slot: blockSlot,
-          columnIdx: columnSidecar.index,
+          columnIndex: columnSidecar.index,
         },
         "DataColumnSidecar has invalid index"
       );
     }
 
-    if (columnSidecar.kzgCommitments.length !== blockBlobCount) {
+    if (columnSidecar.column.length !== blockBlobCount) {
+      throw new DataColumnSidecarValidationError({
+        code: DataColumnSidecarErrorCode.INCORRECT_CELL_COUNT,
+        slot: blockSlot,
+        columnIndex: columnSidecar.index,
+        expected: blockBlobCount,
+        actual: columnSidecar.column.length,
+      });
+    }
+
+    if (columnSidecar.column.length !== columnSidecar.kzgCommitments.length) {
       throw new DataColumnSidecarValidationError({
         code: DataColumnSidecarErrorCode.INCORRECT_KZG_COMMITMENTS_COUNT,
         slot: blockSlot,
-        columnIdx: columnSidecar.index,
-        expected: blockBlobCount,
+        columnIndex: columnSidecar.index,
+        expected: columnSidecar.column.length,
         actual: columnSidecar.kzgCommitments.length,
       });
     }
 
-    if (columnSidecar.kzgProofs.length !== columnSidecar.kzgCommitments.length) {
+    if (columnSidecar.column.length !== columnSidecar.kzgProofs.length) {
       throw new DataColumnSidecarValidationError({
         code: DataColumnSidecarErrorCode.INCORRECT_KZG_PROOF_COUNT,
         slot: blockSlot,
-        columnIdx: columnSidecar.index,
-        expected: columnSidecar.kzgCommitments.length,
+        columnIndex: columnSidecar.index,
+        expected: columnSidecar.column.length,
         actual: columnSidecar.kzgProofs.length,
       });
     }
@@ -336,7 +339,7 @@ export async function validateBlockDataColumnSidecars(
         {
           code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID,
           slot: blockSlot,
-          columnIdx: columnSidecar.index,
+          columnIndex: columnSidecar.index,
         },
         "DataColumnSidecar has invalid inclusion proof"
       );

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -10,7 +10,7 @@ import {
   getBlockHeaderProposerSignatureSet,
 } from "@lodestar/state-transition";
 import {Root, Slot, SubnetID, fulu, ssz} from "@lodestar/types";
-import {prettyBytes, toRootHex, verifyMerkleBranch} from "@lodestar/utils";
+import {toRootHex, verifyMerkleBranch} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {kzg} from "../../util/kzg.js";
 import {
@@ -285,11 +285,10 @@ export async function validateBlockDataColumnSidecars(
   if (blockBlobCount === 0) {
     throw new DataColumnSidecarValidationError(
       {
-        code: DataColumnSidecarErrorCode.INCORRECT_KZG_COMMITMENTS_COUNT,
-        actual: blockBlobCount,
-        slot: dataColumnSidecars.at(0)?.signedBlockHeader.message.slot ?? -1,
-        expected: dataColumnSidecars.at(0)?.kzgCommitments.length ?? -1,
-        columnIndex: dataColumnSidecars.at(0)?.index ?? -1,
+        code: DataColumnSidecarErrorCode.INCORRECT_SIDECAR_COUNT,
+        slot: blockSlot,
+        expected: 0,
+        actual: dataColumnSidecars.length,
       },
       "Block has no blob commitments but data column sidecars were provided"
     );
@@ -303,8 +302,8 @@ export async function validateBlockDataColumnSidecars(
         code: DataColumnSidecarErrorCode.INCORRECT_BLOCK,
         slot: blockSlot,
         columnIndex: 0,
-        expected: prettyBytes(blockRoot),
-        actual: prettyBytes(firstBlockRoot),
+        expected: blockRoot,
+        actual: firstBlockRoot,
       },
       "DataColumnSidecar doesn't match corresponding block"
     );
@@ -321,8 +320,8 @@ export async function validateBlockDataColumnSidecars(
       throw new DataColumnSidecarValidationError({
         code: DataColumnSidecarErrorCode.INCORRECT_HEADER_ROOT,
         slot: blockSlot,
-        expected: prettyBytes(blockRoot),
-        actual: prettyBytes(ssz.phase0.BeaconBlockHeader.hashTreeRoot(columnSidecar.signedBlockHeader.message)),
+        expected: blockRoot,
+        actual: ssz.phase0.BeaconBlockHeader.hashTreeRoot(columnSidecar.signedBlockHeader.message),
       });
     }
 

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -302,8 +302,8 @@ export async function validateBlockDataColumnSidecars(
         code: DataColumnSidecarErrorCode.INCORRECT_BLOCK,
         slot: blockSlot,
         columnIndex: 0,
-        expected: blockRoot,
-        actual: firstBlockRoot,
+        expected: toRootHex(blockRoot),
+        actual: toRootHex(firstBlockRoot),
       },
       "DataColumnSidecar doesn't match corresponding block"
     );
@@ -320,8 +320,8 @@ export async function validateBlockDataColumnSidecars(
       throw new DataColumnSidecarValidationError({
         code: DataColumnSidecarErrorCode.INCORRECT_HEADER_ROOT,
         slot: blockSlot,
-        expected: blockRoot,
-        actual: ssz.phase0.BeaconBlockHeader.hashTreeRoot(columnSidecar.signedBlockHeader.message),
+        expected: toRootHex(blockRoot),
+        actual: toRootHex(ssz.phase0.BeaconBlockHeader.hashTreeRoot(columnSidecar.signedBlockHeader.message)),
       });
     }
 

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -212,7 +212,7 @@ function verifyDataColumnSidecar(config: ChainForkConfig, dataColumnSidecar: ful
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
       code: DataColumnSidecarErrorCode.TOO_MANY_KZG_COMMITMENTS,
       slot: dataColumnSidecar.signedBlockHeader.message.slot,
-      columnIdx: dataColumnSidecar.index,
+      columnIndex: dataColumnSidecar.index,
       count: dataColumnSidecar.kzgCommitments.length,
       limit: maxBlobsPerBlock,
     });

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -10,7 +10,7 @@ import {
   getBlockHeaderProposerSignatureSet,
 } from "@lodestar/state-transition";
 import {Root, Slot, SubnetID, fulu, ssz} from "@lodestar/types";
-import {prettyBytes, toRootHex, verifyMerkleBranch} from "@lodestar/utils";
+import {prettyBytes, prettyPrintIndices, toRootHex, verifyMerkleBranch} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {kzg} from "../../util/kzg.js";
 import {
@@ -278,6 +278,22 @@ export async function validateBlockDataColumnSidecars(
   blockBlobCount: number,
   dataColumnSidecars: fulu.DataColumnSidecars
 ): Promise<void> {
+  if (dataColumnSidecars.length === 0) {
+    return;
+  }
+
+  if (blockBlobCount === 0) {
+    throw new DataColumnSidecarValidationError(
+      {
+        code: DataColumnSidecarErrorCode.INCORRECT_KZG_COMMITMENTS_COUNT,
+        actual: blockBlobCount,
+        expected: dataColumnSidecars[0].kzgCommitments.length,
+        slot: dataColumnSidecars[0].signedBlockHeader.message.slot,
+        columnIndex: prettyPrintIndices(dataColumnSidecars.map((s) => s.index)),
+      },
+      "Block has no blob commitments but data column sidecars were provided"
+    );
+  }
   // Hash the first sidecar block header and compare the rest via (cheaper) equality
   const firstSidecarBlockHeader = dataColumnSidecars[0].signedBlockHeader.message;
   const firstBlockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(firstSidecarBlockHeader);

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -287,9 +287,9 @@ export async function validateBlockDataColumnSidecars(
       {
         code: DataColumnSidecarErrorCode.INCORRECT_KZG_COMMITMENTS_COUNT,
         actual: blockBlobCount,
-        expected: dataColumnSidecars[0].kzgCommitments.length,
-        slot: dataColumnSidecars[0].signedBlockHeader.message.slot,
-        columnIndex: prettyPrintIndices(dataColumnSidecars.map((s) => s.index)),
+        slot: dataColumnSidecars.at(0)?.signedBlockHeader.message.slot ?? -1,
+        expected: dataColumnSidecars.at(0)?.kzgCommitments.length ?? -1,
+        columnIndex: dataColumnSidecars.at(0)?.index ?? -1,
       },
       "Block has no blob commitments but data column sidecars were provided"
     );

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -307,7 +307,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         });
         throw new DataColumnSidecarGossipError(GossipAction.IGNORE, {
           code: DataColumnSidecarErrorCode.ALREADY_KNOWN,
-          columnIdx: dataColumnSidecar.index,
+          columnIndex: dataColumnSidecar.index,
           slot,
         });
       }

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -1,9 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {
-  ForkName,
   ForkPostDeneb,
   ForkPostFulu,
-  ForkPostGloas,
   ForkPreFulu,
   ForkPreGloas,
   isForkPostFulu,

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -119,7 +119,11 @@ export function cacheByRangeResponses({
   }
 
   for (const {blockRoot, blobSidecars} of responses.validatedBlobSidecars ?? []) {
-    const existing = updatedBatchBlocks.get(blobSidecars[0].signedBlockHeader.message.slot);
+    const dataSlot = blobSidecars.at(0)?.signedBlockHeader.message.slot;
+    if (!dataSlot) {
+      throw new Error(`Coding Error: empty blobSidecars returned for blockRoot=${blockRoot} from validation functions`);
+    }
+    const existing = updatedBatchBlocks.get(dataSlot);
     const blockRootHex = toRootHex(blockRoot);
 
     if (!existing) {
@@ -151,7 +155,13 @@ export function cacheByRangeResponses({
   }
 
   for (const {blockRoot, columnSidecars} of responses.validatedColumnSidecars ?? []) {
-    const existing = updatedBatchBlocks.get(columnSidecars[0].signedBlockHeader.message.slot);
+    const dataSlot = columnSidecars.at(0)?.signedBlockHeader.message.slot;
+    if (!dataSlot) {
+      throw new Error(
+        `Coding Error: empty columnSidecars returned for blockRoot=${blockRoot} from validation functions`
+      );
+    }
+    const existing = updatedBatchBlocks.get(dataSlot);
     const blockRootHex = toRootHex(blockRoot);
 
     if (!existing) {

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -8,7 +8,7 @@ import {
   isForkPostGloas,
 } from "@lodestar/params";
 import {SignedBeaconBlock, Slot, deneb, fulu, phase0} from "@lodestar/types";
-import {LodestarError, Logger, fromHex, prettyBytes, prettyPrintIndices, toRootHex} from "@lodestar/utils";
+import {LodestarError, Logger, fromHex, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {
   BlockInputSource,
   DAType,
@@ -132,7 +132,7 @@ export function cacheByRangeResponses({
       throw new DownloadByRangeError({
         code: DownloadByRangeErrorCode.MISMATCH_BLOCK_INPUT_TYPE,
         slot: existing.slot,
-        blockRoot: prettyBytes(existing.blockRootHex),
+        blockRoot: existing.blockRootHex,
         expected: DAType.Blobs,
         actual: existing.type,
       });
@@ -170,7 +170,7 @@ export function cacheByRangeResponses({
       throw new DownloadByRangeError({
         code: DownloadByRangeErrorCode.MISMATCH_BLOCK_INPUT_TYPE,
         slot: existing.slot,
-        blockRoot: prettyBytes(existing.blockRootHex),
+        blockRoot: existing.blockRootHex,
         expected: DAType.Columns,
         actual: existing.type,
       });
@@ -479,8 +479,8 @@ export function validateBlockByRangeResponse(
           {
             code: DownloadByRangeErrorCode.PARENT_ROOT_MISMATCH,
             slot: blocks[i].message.slot,
-            expected: prettyBytes(blockRoot),
-            actual: prettyBytes(parentRoot),
+            expected: toRootHex(blockRoot),
+            actual: toRootHex(parentRoot),
           },
           `Block parent root does not match the previous block's root in BeaconBlocksByRange response`
         );
@@ -778,7 +778,7 @@ export async function validateColumnsByRangeResponse(
         new DownloadByRangeError({
           code: DownloadByRangeErrorCode.MISSING_COLUMNS,
           slot,
-          blockRoot: prettyBytes(blockRoot),
+          blockRoot: toRootHex(blockRoot),
           missingIndices: prettyPrintIndices(request.columns),
         })
       );
@@ -793,7 +793,7 @@ export async function validateColumnsByRangeResponse(
         {
           code: DownloadByRangeErrorCode.EXTRA_COLUMNS,
           slot,
-          blockRoot: prettyBytes(blockRoot),
+          blockRoot: toRootHex(blockRoot),
           invalidIndices: prettyPrintIndices(returnedColumns),
         },
         "Block has no blob commitments but data column sidecars were provided"
@@ -807,7 +807,7 @@ export async function validateColumnsByRangeResponse(
           {
             code: DownloadByRangeErrorCode.MISSING_COLUMNS,
             slot,
-            blockRoot: prettyBytes(blockRoot),
+            blockRoot: toRootHex(blockRoot),
             missingIndices: prettyPrintIndices(missingIndices),
           },
           "Missing data columns in DataColumnSidecarsByRange response"
@@ -822,7 +822,7 @@ export async function validateColumnsByRangeResponse(
           {
             code: DownloadByRangeErrorCode.EXTRA_COLUMNS,
             slot,
-            blockRoot: prettyBytes(blockRoot),
+            blockRoot: toRootHex(blockRoot),
             invalidIndices: prettyPrintIndices(extraIndices),
           },
           "Data column in not in requested columns in DataColumnSidecarsByRange response"

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -714,10 +714,9 @@ export async function validateColumnsByRangeResponse(
 
       seenColumns.set(slot, slotColumns);
     }
-
-    // make sure last iteration gets set to seenColumns
-    seenColumns.set(currentSlot, currentSlotSeen);
   }
+  // make sure last iteration gets set to seenColumns
+  seenColumns.set(currentSlot, currentSlotSeen);
 
   const validationPromises: Promise<ValidatedColumnSidecars>[] = [];
 

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -722,7 +722,7 @@ export async function validateColumnsByRangeResponse(
 
   for (const {blockRoot, block} of blocks) {
     const slot = block.message.slot;
-    // TODO(gloas): Post-gloas's blobKzgCommitments is not in beacon block body. Need to source it from somewhere else.
+    // TODO GLOAS: Post-gloas's blobKzgCommitments is not in beacon block body. Need to source it from somewhere else.
     // if block without columns is passed default to zero and throw below
     const blobCount =
       (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body.blobKzgCommitments?.length ?? 0;

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -612,84 +612,32 @@ export async function validateColumnsByRangeResponse(
   columnSidecars: fulu.DataColumnSidecars
 ): Promise<WarnResult<ValidatedColumnSidecars[], DownloadByRangeError>> {
   const warnings: DownloadByRangeError[] = [];
-  const seenColumns = new Map<Slot, fulu.DataColumnSidecars>();
 
+  const seenColumns = new Map<Slot, Map<number, fulu.DataColumnSidecar>>();
   let currentSlot = -1;
-  let currentSlotSeen: fulu.DataColumnSidecars = [];
+  let currentIndex = -1;
+  // Check for duplicates and order
   for (const columnSidecar of columnSidecars) {
     const slot = columnSidecar.signedBlockHeader.message.slot;
+    let seenSlotColumns = seenColumns.get(slot);
+    if (!seenSlotColumns) {
+      seenSlotColumns = new Map();
+      seenColumns.set(slot, seenSlotColumns);
+    }
 
-    if (slot === currentSlot) {
-      if (currentSlotSeen.find((c) => c.index === columnSidecar.index)) {
-        warnings.push(
-          new DownloadByRangeError({
-            code: DownloadByRangeErrorCode.DUPLICATE_COLUMN,
-            slot,
-            index: columnSidecar.index,
-          })
-        );
+    if (seenSlotColumns.has(columnSidecar.index)) {
+      warnings.push(
+        new DownloadByRangeError({
+          code: DownloadByRangeErrorCode.DUPLICATE_COLUMN,
+          slot,
+          index: columnSidecar.index,
+        })
+      );
 
-        continue;
-      }
+      continue;
+    }
 
-      // check for index order, then push and proceed
-      const lastIndex = currentSlotSeen.at(-1)?.index;
-
-      currentSlotSeen.push(columnSidecar);
-
-      // check for out of order and sort if incorrect
-      if (lastIndex && lastIndex > columnSidecar.index) {
-        warnings.push(
-          new DownloadByRangeError(
-            {
-              code: DownloadByRangeErrorCode.OUT_OF_ORDER_COLUMNS,
-              slot,
-            },
-            "Column indices out of order within a slot"
-          )
-        );
-        currentSlotSeen.sort((a, b) => a.index - b.index);
-      }
-    } else if (slot > currentSlot) {
-      // increment currentSlot
-      if (currentSlotSeen.length) {
-        // avoid setting on first iteration or if no columns in the array
-        seenColumns.set(currentSlot, currentSlotSeen);
-      }
-
-      currentSlot = slot;
-      const existingCurrentSlotSeen = seenColumns.has(slot);
-      currentSlotSeen = seenColumns.get(slot) ?? [];
-
-      if (currentSlotSeen.find((c) => c.index === columnSidecar.index)) {
-        warnings.push(
-          new DownloadByRangeError({
-            code: DownloadByRangeErrorCode.DUPLICATE_COLUMN,
-            slot,
-            index: columnSidecar.index,
-          })
-        );
-
-        continue;
-      }
-
-      currentSlotSeen.push(columnSidecar);
-
-      if (existingCurrentSlotSeen) {
-        warnings.push(
-          new DownloadByRangeError(
-            {
-              code: DownloadByRangeErrorCode.OUT_OF_ORDER_COLUMNS,
-              slot,
-            },
-            "Existing currentSlotSeen was found, slots delivered out of order"
-          )
-        );
-        // sort as they could be out of order
-        currentSlotSeen.sort((a, b) => a.index - b.index);
-      }
-    } else {
-      // out of order
+    if (currentSlot > slot) {
       warnings.push(
         new DownloadByRangeError(
           {
@@ -699,54 +647,41 @@ export async function validateColumnsByRangeResponse(
           "ColumnSidecars received out of slot order"
         )
       );
-
-      const slotColumns = seenColumns.get(slot) ?? [];
-      const lastIndex = slotColumns.at(-1)?.index;
-
-      if (slotColumns.find((c) => c.index === columnSidecar.index)) {
-        warnings.push(
-          new DownloadByRangeError({
-            code: DownloadByRangeErrorCode.DUPLICATE_COLUMN,
-            slot,
-            index: columnSidecar.index,
-          })
-        );
-
-        continue;
-      }
-
-      slotColumns.push(columnSidecar);
-
-      if (lastIndex && lastIndex > columnSidecar.index) {
-        warnings.push(
-          new DownloadByRangeError(
-            {
-              code: DownloadByRangeErrorCode.OUT_OF_ORDER_COLUMNS,
-              slot,
-            },
-            "Column indices out of order within a slot"
-          )
-        );
-        // sort as they could be out of order
-        slotColumns.sort((a, b) => a.index - b.index);
-      }
-
-      seenColumns.set(slot, slotColumns);
     }
+
+    if (currentSlot === slot && currentIndex > columnSidecar.index) {
+      warnings.push(
+        new DownloadByRangeError(
+          {
+            code: DownloadByRangeErrorCode.OUT_OF_ORDER_COLUMNS,
+            slot,
+          },
+          "Column indices out of order within a slot"
+        )
+      );
+    }
+
+    seenSlotColumns.set(columnSidecar.index, columnSidecar);
+    if (currentSlot !== slot) {
+      // a new slot has started, reset index
+      currentIndex = -1;
+    } else {
+      currentIndex = columnSidecar.index;
+    }
+    currentSlot = slot;
   }
-  // make sure last iteration gets set to seenColumns
-  seenColumns.set(currentSlot, currentSlotSeen);
 
   const validationPromises: Promise<ValidatedColumnSidecars>[] = [];
 
   for (const {blockRoot, block} of blocks) {
     const slot = block.message.slot;
     const forkName = config.getForkName(slot);
-    const columnSidecars = seenColumns.get(slot);
+    const columnSidecarsMap: Map<number, fulu.DataColumnSidecar> = seenColumns.get(slot) ?? new Map();
+    const columnSidecars = Array.from(columnSidecarsMap.values()).sort((a, b) => a.index - b.index);
 
     let blobCount: number;
     if (!isForkPostFulu(forkName)) {
-      const dataSlot = columnSidecars?.at(0)?.signedBlockHeader.message.slot;
+      const dataSlot = columnSidecars.at(0)?.signedBlockHeader.message.slot;
       throw new DownloadByRangeError({
         code: DownloadByRangeErrorCode.MISMATCH_BLOCK_FORK,
         slot,
@@ -762,8 +697,7 @@ export async function validateColumnsByRangeResponse(
       blobCount = (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body.blobKzgCommitments.length;
     }
 
-    // conditional a bit wonky so TSC knows we have dataColumns[] below
-    if (!columnSidecars) {
+    if (columnSidecars.length === 0) {
       if (!blobCount) {
         // no columns in the slot
         continue;
@@ -771,7 +705,7 @@ export async function validateColumnsByRangeResponse(
 
       /**
        * If no columns are found for a block and there are commitments on the block then stop checking and just
-       * return early.  Even if there were columns returned for subsequent slots that doesn't matter because
+       * return early. Even if there were columns returned for subsequent slots that doesn't matter because
        * we will be re-requesting them again anyway.  Leftovers just get ignored
        */
       warnings.push(
@@ -785,7 +719,7 @@ export async function validateColumnsByRangeResponse(
       break;
     }
 
-    const returnedColumns = columnSidecars.map((c) => c.index);
+    const returnedColumns = Array.from(columnSidecarsMap.keys()).sort();
     if (!blobCount) {
       // columns for a block that does not have blobs
       // TODO(fulu): should this be a hard error with no data retained from peer or just a warning
@@ -800,7 +734,7 @@ export async function validateColumnsByRangeResponse(
       );
     }
 
-    const missingIndices = request.columns.filter((i) => !returnedColumns.includes(i));
+    const missingIndices = request.columns.filter((i) => !columnSidecarsMap.has(i));
     if (missingIndices.length > 0) {
       warnings.push(
         new DownloadByRangeError(
@@ -833,7 +767,7 @@ export async function validateColumnsByRangeResponse(
     validationPromises.push(
       validateBlockDataColumnSidecars(slot, blockRoot, blobCount, columnSidecars).then(() => ({
         blockRoot,
-        columnSidecars: columnSidecars,
+        columnSidecars,
       }))
     );
   }

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -118,7 +118,7 @@ export function cacheByRangeResponses({
 
   for (const {blockRoot, blobSidecars} of responses.validatedBlobSidecars ?? []) {
     const dataSlot = blobSidecars.at(0)?.signedBlockHeader.message.slot;
-    if (!dataSlot) {
+    if (dataSlot === undefined) {
       throw new Error(`Coding Error: empty blobSidecars returned for blockRoot=${blockRoot} from validation functions`);
     }
     const existing = updatedBatchBlocks.get(dataSlot);
@@ -154,7 +154,7 @@ export function cacheByRangeResponses({
 
   for (const {blockRoot, columnSidecars} of responses.validatedColumnSidecars ?? []) {
     const dataSlot = columnSidecars.at(0)?.signedBlockHeader.message.slot;
-    if (!dataSlot) {
+    if (dataSlot === undefined) {
       throw new Error(
         `Coding Error: empty columnSidecars returned for blockRoot=${blockRoot} from validation functions`
       );

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -163,7 +163,7 @@ export function cacheByRangeResponses({
     const blockRootHex = toRootHex(blockRoot);
 
     if (!existing) {
-      throw new Error("Coding error: blockInput must exist when adding blobs");
+      throw new Error("Coding error: blockInput must exist when adding columns");
     }
 
     if (!isBlockInputColumns(existing)) {

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -393,9 +393,8 @@ export function validateBlockByRangeResponse(
       result: [],
       warnings: [
         new DownloadByRangeError({
-          code: DownloadByRangeErrorCode.MISSING_BLOCK_RESPONSE,
-          expectedCount: count,
-          blockStartSlot: startSlot,
+          code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
+          ...requestsLogMeta({blocksRequest}),
         }),
       ],
     };
@@ -546,7 +545,7 @@ export type ValidatedSlot = {
   blobs?: deneb.BlobSidecars;
   columns?: fulu.DataColumnSidecars;
 };
-export type ValidatedSlots = Map<Slot, ValidateSlot>;
+export type ValidatedSlots = Map<Slot, ValidatedSlot>;
 
 /**
  * Should not be called directly. Only exported for unit testing purposes
@@ -878,7 +877,7 @@ function requestsLogMeta({blocksRequest, blobsRequest, columnsRequest}: Download
 }
 
 export enum DownloadByRangeErrorCode {
-  MISSING_BLOCK_RESPONSE = "DOWNLOAD_BY_RANGE_ERROR_MISSING_BLOCK_RESPONSE",
+  MISSING_BLOCKS_RESPONSE = "DOWNLOAD_BY_RANGE_ERROR_MISSING_BLOCK_RESPONSE",
   MISSING_BLOBS_RESPONSE = "DOWNLOAD_BY_RANGE_ERROR_MISSING_BLOBS_RESPONSE",
   MISSING_COLUMNS_RESPONSE = "DOWNLOAD_BY_RANGE_ERROR_MISSING_COLUMNS_RESPONSE",
 
@@ -907,10 +906,6 @@ export enum DownloadByRangeErrorCode {
 }
 
 export type DownloadByRangeErrorType =
-  | {
-      code: DownloadByRangeErrorCode.MISSING_BLOCK_RESPONSE;
-      expectedCount: number;
-    }
   | {
       code:
         | DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -366,6 +366,7 @@ export async function validateResponses({
     }
 
     const validatedColumnSidecarsResult = await validateColumnsByRangeResponse(
+      config,
       columnsRequest,
       blocksForDataValidation,
       columnSidecars

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -119,7 +119,9 @@ export function cacheByRangeResponses({
   for (const {blockRoot, blobSidecars} of responses.validatedBlobSidecars ?? []) {
     const dataSlot = blobSidecars.at(0)?.signedBlockHeader.message.slot;
     if (dataSlot === undefined) {
-      throw new Error(`Coding Error: empty blobSidecars returned for blockRoot=${blockRoot} from validation functions`);
+      throw new Error(
+        `Coding Error: empty blobSidecars returned for blockRoot=${toRootHex(blockRoot)} from validation functions`
+      );
     }
     const existing = updatedBatchBlocks.get(dataSlot);
     const blockRootHex = toRootHex(blockRoot);
@@ -156,7 +158,7 @@ export function cacheByRangeResponses({
     const dataSlot = columnSidecars.at(0)?.signedBlockHeader.message.slot;
     if (dataSlot === undefined) {
       throw new Error(
-        `Coding Error: empty columnSidecars returned for blockRoot=${blockRoot} from validation functions`
+        `Coding Error: empty columnSidecars returned for blockRoot=${toRootHex(blockRoot)} from validation functions`
       );
     }
     const existing = updatedBatchBlocks.get(dataSlot);

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -579,33 +579,53 @@ export async function validateColumnsByRangeResponse2(
   blocks: ValidatedSlot[],
   columnSidecars: fulu.DataColumnSidecars
 ): Promise<WarnResult<ValidatedSlots, DownloadByRangeError>> {
+  const warnings: DownloadByRangeError[] = [];
   const seenColumns = new Map<Slot, fulu.DataColumnSidecars>();
 
-  const currentSlot = -1;
+  let currentSlot = -1;
+  let currentSlotSeen = [];
   for (const columnSidecar of columnSidecars) {
     const slot = columnSidecar.signedBlockHeader.message.slot;
-    if (slot < currentSlot) {
-      // out of order
+    if (slot === currentSlot) {
+      // push and proceed
+      const lastIndex = currentSlotSeen.at(currentSlotSeen.length)?.index;
+      if (lastIndex && lastIndex > columnSidecar.index) {
+        warnings.push();
+      }
+      currentSlotSeen.push(columnSidecar);
     } else if (slot > currentSlot) {
       // increment currentSlot
+      seenColumns.set(currentSlot, currentSlotSeen);
+      currentSlot = slot;
+      currentSlotSeen = seenColumns.get(slot) ?? [];
+      if (currentSlotSeen.length) {
+        throw new Error();
+      }
+      currentSlotSeen.push(columnSidecar);
     } else {
-      // push and proceed
+      // out of order
+      warnings.push();
+      const slotColumns = seenColumns.get(slot) ?? [];
+      const lastIndex = slotColumns.at(slotColumns.length)?.index;
+      if (lastIndex && lastIndex > columnSidecar.index) {
+        warnings.push();
+      }
+      slotColumns.push(columnSidecar);
+      seenColumns.set(slot, slotColumns);
     }
-    const seenSlot = seenColumns.get(slot) ?? [];
-    seenSlot.push(columnSidecar);
-    seenColumns.set(slot, seenSlot);
+
+    // const seenSlot = seenSlot.push(columnSidecar);
+    // seenColumns.set(slot, seenSlot);
   }
 
-  const validationPromises: Promise<void>[] = [];
-  const validatedColumns = [];
-  const warnings: DownloadByRangeError[] = [];
+  const validationPromises: Promise<ValidatedColumnSidecars[]>[] = [];
 
   for (const {blockRoot, block} of blocks) {
     const slot = block.message.slot;
     const blobCount = (block as SignedBeaconBlock<ForkPostDeneb>).message.body.blobKzgCommitments.length;
-    const dataColumns = seenColumns.get(slot);
+    const columnSidecars = seenColumns.get(slot);
     // conditional a bit wonky so TSC knows we have dataColumns[] below
-    if (!dataColumns) {
+    if (!columnSidecars) {
       if (!blobCount) {
         // no columns in the slot
         continue;
@@ -616,25 +636,40 @@ export async function validateColumnsByRangeResponse2(
        * return early.  Even if there were columns returned for subsequent slots that doesn't matter because
        * we will be re-requesting them again anyway.  Leftovers just get ignored
        */
-      warnings.push(new DownloadByRangeError({}));
+      warnings.push(
+        new DownloadByRangeError({
+          code: DownloadByRangeErrorCode.MISSING_COLUMNS,
+          slot,
+          blockRoot: prettyBytes(blockRoot),
+          missingIndices: prettyPrintIndices(request.columns),
+        })
+      );
       break;
     }
 
+    const returnedColumns = columnSidecars.map((c) => c.index);
     if (!blobCount) {
       // columns for a block that does not have blobs
-      // TODO(fulu): should this be a hard error with no data retained from peer?
-      throw new DownloadByRangeError({});
+      // TODO(fulu): should this be a hard error with no data retained from peer or just a warning
+      throw new DownloadByRangeError(
+        {
+          code: DownloadByRangeErrorCode.EXTRA_COLUMNS,
+          slot,
+          blockRoot: prettyBytes(blockRoot),
+          invalidIndices: prettyPrintIndices(returnedColumns),
+        },
+        "Block has no blob commitments but data column sidecars were provided"
+      );
     }
 
-    const returnedColumns = new Set(blockColumnSidecars.map((c) => c.index));
-    const missingIndices = request.columns.filter((i) => !returnedColumns.has(i));
+    const missingIndices = request.columns.filter((i) => !returnedColumns.includes(i));
     if (missingIndices.length > 0) {
       warnings.push(
         new DownloadByRangeError(
           {
             code: DownloadByRangeErrorCode.MISSING_COLUMNS,
             slot,
-            blockRoot: blockRootHex,
+            blockRoot: prettyBytes(blockRoot),
             missingIndices: prettyPrintIndices(missingIndices),
           },
           "Missing data columns in DataColumnSidecarsByRange response"
@@ -642,14 +677,14 @@ export async function validateColumnsByRangeResponse2(
       );
     }
 
-    const extraIndices = [...returnedColumns].filter((i) => !requestedColumns.has(i));
+    const extraIndices = returnedColumns.filter((i) => !request.columns.includes(i));
     if (extraIndices.length > 0) {
       warnings.push(
         new DownloadByRangeError(
           {
             code: DownloadByRangeErrorCode.EXTRA_COLUMNS,
             slot,
-            blockRoot: blockRootHex,
+            blockRoot: prettyBytes(blockRoot),
             invalidIndices: prettyPrintIndices(extraIndices),
           },
           "Data column in not in requested columns in DataColumnSidecarsByRange response"
@@ -657,16 +692,19 @@ export async function validateColumnsByRangeResponse2(
       );
     }
 
-    validateSidecarsPromises.push(
-      validateBlockDataColumnSidecars(slot, blockRoot, blockKzgCommitments.length, blockColumnSidecars).then(() => ({
+    validationPromises.push(
+      validateBlockDataColumnSidecars(slot, blockRoot, blobCount, columnSidecars).then(() => ({
         blockRoot,
-        columnSidecars: blockColumnSidecars,
+        columnSidecars: columnSidecars,
       }))
     );
   }
 
-  await Promise.all(validationPromises);
-  return {result: validatedColumns, warnings};
+  const validatedColumns = await Promise.all(validationPromises);
+  return {
+    result: validatedColumns.flat(),
+    warnings,
+  };
 }
 
 /**

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -389,15 +389,19 @@ export function validateBlockByRangeResponse(
   // There are instances where clients return no blocks though.  Need to monitor this via the warns to see
   // if what the correct behavior should be
   if (!blocks.length) {
-    return {
-      result: [],
-      warnings: [
-        new DownloadByRangeError({
-          code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
-          ...requestsLogMeta({blocksRequest}),
-        }),
-      ],
-    };
+    throw new DownloadByRangeError({
+      code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
+      ...requestsLogMeta({blocksRequest}),
+    });
+    // return {
+    //   result: [],
+    //   warnings: [
+    //     new DownloadByRangeError({
+    //       code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
+    //       ...requestsLogMeta({blocksRequest}),
+    //     }),
+    //   ],
+    // };
   }
 
   if (blocks.length > count) {

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -728,7 +728,7 @@ export async function validateColumnsByRangeResponse(
       // TODO(fulu): should this be a hard error with no data retained from peer or just a warning
       throw new DownloadByRangeError(
         {
-          code: DownloadByRangeErrorCode.EXTRA_COLUMNS,
+          code: DownloadByRangeErrorCode.NO_COLUMNS_FOR_BLOCK,
           slot,
           blockRoot: rootHex,
           invalidIndices: prettyPrintIndices(returnedColumns),
@@ -867,6 +867,7 @@ export enum DownloadByRangeErrorCode {
   MISSING_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_MISSING_COLUMNS",
   OVER_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_OVER_COLUMNS",
   EXTRA_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_EXTRA_COLUMNS",
+  NO_COLUMNS_FOR_BLOCK = "DOWNLOAD_BY_RANGE_ERROR_NO_COLUMNS_FOR_BLOCK",
   DUPLICATE_COLUMN = "DOWNLOAD_BY_RANGE_ERROR_DUPLICATE_COLUMN",
   OUT_OF_ORDER_COLUMNS = "DOWNLOAD_BY_RANGE_OUT_OF_ORDER_COLUMNS",
 
@@ -953,7 +954,7 @@ export type DownloadByRangeErrorType =
       index: number;
     }
   | {
-      code: DownloadByRangeErrorCode.EXTRA_COLUMNS;
+      code: DownloadByRangeErrorCode.EXTRA_COLUMNS | DownloadByRangeErrorCode.NO_COLUMNS_FOR_BLOCK;
       slot: Slot;
       blockRoot: string;
       invalidIndices: string;

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -526,6 +526,149 @@ export async function validateBlobsByRangeResponse(
   return Promise.all(validateSidecarsPromises);
 }
 
+export type ValidatedSlot = {
+  blockRoot: Uint8Array;
+  block: SignedBeaconBlock;
+  blobs?: deneb.BlobSidecars;
+  columns?: fulu.DataColumnSidecars;
+};
+export type ValidatedSlots = Map<Slot, ValidateSlot>;
+
+/**
+ * Spec states:
+ * 1) must be within range [start_slot, start_slot + count]
+ * 2) should respond with all columns in the range or and 3:ResourceUnavailable (and potentially get down-scored)
+ * 3) must response with at least the sidecars of the first blob-carrying block that exists in the range
+ * 4) must include all sidecars from each block from which there are blobs
+ * 5) where they exists, sidecars must be sent in (slot, index) order
+ * 6) clients may limit the number of sidecars in a response
+ * 7) clients may stop responding mid-response if their view of fork-choice changes
+ *
+ * We will interpret the spec as follows
+ * - Errors when validating: 1, 3, 5
+ * - Warnings when validating: 2, 4, 6, 7
+ *
+ * For "warning" cases, where we get a partial response but sidecars are validated and correct with respect to the
+ * blocks, then they will be kept.  This loosening of the spec is to help ensure sync goes smoothly and we can find
+ * the data needed in difficult network situations.
+ *
+ * Assume for thw following two examples we request indices 5, 10, 15 for a range of slots 32-63
+ *
+ * For slots where we receive no sidecars, example slot 45, but blobs exist we will stop validating subsequent
+ * slots, 45-63.  The next round of requests will get structured to pull the from the slot that had columns
+ * missing to the end of the range for all columns indices that were requested for the current partially failed
+ * request (slots 45-63 and indices 5, 10, 15).
+ *
+ * For slots where only some of the requested sidecars are received we will proceed with validation. For simplicity sake
+ * we will assume that if we only get some indices back for a (or several) slot(s) that the indices we get will be
+ * consistent. IE if a peer returns only index 5, they will most likely return that same index for subsequent slot
+ * (index 5 for slots 34, 35, 36, etc). They will not likely return 5 on slot 34, 10 on slot 35, 15 on slot 36, etc.
+ * This assumption makes the code simpler. For both cases the request for the next round will be structured correctly
+ * to pull any missing column indices for whatever range remains.  The simplification just leads to re-verification
+ * of the columns but the number of columns downloaded will be the same regardless of if they are validated twice.
+ *
+ * validateColumnsByRangeResponse makes some assumptions about the data being passed in
+ * blocks are:
+ * - slotwise in order
+ * - form a chain
+ * - non-sparse response (any missing block is a skipped slot not a bad response)
+ * - last block is last slot received
+ */
+export async function validateColumnsByRangeResponse2(
+  request: fulu.DataColumnSidecarsByRangeRequest,
+  blocks: ValidatedSlot[],
+  columnSidecars: fulu.DataColumnSidecars
+): Promise<WarnResult<ValidatedSlots, DownloadByRangeError>> {
+  const seenColumns = new Map<Slot, fulu.DataColumnSidecars>();
+
+  const currentSlot = -1;
+  for (const columnSidecar of columnSidecars) {
+    const slot = columnSidecar.signedBlockHeader.message.slot;
+    if (slot < currentSlot) {
+      // out of order
+    } else if (slot > currentSlot) {
+      // increment currentSlot
+    } else {
+      // push and proceed
+    }
+    const seenSlot = seenColumns.get(slot) ?? [];
+    seenSlot.push(columnSidecar);
+    seenColumns.set(slot, seenSlot);
+  }
+
+  const validationPromises: Promise<void>[] = [];
+  const validatedColumns = [];
+  const warnings: DownloadByRangeError[] = [];
+
+  for (const {blockRoot, block} of blocks) {
+    const slot = block.message.slot;
+    const blobCount = (block as SignedBeaconBlock<ForkPostDeneb>).message.body.blobKzgCommitments.length;
+    const dataColumns = seenColumns.get(slot);
+    // conditional a bit wonky so TSC knows we have dataColumns[] below
+    if (!dataColumns) {
+      if (!blobCount) {
+        // no columns in the slot
+        continue;
+      }
+
+      /**
+       * If no columns are found for a block and there are commitments on the block then stop checking and just
+       * return early.  Even if there were columns returned for subsequent slots that doesn't matter because
+       * we will be re-requesting them again anyway.  Leftovers just get ignored
+       */
+      warnings.push(new DownloadByRangeError({}));
+      break;
+    }
+
+    if (!blobCount) {
+      // columns for a block that does not have blobs
+      // TODO(fulu): should this be a hard error with no data retained from peer?
+      throw new DownloadByRangeError({});
+    }
+
+    const returnedColumns = new Set(blockColumnSidecars.map((c) => c.index));
+    const missingIndices = request.columns.filter((i) => !returnedColumns.has(i));
+    if (missingIndices.length > 0) {
+      warnings.push(
+        new DownloadByRangeError(
+          {
+            code: DownloadByRangeErrorCode.MISSING_COLUMNS,
+            slot,
+            blockRoot: blockRootHex,
+            missingIndices: prettyPrintIndices(missingIndices),
+          },
+          "Missing data columns in DataColumnSidecarsByRange response"
+        )
+      );
+    }
+
+    const extraIndices = [...returnedColumns].filter((i) => !requestedColumns.has(i));
+    if (extraIndices.length > 0) {
+      warnings.push(
+        new DownloadByRangeError(
+          {
+            code: DownloadByRangeErrorCode.EXTRA_COLUMNS,
+            slot,
+            blockRoot: blockRootHex,
+            invalidIndices: prettyPrintIndices(extraIndices),
+          },
+          "Data column in not in requested columns in DataColumnSidecarsByRange response"
+        )
+      );
+    }
+
+    validateSidecarsPromises.push(
+      validateBlockDataColumnSidecars(slot, blockRoot, blockKzgCommitments.length, blockColumnSidecars).then(() => ({
+        blockRoot,
+        columnSidecars: blockColumnSidecars,
+      }))
+    );
+  }
+
+  await Promise.all(validationPromises);
+  return {result: validatedColumns, warnings};
+}
+
 /**
  * Should not be called directly. Only exported for unit testing purposes
  */
@@ -566,6 +709,10 @@ export async function validateColumnsByRangeResponse(
   // no need to check for columnSidecars.length  vs expectedColumnCount here, will be checked per-block below
   const requestedColumns = new Set(request.columns);
   const validateSidecarsPromises: Promise<ValidatedColumnSidecars>[] = [];
+
+  /**
+   * loop through the block to validate
+   */
   for (let blockIndex = 0, columnSidecarIndex = 0; blockIndex < dataRequestBlocks.length; blockIndex++) {
     const {block, blockRoot} = dataRequestBlocks[blockIndex];
     const slot = block.message.slot;
@@ -587,6 +734,9 @@ export async function validateColumnsByRangeResponse(
       }
       blockColumnSidecars.push(columnSidecar);
       columnSidecarIndex++;
+    }
+
+    if (blockColumnSidecars.length === 0) {
     }
 
     const returnedColumns = new Set(blockColumnSidecars.map((c) => c.index));

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -565,7 +565,7 @@ export async function validateBlobsByRangeResponse(
  * blocks, then they will be kept.  This loosening of the spec is to help ensure sync goes smoothly and we can find
  * the data needed in difficult network situations.
  *
- * Assume for thw following two examples we request indices 5, 10, 15 for a range of slots 32-63
+ * Assume for the following two examples we request indices 5, 10, 15 for a range of slots 32-63
  *
  * For slots where we receive no sidecars, example slot 45, but blobs exist we will stop validating subsequent
  * slots, 45-63.  The next round of requests will get structured to pull the from the slot that had columns

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -677,6 +677,7 @@ export async function validateColumnsByRangeResponse(
 
   for (const {blockRoot, block} of blocks) {
     const slot = block.message.slot;
+    const rootHex = toRootHex(blockRoot);
     const forkName = config.getForkName(slot);
     const columnSidecarsMap: Map<number, fulu.DataColumnSidecar> = seenColumns.get(slot) ?? new Map();
     const columnSidecars = Array.from(columnSidecarsMap.values()).sort((a, b) => a.index - b.index);
@@ -714,7 +715,7 @@ export async function validateColumnsByRangeResponse(
         new DownloadByRangeError({
           code: DownloadByRangeErrorCode.MISSING_COLUMNS,
           slot,
-          blockRoot: toRootHex(blockRoot),
+          blockRoot: rootHex,
           missingIndices: prettyPrintIndices(request.columns),
         })
       );
@@ -729,7 +730,7 @@ export async function validateColumnsByRangeResponse(
         {
           code: DownloadByRangeErrorCode.EXTRA_COLUMNS,
           slot,
-          blockRoot: toRootHex(blockRoot),
+          blockRoot: rootHex,
           invalidIndices: prettyPrintIndices(returnedColumns),
         },
         "Block has no blob commitments but data column sidecars were provided"
@@ -743,7 +744,7 @@ export async function validateColumnsByRangeResponse(
           {
             code: DownloadByRangeErrorCode.MISSING_COLUMNS,
             slot,
-            blockRoot: toRootHex(blockRoot),
+            blockRoot: rootHex,
             missingIndices: prettyPrintIndices(missingIndices),
           },
           "Missing data columns in DataColumnSidecarsByRange response"
@@ -758,7 +759,7 @@ export async function validateColumnsByRangeResponse(
           {
             code: DownloadByRangeErrorCode.EXTRA_COLUMNS,
             slot,
-            blockRoot: toRootHex(blockRoot),
+            blockRoot: rootHex,
             invalidIndices: prettyPrintIndices(extraIndices),
           },
           "Data column in not in requested columns in DataColumnSidecarsByRange response"

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -535,6 +535,8 @@ export type ValidatedSlot = {
 export type ValidatedSlots = Map<Slot, ValidateSlot>;
 
 /**
+ * Should not be called directly. Only exported for unit testing purposes
+ *
  * Spec states:
  * 1) must be within range [start_slot, start_slot + count]
  * 2) should respond with all columns in the range or and 3:ResourceUnavailable (and potentially get down-scored)
@@ -574,7 +576,7 @@ export type ValidatedSlots = Map<Slot, ValidateSlot>;
  * - non-sparse response (any missing block is a skipped slot not a bad response)
  * - last block is last slot received
  */
-export async function validateColumnsByRangeResponse2(
+export async function validateColumnsByRangeResponse(
   request: fulu.DataColumnSidecarsByRangeRequest,
   blocks: ValidatedSlot[],
   columnSidecars: fulu.DataColumnSidecars
@@ -583,39 +585,83 @@ export async function validateColumnsByRangeResponse2(
   const seenColumns = new Map<Slot, fulu.DataColumnSidecars>();
 
   let currentSlot = -1;
-  let currentSlotSeen = [];
+  let currentSlotSeen: fulu.DataColumnSidecars = [];
   for (const columnSidecar of columnSidecars) {
     const slot = columnSidecar.signedBlockHeader.message.slot;
+
     if (slot === currentSlot) {
-      // push and proceed
-      const lastIndex = currentSlotSeen.at(currentSlotSeen.length)?.index;
-      if (lastIndex && lastIndex > columnSidecar.index) {
-        warnings.push();
-      }
+      // check for index order, then push and proceed
+      const lastIndex = currentSlotSeen.at(-1)?.index;
+
       currentSlotSeen.push(columnSidecar);
+
+      // check for out of order and sort if incorrect
+      if (lastIndex && lastIndex > columnSidecar.index) {
+        warnings.push(
+          new DownloadByRangeError(
+            {
+              code: DownloadByRangeErrorCode.OUT_OF_ORDER_COLUMNS,
+              slot,
+            },
+            "Column indices out of order within a slot"
+          )
+        );
+        currentSlotSeen.sort((a, b) => a.index - b.index);
+      }
     } else if (slot > currentSlot) {
       // increment currentSlot
       seenColumns.set(currentSlot, currentSlotSeen);
+
       currentSlot = slot;
+      const existingCurrentSlotSee = seenColumns.has(slot);
       currentSlotSeen = seenColumns.get(slot) ?? [];
-      if (currentSlotSeen.length) {
-        throw new Error();
-      }
+
       currentSlotSeen.push(columnSidecar);
+
+      if (existingCurrentSlotSee) {
+        warnings.push(
+          new DownloadByRangeError(
+            {
+              code: DownloadByRangeErrorCode.OUT_OF_ORDER_COLUMNS,
+              slot,
+            },
+            "Existing currentSlotSeen was found, slots delivered out of order"
+          )
+        );
+        // sort as they could be out of order
+        currentSlotSeen.sort((a, b) => a.index - b.index);
+      }
     } else {
       // out of order
-      warnings.push();
+      warnings.push(
+        new DownloadByRangeError(
+          {
+            code: DownloadByRangeErrorCode.OUT_OF_ORDER_COLUMNS,
+            slot,
+          },
+          "ColumnSidecars received out of slot order"
+        )
+      );
+
       const slotColumns = seenColumns.get(slot) ?? [];
-      const lastIndex = slotColumns.at(slotColumns.length)?.index;
-      if (lastIndex && lastIndex > columnSidecar.index) {
-        warnings.push();
-      }
+      const lastIndex = slotColumns.at(-1)?.index;
+
       slotColumns.push(columnSidecar);
+
+      if (lastIndex && lastIndex > columnSidecar.index) {
+        warnings.push(
+          new DownloadByRangeError(
+            {
+              code: DownloadByRangeErrorCode.OUT_OF_ORDER_COLUMNS,
+              slot,
+            },
+            "Column indices out of order within a slot"
+          )
+        );
+      }
+
       seenColumns.set(slot, slotColumns);
     }
-
-    // const seenSlot = seenSlot.push(columnSidecar);
-    // seenColumns.set(slot, seenSlot);
   }
 
   const validationPromises: Promise<ValidatedColumnSidecars[]>[] = [];
@@ -906,6 +952,7 @@ export enum DownloadByRangeErrorCode {
   MISSING_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_MISSING_COLUMNS",
   OVER_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_OVER_COLUMNS",
   EXTRA_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_EXTRA_COLUMNS",
+  OUT_OF_ORDER_COLUMNS = "DOWNLOAD_BY_RANGE_OUT_OF_ORDER_COLUMNS",
 
   /** Cached block input type mismatches new data */
   MISMATCH_BLOCK_INPUT_TYPE = "DOWNLOAD_BY_RANGE_ERROR_MISMATCH_BLOCK_INPUT_TYPE",
@@ -966,7 +1013,7 @@ export type DownloadByRangeErrorType =
       actual: number;
     }
   | {
-      code: DownloadByRangeErrorCode.OUT_OF_ORDER_BLOBS;
+      code: DownloadByRangeErrorCode.OUT_OF_ORDER_BLOBS | DownloadByRangeErrorCode.OUT_OF_ORDER_COLUMNS;
       slot: number;
     }
   | {

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -580,7 +580,7 @@ export async function validateColumnsByRangeResponse(
   request: fulu.DataColumnSidecarsByRangeRequest,
   blocks: ValidatedSlot[],
   columnSidecars: fulu.DataColumnSidecars
-): Promise<WarnResult<ValidatedSlots, DownloadByRangeError>> {
+): Promise<WarnResult<ValidatedColumnSidecars[], DownloadByRangeError>> {
   const warnings: DownloadByRangeError[] = [];
   const seenColumns = new Map<Slot, fulu.DataColumnSidecars>();
 
@@ -590,6 +590,18 @@ export async function validateColumnsByRangeResponse(
     const slot = columnSidecar.signedBlockHeader.message.slot;
 
     if (slot === currentSlot) {
+      if (currentSlotSeen.find((c) => c.index === columnSidecar.index)) {
+        warnings.push(
+          new DownloadByRangeError({
+            code: DownloadByRangeErrorCode.DUPLICATE_COLUMN,
+            slot,
+            index: columnSidecar.index,
+          })
+        );
+
+        continue;
+      }
+
       // check for index order, then push and proceed
       const lastIndex = currentSlotSeen.at(-1)?.index;
 
@@ -610,15 +622,30 @@ export async function validateColumnsByRangeResponse(
       }
     } else if (slot > currentSlot) {
       // increment currentSlot
-      seenColumns.set(currentSlot, currentSlotSeen);
+      if (currentSlotSeen.length) {
+        // avoid setting on first iteration or if no columns in the array
+        seenColumns.set(currentSlot, currentSlotSeen);
+      }
 
       currentSlot = slot;
-      const existingCurrentSlotSee = seenColumns.has(slot);
+      const existingCurrentSlotSeen = seenColumns.has(slot);
       currentSlotSeen = seenColumns.get(slot) ?? [];
+
+      if (currentSlotSeen.find((c) => c.index === columnSidecar.index)) {
+        warnings.push(
+          new DownloadByRangeError({
+            code: DownloadByRangeErrorCode.DUPLICATE_COLUMN,
+            slot,
+            index: columnSidecar.index,
+          })
+        );
+
+        continue;
+      }
 
       currentSlotSeen.push(columnSidecar);
 
-      if (existingCurrentSlotSee) {
+      if (existingCurrentSlotSeen) {
         warnings.push(
           new DownloadByRangeError(
             {
@@ -646,6 +673,18 @@ export async function validateColumnsByRangeResponse(
       const slotColumns = seenColumns.get(slot) ?? [];
       const lastIndex = slotColumns.at(-1)?.index;
 
+      if (slotColumns.find((c) => c.index === columnSidecar.index)) {
+        warnings.push(
+          new DownloadByRangeError({
+            code: DownloadByRangeErrorCode.DUPLICATE_COLUMN,
+            slot,
+            index: columnSidecar.index,
+          })
+        );
+
+        continue;
+      }
+
       slotColumns.push(columnSidecar);
 
       if (lastIndex && lastIndex > columnSidecar.index) {
@@ -658,18 +697,24 @@ export async function validateColumnsByRangeResponse(
             "Column indices out of order within a slot"
           )
         );
+        // sort as they could be out of order
+        slotColumns.sort((a, b) => a.index - b.index);
       }
 
       seenColumns.set(slot, slotColumns);
     }
+
+    seenColumns.set(currentSlot, currentSlotSeen);
   }
 
-  const validationPromises: Promise<ValidatedColumnSidecars[]>[] = [];
+  const validationPromises: Promise<ValidatedColumnSidecars>[] = [];
 
   for (const {blockRoot, block} of blocks) {
     const slot = block.message.slot;
     // TODO(gloas): Post-gloas's blobKzgCommitments is not in beacon block body. Need to source it from somewhere else.
-    const blobCount = (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body.blobKzgCommitments.length;
+    // if block without columns is passed default to zero and throw below
+    const blobCount =
+      (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body.blobKzgCommitments?.length ?? 0;
     const columnSidecars = seenColumns.get(slot);
     // conditional a bit wonky so TSC knows we have dataColumns[] below
     if (!columnSidecars) {
@@ -839,6 +884,7 @@ export enum DownloadByRangeErrorCode {
   MISSING_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_MISSING_COLUMNS",
   OVER_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_OVER_COLUMNS",
   EXTRA_COLUMNS = "DOWNLOAD_BY_RANGE_ERROR_EXTRA_COLUMNS",
+  DUPLICATE_COLUMN = "DOWNLOAD_BY_RANGE_ERROR_DUPLICATE_COLUMN",
   OUT_OF_ORDER_COLUMNS = "DOWNLOAD_BY_RANGE_OUT_OF_ORDER_COLUMNS",
 
   /** Cached block input type mismatches new data */
@@ -918,6 +964,11 @@ export type DownloadByRangeErrorType =
       slot: Slot;
       blockRoot: string;
       missingIndices: string;
+    }
+  | {
+      code: DownloadByRangeErrorCode.DUPLICATE_COLUMN;
+      slot: Slot;
+      index: number;
     }
   | {
       code: DownloadByRangeErrorCode.EXTRA_COLUMNS;

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -15,7 +15,6 @@ import {validateBlockDataColumnSidecars} from "../../chain/validation/dataColumn
 import {INetwork} from "../../network/index.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {WarnResult} from "../../util/wrapError.js";
-import {DownloadByRootErrorCode} from "./downloadByRoot.js";
 
 export type DownloadByRangeRequests = {
   blocksRequest?: phase0.BeaconBlocksByRangeRequest;
@@ -290,7 +289,7 @@ export async function validateResponses({
   if ((blobsRequest || columnsRequest) && !(blocks || batchBlocks)) {
     throw new DownloadByRangeError(
       {
-        code: DownloadByRangeErrorCode.MISSING_BLOCKS,
+        code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
         ...requestsLogMeta({blobsRequest, columnsRequest}),
       },
       "No blocks to validate data requests against"
@@ -318,7 +317,7 @@ export async function validateResponses({
   if (!dataRequestBlocks.length) {
     throw new DownloadByRangeError(
       {
-        code: DownloadByRangeErrorCode.MISSING_BLOCKS,
+        code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
         ...requestsLogMeta({blobsRequest, columnsRequest}),
       },
       "No blocks in data request slot range to validate data response against"
@@ -863,7 +862,7 @@ function requestsLogMeta({blocksRequest, blobsRequest, columnsRequest}: Download
 }
 
 export enum DownloadByRangeErrorCode {
-  MISSING_BLOCKS = "DOWNLOAD_BY_RANGE_ERROR_MISSING_BLOCKS",
+  MISSING_BLOCK_RESPONSE = "DOWNLOAD_BY_RANGE_ERROR_MISSING_BLOCK_RESPONSE",
   MISSING_BLOBS_RESPONSE = "DOWNLOAD_BY_RANGE_ERROR_MISSING_BLOBS_RESPONSE",
   MISSING_COLUMNS_RESPONSE = "DOWNLOAD_BY_RANGE_ERROR_MISSING_COLUMNS_RESPONSE",
 
@@ -893,12 +892,12 @@ export enum DownloadByRangeErrorCode {
 
 export type DownloadByRangeErrorType =
   | {
-      code: DownloadByRootErrorCode.MISSING_BLOCK_RESPONSE;
+      code: DownloadByRangeErrorCode.MISSING_BLOCK_RESPONSE;
       expectedCount: number;
     }
   | {
       code:
-        | DownloadByRangeErrorCode.MISSING_BLOCKS
+        | DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE
         | DownloadByRangeErrorCode.MISSING_BLOBS_RESPONSE
         | DownloadByRangeErrorCode.MISSING_COLUMNS_RESPONSE;
       blockStartSlot?: number;
@@ -907,10 +906,6 @@ export type DownloadByRangeErrorType =
       blobCount?: number;
       columnStartSlot?: number;
       columnCount?: number;
-    }
-  | {
-      code: DownloadByRootErrorCode.MISSING_BLOCK_RESPONSE;
-      expectedCount: number;
     }
   | {
       code: DownloadByRangeErrorCode.OUT_OF_RANGE_BLOCKS;

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -300,21 +300,25 @@ export async function validateResponses({
   let warnings: DownloadByRangeError[] | null = null;
 
   if (blocksRequest) {
-    validatedResponses.validatedBlocks = validateBlockByRangeResponse(config, blocksRequest, blocks ?? []);
+    const result = validateBlockByRangeResponse(config, blocksRequest, blocks ?? []);
+    if (result.warnings?.length) {
+      warnings = result.warnings;
+    }
+    validatedResponses.validatedBlocks = result.result;
   }
 
   const dataRequest = blobsRequest ?? columnsRequest;
   if (!dataRequest) {
-    return {result: validatedResponses, warnings: null};
+    return {result: validatedResponses, warnings};
   }
 
-  const dataRequestBlocks = getBlocksForDataValidation(
+  const blocksForDataValidation = getBlocksForDataValidation(
     dataRequest,
     batchBlocks,
-    blocksRequest ? validatedResponses.validatedBlocks : undefined
+    validatedResponses.validatedBlocks?.length ? validatedResponses.validatedBlocks : undefined
   );
 
-  if (!dataRequestBlocks.length) {
+  if (!blocksForDataValidation.length) {
     throw new DownloadByRangeError(
       {
         code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
@@ -335,7 +339,10 @@ export async function validateResponses({
       );
     }
 
-    validatedResponses.validatedBlobSidecars = await validateBlobsByRangeResponse(dataRequestBlocks, blobSidecars);
+    validatedResponses.validatedBlobSidecars = await validateBlobsByRangeResponse(
+      blocksForDataValidation,
+      blobSidecars
+    );
   }
 
   if (columnsRequest) {
@@ -351,7 +358,7 @@ export async function validateResponses({
 
     const validatedColumnSidecarsResult = await validateColumnsByRangeResponse(
       columnsRequest,
-      dataRequestBlocks,
+      blocksForDataValidation,
       columnSidecars
     );
     validatedResponses.validatedColumnSidecars = validatedColumnSidecarsResult.result;
@@ -374,20 +381,25 @@ export function validateBlockByRangeResponse(
   config: ChainForkConfig,
   blocksRequest: phase0.BeaconBlocksByRangeRequest,
   blocks: SignedBeaconBlock[]
-): ValidatedBlock[] {
+): WarnResult<ValidatedBlock[], DownloadByRangeError> {
   const {startSlot, count} = blocksRequest;
 
-  // TODO(fulu): This was added by @twoeths in #8150 but it breaks for epochs with 0 blocks during chain
-  //    liveness issues. See comment https://github.com/ChainSafe/lodestar/issues/8147#issuecomment-3246434697
-  // if (!blocks.length) {
-  //   throw new DownloadByRangeError(
-  //     {
-  //       code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
-  //       expectedCount: blocksRequest.count,
-  //     },
-  //     "Zero blocks in response"
-  //   );
-  // }
+  // An error was thrown here by @twoeths in #8150 but it breaks for epochs with 0 blocks during chain
+  // liveness issues. See comment https://github.com/ChainSafe/lodestar/issues/8147#issuecomment-3246434697
+  // There are instances where clients return no blocks though.  Need to monitor this via the warns to see
+  // if what the correct behavior should be
+  if (!blocks.length) {
+    return {
+      result: [],
+      warnings: [
+        new DownloadByRangeError({
+          code: DownloadByRangeErrorCode.MISSING_BLOCK_RESPONSE,
+          expectedCount: count,
+          blockStartSlot: startSlot,
+        }),
+      ],
+    };
+  }
 
   if (blocks.length > count) {
     throw new DownloadByRangeError(
@@ -453,7 +465,10 @@ export function validateBlockByRangeResponse(
     }
   }
 
-  return response;
+  return {
+    result: response,
+    warnings: null,
+  };
 }
 
 /**
@@ -703,6 +718,7 @@ export async function validateColumnsByRangeResponse(
       seenColumns.set(slot, slotColumns);
     }
 
+    // make sure last iteration gets set to seenColumns
     seenColumns.set(currentSlot, currentSlotSeen);
   }
 

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -1,5 +1,14 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkPostDeneb, ForkPostFulu, ForkPreFulu, ForkPreGloas} from "@lodestar/params";
+import {
+  ForkName,
+  ForkPostDeneb,
+  ForkPostFulu,
+  ForkPostGloas,
+  ForkPreFulu,
+  ForkPreGloas,
+  isForkPostFulu,
+  isForkPostGloas,
+} from "@lodestar/params";
 import {SignedBeaconBlock, Slot, deneb, fulu, phase0} from "@lodestar/types";
 import {LodestarError, Logger, fromHex, prettyBytes, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {
@@ -588,6 +597,7 @@ export async function validateBlobsByRangeResponse(
  * - last block is last slot received
  */
 export async function validateColumnsByRangeResponse(
+  config: ChainForkConfig,
   request: fulu.DataColumnSidecarsByRangeRequest,
   blocks: ValidatedBlock[],
   columnSidecars: fulu.DataColumnSidecars
@@ -722,11 +732,27 @@ export async function validateColumnsByRangeResponse(
 
   for (const {blockRoot, block} of blocks) {
     const slot = block.message.slot;
-    // TODO GLOAS: Post-gloas's blobKzgCommitments is not in beacon block body. Need to source it from somewhere else.
-    // if block without columns is passed default to zero and throw below
-    const blobCount =
-      (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body.blobKzgCommitments?.length ?? 0;
+    const forkName = config.getForkName(slot);
     const columnSidecars = seenColumns.get(slot);
+
+    let blobCount: number;
+    if (!isForkPostFulu(forkName)) {
+      const dataSlot = columnSidecars?.at(0)?.signedBlockHeader.message.slot;
+      throw new DownloadByRangeError({
+        code: DownloadByRangeErrorCode.MISMATCH_BLOCK_FORK,
+        slot,
+        blockFork: forkName,
+        dataFork: dataSlot ? config.getForkName(dataSlot) : "unknown",
+      });
+    }
+    if (isForkPostGloas(forkName)) {
+      // TODO GLOAS: Post-gloas's blobKzgCommitments is not in beacon block body. Need to source it from somewhere else.
+      // if block without columns is passed default to zero and throw below
+      blobCount = 0;
+    } else {
+      blobCount = (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body.blobKzgCommitments.length;
+    }
+
     // conditional a bit wonky so TSC knows we have dataColumns[] below
     if (!columnSidecars) {
       if (!blobCount) {
@@ -899,6 +925,7 @@ export enum DownloadByRangeErrorCode {
   OUT_OF_ORDER_COLUMNS = "DOWNLOAD_BY_RANGE_OUT_OF_ORDER_COLUMNS",
 
   /** Cached block input type mismatches new data */
+  MISMATCH_BLOCK_FORK = "DOWNLOAD_BY_RANGE_ERROR_MISMATCH_BLOCK_FORK",
   MISMATCH_BLOCK_INPUT_TYPE = "DOWNLOAD_BY_RANGE_ERROR_MISMATCH_BLOCK_INPUT_TYPE",
 }
 
@@ -918,6 +945,12 @@ export type DownloadByRangeErrorType =
   | {
       code: DownloadByRangeErrorCode.OUT_OF_RANGE_BLOCKS;
       slot: number;
+    }
+  | {
+      code: DownloadByRangeErrorCode.MISMATCH_BLOCK_FORK;
+      slot: number;
+      dataFork: string;
+      blockFork: string;
     }
   | {
       code: DownloadByRangeErrorCode.OUT_OF_ORDER_BLOCKS;

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -668,7 +668,8 @@ export async function validateColumnsByRangeResponse(
 
   for (const {blockRoot, block} of blocks) {
     const slot = block.message.slot;
-    const blobCount = (block as SignedBeaconBlock<ForkPostDeneb>).message.body.blobKzgCommitments.length;
+    // TODO(gloas): Post-gloas's blobKzgCommitments is not in beacon block body. Need to source it from somewhere else.
+    const blobCount = (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body.blobKzgCommitments.length;
     const columnSidecars = seenColumns.get(slot);
     // conditional a bit wonky so TSC knows we have dataColumns[] below
     if (!columnSidecars) {
@@ -749,122 +750,8 @@ export async function validateColumnsByRangeResponse(
   const validatedColumns = await Promise.all(validationPromises);
   return {
     result: validatedColumns.flat(),
-    warnings,
+    warnings: warnings.length ? warnings : null,
   };
-}
-
-/**
- * Should not be called directly. Only exported for unit testing purposes
- */
-export async function validateColumnsByRangeResponse(
-  request: fulu.DataColumnSidecarsByRangeRequest,
-  dataRequestBlocks: ValidatedBlock[],
-  columnSidecars: fulu.DataColumnSidecars
-): Promise<WarnResult<ValidatedColumnSidecars[], DownloadByRangeError>> {
-  // Expected column count considering currently-validated batch blocks
-  // TODO GLOAS: Post-gloas's blobKzgCommitments is not in beacon block body. Need to source it from somewhere else.
-  const expectedColumnCount = dataRequestBlocks.reduce((acc, {block}) => {
-    return (block as SignedBeaconBlock<ForkPostDeneb & ForkPreGloas>).message.body.blobKzgCommitments.length > 0
-      ? request.columns.length + acc
-      : acc;
-  }, 0);
-  const nextSlot = dataRequestBlocks.length
-    ? (dataRequestBlocks.at(-1) as ValidatedBlock).block.message.slot + 1
-    : request.startSlot;
-  const possiblyMissingBlocks = nextSlot - request.startSlot + request.count;
-
-  // Allow for extra columns if some blocks are missing from the end of a batch
-  // Eg: If we requested 10 blocks but only 8 were returned, allow for up to 2 * columns.length extra columns
-  const maxColumnCount = expectedColumnCount + possiblyMissingBlocks * request.columns.length;
-
-  if (columnSidecars.length > maxColumnCount) {
-    // this never happens on devnet, so throw error for now
-    throw new DownloadByRangeError(
-      {
-        code: DownloadByRangeErrorCode.OVER_COLUMNS,
-        max: maxColumnCount,
-        actual: columnSidecars.length,
-      },
-      "Extra data columns received in DataColumnSidecarsByRange response"
-    );
-  }
-
-  const warnings: DownloadByRangeError[] = [];
-  // no need to check for columnSidecars.length  vs expectedColumnCount here, will be checked per-block below
-  const requestedColumns = new Set(request.columns);
-  const validateSidecarsPromises: Promise<ValidatedColumnSidecars>[] = [];
-
-  /**
-   * loop through the block to validate
-   */
-  for (let blockIndex = 0, columnSidecarIndex = 0; blockIndex < dataRequestBlocks.length; blockIndex++) {
-    const {block, blockRoot} = dataRequestBlocks[blockIndex];
-    const slot = block.message.slot;
-    const blockRootHex = toRootHex(blockRoot);
-    // TODO GLOAS: Post-gloas's blobKzgCommitments is not in beacon block body. Need to source it from somewhere else.
-    const blockKzgCommitments = (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body
-      .blobKzgCommitments;
-    const expectedColumns = blockKzgCommitments.length ? request.columns.length : 0;
-
-    if (expectedColumns === 0) {
-      continue;
-    }
-    const blockColumnSidecars: fulu.DataColumnSidecar[] = [];
-    while (columnSidecarIndex < columnSidecars.length) {
-      const columnSidecar = columnSidecars[columnSidecarIndex];
-      if (columnSidecar.signedBlockHeader.message.slot !== block.message.slot) {
-        // We've reached columns for the next block
-        break;
-      }
-      blockColumnSidecars.push(columnSidecar);
-      columnSidecarIndex++;
-    }
-
-    if (blockColumnSidecars.length === 0) {
-    }
-
-    const returnedColumns = new Set(blockColumnSidecars.map((c) => c.index));
-    const missingIndices = request.columns.filter((i) => !returnedColumns.has(i));
-    if (missingIndices.length > 0) {
-      warnings.push(
-        new DownloadByRangeError(
-          {
-            code: DownloadByRangeErrorCode.MISSING_COLUMNS,
-            slot,
-            blockRoot: blockRootHex,
-            missingIndices: prettyPrintIndices(missingIndices),
-          },
-          "Missing data columns in DataColumnSidecarsByRange response"
-        )
-      );
-    }
-
-    const extraIndices = [...returnedColumns].filter((i) => !requestedColumns.has(i));
-    if (extraIndices.length > 0) {
-      warnings.push(
-        new DownloadByRangeError(
-          {
-            code: DownloadByRangeErrorCode.EXTRA_COLUMNS,
-            slot,
-            blockRoot: blockRootHex,
-            invalidIndices: prettyPrintIndices(extraIndices),
-          },
-          "Data column in not in requested columns in DataColumnSidecarsByRange response"
-        )
-      );
-    }
-
-    validateSidecarsPromises.push(
-      validateBlockDataColumnSidecars(slot, blockRoot, blockKzgCommitments.length, blockColumnSidecars).then(() => ({
-        blockRoot,
-        columnSidecars: blockColumnSidecars,
-      }))
-    );
-  }
-
-  // Await all sidecar validations in parallel
-  const result = await Promise.all(validateSidecarsPromises);
-  return {result, warnings: warnings.length ? warnings : null};
 }
 
 /**

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -393,6 +393,8 @@ export function validateBlockByRangeResponse(
       code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
       ...requestsLogMeta({blocksRequest}),
     });
+    // TODO: this was causing deadlock again. need to come back and fix this so that its possible to process through
+    //       an empty epoch for periods with poor liveness
     // return {
     //   result: [],
     //   warnings: [

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -777,7 +777,7 @@ export async function validateColumnsByRangeResponse(
 
   const validatedColumns = await Promise.all(validationPromises);
   return {
-    result: validatedColumns.flat(),
+    result: validatedColumns,
     warnings: warnings.length ? warnings : null,
   };
 }

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -539,14 +539,6 @@ export async function validateBlobsByRangeResponse(
   return Promise.all(validateSidecarsPromises);
 }
 
-export type ValidatedSlot = {
-  blockRoot: Uint8Array;
-  block: SignedBeaconBlock;
-  blobs?: deneb.BlobSidecars;
-  columns?: fulu.DataColumnSidecars;
-};
-export type ValidatedSlots = Map<Slot, ValidatedSlot>;
-
 /**
  * Should not be called directly. Only exported for unit testing purposes
  *
@@ -591,7 +583,7 @@ export type ValidatedSlots = Map<Slot, ValidatedSlot>;
  */
 export async function validateColumnsByRangeResponse(
   request: fulu.DataColumnSidecarsByRangeRequest,
-  blocks: ValidatedSlot[],
+  blocks: ValidatedBlock[],
   columnSidecars: fulu.DataColumnSidecars
 ): Promise<WarnResult<ValidatedColumnSidecars[], DownloadByRangeError>> {
   const warnings: DownloadByRangeError[] = [];


### PR DESCRIPTION
**Motivation**

Found two small bugs while looking through devnet logs
```sh
Sep-25 13:49:19.674[sync]          verbose: Batch download error id=Head-35, startEpoch=14392, status=Downloading, peer=16...wUr9yu - Cannot read properties of undefined (reading 'signedBlockHeader')
TypeError: Cannot read properties of undefined (reading 'signedBlockHeader')
    at cacheByRangeResponses (file:///usr/app/packages/beacon-node/src/sync/utils/downloadByRange.ts:146:63)
    at SyncChain.downloadByRange (file:///usr/app/packages/beacon-node/src/sync/range/range.ts:213:20)
    at wrapError (file:///usr/app/packages/beacon-node/src/util/wrapError.ts:18:32)
    at SyncChain.sendBatch (file:///usr/app/packages/beacon-node/src/sync/range/chain.ts:470:19)
```
and 
```sh
Sep-30 15:39:03.738[sync]          verbose: Batch download error id=Head-12, startEpoch=15436, status=Downloading, peer=16...3aErhh - Cannot read properties of undefined (reading 'message')
TypeError: Cannot read properties of undefined (reading 'message')
    at validateBlockByRangeResponse (file:///usr/app/packages/beacon-node/src/sync/utils/downloadByRange.ts:432:46)
    at validateResponses (file:///usr/app/packages/beacon-node/src/sync/utils/downloadByRange.ts:304:42)
    at downloadByRange (file:///usr/app/packages/beacon-node/src/sync/utils/downloadByRange.ts:206:27)
    at SyncChain.downloadByRange (file:///usr/app/packages/beacon-node/src/sync/range/range.ts:205:32)
    at wrapError (file:///usr/app/packages/beacon-node/src/util/wrapError.ts:18:32)
    at SyncChain.sendBatch (file:///usr/app/packages/beacon-node/src/sync/range/chain.ts:470:19)
```

There is a bug in `validateColumnsByRangeResponse` that is passing through an empty array of `blockColumnSidecars` on this line https://github.com/ChainSafe/lodestar/blob/bca2040ef3735db7343c24bd9465290d17979095/packages/beacon-node/src/sync/utils/downloadByRange.ts#L770 that is throwing in `cacheByRangeResponses`.  While going through the validation with a fine toothed comb I noticed that there were a couple of conditions that we are not checking per spec.

**Scope**
Changed heuristic for how columns are validated in ByRange and added in checks for column delivery in `(slot, column_index)` order.