### PR TITLE
chore: restore `node_modules/.bin/lodestar` for `--prod` installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@biomejs/biome": "^2.2.0",
     "@chainsafe/benchmark": "^1.2.3",
     "@chainsafe/biomejs-config": "^1.0.0",
-    "@chainsafe/lodestar": "workspace:*",
     "@lerna-lite/cli": "^4.9.4",
     "@lerna-lite/exec": "^4.9.4",
     "@lerna-lite/publish": "^4.9.4",
@@ -88,6 +87,7 @@
     "wait-port": "^1.1.0"
   },
   "dependencies": {
+    "@chainsafe/lodestar": "workspace:*",
     "debug": "^4.4.3"
   },
   "resolutions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
 
   .:
     dependencies:
+      '@chainsafe/lodestar':
+        specifier: workspace:*
+        version: link:packages/cli
       debug:
         specifier: ^4.4.3
         version: 4.4.3
@@ -44,9 +47,6 @@ importers:
       '@chainsafe/biomejs-config':
         specifier: ^1.0.0
         version: 1.0.0(@biomejs/biome@2.2.2)
-      '@chainsafe/lodestar':
-        specifier: workspace:*
-        version: link:packages/cli
       '@lerna-lite/cli':
         specifier: ^4.9.4
         version: 4.9.4(@lerna-lite/exec@4.10.3)(@lerna-lite/publish@4.9.4)(@lerna-lite/run@4.9.4)(@lerna-lite/version@4.9.4)(@types/node@24.10.1)


### PR DESCRIPTION
Follow up on https://github.com/ChainSafe/lodestar/pull/8761, we run `pnpm install --frozen-lockfile --prod` during docker build and right now we don't create `.bin/lodestar` as cli package is a dev dependency.