### PR TITLE
feat: update vc to submit beacon committee selections once per epoch

### DIFF
--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -498,6 +498,10 @@ export type Endpoints = {
    * a validator client to correctly determine if one of its validators has been selected to
    * perform an aggregation duty in this slot.
    *
+   * Validator clients running in a distributed validator cluster must query this endpoint
+   * at the start of an epoch for the current and lookahead (next) epochs for all validators
+   * that have attester duties in the current and lookahead epochs.
+   *
    * Note that this endpoint is not implemented by the beacon node and will return a 501 error
    *
    * Returns an array of threshold aggregated beacon committee selection proofs
@@ -520,6 +524,9 @@ export type Endpoints = {
    * partial sync committee selection proofs for combined/aggregated selection proofs to allow
    * a validator client to correctly determine if one of its validators has been selected to
    * perform a sync committee contribution (sync aggregation) duty in this slot.
+   *
+   * Validator clients running in a distributed validator cluster must query this endpoint
+   * at the start of each slot for all validators that are included in the current sync committee.
    *
    * Note that this endpoint is not implemented by the beacon node and will return a 501 error
    *

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -1,8 +1,8 @@
-import {ApiClient, routes} from "@lodestar/api";
+import {ApiClient} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkName, isForkPostElectra} from "@lodestar/params";
-import {computeEpochAtSlot, isAggregatorFromCommitteeLength} from "@lodestar/state-transition";
-import {BLSSignature, SignedAggregateAndProof, SingleAttestation, Slot, phase0, ssz} from "@lodestar/types";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {SignedAggregateAndProof, SingleAttestation, Slot, phase0, ssz} from "@lodestar/types";
 import {prettyBytes, sleep, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../metrics.js";
 import {PubkeyHex} from "../types.js";
@@ -74,18 +74,6 @@ export class AttestationService {
       return;
     }
     const fork = this.config.getForkName(slot);
-
-    if (this.opts?.distributedAggregationSelection) {
-      // Validator in distributed cluster only has a key share, not the full private key.
-      // The partial selection proofs must be exchanged for combined selection proofs by
-      // calling submitBeaconCommitteeSelections on the distributed validator middleware client.
-      // This will run in parallel to other attestation tasks but must be finished before starting
-      // attestation aggregation as it is required to correctly determine if validator is aggregator
-      // and to produce a AggregateAndProof that can be threshold aggregated by the middleware client.
-      this.runDistributedAggregationSelectionTasks(fork, duties, slot, signal).catch((e) =>
-        this.logger.error("Error on attestation aggregation selection", {slot}, e)
-      );
-    }
 
     // A validator should create and broadcast the attestation to the associated attestation subnet when either
     // (a) the validator has received a valid block from the expected block proposer for the assigned slot or
@@ -272,91 +260,6 @@ export class AttestationService {
       } catch (e) {
         this.logger.error("Error publishing aggregateAndProofs", logCtx, e as Error);
       }
-    }
-  }
-
-  /**
-   * Performs additional attestation aggregation tasks required if validator is part of distributed cluster
-   *
-   * 1. Exchange partial for combined selection proofs
-   * 2. Determine validators that should aggregate attestations
-   * 3. Mutate duty objects to set selection proofs for aggregators
-   * 4. Resubscribe validators as aggregators on beacon committee subnets
-   *
-   * See https://docs.google.com/document/d/1q9jOTPcYQa-3L8luRvQJ-M0eegtba4Nmon3dpO79TMk/mobilebasic
-   */
-  private async runDistributedAggregationSelectionTasks(
-    fork: ForkName,
-    duties: AttDutyAndProof[],
-    slot: number,
-    signal: AbortSignal
-  ): Promise<void> {
-    const partialSelections: routes.validator.BeaconCommitteeSelection[] = duties.map(
-      ({duty, partialSelectionProof}) => ({
-        validatorIndex: duty.validatorIndex,
-        slot,
-        selectionProof: partialSelectionProof as BLSSignature,
-      })
-    );
-
-    this.logger.debug("Submitting partial beacon committee selection proofs", {slot, count: partialSelections.length});
-
-    const res = await Promise.race([
-      this.api.validator.submitBeaconCommitteeSelections({selections: partialSelections}),
-      // Exit attestation aggregation flow if there is no response after ATTESTATION_DUE_BPS of the slot as
-      // beacon node would likely not have enough time to prepare an aggregate attestation.
-      // Note that the aggregations flow is not explicitly exited but rather will be skipped
-      // due to the fact that calculation of `is_aggregator` in AttestationDutiesService is not done
-      // and selectionProof is set to null, meaning no validator will be considered an aggregator.
-      sleep(this.config.getAttestationDueMs(fork) - this.clock.msFromSlot(slot), signal),
-    ]);
-
-    if (!res) {
-      throw new Error("Failed to receive combined selection proofs before ATTESTATION_DUE_BPS of the slot");
-    }
-
-    const combinedSelections = res.value();
-    this.logger.debug("Received combined beacon committee selection proofs", {slot, count: combinedSelections.length});
-
-    const beaconCommitteeSubscriptions: routes.validator.BeaconCommitteeSubscription[] = [];
-
-    for (const dutyAndProof of duties) {
-      const {validatorIndex, committeeIndex, committeeLength, committeesAtSlot} = dutyAndProof.duty;
-      const logCtxValidator = {slot, index: committeeIndex, validatorIndex};
-
-      const combinedSelection = combinedSelections.find((s) => s.validatorIndex === validatorIndex && s.slot === slot);
-
-      if (!combinedSelection) {
-        this.logger.warn("Did not receive combined beacon committee selection proof", logCtxValidator);
-        continue;
-      }
-
-      const isAggregator = isAggregatorFromCommitteeLength(committeeLength, combinedSelection.selectionProof);
-
-      if (isAggregator) {
-        // Update selection proof by mutating duty object
-        dutyAndProof.selectionProof = combinedSelection.selectionProof;
-
-        // Only push subnet subscriptions with `isAggregator=true` as all validators
-        // with duties for slot are already subscribed to subnets with `isAggregator=false`.
-        beaconCommitteeSubscriptions.push({
-          validatorIndex,
-          committeesAtSlot,
-          committeeIndex,
-          slot,
-          isAggregator,
-        });
-        this.logger.debug("Resubscribing validator as aggregator on beacon committee subnet", logCtxValidator);
-      }
-    }
-
-    // If there are any subscriptions with aggregators, push them out to the beacon node.
-    if (beaconCommitteeSubscriptions.length > 0) {
-      (await this.api.validator.prepareBeaconCommitteeSubnet({subscriptions: beaconCommitteeSubscriptions})).assertOk();
-      this.logger.debug("Resubscribed validators as aggregators on beacon committee subnets", {
-        slot,
-        count: beaconCommitteeSubscriptions.length,
-      });
     }
   }
 }

