### PR TITLE
fix: simplify getBlockSignatureSets api

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
@@ -28,6 +28,7 @@ export async function verifyBlocksSignatures(
 ): Promise<{verifySignaturesTime: number}> {
   const isValidPromises: Promise<boolean>[] = [];
   const recvToValLatency = Date.now() / 1000 - (opts.seenTimestampSec ?? Date.now() / 1000);
+  const currentSyncCommitteeIndexed = preState0.epochCtx.currentSyncCommitteeIndexed;
 
   // Verifies signatures after running state transition, so all SyncCommittee signed roots are known at this point.
   // We must ensure block.slot <= state.slot before running getAllBlockSignatureSets().
@@ -41,9 +42,16 @@ export async function verifyBlocksSignatures(
       : //
         // Verify signatures per block to track which block is invalid
         bls.verifySignatureSets(
-          getBlockSignatureSets(config, index2pubkey, preState0, block, indexedAttestationsByBlock[i], {
-            skipProposerSignature: opts.validProposerSignature,
-          })
+          getBlockSignatureSets(
+            config,
+            index2pubkey,
+            currentSyncCommitteeIndexed,
+            block,
+            indexedAttestationsByBlock[i],
+            {
+              skipProposerSignature: opts.validProposerSignature,
+            }
+          )
         );
 
     // getBlockSignatureSets() takes 45ms in benchmarks for 2022Q2 mainnet blocks (100 sigs). When syncing a 32 blocks

--- a/packages/beacon-node/src/chain/validation/attesterSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/attesterSlashing.ts
@@ -51,7 +51,12 @@ export async function validateAttesterSlashing(
     });
   }
 
-  const signatureSets = getAttesterSlashingSignatureSets(chain.config, chain.index2pubkey, state, attesterSlashing);
+  const signatureSets = getAttesterSlashingSignatureSets(
+    chain.config,
+    chain.index2pubkey,
+    state.slot,
+    attesterSlashing
+  );
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true, priority: prioritizeBls}))) {
     throw new AttesterSlashingError(GossipAction.REJECT, {
       code: AttesterSlashingErrorCode.INVALID,

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -154,7 +154,7 @@ export async function validateGossipBlock(
 
   // [REJECT] The proposer signature, signed_beacon_block.signature, is valid with respect to the proposer_index pubkey.
   if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockSlot, blockRoot, signedBlock.signature)) {
-    const signatureSet = getBlockProposerSignatureSet(chain.config, chain.index2pubkey, blockState, signedBlock);
+    const signatureSet = getBlockProposerSignatureSet(chain.config, chain.index2pubkey, signedBlock);
     // Don't batch so verification is not delayed
     if (!(await chain.bls.verifySignatureSets([signatureSet], {verifyOnMainThread: true}))) {
       throw new BlockGossipError(GossipAction.REJECT, {

--- a/packages/beacon-node/src/chain/validation/proposerSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/proposerSlashing.ts
@@ -44,7 +44,12 @@ async function validateProposerSlashing(
     });
   }
 
-  const signatureSets = getProposerSlashingSignatureSets(chain.config, chain.index2pubkey, state, proposerSlashing);
+  const signatureSets = getProposerSlashingSignatureSets(
+    chain.config,
+    chain.index2pubkey,
+    state.slot,
+    proposerSlashing
+  );
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true, priority: prioritizeBls}))) {
     throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID,

--- a/packages/beacon-node/src/chain/validation/voluntaryExit.ts
+++ b/packages/beacon-node/src/chain/validation/voluntaryExit.ts
@@ -59,7 +59,7 @@ async function validateVoluntaryExit(
     });
   }
 
