### PR TITLE
chore: add .venv and checkpoint_states to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ packages/cli/.git-data.json
 dictionary.dic
 
 temp/
+
+# Local development artifacts
+.venv/
+checkpoint_states/


### PR DESCRIPTION
Adds local development artifacts to .gitignore:

- `.venv/` - Python virtual environments (used for spec tools like ethspecify)
- `checkpoint_states/` - Checkpoint state files from local testing