### PR TITLE
feat: increase default gas limit to 60M

### DIFF
--- a/docs/pages/run/validator-management/proposer-config.md
+++ b/docs/pages/run/validator-management/proposer-config.md
@@ -15,13 +15,13 @@ proposer_config:
     strict_fee_recipient_check: false
     fee_recipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     builder:
-      gas_limit: "45000000"
+      gas_limit: "60000000"
       selection: "executionalways"
       boost_factor: "0"
   "0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d":
     fee_recipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     builder:
-      gas_limit: "3000000"
+      gas_limit: "4500000"
       selection: "maxprofit"
       boost_factor: "100"
 default_config:
@@ -29,7 +29,7 @@ default_config:
   strict_fee_recipient_check: true
   fee_recipient: "0xcccccccccccccccccccccccccccccccccccccccc"
   builder:
-    gas_limit: "45000000"
+    gas_limit: "60000000"
     selection: "default"
     boost_factor: "90"
 ```

--- a/docs/pages/run/validator-management/proposer-config.md
+++ b/docs/pages/run/validator-management/proposer-config.md
@@ -21,7 +21,7 @@ proposer_config:
   "0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d":
     fee_recipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     builder:
-      gas_limit: "4500000"
+      gas_limit: "45000000"
       selection: "maxprofit"
       boost_factor: "100"
 default_config:

--- a/packages/api/test/unit/keymanager/testData.ts
+++ b/packages/api/test/unit/keymanager/testData.ts
@@ -12,7 +12,7 @@ import {GenericServerTestCases} from "../../utils/genericServerTest.js";
 const pubkeyRand = "0x84105a985058fc8740a48bf1ede9d223ef09e8c6b1735ba0a55cf4a9ff2ff92376b778798365e488dab07a652eb04576";
 const ethaddressRand = "0xabcf8e0d4e9587369b2301d0790347320302cc09";
 const graffitiRandUtf8 = "636861696e736166652f6c6f64657374";
-const gasLimitRand = 45_000_000;
+const gasLimitRand = 60_000_000;
 const builderBoostFactorRand = BigInt(100);
 
 export const testData: GenericServerTestCases<Endpoints> = {

--- a/packages/beacon-node/test/sim/electra-interop.test.ts
+++ b/packages/beacon-node/test/sim/electra-interop.test.ts
@@ -153,7 +153,7 @@ describe("executionEngine / ExecutionEngineHttp", () => {
         256
       ),
       prevRandao: dataToBytes("0x0000000000000000000000000000000000000000000000000000000000000000", 32),
-      gasLimit: 45000000,
+      gasLimit: 60000000,
       gasUsed: 84714,
       timestamp: 16,
       extraData: dataToBytes("0x", 0),

--- a/packages/beacon-node/test/sim/mergemock.test.ts
+++ b/packages/beacon-node/test/sim/mergemock.test.ts
@@ -178,7 +178,7 @@ describe("executionEngine / ExecutionEngineHttp", () => {
         strictFeeRecipientCheck: true,
         feeRecipient: feeRecipientEngine,
         builder: {
-          gasLimit: 30000000,
+          gasLimit: 60000000,
           selection: routes.validator.BuilderSelection.BuilderAlways,
         },
       },

--- a/packages/cli/test/e2e/propserConfigfromKeymanager.test.ts
+++ b/packages/cli/test/e2e/propserConfigfromKeymanager.test.ts
@@ -16,7 +16,7 @@ describe("import keystores from api, test DefaultProposerConfig", () => {
 
   const defaultOptions = {
     suggestedFeeRecipient: "0x0000000000000000000000000000000000000000",
-    gasLimit: 45_000_000,
+    gasLimit: 60_000_000,
     graffiti: "aaaa",
   };
 

--- a/packages/cli/test/unit/validator/parseProposerConfig.test.ts
+++ b/packages/cli/test/unit/validator/parseProposerConfig.test.ts
@@ -13,7 +13,7 @@ const testValue = {
       strictFeeRecipientCheck: true,
       feeRecipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       builder: {
-        gasLimit: 45000000,
+        gasLimit: 60000000,
         selection: undefined,
         boostFactor: undefined,
       },
@@ -34,7 +34,7 @@ const testValue = {
     strictFeeRecipientCheck: true,
     feeRecipient: "0xcccccccccccccccccccccccccccccccccccccccc",
     builder: {
-      gasLimit: 45000000,
+      gasLimit: 60000000,
       selection: routes.validator.BuilderSelection.MaxProfit,
       boostFactor: BigInt(50),
     },

--- a/packages/cli/test/unit/validator/proposerConfigs/invalidData.yaml
+++ b/packages/cli/test/unit/validator/proposerConfigs/invalidData.yaml
@@ -5,16 +5,16 @@ proposer_config:
     fee_recipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     builder:
       enabled: true
-      gas_limit: "45000000"
+      gas_limit: "60000000"
   "0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d":
     fee_recipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     builder:
       enabled: "true"
-      gas_limit: "35000000"
+      gas_limit: "45000000"
 default_config:
   graffiti: "default graffiti"
   strict_fee_recipient_check: true
   fee_recipient: "0xcccccccccccccccccccccccccccccccccccccccc"
   builder:
     enabled: true
-    gas_limit: "45000000"
+    gas_limit: "60000000"

--- a/packages/cli/test/unit/validator/proposerConfigs/validData.yaml
+++ b/packages/cli/test/unit/validator/proposerConfigs/validData.yaml
@@ -4,7 +4,7 @@ proposer_config:
     strict_fee_recipient_check: true
     fee_recipient: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     builder:
-      gas_limit: "45000000"
+      gas_limit: "60000000"
   "0xa4855c83d868f772a579133d9f23818008417b743e8447e235d8eb78b1d8f8a9f63f98c551beb7de254400f89592314d":
     fee_recipient: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     builder:
@@ -16,6 +16,6 @@ default_config:
   strict_fee_recipient_check: "true"
   fee_recipient: "0xcccccccccccccccccccccccccccccccccccccccc"
   builder:
-    gas_limit: "45000000"
+    gas_limit: "60000000"
     selection: "maxprofit"
     boost_factor: "50"

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -131,7 +131,7 @@ type ValidatorData = ProposerConfig & {
 
 export const defaultOptions = {
   suggestedFeeRecipient: "0x0000000000000000000000000000000000000000",
-  defaultGasLimit: 45_000_000,
+  defaultGasLimit: 60_000_000,
   builderSelection: routes.validator.BuilderSelection.ExecutionOnly,
   builderAliasSelection: routes.validator.BuilderSelection.Default,
   builderBoostFactor: BigInt(100),


### PR DESCRIPTION
**Motivation**

Client teams have been instructed to increase default gas limits to 60M for Fusaka. 

**Description**

This will ensure that validators signal 60M by default and updates docs/tests to work with the new 60M configuration.
