### PR TITLE
feat: allow block import after NUMBER_OF_COLUMNS / 2

### DIFF
--- a/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
+++ b/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
@@ -6,14 +6,12 @@ import {BlockInputColumns} from "./blocks/blockInput/index.js";
 import {ChainEventEmitter} from "./emitter.js";
 
 /**
- * Minimum time to wait before attempting reconstruction
+ * Maximum added delay before attempting reconstruction
+ *
+ * From the spec:
+ * If delaying reconstruction, nodes may use a random delay in order to desynchronize reconstruction among nodes, thus reducing overall CPU load.
  */
-const RECONSTRUCTION_DELAY_MIN_MS = 800;
-
-/**
- * Maximum time to wait before attempting reconstruction
- */
-const RECONSTRUCTION_DELAY_MAX_MS = 1200;
+const RECONSTRUCTION_RANDOM_DELAY_MAX_MS = 200;
 
 export type ColumnReconstructionTrackerInit = {
   logger: Logger;
@@ -48,7 +46,7 @@ export class ColumnReconstructionTracker {
     this.config = init.config;
   }
 
-  triggerColumnReconstruction(blockInput: BlockInputColumns): void {
+  triggerColumnReconstruction(delay: number, blockInput: BlockInputColumns): void {
     if (this.running) {
       return;
     }
@@ -61,9 +59,7 @@ export class ColumnReconstructionTracker {
     // just that it has been triggered for this block root.
     this.running = true;
     this.lastBlockRootHex = blockInput.blockRootHex;
-    const delay =
-      RECONSTRUCTION_DELAY_MIN_MS + Math.random() * (RECONSTRUCTION_DELAY_MAX_MS - RECONSTRUCTION_DELAY_MIN_MS);
-    sleep(delay)
+    sleep(delay + Math.random() * RECONSTRUCTION_RANDOM_DELAY_MAX_MS)
       .then(() => {
         const logCtx = {slot: blockInput.slot, root: blockInput.blockRootHex};
         this.logger.debug("Attempting data column sidecar reconstruction", logCtx);

--- a/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
+++ b/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
@@ -6,12 +6,14 @@ import {BlockInputColumns} from "./blocks/blockInput/index.js";
 import {ChainEventEmitter} from "./emitter.js";
 
 /**
- * Maximum added delay before attempting reconstruction
- *
- * From the spec:
- * If delaying reconstruction, nodes may use a random delay in order to desynchronize reconstruction among nodes, thus reducing overall CPU load.
+ * Minimum time to wait before attempting reconstruction
  */
-const RECONSTRUCTION_RANDOM_DELAY_MAX_MS = 200;
+const RECONSTRUCTION_DELAY_MIN_MS = 800;
+
+/**
+ * Maximum time to wait before attempting reconstruction
+ */
+const RECONSTRUCTION_DELAY_MAX_MS = 1200;
 
 export type ColumnReconstructionTrackerInit = {
   logger: Logger;
@@ -46,7 +48,7 @@ export class ColumnReconstructionTracker {
     this.config = init.config;
   }
 
-  triggerColumnReconstruction(delay: number, blockInput: BlockInputColumns): void {
+  triggerColumnReconstruction(blockInput: BlockInputColumns): void {
     if (this.running) {
       return;
     }
@@ -59,7 +61,9 @@ export class ColumnReconstructionTracker {
     // just that it has been triggered for this block root.
     this.running = true;
     this.lastBlockRootHex = blockInput.blockRootHex;
-    sleep(delay + Math.random() * RECONSTRUCTION_RANDOM_DELAY_MAX_MS)
+    const delay =
+      RECONSTRUCTION_DELAY_MIN_MS + Math.random() * (RECONSTRUCTION_DELAY_MAX_MS - RECONSTRUCTION_DELAY_MIN_MS);
+    sleep(delay)
       .then(() => {
         const logCtx = {slot: blockInput.slot, root: blockInput.blockRootHex};
         this.logger.debug("Attempting data column sidecar reconstruction", logCtx);

--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -1,4 +1,4 @@
-import {ForkName, ForkPostFulu, ForkPreDeneb, ForkPreGloas, NUMBER_OF_COLUMNS} from "@lodestar/params";
+import {ForkName, ForkPostFulu, ForkPreDeneb, ForkPreGloas} from "@lodestar/params";
 import {BeaconBlockBody, BlobIndex, ColumnIndex, SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
 import {fromHex, prettyBytes, toRootHex, withTimeout} from "@lodestar/utils";
 import {VersionedHashes} from "../../../execution/index.js";
@@ -789,13 +789,7 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
     this.columnsCache.set(columnSidecar.index, {columnSidecar, source, seenTimestampSec, peerIdStr});
 
     const sampledColumns = this.getSampledColumns();
-    const hasAllData =
-      // already hasAllData
-      this.state.hasAllData ||
-      // has all sampled columns
-      sampledColumns.length === this.sampledColumns.length ||
-      // has enough columns to reconstruct the rest
-      sampledColumns.length >= NUMBER_OF_COLUMNS / 2;
+    const hasAllData = this.state.hasAllData || sampledColumns.length === this.sampledColumns.length;
 
     const hasComputedAllData =
       // already hasAllData

--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -561,6 +561,7 @@ type BlockInputColumnsState =
   | {
       hasBlock: true;
       hasAllData: true;
+      hasComputedAllData: boolean;
       versionedHashes: VersionedHashes;
       block: SignedBeaconBlock<ForkColumnsDA>;
       source: SourceMeta;
@@ -569,6 +570,7 @@ type BlockInputColumnsState =
   | {
       hasBlock: true;
       hasAllData: false;
+      hasComputedAllData: false;
       versionedHashes: VersionedHashes;
       block: SignedBeaconBlock<ForkColumnsDA>;
       source: SourceMeta;
@@ -576,11 +578,13 @@ type BlockInputColumnsState =
   | {
       hasBlock: false;
       hasAllData: true;
+      hasComputedAllData: boolean;
       versionedHashes: VersionedHashes;
     }
   | {
       hasBlock: false;
       hasAllData: false;
+      hasComputedAllData: false;
       versionedHashes: VersionedHashes;
     };
 /**
@@ -598,6 +602,12 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
   private columnsCache = new Map<ColumnIndex, ColumnWithSource>();
   private readonly sampledColumns: ColumnIndex[];
   private readonly custodyColumns: ColumnIndex[];
+  /**
+   * This promise resolves when all sampled columns are available
+   *
+   * This is different from `dataPromise` which resolves when all data is available or could become available (e.g. through reconstruction)
+   */
+  protected computedDataPromise = createPromise<fulu.DataColumnSidecars>();
 
   private constructor(
     init: BlockInputInit,
@@ -626,6 +636,7 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
     const state = {
       hasBlock: true,
       hasAllData,
+      hasComputedAllData: hasAllData,
       versionedHashes: props.block.message.body.blobKzgCommitments.map(kzgCommitmentToVersionedHash),
       block: props.block,
       source: {
@@ -661,6 +672,7 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
     const state: BlockInputColumnsState = {
       hasBlock: false,
       hasAllData,
+      hasComputedAllData: hasAllData as false,
       versionedHashes: props.columnSidecar.kzgCommitments.map(kzgCommitmentToVersionedHash),
     };
     const init: BlockInputInit = {
@@ -722,11 +734,14 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
     const hasAllData =
       (props.block.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments.length === 0 ||
       this.state.hasAllData;
+    const hasComputedAllData =
+      props.block.message.body.blobKzgCommitments.length === 0 || this.state.hasComputedAllData;
 
     this.state = {
       ...this.state,
       hasBlock: true,
       hasAllData,
+      hasComputedAllData,
       block: props.block,
       source: {
         source: props.source,
@@ -782,14 +797,25 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
       // has enough columns to reconstruct the rest
       sampledColumns.length >= NUMBER_OF_COLUMNS / 2;
 
+    const hasComputedAllData =
+      // already hasAllData
+      this.state.hasAllData ||
+      // has all sampled columns
+      sampledColumns.length === this.sampledColumns.length;
+
     this.state = {
       ...this.state,
       hasAllData: hasAllData || this.state.hasAllData,
+      hasComputedAllData: hasComputedAllData,
       timeCompleteSec: hasAllData ? seenTimestampSec : undefined,
     } as BlockInputColumnsState;
 
     if (hasAllData && sampledColumns !== null) {
       this.dataPromise.resolve(sampledColumns);
+    }
+
+    if (hasComputedAllData && sampledColumns !== null) {
+      this.computedDataPromise.resolve(sampledColumns);
     }
   }
 
@@ -864,5 +890,16 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
       missing,
       versionedHashes: this.state.versionedHashes,
     };
+  }
+
+  hasComputedAllData(): boolean {
+    return this.state.hasComputedAllData;
+  }
+
+  waitForComputedAllData(timeout: number, signal?: AbortSignal): Promise<fulu.DataColumnSidecars> {
+    if (!this.state.hasComputedAllData) {
+      return withTimeout(() => this.computedDataPromise.promise, timeout, signal);
+    }
+    return Promise.resolve(this.getSampledColumns());
   }
 }

--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -1,4 +1,4 @@
-import {ForkName, ForkPostFulu, ForkPreDeneb, ForkPreGloas} from "@lodestar/params";
+import {ForkName, ForkPostFulu, ForkPreDeneb, ForkPreGloas, NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {BeaconBlockBody, BlobIndex, ColumnIndex, SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
 import {fromHex, prettyBytes, toRootHex, withTimeout} from "@lodestar/utils";
 import {VersionedHashes} from "../../../execution/index.js";
@@ -789,7 +789,13 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
     this.columnsCache.set(columnSidecar.index, {columnSidecar, source, seenTimestampSec, peerIdStr});
 
     const sampledColumns = this.getSampledColumns();
-    const hasAllData = this.state.hasAllData || sampledColumns.length === this.sampledColumns.length;
+    const hasAllData =
+      // already hasAllData
+      this.state.hasAllData ||
+      // has all sampled columns
+      sampledColumns.length === this.sampledColumns.length ||
+      // has enough columns to reconstruct the rest
+      sampledColumns.length >= NUMBER_OF_COLUMNS / 2;
 
     const hasComputedAllData =
       // already hasAllData

--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -660,6 +660,7 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
     blockInput.blockPromise.resolve(props.block);
     if (hasAllData) {
       blockInput.dataPromise.resolve([]);
+      blockInput.computedDataPromise.resolve([]);
     }
     return blockInput;
   }
@@ -795,7 +796,7 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
       // has all sampled columns
       sampledColumns.length === this.sampledColumns.length ||
       // has enough columns to reconstruct the rest
-      sampledColumns.length >= NUMBER_OF_COLUMNS / 2;
+      this.columnsCache.size >= NUMBER_OF_COLUMNS / 2;
 
     const hasComputedAllData =
       // has all sampled columns
@@ -804,7 +805,7 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
     this.state = {
       ...this.state,
       hasAllData: hasAllData || this.state.hasAllData,
-      hasComputedAllData: hasComputedAllData,
+      hasComputedAllData: hasComputedAllData || this.state.hasComputedAllData,
       timeCompleteSec: hasAllData ? seenTimestampSec : undefined,
     } as BlockInputColumnsState;
 

--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -798,8 +798,6 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
       sampledColumns.length >= NUMBER_OF_COLUMNS / 2;
 
     const hasComputedAllData =
-      // already hasAllData
-      this.state.hasAllData ||
       // has all sampled columns
       sampledColumns.length === this.sampledColumns.length;
 

--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -687,6 +687,7 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
     const blockInput = new BlockInputColumns(init, state, props.sampledColumns, props.custodyColumns);
     if (hasAllData) {
       blockInput.dataPromise.resolve([]);
+      blockInput.computedDataPromise.resolve([]);
     }
     return blockInput;
   }

--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -1,4 +1,4 @@
-import {ForkName, ForkPostFulu, ForkPreDeneb, ForkPreGloas} from "@lodestar/params";
+import {ForkName, ForkPostFulu, ForkPreDeneb, ForkPreGloas, NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {BeaconBlockBody, BlobIndex, ColumnIndex, SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
 import {fromHex, prettyBytes, toRootHex, withTimeout} from "@lodestar/utils";
 import {VersionedHashes} from "../../../execution/index.js";
@@ -774,7 +774,13 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
     this.columnsCache.set(columnSidecar.index, {columnSidecar, source, seenTimestampSec, peerIdStr});
 
     const sampledColumns = this.getSampledColumns();
-    const hasAllData = this.state.hasAllData || sampledColumns.length === this.sampledColumns.length;
+    const hasAllData =
+      // already hasAllData
+      this.state.hasAllData ||
+      // has all sampled columns
+      sampledColumns.length === this.sampledColumns.length ||
+      // has enough columns to reconstruct the rest
+      sampledColumns.length >= NUMBER_OF_COLUMNS / 2;
 
     this.state = {
       ...this.state,

--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -48,7 +48,6 @@ export async function writeBlockInputToDb(this: BeaconChain, blocksInputs: IBloc
         // Supernodes may only have a subset of the data columns by the time the block begins to be imported
         // because full data availability can be assumed after NUMBER_OF_COLUMNS / 2 columns are available.
         // Here, however, all data columns must be fully available/reconstructed before persisting to the DB.
-        this.columnReconstructionTracker.triggerColumnReconstruction(0, blockInput);
         await blockInput.waitForComputedAllData(BLOB_AVAILABILITY_TIMEOUT);
       }
 

--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -44,6 +44,14 @@ export async function writeBlockInputToDb(this: BeaconChain, blocksInputs: IBloc
 
     // NOTE: Old data is pruned on archive
     if (isBlockInputColumns(blockInput)) {
+      if (!blockInput.hasComputedAllData()) {
+        // Supernodes may only have a subset of the data columns by the time the block begins to be imported
+        // because full data availability can be assumed after NUMBER_OF_COLUMNS / 2 columns are available.
+        // Here, however, all data columns must be fully available/reconstructed before persisting to the DB.
+        this.columnReconstructionTracker.triggerColumnReconstruction(0, blockInput);
+        await blockInput.waitForComputedAllData(BLOB_AVAILABILITY_TIMEOUT);
+      }
+
       const {custodyColumns} = this.custodyConfig;
       const blobsLen = (block.message as fulu.BeaconBlock).body.blobKzgCommitments.length;
       let dataColumnsLen: number;

--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -48,7 +48,9 @@ export async function writeBlockInputToDb(this: BeaconChain, blocksInputs: IBloc
         // Supernodes may only have a subset of the data columns by the time the block begins to be imported
         // because full data availability can be assumed after NUMBER_OF_COLUMNS / 2 columns are available.
         // Here, however, all data columns must be fully available/reconstructed before persisting to the DB.
-        await blockInput.waitForComputedAllData(BLOB_AVAILABILITY_TIMEOUT);
+        await blockInput.waitForComputedAllData(BLOB_AVAILABILITY_TIMEOUT).catch(() => {
+          this.logger.debug("Failed to wait for computed all data", {slot, blockRoot: blockRootHex});
+        });
       }
 
       const {custodyColumns} = this.custodyConfig;

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -581,11 +581,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         chain.getBlobsTracker.triggerGetBlobs(blockInput);
         // if we've received at least half of the columns, trigger reconstruction of the rest
         if (blockInput.columnCount >= NUMBER_OF_COLUMNS / 2) {
-          chain.columnReconstructionTracker.triggerColumnReconstruction(
-            // wait to reconstruct until after head vote
-            getCutoffTimeMs(chain, dataColumnSlot, config.getAttestationDueMs(topic.boundary.fork)),
-            blockInput
-          );
+          chain.columnReconstructionTracker.triggerColumnReconstruction(blockInput);
         }
       }
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -581,7 +581,11 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         chain.getBlobsTracker.triggerGetBlobs(blockInput);
         // if we've received at least half of the columns, trigger reconstruction of the rest
         if (blockInput.columnCount >= NUMBER_OF_COLUMNS / 2) {
-          chain.columnReconstructionTracker.triggerColumnReconstruction(blockInput);
+          chain.columnReconstructionTracker.triggerColumnReconstruction(
+            // wait to reconstruct until after head vote
+            getCutoffTimeMs(chain, dataColumnSlot, config.getAttestationDueMs(topic.boundary.fork)),
+            blockInput
+          );
         }
       }
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -576,7 +576,7 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
           break;
       }
 
-      if (!blockInput.hasAllData()) {
+      if (!blockInput.hasComputedAllData()) {
         // immediately attempt fetch of data columns from execution engine
         chain.getBlobsTracker.triggerGetBlobs(blockInput);
         // if we've received at least half of the columns, trigger reconstruction of the rest


### PR DESCRIPTION
**Motivation**

- Resolves https://github.com/ChainSafe/lodestar/issues/8404
- Replaces https://github.com/ChainSafe/lodestar/pull/8408

**Description**

- Add condition to `blockInput.hasAllData` to trigger if the number of columns is enough to reconstruct (gte `NUMBER_OF_COLUMNS / 2`)
- Add `blockInputColumns.hasComputedAllData`, used to await full reconstruction during `writeBlockInputToDb`