### PR TITLE
fix: subscribe gossip core topics during SyncingHead and Stalled states

### DIFF
--- a/packages/beacon-node/src/sync/sync.ts
+++ b/packages/beacon-node/src/sync/sync.ts
@@ -214,48 +214,48 @@ export class BeaconSync implements IBeaconSync {
   private updateSyncState = (): void => {
     const state = this.state; // Don't run the getter twice
 
-    // We have become synced, subscribe to all the gossip core topics
-    if (state === SyncState.Synced && this.chain.clock.currentEpoch >= MIN_EPOCH_TO_START_GOSSIP) {
-      if (!this.network.isSubscribedToGossipCoreTopics()) {
-        this.network
-          .subscribeGossipCoreTopics()
-          .then(() => {
-            this.metrics?.syncSwitchGossipSubscriptions.inc({action: "subscribed"});
-            this.logger.info("Subscribed gossip core topics");
-          })
-          .catch((e) => {
-            this.logger.error("Error subscribing to gossip core topics", {}, e);
-          });
-      }
-
-      // also start searching for unknown blocks
-      if (!this.unknownBlockSync.isSubscribedToNetwork()) {
-        this.unknownBlockSync.subscribeToNetwork();
-        this.metrics?.blockInputSync.switchNetworkSubscriptions.inc({action: "subscribed"});
-      }
-    }
-
-    // If we stopped being synced and fallen significantly behind, stop gossip
-    else if (state !== SyncState.Synced) {
-      const syncDiff = this.chain.clock.currentSlot - this.chain.forkChoice.getHead().slot;
-      if (syncDiff > this.slotImportTolerance * 2) {
-        if (this.network.isSubscribedToGossipCoreTopics()) {
-          this.logger.warn(`Node sync has fallen behind by ${syncDiff} slots`);
+    if (this.chain.clock.currentEpoch >= MIN_EPOCH_TO_START_GOSSIP) {
+      // Subscribe to gossip when synced, doing head sync, or stalled.
+      // During finalized sync, keep gossip off if significantly behind.
+      if (state !== SyncState.SyncingFinalized) {
+        if (!this.network.isSubscribedToGossipCoreTopics()) {
           this.network
-            .unsubscribeGossipCoreTopics()
+            .subscribeGossipCoreTopics()
             .then(() => {
-              this.metrics?.syncSwitchGossipSubscriptions.inc({action: "unsubscribed"});
-              this.logger.info("Un-subscribed gossip core topics");
+              this.metrics?.syncSwitchGossipSubscriptions.inc({action: "subscribed"});
+              this.logger.info("Subscribed gossip core topics");
             })
             .catch((e) => {
-              this.logger.error("Error unsubscribing to gossip core topics", {}, e);
+              this.logger.error("Error subscribing to gossip core topics", {}, e);
             });
         }
 
-        // also stop searching for unknown blocks
-        if (this.unknownBlockSync.isSubscribedToNetwork()) {
-          this.unknownBlockSync.unsubscribeFromNetwork();
-          this.metrics?.blockInputSync.switchNetworkSubscriptions.inc({action: "unsubscribed"});
+        if (!this.unknownBlockSync.isSubscribedToNetwork()) {
+          this.unknownBlockSync.subscribeToNetwork();
+          this.metrics?.blockInputSync.switchNetworkSubscriptions.inc({action: "subscribed"});
+        }
+      }
+
+      if (state === SyncState.SyncingFinalized) {
+        const syncDiff = this.chain.clock.currentSlot - this.chain.forkChoice.getHead().slot;
+        if (syncDiff > this.slotImportTolerance * 2) {
+          if (this.network.isSubscribedToGossipCoreTopics()) {
+            this.logger.warn(`Node sync has fallen behind by ${syncDiff} slots`);
+            this.network
+              .unsubscribeGossipCoreTopics()
+              .then(() => {
+                this.metrics?.syncSwitchGossipSubscriptions.inc({action: "unsubscribed"});
+                this.logger.info("Un-subscribed gossip core topics");
+              })
+              .catch((e) => {
+                this.logger.error("Error unsubscribing to gossip core topics", {}, e);
+              });
+          }
+
+          if (this.unknownBlockSync.isSubscribedToNetwork()) {
+            this.unknownBlockSync.unsubscribeFromNetwork();
+            this.metrics?.blockInputSync.switchNetworkSubscriptions.inc({action: "unsubscribed"});
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

In small-peer devnets, Lodestar enters `SyncingHead`/`Stalled` sync state and does not subscribe to gossip core topics. This prevents it from receiving blocks via gossip, creating a deadlock where the node needs gossip blocks to advance but cannot become synced without them.

## Changes

Change subscription logic in `updateSyncState()`: instead of only subscribing when `state === SyncState.Synced`, subscribe whenever `state !== SyncState.SyncingFinalized`. Only suppress gossip during `SyncingFinalized` when significantly behind (`syncDiff > slotImportTolerance * 2`).

**Before:** Synced → subscribe, everything else → check unsubscribe
**After:** Not SyncingFinalized → subscribe, SyncingFinalized + far behind → unsubscribe

## Motivation

- Cross-client devnets where js-libp2p gossipsub subscription RPCs need to be exchanged before reaching synced state
- Any fork where block data propagates exclusively via gossip (PeerDAS data columns, future upgrades)
- Small testnets where the only way to advance is through gossip blocks

## Test plan

- Type check: `pnpm --filter @lodestar/beacon-node check-types` ✅
- Validated in 2-node LH+LS EPBS devnet: resolved gossip subscription deadlock, blocks received immediately

> [!NOTE]
> This PR was authored with AI assistance (Claude/Codex).