### PR TITLE
chore: skip snappy benchmarks

### DIFF
--- a/packages/beacon-node/test/perf/network/gossip/snappy.test.ts
+++ b/packages/beacon-node/test/perf/network/gossip/snappy.test.ts
@@ -4,7 +4,10 @@ import * as snappyJs from "snappyjs";
 import {bench, describe} from "@chainsafe/benchmark";
 import snappyWasm from "@chainsafe/snappy-wasm";
 
-describe("network / gossip / snappy", () => {
+/**
+ * Enable this benchmark only when we enhance snappy libraries.
+ */
+describe.skip("network / gossip / snappy", () => {
   const msgLens = [
     // ->
     100,


### PR DESCRIPTION
**Motivation**

- our benchmark is super flaky and I rarely see we have CI green
- our snappy benchmark is only useful in scope of a PR #6483, it's not worth to keeps running it on CI
- we want to only run benchmark for functions developed by us to save CI time, see #8664

**Description**

- skip snappy benchmark
