### PR TITLE
chore: decompose VoteTracker

### DIFF
--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -105,6 +105,7 @@ export function initializeForkChoice(
       },
       currentSlot
     ),
+    state.validators.length,
     metrics,
     opts,
     logger

--- a/packages/beacon-node/test/mocks/fork-choice/reorg.ts
+++ b/packages/beacon-node/test/mocks/fork-choice/reorg.ts
@@ -36,9 +36,10 @@ export class ReorgedForkChoice extends ForkChoice {
     fcStore: IForkChoiceStore,
     /** The underlying representation of the block DAG. */
     protoArray: ProtoArray,
+    validatorCount: number,
     opts?: ForkChoiceOpts
   ) {
-    super(config, fcStore, protoArray, null, opts);
+    super(config, fcStore, protoArray, validatorCount, null, opts);
     this._fcStore = fcStore;
   }
 

--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -197,7 +197,7 @@ export type MockedForkChoice = Mocked<ForkChoice>;
 
 export function getMockedForkChoice(): MockedForkChoice {
   // ForkChoice package is mocked globally
-  return vi.mocked(new ForkChoice({} as any, {} as any, {} as any, {} as any));
+  return vi.mocked(new ForkChoice({} as any, {} as any, {} as any, {} as any, {} as any));
 }
 
 // To avoid loading the package in test while mocked, exporting frequently used types and constants

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -118,7 +118,7 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
         justifiedBalancesGetter: () => originalState.epochCtx.effectiveBalanceIncrements,
         equivocatingIndices: new Set(),
       };
-      forkchoice = new ForkChoice(originalState.config, fcStore, protoArray, null);
+      forkchoice = new ForkChoice(originalState.config, fcStore, protoArray, originalState.validators.length, null);
     },
     5 * 60 * 1000
   );

