### PR TITLE
perf: avoid closure allocation in setTimeout/setInterval calls

### DIFF
--- a/packages/api/src/utils/client/httpClient.ts
+++ b/packages/api/src/utils/client/httpClient.ts
@@ -350,15 +350,20 @@ export class HttpClient implements IHttpClient {
   ): Promise<ApiResponse<E>> {
     const abortSignals = [this.signal, init.signal];
 
-    // Implement fetch timeout
+    // Avoid closure allocation: use .bind() instead of arrow function.
+    // Arrow functions capture the surrounding scope (request body, etc.),
+    // which prevents GC when user passes a long-lived AbortSignal.
+    // Using .bind() only retains a reference to the controller itself.
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), init.timeoutMs);
+    const abort = controller.abort.bind(controller);
+    const timeout = setTimeout(abort, init.timeoutMs);
     init.signal = controller.signal;
 
     // Attach global/local signal to this request's controller
-    const onSignalAbort = (): void => controller.abort();
+    // Note: We wrap abort() to avoid passing the Event as abort reason
+    const onAbort = (): void => abort();
     for (const s of abortSignals) {
-      s?.addEventListener("abort", onSignalAbort);
+      s?.addEventListener("abort", onAbort, {once: true});
     }
 
     const routeId = definition.operationId;
@@ -408,7 +413,7 @@ export class HttpClient implements IHttpClient {
 
       clearTimeout(timeout);
       for (const s of abortSignals) {
-        s?.removeEventListener("abort", onSignalAbort);
+        s?.removeEventListener("abort", onAbort);
       }
     }
   }

--- a/packages/beacon-node/src/execution/engine/jsonRpcHttpClient.ts
+++ b/packages/beacon-node/src/execution/engine/jsonRpcHttpClient.ts
@@ -238,11 +238,16 @@ export class JsonRpcHttpClient implements IJsonRpcHttpClient {
    * Fetches JSON and throws detailed errors in case the HTTP request is not ok
    */
   private async fetchJsonOneUrl<R, T = unknown>(url: string, json: T, opts?: ReqOpts): Promise<R> {
+    // Avoid closure allocation: use .bind() instead of arrow function.
+    // Arrow functions capture the surrounding scope (request body, etc.),
+    // which prevents GC when user passes a long-lived AbortSignal.
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), opts?.timeout ?? this.opts?.timeout ?? REQUEST_TIMEOUT);
+    const abort = controller.abort.bind(controller);
+    const timeout = setTimeout(abort, opts?.timeout ?? this.opts?.timeout ?? REQUEST_TIMEOUT);
 
-    const onParentSignalAbort = (): void => controller.abort();
-    this.opts?.signal?.addEventListener("abort", onParentSignalAbort, {once: true});
+    // Wrap abort() to avoid passing the Event as abort reason
+    const onAbort = (): void => abort();
+    this.opts?.signal?.addEventListener("abort", onAbort, {once: true});
 
     // Default to "unknown" to prevent mixing metrics with others.
     const routeId = opts?.routeId ?? "unknown";
@@ -304,7 +309,7 @@ export class JsonRpcHttpClient implements IJsonRpcHttpClient {
       this.metrics?.activeRequests.dec({routeId}, 1);
 
       clearTimeout(timeout);
-      this.opts?.signal?.removeEventListener("abort", onParentSignalAbort);
+      this.opts?.signal?.removeEventListener("abort", onAbort);
     }
   }
 }

