### PR TITLE
fix: ignore already known data column sidecars

### DIFF
--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -39,6 +39,7 @@ import {
   BlockError,
   BlockErrorCode,
   BlockGossipError,
+  DataColumnSidecarErrorCode,
   DataColumnSidecarGossipError,
   GossipAction,
   GossipActionError,
@@ -304,7 +305,11 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
           ...blockInput.getLogMeta(),
           index: dataColumnSidecar.index,
         });
-        return blockInput;
+        throw new DataColumnSidecarGossipError(GossipAction.IGNORE, {
+          code: DataColumnSidecarErrorCode.ALREADY_KNOWN,
+          columnIdx: dataColumnSidecar.index,
+          slot,
+        });
       }
     }
 


### PR DESCRIPTION
**Motivation**

This was brought up in the Fusaka bug bounty, when we receive a already known data column sidecar with the same block header and column index, the gossip message is accepted and rebroadcast without any additional verification.

This allows a malicious peer to send a data column sidecar with the same block header and column index but an invalid block header signature which we would accept and rebroadcast and get downscored by our peers.

**Description**

Ignore already known data column sidecars (based on block header and column index). We could also consider to run `validateGossipDataColumnSidecar` on those sidecars to penalize the node sending us the data but it's just additional work for us and `GossipAction.IGNORE` seems sufficient.

