### PR TITLE
chore: update test current file launch config to work with pnpm

### DIFF
--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -42,7 +42,7 @@
       "name": "Test Current File",
       "type": "node",
       "request": "launch",
-      "program": "${workspaceFolder}/node_modules/.bin/vitest",
+      "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
       "args": [
         "--run",
         "${file}",


### PR DESCRIPTION
All the files inside `node_modules/.bin` are shell scripts since we switched to pnpm which can't be executed via `node`.