### PR TITLE
fix: do not create default cache entry for unknown proposers

### DIFF
--- a/packages/beacon-node/src/chain/beaconProposerCache.ts
+++ b/packages/beacon-node/src/chain/beaconProposerCache.ts
@@ -1,18 +1,14 @@
 import {routes} from "@lodestar/api";
 import {Epoch} from "@lodestar/types";
-import {MapDef} from "@lodestar/utils";
 
 const PROPOSER_PRESERVE_EPOCHS = 2;
 
 export type ProposerPreparationData = routes.validator.ProposerPreparationData;
 
 export class BeaconProposerCache {
-  private readonly feeRecipientByValidatorIndex: MapDef<number, {epoch: Epoch; feeRecipient: string}>;
-  constructor(opts: {suggestedFeeRecipient: string}) {
-    this.feeRecipientByValidatorIndex = new MapDef(() => ({
-      epoch: 0,
-      feeRecipient: opts.suggestedFeeRecipient,
-    }));
+  private readonly feeRecipientByValidatorIndex: Map<number, {epoch: Epoch; feeRecipient: string}>;
+  constructor(readonly opts: {suggestedFeeRecipient: string}) {
+    this.feeRecipientByValidatorIndex = new Map();
   }
 
   add(epoch: Epoch, {validatorIndex, feeRecipient}: ProposerPreparationData): void {
@@ -30,7 +26,7 @@ export class BeaconProposerCache {
   }
 
   getOrDefault(proposerIndex: number): string {
-    return this.feeRecipientByValidatorIndex.getOrDefault(proposerIndex).feeRecipient;
+    return this.feeRecipientByValidatorIndex.get(proposerIndex)?.feeRecipient ?? this.opts.suggestedFeeRecipient;
   }
 
   get(proposerIndex: number): string | undefined {


### PR DESCRIPTION
**Motivation**

If we don't have the proposer index in cache when having to build a block, we create a default entry [here](https://github.com/ChainSafe/lodestar/blob/d9cc6b90f70c4740e9d28b50f01d90d1a25b620e/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts#L196). This shouldn't happen in normal circumstances as proposers are registered beforehand, however if you produce a block each slot for testing purposes this affects the custody of the node as it will have up to 32 validators in proposer cache (assuming a block each slot) and since we never reduce the cgc it will stay at that value.

Logs from Ethpandaops from a node without attached validators but that's producing a block each slot
```
Oct-14 09:12:00.005[chain]         verbose: Updated target custody group count finalizedEpoch=272653, validatorCount=32, targetCustodyGroupCount=33
```
```
Oct-14 09:12:00.008[network]         debug: Updated cgc field in ENR custodyGroupCount=33
```

**Description**

Do not create default cache entry for unknown proposers by using normal `Map` and just fall back to `suggestedFeeRecipient` if there isn't any value. The behavior from a caller perspective stays the same but we no longer create a proposer cache entry for unknown proposers.

