### PR TITLE
refactor: `processWithdrawals`

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -623,7 +623,7 @@ function preparePayloadAttributes(
     (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals = getExpectedWithdrawals(
       ForkSeq[fork],
       prepareState as CachedBeaconStateCapella
-    ).withdrawals;
+    ).expectedWithdrawals;
   }
 
   if (ForkSeq[fork] >= ForkSeq.deneb) {

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -9,7 +9,7 @@ import {
   MIN_ACTIVATION_BALANCE,
 } from "@lodestar/params";
 import {ValidatorIndex, capella, ssz} from "@lodestar/types";
-import {MapDef, toRootHex} from "@lodestar/utils";
+import {toRootHex} from "@lodestar/utils";
 import {CachedBeaconStateCapella, CachedBeaconStateElectra, CachedBeaconStateGloas} from "../types.js";
 import {isBuilderPaymentWithdrawable, isParentBlockFull} from "../util/gloas.ts";
 import {
@@ -30,12 +30,14 @@ export function processWithdrawals(
     return;
   }
 
-  // processedPartialWithdrawalsCount is withdrawals coming from EL since electra (EIP-7002)
   // processedBuilderWithdrawalsCount is withdrawals coming from builder payment since gloas (EIP-7732)
+  // processedPartialWithdrawalsCount is withdrawals coming from EL since electra (EIP-7002)
+  // processedValidatorSweepCount is withdrawals coming from validator sweep
   const {
-    withdrawals: expectedWithdrawals,
-    processedPartialWithdrawalsCount,
+    expectedWithdrawals,
     processedBuilderWithdrawalsCount,
+    processedPartialWithdrawalsCount,
+    processedValidatorSweepCount,
   } = getExpectedWithdrawals(fork, state);
   const numWithdrawals = expectedWithdrawals.length;
 
@@ -68,12 +70,10 @@ export function processWithdrawals(
     }
   }
 
-  for (let i = 0; i < numWithdrawals; i++) {
-    const withdrawal = expectedWithdrawals[i];
-    decreaseBalance(state, withdrawal.validatorIndex, Number(withdrawal.amount));
-  }
+  applyWithdrawals(state, expectedWithdrawals);
 
   if (fork >= ForkSeq.electra) {
+    // https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.0/specs/electra/beacon-chain.md#new-update_pending_partial_withdrawals
     const stateElectra = state as CachedBeaconStateElectra;
     stateElectra.pendingPartialWithdrawals = stateElectra.pendingPartialWithdrawals.sliceFrom(
       processedPartialWithdrawalsCount
@@ -97,161 +97,171 @@ export function processWithdrawals(
       ...remainingWithdrawals,
     ]);
   }
-
   // Update the nextWithdrawalIndex
+  // https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.0/specs/capella/beacon-chain.md#new-update_next_withdrawal_index
   const latestWithdrawal = expectedWithdrawals.at(-1);
   if (latestWithdrawal) {
     state.nextWithdrawalIndex = latestWithdrawal.index + 1;
   }
 
-  // Update the nextWithdrawalValidatorIndex
-  if (latestWithdrawal && expectedWithdrawals.length === MAX_WITHDRAWALS_PER_PAYLOAD) {
-    // All slots filled, nextWithdrawalValidatorIndex should be validatorIndex having next turn
-    state.nextWithdrawalValidatorIndex = (latestWithdrawal.validatorIndex + 1) % state.validators.length;
-  } else {
-    // expected withdrawals came up short in the bound, so we move nextWithdrawalValidatorIndex to
-    // the next post the bound
-    state.nextWithdrawalValidatorIndex =
-      (state.nextWithdrawalValidatorIndex + MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP) % state.validators.length;
-  }
+  // https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.0/specs/capella/beacon-chain.md#new-update_next_withdrawal_validator_index
+  const nextIndex = state.nextWithdrawalValidatorIndex + processedValidatorSweepCount;
+  const nextValidatorIndex = nextIndex % state.validators.length;
+  state.nextWithdrawalValidatorIndex = nextValidatorIndex;
 }
 