--- a/packages/beacon-node/test/unit/util/dependentRoot.test.ts
+++ b/packages/beacon-node/test/unit/util/dependentRoot.test.ts
@@ -14,7 +14,7 @@ describe("util / getShufflingDependentRoot", () => {
   const blockEpoch = computeEpochAtSlot(headBattHeadBlock.slot);
 
   beforeEach(() => {
-    forkchoiceStub = vi.mocked(new ForkChoice({} as any, {} as any, {} as any, {} as any));
+    forkchoiceStub = vi.mocked(new ForkChoice({} as any, {} as any, {} as any, {} as any, {} as any));
   });
 
   afterEach(() => {

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -71,6 +71,9 @@ export type UpdateAndGetHeadOpt =
   | {mode: UpdateHeadOpt.GetProposerHead; secFromSlot: number; slot: Slot}
   | {mode: UpdateHeadOpt.GetPredictedProposerHead; secFromSlot: number; slot: Slot};
 
+// the initial vote epoch for all validators
+const INIT_VOTE_EPOCH: Epoch = 0;
+
 /**
  * Provides an implementation of "Ethereum Consensus -- Beacon Chain Fork Choice":
  *
@@ -149,7 +152,7 @@ export class ForkChoice implements IForkChoice {
     this.voteCurrentIndices = new Array(validatorCount).fill(NULL_VOTE_INDEX);
     this.voteNextIndices = new Array(validatorCount).fill(NULL_VOTE_INDEX);
     // when compute deltas, we ignore epoch if voteNextIndex is NULL_VOTE_INDEX anyway
-    this.voteNextEpochs = new Array(validatorCount).fill(0);
+    this.voteNextEpochs = new Array(validatorCount).fill(INIT_VOTE_EPOCH);
 
     metrics?.forkChoice.votes.addCollect(() => {
       metrics.forkChoice.votes.set(this.voteNextEpochs.length);
@@ -1461,7 +1464,7 @@ export class ForkChoice implements IForkChoice {
 
     const existingNextEpoch = this.voteNextEpochs[validatorIndex];
 
-    if (existingNextEpoch === undefined) {
+    if (existingNextEpoch === undefined || existingNextEpoch === INIT_VOTE_EPOCH) {
       this.voteCurrentIndices[validatorIndex] = NULL_VOTE_INDEX;
       this.voteNextIndices[validatorIndex] = nextIndex;
       this.voteNextEpochs[validatorIndex] = nextEpoch;

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -36,9 +36,10 @@ import {
   HEX_ZERO_HASH,
   LVHExecResponse,
   MaybeValidExecutionStatus,
+  NULL_VOTE_INDEX,
   ProtoBlock,
   ProtoNode,
-  VoteTracker,
+  VoteIndex,
 } from "../protoArray/interface.js";
 import {ProtoArray} from "../protoArray/protoArray.js";
 import {ForkChoiceError, ForkChoiceErrorCode, InvalidAttestationCode, InvalidBlockCode} from "./errors.js";
@@ -47,7 +48,6 @@ import {
   AncestorStatus,
   EpochDifference,
   IForkChoice,
-  LatestMessage,
   NotReorgedReason,
   PowBlockHex,
   ShouldOverrideForkChoiceUpdateResult,
@@ -91,11 +91,12 @@ export type UpdateAndGetHeadOpt =
 export class ForkChoice implements IForkChoice {
   irrecoverableError?: Error;
   /**
-   * Votes currently tracked in the protoArray
-   * Indexed by validator index
-   * Each vote contains the latest message and previous message
+   * Votes currently tracked in the protoArray. Instead of tracking a VoteTracker of currentIndex, nextIndex and epoch,
+   * we decompose the struct and track them in 3 separate arrays for performance reason.
    */
-  private readonly votes: VoteTracker[] = [];
+  private readonly voteCurrentIndices: VoteIndex[] = [];
+  private readonly voteNextIndices: VoteIndex[] = [];
+  private readonly voteNextEpochs: Epoch[] = [];
 
   /**
    * Attestations that arrived at the current slot and must be queued for later processing.
@@ -138,15 +139,20 @@ export class ForkChoice implements IForkChoice {
     private readonly fcStore: IForkChoiceStore,
     /** The underlying representation of the block DAG. */
     private readonly protoArray: ProtoArray,
+    validatorCount: number,
     readonly metrics: ForkChoiceMetrics | null,
     private readonly opts?: ForkChoiceOpts,
     private readonly logger?: Logger
   ) {
     this.head = this.updateHead();
     this.balances = this.fcStore.justified.balances;
+    this.voteCurrentIndices = new Array(validatorCount).fill(NULL_VOTE_INDEX);
+    this.voteNextIndices = new Array(validatorCount).fill(NULL_VOTE_INDEX);
+    // when compute deltas, we ignore epoch if voteNextIndex is NULL_VOTE_INDEX anyway
+    this.voteNextEpochs = new Array(validatorCount).fill(0);
 
     metrics?.forkChoice.votes.addCollect(() => {
-      metrics.forkChoice.votes.set(this.votes.length);
+      metrics.forkChoice.votes.set(this.voteNextEpochs.length);
       metrics.forkChoice.queuedAttestations.set(this.queuedAttestationsPreviousSlot);
       metrics.forkChoice.validatedAttestationDatas.set(this.validatedAttestationDatas.size);
       metrics.forkChoice.balancesLength.set(this.balances.length);
@@ -455,7 +461,8 @@ export class ForkChoice implements IForkChoice {
       newVoteValidators,
     } = computeDeltas(
       this.protoArray.nodes.length,
-      this.votes,
+      this.voteCurrentIndices,
+      this.voteNextIndices,
       oldBalances,
       newBalances,
       this.fcStore.equivocatingIndices
@@ -839,17 +846,6 @@ export class ForkChoice implements IForkChoice {
     }
   }
 
-  getLatestMessage(validatorIndex: ValidatorIndex): LatestMessage | undefined {
-    const vote = this.votes[validatorIndex];
-    if (vote === undefined) {
-      return undefined;
-    }
-    return {
-      epoch: vote.nextEpoch,
-      root: vote.nextIndex === null ? HEX_ZERO_HASH : this.protoArray.nodes[vote.nextIndex].blockRoot,
-    };
-  }
-
   /**
    * Call `onTick` for all slots between `fcStore.getCurrentSlot()` and the provided `currentSlot`.
    * This should only be called once per slot because:
@@ -967,28 +963,26 @@ export class ForkChoice implements IForkChoice {
   prune(finalizedRoot: RootHex): ProtoBlock[] {
     const prunedNodes = this.protoArray.maybePrune(finalizedRoot);
     const prunedCount = prunedNodes.length;
-    for (let i = 0; i < this.votes.length; i++) {
-      const vote = this.votes[i];
-      // validator has never voted
-      if (vote === undefined) {
-        continue;
-      }
+    for (let i = 0; i < this.voteNextEpochs.length; i++) {
+      const currentIndex = this.voteCurrentIndices[i];
 
-      if (vote.currentIndex !== null) {
-        if (vote.currentIndex >= prunedCount) {
-          vote.currentIndex -= prunedCount;
+      if (currentIndex !== NULL_VOTE_INDEX) {
+        if (currentIndex >= prunedCount) {
+          this.voteCurrentIndices[i] = currentIndex - prunedCount;
         } else {
           // the vote was for a pruned proto node
-          vote.currentIndex = null;
+          this.voteCurrentIndices[i] = NULL_VOTE_INDEX;
         }
       }
 
-      if (vote.nextIndex !== null) {
-        if (vote.nextIndex >= prunedCount) {
-          vote.nextIndex -= prunedCount;
+      const nextIndex = this.voteNextIndices[i];
+
+      if (nextIndex !== NULL_VOTE_INDEX) {
+        if (nextIndex >= prunedCount) {
+          this.voteNextIndices[i] = nextIndex - prunedCount;
         } else {
           // the vote was for a pruned proto node
-          vote.nextIndex = null;
+          this.voteNextIndices[i] = NULL_VOTE_INDEX;
         }
       }
     }
@@ -1455,25 +1449,26 @@ export class ForkChoice implements IForkChoice {
   }
 
   /**
-   * Add a validator's latest message to the tracked votes
+   * Add a validator's latest message to the tracked votes.
+   * Always sync voteCurrentIndices and voteNextIndices so that it'll not throw in computeDeltas()
    */
   private addLatestMessage(validatorIndex: ValidatorIndex, nextEpoch: Epoch, nextRoot: RootHex): void {
-    const vote = this.votes[validatorIndex];
     // should not happen, attestation is validated before this step
     const nextIndex = this.protoArray.indices.get(nextRoot);
     if (nextIndex === undefined) {
       throw new Error(`Could not find proto index for nextRoot ${nextRoot}`);
     }
 
-    if (vote === undefined) {
-      this.votes[validatorIndex] = {
-        currentIndex: null,
-        nextIndex,
-        nextEpoch,
-      };
-    } else if (nextEpoch > vote.nextEpoch) {
-      vote.nextIndex = nextIndex;
-      vote.nextEpoch = nextEpoch;
+    const existingNextEpoch = this.voteNextEpochs[validatorIndex];
+
+    if (existingNextEpoch === undefined) {
+      this.voteCurrentIndices[validatorIndex] = NULL_VOTE_INDEX;
+      this.voteNextIndices[validatorIndex] = nextIndex;
+      this.voteNextEpochs[validatorIndex] = nextEpoch;
+    } else if (nextEpoch > existingNextEpoch) {
+      // nextIndex is transfered to currentIndex in computeDeltas()
+      this.voteNextIndices[validatorIndex] = nextIndex;
+      this.voteNextEpochs[validatorIndex] = nextEpoch;
     }
     // else its an old vote, don't count it
   }

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -97,9 +97,9 @@ export class ForkChoice implements IForkChoice {
    * Votes currently tracked in the protoArray. Instead of tracking a VoteTracker of currentIndex, nextIndex and epoch,
    * we decompose the struct and track them in 3 separate arrays for performance reason.
    */
-  private readonly voteCurrentIndices: VoteIndex[] = [];
-  private readonly voteNextIndices: VoteIndex[] = [];
-  private readonly voteNextEpochs: Epoch[] = [];
+  private readonly voteCurrentIndices: VoteIndex[];
+  private readonly voteNextIndices: VoteIndex[];
+  private readonly voteNextEpochs: Epoch[];
 
   /**
    * Attestations that arrived at the current slot and must be queued for later processing.
@@ -147,12 +147,14 @@ export class ForkChoice implements IForkChoice {
     private readonly opts?: ForkChoiceOpts,
     private readonly logger?: Logger
   ) {
-    this.head = this.updateHead();
-    this.balances = this.fcStore.justified.balances;
+    // initialize votes, they will grow in addLatestMessage() function below
     this.voteCurrentIndices = new Array(validatorCount).fill(NULL_VOTE_INDEX);
     this.voteNextIndices = new Array(validatorCount).fill(NULL_VOTE_INDEX);
     // when compute deltas, we ignore epoch if voteNextIndex is NULL_VOTE_INDEX anyway
     this.voteNextEpochs = new Array(validatorCount).fill(INIT_VOTE_EPOCH);
+
+    this.head = this.updateHead();
+    this.balances = this.fcStore.justified.balances;
 
     metrics?.forkChoice.votes.addCollect(() => {
       metrics.forkChoice.votes.set(this.voteNextEpochs.length);
@@ -1462,13 +1464,16 @@ export class ForkChoice implements IForkChoice {
       throw new Error(`Could not find proto index for nextRoot ${nextRoot}`);
     }
 
-    const existingNextEpoch = this.voteNextEpochs[validatorIndex];
+    // ensure there is no undefined entries in Votes arrays
+    if (this.voteNextEpochs.length < validatorIndex + 1) {
+      for (let i = this.voteNextEpochs.length; i < validatorIndex + 1; i++) {
+        this.voteNextEpochs[i] = INIT_VOTE_EPOCH;
+        this.voteCurrentIndices[i] = this.voteNextIndices[i] = NULL_VOTE_INDEX;
+      }
+    }
 
-    if (existingNextEpoch === undefined || existingNextEpoch === INIT_VOTE_EPOCH) {
-      this.voteCurrentIndices[validatorIndex] = NULL_VOTE_INDEX;
-      this.voteNextIndices[validatorIndex] = nextIndex;
-      this.voteNextEpochs[validatorIndex] = nextEpoch;
-    } else if (nextEpoch > existingNextEpoch) {
+    const existingNextEpoch = this.voteNextEpochs[validatorIndex];
+    if (existingNextEpoch === INIT_VOTE_EPOCH || nextEpoch > existingNextEpoch) {
       // nextIndex is transfered to currentIndex in computeDeltas()
       this.voteNextIndices[validatorIndex] = nextIndex;
       this.voteNextEpochs[validatorIndex] = nextEpoch;

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -3,16 +3,7 @@ import {
   DataAvailabilityStatus,
   EffectiveBalanceIncrements,
 } from "@lodestar/state-transition";
-import {
-  AttesterSlashing,
-  BeaconBlock,
-  Epoch,
-  IndexedAttestation,
-  Root,
-  RootHex,
-  Slot,
-  ValidatorIndex,
-} from "@lodestar/types";
+import {AttesterSlashing, BeaconBlock, Epoch, IndexedAttestation, Root, RootHex, Slot} from "@lodestar/types";
 import {LVHExecResponse, MaybeValidExecutionStatus, ProtoBlock, ProtoNode} from "../protoArray/interface.js";
 import {UpdateAndGetHeadOpt} from "./forkChoice.js";
 import {CheckpointWithHex} from "./store.js";
@@ -178,7 +169,6 @@ export interface IForkChoice {
    * https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/fork-choice.md#on_attester_slashing
    */
   onAttesterSlashing(slashing: AttesterSlashing): void;
-  getLatestMessage(validatorIndex: ValidatorIndex): LatestMessage | undefined;
   /**
    * Call `onTick` for all slots between `fcStore.getCurrentSlot()` and the provided `currentSlot`.
    */
@@ -261,9 +251,4 @@ export type PowBlockHex = {
   blockHash: RootHex;
   parentHash: RootHex;
   totalDifficulty: bigint;
-};
-
-export type LatestMessage = {
-  epoch: Epoch;
-  root: RootHex;
 };

--- a/packages/fork-choice/src/protoArray/computeDeltas.ts
+++ b/packages/fork-choice/src/protoArray/computeDeltas.ts
@@ -138,10 +138,8 @@ export function computeDeltas(
   } // end validator loop
 
   if (deltas.length !== numProtoNodes) {
-    // deltas array could be growed in the loop, especially if we mistakenly set the [NULL_VOTE_INDEX] to it , we check to be safe
-    throw new Error(
-      `deltas length mismatch: expected ${numProtoNodes}, got ${deltas.length}`
-    );
+    // deltas array could be growed in the loop, especially if we mistakenly set the [NULL_VOTE_INDEX] to it , just to be safe
+    throw new Error(`deltas length mismatch: expected ${numProtoNodes}, got ${deltas.length}`);
   }
 
   return {

--- a/packages/fork-choice/src/protoArray/computeDeltas.ts
+++ b/packages/fork-choice/src/protoArray/computeDeltas.ts
@@ -1,7 +1,7 @@
 import {EffectiveBalanceIncrements} from "@lodestar/state-transition";
 import {ValidatorIndex} from "@lodestar/types";
 import {ProtoArrayError, ProtoArrayErrorCode} from "./errors.js";
-import {VoteTracker} from "./interface.js";
+import {NULL_VOTE_INDEX, VoteIndex} from "./interface.js";
 
 // reuse arrays to avoid memory reallocation and gc
 const deltas = new Array<number>();
@@ -29,17 +29,29 @@ export type DeltasResult = {
  */
 export function computeDeltas(
   numProtoNodes: number,
-  votes: VoteTracker[],
+  voteCurrentIndices: VoteIndex[],
+  voteNextIndices: VoteIndex[],
   oldBalances: EffectiveBalanceIncrements,
   newBalances: EffectiveBalanceIncrements,
   equivocatingIndices: Set<ValidatorIndex>
 ): DeltasResult {
+  if (voteCurrentIndices.length !== voteNextIndices.length) {
+    throw new Error(
+      `voteCurrentIndices and voteNextIndices must have the same length: ${voteCurrentIndices.length} !== ${voteNextIndices.length}`
+    );
+  }
+
+  if (numProtoNodes >= NULL_VOTE_INDEX) {
+    // this never happen in practice, but we check to be safe
+    throw new Error(`numProtoNodes must be less than NULL_VOTE_INDEX: ${numProtoNodes} >= ${NULL_VOTE_INDEX}`);
+  }
+
   deltas.length = numProtoNodes;
   deltas.fill(0);
 
   // avoid creating new variables in the loop to potentially reduce GC pressure
   let oldBalance: number, newBalance: number;
-  let currentIndex: number | null, nextIndex: number | null;
+  let currentIndex: VoteIndex, nextIndex: VoteIndex;
   // sort equivocating indices to avoid Set.has() in the loop
   const equivocatingArray = Array.from(equivocatingIndices).sort((a, b) => a - b);
   let equivocatingIndex = 0;
@@ -51,16 +63,15 @@ export function computeDeltas(
   let unchangedVoteValidators = 0;
   let newVoteValidators = 0;
 
-  for (let vIndex = 0; vIndex < votes.length; vIndex++) {
-    const vote = votes[vIndex];
+  for (let vIndex = 0; vIndex < voteNextIndices.length; vIndex++) {
+    currentIndex = voteCurrentIndices[vIndex];
+    nextIndex = voteNextIndices[vIndex];
     // There is no need to create a score change if the validator has never voted or both of their
     // votes are for the zero hash (genesis block)
-    if (vote === undefined) {
+    if (currentIndex === NULL_VOTE_INDEX && nextIndex === NULL_VOTE_INDEX) {
       oldInactiveValidators++;
       continue;
     }
-    currentIndex = vote.currentIndex;
-    nextIndex = vote.nextIndex;
 
     // IF the validator was not included in the _old_ balances (i.e. it did not exist yet)
     // then say its balance was 0
@@ -75,7 +86,7 @@ export function computeDeltas(
 
     if (vIndex === equivocatingValidatorIndex) {
       // this function could be called multiple times but we only want to process slashing validator for 1 time
-      if (currentIndex !== null) {
+      if (currentIndex !== NULL_VOTE_INDEX) {
         if (currentIndex >= numProtoNodes) {
           throw new ProtoArrayError({
             code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
@@ -84,7 +95,7 @@ export function computeDeltas(
         }
         deltas[currentIndex] -= oldBalance;
       }
-      vote.currentIndex = null;
+      voteCurrentIndices[vIndex] = NULL_VOTE_INDEX;
       equivocatingIndex++;
       equivocatingValidatorIndex = equivocatingArray[equivocatingIndex];
       continue;
@@ -98,7 +109,7 @@ export function computeDeltas(
     if (currentIndex !== nextIndex || oldBalance !== newBalance) {
       // We ignore the vote if it is not known in `indices .
       // We assume that it is outside of our tree (ie: pre-finalization) and therefore not interesting
-      if (currentIndex !== null) {
+      if (currentIndex !== NULL_VOTE_INDEX) {
         if (currentIndex >= numProtoNodes) {
           throw new ProtoArrayError({
             code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
@@ -110,7 +121,7 @@ export function computeDeltas(
 
       // We ignore the vote if it is not known in `indices .
       // We assume that it is outside of our tree (ie: pre-finalization) and therefore not interesting
-      if (nextIndex !== null) {
+      if (nextIndex !== NULL_VOTE_INDEX) {
         if (nextIndex >= numProtoNodes) {
           throw new ProtoArrayError({
             code: ProtoArrayErrorCode.INVALID_NODE_DELTA,
@@ -119,12 +130,19 @@ export function computeDeltas(
         }
         deltas[nextIndex] += newBalance;
       }
-      vote.currentIndex = nextIndex;
+      voteCurrentIndices[vIndex] = nextIndex;
       newVoteValidators++;
     } else {
       unchangedVoteValidators++;
     }
   } // end validator loop
+
+  if (deltas.length !== numProtoNodes) {
+    // deltas array could be growed in the loop, especially if we mistakenly set the [NULL_VOTE_INDEX] to it , we check to be safe
+    throw new Error(
+      `deltas length mismatch: expected ${numProtoNodes}, got ${deltas.length}`
+    );
+  }
 
   return {
     deltas,

--- a/packages/fork-choice/src/protoArray/interface.ts
+++ b/packages/fork-choice/src/protoArray/interface.ts
@@ -6,15 +6,16 @@ import {Epoch, RootHex, Slot, UintNum64} from "@lodestar/types";
 export const HEX_ZERO_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000";
 
 /**
- * Simplified 'latest message' with previous message
- * The index is relative to ProtoArray indices
+ * The null vote index indicates that a validator votes to a non-existent block. This usually happens when
+ * we prune the proto array and the validator's latest message is in the pruned part.
+ * The number of proto nodes will never exceed this value because it represents (0xffffffff / 365 / 24 / 60 / 5), ie > 1634 years of non-finalized network.
  */
-export type VoteTracker = {
-  currentIndex: number | null;
-  // if a vode is out of date (the voted index was in the past while proto array is pruned), it will be set to null
-  nextIndex: number | null;
-  nextEpoch: Epoch;
-};
+export const NULL_VOTE_INDEX = 0xffffffff;
+
+/**
+ * A vote index is a non-negative integer from 0 to NULL_VOTE_INDEX inclusive, and it will never be undefined.
+ */
+export type VoteIndex = number;
 
 export enum ExecutionStatus {
   Valid = "Valid",

--- a/packages/fork-choice/test/perf/forkChoice/updateHead.test.ts
+++ b/packages/fork-choice/test/perf/forkChoice/updateHead.test.ts
@@ -15,8 +15,6 @@ describe("forkchoice updateHead", () => {
     (4 * 60 * 60) / 12,
     // 1 day of blocks
     (24 * 60 * 60) / 12,
-    // // 20 days of blocks
-    // (20 * 24 * 60 * 60) / 12,
   ]) {
     runUpdateHeadBenchmark({initialValidatorCount: 600_000, initialBlockCount, initialEquivocatedCount: 0});
   }

--- a/packages/fork-choice/test/perf/forkChoice/util.ts
+++ b/packages/fork-choice/test/perf/forkChoice/util.ts
@@ -54,7 +54,7 @@ export function initializeForkChoice(opts: Opts): ForkChoice {
     equivocatingIndices: new Set(Array.from({length: opts.initialEquivocatedCount}, (_, i) => i)),
   };
 
-  const forkchoice = new ForkChoice(config, fcStore, protoArr, null);
+  const forkchoice = new ForkChoice(config, fcStore, protoArr, opts.initialValidatorCount, null);
   let parentBlockRoot = genesisRoot;
 
   for (let slot = 1; slot < opts.initialBlockCount; slot++) {

--- a/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
+++ b/packages/fork-choice/test/perf/protoArray/computeDeltas.test.ts
@@ -1,15 +1,16 @@
 import {beforeAll, bench, describe, setBenchOpts} from "@chainsafe/benchmark";
 import {EffectiveBalanceIncrements, getEffectiveBalanceIncrementsZeroed} from "@lodestar/state-transition";
 import {computeDeltas} from "../../../src/protoArray/computeDeltas.js";
-import {VoteTracker} from "../../../src/protoArray/interface.js";
+import {NULL_VOTE_INDEX} from "../../../src/protoArray/interface.js";
 
 describe("computeDeltas", () => {
   let oldBalances: EffectiveBalanceIncrements;
   let newBalances: EffectiveBalanceIncrements;
 
-  const oneHourProtoNodes = (60 * 60) / 12;
-  const fourHourProtoNodes = 4 * oneHourProtoNodes;
-  const oneDayProtoNodes = 24 * oneHourProtoNodes;
+  // it's not much differences between 1h vs 4h or even 1d proto nodes
+  const numProtoNode = (60 * 60) / 12;
+  const inactiveValidatorsPercentages = [0, 0.1, 0.2, 0.5];
+
   const numValidators = [1_400_000, 2_100_000];
   for (const numValidator of numValidators) {
     beforeAll(
@@ -26,27 +27,38 @@ describe("computeDeltas", () => {
     );
 
     setBenchOpts({
-      minMs: 30 * 1000,
-      maxMs: 40 * 1000,
+      minMs: 10 * 1000,
+      maxMs: 10 * 1000,
     });
 
-    for (const numProtoNode of [oneHourProtoNodes, fourHourProtoNodes, oneDayProtoNodes]) {
+    for (const inainactiveValidatorsPercentage of inactiveValidatorsPercentages) {
+      if (inainactiveValidatorsPercentage < 0 || inainactiveValidatorsPercentage > 1) {
+        throw new Error("inactiveValidatorsPercentage must be between 0 and 1");
+      }
+      // this results in [null, 10, 5, 2], ie for 10% inactive validators, every validator index ending with 0 is inactive
+      const inactiveValidatorMod =
+        inainactiveValidatorsPercentage === 0 ? null : Math.floor(1 / inainactiveValidatorsPercentage);
+      const voteCurrentIndices = Array.from({length: numValidator}, () => NULL_VOTE_INDEX);
+      const voteNextIndices = Array.from({length: numValidator}, () => NULL_VOTE_INDEX);
       bench({
-        id: `computeDeltas ${numValidator} validators ${numProtoNode} proto nodes`,
+        id: `computeDeltas ${numValidator} validators ${inainactiveValidatorsPercentage * 100}% inactive`,
         beforeEach: () => {
-          const votes: VoteTracker[] = [];
-          const epoch = 100_000;
           for (let i = 0; i < numValidator; i++) {
-            votes.push({
-              currentIndex: Math.floor(numProtoNode / 2),
-              nextIndex: Math.floor(numProtoNode / 2) + 1,
-              nextEpoch: epoch,
-            });
+            if (inactiveValidatorMod != null && i % inactiveValidatorMod === 0) continue;
+            voteCurrentIndices[i] = Math.floor(numProtoNode / 2);
+            voteNextIndices[i] = Math.floor(numProtoNode / 2) + 1;
           }
-          return votes;
+          return {voteCurrentIndices, voteNextIndices};
         },
-        fn: (votes) => {
-          computeDeltas(numProtoNode, votes, oldBalances, newBalances, new Set([1, 2, 3, 4, 5]));
+        fn: ({voteCurrentIndices, voteNextIndices}) => {
+          computeDeltas(
+            numProtoNode,
+            voteCurrentIndices,
+            voteNextIndices,
+            oldBalances,
+            newBalances,
+            new Set([1, 2, 3, 4, 5])
+          );
         },
       });
     }

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -23,6 +23,7 @@ describe("Forkchoice", () => {
   const finalizedRoot = getBlockRoot(genesisSlot);
   const parentRoot = toHex(Buffer.alloc(32, 0xff));
   let protoArr: ProtoArray;
+  const validatorCount = 100;
 
   beforeEach(() => {
     protoArr = ProtoArray.initialize(
@@ -119,7 +120,7 @@ describe("Forkchoice", () => {
     // Add block that is a finalized descendant.
     const block = getBlock(genesisSlot + 1);
     protoArr.onBlock(block, block.slot);
-    const forkchoice = new ForkChoice(config, fcStore, protoArr, null);
+    const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
     const summaries = forkchoice.getAllAncestorBlocks(getBlockRoot(genesisSlot + 1));
     // there are 2 blocks in protoArray but iterateAncestorBlocks should only return non-finalized blocks
     expect(summaries).toHaveLength(1);
@@ -137,7 +138,7 @@ describe("Forkchoice", () => {
     };
     protoArr.onBlock(forkBlock, forkBlock.slot);
 
-    const forkchoice = new ForkChoice(config, fcStore, protoArr, null);
+    const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
 
     // Test with a block from the canonical chain
     const canonicalBlockRoot = getBlockRoot(genesisSlot + 3);
@@ -189,7 +190,7 @@ describe("Forkchoice", () => {
   for (const {atSlot, pivotSlot, epoch, skipped} of dependentRootTestCases) {
     it(`getDependentRoot epoch ${epoch} atSlot ${atSlot} skipped ${JSON.stringify(skipped)}`, () => {
       populateProtoArray(atSlot, skipped);
-      const forkchoice = new ForkChoice(config, fcStore, protoArr, null);
+      const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
 
       const blockRoot = getBlockRoot(atSlot);
       const block = forkchoice.getBlockHex(blockRoot);

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -18,6 +18,7 @@ describe("Forkchoice / GetProposerHead", () => {
 
   const parentSlot = genesisSlot + 1;
   const headSlot = genesisSlot + 2;
+  const validatorCount = 100;
 
   let protoArr: ProtoArray;
 
@@ -238,7 +239,7 @@ describe("Forkchoice / GetProposerHead", () => {
         currentSlot,
       });
 
-      const forkChoice = new ForkChoice(config, fcStore, protoArr, null, {
+      const forkChoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null, {
         proposerBoost: true,
         proposerBoostReorg: true,
       });

--- a/packages/fork-choice/test/unit/forkChoice/shouldOverrideForkChoiceUpdate.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/shouldOverrideForkChoiceUpdate.test.ts
@@ -18,6 +18,7 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
 
   const parentSlot = genesisSlot + 1;
   const headSlot = genesisSlot + 2;
+  const validatorCount = 100;
 
   let protoArr: ProtoArray;
 
@@ -194,7 +195,7 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
 
       const secFromSlot = 0;
       const currentSlot = blockSeenSlot ?? headBlock.slot;
-      const forkChoice = new ForkChoice(config, fcStore, protoArr, null, {
+      const forkChoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null, {
         proposerBoost: true,
         proposerBoostReorg: true,
       });

--- a/packages/fork-choice/test/unit/protoArray/computeDeltas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/computeDeltas.test.ts
@@ -279,11 +279,6 @@ describe("computeDeltas", () => {
     indices.set("3", 1);
 
     // Both validators move votes from block1 to block2
-    // const votes = Array.from({length: 2}, () => ({
-    //   currentIndex: 0,
-    //   nextIndex: 1,
-    //   nextEpoch: 0,
-    // }));
     const voteCurrentIndices = Array.from({length: 2}, () => 0);
     const voteNextIndices = Array.from({length: 2}, () => 1);
 

--- a/packages/fork-choice/test/unit/protoArray/computeDeltas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/computeDeltas.test.ts
@@ -1,34 +1,39 @@
 import {describe, expect, it} from "vitest";
 import {getEffectiveBalanceIncrementsZeroed} from "@lodestar/state-transition";
 import {computeDeltas} from "../../../src/protoArray/computeDeltas.js";
+import {NULL_VOTE_INDEX} from "../../../src/protoArray/interface.js";
 
 describe("computeDeltas", () => {
   it("zero hash", () => {
     const validatorCount = 16;
 
     const indices = new Map();
-    const votes = [];
+    const voteCurrentIndices = [];
+    const voteNextIndices = [];
     const oldBalances = getEffectiveBalanceIncrementsZeroed(validatorCount);
     const newBalances = getEffectiveBalanceIncrementsZeroed(validatorCount);
 
     for (const i of Array.from({length: validatorCount}, (_, i) => i)) {
       indices.set(i.toString(), i);
-      votes.push({
-        currentIndex: 0,
-        nextIndex: 0,
-        nextEpoch: 0,
-      });
+      voteCurrentIndices.push(0);
+      voteNextIndices.push(0);
       oldBalances[i] = 0;
       newBalances[i] = 0;
     }
 
-    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(
+      indices.size,
+      voteCurrentIndices,
+      voteNextIndices,
+      oldBalances,
+      newBalances,
+      new Set()
+    );
 
     expect(deltas.length).toEqual(validatorCount);
     expect(deltas).toEqual(Array.from({length: validatorCount}, () => 0));
-
-    for (const vote of votes) {
-      expect(vote.currentIndex).toEqual(vote.nextIndex);
+    for (let i = 0; i < voteCurrentIndices.length; i++) {
+      expect(voteCurrentIndices[i]).toBe(voteNextIndices[i]);
     }
   });
 
@@ -37,22 +42,27 @@ describe("computeDeltas", () => {
     const validatorCount = 16;
 
     const indices = new Map();
-    const votes = [];
+    const voteCurrentIndices = [];
+    const voteNextIndices = [];
     const oldBalances = getEffectiveBalanceIncrementsZeroed(validatorCount);
     const newBalances = getEffectiveBalanceIncrementsZeroed(validatorCount);
 
     for (const i of Array.from({length: validatorCount}, (_, i) => i)) {
       indices.set((i + 1).toString(), i);
-      votes.push({
-        currentIndex: null,
-        nextIndex: 0,
-        nextEpoch: 0,
-      });
+      voteCurrentIndices.push(NULL_VOTE_INDEX);
+      voteNextIndices.push(0);
       oldBalances[i] = balance;
       newBalances[i] = balance;
     }
 
-    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(
+      indices.size,
+      voteCurrentIndices,
+      voteNextIndices,
+      oldBalances,
+      newBalances,
+      new Set()
+    );
 
     expect(deltas.length).toEqual(validatorCount);
 
@@ -70,22 +80,27 @@ describe("computeDeltas", () => {
     const validatorCount = 16;
 
     const indices = new Map();
-    const votes = [];
+    const voteCurrentIndices = [];
+    const voteNextIndices = [];
     const oldBalances = getEffectiveBalanceIncrementsZeroed(validatorCount);
     const newBalances = getEffectiveBalanceIncrementsZeroed(validatorCount);
 
     for (const i of Array.from({length: validatorCount}, (_, i) => i)) {
       indices.set((i + 1).toString(), i);
-      votes.push({
-        currentIndex: null,
-        nextIndex: i,
-        nextEpoch: 0,
-      });
+      voteCurrentIndices.push(NULL_VOTE_INDEX);
+      voteNextIndices.push(i);
       oldBalances[i] = balance;
       newBalances[i] = balance;
     }
 
-    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(
+      indices.size,
+      voteCurrentIndices,
+      voteNextIndices,
+      oldBalances,
+      newBalances,
+      new Set()
+    );
 
     expect(deltas.length).toEqual(validatorCount);
 
@@ -99,22 +114,27 @@ describe("computeDeltas", () => {
     const validatorCount = 16;
 
     const indices = new Map();
-    const votes = [];
+    const voteCurrentIndices = [];
+    const voteNextIndices = [];
     const oldBalances = getEffectiveBalanceIncrementsZeroed(validatorCount);
     const newBalances = getEffectiveBalanceIncrementsZeroed(validatorCount);
 
     for (const i of Array.from({length: validatorCount}, (_, i) => i)) {
       indices.set((i + 1).toString(), i);
-      votes.push({
-        currentIndex: 0,
-        nextIndex: 1,
-        nextEpoch: 0,
-      });
+      voteCurrentIndices.push(0);
+      voteNextIndices.push(1);
       oldBalances[i] = balance;
       newBalances[i] = balance;
     }
 
-    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(
+      indices.size,
+      voteCurrentIndices,
+      voteNextIndices,
+      oldBalances,
+      newBalances,
+      new Set()
+    );
 
     expect(deltas.length).toEqual(validatorCount);
 
@@ -137,22 +157,27 @@ describe("computeDeltas", () => {
     const validatorCount = 16;
 
     const indices = new Map();
-    const votes = [];
+    const voteCurrentIndices = [];
+    const voteNextIndices = [];
     const oldBalances = getEffectiveBalanceIncrementsZeroed(validatorCount);
     const newBalances = getEffectiveBalanceIncrementsZeroed(validatorCount);
 
     for (const i of Array.from({length: validatorCount}, (_, i) => i)) {
       indices.set((i + 1).toString(), i);
-      votes.push({
-        currentIndex: 0,
-        nextIndex: 1,
-        nextEpoch: 0,
-      });
+      voteCurrentIndices.push(0);
+      voteNextIndices.push(1);
       oldBalances[i] = oldBalance;
       newBalances[i] = newBalance;
     }
 
-    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(
+      indices.size,
+      voteCurrentIndices,
+      voteNextIndices,
+      oldBalances,
+      newBalances,
+      new Set()
+    );
 
     expect(deltas.length).toEqual(validatorCount);
 
@@ -176,11 +201,8 @@ describe("computeDeltas", () => {
     indices.set("3", 1);
 
     // Both validators move votes from block1 to block2
-    const votes = Array.from({length: 2}, () => ({
-      currentIndex: 0,
-      nextIndex: 1,
-      nextEpoch: 0,
-    }));
+    const voteCurrentIndices = Array.from({length: 2}, () => 0);
+    const voteNextIndices = Array.from({length: 2}, () => 1);
 
     // There is only one validator in the old balances.
     const oldBalances = getEffectiveBalanceIncrementsZeroed(1);
@@ -190,15 +212,22 @@ describe("computeDeltas", () => {
     newBalances[0] = balance;
     newBalances[1] = balance;
 
-    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(
+      indices.size,
+      voteCurrentIndices,
+      voteNextIndices,
+      oldBalances,
+      newBalances,
+      new Set()
+    );
 
     expect(deltas.length).toEqual(2);
 
     expect(deltas[0].toString()).toEqual((0 - balance).toString());
     expect(deltas[1].toString()).toEqual((balance * 2).toString());
 
-    for (const vote of votes) {
-      expect(vote.currentIndex).toBe(vote.nextIndex);
+    for (let i = 0; i < voteCurrentIndices.length; i++) {
+      expect(voteCurrentIndices[i]).toBe(voteNextIndices[i]);
     }
   });
 
@@ -211,11 +240,8 @@ describe("computeDeltas", () => {
     indices.set("3", 1);
 
     // Both validators move votes from block1 to block2
-    const votes = Array.from({length: 2}, () => ({
-      currentIndex: 0,
-      nextIndex: 1,
-      nextEpoch: 0,
-    }));
+    const voteCurrentIndices = Array.from({length: 2}, () => 0);
+    const voteNextIndices = Array.from({length: 2}, () => 1);
     // There are two validators in the old balances.
     const oldBalances = getEffectiveBalanceIncrementsZeroed(2);
     oldBalances[0] = balance;
@@ -224,15 +250,22 @@ describe("computeDeltas", () => {
     const newBalances = getEffectiveBalanceIncrementsZeroed(1);
     newBalances[0] = balance;
 
-    const {deltas} = computeDeltas(indices.size, votes, oldBalances, newBalances, new Set());
+    const {deltas} = computeDeltas(
+      indices.size,
+      voteCurrentIndices,
+      voteNextIndices,
+      oldBalances,
+      newBalances,
+      new Set()
+    );
 
     expect(deltas.length).toEqual(2);
 
     expect(deltas[0].toString()).toEqual((0 - balance * 2).toString());
     expect(deltas[1].toString()).toEqual(balance.toString());
 
-    for (const vote of votes) {
-      expect(vote.currentIndex).toBe(vote.nextIndex);
+    for (let i = 0; i < voteCurrentIndices.length; i++) {
+      expect(voteCurrentIndices[i]).toBe(voteNextIndices[i]);
     }
   });
 
@@ -246,22 +279,38 @@ describe("computeDeltas", () => {
     indices.set("3", 1);
 
     // Both validators move votes from block1 to block2
-    const votes = Array.from({length: 2}, () => ({
-      currentIndex: 0,
-      nextIndex: 1,
-      nextEpoch: 0,
-    }));
+    // const votes = Array.from({length: 2}, () => ({
+    //   currentIndex: 0,
+    //   nextIndex: 1,
+    //   nextEpoch: 0,
+    // }));
+    const voteCurrentIndices = Array.from({length: 2}, () => 0);
+    const voteNextIndices = Array.from({length: 2}, () => 1);
 
     const balances = new Uint16Array([firstBalance, secondBalance]);
     // 1st validator is part of an attester slashing
     const equivocatingIndices = new Set([0]);
-    let {deltas} = computeDeltas(indices.size, votes, balances, balances, equivocatingIndices);
+    let {deltas} = computeDeltas(
+      indices.size,
+      voteCurrentIndices,
+      voteNextIndices,
+      balances,
+      balances,
+      equivocatingIndices
+    );
     expect(deltas[0]).toBeWithMessage(
       -1 * (firstBalance + secondBalance),
       "should disregard the 1st validator due to attester slashing"
     );
     expect(deltas[1]).toBeWithMessage(secondBalance, "should move 2nd balance from 1st root to 2nd root");
-    deltas = computeDeltas(indices.size, votes, balances, balances, equivocatingIndices).deltas;
+    deltas = computeDeltas(
+      indices.size,
+      voteCurrentIndices,
+      voteNextIndices,
+      balances,
+      balances,
+      equivocatingIndices
+    ).deltas;
     expect(deltas).toEqualWithMessage([0, 0], "calling computeDeltas again should not have any affect on the weight");
   });
 });


### PR DESCRIPTION
**Motivation**

- fix performance issue of Bun due to sparse array, see https://github.com/ChainSafe/lodestar/issues/8519#issuecomment-3420322338
- decompose VoteTracker, same to #6945

**Description**
- decompose VoteTracker to `voteCurrentIndices` `voteNextIndices` `voteNextEpochs`, data is populated on initialization, hence avoid the sparse issue in https://github.com/ChainSafe/lodestar/issues/8519#issuecomment-3420322338
- the old `null` index means not to point to any nodes of ProtoArray, we represent it as 0xffffffff (max u32) instead of null
- update `computeDeltas()` benchmark to reproduce the issue and fix it in this PR. It shows bun loops is 2x faster than NodeJS for now

part of #8519

**Hoodi result**

- 4x-5x faster on NodeJS

<img width="967" height="300" alt="Screenshot 2025-10-20 at 14 35 01" src="https://github.com/user-attachments/assets/80998967-f6d6-4179-8976-699750a1e6fe" />

- almost 30x faster on Bun
<img width="1301" height="377" alt="Screenshot 2025-10-20 at 14 35 32" src="https://github.com/user-attachments/assets/eb51f6b5-2560-478f-865a-c127f1cf008d" />

- overall it shows Bun is >= 2x faster than NodeJS now but we can probably makes it better because this decomposition strategy makes it easier for a native binding (which I will give it a try next)