### PR TITLE
chore: use index2pubkey of BeaconChain

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -143,6 +143,7 @@ export async function verifyBlocksInEpoch(
       // All signatures at once
       opts.skipVerifyBlockSignatures !== true
         ? verifyBlocksSignatures(
+            this.index2pubkey,
             this.bls,
             this.logger,
             this.metrics,

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
@@ -1,4 +1,4 @@
-import {CachedBeaconStateAllForks, getBlockSignatureSets} from "@lodestar/state-transition";
+import {CachedBeaconStateAllForks, Index2PubkeyCache, getBlockSignatureSets} from "@lodestar/state-transition";
 import {IndexedAttestation, SignedBeaconBlock} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
@@ -15,6 +15,7 @@ import {ImportBlockOpts} from "./types.js";
  * Since all data is known in advance all signatures are verified at once in parallel.
  */
 export async function verifyBlocksSignatures(
+  index2pubkey: Index2PubkeyCache,
   bls: IBlsVerifier,
   logger: Logger,
   metrics: Metrics | null,
@@ -38,7 +39,7 @@ export async function verifyBlocksSignatures(
       : //
         // Verify signatures per block to track which block is invalid
         bls.verifySignatureSets(
-          getBlockSignatureSets(preState0, block, indexedAttestationsByBlock[i], {
+          getBlockSignatureSets(index2pubkey, preState0, block, indexedAttestationsByBlock[i], {
             skipProposerSignature: opts.validProposerSignature,
           })
         );

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -757,7 +757,7 @@ export class BeaconChain implements IBeaconChain {
       RegenCaller.produceBlock
     );
     const proposerIndex = state.epochCtx.getBeaconProposer(slot);
-    const proposerPubKey = state.epochCtx.index2pubkey[proposerIndex].toBytes();
+    const proposerPubKey = this.index2pubkey[proposerIndex].toBytes();
 
     const {body, produceResult, executionPayloadValue, shouldOverrideBuilder} = await produceBlockBody.call(
       this,
@@ -1372,6 +1372,6 @@ export class BeaconChain implements IBeaconChain {
 
     preState = processSlots(preState, block.slot); // Dial preState's slot to block.slot
 
-    return computeSyncCommitteeRewards(block, preState.clone(), validatorIds);
+    return computeSyncCommitteeRewards(this.index2pubkey, block, preState.clone(), validatorIds);
   }
 }

--- a/packages/beacon-node/src/chain/rewards/syncCommitteeRewards.ts
+++ b/packages/beacon-node/src/chain/rewards/syncCommitteeRewards.ts
@@ -1,12 +1,13 @@
 import {routes} from "@lodestar/api";
 import {ForkName, SYNC_COMMITTEE_SIZE} from "@lodestar/params";
-import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "@lodestar/state-transition";
+import {CachedBeaconStateAllForks, CachedBeaconStateAltair, Index2PubkeyCache} from "@lodestar/state-transition";
 import {BeaconBlock, ValidatorIndex, altair} from "@lodestar/types";
 
 export type SyncCommitteeRewards = routes.beacon.SyncCommitteeRewards;
 type BalanceRecord = {val: number}; // Use val for convenient way to increment/decrement balance
 
 export async function computeSyncCommitteeRewards(
+  index2pubkey: Index2PubkeyCache,
   block: BeaconBlock,
   preState: CachedBeaconStateAllForks,
   validatorIds: (ValidatorIndex | string)[] = []
@@ -18,7 +19,6 @@ export async function computeSyncCommitteeRewards(
 
   const altairBlock = block as altair.BeaconBlock;
   const preStateAltair = preState as CachedBeaconStateAltair;
-  const {index2pubkey} = preStateAltair.epochCtx;
 
   // Bound syncCommitteeValidatorIndices in case it goes beyond SYNC_COMMITTEE_SIZE just to be safe
   const syncCommitteeValidatorIndices = preStateAltair.epochCtx.currentSyncCommitteeIndexed.validatorIndices.slice(

--- a/packages/beacon-node/src/chain/validation/attesterSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/attesterSlashing.ts
@@ -43,7 +43,7 @@ export async function validateAttesterSlashing(
   // [REJECT] All of the conditions within process_attester_slashing pass validation.
   try {
     // verifySignature = false, verified in batch below
-    assertValidAttesterSlashing(state, attesterSlashing, false);
+    assertValidAttesterSlashing(chain.index2pubkey, state, attesterSlashing, false);
   } catch (e) {
     throw new AttesterSlashingError(GossipAction.REJECT, {
       code: AttesterSlashingErrorCode.INVALID,
@@ -51,7 +51,7 @@ export async function validateAttesterSlashing(
     });
   }
 
-  const signatureSets = getAttesterSlashingSignatureSets(state, attesterSlashing);
+  const signatureSets = getAttesterSlashingSignatureSets(chain.index2pubkey, state, attesterSlashing);
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true, priority: prioritizeBls}))) {
     throw new AttesterSlashingError(GossipAction.REJECT, {
       code: AttesterSlashingErrorCode.INVALID,

--- a/packages/beacon-node/src/chain/validation/blobSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -137,7 +137,11 @@ export async function validateGossipBlobSidecar(
   // [REJECT] The proposer signature, signed_beacon_block.signature, is valid with respect to the proposer_index pubkey.
   const signature = blobSidecar.signedBlockHeader.signature;
   if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blobSlot, blockHex, signature)) {
-    const signatureSet = getBlockHeaderProposerSignatureSetByParentStateSlot(blockState, blobSidecar.signedBlockHeader);
+    const signatureSet = getBlockHeaderProposerSignatureSetByParentStateSlot(
+      chain.index2pubkey,
+      blockState,
+      blobSidecar.signedBlockHeader
+    );
     // Don't batch so verification is not delayed
     if (!(await chain.bls.verifySignatureSets([signatureSet], {verifyOnMainThread: true}))) {
       throw new BlobSidecarGossipError(GossipAction.REJECT, {
@@ -240,7 +244,11 @@ export async function validateBlockBlobSidecars(
     const signature = firstSidecarSignedBlockHeader.signature;
     if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockSlot, blockRootHex, signature)) {
       const headState = await chain.getHeadState();
-      const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(headState, firstSidecarSignedBlockHeader);
+      const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(
+        chain.index2pubkey,
+        headState,
+        firstSidecarSignedBlockHeader
+      );
 
       if (
         !(await chain.bls.verifySignatureSets([signatureSet], {

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -154,7 +154,7 @@ export async function validateGossipBlock(
 
   // [REJECT] The proposer signature, signed_beacon_block.signature, is valid with respect to the proposer_index pubkey.
   if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockSlot, blockRoot, signedBlock.signature)) {
-    const signatureSet = getBlockProposerSignatureSet(blockState, signedBlock);
+    const signatureSet = getBlockProposerSignatureSet(chain.index2pubkey, blockState, signedBlock);
     // Don't batch so verification is not delayed
     if (!(await chain.bls.verifySignatureSets([signatureSet], {verifyOnMainThread: true}))) {
       throw new BlockGossipError(GossipAction.REJECT, {

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -135,6 +135,7 @@ export async function validateGossipDataColumnSidecar(
   const signature = dataColumnSidecar.signedBlockHeader.signature;
   if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockHeader.slot, blockRootHex, signature)) {
     const signatureSet = getBlockHeaderProposerSignatureSetByParentStateSlot(
+      chain.index2pubkey,
       blockState,
       dataColumnSidecar.signedBlockHeader
     );
@@ -336,7 +337,11 @@ export async function validateBlockDataColumnSidecars(
     const signature = firstSidecarSignedBlockHeader.signature;
     if (!chain.seenBlockInputCache.isVerifiedProposerSignature(slot, rootHex, signature)) {
       const headState = await chain.getHeadState();
-      const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(headState, firstSidecarSignedBlockHeader);
+      const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(
+        chain.index2pubkey,
+        headState,
+        firstSidecarSignedBlockHeader
+      );
 
       if (
         !(await chain.bls.verifySignatureSets([signatureSet], {

--- a/packages/beacon-node/src/chain/validation/proposerSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/proposerSlashing.ts
@@ -44,7 +44,7 @@ async function validateProposerSlashing(
     });
   }
 
-  const signatureSets = getProposerSlashingSignatureSets(state, proposerSlashing);
+  const signatureSets = getProposerSlashingSignatureSets(chain.index2pubkey, state, proposerSlashing);
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true, priority: prioritizeBls}))) {
     throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID,

--- a/packages/beacon-node/src/chain/validation/signatureSets/contributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/contributionAndProof.ts
@@ -2,16 +2,17 @@ import {DOMAIN_CONTRIBUTION_AND_PROOF} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   ISignatureSet,
+  Index2PubkeyCache,
   SignatureSetType,
   computeSigningRoot,
 } from "@lodestar/state-transition";
 import {altair, ssz} from "@lodestar/types";
 
 export function getContributionAndProofSignatureSet(
+  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   signedContributionAndProof: altair.SignedContributionAndProof
 ): ISignatureSet {
-  const {epochCtx} = state;
   const domain = state.config.getDomain(
     state.slot,
     DOMAIN_CONTRIBUTION_AND_PROOF,
@@ -20,7 +21,7 @@ export function getContributionAndProofSignatureSet(
   const signingData = signedContributionAndProof.message;
   return {
     type: SignatureSetType.single,
-    pubkey: epochCtx.index2pubkey[signedContributionAndProof.message.aggregatorIndex],
+    pubkey: index2pubkey[signedContributionAndProof.message.aggregatorIndex],
     signingRoot: computeSigningRoot(ssz.altair.ContributionAndProof, signingData, domain),
     signature: signedContributionAndProof.signature,
   };

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommittee.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommittee.ts
@@ -2,12 +2,14 @@ import {DOMAIN_SYNC_COMMITTEE} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   ISignatureSet,
+  Index2PubkeyCache,
   SignatureSetType,
   computeSigningRoot,
 } from "@lodestar/state-transition";
 import {altair, ssz} from "@lodestar/types";
 
 export function getSyncCommitteeSignatureSet(
+  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   syncCommittee: altair.SyncCommitteeMessage
 ): ISignatureSet {
@@ -15,7 +17,7 @@ export function getSyncCommitteeSignatureSet(
 
   return {
     type: SignatureSetType.single,
-    pubkey: state.epochCtx.index2pubkey[syncCommittee.validatorIndex],
+    pubkey: index2pubkey[syncCommittee.validatorIndex],
     signingRoot: computeSigningRoot(ssz.Root, syncCommittee.beaconBlockRoot, domain),
     signature: syncCommittee.signature,
   };

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
@@ -2,16 +2,18 @@ import {DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   ISignatureSet,
+  Index2PubkeyCache,
   SignatureSetType,
   computeSigningRoot,
 } from "@lodestar/state-transition";
 import {altair, ssz} from "@lodestar/types";
 
 export function getSyncCommitteeSelectionProofSignatureSet(
+  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   contributionAndProof: altair.ContributionAndProof
 ): ISignatureSet {
-  const {epochCtx, config} = state;
+  const {config} = state;
   const slot = contributionAndProof.contribution.slot;
   const domain = config.getDomain(state.slot, DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF, slot);
   const signingData: altair.SyncAggregatorSelectionData = {
@@ -20,7 +22,7 @@ export function getSyncCommitteeSelectionProofSignatureSet(
   };
   return {
     type: SignatureSetType.single,
-    pubkey: epochCtx.index2pubkey[contributionAndProof.aggregatorIndex],
+    pubkey: index2pubkey[contributionAndProof.aggregatorIndex],
     signingRoot: computeSigningRoot(ssz.altair.SyncAggregatorSelectionData, signingData, domain),
     signature: contributionAndProof.selectionProof,
   };

--- a/packages/beacon-node/src/chain/validation/syncCommittee.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommittee.ts
@@ -89,7 +89,7 @@ async function validateSyncCommitteeSigOnly(
   syncCommittee: altair.SyncCommitteeMessage,
   prioritizeBls = false
 ): Promise<void> {
-  const signatureSet = getSyncCommitteeSignatureSet(headState, syncCommittee);
+  const signatureSet = getSyncCommitteeSignatureSet(chain.index2pubkey, headState, syncCommittee);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true, priority: prioritizeBls}))) {
     throw new SyncCommitteeError(GossipAction.REJECT, {
       code: SyncCommitteeErrorCode.INVALID_SIGNATURE,

--- a/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -21,6 +21,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   const contributionAndProof = signedContributionAndProof.message;
   const {contribution, aggregatorIndex} = contributionAndProof;
   const {subcommitteeIndex, slot} = contribution;
+  const {index2pubkey} = chain;
 
   const headState = chain.getHeadState();
   validateGossipSyncCommitteeExceptSig(chain, headState, subcommitteeIndex, {
@@ -73,16 +74,14 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   // i.e. state.validators[contribution_and_proof.aggregator_index].pubkey in get_sync_subcommittee_pubkeys(state, contribution.subcommittee_index).
   // > Checked in validateGossipSyncCommitteeExceptSig()
 
-  const participantPubkeys = syncCommitteeParticipantIndices.map(
-    (validatorIndex) => headState.epochCtx.index2pubkey[validatorIndex]
-  );
+  const participantPubkeys = syncCommitteeParticipantIndices.map((validatorIndex) => index2pubkey[validatorIndex]);
   const signatureSets = [
     // [REJECT] The contribution_and_proof.selection_proof is a valid signature of the SyncAggregatorSelectionData
     // derived from the contribution by the validator with index contribution_and_proof.aggregator_index.
-    getSyncCommitteeSelectionProofSignatureSet(headState, contributionAndProof),
+    getSyncCommitteeSelectionProofSignatureSet(index2pubkey, headState, contributionAndProof),
 
     // [REJECT] The aggregator signature, signed_contribution_and_proof.signature, is valid.
-    getContributionAndProofSignatureSet(headState, signedContributionAndProof),
+    getContributionAndProofSignatureSet(index2pubkey, headState, signedContributionAndProof),
 
     // [REJECT] The aggregate signature is valid for the message beacon_block_root and aggregate pubkey derived from
     // the participation info in aggregation_bits for the subcommittee specified by the contribution.subcommittee_index.

--- a/packages/beacon-node/src/chain/validation/voluntaryExit.ts
+++ b/packages/beacon-node/src/chain/validation/voluntaryExit.ts
@@ -59,7 +59,7 @@ async function validateVoluntaryExit(
     });
   }
 
-  const signatureSet = getVoluntaryExitSignatureSet(state, voluntaryExit);
+  const signatureSet = getVoluntaryExitSignatureSet(chain.index2pubkey, state, voluntaryExit);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true, priority: prioritizeBls}))) {
     throw new VoluntaryExitError(GossipAction.REJECT, {
       code: VoluntaryExitErrorCode.INVALID_SIGNATURE,

--- a/packages/beacon-node/src/sync/backfill/backfill.ts
+++ b/packages/beacon-node/src/sync/backfill/backfill.ts
@@ -750,7 +750,9 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
 
     // GENESIS_SLOT doesn't has valid signature
     if (anchorBlock.message.slot === GENESIS_SLOT) return;
-    await verifyBlockProposerSignature(this.chain.bls, this.chain.getHeadState(), [anchorBlock]);
+    await verifyBlockProposerSignature(this.chain.index2pubkey, this.chain.bls, this.chain.getHeadState(), [
+      anchorBlock,
+    ]);
 
     // We can write to the disk if this is ahead of prevFinalizedCheckpointBlock otherwise
     // we will need to go make checks on the top of sync loop before writing as it might
@@ -815,7 +817,12 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
 
     // If any of the block's proposer signature fail, we can't trust this peer at all
     if (verifiedBlocks.length > 0) {
-      await verifyBlockProposerSignature(this.chain.bls, this.chain.getHeadState(), verifiedBlocks);
+      await verifyBlockProposerSignature(
+        this.chain.index2pubkey,
+        this.chain.bls,
+        this.chain.getHeadState(),
+        verifiedBlocks
+      );
 
       // This is bad, like super bad. Abort the backfill
       if (!nextAnchor)

--- a/packages/beacon-node/src/sync/backfill/verify.ts
+++ b/packages/beacon-node/src/sync/backfill/verify.ts
@@ -1,6 +1,11 @@
 import {BeaconConfig} from "@lodestar/config";
 import {GENESIS_SLOT} from "@lodestar/params";
-import {CachedBeaconStateAllForks, ISignatureSet, getBlockProposerSignatureSet} from "@lodestar/state-transition";
+import {
+  CachedBeaconStateAllForks,
+  ISignatureSet,
+  Index2PubkeyCache,
+  getBlockProposerSignatureSet,
+} from "@lodestar/state-transition";
 import {Root, SignedBeaconBlock, Slot, ssz} from "@lodestar/types";
 import {IBlsVerifier} from "../../chain/bls/index.js";
 import {BackfillSyncError, BackfillSyncErrorCode} from "./errors.js";
@@ -41,6 +46,7 @@ export function verifyBlockSequence(
 }
 
 export async function verifyBlockProposerSignature(
+  index2pubkey: Index2PubkeyCache,
   bls: IBlsVerifier,
   state: CachedBeaconStateAllForks,
   blocks: SignedBeaconBlock[]
@@ -48,7 +54,7 @@ export async function verifyBlockProposerSignature(
   if (blocks.length === 1 && blocks[0].message.slot === GENESIS_SLOT) return;
   const signatures = blocks.reduce((sigs: ISignatureSet[], block) => {
     // genesis block doesn't have valid signature
-    if (block.message.slot !== GENESIS_SLOT) sigs.push(getBlockProposerSignatureSet(state, block));
+    if (block.message.slot !== GENESIS_SLOT) sigs.push(getBlockProposerSignatureSet(index2pubkey, state, block));
     return sigs;
   }, []);
 

--- a/packages/beacon-node/test/fixtures/capella.ts
+++ b/packages/beacon-node/test/fixtures/capella.ts
@@ -1,7 +1,8 @@
-import {CachedBeaconStateAltair} from "@lodestar/state-transition";
+import {CachedBeaconStateAltair, Index2PubkeyCache} from "@lodestar/state-transition";
 import {capella} from "@lodestar/types";
 
 export function generateBlsToExecutionChanges(
+  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAltair,
   count: number
 ): capella.SignedBLSToExecutionChange[] {
@@ -10,7 +11,7 @@ export function generateBlsToExecutionChanges(
   for (const validatorIndex of state.epochCtx.proposers) {
     result.push({
       message: {
-        fromBlsPubkey: state.epochCtx.index2pubkey[validatorIndex].toBytes(),
+        fromBlsPubkey: index2pubkey[validatorIndex].toBytes(),
         toExecutionAddress: Buffer.alloc(20),
         validatorIndex,
       },

--- a/packages/beacon-node/test/perf/chain/opPools/opPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/opPool.test.ts
@@ -6,7 +6,7 @@ import {
   MAX_PROPOSER_SLASHINGS,
   MAX_VOLUNTARY_EXITS,
 } from "@lodestar/params";
-import {CachedBeaconStateAltair} from "@lodestar/state-transition";
+import {CachedBeaconStateAltair, Index2PubkeyCache} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {generatePerfTestCachedStateAltair} from "../../../../../state-transition/test/perf/util.js";
 import {BlockType} from "../../../../src/chain/interface.js";
@@ -35,7 +35,8 @@ describe("opPool", () => {
       fillAttesterSlashing(pool, originalState, MAX_ATTESTER_SLASHINGS);
       fillProposerSlashing(pool, originalState, MAX_PROPOSER_SLASHINGS);
       fillVoluntaryExits(pool, originalState, MAX_VOLUNTARY_EXITS);
-      fillBlsToExecutionChanges(pool, originalState, MAX_BLS_TO_EXECUTION_CHANGES);
+      // TODO: feed index2pubkey separately instead of getting from originalState
+      fillBlsToExecutionChanges(originalState.epochCtx.index2pubkey, pool, originalState, MAX_BLS_TO_EXECUTION_CHANGES);
 
       return pool;
     },
@@ -53,7 +54,8 @@ describe("opPool", () => {
       fillAttesterSlashing(pool, originalState, maxItemsInPool);
       fillProposerSlashing(pool, originalState, maxItemsInPool);
       fillVoluntaryExits(pool, originalState, maxItemsInPool);
-      fillBlsToExecutionChanges(pool, originalState, maxItemsInPool);
+      // TODO: feed index2pubkey separately instead of getting from originalState
+      fillBlsToExecutionChanges(originalState.epochCtx.index2pubkey, pool, originalState, maxItemsInPool);
 
       return pool;
     },
@@ -99,8 +101,13 @@ function fillVoluntaryExits(pool: OpPool, state: CachedBeaconStateAltair, count:
 
 // This does not set the `withdrawalCredentials` for the validator
 // So it will be in the pool but not returned from `getSlashingsAndExits`
-function fillBlsToExecutionChanges(pool: OpPool, state: CachedBeaconStateAltair, count: number): OpPool {
-  for (const blsToExecution of generateBlsToExecutionChanges(state, count)) {
+function fillBlsToExecutionChanges(
+  index2pubkey: Index2PubkeyCache,
+  pool: OpPool,
+  state: CachedBeaconStateAltair,
+  count: number
+): OpPool {
+  for (const blsToExecution of generateBlsToExecutionChanges(index2pubkey, state, count)) {
     pool.insertBlsToExecutionChange(blsToExecution);
   }
 

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -1,5 +1,6 @@
 import {ForkSeq, MAX_COMMITTEES_PER_SLOT, MAX_VALIDATORS_PER_COMMITTEE} from "@lodestar/params";
 import {IndexedAttestation, IndexedAttestationBigint} from "@lodestar/types";
+import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {getIndexedAttestationBigintSignatureSet, getIndexedAttestationSignatureSet} from "../signatureSets/index.js";
 import {CachedBeaconStateAllForks} from "../types.js";
 import {verifySignatureSet} from "../util/index.js";
@@ -8,6 +9,7 @@ import {verifySignatureSet} from "../util/index.js";
  * Check if `indexedAttestation` has sorted and unique indices and a valid aggregate signature.
  */
 export function isValidIndexedAttestation(
+  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   indexedAttestation: IndexedAttestation,
   verifySignature: boolean
@@ -17,12 +19,13 @@ export function isValidIndexedAttestation(
   }
 
   if (verifySignature) {
-    return verifySignatureSet(getIndexedAttestationSignatureSet(state, indexedAttestation));
+    return verifySignatureSet(getIndexedAttestationSignatureSet(index2pubkey, state, indexedAttestation));
   }
   return true;
 }
 
 export function isValidIndexedAttestationBigint(
+  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   indexedAttestation: IndexedAttestationBigint,
   verifySignature: boolean
@@ -32,7 +35,7 @@ export function isValidIndexedAttestationBigint(
   }
 
   if (verifySignature) {
-    return verifySignatureSet(getIndexedAttestationBigintSignatureSet(state, indexedAttestation));
+    return verifySignatureSet(getIndexedAttestationBigintSignatureSet(index2pubkey, state, indexedAttestation));
   }
   return true;
 }

--- a/packages/state-transition/src/block/processAttestationPhase0.ts
+++ b/packages/state-transition/src/block/processAttestationPhase0.ts
@@ -50,7 +50,14 @@ export function processAttestationPhase0(
     state.previousEpochAttestations.push(pendingAttestation);
   }
 
-  if (!isValidIndexedAttestation(state, epochCtx.getIndexedAttestation(ForkSeq.phase0, attestation), verifySignature)) {
+  if (
+    !isValidIndexedAttestation(
+      epochCtx.index2pubkey,
+      state,
+      epochCtx.getIndexedAttestation(ForkSeq.phase0, attestation),
+      verifySignature
+    )
+  ) {
     throw new Error("Attestation is not valid");
   }
 }

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -64,7 +64,7 @@ export function processAttestationsAltair(
     // TODO: Why should we verify an indexed attestation that we just created? If it's just for the signature
     // we can verify only that and nothing else.
     if (verifySignature) {
-      const sigSet = getAttestationWithIndicesSignatureSet(state, attestation, attestingIndices);
+      const sigSet = getAttestationWithIndicesSignatureSet(epochCtx.index2pubkey, state, attestation, attestingIndices);
       if (!verifySignatureSet(sigSet)) {
         throw new Error("Attestation signature is not valid");
       }

--- a/packages/state-transition/src/block/processAttesterSlashing.ts
+++ b/packages/state-transition/src/block/processAttesterSlashing.ts
@@ -1,5 +1,6 @@
 import {ForkSeq} from "@lodestar/params";
 import {AttesterSlashing} from "@lodestar/types";
+import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {CachedBeaconStateAllForks} from "../types.js";
 import {getAttesterSlashableIndices, isSlashableAttestationData, isSlashableValidator} from "../util/index.js";
 import {isValidIndexedAttestationBigint} from "./isValidIndexedAttestation.js";
@@ -17,7 +18,8 @@ export function processAttesterSlashing(
   attesterSlashing: AttesterSlashing,
   verifySignatures = true
 ): void {
-  assertValidAttesterSlashing(state, attesterSlashing, verifySignatures);
+  const {epochCtx} = state;
+  assertValidAttesterSlashing(epochCtx.index2pubkey, state, attesterSlashing, verifySignatures);
 
   const intersectingIndices = getAttesterSlashableIndices(attesterSlashing);
 
@@ -25,7 +27,7 @@ export function processAttesterSlashing(
   const validators = state.validators; // Get the validators sub tree once for all indices
   // Spec requires to sort indexes beforehand
   for (const index of intersectingIndices.sort((a, b) => a - b)) {
-    if (isSlashableValidator(validators.getReadonly(index), state.epochCtx.epoch)) {
+    if (isSlashableValidator(validators.getReadonly(index), epochCtx.epoch)) {
       slashValidator(fork, state, index);
       slashedAny = true;
     }
@@ -37,6 +39,7 @@ export function processAttesterSlashing(
 }
 
 export function assertValidAttesterSlashing(
+  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   attesterSlashing: AttesterSlashing,
   verifySignatures = true
@@ -52,7 +55,7 @@ export function assertValidAttesterSlashing(
   // be higher than the clock and the slashing would still be valid. Same applies to attestation data index, which
   // can be any arbitrary value. Must use bigint variants to hash correctly to all possible values
   for (const [i, attestation] of [attestation1, attestation2].entries()) {
-    if (!isValidIndexedAttestationBigint(state, attestation, verifySignatures)) {
+    if (!isValidIndexedAttestationBigint(index2pubkey, state, attestation, verifySignatures)) {
       throw new Error(`AttesterSlashing attestation${i} is invalid`);
     }
   }

--- a/packages/state-transition/src/block/processProposerSlashing.ts
+++ b/packages/state-transition/src/block/processProposerSlashing.ts
@@ -77,7 +77,7 @@ export function assertValidProposerSlashing(
 
   // verify signatures
   if (verifySignatures) {
-    const signatureSets = getProposerSlashingSignatureSets(state, proposerSlashing);
+    const signatureSets = getProposerSlashingSignatureSets(state.epochCtx.index2pubkey, state, proposerSlashing);
     for (let i = 0; i < signatureSets.length; i++) {
       if (!verifySignatureSet(signatureSets[i])) {
         throw new Error(`ProposerSlashing header${i + 1} signature invalid`);

--- a/packages/state-transition/src/block/processRandao.ts
+++ b/packages/state-transition/src/block/processRandao.ts
@@ -17,7 +17,7 @@ export function processRandao(state: CachedBeaconStateAllForks, block: BeaconBlo
   const randaoReveal = block.body.randaoReveal;
 
   // verify RANDAO reveal
-  if (verifySignature && !verifyRandaoSignature(state, block)) {
+  if (verifySignature && !verifyRandaoSignature(epochCtx.index2pubkey, state, block)) {
     throw new Error("RANDAO reveal is an invalid signature");
   }
 

--- a/packages/state-transition/src/block/processVoluntaryExit.ts
+++ b/packages/state-transition/src/block/processVoluntaryExit.ts
@@ -74,7 +74,7 @@ export function getVoluntaryExitValidity(
     return VoluntaryExitValidity.pendingWithdrawals;
   }
 
-  if (verifySignature && !verifyVoluntaryExitSignature(state, signedVoluntaryExit)) {
+  if (verifySignature && !verifyVoluntaryExitSignature(epochCtx.index2pubkey, state, signedVoluntaryExit)) {
     return VoluntaryExitValidity.invalidSignature;
   }
 

--- a/packages/state-transition/src/signatureSets/proposerSlashings.ts
+++ b/packages/state-transition/src/signatureSets/proposerSlashings.ts
@@ -1,5 +1,6 @@
 import {DOMAIN_BEACON_PROPOSER} from "@lodestar/params";
 import {SignedBeaconBlock, phase0, ssz} from "@lodestar/types";
+import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {CachedBeaconStateAllForks} from "../types.js";
 import {ISignatureSet, SignatureSetType, computeSigningRoot} from "../util/index.js";
 
@@ -7,11 +8,11 @@ import {ISignatureSet, SignatureSetType, computeSigningRoot} from "../util/index
  * Extract signatures to allow validating all block signatures at once
  */
 export function getProposerSlashingSignatureSets(
+  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   proposerSlashing: phase0.ProposerSlashing
 ): ISignatureSet[] {
-  const {epochCtx} = state;
-  const pubkey = epochCtx.index2pubkey[proposerSlashing.signedHeader1.message.proposerIndex];
+  const pubkey = index2pubkey[proposerSlashing.signedHeader1.message.proposerIndex];
 
   // In state transition, ProposerSlashing headers are only partially validated. Their slot could be higher than the
   // clock and the slashing would still be valid. Must use bigint variants to hash correctly to all possible values
@@ -32,10 +33,11 @@ export function getProposerSlashingSignatureSets(
 }
 
 export function getProposerSlashingsSignatureSets(
+  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   signedBlock: SignedBeaconBlock
 ): ISignatureSet[] {
   return signedBlock.message.body.proposerSlashings.flatMap((proposerSlashing) =>
-    getProposerSlashingSignatureSets(state, proposerSlashing)
+    getProposerSlashingSignatureSets(index2pubkey, state, proposerSlashing)
   );
 }

--- a/packages/state-transition/src/signatureSets/randao.ts
+++ b/packages/state-transition/src/signatureSets/randao.ts
@@ -1,5 +1,6 @@
 import {DOMAIN_RANDAO} from "@lodestar/params";
 import {BeaconBlock, ssz} from "@lodestar/types";
+import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {CachedBeaconStateAllForks} from "../types.js";
 import {
   ISignatureSet,
@@ -9,22 +10,29 @@ import {
   verifySignatureSet,
 } from "../util/index.js";
 
-export function verifyRandaoSignature(state: CachedBeaconStateAllForks, block: BeaconBlock): boolean {
-  return verifySignatureSet(getRandaoRevealSignatureSet(state, block));
+export function verifyRandaoSignature(
+  index2pubkey: Index2PubkeyCache,
+  state: CachedBeaconStateAllForks,
+  block: BeaconBlock
+): boolean {
+  return verifySignatureSet(getRandaoRevealSignatureSet(index2pubkey, state, block));
 }
 
 /**
  * Extract signatures to allow validating all block signatures at once
  */
-export function getRandaoRevealSignatureSet(state: CachedBeaconStateAllForks, block: BeaconBlock): ISignatureSet {
-  const {epochCtx} = state;
+export function getRandaoRevealSignatureSet(
+  index2pubkey: Index2PubkeyCache,
+  state: CachedBeaconStateAllForks,
+  block: BeaconBlock
+): ISignatureSet {
   // should not get epoch from epochCtx
   const epoch = computeEpochAtSlot(block.slot);
   const domain = state.config.getDomain(state.slot, DOMAIN_RANDAO, block.slot);
 
   return {
     type: SignatureSetType.single,
-    pubkey: epochCtx.index2pubkey[block.proposerIndex],
+    pubkey: index2pubkey[block.proposerIndex],
     signingRoot: computeSigningRoot(ssz.Epoch, epoch, domain),
     signature: block.body.randaoReveal,
   };

--- a/packages/state-transition/src/signatureSets/voluntaryExits.ts
+++ b/packages/state-transition/src/signatureSets/voluntaryExits.ts
@@ -1,4 +1,5 @@
 import {SignedBeaconBlock, phase0, ssz} from "@lodestar/types";
+import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {CachedBeaconStateAllForks} from "../types.js";
 import {
   ISignatureSet,
@@ -9,36 +10,38 @@ import {
 } from "../util/index.js";
 
 export function verifyVoluntaryExitSignature(
+  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   signedVoluntaryExit: phase0.SignedVoluntaryExit
 ): boolean {
-  return verifySignatureSet(getVoluntaryExitSignatureSet(state, signedVoluntaryExit));
+  return verifySignatureSet(getVoluntaryExitSignatureSet(index2pubkey, state, signedVoluntaryExit));
 }
 
 /**
  * Extract signatures to allow validating all block signatures at once
  */
 export function getVoluntaryExitSignatureSet(
+  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   signedVoluntaryExit: phase0.SignedVoluntaryExit
 ): ISignatureSet {
-  const {epochCtx} = state;
   const slot = computeStartSlotAtEpoch(signedVoluntaryExit.message.epoch);
   const domain = state.config.getDomainForVoluntaryExit(state.slot, slot);
 
   return {
     type: SignatureSetType.single,
-    pubkey: epochCtx.index2pubkey[signedVoluntaryExit.message.validatorIndex],
+    pubkey: index2pubkey[signedVoluntaryExit.message.validatorIndex],
     signingRoot: computeSigningRoot(ssz.phase0.VoluntaryExit, signedVoluntaryExit.message, domain),
     signature: signedVoluntaryExit.signature,
   };
 }
 
 export function getVoluntaryExitsSignatureSets(
+  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   signedBlock: SignedBeaconBlock
 ): ISignatureSet[] {
   return signedBlock.message.body.voluntaryExits.map((voluntaryExit) =>
-    getVoluntaryExitSignatureSet(state, voluntaryExit)
+    getVoluntaryExitSignatureSet(index2pubkey, state, voluntaryExit)
   );
 }

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -111,7 +111,7 @@ export function stateTransition(
   postState = processSlotsWithTransientCache(postState, blockSlot, options, {metrics, validatorMonitor});
 
   // Verify proposer signature only
-  if (verifyProposer && !verifyProposerSignature(postState, signedBlock)) {
+  if (verifyProposer && !verifyProposerSignature(postState.epochCtx.index2pubkey, postState, signedBlock)) {
     throw new Error("Invalid block signature");
   }
 

--- a/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
+++ b/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
@@ -45,6 +45,8 @@ describe("validate indexed attestation", () => {
       data: attestationData,
       signature: EMPTY_SIGNATURE,
     };
-    expect(isValidIndexedAttestation(state, indexedAttestation, false)).toBe(expectedValue);
+    expect(isValidIndexedAttestation(state.epochCtx.index2pubkey, state, indexedAttestation, false)).toBe(
+      expectedValue
+    );
   });
 });

--- a/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -70,7 +70,7 @@ describe("signatureSets", () => {
       state.epochCtx.getIndexedAttestation(fork, attestation)
     );
 
-    const signatureSets = getBlockSignatureSets(state, signedBlock, indexedAttestations);
+    const signatureSets = getBlockSignatureSets(state.epochCtx.index2pubkey, state, signedBlock, indexedAttestations);
     expect(signatureSets.length).toBe(
       // block signature
       1 +


### PR DESCRIPTION
**Motivation**

- once we have `state-transition-z`, we're not able to get `index2pubkey` from a light view of BeaconState in beacon-node

**Description**

- in `beacon-node`, use `index2pubkey` of BeaconChain instead as a preparation for working with `state-transition-z`
- it's ok to use `state.epochCtx.index2pubkey` in `state-transition` since it can access the full state there

part of #8652