### PR TITLE
feat: add EraStore for serving historical blocks from ERA files 

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
+++ b/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
@@ -9,6 +9,7 @@ import {JobItemQueue} from "../../util/queue/index.js";
 import {ChainEvent} from "../emitter.js";
 import {IBeaconChain} from "../interface.js";
 import {PROCESS_FINALIZED_CHECKPOINT_QUEUE_LENGTH} from "./constants.js";
+import {archiveToEra, detectLastArchivedEra} from "./eraArchiver.js";
 import {HistoricalStateRegen} from "./historicalState/historicalStateRegen.js";
 import {ArchiveMode, ArchiveStoreOpts, StateArchiveStrategy} from "./interface.js";
 import {FrequencyStateArchiveStrategy} from "./strategies/frequencyStateArchiveStrategy.js";
@@ -28,6 +29,7 @@ type ArchiveStoreInitOpts = ArchiveStoreOpts & {dbName: string; anchorState: {fi
 export enum ArchiveStoreTask {
   ArchiveBlocks = "archive_blocks",
   PruneHistory = "prune_history",
+  ArchiveToEra = "archive_to_era",
   OnFinalizedCheckpoint = "on_finalized_checkpoint",
   MaybeArchiveState = "maybe_archive_state",
   RegenPruneOnFinalized = "regen_prune_on_finalized",
@@ -53,6 +55,9 @@ export class ArchiveStore {
   private readonly signal: AbortSignal;
 
   private historicalStateRegen?: HistoricalStateRegen;
+
+  /** Last era number that was archived to file */
+  private lastArchivedEra = 0;
 
   constructor(modules: ArchiveStoreModules, opts: ArchiveStoreInitOpts, signal: AbortSignal) {
     this.chain = modules.chain;
@@ -125,6 +130,14 @@ export class ArchiveStore {
         metrics: this.metrics,
         logger: this.logger,
         signal: this.signal,
+      });
+    }
+
+    if (this.opts.eraArchiveDir) {
+      this.lastArchivedEra = detectLastArchivedEra(this.opts.eraArchiveDir, this.chain.config.CONFIG_NAME);
+      this.logger.info("Era archiving enabled", {
+        archiveDir: this.opts.eraArchiveDir,
+        lastArchivedEra: this.lastArchivedEra,
       });
     }
   }
@@ -221,8 +234,23 @@ export class ArchiveStore {
 
       // should be after ArchiveBlocksTask to handle restart cleanly
       timer = this.metrics?.processFinalizedCheckpoint.durationByTask.startTimer();
-      await this.statesArchiverStrategy.maybeArchiveState(finalized, this.metrics);
+      await this.statesArchiverStrategy.maybeArchiveState(finalized, this.metrics, this.lastArchivedEra);
       timer?.({source: ArchiveStoreTask.MaybeArchiveState});
+
+      // Archive to ERA files after state archiving
+      if (this.opts.eraArchiveDir) {
+        timer = this.metrics?.processFinalizedCheckpoint.durationByTask.startTimer();
+        this.lastArchivedEra = await archiveToEra(
+          this.chain.config,
+          this.db,
+          this.logger,
+          this.opts.eraArchiveDir,
+          this.chain.clock.currentEpoch,
+          finalizedEpoch,
+          this.lastArchivedEra
+        );
+        timer?.({source: ArchiveStoreTask.ArchiveToEra});
+      }
 
       timer = this.metrics?.processFinalizedCheckpoint.durationByTask.startTimer();
       this.chain.regen.pruneOnFinalized(finalizedEpoch);

--- a/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
+++ b/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
@@ -56,8 +56,8 @@ export class ArchiveStore {
 
   private historicalStateRegen?: HistoricalStateRegen;
 
-  /** Last era number that was archived to file */
-  private lastArchivedEra = 0;
+  /** Last era number that was archived to file (-1 means none archived yet) */
+  private lastArchivedEra = -1;
 
   constructor(modules: ArchiveStoreModules, opts: ArchiveStoreInitOpts, signal: AbortSignal) {
     this.chain = modules.chain;

--- a/packages/beacon-node/src/chain/archiveStore/eraArchiver.ts
+++ b/packages/beacon-node/src/chain/archiveStore/eraArchiver.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs";
+import path from "node:path";
+import {ChainForkConfig} from "@lodestar/config";
+import {
+  EraWriter,
+  computeStartBlockSlotFromEraNumber,
+  computeStateSlotFromEraNumber,
+  getShortHistoricalRoot,
+  parseEraName,
+} from "@lodestar/era/era";
+import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
+import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {BeaconState, Epoch} from "@lodestar/types";
+import {Logger} from "@lodestar/utils";
+import {IBeaconDb} from "../../db/interface.js";
+
+const EPOCHS_PER_ERA = SLOTS_PER_HISTORICAL_ROOT / SLOTS_PER_EPOCH;
+
+export function computeMaxArchivableEra(config: ChainForkConfig, currentEpoch: Epoch, finalizedEpoch: Epoch): number {
+  // Archive 1 era + 1 epoch before blocks become prunable
+  const archiveCutoffEpoch = Math.max(currentEpoch - config.MIN_EPOCHS_FOR_BLOCK_REQUESTS + EPOCHS_PER_ERA + 1, 0);
+  // Don't archive beyond finalized
+  const safeArchiveEpoch = Math.min(archiveCutoffEpoch, finalizedEpoch);
+  const archiveCutoffSlot = computeStartSlotAtEpoch(safeArchiveEpoch);
+
+  // Era N's state is at slot N * SLOTS_PER_HISTORICAL_ROOT
+  return Math.floor(archiveCutoffSlot / SLOTS_PER_HISTORICAL_ROOT);
+}
+
+/**
+ * Archives complete eras to era files.
+ * Returns the new lastArchivedEra value.
+ */
+export async function archiveToEra(
+  config: ChainForkConfig,
+  db: IBeaconDb,
+  logger: Logger,
+  archiveDir: string,
+  currentEpoch: Epoch,
+  finalizedEpoch: Epoch,
+  lastArchivedEra: number
+): Promise<number> {
+  const maxEraToArchive = computeMaxArchivableEra(config, currentEpoch, finalizedEpoch);
+
+  logger.debug("Era archiver check", {maxEraToArchive, lastArchivedEra});
+
+  let newLastArchivedEra = lastArchivedEra;
+
+  // Ensure archive directory exists
+  if (!fs.existsSync(archiveDir)) {
+    fs.mkdirSync(archiveDir, {recursive: true});
+  }
+
+  for (let eraNumber = lastArchivedEra + 1; eraNumber <= maxEraToArchive; eraNumber++) {
+    // Skip era 0 (genesis era) - it only has state, no blocks
+    if (eraNumber === 0) {
+      continue;
+    }
+
+    try {
+      const success = await writeEra(config, db, logger, archiveDir, eraNumber);
+      if (success) {
+        newLastArchivedEra = eraNumber;
+        logger.info("Archived era to file", {eraNumber});
+      } else {
+        logger.debug("Era not ready for archiving", {eraNumber});
+        break;
+      }
+    } catch (e) {
+      logger.error("Failed to archive era", {eraNumber}, e as Error);
+      break;
+    }
+  }
+
+  return newLastArchivedEra;
+}
+
+/**
+ * Writes a complete era file containing blocks and state.
+ */
+async function writeEra(
+  config: ChainForkConfig,
+  db: IBeaconDb,
+  logger: Logger,
+  archiveDir: string,
+  eraNumber: number
+): Promise<boolean> {
+  const stateSlot = computeStateSlotFromEraNumber(eraNumber);
+  const blockStartSlot = computeStartBlockSlotFromEraNumber(eraNumber);
+  const blockEndSlot = stateSlot - 1;
+
+  // Check if state is available at the era boundary
+  const stateBytes = await db.stateArchive.getBinary(stateSlot);
+  if (!stateBytes) {
+    logger.debug("State not available for era", {eraNumber, stateSlot});
+    return false;
+  }
+
+  // Create temporary file for writing
+  const tempPath = path.join(archiveDir, `era-${eraNumber}.tmp`);
+  const writer = await EraWriter.create(config, tempPath, eraNumber);
+
+  try {
+    // binaryEntriesStream yields {key, value} pairs in slot order
+    let blocksWritten = 0;
+    for await (const entry of db.blockArchive.binaryEntriesStream({gte: blockStartSlot, lte: blockEndSlot})) {
+      const slot = db.blockArchive.decodeKey(entry.key);
+      await writer.writeSerializedBlock(slot, entry.value);
+      blocksWritten++;
+    }
+
+    logger.debug("Writing era state", {eraNumber, stateSlot, blocksWritten});
+
+    const state = config.getForkTypes(stateSlot).BeaconState.deserializeToViewDU(stateBytes) as unknown as BeaconState;
+    const shortHistoricalRoot = getShortHistoricalRoot(config, state);
+    await writer.writeSerializedState(stateSlot, shortHistoricalRoot, stateBytes);
+
+    const finalPath = await writer.finish();
+    logger.debug("Created era file", {eraNumber, path: finalPath, blocksWritten});
+
+    return true;
+  } catch (e) {
+    await writer.fh.close();
+    fs.unlinkSync(tempPath);
+
+    throw e;
+  }
+}
+
+/**
+ * Scans the archive directory to detect the last archived era number.
+ */
+export function detectLastArchivedEra(archiveDir: string, configName: string): number {
+  if (!fs.existsSync(archiveDir)) {
+    return 0;
+  }
+
+  const files = fs.readdirSync(archiveDir);
+  let maxEra = 0;
+
+  for (const file of files) {
+    if (!file.endsWith(".era")) continue;
+
+    const {configName: fileConfigName, eraNumber} = parseEraName(file);
+    if (fileConfigName === configName && eraNumber > maxEra) {
+      maxEra = eraNumber;
+    }
+  }
+
+  return maxEra;
+}

--- a/packages/beacon-node/src/chain/archiveStore/eraArchiver.ts
+++ b/packages/beacon-node/src/chain/archiveStore/eraArchiver.ts
@@ -52,11 +52,6 @@ export async function archiveToEra(
   }
 
   for (let eraNumber = lastArchivedEra + 1; eraNumber <= maxEraToArchive; eraNumber++) {
-    // Skip era 0 (genesis era) - it only has state, no blocks
-    if (eraNumber === 0) {
-      continue;
-    }
-
     try {
       const success = await writeEra(config, db, logger, archiveDir, eraNumber);
       if (success) {
@@ -77,6 +72,7 @@ export async function archiveToEra(
 
 /**
  * Writes a complete era file containing blocks and state.
+ * Era 0 contains only the genesis state (no blocks).
  */
 async function writeEra(
   config: ChainForkConfig,
@@ -86,8 +82,6 @@ async function writeEra(
   eraNumber: number
 ): Promise<boolean> {
   const stateSlot = computeStateSlotFromEraNumber(eraNumber);
-  const blockStartSlot = computeStartBlockSlotFromEraNumber(eraNumber);
-  const blockEndSlot = stateSlot - 1;
 
   // Check if state is available at the era boundary
   const stateBytes = await db.stateArchive.getBinary(stateSlot);
@@ -101,12 +95,16 @@ async function writeEra(
   const writer = await EraWriter.create(config, tempPath, eraNumber);
 
   try {
-    // binaryEntriesStream yields {key, value} pairs in slot order
+    // Era 0 has no blocks, only genesis state
     let blocksWritten = 0;
-    for await (const entry of db.blockArchive.binaryEntriesStream({gte: blockStartSlot, lte: blockEndSlot})) {
-      const slot = db.blockArchive.decodeKey(entry.key);
-      await writer.writeSerializedBlock(slot, entry.value);
-      blocksWritten++;
+    if (eraNumber > 0) {
+      const blockStartSlot = computeStartBlockSlotFromEraNumber(eraNumber);
+      const blockEndSlot = stateSlot - 1;
+      for await (const entry of db.blockArchive.binaryEntriesStream({gte: blockStartSlot, lte: blockEndSlot})) {
+        const slot = db.blockArchive.decodeKey(entry.key);
+        await writer.writeSerializedBlock(slot, entry.value);
+        blocksWritten++;
+      }
     }
 
     logger.debug("Writing era state", {eraNumber, stateSlot, blocksWritten});
@@ -129,14 +127,15 @@ async function writeEra(
 
 /**
  * Scans the archive directory to detect the last archived era number.
+ * Returns -1 if no era files exist (so archiving starts from era 0).
  */
 export function detectLastArchivedEra(archiveDir: string, configName: string): number {
   if (!fs.existsSync(archiveDir)) {
-    return 0;
+    return -1;
   }
 
   const files = fs.readdirSync(archiveDir);
-  let maxEra = 0;
+  let maxEra = -1;
 
   for (const file of files) {
     if (!file.endsWith(".era")) continue;

--- a/packages/beacon-node/src/chain/archiveStore/interface.ts
+++ b/packages/beacon-node/src/chain/archiveStore/interface.ts
@@ -25,6 +25,8 @@ export type ArchiveStoreOpts = StatesArchiveOpts & {
   archiveDataEpochs?: number;
   pruneHistory?: boolean;
   serveHistoricalState?: boolean;
+  /** Directory to write archived ERA files to. When set, enables era archiving */
+  eraArchiveDir?: string;
 };
 
 export type ProposalStats = {
@@ -45,7 +47,7 @@ export type FinalizedStats = {
 export interface StateArchiveStrategy {
   onCheckpoint(stateRoot: RootHex, metrics?: Metrics | null): Promise<void>;
   onFinalizedCheckpoint(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<void>;
-  maybeArchiveState(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<void>;
+  maybeArchiveState(finalized: CheckpointWithHex, metrics?: Metrics | null, lastArchivedEra?: number): Promise<void>;
   archiveState(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<void>;
 }
 

--- a/packages/beacon-node/src/chain/archiveStore/strategies/frequencyStateArchiveStrategy.ts
+++ b/packages/beacon-node/src/chain/archiveStore/strategies/frequencyStateArchiveStrategy.ts
@@ -1,5 +1,5 @@
 import {CheckpointWithHex} from "@lodestar/fork-choice";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
@@ -55,7 +55,7 @@ export class FrequencyStateArchiveStrategy implements StateArchiveStrategy {
    * epoch - 1024*2    epoch - 1024    epoch - 32    epoch
    * ```
    */
-  async maybeArchiveState(finalized: CheckpointWithHex, metrics?: Metrics | null): Promise<void> {
+  async maybeArchiveState(finalized: CheckpointWithHex, metrics?: Metrics | null, lastArchivedEra = 0): Promise<void> {
     let timer = metrics?.processFinalizedCheckpoint.frequencyStateArchive.startTimer();
     const lastStoredSlot = await this.db.stateArchive.lastKey();
     timer?.({step: FrequencyStateArchiveStep.LoadLastStoredSlot});
@@ -63,8 +63,14 @@ export class FrequencyStateArchiveStrategy implements StateArchiveStrategy {
     const lastStoredEpoch = computeEpochAtSlot(lastStoredSlot ?? 0);
     const {archiveStateEpochFrequency} = this.opts;
 
-    const logCtx = {finalizedEpoch: finalized.epoch, lastStoredEpoch, archiveStateEpochFrequency};
-    if (finalized.epoch - lastStoredEpoch >= Math.min(PERSIST_TEMP_STATE_EVERY_EPOCHS, archiveStateEpochFrequency)) {
+    const finalizedSlot = computeStartSlotAtEpoch(finalized.epoch);
+    const isEraBoundary = finalizedSlot % SLOTS_PER_HISTORICAL_ROOT === 0;
+
+    const logCtx = {finalizedEpoch: finalized.epoch, lastStoredEpoch, archiveStateEpochFrequency, isEraBoundary};
+    if (
+      finalized.epoch - lastStoredEpoch >= Math.min(PERSIST_TEMP_STATE_EVERY_EPOCHS, archiveStateEpochFrequency) ||
+      isEraBoundary
+    ) {
       this.logger.verbose("Start archiving state", logCtx);
       await this.archiveState(finalized, metrics);
 
@@ -81,7 +87,11 @@ export class FrequencyStateArchiveStrategy implements StateArchiveStrategy {
       });
       timer?.({step: FrequencyStateArchiveStep.LoadStoredSlotsToDelete});
 
-      const statesSlotsToDelete = computeStateSlotsToDelete(storedStateSlots, archiveStateEpochFrequency);
+      const statesSlotsToDelete = computeStateSlotsToDelete(
+        storedStateSlots,
+        archiveStateEpochFrequency,
+        lastArchivedEra
+      );
       timer = metrics?.processFinalizedCheckpoint.frequencyStateArchive.startTimer();
       if (statesSlotsToDelete.length > 0) {
         await this.db.stateArchive.batchDelete(statesSlotsToDelete);
@@ -145,14 +155,28 @@ export class FrequencyStateArchiveStrategy implements StateArchiveStrategy {
 }
 
 /**
- * Keeps first epoch per interval of persistEveryEpochs, deletes the rest
+ * Keeps first epoch per interval of persistEveryEpochs, deletes the rest.
+ * Era boundary states are kept
+ * until they have been archived to an era file.
  */
-export function computeStateSlotsToDelete(storedStateSlots: Slot[], persistEveryEpochs: Epoch): Slot[] {
+export function computeStateSlotsToDelete(
+  storedStateSlots: Slot[],
+  persistEveryEpochs: Epoch,
+  lastArchivedEra = 0
+): Slot[] {
   const persistEverySlots = persistEveryEpochs * SLOTS_PER_EPOCH;
   const intervalsWithStates = new Set<number>();
   const stateSlotsToDelete = new Set<number>();
 
   for (const slot of storedStateSlots) {
+    // Keep era boundary states until they've been archived to era files
+    if (slot % SLOTS_PER_HISTORICAL_ROOT === 0) {
+      const eraNumber = slot / SLOTS_PER_HISTORICAL_ROOT;
+      if (eraNumber > lastArchivedEra) {
+        continue;
+      }
+    }
+
     const interval = Math.floor(slot / persistEverySlots);
     if (intervalsWithStates.has(interval)) {
       stateSlotsToDelete.add(slot);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -682,7 +682,18 @@ export class BeaconChain implements IBeaconChain {
     }
 
     const data = await this.db.blockArchive.get(slot);
-    return data && {block: data, executionOptimistic: false, finalized: true};
+    if (data) {
+      return {block: data, executionOptimistic: false, finalized: true};
+    }
+
+    if (this.db.eraStore?.hasSlot(slot)) {
+      const eraBlock = await this.db.eraStore.getBlockBySlot(slot);
+      if (eraBlock) {
+        return {block: eraBlock, executionOptimistic: false, finalized: true};
+      }
+    }
+
+    return null;
   }
 
   async getBlockByRoot(
@@ -699,7 +710,18 @@ export class BeaconChain implements IBeaconChain {
     }
 
     const data = await this.db.blockArchive.getByRoot(fromHex(root));
-    return data && {block: data, executionOptimistic: false, finalized: true};
+    if (data) {
+      return {block: data, executionOptimistic: false, finalized: true};
+    }
+
+    if (this.db.eraStore) {
+      const eraBlock = await this.db.eraStore.getBlockByRoot(root);
+      if (eraBlock) {
+        return {block: eraBlock, executionOptimistic: false, finalized: true};
+      }
+    }
+
+    return null;
   }
 
   async produceCommonBlockBody(blockAttributes: BlockAttributes): Promise<CommonBlockBody> {

--- a/packages/beacon-node/src/db/beacon.ts
+++ b/packages/beacon-node/src/db/beacon.ts
@@ -1,5 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {Db, LevelDbControllerMetrics} from "@lodestar/db";
+import {EraStore} from "../era/eraStore.js";
 import {IBeaconDb} from "./interface.js";
 import {CheckpointStateRepository} from "./repositories/checkpointState.js";
 import {
@@ -61,6 +62,8 @@ export class BeaconDb implements IBeaconDb {
 
   backfilledRanges: BackfilledRanges;
 
+  eraStore: EraStore | null = null;
+
   constructor(
     config: ChainForkConfig,
     protected readonly db: Db
@@ -95,7 +98,10 @@ export class BeaconDb implements IBeaconDb {
     this.backfilledRanges = new BackfilledRanges(config, db);
   }
 
-  close(): Promise<void> {
+  async close(): Promise<void> {
+    if (this.eraStore) {
+      await this.eraStore.close();
+    }
     return this.db.close();
   }
 

--- a/packages/beacon-node/src/db/interface.ts
+++ b/packages/beacon-node/src/db/interface.ts
@@ -1,4 +1,5 @@
 import {LevelDbControllerMetrics} from "@lodestar/db";
+import {EraStore} from "../era/eraStore.js";
 import {CheckpointStateRepository} from "./repositories/checkpointState.js";
 import {
   AttesterSlashingRepository,
@@ -66,6 +67,8 @@ export interface IBeaconDb {
   syncCommitteeWitness: SyncCommitteeWitnessRepository;
 
   backfilledRanges: BackfilledRanges;
+
+  eraStore: EraStore | null;
 
   pruneHotDb(): Promise<void>;
 

--- a/packages/beacon-node/src/era/eraStore.ts
+++ b/packages/beacon-node/src/era/eraStore.ts
@@ -1,0 +1,223 @@
+import fs from "node:fs";
+import path from "node:path";
+import {ChainForkConfig} from "@lodestar/config";
+import {
+  EraReader,
+  computeEraNumberFromBlockSlot,
+  computeStartBlockSlotFromEraNumber,
+  computeStateSlotFromEraNumber,
+  parseEraName,
+} from "@lodestar/era/era";
+import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
+import {RootHex, SignedBeaconBlock, Slot} from "@lodestar/types";
+import {Logger, toRootHex} from "@lodestar/utils";
+
+/**
+ * EraStore provides read access to historical beacon chain data stored in ERA files.
+ */
+export class EraStore {
+  private readonly config: ChainForkConfig;
+  private readonly logger: Logger;
+  private readonly eraDir: string;
+
+  /** Map of era number -> ERA file path */
+  private readonly eraFiles: Map<number, string> = new Map();
+
+  /** Cache of open ERA readers */
+  private readonly readerCache: Map<number, EraReader> = new Map();
+
+  /** Index of block root -> {era, slot} for fast lookups */
+  private readonly blockRootIndex: Map<RootHex, {era: number; slot: Slot}> = new Map();
+
+  /** Track which eras have been indexed */
+  private readonly indexedEras: Set<number> = new Set();
+
+  private constructor(config: ChainForkConfig, logger: Logger, eraDir: string) {
+    this.config = config;
+    this.logger = logger;
+    this.eraDir = eraDir;
+  }
+
+  /**
+   * Create and initialize an EraStore from a directory of ERA files.
+   */
+  static async create(config: ChainForkConfig, logger: Logger, eraDir: string): Promise<EraStore | null> {
+    if (!eraDir || !fs.existsSync(eraDir)) {
+      logger.debug("ERA directory not found, EraStore disabled", {eraDir});
+      return null;
+    }
+
+    const store = new EraStore(config, logger, eraDir);
+    store.scanEraFiles();
+
+    if (store.eraFiles.size === 0) {
+      logger.debug("No ERA files found in directory", {eraDir});
+      return null;
+    }
+
+    logger.info("EraStore initialized", {
+      eraDir,
+      eraCount: store.eraFiles.size,
+      eraRange: store.getEraRange(),
+    });
+
+    return store;
+  }
+
+  /**
+   * Scan the ERA directory for available files.
+   */
+  private scanEraFiles(): void {
+    const files = fs.readdirSync(this.eraDir).filter((f) => f.endsWith(".era"));
+
+    for (const file of files) {
+      try {
+        const {eraNumber} = parseEraName(file);
+        this.eraFiles.set(eraNumber, path.join(this.eraDir, file));
+      } catch (e) {
+        this.logger.warn("Failed to parse era number from file", {file, error: (e as Error).message});
+      }
+    }
+  }
+
+  private getSortedEras(): number[] {
+    return [...this.eraFiles.keys()].sort((a, b) => a - b);
+  }
+
+  getEraRange(): string {
+    if (this.eraFiles.size === 0) return "none";
+    const eras = this.getSortedEras();
+    return `${eras[0]}-${eras.at(-1)}`;
+  }
+
+  getSlotRange(): {minSlot: Slot; maxSlot: Slot} | null {
+    if (this.eraFiles.size === 0) return null;
+
+    // Era 0 contains only genesis state, no blocks
+    const blockEras = this.getSortedEras().filter((e) => e > 0);
+    if (blockEras.length === 0) return null;
+
+    const minEra = blockEras[0];
+    const maxEra = blockEras.at(-1) as number;
+    const minSlot = computeStartBlockSlotFromEraNumber(minEra);
+    const maxSlot = computeStateSlotFromEraNumber(maxEra) - 1;
+
+    return {minSlot, maxSlot};
+  }
+
+  /**
+   * Check if a slot is covered by available ERA files.
+   */
+  hasSlot(slot: Slot): boolean {
+    return this.eraFiles.has(computeEraNumberFromBlockSlot(slot));
+  }
+
+  /**
+   * Get or open an ERA reader for a given era number.
+   */
+  private async getReader(eraNumber: number): Promise<EraReader | null> {
+    const cached = this.readerCache.get(eraNumber);
+    if (cached) return cached;
+
+    const filePath = this.eraFiles.get(eraNumber);
+    if (!filePath) return null;
+
+    try {
+      const reader = await EraReader.open(this.config, filePath);
+      this.readerCache.set(eraNumber, reader);
+      return reader;
+    } catch (e) {
+      this.logger.warn("Failed to open ERA file", {eraNumber, error: (e as Error).message});
+      return null;
+    }
+  }
+
+  /**
+   * Build block root index for an era using state.blockRoots (lazy, on-demand).
+   */
+  private async indexEra(eraNumber: number): Promise<void> {
+    if (this.indexedEras.has(eraNumber)) return;
+
+    // Era 0 has genesis state only
+    if (eraNumber === 0) {
+      this.indexedEras.add(eraNumber);
+      return;
+    }
+
+    const reader = await this.getReader(eraNumber);
+    if (!reader) return;
+
+    const group = reader.groups[0];
+    if (!group?.blocksIndex) {
+      this.indexedEras.add(eraNumber);
+      return;
+    }
+
+    const stateSlot = computeStateSlotFromEraNumber(eraNumber);
+    const serialized = await reader.readSerializedState(eraNumber);
+    const state = this.config.getForkTypes(stateSlot).BeaconState.deserializeToViewDU(serialized);
+
+    const startSlot = group.blocksIndex.startSlot;
+    for (let i = 0; i < group.blocksIndex.offsets.length; i++) {
+      // Skip slots have offset 0
+      if (group.blocksIndex.offsets[i] === 0) continue;
+
+      const slot = startSlot + i;
+      const blockRoot = state.blockRoots.get(slot % SLOTS_PER_HISTORICAL_ROOT);
+      this.blockRootIndex.set(toRootHex(blockRoot), {era: eraNumber, slot});
+    }
+
+    this.indexedEras.add(eraNumber);
+    this.logger.debug("Indexed ERA file", {eraNumber, indexSize: this.blockRootIndex.size});
+  }
+
+  /**
+   * Get a block by slot from ERA files.
+   */
+  async getBlockBySlot(slot: Slot): Promise<SignedBeaconBlock | null> {
+    const eraNumber = computeEraNumberFromBlockSlot(slot);
+    const reader = await this.getReader(eraNumber);
+    if (!reader) return null;
+
+    try {
+      return await reader.readBlock(slot);
+    } catch (e) {
+      this.logger.debug("Failed to read block from ERA", {slot, era: eraNumber, error: (e as Error).message});
+      return null;
+    }
+  }
+
+  /**
+   * Get a block by root from ERA files.
+   */
+  async getBlockByRoot(root: RootHex): Promise<SignedBeaconBlock | null> {
+    const location = this.blockRootIndex.get(root);
+    if (location) {
+      return this.getBlockBySlot(location.slot);
+    }
+
+    for (const eraNumber of this.getSortedEras()) {
+      if (this.indexedEras.has(eraNumber)) continue;
+
+      await this.indexEra(eraNumber);
+
+      const loc = this.blockRootIndex.get(root);
+      if (loc) {
+        return this.getBlockBySlot(loc.slot);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Close all open ERA readers.
+   */
+  async close(): Promise<void> {
+    for (const reader of this.readerCache.values()) {
+      await reader.close();
+    }
+    this.readerCache.clear();
+    this.logger.debug("EraStore closed");
+  }
+}

--- a/packages/beacon-node/src/era/eraStore.ts
+++ b/packages/beacon-node/src/era/eraStore.ts
@@ -18,7 +18,7 @@ import {Logger, toRootHex} from "@lodestar/utils";
 export class EraStore {
   private readonly config: ChainForkConfig;
   private readonly logger: Logger;
-  private readonly eraDir: string;
+  private readonly eraDirs: string[];
 
   /** Map of era number -> ERA file path */
   private readonly eraFiles: Map<number, string> = new Map();
@@ -32,31 +32,45 @@ export class EraStore {
   /** Track which eras have been indexed */
   private readonly indexedEras: Set<number> = new Set();
 
-  private constructor(config: ChainForkConfig, logger: Logger, eraDir: string) {
+  private constructor(config: ChainForkConfig, logger: Logger, eraDirs: string[]) {
     this.config = config;
     this.logger = logger;
-    this.eraDir = eraDir;
+    this.eraDirs = eraDirs;
   }
 
   /**
    * Create and initialize an EraStore from a directory of ERA files.
    */
-  static async create(config: ChainForkConfig, logger: Logger, eraDir: string): Promise<EraStore | null> {
-    if (!eraDir || !fs.existsSync(eraDir)) {
-      logger.debug("ERA directory not found, EraStore disabled", {eraDir});
+  static async create(
+    config: ChainForkConfig,
+    logger: Logger,
+    eraDir: string,
+    archiveDir?: string
+  ): Promise<EraStore | null> {
+    // Collect all valid directories
+    const eraDirs: string[] = [];
+    if (eraDir && fs.existsSync(eraDir)) {
+      eraDirs.push(eraDir);
+    }
+    if (archiveDir && fs.existsSync(archiveDir) && archiveDir !== eraDir) {
+      eraDirs.push(archiveDir);
+    }
+
+    if (eraDirs.length === 0) {
+      logger.debug("No ERA directories found, EraStore disabled", {eraDir, archiveDir});
       return null;
     }
 
-    const store = new EraStore(config, logger, eraDir);
+    const store = new EraStore(config, logger, eraDirs);
     store.scanEraFiles();
 
     if (store.eraFiles.size === 0) {
-      logger.debug("No ERA files found in directory", {eraDir});
+      logger.debug("No ERA files found in directories", {eraDirs: eraDirs.join(", ")});
       return null;
     }
 
     logger.info("EraStore initialized", {
-      eraDir,
+      eraDirs: eraDirs.join(", "),
       eraCount: store.eraFiles.size,
       eraRange: store.getEraRange(),
     });
@@ -65,17 +79,24 @@ export class EraStore {
   }
 
   /**
-   * Scan the ERA directory for available files.
+   * Scan all ERA directories for available files.
    */
   private scanEraFiles(): void {
-    const files = fs.readdirSync(this.eraDir).filter((f) => f.endsWith(".era"));
+    for (const eraDir of this.eraDirs) {
+      if (!fs.existsSync(eraDir)) continue;
 
-    for (const file of files) {
-      try {
-        const {eraNumber} = parseEraName(file);
-        this.eraFiles.set(eraNumber, path.join(this.eraDir, file));
-      } catch (e) {
-        this.logger.warn("Failed to parse era number from file", {file, error: (e as Error).message});
+      const files = fs.readdirSync(eraDir).filter((f) => f.endsWith(".era"));
+
+      for (const file of files) {
+        try {
+          const {eraNumber} = parseEraName(file);
+          // Don't overwrite if already found (first directory takes precedence)
+          if (!this.eraFiles.has(eraNumber)) {
+            this.eraFiles.set(eraNumber, path.join(eraDir, file));
+          }
+        } catch (e) {
+          this.logger.warn("Failed to parse era number from file", {file, error: (e as Error).message});
+        }
       }
     }
   }

--- a/packages/beacon-node/src/era/options.ts
+++ b/packages/beacon-node/src/era/options.ts
@@ -1,0 +1,8 @@
+export type EraOptions = {
+  /** Directory containing ERA files to serve historical data from */
+  dir: string;
+};
+
+export const defaultEraOptions: EraOptions = {
+  dir: "",
+};

--- a/packages/beacon-node/src/era/options.ts
+++ b/packages/beacon-node/src/era/options.ts
@@ -1,8 +1,11 @@
 export type EraOptions = {
   /** Directory containing ERA files to serve historical data from */
   dir: string;
+  /** Directory to write archived ERA files to. When set, enables era archiving */
+  archiveDir: string;
 };
 
 export const defaultEraOptions: EraOptions = {
   dir: "",
+  archiveDir: "",
 };

--- a/packages/beacon-node/src/index.ts
+++ b/packages/beacon-node/src/index.ts
@@ -6,6 +6,8 @@ export {checkAndPersistAnchorState, initStateFromDb, initStateFromEth1} from "./
 export {DbCPStateDatastore} from "./chain/stateCache/datastore/db.js";
 export {FileCPStateDatastore} from "./chain/stateCache/datastore/file.js";
 export {BeaconDb, type IBeaconDb} from "./db/index.js";
+export {EraStore} from "./era/eraStore.js";
+export {type EraOptions, defaultEraOptions} from "./era/options.js";
 export {Eth1Provider, type IEth1Provider} from "./eth1/index.js";
 // Export metrics utilities to de-duplicate validator metrics
 export {

--- a/packages/beacon-node/src/node/options.ts
+++ b/packages/beacon-node/src/node/options.ts
@@ -2,6 +2,7 @@ import {ApiOptions, defaultApiOptions} from "../api/options.js";
 import {ArchiveMode, DEFAULT_ARCHIVE_MODE, IChainOptions, defaultChainOptions} from "../chain/options.js";
 import {ValidatorMonitorOpts, defaultValidatorMonitorOpts} from "../chain/validatorMonitor.js";
 import {DatabaseOptions, defaultDbOptions} from "../db/options.js";
+import {EraOptions, defaultEraOptions} from "../era/options.js";
 import {Eth1Options, defaultEth1Options} from "../eth1/options.js";
 import {
   ExecutionBuilderOpts,
@@ -26,6 +27,7 @@ export interface IBeaconNodeOptions {
   api: ApiOptions;
   chain: IChainOptions;
   db: DatabaseOptions;
+  era: EraOptions;
   eth1: Eth1Options;
   executionEngine: ExecutionEngineOpts;
   executionBuilder: ExecutionBuilderOpts;
@@ -40,6 +42,7 @@ export const defaultOptions: IBeaconNodeOptions = {
   api: defaultApiOptions,
   chain: defaultChainOptions,
   db: defaultDbOptions,
+  era: defaultEraOptions,
   eth1: defaultEth1Options,
   executionEngine: defaultExecutionEngineOpts,
   executionBuilder: defaultExecutionBuilderOpts,

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import {getHeapStatistics} from "node:v8";
 import {SignableENR} from "@chainsafe/enr";
 import {hasher} from "@chainsafe/persistent-merkle-tree";
-import {BeaconDb, BeaconNode} from "@lodestar/beacon-node";
+import {BeaconDb, BeaconNode, EraStore} from "@lodestar/beacon-node";
 import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {LoggerNode, getNodeLogger} from "@lodestar/logger/node";
@@ -67,6 +67,19 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
 
   const db = new BeaconDb(config, await LevelDbController.create(options.db, {metrics: null, logger}));
   logger.info("Connected to LevelDB database", {path: options.db.name});
+
+  // Initialize EraStore if era.dir is configured
+  if (options.era.dir) {
+    const eraStore = await EraStore.create(config, logger, options.era.dir);
+    if (eraStore) {
+      db.eraStore = eraStore;
+      const slotRange = eraStore.getSlotRange();
+      logger.info("EraStore initialized for historical data", {
+        eraDir: options.era.dir,
+        slotRange: slotRange ? `${slotRange.minSlot}-${slotRange.maxSlot}` : "none",
+      });
+    }
+  }
 
   // BeaconNode setup
   try {

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -68,14 +68,21 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
   const db = new BeaconDb(config, await LevelDbController.create(options.db, {metrics: null, logger}));
   logger.info("Connected to LevelDB database", {path: options.db.name});
 
-  // Initialize EraStore if era.dir is configured
-  if (options.era.dir) {
-    const eraStore = await EraStore.create(config, logger, options.era.dir);
+  // Create archive directory if era archiving is enabled
+  if (options.era.archiveDir) {
+    mkdir(options.era.archiveDir);
+    logger.info("Era archiving enabled", {archiveDir: options.era.archiveDir});
+  }
+
+  // Initialize EraStore if era.dir or era.archiveDir is configured
+  if (options.era.dir || options.era.archiveDir) {
+    const eraStore = await EraStore.create(config, logger, options.era.dir, options.era.archiveDir);
     if (eraStore) {
       db.eraStore = eraStore;
       const slotRange = eraStore.getSlotRange();
       logger.info("EraStore initialized for historical data", {
-        eraDir: options.era.dir,
+        eraDir: options.era.dir || "(none)",
+        archiveDir: options.era.archiveDir || "(none)",
         slotRange: slotRange ? `${slotRange.minSlot}-${slotRange.maxSlot}` : "none",
       });
     }
@@ -225,6 +232,12 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
   }
 
   beaconNodeOptions.set({chain: {initialCustodyGroupCount: getInitialCustodyGroupCount(args, config, logger, enr)}});
+
+  // Pass era options to chain options for era archiving
+  const eraArchiveDir = beaconNodeOptions.get().era?.archiveDir;
+  if (eraArchiveDir) {
+    beaconNodeOptions.set({chain: {eraArchiveDir}});
+  }
 
   if (args.disableLightClientServer) {
     beaconNodeOptions.set({chain: {disableLightClientServer: true}});

--- a/packages/cli/src/options/beaconNodeOptions/era.ts
+++ b/packages/cli/src/options/beaconNodeOptions/era.ts
@@ -3,11 +3,13 @@ import {CliCommandOptions} from "@lodestar/utils";
 
 export type EraArgs = {
   "era.dir"?: string;
+  "era.archiveDir"?: string;
 };
 
 export function parseArgs(args: EraArgs): EraOptions {
   return {
     dir: args["era.dir"] ?? defaultEraOptions.dir,
+    archiveDir: args["era.archiveDir"] ?? defaultEraOptions.archiveDir,
   };
 }
 
@@ -17,6 +19,13 @@ export const options: CliCommandOptions<EraArgs> = {
     description:
       "Directory containing ERA files to serve historical data from. When set, the beacon node will use ERA files as a data source for historical blocks and states.",
     default: defaultEraOptions.dir,
+    group: "era",
+  },
+  "era.archiveDir": {
+    type: "string",
+    description:
+      "Directory to write archived ERA files to. When set, blocks older than MIN_EPOCHS_FOR_BLOCK_REQUESTS will be written to ERA files and pruned from the database. Archived blocks are served via beacon API but not on P2P.",
+    default: defaultEraOptions.archiveDir,
     group: "era",
   },
 };

--- a/packages/cli/src/options/beaconNodeOptions/era.ts
+++ b/packages/cli/src/options/beaconNodeOptions/era.ts
@@ -1,0 +1,22 @@
+import {EraOptions, defaultEraOptions} from "@lodestar/beacon-node";
+import {CliCommandOptions} from "@lodestar/utils";
+
+export type EraArgs = {
+  "era.dir"?: string;
+};
+
+export function parseArgs(args: EraArgs): EraOptions {
+  return {
+    dir: args["era.dir"] ?? defaultEraOptions.dir,
+  };
+}
+
+export const options: CliCommandOptions<EraArgs> = {
+  "era.dir": {
+    type: "string",
+    description:
+      "Directory containing ERA files to serve historical data from. When set, the beacon node will use ERA files as a data source for historical blocks and states.",
+    default: defaultEraOptions.dir,
+    group: "era",
+  },
+};

--- a/packages/cli/src/options/beaconNodeOptions/index.ts
+++ b/packages/cli/src/options/beaconNodeOptions/index.ts
@@ -4,6 +4,7 @@ import {removeUndefinedRecursive} from "../../util/index.js";
 import * as api from "./api.js";
 import * as builder from "./builder.js";
 import * as chain from "./chain.js";
+import * as era from "./era.js";
 import * as eth1 from "./eth1.js";
 import * as execution from "./execution.js";
 import * as metrics from "./metrics.js";
@@ -13,6 +14,7 @@ import * as sync from "./sync.js";
 
 export type BeaconNodeArgs = api.ApiArgs &
   chain.ChainArgs &
+  era.EraArgs &
   eth1.Eth1Args &
   execution.ExecutionEngineArgs &
   builder.ExecutionBuilderArgs &
@@ -27,6 +29,7 @@ export function parseBeaconNodeArgs(args: BeaconNodeArgs): RecursivePartial<IBea
     api: api.parseArgs(args),
     chain: chain.parseArgs(args),
     // db: {},
+    era: era.parseArgs(args),
     eth1: eth1.parseArgs(args),
     executionEngine: execution.parseArgs(args),
     executionBuilder: builder.parseArgs(args),
@@ -40,6 +43,7 @@ export function parseBeaconNodeArgs(args: BeaconNodeArgs): RecursivePartial<IBea
 export const beaconNodeOptions = {
   ...api.options,
   ...chain.options,
+  ...era.options,
   ...eth1.options,
   ...execution.options,
   ...builder.options,

--- a/packages/era/package.json
+++ b/packages/era/package.json
@@ -18,6 +18,11 @@
       "bun": "./src/index.ts",
       "types": "./lib/index.d.ts",
       "import": "./lib/index.js"
+    },
+    "./era": {
+      "bun": "./src/era/index.ts",
+      "types": "./lib/era/index.d.ts",
+      "import": "./lib/era/index.js"
     }
   },
   "files": [

--- a/packages/era/src/era/util.ts
+++ b/packages/era/src/era/util.ts
@@ -139,9 +139,9 @@ export function getShortHistoricalRoot(config: ChainForkConfig, state: BeaconSta
               })()) as capella.BeaconState["historicalSummaries"][0]
           )
         : ((state.historicalRoots.at(-1) ??
-          (() => {
-            throw new Error(`historicalRoots is empty at slot ${state.slot}`);
-          })()) as Uint8Array)
+            (() => {
+              throw new Error(`historicalRoots is empty at slot ${state.slot}`);
+            })()) as Uint8Array)
   )
     .subarray(0, 4)
     .toString("hex");

--- a/packages/era/src/era/util.ts
+++ b/packages/era/src/era/util.ts
@@ -43,6 +43,14 @@ export function computeStartBlockSlotFromEraNumber(eraNumber: number): Slot {
   return (eraNumber - 1) * SLOTS_PER_HISTORICAL_ROOT;
 }
 
+export function computeEraNumberFromStateSlot(slot: Slot): number {
+  return Math.floor(slot / SLOTS_PER_HISTORICAL_ROOT);
+}
+
+export function computeStateSlotFromEraNumber(eraNumber: number): Slot {
+  return eraNumber * SLOTS_PER_HISTORICAL_ROOT;
+}
+
 /**
  * Parse era filename.
  *

--- a/packages/era/src/era/util.ts
+++ b/packages/era/src/era/util.ts
@@ -133,9 +133,15 @@ export function getShortHistoricalRoot(config: ChainForkConfig, state: BeaconSta
       : // Post-Capella, historical_roots is replaced by historical_summaries
         isForkPostCapella(config.getForkName(state.slot))
         ? ssz.capella.HistoricalSummary.hashTreeRoot(
-            (state as capella.BeaconState).historicalSummaries.at(-1) as capella.BeaconState["historicalSummaries"][0]
+            ((state as capella.BeaconState).historicalSummaries.at(-1) ??
+              (() => {
+                throw new Error(`historicalSummaries is empty at slot ${state.slot}`);
+              })()) as capella.BeaconState["historicalSummaries"][0]
           )
-        : (state.historicalRoots.at(-1) as Uint8Array)
+        : ((state.historicalRoots.at(-1) ??
+          (() => {
+            throw new Error(`historicalRoots is empty at slot ${state.slot}`);
+          })()) as Uint8Array)
   )
     .subarray(0, 4)
     .toString("hex");


### PR DESCRIPTION
**Motivation**
- Beacon nodes currently require importing all historical block data into LevelDB to serve historical queries specially blocks which requires a lot of storage .
- ERA files are an efficient file storage format that already contain all verifiable historical beacon chain data. We can serve historical queries directly from ERA files.
<!-- Why does this PR exist? What are the goals of the pull request? -->

**Description**
This pr adds EraStore , that serves historical beacon blocks directly from ERA files without importing them into the db. 
- This pr adds a `--era.dir` CLI option for era directory
- Block and Block root indexing considering we have the ERA files.
<!-- A clear and concise general description of the changes of this pull request. -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

tracks #7048 

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.
Use copilot for auto complete and Claude for understanding codebase and refactors.
<!-- Insert any AI assistance disclosure here -->
