### PR TITLE
fix: use pnpm dlx semver for publish instead of npx

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -54,7 +54,7 @@ jobs:
         id: version
         run: |
           PACKAGE_VERSION=$(node -p "require('./packages/cli/package.json').version")
-          NEXT_VERSION=$(npx --yes semver --increment minor $PACKAGE_VERSION)
+          NEXT_VERSION=$(pnpm dlx semver --increment minor $PACKAGE_VERSION)
           export VERSION=${NEXT_VERSION}-dev.${GITHUB_SHA:0:10}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo PACKAGE_VERSION $PACKAGE_VERSION GITHUB_SHA $GITHUB_SHA VERSION $VERSION

--- a/.github/workflows/publish-nextfork.yml
+++ b/.github/workflows/publish-nextfork.yml
@@ -55,7 +55,7 @@ jobs:
         id: version
         run: |
           PACKAGE_VERSION=$(node -p "require('./packages/cli/package.json').version")
-          NEXT_VERSION=$(npx --yes semver --increment minor $PACKAGE_VERSION)
+          NEXT_VERSION=$(pnpm dlx semver --increment minor $PACKAGE_VERSION)
           export VERSION=${NEXT_VERSION}-${NEXT_FORK}.${GITHUB_SHA:0:10}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo PACKAGE_VERSION $PACKAGE_VERSION GITHUB_SHA $GITHUB_SHA VERSION $VERSION

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ on:
     branches:
       # - peerDAS # Nextfork branch
       - unstable
+  workflow_dispatch:
 
 permissions:
   contents: write # Required for OIDC


### PR DESCRIPTION
**Motivation**

Our publish workflows were breaking due to #8646 `npx` versus `pnpm` for semver package. 

**Description**

This potential fix is get the workflow to use pnpm dlx instead of npx dlx.
