### PR TITLE
chore: add assertions to check prior withdrawals against limit

### DIFF
--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -132,6 +132,9 @@ function getBuilderWithdrawals(
   builderBalanceAfterWithdrawals: Map<number, number>
 ): {builderWithdrawals: capella.Withdrawal[]; withdrawalIndex: number; processedCount: number} {
   const withdrawalsLimit = MAX_WITHDRAWALS_PER_PAYLOAD - 1;
+  if (priorWithdrawals.length > withdrawalsLimit) {
+    throw Error(`Prior withdrawals exceed limit: ${priorWithdrawals.length} > ${withdrawalsLimit}`);
+  }
   const builderWithdrawals: capella.Withdrawal[] = [];
   const allBuilderPendingWithdrawals =
     state.builderPendingWithdrawals.length <= MAX_WITHDRAWALS_PER_PAYLOAD
@@ -182,6 +185,9 @@ function getBuildersSweepWithdrawals(
   builderBalanceAfterWithdrawals: Map<number, number>
 ): {buildersSweepWithdrawals: capella.Withdrawal[]; withdrawalIndex: number; processedCount: number} {
   const withdrawalsLimit = MAX_WITHDRAWALS_PER_PAYLOAD - 1;
+  if (numPriorWithdrawal > withdrawalsLimit) {
+    throw Error(`Prior withdrawals exceed limit: ${numPriorWithdrawal} > ${withdrawalsLimit}`);
+  }
   const buildersSweepWithdrawals: capella.Withdrawal[] = [];
   const epoch = state.epochCtx.epoch;
   const builders = state.builders;


### PR DESCRIPTION
This just adds assertions to check prior withdrawals against limit which is done in the spec [here](https://github.com/ethereum/consensus-specs/blob/ee5d067abf6486b77753e7c2928a81cf50972c75/specs/gloas/beacon-chain.md?plain=1#L862).

This shouldn't happen unless there is a bug in our implementation but it's good to have them as sanity checks.