### PR TITLE
chore: add gloas fork constants to unscheduled networks

### DIFF
--- a/packages/config/src/chainConfig/networks/chiado.ts
+++ b/packages/config/src/chainConfig/networks/chiado.ts
@@ -43,6 +43,9 @@ export const chiadoChainConfig: ChainConfig = {
   // Fulu
   FULU_FORK_VERSION: b("0x0600006f"),
   FULU_FORK_EPOCH: Infinity,
+  // Gloas
+  GLOAS_FORK_VERSION: b("0x0700006f"),
+  GLOAS_FORK_EPOCH: Infinity,
 
   // Blob Scheduling
   BLOB_SCHEDULE: [],

--- a/packages/config/src/chainConfig/networks/ephemery.ts
+++ b/packages/config/src/chainConfig/networks/ephemery.ts
@@ -43,6 +43,9 @@ const baseChainConfig: ChainConfig = {
   // Fulu
   FULU_FORK_VERSION: b("0x7000101b"),
   FULU_FORK_EPOCH: Infinity,
+  // Gloas
+  GLOAS_FORK_VERSION: b("0x8000101b"),
+  GLOAS_FORK_EPOCH: Infinity,
 
   // Deposit contract
   // ---------------------------------------------------------------

--- a/packages/config/src/chainConfig/networks/gnosis.ts
+++ b/packages/config/src/chainConfig/networks/gnosis.ts
@@ -57,6 +57,9 @@ export const gnosisChainConfig: ChainConfig = {
   // Fulu
   FULU_FORK_VERSION: b("0x06000064"),
   FULU_FORK_EPOCH: Infinity,
+  // Gloas
+  GLOAS_FORK_VERSION: b("0x07000064"),
+  GLOAS_FORK_EPOCH: Infinity,
 
   // Deneb
   MAX_BLOBS_PER_BLOCK: 2,

--- a/packages/config/src/chainConfig/networks/holesky.ts
+++ b/packages/config/src/chainConfig/networks/holesky.ts
@@ -39,6 +39,9 @@ export const holeskyChainConfig: ChainConfig = {
   // Fulu
   FULU_FORK_VERSION: b("0x07017000"),
   FULU_FORK_EPOCH: 165120,
+  // Gloas
+  GLOAS_FORK_VERSION: b("0x08017000"),
+  GLOAS_FORK_EPOCH: Infinity,
 
   // # 28,000,000,000 Gwei to ensure quicker ejection
   EJECTION_BALANCE: 28000000000,

--- a/packages/config/src/chainConfig/networks/hoodi.ts
+++ b/packages/config/src/chainConfig/networks/hoodi.ts
@@ -38,6 +38,9 @@ export const hoodiChainConfig: ChainConfig = {
   // Fulu
   FULU_FORK_VERSION: b("0x70000910"),
   FULU_FORK_EPOCH: 50688,
+  // Gloas
+  GLOAS_FORK_VERSION: b("0x80000910"),
+  GLOAS_FORK_EPOCH: Infinity,
 
   // Time parameters
   // ---------------------------------------------------------------

--- a/packages/config/src/chainConfig/networks/sepolia.ts
+++ b/packages/config/src/chainConfig/networks/sepolia.ts
@@ -39,6 +39,9 @@ export const sepoliaChainConfig: ChainConfig = {
   // Fulu
   FULU_FORK_VERSION: b("0x90000075"),
   FULU_FORK_EPOCH: 272640,
+  // Gloas
+  GLOAS_FORK_VERSION: b("0x90000076"),
+  GLOAS_FORK_EPOCH: Infinity,
 
   // Deposit contract
   // ---------------------------------------------------------------


### PR DESCRIPTION
This avoids an issue we had previously where configs that extend mainnet preset would inherit wrong parameters. This just ensures this cannot happen in case we those will be forked after mainnet.

similar to https://github.com/ChainSafe/lodestar/pull/7401