### PR TITLE
chore: simplify start epoch in head chain range sync

### DIFF
--- a/packages/beacon-node/src/sync/utils/remoteSyncType.ts
+++ b/packages/beacon-node/src/sync/utils/remoteSyncType.ts
@@ -134,8 +134,8 @@ export function getRangeSyncTarget(
   return {
     syncType: RangeSyncType.Head,
     // The new peer has the same finalized (earlier filters should prevent a peer with an
-    // earlier finalized chain from reaching here).
-    startEpoch: Math.min(computeEpochAtSlot(local.headSlot), remote.finalizedEpoch),
+    // earlier finalized chain from reaching here) and local head will always be >= local finalized.
+    startEpoch: computeEpochAtSlot(local.headSlot),
     target: {
       slot: remote.headSlot,
       root: remote.headRoot,


### PR DESCRIPTION
This simplifies the calculation of `startEpoch` in head chain range sync.

We check the remote finalized epoch against ours here

https://github.com/ChainSafe/lodestar/blob/d9cc6b90f70c4740e9d28b50f01d90d1a25b620e/packages/beacon-node/src/sync/utils/remoteSyncType.ts#L33

This means `remote.finalizedEpoch == local.finalizedEpoch` in this case and local head epoch should always be >= finalized epoch which means we can simplify use  epoch of `local.headSlot` here.

cc @twoeths 