### PR TITLE
chore: use github runners for publish workflow

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -15,7 +15,8 @@ permissions:
 jobs:
   npm:
     name: Publish to NPM Registry
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    # To support npm provenance we must use github-hosted runners
+    runs-on: ubuntu-latest
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v6

--- a/.github/workflows/publish-nextfork.yml
+++ b/.github/workflows/publish-nextfork.yml
@@ -18,7 +18,8 @@ env:
 jobs:
   npm:
     name: Publish to NPM Registry
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    # To support npm provenance we must use github-hosted runners
+    runs-on: ubuntu-latest
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@v6

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -15,7 +15,8 @@ permissions:
 jobs:
   tag:
     name: Check tag
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    # To support npm provenance we must use github-hosted runners
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -15,7 +15,8 @@ permissions:
 jobs:
   tag:
     name: Check tag
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    # To support npm provenance we must use github-hosted runners
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
**Motivation**

Provide npm provenance for published packages.

https://docs.npmjs.com/generating-provenance-statements

**Description**

- Use github runners for publish workflows to cover the error. 

```
Error verifying sigstore provenance bundle: Unsupported GitHub Actions runner environment: "self-hosted". Only "github-hosted" runners are supported when publishing with provenance.
```