### PR TITLE
feat: track computeDeltas metrics

### DIFF
--- a/packages/fork-choice/src/metrics.ts
+++ b/packages/fork-choice/src/metrics.ts
@@ -66,6 +66,41 @@ export function getForkChoiceMetrics(register: MetricsRegisterExtra) {
         help: "Reason why the current head is not re-orged out",
         labelNames: ["reason"],
       }),
+      computeDeltas: {
+        duration: register.histogram({
+          name: "beacon_fork_choice_compute_deltas_seconds",
+          help: "Time taken to compute deltas in seconds",
+          buckets: [0.01, 0.05, 0.1, 0.2],
+        }),
+        deltasCount: register.gauge({
+          name: "beacon_fork_choice_compute_deltas_deltas_count",
+          help: "Count of deltas computed",
+        }),
+        zeroDeltasCount: register.gauge({
+          name: "beacon_fork_choice_compute_deltas_zero_deltas_count",
+          help: "Count of zero deltas processed",
+        }),
+        equivocatingValidators: register.gauge({
+          name: "beacon_fork_choice_compute_deltas_equivocating_validators_count",
+          help: "Count of equivocating validators processed",
+        }),
+        oldInactiveValidators: register.gauge({
+          name: "beacon_fork_choice_compute_deltas_old_inactive_validators_count",
+          help: "Count of old inactive validators processed",
+        }),
+        newInactiveValidators: register.gauge({
+          name: "beacon_fork_choice_compute_deltas_new_inactive_validators_count",
+          help: "Count of new inactive validators processed",
+        }),
+        unchangedVoteValidators: register.gauge({
+          name: "beacon_fork_choice_compute_deltas_unchanged_vote_validators_count",
+          help: "Count of unchanged vote validators processed",
+        }),
+        newVoteValidators: register.gauge({
+          name: "beacon_fork_choice_compute_deltas_new_vote_validators_count",
+          help: "Count of new vote validators processed",
+        }),
+      },
     },
   };
 }

--- a/packages/fork-choice/test/unit/protoArray/computeDeltas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/computeDeltas.test.ts
@@ -22,7 +22,7 @@ describe("computeDeltas", () => {
       newBalances[i] = 0;
     }
 
-    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).toEqual(validatorCount);
     expect(deltas).toEqual(Array.from({length: validatorCount}, () => 0));
@@ -52,7 +52,7 @@ describe("computeDeltas", () => {
       newBalances[i] = balance;
     }
 
-    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).toEqual(validatorCount);
 
@@ -85,7 +85,7 @@ describe("computeDeltas", () => {
       newBalances[i] = balance;
     }
 
-    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).toEqual(validatorCount);
 
@@ -114,7 +114,7 @@ describe("computeDeltas", () => {
       newBalances[i] = balance;
     }
 
-    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).toEqual(validatorCount);
 
@@ -152,7 +152,7 @@ describe("computeDeltas", () => {
       newBalances[i] = newBalance;
     }
 
-    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).toEqual(validatorCount);
 
@@ -190,7 +190,7 @@ describe("computeDeltas", () => {
     newBalances[0] = balance;
     newBalances[1] = balance;
 
-    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).toEqual(2);
 
@@ -224,7 +224,7 @@ describe("computeDeltas", () => {
     const newBalances = getEffectiveBalanceIncrementsZeroed(1);
     newBalances[0] = balance;
 
-    const deltas = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
 
     expect(deltas.length).toEqual(2);
 
@@ -255,13 +255,13 @@ describe("computeDeltas", () => {
     const balances = new Uint16Array([firstBalance, secondBalance]);
     // 1st validator is part of an attester slashing
     const equivocatingIndices = new Set([0]);
-    let deltas = computeDeltas(indices.size, votes, balances, balances, equivocatingIndices);
+    let {deltas} = computeDeltas(indices.size, votes, balances, balances, equivocatingIndices);
     expect(deltas[0]).toBeWithMessage(
       -1 * (firstBalance + secondBalance),
       "should disregard the 1st validator due to attester slashing"
     );
     expect(deltas[1]).toBeWithMessage(secondBalance, "should move 2nd balance from 1st root to 2nd root");
-    deltas = computeDeltas(indices.size, votes, balances, balances, equivocatingIndices);
+    deltas = computeDeltas(indices.size, votes, balances, balances, equivocatingIndices).deltas;
     expect(deltas).toEqualWithMessage([0, 0], "calling computeDeltas again should not have any affect on the weight");
   });
 });


### PR DESCRIPTION
**Motivation**

- track/maintain computeDeltas() metrics

**Description**

- track computeDeltas() duration, number of 0 deltas, equivocatingValidators, oldInactiveValidators, newInactiveValidators, unchangedVoteValidators, newVoteValidators
- as part of investigation of #8519 we want to make sure metrics are the same with Bun

part of #8519

**Metrics collected**
- hoodi

<img width="1020" height="609" alt="Screenshot 2025-10-14 at 15 08 29" src="https://github.com/user-attachments/assets/4b0ab871-ce04-43c9-8b79-73c13a843f4a" />

- mainnet
<img width="958" height="617" alt="Screenshot 2025-10-14 at 15 08 54" src="https://github.com/user-attachments/assets/bc264eb1-905d-4f90-bd17-39fb58068608" />

- updateHead() is actually ~5ms increase

<img width="842" height="308" alt="Screenshot 2025-10-14 at 15 09 50" src="https://github.com/user-attachments/assets/ec082257-c7c0-4ca3-9908-cd006d23e1de" />

- but it's worth to have more details of `computeDeltas`, we saved ~25ms after #8525

<img width="1461" height="358" alt="Screenshot 2025-10-14 at 15 11 29" src="https://github.com/user-attachments/assets/4cffee0e-d0c0-4f74-a647-59f69af0fd99" />

