### PR TITLE
fix: ensure data column sidecars respect blob limit

### DIFF
--- a/packages/beacon-node/src/chain/errors/dataColumnSidecarError.ts
+++ b/packages/beacon-node/src/chain/errors/dataColumnSidecarError.ts
@@ -8,6 +8,7 @@ export enum DataColumnSidecarErrorCode {
   MISMATCHED_LENGTHS = "DATA_COLUMN_SIDECAR_ERROR_MISMATCHED_LENGTHS",
   INVALID_SUBNET = "DATA_COLUMN_SIDECAR_ERROR_INVALID_SUBNET",
   INVALID_KZG_PROOF = "DATA_COLUMN_SIDECAR_ERROR_INVALID_KZG_PROOF",
+  TOO_MANY_KZG_COMMITMENTS = "DATA_COLUMN_SIDECAR_ERROR_TOO_MANY_KZG_COMMITMENTS",
 
   // Validation errors when validating against an existing block
 
@@ -43,6 +44,13 @@ export type DataColumnSidecarErrorType =
       proofsLength: number;
     }
   | {code: DataColumnSidecarErrorCode.INVALID_SUBNET; columnIdx: number; gossipSubnet: SubnetID}
+  | {
+      code: DataColumnSidecarErrorCode.TOO_MANY_KZG_COMMITMENTS;
+      slot: number;
+      columnIdx: number;
+      count: number;
+      limit: number;
+    }
   | {code: DataColumnSidecarErrorCode.ALREADY_KNOWN; columnIdx: number; slot: Slot}
   | {code: DataColumnSidecarErrorCode.FUTURE_SLOT; blockSlot: Slot; currentSlot: Slot}
   | {code: DataColumnSidecarErrorCode.WOULD_REVERT_FINALIZED_SLOT; blockSlot: Slot; finalizedSlot: Slot}


### PR DESCRIPTION
**Motivation**

See https://github.com/ethereum/consensus-specs/pull/4650

**Description**

 Ensure data column sidecars respect blob limit by checking that `kzgCommitments.length` of each data column sidecar does not exceed `getMaxBlobsPerBlock(epoch)`.