### PR TITLE
refactor: simplify get proposer's SignatureSet

### DIFF
--- a/packages/beacon-node/src/chain/validation/blobSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -138,8 +138,9 @@ export async function validateGossipBlobSidecar(
   const signature = blobSidecar.signedBlockHeader.signature;
   if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blobSlot, blockHex, signature)) {
     const signatureSet = getBlockHeaderProposerSignatureSetByParentStateSlot(
+      chain.config,
       chain.index2pubkey,
-      blockState,
+      blockState.slot,
       blobSidecar.signedBlockHeader
     );
     // Don't batch so verification is not delayed
@@ -243,10 +244,9 @@ export async function validateBlockBlobSidecars(
     const blockRootHex = toRootHex(blockRoot);
     const signature = firstSidecarSignedBlockHeader.signature;
     if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockSlot, blockRootHex, signature)) {
-      const headState = await chain.getHeadState();
       const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(
+        chain.config,
         chain.index2pubkey,
-        headState,
         firstSidecarSignedBlockHeader
       );
 

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -135,8 +135,9 @@ export async function validateGossipDataColumnSidecar(
   const signature = dataColumnSidecar.signedBlockHeader.signature;
   if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockHeader.slot, blockRootHex, signature)) {
     const signatureSet = getBlockHeaderProposerSignatureSetByParentStateSlot(
+      chain.config,
       chain.index2pubkey,
-      blockState,
+      blockState.slot,
       dataColumnSidecar.signedBlockHeader
     );
 
@@ -336,10 +337,9 @@ export async function validateBlockDataColumnSidecars(
     const slot = firstSidecarSignedBlockHeader.message.slot;
     const signature = firstSidecarSignedBlockHeader.signature;
     if (!chain.seenBlockInputCache.isVerifiedProposerSignature(slot, rootHex, signature)) {
-      const headState = await chain.getHeadState();
       const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(
+        chain.config,
         chain.index2pubkey,
-        headState,
         firstSidecarSignedBlockHeader
       );
 

--- a/packages/state-transition/src/signatureSets/proposer.ts
+++ b/packages/state-transition/src/signatureSets/proposer.ts
@@ -2,7 +2,6 @@ import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_PROPOSER} from "@lodestar/params";
 import {SignedBeaconBlock, SignedBlindedBeaconBlock, Slot, isBlindedBeaconBlock, phase0, ssz} from "@lodestar/types";
 import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
-import {CachedBeaconStateAllForks} from "../types.js";
 import {computeSigningRoot} from "../util/index.js";
 import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../util/signatureSets.js";
 
@@ -38,28 +37,28 @@ export function getBlockProposerSignatureSet(
 }
 
 export function getBlockHeaderProposerSignatureSetByParentStateSlot(
+  config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  parentState: CachedBeaconStateAllForks,
+  parentStateSlot: Slot,
   signedBlockHeader: phase0.SignedBeaconBlockHeader
 ) {
-  return getBlockHeaderProposerSignatureSet(index2pubkey, parentState, signedBlockHeader, parentState.slot);
+  return getBlockHeaderProposerSignatureSet(config, index2pubkey, signedBlockHeader, parentStateSlot);
 }
 
 export function getBlockHeaderProposerSignatureSetByHeaderSlot(
+  config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  headState: CachedBeaconStateAllForks,
   signedBlockHeader: phase0.SignedBeaconBlockHeader
 ) {
-  return getBlockHeaderProposerSignatureSet(index2pubkey, headState, signedBlockHeader, signedBlockHeader.message.slot);
+  return getBlockHeaderProposerSignatureSet(config, index2pubkey, signedBlockHeader, signedBlockHeader.message.slot);
 }
 
 function getBlockHeaderProposerSignatureSet(
+  config: BeaconConfig,
   index2pubkey: Index2PubkeyCache,
-  state: CachedBeaconStateAllForks,
   signedBlockHeader: phase0.SignedBeaconBlockHeader,
   domainSlot: Slot
 ): ISignatureSet {
-  const {config} = state;
   const domain = config.getDomain(domainSlot, DOMAIN_BEACON_PROPOSER, signedBlockHeader.message.slot);
 
   return {


### PR DESCRIPTION
**Motivation**

- to get proposer's Signature Set, we pass CachedBeaconStateAllForks just to get config and state slot

**Description**

- pass config and state slot instead of `CachedBeaconStateAllForks`

part of #8657
