### PR TITLE
feat: include commit hash in network lodestar version

### DIFF
--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -221,9 +221,8 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
     beaconNodeOptions.set({network: {private: true}, api: {private: true}});
   } else {
     const versionStr = `Lodestar/${version}`;
-    const simpleVersionStr = version.split("/")[0];
     // Add simple version string for libp2p agent version
-    beaconNodeOptions.set({network: {version: simpleVersionStr}});
+    beaconNodeOptions.set({network: {version}});
     // Add User-Agent header to all builder requests
     beaconNodeOptions.set({executionBuilder: {userAgent: versionStr}});
     // Set jwt version with version string

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -221,7 +221,7 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
     beaconNodeOptions.set({network: {private: true}, api: {private: true}});
   } else {
     const versionStr = `Lodestar/${version}`;
-    // Add simple version string for libp2p agent version
+    // Add version string for libp2p agent version
     beaconNodeOptions.set({network: {version}});
     // Add User-Agent header to all builder requests
     beaconNodeOptions.set({executionBuilder: {userAgent: versionStr}});


### PR DESCRIPTION
We are already including the version (eg. `lodestar/v1.36.0`), there doesn't seem to be much of a benefit in terms of security to not include the commit hash as well and it helps debugging especially in early devnets or release candidates as there the version number is the same while it might run a different commit.

We do have the `--private` flag to avoid including any information about the client on p2p. 