### PR TITLE
chore: use grep -F for fixed string matching in docs workflows

### DIFF
--- a/.github/workflows/docs-backfill.yml
+++ b/.github/workflows/docs-backfill.yml
@@ -34,7 +34,7 @@ jobs:
           COUNT=${{ github.event.inputs.count || '10' }}
 
           # Get the last N stable release tags (exclude rc pre-releases)
-          STABLE_TAGS=$(git tag -l 'v*' --sort=-v:refname | grep -v '-rc\.' | head -n "$COUNT")
+          STABLE_TAGS=$(git tag -l 'v*' --sort=-v:refname | grep -vF -- '-rc.' | head -n "$COUNT")
           echo "Found stable tags:"
           echo "$STABLE_TAGS"
 

--- a/.github/workflows/docs-version.yml
+++ b/.github/workflows/docs-version.yml
@@ -20,7 +20,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
           # Determine if this is a stable release or pre-release
-          if echo "$VERSION" | grep -q '-rc\.'; then
+          if echo "$VERSION" | grep -qF -- '-rc.'; then
             echo "is_stable=false" >> $GITHUB_OUTPUT
             # Extract base version (e.g., 1.40.0 from 1.40.0-rc.0)
             BASE_VERSION=$(echo "$VERSION" | sed 's/-.*//')


### PR DESCRIPTION
## Description

Fixes the backfill workflow silently doing nothing.

The backslash in `grep -v '-rc\.'` was being consumed by YAML/shell expansion in GitHub Actions, causing grep to fail with `invalid option -- '\'`. This made `STABLE_TAGS` empty, so the backfill found nothing to do and reported "All 10 recent stable versions are already cached!"

**Fix:** Switch to `grep -F` (fixed string mode) which doesn't need escaping.

Affected workflows:
- `docs-backfill.yml`: tag filtering for stable releases
- `docs-version.yml`: RC pre-release detection

---

> [!NOTE]
> This PR was authored with AI assistance (Lodekeeper 🌟)