### PR TITLE
feat: update to spec v1.7.0-alpha.2

### DIFF
--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -7,7 +7,7 @@ import {
   isForkPostFulu,
   isForkPostGloas,
 } from "@lodestar/params";
-import {SignedBeaconBlock, Slot, deneb, fulu, phase0} from "@lodestar/types";
+import {SignedBeaconBlock, Slot, deneb, fulu, gloas, phase0} from "@lodestar/types";
 import {LodestarError, Logger, fromHex, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {
   BlockInputSource,
@@ -696,9 +696,9 @@ export async function validateColumnsByRangeResponse(
       });
     }
     if (isForkPostGloas(forkName)) {
-      // TODO GLOAS: Post-gloas's blobKzgCommitments is not in beacon block body. Need to source it from somewhere else.
-      // if block without columns is passed default to zero and throw below
-      blobCount = 0;
+      // For GLOAS+, commitments are in the execution payload bid
+      blobCount = (block as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message.blobKzgCommitments
+        .length;
     } else {
       blobCount = (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body.blobKzgCommitments.length;
     }

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -20,6 +20,7 @@ import {SeenBlockInput} from "../../chain/seenCache/seenGossipBlockInput.js";
 import {validateBlockBlobSidecars} from "../../chain/validation/blobSidecar.js";
 import {validateBlockDataColumnSidecars} from "../../chain/validation/dataColumnSidecar.js";
 import {INetwork} from "../../network/index.js";
+import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {WarnResult} from "../../util/wrapError.js";
 
@@ -695,13 +696,7 @@ export async function validateColumnsByRangeResponse(
         dataFork: dataSlot ? config.getForkName(dataSlot) : "unknown",
       });
     }
