### PR TITLE
chore: v1.39.1 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y git g++ make python3 python3-setuptools
 COPY --from=build_src /usr/app .
 
 # Rebuild native deps
-RUN corepack enable && pnpm rebuild
+RUN corepack enable && pnpm install --frozen-lockfile --prod && pnpm rebuild
 
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# --platform=$BUILDPLATFORM is used build javascript source with host arch
-# Otherwise TS builds on emulated archs and can be extremely slow (+1h)
-FROM --platform=${BUILDPLATFORM:-amd64} node:24-slim AS build_src
+FROM node:24-slim AS build_src
 ARG COMMIT
 WORKDIR /usr/app
 RUN apt-get update && apt-get install -y git g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -20,23 +18,11 @@ RUN corepack enable && corepack prepare --activate && \
 # the terminal and in the logs; which is very useful to track tests better.
 RUN cd packages/cli && GIT_COMMIT=${COMMIT} pnpm write-git-data
 
-
-# Copy built src + node_modules to build native packages for archs different than host.
-# Note: This step is redundant for the host arch
-FROM node:24-slim AS build_deps
-WORKDIR /usr/app
-RUN apt-get update && apt-get install -y git g++ make python3 python3-setuptools && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-COPY --from=build_src /usr/app .
-
-# Rebuild native deps
-RUN corepack enable && pnpm install --frozen-lockfile --prod && pnpm rebuild
-
 # Copy built src + node_modules to a new layer to prune unnecessary fs
 # Previous layer weights 7.25GB, while this final 488MB (as of Oct 2020)
 FROM node:24-slim
 WORKDIR /usr/app
-COPY --from=build_deps /usr/app .
+COPY --from=build_src /usr/app .
 
 # NodeJS applications have a default memory limit of 4GB on most machines.
 # This limit is bit tight for a Mainnet node, it is recommended to raise the limit

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.39.0",
+  "version": "1.39.1",
   "stream": true,
   "command": {
     "version": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ChainSafe/lodestar/issues"
   },
-  "version": "1.39.0",
+  "version": "1.39.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ChainSafe/lodestar/issues"
   },
-  "version": "1.39.0",
+  "version": "1.39.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/lodestar",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "Command line interface for lodestar",
   "author": "ChainSafe Systems",
   "license": "Apache-2.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lodestar/config",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "Chain configuration required for lodestar",
   "author": "ChainSafe Systems",
   "license": "Apache-2.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lodestar/db",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "DB modules of Lodestar",
   "author": "ChainSafe Systems",
   "homepage": "https://github.com/ChainSafe/lodestar#readme",

--- a/packages/era/package.json
+++ b/packages/era/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ChainSafe/lodestar/issues"
   },
-  "version": "1.39.0",
+  "version": "1.39.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/flare/package.json
+++ b/packages/flare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lodestar/flare",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "Beacon chain debugging tool",
   "author": "ChainSafe Systems",
   "license": "Apache-2.0",

--- a/packages/fork-choice/package.json
+++ b/packages/fork-choice/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ChainSafe/lodestar/issues"
   },
-  "version": "1.39.0",
+  "version": "1.39.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/light-client/package.json
+++ b/packages/light-client/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ChainSafe/lodestar/issues"
   },
-  "version": "1.39.0",
+  "version": "1.39.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ChainSafe/lodestar/issues"
   },
-  "version": "1.39.0",
+  "version": "1.39.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/params/package.json
+++ b/packages/params/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lodestar/params",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "Chain parameters required for lodestar",
   "author": "ChainSafe Systems",
   "license": "Apache-2.0",

--- a/packages/prover/package.json
+++ b/packages/prover/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ChainSafe/lodestar/issues"
   },
-  "version": "1.39.0",
+  "version": "1.39.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/reqresp/package.json
+++ b/packages/reqresp/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ChainSafe/lodestar/issues"
   },
-  "version": "1.39.0",
+  "version": "1.39.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/spec-test-util/package.json
+++ b/packages/spec-test-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lodestar/spec-test-util",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "Spec test suite generator from yaml test files",
   "author": "ChainSafe Systems",
   "license": "Apache-2.0",

--- a/packages/state-transition/package.json
+++ b/packages/state-transition/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ChainSafe/lodestar/issues"
   },
-  "version": "1.39.0",
+  "version": "1.39.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lodestar/test-utils",
   "private": true,
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "Test utilities reused across other packages",
   "author": "ChainSafe Systems",
   "license": "Apache-2.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ChainSafe/lodestar/issues"
   },
-  "version": "1.39.0",
+  "version": "1.39.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/ChainSafe/lodestar/issues"
   },
-  "version": "1.39.0",
+  "version": "1.39.1",
   "type": "module",
   "exports": {
     ".": {

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lodestar/validator",
-  "version": "1.39.0",
+  "version": "1.39.1",
   "description": "A Typescript implementation of the validator client",
   "author": "ChainSafe Systems",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Motivation**

This hotfix release includes #8816 and #8819 to prevent dependency issues stemming from pnpm migration. This hotfix will allow arm64 docker users to not experience missing dependencies and keep the image size sane.