### PR TITLE
fix: handle slot 0 correctly in data column sidecar RPC handler

### DIFF
--- a/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
+++ b/packages/beacon-node/src/network/reqresp/utils/dataColumnResponseValidation.ts
@@ -55,7 +55,7 @@ export async function handleColumnSidecarUnavailability({
   const blobsCount = getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized(chain.config, blockBytes);
 
   // There are zero blobs for that column index, so we can safely return without any error
-  if (blobsCount > 0) return;
+  if (blobsCount === 0) return;
 
   // There are blobs for that column index so we should have synced for it
   // We need to inform to peers that we don't have that expected data

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -479,7 +479,7 @@ export function getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized(
   blockBytes: Uint8Array
 ): number {
   const slot = getSlotFromSignedBeaconBlockSerialized(blockBytes);
-  if (!slot) throw new Error("Can not parse the slot from block bytes");
+  if (slot === null) throw new Error("Can not parse the slot from block bytes");
 
   if (config.getForkSeq(slot) < ForkSeq.deneb) return 0;
 


### PR DESCRIPTION
## Summary

Backport of #8781 to unstable branch.

- Fix JavaScript falsy check bug where `!0 === true` caused slot 0 to incorrectly fail validation
- Fix inverted blobsCount logic in dataColumnResponseValidation.ts

## Problem

During custody backfill for epoch 0 (slots 0-7), the `data_column_sidecars_by_range` RPC handler was throwing:
```
Can not parse the slot from block bytes
```

This was caused by the slot parsing check using JavaScript's falsy check:
```typescript
if (!slot) throw new Error("Can not parse the slot from block bytes");
```

Since `!0 === true` in JavaScript, slot 0 (genesis block) incorrectly triggered this error.

## Changes

1. **Root cause fix** (`sszBytes.ts`): Changed `if (!slot)` to `if (slot === null)` for explicit null check
2. **Logic fix** (`dataColumnResponseValidation.ts`): Changed `blobsCount > 0` to `blobsCount === 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)