### PR TITLE
fix: use inclusive boundary for gossip clock disparity checks

### DIFF
--- a/packages/beacon-node/src/util/clock.ts
+++ b/packages/beacon-node/src/util/clock.ts
@@ -92,10 +92,12 @@ export class Clock extends EventEmitter implements IClock {
     }
     return slot;
   }
-
   /**
    * If it's too close to next slot given MAXIMUM_GOSSIP_CLOCK_DISPARITY, return currentSlot + 1.
    * Otherwise return currentSlot
+   *
+   * Spec: phase0/p2p-interface.md - gossip validation uses `current_time + MAXIMUM_GOSSIP_CLOCK_DISPARITY < message_time`
+   * to reject future messages (strict `<`), so the boundary (exactly equal) is accepted, hence `<=` here.
    */
   get currentSlotWithGossipDisparity(): Slot {
     const currentSlot = this.currentSlot;
@@ -121,6 +123,9 @@ export class Clock extends EventEmitter implements IClock {
 
   /**
    * Check if a slot is current slot given MAXIMUM_GOSSIP_CLOCK_DISPARITY.
+   *
+   * Uses `<=` for disparity checks because the spec rejects with strict `<`
+   * (phase0/p2p-interface.md), meaning the boundary (exactly equal) is accepted.
    */
   isCurrentSlotGivenGossipDisparity(slot: Slot): boolean {
     const currentSlot = this.currentSlot;

--- a/packages/beacon-node/src/util/clock.ts
+++ b/packages/beacon-node/src/util/clock.ts
@@ -100,7 +100,7 @@ export class Clock extends EventEmitter implements IClock {
   get currentSlotWithGossipDisparity(): Slot {
     const currentSlot = this.currentSlot;
     const nextSlotTime = computeTimeAtSlot(this.config, currentSlot + 1, this.genesisTime) * 1000;
-    return nextSlotTime - Date.now() < this.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY ? currentSlot + 1 : currentSlot;
+    return nextSlotTime - Date.now() <= this.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY ? currentSlot + 1 : currentSlot;
   }
 
   get currentEpoch(): Epoch {
@@ -129,12 +129,12 @@ export class Clock extends EventEmitter implements IClock {
     }
     const nextSlotTime = computeTimeAtSlot(this.config, currentSlot + 1, this.genesisTime) * 1000;
     // we're too close to next slot, accept next slot
-    if (nextSlotTime - Date.now() < this.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY) {
+    if (nextSlotTime - Date.now() <= this.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY) {
       return slot === currentSlot + 1;
     }
     const currentSlotTime = computeTimeAtSlot(this.config, currentSlot, this.genesisTime) * 1000;
     // we've just passed the current slot, accept previous slot
-    if (Date.now() - currentSlotTime < this.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY) {
+    if (Date.now() - currentSlotTime <= this.config.MAXIMUM_GOSSIP_CLOCK_DISPARITY) {
       return slot === currentSlot - 1;
     }
     return false;


### PR DESCRIPTION
## Description

Fix off-by-one in gossip clock disparity boundary checks. The clock used strict less-than (`<`) instead of less-than-or-equal (`<=`) when comparing time differences against `MAXIMUM_GOSSIP_CLOCK_DISPARITY`, causing messages arriving at exactly the disparity boundary to be incorrectly rejected.

### Spec Reference

The [consensus spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#beacon_block) defines the future slot check as:

```python
block_time_ms = compute_time_at_slot_ms(state, block.slot)
if current_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY < block_time_ms:
    raise GossipIgnore("block is from a future slot")
```

The spec uses strict `<` for the **rejection** condition, meaning a message should be **accepted** when:

```
current_time_ms + MAXIMUM_GOSSIP_CLOCK_DISPARITY >= block_time_ms
```

Which is equivalent to:

```
block_time_ms - current_time_ms <= MAXIMUM_GOSSIP_CLOCK_DISPARITY
```

### The Bug

Our clock was checking `nextSlotTime - Date.now() < MAXIMUM_GOSSIP_CLOCK_DISPARITY` (strict `<`), but the spec requires `<=` (inclusive). At exactly the boundary (e.g. exactly 500ms before the next slot), the clock would reject the message as a future slot when the spec says it should be accepted.

This was caught by the [gossip validation spec tests](https://github.com/ethereum/consensus-specs/tree/dev/tests/minimal/phase0/networking/gossip_beacon_block) which include a test pair that validates the exact boundary:
- `gossip_beacon_block__valid_within_clock_disparity`: `current_time_ms: 5500`, block at slot 1 (6000ms) → gap = 500ms → **expected: valid**
- `gossip_beacon_block__ignore_future_slot`: `current_time_ms: 5499`, same block → gap = 501ms → **expected: ignore**

### Changes

Changed `<` to `<=` in three places in `Clock`:
1. `currentSlotWithGossipDisparity` getter
2. `isCurrentSlotGivenGossipDisparity` — next slot boundary check
3. `isCurrentSlotGivenGossipDisparity` — previous slot boundary check

### Practical Impact

Minimal — this only affects messages arriving at the exact millisecond boundary of the disparity window. But it aligns our implementation with the spec.

---

*This PR was authored with AI assistance (Lodekeeper 🌟).*