### PR TITLE
feat: update to spec v1.7.0-alpha.2

### DIFF
--- a/packages/beacon-node/src/chain/errors/blockError.ts
+++ b/packages/beacon-node/src/chain/errors/blockError.ts
@@ -68,6 +68,8 @@ export enum BlockErrorCode {
   DATA_UNAVAILABLE = "BLOCK_ERROR_DATA_UNAVAILABLE",
   /** Block contains too many kzg commitments */
   TOO_MANY_KZG_COMMITMENTS = "BLOCK_ERROR_TOO_MANY_KZG_COMMITMENTS",
+  /** Bid parent block root does not match block parent root */
+  BID_PARENT_ROOT_MISMATCH = "BLOCK_ERROR_BID_PARENT_ROOT_MISMATCH",
 }
 
 type ExecutionErrorStatus = Exclude<
@@ -111,7 +113,8 @@ export type BlockErrorType =
   | {code: BlockErrorCode.TRANSACTIONS_TOO_BIG; size: number; max: number}
   | {code: BlockErrorCode.EXECUTION_ENGINE_ERROR; execStatus: ExecutionErrorStatus; errorMessage: string}
   | {code: BlockErrorCode.DATA_UNAVAILABLE}
-  | {code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS; blobKzgCommitmentsLen: number; commitmentLimit: number};
+  | {code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS; blobKzgCommitmentsLen: number; commitmentLimit: number}
+  | {code: BlockErrorCode.BID_PARENT_ROOT_MISMATCH; bidParentRoot: RootHex; blockParentRoot: RootHex};
 
 export class BlockGossipError extends GossipActionError<BlockErrorType> {}
 

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -23,6 +23,7 @@ export async function validateGossipBlock(
 ): Promise<void> {
   const block = signedBlock.message;
   const blockSlot = block.slot;
+  const blockEpoch = computeEpochAtSlot(blockSlot);
 
   // [IGNORE] The block is not from a future slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e.validate
   // that signed_beacon_block.message.slot <= current_slot (a client MAY queue future blocks for processing at the
@@ -113,7 +114,7 @@ export async function validateGossipBlock(
   // [REJECT] The length of KZG commitments is less than or equal to the limitation defined in Consensus Layer -- i.e. validate that len(body.signed_beacon_block.message.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
   if (isForkPostDeneb(fork) && !isForkPostGloas(fork)) {
     const blobKzgCommitmentsLen = (block as deneb.BeaconBlock).body.blobKzgCommitments.length;
-    const maxBlobsPerBlock = config.getMaxBlobsPerBlock(computeEpochAtSlot(blockSlot));
+    const maxBlobsPerBlock = config.getMaxBlobsPerBlock(blockEpoch);
     if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
       throw new BlockGossipError(GossipAction.REJECT, {
         code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS,
@@ -129,7 +130,7 @@ export async function validateGossipBlock(
     // [REJECT] The length of KZG commitments is less than or equal to the limitation defined in Consensus Layer
     // -- i.e. validate that len(bid.blob_kzg_commitments) <= max_blobs_per_block
     const blobKzgCommitmentsLen = bid.blobKzgCommitments.length;
-    const maxBlobsPerBlock = config.getMaxBlobsPerBlock(computeEpochAtSlot(blockSlot));
+    const maxBlobsPerBlock = config.getMaxBlobsPerBlock(blockEpoch);
     if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
       throw new BlockGossipError(GossipAction.REJECT, {
         code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS,

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -9,8 +9,8 @@ import {
   isExecutionEnabled,
   isExecutionStateType,
 } from "@lodestar/state-transition";
-import {SignedBeaconBlock, deneb} from "@lodestar/types";
-import {sleep, toRootHex} from "@lodestar/utils";
+import {SignedBeaconBlock, deneb, gloas} from "@lodestar/types";
+import {byteArrayEquals, sleep, toRootHex} from "@lodestar/utils";
 import {BlockErrorCode, BlockGossipError, GossipAction} from "../errors/index.js";
 import {IBeaconChain} from "../interface.js";
 import {RegenCaller} from "../regen/index.js";
@@ -123,12 +123,39 @@ export async function validateGossipBlock(
     }
   }
 
+  if (isForkPostGloas(fork)) {
+    const bid = (block as gloas.BeaconBlock).body.signedExecutionPayloadBid.message;
+
+    // [REJECT] The length of KZG commitments is less than or equal to the limitation defined in Consensus Layer
+    // -- i.e. validate that len(bid.blob_kzg_commitments) <= max_blobs_per_block
+    const blobKzgCommitmentsLen = bid.blobKzgCommitments.length;
+    const maxBlobsPerBlock = config.getMaxBlobsPerBlock(computeEpochAtSlot(blockSlot));
+    if (blobKzgCommitmentsLen > maxBlobsPerBlock) {
+      throw new BlockGossipError(GossipAction.REJECT, {
+        code: BlockErrorCode.TOO_MANY_KZG_COMMITMENTS,
+        blobKzgCommitmentsLen,
+        commitmentLimit: maxBlobsPerBlock,
+      });
+    }
+
+    // [REJECT] The bid's parent (defined by bid.parent_block_root) equals the block's parent (defined by block.parent_root)
+    if (!byteArrayEquals(bid.parentBlockRoot, block.parentRoot)) {
+      throw new BlockGossipError(GossipAction.REJECT, {
+        code: BlockErrorCode.BID_PARENT_ROOT_MISMATCH,
+        bidParentRoot: toRootHex(bid.parentBlockRoot),
+        blockParentRoot: parentRoot,
+      });
+    }
+
+    // TODO GLOAS: [REJECT] The block's execution payload parent (defined by bid.parent_block_hash) passes all validation
+    // This requires execution engine integration to verify the parent block hash
+  }
+
   // use getPreState to reload state if needed. It also checks for whether the current finalized checkpoint is an ancestor of the block.
   // As a result, we throw an IGNORE (whereas the spec says we should REJECT for this scenario).
   // this is something we should change this in the future to make the code airtight to the spec.
   // [IGNORE] The block's parent (defined by block.parent_root) has been seen (via both gossip and non-gossip sources) (a client MAY queue blocks for processing once the parent block is retrieved).
   // [REJECT] The block's parent (defined by block.parent_root) passes validation.
-  // TODO GLOAS: post-gloas, we check the validity of bid's parent payload, not the entire beacon block
   const blockState = await chain.regen
     .getPreState(block, {dontTransferCache: true}, RegenCaller.validateGossipBlock)
     .catch(() => {

--- a/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
@@ -35,7 +35,8 @@ async function validateExecutionPayloadEnvelope(
   // [IGNORE] The envelope's block root `envelope.block_root` has been seen (via
   // gossip or non-gossip sources) (a client MAY queue payload for processing once
   // the block is retrieved).
-  // TODO GLOAS: Need to review this
+  // TODO GLOAS: Need to review this, we should queue the envelope for later
+  // processing if the block is not yet known, otherwise we would ignore it here
   const block = chain.forkChoice.getBlock(envelope.beaconBlockRoot);
   if (block === null) {
     throw new ExecutionPayloadEnvelopeError(GossipAction.IGNORE, {

--- a/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
+++ b/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
@@ -89,7 +89,7 @@ async function validatePayloadAttestationMessage(
   // [REJECT] `payload_attestation_message.signature` is valid with respect to the validator's public key.
   const signatureSet = createSingleSignatureSetFromComponents(
     chain.index2pubkey[validatorIndex],
-    getPayloadAttestationDataSigningRoot(chain.config, state.slot, data),
+    getPayloadAttestationDataSigningRoot(chain.config, data),
     payloadAttestationMessage.signature
   );
 

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -1,12 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {
-  ForkPostDeneb,
-  ForkPostFulu,
-  ForkPreFulu,
-  ForkPreGloas,
-  isForkPostFulu,
-  isForkPostGloas,
-} from "@lodestar/params";
+import {ForkPostDeneb, ForkPostFulu, ForkPreFulu, isForkPostFulu} from "@lodestar/params";
 import {SignedBeaconBlock, Slot, deneb, fulu, phase0} from "@lodestar/types";
 import {LodestarError, Logger, byteArrayEquals, fromHex, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {
@@ -20,6 +13,7 @@ import {SeenBlockInput} from "../../chain/seenCache/seenGossipBlockInput.js";
 import {validateBlockBlobSidecars} from "../../chain/validation/blobSidecar.js";
 import {validateBlockDataColumnSidecars} from "../../chain/validation/dataColumnSidecar.js";
 import {INetwork} from "../../network/index.js";
+import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {WarnResult} from "../../util/wrapError.js";
 
@@ -695,13 +689,7 @@ export async function validateColumnsByRangeResponse(
         dataFork: dataSlot ? config.getForkName(dataSlot) : "unknown",
       });
     }
-    if (isForkPostGloas(forkName)) {
-      // TODO GLOAS: Post-gloas's blobKzgCommitments is not in beacon block body. Need to source it from somewhere else.
-      // if block without columns is passed default to zero and throw below
-      blobCount = 0;
-    } else {
-      blobCount = (block as SignedBeaconBlock<ForkPostFulu & ForkPreGloas>).message.body.blobKzgCommitments.length;
-    }
+    blobCount = getBlobKzgCommitments(forkName, block as SignedBeaconBlock<ForkPostFulu>).length;
 
     if (columnSidecars.length === 0) {
       if (!blobCount) {

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -10,9 +10,9 @@ import {IBeaconChain} from "../../chain/interface.ts";
 import {validateBlockBlobSidecars} from "../../chain/validation/blobSidecar.js";
 import {validateBlockDataColumnSidecars} from "../../chain/validation/dataColumnSidecar.js";
 import {INetwork} from "../../network/interface.js";
-import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
 import {prettyPrintPeerIdStr} from "../../network/util.js";
+import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {WarnResult} from "../../util/wrapError.js";
 import {

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -1,14 +1,7 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {
-  ForkPostDeneb,
-  ForkPostFulu,
-  ForkPreFulu,
-  ForkPreGloas,
-  isForkPostDeneb,
-  isForkPostFulu,
-} from "@lodestar/params";
-import {BeaconBlockBody, BlobIndex, ColumnIndex, SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
+import {ForkPostDeneb, ForkPostFulu, ForkPreFulu, isForkPostDeneb, isForkPostFulu} from "@lodestar/params";
+import {BlobIndex, ColumnIndex, SignedBeaconBlock, Slot, deneb, fulu} from "@lodestar/types";
 import {LodestarError, byteArrayEquals, fromHex, prettyPrintIndices, toHex, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource, IBlockInput} from "../../chain/blocks/blockInput/types.js";
@@ -17,6 +10,7 @@ import {IBeaconChain} from "../../chain/interface.ts";
 import {validateBlockBlobSidecars} from "../../chain/validation/blobSidecar.js";
 import {validateBlockDataColumnSidecars} from "../../chain/validation/dataColumnSidecar.js";
 import {INetwork} from "../../network/interface.js";
+import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
 import {prettyPrintPeerIdStr} from "../../network/util.js";
 import {PeerIdStr} from "../../util/peerId.js";
@@ -378,14 +372,14 @@ export async function fetchAndValidateColumns({
   chain,
   network,
   peerMeta,
+  forkName,
   block,
   blockRoot,
   missing,
 }: FetchByRootAndValidateColumnsProps): Promise<WarnResult<fulu.DataColumnSidecars, DownloadByRootError>> {
   const {peerId: peerIdStr} = peerMeta;
   const slot = block.message.slot;
-  // TODO GLOAS: Get blob count from somewhere else since blobKzgCommitments is absent from block body
-  const blobCount = (block.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments.length;
+  const blobCount = getBlobKzgCommitments(forkName, block).length;
   if (blobCount === 0) {
     return {result: [], warnings: null};
   }

--- a/packages/beacon-node/src/util/dataColumns.ts
+++ b/packages/beacon-node/src/util/dataColumns.ts
@@ -8,6 +8,7 @@ import {
   ForkPreGloas,
   KZG_COMMITMENTS_GINDEX,
   NUMBER_OF_COLUMNS,
+  isForkPostGloas,
 } from "@lodestar/params";
 import {signedBlockToSignedHeader} from "@lodestar/state-transition";
 import {
@@ -19,6 +20,7 @@ import {
   SignedBeaconBlockHeader,
   deneb,
   fulu,
+  gloas,
   ssz,
 } from "@lodestar/types";
 import {bytesToBigInt} from "@lodestar/utils";
@@ -262,6 +264,20 @@ export async function getCellsAndProofs(
 }
 
 /**
+ * Get blob KZG commitments from a signed block, handling the different locations
+ * in pre-Gloas (directly in block body) vs post-Gloas (in execution payload bid).
+ */
+export function getBlobKzgCommitments(
+  fork: ForkName,
+  signedBlock: SignedBeaconBlock<ForkPostFulu>
+): deneb.KZGCommitment[] {
+  if (isForkPostGloas(fork)) {
+    return (signedBlock as gloas.SignedBeaconBlock).message.body.signedExecutionPayloadBid.message.blobKzgCommitments;
+  }
+  return (signedBlock.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>).blobKzgCommitments;
+}
+
+/**
  * Given a signed block header and the commitments, inclusion proof, cells/proofs associated with
  * each blob in the block, assemble the sidecars which can be distributed to peers.
  *
@@ -310,16 +326,13 @@ export function getDataColumnSidecarsFromBlock(
   signedBlock: SignedBeaconBlock<ForkPostFulu>,
   cellsAndKzgProofs: {cells: Uint8Array[]; proofs: Uint8Array[]}[]
 ): fulu.DataColumnSidecars {
-  // TODO GLOAS: Need to get blobKzgCommitments from somewhere else
-  const blobKzgCommitments = (signedBlock.message.body as BeaconBlockBody<ForkPostFulu & ForkPreGloas>)
-    .blobKzgCommitments;
+  const fork = config.getForkName(signedBlock.message.slot);
+  const blobKzgCommitments = getBlobKzgCommitments(fork, signedBlock);
 
   // No need to create data column sidecars if there are no blobs
   if (blobKzgCommitments.length === 0) {
     return [];
   }
-
-  const fork = config.getForkName(signedBlock.message.slot);
   const signedBlockHeader = signedBlockToSignedHeader(config, signedBlock);
 
   const kzgCommitmentsInclusionProof = computePostFuluKzgCommitmentsInclusionProof(fork, signedBlock.message.body);

--- a/packages/beacon-node/test/spec/presets/sanity.test.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.test.ts
@@ -46,7 +46,7 @@ const sanitySlots: TestRunnerFn<SanitySlotsTestCase, BeaconStateAllForks> = (for
         post: ssz[fork].BeaconState,
       },
       shouldError: (testCase) => !testCase.post,
-      timeout: 10000,
+      timeout: 30000,
       getExpected: (testCase) => testCase.post,
       expectFunc: (_testCase, expected, actual) => {
         expectEqualBeaconState(fork, expected, actual);

--- a/packages/beacon-node/test/spec/presets/sanity.test.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.test.ts
@@ -46,7 +46,7 @@ const sanitySlots: TestRunnerFn<SanitySlotsTestCase, BeaconStateAllForks> = (for
         post: ssz[fork].BeaconState,
       },
       shouldError: (testCase) => !testCase.post,
-      timeout: 10000,
+      timeout: 30_000,
       getExpected: (testCase) => testCase.post,
       expectFunc: (_testCase, expected, actual) => {
         expectEqualBeaconState(fork, expected, actual);

--- a/packages/beacon-node/test/spec/presets/sanity.test.ts
+++ b/packages/beacon-node/test/spec/presets/sanity.test.ts
@@ -46,7 +46,7 @@ const sanitySlots: TestRunnerFn<SanitySlotsTestCase, BeaconStateAllForks> = (for
         post: ssz[fork].BeaconState,
       },
       shouldError: (testCase) => !testCase.post,
-      timeout: 30_000,
+      timeout: 10000,
       getExpected: (testCase) => testCase.post,
       expectFunc: (_testCase, expected, actual) => {
         expectEqualBeaconState(fork, expected, actual);

--- a/packages/beacon-node/test/spec/specTestVersioning.ts
+++ b/packages/beacon-node/test/spec/specTestVersioning.ts
@@ -14,7 +14,7 @@ import {DownloadTestsOptions} from "@lodestar/spec-test-util/downloadTests";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const ethereumConsensusSpecsTests: DownloadTestsOptions = {
-  specVersion: "v1.7.0-alpha.1",
+  specVersion: "v1.7.0-alpha.2",
   // Target directory is the host package root: 'packages/*/spec-tests'
   outputDir: path.join(__dirname, "../../spec-tests"),
   specTestsRepoUrl: "https://github.com/ethereum/consensus-specs",

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -72,7 +72,6 @@ export const defaultSkipOpts: SkipOpts = {
     /^electra\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^fulu\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^.+\/light_client\/data_collection\/.*/,
-    // Skip finality/fork_choice for Gloas (still WIP), but run sanity and transition tests
     /^gloas\/(finality|fork_choice)\/.*$/,
     /^gloas\/ssz_static\/ForkChoiceNode.*$/,
   ],

--- a/packages/beacon-node/test/spec/utils/specTestIterator.ts
+++ b/packages/beacon-node/test/spec/utils/specTestIterator.ts
@@ -72,7 +72,8 @@ export const defaultSkipOpts: SkipOpts = {
     /^electra\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^fulu\/light_client\/single_merkle_proof\/BeaconBlockBody.*/,
     /^.+\/light_client\/data_collection\/.*/,
-    /^gloas\/(finality|fork_choice|sanity|transition)\/.*$/,
+    // Skip finality/fork_choice for Gloas (still WIP), but run sanity and transition tests
+    /^gloas\/(finality|fork_choice)\/.*$/,
     /^gloas\/ssz_static\/ForkChoiceNode.*$/,
   ],
   skippedTests: [],

--- a/packages/beacon-node/test/unit/util/kzg.test.ts
+++ b/packages/beacon-node/test/unit/util/kzg.test.ts
@@ -93,7 +93,12 @@ describe("KZG", () => {
       signedBeaconBlock.message.body.blobKzgCommitments.push(commitment);
     }
 
-    const sidecars = getDataColumnSidecarsFromBlock(config, signedBeaconBlock, cellsAndProofs);
+    // Cast to fulu since we're testing with Fulu fork
+    const sidecars = getDataColumnSidecarsFromBlock(
+      config,
+      signedBeaconBlock,
+      cellsAndProofs
+    ) as fulu.DataColumnSidecars;
     const signedBlockHeader = signedBlockToSignedHeader(config, signedBeaconBlock);
 
     sidecars.forEach((sidecar, column) => {
@@ -145,5 +150,5 @@ describe("KZG", () => {
     }
     expect(recoveredSidecars.length).toBe(NUMBER_OF_COLUMNS);
     expect(ssz.fulu.DataColumnSidecars.equals(recoveredSidecars, sidecars)).toBeTruthy();
-  });
+  }, 60_000);
 });

--- a/packages/beacon-node/test/unit/util/kzg.test.ts
+++ b/packages/beacon-node/test/unit/util/kzg.test.ts
@@ -93,12 +93,7 @@ describe("KZG", () => {
       signedBeaconBlock.message.body.blobKzgCommitments.push(commitment);
     }
 
-    // Cast to fulu since we're testing with Fulu fork
-    const sidecars = getDataColumnSidecarsFromBlock(
-      config,
-      signedBeaconBlock,
-      cellsAndProofs
-    ) as fulu.DataColumnSidecars;
+    const sidecars = getDataColumnSidecarsFromBlock(config, signedBeaconBlock, cellsAndProofs);
     const signedBlockHeader = signedBlockToSignedHeader(config, signedBeaconBlock);
 
     sidecars.forEach((sidecar, column) => {

--- a/packages/beacon-node/test/unit/util/kzg.test.ts
+++ b/packages/beacon-node/test/unit/util/kzg.test.ts
@@ -145,5 +145,5 @@ describe("KZG", () => {
     }
     expect(recoveredSidecars.length).toBe(NUMBER_OF_COLUMNS);
     expect(ssz.fulu.DataColumnSidecars.equals(recoveredSidecars, sidecars)).toBeTruthy();
-  }, 60_000);
+  });
 });

--- a/packages/config/src/chainConfig/configs/mainnet.ts
+++ b/packages/config/src/chainConfig/configs/mainnet.ts
@@ -70,8 +70,8 @@ export const chainConfig: ChainConfig = {
   SECONDS_PER_ETH1_BLOCK: 14,
   // 2**8 (= 256) epochs ~27 hours
   MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256,
-  // 2**12 (= 4,096) epochs ~18 days
-  MIN_BUILDER_WITHDRAWABILITY_DELAY: 64, // Updated in v1.7.0-alpha.2 (was 4096)
+  // 2**6 (= 64) epochs
+  MIN_BUILDER_WITHDRAWABILITY_DELAY: 64,
   // 2**8 (= 256) epochs ~27 hours
   SHARD_COMMITTEE_PERIOD: 256,
   // 2**11 (= 2,048) Eth1 blocks ~8 hours

--- a/packages/config/src/chainConfig/configs/mainnet.ts
+++ b/packages/config/src/chainConfig/configs/mainnet.ts
@@ -71,7 +71,7 @@ export const chainConfig: ChainConfig = {
   // 2**8 (= 256) epochs ~27 hours
   MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256,
   // 2**12 (= 4,096) epochs ~18 days
-  MIN_BUILDER_WITHDRAWABILITY_DELAY: 4096,
+  MIN_BUILDER_WITHDRAWABILITY_DELAY: 64, // Updated in v1.7.0-alpha.2 (was 4096)
   // 2**8 (= 256) epochs ~27 hours
   SHARD_COMMITTEE_PERIOD: 256,
   // 2**11 (= 2,048) Eth1 blocks ~8 hours

--- a/packages/config/src/chainConfig/configs/minimal.ts
+++ b/packages/config/src/chainConfig/configs/minimal.ts
@@ -64,7 +64,7 @@ export const chainConfig: ChainConfig = {
   SECONDS_PER_ETH1_BLOCK: 14,
   // 2**8 (= 256) epochs
   MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256,
-  // [customized] 2**3 (= 8) epochs
+  // [customized] 2**1 (= 2) epochs
   MIN_BUILDER_WITHDRAWABILITY_DELAY: 2,
   // [customized] higher frequency of committee turnover and faster time to acceptable voluntary exit
   SHARD_COMMITTEE_PERIOD: 64,

--- a/packages/config/src/chainConfig/configs/minimal.ts
+++ b/packages/config/src/chainConfig/configs/minimal.ts
@@ -65,7 +65,7 @@ export const chainConfig: ChainConfig = {
   // 2**8 (= 256) epochs
   MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256,
   // [customized] 2**3 (= 8) epochs
-  MIN_BUILDER_WITHDRAWABILITY_DELAY: 8,
+  MIN_BUILDER_WITHDRAWABILITY_DELAY: 2,
   // [customized] higher frequency of committee turnover and faster time to acceptable voluntary exit
   SHARD_COMMITTEE_PERIOD: 64,
   // [customized] process deposits more quickly, but insecure

--- a/packages/state-transition/src/block/isValidIndexedPayloadAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedPayloadAttestation.ts
@@ -17,7 +17,7 @@ export function isValidIndexedPayloadAttestation(
 
   if (verifySignature) {
     return verifySignatureSet(
-      getIndexedPayloadAttestationSignatureSet(state, indexedPayloadAttestation),
+      getIndexedPayloadAttestationSignatureSet(state.config, indexedPayloadAttestation),
       state.epochCtx.index2pubkey
     );
   }

--- a/packages/state-transition/src/block/processDepositRequest.ts
+++ b/packages/state-transition/src/block/processDepositRequest.ts
@@ -14,7 +14,8 @@ export function applyDepositForBuilder(
   pubkey: BLSPubkey,
   withdrawalCredentials: Bytes32,
   amount: UintNum64,
-  signature: Bytes32
+  signature: Bytes32,
+  slot: UintNum64
 ): void {
   const builderIndex = findBuilderIndexByPubkey(state, pubkey);
 
@@ -25,7 +26,7 @@ export function applyDepositForBuilder(
   } else {
     // New builder - verify signature and add to registry
     if (isValidDepositSignature(state.config, pubkey, withdrawalCredentials, amount, signature)) {
-      addBuilderToRegistry(state, pubkey, withdrawalCredentials, amount);
+      addBuilderToRegistry(state, pubkey, withdrawalCredentials, amount, slot);
     }
   }
 }
@@ -38,9 +39,11 @@ function addBuilderToRegistry(
   state: CachedBeaconStateGloas,
   pubkey: BLSPubkey,
   withdrawalCredentials: Bytes32,
-  amount: UintNum64
+  amount: UintNum64,
+  slot: UintNum64
 ): void {
   const currentEpoch = computeEpochAtSlot(state.slot);
+  const depositEpoch = computeEpochAtSlot(slot);
 
   // Try to find a reusable slot from an exited builder with zero balance
   let builderIndex = state.builders.length;
@@ -58,7 +61,7 @@ function addBuilderToRegistry(
     version: withdrawalCredentials[0],
     executionAddress: withdrawalCredentials.subarray(12),
     balance: amount,
-    depositEpoch: currentEpoch,
+    depositEpoch: depositEpoch,
     withdrawableEpoch: FAR_FUTURE_EPOCH,
   });
 
@@ -93,7 +96,7 @@ export function processDepositRequest(
     // Route to builder if it's an existing builder OR has builder prefix and is not a validator
     if (isBuilder || (isBuilderPrefix && !isValidator)) {
       // Apply builder deposits immediately
-      applyDepositForBuilder(stateGloas, pubkey, withdrawalCredentials, amount, signature);
+      applyDepositForBuilder(stateGloas, pubkey, withdrawalCredentials, amount, signature, state.slot);
       return;
     }
   }

--- a/packages/state-transition/src/block/processExecutionPayloadBid.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadBid.ts
@@ -63,6 +63,14 @@ export function processExecutionPayloadBid(state: CachedBeaconStateGloas, block:
     throw Error(`Prev randao ${toHex(bid.prevRandao)} of bid does not match state's randao mix ${toHex(stateRandao)}`);
   }
 
+  // Verify commitments are under limit (moved from envelope processing in v1.7.0-alpha.2)
+  const maxBlobsPerBlock = state.config.getMaxBlobsPerBlock(state.epochCtx.epoch);
+  if (bid.blobKzgCommitments.length > maxBlobsPerBlock) {
+    throw Error(
+      `Kzg commitments exceed limit commitment.length=${bid.blobKzgCommitments.length} limit=${maxBlobsPerBlock}`
+    );
+  }
+
   if (amount > 0) {
     const pendingPaymentView = ssz.gloas.BuilderPendingPayment.toViewDU({
       weight: 0,

--- a/packages/state-transition/src/block/processExecutionPayloadBid.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadBid.ts
@@ -63,11 +63,11 @@ export function processExecutionPayloadBid(state: CachedBeaconStateGloas, block:
     throw Error(`Prev randao ${toHex(bid.prevRandao)} of bid does not match state's randao mix ${toHex(stateRandao)}`);
   }
 
-  // Verify commitments are under limit (moved from envelope processing in v1.7.0-alpha.2)
+  // Verify commitments are under limit
   const maxBlobsPerBlock = state.config.getMaxBlobsPerBlock(state.epochCtx.epoch);
   if (bid.blobKzgCommitments.length > maxBlobsPerBlock) {
     throw Error(
-      `Kzg commitments exceed limit commitment.length=${bid.blobKzgCommitments.length} limit=${maxBlobsPerBlock}`
+      `Kzg commitments exceed limit commitments.length=${bid.blobKzgCommitments.length} limit=${maxBlobsPerBlock}`
     );
   }
 

--- a/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
@@ -96,12 +96,8 @@ function validateExecutionPayloadEnvelope(
     );
   }
 
-  const envelopeKzgRoot = ssz.deneb.BlobKzgCommitments.hashTreeRoot(envelope.blobKzgCommitments);
-  if (!byteArrayEquals(committedBid.blobKzgCommitmentsRoot, envelopeKzgRoot)) {
-    throw new Error(
-      `Kzg commitment root mismatch between envelope and committed bid envelope=${toRootHex(envelopeKzgRoot)} committedBid=${toRootHex(committedBid.blobKzgCommitmentsRoot)}`
-    );
-  }
+  // [Removed in v1.7.0-alpha.2] blobKzgCommitments now in bid, not envelope
+  // Verification of commitments is done at bid processing time (process_execution_payload_bid)
 
   if (!byteArrayEquals(committedBid.prevRandao, payload.prevRandao)) {
     throw new Error(
@@ -146,13 +142,8 @@ function validateExecutionPayloadEnvelope(
     );
   }
 
-  // Verify commitments are under limit
-  const maxBlobsPerBlock = state.config.getMaxBlobsPerBlock(state.epochCtx.epoch);
-  if (envelope.blobKzgCommitments.length > maxBlobsPerBlock) {
-    throw new Error(
-      `Kzg commitments exceed limit commitment.length=${envelope.blobKzgCommitments.length} limit=${maxBlobsPerBlock}`
-    );
-  }
+  // [Removed in v1.7.0-alpha.2] Commitments limit check moved to process_execution_payload_bid
+  // blobKzgCommitments now in bid, not envelope
 
   // Skipped: Verify the execution payload is valid
 }

--- a/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
@@ -96,9 +96,6 @@ function validateExecutionPayloadEnvelope(
     );
   }
 
-  // [Removed in v1.7.0-alpha.2] blobKzgCommitments now in bid, not envelope
-  // Verification of commitments is done at bid processing time (process_execution_payload_bid)
-
   if (!byteArrayEquals(committedBid.prevRandao, payload.prevRandao)) {
     throw new Error(
       `Prev randao mismatch between committed bid and payload committedBid=${toHex(committedBid.prevRandao)} payload=${toHex(payload.prevRandao)}`
@@ -141,9 +138,6 @@ function validateExecutionPayloadEnvelope(
       `Timestamp mismatch between envelope's payload and state envelope=${payload.timestamp} state=${computeTimeAtSlot(state.config, state.slot, state.genesisTime)}`
     );
   }
-
-  // [Removed in v1.7.0-alpha.2] Commitments limit check moved to process_execution_payload_bid
-  // blobKzgCommitments now in bid, not envelope
 
   // Skipped: Verify the execution payload is valid
 }

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -249,6 +249,10 @@ function getPendingPartialWithdrawals(
     numPriorWithdrawal + MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
     MAX_WITHDRAWALS_PER_PAYLOAD - 1
   );
+  // There must be at least one space reserved for validator sweep withdrawals
+  if (numPriorWithdrawal > partialWithdrawalBound) {
+    throw Error(`Prior withdrawals exceed limit: ${numPriorWithdrawal} > ${partialWithdrawalBound}`);
+  }
 
   // MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP = 8, PENDING_PARTIAL_WITHDRAWALS_LIMIT: 134217728 so we should only call getAllReadonly() if it makes sense
   // pendingPartialWithdrawals comes from EIP-7002 smart contract where it takes fee so it's more likely than not validator is in correct condition to withdraw
@@ -309,6 +313,11 @@ function getValidatorsSweepWithdrawals(
   numPriorWithdrawal: number,
   validatorBalanceAfterWithdrawals: Map<ValidatorIndex, number>
 ): {sweepWithdrawals: capella.Withdrawal[]; processedCount: number} {
+  // There must be at least one space reserved for validator sweep withdrawals
+  if (numPriorWithdrawal >= MAX_WITHDRAWALS_PER_PAYLOAD) {
+    throw Error(`Prior withdrawals exceed limit: ${numPriorWithdrawal} >= ${MAX_WITHDRAWALS_PER_PAYLOAD}`);
+  }
+
   const sweepWithdrawals: capella.Withdrawal[] = [];
   const epoch = state.epochCtx.epoch;
   const {validators, balances, nextWithdrawalValidatorIndex} = state;

--- a/packages/state-transition/src/block/processWithdrawals.ts
+++ b/packages/state-transition/src/block/processWithdrawals.ts
@@ -319,7 +319,7 @@ function getValidatorsSweepWithdrawals(
   // Just run a bounded loop max iterating over all withdrawals
   // however breaks out once we have MAX_WITHDRAWALS_PER_PAYLOAD
   for (let n = 0; n < validatorsLimit; n++) {
-    if (sweepWithdrawals.length + numPriorWithdrawal === MAX_WITHDRAWALS_PER_PAYLOAD) {
+    if (sweepWithdrawals.length + numPriorWithdrawal >= MAX_WITHDRAWALS_PER_PAYLOAD) {
       break;
     }
 

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -4,7 +4,6 @@ import {BeaconConfig, ChainConfig, createBeaconConfig} from "@lodestar/config";
 import {
   ATTESTATION_SUBNET_COUNT,
   DOMAIN_BEACON_PROPOSER,
-  DOMAIN_PTC_ATTESTER,
   EFFECTIVE_BALANCE_INCREMENT,
   FAR_FUTURE_EPOCH,
   ForkSeq,

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -37,7 +37,7 @@ import {
 import {
   computeActivationExitEpoch,
   computeEpochAtSlot,
-  computePayloadTimelinessCommitteeForSlot,
+  computePayloadTimelinessCommittee,
   computeProposers,
   computeSyncPeriodAtEpoch,
   getActivationChurnLimit,
@@ -235,10 +235,8 @@ export class EpochCache {
   /** TODO: Indexed SyncCommitteeCache */
   nextSyncCommitteeIndexed: SyncCommitteeCache;
 
-  // PTC for current epoch, lazily computed per-slot
-  payloadTimelinessCommittee: (Uint32Array | null)[];
-  // Seed for computing PTC on demand (null if pre-gloas)
-  ptcEpochSeed: Uint8Array | null;
+  // PTC for current epoch, computed eagerly at epoch transition
+  payloadTimelinessCommittee: Uint32Array[];
 
   // TODO: Helper stats
   syncPeriod: SyncPeriod;
@@ -277,8 +275,7 @@ export class EpochCache {
     previousTargetUnslashedBalanceIncrements: number;
     currentSyncCommitteeIndexed: SyncCommitteeCache;
     nextSyncCommitteeIndexed: SyncCommitteeCache;
-    payloadTimelinessCommittee: (Uint32Array | null)[];
-    ptcEpochSeed: Uint8Array | null;
+    payloadTimelinessCommittee: Uint32Array[];
     epoch: Epoch;
     syncPeriod: SyncPeriod;
   }) {
@@ -310,7 +307,6 @@ export class EpochCache {
     this.currentSyncCommitteeIndexed = data.currentSyncCommitteeIndexed;
     this.nextSyncCommitteeIndexed = data.nextSyncCommitteeIndexed;
     this.payloadTimelinessCommittee = data.payloadTimelinessCommittee;
-    this.ptcEpochSeed = data.ptcEpochSeed;
     this.epoch = data.epoch;
     this.syncPeriod = data.syncPeriod;
   }
@@ -461,11 +457,16 @@ export class EpochCache {
       nextSyncCommitteeIndexed = new SyncCommitteeCacheEmpty();
     }
 
-    // PTC is computed lazily per-slot on demand. Just store the seed here.
-    let ptcEpochSeed: Uint8Array | null = null;
-    const payloadTimelinessCommittee: (Uint32Array | null)[] = new Array(SLOTS_PER_EPOCH).fill(null);
+    // Compute PTC eagerly for all slots in the epoch
+    let payloadTimelinessCommittee: Uint32Array[] = [];
     if (currentEpoch >= config.GLOAS_FORK_EPOCH) {
-      ptcEpochSeed = getSeed(state, currentEpoch, DOMAIN_PTC_ATTESTER);
+      const ptcSeed = getSeed(state, currentEpoch, DOMAIN_PTC_ATTESTER);
+      payloadTimelinessCommittee = computePayloadTimelinessCommittee(
+        ptcSeed,
+        currentEpoch,
+        currentShuffling.committees,
+        effectiveBalanceIncrements
+      );
     }
 
     // Precompute churnLimit for efficient initiateValidatorExit() during block proposing MUST be recompute everytime the
@@ -541,8 +542,7 @@ export class EpochCache {
       currentTargetUnslashedBalanceIncrements,
       currentSyncCommitteeIndexed,
       nextSyncCommitteeIndexed,
-      payloadTimelinessCommittee: payloadTimelinessCommittee,
-      ptcEpochSeed,
+      payloadTimelinessCommittee,
       epoch: currentEpoch,
       syncPeriod: computeSyncPeriodAtEpoch(currentEpoch),
     });
@@ -589,7 +589,6 @@ export class EpochCache {
       currentSyncCommitteeIndexed: this.currentSyncCommitteeIndexed,
       nextSyncCommitteeIndexed: this.nextSyncCommitteeIndexed,
       payloadTimelinessCommittee: this.payloadTimelinessCommittee,
-      ptcEpochSeed: this.ptcEpochSeed,
       epoch: this.epoch,
       syncPeriod: this.syncPeriod,
     });
@@ -700,9 +699,13 @@ export class EpochCache {
 
     this.proposersPrevEpoch = this.proposers;
     if (upcomingEpoch >= this.config.GLOAS_FORK_EPOCH) {
-      // Store seed for lazy per-slot PTC computation and reset cache
-      this.ptcEpochSeed = getSeed(state, upcomingEpoch, DOMAIN_PTC_ATTESTER);
-      this.payloadTimelinessCommittee = new Array(SLOTS_PER_EPOCH).fill(null);
+      const ptcSeed = getSeed(state, upcomingEpoch, DOMAIN_PTC_ATTESTER);
+      this.payloadTimelinessCommittee = computePayloadTimelinessCommittee(
+        ptcSeed,
+        upcomingEpoch,
+        this.currentShuffling.committees,
+        this.effectiveBalanceIncrements
+      );
     }
     if (upcomingEpoch >= this.config.FULU_FORK_EPOCH) {
       // Populate proposer cache with lookahead from state
@@ -1032,22 +1035,7 @@ export class EpochCache {
       throw new Error(`Payload Timeliness Committee is not available for slot=${slot}`);
     }
 
-    const slotIndex = slot % SLOTS_PER_EPOCH;
-    let cached = this.payloadTimelinessCommittee[slotIndex];
-    if (cached === null) {
-      if (this.ptcEpochSeed === null) {
-        throw new Error("PTC epoch seed is not available");
-      }
-      const slotCommittees = this.currentShuffling.committees[slotIndex];
-      cached = computePayloadTimelinessCommitteeForSlot(
-        this.ptcEpochSeed,
-        slot,
-        slotCommittees,
-        this.effectiveBalanceIncrements
-      );
-      this.payloadTimelinessCommittee[slotIndex] = cached;
-    }
-    return cached;
+    return this.payloadTimelinessCommittee[slot % SLOTS_PER_EPOCH];
   }
 
   getIndexedPayloadAttestation(

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -275,7 +275,7 @@ export class EpochCache {
     previousTargetUnslashedBalanceIncrements: number;
     currentSyncCommitteeIndexed: SyncCommitteeCache;
     nextSyncCommitteeIndexed: SyncCommitteeCache;
-    payloadTimelinessCommittee: Uint32Array[];
+    payloadTimelinessCommittees: Uint32Array[];
     epoch: Epoch;
     syncPeriod: SyncPeriod;
   }) {
@@ -306,7 +306,7 @@ export class EpochCache {
     this.previousTargetUnslashedBalanceIncrements = data.previousTargetUnslashedBalanceIncrements;
     this.currentSyncCommitteeIndexed = data.currentSyncCommitteeIndexed;
     this.nextSyncCommitteeIndexed = data.nextSyncCommitteeIndexed;
-    this.payloadTimelinessCommittees = data.payloadTimelinessCommittee;
+    this.payloadTimelinessCommittees = data.payloadTimelinessCommittees;
     this.epoch = data.epoch;
     this.syncPeriod = data.syncPeriod;
   }
@@ -458,9 +458,9 @@ export class EpochCache {
     }
 
     // Compute PTC eagerly for all slots in the epoch
-    let payloadTimelinessCommittee: Uint32Array[] = [];
+    let payloadTimelinessCommittees: Uint32Array[] = [];
     if (currentEpoch >= config.GLOAS_FORK_EPOCH) {
-      payloadTimelinessCommittee = computePayloadTimelinessCommitteesForEpoch(
+      payloadTimelinessCommittees = computePayloadTimelinessCommitteesForEpoch(
         state,
         currentEpoch,
         currentShuffling.committees,
@@ -541,7 +541,7 @@ export class EpochCache {
       currentTargetUnslashedBalanceIncrements,
       currentSyncCommitteeIndexed,
       nextSyncCommitteeIndexed,
-      payloadTimelinessCommittee,
+      payloadTimelinessCommittees,
       epoch: currentEpoch,
       syncPeriod: computeSyncPeriodAtEpoch(currentEpoch),
     });
@@ -587,7 +587,7 @@ export class EpochCache {
       currentTargetUnslashedBalanceIncrements: this.currentTargetUnslashedBalanceIncrements,
       currentSyncCommitteeIndexed: this.currentSyncCommitteeIndexed,
       nextSyncCommitteeIndexed: this.nextSyncCommitteeIndexed,
-      payloadTimelinessCommittee: this.payloadTimelinessCommittees,
+      payloadTimelinessCommittees: this.payloadTimelinessCommittees,
       epoch: this.epoch,
       syncPeriod: this.syncPeriod,
     });

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -4,6 +4,7 @@ import {BeaconConfig, ChainConfig, createBeaconConfig} from "@lodestar/config";
 import {
   ATTESTATION_SUBNET_COUNT,
   DOMAIN_BEACON_PROPOSER,
+  DOMAIN_PTC_ATTESTER,
   EFFECTIVE_BALANCE_INCREMENT,
   FAR_FUTURE_EPOCH,
   ForkSeq,
@@ -36,6 +37,7 @@ import {
 import {
   computeActivationExitEpoch,
   computeEpochAtSlot,
+  computePayloadTimelinessCommitteeForSlot,
   computeProposers,
   computeSyncPeriodAtEpoch,
   getActivationChurnLimit,
@@ -43,7 +45,6 @@ import {
   getSeed,
   isActiveValidator,
   isAggregatorFromCommitteeLength,
-  naiveGetPayloadTimlinessCommitteeIndices,
 } from "../util/index.js";
 import {
   AttesterDuty,
@@ -64,7 +65,7 @@ import {
   computeSyncCommitteeCache,
   getSyncCommitteeCache,
 } from "./syncCommitteeCache.js";
-import {BeaconStateAllForks, BeaconStateAltair, BeaconStateGloas, ShufflingGetter} from "./types.js";
+import {BeaconStateAllForks, BeaconStateAltair, ShufflingGetter} from "./types.js";
 
 /** `= PROPOSER_WEIGHT / (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT)` */
 export const PROPOSER_WEIGHT_FACTOR = PROPOSER_WEIGHT / (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT);
@@ -234,9 +235,10 @@ export class EpochCache {
   /** TODO: Indexed SyncCommitteeCache */
   nextSyncCommitteeIndexed: SyncCommitteeCache;
 
-  // TODO GLOAS: See if we need to cached PTC for prev/next epoch
-  // PTC for current epoch
-  payloadTimelinessCommittee: ValidatorIndex[][];
+  // PTC for current epoch, lazily computed per-slot
+  payloadTimelinessCommittee: (Uint32Array | null)[];
+  // Seed for computing PTC on demand (null if pre-gloas)
+  ptcEpochSeed: Uint8Array | null;
 
   // TODO: Helper stats
   syncPeriod: SyncPeriod;
@@ -275,7 +277,8 @@ export class EpochCache {
     previousTargetUnslashedBalanceIncrements: number;
     currentSyncCommitteeIndexed: SyncCommitteeCache;
     nextSyncCommitteeIndexed: SyncCommitteeCache;
-    payloadTimelinessCommittee: ValidatorIndex[][];
+    payloadTimelinessCommittee: (Uint32Array | null)[];
+    ptcEpochSeed: Uint8Array | null;
     epoch: Epoch;
     syncPeriod: SyncPeriod;
   }) {
@@ -307,6 +310,7 @@ export class EpochCache {
     this.currentSyncCommitteeIndexed = data.currentSyncCommitteeIndexed;
     this.nextSyncCommitteeIndexed = data.nextSyncCommitteeIndexed;
     this.payloadTimelinessCommittee = data.payloadTimelinessCommittee;
+    this.ptcEpochSeed = data.ptcEpochSeed;
     this.epoch = data.epoch;
     this.syncPeriod = data.syncPeriod;
   }
@@ -457,15 +461,11 @@ export class EpochCache {
       nextSyncCommitteeIndexed = new SyncCommitteeCacheEmpty();
     }
 
-    // Compute PTC for this epoch
-    let payloadTimelinessCommittee: ValidatorIndex[][] = [];
+    // PTC is computed lazily per-slot on demand. Just store the seed here.
+    let ptcEpochSeed: Uint8Array | null = null;
+    const payloadTimelinessCommittee: (Uint32Array | null)[] = new Array(SLOTS_PER_EPOCH).fill(null);
     if (currentEpoch >= config.GLOAS_FORK_EPOCH) {
-      payloadTimelinessCommittee = naiveGetPayloadTimlinessCommitteeIndices(
-        state as BeaconStateGloas,
-        currentShuffling,
-        effectiveBalanceIncrements,
-        currentEpoch
-      );
+      ptcEpochSeed = getSeed(state, currentEpoch, DOMAIN_PTC_ATTESTER);
     }
 
     // Precompute churnLimit for efficient initiateValidatorExit() during block proposing MUST be recompute everytime the
@@ -542,6 +542,7 @@ export class EpochCache {
       currentSyncCommitteeIndexed,
       nextSyncCommitteeIndexed,
       payloadTimelinessCommittee: payloadTimelinessCommittee,
+      ptcEpochSeed,
       epoch: currentEpoch,
       syncPeriod: computeSyncPeriodAtEpoch(currentEpoch),
     });
@@ -588,6 +589,7 @@ export class EpochCache {
       currentSyncCommitteeIndexed: this.currentSyncCommitteeIndexed,
       nextSyncCommitteeIndexed: this.nextSyncCommitteeIndexed,
       payloadTimelinessCommittee: this.payloadTimelinessCommittee,
+      ptcEpochSeed: this.ptcEpochSeed,
       epoch: this.epoch,
       syncPeriod: this.syncPeriod,
     });
@@ -698,12 +700,9 @@ export class EpochCache {
 
     this.proposersPrevEpoch = this.proposers;
     if (upcomingEpoch >= this.config.GLOAS_FORK_EPOCH) {
-      this.payloadTimelinessCommittee = naiveGetPayloadTimlinessCommitteeIndices(
-        state as BeaconStateGloas,
-        this.currentShuffling,
-        this.effectiveBalanceIncrements,
-        upcomingEpoch
-      );
+      // Store seed for lazy per-slot PTC computation and reset cache
+      this.ptcEpochSeed = getSeed(state, upcomingEpoch, DOMAIN_PTC_ATTESTER);
+      this.payloadTimelinessCommittee = new Array(SLOTS_PER_EPOCH).fill(null);
     }
     if (upcomingEpoch >= this.config.FULU_FORK_EPOCH) {
       // Populate proposer cache with lookahead from state
@@ -1022,18 +1021,33 @@ export class EpochCache {
     return this.epoch >= this.config.ELECTRA_FORK_EPOCH;
   }
 
-  getPayloadTimelinessCommittee(slot: Slot): ValidatorIndex[] {
+  getPayloadTimelinessCommittee(slot: Slot): Uint32Array {
     const epoch = computeEpochAtSlot(slot);
 
     if (epoch < this.config.GLOAS_FORK_EPOCH) {
       throw new Error("Payload Timeliness Committee is not available before gloas fork");
     }
 
-    if (epoch === this.epoch) {
-      return this.payloadTimelinessCommittee[slot % SLOTS_PER_EPOCH];
+    if (epoch !== this.epoch) {
+      throw new Error(`Payload Timeliness Committee is not available for slot=${slot}`);
     }
 
-    throw new Error(`Payload Timeliness Committee is not available for slot=${slot}`);
+    const slotIndex = slot % SLOTS_PER_EPOCH;
+    let cached = this.payloadTimelinessCommittee[slotIndex];
+    if (cached === null) {
+      if (this.ptcEpochSeed === null) {
+        throw new Error("PTC epoch seed is not available");
+      }
+      const slotCommittees = this.currentShuffling.committees[slotIndex];
+      cached = computePayloadTimelinessCommitteeForSlot(
+        this.ptcEpochSeed,
+        slot,
+        slotCommittees,
+        this.effectiveBalanceIncrements
+      );
+      this.payloadTimelinessCommittee[slotIndex] = cached;
+    }
+    return cached;
   }
 
   getIndexedPayloadAttestation(

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -236,7 +236,7 @@ export class EpochCache {
 
   // TODO GLOAS: See if we need to cached PTC for prev/next epoch
   // PTC for current epoch, computed eagerly at epoch transition
-  payloadTimelinessCommittee: Uint32Array[];
+  payloadTimelinessCommittees: Uint32Array[];
 
   // TODO: Helper stats
   syncPeriod: SyncPeriod;
@@ -306,7 +306,7 @@ export class EpochCache {
     this.previousTargetUnslashedBalanceIncrements = data.previousTargetUnslashedBalanceIncrements;
     this.currentSyncCommitteeIndexed = data.currentSyncCommitteeIndexed;
     this.nextSyncCommitteeIndexed = data.nextSyncCommitteeIndexed;
-    this.payloadTimelinessCommittee = data.payloadTimelinessCommittee;
+    this.payloadTimelinessCommittees = data.payloadTimelinessCommittee;
     this.epoch = data.epoch;
     this.syncPeriod = data.syncPeriod;
   }
@@ -587,7 +587,7 @@ export class EpochCache {
       currentTargetUnslashedBalanceIncrements: this.currentTargetUnslashedBalanceIncrements,
       currentSyncCommitteeIndexed: this.currentSyncCommitteeIndexed,
       nextSyncCommitteeIndexed: this.nextSyncCommitteeIndexed,
-      payloadTimelinessCommittee: this.payloadTimelinessCommittee,
+      payloadTimelinessCommittee: this.payloadTimelinessCommittees,
       epoch: this.epoch,
       syncPeriod: this.syncPeriod,
     });
@@ -698,7 +698,7 @@ export class EpochCache {
 
     this.proposersPrevEpoch = this.proposers;
     if (upcomingEpoch >= this.config.GLOAS_FORK_EPOCH) {
-      this.payloadTimelinessCommittee = computePayloadTimelinessCommitteesForEpoch(
+      this.payloadTimelinessCommittees = computePayloadTimelinessCommitteesForEpoch(
         state,
         upcomingEpoch,
         this.currentShuffling.committees,
@@ -1033,7 +1033,7 @@ export class EpochCache {
       throw new Error(`Payload Timeliness Committee is not available for slot=${slot}`);
     }
 
-    return this.payloadTimelinessCommittee[slot % SLOTS_PER_EPOCH];
+    return this.payloadTimelinessCommittees[slot % SLOTS_PER_EPOCH];
   }
 
   getIndexedPayloadAttestation(

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -235,6 +235,7 @@ export class EpochCache {
   /** TODO: Indexed SyncCommitteeCache */
   nextSyncCommitteeIndexed: SyncCommitteeCache;
 
+  // TODO GLOAS: See if we need to cached PTC for prev/next epoch
   // PTC for current epoch, computed eagerly at epoch transition
   payloadTimelinessCommittee: Uint32Array[];
 
@@ -460,9 +461,8 @@ export class EpochCache {
     // Compute PTC eagerly for all slots in the epoch
     let payloadTimelinessCommittee: Uint32Array[] = [];
     if (currentEpoch >= config.GLOAS_FORK_EPOCH) {
-      const ptcSeed = getSeed(state, currentEpoch, DOMAIN_PTC_ATTESTER);
       payloadTimelinessCommittee = computePayloadTimelinessCommittee(
-        ptcSeed,
+        state,
         currentEpoch,
         currentShuffling.committees,
         effectiveBalanceIncrements
@@ -699,9 +699,8 @@ export class EpochCache {
 
     this.proposersPrevEpoch = this.proposers;
     if (upcomingEpoch >= this.config.GLOAS_FORK_EPOCH) {
-      const ptcSeed = getSeed(state, upcomingEpoch, DOMAIN_PTC_ATTESTER);
       this.payloadTimelinessCommittee = computePayloadTimelinessCommittee(
-        ptcSeed,
+        state,
         upcomingEpoch,
         this.currentShuffling.committees,
         this.effectiveBalanceIncrements

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -36,7 +36,7 @@ import {
 import {
   computeActivationExitEpoch,
   computeEpochAtSlot,
-  computePayloadTimelinessCommittee,
+  computePayloadTimelinessCommitteesForEpoch,
   computeProposers,
   computeSyncPeriodAtEpoch,
   getActivationChurnLimit,
@@ -460,7 +460,7 @@ export class EpochCache {
     // Compute PTC eagerly for all slots in the epoch
     let payloadTimelinessCommittee: Uint32Array[] = [];
     if (currentEpoch >= config.GLOAS_FORK_EPOCH) {
-      payloadTimelinessCommittee = computePayloadTimelinessCommittee(
+      payloadTimelinessCommittee = computePayloadTimelinessCommitteesForEpoch(
         state,
         currentEpoch,
         currentShuffling.committees,
@@ -698,7 +698,7 @@ export class EpochCache {
 
     this.proposersPrevEpoch = this.proposers;
     if (upcomingEpoch >= this.config.GLOAS_FORK_EPOCH) {
-      this.payloadTimelinessCommittee = computePayloadTimelinessCommittee(
+      this.payloadTimelinessCommittee = computePayloadTimelinessCommitteesForEpoch(
         state,
         upcomingEpoch,
         this.currentShuffling.committees,

--- a/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
@@ -1,28 +1,23 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_PTC_ATTESTER} from "@lodestar/params";
-import {Slot, gloas, ssz} from "@lodestar/types";
-import {CachedBeaconStateGloas} from "../types.js";
+import {gloas, ssz} from "@lodestar/types";
 import {ISignatureSet, computeSigningRoot, createAggregateSignatureSetFromComponents} from "../util/index.js";
 
 export function getIndexedPayloadAttestationSignatureSet(
-  state: CachedBeaconStateGloas,
+  config: BeaconConfig,
   indexedPayloadAttestation: gloas.IndexedPayloadAttestation
 ): ISignatureSet {
   return createAggregateSignatureSetFromComponents(
     indexedPayloadAttestation.attestingIndices,
-    getPayloadAttestationDataSigningRoot(state.config, state.slot, indexedPayloadAttestation.data),
+    getPayloadAttestationDataSigningRoot(config, indexedPayloadAttestation.data),
     indexedPayloadAttestation.signature
   );
 }
 
 export function getPayloadAttestationDataSigningRoot(
   config: BeaconConfig,
-  _stateSlot: Slot,
   data: gloas.PayloadAttestationData
 ): Uint8Array {
-  // Use attestation data's slot for domain epoch calculation, not state slot
-  // Spec: get_domain(state, DOMAIN_PTC_ATTESTER, compute_epoch_at_slot(attestation.data.slot))
-  // https://github.com/ethereum/consensus-specs/pull/4836
   const domain = config.getDomain(data.slot, DOMAIN_PTC_ATTESTER);
 
   return computeSigningRoot(ssz.gloas.PayloadAttestationData, data, domain);

--- a/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
+++ b/packages/state-transition/src/signatureSets/indexedPayloadAttestation.ts
@@ -17,10 +17,13 @@ export function getIndexedPayloadAttestationSignatureSet(
 
 export function getPayloadAttestationDataSigningRoot(
   config: BeaconConfig,
-  stateSlot: Slot,
+  _stateSlot: Slot,
   data: gloas.PayloadAttestationData
 ): Uint8Array {
-  const domain = config.getDomain(stateSlot, DOMAIN_PTC_ATTESTER);
+  // Use attestation data's slot for domain epoch calculation, not state slot
+  // Spec: get_domain(state, DOMAIN_PTC_ATTESTER, compute_epoch_at_slot(attestation.data.slot))
+  // https://github.com/ethereum/consensus-specs/pull/4836
+  const domain = config.getDomain(data.slot, DOMAIN_PTC_ATTESTER);
 
   return computeSigningRoot(ssz.gloas.PayloadAttestationData, data, domain);
 }

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -87,6 +87,9 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
 function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void {
   const validatorPubkeys = new Set<string>();
 
+  // Track builder pubkeys added during the loop (builders list starts empty at fork transition)
+  const builderPubkeys = new Set<string>();
+
   const remainingPendingDeposits = state.pendingDeposits.sliceFrom(state.pendingDeposits.length);
   for (let i = 0; i < state.pendingDeposits.length; i++) {
     const deposit = state.pendingDeposits.getReadonly(i);
@@ -101,16 +104,11 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
     }
 
     // If the pubkey is associated with a builder that was created in a previous iteration or it
-    // is a builder deposit, try to apply the deposit to the new/existing builder. Note that the
-    // function applyDepositForBuilder can mutate the state and may add a builder to the registry.
-    // For this reason, the set of builder pubkeys must be recomputed each iteration.
-    const builderPubkeys = new Set<string>();
-    for (let j = 0; j < state.builders.length; j++) {
-      builderPubkeys.add(toHex(state.builders.getReadonly(j).pubkey));
-    }
+    // is a builder deposit, try to apply the deposit to the new/existing builder
     const isExistingBuilder = builderPubkeys.has(pubkeyHex);
     const hasBuilderCredentials = isBuilderWithdrawalCredential(deposit.withdrawalCredentials);
     if (isExistingBuilder || hasBuilderCredentials) {
+      const buildersLenBefore = state.builders.length;
       applyDepositForBuilder(
         state,
         deposit.pubkey,
@@ -119,6 +117,10 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
         deposit.signature,
         deposit.slot
       );
+      // Track newly added builders for subsequent iterations
+      if (!isExistingBuilder && state.builders.length > buildersLenBefore) {
+        builderPubkeys.add(pubkeyHex);
+      }
       continue;
     }
 

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -91,7 +91,7 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
   // Track pubkeys of new builders added when applying deposits
   const builderPubkeys = new Set<string>();
 
-  const remainingPendingDeposits = state.pendingDeposits.sliceFrom(state.pendingDeposits.length);
+  const remainingPendingDeposits = ssz.electra.PendingDeposits.defaultViewDU(); 
   for (let i = 0; i < state.pendingDeposits.length; i++) {
     const deposit = state.pendingDeposits.getReadonly(i);
 

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -80,7 +80,7 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
 }
 
 /**
- * Applies any pending deposits for builders, effectively onboarding builders at the fork
+ * Applies any pending deposits for builders to onboard builders during the fork transition
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/fork.md#new-onboard_builders_from_pending_deposits
  */
 function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void {

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -69,6 +69,7 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
 
   const stateGloas = getCachedBeaconState(stateGloasView, stateFulu);
 
+  // Process pending builder deposits at the fork boundary
   onboardBuildersFromPendingDeposits(stateGloas);
 
   stateGloas.commit();

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -85,9 +85,10 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/fork.md#new-onboard_builders_from_pending_deposits
  */
 function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void {
+  // Track pubkeys of new validators to keep their deposits pending
   const validatorPubkeys = new Set<string>();
 
-  // Track builder pubkeys added during the loop (builders list starts empty at fork transition)
+  // Track pubkeys of new builders added when applying deposits
   const builderPubkeys = new Set<string>();
 
   const remainingPendingDeposits = state.pendingDeposits.sliceFrom(state.pendingDeposits.length);
@@ -103,8 +104,8 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
       continue;
     }
 
-    // If the pubkey is associated with a builder that was created in a previous iteration or it
-    // is a builder deposit, try to apply the deposit to the new/existing builder
+    // If the pubkey is associated with a builder that was created in a previous iteration
+    // or it is a builder deposit, try to apply the deposit to the new/existing builder
     const isExistingBuilder = builderPubkeys.has(pubkeyHex);
     const hasBuilderCredentials = isBuilderWithdrawalCredential(deposit.withdrawalCredentials);
     if (isExistingBuilder || hasBuilderCredentials) {

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -1,7 +1,12 @@
 import {SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
+import {toHex} from "@lodestar/utils";
+import {isValidDepositSignature} from "../block/processDeposit.js";
+import {applyDepositForBuilder} from "../block/processDepositRequest.js";
 import {getCachedBeaconState} from "../cache/stateCache.js";
 import {CachedBeaconStateFulu, CachedBeaconStateGloas} from "../types.js";
+import {isBuilderWithdrawalCredential} from "../util/gloas.js";
+import {isValidatorKnown} from "../util/index.js";
 
 /**
  * Upgrade a state from Fulu to Gloas.
@@ -64,10 +69,72 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
 
   const stateGloas = getCachedBeaconState(stateGloasView, stateFulu);
 
+  // Applies any pending deposits for builders, effectively onboarding builders at the fork.
+  // Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/fork.md#new-onboard_builders_from_pending_deposits
+  onboardBuildersFromPendingDeposits(stateGloas);
+
   stateGloas.commit();
   // Clear cache to ensure the cache of fulu fields is not used by new gloas fields
   // biome-ignore lint/complexity/useLiteralKeys: It is a protected attribute
   stateGloas["clearCache"]();
 
   return stateGloas;
+}
+
+function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void {
+  const trackedValidatorPubkeys = new Set<string>();
+
+  // Pre-compute builder pubkeys set for O(1) lookup instead of O(n) per deposit
+  const builderPubkeys = new Set<string>();
+  for (let i = 0; i < state.builders.length; i++) {
+    builderPubkeys.add(toHex(state.builders.getReadonly(i).pubkey));
+  }
+
+  const remainingPendingDeposits = state.pendingDeposits.sliceFrom(state.pendingDeposits.length);
+  for (let i = 0; i < state.pendingDeposits.length; i++) {
+    const deposit = state.pendingDeposits.getReadonly(i);
+
+    const validatorIndex = state.epochCtx.getValidatorIndex(deposit.pubkey);
+    const pubkeyHex = toHex(deposit.pubkey);
+
+    // Deposits for existing validators stay in pending queue
+    if (isValidatorKnown(state, validatorIndex) || trackedValidatorPubkeys.has(pubkeyHex)) {
+      remainingPendingDeposits.push(deposit);
+      continue;
+    }
+
+    // If deposit is for an existing builder or has builder credentials, apply it
+    const isExistingBuilder = builderPubkeys.has(pubkeyHex);
+    const hasBuilderCredentials = isBuilderWithdrawalCredential(deposit.withdrawalCredentials);
+    if (isExistingBuilder || hasBuilderCredentials) {
+      applyDepositForBuilder(
+        state,
+        deposit.pubkey,
+        deposit.withdrawalCredentials,
+        deposit.amount,
+        deposit.signature,
+        deposit.slot
+      );
+      // Track newly added builder pubkeys for subsequent deposits
+      builderPubkeys.add(pubkeyHex);
+      continue;
+    }
+
+    // Track new validator pubkeys with valid signatures so subsequent deposits don't create a builder
+    // Deposits with invalid signatures are dropped here since they would fail in apply_pending_deposit anyway.
+    if (
+      isValidDepositSignature(
+        state.config,
+        deposit.pubkey,
+        deposit.withdrawalCredentials,
+        deposit.amount,
+        deposit.signature
+      )
+    ) {
+      trackedValidatorPubkeys.add(pubkeyHex);
+      remainingPendingDeposits.push(deposit);
+    }
+  }
+
+  state.pendingDeposits = remainingPendingDeposits;
 }

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -91,7 +91,7 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
   // Track pubkeys of new builders added when applying deposits
   const builderPubkeys = new Set<string>();
 
-  const remainingPendingDeposits = ssz.electra.PendingDeposits.defaultViewDU(); 
+  const remainingPendingDeposits = ssz.electra.PendingDeposits.defaultViewDU();
   for (let i = 0; i < state.pendingDeposits.length; i++) {
     const deposit = state.pendingDeposits.getReadonly(i);
 

--- a/packages/state-transition/src/slot/upgradeStateToGloas.ts
+++ b/packages/state-transition/src/slot/upgradeStateToGloas.ts
@@ -69,8 +69,6 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
 
   const stateGloas = getCachedBeaconState(stateGloasView, stateFulu);
 
-  // Applies any pending deposits for builders, effectively onboarding builders at the fork.
-  // Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/fork.md#new-onboard_builders_from_pending_deposits
   onboardBuildersFromPendingDeposits(stateGloas);
 
   stateGloas.commit();
@@ -81,14 +79,12 @@ export function upgradeStateToGloas(stateFulu: CachedBeaconStateFulu): CachedBea
   return stateGloas;
 }
 
+/**
+ * Applies any pending deposits for builders, effectively onboarding builders at the fork
+ * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/fork.md#new-onboard_builders_from_pending_deposits
+ */
 function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void {
-  const trackedValidatorPubkeys = new Set<string>();
-
-  // Pre-compute builder pubkeys set for O(1) lookup instead of O(n) per deposit
-  const builderPubkeys = new Set<string>();
-  for (let i = 0; i < state.builders.length; i++) {
-    builderPubkeys.add(toHex(state.builders.getReadonly(i).pubkey));
-  }
+  const validatorPubkeys = new Set<string>();
 
   const remainingPendingDeposits = state.pendingDeposits.sliceFrom(state.pendingDeposits.length);
   for (let i = 0; i < state.pendingDeposits.length; i++) {
@@ -98,12 +94,19 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
     const pubkeyHex = toHex(deposit.pubkey);
 
     // Deposits for existing validators stay in pending queue
-    if (isValidatorKnown(state, validatorIndex) || trackedValidatorPubkeys.has(pubkeyHex)) {
+    if (isValidatorKnown(state, validatorIndex) || validatorPubkeys.has(pubkeyHex)) {
       remainingPendingDeposits.push(deposit);
       continue;
     }
 
-    // If deposit is for an existing builder or has builder credentials, apply it
+    // If the pubkey is associated with a builder that was created in a previous iteration or it
+    // is a builder deposit, try to apply the deposit to the new/existing builder. Note that the
+    // function applyDepositForBuilder can mutate the state and may add a builder to the registry.
+    // For this reason, the set of builder pubkeys must be recomputed each iteration.
+    const builderPubkeys = new Set<string>();
+    for (let j = 0; j < state.builders.length; j++) {
+      builderPubkeys.add(toHex(state.builders.getReadonly(j).pubkey));
+    }
     const isExistingBuilder = builderPubkeys.has(pubkeyHex);
     const hasBuilderCredentials = isBuilderWithdrawalCredential(deposit.withdrawalCredentials);
     if (isExistingBuilder || hasBuilderCredentials) {
@@ -115,13 +118,13 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
         deposit.signature,
         deposit.slot
       );
-      // Track newly added builder pubkeys for subsequent deposits
-      builderPubkeys.add(pubkeyHex);
       continue;
     }
 
-    // Track new validator pubkeys with valid signatures so subsequent deposits don't create a builder
-    // Deposits with invalid signatures are dropped here since they would fail in apply_pending_deposit anyway.
+    // If there is a pending deposit for a new validator that has a valid signature, track the
+    // pubkey so that subsequent builder deposits for the same pubkey stay in pending (applied to
+    // the validator later) rather than creating a builder. Deposits with invalid signatures are
+    // dropped here since they would fail in apply_pending_deposit anyway.
     if (
       isValidDepositSignature(
         state.config,
@@ -131,7 +134,7 @@ function onboardBuildersFromPendingDeposits(state: CachedBeaconStateGloas): void
         deposit.signature
       )
     ) {
-      trackedValidatorPubkeys.add(pubkeyHex);
+      validatorPubkeys.add(pubkeyHex);
       remainingPendingDeposits.push(deposit);
     }
   }

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -28,13 +28,18 @@ export function getBuilderPaymentQuorumThreshold(state: CachedBeaconStateGloas):
   return Math.floor(quorum / BUILDER_PAYMENT_THRESHOLD_DENOMINATOR);
 }
 
+function hasBuilderIndexFlag(index: number): boolean {
+  // Equivalent to `(index & BUILDER_INDEX_FLAG) != 0`
+  return Math.floor(index / BUILDER_INDEX_FLAG) % 2 === 1;
+}
+
 /**
  * Check if a validator index represents a builder (has the builder flag set).
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-is_builder_index
  */
 export function isBuilderIndex(validatorIndex: number): boolean {
-  // Note: Can't use bitwise AND (&) because BUILDER_INDEX_FLAG exceeds 32 bits
-  return validatorIndex >= BUILDER_INDEX_FLAG;
+  // Note: Can't use bitwise AND (&) because BUILDER_INDEX_FLAG exceeds 32 bits in JS bitwise operations.
+  return hasBuilderIndexFlag(validatorIndex);
 }
 
 /**
@@ -42,8 +47,8 @@ export function isBuilderIndex(validatorIndex: number): boolean {
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-convert_builder_index_to_validator_index
  */
 export function convertBuilderIndexToValidatorIndex(builderIndex: BuilderIndex): ValidatorIndex {
-  // Note: Can't use bitwise OR (|) because BUILDER_INDEX_FLAG exceeds 32 bits
-  return builderIndex + BUILDER_INDEX_FLAG;
+  // Note: Can't use bitwise OR (|) because BUILDER_INDEX_FLAG exceeds 32 bits in JS bitwise operations.
+  return hasBuilderIndexFlag(builderIndex) ? builderIndex : builderIndex + BUILDER_INDEX_FLAG;
 }
 
 /**
@@ -51,8 +56,8 @@ export function convertBuilderIndexToValidatorIndex(builderIndex: BuilderIndex):
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-convert_validator_index_to_builder_index
  */
 export function convertValidatorIndexToBuilderIndex(validatorIndex: ValidatorIndex): BuilderIndex {
-  // Note: Can't use bitwise AND (&) because BUILDER_INDEX_FLAG exceeds 32 bits
-  return validatorIndex - BUILDER_INDEX_FLAG;
+  // Note: Can't use bitwise AND (&) because BUILDER_INDEX_FLAG exceeds 32 bits in JS bitwise operations.
+  return hasBuilderIndexFlag(validatorIndex) ? validatorIndex - BUILDER_INDEX_FLAG : validatorIndex;
 }
 
 /**

--- a/packages/state-transition/src/util/gloas.ts
+++ b/packages/state-transition/src/util/gloas.ts
@@ -33,7 +33,8 @@ export function getBuilderPaymentQuorumThreshold(state: CachedBeaconStateGloas):
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-is_builder_index
  */
 export function isBuilderIndex(validatorIndex: number): boolean {
-  return (validatorIndex & BUILDER_INDEX_FLAG) !== 0;
+  // Note: Can't use bitwise AND (&) because BUILDER_INDEX_FLAG exceeds 32 bits
+  return validatorIndex >= BUILDER_INDEX_FLAG;
 }
 
 /**
@@ -41,7 +42,8 @@ export function isBuilderIndex(validatorIndex: number): boolean {
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-convert_builder_index_to_validator_index
  */
 export function convertBuilderIndexToValidatorIndex(builderIndex: BuilderIndex): ValidatorIndex {
-  return builderIndex | BUILDER_INDEX_FLAG;
+  // Note: Can't use bitwise OR (|) because BUILDER_INDEX_FLAG exceeds 32 bits
+  return builderIndex + BUILDER_INDEX_FLAG;
 }
 
 /**
@@ -49,7 +51,8 @@ export function convertBuilderIndexToValidatorIndex(builderIndex: BuilderIndex):
  * Spec: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-convert_validator_index_to_builder_index
  */
 export function convertValidatorIndexToBuilderIndex(validatorIndex: ValidatorIndex): BuilderIndex {
-  return validatorIndex & ~BUILDER_INDEX_FLAG;
+  // Note: Can't use bitwise AND (&) because BUILDER_INDEX_FLAG exceeds 32 bits
+  return validatorIndex - BUILDER_INDEX_FLAG;
 }
 
 /**

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -268,7 +268,29 @@ export function getNextSyncCommitteeIndices(
 }
 
 /**
- * Compute PTC for a single slot lazily on demand rather than eagerly for all slots.
+ * Compute PTC for all slots in an epoch eagerly.
+ */
+export function computePayloadTimelinessCommittee(
+  epochSeed: Uint8Array,
+  epoch: number,
+  committees: Uint32Array[][],
+  effectiveBalanceIncrements: EffectiveBalanceIncrements
+): Uint32Array[] {
+  const startSlot = epoch * SLOTS_PER_EPOCH;
+  const result: Uint32Array[] = new Array(SLOTS_PER_EPOCH);
+  for (let i = 0; i < SLOTS_PER_EPOCH; i++) {
+    result[i] = computePayloadTimelinessCommitteeForSlot(
+      epochSeed,
+      startSlot + i,
+      committees[i],
+      effectiveBalanceIncrements
+    );
+  }
+  return result;
+}
+
+/**
+ * Compute PTC for a single slot.
  */
 export function computePayloadTimelinessCommitteeForSlot(
   epochSeed: Uint8Array,

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -5,7 +5,6 @@ import {
 } from "@chainsafe/swap-or-not-shuffle";
 import {
   DOMAIN_BEACON_PROPOSER,
-  DOMAIN_PTC_ATTESTER,
   DOMAIN_SYNC_COMMITTEE,
   EFFECTIVE_BALANCE_INCREMENT,
   EPOCHS_PER_HISTORICAL_VECTOR,
@@ -21,7 +20,7 @@ import {
 import {Bytes32, DomainType, Epoch, ValidatorIndex} from "@lodestar/types";
 import {assert, bytesToBigInt, bytesToInt, intToBytes} from "@lodestar/utils";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";
-import {BeaconStateAllForks, BeaconStateGloas, CachedBeaconStateAllForks} from "../types.js";
+import {BeaconStateAllForks, CachedBeaconStateAllForks} from "../types.js";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "./epoch.js";
 
 /**
@@ -268,27 +267,29 @@ export function getNextSyncCommitteeIndices(
   );
 }
 
-export function naiveGetPayloadTimlinessCommitteeIndices(
-  state: BeaconStateGloas,
-  shuffling: {committees: Uint32Array[][]},
-  effectiveBalanceIncrements: EffectiveBalanceIncrements,
-  epoch: Epoch
-): ValidatorIndex[][] {
-  const epochSeed = getSeed(state, epoch, DOMAIN_PTC_ATTESTER);
-  const startSlot = computeStartSlotAtEpoch(epoch);
-  const committeeIndices = [];
-
-  for (let slot = startSlot; slot < startSlot + SLOTS_PER_EPOCH; slot++) {
-    const slotCommittees = shuffling.committees[slot % SLOTS_PER_EPOCH];
-    const indices = naiveComputePayloadTimelinessCommitteeIndices(
-      effectiveBalanceIncrements,
-      slotCommittees.flatMap((c) => Array.from(c)),
-      digest(Buffer.concat([epochSeed, intToBytes(slot, 8)]))
-    );
-    committeeIndices.push(indices);
+/**
+ * Compute PTC for a single slot, using the correct spec algorithm (shuffle_indices=False).
+ * This is computed lazily on demand rather than eagerly for all slots.
+ */
+export function computePayloadTimelinessCommitteeForSlot(
+  epochSeed: Uint8Array,
+  slot: number,
+  slotCommittees: Uint32Array[],
+  effectiveBalanceIncrements: EffectiveBalanceIncrements
+): Uint32Array {
+  // Concatenate all committee Uint32Arrays for this slot
+  const totalLen = slotCommittees.reduce((sum, c) => sum + c.length, 0);
+  const allIndices = new Uint32Array(totalLen);
+  let offset = 0;
+  for (const c of slotCommittees) {
+    allIndices.set(c, offset);
+    offset += c.length;
   }
-
-  return committeeIndices;
+  const slotSeed = digest(Buffer.concat([epochSeed, intToBytes(slot, 8)]));
+  // Use the correct spec algorithm: shuffle_indices=False (no shuffling)
+  return new Uint32Array(
+    naiveComputePayloadTimelinessCommitteeIndices(effectiveBalanceIncrements, allIndices, slotSeed)
+  );
 }
 
 export function naiveComputePayloadTimelinessCommitteeIndices(
@@ -305,10 +306,26 @@ export function naiveComputePayloadTimelinessCommitteeIndices(
   const MAX_RANDOM_VALUE = 2 ** 16 - 1;
   const MAX_EFFECTIVE_BALANCE_INCREMENT = MAX_EFFECTIVE_BALANCE_ELECTRA / EFFECTIVE_BALANCE_INCREMENT;
 
+  // Pre-allocate buffer to avoid repeated Buffer.concat allocations
+  const hashInput = Buffer.alloc(seed.length + 8);
+  hashInput.set(seed, 0);
+
   let i = 0;
+  let lastBlock = -1;
+  let randomBytes: Uint8Array = new Uint8Array(0);
   while (result.length < PTC_SIZE) {
     const candidateIndex = indices[i % indices.length];
-    const randomBytes = digest(Buffer.concat([seed, intToBytes(Math.floor(i / 16), 8, "le")]));
+
+    // Only recompute hash every 16 iterations (digest result changes with Math.floor(i / 16))
+    const block = Math.floor(i / 16);
+    if (block !== lastBlock) {
+      hashInput.writeUInt32LE(block, seed.length);
+      // Zero the upper 4 bytes for correct 8-byte little-endian encoding
+      hashInput.writeUInt32LE(0, seed.length + 4);
+      randomBytes = digest(hashInput);
+      lastBlock = block;
+    }
+
     const offset = (i % 16) * 2;
     const randomValue = bytesToInt(randomBytes.subarray(offset, offset + 2));
 

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -374,7 +374,7 @@ export function computePayloadTimelinessCommitteeIndices(
 }
 
 /**
- * Naive (spec-like) version of PTC indices computation.
+ * Naive version of PTC indices computation.
  * Used to verify the optimized `computePayloadTimelinessCommitteeIndices`.
  *
  * SLOW CODE - 🐢
@@ -396,7 +396,6 @@ export function naiveComputePayloadTimelinessCommitteeIndices(
   let i = 0;
   while (result.length < PTC_SIZE) {
     const candidateIndex = indices[i % indices.length];
-
     const randomBytes = digest(Buffer.concat([seed, intToBytes(Math.floor(i / 16), 8, "le")]));
     const offset = (i % 16) * 2;
     const randomValue = bytesToInt(randomBytes.subarray(offset, offset + 2));

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -375,7 +375,7 @@ export function computePayloadTimelinessCommitteeIndices(
 
 /**
  * Naive (spec-like) version of PTC indices computation.
- * Used for spec tests validation. See `computePayloadTimelinessCommitteeIndices` for the optimized version.
+ * Used to verify the optimized `computePayloadTimelinessCommitteeIndices`.
  *
  * SLOW CODE - 🐢
  */
@@ -393,24 +393,11 @@ export function naiveComputePayloadTimelinessCommitteeIndices(
   const MAX_RANDOM_VALUE = 2 ** 16 - 1;
   const MAX_EFFECTIVE_BALANCE_INCREMENT = MAX_EFFECTIVE_BALANCE_ELECTRA / EFFECTIVE_BALANCE_INCREMENT;
 
-  // Pre-allocate buffer to avoid repeated Buffer.concat allocations
-  const hashInput = Buffer.alloc(seed.length + 8);
-  hashInput.set(seed, 0);
-
   let i = 0;
-  let lastBlock = -1;
-  let randomBytes: Uint8Array = new Uint8Array(0);
   while (result.length < PTC_SIZE) {
     const candidateIndex = indices[i % indices.length];
 
-    // Only recompute hash every 16 iterations (digest result changes with Math.floor(i / 16))
-    const block = Math.floor(i / 16);
-    if (block !== lastBlock) {
-      hashInput.writeBigUInt64LE(BigInt(block), seed.length);
-      randomBytes = digest(hashInput);
-      lastBlock = block;
-    }
-
+    const randomBytes = digest(Buffer.concat([seed, intToBytes(Math.floor(i / 16), 8, "le")]));
     const offset = (i % 16) * 2;
     const randomValue = bytesToInt(randomBytes.subarray(offset, offset + 2));
 

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -5,6 +5,7 @@ import {
 } from "@chainsafe/swap-or-not-shuffle";
 import {
   DOMAIN_BEACON_PROPOSER,
+  DOMAIN_PTC_ATTESTER,
   DOMAIN_SYNC_COMMITTEE,
   EFFECTIVE_BALANCE_INCREMENT,
   EPOCHS_PER_HISTORICAL_VECTOR,
@@ -271,11 +272,12 @@ export function getNextSyncCommitteeIndices(
  * Compute PTC for all slots in an epoch eagerly.
  */
 export function computePayloadTimelinessCommittee(
-  epochSeed: Uint8Array,
+  state: BeaconStateAllForks,
   epoch: number,
   committees: Uint32Array[][],
   effectiveBalanceIncrements: EffectiveBalanceIncrements
 ): Uint32Array[] {
+  const epochSeed = getSeed(state, epoch, DOMAIN_PTC_ATTESTER);
   const startSlot = epoch * SLOTS_PER_EPOCH;
   const result: Uint32Array[] = new Array(SLOTS_PER_EPOCH);
   for (let i = 0; i < SLOTS_PER_EPOCH; i++) {

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -268,8 +268,7 @@ export function getNextSyncCommitteeIndices(
 }
 
 /**
- * Compute PTC for a single slot, using the correct spec algorithm (shuffle_indices=False).
- * This is computed lazily on demand rather than eagerly for all slots.
+ * Compute PTC for a single slot lazily on demand rather than eagerly for all slots.
  */
 export function computePayloadTimelinessCommitteeForSlot(
   epochSeed: Uint8Array,
@@ -286,7 +285,7 @@ export function computePayloadTimelinessCommitteeForSlot(
     offset += c.length;
   }
   const slotSeed = digest(Buffer.concat([epochSeed, intToBytes(slot, 8)]));
-  // Use the correct spec algorithm: shuffle_indices=False (no shuffling)
+  // Use shuffle_indices=False (no shuffling)
   return new Uint32Array(
     naiveComputePayloadTimelinessCommitteeIndices(effectiveBalanceIncrements, allIndices, slotSeed)
   );
@@ -319,9 +318,7 @@ export function naiveComputePayloadTimelinessCommitteeIndices(
     // Only recompute hash every 16 iterations (digest result changes with Math.floor(i / 16))
     const block = Math.floor(i / 16);
     if (block !== lastBlock) {
-      hashInput.writeUInt32LE(block, seed.length);
-      // Zero the upper 4 bytes for correct 8-byte little-endian encoding
-      hashInput.writeUInt32LE(0, seed.length + 4);
+      hashInput.writeBigUInt64LE(BigInt(block), seed.length);
       randomBytes = digest(hashInput);
       lastBlock = block;
     }

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -280,13 +280,20 @@ export function computePayloadTimelinessCommittee(
   const epochSeed = getSeed(state, epoch, DOMAIN_PTC_ATTESTER);
   const startSlot = epoch * SLOTS_PER_EPOCH;
   const result: Uint32Array[] = new Array(SLOTS_PER_EPOCH);
+
+  // Pre-allocate slot seed buffer once, reuse across all slots
+  const slotSeedInput = new Uint8Array(epochSeed.length + 8);
+  slotSeedInput.set(epochSeed, 0);
+  const slotSeedView = new DataView(slotSeedInput.buffer, slotSeedInput.byteOffset, slotSeedInput.byteLength);
+
   for (let i = 0; i < SLOTS_PER_EPOCH; i++) {
-    result[i] = computePayloadTimelinessCommitteeForSlot(
-      epochSeed,
-      startSlot + i,
-      committees[i],
-      effectiveBalanceIncrements
-    );
+    const slot = startSlot + i;
+    // Write slot as little-endian uint64 (fits in uint32 range)
+    slotSeedView.setUint32(epochSeed.length, slot, true);
+    slotSeedView.setUint32(epochSeed.length + 4, 0, true);
+    const slotSeed = digest(slotSeedInput);
+
+    result[i] = computePayloadTimelinessCommitteeForSlot(slotSeed, committees[i], effectiveBalanceIncrements);
   }
   return result;
 }
@@ -295,8 +302,7 @@ export function computePayloadTimelinessCommittee(
  * Compute PTC for a single slot.
  */
 export function computePayloadTimelinessCommitteeForSlot(
-  epochSeed: Uint8Array,
-  slot: number,
+  slotSeed: Uint8Array,
   slotCommittees: Uint32Array[],
   effectiveBalanceIncrements: EffectiveBalanceIncrements
 ): Uint32Array {
@@ -308,13 +314,71 @@ export function computePayloadTimelinessCommitteeForSlot(
     allIndices.set(c, offset);
     offset += c.length;
   }
-  const slotSeed = digest(Buffer.concat([epochSeed, intToBytes(slot, 8)]));
-  // Use shuffle_indices=False (no shuffling)
-  return new Uint32Array(
-    naiveComputePayloadTimelinessCommitteeIndices(effectiveBalanceIncrements, allIndices, slotSeed)
-  );
+  return computePayloadTimelinessCommitteeIndices(effectiveBalanceIncrements, allIndices, slotSeed);
 }
 
+/**
+ * Optimized version of PTC indices computation.
+ * Avoids BigInt conversions and uses DataView for efficient byte reading.
+ */
+export function computePayloadTimelinessCommitteeIndices(
+  effectiveBalanceIncrements: EffectiveBalanceIncrements,
+  indices: Uint32Array,
+  seed: Uint8Array
+): Uint32Array {
+  if (indices.length === 0) {
+    throw Error("Validator indices must not be empty");
+  }
+
+  const result = new Uint32Array(PTC_SIZE);
+  let resultLen = 0;
+
+  const MAX_RANDOM_VALUE = 0xffff; // 2^16 - 1
+  const MAX_EFFECTIVE_BALANCE_INCREMENT = MAX_EFFECTIVE_BALANCE_ELECTRA / EFFECTIVE_BALANCE_INCREMENT;
+  const indicesLen = indices.length;
+
+  // Pre-allocate hash input buffer: seed + 8 bytes for block index
+  const hashInput = new Uint8Array(seed.length + 8);
+  hashInput.set(seed, 0);
+  const hashInputView = new DataView(hashInput.buffer, hashInput.byteOffset, hashInput.byteLength);
+  const seedLen = seed.length;
+
+  let i = 0;
+  let randomBytesView: DataView = new DataView(new ArrayBuffer(0));
+  let lastBlock = -1;
+
+  while (resultLen < PTC_SIZE) {
+    const candidateIndex = indices[i % indicesLen];
+
+    // Only recompute hash every 16 iterations
+    const block = i >>> 4; // Math.floor(i / 16)
+    if (block !== lastBlock) {
+      // Write block as little-endian uint64 (block always fits in uint32 range)
+      hashInputView.setUint32(seedLen, block, true);
+      hashInputView.setUint32(seedLen + 4, 0, true);
+      const randomBytes = digest(hashInput);
+      randomBytesView = new DataView(randomBytes.buffer, randomBytes.byteOffset, randomBytes.byteLength);
+      lastBlock = block;
+    }
+
+    const randomValue = randomBytesView.getUint16((i & 15) * 2, true);
+
+    const effectiveBalanceIncrement = effectiveBalanceIncrements[candidateIndex];
+    if (effectiveBalanceIncrement * MAX_RANDOM_VALUE >= MAX_EFFECTIVE_BALANCE_INCREMENT * randomValue) {
+      result[resultLen++] = candidateIndex;
+    }
+    i += 1;
+  }
+
+  return result;
+}
+
+/**
+ * Naive (spec-like) version of PTC indices computation.
+ * Used for spec tests validation. See `computePayloadTimelinessCommitteeIndices` for the optimized version.
+ *
+ * SLOW CODE - 🐢
+ */
 export function naiveComputePayloadTimelinessCommitteeIndices(
   effectiveBalanceIncrements: EffectiveBalanceIncrements,
   indices: ArrayLike<ValidatorIndex>,

--- a/packages/state-transition/src/util/seed.ts
+++ b/packages/state-transition/src/util/seed.ts
@@ -271,7 +271,7 @@ export function getNextSyncCommitteeIndices(
 /**
  * Compute PTC for all slots in an epoch eagerly.
  */
-export function computePayloadTimelinessCommittee(
+export function computePayloadTimelinessCommitteesForEpoch(
   state: BeaconStateAllForks,
   epoch: number,
   committees: Uint32Array[][],

--- a/packages/state-transition/test/unit/util/seed.test.ts
+++ b/packages/state-transition/test/unit/util/seed.test.ts
@@ -4,11 +4,13 @@ import {toHexString} from "@chainsafe/ssz";
 import {ForkSeq, GENESIS_EPOCH, GENESIS_SLOT, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {bytesToInt} from "@lodestar/utils";
 import {
+  computePayloadTimelinessCommitteeIndices,
   computeProposerIndex,
   computeShuffledIndex,
   getComputeShuffledIndexFn,
   getNextSyncCommitteeIndices,
   getRandaoMix,
+  naiveComputePayloadTimelinessCommitteeIndices,
   naiveComputeProposerIndex,
   naiveGetNextSyncCommitteeIndices,
 } from "../../../src/util/index.js";
@@ -90,6 +92,22 @@ describe("electra getNextSyncCommitteeIndices", () => {
       expect(result).toEqual(new Uint32Array(expected));
     });
   }
+});
+
+describe("computePayloadTimelinessCommitteeIndices", () => {
+  const seed = crypto.randomBytes(32);
+  const vc = 1000;
+  const indices = new Uint32Array(Array.from({length: vc}, (_, i) => i));
+  const effectiveBalanceIncrements = new Uint16Array(vc);
+  for (let i = 0; i < vc; i++) {
+    effectiveBalanceIncrements[i] = 32 + 32 * (i % 64);
+  }
+
+  it("should be the same to the naive version", () => {
+    const expected = naiveComputePayloadTimelinessCommitteeIndices(effectiveBalanceIncrements, indices, seed);
+    const result = computePayloadTimelinessCommitteeIndices(effectiveBalanceIncrements, indices, seed);
+    expect(result).toEqual(new Uint32Array(expected));
+  });
 });
 
 describe("number from 2 bytes bytesToInt", () => {

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -133,7 +133,8 @@ export const ExecutionPayloadBid = new ContainerType(
     slot: Slot,
     value: UintNum64,
     executionPayment: UintNum64,
-    blobKzgCommitmentsRoot: Root,
+    // [Modified in v1.7.0-alpha.2] was blobKzgCommitmentsRoot: Root
+    blobKzgCommitments: denebSsz.BlobKzgCommitments,
   },
   {typeName: "ExecutionPayloadBid", jsonCase: "eth2"}
 );
@@ -153,7 +154,7 @@ export const ExecutionPayloadEnvelope = new ContainerType(
     builderIndex: BuilderIndex,
     beaconBlockRoot: Root,
     slot: Slot,
-    blobKzgCommitments: denebSsz.BlobKzgCommitments,
+    // [Removed in v1.7.0-alpha.2] blobKzgCommitments now in ExecutionPayloadBid
     stateRoot: Root,
   },
   {typeName: "ExecutionPayloadEnvelope", jsonCase: "eth2"}
@@ -272,7 +273,7 @@ export const DataColumnSidecar = new ContainerType(
   {
     index: fuluSsz.DataColumnSidecar.fields.index,
     column: fuluSsz.DataColumnSidecar.fields.column,
-    kzgCommitments: fuluSsz.DataColumnSidecar.fields.kzgCommitments,
+    // [Removed in v1.7.0-alpha.2] kzgCommitments now retrieved from bid via block lookup
     kzgProofs: fuluSsz.DataColumnSidecar.fields.kzgProofs,
     // signedBlockHeader: phase0Ssz.SignedBeaconBlockHeader, // Removed in GLOAS:EIP7732
     // kzgCommitmentsInclusionProof: KzgCommitmentsInclusionProof, // Removed in GLOAS:EIP7732

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -133,7 +133,6 @@ export const ExecutionPayloadBid = new ContainerType(
     slot: Slot,
     value: UintNum64,
     executionPayment: UintNum64,
-    // [Modified in v1.7.0-alpha.2] was blobKzgCommitmentsRoot: Root
     blobKzgCommitments: denebSsz.BlobKzgCommitments,
   },
   {typeName: "ExecutionPayloadBid", jsonCase: "eth2"}
@@ -154,7 +153,6 @@ export const ExecutionPayloadEnvelope = new ContainerType(
     builderIndex: BuilderIndex,
     beaconBlockRoot: Root,
     slot: Slot,
-    // [Removed in v1.7.0-alpha.2] blobKzgCommitments now in ExecutionPayloadBid
     stateRoot: Root,
   },
   {typeName: "ExecutionPayloadEnvelope", jsonCase: "eth2"}
@@ -273,7 +271,7 @@ export const DataColumnSidecar = new ContainerType(
   {
     index: fuluSsz.DataColumnSidecar.fields.index,
     column: fuluSsz.DataColumnSidecar.fields.column,
-    // [Removed in v1.7.0-alpha.2] kzgCommitments now retrieved from bid via block lookup
+    // kzgCommitments: denebSsz.BlobKzgCommitments, // Removed in GLOAS:EIP7732
     kzgProofs: fuluSsz.DataColumnSidecar.fields.kzgProofs,
     // signedBlockHeader: phase0Ssz.SignedBeaconBlockHeader, // Removed in GLOAS:EIP7732
     // kzgCommitmentsInclusionProof: KzgCommitmentsInclusionProof, // Removed in GLOAS:EIP7732

--- a/specrefs/.ethspecify.yml
+++ b/specrefs/.ethspecify.yml
@@ -1,4 +1,4 @@
-version: v1.7.0-alpha.1
+version: v1.7.0-alpha.2
 style: full
 
 specrefs:
@@ -185,7 +185,6 @@ exceptions:
     - get_lc_execution_root#deneb
     - hash_to_bls_field#deneb
     - is_power_of_two#deneb
-    - multi_exp#deneb
     - reverse_bits#deneb
     - validate_kzg_g1#deneb
     - verify_blob_kzg_proof#deneb
@@ -251,7 +250,6 @@ exceptions:
     - get_ancestor#gloas
     - get_attestation_participation_flag_indices#gloas
     - get_attestation_score#gloas
-    - get_builder_from_deposit#gloas
     - get_builder_withdrawals#gloas
     - get_builders_sweep_withdrawals#gloas
     - get_checkpoint_block#gloas

--- a/specrefs/configs.yml
+++ b/specrefs/configs.yml
@@ -482,8 +482,8 @@
     - file: packages/config/src/chainConfig/configs/mainnet.ts
       search: "MIN_BUILDER_WITHDRAWABILITY_DELAY:"
   spec: |
-    <spec config_var="MIN_BUILDER_WITHDRAWABILITY_DELAY" fork="gloas" hash="d378428f">
-    MIN_BUILDER_WITHDRAWABILITY_DELAY: uint64 = 4096
+    <spec config_var="MIN_BUILDER_WITHDRAWABILITY_DELAY" fork="gloas" hash="be7f8473">
+    MIN_BUILDER_WITHDRAWABILITY_DELAY: uint64 = 64
     </spec>
 
 - name: MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS#deneb

--- a/specrefs/containers.yml
+++ b/specrefs/containers.yml
@@ -750,11 +750,12 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const DataColumnSidecar =
   spec: |
-    <spec container="DataColumnSidecar" fork="gloas" hash="8028928b">
+    <spec container="DataColumnSidecar" fork="gloas" hash="332c7cfc">
     class DataColumnSidecar(Container):
         index: ColumnIndex
         column: List[Cell, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+        # [Modified in Gloas:EIP7732]
+        # Removed `kzg_commitments`
         kzg_proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
         # [Modified in Gloas:EIP7732]
         # Removed `signed_block_header`
@@ -932,7 +933,7 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const ExecutionPayloadBid =
   spec: |
-    <spec container="ExecutionPayloadBid" fork="gloas" hash="aa71ba16">
+    <spec container="ExecutionPayloadBid" fork="gloas" hash="1a7b9dea">
     class ExecutionPayloadBid(Container):
         parent_block_hash: Hash32
         parent_block_root: Root
@@ -944,7 +945,7 @@
         slot: Slot
         value: Gwei
         execution_payment: Gwei
-        blob_kzg_commitments_root: Root
+        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     </spec>
 
 - name: ExecutionPayloadEnvelope#gloas
@@ -952,14 +953,13 @@
     - file: packages/types/src/gloas/sszTypes.ts
       search: export const ExecutionPayloadEnvelope =
   spec: |
-    <spec container="ExecutionPayloadEnvelope" fork="gloas" hash="cd522f7f">
+    <spec container="ExecutionPayloadEnvelope" fork="gloas" hash="ec5c0233">
     class ExecutionPayloadEnvelope(Container):
         payload: ExecutionPayload
         execution_requests: ExecutionRequests
         builder_index: BuilderIndex
         beacon_block_root: Root
         slot: Slot
-        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
         state_root: Root
     </spec>
 

--- a/specrefs/functions.yml
+++ b/specrefs/functions.yml
@@ -1,13 +1,26 @@
 - name: add_builder_to_registry#gloas
   sources: []
   spec: |
-    <spec fn="add_builder_to_registry" fork="gloas" hash="938224ec">
+    <spec fn="add_builder_to_registry" fork="gloas" hash="cd0414c9">
     def add_builder_to_registry(
-        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
+        state: BeaconState,
+        pubkey: BLSPubkey,
+        withdrawal_credentials: Bytes32,
+        amount: uint64,
+        slot: Slot,
     ) -> None:
-        index = get_index_for_new_builder(state)
-        builder = get_builder_from_deposit(state, pubkey, withdrawal_credentials, amount)
-        set_or_append_list(state.builders, index, builder)
+        set_or_append_list(
+            state.builders,
+            get_index_for_new_builder(state),
+            Builder(
+                pubkey=pubkey,
+                version=uint8(withdrawal_credentials[0]),
+                execution_address=ExecutionAddress(withdrawal_credentials[12:]),
+                balance=amount,
+                deposit_epoch=compute_epoch_at_slot(slot),
+                withdrawable_epoch=FAR_FUTURE_EPOCH,
+            ),
+        )
     </spec>
 
 - name: add_flag#altair
@@ -145,19 +158,20 @@
     - file: packages/state-transition/src/block/processDepositRequest.ts
       search: export function applyDepositForBuilder(
   spec: |
-    <spec fn="apply_deposit_for_builder" fork="gloas" hash="eae84bc2">
+    <spec fn="apply_deposit_for_builder" fork="gloas" hash="e4bc98c7">
     def apply_deposit_for_builder(
         state: BeaconState,
         pubkey: BLSPubkey,
         withdrawal_credentials: Bytes32,
         amount: uint64,
         signature: BLSSignature,
+        slot: Slot,
     ) -> None:
         builder_pubkeys = [b.pubkey for b in state.builders]
         if pubkey not in builder_pubkeys:
             # Verify the deposit signature (proof of possession) which is not checked by the deposit contract
             if is_valid_deposit_signature(pubkey, withdrawal_credentials, amount, signature):
-                add_builder_to_registry(state, pubkey, withdrawal_credentials, amount)
+                add_builder_to_registry(state, pubkey, withdrawal_credentials, amount, slot)
         else:
             # Increase balance by deposit amount
             builder_index = builder_pubkeys.index(pubkey)
@@ -551,9 +565,11 @@
     - file: packages/state-transition/src/util/domain.ts
       search: export function computeDomain(
   spec: |
-    <spec fn="compute_domain" fork="phase0" hash="948e1334">
+    <spec fn="compute_domain" fork="phase0" hash="a78b32e4">
     def compute_domain(
-        domain_type: DomainType, fork_version: Version = None, genesis_validators_root: Root = None
+        domain_type: DomainType,
+        fork_version: Optional[Version] = None,
+        genesis_validators_root: Optional[Root] = None,
     ) -> Domain:
         """
         Return the domain for the ``domain_type`` and ``fork_version``.
@@ -2275,23 +2291,6 @@
         return bls.Sign(privkey, signing_root)
     </spec>
 
-- name: get_builder_from_deposit#gloas
-  sources: []
-  spec: |
-    <spec fn="get_builder_from_deposit" fork="gloas" hash="7f914af6">
-    def get_builder_from_deposit(
-        state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
-    ) -> Builder:
-        return Builder(
-            pubkey=pubkey,
-            version=uint8(withdrawal_credentials[0]),
-            execution_address=ExecutionAddress(withdrawal_credentials[12:]),
-            balance=amount,
-            deposit_epoch=get_current_epoch(state),
-            withdrawable_epoch=FAR_FUTURE_EPOCH,
-        )
-    </spec>
-
 - name: get_builder_payment_quorum_threshold#gloas
   sources:
     - file: packages/state-transition/src/util/gloas.ts
@@ -2310,19 +2309,20 @@
 - name: get_builder_withdrawals#gloas
   sources: []
   spec: |
-    <spec fn="get_builder_withdrawals" fork="gloas" hash="35cd32cd">
+    <spec fn="get_builder_withdrawals" fork="gloas" hash="d54dd146">
     def get_builder_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
         prior_withdrawals: Sequence[Withdrawal],
     ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
-        withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+        withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD - 1
+        assert len(prior_withdrawals) <= withdrawals_limit
 
         processed_count: uint64 = 0
         withdrawals: List[Withdrawal] = []
         for withdrawal in state.builder_pending_withdrawals:
             all_withdrawals = prior_withdrawals + withdrawals
-            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
 
@@ -2344,7 +2344,7 @@
 - name: get_builders_sweep_withdrawals#gloas
   sources: []
   spec: |
-    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="028d161d">
+    <spec fn="get_builders_sweep_withdrawals" fork="gloas" hash="04c1cb10">
     def get_builders_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -2352,14 +2352,15 @@
     ) -> Tuple[Sequence[Withdrawal], WithdrawalIndex, uint64]:
         epoch = get_current_epoch(state)
         builders_limit = min(len(state.builders), MAX_BUILDERS_PER_WITHDRAWALS_SWEEP)
-        withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+        withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD - 1
+        assert len(prior_withdrawals) <= withdrawals_limit
 
         processed_count: uint64 = 0
         withdrawals: List[Withdrawal] = []
         builder_index = state.next_withdrawal_builder_index
         for _ in range(builders_limit):
             all_withdrawals = prior_withdrawals + withdrawals
-            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
 
@@ -2643,7 +2644,7 @@
 - name: get_data_column_sidecars#gloas
   sources: []
   spec: |
-    <spec fn="get_data_column_sidecars" fork="gloas" hash="c8d64ac9">
+    <spec fn="get_data_column_sidecars" fork="gloas" hash="abaf4385">
     def get_data_column_sidecars(
         # [Modified in Gloas:EIP7732]
         # Removed `signed_block_header`
@@ -2651,7 +2652,8 @@
         beacon_block_root: Root,
         # [New in Gloas:EIP7732]
         slot: Slot,
-        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+        # [Modified in Gloas:EIP7732]
+        # Removed `kzg_commitments`
         # [Modified in Gloas:EIP7732]
         # Removed `kzg_commitments_inclusion_proof`
         cells_and_kzg_proofs: Sequence[
@@ -2659,11 +2661,10 @@
         ],
     ) -> Sequence[DataColumnSidecar]:
         """
-        Given a beacon block root and the commitments, cells/proofs associated with
-        each blob in the block, assemble the sidecars which can be distributed to peers.
+        Given a beacon block root and the cells/proofs associated with each blob
+        in the corresponding payload, assemble the sidecars which can be
+        distributed to peers.
         """
-        assert len(cells_and_kzg_proofs) == len(kzg_commitments)
-
         sidecars = []
         for column_index in range(NUMBER_OF_COLUMNS):
             column_cells, column_proofs = [], []
@@ -2671,10 +2672,10 @@
                 column_cells.append(cells[column_index])
                 column_proofs.append(proofs[column_index])
             sidecars.append(
+                # [Modified in Gloas:EIP7732]
                 DataColumnSidecar(
                     index=column_index,
                     column=column_cells,
-                    kzg_commitments=kzg_commitments,
                     kzg_proofs=column_proofs,
                     slot=slot,
                     beacon_block_root=beacon_block_root,
@@ -2716,11 +2717,9 @@
 - name: get_data_column_sidecars_from_block#gloas
   sources: []
   spec: |
-    <spec fn="get_data_column_sidecars_from_block" fork="gloas" hash="8ac19a18">
+    <spec fn="get_data_column_sidecars_from_block" fork="gloas" hash="302616d2">
     def get_data_column_sidecars_from_block(
         signed_block: SignedBeaconBlock,
-        # [New in Gloas:EIP7732]
-        blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
         cells_and_kzg_proofs: Sequence[
             Tuple[Vector[Cell, CELLS_PER_EXT_BLOB], Vector[KZGProof, CELLS_PER_EXT_BLOB]]
         ],
@@ -2733,7 +2732,6 @@
         return get_data_column_sidecars(
             beacon_block_root,
             signed_block.message.slot,
-            blob_kzg_commitments,
             cells_and_kzg_proofs,
         )
     </spec>
@@ -2743,7 +2741,7 @@
     - file: packages/beacon-node/src/util/dataColumns.ts
       search: export function getDataColumnSidecarsFromColumnSidecar(
   spec: |
-    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="fulu" hash="4304cdec">
+    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="fulu" hash="4877148a">
     def get_data_column_sidecars_from_column_sidecar(
         sidecar: DataColumnSidecar,
         cells_and_kzg_proofs: Sequence[
@@ -2751,7 +2749,7 @@
         ],
     ) -> Sequence[DataColumnSidecar]:
         """
-        Given a DataColumnSidecar and the cells/proofs associated with each blob corresponding
+        Given a data column sidecar and the cells/proofs associated with each blob corresponding
         to the commitments it contains, assemble all sidecars for distribution to peers.
         """
         assert len(cells_and_kzg_proofs) == len(sidecar.kzg_commitments)
@@ -2767,7 +2765,7 @@
 - name: get_data_column_sidecars_from_column_sidecar#gloas
   sources: []
   spec: |
-    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="gloas" hash="a1052a1c">
+    <spec fn="get_data_column_sidecars_from_column_sidecar" fork="gloas" hash="beb1f94f">
     def get_data_column_sidecars_from_column_sidecar(
         sidecar: DataColumnSidecar,
         cells_and_kzg_proofs: Sequence[
@@ -2775,15 +2773,14 @@
         ],
     ) -> Sequence[DataColumnSidecar]:
         """
-        Given a DataColumnSidecar and the cells/proofs associated with each blob corresponding
-        to the commitments it contains, assemble all sidecars for distribution to peers.
+        Given a data column sidecar and the cells/proofs associated with each blob
+        in the corresponding payload, assemble the sidecars which can be
+        distributed to peers.
         """
-        assert len(cells_and_kzg_proofs) == len(sidecar.kzg_commitments)
-
+        # [Modified in Gloas:EIP7732]
         return get_data_column_sidecars(
             sidecar.beacon_block_root,
             sidecar.slot,
-            sidecar.kzg_commitments,
             cells_and_kzg_proofs,
         )
     </spec>
@@ -2793,8 +2790,10 @@
     - file: packages/config/src/genesisConfig/index.ts
       search: "getDomain(domainSlot: Slot, domainType: DomainType, messageSlot?: Slot)"
   spec: |
-    <spec fn="get_domain" fork="phase0" hash="99ea23f6">
-    def get_domain(state: BeaconState, domain_type: DomainType, epoch: Epoch = None) -> Domain:
+    <spec fn="get_domain" fork="phase0" hash="e60c5fbc">
+    def get_domain(
+        state: BeaconState, domain_type: DomainType, epoch: Optional[Epoch] = None
+    ) -> Domain:
         """
         Return the signature domain (fork version concatenated with domain type) of a message.
         """
@@ -3873,7 +3872,7 @@
 - name: get_pending_partial_withdrawals#electra
   sources: []
   spec: |
-    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="b53b25d7">
+    <spec fn="get_pending_partial_withdrawals" fork="electra" hash="306047e9">
     def get_pending_partial_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -3884,13 +3883,14 @@
             len(prior_withdrawals) + MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
             MAX_WITHDRAWALS_PER_PAYLOAD - 1,
         )
+        assert len(prior_withdrawals) <= withdrawals_limit
 
         processed_count: uint64 = 0
         withdrawals: List[Withdrawal] = []
         for withdrawal in state.pending_partial_withdrawals:
             all_withdrawals = prior_withdrawals + withdrawals
             is_withdrawable = withdrawal.withdrawable_epoch <= epoch
-            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if not is_withdrawable or has_reached_limit:
                 break
 
@@ -4079,13 +4079,13 @@
 - name: get_ptc_assignment#gloas
   sources: []
   spec: |
-    <spec fn="get_ptc_assignment" fork="gloas" hash="817acb90">
+    <spec fn="get_ptc_assignment" fork="gloas" hash="7fd50097">
     def get_ptc_assignment(
         state: BeaconState, epoch: Epoch, validator_index: ValidatorIndex
     ) -> Optional[Slot]:
         """
         Returns the slot during the requested epoch in which the validator with
-        index `validator_index` is a member of the PTC. Returns None if no
+        index ``validator_index`` is a member of the PTC. Returns None if no
         assignment is found.
         """
         next_epoch = Epoch(get_current_epoch(state) + 1)
@@ -4501,7 +4501,7 @@
 - name: get_validators_sweep_withdrawals#capella
   sources: []
   spec: |
-    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="81868c81">
+    <spec fn="get_validators_sweep_withdrawals" fork="capella" hash="59563c2a">
     def get_validators_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -4510,13 +4510,15 @@
         epoch = get_current_epoch(state)
         validators_limit = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
         withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+        # There must be at least one space reserved for validator sweep withdrawals
+        assert len(prior_withdrawals) < withdrawals_limit
 
         processed_count: uint64 = 0
         withdrawals: List[Withdrawal] = []
         validator_index = state.next_withdrawal_validator_index
         for _ in range(validators_limit):
             all_withdrawals = prior_withdrawals + withdrawals
-            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
 
@@ -4552,7 +4554,7 @@
 - name: get_validators_sweep_withdrawals#electra
   sources: []
   spec: |
-    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="74bbd437">
+    <spec fn="get_validators_sweep_withdrawals" fork="electra" hash="034093ad">
     def get_validators_sweep_withdrawals(
         state: BeaconState,
         withdrawal_index: WithdrawalIndex,
@@ -4561,13 +4563,15 @@
         epoch = get_current_epoch(state)
         validators_limit = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
         withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD
+        # There must be at least one space reserved for validator sweep withdrawals
+        assert len(prior_withdrawals) < withdrawals_limit
 
         processed_count: uint64 = 0
         withdrawals: List[Withdrawal] = []
         validator_index = state.next_withdrawal_validator_index
         for _ in range(validators_limit):
             all_withdrawals = prior_withdrawals + withdrawals
-            has_reached_limit = len(all_withdrawals) == withdrawals_limit
+            has_reached_limit = len(all_withdrawals) >= withdrawals_limit
             if has_reached_limit:
                 break
 
@@ -5167,6 +5171,29 @@
         )
     </spec>
 
+- name: is_data_available#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/blocks/verifyBlocksDataAvailability.ts
+      search: export async function verifyBlocksDataAvailability(
+  spec: |
+    <spec fn="is_data_available" fork="gloas" hash="92002d87">
+    def is_data_available(beacon_block_root: Root) -> bool:
+        # `retrieve_column_sidecars_and_kzg_commitments` is implementation and
+        # context dependent, replacing `retrieve_column_sidecars`. For the given
+        # block root, it returns all column sidecars to sample, or raises an
+        # exception if they are not available, in addition it returns all the
+        # corresponding kzg commitments. The p2p network does not guarantee sidecar
+        # retrieval outside of `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` epochs.
+        column_sidecars, kzg_commitments = retrieve_column_sidecars_and_kzg_commitments(
+            beacon_block_root
+        )
+        return all(
+            verify_data_column_sidecar(column_sidecar, kzg_commitments)
+            and verify_data_column_sidecar_kzg_proofs(column_sidecar, kzg_commitments)
+            for column_sidecar in column_sidecars
+        )
+    </spec>
+
 - name: is_eligible_for_activation#phase0
   sources:
     - file: packages/state-transition/src/cache/epochTransitionCache.ts
@@ -5738,24 +5765,24 @@
     - file: packages/state-transition/src/block/isValidIndexedPayloadAttestation.ts
       search: export function isValidIndexedPayloadAttestation(
   spec: |
-    <spec fn="is_valid_indexed_payload_attestation" fork="gloas" hash="cf1e65b5">
+    <spec fn="is_valid_indexed_payload_attestation" fork="gloas" hash="d76e0f89">
     def is_valid_indexed_payload_attestation(
-        state: BeaconState, indexed_payload_attestation: IndexedPayloadAttestation
+        state: BeaconState, attestation: IndexedPayloadAttestation
     ) -> bool:
         """
-        Check if ``indexed_payload_attestation`` is non-empty, has sorted indices, and has
+        Check if ``attestation`` is non-empty, has sorted indices, and has
         a valid aggregate signature.
         """
         # Verify indices are non-empty and sorted
-        indices = indexed_payload_attestation.attesting_indices
+        indices = attestation.attesting_indices
         if len(indices) == 0 or not indices == sorted(indices):
             return False
 
         # Verify aggregate signature
         pubkeys = [state.validators[i].pubkey for i in indices]
-        domain = get_domain(state, DOMAIN_PTC_ATTESTER, None)
-        signing_root = compute_signing_root(indexed_payload_attestation.data, domain)
-        return bls.FastAggregateVerify(pubkeys, signing_root, indexed_payload_attestation.signature)
+        domain = get_domain(state, DOMAIN_PTC_ATTESTER, compute_epoch_at_slot(attestation.data.slot))
+        signing_root = compute_signing_root(attestation.data, domain)
+        return bls.FastAggregateVerify(pubkeys, signing_root, attestation.signature)
     </spec>
 
 - name: is_valid_light_client_header#altair
@@ -6547,6 +6574,60 @@
             )
     </spec>
 
+- name: onboard_builders_from_pending_deposits#gloas
+  sources:
+    - file: packages/state-transition/src/slot/upgradeStateToGloas.ts
+      search: function onboardBuildersFromPendingDeposits(
+  spec: |
+    <spec fn="onboard_builders_from_pending_deposits" fork="gloas" hash="2bd662c7">
+    def onboard_builders_from_pending_deposits(state: BeaconState) -> None:
+        """
+        Applies any pending deposit for builders, effectively
+        onboarding builders at the fork.
+        """
+        validator_pubkeys = [v.pubkey for v in state.validators]
+
+        pending_deposits = []
+        for deposit in state.pending_deposits:
+            # Deposits for existing validators stay in pending queue
+            if deposit.pubkey in validator_pubkeys:
+                pending_deposits.append(deposit)
+                continue
+
+            # If the pubkey is associated with a builder that was created in a
+            # previous iteration or it is a builder deposit, try to apply the
+            # deposit to the new/existing builder. Note that the function
+            # apply_deposit_for_builder can mutate the state and may add a builder
+            # to the registry. For this reason, the list of builder pubkeys must
+            # be recomputed each iteration.
+            builder_pubkeys = [b.pubkey for b in state.builders]
+            is_existing_builder = deposit.pubkey in builder_pubkeys
+            has_builder_credentials = is_builder_withdrawal_credential(deposit.withdrawal_credentials)
+            if is_existing_builder or has_builder_credentials:
+                apply_deposit_for_builder(
+                    state,
+                    deposit.pubkey,
+                    deposit.withdrawal_credentials,
+                    deposit.amount,
+                    deposit.signature,
+                    deposit.slot,
+                )
+                continue
+
+            # If there is a pending deposit for a new validator that has a valid
+            # signature, track the pubkey so that subsequent builder deposits for
+            # the same pubkey stay in pending (applied to the validator later)
+            # rather than creating a builder. Deposits with invalid signatures are
+            # dropped here since they would fail in apply_pending_deposit anyway.
+            if is_valid_deposit_signature(
+                deposit.pubkey, deposit.withdrawal_credentials, deposit.amount, deposit.signature
+            ):
+                validator_pubkeys.append(deposit.pubkey)
+                pending_deposits.append(deposit)
+
+        state.pending_deposits = pending_deposits
+    </spec>
+
 - name: prepare_execution_payload#bellatrix
   sources:
     - file: packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -6600,13 +6681,15 @@
     - file: packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
       search: export async function prepareExecutionPayload(
   spec: |
-    <spec fn="prepare_execution_payload" fork="capella" hash="998e8b92">
+    <spec fn="prepare_execution_payload" fork="capella" hash="bdb15c3f">
     def prepare_execution_payload(
         state: BeaconState,
         safe_block_hash: Hash32,
         finalized_block_hash: Hash32,
         suggested_fee_recipient: ExecutionAddress,
         execution_engine: ExecutionEngine,
+        # [Modified in Capella]
+        # Removed `pow_chain`
     ) -> Optional[PayloadId]:
         # [Modified in Capella]
         # Removed `is_merge_transition_complete` check
@@ -6697,7 +6780,7 @@
 - name: prepare_execution_payload#gloas
   sources: []
   spec: |
-    <spec fn="prepare_execution_payload" fork="gloas" hash="c617aa1b">
+    <spec fn="prepare_execution_payload" fork="gloas" hash="f3047927">
     def prepare_execution_payload(
         state: BeaconState,
         safe_block_hash: Hash32,
@@ -6705,20 +6788,17 @@
         suggested_fee_recipient: ExecutionAddress,
         execution_engine: ExecutionEngine,
     ) -> Optional[PayloadId]:
-        # Verify consistency of the parent hash with respect to the previous execution payload header
-        parent_hash = state.latest_execution_payload_header.block_hash
-
         # Set the forkchoice head and initiate the payload build process
         payload_attributes = PayloadAttributes(
             timestamp=compute_time_at_slot(state, state.slot),
             prev_randao=get_randao_mix(state, get_current_epoch(state)),
             suggested_fee_recipient=suggested_fee_recipient,
             withdrawals=get_expected_withdrawals(state).withdrawals,
-            # [New in Deneb:EIP4788]
             parent_beacon_block_root=hash_tree_root(state.latest_block_header),
         )
         return execution_engine.notify_forkchoice_updated(
-            head_block_hash=parent_hash,
+            # [Modified in Gloas:EIP7732]
+            head_block_hash=state.latest_block_hash,
             safe_block_hash=safe_block_hash,
             finalized_block_hash=finalized_block_hash,
             payload_attributes=payload_attributes,
@@ -7376,7 +7456,7 @@
     - file: packages/state-transition/src/block/processDepositRequest.ts
       search: export function processDepositRequest(
   spec: |
-    <spec fn="process_deposit_request" fork="gloas" hash="50ffbd27">
+    <spec fn="process_deposit_request" fork="gloas" hash="3c6b0310">
     def process_deposit_request(state: BeaconState, deposit_request: DepositRequest) -> None:
         # [New in Gloas:EIP7732]
         builder_pubkeys = [b.pubkey for b in state.builders]
@@ -7396,6 +7476,7 @@
                 deposit_request.withdrawal_credentials,
                 deposit_request.amount,
                 deposit_request.signature,
+                state.slot,
             )
             return
 
@@ -7900,7 +7981,7 @@
 - name: process_execution_payload#gloas
   sources: []
   spec: |
-    <spec fn="process_execution_payload" fork="gloas" hash="98cceb7d">
+    <spec fn="process_execution_payload" fork="gloas" hash="36bd3af3">
     def process_execution_payload(
         state: BeaconState,
         # [Modified in Gloas:EIP7732]
@@ -7930,7 +8011,6 @@
         # Verify consistency with the committed bid
         committed_bid = state.latest_execution_payload_bid
         assert envelope.builder_index == committed_bid.builder_index
-        assert committed_bid.blob_kzg_commitments_root == hash_tree_root(envelope.blob_kzg_commitments)
         assert committed_bid.prev_randao == payload.prev_randao
 
         # Verify consistency with expected withdrawals
@@ -7944,14 +8024,11 @@
         assert payload.parent_hash == state.latest_block_hash
         # Verify timestamp
         assert payload.timestamp == compute_time_at_slot(state, state.slot)
-        # Verify commitments are under limit
-        assert (
-            len(envelope.blob_kzg_commitments)
-            <= get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
-        )
         # Verify the execution payload is valid
         versioned_hashes = [
-            kzg_commitment_to_versioned_hash(commitment) for commitment in envelope.blob_kzg_commitments
+            kzg_commitment_to_versioned_hash(commitment)
+            # [Modified in Gloas:EIP7732]
+            for commitment in committed_bid.blob_kzg_commitments
         ]
         requests = envelope.execution_requests
         assert execution_engine.verify_and_notify_new_payload(
@@ -7994,7 +8071,7 @@
     - file: packages/state-transition/src/block/processExecutionPayloadBid.ts
       search: export function processExecutionPayloadBid(
   spec: |
-    <spec fn="process_execution_payload_bid" fork="gloas" hash="6dc696bb">
+    <spec fn="process_execution_payload_bid" fork="gloas" hash="823c9f3a">
     def process_execution_payload_bid(state: BeaconState, block: BeaconBlock) -> None:
         signed_bid = block.body.signed_execution_payload_bid
         bid = signed_bid.message
@@ -8012,6 +8089,12 @@
             assert can_builder_cover_bid(state, builder_index, amount)
             # Verify that the bid signature is valid
             assert verify_execution_payload_bid_signature(state, signed_bid)
+
+        # Verify commitments are under limit
+        assert (
+            len(bid.blob_kzg_commitments)
+            <= get_blob_parameters(get_current_epoch(state)).max_blobs_per_block
+        )
 
         # Verify that the bid is for the current slot
         assert bid.slot == block.slot
@@ -9591,9 +9674,11 @@
     - file: packages/state-transition/src/block/slashValidator.ts
       search: export function slashValidator(
   spec: |
-    <spec fn="slash_validator" fork="phase0" hash="85d8d7c9">
+    <spec fn="slash_validator" fork="phase0" hash="d2b5fafa">
     def slash_validator(
-        state: BeaconState, slashed_index: ValidatorIndex, whistleblower_index: ValidatorIndex = None
+        state: BeaconState,
+        slashed_index: ValidatorIndex,
+        whistleblower_index: Optional[ValidatorIndex] = None,
     ) -> None:
         """
         Slash the validator with index ``slashed_index``.
@@ -9625,9 +9710,11 @@
     - file: packages/state-transition/src/block/slashValidator.ts
       search: export function slashValidator(
   spec: |
-    <spec fn="slash_validator" fork="altair" hash="88f6c284">
+    <spec fn="slash_validator" fork="altair" hash="179ea102">
     def slash_validator(
-        state: BeaconState, slashed_index: ValidatorIndex, whistleblower_index: ValidatorIndex = None
+        state: BeaconState,
+        slashed_index: ValidatorIndex,
+        whistleblower_index: Optional[ValidatorIndex] = None,
     ) -> None:
         """
         Slash the validator with index ``slashed_index``.
@@ -9659,9 +9746,11 @@
     - file: packages/state-transition/src/block/slashValidator.ts
       search: export function slashValidator(
   spec: |
-    <spec fn="slash_validator" fork="bellatrix" hash="124f6889">
+    <spec fn="slash_validator" fork="bellatrix" hash="5964268e">
     def slash_validator(
-        state: BeaconState, slashed_index: ValidatorIndex, whistleblower_index: ValidatorIndex = None
+        state: BeaconState,
+        slashed_index: ValidatorIndex,
+        whistleblower_index: Optional[ValidatorIndex] = None,
     ) -> None:
         """
         Slash the validator with index ``slashed_index``.
@@ -9693,9 +9782,11 @@
     - file: packages/state-transition/src/block/slashValidator.ts
       search: export function slashValidator(
   spec: |
-    <spec fn="slash_validator" fork="electra" hash="54b64d21">
+    <spec fn="slash_validator" fork="electra" hash="07e584e2">
     def slash_validator(
-        state: BeaconState, slashed_index: ValidatorIndex, whistleblower_index: ValidatorIndex = None
+        state: BeaconState,
+        slashed_index: ValidatorIndex,
+        whistleblower_index: Optional[ValidatorIndex] = None,
     ) -> None:
         """
         Slash the validator with index ``slashed_index``.
@@ -10740,7 +10831,7 @@
     - file: packages/state-transition/src/slot/upgradeStateToGloas.ts
       search: export function upgradeStateToGloas(
   spec: |
-    <spec fn="upgrade_to_gloas" fork="gloas" hash="855ad3f7">
+    <spec fn="upgrade_to_gloas" fork="gloas" hash="6e66df25">
     def upgrade_to_gloas(pre: fulu.BeaconState) -> BeaconState:
         epoch = fulu.get_current_epoch(pre)
 
@@ -10808,6 +10899,9 @@
             # [New in Gloas:EIP7732]
             payload_expected_withdrawals=[],
         )
+
+        # [New in Gloas:EIP7732]
+        onboard_builders_from_pending_deposits(post)
 
         return post
     </spec>
@@ -11117,8 +11211,12 @@
 - name: verify_data_column_sidecar#gloas
   sources: []
   spec: |
-    <spec fn="verify_data_column_sidecar" fork="gloas" hash="8838c4fd">
-    def verify_data_column_sidecar(sidecar: DataColumnSidecar) -> bool:
+    <spec fn="verify_data_column_sidecar" fork="gloas" hash="71548b68">
+    def verify_data_column_sidecar(
+        sidecar: DataColumnSidecar,
+        # [New in Gloas:EIP7732]
+        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+    ) -> bool:
         """
         Verify if the data column sidecar is valid.
         """
@@ -11126,18 +11224,14 @@
         if sidecar.index >= NUMBER_OF_COLUMNS:
             return False
 
+        # [Modified in Gloas:EIP7732]
         # A sidecar for zero blobs is invalid
-        if len(sidecar.kzg_commitments) == 0:
+        if len(sidecar.column) == 0:
             return False
 
         # [Modified in Gloas:EIP7732]
-        # Check that the sidecar respects the blob limit
-        epoch = compute_epoch_at_slot(sidecar.slot)
-        if len(sidecar.kzg_commitments) > get_blob_parameters(epoch).max_blobs_per_block:
-            return False
-
         # The column length must be equal to the number of commitments/proofs
-        if len(sidecar.column) != len(sidecar.kzg_commitments) or len(sidecar.column) != len(
+        if len(sidecar.column) != len(kzg_commitments) or len(sidecar.column) != len(
             sidecar.kzg_proofs
         ):
             return False
@@ -11180,6 +11274,33 @@
         # Batch verify that the cells match the corresponding commitments and proofs
         return verify_cell_kzg_proof_batch(
             commitments_bytes=sidecar.kzg_commitments,
+            cell_indices=cell_indices,
+            cells=sidecar.column,
+            proofs_bytes=sidecar.kzg_proofs,
+        )
+    </spec>
+
+- name: verify_data_column_sidecar_kzg_proofs#gloas
+  sources:
+    - file: packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+      search: export async function verifyDataColumnSidecarKzgProofs(
+  spec: |
+    <spec fn="verify_data_column_sidecar_kzg_proofs" fork="gloas" hash="1c4cf857">
+    def verify_data_column_sidecar_kzg_proofs(
+        sidecar: DataColumnSidecar,
+        # [New in Gloas:EIP7732]
+        kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK],
+    ) -> bool:
+        """
+        Verify if the KZG proofs are correct.
+        """
+        # The column index also represents the cell index
+        cell_indices = [CellIndex(sidecar.index)] * len(sidecar.column)
+
+        # Batch verify that the cells match the corresponding commitments and proofs
+        return verify_cell_kzg_proof_batch(
+            # [Modified in Gloas:EIP7732]
+            commitments_bytes=kzg_commitments,
             cell_indices=cell_indices,
             cells=sidecar.column,
             proofs_bytes=sidecar.kzg_proofs,


### PR DESCRIPTION
notable changes
- update to spec [v1.7.0-alpha.2](https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.2)
- improve performance of PTC computation (~4x faster)
- move kzg commitments to bid / beacon block body
- add block validation gossip rules
- enable gloas sanity and transition spec tests