### PR TITLE
test(sim): use directPeers to maintain peer connections during sync

### DIFF
--- a/packages/cli/test/utils/crucible/assertions/defaults/connectedPeerCountAssertion.ts
+++ b/packages/cli/test/utils/crucible/assertions/defaults/connectedPeerCountAssertion.ts
@@ -10,16 +10,12 @@ export const connectedPeerCountAssertion: Assertion<"connectedPeerCount", number
   async assert({nodes, slot, store}) {
     const errors: AssertionResult[] = [];
 
-    // Allow one missing peer connection to account for transient disconnects on CI.
-    // With N nodes, expect at least N-2 connections instead of N-1.
-    // For single-node setups (e.g. endpoint sim), expect 0 peers.
-    const minExpectedConnections = nodes.length <= 1 ? 0 : nodes.length - 2;
-    if (store[slot] < minExpectedConnections) {
+    if (store[slot] < nodes.length - 1) {
       errors.push([
         "node has has low peer connections",
         {
           connections: store[slot],
-          expectedConnections: minExpectedConnections,
+          expectedConnections: nodes.length - 1,
         },
       ]);
     }

--- a/packages/cli/test/utils/crucible/interfaces.ts
+++ b/packages/cli/test/utils/crucible/interfaces.ts
@@ -172,6 +172,11 @@ export interface BeaconNode<C extends BeaconClient = BeaconClient> {
   readonly restPrivateUrl: string;
   readonly api: C extends BeaconClient.Lodestar ? LodestarAPI : LighthouseAPI;
   readonly job: Job;
+  /**
+   * P2P multiaddr including peer ID, populated after the node starts.
+   * Used for configuring `--directPeers` on other nodes.
+   */
+  multiaddr?: string;
 }
 
 export interface ValidatorNode<C extends ValidatorClient = ValidatorClient> {

--- a/packages/cli/test/utils/crucible/utils/network.ts
+++ b/packages/cli/test/utils/crucible/utils/network.ts
@@ -4,6 +4,23 @@ import {BeaconClient, BeaconNode, ExecutionClient, ExecutionNode, NodePair} from
 import {Simulation} from "../simulation.js";
 import {SimulationTrackerEvent} from "../simulationTracker.js";
 
+/**
+ * Get the p2p multiaddrs (including peer ID) for all given CL nodes.
+ * Useful for configuring `--directPeers` on new nodes to maintain
+ * permanent connections without relying on discv5 discovery.
+ */
+export async function getCLNodeMultiaddrs(nodes: BeaconNode[]): Promise<string[]> {
+  const multiaddrs: string[] = [];
+  for (const node of nodes) {
+    const identity = (await node.api.node.getNetworkIdentity()).value();
+    if (identity.peerId && identity.p2pAddresses.length > 0) {
+      // Use the first p2p address, replacing with localhost for local sim
+      multiaddrs.push(identity.p2pAddresses[0].replace(/(\/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/)/, "/127.0.0.1/"));
+    }
+  }
+  return multiaddrs;
+}
+
 export async function connectAllNodes(nodes: NodePair[]): Promise<void> {
   for (const node of nodes) {
     await connectNewNode(node, nodes);

--- a/packages/cli/test/utils/crucible/utils/network.ts
+++ b/packages/cli/test/utils/crucible/utils/network.ts
@@ -5,20 +5,11 @@ import {Simulation} from "../simulation.js";
 import {SimulationTrackerEvent} from "../simulationTracker.js";
 
 /**
- * Get the p2p multiaddrs (including peer ID) for all given CL nodes.
- * Useful for configuring `--directPeers` on new nodes to maintain
- * permanent connections without relying on discv5 discovery.
+ * Get the cached p2p multiaddrs for all given CL nodes.
+ * Multiaddrs are populated during {@link connectNewCLNode}.
  */
-export async function getCLNodeMultiaddrs(nodes: BeaconNode[]): Promise<string[]> {
-  const multiaddrs: string[] = [];
-  for (const node of nodes) {
-    const identity = (await node.api.node.getNetworkIdentity()).value();
-    if (identity.peerId && identity.p2pAddresses.length > 0) {
-      // Use the first p2p address, replacing with localhost for local sim
-      multiaddrs.push(identity.p2pAddresses[0].replace(/(\/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/)/, "/127.0.0.1/"));
-    }
-  }
-  return multiaddrs;
+export function getCLNodeMultiaddrs(nodes: BeaconNode[]): string[] {
+  return nodes.filter((n) => n.multiaddr != null).map((n) => n.multiaddr as string);
 }
 
 export async function connectAllNodes(nodes: NodePair[]): Promise<void> {
@@ -41,6 +32,11 @@ export async function connectNewNode(newNode: NodePair, nodes: NodePair[]): Prom
 export async function connectNewCLNode(newNode: BeaconNode, nodes: BeaconNode[]): Promise<void> {
   const clIdentity = (await newNode.api.node.getNetworkIdentity()).value();
   if (!clIdentity.peerId) return;
+
+  // Cache the multiaddr on the node for use with directPeers
+  if (clIdentity.p2pAddresses.length > 0) {
+    newNode.multiaddr = clIdentity.p2pAddresses[0].replace(/(\/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/)/, "/127.0.0.1/");
+  }
 
   for (const node of nodes) {
     if (node === newNode) continue;

--- a/packages/cli/test/utils/crucible/utils/network.ts
+++ b/packages/cli/test/utils/crucible/utils/network.ts
@@ -4,14 +4,6 @@ import {BeaconClient, BeaconNode, ExecutionClient, ExecutionNode, NodePair} from
 import {Simulation} from "../simulation.js";
 import {SimulationTrackerEvent} from "../simulationTracker.js";
 
-/**
- * Get the cached p2p multiaddrs for all given CL nodes.
- * Multiaddrs are populated during {@link connectNewCLNode}.
- */
-export function getCLNodeMultiaddrs(nodes: BeaconNode[]): string[] {
-  return nodes.filter((n) => n.multiaddr != null).map((n) => n.multiaddr as string);
-}
-
 export async function connectAllNodes(nodes: NodePair[]): Promise<void> {
   for (const node of nodes) {
     await connectNewNode(node, nodes);

--- a/packages/cli/test/utils/crucible/utils/syncing.ts
+++ b/packages/cli/test/utils/crucible/utils/syncing.ts
@@ -44,13 +44,52 @@ export async function assertRangeSync(env: Simulation): Promise<void> {
     env.nodes.map((node) => node.beacon)
   );
 
-  await waitForNodeSync(env, rangeSync, {
-    head: toHex(currentHead.root),
-    slot: currentHead.header.message.slot,
-  });
+  // Maintain peer connections in the background during sync. If peers drop due to
+  // transient reqresp errors (e.g. stream resets), the node has no way to recover
+  // since discv5 has no boot ENRs in sim tests. This loop periodically checks the
+  // peer count and re-establishes connections if needed.
+  const ac = new AbortController();
+  const maintainConnections = maintainPeerConnections(rangeSync, env.nodes, ac.signal);
+
+  try {
+    await waitForNodeSync(env, rangeSync, {
+      head: toHex(currentHead.root),
+      slot: currentHead.header.message.slot,
+    });
+  } finally {
+    ac.abort();
+    await maintainConnections;
+  }
 
   await rangeSync.beacon.job.stop();
   await rangeSync.execution.job.stop();
+}
+
+/**
+ * Periodically check peer count and re-establish CL connections if the node
+ * has lost all peers. This prevents sync from stalling due to transient
+ * network errors in CI environments where discv5 discovery is not available.
+ */
+async function maintainPeerConnections(node: NodePair, allNodes: NodePair[], signal: AbortSignal): Promise<void> {
+  // Check every 4 seconds (one slot duration in minimal preset)
+  const checkIntervalMs = 4000;
+
+  while (!signal.aborted) {
+    await sleep(checkIntervalMs, signal).catch(() => {});
+    if (signal.aborted) break;
+
+    try {
+      const peers = (await node.beacon.api.node.getPeers({state: ["connected"]})).value();
+      if (peers.length === 0) {
+        await connectNewCLNode(
+          node.beacon,
+          allNodes.map((n) => n.beacon)
+        );
+      }
+    } catch {
+      // Node might be shutting down, ignore errors
+    }
+  }
 }
 
 export async function assertCheckpointSync(env: Simulation): Promise<void> {
@@ -85,10 +124,18 @@ export async function assertCheckpointSync(env: Simulation): Promise<void> {
   await checkpointSync.beacon.job.start();
   await connectNewNode(checkpointSync, env.nodes);
 
-  await waitForNodeSync(env, checkpointSync, {
-    head: toHex(finalizedCheckpoint.finalized.root),
-    slot: env.clock.getLastSlotOfEpoch(finalizedCheckpoint.finalized.epoch),
-  });
+  const ac = new AbortController();
+  const maintainConnections = maintainPeerConnections(checkpointSync, env.nodes, ac.signal);
+
+  try {
+    await waitForNodeSync(env, checkpointSync, {
+      head: toHex(finalizedCheckpoint.finalized.root),
+      slot: env.clock.getLastSlotOfEpoch(finalizedCheckpoint.finalized.epoch),
+    });
+  } finally {
+    ac.abort();
+    await maintainConnections;
+  }
 
   await checkpointSync.beacon.job.stop();
   await checkpointSync.execution.job.stop();

--- a/packages/cli/test/utils/crucible/utils/syncing.ts
+++ b/packages/cli/test/utils/crucible/utils/syncing.ts
@@ -4,14 +4,27 @@ import {SignedBeaconBlock, Slot} from "@lodestar/types";
 import {sleep, toHex} from "@lodestar/utils";
 import {BeaconClient, ExecutionClient, NodePair} from "../interfaces.js";
 import type {Simulation} from "../simulation.js";
-import {connectNewCLNode, connectNewELNode, connectNewNode, waitForHead, waitForSlot} from "./network.js";
+import {connectNewCLNode, connectNewELNode, connectNewNode, getCLNodeMultiaddrs, waitForHead, waitForSlot} from "./network.js";
 
 export async function assertRangeSync(env: Simulation): Promise<void> {
   const currentHead = (await env.nodes[0].beacon.api.beacon.getBlockHeader({blockId: "head"})).value();
 
+  // Get multiaddrs of existing nodes to configure as direct peers.
+  // Direct peers maintain permanent GossipSub mesh connections and are
+  // automatically reconnected, preventing sync stalls in CI environments
+  // where discv5 discovery is not available.
+  const directPeers = await getCLNodeMultiaddrs(env.nodes.map((n) => n.beacon));
+
   const rangeSync = await env.createNodePair({
     id: "range-sync-node",
-    beacon: BeaconClient.Lodestar,
+    beacon: {
+      type: BeaconClient.Lodestar,
+      options: {
+        clientOptions: {
+          directPeers,
+        },
+      },
+    },
     execution: ExecutionClient.Geth,
     keysCount: 0,
   });
@@ -44,52 +57,13 @@ export async function assertRangeSync(env: Simulation): Promise<void> {
     env.nodes.map((node) => node.beacon)
   );
 
-  // Maintain peer connections in the background during sync. If peers drop due to
-  // transient reqresp errors (e.g. stream resets), the node has no way to recover
-  // since discv5 has no boot ENRs in sim tests. This loop periodically checks the
-  // peer count and re-establishes connections if needed.
-  const ac = new AbortController();
-  const maintainConnections = maintainPeerConnections(rangeSync, env.nodes, ac.signal);
-
-  try {
-    await waitForNodeSync(env, rangeSync, {
-      head: toHex(currentHead.root),
-      slot: currentHead.header.message.slot,
-    });
-  } finally {
-    ac.abort();
-    await maintainConnections;
-  }
+  await waitForNodeSync(env, rangeSync, {
+    head: toHex(currentHead.root),
+    slot: currentHead.header.message.slot,
+  });
 
   await rangeSync.beacon.job.stop();
   await rangeSync.execution.job.stop();
-}
-
-/**
- * Periodically check peer count and re-establish CL connections if the node
- * has lost all peers. This prevents sync from stalling due to transient
- * network errors in CI environments where discv5 discovery is not available.
- */
-async function maintainPeerConnections(node: NodePair, allNodes: NodePair[], signal: AbortSignal): Promise<void> {
-  // Check every 4 seconds (one slot duration in minimal preset)
-  const checkIntervalMs = 4000;
-
-  while (!signal.aborted) {
-    await sleep(checkIntervalMs, signal).catch(() => {});
-    if (signal.aborted) break;
-
-    try {
-      const peers = (await node.beacon.api.node.getPeers({state: ["connected"]})).value();
-      if (peers.length === 0) {
-        await connectNewCLNode(
-          node.beacon,
-          allNodes.map((n) => n.beacon)
-        );
-      }
-    } catch {
-      // Node might be shutting down, ignore errors
-    }
-  }
 }
 
 export async function assertCheckpointSync(env: Simulation): Promise<void> {
@@ -106,6 +80,8 @@ export async function assertCheckpointSync(env: Simulation): Promise<void> {
     await env.nodes[0].beacon.api.beacon.getStateFinalityCheckpoints({stateId: "head"})
   ).value();
 
+  const directPeers = await getCLNodeMultiaddrs(env.nodes.map((n) => n.beacon));
+
   const checkpointSync = await env.createNodePair({
     id: "checkpoint-sync-node",
     beacon: {
@@ -113,6 +89,7 @@ export async function assertCheckpointSync(env: Simulation): Promise<void> {
       options: {
         clientOptions: {
           wssCheckpoint: `${toHex(finalizedCheckpoint.finalized.root)}:${finalizedCheckpoint.finalized.epoch}`,
+          directPeers,
         },
       },
     },
@@ -124,18 +101,10 @@ export async function assertCheckpointSync(env: Simulation): Promise<void> {
   await checkpointSync.beacon.job.start();
   await connectNewNode(checkpointSync, env.nodes);
 
-  const ac = new AbortController();
-  const maintainConnections = maintainPeerConnections(checkpointSync, env.nodes, ac.signal);
-
-  try {
-    await waitForNodeSync(env, checkpointSync, {
-      head: toHex(finalizedCheckpoint.finalized.root),
-      slot: env.clock.getLastSlotOfEpoch(finalizedCheckpoint.finalized.epoch),
-    });
-  } finally {
-    ac.abort();
-    await maintainConnections;
-  }
+  await waitForNodeSync(env, checkpointSync, {
+    head: toHex(finalizedCheckpoint.finalized.root),
+    slot: env.clock.getLastSlotOfEpoch(finalizedCheckpoint.finalized.epoch),
+  });
 
   await checkpointSync.beacon.job.stop();
   await checkpointSync.execution.job.stop();

--- a/packages/cli/test/utils/crucible/utils/syncing.ts
+++ b/packages/cli/test/utils/crucible/utils/syncing.ts
@@ -4,14 +4,7 @@ import {SignedBeaconBlock, Slot} from "@lodestar/types";
 import {sleep, toHex} from "@lodestar/utils";
 import {BeaconClient, ExecutionClient, NodePair} from "../interfaces.js";
 import type {Simulation} from "../simulation.js";
-import {
-  connectNewCLNode,
-  connectNewELNode,
-  connectNewNode,
-  getCLNodeMultiaddrs,
-  waitForHead,
-  waitForSlot,
-} from "./network.js";
+import {connectNewCLNode, connectNewELNode, connectNewNode, waitForHead, waitForSlot} from "./network.js";
 
 export async function assertRangeSync(env: Simulation): Promise<void> {
   const currentHead = (await env.nodes[0].beacon.api.beacon.getBlockHeader({blockId: "head"})).value();
@@ -20,7 +13,7 @@ export async function assertRangeSync(env: Simulation): Promise<void> {
   // Direct peers maintain permanent GossipSub mesh connections and are
   // automatically reconnected, preventing sync stalls in CI environments
   // where discv5 discovery is not available.
-  const directPeers = getCLNodeMultiaddrs(env.nodes.map((n) => n.beacon));
+  const directPeers = env.nodes.map((n) => n.beacon.multiaddr).filter((m): m is string => m != null);
 
   const rangeSync = await env.createNodePair({
     id: "range-sync-node",
@@ -87,7 +80,7 @@ export async function assertCheckpointSync(env: Simulation): Promise<void> {
     await env.nodes[0].beacon.api.beacon.getStateFinalityCheckpoints({stateId: "head"})
   ).value();
 
-  const directPeers = getCLNodeMultiaddrs(env.nodes.map((n) => n.beacon));
+  const directPeers = env.nodes.map((n) => n.beacon.multiaddr).filter((m): m is string => m != null);
 
   const checkpointSync = await env.createNodePair({
     id: "checkpoint-sync-node",
@@ -123,7 +116,7 @@ export async function assertUnknownBlockSync(env: Simulation): Promise<void> {
     await env.nodes[0].beacon.api.beacon.getBlobSidecars({blockId: currentHead.message.slot})
   ).value();
 
-  const directPeers = getCLNodeMultiaddrs(env.nodes.map((n) => n.beacon));
+  const directPeers = env.nodes.map((n) => n.beacon.multiaddr).filter((m): m is string => m != null);
 
   const unknownBlockSync = await env.createNodePair({
     id: "unknown-block-sync-node",

--- a/packages/cli/test/utils/crucible/utils/syncing.ts
+++ b/packages/cli/test/utils/crucible/utils/syncing.ts
@@ -4,7 +4,14 @@ import {SignedBeaconBlock, Slot} from "@lodestar/types";
 import {sleep, toHex} from "@lodestar/utils";
 import {BeaconClient, ExecutionClient, NodePair} from "../interfaces.js";
 import type {Simulation} from "../simulation.js";
-import {connectNewCLNode, connectNewELNode, connectNewNode, getCLNodeMultiaddrs, waitForHead, waitForSlot} from "./network.js";
+import {
+  connectNewCLNode,
+  connectNewELNode,
+  connectNewNode,
+  getCLNodeMultiaddrs,
+  waitForHead,
+  waitForSlot,
+} from "./network.js";
 
 export async function assertRangeSync(env: Simulation): Promise<void> {
   const currentHead = (await env.nodes[0].beacon.api.beacon.getBlockHeader({blockId: "head"})).value();

--- a/packages/cli/test/utils/crucible/utils/syncing.ts
+++ b/packages/cli/test/utils/crucible/utils/syncing.ts
@@ -116,6 +116,8 @@ export async function assertUnknownBlockSync(env: Simulation): Promise<void> {
     await env.nodes[0].beacon.api.beacon.getBlobSidecars({blockId: currentHead.message.slot})
   ).value();
 
+  const directPeers = await getCLNodeMultiaddrs(env.nodes.map((n) => n.beacon));
+
   const unknownBlockSync = await env.createNodePair({
     id: "unknown-block-sync-node",
     beacon: {
@@ -132,6 +134,7 @@ export async function assertUnknownBlockSync(env: Simulation): Promise<void> {
           contributing to the overall gap. For stability in our CI, we've opted to set a higher limit on this constraint.
           */
           "sync.slotImportTolerance": currentHead.message.slot,
+          directPeers,
         },
       },
     },

--- a/packages/cli/test/utils/crucible/utils/syncing.ts
+++ b/packages/cli/test/utils/crucible/utils/syncing.ts
@@ -20,7 +20,7 @@ export async function assertRangeSync(env: Simulation): Promise<void> {
   // Direct peers maintain permanent GossipSub mesh connections and are
   // automatically reconnected, preventing sync stalls in CI environments
   // where discv5 discovery is not available.
-  const directPeers = await getCLNodeMultiaddrs(env.nodes.map((n) => n.beacon));
+  const directPeers = getCLNodeMultiaddrs(env.nodes.map((n) => n.beacon));
 
   const rangeSync = await env.createNodePair({
     id: "range-sync-node",
@@ -87,7 +87,7 @@ export async function assertCheckpointSync(env: Simulation): Promise<void> {
     await env.nodes[0].beacon.api.beacon.getStateFinalityCheckpoints({stateId: "head"})
   ).value();
 
-  const directPeers = await getCLNodeMultiaddrs(env.nodes.map((n) => n.beacon));
+  const directPeers = getCLNodeMultiaddrs(env.nodes.map((n) => n.beacon));
 
   const checkpointSync = await env.createNodePair({
     id: "checkpoint-sync-node",
@@ -123,7 +123,7 @@ export async function assertUnknownBlockSync(env: Simulation): Promise<void> {
     await env.nodes[0].beacon.api.beacon.getBlobSidecars({blockId: currentHead.message.slot})
   ).value();
 
-  const directPeers = await getCLNodeMultiaddrs(env.nodes.map((n) => n.beacon));
+  const directPeers = getCLNodeMultiaddrs(env.nodes.map((n) => n.beacon));
 
   const unknownBlockSync = await env.createNodePair({
     id: "unknown-block-sync-node",


### PR DESCRIPTION
## Description

Prevent sim test sync assertions from stalling due to transient peer disconnections in CI environments without discv5 boot ENRs.

Instead of a custom peer maintenance loop, this uses GossipSub's built-in `directPeers` feature (as [suggested by @nazarhussain](https://github.com/ChainSafe/lodestar/pull/8912#issuecomment-3907755244)). Direct peers maintain permanent mesh connections and are automatically reconnected during the GossipSub heartbeat.

### Changes

- **`network.ts`**: Add `getCLNodeMultiaddrs()` helper to query existing nodes' p2p addresses
- **`syncing.ts`**: Configure `directPeers` on range-sync and checkpoint-sync nodes via `clientOptions`

### Motivation

In sim tests, nodes don't have discv5 boot ENRs. If a peer disconnects due to transient reqresp errors (e.g. stream resets), the syncing node has no way to rediscover and reconnect. With `directPeers`, GossipSub handles reconnection automatically.

> `@AI assisted`