### PR TITLE
chore: consume BeaconStateView

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -607,7 +607,7 @@ export function getBeaconBlockApi({
         if (slot < head.slot && head.slot <= slot + SLOTS_PER_HISTORICAL_ROOT) {
           const state = chain.getHeadState();
           return {
-            data: {root: state.blockRoots.get(slot % SLOTS_PER_HISTORICAL_ROOT)},
+            data: {root: state.getBlockRootAtSlot(slot)},
             meta: {
               executionOptimistic: isOptimisticBlock(head),
               finalized: computeEpochAtSlot(slot) <= chain.forkChoice.getFinalizedCheckpoint().epoch,

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -1,7 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {ForkPostElectra, ForkPreElectra, SYNC_COMMITTEE_SUBNET_SIZE, isForkPostElectra} from "@lodestar/params";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Attestation, Epoch, SingleAttestation, isElectraAttestation, ssz, sszTypesFor} from "@lodestar/types";
 import {
   AttestationError,
@@ -256,7 +255,7 @@ export function getBeaconPoolApi({
       await Promise.all(
         signatures.map(async (signature, i) => {
           try {
-            const synCommittee = state.getIndexedSyncCommitteeAtEpoch(computeEpochAtSlot(signature.slot));
+            const synCommittee = state.getIndexedSyncCommittee(signature.slot);
             const indexesInCommittee = synCommittee.validatorIndexMap.get(signature.validatorIndex);
             if (indexesInCommittee === undefined || indexesInCommittee.length === 0) {
               return; // Not a sync committee member

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -1,6 +1,7 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {ForkPostElectra, ForkPreElectra, SYNC_COMMITTEE_SUBNET_SIZE, isForkPostElectra} from "@lodestar/params";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {Attestation, Epoch, SingleAttestation, isElectraAttestation, ssz, sszTypesFor} from "@lodestar/types";
 import {
   AttestationError,
@@ -255,7 +256,7 @@ export function getBeaconPoolApi({
       await Promise.all(
         signatures.map(async (signature, i) => {
           try {
-            const synCommittee = state.epochCtx.getIndexedSyncCommittee(signature.slot);
+            const synCommittee = state.getIndexedSyncCommitteeAtEpoch(computeEpochAtSlot(signature.slot));
             const indexesInCommittee = synCommittee.validatorIndexMap.get(signature.validatorIndex);
             if (indexesInCommittee === undefined || indexesInCommittee.length === 0) {
               return; // Not a sync committee member

--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -8,17 +8,12 @@ import {
   isForkPostFulu,
 } from "@lodestar/params";
 import {
-  BeaconStateAllForks,
-  BeaconStateElectra,
-  BeaconStateFulu,
-  CachedBeaconStateAltair,
+  IBeaconStateView,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   getCurrentEpoch,
-  getRandaoMix,
-  loadState,
 } from "@lodestar/state-transition";
-import {ValidatorIndex, getValidatorStatus} from "@lodestar/types";
+import {ValidatorIndex, getValidatorStatus, ssz} from "@lodestar/types";
 import {ApiError} from "../../errors.js";
 import {ApiModules} from "../../types.js";
 import {assertUniqueItems} from "../../utils.js";
@@ -35,11 +30,11 @@ export function getBeaconStateApi({
 }: Pick<ApiModules, "chain" | "config">): ApplicationMethods<routes.beacon.state.Endpoints> {
   async function getState(
     stateId: routes.beacon.StateId
-  ): Promise<{state: BeaconStateAllForks; executionOptimistic: boolean; finalized: boolean}> {
+  ): Promise<{state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean}> {
     const {state, executionOptimistic, finalized} = await getStateResponseWithRegen(chain, stateId);
 
     return {
-      state: state instanceof Uint8Array ? loadState(config, chain.getHeadState(), state).state : state,
+      state: state instanceof Uint8Array ? chain.getHeadState().loadOtherState(state) : state,
       executionOptimistic,
       finalized,
     };
@@ -71,7 +66,7 @@ export function getBeaconStateApi({
         throw new ApiError(400, "Requested epoch is out of range");
       }
 
-      const randao = getRandaoMix(state, usedEpoch);
+      const randao = state.getRandaoMix(usedEpoch);
 
       return {
         data: {randao},
@@ -94,7 +89,6 @@ export function getBeaconStateApi({
     async getStateValidators({stateId, validatorIds = [], statuses = []}) {
       const {state, executionOptimistic, finalized} = await getState(stateId);
       const currentEpoch = getCurrentEpoch(state);
-      const {validators, balances} = state; // Get the validators sub tree once for all the loop
       const {pubkeyCache} = chain;
 
       const validatorResponses: routes.beacon.ValidatorResponse[] = [];
@@ -105,14 +99,14 @@ export function getBeaconStateApi({
           const resp = getStateValidatorIndex(id, state, pubkeyCache);
           if (resp.valid) {
             const validatorIndex = resp.validatorIndex;
-            const validator = validators.getReadonly(validatorIndex);
+            const validator = state.getValidator(validatorIndex);
             if (statuses.length && !statuses.includes(getValidatorStatus(validator, currentEpoch))) {
               continue;
             }
             const validatorResponse = toValidatorResponse(
               validatorIndex,
               validator,
-              balances.get(validatorIndex),
+              state.getBalance(validatorIndex),
               currentEpoch
             );
             validatorResponses.push(validatorResponse);
@@ -135,8 +129,8 @@ export function getBeaconStateApi({
       }
 
       // TODO: This loops over the entire state, it's a DOS vector
-      const validatorsArr = state.validators.getAllReadonlyValues();
-      const balancesArr = state.balances.getAll();
+      const validatorsArr = state.getAllValidators();
+      const balancesArr = state.getAllBalances();
       const resp: routes.beacon.ValidatorResponse[] = [];
       for (let i = 0; i < validatorsArr.length; i++) {
         resp.push(toValidatorResponse(i, validatorsArr[i], balancesArr[i], currentEpoch));
@@ -166,12 +160,12 @@ export function getBeaconStateApi({
           const resp = getStateValidatorIndex(id, state, pubkeyCache);
           if (resp.valid) {
             const index = resp.validatorIndex;
-            const {pubkey, activationEpoch} = state.validators.getReadonly(index);
+            const {pubkey, activationEpoch} = state.getValidator(index);
             validatorIdentities.push({index, pubkey, activationEpoch});
           }
         }
       } else {
-        const validatorsArr = state.validators.getAllReadonlyValues();
+        const validatorsArr = state.getAllValidators();
         validatorIdentities = new Array(validatorsArr.length) as routes.beacon.ValidatorIdentities;
         for (let i = 0; i < validatorsArr.length; i++) {
           const {pubkey, activationEpoch} = validatorsArr[i];
@@ -198,8 +192,8 @@ export function getBeaconStateApi({
       return {
         data: toValidatorResponse(
           validatorIndex,
-          state.validators.getReadonly(validatorIndex),
-          state.balances.get(validatorIndex),
+          state.getValidator(validatorIndex),
+          state.getBalance(validatorIndex),
           getCurrentEpoch(state)
         ),
         meta: {executionOptimistic, finalized},
@@ -219,7 +213,7 @@ export function getBeaconStateApi({
           if (resp.valid) {
             balances.push({
               index: resp.validatorIndex,
-              balance: state.balances.get(resp.validatorIndex),
+              balance: state.getBalance(resp.validatorIndex),
             });
           }
         }
@@ -230,7 +224,7 @@ export function getBeaconStateApi({
       }
 
       // TODO: This loops over the entire state, it's a DOS vector
-      const balancesArr = state.balances.getAll();
+      const balancesArr = state.getAllBalances();
       const resp: routes.beacon.ValidatorBalance[] = [];
       for (let i = 0; i < balancesArr.length; i++) {
         resp.push({index: i, balance: balancesArr[i]});
@@ -248,11 +242,6 @@ export function getBeaconStateApi({
     async getEpochCommittees({stateId, ...filters}) {
       const {state, executionOptimistic, finalized} = await getState(stateId);
 
-      const stateCached = state as CachedBeaconStateAltair;
-      if (stateCached.epochCtx === undefined) {
-        throw new ApiError(400, `No cached state available for stateId: ${stateId}`);
-      }
-
       const stateEpoch = computeEpochAtSlot(state.slot);
       const epoch = filters.epoch ?? stateEpoch;
       const startSlot = computeStartSlotAtEpoch(epoch);
@@ -266,7 +255,7 @@ export function getBeaconStateApi({
         throw new ApiError(400, `Slot ${filters.slot} is not in epoch ${epoch}`);
       }
 
-      const decisionRoot = stateCached.epochCtx.getShufflingDecisionRoot(epoch);
+      const decisionRoot = state.getShufflingDecisionRoot(epoch);
       const shuffling = await chain.shufflingCache.get(epoch, decisionRoot);
       if (!shuffling) {
         throw new ApiError(
@@ -315,12 +304,7 @@ export function getBeaconStateApi({
         throw new ApiError(400, "Requested state before ALTAIR_FORK_EPOCH");
       }
 
-      const stateCached = state as CachedBeaconStateAltair;
-      if (stateCached.epochCtx === undefined) {
-        throw new ApiError(400, `No cached state available for stateId: ${stateId}`);
-      }
-
-      const syncCommitteeCache = stateCached.epochCtx.getIndexedSyncCommitteeAtEpoch(epoch ?? stateEpoch);
+      const syncCommitteeCache = state.getIndexedSyncCommitteeAtEpoch(epoch ?? stateEpoch);
       const validatorIndices = new Array<ValidatorIndex>(...syncCommitteeCache.validatorIndices);
 
       // Subcommittee assignments of the current sync committee
@@ -346,10 +330,10 @@ export function getBeaconStateApi({
         throw new ApiError(400, `Cannot retrieve pending deposits for pre-electra state fork=${fork}`);
       }
 
-      const {pendingDeposits} = state as BeaconStateElectra;
+      const pendingDeposits = state.pendingDeposits;
 
       return {
-        data: context?.returnBytes ? pendingDeposits.serialize() : pendingDeposits.toValue(),
+        data: context?.returnBytes ? ssz.electra.PendingDeposits.serialize(pendingDeposits) : pendingDeposits,
         meta: {executionOptimistic, finalized, version: fork},
       };
     },
@@ -362,10 +346,12 @@ export function getBeaconStateApi({
         throw new ApiError(400, `Cannot retrieve pending partial withdrawals for pre-electra state fork=${fork}`);
       }
 
-      const {pendingPartialWithdrawals} = state as BeaconStateElectra;
+      const pendingPartialWithdrawals = state.pendingPartialWithdrawals;
 
       return {
-        data: context?.returnBytes ? pendingPartialWithdrawals.serialize() : pendingPartialWithdrawals.toValue(),
+        data: context?.returnBytes
+          ? ssz.electra.PendingPartialWithdrawals.serialize(pendingPartialWithdrawals)
+          : pendingPartialWithdrawals,
         meta: {executionOptimistic, finalized, version: fork},
       };
     },
@@ -378,10 +364,12 @@ export function getBeaconStateApi({
         throw new ApiError(400, `Cannot retrieve pending consolidations for pre-electra state fork=${fork}`);
       }
 
-      const {pendingConsolidations} = state as BeaconStateElectra;
+      const pendingConsolidations = state.pendingConsolidations;
 
       return {
-        data: context?.returnBytes ? pendingConsolidations.serialize() : pendingConsolidations.toValue(),
+        data: context?.returnBytes
+          ? ssz.electra.PendingConsolidations.serialize(pendingConsolidations)
+          : pendingConsolidations,
         meta: {executionOptimistic, finalized, version: fork},
       };
     },
@@ -394,10 +382,10 @@ export function getBeaconStateApi({
         throw new ApiError(400, `Cannot retrieve proposer lookahead for pre-fulu state fork=${fork}`);
       }
 
-      const {proposerLookahead} = state as BeaconStateFulu;
+      const proposerLookahead = state.proposerLookahead;
 
       return {
-        data: context?.returnBytes ? proposerLookahead.serialize() : proposerLookahead.toValue(),
+        data: context?.returnBytes ? ssz.fulu.ProposerLookahead.serialize(proposerLookahead) : proposerLookahead,
         meta: {executionOptimistic, finalized, version: fork},
       };
     },

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -1,17 +1,8 @@
 import {routes} from "@lodestar/api";
 import {CheckpointWithPayloadStatus, IForkChoice} from "@lodestar/fork-choice";
 import {GENESIS_SLOT} from "@lodestar/params";
-import {BeaconStateAllForks, CachedBeaconStateAllForks, PubkeyCache} from "@lodestar/state-transition";
-import {
-  BLSPubkey,
-  Epoch,
-  RootHex,
-  Slot,
-  ValidatorIndex,
-  getValidatorStatus,
-  mapToGeneralStatus,
-  phase0,
-} from "@lodestar/types";
+import {IBeaconStateView, PubkeyCache} from "@lodestar/state-transition";
+import {BLSPubkey, Epoch, RootHex, Slot, ValidatorIndex, getValidatorStatus, phase0} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../../chain/index.js";
 import {ApiError, ValidationError} from "../../errors.js";
@@ -52,7 +43,7 @@ export function resolveStateId(
 export async function getStateResponseWithRegen(
   chain: IBeaconChain,
   inStateId: routes.beacon.StateId
-): Promise<{state: CachedBeaconStateAllForks | Uint8Array; executionOptimistic: boolean; finalized: boolean}> {
+): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean}> {
   const stateId = resolveStateId(chain.forkChoice, inStateId);
 
   const res =
@@ -89,22 +80,17 @@ export function toValidatorResponse(
 
 export function filterStateValidatorsByStatus(
   statuses: string[],
-  state: BeaconStateAllForks,
+  state: IBeaconStateView,
   pubkeyCache: PubkeyCache,
   currentEpoch: Epoch
 ): routes.beacon.ValidatorResponse[] {
   const responses: routes.beacon.ValidatorResponse[] = [];
-  const validatorsArr = state.validators.getAllReadonlyValues();
-  const statusSet = new Set(statuses);
-
-  for (const validator of validatorsArr) {
-    const validatorStatus = getValidatorStatus(validator, currentEpoch);
-    const generalStatus = mapToGeneralStatus(validatorStatus);
-
+  const validators = state.getValidatorsByStatus(new Set(statuses), currentEpoch);
+  for (const validator of validators) {
     const resp = getStateValidatorIndex(validator.pubkey, state, pubkeyCache);
-    if (resp.valid && (statusSet.has(validatorStatus) || statusSet.has(generalStatus))) {
+    if (resp.valid) {
       responses.push(
-        toValidatorResponse(resp.validatorIndex, validator, state.balances.get(resp.validatorIndex), currentEpoch)
+        toValidatorResponse(resp.validatorIndex, validator, state.getBalance(resp.validatorIndex), currentEpoch)
       );
     }
   }
@@ -117,7 +103,7 @@ type StateValidatorIndexResponse =
 
 export function getStateValidatorIndex(
   id: routes.beacon.ValidatorId | BLSPubkey,
-  state: BeaconStateAllForks,
+  state: IBeaconStateView,
   pubkeyCache: PubkeyCache
 ): StateValidatorIndexResponse {
   if (typeof id === "string") {
@@ -139,7 +125,7 @@ export function getStateValidatorIndex(
     if (!Number.isSafeInteger(validatorIndex)) {
       return {valid: false, code: 400, reason: "Invalid validator index"};
     }
-    if (validatorIndex >= state.validators.length) {
+    if (validatorIndex >= state.validatorCount) {
       return {valid: false, code: 404, reason: "Validator index from future state"};
     }
     return {valid: true, validatorIndex};
@@ -150,7 +136,7 @@ export function getStateValidatorIndex(
   if (validatorIndex === null) {
     return {valid: false, code: 404, reason: "Validator pubkey not found in state"};
   }
-  if (validatorIndex >= state.validators.length) {
+  if (validatorIndex >= state.validatorCount) {
     return {valid: false, code: 404, reason: "Validator pubkey from future state"};
   }
   return {valid: true, validatorIndex};

--- a/packages/beacon-node/src/api/impl/debug/index.ts
+++ b/packages/beacon-node/src/api/impl/debug/index.ts
@@ -79,7 +79,11 @@ export function getDebugApi({
         data = state;
       } else {
         slot = state.slot;
-        data = context?.returnBytes ? state.serialize() : state.toValue();
+        const stateBytes = state.serialize();
+        data = context?.returnBytes
+          ? stateBytes
+          : // TODO: modify api definition too?
+            sszTypesFor(config.getForkName(slot)).BeaconState.deserialize(stateBytes);
       }
       return {
         data,

--- a/packages/beacon-node/src/api/impl/debug/index.ts
+++ b/packages/beacon-node/src/api/impl/debug/index.ts
@@ -79,11 +79,7 @@ export function getDebugApi({
         data = state;
       } else {
         slot = state.slot;
-        const stateBytes = state.serialize();
-        data = context?.returnBytes
-          ? stateBytes
-          : // TODO: modify api definition too?
-            sszTypesFor(config.getForkName(slot)).BeaconState.deserialize(stateBytes);
+        data = context?.returnBytes ? state.serialize() : state.toValue();
       }
       return {
         data,

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -1,10 +1,8 @@
-import {Tree} from "@chainsafe/persistent-merkle-tree";
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {ChainForkConfig} from "@lodestar/config";
 import {Repository} from "@lodestar/db";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {BeaconStateCapella, getLatestWeakSubjectivityCheckpointEpoch, loadState} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {Checkpoint} from "@lodestar/types/phase0";
 import {fromHex, toHex, toRootHex} from "@lodestar/utils";
@@ -86,7 +84,7 @@ export function getLodestarApi({
 
     async getLatestWeakSubjectivityCheckpointEpoch() {
       const state = chain.getHeadState();
-      return {data: getLatestWeakSubjectivityCheckpointEpoch(config, state)};
+      return {data: state.getLatestWeakSubjectivityCheckpointEpoch()};
     },
 
     async getSyncChainsDebugState() {
@@ -214,9 +212,7 @@ export function getLodestarApi({
     async getHistoricalSummaries({stateId}) {
       const {state, executionOptimistic, finalized} = await getStateResponseWithRegen(chain, stateId);
 
-      const stateView = (
-        state instanceof Uint8Array ? loadState(config, chain.getHeadState(), state).state : state
-      ) as BeaconStateCapella;
+      const stateView = state instanceof Uint8Array ? chain.getHeadState().loadOtherState(state) : state;
 
       const fork = config.getForkName(stateView.slot);
       if (ForkSeq[fork] < ForkSeq.capella) {
@@ -224,12 +220,12 @@ export function getLodestarApi({
       }
 
       const {gindex} = ssz[fork].BeaconState.getPathInfo(["historicalSummaries"]);
-      const proof = new Tree(stateView.node).getSingleProof(gindex);
+      const proof = stateView.getSingleProof(gindex);
 
       return {
         data: {
           slot: stateView.slot,
-          historicalSummaries: stateView.historicalSummaries.toValue(),
+          historicalSummaries: stateView.historicalSummaries,
           proof: proof,
         },
         meta: {executionOptimistic, finalized, version: fork},

--- a/packages/beacon-node/src/api/impl/proof/index.ts
+++ b/packages/beacon-node/src/api/impl/proof/index.ts
@@ -1,7 +1,6 @@
 import {CompactMultiProof, ProofType, createProof} from "@chainsafe/persistent-merkle-tree";
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
-import {loadState} from "@lodestar/state-transition";
 import {ApiOptions} from "../../options.js";
 import {getBlockResponse} from "../beacon/blocks/utils.js";
 import {getStateResponseWithRegen} from "../beacon/state/utils.js";
@@ -24,16 +23,10 @@ export function getProofApi(
 
       const res = await getStateResponseWithRegen(chain, stateId);
 
-      const state =
-        res.state instanceof Uint8Array ? loadState(config, chain.getHeadState(), res.state).state : res.state;
-
-      // there should be no state changes in beacon-node so no need to commit() here
-      const stateNode = state.node;
-
-      const proof = createProof(stateNode, {type: ProofType.compactMulti, descriptor});
+      const state = res.state instanceof Uint8Array ? chain.getHeadState().loadOtherState(res.state) : res.state;
 
       return {
-        data: proof as CompactMultiProof,
+        data: state.createMultiProof(descriptor),
         meta: {version: config.getForkName(state.slot)},
       };
     },

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -17,19 +17,14 @@ import {
   isForkPostGloas,
 } from "@lodestar/params";
 import {
-  CachedBeaconStateAllForks,
   DataAvailabilityStatus,
-  attesterShufflingDecisionRoot,
+  IBeaconStateView,
   beaconBlockToBlinded,
   calculateCommitteeAssignments,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   computeTimeAtSlot,
-  createCachedBeaconState,
-  createPubkeyCache,
-  getBlockRootAtSlot,
   getCurrentSlot,
-  loadState,
   proposerShufflingDecisionRoot,
 } from "@lodestar/state-transition";
 import {
@@ -193,11 +188,11 @@ export function getValidatorApi(
   const MAX_API_CLOCK_DISPARITY_MS = MAX_API_CLOCK_DISPARITY_SEC * 1000;
 
   /** Compute and cache the genesis block root */
-  async function getGenesisBlockRoot(state: CachedBeaconStateAllForks): Promise<Root> {
+  async function getGenesisBlockRoot(state: IBeaconStateView): Promise<Root> {
     if (!genesisBlockRoot) {
       // Close to genesis the genesis block may not be available in the DB
-      if (state.slot < SLOTS_PER_HISTORICAL_ROOT) {
-        genesisBlockRoot = state.blockRoots.get(0);
+      if (state.slot < SLOTS_PER_HISTORICAL_ROOT && state.slot > GENESIS_SLOT) {
+        genesisBlockRoot = state.getBlockRootAtSlot(GENESIS_SLOT);
       }
 
       const blockRes = await chain.getCanonicalBlockAtSlot(GENESIS_SLOT);
@@ -303,7 +298,7 @@ export function getValidatorApi(
    *                    |
    *              prepareNextSlot (4s before next slot)
    */
-  async function waitForCheckpointState(cpHex: CheckpointHexPayload): Promise<CachedBeaconStateAllForks | null> {
+  async function waitForCheckpointState(cpHex: CheckpointHexPayload): Promise<IBeaconStateView | null> {
     const cpState = chain.regen.getCheckpointStateSync(cpHex);
     if (cpState) {
       return cpState;
@@ -995,7 +990,7 @@ export function getValidatorApi(
             headBlockRoot
           : // Permit attesting to slots *prior* to the current head. This is desirable when
             // the VC and BN are out-of-sync due to time issues or overloading.
-            getBlockRootAtSlot(headState, slot);
+            headState.getBlockRootAtSlot(slot);
 
       let index: CommitteeIndex;
       if (isForkPostGloas(fork)) {
@@ -1026,7 +1021,7 @@ export function getValidatorApi(
         targetSlot >= headSlot
           ? // If the state is earlier than the target slot then the target *must* be the head block root.
             headBlockRoot
-          : getBlockRootAtSlot(headState, targetSlot);
+          : headState.getBlockRootAtSlot(targetSlot);
 
       // Check the execution status as validator shouldn't vote on an optimistic head
       // Check on target is sufficient as a valid target would imply a valid source
@@ -1103,7 +1098,7 @@ export function getValidatorApi(
       }
 
       const head = chain.forkChoice.getHead();
-      let state: CachedBeaconStateAllForks | undefined = undefined;
+      let state: IBeaconStateView | undefined = undefined;
       const startSlot = computeStartSlotAtEpoch(epoch);
       const prepareNextSlotLookAheadMs =
         config.SLOT_DURATION_MS - config.getSlotComponentDurationMs(PREPARE_NEXT_SLOT_BPS);
@@ -1133,43 +1128,34 @@ export function getValidatorApi(
         } else {
           const res = await getStateResponseWithRegen(chain, startSlot);
 
-          const stateViewDU =
-            res.state instanceof Uint8Array ? loadState(config, chain.getHeadState(), res.state).state : res.state;
+          state = res.state instanceof Uint8Array ? chain.getHeadState().loadOtherState(res.state) : res.state;
 
-          state = createCachedBeaconState(
-            stateViewDU,
-            {
-              config: chain.config,
-              // Not required to compute proposers
-              pubkeyCache: createPubkeyCache(),
-            },
-            {skipSyncPubkeys: true, skipSyncCommitteeCache: true}
-          );
-
-          if (state.epochCtx.epoch !== epoch) {
-            throw Error(`Loaded state epoch ${state.epochCtx.epoch} does not match requested epoch ${epoch}`);
+          if (state.epoch !== epoch) {
+            throw Error(`Loaded state epoch ${state.epoch} does not match requested epoch ${epoch}`);
           }
         }
       }
 
-      const stateEpoch = state.epochCtx.epoch;
+      const stateEpoch = state.epoch;
       let indexes: ValidatorIndex[] = [];
 
       switch (epoch) {
         case stateEpoch:
-          indexes = state.epochCtx.getBeaconProposers();
+          indexes = state.currentProposers;
           break;
 
-        case stateEpoch + 1:
+        case stateEpoch + 1: {
           // make sure shuffling is calculated and ready for next call to calculate nextProposers
-          await chain.shufflingCache.get(state.epochCtx.nextEpoch, state.epochCtx.nextDecisionRoot);
+          const nextEpoch = state.epoch + 1;
+          await chain.shufflingCache.get(nextEpoch, state.nextDecisionRoot);
           // Requesting duties for next epoch is allowed since they can be predicted with high probabilities.
           // @see `epochCtx.getBeaconProposersNextEpoch` JSDocs for rationale.
-          indexes = state.epochCtx.getBeaconProposersNextEpoch();
+          indexes = state.nextProposers;
           break;
+        }
 
         case stateEpoch - 1: {
-          const indexesPrevEpoch = state.epochCtx.getBeaconProposersPrevEpoch();
+          const indexesPrevEpoch = state.previousProposers;
           if (indexesPrevEpoch === null) {
             // Should not happen as previous proposer duties should be initialized for head state
             // and if we load state from `Uint8Array` it will always be the state of requested epoch
@@ -1188,7 +1174,7 @@ export function getValidatorApi(
       //       See benchmark -> packages/lodestar/test/perf/api/impl/validator/attester.test.ts
       // After dropping the flat caches attached to the CachedBeaconState it's no longer available.
       // TODO: Add a flag to just send 0x00 as pubkeys since the Lodestar validator does not need them.
-      const pubkeys = getPubkeysForIndices(state.validators, indexes);
+      const pubkeys = getPubkeysForIndices(state, indexes);
 
       const duties: routes.validator.ProposerDuty[] = [];
       for (let i = 0; i < SLOTS_PER_EPOCH; i++) {
@@ -1242,8 +1228,8 @@ export function getValidatorApi(
       // will equal `currentEpoch + 1`
 
       // Check that all validatorIndex belong to the state before calling getCommitteeAssignments()
-      const pubkeys = getPubkeysForIndices(state.validators, indices);
-      const decisionRoot = state.epochCtx.getShufflingDecisionRoot(epoch);
+      const pubkeys = getPubkeysForIndices(state, indices);
+      const decisionRoot = state.getShufflingDecisionRoot(epoch);
       const shuffling = await chain.shufflingCache.get(epoch, decisionRoot);
       if (!shuffling) {
         throw new ApiError(
@@ -1264,7 +1250,7 @@ export function getValidatorApi(
         }
       }
 
-      const dependentRoot = attesterShufflingDecisionRoot(state, epoch) || (await getGenesisBlockRoot(state));
+      const dependentRoot = fromHex(state.getShufflingDecisionRoot(epoch)) || (await getGenesisBlockRoot(state));
 
       return {
         data: duties,
@@ -1305,9 +1291,9 @@ export function getValidatorApi(
       const state = chain.getHeadState();
 
       // Check that all validatorIndex belong to the state before calling getCommitteeAssignments()
-      const pubkeys = getPubkeysForIndices(state.validators, indices);
+      const pubkeys = getPubkeysForIndices(state, indices);
       // Ensures `epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD <= current_epoch // EPOCHS_PER_SYNC_COMMITTEE_PERIOD + 1`
-      const syncCommitteeCache = state.epochCtx.getIndexedSyncCommitteeAtEpoch(epoch);
+      const syncCommitteeCache = state.getIndexedSyncCommitteeAtEpoch(epoch);
       const validatorSyncCommitteeIndexMap = syncCommitteeCache.validatorIndexMap;
 
       const duties: routes.validator.SyncDuty[] = [];
@@ -1605,7 +1591,7 @@ export function getValidatorApi(
         const validatorIndex = chain.pubkeyCache.getIndex(pubkey);
         if (validatorIndex === null) return false;
 
-        const validator = headState.validators.getReadonly(validatorIndex);
+        const validator = headState.getValidator(validatorIndex);
         const status = getValidatorStatus(validator, currentEpoch);
         return (
           status === "active_exiting" ||

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -191,7 +191,9 @@ export function getValidatorApi(
   async function getGenesisBlockRoot(state: IBeaconStateView): Promise<Root> {
     if (!genesisBlockRoot) {
       // Close to genesis the genesis block may not be available in the DB
-      if (state.slot < SLOTS_PER_HISTORICAL_ROOT && state.slot > GENESIS_SLOT) {
+      if (state.slot === GENESIS_SLOT) {
+        genesisBlockRoot = state.computeAnchorCheckpoint().checkpoint.root;
+      } else if (state.slot < SLOTS_PER_HISTORICAL_ROOT) {
         genesisBlockRoot = state.getBlockRootAtSlot(GENESIS_SLOT);
       }
 

--- a/packages/beacon-node/src/api/impl/validator/utils.ts
+++ b/packages/beacon-node/src/api/impl/validator/utils.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ATTESTATION_SUBNET_COUNT} from "@lodestar/params";
-import {BeaconStateAllForks, computeSlotsSinceEpochStart} from "@lodestar/state-transition";
+import {IBeaconStateView, computeSlotsSinceEpochStart} from "@lodestar/state-transition";
 import {BLSPubkey, CommitteeIndex, ProducedBlockSource, Slot, SubnetID, ValidatorIndex} from "@lodestar/types";
 import {MAX_BUILDER_BOOST_FACTOR} from "@lodestar/validator";
 import {BlockSelectionResult, BuilderBlockSelectionReason, EngineBlockSelectionReason} from "./index.js";
@@ -24,11 +24,8 @@ export function computeSubnetForCommitteesAtSlot(
  * Note: This is the fastest way of getting compressed pubkeys.
  *       See benchmark -> packages/beacon-node/test/perf/api/impl/validator/attester.test.ts
  */
-export function getPubkeysForIndices(
-  validators: BeaconStateAllForks["validators"],
-  indexes: ValidatorIndex[]
-): BLSPubkey[] {
-  const validatorsLen = validators.length; // Get once, it's expensive
+export function getPubkeysForIndices(state: IBeaconStateView, indexes: ValidatorIndex[]): BLSPubkey[] {
+  const validatorsLen = state.validatorCount; // Get once, it's expensive
 
   const pubkeys: BLSPubkey[] = [];
   for (let i = 0, len = indexes.length; i < len; i++) {
@@ -38,7 +35,7 @@ export function getPubkeysForIndices(
     }
 
     // NOTE: This could be optimized further by traversing the tree optimally with .getNodes()
-    const validator = validators.getReadonly(index);
+    const validator = state.getValidator(index);
     pubkeys.push(validator.pubkey);
   }
 

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -2,7 +2,7 @@ import bearerAuthPlugin from "@fastify/bearer-auth";
 import {fastifyCors} from "@fastify/cors";
 import {FastifyError, FastifyInstance, FastifyRequest, errorCodes, fastify} from "fastify";
 import {parse as parseQueryString} from "qs";
-import {FastifySchema, addSszContentTypeParser} from "@lodestar/api/server";
+import {addSszContentTypeParser} from "@lodestar/api/server";
 import {ErrorAborted, Gauge, Histogram, Logger} from "@lodestar/utils";
 import {isLocalhostIP} from "../../util/ip.js";
 import {ApiError, FailureList, IndexedError, NodeIsSyncing} from "../impl/errors.js";
@@ -214,5 +214,5 @@ export class RestApiServer {
 }
 
 function getOperationId(req: FastifyRequest): string {
-  return (req.routeOptions.schema as FastifySchema | undefined)?.operationId ?? "unknown";
+  return req.routeOptions.schema?.operationId ?? "unknown";
 }

--- a/packages/beacon-node/src/api/rest/base.ts
+++ b/packages/beacon-node/src/api/rest/base.ts
@@ -2,7 +2,7 @@ import bearerAuthPlugin from "@fastify/bearer-auth";
 import {fastifyCors} from "@fastify/cors";
 import {FastifyError, FastifyInstance, FastifyRequest, errorCodes, fastify} from "fastify";
 import {parse as parseQueryString} from "qs";
-import {addSszContentTypeParser} from "@lodestar/api/server";
+import {FastifySchema, addSszContentTypeParser} from "@lodestar/api/server";
 import {ErrorAborted, Gauge, Histogram, Logger} from "@lodestar/utils";
 import {isLocalhostIP} from "../../util/ip.js";
 import {ApiError, FailureList, IndexedError, NodeIsSyncing} from "../impl/errors.js";
@@ -214,5 +214,5 @@ export class RestApiServer {
 }
 
 function getOperationId(req: FastifyRequest): string {
-  return req.routeOptions.schema?.operationId ?? "unknown";
+  return (req.routeOptions.schema as FastifySchema | undefined)?.operationId ?? "unknown";
 }

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
@@ -1,61 +1,26 @@
 import {BeaconConfig} from "@lodestar/config";
 import {
-  BeaconStateAllForks,
-  CachedBeaconStateAllForks,
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
-  PubkeyCache,
-  createCachedBeaconState,
-  stateTransition,
+  IBeaconStateView,
+  createBeaconStateViewForHistoricalRegen,
 } from "@lodestar/state-transition";
 import {byteArrayEquals} from "@lodestar/utils";
 import {IBeaconDb} from "../../../db/index.js";
-import {getStateTypeFromBytes} from "../../../util/multifork.js";
 import {HistoricalStateRegenMetrics} from "./metrics.js";
 import {RegenErrorType} from "./types.js";
 
 /**
- * Populate a PubkeyCache with any new entries based on a BeaconState
- */
-export function syncPubkeyCache(state: BeaconStateAllForks, pubkeyCache: PubkeyCache): void {
-  // Get the validators sub tree once for all the loop
-  const validators = state.validators;
-
-  const newCount = state.validators.length;
-  for (let i = pubkeyCache.size; i < newCount; i++) {
-    const pubkey = validators.getReadonly(i).pubkey;
-    pubkeyCache.set(i, pubkey);
-  }
-}
-
-/**
  * Get the nearest BeaconState at or before a slot
  */
-export async function getNearestState(
-  slot: number,
-  config: BeaconConfig,
-  db: IBeaconDb,
-  pubkeyCache: PubkeyCache
-): Promise<CachedBeaconStateAllForks> {
+export async function getNearestState(slot: number, config: BeaconConfig, db: IBeaconDb): Promise<IBeaconStateView> {
   const stateBytesArr = await db.stateArchive.binaries({limit: 1, lte: slot, reverse: true});
   if (!stateBytesArr.length) {
     throw new Error("No near state found in the database");
   }
 
   const stateBytes = stateBytesArr[0];
-  const state = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);
-  syncPubkeyCache(state, pubkeyCache);
-
-  return createCachedBeaconState(
-    state,
-    {
-      config,
-      pubkeyCache,
-    },
-    {
-      skipSyncPubkeys: true,
-    }
-  );
+  return createBeaconStateViewForHistoricalRegen(config, stateBytes);
 }
 
 /**
@@ -65,13 +30,12 @@ export async function getHistoricalState(
   slot: number,
   config: BeaconConfig,
   db: IBeaconDb,
-  pubkeyCache: PubkeyCache,
   metrics?: HistoricalStateRegenMetrics
 ): Promise<Uint8Array> {
   const regenTimer = metrics?.regenTime.startTimer();
 
   const loadStateTimer = metrics?.loadStateTime.startTimer();
-  let state = await getNearestState(slot, config, db, pubkeyCache).catch((e) => {
+  let state = await getNearestState(slot, config, db).catch((e) => {
     metrics?.regenErrorCount.inc({reason: RegenErrorType.loadState});
     throw e;
   });
@@ -81,8 +45,7 @@ export async function getHistoricalState(
   let blockCount = 0;
   for await (const block of db.blockArchive.valuesStream({gt: state.slot, lte: slot})) {
     try {
-      state = stateTransition(
-        state,
+      state = state.stateTransition(
         block,
         {
           verifyProposer: false,

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
@@ -3,6 +3,7 @@ import {
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
   IBeaconStateView,
+  type PubkeyCache,
   createBeaconStateViewForHistoricalRegen,
 } from "@lodestar/state-transition";
 import {byteArrayEquals} from "@lodestar/utils";
@@ -13,14 +14,19 @@ import {RegenErrorType} from "./types.js";
 /**
  * Get the nearest BeaconState at or before a slot
  */
-export async function getNearestState(slot: number, config: BeaconConfig, db: IBeaconDb): Promise<IBeaconStateView> {
+export async function getNearestState(
+  slot: number,
+  config: BeaconConfig,
+  db: IBeaconDb,
+  pubkeyCache: PubkeyCache
+): Promise<IBeaconStateView> {
   const stateBytesArr = await db.stateArchive.binaries({limit: 1, lte: slot, reverse: true});
   if (!stateBytesArr.length) {
     throw new Error("No near state found in the database");
   }
 
   const stateBytes = stateBytesArr[0];
-  return createBeaconStateViewForHistoricalRegen(config, stateBytes);
+  return createBeaconStateViewForHistoricalRegen(config, stateBytes, pubkeyCache);
 }
 
 /**
@@ -30,12 +36,13 @@ export async function getHistoricalState(
   slot: number,
   config: BeaconConfig,
   db: IBeaconDb,
+  pubkeyCache: PubkeyCache,
   metrics?: HistoricalStateRegenMetrics
 ): Promise<Uint8Array> {
   const regenTimer = metrics?.regenTime.startTimer();
 
   const loadStateTimer = metrics?.loadStateTime.startTimer();
-  let state = await getNearestState(slot, config, db).catch((e) => {
+  let state = await getNearestState(slot, config, db, pubkeyCache).catch((e) => {
     metrics?.regenErrorCount.inc({reason: RegenErrorType.loadState});
     throw e;
   });

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
@@ -3,7 +3,6 @@ import {Transfer, expose} from "@chainsafe/threads/worker";
 import {chainConfigFromJson, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {getNodeLogger} from "@lodestar/logger/node";
-import {createPubkeyCache} from "@lodestar/state-transition";
 import {BeaconDb} from "../../../db/index.js";
 import {RegistryMetricCreator, collectNodeJSMetrics} from "../../../metrics/index.js";
 import {JobFnQueue} from "../../../util/queue/fnQueue.js";
@@ -52,8 +51,6 @@ const queue = new JobFnQueue(
   queueMetrics
 );
 
-const pubkeyCache = createPubkeyCache();
-
 const api: HistoricalStateWorkerApi = {
   async close() {
     abortController.abort();
@@ -65,7 +62,7 @@ const api: HistoricalStateWorkerApi = {
     historicalStateRegenMetrics?.regenRequestCount.inc();
 
     const stateBytes = await queue.push<Uint8Array>(() =>
-      getHistoricalState(slot, config, db, pubkeyCache, historicalStateRegenMetrics)
+      getHistoricalState(slot, config, db, historicalStateRegenMetrics)
     );
     const result = Transfer(stateBytes, [stateBytes.buffer]) as unknown as Uint8Array;
 

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
@@ -3,6 +3,7 @@ import {Transfer, expose} from "@chainsafe/threads/worker";
 import {chainConfigFromJson, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {getNodeLogger} from "@lodestar/logger/node";
+import {createPubkeyCache} from "@lodestar/state-transition";
 import {BeaconDb} from "../../../db/index.js";
 import {RegistryMetricCreator, collectNodeJSMetrics} from "../../../metrics/index.js";
 import {JobFnQueue} from "../../../util/queue/fnQueue.js";
@@ -51,6 +52,9 @@ const queue = new JobFnQueue(
   queueMetrics
 );
 
+// Reuse a single pubkey cache across all historical state regen calls in this worker
+const pubkeyCache = createPubkeyCache();
+
 const api: HistoricalStateWorkerApi = {
   async close() {
     abortController.abort();
@@ -62,7 +66,7 @@ const api: HistoricalStateWorkerApi = {
     historicalStateRegenMetrics?.regenRequestCount.inc();
 
     const stateBytes = await queue.push<Uint8Array>(() =>
-      getHistoricalState(slot, config, db, historicalStateRegenMetrics)
+      getHistoricalState(slot, config, db, pubkeyCache, historicalStateRegenMetrics)
     );
     const result = Transfer(stateBytes, [stateBytes.buffer]) as unknown as Uint8Array;
 

--- a/packages/beacon-node/src/chain/balancesCache.ts
+++ b/packages/beacon-node/src/chain/balancesCache.ts
@@ -1,11 +1,5 @@
 import {CheckpointWithHex} from "@lodestar/fork-choice";
-import {
-  CachedBeaconStateAllForks,
-  EffectiveBalanceIncrements,
-  computeStartSlotAtEpoch,
-  getBlockRootAtSlot,
-  getEffectiveBalanceIncrementsZeroInactive,
-} from "@lodestar/state-transition";
+import {EffectiveBalanceIncrements, IBeaconStateView, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, RootHex} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 
@@ -29,11 +23,11 @@ export class CheckpointBalancesCache {
    * `state.current_epoch`. If there is not already some entry for the given block root, then
    * add the effective balances from the `state` to the cache.
    */
-  processState(blockRootHex: RootHex, state: CachedBeaconStateAllForks): void {
-    const epoch = state.epochCtx.epoch;
+  processState(blockRootHex: RootHex, state: IBeaconStateView): void {
+    const epoch = state.epoch;
     const epochBoundarySlot = computeStartSlotAtEpoch(epoch);
     const epochBoundaryRoot =
-      epochBoundarySlot === state.slot ? blockRootHex : toRootHex(getBlockRootAtSlot(state, epochBoundarySlot));
+      epochBoundarySlot === state.slot ? blockRootHex : toRootHex(state.getBlockRootAtSlot(epochBoundarySlot));
 
     const index = this.items.findIndex((item) => item.epoch === epoch && item.rootHex === epochBoundaryRoot);
     if (index === -1) {
@@ -41,7 +35,7 @@ export class CheckpointBalancesCache {
         this.items.shift();
       }
       // expect to reach this once per epoch
-      this.items.push({epoch, rootHex: epochBoundaryRoot, balances: getEffectiveBalanceIncrementsZeroInactive(state)});
+      this.items.push({epoch, rootHex: epochBoundaryRoot, balances: state.getEffectiveBalanceIncrementsZeroInactive()});
     }
   }
 

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -18,15 +18,12 @@ import {
   SLOTS_PER_EPOCH,
 } from "@lodestar/params";
 import {
-  CachedBeaconStateAltair,
-  EpochCache,
+  IBeaconStateView,
   RootCache,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   computeTimeAtSlot,
-  isExecutionStateType,
   isStartSlotOfEpoch,
-  isStateValidatorsNodesPopulated,
 } from "@lodestar/state-transition";
 import {
   Attestation,
@@ -188,7 +185,7 @@ export async function importBlock(
         const attDataRoot = toRootHex(ssz.phase0.AttestationData.hashTreeRoot(indexedAttestation.data));
         addAttestation.call(
           this,
-          postState.epochCtx,
+          postState,
           target,
           attDataRoot,
           attestation as Attestation<ForkPostElectra>,
@@ -375,7 +372,7 @@ export async function importBlock(
         try {
           this.lightClientServer?.onImportBlockHead(
             block.message as BeaconBlock<ForkPostAltair>,
-            postState as CachedBeaconStateAltair,
+            postState,
             parentBlockSlot
           );
         } catch (e) {
@@ -396,11 +393,11 @@ export async function importBlock(
   // and the block is weak and can potentially be reorged out.
   let shouldOverrideFcu = false;
 
-  if (blockSlot >= currentSlot && isExecutionStateType(postState)) {
+  if (blockSlot >= currentSlot && postState.isExecutionStateType) {
     let notOverrideFcuReason = NotReorgedReason.Unknown;
     const proposalSlot = blockSlot + 1;
     try {
-      const proposerIndex = postState.epochCtx.getBeaconProposer(proposalSlot);
+      const proposerIndex = postState.getBeaconProposer(proposalSlot);
       const feeRecipient = this.beaconProposerCache.get(proposerIndex);
 
       if (feeRecipient) {
@@ -480,7 +477,7 @@ export async function importBlock(
     }
   }
 
-  if (!isStateValidatorsNodesPopulated(postState)) {
+  if (!postState.isStateValidatorsNodesPopulated()) {
     this.logger.verbose("After importBlock caching postState without SSZ cache", {slot: postState.slot});
   }
 
@@ -502,7 +499,7 @@ export async function importBlock(
     // Note: in-lined code from previos handler of ChainEvent.checkpoint
     this.logger.verbose("Checkpoint processed", toCheckpointHexPayload(cp, payloadPresent));
 
-    const activeValidatorsCount = checkpointState.epochCtx.currentShuffling.activeIndices.length;
+    const activeValidatorsCount = checkpointState.activeValidatorCount;
     this.metrics?.currentActiveValidators.set(activeValidatorsCount);
     this.metrics?.currentValidators.set({status: "active"}, activeValidatorsCount);
 
@@ -587,7 +584,7 @@ export async function importBlock(
     this.validatorMonitor?.registerSyncAggregateInBlock(
       blockEpoch,
       (block as altair.SignedBeaconBlock).message.body.syncAggregate,
-      fullyVerifiedBlock.postState.epochCtx.currentSyncCommitteeIndexed.validatorIndices
+      fullyVerifiedBlock.postState.currentSyncCommitteeIndexed.validatorIndices
     );
   }
 
@@ -629,7 +626,7 @@ export async function importBlock(
 export function addAttestationPreElectra(
   this: BeaconChain,
   // added to have the same signature as addAttestationPostElectra
-  _: EpochCache,
+  _: IBeaconStateView,
   target: phase0.Checkpoint,
   attDataRoot: string,
   attestation: Attestation,
@@ -646,7 +643,7 @@ export function addAttestationPreElectra(
 
 export function addAttestationPostElectra(
   this: BeaconChain,
-  epochCtx: EpochCache,
+  state: IBeaconStateView,
   target: phase0.Checkpoint,
   attDataRoot: string,
   attestation: Attestation<ForkPostElectra>,
@@ -664,7 +661,7 @@ export function addAttestationPostElectra(
   } else {
     const attSlot = attestation.data.slot;
     const attEpoch = computeEpochAtSlot(attSlot);
-    const decisionRoot = epochCtx.getShufflingDecisionRoot(attEpoch);
+    const decisionRoot = state.getShufflingDecisionRoot(attEpoch);
     const committees = this.shufflingCache.getBeaconCommittees(attEpoch, decisionRoot, attSlot, committeeIndices);
     const aggregationBools = attestation.aggregationBits.toBoolArray();
     let offset = 0;

--- a/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
+++ b/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
@@ -1,11 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ForkName} from "@lodestar/params";
-import {
-  BeaconStateView,
-  CachedBeaconStateGloas,
-  getExecutionPayloadEnvelopeSignatureSet,
-} from "@lodestar/state-transition";
-import {processExecutionPayloadEnvelope} from "@lodestar/state-transition/block";
+import {getExecutionPayloadEnvelopeSignatureSet} from "@lodestar/state-transition";
 import {byteArrayEquals, fromHex, toRootHex} from "@lodestar/utils";
 import {ExecutionPayloadStatus} from "../../execution/index.js";
 import {isQueueErrorAborted} from "../../util/queue/index.js";
@@ -93,12 +88,12 @@ export async function importExecutionPayload(
 
   // 3. Get pre-state for processExecutionPayloadEnvelope
   // We need the block state (post-block, pre-payload) to process the envelope
-  const blockState = (await this.regen.getBlockSlotState(
+  const blockState = await this.regen.getBlockSlotState(
     protoBlock,
     protoBlock.slot,
     {dontTransferCache: true},
     RegenCaller.processBlock
-  )) as CachedBeaconStateGloas;
+  );
 
   // 4. Run verification steps in parallel
   // Note: No data availability check needed here - importExecutionPayload is only
@@ -117,8 +112,8 @@ export async function importExecutionPayload(
       : (async () => {
           const signatureSet = getExecutionPayloadEnvelopeSignatureSet(
             this.config,
-            blockState.epochCtx.pubkeyCache,
-            new BeaconStateView(blockState),
+            this.pubkeyCache,
+            blockState,
             envelope,
             payloadInput.proposerIndex
           );
@@ -130,7 +125,7 @@ export async function importExecutionPayload(
     (async () => {
       try {
         return {
-          postPayloadState: processExecutionPayloadEnvelope(blockState, envelope, {
+          postPayloadState: blockState.processExecutionPayloadEnvelope(envelope, {
             verifySignature: false,
             verifyStateRoot: false,
           }),

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -126,7 +126,7 @@ export async function processBlocks(
         const {state} = err.type;
         const forkTypes = this.config.getForkTypes(blockSlot);
         this.persistInvalidSszValue(forkTypes.SignedBeaconBlock, signedBlock, `${blockSlot}_invalid_signature`);
-        this.persistInvalidSszView(state, `${state.slot}_invalid_signature`);
+        this.persistInvalidSszBytes("BeaconState", state.serialize(), `${state.slot}_invalid_signature`);
       } else if (err.type.code === BlockErrorCode.INVALID_STATE_ROOT) {
         const {signedBlock} = err;
         const blockSlot = signedBlock.message.slot;

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -1,7 +1,7 @@
 import type {ChainForkConfig} from "@lodestar/config";
 import {MaybeValidExecutionStatus} from "@lodestar/fork-choice";
 import {ForkSeq} from "@lodestar/params";
-import {CachedBeaconStateAllForks, DataAvailabilityStatus, computeEpochAtSlot} from "@lodestar/state-transition";
+import {DataAvailabilityStatus, IBeaconStateView, computeEpochAtSlot} from "@lodestar/state-transition";
 import type {IndexedAttestation, Slot, fulu} from "@lodestar/types";
 import {IBlockInput} from "./blockInput/types.js";
 
@@ -93,7 +93,7 @@ export type ImportBlockOpts = {
  */
 export type FullyVerifiedBlock = {
   blockInput: IBlockInput;
-  postState: CachedBeaconStateAllForks;
+  postState: IBeaconStateView;
   parentBlockSlot: Slot;
   proposerBalanceDelta: number;
   /**

--- a/packages/beacon-node/src/chain/blocks/utils/checkpoint.ts
+++ b/packages/beacon-node/src/chain/blocks/utils/checkpoint.ts
@@ -1,12 +1,12 @@
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {CachedBeaconStateAllForks, computeEpochAtSlot} from "@lodestar/state-transition";
+import {IBeaconStateView, computeEpochAtSlot} from "@lodestar/state-transition";
 import {phase0, ssz} from "@lodestar/types";
 import {ZERO_HASH} from "../../../constants/index.js";
 
 /**
  * Compute a Checkpoint type from `state.latestBlockHeader`
  */
-export function getCheckpointFromState(checkpointState: CachedBeaconStateAllForks): phase0.Checkpoint {
+export function getCheckpointFromState(checkpointState: IBeaconStateView): phase0.Checkpoint {
   const slot = checkpointState.slot;
 
   if (slot % SLOTS_PER_EPOCH !== 0) {

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -1,11 +1,6 @@
 import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName, isForkPostFulu} from "@lodestar/params";
-import {
-  CachedBeaconStateAllForks,
-  DataAvailabilityStatus,
-  computeEpochAtSlot,
-  isStateValidatorsNodesPopulated,
-} from "@lodestar/state-transition";
+import {DataAvailabilityStatus, IBeaconStateView, computeEpochAtSlot} from "@lodestar/state-transition";
 import {IndexedAttestation, deneb} from "@lodestar/types";
 import type {BeaconChain} from "../chain.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
@@ -39,7 +34,7 @@ export async function verifyBlocksInEpoch(
   blockInputs: IBlockInput[],
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<{
-  postStates: CachedBeaconStateAllForks[];
+  postStates: IBeaconStateView[];
   proposerBalanceDeltas: number[];
   segmentExecStatus: SegmentExecStatus;
   dataAvailabilityStatuses: DataAvailabilityStatus[];
@@ -78,10 +73,10 @@ export async function verifyBlocksInEpoch(
   // otherwise it may fail to get indexed attestations from shuffling cache later
   this.shufflingCache.processState(preState0);
 
-  if (!isStateValidatorsNodesPopulated(preState0)) {
+  if (!preState0.isStateValidatorsNodesPopulated()) {
     this.logger.verbose("verifyBlocksInEpoch preState0 SSZ cache stats", {
       slot: preState0.slot,
-      cache: isStateValidatorsNodesPopulated(preState0),
+      cache: preState0.isStateValidatorsNodesPopulated(),
       clonedCount: preState0.clonedCount,
       clonedCountWithTransferCache: preState0.clonedCountWithTransferCache,
       createdWithTransferCache: preState0.createdWithTransferCache,
@@ -110,7 +105,7 @@ export async function verifyBlocksInEpoch(
     for (const [i, block] of blocks.entries()) {
       indexedAttestationsByBlock[i] = block.message.body.attestations.map((attestation) => {
         const attEpoch = computeEpochAtSlot(attestation.data.slot);
-        const decisionRoot = preState0.epochCtx.getShufflingDecisionRoot(attEpoch);
+        const decisionRoot = preState0.getShufflingDecisionRoot(attEpoch);
         return this.shufflingCache.getIndexedAttestation(attEpoch, decisionRoot, fork, attestation);
       });
     }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -8,12 +8,7 @@ import {
   ProtoBlock,
 } from "@lodestar/fork-choice";
 import {ForkSeq} from "@lodestar/params";
-import {
-  CachedBeaconStateAllForks,
-  isExecutionBlockBodyType,
-  isExecutionEnabled,
-  isExecutionStateType,
-} from "@lodestar/state-transition";
+import {IBeaconStateView, isExecutionBlockBodyType} from "@lodestar/state-transition";
 import {bellatrix, electra} from "@lodestar/types";
 import {ErrorAborted, Logger, toRootHex} from "@lodestar/utils";
 import {ExecutionPayloadStatus, IExecutionEngine} from "../../execution/engine/interface.js";
@@ -63,7 +58,7 @@ export async function verifyBlocksExecutionPayload(
   chain: VerifyBlockExecutionPayloadModules,
   parentBlock: ProtoBlock,
   blockInputs: IBlockInput[],
-  preState0: CachedBeaconStateAllForks,
+  preState0: IBeaconStateView,
   signal: AbortSignal,
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<SegmentExecStatus> {
@@ -146,7 +141,7 @@ export async function verifyBlocksExecutionPayload(
 export async function verifyBlockExecutionPayload(
   chain: VerifyBlockExecutionPayloadModules,
   blockInput: IBlockInput,
-  preState0: CachedBeaconStateAllForks
+  preState0: IBeaconStateView
 ): Promise<VerifyBlockExecutionResponse> {
   const block = blockInput.getBlock();
 
@@ -157,9 +152,9 @@ export async function verifyBlockExecutionPayload(
 
   /** Not null if execution is enabled */
   const executionPayloadEnabled =
-    isExecutionStateType(preState0) &&
+    preState0.isExecutionStateType &&
     isExecutionBlockBodyType(block.message.body) &&
-    isExecutionEnabled(preState0, block.message)
+    preState0.isExecutionEnabled(block.message)
       ? block.message.body.executionPayload
       : null;
 

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
@@ -1,5 +1,5 @@
 import {BeaconConfig} from "@lodestar/config";
-import {CachedBeaconStateAllForks, getBlockSignatureSets} from "@lodestar/state-transition";
+import {IBeaconStateView, getBlockSignatureSets} from "@lodestar/state-transition";
 import {IndexedAttestation, SignedBeaconBlock} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
@@ -20,14 +20,14 @@ export async function verifyBlocksSignatures(
   bls: IBlsVerifier,
   logger: Logger,
   metrics: Metrics | null,
-  preState0: CachedBeaconStateAllForks,
+  preState0: IBeaconStateView,
   blocks: SignedBeaconBlock[],
   indexedAttestationsByBlock: IndexedAttestation[][],
   opts: ImportBlockOpts
 ): Promise<{verifySignaturesTime: number}> {
   const isValidPromises: Promise<boolean>[] = [];
   const recvToValLatency = Date.now() / 1000 - (opts.seenTimestampSec ?? Date.now() / 1000);
-  const currentSyncCommitteeIndexed = preState0.epochCtx.currentSyncCommitteeIndexed;
+  const currentSyncCommitteeIndexed = preState0.currentSyncCommitteeIndexed;
 
   // Verifies signatures after running state transition, so all SyncCommittee signed roots are known at this point.
   // We must ensure block.slot <= state.slot before running getAllBlockSignatureSets().

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -1,9 +1,8 @@
 import {
-  CachedBeaconStateAllForks,
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
+  IBeaconStateView,
   StateHashTreeRootSource,
-  stateTransition,
 } from "@lodestar/state-transition";
 import {ErrorAborted, Logger, byteArrayEquals} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
@@ -23,7 +22,7 @@ import {ImportBlockOpts} from "./types.js";
  *   - Check state root matches
  */
 export async function verifyBlocksStateTransitionOnly(
-  preState0: CachedBeaconStateAllForks,
+  preState0: IBeaconStateView,
   blocks: IBlockInput[],
   dataAvailabilityStatuses: DataAvailabilityStatus[],
   logger: Logger,
@@ -31,8 +30,8 @@ export async function verifyBlocksStateTransitionOnly(
   validatorMonitor: ValidatorMonitor | null,
   signal: AbortSignal,
   opts: BlockProcessOpts & ImportBlockOpts
-): Promise<{postStates: CachedBeaconStateAllForks[]; proposerBalanceDeltas: number[]; verifyStateTime: number}> {
-  const postStates: CachedBeaconStateAllForks[] = [];
+): Promise<{postStates: IBeaconStateView[]; proposerBalanceDeltas: number[]; verifyStateTime: number}> {
+  const postStates: IBeaconStateView[] = [];
   const proposerBalanceDeltas: number[] = [];
   const recvToValLatency = Date.now() / 1000 - (opts.seenTimestampSec ?? Date.now() / 1000);
 
@@ -45,8 +44,7 @@ export async function verifyBlocksStateTransitionOnly(
     // STFN - per_slot_processing() + per_block_processing()
     // NOTE: `regen.getPreState()` should have dialed forward the state already caching checkpoint states
     const useBlsBatchVerify = !opts?.disableBlsBatchVerify;
-    const postState = stateTransition(
-      preState,
+    const postState = preState.stateTransition(
       block,
       {
         // NOTE: Assume valid for now while sending payload to execution engine in parallel
@@ -84,7 +82,7 @@ export async function verifyBlocksStateTransitionOnly(
 
     // For metric block profitability
     const proposerIndex = block.message.proposerIndex;
-    proposerBalanceDeltas[i] = postState.balances.get(proposerIndex) - preState.balances.get(proposerIndex);
+    proposerBalanceDeltas[i] = postState.getBalance(proposerIndex) - preState.getBalance(proposerIndex);
 
     // If blocks are invalid in execution the main promise could resolve before this loop ends.
     // In that case stop processing blocks and return early.

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import {PrivateKey} from "@libp2p/interface";
-import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
+import {Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
 import {
   CheckpointWithPayloadStatus,
@@ -14,30 +14,21 @@ import {LoggerNode} from "@lodestar/logger/node";
 import {
   BUILDER_INDEX_SELF_BUILD,
   EFFECTIVE_BALANCE_INCREMENT,
-  ForkPostFulu,
+  type ForkPostFulu,
   GENESIS_SLOT,
   SLOTS_PER_EPOCH,
   isForkPostElectra,
   isForkPostGloas,
 } from "@lodestar/params";
 import {
-  BeaconStateAllForks,
-  BeaconStateElectra,
-  CachedBeaconStateAllForks,
-  CachedBeaconStateGloas,
   EffectiveBalanceIncrements,
   EpochShuffling,
+  IBeaconStateView,
   PubkeyCache,
-  computeAnchorCheckpoint,
-  computeAttestationsRewards,
-  computeBlockRewards,
   computeEndSlotAtEpoch,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
-  computeSyncCommitteeRewards,
-  getEffectiveBalanceIncrementsZeroInactive,
   getEffectiveBalancesFromStateBytes,
-  processSlots,
 } from "@lodestar/state-transition";
 import {
   BeaconBlock,
@@ -283,7 +274,7 @@ export class BeaconChain implements IBeaconChain {
       clock?: IClock;
       metrics: Metrics | null;
       validatorMonitor: ValidatorMonitor | null;
-      anchorState: CachedBeaconStateAllForks;
+      anchorState: IBeaconStateView;
       isAnchorStateFinalized: boolean;
       executionEngine: IExecutionEngine;
       executionBuilder?: IExecutionBuilder;
@@ -359,16 +350,16 @@ export class BeaconChain implements IBeaconChain {
 
     this.shufflingCache = new ShufflingCache(metrics, logger, this.opts, [
       {
-        shuffling: anchorState.epochCtx.previousShuffling,
-        decisionRoot: anchorState.epochCtx.previousDecisionRoot,
+        shuffling: anchorState.getPreviousShuffling(),
+        decisionRoot: anchorState.previousDecisionRoot,
       },
       {
-        shuffling: anchorState.epochCtx.currentShuffling,
-        decisionRoot: anchorState.epochCtx.currentDecisionRoot,
+        shuffling: anchorState.getCurrentShuffling(),
+        decisionRoot: anchorState.currentDecisionRoot,
       },
       {
-        shuffling: anchorState.epochCtx.nextShuffling,
-        decisionRoot: anchorState.epochCtx.nextDecisionRoot,
+        shuffling: anchorState.getNextShuffling(),
+        decisionRoot: anchorState.nextDecisionRoot,
       },
     ]);
 
@@ -377,7 +368,7 @@ export class BeaconChain implements IBeaconChain {
 
     const fileDataStore = opts.nHistoricalStatesFileDataStore ?? true;
     const blockStateCache = new FIFOBlockStateCache(this.opts, {metrics});
-    this.bufferPool = new BufferPool(anchorState.type.tree_serializedSize(anchorState.node), metrics);
+    this.bufferPool = new BufferPool(anchorState.serializedSize(), metrics);
 
     this.cpStateDatastore = fileDataStore ? new FileCPStateDatastore(dataDir) : new DbCPStateDatastore(this.db);
     const checkpointStateCache: CheckpointStateCache = new PersistentCheckpointStateCache(
@@ -393,10 +384,10 @@ export class BeaconChain implements IBeaconChain {
       this.opts
     );
 
-    const {checkpoint} = computeAnchorCheckpoint(config, anchorState);
+    const {checkpoint} = anchorState.computeAnchorCheckpoint();
     blockStateCache.add(anchorState);
     blockStateCache.setHeadState(anchorState);
-    const payloadPresent = getCheckpointPayloadStatus(anchorState, checkpoint.epoch) === PayloadStatus.FULL;
+    const payloadPresent = getCheckpointPayloadStatus(config, anchorState, checkpoint.epoch) === PayloadStatus.FULL;
     checkpointStateCache.add(checkpoint, anchorState, payloadPresent);
 
     const forkChoice = initializeForkChoice(
@@ -557,7 +548,7 @@ export class BeaconChain implements IBeaconChain {
     await this.opPool.toPersisted(this.db);
   }
 
-  getHeadState(): CachedBeaconStateAllForks {
+  getHeadState(): IBeaconStateView {
     // head state should always exist
     const head = this.forkChoice.getHead();
     const headState = this.regen.getClosestHeadState(head);
@@ -567,11 +558,11 @@ export class BeaconChain implements IBeaconChain {
     return headState;
   }
 
-  async getHeadStateAtCurrentEpoch(regenCaller: RegenCaller): Promise<CachedBeaconStateAllForks> {
+  async getHeadStateAtCurrentEpoch(regenCaller: RegenCaller): Promise<IBeaconStateView> {
     return this.getHeadStateAtEpoch(this.clock.currentEpoch, regenCaller);
   }
 
-  async getHeadStateAtEpoch(epoch: Epoch, regenCaller: RegenCaller): Promise<CachedBeaconStateAllForks> {
+  async getHeadStateAtEpoch(epoch: Epoch, regenCaller: RegenCaller): Promise<IBeaconStateView> {
     // using getHeadState() means we'll use checkpointStateCache if it's available
     const headState = this.getHeadState();
     // head state is in the same epoch, or we pulled up head state already from past epoch
@@ -588,7 +579,7 @@ export class BeaconChain implements IBeaconChain {
   async getStateBySlot(
     slot: Slot,
     opts?: StateGetOpts
-  ): Promise<{state: CachedBeaconStateAllForks; executionOptimistic: boolean; finalized: boolean} | null> {
+  ): Promise<{state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean} | null> {
     const finalizedBlock = this.forkChoice.getFinalizedBlock();
 
     if (slot < finalizedBlock.slot) {
@@ -638,15 +629,17 @@ export class BeaconChain implements IBeaconChain {
   async getStateByStateRoot(
     stateRoot: RootHex,
     opts?: StateGetOpts
-  ): Promise<{state: CachedBeaconStateAllForks | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null> {
+  ): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null> {
     if (opts?.allowRegen) {
       const state = await this.regen.getState(stateRoot, RegenCaller.restApi);
-      const block = this.forkChoice.getBlockDefaultStatus(state.latestBlockHeader.hashTreeRoot());
+      const block = this.forkChoice.getBlockDefaultStatus(
+        ssz.phase0.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader)
+      );
       const finalizedEpoch = this.forkChoice.getFinalizedCheckpoint().epoch;
       return {
         state,
         executionOptimistic: block != null && isOptimisticBlock(block),
-        finalized: state.epochCtx.epoch <= finalizedEpoch && finalizedEpoch !== GENESIS_EPOCH,
+        finalized: state.epoch <= finalizedEpoch && finalizedEpoch !== GENESIS_EPOCH,
       };
     }
 
@@ -657,12 +650,14 @@ export class BeaconChain implements IBeaconChain {
     // TODO: This is very inneficient for debug requests of serialized content, since it deserializes to serialize again
     const cachedStateCtx = this.regen.getStateSync(stateRoot);
     if (cachedStateCtx) {
-      const block = this.forkChoice.getBlockDefaultStatus(cachedStateCtx.latestBlockHeader.hashTreeRoot());
+      const block = this.forkChoice.getBlockDefaultStatus(
+        ssz.phase0.BeaconBlockHeader.hashTreeRoot(cachedStateCtx.latestBlockHeader)
+      );
       const finalizedEpoch = this.forkChoice.getFinalizedCheckpoint().epoch;
       return {
         state: cachedStateCtx,
         executionOptimistic: block != null && isOptimisticBlock(block),
-        finalized: cachedStateCtx.epochCtx.epoch <= finalizedEpoch && finalizedEpoch !== GENESIS_EPOCH,
+        finalized: cachedStateCtx.epoch <= finalizedEpoch && finalizedEpoch !== GENESIS_EPOCH,
       };
     }
 
@@ -689,17 +684,19 @@ export class BeaconChain implements IBeaconChain {
 
   getStateByCheckpoint(
     checkpoint: CheckpointWithPayloadStatus
-  ): {state: BeaconStateAllForks; executionOptimistic: boolean; finalized: boolean} | null {
+  ): {state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean} | null {
     // finalized or justified checkpoint states maynot be available with PersistentCheckpointStateCache, use getCheckpointStateOrBytes() api to get Uint8Array
     const checkpointHexPayload = fcCheckpointToHexPayload(checkpoint);
     const cachedStateCtx = this.regen.getCheckpointStateSync(checkpointHexPayload);
     if (cachedStateCtx) {
-      const block = this.forkChoice.getBlockDefaultStatus(cachedStateCtx.latestBlockHeader.hashTreeRoot());
+      const block = this.forkChoice.getBlockDefaultStatus(
+        ssz.phase0.BeaconBlockHeader.hashTreeRoot(cachedStateCtx.latestBlockHeader)
+      );
       const finalizedEpoch = this.forkChoice.getFinalizedCheckpoint().epoch;
       return {
         state: cachedStateCtx,
         executionOptimistic: block != null && isOptimisticBlock(block),
-        finalized: cachedStateCtx.epochCtx.epoch <= finalizedEpoch && finalizedEpoch !== GENESIS_EPOCH,
+        finalized: cachedStateCtx.epoch <= finalizedEpoch && finalizedEpoch !== GENESIS_EPOCH,
       };
     }
 
@@ -708,7 +705,7 @@ export class BeaconChain implements IBeaconChain {
 
   async getStateOrBytesByCheckpoint(
     checkpoint: CheckpointWithPayloadStatus
-  ): Promise<{state: CachedBeaconStateAllForks | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null> {
+  ): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null> {
     const checkpointHexPayload = fcCheckpointToHexPayload(checkpoint);
     const cachedStateCtx = await this.regen.getCheckpointStateOrBytes(checkpointHexPayload);
     if (cachedStateCtx) {
@@ -952,14 +949,13 @@ export class BeaconChain implements IBeaconChain {
     consensusBlockValue: Wei;
     shouldOverrideBuilder?: boolean;
   }> {
-    const fork = this.config.getForkName(slot);
     const state = await this.regen.getBlockSlotState(
       parentBlock,
       slot,
       {dontTransferCache: true},
       RegenCaller.produceBlock
     );
-    const proposerIndex = state.epochCtx.getBeaconProposer(slot);
+    const proposerIndex = state.getBeaconProposer(slot);
     const proposerPubKey = this.pubkeyCache.getOrThrow(proposerIndex).toBytes();
 
     const {body, produceResult, executionPayloadValue, shouldOverrideBuilder} = await produceBlockBody.call(
@@ -981,7 +977,7 @@ export class BeaconChain implements IBeaconChain {
     // The hashtree root computed here for debug log will get cached and hence won't introduce additional delays
     const bodyRoot =
       produceResult.type === BlockType.Full
-        ? sszTypesFor(fork).BeaconBlockBody.hashTreeRoot(body)
+        ? this.config.getForkTypes(slot).BeaconBlockBody.hashTreeRoot(body)
         : this.config
             .getPostBellatrixForkTypes(slot)
             .BlindedBeaconBlockBody.hashTreeRoot(body as BlindedBeaconBlockBody);
@@ -1003,10 +999,11 @@ export class BeaconChain implements IBeaconChain {
     block.stateRoot = newStateRoot;
     const blockRoot =
       produceResult.type === BlockType.Full
-        ? sszTypesFor(fork).BeaconBlock.hashTreeRoot(block)
+        ? this.config.getForkTypes(slot).BeaconBlock.hashTreeRoot(block)
         : this.config.getPostBellatrixForkTypes(slot).BlindedBeaconBlock.hashTreeRoot(block as BlindedBeaconBlock);
     const blockRootHex = toRootHex(blockRoot);
 
+    const fork = this.config.getForkName(slot);
     if (isForkPostGloas(fork)) {
       // TODO GLOAS: we should retire BlockType post-gloas, may need a new enum for self vs non-self built
       if (produceResult.type !== BlockType.Full) {
@@ -1022,7 +1019,7 @@ export class BeaconChain implements IBeaconChain {
         slot,
         stateRoot: ZERO_HASH,
       };
-      const envelopeStateRoot = computeEnvelopeStateRoot(this.metrics, postState as CachedBeaconStateGloas, envelope);
+      const envelopeStateRoot = computeEnvelopeStateRoot(this.metrics, postState, envelope);
       gloasResult.envelopeStateRoot = envelopeStateRoot;
     }
 
@@ -1143,8 +1140,8 @@ export class BeaconChain implements IBeaconChain {
    * persist preState, postState and block for further investigation.
    */
   async persistInvalidStateRoot(
-    preState: CachedBeaconStateAllForks,
-    postState: CachedBeaconStateAllForks,
+    preState: IBeaconStateView,
+    postState: IBeaconStateView,
     block: SignedBeaconBlock
   ): Promise<void> {
     const blockSlot = block.message.slot;
@@ -1159,13 +1156,13 @@ export class BeaconChain implements IBeaconChain {
         `${logStr}_block`
       ),
       this.persistSszObject(
-        `preState_slot_${preState.slot}_${preState.type.typeName}`,
+        `preState_slot_${preState.slot}_BeaconState`,
         preState.serialize(),
         preState.hashTreeRoot(),
         `${logStr}_pre_state`
       ),
       this.persistSszObject(
-        `postState_slot_${postState.slot}_${postState.type.typeName}`,
+        `postState_slot_${postState.slot}_BeaconState`,
         postState.serialize(),
         postState.hashTreeRoot(),
         `${logStr}_post_state`
@@ -1182,12 +1179,6 @@ export class BeaconChain implements IBeaconChain {
   persistInvalidSszBytes(typeName: string, sszBytes: Uint8Array, suffix?: string): void {
     if (this.opts.persistInvalidSszObjects) {
       void this.persistSszObject(typeName, sszBytes, sszBytes, suffix);
-    }
-  }
-
-  persistInvalidSszView(view: TreeView<CompositeTypeAny>, suffix?: string): void {
-    if (this.opts.persistInvalidSszObjects) {
-      void this.persistSszObject(view.type.typeName, view.serialize(), view.hashTreeRoot(), suffix);
     }
   }
 
@@ -1208,7 +1199,7 @@ export class BeaconChain implements IBeaconChain {
     this.shufflingCache.insertPromise(attEpoch, shufflingDependentRoot);
     const blockEpoch = computeEpochAtSlot(attHeadBlock.slot);
 
-    let state: CachedBeaconStateAllForks;
+    let state: IBeaconStateView;
     if (blockEpoch < attEpoch - 1) {
       // thanks to one epoch look ahead, we don't need to dial up to attEpoch
       const targetSlot = computeStartSlotAtEpoch(attEpoch - 1);
@@ -1226,7 +1217,7 @@ export class BeaconChain implements IBeaconChain {
     }
     // resolve the promise to unblock other calls of the same epoch and dependent root
     this.shufflingCache.processState(state);
-    return state.epochCtx.getShufflingAtEpoch(attEpoch);
+    return state.getShufflingAtEpoch(attEpoch);
   }
 
   /**
@@ -1236,7 +1227,7 @@ export class BeaconChain implements IBeaconChain {
    */
   private justifiedBalancesGetter(
     checkpoint: CheckpointWithPayloadStatus,
-    blockState: CachedBeaconStateAllForks
+    blockState: IBeaconStateView
   ): EffectiveBalanceIncrements {
     this.metrics?.balancesCache.requests.inc();
 
@@ -1263,7 +1254,7 @@ export class BeaconChain implements IBeaconChain {
       });
     }
 
-    return getEffectiveBalanceIncrementsZeroInactive(state);
+    return state.getEffectiveBalanceIncrementsZeroInactive();
   }
 
   /**
@@ -1275,8 +1266,8 @@ export class BeaconChain implements IBeaconChain {
    */
   private closestJustifiedBalancesStateToCheckpoint(
     checkpoint: CheckpointWithPayloadStatus,
-    blockState: CachedBeaconStateAllForks
-  ): {state: CachedBeaconStateAllForks; stateId: string; shouldWarn: boolean} {
+    blockState: IBeaconStateView
+  ): {state: IBeaconStateView; stateId: string; shouldWarn: boolean} {
     const checkpointHexPayload = fcCheckpointToHexPayload(checkpoint);
     const state = this.regen.getCheckpointStateSync(checkpointHexPayload);
     if (state) {
@@ -1359,10 +1350,9 @@ export class BeaconChain implements IBeaconChain {
     const fork = this.config.getForkName(headState.slot);
 
     if (isForkPostElectra(fork)) {
-      const headStateElectra = headState as BeaconStateElectra;
-      metrics.pendingDeposits.set(headStateElectra.pendingDeposits.length);
-      metrics.pendingPartialWithdrawals.set(headStateElectra.pendingPartialWithdrawals.length);
-      metrics.pendingConsolidations.set(headStateElectra.pendingConsolidations.length);
+      metrics.pendingDeposits.set(headState.pendingDepositsCount);
+      metrics.pendingPartialWithdrawals.set(headState.pendingPartialWithdrawalsCount);
+      metrics.pendingConsolidations.set(headState.pendingConsolidationsCount);
     }
   }
 
@@ -1426,7 +1416,7 @@ export class BeaconChain implements IBeaconChain {
     this.logger.verbose("Fork choice justified", {epoch: cp.epoch, root: cp.rootHex});
   }
 
-  private onCheckpoint(this: BeaconChain, _checkpoint: phase0.Checkpoint, state: CachedBeaconStateAllForks): void {
+  private onCheckpoint(this: BeaconChain, _checkpoint: phase0.Checkpoint, state: IBeaconStateView): void {
     // Defer to not block other checkpoint event handlers, which can cause lightclient update delays
     callInNextEventLoop(() => {
       this.shufflingCache.processState(state);
@@ -1512,7 +1502,7 @@ export class BeaconChain implements IBeaconChain {
       if (stateOrBytes instanceof Uint8Array) {
         effectiveBalances = getEffectiveBalancesFromStateBytes(this.config, stateOrBytes, validatorIndices);
       } else {
-        effectiveBalances = validatorIndices.map((index) => stateOrBytes.validators.get(index).effectiveBalance ?? 0);
+        effectiveBalances = validatorIndices.map((index) => stateOrBytes.getValidator(index).effectiveBalance ?? 0);
       }
     }
 
@@ -1562,11 +1552,11 @@ export class BeaconChain implements IBeaconChain {
       throw Error(`Pre-state is unavailable given block's parent root ${toRootHex(block.parentRoot)}`);
     }
 
-    preState = processSlots(preState, block.slot); // Dial preState's slot to block.slot
+    preState = preState.processSlots(block.slot); // Dial preState's slot to block.slot
 
     const proposerRewards = this.regen.getStateSync(toRootHex(block.stateRoot))?.proposerRewards ?? undefined;
 
-    return computeBlockRewards(this.config, block, preState, proposerRewards);
+    return preState.computeBlockRewards(block, proposerRewards);
   }
 
   async getAttestationsRewards(
@@ -1590,7 +1580,7 @@ export class BeaconChain implements IBeaconChain {
       throw Error(`State is not in cache for slot ${slot}`);
     }
 
-    const rewards = await computeAttestationsRewards(this.config, this.pubkeyCache, cachedState, validatorIds);
+    const rewards = await cachedState.computeAttestationsRewards(validatorIds);
 
     return {rewards, executionOptimistic, finalized};
   }
@@ -1605,8 +1595,8 @@ export class BeaconChain implements IBeaconChain {
       throw Error(`Pre-state is unavailable given block's parent root ${toRootHex(block.parentRoot)}`);
     }
 
-    preState = processSlots(preState, block.slot); // Dial preState's slot to block.slot
+    preState = preState.processSlots(block.slot); // Dial preState's slot to block.slot
 
-    return computeSyncCommitteeRewards(this.config, this.pubkeyCache, block, preState, validatorIds);
+    return preState.computeSyncCommitteeRewards(block, validatorIds ?? []);
   }
 }

--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -2,7 +2,7 @@ import {EventEmitter} from "node:events";
 import {StrictEventEmitter} from "strict-event-emitter-types";
 import {routes} from "@lodestar/api";
 import {CheckpointWithPayloadStatus} from "@lodestar/fork-choice";
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {IBeaconStateView} from "@lodestar/state-transition";
 import {DataColumnSidecars, RootHex, deneb, phase0} from "@lodestar/types";
 import {PeerIdStr} from "../util/peerId.js";
 import {BlockInputSource, IBlockInput} from "./blocks/blockInput/types.js";
@@ -81,7 +81,7 @@ export type ChainEventData = {
 };
 
 export type IChainEvents = ApiEvents & {
-  [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: CachedBeaconStateAllForks) => void;
+  [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: IBeaconStateView) => void;
 
   [ChainEvent.forkChoiceJustified]: (checkpoint: CheckpointWithPayloadStatus) => void;
   [ChainEvent.forkChoiceFinalized]: (checkpoint: CheckpointWithPayloadStatus) => void;

--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -1,4 +1,4 @@
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {IBeaconStateView} from "@lodestar/state-transition";
 import {RootHex, SignedBeaconBlock, Slot, ValidatorIndex} from "@lodestar/types";
 import {LodestarError, toRootHex} from "@lodestar/utils";
 import {ExecutionPayloadStatus} from "../../execution/engine/interface.js";
@@ -91,13 +91,13 @@ export type BlockErrorType =
   | {code: BlockErrorCode.INCORRECT_PROPOSER; proposerIndex: ValidatorIndex}
   | {code: BlockErrorCode.PROPOSAL_SIGNATURE_INVALID; blockSlot: Slot}
   | {code: BlockErrorCode.UNKNOWN_PROPOSER; proposerIndex: ValidatorIndex}
-  | {code: BlockErrorCode.INVALID_SIGNATURE; state: CachedBeaconStateAllForks}
+  | {code: BlockErrorCode.INVALID_SIGNATURE; state: IBeaconStateView}
   | {
       code: BlockErrorCode.INVALID_STATE_ROOT;
       root: Uint8Array;
       expectedRoot: Uint8Array;
-      preState: CachedBeaconStateAllForks;
-      postState: CachedBeaconStateAllForks;
+      preState: IBeaconStateView;
+      postState: IBeaconStateView;
     }
   | {code: BlockErrorCode.NOT_FINALIZED_DESCENDANT; parentRoot: RootHex}
   | {code: BlockErrorCode.NOT_LATER_THAN_PARENT; parentSlot: Slot; slot: Slot}

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -10,18 +10,12 @@ import {
   ForkChoiceOpts as RawForkChoiceOpts,
   getCheckpointPayloadStatus,
 } from "@lodestar/fork-choice";
-import {ZERO_HASH_HEX} from "@lodestar/params";
+import {ForkSeq, ZERO_HASH_HEX} from "@lodestar/params";
 import {
-  CachedBeaconStateAllForks,
-  CachedBeaconStateGloas,
   DataAvailabilityStatus,
-  computeAnchorCheckpoint,
+  IBeaconStateView,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
-  getBlockRootAtSlot,
-  getEffectiveBalanceIncrementsZeroInactive,
-  isExecutionStateType,
-  isMergeTransitionComplete,
 } from "@lodestar/state-transition";
 import {Slot, ssz} from "@lodestar/types";
 import {Logger, toRootHex} from "@lodestar/utils";
@@ -46,7 +40,7 @@ export function initializeForkChoice(
   config: ChainForkConfig,
   emitter: ChainEventEmitter,
   currentSlot: Slot,
-  state: CachedBeaconStateAllForks,
+  state: IBeaconStateView,
   isFinalizedState: boolean,
   opts: ForkChoiceOpts,
   justifiedBalancesGetter: JustifiedBalancesGetter,
@@ -83,13 +77,13 @@ export function initializeForkChoiceFromFinalizedState(
   config: ChainForkConfig,
   emitter: ChainEventEmitter,
   currentSlot: Slot,
-  state: CachedBeaconStateAllForks,
+  state: IBeaconStateView,
   opts: ForkChoiceOpts,
   justifiedBalancesGetter: JustifiedBalancesGetter,
   metrics: Metrics | null,
   logger?: Logger
 ): ForkChoice {
-  const {blockHeader, checkpoint} = computeAnchorCheckpoint(config, state);
+  const {blockHeader, checkpoint} = state.computeAnchorCheckpoint();
   const finalizedCheckpoint = {...checkpoint};
   const justifiedCheckpoint = {
     ...checkpoint,
@@ -100,19 +94,19 @@ export function initializeForkChoiceFromFinalizedState(
     epoch: checkpoint.epoch === 0 ? checkpoint.epoch : checkpoint.epoch + 1,
   };
 
-  const justifiedBalances = getEffectiveBalanceIncrementsZeroInactive(state);
+  const justifiedBalances = state.getEffectiveBalanceIncrementsZeroInactive();
 
   // forkchoiceConstructor is only used for some test cases
   // production code use ForkChoice constructor directly
   const forkchoiceConstructor = opts.forkchoiceConstructor ?? ForkChoice;
 
-  const isForkPostGloas = (state as CachedBeaconStateGloas).latestBlockHash !== undefined;
+  const isForkPostGloas = computeEpochAtSlot(state.slot) >= config.GLOAS_FORK_EPOCH;
 
   // Determine justified checkpoint payload status
-  const justifiedPayloadStatus = getCheckpointPayloadStatus(state, justifiedCheckpoint.epoch);
+  const justifiedPayloadStatus = getCheckpointPayloadStatus(config, state, justifiedCheckpoint.epoch);
 
   // Determine finalized checkpoint payload status
-  const finalizedPayloadStatus = getCheckpointPayloadStatus(state, finalizedCheckpoint.epoch);
+  const finalizedPayloadStatus = getCheckpointPayloadStatus(config, state, finalizedCheckpoint.epoch);
 
   return new forkchoiceConstructor(
     config,
@@ -148,21 +142,23 @@ export function initializeForkChoiceFromFinalizedState(
         unrealizedFinalizedEpoch: finalizedCheckpoint.epoch,
         unrealizedFinalizedRoot: toRootHex(finalizedCheckpoint.root),
 
-        ...(isExecutionStateType(state) && isMergeTransitionComplete(state)
+        ...(state.isExecutionStateType && state.isMergeTransitionComplete
           ? {
-              executionPayloadBlockHash: toRootHex(state.latestExecutionPayloadHeader.blockHash),
-              executionPayloadNumber: state.latestExecutionPayloadHeader.blockNumber,
+              executionPayloadBlockHash: toRootHex(state.latestBlockHash),
+              // TODO GLOAS: executionPayloadNumber is not tracked in BeaconState post-gloas (EIP-7732 removed
+              // latestExecutionPayloadHeader). Using 0 as unavailable fallback until a solution is found.
+              executionPayloadNumber: config.getForkSeq(state.slot) >= ForkSeq.gloas ? 0 : state.payloadBlockNumber,
               executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,
             }
           : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),
 
         dataAvailabilityStatus: DataAvailabilityStatus.PreData,
         payloadStatus: isForkPostGloas ? PayloadStatus.PENDING : PayloadStatus.FULL, // TODO GLOAS: Post-gloas how do we know if the checkpoint payload is FULL or EMPTY?
-        parentBlockHash: isForkPostGloas ? toRootHex((state as CachedBeaconStateGloas).latestBlockHash) : null,
+        parentBlockHash: isForkPostGloas ? toRootHex(state.latestBlockHash) : null,
       },
       currentSlot
     ),
-    state.validators.length,
+    state.validatorCount,
     metrics,
     opts,
     logger
@@ -176,15 +172,15 @@ export function initializeForkChoiceFromUnfinalizedState(
   config: ChainForkConfig,
   emitter: ChainEventEmitter,
   currentSlot: Slot,
-  unfinalizedState: CachedBeaconStateAllForks,
+  unfinalizedState: IBeaconStateView,
   opts: ForkChoiceOpts,
   justifiedBalancesGetter: JustifiedBalancesGetter,
   metrics: Metrics | null,
   logger?: Logger
 ): ForkChoice {
-  const {blockHeader} = computeAnchorCheckpoint(config, unfinalizedState);
-  const finalizedCheckpoint = unfinalizedState.finalizedCheckpoint.toValue();
-  const justifiedCheckpoint = unfinalizedState.currentJustifiedCheckpoint.toValue();
+  const {blockHeader} = unfinalizedState.computeAnchorCheckpoint();
+  const finalizedCheckpoint = unfinalizedState.finalizedCheckpoint;
+  const justifiedCheckpoint = unfinalizedState.currentJustifiedCheckpoint;
   const headRoot = toRootHex(ssz.phase0.BeaconBlockHeader.hashTreeRoot(blockHeader));
 
   const logCtx = {
@@ -200,14 +196,14 @@ export function initializeForkChoiceFromUnfinalizedState(
   logger?.warn("Initializing fork choice from unfinalized state", logCtx);
 
   // this is not the justified state, but there is no other ways to get justified balances
-  const justifiedBalances = getEffectiveBalanceIncrementsZeroInactive(unfinalizedState);
+  const justifiedBalances = unfinalizedState.getEffectiveBalanceIncrementsZeroInactive();
 
-  const isForkPostGloas = (unfinalizedState as CachedBeaconStateGloas).latestBlockHash !== undefined;
+  const isForkPostGloas = computeEpochAtSlot(unfinalizedState.slot) >= config.GLOAS_FORK_EPOCH;
 
   // For unfinalized state, use getCheckpointPayloadStatus to determine the correct status.
   // It checks state.execution_payload_availability to determine EMPTY vs FULL.
-  const justifiedPayloadStatus = getCheckpointPayloadStatus(unfinalizedState, justifiedCheckpoint.epoch);
-  const finalizedPayloadStatus = getCheckpointPayloadStatus(unfinalizedState, finalizedCheckpoint.epoch);
+  const justifiedPayloadStatus = getCheckpointPayloadStatus(config, unfinalizedState, justifiedCheckpoint.epoch);
+  const finalizedPayloadStatus = getCheckpointPayloadStatus(config, unfinalizedState, finalizedCheckpoint.epoch);
 
   const store = new ForkChoiceStore(
     currentSlot,
@@ -241,17 +237,20 @@ export function initializeForkChoiceFromUnfinalizedState(
     unrealizedFinalizedEpoch: finalizedCheckpoint.epoch,
     unrealizedFinalizedRoot: toRootHex(finalizedCheckpoint.root),
 
-    ...(isExecutionStateType(unfinalizedState) && isMergeTransitionComplete(unfinalizedState)
+    ...(unfinalizedState.isExecutionStateType && unfinalizedState.isMergeTransitionComplete
       ? {
-          executionPayloadBlockHash: toRootHex(unfinalizedState.latestExecutionPayloadHeader.blockHash),
-          executionPayloadNumber: unfinalizedState.latestExecutionPayloadHeader.blockNumber,
+          executionPayloadBlockHash: toRootHex(unfinalizedState.latestBlockHash),
+          // TODO GLOAS: executionPayloadNumber is not tracked in BeaconState post-gloas (EIP-7732 removed
+          // latestExecutionPayloadHeader). Using 0 as unavailable fallback until a solution is found.
+          executionPayloadNumber:
+            config.getForkSeq(unfinalizedState.slot) >= ForkSeq.gloas ? 0 : unfinalizedState.payloadBlockNumber,
           executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,
         }
       : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),
 
     dataAvailabilityStatus: DataAvailabilityStatus.PreData,
     payloadStatus: isForkPostGloas ? PayloadStatus.PENDING : PayloadStatus.FULL, // TODO GLOAS: Post-gloas how do we know if the checkpoint payload is FULL or EMPTY?
-    parentBlockHash: isForkPostGloas ? toRootHex((unfinalizedState as CachedBeaconStateGloas).latestBlockHash) : null,
+    parentBlockHash: isForkPostGloas ? toRootHex(unfinalizedState.latestBlockHash) : null,
   };
 
   const parentSlot = blockHeader.slot - 1;
@@ -265,7 +264,7 @@ export function initializeForkChoiceFromUnfinalizedState(
     // dummy data, we're not able to regen state before headBlock
     stateRoot: ZERO_HASH_HEX,
     blockRoot: headBlock.parentRoot,
-    targetRoot: toRootHex(getBlockRootAtSlot(unfinalizedState, computeStartSlotAtEpoch(parentEpoch))),
+    targetRoot: toRootHex(unfinalizedState.getBlockRootAtSlot(computeStartSlotAtEpoch(parentEpoch))),
   };
 
   const justifiedBlock: ProtoBlock = {
@@ -303,13 +302,5 @@ export function initializeForkChoiceFromUnfinalizedState(
   // production code use ForkChoice constructor directly
   const forkchoiceConstructor = opts.forkchoiceConstructor ?? ForkChoice;
 
-  return new forkchoiceConstructor(
-    config,
-    store,
-    protoArray,
-    unfinalizedState.validators.length,
-    metrics,
-    opts,
-    logger
-  );
+  return new forkchoiceConstructor(config, store, protoArray, unfinalizedState.validatorCount, metrics, opts, logger);
 }

--- a/packages/beacon-node/src/chain/initState.ts
+++ b/packages/beacon-node/src/chain/initState.ts
@@ -1,6 +1,11 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ZERO_HASH} from "@lodestar/params";
-import {BeaconStateAllForks, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {
+  BeaconStateAllForks,
+  IBeaconStateView,
+  computeEpochAtSlot,
+  computeStartSlotAtEpoch,
+} from "@lodestar/state-transition";
 import {SignedBeaconBlock, ssz} from "@lodestar/types";
 import {Logger, byteArrayEquals, toHex, toRootHex} from "@lodestar/utils";
 import {GENESIS_SLOT} from "../constants/index.js";
@@ -119,7 +124,7 @@ export async function checkAndPersistAnchorState(
   }
 }
 
-export function initBeaconMetrics(metrics: Metrics, state: BeaconStateAllForks): void {
+export function initBeaconMetrics(metrics: Metrics, state: IBeaconStateView): void {
   metrics.headSlot.set(state.slot);
   metrics.previousJustifiedEpoch.set(state.previousJustifiedCheckpoint.epoch);
   metrics.currentJustifiedEpoch.set(state.currentJustifiedCheckpoint.epoch);

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -1,7 +1,7 @@
-import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
+import {Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
 import {CheckpointWithHex, CheckpointWithPayloadStatus, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
-import {BeaconStateAllForks, CachedBeaconStateAllForks, EpochShuffling, PubkeyCache} from "@lodestar/state-transition";
+import {EpochShuffling, IBeaconStateView, PubkeyCache} from "@lodestar/state-transition";
 import {
   BeaconBlock,
   BlindedBeaconBlock,
@@ -166,9 +166,9 @@ export interface IBeaconChain {
 
   validatorSeenAtEpoch(index: ValidatorIndex, epoch: Epoch): boolean;
 
-  getHeadState(): CachedBeaconStateAllForks;
-  getHeadStateAtCurrentEpoch(regenCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
-  getHeadStateAtEpoch(epoch: Epoch, regenCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
+  getHeadState(): IBeaconStateView;
+  getHeadStateAtCurrentEpoch(regenCaller: RegenCaller): Promise<IBeaconStateView>;
+  getHeadStateAtEpoch(epoch: Epoch, regenCaller: RegenCaller): Promise<IBeaconStateView>;
 
   getHistoricalStateBySlot(
     slot: Slot
@@ -178,22 +178,22 @@ export interface IBeaconChain {
   getStateBySlot(
     slot: Slot,
     opts?: StateGetOpts
-  ): Promise<{state: CachedBeaconStateAllForks; executionOptimistic: boolean; finalized: boolean} | null>;
+  ): Promise<{state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean} | null>;
   /** Returns a local state by state root */
   getStateByStateRoot(
     stateRoot: RootHex,
     opts?: StateGetOpts
-  ): Promise<{state: CachedBeaconStateAllForks | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null>;
+  ): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null>;
   /** Return serialized bytes of a persisted checkpoint state */
   getPersistedCheckpointState(checkpoint?: phase0.Checkpoint): Promise<Uint8Array | null>;
   /** Returns a cached state by checkpoint */
   getStateByCheckpoint(
     checkpoint: CheckpointWithHex
-  ): {state: BeaconStateAllForks; executionOptimistic: boolean; finalized: boolean} | null;
+  ): {state: IBeaconStateView; executionOptimistic: boolean; finalized: boolean} | null;
   /** Return state bytes by checkpoint */
   getStateOrBytesByCheckpoint(
     checkpoint: CheckpointWithPayloadStatus
-  ): Promise<{state: CachedBeaconStateAllForks | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null>;
+  ): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null>;
 
   /**
    * Since we can have multiple parallel chains,
@@ -261,14 +261,12 @@ export interface IBeaconChain {
 
   persistBlock(data: BeaconBlock | BlindedBeaconBlock, suffix?: string): void;
   persistInvalidStateRoot(
-    preState: CachedBeaconStateAllForks,
-    postState: CachedBeaconStateAllForks,
+    preState: IBeaconStateView,
+    postState: IBeaconStateView,
     block: SignedBeaconBlock
   ): Promise<void>;
   persistInvalidSszValue<T>(type: Type<T>, sszObject: T | Uint8Array, suffix?: string): void;
   persistInvalidSszBytes(type: string, sszBytes: Uint8Array, suffix?: string): void;
-  /** Persist bad items to persistInvalidSszObjectsDir dir, for example invalid state, attestations etc. */
-  persistInvalidSszView(view: TreeView<CompositeTypeAny>, suffix?: string): void;
   regenStateForAttestationVerification(
     attEpoch: Epoch,
     shufflingDependentRoot: RootHex,

--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -1,4 +1,4 @@
-import {BitArray, CompositeViewDU} from "@chainsafe/ssz";
+import {BitArray} from "@chainsafe/ssz";
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {
@@ -21,7 +21,7 @@ import {
   isForkPostElectra,
 } from "@lodestar/params";
 import {
-  CachedBeaconStateAltair,
+  IBeaconStateView,
   computeStartSlotAtEpoch,
   computeSyncPeriodAtEpoch,
   computeSyncPeriodAtSlot,
@@ -54,13 +54,7 @@ import {Metrics} from "../../metrics/index.js";
 import {IClock} from "../../util/clock.js";
 import {ChainEventEmitter} from "../emitter.js";
 import {LightClientServerError, LightClientServerErrorCode} from "../errors/lightClientError.js";
-import {
-  getBlockBodyExecutionHeaderProof,
-  getCurrentSyncCommitteeBranch,
-  getFinalizedRootProof,
-  getNextSyncCommitteeBranch,
-  getSyncCommitteesWitness,
-} from "./proofs.js";
+import {getBlockBodyExecutionHeaderProof, getCurrentSyncCommitteeBranch, getNextSyncCommitteeBranch} from "./proofs.js";
 
 export type LightClientServerOpts = {
   disableLightClientServerOnImportBlockHead?: boolean;
@@ -266,11 +260,7 @@ export class LightClientServer {
    * - Persist state witness
    * - Use block's syncAggregate
    */
-  onImportBlockHead(
-    block: BeaconBlock<ForkPostAltair>,
-    postState: CachedBeaconStateAltair,
-    parentBlockSlot: Slot
-  ): void {
+  onImportBlockHead(block: BeaconBlock<ForkPostAltair>, postState: IBeaconStateView, parentBlockSlot: Slot): void {
     // TEMP: To disable this functionality for fork_choice spec tests.
     // Since the tests have deep-reorgs attested data is not available often printing lots of error logs.
     // While this function is only called for head blocks, best to disable.
@@ -406,7 +396,7 @@ export class LightClientServer {
 
   private async persistPostBlockImportData(
     block: BeaconBlock<ForkPostAltair>,
-    postState: CachedBeaconStateAltair,
+    postState: IBeaconStateView,
     parentBlockSlot: Slot
   ): Promise<void> {
     const blockSlot = block.slot;
@@ -416,7 +406,7 @@ export class LightClientServer {
     const blockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(header.beacon);
     const blockRootHex = toRootHex(blockRoot);
 
-    const syncCommitteeWitness = getSyncCommitteesWitness(fork, postState);
+    const syncCommitteeWitness = postState.getSyncCommitteesWitness();
 
     // Only store current sync committee once per run
     if (!this.storedCurrentSyncCommittee) {
@@ -466,7 +456,7 @@ export class LightClientServer {
             isFinalized: true,
             attestedHeader: header,
             blockRoot,
-            finalityBranch: getFinalizedRootProof(postState),
+            finalityBranch: postState.getFinalizedRootProof(),
             finalizedCheckpoint,
           }
         : {
@@ -724,13 +714,10 @@ export class LightClientServer {
     );
   }
 
-  private async storeSyncCommittee(
-    syncCommittee: CompositeViewDU<typeof ssz.altair.SyncCommittee>,
-    syncCommitteeRoot: Uint8Array
-  ): Promise<void> {
+  private async storeSyncCommittee(syncCommittee: altair.SyncCommittee, syncCommitteeRoot: Uint8Array): Promise<void> {
     const isKnown = await this.db.syncCommittee.has(syncCommitteeRoot);
     if (!isKnown) {
-      await this.db.syncCommittee.putBinary(syncCommitteeRoot, syncCommittee.serialize());
+      await this.db.syncCommittee.putBinary(syncCommitteeRoot, ssz.altair.SyncCommittee.serialize(syncCommittee));
     }
   }
 

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -19,16 +19,13 @@ import {
   isForkPostElectra,
 } from "@lodestar/params";
 import {
-  CachedBeaconStateAllForks,
-  CachedBeaconStateAltair,
-  CachedBeaconStateGloas,
   EffectiveBalanceIncrements,
+  IBeaconStateView,
   RootCache,
   computeEpochAtSlot,
   computeSlotsSinceEpochStart,
   computeStartSlotAtEpoch,
   getAttestationParticipationStatus,
-  getBlockRootAtSlot,
 } from "@lodestar/state-transition";
 import {Attestation, Epoch, RootHex, Slot, electra, isElectraAttestation, phase0, ssz} from "@lodestar/types";
 import {MapDef, assert, toRootHex} from "@lodestar/utils";
@@ -212,7 +209,7 @@ export class AggregatedAttestationPool {
     fork: ForkName,
     forkChoice: IForkChoice,
     shufflingCache: ShufflingCache,
-    state: CachedBeaconStateAllForks
+    state: IBeaconStateView
   ): Attestation[] {
     const forkSeq = ForkSeq[fork];
     if (forkSeq < ForkSeq.electra) {
@@ -229,10 +226,10 @@ export class AggregatedAttestationPool {
     fork: ForkName,
     forkChoice: IForkChoice,
     shufflingCache: ShufflingCache,
-    state: CachedBeaconStateAllForks
+    state: IBeaconStateView
   ): electra.Attestation[] {
     const stateSlot = state.slot;
-    const stateEpoch = state.epochCtx.epoch;
+    const stateEpoch = state.epoch;
     const statePrevEpoch = stateEpoch - 1;
     const rootCache = new RootCache(state);
 
@@ -312,7 +309,7 @@ export class AggregatedAttestationPool {
           // The committeeCountPerSlot can be precomputed once per slot
           const getAttestationGroupResult = attestationGroup.getAttestationsForBlock(
             fork,
-            state.epochCtx.effectiveBalanceIncrements,
+            state.effectiveBalanceIncrements,
             notSeenCommitteeMembers,
             MAX_ATTESTATIONS_PER_GROUP_ELECTRA
           );
@@ -362,9 +359,7 @@ export class AggregatedAttestationPool {
             inclusionDistance,
             stateEpoch,
             rootCache,
-            ForkSeq[fork] >= ForkSeq.gloas
-              ? (state as CachedBeaconStateGloas).executionPayloadAvailability.toBoolArray()
-              : null
+            ForkSeq[fork] >= ForkSeq.gloas ? state.executionPayloadAvailability : null
           );
 
           const weight =
@@ -735,13 +730,13 @@ export function aggregateConsolidation({byCommittee, attData}: AttestationsConso
 }
 
 /**
- * Pre-compute participation from a CachedBeaconStateAllForks, for use to check if an attestation's committee
+ * Pre-compute participation from a IBeaconStateView, for use to check if an attestation's committee
  * has already attested or not.
  */
 export function getNotSeenValidatorsFn(
   config: BeaconConfig,
   shufflingCache: ShufflingCache,
-  state: CachedBeaconStateAllForks
+  state: IBeaconStateView
 ): GetNotSeenValidatorsFn {
   const stateSlot = state.slot;
   if (config.getForkName(stateSlot) === ForkName.phase0) {
@@ -753,9 +748,8 @@ export function getNotSeenValidatorsFn(
   // Attestations are sorted by inclusion distance then number of attesters.
   // Attestations should pass the validation when processing attestations in state-transition.
   // check for altair block already
-  const altairState = state as CachedBeaconStateAltair;
-  const previousParticipation = altairState.previousEpochParticipation.getAll();
-  const currentParticipation = altairState.currentEpochParticipation.getAll();
+  const previousParticipation = state.previousEpochParticipation;
+  const currentParticipation = state.currentEpochParticipation;
   const stateEpoch = computeEpochAtSlot(stateSlot);
   // this function could be called multiple times with same slot + committeeIndex
   const cachedNotSeenValidators = new Map<string, Set<number>>();
@@ -774,7 +768,7 @@ export function getNotSeenValidatorsFn(
       return notSeenCommitteeMembers.size === 0 ? null : notSeenCommitteeMembers;
     }
 
-    const decisionRoot = state.epochCtx.getShufflingDecisionRoot(computeEpochAtSlot(slot));
+    const decisionRoot = state.getShufflingDecisionRoot(computeEpochAtSlot(slot));
     const committee = shufflingCache.getBeaconCommittee(epoch, decisionRoot, slot, committeeIndex);
     notSeenCommitteeMembers = new Set<number>();
     for (const [i, validatorIndex] of committee.entries()) {
@@ -804,11 +798,11 @@ export function getNotSeenValidatorsFn(
  */
 export function getValidateAttestationDataFn(
   forkChoice: IForkChoice,
-  state: CachedBeaconStateAllForks
+  state: IBeaconStateView
 ): ValidateAttestationDataFn {
   const cachedValidatedAttestationData = new Map<string, InvalidAttestationData | null>();
   const {previousJustifiedCheckpoint, currentJustifiedCheckpoint} = state;
-  const stateEpoch = state.epochCtx.epoch;
+  const stateEpoch = state.epoch;
   return (attData: phase0.AttestationData) => {
     const targetEpoch = attData.target.epoch;
     let justifiedCheckpoint: phase0.Checkpoint;
@@ -850,14 +844,14 @@ export function getValidateAttestationDataFn(
  */
 function isValidShuffling(
   forkChoice: IForkChoice,
-  state: CachedBeaconStateAllForks,
+  state: IBeaconStateView,
   blockRootHex: RootHex,
   targetEpoch: Epoch
 ): InvalidAttestationData | null {
   // Otherwise the shuffling is determined by the block at the end of the target epoch
   // minus the shuffling lookahead (usually 2). We call this the "pivot".
   const pivotSlot = computeStartSlotAtEpoch(targetEpoch - 1) - 1;
-  const stateDependentRoot = toRootHex(getBlockRootAtSlot(state, pivotSlot));
+  const stateDependentRoot = toRootHex(state.getBlockRootAtSlot(pivotSlot));
 
   // Use fork choice's view of the block DAG to quickly evaluate whether the attestation's
   // pivot block is the same as the current state's pivot block. If it is, then the

--- a/packages/beacon-node/src/chain/opPools/opPool.ts
+++ b/packages/beacon-node/src/chain/opPools/opPool.ts
@@ -11,11 +11,10 @@ import {
   MAX_VOLUNTARY_EXITS,
 } from "@lodestar/params";
 import {
-  CachedBeaconStateAllForks,
+  IBeaconStateView,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   getAttesterSlashableIndices,
-  isValidVoluntaryExit,
 } from "@lodestar/state-transition";
 import {
   AttesterSlashing,
@@ -185,7 +184,7 @@ export class OpPool {
    * slashings included earlier in the block.
    */
   getSlashingsAndExits(
-    state: CachedBeaconStateAllForks,
+    state: IBeaconStateView,
     blockType: BlockType,
     metrics: Metrics | null
   ): [
@@ -207,7 +206,7 @@ export class OpPool {
     const endProposerSlashing = stepsMetrics?.startTimer();
     for (const proposerSlashing of this.proposerSlashings.values()) {
       const index = proposerSlashing.signedHeader1.message.proposerIndex;
-      const validator = state.validators.getReadonly(index);
+      const validator = state.getValidator(index);
       if (!validator.slashed && validator.activationEpoch <= stateEpoch && stateEpoch < validator.withdrawableEpoch) {
         proposerSlashings.push(proposerSlashing);
         // Set of validators to be slashed, so we don't attempt to construct invalid attester slashings.
@@ -234,7 +233,7 @@ export class OpPool {
           continue attesterSlashing;
         }
 
-        const validator = state.validators.getReadonly(index);
+        const validator = state.getValidator(index);
         if (isSlashableAtEpoch(validator, stateEpoch)) {
           slashableIndices.add(index);
         }
@@ -261,7 +260,7 @@ export class OpPool {
     for (const voluntaryExit of this.voluntaryExits.values()) {
       if (
         !toBeSlashedIndices.has(voluntaryExit.message.validatorIndex) &&
-        isValidVoluntaryExit(stateFork, state, voluntaryExit, false) &&
+        state.isValidVoluntaryExit(voluntaryExit, false) &&
         // Signature validation is skipped in `isValidVoluntaryExit(,,false)` since it was already validated in gossip
         // However we must make sure that the signature fork is the same, or it will become invalid if included through
         // a future fork.
@@ -320,7 +319,7 @@ export class OpPool {
   /**
    * Prune all types of transactions given the latest head state
    */
-  pruneAll(headBlock: SignedBeaconBlock, headState: CachedBeaconStateAllForks): void {
+  pruneAll(headBlock: SignedBeaconBlock, headState: IBeaconStateView): void {
     this.pruneAttesterSlashings(headState);
     this.pruneProposerSlashings(headState);
     this.pruneVoluntaryExits(headState);
@@ -330,7 +329,7 @@ export class OpPool {
   /**
    * Prune attester slashings for all slashed or withdrawn validators.
    */
-  private pruneAttesterSlashings(headState: CachedBeaconStateAllForks): void {
+  private pruneAttesterSlashings(headState: IBeaconStateView): void {
     const finalizedEpoch = headState.finalizedCheckpoint.epoch;
     attesterSlashing: for (const [key, attesterSlashing] of this.attesterSlashings.entries()) {
       // Slashings that don't slash any validators can be dropped
@@ -342,7 +341,7 @@ export class OpPool {
         //
         // We cannot check the `slashed` field since the `head` is not finalized and
         // a fork could un-slash someone.
-        if (headState.validators.getReadonly(index).exitEpoch > finalizedEpoch) {
+        if (headState.getValidator(index).exitEpoch > finalizedEpoch) {
           continue attesterSlashing;
         }
       }
@@ -355,11 +354,11 @@ export class OpPool {
   /**
    * Prune proposer slashings for validators which are exited in the finalized epoch.
    */
-  private pruneProposerSlashings(headState: CachedBeaconStateAllForks): void {
+  private pruneProposerSlashings(headState: IBeaconStateView): void {
     const finalizedEpoch = headState.finalizedCheckpoint.epoch;
     for (const [key, proposerSlashing] of this.proposerSlashings.entries()) {
       const index = proposerSlashing.signedHeader1.message.proposerIndex;
-      if (headState.validators.getReadonly(index).exitEpoch <= finalizedEpoch) {
+      if (headState.getValidator(index).exitEpoch <= finalizedEpoch) {
         this.proposerSlashings.delete(key);
       }
     }
@@ -369,7 +368,7 @@ export class OpPool {
    * Call after finalizing
    * Prune if validator has already exited at or before the finalized checkpoint of the head.
    */
-  private pruneVoluntaryExits(headState: CachedBeaconStateAllForks): void {
+  private pruneVoluntaryExits(headState: IBeaconStateView): void {
     const headStateFork = this.config.getForkSeq(headState.slot);
     const finalizedEpoch = headState.finalizedCheckpoint.epoch;
 
@@ -392,7 +391,7 @@ export class OpPool {
    * In the worse case where head block is reorged, the same BlsToExecutionChange message can be re-added
    * to opPool once gossipsub seen cache TTL passes.
    */
-  private pruneBlsToExecutionChanges(headBlock: SignedBeaconBlock, headState: CachedBeaconStateAllForks): void {
+  private pruneBlsToExecutionChanges(headBlock: SignedBeaconBlock, headState: IBeaconStateView): void {
     const recentBlsToExecutionChanges =
       this.config.getForkSeq(headBlock.message.slot) >= ForkSeq.capella
         ? (headBlock as capella.SignedBeaconBlock).message.body.blsToExecutionChanges
@@ -405,7 +404,7 @@ export class OpPool {
     for (const [key, blsToExecutionChange] of this.blsToExecutionChanges.entries()) {
       const {validatorIndex} = blsToExecutionChange.data.message;
       if (!recentBlsToExecutionChangeIndexes.has(validatorIndex)) {
-        const validator = headState.validators.getReadonly(validatorIndex);
+        const validator = headState.getValidator(validatorIndex);
         if (validator.withdrawalCredentials[0] !== BLS_WITHDRAWAL_PREFIX) {
           this.blsToExecutionChanges.delete(key);
         }

--- a/packages/beacon-node/src/chain/opPools/utils.ts
+++ b/packages/beacon-node/src/chain/opPools/utils.ts
@@ -1,6 +1,6 @@
 import {Signature} from "@chainsafe/blst";
 import {BLS_WITHDRAWAL_PREFIX} from "@lodestar/params";
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {IBeaconStateView} from "@lodestar/state-transition";
 import {Slot, capella} from "@lodestar/types";
 import {AggregateFast, AggregateFastElectra} from "./attestationPool.js";
 
@@ -38,7 +38,7 @@ export function signatureFromBytesNoCheck(signature: Uint8Array): Signature {
  * can become invalid for certain forks.
  */
 export function isValidBlsToExecutionChangeForBlockInclusion(
-  state: CachedBeaconStateAllForks,
+  state: IBeaconStateView,
   signedBLSToExecutionChange: capella.SignedBLSToExecutionChange
 ): boolean {
   // For each condition from https://github.com/ethereum/consensus-specs/blob/v1.6.1/specs/capella/beacon-chain.md#new-process_bls_to_execution_change
@@ -48,7 +48,7 @@ export function isValidBlsToExecutionChangeForBlockInclusion(
   //
   // 2. assert validator.withdrawal_credentials[:1] == BLS_WITHDRAWAL_PREFIX:
   //    Must be checked again, since it can already be changed by now.
-  const validator = state.validators.getReadonly(signedBLSToExecutionChange.message.validatorIndex);
+  const validator = state.getValidator(signedBLSToExecutionChange.message.validatorIndex);
   const {withdrawalCredentials} = validator;
   if (withdrawalCredentials[0] !== BLS_WITHDRAWAL_PREFIX) {
     return false;

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -1,11 +1,9 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {PayloadStatus, getSafeExecutionBlockHash} from "@lodestar/fork-choice";
-import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH, isForkPostBellatrix} from "@lodestar/params";
+import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
-  CachedBeaconStateAllForks,
-  CachedBeaconStateExecutions,
-  CachedBeaconStateGloas,
+  IBeaconStateView,
   StateHashTreeRootSource,
   computeEpochAtSlot,
   computeTimeAtSlot,
@@ -120,10 +118,10 @@ export class PrepareNextSlotScheduler {
         RegenCaller.precomputeEpoch
       );
 
-      if (isForkPostBellatrix(fork)) {
-        const proposerIndex = prepareState.epochCtx.getBeaconProposer(prepareSlot);
+      if (prepareState.isExecutionStateType) {
+        const proposerIndex = prepareState.getBeaconProposer(prepareSlot);
         const feeRecipient = this.chain.beaconProposerCache.get(proposerIndex);
-        let updatedPrepareState = prepareState as CachedBeaconStateExecutions | CachedBeaconStateGloas;
+        let updatedPrepareState = prepareState;
         let updatedHeadRoot = headRoot;
 
         if (feeRecipient) {
@@ -140,13 +138,13 @@ export class PrepareNextSlotScheduler {
               headRoot,
             });
             this.metrics?.weakHeadDetected.inc();
-            updatedPrepareState = (await this.chain.regen.getBlockSlotState(
+            updatedPrepareState = await this.chain.regen.getBlockSlotState(
               proposerHead,
               prepareSlot,
               // only transfer cache if epoch transition because that's the state we will use to stateTransition() the 1st block of epoch
               {dontTransferCache: !isEpochTransition},
               RegenCaller.predictProposerHead
-            )) as CachedBeaconStateExecutions | CachedBeaconStateGloas;
+            );
             updatedHeadRoot = proposerHeadRoot;
           }
 
@@ -239,7 +237,7 @@ export class PrepareNextSlotScheduler {
     }
   };
 
-  computeStateHashTreeRoot(state: CachedBeaconStateAllForks, isEpochTransition: boolean): void {
+  computeStateHashTreeRoot(state: IBeaconStateView, isEpochTransition: boolean): void {
     // cache HashObjects for faster hashTreeRoot() later, especially for computeNewStateRoot() if we need to produce a block at slot 0 of epoch
     // see https://github.com/ChainSafe/lodestar/issues/6194
     const hashTreeRootTimer = this.metrics?.stateHashTreeRootTime.startTimer({

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -1,7 +1,7 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {PayloadStatus, getSafeExecutionBlockHash} from "@lodestar/fork-choice";
-import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkPostBellatrix, ForkSeq, isForkPostBellatrix, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
   IBeaconStateView,
   StateHashTreeRootSource,
@@ -118,7 +118,7 @@ export class PrepareNextSlotScheduler {
         RegenCaller.precomputeEpoch
       );
 
-      if (prepareState.isExecutionStateType) {
+      if (isForkPostBellatrix(fork)) {
         const proposerIndex = prepareState.getBeaconProposer(prepareSlot);
         const feeRecipient = this.chain.beaconProposerCache.get(proposerIndex);
         let updatedPrepareState = prepareState;

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -1,7 +1,7 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {PayloadStatus, getSafeExecutionBlockHash} from "@lodestar/fork-choice";
-import {ForkPostBellatrix, ForkSeq, isForkPostBellatrix, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH, isForkPostBellatrix} from "@lodestar/params";
 import {
   IBeaconStateView,
   StateHashTreeRootSource,

--- a/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
+++ b/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
@@ -1,13 +1,10 @@
 import {
-  CachedBeaconStateAllForks,
-  CachedBeaconStateGloas,
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
   G2_POINT_AT_INFINITY,
+  IBeaconStateView,
   StateHashTreeRootSource,
-  stateTransition,
 } from "@lodestar/state-transition";
-import {processExecutionPayloadEnvelope} from "@lodestar/state-transition/block";
 import {BeaconBlock, BlindedBeaconBlock, Gwei, Root, gloas} from "@lodestar/types";
 import {ZERO_HASH} from "../../constants/index.js";
 import {Metrics} from "../../metrics/index.js";
@@ -19,14 +16,13 @@ import {Metrics} from "../../metrics/index.js";
  */
 export function computeNewStateRoot(
   metrics: Metrics | null,
-  state: CachedBeaconStateAllForks,
+  state: IBeaconStateView,
   block: BeaconBlock | BlindedBeaconBlock
-): {newStateRoot: Root; proposerReward: Gwei; postState: CachedBeaconStateAllForks} {
+): {newStateRoot: Root; proposerReward: Gwei; postState: IBeaconStateView} {
   // Set signature to zero to re-use stateTransition() function which requires the SignedBeaconBlock type
   const blockEmptySig = {message: block, signature: ZERO_HASH};
 
-  const postState = stateTransition(
-    state,
+  const postState = state.stateTransition(
     blockEmptySig,
     {
       // ExecutionPayloadStatus.valid: Assume payload valid, it has been produced by a trusted EL
@@ -64,7 +60,7 @@ export function computeNewStateRoot(
  */
 export function computeEnvelopeStateRoot(
   metrics: Metrics | null,
-  postBlockState: CachedBeaconStateGloas,
+  postBlockState: IBeaconStateView,
   envelope: gloas.ExecutionPayloadEnvelope
 ): Root {
   const signedEnvelope: gloas.SignedExecutionPayloadEnvelope = {
@@ -73,7 +69,7 @@ export function computeEnvelopeStateRoot(
   };
 
   const processEnvelopeTimer = metrics?.blockPayload.executionPayloadEnvelopeProcessingTime.startTimer();
-  const postEnvelopeState = processExecutionPayloadEnvelope(postBlockState, signedEnvelope, {
+  const postEnvelopeState = postBlockState.processExecutionPayloadEnvelope(signedEnvelope, {
     // Signature is zero-ed (G2_POINT_AT_INFINITY), skip verification
     verifySignature: false,
     // State root is being computed here, the envelope doesn't have it yet

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -14,17 +14,7 @@ import {
   isForkPostBellatrix,
   isForkPostGloas,
 } from "@lodestar/params";
-import {
-  CachedBeaconStateAllForks,
-  CachedBeaconStateBellatrix,
-  CachedBeaconStateCapella,
-  CachedBeaconStateExecutions,
-  CachedBeaconStateGloas,
-  G2_POINT_AT_INFINITY,
-  computeTimeAtSlot,
-  getExpectedWithdrawals,
-  getRandaoMix,
-} from "@lodestar/state-transition";
+import {G2_POINT_AT_INFINITY, IBeaconStateView, computeTimeAtSlot} from "@lodestar/state-transition";
 import {
   BLSPubkey,
   BLSSignature,
@@ -161,7 +151,7 @@ export type ProduceResult =
 export async function produceBlockBody<T extends BlockType>(
   this: BeaconChain,
   blockType: T,
-  currentState: CachedBeaconStateAllForks,
+  currentState: IBeaconStateView,
   blockAttr: BlockAttributes & {
     proposerIndex: ValidatorIndex;
     proposerPubKey: BLSPubkey;
@@ -204,7 +194,6 @@ export async function produceBlockBody<T extends BlockType>(
     // TODO GLOAS: support non self-building here, the block type differentiation between
     // full and blinded no longer makes sense in gloas, it might be a good idea to move
     // this into a completely separate function and have pre/post gloas more separated
-    const gloasState = currentState as CachedBeaconStateGloas;
     const safeBlockHash = getSafeExecutionBlockHash(this.forkChoice);
     const finalizedBlockHash = this.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
     const feeRecipient = requestedFeeRecipient ?? this.beaconProposerCache.getOrDefault(proposerIndex);
@@ -225,7 +214,7 @@ export async function produceBlockBody<T extends BlockType>(
       parentBlockRoot,
       safeBlockHash,
       finalizedBlockHash ?? ZERO_HASH_HEX,
-      gloasState,
+      currentState,
       feeRecipient
     );
 
@@ -259,10 +248,10 @@ export async function produceBlockBody<T extends BlockType>(
 
     // Create self-build execution payload bid
     const bid: gloas.ExecutionPayloadBid = {
-      parentBlockHash: gloasState.latestBlockHash,
+      parentBlockHash: currentState.latestBlockHash,
       parentBlockRoot: parentBlockRoot,
       blockHash: executionPayload.blockHash,
-      prevRandao: getRandaoMix(gloasState, gloasState.epochCtx.epoch),
+      prevRandao: currentState.getRandaoMix(currentState.epoch),
       feeRecipient: executionPayload.feeRecipient,
       gasLimit: BigInt(executionPayload.gasLimit),
       builderIndex: BUILDER_INDEX_SELF_BUILD,
@@ -336,7 +325,7 @@ export async function produceBlockBody<T extends BlockType>(
             parentBlockRoot,
             safeBlockHash,
             finalizedBlockHash ?? ZERO_HASH_HEX,
-            currentState as CachedBeaconStateBellatrix,
+            currentState,
             executionBuilder.issueLocalFcUWithFeeRecipient
           );
         }
@@ -348,12 +337,7 @@ export async function produceBlockBody<T extends BlockType>(
           slot: blockSlot,
           proposerPubKey: toHex(proposerPubKey),
         });
-        const headerRes = await prepareExecutionPayloadHeader(
-          this,
-          fork,
-          currentState as CachedBeaconStateBellatrix,
-          proposerPubKey
-        );
+        const headerRes = await prepareExecutionPayloadHeader(this, fork, currentState, proposerPubKey);
 
         endExecutionPayloadHeader?.({
           step: BlockProductionStep.executionPayload,
@@ -388,7 +372,7 @@ export async function produceBlockBody<T extends BlockType>(
         });
       } else {
         const headerGasLimit = builderRes.header.gasLimit;
-        const parentGasLimit = (currentState as CachedBeaconStateBellatrix).latestExecutionPayloadHeader.gasLimit;
+        const parentGasLimit = currentState.latestExecutionPayloadHeader.gasLimit;
         const expectedGasLimit = getExpectedGasLimit(parentGasLimit, targetGasLimit);
 
         const lowerBound = Math.min(parentGasLimit, expectedGasLimit);
@@ -449,7 +433,7 @@ export async function produceBlockBody<T extends BlockType>(
           parentBlockRoot,
           safeBlockHash,
           finalizedBlockHash ?? ZERO_HASH_HEX,
-          currentState as CachedBeaconStateExecutions,
+          currentState,
           feeRecipient
         );
 
@@ -614,14 +598,12 @@ export async function prepareExecutionPayload(
   parentBlockRoot: Root,
   safeBlockHash: RootHex,
   finalizedBlockHash: RootHex,
-  state: CachedBeaconStateExecutions | CachedBeaconStateGloas,
+  state: IBeaconStateView,
   suggestedFeeRecipient: string
 ): Promise<{prepType: PayloadPreparationType; payloadId: PayloadId}> {
-  const parentHash = isForkPostGloas(fork)
-    ? (state as CachedBeaconStateGloas).latestBlockHash
-    : (state as CachedBeaconStateExecutions).latestExecutionPayloadHeader.blockHash;
+  const parentHash = state.latestBlockHash;
   const timestamp = computeTimeAtSlot(chain.config, state.slot, state.genesisTime);
-  const prevRandao = getRandaoMix(state, state.epochCtx.epoch);
+  const prevRandao = state.getRandaoMix(state.epoch);
 
   const payloadIdCached = chain.executionEngine.payloadIdCache.get({
     headBlockHash: toRootHex(parentHash),
@@ -684,7 +666,7 @@ async function prepareExecutionPayloadHeader(
     config: ChainForkConfig;
   },
   fork: ForkPostBellatrix,
-  state: CachedBeaconStateBellatrix,
+  state: IBeaconStateView,
   proposerPubKey: BLSPubkey
 ): Promise<{
   header: ExecutionPayloadHeader;
@@ -711,16 +693,9 @@ export function getPayloadAttributesForSSE(
     prepareSlot,
     parentBlockRoot,
     feeRecipient,
-  }: {
-    prepareState: CachedBeaconStateExecutions | CachedBeaconStateGloas;
-    prepareSlot: Slot;
-    parentBlockRoot: Root;
-    feeRecipient: string;
-  }
+  }: {prepareState: IBeaconStateView; prepareSlot: Slot; parentBlockRoot: Root; feeRecipient: string}
 ): SSEPayloadAttributes {
-  const parentHash = isForkPostGloas(fork)
-    ? (prepareState as CachedBeaconStateGloas).latestBlockHash
-    : (prepareState as CachedBeaconStateExecutions).latestExecutionPayloadHeader.blockHash;
+  const parentHash = prepareState.latestBlockHash;
   const payloadAttributes = preparePayloadAttributes(fork, chain, {
     prepareState,
     prepareSlot,
@@ -736,11 +711,11 @@ export function getPayloadAttributesForSSE(
     }
     parentBlockNumber = parentBlock.executionPayloadNumber;
   } else {
-    parentBlockNumber = (prepareState as CachedBeaconStateExecutions).latestExecutionPayloadHeader.blockNumber;
+    parentBlockNumber = prepareState.payloadBlockNumber;
   }
 
   const ssePayloadAttributes: SSEPayloadAttributes = {
-    proposerIndex: prepareState.epochCtx.getBeaconProposer(prepareSlot),
+    proposerIndex: prepareState.getBeaconProposer(prepareSlot),
     proposalSlot: prepareSlot,
     parentBlockNumber,
     parentBlockRoot,
@@ -761,14 +736,14 @@ function preparePayloadAttributes(
     parentBlockRoot,
     feeRecipient,
   }: {
-    prepareState: CachedBeaconStateExecutions | CachedBeaconStateGloas;
+    prepareState: IBeaconStateView;
     prepareSlot: Slot;
     parentBlockRoot: Root;
     feeRecipient: string;
   }
 ): SSEPayloadAttributes["payloadAttributes"] {
   const timestamp = computeTimeAtSlot(chain.config, prepareSlot, prepareState.genesisTime);
-  const prevRandao = getRandaoMix(prepareState, prepareState.epochCtx.epoch);
+  const prevRandao = prepareState.getRandaoMix(prepareState.epoch);
   const payloadAttributes = {
     timestamp,
     prevRandao,
@@ -777,10 +752,8 @@ function preparePayloadAttributes(
 
   if (ForkSeq[fork] >= ForkSeq.capella) {
     // withdrawals logic is now fork aware as it changes on electra fork post capella
-    (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals = getExpectedWithdrawals(
-      ForkSeq[fork],
-      prepareState as CachedBeaconStateCapella
-    ).expectedWithdrawals;
+    (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
+      prepareState.getExpectedWithdrawals().expectedWithdrawals;
   }
 
   if (ForkSeq[fork] >= ForkSeq.deneb) {
@@ -793,7 +766,7 @@ function preparePayloadAttributes(
 export async function produceCommonBlockBody<T extends BlockType>(
   this: BeaconChain,
   blockType: T,
-  currentState: CachedBeaconStateAllForks,
+  currentState: IBeaconStateView,
   {randaoReveal, graffiti, slot, parentBlock}: BlockAttributes
 ): Promise<CommonBlockBody> {
   const stepsMetrics =

--- a/packages/beacon-node/src/chain/regen/interface.ts
+++ b/packages/beacon-node/src/chain/regen/interface.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ProtoBlock} from "@lodestar/fork-choice";
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {IBeaconStateView} from "@lodestar/state-transition";
 import {BeaconBlock, Epoch, RootHex, Slot, phase0} from "@lodestar/types";
 import {CheckpointHexPayload} from "../stateCache/types.js";
 
@@ -38,21 +38,21 @@ export type StateRegenerationOpts = {
 export interface IStateRegenerator extends IStateRegeneratorInternal {
   dropCache(): void;
   dumpCacheSummary(): routes.lodestar.StateCacheItem[];
-  getStateSync(stateRoot: RootHex): CachedBeaconStateAllForks | null;
-  getPreStateSync(block: BeaconBlock): CachedBeaconStateAllForks | null;
-  getCheckpointStateOrBytes(cp: CheckpointHexPayload): Promise<CachedBeaconStateAllForks | Uint8Array | null>;
-  getCheckpointStateSync(cp: CheckpointHexPayload): CachedBeaconStateAllForks | null;
-  getClosestHeadState(head: ProtoBlock): CachedBeaconStateAllForks | null;
+  getStateSync(stateRoot: RootHex): IBeaconStateView | null;
+  getPreStateSync(block: BeaconBlock): IBeaconStateView | null;
+  getCheckpointStateOrBytes(cp: CheckpointHexPayload): Promise<IBeaconStateView | Uint8Array | null>;
+  getCheckpointStateSync(cp: CheckpointHexPayload): IBeaconStateView | null;
+  getClosestHeadState(head: ProtoBlock): IBeaconStateView | null;
   pruneOnCheckpoint(finalizedEpoch: Epoch, justifiedEpoch: Epoch, headStateRoot: RootHex): void;
   pruneOnFinalized(finalizedEpoch: Epoch): void;
-  processBlockState(blockRootHex: RootHex, postState: CachedBeaconStateAllForks): void;
-  processPayloadState(payloadState: CachedBeaconStateAllForks): void;
+  processBlockState(blockRootHex: RootHex, postState: IBeaconStateView): void;
+  processPayloadState(payloadState: IBeaconStateView): void;
   /**
    * payloadPresent is true if this is payload state, false if block state.
    * payloadPresent is always true for pre-gloas.
    */
-  addCheckpointState(cp: phase0.Checkpoint, item: CachedBeaconStateAllForks, payloadPresent: boolean): void;
-  updateHeadState(newHead: ProtoBlock, maybeHeadState: CachedBeaconStateAllForks): void;
+  addCheckpointState(cp: phase0.Checkpoint, item: IBeaconStateView, payloadPresent: boolean): void;
+  updateHeadState(newHead: ProtoBlock, maybeHeadState: IBeaconStateView): void;
   updatePreComputedCheckpoint(rootHex: RootHex, epoch: Epoch, payloadPresent: boolean): number | null;
   upgradeForGloas(epoch: Epoch): void;
 }
@@ -65,11 +65,7 @@ export interface IStateRegeneratorInternal {
    * Return a valid pre-state for a beacon block
    * This will always return a state in the latest viable epoch
    */
-  getPreState(
-    block: BeaconBlock,
-    opts: StateRegenerationOpts,
-    rCaller: RegenCaller
-  ): Promise<CachedBeaconStateAllForks>;
+  getPreState(block: BeaconBlock, opts: StateRegenerationOpts, rCaller: RegenCaller): Promise<IBeaconStateView>;
 
   /**
    * Return the state of `blockRoot` processed to slot `slot`
@@ -79,10 +75,10 @@ export interface IStateRegeneratorInternal {
     slot: Slot,
     opts: StateRegenerationOpts,
     rCaller: RegenCaller
-  ): Promise<CachedBeaconStateAllForks>;
+  ): Promise<IBeaconStateView>;
 
   /**
    * Return the exact state with `stateRoot`
    */
-  getState(stateRoot: RootHex, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks>;
+  getState(stateRoot: RootHex, rCaller: RegenCaller): Promise<IBeaconStateView>;
 }

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {IForkChoice, PayloadStatus, ProtoBlock} from "@lodestar/fork-choice";
-import {CachedBeaconStateAllForks, computeEpochAtSlot} from "@lodestar/state-transition";
+import {IBeaconStateView, computeEpochAtSlot} from "@lodestar/state-transition";
 import {BeaconBlock, Epoch, RootHex, Slot, isGloasBeaconBlock, phase0} from "@lodestar/types";
 import {Logger, fromHex, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
@@ -34,7 +34,7 @@ export type RegenRequest = RegenRequestByKey[RegenRequestKey];
  * All requests are queued so that only a single state at a time may be regenerated at a time
  */
 export class QueuedStateRegenerator implements IStateRegenerator {
-  readonly jobQueue: JobItemQueue<[RegenRequest], CachedBeaconStateAllForks>;
+  readonly jobQueue: JobItemQueue<[RegenRequest], IBeaconStateView>;
   private readonly regen: StateRegenerator;
 
   private readonly forkChoice: IForkChoice;
@@ -45,7 +45,7 @@ export class QueuedStateRegenerator implements IStateRegenerator {
 
   constructor(modules: QueuedStateRegeneratorModules) {
     this.regen = new StateRegenerator(modules);
-    this.jobQueue = new JobItemQueue<[RegenRequest], CachedBeaconStateAllForks>(
+    this.jobQueue = new JobItemQueue<[RegenRequest], IBeaconStateView>(
       this.jobQueueProcessor,
       {maxLength: REGEN_QUEUE_MAX_LEN, signal: modules.signal},
       modules.metrics ? modules.metrics.regenQueue : undefined
@@ -79,14 +79,14 @@ export class QueuedStateRegenerator implements IStateRegenerator {
   /**
    * Get a state from block state cache.
    */
-  getStateSync(stateRoot: RootHex): CachedBeaconStateAllForks | null {
+  getStateSync(stateRoot: RootHex): IBeaconStateView | null {
     return this.blockStateCache.get(stateRoot);
   }
 
   /**
    * Get state for block processing.
    */
-  getPreStateSync(block: BeaconBlock): CachedBeaconStateAllForks | null {
+  getPreStateSync(block: BeaconBlock): IBeaconStateView | null {
     const parentRoot = toRootHex(block.parentRoot);
     const parentBlock = isGloasBeaconBlock(block)
       ? this.forkChoice.getBlockHexAndBlockHash(
@@ -135,21 +135,21 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     return null;
   }
 
-  async getCheckpointStateOrBytes(cp: CheckpointHexPayload): Promise<CachedBeaconStateAllForks | Uint8Array | null> {
+  async getCheckpointStateOrBytes(cp: CheckpointHexPayload): Promise<IBeaconStateView | Uint8Array | null> {
     return this.checkpointStateCache.getStateOrBytes(cp);
   }
 
   /**
    * Get checkpoint state from cache
    */
-  getCheckpointStateSync(cp: CheckpointHexPayload): CachedBeaconStateAllForks | null {
+  getCheckpointStateSync(cp: CheckpointHexPayload): IBeaconStateView | null {
     return this.checkpointStateCache.get(cp);
   }
 
   /**
    * Get state closest to head
    */
-  getClosestHeadState(head: ProtoBlock): CachedBeaconStateAllForks | null {
+  getClosestHeadState(head: ProtoBlock): IBeaconStateView | null {
     // Convert PayloadStatus to payloadPresent boolean
     if (head.payloadStatus === PayloadStatus.PENDING) {
       throw new RegenError({
@@ -175,7 +175,7 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     this.blockStateCache.deleteAllBeforeEpoch(finalizedEpoch);
   }
 
-  processBlockState(blockRootHex: RootHex, postState: CachedBeaconStateAllForks): void {
+  processBlockState(blockRootHex: RootHex, postState: IBeaconStateView): void {
     this.blockStateCache.add(postState);
     this.checkpointStateCache.processState(blockRootHex, postState).catch((e) => {
       this.logger.debug("Error processing block state", {blockRootHex, slot: postState.slot}, e);
@@ -185,17 +185,17 @@ export class QueuedStateRegenerator implements IStateRegenerator {
   /**
    * Process payload state for caching after importing execution payload.
    */
-  processPayloadState(payloadState: CachedBeaconStateAllForks): void {
+  processPayloadState(payloadState: IBeaconStateView): void {
     // Add payload state to block state cache (keyed by payload state root)
     this.blockStateCache.add(payloadState);
   }
 
   // TODO GLOAS: This should also be called when importing execution payload after we implement it
-  addCheckpointState(cp: phase0.Checkpoint, item: CachedBeaconStateAllForks, payloadPresent: boolean): void {
+  addCheckpointState(cp: phase0.Checkpoint, item: IBeaconStateView, payloadPresent: boolean): void {
     this.checkpointStateCache.add(cp, item, payloadPresent);
   }
 
-  updateHeadState(newHead: ProtoBlock, maybeHeadState: CachedBeaconStateAllForks): void {
+  updateHeadState(newHead: ProtoBlock, maybeHeadState: IBeaconStateView): void {
     const {stateRoot: newHeadStateRoot, blockRoot: newHeadBlockRoot, slot: newHeadSlot} = newHead;
     const maybeHeadStateRoot = toRootHex(maybeHeadState.hashTreeRoot());
     const logCtx = {
@@ -241,11 +241,7 @@ export class QueuedStateRegenerator implements IStateRegenerator {
    * Get the state to run with `block`.
    * - State after `block.parentRoot` dialed forward to block.slot
    */
-  async getPreState(
-    block: BeaconBlock,
-    opts: StateRegenerationOpts,
-    rCaller: RegenCaller
-  ): Promise<CachedBeaconStateAllForks> {
+  async getPreState(block: BeaconBlock, opts: StateRegenerationOpts, rCaller: RegenCaller): Promise<IBeaconStateView> {
     this.metrics?.regenFnCallTotal.inc({caller: rCaller, entrypoint: RegenFnName.getPreState});
 
     // First attempt to fetch the state from caches before queueing
@@ -271,14 +267,14 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     slot: Slot,
     opts: StateRegenerationOpts,
     rCaller: RegenCaller
-  ): Promise<CachedBeaconStateAllForks> {
+  ): Promise<IBeaconStateView> {
     this.metrics?.regenFnCallTotal.inc({caller: rCaller, entrypoint: RegenFnName.getBlockSlotState});
 
     // The state is not immediately available in the caches, enqueue the job
     return this.jobQueue.push({key: "getBlockSlotState", args: [block, slot, opts, rCaller]});
   }
 
-  async getState(stateRoot: RootHex, rCaller: RegenCaller): Promise<CachedBeaconStateAllForks> {
+  async getState(stateRoot: RootHex, rCaller: RegenCaller): Promise<IBeaconStateView> {
     this.metrics?.regenFnCallTotal.inc({caller: rCaller, entrypoint: RegenFnName.getState});
 
     // First attempt to fetch the state from cache before queueing
@@ -292,7 +288,7 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     return this.jobQueue.push({key: "getState", args: [stateRoot, rCaller]});
   }
 
-  private jobQueueProcessor = async (regenRequest: RegenRequest): Promise<CachedBeaconStateAllForks> => {
+  private jobQueueProcessor = async (regenRequest: RegenRequest): Promise<IBeaconStateView> => {
     const metricsLabels = {
       caller: regenRequest.args.at(-1) as RegenCaller,
       entrypoint: regenRequest.key as RegenFnName,

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -2,14 +2,12 @@ import {ChainForkConfig} from "@lodestar/config";
 import {IForkChoice, PayloadStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
-  CachedBeaconStateAllForks,
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
+  IBeaconStateView,
   StateHashTreeRootSource,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
-  processSlots,
-  stateTransition,
 } from "@lodestar/state-transition";
 import {BeaconBlock, RootHex, SignedBeaconBlock, Slot, isGloasBeaconBlock} from "@lodestar/types";
 import {Logger, fromHex, toRootHex} from "@lodestar/utils";
@@ -57,7 +55,7 @@ export class StateRegenerator implements IStateRegeneratorInternal {
     block: BeaconBlock,
     opts: StateRegenerationOpts,
     regenCaller: RegenCaller
-  ): Promise<CachedBeaconStateAllForks> {
+  ): Promise<IBeaconStateView> {
     const parentRoot = toRootHex(block.parentRoot);
     const parentBlock = isGloasBeaconBlock(block)
       ? this.modules.forkChoice.getBlockHexAndBlockHash(
@@ -99,7 +97,7 @@ export class StateRegenerator implements IStateRegeneratorInternal {
     opts: StateRegenerationOpts,
     regenCaller: RegenCaller,
     allowDiskReload = false
-  ): Promise<CachedBeaconStateAllForks> {
+  ): Promise<IBeaconStateView> {
     if (slot < block.slot) {
       throw new RegenError({
         code: RegenErrorCode.SLOT_BEFORE_BLOCK_SLOT,
@@ -149,7 +147,7 @@ export class StateRegenerator implements IStateRegeneratorInternal {
     caller: RegenCaller,
     // internal option, don't want to expose to external caller
     allowDiskReload = false
-  ): Promise<CachedBeaconStateAllForks> {
+  ): Promise<IBeaconStateView> {
     // Trivial case, state at stateRoot is already cached
     const cachedStateCtx = this.modules.blockStateCache.get(stateRoot);
     if (cachedStateCtx) {
@@ -164,7 +162,7 @@ export class StateRegenerator implements IStateRegeneratorInternal {
     // blocks to replay, ordered highest to lowest
     // gets reversed when replayed
     const blocksToReplay = [block];
-    let state: CachedBeaconStateAllForks | null = null;
+    let state: IBeaconStateView | null = null;
     const {checkpointStateCache} = this.modules;
 
     const getSeedStateTimer = this.modules.metrics?.regenGetState.getSeedState.startTimer({caller});
@@ -260,8 +258,7 @@ export class StateRegenerator implements IStateRegeneratorInternal {
         // Only advances state trusting block's signture and hashes.
         // We are only running the state transition to get a specific state's data.
         // stateTransition() does the clone() inside, transfer cache to make the regen faster
-        state = stateTransition(
-          state,
+        state = state.stateTransition(
           block,
           {
             // Replay previously imported blocks, assume valid and available
@@ -333,16 +330,17 @@ async function processSlotsByCheckpoint(
     metrics: Metrics | null;
     validatorMonitor: ValidatorMonitor | null;
     emitter: ChainEventEmitter;
+    config: ChainForkConfig;
     logger: Logger;
   },
-  preState: CachedBeaconStateAllForks,
+  preState: IBeaconStateView,
   slot: Slot,
   regenCaller: RegenCaller,
   opts: StateRegenerationOpts
-): Promise<CachedBeaconStateAllForks> {
+): Promise<IBeaconStateView> {
   let postState = await processSlotsToNearestCheckpoint(modules, preState, slot, regenCaller, opts);
   if (postState.slot < slot) {
-    postState = processSlots(postState, slot, opts, modules);
+    postState = postState.processSlots(slot, opts, modules);
   }
   return postState;
 }
@@ -365,18 +363,19 @@ export async function processSlotsToNearestCheckpoint(
     metrics: Metrics | null;
     validatorMonitor: ValidatorMonitor | null;
     emitter: ChainEventEmitter | null;
+    config: ChainForkConfig;
     logger: Logger | null;
   },
-  preState: CachedBeaconStateAllForks,
+  preState: IBeaconStateView,
   slot: Slot,
   regenCaller: RegenCaller,
   opts: StateRegenerationOpts
-): Promise<CachedBeaconStateAllForks> {
+): Promise<IBeaconStateView> {
   const preSlot = preState.slot;
   const postSlot = slot;
   const preEpoch = computeEpochAtSlot(preSlot);
   let postState = preState;
-  const {checkpointStateCache, emitter, metrics, logger} = modules;
+  const {config, checkpointStateCache, emitter, metrics, logger} = modules;
   let count = 0;
 
   for (
@@ -391,7 +390,7 @@ export async function processSlotsToNearestCheckpoint(
       caller: regenCaller,
     });
     // processSlots calls .clone() before mutating
-    postState = processSlots(postState, nextEpochSlot, opts, modules);
+    postState = postState.processSlots(nextEpochSlot, opts, modules);
     metrics?.epochTransitionByCaller.inc({caller: regenCaller});
 
     // this is usually added when we prepare for next slot or validate gossip block
@@ -403,7 +402,7 @@ export async function processSlotsToNearestCheckpoint(
     // processSlots() only does epoch transitions, never processes payloads
     // Pre-Gloas: payloadPresent is always true (execution payload embedded in block)
     // Post-Gloas: result is a block state (payloadPresent=false)
-    const isPayloadPresent = checkpointState.config.getForkSeq(checkpointState.slot) < ForkSeq.gloas;
+    const isPayloadPresent = config.getForkSeq(checkpointState.slot) < ForkSeq.gloas;
     checkpointStateCache.add(cp, checkpointState, isPayloadPresent);
     // consumers should not mutate state ever
     emitter?.emit(ChainEvent.checkpoint, cp, checkpointState);

--- a/packages/beacon-node/src/chain/serializeState.ts
+++ b/packages/beacon-node/src/chain/serializeState.ts
@@ -1,4 +1,4 @@
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {IBeaconStateView} from "@lodestar/state-transition";
 import {AllocSource, BufferPool} from "../util/bufferPool.js";
 
 type ProcessStateBytesFn<T> = (stateBytes: Uint8Array) => Promise<T>;
@@ -7,12 +7,12 @@ type ProcessStateBytesFn<T> = (stateBytes: Uint8Array) => Promise<T>;
  * Serialize state using the BufferPool if provided.
  */
 export async function serializeState<T>(
-  state: CachedBeaconStateAllForks,
+  state: IBeaconStateView,
   source: AllocSource,
   processFn: ProcessStateBytesFn<T>,
   bufferPool?: BufferPool | null
 ): Promise<T> {
-  const size = state.type.tree_serializedSize(state.node);
+  const size = state.serializedSize();
   let stateBytes: Uint8Array | null = null;
   if (bufferPool) {
     using bufferWithKey = bufferPool.alloc(size, source);

--- a/packages/beacon-node/src/chain/shufflingCache.ts
+++ b/packages/beacon-node/src/chain/shufflingCache.ts
@@ -1,7 +1,7 @@
 import {ForkSeq} from "@lodestar/params";
 import {
-  CachedBeaconStateAllForks,
   EpochShuffling,
+  IBeaconStateView,
   getAttestingIndices,
   getBeaconCommittees,
   getIndexedAttestation,
@@ -159,17 +159,15 @@ export class ShufflingCache {
    * Process a state to extract and cache all shufflings (previous, current, next).
    * Uses the stored decision roots from epochCtx.
    */
-  processState(state: CachedBeaconStateAllForks): void {
-    const {epochCtx} = state;
-
+  processState(state: IBeaconStateView): void {
     // Cache previous shuffling
-    this.set(epochCtx.previousShuffling, epochCtx.previousDecisionRoot);
+    this.set(state.getPreviousShuffling(), state.previousDecisionRoot);
 
     // Cache current shuffling
-    this.set(epochCtx.currentShuffling, epochCtx.currentDecisionRoot);
+    this.set(state.getCurrentShuffling(), state.currentDecisionRoot);
 
     // Cache next shuffling
-    this.set(epochCtx.nextShuffling, epochCtx.nextDecisionRoot);
+    this.set(state.getNextShuffling(), state.nextDecisionRoot);
   }
 
   getIndexedAttestation(

--- a/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/fifoBlockStateCache.ts
@@ -1,5 +1,5 @@
 import {routes} from "@lodestar/api";
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {IBeaconStateView} from "@lodestar/state-transition";
 import {RootHex} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
@@ -48,7 +48,7 @@ export const DEFAULT_MAX_BLOCK_STATES_GLOAS = 128;
 export class FIFOBlockStateCache implements BlockStateCache {
   private maxStates: number;
 
-  private readonly cache: MapTracker<string, CachedBeaconStateAllForks>;
+  private readonly cache: MapTracker<string, IBeaconStateView>;
   /**
    * Key order to implement FIFO cache
    */
@@ -68,7 +68,7 @@ export class FIFOBlockStateCache implements BlockStateCache {
   /**
    * Set a state as head, happens when importing a block and head block is changed.
    */
-  setHeadState(item: CachedBeaconStateAllForks | null): void {
+  setHeadState(item: IBeaconStateView | null): void {
     if (item !== null) {
       this.add(item, true);
     }
@@ -79,7 +79,7 @@ export class FIFOBlockStateCache implements BlockStateCache {
    * base merkle tree for all BeaconState objects across application.
    * See packages/state-transition/src/util/loadState/loadState.ts for more detail
    */
-  getSeedState(): CachedBeaconStateAllForks {
+  getSeedState(): IBeaconStateView {
     const firstValue = this.cache.values().next();
     if (firstValue.done) {
       // should not happen
@@ -94,7 +94,7 @@ export class FIFOBlockStateCache implements BlockStateCache {
   /**
    * Get a state from this cache given a state root hex.
    */
-  get(rootHex: RootHex): CachedBeaconStateAllForks | null {
+  get(rootHex: RootHex): IBeaconStateView | null {
     this.metrics?.lookups.inc();
     const item = this.cache.get(rootHex);
     if (!item) {
@@ -112,7 +112,7 @@ export class FIFOBlockStateCache implements BlockStateCache {
    * @param isHead if true, move it to the head of the list. Otherwise add to the 2nd position.
    * In importBlock() steps, normally it'll call add() with isHead = false first. Then call setHeadState() to set the head.
    */
-  add(item: CachedBeaconStateAllForks, isHead = false): void {
+  add(item: IBeaconStateView, isHead = false): void {
     const key = toRootHex(item.hashTreeRoot());
     if (this.cache.get(key) != null) {
       if (!this.keyOrder.has(key)) {
@@ -200,7 +200,7 @@ export class FIFOBlockStateCache implements BlockStateCache {
     }));
   }
 
-  getStates(): IterableIterator<CachedBeaconStateAllForks> {
+  getStates(): IterableIterator<IBeaconStateView> {
     return this.cache.values();
   }
 

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -217,7 +217,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    */
   async getOrReload(cp: CheckpointHexPayload): Promise<IBeaconStateView | null> {
     const stateOrStateBytesData = await this.getStateOrLoadDb(cp);
-    if (stateOrStateBytesData === null || isCachedBeaconState(stateOrStateBytesData)) {
+    if (stateOrStateBytesData === null || isBeaconStateView(stateOrStateBytesData)) {
       return stateOrStateBytesData ?? null;
     }
     const {persistedKey, stateBytes} = stateOrStateBytesData;
@@ -278,7 +278,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    */
   async getStateOrBytes(cp: CheckpointHexPayload): Promise<IBeaconStateView | Uint8Array | null> {
     const stateOrLoadedState = await this.getStateOrLoadDb(cp);
-    if (stateOrLoadedState === null || isCachedBeaconState(stateOrLoadedState)) {
+    if (stateOrLoadedState === null || isBeaconStateView(stateOrLoadedState)) {
       return stateOrLoadedState;
     }
     return stateOrLoadedState.stateBytes;
@@ -970,7 +970,7 @@ function fromCacheKey(key: CacheKey): CheckpointHexPayload {
   };
 }
 
-function isCachedBeaconState(stateOrBytes: IBeaconStateView | LoadedStateBytesData): stateOrBytes is IBeaconStateView {
+function isBeaconStateView(stateOrBytes: IBeaconStateView | LoadedStateBytesData): stateOrBytes is IBeaconStateView {
   return (stateOrBytes as IBeaconStateView).slot !== undefined;
 }
 

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -1,12 +1,7 @@
 import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
 import {CheckpointWithPayloadStatus} from "@lodestar/fork-choice";
-import {
-  CachedBeaconStateAllForks,
-  computeStartSlotAtEpoch,
-  getBlockRootAtSlot,
-  loadCachedBeaconState,
-} from "@lodestar/state-transition";
+import {IBeaconStateView, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, RootHex, phase0} from "@lodestar/types";
 import {Logger, MapDef, fromHex, sleep, toHex, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
@@ -40,7 +35,7 @@ type CacheKey = string;
 
 type InMemoryCacheItem = {
   type: CacheItemType.inMemory;
-  state: CachedBeaconStateAllForks;
+  state: IBeaconStateView;
   // if a cp state is reloaded from disk, it'll keep track of persistedKey to allow us to remove it from disk later
   // it also helps not to persist it again
   persistedKey?: DatastoreKey;
@@ -220,7 +215,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    * - Get block for processing
    * - Regen head state
    */
-  async getOrReload(cp: CheckpointHexPayload): Promise<CachedBeaconStateAllForks | null> {
+  async getOrReload(cp: CheckpointHexPayload): Promise<IBeaconStateView | null> {
     const stateOrStateBytesData = await this.getStateOrLoadDb(cp);
     if (stateOrStateBytesData === null || isCachedBeaconState(stateOrStateBytesData)) {
       return stateOrStateBytesData ?? null;
@@ -237,7 +232,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       this.clock?.secFromSlot(this.clock?.currentSlot ?? 0) ?? 0
     );
     const seedState = this.findSeedStateToReload(cp);
-    this.metrics?.cpStateCache.stateReloadEpochDiff.observe(Math.abs(seedState.epochCtx.epoch - cp.epoch));
+    this.metrics?.cpStateCache.stateReloadEpochDiff.observe(Math.abs(seedState.epoch - cp.epoch));
     this.logger.debug("Reload: found seed state", {...logMeta, seedSlot: seedState.slot});
 
     try {
@@ -249,19 +244,16 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       if (validatorsBytes == null) {
         // fallback logic in case we can't use the buffer pool
         this.metrics?.cpStateCache.stateReloadValidatorsSerializeAllocCount.inc();
-        validatorsBytes = seedState.validators.serialize();
+        validatorsBytes = seedState.serializeValidators();
       }
       sszTimer?.();
       const timer = this.metrics?.cpStateCache.stateReloadDuration.startTimer();
-      const newCachedState = loadCachedBeaconState(seedState, stateBytes, {}, validatorsBytes);
+      const newCachedState = seedState.loadOtherState(stateBytes, validatorsBytes);
       // hashTreeRoot() calls the commit() inside
       // there is no modification inside the state, it's just that we want to compute and cache all roots
       const stateRoot = toRootHex(newCachedState.hashTreeRoot());
       timer?.();
 
-      // load all cache in order for consumers (usually regen.getState()) to process blocks faster
-      newCachedState.validators.getAllReadonlyValues();
-      newCachedState.balances.getAll();
       this.logger.debug("Reload: cached state load successful", {
         ...logMeta,
         stateSlot: newCachedState.slot,
@@ -284,7 +276,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   /**
    * Return either state or state bytes loaded from db.
    */
-  async getStateOrBytes(cp: CheckpointHexPayload): Promise<CachedBeaconStateAllForks | Uint8Array | null> {
+  async getStateOrBytes(cp: CheckpointHexPayload): Promise<IBeaconStateView | Uint8Array | null> {
     const stateOrLoadedState = await this.getStateOrLoadDb(cp);
     if (stateOrLoadedState === null || isCachedBeaconState(stateOrLoadedState)) {
       return stateOrLoadedState;
@@ -295,7 +287,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   /**
    * Return either state or state bytes with persisted key loaded from db.
    */
-  async getStateOrLoadDb(cp: CheckpointHexPayload): Promise<CachedBeaconStateAllForks | LoadedStateBytesData | null> {
+  async getStateOrLoadDb(cp: CheckpointHexPayload): Promise<IBeaconStateView | LoadedStateBytesData | null> {
     const cpKey = toCacheKey(cp);
     const inMemoryState = this.get(cpKey);
     if (inMemoryState) {
@@ -326,7 +318,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   /**
    * Similar to get() api without reloading from disk
    */
-  get(cpOrKey: CheckpointHexPayload | CacheKey): CachedBeaconStateAllForks | null {
+  get(cpOrKey: CheckpointHexPayload | CacheKey): IBeaconStateView | null {
     this.metrics?.cpStateCache.lookups.inc();
     const cpKey = typeof cpOrKey === "string" ? cpOrKey : toCacheKey(cpOrKey);
     const cacheItem = this.cache.get(cpKey);
@@ -355,7 +347,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    * @param payloadPresent - For Gloas: true if this is payload state, false if block state.
    *                         Always true for pre-Gloas.
    */
-  add(cp: phase0.Checkpoint, state: CachedBeaconStateAllForks, payloadPresent: boolean): void {
+  add(cp: phase0.Checkpoint, state: IBeaconStateView, payloadPresent: boolean): void {
     const cpHex = toCheckpointHexPayload(cp, payloadPresent);
     const key = toCacheKey(cpHex);
     const cacheItem = this.cache.get(key);
@@ -385,7 +377,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   /**
    * Searches in-memory state for the latest cached state with a `root` without reload, starting with `epoch` and descending
    */
-  getLatest(rootHex: RootHex, maxEpoch: Epoch, payloadPresent: boolean): CachedBeaconStateAllForks | null {
+  getLatest(rootHex: RootHex, maxEpoch: Epoch, payloadPresent: boolean): IBeaconStateView | null {
     // sort epochs in descending order, only consider epochs lte `epoch`
     const epochs = Array.from(this.epochIndex.keys())
       .sort((a, b) => b - a)
@@ -412,7 +404,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     rootHex: RootHex,
     maxEpoch: Epoch,
     payloadPresent: boolean
-  ): Promise<CachedBeaconStateAllForks | null> {
+  ): Promise<IBeaconStateView | null> {
     // sort epochs in descending order, only consider epochs lte `epoch`
     const epochs = Array.from(this.epochIndex.keys())
       .sort((a, b) => b - a)
@@ -518,7 +510,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    * For Gloas: Processes both block state and payload state variants together. The decision of which roots to persist/prune
    * is based on root canonicality (from state's view), not payload presence. Both variants are managed as a unit.
    */
-  async processState(blockRootHex: RootHex, state: CachedBeaconStateAllForks): Promise<number> {
+  async processState(blockRootHex: RootHex, state: IBeaconStateView): Promise<number> {
     let persistCount = 0;
     // it's important to sort the epochs in ascending order, in case of big reorg we always want to keep the most recent checkpoint states
     const sortedEpochs = Array.from(this.epochIndex.keys()).sort((a, b) => a - b);
@@ -587,10 +579,10 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    *
    * Use seed state from the block cache if cannot find any seed states within this cache.
    */
-  findSeedStateToReload(reloadedCp: CheckpointHexPayload): CachedBeaconStateAllForks {
+  findSeedStateToReload(reloadedCp: CheckpointHexPayload): IBeaconStateView {
     const maxEpoch = Math.max(...Array.from(this.epochIndex.keys()));
     const reloadedCpSlot = computeStartSlotAtEpoch(reloadedCp.epoch);
-    let firstState: CachedBeaconStateAllForks | null = null;
+    let firstState: IBeaconStateView | null = null;
     const logCtx = {reloadedCpEpoch: reloadedCp.epoch, reloadedCpRoot: reloadedCp.rootHex};
 
     // no need to check epochs before `maxEpoch - this.maxEpochsInMemory + 1` before they are all persisted
@@ -620,7 +612,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
               // amongst states of the same epoch, choose the one with the same view of reloadedCp
               if (
                 reloadedCpSlot < state.slot &&
-                toRootHex(getBlockRootAtSlot(state, reloadedCpSlot)) === reloadedCp.rootHex
+                toRootHex(state.getBlockRootAtSlot(reloadedCpSlot)) === reloadedCp.rootHex
               ) {
                 this.logger.verbose("Reload: use checkpoint state as seed state", {...cpLog, ...logCtx});
                 return state;
@@ -685,7 +677,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     });
   }
 
-  getStates(): IterableIterator<CachedBeaconStateAllForks> {
+  getStates(): IterableIterator<IBeaconStateView> {
     const items = Array.from(this.cache.values())
       .filter(isInMemoryCacheItem)
       .map((item) => item.state);
@@ -735,17 +727,13 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    *   - In normal condition, we persist 1 checkpoint state per epoch.
    *   - In reorged condition, we may persist multiple (most likely 2) checkpoint states per epoch.
    */
-  private async processPastEpoch(
-    blockRootHex: RootHex,
-    state: CachedBeaconStateAllForks,
-    epoch: Epoch
-  ): Promise<number> {
+  private async processPastEpoch(blockRootHex: RootHex, state: IBeaconStateView, epoch: Epoch): Promise<number> {
     let persistCount = 0;
     const epochBoundarySlot = computeStartSlotAtEpoch(epoch);
     const epochBoundaryRoot =
-      epochBoundarySlot === state.slot ? fromHex(blockRootHex) : getBlockRootAtSlot(state, epochBoundarySlot);
+      epochBoundarySlot === state.slot ? fromHex(blockRootHex) : state.getBlockRootAtSlot(epochBoundarySlot);
     const epochBoundaryHex = toRootHex(epochBoundaryRoot);
-    const prevEpochRoot = toRootHex(getBlockRootAtSlot(state, epochBoundarySlot - 1));
+    const prevEpochRoot = toRootHex(state.getBlockRootAtSlot(epochBoundarySlot - 1));
 
     // for each epoch, usually there are 2 rootHexes respective to the 2 checkpoint states: Previous Root Checkpoint State and Current Root Checkpoint State
     const cpRootHexMap = this.epochIndex.get(epoch) ?? new Map<RootHex, number>();
@@ -912,15 +900,14 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    *   - Also `serializeState.test.ts` perf test shows a lot of differences allocating validators bytes once vs every time,
    * This is 2x - 3x faster than allocating memory every time.
    */
-  private serializeStateValidators(state: CachedBeaconStateAllForks): BufferWithKey | null {
-    const type = state.type.fields.validators;
-    const size = type.tree_serializedSize(state.validators.node);
+  private serializeStateValidators(state: IBeaconStateView): BufferWithKey | null {
+    const size = state.serializedValidatorsSize();
     if (this.bufferPool) {
       const bufferWithKey = this.bufferPool.alloc(size, AllocSource.PERSISTENT_CHECKPOINTS_CACHE_VALIDATORS);
       if (bufferWithKey) {
         const validatorsBytes = bufferWithKey.buffer;
         const dataView = new DataView(validatorsBytes.buffer, validatorsBytes.byteOffset, validatorsBytes.byteLength);
-        state.validators.serializeToBytes({uint8Array: validatorsBytes, dataView}, 0);
+        state.serializeValidatorsToBytes({uint8Array: validatorsBytes, dataView}, 0);
         return bufferWithKey;
       }
     }
@@ -983,10 +970,8 @@ function fromCacheKey(key: CacheKey): CheckpointHexPayload {
   };
 }
 
-function isCachedBeaconState(
-  stateOrBytes: CachedBeaconStateAllForks | LoadedStateBytesData
-): stateOrBytes is CachedBeaconStateAllForks {
-  return (stateOrBytes as CachedBeaconStateAllForks).slot !== undefined;
+function isCachedBeaconState(stateOrBytes: IBeaconStateView | LoadedStateBytesData): stateOrBytes is IBeaconStateView {
+  return (stateOrBytes as IBeaconStateView).slot !== undefined;
 }
 
 function isInMemoryCacheItem(cacheItem: CacheItem): cacheItem is InMemoryCacheItem {

--- a/packages/beacon-node/src/chain/stateCache/types.ts
+++ b/packages/beacon-node/src/chain/stateCache/types.ts
@@ -1,5 +1,5 @@
 import {routes} from "@lodestar/api";
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {IBeaconStateView} from "@lodestar/state-transition";
 import {Epoch, RootHex, phase0} from "@lodestar/types";
 
 /**
@@ -24,13 +24,13 @@ export type CheckpointHexPayload = {epoch: Epoch; rootHex: RootHex; payloadPrese
  * The cache key is state root
  */
 export interface BlockStateCache {
-  get(rootHex: RootHex): CachedBeaconStateAllForks | null;
-  add(item: CachedBeaconStateAllForks): void;
-  setHeadState(item: CachedBeaconStateAllForks | null): void;
+  get(rootHex: RootHex): IBeaconStateView | null;
+  add(item: IBeaconStateView): void;
+  setHeadState(item: IBeaconStateView | null): void;
   /**
    * Get a seed state for state reload.
    */
-  getSeedState(): CachedBeaconStateAllForks;
+  getSeedState(): IBeaconStateView;
   clear(): void;
   size: number;
   prune(headStateRootHex: RootHex): void;
@@ -39,7 +39,7 @@ export interface BlockStateCache {
   upgradeToGloas(): void;
   dumpSummary(): routes.lodestar.StateCacheItem[];
   /** Expose beacon states stored in cache. Use with caution */
-  getStates(): IterableIterator<CachedBeaconStateAllForks>;
+  getStates(): IterableIterator<IBeaconStateView>;
 }
 
 /**
@@ -65,24 +65,20 @@ export interface BlockStateCache {
  */
 export interface CheckpointStateCache {
   init?: () => Promise<void>;
-  getOrReload(cp: CheckpointHexPayload): Promise<CachedBeaconStateAllForks | null>;
-  getStateOrBytes(cp: CheckpointHexPayload): Promise<CachedBeaconStateAllForks | Uint8Array | null>;
-  get(cpOrKey: CheckpointHexPayload | string): CachedBeaconStateAllForks | null;
-  add(cp: phase0.Checkpoint, state: CachedBeaconStateAllForks, payloadPresent: boolean): void;
-  getLatest(rootHex: RootHex, maxEpoch: Epoch, payloadPresent: boolean): CachedBeaconStateAllForks | null;
-  getOrReloadLatest(
-    rootHex: RootHex,
-    maxEpoch: Epoch,
-    payloadPresent: boolean
-  ): Promise<CachedBeaconStateAllForks | null>;
+  getOrReload(cp: CheckpointHexPayload): Promise<IBeaconStateView | null>;
+  getStateOrBytes(cp: CheckpointHexPayload): Promise<IBeaconStateView | Uint8Array | null>;
+  get(cpOrKey: CheckpointHexPayload | string): IBeaconStateView | null;
+  add(cp: phase0.Checkpoint, state: IBeaconStateView, payloadPresent: boolean): void;
+  getLatest(rootHex: RootHex, maxEpoch: Epoch, payloadPresent: boolean): IBeaconStateView | null;
+  getOrReloadLatest(rootHex: RootHex, maxEpoch: Epoch, payloadPresent: boolean): Promise<IBeaconStateView | null>;
   updatePreComputedCheckpoint(rootHex: RootHex, epoch: Epoch, payloadPresent: boolean): number | null;
   prune(finalizedEpoch: Epoch, justifiedEpoch: Epoch): void;
   pruneFinalized(finalizedEpoch: Epoch): void;
-  processState(blockRootHex: RootHex, state: CachedBeaconStateAllForks): Promise<number>;
+  processState(blockRootHex: RootHex, state: IBeaconStateView): Promise<number>;
   clear(): void;
   dumpSummary(): routes.lodestar.StateCacheItem[];
   /** Expose beacon states stored in cache. Use with caution */
-  getStates(): IterableIterator<CachedBeaconStateAllForks>;
+  getStates(): IterableIterator<IBeaconStateView>;
 }
 
 export enum CacheItemType {

--- a/packages/beacon-node/src/chain/validation/attesterSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/attesterSlashing.ts
@@ -48,7 +48,7 @@ export async function validateAttesterSlashing(
       chain.config,
       chain.pubkeyCache,
       state.slot,
-      state.validators.length,
+      state.validatorCount,
       attesterSlashing,
       false
     );
@@ -59,8 +59,8 @@ export async function validateAttesterSlashing(
     });
   }
 
-  const currentEpoch = state.epochCtx.epoch;
-  if (!intersectingIndices.some((index) => isSlashableValidator(state.validators.getReadonly(index), currentEpoch))) {
+  const currentEpoch = state.epoch;
+  if (!intersectingIndices.some((index) => isSlashableValidator(state.getValidator(index), currentEpoch))) {
     throw new AttesterSlashingError(GossipAction.REJECT, {
       code: AttesterSlashingErrorCode.INVALID,
       error: Error("AttesterSlashing has no slashable validators"),

--- a/packages/beacon-node/src/chain/validation/blobSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/blobSidecar.ts
@@ -176,7 +176,7 @@ export async function validateGossipBlobSidecar(
   // MAY be queued for later processing while proposers for the block's branch are calculated -- in such
   // a case _do not_ `REJECT`, instead `IGNORE` this message.
   const proposerIndex = blobSidecar.signedBlockHeader.message.proposerIndex;
-  if (blockState.epochCtx.getBeaconProposer(blobSlot) !== proposerIndex) {
+  if (blockState.getBeaconProposer(blobSlot) !== proposerIndex) {
     throw new BlobSidecarGossipError(GossipAction.REJECT, {
       code: BlobSidecarErrorCode.INCORRECT_PROPOSER,
       proposerIndex,

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -6,8 +6,6 @@ import {
   computeTimeAtSlot,
   getBlockProposerSignatureSet,
   isExecutionBlockBodyType,
-  isExecutionEnabled,
-  isExecutionStateType,
 } from "@lodestar/state-transition";
 import {SignedBeaconBlock, deneb, gloas, isGloasBeaconBlock} from "@lodestar/types";
 import {byteArrayEquals, sleep, toRootHex} from "@lodestar/utils";
@@ -176,7 +174,7 @@ export async function validateGossipBlock(
   if (isForkPostBellatrix(fork) && !isForkPostGloas(fork)) {
     if (!isExecutionBlockBodyType(block.body)) throw Error("Not execution block body type");
     const executionPayload = block.body.executionPayload;
-    if (isExecutionStateType(blockState) && isExecutionEnabled(blockState, block)) {
+    if (blockState.isExecutionStateType && blockState.isExecutionEnabled(block)) {
       const expectedTimestamp = computeTimeAtSlot(config, blockSlot, chain.genesisTime);
       if (executionPayload.timestamp !== computeTimeAtSlot(config, blockSlot, chain.genesisTime)) {
         throw new BlockGossipError(GossipAction.REJECT, {
@@ -206,7 +204,7 @@ export async function validateGossipBlock(
   // shuffling (defined by parent_root/slot). If the proposer_index cannot immediately be verified against the expected
   // shuffling, the block MAY be queued for later processing while proposers for the block's branch are calculated --
   // in such a case do not REJECT, instead IGNORE this message.
-  if (blockState.epochCtx.getBeaconProposer(blockSlot) !== proposerIndex) {
+  if (blockState.getBeaconProposer(blockSlot) !== proposerIndex) {
     throw new BlockGossipError(GossipAction.REJECT, {code: BlockErrorCode.INCORRECT_PROPOSER, proposerIndex});
   }
 

--- a/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
+++ b/packages/beacon-node/src/chain/validation/blsToExecutionChange.ts
@@ -39,12 +39,12 @@ async function validateBlsToExecutionChange(
   const state = chain.getHeadState();
   const {config} = chain;
   const addressChange = blsToExecutionChange.message;
-  if (addressChange.validatorIndex >= state.validators.length) {
+  if (addressChange.validatorIndex >= state.validatorCount) {
     throw new BlsToExecutionChangeError(GossipAction.REJECT, {
       code: BlsToExecutionChangeErrorCode.INVALID,
     });
   }
-  const validator = state.validators.getReadonly(addressChange.validatorIndex);
+  const validator = state.getValidator(addressChange.validatorIndex);
   // [REJECT] All of the conditions within process_bls_to_execution_change pass validation.
   // verifySignature = false, verified in batch below
   const {valid} = isValidBlsToExecutionChange(config, validator, blsToExecutionChange, false);

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -122,7 +122,7 @@ export async function validateGossipDataColumnSidecar(
   //              while proposers for the block's branch are calculated -- in such a case do not REJECT, instead IGNORE
   //              this message.
   const proposerIndex = blockHeader.proposerIndex;
-  const expectedProposerIndex = blockState.epochCtx.getBeaconProposer(blockHeader.slot);
+  const expectedProposerIndex = blockState.getBeaconProposer(blockHeader.slot);
 
   if (proposerIndex !== expectedProposerIndex) {
     throw new DataColumnSidecarGossipError(GossipAction.REJECT, {

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -1,7 +1,5 @@
 import {PublicKey} from "@chainsafe/blst";
 import {
-  CachedBeaconStateGloas,
-  canBuilderCoverBid,
   createSingleSignatureSetFromComponents,
   getExecutionPayloadBidSigningRoot,
   isActiveBuilder,
@@ -33,9 +31,7 @@ async function validateExecutionPayloadBid(
   const bid = signedExecutionPayloadBid.message;
   const parentBlockRootHex = toRootHex(bid.parentBlockRoot);
   const parentBlockHashHex = toRootHex(bid.parentBlockHash);
-  const state = (await chain.getHeadStateAtCurrentEpoch(
-    RegenCaller.validateGossipExecutionPayloadBid
-  )) as CachedBeaconStateGloas;
+  const state = await chain.getHeadStateAtCurrentEpoch(RegenCaller.validateGossipExecutionPayloadBid);
 
   // [IGNORE] `bid.slot` is the current slot or the next slot.
   const currentSlot = chain.clock.currentSlot;
@@ -53,7 +49,7 @@ async function validateExecutionPayloadBid(
 
   // [REJECT] `bid.builder_index` is a valid/active builder index -- i.e.
   // `is_active_builder(state, bid.builder_index)` returns `True`.
-  const builder = state.builders.getReadonly(bid.builderIndex);
+  const builder = state.getBuilder(bid.builderIndex);
   if (!isActiveBuilder(builder, state.finalizedCheckpoint.epoch)) {
     throw new ExecutionPayloadBidError(GossipAction.REJECT, {
       code: ExecutionPayloadBidErrorCode.BUILDER_NOT_ELIGIBLE,
@@ -99,7 +95,7 @@ async function validateExecutionPayloadBid(
   }
   // [IGNORE] `bid.value` is less or equal than the builder's excess balance --
   // i.e. `can_builder_cover_bid(state, builder_index, amount)` returns `True`.
-  if (!canBuilderCoverBid(state, bid.builderIndex, bid.value)) {
+  if (!state.canBuilderCoverBid(bid.builderIndex, bid.value)) {
     throw new ExecutionPayloadBidError(GossipAction.IGNORE, {
       code: ExecutionPayloadBidErrorCode.BID_TOO_HIGH,
       bidValue: bid.value,

--- a/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
@@ -1,10 +1,5 @@
 import {PayloadStatus} from "@lodestar/fork-choice";
-import {
-  BeaconStateView,
-  CachedBeaconStateGloas,
-  computeStartSlotAtEpoch,
-  getExecutionPayloadEnvelopeSignatureSet,
-} from "@lodestar/state-transition";
+import {computeStartSlotAtEpoch, getExecutionPayloadEnvelopeSignatureSet} from "@lodestar/state-transition";
 import {gloas} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {ExecutionPayloadEnvelopeError, ExecutionPayloadEnvelopeErrorCode, GossipAction} from "../errors/index.js";
@@ -119,11 +114,10 @@ async function validateExecutionPayloadEnvelope(
       });
     });
 
-  const state = blockState as CachedBeaconStateGloas;
   const signatureSet = getExecutionPayloadEnvelopeSignatureSet(
     chain.config,
     chain.pubkeyCache,
-    new BeaconStateView(state),
+    blockState,
     executionPayloadEnvelope,
     payloadInput.proposerIndex
   );

--- a/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
+++ b/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
@@ -74,7 +74,7 @@ async function validatePayloadAttestationMessage(
   // [REJECT] The message's validator index is within the payload committee in
   // `get_ptc(state, data.slot)`. The `state` is the head state corresponding to
   // processing the block up to the current slot as determined by the fork choice.
-  const validatorCommitteeIndex = state.validatorPTCCommitteeIndex(validatorIndex, data.slot);
+  const validatorCommitteeIndex = state.getIndexInPayloadTimelinessCommittee(validatorIndex, data.slot);
 
   if (validatorCommitteeIndex === -1) {
     throw new PayloadAttestationError(GossipAction.REJECT, {

--- a/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
+++ b/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
@@ -1,5 +1,4 @@
 import {
-  CachedBeaconStateGloas,
   computeEpochAtSlot,
   createSingleSignatureSetFromComponents,
   getPayloadAttestationDataSigningRoot,
@@ -66,7 +65,7 @@ async function validatePayloadAttestationMessage(
     });
   }
 
-  const state = chain.getHeadState() as CachedBeaconStateGloas;
+  const state = chain.getHeadState();
 
   // [REJECT] The message's block `data.beacon_block_root` passes validation.
   // TODO GLOAS: implement this. Technically if we cannot get proto block from fork choice,
@@ -75,8 +74,7 @@ async function validatePayloadAttestationMessage(
   // [REJECT] The message's validator index is within the payload committee in
   // `get_ptc(state, data.slot)`. The `state` is the head state corresponding to
   // processing the block up to the current slot as determined by the fork choice.
-  const ptc = state.epochCtx.getPayloadTimelinessCommittee(data.slot);
-  const validatorCommitteeIndex = ptc.indexOf(validatorIndex);
+  const validatorCommitteeIndex = state.validatorPTCCommitteeIndex(validatorIndex, data.slot);
 
   if (validatorCommitteeIndex === -1) {
     throw new PayloadAttestationError(GossipAction.REJECT, {

--- a/packages/beacon-node/src/chain/validation/proposerSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/proposerSlashing.ts
@@ -35,7 +35,7 @@ async function validateProposerSlashing(
 
   // [REJECT] All of the conditions within process_proposer_slashing pass validation.
   try {
-    const proposer = state.validators.getReadonly(proposerSlashing.signedHeader1.message.proposerIndex);
+    const proposer = state.getValidator(proposerSlashing.signedHeader1.message.proposerIndex);
     // verifySignature = false, verified in batch below
     assertValidProposerSlashing(chain.config, chain.pubkeyCache, state.slot, proposerSlashing, proposer, false);
   } catch (e) {

--- a/packages/beacon-node/src/chain/validation/signatureSets/contributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/contributionAndProof.ts
@@ -1,16 +1,11 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_CONTRIBUTION_AND_PROOF} from "@lodestar/params";
-import {
-  CachedBeaconStateAllForks,
-  ISignatureSet,
-  SignatureSetType,
-  computeSigningRoot,
-} from "@lodestar/state-transition";
+import {IBeaconStateView, ISignatureSet, SignatureSetType, computeSigningRoot} from "@lodestar/state-transition";
 import {altair, ssz} from "@lodestar/types";
 
 export function getContributionAndProofSignatureSet(
   config: BeaconConfig,
-  state: CachedBeaconStateAllForks,
+  state: IBeaconStateView,
   signedContributionAndProof: altair.SignedContributionAndProof
 ): ISignatureSet {
   const domain = config.getDomain(

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommittee.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommittee.ts
@@ -1,16 +1,11 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_SYNC_COMMITTEE} from "@lodestar/params";
-import {
-  CachedBeaconStateAllForks,
-  ISignatureSet,
-  SignatureSetType,
-  computeSigningRoot,
-} from "@lodestar/state-transition";
+import {IBeaconStateView, ISignatureSet, SignatureSetType, computeSigningRoot} from "@lodestar/state-transition";
 import {altair, ssz} from "@lodestar/types";
 
 export function getSyncCommitteeSignatureSet(
   config: BeaconConfig,
-  state: CachedBeaconStateAllForks,
+  state: IBeaconStateView,
   syncCommittee: altair.SyncCommitteeMessage
 ): ISignatureSet {
   const domain = config.getDomain(state.slot, DOMAIN_SYNC_COMMITTEE, syncCommittee.slot);

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeContribution.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeContribution.ts
@@ -1,11 +1,11 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_SYNC_COMMITTEE} from "@lodestar/params";
-import {CachedBeaconStateAltair, ISignatureSet, SignatureSetType, computeSigningRoot} from "@lodestar/state-transition";
+import {IBeaconStateView, ISignatureSet, SignatureSetType, computeSigningRoot} from "@lodestar/state-transition";
 import {altair, ssz} from "@lodestar/types";
 
 export function getSyncCommitteeContributionSignatureSet(
   config: BeaconConfig,
-  state: CachedBeaconStateAltair,
+  state: IBeaconStateView,
   contribution: altair.SyncCommitteeContribution,
   participantIndices: number[]
 ): ISignatureSet {

--- a/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
+++ b/packages/beacon-node/src/chain/validation/signatureSets/syncCommitteeSelectionProof.ts
@@ -1,16 +1,11 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF} from "@lodestar/params";
-import {
-  CachedBeaconStateAllForks,
-  ISignatureSet,
-  SignatureSetType,
-  computeSigningRoot,
-} from "@lodestar/state-transition";
+import {IBeaconStateView, ISignatureSet, SignatureSetType, computeSigningRoot} from "@lodestar/state-transition";
 import {altair, ssz} from "@lodestar/types";
 
 export function getSyncCommitteeSelectionProofSignatureSet(
   config: BeaconConfig,
-  state: CachedBeaconStateAllForks,
+  state: IBeaconStateView,
   contributionAndProof: altair.ContributionAndProof
 ): ISignatureSet {
   const slot = contributionAndProof.contribution.slot;

--- a/packages/beacon-node/src/chain/validation/syncCommittee.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommittee.ts
@@ -1,5 +1,5 @@
 import {SYNC_COMMITTEE_SUBNET_COUNT, SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
-import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {IBeaconStateView, computeEpochAtSlot} from "@lodestar/state-transition";
 import {SubnetID, altair} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {GossipAction, SyncCommitteeError, SyncCommitteeErrorCode} from "../errors/index.js";
@@ -73,7 +73,7 @@ export async function validateGossipSyncCommittee(
 
 export async function validateApiSyncCommittee(
   chain: IBeaconChain,
-  headState: CachedBeaconStateAllForks,
+  headState: IBeaconStateView,
   syncCommittee: altair.SyncCommitteeMessage
 ): Promise<void> {
   const prioritizeBls = true;
@@ -85,7 +85,7 @@ export async function validateApiSyncCommittee(
  */
 async function validateSyncCommitteeSigOnly(
   chain: IBeaconChain,
-  headState: CachedBeaconStateAllForks,
+  headState: IBeaconStateView,
   syncCommittee: altair.SyncCommitteeMessage,
   prioritizeBls = false
 ): Promise<void> {
@@ -102,7 +102,7 @@ async function validateSyncCommitteeSigOnly(
  */
 export function validateGossipSyncCommitteeExceptSig(
   chain: IBeaconChain,
-  headState: CachedBeaconStateAllForks,
+  headState: IBeaconStateView,
   subnet: SubnetID,
   data: Pick<altair.SyncCommitteeMessage, "slot" | "validatorIndex">
 ): IndexInSubcommittee[] {
@@ -144,11 +144,11 @@ export function validateGossipSyncCommitteeExceptSig(
  * A validator may appear multiple times in the same subcommittee.
  */
 function getIndicesInSubcommittee(
-  headState: CachedBeaconStateAllForks,
+  headState: IBeaconStateView,
   subnet: SubnetID,
   data: Pick<altair.SyncCommitteeMessage, "slot" | "validatorIndex">
 ): IndexInSubcommittee[] | null {
-  const syncCommittee = headState.epochCtx.getIndexedSyncCommittee(data.slot);
+  const syncCommittee = headState.getIndexedSyncCommitteeAtEpoch(computeEpochAtSlot(data.slot));
   const indexesInCommittee = syncCommittee.validatorIndexMap.get(data.validatorIndex);
   if (indexesInCommittee === undefined) {
     // Not part of the sync committee

--- a/packages/beacon-node/src/chain/validation/syncCommittee.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommittee.ts
@@ -1,5 +1,5 @@
 import {SYNC_COMMITTEE_SUBNET_COUNT, SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
-import {IBeaconStateView, computeEpochAtSlot} from "@lodestar/state-transition";
+import {IBeaconStateView} from "@lodestar/state-transition";
 import {SubnetID, altair} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {GossipAction, SyncCommitteeError, SyncCommitteeErrorCode} from "../errors/index.js";
@@ -148,7 +148,7 @@ function getIndicesInSubcommittee(
   subnet: SubnetID,
   data: Pick<altair.SyncCommitteeMessage, "slot" | "validatorIndex">
 ): IndexInSubcommittee[] | null {
-  const syncCommittee = headState.getIndexedSyncCommitteeAtEpoch(computeEpochAtSlot(data.slot));
+  const syncCommittee = headState.getIndexedSyncCommittee(data.slot);
   const indexesInCommittee = syncCommittee.validatorIndexMap.get(data.validatorIndex);
   if (indexesInCommittee === undefined) {
     // Not part of the sync committee

--- a/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -1,5 +1,5 @@
 import {SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
-import {CachedBeaconStateAltair, isSyncCommitteeAggregator} from "@lodestar/state-transition";
+import {IBeaconStateView, computeEpochAtSlot, isSyncCommitteeAggregator} from "@lodestar/state-transition";
 import {ValidatorIndex, altair} from "@lodestar/types";
 import {GossipAction, SyncCommitteeError, SyncCommitteeErrorCode} from "../errors/index.js";
 import {IBeaconChain} from "../interface.js";
@@ -53,7 +53,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
   }
 
   // [REJECT] The contribution has participants -- that is, any(contribution.aggregation_bits)
-  const syncCommitteeParticipantIndices = getContributionIndices(headState as CachedBeaconStateAltair, contribution);
+  const syncCommitteeParticipantIndices = getContributionIndices(headState, contribution);
   if (syncCommitteeParticipantIndices.length === 0) {
     throw new SyncCommitteeError(GossipAction.REJECT, {
       code: SyncCommitteeErrorCode.NO_PARTICIPANT,
@@ -83,12 +83,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
 
     // [REJECT] The aggregate signature is valid for the message beacon_block_root and aggregate pubkey derived from
     // the participation info in aggregation_bits for the subcommittee specified by the contribution.subcommittee_index.
-    getSyncCommitteeContributionSignatureSet(
-      chain.config,
-      headState as CachedBeaconStateAltair,
-      contribution,
-      syncCommitteeParticipantIndices
-    ),
+    getSyncCommitteeContributionSignatureSet(chain.config, headState, contribution, syncCommitteeParticipantIndices),
   ];
 
   if (!(await chain.bls.verifySignatureSets(signatureSets, {batchable: true}))) {
@@ -109,12 +104,12 @@ export async function validateSyncCommitteeGossipContributionAndProof(
  * - pubkeyCache
  */
 function getContributionIndices(
-  state: CachedBeaconStateAltair,
+  state: IBeaconStateView,
   contribution: altair.SyncCommitteeContribution
 ): ValidatorIndex[] {
   const startIndex = contribution.subcommitteeIndex * SYNC_COMMITTEE_SUBNET_SIZE;
 
-  const syncCommittee = state.epochCtx.getIndexedSyncCommittee(contribution.slot);
+  const syncCommittee = state.getIndexedSyncCommitteeAtEpoch(computeEpochAtSlot(contribution.slot));
   // The bits in contribution.aggregationBits select validatorIndexes in the subcommittee starting at startIndex
   const subcommitteeValidatorIndices = syncCommittee.validatorIndices.slice(
     startIndex,

--- a/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -1,5 +1,5 @@
 import {SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
-import {IBeaconStateView, computeEpochAtSlot, isSyncCommitteeAggregator} from "@lodestar/state-transition";
+import {IBeaconStateView, isSyncCommitteeAggregator} from "@lodestar/state-transition";
 import {ValidatorIndex, altair} from "@lodestar/types";
 import {GossipAction, SyncCommitteeError, SyncCommitteeErrorCode} from "../errors/index.js";
 import {IBeaconChain} from "../interface.js";
@@ -109,7 +109,7 @@ function getContributionIndices(
 ): ValidatorIndex[] {
   const startIndex = contribution.subcommitteeIndex * SYNC_COMMITTEE_SUBNET_SIZE;
 
-  const syncCommittee = state.getIndexedSyncCommitteeAtEpoch(computeEpochAtSlot(contribution.slot));
+  const syncCommittee = state.getIndexedSyncCommittee(contribution.slot);
   // The bits in contribution.aggregationBits select validatorIndexes in the subcommittee starting at startIndex
   const subcommitteeValidatorIndices = syncCommittee.validatorIndices.slice(
     startIndex,

--- a/packages/beacon-node/src/chain/validation/voluntaryExit.ts
+++ b/packages/beacon-node/src/chain/validation/voluntaryExit.ts
@@ -1,9 +1,4 @@
-import {
-  BeaconStateView,
-  VoluntaryExitValidity,
-  getVoluntaryExitSignatureSet,
-  getVoluntaryExitValidity,
-} from "@lodestar/state-transition";
+import {VoluntaryExitValidity, getVoluntaryExitSignatureSet} from "@lodestar/state-transition";
 import {phase0} from "@lodestar/types";
 import {
   GossipAction,
@@ -53,14 +48,14 @@ async function validateVoluntaryExit(
 
   // [REJECT] All of the conditions within process_voluntary_exit pass validation.
   // verifySignature = false, verified in batch below
-  const validity = getVoluntaryExitValidity(chain.config.getForkSeq(state.slot), state, voluntaryExit, false);
+  const validity = state.getVoluntaryExitValidity(voluntaryExit, false);
   if (validity !== VoluntaryExitValidity.valid) {
     throw new VoluntaryExitError(GossipAction.REJECT, {
       code: voluntaryExitValidityToErrorCode(validity),
     });
   }
 
-  const signatureSet = getVoluntaryExitSignatureSet(chain.config, new BeaconStateView(state), voluntaryExit);
+  const signatureSet = getVoluntaryExitSignatureSet(chain.config, state, voluntaryExit);
   if (!(await chain.bls.verifySignatureSets([signatureSet], {batchable: true, priority: prioritizeBls}))) {
     throw new VoluntaryExitError(GossipAction.REJECT, {
       code: VoluntaryExitErrorCode.INVALID_SIGNATURE,

--- a/packages/beacon-node/src/chain/validatorMonitor.ts
+++ b/packages/beacon-node/src/chain/validatorMonitor.ts
@@ -1,13 +1,11 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkSeq, MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
-  CachedBeaconStateAllForks,
-  CachedBeaconStateAltair,
+  IBeaconStateView,
   ParticipationFlags,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   computeTimeAtSlot,
-  getBlockRootAtSlot,
   getCurrentSlot,
   parseAttesterFlags,
   parseParticipationFlags,
@@ -102,7 +100,7 @@ export type ValidatorMonitor = {
     syncAggregate: altair.SyncAggregate,
     syncCommitteeIndices: Uint32Array
   ): void;
-  onceEveryEndOfEpoch(state: CachedBeaconStateAllForks): void;
+  onceEveryEndOfEpoch(state: IBeaconStateView): void;
   scrapeMetrics(slotClock: Slot): void;
   /** Returns the list of validator indices currently being monitored */
   getMonitoredValidatorIndices(): ValidatorIndex[];
@@ -736,16 +734,19 @@ export function createValidatorMonitor(
         return;
       }
 
+      if (validators.size === 0) {
+        return;
+      }
+
       const rootCache = new RootHexCache(headState);
 
       if (config.getForkSeq(headState.slot) >= ForkSeq.altair) {
-        const {previousEpochParticipation} = headState as CachedBeaconStateAltair;
         const prevEpochStartSlot = computeStartSlotAtEpoch(prevEpoch);
-        const prevEpochTargetRoot = toRootHex(getBlockRootAtSlot(headState, prevEpochStartSlot));
+        const prevEpochTargetRoot = toRootHex(headState.getBlockRootAtSlot(prevEpochStartSlot));
 
         // Check attestation performance
         for (const [index, validator] of validators.entries()) {
-          const flags = parseParticipationFlags(previousEpochParticipation.get(index));
+          const flags = parseParticipationFlags(headState.getPreviousEpochParticipation(index));
           const attestationSummary = validator.attestations.get(prevEpoch)?.get(prevEpochTargetRoot);
           const summary = renderAttestationSummary(config, rootCache, attestationSummary, flags);
           validatorMonitorMetrics?.prevEpochAttestationSummary.inc({summary});
@@ -757,9 +758,9 @@ export function createValidatorMonitor(
         }
       }
 
-      if (headState.epochCtx.proposersPrevEpoch !== null) {
+      if (headState.previousProposers !== null) {
         // proposersPrevEpoch is null on the first epoch of `headState` being generated
-        for (const [slotIndex, validatorIndex] of headState.epochCtx.proposersPrevEpoch.entries()) {
+        for (const [slotIndex, validatorIndex] of headState.previousProposers.entries()) {
           const validator = validators.get(validatorIndex);
           if (validator) {
             // If expected proposer is a tracked validator
@@ -1139,12 +1140,12 @@ function renderBlockProposalSummary(
 export class RootHexCache {
   private readonly blockRootSlotCache = new Map<Slot, RootHex>();
 
-  constructor(private readonly state: CachedBeaconStateAllForks) {}
+  constructor(private readonly state: IBeaconStateView) {}
 
   getBlockRootAtSlot(slot: Slot): RootHex {
     let root = this.blockRootSlotCache.get(slot);
     if (!root) {
-      root = toRootHex(getBlockRootAtSlot(this.state, slot));
+      root = toRootHex(this.state.getBlockRootAtSlot(slot));
       this.blockRootSlotCache.set(slot, root);
     }
     return root;

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -161,7 +161,7 @@ export class Network implements INetwork {
     const events = new NetworkEventBus();
     const aggregatorTracker = new AggregatorTracker();
 
-    const activeValidatorCount = chain.getHeadState().epochCtx.currentShuffling.activeIndices.length;
+    const activeValidatorCount = chain.getHeadState().activeValidatorCount;
     const initialStatus = chain.getStatus();
     const initialCustodyGroupCount = chain.custodyConfig.targetCustodyGroupCount;
 

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -6,7 +6,7 @@ import {BeaconApiMethods} from "@lodestar/api/beacon/server";
 import {BeaconConfig} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
 import {ZERO_HASH_HEX} from "@lodestar/params";
-import {CachedBeaconStateAllForks, PubkeyCache, isExecutionCachedStateType} from "@lodestar/state-transition";
+import {IBeaconStateView, PubkeyCache} from "@lodestar/state-transition";
 import {phase0} from "@lodestar/types";
 import {sleep, toRootHex} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
@@ -53,7 +53,7 @@ export type BeaconNodeInitModules = {
   privateKey: PrivateKey;
   dataDir: string;
   peerStoreDir?: string;
-  anchorState: CachedBeaconStateAllForks;
+  anchorState: IBeaconStateView;
   isAnchorStateFinalized: boolean;
   wsCheckpoint?: phase0.Checkpoint;
   metricsRegistries?: Registry[];
@@ -221,9 +221,7 @@ export class BeaconNode {
 
     let executionEngineOpts = opts.executionEngine;
     if (opts.executionEngine.mode === "mock") {
-      const eth1BlockHash = isExecutionCachedStateType(anchorState)
-        ? toRootHex(anchorState.latestExecutionPayloadHeader.blockHash)
-        : undefined;
+      const eth1BlockHash = anchorState.isExecutionStateType ? toRootHex(anchorState.latestBlockHash) : undefined;
       executionEngineOpts = {
         ...opts.executionEngine,
         genesisBlockHash: ZERO_HASH_HEX,

--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -1,13 +1,7 @@
 import {BeaconConfig} from "@lodestar/config";
 import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {
-  CachedBeaconStateAllForks,
-  computeEpochAtSlot,
-  computeStartSlotAtEpoch,
-  isExecutionCachedStateType,
-  isMergeTransitionComplete,
-} from "@lodestar/state-transition";
+import {IBeaconStateView, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch} from "@lodestar/types";
 import {ErrorAborted, Logger, prettyBytes, prettyBytesShort, sleep} from "@lodestar/utils";
 import {IBeaconChain} from "../chain/index.js";
@@ -161,7 +155,7 @@ function timeToNextHalfSlot(config: BeaconConfig, chain: IBeaconChain, isFirstTi
 function getHeadExecutionInfo(
   config: BeaconConfig,
   clockEpoch: Epoch,
-  headState: CachedBeaconStateAllForks,
+  headState: IBeaconStateView,
   headInfo: ProtoBlock
 ): string[] {
   if (clockEpoch < config.BELLATRIX_FORK_EPOCH) {
@@ -171,8 +165,8 @@ function getHeadExecutionInfo(
   const executionStatusStr = headInfo.executionStatus.toLowerCase();
 
   // Add execution status to notifier only if head is on/post bellatrix
-  if (isExecutionCachedStateType(headState)) {
-    if (isMergeTransitionComplete(headState)) {
+  if (headState.isExecutionStateType) {
+    if (headState.isMergeTransitionComplete) {
       const executionPayloadHashInfo =
         headInfo.executionStatus !== ExecutionStatus.PreMerge ? headInfo.executionPayloadBlockHash : "empty";
       const executionPayloadNumberInfo =

--- a/packages/beacon-node/src/sync/backfill/backfill.ts
+++ b/packages/beacon-node/src/sync/backfill/backfill.ts
@@ -2,7 +2,7 @@ import {EventEmitter} from "node:events";
 import {StrictEventEmitter} from "strict-event-emitter-types";
 import {BeaconConfig, ChainForkConfig} from "@lodestar/config";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {BeaconStateAllForks, blockToHeader, computeAnchorCheckpoint} from "@lodestar/state-transition";
+import {IBeaconStateView, blockToHeader} from "@lodestar/state-transition";
 import {Root, SignedBeaconBlock, Slot, phase0, ssz} from "@lodestar/types";
 import {ErrorAborted, Logger, byteArrayEquals, sleep, toRootHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../chain/index.js";
@@ -29,7 +29,7 @@ export type BackfillSyncModules = {
   config: BeaconConfig;
   logger: Logger;
   metrics: Metrics | null;
-  anchorState: BeaconStateAllForks;
+  anchorState: IBeaconStateView;
   wsCheckpoint?: phase0.Checkpoint;
   signal: AbortSignal;
 };
@@ -231,7 +231,7 @@ export class BackfillSync extends (EventEmitter as {new (): BackfillSyncEmitter}
   ): Promise<T> {
     const {config, anchorState, db, wsCheckpoint, logger} = modules;
 
-    const {checkpoint: anchorCp} = computeAnchorCheckpoint(config, anchorState);
+    const {checkpoint: anchorCp} = anchorState.computeAnchorCheckpoint();
     const anchorSlot = anchorState.latestBlockHeader.slot;
     const syncAnchor = {
       anchorBlock: null,

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -3,7 +3,6 @@ import {HttpHeader, getClient, routes} from "@lodestar/api";
 import {ChainConfig, createBeaconConfig} from "@lodestar/config";
 import {LogLevel, TestLoggerOpts, testLogger} from "@lodestar/logger/test-utils";
 import {ForkName} from "@lodestar/params";
-import {BeaconStateView} from "@lodestar/state-transition";
 import {phase0, ssz} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {Validator} from "@lodestar/validator";

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -3,8 +3,8 @@ import {HttpHeader, getClient, routes} from "@lodestar/api";
 import {ChainConfig, createBeaconConfig} from "@lodestar/config";
 import {LogLevel, TestLoggerOpts, testLogger} from "@lodestar/logger/test-utils";
 import {ForkName} from "@lodestar/params";
-import {CachedBeaconStateAltair} from "@lodestar/state-transition";
-import {phase0} from "@lodestar/types";
+import {BeaconStateView} from "@lodestar/state-transition";
+import {phase0, ssz} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {Validator} from "@lodestar/validator";
 import {BeaconNode} from "../../../../../src/node/nodejs.js";
@@ -131,8 +131,8 @@ describe.skipIf(process.env.CI)("lightclient api", () => {
     // Get the actual sync committee root from the head state
     // The sync committee is computed using a weighted random shuffle, not simple alternation
     // Since the test starts at Electra, headState is always post-Altair and has currentSyncCommittee
-    const headState = bn.chain.getHeadState() as CachedBeaconStateAltair;
-    const expectedRoot = headState.currentSyncCommittee.hashTreeRoot();
+    const headState = bn.chain.getHeadState() as BeaconStateView;
+    const expectedRoot = ssz.altair.SyncCommittee.hashTreeRoot(headState.currentSyncCommittee);
 
     // single committee hash since we requested for the first period
     expect(committeeRes.value()).toEqual([expectedRoot]);

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -131,7 +131,7 @@ describe.skipIf(process.env.CI)("lightclient api", () => {
     // Get the actual sync committee root from the head state
     // The sync committee is computed using a weighted random shuffle, not simple alternation
     // Since the test starts at Electra, headState is always post-Altair and has currentSyncCommittee
-    const headState = bn.chain.getHeadState() as BeaconStateView;
+    const headState = bn.chain.getHeadState();
     const expectedRoot = ssz.altair.SyncCommittee.hashTreeRoot(headState.currentSyncCommittee);
 
     // single committee hash since we requested for the first period

--- a/packages/beacon-node/test/perf/api/impl/validator/attester.test.ts
+++ b/packages/beacon-node/test/perf/api/impl/validator/attester.test.ts
@@ -1,4 +1,5 @@
 import {beforeAll, bench, describe} from "@chainsafe/benchmark";
+import {BeaconStateView} from "@lodestar/state-transition";
 import {generatePerfTestCachedStatePhase0, numValidators} from "@lodestar/state-transition/test-utils";
 import {getPubkeysForIndices} from "../../../../../src/api/impl/validator/utils.js";
 import {linspace} from "../../../../../src/util/numpy.js";
@@ -47,7 +48,7 @@ describe("api / impl / validator", () => {
       noThreshold: reqCount < 1000,
       fn: () => {
         const indexes = linspace(0, reqCount - 1);
-        getPubkeysForIndices(state.validators, indexes);
+        getPubkeysForIndices(new BeaconStateView(state), indexes);
       },
     });
   }

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -4,6 +4,7 @@ import {createBeaconConfig, defaultChainConfig} from "@lodestar/config";
 import {ExecutionStatus, ForkChoice, IForkChoiceStore, PayloadStatus, ProtoArray} from "@lodestar/fork-choice";
 import {HISTORICAL_ROOTS_LIMIT, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
+  BeaconStateView,
   CachedBeaconStateAltair,
   DataAvailabilityStatus,
   computeAnchorCheckpoint,
@@ -183,16 +184,20 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
         state.previousEpochParticipation = ssz.altair.EpochParticipation.toViewDU(previousParticipation);
         state.currentEpochParticipation = ssz.altair.EpochParticipation.toViewDU(currentParticipation);
         state.commit();
-        return state;
+        return new BeaconStateView(state);
       },
       beforeEach: (state) => {
-        const pool = getAggregatedAttestationPool(state, numMissedVotes, numBadVotes);
+        const pool = getAggregatedAttestationPool(
+          state.cachedState as CachedBeaconStateAltair,
+          numMissedVotes,
+          numBadVotes
+        );
         const shufflingCache = new ShufflingCache();
         shufflingCache.processState(state);
         return {state, pool, shufflingCache};
       },
       fn: ({state, pool, shufflingCache}) => {
-        pool.getAttestationsForBlock(state.config.getForkName(state.slot), forkchoice, shufflingCache, state);
+        pool.getAttestationsForBlock(originalState.config.getForkName(state.slot), forkchoice, shufflingCache, state);
       },
     });
   }

--- a/packages/beacon-node/test/perf/chain/opPools/opPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/opPool.test.ts
@@ -8,7 +8,7 @@ import {
   MAX_PROPOSER_SLASHINGS,
   MAX_VOLUNTARY_EXITS,
 } from "@lodestar/params";
-import {CachedBeaconStateAltair, PubkeyCache} from "@lodestar/state-transition";
+import {BeaconStateView, CachedBeaconStateAltair, PubkeyCache} from "@lodestar/state-transition";
 import {generatePerfTestCachedStateAltair} from "@lodestar/state-transition/test-utils";
 import {ssz} from "@lodestar/types";
 import {BlockType} from "../../../../src/chain/interface.js";
@@ -21,12 +21,12 @@ import {
 } from "../../../fixtures/phase0.js";
 
 describe("opPool", () => {
-  let originalState: CachedBeaconStateAltair;
+  let originalState: BeaconStateView;
   const config = createBeaconConfig(chainConfigDef, Buffer.alloc(32, 0xaa));
 
   beforeAll(
     () => {
-      originalState = generatePerfTestCachedStateAltair({goBackOneSlot: true});
+      originalState = new BeaconStateView(generatePerfTestCachedStateAltair({goBackOneSlot: true}));
     },
     2 * 60 * 1000 // Generating the states for the first time is very slow
   );
@@ -35,11 +35,12 @@ describe("opPool", () => {
     id: "getSlashingsAndExits - default max",
     beforeEach: () => {
       const pool = new OpPool(config);
-      fillAttesterSlashing(pool, originalState, MAX_ATTESTER_SLASHINGS);
-      fillProposerSlashing(pool, originalState, MAX_PROPOSER_SLASHINGS);
-      fillVoluntaryExits(pool, originalState, MAX_VOLUNTARY_EXITS);
+      const beaconState = originalState.cachedState as CachedBeaconStateAltair;
+      fillAttesterSlashing(pool, beaconState, MAX_ATTESTER_SLASHINGS);
+      fillProposerSlashing(pool, beaconState, MAX_PROPOSER_SLASHINGS);
+      fillVoluntaryExits(pool, beaconState, MAX_VOLUNTARY_EXITS);
       // TODO: feed pubkeyCache separately instead of getting from originalState
-      fillBlsToExecutionChanges(originalState.epochCtx.pubkeyCache, pool, originalState, MAX_BLS_TO_EXECUTION_CHANGES);
+      fillBlsToExecutionChanges(beaconState.epochCtx.pubkeyCache, pool, beaconState, MAX_BLS_TO_EXECUTION_CHANGES);
 
       return pool;
     },
@@ -53,12 +54,12 @@ describe("opPool", () => {
     beforeEach: () => {
       const pool = new OpPool(config);
       const maxItemsInPool = 2_000;
-
-      fillAttesterSlashing(pool, originalState, maxItemsInPool);
-      fillProposerSlashing(pool, originalState, maxItemsInPool);
-      fillVoluntaryExits(pool, originalState, maxItemsInPool);
+      const beaconState = originalState.cachedState as CachedBeaconStateAltair;
+      fillAttesterSlashing(pool, beaconState, maxItemsInPool);
+      fillProposerSlashing(pool, beaconState, maxItemsInPool);
+      fillVoluntaryExits(pool, beaconState, maxItemsInPool);
       // TODO: feed pubkeyCache separately instead of getting from originalState
-      fillBlsToExecutionChanges(originalState.epochCtx.pubkeyCache, pool, originalState, maxItemsInPool);
+      fillBlsToExecutionChanges(beaconState.epochCtx.pubkeyCache, pool, beaconState, maxItemsInPool);
 
       return pool;
     },

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -3,7 +3,7 @@ import {afterAll, beforeAll, bench, describe} from "@chainsafe/benchmark";
 import {config} from "@lodestar/config/default";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {testLogger} from "@lodestar/logger/test-utils";
-import {CachedBeaconStateAltair} from "@lodestar/state-transition";
+import {BeaconStateView, CachedBeaconStateAltair} from "@lodestar/state-transition";
 import {generatePerfTestCachedStateAltair} from "@lodestar/state-transition/test-utils";
 import {defaultOptions as defaultValidatorOptions} from "@lodestar/validator";
 import {BeaconChain} from "../../../../src/chain/index.js";
@@ -46,7 +46,7 @@ describe("produceBlockBody", () => {
         processShutdownCallback: () => {},
         metrics: null,
         validatorMonitor: null,
-        anchorState: state,
+        anchorState: new BeaconStateView(state),
         isAnchorStateFinalized: true,
         executionEngine: new ExecutionEngineDisabled(),
       }
@@ -69,7 +69,7 @@ describe("produceBlockBody", () => {
       const proposerIndex = state.epochCtx.getBeaconProposer(state.slot);
       const proposerPubKey = state.epochCtx.pubkeyCache.getOrThrow(proposerIndex).toBytes();
 
-      return {chain, state, head, proposerIndex, proposerPubKey};
+      return {chain, state: new BeaconStateView(state), head, proposerIndex, proposerPubKey};
     },
     fn: async ({chain, state, head, proposerIndex, proposerPubKey}) => {
       const slot = state.slot;

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -4,6 +4,7 @@ import {config} from "@lodestar/config/default";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {BeaconStateView} from "@lodestar/state-transition";
 import {getNetworkCachedBlock, getNetworkCachedState, rangeSyncTest} from "@lodestar/state-transition/test-utils";
 import {sleep, toHex} from "@lodestar/utils";
 import {defaultOptions as defaultValidatorOptions} from "@lodestar/validator";
@@ -98,7 +99,7 @@ describe.skip("verify+import blocks - range sync perf test", () => {
           processShutdownCallback: () => {},
           metrics: null,
           validatorMonitor: null,
-          anchorState: state,
+          anchorState: new BeaconStateView(state),
           isAnchorStateFinalized: true,
           executionEngine: new ExecutionEngineDisabled(),
         }

--- a/packages/beacon-node/test/sim/electra-interop.test.ts
+++ b/packages/beacon-node/test/sim/electra-interop.test.ts
@@ -5,7 +5,7 @@ import {ChainConfig} from "@lodestar/config";
 import {TimestampFormatCode} from "@lodestar/logger";
 import {TestLoggerOpts, testLogger} from "@lodestar/logger/test-utils";
 import {ForkName, SLOTS_PER_EPOCH, UNSET_DEPOSIT_REQUESTS_START_INDEX} from "@lodestar/params";
-import {CachedBeaconStateElectra} from "@lodestar/state-transition";
+import {BeaconStateView, CachedBeaconStateElectra} from "@lodestar/state-transition";
 import {Epoch, Slot, electra} from "@lodestar/types";
 import {LogLevel, sleep} from "@lodestar/utils";
 import {ValidatorProposerConfig} from "@lodestar/validator";
@@ -359,9 +359,9 @@ describe("executionEngine / ExecutionEngineHttp", () => {
 
     await waitForSlot(bn, 5);
     // Expect new validator to be in unfinalized cache, in state.validators and not in finalized cache
-    let headState = bn.chain.getHeadState();
-    let epochCtx = headState.epochCtx;
-    if (headState.validators.length !== 33 || headState.balances.length !== 33) {
+    let headState = bn.chain.getHeadState() as BeaconStateView;
+    let epochCtx = headState.cachedState.epochCtx;
+    if (headState.validatorCount !== 33 || headState.getAllBalances().length !== 33) {
       throw Error("New validator is not reflected in the beacon state at slot 5");
     }
     if (epochCtx.pubkeyCache.size !== 33) {
@@ -385,17 +385,20 @@ describe("executionEngine / ExecutionEngineHttp", () => {
     await sleep(500);
 
     // Check if new validator is in finalized cache
-    headState = bn.chain.getHeadState() as CachedBeaconStateElectra;
-    epochCtx = headState.epochCtx;
+    headState = bn.chain.getHeadState() as BeaconStateView;
+    epochCtx = headState.cachedState.epochCtx;
 
-    if (headState.validators.length !== 33 || headState.balances.length !== 33) {
+    if (headState.validatorCount !== 33 || headState.getAllBalances().length !== 33) {
       throw Error("New validator is not reflected in the beacon state.");
     }
     if (epochCtx.pubkeyCache.size !== 33) {
       throw Error("New validator is not in pubkey cache");
     }
 
-    if (headState.depositRequestsStartIndex === UNSET_DEPOSIT_REQUESTS_START_INDEX) {
+    if (
+      (headState.cachedState as CachedBeaconStateElectra).depositRequestsStartIndex ===
+      UNSET_DEPOSIT_REQUESTS_START_INDEX
+    ) {
       throw Error("state.depositRequestsStartIndex is not set upon processing new deposit receipt");
     }
 

--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -18,6 +18,7 @@ import {
 import {InputType} from "@lodestar/spec-test-util";
 import {
   BeaconStateAllForks,
+  BeaconStateView,
   createCachedBeaconState,
   createPubkeyCache,
   isExecutionStateType,
@@ -139,7 +140,7 @@ const forkChoiceTest =
             clock,
             metrics: null,
             validatorMonitor: null,
-            anchorState: cachedState,
+            anchorState: new BeaconStateView(cachedState),
             isAnchorStateFinalized: true,
             executionEngine,
             executionBuilder: undefined,
@@ -167,10 +168,10 @@ const forkChoiceTest =
               logger.debug(`Step ${i}/${stepsLen} attestation`, {root: step.attestation, valid: Boolean(step.valid)});
               const attestation = testcase.attestations.get(step.attestation);
               if (!attestation) throw Error(`No attestation ${step.attestation}`);
-              const headState = chain.getHeadState();
+              const headState = chain.getHeadState() as BeaconStateView;
               const attDataRootHex = toHexString(sszTypesFor(fork).AttestationData.hashTreeRoot(attestation.data));
               chain.forkChoice.onAttestation(
-                headState.epochCtx.getIndexedAttestation(ForkSeq[fork], attestation),
+                headState.cachedState.epochCtx.getIndexedAttestation(ForkSeq[fork], attestation),
                 attDataRootHex
               );
             }

--- a/packages/beacon-node/test/spec/utils/gossipValidation.ts
+++ b/packages/beacon-node/test/spec/utils/gossipValidation.ts
@@ -10,6 +10,7 @@ import {testLogger} from "@lodestar/logger/test-utils";
 import {ForkName} from "@lodestar/params";
 import {
   BeaconStateAllForks,
+  BeaconStateView,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   createCachedBeaconState,
@@ -333,7 +334,7 @@ export async function runGossipValidationTest(
       clock,
       metrics: null,
       validatorMonitor: null,
-      anchorState: cachedState,
+      anchorState: new BeaconStateView(cachedState),
       isAnchorStateFinalized: true,
       executionEngine,
       executionBuilder: undefined,

--- a/packages/beacon-node/test/unit-minimal/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/unit-minimal/chain/opPools/aggregatedAttestationPool.test.ts
@@ -11,7 +11,12 @@ import {
   MAX_EFFECTIVE_BALANCE,
   SLOTS_PER_EPOCH,
 } from "@lodestar/params";
-import {CachedBeaconStateAllForks, CachedBeaconStateElectra, newFilledArray} from "@lodestar/state-transition";
+import {
+  BeaconStateView,
+  CachedBeaconStateAllForks,
+  CachedBeaconStateElectra,
+  newFilledArray,
+} from "@lodestar/state-transition";
 import {Attestation, electra, phase0, ssz} from "@lodestar/types";
 import {
   AggregatedAttestationPool,
@@ -250,8 +255,9 @@ describe("AggregatedAttestationPool - get packed attestations - Electra", () => 
       forkchoiceStub.getDependentRoot.mockReturnValue(ZERO_HASH_HEX);
 
       const shufflingCache = new ShufflingCache();
-      shufflingCache.processState(electraState);
-      const blockAttestations = pool.getAttestationsForBlock(fork, forkchoiceStub, shufflingCache, electraState);
+      const stateView = new BeaconStateView(electraState);
+      shufflingCache.processState(stateView);
+      const blockAttestations = pool.getAttestationsForBlock(fork, forkchoiceStub, shufflingCache, stateView);
       // make sure test data is correct
       expect(packedCommitteeBits.length).toBe(packedAggregationBitsLen.length);
       expect(blockAttestations.length).toBe(packedCommitteeBits.length);

--- a/packages/beacon-node/test/unit-minimal/chain/stateCache/persistentCheckpointsCache.test.ts
+++ b/packages/beacon-node/test/unit-minimal/chain/stateCache/persistentCheckpointsCache.test.ts
@@ -3,7 +3,12 @@ import {createBeaconConfig} from "@lodestar/config";
 import {chainConfig as chainConfigDef} from "@lodestar/config/default";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {ACTIVE_PRESET, PresetName, SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
-import {CachedBeaconStateAllForks, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {
+  BeaconStateView,
+  IBeaconStateView,
+  computeEpochAtSlot,
+  computeStartSlotAtEpoch,
+} from "@lodestar/state-transition";
 import {RootHex, phase0} from "@lodestar/types";
 import {mapValues, toHexString} from "@lodestar/utils";
 import {FIFOBlockStateCache} from "../../../../src/chain/index.js";
@@ -33,7 +38,7 @@ describe("PersistentCheckpointStateCache", () => {
   const startSlotEpoch22 = computeStartSlotAtEpoch(22);
   let cache: PersistentCheckpointStateCache;
   let fileApisBuffer: Map<string, Uint8Array>;
-  let states: Record<"cp0a" | "cp0b" | "cp1" | "cp2", CachedBeaconStateAllForks>;
+  let states: Record<"cp0a" | "cp0b" | "cp1" | "cp2", BeaconStateView>;
   let stateBytes: Record<"cp0a" | "cp0b" | "cp1" | "cp2", Uint8Array>;
   const config = createBeaconConfig(chainConfigDef, Buffer.alloc(32, 0xaa));
 
@@ -66,7 +71,7 @@ describe("PersistentCheckpointStateCache", () => {
           // cp0a
           state.blockRoots.set((startSlotEpoch20 - 1) % SLOTS_PER_HISTORICAL_ROOT, root0a);
           state.blockRoots.set(startSlotEpoch20 % SLOTS_PER_HISTORICAL_ROOT, root0a);
-          return state;
+          return new BeaconStateView(state);
         }
 
         // other states based on cp0b
@@ -79,7 +84,7 @@ describe("PersistentCheckpointStateCache", () => {
         if (stateEpoch >= 22) {
           state.blockRoots.set(startSlotEpoch22 % SLOTS_PER_HISTORICAL_ROOT, root2);
         }
-        return state;
+        return new BeaconStateView(state);
       });
 
     states = {
@@ -153,7 +158,7 @@ describe("PersistentCheckpointStateCache", () => {
 
   it("pruneFinalized and getStateOrBytes", async () => {
     cache.add(cp2, states["cp2"], true);
-    expect(((await cache.getStateOrBytes(cp0bHex)) as CachedBeaconStateAllForks).hashTreeRoot()).toEqual(
+    expect(((await cache.getStateOrBytes(cp0bHex)) as IBeaconStateView).hashTreeRoot()).toEqual(
       states["cp0b"].hashTreeRoot()
     );
     expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
@@ -219,24 +224,24 @@ describe("PersistentCheckpointStateCache", () => {
       expect(await cache.processState(toHexString(cp2.root), states["cp2"])).toEqual(1);
 
       const cp1a = {epoch: 21, root: root0a};
-      const cp1aState = states["cp0a"].clone();
+      const cp1aState = states["cp0a"].cachedState.clone();
       cp1aState.slot = 21 * SLOTS_PER_EPOCH;
       cp1aState.blockRoots.set(startSlotEpoch21 % SLOTS_PER_HISTORICAL_ROOT, root0a);
       cp1aState.commit();
-      cache.add(cp1a, cp1aState, true);
+      cache.add(cp1a, new BeaconStateView(cp1aState), true);
 
       const cp2a = {epoch: 22, root: root0a};
       const cp2aState = cp1aState.clone();
       cp2aState.slot = 22 * SLOTS_PER_EPOCH;
       cp2aState.blockRoots.set(startSlotEpoch22 % SLOTS_PER_HISTORICAL_ROOT, root0a);
       cp2aState.commit();
-      cache.add(cp2a, cp2aState, true);
+      cache.add(cp2a, new BeaconStateView(cp2aState), true);
 
       const root3 = Buffer.alloc(32, 100);
       const state3 = cp2aState.clone();
       state3.slot = 22 * SLOTS_PER_EPOCH + 3;
       state3.commit();
-      await cache.processState(toHexString(root3), state3);
+      await cache.processState(toHexString(root3), new BeaconStateView(state3));
 
       // state of {0a, 21} is choosen because it was built from cp0a
       expect(cache.findSeedStateToReload(cp0aHex)?.hashTreeRoot()).toEqual(cp1aState.hashTreeRoot());
@@ -283,11 +288,11 @@ describe("PersistentCheckpointStateCache", () => {
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
-      const blockStateRoot3 = states["cp2"].clone();
+      const blockStateRoot3 = states["cp2"].cachedState.clone();
       blockStateRoot3.slot = 22 * SLOTS_PER_EPOCH + 3;
       const root3 = Buffer.alloc(32, 100);
       // process state of root3
-      await cache.processState(toHexString(root3), blockStateRoot3);
+      await cache.processState(toHexString(root3), new BeaconStateView(blockStateRoot3));
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       // epoch 22 has 1 checkpoint state
@@ -318,18 +323,18 @@ describe("PersistentCheckpointStateCache", () => {
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
-      const blockStateRoot3 = states["cp2"].clone();
+      const blockStateRoot3 = states["cp2"].cachedState.clone();
       blockStateRoot3.slot = 22 * SLOTS_PER_EPOCH + 3;
       const root3 = Buffer.alloc(32, 100);
       // process state of root3
-      await cache.processState(toHexString(root3), blockStateRoot3);
+      await cache.processState(toHexString(root3), new BeaconStateView(blockStateRoot3));
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
-      const blockStateRoot4 = states["cp2"].clone();
+      const blockStateRoot4 = states["cp2"].cachedState.clone();
       blockStateRoot4.slot = 22 * SLOTS_PER_EPOCH + 4;
       const root4 = Buffer.alloc(32, 101);
       // process state of root4
-      await cache.processState(toHexString(root4), blockStateRoot4);
+      await cache.processState(toHexString(root4), new BeaconStateView(blockStateRoot4));
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
       // epoch 22 has 1 checkpoint state
@@ -363,12 +368,12 @@ describe("PersistentCheckpointStateCache", () => {
       // regen generates cp2a
       const root1a = Buffer.alloc(32, 100);
       const cp2a = {epoch: 22, root: root1a};
-      const cp2aState = states["cp1"].clone();
+      const cp2aState = states["cp1"].cachedState.clone();
       cp2aState.slot = 22 * SLOTS_PER_EPOCH;
       // assuming reorg block is at slot 5 of epoch 21
       cp2aState.blockRoots.set((startSlotEpoch21 + 5) % SLOTS_PER_HISTORICAL_ROOT, root1a);
       cp2aState.blockRoots.set(startSlotEpoch22 % SLOTS_PER_HISTORICAL_ROOT, root1a);
-      cache.add(cp2a, cp2aState, true);
+      cache.add(cp2a, new BeaconStateView(cp2aState), true);
 
       // block state of root3 in epoch 22 is built on cp2a
       const blockStateRoot3 = cp2aState.clone();
@@ -376,7 +381,7 @@ describe("PersistentCheckpointStateCache", () => {
 
       const root3 = Buffer.alloc(32, 101);
       // process state of root3
-      await cache.processState(toHexString(root3), blockStateRoot3);
+      await cache.processState(toHexString(root3), new BeaconStateView(blockStateRoot3));
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // epoch 22 has 2 checkpoint states
       expect(cache.get(cp2Hex)).not.toBeNull();
@@ -412,18 +417,18 @@ describe("PersistentCheckpointStateCache", () => {
       // regen generates cp1a
       const root0a = Buffer.alloc(32, 100);
       const cp1a = {epoch: 21, root: root0a};
-      const cp1aState = states["cp0b"].clone();
+      const cp1aState = states["cp0b"].cachedState.clone();
       cp1aState.slot = 21 * SLOTS_PER_EPOCH;
       // assuming reorg block is at slot 5 of epoch 20
       cp1aState.blockRoots.set((startSlotEpoch20 + 5) % SLOTS_PER_HISTORICAL_ROOT, root0a);
-      cache.add(cp1a, cp1aState, true);
+      cache.add(cp1a, new BeaconStateView(cp1aState), true);
 
       // regen generates cp2a
       const cp2a = {epoch: 22, root: root0a};
       const cp2aState = cp1aState.clone();
       cp2aState.slot = 22 * SLOTS_PER_EPOCH;
       cp2aState.blockRoots.set(startSlotEpoch22 % SLOTS_PER_HISTORICAL_ROOT, root0a);
-      cache.add(cp2a, cp2aState, true);
+      cache.add(cp2a, new BeaconStateView(cp2aState), true);
 
       // block state of root3 in epoch 22 is built on cp2a
       const blockStateRoot3 = cp2aState.clone();
@@ -431,7 +436,7 @@ describe("PersistentCheckpointStateCache", () => {
 
       const root3 = Buffer.alloc(32, 101);
       // process state of root3
-      await cache.processState(toHexString(root3), blockStateRoot3);
+      await cache.processState(toHexString(root3), new BeaconStateView(blockStateRoot3));
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       // epoch 21 and 22 have 2 checkpoint states
       expect(cache.get(cp1Hex)).not.toBeNull();
@@ -469,14 +474,14 @@ describe("PersistentCheckpointStateCache", () => {
       const cp1aState = generateCachedState({slot: 21 * SLOTS_PER_EPOCH});
       cp1aState.blockRoots.set((startSlotEpoch20 - 1) % SLOTS_PER_HISTORICAL_ROOT, root0a);
       cp1aState.blockRoots.set(startSlotEpoch20 % SLOTS_PER_HISTORICAL_ROOT, root0a);
-      cache.add(cp1a, cp1aState, true);
+      cache.add(cp1a, new BeaconStateView(cp1aState), true);
 
       // regen generates cp2a
       const cp2a = {epoch: 22, root: root0a};
       const cp2aState = cp1aState.clone();
       cp2aState.slot = 22 * SLOTS_PER_EPOCH;
       cp2aState.blockRoots.set(startSlotEpoch21 % SLOTS_PER_HISTORICAL_ROOT, root0a);
-      cache.add(cp2a, cp2aState, true);
+      cache.add(cp2a, new BeaconStateView(cp2aState), true);
 
       // block state of root3 in epoch 22 is built on cp2a
       const blockStateRoot3 = cp2aState.clone();
@@ -487,7 +492,7 @@ describe("PersistentCheckpointStateCache", () => {
 
       const root3 = Buffer.alloc(32, 100);
       // process state of root3
-      expect(await cache.processState(toHexString(root3), blockStateRoot3)).toEqual(1);
+      expect(await cache.processState(toHexString(root3), new BeaconStateView(blockStateRoot3))).toEqual(1);
       await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
       // epoch 21 and 22 have 2 checkpoint states
       expect(cache.get(cp1Hex)).not.toBeNull();
@@ -519,30 +524,30 @@ describe("PersistentCheckpointStateCache", () => {
 
       // regen needs to reload cp0b
       cache.add(cp0b, states["cp0b"], true);
-      expect(((await cache.getStateOrBytes(cp0bHex)) as CachedBeaconStateAllForks).hashTreeRoot()).toEqual(
+      expect(((await cache.getStateOrBytes(cp0bHex)) as IBeaconStateView).hashTreeRoot()).toEqual(
         states["cp0b"].hashTreeRoot()
       );
 
       // regen generates cp1b
       const cp1b = {epoch: 21, root: root0b};
-      const cp1bState = states["cp0b"].clone();
+      const cp1bState = states["cp0b"].cachedState.clone();
       cp1bState.slot = 21 * SLOTS_PER_EPOCH;
       cp1bState.blockRoots.set(startSlotEpoch21 % SLOTS_PER_HISTORICAL_ROOT, root0b);
-      cache.add(cp1b, cp1bState, true);
+      cache.add(cp1b, new BeaconStateView(cp1bState), true);
 
       // regen generates cp2b
       const cp2b = {epoch: 22, root: root0b};
       const cp2bState = cp1bState.clone();
       cp2bState.slot = 22 * SLOTS_PER_EPOCH;
       cp2bState.blockRoots.set(startSlotEpoch22 % SLOTS_PER_HISTORICAL_ROOT, root0b);
-      cache.add(cp2b, cp2bState, true);
+      cache.add(cp2b, new BeaconStateView(cp2bState), true);
 
       // block state of root3 in epoch 22 is built on cp2a
       const blockStateRoot3 = cp2bState.clone();
       blockStateRoot3.slot = 22 * SLOTS_PER_EPOCH + 3;
       const root3 = Buffer.alloc(32, 100);
       // process state of root3, nothing is persisted
-      expect(await cache.processState(toHexString(root3), blockStateRoot3)).toEqual(0);
+      expect(await cache.processState(toHexString(root3), new BeaconStateView(blockStateRoot3))).toEqual(0);
       // but state of cp0b is pruned from memory
       expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
@@ -590,11 +595,11 @@ describe("PersistentCheckpointStateCache", () => {
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
-      const blockStateRoot2 = states["cp1"].clone();
+      const blockStateRoot2 = states["cp1"].cachedState.clone();
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2
-      await cache.processState(toHexString(root2), blockStateRoot2);
+      await cache.processState(toHexString(root2), new BeaconStateView(blockStateRoot2));
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
 
@@ -625,18 +630,18 @@ describe("PersistentCheckpointStateCache", () => {
       expect(fileApisBuffer.size).toEqual(1);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
-      const blockStateRoot2 = states["cp1"].clone();
+      const blockStateRoot2 = states["cp1"].cachedState.clone();
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2
-      await cache.processState(toHexString(root2), blockStateRoot2);
+      await cache.processState(toHexString(root2), new BeaconStateView(blockStateRoot2));
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
 
-      const blockStateRoot3 = states["cp1"].clone();
+      const blockStateRoot3 = states["cp1"].cachedState.clone();
       blockStateRoot3.slot = 21 * SLOTS_PER_EPOCH + 4;
       const root3 = Buffer.alloc(32, 101);
       // process state of root3
-      await cache.processState(toHexString(root3), blockStateRoot3);
+      await cache.processState(toHexString(root3), new BeaconStateView(blockStateRoot3));
 
       // epoch 21 has 1 checkpoint state
       expect(cache.get(cp1Hex)).not.toBeNull();
@@ -661,7 +666,7 @@ describe("PersistentCheckpointStateCache", () => {
       // root 1a
       expect(fileApisBuffer.size).toEqual(0);
       const root1a = Buffer.alloc(32, 100);
-      const state1a = states["cp0b"].clone();
+      const state1a = states["cp0b"].cachedState.clone();
       state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - 1;
       state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
       expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(0);
@@ -680,12 +685,12 @@ describe("PersistentCheckpointStateCache", () => {
       const cp1aState = state1a.clone();
       cp1aState.slot = 21 * SLOTS_PER_EPOCH;
       const cp1a = {epoch: 21, root: root1a};
-      cache.add(cp1a, cp1aState, true);
+      cache.add(cp1a, new BeaconStateView(cp1aState), true);
       const blockStateRoot2 = cp1aState.clone();
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2
-      expect(await cache.processState(toHexString(root2), blockStateRoot2)).toEqual(0);
+      expect(await cache.processState(toHexString(root2), new BeaconStateView(blockStateRoot2))).toEqual(0);
       await assertPersistedCheckpointState([cp0b], [stateBytes["cp0b"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       // keep these 2 cp states at epoch 21
@@ -712,19 +717,19 @@ describe("PersistentCheckpointStateCache", () => {
 
       // simulate regen
       cache.add(cp0b, states["cp0b"], true);
-      expect(((await cache.getStateOrBytes(cp0bHex)) as CachedBeaconStateAllForks).hashTreeRoot()).toEqual(
+      expect(((await cache.getStateOrBytes(cp0bHex)) as IBeaconStateView).hashTreeRoot()).toEqual(
         states["cp0b"].hashTreeRoot()
       );
       // root2, regen cp0b
-      const cp1bState = states["cp0b"].clone();
+      const cp1bState = states["cp0b"].cachedState.clone();
       cp1bState.slot = 21 * SLOTS_PER_EPOCH;
       const cp1b = {epoch: 21, root: root0b};
-      cache.add(cp1b, cp1bState, true);
+      cache.add(cp1b, new BeaconStateView(cp1bState), true);
       const blockStateRoot2 = cp1bState.clone();
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2, nothing is persisted
-      expect(await cache.processState(toHexString(root2), blockStateRoot2)).toEqual(0);
+      expect(await cache.processState(toHexString(root2), new BeaconStateView(blockStateRoot2))).toEqual(0);
 
       // but cp0b in-memory state is pruned
       expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
@@ -746,7 +751,7 @@ describe("PersistentCheckpointStateCache", () => {
       // root 1a
       expect(fileApisBuffer.size).toEqual(0);
       const root1a = Buffer.alloc(32, 100);
-      const state1a = states["cp0a"].clone();
+      const state1a = states["cp0a"].cachedState.clone();
       state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH - 1;
       state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
       expect(await cache.processState(toHexString(cp1.root), states["cp1"])).toEqual(0);
@@ -775,12 +780,12 @@ describe("PersistentCheckpointStateCache", () => {
       const cp1aState = state1a.clone();
       cp1aState.slot = 21 * SLOTS_PER_EPOCH;
       const cp1a = {epoch: 21, root: root1a};
-      cache.add(cp1a, cp1aState, true);
+      cache.add(cp1a, new BeaconStateView(cp1aState), true);
       const blockStateRoot2 = cp1aState.clone();
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2, persist cp0a
-      expect(await cache.processState(toHexString(root2), blockStateRoot2)).toEqual(1);
+      expect(await cache.processState(toHexString(root2), new BeaconStateView(blockStateRoot2))).toEqual(1);
       await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       // keep these 2 cp states at epoch 21
@@ -814,15 +819,15 @@ describe("PersistentCheckpointStateCache", () => {
 
       // root2, regen cp0a
       cache.add(cp0a, states["cp0a"], true);
-      const cp1aState = states["cp0a"].clone();
+      const cp1aState = states["cp0a"].cachedState.clone();
       cp1aState.slot = 21 * SLOTS_PER_EPOCH;
       const cp1a = {epoch: 21, root: root0a};
-      cache.add(cp1a, cp1aState, true);
+      cache.add(cp1a, new BeaconStateView(cp1aState), true);
       const blockStateRoot2 = cp1aState.clone();
       blockStateRoot2.slot = 21 * SLOTS_PER_EPOCH + 3;
       const root2 = Buffer.alloc(32, 100);
       // process state of root2, persist cp0a
-      expect(await cache.processState(toHexString(root2), blockStateRoot2)).toEqual(1);
+      expect(await cache.processState(toHexString(root2), new BeaconStateView(blockStateRoot2))).toEqual(1);
       await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
       expect(cache.get(cp1Hex)?.hashTreeRoot()).toEqual(states["cp1"].hashTreeRoot());
       // keep these 2 cp states at epoch 21
@@ -861,10 +866,10 @@ describe("PersistentCheckpointStateCache", () => {
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
 
         const root1a = Buffer.alloc(32, 100);
-        const state1a = states["cp0b"].clone();
+        const state1a = states["cp0b"].cachedState.clone();
         state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH + 3;
         state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-        expect(await cache.processState(toHexString(root1a), state1a)).toEqual(0);
+        expect(await cache.processState(toHexString(root1a), new BeaconStateView(state1a))).toEqual(0);
 
         // nothing change
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -885,10 +890,10 @@ describe("PersistentCheckpointStateCache", () => {
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
 
         const root1a = Buffer.alloc(32, 100);
-        const state1a = states["cp0b"].clone();
+        const state1a = states["cp0b"].cachedState.clone();
         state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH + 3;
         state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-        expect(await cache.processState(toHexString(root1a), state1a)).toEqual(0);
+        expect(await cache.processState(toHexString(root1a), new BeaconStateView(state1a))).toEqual(0);
 
         // nothing change
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -896,15 +901,15 @@ describe("PersistentCheckpointStateCache", () => {
 
         // simulate reload cp1b
         cache.add(cp0b, states["cp0b"], true);
-        expect(((await cache.getStateOrBytes(cp0bHex)) as CachedBeaconStateAllForks).hashTreeRoot()).toEqual(
+        expect(((await cache.getStateOrBytes(cp0bHex)) as IBeaconStateView).hashTreeRoot()).toEqual(
           states["cp0b"].hashTreeRoot()
         );
         const root1b = Buffer.alloc(32, 101);
-        const state1b = states["cp0b"].clone();
+        const state1b = states["cp0b"].cachedState.clone();
         state1b.slot = state1a.slot + 1;
         state1b.blockRoots.set(state1b.slot % SLOTS_PER_HISTORICAL_ROOT, root1b);
         // but no need to persist cp1b
-        expect(await cache.processState(toHexString(root1b), state1b)).toEqual(0);
+        expect(await cache.processState(toHexString(root1b), new BeaconStateView(state1b))).toEqual(0);
         // although states["cp0b"] is pruned
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
@@ -936,7 +941,7 @@ describe("PersistentCheckpointStateCache", () => {
         );
 
         const root1a = Buffer.alloc(32, 100);
-        const state1a = states["cp0b"].clone();
+        const state1a = states["cp0b"].cachedState.clone();
         state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH + 3;
         state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
         // state transition add to cache
@@ -945,14 +950,14 @@ describe("PersistentCheckpointStateCache", () => {
 
         // no need to reload cp0b because it's available in block state
         const root1b = Buffer.alloc(32, 101);
-        const state1b = states["cp0a"].clone();
+        const state1b = states["cp0a"].cachedState.clone();
         state1b.slot = state1a.slot + 1;
         state1b.blockRoots.set(state1b.slot % SLOTS_PER_HISTORICAL_ROOT, root1b);
         // state transition add to cache
         cache.add(cp0a, states["cp0a"], true);
 
         // need to persist 2 checkpoint states
-        expect(await cache.processState(toHexString(root1b), state1b)).toEqual(2);
+        expect(await cache.processState(toHexString(root1b), new BeaconStateView(state1b))).toEqual(2);
         // both are persisited
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
         expect(await cache.getStateOrBytes(cp0aHex)).toEqual(stateBytes["cp0a"]);
@@ -973,22 +978,22 @@ describe("PersistentCheckpointStateCache", () => {
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
 
         const root1a = Buffer.alloc(32, 100);
-        const state1a = states["cp0b"].clone();
+        const state1a = states["cp0b"].cachedState.clone();
         state1a.slot = 20 * SLOTS_PER_EPOCH + SLOTS_PER_EPOCH + 3;
         state1a.blockRoots.set(state1a.slot % SLOTS_PER_HISTORICAL_ROOT, root1a);
-        expect(await cache.processState(toHexString(root1a), state1a)).toEqual(0);
+        expect(await cache.processState(toHexString(root1a), new BeaconStateView(state1a))).toEqual(0);
 
         // nothing change
         expect(await cache.getStateOrBytes(cp0aHex)).toBeNull();
         expect(await cache.getStateOrBytes(cp0bHex)).toEqual(stateBytes["cp0b"]);
 
         const root1b = Buffer.alloc(32, 101);
-        const state1b = states["cp0a"].clone();
+        const state1b = states["cp0a"].cachedState.clone();
         state1b.slot = state1a.slot + 1;
         state1b.blockRoots.set(state1b.slot % SLOTS_PER_HISTORICAL_ROOT, root1b);
         // regen should reload cp0a from disk
         cache.add(cp0a, states["cp0a"], true);
-        expect(await cache.processState(toHexString(root1b), state1b)).toEqual(1);
+        expect(await cache.processState(toHexString(root1b), new BeaconStateView(state1b))).toEqual(1);
         await assertPersistedCheckpointState([cp0b, cp0a], [stateBytes["cp0b"], stateBytes["cp0a"]]);
 
         // both cp0a and cp0b are persisted
@@ -1018,17 +1023,17 @@ describe("PersistentCheckpointStateCache", () => {
         // regen should populate cp0a and cp1a checkpoint states
         cache.add(cp0a, states["cp0a"], true);
         const cp1a = {epoch: 21, root: root0a};
-        const cp1aState = states["cp0a"].clone();
+        const cp1aState = states["cp0a"].cachedState.clone();
         cp1aState.blockRoots.set((20 * SLOTS_PER_EPOCH) % SLOTS_PER_HISTORICAL_ROOT, root0a);
         cp1aState.blockRoots.set((21 * SLOTS_PER_EPOCH) % SLOTS_PER_HISTORICAL_ROOT, root0a);
         cp1aState.slot = 21 * SLOTS_PER_EPOCH;
-        cache.add(cp1a, cp1aState, true);
+        cache.add(cp1a, new BeaconStateView(cp1aState), true);
 
         const root2 = Buffer.alloc(32, 100);
         const state2 = cp1aState.clone();
         state2.slot = 21 * SLOTS_PER_EPOCH + 3;
         state2.blockRoots.set(state2.slot % SLOTS_PER_HISTORICAL_ROOT, root2);
-        expect(await cache.processState(toHexString(root2), state2)).toEqual(2);
+        expect(await cache.processState(toHexString(root2), new BeaconStateView(state2))).toEqual(2);
         // expect 4 cp states are persisted
         await assertPersistedCheckpointState(
           [cp0b, cp1, cp0a, cp1a],

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -1,12 +1,13 @@
 import {describe, expect, it} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
+import {BeaconStateView} from "@lodestar/state-transition";
 import {getStateValidatorIndex} from "../../../../../../src/api/impl/beacon/state/utils.js";
 import {generateCachedAltairState} from "../../../../../utils/state.js";
 
 describe("beacon state api utils", () => {
   describe("getStateValidatorIndex", () => {
-    const state = generateCachedAltairState();
-    const pubkeyCache = state.epochCtx.pubkeyCache;
+    const state = new BeaconStateView(generateCachedAltairState());
+    const pubkeyCache = state.cachedState.epochCtx.pubkeyCache;
 
     it("should return valid: false on invalid input", () => {
       // "invalid validator id number"
@@ -17,7 +18,7 @@ describe("beacon state api utils", () => {
 
     it("should return valid: false on validator indices / pubkeys not in the state", () => {
       // "validator id not in state"
-      expect(getStateValidatorIndex(String(state.validators.length), state, pubkeyCache).valid).toBe(false);
+      expect(getStateValidatorIndex(String(state.validatorCount), state, pubkeyCache).valid).toBe(false);
       // "validator pubkey not in state"
       expect(
         getStateValidatorIndex(
@@ -29,7 +30,7 @@ describe("beacon state api utils", () => {
     });
 
     it("should return valid: true on validator indices / pubkeys in the state", () => {
-      const index = state.validators.length - 1;
+      const index = state.validatorCount - 1;
       const resp1 = getStateValidatorIndex(String(index), state, pubkeyCache);
       if (resp1.valid) {
         expect(resp1.validatorIndex).toBe(index);
@@ -42,7 +43,7 @@ describe("beacon state api utils", () => {
       } else {
         expect.fail("validator index should be found - validator index as number input");
       }
-      const pubkey = state.validators.get(index).pubkey;
+      const pubkey = state.getValidator(index).pubkey;
       const resp3 = getStateValidatorIndex(pubkey, state, pubkeyCache);
       if (resp3.valid) {
         expect(resp3.validatorIndex).toBe(index);

--- a/packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/duties/proposer.test.ts
@@ -2,7 +2,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {routes} from "@lodestar/api";
 import {config} from "@lodestar/config/default";
 import {MAX_EFFECTIVE_BALANCE, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {BeaconStateAllForks} from "@lodestar/state-transition";
+import {BeaconStateAllForks, BeaconStateView} from "@lodestar/state-transition";
 import {Slot} from "@lodestar/types";
 import {SYNC_TOLERANCE_EPOCHS, getValidatorApi} from "../../../../../../src/api/impl/validator/index.js";
 import {defaultApiOptions} from "../../../../../../src/api/options.js";
@@ -30,7 +30,7 @@ describe("get proposers api impl", () => {
 
     initializeState(currentSlot);
 
-    modules.chain.getHeadStateAtCurrentEpoch.mockResolvedValue(cachedState);
+    modules.chain.getHeadStateAtCurrentEpoch.mockResolvedValue(new BeaconStateView(cachedState));
     modules.forkChoice.getHead.mockReturnValue(zeroProtoBlock);
     modules.forkChoice.getFinalizedBlock.mockReturnValue(zeroProtoBlock);
     modules.db.block.get.mockResolvedValue({message: {stateRoot: Buffer.alloc(32)}} as any);
@@ -107,8 +107,12 @@ describe("get proposers api impl", () => {
 
   it("should get proposers for historical epoch", async () => {
     const historicalEpoch = currentEpoch - 2;
-    initializeState(currentSlot - 2 * SLOTS_PER_EPOCH);
-    modules.chain.getStateBySlot.mockResolvedValue({state: cachedState, executionOptimistic: false, finalized: true});
+    initializeState(currentSlot - 2 * SLOTS_PER_EPOCH + 1);
+    modules.chain.getStateBySlot.mockResolvedValue({
+      state: new BeaconStateView(cachedState),
+      executionOptimistic: false,
+      finalized: true,
+    });
 
     const {data: result} = (await api.getProposerDuties({epoch: historicalEpoch})) as {
       data: routes.validator.ProposerDutyList;

--- a/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/produceBlockV3.test.ts
@@ -3,7 +3,7 @@ import {routes} from "@lodestar/api";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName, SLOTS_PER_EPOCH, ZERO_HASH_HEX} from "@lodestar/params";
-import {CachedBeaconStateBellatrix, G2_POINT_AT_INFINITY, computeTimeAtSlot} from "@lodestar/state-transition";
+import {BeaconStateView, G2_POINT_AT_INFINITY, computeTimeAtSlot} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {getValidatorApi} from "../../../../../src/api/impl/validator/index.js";
@@ -21,7 +21,7 @@ import {generateProtoBlock} from "../../../../utils/typeGenerator.js";
 describe("api/validator - produceBlockV3", () => {
   let modules: ApiTestModules;
   let api: ReturnType<typeof getValidatorApi>;
-  let state: CachedBeaconStateBellatrix;
+  let state: BeaconStateView;
 
   const chainConfig = createChainForkConfig({
     ...defaultChainConfig,
@@ -34,7 +34,7 @@ describe("api/validator - produceBlockV3", () => {
   beforeEach(() => {
     modules = getApiTestModules({config});
     api = getValidatorApi(defaultApiOptions, {...modules, config});
-    state = generateCachedBellatrixState();
+    state = new BeaconStateView(generateCachedBellatrixState());
 
     modules.chain.executionBuilder.status = BuilderStatus.enabled;
   });

--- a/packages/beacon-node/test/unit/api/impl/validator/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/validator/utils.test.ts
@@ -1,6 +1,12 @@
 import {beforeAll, describe, expect, it} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
-import {BeaconStateAllForks} from "@lodestar/state-transition";
+import {createBeaconConfig, defaultChainConfig} from "@lodestar/config";
+import {
+  BeaconStateAllForks,
+  BeaconStateView,
+  createCachedBeaconState,
+  createPubkeyCache,
+} from "@lodestar/state-transition";
 import {BLSPubkey, ValidatorIndex, ssz} from "@lodestar/types";
 import {getPubkeysForIndices} from "../../../../../src/api/impl/validator/utils.js";
 
@@ -20,10 +26,19 @@ describe("api / impl / validator / utils", () => {
       pubkeys.push(pubkey);
       validators.push(ssz.phase0.Validator.toViewDU({...validator, pubkey}));
     }
+    state.commit();
   });
 
   it("getPubkeysForIndices", () => {
-    const pubkeysRes = getPubkeysForIndices(state.validators, indexes);
+    const cachedState = createCachedBeaconState(
+      state,
+      {
+        config: createBeaconConfig(defaultChainConfig, state.genesisValidatorsRoot),
+        pubkeyCache: createPubkeyCache(),
+      },
+      {skipSyncPubkeys: true}
+    );
+    const pubkeysRes = getPubkeysForIndices(new BeaconStateView(cachedState), indexes);
     expect(pubkeysRes.map(toHexString)).toEqual(pubkeys.map(toHexString));
   });
 });

--- a/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -4,7 +4,7 @@ import {config} from "@lodestar/config/default";
 import {CheckpointWithHex, ExecutionStatus, ForkChoice, PayloadStatus} from "@lodestar/fork-choice";
 import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE} from "@lodestar/params";
 import {
-  CachedBeaconStateAllForks,
+  BeaconStateView,
   DataAvailabilityStatus,
   computeAnchorCheckpoint,
   computeEpochAtSlot,
@@ -42,6 +42,7 @@ describe("LodestarForkChoice", () => {
     ),
     config
   );
+  const anchorStateView = new BeaconStateView(anchorState);
 
   // 3 validators involved
   const justifiedBalances = getEffectiveBalanceIncrementsZeroed(3);
@@ -54,10 +55,10 @@ describe("LodestarForkChoice", () => {
 
   const hashBlock = (block: phase0.BeaconBlock): string => toHexString(ssz.phase0.BeaconBlock.hashTreeRoot(block));
 
-  let state: CachedBeaconStateAllForks;
+  let state: BeaconStateView;
 
   beforeAll(() => {
-    state = createCachedBeaconStateTest(anchorState, config);
+    state = new BeaconStateView(createCachedBeaconStateTest(anchorState, config));
   });
 
   beforeEach(() => {
@@ -87,7 +88,7 @@ describe("LodestarForkChoice", () => {
       const targetBlock = generateSignedBlockAtSlot(32);
       targetBlock.message.parentRoot = finalizedRoot;
       //
-      const targetState = runStateTransition(anchorState, targetBlock);
+      const targetState = runStateTransition(anchorStateView, targetBlock);
       targetBlock.message.stateRoot = targetState.hashTreeRoot();
       const {block: orphanedBlock, state: orphanedState} = makeChild({block: targetBlock, state: targetState}, 36);
       const {block: parentBlock, state: parentState} = makeChild({block: targetBlock, state: targetState}, 37);
@@ -162,32 +163,32 @@ describe("LodestarForkChoice", () => {
       const finalizedRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(blockHeader);
       const block08 = generateSignedBlockAtSlot(8);
       block08.message.parentRoot = finalizedRoot;
-      const state08 = runStateTransition(anchorState, block08);
+      const state08 = runStateTransition(anchorStateView, block08);
       block08.message.stateRoot = state08.hashTreeRoot();
 
       const {block: block12, state: state12} = makeChild({block: block08, state: state08}, 12);
       const {block: block16, state: state16} = makeChild({block: block12, state: state12}, 16);
-      state16.currentJustifiedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
+      state16.cachedState.currentJustifiedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
         root: ssz.phase0.BeaconBlock.hashTreeRoot(block08.message),
         epoch: 1,
       });
       const {block: block20, state: state20} = makeChild({block: block16, state: state16}, 20);
       const {block: block24, state: state24} = makeChild({block: block20, state: state20}, 24);
-      state24.finalizedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
+      state24.cachedState.finalizedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
         root: ssz.phase0.BeaconBlock.hashTreeRoot(block08.message),
         epoch: 1,
       });
-      state24.currentJustifiedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
+      state24.cachedState.currentJustifiedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
         root: ssz.phase0.BeaconBlock.hashTreeRoot(block16.message),
         epoch: 2,
       });
       const {block: block28, state: state28} = makeChild({block: block24, state: state24}, 28);
       const {block: block32, state: state32} = makeChild({block: block28, state: state28}, 32);
-      state32.finalizedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
+      state32.cachedState.finalizedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
         root: ssz.phase0.BeaconBlock.hashTreeRoot(block16.message),
         epoch: 2,
       });
-      state32.currentJustifiedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
+      state32.cachedState.currentJustifiedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
         root: ssz.phase0.BeaconBlock.hashTreeRoot(block24.message),
         epoch: 3,
       });
@@ -229,7 +230,7 @@ describe("LodestarForkChoice", () => {
       const finalizedRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(blockHeader);
       const targetBlock = generateSignedBlockAtSlot(32);
       targetBlock.message.parentRoot = finalizedRoot;
-      const targetState = runStateTransition(anchorState, targetBlock);
+      const targetState = runStateTransition(anchorStateView, targetBlock);
       targetBlock.message.stateRoot = targetState.hashTreeRoot();
       const {block: orphanedBlock, state: orphanedState} = makeChild({block: targetBlock, state: targetState}, 33);
       const {block: parentBlock, state: parentState} = makeChild({block: targetBlock, state: targetState}, 34);
@@ -305,7 +306,7 @@ describe("LodestarForkChoice", () => {
       // C10
       const blockW = generateSignedBlockAtSlot(8);
       blockW.message.parentRoot = finalizedRoot;
-      const stateW = runStateTransition(anchorState, blockW);
+      const stateW = runStateTransition(anchorStateView, blockW);
       blockW.message.stateRoot = stateW.hashTreeRoot();
       forkChoice.onBlock(
         blockW.message,
@@ -318,7 +319,7 @@ describe("LodestarForkChoice", () => {
 
       // X
       const {block: blockX, state: stateX} = makeChild({block: blockW, state: stateW}, 12);
-      stateX.blockRoots.set(blockW.message.slot, ssz.phase0.BeaconBlock.hashTreeRoot(blockW.message));
+      stateX.cachedState.blockRoots.set(blockW.message.slot, ssz.phase0.BeaconBlock.hashTreeRoot(blockW.message));
       forkChoice.onBlock(
         blockX.message,
         stateX,
@@ -330,7 +331,7 @@ describe("LodestarForkChoice", () => {
 
       // Y, same epoch to X
       const {block: blockY, state: stateY} = makeChild({block: blockX, state: stateX}, 13);
-      stateY.blockRoots.set(blockW.message.slot, ssz.phase0.BeaconBlock.hashTreeRoot(blockW.message));
+      stateY.cachedState.blockRoots.set(blockW.message.slot, ssz.phase0.BeaconBlock.hashTreeRoot(blockW.message));
       forkChoice.onBlock(
         blockY.message,
         stateY,
@@ -367,7 +368,7 @@ describe("LodestarForkChoice", () => {
       // Z stays on next epoch, a child of X which potentially reorg Y
       const {block: blockZ, state: stateZ} = makeChild({block: blockX, state: stateX}, 16);
       // without unrealized checkpoints, Y would be filtered due to different justified checkpoint
-      stateZ.currentJustifiedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
+      stateZ.cachedState.currentJustifiedCheckpoint = ssz.phase0.Checkpoint.toViewDU({
         root: ssz.phase0.BeaconBlock.hashTreeRoot(blockW.message),
         epoch: computeEpochAtSlot(blockW.message.slot),
       });
@@ -391,26 +392,21 @@ describe("LodestarForkChoice", () => {
 });
 
 // lightweight state transtion function for this test
-function runStateTransition(
-  preState: CachedBeaconStateAllForks,
-  signedBlock: phase0.SignedBeaconBlock
-): CachedBeaconStateAllForks {
-  // Clone state because process slots and block are not pure
-  const postState = preState.clone();
+function runStateTransition(preState: BeaconStateView, signedBlock: phase0.SignedBeaconBlock): BeaconStateView {
   // Process slots (including those with no blocks) since block
-  processSlots(postState, signedBlock.message.slot);
+  const postState = processSlots(preState.cachedState, signedBlock.message.slot);
   // processBlock
   postState.latestBlockHeader = ssz.phase0.BeaconBlockHeader.toViewDU(
     getTemporaryBlockHeader(config, signedBlock.message)
   );
-  return postState;
+  return new BeaconStateView(postState);
 }
 
 // create a child block/state from a parent block/state and a provided slot
 function makeChild(
-  parent: {block: phase0.SignedBeaconBlock; state: CachedBeaconStateAllForks},
+  parent: {block: phase0.SignedBeaconBlock; state: BeaconStateView},
   slot: Slot
-): {block: phase0.SignedBeaconBlock; state: CachedBeaconStateAllForks} {
+): {block: phase0.SignedBeaconBlock; state: BeaconStateView} {
   const childBlock = generateSignedBlockAtSlot(slot);
   const parentRoot = ssz.phase0.BeaconBlock.hashTreeRoot(parent.block.message);
   childBlock.message.parentRoot = parentRoot;

--- a/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
+++ b/packages/beacon-node/test/unit/chain/prepareNextSlot.test.ts
@@ -3,6 +3,7 @@ import {routes} from "@lodestar/api";
 import {config} from "@lodestar/config/default";
 import {ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {BeaconStateView} from "@lodestar/state-transition";
 import {IChainOptions} from "../../../src/chain/options.js";
 import {PrepareNextSlotScheduler} from "../../../src/chain/prepareNextSlot.js";
 import {PayloadIdCache} from "../../../src/execution/engine/payloadIdCache.js";
@@ -105,7 +106,7 @@ describe("PrepareNextSlot scheduler", () => {
   it("bellatrix - should skip, no block proposer", async () => {
     getForkStub.mockReturnValue(ForkName.bellatrix);
     chainStub.recomputeForkChoiceHead.mockReturnValue({slot: SLOTS_PER_EPOCH - 3} as ProtoBlock);
-    const state = generateCachedBellatrixState();
+    const state = new BeaconStateView(generateCachedBellatrixState());
     regenStub.getBlockSlotState.mockResolvedValue(state);
     await Promise.all([
       scheduler.prepareForNextSlot(SLOTS_PER_EPOCH - 1),
@@ -126,7 +127,7 @@ describe("PrepareNextSlot scheduler", () => {
     updateBuilderStatus.mockReturnValue(void 0);
     const state = generateCachedBellatrixState();
     vi.spyOn(state.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
-    regenStub.getBlockSlotState.mockResolvedValue(state);
+    regenStub.getBlockSlotState.mockResolvedValue(new BeaconStateView(state));
     beaconProposerCacheStub.get.mockReturnValue("0x fee recipient address");
     (executionEngineStub as unknown as {payloadIdCache: PayloadIdCache}).payloadIdCache = new PayloadIdCache();
 

--- a/packages/beacon-node/test/unit/chain/regen/regen.test.ts
+++ b/packages/beacon-node/test/unit/chain/regen/regen.test.ts
@@ -3,7 +3,7 @@ import {createBeaconConfig} from "@lodestar/config";
 import {chainConfig as chainConfigDef} from "@lodestar/config/default";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
-import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {BeaconStateView, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {RegenCaller} from "../../../../src/chain/regen/interface.js";
 import {processSlotsToNearestCheckpoint} from "../../../../src/chain/regen/regen.js";
 import {FIFOBlockStateCache} from "../../../../src/chain/stateCache/fifoBlockStateCache.js";
@@ -45,7 +45,7 @@ describe("regen", () => {
           // cp0a
           state.blockRoots.set((startSlotEpoch20 - 1) % SLOTS_PER_HISTORICAL_ROOT, root0a);
           state.blockRoots.set(startSlotEpoch20 % SLOTS_PER_HISTORICAL_ROOT, root0a);
-          return state;
+          return new BeaconStateView(state);
         }
 
         // other states based on cp0b
@@ -58,7 +58,7 @@ describe("regen", () => {
         // if (stateEpoch >= 22) {
         //   state.blockRoots.set(startSlotEpoch22 % SLOTS_PER_HISTORICAL_ROOT, root2);
         // }
-        return state;
+        return new BeaconStateView(state);
       });
 
     const states = {
@@ -98,7 +98,14 @@ describe("regen", () => {
       // no state is persisted at the  beginning
       expect(fileApisBuffer.size).toEqual(0);
 
-      const modules = {checkpointStateCache: cache, metrics: null, validatorMonitor: null, emitter: null, logger: null};
+      const modules = {
+        config,
+        checkpointStateCache: cache,
+        metrics: null,
+        validatorMonitor: null,
+        emitter: null,
+        logger: null,
+      };
       const preState = states["cp1"];
       await processSlotsToNearestCheckpoint(modules, preState, startSlotEpoch22, RegenCaller.processBlocksInEpoch, {
         dontTransferCache: true,
@@ -118,7 +125,14 @@ describe("regen", () => {
       // no state is persisted at the  beginning
       expect(fileApisBuffer.size).toEqual(0);
 
-      const modules = {checkpointStateCache: cache, metrics: null, validatorMonitor: null, emitter: null, logger: null};
+      const modules = {
+        config,
+        checkpointStateCache: cache,
+        metrics: null,
+        validatorMonitor: null,
+        emitter: null,
+        logger: null,
+      };
       const preState = states["cp0b"];
       await processSlotsToNearestCheckpoint(modules, preState, startSlotEpoch22, RegenCaller.processBlocksInEpoch, {
         dontTransferCache: true,

--- a/packages/beacon-node/test/unit/chain/stateCache/fifoBlockStateCache.test.ts
+++ b/packages/beacon-node/test/unit/chain/stateCache/fifoBlockStateCache.test.ts
@@ -1,7 +1,7 @@
 import {beforeEach, describe, expect, it} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
-import {CachedBeaconStateAllForks, EpochShuffling} from "@lodestar/state-transition";
+import {BeaconStateView, EpochShuffling} from "@lodestar/state-transition";
 import {FIFOBlockStateCache} from "../../../../src/chain/stateCache/index.js";
 import {generateCachedState} from "../../../utils/state.js";
 
@@ -15,17 +15,17 @@ describe("FIFOBlockStateCache", () => {
     committeesPerSlot: 1,
   };
 
-  const state1 = generateCachedState({slot: 0});
+  const state1 = new BeaconStateView(generateCachedState({slot: 0}));
   const key1 = toHexString(state1.hashTreeRoot());
-  state1.epochCtx.currentShuffling = {...shuffling, epoch: 0};
+  state1.cachedState.epochCtx.currentShuffling = {...shuffling, epoch: 0};
 
-  const state2 = generateCachedState({slot: 1 * SLOTS_PER_EPOCH});
+  const state2 = new BeaconStateView(generateCachedState({slot: 1 * SLOTS_PER_EPOCH}));
   const key2 = toHexString(state2.hashTreeRoot());
-  state2.epochCtx.currentShuffling = {...shuffling, epoch: 1};
+  state2.cachedState.epochCtx.currentShuffling = {...shuffling, epoch: 1};
 
-  const state3 = generateCachedState({slot: 2 * SLOTS_PER_EPOCH});
+  const state3 = new BeaconStateView(generateCachedState({slot: 2 * SLOTS_PER_EPOCH}));
   const key3 = toHexString(state3.hashTreeRoot());
-  state3.epochCtx.currentShuffling = {...shuffling, epoch: 2};
+  state3.cachedState.epochCtx.currentShuffling = {...shuffling, epoch: 2};
 
   beforeEach(() => {
     // max 2 items
@@ -36,7 +36,7 @@ describe("FIFOBlockStateCache", () => {
 
   const testCases: {
     name: string;
-    headState: CachedBeaconStateAllForks;
+    headState: BeaconStateView;
     addAsHeadArr: boolean[];
     keptStates: string[];
     prunedState: string;

--- a/packages/beacon-node/test/unit/chain/validation/attesterSlashing.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attesterSlashing.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, beforeEach, describe, it, vi} from "vitest";
 import {createBeaconConfig} from "@lodestar/config";
 import {chainConfig as chainConfigDef} from "@lodestar/config/default";
+import {BeaconStateView} from "@lodestar/state-transition";
 import {phase0, ssz} from "@lodestar/types";
 import {AttesterSlashingErrorCode} from "../../../../src/chain/errors/attesterSlashingError.js";
 import {validateGossipAttesterSlashing} from "../../../../src/chain/validation/attesterSlashing.js";
@@ -17,7 +18,7 @@ describe("GossipMessageValidator", () => {
     chainStub = getMockedBeaconChain({config});
     opPool = chainStub.opPool;
 
-    const state = generateCachedState();
+    const state = new BeaconStateView(generateCachedState());
     vi.spyOn(chainStub, "getHeadState").mockReturnValue(state);
     vi.spyOn(opPool, "hasSeenAttesterSlashing");
   });

--- a/packages/beacon-node/test/unit/chain/validation/block.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/block.test.ts
@@ -3,6 +3,7 @@ import {createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {config as configDef} from "@lodestar/config/default";
 import {PayloadStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {ForkName, ForkPostDeneb, ForkPreFulu} from "@lodestar/params";
+import {BeaconStateView} from "@lodestar/state-transition";
 import {SignedBeaconBlock, ssz} from "@lodestar/types";
 import {BlockErrorCode} from "../../../../src/chain/errors/index.js";
 import {QueuedStateRegenerator} from "../../../../src/chain/regen/index.js";
@@ -164,7 +165,7 @@ describe("gossip block validation", () => {
     // Returned parent block is latter than proposed block
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
     // Regen returns some state
-    regen.getPreState.mockResolvedValue(generateCachedState());
+    regen.getPreState.mockResolvedValue(new BeaconStateView(generateCachedState()));
     // BLS signature verifier returns invalid
     verifySignature.mockResolvedValue(false);
 
@@ -180,12 +181,12 @@ describe("gossip block validation", () => {
     // Returned parent block is latter than proposed block
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
     // Regen returns some state
-    const state = generateCachedState();
+    const state = new BeaconStateView(generateCachedState());
     regen.getPreState.mockResolvedValue(state);
     // BLS signature verifier returns valid
     verifySignature.mockResolvedValue(true);
     // Force proposer shuffling cache to return wrong value
-    vi.spyOn(state.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex + 1);
+    vi.spyOn(state.cachedState.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex + 1);
 
     await expectRejectedWithLodestarError(
       validateGossipBlock(config, chain, job, ForkName.phase0),
@@ -199,12 +200,12 @@ describe("gossip block validation", () => {
     // Returned parent block is latter than proposed block
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
     // Regen returns some state
-    const state = generateCachedState();
+    const state = new BeaconStateView(generateCachedState());
     regen.getPreState.mockResolvedValue(state);
     // BLS signature verifier returns valid
     verifySignature.mockResolvedValue(true);
     // Force proposer shuffling cache to return correct value
-    vi.spyOn(state.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
+    vi.spyOn(state.cachedState.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
 
     await validateGossipBlock(config, chain, job, ForkName.phase0);
   });
@@ -220,12 +221,12 @@ describe("gossip block validation", () => {
     // Returned parent block is latter than proposed block
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
     // Regen returns some state
-    const state = generateCachedState();
+    const state = new BeaconStateView(generateCachedState());
     regen.getPreState.mockResolvedValue(state);
     // BLS signature verifier returns valid
     verifySignature.mockResolvedValue(true);
     // Force proposer shuffling cache to return correct value
-    vi.spyOn(state.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex + 1);
+    vi.spyOn(state.cachedState.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex + 1);
     // Add one extra kzg commitment in the block so it goes over the limit
     (job as SignedBeaconBlock<ForkPostDeneb & ForkPreFulu>).message.body.blobKzgCommitments.push(new Uint8Array([0]));
 
@@ -246,12 +247,12 @@ describe("gossip block validation", () => {
     // Returned parent block is latter than proposed block
     forkChoice.getBlockHexDefaultStatus.mockReturnValueOnce({slot: clockSlot - 1} as ProtoBlock);
     // Regen returns some state
-    const state = generateCachedState();
+    const state = new BeaconStateView(generateCachedState());
     regen.getPreState.mockResolvedValue(state);
     // BLS signature verifier returns valid
     verifySignature.mockResolvedValue(true);
     // Force proposer shuffling cache to return correct value
-    vi.spyOn(state.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
+    vi.spyOn(state.cachedState.epochCtx, "getBeaconProposer").mockReturnValue(proposerIndex);
     // Keep number of kzg commitments as is so it stays within the limit
 
     await validateGossipBlock(denebConfig, chain, job, ForkName.deneb);

--- a/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/blsToExecutionChange.test.ts
@@ -11,7 +11,7 @@ import {
   ForkName,
   SLOTS_PER_EPOCH,
 } from "@lodestar/params";
-import {computeSigningRoot} from "@lodestar/state-transition";
+import {BeaconStateView, computeSigningRoot} from "@lodestar/state-transition";
 import {capella, ssz} from "@lodestar/types";
 import {BlsToExecutionChangeErrorCode} from "../../../../src/chain/errors/blsToExecutionChangeError.js";
 import {validateGossipBlsToExecutionChange} from "../../../../src/chain/validation/blsToExecutionChange.js";
@@ -69,7 +69,7 @@ describe("validate bls to execution change", () => {
   // Generate the state
   const _state = generateState(stateEmpty, defaultConfig);
   const config = createBeaconConfig(defaultConfig, _state.genesisValidatorsRoot);
-  const state = createCachedBeaconStateTest(_state, config);
+  const state = new BeaconStateView(createCachedBeaconStateTest(_state, config));
 
   // Gen a valid blsToExecutionChange for first val
   const blsToExecutionChange = {

--- a/packages/beacon-node/test/unit/chain/validation/proposerSlashing.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/proposerSlashing.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, beforeEach, describe, it, vi} from "vitest";
 import {createBeaconConfig} from "@lodestar/config";
 import {chainConfig as chainConfigDef} from "@lodestar/config/default";
+import {BeaconStateView} from "@lodestar/state-transition";
 import {phase0, ssz} from "@lodestar/types";
 import {ProposerSlashingErrorCode} from "../../../../src/chain/errors/proposerSlashingError.js";
 import {validateGossipProposerSlashing} from "../../../../src/chain/validation/proposerSlashing.js";
@@ -17,7 +18,7 @@ describe("validate proposer slashing", () => {
     chainStub = getMockedBeaconChain({config});
     opPool = chainStub.opPool;
 
-    const state = generateCachedState();
+    const state = new BeaconStateView(generateCachedState());
     vi.spyOn(chainStub, "getHeadState").mockReturnValue(state);
     vi.spyOn(opPool, "hasSeenProposerSlashing");
   });

--- a/packages/beacon-node/test/unit/chain/validation/syncCommittee.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/syncCommittee.test.ts
@@ -2,6 +2,7 @@ import {Mock, afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, 
 import {toHexString} from "@chainsafe/ssz";
 import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {BeaconStateView} from "@lodestar/state-transition";
 import {Epoch, Slot, altair} from "@lodestar/types";
 import {SyncCommitteeErrorCode} from "../../../../src/chain/errors/syncCommitteeError.js";
 import {SeenSyncCommitteeMessages} from "../../../../src/chain/seenCache/index.js";
@@ -65,7 +66,7 @@ describe("Sync Committee Signature validation", () => {
 
   it("should throw error - messageRoot is same to prevRoot", async () => {
     const syncCommittee = getSyncCommitteeSignature(currentSlot, validatorIndexInSyncCommittee);
-    const headState = generateCachedAltairState({slot: currentSlot}, altairForkEpoch);
+    const headState = new BeaconStateView(generateCachedAltairState({slot: currentSlot}, altairForkEpoch));
     chain.getHeadState.mockReturnValue(headState);
     chain.seenSyncCommitteeMessages.get = () => toHexString(syncCommittee.beaconBlockRoot);
     await expectRejectedWithLodestarError(
@@ -76,7 +77,7 @@ describe("Sync Committee Signature validation", () => {
 
   it("should throw error - messageRoot is different to prevRoot but not forkchoice head", async () => {
     const syncCommittee = getSyncCommitteeSignature(currentSlot, validatorIndexInSyncCommittee);
-    const headState = generateCachedAltairState({slot: currentSlot}, altairForkEpoch);
+    const headState = new BeaconStateView(generateCachedAltairState({slot: currentSlot}, altairForkEpoch));
     chain.getHeadState.mockReturnValue(headState);
     const prevRoot = "0x1234";
     chain.seenSyncCommitteeMessages.get = () => prevRoot;
@@ -89,7 +90,7 @@ describe("Sync Committee Signature validation", () => {
 
   it("should throw error - the validator is not part of the current sync committee", async () => {
     const syncCommittee = getSyncCommitteeSignature(currentSlot, 100);
-    const headState = generateCachedAltairState({slot: currentSlot}, altairForkEpoch);
+    const headState = new BeaconStateView(generateCachedAltairState({slot: currentSlot}, altairForkEpoch));
     chain.getHeadState.mockReturnValue(headState);
 
     await expectRejectedWithLodestarError(
@@ -104,7 +105,7 @@ describe("Sync Committee Signature validation", () => {
    */
   it.skip("should throw error - incorrect subnet", async () => {
     const syncCommittee = getSyncCommitteeSignature(currentSlot, 1);
-    const headState = generateCachedAltairState({slot: currentSlot}, altairForkEpoch);
+    const headState = new BeaconStateView(generateCachedAltairState({slot: currentSlot}, altairForkEpoch));
     chain.getHeadState.mockReturnValue(headState);
     await expectRejectedWithLodestarError(
       validateGossipSyncCommittee(chain, syncCommittee, 0),
@@ -114,7 +115,7 @@ describe("Sync Committee Signature validation", () => {
 
   it("should throw error - invalid signature", async () => {
     const syncCommittee = getSyncCommitteeSignature(currentSlot, validatorIndexInSyncCommittee);
-    const headState = generateCachedAltairState({slot: currentSlot}, altairForkEpoch);
+    const headState = new BeaconStateView(generateCachedAltairState({slot: currentSlot}, altairForkEpoch));
 
     chain.getHeadState.mockReturnValue(headState);
     chain.bls.verifySignatureSets.mockReturnValue(false);
@@ -128,7 +129,7 @@ describe("Sync Committee Signature validation", () => {
     const syncCommittee = getSyncCommitteeSignature(currentSlot, validatorIndexInSyncCommittee);
     const subnet = 3;
     const {slot, validatorIndex} = syncCommittee;
-    const headState = generateCachedAltairState({slot: currentSlot}, altairForkEpoch);
+    const headState = new BeaconStateView(generateCachedAltairState({slot: currentSlot}, altairForkEpoch));
 
     chain.getHeadState.mockReturnValue(headState);
     // "should be null"
@@ -147,7 +148,7 @@ describe("Sync Committee Signature validation", () => {
 
   it("should pass, there is prev root but message root is forkchoice head", async () => {
     const syncCommittee = getSyncCommitteeSignature(currentSlot, validatorIndexInSyncCommittee);
-    const headState = generateCachedAltairState({slot: currentSlot}, altairForkEpoch);
+    const headState = new BeaconStateView(generateCachedAltairState({slot: currentSlot}, altairForkEpoch));
 
     chain.getHeadState.mockReturnValue(headState);
 

--- a/packages/beacon-node/test/unit/chain/validation/voluntaryExit.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/voluntaryExit.test.ts
@@ -16,10 +16,12 @@ import {MockedBeaconChain, getMockedBeaconChain} from "../../../mocks/mockedBeac
 import {createCachedBeaconStateTest} from "../../../utils/cachedBeaconState.js";
 import {expectRejectedWithLodestarError} from "../../../utils/errors.js";
 import {generateState} from "../../../utils/state.js";
+import {TestBeaconStateView} from "../../../utils/stateView.js";
 
 describe("validate voluntary exit", () => {
   let chainStub: MockedBeaconChain;
-  let state: CachedBeaconStateAllForks;
+  let state: TestBeaconStateView;
+  let originalState: CachedBeaconStateAllForks;
   let signedVoluntaryExit: phase0.SignedVoluntaryExit;
   let opPool: MockedBeaconChain["opPool"];
   let config: BeaconConfig;
@@ -59,10 +61,11 @@ describe("validate voluntary exit", () => {
     const _state = generateState(stateEmpty, createChainForkConfig(chainConfig));
     config = createBeaconConfig(chainConfig, _state.genesisValidatorsRoot);
 
-    state = createCachedBeaconStateTest(_state, config);
+    originalState = createCachedBeaconStateTest(_state, config);
   });
 
   beforeEach(() => {
+    state = new TestBeaconStateView(createCachedBeaconStateTest(originalState.clone(), config));
     chainStub = getMockedBeaconChain({config});
     opPool = chainStub.opPool;
     vi.spyOn(chainStub, "getHeadStateAtCurrentEpoch").mockResolvedValue(state);
@@ -107,15 +110,14 @@ describe("validate voluntary exit", () => {
   });
 
   it("should return invalid Voluntary Exit - inactive validator", async () => {
-    const inactiveValidator = ssz.phase0.Validator.toViewDU({
-      ...state.validators.get(0).toValue(),
+    const inactiveValidator: phase0.Validator = {
+      ...state.getValidator(0),
       activationEpoch: FAR_FUTURE_EPOCH, // Make validator inactive
-    });
+    };
 
-    const stateWithInactive = state.clone();
-    stateWithInactive.validators.set(0, inactiveValidator);
+    state.setValidator(0, inactiveValidator);
 
-    vi.spyOn(chainStub, "getHeadStateAtCurrentEpoch").mockResolvedValue(stateWithInactive);
+    vi.spyOn(chainStub, "getHeadStateAtCurrentEpoch").mockResolvedValue(state);
 
     await expectRejectedWithLodestarError(
       validateGossipVoluntaryExit(chainStub, signedVoluntaryExit),
@@ -125,16 +127,15 @@ describe("validate voluntary exit", () => {
 
   it("should return invalid Voluntary Exit - already exited", async () => {
     const currentEpoch = computeEpochAtSlot(state.slot);
-    const exitedValidator = ssz.phase0.Validator.toViewDU({
-      ...state.validators.get(0).toValue(),
+    const exitedValidator: phase0.Validator = {
+      ...state.getValidator(0),
       exitEpoch: currentEpoch + 10,
       activationEpoch: 0,
-    });
+    };
 
-    const stateWithExited = state.clone();
-    stateWithExited.validators.set(0, exitedValidator);
+    state.setValidator(0, exitedValidator);
 
-    vi.spyOn(chainStub, "getHeadStateAtCurrentEpoch").mockResolvedValue(stateWithExited);
+    vi.spyOn(chainStub, "getHeadStateAtCurrentEpoch").mockResolvedValue(state);
 
     await expectRejectedWithLodestarError(
       validateGossipVoluntaryExit(chainStub, signedVoluntaryExit),
@@ -143,15 +144,14 @@ describe("validate voluntary exit", () => {
   });
 
   it("should return invalid Voluntary Exit - short time active", async () => {
-    const recentlyActivated = ssz.phase0.Validator.toViewDU({
-      ...state.validators.get(0).toValue(),
+    const recentlyActivated: phase0.Validator = {
+      ...state.getValidator(0),
       activationEpoch: computeEpochAtSlot(state.slot) - 1, // Recently activated
-    });
+    };
 
-    const stateRecent = state.clone();
-    stateRecent.validators.set(0, recentlyActivated);
+    state.setValidator(0, recentlyActivated);
 
-    vi.spyOn(chainStub, "getHeadStateAtCurrentEpoch").mockResolvedValue(stateRecent);
+    vi.spyOn(chainStub, "getHeadStateAtCurrentEpoch").mockResolvedValue(state);
 
     await expectRejectedWithLodestarError(
       validateGossipVoluntaryExit(chainStub, signedVoluntaryExit),

--- a/packages/beacon-node/test/unit/chain/validatorMonitor.test.ts
+++ b/packages/beacon-node/test/unit/chain/validatorMonitor.test.ts
@@ -1,7 +1,9 @@
 import {describe, expect, it, vi} from "vitest";
-import {createChainForkConfig, defaultChainConfig} from "@lodestar/config";
+import {createBeaconConfig, createChainForkConfig, defaultChainConfig} from "@lodestar/config";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {BeaconStateView, createCachedBeaconState, createPubkeyCache} from "@lodestar/state-transition";
+import {ssz} from "@lodestar/types";
 import {createValidatorMonitor} from "../../../src/chain/validatorMonitor.js";
 
 describe("ValidatorMonitor", () => {
@@ -20,12 +22,14 @@ describe("ValidatorMonitor", () => {
 
   // Helper to create a minimal mock head state for phase0
   function createMockHeadState(slot: number) {
-    return {
-      slot,
-      epochCtx: {
-        proposersPrevEpoch: null,
-      },
-    } as any;
+    const state = ssz.fulu.BeaconState.defaultViewDU();
+    state.slot = slot;
+    const cachedState = createCachedBeaconState(state, {
+      config: createBeaconConfig(defaultChainConfig, state.genesisValidatorsRoot),
+      pubkeyCache: createPubkeyCache(),
+    });
+    expect(cachedState.epochCtx.proposersPrevEpoch).toBeNull();
+    return new BeaconStateView(cachedState);
   }
 
   describe("registerLocalValidator", () => {

--- a/packages/beacon-node/test/utils/networkWithMockDb.ts
+++ b/packages/beacon-node/test/utils/networkWithMockDb.ts
@@ -1,7 +1,7 @@
 import {generateKeyPair} from "@libp2p/crypto/keys";
 import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {testLogger} from "@lodestar/logger/test-utils";
-import {createCachedBeaconState, createPubkeyCache, syncPubkeys} from "@lodestar/state-transition";
+import {BeaconStateView, createCachedBeaconState, createPubkeyCache, syncPubkeys} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {BeaconChain} from "../../src/chain/chain.js";
@@ -84,7 +84,7 @@ export async function getNetworkForTest(
       ),
       metrics: null,
       validatorMonitor: null,
-      anchorState: cachedState,
+      anchorState: new BeaconStateView(cachedState),
       isAnchorStateFinalized: true,
       executionEngine: new ExecutionEngineDisabled(),
     }

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -12,6 +12,7 @@ import {testLogger} from "@lodestar/logger/test-utils";
 import {ForkSeq, GENESIS_SLOT} from "@lodestar/params";
 import {
   BeaconStateAllForks,
+  BeaconStateView,
   computeAnchorCheckpoint,
   computeEpochAtSlot,
   createCachedBeaconState,
@@ -153,7 +154,7 @@ export async function getDevBeaconNode(
     privateKey,
     dataDir: ".",
     peerStoreDir,
-    anchorState: cachedState,
+    anchorState: new BeaconStateView(cachedState),
     wsCheckpoint,
     isAnchorStateFinalized: true,
   });

--- a/packages/beacon-node/test/utils/node/simTest.ts
+++ b/packages/beacon-node/test/utils/node/simTest.ts
@@ -1,8 +1,9 @@
 import {routes} from "@lodestar/api";
 import {BeaconConfig} from "@lodestar/config";
-import {SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
-  CachedBeaconStateAllForks,
+  BeaconStateView,
+  IBeaconStateView,
   beforeProcessEpoch,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
@@ -38,9 +39,13 @@ export function simTestInfoTracker(bn: BeaconNode, logger: Logger): () => void {
     }
   }
 
-  function logParticipation(state: CachedBeaconStateAllForks): void {
+  function logParticipation(view: IBeaconStateView): void {
     // Compute participation (takes 5ms with 64 validators)
     // Need a CachedBeaconStateAllForks where (state.slot + 1) % SLOTS_EPOCH == 0
+    if (!(view instanceof BeaconStateView)) {
+      return;
+    }
+    const state = (view as BeaconStateView).cachedState;
     const epochTransitionCache = beforeProcessEpoch(state);
     const epoch = computeEpochAtSlot(state.slot);
 
@@ -73,7 +78,7 @@ export function simTestInfoTracker(bn: BeaconNode, logger: Logger): () => void {
       throw Error(`Checkpoint state not found for epoch ${checkpoint.epoch} root ${toRootHex(checkpoint.root)}`);
     }
     const lastSlot = computeStartSlotAtEpoch(checkpoint.epoch) - 1;
-    const lastStateRoot = checkpointState.stateRoots.get(lastSlot % SLOTS_PER_HISTORICAL_ROOT);
+    const lastStateRoot = checkpointState.getStateRootAtSlot(lastSlot);
     const lastState = await bn.chain.regen.getState(toRootHex(lastStateRoot), RegenCaller.onForkChoiceFinalized);
     logParticipation(lastState);
   }

--- a/packages/beacon-node/test/utils/stateView.ts
+++ b/packages/beacon-node/test/utils/stateView.ts
@@ -1,0 +1,12 @@
+import {BeaconStateView} from "@lodestar/state-transition";
+import {phase0, ssz} from "@lodestar/types";
+
+export class TestBeaconStateView extends BeaconStateView {
+  setValidator(index: number, validator: phase0.Validator): void {
+    if (index >= super.validatorCount) {
+      throw new Error(`Validator index ${index} out of bounds`);
+    }
+
+    this.cachedState.validators.set(index, ssz.phase0.Validator.toViewDU(validator));
+  }
+}

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -3,6 +3,7 @@ import {ExecutionStatus, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {testLogger} from "@lodestar/logger/test-utils";
 import {DOMAIN_BEACON_ATTESTER} from "@lodestar/params";
 import {
+  BeaconStateView,
   DataAvailabilityStatus,
   computeEpochAtSlot,
   computeSigningRoot,
@@ -155,9 +156,9 @@ export function getAttestationValidData(opts: AttestationValidDataOpts): {
 
   // Add state to regen
   const regen = {
-    getState: async () => state,
+    getState: async () => new BeaconStateView(state),
     // TODO: remove this once we have a better way to get state
-    getStateSync: () => state,
+    getStateSync: () => new BeaconStateView(state),
   } as Partial<IStateRegenerator> as IStateRegenerator;
 
   const chain = {

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -7,7 +7,7 @@ import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {LoggerNode, getNodeLogger} from "@lodestar/logger/node";
 import {ACTIVE_PRESET, PresetName} from "@lodestar/params";
-import {createCachedBeaconState, createPubkeyCache, syncPubkeys} from "@lodestar/state-transition";
+import {BeaconStateView, createCachedBeaconState, createPubkeyCache, syncPubkeys} from "@lodestar/state-transition";
 import {ErrorAborted, bytesToInt, formatBytes} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
 import {BeaconNodeOptions, getBeaconConfigFromArgs} from "../../config/index.js";
@@ -100,7 +100,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       privateKey,
       dataDir: beaconPaths.dataDir,
       peerStoreDir: beaconPaths.peerStoreDir,
-      anchorState: cachedState,
+      anchorState: new BeaconStateView(cachedState),
       isAnchorStateFinalized: isFinalized,
       wsCheckpoint,
     });

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1,20 +1,16 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkSeq, SLOTS_PER_EPOCH, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {
-  CachedBeaconStateAllForks,
-  CachedBeaconStateGloas,
   DataAvailabilityStatus,
   EffectiveBalanceIncrements,
+  IBeaconStateView,
   ZERO_HASH,
   computeEpochAtSlot,
   computeSlotsSinceEpochStart,
   computeStartSlotAtEpoch,
   getAttesterSlashableIndices,
   isExecutionBlockBodyType,
-  isExecutionEnabled,
-  isExecutionStateType,
 } from "@lodestar/state-transition";
-import {computeUnrealizedCheckpoints} from "@lodestar/state-transition/epoch";
 import {
   AttesterSlashing,
   BeaconBlock,
@@ -586,7 +582,7 @@ export class ForkChoice implements IForkChoice {
    */
   onBlock(
     block: BeaconBlock,
-    state: CachedBeaconStateAllForks,
+    state: IBeaconStateView,
     blockDelaySec: number,
     currentSlot: Slot,
     executionStatus: MaybeValidExecutionStatus,
@@ -672,12 +668,16 @@ export class ForkChoice implements IForkChoice {
     }
 
     // Get justified checkpoint with payload status for Gloas
-    const justifiedPayloadStatus = getCheckpointPayloadStatus(state, state.currentJustifiedCheckpoint.epoch);
+    const justifiedPayloadStatus = getCheckpointPayloadStatus(
+      this.config,
+      state,
+      state.currentJustifiedCheckpoint.epoch
+    );
     const justifiedCheckpoint = toCheckpointWithPayload(state.currentJustifiedCheckpoint, justifiedPayloadStatus);
     const stateJustifiedEpoch = justifiedCheckpoint.epoch;
 
     // Get finalized checkpoint with payload status for Gloas
-    const finalizedPayloadStatus = getCheckpointPayloadStatus(state, state.finalizedCheckpoint.epoch);
+    const finalizedPayloadStatus = getCheckpointPayloadStatus(this.config, state, state.finalizedCheckpoint.epoch);
     const finalizedCheckpoint = toCheckpointWithPayload(state.finalizedCheckpoint, finalizedPayloadStatus);
 
     // Justified balances for `justifiedCheckpoint` are new to the fork-choice. Compute them on demand only if
@@ -710,6 +710,7 @@ export class ForkChoice implements IForkChoice {
         // reuse from parent, happens at 1/3 last blocks of epoch as monitored in mainnet
         // Get payload status for unrealized justified checkpoint
         const unrealizedJustifiedPayloadStatus = getCheckpointPayloadStatus(
+          this.config,
           state,
           parentBlock.unrealizedJustifiedEpoch
         );
@@ -721,6 +722,7 @@ export class ForkChoice implements IForkChoice {
         };
         // Get payload status for unrealized finalized checkpoint
         const unrealizedFinalizedPayloadStatus = getCheckpointPayloadStatus(
+          this.config,
           state,
           parentBlock.unrealizedFinalizedEpoch
         );
@@ -732,9 +734,10 @@ export class ForkChoice implements IForkChoice {
         };
       } else {
         // compute new, happens 2/3 first blocks of epoch as monitored in mainnet
-        const unrealized = computeUnrealizedCheckpoints(state);
+        const unrealized = state.computeUnrealizedCheckpoints();
         // Get payload status for unrealized justified checkpoint
         const unrealizedJustifiedPayloadStatus = getCheckpointPayloadStatus(
+          this.config,
           state,
           unrealized.justifiedCheckpoint.epoch
         );
@@ -744,6 +747,7 @@ export class ForkChoice implements IForkChoice {
         );
         // Get payload status for unrealized finalized checkpoint
         const unrealizedFinalizedPayloadStatus = getCheckpointPayloadStatus(
+          this.config,
           state,
           unrealized.finalizedCheckpoint.epoch
         );
@@ -771,7 +775,7 @@ export class ForkChoice implements IForkChoice {
     }
 
     const targetSlot = computeStartSlotAtEpoch(blockEpoch);
-    const targetRoot = slot === targetSlot ? blockRoot : state.blockRoots.get(targetSlot % SLOTS_PER_HISTORICAL_ROOT);
+    const targetRoot = slot === targetSlot ? blockRoot : state.getBlockRootAtSlot(targetSlot);
 
     // This does not apply a vote to the block, it just makes fork choice aware of the block so
     // it can still be identified as the head even if it doesn't have any votes.
@@ -820,7 +824,7 @@ export class ForkChoice implements IForkChoice {
             executionStatus: this.getPostGloasExecStatus(executionStatus),
             dataAvailabilityStatus,
           }
-        : isExecutionBlockBodyType(block.body) && isExecutionStateType(state) && isExecutionEnabled(state, block)
+        : isExecutionBlockBodyType(block.body) && state.isExecutionStateType && state.isExecutionEnabled(block)
           ? {
               executionPayloadBlockHash: toRootHex(block.body.executionPayload.blockHash),
               executionPayloadNumber: block.body.executionPayload.blockNumber,
@@ -1854,10 +1858,14 @@ export function getCommitteeFraction(
  * @param state - The state to check execution_payload_availability
  * @param checkpointEpoch - The epoch of the checkpoint
  */
-export function getCheckpointPayloadStatus(state: CachedBeaconStateAllForks, checkpointEpoch: number): PayloadStatus {
+export function getCheckpointPayloadStatus(
+  config: ChainForkConfig,
+  state: IBeaconStateView,
+  checkpointEpoch: number
+): PayloadStatus {
   // Compute checkpoint slot first to determine the correct fork
   const checkpointSlot = computeStartSlotAtEpoch(checkpointEpoch);
-  const fork = state.config.getForkSeq(checkpointSlot);
+  const fork = config.getForkSeq(checkpointSlot);
 
   // Pre-Gloas: always FULL
   if (fork < ForkSeq.gloas) {
@@ -1867,8 +1875,7 @@ export function getCheckpointPayloadStatus(state: CachedBeaconStateAllForks, che
   // For Gloas, check state.execution_payload_availability
   // - For non-skipped slots at checkpoint: returns false (EMPTY) since payload hasn't arrived yet
   // - For skipped slots at checkpoint: returns the actual availability status from state
-  const gloasState = state as CachedBeaconStateGloas;
-  const payloadAvailable = gloasState.executionPayloadAvailability.get(checkpointSlot % SLOTS_PER_HISTORICAL_ROOT);
+  const payloadAvailable = state.executionPayloadAvailability[checkpointSlot % SLOTS_PER_HISTORICAL_ROOT];
 
   return payloadAvailable ? PayloadStatus.FULL : PayloadStatus.EMPTY;
 }

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1875,7 +1875,7 @@ export function getCheckpointPayloadStatus(
   // For Gloas, check state.execution_payload_availability
   // - For non-skipped slots at checkpoint: returns false (EMPTY) since payload hasn't arrived yet
   // - For skipped slots at checkpoint: returns the actual availability status from state
-  const payloadAvailable = state.executionPayloadAvailability[checkpointSlot % SLOTS_PER_HISTORICAL_ROOT];
+  const payloadAvailable = state.executionPayloadAvailability.get(checkpointSlot % SLOTS_PER_HISTORICAL_ROOT);
 
   return payloadAvailable ? PayloadStatus.FULL : PayloadStatus.EMPTY;
 }

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -1,8 +1,4 @@
-import {
-  CachedBeaconStateAllForks,
-  DataAvailabilityStatus,
-  EffectiveBalanceIncrements,
-} from "@lodestar/state-transition";
+import {DataAvailabilityStatus, EffectiveBalanceIncrements, IBeaconStateView} from "@lodestar/state-transition";
 import {AttesterSlashing, BeaconBlock, Epoch, IndexedAttestation, Root, RootHex, Slot} from "@lodestar/types";
 import {
   LVHExecResponse,
@@ -144,7 +140,7 @@ export interface IForkChoice {
    */
   onBlock(
     block: BeaconBlock,
-    state: CachedBeaconStateAllForks,
+    state: IBeaconStateView,
     blockDelaySec: number,
     currentSlot: Slot,
     executionStatus: MaybeValidExecutionStatus,

--- a/packages/fork-choice/src/forkChoice/store.ts
+++ b/packages/fork-choice/src/forkChoice/store.ts
@@ -1,4 +1,4 @@
-import {CachedBeaconStateAllForks, EffectiveBalanceIncrements} from "@lodestar/state-transition";
+import {EffectiveBalanceIncrements, IBeaconStateView} from "@lodestar/state-transition";
 import {RootHex, Slot, ValidatorIndex, phase0} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {PayloadStatus} from "../protoArray/interface.js";
@@ -30,7 +30,7 @@ export type JustifiedBalances = EffectiveBalanceIncrements;
  */
 export type JustifiedBalancesGetter = (
   checkpoint: CheckpointWithPayloadStatus,
-  blockState: CachedBeaconStateAllForks
+  blockState: IBeaconStateView
 ) => JustifiedBalances;
 
 /**

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -1,3 +1,4 @@
+import {BitArray} from "@chainsafe/ssz";
 import {
   EFFECTIVE_BALANCE_INCREMENT,
   ForkSeq,
@@ -80,7 +81,7 @@ export function processAttestationsAltair(
       stateSlot - data.slot,
       epochCtx.epoch,
       rootCache,
-      fork >= ForkSeq.gloas ? (state as CachedBeaconStateGloas).executionPayloadAvailability.toBoolArray() : null
+      fork >= ForkSeq.gloas ? (state as CachedBeaconStateGloas).executionPayloadAvailability : null
     );
 
     // For each participant, update their participation
@@ -177,7 +178,7 @@ export function getAttestationParticipationStatus(
   inclusionDelay: number,
   currentEpoch: Epoch,
   rootCache: RootCache,
-  executionPayloadAvailability: boolean[] | null
+  executionPayloadAvailability: BitArray | null
 ): number {
   const justifiedCheckpoint =
     data.target.epoch === currentEpoch ? rootCache.currentJustifiedCheckpoint : rootCache.previousJustifiedCheckpoint;
@@ -221,7 +222,8 @@ export function getAttestationParticipationStatus(
         throw new Error(`data index must be 0 or 1 index=${data.index}`);
       }
 
-      isMatchingPayload = Boolean(data.index) === executionPayloadAvailability[data.slot % SLOTS_PER_HISTORICAL_ROOT];
+      isMatchingPayload =
+        Boolean(data.index) === executionPayloadAvailability.get(data.slot % SLOTS_PER_HISTORICAL_ROOT);
     }
 
     isMatchingHead = isMatchingHead && isMatchingPayload;

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -18,6 +18,7 @@ import {Attestation, Epoch, phase0} from "@lodestar/types";
 import {byteArrayEquals, intSqrt} from "@lodestar/utils";
 import {BeaconStateTransitionMetrics} from "../metrics.js";
 import {getAttestationWithIndicesSignatureSet} from "../signatureSets/indexedAttestation.js";
+import {BeaconStateView} from "../stateView/beaconStateView.js";
 import {CachedBeaconStateAltair, CachedBeaconStateGloas} from "../types.js";
 import {isAttestationSameSlot, isAttestationSameSlotRootCache} from "../util/gloas.js";
 import {increaseBalance, verifySignatureSet} from "../util/index.js";
@@ -42,7 +43,7 @@ export function processAttestationsAltair(
   const {epochCtx} = state;
   const {effectiveBalanceIncrements} = epochCtx;
   const stateSlot = state.slot;
-  const rootCache = new RootCache(state);
+  const rootCache = new RootCache(new BeaconStateView(state));
   const currentEpoch = epochCtx.epoch;
 
   // Process all attestations first and then increase the balance of the proposer once

--- a/packages/state-transition/src/signatureSets/index.ts
+++ b/packages/state-transition/src/signatureSets/index.ts
@@ -3,7 +3,7 @@ import {ForkSeq} from "@lodestar/params";
 import {IndexedAttestation, SignedBeaconBlock, altair, capella} from "@lodestar/types";
 import {getSyncCommitteeSignatureSet} from "../block/processSyncCommittee.js";
 import {SyncCommitteeCache} from "../cache/syncCommitteeCache.js";
-import {IBeaconStateView} from "../stateView/interface.ts";
+import {IBeaconStateView} from "../stateView/interface.js";
 import {ISignatureSet} from "../util/index.js";
 import {getAttesterSlashingsSignatureSets} from "./attesterSlashings.js";
 import {getBlsToExecutionChangeSignatureSets} from "./blsToExecutionChange.js";

--- a/packages/state-transition/src/signatureSets/index.ts
+++ b/packages/state-transition/src/signatureSets/index.ts
@@ -3,8 +3,7 @@ import {ForkSeq} from "@lodestar/params";
 import {IndexedAttestation, SignedBeaconBlock, altair, capella} from "@lodestar/types";
 import {getSyncCommitteeSignatureSet} from "../block/processSyncCommittee.js";
 import {SyncCommitteeCache} from "../cache/syncCommitteeCache.js";
-import {BeaconStateView} from "../stateView/beaconStateView.js";
-import {CachedBeaconStateAllForks} from "../types.js";
+import {IBeaconStateView} from "../stateView/interface.ts";
 import {ISignatureSet} from "../util/index.js";
 import {getAttesterSlashingsSignatureSets} from "./attesterSlashings.js";
 import {getBlsToExecutionChangeSignatureSets} from "./blsToExecutionChange.js";
@@ -32,7 +31,7 @@ export * from "./voluntaryExits.js";
 export function getBlockSignatureSets(
   config: BeaconConfig,
   currentSyncCommitteeIndexed: SyncCommitteeCache,
-  state: CachedBeaconStateAllForks,
+  state: IBeaconStateView,
   signedBlock: SignedBeaconBlock,
   indexedAttestations: IndexedAttestation[],
   opts?: {
@@ -48,7 +47,7 @@ export function getBlockSignatureSets(
     ...getProposerSlashingsSignatureSets(config, signedBlock),
     ...getAttesterSlashingsSignatureSets(config, signedBlock),
     ...getAttestationsSignatureSets(config, signedBlock, indexedAttestations),
-    ...getVoluntaryExitsSignatureSets(config, new BeaconStateView(state), signedBlock),
+    ...getVoluntaryExitsSignatureSets(config, state, signedBlock),
   ];
 
   if (!opts?.skipProposerSignature) {

--- a/packages/state-transition/src/slot/upgradeStateToAltair.ts
+++ b/packages/state-transition/src/slot/upgradeStateToAltair.ts
@@ -3,6 +3,7 @@ import {ForkSeq} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {getAttestationParticipationStatus} from "../block/processAttestationsAltair.js";
 import {getCachedBeaconState} from "../cache/stateCache.js";
+import {BeaconStateView} from "../stateView/beaconStateView.js";
 import {CachedBeaconStateAltair, CachedBeaconStatePhase0} from "../types.js";
 import {RootCache, newZeroedArray} from "../util/index.js";
 import {getNextSyncCommittee} from "../util/syncCommittee.js";
@@ -125,7 +126,7 @@ function translateParticipation(
   pendingAttesations: CompositeViewDU<typeof ssz.phase0.EpochAttestations>
 ): void {
   const {epochCtx} = state;
-  const rootCache = new RootCache(state);
+  const rootCache = new RootCache(new BeaconStateView(state));
   const epochParticipation = state.previousEpochParticipation;
 
   for (const attestation of pendingAttesations.getAllReadonly()) {

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -34,7 +34,7 @@ import {VoluntaryExitValidity, getVoluntaryExitValidity} from "../block/processV
 import {getExpectedWithdrawals} from "../block/processWithdrawals.js";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";
 import {EpochTransitionCacheOpts} from "../cache/epochTransitionCache.js";
-import {PubkeyCache, createPubkeyCache} from "../cache/pubkeyCache.js";
+import {PubkeyCache} from "../cache/pubkeyCache.js";
 import {RewardCache} from "../cache/rewardCache.js";
 import {
   CachedBeaconStateAllForks,
@@ -793,16 +793,17 @@ export class BeaconStateView implements IBeaconStateView {
  */
 export function createBeaconStateViewForHistoricalRegen(
   config: BeaconConfig,
-  stateBytes: Uint8Array
+  stateBytes: Uint8Array,
+  pubkeyCache: PubkeyCache
 ): IBeaconStateView {
   const state = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);
 
-  syncPubkeyCache(state, pubkeyCacheRegen);
+  syncPubkeyCache(state, pubkeyCache);
   const cachedState = createCachedBeaconState(
     state,
     {
       config,
-      pubkeyCache: pubkeyCacheRegen,
+      pubkeyCache,
     },
     {
       skipSyncPubkeys: true,
@@ -811,9 +812,6 @@ export function createBeaconStateViewForHistoricalRegen(
 
   return new BeaconStateView(cachedState);
 }
-
-// this is reused for all historical state regens in the worker.
-const pubkeyCacheRegen = createPubkeyCache();
 
 /**
  * Populate a PubkeyIndexMap with any new entries based on a BeaconState

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -780,7 +780,7 @@ export class BeaconStateView implements IBeaconStateView {
 }
 
 /**
- * Create BeaconStateView for historical state regen, no need to sync pubkey cache there.
+ * Create BeaconStateView for historical state regen, this is called from a worker thread.
  */
 export function createBeaconStateViewForHistoricalRegen(
   config: BeaconConfig,
@@ -788,13 +788,12 @@ export function createBeaconStateViewForHistoricalRegen(
 ): IBeaconStateView {
   const state = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);
 
-  const pubkeyCache = createPubkeyCache();
-  syncPubkeyCache(state, pubkeyCache);
+  syncPubkeyCache(state, pubkeyCacheRegen);
   const cachedState = createCachedBeaconState(
     state,
     {
       config,
-      pubkeyCache,
+      pubkeyCache: pubkeyCacheRegen,
     },
     {
       skipSyncPubkeys: true,
@@ -803,6 +802,9 @@ export function createBeaconStateViewForHistoricalRegen(
 
   return new BeaconStateView(cachedState);
 }
+
+// this is reused for all historical state regens in the worker.
+const pubkeyCacheRegen = createPubkeyCache();
 
 /**
  * Populate a PubkeyIndexMap with any new entries based on a BeaconState

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -29,7 +29,7 @@ import {
 } from "@lodestar/types";
 import {Checkpoint, Fork} from "@lodestar/types/phase0";
 import {processExecutionPayloadEnvelope} from "../block/index.js";
-import {ProcessExecutionPayloadEnvelopeOpts} from "../block/processExecutionPayloadEnvelope.ts";
+import {ProcessExecutionPayloadEnvelopeOpts} from "../block/processExecutionPayloadEnvelope.js";
 import {VoluntaryExitValidity, getVoluntaryExitValidity} from "../block/processVoluntaryExit.js";
 import {getExpectedWithdrawals} from "../block/processWithdrawals.js";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -503,6 +503,10 @@ export class BeaconStateView implements IBeaconStateView {
     return this.cachedState.epochCtx.syncProposerReward;
   }
 
+  getIndexedSyncCommittee(slot: Slot): SyncCommitteeCache {
+    return this.cachedState.epochCtx.getIndexedSyncCommittee(slot);
+  }
+
   getIndexedSyncCommitteeAtEpoch(epoch: Epoch): SyncCommitteeCache {
     return this.cachedState.epochCtx.getIndexedSyncCommitteeAtEpoch(epoch);
   }

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -28,7 +28,7 @@ import {
 } from "@lodestar/types";
 import {Checkpoint, Fork} from "@lodestar/types/phase0";
 import {processExecutionPayloadEnvelope} from "../block/index.js";
-import {ProcessExecutionPayloadEnvelopeOpts} from "../block/processExecutionPayloadEnvelope.js";
+import {ProcessExecutionPayloadEnvelopeOpts} from "../block/processExecutionPayloadEnvelope.ts";
 import {VoluntaryExitValidity, getVoluntaryExitValidity} from "../block/processVoluntaryExit.js";
 import {getExpectedWithdrawals} from "../block/processWithdrawals.js";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -1,5 +1,5 @@
 import {CompactMultiProof, ProofType, Tree, createProof} from "@chainsafe/persistent-merkle-tree";
-import {ByteViews} from "@chainsafe/ssz";
+import {BitArray, ByteViews} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq, SLOTS_PER_HISTORICAL_ROOT, isForkPostGloas} from "@lodestar/params";
 import {
@@ -92,7 +92,7 @@ export class BeaconStateView implements IBeaconStateView {
   // fulu
   private _proposerLookahead: fulu.ProposerLookahead | null = null;
   // gloas
-  private _executionPayloadAvailability: boolean[] | null = null;
+  private _executionPayloadAvailability: BitArray | null = null;
   private _latestExecutionPayloadBid: ExecutionPayloadBid | null = null;
 
   constructor(readonly cachedState: CachedBeaconStateAllForks) {
@@ -357,15 +357,15 @@ export class BeaconStateView implements IBeaconStateView {
 
   // gloas
 
-  get executionPayloadAvailability(): boolean[] {
+  get executionPayloadAvailability(): BitArray {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
       throw new Error("executionPayloadAvailability is not available before GLOAS");
     }
 
     if (this._executionPayloadAvailability === null) {
-      this._executionPayloadAvailability = (this.cachedState as CachedBeaconStateGloas).executionPayloadAvailability
-        .toValue()
-        .toBoolArray();
+      this._executionPayloadAvailability = (
+        this.cachedState as CachedBeaconStateGloas
+      ).executionPayloadAvailability.toValue();
     }
 
     return this._executionPayloadAvailability;

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -4,6 +4,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq, SLOTS_PER_HISTORICAL_ROOT, isForkPostGloas} from "@lodestar/params";
 import {
   BeaconBlock,
+  BeaconState,
   BlindedBeaconBlock,
   BuilderIndex,
   Bytes32,
@@ -715,6 +716,10 @@ export class BeaconStateView implements IBeaconStateView {
     cachedState.balances.getAll();
 
     return new BeaconStateView(cachedState);
+  }
+
+  toValue(): BeaconState {
+    return this.cachedState.toValue();
   }
 
   serialize(): Uint8Array {

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -405,7 +405,7 @@ export class BeaconStateView implements IBeaconStateView {
    * Return the index of the validator in the PTC committee for the given slot.
    * return -1 if validator is not in the PTC committee for the given slot.
    */
-  validatorPTCCommitteeIndex(validatorIndex: ValidatorIndex, slot: Slot): number {
+  getIndexInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.gloas) {
       throw new Error("PTC committees are not supported before GLOAS");
     }

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -148,6 +148,7 @@ export interface IBeaconStateView {
     expectedWithdrawals: capella.Withdrawal[];
     processedBuilderWithdrawalsCount: number;
     processedPartialWithdrawalsCount: number;
+    processedBuildersSweepCount: number;
     processedValidatorSweepCount: number;
   };
 

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -2,6 +2,7 @@ import {CompactMultiProof} from "@chainsafe/persistent-merkle-tree";
 import {BitArray, ByteViews} from "@chainsafe/ssz";
 import {
   BeaconBlock,
+  BeaconState,
   BlindedBeaconBlock,
   BuilderIndex,
   Bytes32,
@@ -193,6 +194,7 @@ export interface IBeaconStateView {
 
   // Serialization
   loadOtherState(stateBytes: Uint8Array, seedValidatorsBytes?: Uint8Array): IBeaconStateView;
+  toValue(): BeaconState;
   serialize(): Uint8Array;
   serializedSize(): number;
   serializeToBytes(output: ByteViews, offset: number): number;

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -23,7 +23,7 @@ import {
   rewards,
 } from "@lodestar/types";
 import {Checkpoint, Fork} from "@lodestar/types/phase0";
-import {ProcessExecutionPayloadEnvelopeOpts} from "../block/processExecutionPayloadEnvelope.js";
+import {ProcessExecutionPayloadEnvelopeOpts} from "../block/processExecutionPayloadEnvelope.ts";
 import {VoluntaryExitValidity} from "../block/processVoluntaryExit.js";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";
 import {EpochTransitionCacheOpts} from "../cache/epochTransitionCache.js";
@@ -110,12 +110,11 @@ export interface IBeaconStateView {
   getCurrentShuffling(): EpochShuffling;
   getNextShuffling(): EpochShuffling;
 
-  // utils: proposers, anchor checkpoint
+  // Proposer shuffling
   previousProposers: ValidatorIndex[] | null;
   currentProposers: ValidatorIndex[];
   nextProposers: ValidatorIndex[];
   getBeaconProposer(slot: Slot): ValidatorIndex;
-  computeAnchorCheckpoint(): {checkpoint: phase0.Checkpoint; blockHeader: phase0.BeaconBlockHeader};
 
   // Sync committees
   currentSyncCommittee: altair.SyncCommittee;
@@ -180,6 +179,7 @@ export interface IBeaconStateView {
     justifiedCheckpoint: phase0.Checkpoint;
     finalizedCheckpoint: phase0.Checkpoint;
   };
+  computeAnchorCheckpoint(): {checkpoint: phase0.Checkpoint; blockHeader: phase0.BeaconBlockHeader};
 
   // this is for backward compatible
   clonedCount: number;

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -24,7 +24,7 @@ import {
   rewards,
 } from "@lodestar/types";
 import {Checkpoint, Fork} from "@lodestar/types/phase0";
-import {ProcessExecutionPayloadEnvelopeOpts} from "../block/processExecutionPayloadEnvelope.ts";
+import {ProcessExecutionPayloadEnvelopeOpts} from "../block/processExecutionPayloadEnvelope.js";
 import {VoluntaryExitValidity} from "../block/processVoluntaryExit.js";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";
 import {EpochTransitionCacheOpts} from "../cache/epochTransitionCache.js";

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -1,5 +1,5 @@
 import {CompactMultiProof} from "@chainsafe/persistent-merkle-tree";
-import {ByteViews} from "@chainsafe/ssz";
+import {BitArray, ByteViews} from "@chainsafe/ssz";
 import {
   BeaconBlock,
   BlindedBeaconBlock,
@@ -93,7 +93,7 @@ export interface IBeaconStateView {
   proposerLookahead: fulu.ProposerLookahead;
 
   // gloas
-  executionPayloadAvailability: boolean[];
+  executionPayloadAvailability: BitArray;
   latestExecutionPayloadBid: ExecutionPayloadBid;
   getBuilder(index: BuilderIndex): gloas.Builder;
   canBuilderCoverBid(builderIndex: BuilderIndex, bidAmount: number): boolean;

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -98,7 +98,7 @@ export interface IBeaconStateView {
   latestExecutionPayloadBid: ExecutionPayloadBid;
   getBuilder(index: BuilderIndex): gloas.Builder;
   canBuilderCoverBid(builderIndex: BuilderIndex, bidAmount: number): boolean;
-  validatorPTCCommitteeIndex(validatorIndex: ValidatorIndex, slot: Slot): number;
+  getIndexInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number;
 
   // Shuffling and committees
   getShufflingAtEpoch(epoch: Epoch): EpochShuffling;

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -122,6 +122,8 @@ export interface IBeaconStateView {
   currentSyncCommitteeIndexed: SyncCommitteeCache;
   syncProposerReward: number;
   getIndexedSyncCommitteeAtEpoch(epoch: Epoch): SyncCommitteeCache;
+  /** Get indexed sync committee with slot+1 offset for duty lookups */
+  getIndexedSyncCommittee(slot: Slot): SyncCommitteeCache;
 
   // Validators and balances
   effectiveBalanceIncrements: EffectiveBalanceIncrements;

--- a/packages/state-transition/src/util/rootCache.ts
+++ b/packages/state-transition/src/util/rootCache.ts
@@ -1,6 +1,17 @@
 import {Epoch, Root, Slot, phase0} from "@lodestar/types";
-import {CachedBeaconStateAllForks} from "../types.js";
+import {CachedBeaconStateAllForks} from "../cache/stateCache.js";
+import {IBeaconStateView} from "../stateView/interface.js";
 import {getBlockRoot, getBlockRootAtSlot} from "./blockRoot.js";
+
+/**
+ * Typeguard to distinguish CachedBeaconStateAllForks from IBeaconStateView.
+ * Uses `epochCtx` as the definitive marker of CachedBeaconStateAllForks.
+ */
+export function isCachedBeaconStateAllForks(
+  state: CachedBeaconStateAllForks | IBeaconStateView
+): state is CachedBeaconStateAllForks {
+  return (state as CachedBeaconStateAllForks).epochCtx !== undefined;
+}
 
 /**
  * Cache to prevent accessing the state tree to fetch block roots repeteadly.
@@ -12,7 +23,7 @@ export class RootCache {
   private readonly blockRootEpochCache = new Map<Epoch, Root>();
   private readonly blockRootSlotCache = new Map<Slot, Root>();
 
-  constructor(private readonly state: CachedBeaconStateAllForks) {
+  constructor(private readonly state: CachedBeaconStateAllForks | IBeaconStateView) {
     this.currentJustifiedCheckpoint = state.currentJustifiedCheckpoint;
     this.previousJustifiedCheckpoint = state.previousJustifiedCheckpoint;
   }
@@ -20,7 +31,9 @@ export class RootCache {
   getBlockRoot(epoch: Epoch): Root {
     let root = this.blockRootEpochCache.get(epoch);
     if (!root) {
-      root = getBlockRoot(this.state, epoch);
+      root = isCachedBeaconStateAllForks(this.state)
+        ? getBlockRoot(this.state, epoch)
+        : this.state.getBlockRootAtEpoch(epoch);
       this.blockRootEpochCache.set(epoch, root);
     }
     return root;
@@ -29,7 +42,9 @@ export class RootCache {
   getBlockRootAtSlot(slot: Slot): Root {
     let root = this.blockRootSlotCache.get(slot);
     if (!root) {
-      root = getBlockRootAtSlot(this.state, slot);
+      root = isCachedBeaconStateAllForks(this.state)
+        ? getBlockRootAtSlot(this.state, slot)
+        : this.state.getBlockRootAtSlot(slot);
       this.blockRootSlotCache.set(slot, root);
     }
     return root;

--- a/packages/state-transition/src/util/rootCache.ts
+++ b/packages/state-transition/src/util/rootCache.ts
@@ -1,17 +1,5 @@
 import {Epoch, Root, Slot, phase0} from "@lodestar/types";
-import {CachedBeaconStateAllForks} from "../cache/stateCache.js";
 import {IBeaconStateView} from "../stateView/interface.js";
-import {getBlockRoot, getBlockRootAtSlot} from "./blockRoot.js";
-
-/**
- * Typeguard to distinguish CachedBeaconStateAllForks from IBeaconStateView.
- * Uses `epochCtx` as the definitive marker of CachedBeaconStateAllForks.
- */
-export function isCachedBeaconStateAllForks(
-  state: CachedBeaconStateAllForks | IBeaconStateView
-): state is CachedBeaconStateAllForks {
-  return (state as CachedBeaconStateAllForks).epochCtx !== undefined;
-}
 
 /**
  * Cache to prevent accessing the state tree to fetch block roots repeteadly.
@@ -23,7 +11,7 @@ export class RootCache {
   private readonly blockRootEpochCache = new Map<Epoch, Root>();
   private readonly blockRootSlotCache = new Map<Slot, Root>();
 
-  constructor(private readonly state: CachedBeaconStateAllForks | IBeaconStateView) {
+  constructor(private readonly state: IBeaconStateView) {
     this.currentJustifiedCheckpoint = state.currentJustifiedCheckpoint;
     this.previousJustifiedCheckpoint = state.previousJustifiedCheckpoint;
   }
@@ -31,9 +19,7 @@ export class RootCache {
   getBlockRoot(epoch: Epoch): Root {
     let root = this.blockRootEpochCache.get(epoch);
     if (!root) {
-      root = isCachedBeaconStateAllForks(this.state)
-        ? getBlockRoot(this.state, epoch)
-        : this.state.getBlockRootAtEpoch(epoch);
+      root = this.state.getBlockRootAtEpoch(epoch);
       this.blockRootEpochCache.set(epoch, root);
     }
     return root;
@@ -42,9 +28,7 @@ export class RootCache {
   getBlockRootAtSlot(slot: Slot): Root {
     let root = this.blockRootSlotCache.get(slot);
     if (!root) {
-      root = isCachedBeaconStateAllForks(this.state)
-        ? getBlockRootAtSlot(this.state, slot)
-        : this.state.getBlockRootAtSlot(slot);
+      root = this.state.getBlockRootAtSlot(slot);
       this.blockRootSlotCache.set(slot, root);
     }
     return root;

--- a/packages/state-transition/src/util/shuffling.ts
+++ b/packages/state-transition/src/util/shuffling.ts
@@ -11,6 +11,7 @@ import {
 } from "@lodestar/types";
 import {LodestarError} from "@lodestar/utils";
 import {CachedBeaconStateAllForks} from "../cache/stateCache.js";
+import {IBeaconStateView} from "../stateView/interface.js";
 import {getBlockRootAtSlot} from "./blockRoot.js";
 import {computeStartSlotAtEpoch} from "./epoch.js";
 import {EpochShuffling} from "./epochShuffling.js";
@@ -22,21 +23,21 @@ import {EpochShuffling} from "./epochShuffling.js";
  * Returns `null` on the one-off scenario where the genesis block decides its own shuffling.
  * It should be set to the latest block applied to this `state` or the genesis block root.
  */
-export function proposerShufflingDecisionRoot(fork: ForkName, state: CachedBeaconStateAllForks): Root | null {
+export function proposerShufflingDecisionRoot(fork: ForkName, state: IBeaconStateView): Root | null {
   const decisionSlot = proposerShufflingDecisionSlot(fork, state);
   if (state.slot === decisionSlot) {
     return null;
   }
-  return getBlockRootAtSlot(state, decisionSlot);
+  return state.getBlockRootAtSlot(decisionSlot);
 }
 
 /**
  * Returns the slot at which the proposer shuffling was decided. The block root at this slot
  * can be used to key the proposer shuffling for the current epoch.
  */
-function proposerShufflingDecisionSlot(fork: ForkName, state: CachedBeaconStateAllForks): Slot {
+function proposerShufflingDecisionSlot(fork: ForkName, state: IBeaconStateView): Slot {
   // After fulu, the decision slot is in previous epoch due to deterministic proposer lookahead
-  const epoch = isForkPostFulu(fork) ? state.epochCtx.epoch - 1 : state.epochCtx.epoch;
+  const epoch = isForkPostFulu(fork) ? state.epoch - 1 : state.epoch;
   const startSlot = computeStartSlotAtEpoch(epoch);
   return Math.max(startSlot - 1, 0);
 }

--- a/packages/state-transition/test/perf/util/rootCache.test.ts
+++ b/packages/state-transition/test/perf/util/rootCache.test.ts
@@ -1,4 +1,5 @@
 import {bench, describe} from "@chainsafe/benchmark";
+import {BeaconStateView} from "../../../src/stateView/beaconStateView.js";
 import {generatePerfTestCachedStatePhase0, perfStateEpoch, perfStateId} from "../../../src/testUtils/util.js";
 import {RootCache, computeStartSlotAtEpoch, getBlockRootAtSlot} from "../../../src/util/index.js";
 import {State} from "../types.js";
@@ -8,7 +9,7 @@ const slot = computeStartSlotAtEpoch(perfStateEpoch) - 1;
 describe("RootCache.getBlockRootAtSlot from rootCache", () => {
   bench<RootCache, RootCache>({
     id: `RootCache.getBlockRootAtSlot - ${perfStateId}`,
-    before: () => new RootCache(generatePerfTestCachedStatePhase0()),
+    before: () => new RootCache(new BeaconStateView(generatePerfTestCachedStatePhase0())),
     beforeEach: (rootCache) => rootCache,
     fn: (rootCache) => {
       for (let i = 0; i <= 100; i++) {

--- a/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -6,7 +6,7 @@ import {config} from "@lodestar/config/default";
 import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE} from "@lodestar/params";
 import {BLSSignature, ValidatorIndex, capella, phase0, ssz} from "@lodestar/types";
 import {ZERO_HASH} from "../../../src/constants/index.js";
-import {BeaconStateView} from "../../../src/index.ts";
+import {BeaconStateView} from "../../../src/index.js";
 import {getBlockSignatureSets} from "../../../src/signatureSets/index.js";
 import {generateCachedState} from "../../../src/testUtils/state.js";
 import {generateValidators} from "../../utils/validator.js";

--- a/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
+++ b/packages/state-transition/test/unit/signatureSets/signatureSets.test.ts
@@ -6,6 +6,7 @@ import {config} from "@lodestar/config/default";
 import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE} from "@lodestar/params";
 import {BLSSignature, ValidatorIndex, capella, phase0, ssz} from "@lodestar/types";
 import {ZERO_HASH} from "../../../src/constants/index.js";
+import {BeaconStateView} from "../../../src/index.ts";
 import {getBlockSignatureSets} from "../../../src/signatureSets/index.js";
 import {generateCachedState} from "../../../src/testUtils/state.js";
 import {generateValidators} from "../../utils/validator.js";
@@ -73,7 +74,7 @@ describe("signatureSets", () => {
     const signatureSets = getBlockSignatureSets(
       state.config,
       state.epochCtx.currentSyncCommitteeIndexed,
-      state,
+      new BeaconStateView(state),
       signedBlock,
       indexedAttestations
     );


### PR DESCRIPTION
**Motivation**

- get the beacon-node ready to integrate lodestar-z

**Description**

- use IBeaconStateView in `beacon-node` and `fork-choice` instead of the current `CachedBeaconState*`

Closes #8650

blocked by #8773
