### PR TITLE
fix: verify proposer signatures once per slot

### DIFF
--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -3,7 +3,7 @@ import {CheckpointWithHex} from "@lodestar/fork-choice";
 import {ForkName, ForkPostFulu, ForkPreGloas, isForkPostDeneb, isForkPostFulu, isForkPostGloas} from "@lodestar/params";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {RootHex, SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
-import {LodestarError, Logger} from "@lodestar/utils";
+import {LodestarError, Logger, pruneSetToMax} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {IClock} from "../../util/clock.js";
 import {CustodyConfig} from "../../util/dataColumns.js";
@@ -83,6 +83,9 @@ export class SeenBlockInput {
   private readonly metrics: Metrics | null;
   private readonly logger?: Logger;
   private blockInputs = new Map<RootHex, IBlockInput>();
+  // using a Map of slot helps it more convenient to prune
+  // there should only 1 block root per slot but we need to always compare against rootHex
+  private verifiedProposerSignatures = new Map<Slot, Set<RootHex>>();
 
   constructor({config, custodyConfig, clock, chainEvents, signal, metrics, logger}: SeenBlockInputCacheModules) {
     this.config = config;
@@ -330,6 +333,22 @@ export class SeenBlockInput {
     return blockInput;
   }
 
+  isVerifiedProposerSignature(slot: Slot, blockRootHex: RootHex): boolean {
+    const seenSet = this.verifiedProposerSignatures.get(slot);
+    return seenSet?.has(blockRootHex) ?? false;
+  }
+
+  // Mark that the proposer signature for this slot and block root has been verified
+  // so that we only verify it once per slot
+  markVerifiedProposerSignature(slot: Slot, blockRootHex: RootHex): void {
+    let seenSet = this.verifiedProposerSignatures.get(slot);
+    if (!seenSet) {
+      seenSet = new Set<RootHex>();
+      this.verifiedProposerSignatures.set(slot, seenSet);
+    }
+    seenSet.add(blockRootHex);
+  }
+
   private buildCommonProps(slot: Slot): {
     daOutOfRange: boolean;
     forkName: ForkName;
@@ -356,6 +375,7 @@ export class SeenBlockInput {
         if (itemsToDelete <= 0) return;
       }
     }
+    pruneSetToMax(this.verifiedProposerSignatures, MAX_BLOCK_INPUT_CACHE_SIZE);
   }
 }
 

--- a/packages/beacon-node/src/chain/validation/blobSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -134,16 +134,20 @@ export async function validateGossipBlobSidecar(
       });
     });
 
-  // [REJECT] The proposer signature, signed_beacon_block.signature, is valid with respect to the proposer_index pubkey.
-  const signatureSet = getBlockHeaderProposerSignatureSetByParentStateSlot(blockState, blobSidecar.signedBlockHeader);
-  // Don't batch so verification is not delayed
-  if (!(await chain.bls.verifySignatureSets([signatureSet], {verifyOnMainThread: true}))) {
-    throw new BlobSidecarGossipError(GossipAction.REJECT, {
-      code: BlobSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
-      blockRoot: blockHex,
-      index: blobSidecar.index,
-      slot: blobSlot,
-    });
+  if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blobSlot, blockHex)) {
+    // [REJECT] The proposer signature, signed_beacon_block.signature, is valid with respect to the proposer_index pubkey.
+    const signatureSet = getBlockHeaderProposerSignatureSetByParentStateSlot(blockState, blobSidecar.signedBlockHeader);
+    // Don't batch so verification is not delayed
+    if (!(await chain.bls.verifySignatureSets([signatureSet], {verifyOnMainThread: true}))) {
+      throw new BlobSidecarGossipError(GossipAction.REJECT, {
+        code: BlobSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
+        blockRoot: blockHex,
+        index: blobSidecar.index,
+        slot: blobSlot,
+      });
+    }
+
+    chain.seenBlockInputCache.markVerifiedProposerSignature(blobSlot, blockHex);
   }
 
   // verify if the blob inclusion proof is correct
