### PR TITLE
fix: add slotNumber to ExecutionPayload for EIP-7843

### DIFF
--- a/packages/beacon-node/src/execution/engine/types.ts
+++ b/packages/beacon-node/src/execution/engine/types.ts
@@ -194,7 +194,8 @@ export type ExecutionPayloadRpc = {
   withdrawals?: WithdrawalRpc[]; // Capella hardfork
   blobGasUsed?: QUANTITY; // DENEB
   excessBlobGas?: QUANTITY; // DENEB
-  blockAccessList?: DATA; // GLOAS
+  blockAccessList?: DATA; // GLOAS:EIP-7928
+  slotNumber?: QUANTITY; // GLOAS:EIP-7843
 };
 
 export type WithdrawalRpc = {
@@ -298,8 +299,9 @@ export function serializeExecutionPayload(fork: ForkName, data: ExecutionPayload
   // No changes in Electra
 
   if (ForkSeq[fork] >= ForkSeq.gloas) {
-    const {blockAccessList} = data as gloas.ExecutionPayload;
+    const {blockAccessList, slotNumber} = data as gloas.ExecutionPayload;
     payload.blockAccessList = bytesToData(blockAccessList);
+    payload.slotNumber = numToQuantity(slotNumber);
   }
 
   return payload;
@@ -398,7 +400,7 @@ export function parseExecutionPayload(
   // No changes in Electra
 
   if (ForkSeq[fork] >= ForkSeq.gloas) {
-    const {blockAccessList} = data;
+    const {blockAccessList, slotNumber} = data;
 
     if (blockAccessList == null) {
       throw Error(
@@ -406,7 +408,14 @@ export function parseExecutionPayload(
       );
     }
 
+    if (slotNumber == null) {
+      throw Error(
+        `slotNumber missing for ${fork} >= gloas executionPayload number=${executionPayload.blockNumber} hash=${data.blockHash}`
+      );
+    }
+
     (executionPayload as gloas.ExecutionPayload).blockAccessList = dataToBytes(blockAccessList, null);
+    (executionPayload as gloas.ExecutionPayload).slotNumber = quantityToNum(slotNumber);
   }
 
   return {executionPayload, executionPayloadValue, blobsBundle, executionRequests, shouldOverrideBuilder};

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -23,6 +23,7 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
   stateGloas.latestExecutionPayloadHeader = ssz.gloas.BeaconState.fields.latestExecutionPayloadHeader.toViewDU({
     ...stateFulu.latestExecutionPayloadHeader.toValue(),
     blockAccessListRoot: ssz.Root.defaultViewDU(),
+    slotNumber: stateFulu.latestBlockHeader.slot,
   });
 
   stateGloas.commit();

--- a/packages/state-transition/src/util/execution.ts
+++ b/packages/state-transition/src/util/execution.ts
@@ -178,6 +178,9 @@ export function executionPayloadToPayloadHeader(fork: ForkSeq, payload: Executio
   if (fork >= ForkSeq.gloas) {
     (bellatrixPayloadFields as gloas.ExecutionPayloadHeader).blockAccessListRoot =
       ssz.gloas.BlockAccessList.hashTreeRoot((payload as gloas.ExecutionPayload).blockAccessList);
+    (bellatrixPayloadFields as gloas.ExecutionPayloadHeader).slotNumber = (
+      payload as gloas.ExecutionPayload
+    ).slotNumber;
   }
 
   return bellatrixPayloadFields;

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -19,6 +19,7 @@ export const ExecutionPayload = new ContainerType(
   {
     ...denebSsz.ExecutionPayload.fields,
     blockAccessList: BlockAccessList, // New in GLOAS:EIP-7928
+    slotNumber: Slot, // New in GLOAS:EIP-7843
   },
   {typeName: "ExecutionPayload", jsonCase: "eth2"}
 );
@@ -27,6 +28,7 @@ export const ExecutionPayloadHeader = new ContainerType(
   {
     ...denebSsz.ExecutionPayloadHeader.fields,
     blockAccessListRoot: Root, // New in GLOAS:EIP-7928
+    slotNumber: Slot, // New in GLOAS:EIP-7843
   },
   {typeName: "ExecutionPayloadHeader", jsonCase: "eth2"}
 );


### PR DESCRIPTION
## Summary

The previous EIP-7843 implementation (#8747, cd139943aa) added `slotNumber` to `PayloadAttributesV4` (for `engine_forkchoiceUpdatedV4`) but missed adding it to `ExecutionPayloadV4`.

This causes **INVALID_RESPONSE_SSZ** errors when Lodestar attempts to decode GLOAS blocks from other clients (like Lighthouse) via P2P, because the SSZ schema doesn't match the incoming data.

### Root Cause

EIP-7843 introduces the SLOTNUM opcode (0x4b) that allows smart contracts to get the current slot number. For this to work, `slotNumber` must be present in:

1. **PayloadAttributesV4** (CL → EL): Tells Geth "build me a block for slot X" ✅ Already implemented
2. **ExecutionPayloadV4** (EL ↔ CL): The actual block payload that includes `slotNumber` in the header ❌ **This was missing**

```
BeaconBlockBodyGloas {
  ...
  executionPayload: ExecutionPayloadGloas {
    ...
    blockAccessList,  // EIP-7928
    slotNumber,       // EIP-7843 ← This was missing
  }
}
```

### Changes

**packages/types/src/gloas/sszTypes.ts**
- Added `slotNumber: Slot` to `ExecutionPayload` SSZ type
- Added `slotNumber: Slot` to `ExecutionPayloadHeader` SSZ type

**packages/beacon-node/src/execution/engine/types.ts**
- Added `slotNumber?: QUANTITY` to `ExecutionPayloadRpc` type
- Added serialization in `serializeExecutionPayload()`
- Added deserialization with validation in `parseExecutionPayload()`

**packages/state-transition/src/slot/upgradeStateToGloas.ts**
- Added `slotNumber: 0` to the execution payload header during Fulu → GLOAS state upgrade

**packages/state-transition/src/util/execution.ts**
- Added `slotNumber` copy in `executionPayloadToPayloadHeader()` for GLOAS fork

## Test plan

- [ ] Verify Lodestar can decode GLOAS blocks from Lighthouse via P2P without SSZ errors
- [ ] Verify `newPayloadV5` correctly passes `slotNumber` to the execution layer
- [ ] Verify `getPayloadV6` correctly receives `slotNumber` from the execution layer
- [ ] Verify state upgrade from Fulu to GLOAS correctly initializes `slotNumber`