### PR TITLE
chore: add lerna exec to fix build watch/ifchanged commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@chainsafe/benchmark": "^1.2.3",
     "@chainsafe/biomejs-config": "^1.0.0",
     "@lerna-lite/cli": "^4.9.4",
+    "@lerna-lite/exec": "^4.9.4",
     "@lerna-lite/publish": "^4.9.4",
     "@lerna-lite/run": "^4.9.4",
     "@lerna-lite/version": "^4.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1905,6 +1905,20 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
+"@lerna-lite/cli@4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@lerna-lite/cli/-/cli-4.10.2.tgz#43fac58feafd9cc663c6f78d4d8692b3cf8e6a1a"
+  integrity sha512-yT5/z/FvVKWO9NDF7VTN5bYkuF96yH5VPl1I6n37BOOj/KFtPSG2SEMclbkJ+CCYw/kmV7sxHeodIyWnpJ8Ggw==
+  dependencies:
+    "@lerna-lite/core" "4.10.2"
+    "@lerna-lite/init" "4.10.2"
+    "@lerna-lite/npmlog" "4.10.0"
+    dedent "^1.7.0"
+    dotenv "^17.2.3"
+    import-local "^3.2.0"
+    load-json-file "^7.0.1"
+    yargs "^18.0.0"
+
 "@lerna-lite/cli@4.9.4", "@lerna-lite/cli@^4.9.4":
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/@lerna-lite/cli/-/cli-4.9.4.tgz#e378f4ce0e29cad08e74d5e9a05923e5b183ebbb"
@@ -1918,6 +1932,38 @@
     import-local "^3.2.0"
     load-json-file "^7.0.1"
     yargs "^18.0.0"
+
+"@lerna-lite/core@4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@lerna-lite/core/-/core-4.10.2.tgz#784a0454dd33256589b854d75b5db95e3a62c5d9"
+  integrity sha512-LTGO6tWIBHi5clHECz5tqhtWCUedlyX4n93SbIP1n4ehPS+qSuHh0fJ3QvQQX18jvktKFwaR7AKzrL21lxtGYQ==
+  dependencies:
+    "@inquirer/expand" "^4.0.23"
+    "@inquirer/input" "^4.3.1"
+    "@inquirer/select" "^4.4.2"
+    "@lerna-lite/npmlog" "4.10.0"
+    "@npmcli/run-script" "^10.0.3"
+    ci-info "^4.3.1"
+    config-chain "^1.1.13"
+    dedent "^1.7.0"
+    execa "^9.6.1"
+    fs-extra "^11.3.2"
+    glob-parent "^6.0.2"
+    json5 "^2.2.3"
+    lilconfig "^3.1.3"
+    load-json-file "^7.0.1"
+    npm-package-arg "^13.0.2"
+    p-map "^7.0.4"
+    p-queue "^9.0.1"
+    semver "^7.7.3"
+    slash "^5.1.0"
+    tinyglobby "^0.2.15"
+    tinyrainbow "^3.0.3"
+    write-file-atomic "^7.0.0"
+    write-json-file "^7.0.0"
+    write-package "^7.2.0"
+    yaml "^2.8.2"
+    zeptomatch "^2.1.0"
 
 "@lerna-lite/core@4.9.4":
   version "4.9.4"
@@ -1951,6 +1997,28 @@
     yaml "^2.8.1"
     zeptomatch "^2.1.0"
 
