### PR TITLE
fix: don't try to serve states for future slots

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -71,9 +71,11 @@ export async function getStateResponseWithRegen(
     typeof stateId === "string"
       ? await chain.getStateByStateRoot(stateId, {allowRegen: true})
       : typeof stateId === "number"
-        ? stateId >= chain.forkChoice.getFinalizedBlock().slot
-          ? await chain.getStateBySlot(stateId, {allowRegen: true})
-          : await chain.getHistoricalStateBySlot(stateId)
+        ? stateId > chain.clock.currentSlot
+          ? null // Don't try to serve future slots
+          : stateId >= chain.forkChoice.getFinalizedBlock().slot
+            ? await chain.getStateBySlot(stateId, {allowRegen: true})
+            : await chain.getHistoricalStateBySlot(stateId)
         : await chain.getStateOrBytesByCheckpoint(stateId);
 
   if (!res) {


### PR DESCRIPTION
**Motivation**

When requesting a future slot the node tries to dial the state from head which allows to quite easily DoS the node as it's unbounded amount of work if the slot is very far away from head.

We should not allow to request states that are in the future (> clock slot) and return a 404 instead.

**Description**

In case state is request by slot, check if it's a slot from the future based on clock slot and return 404 state not found error.

I didn't use `forkChoice.getHead().slot` because we should still be able to serve the state if all slots between the requested slot  and the head slot are skipped.

Related [discord discussion](https://discord.com/channels/593655374469660673/1387128551962050751/1445514034592878755), thanks to @guha-rahul for catching and reporting this.