### PR TITLE
fix(api): remove redundant transform from getDebugForkChoice

### DIFF
--- a/packages/api/src/beacon/routes/debug.ts
+++ b/packages/api/src/beacon/routes/debug.ts
@@ -175,14 +175,6 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         data: ForkChoiceResponseType,
         meta: EmptyMetaCodec,
         onlySupport: WireFormat.json,
-        transform: {
-          toResponse: (data) => ({
-            ...(data as ForkChoiceResponse),
-          }),
-          fromResponse: (resp) => ({
-            data: resp as ForkChoiceResponse,
-          }),
-        },
       },
     },
     getProtoArrayNodes: {


### PR DESCRIPTION
**Motivation**

The `getDebugForkChoice` endpoint had a redundant `transform` that changed the response structure from the standard `{data: ...}` format to a plain object. This didn't match the implementation, test expectations, or other debug endpoints.

**Description**

Removed the unnecessary `transform` from `getDebugForkChoice` endpoint. The transform was performing a no-op that incorrectly changed the response structure. The endpoint now uses the standard `{data: ForkChoiceResponse}` format consistent with the implementation, tests, and other debug endpoints.

**AI Assistance Disclosure**

- [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

AI assistance was used to analyze the codebase, identify the redundant transform, and verify the fix.