### PR TITLE
fix: use Buffer.alloc() with snappy-wasm

### DIFF
--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -104,7 +104,7 @@ export class DataTransformSnappy implements DataTransform {
     }
 
     // Only after sanity length checks, we can decompress the data
-    // using Buffer.allocUnsafe() caused huge MarkSweepCompact gc on the main thread of sas nodes
+    // Using Buffer.alloc() instead of Buffer.allocUnsafe() to mitigate high GC pressure observed in some environments
     const uncompressedData = Buffer.alloc(uncompressedDataLength);
     decoder.decompress_into(data, uncompressedData);
     return uncompressedData;
@@ -121,7 +121,7 @@ export class DataTransformSnappy implements DataTransform {
       throw Error(`ssz_snappy encoded data length ${data.length} > ${this.maxSizePerMessage}`);
     }
 
-    // using Buffer.allocUnsafe() caused huge MarkSweepCompact gc on the main thread of sas nodes
+    // Using Buffer.alloc() instead of Buffer.allocUnsafe() to mitigate high GC pressure observed in some environments
     const compressedData = Buffer.alloc(snappyWasm.max_compress_len(data.length));
     const compressedLen = encoder.compress_into(data, compressedData);
     return compressedData.subarray(0, compressedLen);

--- a/packages/beacon-node/src/network/gossip/encoding.ts
+++ b/packages/beacon-node/src/network/gossip/encoding.ts
@@ -104,7 +104,8 @@ export class DataTransformSnappy implements DataTransform {
     }
 
     // Only after sanity length checks, we can decompress the data
-    const uncompressedData = Buffer.allocUnsafe(uncompressedDataLength);
+    // using Buffer.allocUnsafe() caused huge MarkSweepCompact gc on the main thread of sas nodes
+    const uncompressedData = Buffer.alloc(uncompressedDataLength);
     decoder.decompress_into(data, uncompressedData);
     return uncompressedData;
   }
@@ -120,7 +121,8 @@ export class DataTransformSnappy implements DataTransform {
       throw Error(`ssz_snappy encoded data length ${data.length} > ${this.maxSizePerMessage}`);
     }
 
-    const compressedData = Buffer.allocUnsafe(snappyWasm.max_compress_len(data.length));
+    // using Buffer.allocUnsafe() caused huge MarkSweepCompact gc on the main thread of sas nodes
+    const compressedData = Buffer.alloc(snappyWasm.max_compress_len(data.length));
     const compressedLen = encoder.compress_into(data, compressedData);
     return compressedData.subarray(0, compressedLen);
   }

--- a/packages/beacon-node/test/perf/network/gossip/snappy.test.ts
+++ b/packages/beacon-node/test/perf/network/gossip/snappy.test.ts
@@ -57,7 +57,7 @@ describe("network / gossip / snappy", () => {
         runsFactor: RUNS_FACTOR,
         fn: () => {
           for (let i = 0; i < RUNS_FACTOR; i++) {
-            let out = Buffer.allocUnsafe(snappyWasm.max_compress_len(uncompressed.length));
+            let out = Buffer.alloc(snappyWasm.max_compress_len(uncompressed.length));
             const len = encoder.compress_into(uncompressed, out);
             out = out.subarray(0, len);
           }
@@ -108,7 +108,7 @@ describe("network / gossip / snappy", () => {
         runsFactor: RUNS_FACTOR,
         fn: () => {
           for (let i = 0; i < RUNS_FACTOR; i++) {
-            decoder.decompress_into(compressed, Buffer.allocUnsafe(snappyWasm.decompress_len(compressed)));
+            decoder.decompress_into(compressed, Buffer.alloc(snappyWasm.decompress_len(compressed)));
           }
         },
       });


### PR DESCRIPTION
**Motivation**

- high `MarkSweepCompact` gc on #8647
- the reason is the use of `Buffer.allocUnsafe()` as found in https://github.com/ChainSafe/lodestar/pull/8670#issuecomment-3615681274
- an alternative to #8670

**Description**

- use `@chainsafe/snappy-wasm` for all topics but with `Buffer.alloc()`
- this is deployed to `feat2`