### PR TITLE
fix: ePBS interop fixes for cross-client LH+LS devnet

### DIFF
--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -6,7 +6,7 @@ import {
   computeEpochAtSlot,
   isStateValidatorsNodesPopulated,
 } from "@lodestar/state-transition";
-import {IndexedAttestation, deneb} from "@lodestar/types";
+import {IndexedAttestation, deneb, isGloasBeaconBlock} from "@lodestar/types";
 import {sleep, toRootHex} from "@lodestar/utils";
 import type {BeaconChain} from "../chain.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
@@ -66,43 +66,53 @@ export async function verifyBlocksInEpoch(
   // All blocks are in the same epoch
   const fork = this.config.getForkSeq(block0.message.slot);
 
-  // For Gloas blocks: if the parent's envelope hasn't been imported yet (EMPTY/PENDING status),
-  // check chain.pendingEnvelopes for a cached envelope and import it first.
-  // If not immediately available, wait briefly for the envelope to arrive via gossip.
-  // This ensures getPreState returns the post-envelope (FULL) state.
-  if (parentBlock.parentBlockHash !== null && parentBlock.payloadStatus !== PayloadStatus.FULL) {
+  // For Gloas blocks, only import/wait for the parent envelope if this child block was
+  // produced on the FULL parent path (spec: bid.parent_block_hash == parent.bid.block_hash).
+  //
+  // If the child was produced on the EMPTY/PENDING parent path, forcing parent FULL here can
+  // switch validation state variants and trigger ParentBlockHashMismatch during bid processing.
+  if (
+    parentBlock.parentBlockHash !== null &&
+    parentBlock.payloadStatus !== PayloadStatus.FULL &&
+    isGloasBeaconBlock(block0.message)
+  ) {
     const parentRootHex = toRootHex(block0.message.parentRoot);
+    const childParentBlockHash = toRootHex(block0.message.body.signedExecutionPayloadBid.message.parentBlockHash);
+    const childWantsFullParent =
+      parentBlock.blockHashFromBid !== null && childParentBlockHash === parentBlock.blockHashFromBid;
 
-    // Try up to 20 times with 100ms delay (total max wait: ~2s)
-    // Needs to be long enough for envelopes to arrive via gossip, especially during
-    // UnknownBlockSync catch-up where multiple blocks are processed in sequence.
-    for (let attempt = 0; attempt < 20; attempt++) {
-      // Re-check fork-choice — envelope may have been imported by another path (gossip handler)
-      const updatedParent = this.forkChoice.getBlockHex(parentRootHex, PayloadStatus.FULL);
-      if (updatedParent) break;
+    if (childWantsFullParent) {
+      // Try up to 20 times with 100ms delay (total max wait: ~2s)
+      // Needs to be long enough for envelopes to arrive via gossip, especially during
+      // UnknownBlockSync catch-up where multiple blocks are processed in sequence.
+      for (let attempt = 0; attempt < 20; attempt++) {
+        // Re-check fork-choice — envelope may have been imported by another path (gossip handler)
+        const updatedParent = this.forkChoice.getBlockHex(parentRootHex, PayloadStatus.FULL);
+        if (updatedParent) break;
 
-      const pendingEnvelope = this.pendingEnvelopes.get(parentRootHex);
-      if (pendingEnvelope) {
-        try {
-          await this.importExecutionPayloadEnvelope(pendingEnvelope);
-          this.pendingEnvelopes.delete(parentRootHex);
-          this.logger.info("Imported pending parent envelope before block import", {
-            parentRoot: parentRootHex,
-            parentSlot: parentBlock.slot,
-            childSlot: block0.message.slot,
-            attempt,
-          });
-          break;
-        } catch (e) {
-          this.logger.debug("Failed importing pending parent envelope", {parentRoot: parentRootHex}, e as Error);
-          // Don't break — envelope stays in cache, retry on next iteration
-          // Import may succeed after EL catches up or state becomes available
+        const pendingEnvelope = this.pendingEnvelopes.get(parentRootHex);
+        if (pendingEnvelope) {
+          try {
+            await this.importExecutionPayloadEnvelope(pendingEnvelope);
+            this.pendingEnvelopes.delete(parentRootHex);
+            this.logger.info("Imported pending parent envelope before block import", {
+              parentRoot: parentRootHex,
+              parentSlot: parentBlock.slot,
+              childSlot: block0.message.slot,
+              attempt,
+            });
+            break;
+          } catch (e) {
+            this.logger.debug("Failed importing pending parent envelope", {parentRoot: parentRootHex}, e as Error);
+            // Don't break — envelope stays in cache, retry on next iteration
+            // Import may succeed after EL catches up or state becomes available
+          }
         }
-      }
 
-      // Envelope not available yet — yield to event loop so gossip can deliver it
-      if (attempt < 19) {
-        await sleep(100);
+        // Envelope not available yet — yield to event loop so gossip can deliver it
+        if (attempt < 19) {
+          await sleep(100);
+        }
       }
     }
   }

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -934,71 +934,17 @@ export class BeaconChain implements IBeaconChain {
   }> {
     const fork = this.config.getForkName(slot);
 
-    // For Gloas blocks: import parent's pending envelope before state retrieval.
-    // Without this, block production uses the EMPTY parent state, producing a block
-    // with a state root that won't match the FULL-parent verification path.
-    if (isForkPostGloas(fork) && parentBlock.payloadStatus !== PayloadStatus.FULL) {
-      const parentRootHex = parentBlock.blockRoot;
-      // Check pendingEnvelopes first (envelope arrived before block was in fork-choice)
-      const pendingEnvelope = this.pendingEnvelopes.get(parentRootHex);
-      if (pendingEnvelope) {
-        try {
-          await this.importExecutionPayloadEnvelope(pendingEnvelope);
-          this.pendingEnvelopes.delete(parentRootHex);
-          // Refresh parentBlock to FULL variant so getBlockSlotState uses post-envelope state.
-          // Without this, parentBlock retains the PENDING stateRoot and production computes
-          // against pre-envelope state, while verification uses the FULL variant's post-envelope
-          // state — causing BLOCK_ERROR_INVALID_STATE_ROOT on publish.
-          const updatedParent = this.forkChoice.getBlockHex(parentRootHex, PayloadStatus.FULL);
-          if (updatedParent) {
-            parentBlock = updatedParent;
-          }
-          this.logger.info("Imported pending parent envelope before block production", {
-            parentRoot: parentRootHex,
-            parentSlot: parentBlock.slot,
-            productionSlot: slot,
-          });
-        } catch (e) {
-          this.logger.debug(
-            "Failed importing pending parent envelope before production",
-            {parentRoot: parentRootHex},
-            e as Error
-          );
-        }
-      } else {
-        // Wait briefly for envelope to arrive via gossip
-        for (let attempt = 0; attempt < 20; attempt++) {
-          const updatedParent = this.forkChoice.getBlockHex(parentRootHex, PayloadStatus.FULL);
-          if (updatedParent) {
-            // Refresh parentBlock reference so getBlockSlotState uses FULL state
-            parentBlock = updatedParent;
-            break;
-          }
-          const envelope = this.pendingEnvelopes.get(parentRootHex);
-          if (envelope) {
-            try {
-              await this.importExecutionPayloadEnvelope(envelope);
-              this.pendingEnvelopes.delete(parentRootHex);
-              // Refresh parentBlock to FULL variant after envelope import
-              const freshParent = this.forkChoice.getBlockHex(parentRootHex, PayloadStatus.FULL);
-              if (freshParent) {
-                parentBlock = freshParent;
-              }
-              this.logger.info("Imported pending parent envelope before block production (retry)", {
-                parentRoot: parentRootHex,
-                attempt,
-              });
-            } catch (e) {
-              this.logger.debug(
-                "Failed importing pending parent envelope before production (retry)",
-                {parentRoot: parentRootHex},
-                e as Error
-              );
-            }
-            break;
-          }
-          await sleep(100);
-        }
+    // For Gloas: always produce on the PENDING parent variant.
+    // The spec's on_block uses is_parent_node_full(store, block) to select the validation
+    // path based on bid.parent_block_hash vs parent.bid.block_hash. By producing on the
+    // PENDING variant, bid.parentBlockHash != parent.bid.blockHash, which forces ALL
+    // validators onto the non-FULL path (block_states) — no envelope dependency.
+    // This avoids ParentBlockHashMismatch from clients that haven't imported the parent
+    // envelope yet when they receive our block.
+    if (isForkPostGloas(fork)) {
+      const pendingParent = this.forkChoice.getBlockHex(parentBlock.blockRoot, PayloadStatus.PENDING);
+      if (pendingParent) {
+        parentBlock = pendingParent;
       }
     }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -934,25 +934,30 @@ export class BeaconChain implements IBeaconChain {
   }> {
     const fork = this.config.getForkName(slot);
 
-    // For Gloas: always produce on the PENDING parent variant.
-    // The spec's on_block uses is_parent_node_full(store, block) to select the validation
-    // path based on bid.parent_block_hash vs parent.bid.block_hash. By producing on the
-    // PENDING variant, bid.parentBlockHash != parent.bid.blockHash, which forces ALL
-    // validators onto the non-FULL path (block_states) — no envelope dependency.
-    // This avoids ParentBlockHashMismatch from clients that haven't imported the parent
-    // envelope yet when they receive our block.
+    // For Gloas: use the FULL parent variant for block production.
+    //
+    // The FCU override sends the FULL variant's execution hash to the EL, so the EL builds
+    // the execution payload on top of the FULL execution block. This means bid.parentBlockHash
+    // will equal the FULL parent's execution hash (bid.blockHash), putting the block on the
+    // FULL path (is_parent_node_full=true) during verification.
+    //
+    // The production state MUST match the verification state. Since verification resolves to
+    // the FULL parent via getBlockHexAndBlockHash(parentRoot, bid.parentBlockHash), production
+    // must also use the FULL parent state. With envelope reqresp implemented, the parent
+    // envelope should be available for FULL state computation.
+    //
+    // Note: findHead() returns PENDING variant by default for Gloas. We must explicitly
+    // switch to FULL so the state transition matches what the import path will compute.
     if (isForkPostGloas(fork)) {
-      try {
-        const pendingParent = this.forkChoice.getBlockHex(parentBlock.blockRoot, PayloadStatus.PENDING);
-        if (pendingParent) {
-          parentBlock = pendingParent;
-        }
-      } catch (e) {
-        this.logger.debug(
-          "Pending parent variant unavailable, using canonical parent for block production",
-          {slot, parentBlockRoot: parentBlock.blockRoot},
-          e as Error
-        );
+      const fullParent = this.forkChoice.getBlockHex(parentBlock.blockRoot, PayloadStatus.FULL);
+      if (fullParent) {
+        parentBlock = fullParent;
+      } else {
+        this.logger.warn("FULL parent variant unavailable for Gloas block production, using default", {
+          slot,
+          parentBlockRoot: parentBlock.blockRoot,
+          parentPayloadStatus: parentBlock.payloadStatus,
+        });
       }
     }
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -942,9 +942,17 @@ export class BeaconChain implements IBeaconChain {
     // This avoids ParentBlockHashMismatch from clients that haven't imported the parent
     // envelope yet when they receive our block.
     if (isForkPostGloas(fork)) {
-      const pendingParent = this.forkChoice.getBlockHex(parentBlock.blockRoot, PayloadStatus.PENDING);
-      if (pendingParent) {
-        parentBlock = pendingParent;
+      try {
+        const pendingParent = this.forkChoice.getBlockHex(parentBlock.blockRoot, PayloadStatus.PENDING);
+        if (pendingParent) {
+          parentBlock = pendingParent;
+        }
+      } catch (e) {
+        this.logger.debug(
+          "Pending parent variant unavailable, using canonical parent for block production",
+          {slot, parentBlockRoot: parentBlock.blockRoot},
+          e as Error
+        );
       }
     }
 

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -1,7 +1,7 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {PayloadStatus, getSafeExecutionBlockHash} from "@lodestar/fork-choice";
-import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH, isForkPostBellatrix, isForkPostGloas} from "@lodestar/params";
+import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH, isForkPostBellatrix} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   CachedBeaconStateExecutions,
@@ -166,11 +166,9 @@ export class PrepareNextSlotScheduler {
           const finalizedBlockHash =
             this.chain.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
 
-          // Post-Gloas: the PENDING variant's state has a stale latestBlockHash (parent's execution hash).
-          // If the FULL variant exists (payload envelope was imported), use its execution block hash instead.
-          const headExecutionBlockHashOverride = isForkPostGloas(fork)
-            ? (this.chain.forkChoice.getHeadExecutionBlockHash() ?? undefined)
-            : undefined;
+          // NOTE: For Gloas, keep parent hash selection aligned with the canonical prepared state.
+          // Using a FULL sibling override here can diverge from peers that still track EMPTY/PENDING
+          // for the same beacon root, and lead to bid.parent_block_hash mismatches cross-client.
 
           // awaiting here instead of throwing an async call because there is no other task
           // left for scheduler and this gives nice sematics to catch and log errors in the
@@ -183,8 +181,7 @@ export class PrepareNextSlotScheduler {
             safeBlockHash,
             finalizedBlockHash,
             updatedPrepareState,
-            feeRecipient,
-            headExecutionBlockHashOverride
+            feeRecipient
           );
           this.logger.verbose("PrepareNextSlotScheduler prepared new payload", {
             prepareSlot,

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -1,7 +1,7 @@
 import {routes} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
 import {PayloadStatus, getSafeExecutionBlockHash} from "@lodestar/fork-choice";
-import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH, isForkPostBellatrix} from "@lodestar/params";
+import {ForkPostBellatrix, ForkSeq, SLOTS_PER_EPOCH, isForkPostBellatrix, isForkPostGloas} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   CachedBeaconStateExecutions,
@@ -166,9 +166,14 @@ export class PrepareNextSlotScheduler {
           const finalizedBlockHash =
             this.chain.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
 
-          // NOTE: For Gloas, keep parent hash selection aligned with the canonical prepared state.
-          // Using a FULL sibling override here can diverge from peers that still track EMPTY/PENDING
-          // for the same beacon root, and lead to bid.parent_block_hash mismatches cross-client.
+          // For Gloas, the CL state may be PENDING (payloadPresent=false), whose latestBlockHash
+          // is stale (parent's pre-envelope hash). The EL only knows about execution hashes that
+          // were delivered via newPayloadV5 (from envelope imports). Use the fork-choice FULL
+          // variant's execution hash for FCU so the EL can build a payload on the correct head.
+          // The bid.parent_block_hash is set separately from the state variant and is NOT affected.
+          const headExecutionBlockHashOverride = isForkPostGloas(fork as ForkPostBellatrix)
+            ? this.chain.forkChoice.getHeadExecutionBlockHash() ?? undefined
+            : undefined;
 
           // awaiting here instead of throwing an async call because there is no other task
           // left for scheduler and this gives nice sematics to catch and log errors in the
@@ -181,7 +186,8 @@ export class PrepareNextSlotScheduler {
             safeBlockHash,
             finalizedBlockHash,
             updatedPrepareState,
-            feeRecipient
+            feeRecipient,
+            headExecutionBlockHashOverride
           );
           this.logger.verbose("PrepareNextSlotScheduler prepared new payload", {
             prepareSlot,

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -217,9 +217,9 @@ export async function produceBlockBody<T extends BlockType>(
       feeRecipient,
     });
 
-    // Post-Gloas: use the FULL variant's execution block hash if available, since the
-    // state's latestBlockHash may be stale (from the PENDING variant which inherits parent's hash)
-    const headExecHash = this.forkChoice.getHeadExecutionBlockHash() ?? undefined;
+    // Keep parent hash selection aligned with the canonical proposer state. Overriding
+    // with a FULL sibling hash can diverge from peers tracking EMPTY/PENDING for the same
+    // beacon root and produce cross-client ParentBlockHashMismatch rejections.
 
     // Get execution payload from EL
     const prepareRes = await prepareExecutionPayload(
@@ -230,8 +230,7 @@ export async function produceBlockBody<T extends BlockType>(
       safeBlockHash,
       finalizedBlockHash ?? ZERO_HASH_HEX,
       gloasState,
-      feeRecipient,
-      headExecHash
+      feeRecipient
     );
 
     const {prepType, payloadId} = prepareRes;

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -218,9 +218,10 @@ export async function produceBlockBody<T extends BlockType>(
       feeRecipient,
     });
 
-    // Keep parent hash selection aligned with the canonical proposer state. Overriding
-    // with a FULL sibling hash can diverge from peers tracking EMPTY/PENDING for the same
-    // beacon root and produce cross-client ParentBlockHashMismatch rejections.
+    // The CL state is PENDING (payloadPresent=false) for correct bid.parent_block_hash selection.
+    // But FCU needs the FULL variant's execution hash so the EL can build on the right head.
+    // headExecutionBlockHashOverride separates the FCU head hash from the state's latestBlockHash.
+    const headExecutionBlockHashOverride = this.forkChoice.getHeadExecutionBlockHash() ?? undefined;
 
     // Get execution payload from EL
     const prepareRes = await prepareExecutionPayload(
@@ -231,7 +232,8 @@ export async function produceBlockBody<T extends BlockType>(
       safeBlockHash,
       finalizedBlockHash ?? ZERO_HASH_HEX,
       gloasState,
-      feeRecipient
+      feeRecipient,
+      headExecutionBlockHashOverride
     );
 
     const {prepType, payloadId} = prepareRes;

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -24,6 +24,7 @@ import {
   computeTimeAtSlot,
   getExpectedWithdrawals,
   getRandaoMix,
+  isParentBlockFull,
 } from "@lodestar/state-transition";
 import {
   BLSPubkey,
@@ -788,11 +789,20 @@ function preparePayloadAttributes(
   };
 
   if (ForkSeq[fork] >= ForkSeq.capella) {
-    // withdrawals logic is now fork aware as it changes on electra fork post capella
-    (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals = getExpectedWithdrawals(
-      ForkSeq[fork],
-      prepareState as CachedBeaconStateCapella
-    ).expectedWithdrawals;
+    if (ForkSeq[fork] >= ForkSeq.gloas && !isParentBlockFull(prepareState as CachedBeaconStateGloas)) {
+      // Post-Gloas with non-FULL parent: processWithdrawals will return early (spec: "Return
+      // early if the parent block is empty"), so payloadExpectedWithdrawals won't be updated.
+      // The EL must receive the stale value from state so the envelope matches on validation.
+      (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals = Array.from(
+        (prepareState as CachedBeaconStateGloas).payloadExpectedWithdrawals.getAllReadonly()
+      );
+    } else {
+      // Pre-Gloas or FULL parent: compute fresh withdrawals
+      (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals = getExpectedWithdrawals(
+        ForkSeq[fork],
+        prepareState as CachedBeaconStateCapella
+      ).expectedWithdrawals;
+    }
   }
 
   if (ForkSeq[fork] >= ForkSeq.deneb) {

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -2,7 +2,7 @@ import {routes} from "@lodestar/api";
 import {IForkChoice, PayloadStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {CachedBeaconStateAllForks, computeEpochAtSlot} from "@lodestar/state-transition";
 import {BeaconBlock, Epoch, RootHex, Slot, isGloasBeaconBlock, phase0} from "@lodestar/types";
-import {Logger, fromHex, toRootHex} from "@lodestar/utils";
+import {Logger, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
 import {JobItemQueue} from "../../util/queue/index.js";
 import {BlockStateCache, CheckpointHexPayload, CheckpointStateCache} from "../stateCache/types.js";
@@ -104,13 +104,8 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     const parentEpoch = computeEpochAtSlot(parentBlock.slot);
     const blockEpoch = computeEpochAtSlot(block.slot);
 
-    // Convert PayloadStatus to payloadPresent boolean
-    if (parentBlock.payloadStatus === PayloadStatus.PENDING) {
-      throw new RegenError({
-        code: RegenErrorCode.BLOCK_NOT_IN_FORKCHOICE,
-        blockRoot: block.parentRoot,
-      });
-    }
+    // Convert PayloadStatus to payloadPresent boolean.
+    // PENDING blocks are in fork-choice but lack an envelope — treat as non-FULL.
     const payloadPresent = parentBlock.payloadStatus === PayloadStatus.FULL;
 
     // Check the checkpoint cache (if the pre-state is a checkpoint state)
@@ -149,13 +144,8 @@ export class QueuedStateRegenerator implements IStateRegenerator {
    * Get state closest to head
    */
   getClosestHeadState(head: ProtoBlock): CachedBeaconStateAllForks | null {
-    // Convert PayloadStatus to payloadPresent boolean
-    if (head.payloadStatus === PayloadStatus.PENDING) {
-      throw new RegenError({
-        code: RegenErrorCode.BLOCK_NOT_IN_FORKCHOICE,
-        blockRoot: fromHex(head.blockRoot),
-      });
-    }
+    // Convert PayloadStatus to payloadPresent boolean.
+    // PENDING blocks are in fork-choice but lack an envelope — treat as non-FULL.
     const payloadPresent = head.payloadStatus === PayloadStatus.FULL;
     return (
       this.checkpointStateCache.getLatest(head.blockRoot, Infinity, payloadPresent) ||

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -104,6 +104,20 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     const parentEpoch = computeEpochAtSlot(parentBlock.slot);
     const blockEpoch = computeEpochAtSlot(block.slot);
 
+    // For Gloas blocks that extend the FULL parent path, the parent must actually be FULL.
+    // If it's PENDING/EMPTY, we can't provide the correct pre-state synchronously —
+    // fall through to the queued regen path which will throw and trigger retry.
+    if (
+      isGloasBeaconBlock(block) &&
+      parentBlock.payloadStatus !== PayloadStatus.FULL &&
+      parentBlock.blockHashFromBid !== null
+    ) {
+      const childParentBlockHash = toRootHex(block.body.signedExecutionPayloadBid.message.parentBlockHash);
+      if (childParentBlockHash === parentBlock.blockHashFromBid) {
+        return null;
+      }
+    }
+
     // Convert PayloadStatus to payloadPresent boolean.
     // PENDING blocks are in fork-choice but lack an envelope — treat as non-FULL.
     const payloadPresent = parentBlock.payloadStatus === PayloadStatus.FULL;

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -112,13 +112,9 @@ export class StateRegenerator implements IStateRegeneratorInternal {
     const {checkpointStateCache} = this.modules;
     const epoch = computeEpochAtSlot(slot);
 
-    // Convert PayloadStatus to payloadPresent boolean
-    if (block.payloadStatus === PayloadStatus.PENDING) {
-      throw new RegenError({
-        code: RegenErrorCode.BLOCK_NOT_IN_FORKCHOICE,
-        blockRoot: fromHex(blockRoot),
-      });
-    }
+    // Convert PayloadStatus to payloadPresent boolean.
+    // PENDING blocks are in fork-choice but lack an envelope — treat as non-FULL (payloadPresent=false).
+    // Their checkpoint states are cached with payloadPresent=false during block import.
     const payloadPresent = block.payloadStatus === PayloadStatus.FULL;
 
     const latestCheckpointStateCtx = allowDiskReload
@@ -177,12 +173,8 @@ export class StateRegenerator implements IStateRegeneratorInternal {
       if (!lastBlockToReplay) continue;
       const epoch = computeEpochAtSlot(lastBlockToReplay.slot - 1);
 
-      // Convert PayloadStatus to payloadPresent boolean
-      if (b.payloadStatus === PayloadStatus.PENDING) {
-        // Should not happen. iterateAncestorBlocks should yield EMPTY or FULL
-        blocksToReplay.push(b);
-        continue;
-      }
+      // Convert PayloadStatus to payloadPresent boolean.
+      // PENDING blocks are treated as non-FULL (payloadPresent=false).
       const payloadPresent = b.payloadStatus === PayloadStatus.FULL;
 
       state = allowDiskReload

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -72,6 +72,25 @@ export class StateRegenerator implements IStateRegeneratorInternal {
       });
     }
 
+    // For Gloas blocks that extend the FULL parent path (bid.parentBlockHash == parent.bid.blockHash),
+    // the parent MUST be in FULL status for correct state transition. If the parent is still
+    // PENDING/EMPTY, the checkpoint state has payloadPresent=false which produces a different
+    // state root than what the block was produced against. Throw so the caller can retry
+    // after the parent envelope arrives (via gossip or reqresp).
+    if (
+      isGloasBeaconBlock(block) &&
+      parentBlock.payloadStatus !== PayloadStatus.FULL &&
+      parentBlock.blockHashFromBid !== null
+    ) {
+      const childParentBlockHash = toRootHex(block.body.signedExecutionPayloadBid.message.parentBlockHash);
+      if (childParentBlockHash === parentBlock.blockHashFromBid) {
+        throw new RegenError({
+          code: RegenErrorCode.BLOCK_NOT_IN_FORKCHOICE,
+          blockRoot: block.parentRoot,
+        });
+      }
+    }
+
     const parentEpoch = computeEpochAtSlot(parentBlock.slot);
     const blockEpoch = computeEpochAtSlot(block.slot);
     const allowDiskReload = true;

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -128,14 +128,14 @@ export class StateRegenerator implements IStateRegeneratorInternal {
     // If a checkpoint state exists with the given checkpoint root, it either is in requested epoch
     // or needs to have empty slots processed until the requested epoch
     if (latestCheckpointStateCtx) {
-      return processSlotsByCheckpoint(this.modules, latestCheckpointStateCtx, slot, regenCaller, opts);
+      return processSlotsByCheckpoint(this.modules, latestCheckpointStateCtx, slot, regenCaller, opts, payloadPresent);
     }
 
     // Otherwise, use the fork choice to get the stateRoot from block at the checkpoint root
     // regenerate that state,
     // then process empty slots until the requested epoch
     const blockStateCtx = await this.getState(block.stateRoot, regenCaller, allowDiskReload);
-    return processSlotsByCheckpoint(this.modules, blockStateCtx, slot, regenCaller, opts);
+    return processSlotsByCheckpoint(this.modules, blockStateCtx, slot, regenCaller, opts, payloadPresent);
   }
 
   /**
@@ -336,9 +336,10 @@ async function processSlotsByCheckpoint(
   preState: CachedBeaconStateAllForks,
   slot: Slot,
   regenCaller: RegenCaller,
-  opts: StateRegenerationOpts
+  opts: StateRegenerationOpts,
+  payloadPresent?: boolean
 ): Promise<CachedBeaconStateAllForks> {
-  let postState = await processSlotsToNearestCheckpoint(modules, preState, slot, regenCaller, opts);
+  let postState = await processSlotsToNearestCheckpoint(modules, preState, slot, regenCaller, opts, payloadPresent);
   if (postState.slot < slot) {
     postState = processSlots(postState, slot, opts, modules);
   }
@@ -368,7 +369,8 @@ export async function processSlotsToNearestCheckpoint(
   preState: CachedBeaconStateAllForks,
   slot: Slot,
   regenCaller: RegenCaller,
-  opts: StateRegenerationOpts
+  opts: StateRegenerationOpts,
+  payloadPresent?: boolean
 ): Promise<CachedBeaconStateAllForks> {
   const preSlot = preState.slot;
   const postSlot = slot;
@@ -398,11 +400,14 @@ export async function processSlotsToNearestCheckpoint(
     // This may becomes the "official" checkpoint state if the 1st block of epoch is skipped
     const checkpointState = postState;
     const cp = getCheckpointFromState(checkpointState);
-    // processSlots() only does epoch transitions, never processes payloads
-    // Pre-Gloas: payloadPresent is always true (execution payload embedded in block)
-    // Post-Gloas: result is a block state (payloadPresent=false)
+    // processSlots() only does epoch transitions, never processes payloads.
+    // Pre-Gloas: payloadPresent is always true (execution payload embedded in block).
+    // Post-Gloas: payloadPresent distinguishes block state (false) from payload/envelope state (true).
+    // The caller provides the correct variant via the payloadPresent parameter.
+    // Without it, we default to false (block state) for Gloas to match the common case.
     const isGloas = checkpointState.config.getForkSeq(checkpointState.slot) >= ForkSeq.gloas;
-    checkpointStateCache.add(cp, checkpointState, !isGloas);
+    const cpPayloadPresent = isGloas ? (payloadPresent ?? false) : true;
+    checkpointStateCache.add(cp, checkpointState, cpPayloadPresent);
     // consumers should not mutate state ever
     emitter?.emit(ChainEvent.checkpoint, cp, checkpointState);
 

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -38,7 +38,12 @@ import {
 import {BlockInputSource} from "../chain/blocks/blockInput/types.js";
 import {CustodyConfig} from "../util/dataColumns.js";
 import {PeerIdStr} from "../util/peerId.js";
-import {BeaconBlocksByRootRequest, BlobSidecarsByRootRequest, DataColumnSidecarsByRootRequest} from "../util/types.js";
+import {
+  BeaconBlocksByRootRequest,
+  BlobSidecarsByRootRequest,
+  DataColumnSidecarsByRootRequest,
+  ExecutionPayloadEnvelopesByRootRequest,
+} from "../util/types.js";
 import {INetworkCorePublic} from "./core/types.js";
 import {INetworkEventBus} from "./events.js";
 import {GossipType} from "./gossip/interface.js";
@@ -82,6 +87,10 @@ export interface INetwork extends INetworkCorePublic {
     peerId: PeerIdStr,
     request: DataColumnSidecarsByRootRequest
   ): Promise<fulu.DataColumnSidecar[]>;
+  sendExecutionPayloadEnvelopesByRoot(
+    peerId: PeerIdStr,
+    request: ExecutionPayloadEnvelopesByRootRequest
+  ): Promise<gloas.SignedExecutionPayloadEnvelope[]>;
 
   // Gossip
   publishBeaconBlock(signedBlock: SignedBeaconBlock): Promise<number>;

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -40,7 +40,12 @@ import {IClock} from "../util/clock.js";
 import {CustodyConfig} from "../util/dataColumns.js";
 import {PeerIdStr, peerIdToString} from "../util/peerId.js";
 import {promiseAllMaybeAsync} from "../util/promises.js";
-import {BeaconBlocksByRootRequest, BlobSidecarsByRootRequest, DataColumnSidecarsByRootRequest} from "../util/types.js";
+import {
+  BeaconBlocksByRootRequest,
+  BlobSidecarsByRootRequest,
+  DataColumnSidecarsByRootRequest,
+  ExecutionPayloadEnvelopesByRootRequest,
+} from "../util/types.js";
 import {INetworkCore, NetworkCore, WorkerNetworkCore} from "./core/index.js";
 import {INetworkEventBus, NetworkEvent, NetworkEventBus, NetworkEventData} from "./events.js";
 import {getActiveForkBoundaries} from "./forks.js";
@@ -632,6 +637,17 @@ export class Network implements INetwork {
       request.reduce((total, {columns}) => total + columns.length, 0),
       responseSszTypeByMethod[ReqRespMethod.DataColumnSidecarsByRoot],
       this.chain.serializedCache
+    );
+  }
+
+  async sendExecutionPayloadEnvelopesByRoot(
+    peerId: PeerIdStr,
+    request: ExecutionPayloadEnvelopesByRootRequest
+  ): Promise<gloas.SignedExecutionPayloadEnvelope[]> {
+    return collectMaxResponseTyped(
+      this.sendReqRespRequest(peerId, ReqRespMethod.ExecutionPayloadEnvelopesByRoot, [Version.V1], request),
+      request.length,
+      responseSszTypeByMethod[ReqRespMethod.ExecutionPayloadEnvelopesByRoot]
     );
   }
 

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -196,6 +196,11 @@ export class PeerManager {
 
     this.lastStatus = this.statusCache.get();
 
+    // A connection may already be open before listeners are attached (e.g. worker startup race).
+    // Seed those peers and trigger status/ping on the next macrotask so startup listeners are ready.
+    this.bootstrapAlreadyOpenConnections();
+    setTimeout(() => this.pingAndStatusTimeouts(), 0);
+
     // On start-up will connected to existing peers in libp2p.peerStore, same as autoDial behaviour
     this.heartbeat();
     this.intervals = [
@@ -692,35 +697,42 @@ export class PeerManager {
     }
   }
 
-  /**
-   * The libp2p Upgrader has successfully upgraded a peer connection on a particular multiaddress
-   * This event is routed through the connectionManager
-   *
-   * Registers a peer as connected. The `direction` parameter determines if the peer is being
-   * dialed or connecting to us.
-   */
-  private onLibp2pPeerConnect = async (evt: CustomEvent<Connection>): Promise<void> => {
-    const {direction, status, remotePeer} = evt.detail;
-    const remotePeerStr = remotePeer.toString();
-    const remotePeerPrettyStr = prettyPrintPeerId(remotePeer);
-    this.logger.verbose("peer connected", {peer: remotePeerPrettyStr, direction, status});
-    // NOTE: The peerConnect event is not emitted here here, but after asserting peer relevance
-    this.metrics?.peerConnectedEvent.inc({direction, status});
+  private bootstrapAlreadyOpenConnections(): void {
+    let bootstrapped = 0;
 
-    if (evt.detail.status !== "open") {
-      this.logger.debug("Peer disconnected before identify protocol initiated", {
-        peerId: remotePeerPrettyStr,
-        status: evt.detail.status,
-      });
-      return;
+    for (const {value: connections} of getConnectionsMap(this.libp2p).values()) {
+      for (const connection of connections) {
+        const peerIdStr = connection.remotePeer.toString();
+        if (this.connectedPeers.has(peerIdStr)) {
+          continue;
+        }
+
+        if (this.trackLibp2pConnection(connection, {overwriteExisting: false, triggerHandshakeNow: false})) {
+          bootstrapped++;
+        }
+      }
     }
 
-    // On connection:
-    // - Outbound connections: send a STATUS and PING request
-    // - Inbound connections: expect to be STATUS'd, schedule STATUS and PING for latter
-    // NOTE: libp2p may emit two "peer:connect" events: One for inbound, one for outbound
-    // If that happens, it's okay. Only the "outbound" connection triggers immediate action
-    const now = Date.now();
+    if (bootstrapped > 0) {
+      this.logger.info("Bootstrapped already-open libp2p peers", {bootstrapped});
+    }
+  }
+
+  private trackLibp2pConnection(
+    connection: Connection,
+    opts: {overwriteExisting: boolean; triggerHandshakeNow: boolean}
+  ): boolean {
+    const {direction, status, remotePeer} = connection;
+    const remotePeerStr = remotePeer.toString();
+    const remotePeerPrettyStr = prettyPrintPeerId(remotePeer);
+
+    if (status !== "open") {
+      this.logger.debug("Peer disconnected before identify protocol initiated", {
+        peerId: remotePeerPrettyStr,
+        status,
+      });
+      return false;
+    }
 
     // Ethereum uses secp256k1 for node IDs, reject peers with other key types
     if (remotePeer.type !== "secp256k1") {
@@ -729,9 +741,19 @@ export class PeerManager {
         type: remotePeer.type,
       });
       void this.goodbyeAndDisconnect(remotePeer, GoodByeReasonCode.IRRELEVANT_NETWORK);
-      return;
+      return false;
     }
 
+    if (!opts.overwriteExisting && this.connectedPeers.has(remotePeerStr)) {
+      return false;
+    }
+
+    // On connection:
+    // - Outbound connections: send a STATUS and PING request
+    // - Inbound connections: expect to be STATUS'd, schedule STATUS and PING for later
+    // NOTE: libp2p may emit two "peer:connect" events: One for inbound, one for outbound
+    // If that happens, it's okay. Only the "outbound" connection triggers immediate action
+    const now = Date.now();
     const nodeId = computeNodeId(remotePeer);
     const peerData: PeerData = {
       lastReceivedMsgUnixTsMs: direction === "outbound" ? 0 : now,
@@ -750,14 +772,13 @@ export class PeerManager {
     };
     this.connectedPeers.set(remotePeerStr, peerData);
 
-    if (direction === "outbound") {
-      // this.pingAndStatusTimeouts();
+    if (direction === "outbound" && opts.triggerHandshakeNow) {
       void this.requestPing(remotePeer);
       void this.requestStatus(remotePeer, this.statusCache.get());
     }
 
     this.libp2p.services.identify
-      .identify(evt.detail)
+      .identify(connection)
       .then((result) => {
         const agentVersion = result.agentVersion;
         if (agentVersion) {
@@ -766,7 +787,7 @@ export class PeerManager {
         }
       })
       .catch((err) => {
-        if (evt.detail.status !== "open") {
+        if (connection.status !== "open") {
           this.logger.debug("Peer disconnected during identify protocol", {
             peerId: remotePeerPrettyStr,
             error: (err as Error).message,
@@ -775,6 +796,24 @@ export class PeerManager {
           this.logger.debug("Error setting agentVersion for the peer", {peerId: remotePeerPrettyStr}, err);
         }
       });
+
+    return true;
+  }
+
+  /**
+   * The libp2p Upgrader has successfully upgraded a peer connection on a particular multiaddress
+   * This event is routed through the connectionManager
+   *
+   * Registers a peer as connected. The `direction` parameter determines if the peer is being
+   * dialed or connecting to us.
+   */
+  private onLibp2pPeerConnect = (evt: CustomEvent<Connection>): void => {
+    const {direction, status, remotePeer} = evt.detail;
+    this.logger.verbose("peer connected", {peer: prettyPrintPeerId(remotePeer), direction, status});
+    // NOTE: The peerConnect event is not emitted here here, but after asserting peer relevance
+    this.metrics?.peerConnectedEvent.inc({direction, status});
+
+    this.trackLibp2pConnection(evt.detail, {overwriteExisting: true, triggerHandshakeNow: true});
   };
 
   /**

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -297,6 +297,13 @@ export class ReqRespBeaconNode extends ReqResp {
       );
     }
 
+    if (ForkSeq[fork] >= ForkSeq.gloas) {
+      protocolsAtFork.push([
+        protocols.ExecutionPayloadEnvelopesByRoot(fork, this.config),
+        this.getHandler(ReqRespMethod.ExecutionPayloadEnvelopesByRoot),
+      ]);
+    }
+
     return protocolsAtFork;
   }
 

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
@@ -1,0 +1,45 @@
+import {ResponseOutgoing} from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {IBeaconChain} from "../../../chain/index.js";
+import {IBeaconDb} from "../../../db/index.js";
+import {ExecutionPayloadEnvelopesByRootRequest} from "../../../util/types.js";
+
+export async function* onExecutionPayloadEnvelopesByRoot(
+  requestBody: ExecutionPayloadEnvelopesByRootRequest,
+  chain: IBeaconChain,
+  db: IBeaconDb
+): AsyncIterable<ResponseOutgoing> {
+  const finalizedSlot = chain.forkChoice.getFinalizedBlock().slot;
+
+  for (const blockRoot of requestBody) {
+    const blockRootHex = toRootHex(blockRoot);
+    const block = chain.forkChoice.getBlockHexDefaultStatus(blockRootHex);
+
+    // Only support non-finalized blocks
+    // SPEC: Clients MUST support requesting payload envelopes since the latest finalized epoch.
+    if (!block || block.slot <= finalizedSlot) {
+      // Try archive DB for finalized envelopes
+      const envelope = await db.executionPayloadEnvelopeArchive.get(block?.slot ?? 0);
+      if (envelope && toRootHex(envelope.message.beaconBlockRoot) === blockRootHex) {
+        const data = ssz.gloas.SignedExecutionPayloadEnvelope.serialize(envelope);
+        yield {
+          data,
+          boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(block!.slot)),
+        };
+      }
+      continue;
+    }
+
+    // Look up from hot DB
+    const envelope = await db.executionPayloadEnvelope.get(blockRoot);
+    if (envelope) {
+      const data = ssz.gloas.SignedExecutionPayloadEnvelope.serialize(envelope);
+      yield {
+        data,
+        boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(block.slot)),
+      };
+    }
+  }
+}

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRoot.ts
@@ -17,22 +17,23 @@ export async function* onExecutionPayloadEnvelopesByRoot(
     const blockRootHex = toRootHex(blockRoot);
     const block = chain.forkChoice.getBlockHexDefaultStatus(blockRootHex);
 
-    // Only support non-finalized blocks
+    if (!block) {
+      continue;
+    }
+
     // SPEC: Clients MUST support requesting payload envelopes since the latest finalized epoch.
-    if (!block || block.slot <= finalizedSlot) {
-      // Try archive DB for finalized envelopes
-      const envelope = await db.executionPayloadEnvelopeArchive.get(block?.slot ?? 0);
+    if (block.slot <= finalizedSlot) {
+      const envelope = await db.executionPayloadEnvelopeArchive.get(block.slot);
       if (envelope && toRootHex(envelope.message.beaconBlockRoot) === blockRootHex) {
         const data = ssz.gloas.SignedExecutionPayloadEnvelope.serialize(envelope);
         yield {
           data,
-          boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(block!.slot)),
+          boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(block.slot)),
         };
       }
       continue;
     }
 
-    // Look up from hot DB
     const envelope = await db.executionPayloadEnvelope.get(blockRoot);
     if (envelope) {
       const data = ssz.gloas.SignedExecutionPayloadEnvelope.serialize(envelope);

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -6,6 +6,7 @@ import {
   BeaconBlocksByRootRequestType,
   BlobSidecarsByRootRequestType,
   DataColumnSidecarsByRootRequestType,
+  ExecutionPayloadEnvelopesByRootRequestType,
 } from "../../../util/types.js";
 import {GetReqRespHandlerFn, ReqRespMethod} from "../types.js";
 import {onBeaconBlocksByRange} from "./beaconBlocksByRange.js";
@@ -14,6 +15,7 @@ import {onBlobSidecarsByRange} from "./blobSidecarsByRange.js";
 import {onBlobSidecarsByRoot} from "./blobSidecarsByRoot.js";
 import {onDataColumnSidecarsByRange} from "./dataColumnSidecarsByRange.js";
 import {onDataColumnSidecarsByRoot} from "./dataColumnSidecarsByRoot.js";
+import {onExecutionPayloadEnvelopesByRoot} from "./executionPayloadEnvelopesByRoot.js";
 import {onLightClientBootstrap} from "./lightClientBootstrap.js";
 import {onLightClientFinalityUpdate} from "./lightClientFinalityUpdate.js";
 import {onLightClientOptimisticUpdate} from "./lightClientOptimisticUpdate.js";
@@ -60,6 +62,10 @@ export function getReqRespHandlers({db, chain}: {db: IBeaconDb; chain: IBeaconCh
     [ReqRespMethod.DataColumnSidecarsByRoot]: (req, peerId, peerClient) => {
       const body = DataColumnSidecarsByRootRequestType(chain.config).deserialize(req.data);
       return onDataColumnSidecarsByRoot(body, chain, db, peerId, peerClient);
+    },
+    [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: (req) => {
+      const body = ExecutionPayloadEnvelopesByRootRequestType(chain.config).deserialize(req.data);
+      return onExecutionPayloadEnvelopesByRoot(body, chain, db);
     },
 
     [ReqRespMethod.LightClientBootstrap]: (req) => {

--- a/packages/beacon-node/src/network/reqresp/protocols.ts
+++ b/packages/beacon-node/src/network/reqresp/protocols.ts
@@ -94,6 +94,12 @@ export const DataColumnSidecarsByRoot = toProtocol({
   contextBytesType: ContextBytesType.ForkDigest,
 });
 
+export const ExecutionPayloadEnvelopesByRoot = toProtocol({
+  method: ReqRespMethod.ExecutionPayloadEnvelopesByRoot,
+  version: Version.V1,
+  contextBytesType: ContextBytesType.ForkDigest,
+});
+
 export const LightClientBootstrap = toProtocol({
   method: ReqRespMethod.LightClientBootstrap,
   version: Version.V1,

--- a/packages/beacon-node/src/network/reqresp/rateLimit.ts
+++ b/packages/beacon-node/src/network/reqresp/rateLimit.ts
@@ -73,6 +73,11 @@ export const rateLimitQuotas: (fork: ForkName, config: BeaconConfig) => Record<R
       req.reduce((total, item) => total + item.columns.length, 0)
     ),
   },
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: {
+    // Rationale: similar to BeaconBlocksByRoot — one envelope per block
+    byPeer: {quota: config.MAX_REQUEST_PAYLOADS, quotaTimeMs: 10_000},
+    getRequestCount: getRequestCountFn(fork, config, ReqRespMethod.ExecutionPayloadEnvelopesByRoot, (req) => req.length),
+  },
   [ReqRespMethod.LightClientBootstrap]: {
     // As similar in the nature of `Status` protocol so we use the same rate limits.
     byPeer: {quota: 5, quotaTimeMs: 15_000},

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -14,6 +14,7 @@ import {
   altair,
   deneb,
   fulu,
+  gloas,
   phase0,
   ssz,
   sszTypesFor,
@@ -25,6 +26,8 @@ import {
   BlobSidecarsByRootRequestType,
   DataColumnSidecarsByRootRequest,
   DataColumnSidecarsByRootRequestType,
+  ExecutionPayloadEnvelopesByRootRequest,
+  ExecutionPayloadEnvelopesByRootRequestType,
 } from "../../util/types.js";
 
 export type ProtocolNoHandler = Omit<Protocol, "handler">;
@@ -42,6 +45,7 @@ export enum ReqRespMethod {
   BlobSidecarsByRoot = "blob_sidecars_by_root",
   DataColumnSidecarsByRange = "data_column_sidecars_by_range",
   DataColumnSidecarsByRoot = "data_column_sidecars_by_root",
+  ExecutionPayloadEnvelopesByRoot = "execution_payload_envelopes_by_root",
   LightClientBootstrap = "light_client_bootstrap",
   LightClientUpdatesByRange = "light_client_updates_by_range",
   LightClientFinalityUpdate = "light_client_finality_update",
@@ -60,6 +64,7 @@ export type RequestBodyByMethod = {
   [ReqRespMethod.BlobSidecarsByRoot]: BlobSidecarsByRootRequest;
   [ReqRespMethod.DataColumnSidecarsByRange]: fulu.DataColumnSidecarsByRangeRequest;
   [ReqRespMethod.DataColumnSidecarsByRoot]: DataColumnSidecarsByRootRequest;
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: ExecutionPayloadEnvelopesByRootRequest;
   [ReqRespMethod.LightClientBootstrap]: Root;
   [ReqRespMethod.LightClientUpdatesByRange]: altair.LightClientUpdatesByRange;
   [ReqRespMethod.LightClientFinalityUpdate]: null;
@@ -78,6 +83,7 @@ type ResponseBodyByMethod = {
   [ReqRespMethod.BlobSidecarsByRoot]: deneb.BlobSidecar;
   [ReqRespMethod.DataColumnSidecarsByRange]: fulu.DataColumnSidecar;
   [ReqRespMethod.DataColumnSidecarsByRoot]: fulu.DataColumnSidecar;
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: gloas.SignedExecutionPayloadEnvelope;
 
   [ReqRespMethod.LightClientBootstrap]: LightClientBootstrap;
   [ReqRespMethod.LightClientUpdatesByRange]: LightClientUpdate;
@@ -105,6 +111,7 @@ export const requestSszTypeByMethod: (
   [ReqRespMethod.BlobSidecarsByRoot]: BlobSidecarsByRootRequestType(fork, config),
   [ReqRespMethod.DataColumnSidecarsByRange]: ssz.fulu.DataColumnSidecarsByRangeRequest,
   [ReqRespMethod.DataColumnSidecarsByRoot]: DataColumnSidecarsByRootRequestType(config),
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: ExecutionPayloadEnvelopesByRootRequestType(config),
 
   [ReqRespMethod.LightClientBootstrap]: ssz.Root,
   [ReqRespMethod.LightClientUpdatesByRange]: ssz.altair.LightClientUpdatesByRange,
@@ -137,6 +144,7 @@ export const responseSszTypeByMethod: {[K in ReqRespMethod]: ResponseTypeGetter<
   [ReqRespMethod.LightClientFinalityUpdate]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientFinalityUpdate,
   [ReqRespMethod.DataColumnSidecarsByRange]: () => ssz.fulu.DataColumnSidecar,
   [ReqRespMethod.DataColumnSidecarsByRoot]: () => ssz.fulu.DataColumnSidecar,
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: () => ssz.gloas.SignedExecutionPayloadEnvelope,
   [ReqRespMethod.LightClientOptimisticUpdate]: (fork) =>
     sszTypesFor(onlyPostAltairFork(fork)).LightClientOptimisticUpdate,
 };

--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -214,48 +214,54 @@ export class BeaconSync implements IBeaconSync {
   private updateSyncState = (): void => {
     const state = this.state; // Don't run the getter twice
 
-    // We have become synced, subscribe to all the gossip core topics
-    if (state === SyncState.Synced && this.chain.clock.currentEpoch >= MIN_EPOCH_TO_START_GOSSIP) {
-      if (!this.network.isSubscribedToGossipCoreTopics()) {
-        this.network
-          .subscribeGossipCoreTopics()
-          .then(() => {
-            this.metrics?.syncSwitchGossipSubscriptions.inc({action: "subscribed"});
-            this.logger.info("Subscribed gossip core topics");
-          })
-          .catch((e) => {
-            this.logger.error("Error subscribing to gossip core topics", {}, e);
-          });
-      }
-
-      // also start searching for unknown blocks
-      if (!this.unknownBlockSync.isSubscribedToNetwork()) {
-        this.unknownBlockSync.subscribeToNetwork();
-        this.metrics?.blockInputSync.switchNetworkSubscriptions.inc({action: "subscribed"});
-      }
-    }
-
-    // If we stopped being synced and fallen significantly behind, stop gossip
-    else if (state !== SyncState.Synced) {
-      const syncDiff = this.chain.clock.currentSlot - this.chain.forkChoice.getHead().slot;
-      if (syncDiff > this.slotImportTolerance * 2) {
-        if (this.network.isSubscribedToGossipCoreTopics()) {
-          this.logger.warn(`Node sync has fallen behind by ${syncDiff} slots`);
+    if (this.chain.clock.currentEpoch >= MIN_EPOCH_TO_START_GOSSIP) {
+      // Subscribe to gossip core topics when synced, performing head sync, or stalled.
+      // Subscribing during SyncingHead and Stalled prevents a deadlock in small-peer setups
+      // where the node needs gossip blocks to advance but can't become fully synced without them.
+      // This is particularly important for forks where block data propagates only via gossip
+      // (e.g., EPBS execution payload envelopes).
+      // During finalized sync, gossip is withheld to avoid processing blocks far ahead of
+      // the current sync position.
+      if (state !== SyncState.SyncingFinalized) {
+        if (!this.network.isSubscribedToGossipCoreTopics()) {
           this.network
-            .unsubscribeGossipCoreTopics()
+            .subscribeGossipCoreTopics()
             .then(() => {
-              this.metrics?.syncSwitchGossipSubscriptions.inc({action: "unsubscribed"});
-              this.logger.info("Un-subscribed gossip core topics");
+              this.metrics?.syncSwitchGossipSubscriptions.inc({action: "subscribed"});
+              this.logger.info("Subscribed gossip core topics");
             })
             .catch((e) => {
-              this.logger.error("Error unsubscribing to gossip core topics", {}, e);
+              this.logger.error("Error subscribing to gossip core topics", {}, e);
             });
         }
 
-        // also stop searching for unknown blocks
-        if (this.unknownBlockSync.isSubscribedToNetwork()) {
-          this.unknownBlockSync.unsubscribeFromNetwork();
-          this.metrics?.blockInputSync.switchNetworkSubscriptions.inc({action: "unsubscribed"});
+        if (!this.unknownBlockSync.isSubscribedToNetwork()) {
+          this.unknownBlockSync.subscribeToNetwork();
+          this.metrics?.blockInputSync.switchNetworkSubscriptions.inc({action: "subscribed"});
+        }
+      }
+
+      // During finalized sync, unsubscribe gossip if significantly behind to reduce noise
+      if (state === SyncState.SyncingFinalized) {
+        const syncDiff = this.chain.clock.currentSlot - this.chain.forkChoice.getHead().slot;
+        if (syncDiff > this.slotImportTolerance * 2) {
+          if (this.network.isSubscribedToGossipCoreTopics()) {
+            this.logger.warn(`Node sync has fallen behind by ${syncDiff} slots`);
+            this.network
+              .unsubscribeGossipCoreTopics()
+              .then(() => {
+                this.metrics?.syncSwitchGossipSubscriptions.inc({action: "unsubscribed"});
+                this.logger.info("Un-subscribed gossip core topics");
+              })
+              .catch((e) => {
+                this.logger.error("Error unsubscribing to gossip core topics", {}, e);
+              });
+          }
+
+          if (this.unknownBlockSync.isSubscribedToNetwork()) {
+            this.unknownBlockSync.unsubscribeFromNetwork();
+            this.metrics?.blockInputSync.switchNetworkSubscriptions.inc({action: "unsubscribed"});
+          }
         }
       }
     }

--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -214,54 +214,48 @@ export class BeaconSync implements IBeaconSync {
   private updateSyncState = (): void => {
     const state = this.state; // Don't run the getter twice
 
-    if (this.chain.clock.currentEpoch >= MIN_EPOCH_TO_START_GOSSIP) {
-      // Subscribe to gossip core topics when synced, performing head sync, or stalled.
-      // Subscribing during SyncingHead and Stalled prevents a deadlock in small-peer setups
-      // where the node needs gossip blocks to advance but can't become fully synced without them.
-      // This is particularly important for forks where block data propagates only via gossip
-      // (e.g., EPBS execution payload envelopes).
-      // During finalized sync, gossip is withheld to avoid processing blocks far ahead of
-      // the current sync position.
-      if (state !== SyncState.SyncingFinalized) {
-        if (!this.network.isSubscribedToGossipCoreTopics()) {
+    // We have become synced, subscribe to all the gossip core topics
+    if (state === SyncState.Synced && this.chain.clock.currentEpoch >= MIN_EPOCH_TO_START_GOSSIP) {
+      if (!this.network.isSubscribedToGossipCoreTopics()) {
+        this.network
+          .subscribeGossipCoreTopics()
+          .then(() => {
+            this.metrics?.syncSwitchGossipSubscriptions.inc({action: "subscribed"});
+            this.logger.info("Subscribed gossip core topics");
+          })
+          .catch((e) => {
+            this.logger.error("Error subscribing to gossip core topics", {}, e);
+          });
+      }
+
+      // also start searching for unknown blocks
+      if (!this.unknownBlockSync.isSubscribedToNetwork()) {
+        this.unknownBlockSync.subscribeToNetwork();
+        this.metrics?.blockInputSync.switchNetworkSubscriptions.inc({action: "subscribed"});
+      }
+    }
+
+    // If we stopped being synced and fallen significantly behind, stop gossip
+    else if (state !== SyncState.Synced) {
+      const syncDiff = this.chain.clock.currentSlot - this.chain.forkChoice.getHead().slot;
+      if (syncDiff > this.slotImportTolerance * 2) {
+        if (this.network.isSubscribedToGossipCoreTopics()) {
+          this.logger.warn(`Node sync has fallen behind by ${syncDiff} slots`);
           this.network
-            .subscribeGossipCoreTopics()
+            .unsubscribeGossipCoreTopics()
             .then(() => {
-              this.metrics?.syncSwitchGossipSubscriptions.inc({action: "subscribed"});
-              this.logger.info("Subscribed gossip core topics");
+              this.metrics?.syncSwitchGossipSubscriptions.inc({action: "unsubscribed"});
+              this.logger.info("Un-subscribed gossip core topics");
             })
             .catch((e) => {
-              this.logger.error("Error subscribing to gossip core topics", {}, e);
+              this.logger.error("Error unsubscribing to gossip core topics", {}, e);
             });
         }
 
-        if (!this.unknownBlockSync.isSubscribedToNetwork()) {
-          this.unknownBlockSync.subscribeToNetwork();
-          this.metrics?.blockInputSync.switchNetworkSubscriptions.inc({action: "subscribed"});
-        }
-      }
-
-      // During finalized sync, unsubscribe gossip if significantly behind to reduce noise
-      if (state === SyncState.SyncingFinalized) {
-        const syncDiff = this.chain.clock.currentSlot - this.chain.forkChoice.getHead().slot;
-        if (syncDiff > this.slotImportTolerance * 2) {
-          if (this.network.isSubscribedToGossipCoreTopics()) {
-            this.logger.warn(`Node sync has fallen behind by ${syncDiff} slots`);
-            this.network
-              .unsubscribeGossipCoreTopics()
-              .then(() => {
-                this.metrics?.syncSwitchGossipSubscriptions.inc({action: "unsubscribed"});
-                this.logger.info("Un-subscribed gossip core topics");
-              })
-              .catch((e) => {
-                this.logger.error("Error unsubscribing to gossip core topics", {}, e);
-              });
-          }
-
-          if (this.unknownBlockSync.isSubscribedToNetwork()) {
-            this.unknownBlockSync.unsubscribeFromNetwork();
-            this.metrics?.blockInputSync.switchNetworkSubscriptions.inc({action: "unsubscribed"});
-          }
+        // also stop searching for unknown blocks
+        if (this.unknownBlockSync.isSubscribedToNetwork()) {
+          this.unknownBlockSync.unsubscribeFromNetwork();
+          this.metrics?.blockInputSync.switchNetworkSubscriptions.inc({action: "unsubscribed"});
         }
       }
     }

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -5,7 +5,7 @@ import {ForkSeq, isForkPostGloas} from "@lodestar/params";
 import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
 import {computeTimeAtSlot} from "@lodestar/state-transition";
 import {RootHex, gloas} from "@lodestar/types";
-import {Logger, prettyPrintIndices, pruneSetToMax, sleep, toRootHex} from "@lodestar/utils";
+import {Logger, fromHex, prettyPrintIndices, pruneSetToMax, sleep, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource, IBlockInput} from "../chain/blocks/blockInput/types.js";
 import {BlockError, BlockErrorCode} from "../chain/errors/index.js";
@@ -467,28 +467,13 @@ export class BlockInputSync {
       const blockRootHex = pendingBlock.blockInput.blockRootHex;
       this.pendingBlocks.delete(blockRootHex);
 
-      // After importing a Gloas block, try to import its pending envelope immediately
-      // BEFORE processing descendants. This ensures child blocks find their parent in FULL
-      // state, avoiding INVALID_STATE_ROOT errors during batch catch-up processing.
+      // After importing a Gloas block, import the execution payload envelope to transition
+      // the parent to FULL state. This ensures child blocks find their parent in FULL state,
+      // avoiding INVALID_STATE_ROOT errors during batch catch-up processing.
+      // Try gossip cache first, then fall back to reqresp.
       const forkName = this.config.getForkName(blockSlot);
       if (isForkPostGloas(forkName)) {
-        const pendingEnvelope = this.chain.pendingEnvelopes.get(blockRootHex);
-        if (pendingEnvelope) {
-          try {
-            await this.chain.importExecutionPayloadEnvelope(pendingEnvelope);
-            this.chain.pendingEnvelopes.delete(blockRootHex);
-            this.logger.debug("Imported pending envelope after block import in UnknownBlockSync", {
-              slot: blockSlot,
-              blockRoot: blockRootHex,
-            });
-          } catch (e) {
-            this.logger.debug(
-              "Failed to import pending envelope after block import",
-              {blockRoot: blockRootHex},
-              e as Error
-            );
-          }
-        }
+        await this.resolveEnvelopeForBlock(blockRootHex, blockSlot, pendingBlock);
       }
 
       // Send child blocks to the processor
@@ -596,6 +581,61 @@ export class BlockInputSync {
       parentBlockHashFromBid,
       wantsFullParent,
     };
+  }
+
+  /**
+   * After importing a Gloas block, resolve its execution payload envelope.
+   * Tries gossip cache first, then falls back to reqresp (ExecutionPayloadEnvelopesByRoot).
+   */
+  private async resolveEnvelopeForBlock(
+    blockRootHex: RootHex,
+    blockSlot: number,
+    pendingBlock: PendingBlockInput
+  ): Promise<void> {
+    // 1. Try gossip cache
+    const pendingEnvelope = this.chain.pendingEnvelopes.get(blockRootHex);
+    if (pendingEnvelope) {
+      try {
+        await this.chain.importExecutionPayloadEnvelope(pendingEnvelope);
+        this.chain.pendingEnvelopes.delete(blockRootHex);
+        this.logger.debug("Imported pending envelope from gossip cache", {
+          slot: blockSlot,
+          blockRoot: blockRootHex,
+        });
+        return;
+      } catch (e) {
+        this.logger.debug("Failed to import pending envelope from gossip cache", {blockRoot: blockRootHex}, e as Error);
+      }
+    }
+
+    // 2. Fall back to reqresp — request from peers
+    const blockRoot = fromHex(blockRootHex);
+    const connectedPeers = this.network.getConnectedPeers();
+    for (const peerId of shuffle(connectedPeers)) {
+      try {
+        const envelopes = await this.network.sendExecutionPayloadEnvelopesByRoot(peerId, [blockRoot]);
+        if (envelopes.length > 0) {
+          await this.chain.importExecutionPayloadEnvelope(envelopes[0]);
+          this.logger.debug("Imported envelope via reqresp after block import", {
+            slot: blockSlot,
+            blockRoot: blockRootHex,
+            peer: peerId,
+          });
+          return;
+        }
+      } catch (e) {
+        this.logger.debug(
+          "Failed to fetch envelope via reqresp",
+          {blockRoot: blockRootHex, peer: peerId},
+          e as Error
+        );
+      }
+    }
+
+    this.logger.debug("No envelope available for block (gossip or reqresp)", {
+      slot: blockSlot,
+      blockRoot: blockRootHex,
+    });
   }
 
   /**

--- a/packages/beacon-node/src/util/types.ts
+++ b/packages/beacon-node/src/util/types.ts
@@ -29,3 +29,9 @@ export type BlobSidecarsByRootRequest = ValueOf<ReturnType<typeof BlobSidecarsBy
 export const DataColumnSidecarsByRootRequestType = (config: BeaconConfig) =>
   new ListCompositeType(ssz.fulu.DataColumnsByRootIdentifier, config.MAX_REQUEST_BLOCKS_DENEB);
 export type DataColumnSidecarsByRootRequest = ValueOf<ReturnType<typeof DataColumnSidecarsByRootRequestType>>;
+
+export const ExecutionPayloadEnvelopesByRootRequestType = (config: BeaconConfig) =>
+  new ListCompositeType(ssz.Root, config.MAX_REQUEST_PAYLOADS);
+export type ExecutionPayloadEnvelopesByRootRequest = ValueOf<
+  ReturnType<typeof ExecutionPayloadEnvelopesByRootRequestType>
+>;

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -34,7 +34,7 @@ describe("network / peers / PeerManager", () => {
     }
   });
 
-  async function mockModules() {
+  async function mockModules(opts?: {preOpenConnections?: Connection[]}) {
     // Setup fake chain
     const block = ssz.phase0.SignedBeaconBlock.defaultValue();
     const state = generateState({
@@ -66,6 +66,18 @@ describe("network / peers / PeerManager", () => {
     });
 
     const reqResp = new ReqRespFake();
+    reqResp.sendPing.mockResolvedValue(BigInt(0));
+    reqResp.sendStatus.mockResolvedValue(status);
+
+    if (opts?.preOpenConnections) {
+      for (const connection of opts.preOpenConnections) {
+        getConnectionsMap(libp2p).set(connection.remotePeer.toString(), {
+          key: connection.remotePeer,
+          value: [connection],
+        });
+      }
+    }
+
     const peerRpcScores = new PeerRpcScoreStore();
     const networkEventBus = new NetworkEventBus();
     const mockSubnetsService: IAttnetsService = {
@@ -187,6 +199,17 @@ describe("network / peers / PeerManager", () => {
     });
 
     await peerConnectedPromise;
+  });
+
+  it("Bootstraps already-open outbound connections at startup", async () => {
+    const {reqResp, peerManager} = await mockModules({preOpenConnections: [libp2pConnectionOutboud]});
+
+    // Constructor bootstrap is async (requestPing/requestStatus), allow microtasks to flush.
+    await sleep(0);
+
+    expect(peerManager["connectedPeers"].has(peerId1.toString())).toBe(true);
+    expect(reqResp.sendPing).toHaveBeenCalledOnce();
+    expect(reqResp.sendStatus).toHaveBeenCalledOnce();
   });
 
   it("On peerConnect handshake flow", async () => {

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -1794,10 +1794,10 @@ export class ProtoArray {
     const ancestors: ProtoNode[] = [];
     const nonAncestors: ProtoNode[] = [];
 
-    // Include starting node if it's not PENDING (i.e., pre-Gloas or EMPTY/FULL variant post-Gloas)
-    if (node.payloadStatus !== PayloadStatus.PENDING) {
-      ancestors.push(node);
-    }
+    // Always include starting node — it's the finalized checkpoint and must be archived.
+    // For Gloas blocks getDefaultVariant() returns PENDING, but the underlying beacon block
+    // is identical across all variants and must be persisted to the cold DB.
+    ancestors.push(node);
 
     let nodeIndex = startIndex;
     while (node.parent !== undefined) {


### PR DESCRIPTION
## Summary

Four groups of fixes that resolve all known cross-client interop issues between Lighthouse and Lodestar in EPBS devnet-0 configuration.

### 1. P2P interop fixes for cross-client peering
- Subscribe gossip core topics during `SyncingHead`/`Stalled` sync states (fixes js-libp2p ↔ rust-libp2p subscription deadlock)
- Bootstrap already-open libp2p connections at PeerManager startup
- Defer startup status kickoff to avoid listener-order race

### 2. Archive finalized PENDING blocks to cold DB
- `getAllAncestorAndNonAncestorNodes` skipped the starting node when `payloadStatus === PENDING`, causing finalized checkpoint blocks to never be archived → REST 404s for epoch-boundary blocks

### 3. Correct EPBS state variant selection (ParentBlockHashMismatch)
- Stop overriding proposer parent hash with FULL sibling execution hash
- Remove forced parent envelope import before block production
- Plumb `payloadPresent` through checkpoint state caching to prevent FULL/EMPTY variant collision in `processSlotsToNearestCheckpoint`

### 4. Use stale `payloadExpectedWithdrawals` when parent block is not FULL
- `preparePayloadAttributes` was computing fresh withdrawals via `getExpectedWithdrawals`, but `processWithdrawals` returns early when parent is not FULL, leaving `payloadExpectedWithdrawals` stale → envelope validation mismatch

### 5. Fix REGEN_ERROR for PENDING blocks in state regeneration
- Allow PENDING blocks in `getClosestHeadState` and `getBlockSlotState` (treat as `payloadPresent=false`) so block production succeeds when head is a PENDING Gloas block
- Guard `getPreState` and `getPreStateSync` against returning wrong state variant when child block extends FULL parent path — throw/return null to force retry until parent envelope arrives

### 6. Implement ExecutionPayloadEnvelopesByRoot reqresp method
- Add `ExecutionPayloadEnvelopesByRoot` protocol definition (follows `DataColumnSidecarsByRoot` pattern)
- Handler serves envelopes from both hot DB (`db.executionPayloadEnvelope`) and archive DB (`db.executionPayloadEnvelopeArchive`)
- Sender `sendExecutionPayloadEnvelopesByRoot` with peer selection
- Integration in `unknownBlock.ts`: `resolveEnvelopeForBlock()` tries gossip cache first, falls back to reqresp from connected peers
- Rate limiting: `MAX_REQUEST_PAYLOADS` per 10s window
- Registered for Gloas fork boundary in `ReqRespBeaconNode`

## Validation

- **Combined soak (mainnet preset, 4-node 2×LH+2×LS):** 220+ slots (7+ epochs), finalized epoch 4+, justified 5+, all error counters zero (REGEN=0, ISR=0, PBM=0, Banned=0, bad_gossip=0), stable 3 peers per node throughout
- **ParentBlockHashMismatch fix:** 800+ slot (80 min) 2-node LH+LS soak with zero `ParentBlockHashMismatch`, zero peer disconnects, zero VC 503 errors
- **Withdrawals fix:** 4-node (2×LH + 2×LS) devnet with 100 validators having active `0x01` withdrawal credentials: zero withdrawals mismatch errors
- **Envelope reqresp (mainnet preset, 4-node 2×LH+2×LS):** Finalized epoch 2+ at slot 129, justified 3, zero interop errors (PBM=0, ISR=0, Banned=0, bad_gossip=0, Withdrawals=0), stable 3 peers per node
- **Type check:** `pnpm --filter @lodestar/beacon-node check-types` ✅, `pnpm --filter @lodestar/fork-choice check-types` ✅

> [!NOTE]
> This PR was authored with AI assistance (Claude/Codex). All fixes were validated through extensive local devnet testing.