### PR TITLE
chore: unbreak lodestar dev command

### DIFF
--- a/packages/cli/src/util/file.ts
+++ b/packages/cli/src/util/file.ts
@@ -4,7 +4,6 @@ import {Readable} from "node:stream";
 import stream from "node:stream/promises";
 import {ReadableStream as NodeReadableStream} from "node:stream/web";
 import yaml from "js-yaml";
-import {HttpHeader, MediaType} from "@lodestar/api";
 import {fetch} from "@lodestar/utils";
 
 const {load, dump, FAILSAFE_SCHEMA, Type} = yaml;
@@ -152,7 +151,7 @@ export async function downloadOrLoadFile(pathOrUrl: string): Promise<Uint8Array>
   if (isUrl(pathOrUrl)) {
     const res = await fetch(pathOrUrl, {
       // Ensure we only receive SSZ responses if REST API is queried
-      headers: {[HttpHeader.Accept]: MediaType.ssz},
+      headers: {accept: "application/octet-stream"},
     });
     if (!res.ok) {
       throw new Error(`Failed to download file from ${pathOrUrl}: ${res.status} ${res.statusText}`);


### PR DESCRIPTION
**Motivation**

```
> ./lodestar dev
file:///home/nico/projects/ethereum/lodestar/packages/params/lib/setPreset.js:27
        throw Error(`Lodestar preset is already frozen. You must call setActivePreset() at the top of your
              ^

Error: Lodestar preset is already frozen. You must call setActivePreset() at the top of your
application entry point, before importing @lodestar/params, or any library that may import it.


// index.ts
import {setActivePreset, PresetName} from "@lodestar/params/setPreset"
setActivePreset(PresetName.minimal)
// Now you can safely import from other paths and consume params
import {SLOTS_PER_EPOCH} from "@lodestar/params"
console.log({SLOTS_PER_EPOCH})


    at setActivePreset (file:///home/nico/projects/ethereum/lodestar/packages/params/lib/setPreset.js:27:15)
    at file:///home/nico/projects/ethereum/lodestar/packages/cli/lib/applyPreset.js:49:5
    at ModuleJob.run (node:internal/modules/esm/module_job:262:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:485:26)
    at async file:///home/nico/projects/ethereum/lodestar/packages/cli/bin/lodestar.js:3:1

Node.js v22.4.1

```

**Description**

We cannot import any lodestar packages that depend on `@lodestar/params` into `packages/cli/src/util/file.ts` since this is loaded from `packages/cli/src/applyPreset.ts` and we run in the error above.