### PR TITLE
fix: skip genesis slot signature check when validating ERA files

### DIFF
--- a/packages/era/src/era/reader.ts
+++ b/packages/era/src/era/reader.ts
@@ -2,7 +2,7 @@ import {type FileHandle, open} from "node:fs/promises";
 import {basename} from "node:path";
 import {PublicKey, Signature, verify} from "@chainsafe/blst";
 import {ChainForkConfig, createCachedGenesis} from "@lodestar/config";
-import {DOMAIN_BEACON_PROPOSER, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
+import {DOMAIN_BEACON_PROPOSER, GENESIS_SLOT, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {BeaconState, SignedBeaconBlock, Slot, ssz} from "@lodestar/types";
 import {E2STORE_HEADER_SIZE, EntryType, readEntry, readVersion} from "../e2s.ts";
 import {snappyUncompress} from "../util.ts";
@@ -181,7 +181,7 @@ export class EraReader {
             throw new Error(`Block root mismatch at slot ${slot}`);
           }
           // genesis block doesn't have valid signature
-          if (slot === 0) {
+          if (slot === GENESIS_SLOT) {
             continue;
           }
           const msg = ssz.phase0.SigningData.hashTreeRoot({

--- a/packages/era/src/era/reader.ts
+++ b/packages/era/src/era/reader.ts
@@ -180,6 +180,10 @@ export class EraReader {
           if (Buffer.compare(blockRoot, state.blockRoots[slot % SLOTS_PER_HISTORICAL_ROOT]) !== 0) {
             throw new Error(`Block root mismatch at slot ${slot}`);
           }
+          // genesis block doesn't have valid signature
+          if (slot === 0) {
+            continue;
+          }
           const msg = ssz.phase0.SigningData.hashTreeRoot({
             objectRoot: blockRoot,
             domain: cachedGenesis.getDomain(slot, DOMAIN_BEACON_PROPOSER),


### PR DESCRIPTION
**Motivation**

- Era validation lacked genesis slot signature verification skip

**Description**

- Adds a check for genesis slot and skips signature verification for slot 0 in ERA validation

tracks #7048 
**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.
No AI is used.
<!-- Insert any AI assistance disclosure here -->
