### PR TITLE
chore: update execution payload and blobs bundle for fulu

### DIFF
--- a/packages/types/src/fulu/sszTypes.ts
+++ b/packages/types/src/fulu/sszTypes.ts
@@ -111,6 +111,14 @@ export const BlobsBundle = new ContainerType(
   {typeName: "BlobsBundle", jsonCase: "eth2"}
 );
 
+export const ExecutionPayloadAndBlobsBundle = new ContainerType(
+  {
+    executionPayload: electraSsz.ExecutionPayload,
+    blobsBundle: BlobsBundle,
+  },
+  {typeName: "ExecutionPayloadAndBlobsBundle", jsonCase: "eth2"}
+);
+
 export const BeaconState = new ContainerType(
   {
     ...electraSsz.BeaconState.fields,

--- a/packages/types/src/fulu/types.ts
+++ b/packages/types/src/fulu/types.ts
@@ -24,6 +24,7 @@ export type SignedBeaconBlock = ValueOf<typeof ssz.SignedBeaconBlock>;
 export type BeaconState = ValueOf<typeof ssz.BeaconState>;
 export type BlockContents = ValueOf<typeof ssz.BlockContents>;
 export type SignedBlockContents = ValueOf<typeof ssz.SignedBlockContents>;
+export type ExecutionPayloadAndBlobsBundle = ValueOf<typeof ssz.ExecutionPayloadAndBlobsBundle>;
 export type BlobsBundle = ValueOf<typeof ssz.BlobsBundle>;
 export type BlobAndProofV2 = {
   blob: Blob;

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -261,7 +261,7 @@ type TypesByFork = {
     SSEPayloadAttributes: electra.SSEPayloadAttributes;
     BlockContents: fulu.BlockContents;
     SignedBlockContents: fulu.SignedBlockContents;
-    ExecutionPayloadAndBlobsBundle: deneb.ExecutionPayloadAndBlobsBundle;
+    ExecutionPayloadAndBlobsBundle: fulu.ExecutionPayloadAndBlobsBundle;
     BlobsBundle: fulu.BlobsBundle;
     SyncCommittee: altair.SyncCommittee;
     SyncAggregate: altair.SyncAggregate;
@@ -299,7 +299,7 @@ type TypesByFork = {
     SSEPayloadAttributes: electra.SSEPayloadAttributes;
     BlockContents: fulu.BlockContents;
     SignedBlockContents: fulu.SignedBlockContents;
-    ExecutionPayloadAndBlobsBundle: deneb.ExecutionPayloadAndBlobsBundle;
+    ExecutionPayloadAndBlobsBundle: fulu.ExecutionPayloadAndBlobsBundle;
     BlobsBundle: fulu.BlobsBundle;
     SyncCommittee: altair.SyncCommittee;
     SyncAggregate: altair.SyncAggregate;


### PR DESCRIPTION
This is just relevant to be compliant with the [builder spec](https://github.com/ethereum/builder-specs/blob/db7c5ee0363c6449997e2a1d5bc9481ed87ba223/specs/fulu/builder.md?plain=1#L39-L45)
```python
class ExecutionPayloadAndBlobsBundle(Container):
    execution_payload: ExecutionPayload
    blobs_bundle: BlobsBundle  # [Modified in Fulu:EIP7594]
```
We haven't seen issues due to this because once Fulu activates we use `submitBlindedBlockV2` which no longer returns `ExecutionPayloadAndBlobsBundle` in the response.