### PR TITLE
fix: prevent duplicate aggregates passing validation due to race condition

### DIFF
--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -245,6 +245,18 @@ async function validateAggregateAndProof(
     });
   }
 
+  // Same race-condition check as above for seen aggregators
+  if (
+    !skipValidationKnownAttesters &&
+    chain.seenAggregatedAttestations.isKnown(targetEpoch, attIndex, attDataRootHex, aggregationBits)
+  ) {
+    throw new AttestationError(GossipAction.IGNORE, {
+      code: AttestationErrorCode.ATTESTERS_ALREADY_KNOWN,
+      targetEpoch,
+      aggregateRoot: attDataRootHex,
+    });
+  }
+
   chain.seenAggregators.add(targetEpoch, aggregatorIndex);
   chain.seenAggregatedAttestations.add(
     targetEpoch,


### PR DESCRIPTION
**Motivation**

https://github.com/ChainSafe/lodestar/pull/8711#pullrequestreview-3612431091

**Description**

Prevent duplicate aggregates passing gossip validation due to race condition by checking again if we've seen the aggregate before inserting it into op pool. This is required since we run multiple async operations in-between first check and inserting it into op pool.


<img width="942" height="301" alt="image" src="https://github.com/user-attachments/assets/2701a92e-7733-4de3-bf4a-ac853fd5c0b7" />

`AlreadyKnown` disappears since we now filter those out properly during gossip validation which is important since we don't wanna re-gossip those aggregates.
