### PR TITLE
chore: fix lint warnings

### DIFF
--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -340,9 +340,8 @@ export class BeaconChain implements IBeaconChain {
     const blockStateCache = new FIFOBlockStateCache(this.opts, {metrics});
     this.bufferPool = new BufferPool(anchorState.type.tree_serializedSize(anchorState.node), metrics);
 
-    let checkpointStateCache: CheckpointStateCache;
     this.cpStateDatastore = fileDataStore ? new FileCPStateDatastore(dataDir) : new DbCPStateDatastore(this.db);
-    checkpointStateCache = new PersistentCheckpointStateCache(
+    const checkpointStateCache: CheckpointStateCache = new PersistentCheckpointStateCache(
       {
         config,
         metrics,


### PR DESCRIPTION
## Description

Fix two lint warnings in the codebase:

1. **packages/beacon-node/src/chain/chain.ts:343** - `let` → `const` for `checkpointStateCache` since it's only assigned once

2. **packages/light-client/test/unit/webEsmBundle.browser.test.ts:3** - Remove unused `biome-ignore` comment (the rule it was suppressing is no longer triggered)

---

*This PR was authored with AI assistance (Lodekeeper 🔥)*