### PR TITLE
test: disable flaky E2E tests on slow CI runners

### DIFF
--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -12,7 +12,9 @@ import {LogLevel, TestLoggerOpts, testLogger} from "../../../../utils/logger.js"
 import {getDevBeaconNode} from "../../../../utils/node/beacon.js";
 import {getAndInitDevValidators} from "../../../../utils/node/validator.js";
 
-describe("lightclient api", () => {
+// TODO: Re-enable once lightclient E2E timing is stabilized
+// Disabled due to flaky event timeout on slow CI runners
+describe.skip("lightclient api", () => {
   vi.setConfig({testTimeout: 10_000});
 
   const SLOT_DURATION_MS = 1000;

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -12,7 +12,7 @@ import {LogLevel, TestLoggerOpts, testLogger} from "../../../../utils/logger.js"
 import {getDevBeaconNode} from "../../../../utils/node/beacon.js";
 import {getAndInitDevValidators} from "../../../../utils/node/validator.js";
 
-// TODO: Re-enable once lightclient E2E timing is stabilized
+// TODO: Re-enable once lightclient E2E timing is stabilized (#8937)
 // Disabled due to flaky event timeout on slow CI runners
 describe.skip("lightclient api", () => {
   vi.setConfig({testTimeout: 10_000});

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -1,4 +1,4 @@
-import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
 import {HttpHeader, getClient, routes} from "@lodestar/api";
 import {ChainConfig, createBeaconConfig} from "@lodestar/config";
 import {ForkName} from "@lodestar/params";
@@ -15,8 +15,6 @@ import {getAndInitDevValidators} from "../../../../utils/node/validator.js";
 // TODO: Re-enable once lightclient E2E timing is stabilized (#8937)
 // Disabled due to flaky event timeout on slow CI runners
 describe.skip("lightclient api", () => {
-  vi.setConfig({testTimeout: 10_000});
-
   const SLOT_DURATION_MS = 1000;
   const restPort = 9596;
   const ELECTRA_FORK_EPOCH = 0;

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -12,9 +12,9 @@ import {LogLevel, TestLoggerOpts, testLogger} from "../../../../utils/logger.js"
 import {getDevBeaconNode} from "../../../../utils/node/beacon.js";
 import {getAndInitDevValidators} from "../../../../utils/node/validator.js";
 
-// TODO: Re-enable once lightclient E2E timing is stabilized (#8937)
-// Disabled due to flaky event timeout on slow CI runners
-describe.skip("lightclient api", () => {
+// TODO: Re-enable once lightclient E2E timing is stabilized
+// https://github.com/ChainSafe/lodestar/issues/8937
+describe.skipIf(process.env.CI)("lightclient api", () => {
   const SLOT_DURATION_MS = 1000;
   const restPort = 9596;
   const ELECTRA_FORK_EPOCH = 0;

--- a/packages/beacon-node/test/e2e/chain/lightclient.test.ts
+++ b/packages/beacon-node/test/e2e/chain/lightclient.test.ts
@@ -14,7 +14,7 @@ import {LogLevel, TestLoggerOpts, testLogger} from "../../utils/logger.js";
 import {getDevBeaconNode} from "../../utils/node/beacon.js";
 import {getAndInitDevValidators} from "../../utils/node/validator.js";
 
-// TODO: Re-enable once lightclient E2E timing is stabilized
+// TODO: Re-enable once lightclient E2E timing is stabilized (#8937)
 // Disabled due to flaky head block DB race on slow CI runners
 describe.skip("chain / lightclient", () => {
   vi.setConfig({testTimeout: 600_000});

--- a/packages/beacon-node/test/e2e/chain/lightclient.test.ts
+++ b/packages/beacon-node/test/e2e/chain/lightclient.test.ts
@@ -14,9 +14,9 @@ import {LogLevel, TestLoggerOpts, testLogger} from "../../utils/logger.js";
 import {getDevBeaconNode} from "../../utils/node/beacon.js";
 import {getAndInitDevValidators} from "../../utils/node/validator.js";
 
-// TODO: Re-enable once lightclient E2E timing is stabilized (#8937)
-// Disabled due to flaky head block DB race on slow CI runners
-describe.skip("chain / lightclient", () => {
+// TODO: Re-enable once lightclient E2E timing is stabilized
+// https://github.com/ChainSafe/lodestar/issues/8937
+describe.skipIf(process.env.CI)("chain / lightclient", () => {
   vi.setConfig({testTimeout: 600_000});
 
   /**

--- a/packages/beacon-node/test/e2e/chain/lightclient.test.ts
+++ b/packages/beacon-node/test/e2e/chain/lightclient.test.ts
@@ -14,7 +14,9 @@ import {LogLevel, TestLoggerOpts, testLogger} from "../../utils/logger.js";
 import {getDevBeaconNode} from "../../utils/node/beacon.js";
 import {getAndInitDevValidators} from "../../utils/node/validator.js";
 
-describe("chain / lightclient", () => {
+// TODO: Re-enable once lightclient E2E timing is stabilized
+// Disabled due to flaky head block DB race on slow CI runners
+describe.skip("chain / lightclient", () => {
   vi.setConfig({testTimeout: 600_000});
 
   /**

--- a/packages/prover/test/e2e/cli/cmds/start.test.ts
+++ b/packages/prover/test/e2e/cli/cmds/start.test.ts
@@ -7,15 +7,7 @@ import {ChainConfig, chainConfigToJson} from "@lodestar/config";
 import {runCliCommand, spawnCliCommand, stopChildProcess} from "@lodestar/test-utils";
 import {sleep} from "@lodestar/utils";
 import {getLodestarProverCli} from "../../../../src/cli/cli.js";
-import {
-  beaconUrl,
-  chainId,
-  config,
-  proxyPort,
-  proxyUrl,
-  rpcUrl,
-  waitForFinalized,
-} from "../../../utils/e2e_env.js";
+import {beaconUrl, chainId, config, proxyPort, proxyUrl, rpcUrl, waitForFinalized} from "../../../utils/e2e_env.js";
 
 const cli = getLodestarProverCli();
 

--- a/packages/prover/test/e2e/cli/cmds/start.test.ts
+++ b/packages/prover/test/e2e/cli/cmds/start.test.ts
@@ -20,7 +20,7 @@ import {
 
 const cli = getLodestarProverCli();
 
-// TODO: Re-enable once shared E2E env timing is stabilized
+// TODO: Re-enable once shared E2E env timing is stabilized (#8937)
 // Disabled due to flaky hook timeout on slow CI runners
 describe.skip("prover/proxy", () => {
   it("should show help", async () => {

--- a/packages/prover/test/e2e/cli/cmds/start.test.ts
+++ b/packages/prover/test/e2e/cli/cmds/start.test.ts
@@ -19,9 +19,9 @@ import {
 
 const cli = getLodestarProverCli();
 
-// TODO: Re-enable once shared E2E env timing is stabilized (#8937)
-// Disabled due to flaky hook timeout on slow CI runners
-describe.skip("prover/proxy", () => {
+// TODO: Re-enable once shared E2E env timing is stabilized
+// https://github.com/ChainSafe/lodestar/issues/8937
+describe.skipIf(process.env.CI)("prover/proxy", () => {
   it("should show help", async () => {
     const output = await runCliCommand(cli, ["proxy", "--help"]);
 

--- a/packages/prover/test/e2e/cli/cmds/start.test.ts
+++ b/packages/prover/test/e2e/cli/cmds/start.test.ts
@@ -20,7 +20,9 @@ import {
 
 const cli = getLodestarProverCli();
 
-describe("prover/proxy", () => {
+// TODO: Re-enable once shared E2E env timing is stabilized
+// Disabled due to flaky hook timeout on slow CI runners
+describe.skip("prover/proxy", () => {
   it("should show help", async () => {
     const output = await runCliCommand(cli, ["proxy", "--help"]);
 

--- a/packages/prover/test/e2e/cli/cmds/start.test.ts
+++ b/packages/prover/test/e2e/cli/cmds/start.test.ts
@@ -11,7 +11,6 @@ import {
   beaconUrl,
   chainId,
   config,
-  minFinalizedTimeMs,
   proxyPort,
   proxyUrl,
   rpcUrl,
@@ -64,7 +63,7 @@ describe.skip("prover/proxy", () => {
       );
       // Give sometime to the prover to start proxy server
       await sleep(3000);
-    }, minFinalizedTimeMs);
+    }, 50000);
 
     afterAll(async () => {
       if (proc) {

--- a/packages/prover/test/e2e/web3_batch_request.test.ts
+++ b/packages/prover/test/e2e/web3_batch_request.test.ts
@@ -5,7 +5,9 @@ import {getVerificationFailedMessage} from "../../src/utils/json_rpc.js";
 import {createVerifiedExecutionProvider} from "../../src/web3_provider.js";
 import {beaconUrl, config, minFinalizedTimeMs, rpcUrl, waitForFinalized} from "../utils/e2e_env.js";
 
-describe("web3_batch_requests", () => {
+// TODO: Re-enable once shared E2E env timing is stabilized
+// Disabled due to flaky hook timeout on slow CI runners
+describe.skip("web3_batch_requests", () => {
   vi.setConfig({hookTimeout: minFinalizedTimeMs});
 
   let web3: Web3;

--- a/packages/prover/test/e2e/web3_batch_request.test.ts
+++ b/packages/prover/test/e2e/web3_batch_request.test.ts
@@ -5,7 +5,7 @@ import {getVerificationFailedMessage} from "../../src/utils/json_rpc.js";
 import {createVerifiedExecutionProvider} from "../../src/web3_provider.js";
 import {beaconUrl, config, minFinalizedTimeMs, rpcUrl, waitForFinalized} from "../utils/e2e_env.js";
 
-// TODO: Re-enable once shared E2E env timing is stabilized
+// TODO: Re-enable once shared E2E env timing is stabilized (#8937)
 // Disabled due to flaky hook timeout on slow CI runners
 describe.skip("web3_batch_requests", () => {
   vi.setConfig({hookTimeout: minFinalizedTimeMs});

--- a/packages/prover/test/e2e/web3_batch_request.test.ts
+++ b/packages/prover/test/e2e/web3_batch_request.test.ts
@@ -5,9 +5,9 @@ import {getVerificationFailedMessage} from "../../src/utils/json_rpc.js";
 import {createVerifiedExecutionProvider} from "../../src/web3_provider.js";
 import {beaconUrl, config, minFinalizedTimeMs, rpcUrl, waitForFinalized} from "../utils/e2e_env.js";
 
-// TODO: Re-enable once shared E2E env timing is stabilized (#8937)
-// Disabled due to flaky hook timeout on slow CI runners
-describe.skip("web3_batch_requests", () => {
+// TODO: Re-enable once shared E2E env timing is stabilized
+// https://github.com/ChainSafe/lodestar/issues/8937
+describe.skipIf(process.env.CI)("web3_batch_requests", () => {
   vi.setConfig({hookTimeout: minFinalizedTimeMs});
 
   let web3: Web3;

--- a/packages/prover/test/e2e/web3_provider.test.ts
+++ b/packages/prover/test/e2e/web3_provider.test.ts
@@ -5,7 +5,7 @@ import {LCTransport} from "../../src/interfaces.js";
 import {createVerifiedExecutionProvider} from "../../src/web3_provider.js";
 import {beaconUrl, config, minFinalizedTimeMs, rpcUrl, waitForFinalized} from "../utils/e2e_env.js";
 
-// TODO: Re-enable once shared E2E env timing is stabilized
+// TODO: Re-enable once shared E2E env timing is stabilized (#8937)
 // Disabled due to flaky hook timeout on slow CI runners
 describe.skip("web3_provider", () => {
   vi.setConfig({hookTimeout: minFinalizedTimeMs});

--- a/packages/prover/test/e2e/web3_provider.test.ts
+++ b/packages/prover/test/e2e/web3_provider.test.ts
@@ -5,9 +5,9 @@ import {LCTransport} from "../../src/interfaces.js";
 import {createVerifiedExecutionProvider} from "../../src/web3_provider.js";
 import {beaconUrl, config, minFinalizedTimeMs, rpcUrl, waitForFinalized} from "../utils/e2e_env.js";
 
-// TODO: Re-enable once shared E2E env timing is stabilized (#8937)
-// Disabled due to flaky hook timeout on slow CI runners
-describe.skip("web3_provider", () => {
+// TODO: Re-enable once shared E2E env timing is stabilized
+// https://github.com/ChainSafe/lodestar/issues/8937
+describe.skipIf(process.env.CI)("web3_provider", () => {
   vi.setConfig({hookTimeout: minFinalizedTimeMs});
 
   beforeAll(async () => {

--- a/packages/prover/test/e2e/web3_provider.test.ts
+++ b/packages/prover/test/e2e/web3_provider.test.ts
@@ -5,7 +5,9 @@ import {LCTransport} from "../../src/interfaces.js";
 import {createVerifiedExecutionProvider} from "../../src/web3_provider.js";
 import {beaconUrl, config, minFinalizedTimeMs, rpcUrl, waitForFinalized} from "../utils/e2e_env.js";
 
-describe("web3_provider", () => {
+// TODO: Re-enable once shared E2E env timing is stabilized
+// Disabled due to flaky hook timeout on slow CI runners
+describe.skip("web3_provider", () => {
   vi.setConfig({hookTimeout: minFinalizedTimeMs});
 
   beforeAll(async () => {

--- a/packages/prover/test/utils/e2e_env.ts
+++ b/packages/prover/test/utils/e2e_env.ts
@@ -15,10 +15,8 @@ const denebForkEpoch = 0;
 const electraForkEpoch = 0;
 const genesisDelaySeconds = 30 * secondsPerSlot;
 
-// Wait for genesis delay + at least 3 epochs to ensure light client can sync from a finalized checkpoint.
-// The e2e test env has a genesis delay of ~24-30 slots (96-120s) before the chain starts producing blocks,
-// then needs 3 epochs (96s) to reach finalization. The hook timeout must cover both.
-export const minFinalizedTimeMs = (genesisDelaySeconds + 3 * 8 * secondsPerSlot) * 1000;
+// Wait for at least 2 epochs to ensure light client can sync from a finalized checkpoint
+export const minFinalizedTimeMs = 2 * 8 * 4 * 1000;
 
 export const config = {
   ALTAIR_FORK_EPOCH: altairForkEpoch,


### PR DESCRIPTION
## Description

Disables 5 E2E test suites that intermittently fail due to timing issues on slow CI runners.

### Disabled Tests

| File | Failure Pattern |
|------|----------------|
| `packages/prover/test/e2e/cli/cmds/start.test.ts` | Hook timeout — shared env finalization too slow |
| `packages/prover/test/e2e/web3_provider.test.ts` | Hook timeout — same root cause |
| `packages/prover/test/e2e/web3_batch_request.test.ts` | Hook timeout — same root cause |
| `packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts` | Event timeout waiting for best update |
| `packages/beacon-node/test/e2e/chain/lightclient.test.ts` | Head block not yet in DB after finalization |

### Failing Runs (across multiple branches)

| Run | Branch | Failed Tests |
|-----|--------|-------------|
| [22198845236](https://github.com/ChainSafe/lodestar/actions/runs/22198845236) | fix-peerdas-metrics | 3 prover E2E |
| [22201602777](https://github.com/ChainSafe/lodestar/actions/runs/22201602777) | bing/blst-z | 6 lightclient + prover |
| [22202711645](https://github.com/ChainSafe/lodestar/actions/runs/22202711645) | bing/blst-z | 6 lightclient + prover |
| [22221523269](https://github.com/ChainSafe/lodestar/actions/runs/22221523269) | chore/improve-agents-md | 1 lightclient |
| [22222646977](https://github.com/ChainSafe/lodestar/actions/runs/22222646977) | chore/improve-agents-md | 3 prover E2E |
| [22227973093](https://github.com/ChainSafe/lodestar/actions/runs/22227973093) | bing/blst-z | 6 lightclient + prover |

All failures are timing-related in test infrastructure, not production code. Tests should be re-enabled once the shared E2E environment timing is stabilized.

_This PR was authored with AI assistance (Claude)._