### PR TITLE
refactor: pass validators pubkey-index map from cli

### DIFF
--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -2,10 +2,11 @@ import {setMaxListeners} from "node:events";
 import {PrivateKey} from "@libp2p/interface";
 import {Registry} from "prom-client";
 import {hasher} from "@chainsafe/persistent-merkle-tree";
+import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {BeaconApiMethods} from "@lodestar/api/beacon/server";
 import {BeaconConfig} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
-import {BeaconStateAllForks} from "@lodestar/state-transition";
+import {CachedBeaconStateAllForks, Index2PubkeyCache} from "@lodestar/state-transition";
 import {phase0} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
@@ -45,13 +46,15 @@ export type BeaconNodeModules = {
 export type BeaconNodeInitModules = {
   opts: IBeaconNodeOptions;
   config: BeaconConfig;
+  pubkey2index: PubkeyIndexMap;
+  index2pubkey: Index2PubkeyCache;
   db: IBeaconDb;
   logger: LoggerNode;
   processShutdownCallback: ProcessShutdownCallback;
   privateKey: PrivateKey;
   dataDir: string;
   peerStoreDir?: string;
-  anchorState: BeaconStateAllForks;
+  anchorState: CachedBeaconStateAllForks;
   isAnchorStateFinalized: boolean;
   wsCheckpoint?: phase0.Checkpoint;
   metricsRegistries?: Registry[];
@@ -146,6 +149,8 @@ export class BeaconNode {
   static async init<T extends BeaconNode = BeaconNode>({
     opts,
     config,
+    pubkey2index,
+    index2pubkey,
     db,
     logger,
     processShutdownCallback,
@@ -220,6 +225,8 @@ export class BeaconNode {
       privateKey,
       config,
       clock,
+      pubkey2index,
+      index2pubkey,
       dataDir,
       db,
       dbName: opts.db.name,

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -39,6 +39,8 @@ describe("produceBlockBody", () => {
       {
         privateKey: await generateKeyPair("secp256k1"),
         config: state.config,
+        pubkey2index: state.epochCtx.pubkey2index,
+        index2pubkey: state.epochCtx.index2pubkey,
         db,
         dataDir: ".",
         dbName: ".",

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -1,5 +1,6 @@
 import {generateKeyPair} from "@libp2p/crypto/keys";
 import {afterAll, beforeAll, bench, describe, setBenchOpts} from "@chainsafe/benchmark";
+import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {config} from "@lodestar/config/default";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
@@ -91,6 +92,8 @@ describe.skip("verify+import blocks - range sync perf test", () => {
         {
           privateKey: await generateKeyPair("secp256k1"),
           config: state.config,
+          pubkey2index: new PubkeyIndexMap(),
+          index2pubkey: [],
           db,
           dataDir: ".",
           dbName: ".",

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -1,6 +1,5 @@
 import {generateKeyPair} from "@libp2p/crypto/keys";
 import {afterAll, beforeAll, bench, describe, setBenchOpts} from "@chainsafe/benchmark";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {config} from "@lodestar/config/default";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
@@ -92,8 +91,8 @@ describe.skip("verify+import blocks - range sync perf test", () => {
         {
           privateKey: await generateKeyPair("secp256k1"),
           config: state.config,
-          pubkey2index: new PubkeyIndexMap(),
-          index2pubkey: [],
+          pubkey2index: state.epochCtx.pubkey2index,
+          index2pubkey: state.epochCtx.index2pubkey,
           db,
           dataDir: ".",
           dbName: ".",

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -4,12 +4,19 @@ import deepmerge from "deepmerge";
 import tmp from "tmp";
 import {setHasher} from "@chainsafe/persistent-merkle-tree";
 import {hasher} from "@chainsafe/persistent-merkle-tree/hasher/hashtree";
+import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {ChainConfig, createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {config as minimalConfig} from "@lodestar/config/default";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {LoggerNode} from "@lodestar/logger/node";
 import {ForkSeq, GENESIS_SLOT, SLOTS_PER_EPOCH, ZERO_HASH_HEX} from "@lodestar/params";
-import {BeaconStateAllForks, computeTimeAtSlot} from "@lodestar/state-transition";
+import {
+  BeaconStateAllForks,
+  Index2PubkeyCache,
+  computeTimeAtSlot,
+  createCachedBeaconState,
+  syncPubkeys,
+} from "@lodestar/state-transition";
 import {phase0, ssz} from "@lodestar/types";
 import {RecursivePartial, isPlainObject, toRootHex} from "@lodestar/utils";
 import {BeaconDb} from "../../../src/db/index.js";
@@ -116,16 +123,31 @@ export async function getDevBeaconNode(
   );
 
   const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
+  const pubkey2index = new PubkeyIndexMap();
+  const index2pubkey: Index2PubkeyCache = [];
+  syncPubkeys(anchorState.validators.getAllReadonlyValues(), pubkey2index, index2pubkey);
+  const cachedState = createCachedBeaconState(
+    anchorState,
+    {
+      config: beaconConfig,
+      pubkey2index,
+      index2pubkey,
+    },
+    {skipSyncPubkeys: true}
+  );
+
   return BeaconNode.init({
     opts: options as IBeaconNodeOptions,
     config: beaconConfig,
+    pubkey2index,
+    index2pubkey,
     db,
     logger,
     processShutdownCallback: () => {},
     privateKey,
     dataDir: ".",
     peerStoreDir,
-    anchorState,
+    anchorState: cachedState,
     wsCheckpoint: opts.wsCheckpoint,
     isAnchorStateFinalized: true,
   });

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -27,8 +27,7 @@ export {
   createEmptyEpochCacheImmutableData,
 } from "./cache/epochCache.js";
 export {type EpochTransitionCache, beforeProcessEpoch} from "./cache/epochTransitionCache.js";
-// Aux data-structures
-export {type Index2PubkeyCache} from "./cache/pubkeyCache.js";
+export {type Index2PubkeyCache, syncPubkeys} from "./cache/pubkeyCache.js";
 // Main state caches
 export {
   type BeaconStateCache,


### PR DESCRIPTION
**Motivation**

- we will not be able to access `pubkey2index` or `index2pubkey` once we switch to a native state-transition so we need to be prepared for that

**Description**

- pass `pubkey2index`, `index2pubkey` from cli instead
- in the future, we should find a way to extract them given a BeaconState so that we don't have to depend on any implementations of BeaconStateView, see https://github.com/ChainSafe/lodestar/issues/8706#issue-3741320691

Closes #8652