### PR TITLE
fix: align with signature set refactor from #8803

### DIFF
--- a/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
@@ -9,7 +9,7 @@ export function getIndexedPayloadAttestationSignatureSet(
   indexedPayloadAttestation: gloas.IndexedPayloadAttestation
 ): ISignatureSet {
   return createAggregateSignatureSetFromComponents(
-    indexedPayloadAttestation.attestingIndices.map((i) => state.epochCtx.index2pubkey[i]),
+    indexedPayloadAttestation.attestingIndices,
     getPayloadAttestationDataSigningRoot(state.config, state.slot, indexedPayloadAttestation.data),
     indexedPayloadAttestation.signature
   );


### PR DESCRIPTION
Updates `indexedPayloadAttestation.attestingIndices` usage to match the signature set refactor merged in #8803.

This resolves merge conflicts when merging to unstable.