### PR TITLE
fix: yield to event loop between block imports during sync

### DIFF
--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -1,6 +1,7 @@
 import {SignedBeaconBlock} from "@lodestar/types";
 import {isErrorAborted, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
+import {nextEventLoop} from "../../util/eventLoop.js";
 import {JobItemQueue, isQueueErrorAborted} from "../../util/queue/index.js";
 import type {BeaconChain} from "../chain.js";
 import {BlockError, BlockErrorCode, isBlockErrorAborted} from "../errors/index.js";
@@ -100,9 +101,9 @@ export async function processBlocks(
     );
 
     for (const fullyVerifiedBlock of fullyVerifiedBlocks) {
-      // No need to sleep(0) here since `importBlock` includes a disk write
       // TODO: Consider batching importBlock too if it takes significant time
       await importBlock.call(this, fullyVerifiedBlock, opts);
+      await nextEventLoop();
     }
   } catch (e) {
     if (isErrorAborted(e) || isQueueErrorAborted(e) || isBlockErrorAborted(e)) {


### PR DESCRIPTION
## Description

During finalized sync, blocks are imported in a tight loop without yielding to the event loop. When BLS verification is async (not awaiting the execution engine's `newPayload`), this prevents the checkpoint state cache's `processState()` cleanup from running, causing unbounded state accumulation and OOM on memory-constrained hosts.

This adds `nextEventLoop()` after each `importBlock` to allow pending async cleanup (state serialization, cache eviction) to execute between block imports.

### Root Cause

In `processBlocks()`, the import loop previously had a natural yield point when `importBlock` awaited the execution engine. With async BLS via `@chainsafe/blst` (PR #8900), `importBlock` no longer blocks on the EL call, so blocks blast through without yielding. The checkpoint state cache's `processState()` — which runs as fire-and-forget async — never gets a chance to serialize and evict old states, causing memory to climb until OOM.

### Fix

```typescript
for (const fullyVerifiedBlock of fullyVerifiedBlocks) {
  await importBlock.call(this, fullyVerifiedBlock, opts);
  await nextEventLoop(); // Allow processState() cleanup to run
}
```

`nextEventLoop()` is an existing utility (`sleep(0)`) that yields to the event loop's timers phase, giving pending microtasks and macrotasks a chance to execute.

### Testing

Deployed as commit 983d923f on feat3 infrastructure nodes — resolved OOM crash loops on nodes with sufficient memory. Memory-constrained hosts (~16GB) may need additional tuning (reduced `maxBlockStates`, queue depth limits).

Co-authored-by: Cayman <caymannava@gmail.com>

---
> [!NOTE]
> This PR was authored with AI assistance (Claude). All code has been reviewed and validated.