### PR TITLE
fix: return available light client updates instead of throwing on missing periods

### DIFF
--- a/packages/beacon-node/src/api/impl/lightclient/index.ts
+++ b/packages/beacon-node/src/api/impl/lightclient/index.ts
@@ -1,7 +1,9 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {MAX_REQUEST_LIGHT_CLIENT_COMMITTEE_HASHES, MAX_REQUEST_LIGHT_CLIENT_UPDATES} from "@lodestar/params";
+import type {LightClientUpdate} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
+import {LightClientServerError, LightClientServerErrorCode} from "../../../chain/errors/lightClientError.js";
 import {assertLightClientServer} from "../../../node/utils/lightclient.js";
 import {ApiModules} from "../types.js";
 // TODO: Import from lightclient/server package
@@ -16,8 +18,25 @@ export function getLightclientApi({
       assertLightClientServer(lightClientServer);
 
       const maxAllowedCount = Math.min(MAX_REQUEST_LIGHT_CLIENT_UPDATES, count);
-      const periods = Array.from({length: maxAllowedCount}, (_ignored, i) => i + startPeriod);
-      const updates = await Promise.all(periods.map((period) => lightClientServer.getUpdate(period)));
+      const updates: LightClientUpdate[] = [];
+      for (let i = 0; i < maxAllowedCount; i++) {
+        try {
+          const update = await lightClientServer.getUpdate(startPeriod + i);
+          updates.push(update);
+        } catch (e) {
+          if (
+            (e as LightClientServerError).type?.code === LightClientServerErrorCode.RESOURCE_UNAVAILABLE
+          ) {
+            // Period not available — if we already have results, stop to preserve
+            // consecutive order. If not, skip and try the next period.
+            if (updates.length > 0) break;
+            continue;
+          }
+          // Unexpected error — rethrow
+          throw e;
+        }
+      }
+
       return {
         data: updates,
         meta: {versions: updates.map((update) => config.getForkName(update.attestedHeader.beacon.slot))},

--- a/packages/beacon-node/src/api/impl/lightclient/index.ts
+++ b/packages/beacon-node/src/api/impl/lightclient/index.ts
@@ -25,12 +25,12 @@ export function getLightclientApi({
           updates.push(update);
         } catch (e) {
           if ((e as LightClientServerError).type?.code === LightClientServerErrorCode.RESOURCE_UNAVAILABLE) {
-            // Period not available — if we already have results, stop to preserve
+            // Period not available, if we already have results, stop to preserve
             // consecutive order. If not, skip and try the next period.
             if (updates.length > 0) break;
             continue;
           }
-          // Unexpected error — rethrow
+          // Unexpected error
           throw e;
         }
       }

--- a/packages/beacon-node/src/api/impl/lightclient/index.ts
+++ b/packages/beacon-node/src/api/impl/lightclient/index.ts
@@ -24,9 +24,7 @@ export function getLightclientApi({
           const update = await lightClientServer.getUpdate(startPeriod + i);
           updates.push(update);
         } catch (e) {
-          if (
-            (e as LightClientServerError).type?.code === LightClientServerErrorCode.RESOURCE_UNAVAILABLE
-          ) {
+          if ((e as LightClientServerError).type?.code === LightClientServerErrorCode.RESOURCE_UNAVAILABLE) {
             // Period not available — if we already have results, stop to preserve
             // consecutive order. If not, skip and try the next period.
             if (updates.length > 0) break;

--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -355,7 +355,10 @@ export class LightClientServer {
     // Signature data
     const update = await this.db.bestLightClientUpdate.get(period);
     if (!update) {
-      throw Error(`No partialUpdate available for period ${period}`);
+      throw new LightClientServerError(
+        {code: LightClientServerErrorCode.RESOURCE_UNAVAILABLE},
+        `No partialUpdate available for period ${period}`
+      );
     }
     return update;
   }

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientUpdatesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientUpdatesByRange.ts
@@ -19,6 +19,7 @@ export async function* onLightClientUpdatesByRange(
   assertLightClientServer(chain.lightClientServer);
 
   const count = Math.min(MAX_REQUEST_LIGHT_CLIENT_UPDATES, requestBody.count);
+  let started = false;
   for (let period = requestBody.startPeriod; period < requestBody.startPeriod + count; period++) {
     try {
       const update = await chain.lightClientServer.getUpdate(period);
@@ -29,9 +30,13 @@ export async function* onLightClientUpdatesByRange(
         data: type.serialize(update),
         boundary,
       };
+      started = true;
     } catch (e) {
       if ((e as LightClientServerError).type?.code === LightClientServerErrorCode.RESOURCE_UNAVAILABLE) {
-        throw new ResponseError(RespStatus.RESOURCE_UNAVAILABLE, (e as Error).message);
+        // Period not available — if we already started yielding, stop to
+        // preserve consecutive order. Otherwise skip leading gaps.
+        if (started) return;
+        continue;
       }
       throw new ResponseError(RespStatus.SERVER_ERROR, (e as Error).message);
     }

--- a/packages/beacon-node/src/network/reqresp/handlers/lightClientUpdatesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/lightClientUpdatesByRange.ts
@@ -33,7 +33,7 @@ export async function* onLightClientUpdatesByRange(
       started = true;
     } catch (e) {
       if ((e as LightClientServerError).type?.code === LightClientServerErrorCode.RESOURCE_UNAVAILABLE) {
-        // Period not available — if we already started yielding, stop to
+        // Period not available, if we already started yielding, stop to
         // preserve consecutive order. Otherwise skip leading gaps.
         if (started) return;
         continue;


### PR DESCRIPTION
## Description

When `getLightClientUpdatesByRange` is called with a range that extends beyond the current sync committee period (e.g., `start_period=1172&count=128` where 1172 is the latest period), it returns a 500 error because `Promise.all` rejects when any period throws `No partialUpdate available`.

Per the [beacon API spec](https://github.com/ethereum/beacon-APIs/blob/master/apis/beacon/light_client/updates.yaml):
> Servers MUST respond with at least the earliest known result within the requested range, and MUST send results in consecutive order (by period).

### Changes

**`getUpdate()` — consistent error type:**
- Now throws `LightClientServerError(RESOURCE_UNAVAILABLE)` instead of generic `Error`, consistent with all other light client server methods (`getBootstrap`, `getCommitteeRoot`)

**REST API handler (`/eth/v1/beacon/light_client/updates`):**
- Replaces `Promise.all` with sequential iteration
- Skips leading unavailable periods to find the earliest known result in the range
- Collects consecutive updates until a gap is hit
- Only catches `RESOURCE_UNAVAILABLE`; unexpected errors are rethrown (no silent swallowing)
- Returns empty array (not 500) if no updates exist in range

**P2P req/resp handler (`light_client_updates_by_range`):**
- Stops yielding gracefully on unavailable periods instead of throwing `RESOURCE_UNAVAILABLE` error response
- Also skips leading gaps, matching the spec semantics

### Before
```
GET /eth/v1/beacon/light_client/updates?start_period=1172&count=2
→ 500: "No partialUpdate available for 1173"
```

### After
```
GET /eth/v1/beacon/light_client/updates?start_period=1172&count=2
→ 200: [update for period 1172]
```

Closes #8902

> [!NOTE]
> This PR was authored with AI assistance 🤖