### PR TITLE
fix: handle slot 0 correctly in data column sidecar RPC handler

### DIFF
--- a/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
+++ b/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
@@ -1,7 +1,7 @@
 import {LogData} from "@lodestar/logger";
 import {RespStatus, ResponseError} from "@lodestar/reqresp";
 import {ColumnIndex, Slot} from "@lodestar/types";
-import {prettyBytes, prettyPrintIndices, toRootHex} from "@lodestar/utils";
+import {prettyBytes, prettyPrintIndices, toHex, toRootHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/interface.js";
 import {IBeaconDb} from "../../../db/interface.js";
 import {getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized} from "../../../util/sszBytes.js";
@@ -38,10 +38,11 @@ export async function handleColumnSidecarUnavailability({
 
   chain.logger.debug("dataColumnSidecar requested unavailable", logData);
 
+  const isFinalized = !blockRoot;
   const blockBytes = blockRoot ? await db.block.getBinary(blockRoot) : await db.blockArchive.getBinary(slot);
   if (!blockBytes) {
     chain.logger.verbose(
-      `Expected ${blockRoot ? "unfinalized" : "finalized"} block not found while handling unavailable dataColumnSidecar`,
+      `Expected ${isFinalized ? "finalized" : "unfinalized"} block not found while handling unavailable dataColumnSidecar`,
       {
         slot,
         blockRoot: blockRoot ? toRootHex(blockRoot) : "unknown",
@@ -52,7 +53,27 @@ export async function handleColumnSidecarUnavailability({
   }
 
   // Check for blob count in actual block
-  const blobsCount = getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized(chain.config, blockBytes);
+  let blobsCount: number;
+  try {
+    blobsCount = getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized(chain.config, blockBytes);
+  } catch (e) {
+    // Log detailed info to diagnose why block bytes couldn't be parsed
+    // This should not happen for valid blocks, but we don't want to crash the RPC handler
+    const blockBytesPreview =
+      blockBytes.length > 0 ? toHex(blockBytes.subarray(0, Math.min(120, blockBytes.length))) : "empty";
+    chain.logger.error("Failed to parse block bytes for blob count check in dataColumnSidecar handler", {
+      slot,
+      blockRoot: blockRoot ? toRootHex(blockRoot) : "unknown",
+      isFinalized,
+      blockBytesLength: blockBytes.length,
+      blockBytesPreview,
+      forkName: chain.config.getForkName(slot),
+      error: (e as Error).message,
+    });
+    // Return without throwing - we can't determine blob count but shouldn't crash the RPC
+    // The peer will get an incomplete response but won't be penalized with SERVER_ERROR
+    return;
+  }
 
   // There are zero blobs for that column index, so we can safely return without any error
   if (blobsCount > 0) return;

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -449,7 +449,7 @@ export function getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized(
   blockBytes: Uint8Array
 ): number {
   const slot = getSlotFromSignedBeaconBlockSerialized(blockBytes);
-  if (!slot) throw new Error("Can not parse the slot from block bytes");
+  if (slot === null) throw new Error("Can not parse the slot from block bytes");
 
   if (config.getForkSeq(slot) < ForkSeq.deneb) return 0;
 


### PR DESCRIPTION
## Summary

- Fix JavaScript falsy check bug where `!0 === true` caused slot 0 to incorrectly fail validation
- Add defensive error handling with detailed logging in dataColumnResponseValidation.ts

## Problem

During custody backfill for epoch 0 (slots 0-7), the `data_column_sidecars_by_range` RPC handler was throwing:
```
Can not parse the slot from block bytes
```

This was caused by the slot parsing check using JavaScript's falsy check:
```typescript
if (!slot) throw new Error("Can not parse the slot from block bytes");
```

Since `!0 === true` in JavaScript, slot 0 (genesis block) incorrectly triggered this error.

The error was converted to an RPC `SERVER_ERROR`, causing peers (e.g., Lighthouse) to downscore Lodestar nodes by -29.97 per error. This led to peer disconnections and network forks during bal-devnet-2 testing.

## Changes

1. **Root cause fix** (`sszBytes.ts`): Changed `if (!slot)` to `if (slot === null)` for explicit null check
2. **Defensive fix** (`dataColumnResponseValidation.ts`): Added try-catch with detailed logging including:
   - Block bytes length and preview
   - Fork name at the slot
   - Whether block is finalized
   - Original error message

## Testing

- Built local Docker image with fix
- Ran Kurtosis devnet with 1 Lighthouse + 2 Lodestar nodes
- Verified no "Can not parse the slot from block bytes" errors during epoch 0 custody backfill
- Network remained healthy with all peers connected

## Related

- Discovered during bal-devnet-2 testing
- Lighthouse logs showed `batch_epoch: 0, Start Slot: 0, End Slot: 8, CustodyBackfill` triggering the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)