### PR TITLE
feat: track DataTransform metrics

### DIFF
--- a/packages/beacon-node/src/network/gossip/metrics.ts
+++ b/packages/beacon-node/src/network/gossip/metrics.ts
@@ -67,5 +67,17 @@ export function createEth2GossipsubMetrics(register: RegistryMetricCreator) {
         labelNames: ["subnet", "boundary"],
       }),
     },
+    dataTransform: {
+      inbound: register.counter<{type: GossipType}>({
+        name: "lodestar_gossip_data_transform_inbound_total",
+        help: "Total number of inbound data transforms by gossip type",
+        labelNames: ["type"],
+      }),
+      outbound: register.counter<{type: GossipType}>({
+        name: "lodestar_gossip_data_transform_outbound_total",
+        help: "Total number of outbound data transforms by gossip type",
+        labelNames: ["type"],
+      }),
+    },
   };
 }


### PR DESCRIPTION
**Motivation**

- we usually have to uncompress more messages than needed so it's good to track it in DataTransform

**Description**

- track `compress` and `uncompress` times by topic type
- in this instance, this node only subscribe to 8 column subnets but we usually have to uncompress 9 or up to 10/11 DataColumnSidecars per slot, they will likely be duplicated in the end. See also https://github.com/ChainSafe/js-libp2p-gossipsub/pull/536

part of #8629
<img width="1046" height="485" alt="Screenshot 2025-11-28 at 17 02 42" src="https://github.com/user-attachments/assets/df190b29-6681-48de-a04e-cd79ab82858d" />


