### PR TITLE
fix: handle Gloas attestation data.index payload status signaling

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -936,11 +936,14 @@ export function getValidatorApi(
         if (attestedBlock !== null && attestedBlock.slot === slot) {
           // Same-slot attestation — payload may not have arrived yet
           index = 0;
+        } else if (attestedBlock === null) {
+          // Block not in fork-choice — historical block on canonical chain,
+          // payload should be considered available
+          index = 1;
         } else {
           // Look up payload availability for the attested block's slot
-          const attestedSlot = attestedBlock?.slot ?? slot;
           index = (headState as CachedBeaconStateGloas).executionPayloadAvailability.get(
-            attestedSlot % SLOTS_PER_HISTORICAL_ROOT
+            attestedBlock.slot % SLOTS_PER_HISTORICAL_ROOT
           )
             ? 1
             : 0;

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -14,9 +14,11 @@ import {
   isForkPostBellatrix,
   isForkPostDeneb,
   isForkPostElectra,
+  isForkPostGloas,
 } from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
+  CachedBeaconStateGloas,
   DataAvailabilityStatus,
   attesterShufflingDecisionRoot,
   beaconBlockToBlinded,
@@ -915,16 +917,7 @@ export function getValidatorApi(
       const headBlockRoot = fromHex(headBlockRootHex);
       const fork = config.getForkName(slot);
 
-      let index: CommitteeIndex;
-      if (isForkPostElectra(fork)) {
-        index = 0;
-      } else {
-        if (committeeIndex === undefined) {
-          throw new ApiError(400, `Committee index must be provided for pre-electra fork=${fork}`);
-        }
-        index = committeeIndex;
-      }
-
+      // Compute beaconBlockRoot first — needed for Gloas index derivation
       const beaconBlockRoot =
         slot >= headSlot
           ? // When attesting to the head slot or later, always use the head of the chain.
@@ -932,6 +925,34 @@ export function getValidatorApi(
           : // Permit attesting to slots *prior* to the current head. This is desirable when
             // the VC and BN are out-of-sync due to time issues or overloading.
             getBlockRootAtSlot(headState, slot);
+
+      let index: CommitteeIndex;
+      if (isForkPostGloas(fork)) {
+        // In Gloas (ePBS), attestation.data.index signals payload status:
+        //   0 = payload EMPTY (not available in canonical chain)
+        //   1 = payload FULL  (available in canonical chain)
+        // Per spec: if attested block.slot == data.slot, always 0 (payload not yet known)
+        const attestedBlock = chain.forkChoice.getBlock(beaconBlockRoot);
+        if (attestedBlock !== null && attestedBlock.slot === slot) {
+          // Same-slot attestation — payload may not have arrived yet
+          index = 0;
+        } else {
+          // Look up payload availability for the attested block's slot
+          const attestedSlot = attestedBlock?.slot ?? slot;
+          index = (headState as CachedBeaconStateGloas).executionPayloadAvailability.get(
+            attestedSlot % SLOTS_PER_HISTORICAL_ROOT
+          )
+            ? 1
+            : 0;
+        }
+      } else if (isForkPostElectra(fork)) {
+        index = 0;
+      } else {
+        if (committeeIndex === undefined) {
+          throw new ApiError(400, `Committee index must be provided for pre-electra fork=${fork}`);
+        }
+        index = committeeIndex;
+      }
 
       const targetSlot = computeStartSlotAtEpoch(attEpoch);
       const targetRoot =

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -1,6 +1,6 @@
 import {ApiClient} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, isForkPostElectra} from "@lodestar/params";
+import {ForkName, isForkPostElectra, isForkPostGloas} from "@lodestar/params";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {SignedAggregateAndProof, SingleAttestation, Slot, phase0, ssz} from "@lodestar/types";
 import {prettyBytes, sleep, toRootHex} from "@lodestar/utils";
@@ -108,7 +108,8 @@ export class AttestationService {
         Array.from(dutiesByCommitteeIndex.entries()).map(([index, dutiesSameCommittee]) => {
           const attestationData: phase0.AttestationData = {
             ...attestationNoCommittee,
-            index: isForkPostElectra(fork) ? 0 : index,
+            // Post-Gloas: preserve BN's data.index (payload status signal)
+            index: isForkPostGloas(fork) ? attestationNoCommittee.index : isForkPostElectra(fork) ? 0 : index,
           };
           return this.produceAndPublishAggregates(fork, attestationData, index, dutiesSameCommittee);
         })
@@ -145,7 +146,14 @@ export class AttestationService {
 
     await Promise.all(
       duties.map(async ({duty}) => {
-        const index = isForkPostElectra(fork) ? 0 : duty.committeeIndex;
+        // Post-Gloas: preserve BN's data.index which signals payload status (0=EMPTY, 1=FULL)
+        // Post-Electra (pre-Gloas): committee index is always 0
+        // Pre-Electra: use the duty's committee index
+        const index = isForkPostGloas(fork)
+          ? attestationNoCommittee.index
+          : isForkPostElectra(fork)
+            ? 0
+            : duty.committeeIndex;
         const attestationData: phase0.AttestationData = {...attestationNoCommittee, index};
         const logCtxValidator = {slot, index, head: headRootHex, validatorIndex: duty.validatorIndex};
 

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -797,13 +797,20 @@ export class ValidatorStore {
       throw Error(`Inconsistent duties during signing: duty.slot ${duty.slot} != att.slot ${data.slot}`);
     }
 
-    const isPostElectra = this.config.getForkSeq(data.slot) >= ForkSeq.electra;
+    const forkSeq = this.config.getForkSeq(data.slot);
+    const isPostElectra = forkSeq >= ForkSeq.electra;
+    const isPostGloas = forkSeq >= ForkSeq.gloas;
     if (!isPostElectra && duty.committeeIndex !== data.index) {
       throw Error(
         `Inconsistent duties during signing: duty.committeeIndex ${duty.committeeIndex} != att.committeeIndex ${data.index}`
       );
     }
-    if (isPostElectra && data.index !== 0) {
+    if (isPostGloas) {
+      // In Gloas, data.index signals payload status: 0 (EMPTY) or 1 (FULL)
+      if (data.index !== 0 && data.index !== 1) {
+        throw Error(`Invalid payload status index post-Gloas during signing: data.index=${data.index}`);
+      }
+    } else if (isPostElectra && data.index !== 0) {
       throw Error(`Non-zero committee index post-electra during signing: att.committeeIndex ${data.index}`);
     }
   }


### PR DESCRIPTION
## Description

In Gloas (ePBS), `attestation.data.index` is repurposed to signal payload status instead of committee index:
- `0` = payload EMPTY (not available in canonical chain)
- `1` = payload FULL (available in canonical chain)

Per spec (`consensus-specs/specs/gloas/validator.md`): if the attested block slot equals `data.slot`, always set `index = 0` (payload not yet known).

## Bugs Fixed

### 1. BN `produceAttestationData` — missing Gloas payload status logic
**File:** `packages/beacon-node/src/api/impl/validator/index.ts`

Previously always set `index = 0` for all post-Electra forks. Now correctly:
- Computes `beaconBlockRoot` first (moved before index derivation)
- Looks up the attested block via fork-choice to get its actual slot
- If `attestedBlock.slot === slot` → `index = 0` (same-slot, payload unknown)
- Otherwise → reads `executionPayloadAvailability` from head state at the attested slot

### 2. VC `validateAttestationDuty` — rejected valid Gloas attestations
**File:** `packages/validator/src/services/validatorStore.ts`

Previously rejected any `data.index !== 0` post-Electra. Now allows `{0, 1}` for Gloas while keeping the strict `index === 0` check for Electra.

### 3. VC attestation signing & aggregate paths — force-zeroed `data.index`
**File:** `packages/validator/src/services/attestation.ts`

Both the signing path and aggregate path force-overwrote `data.index` to `0` for all post-Electra forks. Even if the BN correctly produced `index = 1`, the VC would overwrite it before broadcasting. Now preserves BN-provided index for Gloas.

## Spec Reference
- `consensus-specs/specs/gloas/validator.md` — attestation data index semantics
- `consensus-specs/specs/gloas/beacon-chain.md` — `executionPayloadAvailability` state field

> **Note:** This PR was authored with AI assistance (Claude/GPT via [OpenClaw](https://openclaw.ai)). All changes have been reviewed for spec compliance.