### PR TITLE
ci: disable bun unit tests in code

### DIFF
--- a/.github/workflows/test-bun.yml
+++ b/.github/workflows/test-bun.yml
@@ -1,40 +1,40 @@
-name: Bun Tests
-# only one can run at a time
-concurrency:
-  # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+# name: Bun Tests
+# # only one can run at a time
+# concurrency:
+#   # If PR, cancel prev commits. head_ref = source branch name on pull_request, null if push
+#   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+#   cancel-in-progress: true
 
-on:
-  push:
-    # We intentionally don't run push on feature branches. See PR for rational.
-    branches: [unstable, stable]
-  pull_request:
-  workflow_dispatch:
+# on:
+#   push:
+#     # We intentionally don't run push on feature branches. See PR for rational.
+#     branches: [unstable, stable]
+#   pull_request:
+#   workflow_dispatch:
 
-jobs:
-  unit-tests-bun:
-    name: Unit Tests (Bun)
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install pnpm before setup node
-        uses: pnpm/action-setup@v4
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - name: Install pnpm
-        run: bun install -g npm:pnpm
-      - name: Install
-        run: pnpm install --frozen-lockfile
-      - name: Build
-        run: pnpm build
-      - name: Unit Tests
-        # These packages are not testable yet in Bun because of `@chainsafe/blst` dependency.
-        run: excluded=(beacon-node prover light-client cli); for pkg in packages/*/; do [[ ! " ${excluded[@]} " =~ " $(basename "$pkg") " ]] && echo "Testing $(basename "$pkg")" && (cd "$pkg" && bun run --bun test:unit); done
-        shell: bash
+# jobs:
+#   unit-tests-bun:
+#     name: Unit Tests (Bun)
+#     runs-on: buildjet-4vcpu-ubuntu-2204
+#     steps:
+#       - uses: actions/checkout@v4
+#       - name: Install pnpm before setup node
+#         uses: pnpm/action-setup@v4
+#       - name: Setup Node
+#         uses: actions/setup-node@v6
+#         with:
+#           node-version: 24
+#           cache: pnpm
+#       - uses: oven-sh/setup-bun@v2
+#         with:
+#           bun-version: latest
+#       - name: Install pnpm
+#         run: bun install -g npm:pnpm
+#       - name: Install
+#         run: pnpm install --frozen-lockfile
+#       - name: Build
+#         run: pnpm build
+#       - name: Unit Tests
+#         # These packages are not testable yet in Bun because of `@chainsafe/blst` dependency.
+#         run: excluded=(beacon-node prover light-client cli); for pkg in packages/*/; do [[ ! " ${excluded[@]} " =~ " $(basename "$pkg") " ]] && echo "Testing $(basename "$pkg")" && (cd "$pkg" && bun run --bun test:unit); done
+#         shell: bash


### PR DESCRIPTION
**Motivation**

Discussed in Bun discord thread that since we are no longer targeting Bun currently in our main development path, we can disabled unit tests until there's a bit more maturity upstream. This was also discussed on standup Feb 3, 2026: #8843 

**Description**

This PR disables `test-bun.yml` by commenting out the yaml.
