### PR TITLE
chore: ignore local tsbuildinfo files in docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -67,5 +67,6 @@ docs/site
 **/dist
 *.log
 **/*.log
+**/*.tsbuildinfo
 .idea
 .tmp


### PR DESCRIPTION
Local docker builds (with existing build artifacts) no longer work since https://github.com/ChainSafe/lodestar/pull/8481 because the file `packages/cli/tsconfig.build.tsbuildinfo` is copied to docker build which causes typescript to skip the build, but we are not copying the `lib` which means the whole build is missing (and not rebuilt). The tsbuildinfo is usually part of `lib` which is why this was no issue before.

I believe this happens because `"rootDir": "src"` was added to tsconfig, there might be a different way to fix this but in general we don't want to copy  tsbuildinfo files into docker builds.