### PR TITLE
refactor: simplify assertValidAttesterSlashing() assertValidProposerSlashing()

### DIFF
--- a/packages/beacon-node/src/chain/validation/attesterSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/attesterSlashing.ts
@@ -43,7 +43,14 @@ export async function validateAttesterSlashing(
   // [REJECT] All of the conditions within process_attester_slashing pass validation.
   try {
     // verifySignature = false, verified in batch below
-    assertValidAttesterSlashing(chain.index2pubkey, state, attesterSlashing, false);
+    assertValidAttesterSlashing(
+      chain.config,
+      chain.index2pubkey,
+      state.slot,
+      state.validators.length,
+      attesterSlashing,
+      false
+    );
   } catch (e) {
     throw new AttesterSlashingError(GossipAction.REJECT, {
       code: AttesterSlashingErrorCode.INVALID,

--- a/packages/beacon-node/src/chain/validation/proposerSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/proposerSlashing.ts
@@ -35,8 +35,9 @@ async function validateProposerSlashing(
 
   // [REJECT] All of the conditions within process_proposer_slashing pass validation.
   try {
+    const proposer = state.validators.getReadonly(proposerSlashing.signedHeader1.message.proposerIndex);
     // verifySignature = false, verified in batch below
-    assertValidProposerSlashing(state, proposerSlashing, false);
+    assertValidProposerSlashing(chain.config, chain.index2pubkey, state.slot, proposerSlashing, proposer, false);
   } catch (e) {
     throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID,

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -74,7 +74,6 @@ export function isValidIndexedAttestationIndices(
   }
 
   // check if indices are out of bounds, by checking the highest index (since it is sorted)
-  // TODO - SLOW CODE - Does this .length check the tree and is expensive?
   const lastIndex = indices.at(-1);
   if (lastIndex && lastIndex >= validatorsLen) {
     return false;

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -1,9 +1,8 @@
 import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq, MAX_COMMITTEES_PER_SLOT, MAX_VALIDATORS_PER_COMMITTEE} from "@lodestar/params";
-import {IndexedAttestation, IndexedAttestationBigint} from "@lodestar/types";
+import {IndexedAttestation, IndexedAttestationBigint, Slot} from "@lodestar/types";
 import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {getIndexedAttestationBigintSignatureSet, getIndexedAttestationSignatureSet} from "../signatureSets/index.js";
-import {CachedBeaconStateAllForks} from "../types.js";
 import {verifySignatureSet} from "../util/index.js";
 
 /**
@@ -12,16 +11,17 @@ import {verifySignatureSet} from "../util/index.js";
 export function isValidIndexedAttestation(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
+  stateSlot: Slot,
+  validatorsLen: number,
   indexedAttestation: IndexedAttestation,
   verifySignature: boolean
 ): boolean {
-  if (!isValidIndexedAttestationIndices(state, indexedAttestation.attestingIndices)) {
+  if (!isValidIndexedAttestationIndices(config, stateSlot, validatorsLen, indexedAttestation.attestingIndices)) {
     return false;
   }
 
   if (verifySignature) {
-    return verifySignatureSet(getIndexedAttestationSignatureSet(config, index2pubkey, state.slot, indexedAttestation));
+    return verifySignatureSet(getIndexedAttestationSignatureSet(config, index2pubkey, stateSlot, indexedAttestation));
   }
   return true;
 }
@@ -29,17 +29,18 @@ export function isValidIndexedAttestation(
 export function isValidIndexedAttestationBigint(
   config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
+  stateSlot: Slot,
+  validatorsLen: number,
   indexedAttestation: IndexedAttestationBigint,
   verifySignature: boolean
 ): boolean {
-  if (!isValidIndexedAttestationIndices(state, indexedAttestation.attestingIndices)) {
+  if (!isValidIndexedAttestationIndices(config, stateSlot, validatorsLen, indexedAttestation.attestingIndices)) {
     return false;
   }
 
   if (verifySignature) {
     return verifySignatureSet(
-      getIndexedAttestationBigintSignatureSet(config, index2pubkey, state.slot, indexedAttestation)
+      getIndexedAttestationBigintSignatureSet(config, index2pubkey, stateSlot, indexedAttestation)
     );
   }
   return true;
@@ -48,10 +49,15 @@ export function isValidIndexedAttestationBigint(
 /**
  * Check if `indexedAttestation` has sorted and unique indices and a valid aggregate signature.
  */
-export function isValidIndexedAttestationIndices(state: CachedBeaconStateAllForks, indices: number[]): boolean {
+export function isValidIndexedAttestationIndices(
+  config: BeaconConfig,
+  stateSlot: Slot,
+  validatorsLen: number,
+  indices: number[]
+): boolean {
   // verify max number of indices
   const maxIndices =
-    state.config.getForkSeq(state.slot) >= ForkSeq.electra
+    config.getForkSeq(stateSlot) >= ForkSeq.electra
       ? MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT
       : MAX_VALIDATORS_PER_COMMITTEE;
   if (!(indices.length > 0 && indices.length <= maxIndices)) {
@@ -70,7 +76,7 @@ export function isValidIndexedAttestationIndices(state: CachedBeaconStateAllFork
   // check if indices are out of bounds, by checking the highest index (since it is sorted)
   // TODO - SLOW CODE - Does this .length check the tree and is expensive?
   const lastIndex = indices.at(-1);
-  if (lastIndex && lastIndex >= state.validators.length) {
+  if (lastIndex && lastIndex >= validatorsLen) {
     return false;
   }
 

--- a/packages/state-transition/src/block/processAttestationPhase0.ts
+++ b/packages/state-transition/src/block/processAttestationPhase0.ts
@@ -54,7 +54,8 @@ export function processAttestationPhase0(
     !isValidIndexedAttestation(
       state.config,
       epochCtx.index2pubkey,
-      state,
+      state.slot,
+      state.validators.length,
       epochCtx.getIndexedAttestation(ForkSeq.phase0, attestation),
       verifySignature
     )

--- a/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
+++ b/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
@@ -45,7 +45,7 @@ describe("validate indexed attestation", () => {
       data: attestationData,
       signature: EMPTY_SIGNATURE,
     };
-    expect(isValidIndexedAttestation(state.config, state.epochCtx.index2pubkey, state, indexedAttestation, false)).toBe(
+    expect(isValidIndexedAttestation(state.config, state.epochCtx.index2pubkey, state.slot, state.validators.length, indexedAttestation, false)).toBe(
       expectedValue
     );
   });

--- a/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
+++ b/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
@@ -45,8 +45,15 @@ describe("validate indexed attestation", () => {
       data: attestationData,
       signature: EMPTY_SIGNATURE,
     };
-    expect(isValidIndexedAttestation(state.config, state.epochCtx.index2pubkey, state.slot, state.validators.length, indexedAttestation, false)).toBe(
-      expectedValue
-    );
+    expect(
+      isValidIndexedAttestation(
+        state.config,
+        state.epochCtx.index2pubkey,
+        state.slot,
+        state.validators.length,
+        indexedAttestation,
+        false
+      )
+    ).toBe(expectedValue);
   });
 });


### PR DESCRIPTION
**Motivation**

- the 2 functions `assertValidAttesterSlashing()` and `assertValidProposerSlashing()` requrie the full `CachedBeaconStateAllForks` but we don't need to
- this PR simplifies it so that it'll work with the future BeaconStateView when we integrate the native state-transition, see #8650

**Description**

pass required properties from state instead
- `assertValidAttesterSlashing()`: pass config, stateSlot, validators length instead of the whole `CachedBeaconStateAllForks`
- `assertValidProposerSlashing()`: config, index2pubkey, stateSlot, proposer instead of the whole `CachedBeaconStateAllForks`

part of #8657
