### PR TITLE
test: increase prover e2e hook timeout to include genesis delay

### DIFF
--- a/packages/prover/test/e2e/cli/cmds/start.test.ts
+++ b/packages/prover/test/e2e/cli/cmds/start.test.ts
@@ -7,7 +7,16 @@ import {ChainConfig, chainConfigToJson} from "@lodestar/config";
 import {runCliCommand, spawnCliCommand, stopChildProcess} from "@lodestar/test-utils";
 import {sleep} from "@lodestar/utils";
 import {getLodestarProverCli} from "../../../../src/cli/cli.js";
-import {beaconUrl, chainId, config, proxyPort, proxyUrl, rpcUrl, waitForFinalized} from "../../../utils/e2e_env.js";
+import {
+  beaconUrl,
+  chainId,
+  config,
+  minFinalizedTimeMs,
+  proxyPort,
+  proxyUrl,
+  rpcUrl,
+  waitForFinalized,
+} from "../../../utils/e2e_env.js";
 
 const cli = getLodestarProverCli();
 
@@ -53,7 +62,7 @@ describe("prover/proxy", () => {
       );
       // Give sometime to the prover to start proxy server
       await sleep(3000);
-    }, 80000);
+    }, minFinalizedTimeMs);
 
     afterAll(async () => {
       if (proc) {

--- a/packages/prover/test/utils/e2e_env.ts
+++ b/packages/prover/test/utils/e2e_env.ts
@@ -15,8 +15,10 @@ const denebForkEpoch = 0;
 const electraForkEpoch = 0;
 const genesisDelaySeconds = 30 * secondsPerSlot;
 
-// Wait for at least 3 epochs to ensure light client can sync from a finalized checkpoint
-export const minFinalizedTimeMs = 3 * 8 * 4 * 1000;
+// Wait for genesis delay + at least 3 epochs to ensure light client can sync from a finalized checkpoint.
+// The e2e test env has a genesis delay of ~24-30 slots (96-120s) before the chain starts producing blocks,
+// then needs 3 epochs (96s) to reach finalization. The hook timeout must cover both.
+export const minFinalizedTimeMs = (genesisDelaySeconds + 3 * 8 * secondsPerSlot) * 1000;
 
 export const config = {
   ALTAIR_FORK_EPOCH: altairForkEpoch,

--- a/packages/prover/test/utils/e2e_env.ts
+++ b/packages/prover/test/utils/e2e_env.ts
@@ -13,12 +13,18 @@ const bellatrixForkEpoch = 0;
 const capellaForkEpoch = 0;
 const denebForkEpoch = 0;
 const electraForkEpoch = 0;
+
+// Minimal preset constants used by prover e2e env
+const SLOTS_PER_EPOCH_MINIMAL = 8;
+const EPOCHS_TO_FINALIZE = 3;
+
 const genesisDelaySeconds = 30 * secondsPerSlot;
 
 // Wait for genesis delay + at least 3 epochs to ensure light client can sync from a finalized checkpoint.
 // The e2e test env has a genesis delay of ~24-30 slots (96-120s) before the chain starts producing blocks,
 // then needs 3 epochs (96s) to reach finalization. The hook timeout must cover both.
-export const minFinalizedTimeMs = (genesisDelaySeconds + 3 * 8 * secondsPerSlot) * 1000;
+export const minFinalizedTimeMs =
+  (genesisDelaySeconds + EPOCHS_TO_FINALIZE * SLOTS_PER_EPOCH_MINIMAL * secondsPerSlot) * 1000;
 
 export const config = {
   ALTAIR_FORK_EPOCH: altairForkEpoch,
@@ -32,5 +38,5 @@ export const config = {
 
 export function waitForFinalized(): Promise<void> {
   // Wait for 2 epochs to pass so that the light client can sync from a finalized checkpoint
-  return waitForEndpoint(`${beaconUrl}/eth/v1/beacon/headers/${2 * 8}`);
+  return waitForEndpoint(`${beaconUrl}/eth/v1/beacon/headers/${2 * SLOTS_PER_EPOCH_MINIMAL}`);
 }

--- a/packages/prover/test/utils/e2e_env.ts
+++ b/packages/prover/test/utils/e2e_env.ts
@@ -13,18 +13,12 @@ const bellatrixForkEpoch = 0;
 const capellaForkEpoch = 0;
 const denebForkEpoch = 0;
 const electraForkEpoch = 0;
-
-// Minimal preset constants used by prover e2e env
-const SLOTS_PER_EPOCH_MINIMAL = 8;
-const EPOCHS_TO_FINALIZE = 3;
-
 const genesisDelaySeconds = 30 * secondsPerSlot;
 
 // Wait for genesis delay + at least 3 epochs to ensure light client can sync from a finalized checkpoint.
 // The e2e test env has a genesis delay of ~24-30 slots (96-120s) before the chain starts producing blocks,
 // then needs 3 epochs (96s) to reach finalization. The hook timeout must cover both.
-export const minFinalizedTimeMs =
-  (genesisDelaySeconds + EPOCHS_TO_FINALIZE * SLOTS_PER_EPOCH_MINIMAL * secondsPerSlot) * 1000;
+export const minFinalizedTimeMs = (genesisDelaySeconds + 3 * 8 * secondsPerSlot) * 1000;
 
 export const config = {
   ALTAIR_FORK_EPOCH: altairForkEpoch,
@@ -38,5 +32,5 @@ export const config = {
 
 export function waitForFinalized(): Promise<void> {
   // Wait for 2 epochs to pass so that the light client can sync from a finalized checkpoint
-  return waitForEndpoint(`${beaconUrl}/eth/v1/beacon/headers/${2 * SLOTS_PER_EPOCH_MINIMAL}`);
+  return waitForEndpoint(`${beaconUrl}/eth/v1/beacon/headers/${2 * 8}`);
 }


### PR DESCRIPTION
## Motivation

The prover e2e tests (`web3_batch_request`, `web3_provider`, `cli/cmds/start`) frequently fail with hook timeouts:

```
Error: Hook timed out in 96000ms.
Error: Hook timed out in 80000ms.
```

These 3 tests are the most common E2E failures after the reqresp fix (#8908).

## Root Cause

`minFinalizedTimeMs` is set to `3 * 8 * 4 * 1000 = 96000ms` (3 epochs of chain time), but this does **not** include genesis delay. The e2e test environment has a genesis delay of `30 * 4 = 120s` before the chain starts producing blocks.

The actual time from env start to finalization:
- Genesis delay: ~120s
- 3 epochs to finalize: ~96s  
- **Total: ~216s** vs **96s timeout**

The tests only passed when other tests happened to run first and consume enough wall time for the chain to progress past finalization.

Additionally, `start.test.ts` used a hardcoded `80000ms` timeout — even shorter than `minFinalizedTimeMs`.

## Fix

1. Include `genesisDelaySeconds` in `minFinalizedTimeMs`: `(genesisDelay + 3 epochs) * 1000 = 216s`
2. Use `minFinalizedTimeMs` consistently in `start.test.ts` instead of hardcoded `80000ms`

## Notes

- No production logic changes — test config only
- This PR was authored by an AI contributor.