### PR TITLE
fix: add triple-beam dependency to package.json

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -63,6 +63,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@lodestar/utils": "workspace:^",
+    "triple-beam": "^1.3.0",
     "winston": "^3.8.2",
     "winston-daily-rotate-file": "^4.7.1",
     "winston-transport": "^4.5.0"
@@ -71,8 +72,7 @@
     "@chainsafe/ssz": "^1.2.2",
     "@chainsafe/threads": "^1.11.3",
     "@lodestar/test-utils": "workspace:^",
-    "@types/triple-beam": "^1.3.2",
-    "triple-beam": "^1.3.0"
+    "@types/triple-beam": "^1.3.2"
   },
   "keywords": [
     "ethereum",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -746,6 +746,9 @@ importers:
       '@lodestar/utils':
         specifier: workspace:^
         version: link:../utils
+      triple-beam:
+        specifier: ^1.3.0
+        version: 1.3.0
       winston:
         specifier: ^3.8.2
         version: 3.8.2
@@ -768,9 +771,6 @@ importers:
       '@types/triple-beam':
         specifier: ^1.3.2
         version: 1.3.2
-      triple-beam:
-        specifier: ^1.3.0
-        version: 1.3.0
 
   packages/params:
     devDependencies:


### PR DESCRIPTION
Fixing [this](https://github.com/ethpandaops/ethereum-package/actions/runs/20928843912/job/60134147175#step:5:482)
```sh
  Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'triple-beam' imported from /usr/app/packages/logger/lib/interface.js
      at Object.getPackageJSONURL (node:internal/modules/package_json_reader:316:9)
      at packageResolve (node:internal/modules/esm/resolve:768:81)
      at moduleResolve (node:internal/modules/esm/resolve:858:18)
      at defaultResolve (node:internal/modules/esm/resolve:990:11)
      at #cachedDefaultResolve (node:internal/modules/esm/loader:718:20)
      at #resolveAndMaybeBlockOnLoaderThread (node:internal/modules/esm/loader:735:38)
      at ModuleLoader.resolveSync (node:internal/modules/esm/loader:764:52)
      at #resolve (node:internal/modules/esm/loader:700:17)
      at ModuleLoader.getOrCreateModuleJob (node:internal/modules/esm/loader:620:35)
      at ModuleJob.syncLink (node:internal/modules/esm/module_job:143:33) {
    code: 'ERR_MODULE_NOT_FOUND'
  }
  
  Node.js v24.12.0
```

**Motivation**

<!-- Why does this PR exist? What are the goals of the pull request? -->

**Description**

<!-- A clear and concise general description of the changes of this pull request. -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->

Closes #issue_number

**AI Assistance Disclosure**

- [ ] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

<!-- Insert any AI assistance disclosure here -->
