### PR TITLE
fix(api): allow duplicate columns/blobs in publishBlock for multi-BN setups

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -141,7 +141,7 @@ export function getBeaconBlockApi({
             seenTimestampSec,
           },
           // In multi-BN setups (DVT, fallback), the same block may be published to multiple nodes.
-          // Data columns/blobs may arrive via gossip from another node before the API publish completes,
+          // Data columns may arrive via gossip from another node before the API publish completes,
           // so we allow duplicates here instead of throwing an error.
           {throwOnDuplicateAdd: false}
         );

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -131,9 +131,6 @@ export function getBeaconBlockApi({
       dataColumnSidecars = [];
     }
 
-    // In multi-BN setups (DVT, fallback), the same block may be published to multiple nodes.
-    // Data columns/blobs may arrive via gossip from another node before the API publish completes,
-    // so we allow duplicates here instead of throwing an error.
     if (isBlockInputColumns(blockForImport)) {
       for (const dataColumnSidecar of dataColumnSidecars) {
         blockForImport.addColumn(
@@ -143,6 +140,9 @@ export function getBeaconBlockApi({
             source: BlockInputSource.api,
             seenTimestampSec,
           },
+          // In multi-BN setups (DVT, fallback), the same block may be published to multiple nodes.
+          // Data columns/blobs may arrive via gossip from another node before the API publish completes,
+          // so we allow duplicates here instead of throwing an error.
           {throwOnDuplicateAdd: false}
         );
       }
@@ -155,6 +155,7 @@ export function getBeaconBlockApi({
             source: BlockInputSource.api,
             seenTimestampSec,
           },
+          // Same as above for columns
           {throwOnDuplicateAdd: false}
         );
       }

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -131,6 +131,9 @@ export function getBeaconBlockApi({
       dataColumnSidecars = [];
     }
 
+    // In multi-BN setups (DVT, fallback), the same block may be published to multiple nodes.
+    // Data columns/blobs may arrive via gossip from another node before the API publish completes,
+    // so we allow duplicates here instead of throwing an error.
     if (isBlockInputColumns(blockForImport)) {
       for (const dataColumnSidecar of dataColumnSidecars) {
         blockForImport.addColumn(
@@ -140,9 +143,6 @@ export function getBeaconBlockApi({
             source: BlockInputSource.api,
             seenTimestampSec,
           },
-          // In multi-BN setups (DVT, fallback), the same block may be published to multiple nodes.
-          // Columns may arrive via gossip from another node before the API publish completes,
-          // so we allow duplicates here instead of throwing an error.
           {throwOnDuplicateAdd: false}
         );
       }
@@ -155,9 +155,6 @@ export function getBeaconBlockApi({
             source: BlockInputSource.api,
             seenTimestampSec,
           },
-          // In multi-BN setups (DVT, fallback), the same block may be published to multiple nodes.
-          // Blobs may arrive via gossip from another node before the API publish completes,
-          // so we allow duplicates here instead of throwing an error.
           {throwOnDuplicateAdd: false}
         );
       }

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -133,9 +133,6 @@ export function getBeaconBlockApi({
 
     if (isBlockInputColumns(blockForImport)) {
       for (const dataColumnSidecar of dataColumnSidecars) {
-        // In multi-BN setups (DVT, fallback), the same block may be published to multiple nodes.
-        // Columns may arrive via gossip from another node before the API publish completes,
-        // so we allow duplicates here instead of throwing an error.
         blockForImport.addColumn(
           {
             blockRootHex: blockRoot,
@@ -143,14 +140,14 @@ export function getBeaconBlockApi({
             source: BlockInputSource.api,
             seenTimestampSec,
           },
+          // In multi-BN setups (DVT, fallback), the same block may be published to multiple nodes.
+          // Columns may arrive via gossip from another node before the API publish completes,
+          // so we allow duplicates here instead of throwing an error.
           {throwOnDuplicateAdd: false}
         );
       }
     } else if (isBlockInputBlobs(blockForImport)) {
       for (const blobSidecar of blobSidecars) {
-        // In multi-BN setups (DVT, fallback), the same block may be published to multiple nodes.
-        // Blobs may arrive via gossip from another node before the API publish completes,
-        // so we allow duplicates here instead of throwing an error.
         blockForImport.addBlob(
           {
             blockRootHex: blockRoot,
@@ -158,6 +155,9 @@ export function getBeaconBlockApi({
             source: BlockInputSource.api,
             seenTimestampSec,
           },
+          // In multi-BN setups (DVT, fallback), the same block may be published to multiple nodes.
+          // Blobs may arrive via gossip from another node before the API publish completes,
+          // so we allow duplicates here instead of throwing an error.
           {throwOnDuplicateAdd: false}
         );
       }

--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -133,21 +133,33 @@ export function getBeaconBlockApi({
 
     if (isBlockInputColumns(blockForImport)) {
       for (const dataColumnSidecar of dataColumnSidecars) {
-        blockForImport.addColumn({
-          blockRootHex: blockRoot,
-          columnSidecar: dataColumnSidecar,
-          source: BlockInputSource.api,
-          seenTimestampSec,
-        });
+        // In multi-BN setups (DVT, fallback), the same block may be published to multiple nodes.
+        // Columns may arrive via gossip from another node before the API publish completes,
+        // so we allow duplicates here instead of throwing an error.
+        blockForImport.addColumn(
+          {
+            blockRootHex: blockRoot,
+            columnSidecar: dataColumnSidecar,
+            source: BlockInputSource.api,
+            seenTimestampSec,
+          },
+          {throwOnDuplicateAdd: false}
+        );
       }
     } else if (isBlockInputBlobs(blockForImport)) {
       for (const blobSidecar of blobSidecars) {
-        blockForImport.addBlob({
-          blockRootHex: blockRoot,
-          blobSidecar,
-          source: BlockInputSource.api,
-          seenTimestampSec,
-        });
+        // In multi-BN setups (DVT, fallback), the same block may be published to multiple nodes.
+        // Blobs may arrive via gossip from another node before the API publish completes,
+        // so we allow duplicates here instead of throwing an error.
+        blockForImport.addBlob(
+          {
+            blockRootHex: blockRoot,
+            blobSidecar,
+            source: BlockInputSource.api,
+            seenTimestampSec,
+          },
+          {throwOnDuplicateAdd: false}
+        );
       }
     }
 


### PR DESCRIPTION
## Description

Fixes #8848

In multi-beacon-node setups (DVT, fallback configurations, high-availability validators), the same block may be published to multiple beacon nodes simultaneously. When this happens, a race condition can occur:

1. Validator client (e.g., Vero) requests an unsigned block from Node A
2. Validator signs the block
3. Validator publishes the signed block to **multiple nodes** (Node A and Node B)
4. Node A receives the publish first and starts gossiping the block + data columns
5. Node B receives columns via gossip from Node A
6. Node B's API publish handler tries to add columns that already exist in the cache
7. `publishBlockV2` throws `BLOCK_INPUT_ERROR_INVALID_CONSTRUCTION` with message "Cannot addColumn to BlockInputColumns with duplicate column index"

The same issue can occur with blobs in pre-Fulu forks.

## Solution

Pass `{throwOnDuplicateAdd: false}` to `addColumn()` and `addBlob()` in `publishBlock`. This option already exists and is used correctly in `seenGossipBlockInput.ts` when handling gossip-received data. Receiving the same columns/blobs from both gossip and API is valid behavior in multi-BN setups and should not throw an error.

## Testing

The fix uses an existing, well-tested code path. The `throwOnDuplicateAdd: false` option causes `addColumn`/`addBlob` to silently return when a duplicate is detected, which is the correct behavior when the same data arrives from multiple sources.

---

*This PR was developed with AI assistance (disclosure per project contribution guidelines).*