### PR TITLE
fix: avoid calling committee selection apis if there are no duties

### DIFF
--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -453,6 +453,10 @@ export class AttestationDutiesService {
    * 3. Mutate duty objects to set selection proofs for aggregators
    */
   private async runDistributedAggregationSelectionTasks(duties: AttDutyAndProof[], epoch: Epoch): Promise<void> {
+    if (duties.length === 0) {
+      return;
+    }
+
     const partialSelections: routes.validator.BeaconCommitteeSelection[] = duties.map(
       ({duty, partialSelectionProof}) => ({
         validatorIndex: duty.validatorIndex,

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -355,6 +355,10 @@ export class SyncCommitteeDutiesService {
    * 3. Mutate duty objects to set selection proofs for aggregators
    */
   private async runDistributedAggregationSelectionTasks(duties: SyncDutyAndProofs[], slot: number): Promise<void> {
+    if (duties.length === 0) {
+      return;
+    }
+
     const partialSelections: routes.validator.SyncCommitteeSelection[] = [];
 
     for (const {duty, selectionProofs} of duties) {


### PR DESCRIPTION
Since https://github.com/ChainSafe/lodestar/pull/8669 we might call the committee selection apis even if we don't have any duties which is unnecessary and charon doesn't like it.

```
lodestar-1  | Dec-19 16:16:47.001[]                error: Error on sync committee aggregation selection slot=13278082 - JSON is not an array
lodestar-1  | Error: JSON is not an array
lodestar-1  |     at value_fromJsonArray (file:///usr/app/node_modules/@chainsafe/ssz/src/type/arrayBasic.ts:162:11)
lodestar-1  |     at ListCompositeType.fromJson (file:///usr/app/node_modules/@chainsafe/ssz/src/type/array.ts:121:12)
lodestar-1  |     at ApiResponse.value (file:///usr/app/packages/api/src/utils/client/response.ts:115:51)
lodestar-1  |     at SyncCommitteeDutiesService.runDistributedAggregationSelectionTasks (file:///usr/app/packages/validator/src/services/syncCommitteeDuties.ts:385:36)
lodestar-1  |     at processTicksAndRejections (node:internal/process/task_queues:103:5)
```