### PR TITLE
fix(docker): reinstall dependencies on target platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y git g++ make python3 python3-setuptools
 COPY --from=build_src /usr/app .
 
 # Rebuild native deps
-RUN corepack enable && pnpm rebuild
+RUN corepack enable && pnpm install --frozen-lockfile --prod && pnpm rebuild
 
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)


### PR DESCRIPTION
**Motivation**

- Report of our latest release not working on aarch64 via docker

**Description**

It seems that pnpm has stricter rules around which optionalDependencies are installed, which lead to platform-specific dependencies not being available in the final docker image on aarch64 builds.

Old dockerfile steps:
```
step 1: (on x86_64) install packages (doesn't install aarch64 packages)
step 2: (on aarch64) rebuild packages
final: doesn't have aarch64 packages
```

This PR adds to step 2 of the dockerfile to re-`pnpm install` when on the target platform.