### PR TITLE
feat: add option to prune persisted cp states

### DIFF
--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -8,6 +8,7 @@ import {ShufflingCacheOpts} from "./shufflingCache.js";
 import {DEFAULT_MAX_BLOCK_STATES, FIFOBlockStateCacheOpts} from "./stateCache/fifoBlockStateCache.js";
 import {
   DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY,
+  DEFAULT_MAX_CP_STATE_ON_DISK,
   PersistentCheckpointStateCacheOpts,
 } from "./stateCache/persistentCheckpointsCache.js";
 import {ValidatorMonitorOpts} from "./validatorMonitor.js";
@@ -132,4 +133,5 @@ export const defaultChainOptions: IChainOptions = {
   nHistoricalStatesFileDataStore: true,
   maxBlockStates: DEFAULT_MAX_BLOCK_STATES,
   maxCPStateEpochsInMemory: DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY,
+  maxCPStateEpochsOnDisk: DEFAULT_MAX_CP_STATE_ON_DISK,
 };

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -17,8 +17,10 @@ import {MapTracker} from "./mapMetrics.js";
 import {BlockStateCache, CacheItemType, CheckpointHex, CheckpointStateCache} from "./types.js";
 
 export type PersistentCheckpointStateCacheOpts = {
-  /** Keep max n states in memory, persist the rest to disk */
+  /** Keep max n state epochs in memory, persist the rest to disk */
   maxCPStateEpochsInMemory?: number;
+  /** Keep max n state epochs on disk */
+  maxCPStateEpochsOnDisk?: number;
 };
 
 type PersistentCheckpointStateCacheModules = {
@@ -60,6 +62,12 @@ export const DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY = 3;
 
 // TODO GLOAS: re-evaluate this timing
 const PROCESS_CHECKPOINT_STATES_BPS = 6667;
+
+/**
+ * During nft state of Holesky in Feb 2025, lodestar stores ~250MB per epoch and it's not sustainable to keep all states on disk.
+ * It's not likely to have reorgs that go back to 10 epochs ago, so we only keep 10 epochs on disk.
+ */
+export const DEFAULT_MAX_CP_STATE_ON_DISK = 10;
 
 /**
  * An implementation of CheckpointStateCache that keep up to n epoch checkpoint states in memory and persist the rest to disk
@@ -104,6 +112,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   private preComputedCheckpoint: string | null = null;
   private preComputedCheckpointHits: number | null = null;
   private readonly maxEpochsInMemory: number;
+  private readonly maxEpochsOnDisk: number;
   private readonly datastore: CPStateDatastore;
   private readonly blockStateCache: BlockStateCache;
   private readonly bufferPool?: BufferPool | null;
@@ -139,10 +148,16 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     this.logger = logger;
     this.clock = clock;
     this.signal = signal;
+
     if (opts.maxCPStateEpochsInMemory !== undefined && opts.maxCPStateEpochsInMemory < 0) {
       throw new Error("maxEpochsInMemory must be >= 0");
     }
+    if (opts.maxCPStateEpochsOnDisk !== undefined && opts.maxCPStateEpochsOnDisk < 0) {
+      throw new Error("maxCPStateEpochsOnDisk must be >= 0");
+    }
+
     this.maxEpochsInMemory = opts.maxCPStateEpochsInMemory ?? DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY;
+    this.maxEpochsOnDisk = opts.maxCPStateEpochsOnDisk ?? DEFAULT_MAX_CP_STATE_ON_DISK;
     // Specify different datastore for testing
     this.datastore = datastore;
     this.blockStateCache = blockStateCache;
@@ -324,6 +339,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       this.logger.verbose("Added checkpoint state to memory", {epoch: cp.epoch, rootHex: cpHex.rootHex});
     }
     this.epochIndex.getOrDefault(cp.epoch).add(cpHex.rootHex);
+    this.prunePersistedStates();
   }
 
   /**
@@ -766,11 +782,36 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       this.cache.delete(key);
     }
     this.epochIndex.delete(epoch);
-    this.logger.verbose("Pruned finalized checkpoints states for epoch", {
+    this.logger.verbose("Pruned checkpoints state for epoch", {
       epoch,
       persistCount,
       rootHexes: Array.from(rootHexes).join(","),
     });
+  }
+
+  /**
+   * Prune persisted checkpoint states from disk.
+   * Note that this should handle all possible errors and not throw.
+   */
+  private prunePersistedStates(): void {
+    //                epochsOnDisk                                   epochsInMemory
+    // |----------------------------------------------------------|----------------------|
+    const maxTrackedEpochs = this.maxEpochsOnDisk + this.maxEpochsInMemory;
+    if (this.epochIndex.size <= maxTrackedEpochs) {
+      return;
+    }
+
+    const sortedEpochs = Array.from(this.epochIndex.keys()).sort((a, b) => a - b);
+    const pruneEpochs = sortedEpochs.slice(0, sortedEpochs.length - maxTrackedEpochs);
+    for (const epoch of pruneEpochs) {
+      this.deleteAllEpochItems(epoch).catch((e) =>
+        this.logger.debug(
+          "Error delete all epoch items",
+          {epoch, maxCPStateEpochsOnDisk: this.maxEpochsOnDisk, maxEpochsInMemory: this.maxEpochsInMemory},
+          e as Error
+        )
+      );
+    }
   }
 
   /**

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -63,7 +63,8 @@ export const DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY = 3;
 /**
  * By default we don't prune any persistent checkpoint states as it's not safe to delete them during
  * long non-finality as we don't know the state of the chain and there could be a deep (hundreds of epochs) reorg
- * if there two competing chains with similar weight.
+ * if there two competing chains with similar weight but we wouldn't have a close enough state to pivot to this chain
+ * and instead require a resync from last finalized checkpoint state which could be very far in the past.
  */
 export const DEFAULT_MAX_CP_STATE_ON_DISK = Infinity;
 

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -64,10 +64,11 @@ export const DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY = 3;
 const PROCESS_CHECKPOINT_STATES_BPS = 6667;
 
 /**
- * During nft state of Holesky in Feb 2025, lodestar stores ~250MB per epoch and it's not sustainable to keep all states on disk.
- * It's not likely to have reorgs that go back to 10 epochs ago, so we only keep 10 epochs on disk.
+ * By default we don't prune any persistent checkpoint states as it's not safe to delete them during
+ * long non-finality as we don't know the state of the chain and there could be a deep (hundreds of epochs) reorg
+ * if there two competing chains with similar weight.
  */
-export const DEFAULT_MAX_CP_STATE_ON_DISK = 10;
+export const DEFAULT_MAX_CP_STATE_ON_DISK = Infinity;
 
 /**
  * An implementation of CheckpointStateCache that keep up to n epoch checkpoint states in memory and persist the rest to disk
@@ -782,7 +783,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       this.cache.delete(key);
     }
     this.epochIndex.delete(epoch);
-    this.logger.verbose("Pruned checkpoints state for epoch", {
+    this.logger.verbose("Pruned checkpoint states for epoch", {
       epoch,
       persistCount,
       rootHexes: Array.from(rootHexes).join(","),
@@ -807,7 +808,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       this.deleteAllEpochItems(epoch).catch((e) =>
         this.logger.debug(
           "Error delete all epoch items",
-          {epoch, maxCPStateEpochsOnDisk: this.maxEpochsOnDisk, maxEpochsInMemory: this.maxEpochsInMemory},
+          {epoch, maxEpochsOnDisk: this.maxEpochsOnDisk, maxEpochsInMemory: this.maxEpochsInMemory},
           e as Error
         )
       );

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -60,15 +60,15 @@ type LoadedStateBytesData = {persistedKey: DatastoreKey; stateBytes: Uint8Array}
  */
 export const DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY = 3;
 
-// TODO GLOAS: re-evaluate this timing
-const PROCESS_CHECKPOINT_STATES_BPS = 6667;
-
 /**
  * By default we don't prune any persistent checkpoint states as it's not safe to delete them during
  * long non-finality as we don't know the state of the chain and there could be a deep (hundreds of epochs) reorg
  * if there two competing chains with similar weight.
  */
 export const DEFAULT_MAX_CP_STATE_ON_DISK = Infinity;
+
+// TODO GLOAS: re-evaluate this timing
+const PROCESS_CHECKPOINT_STATES_BPS = 6667;
 
 /**
  * An implementation of CheckpointStateCache that keep up to n epoch checkpoint states in memory and persist the rest to disk

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -35,6 +35,7 @@ export type ChainArgs = {
   "chain.nHistoricalStatesFileDataStore"?: boolean;
   "chain.maxBlockStates"?: number;
   "chain.maxCPStateEpochsInMemory"?: number;
+  "chain.maxCPStateEpochsOnDisk"?: number;
 
   "chain.pruneHistory"?: boolean;
 };
@@ -76,6 +77,7 @@ export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
       args["chain.nHistoricalStatesFileDataStore"] ?? defaultOptions.chain.nHistoricalStatesFileDataStore,
     maxBlockStates: args["chain.maxBlockStates"] ?? defaultOptions.chain.maxBlockStates,
     maxCPStateEpochsInMemory: args["chain.maxCPStateEpochsInMemory"] ?? defaultOptions.chain.maxCPStateEpochsInMemory,
+    maxCPStateEpochsOnDisk: args["chain.maxCPStateEpochsOnDisk"] ?? defaultOptions.chain.maxCPStateEpochsOnDisk,
     pruneHistory: args["chain.pruneHistory"],
   };
 }
@@ -313,6 +315,14 @@ Will double processing times. Use only for debugging purposes.",
     description: "Max epochs to cache checkpoint states in memory, used for PersistentCheckpointStateCache",
     type: "number",
     default: defaultOptions.chain.maxCPStateEpochsInMemory,
+    group: "chain",
+  },
+
+  "chain.maxCPStateEpochsOnDisk": {
+    hidden: true,
+    description: "Max epochs to cache checkpoint states on disk, used for PersistentCheckpointStateCache",
+    type: "number",
+    default: defaultOptions.chain.maxCPStateEpochsOnDisk,
     group: "chain",
   },
 

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -42,6 +42,7 @@ describe("options / beaconNodeOptions", () => {
       "chain.nHistoricalStatesFileDataStore": true,
       "chain.maxBlockStates": 100,
       "chain.maxCPStateEpochsInMemory": 100,
+      "chain.maxCPStateEpochsOnDisk": 1000,
       "chain.archiveMode": ArchiveMode.Frequency,
       emitPayloadAttributes: false,
 
@@ -152,6 +153,7 @@ describe("options / beaconNodeOptions", () => {
         nHistoricalStatesFileDataStore: true,
         maxBlockStates: 100,
         maxCPStateEpochsInMemory: 100,
+        maxCPStateEpochsOnDisk: 1000,
       },
       eth1: {
         enabled: true,


### PR DESCRIPTION
**Motivation**

Last change from https://github.com/ChainSafe/lodestar/pull/7501 which we implemented because persisted checkpoint states are added each epoch during non-finality and never pruned until the chain finalizes again. It turns out this is not sustainable if we have multiple weeks of non-finality since it takes up hundreds of GB of disk space and many nodes don't have sufficient disk space to handle this.

The long term solution is to store states more efficiently but for now we should at least have a option to enable pruning, there is also always the options to clean up the `checkpoint_states` folder manually.

**Description**

This PR adds a new flag `--chain.maxCPStateEpochsOnDisk` to enable pruning of persisted checkpoint states. By default we don't prune any persistent checkpoint states as it's not safe to delete them during long non-finality as we don't know the state of the chain and there could be a deep (hundreds of epochs) reorg if there two competing chains with similar weight but we wouldn't have a close enough state to pivot to this chain and instead require a resync from last finalized checkpoint state which could be very far in the past.


Previous PR https://github.com/ChainSafe/lodestar/pull/7510