### PR TITLE
fix: align getNodeVersionV2 with latest spec - singular execution_client

### DIFF
--- a/packages/api/src/beacon/routes/node.ts
+++ b/packages/api/src/beacon/routes/node.ts
@@ -131,7 +131,7 @@ export type ClientVersion = {
 
 export type NodeVersionV2 = {
   beaconNode: ClientVersion;
-  executionClient?: ClientVersion[];
+  executionClient?: ClientVersion;
 };
 
 /**

--- a/packages/api/test/unit/beacon/testData/node.ts
+++ b/packages/api/test/unit/beacon/testData/node.ts
@@ -57,14 +57,12 @@ export const testData: GenericServerTestCases<Endpoints> = {
           version: "v1.38.0",
           commit: "0xdbd94781",
         },
-        executionClient: [
-          {
-            code: ClientCode.NM,
-            name: "Nethermind",
-            version: "v1.35.8",
-            commit: "0xc066aee2",
-          },
-        ],
+        executionClient: {
+          code: ClientCode.NM,
+          name: "Nethermind",
+          version: "v1.35.8",
+          commit: "0xc066aee2",
+        },
       },
     },
   },

--- a/packages/beacon-node/src/api/impl/node/index.ts
+++ b/packages/beacon-node/src/api/impl/node/index.ts
@@ -70,7 +70,7 @@ export function getNodeApi(
           beaconNode: toSpecClientVersion(getLodestarClientVersion(opts)),
           executionClient:
             chain.executionEngine.clientVersion != null
-              ? [toSpecClientVersion(chain.executionEngine.clientVersion)]
+              ? toSpecClientVersion(chain.executionEngine.clientVersion)
               : undefined,
         },
       };


### PR DESCRIPTION
## Description

Aligns `getNodeVersionV2` with the latest spec change in [ethereum/beacon-APIs#568](https://github.com/ethereum/beacon-APIs/pull/568).

The spec [reverted `execution_client` from an array to a single optional object](https://github.com/eth2353/beacon-APIs/commit/938aa33d) — if the Engine API returns multiple values, the beacon node should return only the first one for consistent behavior across clients.

### Changes
- `NodeVersionV2.executionClient`: `ClientVersion[]` → `ClientVersion` (optional singular)
- Updated implementation to return single object instead of wrapping in array
- Updated test data

### Type of change
- [x] Bug fix (non-breaking)

### Checklist
- [x] Types compile (`pnpm build` passes)
- [x] Unit tests pass (`pnpm --filter @lodestar/api test:unit` — 611/611)

_This PR was created with AI assistance (Lodekeeper 🌟)_