### PR TITLE
ci: update docker sanity check to perform before publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,6 +46,13 @@ jobs:
           --platform linux/${{ matrix.arch }}
           --build-arg COMMIT=$(git rev-parse HEAD)
 
+      - name: Sanity check lodestar (${{ matrix.arch }})
+        run: |
+          docker run -d --name lodestar-sanity-${{ matrix.arch }} -p 9596:9596 chainsafe/lodestar:${{ inputs.tag }}-${{ matrix.arch }} dev --rest.address 0.0.0.0
+          sleep 30
+          curl -f http://127.0.0.1:9596/eth/v1/node/version || (docker logs lodestar-sanity-${{ matrix.arch }} && exit 1)
+          docker stop lodestar-sanity-${{ matrix.arch }}
+
       - name: Build and push custom Grafana
         run: >
           docker buildx build ./docker/grafana/ --push
@@ -97,12 +104,5 @@ jobs:
           docker buildx imagetools create -t chainsafe/lodestar-prometheus:${{ inputs.tag }} \
             chainsafe/lodestar-prometheus:${{ inputs.tag }}-amd64 \
             chainsafe/lodestar-prometheus:${{ inputs.tag }}-arm64
-
-      - name: Sanity check image
-        run: |
-          docker run -d --name lodestar-sanity -p 9596:9596 chainsafe/lodestar:${{ inputs.tag }} dev --rest.address 0.0.0.0
-          sleep 30
-          curl -f http://127.0.0.1:9596/eth/v1/node/version || (docker logs lodestar-sanity && exit 1)
-          docker stop lodestar-sanity
 
       - run: docker image history chainsafe/lodestar:${{ inputs.tag }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -105,4 +105,7 @@ jobs:
             chainsafe/lodestar-prometheus:${{ inputs.tag }}-amd64 \
             chainsafe/lodestar-prometheus:${{ inputs.tag }}-arm64
 
-      - run: docker image history chainsafe/lodestar:${{ inputs.tag }}
+      - name: Verify lodestar manifest
+        run: |
+          docker pull chainsafe/lodestar:${{ inputs.tag }}
+          docker image history chainsafe/lodestar:${{ inputs.tag }}


### PR DESCRIPTION
**Motivation**

Make safety checks so docker build should not fail for/between releases. 

**Description**

- Update docker workflow to accept `push` and `sanity-check` inputs 
- Run docker workflow during tests without pushing 
- Publish docker for branches starting with `feature/*` converted to tag as `feature-*`

