### PR TITLE
fix: use previous slot to get sync aggregate for block

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -411,11 +411,9 @@ export function getValidatorApi(
     {
       commonBlockBodyPromise,
       parentBlockRoot,
-      parentSlot,
     }: Omit<routes.validator.ExtraProduceBlockOpts, "builderSelection"> & {
       commonBlockBodyPromise: Promise<CommonBlockBody>;
       parentBlockRoot: Root;
-      parentSlot: Slot;
     }
   ): Promise<ProduceBlindedBlockRes> {
     const version = config.getForkName(slot);
@@ -447,7 +445,6 @@ export function getValidatorApi(
       const {block, executionPayloadValue, consensusBlockValue} = await chain.produceBlindedBlock({
         slot,
         parentBlockRoot,
-        parentSlot,
         randaoReveal,
         graffiti,
         commonBlockBodyPromise,
@@ -483,11 +480,9 @@ export function getValidatorApi(
       strictFeeRecipientCheck,
       commonBlockBodyPromise,
       parentBlockRoot,
-      parentSlot,
     }: Omit<routes.validator.ExtraProduceBlockOpts, "builderSelection"> & {
       commonBlockBodyPromise: Promise<CommonBlockBody>;
       parentBlockRoot: Root;
-      parentSlot: Slot;
     }
   ): Promise<ProduceBlockContentsRes & {shouldOverrideBuilder?: boolean}> {
     const source = ProducedBlockSource.engine;
@@ -499,7 +494,6 @@ export function getValidatorApi(
       const {block, executionPayloadValue, consensusBlockValue, shouldOverrideBuilder} = await chain.produceBlock({
         slot,
         parentBlockRoot,
-        parentSlot,
         randaoReveal,
         graffiti,
         feeRecipient,
@@ -642,7 +636,6 @@ export function getValidatorApi(
           strictFeeRecipientCheck: false,
           commonBlockBodyPromise,
           parentBlockRoot,
-          parentSlot,
         })
       : Promise.reject(new Error("Builder disabled"));
 
@@ -652,7 +645,6 @@ export function getValidatorApi(
           strictFeeRecipientCheck,
           commonBlockBodyPromise,
           parentBlockRoot,
-          parentSlot,
         }).then((engineBlock) => {
           // Once the engine returns a block, in the event of either:
           // - suspected builder censorship
@@ -695,7 +687,6 @@ export function getValidatorApi(
         .produceCommonBlockBody({
           slot,
           parentBlockRoot,
-          parentSlot,
           randaoReveal,
           graffiti: graffitiBytes,
         })

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -719,7 +719,6 @@ export class BeaconChain implements IBeaconChain {
       feeRecipient,
       commonBlockBodyPromise,
       parentBlockRoot,
-      parentSlot,
     }: BlockAttributes & {commonBlockBodyPromise: Promise<CommonBlockBody>}
   ): Promise<{
     block: AssembledBlockType<T>;
@@ -745,7 +744,6 @@ export class BeaconChain implements IBeaconChain {
         graffiti,
         slot,
         feeRecipient,
-        parentSlot,
         parentBlockRoot,
         proposerIndex,
         proposerPubKey,

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -92,7 +92,6 @@ export type BlockAttributes = {
   graffiti: Bytes32;
   slot: Slot;
   parentBlockRoot: Root;
-  parentSlot: Slot;
   feeRecipient?: string;
 };
 
@@ -733,15 +732,7 @@ export async function produceCommonBlockBody<T extends BlockType>(
   this: BeaconChain,
   blockType: T,
   currentState: CachedBeaconStateAllForks,
-  {
-    randaoReveal,
-    graffiti,
-    slot,
-    parentSlot,
-    parentBlockRoot,
-  }: BlockAttributes & {
-    parentSlot: Slot;
-  }
+  {randaoReveal, graffiti, slot, parentBlockRoot}: BlockAttributes
 ): Promise<CommonBlockBody> {
   const stepsMetrics =
     blockType === BlockType.Full
@@ -793,7 +784,8 @@ export async function produceCommonBlockBody<T extends BlockType>(
 
   const endSyncAggregate = stepsMetrics?.startTimer();
   if (ForkSeq[fork] >= ForkSeq.altair) {
-    const syncAggregate = this.syncContributionAndProofPool.getAggregate(parentSlot, parentBlockRoot);
+    const previousSlot = slot - 1;
+    const syncAggregate = this.syncContributionAndProofPool.getAggregate(previousSlot, parentBlockRoot);
     this.metrics?.production.producedSyncAggregateParticipants.observe(
       syncAggregate.syncCommitteeBits.getTrueBitIndexes().length
     );

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -78,7 +78,6 @@ describe("produceBlockBody", () => {
       const slot = state.slot;
 
       const commonBlockBodyPromise = chain.produceCommonBlockBody({
-        parentSlot: slot,
         slot: slot + 1,
         graffiti: Buffer.alloc(32),
         randaoReveal: Buffer.alloc(96),
@@ -86,7 +85,6 @@ describe("produceBlockBody", () => {
       });
 
       await produceBlockBody.call(chain, BlockType.Full, state, {
-        parentSlot: slot,
         slot: slot + 1,
         graffiti: Buffer.alloc(32),
         randaoReveal: Buffer.alloc(96),

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -214,7 +214,6 @@ describe("api/validator - produceBlockV3", () => {
       graffiti: toGraffitiBytes(graffiti),
       slot,
       parentBlockRoot,
-      parentSlot: currentSlot - 1,
       feeRecipient,
       commonBlockBodyPromise: expect.any(Promise),
     });
@@ -227,7 +226,6 @@ describe("api/validator - produceBlockV3", () => {
       graffiti: toGraffitiBytes(graffiti),
       slot,
       parentBlockRoot,
-      parentSlot: currentSlot - 1,
       feeRecipient: undefined,
       commonBlockBodyPromise: expect.any(Promise),
     });
@@ -285,7 +283,6 @@ describe("api/validator - produceBlockV3", () => {
       graffiti: toGraffitiBytes(graffiti),
       slot,
       feeRecipient,
-      parentSlot: slot - 1,
       parentBlockRoot: fromHexString(ZERO_HASH_HEX),
       proposerIndex: 0,
       proposerPubKey: new Uint8Array(32).fill(1),
@@ -311,7 +308,6 @@ describe("api/validator - produceBlockV3", () => {
       randaoReveal,
       graffiti: toGraffitiBytes(graffiti),
       slot,
-      parentSlot: slot - 1,
       parentBlockRoot: fromHexString(ZERO_HASH_HEX),
       proposerIndex: 0,
       proposerPubKey: new Uint8Array(32).fill(1),


### PR DESCRIPTION
**Motivation**

Since https://github.com/ChainSafe/lodestar/pull/7927 we started to use parent slot (the slot of parent block) to get sync aggregate for block but this can cause `BLOCK_ERROR_INVALID_SIGNATURE` during fork transition as might include sync aggregates into our block that are older than block slot - 1 which is used to compute domain during signature verification.

https://github.com/ChainSafe/lodestar/blob/8961b06c11ac67baab79fe774e0a3d1bfb217ea1/packages/state-transition/src/block/processSyncCommittee.ts#L81

This means we will reject our own block due to invalid signature if there are missed slots during the epoch transition.


> we currently hard code parent slot as producedSlot - 1 which is incorrect in reorg scenario

This was the motivation from the previous change but this doesn't seem right, sync committee messages are produced at latest 4 seconds into the slot so if we re-org the block due to it being weak/late then sync committee votes will also be for parent block root of that block and not the block itself.

So irrespective of block being reorged or not we should always include sync committee messages from previous slot.

**Description**

Use previous slot to get sync aggregate for block to avoid `BLOCK_ERROR_INVALID_SIGNATURE` in case there are missed slots.

