### PR TITLE
fix: remove extraneous fields from `/eth/v1/node/peers` response

### DIFF
--- a/packages/beacon-node/src/api/impl/node/utils.ts
+++ b/packages/beacon-node/src/api/impl/node/utils.ts
@@ -10,7 +10,7 @@ export function formatNodePeer(peerIdStr: string, connections: Connection[]): ro
   return {
     peerId: conn ? conn.remotePeer.toString() : peerIdStr,
     // TODO: figure out how to get enr of peer
-    enr: "",
+    enr: null,
     lastSeenP2pAddress: conn ? conn.remoteAddr.toString() : "",
     direction: conn ? (conn.direction as routes.node.PeerDirection) : null,
     state: conn ? getPeerState(conn.status) : "disconnected",


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/7909

**Description**

- remove extraneous fields from `/eth/v1/node/peers` response
- return `null` as enr of peers instead of empty string `""`


```bash
~> curl -s localhost:9596/eth/v1/node/peers | jq ".data[0]"
{
  "peer_id": "16Uiu2HAmLiPFRNHiS7FdJb8hX3wfVWF5EUVdTunbvN1L3mYeSVLa",
  "enr": null,
  "last_seen_p2p_address": "/ip4/188.165.77.35/tcp/9000/p2p/16Uiu2HAmLiPFRNHiS7FdJb8hX3wfVWF5EUVdTunbvN1L3mYeSVLa",
  "state": "connected",
  "direction": "outbound"
}

```

