### PR TITLE
fix: resubscribe to beacon subnets on current epoch reorg

### DIFF
--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -372,9 +372,9 @@ export class AttestationDutiesService {
         this.logger.error("Failed to redownload attester duties when reorg happens", logContext, e);
       });
 
-      const beaconCommitteeSubscriptions: routes.validator.BeaconCommitteeSubscription[] = [];
-      const epochDuties = this.dutiesByIndexByEpoch.get(dutyEpoch)?.dutiesByIndex;
-    
+    const beaconCommitteeSubscriptions: routes.validator.BeaconCommitteeSubscription[] = [];
+    const epochDuties = this.dutiesByIndexByEpoch.get(dutyEpoch)?.dutiesByIndex;
+
     if (epochDuties) {
       for (const {duty, selectionProof} of epochDuties.values()) {
         beaconCommitteeSubscriptions.push({
@@ -390,9 +390,7 @@ export class AttestationDutiesService {
     if (beaconCommitteeSubscriptions.length > 0) {
       const subscriptionsBatches = batchItems(beaconCommitteeSubscriptions, {batchSize: SUBSCRIPTIONS_PER_REQUEST});
       await Promise.all(
-        subscriptionsBatches.map((subscriptions) => 
-          this.api.validator.prepareBeaconCommitteeSubnet({subscriptions})
-        )
+        subscriptionsBatches.map((subscriptions) => this.api.validator.prepareBeaconCommitteeSubnet({subscriptions}))
       );
     }
   }

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -371,6 +371,30 @@ export class AttestationDutiesService {
       .catch((e: Error) => {
         this.logger.error("Failed to redownload attester duties when reorg happens", logContext, e);
       });
+
+      const beaconCommitteeSubscriptions: routes.validator.BeaconCommitteeSubscription[] = [];
+      const epochDuties = this.dutiesByIndexByEpoch.get(dutyEpoch)?.dutiesByIndex;
+    
+    if (epochDuties) {
+      for (const {duty, selectionProof} of epochDuties.values()) {
+        beaconCommitteeSubscriptions.push({
+          validatorIndex: duty.validatorIndex,
+          committeesAtSlot: duty.committeesAtSlot,
+          committeeIndex: duty.committeeIndex,
+          slot: duty.slot,
+          isAggregator: selectionProof !== null,
+        });
+      }
+    }
+
+    if (beaconCommitteeSubscriptions.length > 0) {
+      const subscriptionsBatches = batchItems(beaconCommitteeSubscriptions, {batchSize: SUBSCRIPTIONS_PER_REQUEST});
+      await Promise.all(
+        subscriptionsBatches.map((subscriptions) => 
+          this.api.validator.prepareBeaconCommitteeSubnet({subscriptions})
+        )
+      );
+    }
   }
 
   private async getDutyAndProof(duty: routes.validator.AttesterDuty): Promise<AttDutyAndProof> {

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -169,24 +169,6 @@ export class AttestationDutiesService {
   };
 
   /**
-   * Subscribe to beacon committee subnets with batching and error handling
-   */
-  private async subscribeToBeaconCommitteeSubnets(
-    beaconCommitteeSubscriptions: routes.validator.BeaconCommitteeSubscription[]
-  ): Promise<void> {
-    if (beaconCommitteeSubscriptions.length > 0) {
-      const subscriptionsBatches = batchItems(beaconCommitteeSubscriptions, {batchSize: SUBSCRIPTIONS_PER_REQUEST});
-      const responses = await Promise.all(
-        subscriptionsBatches.map((subscriptions) => this.api.validator.prepareBeaconCommitteeSubnet({subscriptions}))
-      );
-
-      for (const res of responses) {
-        res.assertOk();
-      }
-    }
-  }
-
-  /**
    * Query the beacon node for attestation duties for any known validators.
    *
    * This function will perform (in the following order):
@@ -397,6 +379,21 @@ export class AttestationDutiesService {
     }
 
     await this.subscribeToBeaconCommitteeSubnets(beaconCommitteeSubscriptions);
+  }
+
+  private async subscribeToBeaconCommitteeSubnets(
+    beaconCommitteeSubscriptions: routes.validator.BeaconCommitteeSubscription[]
+  ): Promise<void> {
+    if (beaconCommitteeSubscriptions.length > 0) {
+      const subscriptionsBatches = batchItems(beaconCommitteeSubscriptions, {batchSize: SUBSCRIPTIONS_PER_REQUEST});
+      const responses = await Promise.all(
+        subscriptionsBatches.map((subscriptions) => this.api.validator.prepareBeaconCommitteeSubnet({subscriptions}))
+      );
+
+      for (const res of responses) {
+        res.assertOk();
+      }
+    }
   }
 
   private async getDutyAndProof(duty: routes.validator.AttesterDuty): Promise<AttDutyAndProof> {

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -378,6 +378,7 @@ export class AttestationDutiesService {
       }
     }
 
+    // Previous subscriptions are no longer valid and need to updated
     await this.subscribeToBeaconCommitteeSubnets(beaconCommitteeSubscriptions);
   }
 

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -169,6 +169,24 @@ export class AttestationDutiesService {
   };
 
   /**
+   * Subscribe to beacon committee subnets with batching and error handling
+   */
+  private async subscribeToBeaconCommitteeSubnets(
+    beaconCommitteeSubscriptions: routes.validator.BeaconCommitteeSubscription[]
+  ): Promise<void> {
+    if (beaconCommitteeSubscriptions.length > 0) {
+      const subscriptionsBatches = batchItems(beaconCommitteeSubscriptions, {batchSize: SUBSCRIPTIONS_PER_REQUEST});
+      const responses = await Promise.all(
+        subscriptionsBatches.map((subscriptions) => this.api.validator.prepareBeaconCommitteeSubnet({subscriptions}))
+      );
+
+      for (const res of responses) {
+        res.assertOk();
+      }
+    }
+  }
+
+  /**
    * Query the beacon node for attestation duties for any known validators.
    *
    * This function will perform (in the following order):
@@ -219,16 +237,7 @@ export class AttestationDutiesService {
     }
 
     // If there are any subscriptions, push them out to the beacon node.
-    if (beaconCommitteeSubscriptions.length > 0) {
-      const subscriptionsBatches = batchItems(beaconCommitteeSubscriptions, {batchSize: SUBSCRIPTIONS_PER_REQUEST});
-      const responses = await Promise.all(
-        subscriptionsBatches.map((subscriptions) => this.api.validator.prepareBeaconCommitteeSubnet({subscriptions}))
-      );
-
-      for (const res of responses) {
-        res.assertOk();
-      }
-    }
+    await this.subscribeToBeaconCommitteeSubnets(beaconCommitteeSubscriptions);
   }
 
   /**
@@ -387,12 +396,7 @@ export class AttestationDutiesService {
       }
     }
 
-    if (beaconCommitteeSubscriptions.length > 0) {
-      const subscriptionsBatches = batchItems(beaconCommitteeSubscriptions, {batchSize: SUBSCRIPTIONS_PER_REQUEST});
-      await Promise.all(
-        subscriptionsBatches.map((subscriptions) => this.api.validator.prepareBeaconCommitteeSubnet({subscriptions}))
-      );
-    }
+    await this.subscribeToBeaconCommitteeSubnets(beaconCommitteeSubscriptions);
   }
 
   private async getDutyAndProof(duty: routes.validator.AttesterDuty): Promise<AttDutyAndProof> {

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -378,7 +378,7 @@ export class AttestationDutiesService {
       }
     }
 
-    // Previous subscriptions are no longer valid and need to updated
+    // Previous subscriptions are no longer valid and need to be updated
     await this.subscribeToBeaconCommitteeSubnets(beaconCommitteeSubscriptions);
   }
 

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -241,4 +241,76 @@ describe("AttestationDutiesService", () => {
 
     expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledOnce();
   });
+
+  it("Should resubscribe to beacon subnets when current epoch dependent root changes", async () => {
+    const slot = 1;
+    const epoch = computeEpochAtSlot(slot);
+    
+    // Setup initial duties setup
+    const duty: routes.validator.AttesterDuty = {
+      slot: slot,
+      committeeIndex: 1,
+      committeeLength: 120,
+      committeesAtSlot: 120,
+      validatorCommitteeIndex: 1,
+      validatorIndex: index,
+      pubkey: pubkeys[0],
+    };
+    
+    api.validator.getAttesterDuties.mockResolvedValue(
+      mockApiResponse({
+        data: [duty], 
+        meta: {dependentRoot: "0xOLD_ROOT", executionOptimistic: false}
+      })
+    );
+    api.validator.prepareBeaconCommitteeSubnet.mockResolvedValue(mockApiResponse({}));
+
+    const clock = new ClockMock();
+    const syncingStatusTracker = new SyncingStatusTracker(loggerVc, api, clock, null);
+    const dutiesService = new AttestationDutiesService(
+      loggerVc,
+      api,
+      clock,
+      validatorStore,
+      chainHeadTracker,
+      syncingStatusTracker,
+      null
+    );
+
+    // Initial duties fetch
+    await clock.tickEpochFns(0, controller.signal);
+    
+    // Verify initial subscription
+    expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(1);
+
+    // Seting up new duties with different dependent root (REORG!)
+    const newDuty = {...duty, slot: 2, committeeIndex: 3};
+    api.validator.getAttesterDuties.mockResolvedValue(
+      mockApiResponse({
+        data: [newDuty], 
+        meta: {dependentRoot: "0xNEW_ROOT", executionOptimistic: false}
+      })
+    );
+
+    // Call handleAttesterDutiesReorg (simulates reorg)
+    await dutiesService["handleAttesterDutiesReorg"](
+      epoch,
+      slot,
+      "0xOLD_ROOT",
+      "0xNEW_ROOT"
+    );
+
+    expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(2);
+  
+    // Verify the new subscription contains updated duties
+    const lastCallArgs = api.validator.prepareBeaconCommitteeSubnet.mock.calls[1][0];
+    expect(lastCallArgs.subscriptions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          slot: newDuty.slot,
+          committeeIndex: newDuty.committeeIndex,
+        })
+      ])
+    );
+  });
 });

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -7,6 +7,7 @@ import {chainConfig} from "@lodestar/config/default";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
 import {AttestationDutiesService} from "../../../src/services/attestationDuties.js";
 import {ChainHeaderTracker, HeadEventData} from "../../../src/services/chainHeaderTracker.js";
 import {SyncingStatusTracker} from "../../../src/services/syncingStatusTracker.js";
@@ -244,21 +245,28 @@ describe("AttestationDutiesService", () => {
   });
 
   describe("Reorg handling", () => {
-    const setupDuty = (slot: number): routes.validator.AttesterDuty => ({
-      slot,
-      committeeIndex: 1,
-      committeeLength: 120,
-      committeesAtSlot: 120,
-      validatorCommitteeIndex: 1,
-      validatorIndex: index,
-      pubkey: pubkeys[0],
-    });
+    const oldDependentRoot = toRootHex(Buffer.alloc(32, 1));
+    const newDependentRoot = toRootHex(Buffer.alloc(32, 2));
+    const headBlockRoot = toRootHex(Buffer.alloc(32, 3));
 
-    async function setupTestEnvironment(duty: routes.validator.AttesterDuty, dependentRoot = "0xOLD_ROOT") {
+    it("Should resubscribe to beacon subnets when current epoch dependent root changes", async () => {
+      const slot = 5;
+      const currentEpoch = computeEpochAtSlot(slot);
+
+      const duty: routes.validator.AttesterDuty = {
+        slot,
+        committeeIndex: 1,
+        committeeLength: 120,
+        committeesAtSlot: 120,
+        validatorCommitteeIndex: 1,
+        validatorIndex: index,
+        pubkey: pubkeys[0],
+      };
+
       api.validator.getAttesterDuties.mockResolvedValue(
         mockApiResponse({
           data: [duty],
-          meta: {dependentRoot, executionOptimistic: false},
+          meta: {dependentRoot: oldDependentRoot, executionOptimistic: false},
         })
       );
       api.validator.prepareBeaconCommitteeSubnet.mockResolvedValue(mockApiResponse({}));
@@ -266,6 +274,7 @@ describe("AttestationDutiesService", () => {
       const clock = new ClockMock();
       const syncingStatusTracker = new SyncingStatusTracker(loggerVc, api, clock, null);
 
+      vi.spyOn(chainHeadTracker, "runOnNewHead");
       let onNewHeadCallback: ((headEvent: HeadEventData) => Promise<void>) | undefined;
       chainHeadTracker.runOnNewHead.mockImplementation((callback) => {
         onNewHeadCallback = callback;
@@ -281,34 +290,24 @@ describe("AttestationDutiesService", () => {
         null
       );
 
-      if (!onNewHeadCallback) throw new Error("onNewHeadCallback not initialized");
-      return {clock, dutiesService, onNewHeadCallback: onNewHeadCallback};
-    }
+      await clock.tickEpochFns(currentEpoch, controller.signal);
 
-    it("Should resubscribe to beacon subnets when current epoch dependent root changes", async () => {
-      const slot = 5;
-      const epoch = computeEpochAtSlot(slot);
-      const duty = setupDuty(slot);
-
-      const {clock, dutiesService, onNewHeadCallback} = await setupTestEnvironment(duty);
-      await clock.tickEpochFns(epoch, controller.signal);
-
-      expect(dutiesService["dutiesByIndexByEpoch"].get(epoch)).toBeDefined();
+      expect(dutiesService["dutiesByIndexByEpoch"].get(currentEpoch)).toBeDefined();
       expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(1);
 
       const reorgedDuty = {...duty, slot: slot + 1, committeeIndex: 3};
       api.validator.getAttesterDuties.mockResolvedValue(
         mockApiResponse({
           data: [reorgedDuty],
-          meta: {dependentRoot: "0xNEW_ROOT", executionOptimistic: false},
+          meta: {dependentRoot: newDependentRoot, executionOptimistic: false},
         })
       );
 
-      await onNewHeadCallback({
+      await onNewHeadCallback!({
         slot,
-        head: "0xHEAD_BLOCK",
-        previousDutyDependentRoot: "0xOLD_ROOT",
-        currentDutyDependentRoot: "0xNEW_ROOT",
+        head: headBlockRoot,
+        previousDutyDependentRoot: newDependentRoot,
+        currentDutyDependentRoot: oldDependentRoot,
       });
 
       expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(2);
@@ -328,48 +327,141 @@ describe("AttestationDutiesService", () => {
     it("Should resubscribe when next epoch dependent root changes", async () => {
       const slot = 5;
       const currentEpoch = computeEpochAtSlot(slot);
-      const duty = setupDuty(slot);
+      const nextEpoch = currentEpoch + 1;
 
-      const {clock, dutiesService, onNewHeadCallback} = await setupTestEnvironment(duty);
+      const currentEpochDuty: routes.validator.AttesterDuty = {
+        slot,
+        committeeIndex: 1,
+        committeeLength: 120,
+        committeesAtSlot: 120,
+        validatorCommitteeIndex: 1,
+        validatorIndex: index,
+        pubkey: pubkeys[0],
+      };
+
+      const nextEpochDuty: routes.validator.AttesterDuty = {
+        slot: slot + SLOTS_PER_EPOCH,
+        committeeIndex: 2,
+        committeeLength: 120,
+        committeesAtSlot: 120,
+        validatorCommitteeIndex: 1,
+        validatorIndex: index,
+        pubkey: pubkeys[0],
+      };
+
+      api.validator.getAttesterDuties.mockResolvedValue(
+        mockApiResponse({
+          data: [currentEpochDuty],
+          meta: {dependentRoot: oldDependentRoot, executionOptimistic: false},
+        })
+      );
+      api.validator.prepareBeaconCommitteeSubnet.mockResolvedValue(mockApiResponse({}));
+
+      const clock = new ClockMock();
+      const syncingStatusTracker = new SyncingStatusTracker(loggerVc, api, clock, null);
+
+      vi.spyOn(chainHeadTracker, "runOnNewHead");
+      let onNewHeadCallback: ((headEvent: HeadEventData) => Promise<void>) | undefined;
+      chainHeadTracker.runOnNewHead.mockImplementation((callback) => {
+        onNewHeadCallback = callback;
+      });
+
+      const dutiesService = new AttestationDutiesService(
+        loggerVc,
+        api,
+        clock,
+        validatorStore,
+        chainHeadTracker,
+        syncingStatusTracker,
+        null
+      );
+
       await clock.tickEpochFns(currentEpoch, controller.signal);
 
       expect(dutiesService["dutiesByIndexByEpoch"].get(currentEpoch)).toBeDefined();
+      expect(dutiesService["dutiesByIndexByEpoch"].get(nextEpoch)).toBeDefined();
       expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(1);
 
-      const reorgedDuty = {...duty, slot: slot + SLOTS_PER_EPOCH, committeeIndex: 3};
+      const reorgedNextEpochDuty = {...nextEpochDuty, committeeIndex: 4};
       api.validator.getAttesterDuties.mockResolvedValue(
         mockApiResponse({
-          data: [reorgedDuty],
-          meta: {dependentRoot: "0xNEW_NEXT_ROOT", executionOptimistic: false},
+          data: [reorgedNextEpochDuty],
+          meta: {dependentRoot: newDependentRoot, executionOptimistic: false},
         })
       );
 
-      await onNewHeadCallback({
+      await onNewHeadCallback!({
         slot,
-        head: "0xHEAD_BLOCK",
-        previousDutyDependentRoot: "0xOLD_ROOT",
-        currentDutyDependentRoot: "0xNEW_NEXT_ROOT",
+        head: headBlockRoot,
+        previousDutyDependentRoot: oldDependentRoot,
+        currentDutyDependentRoot: newDependentRoot,
       });
 
       expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(2);
+
+      const lastCallArgs = api.validator.prepareBeaconCommitteeSubnet.mock.calls[1][0];
+      expect(lastCallArgs.subscriptions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            validatorIndex: index,
+            slot: reorgedNextEpochDuty.slot,
+            committeeIndex: reorgedNextEpochDuty.committeeIndex,
+          }),
+        ])
+      );
     });
 
     it("Should not resubscribe when dependent root unchanged", async () => {
       const slot = 5;
       const currentEpoch = computeEpochAtSlot(slot);
-      const duty = setupDuty(slot);
 
-      const {clock, dutiesService, onNewHeadCallback} = await setupTestEnvironment(duty);
+      const duty: routes.validator.AttesterDuty = {
+        slot,
+        committeeIndex: 1,
+        committeeLength: 120,
+        committeesAtSlot: 120,
+        validatorCommitteeIndex: 1,
+        validatorIndex: index,
+        pubkey: pubkeys[0],
+      };
+
+      api.validator.getAttesterDuties.mockResolvedValue(
+        mockApiResponse({
+          data: [duty],
+          meta: {dependentRoot: oldDependentRoot, executionOptimistic: false},
+        })
+      );
+      api.validator.prepareBeaconCommitteeSubnet.mockResolvedValue(mockApiResponse({}));
+
+      const clock = new ClockMock();
+      const syncingStatusTracker = new SyncingStatusTracker(loggerVc, api, clock, null);
+
+      vi.spyOn(chainHeadTracker, "runOnNewHead");
+      let onNewHeadCallback: ((headEvent: HeadEventData) => Promise<void>) | undefined;
+      chainHeadTracker.runOnNewHead.mockImplementation((callback) => {
+        onNewHeadCallback = callback;
+      });
+
+      const dutiesService = new AttestationDutiesService(
+        loggerVc,
+        api,
+        clock,
+        validatorStore,
+        chainHeadTracker,
+        syncingStatusTracker,
+        null
+      );
+
       await clock.tickEpochFns(currentEpoch, controller.signal);
 
       expect(dutiesService["dutiesByIndexByEpoch"].get(currentEpoch)).toBeDefined();
       const initialCalls = api.validator.prepareBeaconCommitteeSubnet.mock.calls.length;
 
-      await onNewHeadCallback({
+      await onNewHeadCallback!({
         slot,
-        head: "0xHEAD_BLOCK",
-        previousDutyDependentRoot: "0xOLD_ROOT",
-        currentDutyDependentRoot: "0xOLD_ROOT",
+        head: headBlockRoot,
+        previousDutyDependentRoot: oldDependentRoot,
+        currentDutyDependentRoot: oldDependentRoot,
       });
 
       expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(initialCalls);

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -249,6 +249,32 @@ describe("AttestationDutiesService", () => {
     const newDependentRoot = toRootHex(Buffer.alloc(32, 2));
     const headBlockRoot = toRootHex(Buffer.alloc(32, 3));
 
+    let clock: ClockMock;
+    let dutiesService: AttestationDutiesService;
+    let onNewHeadCallback: (headEvent: HeadEventData) => Promise<void>;
+
+    beforeEach(() => {
+      api.validator.prepareBeaconCommitteeSubnet.mockResolvedValue(mockApiResponse({}));
+
+      clock = new ClockMock();
+      const syncingStatusTracker = new SyncingStatusTracker(loggerVc, api, clock, null);
+
+      vi.spyOn(chainHeadTracker, "runOnNewHead");
+      chainHeadTracker.runOnNewHead.mockImplementation((callback) => {
+        onNewHeadCallback = callback;
+      });
+
+      dutiesService = new AttestationDutiesService(
+        loggerVc,
+        api,
+        clock,
+        validatorStore,
+        chainHeadTracker,
+        syncingStatusTracker,
+        null
+      );
+    });
+
     it("Should resubscribe to beacon subnets when current epoch dependent root changes", async () => {
       const slot = 5;
       const currentEpoch = computeEpochAtSlot(slot);
@@ -269,33 +295,13 @@ describe("AttestationDutiesService", () => {
           meta: {dependentRoot: oldDependentRoot, executionOptimistic: false},
         })
       );
-      api.validator.prepareBeaconCommitteeSubnet.mockResolvedValue(mockApiResponse({}));
-
-      const clock = new ClockMock();
-      const syncingStatusTracker = new SyncingStatusTracker(loggerVc, api, clock, null);
-
-      vi.spyOn(chainHeadTracker, "runOnNewHead");
-      let onNewHeadCallback: ((headEvent: HeadEventData) => Promise<void>) | undefined;
-      chainHeadTracker.runOnNewHead.mockImplementation((callback) => {
-        onNewHeadCallback = callback;
-      });
-
-      const dutiesService = new AttestationDutiesService(
-        loggerVc,
-        api,
-        clock,
-        validatorStore,
-        chainHeadTracker,
-        syncingStatusTracker,
-        null
-      );
 
       await clock.tickEpochFns(currentEpoch, controller.signal);
 
-      expect(dutiesService["dutiesByIndexByEpoch"].get(currentEpoch)).toBeDefined();
+      expect(dutiesService["dutiesByIndexByEpoch"].get(currentEpoch)?.dutiesByIndex.get(index)?.duty).toEqual(duty);
       expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(1);
 
-      const reorgedDuty = {...duty, slot: slot + 1, committeeIndex: 3};
+      const reorgedDuty: routes.validator.AttesterDuty = {...duty, slot: slot + 1, committeeIndex: 3};
       api.validator.getAttesterDuties.mockResolvedValue(
         mockApiResponse({
           data: [reorgedDuty],
@@ -303,7 +309,7 @@ describe("AttestationDutiesService", () => {
         })
       );
 
-      await onNewHeadCallback!({
+      await onNewHeadCallback({
         slot,
         head: headBlockRoot,
         previousDutyDependentRoot: newDependentRoot,
@@ -311,20 +317,23 @@ describe("AttestationDutiesService", () => {
       });
 
       expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(2);
-
-      const lastCallArgs = api.validator.prepareBeaconCommitteeSubnet.mock.calls[1][0];
-      expect(lastCallArgs.subscriptions).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            validatorIndex: index,
-            slot: reorgedDuty.slot,
+      expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenLastCalledWith({
+        subscriptions: [
+          {
+            validatorIndex: reorgedDuty.validatorIndex,
+            committeesAtSlot: reorgedDuty.committeesAtSlot,
             committeeIndex: reorgedDuty.committeeIndex,
-          }),
-        ])
+            slot: reorgedDuty.slot,
+            isAggregator: false,
+          },
+        ],
+      });
+      expect(dutiesService["dutiesByIndexByEpoch"].get(currentEpoch)?.dutiesByIndex.get(index)?.duty).toEqual(
+        reorgedDuty
       );
     });
 
-    it("Should resubscribe when next epoch dependent root changes", async () => {
+    it("Should resubscribe to beacon subnets when next epoch dependent root changes", async () => {
       const slot = 5;
       const currentEpoch = computeEpochAtSlot(slot);
       const nextEpoch = currentEpoch + 1;
@@ -349,40 +358,33 @@ describe("AttestationDutiesService", () => {
         pubkey: pubkeys[0],
       };
 
-      api.validator.getAttesterDuties.mockResolvedValue(
+      // First call for current epoch
+      api.validator.getAttesterDuties.mockResolvedValueOnce(
         mockApiResponse({
           data: [currentEpochDuty],
           meta: {dependentRoot: oldDependentRoot, executionOptimistic: false},
         })
       );
-      api.validator.prepareBeaconCommitteeSubnet.mockResolvedValue(mockApiResponse({}));
 
-      const clock = new ClockMock();
-      const syncingStatusTracker = new SyncingStatusTracker(loggerVc, api, clock, null);
-
-      vi.spyOn(chainHeadTracker, "runOnNewHead");
-      let onNewHeadCallback: ((headEvent: HeadEventData) => Promise<void>) | undefined;
-      chainHeadTracker.runOnNewHead.mockImplementation((callback) => {
-        onNewHeadCallback = callback;
-      });
-
-      const dutiesService = new AttestationDutiesService(
-        loggerVc,
-        api,
-        clock,
-        validatorStore,
-        chainHeadTracker,
-        syncingStatusTracker,
-        null
+      // Second call for next epoch
+      api.validator.getAttesterDuties.mockResolvedValueOnce(
+        mockApiResponse({
+          data: [nextEpochDuty],
+          meta: {dependentRoot: oldDependentRoot, executionOptimistic: false},
+        })
       );
 
       await clock.tickEpochFns(currentEpoch, controller.signal);
 
-      expect(dutiesService["dutiesByIndexByEpoch"].get(currentEpoch)).toBeDefined();
-      expect(dutiesService["dutiesByIndexByEpoch"].get(nextEpoch)).toBeDefined();
+      expect(dutiesService["dutiesByIndexByEpoch"].get(currentEpoch)?.dutiesByIndex.get(index)?.duty).toEqual(
+        currentEpochDuty
+      );
+      expect(dutiesService["dutiesByIndexByEpoch"].get(nextEpoch)?.dutiesByIndex.get(index)?.duty).toEqual(
+        nextEpochDuty
+      );
       expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(1);
 
-      const reorgedNextEpochDuty = {...nextEpochDuty, committeeIndex: 4};
+      const reorgedNextEpochDuty: routes.validator.AttesterDuty = {...nextEpochDuty, committeeIndex: 4};
       api.validator.getAttesterDuties.mockResolvedValue(
         mockApiResponse({
           data: [reorgedNextEpochDuty],
@@ -390,7 +392,7 @@ describe("AttestationDutiesService", () => {
         })
       );
 
-      await onNewHeadCallback!({
+      await onNewHeadCallback({
         slot,
         head: headBlockRoot,
         previousDutyDependentRoot: oldDependentRoot,
@@ -398,20 +400,23 @@ describe("AttestationDutiesService", () => {
       });
 
       expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(2);
-
-      const lastCallArgs = api.validator.prepareBeaconCommitteeSubnet.mock.calls[1][0];
-      expect(lastCallArgs.subscriptions).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            validatorIndex: index,
-            slot: reorgedNextEpochDuty.slot,
+      expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenLastCalledWith({
+        subscriptions: [
+          {
+            validatorIndex: reorgedNextEpochDuty.validatorIndex,
+            committeesAtSlot: reorgedNextEpochDuty.committeesAtSlot,
             committeeIndex: reorgedNextEpochDuty.committeeIndex,
-          }),
-        ])
+            slot: reorgedNextEpochDuty.slot,
+            isAggregator: false,
+          },
+        ],
+      });
+      expect(dutiesService["dutiesByIndexByEpoch"].get(nextEpoch)?.dutiesByIndex.get(index)?.duty).toEqual(
+        reorgedNextEpochDuty
       );
     });
 
-    it("Should not resubscribe when dependent root unchanged", async () => {
+    it("Should not resubscribe to beacon subnets when dependent root is unchanged", async () => {
       const slot = 5;
       const currentEpoch = computeEpochAtSlot(slot);
 
@@ -431,33 +436,13 @@ describe("AttestationDutiesService", () => {
           meta: {dependentRoot: oldDependentRoot, executionOptimistic: false},
         })
       );
-      api.validator.prepareBeaconCommitteeSubnet.mockResolvedValue(mockApiResponse({}));
-
-      const clock = new ClockMock();
-      const syncingStatusTracker = new SyncingStatusTracker(loggerVc, api, clock, null);
-
-      vi.spyOn(chainHeadTracker, "runOnNewHead");
-      let onNewHeadCallback: ((headEvent: HeadEventData) => Promise<void>) | undefined;
-      chainHeadTracker.runOnNewHead.mockImplementation((callback) => {
-        onNewHeadCallback = callback;
-      });
-
-      const dutiesService = new AttestationDutiesService(
-        loggerVc,
-        api,
-        clock,
-        validatorStore,
-        chainHeadTracker,
-        syncingStatusTracker,
-        null
-      );
 
       await clock.tickEpochFns(currentEpoch, controller.signal);
 
-      expect(dutiesService["dutiesByIndexByEpoch"].get(currentEpoch)).toBeDefined();
+      expect(dutiesService["dutiesByIndexByEpoch"].get(currentEpoch)?.dutiesByIndex.get(index)?.duty).toEqual(duty);
       const initialCalls = api.validator.prepareBeaconCommitteeSubnet.mock.calls.length;
 
-      await onNewHeadCallback!({
+      await onNewHeadCallback({
         slot,
         head: headBlockRoot,
         previousDutyDependentRoot: oldDependentRoot,

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -4,10 +4,11 @@ import {SecretKey} from "@chainsafe/blst";
 import {toHexString} from "@chainsafe/ssz";
 import {routes} from "@lodestar/api";
 import {chainConfig} from "@lodestar/config/default";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {AttestationDutiesService} from "../../../src/services/attestationDuties.js";
-import {ChainHeaderTracker} from "../../../src/services/chainHeaderTracker.js";
+import {ChainHeaderTracker, HeadEventData} from "../../../src/services/chainHeaderTracker.js";
 import {SyncingStatusTracker} from "../../../src/services/syncingStatusTracker.js";
 import {ValidatorStore} from "../../../src/services/validatorStore.js";
 import {getApiClientStub, mockApiResponse} from "../../utils/apiStub.js";
@@ -242,75 +243,136 @@ describe("AttestationDutiesService", () => {
     expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledOnce();
   });
 
-  it("Should resubscribe to beacon subnets when current epoch dependent root changes", async () => {
-    const slot = 1;
-    const epoch = computeEpochAtSlot(slot);
-    
-    // Setup initial duties setup
-    const duty: routes.validator.AttesterDuty = {
-      slot: slot,
+  describe("Reorg handling", () => {
+    const setupDuty = (slot: number): routes.validator.AttesterDuty => ({
+      slot,
       committeeIndex: 1,
       committeeLength: 120,
       committeesAtSlot: 120,
       validatorCommitteeIndex: 1,
       validatorIndex: index,
       pubkey: pubkeys[0],
-    };
-    
-    api.validator.getAttesterDuties.mockResolvedValue(
-      mockApiResponse({
-        data: [duty], 
-        meta: {dependentRoot: "0xOLD_ROOT", executionOptimistic: false}
-      })
-    );
-    api.validator.prepareBeaconCommitteeSubnet.mockResolvedValue(mockApiResponse({}));
+    });
 
-    const clock = new ClockMock();
-    const syncingStatusTracker = new SyncingStatusTracker(loggerVc, api, clock, null);
-    const dutiesService = new AttestationDutiesService(
-      loggerVc,
-      api,
-      clock,
-      validatorStore,
-      chainHeadTracker,
-      syncingStatusTracker,
-      null
-    );
-
-    // Initial duties fetch
-    await clock.tickEpochFns(0, controller.signal);
-    
-    // Verify initial subscription
-    expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(1);
-
-    // Seting up new duties with different dependent root (REORG!)
-    const newDuty = {...duty, slot: 2, committeeIndex: 3};
-    api.validator.getAttesterDuties.mockResolvedValue(
-      mockApiResponse({
-        data: [newDuty], 
-        meta: {dependentRoot: "0xNEW_ROOT", executionOptimistic: false}
-      })
-    );
-
-    // Call handleAttesterDutiesReorg (simulates reorg)
-    await dutiesService["handleAttesterDutiesReorg"](
-      epoch,
-      slot,
-      "0xOLD_ROOT",
-      "0xNEW_ROOT"
-    );
-
-    expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(2);
-  
-    // Verify the new subscription contains updated duties
-    const lastCallArgs = api.validator.prepareBeaconCommitteeSubnet.mock.calls[1][0];
-    expect(lastCallArgs.subscriptions).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          slot: newDuty.slot,
-          committeeIndex: newDuty.committeeIndex,
+    async function setupTestEnvironment(duty: routes.validator.AttesterDuty, dependentRoot = "0xOLD_ROOT") {
+      api.validator.getAttesterDuties.mockResolvedValue(
+        mockApiResponse({
+          data: [duty],
+          meta: {dependentRoot, executionOptimistic: false},
         })
-      ])
-    );
+      );
+      api.validator.prepareBeaconCommitteeSubnet.mockResolvedValue(mockApiResponse({}));
+
+      const clock = new ClockMock();
+      const syncingStatusTracker = new SyncingStatusTracker(loggerVc, api, clock, null);
+
+      let onNewHeadCallback: ((headEvent: HeadEventData) => Promise<void>) | undefined;
+      chainHeadTracker.runOnNewHead.mockImplementation((callback) => {
+        onNewHeadCallback = callback;
+      });
+
+      const dutiesService = new AttestationDutiesService(
+        loggerVc,
+        api,
+        clock,
+        validatorStore,
+        chainHeadTracker,
+        syncingStatusTracker,
+        null
+      );
+
+      if (!onNewHeadCallback) throw new Error("onNewHeadCallback not initialized");
+      return {clock, dutiesService, onNewHeadCallback: onNewHeadCallback};
+    }
+
+    it("Should resubscribe to beacon subnets when current epoch dependent root changes", async () => {
+      const slot = 5;
+      const epoch = computeEpochAtSlot(slot);
+      const duty = setupDuty(slot);
+
+      const {clock, dutiesService, onNewHeadCallback} = await setupTestEnvironment(duty);
+      await clock.tickEpochFns(epoch, controller.signal);
+
+      expect(dutiesService["dutiesByIndexByEpoch"].get(epoch)).toBeDefined();
+      expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(1);
+
+      const reorgedDuty = {...duty, slot: slot + 1, committeeIndex: 3};
+      api.validator.getAttesterDuties.mockResolvedValue(
+        mockApiResponse({
+          data: [reorgedDuty],
+          meta: {dependentRoot: "0xNEW_ROOT", executionOptimistic: false},
+        })
+      );
+
+      await onNewHeadCallback({
+        slot,
+        head: "0xHEAD_BLOCK",
+        previousDutyDependentRoot: "0xOLD_ROOT",
+        currentDutyDependentRoot: "0xNEW_ROOT",
+      });
+
+      expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(2);
+
+      const lastCallArgs = api.validator.prepareBeaconCommitteeSubnet.mock.calls[1][0];
+      expect(lastCallArgs.subscriptions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            validatorIndex: index,
+            slot: reorgedDuty.slot,
+            committeeIndex: reorgedDuty.committeeIndex,
+          }),
+        ])
+      );
+    });
+
+    it("Should resubscribe when next epoch dependent root changes", async () => {
+      const slot = 5;
+      const currentEpoch = computeEpochAtSlot(slot);
+      const duty = setupDuty(slot);
+
+      const {clock, dutiesService, onNewHeadCallback} = await setupTestEnvironment(duty);
+      await clock.tickEpochFns(currentEpoch, controller.signal);
+
+      expect(dutiesService["dutiesByIndexByEpoch"].get(currentEpoch)).toBeDefined();
+      expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(1);
+
+      const reorgedDuty = {...duty, slot: slot + SLOTS_PER_EPOCH, committeeIndex: 3};
+      api.validator.getAttesterDuties.mockResolvedValue(
+        mockApiResponse({
+          data: [reorgedDuty],
+          meta: {dependentRoot: "0xNEW_NEXT_ROOT", executionOptimistic: false},
+        })
+      );
+
+      await onNewHeadCallback({
+        slot,
+        head: "0xHEAD_BLOCK",
+        previousDutyDependentRoot: "0xOLD_ROOT",
+        currentDutyDependentRoot: "0xNEW_NEXT_ROOT",
+      });
+
+      expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(2);
+    });
+
+    it("Should not resubscribe when dependent root unchanged", async () => {
+      const slot = 5;
+      const currentEpoch = computeEpochAtSlot(slot);
+      const duty = setupDuty(slot);
+
+      const {clock, dutiesService, onNewHeadCallback} = await setupTestEnvironment(duty);
+      await clock.tickEpochFns(currentEpoch, controller.signal);
+
+      expect(dutiesService["dutiesByIndexByEpoch"].get(currentEpoch)).toBeDefined();
+      const initialCalls = api.validator.prepareBeaconCommitteeSubnet.mock.calls.length;
+
+      await onNewHeadCallback({
+        slot,
+        head: "0xHEAD_BLOCK",
+        previousDutyDependentRoot: "0xOLD_ROOT",
+        currentDutyDependentRoot: "0xOLD_ROOT",
+      });
+
+      expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledTimes(initialCalls);
+    });
   });
 });


### PR DESCRIPTION
**Motivation**

Not resubscribing to beacon subnets (prepareBeaconCommitteeSubnet) as dependent root for current epoch changes. When this happens, previous subscriptions are no longer valid

validator duties changed (slot, committee index, etc.)
is_aggregator results are different

**Description**

Added subnet resubscription logic to `handleAttesterDutiesReorg` that fetches updated attester duties, rebuild beaconCommitteeSubscriptions and resubscribe validators to the correct beacon subnets by calling the prepareBeaconCommitteeSubnet api

Added test to handle: 
- resubscribe to beacon subnets when current epoch dependent root changes,
- resubscribe when next epoch dependent root changes and
- not resubscribe when dependent root unchanged

There was intentional use of claude AI in writing the test.

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #6034

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
