### PR TITLE
fix: respect `reverse` and `limit` in bun leveldb controller

### DIFF
--- a/packages/db/src/controller/level_bun.ts
+++ b/packages/db/src/controller/level_bun.ts
@@ -312,15 +312,15 @@ function consumeFilterOptions(opts: FilterOptions<Uint8Array>) {
   let lt: ((k: Uint8Array) => boolean) | undefined;
   let lte: ((k: Uint8Array) => boolean) | undefined;
   if (opts.reverse) {
-    next = iteratorNext;
-    seekToFirst = iteratorSeekToFirst;
+    next = iteratorPrev;
+    seekToFirst = iteratorSeekToLast;
     gt = opts.lt;
     gte = opts.lte;
     lt = opts.gt ? (k: Uint8Array) => Buffer.compare(k, opts.gt as Uint8Array) <= 0 : undefined;
     lte = opts.gte ? (k: Uint8Array) => Buffer.compare(k, opts.gte as Uint8Array) < 0 : undefined;
   } else {
-    next = iteratorPrev;
-    seekToFirst = iteratorSeekToLast;
+    next = iteratorNext;
+    seekToFirst = iteratorSeekToFirst;
     gt = opts.gt;
     gte = opts.gte;
     lt = opts.lt ? (k: Uint8Array) => Buffer.compare(k, opts.lt as Uint8Array) >= 0 : undefined;

--- a/packages/db/src/controller/level_bun.ts
+++ b/packages/db/src/controller/level_bun.ts
@@ -1,5 +1,6 @@
 import {
   DB,
+  Iterator,
   dbBatchDelete,
   dbBatchPut,
   dbClose,
@@ -12,8 +13,10 @@ import {
   iteratorDestroy,
   iteratorKey,
   iteratorNext,
+  iteratorPrev,
   iteratorSeek,
   iteratorSeekToFirst,
+  iteratorSeekToLast,
   iteratorValid,
   iteratorValue,
 } from "@lodestar/bun";
@@ -109,14 +112,16 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
   }
 
   keysStream(opts: FilterOptions<Uint8Array> = {}): AsyncIterable<Uint8Array> {
+    const {limit, next, seekToFirst, gt, gte, lt, lte} = consumeFilterOptions(opts);
     const iterator = dbIterator(this.db);
-    if (opts.gt) {
-      iteratorSeek(iterator, opts.gt);
-      iteratorNext(iterator);
-    } else if (opts.gte) {
-      iteratorSeek(iterator, opts.gte);
+
+    if (gt) {
+      iteratorSeek(iterator, gt);
+      next(iterator);
+    } else if (gte) {
+      iteratorSeek(iterator, gte);
     } else {
-      iteratorSeekToFirst(iterator);
+      seekToFirst(iterator);
     }
     const bucket = opts.bucketId ?? BUCKET_ID_UNKNOWN;
     const metrics = this.metrics;
@@ -124,13 +129,13 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
     let itemsRead = 0;
     return (async function* () {
       try {
-        while (iteratorValid(iterator)) {
+        while (iteratorValid(iterator) && itemsRead < limit) {
           const key = iteratorKey(iterator);
-          if (opts.lt && Buffer.compare(key, opts.lt) >= 0) break;
-          if (opts.lte && Buffer.compare(key, opts.lte) > 0) break;
+          if (lt?.(key)) break;
+          if (lte?.(key)) break;
           itemsRead++;
           yield key;
-          iteratorNext(iterator);
+          next(iterator);
         }
       } finally {
         metrics?.dbReadItems.inc({bucket}, itemsRead);
@@ -140,24 +145,26 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
   }
 
   async keys(opts: FilterOptions<Uint8Array> = {}): Promise<Uint8Array[]> {
+    const {limit, next, seekToFirst, gt, gte, lt, lte} = consumeFilterOptions(opts);
     const iterator = dbIterator(this.db);
-    if (opts.gt) {
-      iteratorSeek(iterator, opts.gt);
-      iteratorNext(iterator);
-    } else if (opts.gte) {
-      iteratorSeek(iterator, opts.gte);
+
+    if (gt) {
+      iteratorSeek(iterator, gt);
+      next(iterator);
+    } else if (gte) {
+      iteratorSeek(iterator, gte);
     } else {
-      iteratorSeekToFirst(iterator);
+      seekToFirst(iterator);
     }
     const keys = [];
     this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
     try {
-      while (iteratorValid(iterator)) {
+      while (iteratorValid(iterator) && keys.length < limit) {
         const key = iteratorKey(iterator);
-        if (opts.lt && Buffer.compare(key, opts.lt) >= 0) break;
-        if (opts.lte && Buffer.compare(key, opts.lte) > 0) break;
+        if (lt?.(key)) break;
+        if (lte?.(key)) break;
         keys.push(key);
-        iteratorNext(iterator);
+        next(iterator);
       }
       return keys;
     } finally {
@@ -167,14 +174,16 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
   }
 
   valuesStream(opts: FilterOptions<Uint8Array> = {}): AsyncIterable<Uint8Array> {
+    const {limit, next, seekToFirst, gt, gte, lt, lte} = consumeFilterOptions(opts);
     const iterator = dbIterator(this.db);
-    if (opts.gt) {
-      iteratorSeek(iterator, opts.gt);
-      iteratorNext(iterator);
-    } else if (opts.gte) {
-      iteratorSeek(iterator, opts.gte);
+
+    if (gt) {
+      iteratorSeek(iterator, gt);
+      next(iterator);
+    } else if (gte) {
+      iteratorSeek(iterator, gte);
     } else {
-      iteratorSeekToFirst(iterator);
+      seekToFirst(iterator);
     }
     const bucket = opts.bucketId ?? BUCKET_ID_UNKNOWN;
     const metrics = this.metrics;
@@ -182,14 +191,14 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
     let itemsRead = 0;
     return (async function* () {
       try {
-        while (iteratorValid(iterator)) {
+        while (iteratorValid(iterator) && itemsRead < limit) {
           const key = iteratorKey(iterator);
-          if (opts.lt && Buffer.compare(key, opts.lt) >= 0) break;
-          if (opts.lte && Buffer.compare(key, opts.lte) > 0) break;
+          if (lt?.(key)) break;
+          if (lte?.(key)) break;
           itemsRead++;
           const value = iteratorValue(iterator);
           yield value;
-          iteratorNext(iterator);
+          next(iterator);
         }
       } finally {
         metrics?.dbReadItems.inc({bucket}, itemsRead);
@@ -199,25 +208,27 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
   }
 
   async values(opts: FilterOptions<Uint8Array> = {}): Promise<Uint8Array[]> {
+    const {limit, next, seekToFirst, gt, gte, lt, lte} = consumeFilterOptions(opts);
     const iterator = dbIterator(this.db);
-    if (opts.gt) {
-      iteratorSeek(iterator, opts.gt);
-      iteratorNext(iterator);
-    } else if (opts.gte) {
-      iteratorSeek(iterator, opts.gte);
+
+    if (gt) {
+      iteratorSeek(iterator, gt);
+      next(iterator);
+    } else if (gte) {
+      iteratorSeek(iterator, gte);
     } else {
-      iteratorSeekToFirst(iterator);
+      seekToFirst(iterator);
     }
     const values = [];
     this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
     try {
-      while (iteratorValid(iterator)) {
+      while (iteratorValid(iterator) && values.length < limit) {
         const key = iteratorKey(iterator);
-        if (opts.lt && Buffer.compare(key, opts.lt) >= 0) break;
-        if (opts.lte && Buffer.compare(key, opts.lte) > 0) break;
+        if (lt?.(key)) break;
+        if (lte?.(key)) break;
         const value = iteratorValue(iterator);
         values.push(value);
-        iteratorNext(iterator);
+        next(iterator);
       }
       return values;
     } finally {
@@ -227,14 +238,16 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
   }
 
   entriesStream(opts: FilterOptions<Uint8Array> = {}): AsyncIterable<KeyValue<Uint8Array, Uint8Array>> {
+    const {limit, next, seekToFirst, gt, gte, lt, lte} = consumeFilterOptions(opts);
     const iterator = dbIterator(this.db);
-    if (opts.gt) {
-      iteratorSeek(iterator, opts.gt);
-      iteratorNext(iterator);
-    } else if (opts.gte) {
-      iteratorSeek(iterator, opts.gte);
+
+    if (gt) {
+      iteratorSeek(iterator, gt);
+      next(iterator);
+    } else if (gte) {
+      iteratorSeek(iterator, gte);
     } else {
-      iteratorSeekToFirst(iterator);
+      seekToFirst(iterator);
     }
     const bucket = opts.bucketId ?? BUCKET_ID_UNKNOWN;
     const metrics = this.metrics;
@@ -242,14 +255,14 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
     let itemsRead = 0;
     return (async function* () {
       try {
-        while (iteratorValid(iterator)) {
+        while (iteratorValid(iterator) && itemsRead < limit) {
           const key = iteratorKey(iterator);
-          if (opts.lt && Buffer.compare(key, opts.lt) >= 0) break;
-          if (opts.lte && Buffer.compare(key, opts.lte) > 0) break;
+          if (lt?.(key)) break;
+          if (lte?.(key)) break;
           itemsRead++;
           const value = iteratorValue(iterator);
           yield {key, value};
-          iteratorNext(iterator);
+          next(iterator);
         }
       } finally {
         metrics?.dbReadItems.inc({bucket}, itemsRead);
@@ -259,25 +272,27 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
   }
 
   async entries(opts: FilterOptions<Uint8Array> = {}): Promise<KeyValue<Uint8Array, Uint8Array>[]> {
+    const {limit, next, seekToFirst, gt, gte, lt, lte} = consumeFilterOptions(opts);
     const iterator = dbIterator(this.db);
-    if (opts.gt) {
-      iteratorSeek(iterator, opts.gt);
-      iteratorNext(iterator);
-    } else if (opts.gte) {
-      iteratorSeek(iterator, opts.gte);
+
+    if (gt) {
+      iteratorSeek(iterator, gt);
+      next(iterator);
+    } else if (gte) {
+      iteratorSeek(iterator, gte);
     } else {
-      iteratorSeekToFirst(iterator);
+      seekToFirst(iterator);
     }
     const entries = [];
     this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
     try {
-      while (iteratorValid(iterator)) {
+      while (iteratorValid(iterator) && entries.length < limit) {
         const key = iteratorKey(iterator);
-        if (opts.lt && Buffer.compare(key, opts.lt) >= 0) break;
-        if (opts.lte && Buffer.compare(key, opts.lte) > 0) break;
+        if (lt?.(key)) break;
+        if (lte?.(key)) break;
         const value = iteratorValue(iterator);
         entries.push({key, value});
-        iteratorNext(iterator);
+        next(iterator);
       }
       return entries;
     } finally {
@@ -285,4 +300,31 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
       iteratorDestroy(iterator);
     }
   }
+}
+
+/** Return filter options and operations which consider `reverse` and `limit` */
+function consumeFilterOptions(opts: FilterOptions<Uint8Array>) {
+  const limit = opts.limit ?? Number.POSITIVE_INFINITY;
+  let next: (it: Iterator) => void;
+  let seekToFirst: (it: Iterator) => void;
+  let gt: Uint8Array | undefined;
+  let gte: Uint8Array | undefined;
+  let lt: ((k: Uint8Array) => boolean) | undefined;
+  let lte: ((k: Uint8Array) => boolean) | undefined;
+  if (opts.reverse) {
+    next = iteratorNext;
+    seekToFirst = iteratorSeekToFirst;
+    gt = opts.lt;
+    gte = opts.lte;
+    lt = opts.gt ? (k: Uint8Array) => Buffer.compare(k, opts.gt as Uint8Array) <= 0 : undefined;
+    lte = opts.gte ? (k: Uint8Array) => Buffer.compare(k, opts.gte as Uint8Array) < 0 : undefined;
+  } else {
+    next = iteratorPrev;
+    seekToFirst = iteratorSeekToLast;
+    gt = opts.gt;
+    gte = opts.gte;
+    lt = opts.lt ? (k: Uint8Array) => Buffer.compare(k, opts.lt as Uint8Array) >= 0 : undefined;
+    lte = opts.lte ? (k: Uint8Array) => Buffer.compare(k, opts.lte as Uint8Array) > 0 : undefined;
+  }
+  return {limit, next, seekToFirst, gt, gte, lt, lte};
 }

--- a/packages/db/src/controller/level_bun.ts
+++ b/packages/db/src/controller/level_bun.ts
@@ -112,18 +112,8 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
   }
 
   keysStream(opts: FilterOptions<Uint8Array> = {}): AsyncIterable<Uint8Array> {
-    const {limit, next, seekToFirst, gt, gte, lt, lte} = consumeFilterOptions(opts);
-    const iterator = dbIterator(this.db);
+    const {bucket, iterator, limit, next, outOfRange} = consumeFilterOptions(this.db, opts);
 
-    if (gt) {
-      iteratorSeek(iterator, gt);
-      next(iterator);
-    } else if (gte) {
-      iteratorSeek(iterator, gte);
-    } else {
-      seekToFirst(iterator);
-    }
-    const bucket = opts.bucketId ?? BUCKET_ID_UNKNOWN;
     const metrics = this.metrics;
     metrics?.dbReadReq.inc({bucket}, 1);
     let itemsRead = 0;
@@ -131,8 +121,7 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
       try {
         while (iteratorValid(iterator) && itemsRead < limit) {
           const key = iteratorKey(iterator);
-          if (lt?.(key)) break;
-          if (lte?.(key)) break;
+          if (outOfRange?.(key)) break;
           itemsRead++;
           yield key;
           next(iterator);
@@ -145,47 +134,25 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
   }
 
   async keys(opts: FilterOptions<Uint8Array> = {}): Promise<Uint8Array[]> {
-    const {limit, next, seekToFirst, gt, gte, lt, lte} = consumeFilterOptions(opts);
-    const iterator = dbIterator(this.db);
-
-    if (gt) {
-      iteratorSeek(iterator, gt);
-      next(iterator);
-    } else if (gte) {
-      iteratorSeek(iterator, gte);
-    } else {
-      seekToFirst(iterator);
-    }
+    const {bucket, iterator, limit, next, outOfRange} = consumeFilterOptions(this.db, opts);
     const keys = [];
-    this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    this.metrics?.dbReadReq.inc({bucket}, 1);
     try {
       while (iteratorValid(iterator) && keys.length < limit) {
         const key = iteratorKey(iterator);
-        if (lt?.(key)) break;
-        if (lte?.(key)) break;
+        if (outOfRange?.(key)) break;
         keys.push(key);
         next(iterator);
       }
       return keys;
     } finally {
-      this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, keys.length);
+      this.metrics?.dbReadItems.inc({bucket}, keys.length);
       iteratorDestroy(iterator);
     }
   }
 
   valuesStream(opts: FilterOptions<Uint8Array> = {}): AsyncIterable<Uint8Array> {
-    const {limit, next, seekToFirst, gt, gte, lt, lte} = consumeFilterOptions(opts);
-    const iterator = dbIterator(this.db);
-
-    if (gt) {
-      iteratorSeek(iterator, gt);
-      next(iterator);
-    } else if (gte) {
-      iteratorSeek(iterator, gte);
-    } else {
-      seekToFirst(iterator);
-    }
-    const bucket = opts.bucketId ?? BUCKET_ID_UNKNOWN;
+    const {bucket, iterator, limit, next, outOfRange} = consumeFilterOptions(this.db, opts);
     const metrics = this.metrics;
     metrics?.dbReadReq.inc({bucket}, 1);
     let itemsRead = 0;
@@ -193,8 +160,7 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
       try {
         while (iteratorValid(iterator) && itemsRead < limit) {
           const key = iteratorKey(iterator);
-          if (lt?.(key)) break;
-          if (lte?.(key)) break;
+          if (outOfRange?.(key)) break;
           itemsRead++;
           const value = iteratorValue(iterator);
           yield value;
@@ -208,48 +174,26 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
   }
 
   async values(opts: FilterOptions<Uint8Array> = {}): Promise<Uint8Array[]> {
-    const {limit, next, seekToFirst, gt, gte, lt, lte} = consumeFilterOptions(opts);
-    const iterator = dbIterator(this.db);
-
-    if (gt) {
-      iteratorSeek(iterator, gt);
-      next(iterator);
-    } else if (gte) {
-      iteratorSeek(iterator, gte);
-    } else {
-      seekToFirst(iterator);
-    }
+    const {bucket, iterator, limit, next, outOfRange} = consumeFilterOptions(this.db, opts);
     const values = [];
-    this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    this.metrics?.dbReadReq.inc({bucket}, 1);
     try {
       while (iteratorValid(iterator) && values.length < limit) {
         const key = iteratorKey(iterator);
-        if (lt?.(key)) break;
-        if (lte?.(key)) break;
+        if (outOfRange?.(key)) break;
         const value = iteratorValue(iterator);
         values.push(value);
         next(iterator);
       }
       return values;
     } finally {
-      this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, values.length);
+      this.metrics?.dbReadItems.inc({bucket}, values.length);
       iteratorDestroy(iterator);
     }
   }
 
   entriesStream(opts: FilterOptions<Uint8Array> = {}): AsyncIterable<KeyValue<Uint8Array, Uint8Array>> {
-    const {limit, next, seekToFirst, gt, gte, lt, lte} = consumeFilterOptions(opts);
-    const iterator = dbIterator(this.db);
-
-    if (gt) {
-      iteratorSeek(iterator, gt);
-      next(iterator);
-    } else if (gte) {
-      iteratorSeek(iterator, gte);
-    } else {
-      seekToFirst(iterator);
-    }
-    const bucket = opts.bucketId ?? BUCKET_ID_UNKNOWN;
+    const {bucket, iterator, limit, next, outOfRange} = consumeFilterOptions(this.db, opts);
     const metrics = this.metrics;
     metrics?.dbReadReq.inc({bucket}, 1);
     let itemsRead = 0;
@@ -257,8 +201,7 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
       try {
         while (iteratorValid(iterator) && itemsRead < limit) {
           const key = iteratorKey(iterator);
-          if (lt?.(key)) break;
-          if (lte?.(key)) break;
+          if (outOfRange?.(key)) break;
           itemsRead++;
           const value = iteratorValue(iterator);
           yield {key, value};
@@ -272,59 +215,67 @@ export class LevelDbController implements DatabaseController<Uint8Array, Uint8Ar
   }
 
   async entries(opts: FilterOptions<Uint8Array> = {}): Promise<KeyValue<Uint8Array, Uint8Array>[]> {
-    const {limit, next, seekToFirst, gt, gte, lt, lte} = consumeFilterOptions(opts);
-    const iterator = dbIterator(this.db);
-
-    if (gt) {
-      iteratorSeek(iterator, gt);
-      next(iterator);
-    } else if (gte) {
-      iteratorSeek(iterator, gte);
-    } else {
-      seekToFirst(iterator);
-    }
+    const {bucket, iterator, limit, next, outOfRange} = consumeFilterOptions(this.db, opts);
     const entries = [];
-    this.metrics?.dbReadReq.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, 1);
+    this.metrics?.dbReadReq.inc({bucket}, 1);
     try {
       while (iteratorValid(iterator) && entries.length < limit) {
         const key = iteratorKey(iterator);
-        if (lt?.(key)) break;
-        if (lte?.(key)) break;
+        if (outOfRange?.(key)) break;
         const value = iteratorValue(iterator);
         entries.push({key, value});
         next(iterator);
       }
       return entries;
     } finally {
-      this.metrics?.dbReadItems.inc({bucket: opts?.bucketId ?? BUCKET_ID_UNKNOWN}, entries.length);
+      this.metrics?.dbReadItems.inc({bucket}, entries.length);
       iteratorDestroy(iterator);
     }
   }
 }
 
-/** Return filter options and operations which consider `reverse` and `limit` */
-function consumeFilterOptions(opts: FilterOptions<Uint8Array>) {
+/**
+ * Return initialized iterator, filter options and operations.
+ */
+function consumeFilterOptions(db: DB, opts: FilterOptions<Uint8Array>) {
+  const iterator = dbIterator(db);
+
   const limit = opts.limit ?? Number.POSITIVE_INFINITY;
   let next: (it: Iterator) => void;
   let seekToFirst: (it: Iterator) => void;
   let gt: Uint8Array | undefined;
   let gte: Uint8Array | undefined;
-  let lt: ((k: Uint8Array) => boolean) | undefined;
-  let lte: ((k: Uint8Array) => boolean) | undefined;
+  let outOfRange: ((k: Uint8Array) => boolean) | undefined;
   if (opts.reverse) {
     next = iteratorPrev;
     seekToFirst = iteratorSeekToLast;
     gt = opts.lt;
     gte = opts.lte;
-    lt = opts.gt ? (k: Uint8Array) => Buffer.compare(k, opts.gt as Uint8Array) <= 0 : undefined;
-    lte = opts.gte ? (k: Uint8Array) => Buffer.compare(k, opts.gte as Uint8Array) < 0 : undefined;
+    outOfRange = opts.gt
+      ? (k: Uint8Array) => Buffer.compare(k, opts.gt as Uint8Array) <= 0
+      : opts.gte
+        ? (k: Uint8Array) => Buffer.compare(k, opts.gte as Uint8Array) < 0
+        : undefined;
   } else {
     next = iteratorNext;
     seekToFirst = iteratorSeekToFirst;
     gt = opts.gt;
     gte = opts.gte;
-    lt = opts.lt ? (k: Uint8Array) => Buffer.compare(k, opts.lt as Uint8Array) >= 0 : undefined;
-    lte = opts.lte ? (k: Uint8Array) => Buffer.compare(k, opts.lte as Uint8Array) > 0 : undefined;
+    outOfRange = opts.lt
+      ? (k: Uint8Array) => Buffer.compare(k, opts.lt as Uint8Array) >= 0
+      : opts.lte
+        ? (k: Uint8Array) => Buffer.compare(k, opts.lte as Uint8Array) > 0
+        : undefined;
   }
-  return {limit, next, seekToFirst, gt, gte, lt, lte};
+  if (gt) {
+    iteratorSeek(iterator, gt);
+    next(iterator);
+  } else if (gte) {
+    iteratorSeek(iterator, gte);
+  } else {
+    seekToFirst(iterator);
+  }
+  const bucket = opts.bucketId ?? BUCKET_ID_UNKNOWN;
+
+  return {bucket, iterator, limit, next, outOfRange};
 }

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -1,7 +1,7 @@
 import {execSync} from "node:child_process";
 import os from "node:os";
 import all from "it-all";
-import {afterAll, beforeAll, describe, expect, it} from "vitest";
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
 import {LevelDbController} from "#controller/level";
 import {getEnvLogger} from "@lodestar/logger/env";
 
@@ -9,11 +9,11 @@ describe("LevelDB controller", () => {
   const dbLocation = "./.__testdb";
   let db: LevelDbController;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     db = await LevelDbController.create({name: dbLocation}, {metrics: null, logger: getEnvLogger()});
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await db.close();
     await LevelDbController.destroy(dbLocation);
   });
@@ -121,6 +121,28 @@ describe("LevelDB controller", () => {
     });
     const result = await all(resultStream);
     expect(result.length).toBe(2);
+  });
+
+  it("test limit", async () => {
+    const indexes = Array.from({length: 10}, (_, i) => i);
+    const keys = indexes.map((i) => Buffer.from([i]));
+    const values = indexes.map((i) => Buffer.from([i]));
+    await db.batchPut(keys.map((key, i) => ({key, value: values[i]})));
+    const result = await db.entries({limit: 3});
+    expect(result.length).toBe(3);
+    const resultStream = db.entriesStream({limit: 3});
+    expect((await all(resultStream)).length).toBe(3);
+  });
+
+  it("test reverse", async () => {
+    const indexes = Array.from({length: 10}, (_, i) => i);
+    const keys = indexes.map((i) => Buffer.from([i]));
+    const values = indexes.map((i) => Buffer.from([i]));
+    await db.batchPut(keys.map((key, i) => ({key, value: values[i]})));
+
+    const result = await db.entries({reverse: true, limit: 1});
+    expect(result.length).toBe(1);
+    expect(Uint8Array.from(result[0].key)).toEqual(Uint8Array.from([9]));
   });
 
   it("test compactRange + approximateSize", async () => {

--- a/packages/db/test/unit/controller/level.test.ts
+++ b/packages/db/test/unit/controller/level.test.ts
@@ -140,9 +140,9 @@ describe("LevelDB controller", () => {
     const values = indexes.map((i) => Buffer.from([i]));
     await db.batchPut(keys.map((key, i) => ({key, value: values[i]})));
 
-    const result = await db.entries({reverse: true, limit: 1});
+    const result = await db.entries({reverse: true, limit: 1, lt: Buffer.from([9])});
     expect(result.length).toBe(1);
-    expect(Uint8Array.from(result[0].key)).toEqual(Uint8Array.from([9]));
+    expect(Uint8Array.from(result[0].key)).toEqual(Uint8Array.from([8]));
   });
 
   it("test compactRange + approximateSize", async () => {


### PR DESCRIPTION
**Motivation**

- https://github.com/ChainSafe/lodestar/issues/8526

**Description**

- In #8526 it was discovered that the leveldb controller did not respect `reverse`
- Visual review of the code shows it doesn't respect `reverse` nor `limit`
- Add support for both `reverse` and `limit`