### PR TITLE
fix: handle floating promise rejection in block production race

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -632,6 +632,10 @@ export function getValidatorApi(
     // Defer common block body production to make sure we sent async builder and engine requests before
     const deferredCommonBlockBody = defer<CommonBlockBody>();
     const commonBlockBodyPromise = deferredCommonBlockBody.promise;
+    // Prevent unhandled rejection if common block body production fails after the
+    // block production race settles (e.g. regen queue aborted during chain shutdown).
+    // The rejection still propagates to any consumer that awaits commonBlockBodyPromise.
+    commonBlockBodyPromise.catch(() => {});
 
     // use abort controller to stop waiting for both block sources
     const controller = new AbortController();


### PR DESCRIPTION
## Description

During E2E teardown, the chain's regen queue aborts while a deferred `produceCommonBlockBody` call is still pending in the next event loop tick. When the deferred rejects after the block production race has already settled, the rejection becomes unhandled, causing test runners to exit with a non-zero code despite all tests passing.

### Root Cause

1. `callInNextEventLoop` schedules `chain.produceCommonBlockBody()` for the next tick
2. During teardown, `chain.close()` → `abortController.abort()` → queue rejects all jobs
3. Next tick fires → `regen.getBlockSlotState()` → `queue.push()` throws `QUEUE_ABORTED`
4. `.catch(deferredCommonBlockBody.reject)` rejects the deferred promise
5. But `resolveOrRacePromises` has already settled → no consumer awaiting → **unhandled rejection**

### Fix

Add a no-op `.catch()` on `commonBlockBodyPromise` right after creation. This marks the rejection as "handled" from Node.js's perspective while still propagating errors to any active consumer that awaits the promise.

This is the standard pattern for floating promises in Node.js — a promise that may reject after all consumers have settled.

### Failing CI Runs

- [unstable Tests #22228211648](https://github.com/ChainSafe/lodestar/actions/runs/22228211648) — `QUEUE_ERROR_QUEUE_ABORTED` unhandled rejection
- Multiple feature branch E2E runs with the same pattern

Supersedes #8933 (closed — previous approach incorrectly used the race controller signal instead of addressing the root cause).

_This PR was authored with AI assistance (Claude)._