### PR TITLE
chore: replace bigint-buffer

### DIFF
--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -66,7 +66,7 @@
     "@lodestar/params": "workspace:^",
     "@lodestar/types": "workspace:^",
     "@lodestar/utils": "workspace:^",
-    "bigint-buffer": "^1.1.5"
+    "@vekexasia/bigint-buffer2": "^1.0.4"
   },
   "devDependencies": {
     "@lodestar/api": "workspace:^"

--- a/packages/state-transition/src/util/interop.ts
+++ b/packages/state-transition/src/util/interop.ts
@@ -1,4 +1,4 @@
-import {toBufferBE} from "bigint-buffer";
+import {toBufferBE} from "@vekexasia/bigint-buffer2";
 import {digest} from "@chainsafe/as-sha256";
 import {SecretKey} from "@chainsafe/blst";
 import {bytesToBigInt, intToBytes} from "@lodestar/utils";

--- a/packages/state-transition/test/unit/util/misc.test.ts
+++ b/packages/state-transition/test/unit/util/misc.test.ts
@@ -1,4 +1,4 @@
-import {toBigIntLE} from "bigint-buffer";
+import {toBigIntLE} from "@vekexasia/bigint-buffer2";
 import {describe, expect, it} from "vitest";
 import {GENESIS_SLOT, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {getBlockRoot} from "../../../src/util/index.js";

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@chainsafe/as-sha256": "^1.2.0",
     "any-signal": "^4.1.1",
-    "bigint-buffer": "^1.1.5",
+    "@vekexasia/bigint-buffer2": "^1.0.4",
     "case": "^1.6.3",
     "js-yaml": "^4.1.0"
   },

--- a/packages/utils/src/bytes/browser.ts
+++ b/packages/utils/src/bytes/browser.ts
@@ -122,7 +122,7 @@ function charCodeToByte(charCode: number): number {
   throw new Error(`Invalid hex character code: ${charCode}`);
 }
 
-import {toBigIntBE, toBigIntLE, toBufferBE, toBufferLE} from "bigint-buffer";
+import {toBigIntBE, toBigIntLE, toBufferBE, toBufferLE} from "@vekexasia/bigint-buffer2";
 
 type Endianness = "le" | "be";
 

--- a/packages/utils/test/unit/bytes.test.ts
+++ b/packages/utils/test/unit/bytes.test.ts
@@ -36,7 +36,7 @@ describe("intToBytes", () => {
     const type = typeof input;
     const length = input[1];
     it(`should correctly serialize ${type} to bytes length ${length}`, () => {
-      expect(intToBytes(input[0], input[1])).toEqual(output);
+      expect(toHex(intToBytes(input[0], input[1]))).toEqual(toHex(output));
     });
   }
 });

