### PR TITLE
chore: log aggregation selection errors to debug

### DIFF
--- a/packages/validator/src/services/attestationDuties.ts
+++ b/packages/validator/src/services/attestationDuties.ts
@@ -211,7 +211,7 @@ export class AttestationDutiesService {
           // This is required to correctly determine if validator is aggregator and to produce
           // a AggregateAndProof that can be threshold aggregated by the middleware client.
           await this.runDistributedAggregationSelectionTasks(Array.from(epochDuties.values()), epoch).catch((e) =>
-            this.logger.error("Error on attestation aggregation selection", {epoch}, e)
+            this.logger.debug("Error on attestation aggregation selection", {epoch}, e)
           );
         }
 
@@ -380,7 +380,7 @@ export class AttestationDutiesService {
     if (epochDuties) {
       if (this.opts?.distributedAggregationSelection) {
         await this.runDistributedAggregationSelectionTasks(Array.from(epochDuties.values()), dutyEpoch).catch((e) =>
-          this.logger.error("Error on attestation aggregation selection after duties reorg", logContext, e)
+          this.logger.debug("Error on attestation aggregation selection after duties reorg", logContext, e)
         );
       }
 
@@ -479,7 +479,7 @@ export class AttestationDutiesService {
       const combinedSelection = combinedSelections.find((s) => s.validatorIndex === validatorIndex && s.slot === slot);
 
       if (!combinedSelection) {
-        this.logger.warn("Did not receive combined beacon committee selection proof", logCtxValidator);
+        this.logger.debug("Did not receive combined beacon committee selection proof", logCtxValidator);
         continue;
       }
 

--- a/packages/validator/src/services/syncCommitteeDuties.ts
+++ b/packages/validator/src/services/syncCommitteeDuties.ts
@@ -143,7 +143,7 @@ export class SyncCommitteeDutiesService {
         // sync committee contributions as it is required to correctly determine if validator is aggregator
         // and to produce a ContributionAndProof that can be threshold aggregated by the middleware client.
         this.runDistributedAggregationSelectionTasks(duties, slot).catch((e) =>
-          this.logger.error("Error on sync committee aggregation selection", {slot}, e)
+          this.logger.debug("Error on sync committee aggregation selection", {slot}, e)
         );
       }
     }
@@ -400,7 +400,7 @@ export class SyncCommitteeDutiesService {
         );
 
         if (!combinedSelection) {
-          this.logger.warn("Did not receive combined sync committee selection proof", logCtxValidator);
+          this.logger.debug("Did not receive combined sync committee selection proof", logCtxValidator);
           continue;
         }
 


### PR DESCRIPTION
These errors aren't really critical and might be common right now because we moved from per slot to per epoch in https://github.com/ChainSafe/lodestar/pull/8669 and not all validator clients doing the same will cause calls to time out if signature threshold in DVT middleware is not reached.