### PR TITLE
feat: eip-8025 optional execution proofs

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -254,3 +254,4 @@ xcode
 yaml
 yamux
 yml
+zkvm

--- a/packages/api/src/beacon/routes/beacon/pool.ts
+++ b/packages/api/src/beacon/routes/beacon/pool.ts
@@ -5,6 +5,7 @@ import {
   ArrayOf,
   AttesterSlashing,
   CommitteeIndex,
+  ExecutionProof,
   SingleAttestation,
   Slot,
   capella,
@@ -37,6 +38,7 @@ const ProposerSlashingListType = ArrayOf(ssz.phase0.ProposerSlashing);
 const SignedVoluntaryExitListType = ArrayOf(ssz.phase0.SignedVoluntaryExit);
 const SignedBLSToExecutionChangeListType = ArrayOf(ssz.capella.SignedBLSToExecutionChange);
 const SyncCommitteeMessageListType = ArrayOf(ssz.altair.SyncCommitteeMessage);
+const ExecutionProofListType = ArrayOf(ssz.eip8025.ExecutionProof);
 
 type AttestationListPhase0 = ValueOf<typeof AttestationListTypePhase0>;
 type AttestationListElectra = ValueOf<typeof AttestationListTypeElectra>;
@@ -50,6 +52,7 @@ type ProposerSlashingList = ValueOf<typeof ProposerSlashingListType>;
 type SignedVoluntaryExitList = ValueOf<typeof SignedVoluntaryExitListType>;
 type SignedBLSToExecutionChangeList = ValueOf<typeof SignedBLSToExecutionChangeListType>;
 type SyncCommitteeMessageList = ValueOf<typeof SyncCommitteeMessageListType>;
+type ExecutionProofList = ValueOf<typeof ExecutionProofListType>;
 
 export type Endpoints = {
   /**
@@ -240,6 +243,26 @@ export type Endpoints = {
   submitPoolSyncCommitteeSignatures: Endpoint<
     "POST",
     {signatures: SyncCommitteeMessageList},
+    {body: unknown},
+    EmptyResponseData,
+    EmptyMeta
+  >;
+
+  /**
+   * Get ExecutionProofs from operations pool (EIP-8025)
+   * Retrieves execution proofs known by the node, optionally filtered by slot.
+   */
+  getPoolExecutionProofs: Endpoint<"GET", {slot?: Slot}, {query: {slot?: number}}, ExecutionProofList, EmptyMeta>;
+
+  /**
+   * Submit an ExecutionProof to the node's pool (EIP-8025)
+   * Submits an execution proof to the beacon node.
+   * The proof will be validated and stored in the execution proof pool.
+   * If valid, the proof will be published to the gossip network.
+   */
+  submitPoolExecutionProofs: Endpoint<
+    "POST",
+    {executionProof: ExecutionProof},
     {body: unknown},
     EmptyResponseData,
     EmptyMeta
@@ -495,6 +518,33 @@ export function getDefinitions(config: ChainForkConfig): RouteDefinitions<Endpoi
         parseReqSsz: ({body}) => ({signatures: SyncCommitteeMessageListType.deserialize(body)}),
         schema: {
           body: Schema.ObjectArray,
+        },
+      },
+      resp: EmptyResponseCodec,
+    },
+    getPoolExecutionProofs: {
+      url: "/eth/v1/beacon/pool/execution_proofs",
+      method: "GET",
+      req: {
+        writeReq: ({slot}) => ({query: {slot}}),
+        parseReq: ({query}) => ({slot: query.slot}),
+        schema: {query: {slot: Schema.Uint}},
+      },
+      resp: {
+        data: ExecutionProofListType,
+        meta: EmptyMetaCodec,
+      },
+    },
+    submitPoolExecutionProofs: {
+      url: "/eth/v1/beacon/pool/execution_proofs",
+      method: "POST",
+      req: {
+        writeReqJson: ({executionProof}) => ({body: ssz.eip8025.ExecutionProof.toJson(executionProof)}),
+        parseReqJson: ({body}) => ({executionProof: ssz.eip8025.ExecutionProof.fromJson(body)}),
+        writeReqSsz: ({executionProof}) => ({body: ssz.eip8025.ExecutionProof.serialize(executionProof)}),
+        parseReqSsz: ({body}) => ({executionProof: ssz.eip8025.ExecutionProof.deserialize(body)}),
+        schema: {
+          body: Schema.Object,
         },
       },
       resp: EmptyResponseCodec,

--- a/packages/api/test/unit/beacon/testData/beacon.ts
+++ b/packages/api/test/unit/beacon/testData/beacon.ts
@@ -168,6 +168,14 @@ export const testData: GenericServerTestCases<Endpoints> = {
     args: {signatures: [ssz.altair.SyncCommitteeMessage.defaultValue()]},
     res: undefined,
   },
+  getPoolExecutionProofs: {
+    args: {slot: 1},
+    res: {data: [ssz.eip8025.ExecutionProof.defaultValue()]},
+  },
+  submitPoolExecutionProofs: {
+    args: {executionProof: ssz.eip8025.ExecutionProof.defaultValue()},
+    res: undefined,
+  },
 
   // state
 

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -9,6 +9,7 @@ import {
   GossipAction,
   SyncCommitteeError,
 } from "../../../../chain/errors/index.js";
+import {InsertOutcome} from "../../../../chain/opPools/types.js";
 import {validateApiAttesterSlashing} from "../../../../chain/validation/attesterSlashing.js";
 import {validateApiBlsToExecutionChange} from "../../../../chain/validation/blsToExecutionChange.js";
 import {toElectraSingleAttestation, validateApiAttestation} from "../../../../chain/validation/index.js";
@@ -341,8 +342,9 @@ export function getBeaconPoolApi({
 
       // TODO EIP-8025: Add full proof verification (dummy accept for devnet)
 
-      // Add to pool
-      const insertOutcome = chain.executionProofPool.add(executionProof);
+      // Add to pool (pass clock slot to reject far-future proofs)
+      const clockSlot = chain.clock.currentSlot;
+      const insertOutcome = chain.executionProofPool.add(executionProof, clockSlot);
       logger.info("Execution proof submitted via API", {
         slot,
         blockRoot: blockRootHex,
@@ -350,11 +352,13 @@ export function getBeaconPoolApi({
         insertOutcome,
       });
 
-      // Publish to gossip network (best-effort — may fail if no peers subscribe)
-      try {
-        await network.publishExecutionProof(executionProof);
-      } catch (e) {
-        logger.debug("Failed to publish execution proof to gossip", {slot, proofId}, e as Error);
+      // Only publish to gossip if the proof was actually accepted
+      if (insertOutcome === InsertOutcome.NewData) {
+        try {
+          await network.publishExecutionProof(executionProof);
+        } catch (e) {
+          logger.debug("Failed to publish execution proof to gossip", {slot, proofId}, e as Error);
+        }
       }
 
       return {};

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -350,8 +350,12 @@ export function getBeaconPoolApi({
         insertOutcome,
       });
 
-      // Publish to gossip network
-      await network.publishExecutionProof(executionProof);
+      // Publish to gossip network (best-effort — may fail if no peers subscribe)
+      try {
+        await network.publishExecutionProof(executionProof);
+      } catch (e) {
+        logger.debug("Failed to publish execution proof to gossip", {slot, proofId}, e as Error);
+      }
 
       return {};
     },

--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -2,6 +2,7 @@ import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {ForkPostElectra, ForkPreElectra, SYNC_COMMITTEE_SUBNET_SIZE, isForkPostElectra} from "@lodestar/params";
 import {Attestation, Epoch, SingleAttestation, isElectraAttestation, ssz, sszTypesFor} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
 import {
   AttestationError,
   AttestationErrorCode,
@@ -309,6 +310,50 @@ export function getBeaconPoolApi({
       if (failures.length > 0) {
         throw new IndexedError("Error processing sync committee signatures", failures);
       }
+    },
+
+    async getPoolExecutionProofs({slot}) {
+      // Return all proofs in the pool, optionally filtered by slot
+      const allProofs: import("@lodestar/types").ExecutionProof[] = [];
+      if (slot !== undefined) {
+        // Get proofs for a single slot
+        const proofs = chain.executionProofPool.getProofsByRange(slot, 1);
+        allProofs.push(...proofs);
+      } else {
+        // Get proofs for a wide range around the current slot (recent SLOTS_RETAINED window)
+        const currentSlot = chain.clock.currentSlot;
+        const proofs = chain.executionProofPool.getProofsByRange(Math.max(0, currentSlot - 8), 9);
+        allProofs.push(...proofs);
+      }
+      return {data: allProofs};
+    },
+
+    async submitPoolExecutionProofs({executionProof}) {
+      // Validate basic fields
+      const {slot, blockRoot, proofId} = executionProof;
+      const blockRootHex = toRootHex(blockRoot);
+
+      // Check for duplicates
+      if (chain.executionProofPool.has(blockRootHex, proofId)) {
+        logger.debug("Ignoring known execution proof", {slot, blockRoot: blockRootHex, proofId});
+        return {};
+      }
+
+      // TODO EIP-8025: Add full proof verification (dummy accept for devnet)
+
+      // Add to pool
+      const insertOutcome = chain.executionProofPool.add(executionProof);
+      logger.info("Execution proof submitted via API", {
+        slot,
+        blockRoot: blockRootHex,
+        proofId,
+        insertOutcome,
+      });
+
+      // Publish to gossip network
+      await network.publishExecutionProof(executionProof);
+
+      return {};
     },
   };
 }

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -80,6 +80,7 @@ import {
   AggregatedAttestationPool,
   AttestationPool,
   ExecutionPayloadBidPool,
+  ExecutionProofPool,
   OpPool,
   PayloadAttestationPool,
   SyncCommitteeMessagePool,
@@ -163,6 +164,7 @@ export class BeaconChain implements IBeaconChain {
   readonly syncCommitteeMessagePool: SyncCommitteeMessagePool;
   readonly syncContributionAndProofPool;
   readonly executionPayloadBidPool: ExecutionPayloadBidPool;
+  readonly executionProofPool: ExecutionProofPool;
   readonly payloadAttestationPool: PayloadAttestationPool;
   readonly opPool: OpPool;
 
@@ -290,6 +292,7 @@ export class BeaconChain implements IBeaconChain {
     this.syncCommitteeMessagePool = new SyncCommitteeMessagePool(config, clock, this.opts?.preaggregateSlotDistance);
     this.syncContributionAndProofPool = new SyncContributionAndProofPool(config, clock, metrics, logger);
     this.executionPayloadBidPool = new ExecutionPayloadBidPool();
+    this.executionProofPool = new ExecutionProofPool();
     this.payloadAttestationPool = new PayloadAttestationPool(config, clock, metrics);
     this.opPool = new OpPool(config);
 
@@ -1302,6 +1305,7 @@ export class BeaconChain implements IBeaconChain {
     this.seenSyncCommitteeMessages.prune(slot);
     this.payloadAttestationPool.prune(slot);
     this.executionPayloadBidPool.prune(slot);
+    this.executionProofPool.prune(slot);
     this.seenExecutionPayloadBids.prune(slot);
     this.seenAttestationDatas.onSlot(slot);
     this.reprocessController.onSlot(slot);

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -49,6 +49,7 @@ import {AggregatedAttestationPool} from "./opPools/aggregatedAttestationPool.js"
 import {
   AttestationPool,
   ExecutionPayloadBidPool,
+  ExecutionProofPool,
   OpPool,
   PayloadAttestationPool,
   SyncCommitteeMessagePool,
@@ -127,6 +128,8 @@ export interface IBeaconChain {
   readonly syncCommitteeMessagePool: SyncCommitteeMessagePool;
   readonly syncContributionAndProofPool: SyncContributionAndProofPool;
   readonly executionPayloadBidPool: ExecutionPayloadBidPool;
+  /** EIP-8025: Pool for execution proofs */
+  readonly executionProofPool: ExecutionProofPool;
   readonly payloadAttestationPool: PayloadAttestationPool;
   readonly opPool: OpPool;
 

--- a/packages/beacon-node/src/chain/opPools/executionProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/executionProofPool.ts
@@ -26,6 +26,8 @@ export class ExecutionProofPool {
   private readonly proofsByBlockRootBySlot = new MapDef<Slot, MapDef<BlockRootHex, Map<ProofId, ExecutionProof>>>(
     () => new MapDef<BlockRootHex, Map<ProofId, ExecutionProof>>(() => new Map())
   );
+  /** Reverse index: blockRootHex → slot for O(1) lookups */
+  private readonly blockRootToSlot = new Map<BlockRootHex, Slot>();
   private lowestPermissibleSlot = 0;
 
   /** Total number of individual proofs in the pool */
@@ -62,23 +64,19 @@ export class ExecutionProofPool {
     }
 
     proofsByProofId.set(proofId, proof);
+    this.blockRootToSlot.set(blockRootHex, slot);
     return InsertOutcome.NewData;
   }
 
   /**
-   * Get all proofs for a given block root.
+   * Get all proofs for a given block root. O(1) slot lookup via reverse index.
    */
   getProofsByBlockRoot(blockRootHex: BlockRootHex): ExecutionProof[] {
-    const proofs: ExecutionProof[] = [];
-    for (const byBlockRoot of this.proofsByBlockRootBySlot.values()) {
-      const byProofId = byBlockRoot.get(blockRootHex);
-      if (byProofId) {
-        for (const proof of byProofId.values()) {
-          proofs.push(proof);
-        }
-      }
-    }
-    return proofs;
+    const slot = this.blockRootToSlot.get(blockRootHex);
+    if (slot === undefined) return [];
+
+    const byProofId = this.proofsByBlockRootBySlot.get(slot)?.get(blockRootHex);
+    return byProofId ? Array.from(byProofId.values()) : [];
   }
 
   /**
@@ -101,29 +99,26 @@ export class ExecutionProofPool {
 
   /**
    * Check whether a block has enough distinct proof types for availability.
+   * O(1) slot lookup via reverse index.
    */
   hasEnoughProofs(blockRootHex: BlockRootHex, minRequired: number): boolean {
-    let count = 0;
-    for (const byBlockRoot of this.proofsByBlockRootBySlot.values()) {
-      const byProofId = byBlockRoot.get(blockRootHex);
-      if (byProofId) {
-        count += byProofId.size;
-        if (count >= minRequired) return true;
-      }
-    }
-    return count >= minRequired;
+    const slot = this.blockRootToSlot.get(blockRootHex);
+    if (slot === undefined) return false;
+
+    const byProofId = this.proofsByBlockRootBySlot.get(slot)?.get(blockRootHex);
+    return byProofId !== undefined && byProofId.size >= minRequired;
   }
 
   /**
    * Check if a specific (blockRoot, proofId) combination is already known.
    * Used for gossip deduplication (IGNORE if already seen).
+   * O(1) slot lookup via reverse index.
    */
   has(blockRootHex: BlockRootHex, proofId: ProofId): boolean {
-    for (const byBlockRoot of this.proofsByBlockRootBySlot.values()) {
-      const byProofId = byBlockRoot.get(blockRootHex);
-      if (byProofId?.has(proofId)) return true;
-    }
-    return false;
+    const slot = this.blockRootToSlot.get(blockRootHex);
+    if (slot === undefined) return false;
+
+    return this.proofsByBlockRootBySlot.get(slot)?.get(blockRootHex)?.has(proofId) ?? false;
   }
 
   /**
@@ -131,6 +126,13 @@ export class ExecutionProofPool {
    * Called periodically (e.g., on slot clock tick).
    */
   prune(clockSlot: Slot): void {
+    // Clean up reverse index for pruned slots
+    const cutoffSlot = clockSlot - SLOTS_RETAINED;
+    for (const [blockRootHex, slot] of this.blockRootToSlot) {
+      if (slot < cutoffSlot) {
+        this.blockRootToSlot.delete(blockRootHex);
+      }
+    }
     this.lowestPermissibleSlot = pruneBySlot(this.proofsByBlockRootBySlot, clockSlot, SLOTS_RETAINED);
   }
 }

--- a/packages/beacon-node/src/chain/opPools/executionProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/executionProofPool.ts
@@ -45,10 +45,15 @@ export class ExecutionProofPool {
    * Add a verified proof to the pool.
    * Deduplicates by (blockRoot, proofId) — only one proof per type per block.
    */
-  add(proof: ExecutionProof): InsertOutcome {
+  add(proof: ExecutionProof, clockSlot?: Slot): InsertOutcome {
     const {slot, blockRoot, proofId} = proof;
 
     if (slot < this.lowestPermissibleSlot) {
+      return InsertOutcome.Old;
+    }
+
+    // Reject far-future slots to prevent unbounded memory growth via spam
+    if (clockSlot !== undefined && slot > clockSlot + SLOTS_RETAINED) {
       return InsertOutcome.Old;
     }
 

--- a/packages/beacon-node/src/chain/opPools/executionProofPool.ts
+++ b/packages/beacon-node/src/chain/opPools/executionProofPool.ts
@@ -1,0 +1,136 @@
+import {EXECUTION_PROOF_TYPE_COUNT} from "@lodestar/params";
+import {ExecutionProof, Slot} from "@lodestar/types";
+import {MapDef, toRootHex} from "@lodestar/utils";
+import {InsertOutcome} from "./types.js";
+import {pruneBySlot} from "./utils.js";
+
+/**
+ * Number of slots to retain proofs for.
+ * Keep proofs around for a few slots in case of reorgs.
+ */
+const SLOTS_RETAINED = 8;
+
+type BlockRootHex = string;
+type ProofId = number;
+
+/**
+ * EIP-8025: In-memory pool for execution proofs, indexed by slot → blockRoot → proofId.
+ *
+ * Stores verified execution proofs received via gossip or API submission.
+ * Used to:
+ * - Track proof availability for blocks (zkvm mode gating)
+ * - Serve proofs via req/resp to peers
+ * - Deduplicate incoming proofs
+ */
+export class ExecutionProofPool {
+  private readonly proofsByBlockRootBySlot = new MapDef<Slot, MapDef<BlockRootHex, Map<ProofId, ExecutionProof>>>(
+    () => new MapDef<BlockRootHex, Map<ProofId, ExecutionProof>>(() => new Map())
+  );
+  private lowestPermissibleSlot = 0;
+
+  /** Total number of individual proofs in the pool */
+  get size(): number {
+    let count = 0;
+    for (const byBlockRoot of this.proofsByBlockRootBySlot.values()) {
+      for (const byProofId of byBlockRoot.values()) {
+        count += byProofId.size;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Add a verified proof to the pool.
+   * Deduplicates by (blockRoot, proofId) — only one proof per type per block.
+   */
+  add(proof: ExecutionProof): InsertOutcome {
+    const {slot, blockRoot, proofId} = proof;
+
+    if (slot < this.lowestPermissibleSlot) {
+      return InsertOutcome.Old;
+    }
+
+    if (proofId >= EXECUTION_PROOF_TYPE_COUNT) {
+      return InsertOutcome.Old; // Invalid proof type
+    }
+
+    const blockRootHex = toRootHex(blockRoot);
+    const proofsByProofId = this.proofsByBlockRootBySlot.getOrDefault(slot).getOrDefault(blockRootHex);
+
+    if (proofsByProofId.has(proofId)) {
+      return InsertOutcome.AlreadyKnown;
+    }
+
+    proofsByProofId.set(proofId, proof);
+    return InsertOutcome.NewData;
+  }
+
+  /**
+   * Get all proofs for a given block root.
+   */
+  getProofsByBlockRoot(blockRootHex: BlockRootHex): ExecutionProof[] {
+    const proofs: ExecutionProof[] = [];
+    for (const byBlockRoot of this.proofsByBlockRootBySlot.values()) {
+      const byProofId = byBlockRoot.get(blockRootHex);
+      if (byProofId) {
+        for (const proof of byProofId.values()) {
+          proofs.push(proof);
+        }
+      }
+    }
+    return proofs;
+  }
+
+  /**
+   * Get proofs for a range of slots. Used to serve ExecutionProofsByRange req/resp.
+   */
+  getProofsByRange(startSlot: Slot, count: number): ExecutionProof[] {
+    const proofs: ExecutionProof[] = [];
+    for (let slot = startSlot; slot < startSlot + count; slot++) {
+      const byBlockRoot = this.proofsByBlockRootBySlot.get(slot);
+      if (byBlockRoot) {
+        for (const byProofId of byBlockRoot.values()) {
+          for (const proof of byProofId.values()) {
+            proofs.push(proof);
+          }
+        }
+      }
+    }
+    return proofs;
+  }
+
+  /**
+   * Check whether a block has enough distinct proof types for availability.
+   */
+  hasEnoughProofs(blockRootHex: BlockRootHex, minRequired: number): boolean {
+    let count = 0;
+    for (const byBlockRoot of this.proofsByBlockRootBySlot.values()) {
+      const byProofId = byBlockRoot.get(blockRootHex);
+      if (byProofId) {
+        count += byProofId.size;
+        if (count >= minRequired) return true;
+      }
+    }
+    return count >= minRequired;
+  }
+
+  /**
+   * Check if a specific (blockRoot, proofId) combination is already known.
+   * Used for gossip deduplication (IGNORE if already seen).
+   */
+  has(blockRootHex: BlockRootHex, proofId: ProofId): boolean {
+    for (const byBlockRoot of this.proofsByBlockRootBySlot.values()) {
+      const byProofId = byBlockRoot.get(blockRootHex);
+      if (byProofId?.has(proofId)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Prune proofs older than clockSlot - SLOTS_RETAINED.
+   * Called periodically (e.g., on slot clock tick).
+   */
+  prune(clockSlot: Slot): void {
+    this.lowestPermissibleSlot = pruneBySlot(this.proofsByBlockRootBySlot, clockSlot, SLOTS_RETAINED);
+  }
+}

--- a/packages/beacon-node/src/chain/opPools/index.ts
+++ b/packages/beacon-node/src/chain/opPools/index.ts
@@ -1,6 +1,7 @@
 export {AggregatedAttestationPool} from "./aggregatedAttestationPool.js";
 export {AttestationPool} from "./attestationPool.js";
 export {ExecutionPayloadBidPool} from "./executionPayloadBidPool.js";
+export {ExecutionProofPool} from "./executionProofPool.js";
 export {OpPool} from "./opPool.js";
 export {PayloadAttestationPool} from "./payloadAttestationPool.js";
 export {SyncCommitteeMessagePool} from "./syncCommitteeMessagePool.js";

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -1,3 +1,4 @@
+import {DEFAULT_MIN_PROOFS_REQUIRED} from "@lodestar/params";
 import {defaultOptions as defaultValidatorOptions} from "@lodestar/validator";
 import {DEFAULT_ARCHIVE_MODE} from "./archiveStore/constants.js";
 import {ArchiveMode, ArchiveStoreOpts} from "./archiveStore/interface.js";
@@ -46,6 +47,12 @@ export type IChainOptions = BlockProcessOpts &
     minSameMessageSignatureSetsToBatch: number;
     archiveDateEpochs?: number;
     nHistoricalStatesFileDataStore?: boolean;
+    /** EIP-8025: Enable zkvm/stateless execution mode. Blocks gated by proof availability instead of EL. */
+    activateZkvm?: boolean;
+    /** EIP-8025: Minimum distinct proof types required per block in zkvm mode (default: 1) */
+    minProofsRequired?: number;
+    /** EIP-8025: Which proof type IDs this node generates (for prover mode). Empty = verify-only. */
+    zkvmGenerationProofTypes?: number[];
   };
 
 export type BlockProcessOpts = {
@@ -126,4 +133,8 @@ export const defaultChainOptions: IChainOptions = {
   maxBlockStates: DEFAULT_MAX_BLOCK_STATES,
   maxCPStateEpochsInMemory: DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY,
   maxCPStateEpochsOnDisk: DEFAULT_MAX_CP_STATE_ON_DISK,
+  // EIP-8025: zkvm/stateless execution mode
+  activateZkvm: false,
+  minProofsRequired: DEFAULT_MIN_PROOFS_REQUIRED,
+  zkvmGenerationProofTypes: [],
 };

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -590,11 +590,12 @@ export class NetworkCore implements INetworkCore {
   private subscribeCoreTopicsAtBoundary(networkConfig: NetworkConfig, boundary: ForkBoundary): void {
     if (this.forkBoundariesByEpoch.has(boundary.epoch)) return;
     this.forkBoundariesByEpoch.set(boundary.epoch, boundary);
-    const {subscribeAllSubnets, disableLightClientServer} = this.opts;
+    const {subscribeAllSubnets, disableLightClientServer, activateZkvm} = this.opts;
 
     for (const topic of getCoreTopicsAtFork(networkConfig, boundary.fork, {
       subscribeAllSubnets,
       disableLightClientServer,
+      activateZkvm,
     })) {
       this.gossip.subscribeTopic({...topic, boundary});
     }
@@ -603,11 +604,12 @@ export class NetworkCore implements INetworkCore {
   private unsubscribeCoreTopicsAtBoundary(networkConfig: NetworkConfig, boundary: ForkBoundary): void {
     if (!this.forkBoundariesByEpoch.has(boundary.epoch)) return;
     this.forkBoundariesByEpoch.delete(boundary.epoch);
-    const {subscribeAllSubnets, disableLightClientServer} = this.opts;
+    const {subscribeAllSubnets, disableLightClientServer, activateZkvm} = this.opts;
 
     for (const topic of getCoreTopicsAtFork(networkConfig, boundary.fork, {
       subscribeAllSubnets,
       disableLightClientServer,
+      activateZkvm,
     })) {
       this.gossip.unsubscribeTopic({...topic, boundary});
     }

--- a/packages/beacon-node/src/network/core/networkCore.ts
+++ b/packages/beacon-node/src/network/core/networkCore.ts
@@ -167,7 +167,10 @@ export class NetworkCore implements INetworkCore {
       config,
       custodyConfig: new CustodyConfig({nodeId, config, initialCustodyGroupCount}),
     };
-    const metadata = new MetadataController({}, {networkConfig, logger, onSetValue: onMetadataSetValue});
+    const metadata = new MetadataController(
+      {activateZkvm: opts.activateZkvm},
+      {networkConfig, logger, onSetValue: onMetadataSetValue}
+    );
 
     const reqResp = new ReqRespBeaconNode(
       {

--- a/packages/beacon-node/src/network/gossip/gossipsub.ts
+++ b/packages/beacon-node/src/network/gossip/gossipsub.ts
@@ -59,6 +59,8 @@ export type Eth2GossipsubOpts = {
   disableFloodPublish?: boolean;
   skipParamsLog?: boolean;
   disableLightClientServer?: boolean;
+  /** EIP-8025: Enable execution proof gossip topic */
+  activateZkvm?: boolean;
   /**
    * Direct peers for GossipSub - these peers maintain permanent mesh connections without GRAFT/PRUNE.
    * Supports multiaddr strings with peer ID (e.g., "/ip4/192.168.1.1/tcp/9000/p2p/16Uiu2HAmKLhW7...")
@@ -416,7 +418,7 @@ function attSubnetLabel(subnet: SubnetID): string {
 
 function getMetricsTopicStrToLabel(
   networkConfig: NetworkConfig,
-  opts: {disableLightClientServer: boolean}
+  opts: {disableLightClientServer: boolean; activateZkvm?: boolean}
 ): TopicStrToLabel {
   const {config} = networkConfig;
   const metricsTopicStrToLabel = new Map<TopicStr, TopicLabel>();
@@ -434,6 +436,7 @@ function getMetricsTopicStrToLabel(
     const topics = getCoreTopicsAtFork(networkConfig, currentForkBoundary.fork, {
       subscribeAllSubnets: true,
       disableLightClientServer: opts.disableLightClientServer,
+      activateZkvm: opts.activateZkvm,
     });
     for (const topic of topics) {
       metricsTopicStrToLabel.set(stringifyGossipTopic(config, {...topic, boundary: currentForkBoundary}), topic.type);

--- a/packages/beacon-node/src/network/gossip/interface.ts
+++ b/packages/beacon-node/src/network/gossip/interface.ts
@@ -4,6 +4,7 @@ import {PeerIdStr} from "@chainsafe/libp2p-gossipsub/types";
 import {BeaconConfig, ForkBoundary} from "@lodestar/config";
 import {
   AttesterSlashing,
+  ExecutionProof,
   LightClientFinalityUpdate,
   LightClientOptimisticUpdate,
   SignedAggregateAndProof,
@@ -41,6 +42,7 @@ export enum GossipType {
   execution_payload = "execution_payload",
   payload_attestation_message = "payload_attestation_message",
   execution_payload_bid = "execution_payload_bid",
+  execution_proof = "execution_proof",
 }
 
 export type SequentialGossipType = Exclude<GossipType, GossipType.beacon_attestation>;
@@ -78,6 +80,7 @@ export type GossipTopicTypeMap = {
   [GossipType.execution_payload]: {type: GossipType.execution_payload};
   [GossipType.payload_attestation_message]: {type: GossipType.payload_attestation_message};
   [GossipType.execution_payload_bid]: {type: GossipType.execution_payload_bid};
+  [GossipType.execution_proof]: {type: GossipType.execution_proof};
 };
 
 export type GossipTopicMap = {
@@ -110,6 +113,7 @@ export type GossipTypeMap = {
   [GossipType.execution_payload]: gloas.SignedExecutionPayloadEnvelope;
   [GossipType.payload_attestation_message]: gloas.PayloadAttestationMessage;
   [GossipType.execution_payload_bid]: gloas.SignedExecutionPayloadBid;
+  [GossipType.execution_proof]: ExecutionProof;
 };
 
 export type GossipFnByType = {
@@ -141,6 +145,7 @@ export type GossipFnByType = {
     payloadAttestationMessage: gloas.PayloadAttestationMessage
   ) => Promise<void> | void;
   [GossipType.execution_payload_bid]: (executionPayloadBid: gloas.SignedExecutionPayloadBid) => Promise<void> | void;
+  [GossipType.execution_proof]: (executionProof: ExecutionProof) => Promise<void> | void;
 };
 
 export type GossipFn = GossipFnByType[keyof GossipFnByType];

--- a/packages/beacon-node/src/network/gossip/scoringParameters.ts
+++ b/packages/beacon-node/src/network/gossip/scoringParameters.ts
@@ -198,6 +198,17 @@ function getAllTopicsScoreParams(
       expectedMessageRate: 1024, // TODO GLOAS: Need an estimate for this
       firstMessageDecayTime: epochDurationMs * 100,
     });
+    // EIP-8025: execution_proof topic scoring
+    topicsParams[
+      stringifyGossipTopic(config, {
+        type: GossipType.execution_proof,
+        boundary,
+      })
+    ] = getTopicScoreParams(config, precomputedParams, {
+      topicWeight: 0.5, // Similar weight to voluntary_exit — low frequency, important
+      expectedMessageRate: 8, // Up to EXECUTION_PROOF_TYPE_COUNT per slot
+      firstMessageDecayTime: epochDurationMs * 100,
+    });
 
     // other topics
     topicsParams[

--- a/packages/beacon-node/src/network/gossip/topic.ts
+++ b/packages/beacon-node/src/network/gossip/topic.ts
@@ -72,6 +72,7 @@ function stringifyGossipTopicType(topic: GossipTopic): string {
     case GossipType.execution_payload:
     case GossipType.payload_attestation_message:
     case GossipType.execution_payload_bid:
+    case GossipType.execution_proof:
       return topic.type;
     case GossipType.beacon_attestation:
     case GossipType.sync_committee:
@@ -123,6 +124,8 @@ export function getGossipSSZType(topic: GossipTopic) {
       return ssz.gloas.PayloadAttestationMessage;
     case GossipType.execution_payload_bid:
       return ssz.gloas.SignedExecutionPayloadBid;
+    case GossipType.execution_proof:
+      return ssz.eip8025.ExecutionProof;
   }
 }
 
@@ -202,6 +205,7 @@ export function parseGossipTopic(forkDigestContext: ForkDigestContext, topicStr:
       case GossipType.execution_payload:
       case GossipType.payload_attestation_message:
       case GossipType.execution_payload_bid:
+      case GossipType.execution_proof:
         return {type: gossipTypeStr, boundary, encoding};
     }
 
@@ -241,7 +245,7 @@ export function parseGossipTopic(forkDigestContext: ForkDigestContext, topicStr:
 export function getCoreTopicsAtFork(
   networkConfig: NetworkConfig,
   fork: ForkName,
-  opts: {subscribeAllSubnets?: boolean; disableLightClientServer?: boolean}
+  opts: {subscribeAllSubnets?: boolean; disableLightClientServer?: boolean; activateZkvm?: boolean}
 ): GossipTopicTypeMap[keyof GossipTopicTypeMap][] {
   // Common topics for all forks
   const topics: GossipTopicTypeMap[keyof GossipTopicTypeMap][] = [
@@ -261,6 +265,11 @@ export function getCoreTopicsAtFork(
   // After fulu also track data_column_sidecar_{index}
   if (ForkSeq[fork] >= ForkSeq.fulu) {
     topics.push(...getDataColumnSidecarTopics(networkConfig));
+  }
+
+  // EIP-8025: Subscribe to execution_proof gossip when zkvm mode is active on Fulu+
+  if (opts.activateZkvm && ForkSeq[fork] >= ForkSeq.fulu) {
+    topics.push({type: GossipType.execution_proof});
   }
 
   // After Deneb and before Fulu also track blob_sidecar_{subnet_id}
@@ -350,4 +359,5 @@ export const gossipTopicIgnoreDuplicatePublishError: Record<GossipType, boolean>
   [GossipType.execution_payload]: true,
   [GossipType.payload_attestation_message]: true,
   [GossipType.execution_payload_bid]: true,
+  [GossipType.execution_proof]: true,
 };

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -19,6 +19,7 @@ import type {Datastore} from "interface-datastore";
 import {Libp2p as ILibp2p} from "libp2p";
 import {
   AttesterSlashing,
+  ExecutionProof,
   LightClientFinalityUpdate,
   LightClientOptimisticUpdate,
   SignedAggregateAndProof,
@@ -95,6 +96,7 @@ export interface INetwork extends INetworkCorePublic {
   publishContributionAndProof(contributionAndProof: altair.SignedContributionAndProof): Promise<number>;
   publishLightClientFinalityUpdate(update: LightClientFinalityUpdate): Promise<number>;
   publishLightClientOptimisticUpdate(update: LightClientOptimisticUpdate): Promise<number>;
+  publishExecutionProof(executionProof: ExecutionProof): Promise<number>;
 
   // Debug
   dumpGossipQueue(gossipType: GossipType): Promise<PendingGossipsubMessage[]>;

--- a/packages/beacon-node/src/network/metadata.ts
+++ b/packages/beacon-node/src/network/metadata.ts
@@ -16,6 +16,8 @@ export enum ENRKey {
   syncnets = "syncnets",
   cgc = "cgc",
   nfd = "nfd",
+  /** EIP-8025: zkvm enabled flag */
+  zkvm = "zkvm",
 }
 export enum SubnetType {
   attnets = "attnets",
@@ -24,6 +26,8 @@ export enum SubnetType {
 
 export type MetadataOpts = {
   metadata?: fulu.Metadata;
+  /** EIP-8025: Enable zkvm ENR key signaling */
+  activateZkvm?: boolean;
 };
 
 export type MetadataModules = {
@@ -42,11 +46,13 @@ export class MetadataController {
   private networkConfig: NetworkConfig;
   private logger: Logger;
   private _metadata: fulu.Metadata;
+  private readonly activateZkvm: boolean;
 
   constructor(opts: MetadataOpts, modules: MetadataModules) {
     this.networkConfig = modules.networkConfig;
     this.logger = modules.logger;
     this.onSetValue = modules.onSetValue;
+    this.activateZkvm = opts.activateZkvm ?? false;
     this._metadata = opts.metadata ?? {
       ...ssz.fulu.Metadata.defaultValue(),
       custodyGroupCount: modules.networkConfig.custodyConfig.targetCustodyGroupCount,
@@ -69,6 +75,11 @@ export class MetadataController {
 
     // Set CGC regardless of fork. It may be useful to clients before Fulu, and will be ignored otherwise.
     this.onSetValue(ENRKey.cgc, serializeCgc(this._metadata.custodyGroupCount));
+
+    // EIP-8025: Set zkvm ENR key when activated
+    if (this.activateZkvm) {
+      this.onSetValue(ENRKey.zkvm, new Uint8Array([1]));
+    }
   }
 
   get seqNumber(): bigint {

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -10,6 +10,7 @@ import {ResponseIncoming} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {
   AttesterSlashing,
+  ExecutionProof,
   LightClientBootstrap,
   LightClientFinalityUpdate,
   LightClientOptimisticUpdate,
@@ -486,6 +487,17 @@ export class Network implements INetwork {
     return this.publishGossip<GossipType.light_client_optimistic_update>(
       {type: GossipType.light_client_optimistic_update, boundary},
       update
+    );
+  }
+
+  async publishExecutionProof(executionProof: ExecutionProof): Promise<number> {
+    const epoch = computeEpochAtSlot(executionProof.slot);
+    const boundary = this.config.getForkBoundaryAtEpoch(epoch);
+
+    return this.publishGossip<GossipType.execution_proof>(
+      {type: GossipType.execution_proof, boundary},
+      executionProof,
+      {ignoreDuplicatePublishError: true}
     );
   }
 

--- a/packages/beacon-node/src/network/options.ts
+++ b/packages/beacon-node/src/network/options.ts
@@ -29,6 +29,8 @@ export interface NetworkOptions
   useWorker?: boolean;
   maxYoungGenerationSizeMb?: number;
   disableLightClientServer?: boolean;
+  /** EIP-8025: Enable execution proof gossip and req/resp protocols */
+  activateZkvm?: boolean;
 
   /**
    * During E2E tests observe a lot of following `missing stream`:
@@ -67,6 +69,8 @@ export const defaultNetworkOptions: NetworkOptions = {
   slotsToSubscribeBeforeAggregatorDuty: 2,
   // This will enable the light client server by default
   disableLightClientServer: false,
+  // EIP-8025: zkvm mode disabled by default
+  activateZkvm: false,
   // specific option for fulu
   //   - this is the same to TARGET_SUBNET_PEERS
   //   - for fusaka-devnets, we have 25-30 peers per subnet

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -874,7 +874,8 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
       // For now, basic deserialization validation is sufficient for initial interop
 
       try {
-        const insertOutcome = chain.executionProofPool.add(executionProof);
+        const clockSlot = chain.clock.currentSlot;
+        const insertOutcome = chain.executionProofPool.add(executionProof, clockSlot);
         logger.debug("Received execution proof via gossip", {
           proofId: executionProof.proofId,
           slot: executionProof.slot,

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -863,6 +863,22 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
         logger.error("Error adding to executionPayloadBid pool", {}, e as Error);
       }
     },
+    [GossipType.execution_proof]: async ({
+      gossipData,
+      topic,
+    }: GossipHandlerParamGeneric<GossipType.execution_proof>) => {
+      const {serializedData} = gossipData;
+      const executionProof = sszDeserialize(topic, serializedData);
+
+      // TODO EIP-8025: Add full gossip validation (slot bounds, dedup, proof verification)
+      // For now, basic deserialization validation is sufficient for initial interop
+      logger.debug("Received execution proof via gossip", {
+        proofId: executionProof.proofId,
+        slot: executionProof.slot,
+      });
+
+      // TODO EIP-8025: Store in ExecutionProofPool (Phase C)
+    },
   };
 }
 

--- a/packages/beacon-node/src/network/processor/gossipHandlers.ts
+++ b/packages/beacon-node/src/network/processor/gossipHandlers.ts
@@ -872,12 +872,17 @@ function getSequentialHandlers(modules: ValidatorFnsModules, options: GossipHand
 
       // TODO EIP-8025: Add full gossip validation (slot bounds, dedup, proof verification)
       // For now, basic deserialization validation is sufficient for initial interop
-      logger.debug("Received execution proof via gossip", {
-        proofId: executionProof.proofId,
-        slot: executionProof.slot,
-      });
 
-      // TODO EIP-8025: Store in ExecutionProofPool (Phase C)
+      try {
+        const insertOutcome = chain.executionProofPool.add(executionProof);
+        logger.debug("Received execution proof via gossip", {
+          proofId: executionProof.proofId,
+          slot: executionProof.slot,
+          insertOutcome,
+        });
+      } catch (e) {
+        logger.error("Error adding execution proof to pool", {}, e as Error);
+      }
     },
   };
 }

--- a/packages/beacon-node/src/network/processor/gossipQueues/index.ts
+++ b/packages/beacon-node/src/network/processor/gossipQueues/index.ts
@@ -83,6 +83,12 @@ const linearGossipQueueOpts: {
     type: QueueType.FIFO,
     dropOpts: {type: DropType.count, count: 1},
   },
+  // EIP-8025: Execution proofs — expect up to EXECUTION_PROOF_TYPE_COUNT per block
+  [GossipType.execution_proof]: {
+    maxLength: 256,
+    type: QueueType.FIFO,
+    dropOpts: {type: DropType.count, count: 1},
+  },
 };
 
 const indexedGossipQueueOpts: {

--- a/packages/beacon-node/src/network/processor/index.ts
+++ b/packages/beacon-node/src/network/processor/index.ts
@@ -81,6 +81,7 @@ const executeGossipWorkOrderObj: Record<GossipType, WorkOpts> = {
   [GossipType.execution_payload]: {bypassQueue: true},
   [GossipType.payload_attestation_message]: {},
   [GossipType.execution_payload_bid]: {},
+  [GossipType.execution_proof]: {},
 };
 const executeGossipWorkOrder = Object.keys(executeGossipWorkOrderObj) as (keyof typeof executeGossipWorkOrderObj)[];
 

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -52,7 +52,7 @@ export interface ReqRespBeaconNodeModules {
   getHandler: GetReqRespHandlerFn;
 }
 
-export type ReqRespBeaconNodeOpts = ReqRespOpts & {disableLightClientServer?: boolean};
+export type ReqRespBeaconNodeOpts = ReqRespOpts & {disableLightClientServer?: boolean; activateZkvm?: boolean};
 
 /**
  * Implementation of Ethereum Consensus p2p Req/Resp domain.
@@ -74,6 +74,7 @@ export class ReqRespBeaconNode extends ReqResp {
   private readonly config: BeaconConfig;
   protected readonly logger: Logger;
   protected readonly disableLightClientServer: boolean;
+  protected readonly activateZkvm: boolean;
 
   constructor(modules: ReqRespBeaconNodeModules, options: ReqRespBeaconNodeOpts = {}) {
     const {events, peersData, peerRpcScores, metadata, metrics, logger} = modules;
@@ -98,6 +99,7 @@ export class ReqRespBeaconNode extends ReqResp {
     );
 
     this.disableLightClientServer = options.disableLightClientServer ?? false;
+    this.activateZkvm = options.activateZkvm ?? false;
     this.peerRpcScores = peerRpcScores;
     this.peersData = peersData;
     this.config = modules.config;
@@ -295,6 +297,14 @@ export class ReqRespBeaconNode extends ReqResp {
           this.getHandler(ReqRespMethod.DataColumnSidecarsByRange),
         ]
       );
+
+      // EIP-8025: Register execution proof protocols when zkvm mode is active
+      if (this.activateZkvm) {
+        protocolsAtFork.push(
+          [protocols.ExecutionProofsByRoot(fork, this.config), this.getHandler(ReqRespMethod.ExecutionProofsByRoot)],
+          [protocols.ExecutionProofsByRange(fork, this.config), this.getHandler(ReqRespMethod.ExecutionProofsByRange)]
+        );
+      }
     }
 
     return protocolsAtFork;

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -1,5 +1,7 @@
 import {ProtocolHandler} from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
 import {IBeaconDb} from "../../../db/index.js";
 import {
@@ -74,17 +76,32 @@ export function getReqRespHandlers({db, chain}: {db: IBeaconDb; chain: IBeaconCh
     [ReqRespMethod.LightClientOptimisticUpdate]: () => onLightClientOptimisticUpdate(chain),
 
     // EIP-8025: Execution proof req/resp handlers
-    // TODO: Wire up to ExecutionProofPool once implemented in Phase C
-    [ReqRespMethod.ExecutionProofsByRoot]: (_req) => {
-      // Stub: return empty response until proof pool is implemented
+    [ReqRespMethod.ExecutionProofsByRoot]: (req) => {
+      const body = ssz.eip8025.ExecutionProofsByRootRequest.deserialize(req.data);
+      const blockRootHex = toRootHex(body.blockRoot);
+      const alreadyHaveSet = new Set(body.alreadyHave);
+      const proofs = chain.executionProofPool
+        .getProofsByBlockRoot(blockRootHex)
+        .filter((p) => !alreadyHaveSet.has(p.proofId));
       return (async function* () {
-        // No proofs to serve yet
+        for (const proof of proofs) {
+          yield {
+            data: ssz.eip8025.ExecutionProof.serialize(proof),
+            boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(proof.slot)),
+          };
+        }
       })();
     },
-    [ReqRespMethod.ExecutionProofsByRange]: (_req) => {
-      // Stub: return empty response until proof pool is implemented
+    [ReqRespMethod.ExecutionProofsByRange]: (req) => {
+      const body = ssz.eip8025.ExecutionProofsByRangeRequest.deserialize(req.data);
+      const proofs = chain.executionProofPool.getProofsByRange(body.startSlot, Number(body.count));
       return (async function* () {
-        // No proofs to serve yet
+        for (const proof of proofs) {
+          yield {
+            data: ssz.eip8025.ExecutionProof.serialize(proof),
+            boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(proof.slot)),
+          };
+        }
       })();
     },
   };

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -72,6 +72,21 @@ export function getReqRespHandlers({db, chain}: {db: IBeaconDb; chain: IBeaconCh
     },
     [ReqRespMethod.LightClientFinalityUpdate]: () => onLightClientFinalityUpdate(chain),
     [ReqRespMethod.LightClientOptimisticUpdate]: () => onLightClientOptimisticUpdate(chain),
+
+    // EIP-8025: Execution proof req/resp handlers
+    // TODO: Wire up to ExecutionProofPool once implemented in Phase C
+    [ReqRespMethod.ExecutionProofsByRoot]: (_req) => {
+      // Stub: return empty response until proof pool is implemented
+      return (async function* () {
+        // No proofs to serve yet
+      })();
+    },
+    [ReqRespMethod.ExecutionProofsByRange]: (_req) => {
+      // Stub: return empty response until proof pool is implemented
+      return (async function* () {
+        // No proofs to serve yet
+      })();
+    },
   };
 
   return (method) => handlers[method];

--- a/packages/beacon-node/src/network/reqresp/protocols.ts
+++ b/packages/beacon-node/src/network/reqresp/protocols.ts
@@ -118,6 +118,19 @@ export const LightClientUpdatesByRange = toProtocol({
   contextBytesType: ContextBytesType.ForkDigest,
 });
 
+// EIP-8025: Execution proof protocols
+export const ExecutionProofsByRoot = toProtocol({
+  method: ReqRespMethod.ExecutionProofsByRoot,
+  version: Version.V1,
+  contextBytesType: ContextBytesType.Empty,
+});
+
+export const ExecutionProofsByRange = toProtocol({
+  method: ReqRespMethod.ExecutionProofsByRange,
+  version: Version.V1,
+  contextBytesType: ContextBytesType.Empty,
+});
+
 type ProtocolSummary = {
   method: ReqRespMethod;
   version: Version;

--- a/packages/beacon-node/src/network/reqresp/rateLimit.ts
+++ b/packages/beacon-node/src/network/reqresp/rateLimit.ts
@@ -92,6 +92,16 @@ export const rateLimitQuotas: (fork: ForkName, config: BeaconConfig) => Record<R
     // Allow 2 per slot and a very safe bound until there's more testing of real usage.
     byPeer: {quota: 2, quotaTimeMs: 12_000},
   },
+  // EIP-8025: Execution proof protocols
+  [ReqRespMethod.ExecutionProofsByRoot]: {
+    // Similar to BeaconBlocksByRoot — one request per block root
+    byPeer: {quota: 16, quotaTimeMs: 10_000},
+  },
+  [ReqRespMethod.ExecutionProofsByRange]: {
+    // Similar to BeaconBlocksByRange
+    byPeer: {quota: 16, quotaTimeMs: 10_000},
+    getRequestCount: getRequestCountFn(fork, config, ReqRespMethod.ExecutionProofsByRange, (req) => Number(req.count)),
+  },
 });
 
 // Helper to produce a getRequestCount function

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -3,6 +3,9 @@ import {BeaconConfig} from "@lodestar/config";
 import {ForkName, ForkPostAltair, isForkPostAltair} from "@lodestar/params";
 import {Protocol, ProtocolHandler, ReqRespRequest} from "@lodestar/reqresp";
 import {
+  ExecutionProof,
+  ExecutionProofsByRangeRequest,
+  ExecutionProofsByRootRequest,
   LightClientBootstrap,
   LightClientFinalityUpdate,
   LightClientOptimisticUpdate,
@@ -46,6 +49,9 @@ export enum ReqRespMethod {
   LightClientUpdatesByRange = "light_client_updates_by_range",
   LightClientFinalityUpdate = "light_client_finality_update",
   LightClientOptimisticUpdate = "light_client_optimistic_update",
+  // EIP-8025
+  ExecutionProofsByRoot = "execution_proofs_by_root",
+  ExecutionProofsByRange = "execution_proofs_by_range",
 }
 
 // To typesafe events to network
@@ -64,6 +70,9 @@ export type RequestBodyByMethod = {
   [ReqRespMethod.LightClientUpdatesByRange]: altair.LightClientUpdatesByRange;
   [ReqRespMethod.LightClientFinalityUpdate]: null;
   [ReqRespMethod.LightClientOptimisticUpdate]: null;
+  // EIP-8025
+  [ReqRespMethod.ExecutionProofsByRoot]: ExecutionProofsByRootRequest;
+  [ReqRespMethod.ExecutionProofsByRange]: ExecutionProofsByRangeRequest;
 };
 
 type ResponseBodyByMethod = {
@@ -83,6 +92,9 @@ type ResponseBodyByMethod = {
   [ReqRespMethod.LightClientUpdatesByRange]: LightClientUpdate;
   [ReqRespMethod.LightClientFinalityUpdate]: LightClientFinalityUpdate;
   [ReqRespMethod.LightClientOptimisticUpdate]: LightClientOptimisticUpdate;
+  // EIP-8025
+  [ReqRespMethod.ExecutionProofsByRoot]: ExecutionProof;
+  [ReqRespMethod.ExecutionProofsByRange]: ExecutionProof;
 };
 
 /** Request SSZ type for each method and ForkName */
@@ -110,6 +122,9 @@ export const requestSszTypeByMethod: (
   [ReqRespMethod.LightClientUpdatesByRange]: ssz.altair.LightClientUpdatesByRange,
   [ReqRespMethod.LightClientFinalityUpdate]: null,
   [ReqRespMethod.LightClientOptimisticUpdate]: null,
+  // EIP-8025
+  [ReqRespMethod.ExecutionProofsByRoot]: ssz.eip8025.ExecutionProofsByRootRequest,
+  [ReqRespMethod.ExecutionProofsByRange]: ssz.eip8025.ExecutionProofsByRangeRequest,
 });
 
 export type ResponseTypeGetter<T> = (fork: ForkName, version: number) => Type<T>;
@@ -139,6 +154,9 @@ export const responseSszTypeByMethod: {[K in ReqRespMethod]: ResponseTypeGetter<
   [ReqRespMethod.DataColumnSidecarsByRoot]: () => ssz.fulu.DataColumnSidecar,
   [ReqRespMethod.LightClientOptimisticUpdate]: (fork) =>
     sszTypesFor(onlyPostAltairFork(fork)).LightClientOptimisticUpdate,
+  // EIP-8025
+  [ReqRespMethod.ExecutionProofsByRoot]: () => ssz.eip8025.ExecutionProof,
+  [ReqRespMethod.ExecutionProofsByRange]: () => ssz.eip8025.ExecutionProof,
 };
 
 function onlyPostAltairFork(fork: ForkName): ForkPostAltair {

--- a/packages/beacon-node/test/unit/chain/opPools/executionProofPool.test.ts
+++ b/packages/beacon-node/test/unit/chain/opPools/executionProofPool.test.ts
@@ -1,0 +1,190 @@
+import {describe, expect, it} from "vitest";
+import {fromHexString} from "@chainsafe/ssz";
+import {EXECUTION_PROOF_TYPE_COUNT} from "@lodestar/params";
+import {ExecutionProof} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {ExecutionProofPool} from "../../../../src/chain/opPools/executionProofPool.js";
+import {InsertOutcome} from "../../../../src/chain/opPools/types.js";
+
+function createProof(overrides: Partial<ExecutionProof> = {}): ExecutionProof {
+  return {
+    proofId: 0,
+    slot: 10,
+    blockHash: fromHexString("0x" + "ab".repeat(32)),
+    blockRoot: fromHexString("0x" + "cd".repeat(32)),
+    proofData: new Uint8Array(64),
+    ...overrides,
+  };
+}
+
+describe("ExecutionProofPool", () => {
+  it("should add and retrieve a proof by block root", () => {
+    const pool = new ExecutionProofPool();
+    const proof = createProof();
+    const blockRootHex = toRootHex(proof.blockRoot);
+
+    expect(pool.add(proof)).toBe(InsertOutcome.NewData);
+    expect(pool.size).toBe(1);
+
+    const retrieved = pool.getProofsByBlockRoot(blockRootHex);
+    expect(retrieved).toHaveLength(1);
+    expect(retrieved[0].proofId).toBe(0);
+    expect(retrieved[0].slot).toBe(10);
+  });
+
+  it("should deduplicate by (blockRoot, proofId)", () => {
+    const pool = new ExecutionProofPool();
+    const proof = createProof();
+
+    expect(pool.add(proof)).toBe(InsertOutcome.NewData);
+    expect(pool.add(proof)).toBe(InsertOutcome.AlreadyKnown);
+    expect(pool.size).toBe(1);
+  });
+
+  it("should store multiple proof types for the same block", () => {
+    const pool = new ExecutionProofPool();
+    const blockRoot = fromHexString("0x" + "aa".repeat(32));
+
+    for (let proofId = 0; proofId < 3; proofId++) {
+      expect(pool.add(createProof({blockRoot, proofId}))).toBe(InsertOutcome.NewData);
+    }
+
+    expect(pool.size).toBe(3);
+    const proofs = pool.getProofsByBlockRoot(toRootHex(blockRoot));
+    expect(proofs).toHaveLength(3);
+  });
+
+  it("should store proofs for different blocks independently", () => {
+    const pool = new ExecutionProofPool();
+    const root1 = fromHexString("0x" + "11".repeat(32));
+    const root2 = fromHexString("0x" + "22".repeat(32));
+
+    pool.add(createProof({blockRoot: root1, proofId: 0}));
+    pool.add(createProof({blockRoot: root2, proofId: 0}));
+
+    expect(pool.size).toBe(2);
+    expect(pool.getProofsByBlockRoot(toRootHex(root1))).toHaveLength(1);
+    expect(pool.getProofsByBlockRoot(toRootHex(root2))).toHaveLength(1);
+  });
+
+  it("should reject proofs older than lowestPermissibleSlot", () => {
+    const pool = new ExecutionProofPool();
+
+    // Add a proof at slot 20
+    pool.add(createProof({slot: 20}));
+    // Prune at slot 30 (retains 8 slots → cutoff = 22)
+    pool.prune(30);
+
+    // Slot 10 is below cutoff
+    expect(pool.add(createProof({slot: 10, blockRoot: fromHexString("0x" + "ff".repeat(32))}))).toBe(InsertOutcome.Old);
+  });
+
+  it("should reject far-future proofs when clockSlot is provided", () => {
+    const pool = new ExecutionProofPool();
+    const clockSlot = 100;
+
+    // Proof at slot 200 is far in the future (> clockSlot + 8)
+    expect(pool.add(createProof({slot: 200}), clockSlot)).toBe(InsertOutcome.Old);
+
+    // Proof at slot 105 is within the window (≤ clockSlot + 8)
+    expect(pool.add(createProof({slot: 105}), clockSlot)).toBe(InsertOutcome.NewData);
+  });
+
+  it("should reject invalid proofId >= EXECUTION_PROOF_TYPE_COUNT", () => {
+    const pool = new ExecutionProofPool();
+
+    expect(pool.add(createProof({proofId: EXECUTION_PROOF_TYPE_COUNT}))).toBe(InsertOutcome.Old);
+    expect(pool.add(createProof({proofId: 255}))).toBe(InsertOutcome.Old);
+    expect(pool.size).toBe(0);
+  });
+
+  it("should return proofs by range", () => {
+    const pool = new ExecutionProofPool();
+
+    for (let slot = 10; slot < 15; slot++) {
+      pool.add(createProof({slot, blockRoot: fromHexString("0x" + slot.toString(16).padStart(64, "0"))}));
+    }
+
+    const proofs = pool.getProofsByRange(10, 5);
+    expect(proofs).toHaveLength(5);
+
+    // Subset: only slots 12-13
+    const subset = pool.getProofsByRange(12, 2);
+    expect(subset).toHaveLength(2);
+    expect(subset.every((p) => p.slot >= 12 && p.slot < 14)).toBe(true);
+  });
+
+  it("should return empty array for unknown block root", () => {
+    const pool = new ExecutionProofPool();
+    expect(pool.getProofsByBlockRoot("0x" + "00".repeat(32))).toEqual([]);
+  });
+
+  describe("hasEnoughProofs", () => {
+    it("should return true when enough distinct proof types exist", () => {
+      const pool = new ExecutionProofPool();
+      const blockRoot = fromHexString("0x" + "aa".repeat(32));
+      const blockRootHex = toRootHex(blockRoot);
+
+      pool.add(createProof({blockRoot, proofId: 0}));
+      pool.add(createProof({blockRoot, proofId: 1}));
+
+      expect(pool.hasEnoughProofs(blockRootHex, 2)).toBe(true);
+      expect(pool.hasEnoughProofs(blockRootHex, 3)).toBe(false);
+    });
+
+    it("should return false for unknown block root", () => {
+      const pool = new ExecutionProofPool();
+      expect(pool.hasEnoughProofs("0x" + "00".repeat(32), 1)).toBe(false);
+    });
+  });
+
+  describe("has", () => {
+    it("should check for specific (blockRoot, proofId)", () => {
+      const pool = new ExecutionProofPool();
+      const blockRoot = fromHexString("0x" + "aa".repeat(32));
+      const blockRootHex = toRootHex(blockRoot);
+
+      pool.add(createProof({blockRoot, proofId: 0}));
+
+      expect(pool.has(blockRootHex, 0)).toBe(true);
+      expect(pool.has(blockRootHex, 1)).toBe(false);
+    });
+
+    it("should return false for unknown block root", () => {
+      const pool = new ExecutionProofPool();
+      expect(pool.has("0x" + "00".repeat(32), 0)).toBe(false);
+    });
+  });
+
+  describe("prune", () => {
+    it("should remove oldest proofs beyond retention window", () => {
+      const pool = new ExecutionProofPool();
+
+      // Add proofs at 10 slots (10-19), exceeding SLOTS_RETAINED=8
+      for (let slot = 10; slot < 20; slot++) {
+        pool.add(createProof({slot, blockRoot: fromHexString("0x" + slot.toString(16).padStart(64, "0"))}));
+      }
+      expect(pool.size).toBe(10);
+
+      // Prune keeps newest 8 slots by count: 12-19 survive, 10-11 pruned
+      pool.prune(25);
+
+      // Slots 10-11 should be pruned (oldest 2 beyond retention count)
+      expect(pool.getProofsByRange(10, 2)).toHaveLength(0);
+      // Slots 12-19 should remain (newest 8)
+      expect(pool.getProofsByRange(12, 8)).toHaveLength(8);
+    });
+
+    it("should clean up reverse index during prune", () => {
+      const pool = new ExecutionProofPool();
+      const oldBlockRoot = fromHexString("0x" + "aa".repeat(32));
+
+      pool.add(createProof({slot: 5, blockRoot: oldBlockRoot}));
+      pool.prune(20);
+
+      // Reverse index should be cleaned
+      expect(pool.getProofsByBlockRoot(toRootHex(oldBlockRoot))).toHaveLength(0);
+      expect(pool.has(toRootHex(oldBlockRoot), 0)).toBe(false);
+    });
+  });
+});

--- a/packages/beacon-node/test/unit/network/gossip/topic.test.ts
+++ b/packages/beacon-node/test/unit/network/gossip/topic.test.ts
@@ -167,6 +167,20 @@ describe("network / gossip / topic", () => {
         topicStr: "/eth2/a41d57bd/execution_payload_bid/ssz_snappy",
       },
     ],
+    [GossipType.execution_proof]: [
+      {
+        topic: {
+          type: GossipType.execution_proof,
+          boundary: {fork: ForkName.fulu, epoch: config.FULU_FORK_EPOCH},
+          encoding,
+        },
+        topicStr: stringifyGossipTopic(config, {
+          type: GossipType.execution_proof,
+          boundary: {fork: ForkName.fulu, epoch: config.FULU_FORK_EPOCH},
+          encoding,
+        }),
+      },
+    ],
   };
 
   for (const topics of Object.values(testCases)) {

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -226,6 +226,11 @@ export async function beaconHandlerInit(args: BeaconArgs & GlobalArgs) {
     beaconNodeOptions.set({chain: {disableLightClientServer: true}});
   }
 
+  // EIP-8025: Bridge activateZkvm from chain to network options
+  if (args.activateZkvm) {
+    beaconNodeOptions.set({network: {activateZkvm: true}});
+  }
+
   if (args.private) {
     beaconNodeOptions.set({network: {private: true}, api: {private: true}});
   } else {

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -36,6 +36,10 @@ export type ChainArgs = {
   "chain.maxCPStateEpochsOnDisk"?: number;
 
   "chain.pruneHistory"?: boolean;
+  // EIP-8025: zkvm/stateless execution
+  activateZkvm?: boolean;
+  "chain.minProofsRequired"?: number;
+  "chain.zkvmGenerationProofTypes"?: number[];
 };
 
 export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
@@ -75,6 +79,10 @@ export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
     maxCPStateEpochsInMemory: args["chain.maxCPStateEpochsInMemory"] ?? defaultOptions.chain.maxCPStateEpochsInMemory,
     maxCPStateEpochsOnDisk: args["chain.maxCPStateEpochsOnDisk"] ?? defaultOptions.chain.maxCPStateEpochsOnDisk,
     pruneHistory: args["chain.pruneHistory"],
+    // EIP-8025: zkvm/stateless execution
+    activateZkvm: args.activateZkvm,
+    minProofsRequired: args["chain.minProofsRequired"],
+    zkvmGenerationProofTypes: args["chain.zkvmGenerationProofTypes"],
   };
 }
 
@@ -308,6 +316,32 @@ Will double processing times. Use only for debugging purposes.",
     description: "Prune historical blocks and state",
     type: "boolean",
     default: defaultOptions.chain.pruneHistory,
+    group: "chain",
+  },
+
+  // EIP-8025: zkvm/stateless execution options
+
+  activateZkvm: {
+    alias: ["activate-zkvm"],
+    description:
+      "Enable zkvm/stateless execution mode (EIP-8025). Blocks are gated by proof availability instead of execution layer validation.",
+    type: "boolean",
+    default: defaultOptions.chain.activateZkvm,
+    group: "chain",
+  },
+
+  "chain.minProofsRequired": {
+    description: "Minimum distinct proof types required per block in zkvm mode",
+    type: "number",
+    default: defaultOptions.chain.minProofsRequired,
+    group: "chain",
+  },
+
+  "chain.zkvmGenerationProofTypes": {
+    description: "Which proof type IDs this node generates (comma-separated). Empty = verify-only node.",
+    type: "array",
+    number: true,
+    coerce: (ids: number[]): number[] => ids.flatMap((id) => String(id).split(",").map(Number)),
     group: "chain",
   },
 };

--- a/packages/params/src/index.ts
+++ b/packages/params/src/index.ts
@@ -315,6 +315,14 @@ export const BYTES_PER_CELL = FIELD_ELEMENTS_PER_CELL * BYTES_PER_FIELD_ELEMENT;
 export const KZG_COMMITMENTS_GINDEX = 27;
 export const KZG_COMMITMENTS_SUBTREE_INDEX = KZG_COMMITMENTS_GINDEX - 2 ** KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH;
 
+// EIP-8025: Optional Execution Proofs
+/** Maximum size of proof data in bytes (1MB, matching devnet implementations) */
+export const MAX_PROOF_DATA_BYTES = 1_048_576;
+/** Maximum number of execution proof types (zkVM+EL combinations) */
+export const EXECUTION_PROOF_TYPE_COUNT = 8;
+/** Default minimum number of distinct proof types required for DA in zkvm mode */
+export const DEFAULT_MIN_PROOFS_REQUIRED = 2;
+
 // Gloas Misc
 export const BUILDER_INDEX_FLAG = 2 ** 40;
 export const BUILDER_INDEX_SELF_BUILD = Infinity;

--- a/packages/types/src/eip8025/index.ts
+++ b/packages/types/src/eip8025/index.ts
@@ -1,0 +1,2 @@
+export * from "./types.js";
+export {ExecutionProof as ExecutionProofType} from "./sszTypes.js";

--- a/packages/types/src/eip8025/index.ts
+++ b/packages/types/src/eip8025/index.ts
@@ -1,2 +1,6 @@
+export {
+  ExecutionProof as ExecutionProofType,
+  ExecutionProofsByRangeRequest as ExecutionProofsByRangeRequestType,
+  ExecutionProofsByRootRequest as ExecutionProofsByRootRequestType,
+} from "./sszTypes.js";
 export * from "./types.js";
-export {ExecutionProof as ExecutionProofType} from "./sszTypes.js";

--- a/packages/types/src/eip8025/sszTypes.ts
+++ b/packages/types/src/eip8025/sszTypes.ts
@@ -1,0 +1,40 @@
+import {ByteListType, ContainerType} from "@chainsafe/ssz";
+import {MAX_PROOF_DATA_BYTES} from "@lodestar/params";
+import {Root, Slot, Uint8} from "../primitive/sszTypes.js";
+
+/**
+ * ExecutionProofId identifies which zkVM/proof system + EL combination a proof belongs to.
+ * Examples: 0=SP1+Reth, 1=Risc0+Geth, 2=SP1+Geth, etc.
+ *
+ * Note: Uses Uint8 (uint8) per Lighthouse/Prysm devnet implementation.
+ */
+export const ExecutionProofId = Uint8;
+
+/**
+ * The actual proof data, variable length up to MAX_PROOF_DATA_BYTES (1MB).
+ */
+export const ProofData = new ByteListType(MAX_PROOF_DATA_BYTES);
+
+/**
+ * ExecutionProof represents a cryptographic proof that an execution payload is valid.
+ *
+ * Note: This type matches the Lighthouse/Prysm devnet wire format, which diverges from
+ * the consensus spec (no BLS signatures, extra fields for slot/blockHash/blockRoot).
+ * The consensus spec uses SignedExecutionProof with validator_index + BLS signature,
+ * but for devnet interop we match the actual implementation.
+ */
+export const ExecutionProof = new ContainerType(
+  {
+    /** Which proof type (zkVM+EL combination) this proof belongs to (0-7) */
+    proofId: ExecutionProofId,
+    /** The slot of the beacon block this proof validates */
+    slot: Slot,
+    /** The block hash of the execution payload this proof validates */
+    blockHash: Root,
+    /** The beacon block root corresponding to the block with the execution payload */
+    blockRoot: Root,
+    /** The actual ZK proof data */
+    proofData: ProofData,
+  },
+  {typeName: "ExecutionProof", jsonCase: "eth2"}
+);

--- a/packages/types/src/eip8025/sszTypes.ts
+++ b/packages/types/src/eip8025/sszTypes.ts
@@ -1,6 +1,6 @@
-import {ByteListType, ContainerType} from "@chainsafe/ssz";
-import {MAX_PROOF_DATA_BYTES} from "@lodestar/params";
-import {Root, Slot, Uint8} from "../primitive/sszTypes.js";
+import {ByteListType, ContainerType, ListBasicType, UintNumberType} from "@chainsafe/ssz";
+import {EXECUTION_PROOF_TYPE_COUNT, MAX_PROOF_DATA_BYTES} from "@lodestar/params";
+import {Root, Slot, Uint8, UintNum64} from "../primitive/sszTypes.js";
 
 /**
  * ExecutionProofId identifies which zkVM/proof system + EL combination a proof belongs to.
@@ -37,4 +37,34 @@ export const ExecutionProof = new ContainerType(
     proofData: ProofData,
   },
   {typeName: "ExecutionProof", jsonCase: "eth2"}
+);
+
+/**
+ * Request proofs for a specific block root.
+ * Matches Lighthouse `ExecutionProofsByRootRequest` wire format.
+ */
+export const ExecutionProofsByRootRequest = new ContainerType(
+  {
+    /** The block root we need proofs for */
+    blockRoot: Root,
+    /** How many additional proofs we need */
+    countNeeded: UintNum64,
+    /** Proof IDs we already have (responder should exclude these) */
+    alreadyHave: new ListBasicType(new UintNumberType(1), EXECUTION_PROOF_TYPE_COUNT),
+  },
+  {typeName: "ExecutionProofsByRootRequest", jsonCase: "eth2"}
+);
+
+/**
+ * Request proofs for a range of slots.
+ * Matches Lighthouse `ExecutionProofsByRangeRequest` wire format.
+ */
+export const ExecutionProofsByRangeRequest = new ContainerType(
+  {
+    /** The starting slot to request execution proofs */
+    startSlot: UintNum64,
+    /** The number of slots from the start slot */
+    count: UintNum64,
+  },
+  {typeName: "ExecutionProofsByRangeRequest", jsonCase: "eth2"}
 );

--- a/packages/types/src/eip8025/types.ts
+++ b/packages/types/src/eip8025/types.ts
@@ -1,0 +1,5 @@
+import {ValueOf} from "@chainsafe/ssz";
+import * as ssz from "./sszTypes.js";
+
+export type ExecutionProofId = ValueOf<typeof ssz.ExecutionProofId>;
+export type ExecutionProof = ValueOf<typeof ssz.ExecutionProof>;

--- a/packages/types/src/eip8025/types.ts
+++ b/packages/types/src/eip8025/types.ts
@@ -3,3 +3,5 @@ import * as ssz from "./sszTypes.js";
 
 export type ExecutionProofId = ValueOf<typeof ssz.ExecutionProofId>;
 export type ExecutionProof = ValueOf<typeof ssz.ExecutionProof>;
+export type ExecutionProofsByRootRequest = ValueOf<typeof ssz.ExecutionProofsByRootRequest>;
+export type ExecutionProofsByRangeRequest = ValueOf<typeof ssz.ExecutionProofsByRangeRequest>;

--- a/packages/types/src/sszTypes.ts
+++ b/packages/types/src/sszTypes.ts
@@ -9,8 +9,8 @@ import {ssz as fuluSsz} from "./fulu/index.js";
 import {ssz as gloasSsz} from "./gloas/index.js";
 import {ssz as phase0Ssz} from "./phase0/index.js";
 
-export * from "./primitive/sszTypes.js";
 export * as eip8025 from "./eip8025/sszTypes.js";
+export * from "./primitive/sszTypes.js";
 
 /**
  * Index the ssz types that differ by fork

--- a/packages/types/src/sszTypes.ts
+++ b/packages/types/src/sszTypes.ts
@@ -10,6 +10,7 @@ import {ssz as gloasSsz} from "./gloas/index.js";
 import {ssz as phase0Ssz} from "./phase0/index.js";
 
 export * from "./primitive/sszTypes.js";
+export * as eip8025 from "./eip8025/sszTypes.js";
 
 /**
  * Index the ssz types that differ by fork

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -17,6 +17,7 @@ export {ts as electra} from "./electra/index.js";
 export {ts as fulu} from "./fulu/index.js";
 export {ts as gloas} from "./gloas/index.js";
 export {ts as phase0} from "./phase0/index.js";
+export * from "./eip8025/types.js";
 export * from "./primitive/types.js";
 
 /** Common non-spec type to represent roots as strings */

--- a/packages/types/src/types.ts
+++ b/packages/types/src/types.ts
@@ -13,11 +13,11 @@ export {ts as altair} from "./altair/index.js";
 export {ts as bellatrix} from "./bellatrix/index.js";
 export {ts as capella} from "./capella/index.js";
 export {ts as deneb} from "./deneb/index.js";
+export * from "./eip8025/types.js";
 export {ts as electra} from "./electra/index.js";
 export {ts as fulu} from "./fulu/index.js";
 export {ts as gloas} from "./gloas/index.js";
 export {ts as phase0} from "./phase0/index.js";
-export * from "./eip8025/types.js";
 export * from "./primitive/types.js";
 
 /** Common non-spec type to represent roots as strings */

--- a/scripts/dummy-prover.mjs
+++ b/scripts/dummy-prover.mjs
@@ -193,7 +193,7 @@ async function subscribeToEvents(onEvent) {
           if (line.startsWith("event: ")) {
             currentEvent = line.slice(7).trim();
           } else if (line.startsWith("data: ")) {
-            currentData += line.slice(6);
+            currentData += (currentData ? "\n" : "") + line.slice(6);
           } else if (line === "") {
             // Empty line = end of event
             if (currentEvent && currentData) {

--- a/scripts/dummy-prover.mjs
+++ b/scripts/dummy-prover.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+
+/**
+ * EIP-8025 Dummy Prover
+ *
+ * Subscribes to beacon node head events and submits dummy execution proofs
+ * for each new block. Used for devnet/interop testing.
+ *
+ * Usage:
+ *   node scripts/dummy-prover.mjs [options]
+ *
+ * Options:
+ *   --beacon-node URL        Beacon node HTTP endpoint (default: http://localhost:5052)
+ *   --proofs-per-block N     Number of proof IDs to submit per block (default: 1, max: 8)
+ *   --proof-delay-ms N       Simulated proof generation delay in ms (default: 1000)
+ *   --backfill-slots N       Backfill this many recent slots on startup (default: 0)
+ */
+
+import {randomBytes} from "node:crypto";
+
+// Parse CLI args
+const args = process.argv.slice(2);
+function getArg(name, defaultValue) {
+  const idx = args.indexOf(name);
+  if (idx === -1 || idx + 1 >= args.length) return defaultValue;
+  return args[idx + 1];
+}
+
+const BEACON_NODE = getArg("--beacon-node", "http://localhost:5052");
+const PROOFS_PER_BLOCK = Math.min(8, Math.max(1, parseInt(getArg("--proofs-per-block", "1"), 10)));
+const PROOF_DELAY_MS = parseInt(getArg("--proof-delay-ms", "1000"), 10);
+const BACKFILL_SLOTS = parseInt(getArg("--backfill-slots", "0"), 10);
+
+console.log(`Dummy Prover starting...`);
+console.log(`  beacon-node:      ${BEACON_NODE}`);
+console.log(`  proofs-per-block: ${PROOFS_PER_BLOCK}`);
+console.log(`  proof-delay-ms:   ${PROOF_DELAY_MS}`);
+console.log(`  backfill-slots:   ${BACKFILL_SLOTS}`);
+
+/**
+ * Generate dummy proof data (random bytes).
+ * In a real prover, this would be a ZK proof.
+ */
+function generateDummyProofData(size = 256) {
+  return "0x" + randomBytes(size).toString("hex");
+}
+
+/**
+ * Fetch a block from the beacon node and extract execution payload info.
+ */
+async function fetchBlock(blockId) {
+  const resp = await fetch(`${BEACON_NODE}/eth/v2/beacon/blocks/${blockId}`);
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch block ${blockId}: ${resp.status} ${resp.statusText}`);
+  }
+  const json = await resp.json();
+  const block = json.data.message || json.data;
+  const slot = parseInt(block.slot, 10);
+  const executionPayload = block.body?.execution_payload;
+
+  if (!executionPayload) {
+    return null; // Pre-merge block
+  }
+
+  return {
+    slot,
+    blockHash: executionPayload.block_hash,
+  };
+}
+
+/**
+ * Submit an execution proof to the beacon node via REST API.
+ */
+async function submitProof(proof) {
+  const resp = await fetch(`${BEACON_NODE}/eth/v1/beacon/pool/execution_proofs`, {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify(proof),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Failed to submit proof: ${resp.status} ${text}`);
+  }
+}
+
+/**
+ * Generate and submit dummy proofs for a block.
+ */
+async function handleBlock(slot, blockRoot) {
+  try {
+    const blockInfo = await fetchBlock(blockRoot);
+    if (!blockInfo) {
+      console.log(`  [slot ${slot}] No execution payload, skipping`);
+      return;
+    }
+
+    // Simulate proof generation delay
+    if (PROOF_DELAY_MS > 0) {
+      await new Promise((r) => setTimeout(r, PROOF_DELAY_MS));
+    }
+
+    for (let proofId = 0; proofId < PROOFS_PER_BLOCK; proofId++) {
+      const proof = {
+        proof_id: proofId,
+        slot: String(slot),
+        block_hash: blockInfo.blockHash,
+        block_root: blockRoot,
+        proof_data: generateDummyProofData(256),
+      };
+
+      try {
+        await submitProof(proof);
+        console.log(`  [slot ${slot}] Submitted proof id=${proofId}`);
+      } catch (e) {
+        console.error(`  [slot ${slot}] Failed proof id=${proofId}: ${e.message}`);
+      }
+    }
+  } catch (e) {
+    console.error(`  [slot ${slot}] Error: ${e.message}`);
+  }
+}
+
+/**
+ * Backfill proofs for recent slots.
+ */
+async function backfill(numSlots) {
+  if (numSlots <= 0) return;
+
+  console.log(`Backfilling ${numSlots} recent slots...`);
+
+  const resp = await fetch(`${BEACON_NODE}/eth/v1/beacon/headers/head`);
+  if (!resp.ok) {
+    console.error(`Failed to fetch head: ${resp.status}`);
+    return;
+  }
+  const json = await resp.json();
+  const headSlot = parseInt(json.data.header.message.slot, 10);
+  const startSlot = Math.max(0, headSlot - numSlots + 1);
+
+  for (let slot = startSlot; slot <= headSlot; slot++) {
+    try {
+      const headerResp = await fetch(`${BEACON_NODE}/eth/v1/beacon/headers/${slot}`);
+      if (!headerResp.ok) continue;
+      const headerJson = await headerResp.json();
+      const blockRoot = headerJson.data.root;
+      console.log(`Backfill slot ${slot} root=${blockRoot.substring(0, 10)}...`);
+      await handleBlock(slot, blockRoot);
+    } catch (e) {
+      console.error(`Backfill slot ${slot} error: ${e.message}`);
+    }
+  }
+  console.log("Backfill complete.");
+}
+
+/**
+ * Subscribe to SSE events using fetch streaming.
+ * Handles reconnection automatically.
+ */
+async function subscribeToEvents(onEvent) {
+  const url = `${BEACON_NODE}/eth/v1/events?topics=head`;
+  console.log(`Subscribing to events: ${url}`);
+
+  while (true) {
+    try {
+      const resp = await fetch(url, {
+        headers: {Accept: "text/event-stream"},
+        signal: AbortSignal.timeout(0), // no timeout for streaming
+      });
+
+      if (!resp.ok) {
+        console.error(`SSE connection failed: ${resp.status}`);
+        await new Promise((r) => setTimeout(r, 2000));
+        continue;
+      }
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      let currentEvent = "";
+      let currentData = "";
+
+      while (true) {
+        const {done, value} = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, {stream: true});
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || ""; // Keep incomplete line in buffer
+
+        for (const line of lines) {
+          if (line.startsWith("event: ")) {
+            currentEvent = line.slice(7).trim();
+          } else if (line.startsWith("data: ")) {
+            currentData += line.slice(6);
+          } else if (line === "") {
+            // Empty line = end of event
+            if (currentEvent && currentData) {
+              onEvent(currentEvent, currentData);
+            }
+            currentEvent = "";
+            currentData = "";
+          }
+        }
+      }
+
+      console.log("SSE stream ended, reconnecting...");
+    } catch (e) {
+      if (e.name === "AbortError") continue;
+      console.error(`SSE error: ${e.message}, reconnecting in 2s...`);
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+}
+
+/**
+ * Main: wait for beacon node, backfill, then subscribe to events.
+ */
+async function main() {
+  // Wait for beacon node to be ready
+  let ready = false;
+  while (!ready) {
+    try {
+      const resp = await fetch(`${BEACON_NODE}/eth/v1/node/health`);
+      if (resp.ok || resp.status === 206) {
+        ready = true;
+      } else {
+        console.log(`Waiting for beacon node (status=${resp.status})...`);
+        await new Promise((r) => setTimeout(r, 2000));
+      }
+    } catch {
+      console.log("Waiting for beacon node...");
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+  }
+  console.log("Beacon node ready.");
+
+  // Backfill if requested
+  await backfill(BACKFILL_SLOTS);
+
+  // Subscribe to head events
+  await subscribeToEvents((event, data) => {
+    if (event !== "head") return;
+
+    try {
+      const parsed = JSON.parse(data);
+      const slot = parseInt(parsed.slot, 10);
+      const blockRoot = parsed.block;
+      console.log(`New head: slot=${slot} root=${blockRoot.substring(0, 10)}...`);
+      handleBlock(slot, blockRoot);
+    } catch (e) {
+      console.error(`Event parse error: ${e.message}`);
+    }
+  });
+}
+
+main().catch((e) => {
+  console.error("Fatal:", e);
+  process.exit(1);
+});

--- a/scripts/dummy-prover.mjs
+++ b/scripts/dummy-prover.mjs
@@ -163,9 +163,10 @@ async function subscribeToEvents(onEvent) {
 
   while (true) {
     try {
+      const controller = new AbortController();
       const resp = await fetch(url, {
         headers: {Accept: "text/event-stream"},
-        signal: AbortSignal.timeout(0), // no timeout for streaming
+        signal: controller.signal,
       });
 
       if (!resp.ok) {

--- a/scripts/eip8025-devnet/README.md
+++ b/scripts/eip8025-devnet/README.md
@@ -1,112 +1,60 @@
-# EIP-8025 Mixed Client Devnet
+# EIP-8025 Devnet (Lodestar-first)
 
-Local kurtosis devnet for testing EIP-8025 optional execution proofs across clients.
+Kurtosis devnet to validate Lodestar EIP-8025 implementation end-to-end.
 
-## Architecture
+> Current state: Lodestar-only topology is fully runnable.
+> Cross-client Lighthouse/Prysm interop in this script is pending availability of published optional-proofs images.
 
-```
-┌─────────────────────────────────────────────────┐
-│  Kurtosis Devnet                                │
-│                                                 │
-│  ┌──────────────┐    ┌──────────────┐          │
-│  │ Lodestar     │    │ Lighthouse   │          │
-│  │ + reth (EL)  │◄──►│ + geth (EL)  │          │
-│  │ validators   │    │ validators   │          │
-│  └──────┬───────┘    └──────┬───────┘          │
-│         │   gossip          │                   │
-│  ┌──────▼───────┐    ┌──────▼───────┐          │
-│  │ Lodestar     │    │ Lighthouse   │          │
-│  │ --activateZkvm│   │ --activate-  │          │
-│  │ + reth (EL)  │◄──►│   zkvm       │          │
-│  │ no validators│    │ + reth (EL)  │          │
-│  └──────────────┘    └──────────────┘          │
-└─────────────────────────────────────────────────┘
-         ▲                      ▲
-         │  POST /pool/         │
-         │  execution_proofs    │
-    ┌────┴──────────────────────┴────┐
-    │       Dummy Prover             │
-    │  (subscribes to head events,   │
-    │   submits fake proofs)         │
-    └────────────────────────────────┘
-```
+## Topology
 
-## Prerequisites
+- `cl-1-lodestar-reth`: normal node + validators (supernode)
+- `cl-2-lodestar-geth`: normal node + validators (supernode)
+- `cl-3-lodestar-reth`: zkvm node (`--activateZkvm`, no validators)
+- `el-*`: matching EL clients (reth/geth)
+- `dora`: optional dashboard
 
-- Docker
-- [Kurtosis](https://docs.kurtosis.com/install/)
-- Node.js 20+
-- Lodestar Docker image built from this branch
+Dummy prover submits proofs to zkvm node via:
+- `POST /eth/v1/beacon/pool/execution_proofs`
 
 ## Quick Start
 
 ```bash
-# 1. Build the Lodestar image from the EIP-8025 branch (Dockerfile.dev is faster)
+# 1) Build Lodestar image from this branch
 cd ~/lodestar-eip8025
-docker build -t lodestar:eip8025 -f Dockerfile.dev .
+docker build -t lodestar:eip8025 -f Dockerfile .
 
-# 2. Start the devnet
-./scripts/eip8025-devnet/start-devnet.sh
+# 2) Start devnet
+kurtosis run github.com/ethpandaops/ethereum-package \
+  --enclave eip8025-devnet \
+  --args-file scripts/eip8025-devnet/network_params.yaml
 
-# 3. Find the Lodestar zkvm node's beacon API URL
-kurtosis port print eip8025-devnet cl-3-lodestar-reth http
-
-# 4. Start the dummy prover against it
+# 3) Start dummy prover against zkvm node
 node scripts/dummy-prover.mjs \
-  --beacon-node http://127.0.0.1:<PORT> \
+  --beacon-node http://127.0.0.1:33015 \
   --proofs-per-block 1 \
-  --proof-delay-ms 500
+  --proof-delay-ms 200
 ```
 
-## Verifying Interop
+## Verify
 
-### Check proof gossip
 ```bash
-# Lodestar logs — look for "Received execution proof via gossip"
-kurtosis service logs eip8025-devnet cl-3-lodestar-reth 2>&1 | grep -i "execution.proof"
+# Proofs are being submitted
+curl -s http://127.0.0.1:33015/eth/v1/beacon/pool/execution_proofs | jq '.data | length'
 
-# Lighthouse logs — look for execution proof messages
-kurtosis service logs eip8025-devnet cl-4-lighthouse-reth 2>&1 | grep -i "execution.proof"
+# Check execution proof handling logs
+kurtosis service logs eip8025-devnet cl-3-lodestar-reth | grep -i "execution proof\|execution_proof"
+
+# Check zkvm ENR
+curl -s http://127.0.0.1:33015/eth/v1/node/identity | jq -r '.data.enr'
 ```
 
-### Query proof pool via API
-```bash
-# Get proofs from Lodestar
-curl http://127.0.0.1:<PORT>/eth/v1/beacon/pool/execution_proofs
+## Known caveats
 
-# Get proofs from Lighthouse
-curl http://127.0.0.1:<PORT>/eth/v1/beacon/pool/execution_proofs
-```
-
-### Check ENR zkvm flag
-```bash
-# Lodestar node identity
-curl http://127.0.0.1:<PORT>/eth/v1/node/identity | jq '.data.enr'
-# Should contain zkvm=1 in the ENR
-```
-
-## Configuration
-
-### network_params.yaml
-
-Key settings:
-- `fulu_fork_epoch: 1` — Fulu activates at epoch 1 (zkvm only available post-Fulu)
-- `seconds_per_slot: 6` — Faster than mainnet for quicker testing
-- `--activateZkvm` / `--activate-zkvm` — Enables zkvm mode per client
-- `--chain.minProofsRequired=1` — Only require 1 proof type for availability (Lodestar)
-
-### dummy-prover.mjs
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--beacon-node` | `http://localhost:5052` | Beacon node HTTP endpoint |
-| `--proofs-per-block` | `1` | Number of proof IDs (0..N-1) per block |
-| `--proof-delay-ms` | `1000` | Simulated proof generation time |
-| `--backfill-slots` | `0` | Backfill proofs for N recent slots on startup |
+- If no peers subscribe to `execution_proof` gossip topic, API submission still succeeds (proof is stored locally; gossip publish is best-effort).
+- For mixed-client interop, update `network_params.yaml` to include Lighthouse/Prysm optional-proofs images when available.
 
 ## Cleanup
 
 ```bash
-kurtosis enclave stop eip8025-devnet
-kurtosis enclave rm eip8025-devnet
+kurtosis enclave rm -f eip8025-devnet
 ```

--- a/scripts/eip8025-devnet/README.md
+++ b/scripts/eip8025-devnet/README.md
@@ -22,7 +22,7 @@ Dummy prover submits proofs to zkvm node via:
 ```bash
 # 1) Build Lodestar image from this branch
 cd ~/lodestar-eip8025
-docker build -t lodestar:eip8025 -f Dockerfile .
+docker build -t lodestar:eip8025 -f Dockerfile.dev .
 
 # 2) Start devnet
 kurtosis run github.com/ethpandaops/ethereum-package \

--- a/scripts/eip8025-devnet/README.md
+++ b/scripts/eip8025-devnet/README.md
@@ -14,6 +14,7 @@ Kurtosis devnet to validate Lodestar EIP-8025 implementation end-to-end.
 - `dora`: optional dashboard
 
 Dummy prover submits proofs to zkvm node via:
+
 - `POST /eth/v1/beacon/pool/execution_proofs`
 
 ## Quick Start

--- a/scripts/eip8025-devnet/README.md
+++ b/scripts/eip8025-devnet/README.md
@@ -1,0 +1,112 @@
+# EIP-8025 Mixed Client Devnet
+
+Local kurtosis devnet for testing EIP-8025 optional execution proofs across clients.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│  Kurtosis Devnet                                │
+│                                                 │
+│  ┌──────────────┐    ┌──────────────┐          │
+│  │ Lodestar     │    │ Lighthouse   │          │
+│  │ + reth (EL)  │◄──►│ + geth (EL)  │          │
+│  │ validators   │    │ validators   │          │
+│  └──────┬───────┘    └──────┬───────┘          │
+│         │   gossip          │                   │
+│  ┌──────▼───────┐    ┌──────▼───────┐          │
+│  │ Lodestar     │    │ Lighthouse   │          │
+│  │ --activateZkvm│   │ --activate-  │          │
+│  │ + reth (EL)  │◄──►│   zkvm       │          │
+│  │ no validators│    │ + reth (EL)  │          │
+│  └──────────────┘    └──────────────┘          │
+└─────────────────────────────────────────────────┘
+         ▲                      ▲
+         │  POST /pool/         │
+         │  execution_proofs    │
+    ┌────┴──────────────────────┴────┐
+    │       Dummy Prover             │
+    │  (subscribes to head events,   │
+    │   submits fake proofs)         │
+    └────────────────────────────────┘
+```
+
+## Prerequisites
+
+- Docker
+- [Kurtosis](https://docs.kurtosis.com/install/)
+- Node.js 20+
+- Lodestar Docker image built from this branch
+
+## Quick Start
+
+```bash
+# 1. Build the Lodestar image from the EIP-8025 branch (Dockerfile.dev is faster)
+cd ~/lodestar-eip8025
+docker build -t lodestar:eip8025 -f Dockerfile.dev .
+
+# 2. Start the devnet
+./scripts/eip8025-devnet/start-devnet.sh
+
+# 3. Find the Lodestar zkvm node's beacon API URL
+kurtosis port print eip8025-devnet cl-3-lodestar-reth http
+
+# 4. Start the dummy prover against it
+node scripts/dummy-prover.mjs \
+  --beacon-node http://127.0.0.1:<PORT> \
+  --proofs-per-block 1 \
+  --proof-delay-ms 500
+```
+
+## Verifying Interop
+
+### Check proof gossip
+```bash
+# Lodestar logs — look for "Received execution proof via gossip"
+kurtosis service logs eip8025-devnet cl-3-lodestar-reth 2>&1 | grep -i "execution.proof"
+
+# Lighthouse logs — look for execution proof messages
+kurtosis service logs eip8025-devnet cl-4-lighthouse-reth 2>&1 | grep -i "execution.proof"
+```
+
+### Query proof pool via API
+```bash
+# Get proofs from Lodestar
+curl http://127.0.0.1:<PORT>/eth/v1/beacon/pool/execution_proofs
+
+# Get proofs from Lighthouse
+curl http://127.0.0.1:<PORT>/eth/v1/beacon/pool/execution_proofs
+```
+
+### Check ENR zkvm flag
+```bash
+# Lodestar node identity
+curl http://127.0.0.1:<PORT>/eth/v1/node/identity | jq '.data.enr'
+# Should contain zkvm=1 in the ENR
+```
+
+## Configuration
+
+### network_params.yaml
+
+Key settings:
+- `fulu_fork_epoch: 1` — Fulu activates at epoch 1 (zkvm only available post-Fulu)
+- `seconds_per_slot: 6` — Faster than mainnet for quicker testing
+- `--activateZkvm` / `--activate-zkvm` — Enables zkvm mode per client
+- `--chain.minProofsRequired=1` — Only require 1 proof type for availability (Lodestar)
+
+### dummy-prover.mjs
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--beacon-node` | `http://localhost:5052` | Beacon node HTTP endpoint |
+| `--proofs-per-block` | `1` | Number of proof IDs (0..N-1) per block |
+| `--proof-delay-ms` | `1000` | Simulated proof generation time |
+| `--backfill-slots` | `0` | Backfill proofs for N recent slots on startup |
+
+## Cleanup
+
+```bash
+kurtosis enclave stop eip8025-devnet
+kurtosis enclave rm eip8025-devnet
+```

--- a/scripts/eip8025-devnet/network_params.yaml
+++ b/scripts/eip8025-devnet/network_params.yaml
@@ -1,13 +1,12 @@
-# EIP-8025 Optional Execution Proofs — Lodestar Devnet
+# EIP-8025 Optional Execution Proofs — Mixed Client Devnet
 #
-# Lodestar-only devnet to validate EIP-8025 implementation.
-# Cross-client testing (Lighthouse/Prysm) pending ethpandaops image builds.
+# Lodestar + Lighthouse mixed devnet for EIP-8025 interop testing.
 #
 # Usage:
 #   kurtosis run github.com/ethpandaops/ethereum-package --args-file network_params.yaml
 
 participants:
-  # Normal supernode with real execution (produces blocks)
+  # Normal Lodestar supernode (produces blocks)
   - el_type: reth
     el_image: ghcr.io/paradigmxyz/reth:latest
     cl_type: lodestar
@@ -18,17 +17,18 @@ participants:
     count: 1
     validator_count: 128
 
+  # Normal Lighthouse supernode (produces blocks)
   - el_type: geth
     el_image: ethereum/client-go:latest
-    cl_type: lodestar
-    cl_image: lodestar:eip8025
+    cl_type: lighthouse
+    cl_image: ethpandaops/lighthouse:eth-act-optional-proofs
     cl_extra_params:
-      - --targetPeers=5
+      - --target-peers=5
     supernode: true
     count: 1
     validator_count: 128
 
-  # Lodestar zkvm node — receives proofs via gossip/API
+  # Lodestar zkvm node
   - el_type: reth
     el_image: ghcr.io/paradigmxyz/reth:latest
     cl_type: lodestar
@@ -37,6 +37,17 @@ participants:
       - --activateZkvm
       - --chain.minProofsRequired=1
       - --targetPeers=5
+    count: 1
+    validator_count: 0
+
+  # Lighthouse zkvm node — interop target
+  - el_type: reth
+    el_image: ghcr.io/paradigmxyz/reth:latest
+    cl_type: lighthouse
+    cl_image: ethpandaops/lighthouse:eth-act-optional-proofs
+    cl_extra_params:
+      - --activate-zkvm
+      - --target-peers=5
     count: 1
     validator_count: 0
 

--- a/scripts/eip8025-devnet/network_params.yaml
+++ b/scripts/eip8025-devnet/network_params.yaml
@@ -1,38 +1,34 @@
-# EIP-8025 Optional Execution Proofs — Mixed Client Devnet
+# EIP-8025 Optional Execution Proofs — Lodestar Devnet
 #
-# This config runs a kurtosis devnet with:
-# - 2 normal nodes (reth EL, no zkvm)
-# - 1 Lodestar node in zkvm mode
-# - 1 Lighthouse node in zkvm mode (interop target)
+# Lodestar-only devnet to validate EIP-8025 implementation.
+# Cross-client testing (Lighthouse/Prysm) pending ethpandaops image builds.
 #
 # Usage:
 #   kurtosis run github.com/ethpandaops/ethereum-package --args-file network_params.yaml
-#
-# Build Lodestar image first:
-#   cd ~/lodestar-eip8025
-#   docker build -t lodestar:eip8025 -f Dockerfile .
 
 participants:
-  # Normal nodes with real execution (validators produce blocks)
+  # Normal supernode with real execution (produces blocks)
   - el_type: reth
     el_image: ghcr.io/paradigmxyz/reth:latest
     cl_type: lodestar
     cl_image: lodestar:eip8025
     cl_extra_params:
       - --targetPeers=5
+    supernode: true
     count: 1
-    validator_count: 32
+    validator_count: 128
 
   - el_type: geth
     el_image: ethereum/client-go:latest
-    cl_type: lighthouse
-    cl_image: ethpandaops/lighthouse:optional-proofs
+    cl_type: lodestar
+    cl_image: lodestar:eip8025
     cl_extra_params:
-      - --target-peers=5
+      - --targetPeers=5
+    supernode: true
     count: 1
-    validator_count: 32
+    validator_count: 128
 
-  # Lodestar zkvm node — tracks chain via proofs
+  # Lodestar zkvm node — receives proofs via gossip/API
   - el_type: reth
     el_image: ghcr.io/paradigmxyz/reth:latest
     cl_type: lodestar
@@ -41,17 +37,6 @@ participants:
       - --activateZkvm
       - --chain.minProofsRequired=1
       - --targetPeers=5
-    count: 1
-    validator_count: 0
-
-  # Lighthouse zkvm node — interop target
-  - el_type: reth
-    el_image: ghcr.io/paradigmxyz/reth:latest
-    cl_type: lighthouse
-    cl_image: ethpandaops/lighthouse:optional-proofs
-    cl_extra_params:
-      - --activate-zkvm
-      - --target-peers=5
     count: 1
     validator_count: 0
 

--- a/scripts/eip8025-devnet/network_params.yaml
+++ b/scripts/eip8025-devnet/network_params.yaml
@@ -1,6 +1,6 @@
 # EIP-8025 Optional Execution Proofs — Mixed Client Devnet
 #
-# Lodestar + Lighthouse mixed devnet for EIP-8025 interop testing.
+# Lodestar + Lighthouse + Prysm mixed devnet for EIP-8025 interop testing.
 #
 # Usage:
 #   kurtosis run github.com/ethpandaops/ethereum-package --args-file network_params.yaml
@@ -12,10 +12,10 @@ participants:
     cl_type: lodestar
     cl_image: lodestar:eip8025
     cl_extra_params:
-      - --targetPeers=5
+      - --targetPeers=8
     supernode: true
     count: 1
-    validator_count: 128
+    validator_count: 96
 
   # Normal Lighthouse supernode (produces blocks)
   - el_type: geth
@@ -23,10 +23,23 @@ participants:
     cl_type: lighthouse
     cl_image: ethpandaops/lighthouse:eth-act-optional-proofs
     cl_extra_params:
-      - --target-peers=5
+      - --target-peers=8
     supernode: true
     count: 1
-    validator_count: 128
+    validator_count: 96
+
+  # Normal Prysm supernode (produces blocks)
+  - el_type: geth
+    el_image: ethereum/client-go:latest
+    cl_type: prysm
+    cl_image: ethpandaops/prysm-beacon-chain:developeruche-poc-optional-proofs
+    cl_extra_params:
+      - --activate-zkvm
+      - --zkvm-generation-proof-types=0,1
+    vc_image: ethpandaops/prysm-validator:developeruche-poc-optional-proofs
+    supernode: true
+    count: 1
+    validator_count: 96
 
   # Lodestar zkvm node
   - el_type: reth
@@ -36,18 +49,29 @@ participants:
     cl_extra_params:
       - --activateZkvm
       - --chain.minProofsRequired=1
-      - --targetPeers=5
+      - --targetPeers=8
     count: 1
     validator_count: 0
 
-  # Lighthouse zkvm node — interop target
+  # Lighthouse zkvm node
   - el_type: reth
     el_image: ghcr.io/paradigmxyz/reth:latest
     cl_type: lighthouse
     cl_image: ethpandaops/lighthouse:eth-act-optional-proofs
     cl_extra_params:
       - --activate-zkvm
-      - --target-peers=5
+      - --target-peers=8
+    count: 1
+    validator_count: 0
+
+  # Prysm zkvm node
+  - el_type: reth
+    el_image: ghcr.io/paradigmxyz/reth:latest
+    cl_type: prysm
+    cl_image: ethpandaops/prysm-beacon-chain:developeruche-poc-optional-proofs
+    cl_extra_params:
+      - --activate-zkvm
+    vc_image: ethpandaops/prysm-validator:developeruche-poc-optional-proofs
     count: 1
     validator_count: 0
 

--- a/scripts/eip8025-devnet/network_params.yaml
+++ b/scripts/eip8025-devnet/network_params.yaml
@@ -1,0 +1,74 @@
+# EIP-8025 Optional Execution Proofs — Mixed Client Devnet
+#
+# This config runs a kurtosis devnet with:
+# - 2 normal nodes (reth EL, no zkvm)
+# - 1 Lodestar node in zkvm mode
+# - 1 Lighthouse node in zkvm mode (interop target)
+#
+# Usage:
+#   kurtosis run github.com/ethpandaops/ethereum-package --args-file network_params.yaml
+#
+# Build Lodestar image first:
+#   cd ~/lodestar-eip8025
+#   docker build -t lodestar:eip8025 -f Dockerfile .
+
+participants:
+  # Normal nodes with real execution (validators produce blocks)
+  - el_type: reth
+    el_image: ghcr.io/paradigmxyz/reth:latest
+    cl_type: lodestar
+    cl_image: lodestar:eip8025
+    cl_extra_params:
+      - --targetPeers=5
+    count: 1
+    validator_count: 32
+
+  - el_type: geth
+    el_image: ethereum/client-go:latest
+    cl_type: lighthouse
+    cl_image: ethpandaops/lighthouse:optional-proofs
+    cl_extra_params:
+      - --target-peers=5
+    count: 1
+    validator_count: 32
+
+  # Lodestar zkvm node — tracks chain via proofs
+  - el_type: reth
+    el_image: ghcr.io/paradigmxyz/reth:latest
+    cl_type: lodestar
+    cl_image: lodestar:eip8025
+    cl_extra_params:
+      - --activateZkvm
+      - --chain.minProofsRequired=1
+      - --targetPeers=5
+    count: 1
+    validator_count: 0
+
+  # Lighthouse zkvm node — interop target
+  - el_type: reth
+    el_image: ghcr.io/paradigmxyz/reth:latest
+    cl_type: lighthouse
+    cl_image: ethpandaops/lighthouse:optional-proofs
+    cl_extra_params:
+      - --activate-zkvm
+      - --target-peers=5
+    count: 1
+    validator_count: 0
+
+network_params:
+  electra_fork_epoch: 0
+  fulu_fork_epoch: 1
+  seconds_per_slot: 6
+
+global_log_level: debug
+
+additional_services:
+  - dora
+
+port_publisher:
+  el:
+    enabled: true
+    public_port_start: 32000
+  cl:
+    enabled: true
+    public_port_start: 33000

--- a/scripts/eip8025-devnet/start-devnet.sh
+++ b/scripts/eip8025-devnet/start-devnet.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_DIR="$(cd -- "$SCRIPT_DIR/../.." &>/dev/null && pwd)"
+
+ENCLAVE_NAME="${ENCLAVE_NAME:-eip8025-devnet}"
+
+echo "=== EIP-8025 Mixed Client Devnet ==="
+echo ""
+
+# Step 1: Build Lodestar image (use Dockerfile.dev for faster builds)
+echo "1. Building Lodestar Docker image (Dockerfile.dev)..."
+cd "$REPO_DIR"
+docker build -t lodestar:eip8025 -f Dockerfile.dev .
+echo "   Done."
+
+# Step 2: Start kurtosis devnet
+echo ""
+echo "2. Starting kurtosis devnet (enclave: $ENCLAVE_NAME)..."
+kurtosis run github.com/ethpandaops/ethereum-package \
+  --enclave "$ENCLAVE_NAME" \
+  --args-file "$SCRIPT_DIR/network_params.yaml"
+
+echo ""
+echo "3. Devnet is running!"
+echo ""
+echo "   View services:  kurtosis enclave inspect $ENCLAVE_NAME"
+echo "   View logs:      kurtosis service logs $ENCLAVE_NAME <service-name>"
+echo ""
+
+# Step 3: Print beacon node URLs
+echo "   Beacon node endpoints:"
+for svc in $(kurtosis enclave inspect "$ENCLAVE_NAME" 2>/dev/null | grep "cl-" | awk '{print $1}'); do
+  url=$(kurtosis port print "$ENCLAVE_NAME" "$svc" http 2>/dev/null || echo "N/A")
+  echo "     $svc → $url"
+done
+
+echo ""
+echo "4. Start the dummy prover against a Lodestar node:"
+echo "   node $REPO_DIR/scripts/dummy-prover.mjs --beacon-node <LODESTAR_URL> --proofs-per-block 1"
+echo ""
+echo "5. Monitor proof gossip in logs:"
+echo "   kurtosis service logs $ENCLAVE_NAME <cl-service> | grep -i 'execution.proof\\|zkvm'"


### PR DESCRIPTION
## Description

Implements EIP-8025 optional execution proofs for Lodestar — validated with 3-client interop (Lodestar + Lighthouse + Prysm) in a kurtosis devnet with assertoor.

### What's included

| Phase | Description | Commit |
|-------|-------------|--------|
| A | SSZ types & constants (`ExecutionProof`, proof IDs, size limits) | `5ee6cf3` |
| F | CLI: `--activateZkvm`, `--chain.minProofsRequired`, `--chain.zkvmGenerationProofTypes` | `50cb096` |
| B.1 | Gossip: `execution_proof` topic wiring (parse, queue, scoring, handler, zkvm-gated subscription) | `e33b004` |
| B.2 | Req/Resp: `ExecutionProofsByRoot` + `ExecutionProofsByRange` protocols | `ae6f0f4` |
| B.4 | ENR `zkvm` key signaling | `3e8fae0` |
| C | `ExecutionProofPool` (in-memory, indexed by slot→blockRoot→proofId, 8-slot retention) | `da648a6` |
| D | REST API: `GET/POST /eth/v1/beacon/pool/execution_proofs` | `08b4871` |
| G | Kurtosis devnet config + dummy prover script | `6f59221` |
| fix | Best-effort gossip publish on API submit, SSE timeout fix | `0f5c734` |
| fix | Bridge `activateZkvm` CLI flag to network options | `5b1afeb` |
| fix | Far-future slot rejection in gossip handler | `acefaea` |
| test | ExecutionProofPool unit tests (15 tests) | `1bd02bb` |

### Interop validation (3-client, assertoor)

6-node kurtosis devnet: 3 supernodes (Lodestar+Lighthouse+Prysm, 96 validators each) + 3 zkvm observer nodes. Fulu fork epoch 1, 6s slots.

**Assertoor results — all passed:**
- ✅ Chain stability (finality, no reorgs, no forks)
- ✅ Block proposals from all client pairs
- ✅ Finality reached (finalized epoch 3, justified 4 at slot 171)
- ✅ 0 missed slots (130 blocks: Lodestar 46, Lighthouse 40, Prysm 44)

**Proof gossip — 100% delivery:**
- Prysm generates 2 proofs per block (proofId 0 and 1)
- Lodestar zkvm node received 278 proofs (2 × 139 slots), all `insertOutcome=NewData`
- Lighthouse zkvm node received 156+ proofs
- SSZ wire format compatible across all 3 clients (uint8 ProofId, fixed part = 77 bytes)

**Errors:** 1 harmless startup warning ("discv5 has no boot enr"), zero errors across all 6 CL + 3 VC nodes.

### Not included (future work)

- **Phase E (sync integration)**: Range sync proof fetching + DA gating — not needed for all-start-at-genesis devnets
- **Proof verification**: Gossip handler accepts all well-formed proofs without cryptographic verification (TODO)
- **Cross-client req/resp**: Only gossip tested; req/resp protocol handlers are stubbed

### How to test

```bash
# Build image
docker build -t lodestar:eip8025 -f Dockerfile.dev .

# Start mixed devnet
kurtosis run github.com/ethpandaops/ethereum-package \
  --enclave eip8025-devnet \
  --args-file scripts/eip8025-devnet/network_params.yaml

# Run dummy prover against Lodestar zkvm node
node scripts/dummy-prover.mjs --beacon-node http://127.0.0.1:33015
```

---

*This PR was authored with AI assistance (Claude Opus 4.6 + sub-agents for review).*
