### PR TITLE
feat: implement Buffer pool for inbound data transform of network thread

### DIFF
--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -156,4 +156,5 @@ export class InboundTransformBufferPool {
 // pool of buffers for each topic to uncompress incoming messages into
 export const globalInboundCache = new Map<GossipType, InboundTransformBufferPool>();
 globalInboundCache.set(GossipType.data_column_sidecar, new InboundTransformBufferPool(NUMBER_OF_COLUMNS));
-globalInboundCache.set(GossipType.beacon_attestation, new InboundTransformBufferPool(10_000));
+// TODO: reevaluate this number
+globalInboundCache.set(GossipType.beacon_attestation, new InboundTransformBufferPool(1_000));

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -8,11 +8,11 @@ import {ForkName, NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {intToBytes} from "@lodestar/utils";
 import {LinkedList} from "../../util/array.js";
-import {getMaxDataColumnSizeCarBytes} from "../../util/sszBytes.js";
+import {getDataColumnSideCarBytes} from "../../util/sszBytes.js";
 import {MESSAGE_DOMAIN_VALID_SNAPPY} from "./constants.js";
 import {GossipType} from "./interface.js";
 import {SnappyError, SnappyErrorCode} from "./snappy/error.js";
-import {compress, uncompress} from "./snappy/index.js";
+import {compress, uncompress as uncompressSnappy} from "./snappy/index.js";
 import {GossipTopicCache, getGossipSSZType} from "./topic.js";
 
 // Load WASM
@@ -87,7 +87,7 @@ export class DataTransformSnappy implements DataTransform {
    * - `inboundTransform()`: decompress snappy payload
    * - `outboundTransform()`: compress snappy payload
    */
-  inboundTransform(topicStr: string, data: Uint8Array): Uint8Array {
+  inboundTransform(topicStr: string, compressedData: Uint8Array): Uint8Array {
     const topic = this.gossipTopicCache.getTopic(topicStr);
     let buffer: Uint8Array | undefined = undefined;
     const inboundCache = globalInboundCache.get(topic.type);
@@ -109,7 +109,8 @@ export class DataTransformSnappy implements DataTransform {
           // fulu
           case GossipType.data_column_sidecar: {
             const maxBlobs = this.config.getMaxBlobsPerBlock(topic.boundary.epoch);
-            buffer = new Uint8Array(getMaxDataColumnSizeCarBytes(maxBlobs));
+            // allocate based on max blobs in order to reuse the allocated buffer
+            buffer = new Uint8Array(getDataColumnSideCarBytes(maxBlobs));
             break;
           }
           // all forks
@@ -136,7 +137,7 @@ export class DataTransformSnappy implements DataTransform {
         }
       }
     }
-    const uncompressedData = this.uncompress(topic.type, data, buffer);
+    const uncompressedData = this.uncompress(topic.type, compressedData, buffer);
     const sszType = getGossipSSZType(topic);
 
     // check uncompressed data length before we extract beacon block root, slot or
@@ -164,16 +165,18 @@ export class DataTransformSnappy implements DataTransform {
     return compress(data);
   }
 
-  private uncompress(type: GossipType, data: Uint8Array, buffer: Uint8Array | undefined): Uint8Array {
+  private uncompress(type: GossipType, compressedData: Uint8Array, buffer: Uint8Array | undefined): Uint8Array {
     try {
-      return uncompress(data, this.maxSizePerMessage, buffer);
+      return uncompressSnappy(compressedData, this.maxSizePerMessage, buffer);
     } catch (e) {
       if (buffer === undefined || !(e instanceof SnappyError)) {
         throw e;
       }
+
       if ((e as SnappyError<{code: SnappyErrorCode}>).type.code === SnappyErrorCode.UNCOMPRESS_BUFFER_TOO_SMALL) {
+        // the provided buffer is too small, let snappy uncompress allocate a new one
         this.allocByTopicType.set(type, (this.allocByTopicType.get(type) ?? 0) + 1);
-        return uncompress(data, this.maxSizePerMessage, undefined);
+        return uncompressSnappy(compressedData, this.maxSizePerMessage, undefined);
       }
       throw e;
     }

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -92,7 +92,7 @@ export class DataTransformSnappy implements DataTransform {
     let buffer: Uint8Array | undefined = undefined;
     const inboundCache = globalInboundCache.get(topic.type);
     if (inboundCache) {
-      const arraybuffer = inboundCache.pop();
+      const arraybuffer = inboundCache.shift();
       if (arraybuffer) {
         buffer = new Uint8Array(arraybuffer);
       } else {
@@ -193,8 +193,12 @@ export class InboundTransformBufferPool {
     }
   }
 
-  pop(): ArrayBuffer | null {
-    return this.buffers.pop();
+  /**
+   * get from the head of the queue in order to get rid of the oldest buffer first
+   * in case the latter ones have bigger size
+   */
+  shift(): ArrayBuffer | null {
+    return this.buffers.shift();
   }
 
   size(): number {

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -203,15 +203,16 @@ export class InboundTransformBufferPool {
 }
 
 // pool of buffers for each topic to uncompress incoming messages into
-// TODO: reevaluate these numbers
+// these parameters were tuned based on hoodi + mainnet as of Nov 2025
 export const globalInboundCache = new Map<GossipType, InboundTransformBufferPool>();
 // electra
 globalInboundCache.set(GossipType.blob_sidecar, new InboundTransformBufferPool(9));
 // fulu
-globalInboundCache.set(GossipType.data_column_sidecar, new InboundTransformBufferPool(NUMBER_OF_COLUMNS));
-globalInboundCache.set(GossipType.beacon_attestation, new InboundTransformBufferPool(1_000));
-globalInboundCache.set(GossipType.beacon_aggregate_and_proof, new InboundTransformBufferPool(100));
-globalInboundCache.set(GossipType.sync_committee, new InboundTransformBufferPool(100));
+globalInboundCache.set(GossipType.data_column_sidecar, new InboundTransformBufferPool(NUMBER_OF_COLUMNS * 2));
+// depends on a node subscribing to all subnets or not, we can tweak this number later
+globalInboundCache.set(GossipType.beacon_attestation, new InboundTransformBufferPool(30_000));
+globalInboundCache.set(GossipType.beacon_aggregate_and_proof, new InboundTransformBufferPool(300));
+globalInboundCache.set(GossipType.sync_committee, new InboundTransformBufferPool(200));
 globalInboundCache.set(GossipType.sync_committee_contribution_and_proof, new InboundTransformBufferPool(100));
 globalInboundCache.set(GossipType.beacon_block, new InboundTransformBufferPool(1));
 // TODO: other topics

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -73,6 +73,8 @@ export function msgIdFn(gossipTopicCache: GossipTopicCache, msg: Message): Uint8
 }
 
 export class DataTransformSnappy implements DataTransform {
+  allocByTopicType = new Map<GossipType, number>();
+
   constructor(
     private readonly gossipTopicCache: GossipTopicCache,
     private readonly maxSizePerMessage: number,
@@ -96,6 +98,7 @@ export class DataTransformSnappy implements DataTransform {
       } else {
         // for some first few messages when pool is empty, allocate new buffer
         // they will be added back to pool after emit to the main thread
+        this.allocByTopicType.set(topic.type, this.allocByTopicType.get(topic.type) ?? 0 + 1);
         switch (topic.type) {
           case GossipType.data_column_sidecar: {
             const maxBlobs = this.config.getMaxBlobsPerBlock(topic.boundary.epoch);
@@ -111,7 +114,7 @@ export class DataTransformSnappy implements DataTransform {
         }
       }
     }
-    const uncompressedData = this.uncompress(data, buffer);
+    const uncompressedData = this.uncompress(topic.type, data, buffer);
     const sszType = getGossipSSZType(topic);
 
     // check uncompressed data length before we extract beacon block root, slot or
@@ -139,7 +142,7 @@ export class DataTransformSnappy implements DataTransform {
     return compress(data);
   }
 
-  private uncompress(data: Uint8Array, buffer: Uint8Array | undefined): Uint8Array {
+  private uncompress(type: GossipType, data: Uint8Array, buffer: Uint8Array | undefined): Uint8Array {
     try {
       return uncompress(data, this.maxSizePerMessage, buffer);
     } catch (e) {
@@ -147,6 +150,7 @@ export class DataTransformSnappy implements DataTransform {
         throw e;
       }
       if ((e as SnappyError<{code: SnappyErrorCode}>).type.code === SnappyErrorCode.UNCOMPRESS_BUFFER_TOO_SMALL) {
+        this.allocByTopicType.set(type, (this.allocByTopicType.get(type) ?? 0) + 1);
         return uncompress(data, this.maxSizePerMessage, undefined);
       }
       throw e;

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -1,13 +1,17 @@
 import {Message} from "@libp2p/interface";
-// snappyjs is better for compression for smaller payloads
-import {compress, uncompress} from "snappyjs";
 import xxhashFactory from "xxhash-wasm";
 import {digest} from "@chainsafe/as-sha256";
 import {RPC} from "@chainsafe/libp2p-gossipsub/message";
 import {DataTransform} from "@chainsafe/libp2p-gossipsub/types";
-import {ForkName} from "@lodestar/params";
+import {BeaconConfig} from "@lodestar/config";
+import {ForkName, NUMBER_OF_COLUMNS} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
 import {intToBytes} from "@lodestar/utils";
+import {LinkedList} from "../../util/array.js";
+import {getMaxDataColumnSizeCarBytes} from "../../util/sszBytes.js";
 import {MESSAGE_DOMAIN_VALID_SNAPPY} from "./constants.js";
+import {GossipType} from "./interface.js";
+import {compress, uncompress} from "./snappy/index.js";
 import {GossipTopicCache, getGossipSSZType} from "./topic.js";
 
 // Load WASM
@@ -70,7 +74,8 @@ export function msgIdFn(gossipTopicCache: GossipTopicCache, msg: Message): Uint8
 export class DataTransformSnappy implements DataTransform {
   constructor(
     private readonly gossipTopicCache: GossipTopicCache,
-    private readonly maxSizePerMessage: number
+    private readonly maxSizePerMessage: number,
+    private readonly config: BeaconConfig
   ) {}
 
   /**
@@ -80,14 +85,30 @@ export class DataTransformSnappy implements DataTransform {
    * - `outboundTransform()`: compress snappy payload
    */
   inboundTransform(topicStr: string, data: Uint8Array): Uint8Array {
-    const uncompressedData = uncompress(data, this.maxSizePerMessage);
+    const topic = this.gossipTopicCache.getTopic(topicStr);
+    let buffer: Uint8Array | undefined = undefined;
+    const inboundCache = globalInboundCache.get(topic.type);
+    if (inboundCache) {
+      const arraybuffer = inboundCache.pop();
+      if (arraybuffer) {
+        buffer = new Uint8Array(arraybuffer);
+      } else {
+        // for some first few messages when pool is empty, allocate new buffer
+        // they will be added back to pool after emit to the main thread
+        if (topic.type === GossipType.data_column_sidecar) {
+          const maxBlobs = this.config.getMaxBlobsPerBlock(topic.boundary.epoch);
+          buffer = new Uint8Array(getMaxDataColumnSizeCarBytes(maxBlobs));
+        } else if (topic.type === GossipType.beacon_attestation) {
+          buffer = new Uint8Array(ssz.electra.SingleAttestation.fixedSize as number);
+        }
+      }
+    }
+    const uncompressedData = uncompress(data, this.maxSizePerMessage, buffer);
+    const sszType = getGossipSSZType(topic);
 
     // check uncompressed data length before we extract beacon block root, slot or
     // attestation data at later steps
     const uncompressedDataLength = uncompressedData.length;
-    const topic = this.gossipTopicCache.getTopic(topicStr);
-    const sszType = getGossipSSZType(topic);
-
     if (uncompressedDataLength < sszType.minSize) {
       throw Error(`ssz_snappy decoded data length ${uncompressedDataLength} < ${sszType.minSize}`);
     }
@@ -110,3 +131,29 @@ export class DataTransformSnappy implements DataTransform {
     return compress(data);
   }
 }
+
+export class InboundTransformBufferPool {
+  private buffers: LinkedList<ArrayBuffer> = new LinkedList<ArrayBuffer>();
+  constructor(private readonly maxLength: number) {}
+
+  add(buffer: ArrayBuffer): void {
+    if (this.buffers.length >= this.maxLength) {
+      return;
+    }
+
+    this.buffers.push(buffer);
+  }
+
+  pop(): ArrayBuffer | null {
+    return this.buffers.pop();
+  }
+
+  size(): number {
+    return this.buffers.length;
+  }
+}
+
+// pool of buffers for each topic to uncompress incoming messages into
+export const globalInboundCache = new Map<GossipType, InboundTransformBufferPool>();
+globalInboundCache.set(GossipType.data_column_sidecar, new InboundTransformBufferPool(NUMBER_OF_COLUMNS));
+globalInboundCache.set(GossipType.beacon_attestation, new InboundTransformBufferPool(10_000));

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -100,14 +100,36 @@ export class DataTransformSnappy implements DataTransform {
         // they will be added back to pool after emit to the main thread
         this.allocByTopicType.set(topic.type, this.allocByTopicType.get(topic.type) ?? 0 + 1);
         switch (topic.type) {
+          // TODO: reevaluate after each hard fork
+          // deneb + electra
+          case GossipType.blob_sidecar: {
+            buffer = new Uint8Array(ssz.deneb.BlobSidecar.fixedSize as number);
+            break;
+          }
+          // fulu
           case GossipType.data_column_sidecar: {
             const maxBlobs = this.config.getMaxBlobsPerBlock(topic.boundary.epoch);
             buffer = new Uint8Array(getMaxDataColumnSizeCarBytes(maxBlobs));
             break;
           }
+          // all forks
           case GossipType.beacon_attestation:
             buffer = new Uint8Array(ssz.electra.SingleAttestation.fixedSize as number);
             break;
+          case GossipType.beacon_aggregate_and_proof:
+            buffer = new Uint8Array(ssz.electra.SignedAggregateAndProof.maxSize);
+            break;
+          case GossipType.sync_committee:
+            buffer = new Uint8Array(ssz.altair.SyncCommitteeMessage.fixedSize as number);
+            break;
+          case GossipType.sync_committee_contribution_and_proof:
+            buffer = new Uint8Array(ssz.altair.SignedContributionAndProof.maxSize);
+            break;
+          case GossipType.beacon_block:
+          // should not put the max size of beacon block here
+          // instead of that, we allocate the exact size initially and reuse it
+          // if a bigger block comes, we fall back to allocate new buffer without reusing
+          // and use it for future blocks
           default:
             buffer = undefined;
             break;
@@ -181,7 +203,15 @@ export class InboundTransformBufferPool {
 }
 
 // pool of buffers for each topic to uncompress incoming messages into
+// TODO: reevaluate these numbers
 export const globalInboundCache = new Map<GossipType, InboundTransformBufferPool>();
+// electra
+globalInboundCache.set(GossipType.blob_sidecar, new InboundTransformBufferPool(9));
+// fulu
 globalInboundCache.set(GossipType.data_column_sidecar, new InboundTransformBufferPool(NUMBER_OF_COLUMNS));
-// TODO: reevaluate this number
 globalInboundCache.set(GossipType.beacon_attestation, new InboundTransformBufferPool(1_000));
+globalInboundCache.set(GossipType.beacon_aggregate_and_proof, new InboundTransformBufferPool(100));
+globalInboundCache.set(GossipType.sync_committee, new InboundTransformBufferPool(100));
+globalInboundCache.set(GossipType.sync_committee_contribution_and_proof, new InboundTransformBufferPool(100));
+globalInboundCache.set(GossipType.beacon_block, new InboundTransformBufferPool(1));
+// TODO: other topics

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -98,7 +98,7 @@ export class DataTransformSnappy implements DataTransform {
       } else {
         // for some first few messages when pool is empty, allocate new buffer
         // they will be added back to pool after emit to the main thread
-        this.allocByTopicType.set(topic.type, this.allocByTopicType.get(topic.type) ?? 0 + 1);
+        this.allocByTopicType.set(topic.type, (this.allocByTopicType.get(topic.type) ?? 0) + 1);
         switch (topic.type) {
           // TODO: reevaluate after each hard fork
           // deneb + electra

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -11,6 +11,7 @@ import {LinkedList} from "../../util/array.js";
 import {getMaxDataColumnSizeCarBytes} from "../../util/sszBytes.js";
 import {MESSAGE_DOMAIN_VALID_SNAPPY} from "./constants.js";
 import {GossipType} from "./interface.js";
+import {SnappyError, SnappyErrorCode} from "./snappy/error.js";
 import {compress, uncompress} from "./snappy/index.js";
 import {GossipTopicCache, getGossipSSZType} from "./topic.js";
 
@@ -95,15 +96,22 @@ export class DataTransformSnappy implements DataTransform {
       } else {
         // for some first few messages when pool is empty, allocate new buffer
         // they will be added back to pool after emit to the main thread
-        if (topic.type === GossipType.data_column_sidecar) {
-          const maxBlobs = this.config.getMaxBlobsPerBlock(topic.boundary.epoch);
-          buffer = new Uint8Array(getMaxDataColumnSizeCarBytes(maxBlobs));
-        } else if (topic.type === GossipType.beacon_attestation) {
-          buffer = new Uint8Array(ssz.electra.SingleAttestation.fixedSize as number);
+        switch (topic.type) {
+          case GossipType.data_column_sidecar: {
+            const maxBlobs = this.config.getMaxBlobsPerBlock(topic.boundary.epoch);
+            buffer = new Uint8Array(getMaxDataColumnSizeCarBytes(maxBlobs));
+            break;
+          }
+          case GossipType.beacon_attestation:
+            buffer = new Uint8Array(ssz.electra.SingleAttestation.fixedSize as number);
+            break;
+          default:
+            buffer = undefined;
+            break;
         }
       }
     }
-    const uncompressedData = uncompress(data, this.maxSizePerMessage, buffer);
+    const uncompressedData = this.uncompress(data, buffer);
     const sszType = getGossipSSZType(topic);
 
     // check uncompressed data length before we extract beacon block root, slot or
@@ -130,6 +138,20 @@ export class DataTransformSnappy implements DataTransform {
     // No need to parse topic, everything is snappy compressed
     return compress(data);
   }
+
+  private uncompress(data: Uint8Array, buffer: Uint8Array | undefined): Uint8Array {
+    try {
+      return uncompress(data, this.maxSizePerMessage, buffer);
+    } catch (e) {
+      if (buffer === undefined || !(e instanceof SnappyError)) {
+        throw e;
+      }
+      if ((e as SnappyError<{code: SnappyErrorCode}>).type.code === SnappyErrorCode.UNCOMPRESS_BUFFER_TOO_SMALL) {
+        return uncompress(data, this.maxSizePerMessage, undefined);
+      }
+      throw e;
+    }
+  }
 }
 
 export class InboundTransformBufferPool {
@@ -137,11 +159,12 @@ export class InboundTransformBufferPool {
   constructor(private readonly maxLength: number) {}
 
   add(buffer: ArrayBuffer): void {
-    if (this.buffers.length >= this.maxLength) {
-      return;
-    }
-
+    // prefer new buffer because it may have bigger length than the old one
+    // for example when the max blobs per block increases
     this.buffers.push(buffer);
+    while (this.buffers.length > this.maxLength) {
+      this.buffers.shift();
+    }
   }
 
   pop(): ArrayBuffer | null {

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -81,6 +81,7 @@ export class Eth2Gossipsub extends GossipSub {
 
   // Internal caches
   private readonly gossipTopicCache: GossipTopicCache;
+  private readonly dataTransformSnappy: DataTransformSnappy;
 
   constructor(opts: Eth2GossipsubOpts, modules: Eth2GossipsubModules) {
     const {allowPublishToZeroPeers, gossipsubD, gossipsubDLow, gossipsubDHigh} = opts;
@@ -89,6 +90,7 @@ export class Eth2Gossipsub extends GossipSub {
     const gossipTopicCache = new GossipTopicCache(config);
 
     const scoreParams = computeGossipPeerScoreParams({config, eth2Context: modules.eth2Context});
+    const dataTransform = new DataTransformSnappy(gossipTopicCache, config.MAX_PAYLOAD_SIZE, config);
 
     // Gossipsub parameters defined here:
     // https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#the-gossip-domain-gossipsub
@@ -116,7 +118,7 @@ export class Eth2Gossipsub extends GossipSub {
       fastMsgIdFn: fastMsgIdFn,
       msgIdFn: msgIdFn.bind(msgIdFn, gossipTopicCache),
       msgIdToStrFn: msgIdToStrFn,
-      dataTransform: new DataTransformSnappy(gossipTopicCache, config.MAX_PAYLOAD_SIZE, config),
+      dataTransform,
       metricsRegister: metricsRegister as MetricsRegister | null,
       metricsTopicStrToLabel: metricsRegister
         ? getMetricsTopicStrToLabel(networkConfig, {disableLightClientServer: opts.disableLightClientServer ?? false})
@@ -140,6 +142,7 @@ export class Eth2Gossipsub extends GossipSub {
     this.peersData = peersData;
     this.events = events;
     this.gossipTopicCache = gossipTopicCache;
+    this.dataTransformSnappy = dataTransform;
 
     if (metricsRegister) {
       const metrics = createEth2GossipsubMetrics(metricsRegister);
@@ -287,7 +290,10 @@ export class Eth2Gossipsub extends GossipSub {
     metrics.gossipPeer.score.set(gossipScores);
 
     for (const gossipType of [GossipType.data_column_sidecar, GossipType.beacon_attestation]) {
-      metrics.inboundTransformBufferPool.set({type: gossipType}, globalInboundCache.get(gossipType)?.size() ?? 0);
+      metrics.inboundTransformBufferPool.size.set({type: gossipType}, globalInboundCache.get(gossipType)?.size() ?? 0);
+    }
+    for (const [type, count] of this.dataTransformSnappy.allocByTopicType.entries()) {
+      metrics.inboundTransformBufferPool.allocs.set({type}, count);
     }
   }
 

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -13,7 +13,7 @@ import {Libp2p} from "../interface.js";
 import {NetworkConfig} from "../networkConfig.js";
 import {ClientKind} from "../peers/client.js";
 import {PeersData} from "../peers/peersData.js";
-import {DataTransformSnappy, fastMsgIdFn, msgIdFn, msgIdToStrFn} from "./encoding.js";
+import {DataTransformSnappy, fastMsgIdFn, globalInboundCache, msgIdFn, msgIdToStrFn} from "./encoding.js";
 import {GossipTopic, GossipType} from "./interface.js";
 import {Eth2GossipsubMetrics, createEth2GossipsubMetrics} from "./metrics.js";
 import {
@@ -116,7 +116,7 @@ export class Eth2Gossipsub extends GossipSub {
       fastMsgIdFn: fastMsgIdFn,
       msgIdFn: msgIdFn.bind(msgIdFn, gossipTopicCache),
       msgIdToStrFn: msgIdToStrFn,
-      dataTransform: new DataTransformSnappy(gossipTopicCache, config.MAX_PAYLOAD_SIZE),
+      dataTransform: new DataTransformSnappy(gossipTopicCache, config.MAX_PAYLOAD_SIZE, config),
       metricsRegister: metricsRegister as MetricsRegister | null,
       metricsTopicStrToLabel: metricsRegister
         ? getMetricsTopicStrToLabel(networkConfig, {disableLightClientServer: opts.disableLightClientServer ?? false})
@@ -315,6 +315,11 @@ export class Eth2Gossipsub extends GossipSub {
         seenTimestampSec,
         startProcessUnixSec: null,
       });
+      // return msg.data to the pool
+      const inboundCache = globalInboundCache.get(topic.type);
+      if (inboundCache) {
+        inboundCache.add(msg.data.buffer as ArrayBuffer);
+      }
     });
   }
 

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -285,6 +285,10 @@ export class Eth2Gossipsub extends GossipSub {
 
     // Register full score too
     metrics.gossipPeer.score.set(gossipScores);
+
+    for (const gossipType of [GossipType.data_column_sidecar, GossipType.beacon_attestation]) {
+      metrics.inboundTransformBufferPool.set({type: gossipType}, globalInboundCache.get(gossipType)?.size() ?? 0);
+    }
   }
 
   private onGossipsubMessage(event: GossipsubEvents["gossipsub:message"]): void {

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -289,8 +289,8 @@ export class Eth2Gossipsub extends GossipSub {
     // Register full score too
     metrics.gossipPeer.score.set(gossipScores);
 
-    for (const gossipType of [GossipType.data_column_sidecar, GossipType.beacon_attestation]) {
-      metrics.inboundTransformBufferPool.size.set({type: gossipType}, globalInboundCache.get(gossipType)?.size() ?? 0);
+    for (const [type, inboundCache] of globalInboundCache.entries()) {
+      metrics.inboundTransformBufferPool.size.set({type}, inboundCache.size());
     }
     for (const [type, count] of this.dataTransformSnappy.allocByTopicType.entries()) {
       metrics.inboundTransformBufferPool.allocs.set({type}, count);

--- a/packages/beacon-node/src/network/gossip/metrics.ts
+++ b/packages/beacon-node/src/network/gossip/metrics.ts
@@ -67,5 +67,10 @@ export function createEth2GossipsubMetrics(register: RegistryMetricCreator) {
         labelNames: ["subnet", "boundary"],
       }),
     },
+    inboundTransformBufferPool: register.gauge<{type: GossipType}>({
+      name: "lodestar_gossip_inbound_transform_buffer_pool_size",
+      help: "Size of the inbound transform buffer pool per gossip type",
+      labelNames: ["type"],
+    }),
   };
 }

--- a/packages/beacon-node/src/network/gossip/metrics.ts
+++ b/packages/beacon-node/src/network/gossip/metrics.ts
@@ -67,10 +67,17 @@ export function createEth2GossipsubMetrics(register: RegistryMetricCreator) {
         labelNames: ["subnet", "boundary"],
       }),
     },
-    inboundTransformBufferPool: register.gauge<{type: GossipType}>({
-      name: "lodestar_gossip_inbound_transform_buffer_pool_size",
-      help: "Size of the inbound transform buffer pool per gossip type",
-      labelNames: ["type"],
-    }),
+    inboundTransformBufferPool: {
+      size: register.gauge<{type: GossipType}>({
+        name: "lodestar_gossip_inbound_transform_buffer_pool_size",
+        help: "Size of the inbound transform buffer pool per gossip type",
+        labelNames: ["type"],
+      }),
+      allocs: register.gauge<{type: GossipType}>({
+        name: "lodestar_gossip_inbound_transform_buffer_allocs_total",
+        help: "Number of buffer allocs in inbound transform per gossip type",
+        labelNames: ["type"],
+      }),
+    },
   };
 }

--- a/packages/beacon-node/src/network/gossip/snappy/compressor.ts
+++ b/packages/beacon-node/src/network/gossip/snappy/compressor.ts
@@ -1,0 +1,212 @@
+const BLOCK_LOG = 16;
+const BLOCK_SIZE = 1 << BLOCK_LOG;
+
+const MAX_HASH_TABLE_BITS = 14;
+const globalHashTables = new Array(MAX_HASH_TABLE_BITS + 1);
+
+export class SnappyCompressor {
+  constructor(private readonly array: Uint8Array) {}
+
+  maxCompressedLength(): number {
+    const sourceLen = this.array.length;
+    return 32 + sourceLen + Math.floor(sourceLen / 6);
+  }
+
+  compressToBuffer(outBuffer: Uint8Array): number {
+    const array = this.array;
+    const length = array.length;
+    let pos = 0;
+    let outPos = 0;
+
+    let fragmentSize: number;
+
+    outPos = putVarint(length, outBuffer, outPos);
+    while (pos < length) {
+      fragmentSize = Math.min(length - pos, BLOCK_SIZE);
+      outPos = compressFragment(array, pos, fragmentSize, outBuffer, outPos);
+      pos += fragmentSize;
+    }
+
+    return outPos;
+  }
+}
+
+function hashFunc(key: number, hashFuncShift: number): number {
+  return (key * 0x1e35a7bd) >>> hashFuncShift;
+}
+
+function load32(array: Uint8Array, pos: number): number {
+  return array[pos] + (array[pos + 1] << 8) + (array[pos + 2] << 16) + (array[pos + 3] << 24);
+}
+
+function equals32(array: Uint8Array, pos1: number, pos2: number): boolean {
+  return (
+    array[pos1] === array[pos2] &&
+    array[pos1 + 1] === array[pos2 + 1] &&
+    array[pos1 + 2] === array[pos2 + 2] &&
+    array[pos1 + 3] === array[pos2 + 3]
+  );
+}
+
+function copyBytes(fromArray: Uint8Array, fromPos: number, toArray: Uint8Array, toPos: number, length: number): void {
+  for (let i = 0; i < length; i++) {
+    toArray[toPos + i] = fromArray[fromPos + i];
+  }
+}
+
+function emitLiteral(input: Uint8Array, ip: number, len: number, output: Uint8Array, op: number): number {
+  if (len <= 60) {
+    output[op] = (len - 1) << 2;
+    op += 1;
+  } else if (len < 256) {
+    output[op] = 60 << 2;
+    output[op + 1] = len - 1;
+    op += 2;
+  } else {
+    output[op] = 61 << 2;
+    output[op + 1] = (len - 1) & 0xff;
+    output[op + 2] = (len - 1) >>> 8;
+    op += 3;
+  }
+  copyBytes(input, ip, output, op, len);
+  return op + len;
+}
+
+function emitCopyLessThan64(output: Uint8Array, op: number, offset: number, len: number): number {
+  if (len < 12 && offset < 2048) {
+    output[op] = 1 + ((len - 4) << 2) + ((offset >>> 8) << 5);
+    output[op + 1] = offset & 0xff;
+    return op + 2;
+  }
+  output[op] = 2 + ((len - 1) << 2);
+  output[op + 1] = offset & 0xff;
+  output[op + 2] = offset >>> 8;
+  return op + 3;
+}
+
+function emitCopy(output: Uint8Array, op: number, offset: number, len: number): number {
+  while (len >= 68) {
+    op = emitCopyLessThan64(output, op, offset, 64);
+    len -= 64;
+  }
+  if (len > 64) {
+    op = emitCopyLessThan64(output, op, offset, 60);
+    len -= 60;
+  }
+  return emitCopyLessThan64(output, op, offset, len);
+}
+
+function compressFragment(input: Uint8Array, ip: number, inputSize: number, output: Uint8Array, op: number): number {
+  let hashTableBits = 1;
+  while (1 << hashTableBits <= inputSize && hashTableBits <= MAX_HASH_TABLE_BITS) {
+    hashTableBits += 1;
+  }
+  hashTableBits -= 1;
+  const hashFuncShift = 32 - hashTableBits;
+
+  if (typeof globalHashTables[hashTableBits] === "undefined") {
+    globalHashTables[hashTableBits] = new Uint16Array(1 << hashTableBits);
+  }
+  const hashTable = globalHashTables[hashTableBits];
+  for (let i = 0; i < hashTable.length; i++) {
+    hashTable[i] = 0;
+  }
+
+  const ipEnd = ip + inputSize;
+  let ipLimit: number;
+  const baseIp = ip;
+  let nextEmit = ip;
+
+  let hash: number;
+  let nextHash: number;
+  let nextIp: number;
+  let candidate = 0;
+  let skip: number;
+  let bytesBetweenHashLookups: number;
+  let base: number;
+  let matched: number;
+  let offset: number;
+  let prevHash: number;
+  let curHash: number;
+  let flag = true;
+
+  const INPUT_MARGIN = 15;
+  if (inputSize >= INPUT_MARGIN) {
+    ipLimit = ipEnd - INPUT_MARGIN;
+
+    ip += 1;
+    nextHash = hashFunc(load32(input, ip), hashFuncShift);
+
+    while (flag) {
+      skip = 32;
+      nextIp = ip;
+      do {
+        ip = nextIp;
+        hash = nextHash;
+        bytesBetweenHashLookups = skip >>> 5;
+        skip += 1;
+        nextIp = ip + bytesBetweenHashLookups;
+        if (ip > ipLimit) {
+          flag = false;
+          break;
+        }
+        nextHash = hashFunc(load32(input, nextIp), hashFuncShift);
+        candidate = baseIp + hashTable[hash];
+        hashTable[hash] = ip - baseIp;
+      } while (!equals32(input, ip, candidate));
+
+      if (!flag) {
+        break;
+      }
+
+      op = emitLiteral(input, nextEmit, ip - nextEmit, output, op);
+
+      do {
+        base = ip;
+        matched = 4;
+        while (ip + matched < ipEnd && input[ip + matched] === input[candidate + matched]) {
+          matched += 1;
+        }
+        ip += matched;
+        offset = base - candidate;
+        op = emitCopy(output, op, offset, matched);
+
+        nextEmit = ip;
+        if (ip >= ipLimit) {
+          flag = false;
+          break;
+        }
+        prevHash = hashFunc(load32(input, ip - 1), hashFuncShift);
+        hashTable[prevHash] = ip - 1 - baseIp;
+        curHash = hashFunc(load32(input, ip), hashFuncShift);
+        candidate = baseIp + hashTable[curHash];
+        hashTable[curHash] = ip - baseIp;
+      } while (equals32(input, ip, candidate));
+
+      if (!flag) {
+        break;
+      }
+
+      ip += 1;
+      nextHash = hashFunc(load32(input, ip), hashFuncShift);
+    }
+  }
+
+  if (nextEmit < ipEnd) {
+    op = emitLiteral(input, nextEmit, ipEnd - nextEmit, output, op);
+  }
+
+  return op;
+}
+
+function putVarint(value: number, output: Uint8Array, op: number): number {
+  do {
+    output[op] = value & 0x7f;
+    value = value >>> 7;
+    if (value > 0) {
+      output[op] += 0x80;
+    }
+    op += 1;
+  } while (value > 0);
+  return op;
+}

--- a/packages/beacon-node/src/network/gossip/snappy/decompressor.ts
+++ b/packages/beacon-node/src/network/gossip/snappy/decompressor.ts
@@ -1,0 +1,107 @@
+const WORD_MASK = [0, 0xff, 0xffff, 0xffffff, 0xffffffff];
+function copyBytes(fromArray: Uint8Array, fromPos: number, toArray: Uint8Array, toPos: number, length: number): void {
+  for (let i = 0; i < length; i++) {
+    toArray[toPos + i] = fromArray[fromPos + i];
+  }
+}
+
+function selfCopyBytes(array: Uint8Array, pos: number, offset: number, length: number): void {
+  for (let i = 0; i < length; i++) {
+    array[pos + i] = array[pos - offset + i];
+  }
+}
+
+export class SnappyDecompressor {
+  private pos = 0;
+  constructor(private readonly array: Uint8Array) {}
+
+  readUncompressedLength(): number {
+    let result = 0;
+    let shift = 0;
+    let c: number;
+    let val: number;
+
+    while (shift < 32 && this.pos < this.array.length) {
+      c = this.array[this.pos];
+      this.pos += 1;
+      val = c & 0x7f;
+      if ((val << shift) >>> shift !== val) {
+        return -1;
+      }
+      result |= val << shift;
+      if (c < 128) {
+        return result;
+      }
+      shift += 7;
+    }
+    return -1;
+  }
+
+  uncompressToBuffer(outBuffer: Uint8Array): boolean {
+    const array = this.array;
+    const arrayLength = array.length;
+    let pos = this.pos;
+    let outPos = 0;
+
+    let c: number;
+    let len = 0;
+    let smallLen: number;
+    let offset = 0;
+
+    while (pos < array.length) {
+      c = array[pos];
+      pos += 1;
+      if ((c & 0x3) === 0) {
+        // Literal
+        len = (c >>> 2) + 1;
+        if (len > 60) {
+          if (pos + 3 >= arrayLength) {
+            return false;
+          }
+          smallLen = len - 60;
+          len = array[pos] + (array[pos + 1] << 8) + (array[pos + 2] << 16) + (array[pos + 3] << 24);
+          len = (len & WORD_MASK[smallLen]) + 1;
+          pos += smallLen;
+        }
+        if (pos + len > arrayLength) {
+          return false;
+        }
+        copyBytes(array, pos, outBuffer, outPos, len);
+        pos += len;
+        outPos += len;
+      } else {
+        switch (c & 0x3) {
+          case 1:
+            len = ((c >>> 2) & 0x7) + 4;
+            offset = array[pos] + ((c >>> 5) << 8);
+            pos += 1;
+            break;
+          case 2:
+            if (pos + 1 >= arrayLength) {
+              return false;
+            }
+            len = (c >>> 2) + 1;
+            offset = array[pos] + (array[pos + 1] << 8);
+            pos += 2;
+            break;
+          case 3:
+            if (pos + 3 >= arrayLength) {
+              return false;
+            }
+            len = (c >>> 2) + 1;
+            offset = array[pos] + (array[pos + 1] << 8) + (array[pos + 2] << 16) + (array[pos + 3] << 24);
+            pos += 4;
+            break;
+          default:
+            break;
+        }
+        if (offset === 0 || offset > outPos) {
+          return false;
+        }
+        selfCopyBytes(outBuffer, outPos, offset, len);
+        outPos += len;
+      }
+    }
+    return true;
+  }
+}

--- a/packages/beacon-node/src/network/gossip/snappy/error.ts
+++ b/packages/beacon-node/src/network/gossip/snappy/error.ts
@@ -1,0 +1,14 @@
+import {LodestarError} from "@lodestar/utils";
+
+export enum SnappyErrorCode {
+  UNCOMPRESS_EXCEED_MAX_LENGTH = "SNAPPY_ERROR_UNCOMPRESS_EXCEED_MAX_LENGTH",
+  UNCOMPRESS_CANNOT_EXTRACT_LENGTH = "SNAPPY_ERROR_UNCOMPRESS_CANNOT_EXTRACT_LENGTH",
+  UNCOMPRESS_BUFFER_TOO_SMALL = "SNAPPY_ERROR_UNCOMPRESS_BUFFER_TOO_SMALL",
+  UNCOMPRESS_INVALID_BITSTREAM = "SNAPPY_ERROR_UNCOMPRESS_INVALID_BITSTREAM",
+}
+
+export class SnappyError<T extends {code: string}> extends LodestarError<T> {
+  constructor(type: T) {
+    super(type);
+  }
+}

--- a/packages/beacon-node/src/network/gossip/snappy/index.ts
+++ b/packages/beacon-node/src/network/gossip/snappy/index.ts
@@ -12,41 +12,12 @@ function isNode(): boolean {
   return false;
 }
 
-function isUint8Array(object: Uint8Array | ArrayBuffer | Buffer): object is Uint8Array {
+function isUint8Array(object: Uint8Array | Buffer): object is Uint8Array {
   return object instanceof Uint8Array && (!isNode() || !Buffer.isBuffer(object));
 }
 
-function isArrayBuffer(object: Uint8Array | ArrayBuffer | Buffer): object is ArrayBuffer {
-  return object instanceof ArrayBuffer;
-}
-
-function isBuffer(object: Uint8Array | ArrayBuffer | Buffer): object is Buffer {
-  if (!isNode()) {
-    return false;
-  }
-  return Buffer.isBuffer(object);
-}
-
-const TYPE_ERROR_MSG = "Argument compressed must be type of ArrayBuffer, Buffer, or Uint8Array";
-
-export function uncompress<T extends ArrayBuffer | Buffer | Uint8Array>(compressed: T, maxLength?: number): T {
-  if (!isUint8Array(compressed) && !isArrayBuffer(compressed) && !isBuffer(compressed)) {
-    throw new TypeError(TYPE_ERROR_MSG);
-  }
-  let uint8Mode = false;
-  let arrayBufferMode = false;
-  let compressedView: Uint8Array;
-  if (isUint8Array(compressed)) {
-    uint8Mode = true;
-    compressedView = compressed;
-  } else if (isArrayBuffer(compressed)) {
-    arrayBufferMode = true;
-    compressedView = new Uint8Array(compressed);
-  } else {
-    compressedView = compressed;
-  }
-
-  const decompressor = new SnappyDecompressor(compressedView);
+export function uncompress<T extends Buffer | Uint8Array>(compressed: T, maxLength: number, outBuf?: Uint8Array): T {
+  const decompressor = new SnappyDecompressor(compressed);
   const length = decompressor.readUncompressedLength();
   if (length === -1) {
     throw new Error("Invalid Snappy bitstream");
@@ -54,59 +25,31 @@ export function uncompress<T extends ArrayBuffer | Buffer | Uint8Array>(compress
   if (maxLength !== undefined && length > maxLength) {
     throw new Error(`The uncompressed length of ${length} is too big, expect at most ${maxLength}`);
   }
+  if (outBuf !== undefined && outBuf.length < length) {
+    throw new Error(`The provided output buffer is too small: ${outBuf.length}, expect at least ${length}`);
+  }
 
-  let uncompressed: ArrayBuffer | Buffer | Uint8Array;
-  if (uint8Mode) {
-    uncompressed = new Uint8Array(length);
-    if (!decompressor.uncompressToBuffer(uncompressed)) {
-      throw new Error("Invalid Snappy bitstream");
-    }
-  } else if (arrayBufferMode) {
-    uncompressed = new ArrayBuffer(length);
-    const uncompressedView = new Uint8Array(uncompressed);
-    if (!decompressor.uncompressToBuffer(uncompressedView)) {
-      throw new Error("Invalid Snappy bitstream");
-    }
-  } else {
-    uncompressed = Buffer.allocUnsafe(length);
-    if (!decompressor.uncompressToBuffer(uncompressed)) {
-      throw new Error("Invalid Snappy bitstream");
-    }
+  const uncompressed =
+    outBuf !== undefined
+      ? outBuf.subarray(0, length)
+      : isUint8Array(compressed)
+        ? new Uint8Array(length)
+        : Buffer.allocUnsafe(length);
+
+  if (!decompressor.uncompressToBuffer(uncompressed)) {
+    throw new Error("Invalid Snappy bitstream");
   }
   return uncompressed as T;
 }
 
-export function compress<T extends ArrayBuffer | Buffer | Uint8Array>(uncompressed: T): T {
-  if (!isUint8Array(uncompressed) && !isArrayBuffer(uncompressed) && !isBuffer(uncompressed)) {
-    throw new TypeError(TYPE_ERROR_MSG);
-  }
-  let uint8Mode = false;
-  let arrayBufferMode = false;
-  let uncompressedView: Uint8Array;
-  if (isUint8Array(uncompressed)) {
-    uint8Mode = true;
-    uncompressedView = uncompressed;
-  } else if (isArrayBuffer(uncompressed)) {
-    arrayBufferMode = true;
-    uncompressedView = new Uint8Array(uncompressed);
-  } else {
-    uncompressedView = uncompressed;
-  }
-
-  const compressor = new SnappyCompressor(uncompressedView);
+export function compress<T extends Buffer | Uint8Array>(uncompressed: T): T {
+  const compressor = new SnappyCompressor(uncompressed);
   const maxLength = compressor.maxCompressedLength();
+  const uint8Mode = isUint8Array(uncompressed);
+  const compressed = uint8Mode ? new Uint8Array(maxLength) : Buffer.allocUnsafe(maxLength);
+  const length = compressor.compressToBuffer(compressed);
   if (uint8Mode) {
-    const compressed = new Uint8Array(maxLength);
-    const length = compressor.compressToBuffer(compressed as Uint8Array);
     return compressed.subarray(0, length) as T;
-  } else if (arrayBufferMode) {
-    const compressed = new ArrayBuffer(maxLength) as T;
-    const compressedView = new Uint8Array(compressed);
-    const length = compressor.compressToBuffer(compressedView);
-    return compressed.slice(0, length) as T;
-  } else {
-    const compressed = Buffer.allocUnsafe(maxLength) as T;
-    const length = compressor.compressToBuffer(compressed as Uint8Array);
-    return compressed.slice(0, length) as T;
   }
+  return compressed.slice(0, length) as T;
 }

--- a/packages/beacon-node/src/network/gossip/snappy/index.ts
+++ b/packages/beacon-node/src/network/gossip/snappy/index.ts
@@ -54,8 +54,8 @@ export function uncompress<T extends ArrayBuffer | Buffer | Uint8Array>(compress
   if (maxLength !== undefined && length > maxLength) {
     throw new Error(`The uncompressed length of ${length} is too big, expect at most ${maxLength}`);
   }
+
   let uncompressed: ArrayBuffer | Buffer | Uint8Array;
-  let uncompressedView: Uint8Array;
   if (uint8Mode) {
     uncompressed = new Uint8Array(length);
     if (!decompressor.uncompressToBuffer(uncompressed)) {
@@ -63,7 +63,7 @@ export function uncompress<T extends ArrayBuffer | Buffer | Uint8Array>(compress
     }
   } else if (arrayBufferMode) {
     uncompressed = new ArrayBuffer(length);
-    uncompressedView = new Uint8Array(uncompressed);
+    const uncompressedView = new Uint8Array(uncompressed);
     if (!decompressor.uncompressToBuffer(uncompressedView)) {
       throw new Error("Invalid Snappy bitstream");
     }
@@ -92,33 +92,21 @@ export function compress<T extends ArrayBuffer | Buffer | Uint8Array>(uncompress
   } else {
     uncompressedView = uncompressed;
   }
+
   const compressor = new SnappyCompressor(uncompressedView);
   const maxLength = compressor.maxCompressedLength();
-  let compressed: T;
-  let compressedView: Uint8Array;
-  let length: number;
   if (uint8Mode) {
-    compressed = new Uint8Array(maxLength) as T;
-    length = compressor.compressToBuffer(compressed as Uint8Array);
+    const compressed = new Uint8Array(maxLength);
+    const length = compressor.compressToBuffer(compressed as Uint8Array);
+    return compressed.subarray(0, length) as T;
   } else if (arrayBufferMode) {
-    compressed = new ArrayBuffer(maxLength) as T;
-    compressedView = new Uint8Array(compressed);
-    length = compressor.compressToBuffer(compressedView);
+    const compressed = new ArrayBuffer(maxLength) as T;
+    const compressedView = new Uint8Array(compressed);
+    const length = compressor.compressToBuffer(compressedView);
+    return compressed.slice(0, length) as T;
   } else {
-    compressed = Buffer.allocUnsafe(maxLength) as T;
-    length = compressor.compressToBuffer(compressed as Uint8Array);
+    const compressed = Buffer.allocUnsafe(maxLength) as T;
+    const length = compressor.compressToBuffer(compressed as Uint8Array);
+    return compressed.slice(0, length) as T;
   }
-  if (!compressed.slice) {
-    // ie11
-    const compressedArray = new Uint8Array(Array.prototype.slice.call(compressed, 0, length));
-    if (uint8Mode) {
-      return compressedArray as T;
-    }
-    if (arrayBufferMode) {
-      return compressedArray.buffer as T;
-    }
-    throw new Error("Not implemented");
-  }
-
-  return compressed.slice(0, length) as T;
 }

--- a/packages/beacon-node/src/network/gossip/snappy/index.ts
+++ b/packages/beacon-node/src/network/gossip/snappy/index.ts
@@ -1,0 +1,124 @@
+import {SnappyCompressor} from "./compressor.js";
+import {SnappyDecompressor} from "./decompressor.js";
+
+function isNode(): boolean {
+  if (
+    typeof process === "object" &&
+    typeof process.versions === "object" &&
+    typeof process.versions.node !== "undefined"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function isUint8Array(object: Uint8Array | ArrayBuffer | Buffer): object is Uint8Array {
+  return object instanceof Uint8Array && (!isNode() || !Buffer.isBuffer(object));
+}
+
+function isArrayBuffer(object: Uint8Array | ArrayBuffer | Buffer): object is ArrayBuffer {
+  return object instanceof ArrayBuffer;
+}
+
+function isBuffer(object: Uint8Array | ArrayBuffer | Buffer): object is Buffer {
+  if (!isNode()) {
+    return false;
+  }
+  return Buffer.isBuffer(object);
+}
+
+const TYPE_ERROR_MSG = "Argument compressed must be type of ArrayBuffer, Buffer, or Uint8Array";
+
+export function uncompress<T extends ArrayBuffer | Buffer | Uint8Array>(compressed: T, maxLength?: number): T {
+  if (!isUint8Array(compressed) && !isArrayBuffer(compressed) && !isBuffer(compressed)) {
+    throw new TypeError(TYPE_ERROR_MSG);
+  }
+  let uint8Mode = false;
+  let arrayBufferMode = false;
+  let compressedView: Uint8Array;
+  if (isUint8Array(compressed)) {
+    uint8Mode = true;
+    compressedView = compressed;
+  } else if (isArrayBuffer(compressed)) {
+    arrayBufferMode = true;
+    compressedView = new Uint8Array(compressed);
+  } else {
+    compressedView = compressed;
+  }
+
+  const decompressor = new SnappyDecompressor(compressedView);
+  const length = decompressor.readUncompressedLength();
+  if (length === -1) {
+    throw new Error("Invalid Snappy bitstream");
+  }
+  if (maxLength !== undefined && length > maxLength) {
+    throw new Error(`The uncompressed length of ${length} is too big, expect at most ${maxLength}`);
+  }
+  let uncompressed: ArrayBuffer | Buffer | Uint8Array;
+  let uncompressedView: Uint8Array;
+  if (uint8Mode) {
+    uncompressed = new Uint8Array(length);
+    if (!decompressor.uncompressToBuffer(uncompressed)) {
+      throw new Error("Invalid Snappy bitstream");
+    }
+  } else if (arrayBufferMode) {
+    uncompressed = new ArrayBuffer(length);
+    uncompressedView = new Uint8Array(uncompressed);
+    if (!decompressor.uncompressToBuffer(uncompressedView)) {
+      throw new Error("Invalid Snappy bitstream");
+    }
+  } else {
+    uncompressed = Buffer.alloc(length);
+    if (!decompressor.uncompressToBuffer(uncompressed)) {
+      throw new Error("Invalid Snappy bitstream");
+    }
+  }
+  return uncompressed as T;
+}
+
+export function compress<T extends ArrayBuffer | Buffer | Uint8Array>(uncompressed: T): T {
+  if (!isUint8Array(uncompressed) && !isArrayBuffer(uncompressed) && !isBuffer(uncompressed)) {
+    throw new TypeError(TYPE_ERROR_MSG);
+  }
+  let uint8Mode = false;
+  let arrayBufferMode = false;
+  let uncompressedView: Uint8Array;
+  if (isUint8Array(uncompressed)) {
+    uint8Mode = true;
+    uncompressedView = uncompressed;
+  } else if (isArrayBuffer(uncompressed)) {
+    arrayBufferMode = true;
+    uncompressedView = new Uint8Array(uncompressed);
+  } else {
+    uncompressedView = uncompressed;
+  }
+  const compressor = new SnappyCompressor(uncompressedView);
+  const maxLength = compressor.maxCompressedLength();
+  let compressed: T;
+  let compressedView: Uint8Array;
+  let length: number;
+  if (uint8Mode) {
+    compressed = new Uint8Array(maxLength) as T;
+    length = compressor.compressToBuffer(compressed as Uint8Array);
+  } else if (arrayBufferMode) {
+    compressed = new ArrayBuffer(maxLength) as T;
+    compressedView = new Uint8Array(compressed);
+    length = compressor.compressToBuffer(compressedView);
+  } else {
+    compressed = Buffer.alloc(maxLength) as T;
+    length = compressor.compressToBuffer(compressed as Uint8Array);
+  }
+  if (!compressed.slice) {
+    // ie11
+    const compressedArray = new Uint8Array(Array.prototype.slice.call(compressed, 0, length));
+    if (uint8Mode) {
+      return compressedArray as T;
+    }
+    if (arrayBufferMode) {
+      return compressedArray.buffer as T;
+    }
+    throw new Error("Not implemented");
+  }
+
+  return compressed.slice(0, length) as T;
+}

--- a/packages/beacon-node/src/network/gossip/snappy/index.ts
+++ b/packages/beacon-node/src/network/gossip/snappy/index.ts
@@ -1,5 +1,6 @@
 import {SnappyCompressor} from "./compressor.js";
 import {SnappyDecompressor} from "./decompressor.js";
+import {SnappyError, SnappyErrorCode} from "./error.js";
 
 function isNode(): boolean {
   if (
@@ -20,13 +21,13 @@ export function uncompress<T extends Buffer | Uint8Array>(compressed: T, maxLeng
   const decompressor = new SnappyDecompressor(compressed);
   const length = decompressor.readUncompressedLength();
   if (length === -1) {
-    throw new Error("Invalid Snappy bitstream");
+    throw new SnappyError({code: SnappyErrorCode.UNCOMPRESS_CANNOT_EXTRACT_LENGTH});
   }
   if (maxLength !== undefined && length > maxLength) {
-    throw new Error(`The uncompressed length of ${length} is too big, expect at most ${maxLength}`);
+    throw new SnappyError({code: SnappyErrorCode.UNCOMPRESS_EXCEED_MAX_LENGTH});
   }
   if (outBuf !== undefined && outBuf.length < length) {
-    throw new Error(`The provided output buffer is too small: ${outBuf.length}, expect at least ${length}`);
+    throw new SnappyError({code: SnappyErrorCode.UNCOMPRESS_BUFFER_TOO_SMALL});
   }
 
   const uncompressed =
@@ -37,7 +38,7 @@ export function uncompress<T extends Buffer | Uint8Array>(compressed: T, maxLeng
         : Buffer.allocUnsafe(length);
 
   if (!decompressor.uncompressToBuffer(uncompressed)) {
-    throw new Error("Invalid Snappy bitstream");
+    throw new SnappyError({code: SnappyErrorCode.UNCOMPRESS_INVALID_BITSTREAM});
   }
   return uncompressed as T;
 }

--- a/packages/beacon-node/src/network/gossip/snappy/index.ts
+++ b/packages/beacon-node/src/network/gossip/snappy/index.ts
@@ -68,7 +68,7 @@ export function uncompress<T extends ArrayBuffer | Buffer | Uint8Array>(compress
       throw new Error("Invalid Snappy bitstream");
     }
   } else {
-    uncompressed = Buffer.alloc(length);
+    uncompressed = Buffer.allocUnsafe(length);
     if (!decompressor.uncompressToBuffer(uncompressed)) {
       throw new Error("Invalid Snappy bitstream");
     }
@@ -105,7 +105,7 @@ export function compress<T extends ArrayBuffer | Buffer | Uint8Array>(uncompress
     compressedView = new Uint8Array(compressed);
     length = compressor.compressToBuffer(compressedView);
   } else {
-    compressed = Buffer.alloc(maxLength) as T;
+    compressed = Buffer.allocUnsafe(maxLength) as T;
     length = compressor.compressToBuffer(compressed as Uint8Array);
   }
   if (!compressed.slice) {

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -418,6 +418,7 @@ export function getSlotFromDataColumnSidecarSerialized(data: Uint8Array): Slot |
   return getSlotFromOffset(data, SLOT_BYTES_POSITION_IN_SIGNED_DATA_COLUMN_SIDECAR);
 }
 
+// TODO: review this
 export function getMaxDataColumnSizeCarBytes(maxBlobs: number): number {
   // index: 8 bytes
   let maxSize = 8;

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -418,22 +418,21 @@ export function getSlotFromDataColumnSidecarSerialized(data: Uint8Array): Slot |
   return getSlotFromOffset(data, SLOT_BYTES_POSITION_IN_SIGNED_DATA_COLUMN_SIDECAR);
 }
 
-// TODO: review this
-export function getMaxDataColumnSizeCarBytes(maxBlobs: number): number {
+export function getDataColumnSideCarBytes(blobCount: number): number {
   // index: 8 bytes
   let maxSize = 8;
   // column is dynamic size
   maxSize += 4;
   // column: Cell * maxBlobs = 64 * 32 * maxBlobs
-  maxSize += 64 * 32 * maxBlobs;
+  maxSize += 64 * 32 * blobCount;
   // kzgCommitments length is dynamic size
   maxSize += 4;
   // kzgCommitments: 48 * maxBlobs
-  maxSize += 48 * maxBlobs;
+  maxSize += 48 * blobCount;
   // kzgProofs length is dynamic size
   maxSize += 4;
   // kzgProofs: 48 * maxBlobs
-  maxSize += 48 * maxBlobs;
+  maxSize += 48 * blobCount;
   // SignedBeaconBlockHeader is 208 bytes
   maxSize += 208;
   maxSize += 32 * KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH;

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -6,6 +6,7 @@ import {
   ForkName,
   ForkPostDeneb,
   ForkSeq,
+  KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH,
   MAX_COMMITTEES_PER_SLOT,
   isForkPostElectra,
 } from "@lodestar/params";
@@ -415,6 +416,28 @@ export function getSlotFromDataColumnSidecarSerialized(data: Uint8Array): Slot |
   }
 
   return getSlotFromOffset(data, SLOT_BYTES_POSITION_IN_SIGNED_DATA_COLUMN_SIDECAR);
+}
+
+export function getMaxDataColumnSizeCarBytes(maxBlobs: number): number {
+  // index: 8 bytes
+  let maxSize = 8;
+  // column is dynamic size
+  maxSize += 4;
+  // column: Cell * maxBlobs = 64 * 32 * maxBlobs
+  maxSize += 64 * 32 * maxBlobs;
+  // kzgCommitments length is dynamic size
+  maxSize += 4;
+  // kzgCommitments: 48 * maxBlobs
+  maxSize += 48 * maxBlobs;
+  // kzgProofs length is dynamic size
+  maxSize += 4;
+  // kzgProofs: 48 * maxBlobs
+  maxSize += 48 * maxBlobs;
+  // SignedBeaconBlockHeader is 208 bytes
+  maxSize += 208;
+  maxSize += 32 * KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH;
+  // total fixed size = 208 bytes + variable size
+  return maxSize;
 }
 
 /**

--- a/packages/beacon-node/test/unit/network/gossip/encoding.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/encoding.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from "vitest";
+import {createBeaconConfig} from "@lodestar/config";
+import {config as chainConfig} from "@lodestar/config/default";
+import {ForkName, ZERO_HASH} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
+import {DataColumnSidecar} from "@lodestar/types/fulu";
+import {DataTransformSnappy, globalInboundCache} from "../../../../src/network/gossip/encoding.js";
+import {GossipEncoding, GossipTopic, GossipType} from "../../../../src/network/gossip/interface.js";
+import {compress} from "../../../../src/network/gossip/snappy/index.js";
+import {GossipTopicCache} from "../../../../src/network/gossip/topic.js";
+import {kzg} from "../../../../src/util/kzg.js";
+import {generateRandomBlob} from "../../../utils/kzg.js";
+
+describe("DataTransformSnappy", () => {
+  const config = createBeaconConfig(chainConfig, ZERO_HASH);
+  const topic: GossipTopic = {
+    type: GossipType.data_column_sidecar,
+    subnet: 1,
+    boundary: {fork: ForkName.fulu, epoch: config.FULU_FORK_EPOCH},
+    encoding: GossipEncoding.ssz_snappy,
+  };
+  const topicStr = "/eth2/4ba67af9/data_column_sidecar_1/ssz_snappy";
+  const gossipTopicCache = new GossipTopicCache(config);
+  gossipTopicCache.setTopic(topicStr, topic);
+
+  it("uncompress DataColumnSidecar using buffer pool", () => {
+    const dataTransform = new DataTransformSnappy(gossipTopicCache, 1e9, config);
+    const maxBlobs = config.getMaxBlobsPerBlock(config.FULU_FORK_EPOCH);
+    // this is not max data size but DataTransformSnappy should still alloc max size buffer and use it for later messages
+    const data = createDataColumnSidecarSsz(maxBlobs - 2);
+    expect(globalInboundCache.get(GossipType.data_column_sidecar)?.size()).toBe(0);
+    expect(dataTransform.allocByTopicType.get(GossipType.data_column_sidecar)).toBeUndefined();
+    const compressed = compress(data);
+    const uncompressed = dataTransform.inboundTransform(topicStr, compressed);
+    expect(uncompressed).toEqual(data);
+    expect(dataTransform.allocByTopicType.get(GossipType.data_column_sidecar)).toBe(1);
+
+    // add to pool, this simulates the gossipsub behavior after emitting msg to the main thread
+    globalInboundCache.get(GossipType.data_column_sidecar)?.add(uncompressed.buffer as ArrayBuffer);
+    expect(globalInboundCache.get(GossipType.data_column_sidecar)?.size()).toBe(1);
+
+    // new message comes, no need to alloc a new buffer
+    const maxData = createDataColumnSidecarSsz(maxBlobs);
+    const compressed2 = compress(maxData);
+    const uncompressed2 = dataTransform.inboundTransform(topicStr, compressed2);
+    expect(uncompressed2).toEqual(maxData);
+    // no need to alloc again
+    expect(dataTransform.allocByTopicType.get(GossipType.data_column_sidecar)).toBe(1);
+    // we used the buffer from pool so its size is now 0
+    expect(globalInboundCache.get(GossipType.data_column_sidecar)?.size()).toBe(0);
+  });
+});
+
+function createDataColumnSidecarSsz(blobs: number): Uint8Array {
+  return ssz.fulu.DataColumnSidecar.serialize(createDataColumnSidecar(blobs));
+}
+
+function createDataColumnSidecar(numberOfBlobs: number): DataColumnSidecar {
+  const blobs = Array.from({length: numberOfBlobs}, () => generateRandomBlob());
+  const kzgCommitments = blobs.map((blob) => kzg.blobToKzgCommitment(blob));
+  const cellsAndProofs = blobs.map((blob) => kzg.computeCellsAndKzgProofs(blob));
+  const columnIndex = 10;
+  const dataColumnSidecar: DataColumnSidecar = {
+    index: columnIndex,
+    column: Array.from({length: numberOfBlobs}, (_, rowNumber) => cellsAndProofs[rowNumber].cells[columnIndex]),
+    kzgCommitments,
+    kzgProofs: Array.from({length: numberOfBlobs}, (_, rowNumber) => cellsAndProofs[rowNumber].proofs[columnIndex]),
+    signedBlockHeader: ssz.phase0.SignedBeaconBlockHeader.defaultValue(),
+    kzgCommitmentsInclusionProof: ssz.fulu.KzgCommitmentsInclusionProof.defaultValue(),
+  };
+  return dataColumnSidecar;
+}

--- a/packages/beacon-node/test/unit/network/gossip/snappy.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/snappy.test.ts
@@ -5,6 +5,7 @@ import {compress, uncompress} from "../../../../src/network/gossip/snappy/index.
 
 describe("snappy", () => {
   const lengths = [0, 1, 10, 100, 1000, 10000, 100000];
+  const maxLength = 1000000;
   for (const length of lengths) {
     it(`should compress and uncompress data of length ${length}`, () => {
       const buffer = randomBytes(length);
@@ -15,7 +16,7 @@ describe("snappy", () => {
         const expectedCompressed = snappyJsCompress(buf);
         expect(compressed).toEqual(expectedCompressed);
 
-        const uncompressed = uncompress(compressed);
+        const uncompressed = uncompress(compressed, maxLength);
         const expectedUncompressed = snappyJsUncompress(compressed);
         expect(uncompressed).toEqual(expectedUncompressed);
       }

--- a/packages/beacon-node/test/unit/network/gossip/snappy.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/snappy.test.ts
@@ -1,0 +1,24 @@
+import {randomBytes} from "crypto";
+import {compress as snappyJsCompress, uncompress as snappyJsUncompress} from "snappyjs";
+import {describe, expect, it} from "vitest";
+import {compress, uncompress} from "../../../../src/network/gossip/snappy/index.js";
+
+describe("snappy", () => {
+  const lengths = [0, 1, 10, 100, 1000, 10000, 100000];
+  for (const length of lengths) {
+    it(`should compress and uncompress data of length ${length}`, () => {
+      const buffer = randomBytes(length);
+      const uint8array = new Uint8Array(buffer);
+
+      for (const buf of [buffer, uint8array]) {
+        const compressed = compress(buf);
+        const expectedCompressed = snappyJsCompress(buf);
+        expect(compressed).toEqual(expectedCompressed);
+
+        const uncompressed = uncompress(compressed);
+        const expectedUncompressed = snappyJsUncompress(compressed);
+        expect(uncompressed).toEqual(expectedUncompressed);
+      }
+    });
+  }
+});

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -17,6 +17,7 @@ import {
   ssz,
   sszTypesFor,
 } from "@lodestar/types";
+import {DataColumnSidecar} from "@lodestar/types/fulu";
 import {fromHex, toHex, toRootHex} from "@lodestar/utils";
 import {kzg} from "../../../src/util/kzg.js";
 import {
@@ -32,6 +33,7 @@ import {
   getBlockRootFromSingleAttestationSerialized,
   getCommitteeBitsFromSignedAggregateAndProofElectra,
   getCommitteeIndexFromSingleAttestationSerialized,
+  getDataColumnSideCarBytes,
   getLastProcessedSlotFromBeaconStateSerialized,
   getSignatureFromAttestationSerialized,
   getSignatureFromSingleAttestationSerialized,
@@ -404,6 +406,25 @@ describe("BeaconState ssz serialized picking", () => {
       expect(getSlotFromBeaconStateSerialized(Buffer.alloc(size))).toBeNull();
     }
   });
+});
+
+it("getDataColumnSideCarBytes", () => {
+  for (const blobCount of [9, 21]) {
+    const blobs = Array.from({length: blobCount}, () => generateRandomBlob());
+    const kzgCommitments = blobs.map((blob) => kzg.blobToKzgCommitment(blob));
+    const cellsAndProofs = blobs.map((blob) => kzg.computeCellsAndKzgProofs(blob));
+    const columnIndex = 10;
+    const dataColumnSidecar: DataColumnSidecar = {
+      index: columnIndex,
+      column: Array.from({length: blobCount}, (_, rowNumber) => cellsAndProofs[rowNumber].cells[columnIndex]),
+      kzgCommitments,
+      kzgProofs: Array.from({length: blobCount}, (_, rowNumber) => cellsAndProofs[rowNumber].proofs[columnIndex]),
+      signedBlockHeader: ssz.phase0.SignedBeaconBlockHeader.defaultValue(),
+      kzgCommitmentsInclusionProof: ssz.fulu.KzgCommitmentsInclusionProof.defaultValue(),
+    };
+    const data = ssz.fulu.DataColumnSidecar.serialize(dataColumnSidecar);
+    expect(getDataColumnSideCarBytes(blobCount)).toBe(data.length);
+  }
 });
 
 function phase0SingleAttestationFromValues(


### PR DESCRIPTION
**Motivation**

- improve network thread `gc` time

**Description**

`msg.data` is short lived objects. This strategy implement a Buffer pool at network thread gossipsub for each topic:
- populate it after emitting msg to main thread
- get buffer from it when uncompressing inbound data
- in order to do that, move the snappy implementation to lodestar to support an output param for `uncompress()` function

part of #8629
