### PR TITLE
test: allow custom db path and `resumeFromDb` in `getDevBeaconNode`

### DIFF
--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -10,9 +10,17 @@ import {config as minimalConfig} from "@lodestar/config/default";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {LoggerNode} from "@lodestar/logger/node";
 import {ForkSeq, GENESIS_SLOT} from "@lodestar/params";
-import {BeaconStateAllForks, Index2PubkeyCache, createCachedBeaconState, syncPubkeys} from "@lodestar/state-transition";
+import {
+  BeaconStateAllForks,
+  Index2PubkeyCache,
+  computeAnchorCheckpoint,
+  computeEpochAtSlot,
+  createCachedBeaconState,
+  syncPubkeys,
+} from "@lodestar/state-transition";
 import {phase0, ssz} from "@lodestar/types";
 import {RecursivePartial, isPlainObject} from "@lodestar/utils";
+import {initStateFromDb} from "../../../src/chain/initState.js";
 import {BeaconDb} from "../../../src/db/index.js";
 import {BeaconNode} from "../../../src/index.js";
 import {defaultNetworkOptions} from "../../../src/network/options.js";
@@ -31,6 +39,11 @@ export async function getDevBeaconNode(
     peerStoreDir?: string;
     anchorState?: BeaconStateAllForks;
     wsCheckpoint?: phase0.Checkpoint;
+    /**
+     * When true, load anchor state from existing DB instead of creating fresh genesis.
+     * Requires `options.db.name` to be set explicitly.
+     */
+    resumeFromDb?: boolean;
   } & InteropStateOpts
 ): Promise<BeaconNode> {
   setHasher(hasher);
@@ -45,17 +58,41 @@ export async function getDevBeaconNode(
   const db = new BeaconDb(config, await LevelDbController.create({name: options.db?.name ?? tmpDir.name}, {logger}));
 
   let anchorState = opts.anchorState;
+  let wsCheckpoint = opts.wsCheckpoint;
+
   if (!anchorState) {
-    anchorState = initDevState(config, validatorCount, opts);
+    if (opts.resumeFromDb) {
+      if (!options.db?.name) {
+        throw new Error("resumeFromDb requires explicit options.db.name to be set");
+      }
 
-    const block = config.getForkTypes(GENESIS_SLOT).SignedBeaconBlock.defaultValue();
-    block.message.stateRoot = anchorState.hashTreeRoot();
-    await db.blockArchive.add(block);
+      // reuse production code for state loading from DB
+      anchorState = await initStateFromDb(config, db, logger);
+      const resumedEpoch = computeEpochAtSlot(anchorState.slot);
 
-    if (config.getForkSeq(GENESIS_SLOT) >= ForkSeq.deneb) {
-      const blobSidecars = ssz.deneb.BlobSidecars.defaultValue();
-      const blockRoot = config.getForkTypes(GENESIS_SLOT).BeaconBlock.hashTreeRoot(block.message);
-      await db.blobSidecars.add({blobSidecars, slot: GENESIS_SLOT, blockRoot});
+      // resuming from epoch 0 defeats the purpose of resuming
+      if (resumedEpoch === 0) {
+        logger.warn("Resumed state from epoch 0. Range Sync may trigger from genesis");
+      }
+
+      // derive wsCheckpoint if not provided
+      if (!wsCheckpoint) {
+        const {checkpoint} = computeAnchorCheckpoint(config, anchorState);
+        wsCheckpoint = {root: checkpoint.root, epoch: checkpoint.epoch};
+        logger.debug("Derived wsCheckpoint", {epoch: checkpoint.epoch});
+      }
+    } else {
+      anchorState = initDevState(config, validatorCount, opts);
+
+      const block = config.getForkTypes(GENESIS_SLOT).SignedBeaconBlock.defaultValue();
+      block.message.stateRoot = anchorState.hashTreeRoot();
+      await db.blockArchive.add(block);
+
+      if (config.getForkSeq(GENESIS_SLOT) >= ForkSeq.deneb) {
+        const blobSidecars = ssz.deneb.BlobSidecars.defaultValue();
+        const blockRoot = config.getForkTypes(GENESIS_SLOT).BeaconBlock.hashTreeRoot(block.message);
+        await db.blobSidecars.add({blobSidecars, slot: GENESIS_SLOT, blockRoot});
+      }
     }
   }
 
@@ -121,7 +158,7 @@ export async function getDevBeaconNode(
     dataDir: ".",
     peerStoreDir,
     anchorState: cachedState,
-    wsCheckpoint: opts.wsCheckpoint,
+    wsCheckpoint,
     isAnchorStateFinalized: true,
   });
 }

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -42,7 +42,7 @@ export async function getDevBeaconNode(
   const config = createChainForkConfig({...minimalConfig, ...params});
   logger = logger ?? testLogger();
 
-  const db = new BeaconDb(config, await LevelDbController.create({name: tmpDir.name}, {logger}));
+  const db = new BeaconDb(config, await LevelDbController.create({name: options.db?.name ?? tmpDir.name}, {logger}));
 
   let anchorState = opts.anchorState;
   if (!anchorState) {


### PR DESCRIPTION
**Motivation**
Enables tests that need DB persistence and state resumption across node restarts.

**Description**
- Use `options.db?.name ?? tmpDir.name` instead of hardcoded `tmpDir.name` in `getDevBeaconNode()`.
- Added `resumeFromDb` option that loads anchor state from existing DB via `initStateFromDb()` instead of creating fresh genesis. This preserves the finalized epoch from previous runs.

**Use case**: Backfill sync tests that restart nodes mid-sync need to resume from persisted state, not start fresh from epoch 0.