### PR TITLE
fix: make column reconstruction delay a function of slot time

### DIFF
--- a/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
+++ b/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
@@ -63,9 +63,8 @@ export class ColumnReconstructionTracker {
     // just that it has been triggered for this block root.
     this.running = true;
     this.lastBlockRootHex = blockInput.blockRootHex;
-    const slotMs = this.config.SECONDS_PER_SLOT * 1000;
-    const minDelayMs = (slotMs * RECONSTRUCTION_DELAY_MIN_BPS) / 10000;
-    const maxDelayMs = (slotMs * RECONSTRUCTION_DELAY_MAX_BPS) / 10000;
+    const minDelayMs = this.config.getSlotComponentDurationMs(RECONSTRUCTION_DELAY_MIN_BPS);
+    const maxDelayMs = this.config.getSlotComponentDurationMs(RECONSTRUCTION_DELAY_MAX_BPS);
     const delay = minDelayMs + Math.random() * (maxDelayMs - minDelayMs);
     sleep(delay)
       .then(() => {

--- a/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
+++ b/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
@@ -6,14 +6,16 @@ import {BlockInputColumns} from "./blocks/blockInput/index.js";
 import {ChainEventEmitter} from "./emitter.js";
 
 /**
- * Minimum time to wait before attempting reconstruction
+ * Minimum delay before attempting reconstruction as a ratio of slot duration.
+ * For a 12s slot, this equates to 800ms (the original hardcoded value).
  */
-const RECONSTRUCTION_DELAY_MIN_MS = 800;
+const RECONSTRUCTION_DELAY_MIN_RATIO = 1 / 15;
 
 /**
- * Maximum time to wait before attempting reconstruction
+ * Maximum delay before attempting reconstruction as a ratio of slot duration.
+ * For a 12s slot, this equates to 1200ms (the original hardcoded value).
  */
-const RECONSTRUCTION_DELAY_MAX_MS = 1200;
+const RECONSTRUCTION_DELAY_MAX_RATIO = 1 / 10;
 
 export type ColumnReconstructionTrackerInit = {
   logger: Logger;
@@ -61,8 +63,10 @@ export class ColumnReconstructionTracker {
     // just that it has been triggered for this block root.
     this.running = true;
     this.lastBlockRootHex = blockInput.blockRootHex;
-    const delay =
-      RECONSTRUCTION_DELAY_MIN_MS + Math.random() * (RECONSTRUCTION_DELAY_MAX_MS - RECONSTRUCTION_DELAY_MIN_MS);
+    const slotMs = this.config.SECONDS_PER_SLOT * 1000;
+    const minDelayMs = slotMs * RECONSTRUCTION_DELAY_MIN_RATIO;
+    const maxDelayMs = slotMs * RECONSTRUCTION_DELAY_MAX_RATIO;
+    const delay = minDelayMs + Math.random() * (maxDelayMs - minDelayMs);
     sleep(delay)
       .then(() => {
         const logCtx = {slot: blockInput.slot, root: blockInput.blockRootHex};

--- a/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
+++ b/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
@@ -6,16 +6,16 @@ import {BlockInputColumns} from "./blocks/blockInput/index.js";
 import {ChainEventEmitter} from "./emitter.js";
 
 /**
- * Minimum delay before attempting reconstruction as a ratio of slot duration.
- * For a 12s slot, this equates to 800ms (the original hardcoded value).
+ * Minimum delay before attempting reconstruction in basis points (BPS) of slot duration.
+ * 667 BPS = 6.67% of slot. For a 12s slot, this equates to ~800ms.
  */
-const RECONSTRUCTION_DELAY_MIN_RATIO = 1 / 15;
+const RECONSTRUCTION_DELAY_MIN_BPS = 667;
 
 /**
- * Maximum delay before attempting reconstruction as a ratio of slot duration.
- * For a 12s slot, this equates to 1200ms (the original hardcoded value).
+ * Maximum delay before attempting reconstruction in basis points (BPS) of slot duration.
+ * 1000 BPS = 10% of slot. For a 12s slot, this equates to 1200ms.
  */
-const RECONSTRUCTION_DELAY_MAX_RATIO = 1 / 10;
+const RECONSTRUCTION_DELAY_MAX_BPS = 1000;
 
 export type ColumnReconstructionTrackerInit = {
   logger: Logger;
@@ -64,8 +64,8 @@ export class ColumnReconstructionTracker {
     this.running = true;
     this.lastBlockRootHex = blockInput.blockRootHex;
     const slotMs = this.config.SECONDS_PER_SLOT * 1000;
-    const minDelayMs = slotMs * RECONSTRUCTION_DELAY_MIN_RATIO;
-    const maxDelayMs = slotMs * RECONSTRUCTION_DELAY_MAX_RATIO;
+    const minDelayMs = (slotMs * RECONSTRUCTION_DELAY_MIN_BPS) / 10000;
+    const maxDelayMs = (slotMs * RECONSTRUCTION_DELAY_MAX_BPS) / 10000;
     const delay = minDelayMs + Math.random() * (maxDelayMs - minDelayMs);
     sleep(delay)
       .then(() => {

--- a/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
+++ b/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
@@ -41,11 +41,16 @@ export class ColumnReconstructionTracker {
   /** Track if a reconstruction attempt is in-flight */
   running = false;
 
+  private readonly minDelayMs: number;
+  private readonly maxDelayMs: number;
+
   constructor(init: ColumnReconstructionTrackerInit) {
     this.logger = init.logger;
     this.emitter = init.emitter;
     this.metrics = init.metrics;
     this.config = init.config;
+    this.minDelayMs = this.config.getSlotComponentDurationMs(RECONSTRUCTION_DELAY_MIN_BPS);
+    this.maxDelayMs = this.config.getSlotComponentDurationMs(RECONSTRUCTION_DELAY_MAX_BPS);
   }
 
   triggerColumnReconstruction(blockInput: BlockInputColumns): void {
@@ -61,9 +66,7 @@ export class ColumnReconstructionTracker {
     // just that it has been triggered for this block root.
     this.running = true;
     this.lastBlockRootHex = blockInput.blockRootHex;
-    const minDelayMs = this.config.getSlotComponentDurationMs(RECONSTRUCTION_DELAY_MIN_BPS);
-    const maxDelayMs = this.config.getSlotComponentDurationMs(RECONSTRUCTION_DELAY_MAX_BPS);
-    const delay = minDelayMs + Math.random() * (maxDelayMs - minDelayMs);
+    const delay = this.minDelayMs + Math.random() * (this.maxDelayMs - this.minDelayMs);
     sleep(delay)
       .then(() => {
         const logCtx = {slot: blockInput.slot, root: blockInput.blockRootHex};

--- a/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
+++ b/packages/beacon-node/src/chain/ColumnReconstructionTracker.ts
@@ -6,14 +6,12 @@ import {BlockInputColumns} from "./blocks/blockInput/index.js";
 import {ChainEventEmitter} from "./emitter.js";
 
 /**
- * Minimum delay before attempting reconstruction in basis points (BPS) of slot duration.
- * 667 BPS = 6.67% of slot. For a 12s slot, this equates to ~800ms.
+ * Minimum time to wait before attempting reconstruction
  */
 const RECONSTRUCTION_DELAY_MIN_BPS = 667;
 
 /**
- * Maximum delay before attempting reconstruction in basis points (BPS) of slot duration.
- * 1000 BPS = 10% of slot. For a 12s slot, this equates to 1200ms.
+ * Maximum time to wait before attempting reconstruction
  */
 const RECONSTRUCTION_DELAY_MAX_BPS = 1000;
 


### PR DESCRIPTION
## Description

Makes the column reconstruction delay constants relative to slot duration instead of hardcoded milliseconds. This ensures proper timing on networks with different slot durations.

### Problem

The current implementation uses hardcoded values:
- `RECONSTRUCTION_DELAY_MIN_MS = 800`
- `RECONSTRUCTION_DELAY_MAX_MS = 1200`

These are based on 12s mainnet slots and don't scale properly for:
- Gnosis Chain (5s slots)
- Devnets with custom slot times
- Future forks with shorter slots

### Solution

Use ratios of slot duration instead:
- `RECONSTRUCTION_DELAY_MIN_RATIO = 1/15` (~6.67% of slot)
- `RECONSTRUCTION_DELAY_MAX_RATIO = 1/10` (10% of slot)

This maintains the same 800-1200ms delay for 12s slots while automatically adapting for other networks:
- 5s slots (Gnosis): ~333-500ms
- 6s slots: ~400-600ms

Closes #8569

---

*This PR was authored with AI assistance (lodekeeper using Claude Opus 4).*