### PR TITLE
fix: detect package manager in docs-backfill workflow

### DIFF
--- a/.github/workflows/docs-backfill.yml
+++ b/.github/workflows/docs-backfill.yml
@@ -112,12 +112,22 @@ jobs:
             # Checkout the tag
             git checkout "$TAG"
 
+            # Detect package manager (older versions use yarn, newer use pnpm)
+            if grep -q '"packageManager": "pnpm' package.json 2>/dev/null; then
+              PM="pnpm"
+              INSTALL="pnpm install --frozen-lockfile"
+            else
+              PM="yarn"
+              INSTALL="yarn install --frozen-lockfile"
+            fi
+            echo "Using package manager: $PM"
+
             # Install and build at that tag
-            pnpm install --frozen-lockfile
-            pnpm build
+            $INSTALL
+            $PM build
 
             # Generate docs
-            pnpm docs:build
+            $PM docs:build
 
             # Restore existing versioned content into docs/
             cp -r "$VERSIONED_DIR/versioned_docs" docs/ 2>/dev/null || true
@@ -126,7 +136,7 @@ jobs:
 
             # Install docs deps and create version snapshot
             cd docs
-            pnpm install
+            $PM install
             npx docusaurus docs:version "$VERSION"
             cd ..
 


### PR DESCRIPTION
## Description

Fixes backfill failing on older releases that use yarn instead of pnpm.

Lodestar releases v1.33.0–v1.38.0 use **yarn**, while v1.39.0+ use **pnpm**. The backfill workflow was hardcoded to use `pnpm`, causing it to fail immediately on v1.33.0 with:

```
ERROR  This project is configured to use yarn
```

**Fix:** Detect the package manager from `packageManager` field in `package.json` at each tag and use the correct one.

---

> [!NOTE]
> This PR was authored with AI assistance (Lodekeeper 🌟)