+"@lerna-lite/exec@^4.9.4":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@lerna-lite/exec/-/exec-4.10.2.tgz#dfd0e5ba07c38b67bfcdf9324ea16e06fb50d4a8"
+  integrity sha512-18wY/LcFpvWt7eIW3SyEJ6aaSUrhj10eZV6EAOtBan+b4x+U05WEqHgSXdOGDaiEinkrO5tToR/cvY7j9+gM2g==
+  dependencies:
+    "@lerna-lite/cli" "4.10.2"
+    "@lerna-lite/core" "4.10.2"
+    "@lerna-lite/profiler" "4.10.2"
+    dotenv "^17.2.3"
+    p-map "^7.0.4"
+    tinyrainbow "^3.0.3"
+
+"@lerna-lite/init@4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@lerna-lite/init/-/init-4.10.2.tgz#8fc5288f0dd8753c6821e005b963f84a924131f8"
+  integrity sha512-TNnSQ7ewaY/jSvJGQSTRQT+vHt/wa3LKEEM7jkH4VSG4wCbzIV2u3xCOZ1n+oVaBaH2FO54qUKaqU8qruxVy4g==
+  dependencies:
+    "@lerna-lite/core" "4.10.2"
+    fs-extra "^11.3.2"
+    p-map "^7.0.4"
+    write-json-file "^7.0.0"
+
 "@lerna-lite/init@4.9.4":
   version "4.9.4"
   resolved "https://registry.yarnpkg.com/@lerna-lite/init/-/init-4.9.4.tgz#59ec9cdc5966cc3860590884bfb1738f5ce6b38e"
@@ -1960,6 +2028,19 @@
     fs-extra "^11.3.2"
     p-map "^7.0.4"
     write-json-file "^7.0.0"
+
+"@lerna-lite/npmlog@4.10.0":
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/@lerna-lite/npmlog/-/npmlog-4.10.0.tgz#add4715f0f91ee0494aaaf491a11bbb1480a3629"
+  integrity sha512-vwI9qbhbbEjZJW/xXcOypqbIp3QXjsFD0kxGeHpGWXheeMtQSkRicJHH6v2dwVFid10EQmET47ItlCRAMhp12g==
+  dependencies:
+    aproba "^2.1.0"
+    fast-string-width "^3.0.2"
+    has-unicode "^2.0.1"
+    set-blocking "^2.0.0"
+    signal-exit "^4.1.0"
+    tinyrainbow "^3.0.3"
+    wide-align "^1.1.5"
 
 "@lerna-lite/npmlog@4.9.4":
   version "4.9.4"
@@ -1973,6 +2054,16 @@
     signal-exit "^4.1.0"
     tinyrainbow "^3.0.3"
     wide-align "^1.1.5"
+
+"@lerna-lite/profiler@4.10.2":
+  version "4.10.2"
+  resolved "https://registry.yarnpkg.com/@lerna-lite/profiler/-/profiler-4.10.2.tgz#ea20b51cc32088c0f4b23b49fdccf92ed6d5206d"
+  integrity sha512-JAjHF74g52AOJFxxOcF3lA2G1BcEjU6nZ3E/F7tJ+P5ct4Hc6VaMsP61OHYLUjNWzIq3L8y3csVHX1i4MyzNIA==
+  dependencies:
+    "@lerna-lite/core" "4.10.2"
+    "@lerna-lite/npmlog" "4.10.0"
+    fs-extra "^11.3.2"
+    upath "^2.0.1"
 
 "@lerna-lite/profiler@4.9.4":
   version "4.9.4"
@@ -5949,7 +6040,7 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
-execa@^9.6.0:
+execa@^9.6.0, execa@^9.6.1:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-9.6.1.tgz#5b90acedc6bdc0fa9b9a6ddf8f9cbb0c75a7c471"
   integrity sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==
@@ -12019,7 +12110,7 @@ yaml@^2.7.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.7.0.tgz#aef9bb617a64c937a9a748803786ad8d3ffe1e98"
   integrity sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==
 
-yaml@^2.8.1:
+yaml@^2.8.1, yaml@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.2.tgz#5694f25eca0ce9c3e7a9d9e00ce0ddabbd9e35c5"
   integrity sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==


### PR DESCRIPTION
`yarn build:watch` and `yarn build:ifchanged` no longer work since https://github.com/ChainSafe/lodestar/pull/8675 since `lerna exec` requires to install a separate package `@lerna-lite/exec` to work properly