### PR TITLE
fix(network): handle invalid peer public key in onLibp2pPeerConnect

### DIFF
--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -724,7 +724,10 @@ export class PeerManager {
 
     // Ethereum uses secp256k1 for node IDs, reject peers with other key types
     if (remotePeer.type !== "secp256k1") {
-      this.logger.debug("Peer does not have secp256k1 key, disconnecting", {peer: remotePeerPrettyStr, type: remotePeer.type});
+      this.logger.debug("Peer does not have secp256k1 key, disconnecting", {
+        peer: remotePeerPrettyStr,
+        type: remotePeer.type,
+      });
       void this.goodbyeAndDisconnect(remotePeer, GoodByeReasonCode.IRRELEVANT_NETWORK);
       return;
     }

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -722,15 +722,14 @@ export class PeerManager {
     // If that happens, it's okay. Only the "outbound" connection triggers immediate action
     const now = Date.now();
 
-    let nodeId: Uint8Array;
-    try {
-      nodeId = computeNodeId(remotePeer);
-    } catch (e) {
-      // Can happen if peer has invalid/malformed public key
-      this.logger.debug("Failed to compute nodeId for peer, disconnecting", {peer: remotePeerPrettyStr}, e as Error);
-      void this.goodbyeAndDisconnect(remotePeer, GoodByeReasonCode.ERROR);
+    // Ethereum uses secp256k1 for node IDs, reject peers with other key types
+    if (remotePeer.type !== "secp256k1") {
+      this.logger.debug("Peer does not have secp256k1 key, disconnecting", {peer: remotePeerPrettyStr, type: remotePeer.type});
+      void this.goodbyeAndDisconnect(remotePeer, GoodByeReasonCode.IRRELEVANT_NETWORK);
       return;
     }
+
+    const nodeId = computeNodeId(remotePeer);
     const peerData: PeerData = {
       lastReceivedMsgUnixTsMs: direction === "outbound" ? 0 : now,
       // If inbound, request after STATUS_INBOUND_GRACE_PERIOD

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -721,7 +721,16 @@ export class PeerManager {
     // NOTE: libp2p may emit two "peer:connect" events: One for inbound, one for outbound
     // If that happens, it's okay. Only the "outbound" connection triggers immediate action
     const now = Date.now();
-    const nodeId = computeNodeId(remotePeer);
+
+    let nodeId: Uint8Array;
+    try {
+      nodeId = computeNodeId(remotePeer);
+    } catch (e) {
+      // Can happen if peer has invalid/malformed public key
+      this.logger.debug("Failed to compute nodeId for peer, disconnecting", {peer: remotePeerPrettyStr}, e as Error);
+      void this.goodbyeAndDisconnect(remotePeer, GoodByeReasonCode.ERROR);
+      return;
+    }
     const peerData: PeerData = {
       lastReceivedMsgUnixTsMs: direction === "outbound" ? 0 : now,
       // If inbound, request after STATUS_INBOUND_GRACE_PERIOD


### PR DESCRIPTION
## Description

Fixes an uncaughtException crash when connecting to a peer with a malformed public key.

### Error

```
uncaughtException: Point of length 294 was invalid. Expected 33 compressed bytes or 65 uncompressed bytes
    at fromBytes (node_modules/@noble/curves/esm/abstract/weierstrass.js:594:23)
    at uncompressPublicKey (node_modules/@chainsafe/enr/lib/defaultCrypto.js:17:38)
    at computeNodeId (packages/beacon-node/lib/network/subnets/interface.js:12:37)
    at PeerManager.onLibp2pPeerConnect (packages/beacon-node/lib/network/peers/peerManager.js:117:28)
```

### Fix

Wrap `computeNodeId(remotePeer)` in a try-catch. If computing the node ID fails (due to invalid public key), log at debug level and disconnect the peer gracefully with a GOODBYE.

### Notes

This is a defensive fix - we shouldn't crash the node because one peer has malformed crypto data. The peer is simply disconnected.

Closes #8302

---

*This PR was authored with AI assistance (lodekeeper using Claude Opus 4).*