### PR TITLE
refactor: clean up supernode config

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -271,8 +271,7 @@ export class BeaconChain implements IBeaconChain {
     this.seenAttestationDatas = new SeenAttestationDatas(metrics, this.opts?.attDataCacheSlotDistance);
 
     const nodeId = computeNodeIdFromPrivateKey(privateKey);
-    const initialCustodyGroupCount =
-      opts.initialCustodyGroupCount ?? (opts.supernode ? config.NUMBER_OF_CUSTODY_GROUPS : config.CUSTODY_REQUIREMENT);
+    const initialCustodyGroupCount = opts.initialCustodyGroupCount ?? config.CUSTODY_REQUIREMENT;
     this.metrics?.peerDas.targetCustodyGroupCount.set(initialCustodyGroupCount);
     this.custodyConfig = new CustodyConfig({
       nodeId,
@@ -1241,9 +1240,10 @@ export class BeaconChain implements IBeaconChain {
   }
 
   private async updateValidatorsCustodyRequirement(finalizedCheckpoint: CheckpointWithHex): Promise<void> {
-    if (this.opts.supernode) {
-      // Disable dynamic custody updates for supernodes since they must maintain custody
-      // of all custody groups regardless of validator effective balances
+    if (this.custodyConfig.targetCustodyGroupCount === this.config.NUMBER_OF_CUSTODY_GROUPS) {
+      // Custody requirements can only be increased. Disable dynamic custody updates if we already
+      // maintain custody of all custody groups in case the node is configured as a supernode
+      // or has validators attached with a total effective balance of at least 4096 ETH.
       return;
     }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1241,9 +1241,9 @@ export class BeaconChain implements IBeaconChain {
 
   private async updateValidatorsCustodyRequirement(finalizedCheckpoint: CheckpointWithHex): Promise<void> {
     if (this.custodyConfig.targetCustodyGroupCount === this.config.NUMBER_OF_CUSTODY_GROUPS) {
-      // Custody requirements can only be increased. Disable dynamic custody updates if we already
-      // maintain custody of all custody groups in case the node is configured as a supernode
-      // or has validators attached with a total effective balance of at least 4096 ETH.
+      // Custody requirements can only be increased, we can disable dynamic custody updates
+      // if the node already maintains custody of all custody groups in case it is configured
+      // as a supernode or has validators attached with a total effective balance of at least 4096 ETH.
       return;
     }
 

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -41,8 +41,6 @@ export type IChainOptions = BlockProcessOpts &
     maxCachedBlobSidecars?: number;
     /** Max number of produced block roots (blinded or full) cached for broadcast validations */
     maxCachedProducedRoots?: number;
-    /** Subscribe to and custody all data column sidecar subnets */
-    supernode?: boolean;
     initialCustodyGroupCount?: number;
     broadcastValidationStrictness?: string;
     minSameMessageSignatureSetsToBatch: number;
@@ -118,7 +116,6 @@ export const defaultChainOptions: IChainOptions = {
   archiveMode: DEFAULT_ARCHIVE_MODE,
   pruneHistory: false,
   emitPayloadAttributes: false,
-  supernode: false,
   // for gossip block validation, it's unlikely we see a reorg with 32 slots
   // for attestation validation, having this value ensures we don't have to regen states most of the time
   maxSkipSlots: 32,

--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -23,7 +23,6 @@ export interface NetworkOptions
   useWorker?: boolean;
   maxYoungGenerationSizeMb?: number;
   disableLightClientServer?: boolean;
-  supernode?: boolean;
 
   /**
    * During E2E tests observe a lot of following `missing stream`:

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -8,7 +8,7 @@ import {ChainConfig, createBeaconConfig, createChainForkConfig} from "@lodestar/
 import {config as minimalConfig} from "@lodestar/config/default";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {LoggerNode} from "@lodestar/logger/node";
-import {ForkSeq, GENESIS_SLOT, NUMBER_OF_COLUMNS, SLOTS_PER_EPOCH, ZERO_HASH_HEX} from "@lodestar/params";
+import {ForkSeq, GENESIS_SLOT, SLOTS_PER_EPOCH, ZERO_HASH_HEX} from "@lodestar/params";
 import {BeaconStateAllForks, computeTimeAtSlot} from "@lodestar/state-transition";
 import {phase0, ssz} from "@lodestar/types";
 import {RecursivePartial, isPlainObject, toRootHex} from "@lodestar/utils";
@@ -83,7 +83,7 @@ export async function getDevBeaconNode(
         },
         chain: {
           // configure supernode does not work because we don't get through cli
-          initialCustodyGroupCount: NUMBER_OF_COLUMNS,
+          initialCustodyGroupCount: config.NUMBER_OF_CUSTODY_GROUPS,
         },
         executionEngine: {
           mode: "mock",

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -189,10 +189,6 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
   // Add detailed version string for API node/version endpoint
   beaconNodeOptions.set({api: {commit, version}});
 
-  if (args.supernode) {
-    beaconNodeOptions.set({chain: {supernode: true}, network: {supernode: true}});
-  }
-
   // Set known depositContractDeployBlock
   if (isKnownNetworkName(network)) {
     const {depositContractDeployBlock} = getNetworkData(network);


### PR DESCRIPTION
It doesn't seem necessary to pass down `supernode` config into different modules like chain or network, it's better to handle initial custody config only in beacon handler and then use `initialCustodyGroupCount` downstream.