### PR TITLE
fix: add head slot check for state retrieval

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -71,7 +71,7 @@ export async function getStateResponseWithRegen(
     typeof stateId === "string"
       ? await chain.getStateByStateRoot(stateId, {allowRegen: true})
       : typeof stateId === "number"
-        ? stateId >= chain.forkChoice.getFinalizedBlock().slot
+        ? stateId >= chain.forkChoice.getFinalizedBlock().slot && stateId <= chain.forkChoice.getHead().slot
           ? await chain.getStateBySlot(stateId, {allowRegen: true})
           : await chain.getHistoricalStateBySlot(stateId)
         : await chain.getStateOrBytesByCheckpoint(stateId);


### PR DESCRIPTION
**Motivation**

- We are getting jibberish values instead of 404 when we are requesting state for slots which are non existent aka asking for `eth/v2/beacon/states/10000/root` when the chain has synced till only 2000.

**Description**

This pr adds a simple check that if the `stateId` should be less than the slot of my chain head.
<!-- A clear and concise general description of the changes of this pull request. -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

<!-- Insert any AI assistance disclosure here -->
