### PR TITLE
chore: unhide prune history option

### DIFF
--- a/docs/pages/run/beacon-management/data-retention.md
+++ b/docs/pages/run/beacon-management/data-retention.md
@@ -53,6 +53,6 @@ Logs can also become quite large so please check out the section on [log managem
 
 There is really only one flag that is needed to manage the data for Lodestar, [`--dataDir`](./beacon-cli#--datadir). Other than that handling log management is really the heart of the data management story. Beacon node data is what it is. Depending on the execution client that is chosen, there may be flags to help with data storage growth but that is outside the scope of this document.
 
-<!-- ### Pruning history
+### Pruning history
 
-For validators seeking to store the least amount of data possible, and store no historical data, use [`--chain.pruneHistory`](./beacon-cli#--chainprunehistory). This flag will configure the beacon node to continually prune all old blocks (older than `config.MIN_EPOCHS_FOR_BLOCK_REQUESTS`) and all prior finalized states. -->
+For validators seeking to store the least amount of data possible, and store no historical data, use [`--chain.pruneHistory`](./beacon-cli#--chainprunehistory). This flag will configure the beacon node to continually prune all old blocks (older than `config.MIN_EPOCHS_FOR_BLOCK_REQUESTS`) and all prior finalized states.

--- a/docs/pages/run/beacon-management/data-retention.md
+++ b/docs/pages/run/beacon-management/data-retention.md
@@ -57,4 +57,4 @@ There is really only one flag that is needed to manage the data for Lodestar, [`
 
 For validators seeking to store the least amount of data possible, and store no historical data, use [`--chain.pruneHistory`](./beacon-cli#--chainprunehistory). This flag will configure the beacon node to continually prune all old blocks (older than `config.MIN_EPOCHS_FOR_BLOCK_REQUESTS`) and all prior finalized states.
 
-**Note:** On first startup with an existing large database, the initial pruning process can be slow.
+**Note:** The initial pruning process can be slow on first startup with an existing large database.

--- a/docs/pages/run/beacon-management/data-retention.md
+++ b/docs/pages/run/beacon-management/data-retention.md
@@ -56,3 +56,5 @@ There is really only one flag that is needed to manage the data for Lodestar, [`
 ### Pruning history
 
 For validators seeking to store the least amount of data possible, and store no historical data, use [`--chain.pruneHistory`](./beacon-cli#--chainprunehistory). This flag will configure the beacon node to continually prune all old blocks (older than `config.MIN_EPOCHS_FOR_BLOCK_REQUESTS`) and all prior finalized states.
+
+**Note:** On first startup with an existing large database, the initial pruning process can be slow.

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1878,7 +1878,7 @@ export function createLodestarMetrics(
       fetchKeys: register.histogram({
         name: "lodestar_prune_history_fetch_keys_time_seconds",
         help: "Time to fetch keys in seconds",
-        buckets: [0.001, 0.01, 0.1, 1],
+        buckets: [0.001, 0.01, 0.1, 0.3, 0.5, 1],
       }),
 
       pruneKeys: register.histogram({

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -317,7 +317,6 @@ Will double processing times. Use only for debugging purposes.",
   },
 
   "chain.pruneHistory": {
-    hidden: true,
     description: "Prune historical blocks and state",
     type: "boolean",
     default: defaultOptions.chain.pruneHistory,


### PR DESCRIPTION
Reverts https://github.com/ChainSafe/lodestar/pull/7448 to unhide prune history option. I've been running this on mainnet for a while and it's seems pretty stable with no noticable impact on performance. The feature is already widely used even though it was hidden so might as well show it in our docs.


Metrics from my node

<img width="1888" height="340" alt="image" src="https://github.com/user-attachments/assets/223b7e6b-101e-4b4f-b06a-6d74f830bf96" />

I did a few tweaks to how we query keys but nothing really improved the fetch keys duration.

Caveat still remains that it's quite slow on first startup if the previous db is large but that's a one time operation.

Closes https://github.com/ChainSafe/lodestar/issues/7556