### PR TITLE
chore: remove usage of `prettyBytes` in errors

### DIFF
--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -9,7 +9,7 @@ import {
   isForkPostFulu,
 } from "@lodestar/params";
 import {BeaconBlockBody, BlobIndex, ColumnIndex, SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
-import {LodestarError, fromHex, prettyBytes, prettyPrintIndices, toHex, toRootHex} from "@lodestar/utils";
+import {LodestarError, fromHex, prettyPrintIndices, toHex, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource, IBlockInput} from "../../chain/blocks/blockInput/types.js";
 import {ChainEventEmitter} from "../../chain/emitter.js";
@@ -119,7 +119,7 @@ export async function downloadByRoot({
     if (!blobSidecars) {
       throw new DownloadByRootError({
         code: DownloadByRootErrorCode.MISSING_BLOB_RESPONSE,
-        blockRoot: prettyBytes(rootHex),
+        blockRoot: rootHex,
         peer: peerIdStr,
       });
     }
@@ -157,7 +157,7 @@ export async function downloadByRoot({
     if (!columnSidecars) {
       throw new DownloadByRootError({
         code: DownloadByRootErrorCode.MISSING_COLUMN_RESPONSE,
-        blockRoot: prettyBytes(rootHex),
+        blockRoot: rootHex,
         peer: peerIdStr,
       });
     }
@@ -312,7 +312,7 @@ export async function fetchAndValidateBlock({
     throw new DownloadByRootError({
       code: DownloadByRootErrorCode.MISSING_BLOCK_RESPONSE,
       peer: prettyPrintPeerIdStr(peerIdStr),
-      blockRoot: prettyBytes(blockRoot),
+      blockRoot: toRootHex(blockRoot),
     });
   }
   const receivedRoot = config.getForkTypes(block.message.slot).BeaconBlock.hashTreeRoot(block.message);
@@ -321,8 +321,8 @@ export async function fetchAndValidateBlock({
       {
         code: DownloadByRootErrorCode.MISMATCH_BLOCK_ROOT,
         peer: prettyPrintPeerIdStr(peerIdStr),
-        requestedBlockRoot: prettyBytes(blockRoot),
-        receivedBlockRoot: prettyBytes(toRootHex(receivedRoot)),
+        requestedBlockRoot: toRootHex(blockRoot),
+        receivedBlockRoot: toRootHex(receivedRoot),
       },
       "block does not match requested root"
     );
@@ -490,7 +490,7 @@ export async function validateColumnSidecars({
         code: DownloadByRootErrorCode.EXTRA_SIDECAR_RECEIVED,
         peer: prettyPrintPeerIdStr(peerMeta.peerId),
         slot,
-        blockRoot: prettyBytes(blockRoot),
+        blockRoot: toRootHex(blockRoot),
         invalidIndices: prettyPrintIndices(extraIndices),
       },
       "Received a columnSidecar that was not requested"


### PR DESCRIPTION
Closes https://github.com/ChainSafe/lodestar/issues/8566, this just removes usage of `prettyBytes` as it's objectively bad to do that as it doesn't allow external lookup.