### PR TITLE
fix(beacon-node): move serializedCache.clear() to after DB write completes

### DIFF
--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -101,9 +101,6 @@ export async function importBlock(
     }
   });
 
-  // Without forcefully clearing this cache, we would rely on WeakMap to evict memory which is not reliable
-  this.serializedCache.clear();
-
   // 2. Import block to fork choice
 
   // Should compute checkpoint balances before forkchoice.onBlock

--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -125,6 +125,9 @@ export async function persistBlockInputs(this: BeaconChain, blockInputs: IBlockI
       for (const blockInput of blockInputs) {
         this.seenBlockInputCache.prune(blockInput.blockRootHex);
       }
+      // Without forcefully clearing this cache, we would rely on WeakMap to evict memory which is not reliable.
+      // Clear here (after the DB write) so that writeBlockInputToDb can still use the cached serialized bytes.
+      this.serializedCache.clear();
       if (blockInputs.length === 1) {
         this.logger.debug("Pruned block input", {
           slot: blockInputs[0].slot,

--- a/packages/beacon-node/src/util/serializedCache.ts
+++ b/packages/beacon-node/src/util/serializedCache.ts
@@ -14,6 +14,11 @@ export class SerializedCache {
     this.map.set(obj, serialized);
   }
 
+  /**
+   * Replace the internal WeakMap to force GC of all cached entries.
+   * Must only be called after all DB writes that may read from this cache have completed,
+   * otherwise cached serialized bytes will be unavailable and data will be re-serialized unnecessarily.
+   */
   clear(): void {
     this.map = new WeakMap();
   }


### PR DESCRIPTION
**Motivation**

`serializedCache.clear()` was called immediately after queuing the block for async DB persistence in `importBlock()`. Since the DB write (`writeBlockInputToDb`) runs asynchronously, the cache was always empty by the time the write tried to read from it — silently defeating the serialization optimization on every block import.

The regression was introduced in #8784 when the DB write was converted from `await` to fire-and-forget, without moving the cache clear accordingly.

**Description**

- Remove `serializedCache.clear()` from `importBlock.ts` where it ran too early (before the async DB write)
- Move it to the `finally` block of `persistBlockInputs` in `writeBlockInputToDb.ts`, so it runs after the DB write completes regardless of success or failure
- Add a JSDoc on `SerializedCache.clear()` documenting that it must only be called after all DB writes that may read from the cache have completed

**AI Assistance Disclosure**

This fix was identified and authored with Claude Code (Claude Sonnet 4.5).