### PR TITLE
refactor: generalize state repositories

### DIFF
--- a/packages/beacon-node/src/chain/initState.ts
+++ b/packages/beacon-node/src/chain/initState.ts
@@ -6,6 +6,7 @@ import {Logger, toHex, toRootHex} from "@lodestar/utils";
 import {GENESIS_SLOT} from "../constants/index.js";
 import {IBeaconDb} from "../db/index.js";
 import {Metrics} from "../metrics/index.js";
+import {getStateTypeFromBytes} from "../util/multifork.js";
 
 export async function persistAnchorState(
   config: ChainForkConfig,
@@ -47,6 +48,29 @@ export function createGenesisBlock(config: ChainForkConfig, genesisState: Beacon
   const stateRoot = genesisState.hashTreeRoot();
   genesisBlock.message.stateRoot = stateRoot;
   return genesisBlock;
+}
+
+/**
+ * Restore the latest beacon state from db
+ */
+export async function initStateFromDb(
+  config: ChainForkConfig,
+  db: IBeaconDb,
+  logger: Logger
+): Promise<BeaconStateAllForks> {
+  const stateBytes = await db.stateArchive.lastBinary();
+  if (stateBytes == null) {
+    throw new Error("No state exists in database");
+  }
+  const state = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);
+
+  logger.info("Initializing beacon state from db", {
+    slot: state.slot,
+    epoch: computeEpochAtSlot(state.slot),
+    stateRoot: toRootHex(state.hashTreeRoot()),
+  });
+
+  return state;
 }
 
 /**

--- a/packages/beacon-node/src/chain/initState.ts
+++ b/packages/beacon-node/src/chain/initState.ts
@@ -50,28 +50,6 @@ export function createGenesisBlock(config: ChainForkConfig, genesisState: Beacon
 }
 
 /**
- * Restore the latest beacon state from db
- */
-export async function initStateFromDb(
-  _config: ChainForkConfig,
-  db: IBeaconDb,
-  logger: Logger
-): Promise<BeaconStateAllForks> {
-  const state = await db.stateArchive.lastValue();
-  if (!state) {
-    throw new Error("No state exists in database");
-  }
-
-  logger.info("Initializing beacon state from db", {
-    slot: state.slot,
-    epoch: computeEpochAtSlot(state.slot),
-    stateRoot: toRootHex(state.hashTreeRoot()),
-  });
-
-  return state;
-}
-
-/**
  * Initialize and persist an anchor state (either weak subjectivity or genesis)
  */
 export async function checkAndPersistAnchorState(

--- a/packages/beacon-node/src/db/repositories/checkpointState.ts
+++ b/packages/beacon-node/src/db/repositories/checkpointState.ts
@@ -1,31 +1,15 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Db, Repository} from "@lodestar/db";
-import {BeaconStateAllForks} from "@lodestar/state-transition";
-import {ssz} from "@lodestar/types";
+import {BinaryRepository, Db} from "@lodestar/db";
 import {Bucket, getBucketNameByValue} from "../buckets.js";
 
 /**
  * Store temporary checkpoint states.
  * We should only put/get binary data from this repository, consumer will load it into an existing state ViewDU object.
  */
-export class CheckpointStateRepository extends Repository<Uint8Array, BeaconStateAllForks> {
+export class CheckpointStateRepository extends BinaryRepository<Uint8Array> {
   constructor(config: ChainForkConfig, db: Db) {
-    // Pick some type but won't be used. Casted to any because no type can match `BeaconStateAllForks`
-    const type = ssz.phase0.BeaconState;
     const bucket = Bucket.allForks_checkpointState;
     // biome-ignore lint/suspicious/noExplicitAny: The type is complex to specify a proper override
-    super(config, db, bucket, type as any, getBucketNameByValue(bucket));
-  }
-
-  getId(): Uint8Array {
-    throw Error("CheckpointStateRepository does not work with value");
-  }
-
-  encodeValue(): Uint8Array {
-    throw Error("CheckpointStateRepository does not work with value");
-  }
-
-  decodeValue(): BeaconStateAllForks {
-    throw Error("CheckpointStateRepository does not work with value");
+    super(config, db, bucket, getBucketNameByValue(bucket));
   }
 }

--- a/packages/beacon-node/src/index.ts
+++ b/packages/beacon-node/src/index.ts
@@ -2,7 +2,7 @@
 
 export type {RestApiServerMetrics, RestApiServerModules, RestApiServerOpts} from "./api/rest/base.js";
 export {RestApiServer} from "./api/rest/base.js";
-export {checkAndPersistAnchorState, initStateFromDb} from "./chain/index.js";
+export {checkAndPersistAnchorState} from "./chain/index.js";
 export {DbCPStateDatastore} from "./chain/stateCache/datastore/db.js";
 export {FileCPStateDatastore} from "./chain/stateCache/datastore/file.js";
 export {BeaconDb, type IBeaconDb} from "./db/index.js";

--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -236,6 +236,18 @@ export abstract class Repository<I extends Id, T> extends BinaryRepository<I> {
     );
   }
 
