### PR TITLE
fix: bootstrap already-open libp2p connections at PeerManager startup

### DIFF
--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -196,6 +196,11 @@ export class PeerManager {
 
     this.lastStatus = this.statusCache.get();
 
+    // A connection may already be open before listeners are attached.
+    // Seed those peers and trigger status/ping on the next macrotask.
+    this.bootstrapAlreadyOpenConnections();
+    setTimeout(() => this.pingAndStatusTimeouts(), 0);
+
     // On start-up will connected to existing peers in libp2p.peerStore, same as autoDial behaviour
     this.heartbeat();
     this.intervals = [
@@ -692,35 +697,42 @@ export class PeerManager {
     }
   }
 
-  /**
-   * The libp2p Upgrader has successfully upgraded a peer connection on a particular multiaddress
-   * This event is routed through the connectionManager
-   *
-   * Registers a peer as connected. The `direction` parameter determines if the peer is being
-   * dialed or connecting to us.
-   */
-  private onLibp2pPeerConnect = async (evt: CustomEvent<Connection>): Promise<void> => {
-    const {direction, status, remotePeer} = evt.detail;
-    const remotePeerStr = remotePeer.toString();
-    const remotePeerPrettyStr = prettyPrintPeerId(remotePeer);
-    this.logger.verbose("peer connected", {peer: remotePeerPrettyStr, direction, status});
-    // NOTE: The peerConnect event is not emitted here here, but after asserting peer relevance
-    this.metrics?.peerConnectedEvent.inc({direction, status});
+  private bootstrapAlreadyOpenConnections(): void {
+    let bootstrapped = 0;
 
-    if (evt.detail.status !== "open") {
-      this.logger.debug("Peer disconnected before identify protocol initiated", {
-        peerId: remotePeerPrettyStr,
-        status: evt.detail.status,
-      });
-      return;
+    for (const {value: connections} of getConnectionsMap(this.libp2p).values()) {
+      for (const connection of connections) {
+        const peerIdStr = connection.remotePeer.toString();
+        if (this.connectedPeers.has(peerIdStr)) {
+          continue;
+        }
+
+        if (this.trackLibp2pConnection(connection, {overwriteExisting: false, triggerHandshakeNow: false})) {
+          bootstrapped++;
+        }
+      }
     }
 
-    // On connection:
-    // - Outbound connections: send a STATUS and PING request
-    // - Inbound connections: expect to be STATUS'd, schedule STATUS and PING for latter
-    // NOTE: libp2p may emit two "peer:connect" events: One for inbound, one for outbound
-    // If that happens, it's okay. Only the "outbound" connection triggers immediate action
-    const now = Date.now();
+    if (bootstrapped > 0) {
+      this.logger.info("Bootstrapped already-open libp2p peers", {bootstrapped});
+    }
+  }
+
+  private trackLibp2pConnection(
+    connection: Connection,
+    opts: {overwriteExisting: boolean; triggerHandshakeNow: boolean}
+  ): boolean {
+    const {direction, status, remotePeer} = connection;
+    const remotePeerStr = remotePeer.toString();
+    const remotePeerPrettyStr = prettyPrintPeerId(remotePeer);
+
+    if (status !== "open") {
+      this.logger.debug("Peer disconnected before identify protocol initiated", {
+        peerId: remotePeerPrettyStr,
+        status,
+      });
+      return false;
+    }
 
     // Ethereum uses secp256k1 for node IDs, reject peers with other key types
     if (remotePeer.type !== "secp256k1") {
@@ -729,9 +741,19 @@ export class PeerManager {
         type: remotePeer.type,
       });
       void this.goodbyeAndDisconnect(remotePeer, GoodByeReasonCode.IRRELEVANT_NETWORK);
-      return;
+      return false;
     }
 
+    if (!opts.overwriteExisting && this.connectedPeers.has(remotePeerStr)) {
+      return false;
+    }
+
+    // On connection:
+    // - Outbound connections: send a STATUS and PING request
+    // - Inbound connections: expect to be STATUS'd, schedule STATUS and PING for later
+    // NOTE: libp2p may emit two "peer:connect" events: One for inbound, one for outbound
+    // If that happens, it's okay. Only the "outbound" connection triggers immediate action
+    const now = Date.now();
     const nodeId = computeNodeId(remotePeer);
     const peerData: PeerData = {
       lastReceivedMsgUnixTsMs: direction === "outbound" ? 0 : now,
@@ -750,14 +772,13 @@ export class PeerManager {
     };
     this.connectedPeers.set(remotePeerStr, peerData);
 
-    if (direction === "outbound") {
-      // this.pingAndStatusTimeouts();
+    if (direction === "outbound" && opts.triggerHandshakeNow) {
       void this.requestPing(remotePeer);
       void this.requestStatus(remotePeer, this.statusCache.get());
     }
 
     this.libp2p.services.identify
-      .identify(evt.detail)
+      .identify(connection)
       .then((result) => {
         const agentVersion = result.agentVersion;
         if (agentVersion) {
@@ -766,7 +787,7 @@ export class PeerManager {
         }
       })
       .catch((err) => {
-        if (evt.detail.status !== "open") {
+        if (connection.status !== "open") {
           this.logger.debug("Peer disconnected during identify protocol", {
             peerId: remotePeerPrettyStr,
             error: (err as Error).message,
@@ -775,6 +796,24 @@ export class PeerManager {
           this.logger.debug("Error setting agentVersion for the peer", {peerId: remotePeerPrettyStr}, err);
         }
       });
+
+    return true;
+  }
+
+  /**
+   * The libp2p Upgrader has successfully upgraded a peer connection on a particular multiaddress
+   * This event is routed through the connectionManager
+   *
+   * Registers a peer as connected. The `direction` parameter determines if the peer is being
+   * dialed or connecting to us.
+   */
+  private onLibp2pPeerConnect = (evt: CustomEvent<Connection>): void => {
+    const {direction, status, remotePeer} = evt.detail;
+    this.logger.verbose("peer connected", {peer: prettyPrintPeerId(remotePeer), direction, status});
+    // NOTE: The peerConnect event is not emitted here here, but after asserting peer relevance
+    this.metrics?.peerConnectedEvent.inc({direction, status});
+
+    this.trackLibp2pConnection(evt.detail, {overwriteExisting: true, triggerHandshakeNow: true});
   };
 
   /**

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -164,6 +164,7 @@ export class PeerManager {
 
   private opts: PeerManagerOpts;
   private intervals: NodeJS.Timeout[] = [];
+  private bootstrapTimeout: NodeJS.Timeout | null = null;
 
   constructor(modules: PeerManagerModules, opts: PeerManagerOpts, discovery: PeerDiscovery | null) {
     const {networkConfig} = modules;
@@ -199,7 +200,7 @@ export class PeerManager {
     // A connection may already be open before listeners are attached.
     // Seed those peers and trigger status/ping on the next macrotask.
     this.bootstrapAlreadyOpenConnections();
-    setTimeout(() => this.pingAndStatusTimeouts(), 0);
+    this.bootstrapTimeout = setTimeout(() => this.pingAndStatusTimeouts(), 0);
 
     // On start-up will connected to existing peers in libp2p.peerStore, same as autoDial behaviour
     this.heartbeat();
@@ -235,6 +236,7 @@ export class PeerManager {
     );
     this.networkEventBus.off(NetworkEvent.reqRespRequest, this.onRequest);
     for (const interval of this.intervals) clearInterval(interval);
+    if (this.bootstrapTimeout) clearTimeout(this.bootstrapTimeout);
   }
 
   /**

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -9,6 +9,7 @@ import {prettyPrintIndices, toHex, withTimeout} from "@lodestar/utils";
 import {GOODBYE_KNOWN_CODES, GoodByeReasonCode, Libp2pEvent} from "../../constants/index.js";
 import {IClock} from "../../util/clock.js";
 import {computeColumnsForCustodyGroup, getCustodyGroups} from "../../util/dataColumns.js";
+import {callInNextEventLoop} from "../../util/eventLoop.js";
 import {NetworkCoreMetrics} from "../core/metrics.js";
 import {LodestarDiscv5Opts} from "../discv5/types.js";
 import {INetworkEventBus, NetworkEvent, NetworkEventData} from "../events.js";
@@ -164,7 +165,6 @@ export class PeerManager {
 
   private opts: PeerManagerOpts;
   private intervals: NodeJS.Timeout[] = [];
-  private bootstrapTimeout: NodeJS.Timeout | null = null;
 
   constructor(modules: PeerManagerModules, opts: PeerManagerOpts, discovery: PeerDiscovery | null) {
     const {networkConfig} = modules;
@@ -200,9 +200,9 @@ export class PeerManager {
     // A connection may already be open before listeners are attached.
     // Seed those peers so they are tracked in connectedPeers immediately.
     this.bootstrapAlreadyOpenConnections();
-    // Defer status/ping to the next macrotask so the heartbeat interval and
+    // Defer status/ping to the next event loop tick so the heartbeat interval and
     // event listeners are fully registered before we begin handshakes.
-    this.bootstrapTimeout = setTimeout(() => this.pingAndStatusTimeouts(), 0);
+    callInNextEventLoop(() => this.pingAndStatusTimeouts());
 
     // On start-up will connected to existing peers in libp2p.peerStore, same as autoDial behaviour
     this.heartbeat();
@@ -238,7 +238,6 @@ export class PeerManager {
     );
     this.networkEventBus.off(NetworkEvent.reqRespRequest, this.onRequest);
     for (const interval of this.intervals) clearInterval(interval);
-    if (this.bootstrapTimeout) clearTimeout(this.bootstrapTimeout);
   }
 
   /**
@@ -714,7 +713,7 @@ export class PeerManager {
     }
 
     if (bootstrapped > 0) {
-      this.logger.info("Bootstrapped already-open libp2p peers", {bootstrapped});
+      this.logger.verbose("Bootstrapped already-open libp2p peers", {bootstrapped});
     }
   }
 

--- a/packages/beacon-node/src/network/peers/peerManager.ts
+++ b/packages/beacon-node/src/network/peers/peerManager.ts
@@ -198,8 +198,10 @@ export class PeerManager {
     this.lastStatus = this.statusCache.get();
 
     // A connection may already be open before listeners are attached.
-    // Seed those peers and trigger status/ping on the next macrotask.
+    // Seed those peers so they are tracked in connectedPeers immediately.
     this.bootstrapAlreadyOpenConnections();
+    // Defer status/ping to the next macrotask so the heartbeat interval and
+    // event listeners are fully registered before we begin handshakes.
     this.bootstrapTimeout = setTimeout(() => this.pingAndStatusTimeouts(), 0);
 
     // On start-up will connected to existing peers in libp2p.peerStore, same as autoDial behaviour
@@ -704,11 +706,7 @@ export class PeerManager {
 
     for (const {value: connections} of getConnectionsMap(this.libp2p).values()) {
       for (const connection of connections) {
-        const peerIdStr = connection.remotePeer.toString();
-        if (this.connectedPeers.has(peerIdStr)) {
-          continue;
-        }
-
+        // trackLibp2pConnection handles deduplication via overwriteExisting: false
         if (this.trackLibp2pConnection(connection, {overwriteExisting: false, triggerHandshakeNow: false})) {
           bootstrapped++;
         }

--- a/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
+++ b/packages/beacon-node/test/e2e/network/peers/peerManager.test.ts
@@ -34,7 +34,7 @@ describe("network / peers / PeerManager", () => {
     }
   });
 
-  async function mockModules() {
+  async function mockModules(opts?: {preOpenConnections?: Connection[]}) {
     // Setup fake chain
     const block = ssz.phase0.SignedBeaconBlock.defaultValue();
     const state = generateState({
@@ -66,6 +66,18 @@ describe("network / peers / PeerManager", () => {
     });
 
     const reqResp = new ReqRespFake();
+    reqResp.sendPing.mockResolvedValue(BigInt(0));
+    reqResp.sendStatus.mockResolvedValue(status);
+
+    if (opts?.preOpenConnections) {
+      for (const connection of opts.preOpenConnections) {
+        getConnectionsMap(libp2p).set(connection.remotePeer.toString(), {
+          key: connection.remotePeer,
+          value: [connection],
+        });
+      }
+    }
+
     const peerRpcScores = new PeerRpcScoreStore();
     const networkEventBus = new NetworkEventBus();
     const mockSubnetsService: IAttnetsService = {
@@ -187,6 +199,17 @@ describe("network / peers / PeerManager", () => {
     });
 
     await peerConnectedPromise;
+  });
+
+  it("Bootstraps already-open outbound connections at startup", async () => {
+    const {reqResp, peerManager} = await mockModules({preOpenConnections: [libp2pConnectionOutboud]});
+
+    // Constructor bootstrap is async (requestPing/requestStatus), allow microtasks to flush.
+    await sleep(0);
+
+    expect(peerManager["connectedPeers"].has(peerId1.toString())).toBe(true);
+    expect(reqResp.sendPing).toHaveBeenCalledOnce();
+    expect(reqResp.sendStatus).toHaveBeenCalledOnce();
   });
 
   it("On peerConnect handshake flow", async () => {


### PR DESCRIPTION
## Summary

PeerManager.connectedPeers map was empty at startup even when libp2p already had established connections (e.g., from bootnodes). This caused STATUS not being sent to peers, violating the consensus spec requirement that the dialing client MUST send a Status request upon connection.

This is the same issue addressed in PR #8770 (`bal-devnet-2`), ported to `unstable`.

## Changes

1. Extract core peer-tracking logic from `onLibp2pPeerConnect` into a reusable `trackLibp2pConnection()` helper
2. Add `bootstrapAlreadyOpenConnections()` that seeds `connectedPeers` from existing libp2p connections at init
3. Defer initial status/ping sweep via `setTimeout` to avoid listener-order race

## Test plan

- Added E2E test verifying peers connected before PeerManager init are tracked
- Type check: `pnpm --filter @lodestar/beacon-node check-types` ✅
- Validated in cross-client EPBS devnet (LH+LS): resolved immediate peer disconnect at startup

Closes https://github.com/ChainSafe/lodestar/issues/8779


> [!NOTE]
> This PR was authored with AI assistance (Claude/Codex).