### PR TITLE
test: prevent unhandled QUEUE_ABORTED rejection during E2E teardown

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -688,6 +688,16 @@ export function getValidatorApi(
     // by deferring the call to next event loop iteration, allowing pending I/O operations like
     // HTTP requests to be processed first and sent out early in slot.
     callInNextEventLoop(() => {
+      // Guard against producing blocks after the chain has started shutting down.
+      // During teardown the regen queue's abort signal fires, and any call to
+      // queue.push() would throw QUEUE_ERROR_QUEUE_ABORTED. Without this check
+      // the rejection leaks as an unhandled promise rejection, causing Vitest
+      // (and other test runners) to exit with a non-zero code even when all
+      // tests pass.
+      if (controller.signal.aborted) {
+        return;
+      }
+
       logger.verbose("Producing common block body", loggerContext);
       const commonBlockBodyStartedAt = Date.now();
 
@@ -705,7 +715,15 @@ export function getValidatorApi(
             durationMs: Date.now() - commonBlockBodyStartedAt,
           });
         })
-        .catch(deferredCommonBlockBody.reject);
+        .catch((e) => {
+          // Silently ignore queue abort errors during shutdown to prevent
+          // unhandled rejections when the deferred has no awaiter
+          if (controller.signal.aborted) {
+            logger.debug("Common block body production aborted during shutdown", loggerContext);
+            return;
+          }
+          deferredCommonBlockBody.reject(e);
+        });
     });
 
     const [builder, engine] = await blockProductionRacePromise;

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -86,6 +86,7 @@ import {callInNextEventLoop} from "../../../util/eventLoop.js";
 import {isOptimisticBlock} from "../../../util/forkChoice.js";
 import {getDefaultGraffiti, toGraffitiBytes} from "../../../util/graffiti.js";
 import {getLodestarClientVersion} from "../../../util/metadata.js";
+import {isQueueErrorAborted} from "../../../util/queue/index.js";
 import {ApiOptions} from "../../options.js";
 import {getStateResponseWithRegen} from "../beacon/state/utils.js";
 import {ApiError, FailureList, IndexedError, NodeIsSyncing, OnlySupportedByDVT} from "../errors.js";
@@ -717,8 +718,9 @@ export function getValidatorApi(
         })
         .catch((e) => {
           // Silently ignore queue abort errors during shutdown to prevent
-          // unhandled rejections when the deferred has no awaiter
-          if (controller.signal.aborted) {
+          // unhandled rejections when the deferred has no awaiter.
+          // Only suppress the specific abort error — propagate unexpected ones.
+          if (isQueueErrorAborted(e)) {
             logger.debug("Common block body production aborted during shutdown", loggerContext);
             return;
           }


### PR DESCRIPTION
## What
Fix flaky E2E failures where all tests pass but CI exits non-zero due to an unhandled `QUEUE_ERROR_QUEUE_ABORTED` rejection during teardown.

## Root cause
In `validator/index.ts`, common block body production is scheduled with `callInNextEventLoop`.
If shutdown starts before that callback runs:
1. abort signal fires
2. callback still runs and calls `produceCommonBlockBody`
3. regen queue is aborted, so `queue.push()` throws `QUEUE_ERROR_QUEUE_ABORTED`
4. rejection can surface as an unhandled rejection in Vitest

This matches recent unstable E2E failures (run `22228211648`):
- 44 test files passed
- then unhandled rejection: `QUEUE_ERROR_QUEUE_ABORTED`
- stack: `itemQueue.ts -> queued.ts -> chain.ts -> validator/index.ts:695`

## Fix
- Guard the next-tick callback: return early if `controller.signal.aborted`
- In the async catch block, ignore errors when shutdown is already in progress instead of propagating as unhandled rejection

## Validation
- `pnpm build` passes locally
- behavior change is limited to shutdown/abort path

> 🤖 This PR was authored by Lodekeeper with AI assistance.
