### PR TITLE
fix: use datastore-level by default

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -67,6 +67,10 @@
     "#prometheus-gc-stats-wrapper": {
       "bun": "./src/bun-wrappers/prometheus-gc-stats.ts",
       "default": "@chainsafe/prometheus-gc-stats"
+    },
+    "#datastore-wrapper": {
+      "bun": "./src/network/peers/datastore_bun.ts",
+      "default": "datastore-level"
     }
   },
   "typesVersions": {
@@ -149,6 +153,7 @@
     "@multiformats/multiaddr": "^12.1.3",
     "datastore-core": "^10.0.2",
     "datastore-fs": "^10.0.6",
+    "datastore-level": "^11.0.3",
     "deepmerge": "^4.3.1",
     "fastify": "^5.2.1",
     "interface-datastore": "^8.3.0",

--- a/packages/beacon-node/src/network/peers/datastore.ts
+++ b/packages/beacon-node/src/network/peers/datastore.ts
@@ -1,7 +1,7 @@
 import {AbortOptions} from "@libp2p/interface";
 import {BaseDatastore} from "datastore-core";
-import {FsDatastore} from "datastore-fs";
 import {Key, KeyQuery, Pair, Query} from "interface-datastore";
+import {LevelDatastore} from "#datastore-wrapper";
 
 type MemoryItem = {
   lastAccessedMs: number;
@@ -22,7 +22,7 @@ type MemoryItem = {
  *     -  Update lastAccessedMs
  */
 export class Eth2PeerDataStore extends BaseDatastore {
-  private _dbDatastore: FsDatastore;
+  private _dbDatastore: LevelDatastore;
   private _memoryDatastore: Map<string, MemoryItem>;
   /** Same to PersistentPeerStore of the old libp2p implementation */
   private _dirtyItems = new Set<string>();
@@ -32,7 +32,7 @@ export class Eth2PeerDataStore extends BaseDatastore {
   private _maxMemoryItems: number;
 
   constructor(
-    dbDatastore: FsDatastore | string,
+    dbDatastore: LevelDatastore | string,
     {threshold = 5, maxMemoryItems = 50}: {threshold?: number | undefined; maxMemoryItems?: number | undefined} = {}
   ) {
     super();
@@ -44,7 +44,7 @@ export class Eth2PeerDataStore extends BaseDatastore {
       throw Error(`Threshold ${threshold} should be at most maxMemoryItems ${maxMemoryItems}`);
     }
 
-    this._dbDatastore = typeof dbDatastore === "string" ? new FsDatastore(dbDatastore) : dbDatastore;
+    this._dbDatastore = typeof dbDatastore === "string" ? new LevelDatastore(dbDatastore) : dbDatastore;
     this._memoryDatastore = new Map();
     this._threshold = threshold;
     this._maxMemoryItems = maxMemoryItems;

--- a/packages/beacon-node/src/network/peers/datastore_bun.ts
+++ b/packages/beacon-node/src/network/peers/datastore_bun.ts
@@ -1,0 +1,3 @@
+import {FsDatastore} from "datastore-fs";
+
+export const LevelDatastore = FsDatastore;

--- a/packages/beacon-node/test/unit/network/peers/datastore.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/datastore.test.ts
@@ -3,7 +3,7 @@ import {MockedObject, afterEach, beforeEach, describe, expect, it, vi} from "vit
 import {LevelDatastore} from "#datastore-wrapper";
 import {Eth2PeerDataStore} from "../../../../src/network/peers/datastore.js";
 
-vi.mock("datastore-fs");
+vi.mock(globalThis.Bun ? "datastore-fs" : "datastore-level");
 
 describe("Eth2PeerDataStore", () => {
   let eth2Datastore: Eth2PeerDataStore;

--- a/packages/beacon-node/test/unit/network/peers/datastore.test.ts
+++ b/packages/beacon-node/test/unit/network/peers/datastore.test.ts
@@ -1,18 +1,18 @@
-import {FsDatastore} from "datastore-fs";
 import {Key} from "interface-datastore";
 import {MockedObject, afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {LevelDatastore} from "#datastore-wrapper";
 import {Eth2PeerDataStore} from "../../../../src/network/peers/datastore.js";
 
 vi.mock("datastore-fs");
 
 describe("Eth2PeerDataStore", () => {
   let eth2Datastore: Eth2PeerDataStore;
-  let dbDatastoreStub: MockedObject<FsDatastore>;
+  let dbDatastoreStub: MockedObject<LevelDatastore>;
 
   beforeEach(() => {
     vi.useFakeTimers({now: Date.now()});
 
-    dbDatastoreStub = vi.mocked(new FsDatastore({} as any));
+    dbDatastoreStub = vi.mocked(new LevelDatastore({} as any));
     eth2Datastore = new Eth2PeerDataStore(dbDatastoreStub, {threshold: 2, maxMemoryItems: 3});
 
     vi.spyOn(dbDatastoreStub, "put").mockResolvedValue({} as any);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3984,6 +3984,19 @@ abstract-level@^1.0.0, abstract-level@^1.0.2, abstract-level@^1.0.3:
     module-error "^1.0.1"
     queue-microtask "^1.2.3"
 
+abstract-level@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/abstract-level/-/abstract-level-1.0.4.tgz#3ad8d684c51cc9cbc9cf9612a7100b716c414b57"
+  integrity sha512-eUP/6pbXBkMbXFdx4IH2fVgvB7M0JvR7/lIL33zcs0IBcwjdzSSl31TOJsaCzmKSSDF9h8QYSOJux4Nd4YJqFg==
+  dependencies:
+    buffer "^6.0.3"
+    catering "^2.1.0"
+    is-buffer "^2.0.5"
+    level-supports "^4.0.0"
+    level-transcoder "^1.0.1"
+    module-error "^1.0.1"
+    queue-microtask "^1.2.3"
+
 abstract-logging@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/abstract-logging/-/abstract-logging-2.0.1.tgz#6b0c371df212db7129b57d2e7fcf282b8bf1c839"
@@ -5601,6 +5614,21 @@ datastore-fs@^10.0.6:
     it-parallel-batch "^3.0.8"
     race-signal "^2.0.0"
     steno "^4.0.2"
+
+datastore-level@^11.0.3:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/datastore-level/-/datastore-level-11.0.4.tgz#6f9d775ff7166b28558372e38d143424fbaa5b72"
+  integrity sha512-vwiOglxBXMhhEa2r5sh3iQrkrnK3HDYT/7V9dAb+/IvKotqHFsyio+tii9XNuWes1bj3yOCIQ/w8kdV3LZ/Glg==
+  dependencies:
+    datastore-core "^10.0.0"
+    interface-datastore "^8.0.0"
+    interface-store "^6.0.0"
+    it-filter "^3.1.3"
+    it-map "^3.1.3"
+    it-sort "^3.0.8"
+    it-take "^3.0.8"
+    level "^8.0.1"
+    race-signal "^2.0.0"
 
 dateformat@^3.0.3:
   version "3.0.3"
@@ -8024,6 +8052,13 @@ it-filter@^3.1.1:
   dependencies:
     it-peekable "^3.0.0"
 
+it-filter@^3.1.3:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/it-filter/-/it-filter-3.1.4.tgz#bcbeb74edd45c6b8d522e6581edf8a4c0bbb02af"
+  integrity sha512-80kWEKgiFEa4fEYD3mwf2uygo1dTQ5Y5midKtL89iXyjinruA/sNXl6iFkTcdNedydjvIsFhWLiqRPQP4fAwWQ==
+  dependencies:
+    it-peekable "^3.0.0"
+
 it-foreach@^2.1.3:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/it-foreach/-/it-foreach-2.1.4.tgz#f7295feefe40b47569863b34271efc3682f62708"
@@ -8180,6 +8215,13 @@ it-sort@^3.0.6:
   dependencies:
     it-all "^3.0.0"
 
+it-sort@^3.0.8:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/it-sort/-/it-sort-3.0.9.tgz#2a1ffca46c1a947b1f230f6249a2e5484bd9c2cf"
+  integrity sha512-jsM6alGaPiQbcAJdzMsuMh00uJcI+kD9TBoScB8TR75zUFOmHvhSsPi+Dmh2zfVkcoca+14EbfeIZZXTUGH63w==
+  dependencies:
+    it-all "^3.0.0"
+
 it-stream-types@^2.0.1, it-stream-types@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/it-stream-types/-/it-stream-types-2.0.2.tgz#60bbace90096796b4e6cc3bfab99cf9f2b86c152"
@@ -8189,6 +8231,11 @@ it-take@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/it-take/-/it-take-3.0.6.tgz#509283b69b88f823350b256392525267609f1925"
   integrity sha512-uqw3MRzf9to1SOLxaureGa73lK8k8ZB/asOApTAkvrzUqCznGtKNgPFH7uYIWlt4UuWq/hU6I+U4Fm5xpjN8Vg==
+
+it-take@^3.0.8:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/it-take/-/it-take-3.0.9.tgz#50c99ef24991f87bc4351a9a537db292e7facfe2"
+  integrity sha512-XMeUbnjOcgrhFXPUqa7H0VIjYSV/BvyxxjCp76QHVAFDJw2LmR1SHxUFiqyGeobgzJr7P2ZwSRRJQGn4D2BVlA==
 
 jackspeak@^2.0.3:
   version "2.3.3"
@@ -8539,6 +8586,15 @@ level@^8.0.0:
   resolved "https://registry.yarnpkg.com/level/-/level-8.0.0.tgz#41b4c515dabe28212a3e881b61c161ffead14394"
   integrity sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==
   dependencies:
+    browser-level "^1.0.1"
+    classic-level "^1.2.0"
+
+level@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/level/-/level-8.0.1.tgz#737161db1bc317193aca4e7b6f436e7e1df64379"
+  integrity sha512-oPBGkheysuw7DmzFQYyFe8NAia5jFLAgEnkgWnK3OXAuJr8qFT+xBQIwokAZPME2bhPFzS8hlYcL16m8UZrtwQ==
+  dependencies:
+    abstract-level "^1.0.4"
     browser-level "^1.0.1"
     classic-level "^1.2.0"
 


### PR DESCRIPTION
**Motivation**

- Review of #8468 metrics
- In https://github.com/ChainSafe/lodestar/pull/8449, use of `datastore-level` was unilaterally removed in favor of the bun-supported `datastore-fs`
- This caused a regression

**Description**
- use `datastore-level` by default, only use `datastore-fs` in bun