### PR TITLE
fix: bypass payloadId cache for Gloas to prevent withdrawals mismatch

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -649,7 +649,13 @@ export async function prepareExecutionPayload(
   let payloadId: PayloadId | null;
   let prepType: PayloadPreparationType;
 
-  if (payloadIdCached) {
+  // Post-Gloas: never use cached payloadId during block production. The cached payload
+  // was prepared by prepareNextSlot using PENDING parent state, but block production
+  // uses FULL parent state. The FULL state may have different pendingPartialWithdrawals
+  // (from processWithdrawalRequest during envelope processing), causing getExpectedWithdrawals
+  // to return different withdrawals → Withdrawals mismatch in validateExecutionPayloadEnvelope.
+  // Always send a fresh FCU to ensure the EL builds with correct FULL-state withdrawals.
+  if (payloadIdCached && !isForkPostGloas(fork)) {
     payloadId = payloadIdCached;
     prepType = PayloadPreparationType.Cached;
   } else {


### PR DESCRIPTION
## Motivation

After merging #8947, two interop regressions appeared on `epbs-devnet-0`:

1. **Withdrawals mismatch** — `produceBlockV4` fails with `Withdrawals mismatch between payload and expected withdrawals` when validators have withdrawal credentials
2. **ParentBlockHashMismatch** — Lighthouse rejects Lodestar gossip blocks because LS uses the FULL variant's execution hash (from imported envelopes) while LH still has the PENDING variant's hash in state

## Root Cause

### Withdrawals mismatch
The `payloadIdCache` stores a payloadId prepared by `prepareNextSlot` using PENDING parent state. But Gloas block production uses FULL parent state (after envelope import), which may have different `pendingPartialWithdrawals` — causing `getExpectedWithdrawals` to return different withdrawals.

**Fix:** Bypass `payloadIdCache` for Gloas blocks. Always send a fresh `engine_forkchoiceUpdated` during production to ensure the EL builds with correct FULL-state withdrawals. The ~500ms overhead is acceptable since the EL reuses prep work.

### ParentBlockHashMismatch
When an envelope arrives via gossip, the fork-choice head transitions from PENDING to FULL. Both `produceBlockWrapper` and `getHeadExecutionBlockHash()` then use the FULL variant's execution hash. Remote verifiers (e.g., Lighthouse) that haven't received the envelope still have the PENDING hash in their state → `ParentBlockHashMismatch` → peer score penalty → Goodbye → disconnect.

**Fix:** Force the PENDING variant for Gloas block production:
- `produceBlockWrapper`: Explicitly look up the PENDING variant of the parent block before `getBlockSlotState`, regardless of the head's current status
- `getHeadExecutionBlockHash()`: Return the PENDING variant's execution hash (the universally-known `latestBlockHash` from the last processed envelope)

This ensures `bid.parentBlockHash` matches what ALL verifiers expect, regardless of envelope availability.

## Kurtosis Validation

### Withdrawals fix (commit `e8d1f2bd32`)
- 4-node (2×LH + 2×LS), minimal preset, Gloas epoch 1
- Slot 129+, finalized epoch 2, zero errors across all counters

### PBM fix (commit `fb1bd9315e`)
- 4-node (2×LH + 2×LS), minimal preset, Gloas epoch 1
- **305+ clean slots**, finalized epoch 36
- 0 ParentBlockHashMismatch, 0 Goodbye, 0 peer disconnects
- Peers stable throughout (LH 2/2, LS 3/3)

---

*AI-assisted: this PR was authored with AI assistance and verified through automated testing.*