@@ -231,23 +235,28 @@ export async function validateBlockBlobSidecars(
   }
 
   if (chain !== null) {
-    const headState = await chain.getHeadState();
-    const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(headState, firstSidecarSignedBlockHeader);
+    const blockRootHex = toRootHex(blockRoot);
+    if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockSlot, blockRootHex)) {
+      const headState = await chain.getHeadState();
+      const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(headState, firstSidecarSignedBlockHeader);
 
-    if (
-      !(await chain.bls.verifySignatureSets([signatureSet], {
-        batchable: true,
-        priority: true,
-        verifyOnMainThread: false,
-      }))
-    ) {
-      throw new BlobSidecarValidationError({
-        code: BlobSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
-        blockRoot: toRootHex(blockRoot),
-        slot: blockSlot,
-        index: blobSidecars[0].index,
-      });
+      if (
+        !(await chain.bls.verifySignatureSets([signatureSet], {
+          batchable: true,
+          priority: true,
+          verifyOnMainThread: true,
+        }))
+      ) {
+        throw new BlobSidecarValidationError({
+          code: BlobSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
+          blockRoot: toRootHex(blockRoot),
+          slot: blockSlot,
+          index: blobSidecars[0].index,
+        });
+      }
     }
+
+    chain.seenBlockInputCache.markVerifiedProposerSignature(blockSlot, blockRootHex);
   }
 
   const commitments = [];

--- a/packages/beacon-node/src/chain/validation/blobSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -247,7 +247,7 @@ export async function validateBlockBlobSidecars(
       ) {
         throw new BlobSidecarValidationError({
           code: BlobSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
-          blockRoot: toRootHex(blockRoot),
+          blockRoot: blockRootHex,
           slot: blockSlot,
           index: blobSidecars[0].index,
         });

--- a/packages/beacon-node/src/chain/validation/blobSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -242,8 +242,6 @@ export async function validateBlockBlobSidecars(
 
       if (
         !(await chain.bls.verifySignatureSets([signatureSet], {
-          batchable: true,
-          priority: true,
           verifyOnMainThread: true,
         }))
       ) {
@@ -254,9 +252,9 @@ export async function validateBlockBlobSidecars(
           index: blobSidecars[0].index,
         });
       }
-    }
 
-    chain.seenBlockInputCache.markVerifiedProposerSignature(blockSlot, blockRootHex);
+      chain.seenBlockInputCache.markVerifiedProposerSignature(blockSlot, blockRootHex);
+    }
   }
 
   const commitments = [];

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -153,13 +153,17 @@ export async function validateGossipBlock(
   }
 
   // [REJECT] The proposer signature, signed_beacon_block.signature, is valid with respect to the proposer_index pubkey.
