### PR TITLE
refactor: simplify isValidBlsToExecutionChange()

### DIFF
--- a/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
@@ -1,5 +1,4 @@
 import {
-  CachedBeaconStateCapella,
   getBlsToExecutionChangeSignatureSet,
   isValidBlsToExecutionChange,
 } from "@lodestar/state-transition";
@@ -42,10 +41,16 @@ async function validateBlsToExecutionChange(
   // and chanes relevant to `isValidBlsToExecutionChange()` happen only on processBlock(), not processEpoch()
   const state = chain.getHeadState();
   const {config} = chain;
-
+  const addressChange = blsToExecutionChange.message;
+  if (addressChange.validatorIndex >= state.validators.length) {
+    throw Error(
+      `withdrawalValidatorIndex ${addressChange.validatorIndex} > state.validators len ${state.validators.length}`
+    );
+  }
+  const validator = state.validators.get(addressChange.validatorIndex);
   // [REJECT] All of the conditions within process_bls_to_execution_change pass validation.
   // verifySignature = false, verified in batch below
-  const {valid} = isValidBlsToExecutionChange(state as CachedBeaconStateCapella, blsToExecutionChange, false);
+  const {valid} = isValidBlsToExecutionChange(config, validator, blsToExecutionChange, false);
   if (!valid) {
     throw new BlsToExecutionChangeError(GossipAction.REJECT, {
       code: BlsToExecutionChangeErrorCode.INVALID,

--- a/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
@@ -40,9 +40,9 @@ async function validateBlsToExecutionChange(
   const {config} = chain;
   const addressChange = blsToExecutionChange.message;
   if (addressChange.validatorIndex >= state.validators.length) {
-    throw Error(
-      `withdrawalValidatorIndex ${addressChange.validatorIndex} > state.validators len ${state.validators.length}`
-    );
+    throw new BlsToExecutionChangeError(GossipAction.REJECT, {
+      code: BlsToExecutionChangeErrorCode.INVALID,
+    });
   }
   const validator = state.validators.get(addressChange.validatorIndex);
   // [REJECT] All of the conditions within process_bls_to_execution_change pass validation.

--- a/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
@@ -44,7 +44,7 @@ async function validateBlsToExecutionChange(
       code: BlsToExecutionChangeErrorCode.INVALID,
     });
   }
-  const validator = state.validators.get(addressChange.validatorIndex);
+  const validator = state.validators.getReadonly(addressChange.validatorIndex);
   // [REJECT] All of the conditions within process_bls_to_execution_change pass validation.
   // verifySignature = false, verified in batch below
   const {valid} = isValidBlsToExecutionChange(config, validator, blsToExecutionChange, false);

--- a/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
@@ -1,7 +1,4 @@
-import {
-  getBlsToExecutionChangeSignatureSet,
-  isValidBlsToExecutionChange,
-} from "@lodestar/state-transition";
+import {getBlsToExecutionChangeSignatureSet, isValidBlsToExecutionChange} from "@lodestar/state-transition";
 import {capella} from "@lodestar/types";
 import {BlsToExecutionChangeError, BlsToExecutionChangeErrorCode, GossipAction} from "../errors/index.js";
 import {IBeaconChain} from "../index.js";

--- a/packages/state-transition/src/block/processBlsToExecutionChange.ts
+++ b/packages/state-transition/src/block/processBlsToExecutionChange.ts
@@ -1,7 +1,9 @@
 import {digest} from "@chainsafe/as-sha256";
 import {byteArrayEquals} from "@chainsafe/ssz";
+import {BeaconConfig} from "@lodestar/config";
 import {BLS_WITHDRAWAL_PREFIX, ETH1_ADDRESS_WITHDRAWAL_PREFIX} from "@lodestar/params";
 import {capella} from "@lodestar/types";
+import {Validator} from "@lodestar/types/phase0";
 import {toHex} from "@lodestar/utils";
 import {verifyBlsToExecutionChangeSignature} from "../signatureSets/index.js";
 import {CachedBeaconStateCapella} from "../types.js";
@@ -12,12 +14,18 @@ export function processBlsToExecutionChange(
 ): void {
   const addressChange = signedBlsToExecutionChange.message;
 
-  const validation = isValidBlsToExecutionChange(state, signedBlsToExecutionChange, true);
+  if (addressChange.validatorIndex >= state.validators.length) {
+    throw Error(
+      `withdrawalValidatorIndex ${addressChange.validatorIndex} > state.validators len ${state.validators.length}`
+    );
+  }
+
+  const validator = state.validators.get(addressChange.validatorIndex);
+  const validation = isValidBlsToExecutionChange(state.config, validator, signedBlsToExecutionChange, true);
   if (!validation.valid) {
     throw validation.error;
   }
 
-  const validator = state.validators.get(addressChange.validatorIndex);
   const newWithdrawalCredentials = new Uint8Array(32);
   newWithdrawalCredentials[0] = ETH1_ADDRESS_WITHDRAWAL_PREFIX;
   newWithdrawalCredentials.set(addressChange.toExecutionAddress, 12);
@@ -27,22 +35,13 @@ export function processBlsToExecutionChange(
 }
 
 export function isValidBlsToExecutionChange(
-  state: CachedBeaconStateCapella,
+  config: BeaconConfig,
+  validator: Validator,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange,
   verifySignature = true
 ): {valid: true} | {valid: false; error: Error} {
   const addressChange = signedBLSToExecutionChange.message;
 
-  if (addressChange.validatorIndex >= state.validators.length) {
-    return {
-      valid: false,
-      error: Error(
-        `withdrawalValidatorIndex ${addressChange.validatorIndex} > state.validators len ${state.validators.length}`
-      ),
-    };
-  }
-
-  const validator = state.validators.getReadonly(addressChange.validatorIndex);
   const {withdrawalCredentials} = validator;
   if (withdrawalCredentials[0] !== BLS_WITHDRAWAL_PREFIX) {
     return {
@@ -65,7 +64,7 @@ export function isValidBlsToExecutionChange(
     };
   }
 
-  if (verifySignature && !verifyBlsToExecutionChangeSignature(state, signedBLSToExecutionChange)) {
+  if (verifySignature && !verifyBlsToExecutionChangeSignature(config, signedBLSToExecutionChange)) {
     return {
       valid: false,
       error: Error(

--- a/packages/state-transition/src/block/processBlsToExecutionChange.ts
+++ b/packages/state-transition/src/block/processBlsToExecutionChange.ts
@@ -16,7 +16,7 @@ export function processBlsToExecutionChange(
 
   if (addressChange.validatorIndex >= state.validators.length) {
     throw Error(
-      `withdrawalValidatorIndex ${addressChange.validatorIndex} > state.validators len ${state.validators.length}`
+      `withdrawalValidatorIndex ${addressChange.validatorIndex} >= state.validators len ${state.validators.length}`
     );
   }
 

--- a/packages/state-transition/src/signatureSets/blsToExecutionChange.ts
+++ b/packages/state-transition/src/signatureSets/blsToExecutionChange.ts
@@ -2,14 +2,13 @@ import {PublicKey} from "@chainsafe/blst";
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BLS_TO_EXECUTION_CHANGE, ForkName} from "@lodestar/params";
 import {capella, ssz} from "@lodestar/types";
-import {CachedBeaconStateAllForks} from "../types.js";
 import {ISignatureSet, SignatureSetType, computeSigningRoot, verifySignatureSet} from "../util/index.js";
 
 export function verifyBlsToExecutionChangeSignature(
-  state: CachedBeaconStateAllForks,
+  config: BeaconConfig,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
 ): boolean {
-  return verifySignatureSet(getBlsToExecutionChangeSignatureSet(state.config, signedBLSToExecutionChange));
+  return verifySignatureSet(getBlsToExecutionChangeSignatureSet(config, signedBLSToExecutionChange));
 }
 
 /**


### PR DESCRIPTION
**Motivation**

- the function isValidBlsToExecutionChange() requires a state which is used to get config and validator from
- but we'll not have `CachedBeaconStateAllForks` after #8650

**Description**

- pass config and validator to this function instead

part of #8657

