### PR TITLE
fix: update local status fork digest on fork boundary transition

### DIFF
--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -553,7 +553,11 @@ export class NetworkCore implements INetworkCore {
           // On fork boundary transition
           if (epoch === nextBoundaryEpoch) {
             // updateEth2Field() MUST be called with clock epoch, onEpoch event is emitted in response to clock events
-            this.metadata.updateEth2Field(epoch);
+            const {forkDigest} = this.metadata.updateEth2Field(epoch);
+            // Update local status to reflect the new fork digest, otherwise we will disconnect peers that re-status us
+            // right after the fork transition due to incompatible forks as our fork digest is stale since we only
+            // update it once we import a new head or when emitting update status event.
+            this.statusCache.update({...this.statusCache.get(), forkDigest});
             this.reqResp.registerProtocolsAtBoundary(nextBoundary);
           }
 

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -126,7 +126,7 @@ export class MetadataController {
    * 2. Network MUST call this method on fork transition.
    *    Current Clock implementation ensures no race conditions, epoch is correct if re-fetched
    */
-  updateEth2Field(epoch: Epoch): void {
+  updateEth2Field(epoch: Epoch): phase0.ENRForkID {
     const config = this.networkConfig.config;
     const enrForkId = getENRForkID(config, epoch);
     const {forkDigest, nextForkVersion, nextForkEpoch} = enrForkId;
@@ -143,6 +143,8 @@ export class MetadataController {
         : ssz.ForkDigest.defaultValue();
     this.onSetValue(ENRKey.nfd, nextForkDigest);
     this.logger.debug("Updated nfd field in ENR", {nextForkDigest: toHex(nextForkDigest)});
+
+    return enrForkId;
   }
 }
 


### PR DESCRIPTION
**Motivation**

Seems like we only update our local status if we receive a new block after fork, and incorrectly disconnect peers due to that
```txt
[32minfo[39m: Synced - slot: 32 - head: (slot -1) 0x355c…8bed - exec-block: valid(29 0xd623…) - finalized: 0x0000…0000:0 - peers: 3
[34mdebug[39m: Req  received method=status, version=2, client=Prysm, peer=16...HcnnMH, requestId=48
[36mverbose[39m: Resp done method=status, version=2, client=Prysm, peer=16...HcnnMH, requestId=48
[34mdebug[39m: Irrelevant peer peer=16...HcnnMH, reason=INCOMPATIBLE_FORKS ours: 0x12e80bb5 theirs: 0x450757b9
[34mdebug[39m: initiating goodbyeAndDisconnect peer reason=Irrelevant network, peerId=16...HcnnMH
```
`ours` here is still the previous fork digest

**Description**

Update local status fork digest on fork boundary transition. It seemed the easiest to do this in the network thread directly as we also update the fork digest of the ENR there.