-  const signatureSet = getBlockProposerSignatureSet(blockState, signedBlock);
-  // Don't batch so verification is not delayed
-  if (!(await chain.bls.verifySignatureSets([signatureSet], {verifyOnMainThread: true}))) {
-    throw new BlockGossipError(GossipAction.REJECT, {
-      code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID,
-      blockSlot,
-    });
+  if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockSlot, blockRoot)) {
+    const signatureSet = getBlockProposerSignatureSet(blockState, signedBlock);
+    // Don't batch so verification is not delayed
+    if (!(await chain.bls.verifySignatureSets([signatureSet], {verifyOnMainThread: true}))) {
+      throw new BlockGossipError(GossipAction.REJECT, {
+        code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID,
+        blockSlot,
+      });
+    }
+
+    chain.seenBlockInputCache.markVerifiedProposerSignature(blockSlot, blockRoot);
   }
 
   // [REJECT] The block is proposed by the expected proposer_index for the block's slot in the context of the current

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -144,8 +144,6 @@ export async function validateGossipDataColumnSidecar(
         verifyOnMainThread: true,
       }))
     ) {
-      const blockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(dataColumnSidecar.signedBlockHeader.message);
-      const blockRootHex = toRootHex(blockRoot);
       throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
         code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
         blockRoot: blockRootHex,
@@ -345,7 +343,7 @@ export async function validateBlockDataColumnSidecars(
       ) {
         throw new DataColumnSidecarValidationError({
           code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
-          blockRoot: toRootHex(blockRoot),
+          blockRoot: rootHex,
           slot: blockSlot,
           index: dataColumnSidecars[0].index,
         });

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -141,7 +141,7 @@ export async function validateGossipDataColumnSidecar(
     if (
       !(await chain.bls.verifySignatureSets([signatureSet], {
         // verify on main thread so that we only need to verify block proposer signature once per block
-        verifyOnMainThread: blockHeader.slot > chain.forkChoice.getHead().slot,
+        verifyOnMainThread: true,
       }))
     ) {
       const blockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(dataColumnSidecar.signedBlockHeader.message);
@@ -339,10 +339,7 @@ export async function validateBlockDataColumnSidecars(
       const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(headState, firstSidecarSignedBlockHeader);
 
       if (
-        !chain.seenBlockInputCache.has(toRootHex(blockRoot)) &&
         !(await chain.bls.verifySignatureSets([signatureSet], {
-          batchable: true,
-          priority: true,
           verifyOnMainThread: true,
         }))
       ) {
@@ -353,9 +350,9 @@ export async function validateBlockDataColumnSidecars(
           index: dataColumnSidecars[0].index,
         });
       }
-    }
 
-    chain.seenBlockInputCache.markVerifiedProposerSignature(slot, rootHex);
+      chain.seenBlockInputCache.markVerifiedProposerSignature(slot, rootHex);
+    }
   }
 
   const commitments: Uint8Array[] = [];

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -32,6 +32,7 @@ export async function validateGossipDataColumnSidecar(
   metrics: Metrics | null
 ): Promise<void> {
   const blockHeader = dataColumnSidecar.signedBlockHeader.message;
+  const blockRootHex = toRootHex(ssz.phase0.BeaconBlockHeader.hashTreeRoot(blockHeader));
 
   // 1) [REJECT] The sidecar is valid as verified by verify_data_column_sidecar
   verifyDataColumnSidecar(chain.config, dataColumnSidecar);
@@ -135,20 +136,25 @@ export async function validateGossipDataColumnSidecar(
     blockState,
     dataColumnSidecar.signedBlockHeader
   );
-  // Don't batch so verification is not delayed
-  if (
-    !(await chain.bls.verifySignatureSets([signatureSet], {
-      verifyOnMainThread: blockHeader.slot > chain.forkChoice.getHead().slot,
-    }))
-  ) {
-    const blockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(dataColumnSidecar.signedBlockHeader.message);
-    const blockRootHex = toRootHex(blockRoot);
-    throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
-      code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
-      blockRoot: blockRootHex,
-      index: dataColumnSidecar.index,
-      slot: blockHeader.slot,
-    });
+
+  if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockHeader.slot, blockRootHex)) {
+    if (
+      !(await chain.bls.verifySignatureSets([signatureSet], {
+        // verify on main thread so that we only need to verify block proposer signature once per block
+        verifyOnMainThread: blockHeader.slot > chain.forkChoice.getHead().slot,
+      }))
+    ) {
+      const blockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(dataColumnSidecar.signedBlockHeader.message);
+      const blockRootHex = toRootHex(blockRoot);
+      throw new DataColumnSidecarGossipError(GossipAction.REJECT, {
+        code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
+        blockRoot: blockRootHex,
+        index: dataColumnSidecar.index,
+        slot: blockHeader.slot,
+      });
+    }
+
+    chain.seenBlockInputCache.markVerifiedProposerSignature(blockHeader.slot, blockRootHex);
   }
 
   // 9) [REJECT] The current finalized_checkpoint is an ancestor of the sidecar's block
