### PR TITLE
ci: fix the root level binary path

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "wait-port": "^1.1.0"
   },
   "dependencies": {
+    "@chainsafe/lodestar": "workspace:",
     "debug": "^4.4.3"
   },
   "resolutions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
 
   .:
     dependencies:
+      '@chainsafe/lodestar':
+        specifier: 'workspace:'
+        version: link:packages/cli
       debug:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
**Motivation**

Fix the root level binary path

**Description**

- Add `@chainsafe/lodestar` to root level dependency
