### PR TITLE
fix(fork-choice): thread proposerBoostRoot into getPayloadStatusTiebreaker

### DIFF
--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -303,9 +303,9 @@ export function initializeForkChoiceFromUnfinalizedState(
   };
 
   const protoArray = ProtoArray.initialize(finalizedBlock, currentSlot);
-  protoArray.onBlock(justifiedBlock, currentSlot);
-  protoArray.onBlock(parentBlock, currentSlot);
-  protoArray.onBlock(headBlock, currentSlot);
+  protoArray.onBlock(justifiedBlock, currentSlot, null);
+  protoArray.onBlock(parentBlock, currentSlot, null);
+  protoArray.onBlock(headBlock, currentSlot, null);
 
   logger?.verbose("Initialized protoArray successfully", {...logCtx, length: protoArray.length()});
 

--- a/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/aggregatedAttestationPool.test.ts
@@ -104,7 +104,8 @@ describe(`getAttestationsForBlock vc=${vc}`, () => {
             builderIndex: null,
             blockHashFromBid: null,
           },
-          slot
+          slot,
+          null
         );
       }
 

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -838,7 +838,7 @@ export class ForkChoice implements IForkChoice {
       parentBlockHash: parentHashHex,
     };
 
-    this.protoArray.onBlock(protoBlock, currentSlot);
+    this.protoArray.onBlock(protoBlock, currentSlot, this.proposerBoostRoot);
 
     return protoBlock;
   }
@@ -981,7 +981,8 @@ export class ForkChoice implements IForkChoice {
       this.fcStore.currentSlot,
       executionPayloadBlockHash,
       executionPayloadNumber,
-      executionPayloadStateRoot
+      executionPayloadStateRoot,
+      this.proposerBoostRoot
     );
   }
 

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -103,7 +103,8 @@ export class ProtoArray {
         // We are using the blockROot as the targetRoot, since it always lies on an epoch boundary
         targetRoot: block.blockRoot,
       } as ProtoBlock,
-      currentSlot
+      currentSlot,
+      null
     );
     return protoArray;
   }
@@ -381,7 +382,7 @@ export class ProtoArray {
       // If the node has a parent, try to update its best-child and best-descendant.
       const parentIndex = node.parent;
       if (parentIndex !== undefined) {
-        this.maybeUpdateBestChildAndDescendant(parentIndex, nodeIndex, currentSlot);
+        this.maybeUpdateBestChildAndDescendant(parentIndex, nodeIndex, currentSlot, proposerBoost?.root ?? null);
       }
     }
     // Update the previous proposer boost
