### PR TITLE
feat: add semi supernode flag

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -225,6 +225,7 @@ stakers
 subnet
 subnets
 sudo
+supernode
 tcp
 testnet
 testnets

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -211,7 +211,7 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
     beaconNodeOptions.set({network: {discv5: {bootEnrs: [...new Set(bootnodes)]}}});
   }
 
-  beaconNodeOptions.set({chain: {initialCustodyGroupCount: getInitialCustodyGroupCount(args, config, enr)}});
+  beaconNodeOptions.set({chain: {initialCustodyGroupCount: getInitialCustodyGroupCount(args, config, logger, enr)}});
 
   if (args.disableLightClientServer) {
     beaconNodeOptions.set({chain: {disableLightClientServer: true}});
@@ -255,13 +255,27 @@ export function initLogger(
   return logger;
 }
 
-function getInitialCustodyGroupCount(args: BeaconArgs & GlobalArgs, config: ChainForkConfig, enr: SignableENR): number {
+function getInitialCustodyGroupCount(
+  args: BeaconArgs & GlobalArgs,
+  config: ChainForkConfig,
+  logger: LoggerNode,
+  enr: SignableENR
+): number {
   if (args.supernode) {
     return config.NUMBER_OF_CUSTODY_GROUPS;
   }
 
   const enrCgcBytes = enr.kvs.get("cgc");
   const enrCgc = enrCgcBytes != null ? bytesToInt(enrCgcBytes, "be") : 0;
+
+  if (args.semiSupernode) {
+    if (enrCgc > config.NUMBER_OF_CUSTODY_GROUPS / 2) {
+      logger.warn(
+        `Reducing custody requirements is not supported, will continue to use custody group count of ${enrCgc}`
+      );
+    }
+    return Math.max(enrCgc, config.NUMBER_OF_CUSTODY_GROUPS / 2);
+  }
 
   return Math.max(enrCgc, config.CUSTODY_REQUIREMENT);
 }

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -269,12 +269,13 @@ function getInitialCustodyGroupCount(
   const enrCgc = enrCgcBytes != null ? bytesToInt(enrCgcBytes, "be") : 0;
 
   if (args.semiSupernode) {
-    if (enrCgc > config.NUMBER_OF_CUSTODY_GROUPS / 2) {
+    const semiSupernodeCgc = config.NUMBER_OF_CUSTODY_GROUPS / 2;
+    if (enrCgc > semiSupernodeCgc) {
       logger.warn(
         `Reducing custody requirements is not supported, will continue to use custody group count of ${enrCgc}`
       );
     }
-    return Math.max(enrCgc, config.NUMBER_OF_CUSTODY_GROUPS / 2);
+    return Math.max(enrCgc, semiSupernodeCgc);
   }
 
   return Math.max(enrCgc, config.CUSTODY_REQUIREMENT);

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -269,7 +269,7 @@ function getInitialCustodyGroupCount(
   const enrCgc = enrCgcBytes != null ? bytesToInt(enrCgcBytes, "be") : 0;
 
   if (args.semiSupernode) {
-    const semiSupernodeCgc = config.NUMBER_OF_CUSTODY_GROUPS / 2;
+    const semiSupernodeCgc = Math.floor(config.NUMBER_OF_CUSTODY_GROUPS / 2);
     if (enrCgc > semiSupernodeCgc) {
       logger.warn(
         `Reducing custody requirements is not supported, will continue to use custody group count of ${enrCgc}`

--- a/packages/cli/src/options/globalOptions.ts
+++ b/packages/cli/src/options/globalOptions.ts
@@ -12,6 +12,7 @@ type GlobalSingleArgs = {
   presetFile?: string;
   rcConfig?: string;
   supernode?: boolean;
+  semiSupernode?: boolean;
 };
 
 export const defaultNetwork: NetworkName = "mainnet";
@@ -55,6 +56,14 @@ const globalSingleOptions: CliCommandOptions<GlobalSingleArgs> = {
   supernode: {
     description: "Subscribe to and custody all data column sidecar subnets",
     type: "boolean",
+    conflicts: ["semiSupernode"],
+  },
+
+  semiSupernode: {
+    description:
+      "Subscribe to and custody half of the data column sidecar subnets to support blob reconstruction, enabling more efficient data availability with lower bandwidth and storage requirements compared to a supernode.",
+    type: "boolean",
+    conflicts: ["supernode"],
   },
 };
 


### PR DESCRIPTION
**Motivation**

Enable more efficient data availability with lower bandwidth and storage requirements compared to a supernode.

**Description**

Adds new `--semiSupernode` flag to subscribe to and custody half of the data column sidecar subnets to support blob reconstruction. This change in combination with https://github.com/ChainSafe/lodestar/pull/8567 will make it a lot less resource intensive to run a blob serving node.

I went with the same flag name as Lighthouse currently uses for this https://github.com/sigp/lighthouse/issues/8218 to make it easier for users, even though I don't think this flag name is great. We can look into other ways to reconstruct blobs later, like fetching missing columns over req/resp, which will eventually become necessary if we want to support home operators that need blobs with higher max blob counts.

**Note:** If the custody group count of the node was higher than 64 previously it will not be reduced. It is required to remove the ENR either manually or by setting `--persistNetworkIdentity false` to reset the custody requirements.
