### PR TITLE
chore: fix test current file launch args

### DIFF
--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -50,7 +50,10 @@
         "${input:testName}",
         "--pool",
         "forks",
-        "--poolOptions.forks.singleFork"
+        "--maxWorkers",
+        "1",
+        "--isolate",
+        "true"
       ],
       "cwd": "${workspaceFolder}/${input:packageName}",
       "console": "integratedTerminal",


### PR DESCRIPTION
Updates `Test Current File` launch config to work with vitest 4 (updated in https://github.com/ChainSafe/lodestar/pull/8599).