### PR TITLE
chore: fix typo in test/unit/sanityCheck.test.ts hiding root cause of error

### DIFF
--- a/packages/state-transition/test/unit/sanityCheck.test.ts
+++ b/packages/state-transition/test/unit/sanityCheck.test.ts
@@ -12,7 +12,7 @@ describe("Perf test sanity check", () => {
 
   const numValidators = 250000;
   const targetStakeYWei = 7;
-  const targetStake = BigInt(targetStakeYWei) * BigInt(1) ** BigInt(15);
+  const targetStake = BigInt(targetStakeYWei) * BigInt(10) ** BigInt(15);
 
   beforeAll(() => {
     expect(perfStateId).toEqualWithMessage(`${numValidators} vs - ${targetStakeYWei}PWei`, "perfStateId has changed");


### PR DESCRIPTION
Replace `BigInt(1) ** BigInt(15);` to `BigInt(10) ** BigInt(15);`

Fixes 6358

**Motivation**

When trying to fix flaky `test/unit/sanityCheck.test.ts` test in https://github.com/ChainSafe/lodestar/issues/6358 I noticed the test has a typo causing it to pass when I don't think it should. I don't have time to fix the underlying issue but thought I should let you know there is a deeper issue.

**Description**

It appears there to be a typo in the test, multiplying 1^15 instead of 10^15. The test now fails properly instead of incorrectly passing.

**Steps to test or reproduce**
```sh
git checkout matthandzel/fixing-typo-in-sanity-check-test
yarn install
yarn build
yarn vitest run test/unit/sanityCheck.test.ts
```