--- a/packages/utils/test/unit/bytes.test.ts
+++ b/packages/utils/test/unit/bytes.test.ts
@@ -13,24 +13,24 @@ import {
 
 describe("intToBytes", () => {
   const zeroedArray = (length: number): number[] => Array.from({length}, () => 0);
-  const testCases: {input: [bigint | number, number]; output: Uint8Array}[] = [
-    {input: [255, 1], output: Uint8Array.from([255])},
-    {input: [1, 4], output: Uint8Array.from([1, 0, 0, 0])},
-    {input: [BigInt(255), 1], output: Uint8Array.from([255])},
-    {input: [65535, 2], output: Uint8Array.from([255, 255])},
-    {input: [BigInt(65535), 2], output: Uint8Array.from([255, 255])},
-    {input: [16777215, 3], output: Uint8Array.from([255, 255, 255])},
-    {input: [BigInt(16777215), 3], output: Uint8Array.from([255, 255, 255])},
-    {input: [4294967295, 4], output: Uint8Array.from([255, 255, 255, 255])},
-    {input: [BigInt(4294967295), 4], output: Uint8Array.from([255, 255, 255, 255])},
-    {input: [65535, 8], output: Uint8Array.from([255, 255, ...zeroedArray(8 - 2)])},
-    {input: [BigInt(65535), 8], output: Uint8Array.from([255, 255, ...zeroedArray(8 - 2)])},
-    {input: [65535, 32], output: Uint8Array.from([255, 255, ...zeroedArray(32 - 2)])},
-    {input: [BigInt(65535), 32], output: Uint8Array.from([255, 255, ...zeroedArray(32 - 2)])},
-    {input: [65535, 48], output: Uint8Array.from([255, 255, ...zeroedArray(48 - 2)])},
-    {input: [BigInt(65535), 48], output: Uint8Array.from([255, 255, ...zeroedArray(48 - 2)])},
-    {input: [65535, 96], output: Uint8Array.from([255, 255, ...zeroedArray(96 - 2)])},
-    {input: [BigInt(65535), 96], output: Uint8Array.from([255, 255, ...zeroedArray(96 - 2)])},
+  const testCases: {input: [bigint | number, number]; output: Buffer}[] = [
+    {input: [255, 1], output: Buffer.from([255])},
+    {input: [1, 4], output: Buffer.from([1, 0, 0, 0])},
+    {input: [BigInt(255), 1], output: Buffer.from([255])},
+    {input: [65535, 2], output: Buffer.from([255, 255])},
+    {input: [BigInt(65535), 2], output: Buffer.from([255, 255])},
+    {input: [16777215, 3], output: Buffer.from([255, 255, 255])},
+    {input: [BigInt(16777215), 3], output: Buffer.from([255, 255, 255])},
+    {input: [4294967295, 4], output: Buffer.from([255, 255, 255, 255])},
+    {input: [BigInt(4294967295), 4], output: Buffer.from([255, 255, 255, 255])},
+    {input: [65535, 8], output: Buffer.from([255, 255, ...zeroedArray(8 - 2)])},
+    {input: [BigInt(65535), 8], output: Buffer.from([255, 255, ...zeroedArray(8 - 2)])},
+    {input: [65535, 32], output: Buffer.from([255, 255, ...zeroedArray(32 - 2)])},
+    {input: [BigInt(65535), 32], output: Buffer.from([255, 255, ...zeroedArray(32 - 2)])},
+    {input: [65535, 48], output: Buffer.from([255, 255, ...zeroedArray(48 - 2)])},
+    {input: [BigInt(65535), 48], output: Buffer.from([255, 255, ...zeroedArray(48 - 2)])},
+    {input: [65535, 96], output: Buffer.from([255, 255, ...zeroedArray(96 - 2)])},
+    {input: [BigInt(65535), 96], output: Buffer.from([255, 255, ...zeroedArray(96 - 2)])},
   ];
   for (const {input, output} of testCases) {
     const type = typeof input;

--- a/packages/utils/test/unit/bytes.test.ts
+++ b/packages/utils/test/unit/bytes.test.ts
@@ -13,24 +13,24 @@ import {
 
 describe("intToBytes", () => {
   const zeroedArray = (length: number): number[] => Array.from({length}, () => 0);
-  const testCases: {input: [bigint | number, number]; output: Buffer}[] = [
-    {input: [255, 1], output: Buffer.from([255])},
-    {input: [1, 4], output: Buffer.from([1, 0, 0, 0])},
-    {input: [BigInt(255), 1], output: Buffer.from([255])},
-    {input: [65535, 2], output: Buffer.from([255, 255])},
-    {input: [BigInt(65535), 2], output: Buffer.from([255, 255])},
-    {input: [16777215, 3], output: Buffer.from([255, 255, 255])},
-    {input: [BigInt(16777215), 3], output: Buffer.from([255, 255, 255])},
-    {input: [4294967295, 4], output: Buffer.from([255, 255, 255, 255])},
-    {input: [BigInt(4294967295), 4], output: Buffer.from([255, 255, 255, 255])},
-    {input: [65535, 8], output: Buffer.from([255, 255, ...zeroedArray(8 - 2)])},
-    {input: [BigInt(65535), 8], output: Buffer.from([255, 255, ...zeroedArray(8 - 2)])},
-    {input: [65535, 32], output: Buffer.from([255, 255, ...zeroedArray(32 - 2)])},
-    {input: [BigInt(65535), 32], output: Buffer.from([255, 255, ...zeroedArray(32 - 2)])},
-    {input: [65535, 48], output: Buffer.from([255, 255, ...zeroedArray(48 - 2)])},
-    {input: [BigInt(65535), 48], output: Buffer.from([255, 255, ...zeroedArray(48 - 2)])},
-    {input: [65535, 96], output: Buffer.from([255, 255, ...zeroedArray(96 - 2)])},
-    {input: [BigInt(65535), 96], output: Buffer.from([255, 255, ...zeroedArray(96 - 2)])},
+  const testCases: {input: [bigint | number, number]; output: Uint8Array}[] = [
+    {input: [255, 1], output: Uint8Array.from([255])},
+    {input: [1, 4], output: Uint8Array.from([1, 0, 0, 0])},
+    {input: [BigInt(255), 1], output: Uint8Array.from([255])},
+    {input: [65535, 2], output: Uint8Array.from([255, 255])},
+    {input: [BigInt(65535), 2], output: Uint8Array.from([255, 255])},
+    {input: [16777215, 3], output: Uint8Array.from([255, 255, 255])},
+    {input: [BigInt(16777215), 3], output: Uint8Array.from([255, 255, 255])},
+    {input: [4294967295, 4], output: Uint8Array.from([255, 255, 255, 255])},
+    {input: [BigInt(4294967295), 4], output: Uint8Array.from([255, 255, 255, 255])},
+    {input: [65535, 8], output: Uint8Array.from([255, 255, ...zeroedArray(8 - 2)])},
+    {input: [BigInt(65535), 8], output: Uint8Array.from([255, 255, ...zeroedArray(8 - 2)])},
+    {input: [65535, 32], output: Uint8Array.from([255, 255, ...zeroedArray(32 - 2)])},
+    {input: [BigInt(65535), 32], output: Uint8Array.from([255, 255, ...zeroedArray(32 - 2)])},
+    {input: [65535, 48], output: Uint8Array.from([255, 255, ...zeroedArray(48 - 2)])},
+    {input: [BigInt(65535), 48], output: Uint8Array.from([255, 255, ...zeroedArray(48 - 2)])},
+    {input: [65535, 96], output: Uint8Array.from([255, 255, ...zeroedArray(96 - 2)])},
+    {input: [BigInt(65535), 96], output: Uint8Array.from([255, 255, ...zeroedArray(96 - 2)])},
   ];
   for (const {input, output} of testCases) {
     const type = typeof input;

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -63,7 +63,7 @@
     "@lodestar/logger": "workspace:^",
     "@lodestar/spec-test-util": "workspace:^",
     "@lodestar/test-utils": "workspace:^",
-    "bigint-buffer": "^1.1.5",
+    "@vekexasia/bigint-buffer2": "^1.0.4",
     "rimraf": "^4.4.1"
   }
 }

--- a/packages/validator/test/unit/services/attestationDuties.test.ts
+++ b/packages/validator/test/unit/services/attestationDuties.test.ts
@@ -1,4 +1,4 @@
-import {toBufferBE} from "bigint-buffer";
+import {toBufferBE} from "@vekexasia/bigint-buffer2";
 import {Mocked, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {SecretKey} from "@chainsafe/blst";
 import {toHexString} from "@chainsafe/ssz";

--- a/packages/validator/test/unit/services/blockDuties.test.ts
+++ b/packages/validator/test/unit/services/blockDuties.test.ts
@@ -1,4 +1,4 @@
-import {toBufferBE} from "bigint-buffer";
+import {toBufferBE} from "@vekexasia/bigint-buffer2";
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {SecretKey} from "@chainsafe/blst";
 import {toHexString} from "@chainsafe/ssz";

--- a/packages/validator/test/unit/services/externalSignerSync.test.ts
+++ b/packages/validator/test/unit/services/externalSignerSync.test.ts
@@ -1,4 +1,4 @@
-import {toBufferBE} from "bigint-buffer";
+import {toBufferBE} from "@vekexasia/bigint-buffer2";
 import {MockInstance, afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {SecretKey} from "@chainsafe/blst";
 import {createChainForkConfig} from "@lodestar/config";

--- a/packages/validator/test/unit/services/indicesService.test.ts
+++ b/packages/validator/test/unit/services/indicesService.test.ts
@@ -1,4 +1,4 @@
-import {toBufferBE} from "bigint-buffer";
+import {toBufferBE} from "@vekexasia/bigint-buffer2";
 import {beforeAll, describe, expect, it} from "vitest";
 import {SecretKey} from "@chainsafe/blst";
 import {toHexString} from "@chainsafe/ssz";

--- a/packages/validator/test/unit/services/syncCommitteDuties.test.ts
+++ b/packages/validator/test/unit/services/syncCommitteDuties.test.ts
@@ -1,4 +1,4 @@
-import {toBufferBE} from "bigint-buffer";
+import {toBufferBE} from "@vekexasia/bigint-buffer2";
 import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {when} from "vitest-when";
 import {SecretKey} from "@chainsafe/blst";

--- a/packages/validator/test/unit/validatorStore.test.ts
+++ b/packages/validator/test/unit/validatorStore.test.ts
@@ -1,4 +1,4 @@
-import {toBufferBE} from "bigint-buffer";
+import {toBufferBE} from "@vekexasia/bigint-buffer2";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {SecretKey} from "@chainsafe/blst";
 import {fromHexString, toHexString} from "@chainsafe/ssz";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1004,9 +1004,9 @@ importers:
       '@lodestar/utils':
         specifier: workspace:^
         version: link:../utils
-      bigint-buffer:
-        specifier: ^1.1.5
-        version: 1.1.5
+      '@vekexasia/bigint-buffer2':
+        specifier: ^1.0.4
+        version: 1.0.4
     devDependencies:
       '@lodestar/api':
         specifier: workspace:^
@@ -1060,12 +1060,12 @@ importers:
       '@chainsafe/as-sha256':
         specifier: ^1.2.0
         version: 1.2.0
+      '@vekexasia/bigint-buffer2':
+        specifier: ^1.0.4
+        version: 1.0.4
       any-signal:
         specifier: ^4.1.1
         version: 4.1.1
-      bigint-buffer:
-        specifier: ^1.1.5
-        version: 1.1.5
       case:
         specifier: ^1.6.3
         version: 1.6.3
@@ -1128,9 +1128,9 @@ importers:
       '@lodestar/test-utils':
         specifier: workspace:^
         version: link:../test-utils
-      bigint-buffer:
-        specifier: ^1.1.5
-        version: 1.1.5
+      '@vekexasia/bigint-buffer2':
+        specifier: ^1.0.4
+        version: 1.0.4
       rimraf:
         specifier: ^4.4.1
         version: 4.4.1
@@ -3168,6 +3168,15 @@ packages:
   '@types/yauzl@2.10.0':
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
 
+  '@vekexasia/bigint-buffer2@1.0.4':
+    resolution: {integrity: sha512-B2AG3lN2FRxLwqstNtJAYKL4758VxATXtwc3289PSl7gOXQ1wudHC4YrHUFyWYf4//oE5omHWYL8a85OG5OQQg==}
+    engines: {node: '>= 14.0.0'}
+    peerDependencies:
+      '@vekexasia/bigint-uint8array': '*'
+    peerDependenciesMeta:
+      '@vekexasia/bigint-uint8array':
+        optional: true
+
   '@vitest/browser-playwright@4.0.7':
     resolution: {integrity: sha512-j5vA74jIqKbMA6yRTQ4PwEwbuPx+Ldtdb12gAJt++eds3kDtuvmfqRe9SmCxXRJ50drZaSai6Vunh2WcjUw8Fg==}
     peerDependencies:
@@ -3459,10 +3468,6 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
-  bigint-buffer@1.1.5:
-    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
-    engines: {node: '>= 10.0.0'}
-
   bigint-crypto-utils@3.2.2:
     resolution: {integrity: sha512-U1RbE3aX9ayCUVcIPHuPDPKcK3SFOXf93J1UK/iHlJuQB7bhagPIX06/CLpLEsDThJ7KA4Dhrnzynl+d2weTiw==}
     engines: {node: '>=14.0.0'}
@@ -3470,9 +3475,6 @@ packages:
   bin-links@6.0.0:
     resolution: {integrity: sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==}
     engines: {node: ^20.17.0 || >=22.9.0}
-
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bintrees@1.0.1:
     resolution: {integrity: sha512-tbaUB1QpTIj4cKY8c1rvNAvEQXA+ekzHmbe4jzNfW3QWsF9GnnP/BRWyl6/qqS53heoYJ93naaFcm/jooONH8g==}
@@ -4267,9 +4269,6 @@ packages:
 
   file-stream-rotator@0.6.1:
     resolution: {integrity: sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==}
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -9962,6 +9961,8 @@ snapshots:
       '@types/node': 24.10.1
     optional: true
 
+  '@vekexasia/bigint-buffer2@1.0.4': {}
+
   '@vitest/browser-playwright@4.0.7(playwright@1.56.1)(vite@6.1.6(@types/node@24.10.1)(yaml@2.8.2))(vitest@4.0.7)':
     dependencies:
       '@vitest/browser': 4.0.7(vite@6.1.6(@types/node@24.10.1)(yaml@2.8.2))(vitest@4.0.7)
@@ -10343,10 +10344,6 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  bigint-buffer@1.1.5:
-    dependencies:
-      bindings: 1.5.0
-
   bigint-crypto-utils@3.2.2: {}
 
   bin-links@6.0.0:
@@ -10356,10 +10353,6 @@ snapshots:
       proc-log: 6.1.0
       read-cmd-shim: 6.0.0
       write-file-atomic: 7.0.0
-
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
 
   bintrees@1.0.1: {}
 
@@ -11345,8 +11338,6 @@ snapshots:
   file-stream-rotator@0.6.1:
     dependencies:
       moment: 2.29.4
-
-  file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ onlyBuiltDependencies:
   - "@parcel/watcher"
   - "@swc/core"
   - aws-sdk
-  - bigint-buffer
+  - "@vekexasia/bigint-buffer2"
   - classic-level
   - core-js
   - cpu-features


### PR DESCRIPTION
**Motivation**

- https://github.com/ChainSafe/lodestar/issues/8771

**Description**

- Replace `bigint-buffer` with [`@vekexasia/bigint-buffer2`](https://github.com/vekexasia/bigint-swissknife/tree/main/packages/bigint-buffer2)
- The old implementation returned a buffer regardless of context, new implementation returns a buffer when in a browser and an Uint8Array in Node, unit/browser tests were fixed to accept either.


Closes #8771