### PR TITLE
chore: avoid passing CachedBeaconStateGloas to state-transition apis from beacon-node

### DIFF
--- a/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
+++ b/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
@@ -89,7 +89,7 @@ async function validatePayloadAttestationMessage(
   // [REJECT] `payload_attestation_message.signature` is valid with respect to the validator's public key.
   const signatureSet = createSingleSignatureSetFromComponents(
     chain.index2pubkey[validatorIndex],
-    getPayloadAttestationDataSigningRoot(state, data),
+    getPayloadAttestationDataSigningRoot(chain.config, state.slot, data),
     payloadAttestationMessage.signature
   );
 

--- a/packages/state-transition/src/block/processExecutionPayloadBid.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadBid.ts
@@ -28,7 +28,7 @@ export function processExecutionPayloadBid(state: CachedBeaconStateGloas, block:
     const builder = state.builders.getReadonly(builderIndex);
 
     // Verify that the builder is active
-    if (!isActiveBuilder(state, builderIndex)) {
+    if (!isActiveBuilder(builder, state.finalizedCheckpoint.epoch)) {
       throw Error(`Invalid execution payload bid: builder ${builderIndex} is not active`);
     }
 
@@ -85,7 +85,7 @@ function verifyExecutionPayloadBidSignature(
   pubkey: Uint8Array,
   signedBid: gloas.SignedExecutionPayloadBid
 ): boolean {
-  const signingRoot = getExecutionPayloadBidSigningRoot(state.config, state, signedBid.message);
+  const signingRoot = getExecutionPayloadBidSigningRoot(state.config, state.slot, signedBid.message);
 
   try {
     const publicKey = PublicKey.fromBytes(pubkey);

--- a/packages/state-transition/src/block/processVoluntaryExit.ts
+++ b/packages/state-transition/src/block/processVoluntaryExit.ts
@@ -49,7 +49,7 @@ export function processVoluntaryExit(
     const builder = stateGloas.builders.getReadonly(builderIndex);
 
     // Verify the builder is active
-    if (!isActiveBuilder(stateGloas, builderIndex)) {
+    if (!isActiveBuilder(builder, state.finalizedCheckpoint.epoch)) {
       throw Error(`Builder ${builderIndex} is not active`);
     }
 

--- a/packages/state-transition/src/signatureSets/executionPayloadBid.ts
+++ b/packages/state-transition/src/signatureSets/executionPayloadBid.ts
@@ -1,15 +1,14 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_BUILDER} from "@lodestar/params";
-import {gloas, ssz} from "@lodestar/types";
-import {CachedBeaconStateGloas} from "../types.js";
+import {Slot, gloas, ssz} from "@lodestar/types";
 import {computeSigningRoot} from "../util/index.js";
 
 export function getExecutionPayloadBidSigningRoot(
   config: BeaconConfig,
-  state: CachedBeaconStateGloas,
+  stateSlot: Slot,
   bid: gloas.ExecutionPayloadBid
 ): Uint8Array {
-  const domain = config.getDomain(state.slot, DOMAIN_BEACON_BUILDER);
+  const domain = config.getDomain(stateSlot, DOMAIN_BEACON_BUILDER);
 
   return computeSigningRoot(ssz.gloas.ExecutionPayloadBid, bid, domain);
 }

--- a/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
@@ -9,7 +9,7 @@ export function getIndexedPayloadAttestationSignatureSet(
   indexedPayloadAttestation: gloas.IndexedPayloadAttestation
 ): ISignatureSet {
   return createAggregateSignatureSetFromComponents(
-    indexedPayloadAttestation.attestingIndices.map((i) => state.epochCtx.index2pubkey[i]),
+    indexedPayloadAttestation.attestingIndices,
     getPayloadAttestationDataSigningRoot(state.config, state.slot, indexedPayloadAttestation.data),
     indexedPayloadAttestation.signature
   );

--- a/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
@@ -1,5 +1,6 @@
+import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_PTC_ATTESTER} from "@lodestar/params";
-import {gloas, ssz} from "@lodestar/types";
+import {Slot, gloas, ssz} from "@lodestar/types";
 import {CachedBeaconStateGloas} from "../types.js";
 import {ISignatureSet, computeSigningRoot, createAggregateSignatureSetFromComponents} from "../util/index.js";
 
@@ -9,16 +10,17 @@ export function getIndexedPayloadAttestationSignatureSet(
 ): ISignatureSet {
   return createAggregateSignatureSetFromComponents(
     indexedPayloadAttestation.attestingIndices.map((i) => state.epochCtx.index2pubkey[i]),
-    getPayloadAttestationDataSigningRoot(state, indexedPayloadAttestation.data),
+    getPayloadAttestationDataSigningRoot(state.config, state.slot, indexedPayloadAttestation.data),
     indexedPayloadAttestation.signature
   );
 }
 
 export function getPayloadAttestationDataSigningRoot(
-  state: CachedBeaconStateGloas,
+  config: BeaconConfig,
+  stateSlot: Slot,
   data: gloas.PayloadAttestationData
 ): Uint8Array {
-  const domain = state.config.getDomain(state.slot, DOMAIN_PTC_ATTESTER);
+  const domain = config.getDomain(stateSlot, DOMAIN_PTC_ATTESTER);
 
   return computeSigningRoot(ssz.gloas.PayloadAttestationData, data, domain);
 }

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -9,7 +9,7 @@ import {
   MIN_DEPOSIT_AMOUNT,
   SLOTS_PER_EPOCH,
 } from "@lodestar/params";
-import {BuilderIndex, ValidatorIndex} from "@lodestar/types";
+import {BuilderIndex, Epoch, ValidatorIndex, gloas} from "@lodestar/types";
 import {AttestationData} from "@lodestar/types/phase0";
 import {CachedBeaconStateGloas} from "../types.js";
 import {getBlockRootAtSlot} from "./blockRoot.js";
@@ -56,10 +56,7 @@ export function convertValidatorIndexToBuilderIndex(validatorIndex: ValidatorInd
  * Check if a builder is active (deposited and not yet withdrawable).
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#isactivebuilder
  */
-export function isActiveBuilder(state: CachedBeaconStateGloas, builderIndex: BuilderIndex): boolean {
-  const builder = state.builders.getReadonly(builderIndex);
-  const finalizedEpoch = state.finalizedCheckpoint.epoch;
-
+export function isActiveBuilder(builder: gloas.Builder, finalizedEpoch: Epoch): boolean {
   return builder.depositEpoch < finalizedEpoch && builder.withdrawableEpoch === FAR_FUTURE_EPOCH;
 }
 

--- a/packages/types/src/gloas/types.ts
+++ b/packages/types/src/gloas/types.ts
@@ -1,6 +1,7 @@
 import {ValueOf} from "@chainsafe/ssz";
 import * as ssz from "./sszTypes.js";
 
+export type Builder = ValueOf<typeof ssz.Builder>;
 export type BuilderPendingWithdrawal = ValueOf<typeof ssz.BuilderPendingWithdrawal>;
 export type BuilderPendingPayment = ValueOf<typeof ssz.BuilderPendingPayment>;
 export type PayloadAttestationData = ValueOf<typeof ssz.PayloadAttestationData>;


### PR DESCRIPTION
**Motivation**

- decouple beacon-node and state-transition
- to prepare for BeaconStateView change

**Description**

- avoid using `CachedBeaconStateGloas` in state-transition apis

part of #8650

see also the old similar work #8720