### PR TITLE
fix: update incorrect assertions in `handleColumnSidecarUnavailability`

### DIFF
--- a/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
+++ b/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
@@ -55,7 +55,7 @@ export async function handleColumnSidecarUnavailability({
   const blobsCount = getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized(chain.config, blockBytes);
 
   // There are zero blobs for that column index, so we can safely return without any error
-  if (blobsCount > 0) return;
+  if (blobsCount === 0) return;
 
   // There are blobs for that column index so we should have synced for it
   // We need to inform to peers that we don't have that expected data

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -479,7 +479,7 @@ export function getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized(
   blockBytes: Uint8Array
 ): number {
   const slot = getSlotFromSignedBeaconBlockSerialized(blockBytes);
-  if (!slot) throw new Error("Can not parse the slot from block bytes");
+  if (slot === null) throw new Error("Can not parse the slot from block bytes");
 
   if (config.getForkSeq(slot) < ForkSeq.deneb) return 0;
 


### PR DESCRIPTION
There are two bugs in `handleColumnSidecarUnavailability`, one was found by @qu0b in https://github.com/ChainSafe/lodestar/pull/8781 and while looking at that I found another one.

None of these are critical for mainnet but good to have them fixed on unstable.