-    if (isForkPostGloas(forkName)) {
-      // For GLOAS+, commitments are in the execution payload bid
-      blobCount = (block as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message.blobKzgCommitments
-        .length;
-    } else {
-      blobCount = (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body.blobKzgCommitments.length;
-    }
+    blobCount = getBlobKzgCommitments(forkName, block as SignedBeaconBlock<ForkPostFulu>).length;
 
     if (columnSidecars.length === 0) {
       if (!blobCount) {

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -1,13 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {
-  ForkPostDeneb,
-  ForkPostFulu,
-  ForkPreFulu,
-  ForkPreGloas,
-  isForkPostFulu,
-  isForkPostGloas,
-} from "@lodestar/params";
-import {SignedBeaconBlock, Slot, deneb, fulu, gloas, phase0} from "@lodestar/types";
+import {ForkPostDeneb, ForkPostFulu, ForkPreFulu, isForkPostFulu} from "@lodestar/params";
+import {SignedBeaconBlock, Slot, deneb, fulu, phase0} from "@lodestar/types";
 import {LodestarError, Logger, fromHex, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {
   BlockInputSource,
@@ -20,6 +13,7 @@ import {SeenBlockInput} from "../../chain/seenCache/seenGossipBlockInput.js";
 import {validateBlockBlobSidecars} from "../../chain/validation/blobSidecar.js";
 import {validateBlockDataColumnSidecars} from "../../chain/validation/dataColumnSidecar.js";
 import {INetwork} from "../../network/index.js";
+import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {WarnResult} from "../../util/wrapError.js";
 
@@ -695,9 +689,7 @@ export async function validateColumnsByRangeResponse(
         dataFork: dataSlot ? config.getForkName(dataSlot) : "unknown",
       });
     }
-    blobCount = isForkPostGloas(forkName)
-      ? (block as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message.blobKzgCommitments.length
-      : (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body.blobKzgCommitments.length;
+    blobCount = getBlobKzgCommitments(forkName, block as SignedBeaconBlock<ForkPostFulu>).length;
 
     if (columnSidecars.length === 0) {
       if (!blobCount) {

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -20,7 +20,6 @@ import {SeenBlockInput} from "../../chain/seenCache/seenGossipBlockInput.js";
 import {validateBlockBlobSidecars} from "../../chain/validation/blobSidecar.js";
 import {validateBlockDataColumnSidecars} from "../../chain/validation/dataColumnSidecar.js";
 import {INetwork} from "../../network/index.js";
-import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {WarnResult} from "../../util/wrapError.js";
 
@@ -696,7 +695,9 @@ export async function validateColumnsByRangeResponse(
         dataFork: dataSlot ? config.getForkName(dataSlot) : "unknown",
       });
     }
-    blobCount = getBlobKzgCommitments(forkName, block as SignedBeaconBlock<ForkPostFulu>).length;
+    blobCount = isForkPostGloas(forkName)
+      ? (block as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message.blobKzgCommitments.length
+      : (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body.blobKzgCommitments.length;
 
     if (columnSidecars.length === 0) {
       if (!blobCount) {

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -7,8 +7,9 @@ import {
   ForkPreGloas,
   isForkPostDeneb,
   isForkPostFulu,
+  isForkPostGloas,
 } from "@lodestar/params";
-import {BeaconBlockBody, BlobIndex, ColumnIndex, SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
+import {BeaconBlockBody, BlobIndex, ColumnIndex, SignedBeaconBlock, Slot, deneb, fulu, gloas} from "@lodestar/types";
 import {LodestarError, fromHex, prettyPrintIndices, toHex, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource, IBlockInput} from "../../chain/blocks/blockInput/types.js";
@@ -379,14 +380,17 @@ export async function fetchAndValidateColumns({
   chain,
   network,
   peerMeta,
+  forkName,
   block,
   blockRoot,
   missing,
 }: FetchByRootAndValidateColumnsProps): Promise<WarnResult<fulu.DataColumnSidecars, DownloadByRootError>> {
   const {peerId: peerIdStr} = peerMeta;
   const slot = block.message.slot;
-  // TODO GLOAS: Get blob count from somewhere else since blobKzgCommitments is absent from block body
-  const blobCount = (block.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments.length;
+  // For GLOAS+, commitments are in the execution payload bid
+  const blobCount = isForkPostGloas(forkName)
+    ? (block as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message.blobKzgCommitments.length
+    : (block.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments.length;
   if (blobCount === 0) {
     return {result: [], warnings: null};
   }

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -18,7 +18,6 @@ import {IBeaconChain} from "../../chain/interface.ts";
 import {validateBlockBlobSidecars} from "../../chain/validation/blobSidecar.js";
 import {validateBlockDataColumnSidecars} from "../../chain/validation/dataColumnSidecar.js";
 import {INetwork} from "../../network/interface.js";
-import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
 import {prettyPrintPeerIdStr} from "../../network/util.js";
 import {byteArrayEquals} from "../../util/bytes.js";
@@ -388,7 +387,9 @@ export async function fetchAndValidateColumns({
 }: FetchByRootAndValidateColumnsProps): Promise<WarnResult<fulu.DataColumnSidecars, DownloadByRootError>> {
   const {peerId: peerIdStr} = peerMeta;
   const slot = block.message.slot;
-  const blobCount = getBlobKzgCommitments(forkName, block).length;
+  const blobCount = isForkPostGloas(forkName)
+    ? (block as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message.blobKzgCommitments.length
+    : (block.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments.length;
   if (blobCount === 0) {
     return {result: [], warnings: null};
   }

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -1,15 +1,7 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {
-  ForkPostDeneb,
-  ForkPostFulu,
-  ForkPreFulu,
-  ForkPreGloas,
-  isForkPostDeneb,
-  isForkPostFulu,
-  isForkPostGloas,
-} from "@lodestar/params";
-import {BeaconBlockBody, BlobIndex, ColumnIndex, SignedBeaconBlock, Slot, deneb, fulu, gloas} from "@lodestar/types";
+import {ForkPostDeneb, ForkPostFulu, ForkPreFulu, isForkPostDeneb, isForkPostFulu} from "@lodestar/params";
+import {BlobIndex, ColumnIndex, SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
 import {LodestarError, fromHex, prettyPrintIndices, toHex, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource, IBlockInput} from "../../chain/blocks/blockInput/types.js";
@@ -21,6 +13,7 @@ import {INetwork} from "../../network/interface.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
 import {prettyPrintPeerIdStr} from "../../network/util.js";
 import {byteArrayEquals} from "../../util/bytes.js";
+import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {WarnResult} from "../../util/wrapError.js";
 import {
@@ -387,9 +380,7 @@ export async function fetchAndValidateColumns({
 }: FetchByRootAndValidateColumnsProps): Promise<WarnResult<fulu.DataColumnSidecars, DownloadByRootError>> {
   const {peerId: peerIdStr} = peerMeta;
   const slot = block.message.slot;
-  const blobCount = isForkPostGloas(forkName)
-    ? (block as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message.blobKzgCommitments.length
-    : (block.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments.length;
+  const blobCount = getBlobKzgCommitments(forkName, block).length;
   if (blobCount === 0) {
     return {result: [], warnings: null};
   }

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -18,6 +18,7 @@ import {IBeaconChain} from "../../chain/interface.ts";
 import {validateBlockBlobSidecars} from "../../chain/validation/blobSidecar.js";
 import {validateBlockDataColumnSidecars} from "../../chain/validation/dataColumnSidecar.js";
 import {INetwork} from "../../network/interface.js";
+import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
 import {prettyPrintPeerIdStr} from "../../network/util.js";
 import {byteArrayEquals} from "../../util/bytes.js";
@@ -387,10 +388,7 @@ export async function fetchAndValidateColumns({
 }: FetchByRootAndValidateColumnsProps): Promise<WarnResult<fulu.DataColumnSidecars, DownloadByRootError>> {
   const {peerId: peerIdStr} = peerMeta;
   const slot = block.message.slot;
-  // For GLOAS+, commitments are in the execution payload bid
-  const blobCount = isForkPostGloas(forkName)
-    ? (block as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message.blobKzgCommitments.length
-    : (block.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments.length;
+  const blobCount = getBlobKzgCommitments(forkName, block).length;
   if (blobCount === 0) {
     return {result: [], warnings: null};
   }

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -32,22 +32,6 @@ import {NodeId} from "../network/subnets/index.js";
 import {dataColumnMatrixRecovery} from "./blobs.js";
 import {kzg} from "./kzg.js";
 
-/**
- * Get blob KZG commitments from a block, handling fork differences.
- * Pre-GLOAS: commitments are in block.body.blobKzgCommitments
- * GLOAS+: commitments are in block.body.signedExecutionPayloadBid.message.blobKzgCommitments
- */
-export function getBlobKzgCommitments(
-  fork: ForkName,
-  block: SignedBeaconBlock<ForkPostFulu>
-): deneb.KZGCommitment[] {
-  if (isForkPostGloas(fork)) {
-    return (block as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message
-      .blobKzgCommitments as deneb.KZGCommitment[];
-  }
-  return (block.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments;
-}
-
 export enum RecoverResult {
   // the recover is not attempted because we have less than `NUMBER_OF_COLUMNS / 2` columns
   NotAttemptedLessThanHalf = "not_attempted_less_than_half",
@@ -329,7 +313,9 @@ export function getDataColumnSidecarsFromBlock(
   cellsAndKzgProofs: {cells: Uint8Array[]; proofs: Uint8Array[]}[]
 ): fulu.DataColumnSidecars {
   const fork = config.getForkName(signedBlock.message.slot);
-  const blobKzgCommitments = getBlobKzgCommitments(fork, signedBlock);
+  const blobKzgCommitments = isForkPostGloas(fork)
+    ? (signedBlock as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message.blobKzgCommitments
+    : (signedBlock.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments;
 
   // No need to create data column sidecars if there are no blobs
   if (blobKzgCommitments.length === 0) {

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -301,6 +301,20 @@ export function getDataColumnSidecars(
 }
 
 /**
+ * Get blob KZG commitments from a signed block, handling the different locations
+ * in pre-Gloas (directly in block body) vs post-Gloas (in execution payload bid).
+ */
+export function getBlobKzgCommitments(
+  fork: ForkName,
+  signedBlock: SignedBeaconBlock<ForkPostFulu>
+): deneb.KZGCommitment[] {
+  if (isForkPostGloas(fork)) {
+    return (signedBlock as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message.blobKzgCommitments;
+  }
+  return (signedBlock.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments;
+}
+
+/**
  * Given a signed block and the cells/proofs associated with each blob in the
  * block, assemble the sidecars which can be distributed to peers.
  *
@@ -313,9 +327,7 @@ export function getDataColumnSidecarsFromBlock(
   cellsAndKzgProofs: {cells: Uint8Array[]; proofs: Uint8Array[]}[]
 ): fulu.DataColumnSidecars {
   const fork = config.getForkName(signedBlock.message.slot);
-  const blobKzgCommitments = isForkPostGloas(fork)
-    ? (signedBlock as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message.blobKzgCommitments
-    : (signedBlock.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments;
+  const blobKzgCommitments = getBlobKzgCommitments(fork, signedBlock);
 
   // No need to create data column sidecars if there are no blobs
   if (blobKzgCommitments.length === 0) {

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -32,6 +32,22 @@ import {NodeId} from "../network/subnets/index.js";
 import {dataColumnMatrixRecovery} from "./blobs.js";
 import {kzg} from "./kzg.js";
 
+/**
+ * Get blob KZG commitments from a block, handling fork differences.
+ * Pre-GLOAS: commitments are in block.body.blobKzgCommitments
+ * GLOAS+: commitments are in block.body.signedExecutionPayloadBid.message.blobKzgCommitments
+ */
+export function getBlobKzgCommitments(
+  fork: ForkName,
+  block: SignedBeaconBlock<ForkPostFulu>
+): deneb.KZGCommitment[] {
+  if (isForkPostGloas(fork)) {
+    return (block as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message
+      .blobKzgCommitments as deneb.KZGCommitment[];
+  }
+  return (block.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments;
+}
+
 export enum RecoverResult {
   // the recover is not attempted because we have less than `NUMBER_OF_COLUMNS / 2` columns
   NotAttemptedLessThanHalf = "not_attempted_less_than_half",
@@ -313,12 +329,7 @@ export function getDataColumnSidecarsFromBlock(
   cellsAndKzgProofs: {cells: Uint8Array[]; proofs: Uint8Array[]}[]
 ): fulu.DataColumnSidecars {
   const fork = config.getForkName(signedBlock.message.slot);
-
-  // For GLOAS+, commitments are in the execution payload bid
-  // For pre-GLOAS (Fulu), commitments are in the block body
-  const blobKzgCommitments = isForkPostGloas(fork)
-    ? (signedBlock.message.body as gloas.BeaconBlockBody).signedExecutionPayloadBid.message.blobKzgCommitments
-    : (signedBlock.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments;
+  const blobKzgCommitments = getBlobKzgCommitments(fork, signedBlock);
 
   // No need to create data column sidecars if there are no blobs
   if (blobKzgCommitments.length === 0) {

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -5,7 +5,6 @@ import {
   ForkAll,
   ForkName,
   ForkPostFulu,
-  ForkPostGloas,
   ForkPreGloas,
   KZG_COMMITMENTS_GINDEX,
   NUMBER_OF_COLUMNS,

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -5,9 +5,11 @@ import {
   ForkAll,
   ForkName,
   ForkPostFulu,
+  ForkPostGloas,
   ForkPreGloas,
   KZG_COMMITMENTS_GINDEX,
   NUMBER_OF_COLUMNS,
+  isForkPostGloas,
 } from "@lodestar/params";
 import {signedBlockToSignedHeader} from "@lodestar/state-transition";
 import {
@@ -19,6 +21,7 @@ import {
   SignedBeaconBlockHeader,
   deneb,
   fulu,
+  gloas,
   ssz,
 } from "@lodestar/types";
 import {bytesToBigInt} from "@lodestar/utils";
@@ -310,16 +313,19 @@ export function getDataColumnSidecarsFromBlock(
   signedBlock: SignedBeaconBlock<ForkPostFulu>,
   cellsAndKzgProofs: {cells: Uint8Array[]; proofs: Uint8Array[]}[]
 ): fulu.DataColumnSidecars {
-  // TODO GLOAS: Need to get blobKzgCommitments from somewhere else
-  const blobKzgCommitments = (signedBlock.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>)
-    .blobKzgCommitments;
+  const fork = config.getForkName(signedBlock.message.slot);
+
+  // For GLOAS+, commitments are in the execution payload bid
+  // For pre-GLOAS (Fulu), commitments are in the block body
+  const blobKzgCommitments = isForkPostGloas(fork)
+    ? (signedBlock.message.body as gloas.BeaconBlockBody).signedExecutionPayloadBid.message.blobKzgCommitments
+    : (signedBlock.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments;
 
   // No need to create data column sidecars if there are no blobs
   if (blobKzgCommitments.length === 0) {
     return [];
   }
 
-  const fork = config.getForkName(signedBlock.message.slot);
   const signedBlockHeader = signedBlockToSignedHeader(config, signedBlock);
 
   const kzgCommitmentsInclusionProof = computePostFuluKzgCommitmentsInclusionProof(fork, signedBlock.message.body);

--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -14,7 +14,7 @@ import {DownloadTestsOptions} from "@lodestar/spec-test-util/downloadTests";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: DownloadTestsOptions = {
-  specVersion: "v1.7.0-alpha.1",
+  specVersion: "v1.7.0-alpha.2",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-specs",

--- a/packages/config/src/chainConfig/configs/mainnet.ts
+++ b/packages/config/src/chainConfig/configs/mainnet.ts
@@ -71,7 +71,7 @@ export const chainConfig: ChainConfig = {
   // 2**8 (= 256) epochs ~27 hours
   MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256,
   // 2**12 (= 4,096) epochs ~18 days
-  MIN_BUILDER_WITHDRAWABILITY_DELAY: 4096,
+  MIN_BUILDER_WITHDRAWABILITY_DELAY: 64,
   // 2**8 (= 256) epochs ~27 hours
   SHARD_COMMITTEE_PERIOD: 256,
   // 2**11 (= 2,048) Eth1 blocks ~8 hours

--- a/packages/config/src/chainConfig/configs/minimal.ts
+++ b/packages/config/src/chainConfig/configs/minimal.ts
@@ -65,7 +65,7 @@ export const chainConfig: ChainConfig = {
   // 2**8 (= 256) epochs
   MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256,
   // [customized] 2**3 (= 8) epochs
-  MIN_BUILDER_WITHDRAWABILITY_DELAY: 8,
+  MIN_BUILDER_WITHDRAWABILITY_DELAY: 2,
   // [customized] higher frequency of committee turnover and faster time to acceptable voluntary exit
   SHARD_COMMITTEE_PERIOD: 64,
   // [customized] process deposits more quickly, but insecure

--- a/packages/params/test/e2e/ensure-config-is-synced.test.ts
+++ b/packages/params/test/e2e/ensure-config-is-synced.test.ts
@@ -8,7 +8,7 @@ import {loadConfigYaml} from "../yaml.js";
 // Not e2e, but slow. Run with e2e tests
 
 /** https://github.com/ethereum/consensus-specs/releases */
-const specConfigCommit = "v1.7.0-alpha.1";
+const specConfigCommit = "v1.7.0-alpha.2";
 /**
  * Fields that we filter from local config when doing comparison.
  * Ideally this should be empty as it is not spec compliant

--- a/packages/state-transition/src/block/processDepositRequest.ts
+++ b/packages/state-transition/src/block/processDepositRequest.ts
@@ -14,7 +14,8 @@ export function applyDepositForBuilder(
   pubkey: BLSPubkey,
   withdrawalCredentials: Bytes32,
   amount: UintNum64,
-  signature: Bytes32
+  signature: Bytes32,
+  slot: number
 ): void {
   const builderIndex = findBuilderIndexByPubkey(state, pubkey);
 
@@ -25,7 +26,7 @@ export function applyDepositForBuilder(
   } else {
     // New builder - verify signature and add to registry
     if (isValidDepositSignature(state.config, pubkey, withdrawalCredentials, amount, signature)) {
-      addBuilderToRegistry(state, pubkey, withdrawalCredentials, amount);
+      addBuilderToRegistry(state, pubkey, withdrawalCredentials, amount, slot);
     }
   }
 }
@@ -38,7 +39,8 @@ function addBuilderToRegistry(
   state: CachedBeaconStateGloas,
   pubkey: BLSPubkey,
   withdrawalCredentials: Bytes32,
-  amount: UintNum64
+  amount: UintNum64,
+  slot: number
 ): void {
   const currentEpoch = computeEpochAtSlot(state.slot);
 
@@ -58,7 +60,7 @@ function addBuilderToRegistry(
     version: withdrawalCredentials[0],
     executionAddress: withdrawalCredentials.subarray(12),
     balance: amount,
-    depositEpoch: currentEpoch,
+    depositEpoch: computeEpochAtSlot(slot),
     withdrawableEpoch: FAR_FUTURE_EPOCH,
   });
 
@@ -93,7 +95,7 @@ export function processDepositRequest(
     // Route to builder if it's an existing builder OR has builder prefix and is not a validator
     if (isBuilder || (isBuilderPrefix && !isValidator)) {
       // Apply builder deposits immediately
-      applyDepositForBuilder(stateGloas, pubkey, withdrawalCredentials, amount, signature);
+      applyDepositForBuilder(stateGloas, pubkey, withdrawalCredentials, amount, signature, state.slot);
       return;
     }
   }

--- a/packages/state-transition/src/block/processExecutionPayloadBid.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadBid.ts
@@ -43,7 +43,7 @@ export function processExecutionPayloadBid(state: CachedBeaconStateGloas, block:
     }
   }
 
-  // Verify commitments are under limit [New in Gloas:EIP7732]
+  // Verify commitments are under limit
   const maxBlobsPerBlock = state.config.getMaxBlobsPerBlock(state.epochCtx.epoch);
   if (bid.blobKzgCommitments.length > maxBlobsPerBlock) {
     throw Error(

--- a/packages/state-transition/src/block/processExecutionPayloadBid.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadBid.ts
@@ -43,6 +43,14 @@ export function processExecutionPayloadBid(state: CachedBeaconStateGloas, block:
     }
   }
 
+  // Verify commitments are under limit [New in Gloas:EIP7732]
+  const maxBlobsPerBlock = state.config.getMaxBlobsPerBlock(state.epochCtx.epoch);
+  if (bid.blobKzgCommitments.length > maxBlobsPerBlock) {
+    throw Error(
+      `Kzg commitments exceed limit commitment.length=${bid.blobKzgCommitments.length} limit=${maxBlobsPerBlock}`
+    );
+  }
+
   if (bid.slot !== block.slot) {
     throw Error(`Bid slot ${bid.slot} does not match block slot ${block.slot}`);
   }

--- a/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
@@ -140,7 +140,6 @@ function validateExecutionPayloadEnvelope(
       `Timestamp mismatch between envelope's payload and state envelope=${payload.timestamp} state=${computeTimeAtSlot(state.config, state.slot, state.genesisTime)}`
     );
   }
-  // [Modified in Gloas:EIP7732] - commitments limit check moved to processExecutionPayloadBid
 
   // Skipped: Verify the execution payload is valid
 }

--- a/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
@@ -96,7 +96,6 @@ function validateExecutionPayloadEnvelope(
       `Builder index mismatch between envelope and committed bid envelope=${envelope.builderIndex} committedBid=${committedBid.builderIndex}`
     );
   }
-  // [Modified in Gloas:EIP7732] - blobKzgCommitmentsRoot check removed, commitments now in bid
 
   if (!byteArrayEquals(committedBid.prevRandao, payload.prevRandao)) {
     throw new Error(

--- a/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
@@ -96,13 +96,7 @@ function validateExecutionPayloadEnvelope(
       `Builder index mismatch between envelope and committed bid envelope=${envelope.builderIndex} committedBid=${committedBid.builderIndex}`
     );
   }
-
-  const envelopeKzgRoot = ssz.deneb.BlobKzgCommitments.hashTreeRoot(envelope.blobKzgCommitments);
-  if (!byteArrayEquals(committedBid.blobKzgCommitmentsRoot, envelopeKzgRoot)) {
-    throw new Error(
-      `Kzg commitment root mismatch between envelope and committed bid envelope=${toRootHex(envelopeKzgRoot)} committedBid=${toRootHex(committedBid.blobKzgCommitmentsRoot)}`
-    );
-  }
+  // [Modified in Gloas:EIP7732] - blobKzgCommitmentsRoot check removed, commitments now in bid
 
   if (!byteArrayEquals(committedBid.prevRandao, payload.prevRandao)) {
     throw new Error(
@@ -146,14 +140,7 @@ function validateExecutionPayloadEnvelope(
       `Timestamp mismatch between envelope's payload and state envelope=${payload.timestamp} state=${computeTimeAtSlot(state.config, state.slot, state.genesisTime)}`
     );
   }
-
-  // Verify commitments are under limit
-  const maxBlobsPerBlock = state.config.getMaxBlobsPerBlock(state.epochCtx.epoch);
-  if (envelope.blobKzgCommitments.length > maxBlobsPerBlock) {
-    throw new Error(
-      `Kzg commitments exceed limit commitment.length=${envelope.blobKzgCommitments.length} limit=${maxBlobsPerBlock}`
-    );
-  }
+  // [Modified in Gloas:EIP7732] - commitments limit check moved to processExecutionPayloadBid
 
   // Skipped: Verify the execution payload is valid
 }

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -320,7 +320,8 @@ function getValidatorsSweepWithdrawals(
   // Just run a bounded loop max iterating over all withdrawals
   // however breaks out once we have MAX_WITHDRAWALS_PER_PAYLOAD
   for (let n = 0; n < validatorsLimit; n++) {
-    if (sweepWithdrawals.length + numPriorWithdrawal === MAX_WITHDRAWALS_PER_PAYLOAD) {
+    // Use >= per consensus-specs #4832 (reserve space for validator sweep)
+    if (sweepWithdrawals.length + numPriorWithdrawal >= MAX_WITHDRAWALS_PER_PAYLOAD) {
       break;
     }
 

--- a/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
@@ -17,10 +17,11 @@ export function getIndexedPayloadAttestationSignatureSet(
 
 export function getPayloadAttestationDataSigningRoot(
   config: BeaconConfig,
-  stateSlot: Slot,
+  _stateSlot: Slot,
   data: gloas.PayloadAttestationData
 ): Uint8Array {
-  const domain = config.getDomain(stateSlot, DOMAIN_PTC_ATTESTER);
+  // Use attestation data's slot for domain epoch calculation per consensus-specs #4836
+  const domain = config.getDomain(data.slot, DOMAIN_PTC_ATTESTER);
 
   return computeSigningRoot(ssz.gloas.PayloadAttestationData, data, domain);
 }

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -1,7 +1,11 @@
 import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
 import {getCachedBeaconState} from "../cache/stateCache.js";
+import {applyDepositForBuilder} from "../block/processDepositRequest.js";
+import {isValidDepositSignature} from "../block/processDeposit.js";
 import {CachedBeaconStateFulu, CachedBeaconStateGloas} from "../types.js";
+import {isBuilderWithdrawalCredential} from "../util/gloas.js";
 
 /**
  * Upgrade a state from Fulu to Gloas.
@@ -64,10 +68,102 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
 
   const stateGloas = getCachedBeaconState(stateGloasView, stateFulu);
 
+  // Process pending builder deposits at the fork boundary
+  onboardBuildersFromPendingDeposits(stateGloas);
+
   stateGloas.commit();
   // Clear cache to ensure the cache of fulu fields is not used by new gloas fields
   // biome-ignore lint/complexity/useLiteralKeys: It is a protected attribute
   stateGloas["clearCache"]();
 
   return stateGloas;
+}
+
+/**
+ * Applies any pending deposit for builders, effectively onboarding builders at the fork.
+ * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/fork.md#onboard_builders_from_pending_deposits
+ */
+function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void {
+  // Build set of validator pubkeys (mutable - new valid deposits add to this)
+  const validatorPubkeys = new Set<string>();
+  for (let i = 0; i < state.validators.length; i++) {
+    validatorPubkeys.add(toHex(state.validators.getReadonly(i).pubkey));
+  }
+
+  const pendingDeposits: {
+    pubkey: Uint8Array;
+    withdrawalCredentials: Uint8Array;
+    amount: number;
+    signature: Uint8Array;
+    slot: number;
+  }[] = [];
+
+  const numDeposits = state.pendingDeposits.length;
+
+  for (let idx = 0; idx < numDeposits; idx++) {
+    const deposit = state.pendingDeposits.getReadonly(idx);
+    const pubkeyHex = toHex(deposit.pubkey);
+
+    // Deposits for existing validators stay in pending queue
+    if (validatorPubkeys.has(pubkeyHex)) {
+      pendingDeposits.push({
+        pubkey: deposit.pubkey,
+        withdrawalCredentials: deposit.withdrawalCredentials,
+        amount: deposit.amount,
+        signature: deposit.signature,
+        slot: deposit.slot,
+      });
+      continue;
+    }
+
+    // Check if pubkey is associated with a builder (recompute each iteration as
+    // apply_deposit_for_builder may add builders to the registry)
+    let isExistingBuilder = false;
+    for (let i = 0; i < state.builders.length; i++) {
+      if (toHex(state.builders.getReadonly(i).pubkey) === pubkeyHex) {
+        isExistingBuilder = true;
+        break;
+      }
+    }
+
+    const hasBuilderCredentials = isBuilderWithdrawalCredential(deposit.withdrawalCredentials);
+
+    if (isExistingBuilder || hasBuilderCredentials) {
+      // Apply deposit to new/existing builder
+      applyDepositForBuilder(
+        state,
+        deposit.pubkey,
+        deposit.withdrawalCredentials,
+        deposit.amount,
+        deposit.signature,
+        deposit.slot
+      );
+      continue;
+    }
+
+    // If pending deposit for a new validator with valid signature, track the pubkey
+    // so subsequent builder deposits for the same pubkey stay in pending (applied
+    // to the validator later). Deposits with invalid signatures are dropped.
+    if (isValidDepositSignature(state.config, deposit.pubkey, deposit.withdrawalCredentials, deposit.amount, deposit.signature)) {
+      validatorPubkeys.add(pubkeyHex);
+      pendingDeposits.push({
+        pubkey: deposit.pubkey,
+        withdrawalCredentials: deposit.withdrawalCredentials,
+        amount: deposit.amount,
+        signature: deposit.signature,
+        slot: deposit.slot,
+      });
+    }
+  }
+
+  // Replace pending deposits with filtered list
+  state.pendingDeposits = ssz.electra.PendingDeposits.toViewDU(
+    pendingDeposits.map((d) => ({
+      pubkey: d.pubkey,
+      withdrawalCredentials: d.withdrawalCredentials,
+      amount: d.amount,
+      signature: d.signature,
+      slot: d.slot,
+    }))
+  );
 }

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -1,9 +1,9 @@
 import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {toHex} from "@lodestar/utils";
-import {getCachedBeaconState} from "../cache/stateCache.js";
-import {applyDepositForBuilder} from "../block/processDepositRequest.js";
 import {isValidDepositSignature} from "../block/processDeposit.js";
+import {applyDepositForBuilder} from "../block/processDepositRequest.js";
+import {getCachedBeaconState} from "../cache/stateCache.js";
 import {CachedBeaconStateFulu, CachedBeaconStateGloas} from "../types.js";
 import {isBuilderWithdrawalCredential} from "../util/gloas.js";
 
@@ -144,7 +144,15 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
     // If pending deposit for a new validator with valid signature, track the pubkey
     // so subsequent builder deposits for the same pubkey stay in pending (applied
     // to the validator later). Deposits with invalid signatures are dropped.
-    if (isValidDepositSignature(state.config, deposit.pubkey, deposit.withdrawalCredentials, deposit.amount, deposit.signature)) {
+    if (
+      isValidDepositSignature(
+        state.config,
+        deposit.pubkey,
+        deposit.withdrawalCredentials,
+        deposit.amount,
+        deposit.signature
+      )
+    ) {
       validatorPubkeys.add(pubkeyHex);
       pendingDeposits.push({
         pubkey: deposit.pubkey,

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -32,7 +32,8 @@ export function getBuilderPaymentQuorumThreshold(state: CachedBeaconStateGloas):
  * Check if a validator index represents a builder (has the builder flag set).
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-is_builder_index
  *
- * Note: Uses BigInt for bitwise operations since BUILDER_INDEX_FLAG (2^40) exceeds 32-bit integer range.
+ * Note: Uses BigInt because JavaScript bitwise operators (&, |, etc.) coerce operands to 32-bit
+ * integers, which would truncate BUILDER_INDEX_FLAG (2^40).
  */
 export function isBuilderIndex(validatorIndex: number): boolean {
   return (BigInt(validatorIndex) & BigInt(BUILDER_INDEX_FLAG)) !== 0n;
@@ -42,7 +43,7 @@ export function isBuilderIndex(validatorIndex: number): boolean {
  * Convert a builder index to a flagged validator index for use in Withdrawal containers.
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-convert_builder_index_to_validator_index
  *
- * Note: Uses BigInt for bitwise operations since BUILDER_INDEX_FLAG (2^40) exceeds 32-bit integer range.
+ * Note: Uses BigInt because JavaScript bitwise operators coerce operands to 32-bit integers.
  */
 export function convertBuilderIndexToValidatorIndex(builderIndex: BuilderIndex): ValidatorIndex {
   return Number(BigInt(builderIndex) | BigInt(BUILDER_INDEX_FLAG));
@@ -52,7 +53,7 @@ export function convertBuilderIndexToValidatorIndex(builderIndex: BuilderIndex):
  * Convert a flagged validator index back to a builder index.
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-convert_validator_index_to_builder_index
  *
- * Note: Uses BigInt for bitwise operations since BUILDER_INDEX_FLAG (2^40) exceeds 32-bit integer range.
+ * Note: Uses BigInt because JavaScript bitwise operators coerce operands to 32-bit integers.
  */
 export function convertValidatorIndexToBuilderIndex(validatorIndex: ValidatorIndex): BuilderIndex {
   return Number(BigInt(validatorIndex) & ~BigInt(BUILDER_INDEX_FLAG));

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -31,25 +31,31 @@ export function getBuilderPaymentQuorumThreshold(state: CachedBeaconStateGloas):
 /**
  * Check if a validator index represents a builder (has the builder flag set).
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-is_builder_index
+ *
+ * Note: Uses BigInt for bitwise operations since BUILDER_INDEX_FLAG (2^40) exceeds 32-bit integer range.
  */
 export function isBuilderIndex(validatorIndex: number): boolean {
-  return (validatorIndex & BUILDER_INDEX_FLAG) !== 0;
+  return (BigInt(validatorIndex) & BigInt(BUILDER_INDEX_FLAG)) !== 0n;
 }
 
 /**
  * Convert a builder index to a flagged validator index for use in Withdrawal containers.
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-convert_builder_index_to_validator_index
+ *
+ * Note: Uses BigInt for bitwise operations since BUILDER_INDEX_FLAG (2^40) exceeds 32-bit integer range.
  */
 export function convertBuilderIndexToValidatorIndex(builderIndex: BuilderIndex): ValidatorIndex {
-  return builderIndex | BUILDER_INDEX_FLAG;
+  return Number(BigInt(builderIndex) | BigInt(BUILDER_INDEX_FLAG));
 }
 
 /**
  * Convert a flagged validator index back to a builder index.
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-convert_validator_index_to_builder_index
+ *
+ * Note: Uses BigInt for bitwise operations since BUILDER_INDEX_FLAG (2^40) exceeds 32-bit integer range.
  */
 export function convertValidatorIndexToBuilderIndex(validatorIndex: ValidatorIndex): BuilderIndex {
-  return validatorIndex & ~BUILDER_INDEX_FLAG;
+  return Number(BigInt(validatorIndex) & ~BigInt(BUILDER_INDEX_FLAG));
 }
 
 /**

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -275,8 +275,8 @@ export const DataColumnSidecar = new ContainerType(
     kzgProofs: fuluSsz.DataColumnSidecar.fields.kzgProofs,
     // Removed signedBlockHeader
     // Removed kzgCommitmentsInclusionProof
-    slot: Slot,
-    beaconBlockRoot: Root,
+    slot: Slot, // New in GLOAS:EIP7732
+    beaconBlockRoot: Root, // New in GLOAS:EIP7732
   },
   {typeName: "DataColumnSidecar", jsonCase: "eth2"}
 );

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -271,10 +271,10 @@ export const DataColumnSidecar = new ContainerType(
   {
     index: fuluSsz.DataColumnSidecar.fields.index,
     column: fuluSsz.DataColumnSidecar.fields.column,
-    // kzgCommitments: fuluSsz.DataColumnSidecar.fields.kzgCommitments, // Removed in GLOAS:EIP7732
+    // kzgCommitments: denebSsz.BlobKzgCommitments, // Removed in GLOAS:EIP7732
     kzgProofs: fuluSsz.DataColumnSidecar.fields.kzgProofs,
-    // signedBlockHeader: fuluSsz.DataColumnSidecar.fields.signedBlockHeader, // Removed in GLOAS:EIP7732
-    // kzgCommitmentsInclusionProof: fuluSsz.DataColumnSidecar.fields.kzgCommitmentsInclusionProof, // Removed in GLOAS:EIP7732
+    // signedBlockHeader: phase0Ssz.SignedBeaconBlockHeader, // Removed in GLOAS:EIP7732
+    // kzgCommitmentsInclusionProof: KzgCommitmentsInclusionProof, // Removed in GLOAS:EIP7732
     slot: Slot, // New in GLOAS:EIP7732
     beaconBlockRoot: Root, // New in GLOAS:EIP7732
   },

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -133,7 +133,7 @@ export const ExecutionPayloadBid = new ContainerType(
     slot: Slot,
     value: UintNum64,
     executionPayment: UintNum64,
-    blobKzgCommitmentsRoot: Root,
+    blobKzgCommitments: denebSsz.BlobKzgCommitments, // [Modified in Gloas:EIP7732] - was blobKzgCommitmentsRoot
   },
   {typeName: "ExecutionPayloadBid", jsonCase: "eth2"}
 );
@@ -153,7 +153,7 @@ export const ExecutionPayloadEnvelope = new ContainerType(
     builderIndex: BuilderIndex,
     beaconBlockRoot: Root,
     slot: Slot,
-    blobKzgCommitments: denebSsz.BlobKzgCommitments,
+    // [Modified in Gloas:EIP7732] - blobKzgCommitments moved to ExecutionPayloadBid
     stateRoot: Root,
   },
   {typeName: "ExecutionPayloadEnvelope", jsonCase: "eth2"}
@@ -272,7 +272,7 @@ export const DataColumnSidecar = new ContainerType(
   {
     index: fuluSsz.DataColumnSidecar.fields.index,
     column: fuluSsz.DataColumnSidecar.fields.column,
-    kzgCommitments: fuluSsz.DataColumnSidecar.fields.kzgCommitments,
+    // [Modified in Gloas:EIP7732] - kzgCommitments removed, now in ExecutionPayloadBid
     kzgProofs: fuluSsz.DataColumnSidecar.fields.kzgProofs,
     // signedBlockHeader: phase0Ssz.SignedBeaconBlockHeader, // Removed in GLOAS:EIP7732
     // kzgCommitmentsInclusionProof: KzgCommitmentsInclusionProof, // Removed in GLOAS:EIP7732

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -153,6 +153,7 @@ export const ExecutionPayloadEnvelope = new ContainerType(
     builderIndex: BuilderIndex,
     beaconBlockRoot: Root,
     slot: Slot,
+    // blobKzgCommitments: denebSsz.BlobKzgCommitments, // Removed in GLOAS:EIP7732
     stateRoot: Root,
   },
   {typeName: "ExecutionPayloadEnvelope", jsonCase: "eth2"}

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -153,7 +153,6 @@ export const ExecutionPayloadEnvelope = new ContainerType(
     builderIndex: BuilderIndex,
     beaconBlockRoot: Root,
     slot: Slot,
-    // blobKzgCommitments: denebSsz.BlobKzgCommitments, // Removed in GLOAS:EIP7732
     stateRoot: Root,
   },
   {typeName: "ExecutionPayloadEnvelope", jsonCase: "eth2"}
@@ -272,12 +271,12 @@ export const DataColumnSidecar = new ContainerType(
   {
     index: fuluSsz.DataColumnSidecar.fields.index,
     column: fuluSsz.DataColumnSidecar.fields.column,
+    // Removed kzgCommitments
     kzgProofs: fuluSsz.DataColumnSidecar.fields.kzgProofs,
-    // kzgCommitments: fuluSsz.DataColumnSidecar.fields.kzgCommitments, // Removed in GLOAS:EIP7732
-    // signedBlockHeader: phase0Ssz.SignedBeaconBlockHeader, // Removed in GLOAS:EIP7732
-    // kzgCommitmentsInclusionProof: KzgCommitmentsInclusionProof, // Removed in GLOAS:EIP7732
-    slot: Slot, // New in GLOAS:EIP7732
-    beaconBlockRoot: Root, // New in GLOAS:EIP7732
+    // Removed signedBlockHeader
+    // Removed kzgCommitmentsInclusionProof
+    slot: Slot,
+    beaconBlockRoot: Root,
   },
   {typeName: "DataColumnSidecar", jsonCase: "eth2"}
 );

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -271,10 +271,10 @@ export const DataColumnSidecar = new ContainerType(
   {
     index: fuluSsz.DataColumnSidecar.fields.index,
     column: fuluSsz.DataColumnSidecar.fields.column,
-    // Removed kzgCommitments
+    // kzgCommitments: fuluSsz.DataColumnSidecar.fields.kzgCommitments, // Removed in GLOAS:EIP7732
     kzgProofs: fuluSsz.DataColumnSidecar.fields.kzgProofs,
-    // Removed signedBlockHeader
-    // Removed kzgCommitmentsInclusionProof
+    // signedBlockHeader: fuluSsz.DataColumnSidecar.fields.signedBlockHeader, // Removed in GLOAS:EIP7732
+    // kzgCommitmentsInclusionProof: fuluSsz.DataColumnSidecar.fields.kzgCommitmentsInclusionProof, // Removed in GLOAS:EIP7732
     slot: Slot, // New in GLOAS:EIP7732
     beaconBlockRoot: Root, // New in GLOAS:EIP7732
   },

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -133,7 +133,7 @@ export const ExecutionPayloadBid = new ContainerType(
     slot: Slot,
     value: UintNum64,
     executionPayment: UintNum64,
-    blobKzgCommitments: denebSsz.BlobKzgCommitments, // [Modified in Gloas:EIP7732] - was blobKzgCommitmentsRoot
+    blobKzgCommitments: denebSsz.BlobKzgCommitments,
   },
   {typeName: "ExecutionPayloadBid", jsonCase: "eth2"}
 );
@@ -153,7 +153,6 @@ export const ExecutionPayloadEnvelope = new ContainerType(
     builderIndex: BuilderIndex,
     beaconBlockRoot: Root,
     slot: Slot,
-    // [Modified in Gloas:EIP7732] - blobKzgCommitments moved to ExecutionPayloadBid
     stateRoot: Root,
   },
   {typeName: "ExecutionPayloadEnvelope", jsonCase: "eth2"}
@@ -272,8 +271,8 @@ export const DataColumnSidecar = new ContainerType(
   {
     index: fuluSsz.DataColumnSidecar.fields.index,
     column: fuluSsz.DataColumnSidecar.fields.column,
-    // [Modified in Gloas:EIP7732] - kzgCommitments removed, now in ExecutionPayloadBid
     kzgProofs: fuluSsz.DataColumnSidecar.fields.kzgProofs,
+    // kzgCommitments: fuluSsz.DataColumnSidecar.fields.kzgCommitments, // Removed in GLOAS:EIP7732
     // signedBlockHeader: phase0Ssz.SignedBeaconBlockHeader, // Removed in GLOAS:EIP7732
     // kzgCommitmentsInclusionProof: KzgCommitmentsInclusionProof, // Removed in GLOAS:EIP7732
     slot: Slot, // New in GLOAS:EIP7732

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.7.0-alpha.1
+version: v1.7.0-alpha.2
 style: full
 
 specrefs:

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -185,7 +185,6 @@ exceptions:
     - get_lc_execution_root#deneb
     - hash_to_bls_field#deneb
     - is_power_of_two#deneb
-    - multi_exp#deneb
     - reverse_bits#deneb
     - validate_kzg_g1#deneb
     - verify_blob_kzg_proof#deneb
@@ -251,7 +250,6 @@ exceptions:
     - get_ancestor#gloas
     - get_attestation_participation_flag_indices#gloas
     - get_attestation_score#gloas
-    - get_builder_from_deposit#gloas
     - get_builder_withdrawals#gloas
     - get_builders_sweep_withdrawals#gloas
     - get_checkpoint_block#gloas

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -482,8 +482,8 @@
     - file: packages/config/src/chainConfig/configs/mainnet.ts
       search: "MIN_BUILDER_WITHDRAWABILITY_DELAY:"
   spec: |
-    <spec config_var="MIN_BUILDER_WITHDRAWABILITY_DELAY" fork="gloas" hash="d378428f">
-    MIN_BUILDER_WITHDRAWABILITY_DELAY: uint64 = 4096
+    <spec config_var="MIN_BUILDER_WITHDRAWABILITY_DELAY" fork="gloas" hash="be7f8473">
+    MIN_BUILDER_WITHDRAWABILITY_DELAY: uint64 = 64
     </spec>
 
 - name: MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS#deneb

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -750,11 +750,12 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const DataColumnSidecar =
   spec: |
-    <spec container="DataColumnSidecar" fork="gloas" hash="8028928b">
+    <spec container="DataColumnSidecar" fork="gloas" hash="332c7cfc">
     class DataColumnSidecar(Container):
         index: ColumnIndex
         column: List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        # [Modified in Gloas:EIP7732]
+        # Removed `kzg_commitments`
         kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
         # [Modified in Gloas:EIP7732]
         # Removed `signed_block_header`
@@ -932,7 +933,7 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const ExecutionPayloadBid =
   spec: |
-    <spec container="ExecutionPayloadBid" fork="gloas" hash="aa71ba16">
+    <spec container="ExecutionPayloadBid" fork="gloas" hash="1a7b9dea">
     class ExecutionPayloadBid(Container):
         parent_block_hash: Hash32
         parent_block_root: Root
@@ -944,7 +945,7 @@
         slot: Slot
         value: Gwei
         execution_payment: Gwei
-        blob_kzg_commitments_root: Root
+        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     </spec>
 
 - name: ExecutionPayloadEnvelope#gloas
@@ -952,14 +953,13 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const ExecutionPayloadEnvelope =
   spec: |
-    <spec container="ExecutionPayloadEnvelope" fork="gloas" hash="cd522f7f">
+    <spec container="ExecutionPayloadEnvelope" fork="gloas" hash="ec5c0233">
     class ExecutionPayloadEnvelope(Container):
         payload: ExecutionPayload
         execution_requests: ExecutionRequests
         builder_index: BuilderIndex
         beacon_block_root: Root
         slot: Slot
-        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
         state_root: Root
     </spec>
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -2275,23 +2275,6 @@
         return bls.Sign(privkey, signing_root)
     </spec>
 
-- name: get_builder_from_deposit#gloas
-  sources: []
-  spec: |
-    <spec fn="get_builder_from_deposit" fork="gloas" hash="7f914af6">
-    def get_builder_from_deposit(
-        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
-    ) -> Builder:
-        return Builder(
-            pubkey=pubkey,
-            version=uint8(withdrawal_credentials[0]),
-            execution_address=ExecutionAddress(withdrawal_credentials[12:]),
-            balance=amount,
-            deposit_epoch=get_current_epoch(state),
-            withdrawable_epoch=FAR_FUTURE_EPOCH,
-        )
-    </spec>
-
 - name: get_builder_payment_quorum_threshold#gloas
   sources:
     - file: packages/state-transition/src/util/gloas.ts

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1,13 +1,26 @@
 - name: add_builder_to_registry#gloas
   sources: []
   spec: |
-    <spec fn="add_builder_to_registry" fork="gloas" hash="938224ec">
+    <spec fn="add_builder_to_registry" fork="gloas" hash="cd0414c9">
     def add_builder_to_registry(
-        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
+        state: BeaconState,
+        pubkey: BLSPubkey,
+        withdrawal_credentials: Bytes32,
+        amount: uint64,
+        slot: Slot,
     ) -> None:
-        index = get_index_for_new_builder(state)
-        builder = get_builder_from_deposit(state, pubkey, withdrawal_credentials, amount)
-        set_or_append_list(state.builders, index, builder)
+        set_or_append_list(
+            state.builders,
+            get_index_for_new_builder(state),
+            Builder(
+                pubkey=pubkey,
+                version=uint8(withdrawal_credentials[0]),
+                execution_address=ExecutionAddress(withdrawal_credentials[12:]),
+                balance=amount,
+                deposit_epoch=compute_epoch_at_slot(slot),
+                withdrawable_epoch=FAR_FUTURE_EPOCH,
+            ),
+        )
     </spec>
 
 - name: add_flag#altair
@@ -145,19 +158,20 @@
     - file: packages/state-transition/src/block/processDepositRequest.ts
       search: export function applyDepositForBuilder(
   spec: |
-    <spec fn="apply_deposit_for_builder" fork="gloas" hash="eae84bc2">
+    <spec fn="apply_deposit_for_builder" fork="gloas" hash="e4bc98c7">
     def apply_deposit_for_builder(
         state: BeaconState,
         pubkey: BLSPubkey,
         withdrawal_credentials: Bytes32,
         amount: uint64,
         signature: BLSSignature,
+        slot: Slot,
     ) -> None:
         builder_pubkeys = [b.pubkey for b in state.builders]
         if pubkey not in builder_pubkeys:
             # Verify the deposit signature (proof of possession) which is not checked by the deposit contract
             if is_valid_deposit_signature(pubkey, withdrawal_credentials, amount, signature):
-                add_builder_to_registry(state, pubkey, withdrawal_credentials, amount)
+                add_builder_to_registry(state, pubkey, withdrawal_credentials, amount, slot)
         else:
             # Increase balance by deposit amount
             builder_index = builder_pubkeys.index(pubkey)
@@ -551,9 +565,11 @@
     - file: packages/state-transition/src/util/domain.ts
       search: export function computeDomain(
   spec: |
-    <spec fn="compute_domain" fork="phase0" hash="948e1334">
+    <spec fn="compute_domain" fork="phase0" hash="a78b32e4">
     def compute_domain(
-        domain_type: DomainType, fork_version: Version = None, genesis_validators_root: Root = None
+        domain_type: DomainType,
+        fork_version: Optional[Version] = None,
+        genesis_validators_root: Optional[Root] = None,
     ) -> Domain:
         """
         Return the domain for the ``domain_type`` and ``fork_version``.
@@ -2293,19 +2309,20 @@
 - name: get_builder_withdrawals#gloas
   sources: []
   spec: |
-    <spec fn="get_builder_withdrawals" fork="gloas" hash="35cd32cd">
+    <spec fn="get_builder_withdrawals" fork="gloas" hash="d54dd146">
     def get_builder_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
         prior_withdrawals: Sequence[Withdrawal],
     ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
-        withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+        withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD - 1
+        assert len(prior_withdrawals) <= withdrawals_limit
 
         processed_count: uint64 = 0
         withdrawals: List[Withdrawal] = []
         for withdrawal in state.builder_pending_withdrawals:
             all_withdrawals = prior_withdrawals + withdrawals
-            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
 
@@ -2327,7 +2344,7 @@
 - name: get_builders_sweep_withdrawals#gloas
   sources: []
   spec: |
-    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="028d161d">
+    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="04c1cb10">
     def get_builders_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -2335,14 +2352,15 @@
     ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
         epoch = get_current_epoch(state)
         builders_limit = min(len(state.builders), MAX_BUILDERS_PER_WITHDRAWALS_SWEEP)
-        withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+        withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD - 1
+        assert len(prior_withdrawals) <= withdrawals_limit
 
         processed_count: uint64 = 0
         withdrawals: List[Withdrawal] = []
         builder_index = state.next_withdrawal_builder_index
         for _ in range(builders_limit):
             all_withdrawals = prior_withdrawals + withdrawals
-            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
 
@@ -2626,7 +2644,7 @@
 - name: get_data_column_sidecars#gloas
   sources: []
   spec: |
-    <spec fn="get_data_column_sidecars" fork="gloas" hash="c8d64ac9">
+    <spec fn="get_data_column_sidecars" fork="gloas" hash="abaf4385">
     def get_data_column_sidecars(
         # [Modified in Gloas:EIP7732]
         # Removed `signed_block_header`
@@ -2634,7 +2652,8 @@
         beacon_block_root: Root,
         # [New in Gloas:EIP7732]
         slot: Slot,
-        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+        # [Modified in Gloas:EIP7732]
+        # Removed `kzg_commitments`
         # [Modified in Gloas:EIP7732]
         # Removed `kzg_commitments_inclusion_proof`
         cells_and_kzg_proofs: Sequence[
@@ -2642,11 +2661,10 @@
         ],
     ) -> Sequence[DataColumnSidecar]:
         """
-        Given a beacon block root and the commitments, cells/proofs associated with
-        each blob in the block, assemble the sidecars which can be distributed to peers.
+        Given a beacon block root and the cells/proofs associated with each blob
+        in the corresponding payload, assemble the sidecars which can be
+        distributed to peers.
         """
-        assert len(cells_and_kzg_proofs) == len(kzg_commitments)
-
         sidecars = []
         for column_index in range(NUMBER_OF_COLUMNS):
             column_cells, column_proofs = [], []
@@ -2654,10 +2672,10 @@
                 column_cells.append(cells[column_index])
                 column_proofs.append(proofs[column_index])
             sidecars.append(
+                # [Modified in Gloas:EIP7732]
                 DataColumnSidecar(
                     index=column_index,
                     column=column_cells,
-                    kzg_commitments=kzg_commitments,
                     kzg_proofs=column_proofs,
                     slot=slot,
                     beacon_block_root=beacon_block_root,
@@ -2699,11 +2717,9 @@
 - name: get_data_column_sidecars_from_block#gloas
   sources: []
   spec: |
-    <spec fn="get_data_column_sidecars_from_block" fork="gloas" hash="8ac19a18">
+    <spec fn="get_data_column_sidecars_from_block" fork="gloas" hash="302616d2">
     def get_data_column_sidecars_from_block(
         signed_block: SignedBeaconBlock,
-        # [New in Gloas:EIP7732]
-        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
         cells_and_kzg_proofs: Sequence[
             Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
         ],
@@ -2716,7 +2732,6 @@
         return get_data_column_sidecars(
             beacon_block_root,
             signed_block.message.slot,
-            blob_kzg_commitments,
             cells_and_kzg_proofs,
         )
     </spec>
@@ -2726,7 +2741,7 @@
     - file: packages/beacon-node/src/util/dataColumns.ts
       search: export function getDataColumnSidecarsFromColumnSidecar(
   spec: |
-    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="fulu" hash="4304cdec">
+    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="fulu" hash="4877148a">
     def get_data_column_sidecars_from_column_sidecar(
         sidecar: DataColumnSidecar,
         cells_and_kzg_proofs: Sequence[
@@ -2734,7 +2749,7 @@
         ],
     ) -> Sequence[DataColumnSidecar]:
         """
-        Given a DataColumnSidecar and the cells/proofs associated with each blob corresponding
+        Given a data column sidecar and the cells/proofs associated with each blob corresponding
         to the commitments it contains, assemble all sidecars for distribution to peers.
         """
         assert len(cells_and_kzg_proofs) == len(sidecar.kzg_commitments)
@@ -2750,7 +2765,7 @@
 - name: get_data_column_sidecars_from_column_sidecar#gloas
   sources: []
   spec: |
-    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="gloas" hash="a1052a1c">
+    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="gloas" hash="beb1f94f">
     def get_data_column_sidecars_from_column_sidecar(
         sidecar: DataColumnSidecar,
         cells_and_kzg_proofs: Sequence[
@@ -2758,15 +2773,14 @@
         ],
     ) -> Sequence[DataColumnSidecar]:
         """
-        Given a DataColumnSidecar and the cells/proofs associated with each blob corresponding
-        to the commitments it contains, assemble all sidecars for distribution to peers.
+        Given a data column sidecar and the cells/proofs associated with each blob
+        in the corresponding payload, assemble the sidecars which can be
+        distributed to peers.
         """
-        assert len(cells_and_kzg_proofs) == len(sidecar.kzg_commitments)
-
+        # [Modified in Gloas:EIP7732]
         return get_data_column_sidecars(
             sidecar.beacon_block_root,
             sidecar.slot,
-            sidecar.kzg_commitments,
             cells_and_kzg_proofs,
         )
     </spec>
@@ -2776,8 +2790,10 @@
     - file: packages/config/src/genesisConfig/index.ts
       search: "getDomain(domainSlot: Slot, domainType: DomainType, messageSlot?: Slot)"
   spec: |
-    <spec fn="get_domain" fork="phase0" hash="99ea23f6">
-    def get_domain(state: BeaconState, domain_type: DomainType, epoch: Epoch = None) -> Domain:
+    <spec fn="get_domain" fork="phase0" hash="e60c5fbc">
+    def get_domain(
+        state: BeaconState, domain_type: DomainType, epoch: Optional[Epoch] = None
+    ) -> Domain:
         """
         Return the signature domain (fork version concatenated with domain type) of a message.
         """
@@ -3856,7 +3872,7 @@
 - name: get_pending_partial_withdrawals#electra
   sources: []
   spec: |
-    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="b53b25d7">
+    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="306047e9">
     def get_pending_partial_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -3867,13 +3883,14 @@
             len(prior_withdrawals) + MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
             MAX_WITHDRAWALS_PER_PAYLOAD - 1,
         )
+        assert len(prior_withdrawals) <= withdrawals_limit
 
         processed_count: uint64 = 0
         withdrawals: List[Withdrawal] = []
         for withdrawal in state.pending_partial_withdrawals:
             all_withdrawals = prior_withdrawals + withdrawals
             is_withdrawable = withdrawal.withdrawable_epoch <= epoch
-            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if not is_withdrawable or has_reached_limit:
                 break
 
@@ -4062,13 +4079,13 @@
 - name: get_ptc_assignment#gloas
   sources: []
   spec: |
-    <spec fn="get_ptc_assignment" fork="gloas" hash="817acb90">
+    <spec fn="get_ptc_assignment" fork="gloas" hash="7fd50097">
     def get_ptc_assignment(
         state: BeaconState, epoch: Epoch, validator_index: ValidatorIndex
     ) -> Optional[Slot]:
         """
         Returns the slot during the requested epoch in which the validator with
-        index `validator_index` is a member of the PTC. Returns None if no
+        index ``validator_index`` is a member of the PTC. Returns None if no
         assignment is found.
         """
         next_epoch = Epoch(get_current_epoch(state) + 1)
@@ -4484,7 +4501,7 @@
 - name: get_validators_sweep_withdrawals#capella
   sources: []
   spec: |
-    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="81868c81">
+    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="59563c2a">
     def get_validators_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -4493,13 +4510,15 @@
         epoch = get_current_epoch(state)
         validators_limit = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
         withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+        # There must be at least one space reserved for validator sweep withdrawals
+        assert len(prior_withdrawals) < withdrawals_limit
 
         processed_count: uint64 = 0
         withdrawals: List[Withdrawal] = []
         validator_index = state.next_withdrawal_validator_index
         for _ in range(validators_limit):
             all_withdrawals = prior_withdrawals + withdrawals
-            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
 
@@ -4535,7 +4554,7 @@
 - name: get_validators_sweep_withdrawals#electra
   sources: []
   spec: |
-    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="74bbd437">
+    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="034093ad">
     def get_validators_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -4544,13 +4563,15 @@
         epoch = get_current_epoch(state)
         validators_limit = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
         withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+        # There must be at least one space reserved for validator sweep withdrawals
+        assert len(prior_withdrawals) < withdrawals_limit
 
         processed_count: uint64 = 0
         withdrawals: List[Withdrawal] = []
         validator_index = state.next_withdrawal_validator_index
         for _ in range(validators_limit):
             all_withdrawals = prior_withdrawals + withdrawals
-            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
 
@@ -5150,6 +5171,29 @@
         )
     </spec>
 
+- name: is_data_available#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+      search: export async function verifyBlocksDataAvailability(
+  spec: |
+    <spec fn="is_data_available" fork="gloas" hash="92002d87">
+    def is_data_available(beacon_block_root: Root) -> bool:
+        # `retrieve_column_sidecars_and_kzg_commitments` is implementation and
+        # context dependent, replacing `retrieve_column_sidecars`. For the given
+        # block root, it returns all column sidecars to sample, or raises an
+        # exception if they are not available, in addition it returns all the
+        # corresponding kzg commitments. The p2p network does not guarantee sidecar
+        # retrieval outside of `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` epochs.
+        column_sidecars, kzg_commitments = retrieve_column_sidecars_and_kzg_commitments(
+            beacon_block_root
+        )
+        return all(
+            verify_data_column_sidecar(column_sidecar, kzg_commitments)
+            and verify_data_column_sidecar_kzg_proofs(column_sidecar, kzg_commitments)
+            for column_sidecar in column_sidecars
+        )
+    </spec>
+
 - name: is_eligible_for_activation#phase0
   sources:
     - file: packages/state-transition/src/cache/epochTransitionCache.ts
@@ -5721,24 +5765,24 @@
     - file: packages/state-transition/src/block/isValidIndexedPayloadAttestation.ts
       search: export function isValidIndexedPayloadAttestation(
   spec: |
-    <spec fn="is_valid_indexed_payload_attestation" fork="gloas" hash="cf1e65b5">
+    <spec fn="is_valid_indexed_payload_attestation" fork="gloas" hash="d76e0f89">
     def is_valid_indexed_payload_attestation(
-        state: BeaconState, indexed_payload_attestation: IndexedPayloadAttestation
+        state: BeaconState, attestation: IndexedPayloadAttestation
     ) -> bool:
         """
-        Check if ``indexed_payload_attestation`` is non-empty, has sorted indices, and has
+        Check if ``attestation`` is non-empty, has sorted indices, and has
         a valid aggregate signature.
         """
         # Verify indices are non-empty and sorted
-        indices = indexed_payload_attestation.attesting_indices
+        indices = attestation.attesting_indices
         if len(indices) == 0 or not indices == sorted(indices):
             return False
 
         # Verify aggregate signature
         pubkeys = [state.validators[i].pubkey for i in indices]
-        domain = get_domain(state, DOMAIN_PTC_ATTESTER, None)
-        signing_root = compute_signing_root(indexed_payload_attestation.data, domain)
-        return bls.FastAggregateVerify(pubkeys, signing_root, indexed_payload_attestation.signature)
+        domain = get_domain(state, DOMAIN_PTC_ATTESTER, compute_epoch_at_slot(attestation.data.slot))
+        signing_root = compute_signing_root(attestation.data, domain)
+        return bls.FastAggregateVerify(pubkeys, signing_root, attestation.signature)
     </spec>
 
 - name: is_valid_light_client_header#altair
@@ -6530,6 +6574,60 @@
             )
     </spec>
 
+- name: onboard_builders_from_pending_deposits#gloas
+  sources:
+    - file: packages/state-transition/src/slot/upgradeStateToGloas.ts
+      search: export function upgradeStateToGloas(
+  spec: |
+    <spec fn="onboard_builders_from_pending_deposits" fork="gloas" hash="2bd662c7">
+    def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
+        """
+        Applies any pending deposit for builders, effectively
+        onboarding builders at the fork.
+        """
+        validator_pubkeys = [v.pubkey for v in state.validators]
+
+        pending_deposits = []
+        for deposit in state.pending_deposits:
+            # Deposits for existing validators stay in pending queue
+            if deposit.pubkey in validator_pubkeys:
+                pending_deposits.append(deposit)
+                continue
+
+            # If the pubkey is associated with a builder that was created in a
+            # previous iteration or it is a builder deposit, try to apply the
+            # deposit to the new/existing builder. Note that the function
+            # apply_deposit_for_builder can mutate the state and may add a builder
+            # to the registry. For this reason, the list of builder pubkeys must
+            # be recomputed each iteration.
+            builder_pubkeys = [b.pubkey for b in state.builders]
+            is_existing_builder = deposit.pubkey in builder_pubkeys
+            has_builder_credentials = is_builder_withdrawal_credential(deposit.withdrawal_credentials)
+            if is_existing_builder or has_builder_credentials:
+                apply_deposit_for_builder(
+                    state,
+                    deposit.pubkey,
+                    deposit.withdrawal_credentials,
+                    deposit.amount,
+                    deposit.signature,
+                    deposit.slot,
+                )
+                continue
+
+            # If there is a pending deposit for a new validator that has a valid
+            # signature, track the pubkey so that subsequent builder deposits for
+            # the same pubkey stay in pending (applied to the validator later)
+            # rather than creating a builder. Deposits with invalid signatures are
+            # dropped here since they would fail in apply_pending_deposit anyway.
+            if is_valid_deposit_signature(
+                deposit.pubkey, deposit.withdrawal_credentials, deposit.amount, deposit.signature
+            ):
+                validator_pubkeys.append(deposit.pubkey)
+                pending_deposits.append(deposit)
+
+        state.pending_deposits = pending_deposits
+    </spec>
+
 - name: prepare_execution_payload#bellatrix
   sources:
     - file: packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -6583,13 +6681,15 @@
     - file: packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
       search: export async function prepareExecutionPayload(
   spec: |
-    <spec fn="prepare_execution_payload" fork="capella" hash="998e8b92">
+    <spec fn="prepare_execution_payload" fork="capella" hash="bdb15c3f">
     def prepare_execution_payload(
         state: BeaconState,
         safe_block_hash: Hash32,
         finalized_block_hash: Hash32,
         suggested_fee_recipient: ExecutionAddress,
         execution_engine: ExecutionEngine,
+        # [Modified in Capella]
+        # Removed `pow_chain`
     ) -> Optional[PayloadId]:
         # [Modified in Capella]
         # Removed `is_merge_transition_complete` check
@@ -6680,7 +6780,7 @@
 - name: prepare_execution_payload#gloas
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="gloas" hash="c617aa1b">
+    <spec fn="prepare_execution_payload" fork="gloas" hash="f3047927">
     def prepare_execution_payload(
         state: BeaconState,
         safe_block_hash: Hash32,
@@ -6688,20 +6788,17 @@
         suggested_fee_recipient: ExecutionAddress,
         execution_engine: ExecutionEngine,
     ) -> Optional[PayloadId]:
-        # Verify consistency of the parent hash with respect to the previous execution payload header
-        parent_hash = state.latest_execution_payload_header.block_hash
-
         # Set the forkchoice head and initiate the payload build process
         payload_attributes = PayloadAttributes(
             timestamp=compute_time_at_slot(state, state.slot),
             prev_randao=get_randao_mix(state, get_current_epoch(state)),
             suggested_fee_recipient=suggested_fee_recipient,
             withdrawals=get_expected_withdrawals(state).withdrawals,
-            # [New in Deneb:EIP4788]
             parent_beacon_block_root=hash_tree_root(state.latest_block_header),
         )
         return execution_engine.notify_forkchoice_updated(
-            head_block_hash=parent_hash,
+            # [Modified in Gloas:EIP7732]
+            head_block_hash=state.latest_block_hash,
             safe_block_hash=safe_block_hash,
             finalized_block_hash=finalized_block_hash,
             payload_attributes=payload_attributes,
@@ -7359,7 +7456,7 @@
     - file: packages/state-transition/src/block/processDepositRequest.ts
       search: export function processDepositRequest(
   spec: |
-    <spec fn="process_deposit_request" fork="gloas" hash="50ffbd27">
+    <spec fn="process_deposit_request" fork="gloas" hash="3c6b0310">
     def process_deposit_request(state: BeaconState, deposit_request: DepositRequest) -> None:
         # [New in Gloas:EIP7732]
         builder_pubkeys = [b.pubkey for b in state.builders]
@@ -7379,6 +7476,7 @@
                 deposit_request.withdrawal_credentials,
                 deposit_request.amount,
                 deposit_request.signature,
+                state.slot,
             )
             return
 
@@ -7883,7 +7981,7 @@
 - name: process_execution_payload#gloas
   sources: []
   spec: |
-    <spec fn="process_execution_payload" fork="gloas" hash="98cceb7d">
+    <spec fn="process_execution_payload" fork="gloas" hash="36bd3af3">
     def process_execution_payload(
         state: BeaconState,
         # [Modified in Gloas:EIP7732]
@@ -7913,7 +8011,6 @@
         # Verify consistency with the committed bid
         committed_bid = state.latest_execution_payload_bid
         assert envelope.builder_index == committed_bid.builder_index
-        assert committed_bid.blob_kzg_commitments_root == hash_tree_root(envelope.blob_kzg_commitments)
         assert committed_bid.prev_randao == payload.prev_randao
 
         # Verify consistency with expected withdrawals
@@ -7927,14 +8024,11 @@
         assert payload.parent_hash == state.latest_block_hash
         # Verify timestamp
         assert payload.timestamp == compute_time_at_slot(state, state.slot)
-        # Verify commitments are under limit
-        assert (
-            len(envelope.blob_kzg_commitments)
-            <= get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
-        )
         # Verify the execution payload is valid
         versioned_hashes = [
-            kzg_commitment_to_versioned_hash(commitment) for commitment in envelope.blob_kzg_commitments
+            kzg_commitment_to_versioned_hash(commitment)
+            # [Modified in Gloas:EIP7732]
+            for commitment in committed_bid.blob_kzg_commitments
         ]
         requests = envelope.execution_requests
         assert execution_engine.verify_and_notify_new_payload(
@@ -7977,7 +8071,7 @@
     - file: packages/state-transition/src/block/processExecutionPayloadBid.ts
       search: export function processExecutionPayloadBid(
   spec: |
-    <spec fn="process_execution_payload_bid" fork="gloas" hash="6dc696bb">
+    <spec fn="process_execution_payload_bid" fork="gloas" hash="823c9f3a">
     def process_execution_payload_bid(state: BeaconState, block: BeaconBlock) -> None:
         signed_bid = block.body.signed_execution_payload_bid
         bid = signed_bid.message
@@ -7995,6 +8089,12 @@
             assert can_builder_cover_bid(state, builder_index, amount)
             # Verify that the bid signature is valid
             assert verify_execution_payload_bid_signature(state, signed_bid)
+
+        # Verify commitments are under limit
+        assert (
+            len(bid.blob_kzg_commitments)
+            <= get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
+        )
 
         # Verify that the bid is for the current slot
         assert bid.slot == block.slot
@@ -9574,9 +9674,11 @@
     - file: packages/state-transition/src/block/slashValidator.ts
       search: export function slashValidator(
   spec: |
-    <spec fn="slash_validator" fork="phase0" hash="85d8d7c9">
+    <spec fn="slash_validator" fork="phase0" hash="d2b5fafa">
     def slash_validator(
-        state: BeaconState, slashed_index: ValidatorIndex, whistleblower_index: ValidatorIndex = None
+        state: BeaconState,
+        slashed_index: ValidatorIndex,
+        whistleblower_index: Optional[ValidatorIndex] = None,
     ) -> None:
         """
         Slash the validator with index ``slashed_index``.
@@ -9608,9 +9710,11 @@
     - file: packages/state-transition/src/block/slashValidator.ts
       search: export function slashValidator(
   spec: |
-    <spec fn="slash_validator" fork="altair" hash="88f6c284">
+    <spec fn="slash_validator" fork="altair" hash="179ea102">
     def slash_validator(
-        state: BeaconState, slashed_index: ValidatorIndex, whistleblower_index: ValidatorIndex = None
+        state: BeaconState,
+        slashed_index: ValidatorIndex,
+        whistleblower_index: Optional[ValidatorIndex] = None,
     ) -> None:
         """
         Slash the validator with index ``slashed_index``.
@@ -9642,9 +9746,11 @@
     - file: packages/state-transition/src/block/slashValidator.ts
       search: export function slashValidator(
   spec: |
-    <spec fn="slash_validator" fork="bellatrix" hash="124f6889">
+    <spec fn="slash_validator" fork="bellatrix" hash="5964268e">
     def slash_validator(
-        state: BeaconState, slashed_index: ValidatorIndex, whistleblower_index: ValidatorIndex = None
+        state: BeaconState,
+        slashed_index: ValidatorIndex,
+        whistleblower_index: Optional[ValidatorIndex] = None,
     ) -> None:
         """
         Slash the validator with index ``slashed_index``.
@@ -9676,9 +9782,11 @@
     - file: packages/state-transition/src/block/slashValidator.ts
       search: export function slashValidator(
   spec: |
-    <spec fn="slash_validator" fork="electra" hash="54b64d21">
+    <spec fn="slash_validator" fork="electra" hash="07e584e2">
     def slash_validator(
-        state: BeaconState, slashed_index: ValidatorIndex, whistleblower_index: ValidatorIndex = None
+        state: BeaconState,
+        slashed_index: ValidatorIndex,
+        whistleblower_index: Optional[ValidatorIndex] = None,
     ) -> None:
         """
         Slash the validator with index ``slashed_index``.
@@ -10723,7 +10831,7 @@
     - file: packages/state-transition/src/slot/upgradeStateToGloas.ts
       search: export function upgradeStateToGloas(
   spec: |
-    <spec fn="upgrade_to_gloas" fork="gloas" hash="855ad3f7">
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="6e66df25">
     def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         epoch = fulu.get_current_epoch(pre)
 
@@ -10791,6 +10899,9 @@
             # [New in Gloas:EIP7732]
             payload_expected_withdrawals=[],
         )
+
+        # [New in Gloas:EIP7732]
+        onboard_builders_from_pending_deposits(post)
 
         return post
     </spec>
@@ -11100,8 +11211,12 @@
 - name: verify_data_column_sidecar#gloas
   sources: []
   spec: |
-    <spec fn="verify_data_column_sidecar" fork="gloas" hash="8838c4fd">
-    def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
+    <spec fn="verify_data_column_sidecar" fork="gloas" hash="71548b68">
+    def verify_data_column_sidecar(
+        sidecar: DataColumnSidecar,
+        # [New in Gloas:EIP7732]
+        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+    ) -> bool:
         """
         Verify if the data column sidecar is valid.
         """
@@ -11109,18 +11224,14 @@
         if sidecar.index >= NUMBER_OF_COLUMNS:
             return False
 
+        # [Modified in Gloas:EIP7732]
         # A sidecar for zero blobs is invalid
-        if len(sidecar.kzg_commitments) == 0:
+        if len(sidecar.column) == 0:
             return False
 
         # [Modified in Gloas:EIP7732]
-        # Check that the sidecar respects the blob limit
-        epoch = compute_epoch_at_slot(sidecar.slot)
-        if len(sidecar.kzg_commitments) > get_blob_parameters(epoch).max_blobs_per_block:
-            return False
-
         # The column length must be equal to the number of commitments/proofs
-        if len(sidecar.column) != len(sidecar.kzg_commitments) or len(sidecar.column) != len(
+        if len(sidecar.column) != len(kzg_commitments) or len(sidecar.column) != len(
             sidecar.kzg_proofs
         ):
             return False
@@ -11163,6 +11274,33 @@
         # Batch verify that the cells match the corresponding commitments and proofs
         return verify_cell_kzg_proof_batch(
             commitments_bytes=sidecar.kzg_commitments,
+            cell_indices=cell_indices,
+            cells=sidecar.column,
+            proofs_bytes=sidecar.kzg_proofs,
+        )
+    </spec>
+
+- name: verify_data_column_sidecar_kzg_proofs#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+      search: export async function verifyDataColumnSidecarKzgProofs(
+  spec: |
+    <spec fn="verify_data_column_sidecar_kzg_proofs" fork="gloas" hash="1c4cf857">
+    def verify_data_column_sidecar_kzg_proofs(
+        sidecar: DataColumnSidecar,
+        # [New in Gloas:EIP7732]
+        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+    ) -> bool:
+        """
+        Verify if the KZG proofs are correct.
+        """
+        # The column index also represents the cell index
+        cell_indices = [CellIndex(sidecar.index)] * len(sidecar.column)
+
+        # Batch verify that the cells match the corresponding commitments and proofs
+        return verify_cell_kzg_proof_batch(
+            # [Modified in Gloas:EIP7732]
+            commitments_bytes=kzg_commitments,
             cell_indices=cell_indices,
             cells=sidecar.column,
             proofs_bytes=sidecar.kzg_proofs,


### PR DESCRIPTION
## Motivation

This implements [consensus-specs PR #4875](https://github.com/ethereum/consensus-specs/pull/4875) which moves `blobKzgCommitments` from the `ExecutionPayloadEnvelope` to the `ExecutionPayloadBid` for the GLOAS fork.

## Changes

### Types (`packages/types`)
- `ExecutionPayloadBid`: Changed `blobKzgCommitmentsRoot: Root` → `blobKzgCommitments: BlobKzgCommitments`
- `ExecutionPayloadEnvelope`: Removed `blobKzgCommitments` field
- `DataColumnSidecar`: Updated comments to reflect that `kzgCommitments` and `kzgProofs` now come from the bid

### State Transition (`packages/state-transition`)
- `processExecutionPayloadBid`: Added commitments length check (moved from envelope)
- `processExecutionPayloadEnvelope`: Removed KZG root check, removed commitments length check
- `upgradeStateToGloas`: Added `onboard_builders_from_pending_deposits` per spec

### Sync Utilities (`packages/beacon-node`)
- `downloadByRange.ts` / `downloadByRoot.ts`: Get `blobCount` from bid for GLOAS+ forks

### Spec Updates
- Updated spec test version to v1.7.0-alpha.2
- Updated spec references in `specrefs/`

## Testing

- All existing unit tests pass
- Spec tests pass with v1.7.0-alpha.2 fixtures

## Breaking Changes

None for external consumers.

---
*This PR was mass-produced by a mass-production AI 🤖*