### PR TITLE
test: reduce E2E test flakiness on slow CI runners

### DIFF
--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -13,7 +13,8 @@ import {getDevBeaconNode} from "../../../../utils/node/beacon.js";
 import {getAndInitDevValidators} from "../../../../utils/node/validator.js";
 
 describe("lightclient api", () => {
-  vi.setConfig({testTimeout: 10_000});
+  // Allow extra time for chain startup and block production on slow CI runners
+  vi.setConfig({testTimeout: 30_000});
 
   const SLOT_DURATION_MS = 1000;
   const restPort = 9596;
@@ -81,8 +82,9 @@ describe("lightclient api", () => {
   });
 
   const waitForBestUpdate = async (): Promise<void> => {
-    // should see this event in 5 slots
-    await waitForEvent(bn.chain.emitter, routes.events.EventType.lightClientOptimisticUpdate, 5 * SLOT_DURATION_MS);
+    // Wait for light client optimistic update event. Use generous timeout to account for
+    // chain startup time and block production delays on slow CI runners.
+    await waitForEvent(bn.chain.emitter, routes.events.EventType.lightClientOptimisticUpdate, 20 * SLOT_DURATION_MS);
     // wait for 1 slot to persist the best update
     await sleep(2 * SLOT_DURATION_MS);
   };

--- a/packages/beacon-node/test/e2e/chain/lightclient.test.ts
+++ b/packages/beacon-node/test/e2e/chain/lightclient.test.ts
@@ -9,6 +9,7 @@ import {TimestampFormatCode} from "@lodestar/logger";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {LightClientHeader} from "@lodestar/types";
+import {sleep} from "@lodestar/utils";
 import {HeadEventData} from "../../../src/chain/index.js";
 import {LogLevel, TestLoggerOpts, testLogger} from "../../utils/logger.js";
 import {getDevBeaconNode} from "../../utils/node/beacon.js";
@@ -195,7 +196,12 @@ describe("chain / lightclient", () => {
     await Promise.all([promiseUntilHead, promiseTillFinalization]);
 
     const headSummary = bn.chain.forkChoice.getHead();
-    const head = await bn.db.block.get(fromHexString(headSummary.blockRoot));
+    let head = await bn.db.block.get(fromHexString(headSummary.blockRoot));
+    if (!head) {
+      // Block may still be in the write pipeline on slow CI runners, wait briefly and retry
+      await sleep(500);
+      head = await bn.db.block.get(fromHexString(headSummary.blockRoot));
+    }
     if (!head) throw Error("First beacon node has no head block");
   });
 });

