### PR TITLE
close : use sha commit to docs for spec references #8171

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -192,7 +192,8 @@ export async function verifyBlocksExecutionPayload(
     // a valid terminal PoW block.
     //
     // However specs define this check to be run inside forkChoice's onBlock
-    // (https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/fork-choice.md#on_block)
+    // Reference : On_block
+    // (https://github.com/ethereum/consensus-specs/blob/46306c4f8addef64defc2a52d85f46992ba2421b/specs/bellatrix/fork-choice.md#on_block)
     // but we perform the check here (as inspired from the lighthouse impl)
     //
     // Reasons:

--- a/packages/beacon-node/src/chain/bls/maybeBatch.ts
+++ b/packages/beacon-node/src/chain/bls/maybeBatch.ts
@@ -39,7 +39,8 @@ export function verifySignatureSetsMaybeBatch(sets: SignatureSetDeserialized[]):
   } catch (_) {
     // A signature could be malformed, in that case fromBytes throws error
     // blst-ts `verifyMultipleSignatures` is also a fallible operation if mul_n_aggregate fails
-    // see https://github.com/ChainSafe/blst-ts/blob/b1ba6333f664b08e5c50b2b0d18c4f079203962b/src/lib.ts#L291
+    // Reference : throw new ErrorBLST
+    // see https://github.com/ChainSafe/blst-ts/blob/bc9f2a46059bc437e1e045b086f8269d00c1343c/src/lib.ts#L291
     return false;
   }
 }

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -831,7 +831,8 @@ export function aggregateInto(attestation1: AttestationWithIndex, attestation2: 
 /**
  * Electra and after: Block proposer consolidates attestations with the same
  * attestation data from different committee into a single attestation
- * https://github.com/ethereum/consensus-specs/blob/aba6345776aa876dad368cab27fbbb23fae20455/specs/_features/eip7549/validator.md?plain=1#L39
+ * Reference: Attestation
+ * https://github.com/ethereum/consensus-specs/blob/cf3c4eca8cff71de66153c1969ab66c1ea2c3338/specs/_features/eip7549/validator.md?plain=1#L39
  */
 export function aggregateConsolidation({byCommittee, attData}: AttestationsConsolidation): electra.Attestation {
   const committeeBits = BitArray.fromBitLen(MAX_COMMITTEES_PER_SLOT);

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -131,7 +131,8 @@ const MAX_ATTESTATIONS_PER_GROUP_ELECTRA = Math.min(
   MAX_ATTESTATIONS_ELECTRA
 );
 
-/** Same to https://github.com/ethereum/consensus-specs/blob/v1.5.0/specs/altair/beacon-chain.md#has_flag */
+//Reference : has_flag
+/** Same to https://github.com/ethereum/consensus-specs/blob/372e9e0ca53c066bee008f6fcb66ae1f94204ad0/specs/altair/beacon-chain.md#has_flag */
 const TIMELY_SOURCE = 1 << TIMELY_SOURCE_FLAG_INDEX;
 const TIMELY_TARGET = 1 << TIMELY_TARGET_FLAG_INDEX;
 const TIMELY_HEAD = 1 << TIMELY_HEAD_FLAG_INDEX;

--- a/packages/beacon-node/src/chain/opPools/utils.ts
+++ b/packages/beacon-node/src/chain/opPools/utils.ts
@@ -41,7 +41,8 @@ export function isValidBlsToExecutionChangeForBlockInclusion(
   state: CachedBeaconStateAllForks,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
 ): boolean {
-  // For each condition from https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#new-process_bls_to_execution_change
+  // Reference : New process_bls_to_execution_change
+  // For each condition from https://github.com/ethereum/consensus-specs/blob/cf3eaab2b2c9039fc250db93bef7a3e92d49d594/specs/capella/beacon-chain.md#new-process_bls_to_execution_change
   //
   // 1. assert address_change.validator_index < len(state.validators):
   //    If valid before will always be valid in the future, no need to check

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -315,7 +315,9 @@ export async function produceBlockBody<T extends BlockType>(
           parentBlockRoot: toRootHex(parentBlockRoot),
           feeRecipient,
         });
-        // https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/validator.md#constructing-the-beaconblockbody
+        // Reference : Constructing the BeaconBlockBody
+
+        // https://github.com/ethereum/consensus-specs/blob/ad1c65b7afff775ad208f203b766aa4038b57f41/specs/deneb/validator.md#constructing-the-beaconblockbody
         const prepareRes = await prepareExecutionPayload(
           this,
           this.logger,

--- a/packages/beacon-node/src/chain/validation/lightClientFinalityUpdate.ts
+++ b/packages/beacon-node/src/chain/validation/lightClientFinalityUpdate.ts
@@ -6,7 +6,8 @@ import {LightClientError, LightClientErrorCode} from "../errors/lightClientError
 import {IBeaconChain} from "../interface.js";
 import {updateReceivedTooEarly} from "./lightClientOptimisticUpdate.js";
 
-// https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#light_client_finality_update
+// Reference : light_client_finality_update
+// https://github.com/ethereum/consensus-specs/blob/03c4ea240fccfa78469aa039a4a7177beca54074/specs/altair/light-client/p2p-interface.md#light_client_finality_update
 export function validateLightClientFinalityUpdate(
   config: ChainForkConfig,
   chain: IBeaconChain,

--- a/packages/beacon-node/src/chain/validation/lightClientOptimisticUpdate.ts
+++ b/packages/beacon-node/src/chain/validation/lightClientOptimisticUpdate.ts
@@ -7,7 +7,8 @@ import {GossipAction} from "../errors/index.js";
 import {LightClientError, LightClientErrorCode} from "../errors/lightClientError.js";
 import {IBeaconChain} from "../interface.js";
 
-// https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#light_client_optimistic_update
+// Reference : light_client_optimistic_update
+// https://github.com/ethereum/consensus-specs/blob/03c4ea240fccfa78469aa039a4a7177beca54074/specs/altair/light-client/p2p-interface.md#light_client_optimistic_update
 export function validateLightClientOptimisticUpdate(
   config: ChainForkConfig,
   chain: IBeaconChain,

--- a/packages/beacon-node/src/chain/validatorMonitor.ts
+++ b/packages/beacon-node/src/chain/validatorMonitor.ts
@@ -839,7 +839,8 @@ function renderAttestationSummary(
   summary: AttestationSummary | undefined,
   flags: ParticipationFlags
 ): string {
-  // Reference https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/beacon-chain.md#get_attestation_participation_flag_indices
+  // Reference : get_attestation_participation_flag_indices
+  // https://github.com/ethereum/consensus-specs/blob/46306c4f8addef64defc2a52d85f46992ba2421b/specs/altair/beacon-chain.md#get_attestation_participation_flag_indices
   //
   // is_matching_source = data.source == justified_checkpoint
   // is_matching_target = is_matching_source and data.target.root == get_block_root(state, data.target.epoch)

--- a/packages/beacon-node/src/constants/network.ts
+++ b/packages/beacon-node/src/constants/network.ts
@@ -1,6 +1,7 @@
 /**
  * For more info on some of these constants:
- * https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#configuration
+ * Reference : Configuration
+ * https://github.com/ethereum/consensus-specs/blob/3f2d5ecda7c16187db9b1ad95820273be3ff2700/specs/phase0/p2p-interface.md#configuration
  */
 
 // Gossip constants

--- a/packages/beacon-node/src/execution/engine/interface.ts
+++ b/packages/beacon-node/src/execution/engine/interface.ts
@@ -132,7 +132,8 @@ export interface IExecutionEngine {
    * Returns ``True`` iff ``execution_payload`` is valid with respect to ``self.execution_state``.
    *
    * Required for block processing in the beacon state transition function.
-   * https://github.com/ethereum/consensus-specs/blob/0eb0a934a3/specs/merge/beacon-chain.md#on_payload
+   * Reference : on_payload
+   * https://github.com/ethereum/consensus-specs/blob/4c1156d504279069799924dbbc79cf13d9454ae3/specs/merge/beacon-chain.md#on_payload
    *
    * Should be called in advance before, after or in parallel to block processing
    */

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -690,7 +690,9 @@ export class Network implements INetwork {
 
     try {
       // messages SHOULD be broadcast after SYNC_MESSAGE_DUE_BPS of slot has transpired
-      // https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#sync-committee
+      //Reference : Sync committee
+
+      // https://github.com/ethereum/consensus-specs/blob/03c4ea240fccfa78469aa039a4a7177beca54074/specs/altair/light-client/p2p-interface.md#sync-committee
       await this.waitForSyncMessageCutoff(finalityUpdate.signatureSlot);
       await this.publishLightClientFinalityUpdate(finalityUpdate);
     } catch (e) {
@@ -707,7 +709,7 @@ export class Network implements INetwork {
 
     try {
       // messages SHOULD be broadcast after SYNC_MESSAGE_DUE_BPS of slot has transpired
-      // https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#sync-committee
+      // https://github.com/ethereum/consensus-specs/blob/03c4ea240fccfa78469aa039a4a7177beca54074/specs/altair/light-client/p2p-interface.md#sync-committee
       await this.waitForSyncMessageCutoff(optimisticUpdate.signatureSlot);
       await this.publishLightClientOptimisticUpdate(optimisticUpdate);
     } catch (e) {

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -57,7 +57,8 @@ export type ReqRespBeaconNodeOpts = ReqRespOpts & {disableLightClientServer?: bo
  * Implementation of Ethereum Consensus p2p Req/Resp domain.
  * For the spec that this code is based on, see:
  * https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#the-reqresp-domain
- * https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#the-reqresp-domain
+ * Reference : the-reqresp-domain
+ * https://github.com/ethereum/consensus-specs/blob/03c4ea240fccfa78469aa039a4a7177beca54074/specs/altair/light-client/p2p-interface.md#the-reqresp-domain
  */
 export class ReqRespBeaconNode extends ReqResp {
   private readonly metadataController: MetadataController;

--- a/packages/beacon-node/src/sync/backfill/backfill.ts
+++ b/packages/beacon-node/src/sync/backfill/backfill.ts
@@ -128,7 +128,8 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
   private wsValidated = false;
 
   /**
-   * From https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/weak-subjectivity.md
+   * Reference : 
+   * From https://github.com/ethereum/consensus-specs/blob/46306c4f8addef64defc2a52d85f46992ba2421b/specs/phase0/weak-subjectivity.md
    *
    *
    * If

--- a/packages/beacon-node/src/sync/constants.ts
+++ b/packages/beacon-node/src/sync/constants.ts
@@ -59,7 +59,7 @@ export const BATCH_BUFFER_SIZE = Math.ceil(10 / EPOCHS_PER_BATCH);
 
 /**
  * Maximum number of concurrent requests to perform with a SyncChain.
- * This is according to the spec https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md
+ * This is according to the spec https://github.com/ethereum/consensus-specs/blob/46306c4f8addef64defc2a52d85f46992ba2421b/specs/phase0/p2p-interface.md
  */
 export const MAX_CONCURRENT_REQUESTS = 2;
 

--- a/packages/beacon-node/test/spec/bls/bls.ts
+++ b/packages/beacon-node/test/spec/bls/bls.ts
@@ -25,7 +25,8 @@ export const testFnByType: Record<string, "skip" | ((data: any) => any)> = {
 };
 
 /**
- * https://github.com/ethereum/bls12-381-tests/blob/master/formats/aggregate_verify.md
+ * Reference : aggregate_verify
+ * https://github.com/ethereum/bls12-381-tests/blob/7a1e2f64adf524d7c53c33c7bfbed6afcc73f664/formats/aggregate_verify.md
  * ```
  * input:
  *   pubkeys: List[bytes48] -- the pubkeys
@@ -89,7 +90,8 @@ function fast_aggregate_verify(input: {pubkeys: string[]; message: string; signa
  *   signatures: List[bytes96] -- the signatures to verify against pubkeys and messages
  * output: bool  -- VALID or INVALID
  * ```
- * https://github.com/ethereum/bls12-381-tests/blob/master/formats/batch_verify.md
+ * Reference : batch_verify
+ * https://github.com/ethereum/bls12-381-tests/blob/2e357bf380a3eb72883f529d0e303ae03251767c/formats/batch_verify.md
  */
 function batch_verify(input: {pubkeys: string[]; messages: string[]; signatures: string[]}): boolean | null {
   const {pubkeys, messages, signatures} = input;
@@ -113,7 +115,8 @@ function batch_verify(input: {pubkeys: string[]; messages: string[]; signatures:
  *   message: bytes32 -- input message to sign (a hash)
  * output: BLS Signature -- expected output, single BLS signature or empty.
  * ```
- * https://github.com/ethereum/bls12-381-tests/blob/master/formats/sign.md
+ * Reference - sign.md
+ * https://github.com/ethereum/bls12-381-tests/blob/c01854d47b936b65404e5f08181f05db48792679/formats/sign.md
  */
 function sign(input: {privkey: string; message: string}): string | null {
   const {privkey, message} = input;
@@ -145,7 +148,8 @@ function verify(input: {pubkey: string; message: string; signature: string}): bo
  * input: pubkey: bytes48 -- the pubkey
  * output: bool  -- VALID or INVALID
  * ```
- * https://github.com/ethereum/bls12-381-tests/blob/master/formats/deserialization_G1.md
+ * Reference : deserialization_G1
+ * https://github.com/ethereum/bls12-381-tests/blob/f61f5f01e41c0e422d812d1254f06e89c2531c5b/formats/deserialization_G1.md
  */
 function deserialization_G1(input: {pubkey: string}): boolean {
   try {

--- a/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
+++ b/packages/beacon-node/test/spec/presets/epoch_processing.test.ts
@@ -54,7 +54,8 @@ const epochTransitionFns: Record<string, EpochTransitionFn> = {
 };
 
 /**
- * https://github.com/ethereum/consensus-specs/blob/dev/tests/formats/epoch_processing/README.md
+ * Reference : ReadMe.md
+ * https://github.com/ethereum/consensus-specs/blob/e660623d12f8a99d39c5341a2848202974fa1848/tests/formats/epoch_processing/README.md
  */
 type EpochTransitionCacheingTestCase = {
   meta?: {bls_setting?: bigint};
@@ -86,7 +87,8 @@ const epochProcessing =
 
         if (testcase.post === undefined) {
           // If post.ssz_snappy is not value, the sub-transition processing is aborted
-          // https://github.com/ethereum/consensus-specs/blob/dev/tests/formats/epoch_processing/README.md#postssz_snappy
+          // Reference : postssz_snappy
+          // https://github.com/ethereum/consensus-specs/blob/e660623d12f8a99d39c5341a2848202974fa1848/tests/formats/epoch_processing/README.md#postssz_snappy
           expect(() => epochTransitionFn(state, epochTransitionCache)).toThrow();
         } else {
           epochTransitionFn(state, epochTransitionCache);
@@ -121,7 +123,8 @@ specTestIterator(path.join(ethereumConsensusSpecsTests.outputDir, "tests", ACTIV
     fn: epochProcessing([
       // TODO: invalid_large_withdrawable_epoch asserts an overflow on a u64 for its exit epoch.
       // Currently unable to reproduce in Lodestar, skipping for now
-      // https://github.com/ethereum/consensus-specs/blob/3212c419f6335e80ed825b4855a071f76bef70c3/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_registry_updates.py#L349
+      // Reference : L349
+      // https://github.com/ethereum/consensus-specs/blob/bbc3ec02ff4154b08ccddf275d6ef51571da5ded/tests/core/pyspec/eth2spec/test/phase0/epoch_processing/test_process_registry_updates.py#L349
       "invalid_large_withdrawable_epoch",
     ]),
   },

--- a/packages/beacon-node/test/spec/presets/finality.test.ts
+++ b/packages/beacon-node/test/spec/presets/finality.test.ts
@@ -70,7 +70,8 @@ export function generateBlocksSZZTypeMapping(fork: ForkName, n: number): BlocksS
  * ```
  * {blocks_count: 16}
  * ```
- * https://github.com/ethereum/consensus-specs/blob/dev/tests/formats/finality/README.md
+ * Reference : README.md
+ * https://github.com/ethereum/consensus-specs/blob/e660623d12f8a99d39c5341a2848202974fa1848/tests/formats/finality/README.md
  */
 type FinalityTestCase = {
   [k: string]: altair.SignedBeaconBlock | unknown | null | undefined;

--- a/packages/beacon-node/test/spec/presets/ssz_static.test.ts
+++ b/packages/beacon-node/test/spec/presets/ssz_static.test.ts
@@ -19,7 +19,9 @@ import {RunnerType} from "../utils/types.js";
 //       | serialized.ssz_snappy
 //       | value.yaml
 //
-// Docs: https://github.com/ethereum/consensus-specs/blob/master/tests/formats/ssz_static/core.md
+// 
+// Reference : core
+// Docs: https://github.com/ethereum/consensus-specs/blob/e660623d12f8a99d39c5341a2848202974fa1848/tests/formats/ssz_static/core.md
 
 type Types = Record<string, Type<any>>;
 

--- a/packages/config/src/chainConfig/configs/mainnet.ts
+++ b/packages/config/src/chainConfig/configs/mainnet.ts
@@ -3,7 +3,7 @@ import {fromHex as b} from "@lodestar/utils";
 import {ChainConfig} from "../types.js";
 
 // Mainnet config
-// https://github.com/ethereum/consensus-specs/blob/dev/configs/mainnet.yaml
+// https://github.com/ethereum/consensus-specs/blob/a58c80d3a76ed7b0c1b4f318647675268f3d1abf/configs/mainnet.yaml
 
 export const chainConfig: ChainConfig = {
   // Extends the mainnet preset

--- a/packages/config/src/chainConfig/configs/minimal.ts
+++ b/packages/config/src/chainConfig/configs/minimal.ts
@@ -3,7 +3,7 @@ import {fromHex as b} from "@lodestar/utils";
 import {ChainConfig} from "../types.js";
 
 // Minimal config
-// https://github.com/ethereum/consensus-specs/blob/dev/configs/minimal.yaml
+// https://github.com/ethereum/consensus-specs/blob/a58c80d3a76ed7b0c1b4f318647675268f3d1abf/configs/minimal.yaml
 
 export const chainConfig: ChainConfig = {
   // Extends the minimal preset

--- a/packages/config/src/chainConfig/networks/chiado.ts
+++ b/packages/config/src/chainConfig/networks/chiado.ts
@@ -3,7 +3,8 @@ import {ChainConfig} from "../types.js";
 import {gnosisChainConfig as gnosis} from "./gnosis.js";
 
 // Chiado beacon chain config:
-// https://github.com/gnosischain/configs/blob/main/chiado/config.yaml
+// Reference : config
+// https://github.com/gnosischain/configs/blob/3f44fafa888439f56fc60d2f6173bfe63f31c962/chiado/config.yaml
 
 export const chiadoChainConfig: ChainConfig = {
   ...gnosis,

--- a/packages/config/src/chainConfig/networks/ephemery.ts
+++ b/packages/config/src/chainConfig/networks/ephemery.ts
@@ -3,7 +3,8 @@ import {chainConfig as mainnet} from "../configs/mainnet.js";
 import {ChainConfig} from "../types.js";
 
 // Ephemery dynamic beacon chain config:
-// https://github.com/ephemery-testnet/ephemery-genesis/blob/master/cl-config.yaml
+//Reference : config
+// https://github.com/ephemery-testnet/ephemery-genesis/blob/dbc3377143c6fc1a688d4a9c648f89d8812ec7aa/cl-config.yaml
 
 // Ephemery specification:
 // https://eips.ethereum.org/EIPS/eip-6916

--- a/packages/config/src/chainConfig/networks/gnosis.ts
+++ b/packages/config/src/chainConfig/networks/gnosis.ts
@@ -4,7 +4,8 @@ import {chainConfig as mainnet} from "../configs/mainnet.js";
 import {ChainConfig} from "../types.js";
 
 // Gnosis beacon chain config:
-// https://github.com/gnosischain/configs/blob/main/mainnet/config.yaml
+//Reference : config
+// https://github.com/gnosischain/configs/blob/d447a94bbe1bafbef4fe5a2fbb2e5469e7b494bb/mainnet/config.yaml
 
 export const gnosisChainConfig: ChainConfig = {
   ...mainnet,

--- a/packages/config/src/chainConfig/networks/holesky.ts
+++ b/packages/config/src/chainConfig/networks/holesky.ts
@@ -3,7 +3,8 @@ import {chainConfig as mainnet} from "../configs/mainnet.js";
 import {ChainConfig} from "../types.js";
 
 // Holesky beacon chain config:
-// https://github.com/eth-clients/holesky/blob/main/metadata/config.yaml
+// Reference : config
+// https://github.com/eth-clients/holesky/blob/8aec65f11f0c986d6b76b2eb902420635eb9b815/metadata/config.yaml
 
 export const holeskyChainConfig: ChainConfig = {
   ...mainnet,

--- a/packages/config/src/chainConfig/networks/hoodi.ts
+++ b/packages/config/src/chainConfig/networks/hoodi.ts
@@ -3,7 +3,8 @@ import {chainConfig as mainnet} from "../configs/mainnet.js";
 import {ChainConfig} from "../types.js";
 
 // Hoodi beacon chain config:
-// https://github.com/eth-clients/hoodi/blob/main/metadata/config.yaml
+//Referece : config
+// https://github.com/eth-clients/hoodi/blob/21a110a60e6558a2ba7c819fa4b80029d49ab205/metadata/config.yaml
 
 export const hoodiChainConfig: ChainConfig = {
   ...mainnet,

--- a/packages/config/src/chainConfig/networks/sepolia.ts
+++ b/packages/config/src/chainConfig/networks/sepolia.ts
@@ -3,7 +3,8 @@ import {chainConfig as mainnet} from "../configs/mainnet.js";
 import {ChainConfig} from "../types.js";
 
 // Sepolia beacon chain config:
-// https://github.com/eth-clients/sepolia/blob/main/metadata/config.yaml
+//Reference : config
+// https://github.com/eth-clients/sepolia/blob/56f0bff41cecab6c661251d72b73ceecc52c5701/metadata/config.yaml
 
 export const sepoliaChainConfig: ChainConfig = {
   ...mainnet,

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -74,6 +74,7 @@ export type UpdateAndGetHeadOpt =
 /**
  * Provides an implementation of "Ethereum Consensus -- Beacon Chain Fork Choice":
  *
+ * Reference : Fork Choice
  * https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/fork-choice.md#fork-choice
  *
  * ## Detail
@@ -397,7 +398,8 @@ export class ForkChoice implements IForkChoice {
     }
 
     // No reorg if parentBlock is "not strong" ie. parentBlock's weight is less than or equal to (REORG_PARENT_WEIGHT_THRESHOLD = 160)% of total attester weight
-    // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/fork-choice.md#is_parent_strong
+    // Reference : is_parent_strong
+    // https://github.com/ethereum/consensus-specs/blob/46306c4f8addef64defc2a52d85f46992ba2421b/specs/phase0/fork-choice.md#is_parent_strong
     const parentThreshold = getCommitteeFraction(this.fcStore.justified.totalBalance, {
       slotsPerEpoch: SLOTS_PER_EPOCH,
       committeePercent: this.config.REORG_PARENT_WEIGHT_THRESHOLD,
@@ -626,7 +628,8 @@ export class ForkChoice implements IForkChoice {
 
     // As per specs, we should be validating here the terminal conditions of
     // the PoW if this were a merge transition block.
-    // (https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/fork-choice.md#on_block)
+    // Reference : on_block
+    // (https://github.com/ethereum/consensus-specs/blob/46306c4f8addef64defc2a52d85f46992ba2421b/specs/bellatrix/fork-choice.md#on_block)
     //
     // However this check has been moved to the `verifyBlockStateTransition` in
     // `packages/beacon-node/src/chain/blocks/verifyBlock.ts` as:
@@ -1640,7 +1643,8 @@ export function assertValidTerminalPowBlock(
     }
   }
 }
-// Approximate https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/fork-choice.md#calculate_committee_fraction
+// Reference : calculate_committee_fraction.
+// Approximate https://github.com/ethereum/consensus-specs/blob/46306c4f8addef64defc2a52d85f46992ba2421b/specs/phase0/fork-choice.md#calculate_committee_fraction
 // Calculates proposer boost score when committeePercent = config.PROPOSER_SCORE_BOOST
 export function getCommitteeFraction(
   justifiedTotalActiveBalanceByIncrement: number,

--- a/packages/prover/src/constants.ts
+++ b/packages/prover/src/constants.ts
@@ -1,4 +1,5 @@
-// https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#configuration
+// Reference : Configuration
+// https://github.com/ethereum/consensus-specs/blob/03c4ea240fccfa78469aa039a4a7177beca54074/specs/altair/light-client/p2p-interface.md#configuration
 export const MAX_REQUEST_LIGHT_CLIENT_UPDATES = 128;
 export const MAX_PAYLOAD_HISTORY = 32;
 export const VERIFICATION_FAILED_RESPONSE_CODE = -33091;

--- a/packages/reqresp/src/ReqResp.ts
+++ b/packages/reqresp/src/ReqResp.ts
@@ -38,7 +38,8 @@ export interface ReqRespOpts extends SendRequestOpts, ReqRespRateLimiterOpts {
  * Implementation of Ethereum Consensus p2p Req/Resp domain.
  * For the spec that this code is based on, see:
  * https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#the-reqresp-domain
- * https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#the-reqresp-domain
+ * Reference : the-reqresp-domain
+ * https://github.com/ethereum/consensus-specs/blob/03c4ea240fccfa78469aa039a4a7177beca54074/specs/altair/light-client/p2p-interface.md#the-reqresp-domain
  */
 export class ReqResp {
   // protected to be usable by extending class


### PR DESCRIPTION
**Motivation**
This PR replaces documentation and code references that previously pointed to the dev, main, master branches while also updating existing SHA commits with the most current verified SHA commits. However, references with release tags have not been changed

**Description**
-Updated only .ts files containing github.com/ethereum/consensus-specs/blob/dev links. Afew of these files were not changed as they reference links redirected to page with Error 404.
-Also verified that no auto-generated file such as .js and .d.ts  were modified. 

**Steps to test or reproduce**
$ cd lodestar
$ git checkout issue-#8171
$ grep -RIn --include='*.ts' --exclude='*.d.ts' --exclude='*.js' 'github.com'

**Conclusion**
I invite review and I am ready to make request changes.

