### PR TITLE
fix: update default dashboards to new infra hostnames

### DIFF
--- a/dashboards/lodestar_beacon_chain.json
+++ b/dashboards/lodestar_beacon_chain.json
@@ -1478,7 +1478,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_block_processor.json
+++ b/dashboards/lodestar_block_processor.json
@@ -8465,7 +8465,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_block_production.json
+++ b/dashboards/lodestar_block_production.json
@@ -4119,7 +4119,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_block_production.json
+++ b/dashboards/lodestar_block_production.json
@@ -4145,7 +4145,7 @@
       "1h",
       "2h",
       "1d"
-    ]
+    ]unstable-super
   },
   "timezone": "utc",
   "title": "Lodestar - block production",

--- a/dashboards/lodestar_block_production.json
+++ b/dashboards/lodestar_block_production.json
@@ -4145,7 +4145,7 @@
       "1h",
       "2h",
       "1d"
-    ]unstable-super
+    ]
   },
   "timezone": "utc",
   "title": "Lodestar - block production",

--- a/dashboards/lodestar_bls_thread_pool.json
+++ b/dashboards/lodestar_bls_thread_pool.json
@@ -1483,7 +1483,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_debug_gossipsub.json
+++ b/dashboards/lodestar_debug_gossipsub.json
@@ -9420,7 +9420,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_discv5.json
+++ b/dashboards/lodestar_discv5.json
@@ -2168,7 +2168,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_execution_engine.json
+++ b/dashboards/lodestar_execution_engine.json
@@ -1721,7 +1721,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_execution_engine.json
+++ b/dashboards/lodestar_execution_engine.json
@@ -1755,4 +1755,3 @@
   "version": 7,
   "weekStart": "monday"
 }
-unstable-super

--- a/dashboards/lodestar_execution_engine.json
+++ b/dashboards/lodestar_execution_engine.json
@@ -1755,3 +1755,4 @@
   "version": 7,
   "weekStart": "monday"
 }
+unstable-super

--- a/dashboards/lodestar_historical_state_regen.json
+++ b/dashboards/lodestar_historical_state_regen.json
@@ -2601,7 +2601,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_libp2p.json
+++ b/dashboards/lodestar_libp2p.json
@@ -1538,7 +1538,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_multinode.json
+++ b/dashboards/lodestar_multinode.json
@@ -844,7 +844,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_networking.json
+++ b/dashboards/lodestar_networking.json
@@ -6753,7 +6753,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_peerdas.json
+++ b/dashboards/lodestar_peerdas.json
@@ -2002,7 +2002,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_rest_api.json
+++ b/dashboards/lodestar_rest_api.json
@@ -649,7 +649,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_state_cache_regen.json
+++ b/dashboards/lodestar_state_cache_regen.json
@@ -3582,7 +3582,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -3264,7 +3264,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -3276,7 +3276,7 @@
         "current": {
           "selected": false,
           "text": "${VAR_BEACON_JOB}",
-          "value": "${VAR_BEACON_JOB}"
+          "value": "${unstable-super
         },
         "description": "Job name used in Prometheus config to scrape Beacon node",
         "hide": 2,

--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -3276,7 +3276,7 @@
         "current": {
           "selected": false,
           "text": "${VAR_BEACON_JOB}",
-          "value": "${unstable-super
+          "value": "${VAR_BEACON_JOB}"
         },
         "description": "Job name used in Prometheus config to scrape Beacon node",
         "hide": 2,

--- a/dashboards/lodestar_sync.json
+++ b/dashboards/lodestar_sync.json
@@ -2829,7 +2829,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_validator_client.json
+++ b/dashboards/lodestar_validator_client.json
@@ -2804,7 +2804,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_validator_monitor.json
+++ b/dashboards/lodestar_validator_monitor.json
@@ -1896,7 +1896,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/dashboards/lodestar_vm_host.json
+++ b/dashboards/lodestar_vm_host.json
@@ -5928,7 +5928,7 @@
             "condition": "",
             "key": "instance",
             "operator": "=",
-            "value": "unstable-lg1k-hzax41-dkr"
+            "value": "unstable-super"
           }
         ],
         "hide": 0,

--- a/scripts/lint-grafana-dashboard.mjs
+++ b/scripts/lint-grafana-dashboard.mjs
@@ -245,7 +245,7 @@ export function lintGrafanaDashboard(json) {
         condition: "",
         key: "instance",
         operator: "=",
-        value: "unstable-lg1k-hzax41-dkr",
+        value: "unstable-super",
       },
     ],
     hide: 0,


### PR DESCRIPTION
**Motivation**

A recent internal infrastructure change includes renaming default host instance on our dashboards.

**Description**

This PR allows our dashboards to easily default to the new infrastructure host instance for display.
