### PR TITLE
chore: add manually triggered workflow for ad-hoc Docker image tagging

### DIFF
--- a/.github/workflows/publish-adhoc.yml
+++ b/.github/workflows/publish-adhoc.yml
@@ -1,0 +1,87 @@
+name: Publish ad-hoc Docker image
+
+# Manual workflow for tagging ad-hoc Docker images from any commit
+# Useful for testing specific commits or creating custom releases
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build from (commit SHA, branch, or tag)"
+        required: true
+        type: string
+      tag:
+        description: "Docker tag to apply (e.g., test-feature, debug-v1.2.3)"
+        required: true
+        type: string
+      push:
+        description: "Push image to Docker Hub (uncheck for local build test)"
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    name: Build and push Docker image
+    runs-on: buildjet-4vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Validate inputs
+        run: |
+          # Ensure tag doesn't conflict with protected tags
+          if [[ "${{ inputs.tag }}" =~ ^(latest|next|stable|rc)$ ]]; then
+            echo "Error: Cannot use reserved tag '${{ inputs.tag }}'. Use a custom tag name."
+            exit 1
+          fi
+          # Ensure ref exists
+          git rev-parse --verify ${{ inputs.ref }} || {
+            echo "Error: Git ref '${{ inputs.ref }}' not found"
+            exit 1
+          }
+          echo "Building from ref: ${{ inputs.ref }}"
+          echo "Commit: $(git rev-parse HEAD)"
+          echo "Tag: ${{ inputs.tag }}"
+
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: ${{ inputs.push }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push lodestar
+        run: >
+          docker buildx build . ${{ inputs.push && '--push' || '--load' }}
+          --tag chainsafe/lodestar:${{ inputs.tag }}
+          --platform ${{ inputs.push && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          --build-arg COMMIT=$(git rev-parse HEAD)
+
+      - name: Test image
+        run: docker run chainsafe/lodestar:${{ inputs.tag }} --help
+
+      - name: Display image history
+        run: docker image history chainsafe/lodestar:${{ inputs.tag }}
+
+      - name: Summary
+        run: |
+          echo "## Docker Image Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag:** \`chainsafe/lodestar:${{ inputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Ref:** \`${{ inputs.ref }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit:** \`$(git rev-parse HEAD)\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Pushed:** ${{ inputs.push }}" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ inputs.push }}" == "true" ]]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Pull with: \`docker pull chainsafe/lodestar:${{ inputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Motivation

Follow-up from #8821 — adds a manually triggered workflow for ad-hoc Docker image tagging.

## Description

Adds a `workflow_dispatch` workflow that allows building and tagging Docker images from any git ref with a custom tag name.

### Features

- **Git ref input**: Build from any commit SHA, branch, or tag
- **Custom tag**: Apply any custom Docker tag (with validation to prevent overwriting `latest`, `next`, etc.)
- **Push toggle**: Option to push to Docker Hub or just build locally for testing
- **Multi-platform**: Builds for amd64/arm64 when pushing
- **Sanity checks**: Runs `--help` and displays image history
- **Job summary**: Shows pull command after successful push

### Usage

1. Go to Actions → "Publish ad-hoc Docker image"
2. Click "Run workflow"
3. Enter:
   - Git ref (e.g., `abc1234`, `unstable`, `v1.24.0`)
   - Docker tag (e.g., `test-feature`, `debug-issue-123`)
   - Whether to push to Docker Hub
4. Pull with `docker pull chainsafe/lodestar:<your-tag>`

---

*This PR was authored by an AI contributor (Lodekeeper) with human supervision.*