### PR TITLE
refactor: unified pubkey cache

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -95,14 +95,14 @@ export function getBeaconStateApi({
       const {state, executionOptimistic, finalized} = await getState(stateId);
       const currentEpoch = getCurrentEpoch(state);
       const {validators, balances} = state; // Get the validators sub tree once for all the loop
-      const {pubkey2index} = chain;
+      const {pubkeyCache} = chain;
 
       const validatorResponses: routes.beacon.ValidatorResponse[] = [];
       if (validatorIds.length) {
         assertUniqueItems(validatorIds, "Duplicate validator IDs provided");
 
         for (const id of validatorIds) {
-          const resp = getStateValidatorIndex(id, state, pubkey2index);
+          const resp = getStateValidatorIndex(id, state, pubkeyCache);
           if (resp.valid) {
             const validatorIndex = resp.validatorIndex;
             const validator = validators.getReadonly(validatorIndex);
@@ -127,7 +127,7 @@ export function getBeaconStateApi({
       if (statuses.length) {
         assertUniqueItems(statuses, "Duplicate statuses provided");
 
-        const validatorsByStatus = filterStateValidatorsByStatus(statuses, state, pubkey2index, currentEpoch);
+        const validatorsByStatus = filterStateValidatorsByStatus(statuses, state, pubkeyCache, currentEpoch);
         return {
           data: validatorsByStatus,
           meta: {executionOptimistic, finalized},
@@ -154,7 +154,7 @@ export function getBeaconStateApi({
 
     async postStateValidatorIdentities({stateId, validatorIds = []}) {
       const {state, executionOptimistic, finalized} = await getState(stateId);
-      const {pubkey2index} = chain;
+      const {pubkeyCache} = chain;
 
       let validatorIdentities: routes.beacon.ValidatorIdentities;
 
@@ -163,7 +163,7 @@ export function getBeaconStateApi({
 
         validatorIdentities = [];
         for (const id of validatorIds) {
-          const resp = getStateValidatorIndex(id, state, pubkey2index);
+          const resp = getStateValidatorIndex(id, state, pubkeyCache);
           if (resp.valid) {
             const index = resp.validatorIndex;
             const {pubkey, activationEpoch} = state.validators.getReadonly(index);
@@ -187,9 +187,9 @@ export function getBeaconStateApi({
 
     async getStateValidator({stateId, validatorId}) {
       const {state, executionOptimistic, finalized} = await getState(stateId);
-      const {pubkey2index} = chain;
+      const {pubkeyCache} = chain;
 
-      const resp = getStateValidatorIndex(validatorId, state, pubkey2index);
+      const resp = getStateValidatorIndex(validatorId, state, pubkeyCache);
       if (!resp.valid) {
         throw new ApiError(resp.code, resp.reason);
       }
@@ -214,7 +214,7 @@ export function getBeaconStateApi({
 
         const balances: routes.beacon.ValidatorBalance[] = [];
         for (const id of validatorIds) {
-          const resp = getStateValidatorIndex(id, state, chain.pubkey2index);
+          const resp = getStateValidatorIndex(id, state, chain.pubkeyCache);
 
           if (resp.valid) {
             balances.push({

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -1,8 +1,7 @@
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {routes} from "@lodestar/api";
 import {CheckpointWithHex, IForkChoice} from "@lodestar/fork-choice";
 import {GENESIS_SLOT} from "@lodestar/params";
-import {BeaconStateAllForks, CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {BeaconStateAllForks, CachedBeaconStateAllForks, PubkeyCache} from "@lodestar/state-transition";
 import {BLSPubkey, Epoch, RootHex, Slot, ValidatorIndex, getValidatorStatus, phase0} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../../chain/index.js";
@@ -104,7 +103,7 @@ export function toValidatorResponse(
 export function filterStateValidatorsByStatus(
   statuses: string[],
   state: BeaconStateAllForks,
-  pubkey2index: PubkeyIndexMap,
+  pubkeyCache: PubkeyCache,
   currentEpoch: Epoch
 ): routes.beacon.ValidatorResponse[] {
   const responses: routes.beacon.ValidatorResponse[] = [];
@@ -115,7 +114,7 @@ export function filterStateValidatorsByStatus(
     const validatorStatus = getValidatorStatus(validator, currentEpoch);
     const generalStatus = mapToGeneralStatus(validatorStatus);
 
-    const resp = getStateValidatorIndex(validator.pubkey, state, pubkey2index);
+    const resp = getStateValidatorIndex(validator.pubkey, state, pubkeyCache);
     if (resp.valid && (statusSet.has(validatorStatus) || statusSet.has(generalStatus))) {
       responses.push(
         toValidatorResponse(resp.validatorIndex, validator, state.balances.get(resp.validatorIndex), currentEpoch)
@@ -132,7 +131,7 @@ type StateValidatorIndexResponse =
 export function getStateValidatorIndex(
   id: routes.beacon.ValidatorId | BLSPubkey,
   state: BeaconStateAllForks,
-  pubkey2index: PubkeyIndexMap
+  pubkeyCache: PubkeyCache
 ): StateValidatorIndexResponse {
   if (typeof id === "string") {
     // mutate `id` and fallthrough to below
@@ -160,7 +159,7 @@ export function getStateValidatorIndex(
   }
 
   // typeof id === Uint8Array
-  const validatorIndex = pubkey2index.get(id);
+  const validatorIndex = pubkeyCache.getIndex(id);
   if (validatorIndex === null) {
     return {valid: false, code: 404, reason: "Validator pubkey not found in state"};
   }

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1,4 +1,3 @@
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
@@ -27,6 +26,7 @@ import {
   computeStartSlotAtEpoch,
   computeTimeAtSlot,
   createCachedBeaconState,
+  createPubkeyCache,
   getBlockRootAtSlot,
   getCurrentSlot,
   loadState,
@@ -1123,8 +1123,7 @@ export function getValidatorApi(
             {
               config: chain.config,
               // Not required to compute proposers
-              pubkey2index: new PubkeyIndexMap(),
-              index2pubkey: [],
+              pubkeyCache: createPubkeyCache(),
             },
             {skipSyncPubkeys: true, skipSyncCommitteeCache: true}
           );
@@ -1585,7 +1584,7 @@ export function getValidatorApi(
 
       const filteredRegistrations = registrations.filter((registration) => {
         const {pubkey} = registration.message;
-        const validatorIndex = chain.pubkey2index.get(pubkey);
+        const validatorIndex = chain.pubkeyCache.getIndex(pubkey);
         if (validatorIndex === null) return false;
 
         const validator = headState.validators.getReadonly(validatorIndex);

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
@@ -1,10 +1,10 @@
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {BeaconConfig} from "@lodestar/config";
 import {
   BeaconStateAllForks,
   CachedBeaconStateAllForks,
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
+  PubkeyCache,
   createCachedBeaconState,
   stateTransition,
 } from "@lodestar/state-transition";
@@ -15,16 +15,16 @@ import {HistoricalStateRegenMetrics} from "./metrics.js";
 import {RegenErrorType} from "./types.js";
 
 /**
- * Populate a PubkeyIndexMap with any new entries based on a BeaconState
+ * Populate a PubkeyCache with any new entries based on a BeaconState
  */
-export function syncPubkeyCache(state: BeaconStateAllForks, pubkey2index: PubkeyIndexMap): void {
+export function syncPubkeyCache(state: BeaconStateAllForks, pubkeyCache: PubkeyCache): void {
   // Get the validators sub tree once for all the loop
   const validators = state.validators;
 
   const newCount = state.validators.length;
-  for (let i = pubkey2index.size; i < newCount; i++) {
+  for (let i = pubkeyCache.size; i < newCount; i++) {
     const pubkey = validators.getReadonly(i).pubkey;
-    pubkey2index.set(pubkey, i);
+    pubkeyCache.set(i, pubkey);
   }
 }
 
@@ -35,7 +35,7 @@ export async function getNearestState(
   slot: number,
   config: BeaconConfig,
   db: IBeaconDb,
-  pubkey2index: PubkeyIndexMap
+  pubkeyCache: PubkeyCache
 ): Promise<CachedBeaconStateAllForks> {
   const stateBytesArr = await db.stateArchive.binaries({limit: 1, lte: slot, reverse: true});
   if (!stateBytesArr.length) {
@@ -44,14 +44,13 @@ export async function getNearestState(
 
   const stateBytes = stateBytesArr[0];
   const state = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);
-  syncPubkeyCache(state, pubkey2index);
+  syncPubkeyCache(state, pubkeyCache);
 
   return createCachedBeaconState(
     state,
     {
       config,
-      pubkey2index,
-      index2pubkey: [],
+      pubkeyCache,
     },
     {
       skipSyncPubkeys: true,
@@ -66,13 +65,13 @@ export async function getHistoricalState(
   slot: number,
   config: BeaconConfig,
   db: IBeaconDb,
-  pubkey2index: PubkeyIndexMap,
+  pubkeyCache: PubkeyCache,
   metrics?: HistoricalStateRegenMetrics
 ): Promise<Uint8Array> {
   const regenTimer = metrics?.regenTime.startTimer();
 
   const loadStateTimer = metrics?.loadStateTime.startTimer();
-  let state = await getNearestState(slot, config, db, pubkey2index).catch((e) => {
+  let state = await getNearestState(slot, config, db, pubkeyCache).catch((e) => {
     metrics?.regenErrorCount.inc({reason: RegenErrorType.loadState});
     throw e;
   });

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
@@ -1,9 +1,9 @@
 import worker from "node:worker_threads";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {Transfer, expose} from "@chainsafe/threads/worker";
 import {chainConfigFromJson, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {getNodeLogger} from "@lodestar/logger/node";
+import {createPubkeyCache} from "@lodestar/state-transition";
 import {BeaconDb} from "../../../db/index.js";
 import {RegistryMetricCreator, collectNodeJSMetrics} from "../../../metrics/index.js";
 import {JobFnQueue} from "../../../util/queue/fnQueue.js";
@@ -52,7 +52,7 @@ const queue = new JobFnQueue(
   queueMetrics
 );
 
-const pubkey2index = new PubkeyIndexMap();
+const pubkeyCache = createPubkeyCache();
 
 const api: HistoricalStateWorkerApi = {
   async close() {
@@ -65,7 +65,7 @@ const api: HistoricalStateWorkerApi = {
     historicalStateRegenMetrics?.regenRequestCount.inc();
 
     const stateBytes = await queue.push<Uint8Array>(() =>
-      getHistoricalState(slot, config, db, pubkey2index, historicalStateRegenMetrics)
+      getHistoricalState(slot, config, db, pubkeyCache, historicalStateRegenMetrics)
     );
     const result = Transfer(stateBytes, [stateBytes.buffer]) as unknown as Uint8Array;
 

--- a/packages/beacon-node/src/chain/bls/multithread/index.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/index.ts
@@ -7,7 +7,7 @@ import {Worker, spawn} from "@chainsafe/threads";
 self = undefined;
 
 import {PublicKey} from "@chainsafe/blst";
-import {ISignatureSet, Index2PubkeyCache} from "@lodestar/state-transition";
+import {ISignatureSet, PubkeyCache} from "@lodestar/state-transition";
 import {Logger} from "@lodestar/utils";
 import {Metrics} from "../../../metrics/index.js";
 import {LinkedList} from "../../../util/array.js";
@@ -34,7 +34,7 @@ const workerDir = process.env.NODE_ENV === "test" ? "../../../../lib/chain/bls/m
 export type BlsMultiThreadWorkerPoolModules = {
   logger: Logger;
   metrics: Metrics | null;
-  index2pubkey: Index2PubkeyCache;
+  pubkeyCache: PubkeyCache;
 };
 
 export type BlsMultiThreadWorkerPoolOptions = {
@@ -114,7 +114,7 @@ type WorkerDescriptor = {
 export class BlsMultiThreadWorkerPool implements IBlsVerifier {
   private readonly logger: Logger;
   private readonly metrics: Metrics | null;
-  private readonly index2pubkey: Index2PubkeyCache;
+  private readonly pubkeyCache: PubkeyCache;
 
   private readonly workers: WorkerDescriptor[];
   private readonly jobs = new LinkedList<JobQueueItem>();
@@ -130,10 +130,10 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
   private workersBusy = 0;
 
   constructor(options: BlsMultiThreadWorkerPoolOptions, modules: BlsMultiThreadWorkerPoolModules) {
-    const {logger, metrics, index2pubkey} = modules;
+    const {logger, metrics, pubkeyCache} = modules;
     this.logger = logger;
     this.metrics = metrics;
-    this.index2pubkey = index2pubkey;
+    this.pubkeyCache = pubkeyCache;
     this.blsVerifyAllMultiThread = options.blsVerifyAllMultiThread ?? false;
 
     // Use compressed for herumi for now.
@@ -173,7 +173,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
       try {
         return verifySignatureSetsMaybeBatch(
           sets.map((set) => ({
-            publicKey: getAggregatedPubkey(set, this.index2pubkey),
+            publicKey: getAggregatedPubkey(set, this.pubkeyCache),
             message: set.signingRoot.valueOf(),
             signature: set.signature,
           }))
@@ -398,7 +398,7 @@ export class BlsMultiThreadWorkerPool implements IBlsVerifier {
         try {
           // Note: This can throw, must be handled per-job.
           // Pubkey and signature aggregation is defered here
-          workReq = await jobItemWorkReq(job, this.index2pubkey, this.metrics);
+          workReq = await jobItemWorkReq(job, this.pubkeyCache, this.metrics);
         } catch (e) {
           this.metrics?.blsThreadPool.errorAggregateSignatureSetsCount.inc({type: job.type});
 

--- a/packages/beacon-node/src/chain/bls/multithread/jobItem.ts
+++ b/packages/beacon-node/src/chain/bls/multithread/jobItem.ts
@@ -1,5 +1,5 @@
 import {PublicKey, asyncAggregateWithRandomness} from "@chainsafe/blst";
-import {ISignatureSet, Index2PubkeyCache, SignatureSetType} from "@lodestar/state-transition";
+import {ISignatureSet, PubkeyCache, SignatureSetType} from "@lodestar/state-transition";
 import {Metrics} from "../../../metrics/metrics.js";
 import {LinkedList} from "../../../util/array.js";
 import {VerifySignatureOpts} from "../interface.js";
@@ -50,7 +50,7 @@ export function jobItemSigSets(job: JobQueueItem): number {
  */
 export async function jobItemWorkReq(
   job: JobQueueItem,
-  index2pubkey: Index2PubkeyCache,
+  pubkeyCache: PubkeyCache,
   metrics: Metrics | null
 ): Promise<BlsWorkReq> {
   switch (job.type) {
@@ -59,7 +59,7 @@ export async function jobItemWorkReq(
         opts: job.opts,
         sets: job.sets.map((set) => ({
           // this can throw, handled in the consumer code
-          publicKey: getAggregatedPubkey(set, index2pubkey, metrics).toBytes(),
+          publicKey: getAggregatedPubkey(set, pubkeyCache, metrics).toBytes(),
           signature: set.signature,
           message: set.signingRoot,
         })),

--- a/packages/beacon-node/src/chain/bls/singleThread.ts
+++ b/packages/beacon-node/src/chain/bls/singleThread.ts
@@ -1,5 +1,5 @@
 import {PublicKey, Signature, aggregatePublicKeys, aggregateSignatures, verify} from "@chainsafe/blst";
-import {ISignatureSet, Index2PubkeyCache} from "@lodestar/state-transition";
+import {ISignatureSet, PubkeyCache} from "@lodestar/state-transition";
 import {Metrics} from "../../metrics/index.js";
 import {IBlsVerifier} from "./interface.js";
 import {verifySignatureSetsMaybeBatch} from "./maybeBatch.js";
@@ -7,18 +7,18 @@ import {getAggregatedPubkey, getAggregatedPubkeysCount} from "./utils.js";
 
 export class BlsSingleThreadVerifier implements IBlsVerifier {
   private readonly metrics: Metrics | null;
-  private readonly index2pubkey: Index2PubkeyCache;
+  private readonly pubkeyCache: PubkeyCache;
 
-  constructor({metrics = null, index2pubkey}: {metrics: Metrics | null; index2pubkey: Index2PubkeyCache}) {
+  constructor({metrics = null, pubkeyCache}: {metrics: Metrics | null; pubkeyCache: PubkeyCache}) {
     this.metrics = metrics;
-    this.index2pubkey = index2pubkey;
+    this.pubkeyCache = pubkeyCache;
   }
 
   async verifySignatureSets(sets: ISignatureSet[]): Promise<boolean> {
     this.metrics?.bls.aggregatedPubkeys.inc(getAggregatedPubkeysCount(sets));
 
     const setsAggregated = sets.map((set) => ({
-      publicKey: getAggregatedPubkey(set, this.index2pubkey, this.metrics),
+      publicKey: getAggregatedPubkey(set, this.pubkeyCache, this.metrics),
       message: set.signingRoot,
       signature: set.signature,
     }));

--- a/packages/beacon-node/src/chain/bls/utils.ts
+++ b/packages/beacon-node/src/chain/bls/utils.ts
@@ -1,22 +1,33 @@
 import {PublicKey, aggregatePublicKeys} from "@chainsafe/blst";
-import {ISignatureSet, Index2PubkeyCache, SignatureSetType} from "@lodestar/state-transition";
+import {ISignatureSet, PubkeyCache, SignatureSetType} from "@lodestar/state-transition";
 import {Metrics} from "../../metrics/metrics.js";
 
 export function getAggregatedPubkey(
   signatureSet: ISignatureSet,
-  index2pubkey: Index2PubkeyCache,
+  pubkeyCache: PubkeyCache,
   metrics: Metrics | null = null
 ): PublicKey {
   switch (signatureSet.type) {
     case SignatureSetType.single:
       return signatureSet.pubkey;
 
-    case SignatureSetType.indexed:
-      return index2pubkey[signatureSet.index];
+    case SignatureSetType.indexed: {
+      const pubkey = pubkeyCache.get(signatureSet.index);
+      if (!pubkey) {
+        throw Error(`Missing pubkey for validator index ${signatureSet.index}`);
+      }
+      return pubkey;
+    }
 
     case SignatureSetType.aggregate: {
       const timer = metrics?.blsThreadPool.pubkeysAggregationMainThreadDuration.startTimer();
-      const pubkeys = signatureSet.indices.map((i) => index2pubkey[i]);
+      const pubkeys = signatureSet.indices.map((i) => {
+        const pubkey = pubkeyCache.get(i);
+        if (!pubkey) {
+          throw Error(`Missing pubkey for validator index ${i}`);
+        }
+        return pubkey;
+      });
       const aggregated = aggregatePublicKeys(pubkeys);
       timer?.();
       return aggregated;

--- a/packages/beacon-node/src/chain/bls/utils.ts
+++ b/packages/beacon-node/src/chain/bls/utils.ts
@@ -12,21 +12,13 @@ export function getAggregatedPubkey(
       return signatureSet.pubkey;
 
     case SignatureSetType.indexed: {
-      const pubkey = pubkeyCache.get(signatureSet.index);
-      if (!pubkey) {
-        throw Error(`Missing pubkey for validator index ${signatureSet.index}`);
-      }
-      return pubkey;
+      return pubkeyCache.getOrThrow(signatureSet.index);
     }
 
     case SignatureSetType.aggregate: {
       const timer = metrics?.blsThreadPool.pubkeysAggregationMainThreadDuration.startTimer();
       const pubkeys = signatureSet.indices.map((i) => {
-        const pubkey = pubkeyCache.get(i);
-        if (!pubkey) {
-          throw Error(`Missing pubkey for validator index ${i}`);
-        }
-        return pubkey;
+        return pubkeyCache.getOrThrow(i);
       });
       const aggregated = aggregatePublicKeys(pubkeys);
       timer?.();

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -915,10 +915,7 @@ export class BeaconChain implements IBeaconChain {
       RegenCaller.produceBlock
     );
     const proposerIndex = state.epochCtx.getBeaconProposer(slot);
-    const proposerPubKey = this.pubkeyCache.get(proposerIndex)?.toBytes();
-    if (!proposerPubKey) {
-      throw Error(`Missing proposer pubkey for validator index ${proposerIndex}`);
-    }
+    const proposerPubKey = this.pubkeyCache.getOrThrow(proposerIndex).toBytes();
 
     const {body, produceResult, executionPayloadValue, shouldOverrideBuilder} = await produceBlockBody.call(
       this,

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import {PrivateKey} from "@libp2p/interface";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
 import {CheckpointWithHex, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
@@ -21,7 +20,7 @@ import {
   CachedBeaconStateGloas,
   EffectiveBalanceIncrements,
   EpochShuffling,
-  Index2PubkeyCache,
+  PubkeyCache,
   computeAnchorCheckpoint,
   computeAttestationsRewards,
   computeBlockRewards,
@@ -192,8 +191,7 @@ export class BeaconChain implements IBeaconChain {
   readonly seenBlockAttesters = new SeenBlockAttesters();
 
   // Global state caches
-  readonly pubkey2index: PubkeyIndexMap;
-  readonly index2pubkey: Index2PubkeyCache;
+  readonly pubkeyCache: PubkeyCache;
 
   readonly beaconProposerCache: BeaconProposerCache;
   readonly checkpointBalancesCache: CheckpointBalancesCache;
@@ -239,8 +237,7 @@ export class BeaconChain implements IBeaconChain {
     {
       privateKey,
       config,
-      pubkey2index,
-      index2pubkey,
+      pubkeyCache,
       db,
       dbName,
       dataDir,
@@ -256,8 +253,7 @@ export class BeaconChain implements IBeaconChain {
     }: {
       privateKey: PrivateKey;
       config: BeaconConfig;
-      pubkey2index: PubkeyIndexMap;
-      index2pubkey: Index2PubkeyCache;
+      pubkeyCache: PubkeyCache;
       db: IBeaconDb;
       dbName: string;
       dataDir: string;
@@ -289,8 +285,8 @@ export class BeaconChain implements IBeaconChain {
     const emitter = new ChainEventEmitter();
     // by default, verify signatures on both main threads and worker threads
     const bls = opts.blsVerifyAllMainThread
-      ? new BlsSingleThreadVerifier({metrics, index2pubkey})
-      : new BlsMultiThreadWorkerPool(opts, {logger, metrics, index2pubkey});
+      ? new BlsSingleThreadVerifier({metrics, pubkeyCache})
+      : new BlsMultiThreadWorkerPool(opts, {logger, metrics, pubkeyCache});
 
     if (!clock) clock = new Clock({config, genesisTime: this.genesisTime, signal});
 
@@ -346,8 +342,7 @@ export class BeaconChain implements IBeaconChain {
     ]);
 
     // Global cache of validators pubkey/index mapping
-    this.pubkey2index = pubkey2index;
-    this.index2pubkey = index2pubkey;
+    this.pubkeyCache = pubkeyCache;
 
     const fileDataStore = opts.nHistoricalStatesFileDataStore ?? true;
     const blockStateCache = new FIFOBlockStateCache(this.opts, {metrics});
@@ -920,7 +915,10 @@ export class BeaconChain implements IBeaconChain {
       RegenCaller.produceBlock
     );
     const proposerIndex = state.epochCtx.getBeaconProposer(slot);
-    const proposerPubKey = this.index2pubkey[proposerIndex].toBytes();
+    const proposerPubKey = this.pubkeyCache.get(proposerIndex)?.toBytes();
+    if (!proposerPubKey) {
+      throw Error(`Missing proposer pubkey for validator index ${proposerIndex}`);
+    }
 
     const {body, produceResult, executionPayloadValue, shouldOverrideBuilder} = await produceBlockBody.call(
       this,
@@ -1536,7 +1534,7 @@ export class BeaconChain implements IBeaconChain {
       throw Error(`State is not in cache for slot ${slot}`);
     }
 
-    const rewards = await computeAttestationsRewards(this.config, this.pubkey2index, cachedState, validatorIds);
+    const rewards = await computeAttestationsRewards(this.config, this.pubkeyCache, cachedState, validatorIds);
 
     return {rewards, executionOptimistic, finalized};
   }
@@ -1553,6 +1551,6 @@ export class BeaconChain implements IBeaconChain {
 
     preState = processSlots(preState, block.slot); // Dial preState's slot to block.slot
 
-    return computeSyncCommitteeRewards(this.config, this.index2pubkey, block, preState, validatorIds);
+    return computeSyncCommitteeRewards(this.config, this.pubkeyCache, block, preState, validatorIds);
   }
 }

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -1,13 +1,7 @@
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
 import {CheckpointWithHex, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
-import {
-  BeaconStateAllForks,
-  CachedBeaconStateAllForks,
-  EpochShuffling,
-  Index2PubkeyCache,
-} from "@lodestar/state-transition";
+import {BeaconStateAllForks, CachedBeaconStateAllForks, EpochShuffling, PubkeyCache} from "@lodestar/state-transition";
 import {
   BeaconBlock,
   BlindedBeaconBlock,
@@ -117,8 +111,7 @@ export interface IBeaconChain {
   readonly regen: IStateRegenerator;
   readonly lightClientServer?: LightClientServer;
   readonly reprocessController: ReprocessController;
-  readonly pubkey2index: PubkeyIndexMap;
-  readonly index2pubkey: Index2PubkeyCache;
+  readonly pubkeyCache: PubkeyCache;
   readonly archiveStore: IArchiveStore;
 
   // Ops pool

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -143,7 +143,13 @@ export async function validateGossipAttestationsSameAttData(
   if (batchableBls) {
     // all signature sets should have same signing root since we filtered in network processor
     signatureValids = await chain.bls.verifySignatureSetsSameMessage(
-      signatureSets.map((set) => ({publicKey: chain.index2pubkey[set.index], signature: set.signature})),
+      signatureSets.map((set) => {
+        const publicKey = chain.pubkeyCache.get(set.index);
+        if (!publicKey) {
+          throw Error(`Missing pubkey for validator index ${set.index}`);
+        }
+        return {publicKey, signature: set.signature};
+      }),
       signatureSets[0].signingRoot
     );
   } else {

--- a/packages/beacon-node/src/chain/validation/attestation.ts
+++ b/packages/beacon-node/src/chain/validation/attestation.ts
@@ -144,10 +144,7 @@ export async function validateGossipAttestationsSameAttData(
     // all signature sets should have same signing root since we filtered in network processor
     signatureValids = await chain.bls.verifySignatureSetsSameMessage(
       signatureSets.map((set) => {
-        const publicKey = chain.pubkeyCache.get(set.index);
-        if (!publicKey) {
-          throw Error(`Missing pubkey for validator index ${set.index}`);
-        }
+        const publicKey = chain.pubkeyCache.getOrThrow(set.index);
         return {publicKey, signature: set.signature};
       }),
       signatureSets[0].signingRoot

--- a/packages/beacon-node/src/chain/validation/attesterSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/attesterSlashing.ts
@@ -45,7 +45,7 @@ export async function validateAttesterSlashing(
     // verifySignature = false, verified in batch below
     assertValidAttesterSlashing(
       chain.config,
-      chain.index2pubkey,
+      chain.pubkeyCache,
       state.slot,
       state.validators.length,
       attesterSlashing,

--- a/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
+++ b/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
@@ -87,8 +87,16 @@ async function validatePayloadAttestationMessage(
   }
 
   // [REJECT] `payload_attestation_message.signature` is valid with respect to the validator's public key.
+  const validatorPubkey = chain.pubkeyCache.get(validatorIndex);
+  if (!validatorPubkey) {
+    throw new PayloadAttestationError(GossipAction.REJECT, {
+      code: PayloadAttestationErrorCode.INVALID_ATTESTER,
+      attesterIndex: validatorIndex,
+    });
+  }
+
   const signatureSet = createSingleSignatureSetFromComponents(
-    chain.index2pubkey[validatorIndex],
+    validatorPubkey,
     getPayloadAttestationDataSigningRoot(chain.config, data),
     payloadAttestationMessage.signature
   );

--- a/packages/beacon-node/src/chain/validation/proposerSlashing.ts
+++ b/packages/beacon-node/src/chain/validation/proposerSlashing.ts
@@ -37,7 +37,7 @@ async function validateProposerSlashing(
   try {
     const proposer = state.validators.getReadonly(proposerSlashing.signedHeader1.message.proposerIndex);
     // verifySignature = false, verified in batch below
-    assertValidProposerSlashing(chain.config, chain.index2pubkey, state.slot, proposerSlashing, proposer, false);
+    assertValidProposerSlashing(chain.config, chain.pubkeyCache, state.slot, proposerSlashing, proposer, false);
   } catch (e) {
     throw new ProposerSlashingError(GossipAction.REJECT, {
       code: ProposerSlashingErrorCode.INVALID,

--- a/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -106,7 +106,7 @@ export async function validateSyncCommitteeGossipContributionAndProof(
 /**
  * Retrieve pubkeys in contribution aggregate using epochCtx:
  * - currSyncCommitteeIndexes cache
- * - index2pubkey cache
+ * - pubkeyCache
  */
 function getContributionIndices(
   state: CachedBeaconStateAltair,

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -2,12 +2,11 @@ import {setMaxListeners} from "node:events";
 import {PrivateKey} from "@libp2p/interface";
 import {Registry} from "prom-client";
 import {hasher} from "@chainsafe/persistent-merkle-tree";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {BeaconApiMethods} from "@lodestar/api/beacon/server";
 import {BeaconConfig} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
 import {ZERO_HASH_HEX} from "@lodestar/params";
-import {CachedBeaconStateAllForks, Index2PubkeyCache, isExecutionCachedStateType} from "@lodestar/state-transition";
+import {CachedBeaconStateAllForks, PubkeyCache, isExecutionCachedStateType} from "@lodestar/state-transition";
 import {phase0} from "@lodestar/types";
 import {sleep, toRootHex} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
@@ -47,8 +46,7 @@ export type BeaconNodeModules = {
 export type BeaconNodeInitModules = {
   opts: IBeaconNodeOptions;
   config: BeaconConfig;
-  pubkey2index: PubkeyIndexMap;
-  index2pubkey: Index2PubkeyCache;
+  pubkeyCache: PubkeyCache;
   db: IBeaconDb;
   logger: LoggerNode;
   processShutdownCallback: ProcessShutdownCallback;
@@ -150,8 +148,7 @@ export class BeaconNode {
   static async init<T extends BeaconNode = BeaconNode>({
     opts,
     config,
-    pubkey2index,
-    index2pubkey,
+    pubkeyCache,
     db,
     logger,
     processShutdownCallback,
@@ -240,8 +237,7 @@ export class BeaconNode {
       privateKey,
       config,
       clock,
-      pubkey2index,
-      index2pubkey,
+      pubkeyCache,
       dataDir,
       db,
       dbName: opts.db.name,

--- a/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
+++ b/packages/beacon-node/test/e2e/chain/bls/multithread.test.ts
@@ -1,6 +1,6 @@
 import {afterEach, beforeAll, beforeEach, describe, expect, it} from "vitest";
 import {PublicKey, SecretKey} from "@chainsafe/blst";
-import {ISignatureSet, SignatureSetType} from "@lodestar/state-transition";
+import {ISignatureSet, SignatureSetType, createPubkeyCache} from "@lodestar/state-transition";
 import {VerifySignatureOpts} from "../../../../src/chain/bls/interface.js";
 import {BlsMultiThreadWorkerPool} from "../../../../src/chain/bls/multithread/index.js";
 import {testLogger} from "../../../utils/logger.js";
@@ -13,7 +13,7 @@ describe("chain / bls / multithread queue", () => {
   const sets: ISignatureSet[] = [];
   const sameMessageSets: {publicKey: PublicKey; signature: Uint8Array}[] = [];
   const sameMessage = Buffer.alloc(32, 100);
-  const index2pubkey: PublicKey[] = [];
+  const pubkeyCache = createPubkeyCache();
 
   beforeAll(() => {
     for (let i = 0; i < 3; i++) {
@@ -31,7 +31,7 @@ describe("chain / bls / multithread queue", () => {
         publicKey: pk,
         signature: sk.sign(sameMessage).toBytes(),
       });
-      index2pubkey.push(pk);
+      pubkeyCache.set(pubkeyCache.size, pk.toBytes());
     }
   });
 
@@ -49,7 +49,7 @@ describe("chain / bls / multithread queue", () => {
   });
 
   async function initializePool(): Promise<BlsMultiThreadWorkerPool> {
-    const pool = new BlsMultiThreadWorkerPool({}, {logger, metrics: null, index2pubkey});
+    const pool = new BlsMultiThreadWorkerPool({}, {logger, metrics: null, pubkeyCache});
     // await terminating all workers
     afterEachCallbacks.push(() => pool.close());
     // Wait until initialized

--- a/packages/beacon-node/test/fixtures/capella.ts
+++ b/packages/beacon-node/test/fixtures/capella.ts
@@ -1,17 +1,22 @@
-import {CachedBeaconStateAltair, Index2PubkeyCache} from "@lodestar/state-transition";
+import {CachedBeaconStateAltair, PubkeyCache} from "@lodestar/state-transition";
 import {capella} from "@lodestar/types";
 
 export function generateBlsToExecutionChanges(
-  index2pubkey: Index2PubkeyCache,
+  pubkeyCache: PubkeyCache,
   state: CachedBeaconStateAltair,
   count: number
 ): capella.SignedBLSToExecutionChange[] {
   const result: capella.SignedBLSToExecutionChange[] = [];
 
   for (const validatorIndex of state.epochCtx.proposers) {
+    const pubkey = pubkeyCache.get(validatorIndex);
+    if (!pubkey) {
+      throw Error(`Missing pubkey for validator index ${validatorIndex}`);
+    }
+
     result.push({
       message: {
-        fromBlsPubkey: index2pubkey[validatorIndex].toBytes(),
+        fromBlsPubkey: pubkey.toBytes(),
         toExecutionAddress: Buffer.alloc(20),
         validatorIndex,
       },

--- a/packages/beacon-node/test/fixtures/capella.ts
+++ b/packages/beacon-node/test/fixtures/capella.ts
@@ -9,10 +9,7 @@ export function generateBlsToExecutionChanges(
   const result: capella.SignedBLSToExecutionChange[] = [];
 
   for (const validatorIndex of state.epochCtx.proposers) {
-    const pubkey = pubkeyCache.get(validatorIndex);
-    if (!pubkey) {
-      throw Error(`Missing pubkey for validator index ${validatorIndex}`);
-    }
+    const pubkey = pubkeyCache.getOrThrow(validatorIndex);
 
     result.push({
       message: {

--- a/packages/beacon-node/test/mocks/mockedBeaconChain.ts
+++ b/packages/beacon-node/test/mocks/mockedBeaconChain.ts
@@ -1,8 +1,8 @@
 import {Mock, Mocked, vi} from "vitest";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {BeaconConfig, ChainForkConfig} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
 import {EpochDifference, ForkChoice, ProtoBlock} from "@lodestar/fork-choice";
+import {createPubkeyCache} from "@lodestar/state-transition";
 import {Logger} from "@lodestar/utils";
 import {BeaconProposerCache} from "../../src/chain/beaconProposerCache.js";
 import {BeaconChain} from "../../src/chain/chain.js";
@@ -141,8 +141,7 @@ vi.mock("../../src/chain/chain.js", async (importActual) => {
       // @ts-expect-error
       seenBlockInputCache: new SeenBlockInput(),
       shufflingCache: new ShufflingCache(),
-      pubkey2index: new PubkeyIndexMap(),
-      index2pubkey: [],
+      pubkeyCache: createPubkeyCache(),
       produceCommonBlockBody: vi.fn(),
       getProposerHead: vi.fn(),
       produceBlock: vi.fn(),

--- a/packages/beacon-node/test/perf/api/impl/validator/attester.test.ts
+++ b/packages/beacon-node/test/perf/api/impl/validator/attester.test.ts
@@ -32,10 +32,7 @@ describe("api / impl / validator", () => {
       noThreshold: true,
       fn: () => {
         for (let i = 0; i < reqCount; i++) {
-          const pubkey = state.epochCtx.pubkeyCache.get(i);
-          if (!pubkey) {
-            throw Error(`Missing pubkey for validator index ${i}`);
-          }
+          const pubkey = state.epochCtx.pubkeyCache.getOrThrow(i);
           pubkey.toBytes();
         }
       },

--- a/packages/beacon-node/test/perf/api/impl/validator/attester.test.ts
+++ b/packages/beacon-node/test/perf/api/impl/validator/attester.test.ts
@@ -32,7 +32,10 @@ describe("api / impl / validator", () => {
       noThreshold: true,
       fn: () => {
         for (let i = 0; i < reqCount; i++) {
-          const pubkey = state.epochCtx.index2pubkey[i];
+          const pubkey = state.epochCtx.pubkeyCache.get(i);
+          if (!pubkey) {
+            throw Error(`Missing pubkey for validator index ${i}`);
+          }
           pubkey.toBytes();
         }
       },

--- a/packages/beacon-node/test/perf/chain/opPools/opPool.test.ts
+++ b/packages/beacon-node/test/perf/chain/opPools/opPool.test.ts
@@ -8,7 +8,7 @@ import {
   MAX_PROPOSER_SLASHINGS,
   MAX_VOLUNTARY_EXITS,
 } from "@lodestar/params";
-import {CachedBeaconStateAltair, Index2PubkeyCache} from "@lodestar/state-transition";
+import {CachedBeaconStateAltair, PubkeyCache} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {generatePerfTestCachedStateAltair} from "../../../../../state-transition/test/perf/util.js";
 import {BlockType} from "../../../../src/chain/interface.js";
@@ -38,8 +38,8 @@ describe("opPool", () => {
       fillAttesterSlashing(pool, originalState, MAX_ATTESTER_SLASHINGS);
       fillProposerSlashing(pool, originalState, MAX_PROPOSER_SLASHINGS);
       fillVoluntaryExits(pool, originalState, MAX_VOLUNTARY_EXITS);
-      // TODO: feed index2pubkey separately instead of getting from originalState
-      fillBlsToExecutionChanges(originalState.epochCtx.index2pubkey, pool, originalState, MAX_BLS_TO_EXECUTION_CHANGES);
+      // TODO: feed pubkeyCache separately instead of getting from originalState
+      fillBlsToExecutionChanges(originalState.epochCtx.pubkeyCache, pool, originalState, MAX_BLS_TO_EXECUTION_CHANGES);
 
       return pool;
     },
@@ -57,8 +57,8 @@ describe("opPool", () => {
       fillAttesterSlashing(pool, originalState, maxItemsInPool);
       fillProposerSlashing(pool, originalState, maxItemsInPool);
       fillVoluntaryExits(pool, originalState, maxItemsInPool);
-      // TODO: feed index2pubkey separately instead of getting from originalState
-      fillBlsToExecutionChanges(originalState.epochCtx.index2pubkey, pool, originalState, maxItemsInPool);
+      // TODO: feed pubkeyCache separately instead of getting from originalState
+      fillBlsToExecutionChanges(originalState.epochCtx.pubkeyCache, pool, originalState, maxItemsInPool);
 
       return pool;
     },
@@ -105,12 +105,12 @@ function fillVoluntaryExits(pool: OpPool, state: CachedBeaconStateAltair, count:
 // This does not set the `withdrawalCredentials` for the validator
 // So it will be in the pool but not returned from `getSlashingsAndExits`
 function fillBlsToExecutionChanges(
-  index2pubkey: Index2PubkeyCache,
+  pubkeyCache: PubkeyCache,
   pool: OpPool,
   state: CachedBeaconStateAltair,
   count: number
 ): OpPool {
-  for (const blsToExecution of generateBlsToExecutionChanges(index2pubkey, state, count)) {
+  for (const blsToExecution of generateBlsToExecutionChanges(pubkeyCache, state, count)) {
     pool.insertBlsToExecutionChange(blsToExecution);
   }
 

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -67,10 +67,7 @@ describe("produceBlockBody", () => {
     beforeEach: async () => {
       const head = chain.forkChoice.getHead();
       const proposerIndex = state.epochCtx.getBeaconProposer(state.slot);
-      const proposerPubKey = state.epochCtx.pubkeyCache.get(proposerIndex)?.toBytes();
-      if (!proposerPubKey) {
-        throw Error(`Missing proposer pubkey for validator index ${proposerIndex}`);
-      }
+      const proposerPubKey = state.epochCtx.pubkeyCache.getOrThrow(proposerIndex).toBytes();
 
       return {chain, state, head, proposerIndex, proposerPubKey};
     },

--- a/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
+++ b/packages/beacon-node/test/perf/chain/produceBlock/produceBlockBody.test.ts
@@ -38,8 +38,7 @@ describe("produceBlockBody", () => {
       {
         privateKey: await generateKeyPair("secp256k1"),
         config: state.config,
-        pubkey2index: state.epochCtx.pubkey2index,
-        index2pubkey: state.epochCtx.index2pubkey,
+        pubkeyCache: state.epochCtx.pubkeyCache,
         db,
         dataDir: ".",
         dbName: ".",
@@ -68,7 +67,10 @@ describe("produceBlockBody", () => {
     beforeEach: async () => {
       const head = chain.forkChoice.getHead();
       const proposerIndex = state.epochCtx.getBeaconProposer(state.slot);
-      const proposerPubKey = state.epochCtx.index2pubkey[proposerIndex].toBytes();
+      const proposerPubKey = state.epochCtx.pubkeyCache.get(proposerIndex)?.toBytes();
+      if (!proposerPubKey) {
+        throw Error(`Missing proposer pubkey for validator index ${proposerIndex}`);
+      }
 
       return {chain, state, head, proposerIndex, proposerPubKey};
     },

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -91,8 +91,7 @@ describe.skip("verify+import blocks - range sync perf test", () => {
         {
           privateKey: await generateKeyPair("secp256k1"),
           config: state.config,
-          pubkey2index: state.epochCtx.pubkey2index,
-          index2pubkey: state.epochCtx.index2pubkey,
+          pubkeyCache: state.epochCtx.pubkeyCache,
           db,
           dataDir: ".",
           dbName: ".",

--- a/packages/beacon-node/test/sim/electra-interop.test.ts
+++ b/packages/beacon-node/test/sim/electra-interop.test.ts
@@ -364,7 +364,7 @@ describe("executionEngine / ExecutionEngineHttp", () => {
     if (headState.validators.length !== 33 || headState.balances.length !== 33) {
       throw Error("New validator is not reflected in the beacon state at slot 5");
     }
-    if (epochCtx.index2pubkey.length !== 33 || epochCtx.pubkey2index.size !== 33) {
+    if (epochCtx.pubkeyCache.size !== 33) {
       throw Error("Pubkey cache is not updated");
     }
 
@@ -391,7 +391,7 @@ describe("executionEngine / ExecutionEngineHttp", () => {
     if (headState.validators.length !== 33 || headState.balances.length !== 33) {
       throw Error("New validator is not reflected in the beacon state.");
     }
-    if (epochCtx.index2pubkey.length !== 33 || epochCtx.pubkey2index.size !== 33) {
+    if (epochCtx.pubkeyCache.size !== 33) {
       throw Error("New validator is not in pubkey cache");
     }
 

--- a/packages/beacon-node/test/spec/presets/fork_choice.test.ts
+++ b/packages/beacon-node/test/spec/presets/fork_choice.test.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import {generateKeyPair} from "@libp2p/crypto/keys";
 import {expect} from "vitest";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {toHexString} from "@chainsafe/ssz";
 import {createBeaconConfig} from "@lodestar/config";
 import {CheckpointWithHex, ForkChoice} from "@lodestar/fork-choice";
@@ -17,8 +16,8 @@ import {
 import {InputType} from "@lodestar/spec-test-util";
 import {
   BeaconStateAllForks,
-  Index2PubkeyCache,
   createCachedBeaconState,
+  createPubkeyCache,
   isExecutionStateType,
   signedBlockToSignedHeader,
   syncPubkeys,
@@ -97,15 +96,13 @@ const forkChoiceTest =
         });
 
         const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
-        const pubkey2index = new PubkeyIndexMap();
-        const index2pubkey: Index2PubkeyCache = [];
-        syncPubkeys(anchorState.validators.getAllReadonlyValues(), pubkey2index, index2pubkey);
+        const pubkeyCache = createPubkeyCache();
+        syncPubkeys(pubkeyCache, anchorState.validators.getAllReadonlyValues());
         const cachedState = createCachedBeaconState(
           anchorState,
           {
             config: beaconConfig,
-            pubkey2index,
-            index2pubkey,
+            pubkeyCache,
           },
           {skipSyncPubkeys: true}
         );
@@ -133,8 +130,7 @@ const forkChoiceTest =
           {
             privateKey: await generateKeyPair("secp256k1"),
             config: beaconConfig,
-            pubkey2index,
-            index2pubkey,
+            pubkeyCache,
             db: getMockedBeaconDb(),
             dataDir: ".",
             dbName: ",",

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -6,50 +6,50 @@ import {generateCachedAltairState} from "../../../../../utils/state.js";
 describe("beacon state api utils", () => {
   describe("getStateValidatorIndex", () => {
     const state = generateCachedAltairState();
-    const pubkey2index = state.epochCtx.pubkey2index;
+    const pubkeyCache = state.epochCtx.pubkeyCache;
 
     it("should return valid: false on invalid input", () => {
       // "invalid validator id number"
-      expect(getStateValidatorIndex("foo", state, pubkey2index).valid).toBe(false);
+      expect(getStateValidatorIndex("foo", state, pubkeyCache).valid).toBe(false);
       // "invalid hex"
-      expect(getStateValidatorIndex("0xfoo", state, pubkey2index).valid).toBe(false);
+      expect(getStateValidatorIndex("0xfoo", state, pubkeyCache).valid).toBe(false);
     });
 
     it("should return valid: false on validator indices / pubkeys not in the state", () => {
       // "validator id not in state"
-      expect(getStateValidatorIndex(String(state.validators.length), state, pubkey2index).valid).toBe(false);
+      expect(getStateValidatorIndex(String(state.validators.length), state, pubkeyCache).valid).toBe(false);
       // "validator pubkey not in state"
       expect(
         getStateValidatorIndex(
           "0xa99af0913a2834ef4959637e8d7c4e17f0b63adc587d36ab43510452db3102d0771a4554ea4118a33913827d5ee80b76",
           state,
-          pubkey2index
+          pubkeyCache
         ).valid
       ).toBe(false);
     });
 
     it("should return valid: true on validator indices / pubkeys in the state", () => {
       const index = state.validators.length - 1;
-      const resp1 = getStateValidatorIndex(String(index), state, pubkey2index);
+      const resp1 = getStateValidatorIndex(String(index), state, pubkeyCache);
       if (resp1.valid) {
         expect(resp1.validatorIndex).toBe(index);
       } else {
         expect.fail("validator index should be found - validator index as string input");
       }
-      const resp2 = getStateValidatorIndex(index, state, pubkey2index);
+      const resp2 = getStateValidatorIndex(index, state, pubkeyCache);
       if (resp2.valid) {
         expect(resp2.validatorIndex).toBe(index);
       } else {
         expect.fail("validator index should be found - validator index as number input");
       }
       const pubkey = state.validators.get(index).pubkey;
-      const resp3 = getStateValidatorIndex(pubkey, state, pubkey2index);
+      const resp3 = getStateValidatorIndex(pubkey, state, pubkeyCache);
       if (resp3.valid) {
         expect(resp3.validatorIndex).toBe(index);
       } else {
         expect.fail("validator index should be found - Uint8Array input");
       }
-      const resp4 = getStateValidatorIndex(toHexString(pubkey), state, pubkey2index);
+      const resp4 = getStateValidatorIndex(toHexString(pubkey), state, pubkeyCache);
       if (resp4.valid) {
         expect(resp4.validatorIndex).toBe(index);
       } else {

--- a/packages/beacon-node/test/unit/chain/bls/bls.test.ts
+++ b/packages/beacon-node/test/unit/chain/bls/bls.test.ts
@@ -1,6 +1,6 @@
 import {beforeEach, describe, expect, it} from "vitest";
 import {PublicKey, SecretKey, Signature} from "@chainsafe/blst";
-import {ISignatureSet, SignatureSetType} from "@lodestar/state-transition";
+import {ISignatureSet, SignatureSetType, createPubkeyCache} from "@lodestar/state-transition";
 import {BlsMultiThreadWorkerPool} from "../../../../src/chain/bls/multithread/index.js";
 import {BlsSingleThreadVerifier} from "../../../../src/chain/bls/singleThread.js";
 import {testLogger} from "../../../utils/logger.js";
@@ -9,11 +9,14 @@ describe("BlsVerifier ", () => {
   // take time for creating thread pool
   const numKeys = 3;
   const secretKeys = Array.from({length: numKeys}, (_, i) => SecretKey.fromKeygen(Buffer.alloc(32, i)));
-  // Create a mock index2pubkey that maps indices to public keys
-  const index2pubkey = secretKeys.map((sk) => sk.toPublicKey());
+  // Create a mock pubkeyCache that maps indices to public keys
+  const pubkeyCache = createPubkeyCache();
+  for (const [i, sk] of secretKeys.entries()) {
+    pubkeyCache.set(i, sk.toPublicKey().toBytes());
+  }
   const verifiers = [
-    new BlsSingleThreadVerifier({metrics: null, index2pubkey}),
-    new BlsMultiThreadWorkerPool({}, {metrics: null, logger: testLogger(), index2pubkey}),
+    new BlsSingleThreadVerifier({metrics: null, pubkeyCache}),
+    new BlsMultiThreadWorkerPool({}, {metrics: null, logger: testLogger(), pubkeyCache}),
   ];
 
   for (const verifier of verifiers) {

--- a/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {PublicKey, SecretKey} from "@chainsafe/blst";
 import {ForkName} from "@lodestar/params";
-import {SignatureSetType} from "@lodestar/state-transition";
+import {SignatureSetType, createPubkeyCache} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {BlsSingleThreadVerifier} from "../../../../../src/chain/bls/singleThread.js";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../../../../../src/chain/errors/index.js";
@@ -56,22 +56,22 @@ describe("validateGossipAttestationsSameAttData", () => {
     return keypair;
   }
 
-  // Build index2pubkey cache for test
-  const index2pubkey: PublicKey[] = [];
+  // Build pubkeyCache for test
+  const pubkeyCache = createPubkeyCache();
   for (let i = 0; i < 10; i++) {
-    index2pubkey.push(getKeypair(i).publicKey);
+    pubkeyCache.set(i, getKeypair(i).publicKey.toBytes());
   }
   // Add a special keypair for invalid signatures
-  index2pubkey[2023] = getKeypair(2023).publicKey;
+  pubkeyCache.set(2023, getKeypair(2023).publicKey.toBytes());
 
   let chain: IBeaconChain;
   const signingRoot = Buffer.alloc(32, 1);
 
   beforeEach(() => {
     chain = {
-      bls: new BlsSingleThreadVerifier({metrics: null, index2pubkey}),
+      bls: new BlsSingleThreadVerifier({metrics: null, pubkeyCache}),
       seenAttesters: new SeenAttesters(),
-      index2pubkey,
+      pubkeyCache,
       opts: {
         minSameMessageSignatureSetsToBatch: 2,
       } as IBeaconChain["opts"],

--- a/packages/beacon-node/test/utils/networkWithMockDb.ts
+++ b/packages/beacon-node/test/utils/networkWithMockDb.ts
@@ -1,7 +1,6 @@
 import {generateKeyPair} from "@libp2p/crypto/keys";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
-import {Index2PubkeyCache, createCachedBeaconState, syncPubkeys} from "@lodestar/state-transition";
+import {createCachedBeaconState, createPubkeyCache, syncPubkeys} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {BeaconChain} from "../../src/chain/chain.js";
@@ -43,15 +42,13 @@ export async function getNetworkForTest(
   );
 
   const beaconConfig = createBeaconConfig(config, state.genesisValidatorsRoot);
-  const pubkey2index = new PubkeyIndexMap();
-  const index2pubkey: Index2PubkeyCache = [];
-  syncPubkeys(state.validators.getAllReadonlyValues(), pubkey2index, index2pubkey);
+  const pubkeyCache = createPubkeyCache();
+  syncPubkeys(pubkeyCache, state.validators.getAllReadonlyValues());
   const cachedState = createCachedBeaconState(
     state,
     {
       config: beaconConfig,
-      pubkey2index,
-      index2pubkey,
+      pubkeyCache,
     },
     {skipSyncPubkeys: true}
   );
@@ -73,8 +70,7 @@ export async function getNetworkForTest(
     {
       privateKey,
       config: beaconConfig,
-      pubkey2index,
-      index2pubkey,
+      pubkeyCache,
       db,
       dataDir: ".",
       dbName: ".",

--- a/packages/beacon-node/test/utils/node/beacon.ts
+++ b/packages/beacon-node/test/utils/node/beacon.ts
@@ -4,7 +4,6 @@ import deepmerge from "deepmerge";
 import tmp from "tmp";
 import {setHasher} from "@chainsafe/persistent-merkle-tree";
 import {hasher} from "@chainsafe/persistent-merkle-tree/hasher/hashtree";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {ChainConfig, createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {config as minimalConfig} from "@lodestar/config/default";
 import {LevelDbController} from "@lodestar/db/controller/level";
@@ -12,10 +11,10 @@ import {LoggerNode} from "@lodestar/logger/node";
 import {ForkSeq, GENESIS_SLOT} from "@lodestar/params";
 import {
   BeaconStateAllForks,
-  Index2PubkeyCache,
   computeAnchorCheckpoint,
   computeEpochAtSlot,
   createCachedBeaconState,
+  createPubkeyCache,
   syncPubkeys,
 } from "@lodestar/state-transition";
 import {phase0, ssz} from "@lodestar/types";
@@ -133,15 +132,13 @@ export async function getDevBeaconNode(
   );
 
   const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
-  const pubkey2index = new PubkeyIndexMap();
-  const index2pubkey: Index2PubkeyCache = [];
-  syncPubkeys(anchorState.validators.getAllReadonlyValues(), pubkey2index, index2pubkey);
+  const pubkeyCache = createPubkeyCache();
+  syncPubkeys(pubkeyCache, anchorState.validators.getAllReadonlyValues());
   const cachedState = createCachedBeaconState(
     anchorState,
     {
       config: beaconConfig,
-      pubkey2index,
-      index2pubkey,
+      pubkeyCache,
     },
     {skipSyncPubkeys: true}
   );
@@ -149,8 +146,7 @@ export async function getDevBeaconNode(
   return BeaconNode.init({
     opts: options as IBeaconNodeOptions,
     config: beaconConfig,
-    pubkey2index,
-    index2pubkey,
+    pubkeyCache,
     db,
     logger,
     processShutdownCallback: () => {},

--- a/packages/beacon-node/test/utils/state.ts
+++ b/packages/beacon-node/test/utils/state.ts
@@ -1,5 +1,4 @@
 import {SecretKey} from "@chainsafe/blst";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {config as minimalConfig} from "@lodestar/config/default";
 import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
@@ -13,6 +12,7 @@ import {
   CachedBeaconStateElectra,
   DataAvailabilityStatus,
   createCachedBeaconState,
+  createPubkeyCache,
 } from "@lodestar/state-transition";
 import {BeaconState, altair, bellatrix, electra, ssz} from "@lodestar/types";
 import {ZERO_HASH_HEX} from "../../src/constants/constants.js";
@@ -114,8 +114,7 @@ export function generateCachedState(opts?: TestBeaconState): CachedBeaconStateAl
   return createCachedBeaconState(state, {
     config: createBeaconConfig(config, state.genesisValidatorsRoot),
     // This is a performance test, there's no need to have a global shared cache of keys
-    pubkey2index: new PubkeyIndexMap(),
-    index2pubkey: [],
+    pubkeyCache: createPubkeyCache(),
   });
 }
 
@@ -128,8 +127,7 @@ export function generateCachedAltairState(opts?: TestBeaconState, altairForkEpoc
   return createCachedBeaconState(state, {
     config: createBeaconConfig(config, state.genesisValidatorsRoot),
     // This is a performance test, there's no need to have a global shared cache of keys
-    pubkey2index: new PubkeyIndexMap(),
-    index2pubkey: [],
+    pubkeyCache: createPubkeyCache(),
   });
 }
 
@@ -142,8 +140,7 @@ export function generateCachedBellatrixState(opts?: TestBeaconState): CachedBeac
   return createCachedBeaconState(state as BeaconStateBellatrix, {
     config: createBeaconConfig(config, state.genesisValidatorsRoot),
     // This is a performance test, there's no need to have a global shared cache of keys
-    pubkey2index: new PubkeyIndexMap(),
-    index2pubkey: [],
+    pubkeyCache: createPubkeyCache(),
   });
 }
 
@@ -155,8 +152,7 @@ export function generateCachedElectraState(opts?: TestBeaconState, electraForkEp
   const state = generateState(opts, config);
   return createCachedBeaconState(state as BeaconStateElectra, {
     config: createBeaconConfig(config, state.genesisValidatorsRoot),
-    pubkey2index: new PubkeyIndexMap(),
-    index2pubkey: [],
+    pubkeyCache: createPubkeyCache(),
   });
 }
 export const zeroProtoBlock: ProtoBlock = {

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -153,13 +153,13 @@ export function getAttestationValidData(opts: AttestationValidDataOpts): {
     seenAggregatedAttestations: new SeenAggregatedAttestations(null),
     seenAttestationDatas: new SeenAttestationDatas(null, 0, 0),
     bls: blsVerifyAllMainThread
-      ? new BlsSingleThreadVerifier({metrics: null, index2pubkey: state.epochCtx.index2pubkey})
+      ? new BlsSingleThreadVerifier({metrics: null, pubkeyCache: state.epochCtx.pubkeyCache})
       : new BlsMultiThreadWorkerPool(
           {},
-          {logger: testLogger(), metrics: null, index2pubkey: state.epochCtx.index2pubkey}
+          {logger: testLogger(), metrics: null, pubkeyCache: state.epochCtx.pubkeyCache}
         ),
     waitForBlock: () => Promise.resolve(false),
-    index2pubkey: state.epochCtx.index2pubkey,
+    pubkeyCache: state.epochCtx.pubkeyCache,
     shufflingCache,
     opts: defaultChainOptions,
   } as Partial<IBeaconChain> as IBeaconChain;

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -2,13 +2,12 @@ import path from "node:path";
 import {getHeapStatistics} from "node:v8";
 import {SignableENR} from "@chainsafe/enr";
 import {hasher} from "@chainsafe/persistent-merkle-tree";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {BeaconDb, BeaconNode} from "@lodestar/beacon-node";
 import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {LoggerNode, getNodeLogger} from "@lodestar/logger/node";
 import {ACTIVE_PRESET, PresetName} from "@lodestar/params";
-import {Index2PubkeyCache, createCachedBeaconState, syncPubkeys} from "@lodestar/state-transition";
+import {createCachedBeaconState, createPubkeyCache, syncPubkeys} from "@lodestar/state-transition";
 import {ErrorAborted, bytesToInt, formatBytes} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
 import {BeaconNodeOptions, getBeaconConfigFromArgs} from "../../config/index.js";
@@ -80,15 +79,13 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       logger
     );
     const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
-    const pubkey2index = new PubkeyIndexMap();
-    const index2pubkey: Index2PubkeyCache = [];
-    syncPubkeys(anchorState.validators.getAllReadonlyValues(), pubkey2index, index2pubkey);
+    const pubkeyCache = createPubkeyCache();
+    syncPubkeys(pubkeyCache, anchorState.validators.getAllReadonlyValues());
     const cachedState = createCachedBeaconState(
       anchorState,
       {
         config: beaconConfig,
-        pubkey2index,
-        index2pubkey,
+        pubkeyCache,
       },
       {skipSyncPubkeys: true}
     );
@@ -96,8 +93,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
     const node = await BeaconNode.init({
       opts: options,
       config: beaconConfig,
-      pubkey2index,
-      index2pubkey,
+      pubkeyCache,
       db,
       logger,
       processShutdownCallback,

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -1,7 +1,7 @@
 import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq, MAX_COMMITTEES_PER_SLOT, MAX_VALIDATORS_PER_COMMITTEE} from "@lodestar/params";
 import {IndexedAttestation, IndexedAttestationBigint, Slot} from "@lodestar/types";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
+import {PubkeyCache} from "../cache/pubkeyCache.js";
 import {getIndexedAttestationBigintSignatureSet, getIndexedAttestationSignatureSet} from "../signatureSets/index.js";
 import {verifySignatureSet} from "../util/index.js";
 
@@ -10,7 +10,7 @@ import {verifySignatureSet} from "../util/index.js";
  */
 export function isValidIndexedAttestation(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
+  pubkeyCache: PubkeyCache,
   stateSlot: Slot,
   validatorsLen: number,
   indexedAttestation: IndexedAttestation,
@@ -21,14 +21,14 @@ export function isValidIndexedAttestation(
   }
 
   if (verifySignature) {
-    return verifySignatureSet(getIndexedAttestationSignatureSet(config, stateSlot, indexedAttestation), index2pubkey);
+    return verifySignatureSet(getIndexedAttestationSignatureSet(config, stateSlot, indexedAttestation), pubkeyCache);
   }
   return true;
 }
 
 export function isValidIndexedAttestationBigint(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
+  pubkeyCache: PubkeyCache,
   stateSlot: Slot,
   validatorsLen: number,
   indexedAttestation: IndexedAttestationBigint,
@@ -41,7 +41,7 @@ export function isValidIndexedAttestationBigint(
   if (verifySignature) {
     return verifySignatureSet(
       getIndexedAttestationBigintSignatureSet(config, stateSlot, indexedAttestation),
-      index2pubkey
+      pubkeyCache
     );
   }
   return true;

--- a/packages/state-transition/src/block/isValidIndexedPayloadAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedPayloadAttestation.ts
@@ -18,7 +18,7 @@ export function isValidIndexedPayloadAttestation(
   if (verifySignature) {
     return verifySignatureSet(
       getIndexedPayloadAttestationSignatureSet(state.config, indexedPayloadAttestation),
-      state.epochCtx.index2pubkey
+      state.epochCtx.pubkeyCache
     );
   }
 

--- a/packages/state-transition/src/block/processAttestationPhase0.ts
+++ b/packages/state-transition/src/block/processAttestationPhase0.ts
@@ -53,7 +53,7 @@ export function processAttestationPhase0(
   if (
     !isValidIndexedAttestation(
       state.config,
-      epochCtx.index2pubkey,
+      epochCtx.pubkeyCache,
       state.slot,
       state.validators.length,
       epochCtx.getIndexedAttestation(ForkSeq.phase0, attestation),

--- a/packages/state-transition/src/block/processAttestationsAltair.ts
+++ b/packages/state-transition/src/block/processAttestationsAltair.ts
@@ -64,7 +64,7 @@ export function processAttestationsAltair(
     // we can verify only that and nothing else.
     if (verifySignature) {
       const sigSet = getAttestationWithIndicesSignatureSet(state.config, state.slot, attestation, attestingIndices);
-      if (!verifySignatureSet(sigSet, state.epochCtx.index2pubkey)) {
+      if (!verifySignatureSet(sigSet, state.epochCtx.pubkeyCache)) {
         throw new Error("Attestation signature is not valid");
       }
     }

--- a/packages/state-transition/src/block/processAttesterSlashing.ts
+++ b/packages/state-transition/src/block/processAttesterSlashing.ts
@@ -1,7 +1,7 @@
 import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq} from "@lodestar/params";
 import {AttesterSlashing, Slot} from "@lodestar/types";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
+import {PubkeyCache} from "../cache/pubkeyCache.js";
 import {CachedBeaconStateAllForks} from "../types.js";
 import {getAttesterSlashableIndices, isSlashableAttestationData, isSlashableValidator} from "../util/index.js";
 import {isValidIndexedAttestationBigint} from "./isValidIndexedAttestation.js";
@@ -22,7 +22,7 @@ export function processAttesterSlashing(
   const {epochCtx} = state;
   assertValidAttesterSlashing(
     state.config,
-    epochCtx.index2pubkey,
+    epochCtx.pubkeyCache,
     state.slot,
     state.validators.length,
     attesterSlashing,
@@ -48,7 +48,7 @@ export function processAttesterSlashing(
 
 export function assertValidAttesterSlashing(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
+  pubkeyCache: PubkeyCache,
   stateSlot: Slot,
   validatorsLen: number,
   attesterSlashing: AttesterSlashing,
@@ -66,7 +66,7 @@ export function assertValidAttesterSlashing(
   // can be any arbitrary value. Must use bigint variants to hash correctly to all possible values
   for (const [i, attestation] of [attestation1, attestation2].entries()) {
     if (
-      !isValidIndexedAttestationBigint(config, index2pubkey, stateSlot, validatorsLen, attestation, verifySignatures)
+      !isValidIndexedAttestationBigint(config, pubkeyCache, stateSlot, validatorsLen, attestation, verifySignatures)
     ) {
       throw new Error(`AttesterSlashing attestation${i} is invalid`);
     }

--- a/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
@@ -156,7 +156,11 @@ function verifyExecutionPayloadEnvelopeSignature(
 
     if (builderIndex === BUILDER_INDEX_SELF_BUILD) {
       const validatorIndex = state.latestBlockHeader.proposerIndex;
-      publicKey = state.epochCtx.index2pubkey[validatorIndex];
+      const proposerPubkey = state.epochCtx.pubkeyCache.get(validatorIndex);
+      if (!proposerPubkey) {
+        return false;
+      }
+      publicKey = proposerPubkey;
     } else {
       publicKey = PublicKey.fromBytes(state.builders.getReadonly(builderIndex).pubkey);
     }

--- a/packages/state-transition/src/block/processProposerSlashing.ts
+++ b/packages/state-transition/src/block/processProposerSlashing.ts
@@ -2,7 +2,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {Slot, phase0, ssz} from "@lodestar/types";
 import {Validator} from "@lodestar/types/phase0";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
+import {PubkeyCache} from "../cache/pubkeyCache.js";
 import {getProposerSlashingSignatureSets} from "../signatureSets/index.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateGloas} from "../types.js";
 import {computeEpochAtSlot, isSlashableValidator} from "../util/index.js";
@@ -24,7 +24,7 @@ export function processProposerSlashing(
   const proposer = state.validators.getReadonly(proposerSlashing.signedHeader1.message.proposerIndex);
   assertValidProposerSlashing(
     state.config,
-    state.epochCtx.index2pubkey,
+    state.epochCtx.pubkeyCache,
     state.slot,
     proposerSlashing,
     proposer,
@@ -57,7 +57,7 @@ export function processProposerSlashing(
 
 export function assertValidProposerSlashing(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
+  pubkeyCache: PubkeyCache,
   stateSlot: Slot,
   proposerSlashing: phase0.ProposerSlashing,
   proposer: Validator,
@@ -94,7 +94,7 @@ export function assertValidProposerSlashing(
   if (verifySignatures) {
     const signatureSets = getProposerSlashingSignatureSets(config, stateSlot, proposerSlashing);
     for (let i = 0; i < signatureSets.length; i++) {
-      if (!verifySignatureSet(signatureSets[i], index2pubkey)) {
+      if (!verifySignatureSet(signatureSets[i], pubkeyCache)) {
         throw new Error(`ProposerSlashing header${i + 1} signature invalid`);
       }
     }

--- a/packages/state-transition/src/block/processRandao.ts
+++ b/packages/state-transition/src/block/processRandao.ts
@@ -17,7 +17,7 @@ export function processRandao(state: CachedBeaconStateAllForks, block: BeaconBlo
   const randaoReveal = block.body.randaoReveal;
 
   // verify RANDAO reveal
-  if (verifySignature && !verifyRandaoSignature(config, epochCtx.index2pubkey, block)) {
+  if (verifySignature && !verifyRandaoSignature(config, epochCtx.pubkeyCache, block)) {
     throw new Error("RANDAO reveal is an invalid signature");
   }
 

--- a/packages/state-transition/src/block/processSyncCommittee.ts
+++ b/packages/state-transition/src/block/processSyncCommittee.ts
@@ -32,7 +32,7 @@ export function processSyncAggregate(
       participantIndices
     );
     // When there's no participation we consider the signature valid and just ignore it
-    if (signatureSet !== null && !verifySignatureSet(signatureSet, state.epochCtx.index2pubkey)) {
+    if (signatureSet !== null && !verifySignatureSet(signatureSet, state.epochCtx.pubkeyCache)) {
       throw Error("Sync committee signature invalid");
     }
   }

--- a/packages/state-transition/src/block/processVoluntaryExit.ts
+++ b/packages/state-transition/src/block/processVoluntaryExit.ts
@@ -131,7 +131,7 @@ export function getVoluntaryExitValidity(
 
   if (
     verifySignature &&
-    !verifyVoluntaryExitSignature(state.config, epochCtx.index2pubkey, state.slot, signedVoluntaryExit)
+    !verifyVoluntaryExitSignature(state.config, epochCtx.pubkeyCache, state.slot, signedVoluntaryExit)
   ) {
     return VoluntaryExitValidity.invalidSignature;
   }

--- a/packages/state-transition/src/block/processWithdrawalRequest.ts
+++ b/packages/state-transition/src/block/processWithdrawalRequest.ts
@@ -21,7 +21,7 @@ export function processWithdrawalRequest(
   const amount = Number(withdrawalRequest.amount);
   const {pendingPartialWithdrawals, validators, epochCtx} = state;
   // no need to use unfinalized pubkey cache from 6110 as validator won't be active anyway
-  const {pubkey2index, config} = epochCtx;
+  const {pubkeyCache, config} = epochCtx;
   const isFullExitRequest = amount === FULL_EXIT_REQUEST_AMOUNT;
 
   // If partial withdrawal queue is full, only full exits are processed
@@ -31,7 +31,7 @@ export function processWithdrawalRequest(
 
   // bail out if validator is not in beacon state
   // note that we don't need to check for 6110 unfinalized vals as they won't be eligible for withdraw/exit anyway
-  const validatorIndex = pubkey2index.get(withdrawalRequest.validatorPubkey);
+  const validatorIndex = pubkeyCache.getIndex(withdrawalRequest.validatorPubkey);
   if (validatorIndex === null) {
     return;
   }

--- a/packages/state-transition/src/cache/epochCache.ts
+++ b/packages/state-transition/src/cache/epochCache.ts
@@ -1,5 +1,4 @@
 import {PublicKey} from "@chainsafe/blst";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {BeaconConfig, ChainConfig, createBeaconConfig} from "@lodestar/config";
 import {
   ATTESTATION_SUBNET_COUNT,
@@ -56,7 +55,7 @@ import {computeBaseRewardPerIncrement, computeSyncParticipantReward} from "../ut
 import {sumTargetUnslashedBalanceIncrements} from "../util/targetUnslashedBalance.js";
 import {EffectiveBalanceIncrements, getEffectiveBalanceIncrementsWithLen} from "./effectiveBalanceIncrements.js";
 import {EpochTransitionCache} from "./epochTransitionCache.js";
-import {Index2PubkeyCache, syncPubkeys} from "./pubkeyCache.js";
+import {PubkeyCache, createPubkeyCache, syncPubkeys} from "./pubkeyCache.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateFulu} from "./stateCache.js";
 import {
   SyncCommitteeCache,
@@ -71,8 +70,7 @@ export const PROPOSER_WEIGHT_FACTOR = PROPOSER_WEIGHT / (WEIGHT_DENOMINATOR - PR
 
 export type EpochCacheImmutableData = {
   config: BeaconConfig;
-  pubkey2index: PubkeyIndexMap;
-  index2pubkey: Index2PubkeyCache;
+  pubkeyCache: PubkeyCache;
 };
 
 export type EpochCacheOpts = {
@@ -111,15 +109,9 @@ export class EpochCache {
   /**
    * Unique globally shared pubkey registry. There should only exist one for the entire application.
    *
-   * $VALIDATOR_COUNT x 192 char String -> Number Map
+   * Couples both index→pubkey and pubkey→index lookups, keeping them in sync atomically.
    */
-  pubkey2index: PubkeyIndexMap;
-  /**
-   * Unique globally shared pubkey registry. There should only exist one for the entire application.
-   *
-   * $VALIDATOR_COUNT x BLST deserialized pubkey (Jacobian coordinates)
-   */
-  index2pubkey: Index2PubkeyCache;
+  pubkeyCache: PubkeyCache;
   /**
    * Indexes of the block proposers for the current epoch.
    * For pre-fulu, this is computed and cached from the current shuffling.
@@ -249,8 +241,7 @@ export class EpochCache {
 
   constructor(data: {
     config: BeaconConfig;
-    pubkey2index: PubkeyIndexMap;
-    index2pubkey: Index2PubkeyCache;
+    pubkeyCache: PubkeyCache;
     proposers: number[];
     proposersPrevEpoch: number[] | null;
     proposersNextEpoch: ProposersDeferred;
@@ -280,8 +271,7 @@ export class EpochCache {
     syncPeriod: SyncPeriod;
   }) {
     this.config = data.config;
-    this.pubkey2index = data.pubkey2index;
-    this.index2pubkey = data.index2pubkey;
+    this.pubkeyCache = data.pubkeyCache;
     this.proposers = data.proposers;
     this.proposersPrevEpoch = data.proposersPrevEpoch;
     this.proposersNextEpoch = data.proposersNextEpoch;
@@ -319,7 +309,7 @@ export class EpochCache {
    */
   static createFromState(
     state: BeaconStateAllForks,
-    {config, pubkey2index, index2pubkey}: EpochCacheImmutableData,
+    {config, pubkeyCache}: EpochCacheImmutableData,
     opts?: EpochCacheOpts
   ): EpochCache {
     const currentEpoch = computeEpochAtSlot(state.slot);
@@ -335,9 +325,9 @@ export class EpochCache {
     const validatorCount = validators.length;
 
     // syncPubkeys here to ensure EpochCacheImmutableData is popualted before computing the rest of caches
-    // - computeSyncCommitteeCache() needs a fully populated pubkey2index cache
+    // - computeSyncCommitteeCache() needs a fully populated pubkeyCache
     if (!opts?.skipSyncPubkeys) {
-      syncPubkeys(validators, pubkey2index, index2pubkey);
+      syncPubkeys(pubkeyCache, validators);
     }
 
     const effectiveBalanceIncrements = getEffectiveBalanceIncrementsWithLen(validatorCount);
@@ -450,8 +440,8 @@ export class EpochCache {
     // Allow to skip populating sync committee for initializeBeaconStateFromEth1()
     if (afterAltairFork && !opts?.skipSyncCommitteeCache) {
       const altairState = state as BeaconStateAltair;
-      currentSyncCommitteeIndexed = computeSyncCommitteeCache(altairState.currentSyncCommittee, pubkey2index);
-      nextSyncCommitteeIndexed = computeSyncCommitteeCache(altairState.nextSyncCommittee, pubkey2index);
+      currentSyncCommitteeIndexed = computeSyncCommitteeCache(altairState.currentSyncCommittee, pubkeyCache);
+      nextSyncCommitteeIndexed = computeSyncCommitteeCache(altairState.nextSyncCommittee, pubkeyCache);
     } else {
       currentSyncCommitteeIndexed = new SyncCommitteeCacheEmpty();
       nextSyncCommitteeIndexed = new SyncCommitteeCacheEmpty();
@@ -514,8 +504,7 @@ export class EpochCache {
 
     return new EpochCache({
       config,
-      pubkey2index,
-      index2pubkey,
+      pubkeyCache,
       proposers,
       // On first epoch, set to null to prevent unnecessary work since this is only used for metrics
       proposersPrevEpoch: null,
@@ -557,8 +546,7 @@ export class EpochCache {
     return new EpochCache({
       config: this.config,
       // Common append-only structures shared with all states, no need to clone
-      pubkey2index: this.pubkey2index,
-      index2pubkey: this.index2pubkey,
+      pubkeyCache: this.pubkeyCache,
       // Immutable data
       proposers: this.proposers,
       proposersPrevEpoch: this.proposersPrevEpoch,
@@ -882,16 +870,15 @@ export class EpochCache {
    * Return pubkey given the validator index.
    */
   getPubkey(index: ValidatorIndex): PublicKey | undefined {
-    return this.index2pubkey[index];
+    return this.pubkeyCache.get(index);
   }
 
   getValidatorIndex(pubkey: Uint8Array): ValidatorIndex | null {
-    return this.pubkey2index.get(pubkey);
+    return this.pubkeyCache.getIndex(pubkey);
   }
 
   addPubkey(index: ValidatorIndex, pubkey: Uint8Array): void {
-    this.pubkey2index.set(pubkey, index);
-    this.index2pubkey[index] = PublicKey.fromBytes(pubkey); // Optimize for aggregation
+    this.pubkeyCache.set(index, pubkey);
   }
 
   getShufflingAtSlot(slot: Slot): EpochShuffling {
@@ -1099,7 +1086,6 @@ export function createEmptyEpochCacheImmutableData(
   return {
     config: createBeaconConfig(chainConfig, state.genesisValidatorsRoot),
     // This is a test state, there's no need to have a global shared cache of keys
-    pubkey2index: new PubkeyIndexMap(),
-    index2pubkey: [],
+    pubkeyCache: createPubkeyCache(),
   };
 }

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -2,32 +2,65 @@ import {PublicKey} from "@chainsafe/blst";
 import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {phase0} from "@lodestar/types";
 
-export type Index2PubkeyCache = PublicKey[];
+/**
+ * Unified pubkey cache coupling index→pubkey and pubkey→index lookups.
+ * Both directions are kept in sync atomically via `set()`.
+ */
+export interface PubkeyCache {
+  /** Get deserialized PublicKey by validator index */
+  get(index: number): PublicKey | undefined;
+  /** Get validator index by pubkey bytes */
+  getIndex(pubkey: Uint8Array): number | null;
+  /** Set both directions atomically. Takes raw pubkey bytes — deserialization is handled internally. */
+  set(index: number, pubkey: Uint8Array): void;
+  /** Number of entries */
+  readonly size: number;
+}
+
+class StandardPubkeyCache implements PubkeyCache {
+  private readonly pubkey2index: PubkeyIndexMap;
+  private readonly index2pubkey: (PublicKey | undefined)[];
+
+  constructor(pubkey2index?: PubkeyIndexMap, index2pubkey?: (PublicKey | undefined)[]) {
+    this.pubkey2index = pubkey2index ?? new PubkeyIndexMap();
+    this.index2pubkey = index2pubkey ?? [];
+  }
+
+  get size(): number {
+    return this.index2pubkey.length;
+  }
+
+  get(index: number): PublicKey | undefined {
+    return this.index2pubkey[index];
+  }
+
+  getIndex(pubkey: Uint8Array): number | null {
+    return this.pubkey2index.get(pubkey);
+  }
+
+  set(index: number, pubkey: Uint8Array): void {
+    this.pubkey2index.set(pubkey, index);
+    // Pubkeys must be checked for group + inf. This must be done only once when the validator deposit is processed.
+    // Afterwards any public key in the state is considered validated.
+    // > Do not do any validation here
+    this.index2pubkey[index] = PublicKey.fromBytes(pubkey); // Optimize for aggregation
+  }
+}
+
+export function createPubkeyCache(): PubkeyCache {
+  return new StandardPubkeyCache();
+}
 
 /**
  * Checks the pubkey indices against a state and adds missing pubkeys
  *
- * Mutates `pubkey2index` and `index2pubkey`
+ * Mutates `pubkeyCache`
  *
- * If pubkey caches are empty: SLOW CODE - 🐢
+ * If pubkey cache is empty: SLOW CODE - 🐢
  */
-export function syncPubkeys(
-  validators: phase0.Validator[],
-  pubkey2index: PubkeyIndexMap,
-  index2pubkey: Index2PubkeyCache
-): void {
-  if (pubkey2index.size !== index2pubkey.length) {
-    throw new Error(`Pubkey indices have fallen out of sync: ${pubkey2index.size} != ${index2pubkey.length}`);
-  }
-
+export function syncPubkeys(pubkeyCache: PubkeyCache, validators: phase0.Validator[]): void {
   const newCount = validators.length;
-  index2pubkey.length = newCount;
-  for (let i = pubkey2index.size; i < newCount; i++) {
-    const pubkey = validators[i].pubkey;
-    pubkey2index.set(pubkey, i);
-    // Pubkeys must be checked for group + inf. This must be done only once when the validator deposit is processed.
-    // Afterwards any public key is the state consider validated.
-    // > Do not do any validation here
-    index2pubkey[i] = PublicKey.fromBytes(pubkey); // Optimize for aggregation
+  for (let i = pubkeyCache.size; i < newCount; i++) {
+    pubkeyCache.set(i, validators[i].pubkey);
   }
 }

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -1,6 +1,6 @@
 import {PublicKey} from "@chainsafe/blst";
 import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
-import {phase0} from "@lodestar/types";
+import {ValidatorIndex, phase0} from "@lodestar/types";
 
 /**
  * Unified pubkey cache coupling index→pubkey and pubkey→index lookups.
@@ -8,11 +8,13 @@ import {phase0} from "@lodestar/types";
  */
 export interface PubkeyCache {
   /** Get deserialized PublicKey by validator index */
-  get(index: number): PublicKey | undefined;
+  get(index: ValidatorIndex): PublicKey | undefined;
+  /** Get deserialized PublicKey by validator index or throw if not found */
+  getOrThrow(index: ValidatorIndex): PublicKey;
   /** Get validator index by pubkey bytes */
-  getIndex(pubkey: Uint8Array): number | null;
+  getIndex(pubkey: Uint8Array): ValidatorIndex | null;
   /** Set both directions atomically. Takes raw pubkey bytes — deserialization is handled internally. */
-  set(index: number, pubkey: Uint8Array): void;
+  set(index: ValidatorIndex, pubkey: Uint8Array): void;
   /** Number of entries */
   readonly size: number;
 }
@@ -27,22 +29,24 @@ class StandardPubkeyCache implements PubkeyCache {
   }
 
   get size(): number {
-    return this.index2pubkey.length;
+    return this.pubkey2index.size;
   }
 
-  get(index: number): PublicKey | undefined {
+  get(index: ValidatorIndex): PublicKey | undefined {
     return this.index2pubkey[index];
   }
 
-  getIndex(pubkey: Uint8Array): number | null {
+  getOrThrow(index: ValidatorIndex): PublicKey {
+    const pubkey = this.get(index);
+    if (!pubkey) throw Error(`Missing pubkey for validator index ${index}`);
+    return pubkey;
+  }
+
+  getIndex(pubkey: Uint8Array): ValidatorIndex | null {
     return this.pubkey2index.get(pubkey);
   }
 
-  set(index: number, pubkey: Uint8Array): void {
-    if (index !== this.index2pubkey.length) {
-      throw Error(`PubkeyCache set() must be called with sequential indices. Expected index ${this.index2pubkey.length} but got ${index}`);
-    }
-
+  set(index: ValidatorIndex, pubkey: Uint8Array): void {
     this.pubkey2index.set(pubkey, index);
     // Pubkeys must be checked for group + inf. This must be done only once when the validator deposit is processed.
     // Afterwards any public key in the state is considered validated.

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -40,7 +40,9 @@ class StandardPubkeyCache implements PubkeyCache {
 
   set(index: number, pubkey: Uint8Array): void {
     if (index !== this.index2pubkey.length) {
-      throw Error(`PubkeyCache set() must be called with sequential indices. Expected index ${this.index2pubkey.length} but got ${index}`);
+      throw Error(
+        `PubkeyCache set() must be called with sequential indices. Expected index ${this.index2pubkey.length} but got ${index}`
+      );
     }
 
     this.pubkey2index.set(pubkey, index);

--- a/packages/state-transition/src/cache/pubkeyCache.ts
+++ b/packages/state-transition/src/cache/pubkeyCache.ts
@@ -39,6 +39,10 @@ class StandardPubkeyCache implements PubkeyCache {
   }
 
   set(index: number, pubkey: Uint8Array): void {
+    if (index !== this.index2pubkey.length) {
+      throw Error(`PubkeyCache set() must be called with sequential indices. Expected index ${this.index2pubkey.length} but got ${index}`);
+    }
+
     this.pubkey2index.set(pubkey, index);
     // Pubkeys must be checked for group + inf. This must be done only once when the validator deposit is processed.
     // Afterwards any public key in the state is considered validated.

--- a/packages/state-transition/src/cache/stateCache.ts
+++ b/packages/state-transition/src/cache/stateCache.ts
@@ -1,4 +1,3 @@
-import {PublicKey} from "@chainsafe/blst";
 import {BeaconConfig} from "@lodestar/config";
 import {loadState} from "../util/loadState/loadState.js";
 import {EpochCache, EpochCacheImmutableData, EpochCacheOpts} from "./epochCache.js";
@@ -180,22 +179,19 @@ export function loadCachedBeaconState<T extends BeaconStateAllForks & BeaconStat
     stateBytes,
     seedValidatorsBytes
   );
-  const {pubkey2index, index2pubkey} = cachedSeedState.epochCtx;
+  const {pubkeyCache} = cachedSeedState.epochCtx;
   // Get the validators sub tree once for all the loop
   const validators = migratedState.validators;
   for (const validatorIndex of modifiedValidators) {
     const validator = validators.getReadonly(validatorIndex);
-    const pubkey = validator.pubkey;
-    pubkey2index.set(pubkey, validatorIndex);
-    index2pubkey[validatorIndex] = PublicKey.fromBytes(pubkey);
+    pubkeyCache.set(validatorIndex, validator.pubkey);
   }
 
   return createCachedBeaconState(
     migratedState,
     {
       config: cachedSeedState.config,
-      pubkey2index,
-      index2pubkey,
+      pubkeyCache,
     },
     {...(opts ?? {}), ...{skipSyncPubkeys: true}}
   ) as T;

--- a/packages/state-transition/src/cache/syncCommitteeCache.ts
+++ b/packages/state-transition/src/cache/syncCommitteeCache.ts
@@ -1,4 +1,3 @@
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {CompositeViewDU} from "@chainsafe/ssz";
 import {ValidatorIndex, ssz} from "@lodestar/types";
 import {toPubkeyHex} from "@lodestar/utils";
@@ -39,9 +38,9 @@ export function getSyncCommitteeCache(validatorIndices: Uint32Array): SyncCommit
 
 export function computeSyncCommitteeCache(
   syncCommittee: CompositeViewDU<typeof ssz.altair.SyncCommittee>,
-  pubkey2index: PubkeyIndexMap
+  pubkeyCache: {getIndex(pubkey: Uint8Array): number | null}
 ): SyncCommitteeCache {
-  const validatorIndices = computeSyncCommitteeValidatorIndices(syncCommittee, pubkey2index);
+  const validatorIndices = computeSyncCommitteeValidatorIndices(syncCommittee, pubkeyCache);
   const validatorIndexMap = computeValidatorSyncCommitteeIndexMap(validatorIndices);
   return {
     validatorIndices,
@@ -79,12 +78,12 @@ export function computeValidatorSyncCommitteeIndexMap(
  */
 function computeSyncCommitteeValidatorIndices(
   syncCommittee: CompositeViewDU<typeof ssz.altair.SyncCommittee>,
-  pubkey2index: PubkeyIndexMap
+  pubkeyCache: {getIndex(pubkey: Uint8Array): number | null}
 ): Uint32Array {
   const pubkeys = syncCommittee.pubkeys.getAllReadonly();
   const validatorIndices = new Uint32Array(pubkeys.length);
   for (const [i, pubkey] of pubkeys.entries()) {
-    const validatorIndex = pubkey2index.get(pubkey);
+    const validatorIndex = pubkeyCache.getIndex(pubkey);
     if (validatorIndex === null) {
       throw Error(`SyncCommittee pubkey is unknown ${toPubkeyHex(pubkey)}`);
     }

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -25,7 +25,7 @@ export {
   createEmptyEpochCacheImmutableData,
 } from "./cache/epochCache.js";
 export {type EpochTransitionCache, beforeProcessEpoch} from "./cache/epochTransitionCache.js";
-export {type Index2PubkeyCache, syncPubkeys} from "./cache/pubkeyCache.js";
+export {type PubkeyCache, createPubkeyCache, syncPubkeys} from "./cache/pubkeyCache.js";
 // Main state caches
 export {
   type BeaconStateCache,

--- a/packages/state-transition/src/rewards/attestationsRewards.ts
+++ b/packages/state-transition/src/rewards/attestationsRewards.ts
@@ -1,4 +1,3 @@
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {BeaconConfig} from "@lodestar/config";
 import {
   EFFECTIVE_BALANCE_INCREMENT,
@@ -16,6 +15,7 @@ import {
 import {ValidatorIndex, rewards} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {EpochTransitionCache, beforeProcessEpoch} from "../cache/epochTransitionCache.js";
+import {PubkeyCache} from "../cache/pubkeyCache.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../types.js";
 import {
   FLAG_ELIGIBLE_ATTESTER,
@@ -34,7 +34,7 @@ const defaultAttestationsPenalty = {target: 0, source: 0};
 
 export async function computeAttestationsRewards(
   config: BeaconConfig,
-  pubkey2index: PubkeyIndexMap,
+  pubkeyCache: PubkeyCache,
   state: CachedBeaconStateAllForks,
   validatorIds?: (ValidatorIndex | string)[]
 ): Promise<rewards.AttestationsRewards> {
@@ -53,7 +53,7 @@ export async function computeAttestationsRewards(
   );
   const totalRewards = computeTotalAttestationsRewardsAltair(
     config,
-    pubkey2index,
+    pubkeyCache,
     stateAltair,
     transitionCache,
     idealRewards,
@@ -142,7 +142,7 @@ function computeIdealAttestationsRewardsAndPenaltiesAltair(
 // Same calculation as `getRewardsAndPenaltiesAltair` but returns the breakdown of rewards instead of aggregated
 function computeTotalAttestationsRewardsAltair(
   config: BeaconConfig,
-  pubkey2index: PubkeyIndexMap,
+  pubkeyCache: PubkeyCache,
   state: CachedBeaconStateAltair,
   transitionCache: EpochTransitionCache,
   idealRewards: rewards.IdealAttestationsReward[],
@@ -153,7 +153,7 @@ function computeTotalAttestationsRewardsAltair(
   const {flags} = transitionCache;
   const {epochCtx} = state;
   const validatorIndices = validatorIds
-    .map((id) => (typeof id === "number" ? id : pubkey2index.get(fromHex(id))))
+    .map((id) => (typeof id === "number" ? id : pubkeyCache.getIndex(fromHex(id))))
     .filter((index) => index !== undefined); // Validator indices to include in the result
 
   const inactivityPenaltyDenominator = config.INACTIVITY_SCORE_BIAS * INACTIVITY_PENALTY_QUOTIENT_ALTAIR;

--- a/packages/state-transition/src/rewards/syncCommitteeRewards.ts
+++ b/packages/state-transition/src/rewards/syncCommitteeRewards.ts
@@ -1,12 +1,12 @@
 import {BeaconConfig} from "@lodestar/config";
 import {ForkName, SYNC_COMMITTEE_SIZE} from "@lodestar/params";
 import {BeaconBlock, ValidatorIndex, altair, rewards} from "@lodestar/types";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
+import {PubkeyCache} from "../cache/pubkeyCache.js";
 import {CachedBeaconStateAllForks, CachedBeaconStateAltair} from "../cache/stateCache.js";
 
 export async function computeSyncCommitteeRewards(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
+  pubkeyCache: PubkeyCache,
   block: BeaconBlock,
   preState: CachedBeaconStateAllForks,
   validatorIds: (ValidatorIndex | string)[] = []
@@ -47,9 +47,10 @@ export async function computeSyncCommitteeRewards(
 
   if (validatorIds.length) {
     const filtersSet = new Set(validatorIds);
-    return rewards.filter(
-      (reward) => filtersSet.has(reward.validatorIndex) || filtersSet.has(index2pubkey[reward.validatorIndex].toHex())
-    );
+    return rewards.filter((reward) => {
+      const pubkeyHex = pubkeyCache.get(reward.validatorIndex)?.toHex();
+      return filtersSet.has(reward.validatorIndex) || (pubkeyHex !== undefined && filtersSet.has(pubkeyHex));
+    });
   }
 
   return rewards;

--- a/packages/state-transition/src/signatureSets/proposer.ts
+++ b/packages/state-transition/src/signatureSets/proposer.ts
@@ -1,17 +1,17 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_BEACON_PROPOSER} from "@lodestar/params";
 import {SignedBeaconBlock, SignedBlindedBeaconBlock, Slot, isBlindedBeaconBlock, phase0, ssz} from "@lodestar/types";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
+import {PubkeyCache} from "../cache/pubkeyCache.js";
 import {computeSigningRoot} from "../util/index.js";
 import {ISignatureSet, SignatureSetType, verifySignatureSet} from "../util/signatureSets.js";
 
 export function verifyProposerSignature(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
+  pubkeyCache: PubkeyCache,
   signedBlock: SignedBeaconBlock | SignedBlindedBeaconBlock
 ): boolean {
   const signatureSet = getBlockProposerSignatureSet(config, signedBlock);
-  return verifySignatureSet(signatureSet, index2pubkey);
+  return verifySignatureSet(signatureSet, pubkeyCache);
 }
 
 export function getBlockProposerSignatureSet(

--- a/packages/state-transition/src/signatureSets/randao.ts
+++ b/packages/state-transition/src/signatureSets/randao.ts
@@ -1,7 +1,7 @@
 import {BeaconConfig} from "@lodestar/config";
 import {DOMAIN_RANDAO} from "@lodestar/params";
 import {BeaconBlock, ssz} from "@lodestar/types";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
+import {PubkeyCache} from "../cache/pubkeyCache.js";
 import {
   ISignatureSet,
   SignatureSetType,
@@ -10,12 +10,8 @@ import {
   verifySignatureSet,
 } from "../util/index.js";
 
-export function verifyRandaoSignature(
-  config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
-  block: BeaconBlock
-): boolean {
-  return verifySignatureSet(getRandaoRevealSignatureSet(config, block), index2pubkey);
+export function verifyRandaoSignature(config: BeaconConfig, pubkeyCache: PubkeyCache, block: BeaconBlock): boolean {
+  return verifySignatureSet(getRandaoRevealSignatureSet(config, block), pubkeyCache);
 }
 
 /**

--- a/packages/state-transition/src/signatureSets/voluntaryExits.ts
+++ b/packages/state-transition/src/signatureSets/voluntaryExits.ts
@@ -1,6 +1,6 @@
 import {BeaconConfig} from "@lodestar/config";
 import {SignedBeaconBlock, Slot, phase0, ssz} from "@lodestar/types";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
+import {PubkeyCache} from "../cache/pubkeyCache.js";
 import {
   ISignatureSet,
   SignatureSetType,
@@ -11,11 +11,11 @@ import {
 
 export function verifyVoluntaryExitSignature(
   config: BeaconConfig,
-  index2pubkey: Index2PubkeyCache,
+  pubkeyCache: PubkeyCache,
   stateSlot: Slot,
   signedVoluntaryExit: phase0.SignedVoluntaryExit
 ): boolean {
-  return verifySignatureSet(getVoluntaryExitSignatureSet(config, stateSlot, signedVoluntaryExit), index2pubkey);
+  return verifySignatureSet(getVoluntaryExitSignatureSet(config, stateSlot, signedVoluntaryExit), pubkeyCache);
 }
 
 /**

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -112,7 +112,7 @@ export function stateTransition(
   postState = processSlotsWithTransientCache(postState, blockSlot, options, {metrics, validatorMonitor});
 
   // Verify proposer signature only
-  if (verifyProposer && !verifyProposerSignature(postState.config, postState.epochCtx.index2pubkey, signedBlock)) {
+  if (verifyProposer && !verifyProposerSignature(postState.config, postState.epochCtx.pubkeyCache, signedBlock)) {
     throw new Error("Invalid block signature");
   }
 

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -31,7 +31,7 @@ import {VoluntaryExitValidity, getVoluntaryExitValidity} from "../block/processV
 import {getExpectedWithdrawals} from "../block/processWithdrawals.js";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";
 import {EpochTransitionCacheOpts} from "../cache/epochTransitionCache.js";
-import {PubkeyCache, createPubkeyCache} from "../cache/pubkeyCache.ts";
+import {PubkeyCache, createPubkeyCache} from "../cache/pubkeyCache.js";
 import {RewardCache} from "../cache/rewardCache.js";
 import {
   CachedBeaconStateAllForks,

--- a/packages/state-transition/src/util/signatureSets.ts
+++ b/packages/state-transition/src/util/signatureSets.ts
@@ -57,20 +57,12 @@ export function getSignatureSetPubkey(signatureSet: ISignatureSet, pubkeyCache: 
       return signatureSet.pubkey;
 
     case SignatureSetType.indexed: {
-      const pubkey = pubkeyCache.get(signatureSet.index);
-      if (!pubkey) {
-        throw Error(`Missing pubkey for validator index ${signatureSet.index}`);
-      }
-      return pubkey;
+      return pubkeyCache.getOrThrow(signatureSet.index);
     }
 
     case SignatureSetType.aggregate: {
       const pubkeys = signatureSet.indices.map((i) => {
-        const pubkey = pubkeyCache.get(i);
-        if (!pubkey) {
-          throw Error(`Missing pubkey for validator index ${i}`);
-        }
-        return pubkey;
+        return pubkeyCache.getOrThrow(i);
       });
       return aggregatePublicKeys(pubkeys);
     }
@@ -96,10 +88,7 @@ export function verifySignatureSet(signatureSet: ISignatureSet, pubkeyCache?: Pu
       if (!pubkeyCache) {
         throw Error("pubkeyCache required for indexed signature set");
       }
-      const pubkey = pubkeyCache.get(signatureSet.index);
-      if (!pubkey) {
-        throw Error(`Missing pubkey for validator index ${signatureSet.index}`);
-      }
+      const pubkey = pubkeyCache.getOrThrow(signatureSet.index);
       return verify(signatureSet.signingRoot, pubkey, signature);
     }
 
@@ -108,11 +97,7 @@ export function verifySignatureSet(signatureSet: ISignatureSet, pubkeyCache?: Pu
         throw Error("pubkeyCache required for aggregate signature set");
       }
       const pubkeys = signatureSet.indices.map((i) => {
-        const pk = pubkeyCache.get(i);
-        if (!pk) {
-          throw Error(`Missing pubkey for validator index ${i}`);
-        }
-        return pk;
+        return pubkeyCache.getOrThrow(i);
       });
       return fastAggregateVerify(signatureSet.signingRoot, pubkeys, signature);
     }

--- a/packages/state-transition/src/util/signatureSets.ts
+++ b/packages/state-transition/src/util/signatureSets.ts
@@ -1,6 +1,6 @@
 import {PublicKey, Signature, aggregatePublicKeys, fastAggregateVerify, verify} from "@chainsafe/blst";
 import {Root} from "@lodestar/types";
-import {Index2PubkeyCache} from "../cache/pubkeyCache.js";
+import {PubkeyCache} from "../cache/pubkeyCache.js";
 
 export enum SignatureSetType {
   single = "single",
@@ -49,18 +49,29 @@ export type ISignatureSet = SingleSignatureSet | IndexedSignatureSet | Aggregate
 
 /**
  * Get the pubkey for a signature set, performing aggregation if necessary.
- * Requires index2pubkey cache for indexed and aggregate sets.
+ * Requires pubkeyCache for indexed and aggregate sets.
  */
-export function getSignatureSetPubkey(signatureSet: ISignatureSet, index2pubkey: Index2PubkeyCache): PublicKey {
+export function getSignatureSetPubkey(signatureSet: ISignatureSet, pubkeyCache: PubkeyCache): PublicKey {
   switch (signatureSet.type) {
     case SignatureSetType.single:
       return signatureSet.pubkey;
 
-    case SignatureSetType.indexed:
-      return index2pubkey[signatureSet.index];
+    case SignatureSetType.indexed: {
+      const pubkey = pubkeyCache.get(signatureSet.index);
+      if (!pubkey) {
+        throw Error(`Missing pubkey for validator index ${signatureSet.index}`);
+      }
+      return pubkey;
+    }
 
     case SignatureSetType.aggregate: {
-      const pubkeys = signatureSet.indices.map((i) => index2pubkey[i]);
+      const pubkeys = signatureSet.indices.map((i) => {
+        const pubkey = pubkeyCache.get(i);
+        if (!pubkey) {
+          throw Error(`Missing pubkey for validator index ${i}`);
+        }
+        return pubkey;
+      });
       return aggregatePublicKeys(pubkeys);
     }
 
@@ -69,11 +80,11 @@ export function getSignatureSetPubkey(signatureSet: ISignatureSet, index2pubkey:
   }
 }
 
-export function verifySignatureSet(signatureSet: SingleSignatureSet, index2pubkey?: Index2PubkeyCache): boolean;
-export function verifySignatureSet(signatureSet: IndexedSignatureSet, index2pubkey: Index2PubkeyCache): boolean;
-export function verifySignatureSet(signatureSet: AggregatedSignatureSet, index2pubkey: Index2PubkeyCache): boolean;
-export function verifySignatureSet(signatureSet: ISignatureSet, index2pubkey: Index2PubkeyCache): boolean;
-export function verifySignatureSet(signatureSet: ISignatureSet, index2pubkey?: Index2PubkeyCache): boolean {
+export function verifySignatureSet(signatureSet: SingleSignatureSet, pubkeyCache?: PubkeyCache): boolean;
+export function verifySignatureSet(signatureSet: IndexedSignatureSet, pubkeyCache: PubkeyCache): boolean;
+export function verifySignatureSet(signatureSet: AggregatedSignatureSet, pubkeyCache: PubkeyCache): boolean;
+export function verifySignatureSet(signatureSet: ISignatureSet, pubkeyCache: PubkeyCache): boolean;
+export function verifySignatureSet(signatureSet: ISignatureSet, pubkeyCache?: PubkeyCache): boolean {
   // All signatures are not trusted and must be group checked (p2.subgroup_check)
   const signature = Signature.fromBytes(signatureSet.signature, true);
 
@@ -82,17 +93,27 @@ export function verifySignatureSet(signatureSet: ISignatureSet, index2pubkey?: I
       return verify(signatureSet.signingRoot, signatureSet.pubkey, signature);
 
     case SignatureSetType.indexed: {
-      if (!index2pubkey) {
-        throw Error("index2pubkey required for indexed signature set");
+      if (!pubkeyCache) {
+        throw Error("pubkeyCache required for indexed signature set");
       }
-      return verify(signatureSet.signingRoot, index2pubkey[signatureSet.index], signature);
+      const pubkey = pubkeyCache.get(signatureSet.index);
+      if (!pubkey) {
+        throw Error(`Missing pubkey for validator index ${signatureSet.index}`);
+      }
+      return verify(signatureSet.signingRoot, pubkey, signature);
     }
 
     case SignatureSetType.aggregate: {
-      if (!index2pubkey) {
-        throw Error("index2pubkey required for aggregate signature set");
+      if (!pubkeyCache) {
+        throw Error("pubkeyCache required for aggregate signature set");
       }
-      const pubkeys = signatureSet.indices.map((i) => index2pubkey[i]);
+      const pubkeys = signatureSet.indices.map((i) => {
+        const pk = pubkeyCache.get(i);
+        if (!pk) {
+          throw Error(`Missing pubkey for validator index ${i}`);
+        }
+        return pk;
+      });
       return fastAggregateVerify(signatureSet.signingRoot, pubkeys, signature);
     }
 

--- a/packages/state-transition/test/perf/util.ts
+++ b/packages/state-transition/test/perf/util.ts
@@ -1,5 +1,4 @@
 import {PublicKey, SecretKey} from "@chainsafe/blst";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {BitArray, fromHexString} from "@chainsafe/ssz";
 import {createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
@@ -19,6 +18,7 @@ import {
   computeCommitteeCount,
   computeEpochAtSlot,
   createCachedBeaconState,
+  createPubkeyCache,
   interopSecretKey,
   newFilledArray,
   processSlots,
@@ -84,32 +84,21 @@ export function getSecretKeyFromIndexCached(validatorIndex: number): SecretKey {
   return sk;
 }
 
-function getPubkeyCaches({pubkeysMod, pubkeysModObj}: ReturnType<typeof getPubkeys>) {
+function getPubkeyCaches({pubkeysMod}: ReturnType<typeof getPubkeys>) {
   // Manually sync pubkeys to prevent doing BLS opts 110_000 times
-  const pubkey2index = new PubkeyIndexMap();
-  const index2pubkey = [] as PublicKey[];
+  const pubkeyCache = createPubkeyCache();
   for (let i = 0; i < numValidators; i++) {
     const pubkey = pubkeysMod[i % keypairsMod];
-    const pubkeyObj = pubkeysModObj[i % keypairsMod];
-    pubkey2index.set(pubkey, i);
-    index2pubkey.push(pubkeyObj);
+    pubkeyCache.set(i, pubkey);
   }
 
-  // Since most pubkeys are equal the size of pubkey2index is not numValidators.
-  // Fill with junk up to numValidators
-  for (let i = pubkey2index.size; i < numValidators; i++) {
-    const buf = Buffer.alloc(48, 0);
-    buf.writeInt32LE(i);
-    pubkey2index.set(buf, i);
-  }
-
-  return {pubkey2index, index2pubkey};
+  return {pubkeyCache};
 }
 
 export function generatePerfTestCachedStatePhase0(opts?: {goBackOneSlot: boolean}): CachedBeaconStatePhase0 {
   // Generate only some publicKeys
   const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys();
-  const {pubkey2index, index2pubkey} = getPubkeyCaches({pubkeys, pubkeysMod, pubkeysModObj});
+  const {pubkeyCache} = getPubkeyCaches({pubkeys, pubkeysMod, pubkeysModObj});
 
   if (!phase0State) {
     const state = buildPerformanceStatePhase0();
@@ -126,8 +115,7 @@ export function generatePerfTestCachedStatePhase0(opts?: {goBackOneSlot: boolean
     state.slot -= 1;
     phase0CachedState23637 = createCachedBeaconState(state, {
       config: createBeaconConfig(config, state.genesisValidatorsRoot),
-      pubkey2index,
-      index2pubkey,
+      pubkeyCache,
     });
 
     const currentEpoch = computeEpochAtSlot(state.slot - 1);
@@ -219,7 +207,7 @@ export function generatePerfTestCachedStateAltair(opts?: {
   vc?: number;
 }): CachedBeaconStateAltair {
   const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys(opts?.vc);
-  const {pubkey2index, index2pubkey} = getPubkeyCaches({pubkeys, pubkeysMod, pubkeysModObj});
+  const {pubkeyCache} = getPubkeyCaches({pubkeys, pubkeysMod, pubkeysModObj});
 
   const altairConfig = createChainForkConfig({ALTAIR_FORK_EPOCH: 0});
 
@@ -230,8 +218,7 @@ export function generatePerfTestCachedStateAltair(opts?: {
     state.slot -= 1;
     altairCachedState23637 = createCachedBeaconState(state, {
       config: createBeaconConfig(altairConfig, state.genesisValidatorsRoot),
-      pubkey2index,
-      index2pubkey,
+      pubkeyCache,
     });
   }
   if (!altairCachedState23638) {
@@ -389,16 +376,13 @@ export function generateTestCachedBeaconStateOnlyValidators({
   slot: Slot;
 }): CachedBeaconStateAllForks {
   // Generate only some publicKeys
-  const {pubkeys, pubkeysMod, pubkeysModObj} = getPubkeys(vc);
+  const {pubkeys, pubkeysMod} = getPubkeys(vc);
 
   // Manually sync pubkeys to prevent doing BLS opts 110_000 times
-  const pubkey2index = new PubkeyIndexMap();
-  const index2pubkey = [] as PublicKey[];
+  const pubkeyCache = createPubkeyCache();
   for (let i = 0; i < vc; i++) {
     const pubkey = pubkeysMod[i % keypairsMod];
-    const pubkeyObj = pubkeysModObj[i % keypairsMod];
-    pubkey2index.set(pubkey, i);
-    index2pubkey.push(pubkeyObj);
+    pubkeyCache.set(i, pubkey);
   }
 
   const state = ssz.phase0.BeaconState.defaultViewDU();
@@ -438,8 +422,7 @@ export function generateTestCachedBeaconStateOnlyValidators({
     state,
     {
       config: createBeaconConfig(config, state.genesisValidatorsRoot),
-      pubkey2index,
-      index2pubkey,
+      pubkeyCache,
     },
     {skipSyncPubkeys: true}
   );

--- a/packages/state-transition/test/perf/util/loadState/loadState.test.ts
+++ b/packages/state-transition/test/perf/util/loadState/loadState.test.ts
@@ -1,7 +1,5 @@
 import {bench, describe} from "@chainsafe/benchmark";
-import {PublicKey} from "@chainsafe/blst";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
-import {Index2PubkeyCache} from "../../../../src/cache/pubkeyCache.js";
+import {PubkeyCache, createPubkeyCache} from "../../../../src/cache/pubkeyCache.js";
 import {createCachedBeaconState} from "../../../../src/cache/stateCache.js";
 import {loadState} from "../../../../src/util/loadState/loadState.js";
 import {generatePerfTestCachedStateAltair} from "../../util.js";
@@ -49,21 +47,18 @@ describe("loadState", () => {
         migratedState.hashTreeRoot();
         // Get the validators sub tree once for all the loop
         const validators = migratedState.validators;
-        const pubkey2index = new PubkeyIndexMap();
-        const index2pubkey: Index2PubkeyCache = [];
+        const pubkeyCache: PubkeyCache = createPubkeyCache();
         for (const validatorIndex of modifiedValidators) {
           const validator = validators.getReadonly(validatorIndex);
           const pubkey = validator.pubkey;
-          pubkey2index.set(pubkey, validatorIndex);
-          index2pubkey[validatorIndex] = PublicKey.fromBytes(pubkey);
+          pubkeyCache.set(validatorIndex, pubkey);
         }
         const shufflingGetter = () => seedState.epochCtx.currentShuffling;
         createCachedBeaconState(
           migratedState,
           {
             config: seedState.config,
-            pubkey2index,
-            index2pubkey,
+            pubkeyCache,
           },
           {skipSyncPubkeys: true, skipSyncCommitteeCache: true, shufflingGetter}
         );

--- a/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
+++ b/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
@@ -48,7 +48,7 @@ describe("validate indexed attestation", () => {
     expect(
       isValidIndexedAttestation(
         state.config,
-        state.epochCtx.index2pubkey,
+        state.epochCtx.pubkeyCache,
         state.slot,
         state.validators.length,
         indexedAttestation,

--- a/packages/state-transition/test/unit/cachedBeaconState.test.ts
+++ b/packages/state-transition/test/unit/cachedBeaconState.test.ts
@@ -1,10 +1,10 @@
 import {describe, expect, it, vi} from "vitest";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {fromHexString} from "@chainsafe/ssz";
 import {createBeaconConfig} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
 import {Epoch, RootHex, ssz} from "@lodestar/types";
 import {toHexString} from "@lodestar/utils";
+import {createPubkeyCache} from "../../src/cache/pubkeyCache.js";
 import {createCachedBeaconState, loadCachedBeaconState} from "../../src/cache/stateCache.js";
 import {EpochShuffling, calculateShufflingDecisionRoot} from "../../src/util/epochShuffling.js";
 import {modifyStateSameValidator, newStateWithValidators} from "../utils/capella.js";
@@ -92,8 +92,7 @@ describe("CachedBeaconState", () => {
       stateView,
       {
         config,
-        pubkey2index: new PubkeyIndexMap(),
-        index2pubkey: [],
+        pubkeyCache: createPubkeyCache(),
       },
       {skipSyncCommitteeCache: true}
     );
@@ -195,8 +194,7 @@ describe("CachedBeaconState", () => {
           state,
           {
             config,
-            pubkey2index: new PubkeyIndexMap(),
-            index2pubkey: [],
+            pubkeyCache: createPubkeyCache(),
           },
           {skipSyncCommitteeCache: true, shufflingGetter}
         );
@@ -207,8 +205,8 @@ describe("CachedBeaconState", () => {
 
         // confirm loadCachedBeaconState() result
         for (let i = 0; i < newCachedState.validators.length; i++) {
-          expect(newCachedState.epochCtx.pubkey2index.get(newCachedState.validators.get(i).pubkey)).toBe(i);
-          expect(newCachedState.epochCtx.index2pubkey[i].toBytes()).toEqual(pubkeys[i]);
+          expect(newCachedState.epochCtx.getValidatorIndex(newCachedState.validators.get(i).pubkey)).toBe(i);
+          expect(newCachedState.epochCtx.pubkeyCache.get(i)?.toBytes()).toEqual(pubkeys[i]);
         }
       });
     }

--- a/packages/state-transition/test/unit/upgradeState.test.ts
+++ b/packages/state-transition/test/unit/upgradeState.test.ts
@@ -1,9 +1,9 @@
 import {describe, expect, it} from "vitest";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {ChainForkConfig, createBeaconConfig, createChainForkConfig} from "@lodestar/config";
 import {config as chainConfig} from "@lodestar/config/default";
 import {ForkName} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
+import {createPubkeyCache} from "../../src/cache/pubkeyCache.js";
 import {createCachedBeaconState} from "../../src/cache/stateCache.js";
 import {upgradeStateToDeneb} from "../../src/slot/upgradeStateToDeneb.js";
 import {upgradeStateToElectra} from "../../src/slot/upgradeStateToElectra.js";
@@ -16,8 +16,7 @@ describe("upgradeState", () => {
       capellaState,
       {
         config: createBeaconConfig(config, capellaState.genesisValidatorsRoot),
-        pubkey2index: new PubkeyIndexMap(),
-        index2pubkey: [],
+        pubkeyCache: createPubkeyCache(),
       },
       {skipSyncCommitteeCache: true}
     );
@@ -31,8 +30,7 @@ describe("upgradeState", () => {
       denebState,
       {
         config: createBeaconConfig(config, denebState.genesisValidatorsRoot),
-        pubkey2index: new PubkeyIndexMap(),
-        index2pubkey: [],
+        pubkeyCache: createPubkeyCache(),
       },
       {skipSyncCommitteeCache: true}
     );

--- a/packages/state-transition/test/unit/util/cachedBeaconState.test.ts
+++ b/packages/state-transition/test/unit/util/cachedBeaconState.test.ts
@@ -1,9 +1,8 @@
 import {describe, it} from "vitest";
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {createBeaconConfig} from "@lodestar/config";
 import {config} from "@lodestar/config/default";
 import {ssz} from "@lodestar/types";
-import {createCachedBeaconState} from "../../../src/index.js";
+import {createCachedBeaconState, createPubkeyCache} from "../../../src/index.js";
 
 describe("CachedBeaconState", () => {
   it("Create empty CachedBeaconState", () => {
@@ -11,8 +10,7 @@ describe("CachedBeaconState", () => {
 
     createCachedBeaconState(emptyState, {
       config: createBeaconConfig(config, emptyState.genesisValidatorsRoot),
-      pubkey2index: new PubkeyIndexMap(),
-      index2pubkey: [],
+      pubkeyCache: createPubkeyCache(),
     });
   });
 });

--- a/packages/state-transition/test/utils/state.ts
+++ b/packages/state-transition/test/utils/state.ts
@@ -1,4 +1,3 @@
-import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {config, config as minimalConfig} from "@lodestar/config/default";
 import {
@@ -17,6 +16,7 @@ import {
   BeaconStatePhase0,
   CachedBeaconStateAllForks,
   createCachedBeaconState,
+  createPubkeyCache,
 } from "../../src/index.js";
 import {newZeroedArray} from "../../src/util/index.js";
 
@@ -89,8 +89,7 @@ export function generateCachedState(
   return createCachedBeaconState(state, {
     config: createBeaconConfig(config, state.genesisValidatorsRoot),
     // This is a test state, there's no need to have a global shared cache of keys
-    pubkey2index: new PubkeyIndexMap(),
-    index2pubkey: [],
+    pubkeyCache: createPubkeyCache(),
   });
 }
 
@@ -104,8 +103,7 @@ export function createCachedBeaconStateTest<T extends BeaconStateAllForks>(
     {
       config: createBeaconConfig(configCustom, state.genesisValidatorsRoot),
       // This is a test state, there's no need to have a global shared cache of keys
-      pubkey2index: new PubkeyIndexMap(),
-      index2pubkey: [],
+      pubkeyCache: createPubkeyCache(),
     },
     opts
   );


### PR DESCRIPTION
- helpful towards lodestar-z integration
- combining index2pubkey and pubkey2index allows them to stay synchronized by construction