### PR TITLE
chore: migrate to `consensus-specs` for spec tests

### DIFF
--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -17,7 +17,7 @@ export const ethereumConsensusSpecsTests: DownloadTestsOptions = {
   specVersion: "v1.6.0-beta.0",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
-  specTestsRepoUrl: "https://github.com/ethereum/consensus-spec-tests",
+  specTestsRepoUrl: "https://github.com/ethereum/consensus-specs",
   testsToDownload: ["general", "mainnet", "minimal"],
 };
 

--- a/packages/spec-test-util/src/downloadTests.ts
+++ b/packages/spec-test-util/src/downloadTests.ts
@@ -7,14 +7,14 @@ import {promisify} from "node:util";
 import {rimraf} from "rimraf";
 import {fetch, retry} from "@lodestar/utils";
 
-export const defaultSpecTestsRepoUrl = "https://github.com/ethereum/consensus-spec-tests";
+export const defaultSpecTestsRepoUrl = "https://github.com/ethereum/consensus-specs";
 
 const logEmpty = (): void => {};
 
 export type DownloadTestsOptions = {
   specVersion: string;
   outputDir: string;
-  /** Root Github URL `https://github.com/ethereum/consensus-spec-tests` */
+  /** Root Github URL `https://github.com/ethereum/consensus-specs` */
   specTestsRepoUrl: string;
   /** Release files names to download without prefix `["general", "mainnet", "minimal"]` */
   testsToDownload: string[];


### PR DESCRIPTION
[ethereum/consensus-spec-tests](https://github.com/ethereum/consensus-spec-tests) are archived as of October 22. 

We need to point to `ethereum/consensus-specs` for spec test vectors. 