### PR TITLE
fix: subscribe all attestation subnets for fork boundary in supernode mode

### DIFF
--- a/packages/beacon-node/src/network/subnets/attnetsService.ts
+++ b/packages/beacon-node/src/network/subnets/attnetsService.ts
@@ -133,11 +133,18 @@ export class AttnetsService implements IAttnetsService {
    * Call ONLY ONCE: Two epoch before the fork, re-subscribe all existing random subscriptions to the new fork
    **/
   subscribeSubnetsNextBoundary(boundary: ForkBoundary): void {
-    this.logger.info("Subscribing to long lived attnets for next fork boundary", {
+    const subnets = this.opts.subscribeAllSubnets
+      ? Array.from({length: ATTESTATION_SUBNET_COUNT}, (_, subnet) => subnet)
+      : Array.from(this.longLivedSubscriptions);
+
+    this.logger.info("Subscribing to attnets for next fork boundary", {
       ...boundary,
-      subnets: Array.from(this.longLivedSubscriptions).join(","),
+      subscribeAllSubnets: this.opts.subscribeAllSubnets,
+      subnetCount: subnets.length,
+      subnets: subnets.join(","),
     });
-    for (const subnet of this.longLivedSubscriptions) {
+
+    for (const subnet of subnets) {
       this.gossip.subscribeTopic({type: gossipType, subnet, boundary});
     }
   }

--- a/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
+++ b/packages/beacon-node/test/unit/network/subnets/attnetsService.test.ts
@@ -114,6 +114,27 @@ describe("AttnetsService", () => {
     expect(gossipStub.unsubscribeTopic).toBeCalledTimes(ATTESTATION_SUBNET_COUNT);
   });
 
+  it("should subscribe all attestation subnets for next fork boundary in supernode mode", () => {
+    const supernodeService = new AttnetsService(config, clock, gossipStub, metadata, logger, null, nodeId, {
+      slotsToSubscribeBeforeAggregatorDuty: 2,
+      subscribeAllSubnets: true,
+    });
+
+    gossipStub.subscribeTopic.mockClear();
+
+    supernodeService.subscribeSubnetsNextBoundary({fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH});
+
+    expect(gossipStub.subscribeTopic).toBeCalledTimes(ATTESTATION_SUBNET_COUNT);
+    expect(gossipStub.subscribeTopic).toHaveBeenCalledWith(
+      expect.objectContaining({boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH}, subnet: 0})
+    );
+    expect(gossipStub.subscribeTopic).toHaveBeenCalledWith(
+      expect.objectContaining({boundary: {fork: ForkName.altair, epoch: config.ALTAIR_FORK_EPOCH}, subnet: 63})
+    );
+
+    supernodeService.close();
+  });
+
   it("should not subscribe to new short lived subnet if not aggregator", () => {
     expect(gossipStub.subscribeTopic).toBeCalledTimes(config.SUBNETS_PER_NODE);
     const firstSubnet = (gossipStub.subscribeTopic.mock.calls[0][0] as unknown as {subnet: SubnetID}).subnet;


### PR DESCRIPTION
## Summary

`subscribeSubnetsNextBoundary()` only iterated `longLivedSubscriptions` when subscribing subnets for a fork boundary. Supernodes with `subscribeAllSubnets=true` need ALL attestation subnets (0-63) subscribed for the boundary, not just the randomly selected long-lived ones.

Without this fix, supernodes would miss attestation messages on non-subscribed subnets during the first epochs after a fork transition.

## Changes

- Check `this.opts.subscribeAllSubnets` to decide whether to subscribe all subnets or just long-lived ones
- Updated log message to include `subscribeAllSubnets` flag and subnet count
- Added unit test for supernode mode fork boundary subscription

## Origin

Originally fixed in commit `933d8cc` (epbs-devnet-0 interop fixes). This change is not EPBS-specific and applies to any fork transition.

## Test plan

- Added unit test: supernode subscribes all 64 subnets on fork boundary ✅
- Type check: `pnpm --filter @lodestar/beacon-node check-types` ✅

> [!NOTE]
> This PR was authored with AI assistance (Claude/Codex).