### PR TITLE
feat: use snappy from lodestar-bun

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -83,6 +83,10 @@
     "#datastore-wrapper": {
       "bun": "./src/network/peers/datastore_bun.ts",
       "default": "datastore-level"
+    },
+    "#snappy": {
+      "bun": "./src/network/gossip/snappy_bun.ts",
+      "default": "snappyjs"
     }
   },
   "files": [

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -276,5 +276,13 @@ export function initializeForkChoiceFromUnfinalizedState(
   // production code use ForkChoice constructor directly
   const forkchoiceConstructor = opts.forkchoiceConstructor ?? ForkChoice;
 
-  return new forkchoiceConstructor(config, store, protoArray, metrics, opts, logger);
+  return new forkchoiceConstructor(
+    config,
+    store,
+    protoArray,
+    unfinalizedState.validators.length,
+    metrics,
+    opts,
+    logger
+  );
 }

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -1,6 +1,6 @@
 import {Message} from "@libp2p/interface";
-import {compress, uncompress} from "snappyjs";
 import xxhashFactory from "xxhash-wasm";
+import {compress, uncompress} from "#snappy";
 import {digest} from "@chainsafe/as-sha256";
 import {RPC} from "@chainsafe/libp2p-gossipsub/message";
 import {DataTransform} from "@chainsafe/libp2p-gossipsub/types";

--- a/packages/beacon-node/src/network/gossip/snappy_bun.ts
+++ b/packages/beacon-node/src/network/gossip/snappy_bun.ts
@@ -1,0 +1,2 @@
+import {snappy} from "@lodestar/bun";
+export const {compress, uncompress} = snappy;

--- a/packages/beacon-node/test/perf/network/gossip/snappy.test.ts
+++ b/packages/beacon-node/test/perf/network/gossip/snappy.test.ts
@@ -1,0 +1,113 @@
+import {randomBytes} from "node:crypto";
+import * as snappyRs from "snappy";
+import * as snappyJs from "snappyjs";
+import * as snappyBun from "#snappy";
+import {bench, describe} from "@chainsafe/benchmark";
+
+describe("network / gossip / snappy", () => {
+  const msgLens = [
+    // ->
+    100,
+    200,
+    300,
+    400,
+    500,
+    1000,
+    10000, // 100000,
+  ];
+  describe("compress", () => {
+    for (const msgLen of msgLens) {
+      const uncompressed = randomBytes(msgLen);
+      const RUNS_FACTOR = 1000;
+
+      bench({
+        id: `${msgLen} bytes - compress - snappyjs`,
+        runsFactor: RUNS_FACTOR,
+        fn: () => {
+          for (let i = 0; i < RUNS_FACTOR; i++) {
+            snappyJs.compress(uncompressed);
+          }
+        },
+      });
+
+      bench({
+        id: `${msgLen} bytes - compress - snappy`,
+        runsFactor: RUNS_FACTOR,
+        fn: () => {
+          for (let i = 0; i < RUNS_FACTOR; i++) {
+            snappyRs.compressSync(uncompressed);
+          }
+        },
+      });
+
+      bench({
+        id: `${msgLen} bytes - compress - #snappy`,
+        runsFactor: RUNS_FACTOR,
+        fn: () => {
+          for (let i = 0; i < RUNS_FACTOR; i++) {
+            snappyBun.compress(uncompressed);
+          }
+        },
+      });
+
+      // bench({
+      //   id: `${msgLen} bytes - compress - snappy-wasm - prealloc`,
+      //   runsFactor: RUNS_FACTOR,
+      //   fn: () => {
+      //     for (let i = 0; i < RUNS_FACTOR; i++) {
+      //       let out = Buffer.allocUnsafe(snappyBun.max_compress_len(uncompressed.length));
+      //       const len = snappyBun.compress_into(uncompressed, out);
+      //       out = out.subarray(0, len);
+      //     }
+      //   },
+      // });
+    }
+  });
+  describe("uncompress", () => {
+    for (const msgLen of msgLens) {
+      const uncompressed = randomBytes(msgLen);
+      const compressed = snappyJs.compress(uncompressed);
+      const RUNS_FACTOR = 1000;
+
+      bench({
+        id: `${msgLen} bytes - uncompress - snappyjs`,
+        runsFactor: RUNS_FACTOR,
+        fn: () => {
+          for (let i = 0; i < RUNS_FACTOR; i++) {
+            snappyJs.uncompress(compressed);
+          }
+        },
+      });
+
+      bench({
+        id: `${msgLen} bytes - uncompress - snappy`,
+        runsFactor: RUNS_FACTOR,
+        fn: () => {
+          for (let i = 0; i < RUNS_FACTOR; i++) {
+            snappyRs.uncompressSync(compressed);
+          }
+        },
+      });
+
+      bench({
+        id: `${msgLen} bytes - uncompress - #snappy`,
+        runsFactor: RUNS_FACTOR,
+        fn: () => {
+          for (let i = 0; i < RUNS_FACTOR; i++) {
+            snappyBun.uncompress(compressed);
+          }
+        },
+      });
+
+      // bench({
+      //   id: `${msgLen} bytes - uncompress - snappy-wasm - prealloc`,
+      //   runsFactor: RUNS_FACTOR,
+      //   fn: () => {
+      //     for (let i = 0; i < RUNS_FACTOR; i++) {
+      //       decoder.decompress_into(compressed, Buffer.allocUnsafe(snappyBun.decompress_len(compressed)));
+      //     }
+      //   },
+      // });
+    }
+  });
+});

--- a/packages/reqresp/package.json
+++ b/packages/reqresp/package.json
@@ -25,6 +25,12 @@
       "import": "./lib/utils/index.js"
     }
   },
