### PR TITLE
chore: enable corepack in Dockerfile.dev for pnpm support

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,7 +10,8 @@ WORKDIR /usr/app
 
 COPY . .
 
-RUN pnpm install --non-interactive && pnpm build
+RUN corepack enable && corepack prepare --activate && \
+  pnpm install --non-interactive && pnpm build
 
 RUN cd packages/cli && GIT_COMMIT=${COMMIT} pnpm write-git-data
 


### PR DESCRIPTION
## Description

`Dockerfile.dev` fails with `pnpm: not found` because `corepack enable` was never added when the project migrated from yarn to pnpm. The production `Dockerfile` already has this (`corepack enable && corepack prepare --activate`) but `Dockerfile.dev` was missed.

### Fix

Add `corepack enable && corepack prepare --activate` before `pnpm install`, matching the production Dockerfile pattern.

---

*This PR was authored with AI assistance (Claude Opus 4.6).*