### PR TITLE
chore: properly prune dev dependencies in docker/binary builds

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -42,7 +42,7 @@ jobs:
       - run: |
           mkdir -p dist
           pnpm add -g @chainsafe/caxa@3.0.6
-          npx caxa -m "Unpacking Lodestar binary, please wait..." -e "dashboards/**" -e "docs/**" -D -p "pnpm install --frozen-lockfile --production" --input . --output "lodestar" -- "{{caxa}}/node_modules/.bin/node" "--max-old-space-size=8192" "{{caxa}}/packages/cli/bin/lodestar.js"
+          npx caxa -m "Unpacking Lodestar binary, please wait..." -e "dashboards/**" -e "docs/**" -D -p "pnpm prune --prod" --input . --output "lodestar" -- "{{caxa}}/node_modules/.bin/node" "--max-old-space-size=8192" "{{caxa}}/packages/cli/bin/lodestar.js"
           tar -czf "dist/lodestar-${{ inputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz" "lodestar"
       - name: Upload binaries
         uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV CI=true
 RUN corepack enable && corepack prepare --activate && \
   pnpm install --frozen-lockfile && \
   pnpm build && \
-  pnpm install --frozen-lockfile --prod
+  pnpm prune --prod
 
 # To have access to the specific branch and commit used to build this source,
 # a git-data.json file is created by persisting git data at build time. Then,


### PR DESCRIPTION
Our docker and binary size is 2x since we switched to pnpm but this fixes it by correctly pruning dev dependencies.

<img width="1854" height="210" alt="image" src="https://github.com/user-attachments/assets/6f651370-20ca-4492-b520-ad692c936b87" />


<img width="1826" height="203" alt="image" src="https://github.com/user-attachments/assets/52871f34-191e-4705-9f9f-00292c02b463" />


After the fix

<img width="1843" height="198" alt="image" src="https://github.com/user-attachments/assets/f3c3a8ea-8656-454e-bb80-84b10f91d8ce" />
