### PR TITLE
fix: revert changes to `getPendingBalanceToWithdraw`

### DIFF
--- a/packages/beacon-node/test/spec/presets/operations.test.ts
+++ b/packages/beacon-node/test/spec/presets/operations.test.ts
@@ -108,8 +108,7 @@ const operationFns: Record<string, BlockProcessFn<CachedBeaconStateAllForks>> = 
   },
 
   consolidation_request: (state, testCase: {consolidation_request: electra.ConsolidationRequest}) => {
-    const fork = state.config.getForkSeq(state.slot);
-    blockFns.processConsolidationRequest(fork, state as CachedBeaconStateElectra, testCase.consolidation_request);
+    blockFns.processConsolidationRequest(state as CachedBeaconStateElectra, testCase.consolidation_request);
   },
 
   execution_payload_bid: (state, testCase: {block: gloas.BeaconBlock}) => {

--- a/packages/state-transition/src/block/processConsolidationRequest.ts
+++ b/packages/state-transition/src/block/processConsolidationRequest.ts
@@ -1,4 +1,4 @@
-import {FAR_FUTURE_EPOCH, ForkSeq, MIN_ACTIVATION_BALANCE, PENDING_CONSOLIDATIONS_LIMIT} from "@lodestar/params";
+import {FAR_FUTURE_EPOCH, MIN_ACTIVATION_BALANCE, PENDING_CONSOLIDATIONS_LIMIT} from "@lodestar/params";
 import {electra, ssz} from "@lodestar/types";
 import {CachedBeaconStateElectra, CachedBeaconStateGloas} from "../types.js";
 import {hasEth1WithdrawalCredential} from "../util/capella.js";
@@ -13,7 +13,6 @@ import {getConsolidationChurnLimit, getPendingBalanceToWithdraw, isActiveValidat
 
 // TODO Electra: Clean up necessary as there is a lot of overlap with isValidSwitchToCompoundRequest
 export function processConsolidationRequest(
-  fork: ForkSeq,
   state: CachedBeaconStateElectra | CachedBeaconStateGloas,
   consolidationRequest: electra.ConsolidationRequest
 ): void {
@@ -83,7 +82,7 @@ export function processConsolidationRequest(
   }
 
   // Verify the source has no pending withdrawals in the queue
-  if (getPendingBalanceToWithdraw(fork, state, sourceIndex) > 0) {
+  if (getPendingBalanceToWithdraw(state, sourceIndex) > 0) {
     return;
   }
 

--- a/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
@@ -41,7 +41,7 @@ export function processExecutionPayloadEnvelope(
   }
 
   for (const consolidation of requests.consolidations) {
-    processConsolidationRequest(fork, state, consolidation);
+    processConsolidationRequest(state, consolidation);
   }
 
   // Queue the builder payment

--- a/packages/state-transition/src/block/processOperations.ts
+++ b/packages/state-transition/src/block/processOperations.ts
@@ -83,7 +83,7 @@ export function processOperations(
     }
 
     for (const elConsolidationRequest of bodyElectra.executionRequests.consolidations) {
-      processConsolidationRequest(fork, stateElectra, elConsolidationRequest);
+      processConsolidationRequest(stateElectra, elConsolidationRequest);
     }
   }
 

--- a/packages/state-transition/src/block/processVoluntaryExit.ts
+++ b/packages/state-transition/src/block/processVoluntaryExit.ts
@@ -124,7 +124,7 @@ export function getVoluntaryExitValidity(
   // only exit validator if it has no pending withdrawals in the queue
   if (
     fork >= ForkSeq.electra &&
-    getPendingBalanceToWithdraw(fork, state as CachedBeaconStateElectra, voluntaryExit.validatorIndex) !== 0
+    getPendingBalanceToWithdraw(state as CachedBeaconStateElectra, voluntaryExit.validatorIndex) !== 0
   ) {
     return VoluntaryExitValidity.pendingWithdrawals;
   }

--- a/packages/state-transition/src/block/processWithdrawalRequest.ts
+++ b/packages/state-transition/src/block/processWithdrawalRequest.ts
@@ -42,7 +42,7 @@ export function processWithdrawalRequest(
   }
 
   // TODO Electra: Consider caching pendingPartialWithdrawals
-  const pendingBalanceToWithdraw = getPendingBalanceToWithdraw(fork, state, validatorIndex);
+  const pendingBalanceToWithdraw = getPendingBalanceToWithdraw(state, validatorIndex);
   const validatorBalance = state.balances.get(validatorIndex);
 
   if (isFullExitRequest) {

--- a/packages/state-transition/src/util/validator.ts
+++ b/packages/state-transition/src/util/validator.ts
@@ -125,7 +125,6 @@ export function isPartiallyWithdrawableValidator(fork: ForkSeq, validator: phase
 }
 
 export function getPendingBalanceToWithdraw(
-  fork: ForkSeq,
   state: CachedBeaconStateElectra | CachedBeaconStateGloas,
   validatorIndex: ValidatorIndex
 ): number {
@@ -133,20 +132,6 @@ export function getPendingBalanceToWithdraw(
   for (const item of state.pendingPartialWithdrawals.getAllReadonly()) {
     if (item.validatorIndex === validatorIndex) {
       total += Number(item.amount);
-    }
-  }
-
-  if (fork >= ForkSeq.gloas) {
-    const stateGloas = state as CachedBeaconStateGloas;
-    for (const item of stateGloas.builderPendingWithdrawals.getAllReadonly()) {
-      if (item.builderIndex === validatorIndex) {
-        total += item.amount;
-      }
-    }
-    for (const item of stateGloas.builderPendingPayments.getAllReadonly()) {
-      if (item.withdrawal.builderIndex === validatorIndex) {
-        total += item.withdrawal.amount;
-      }
     }
   }
 

--- a/packages/state-transition/test/unit/block/processConsolidationRequest.test.ts
+++ b/packages/state-transition/test/unit/block/processConsolidationRequest.test.ts
@@ -5,7 +5,6 @@ import {
   BLS_WITHDRAWAL_PREFIX,
   COMPOUNDING_WITHDRAWAL_PREFIX,
   FAR_FUTURE_EPOCH,
-  ForkSeq,
   SLOTS_PER_EPOCH,
 } from "@lodestar/params";
 import {ssz} from "@lodestar/types";
@@ -52,7 +51,7 @@ describe("processConsolidationRequest", () => {
 
     expect(state.pendingConsolidations.length).eq(0);
 
-    processConsolidationRequest(ForkSeq.electra, state, request);
+    processConsolidationRequest(state, request);
 
     expect(state.pendingConsolidations.length).eq(0);
   });


### PR DESCRIPTION
In #8759 we forgot to revert the changes to `getPendingBalanceToWithdraw`. 