### PR TITLE
chore: add notifyForkchoiceUpdate result panel to execution engine dashboard

### DIFF
--- a/dashboards/lodestar_execution_engine.json
+++ b/dashboards/lodestar_execution_engine.json
@@ -1276,12 +1276,93 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 483,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "builder",
+          "expr": "rate(lodestar_execution_engine_notify_forkchoice_update_result_total[1h])",
+          "legendFormat": "{{result}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "notifyForkchoiceUpdate result",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 58
       },
       "id": 482,
       "panels": [],

--- a/dashboards/lodestar_execution_engine.json
+++ b/dashboards/lodestar_execution_engine.json
@@ -1267,80 +1267,10 @@
           },
           "editorMode": "builder",
           "expr": "rate(lodestar_execution_engine_notify_new_payload_result_total[1h])",
-          "legendFormat": "{{result}}",
+          "legendFormat": "newPayload_{{result}}",
           "range": true,
           "refId": "A"
-        }
-      ],
-      "title": "notifyNewPayload result",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": []
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 50
-      },
-      "id": 483,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
         {
           "datasource": {
             "type": "prometheus",
@@ -1348,12 +1278,12 @@
           },
           "editorMode": "builder",
           "expr": "rate(lodestar_execution_engine_notify_forkchoice_update_result_total[1h])",
-          "legendFormat": "{{result}}",
+          "legendFormat": "fcu_{{result}}",
           "range": true,
-          "refId": "A"
+          "refId": "B"
         }
       ],
-      "title": "notifyForkchoiceUpdate result",
+      "title": "notifyNewPayload / notifyForkchoiceUpdate result",
       "type": "timeseries"
     },
     {
@@ -1362,7 +1292,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 50
       },
       "id": 482,
       "panels": [],


### PR DESCRIPTION
## Summary

Adds a Grafana timeseries panel for the new `lodestar_execution_engine_notify_forkchoice_update_result_total` metric introduced in #8895.

The panel is placed in the Execution Engine dashboard alongside the existing `notifyNewPayload result` panel, showing the rate of FCU results (VALID/SYNCING/error) to help operators detect EL/CL head mismatches.

## Changes

- `dashboards/lodestar_execution_engine.json`: Added `notifyForkchoiceUpdate result` timeseries panel with `rate(...[1h])` query, matching the existing notifyNewPayload panel style

## Test plan

- [x] Valid JSON (verified locally)
- [ ] Import dashboard in Grafana and confirm panel renders

Closes comment: https://github.com/ChainSafe/lodestar/pull/8895#issuecomment-3951420004