### PR TITLE
refactor: move reward apis to state-transition

### DIFF
--- a/packages/api/src/beacon/routes/beacon/index.ts
+++ b/packages/api/src/beacon/routes/beacon/index.ts
@@ -13,13 +13,6 @@ export {block, pool, state, rewards};
 
 export type {BlockHeaderResponse, BlockId} from "./block.js";
 export {BroadcastValidation} from "./block.js";
-export type {
-  AttestationsRewards,
-  BlockRewards,
-  IdealAttestationsReward,
-  SyncCommitteeRewards,
-  TotalAttestationsReward,
-} from "./rewards.js";
 // TODO: Review if re-exporting all these types is necessary
 export type {
   EpochCommitteeResponse,

--- a/packages/api/src/beacon/routes/beacon/pool.ts
+++ b/packages/api/src/beacon/routes/beacon/pool.ts
@@ -2,6 +2,7 @@ import {ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPostElectra, ForkPreElectra, isForkPostElectra} from "@lodestar/params";
 import {
+  ArrayOf,
   AttesterSlashing,
   CommitteeIndex,
   SingleAttestation,
@@ -12,7 +13,6 @@ import {
   ssz,
 } from "@lodestar/types";
 import {
-  ArrayOf,
   EmptyArgs,
   EmptyMeta,
   EmptyMetaCodec,

--- a/packages/api/src/beacon/routes/beacon/rewards.ts
+++ b/packages/api/src/beacon/routes/beacon/rewards.ts
@@ -1,111 +1,19 @@
-import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {Epoch, ssz} from "@lodestar/types";
-import {ArrayOf, JsonOnlyReq} from "../../../utils/codecs.js";
+import {
+  AttestationsRewards,
+  AttestationsRewardsType,
+  BlockRewards,
+  BlockRewardsType,
+  Epoch,
+  SyncCommitteeRewards,
+  SyncCommitteeRewardsType,
+} from "@lodestar/types";
+import {JsonOnlyReq} from "../../../utils/codecs.js";
 import {Endpoint, RouteDefinitions, Schema} from "../../../utils/index.js";
 import {ExecutionOptimisticAndFinalizedCodec, ExecutionOptimisticAndFinalizedMeta} from "../../../utils/metadata.js";
 import {fromValidatorIdsStr, toValidatorIdsStr} from "../../../utils/serdes.js";
 import {BlockArgs} from "./block.js";
 import {ValidatorId} from "./state.js";
-
-const BlockRewardsType = new ContainerType(
-  {
-    /** Proposer of the block, the proposer index who receives these rewards */
-    proposerIndex: ssz.ValidatorIndex,
-    /** Total block reward, equal to attestations + sync_aggregate + proposer_slashings + attester_slashings */
-    total: ssz.UintNum64,
-    /** Block reward component due to included attestations */
-    attestations: ssz.UintNum64,
-    /** Block reward component due to included sync_aggregate */
-    syncAggregate: ssz.UintNum64,
-    /** Block reward component due to included proposer_slashings */
-    proposerSlashings: ssz.UintNum64,
-    /** Block reward component due to included attester_slashings */
-    attesterSlashings: ssz.UintNum64,
-  },
-  {jsonCase: "eth2"}
-);
-
-const AttestationsRewardType = new ContainerType(
-  {
-    /** Reward for head vote. Could be negative to indicate penalty */
-    head: ssz.UintNum64,
-    /** Reward for target vote. Could be negative to indicate penalty */
-    target: ssz.UintNum64,
-    /** Reward for source vote. Could be negative to indicate penalty */
-    source: ssz.UintNum64,
-    /** Inclusion delay reward (phase0 only) */
-    inclusionDelay: ssz.UintNum64,
-    /** Inactivity penalty. Should be a negative number to indicate penalty */
-    inactivity: ssz.UintNum64,
-  },
-  {jsonCase: "eth2"}
-);
-
-const IdealAttestationsRewardsType = new ContainerType(
-  {
-    ...AttestationsRewardType.fields,
-    effectiveBalance: ssz.UintNum64,
-  },
-  {jsonCase: "eth2"}
-);
-
-const TotalAttestationsRewardsType = new ContainerType(
-  {
-    ...AttestationsRewardType.fields,
-    validatorIndex: ssz.ValidatorIndex,
-  },
-  {jsonCase: "eth2"}
-);
-
-const AttestationsRewardsType = new ContainerType(
-  {
-    idealRewards: ArrayOf(IdealAttestationsRewardsType),
-    totalRewards: ArrayOf(TotalAttestationsRewardsType),
-  },
-  {jsonCase: "eth2"}
-);
-
-const SyncCommitteeRewardsType = ArrayOf(
-  new ContainerType(
-    {
-      validatorIndex: ssz.ValidatorIndex,
-      reward: ssz.UintNum64,
-    },
-    {jsonCase: "eth2"}
-  )
-);
-
-/**
- * Rewards info for a single block. Every reward value is in Gwei.
- */
-export type BlockRewards = ValueOf<typeof BlockRewardsType>;
-
-/**
- * Rewards for a single set of (ideal or actual depending on usage) attestations. Reward value is in Gwei
- */
-export type AttestationsReward = ValueOf<typeof AttestationsRewardType>;
-
-/**
- * Rewards info for ideal attestations ie. Maximum rewards could be earned by making timely head, target and source vote.
- * `effectiveBalance` is in Gwei
- */
-export type IdealAttestationsReward = ValueOf<typeof IdealAttestationsRewardsType>;
-
-/**
- * Rewards info for actual attestations
- */
-export type TotalAttestationsReward = ValueOf<typeof TotalAttestationsRewardsType>;
-
-export type AttestationsRewards = ValueOf<typeof AttestationsRewardsType>;
-
-/**
- * Rewards info for sync committee participation. Every reward value is in Gwei.
- * Note: In the case that block proposer is present in `SyncCommitteeRewards`, the reward value only reflects rewards for
- * participating in sync committee. Please refer to `BlockRewards.syncAggregate` for rewards of proposer including sync committee
- * outputs into their block
- */
-export type SyncCommitteeRewards = ValueOf<typeof SyncCommitteeRewardsType>;
 
 export type Endpoints = {
   /**

--- a/packages/api/src/beacon/routes/beacon/rewards.ts
+++ b/packages/api/src/beacon/routes/beacon/rewards.ts
@@ -1,13 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {
-  AttestationsRewards,
-  AttestationsRewardsType,
-  BlockRewards,
-  BlockRewardsType,
-  Epoch,
-  SyncCommitteeRewards,
-  SyncCommitteeRewardsType,
-} from "@lodestar/types";
+import {Epoch, rewards} from "@lodestar/types";
 import {JsonOnlyReq} from "../../../utils/codecs.js";
 import {Endpoint, RouteDefinitions, Schema} from "../../../utils/index.js";
 import {ExecutionOptimisticAndFinalizedCodec, ExecutionOptimisticAndFinalizedMeta} from "../../../utils/metadata.js";
@@ -24,7 +16,7 @@ export type Endpoints = {
     "GET",
     BlockArgs,
     {params: {block_id: string}},
-    BlockRewards,
+    rewards.BlockRewards,
     ExecutionOptimisticAndFinalizedMeta
   >;
 
@@ -41,7 +33,7 @@ export type Endpoints = {
       validatorIds?: ValidatorId[];
     },
     {params: {epoch: number}; body: string[]},
-    AttestationsRewards,
+    rewards.AttestationsRewards,
     ExecutionOptimisticAndFinalizedMeta
   >;
 
@@ -56,7 +48,7 @@ export type Endpoints = {
       validatorIds?: ValidatorId[];
     },
     {params: {block_id: string}; body: string[]},
-    SyncCommitteeRewards,
+    rewards.SyncCommitteeRewards,
     ExecutionOptimisticAndFinalizedMeta
   >;
 };
@@ -72,7 +64,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         schema: {params: {block_id: Schema.StringRequired}},
       },
       resp: {
-        data: BlockRewardsType,
+        data: rewards.BlockRewardsType,
         meta: ExecutionOptimisticAndFinalizedCodec,
       },
     },
@@ -94,7 +86,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         },
       }),
       resp: {
-        data: AttestationsRewardsType,
+        data: rewards.AttestationsRewardsType,
         meta: ExecutionOptimisticAndFinalizedCodec,
       },
     },
@@ -116,7 +108,7 @@ export function getDefinitions(_config: ChainForkConfig): RouteDefinitions<Endpo
         },
       }),
       resp: {
-        data: SyncCommitteeRewardsType,
+        data: rewards.SyncCommitteeRewardsType,
         meta: ExecutionOptimisticAndFinalizedCodec,
       },
     },

--- a/packages/api/src/beacon/routes/beacon/state.ts
+++ b/packages/api/src/beacon/routes/beacon/state.ts
@@ -2,6 +2,7 @@ import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
 import {MAX_VALIDATORS_PER_COMMITTEE} from "@lodestar/params";
 import {
+  ArrayOf,
   CommitteeIndex,
   Epoch,
   RootHex,
@@ -13,7 +14,7 @@ import {
   phase0,
   ssz,
 } from "@lodestar/types";
-import {ArrayOf, JsonOnlyReq} from "../../../utils/codecs.js";
+import {JsonOnlyReq} from "../../../utils/codecs.js";
 import {Endpoint, RequestCodec, RouteDefinitions, Schema} from "../../../utils/index.js";
 import {
   ExecutionOptimisticAndFinalizedCodec,

--- a/packages/api/src/beacon/routes/config.ts
+++ b/packages/api/src/beacon/routes/config.ts
@@ -1,8 +1,7 @@
 import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig, SpecJson} from "@lodestar/config";
-import {ssz} from "@lodestar/types";
+import {ArrayOf, ssz} from "@lodestar/types";
 import {
-  ArrayOf,
   EmptyArgs,
   EmptyMeta,
   EmptyMetaCodec,

--- a/packages/api/src/beacon/routes/debug.ts
+++ b/packages/api/src/beacon/routes/debug.ts
@@ -1,8 +1,7 @@
 import {ContainerType, Type, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {BeaconState, StringType, fulu, ssz} from "@lodestar/types";
+import {ArrayOf, BeaconState, StringType, fulu, ssz} from "@lodestar/types";
 import {
-  ArrayOf,
   EmptyArgs,
   EmptyMeta,
   EmptyMetaCodec,

--- a/packages/api/src/beacon/routes/lodestar.ts
+++ b/packages/api/src/beacon/routes/lodestar.ts
@@ -1,8 +1,7 @@
 import {ContainerType, Type, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {BeaconState, Epoch, RootHex, Slot, ssz} from "@lodestar/types";
+import {ArrayOf, BeaconState, Epoch, RootHex, Slot, ssz} from "@lodestar/types";
 import {
-  ArrayOf,
   EmptyArgs,
   EmptyMeta,
   EmptyRequest,

--- a/packages/api/src/beacon/routes/node.ts
+++ b/packages/api/src/beacon/routes/node.ts
@@ -1,8 +1,7 @@
 import {ContainerType, OptionalType, ValueOf} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {StringType, fulu, ssz, stringType} from "@lodestar/types";
+import {ArrayOf, StringType, fulu, ssz, stringType} from "@lodestar/types";
 import {
-  ArrayOf,
   EmptyArgs,
   EmptyMeta,
   EmptyMetaCodec,

--- a/packages/api/src/beacon/routes/proof.ts
+++ b/packages/api/src/beacon/routes/proof.ts
@@ -1,9 +1,8 @@
 import {CompactMultiProof, ProofType} from "@chainsafe/persistent-merkle-tree";
 import {ByteListType, ContainerType} from "@chainsafe/ssz";
 import {ChainForkConfig} from "@lodestar/config";
-import {ssz} from "@lodestar/types";
+import {ArrayOf, ssz} from "@lodestar/types";
 import {fromHex, toHex} from "@lodestar/utils";
-import {ArrayOf} from "../../utils/codecs.js";
 import {Endpoint, RouteDefinitions, Schema} from "../../utils/index.js";
 import {VersionCodec, VersionMeta} from "../../utils/metadata.js";
 

--- a/packages/api/src/beacon/routes/validator.ts
+++ b/packages/api/src/beacon/routes/validator.ts
@@ -8,6 +8,7 @@ import {
   isForkPostElectra,
 } from "@lodestar/params";
 import {
+  ArrayOf,
   Attestation,
   BLSSignature,
   BeaconBlock,
@@ -28,7 +29,6 @@ import {
 } from "@lodestar/types";
 import {fromHex, toHex, toRootHex} from "@lodestar/utils";
 import {
-  ArrayOf,
   EmptyMeta,
   EmptyMetaCodec,
   EmptyResponseCodec,

--- a/packages/api/src/builder/routes.ts
+++ b/packages/api/src/builder/routes.ts
@@ -1,6 +1,7 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkName, VALIDATOR_REGISTRY_LIMIT, isForkPostDeneb} from "@lodestar/params";
 import {
+  ArrayOf,
   BLSPubkey,
   ExecutionPayload,
   ExecutionPayloadAndBlobsBundle,
@@ -14,7 +15,6 @@ import {
 } from "@lodestar/types";
 import {fromHex, toPubkeyHex, toRootHex} from "@lodestar/utils";
 import {
-  ArrayOf,
   EmptyArgs,
   EmptyMeta,
   EmptyRequest,

--- a/packages/api/src/utils/codecs.ts
+++ b/packages/api/src/utils/codecs.ts
@@ -1,4 +1,4 @@
-import {ArrayType, ListBasicType, ListCompositeType, Type, isBasicType, isCompositeType} from "@chainsafe/ssz";
+import {Type} from "@chainsafe/ssz";
 import {ForkName} from "@lodestar/params";
 import {objectToExpectedCase} from "@lodestar/utils";
 import {
@@ -67,16 +67,6 @@ export const EmptyResponseCodec: ResponseCodec<EmptyResponseEndpoint> = {
   meta: EmptyMetaCodec,
   isEmpty: true,
 };
-
-export function ArrayOf<T>(elementType: Type<T>, limit = Infinity): ArrayType<Type<T>, unknown, unknown> {
-  if (isCompositeType(elementType)) {
-    return new ListCompositeType(elementType, limit) as unknown as ArrayType<Type<T>, unknown, unknown>;
-  }
-  if (isBasicType(elementType)) {
-    return new ListBasicType(elementType, limit) as unknown as ArrayType<Type<T>, unknown, unknown>;
-  }
-  throw Error(`Unknown type ${elementType.typeName}`);
-}
 
 export function WithMeta<T, M extends {version: ForkName}>(getType: (m: M) => Type<T>): ResponseDataCodec<T, M> {
   return {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -25,23 +25,21 @@ import {
   processSlots,
 } from "@lodestar/state-transition";
 import {
-  AttestationsRewards,
   BeaconBlock,
   BlindedBeaconBlock,
   BlindedBeaconBlockBody,
-  BlockRewards,
   Epoch,
   Root,
   RootHex,
   SignedBeaconBlock,
   Slot,
   Status,
-  SyncCommitteeRewards,
   UintNum64,
   ValidatorIndex,
   Wei,
   isBlindedBeaconBlock,
   phase0,
+  rewards,
 } from "@lodestar/types";
 import {Logger, fromHex, gweiToWei, isErrorAborted, pruneSetToMax, sleep, toRootHex} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
@@ -1288,7 +1286,7 @@ export class BeaconChain implements IBeaconChain {
     }
   }
 
-  async getBlockRewards(block: BeaconBlock | BlindedBeaconBlock): Promise<BlockRewards> {
+  async getBlockRewards(block: BeaconBlock | BlindedBeaconBlock): Promise<rewards.BlockRewards> {
     let preState = this.regen.getPreStateSync(block);
 
     if (preState === null) {
@@ -1305,7 +1303,7 @@ export class BeaconChain implements IBeaconChain {
   async getAttestationsRewards(
     epoch: Epoch,
     validatorIds?: (ValidatorIndex | string)[]
-  ): Promise<{rewards: AttestationsRewards; executionOptimistic: boolean; finalized: boolean}> {
+  ): Promise<{rewards: rewards.AttestationsRewards; executionOptimistic: boolean; finalized: boolean}> {
     // We use end slot of (epoch + 1) to ensure we have seen all attestations. On-time or late. Any late attestation beyond this slot is not considered
     const slot = computeEndSlotAtEpoch(epoch + 1);
     const stateResult = await this.getStateBySlot(slot, {allowRegen: false}); // No regen if state not in cache
@@ -1331,7 +1329,7 @@ export class BeaconChain implements IBeaconChain {
   async getSyncCommitteeRewards(
     block: BeaconBlock | BlindedBeaconBlock,
     validatorIds?: (ValidatorIndex | string)[]
-  ): Promise<SyncCommitteeRewards> {
+  ): Promise<rewards.SyncCommitteeRewards> {
     let preState = this.regen.getPreStateSync(block);
 
     if (preState === null) {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -14,23 +14,29 @@ import {
   EpochShuffling,
   Index2PubkeyCache,
   computeAnchorCheckpoint,
+  computeAttestationsRewards,
+  computeBlockRewards,
   computeEndSlotAtEpoch,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
+  computeSyncCommitteeRewards,
   getEffectiveBalanceIncrementsZeroInactive,
   getEffectiveBalancesFromStateBytes,
   processSlots,
 } from "@lodestar/state-transition";
 import {
+  AttestationsRewards,
   BeaconBlock,
   BlindedBeaconBlock,
   BlindedBeaconBlockBody,
+  BlockRewards,
   Epoch,
   Root,
   RootHex,
   SignedBeaconBlock,
   Slot,
   Status,
+  SyncCommitteeRewards,
   UintNum64,
   ValidatorIndex,
   Wei,
@@ -77,9 +83,6 @@ import {AssembledBlockType, BlockType, ProduceResult} from "./produceBlock/index
 import {BlockAttributes, produceBlockBody, produceCommonBlockBody} from "./produceBlock/produceBlockBody.js";
 import {QueuedStateRegenerator, RegenCaller} from "./regen/index.js";
 import {ReprocessController} from "./reprocess.js";
-import {AttestationsRewards, computeAttestationsRewards} from "./rewards/attestationsRewards.js";
-import {BlockRewards, computeBlockRewards} from "./rewards/blockRewards.js";
-import {SyncCommitteeRewards, computeSyncCommitteeRewards} from "./rewards/syncCommitteeRewards.js";
 import {
   SeenAggregators,
   SeenAttesters,

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -9,14 +9,17 @@ import {
   Index2PubkeyCache,
 } from "@lodestar/state-transition";
 import {
+  AttestationsRewards,
   BeaconBlock,
   BlindedBeaconBlock,
+  BlockRewards,
   Epoch,
   Root,
   RootHex,
   SignedBeaconBlock,
   Slot,
   Status,
+  SyncCommitteeRewards,
   UintNum64,
   ValidatorIndex,
   Wei,
@@ -48,9 +51,9 @@ import {IChainOptions} from "./options.js";
 import {AssembledBlockType, BlockAttributes, BlockType, ProduceResult} from "./produceBlock/produceBlockBody.js";
 import {IStateRegenerator, RegenCaller} from "./regen/index.js";
 import {ReprocessController} from "./reprocess.js";
-import {AttestationsRewards} from "./rewards/attestationsRewards.js";
-import {BlockRewards} from "./rewards/blockRewards.js";
-import {SyncCommitteeRewards} from "./rewards/syncCommitteeRewards.js";
+// import {AttestationsRewards} from "./rewards/attestationsRewards.js";
+// import {BlockRewards} from "./rewards/blockRewards.js";
+// import {SyncCommitteeRewards} from "./rewards/syncCommitteeRewards.js";
 import {
   SeenAggregators,
   SeenAttesters,

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -9,23 +9,21 @@ import {
   Index2PubkeyCache,
 } from "@lodestar/state-transition";
 import {
-  AttestationsRewards,
   BeaconBlock,
   BlindedBeaconBlock,
-  BlockRewards,
   Epoch,
   Root,
   RootHex,
   SignedBeaconBlock,
   Slot,
   Status,
-  SyncCommitteeRewards,
   UintNum64,
   ValidatorIndex,
   Wei,
   altair,
   capella,
   phase0,
+  rewards,
 } from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {IExecutionBuilder, IExecutionEngine} from "../execution/index.js";
@@ -255,15 +253,15 @@ export interface IBeaconChain {
   regenCanAcceptWork(): boolean;
   blsThreadPoolCanAcceptWork(): boolean;
 
-  getBlockRewards(blockRef: BeaconBlock | BlindedBeaconBlock): Promise<BlockRewards>;
+  getBlockRewards(blockRef: BeaconBlock | BlindedBeaconBlock): Promise<rewards.BlockRewards>;
   getAttestationsRewards(
     epoch: Epoch,
     validatorIds?: (ValidatorIndex | string)[]
-  ): Promise<{rewards: AttestationsRewards; executionOptimistic: boolean; finalized: boolean}>;
+  ): Promise<{rewards: rewards.AttestationsRewards; executionOptimistic: boolean; finalized: boolean}>;
   getSyncCommitteeRewards(
     blockRef: BeaconBlock | BlindedBeaconBlock,
     validatorIds?: (ValidatorIndex | string)[]
-  ): Promise<SyncCommitteeRewards>;
+  ): Promise<rewards.SyncCommitteeRewards>;
 }
 
 export type SSZObjectType =

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -51,9 +51,6 @@ import {IChainOptions} from "./options.js";
 import {AssembledBlockType, BlockAttributes, BlockType, ProduceResult} from "./produceBlock/produceBlockBody.js";
 import {IStateRegenerator, RegenCaller} from "./regen/index.js";
 import {ReprocessController} from "./reprocess.js";
-// import {AttestationsRewards} from "./rewards/attestationsRewards.js";
-// import {BlockRewards} from "./rewards/blockRewards.js";
-// import {SyncCommitteeRewards} from "./rewards/syncCommitteeRewards.js";
 import {
   SeenAggregators,
   SeenAttesters,

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -40,6 +40,7 @@ export {
 export * from "./constants/index.js";
 export type {EpochTransitionStep} from "./epoch/index.js";
 export {type BeaconStateTransitionMetrics, getMetrics} from "./metrics.js";
+export * from "./rewards/index.js";
 export * from "./signatureSets/index.js";
 export * from "./stateTransition.js";
 export type {

--- a/packages/state-transition/src/rewards/attestationsRewards.ts
+++ b/packages/state-transition/src/rewards/attestationsRewards.ts
@@ -1,5 +1,4 @@
 import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
-import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
 import {
   EFFECTIVE_BALANCE_INCREMENT,
@@ -14,24 +13,19 @@ import {
   WEIGHT_DENOMINATOR,
   isForkPostElectra,
 } from "@lodestar/params";
+import {AttestationsRewards, IdealAttestationsReward, TotalAttestationsReward, ValidatorIndex} from "@lodestar/types";
+import {fromHex} from "@lodestar/utils";
+import {EpochTransitionCache, beforeProcessEpoch} from "../cache/epochTransitionCache.js";
+import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../types.js";
 import {
-  CachedBeaconStateAllForks,
-  CachedBeaconStateAltair,
-  EpochTransitionCache,
   FLAG_ELIGIBLE_ATTESTER,
   FLAG_PREV_HEAD_ATTESTER_UNSLASHED,
   FLAG_PREV_SOURCE_ATTESTER_UNSLASHED,
   FLAG_PREV_TARGET_ATTESTER_UNSLASHED,
-  beforeProcessEpoch,
   hasMarkers,
   isInInactivityLeak,
-} from "@lodestar/state-transition";
-import {ValidatorIndex} from "@lodestar/types";
-import {fromHex} from "@lodestar/utils";
+} from "../util/index.js";
 
-export type AttestationsRewards = routes.beacon.AttestationsRewards;
-type IdealAttestationsReward = routes.beacon.IdealAttestationsReward;
-type TotalAttestationsReward = routes.beacon.TotalAttestationsReward;
 /** Attestations penalty with respect to effective balance in Gwei */
 type AttestationsPenalty = {target: number; source: number; effectiveBalance: number};
 

--- a/packages/state-transition/src/rewards/attestationsRewards.ts
+++ b/packages/state-transition/src/rewards/attestationsRewards.ts
@@ -13,7 +13,7 @@ import {
   WEIGHT_DENOMINATOR,
   isForkPostElectra,
 } from "@lodestar/params";
-import {AttestationsRewards, IdealAttestationsReward, TotalAttestationsReward, ValidatorIndex} from "@lodestar/types";
+import {ValidatorIndex, rewards} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {EpochTransitionCache, beforeProcessEpoch} from "../cache/epochTransitionCache.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../types.js";
@@ -37,7 +37,7 @@ export async function computeAttestationsRewards(
   pubkey2index: PubkeyIndexMap,
   state: CachedBeaconStateAllForks,
   validatorIds?: (ValidatorIndex | string)[]
-): Promise<AttestationsRewards> {
+): Promise<rewards.AttestationsRewards> {
   const fork = config.getForkName(state.slot);
   if (fork === ForkName.phase0) {
     throw Error("Unsupported fork. Attestations rewards calculation is not available in phase0");
@@ -68,7 +68,7 @@ function computeIdealAttestationsRewardsAndPenaltiesAltair(
   config: BeaconConfig,
   state: CachedBeaconStateAllForks,
   transitionCache: EpochTransitionCache
-): [IdealAttestationsReward[], AttestationsPenalty[]] {
+): [rewards.IdealAttestationsReward[], AttestationsPenalty[]] {
   const baseRewardPerIncrement = transitionCache.baseRewardPerIncrement;
   const activeBalanceByIncrement = transitionCache.totalActiveStakeByIncrement;
   const fork = config.getForkName(state.slot);
@@ -92,7 +92,7 @@ function computeIdealAttestationsRewardsAndPenaltiesAltair(
     const weight = PARTICIPATION_FLAG_WEIGHTS[i];
 
     let unslashedStakeByIncrement: number;
-    let flagName: keyof IdealAttestationsReward;
+    let flagName: keyof rewards.IdealAttestationsReward;
 
     switch (i) {
       case TIMELY_SOURCE_FLAG_INDEX: {
@@ -145,10 +145,10 @@ function computeTotalAttestationsRewardsAltair(
   pubkey2index: PubkeyIndexMap,
   state: CachedBeaconStateAltair,
   transitionCache: EpochTransitionCache,
-  idealRewards: IdealAttestationsReward[],
+  idealRewards: rewards.IdealAttestationsReward[],
   penalties: AttestationsPenalty[],
   validatorIds: (ValidatorIndex | string)[] = []
-): TotalAttestationsReward[] {
+): rewards.TotalAttestationsReward[] {
   const rewards = [];
   const {flags} = transitionCache;
   const {epochCtx} = state;

--- a/packages/state-transition/src/rewards/blockRewards.ts
+++ b/packages/state-transition/src/rewards/blockRewards.ts
@@ -5,7 +5,7 @@ import {
   WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA,
   isForkPostElectra,
 } from "@lodestar/params";
-import {BeaconBlock, BlockRewards, altair, phase0} from "@lodestar/types";
+import {BeaconBlock, altair, phase0, rewards} from "@lodestar/types";
 import {processAttestationsAltair} from "../block/processAttestationsAltair.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateAltair, CachedBeaconStatePhase0} from "../cache/stateCache.js";
 import {getAttesterSlashableIndices} from "../util/attestation.js";
@@ -25,7 +25,7 @@ export async function computeBlockRewards(
   block: BeaconBlock,
   preState: CachedBeaconStateAllForks,
   postState?: CachedBeaconStateAllForks
-): Promise<BlockRewards> {
+): Promise<rewards.BlockRewards> {
   const fork = config.getForkName(block.slot);
   const {attestations: cachedAttestationsReward = 0, syncAggregate: cachedSyncAggregateReward = 0} =
     postState?.proposerRewards ?? {};

--- a/packages/state-transition/src/rewards/blockRewards.ts
+++ b/packages/state-transition/src/rewards/blockRewards.ts
@@ -1,4 +1,3 @@
-import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
 import {
   ForkName,
@@ -6,16 +5,11 @@ import {
   WHISTLEBLOWER_REWARD_QUOTIENT_ELECTRA,
   isForkPostElectra,
 } from "@lodestar/params";
-import {
-  CachedBeaconStateAllForks,
-  CachedBeaconStateAltair,
-  CachedBeaconStatePhase0,
-  getAttesterSlashableIndices,
-  processAttestationsAltair,
-} from "@lodestar/state-transition";
-import {BeaconBlock, altair, phase0} from "@lodestar/types";
+import {BeaconBlock, BlockRewards, altair, phase0} from "@lodestar/types";
+import {processAttestationsAltair} from "../block/processAttestationsAltair.js";
+import {CachedBeaconStateAllForks, CachedBeaconStateAltair, CachedBeaconStatePhase0} from "../cache/stateCache.js";
+import {getAttesterSlashableIndices} from "../util/attestation.js";
 
-export type BlockRewards = routes.beacon.BlockRewards;
 type SubRewardValue = number; // All reward values should be integer
 
 /**

--- a/packages/state-transition/src/rewards/index.ts
+++ b/packages/state-transition/src/rewards/index.ts
@@ -1,0 +1,3 @@
+export * from "./attestationsRewards.js";
+export * from "./blockRewards.js";
+export * from "./syncCommitteeRewards.js";

--- a/packages/state-transition/src/rewards/syncCommitteeRewards.ts
+++ b/packages/state-transition/src/rewards/syncCommitteeRewards.ts
@@ -1,6 +1,6 @@
 import {BeaconConfig} from "@lodestar/config";
 import {ForkName, SYNC_COMMITTEE_SIZE} from "@lodestar/params";
-import {BeaconBlock, SyncCommitteeRewards, ValidatorIndex, altair} from "@lodestar/types";
+import {BeaconBlock, ValidatorIndex, altair, rewards} from "@lodestar/types";
 import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../cache/stateCache.js";
 
@@ -12,7 +12,7 @@ export async function computeSyncCommitteeRewards(
   block: BeaconBlock,
   preState: CachedBeaconStateAllForks,
   validatorIds: (ValidatorIndex | string)[] = []
-): Promise<SyncCommitteeRewards> {
+): Promise<rewards.SyncCommitteeRewards> {
   const fork = config.getForkName(block.slot);
   if (fork === ForkName.phase0) {
     throw Error("Cannot get sync rewards as phase0 block does not have sync committee");

--- a/packages/state-transition/src/rewards/syncCommitteeRewards.ts
+++ b/packages/state-transition/src/rewards/syncCommitteeRewards.ts
@@ -1,10 +1,9 @@
-import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
 import {ForkName, SYNC_COMMITTEE_SIZE} from "@lodestar/params";
-import {CachedBeaconStateAllForks, CachedBeaconStateAltair, Index2PubkeyCache} from "@lodestar/state-transition";
-import {BeaconBlock, ValidatorIndex, altair} from "@lodestar/types";
+import {BeaconBlock, SyncCommitteeRewards, ValidatorIndex, altair} from "@lodestar/types";
+import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
+import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../cache/stateCache.js";
 
-export type SyncCommitteeRewards = routes.beacon.SyncCommitteeRewards;
 type BalanceRecord = {val: number}; // Use val for convenient way to increment/decrement balance
 
 export async function computeSyncCommitteeRewards(

--- a/packages/state-transition/test/unit/rewards/blockRewards.test.ts
+++ b/packages/state-transition/test/unit/rewards/blockRewards.test.ts
@@ -6,15 +6,12 @@ import {
   CachedBeaconStateAllForks,
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
+  computeBlockRewards,
   stateTransition,
 } from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
-import {BlockAltairOpts, getBlockAltair} from "../../../../../state-transition/test/perf/block/util.js";
-import {
-  cachedStateAltairPopulateCaches,
-  generatePerfTestCachedStateAltair,
-} from "../../../../../state-transition/test/perf/util.js";
-import {computeBlockRewards} from "../../../../src/chain/rewards/blockRewards.js";
+import { BlockAltairOpts, getBlockAltair } from "../../perf/block/util.js";
+import { cachedStateAltairPopulateCaches, generatePerfTestCachedStateAltair } from "../../perf/util.js";
 
 describe("chain / rewards / blockRewards", () => {
   const config = createBeaconConfig({...chainConfigDef, ALTAIR_FORK_EPOCH: 0}, Buffer.alloc(32, 0xaa));

--- a/packages/state-transition/test/unit/rewards/blockRewards.test.ts
+++ b/packages/state-transition/test/unit/rewards/blockRewards.test.ts
@@ -10,8 +10,8 @@ import {
   stateTransition,
 } from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
-import { BlockAltairOpts, getBlockAltair } from "../../perf/block/util.js";
-import { cachedStateAltairPopulateCaches, generatePerfTestCachedStateAltair } from "../../perf/util.js";
+import {BlockAltairOpts, getBlockAltair} from "../../perf/block/util.js";
+import {cachedStateAltairPopulateCaches, generatePerfTestCachedStateAltair} from "../../perf/util.js";
 
 describe("chain / rewards / blockRewards", () => {
   const config = createBeaconConfig({...chainConfigDef, ALTAIR_FORK_EPOCH: 0}, Buffer.alloc(32, 0xaa));

--- a/packages/state-transition/test/unit/rewards/blockRewards.test.ts
+++ b/packages/state-transition/test/unit/rewards/blockRewards.test.ts
@@ -2,14 +2,11 @@ import {describe, expect, it, vi} from "vitest";
 import {createBeaconConfig} from "@lodestar/config";
 import {chainConfig as chainConfigDef} from "@lodestar/config/default";
 import {SYNC_COMMITTEE_SIZE} from "@lodestar/params";
-import {
-  CachedBeaconStateAllForks,
-  DataAvailabilityStatus,
-  ExecutionPayloadStatus,
-  computeBlockRewards,
-  stateTransition,
-} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
+import {DataAvailabilityStatus, ExecutionPayloadStatus} from "../../../src/block/externalData.js";
+import {computeBlockRewards} from "../../../src/rewards/blockRewards.js";
+import {stateTransition} from "../../../src/stateTransition.js";
+import {CachedBeaconStateAllForks} from "../../../src/types.js";
 import {BlockAltairOpts, getBlockAltair} from "../../perf/block/util.js";
 import {cachedStateAltairPopulateCaches, generatePerfTestCachedStateAltair} from "../../perf/util.js";
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,11 +5,11 @@ import * as ssz from "./sszTypes.js";
 import {sszTypesFor} from "./sszTypes.js";
 export {sszTypesFor, SSZTypesFor, ssz};
 
-export * from "./rewards.js";
 export * from "./utils/array.js";
 // Container utils
 export * from "./utils/container.js";
 export {ExecutionAddressType} from "./utils/executionAddress.js";
+export * as rewards from "./utils/rewards.js";
 // String type
 export {StringType, stringType} from "./utils/stringType.js";
 // Typeguards

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,6 +6,7 @@ import {sszTypesFor} from "./sszTypes.js";
 export {sszTypesFor, SSZTypesFor, ssz};
 
 export * from "./rewards.js";
+export * from "./utils/array.js";
 // Container utils
 export * from "./utils/container.js";
 export {ExecutionAddressType} from "./utils/executionAddress.js";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,6 +5,7 @@ import * as ssz from "./sszTypes.js";
 import {sszTypesFor} from "./sszTypes.js";
 export {sszTypesFor, SSZTypesFor, ssz};
 
+export * from "./rewards.js";
 // Container utils
 export * from "./utils/container.js";
 export {ExecutionAddressType} from "./utils/executionAddress.js";

--- a/packages/types/src/rewards.ts
+++ b/packages/types/src/rewards.ts
@@ -1,0 +1,120 @@
+import {
+  ArrayType,
+  ContainerType,
+  ListBasicType,
+  ListCompositeType,
+  Type,
+  ValueOf,
+  isBasicType,
+  isCompositeType,
+} from "@chainsafe/ssz";
+import {UintNum64, ValidatorIndex} from "./sszTypes.js";
+
+export const BlockRewardsType = new ContainerType(
+  {
+    /** Proposer of the block, the proposer index who receives these rewards */
+    proposerIndex: ValidatorIndex,
+    /** Total block reward, equal to attestations + sync_aggregate + proposer_slashings + attester_slashings */
+    total: UintNum64,
+    /** Block reward component due to included attestations */
+    attestations: UintNum64,
+    /** Block reward component due to included sync_aggregate */
+    syncAggregate: UintNum64,
+    /** Block reward component due to included proposer_slashings */
+    proposerSlashings: UintNum64,
+    /** Block reward component due to included attester_slashings */
+    attesterSlashings: UintNum64,
+  },
+  {jsonCase: "eth2"}
+);
+
+export const AttestationsRewardType = new ContainerType(
+  {
+    /** Reward for head vote. Could be negative to indicate penalty */
+    head: UintNum64,
+    /** Reward for target vote. Could be negative to indicate penalty */
+    target: UintNum64,
+    /** Reward for source vote. Could be negative to indicate penalty */
+    source: UintNum64,
+    /** Inclusion delay reward (phase0 only) */
+    inclusionDelay: UintNum64,
+    /** Inactivity penalty. Should be a negative number to indicate penalty */
+    inactivity: UintNum64,
+  },
+  {jsonCase: "eth2"}
+);
+
+export const IdealAttestationsRewardsType = new ContainerType(
+  {
+    ...AttestationsRewardType.fields,
+    effectiveBalance: UintNum64,
+  },
+  {jsonCase: "eth2"}
+);
+
+export const TotalAttestationsRewardsType = new ContainerType(
+  {
+    ...AttestationsRewardType.fields,
+    validatorIndex: ValidatorIndex,
+  },
+  {jsonCase: "eth2"}
+);
+
+export const AttestationsRewardsType = new ContainerType(
+  {
+    idealRewards: ArrayOf(IdealAttestationsRewardsType),
+    totalRewards: ArrayOf(TotalAttestationsRewardsType),
+  },
+  {jsonCase: "eth2"}
+);
+
+export const SyncCommitteeRewardsType = ArrayOf(
+  new ContainerType(
+    {
+      validatorIndex: ValidatorIndex,
+      reward: UintNum64,
+    },
+    {jsonCase: "eth2"}
+  )
+);
+
+/**
+ * Rewards info for a single block. Every reward value is in Gwei.
+ */
+export type BlockRewards = ValueOf<typeof BlockRewardsType>;
+
+/**
+ * Rewards for a single set of (ideal or actual depending on usage) attestations. Reward value is in Gwei
+ */
+export type AttestationsReward = ValueOf<typeof AttestationsRewardType>;
+
+/**
+ * Rewards info for ideal attestations ie. Maximum rewards could be earned by making timely head, target and source vote.
+ * `effectiveBalance` is in Gwei
+ */
+export type IdealAttestationsReward = ValueOf<typeof IdealAttestationsRewardsType>;
+
+/**
+ * Rewards info for actual attestations
+ */
+export type TotalAttestationsReward = ValueOf<typeof TotalAttestationsRewardsType>;
+
+export type AttestationsRewards = ValueOf<typeof AttestationsRewardsType>;
+
+/**
+ * Rewards info for sync committee participation. Every reward value is in Gwei.
+ * Note: In the case that block proposer is present in `SyncCommitteeRewards`, the reward value only reflects rewards for
+ * participating in sync committee. Please refer to `BlockRewards.syncAggregate` for rewards of proposer including sync committee
+ * outputs into their block
+ */
+export type SyncCommitteeRewards = ValueOf<typeof SyncCommitteeRewardsType>;
+
+export function ArrayOf<T>(elementType: Type<T>, limit = Infinity): ArrayType<Type<T>, unknown, unknown> {
+  if (isCompositeType(elementType)) {
+    return new ListCompositeType(elementType, limit) as unknown as ArrayType<Type<T>, unknown, unknown>;
+  }
+  if (isBasicType(elementType)) {
+    return new ListBasicType(elementType, limit) as unknown as ArrayType<Type<T>, unknown, unknown>;
+  }
+  throw Error(`Unknown type ${elementType.typeName}`);
+}

--- a/packages/types/src/rewards.ts
+++ b/packages/types/src/rewards.ts
@@ -1,14 +1,6 @@
-import {
-  ArrayType,
-  ContainerType,
-  ListBasicType,
-  ListCompositeType,
-  Type,
-  ValueOf,
-  isBasicType,
-  isCompositeType,
-} from "@chainsafe/ssz";
+import {ContainerType, ValueOf} from "@chainsafe/ssz";
 import {UintNum64, ValidatorIndex} from "./sszTypes.js";
+import {ArrayOf} from "./utils/array.js";
 
 export const BlockRewardsType = new ContainerType(
   {
@@ -108,13 +100,3 @@ export type AttestationsRewards = ValueOf<typeof AttestationsRewardsType>;
  * outputs into their block
  */
 export type SyncCommitteeRewards = ValueOf<typeof SyncCommitteeRewardsType>;
-
-export function ArrayOf<T>(elementType: Type<T>, limit = Infinity): ArrayType<Type<T>, unknown, unknown> {
-  if (isCompositeType(elementType)) {
-    return new ListCompositeType(elementType, limit) as unknown as ArrayType<Type<T>, unknown, unknown>;
-  }
-  if (isBasicType(elementType)) {
-    return new ListBasicType(elementType, limit) as unknown as ArrayType<Type<T>, unknown, unknown>;
-  }
-  throw Error(`Unknown type ${elementType.typeName}`);
-}

--- a/packages/types/src/utils/array.ts
+++ b/packages/types/src/utils/array.ts
@@ -1,0 +1,11 @@
+import {ArrayType, ListBasicType, ListCompositeType, Type, isBasicType, isCompositeType} from "@chainsafe/ssz";
+
+export function ArrayOf<T>(elementType: Type<T>, limit = Infinity): ArrayType<Type<T>, unknown, unknown> {
+  if (isCompositeType(elementType)) {
+    return new ListCompositeType(elementType, limit) as unknown as ArrayType<Type<T>, unknown, unknown>;
+  }
+  if (isBasicType(elementType)) {
+    return new ListBasicType(elementType, limit) as unknown as ArrayType<Type<T>, unknown, unknown>;
+  }
+  throw Error(`Unknown type ${elementType.typeName}`);
+}

--- a/packages/types/src/utils/rewards.ts
+++ b/packages/types/src/utils/rewards.ts
@@ -1,6 +1,6 @@
 import {ContainerType, ValueOf} from "@chainsafe/ssz";
-import {UintNum64, ValidatorIndex} from "./sszTypes.js";
-import {ArrayOf} from "./utils/array.js";
+import {UintNum64, ValidatorIndex} from "../sszTypes.js";
+import {ArrayOf} from "./array.js";
 
 export const BlockRewardsType = new ContainerType(
   {


### PR DESCRIPTION
**Motivation**

- the reward apis tightly couple to state-transition functions like `beforeProcessEpoch() processBlock() processAttestationAltair()` so it needs to be moved there

**Description**

- move api type definitions to `types` package so that it can be used everywhere
- move reward apis implementation to `state-transition` package

Closes #8690