### PR TITLE
feat(bls): add benchmarks for napi bls batching apis

### DIFF
--- a/packages/beacon-node/test/perf/bls/bls.test.ts
+++ b/packages/beacon-node/test/perf/bls/bls.test.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import {bench, describe} from "@chainsafe/benchmark";
+import {blsBatch} from "@chainsafe/lodestar-z/bls-batch";
 import {
   PublicKey,
   SecretKey,
@@ -9,7 +10,8 @@ import {
   verify,
   verifyMultipleAggregateSignatures,
 } from "@chainsafe/lodestar-z/blst";
-import {linspace} from "../../../src/util/numpy.js";
+import {pubkeyCache} from "@chainsafe/lodestar-z/pubkeys";
+import {linspace} from "../../../src/util/numpy.ts";
 
 describe("BLS ops", () => {
   type Keypair = {publicKey: PublicKey; secretKey: SecretKey};
@@ -123,6 +125,98 @@ describe("BLS ops", () => {
       beforeEach: () => linspace(0, count - 1).map((i) => getKeypair(i).publicKey),
       fn: (pubkeys) => {
         aggregatePublicKeys(pubkeys);
+      },
+    });
+  }
+});
+
+describe("BLS napi batching bindings", () => {
+  const maxKeys = 256;
+  blsBatch.init(40_000);
+
+  const secretKeys: SecretKey[] = [];
+  for (let i = 0; i < maxKeys; i++) {
+    const bytes = new Uint8Array(32);
+    const dataView = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    dataView.setUint32(0, i + 1, true);
+    const sk = SecretKey.fromKeygen(bytes);
+    secretKeys.push(sk);
+    pubkeyCache.set(i, sk.toPublicKey().toBytes());
+  }
+
+  type IndexedSet = {index: number; message: Uint8Array; signature: Uint8Array};
+  type SingleSet = {publicKey: Uint8Array; message: Uint8Array; signature: Uint8Array};
+
+  function getIndexedSet(i: number): IndexedSet {
+    const message = Buffer.alloc(32, i + 1);
+    return {index: i, message, signature: secretKeys[i].sign(message).toBytes()};
+  }
+
+  function getSingleSet(i: number): SingleSet {
+    const message = Buffer.alloc(32, i + 1);
+    return {
+      publicKey: secretKeys[i].toPublicKey().toBytes(),
+      message,
+      signature: secretKeys[i].sign(message).toBytes(),
+    };
+  }
+
+  const seedMessage = crypto.randomBytes(32);
+  function getSameMessageSet(i: number): {index: number; signature: Uint8Array} {
+    return {index: i, signature: secretKeys[i].sign(seedMessage).toBytes()};
+  }
+
+  for (const count of [3, 8, 32, 64, 128]) {
+    bench({
+      id: `blsBatch.verify(indexed) ${count}`,
+      beforeEach: () => linspace(0, count - 1).map((i) => getIndexedSet(i)),
+      fn: (sets) => {
+        const isValid = blsBatch.verify(blsBatch.indexed, sets);
+        if (!isValid) throw Error("Invalid");
+      },
+    });
+  }
+
+  for (const count of [3, 8, 32, 64, 128]) {
+    bench({
+      id: `blsBatch.verify(single) ${count}`,
+      beforeEach: () => linspace(0, count - 1).map((i) => getSingleSet(i)),
+      fn: (sets) => {
+        const isValid = blsBatch.verify(blsBatch.single, sets);
+        if (!isValid) throw Error("Invalid");
+      },
+    });
+  }
+
+  for (const count of [3, 8, 32, 64, 128]) {
+    bench({
+      id: `blsBatch.asyncVerify(indexed) ${count}`,
+      beforeEach: () => linspace(0, count - 1).map((i) => getIndexedSet(i)),
+      fn: async (sets) => {
+        const isValid = await blsBatch.asyncVerify(blsBatch.indexed, sets);
+        if (!isValid) throw Error("Invalid");
+      },
+    });
+  }
+
+  for (const count of [3, 8, 32, 64, 128]) {
+    bench({
+      id: `blsBatch.asyncVerify(single) ${count}`,
+      beforeEach: () => linspace(0, count - 1).map((i) => getSingleSet(i)),
+      fn: (sets) => {
+        const isValid = blsBatch.asyncVerify(blsBatch.single, sets);
+        if (!isValid) throw Error("Invalid");
+      },
+    });
+  }
+
+  for (const count of [3, 8, 32, 64, 128]) {
+    bench({
+      id: `blsBatch.asyncVerifySameMessage ${count}`,
+      beforeEach: () => linspace(0, count - 1).map((i) => getSameMessageSet(i)),
+      fn: async (sets) => {
+        const isValid = await blsBatch.asyncVerifySameMessage(sets, seedMessage);
+        if (!isValid) throw Error("Invalid");
       },
     });
   }

--- a/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
+++ b/packages/beacon-node/test/unit/chain/validation/attestation/validateGossipAttestationsSameAttData.test.ts
@@ -1,9 +1,9 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {PublicKey, SecretKey} from "@chainsafe/lodestar-z/blst";
+import {getEmptyLogger} from "@lodestar/logger/empty";
 import {ForkName} from "@lodestar/params";
 import {SignatureSetType, getPubkeyCache} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
-import {getEmptyLogger} from "@lodestar/logger/empty";
 import {BlsVerifier} from "../../../../../src/chain/bls/blsVerifier.js";
 import {AttestationError, AttestationErrorCode, GossipAction} from "../../../../../src/chain/errors/index.js";
 import {IBeaconChain} from "../../../../../src/chain/index.js";

--- a/packages/beacon-node/test/utils/validationData/attestation.ts
+++ b/packages/beacon-node/test/utils/validationData/attestation.ts
@@ -1,5 +1,6 @@
 import {BitArray, toHexString} from "@chainsafe/ssz";
 import {ExecutionStatus, IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
+import {getEmptyLogger} from "@lodestar/logger/empty";
 import {DOMAIN_BEACON_ATTESTER} from "@lodestar/params";
 import {
   DataAvailabilityStatus,
@@ -12,7 +13,6 @@ import {
   generateTestCachedBeaconStateOnlyValidators,
   getSecretKeyFromIndexCached,
 } from "../../../../state-transition/test/perf/util.js";
-import {getEmptyLogger} from "@lodestar/logger/empty";
 import {BlsVerifier} from "../../../src/chain/bls/index.js";
 import {IBeaconChain} from "../../../src/chain/index.js";
 import {defaultChainOptions} from "../../../src/chain/options.js";


### PR DESCRIPTION
Add benchmarks for bls batching API.

Local run:

```console
  BLS ops
    ✔ BLS verifyMultipleSignatures 3 - blst                               594.6279 ops/s    1.681724 ms/op        -        121 runs  0.706 s
    ✔ BLS verifyMultipleSignatures 8 - blst                               275.5645 ops/s    3.628914 ms/op        -         56 runs  0.713 s
    ✔ BLS verifyMultipleSignatures 32 - blst                              75.50866 ops/s    13.24351 ms/op        -         17 runs  0.727 s
    ✔ BLS verifyMultipleSignatures 64 - blst                              38.50739 ops/s    25.96904 ms/op        -         13 runs  0.843 s
    ✔ BLS verifyMultipleSignatures 128 - blst                             19.66558 ops/s    50.85027 ms/op        -         11 runs   1.07 s
    ✔ BLS verifyMultipleSignatures - same message - 3 - blst              1052.640 ops/s    949.9920 us/op        -        212 runs  0.706 s
    ✔ BLS verifyMultipleSignatures - same message - 8 - blst              921.3074 ops/s    1.085414 ms/op        -        186 runs  0.705 s
    ✔ BLS verifyMultipleSignatures - same message - 32 - blst             587.3160 ops/s    1.702661 ms/op        -        119 runs  0.727 s
    ✔ BLS verifyMultipleSignatures - same message - 64 - blst             398.4102 ops/s    2.509976 ms/op        -         81 runs  0.717 s
    ✔ BLS verifyMultipleSignatures - same message - 128 - blst            240.8998 ops/s    4.151104 ms/op        -         49 runs  0.736 s

  BLS napi batching bindings
    ✔ blsBatch.verify(indexed) 3                                          547.1447 ops/s    1.827670 ms/op        -         77 runs  0.949 s
    ✔ blsBatch.verify(indexed) 8                                          247.2610 ops/s    4.044309 ms/op        -         33 runs   1.00 s
    ✔ blsBatch.verify(indexed) 32                                         68.42452 ops/s    14.61464 ms/op        -         11 runs   1.08 s
    ✔ blsBatch.verify(indexed) 64                                         34.28697 ops/s    29.16560 ms/op        -         10 runs   1.33 s
    ✔ blsBatch.verify(indexed) 128                                        17.56316 ops/s    56.93736 ms/op        -         11 runs   1.90 s
    ✔ blsBatch.verify(single) 3                                           500.5496 ops/s    1.997804 ms/op        -         66 runs  0.994 s
    ✔ blsBatch.verify(single) 8                                           223.3085 ops/s    4.478110 ms/op        -         29 runs   1.06 s
    ✔ blsBatch.verify(single) 32                                          62.10694 ops/s    16.10126 ms/op        -         13 runs   1.24 s
    ✔ blsBatch.verify(single) 64                                          31.24975 ops/s    32.00025 ms/op        -         11 runs   1.51 s
    ✔ blsBatch.verify(single) 128                                         15.72774 ops/s    63.58192 ms/op        -         10 runs   2.01 s
    ✔ blsBatch.asyncVerify(indexed) 3                                     547.1971 ops/s    1.827495 ms/op        -         77 runs  0.828 s
    ✔ blsBatch.asyncVerify(indexed) 8                                     247.2244 ops/s    4.044909 ms/op        -         32 runs   1.00 s
    ✔ blsBatch.asyncVerify(indexed) 32                                    68.08356 ops/s    14.68783 ms/op        -         11 runs   1.11 s
    ✔ blsBatch.asyncVerify(indexed) 64                                    35.13980 ops/s    28.45776 ms/op        -         10 runs   1.32 s
    ✔ blsBatch.asyncVerify(indexed) 128                                   17.62230 ops/s    56.74628 ms/op        -         11 runs   1.88 s
    ✔ blsBatch.asyncVerify(single) 3                                      2795.834 ops/s    357.6750 us/op        -        134 runs   1.71 s
    ✔ blsBatch.asyncVerify(single) 8                                      1076.646 ops/s    928.8100 us/op        -         51 runs   2.35 s
    ✔ blsBatch.asyncVerify(single) 32                                     271.1158 ops/s    3.688461 ms/op        -         15 runs   2.42 s
    ✔ blsBatch.asyncVerify(single) 64                                     138.8553 ops/s    7.201740 ms/op        -         13 runs   2.59 s
    ✔ blsBatch.asyncVerify(single) 128                                    67.72748 ops/s    14.76506 ms/op        -         11 runs   2.92 s
    ✔ blsBatch.asyncVerifySameMessage 3                                   836.4876 ops/s    1.195475 ms/op        -         98 runs   1.07 s
    ✔ blsBatch.asyncVerifySameMessage 8                                   579.9115 ops/s    1.724401 ms/op        -         51 runs   1.40 s
    ✔ blsBatch.asyncVerifySameMessage 32                                  260.1900 ops/s    3.843345 ms/op        -         17 runs   1.96 s
    ✔ blsBatch.asyncVerifySameMessage 64                                  159.4168 ops/s    6.272863 ms/op        -         11 runs   2.27 s
    ✔ blsBatch.asyncVerifySameMessage 128                                 87.91540 ops/s    11.37457 ms/op        -         14 runs   2.87 s
```