### PR TITLE
fix(epbs): set Gloas attestation.data.index from canonical payload status

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1014,10 +1014,10 @@ export function getValidatorApi(
         const isMatchingCanonicalRoot =
           canonicalAttestedBlock !== null && canonicalAttestedBlock.blockRoot === toRootHex(beaconBlockRoot);
 
-        if (isMatchingCanonicalRoot && canonicalAttestedBlock.slot === slot) {
+        if (!isMatchingCanonicalRoot || canonicalAttestedBlock.slot === slot) {
           index = 0;
         } else {
-          index = isMatchingCanonicalRoot && canonicalAttestedBlock.payloadStatus === PayloadStatus.FULL ? 1 : 0;
+          index = canonicalAttestedBlock.payloadStatus === PayloadStatus.FULL ? 1 : 0;
         }
       } else if (isForkPostElectra(fork)) {
         index = 0;

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -997,16 +997,6 @@ export function getValidatorApi(
       const headBlockRoot = fromHex(headBlockRootHex);
       const fork = config.getForkName(slot);
 
-      let index: CommitteeIndex;
-      if (isForkPostElectra(fork)) {
-        index = 0;
-      } else {
-        if (committeeIndex === undefined) {
-          throw new ApiError(400, `Committee index must be provided for pre-electra fork=${fork}`);
-        }
-        index = committeeIndex;
-      }
-
       const beaconBlockRoot =
         slot >= headSlot
           ? // When attesting to the head slot or later, always use the head of the chain.
@@ -1014,6 +1004,29 @@ export function getValidatorApi(
           : // Permit attesting to slots *prior* to the current head. This is desirable when
             // the VC and BN are out-of-sync due to time issues or overloading.
             getBlockRootAtSlot(headState, slot);
+
+      let index: CommitteeIndex;
+      if (isForkPostGloas(fork)) {
+        // In Gloas (ePBS), attestation.data.index signals payload status in fork-choice:
+        // 0 = EMPTY / not present, 1 = FULL / present.
+        // Per spec, same-slot attestations must always use index = 0.
+        const canonicalAttestedBlock = chain.forkChoice.getCanonicalBlockClosestLteSlot(slot);
+        const isMatchingCanonicalRoot =
+          canonicalAttestedBlock !== null && canonicalAttestedBlock.blockRoot === toRootHex(beaconBlockRoot);
+
+        if (isMatchingCanonicalRoot && canonicalAttestedBlock.slot === slot) {
+          index = 0;
+        } else {
+          index = isMatchingCanonicalRoot && canonicalAttestedBlock.payloadStatus === PayloadStatus.FULL ? 1 : 0;
+        }
+      } else if (isForkPostElectra(fork)) {
+        index = 0;
+      } else {
+        if (committeeIndex === undefined) {
+          throw new ApiError(400, `Committee index must be provided for pre-electra fork=${fork}`);
+        }
+        index = committeeIndex;
+      }
 
       const targetSlot = computeStartSlotAtEpoch(attEpoch);
       const targetRoot =

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -1,6 +1,6 @@
 import {ApiClient} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, isForkPostElectra} from "@lodestar/params";
+import {ForkName, isForkPostElectra, isForkPostGloas} from "@lodestar/params";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {SignedAggregateAndProof, SingleAttestation, Slot, phase0, ssz} from "@lodestar/types";
 import {prettyBytes, sleep, toRootHex} from "@lodestar/utils";
@@ -108,7 +108,8 @@ export class AttestationService {
         Array.from(dutiesByCommitteeIndex.entries()).map(([index, dutiesSameCommittee]) => {
           const attestationData: phase0.AttestationData = {
             ...attestationNoCommittee,
-            index: isForkPostElectra(fork) ? 0 : index,
+            // Post-Gloas: preserve BN-provided index (payload status signal)
+            index: isForkPostGloas(fork) ? attestationNoCommittee.index : isForkPostElectra(fork) ? 0 : index,
           };
           return this.produceAndPublishAggregates(fork, attestationData, index, dutiesSameCommittee);
         })
@@ -145,7 +146,11 @@ export class AttestationService {
 
     await Promise.all(
       duties.map(async ({duty}) => {
-        const index = isForkPostElectra(fork) ? 0 : duty.committeeIndex;
+        const index = isForkPostGloas(fork)
+          ? attestationNoCommittee.index
+          : isForkPostElectra(fork)
+            ? 0
+            : duty.committeeIndex;
         const attestationData: phase0.AttestationData = {...attestationNoCommittee, index};
         const logCtxValidator = {slot, index, head: headRootHex, validatorIndex: duty.validatorIndex};
 

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -831,13 +831,20 @@ export class ValidatorStore {
       throw Error(`Inconsistent duties during signing: duty.slot ${duty.slot} != att.slot ${data.slot}`);
     }
 
-    const isPostElectra = this.config.getForkSeq(data.slot) >= ForkSeq.electra;
+    const forkSeq = this.config.getForkSeq(data.slot);
+    const isPostElectra = forkSeq >= ForkSeq.electra;
+    const isPostGloas = forkSeq >= ForkSeq.gloas;
     if (!isPostElectra && duty.committeeIndex !== data.index) {
       throw Error(
         `Inconsistent duties during signing: duty.committeeIndex ${duty.committeeIndex} != att.committeeIndex ${data.index}`
       );
     }
-    if (isPostElectra && data.index !== 0) {
+    if (isPostGloas) {
+      // In Gloas, data.index signals payload status: 0 (EMPTY) or 1 (FULL)
+      if (data.index !== 0 && data.index !== 1) {
+        throw Error(`Invalid payload status index post-Gloas during signing: data.index=${data.index}`);
+      }
+    } else if (isPostElectra && data.index !== 0) {
       throw Error(`Non-zero committee index post-electra during signing: att.committeeIndex ${data.index}`);
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #8914 on `epbs-devnet-0` now that fork-choice payload variants are in place.

Implements CL-spec attestation `data.index` semantics for Gloas/ePBS:
- `index = 0` for same-slot attestations (payload status unknown at attestation time)
- otherwise derive from canonical payload status (`FULL => 1`, `EMPTY/PENDING => 0`)

## Code changes

1. **BN `produceAttestationData`** (`packages/beacon-node/src/api/impl/validator/index.ts`)
   - compute `beaconBlockRoot` before deriving index
   - on post-Gloas forks, derive `data.index` from canonical block status at/<= `slot`
   - keep pre-Gloas behavior unchanged

2. **VC attestation publish path** (`packages/validator/src/services/attestation.ts`)
   - preserve BN-provided `data.index` for Gloas (do not force-zero)
   - keep Electra pre-Gloas zeroing behavior

3. **VC duty validation** (`packages/validator/src/services/validatorStore.ts`)
   - allow only `{0,1}` for post-Gloas
   - retain strict `index===0` check for Electra pre-Gloas

## Spec references

- `consensus-specs/specs/gloas/validator.md` (attestation index signaling)
- `consensus-specs/specs/gloas/beacon-chain.md` (`is_attestation_same_slot`, payload match rule)

## Testing

### Local checks
- `pnpm --filter @lodestar/beacon-node check-types` ✅
- `pnpm --filter @lodestar/validator check-types` ✅
- `pnpm --filter @lodestar/beacon-node exec vitest run --project unit test/unit/api/impl/validator/produceAttestationData.test.ts` ✅
- `pnpm --filter @lodestar/validator test:unit -- test/unit/services/attestation.test.ts` ✅

### ePBS devnet sanity run (Kurtosis)
- Config: `notes/epbs-devnet-0/kurtosis-configs/epbs-devnet-0-minimal-2node.yaml`
- Network reached slot 40+ with LH+LS peers connected (sanity progression)
- Direct BN API probe during slot transition observed expected non-zero case:
  - `slot=58`, `head=57`, `attestation_data.index=1` (head lagging by one slot)
  - same-slot calls continued returning `index=0`

This validates both sides of the spec behavior (same-slot=0, non-same-slot with FULL payload=1).

---

> This PR was authored with AI assistance (OpenClaw/Codex). Changes were reviewed against CL spec behavior and validated locally.
