### PR TITLE
refactor: update signature sets to use validator indices instead of pubkeys

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -146,7 +146,6 @@ export async function verifyBlocksInEpoch(
       opts.skipVerifyBlockSignatures !== true
         ? verifyBlocksSignatures(
             this.config,
-            this.index2pubkey,
             this.bls,
             this.logger,
             this.metrics,

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
@@ -1,5 +1,5 @@
 import {BeaconConfig} from "@lodestar/config";
-import {CachedBeaconStateAllForks, Index2PubkeyCache, getBlockSignatureSets} from "@lodestar/state-transition";
+import {CachedBeaconStateAllForks, getBlockSignatureSets} from "@lodestar/state-transition";
 import {IndexedAttestation, SignedBeaconBlock} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
@@ -17,7 +17,6 @@ import {ImportBlockOpts} from "./types.js";
  */
 export async function verifyBlocksSignatures(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   bls: IBlsVerifier,
   logger: Logger,
   metrics: Metrics | null,
@@ -44,7 +43,6 @@ export async function verifyBlocksSignatures(
         bls.verifySignatureSets(
           getBlockSignatureSets(
             config,
-            index2pubkey,
             currentSyncCommitteeIndexed,
             block,
             indexedAttestationsByBlock[i],

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
@@ -41,15 +41,9 @@ export async function verifyBlocksSignatures(
       : //
         // Verify signatures per block to track which block is invalid
         bls.verifySignatureSets(
-          getBlockSignatureSets(
-            config,
-            currentSyncCommitteeIndexed,
-            block,
-            indexedAttestationsByBlock[i],
-            {
-              skipProposerSignature: opts.validProposerSignature,
-            }
-          )
+          getBlockSignatureSets(config, currentSyncCommitteeIndexed, block, indexedAttestationsByBlock[i], {
+            skipProposerSignature: opts.validProposerSignature,
+          })
         );
 
     // getBlockSignatureSets() takes 45ms in benchmarks for 2022Q2 mainnet blocks (100 sigs). When syncing a 32 blocks

--- a/packages/beacon-node/src/chain/bls/multithread/jobItem.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/jobItem.ts
@@ -1,5 +1,5 @@
 import {PublicKey, asyncAggregateWithRandomness} from "@chainsafe/blst";
-import {ISignatureSet, SignatureSetType} from "@lodestar/state-transition";
+import {ISignatureSet, Index2PubkeyCache, SignatureSetType} from "@lodestar/state-transition";
 import {Metrics} from "../../../metrics/metrics.js";
 import {LinkedList} from "../../../util/array.js";
 import {VerifySignatureOpts} from "../interface.js";
@@ -48,14 +48,18 @@ export function jobItemSigSets(job: JobQueueItem): number {
  * Prepare BlsWorkReq from JobQueueItem
  * WARNING: May throw with untrusted user input
  */
-export async function jobItemWorkReq(job: JobQueueItem, metrics: Metrics | null): Promise<BlsWorkReq> {
+export async function jobItemWorkReq(
+  job: JobQueueItem,
+  index2pubkey: Index2PubkeyCache,
+  metrics: Metrics | null
+): Promise<BlsWorkReq> {
   switch (job.type) {
     case JobQueueItemType.default:
       return {
         opts: job.opts,
         sets: job.sets.map((set) => ({
           // this can throw, handled in the consumer code
-          publicKey: getAggregatedPubkey(set, metrics).toBytes(),
+          publicKey: getAggregatedPubkey(set, index2pubkey, metrics).toBytes(),
           signature: set.signature,
           message: set.signingRoot,
         })),

--- a/packages/beacon-node/src/chain/bls/utils.ts
+++ b/packages/beacon-node/src/chain/bls/utils.ts
@@ -1,17 +1,25 @@
 import {PublicKey, aggregatePublicKeys} from "@chainsafe/blst";
-import {ISignatureSet, SignatureSetType} from "@lodestar/state-transition";
+import {ISignatureSet, Index2PubkeyCache, SignatureSetType} from "@lodestar/state-transition";
 import {Metrics} from "../../metrics/metrics.js";
 
-export function getAggregatedPubkey(signatureSet: ISignatureSet, metrics: Metrics | null = null): PublicKey {
+export function getAggregatedPubkey(
+  signatureSet: ISignatureSet,
+  index2pubkey: Index2PubkeyCache,
+  metrics: Metrics | null = null
+): PublicKey {
   switch (signatureSet.type) {
     case SignatureSetType.single:
       return signatureSet.pubkey;
 
+    case SignatureSetType.indexed:
+      return index2pubkey[signatureSet.index];
+
     case SignatureSetType.aggregate: {
       const timer = metrics?.blsThreadPool.pubkeysAggregationMainThreadDuration.startTimer();
-      const pubkeys = aggregatePublicKeys(signatureSet.pubkeys);
+      const pubkeys = signatureSet.indices.map((i) => index2pubkey[i]);
+      const aggregated = aggregatePublicKeys(pubkeys);
       timer?.();
-      return pubkeys;
+      return aggregated;
     }
 
     default:
@@ -20,11 +28,11 @@ export function getAggregatedPubkey(signatureSet: ISignatureSet, metrics: Metric
 }
 
 export function getAggregatedPubkeysCount(signatureSets: ISignatureSet[]): number {
-  let pubkeysConut = 0;
+  let pubkeysCount = 0;
   for (const set of signatureSets) {
     if (set.type === SignatureSetType.aggregate) {
-      pubkeysConut += set.pubkeys.length;
+      pubkeysCount += set.indices.length;
     }
   }
-  return pubkeysConut;
+  return pubkeysCount;
 }

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -254,7 +254,7 @@ export class BeaconChain implements IBeaconChain {
     const emitter = new ChainEventEmitter();
     // by default, verify signatures on both main threads and worker threads
     const bls = opts.blsVerifyAllMainThread
-      ? new BlsSingleThreadVerifier({metrics})
+      ? new BlsSingleThreadVerifier({metrics, index2pubkey})
       : new BlsMultiThreadWorkerPool(opts, {logger, metrics, index2pubkey});
 
     if (!clock) clock = new Clock({config, genesisTime: this.genesisTime, signal});

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -255,7 +255,7 @@ export class BeaconChain implements IBeaconChain {
     // by default, verify signatures on both main threads and worker threads
     const bls = opts.blsVerifyAllMainThread
       ? new BlsSingleThreadVerifier({metrics})
-      : new BlsMultiThreadWorkerPool(opts, {logger, metrics});
+      : new BlsMultiThreadWorkerPool(opts, {logger, metrics, index2pubkey});
 
     if (!clock) clock = new Clock({config, genesisTime: this.genesisTime, signal});
 

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -216,7 +216,6 @@ async function validateAggregateAndProof(
   // by the validator with index aggregate_and_proof.aggregator_index.
   // [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
   // [REJECT] The signature of aggregate is valid.
-  const aggregatorIndex = aggregateAndProof.aggregatorIndex;
   const signingRoot = cachedAttData ? cachedAttData.signingRoot : getAttestationDataSigningRoot(chain.config, attData);
   const indexedAttestationSignatureSet = createAggregateSignatureSetFromComponents(
     indexedAttestation.attestingIndices,

--- a/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/aggregateAndProof.ts
@@ -216,16 +216,16 @@ async function validateAggregateAndProof(
   // by the validator with index aggregate_and_proof.aggregator_index.
   // [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
   // [REJECT] The signature of aggregate is valid.
-  const aggregator = chain.index2pubkey[aggregateAndProof.aggregatorIndex];
+  const aggregatorIndex = aggregateAndProof.aggregatorIndex;
   const signingRoot = cachedAttData ? cachedAttData.signingRoot : getAttestationDataSigningRoot(chain.config, attData);
   const indexedAttestationSignatureSet = createAggregateSignatureSetFromComponents(
-    indexedAttestation.attestingIndices.map((i) => chain.index2pubkey[i]),
+    indexedAttestation.attestingIndices,
     signingRoot,
     indexedAttestation.signature
   );
   const signatureSets = [
-    getSelectionProofSignatureSet(chain.config, attSlot, aggregator, signedAggregateAndProof),
-    getAggregateAndProofSignatureSet(chain.config, attEpoch, aggregator, signedAggregateAndProof),
+    getSelectionProofSignatureSet(chain.config, attSlot, aggregatorIndex, signedAggregateAndProof),
+    getAggregateAndProofSignatureSet(chain.config, attEpoch, aggregatorIndex, signedAggregateAndProof),
     indexedAttestationSignatureSet,
   ];
   // no need to write to SeenAttestationDatas

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -13,13 +13,13 @@ import {
 } from "@lodestar/params";
 import {
   EpochShuffling,
+  IndexedSignatureSet,
   ShufflingError,
   ShufflingErrorCode,
-  SingleSignatureSet,
   computeEpochAtSlot,
   computeSigningRoot,
   computeStartSlotAtEpoch,
-  createSingleSignatureSetFromComponents,
+  createIndexedSignatureSetFromComponents,
 } from "@lodestar/state-transition";
 import {
   CommitteeIndex,
@@ -89,7 +89,7 @@ export type GossipAttestation = {
 };
 
 export type Step0Result = AttestationValidationResult & {
-  signatureSet: SingleSignatureSet;
+  signatureSet: IndexedSignatureSet;
   validatorIndex: number;
 };
 
@@ -124,7 +124,7 @@ export async function validateGossipAttestationsSameAttData(
   // step1: verify signatures of all valid attestations
   // map new index to index in resultOrErrors
   const newIndexToOldIndex = new Map<number, number>();
-  const signatureSets: SingleSignatureSet[] = [];
+  const signatureSets: IndexedSignatureSet[] = [];
   let newIndex = 0;
   const step0Results: Step0Result[] = [];
   for (const [i, resultOrError] of step0ResultOrErrors.entries()) {
@@ -142,7 +142,7 @@ export async function validateGossipAttestationsSameAttData(
   if (batchableBls) {
     // all signature sets should have same signing root since we filtered in network processor
     signatureValids = await chain.bls.verifySignatureSetsSameMessage(
-      signatureSets.map((set) => ({publicKey: set.pubkey, signature: set.signature})),
+      signatureSets.map((set) => ({publicKey: chain.index2pubkey[set.index], signature: set.signature})),
       signatureSets[0].signingRoot
     );
   } else {
@@ -477,7 +477,7 @@ async function validateAttestationNoSignatureCheck(
 
   // [REJECT] The signature of attestation is valid.
   const attestingIndices = [validatorIndex];
-  let signatureSet: SingleSignatureSet;
+  let signatureSet: IndexedSignatureSet;
   let attDataRootHex: RootHex;
   const signature = attestationOrCache.attestation
     ? attestationOrCache.attestation.signature
@@ -492,15 +492,15 @@ async function validateAttestationNoSignatureCheck(
 
   if (attestationOrCache.cache) {
     // there could be up to 6% of cpu time to compute signing root if we don't clone the signature set
-    signatureSet = createSingleSignatureSetFromComponents(
-      chain.index2pubkey[validatorIndex],
+    signatureSet = createIndexedSignatureSetFromComponents(
+      validatorIndex,
       attestationOrCache.cache.signingRoot,
       signature
     );
     attDataRootHex = attestationOrCache.cache.attDataRootHex;
   } else {
-    signatureSet = createSingleSignatureSetFromComponents(
-      chain.index2pubkey[validatorIndex],
+    signatureSet = createIndexedSignatureSetFromComponents(
+      validatorIndex,
       getSigningRoot(),
       signature
     );

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -499,11 +499,7 @@ async function validateAttestationNoSignatureCheck(
     );
     attDataRootHex = attestationOrCache.cache.attDataRootHex;
   } else {
-    signatureSet = createIndexedSignatureSetFromComponents(
-      validatorIndex,
-      getSigningRoot(),
-      signature
-    );
+    signatureSet = createIndexedSignatureSetFromComponents(validatorIndex, getSigningRoot(), signature);
 
     // add cached attestation data before verifying signature
     attDataRootHex = toRootHex(ssz.phase0.AttestationData.hashTreeRoot(attData));

--- a/packages/beacon-node/src/chain/validation/attesterSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/attesterSlashing.ts
@@ -58,12 +58,7 @@ export async function validateAttesterSlashing(
     });
   }
 
-  const signatureSets = getAttesterSlashingSignatureSets(
-    chain.config,
-    chain.index2pubkey,
-    state.slot,
-    attesterSlashing
-  );
+  const signatureSets = getAttesterSlashingSignatureSets(chain.config, state.slot, attesterSlashing);
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true, priority: prioritizeBls}))) {
     throw new AttesterSlashingError(GossipAction.REJECT, {
       code: AttesterSlashingErrorCode.INVALID,

--- a/packages/beacon-node/src/chain/validation/blobSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -139,7 +139,6 @@ export async function validateGossipBlobSidecar(
   if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blobSlot, blockHex, signature)) {
     const signatureSet = getBlockHeaderProposerSignatureSetByParentStateSlot(
       chain.config,
-      chain.index2pubkey,
       blockState.slot,
       blobSidecar.signedBlockHeader
     );
@@ -244,11 +243,7 @@ export async function validateBlockBlobSidecars(
     const blockRootHex = toRootHex(blockRoot);
     const signature = firstSidecarSignedBlockHeader.signature;
     if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockSlot, blockRootHex, signature)) {
-      const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(
-        chain.config,
-        chain.index2pubkey,
-        firstSidecarSignedBlockHeader
-      );
+      const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(chain.config, firstSidecarSignedBlockHeader);
 
       if (
         !(await chain.bls.verifySignatureSets([signatureSet], {

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -157,7 +157,7 @@ export async function validateGossipBlock(
 
   // [REJECT] The proposer signature, signed_beacon_block.signature, is valid with respect to the proposer_index pubkey.
   if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockSlot, blockRoot, signedBlock.signature)) {
-    const signatureSet = getBlockProposerSignatureSet(chain.config, chain.index2pubkey, signedBlock);
+    const signatureSet = getBlockProposerSignatureSet(chain.config, signedBlock);
     // Don't batch so verification is not delayed
     if (!(await chain.bls.verifySignatureSets([signatureSet], {verifyOnMainThread: true}))) {
       throw new BlockGossipError(GossipAction.REJECT, {

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -136,7 +136,6 @@ export async function validateGossipDataColumnSidecar(
   if (!chain.seenBlockInputCache.isVerifiedProposerSignature(blockHeader.slot, blockRootHex, signature)) {
     const signatureSet = getBlockHeaderProposerSignatureSetByParentStateSlot(
       chain.config,
-      chain.index2pubkey,
       blockState.slot,
       dataColumnSidecar.signedBlockHeader
     );
@@ -337,11 +336,7 @@ export async function validateBlockDataColumnSidecars(
     const slot = firstSidecarSignedBlockHeader.message.slot;
     const signature = firstSidecarSignedBlockHeader.signature;
     if (!chain.seenBlockInputCache.isVerifiedProposerSignature(slot, rootHex, signature)) {
-      const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(
-        chain.config,
-        chain.index2pubkey,
-        firstSidecarSignedBlockHeader
-      );
+      const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(chain.config, firstSidecarSignedBlockHeader);
 
       if (
         !(await chain.bls.verifySignatureSets([signatureSet], {

--- a/packages/beacon-node/src/chain/validation/proposerSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/proposerSlashing.ts
@@ -37,7 +37,7 @@ async function validateProposerSlashing(
   try {
     const proposer = state.validators.getReadonly(proposerSlashing.signedHeader1.message.proposerIndex);
     // verifySignature = false, verified in batch below
-    assertValidProposerSlashing(chain.config, state.slot, proposerSlashing, proposer, false);
+    assertValidProposerSlashing(chain.config, chain.index2pubkey, state.slot, proposerSlashing, proposer, false);
   } catch (e) {
     throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID,

--- a/packages/beacon-node/src/chain/validation/proposerSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/proposerSlashing.ts
@@ -37,7 +37,7 @@ async function validateProposerSlashing(
   try {
     const proposer = state.validators.getReadonly(proposerSlashing.signedHeader1.message.proposerIndex);
     // verifySignature = false, verified in batch below
-    assertValidProposerSlashing(chain.config, chain.index2pubkey, state.slot, proposerSlashing, proposer, false);
+    assertValidProposerSlashing(chain.config, state.slot, proposerSlashing, proposer, false);
   } catch (e) {
     throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID,
@@ -45,12 +45,7 @@ async function validateProposerSlashing(
     });
   }
 
-  const signatureSets = getProposerSlashingSignatureSets(
-    chain.config,
-    chain.index2pubkey,
-    state.slot,
-    proposerSlashing
-  );
+  const signatureSets = getProposerSlashingSignatureSets(chain.config, state.slot, proposerSlashing);
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true, priority: prioritizeBls}))) {
     throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID,

--- a/packages/beacon-node/src/chain/validation/signatureSets/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/aggregateAndProof.ts
@@ -1,13 +1,12 @@
-import {PublicKey} from "@chainsafe/blst";
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_AGGREGATE_AND_PROOF, ForkSeq} from "@lodestar/params";
 import {
   ISignatureSet,
+  SignatureSetType,
   computeSigningRoot,
   computeStartSlotAtEpoch,
-  createSingleSignatureSetFromComponents,
 } from "@lodestar/state-transition";
-import {Epoch, SignedAggregateAndProof, ssz} from "@lodestar/types";
+import {Epoch, SignedAggregateAndProof, ValidatorIndex, ssz} from "@lodestar/types";
 
 export function getAggregateAndProofSigningRoot(
   config: BeaconConfig,
@@ -27,12 +26,13 @@ export function getAggregateAndProofSigningRoot(
 export function getAggregateAndProofSignatureSet(
   config: BeaconConfig,
   epoch: Epoch,
-  aggregator: PublicKey,
+  aggregatorIndex: ValidatorIndex,
   aggregateAndProof: SignedAggregateAndProof
 ): ISignatureSet {
-  return createSingleSignatureSetFromComponents(
-    aggregator,
-    getAggregateAndProofSigningRoot(config, epoch, aggregateAndProof),
-    aggregateAndProof.signature
-  );
+  return {
+    type: SignatureSetType.indexed,
+    index: aggregatorIndex,
+    signingRoot: getAggregateAndProofSigningRoot(config, epoch, aggregateAndProof),
+    signature: aggregateAndProof.signature,
+  };
 }

--- a/packages/beacon-node/src/chain/validation/signatureSets/aggregateAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/aggregateAndProof.ts
@@ -1,11 +1,6 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_AGGREGATE_AND_PROOF, ForkSeq} from "@lodestar/params";
-import {
-  ISignatureSet,
-  SignatureSetType,
-  computeSigningRoot,
-  computeStartSlotAtEpoch,
-} from "@lodestar/state-transition";
+import {ISignatureSet, SignatureSetType, computeSigningRoot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, SignedAggregateAndProof, ValidatorIndex, ssz} from "@lodestar/types";
 
 export function getAggregateAndProofSigningRoot(

--- a/packages/beacon-node/src/chain/validation/signatureSets/contributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/contributionAndProof.ts
@@ -3,7 +3,6 @@ import {DOMAIN_CONTRIBUTION_AND_PROOF} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   ISignatureSet,
-  Index2PubkeyCache,
   SignatureSetType,
   computeSigningRoot,
 } from "@lodestar/state-transition";
@@ -11,7 +10,6 @@ import {altair, ssz} from "@lodestar/types";
 
 export function getContributionAndProofSignatureSet(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   signedContributionAndProof: altair.SignedContributionAndProof
 ): ISignatureSet {
@@ -22,8 +20,8 @@ export function getContributionAndProofSignatureSet(
   );
   const signingData = signedContributionAndProof.message;
   return {
-    type: SignatureSetType.single,
-    pubkey: index2pubkey[signedContributionAndProof.message.aggregatorIndex],
+    type: SignatureSetType.indexed,
+    index: signedContributionAndProof.message.aggregatorIndex,
     signingRoot: computeSigningRoot(ssz.altair.ContributionAndProof, signingData, domain),
     signature: signedContributionAndProof.signature,
   };

--- a/packages/beacon-node/src/chain/validation/signatureSets/selectionProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/selectionProof.ts
@@ -1,8 +1,7 @@
-import {PublicKey} from "@chainsafe/blst";
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_SELECTION_PROOF} from "@lodestar/params";
-import {ISignatureSet, computeSigningRoot, createSingleSignatureSetFromComponents} from "@lodestar/state-transition";
-import {Slot, phase0, ssz} from "@lodestar/types";
+import {ISignatureSet, SignatureSetType, computeSigningRoot} from "@lodestar/state-transition";
+import {Slot, ValidatorIndex, phase0, ssz} from "@lodestar/types";
 
 export function getSelectionProofSigningRoot(config: BeaconConfig, slot: Slot): Uint8Array {
   // previously, we call `const selectionProofDomain = config.getDomain(state.slot, DOMAIN_SELECTION_PROOF, slot)`
@@ -16,12 +15,13 @@ export function getSelectionProofSigningRoot(config: BeaconConfig, slot: Slot): 
 export function getSelectionProofSignatureSet(
   config: BeaconConfig,
   slot: Slot,
-  aggregator: PublicKey,
+  aggregatorIndex: ValidatorIndex,
   aggregateAndProof: phase0.SignedAggregateAndProof
 ): ISignatureSet {
-  return createSingleSignatureSetFromComponents(
-    aggregator,
-    getSelectionProofSigningRoot(config, slot),
-    aggregateAndProof.message.selectionProof
-  );
+  return {
+    type: SignatureSetType.indexed,
+    index: aggregatorIndex,
+    signingRoot: getSelectionProofSigningRoot(config, slot),
+    signature: aggregateAndProof.message.selectionProof,
+  };
 }

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommittee.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommittee.ts
@@ -3,7 +3,6 @@ import {DOMAIN_SYNC_COMMITTEE} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   ISignatureSet,
-  Index2PubkeyCache,
   SignatureSetType,
   computeSigningRoot,
 } from "@lodestar/state-transition";
@@ -11,15 +10,14 @@ import {altair, ssz} from "@lodestar/types";
 
 export function getSyncCommitteeSignatureSet(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   syncCommittee: altair.SyncCommitteeMessage
 ): ISignatureSet {
   const domain = config.getDomain(state.slot, DOMAIN_SYNC_COMMITTEE, syncCommittee.slot);
 
   return {
-    type: SignatureSetType.single,
-    pubkey: index2pubkey[syncCommittee.validatorIndex],
+    type: SignatureSetType.indexed,
+    index: syncCommittee.validatorIndex,
     signingRoot: computeSigningRoot(ssz.Root, syncCommittee.beaconBlockRoot, domain),
     signature: syncCommittee.signature,
   };

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeContribution.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeContribution.ts
@@ -1,4 +1,3 @@
-import {PublicKey} from "@chainsafe/blst";
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_SYNC_COMMITTEE} from "@lodestar/params";
 import {CachedBeaconStateAltair, ISignatureSet, SignatureSetType, computeSigningRoot} from "@lodestar/state-transition";
@@ -8,12 +7,12 @@ export function getSyncCommitteeContributionSignatureSet(
   config: BeaconConfig,
   state: CachedBeaconStateAltair,
   contribution: altair.SyncCommitteeContribution,
-  pubkeys: PublicKey[]
+  participantIndices: number[]
 ): ISignatureSet {
   const domain = config.getDomain(state.slot, DOMAIN_SYNC_COMMITTEE, contribution.slot);
   return {
     type: SignatureSetType.aggregate,
-    pubkeys,
+    indices: participantIndices,
     signingRoot: computeSigningRoot(ssz.Root, contribution.beaconBlockRoot, domain),
     signature: contribution.signature,
   };

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
@@ -3,7 +3,6 @@ import {DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   ISignatureSet,
-  Index2PubkeyCache,
   SignatureSetType,
   computeSigningRoot,
 } from "@lodestar/state-transition";
@@ -11,7 +10,6 @@ import {altair, ssz} from "@lodestar/types";
 
 export function getSyncCommitteeSelectionProofSignatureSet(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   state: CachedBeaconStateAllForks,
   contributionAndProof: altair.ContributionAndProof
 ): ISignatureSet {
@@ -22,8 +20,8 @@ export function getSyncCommitteeSelectionProofSignatureSet(
     subcommitteeIndex: contributionAndProof.contribution.subcommitteeIndex,
   };
   return {
-    type: SignatureSetType.single,
-    pubkey: index2pubkey[contributionAndProof.aggregatorIndex],
+    type: SignatureSetType.indexed,
+    index: contributionAndProof.aggregatorIndex,
     signingRoot: computeSigningRoot(ssz.altair.SyncAggregatorSelectionData, signingData, domain),
     signature: contributionAndProof.selectionProof,
   };

--- a/packages/beacon-node/src/chain/validation/syncCommittee.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommittee.ts
@@ -89,7 +89,7 @@ async function validateSyncCommitteeSigOnly(
   syncCommittee: altair.SyncCommitteeMessage,
   prioritizeBls = false
 ): Promise<void> {
-  const signatureSet = getSyncCommitteeSignatureSet(chain.config, chain.index2pubkey, headState, syncCommittee);
+  const signatureSet = getSyncCommitteeSignatureSet(chain.config, headState, syncCommittee);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true, priority: prioritizeBls}))) {
     throw new SyncCommitteeError(GossipAction.REJECT, {
       code: SyncCommitteeErrorCode.INVALID_SIGNATURE,

--- a/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -21,7 +21,6 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   const contributionAndProof = signedContributionAndProof.message;
   const {contribution, aggregatorIndex} = contributionAndProof;
   const {subcommitteeIndex, slot} = contribution;
-  const {index2pubkey} = chain;
 
   const headState = chain.getHeadState();
   validateGossipSyncCommitteeExceptSig(chain, headState, subcommitteeIndex, {
@@ -74,14 +73,13 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   // i.e. state.validators[contribution_and_proof.aggregator_index].pubkey in get_sync_subcommittee_pubkeys(state, contribution.subcommittee_index).
   // > Checked in validateGossipSyncCommitteeExceptSig()
 
-  const participantPubkeys = syncCommitteeParticipantIndices.map((validatorIndex) => index2pubkey[validatorIndex]);
   const signatureSets = [
     // [REJECT] The contribution_and_proof.selection_proof is a valid signature of the SyncAggregatorSelectionData
     // derived from the contribution by the validator with index contribution_and_proof.aggregator_index.
-    getSyncCommitteeSelectionProofSignatureSet(chain.config, index2pubkey, headState, contributionAndProof),
+    getSyncCommitteeSelectionProofSignatureSet(chain.config, headState, contributionAndProof),
 
     // [REJECT] The aggregator signature, signed_contribution_and_proof.signature, is valid.
-    getContributionAndProofSignatureSet(chain.config, index2pubkey, headState, signedContributionAndProof),
+    getContributionAndProofSignatureSet(chain.config, headState, signedContributionAndProof),
 
     // [REJECT] The aggregate signature is valid for the message beacon_block_root and aggregate pubkey derived from
     // the participation info in aggregation_bits for the subcommittee specified by the contribution.subcommittee_index.
@@ -89,7 +87,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
       chain.config,
       headState as CachedBeaconStateAltair,
       contribution,
-      participantPubkeys
+      syncCommitteeParticipantIndices
     ),
   ];
 

--- a/packages/beacon-node/src/chain/validation/voluntaryExit.ts
+++ b/packages/beacon-node/src/chain/validation/voluntaryExit.ts
@@ -59,7 +59,7 @@ async function validateVoluntaryExit(
     });
   }
 
-  const signatureSet = getVoluntaryExitSignatureSet(chain.config, chain.index2pubkey, state.slot, voluntaryExit);
+  const signatureSet = getVoluntaryExitSignatureSet(chain.config, state.slot, voluntaryExit);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true, priority: prioritizeBls}))) {
     throw new VoluntaryExitError(GossipAction.REJECT, {
       code: VoluntaryExitErrorCode.INVALID_SIGNATURE,

--- a/packages/beacon-node/src/sync/backfill/backfill.ts
+++ b/packages/beacon-node/src/sync/backfill/backfill.ts
@@ -750,7 +750,7 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
 
     // GENESIS_SLOT doesn't has valid signature
     if (anchorBlock.message.slot === GENESIS_SLOT) return;
-    await verifyBlockProposerSignature(this.chain.config, this.chain.index2pubkey, this.chain.bls, [anchorBlock]);
+    await verifyBlockProposerSignature(this.chain.config, this.chain.bls, [anchorBlock]);
 
     // We can write to the disk if this is ahead of prevFinalizedCheckpointBlock otherwise
     // we will need to go make checks on the top of sync loop before writing as it might
@@ -815,7 +815,7 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
 
     // If any of the block's proposer signature fail, we can't trust this peer at all
     if (verifiedBlocks.length > 0) {
-      await verifyBlockProposerSignature(this.chain.config, this.chain.index2pubkey, this.chain.bls, verifiedBlocks);
+      await verifyBlockProposerSignature(this.chain.config, this.chain.bls, verifiedBlocks);
 
       // This is bad, like super bad. Abort the backfill
       if (!nextAnchor)

--- a/packages/beacon-node/src/sync/backfill/verify.ts
+++ b/packages/beacon-node/src/sync/backfill/verify.ts
@@ -1,6 +1,6 @@
 import {BeaconConfig} from "@lodestar/config";
 import {GENESIS_SLOT} from "@lodestar/params";
-import {ISignatureSet, Index2PubkeyCache, getBlockProposerSignatureSet} from "@lodestar/state-transition";
+import {ISignatureSet, getBlockProposerSignatureSet} from "@lodestar/state-transition";
 import {Root, SignedBeaconBlock, Slot, ssz} from "@lodestar/types";
 import {IBlsVerifier} from "../../chain/bls/index.js";
 import {BackfillSyncError, BackfillSyncErrorCode} from "./errors.js";
@@ -42,14 +42,13 @@ export function verifyBlockSequence(
 
 export async function verifyBlockProposerSignature(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   bls: IBlsVerifier,
   blocks: SignedBeaconBlock[]
 ): Promise<void> {
   if (blocks.length === 1 && blocks[0].message.slot === GENESIS_SLOT) return;
   const signatures = blocks.reduce((sigs: ISignatureSet[], block) => {
     // genesis block doesn't have valid signature
-    if (block.message.slot !== GENESIS_SLOT) sigs.push(getBlockProposerSignatureSet(config, index2pubkey, block));
+    if (block.message.slot !== GENESIS_SLOT) sigs.push(getBlockProposerSignatureSet(config, block));
     return sigs;
   }, []);
 

--- a/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
@@ -13,6 +13,7 @@ describe("chain / bls / multithread queue", () => {
   const sets: ISignatureSet[] = [];
   const sameMessageSets: {publicKey: PublicKey; signature: Uint8Array}[] = [];
   const sameMessage = Buffer.alloc(32, 100);
+  const index2pubkey: PublicKey[] = [];
 
   beforeAll(() => {
     for (let i = 0; i < 3; i++) {
@@ -30,6 +31,7 @@ describe("chain / bls / multithread queue", () => {
         publicKey: pk,
         signature: sk.sign(sameMessage).toBytes(),
       });
+      index2pubkey.push(pk);
     }
   });
 
@@ -47,7 +49,7 @@ describe("chain / bls / multithread queue", () => {
   });
 
   async function initializePool(): Promise<BlsMultiThreadWorkerPool> {
-    const pool = new BlsMultiThreadWorkerPool({}, {logger, metrics: null});
+    const pool = new BlsMultiThreadWorkerPool({}, {logger, metrics: null, index2pubkey});
     // await terminating all workers
     afterEachCallbacks.push(() => pool.close());
     // Wait until initialized

--- a/packages/beacon-node/test/unit/chain/bls/bls.test.ts
+++ b/packages/beacon-node/test/unit/chain/bls/bls.test.ts
@@ -9,9 +9,11 @@ describe("BlsVerifier ", () => {
   // take time for creating thread pool
   const numKeys = 3;
   const secretKeys = Array.from({length: numKeys}, (_, i) => SecretKey.fromKeygen(Buffer.alloc(32, i)));
+  // Create a mock index2pubkey that maps indices to public keys
+  const index2pubkey = secretKeys.map((sk) => sk.toPublicKey());
   const verifiers = [
     new BlsSingleThreadVerifier({metrics: null}),
-    new BlsMultiThreadWorkerPool({}, {metrics: null, logger: testLogger()}),
+    new BlsMultiThreadWorkerPool({}, {metrics: null, logger: testLogger(), index2pubkey}),
   ];
 
   for (const verifier of verifiers) {

--- a/packages/beacon-node/test/unit/chain/bls/bls.test.ts
+++ b/packages/beacon-node/test/unit/chain/bls/bls.test.ts
@@ -12,7 +12,7 @@ describe("BlsVerifier ", () => {
   // Create a mock index2pubkey that maps indices to public keys
   const index2pubkey = secretKeys.map((sk) => sk.toPublicKey());
   const verifiers = [
-    new BlsSingleThreadVerifier({metrics: null}),
+    new BlsSingleThreadVerifier({metrics: null, index2pubkey}),
     new BlsMultiThreadWorkerPool({}, {metrics: null, logger: testLogger(), index2pubkey}),
   ];
 

--- a/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
@@ -69,7 +69,7 @@ describe("validateGossipAttestationsSameAttData", () => {
 
   beforeEach(() => {
     chain = {
-      bls: new BlsSingleThreadVerifier({metrics: null}),
+      bls: new BlsSingleThreadVerifier({metrics: null, index2pubkey}),
       seenAttesters: new SeenAttesters(),
       index2pubkey,
       opts: {

--- a/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
@@ -56,6 +56,14 @@ describe("validateGossipAttestationsSameAttData", () => {
     return keypair;
   }
 
+  // Build index2pubkey cache for test
+  const index2pubkey: PublicKey[] = [];
+  for (let i = 0; i < 10; i++) {
+    index2pubkey.push(getKeypair(i).publicKey);
+  }
+  // Add a special keypair for invalid signatures
+  index2pubkey[2023] = getKeypair(2023).publicKey;
+
   let chain: IBeaconChain;
   const signingRoot = Buffer.alloc(32, 1);
 
@@ -63,6 +71,7 @@ describe("validateGossipAttestationsSameAttData", () => {
     chain = {
       bls: new BlsSingleThreadVerifier({metrics: null}),
       seenAttesters: new SeenAttesters(),
+      index2pubkey,
       opts: {
         minSameMessageSignatureSetsToBatch: 2,
       } as IBeaconChain["opts"],
@@ -78,17 +87,19 @@ describe("validateGossipAttestationsSameAttData", () => {
     it(`test case ${testCaseIndex}`, async () => {
       const phase0Results: Promise<Step0Result>[] = [];
       for (const [i, isValid] of phase0Result.entries()) {
+        // Create an indexed signature set
+        let signature = getKeypair(i).secretKey.sign(signingRoot).toBytes();
+        if (isValid && !phase1Result[i]) {
+          // invalid signature - sign with a different key
+          signature = getKeypair(2023).secretKey.sign(signingRoot).toBytes();
+        }
         const signatureSet = {
-          type: SignatureSetType.single,
-          pubkey: getKeypair(i).publicKey,
+          type: SignatureSetType.indexed as const,
+          index: i,
           signingRoot,
-          signature: getKeypair(i).secretKey.sign(signingRoot).toBytes(),
+          signature,
         };
         if (isValid) {
-          if (!phase1Result[i]) {
-            // invalid signature
-            signatureSet.signature = getKeypair(2023).secretKey.sign(signingRoot).toBytes();
-          }
           phase0Results.push(
             Promise.resolve({
               attestation: ssz.phase0.Attestation.defaultValue(),

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -154,7 +154,7 @@ export function getAttestationValidData(opts: AttestationValidDataOpts): {
     seenAttestationDatas: new SeenAttestationDatas(null, 0, 0),
     bls: blsVerifyAllMainThread
       ? new BlsSingleThreadVerifier({metrics: null})
-      : new BlsMultiThreadWorkerPool({}, {logger: testLogger(), metrics: null}),
+      : new BlsMultiThreadWorkerPool({}, {logger: testLogger(), metrics: null, index2pubkey: state.epochCtx.index2pubkey}),
     waitForBlock: () => Promise.resolve(false),
     index2pubkey: state.epochCtx.index2pubkey,
     shufflingCache,

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -153,8 +153,11 @@ export function getAttestationValidData(opts: AttestationValidDataOpts): {
     seenAggregatedAttestations: new SeenAggregatedAttestations(null),
     seenAttestationDatas: new SeenAttestationDatas(null, 0, 0),
     bls: blsVerifyAllMainThread
-      ? new BlsSingleThreadVerifier({metrics: null})
-      : new BlsMultiThreadWorkerPool({}, {logger: testLogger(), metrics: null, index2pubkey: state.epochCtx.index2pubkey}),
+      ? new BlsSingleThreadVerifier({metrics: null, index2pubkey: state.epochCtx.index2pubkey})
+      : new BlsMultiThreadWorkerPool(
+          {},
+          {logger: testLogger(), metrics: null, index2pubkey: state.epochCtx.index2pubkey}
+        ),
     waitForBlock: () => Promise.resolve(false),
     index2pubkey: state.epochCtx.index2pubkey,
     shufflingCache,

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -21,7 +21,7 @@ export function isValidIndexedAttestation(
   }
 
   if (verifySignature) {
-    return verifySignatureSet(getIndexedAttestationSignatureSet(config, index2pubkey, stateSlot, indexedAttestation));
+    return verifySignatureSet(getIndexedAttestationSignatureSet(config, stateSlot, indexedAttestation), index2pubkey);
   }
   return true;
 }
@@ -40,7 +40,8 @@ export function isValidIndexedAttestationBigint(
 
   if (verifySignature) {
     return verifySignatureSet(
-      getIndexedAttestationBigintSignatureSet(config, index2pubkey, stateSlot, indexedAttestation)
+      getIndexedAttestationBigintSignatureSet(config, stateSlot, indexedAttestation),
+      index2pubkey
     );
   }
   return true;

--- a/packages/state-transition/src/block/isValidIndexedPayloadAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedPayloadAttestation.ts
@@ -16,7 +16,10 @@ export function isValidIndexedPayloadAttestation(
   }
 
   if (verifySignature) {
-    return verifySignatureSet(getIndexedPayloadAttestationSignatureSet(state, indexedPayloadAttestation));
+    return verifySignatureSet(
+      getIndexedPayloadAttestationSignatureSet(state, indexedPayloadAttestation),
+      state.epochCtx.index2pubkey
+    );
   }
 
   return true;

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -64,13 +64,7 @@ export function processAttestationsAltair(
     // TODO: Why should we verify an indexed attestation that we just created? If it's just for the signature
     // we can verify only that and nothing else.
     if (verifySignature) {
-      const sigSet = getAttestationWithIndicesSignatureSet(
-        state.config,
-        epochCtx.index2pubkey,
-        state.slot,
-        attestation,
-        attestingIndices
-      );
+      const sigSet = getAttestationWithIndicesSignatureSet(state.config, state.slot, attestation, attestingIndices);
       if (!verifySignatureSet(sigSet)) {
         throw new Error("Attestation signature is not valid");
       }

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -65,7 +65,7 @@ export function processAttestationsAltair(
     // we can verify only that and nothing else.
     if (verifySignature) {
       const sigSet = getAttestationWithIndicesSignatureSet(state.config, state.slot, attestation, attestingIndices);
-      if (!verifySignatureSet(sigSet)) {
+      if (!verifySignatureSet(sigSet, state.epochCtx.index2pubkey)) {
         throw new Error("Attestation signature is not valid");
       }
     }

--- a/packages/state-transition/src/block/processProposerSlashing.ts
+++ b/packages/state-transition/src/block/processProposerSlashing.ts
@@ -2,7 +2,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Slot, phase0, ssz} from "@lodestar/types";
 import {Validator} from "@lodestar/types/phase0";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.ts";
+import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {getProposerSlashingSignatureSets} from "../signatureSets/index.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateGloas} from "../types.js";
 import {computeEpochAtSlot, isSlashableValidator} from "../util/index.js";

--- a/packages/state-transition/src/block/processProposerSlashing.ts
+++ b/packages/state-transition/src/block/processProposerSlashing.ts
@@ -2,6 +2,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Slot, phase0, ssz} from "@lodestar/types";
 import {Validator} from "@lodestar/types/phase0";
+import {Index2PubkeyCache} from "../cache/pubkeyCache.ts";
 import {getProposerSlashingSignatureSets} from "../signatureSets/index.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateGloas} from "../types.js";
 import {computeEpochAtSlot, isSlashableValidator} from "../util/index.js";
@@ -21,7 +22,14 @@ export function processProposerSlashing(
   verifySignatures = true
 ): void {
   const proposer = state.validators.getReadonly(proposerSlashing.signedHeader1.message.proposerIndex);
-  assertValidProposerSlashing(state.config, state.slot, proposerSlashing, proposer, verifySignatures);
+  assertValidProposerSlashing(
+    state.config,
+    state.epochCtx.index2pubkey,
+    state.slot,
+    proposerSlashing,
+    proposer,
+    verifySignatures
+  );
 
   if (fork >= ForkSeq.gloas) {
     const slot = Number(proposerSlashing.signedHeader1.message.slot);
@@ -49,6 +57,7 @@ export function processProposerSlashing(
 
 export function assertValidProposerSlashing(
   config: BeaconConfig,
+  index2pubkey: Index2PubkeyCache,
   stateSlot: Slot,
   proposerSlashing: phase0.ProposerSlashing,
   proposer: Validator,
@@ -85,7 +94,7 @@ export function assertValidProposerSlashing(
   if (verifySignatures) {
     const signatureSets = getProposerSlashingSignatureSets(config, stateSlot, proposerSlashing);
     for (let i = 0; i < signatureSets.length; i++) {
-      if (!verifySignatureSet(signatureSets[i])) {
+      if (!verifySignatureSet(signatureSets[i], index2pubkey)) {
         throw new Error(`ProposerSlashing header${i + 1} signature invalid`);
       }
     }

--- a/packages/state-transition/src/block/processProposerSlashing.ts
+++ b/packages/state-transition/src/block/processProposerSlashing.ts
@@ -2,7 +2,6 @@ import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Slot, phase0, ssz} from "@lodestar/types";
 import {Validator} from "@lodestar/types/phase0";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {getProposerSlashingSignatureSets} from "../signatureSets/index.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateGloas} from "../types.js";
 import {computeEpochAtSlot, isSlashableValidator} from "../util/index.js";
@@ -22,14 +21,7 @@ export function processProposerSlashing(
   verifySignatures = true
 ): void {
   const proposer = state.validators.getReadonly(proposerSlashing.signedHeader1.message.proposerIndex);
-  assertValidProposerSlashing(
-    state.config,
-    state.epochCtx.index2pubkey,
-    state.slot,
-    proposerSlashing,
-    proposer,
-    verifySignatures
-  );
+  assertValidProposerSlashing(state.config, state.slot, proposerSlashing, proposer, verifySignatures);
 
   if (fork >= ForkSeq.gloas) {
     const slot = Number(proposerSlashing.signedHeader1.message.slot);
@@ -57,7 +49,6 @@ export function processProposerSlashing(
 
 export function assertValidProposerSlashing(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   stateSlot: Slot,
   proposerSlashing: phase0.ProposerSlashing,
   proposer: Validator,
@@ -92,7 +83,7 @@ export function assertValidProposerSlashing(
 
   // verify signatures
   if (verifySignatures) {
-    const signatureSets = getProposerSlashingSignatureSets(config, index2pubkey, stateSlot, proposerSlashing);
+    const signatureSets = getProposerSlashingSignatureSets(config, stateSlot, proposerSlashing);
     for (let i = 0; i < signatureSets.length; i++) {
       if (!verifySignatureSet(signatureSets[i])) {
         throw new Error(`ProposerSlashing header${i + 1} signature invalid`);

--- a/packages/state-transition/src/block/processSyncCommittee.ts
+++ b/packages/state-transition/src/block/processSyncCommittee.ts
@@ -2,7 +2,6 @@ import {byteArrayEquals} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_SYNC_COMMITTEE, SYNC_COMMITTEE_SIZE} from "@lodestar/params";
 import {altair, ssz} from "@lodestar/types";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {SyncCommitteeCache} from "../cache/syncCommitteeCache.js";
 import {G2_POINT_AT_INFINITY} from "../constants/index.js";
 import {CachedBeaconStateAllForks} from "../types.js";

--- a/packages/state-transition/src/block/processSyncCommittee.ts
+++ b/packages/state-transition/src/block/processSyncCommittee.ts
@@ -28,13 +28,12 @@ export function processSyncAggregate(
     const participantIndices = block.body.syncAggregate.syncCommitteeBits.intersectValues(committeeIndices);
     const signatureSet = getSyncCommitteeSignatureSet(
       state.config,
-      state.epochCtx.index2pubkey,
       state.epochCtx.currentSyncCommitteeIndexed,
       block,
       participantIndices
     );
-    // When there's no participation we consider the signature valid and just ignore i
-    if (signatureSet !== null && !verifySignatureSet(signatureSet)) {
+    // When there's no participation we consider the signature valid and just ignore it
+    if (signatureSet !== null && !verifySignatureSet(signatureSet, state.epochCtx.index2pubkey)) {
       throw Error("Sync committee signature invalid");
     }
   }
@@ -73,7 +72,6 @@ export function processSyncAggregate(
 
 export function getSyncCommitteeSignatureSet(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   currentSyncCommitteeIndexed: SyncCommitteeCache,
   block: altair.BeaconBlock,
   /** Optional parameter to prevent computing it twice */
@@ -122,7 +120,7 @@ export function getSyncCommitteeSignatureSet(
 
   return {
     type: SignatureSetType.aggregate,
-    pubkeys: participantIndices.map((i) => index2pubkey[i]),
+    indices: participantIndices,
     signingRoot: computeSigningRoot(ssz.Root, rootSigned, domain),
     signature,
   };

--- a/packages/state-transition/src/signatureSets/attesterSlashings.ts
+++ b/packages/state-transition/src/signatureSets/attesterSlashings.ts
@@ -1,38 +1,34 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_ATTESTER} from "@lodestar/params";
 import {AttesterSlashing, IndexedAttestationBigint, SignedBeaconBlock, Slot, ssz} from "@lodestar/types";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {ISignatureSet, SignatureSetType, computeSigningRoot, computeStartSlotAtEpoch} from "../util/index.js";
 
 /** Get signature sets from all AttesterSlashing objects in a block */
 export function getAttesterSlashingsSignatureSets(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   signedBlock: SignedBeaconBlock
 ): ISignatureSet[] {
   // the getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition
   // and the same epoch when we verify blocks in batch in beacon-node. So we can safely use block.slot here.
   const blockSlot = signedBlock.message.slot;
   return signedBlock.message.body.attesterSlashings.flatMap((attesterSlashing) =>
-    getAttesterSlashingSignatureSets(config, index2pubkey, blockSlot, attesterSlashing)
+    getAttesterSlashingSignatureSets(config, blockSlot, attesterSlashing)
   );
 }
 
 /** Get signature sets from a single AttesterSlashing object */
 export function getAttesterSlashingSignatureSets(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   stateSlot: Slot,
   attesterSlashing: AttesterSlashing
 ): ISignatureSet[] {
   return [attesterSlashing.attestation1, attesterSlashing.attestation2].map((attestation) =>
-    getIndexedAttestationBigintSignatureSet(config, index2pubkey, stateSlot, attestation)
+    getIndexedAttestationBigintSignatureSet(config, stateSlot, attestation)
   );
 }
 
 export function getIndexedAttestationBigintSignatureSet(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   stateSlot: Slot,
   indexedAttestation: IndexedAttestationBigint
 ): ISignatureSet {
@@ -41,7 +37,7 @@ export function getIndexedAttestationBigintSignatureSet(
 
   return {
     type: SignatureSetType.aggregate,
-    pubkeys: indexedAttestation.attestingIndices.map((i) => index2pubkey[i]),
+    indices: indexedAttestation.attestingIndices.map((i) => Number(i)),
     signingRoot: computeSigningRoot(ssz.phase0.AttestationDataBigint, indexedAttestation.data, domain),
     signature: indexedAttestation.signature,
   };

--- a/packages/state-transition/src/signatureSets/blsToExecutionChange.ts
+++ b/packages/state-transition/src/signatureSets/blsToExecutionChange.ts
@@ -2,7 +2,7 @@ import {PublicKey} from "@chainsafe/blst";
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BLS_TO_EXECUTION_CHANGE, ForkName} from "@lodestar/params";
 import {capella, ssz} from "@lodestar/types";
-import {ISignatureSet, SignatureSetType, computeSigningRoot, verifySignatureSet} from "../util/index.js";
+import {SignatureSetType, SingleSignatureSet, computeSigningRoot, verifySignatureSet} from "../util/index.js";
 
 export function verifyBlsToExecutionChangeSignature(
   config: BeaconConfig,
@@ -17,7 +17,7 @@ export function verifyBlsToExecutionChangeSignature(
 export function getBlsToExecutionChangeSignatureSet(
   config: BeaconConfig,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
-): ISignatureSet {
+): SingleSignatureSet {
   // signatureFork for signing domain is fixed
   const signatureFork = ForkName.phase0;
   const domain = config.getDomainAtFork(signatureFork, DOMAIN_BLS_TO_EXECUTION_CHANGE);
@@ -35,7 +35,7 @@ export function getBlsToExecutionChangeSignatureSet(
 export function getBlsToExecutionChangeSignatureSets(
   config: BeaconConfig,
   signedBlock: capella.SignedBeaconBlock
-): ISignatureSet[] {
+): SingleSignatureSet[] {
   return signedBlock.message.body.blsToExecutionChanges.map((blsToExecutionChange) =>
     getBlsToExecutionChangeSignatureSet(config, blsToExecutionChange)
   );

--- a/packages/state-transition/src/signatureSets/index.ts
+++ b/packages/state-transition/src/signatureSets/index.ts
@@ -2,7 +2,6 @@ import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq} from "@lodestar/params";
 import {IndexedAttestation, SignedBeaconBlock, altair, capella} from "@lodestar/types";
 import {getSyncCommitteeSignatureSet} from "../block/processSyncCommittee.js";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {SyncCommitteeCache} from "../cache/syncCommitteeCache.js";
 import {ISignatureSet} from "../util/index.js";
 import {getAttesterSlashingsSignatureSets} from "./attesterSlashings.js";
@@ -28,7 +27,6 @@ export * from "./voluntaryExits.js";
  */
 export function getBlockSignatureSets(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   currentSyncCommitteeIndexed: SyncCommitteeCache,
   signedBlock: SignedBeaconBlock,
   indexedAttestations: IndexedAttestation[],
@@ -41,22 +39,21 @@ export function getBlockSignatureSets(
   const fork = config.getForkSeq(signedBlock.message.slot);
 
   const signatureSets = [
-    getRandaoRevealSignatureSet(config, index2pubkey, signedBlock.message),
-    ...getProposerSlashingsSignatureSets(config, index2pubkey, signedBlock),
-    ...getAttesterSlashingsSignatureSets(config, index2pubkey, signedBlock),
-    ...getAttestationsSignatureSets(config, index2pubkey, signedBlock, indexedAttestations),
-    ...getVoluntaryExitsSignatureSets(config, index2pubkey, signedBlock),
+    getRandaoRevealSignatureSet(config, signedBlock.message),
+    ...getProposerSlashingsSignatureSets(config, signedBlock),
+    ...getAttesterSlashingsSignatureSets(config, signedBlock),
+    ...getAttestationsSignatureSets(config, signedBlock, indexedAttestations),
+    ...getVoluntaryExitsSignatureSets(config, signedBlock),
   ];
 
   if (!opts?.skipProposerSignature) {
-    signatureSets.push(getBlockProposerSignatureSet(config, index2pubkey, signedBlock));
+    signatureSets.push(getBlockProposerSignatureSet(config, signedBlock));
   }
 
   // Only after altair fork, validate tSyncCommitteeSignature
   if (fork >= ForkSeq.altair) {
     const syncCommitteeSignatureSet = getSyncCommitteeSignatureSet(
       config,
-      index2pubkey,
       currentSyncCommitteeIndexed,
       (signedBlock as altair.SignedBeaconBlock).message
     );

--- a/packages/state-transition/src/signatureSets/indexedAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedAttestation.ts
@@ -1,7 +1,6 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_ATTESTER} from "@lodestar/params";
 import {IndexedAttestation, SignedBeaconBlock, Slot, phase0, ssz} from "@lodestar/types";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 import {
   ISignatureSet,
   computeSigningRoot,
@@ -22,13 +21,12 @@ export function getAttestationDataSigningRoot(
 
 export function getAttestationWithIndicesSignatureSet(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   stateSlot: Slot,
   attestation: Pick<phase0.Attestation, "data" | "signature">,
   attestingIndices: number[]
 ): ISignatureSet {
   return createAggregateSignatureSetFromComponents(
-    attestingIndices.map((i) => index2pubkey[i]),
+    attestingIndices,
     getAttestationDataSigningRoot(config, stateSlot, attestation.data),
     attestation.signature
   );
@@ -36,13 +34,11 @@ export function getAttestationWithIndicesSignatureSet(
 
 export function getIndexedAttestationSignatureSet(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   stateSlot: Slot,
   indexedAttestation: IndexedAttestation
 ): ISignatureSet {
   return getAttestationWithIndicesSignatureSet(
     config,
-    index2pubkey,
     stateSlot,
     indexedAttestation,
     indexedAttestation.attestingIndices
@@ -51,7 +47,6 @@ export function getIndexedAttestationSignatureSet(
 
 export function getAttestationsSignatureSets(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   signedBlock: SignedBeaconBlock,
   indexedAttestations: IndexedAttestation[]
 ): ISignatureSet[] {
@@ -64,6 +59,6 @@ export function getAttestationsSignatureSets(
   // and the same epoch when we verify blocks in batch in beacon-node. So we can safely use block.slot here.
   const blockSlot = signedBlock.message.slot;
   return indexedAttestations.map((indexedAttestation) =>
-    getIndexedAttestationSignatureSet(config, index2pubkey, blockSlot, indexedAttestation)
+    getIndexedAttestationSignatureSet(config, blockSlot, indexedAttestation)
   );
 }

--- a/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
@@ -8,7 +8,7 @@ export function getIndexedPayloadAttestationSignatureSet(
   indexedPayloadAttestation: gloas.IndexedPayloadAttestation
 ): ISignatureSet {
   return createAggregateSignatureSetFromComponents(
-    indexedPayloadAttestation.attestingIndices.map((i) => state.epochCtx.index2pubkey[i]),
+    indexedPayloadAttestation.attestingIndices,
     getPayloadAttestationDataSigningRoot(state, indexedPayloadAttestation.data),
     indexedPayloadAttestation.signature
   );

--- a/packages/state-transition/src/signatureSets/randao.ts
+++ b/packages/state-transition/src/signatureSets/randao.ts
@@ -21,10 +21,7 @@ export function verifyRandaoSignature(
 /**
  * Extract signatures to allow validating all block signatures at once
  */
-export function getRandaoRevealSignatureSet(
-  config: BeaconConfig,
-  block: BeaconBlock
-): ISignatureSet {
+export function getRandaoRevealSignatureSet(config: BeaconConfig, block: BeaconBlock): ISignatureSet {
   // should not get epoch from epochCtx
   const epoch = computeEpochAtSlot(block.slot);
   // the getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition

--- a/packages/state-transition/src/signatureSets/randao.ts
+++ b/packages/state-transition/src/signatureSets/randao.ts
@@ -15,7 +15,7 @@ export function verifyRandaoSignature(
   index2pubkey: Index2PubkeyCache,
   block: BeaconBlock
 ): boolean {
-  return verifySignatureSet(getRandaoRevealSignatureSet(config, index2pubkey, block));
+  return verifySignatureSet(getRandaoRevealSignatureSet(config, block), index2pubkey);
 }
 
 /**
@@ -23,7 +23,6 @@ export function verifyRandaoSignature(
  */
 export function getRandaoRevealSignatureSet(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   block: BeaconBlock
 ): ISignatureSet {
   // should not get epoch from epochCtx
@@ -33,8 +32,8 @@ export function getRandaoRevealSignatureSet(
   const domain = config.getDomain(block.slot, DOMAIN_RANDAO, block.slot);
 
   return {
-    type: SignatureSetType.single,
-    pubkey: index2pubkey[block.proposerIndex],
+    type: SignatureSetType.indexed,
+    index: block.proposerIndex,
     signingRoot: computeSigningRoot(ssz.Epoch, epoch, domain),
     signature: block.body.randaoReveal,
   };

--- a/packages/state-transition/src/signatureSets/voluntaryExits.ts
+++ b/packages/state-transition/src/signatureSets/voluntaryExits.ts
@@ -37,10 +37,7 @@ export function getVoluntaryExitSignatureSet(
   };
 }
 
-export function getVoluntaryExitsSignatureSets(
-  config: BeaconConfig,
-  signedBlock: SignedBeaconBlock
-): ISignatureSet[] {
+export function getVoluntaryExitsSignatureSets(config: BeaconConfig, signedBlock: SignedBeaconBlock): ISignatureSet[] {
   // the getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition
   // and the same epoch when we verify blocks in batch in beacon-node. So we can safely use block.slot here.
   const blockSlot = signedBlock.message.slot;

--- a/packages/state-transition/src/signatureSets/voluntaryExits.ts
+++ b/packages/state-transition/src/signatureSets/voluntaryExits.ts
@@ -15,7 +15,7 @@ export function verifyVoluntaryExitSignature(
   stateSlot: Slot,
   signedVoluntaryExit: phase0.SignedVoluntaryExit
 ): boolean {
-  return verifySignatureSet(getVoluntaryExitSignatureSet(config, index2pubkey, stateSlot, signedVoluntaryExit));
+  return verifySignatureSet(getVoluntaryExitSignatureSet(config, stateSlot, signedVoluntaryExit), index2pubkey);
 }
 
 /**
@@ -23,7 +23,6 @@ export function verifyVoluntaryExitSignature(
  */
 export function getVoluntaryExitSignatureSet(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   stateSlot: Slot,
   signedVoluntaryExit: phase0.SignedVoluntaryExit
 ): ISignatureSet {
@@ -31,8 +30,8 @@ export function getVoluntaryExitSignatureSet(
   const domain = config.getDomainForVoluntaryExit(stateSlot, messageSlot);
 
   return {
-    type: SignatureSetType.single,
-    pubkey: index2pubkey[signedVoluntaryExit.message.validatorIndex],
+    type: SignatureSetType.indexed,
+    index: signedVoluntaryExit.message.validatorIndex,
     signingRoot: computeSigningRoot(ssz.phase0.VoluntaryExit, signedVoluntaryExit.message, domain),
     signature: signedVoluntaryExit.signature,
   };
@@ -40,13 +39,12 @@ export function getVoluntaryExitSignatureSet(
 
 export function getVoluntaryExitsSignatureSets(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
   signedBlock: SignedBeaconBlock
 ): ISignatureSet[] {
   // the getDomain() api requires the state slot as 1st param, however it's the same to block.slot in state-transition
   // and the same epoch when we verify blocks in batch in beacon-node. So we can safely use block.slot here.
   const blockSlot = signedBlock.message.slot;
   return signedBlock.message.body.voluntaryExits.map((voluntaryExit) =>
-    getVoluntaryExitSignatureSet(config, index2pubkey, blockSlot, voluntaryExit)
+    getVoluntaryExitSignatureSet(config, blockSlot, voluntaryExit)
   );
 }

--- a/packages/state-transition/src/util/signatureSets.ts
+++ b/packages/state-transition/src/util/signatureSets.ts
@@ -1,11 +1,21 @@
-import {PublicKey, Signature, fastAggregateVerify, verify} from "@chainsafe/blst";
+import {PublicKey, Signature, aggregatePublicKeys, fastAggregateVerify, verify} from "@chainsafe/blst";
 import {Root} from "@lodestar/types";
+import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
 
 export enum SignatureSetType {
   single = "single",
   aggregate = "aggregate",
+  /**
+   * Single signature with validator index instead of pubkey.
+   * Pubkey lookup is deferred to verification time.
+   */
+  indexed = "indexed",
 }
 
+/**
+ * Single signature with pubkey directly.
+ * Used when pubkey comes from the message itself (e.g. BLS to execution change).
+ */
 export type SingleSignatureSet = {
   type: SignatureSetType.single;
   pubkey: PublicKey;
@@ -13,16 +23,56 @@ export type SingleSignatureSet = {
   signature: Uint8Array;
 };
 
-export type AggregatedSignatureSet = {
-  type: SignatureSetType.aggregate;
-  pubkeys: PublicKey[];
+/**
+ * Single signature with validator index.
+ * Pubkey is looked up at verification time.
+ */
+export type IndexedSignatureSet = {
+  type: SignatureSetType.indexed;
+  index: number;
   signingRoot: Root;
   signature: Uint8Array;
 };
 
-export type ISignatureSet = SingleSignatureSet | AggregatedSignatureSet;
+/**
+ * Aggregate signature with validator indices.
+ * Pubkeys are looked up and aggregated at verification time.
+ */
+export type AggregatedSignatureSet = {
+  type: SignatureSetType.aggregate;
+  indices: number[];
+  signingRoot: Root;
+  signature: Uint8Array;
+};
 
-export function verifySignatureSet(signatureSet: ISignatureSet): boolean {
+export type ISignatureSet = SingleSignatureSet | IndexedSignatureSet | AggregatedSignatureSet;
+
+/**
+ * Get the pubkey for a signature set, performing aggregation if necessary.
+ * Requires index2pubkey cache for indexed and aggregate sets.
+ */
+export function getSignatureSetPubkey(
+  signatureSet: ISignatureSet,
+  index2pubkey: Index2PubkeyCache
+): PublicKey {
+  switch (signatureSet.type) {
+    case SignatureSetType.single:
+      return signatureSet.pubkey;
+
+    case SignatureSetType.indexed:
+      return index2pubkey[signatureSet.index];
+
+    case SignatureSetType.aggregate: {
+      const pubkeys = signatureSet.indices.map((i) => index2pubkey[i]);
+      return aggregatePublicKeys(pubkeys);
+    }
+
+    default:
+      throw Error("Unknown signature set type");
+  }
+}
+
+export function verifySignatureSet(signatureSet: ISignatureSet, index2pubkey?: Index2PubkeyCache): boolean {
   // All signatures are not trusted and must be group checked (p2.subgroup_check)
   const signature = Signature.fromBytes(signatureSet.signature, true);
 
@@ -30,8 +80,20 @@ export function verifySignatureSet(signatureSet: ISignatureSet): boolean {
     case SignatureSetType.single:
       return verify(signatureSet.signingRoot, signatureSet.pubkey, signature);
 
-    case SignatureSetType.aggregate:
-      return fastAggregateVerify(signatureSet.signingRoot, signatureSet.pubkeys, signature);
+    case SignatureSetType.indexed: {
+      if (!index2pubkey) {
+        throw Error("index2pubkey required for indexed signature set");
+      }
+      return verify(signatureSet.signingRoot, index2pubkey[signatureSet.index], signature);
+    }
+
+    case SignatureSetType.aggregate: {
+      if (!index2pubkey) {
+        throw Error("index2pubkey required for aggregate signature set");
+      }
+      const pubkeys = signatureSet.indices.map((i) => index2pubkey[i]);
+      return fastAggregateVerify(signatureSet.signingRoot, pubkeys, signature);
+    }
 
     default:
       throw Error("Unknown signature set type");
@@ -51,14 +113,27 @@ export function createSingleSignatureSetFromComponents(
   };
 }
 
+export function createIndexedSignatureSetFromComponents(
+  index: number,
+  signingRoot: Root,
+  signature: Uint8Array
+): IndexedSignatureSet {
+  return {
+    type: SignatureSetType.indexed,
+    index,
+    signingRoot,
+    signature,
+  };
+}
+
 export function createAggregateSignatureSetFromComponents(
-  pubkeys: PublicKey[],
+  indices: number[],
   signingRoot: Root,
   signature: Uint8Array
 ): AggregatedSignatureSet {
   return {
     type: SignatureSetType.aggregate,
-    pubkeys,
+    indices,
     signingRoot,
     signature,
   };

--- a/packages/state-transition/src/util/signatureSets.ts
+++ b/packages/state-transition/src/util/signatureSets.ts
@@ -51,10 +51,7 @@ export type ISignatureSet = SingleSignatureSet | IndexedSignatureSet | Aggregate
  * Get the pubkey for a signature set, performing aggregation if necessary.
  * Requires index2pubkey cache for indexed and aggregate sets.
  */
-export function getSignatureSetPubkey(
-  signatureSet: ISignatureSet,
-  index2pubkey: Index2PubkeyCache
-): PublicKey {
+export function getSignatureSetPubkey(signatureSet: ISignatureSet, index2pubkey: Index2PubkeyCache): PublicKey {
   switch (signatureSet.type) {
     case SignatureSetType.single:
       return signatureSet.pubkey;
@@ -72,6 +69,10 @@ export function getSignatureSetPubkey(
   }
 }
 
+export function verifySignatureSet(signatureSet: SingleSignatureSet, index2pubkey?: Index2PubkeyCache): boolean;
+export function verifySignatureSet(signatureSet: IndexedSignatureSet, index2pubkey: Index2PubkeyCache): boolean;
+export function verifySignatureSet(signatureSet: AggregatedSignatureSet, index2pubkey: Index2PubkeyCache): boolean;
+export function verifySignatureSet(signatureSet: ISignatureSet, index2pubkey: Index2PubkeyCache): boolean;
 export function verifySignatureSet(signatureSet: ISignatureSet, index2pubkey?: Index2PubkeyCache): boolean {
   // All signatures are not trusted and must be group checked (p2.subgroup_check)
   const signature = Signature.fromBytes(signatureSet.signature, true);

--- a/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -72,7 +72,6 @@ describe("signatureSets", () => {
 
     const signatureSets = getBlockSignatureSets(
       state.config,
-      state.epochCtx.index2pubkey,
       state.epochCtx.currentSyncCommitteeIndexed,
       signedBlock,
       indexedAttestations


### PR DESCRIPTION
This refactoring prepares for future optimization where BLS workers will have access to the index→pubkey map and perform aggregation themselves.

Changes:
- Add new SignatureSetType.indexed for single signatures with validator index
- Modify AggregatedSignatureSet to use indices[] instead of pubkeys[]
- Keep SingleSignatureSet with pubkey for cases where pubkey comes from message itself (e.g., BLS to execution change)
- Update BLS worker pool to receive index2pubkey cache and perform pubkey lookup when preparing work requests
- Update all signature set construction sites to pass indices instead of pubkeys
- Update getBlockSignatureSets and related functions to use new signature

Closes: https://github.com/ChainSafe/lodestar/issues/8801