-  const signatureSet = getVoluntaryExitSignatureSet(chain.config, chain.index2pubkey, state, voluntaryExit);
+  const signatureSet = getVoluntaryExitSignatureSet(chain.config, chain.index2pubkey, state.slot, voluntaryExit);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true, priority: prioritizeBls}))) {
     throw new VoluntaryExitError(GossipAction.REJECT, {
       code: VoluntaryExitErrorCode.INVALID_SIGNATURE,

--- a/packages/beacon-node/src/sync/backfill/verify.ts
+++ b/packages/beacon-node/src/sync/backfill/verify.ts
@@ -55,8 +55,7 @@ export async function verifyBlockProposerSignature(
   if (blocks.length === 1 && blocks[0].message.slot === GENESIS_SLOT) return;
   const signatures = blocks.reduce((sigs: ISignatureSet[], block) => {
     // genesis block doesn't have valid signature
-    if (block.message.slot !== GENESIS_SLOT)
-      sigs.push(getBlockProposerSignatureSet(config, index2pubkey, state, block));
+    if (block.message.slot !== GENESIS_SLOT) sigs.push(getBlockProposerSignatureSet(config, index2pubkey, block));
     return sigs;
   }, []);
 

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -21,7 +21,7 @@ export function isValidIndexedAttestation(
   }
 
   if (verifySignature) {
-    return verifySignatureSet(getIndexedAttestationSignatureSet(config, index2pubkey, state, indexedAttestation));
+    return verifySignatureSet(getIndexedAttestationSignatureSet(config, index2pubkey, state.slot, indexedAttestation));
   }
   return true;
 }
@@ -38,7 +38,9 @@ export function isValidIndexedAttestationBigint(
   }
 
   if (verifySignature) {
-    return verifySignatureSet(getIndexedAttestationBigintSignatureSet(config, index2pubkey, state, indexedAttestation));
+    return verifySignatureSet(
+      getIndexedAttestationBigintSignatureSet(config, index2pubkey, state.slot, indexedAttestation)
+    );
   }
   return true;
 }

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -67,7 +67,7 @@ export function processAttestationsAltair(
       const sigSet = getAttestationWithIndicesSignatureSet(
         state.config,
         epochCtx.index2pubkey,
-        state,
+        state.slot,
         attestation,
         attestingIndices
       );

--- a/packages/state-transition/src/block/processProposerSlashing.ts
+++ b/packages/state-transition/src/block/processProposerSlashing.ts
@@ -80,7 +80,7 @@ export function assertValidProposerSlashing(
     const signatureSets = getProposerSlashingSignatureSets(
       state.config,
       state.epochCtx.index2pubkey,
-      state,
+      state.slot,
       proposerSlashing
     );
     for (let i = 0; i < signatureSets.length; i++) {

--- a/packages/state-transition/src/block/processRandao.ts
+++ b/packages/state-transition/src/block/processRandao.ts
@@ -12,12 +12,12 @@ import {getRandaoMix} from "../util/index.js";
  * PERF: Fixed work independent of block contents.
  */
 export function processRandao(state: CachedBeaconStateAllForks, block: BeaconBlock, verifySignature = true): void {
-  const {epochCtx} = state;
+  const {epochCtx, config} = state;
   const epoch = epochCtx.epoch;
   const randaoReveal = block.body.randaoReveal;
 
   // verify RANDAO reveal
-  if (verifySignature && !verifyRandaoSignature(state.config, epochCtx.index2pubkey, state, block)) {
+  if (verifySignature && !verifyRandaoSignature(config, epochCtx.index2pubkey, block)) {
     throw new Error("RANDAO reveal is an invalid signature");
   }
 

--- a/packages/state-transition/src/block/processVoluntaryExit.ts
+++ b/packages/state-transition/src/block/processVoluntaryExit.ts
@@ -76,7 +76,7 @@ export function getVoluntaryExitValidity(
 
   if (
     verifySignature &&
-    !verifyVoluntaryExitSignature(state.config, epochCtx.index2pubkey, state, signedVoluntaryExit)
+    !verifyVoluntaryExitSignature(state.config, epochCtx.index2pubkey, state.slot, signedVoluntaryExit)
   ) {
     return VoluntaryExitValidity.invalidSignature;
   }

--- a/packages/state-transition/src/signatureSets/attesterSlashings.ts
+++ b/packages/state-transition/src/signatureSets/attesterSlashings.ts
@@ -10,10 +10,11 @@ export function getAttesterSlashingsSignatureSets(
   index2pubkey: Index2PubkeyCache,
   signedBlock: SignedBeaconBlock
 ): ISignatureSet[] {
+  // the getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition
+  // and the same epoch when we verify blocks in batch in beacon-node. So we can safely use block.slot here.
+  const blockSlot = signedBlock.message.slot;
   return signedBlock.message.body.attesterSlashings.flatMap((attesterSlashing) =>
-    // the getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition
-    // and the same epoch when we verify blocks in batch in beacon-node. So we can safely use block.slot here.
-    getAttesterSlashingSignatureSets(config, index2pubkey, signedBlock.message.slot, attesterSlashing)
+    getAttesterSlashingSignatureSets(config, index2pubkey, blockSlot, attesterSlashing)
   );
 }
 

--- a/packages/state-transition/src/signatureSets/attesterSlashings.ts
+++ b/packages/state-transition/src/signatureSets/attesterSlashings.ts
@@ -1,19 +1,19 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_ATTESTER} from "@lodestar/params";
-import {AttesterSlashing, IndexedAttestationBigint, SignedBeaconBlock, ssz} from "@lodestar/types";
+import {AttesterSlashing, IndexedAttestationBigint, SignedBeaconBlock, Slot, ssz} from "@lodestar/types";
 import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
-import {CachedBeaconStateAllForks} from "../types.js";
 import {ISignatureSet, SignatureSetType, computeSigningRoot, computeStartSlotAtEpoch} from "../util/index.js";
 
 /** Get signature sets from all AttesterSlashing objects in a block */
 export function getAttesterSlashingsSignatureSets(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
   signedBlock: SignedBeaconBlock
 ): ISignatureSet[] {
   return signedBlock.message.body.attesterSlashings.flatMap((attesterSlashing) =>
-    getAttesterSlashingSignatureSets(config, index2pubkey, state, attesterSlashing)
+    // the getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition
+    // and the same epoch when we verify blocks in batch in beacon-node. So we can safely use block.slot here.
+    getAttesterSlashingSignatureSets(config, index2pubkey, signedBlock.message.slot, attesterSlashing)
   );
 }
 
@@ -21,22 +21,22 @@ export function getAttesterSlashingsSignatureSets(
 export function getAttesterSlashingSignatureSets(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
+  stateSlot: Slot,
   attesterSlashing: AttesterSlashing
 ): ISignatureSet[] {
   return [attesterSlashing.attestation1, attesterSlashing.attestation2].map((attestation) =>
-    getIndexedAttestationBigintSignatureSet(config, index2pubkey, state, attestation)
+    getIndexedAttestationBigintSignatureSet(config, index2pubkey, stateSlot, attestation)
   );
 }
 
 export function getIndexedAttestationBigintSignatureSet(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
+  stateSlot: Slot,
   indexedAttestation: IndexedAttestationBigint
 ): ISignatureSet {
-  const slot = computeStartSlotAtEpoch(Number(indexedAttestation.data.target.epoch as bigint));
-  const domain = config.getDomain(state.slot, DOMAIN_BEACON_ATTESTER, slot);
+  const messageSlot = computeStartSlotAtEpoch(Number(indexedAttestation.data.target.epoch as bigint));
+  const domain = config.getDomain(stateSlot, DOMAIN_BEACON_ATTESTER, messageSlot);
 
   return {
     type: SignatureSetType.aggregate,

--- a/packages/state-transition/src/signatureSets/indexedAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedAttestation.ts
@@ -1,8 +1,7 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_ATTESTER} from "@lodestar/params";
-import {IndexedAttestation, SignedBeaconBlock, phase0, ssz} from "@lodestar/types";
+import {IndexedAttestation, SignedBeaconBlock, Slot, phase0, ssz} from "@lodestar/types";
 import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
-import {CachedBeaconStateAllForks} from "../types.js";
 import {
   ISignatureSet,
   computeSigningRoot,
@@ -12,11 +11,11 @@ import {
 
 export function getAttestationDataSigningRoot(
   config: BeaconConfig,
-  state: CachedBeaconStateAllForks,
+  stateSlot: Slot,
   data: phase0.AttestationData
 ): Uint8Array {
-  const slot = computeStartSlotAtEpoch(data.target.epoch);
-  const domain = config.getDomain(state.slot, DOMAIN_BEACON_ATTESTER, slot);
+  const messageSlot = computeStartSlotAtEpoch(data.target.epoch);
+  const domain = config.getDomain(stateSlot, DOMAIN_BEACON_ATTESTER, messageSlot);
 
   return computeSigningRoot(ssz.phase0.AttestationData, data, domain);
 }
@@ -24,13 +23,13 @@ export function getAttestationDataSigningRoot(
 export function getAttestationWithIndicesSignatureSet(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
+  stateSlot: Slot,
   attestation: Pick<phase0.Attestation, "data" | "signature">,
   attestingIndices: number[]
 ): ISignatureSet {
   return createAggregateSignatureSetFromComponents(
     attestingIndices.map((i) => index2pubkey[i]),
-    getAttestationDataSigningRoot(config, state, attestation.data),
+    getAttestationDataSigningRoot(config, stateSlot, attestation.data),
     attestation.signature
   );
 }
@@ -38,13 +37,13 @@ export function getAttestationWithIndicesSignatureSet(
 export function getIndexedAttestationSignatureSet(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
+  stateSlot: Slot,
   indexedAttestation: IndexedAttestation
 ): ISignatureSet {
   return getAttestationWithIndicesSignatureSet(
     config,
     index2pubkey,
-    state,
+    stateSlot,
     indexedAttestation,
     indexedAttestation.attestingIndices
   );
@@ -53,7 +52,6 @@ export function getIndexedAttestationSignatureSet(
 export function getAttestationsSignatureSets(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
   signedBlock: SignedBeaconBlock,
   indexedAttestations: IndexedAttestation[]
 ): ISignatureSet[] {
@@ -62,7 +60,10 @@ export function getAttestationsSignatureSets(
       `Indexed attestations length mismatch: got ${indexedAttestations.length}, expected ${signedBlock.message.body.attestations.length}`
     );
   }
+  // the getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition
+  // and the same epoch when we verify blocks in batch in beacon-node. So we can safely use block.slot here.
+  const blockSlot = signedBlock.message.slot;
   return indexedAttestations.map((indexedAttestation) =>
-    getIndexedAttestationSignatureSet(config, index2pubkey, state, indexedAttestation)
+    getIndexedAttestationSignatureSet(config, index2pubkey, blockSlot, indexedAttestation)
   );
 }

--- a/packages/state-transition/src/signatureSets/proposer.ts
+++ b/packages/state-transition/src/signatureSets/proposer.ts
@@ -9,20 +9,21 @@ import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../util/signa
 export function verifyProposerSignature(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
   signedBlock: SignedBeaconBlock | SignedBlindedBeaconBlock
 ): boolean {
-  const signatureSet = getBlockProposerSignatureSet(config, index2pubkey, state, signedBlock);
+  const signatureSet = getBlockProposerSignatureSet(config, index2pubkey, signedBlock);
   return verifySignatureSet(signatureSet);
 }
 
 export function getBlockProposerSignatureSet(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
   signedBlock: SignedBeaconBlock | SignedBlindedBeaconBlock
 ): ISignatureSet {
-  const domain = config.getDomain(state.slot, DOMAIN_BEACON_PROPOSER, signedBlock.message.slot);
+  // the getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition
+  // and the same epoch when we verify blocks in batch in beacon-node. So we can safely use block.slot here.
+  const blockSlot = signedBlock.message.slot;
+  const domain = config.getDomain(blockSlot, DOMAIN_BEACON_PROPOSER, blockSlot);
 
   const blockType = isBlindedBeaconBlock(signedBlock.message)
     ? config.getPostBellatrixForkTypes(signedBlock.message.slot).BlindedBeaconBlock

--- a/packages/state-transition/src/signatureSets/proposerSlashings.ts
+++ b/packages/state-transition/src/signatureSets/proposerSlashings.ts
@@ -1,17 +1,18 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_PROPOSER} from "@lodestar/params";
-import {SignedBeaconBlock, phase0, ssz} from "@lodestar/types";
+import {SignedBeaconBlock, Slot, phase0, ssz} from "@lodestar/types";
 import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
-import {CachedBeaconStateAllForks} from "../types.js";
 import {ISignatureSet, SignatureSetType, computeSigningRoot} from "../util/index.js";
 
 /**
  * Extract signatures to allow validating all block signatures at once
+ * The getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition
+ * and the same epoch when we verify blocks in batch in beacon-node. So we can also safely use block.slot here.
  */
 export function getProposerSlashingSignatureSets(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
+  stateSlot: Slot,
   proposerSlashing: phase0.ProposerSlashing
 ): ISignatureSet[] {
   const pubkey = index2pubkey[proposerSlashing.signedHeader1.message.proposerIndex];
@@ -19,7 +20,7 @@ export function getProposerSlashingSignatureSets(
   // In state transition, ProposerSlashing headers are only partially validated. Their slot could be higher than the
   // clock and the slashing would still be valid. Must use bigint variants to hash correctly to all possible values
   return [proposerSlashing.signedHeader1, proposerSlashing.signedHeader2].map((signedHeader): ISignatureSet => {
-    const domain = config.getDomain(state.slot, DOMAIN_BEACON_PROPOSER, Number(signedHeader.message.slot as bigint));
+    const domain = config.getDomain(stateSlot, DOMAIN_BEACON_PROPOSER, Number(signedHeader.message.slot as bigint));
 
     return {
       type: SignatureSetType.single,
@@ -33,10 +34,10 @@ export function getProposerSlashingSignatureSets(
 export function getProposerSlashingsSignatureSets(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
   signedBlock: SignedBeaconBlock
 ): ISignatureSet[] {
+  const blockSlot = signedBlock.message.slot;
   return signedBlock.message.body.proposerSlashings.flatMap((proposerSlashing) =>
-    getProposerSlashingSignatureSets(config, index2pubkey, state, proposerSlashing)
+    getProposerSlashingSignatureSets(config, index2pubkey, blockSlot, proposerSlashing)
   );
 }

--- a/packages/state-transition/src/signatureSets/proposerSlashings.ts
+++ b/packages/state-transition/src/signatureSets/proposerSlashings.ts
@@ -6,8 +6,6 @@ import {ISignatureSet, SignatureSetType, computeSigningRoot} from "../util/index
 
 /**
  * Extract signatures to allow validating all block signatures at once
- * The getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition
- * and the same epoch when we verify blocks in batch in beacon-node. So we can also safely use block.slot here.
  */
 export function getProposerSlashingSignatureSets(
   config: BeaconConfig,
@@ -36,6 +34,8 @@ export function getProposerSlashingsSignatureSets(
   index2pubkey: Index2PubkeyCache,
   signedBlock: SignedBeaconBlock
 ): ISignatureSet[] {
+  // the getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition
+  // and the same epoch when we verify blocks in batch in beacon-node. So we can safely use block.slot here.
   const blockSlot = signedBlock.message.slot;
   return signedBlock.message.body.proposerSlashings.flatMap((proposerSlashing) =>
     getProposerSlashingSignatureSets(config, index2pubkey, blockSlot, proposerSlashing)

--- a/packages/state-transition/src/signatureSets/randao.ts
+++ b/packages/state-transition/src/signatureSets/randao.ts
@@ -2,7 +2,6 @@ import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_RANDAO} from "@lodestar/params";
 import {BeaconBlock, ssz} from "@lodestar/types";
 import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
-import {CachedBeaconStateAllForks} from "../types.js";
 import {
   ISignatureSet,
   SignatureSetType,
@@ -14,10 +13,9 @@ import {
 export function verifyRandaoSignature(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
   block: BeaconBlock
 ): boolean {
-  return verifySignatureSet(getRandaoRevealSignatureSet(config, index2pubkey, state, block));
+  return verifySignatureSet(getRandaoRevealSignatureSet(config, index2pubkey, block));
 }
 
 /**
@@ -26,12 +24,13 @@ export function verifyRandaoSignature(
 export function getRandaoRevealSignatureSet(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
   block: BeaconBlock
 ): ISignatureSet {
   // should not get epoch from epochCtx
   const epoch = computeEpochAtSlot(block.slot);
-  const domain = config.getDomain(state.slot, DOMAIN_RANDAO, block.slot);
+  // the getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition
+  // and the same epoch when we verify blocks in batch in beacon-node. So we can safely use block.slot here.
+  const domain = config.getDomain(block.slot, DOMAIN_RANDAO, block.slot);
 
   return {
     type: SignatureSetType.single,

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -111,10 +111,7 @@ export function stateTransition(
   postState = processSlotsWithTransientCache(postState, blockSlot, options, {metrics, validatorMonitor});
 
   // Verify proposer signature only
-  if (
-    verifyProposer &&
-    !verifyProposerSignature(postState.config, postState.epochCtx.index2pubkey, postState, signedBlock)
-  ) {
+  if (verifyProposer && !verifyProposerSignature(postState.config, postState.epochCtx.index2pubkey, signedBlock)) {
     throw new Error("Invalid block signature");
   }
 

--- a/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -73,7 +73,7 @@ describe("signatureSets", () => {
     const signatureSets = getBlockSignatureSets(
       state.config,
       state.epochCtx.index2pubkey,
-      state,
+      state.epochCtx.currentSyncCommitteeIndexed,
       signedBlock,
       indexedAttestations
     );


### PR DESCRIPTION
**Motivation**

- we use the whole CachedBeaconStateAllForks to get all block signatures, turn out we only need the validator indices of the current SyncCommittee 

**Description**

given this `getConfig` api: 
```typescript
getDomain(domainSlot: Slot, domainType: DomainType, messageSlot?: Slot): Uint8Array
```

we currently pass `state.slot` as the 1st param. However it's the same to `block.slot` in `state-transition` and the same epoch when we verify blocks in batch in [beacon-node](https://github.com/ChainSafe/lodestar/blob/b255111a2013d43d5f65889274294e2740493c28/packages/beacon-node/src/chain/blocks/verifyBlock.ts#L62)

- so we can just use `block.slot` instead of passing the whole CachedBeaconStateAllForks in `getBlockSignatureSets()` api
- still have to pass in `currentSyncCommitteeIndexed` instead

part of #8650
