### PR TITLE
chore: drop support for node v22

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "root",
   "private": true,
   "engines": {
-    "node": "^22.22.0 || ^24.13.0"
+    "node": "^24.13.0"
   },
   "packageManager": "pnpm@10.24.0",
   "workspaces": [


### PR DESCRIPTION
Closes https://github.com/ChainSafe/lodestar/issues/8867, details are in the issue but the tl;dr is that we do not test node v22 anymore and there are negative performance implications and changes like https://github.com/ChainSafe/lodestar/pull/8846 are specifically optimized for node v24 while they would cause a regression for node v22.