### PR TITLE
feat(state-transition): add gloas fields/methods to IBeaconStateView

### DIFF
--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -79,7 +79,7 @@ export class BeaconStateView implements IBeaconStateView {
   private _currentEpochParticipation: number[] | null = null;
   // bellatrix
   private _latestExecutionPayloadHeader: ExecutionPayloadHeader | null = null;
-  // this map to latestBlockHash of Gloas too
+  // Caches the cross-fork latestBlockHash value
   private _latestBlockHash: Bytes32 | null = null;
   // capella
   private _historicalSummaries: capella.HistoricalSummaries | null = null;
@@ -213,12 +213,13 @@ export class BeaconStateView implements IBeaconStateView {
    * Gloas+: reads the dedicated latestBlockHash field (EIP-7732).
    */
   get latestBlockHash(): Bytes32 {
-    if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.bellatrix) {
+    const forkSeq = this.config.getForkSeq(this.cachedState.slot);
+    if (forkSeq < ForkSeq.bellatrix) {
       throw new Error("latestBlockHash is not available before Bellatrix");
     }
 
     if (this._latestBlockHash === null) {
-      if (this.config.getForkSeq(this.cachedState.slot) >= ForkSeq.gloas) {
+      if (forkSeq >= ForkSeq.gloas) {
         this._latestBlockHash = (this.cachedState as CachedBeaconStateGloas).latestBlockHash;
       } else {
         this._latestBlockHash = (

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -1,7 +1,7 @@
 import {CompactMultiProof, ProofType, Tree, createProof} from "@chainsafe/persistent-merkle-tree";
 import {ByteViews} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {ForkSeq, SLOTS_PER_HISTORICAL_ROOT} from "@lodestar/params";
+import {ForkSeq, SLOTS_PER_HISTORICAL_ROOT, isForkPostGloas} from "@lodestar/params";
 import {
   BeaconBlock,
   BlindedBeaconBlock,
@@ -27,6 +27,7 @@ import {
   rewards,
 } from "@lodestar/types";
 import {Checkpoint, Fork} from "@lodestar/types/phase0";
+import {processExecutionPayloadEnvelope} from "../block/index.js";
 import {VoluntaryExitValidity, getVoluntaryExitValidity} from "../block/processVoluntaryExit.js";
 import {getExpectedWithdrawals} from "../block/processWithdrawals.js";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";
@@ -75,8 +76,8 @@ export class BeaconStateView implements IBeaconStateView {
   // altair
   private _currentSyncCommittee: SyncCommittee | null = null;
   private _nextSyncCommittee: SyncCommittee | null = null;
-  private _previousEpochParticipation: number[] | null = null;
-  private _currentEpochParticipation: number[] | null = null;
+  private _previousEpochParticipation: Uint8Array | null = null;
+  private _currentEpochParticipation: Uint8Array | null = null;
   // bellatrix
   private _latestExecutionPayloadHeader: ExecutionPayloadHeader | null = null;
   // Caches the cross-fork latestBlockHash value
@@ -161,7 +162,7 @@ export class BeaconStateView implements IBeaconStateView {
     return getRandaoMix(this.cachedState, epoch);
   }
 
-  get previousEpochParticipation(): number[] {
+  get previousEpochParticipation(): Uint8Array {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.altair) {
       throw new Error("previousEpochParticipation is not available before Altair");
     }
@@ -169,7 +170,7 @@ export class BeaconStateView implements IBeaconStateView {
     if (this._previousEpochParticipation === null) {
       this._previousEpochParticipation = (
         this.cachedState as CachedBeaconStateAltair
-      ).previousEpochParticipation.toValue();
+      ).previousEpochParticipation.serialize();
     }
 
     return this._previousEpochParticipation;
@@ -177,7 +178,7 @@ export class BeaconStateView implements IBeaconStateView {
 
   // altair
 
-  get currentEpochParticipation(): number[] {
+  get currentEpochParticipation(): Uint8Array {
     if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.altair) {
       throw new Error("currentEpochParticipation is not available before Altair");
     }
@@ -185,10 +186,24 @@ export class BeaconStateView implements IBeaconStateView {
     if (this._currentEpochParticipation === null) {
       this._currentEpochParticipation = (
         this.cachedState as CachedBeaconStateAltair
-      ).currentEpochParticipation.toValue();
+      ).currentEpochParticipation.serialize();
     }
 
     return this._currentEpochParticipation;
+  }
+
+  getPreviousEpochParticipation(validatorIndex: ValidatorIndex): number {
+    if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.altair) {
+      throw new Error("previousEpochParticipation is not available before Altair");
+    }
+    return (this.cachedState as CachedBeaconStateAltair).previousEpochParticipation.get(validatorIndex);
+  }
+
+  getCurrentEpochParticipation(validatorIndex: ValidatorIndex): number {
+    if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.altair) {
+      throw new Error("currentEpochParticipation is not available before Altair");
+    }
+    return (this.cachedState as CachedBeaconStateAltair).currentEpochParticipation.get(validatorIndex);
   }
 
   // bellatrix
@@ -242,9 +257,7 @@ export class BeaconStateView implements IBeaconStateView {
       throw new Error("payloadBlockNumber is not available before Bellatrix");
     }
     if (forkSeq >= ForkSeq.gloas) {
-      throw new Error(
-        "payloadBlockNumber is not available in Gloas+: latestExecutionPayloadHeader was removed in EIP-7732"
-      );
+      throw new Error("payloadBlockNumber is not available post-gloas");
     }
     return (this.cachedState as CachedBeaconStateExecutions).latestExecutionPayloadHeader.blockNumber;
   }
@@ -746,6 +759,14 @@ export class BeaconStateView implements IBeaconStateView {
   ): IBeaconStateView {
     const newState = processSlots(this.cachedState, slot, epochTransitionCacheOpts, modules);
     return new BeaconStateView(newState);
+  }
+
+  processExecutionPayloadEnvelope(signedEnvelope: gloas.SignedExecutionPayloadEnvelope, verify: boolean): void {
+    const fork = this.config.getForkName(this.cachedState.slot);
+    if (!isForkPostGloas(fork)) {
+      throw Error(`processExecutionPayloadEnvelope is only available for gloas+ forks, got fork=${fork}`);
+    }
+    processExecutionPayloadEnvelope(this.cachedState as CachedBeaconStateGloas, signedEnvelope, verify);
   }
 }
 

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -79,6 +79,8 @@ export class BeaconStateView implements IBeaconStateView {
   private _currentEpochParticipation: number[] | null = null;
   // bellatrix
   private _latestExecutionPayloadHeader: ExecutionPayloadHeader | null = null;
+  // this map to latestBlockHash of Gloas too
+  private _latestBlockHash: Bytes32 | null = null;
   // capella
   private _historicalSummaries: capella.HistoricalSummaries | null = null;
   // electra
@@ -203,6 +205,47 @@ export class BeaconStateView implements IBeaconStateView {
     }
 
     return this._latestExecutionPayloadHeader;
+  }
+
+  /**
+   * Cross-fork accessor for the execution block hash of the most recently included payload.
+   * Pre-gloas: reads from latestExecutionPayloadHeader.blockHash.
+   * Gloas+: reads the dedicated latestBlockHash field (EIP-7732).
+   */
+  get latestBlockHash(): Bytes32 {
+    if (this.config.getForkSeq(this.cachedState.slot) < ForkSeq.bellatrix) {
+      throw new Error("latestBlockHash is not available before Bellatrix");
+    }
+
+    if (this._latestBlockHash === null) {
+      if (this.config.getForkSeq(this.cachedState.slot) >= ForkSeq.gloas) {
+        this._latestBlockHash = (this.cachedState as CachedBeaconStateGloas).latestBlockHash;
+      } else {
+        this._latestBlockHash = (
+          this.cachedState as CachedBeaconStateExecutions
+        ).latestExecutionPayloadHeader.blockHash;
+      }
+    }
+
+    return this._latestBlockHash;
+  }
+
+  /**
+   * The execution block number of the most recently included payload.
+   * Named payloadBlockNumber (not latestBlockNumber) to mirror ExecutionPayloadHeader.blockNumber pre-gloas.
+   * Only available from bellatrix through fulu — not tracked on BeaconState in gloas+ (EIP-7732).
+   */
+  get payloadBlockNumber(): number {
+    const forkSeq = this.config.getForkSeq(this.cachedState.slot);
+    if (forkSeq < ForkSeq.bellatrix) {
+      throw new Error("payloadBlockNumber is not available before Bellatrix");
+    }
+    if (forkSeq >= ForkSeq.gloas) {
+      throw new Error(
+        "payloadBlockNumber is not available in Gloas+: latestExecutionPayloadHeader was removed in EIP-7732"
+      );
+    }
+    return (this.cachedState as CachedBeaconStateExecutions).latestExecutionPayloadHeader.blockNumber;
   }
 
   // capella

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -55,8 +55,10 @@ export interface IBeaconStateView {
   getRandaoMix(epoch: Epoch): Bytes32;
 
   // altair
-  previousEpochParticipation: number[];
-  currentEpochParticipation: number[];
+  previousEpochParticipation: Uint8Array;
+  currentEpochParticipation: Uint8Array;
+  getPreviousEpochParticipation(validatorIndex: ValidatorIndex): number;
+  getCurrentEpochParticipation(validatorIndex: ValidatorIndex): number;
 
   // bellatrix
   latestExecutionPayloadHeader: ExecutionPayloadHeader;
@@ -207,4 +209,5 @@ export interface IBeaconStateView {
     epochTransitionCacheOpts?: EpochTransitionCacheOpts & {dontTransferCache?: boolean},
     modules?: StateTransitionModules
   ): IBeaconStateView;
+  processExecutionPayloadEnvelope(signedEnvelope: gloas.SignedExecutionPayloadEnvelope, verify: boolean): void;
 }

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -107,11 +107,12 @@ export interface IBeaconStateView {
   getCurrentShuffling(): EpochShuffling;
   getNextShuffling(): EpochShuffling;
 
-  // Proposer shuffling
+  // utils: proposers, anchor checkpoint
   previousProposers: ValidatorIndex[] | null;
   currentProposers: ValidatorIndex[];
   nextProposers: ValidatorIndex[];
   getBeaconProposer(slot: Slot): ValidatorIndex;
+  computeAnchorCheckpoint(): {checkpoint: phase0.Checkpoint; blockHeader: phase0.BeaconBlockHeader};
 
   // Sync committees
   currentSyncCommittee: altair.SyncCommittee;

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -60,6 +60,20 @@ export interface IBeaconStateView {
 
   // bellatrix
   latestExecutionPayloadHeader: ExecutionPayloadHeader;
+  /**
+   * Cross-fork accessor for the execution block hash of the most recently included payload.
+   * Pre-gloas: returns latestExecutionPayloadHeader.blockHash (bellatrix–fulu).
+   * Gloas+: returns the dedicated latestBlockHash state field (EIP-7732).
+   * Throws before bellatrix.
+   */
+  latestBlockHash: Bytes32;
+  /**
+   * The execution block number of the most recently included payload.
+   * Named payloadBlockNumber (not latestBlockNumber) to mirror ExecutionPayloadHeader.blockNumber pre-gloas.
+   * Only available from bellatrix through fulu — not tracked on BeaconState in gloas+ (EIP-7732).
+   * Throws before bellatrix and from gloas onwards.
+   */
+  payloadBlockNumber: number;
 
   // capella
   historicalSummaries: capella.HistoricalSummaries;
@@ -93,12 +107,11 @@ export interface IBeaconStateView {
   getCurrentShuffling(): EpochShuffling;
   getNextShuffling(): EpochShuffling;
 
-  // utils: proposers, anchor checkpoint
+  // Proposer shuffling
   previousProposers: ValidatorIndex[] | null;
   currentProposers: ValidatorIndex[];
   nextProposers: ValidatorIndex[];
   getBeaconProposer(slot: Slot): ValidatorIndex;
-  computeAnchorCheckpoint(): {checkpoint: phase0.Checkpoint; blockHeader: phase0.BeaconBlockHeader};
 
   // Sync committees
   currentSyncCommittee: altair.SyncCommittee;


### PR DESCRIPTION
**Motivation**

cherry-pick from #8857 to make it easier to review

**Description**

Adds two new cross-fork accessors to `IBeaconStateView` / `BeaconStateView`:

- **`latestBlockHash: Bytes32`** — returns the execution block hash of the most recently included payload, regardless of fork:
  - Bellatrix – Fulu: reads `latestExecutionPayloadHeader.blockHash`
  - Gloas+: reads the dedicated `latestBlockHash` state field (EIP-7732)
  - Throws before Bellatrix

- **`payloadBlockNumber: number`** — returns the execution block number from the payload header:
  - Only available Bellatrix – Fulu (named `payloadBlockNumber` to mirror `ExecutionPayloadHeader.blockNumber`)
  - Throws before Bellatrix and from Gloas onward (header no longer exists in EIP-7732)

- change **`previousEpochParticipation`** and **`currentEpochParticipation`** to Uint8Array for memory efficiency
- add **`getPreviousEpochParticipation`** **`getCurrentEpochParticipation`** when we only check some index, this saves a lot of memory
- add **`processExecutionPayloadEnvelope`** for gloas

**AI Assistance Disclosure**

- [ ] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

Claude Sonnet 4.6 assisted with commit message and PR description.