### PR TITLE
chore: use pubkey2index from BeaconChain

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -95,7 +95,7 @@ export function getBeaconStateApi({
       const {state, executionOptimistic, finalized} = await getState(stateId);
       const currentEpoch = getCurrentEpoch(state);
       const {validators, balances} = state; // Get the validators sub tree once for all the loop
-      const {pubkey2index} = chain.getHeadState().epochCtx;
+      const {pubkey2index} = chain;
 
       const validatorResponses: routes.beacon.ValidatorResponse[] = [];
       if (validatorIds.length) {
@@ -154,7 +154,7 @@ export function getBeaconStateApi({
 
     async postStateValidatorIdentities({stateId, validatorIds = []}) {
       const {state, executionOptimistic, finalized} = await getState(stateId);
-      const {pubkey2index} = chain.getHeadState().epochCtx;
+      const {pubkey2index} = chain;
 
       let validatorIdentities: routes.beacon.ValidatorIdentities;
 
@@ -187,7 +187,7 @@ export function getBeaconStateApi({
 
     async getStateValidator({stateId, validatorId}) {
       const {state, executionOptimistic, finalized} = await getState(stateId);
-      const {pubkey2index} = chain.getHeadState().epochCtx;
+      const {pubkey2index} = chain;
 
       const resp = getStateValidatorIndex(validatorId, state, pubkey2index);
       if (!resp.valid) {
@@ -212,10 +212,9 @@ export function getBeaconStateApi({
       if (validatorIds.length) {
         assertUniqueItems(validatorIds, "Duplicate validator IDs provided");
 
-        const headState = chain.getHeadState();
         const balances: routes.beacon.ValidatorBalance[] = [];
         for (const id of validatorIds) {
-          const resp = getStateValidatorIndex(id, state, headState.epochCtx.pubkey2index);
+          const resp = getStateValidatorIndex(id, state, chain.pubkey2index);
 
           if (resp.valid) {
             balances.push({

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1511,7 +1511,7 @@ export function getValidatorApi(
 
       const filteredRegistrations = registrations.filter((registration) => {
         const {pubkey} = registration.message;
-        const validatorIndex = headState.epochCtx.pubkey2index.get(pubkey);
+        const validatorIndex = chain.pubkey2index.get(pubkey);
         if (validatorIndex === null) return false;
 
         const validator = headState.validators.getReadonly(validatorIndex);

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1344,7 +1344,7 @@ export class BeaconChain implements IBeaconChain {
       throw Error(`State is not in cache for slot ${slot}`);
     }
 
-    const rewards = await computeAttestationsRewards(epoch, cachedState, this.config, validatorIds);
+    const rewards = await computeAttestationsRewards(this.pubkey2index, cachedState, validatorIds);
 
     return {rewards, executionOptimistic, finalized};
   }


### PR DESCRIPTION
**Motivation**

- as a preparation for lodestar-z integration, we should not access pubkey2index from CachedBeaconState

**Description**

- use that from BeaconChain instead

part of #8652