### PR TITLE
test: update web3signer e2e tests to fulu

### DIFF
--- a/packages/test-utils/src/externalSigner.ts
+++ b/packages/test-utils/src/externalSigner.ts
@@ -4,10 +4,10 @@ import {GenericContainer, StartedTestContainer, Wait} from "testcontainers";
 import {dirSync as tmpDirSync} from "tmp";
 import {ForkSeq} from "@lodestar/params";
 
-const web3signerVersion = "25.4.1";
+const web3signerVersion = "25.11.0";
 
 /** Till what version is the web3signer image updated for signature verification */
-const supportedForkSeq = ForkSeq.electra;
+const supportedForkSeq = ForkSeq.fulu;
 
 export type StartedExternalSigner = {
   container: StartedTestContainer;


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/8316

**Description**

- enable fulu signature tests
- update web3signer to version [25.11.0](https://github.com/Consensys/web3signer/releases/tag/25.11.0)