### PR TITLE
refactor: getBlockSlotState()

### DIFF
--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -249,9 +249,6 @@ function regenRequestToJson(config: ChainForkConfig, regenRequest: RegenRequest)
         slot: regenRequest.args[1],
       };
 
-    case "getCheckpointState":
-      return ssz.phase0.Checkpoint.toJson(regenRequest.args[0]);
-
     case "getPreState": {
       const slot = regenRequest.args[0].slot;
       return {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -501,7 +501,7 @@ export class BeaconChain implements IBeaconChain {
     // only use regen queue if necessary, it'll cache in checkpointStateCache if regen gets through epoch transition
     const head = this.forkChoice.getHead();
     const startSlot = computeStartSlotAtEpoch(epoch);
-    return this.regen.getBlockSlotState(head.blockRoot, startSlot, {dontTransferCache: true}, regenCaller);
+    return this.regen.getBlockSlotState(head, startSlot, {dontTransferCache: true}, regenCaller);
   }
 
   async getStateBySlot(
@@ -519,12 +519,7 @@ export class BeaconChain implements IBeaconChain {
     if (opts?.allowRegen) {
       // Find closest canonical block to slot, then trigger regen
       const block = this.forkChoice.getCanonicalBlockClosestLteSlot(slot) ?? finalizedBlock;
-      const state = await this.regen.getBlockSlotState(
-        block.blockRoot,
-        slot,
-        {dontTransferCache: true},
-        RegenCaller.restApi
-      );
+      const state = await this.regen.getBlockSlotState(block, slot, {dontTransferCache: true}, RegenCaller.restApi);
       return {
         state,
         executionOptimistic: isOptimisticBlock(block),
@@ -684,9 +679,9 @@ export class BeaconChain implements IBeaconChain {
   }
 
   async produceCommonBlockBody(blockAttributes: BlockAttributes): Promise<CommonBlockBody> {
-    const {slot, parentBlockRoot} = blockAttributes;
+    const {slot, parentBlock} = blockAttributes;
     const state = await this.regen.getBlockSlotState(
-      toRootHex(parentBlockRoot),
+      parentBlock,
       slot,
       {dontTransferCache: true},
       RegenCaller.produceBlock
@@ -723,7 +718,7 @@ export class BeaconChain implements IBeaconChain {
       slot,
       feeRecipient,
       commonBlockBodyPromise,
-      parentBlockRoot,
+      parentBlock,
     }: BlockAttributes & {commonBlockBodyPromise: Promise<CommonBlockBody>}
   ): Promise<{
     block: AssembledBlockType<T>;
@@ -732,7 +727,7 @@ export class BeaconChain implements IBeaconChain {
     shouldOverrideBuilder?: boolean;
   }> {
     const state = await this.regen.getBlockSlotState(
-      toRootHex(parentBlockRoot),
+      parentBlock,
       slot,
       {dontTransferCache: true},
       RegenCaller.produceBlock
@@ -749,7 +744,7 @@ export class BeaconChain implements IBeaconChain {
         graffiti,
         slot,
         feeRecipient,
-        parentBlockRoot,
+        parentBlock,
         proposerIndex,
         proposerPubKey,
         commonBlockBodyPromise,
@@ -772,7 +767,7 @@ export class BeaconChain implements IBeaconChain {
     const block = {
       slot,
       proposerIndex,
-      parentRoot: parentBlockRoot,
+      parentRoot: fromHex(parentBlock.blockRoot),
       stateRoot: ZERO_HASH,
       body,
     } as AssembledBlockType<T>;
@@ -968,12 +963,7 @@ export class BeaconChain implements IBeaconChain {
       // thanks to one epoch look ahead, we don't need to dial up to attEpoch
       const targetSlot = computeStartSlotAtEpoch(attEpoch - 1);
       this.metrics?.gossipAttestation.useHeadBlockStateDialedToTargetEpoch.inc({caller: regenCaller});
-      state = await this.regen.getBlockSlotState(
-        attHeadBlock.blockRoot,
-        targetSlot,
-        {dontTransferCache: true},
-        regenCaller
-      );
+      state = await this.regen.getBlockSlotState(attHeadBlock, targetSlot, {dontTransferCache: true}, regenCaller);
     } else if (blockEpoch > attEpoch) {
       // should not happen, handled inside attestation verification code
       throw Error(`Block epoch ${blockEpoch} is after attestation epoch ${attEpoch}`);

--- a/packages/beacon-node/src/chain/regen/interface.ts
+++ b/packages/beacon-node/src/chain/regen/interface.ts
@@ -26,7 +26,6 @@ export enum RegenFnName {
   getBlockSlotState = "getBlockSlotState",
   getState = "getState",
   getPreState = "getPreState",
-  getCheckpointState = "getCheckpointState",
 }
 
 export type StateRegenerationOpts = {
@@ -64,20 +63,10 @@ export interface IStateRegeneratorInternal {
   ): Promise<CachedBeaconStateAllForks>;
 
   /**
-   * Return a valid checkpoint state
-   * This will always return a state with `state.slot % SLOTS_PER_EPOCH === 0`
-   */
-  getCheckpointState(
-    cp: phase0.Checkpoint,
-    opts: StateRegenerationOpts,
-    rCaller: RegenCaller
-  ): Promise<CachedBeaconStateAllForks>;
-
-  /**
    * Return the state of `blockRoot` processed to slot `slot`
    */
   getBlockSlotState(
-    blockRoot: RootHex,
+    block: ProtoBlock,
     slot: Slot,
     opts: StateRegenerationOpts,
     rCaller: RegenCaller

--- a/packages/beacon-node/src/chain/validation/blobSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -124,7 +124,7 @@ export async function validateGossipBlobSidecar(
   // [IGNORE] The block's parent (defined by block.parent_root) has been seen (via both gossip and non-gossip sources) (a client MAY queue blocks for processing once the parent block is retrieved).
   // [REJECT] The block's parent (defined by block.parent_root) passes validation.
   const blockState = await chain.regen
-    .getBlockSlotState(parentRoot, blobSlot, {dontTransferCache: true}, RegenCaller.validateGossipBlock)
+    .getBlockSlotState(parentBlock, blobSlot, {dontTransferCache: true}, RegenCaller.validateGossipBlock)
     .catch(() => {
       throw new BlobSidecarGossipError(GossipAction.IGNORE, {
         code: BlobSidecarErrorCode.PARENT_UNKNOWN,

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -106,7 +106,7 @@ export async function validateGossipDataColumnSidecar(
   // this is something we should change this in the future to make the code airtight to the spec.
   // 7) [REJECT] The sidecar's block's parent passes validation.
   const blockState = await chain.regen
-    .getBlockSlotState(parentRoot, blockHeader.slot, {dontTransferCache: true}, RegenCaller.validateGossipDataColumn)
+    .getBlockSlotState(parentBlock, blockHeader.slot, {dontTransferCache: true}, RegenCaller.validateGossipDataColumn)
     .catch(() => {
       throw new DataColumnSidecarGossipError(GossipAction.IGNORE, {
         code: DataColumnSidecarErrorCode.PARENT_UNKNOWN,

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -1,6 +1,5 @@
 import {generateKeyPair} from "@libp2p/crypto/keys";
 import {afterAll, beforeAll, bench, describe} from "@chainsafe/benchmark";
-import {fromHexString} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {CachedBeaconStateAltair} from "@lodestar/state-transition";
@@ -80,14 +79,14 @@ describe("produceBlockBody", () => {
         slot: slot + 1,
         graffiti: Buffer.alloc(32),
         randaoReveal: Buffer.alloc(96),
-        parentBlockRoot: fromHexString(head.blockRoot),
+        parentBlock: head,
       });
 
       await produceBlockBody.call(chain, BlockType.Full, state, {
         slot: slot + 1,
         graffiti: Buffer.alloc(32),
         randaoReveal: Buffer.alloc(96),
-        parentBlockRoot: fromHexString(head.blockRoot),
+        parentBlock: head,
         proposerIndex,
         proposerPubKey,
         commonBlockBodyPromise,

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -1,5 +1,5 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
-import {fromHexString, toHexString} from "@chainsafe/ssz";
+import {toHexString} from "@chainsafe/ssz";
 import {routes} from "@lodestar/api";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {ProtoBlock} from "@lodestar/fork-choice";
@@ -179,16 +179,13 @@ describe("api/validator - produceBlockV3", () => {
     const slot = 100000;
     const randaoReveal = fullBlock.body.randaoReveal;
     const parentBlockRoot = fullBlock.parentRoot;
+    const parentBlock = generateProtoBlock({blockRoot: toHexString(parentBlockRoot), slot: currentSlot - 1});
     const graffiti = "a".repeat(32);
     const feeRecipient = "0xcccccccccccccccccccccccccccccccccccccccc";
 
-    modules.chain.getProposerHead.mockReturnValue(
-      generateProtoBlock({blockRoot: toHexString(parentBlockRoot), slot: currentSlot - 1})
-    );
-    modules.chain.recomputeForkChoiceHead.mockReturnValue(
-      generateProtoBlock({blockRoot: toHexString(parentBlockRoot)})
-    );
-    modules.chain.forkChoice.getBlock.mockReturnValue(generateProtoBlock({blockRoot: toHexString(parentBlockRoot)}));
+    modules.chain.getProposerHead.mockReturnValue(parentBlock);
+    modules.chain.recomputeForkChoiceHead.mockReturnValue(parentBlock);
+    modules.chain.forkChoice.getBlock.mockReturnValue(parentBlock);
     modules.chain.produceBlock.mockResolvedValue({
       block: fullBlock,
       executionPayloadValue,
@@ -213,7 +210,7 @@ describe("api/validator - produceBlockV3", () => {
       randaoReveal,
       graffiti: toGraffitiBytes(graffiti),
       slot,
-      parentBlockRoot,
+      parentBlock,
       feeRecipient,
       commonBlockBodyPromise: expect.any(Promise),
     });
@@ -225,7 +222,7 @@ describe("api/validator - produceBlockV3", () => {
       randaoReveal,
       graffiti: toGraffitiBytes(graffiti),
       slot,
-      parentBlockRoot,
+      parentBlock,
       feeRecipient: undefined,
       commonBlockBodyPromise: expect.any(Promise),
     });
@@ -279,7 +276,7 @@ describe("api/validator - produceBlockV3", () => {
       graffiti: toGraffitiBytes(graffiti),
       slot,
       feeRecipient,
-      parentBlockRoot: fromHexString(ZERO_HASH_HEX),
+      parentBlock: generateProtoBlock({blockRoot: ZERO_HASH_HEX}),
       proposerIndex: 0,
       proposerPubKey: new Uint8Array(32).fill(1),
       commonBlockBodyPromise: createCommonBlockBodyPromise(),
@@ -304,7 +301,7 @@ describe("api/validator - produceBlockV3", () => {
       randaoReveal,
       graffiti: toGraffitiBytes(graffiti),
       slot,
-      parentBlockRoot: fromHexString(ZERO_HASH_HEX),
+      parentBlock: generateProtoBlock({blockRoot: ZERO_HASH_HEX}),
       proposerIndex: 0,
       proposerPubKey: new Uint8Array(32).fill(1),
       commonBlockBodyPromise: createCommonBlockBodyPromise(),

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -1,11 +1,11 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
-import {toHexString} from "@chainsafe/ssz";
 import {routes} from "@lodestar/api";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName, SLOTS_PER_EPOCH, ZERO_HASH_HEX} from "@lodestar/params";
 import {CachedBeaconStateBellatrix, G2_POINT_AT_INFINITY, computeTimeAtSlot} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
 import {getValidatorApi} from "../../../../../src/api/impl/validator/index.js";
 import {defaultApiOptions} from "../../../../../src/api/options.js";
 import {BeaconChain} from "../../../../../src/chain/chain.js";
@@ -93,9 +93,9 @@ describe("api/validator - produceBlockV3", () => {
       vi.spyOn(modules.chain.clock, "currentSlot", "get").mockReturnValue(currentSlot);
       vi.spyOn(modules.sync, "state", "get").mockReturnValue(SyncState.Synced);
       modules.chain.recomputeForkChoiceHead.mockReturnValue({
-        blockRoot: toHexString(fullBlock.parentRoot),
+        blockRoot: toRootHex(fullBlock.parentRoot),
       } as ProtoBlock);
-      modules.chain.getProposerHead.mockReturnValue({blockRoot: toHexString(fullBlock.parentRoot)} as ProtoBlock);
+      modules.chain.getProposerHead.mockReturnValue({blockRoot: toRootHex(fullBlock.parentRoot)} as ProtoBlock);
       modules.chain.forkChoice.getBlock.mockReturnValue(zeroProtoBlock);
       modules.chain.produceCommonBlockBody.mockResolvedValue({
         attestations: fullBlock.body.attestations,
@@ -179,7 +179,7 @@ describe("api/validator - produceBlockV3", () => {
     const slot = 100000;
     const randaoReveal = fullBlock.body.randaoReveal;
     const parentBlockRoot = fullBlock.parentRoot;
-    const parentBlock = generateProtoBlock({blockRoot: toHexString(parentBlockRoot), slot: currentSlot - 1});
+    const parentBlock = generateProtoBlock({blockRoot: toRootHex(parentBlockRoot), slot: currentSlot - 1});
     const graffiti = "a".repeat(32);
     const feeRecipient = "0xcccccccccccccccccccccccccccccccccccccccc";
 

--- a/packages/beacon-node/test/utils/node/simTest.ts
+++ b/packages/beacon-node/test/utils/node/simTest.ts
@@ -1,4 +1,3 @@
-import {toHexString} from "@chainsafe/ssz";
 import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
@@ -10,7 +9,7 @@ import {
 } from "@lodestar/state-transition";
 import {BeaconBlock, Epoch, Slot} from "@lodestar/types";
 import {Checkpoint} from "@lodestar/types/phase0";
-import {Logger, mapValues} from "@lodestar/utils";
+import {Logger, mapValues, toRootHex} from "@lodestar/utils";
 import {ChainEvent, HeadEventData} from "../../../src/chain/index.js";
 import {RegenCaller} from "../../../src/chain/regen/index.js";
 import {BeaconNode} from "../../../src/index.js";
@@ -66,14 +65,14 @@ export function simTestInfoTracker(bn: BeaconNode, logger: Logger): () => void {
 
     const checkpointState = bn.chain.regen.getCheckpointStateSync({
       ...checkpoint,
-      rootHex: toHexString(checkpoint.root),
+      rootHex: toRootHex(checkpoint.root),
     });
     if (checkpointState == null) {
-      throw Error(`Checkpoint state not found for epoch ${checkpoint.epoch} root ${toHexString(checkpoint.root)}`);
+      throw Error(`Checkpoint state not found for epoch ${checkpoint.epoch} root ${toRootHex(checkpoint.root)}`);
     }
     const lastSlot = computeStartSlotAtEpoch(checkpoint.epoch) - 1;
     const lastStateRoot = checkpointState.stateRoots.get(lastSlot % SLOTS_PER_HISTORICAL_ROOT);
-    const lastState = await bn.chain.regen.getState(toHexString(lastStateRoot), RegenCaller.onForkChoiceFinalized);
+    const lastState = await bn.chain.regen.getState(toRootHex(lastStateRoot), RegenCaller.onForkChoiceFinalized);
     logParticipation(lastState);
   }
 

--- a/packages/beacon-node/test/utils/node/simTest.ts
+++ b/packages/beacon-node/test/utils/node/simTest.ts
@@ -64,12 +64,13 @@ export function simTestInfoTracker(bn: BeaconNode, logger: Logger): () => void {
     if (checkpoint.epoch <= lastSeenEpoch) return;
     lastSeenEpoch = checkpoint.epoch;
 
-    // Recover the pre-epoch transition state, use any random caller for regen
-    const checkpointState = await bn.chain.regen.getCheckpointState(
-      checkpoint,
-      {dontTransferCache: true},
-      RegenCaller.onForkChoiceFinalized
-    );
+    const checkpointState = bn.chain.regen.getCheckpointStateSync({
+      ...checkpoint,
+      rootHex: toHexString(checkpoint.root),
+    });
+    if (checkpointState == null) {
+      throw Error(`Checkpoint state not found for epoch ${checkpoint.epoch} root ${toHexString(checkpoint.root)}`);
+    }
     const lastSlot = computeStartSlotAtEpoch(checkpoint.epoch) - 1;
     const lastStateRoot = checkpointState.stateRoots.get(lastSlot % SLOTS_PER_HISTORICAL_ROOT);
     const lastState = await bn.chain.regen.getState(toHexString(lastStateRoot), RegenCaller.onForkChoiceFinalized);


### PR DESCRIPTION
**Motivation**

- `getBlockSlotState()` with only block root is ambiguous in the context of ePBS because for each block there are 2 variants: EMPTY vs FULL

**Description**

- refactor it to accept a ProtoBlock as 1st param. When we implement ePBS forkchoice in #8739 we have the context of variant there
- change all consumers to provide ProtoBlock
- later on we should enhance our state caches to get the correct BeaconState based on that `ProtoBlock`
 
part of #8439

cc @ensi321 @nflaig 