### PR TITLE
fix: use cli execution path for binary

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -42,7 +42,7 @@ jobs:
       - run: |
           mkdir -p dist
           pnpm add -g @chainsafe/caxa@3.0.6
-          npx caxa -m "Unpacking Lodestar binary, please wait..." -e "dashboards/**" -e "docs/**" -D -p "pnpm install --frozen-lockfile --production" --input . --output "lodestar" -- "{{caxa}}/node_modules/.bin/node" "--max-old-space-size=8192" "{{caxa}}/node_modules/.bin/lodestar"
+          npx caxa -m "Unpacking Lodestar binary, please wait..." -e "dashboards/**" -e "docs/**" -D -p "pnpm install --frozen-lockfile --production" --input . --output "lodestar" -- "{{caxa}}/node_modules/.bin/node" "--max-old-space-size=8192" "{{caxa}}/packages/cli/bin/lodestar.js"
           tar -czf "dist/lodestar-${{ inputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz" "lodestar"
       - name: Upload binaries
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "wait-port": "^1.1.0"
   },
   "dependencies": {
-    "@chainsafe/lodestar": "workspace:",
     "debug": "^4.4.3"
   },
   "resolutions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,9 +28,6 @@ importers:
 
   .:
     dependencies:
-      '@chainsafe/lodestar':
-        specifier: 'workspace:'
-        version: link:packages/cli
       debug:
         specifier: ^4.4.3
         version: 4.4.3


### PR DESCRIPTION
**Motivation**

Use the `package/cli/bin/lodestar.js` as execution path for the binary.

**Description**

- Use the binary path from the cli package

Closes #8755
