### PR TITLE
chore: restore node_modules/.bin/lodestar

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@biomejs/biome": "^2.2.0",
     "@chainsafe/benchmark": "^1.2.3",
     "@chainsafe/biomejs-config": "^1.0.0",
+    "@chainsafe/lodestar": "workspace:*",
     "@lerna-lite/cli": "^4.9.4",
     "@lerna-lite/exec": "^4.9.4",
     "@lerna-lite/publish": "^4.9.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@chainsafe/biomejs-config':
         specifier: ^1.0.0
         version: 1.0.0(@biomejs/biome@2.2.2)
+      '@chainsafe/lodestar':
+        specifier: workspace:*
+        version: link:packages/cli
       '@lerna-lite/cli':
         specifier: ^4.9.4
         version: 4.9.4(@lerna-lite/exec@4.10.3)(@lerna-lite/publish@4.9.4)(@lerna-lite/run@4.9.4)(@lerna-lite/version@4.9.4)(@types/node@24.10.1)


### PR DESCRIPTION
Both eth-docker and rocketpool rely on `node_modules/.bin/lodestar` and we wanna avoid breaking existing deployments.