### PR TITLE
fix(cli): handle missing proposer config directory in deleteProposerConfigs

### DIFF
--- a/packages/cli/src/cmds/validator/keymanager/persistedKeys.ts
+++ b/packages/cli/src/cmds/validator/keymanager/persistedKeys.ts
@@ -79,6 +79,10 @@ export class PersistedKeysBackend implements IPersistedKeysBackend {
   }
 
   deleteProposerConfigs(): void {
+    if (!fs.existsSync(this.paths.proposerDir)) {
+      return;
+    }
+
     for (const pubkey of fs.readdirSync(this.paths.proposerDir)) {
       this.deleteProposerConfig(pubkey);
     }


### PR DESCRIPTION


Adds a guard check to ensure the proposer config directory exists before attempting to read it. This makes the cleanup operation safe and idempotent—if the directory doesn't exist, the method simply returns early, which is the expected behavior for a cleanup operation.

The fix aligns with the pattern already used in other methods of the same class like `readProposerConfigs()` and `deleteProposerConfig()`.

