### PR TITLE
fix: remove index label from validator_monitor_prev_epoch_on_chain_balance metric

### DIFF
--- a/dashboards/lodestar_summary.json
+++ b/dashboards/lodestar_summary.json
@@ -1361,7 +1361,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "avg(\n  rate(validator_monitor_prev_epoch_on_chain_balance[32m])\n)",
+          "expr": "rate(validator_monitor_prev_epoch_on_chain_balance[32m]) / validator_monitor_validators",
           "hide": false,
           "interval": "",
           "legendFormat": "balance_delta",

--- a/dashboards/lodestar_validator_monitor.json
+++ b/dashboards/lodestar_validator_monitor.json
@@ -650,7 +650,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": false,
-          "expr": "avg(\n  rate(validator_monitor_prev_epoch_on_chain_balance[32m])\n)",
+          "expr": "rate(validator_monitor_prev_epoch_on_chain_balance[32m]) / validator_monitor_validators",
           "hide": false,
           "interval": "",
           "legendFormat": "balance_delta",

--- a/packages/beacon-node/src/chain/validatorMonitor.ts
+++ b/packages/beacon-node/src/chain/validatorMonitor.ts
@@ -425,7 +425,7 @@ export function createValidatorMonitor(
       }
 
       // Set total balance of all monitored validators
-      if (balances) {
+      if (balances !== undefined) {
         validatorMonitorMetrics?.prevEpochOnChainBalance.set(totalBalance);
       }
     },

--- a/packages/beacon-node/src/chain/validatorMonitor.ts
+++ b/packages/beacon-node/src/chain/validatorMonitor.ts
@@ -347,7 +347,7 @@ export function createValidatorMonitor(
         return;
       }
 
-      // Track total balance for prevEpochOnChainBalance metric instead of per-validator to avoid high cardinality
+      // Track total balance instead of per-validator balance to reduce metric cardinality
       let totalBalance = 0;
 
       for (const [index, monitoredValidator] of validators.entries()) {

--- a/packages/beacon-node/src/chain/validatorMonitor.ts
+++ b/packages/beacon-node/src/chain/validatorMonitor.ts
@@ -424,7 +424,6 @@ export function createValidatorMonitor(
         }
       }
 
-      // Set total balance of all monitored validators
       if (balances !== undefined) {
         validatorMonitorMetrics?.prevEpochOnChainBalance.set(totalBalance);
       }

--- a/packages/beacon-node/src/chain/validatorMonitor.ts
+++ b/packages/beacon-node/src/chain/validatorMonitor.ts
@@ -347,7 +347,7 @@ export function createValidatorMonitor(
         return;
       }
 
-      // Track total balance instead of per-validator balance to reduce metric cardinality
+      // Track total balance for prevEpochOnChainBalance metric instead of per-validator to avoid high cardinality
       let totalBalance = 0;
 
       for (const [index, monitoredValidator] of validators.entries()) {

--- a/packages/beacon-node/src/chain/validatorMonitor.ts
+++ b/packages/beacon-node/src/chain/validatorMonitor.ts
@@ -347,7 +347,7 @@ export function createValidatorMonitor(
         return;
       }
 
-      // Track total balance of all monitored validators to avoid high cardinality
+      // Track total balance instead of per-validator balance to reduce metric cardinality
       let totalBalance = 0;
 
       for (const [index, monitoredValidator] of validators.entries()) {

--- a/packages/beacon-node/src/chain/validatorMonitor.ts
+++ b/packages/beacon-node/src/chain/validatorMonitor.ts
@@ -347,6 +347,9 @@ export function createValidatorMonitor(
         return;
       }
 
+      // Track total balance of all monitored validators to avoid high cardinality
+      let totalBalance = 0;
+
       for (const [index, monitoredValidator] of validators.entries()) {
         // We subtract two from the state of the epoch that generated these summaries.
         //
@@ -405,7 +408,7 @@ export function createValidatorMonitor(
 
         const balance = balances?.[index];
         if (balance !== undefined) {
-          validatorMonitorMetrics?.prevEpochOnChainBalance.set({index}, balance);
+          totalBalance += balance;
         }
 
         if (!summary.isPrevSourceAttester || !summary.isPrevTargetAttester || !summary.isPrevHeadAttester) {
@@ -419,6 +422,11 @@ export function createValidatorMonitor(
             inclusionDistance,
           });
         }
+      }
+
+      // Set total balance of all monitored validators
+      if (balances) {
+        validatorMonitorMetrics?.prevEpochOnChainBalance.set(totalBalance);
       }
     },
 
@@ -1153,11 +1161,9 @@ function createValidatorMonitorMetrics(register: RegistryMetricCreator) {
     }),
 
     // Validator Monitor Metrics (per-epoch summaries)
-    // Only track prevEpochOnChainBalance per index
-    prevEpochOnChainBalance: register.gauge<{index: number}>({
+    prevEpochOnChainBalance: register.gauge({
       name: "validator_monitor_prev_epoch_on_chain_balance",
-      help: "Balance of validator after an epoch",
-      labelNames: ["index"],
+      help: "Total balance of all monitored validators after an epoch",
     }),
     prevEpochOnChainAttesterHit: register.gauge({
       name: "validator_monitor_prev_epoch_on_chain_attester_hit_total",


### PR DESCRIPTION
## Description

This PR fixes the high cardinality issue with the `validator_monitor_prev_epoch_on_chain_balance` metric by removing the `index` label.

### Changes

1. **Removed `index` label** from the metric definition
2. **Track total balance** instead of per-validator balances - the metric now reports the sum of balances of all monitored validators
3. **Updated dashboards** to divide by `validator_monitor_validators` count to maintain the same average balance visualization

### Why this approach?

As discussed in the issue, the `index` label was the only metric using per-validator labels, and it was not being used in dashboards (which always averaged). By tracking total balance instead:

- Cardinality is reduced from O(n) to O(1) where n = number of validators
- Average balance can still be computed: `total_balance / validator_count`
- Rate of change still works: `rate(total_balance) / validator_count`

Closes #8740

---

> [!NOTE]
> This PR was authored by Lodekeeper (AI assistant) under supervision of @nflaig.