### PR TITLE
feat: log clientAgent and clientVersion for gossip errors

### DIFF
--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -296,6 +296,10 @@ export class Eth2Gossipsub extends GossipSub {
     // Get seenTimestamp before adding the message to the queue or add async delays
     const seenTimestampSec = Date.now() / 1000;
 
+    const peerIdStr = propagationSource.toString();
+    const clientAgent = this.peersData.getPeerKind(peerIdStr) ?? "Unknown";
+    const clientVersion = this.peersData.getAgentVersion(peerIdStr) ?? "Unknown";
+
     // Use setTimeout to yield to the macro queue
     // Without this we'll have huge event loop lag
     // See https://github.com/ChainSafe/lodestar/issues/5604
@@ -305,7 +309,9 @@ export class Eth2Gossipsub extends GossipSub {
         msg,
         msgId,
         // Hot path, use cached .toString() version
-        propagationSource: propagationSource.toString(),
+        propagationSource: peerIdStr,
+        clientVersion,
+        clientAgent,
         seenTimestampSec,
         startProcessUnixSec: null,
       });

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -298,7 +298,7 @@ export class Eth2Gossipsub extends GossipSub {
 
     const peerIdStr = propagationSource.toString();
     const clientAgent = this.peersData.getPeerKind(peerIdStr) ?? "Unknown";
-    const clientVersion = this.peersData.getAgentVersion(peerIdStr) ?? "Unknown";
+    const clientVersion = this.peersData.getAgentVersion(peerIdStr);
 
     // Use setTimeout to yield to the macro queue
     // Without this we'll have huge event loop lag

--- a/packages/beacon-node/src/network/gossip/interface.ts
+++ b/packages/beacon-node/src/network/gossip/interface.ts
@@ -150,6 +150,8 @@ export type GossipMessageInfo = {
   topic: GossipTopic;
   msg: Message;
   propagationSource: PeerIdStr;
+  clientAgent: string;
+  clientVersion: string;
   seenTimestampSec: number;
   msgSlot: Slot | null;
   indexed?: string;

--- a/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
+++ b/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
@@ -145,7 +145,7 @@ export function getGossipValidatorFn(gossipHandlers: GossipHandlers, modules: Va
           metrics?.networkProcessor.gossipValidationReject.inc({topic: type});
           logger.debug(
             `Gossip validation ${type} rejected`,
-            {clientAgent, clientVersion, peerId: prettyPrintPeerIdStr(propagationSource)},
+            {peerId: prettyPrintPeerIdStr(propagationSource), clientAgent, clientVersion},
             e
           );
           return TopicValidatorResult.Reject;

--- a/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
+++ b/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
@@ -11,6 +11,7 @@ import {
   GossipValidatorBatchFn,
   GossipValidatorFn,
 } from "../gossip/interface.js";
+import {prettyPrintPeerIdStr} from "../util.ts";
 
 export type ValidatorFnModules = {
   config: ChainForkConfig;
@@ -142,7 +143,11 @@ export function getGossipValidatorFn(gossipHandlers: GossipHandlers, modules: Va
 
         case GossipAction.REJECT:
           metrics?.networkProcessor.gossipValidationReject.inc({topic: type});
-          logger.debug(`Gossip validation ${type} rejected`, {clientAgent, clientVersion}, e);
+          logger.debug(
+            `Gossip validation ${type} rejected`,
+            {clientAgent, clientVersion, peerId: prettyPrintPeerIdStr(propagationSource)},
+            e
+          );
           return TopicValidatorResult.Reject;
       }
     }

--- a/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
+++ b/packages/beacon-node/src/network/processor/gossipValidatorFn.ts
@@ -99,7 +99,15 @@ export function getGossipValidatorBatchFn(
 export function getGossipValidatorFn(gossipHandlers: GossipHandlers, modules: ValidatorFnModules): GossipValidatorFn {
   const {logger, metrics} = modules;
 
-  return async function gossipValidatorFn({topic, msg, propagationSource, seenTimestampSec, msgSlot}) {
+  return async function gossipValidatorFn({
+    topic,
+    msg,
+    propagationSource,
+    clientAgent,
+    clientVersion,
+    seenTimestampSec,
+    msgSlot,
+  }) {
     const type = topic.type;
 
     try {
@@ -134,7 +142,7 @@ export function getGossipValidatorFn(gossipHandlers: GossipHandlers, modules: Va
 
         case GossipAction.REJECT:
           metrics?.networkProcessor.gossipValidationReject.inc({topic: type});
-          logger.debug(`Gossip validation ${type} rejected`, {}, e);
+          logger.debug(`Gossip validation ${type} rejected`, {clientAgent, clientVersion}, e);
           return TopicValidatorResult.Reject;
       }
     }

--- a/packages/beacon-node/src/network/processor/types.ts
+++ b/packages/beacon-node/src/network/processor/types.ts
@@ -15,6 +15,8 @@ export type PendingGossipsubMessage = {
   msgSlot?: Slot;
   msgId: string;
   propagationSource: PeerIdStr;
+  clientAgent: string;
+  clientVersion: string;
   seenTimestampSec: number;
   startProcessUnixSec: number | null;
   // specific properties for IndexedGossipQueueMinSize, for beacon_attestation topic only

--- a/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
+++ b/packages/beacon-node/test/e2e/network/onWorker/dataSerialization.test.ts
@@ -91,6 +91,8 @@ describe("data serialization through worker boundary", () => {
       msgSlot: 1000,
       msgId: ZERO_HASH_HEX,
       propagationSource: peerId,
+      clientAgent: "Unknown",
+      clientVersion: "NA",
       seenTimestampSec: 1600000000,
       startProcessUnixSec: 1600000000,
     },


### PR DESCRIPTION
**Motivation**
 
When gossip errors occur it will be helpful to see the client and version sending the invalid gossip message