### PR TITLE
fix: skip prometheus metrics trackProtocolStream for identify

### DIFF
--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -73,6 +73,30 @@ export async function createNodeJsLibp2p(
     noiseCrypto.chaCha20Poly1305Encrypt = asCrypto.chaCha20Poly1305Encrypt;
   }
 
+  const libp2pMetrics = nodeJsLibp2pOpts.metrics
+    ? ((components: LodestarComponents) => {
+        const metrics = prometheusMetrics({
+          collectDefaultMetrics: false,
+          preserveExistingMetrics: true,
+          registry: nodeJsLibp2pOpts.metricsRegistry,
+        })(components);
+
+        // Work around identify EOF race:
+        // `trackProtocolStream` attaches a `message` listener immediately after protocol
+        // negotiation. For `/ipfs/id/1.0.0`, identify() adds its own reader later and can
+        // miss the first response frame when metrics listener drains events first.
+        const originalTrackProtocolStream = metrics.trackProtocolStream.bind(metrics);
+        metrics.trackProtocolStream = ((stream) => {
+          if (stream.protocol === "/ipfs/id/1.0.0") {
+            return;
+          }
+          originalTrackProtocolStream(stream);
+        }) as typeof metrics.trackProtocolStream;
+
+        return metrics;
+      })
+    : undefined;
+
   return createLibp2p({
     privateKey,
     nodeInfo: {
@@ -101,13 +125,7 @@ export async function createNodeJsLibp2p(
     ],
     streamMuxers: [mplex({disconnectThreshold})],
     peerDiscovery,
-    metrics: nodeJsLibp2pOpts.metrics
-      ? prometheusMetrics({
-          collectDefaultMetrics: false,
-          preserveExistingMetrics: true,
-          registry: nodeJsLibp2pOpts.metricsRegistry,
-        })
-      : undefined,
+    metrics: libp2pMetrics,
     connectionManager: {
       // dialer config
       maxParallelDials: 100,


### PR DESCRIPTION
## Motivation

After the libp2p v3 upgrade (#8890), ~20-30% of connected peers remain as "Unknown" client on monitored nodes (feat1), compared to ~3-5% on stable/unstable. This is caused by identify stream failures — the identify response data is consumed before `identify()` can read it.

## Root Cause

`@libp2p/prometheus-metrics` v5 `trackProtocolStream()` adds a `message` event listener on protocol streams immediately after negotiation. For outbound `/ipfs/id/1.0.0` streams, this listener fires (via `queueMicrotask` in `dispatchReadBuffer`) before identify's `pb.read()` attaches its own reader, consuming all identify response data and causing EOF.

**Trace:**
1. `connection.newStream()` negotiates `/ipfs/id/1.0.0` via MSS
2. `connection.js` calls `metrics.trackProtocolStream(stream)` → adds `addEventListener('message', ...)` to count bytes
3. MSS `unwrap()` pushes unread protocol data back to the stream
4. `dispatchReadBuffer` fires via `queueMicrotask` — metrics listener consumes all data from `readBuffer`
5. `finally` block: `readBuffer.byteLength === 0 && remoteWriteStatus === 'closed'` → sets `readStatus = 'closed'`
6. identify's `pb.read()` sees EOF → peer stays Unknown

This is a **libp2p v3 regression**: in v2, the stream API was iterator-based (pull model) so the metrics listener was harmless. In v3, it's event-based (push model) where `addEventListener` actively consumes from the `readBuffer`.

## Fix

Wrap the prometheus metrics service to skip `trackProtocolStream` for `/ipfs/id/1.0.0` streams only, preserving all other protocol stream byte-counting metrics.

## Validation

A/B testing on local mainnet (90-second samples each):

| Condition | Identify Opens | Failures | Failure Rate |
|-----------|---------------|----------|-------------|
| Tracking enabled (baseline) | 35 | 28 | 80% |
| All tracking disabled | 24 | 0 | 0% |
| **Skip identify only (this PR)** | 33 | 0 | **0%** |

Extended clean validation run (120s, `--logLevel debug`, no debug patches):
- `Error setting agentVersion for the peer`: **0**
- Unknown peer ratio in metrics samples: **0.0-2.4%** (within stable/unstable baseline)

## Upstream

The underlying issue is in `@libp2p/prometheus-metrics` `_track()` method which uses a consuming `addEventListener('message', ...)` pattern that races with protocol handlers. An upstream fix should use a non-consuming observer, but that requires changes to `@libp2p/utils` `AbstractMessageStream`. This PR provides a targeted Lodestar-side workaround.

---

> [!NOTE]
> This PR was authored with AI assistance (Lodekeeper 🌟). Root cause analysis, instrumentation, A/B validation, and fix implementation were performed by the AI agent with human oversight.
