### PR TITLE
test: correct lightclient committee root test for electra

### DIFF
--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -1,8 +1,7 @@
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
-import {aggregateSerializedPublicKeys} from "@chainsafe/blst";
 import {HttpHeader, getClient, routes} from "@lodestar/api";
 import {ChainConfig, createBeaconConfig} from "@lodestar/config";
-import {ForkName, SYNC_COMMITTEE_SIZE} from "@lodestar/params";
+import {ForkName} from "@lodestar/params";
 import {phase0, ssz} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {Validator} from "@lodestar/validator";
@@ -119,29 +118,19 @@ describe("lightclient api", () => {
     expect(finalityUpdate).toBeDefined();
   });
 
-  it.skip("getLightClientCommitteeRoot() for the 1st period", async () => {
-    // need to investigate why this test fails after upgrading to electra
-    // TODO: https://github.com/ChainSafe/lodestar/issues/8723
+  it("getLightClientCommitteeRoot() for the 1st period", async () => {
     await waitForBestUpdate();
 
     const lightclient = getClient({baseUrl: `http://127.0.0.1:${restPort}`}, {config}).lightclient;
     const committeeRes = await lightclient.getLightClientCommitteeRoot({startPeriod: 0, count: 1});
     committeeRes.assertOk();
-    const client = getClient({baseUrl: `http://127.0.0.1:${restPort}`}, {config}).beacon;
-    const validators = (await client.postStateValidators({stateId: "head"})).value();
-    const pubkeys = validators.map((v) => v.validator.pubkey);
-    expect(pubkeys.length).toBe(validatorCount);
-    // only 2 validators spreading to 512 committee slots
-    const committeePubkeys = Array.from({length: SYNC_COMMITTEE_SIZE}, (_, i) =>
-      i % 2 === 0 ? pubkeys[0] : pubkeys[1]
-    );
-    const aggregatePubkey = aggregateSerializedPublicKeys(committeePubkeys).toBytes();
+
+    // Get the actual sync committee root from the head state
+    // The sync committee is computed using a weighted random shuffle, not simple alternation
+    const headState = bn.chain.getHeadState();
+    const expectedRoot = headState.currentSyncCommittee.hashTreeRoot();
+
     // single committee hash since we requested for the first period
-    expect(committeeRes.value()).toEqual([
-      ssz.altair.SyncCommittee.hashTreeRoot({
-        pubkeys: committeePubkeys,
-        aggregatePubkey,
-      }),
-    ]);
+    expect(committeeRes.value()).toEqual([expectedRoot]);
   });
 });

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -2,7 +2,8 @@ import {afterEach, beforeEach, describe, expect, it} from "vitest";
 import {HttpHeader, getClient, routes} from "@lodestar/api";
 import {ChainConfig, createBeaconConfig} from "@lodestar/config";
 import {ForkName} from "@lodestar/params";
-import {phase0, ssz} from "@lodestar/types";
+import {CachedBeaconStateAltair} from "@lodestar/state-transition";
+import {phase0} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {Validator} from "@lodestar/validator";
 import {BeaconNode} from "../../../../../src/node/nodejs.js";
@@ -127,7 +128,8 @@ describe("lightclient api", () => {
 
     // Get the actual sync committee root from the head state
     // The sync committee is computed using a weighted random shuffle, not simple alternation
-    const headState = bn.chain.getHeadState();
+    // Since the test starts at Electra, headState is always post-Altair and has currentSyncCommittee
+    const headState = bn.chain.getHeadState() as CachedBeaconStateAltair;
     const expectedRoot = headState.currentSyncCommittee.hashTreeRoot();
 
     // single committee hash since we requested for the first period


### PR DESCRIPTION
## Description

Fixes the failing lightclient e2e test after upgrading to electra.

### Root Cause

The test incorrectly assumed sync committees would have alternating pubkeys `[pk0, pk1, pk0, pk1, ...]`:

```typescript
const committeePubkeys = Array.from({length: SYNC_COMMITTEE_SIZE}, (_, i) =>
  i % 2 === 0 ? pubkeys[0] : pubkeys[1]
);
```

However, sync committees are computed using a **weighted random shuffle** based on:
- A seed derived from the state
- Validator effective balances

### Why it broke post-electra

In `getNextSyncCommitteeIndices()`, the shuffle parameters changed for electra:

```typescript
if (fork >= ForkSeq.electra) {
  maxEffectiveBalance = MAX_EFFECTIVE_BALANCE_ELECTRA;  // Different!
  randByteCount = 2;  // Different! (was 1)
}
```

The shuffle algorithm now uses 2 random bytes instead of 1, producing a completely different committee distribution even with the same validators.

### Fix

Get the actual sync committee root from the head state instead of constructing an incorrect expected committee.

Closes #8723

---

> [!NOTE]
> This PR was authored by Lodekeeper (AI assistant) under supervision of @nflaig.