### PR TITLE
test: improve type check performance

### DIFF
--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -3,7 +3,6 @@ import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {ChainForkConfig} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
 import {EpochDifference, ForkChoice, ProtoBlock} from "@lodestar/fork-choice";
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {Logger} from "@lodestar/utils";
 import {BeaconProposerCache} from "../../src/chain/beaconProposerCache.js";
 import {BeaconChain} from "../../src/chain/chain.js";
@@ -21,7 +20,6 @@ import {getMockedLogger} from "./loggerMock.js";
 
 export type MockedBeaconChain = Mocked<BeaconChain> & {
   logger: Mocked<Logger>;
-  getHeadState: Mocked<CachedBeaconStateAllForks>;
   forkChoice: MockedForkChoice;
   executionEngine: Mocked<ExecutionEngineHttp>;
   executionBuilder: Mocked<ExecutionBuilderHttp>;


### PR DESCRIPTION
**Motivation**

Improve type check performance. 

**Description**

- Improve the type check performance which was degraded in recent changes. From `100s` to `8s` for `beacon-node` package. 

```
time yarn check-types
yarn run v1.22.22
$ tsc
✨  Done in 105.85s.
yarn check-types  108.35s user 2.59s system 104% cpu 1:46.08 total
```

vs

```
time yarn check-types
yarn run v1.22.22
$ tsc
✨  Done in 8.46s.
yarn check-types  14.60s user 0.86s system 178% cpu 8.661 total
```

**Steps to test or reproduce**

- Run all jobs