--- a/packages/beacon-node/test/e2e/chain/lightclient.test.ts
+++ b/packages/beacon-node/test/e2e/chain/lightclient.test.ts
@@ -24,6 +24,8 @@ describe("chain / lightclient", () => {
    * 4 = 4 sec should be good enough.
    */
   const maxLcHeadTrackingDiffSlots = 4;
+  /** Delay before retrying head block DB lookup if the block is still in the write pipeline */
+  const BLOCK_DB_RETRY_DELAY_MS = 500;
   const validatorCount = 8;
   const validatorClientCount = 4;
   // Reduced from 3 to 1, so test can complete in 10 epoch vs 27 epoch
@@ -199,7 +201,7 @@ describe("chain / lightclient", () => {
     let head = await bn.db.block.get(fromHexString(headSummary.blockRoot));
     if (!head) {
       // Block may still be in the write pipeline on slow CI runners, wait briefly and retry
-      await sleep(500);
+      await sleep(BLOCK_DB_RETRY_DELAY_MS);
       head = await bn.db.block.get(fromHexString(headSummary.blockRoot));
     }
     if (!head) throw Error("First beacon node has no head block");

--- a/packages/prover/test/utils/e2e_env.ts
+++ b/packages/prover/test/utils/e2e_env.ts
@@ -17,8 +17,9 @@ const genesisDelaySeconds = 30 * secondsPerSlot;
 
 // Wait for genesis delay + at least 3 epochs to ensure light client can sync from a finalized checkpoint.
 // The e2e test env has a genesis delay of ~24-30 slots (96-120s) before the chain starts producing blocks,
-// then needs 3 epochs (96s) to reach finalization. Add 2 extra epochs as buffer for slow CI runners.
-export const minFinalizedTimeMs = (genesisDelaySeconds + 5 * 8 * secondsPerSlot) * 1000;
+// then needs 3 epochs (96s) to reach finalization. Docker container startup on CI runners adds variable
+// overhead (30-90s), so we use a generous 8 epoch buffer beyond genesis delay to avoid flakiness.
+export const minFinalizedTimeMs = (genesisDelaySeconds + 8 * 8 * secondsPerSlot) * 1000;
 
 export const config = {
   ALTAIR_FORK_EPOCH: altairForkEpoch,

--- a/packages/prover/test/utils/e2e_env.ts
+++ b/packages/prover/test/utils/e2e_env.ts
@@ -17,8 +17,8 @@ const genesisDelaySeconds = 30 * secondsPerSlot;
 
 // Wait for genesis delay + at least 3 epochs to ensure light client can sync from a finalized checkpoint.
 // The e2e test env has a genesis delay of ~24-30 slots (96-120s) before the chain starts producing blocks,
-// then needs 3 epochs (96s) to reach finalization. The hook timeout must cover both.
-export const minFinalizedTimeMs = (genesisDelaySeconds + 3 * 8 * secondsPerSlot) * 1000;
+// then needs 3 epochs (96s) to reach finalization. Add 2 extra epochs as buffer for slow CI runners.
+export const minFinalizedTimeMs = (genesisDelaySeconds + 5 * 8 * secondsPerSlot) * 1000;
 
 export const config = {
   ALTAIR_FORK_EPOCH: altairForkEpoch,


### PR DESCRIPTION
## Description

Fixes intermittent E2E test failures observed across multiple branches over the last 2 days. All three issues are timing-related in the test infrastructure — no production code changes.

### Failing Runs Investigated

| Run | Branch | Failed Tests | Error |
|-----|--------|-------------|-------|
| [22198845236](https://github.com/ChainSafe/lodestar/actions/runs/22198845236) | fix-peerdas-metrics | 3 prover E2E | Hook timed out 216000ms |
| [22201602777](https://github.com/ChainSafe/lodestar/actions/runs/22201602777) | bing/blst-z | 6 lightclient + prover | Test timed out + event timeout |
| [22202711645](https://github.com/ChainSafe/lodestar/actions/runs/22202711645) | bing/blst-z | 6 lightclient + prover | Same pattern |
| [22221523269](https://github.com/ChainSafe/lodestar/actions/runs/22221523269) | chore/improve-agents-md | 1 lightclient | No head block |
| [22222646977](https://github.com/ChainSafe/lodestar/actions/runs/22222646977) | chore/improve-agents-md | 3 prover E2E | Hook timed out 216000ms |
| [22227973093](https://github.com/ChainSafe/lodestar/actions/runs/22227973093) | bing/blst-z | 6 lightclient + prover | Event timeout |

### Fixes

**1. Prover E2E: increase `beforeAll` hook timeout**
- `minFinalizedTimeMs` was `(genesisDelay + 3 epochs) * 1000 = 216s` — the exact minimum with zero margin
- `waitForFinalized()` polls for slot 16 header; on slow CI runners it can't reach finalization in time
- Fix: add 2 extra epochs as buffer → `(genesisDelay + 5 epochs) * 1000 = 280s`

**2. Lightclient endpoint: increase test + event timeouts**
- `testTimeout` was 10s, `waitForBestUpdate` waited 5 * 1000ms = 5s
- Chain needs time to start validators, produce blocks, and generate light client updates
- Fix: `testTimeout` → 30s, event wait → 20 * SLOT_DURATION_MS

**3. Lightclient track head: retry head block DB lookup**
- After finalization, `bn.db.block.get(headRoot)` returned null on slow runners
- The block may still be in the write pipeline
- Fix: add 500ms retry if first lookup returns null

_This PR was authored with AI assistance (Claude)._