@@ -326,23 +332,30 @@ export async function validateBlockDataColumnSidecars(
   }
 
   if (chain !== null) {
-    const headState = await chain.getHeadState();
-    const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(headState, firstSidecarSignedBlockHeader);
+    const rootHex = toRootHex(blockRoot);
+    const slot = firstSidecarSignedBlockHeader.message.slot;
+    if (!chain.seenBlockInputCache.isVerifiedProposerSignature(slot, rootHex)) {
+      const headState = await chain.getHeadState();
+      const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(headState, firstSidecarSignedBlockHeader);
 
-    if (
-      !(await chain.bls.verifySignatureSets([signatureSet], {
-        batchable: true,
-        priority: true,
-        verifyOnMainThread: false,
-      }))
-    ) {
-      throw new DataColumnSidecarValidationError({
-        code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
-        blockRoot: toRootHex(blockRoot),
-        slot: blockSlot,
-        index: dataColumnSidecars[0].index,
-      });
+      if (
+        !chain.seenBlockInputCache.has(toRootHex(blockRoot)) &&
+        !(await chain.bls.verifySignatureSets([signatureSet], {
+          batchable: true,
+          priority: true,
+          verifyOnMainThread: true,
+        }))
+      ) {
+        throw new DataColumnSidecarValidationError({
+          code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
+          blockRoot: toRootHex(blockRoot),
+          slot: blockSlot,
+          index: dataColumnSidecars[0].index,
+        });
+      }
     }
+
+    chain.seenBlockInputCache.markVerifiedProposerSignature(slot, rootHex);
   }
 
   const commitments: Uint8Array[] = [];

--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -10,6 +10,7 @@ import {ChainEventEmitter} from "../../src/chain/emitter.js";
 import {LightClientServer} from "../../src/chain/lightClient/index.js";
 import {AggregatedAttestationPool, OpPool, SyncContributionAndProofPool} from "../../src/chain/opPools/index.js";
 import {QueuedStateRegenerator} from "../../src/chain/regen/index.js";
+import {SeenBlockInput} from "../../src/chain/seenCache/seenGossipBlockInput.js";
 import {ShufflingCache} from "../../src/chain/shufflingCache.js";
 import {Eth1ForBlockProduction} from "../../src/eth1/index.js";
 import {ExecutionBuilderHttp} from "../../src/execution/builder/http.js";
@@ -28,6 +29,7 @@ export type MockedBeaconChain = Mocked<BeaconChain> & {
   aggregatedAttestationPool: Mocked<AggregatedAttestationPool>;
   syncContributionAndProofPool: Mocked<SyncContributionAndProofPool>;
   beaconProposerCache: Mocked<BeaconProposerCache>;
+  seenBlockInputCache: Mocked<SeenBlockInput>;
   shufflingCache: Mocked<ShufflingCache>;
   regen: Mocked<QueuedStateRegenerator>;
   bls: {
@@ -73,6 +75,7 @@ vi.mock("@lodestar/fork-choice", async (importActual) => {
 vi.mock("../../src/chain/regen/index.js");
 vi.mock("../../src/eth1/index.js");
 vi.mock("../../src/chain/beaconProposerCache.js");
+vi.mock("../../src/chain/seenCache/seenGossipBlockInput.js");
 vi.mock("../../src/chain/shufflingCache.js");
 vi.mock("../../src/chain/lightClient/index.js");
 
@@ -140,6 +143,8 @@ vi.mock("../../src/chain/chain.js", async (importActual) => {
       syncContributionAndProofPool: new SyncContributionAndProofPool(config, clock),
       // @ts-expect-error
       beaconProposerCache: new BeaconProposerCache(),
+      // @ts-expect-error
+      seenBlockInputCache: new SeenBlockInput(),
       shufflingCache: new ShufflingCache(),
       pubkey2index: new PubkeyIndexMap(),
       index2pubkey: [],


### PR DESCRIPTION
**Motivation**

- I found we verify proposer signatures multiple times per slot. On hoodi it takes 20ms to 40ms, if we receive all DataColumnSidecars by gossip it would be a lot of time

<img width="1594" height="294" alt="Screenshot 2025-11-20 at 15 15 01" src="https://github.com/user-attachments/assets/6797bb8b-e4a6-4b10-a939-30fc45658f45" />

proposer signatures are verified when we receive gossip block, BlobSidecar or DataColumnSidecar

**Description**
- enhance `SeenBlockInput` with a map to cache verified proposer signature by slot + root hex
- verify Block/Blob/DataColumnSidecar proposer signature on main thread and cache. It will takes ~30ms to do that, and we only have to do it once per slot

part of #8619

**Testing**
- [x] deployed to feat4
- [x] monitor result