+  async batch(batch: DbBatch<I, T>): Promise<void> {
+    const batchWithKeys: DbBatch<Uint8Array, Uint8Array> = [];
+    for (const b of batch) {
+      if (b.type === "del") {
+        batchWithKeys.push({...b, key: this.encodeKey(b.key)});
+      } else {
+        batchWithKeys.push({...b, key: this.encodeKey(b.key), value: this.encodeValue(b.value)});
+      }
+    }
+    await this.db.batch(batchWithKeys, this.dbReqOpts);
+  }
+
   async batchAdd(values: T[]): Promise<void> {
     // handle single value in batchPut
     await this.batchPut(

--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -155,7 +155,7 @@ export abstract class BinaryRepository<I extends Id> {
       optsBuff.lt = this.maxKey;
     }
 
-    // Set at least on max key
+    // Set at least one max key
     if (opts?.gt !== undefined) {
       optsBuff.gt = this.encodeKey(opts.gt);
     } else if (opts?.gte !== undefined) {

--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -119,6 +119,25 @@ export abstract class BinaryRepository<I extends Id> {
     await this.db.delete(this.encodeKey(id), this.dbReqOpts);
   }
 
+  async batchDelete(ids: I[]): Promise<void> {
+    if (ids.length === 1) {
+      return this.delete(ids[0]);
+    }
+
+    await this.db.batchDelete(
+      Array.from({length: ids.length}, (_, i) => this.encodeKey(ids[i])),
+      this.dbReqOpts
+    );
+  }
+
+  async batchBinary(batch: DbBatch<I, Uint8Array>): Promise<void> {
+    const batchWithKeys: DbBatch<Uint8Array, Uint8Array> = [];
+    for (const b of batch) {
+      batchWithKeys.push({...b, key: this.encodeKey(b.key)});
+    }
+    await this.db.batch(batchWithKeys, this.dbReqOpts);
+  }
+
   /**
    * Transforms opts from I to Uint8Array
    */
@@ -215,37 +234,6 @@ export abstract class Repository<I extends Id, T> extends BinaryRepository<I> {
       })),
       this.dbReqOpts
     );
