### PR TITLE
test: ensure sim tests run successfully on mac and windows

### DIFF
--- a/packages/beacon-node/test/scripts/el-interop/ethereumjsdocker/post-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/ethereumjsdocker/post-merge.sh
@@ -5,4 +5,4 @@ currentDir=$(pwd)
 
 . $scriptDir/common-setup.sh
 
-docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --name custom-execution --network host -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --dataDir /data/ethereumjs --gethGenesis /data/genesis.json --rpc --rpcEngineAddr 0.0.0.0 --rpcAddr 0.0.0.0 --rpcEngine --jwt-secret /data/jwtsecret --logLevel debug --isSingleNode
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --name custom-execution -p $ETH_PORT:$ETH_PORT -p $ENGINE_PORT:$ENGINE_PORT -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --dataDir /data/ethereumjs --gethGenesis /data/genesis.json --rpc --rpcEngineAddr 0.0.0.0 --rpcAddr 0.0.0.0 --rpcEngine --jwt-secret /data/jwtsecret --logLevel debug --isSingleNode

--- a/packages/beacon-node/test/scripts/el-interop/gethdocker/post-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/gethdocker/post-merge.sh
@@ -5,4 +5,4 @@ currentDir=$(pwd)
 
 . $scriptDir/common-setup.sh
 
-docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --name custom-execution --network host -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --http -http.api "engine,net,eth,miner" --http.port $ETH_PORT --authrpc.port $ENGINE_PORT --authrpc.jwtsecret /data/jwtsecret --allow-insecure-unlock --unlock $pubKey --password /data/password.txt --datadir /data/geth --syncmode full
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --name custom-execution -p $ETH_PORT:$ETH_PORT -p $ENGINE_PORT:$ENGINE_PORT -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --http --http.addr 0.0.0.0 -http.api "engine,net,eth,miner" --http.port $ETH_PORT --authrpc.port $ENGINE_PORT --authrpc.addr 0.0.0.0 --authrpc.jwtsecret /data/jwtsecret --allow-insecure-unlock --unlock $pubKey --password /data/password.txt --datadir /data/geth --syncmode full

--- a/packages/beacon-node/test/scripts/el-interop/gethdocker/pre-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/gethdocker/pre-merge.sh
@@ -6,4 +6,4 @@ currentDir=$(pwd)
 . $scriptDir/common-setup.sh
 
 # EL_BINARY_DIR refers to the local docker image build from kiln/gethdocker folder
-docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --name custom-execution --network host -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --http -http.api "engine,net,eth,miner" --http.port $ETH_PORT --authrpc.port $ENGINE_PORT --authrpc.jwtsecret /data/jwtsecret --allow-insecure-unlock --unlock $pubKey --password /data/password.txt --datadir /data/geth --nodiscover --mine --syncmode full
+docker run --rm -u $(id -u ${USER}):$(id -g ${USER}) --name custom-execution -p $ETH_PORT:$ETH_PORT -p $ENGINE_PORT:$ENGINE_PORT -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --http --http.addr 0.0.0.0 -http.api "engine,net,eth,miner" --http.port $ETH_PORT --authrpc.port $ENGINE_PORT --authrpc.addr 0.0.0.0 --authrpc.jwtsecret /data/jwtsecret --allow-insecure-unlock --unlock $pubKey --password /data/password.txt --datadir /data/geth --nodiscover --mine --syncmode full

--- a/packages/beacon-node/test/scripts/el-interop/netherminddocker/post-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/netherminddocker/post-merge.sh
@@ -13,4 +13,4 @@ else
 fi;
 
 
-docker run --rm --network host --name custom-execution -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data/nethermind --config $configVector --Merge.TerminalTotalDifficulty $TTD --JsonRpc.JwtSecretFile /data/jwtsecret --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.AdditionalRpcUrls "http://localhost:$ETH_PORT|http|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:$ENGINE_PORT|http|eth;engine" --Sync.SnapSync false
+docker run --rm -p $ETH_PORT:$ETH_PORT -p $ENGINE_PORT:$ENGINE_PORT --name custom-execution -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data/nethermind --config $configVector --Merge.TerminalTotalDifficulty $TTD --JsonRpc.JwtSecretFile /data/jwtsecret --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.AdditionalRpcUrls "http://localhost:$ETH_PORT|http|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:$ENGINE_PORT|http|eth;engine" --Sync.SnapSync false

--- a/packages/beacon-node/test/scripts/el-interop/netherminddocker/pre-merge.sh
+++ b/packages/beacon-node/test/scripts/el-interop/netherminddocker/pre-merge.sh
@@ -7,4 +7,4 @@ currentDir=$(pwd)
 
 echo "sleeping for 10 seconds..."
 
-docker run --rm --network host --name custom-execution -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data/nethermind --config themerge_kiln_m2 --Merge.TerminalTotalDifficulty $TTD --JsonRpc.JwtSecretFile /data/jwtsecret --Merge.Enabled true  --Init.DiagnosticMode=None --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.AdditionalRpcUrls "http://localhost:$ETH_PORT|http|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:$ENGINE_PORT|http|eth;engine" --Sync.SnapSync false
+docker run --rm -p $ETH_PORT:$ETH_PORT -p $ENGINE_PORT:$ENGINE_PORT --name custom-execution -v $currentDir/$DATA_DIR:/data $EL_BINARY_DIR --datadir /data/nethermind --config themerge_kiln_m2 --Merge.TerminalTotalDifficulty $TTD --JsonRpc.JwtSecretFile /data/jwtsecret --Merge.Enabled true  --Init.DiagnosticMode=None --JsonRpc.Enabled true --JsonRpc.Host 0.0.0.0 --JsonRpc.AdditionalRpcUrls "http://localhost:$ETH_PORT|http|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:$ENGINE_PORT|http|eth;engine" --Sync.SnapSync false


### PR DESCRIPTION
**Motivation**

The goal of this PR is to enable sim tests to be run on Mac and Windows successfully

**Description**

This PR changes the docker command in the shell scripts:
- packages/beacon-node/test/scripts/el-interop/netherminddocker/pre-merge.sh
- packages/beacon-node/test/scripts/el-interop/netherminddocker/post-merge.sh
- packages/beacon-node/test/scripts/el-interop/gethdocker/pre-merge.sh
- packages/beacon-node/test/scripts/el-interop/gethdocker/post-merge.sh
- packages/beacon-node/test/scripts/el-interop/ethereumjsdocker/post-merge.sh
from using "--network host" to using port mapping "-p HOST_PORT:CLIENT_PORT" since using the host network only works on Linux, while port mapping works on all devices.

This PR resolves issue #6318 

Closes #6318 

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout fix/sim-tests-on-mac-and-windows
cd lodestar
# Show the problematic line
cat packages/beacon-node/test/scripts/el-interop/gethdocker/post-merge.sh | grep "network host"
Then compare networks:
# What container sees with --network host
docker run --rm --network host alpine:latest ip addr show eth0 | grep "inet "

# Your actual Mac network
ifconfig en0 | grep "inet " | head -1

Expected behavior (on Linux):
Container with --network host sees host's real network interfaces
Container's eth0 IP = Host's eth0 IP

Actual behavior (on Mac/Windows):
Container with --network host sees the Linux VM's network
Container's eth0 IP ≠ Mac's en0 IP
```
-->
