### PR TITLE
chore: downgrade enr without tcp multiaddr log to warning

### DIFF
--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -391,7 +391,7 @@ export class PeerDiscovery {
     // tcp multiaddr is known to be be present, checked inside the worker
     const multiaddrTCP = enr.getLocationMultiaddr(ENRKey.tcp);
     if (!multiaddrTCP) {
-      this.logger.error("Discv5 worker sent enr without tcp multiaddr", {enr: enr.encodeTxt()});
+      this.logger.warn("Discv5 worker sent enr without tcp multiaddr", {enr: enr.encodeTxt()});
       this.metrics?.discovery.discoveredStatus.inc({status: DiscoveredPeerStatus.error});
       return;
     }

--- a/packages/beacon-node/src/network/peers/discover.ts
+++ b/packages/beacon-node/src/network/peers/discover.ts
@@ -392,7 +392,7 @@ export class PeerDiscovery {
     const multiaddrTCP = enr.getLocationMultiaddr(ENRKey.tcp);
     if (!multiaddrTCP) {
       this.logger.warn("Discv5 worker sent enr without tcp multiaddr", {enr: enr.encodeTxt()});
-      this.metrics?.discovery.discoveredStatus.inc({status: DiscoveredPeerStatus.error});
+      this.metrics?.discovery.discoveredStatus.inc({status: DiscoveredPeerStatus.no_multiaddrs});
       return;
     }
     // Are this fields mandatory?


### PR DESCRIPTION
This happens if the node has ENRs without a tcp4 or tcp6 multiaddress field and `--connectToDiscv5Bootnodes` flag is added. It's not really critical so `warn` seems more appropriate than `error`. 
