### PR TITLE
chore: fix Dockerfile.dev build and improve layer caching

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,15 +11,33 @@ WORKDIR /usr/app
 # Enable corepack for pnpm support
 RUN corepack enable
 
-# Copy dependency manifests and workspace packages first for better layer caching.
-# The install layer is only invalidated when dependency-related files change,
-# not on every source code change.
+# Copy dependency manifests first for optimal layer caching.
+# Only changes to package.json or lockfile will invalidate the install layer,
+# source code changes will only invalidate the build layer.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY packages/ packages/
+COPY packages/api/package.json packages/api/
+COPY packages/beacon-node/package.json packages/beacon-node/
+COPY packages/cli/package.json packages/cli/
+COPY packages/config/package.json packages/config/
+COPY packages/db/package.json packages/db/
+COPY packages/era/package.json packages/era/
+COPY packages/flare/package.json packages/flare/
+COPY packages/fork-choice/package.json packages/fork-choice/
+COPY packages/light-client/package.json packages/light-client/
+COPY packages/logger/package.json packages/logger/
+COPY packages/params/package.json packages/params/
+COPY packages/prover/package.json packages/prover/
+COPY packages/reqresp/package.json packages/reqresp/
+COPY packages/spec-test-util/package.json packages/spec-test-util/
+COPY packages/state-transition/package.json packages/state-transition/
+COPY packages/test-utils/package.json packages/test-utils/
+COPY packages/types/package.json packages/types/
+COPY packages/utils/package.json packages/utils/
+COPY packages/validator/package.json packages/validator/
 
 RUN pnpm install --frozen-lockfile
 
-# Copy remaining files (root configs, scripts, etc.)
+# Copy source code and build
 COPY . .
 
 RUN pnpm build

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,10 +8,21 @@ ARG COMMIT
 
 WORKDIR /usr/app
 
+# Enable corepack for pnpm support
+RUN corepack enable
+
+# Copy dependency manifests and workspace packages first for better layer caching.
+# The install layer is only invalidated when dependency-related files change,
+# not on every source code change.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/ packages/
+
+RUN pnpm install --frozen-lockfile
+
+# Copy remaining files (root configs, scripts, etc.)
 COPY . .
 
-RUN corepack enable && corepack prepare --activate && \
-  pnpm install --non-interactive && pnpm build
+RUN pnpm build
 
 RUN cd packages/cli && GIT_COMMIT=${COMMIT} pnpm write-git-data
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,6 @@
 # Generated image is larger than production image. Do not use this for production.
 
 FROM --platform=${BUILDPLATFORM:-amd64} node:24 AS build_dev
-ARG COMMIT
 
 WORKDIR /usr/app
 
@@ -42,6 +41,8 @@ COPY . .
 
 RUN pnpm build
 
+# Declare COMMIT arg after install+build layers to avoid cache invalidation
+ARG COMMIT
 RUN cd packages/cli && GIT_COMMIT=${COMMIT} pnpm write-git-data
 
 ENV NODE_OPTIONS=--max-old-space-size=8192


### PR DESCRIPTION
## Motivation

Dockerfile.dev is broken: `pnpm install --non-interactive` fails because pnpm does not support the `--non-interactive` flag. Additionally, `corepack enable` was missing, which is required for pnpm support on Node 24 images.

Supersedes #8921 which only added `corepack enable` but didn't fix the `--non-interactive` flag issue.

## Description

- Enable corepack before pnpm install (required for pnpm support)
- Remove unsupported `--non-interactive` flag
- Add `--frozen-lockfile` for reproducible builds
- Separate dependency install from build step for better Docker layer caching
  - Copy dependency manifests and workspace packages first (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `packages/`)
  - Run `pnpm install` in its own layer
  - Then copy remaining source and build
  - This means the install layer is cached when only source code changes (though changes within `packages/` will still invalidate it)

Incorporates suggestion from https://github.com/ChainSafe/lodestar/pull/8921#discussion_r2816121356

## Testing

Tested locally:
```
docker build -f Dockerfile.dev -t lodestar-dev-test --build-arg COMMIT=$(git rev-parse HEAD) .
docker run --rm lodestar-dev-test --version
🌟 Lodestar: TypeScript Implementation of the Ethereum Consensus Beacon Chain.
  * Version: v1.40.0/07f3dcc
```

> [!NOTE]
> This PR was authored with AI assistance (Lodekeeper 🌟)