--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -163,9 +163,8 @@ export class AttnetsService implements IAttnetsService {
    */
   private onSlot = (clockSlot: Slot): void => {
     try {
-      setTimeout(() => {
-        this.onHalfSlot(clockSlot);
-      }, this.config.SLOT_DURATION_MS * 0.5);
+      // Use setTimeout's argument passing to avoid closure allocation
+      setTimeout(this.onHalfSlot, this.config.SLOT_DURATION_MS * 0.5, clockSlot);
 
       for (const [dutiedSlot, dutiedInfo] of this.aggregatorSlotSubnet.entries()) {
         if (dutiedSlot === clockSlot + this.opts.slotsToSubscribeBeforeAggregatorDuty) {

--- a/packages/logger/src/browser.ts
+++ b/packages/logger/src/browser.ts
@@ -35,6 +35,11 @@ export function getBrowserLogger(opts: BrowserLoggerOpts): Logger {
   );
 }
 
+/** Static helper to emit logged event - avoids closure allocation in setTimeout */
+function emitLogged(transport: BrowserConsole, info: WinstonLogInfo): void {
+  transport.emit("logged", info);
+}
+
 class BrowserConsole extends Transport {
   name = "BrowserConsole";
   private levels: Record<LogLevel, number> = {
@@ -61,9 +66,8 @@ class BrowserConsole extends Transport {
   }
 
   log(info: WinstonLogInfo, callback: () => void): void {
-    setTimeout(() => {
-      this.emit("logged", info);
-    }, 0);
+    // Use static helper with setTimeout arg passing to avoid closure allocation
+    setTimeout(emitLogged, 0, this, info);
 
     const val = this.levels[info[LEVEL]];
     const mappedMethod = this.methods[info[LEVEL]];

--- a/packages/reqresp/src/request/index.ts
+++ b/packages/reqresp/src/request/index.ts
@@ -19,6 +19,30 @@ export const DEFAULT_REQUEST_TIMEOUT = 5 * 1000; // 5 sec
 export const DEFAULT_TTFB_TIMEOUT = 5 * 1000; // 5 sec
 export const DEFAULT_RESP_TIMEOUT = 10 * 1000; // 10 sec
 
+/** State object for timeout handling - avoids closure allocations */
+interface TimeoutState {
+  timeoutRESP: NodeJS.Timeout | null;
+  respTimeoutController: AbortController;
+  RESP_TIMEOUT: number;
+}
+
+/** Static helper for TTFB timeout - avoids closure allocation */
+function handleTTFBTimeout(state: TimeoutState, ttfbTimeoutController: AbortController): void {
+  if (state.timeoutRESP) clearTimeout(state.timeoutRESP);
+  ttfbTimeoutController.abort();
+}
+
+/** Static helper for RESP timeout - avoids closure allocation */
+function handleRespTimeout(state: TimeoutState): void {
+  state.respTimeoutController.abort();
+}
+
+/** Restart response timeout - uses static helpers to avoid closures */
+function restartRespTimeout(state: TimeoutState): void {
+  if (state.timeoutRESP) clearTimeout(state.timeoutRESP);
+  state.timeoutRESP = setTimeout(handleRespTimeout, state.RESP_TIMEOUT, state);
+}
+
 export interface SendRequestOpts {
   /** The maximum time for complete response transfer. */
   respTimeoutMs?: number;
@@ -157,18 +181,15 @@ export async function* sendRequest(
     const ttfbTimeoutController = new AbortController();
     const respTimeoutController = new AbortController();
 
-    let timeoutRESP: NodeJS.Timeout | null = null;
-
-    const timeoutTTFB = setTimeout(() => {
-      // If we abort on first byte delay, don't need to abort for response delay
-      if (timeoutRESP) clearTimeout(timeoutRESP);
-      ttfbTimeoutController.abort();
-    }, TTFB_TIMEOUT);
-
-    const restartRespTimeout = (): void => {
-      if (timeoutRESP) clearTimeout(timeoutRESP);
-      timeoutRESP = setTimeout(() => respTimeoutController.abort(), RESP_TIMEOUT);
+    // State object for timeout handling - avoids closure allocations on each chunk
+    const timeoutState: TimeoutState = {
+      timeoutRESP: null,
+      respTimeoutController,
+      RESP_TIMEOUT,
     };
+
+    // Use static helpers with setTimeout arg passing to avoid closure allocation
+    const timeoutTTFB = setTimeout(handleTTFBTimeout, TTFB_TIMEOUT, timeoutState, ttfbTimeoutController);
 
     try {
       // Note: libp2p.stop() will close all connections, so not necessary to abort this pipe on parent stop
@@ -190,11 +211,11 @@ export async function* sendRequest(
             // On first byte, cancel the single use TTFB_TIMEOUT, and start RESP_TIMEOUT
             clearTimeout(timeoutTTFB);
             timerTTFB?.();
-            restartRespTimeout();
+            restartRespTimeout(timeoutState);
           },
           onFirstResponseChunk() {
             // On <response_chunk>, cancel this chunk's RESP_TIMEOUT and start next's
-            restartRespTimeout();
+            restartRespTimeout(timeoutState);
           },
         })
       );
@@ -205,7 +226,7 @@ export async function* sendRequest(
       logger.verbose("Req  done", logCtx);
     } finally {
       clearTimeout(timeoutTTFB);
-      if (timeoutRESP !== null) clearTimeout(timeoutRESP);
+      if (timeoutState.timeoutRESP !== null) clearTimeout(timeoutState.timeoutRESP);
 
       // Necessary to call `stream.close()` since collectResponses() may break out of the source before exhausting it
       // `stream.close()` libp2p-mplex will .end() the source (it-pushable instance)


### PR DESCRIPTION
## Description

Use setTimeout's built-in argument passing and `.bind()` pattern to avoid closure allocation, following the pattern from [anthropics/anthropic-sdk-typescript#895](https://github.com/anthropics/anthropic-sdk-typescript/pull/895).

**Key insight:** Arrow functions capture the surrounding scope (request body, etc.), which prevents GC when user passes a long-lived AbortSignal. Using `.bind()` only retains a reference to the controller itself.

```ts
// Before: creates closure per call, captures large request body
setTimeout(() => controller.abort(), delay);
signal.addEventListener('abort', () => controller.abort());

// After: bind() once, reuse - only captures controller reference
const abort = controller.abort.bind(controller);
setTimeout(abort, delay);
signal.addEventListener('abort', () => abort(), {once: true});
```

Note: Event listeners need a wrapper to avoid passing the Event as the abort reason.

## Changes

- **api/httpClient**: Use `abort.bind(controller)` for setTimeout, wrap for addEventListener
- **beacon-node/jsonRpcHttpClient**: Same pattern
- **beacon-node/attnetsService**: Use direct method reference with arg passing
- **reqresp/request**: Use state object pattern for timeout handling (hot path - called per response chunk)
- **logger/browser**: Use static `emitLogged` helper

## Impact

Medium. The most impactful changes are in HTTP clients (per request) and reqresp where `restartRespTimeout` is called on each response chunk during P2P streaming.

---

🤖 Generated with AI assistance