### PR TITLE
chore: skip Map benchmarks

### DIFF
--- a/packages/beacon-node/test/perf/misc/map.test.ts
+++ b/packages/beacon-node/test/perf/misc/map.test.ts
@@ -1,6 +1,6 @@
 import {bench, describe} from "@chainsafe/benchmark";
 
-describe("misc / Map", () => {
+describe.skip("misc / Map", () => {
   const times = 1000;
 
   type ObjData = {obj: Record<string, number>; keys: string[]};


### PR DESCRIPTION
**Motivation**

- found failed benchmark in [CI](https://github.com/ChainSafe/lodestar/actions/runs/21348436170/job/61440256289?pr=8732) but that's not lodestar code
- see also #8786

**Description**

- skip Map benchmark