-  }
-
-  async batchDelete(ids: I[]): Promise<void> {
-    if (ids.length === 1) {
-      return this.delete(ids[0]);
-    }
-
-    await this.db.batchDelete(
-      Array.from({length: ids.length}, (_, i) => this.encodeKey(ids[i])),
-      this.dbReqOpts
-    );
-  }
-
-  async batch(batch: DbBatch<I, T>): Promise<void> {
-    const batchWithKeys: DbBatch<Uint8Array, Uint8Array> = [];
-    for (const b of batch) {
-      if (b.type === "del") {
-        batchWithKeys.push({...b, key: this.encodeKey(b.key)});
-      } else {
-        batchWithKeys.push({...b, key: this.encodeKey(b.key), value: this.encodeValue(b.value)});
-      }
-    }
-    await this.db.batch(batchWithKeys, this.dbReqOpts);
-  }
-
-  async batchBinary(batch: DbBatch<I, Uint8Array>): Promise<void> {
-    const batchWithKeys: DbBatch<Uint8Array, Uint8Array> = [];
-    for (const b of batch) {
-      batchWithKeys.push({...b, key: this.encodeKey(b.key)});
-    }
-    await this.db.batch(batchWithKeys, this.dbReqOpts);
   }
 
   async batchAdd(values: T[]): Promise<void> {

--- a/packages/db/src/abstractRepository.ts
+++ b/packages/db/src/abstractRepository.ts
@@ -8,24 +8,20 @@ import {encodeKey as _encodeKey} from "./util.js";
 export type Id = Uint8Array | string | number | bigint;
 
 /**
- * Repository is a high level kv storage
+ * BinaryRepository is a high level kv storage
  * managing a Uint8Array to Uint8Array kv database
- * It translates typed keys and values to Uint8Arrays required by the underlying database
- *
- * By default, SSZ-encoded values,
- * indexed by root
+ * It translates typed keys and Uint8Array values required by the underlying database
  */
-export abstract class Repository<I extends Id, T> {
-  private readonly dbReqOpts: DbReqOpts;
+export abstract class BinaryRepository<I extends Id> {
+  protected readonly dbReqOpts: DbReqOpts;
 
-  private readonly minKey: Uint8Array;
-  private readonly maxKey: Uint8Array;
+  protected readonly minKey: Uint8Array;
+  protected readonly maxKey: Uint8Array;
 
   protected constructor(
     protected config: ChainForkConfig,
     protected db: Db,
     protected bucket: number,
-    protected type: Type<T>,
     protected readonly bucketId: string
   ) {
     this.dbReqOpts = {bucketId: this.bucketId};
@@ -33,12 +29,35 @@ export abstract class Repository<I extends Id, T> {
     this.maxKey = _encodeKey(bucket + 1, Buffer.alloc(0));
   }
 
-  encodeValue(value: T): Uint8Array {
-    return this.type.serialize(value);
+  async keys(opts?: FilterOptions<I>): Promise<I[]> {
+    const data = await this.db.keys(this.dbFilterOptions(opts));
+    return (data ?? []).map((data) => this.decodeKey(data));
   }
 
-  decodeValue(data: Uint8Array): T {
-    return this.type.deserialize(data);
+  async *keysStream(opts?: FilterOptions<I>): AsyncIterable<I> {
+    const keysStream = this.db.keysStream(this.dbFilterOptions(opts));
+    const decodeKey = this.decodeKey.bind(this);
+    for await (const key of keysStream) {
+      yield decodeKey(key);
+    }
+  }
+
+  async firstKey(): Promise<I | null> {
+    // Metrics accounted in this.keys()
+    const keys = await this.keys({limit: 1, bucketId: this.bucketId});
+    if (!keys.length) {
+      return null;
+    }
+    return keys[0];
+  }
+
+  async lastKey(): Promise<I | null> {
+    // Metrics accounted in this.keys()
+    const keys = await this.keys({limit: 1, reverse: true, bucketId: this.bucketId});
+    if (!keys.length) {
+      return null;
+    }
+    return keys[0];
   }
 
   encodeKey(id: I): Uint8Array {
@@ -49,32 +68,126 @@ export abstract class Repository<I extends Id, T> {
     return key.slice(BUCKET_LENGTH) as I;
   }
 
-  async get(id: I): Promise<T | null> {
-    const value = await this.db.get(this.encodeKey(id), this.dbReqOpts);
-    if (!value) return null;
-    return this.decodeValue(value);
-  }
-
   async getBinary(id: I): Promise<Uint8Array | null> {
     const value = await this.db.get(this.encodeKey(id), this.dbReqOpts);
     if (!value) return null;
     return value;
   }
 
-  async has(id: I): Promise<boolean> {
-    return (await this.get(id)) !== null;
-  }
-
-  async put(id: I, value: T): Promise<void> {
-    await this.db.put(this.encodeKey(id), this.encodeValue(value), this.dbReqOpts);
-  }
-
   async putBinary(id: I, value: Uint8Array): Promise<void> {
     await this.db.put(this.encodeKey(id), value, this.dbReqOpts);
   }
 
+  async binaries(opts?: FilterOptions<I>): Promise<Uint8Array[]> {
+    const data = await this.db.values(this.dbFilterOptions(opts));
+    return data ?? [];
+  }
+
+  async lastBinary(): Promise<Uint8Array | null> {
+    // Metrics accounted in this.values()
+    const binaryValues = await this.binaries({limit: 1, reverse: true, bucketId: this.bucketId});
+    if (!binaryValues.length) {
+      return null;
+    }
+    return binaryValues[0];
+  }
+
+  // Similar to batchPut but we support value as Uint8Array
+  async batchPutBinary(items: KeyValue<I, Uint8Array>[]): Promise<void> {
+    if (items.length === 1) {
+      return this.db.put(this.encodeKey(items[0].key), items[0].value, this.dbReqOpts);
+    }
+
+    await this.db.batchPut(
+      Array.from({length: items.length}, (_, i) => ({
+        key: this.encodeKey(items[i].key),
+        value: items[i].value,
+      })),
+      this.dbReqOpts
+    );
+  }
+
+  async *binaryEntriesStream(opts?: FilterOptions<I>): AsyncIterable<KeyValue<Uint8Array, Uint8Array>> {
+    yield* this.db.entriesStream(this.dbFilterOptions(opts));
+  }
+
+  async has(id: I): Promise<boolean> {
+    return (await this.getBinary(id)) !== null;
+  }
+
   async delete(id: I): Promise<void> {
     await this.db.delete(this.encodeKey(id), this.dbReqOpts);
+  }
+
+  /**
+   * Transforms opts from I to Uint8Array
+   */
+  protected dbFilterOptions(opts?: FilterOptions<I>): FilterOptions<Uint8Array> {
+    const optsBuff: FilterOptions<Uint8Array> = {
+      bucketId: this.bucketId,
+    };
+
+    // Set at least one min key
+    if (opts?.lt !== undefined) {
+      optsBuff.lt = this.encodeKey(opts.lt);
+    } else if (opts?.lte !== undefined) {
+      optsBuff.lte = this.encodeKey(opts.lte);
+    } else {
+      optsBuff.lt = this.maxKey;
+    }
+
+    // Set at least on max key
+    if (opts?.gt !== undefined) {
+      optsBuff.gt = this.encodeKey(opts.gt);
+    } else if (opts?.gte !== undefined) {
+      optsBuff.gte = this.encodeKey(opts.gte);
+    } else {
+      optsBuff.gte = this.minKey;
+    }
+
+    if (opts?.reverse !== undefined) optsBuff.reverse = opts.reverse;
+    if (opts?.limit !== undefined) optsBuff.limit = opts.limit;
+
+    return optsBuff;
+  }
+}
+
+/**
+ * Repository is a high level kv storage
+ * managing a Uint8Array to Uint8Array kv database
+ * It translates typed keys and values to Uint8Arrays required by the underlying database
+ *
+ * By default, SSZ-encoded values,
+ * indexed by root
+ */
+export abstract class Repository<I extends Id, T> extends BinaryRepository<I> {
+  protected constructor(
+    config: ChainForkConfig,
+    db: Db,
+    bucket: number,
+    protected type: Type<T>,
+    bucketId: string
+  ) {
+    super(config, db, bucket, bucketId);
+    this.type = type;
+  }
+
+  encodeValue(value: T): Uint8Array {
+    return this.type.serialize(value);
+  }
+
+  decodeValue(data: Uint8Array): T {
+    return this.type.deserialize(data);
+  }
+
+  async get(id: I): Promise<T | null> {
+    const value = await this.db.get(this.encodeKey(id), this.dbReqOpts);
+    if (!value) return null;
+    return this.decodeValue(value);
+  }
+
+  async put(id: I, value: T): Promise<void> {
+    await this.db.put(this.encodeKey(id), this.encodeValue(value), this.dbReqOpts);
   }
 
   // The Id can be inferred from the value
@@ -99,21 +212,6 @@ export abstract class Repository<I extends Id, T> {
       Array.from({length: items.length}, (_, i) => ({
         key: this.encodeKey(items[i].key),
         value: this.encodeValue(items[i].value),
-      })),
-      this.dbReqOpts
-    );
-  }
-
-  // Similar to batchPut but we support value as Uint8Array
-  async batchPutBinary(items: KeyValue<I, Uint8Array>[]): Promise<void> {
-    if (items.length === 1) {
-      return this.db.put(this.encodeKey(items[0].key), items[0].value, this.dbReqOpts);
-    }
-
-    await this.db.batchPut(
-      Array.from({length: items.length}, (_, i) => ({
-        key: this.encodeKey(items[i].key),
-        value: items[i].value,
       })),
       this.dbReqOpts
     );
@@ -165,21 +263,8 @@ export abstract class Repository<I extends Id, T> {
     await this.batchDelete(Array.from({length: values.length}, (_ignored, i) => this.getId(values[i])));
   }
 
-  async keys(opts?: FilterOptions<I>): Promise<I[]> {
-    const data = await this.db.keys(this.dbFilterOptions(opts));
-    return (data ?? []).map((data) => this.decodeKey(data));
-  }
-
-  async *keysStream(opts?: FilterOptions<I>): AsyncIterable<I> {
-    const keysStream = this.db.keysStream(this.dbFilterOptions(opts));
-    const decodeKey = this.decodeKey.bind(this);
-    for await (const key of keysStream) {
-      yield decodeKey(key);
-    }
-  }
-
   async values(opts?: FilterOptions<I>): Promise<T[]> {
-    const data = await this.db.values(this.dbFilterOptions(opts));
+    const data = await this.binaries(opts);
     return (data ?? []).map((data) => this.decodeValue(data));
   }
 
@@ -189,10 +274,6 @@ export abstract class Repository<I extends Id, T> {
     for await (const value of valuesStream) {
       yield decodeValue(value);
     }
-  }
-
-  async *binaryEntriesStream(opts?: FilterOptions<I>): AsyncIterable<KeyValue<Uint8Array, Uint8Array>> {
-    yield* this.db.entriesStream(this.dbFilterOptions(opts));
   }
 
   async entries(opts?: FilterOptions<I>): Promise<KeyValue<I, T>[]> {
@@ -213,24 +294,6 @@ export abstract class Repository<I extends Id, T> {
         value: decodeValue(entry.value),
       };
     }
-  }
-
-  async firstKey(): Promise<I | null> {
-    // Metrics accounted in this.keys()
-    const keys = await this.keys({limit: 1, bucketId: this.bucketId});
-    if (!keys.length) {
-      return null;
-    }
-    return keys[0];
-  }
-
-  async lastKey(): Promise<I | null> {
-    // Metrics accounted in this.keys()
-    const keys = await this.keys({limit: 1, reverse: true, bucketId: this.bucketId});
-    if (!keys.length) {
-      return null;
-    }
-    return keys[0];
   }
 
   async firstValue(): Promise<T | null> {
@@ -267,37 +330,5 @@ export abstract class Repository<I extends Id, T> {
       return null;
     }
     return entries[0];
-  }
-
-  /**
-   * Transforms opts from I to Uint8Array
-   */
-  protected dbFilterOptions(opts?: FilterOptions<I>): FilterOptions<Uint8Array> {
-    const optsBuff: FilterOptions<Uint8Array> = {
-      bucketId: this.bucketId,
-    };
-
-    // Set at least one min key
-    if (opts?.lt !== undefined) {
-      optsBuff.lt = this.encodeKey(opts.lt);
-    } else if (opts?.lte !== undefined) {
-      optsBuff.lte = this.encodeKey(opts.lte);
-    } else {
-      optsBuff.lt = this.maxKey;
-    }
-
-    // Set at least on max key
-    if (opts?.gt !== undefined) {
-      optsBuff.gt = this.encodeKey(opts.gt);
-    } else if (opts?.gte !== undefined) {
-      optsBuff.gte = this.encodeKey(opts.gte);
-    } else {
-      optsBuff.gte = this.minKey;
-    }
-
-    if (opts?.reverse !== undefined) optsBuff.reverse = opts.reverse;
-    if (opts?.limit !== undefined) optsBuff.limit = opts.limit;
-
-    return optsBuff;
   }
 }


### PR DESCRIPTION
**Motivation**

- currently state repositories (StateArchiveRepository + CheckpointStateRepository) tightly coupled with `BeaconStateAllForks` which make it hard when we migrate to a generic BeaconStateView (to be come later, see #8650)
- so we need to let these repos to work with Uint8Array and let consumers decide how to create a type/view of BeaconState from there

**Description**

- separate the abstract repository to be extended from a newly created `BinaryRepository`
- then let `StateArchiveRepository + CheckpointStateRepository` to be extended from `BinaryRepository`
  - the benefit is consumer can only use methods in `BinaryRepository`, it's a compile time check, vs calling methods in `Repository` and throw runtime error which make it harder to detect errors
  - so we only need to validate this PR via compilation instead of having to launch a node to confirm, and it's tricky to detect error there
- update consumers accordingly

Closes  #8729
