### PR TITLE
chore: fix build after merge to unstable

### DIFF
--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -276,5 +276,13 @@ export function initializeForkChoiceFromUnfinalizedState(
   // production code use ForkChoice constructor directly
   const forkchoiceConstructor = opts.forkchoiceConstructor ?? ForkChoice;
 
-  return new forkchoiceConstructor(config, store, protoArray, metrics, opts, logger);
+  return new forkchoiceConstructor(
+    config,
+    store,
+    protoArray,
+    unfinalizedState.validators.length,
+    metrics,
+    opts,
+    logger
+  );
 }


### PR DESCRIPTION
We need to pass validator count to fork choice since https://github.com/ChainSafe/lodestar/pull/8549 but that wasn't done in https://github.com/ChainSafe/lodestar/pull/8527 for `initializeForkChoiceFromUnfinalizedState` which breaks our code.