-export function getExpectedWithdrawals(
-  fork: ForkSeq,
-  state: CachedBeaconStateCapella | CachedBeaconStateElectra | CachedBeaconStateGloas
-): {
-  withdrawals: capella.Withdrawal[];
-  sampledValidators: number;
-  processedPartialWithdrawalsCount: number;
-  processedBuilderWithdrawalsCount: number;
-} {
-  if (fork < ForkSeq.capella) {
-    throw new Error(`getExpectedWithdrawals not supported at forkSeq=${fork} < ForkSeq.capella`);
-  }
-
+function getBuilderWithdrawals(
+  state: CachedBeaconStateGloas,
+  withdrawalIndex: number,
+  balanceAfterWithdrawals: Map<ValidatorIndex, number>
+): {builderWithdrawals: capella.Withdrawal[]; withdrawalIndex: number; processedCount: number} {
+  const builderWithdrawals: capella.Withdrawal[] = [];
   const epoch = state.epochCtx.epoch;
-  let withdrawalIndex = state.nextWithdrawalIndex;
-  const {validators, balances, nextWithdrawalValidatorIndex} = state;
+  const allBuilderPendingWithdrawals =
+    state.builderPendingWithdrawals.length <= MAX_WITHDRAWALS_PER_PAYLOAD
+      ? state.builderPendingWithdrawals.getAllReadonly()
+      : null;
 
-  const withdrawals: capella.Withdrawal[] = [];
-  const withdrawnBalances = new MapDef<ValidatorIndex, number>(() => 0);
-  const isPostElectra = fork >= ForkSeq.electra;
-  const isPostGloas = fork >= ForkSeq.gloas;
-  // partialWithdrawalsCount is withdrawals coming from EL since electra (EIP-7002)
-  let processedPartialWithdrawalsCount = 0;
-  // builderWithdrawalsCount is withdrawals coming from builder payments since Gloas (EIP-7732)
-  let processedBuilderWithdrawalsCount = 0;
+  let i = 0;
+  for (i = 0; i < state.builderPendingWithdrawals.length; i++) {
+    const withdrawal = allBuilderPendingWithdrawals
+      ? allBuilderPendingWithdrawals[i]
+      : state.builderPendingWithdrawals.getReadonly(i);
 
-  if (isPostGloas) {
-    const stateGloas = state as CachedBeaconStateGloas;
-
-    const allBuilderPendingWithdrawals =
-      stateGloas.builderPendingWithdrawals.length <= MAX_WITHDRAWALS_PER_PAYLOAD
-        ? stateGloas.builderPendingWithdrawals.getAllReadonly()
-        : null;
-
-    for (let i = 0; i < stateGloas.builderPendingWithdrawals.length; i++) {
-      const withdrawal = allBuilderPendingWithdrawals
-        ? allBuilderPendingWithdrawals[i]
-        : stateGloas.builderPendingWithdrawals.getReadonly(i);
-
-      if (withdrawal.withdrawableEpoch > epoch || withdrawals.length + 1 === MAX_WITHDRAWALS_PER_PAYLOAD) {
-        break;
-      }
-
-      if (isBuilderPaymentWithdrawable(stateGloas, withdrawal)) {
-        const totalWithdrawn = withdrawnBalances.getOrDefault(withdrawal.builderIndex);
-        const balance = state.balances.get(withdrawal.builderIndex) - totalWithdrawn;
-        const builder = state.validators.get(withdrawal.builderIndex);
-
-        let withdrawableBalance = 0;
-
-        if (builder.slashed) {
-          withdrawableBalance = balance < withdrawal.amount ? balance : withdrawal.amount;
-        } else if (balance > MIN_ACTIVATION_BALANCE) {
-          withdrawableBalance =
-            balance - MIN_ACTIVATION_BALANCE < withdrawal.amount ? balance - MIN_ACTIVATION_BALANCE : withdrawal.amount;
-        }
-
-        if (withdrawableBalance > 0) {
-          withdrawals.push({
-            index: withdrawalIndex,
-            validatorIndex: withdrawal.builderIndex,
-            address: withdrawal.feeRecipient,
-            amount: BigInt(withdrawableBalance),
-          });
-          withdrawalIndex++;
-          withdrawnBalances.set(withdrawal.builderIndex, totalWithdrawn + withdrawableBalance);
-        }
-      }
-      processedBuilderWithdrawalsCount++;
+    if (withdrawal.withdrawableEpoch > epoch || builderWithdrawals.length + 1 === MAX_WITHDRAWALS_PER_PAYLOAD) {
+      break;
     }
-  }
 
-  if (isPostElectra) {
-    // In pre-gloas, partialWithdrawalBound == MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
-    const partialWithdrawalBound = Math.min(
-      withdrawals.length + MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
-      MAX_WITHDRAWALS_PER_PAYLOAD - 1
-    );
-    const stateElectra = state as CachedBeaconStateElectra;
+    if (isBuilderPaymentWithdrawable(state, withdrawal)) {
+      const builderIndex = withdrawal.builderIndex;
+      const builder = state.validators.get(withdrawal.builderIndex);
 
-    // MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP = 8, PENDING_PARTIAL_WITHDRAWALS_LIMIT: 134217728 so we should only call getAllReadonly() if it makes sense
-    // pendingPartialWithdrawals comes from EIP-7002 smart contract where it takes fee so it's more likely than not validator is in correct condition to withdraw
-    // also we may break early if withdrawableEpoch > epoch
-    const allPendingPartialWithdrawals =
-      stateElectra.pendingPartialWithdrawals.length <= partialWithdrawalBound
-        ? stateElectra.pendingPartialWithdrawals.getAllReadonly()
-        : null;
-
-    // EIP-7002: Execution layer triggerable withdrawals
-    for (let i = 0; i < stateElectra.pendingPartialWithdrawals.length; i++) {
-      const withdrawal = allPendingPartialWithdrawals
-        ? allPendingPartialWithdrawals[i]
-        : stateElectra.pendingPartialWithdrawals.getReadonly(i);
-      if (withdrawal.withdrawableEpoch > epoch || withdrawals.length === partialWithdrawalBound) {
-        break;
+      let balance = balanceAfterWithdrawals.get(builderIndex);
+      if (balance === undefined) {
+        balance = state.balances.get(builderIndex);
+        balanceAfterWithdrawals.set(builderIndex, balance);
       }
 
-      const validator = validators.getReadonly(withdrawal.validatorIndex);
-      const totalWithdrawn = withdrawnBalances.getOrDefault(withdrawal.validatorIndex);
-      const balance = state.balances.get(withdrawal.validatorIndex) - totalWithdrawn;
+      let withdrawableBalance = 0;
 
-      if (
-        validator.exitEpoch === FAR_FUTURE_EPOCH &&
-        validator.effectiveBalance >= MIN_ACTIVATION_BALANCE &&
-        balance > MIN_ACTIVATION_BALANCE
-      ) {
-        const balanceOverMinActivationBalance = BigInt(balance - MIN_ACTIVATION_BALANCE);
-        const withdrawableBalance =
-          balanceOverMinActivationBalance < withdrawal.amount ? balanceOverMinActivationBalance : withdrawal.amount;
-        withdrawals.push({
+      if (builder.slashed) {
+        withdrawableBalance = balance < withdrawal.amount ? balance : withdrawal.amount;
+      } else if (balance > MIN_ACTIVATION_BALANCE) {
+        withdrawableBalance =
+          balance - MIN_ACTIVATION_BALANCE < withdrawal.amount ? balance - MIN_ACTIVATION_BALANCE : withdrawal.amount;
+      }
+
+      if (withdrawableBalance > 0) {
+        builderWithdrawals.push({
           index: withdrawalIndex,
-          validatorIndex: withdrawal.validatorIndex,
-          address: validator.withdrawalCredentials.subarray(12),
-          amount: withdrawableBalance,
+          validatorIndex: withdrawal.builderIndex,
+          address: withdrawal.feeRecipient,
+          amount: BigInt(withdrawableBalance),
         });
         withdrawalIndex++;
-        withdrawnBalances.set(withdrawal.validatorIndex, totalWithdrawn + Number(withdrawableBalance));
+        balanceAfterWithdrawals.set(builderIndex, balance - withdrawableBalance);
       }
-      processedPartialWithdrawalsCount++;
     }
   }
 
-  const withdrawalBound = Math.min(validators.length, MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP);
+  return {builderWithdrawals, withdrawalIndex, processedCount: i};
+}
+
+function getPendingPartialWithdrawals(
+  state: CachedBeaconStateElectra,
+  withdrawalIndex: number,
+  numPriorWithdrawal: number,
+  balanceAfterWithdrawals: Map<ValidatorIndex, number>
+): {pendingPartialWithdrawals: capella.Withdrawal[]; withdrawalIndex: number; processedCount: number} {
+  const epoch = state.epochCtx.epoch;
+  const pendingPartialWithdrawals: capella.Withdrawal[] = [];
+  const validators = state.validators;
+
+  // In pre-gloas, partialWithdrawalBound == MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
+  const partialWithdrawalBound = Math.min(
+    numPriorWithdrawal + MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
+    MAX_WITHDRAWALS_PER_PAYLOAD - 1
+  );
+
+  // MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP = 8, PENDING_PARTIAL_WITHDRAWALS_LIMIT: 134217728 so we should only call getAllReadonly() if it makes sense
+  // pendingPartialWithdrawals comes from EIP-7002 smart contract where it takes fee so it's more likely than not validator is in correct condition to withdraw
+  // also we may break early if withdrawableEpoch > epoch
+  const allPendingPartialWithdrawals =
+    state.pendingPartialWithdrawals.length <= partialWithdrawalBound
+      ? state.pendingPartialWithdrawals.getAllReadonly()
+      : null;
+
+  // EIP-7002: Execution layer triggerable withdrawals
+  let i = 0;
+  for (i = 0; i < state.pendingPartialWithdrawals.length; i++) {
+    const withdrawal = allPendingPartialWithdrawals
+      ? allPendingPartialWithdrawals[i]
+      : state.pendingPartialWithdrawals.getReadonly(i);
+    if (withdrawal.withdrawableEpoch > epoch || pendingPartialWithdrawals.length === partialWithdrawalBound) {
+      break;
+    }
+
+    const validatorIndex = withdrawal.validatorIndex;
+    const validator = validators.getReadonly(validatorIndex);
+    let balance = balanceAfterWithdrawals.get(validatorIndex);
+    if (balance === undefined) {
+      balance = state.balances.get(validatorIndex);
+      balanceAfterWithdrawals.set(validatorIndex, balance);
+    }
+
+    if (
+      validator.exitEpoch === FAR_FUTURE_EPOCH &&
+      validator.effectiveBalance >= MIN_ACTIVATION_BALANCE &&
+      balance > MIN_ACTIVATION_BALANCE
+    ) {
+      const balanceOverMinActivationBalance = BigInt(balance - MIN_ACTIVATION_BALANCE);
+      const withdrawableBalance =
+        balanceOverMinActivationBalance < withdrawal.amount ? balanceOverMinActivationBalance : withdrawal.amount;
+      pendingPartialWithdrawals.push({
+        index: withdrawalIndex,
+        validatorIndex,
+        address: validator.withdrawalCredentials.subarray(12),
+        amount: withdrawableBalance,
+      });
+      withdrawalIndex++;
+      balanceAfterWithdrawals.set(withdrawal.validatorIndex, balance - Number(withdrawableBalance));
+    }
+  }
+
+  return {pendingPartialWithdrawals, withdrawalIndex, processedCount: i};
+}
+
+function getValidatorsSweepWithdrawals(
+  fork: ForkSeq,
+  state: CachedBeaconStateCapella | CachedBeaconStateElectra | CachedBeaconStateGloas,
+  withdrawalIndex: number,
+  numPriorWithdrawal: number,
+  balanceAfterWithdrawals: Map<ValidatorIndex, number>
+): {sweepWithdrawals: capella.Withdrawal[]; processedCount: number} {
+  const sweepWithdrawals: capella.Withdrawal[] = [];
+  const epoch = state.epochCtx.epoch;
+  const {validators, balances, nextWithdrawalValidatorIndex} = state;
+  const isPostElectra = fork >= ForkSeq.electra;
+
+  const validatorsLimit = Math.min(state.validators.length, MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP);
   let n = 0;
   // Just run a bounded loop max iterating over all withdrawals
   // however breaks out once we have MAX_WITHDRAWALS_PER_PAYLOAD
-  for (n = 0; n < withdrawalBound; n++) {
+  for (n = 0; n < validatorsLimit; n++) {
+    if (sweepWithdrawals.length + numPriorWithdrawal === MAX_WITHDRAWALS_PER_PAYLOAD) {
+      break;
+    }
+
     // Get next validator in turn
     const validatorIndex = (nextWithdrawalValidatorIndex + n) % validators.length;
 
     const validator = validators.getReadonly(validatorIndex);
-    const withdrawnBalance = withdrawnBalances.getOrDefault(validatorIndex);
-    const balance = isPostElectra
-      ? // Deduct partially withdrawn balance already queued above
-        balances.get(validatorIndex) - withdrawnBalance
-      : balances.get(validatorIndex);
+    let balance = balanceAfterWithdrawals.get(validatorIndex);
+    if (balance === undefined) {
+      balance = balances.get(validatorIndex);
+      balanceAfterWithdrawals.set(validatorIndex, balance);
+    }
+
     const {withdrawableEpoch, withdrawalCredentials, effectiveBalance} = validator;
     const hasWithdrawableCredentials = isPostElectra
       ? hasExecutionWithdrawalCredential(withdrawalCredentials)
@@ -264,35 +274,108 @@ export function getExpectedWithdrawals(
 
     // capella full withdrawal
     if (withdrawableEpoch <= epoch) {
-      withdrawals.push({
+      sweepWithdrawals.push({
         index: withdrawalIndex,
         validatorIndex,
         address: validator.withdrawalCredentials.subarray(12),
         amount: BigInt(balance),
       });
       withdrawalIndex++;
-      withdrawnBalances.set(validatorIndex, withdrawnBalance + balance);
+      balanceAfterWithdrawals.set(validatorIndex, 0);
     } else if (
       effectiveBalance === (isPostElectra ? getMaxEffectiveBalance(withdrawalCredentials) : MAX_EFFECTIVE_BALANCE) &&
       balance > effectiveBalance
     ) {
       // capella partial withdrawal
       const partialAmount = balance - effectiveBalance;
-      withdrawals.push({
+      sweepWithdrawals.push({
         index: withdrawalIndex,
         validatorIndex,
         address: validator.withdrawalCredentials.subarray(12),
         amount: BigInt(partialAmount),
       });
       withdrawalIndex++;
-      withdrawnBalances.set(validatorIndex, withdrawnBalance + partialAmount);
-    }
-
-    // Break if we have enough to pack the block
-    if (withdrawals.length >= MAX_WITHDRAWALS_PER_PAYLOAD) {
-      break;
+      balanceAfterWithdrawals.set(validatorIndex, balance - partialAmount);
     }
   }
 
-  return {withdrawals, sampledValidators: n, processedPartialWithdrawalsCount, processedBuilderWithdrawalsCount};
+  return {sweepWithdrawals: sweepWithdrawals, processedCount: n};
+}
+
+function applyWithdrawals(
+  state: CachedBeaconStateCapella | CachedBeaconStateElectra | CachedBeaconStateGloas,
+  withdrawals: capella.Withdrawal[]
+): void {
+  for (const withdrawal of withdrawals) {
+    decreaseBalance(state, withdrawal.validatorIndex, Number(withdrawal.amount));
+  }
+}
+
+export function getExpectedWithdrawals(
+  fork: ForkSeq,
+  state: CachedBeaconStateCapella | CachedBeaconStateElectra | CachedBeaconStateGloas
+): {
+  expectedWithdrawals: capella.Withdrawal[];
+  processedBuilderWithdrawalsCount: number;
+  processedPartialWithdrawalsCount: number;
+  processedValidatorSweepCount: number;
+} {
+  if (fork < ForkSeq.capella) {
+    throw new Error(`getExpectedWithdrawals not supported at forkSeq=${fork} < ForkSeq.capella`);
+  }
+
+  let withdrawalIndex = state.nextWithdrawalIndex;
+
+  const expectedWithdrawals: capella.Withdrawal[] = [];
+  const balanceAfterWithdrawals = new Map<ValidatorIndex, number>();
+  // partialWithdrawalsCount is withdrawals coming from EL since electra (EIP-7002)
+  let processedPartialWithdrawalsCount = 0;
+  // builderWithdrawalsCount is withdrawals coming from builder payments since Gloas (EIP-7732)
+  let processedBuilderWithdrawalsCount = 0;
+
+  if (fork >= ForkSeq.gloas) {
+    const {
+      builderWithdrawals,
+      withdrawalIndex: newWithdrawalIndex,
+      processedCount,
+    } = getBuilderWithdrawals(state as CachedBeaconStateGloas, withdrawalIndex, balanceAfterWithdrawals);
+
+    expectedWithdrawals.push(...builderWithdrawals);
+    withdrawalIndex = newWithdrawalIndex;
+    processedBuilderWithdrawalsCount = processedCount;
+  }
+
+  if (fork >= ForkSeq.electra) {
+    const {
+      pendingPartialWithdrawals,
+      withdrawalIndex: newWithdrawalIndex,
+      processedCount,
+    } = getPendingPartialWithdrawals(
+      state as CachedBeaconStateElectra,
+      withdrawalIndex,
+      expectedWithdrawals.length,
+      balanceAfterWithdrawals
+    );
+
+    expectedWithdrawals.push(...pendingPartialWithdrawals);
+    withdrawalIndex = newWithdrawalIndex;
+    processedPartialWithdrawalsCount = processedCount;
+  }
+
+  const {sweepWithdrawals, processedCount: processedValidatorSweepCount} = getValidatorsSweepWithdrawals(
+    fork,
+    state,
+    withdrawalIndex,
+    0,
+    balanceAfterWithdrawals
+  );
+
+  expectedWithdrawals.push(...sweepWithdrawals);
+
+  return {
+    expectedWithdrawals,
+    processedBuilderWithdrawalsCount,
+    processedPartialWithdrawalsCount,
+    processedValidatorSweepCount,
+  };
 }

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -122,8 +122,8 @@ function getBuilderWithdrawals(
       ? state.builderPendingWithdrawals.getAllReadonly()
       : null;
 
-  let i = 0;
-  for (i = 0; i < state.builderPendingWithdrawals.length; i++) {
+  let processedCount = 0;
+  for (let i = 0; i < state.builderPendingWithdrawals.length; i++) {
     const withdrawal = allBuilderPendingWithdrawals
       ? allBuilderPendingWithdrawals[i]
       : state.builderPendingWithdrawals.getReadonly(i);
@@ -162,9 +162,10 @@ function getBuilderWithdrawals(
         balanceAfterWithdrawals.set(builderIndex, balance - withdrawableBalance);
       }
     }
+    processedCount++;
   }
 
-  return {builderWithdrawals, withdrawalIndex, processedCount: i};
+  return {builderWithdrawals, withdrawalIndex, processedCount};
 }
 
 function getPendingPartialWithdrawals(
@@ -192,8 +193,8 @@ function getPendingPartialWithdrawals(
       : null;
 
   // EIP-7002: Execution layer triggerable withdrawals
-  let i = 0;
-  for (i = 0; i < state.pendingPartialWithdrawals.length; i++) {
+  let processedCount = 0;
+  for (let i = 0; i < state.pendingPartialWithdrawals.length; i++) {
     const withdrawal = allPendingPartialWithdrawals
       ? allPendingPartialWithdrawals[i]
       : state.pendingPartialWithdrawals.getReadonly(i);
@@ -229,9 +230,10 @@ function getPendingPartialWithdrawals(
       withdrawalIndex++;
       balanceAfterWithdrawals.set(withdrawal.validatorIndex, balance - Number(withdrawableBalance));
     }
+    processedCount++;
   }
 
-  return {pendingPartialWithdrawals, withdrawalIndex, processedCount: i};
+  return {pendingPartialWithdrawals, withdrawalIndex, processedCount};
 }
 
 function getValidatorsSweepWithdrawals(
@@ -247,10 +249,10 @@ function getValidatorsSweepWithdrawals(
   const isPostElectra = fork >= ForkSeq.electra;
 
   const validatorsLimit = Math.min(state.validators.length, MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP);
-  let n = 0;
+  let processedCount = 0;
   // Just run a bounded loop max iterating over all withdrawals
   // however breaks out once we have MAX_WITHDRAWALS_PER_PAYLOAD
-  for (n = 0; n < validatorsLimit; n++) {
+  for (let n = 0; n < validatorsLimit; n++) {
     if (sweepWithdrawals.length + numPriorWithdrawal === MAX_WITHDRAWALS_PER_PAYLOAD) {
       break;
     }
@@ -272,6 +274,7 @@ function getValidatorsSweepWithdrawals(
     // early skip for balance = 0 as its now more likely that validator has exited/slashed with
     // balance zero than not have withdrawal credentials set
     if (balance === 0 || !hasWithdrawableCredentials) {
+      processedCount++;
       continue;
     }
 
@@ -300,9 +303,10 @@ function getValidatorsSweepWithdrawals(
       withdrawalIndex++;
       balanceAfterWithdrawals.set(validatorIndex, balance - partialAmount);
     }
+    processedCount++;
   }
 
-  return {sweepWithdrawals: sweepWithdrawals, processedCount: n};
+  return {sweepWithdrawals: sweepWithdrawals, processedCount};
 }
 
 function applyWithdrawals(

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -327,6 +327,8 @@ export function getExpectedWithdrawals(
   let withdrawalIndex = state.nextWithdrawalIndex;
 
   const expectedWithdrawals: capella.Withdrawal[] = [];
+  // Map to track balances after applying withdrawals
+  // https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.0/specs/capella/beacon-chain.md#new-get_balance_after_withdrawals
   const balanceAfterWithdrawals = new Map<ValidatorIndex, number>();
   // partialWithdrawalsCount is withdrawals coming from EL since electra (EIP-7002)
   let processedPartialWithdrawalsCount = 0;

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -105,7 +105,8 @@ export function processWithdrawals(
   }
 
   // https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.0/specs/capella/beacon-chain.md#new-update_next_withdrawal_validator_index
-  const nextIndex = state.nextWithdrawalValidatorIndex + processedValidatorSweepCount;
+  const nextIndex =
+    state.nextWithdrawalValidatorIndex + Math.max(processedValidatorSweepCount, MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP);
   const nextValidatorIndex = nextIndex % state.validators.length;
   state.nextWithdrawalValidatorIndex = nextValidatorIndex;
 }

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -231,7 +231,7 @@ function getPendingPartialWithdrawals(
         amount: withdrawableBalance,
       });
       withdrawalIndex++;
-      balanceAfterWithdrawals.set(withdrawal.validatorIndex, balance - Number(withdrawableBalance));
+      balanceAfterWithdrawals.set(validatorIndex, balance - Number(withdrawableBalance));
     }
     processedCount++;
   }
@@ -309,7 +309,7 @@ function getValidatorsSweepWithdrawals(
     processedCount++;
   }
 
-  return {sweepWithdrawals: sweepWithdrawals, processedCount};
+  return {sweepWithdrawals, processedCount};
 }
 
 function applyWithdrawals(

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -128,7 +128,7 @@ function getBuilderWithdrawals(
       ? allBuilderPendingWithdrawals[i]
       : state.builderPendingWithdrawals.getReadonly(i);
 
-    if (withdrawal.withdrawableEpoch > epoch || builderWithdrawals.length + 1 === MAX_WITHDRAWALS_PER_PAYLOAD) {
+    if (withdrawal.withdrawableEpoch > epoch || builderWithdrawals.length === MAX_WITHDRAWALS_PER_PAYLOAD) {
       break;
     }
 
@@ -197,7 +197,10 @@ function getPendingPartialWithdrawals(
     const withdrawal = allPendingPartialWithdrawals
       ? allPendingPartialWithdrawals[i]
       : state.pendingPartialWithdrawals.getReadonly(i);
-    if (withdrawal.withdrawableEpoch > epoch || pendingPartialWithdrawals.length === partialWithdrawalBound) {
+    if (
+      withdrawal.withdrawableEpoch > epoch ||
+      pendingPartialWithdrawals.length + numPriorWithdrawal === partialWithdrawalBound
+    ) {
       break;
     }
 
@@ -368,7 +371,7 @@ export function getExpectedWithdrawals(
     fork,
     state,
     withdrawalIndex,
-    0,
+    expectedWithdrawals.length,
     balanceAfterWithdrawals
   );
 

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -33,12 +33,8 @@ export function processWithdrawals(
   // processedBuilderWithdrawalsCount is withdrawals coming from builder payment since gloas (EIP-7732)
   // processedPartialWithdrawalsCount is withdrawals coming from EL since electra (EIP-7002)
   // processedValidatorSweepCount is withdrawals coming from validator sweep
-  const {
-    expectedWithdrawals,
-    processedBuilderWithdrawalsCount,
-    processedPartialWithdrawalsCount,
-    processedValidatorSweepCount,
-  } = getExpectedWithdrawals(fork, state);
+  const {expectedWithdrawals, processedBuilderWithdrawalsCount, processedPartialWithdrawalsCount} =
+    getExpectedWithdrawals(fork, state);
   const numWithdrawals = expectedWithdrawals.length;
 
   // After gloas, withdrawals are verified later in processExecutionPayloadEnvelope
@@ -107,7 +103,7 @@ export function processWithdrawals(
   // https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.0/specs/capella/beacon-chain.md#new-update_next_withdrawal_validator_index
   // Update the nextWithdrawalValidatorIndex
   if (latestWithdrawal && expectedWithdrawals.length === MAX_WITHDRAWALS_PER_PAYLOAD) {
-     // All slots filled, nextWithdrawalValidatorIndex should be validatorIndex having next turn
+    // All slots filled, nextWithdrawalValidatorIndex should be validatorIndex having next turn
     state.nextWithdrawalValidatorIndex = (latestWithdrawal.validatorIndex + 1) % state.validators.length;
   } else {
     // expected withdrawals came up short in the bound, so we move nextWithdrawalValidatorIndex to

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -105,10 +105,16 @@ export function processWithdrawals(
   }
 
   // https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.0/specs/capella/beacon-chain.md#new-update_next_withdrawal_validator_index
-  const nextIndex =
-    state.nextWithdrawalValidatorIndex + Math.max(processedValidatorSweepCount, MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP);
-  const nextValidatorIndex = nextIndex % state.validators.length;
-  state.nextWithdrawalValidatorIndex = nextValidatorIndex;
+  // Update the nextWithdrawalValidatorIndex
+  if (latestWithdrawal && expectedWithdrawals.length === MAX_WITHDRAWALS_PER_PAYLOAD) {
+     // All slots filled, nextWithdrawalValidatorIndex should be validatorIndex having next turn
+    state.nextWithdrawalValidatorIndex = (latestWithdrawal.validatorIndex + 1) % state.validators.length;
+  } else {
+    // expected withdrawals came up short in the bound, so we move nextWithdrawalValidatorIndex to
+    // the next post the bound
+    state.nextWithdrawalValidatorIndex =
+      (state.nextWithdrawalValidatorIndex + MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP) % state.validators.length;
+  }
 }
 
 function getBuilderWithdrawals(

--- a/packages/state-transition/test/perf/block/processWithdrawals.test.ts
+++ b/packages/state-transition/test/perf/block/processWithdrawals.test.ts
@@ -24,15 +24,15 @@ describe("getExpectedWithdrawals", () => {
   //  - or they were full withdrawan and zero balance
   const testCases: (WithdrawalOpts & {cache: boolean; sampled: number})[] = [
     // Best case when every probe results into a withdrawal candidate
-    {excessBalance: 1, eth1Credentials: 1, withdrawable: 0, withdrawn: 0, cache: true, sampled: 15},
+    {excessBalance: 1, eth1Credentials: 1, withdrawable: 0, withdrawn: 0, cache: true, sampled: 16},
     // Normal case based on mainnet conditions: mainnet network conditions: 95% reward rate
-    {excessBalance: 0.95, eth1Credentials: 0.1, withdrawable: 0.05, withdrawn: 0, cache: true, sampled: 219},
+    {excessBalance: 0.95, eth1Credentials: 0.1, withdrawable: 0.05, withdrawn: 0, cache: true, sampled: 220},
     // Intermediate good case
-    {excessBalance: 0.95, eth1Credentials: 0.3, withdrawable: 0.05, withdrawn: 0, cache: true, sampled: 42},
-    {excessBalance: 0.95, eth1Credentials: 0.7, withdrawable: 0.05, withdrawn: 0, cache: true, sampled: 18},
+    {excessBalance: 0.95, eth1Credentials: 0.3, withdrawable: 0.05, withdrawn: 0, cache: true, sampled: 43},
+    {excessBalance: 0.95, eth1Credentials: 0.7, withdrawable: 0.05, withdrawn: 0, cache: true, sampled: 19},
     // Intermediate bad case
-    {excessBalance: 0.1, eth1Credentials: 0.1, withdrawable: 0, withdrawn: 0, cache: true, sampled: 1_020},
-    {excessBalance: 0.03, eth1Credentials: 0.03, withdrawable: 0, withdrawn: 0, cache: true, sampled: 11_777},
+    {excessBalance: 0.1, eth1Credentials: 0.1, withdrawable: 0, withdrawn: 0, cache: true, sampled: 1_021},
+    {excessBalance: 0.03, eth1Credentials: 0.03, withdrawable: 0, withdrawn: 0, cache: true, sampled: 11_778},
     // Expected 141_069 but gets bounded at 16_384
     {excessBalance: 0.01, eth1Credentials: 0.01, withdrawable: 0, withdrawn: 0, cache: true, sampled: 16_384},
     // Worst case: All validators 250_000 need to be probed but get bounded at 16_384

--- a/packages/state-transition/test/perf/block/processWithdrawals.test.ts
+++ b/packages/state-transition/test/perf/block/processWithdrawals.test.ts
@@ -70,9 +70,9 @@ describe("getExpectedWithdrawals", () => {
         return opts.cache ? state : state.clone(true);
       },
       fn: (state) => {
-        const {sampledValidators} = getExpectedWithdrawals(ForkSeq.capella, state); // TODO Electra: Do test for electra
-        if (sampledValidators !== opts.sampled) {
-          throw Error(`Wrong sampledValidators ${sampledValidators} != ${opts.sampled}`);
+        const {processedValidatorSweepCount} = getExpectedWithdrawals(ForkSeq.capella, state); // TODO Electra: Do test for electra
+        if (processedValidatorSweepCount !== opts.sampled) {
+          throw Error(`Wrong sampledValidators ${processedValidatorSweepCount} != ${opts.sampled}`);
         }
       },
     });

--- a/packages/state-transition/test/unit/block/processWithdrawals.test.ts
+++ b/packages/state-transition/test/unit/block/processWithdrawals.test.ts
@@ -10,14 +10,14 @@ describe("getExpectedWithdrawals", () => {
 
   const testCases: (WithdrawalOpts & {withdrawals: number; sampled: number})[] = [
     // Best case when every probe results into a withdrawal candidate
-    {excessBalance: 1, eth1Credentials: 1, withdrawable: 0, withdrawn: 0, withdrawals: 16, sampled: 15},
+    {excessBalance: 1, eth1Credentials: 1, withdrawable: 0, withdrawn: 0, withdrawals: 16, sampled: 16},
     // Normal case based on mainnet conditions: mainnet network conditions: 95% reward rate
-    {excessBalance: 0.95, eth1Credentials: 0.1, withdrawable: 0.05, withdrawn: 0, withdrawals: 16, sampled: 219},
+    {excessBalance: 0.95, eth1Credentials: 0.1, withdrawable: 0.05, withdrawn: 0, withdrawals: 16, sampled: 220},
     // Intermediate good case
-    {excessBalance: 0.95, eth1Credentials: 0.3, withdrawable: 0.05, withdrawn: 0, withdrawals: 16, sampled: 42},
-    {excessBalance: 0.95, eth1Credentials: 0.7, withdrawable: 0.05, withdrawn: 0, withdrawals: 16, sampled: 18},
+    {excessBalance: 0.95, eth1Credentials: 0.3, withdrawable: 0.05, withdrawn: 0, withdrawals: 16, sampled: 43},
+    {excessBalance: 0.95, eth1Credentials: 0.7, withdrawable: 0.05, withdrawn: 0, withdrawals: 16, sampled: 19},
     // Intermediate bad case
-    {excessBalance: 0.1, eth1Credentials: 0.1, withdrawable: 0, withdrawn: 0, withdrawals: 16, sampled: 1020},
+    {excessBalance: 0.1, eth1Credentials: 0.1, withdrawable: 0, withdrawn: 0, withdrawals: 16, sampled: 1021},
     // Expected 141069 but gets bounded by 16384
     {excessBalance: 0.01, eth1Credentials: 0.01, withdrawable: 0, withdrawn: 0, withdrawals: 2, sampled: 16384},
     // Expected 250000 but gets bounded by 16384

--- a/packages/state-transition/test/unit/block/processWithdrawals.test.ts
+++ b/packages/state-transition/test/unit/block/processWithdrawals.test.ts
@@ -39,9 +39,9 @@ describe("getExpectedWithdrawals", () => {
 
     // TODO Electra: Add test for electra
     it(`getExpectedWithdrawals ${vc} ${caseID}`, () => {
-      const {sampledValidators, withdrawals} = getExpectedWithdrawals(ForkSeq.capella, state.value);
-      expect(sampledValidators).toBe(opts.sampled);
-      expect(withdrawals.length).toBe(opts.withdrawals);
+      const {processedValidatorSweepCount, expectedWithdrawals} = getExpectedWithdrawals(ForkSeq.capella, state.value);
+      expect(processedValidatorSweepCount).toBe(opts.sampled);
+      expect(expectedWithdrawals.length).toBe(opts.withdrawals);
     });
   }
 });


### PR DESCRIPTION
Refactor so our codebase is more aligned with the recent spec change. Majority of the refactor is in `getExpectedWithdrawals`. 

See ethereum/consensus-specs#4766 and ethereum/consensus-specs#4765 for context.

- Logic of each of the (gloas's builder withdrawals, electra's pending partial withdrawals and capella's sweep withdrawals) will live in their own respective function
- `withdrawnBalances` is replaced by `balanceAfterWithdrawals`. Instead of tracking amounts getting withdrawn, it tracks remaining balance of each validator after withdrawals.

Note the builder pending withdrawal logic is outdated. It is out of this refactor PR's scope. Will update it in the following PR.