@@ -393,7 +394,7 @@ export class ProtoArray {
    *
    * It is only sane to supply an undefined parent for the genesis block
    */
-  onBlock(block: ProtoBlock, currentSlot: Slot): void {
+  onBlock(block: ProtoBlock, currentSlot: Slot, proposerBoostRoot: RootHex | null): void {
     // If the block is already known, simply ignore it
     if (this.hasBlock(block.blockRoot)) {
       return;
@@ -465,7 +466,7 @@ export class ProtoArray {
 
       // Update bestChild pointers
       if (parentIndex !== undefined) {
-        this.maybeUpdateBestChildAndDescendant(parentIndex, pendingIndex, currentSlot);
+        this.maybeUpdateBestChildAndDescendant(parentIndex, pendingIndex, currentSlot, proposerBoostRoot);
 
         if (pendingNode.executionStatus === ExecutionStatus.Valid) {
           this.propagateValidExecutionStatusByIndex(parentIndex);
@@ -473,7 +474,7 @@ export class ProtoArray {
       }
 
       // Update bestChild for PENDING → EMPTY edge
-      this.maybeUpdateBestChildAndDescendant(pendingIndex, emptyIndex, currentSlot);
+      this.maybeUpdateBestChildAndDescendant(pendingIndex, emptyIndex, currentSlot, proposerBoostRoot);
 
       // Initialize PTC votes for this block (all false initially)
       // Spec: gloas/fork-choice.md#modified-on_block (line 645)
@@ -498,7 +499,7 @@ export class ProtoArray {
       // If this node is valid, lets propagate the valid status up the chain
       // and throw error if we counter invalid, as this breaks consensus
       if (node.parent !== undefined) {
-        this.maybeUpdateBestChildAndDescendant(node.parent, nodeIndex, currentSlot);
+        this.maybeUpdateBestChildAndDescendant(node.parent, nodeIndex, currentSlot, proposerBoostRoot);
 
         if (node.executionStatus === ExecutionStatus.Valid) {
           this.propagateValidExecutionStatusByIndex(node.parent);
@@ -519,7 +520,8 @@ export class ProtoArray {
     currentSlot: Slot,
     executionPayloadBlockHash: RootHex,
     executionPayloadNumber: number,
-    executionPayloadStateRoot: RootHex
+    executionPayloadStateRoot: RootHex,
+    proposerBoostRoot: RootHex | null
   ): void {
     // First check if block exists
     const variants = this.indices.get(blockRoot);
@@ -582,7 +584,7 @@ export class ProtoArray {
     variants[PayloadStatus.FULL] = fullIndex;
 
     // Update bestChild for PENDING node (may now prefer FULL over EMPTY)
-    this.maybeUpdateBestChildAndDescendant(pendingIndex, fullIndex, currentSlot);
+    this.maybeUpdateBestChildAndDescendant(pendingIndex, fullIndex, currentSlot, proposerBoostRoot);
   }
 
   /**
@@ -1183,7 +1185,7 @@ export class ProtoArray {
     return isFromPreviousSlot || isFromCurrentSlot;
   }
 
-  maybeUpdateBestChildAndDescendant(parentIndex: number, childIndex: number, currentSlot: Slot): void {
+  maybeUpdateBestChildAndDescendant(parentIndex: number, childIndex: number, currentSlot: Slot, proposerBoostRoot: RootHex | null): void {
     const childNode = this.nodes[childIndex];
     if (childNode === undefined) {
       throw new ProtoArrayError({
@@ -1278,13 +1280,9 @@ export class ProtoArray {
           }
 
           // Same weight and same root (or edge case), tie-breaker by payload status
-          const childTiebreaker = this.getPayloadStatusTiebreaker(
-            childNode,
-            currentSlot,
-            null // proposerBoostRoot
-          );
+          const childTiebreaker = this.getPayloadStatusTiebreaker(childNode, currentSlot, proposerBoostRoot);
 
-          const bestChildTiebreaker = this.getPayloadStatusTiebreaker(bestChildNode, currentSlot, null);
+          const bestChildTiebreaker = this.getPayloadStatusTiebreaker(bestChildNode, currentSlot, proposerBoostRoot);
 
           if (childTiebreaker > bestChildTiebreaker) {
             newChildAndDescendant = changeToChild;

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -1185,7 +1185,12 @@ export class ProtoArray {
     return isFromPreviousSlot || isFromCurrentSlot;
   }
 
-  maybeUpdateBestChildAndDescendant(parentIndex: number, childIndex: number, currentSlot: Slot, proposerBoostRoot: RootHex | null): void {
+  maybeUpdateBestChildAndDescendant(
+    parentIndex: number,
+    childIndex: number,
+    currentSlot: Slot,
+    proposerBoostRoot: RootHex | null
+  ): void {
     const childNode = this.nodes[childIndex];
     if (childNode === undefined) {
       throw new ProtoArrayError({

--- a/packages/fork-choice/test/perf/forkChoice/util.ts
+++ b/packages/fork-choice/test/perf/forkChoice/util.ts
@@ -114,7 +114,7 @@ export function initializeForkChoice(opts: Opts): ForkChoice {
       blockHashFromBid: null,
     };
 
-    protoArr.onBlock(block, block.slot);
+    protoArr.onBlock(block, block.slot, null);
     parentBlockRoot = blockRoot;
   }
 

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -142,7 +142,7 @@ describe("Forkchoice", () => {
     for (let slot = genesisSlot + 1; slot <= tillSlot; slot++) {
       if (!skippedSlots.includes(slot)) {
         const block = getBlock(slot, skippedSlots);
-        protoArr.onBlock(block, block.slot);
+        protoArr.onBlock(block, block.slot, null);
       }
     }
   };
@@ -150,7 +150,7 @@ describe("Forkchoice", () => {
   it("getAllAncestorBlocks", () => {
     // Add block that is a finalized descendant.
     const block = getBlock(genesisSlot + 1);
-    protoArr.onBlock(block, block.slot);
+    protoArr.onBlock(block, block.slot, null);
     const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
     const summaries = forkchoice.getAllAncestorBlocks(getBlockRoot(genesisSlot + 1));
     // there are 2 blocks in protoArray but iterateAncestorBlocks should only return non-finalized blocks
@@ -174,7 +174,7 @@ describe("Forkchoice", () => {
       ...getBlock(genesisSlot + 10),
       parentRoot: finalizedRoot, // Connect directly to genesis
     };
-    protoArr.onBlock(forkBlock, forkBlock.slot);
+    protoArr.onBlock(forkBlock, forkBlock.slot, null);
 
     const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
 

--- a/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/getProposerHead.test.ts
@@ -258,8 +258,8 @@ describe("Forkchoice / GetProposerHead", () => {
     expectedNotReorgedReason,
   } of testCases) {
     it(`${id}`, async () => {
-      protoArr.onBlock(parentBlock, parentBlock.slot);
-      protoArr.onBlock(headBlock, headBlock.slot);
+      protoArr.onBlock(parentBlock, parentBlock.slot, null);
+      protoArr.onBlock(headBlock, headBlock.slot, null);
 
       const currentSlot = proposalSlot ?? headBlock.slot + 1;
       const currentSecFromSlot = secFromSlot ?? 0;

--- a/packages/fork-choice/test/unit/forkChoice/shouldOverrideForkChoiceUpdate.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/shouldOverrideForkChoiceUpdate.test.ts
@@ -224,8 +224,8 @@ describe("Forkchoice / shouldOverrideForkChoiceUpdate", () => {
     expectedNotReorgedReason,
   } of testCases) {
     it(id, async () => {
-      protoArr.onBlock(parentBlock, parentBlock.slot);
-      protoArr.onBlock(headBlock, headBlock.slot);
+      protoArr.onBlock(parentBlock, parentBlock.slot, null);
+      protoArr.onBlock(headBlock, headBlock.slot, null);
 
       const secFromSlot = 0;
       const currentSlot = blockSeenSlot ?? headBlock.slot;

--- a/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/executionStatusUpdates.test.ts
@@ -127,7 +127,8 @@ function setupForkChoice(): ProtoArray {
         builderIndex: null,
         blockHashFromBid: null,
       },
-      block.slot
+      block.slot,
+      null
     );
   }
 

--- a/packages/fork-choice/test/unit/protoArray/getCommonAncestor.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/getCommonAncestor.test.ts
@@ -82,7 +82,8 @@ describe("getCommonAncestor", () => {
         builderIndex: null,
         blockHashFromBid: null,
       },
-      block.slot
+      block.slot,
+      null
     );
   }
 

--- a/packages/fork-choice/test/unit/protoArray/gloas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/gloas.test.ts
@@ -335,7 +335,9 @@ describe("Gloas Fork Choice", () => {
     });
 
     it("throws for unknown block", () => {
-      expect(() => protoArray.onExecutionPayload("0x99", gloasForkSlot, "0x99", gloasForkSlot, stateRoot, null)).toThrow();
+      expect(() =>
+        protoArray.onExecutionPayload("0x99", gloasForkSlot, "0x99", gloasForkSlot, stateRoot, null)
+      ).toThrow();
     });
   });
 

--- a/packages/fork-choice/test/unit/protoArray/gloas.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/gloas.test.ts
@@ -95,7 +95,7 @@ describe("Gloas Fork Choice", () => {
 
       // Add a Gloas block
       const gloasBlock = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(gloasBlock, gloasForkSlot);
+      protoArray.onBlock(gloasBlock, gloasForkSlot, null);
 
       const variants = (protoArray as any).indices.get("0x02");
       expect(variants).toBeDefined();
@@ -122,7 +122,7 @@ describe("Gloas Fork Choice", () => {
 
     it("creates only FULL nodes for pre-Gloas blocks", () => {
       const block = createTestBlock(1, "0x02", genesisRoot);
-      protoArray.onBlock(block, 1);
+      protoArray.onBlock(block, 1, null);
 
       // Should only have FULL variant
       const fullNode = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL);
@@ -136,7 +136,7 @@ describe("Gloas Fork Choice", () => {
 
     it("getNode() finds pre-Gloas blocks by root (FULL)", () => {
       const block = createTestBlock(1, "0x02", genesisRoot);
-      protoArray.onBlock(block, 1);
+      protoArray.onBlock(block, 1, null);
 
       const defaultStatus = protoArray.getDefaultVariant("0x02");
       expect(defaultStatus).toBe(PayloadStatus.FULL);
@@ -147,7 +147,7 @@ describe("Gloas Fork Choice", () => {
 
     it("hasBlock() returns true for pre-Gloas blocks", () => {
       const block = createTestBlock(1, "0x02", genesisRoot);
-      protoArray.onBlock(block, 1);
+      protoArray.onBlock(block, 1, null);
 
       expect(protoArray.hasBlock("0x02")).toBe(true);
       expect(protoArray.hasBlock("0x99")).toBe(false);
@@ -169,7 +169,7 @@ describe("Gloas Fork Choice", () => {
 
     it("creates PENDING + EMPTY nodes for Gloas blocks", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
+      protoArray.onBlock(block, gloasForkSlot, null);
 
       // Should have PENDING variant
       const pendingNode = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.PENDING);
@@ -188,7 +188,7 @@ describe("Gloas Fork Choice", () => {
 
     it("EMPTY node has PENDING as parent", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
+      protoArray.onBlock(block, gloasForkSlot, null);
 
       const emptyNode = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.EMPTY);
       const pendingIndex = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.PENDING);
@@ -198,7 +198,7 @@ describe("Gloas Fork Choice", () => {
 
     it("initializes PTC votes for Gloas blocks", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
+      protoArray.onBlock(block, gloasForkSlot, null);
 
       // All PTC votes should be false initially
       const isTimely = protoArray.isPayloadTimely("0x02");
@@ -207,7 +207,7 @@ describe("Gloas Fork Choice", () => {
 
     it("does not create PENDING/EMPTY for pre-fork blocks", () => {
       const block = createTestBlock(gloasForkSlot - 1, "0x02", genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot - 1);
+      protoArray.onBlock(block, gloasForkSlot - 1, null);
 
       // Should only have FULL (pre-Gloas behavior)
       const fullNode = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL);
@@ -233,11 +233,11 @@ describe("Gloas Fork Choice", () => {
     it("first Gloas block points to FULL parent (Fulu block)", () => {
       // Add pre-Gloas block
       const fuluBlock = createTestBlock(gloasForkSlot - 1, "0x02", genesisRoot);
-      protoArray.onBlock(fuluBlock, gloasForkSlot - 1);
+      protoArray.onBlock(fuluBlock, gloasForkSlot - 1, null);
 
       // Add first Gloas block
       const gloasBlock = createTestBlock(gloasForkSlot, "0x03", "0x02", "0x02");
-      protoArray.onBlock(gloasBlock, gloasForkSlot);
+      protoArray.onBlock(gloasBlock, gloasForkSlot, null);
 
       const gloasPendingNode = getNodeByPayloadStatus(protoArray, "0x03", PayloadStatus.PENDING);
       const fuluFullIndex = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.FULL);
@@ -249,11 +249,11 @@ describe("Gloas Fork Choice", () => {
     it("getNode() finds blocks across fork transition", () => {
       // Add pre-Gloas block
       const fuluBlock = createTestBlock(gloasForkSlot - 1, "0x02", genesisRoot);
-      protoArray.onBlock(fuluBlock, gloasForkSlot - 1);
+      protoArray.onBlock(fuluBlock, gloasForkSlot - 1, null);
 
       // Add Gloas block
       const gloasBlock = createTestBlock(gloasForkSlot, "0x03", "0x02", "0x02");
-      protoArray.onBlock(gloasBlock, gloasForkSlot);
+      protoArray.onBlock(gloasBlock, gloasForkSlot, null);
 
       // Should find both blocks with correct default variants
       const fuluDefaultStatus = protoArray.getDefaultVariant("0x02");
@@ -283,13 +283,13 @@ describe("Gloas Fork Choice", () => {
 
     it("creates FULL variant when payload arrives", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
+      protoArray.onBlock(block, gloasForkSlot, null);
 
       // FULL should not exist yet
       expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL)).toBeUndefined();
 
       // Call onExecutionPayload
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot);
+      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot, null);
 
       // FULL should now exist
       const fullNode = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL);
@@ -299,9 +299,9 @@ describe("Gloas Fork Choice", () => {
 
     it("FULL node has PENDING as parent", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
+      protoArray.onBlock(block, gloasForkSlot, null);
 
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot);
+      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot, null);
 
       const fullNode = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL);
       const pendingIndex = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.PENDING);
@@ -311,10 +311,10 @@ describe("Gloas Fork Choice", () => {
 
     it("is idempotent (calling twice does not create duplicate)", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
+      protoArray.onBlock(block, gloasForkSlot, null);
 
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot);
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot);
+      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot, null);
+      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot, null);
 
       // Should still only have one FULL node
       const fullNode = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL);
@@ -323,19 +323,19 @@ describe("Gloas Fork Choice", () => {
 
     it("throws for pre-Gloas blocks", () => {
       const block = createTestBlock(gloasForkSlot - 1, "0x02", genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot - 1);
+      protoArray.onBlock(block, gloasForkSlot - 1, null);
 
       // Pre-Gloas block already has FULL
       expect(getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.FULL)).toBeDefined();
 
       // Calling onExecutionPayload should throw for pre-Gloas blocks
       expect(() =>
-        protoArray.onExecutionPayload("0x02", gloasForkSlot - 1, "0x02", gloasForkSlot - 1, stateRoot)
+        protoArray.onExecutionPayload("0x02", gloasForkSlot - 1, "0x02", gloasForkSlot - 1, stateRoot, null)
       ).toThrow();
     });
 
     it("throws for unknown block", () => {
-      expect(() => protoArray.onExecutionPayload("0x99", gloasForkSlot, "0x99", gloasForkSlot, stateRoot)).toThrow();
+      expect(() => protoArray.onExecutionPayload("0x99", gloasForkSlot, "0x99", gloasForkSlot, stateRoot, null)).toThrow();
     });
   });
 
@@ -354,7 +354,7 @@ describe("Gloas Fork Choice", () => {
 
     it("notifyPtcMessage() updates votes for multiple validators", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
+      protoArray.onBlock(block, gloasForkSlot, null);
 
       // Initially not timely (no votes)
       expect(protoArray.isPayloadTimely("0x02")).toBe(false);
@@ -368,7 +368,7 @@ describe("Gloas Fork Choice", () => {
 
     it("notifyPtcMessage() validates ptcIndex range", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
+      protoArray.onBlock(block, gloasForkSlot, null);
 
       expect(() => protoArray.notifyPtcMessage("0x02", [-1], true)).toThrow(/Invalid PTC index/);
       expect(() => protoArray.notifyPtcMessage("0x02", [PTC_SIZE], true)).toThrow(/Invalid PTC index/);
@@ -383,7 +383,7 @@ describe("Gloas Fork Choice", () => {
 
     it("isPayloadTimely() returns false when payload not locally available", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
+      protoArray.onBlock(block, gloasForkSlot, null);
 
       // Vote yes from majority of PTC
       const threshold = Math.floor(PTC_SIZE / 2) + 1;
@@ -396,10 +396,10 @@ describe("Gloas Fork Choice", () => {
 
     it("isPayloadTimely() returns true when threshold met and payload available", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
+      protoArray.onBlock(block, gloasForkSlot, null);
 
       // Make execution payload available by creating FULL variant
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot);
+      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot, null);
 
       // Vote yes from majority of PTC (>50%)
       const threshold = Math.floor(PTC_SIZE / 2) + 1;
@@ -412,10 +412,10 @@ describe("Gloas Fork Choice", () => {
 
     it("isPayloadTimely() returns false when threshold not met", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
+      protoArray.onBlock(block, gloasForkSlot, null);
 
       // Make execution payload available by creating FULL variant
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot);
+      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot, null);
 
       // Vote yes from exactly 50% (not >50%)
       const threshold = Math.floor(PTC_SIZE / 2);
@@ -428,10 +428,10 @@ describe("Gloas Fork Choice", () => {
 
     it("isPayloadTimely() counts only 'true' votes", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
+      protoArray.onBlock(block, gloasForkSlot, null);
 
       // Make execution payload available by creating FULL variant
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot);
+      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot, null);
 
       // Vote mixed yes/no
       const threshold = Math.floor(PTC_SIZE / 2) + 1;
@@ -458,7 +458,7 @@ describe("Gloas Fork Choice", () => {
 
     it("does not initialize PTC votes for pre-Gloas blocks", () => {
       const block = createTestBlock(gloasForkSlot - 1, "0x02", genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot - 1);
+      protoArray.onBlock(block, gloasForkSlot - 1, null);
 
       // Pre-Gloas blocks should not have PTC tracking
       expect(protoArray.isPayloadTimely("0x02")).toBe(false);
@@ -483,8 +483,8 @@ describe("Gloas Fork Choice", () => {
 
     it("intra-block: EMPTY/FULL variants have PENDING as parent", () => {
       const block = createTestBlock(gloasForkSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, gloasForkSlot);
-      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot);
+      protoArray.onBlock(block, gloasForkSlot, null);
+      protoArray.onExecutionPayload("0x02", gloasForkSlot, "0x02", gloasForkSlot, stateRoot, null);
 
       const pendingIndex = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.PENDING);
       const emptyNode = getNodeByPayloadStatus(protoArray, "0x02", PayloadStatus.EMPTY);
@@ -497,12 +497,12 @@ describe("Gloas Fork Choice", () => {
     it("inter-block: new PENDING extends parent's EMPTY or FULL", () => {
       // Block A
       const blockA = createTestBlock(gloasForkSlot, "0x02Root", genesisRoot, genesisRoot);
-      protoArray.onBlock(blockA, gloasForkSlot);
-      protoArray.onExecutionPayload("0x02Root", gloasForkSlot, "0x02Hash", gloasForkSlot, stateRoot);
+      protoArray.onBlock(blockA, gloasForkSlot, null);
+      protoArray.onExecutionPayload("0x02Root", gloasForkSlot, "0x02Hash", gloasForkSlot, stateRoot, null);
 
       // Block B extends A's FULL (parentBlockHash matches)
       const blockB = createTestBlock(gloasForkSlot + 1, "0x03Root", "0x02Root", "0x02Hash");
-      protoArray.onBlock(blockB, gloasForkSlot + 1);
+      protoArray.onBlock(blockB, gloasForkSlot + 1, null);
 
       const blockAPending = protoArray.getNodeIndexByRootAndStatus("0x02Root", PayloadStatus.PENDING);
       const blockAFull = protoArray.getNodeIndexByRootAndStatus("0x02Root", PayloadStatus.FULL);
@@ -526,8 +526,8 @@ describe("Gloas Fork Choice", () => {
     it("EMPTY vs FULL comparison uses explicit tiebreaker for slot n-1 blocks", () => {
       const blockSlot = gloasForkSlot + 10;
       const block = createTestBlock(blockSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, blockSlot);
-      protoArray.onExecutionPayload("0x02", blockSlot, "0x02", blockSlot, stateRoot);
+      protoArray.onBlock(block, blockSlot, null);
+      protoArray.onExecutionPayload("0x02", blockSlot, "0x02", blockSlot, stateRoot, null);
 
       const emptyIndex = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.EMPTY);
       if (emptyIndex === undefined) throw new Error("Expected emptyIndex to exist");
@@ -567,8 +567,8 @@ describe("Gloas Fork Choice", () => {
       const blockA = createTestBlock(blockSlot, "0x02", genesisRoot, genesisRoot);
       const blockB = createTestBlock(blockSlot, "0x03", genesisRoot, genesisRoot);
 
-      protoArray.onBlock(blockA, blockSlot);
-      protoArray.onBlock(blockB, blockSlot);
+      protoArray.onBlock(blockA, blockSlot, null);
+      protoArray.onBlock(blockB, blockSlot, null);
 
       const emptyAIndex = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.EMPTY);
       if (emptyAIndex === undefined) throw new Error("Expected emptyAIndex to exist");
@@ -603,8 +603,8 @@ describe("Gloas Fork Choice", () => {
     it("EMPTY vs FULL from older slots (n-2) uses weight comparison", () => {
       const blockSlot = gloasForkSlot + 10;
       const block = createTestBlock(blockSlot, "0x02", genesisRoot, genesisRoot);
-      protoArray.onBlock(block, blockSlot);
-      protoArray.onExecutionPayload("0x02", blockSlot, "0x02", blockSlot, stateRoot);
+      protoArray.onBlock(block, blockSlot, null);
+      protoArray.onExecutionPayload("0x02", blockSlot, "0x02", blockSlot, stateRoot, null);
 
       const emptyIndex = protoArray.getNodeIndexByRootAndStatus("0x02", PayloadStatus.EMPTY);
       if (emptyIndex === undefined) throw new Error("Expected emptyIndex to exist");

--- a/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
@@ -71,7 +71,8 @@ describe("ProtoArray", () => {
         builderIndex: null,
         blockHashFromBid: null,
       },
-      genesisSlot + 1
+      genesisSlot + 1,
+      null
     );
 
     // Add block that is *not* a finalized descendant.
@@ -102,7 +103,8 @@ describe("ProtoArray", () => {
         builderIndex: null,
         blockHashFromBid: null,
       },
-      genesisSlot + 1
+      genesisSlot + 1,
+      null
     );
 
     // ancestorRoot, descendantRoot, isDescendant


### PR DESCRIPTION
## Summary

Fixes a bug in the Gloas (ePBS) fork choice where `proposerBoostRoot` was hardcoded to `null` at every call site of `getPayloadStatusTiebreaker` inside `maybeUpdateBestChildAndDescendant`.

**Root cause:** `shouldExtendPayload` checks four conditions in order. Condition 2 is `proposerBoostRoot === null → return true`. With `null` always passed, FULL always wins the EMPTY vs FULL tiebreaker for previous-slot blocks, regardless of PTC votes. This breaks the core ePBS invariant: when a payload is not timely, the chain should extend via EMPTY.

**Fix:** Thread `proposerBoostRoot` explicitly through the call chain:
- `maybeUpdateBestChildAndDescendant(parentIndex, childIndex, currentSlot, proposerBoostRoot)`
- `applyScoreChanges` → passes `proposerBoost?.root ?? null`
- `ProtoArray.onBlock` and `ProtoArray.onExecutionPayload` → accept and forward the param
- `ForkChoice.onBlock` and `ForkChoice.onExecutionPayload` → pass `this.proposerBoostRoot`

The `getPayloadStatusTiebreaker` body (`return shouldExtend ? 2 : 0`) is already spec-correct and is unchanged.

## Test plan

- [x] All existing fork-choice unit tests pass (`pnpm vitest run packages/fork-choice`)
- [ ] Add a test case to `gloas.test.ts` that sets a `proposerBoostRoot` and verifies EMPTY is preferred when `shouldExtendPayload` returns false (payload not timely, proposer boost applies to this block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @ensi321 @nflaig 