+  "imports": {
+    "#snappy": {
+      "bun": "./src/encodingStrategies/sszSnappy/snappyFrames/snappy_bun.ts",
+      "default": "./lib/encodingStrategies/sszSnappy/snappyFrames/snappy.js"
+    }
+  },
   "files": [
     "src",
     "lib",

--- a/packages/reqresp/src/encodingStrategies/sszSnappy/snappyFrames/compress.ts
+++ b/packages/reqresp/src/encodingStrategies/sszSnappy/snappyFrames/compress.ts
@@ -1,4 +1,4 @@
-import snappy from "snappy";
+import {compress} from "#snappy";
 import {ChunkType, IDENTIFIER_FRAME, UNCOMPRESSED_CHUNK_SIZE, crc} from "./common.js";
 
 // The logic in this file is largely copied (in simplified form) from https://github.com/ChainSafe/node-snappy-stream/
@@ -8,7 +8,7 @@ export async function* encodeSnappy(bytes: Buffer): AsyncGenerator<Buffer> {
 
   for (let i = 0; i < bytes.length; i += UNCOMPRESSED_CHUNK_SIZE) {
     const chunk = bytes.subarray(i, i + UNCOMPRESSED_CHUNK_SIZE);
-    const compressed = snappy.compressSync(chunk);
+    const compressed = compress(chunk);
     if (compressed.length < chunk.length) {
       const size = compressed.length + 4;
       yield Buffer.concat([Buffer.from([ChunkType.COMPRESSED, size, size >> 8, size >> 16]), crc(chunk), compressed]);

--- a/packages/reqresp/src/encodingStrategies/sszSnappy/snappyFrames/snappy.ts
+++ b/packages/reqresp/src/encodingStrategies/sszSnappy/snappyFrames/snappy.ts
@@ -1,0 +1,2 @@
+export {compressSync as compress} from "snappy";
+export {uncompress} from "snappyjs";

--- a/packages/reqresp/src/encodingStrategies/sszSnappy/snappyFrames/snappy_bun.ts
+++ b/packages/reqresp/src/encodingStrategies/sszSnappy/snappyFrames/snappy_bun.ts
@@ -1,0 +1,2 @@
+import {snappy} from "@lodestar/bun";
+export const {compress, uncompress} = snappy;

--- a/packages/reqresp/src/encodingStrategies/sszSnappy/snappyFrames/uncompress.ts
+++ b/packages/reqresp/src/encodingStrategies/sszSnappy/snappyFrames/uncompress.ts
@@ -1,5 +1,5 @@
-import {uncompress} from "snappyjs";
 import {Uint8ArrayList} from "uint8arraylist";
+import {uncompress} from "#snappy";
 import {ChunkType, IDENTIFIER, UNCOMPRESSED_CHUNK_SIZE, crc} from "./common.js";
 
 export class SnappyFramesUncompress {

--- a/packages/reqresp/tsconfig.build.json
+++ b/packages/reqresp/tsconfig.build.json
@@ -4,6 +4,7 @@
     "src"
   ],
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "lib",
     "typeRoots": [
       "../../node_modules/@types",

--- a/packages/reqresp/tsconfig.json
+++ b/packages/reqresp/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src", "test"],
   "exclude": ["../../node_modules/it-pipe"],
   "compilerOptions": {
+    "rootDir": "../..",
     "outDir": "lib",
     "typeRoots": ["../../node_modules/@types", "../../types"]
   }

--- a/types/snappyjs/index.d.ts
+++ b/types/snappyjs/index.d.ts
@@ -2,3 +2,8 @@ declare module "snappyjs" {
   export function compress<T extends ArrayBuffer | Buffer | Uint8Array>(input: T): T;
   export function uncompress<T extends ArrayBuffer | Buffer | Uint8Array>(input: T, maxLength?: number): T;
 }
+
+declare module "#snappy" {
+  export function compress<T extends ArrayBuffer | Buffer | Uint8Array>(input: T): T;
+  export function uncompress<T extends ArrayBuffer | Buffer | Uint8Array>(input: T, maxLength?: number): T;
+}


### PR DESCRIPTION
**Motivation**

- #7280 

**Description**

- Use lodestar-bun's snappy when possible
- nodejs snappy usage unaffected
- revive benchmarks from #7451 
```
  network / gossip / snappy
    compress
      ✔ 100 bytes - compress - snappyjs                                     904194.3 ops/s    1.105957 us/op   x0.973        249 runs  0.807 s
      ✔ 100 bytes - compress - snappy                                        1033261 ops/s    967.8100 ns/op   x0.990        271 runs  0.812 s
      ✔ 100 bytes - compress - #snappy                                       1380371 ops/s    724.4430 ns/op        -        352 runs  0.808 s
      ✔ 200 bytes - compress - snappyjs                                     634155.6 ops/s    1.576900 us/op   x0.991        171 runs  0.806 s
      ✔ 200 bytes - compress - snappy                                       901956.4 ops/s    1.108701 us/op   x1.010        301 runs  0.913 s
      ✔ 200 bytes - compress - #snappy                                       1202879 ops/s    831.3390 ns/op        -        295 runs  0.805 s
      ✔ 300 bytes - compress - snappyjs                                     509230.6 ops/s    1.963747 us/op   x1.006        140 runs  0.814 s
      ✔ 300 bytes - compress - snappy                                       843395.0 ops/s    1.185684 us/op   x1.009        216 runs  0.808 s
      ✔ 300 bytes - compress - #snappy                                       1052744 ops/s    949.8990 ns/op        -        268 runs  0.808 s
      ✔ 400 bytes - compress - snappyjs                                     449093.7 ops/s    2.226707 us/op   x0.984        121 runs  0.808 s
      ✔ 400 bytes - compress - snappy                                       782524.0 ops/s    1.277916 us/op   x1.015        206 runs  0.807 s
      ✔ 400 bytes - compress - #snappy                                       1008783 ops/s    991.2930 ns/op        -        250 runs  0.806 s
      ✔ 500 bytes - compress - snappyjs                                     390406.2 ops/s    2.561435 us/op   x0.991        107 runs  0.814 s
      ✔ 500 bytes - compress - snappy                                       733727.9 ops/s    1.362903 us/op   x1.000        187 runs  0.806 s
      ✔ 500 bytes - compress - #snappy                                      922128.1 ops/s    1.084448 us/op        -        222 runs  0.805 s
      ✔ 1000 bytes - compress - snappyjs                                    262729.3 ops/s    3.806199 us/op   x0.990         73 runs  0.813 s
      ✔ 1000 bytes - compress - snappy                                      544451.8 ops/s    1.836710 us/op   x0.998        144 runs  0.809 s
      ✔ 1000 bytes - compress - #snappy                                     765966.6 ops/s    1.305540 us/op        -        180 runs  0.814 s
      ✔ 10000 bytes - compress - snappyjs                                   19414.94 ops/s    51.50673 us/op   x1.131         11 runs   1.15 s
      ✔ 10000 bytes - compress - snappy                                     99177.41 ops/s    10.08294 us/op   x1.001         30 runs  0.835 s
      ✔ 10000 bytes - compress - #snappy                                    169126.1 ops/s    5.912749 us/op        -         52 runs  0.812 s
    uncompress
      ✔ 100 bytes - uncompress - snappyjs                                    6471152 ops/s    154.5320 ns/op   x0.984       1789 runs  0.488 s
      ✔ 100 bytes - uncompress - snappy                                      1250499 ops/s    799.6810 ns/op   x0.995        318 runs  0.805 s
      ✔ 100 bytes - uncompress - #snappy                                     4245942 ops/s    235.5190 ns/op        -        797 runs  0.502 s
      ✔ 200 bytes - uncompress - snappyjs                                    4229761 ops/s    236.4200 ns/op   x1.039       1188 runs  0.574 s
      ✔ 200 bytes - uncompress - snappy                                      1136787 ops/s    879.6720 ns/op   x0.997        293 runs  0.808 s
      ✔ 200 bytes - uncompress - #snappy                                     3771208 ops/s    265.1670 ns/op        -       1036 runs  0.608 s
      ✔ 300 bytes - uncompress - snappyjs                                    3219865 ops/s    310.5720 ns/op   x1.028        612 runs  0.560 s
      ✔ 300 bytes - uncompress - snappy                                      1046605 ops/s    955.4700 ns/op   x1.006        260 runs  0.806 s
      ✔ 300 bytes - uncompress - #snappy                                     3654276 ops/s    273.6520 ns/op        -        994 runs  0.631 s
      ✔ 400 bytes - uncompress - snappyjs                                    2623625 ops/s    381.1520 ns/op   x1.018        489 runs  0.627 s
      ✔ 400 bytes - uncompress - snappy                                     946192.0 ops/s    1.056868 us/op   x1.028        158 runs  0.705 s
      ✔ 400 bytes - uncompress - #snappy                                     3627697 ops/s    275.6570 ns/op        -        950 runs  0.630 s
      ✔ 500 bytes - uncompress - snappyjs                                    2177672 ops/s    459.2060 ns/op   x1.011        611 runs  0.800 s
      ✔ 500 bytes - uncompress - snappy                                     917029.0 ops/s    1.090478 us/op   x0.995        235 runs  0.813 s
      ✔ 500 bytes - uncompress - #snappy                                     3482779 ops/s    287.1270 ns/op        -        902 runs  0.656 s
      ✔ 1000 bytes - uncompress - snappyjs                                   1178109 ops/s    848.8180 ns/op   x0.992        221 runs  0.706 s
      ✔ 1000 bytes - uncompress - snappy                                    695356.6 ops/s    1.438111 us/op   x0.991        170 runs  0.811 s
      ✔ 1000 bytes - uncompress - #snappy                                    2737986 ops/s    365.2320 ns/op        -        685 runs  0.760 s
      ✔ 10000 bytes - uncompress - snappyjs                                 115614.7 ops/s    8.649418 us/op   x1.002         25 runs  0.722 s
      ✔ 10000 bytes - uncompress - snappy                                   114448.8 ops/s    8.737535 us/op   x1.006         23 runs  0.738 s
      ✔ 10000 bytes - uncompress - #snappy                                  436138.4 ops/s    2.292850 us/op        -        134 runs  0.812 s
```