--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -204,6 +204,17 @@ export class AttestationDutiesService {
     for (const epoch of [currentEpoch, nextEpoch]) {
       const epochDuties = this.dutiesByIndexByEpoch.get(epoch)?.dutiesByIndex;
       if (epochDuties) {
+        if (this.opts?.distributedAggregationSelection) {
+          // Validator in distributed cluster only has a key share, not the full private key.
+          // The partial selection proofs must be exchanged for combined selection proofs by
+          // calling submitBeaconCommitteeSelections on the distributed validator middleware client.
+          // This is required to correctly determine if validator is aggregator and to produce
+          // a AggregateAndProof that can be threshold aggregated by the middleware client.
+          await this.runDistributedAggregationSelectionTasks(Array.from(epochDuties.values()), epoch).catch((e) =>
+            this.logger.error("Error on attestation aggregation selection", {epoch}, e)
+          );
+        }
+
         for (const {duty, selectionProof} of epochDuties.values()) {
           if (indexSet.has(duty.validatorIndex)) {
             beaconCommitteeSubscriptions.push({
@@ -367,6 +378,12 @@ export class AttestationDutiesService {
     const epochDuties = this.dutiesByIndexByEpoch.get(dutyEpoch)?.dutiesByIndex;
 
     if (epochDuties) {
+      if (this.opts?.distributedAggregationSelection) {
+        await this.runDistributedAggregationSelectionTasks(Array.from(epochDuties.values()), dutyEpoch).catch((e) =>
+          this.logger.error("Error on attestation aggregation selection after duties reorg", logContext, e)
+        );
+      }
+
       for (const {duty, selectionProof} of epochDuties.values()) {
         beaconCommitteeSubscriptions.push({
           validatorIndex: duty.validatorIndex,
@@ -403,8 +420,8 @@ export class AttestationDutiesService {
     if (this.opts?.distributedAggregationSelection) {
       // Validator in distributed cluster only has a key share, not the full private key.
       // Passing a partial selection proof to `is_aggregator` would produce incorrect result.
-      // AttestationService will exchange partial for combined selection proofs retrieved from
-      // distributed validator middleware client and determine aggregators at beginning of every slot.
+      // Before subscribing to beacon committee subnets, aggregators are determined by exchanging
+      // partial for combined selection proofs retrieved from distributed validator middleware client.
       return {duty, selectionProof: null, partialSelectionProof: selectionProof};
     }
 
@@ -424,6 +441,49 @@ export class AttestationDutiesService {
         if (epoch + HISTORICAL_DUTIES_EPOCHS < currentEpoch) {
           byEpochMap.delete(epoch);
         }
+      }
+    }
+  }
+
+  /**
+   * Performs additional attestation aggregation tasks required if validator is part of distributed cluster
+   *
+   * 1. Exchange partial for combined selection proofs
+   * 2. Determine validators that should aggregate attestations
+   * 3. Mutate duty objects to set selection proofs for aggregators
+   */
+  private async runDistributedAggregationSelectionTasks(duties: AttDutyAndProof[], epoch: Epoch): Promise<void> {
+    const partialSelections: routes.validator.BeaconCommitteeSelection[] = duties.map(
+      ({duty, partialSelectionProof}) => ({
+        validatorIndex: duty.validatorIndex,
+        slot: duty.slot,
+        selectionProof: partialSelectionProof as BLSSignature,
+      })
+    );
+
+    this.logger.debug("Submitting partial beacon committee selection proofs", {epoch, count: partialSelections.length});
+
+    const res = await this.api.validator.submitBeaconCommitteeSelections({selections: partialSelections});
+
+    const combinedSelections = res.value();
+    this.logger.debug("Received combined beacon committee selection proofs", {epoch, count: combinedSelections.length});
+
+    for (const dutyAndProof of duties) {
+      const {slot, validatorIndex, committeeIndex, committeeLength} = dutyAndProof.duty;
+      const logCtxValidator = {slot, index: committeeIndex, validatorIndex};
+
+      const combinedSelection = combinedSelections.find((s) => s.validatorIndex === validatorIndex && s.slot === slot);
+
+      if (!combinedSelection) {
+        this.logger.warn("Did not receive combined beacon committee selection proof", logCtxValidator);
+        continue;
+      }
+
+      const isAggregator = isAggregatorFromCommitteeLength(committeeLength, combinedSelection.selectionProof);
+
+      if (isAggregator) {
+        // Update selection proof by mutating duty object
+        dutyAndProof.selectionProof = combinedSelection.selectionProof;
       }
     }
   }

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -1,7 +1,6 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {SecretKey} from "@chainsafe/blst";
 import {toHexString} from "@chainsafe/ssz";
-import {routes} from "@lodestar/api";
 import {ChainConfig, createChainForkConfig} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -63,7 +63,6 @@ describe("AttestationService", () => {
   const testContexts: [string, AttestationServiceOpts, Partial<ChainConfig>][] = [
     ["With default configuration", {}, {}],
     ["With default configuration post-electra", {}, electraConfig],
-    ["With distributed aggregation selection enabled", {distributedAggregationSelection: true}, {}],
   ];
 
   for (const [title, opts, chainConfig] of testContexts) {
@@ -105,8 +104,7 @@ describe("AttestationService", () => {
               validatorIndex: 0,
               pubkey: pubkeys[0],
             },
-            selectionProof: opts.distributedAggregationSelection ? null : ZERO_HASH,
-            partialSelectionProof: opts.distributedAggregationSelection ? ZERO_HASH : undefined,
+            selectionProof: ZERO_HASH,
           },
         ];
 
@@ -129,44 +127,12 @@ describe("AttestationService", () => {
         api.beacon.submitPoolAttestationsV2.mockResolvedValue(mockApiResponse({}));
         api.validator.publishAggregateAndProofsV2.mockResolvedValue(mockApiResponse({}));
 
-        if (opts.distributedAggregationSelection) {
-          // Mock distributed validator middleware client selections endpoint
-          // and return a selection proof that passes `is_aggregator` test
-          api.validator.submitBeaconCommitteeSelections.mockResolvedValue(
-            mockApiResponse({data: [{validatorIndex: 0, slot: 0, selectionProof: Buffer.alloc(1, 0x10)}]})
-          );
-          // Accept all subscriptions
-          api.validator.prepareBeaconCommitteeSubnet.mockResolvedValue(mockApiResponse({}));
-        }
-
         // Mock signing service
         validatorStore.signAttestation.mockResolvedValue(singleAttestation);
         validatorStore.signAggregateAndProof.mockResolvedValue(aggregateAndProof);
 
         // Trigger clock onSlot for slot 0
         await clock.tickSlotFns(0, controller.signal);
-
-        if (opts.distributedAggregationSelection) {
-          // Must submit partial beacon committee selection proof based on duty
-          const selection: routes.validator.BeaconCommitteeSelection = {
-            validatorIndex: 0,
-            slot: 0,
-            selectionProof: ZERO_HASH,
-          };
-          expect(api.validator.submitBeaconCommitteeSelections).toHaveBeenCalledOnce();
-          expect(api.validator.submitBeaconCommitteeSelections).toHaveBeenCalledWith({selections: [selection]});
-
-          // Must resubscribe validator as aggregator on beacon committee subnet
-          const subscription: routes.validator.BeaconCommitteeSubscription = {
-            validatorIndex: 0,
-            committeeIndex: 0,
-            committeesAtSlot: 120,
-            slot: 0,
-            isAggregator: true,
-          };
-          expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledOnce();
-          expect(api.validator.prepareBeaconCommitteeSubnet).toHaveBeenCalledWith({subscriptions: [subscription]});
-        }
 
         // Must submit the attestation received through produceAttestationData()
         expect(api.beacon.submitPoolAttestationsV2).toHaveBeenCalledOnce();


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/lodestar/issues/8606

**Description**

This updates our implementation to be compliant with latest spec https://github.com/ethereum/beacon-APIs/pull/368.

For sync committee aggregation selection (unchanged)
-  we call `submitSyncCommitteeSelections` at the start of the slot
-  the timeout is still based on `CONTRIBUTION_DUE_BPS` into the slot (8 seconds)
-  we call the endpoint for all duties of this slot
-  logic has been moved to duties service


For attestation aggregation selection
- we call `submitBeaconCommitteeSelections` at the start of the epoch for current and next epoch (2 separate calls)
- the timeout uses default which is based on `SLOT_DURATION_MS` (12 seconds)
- we only call `prepareBeaconCommitteeSubnet` once the above call either resolved or failed, this should be fine as it's not that time sensitive (one epoch lookahead)
- if duties are reorged, we will call `submitBeaconCommitteeSelections` with duties of affected epoch
- logic has been moved to duties service


Previous PR https://github.com/ChainSafe/lodestar/pull/5344