### PR TITLE
feat: set attestation data index based on payload status

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1002,15 +1002,16 @@ export function getValidatorApi(
         // After Gloas, attestation.data.index signals payload status in fork-choice:
         // - 0 = EMPTY / not present, 1 = FULL / present
         // - same-slot attestations must always use index = 0
-        const canonicalAttestedBlock = chain.forkChoice.getCanonicalBlockClosestLteSlot(slot);
-        if (
-          !canonicalAttestedBlock ||
-          canonicalAttestedBlock.blockRoot !== toRootHex(beaconBlockRoot) ||
-          canonicalAttestedBlock.slot === slot
-        ) {
+        const canonicalBlock = chain.forkChoice.getCanonicalBlockByRoot(beaconBlockRoot);
+        if (!canonicalBlock) {
+          // This should never happen
+          throw Error(`Block not found in fork choice slot=${slot}, root=${toRootHex(beaconBlockRoot)}`);
+        }
+
+        if (canonicalBlock.slot === slot) {
           index = 0;
         } else {
-          index = canonicalAttestedBlock.payloadStatus === PayloadStatus.FULL ? 1 : 0;
+          index = canonicalBlock.payloadStatus === PayloadStatus.FULL ? 1 : 0;
         }
       } else if (isForkPostElectra(fork)) {
         index = 0;

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1002,15 +1002,15 @@ export function getValidatorApi(
         const canonicalBlock = chain.forkChoice.getCanonicalBlockByRoot(beaconBlockRoot);
         if (!canonicalBlock) {
           // This should never happen
-          throw Error(`Block not found in fork choice slot=${slot}, root=${toRootHex(beaconBlockRoot)}`);
+          throw Error(`Block not found in fork choice for slot=${slot}, root=${toRootHex(beaconBlockRoot)}`);
         }
         // After Gloas, attestation.data.index signals payload status in fork-choice:
         // - 0 = EMPTY / not present, 1 = FULL / present
         // - same-slot attestations must always use index = 0
-        if (canonicalBlock.slot === slot) {
-          index = 0;
-        } else {
+        if (canonicalBlock.slot !== slot) {
           index = canonicalBlock.payloadStatus === PayloadStatus.FULL ? 1 : 0;
+        } else {
+          index = 0;
         }
       } else if (isForkPostElectra(fork)) {
         index = 0;

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -989,16 +989,6 @@ export function getValidatorApi(
       const headBlockRoot = fromHex(headBlockRootHex);
       const fork = config.getForkName(slot);
 
-      let index: CommitteeIndex;
-      if (isForkPostElectra(fork)) {
-        index = 0;
-      } else {
-        if (committeeIndex === undefined) {
-          throw new ApiError(400, `Committee index must be provided for pre-electra fork=${fork}`);
-        }
-        index = committeeIndex;
-      }
-
       const beaconBlockRoot =
         slot >= headSlot
           ? // When attesting to the head slot or later, always use the head of the chain.
@@ -1006,6 +996,29 @@ export function getValidatorApi(
           : // Permit attesting to slots *prior* to the current head. This is desirable when
             // the VC and BN are out-of-sync due to time issues or overloading.
             getBlockRootAtSlot(headState, slot);
+
+      let index: CommitteeIndex;
+      if (isForkPostGloas(fork)) {
+        // In Gloas (ePBS), attestation.data.index signals payload status in fork-choice:
+        // 0 = EMPTY / not present, 1 = FULL / present.
+        // Per spec, same-slot attestations must always use index = 0.
+        const canonicalAttestedBlock = chain.forkChoice.getCanonicalBlockClosestLteSlot(slot);
+        const isMatchingCanonicalRoot =
+          canonicalAttestedBlock !== null && canonicalAttestedBlock.blockRoot === toRootHex(beaconBlockRoot);
+
+        if (!isMatchingCanonicalRoot || canonicalAttestedBlock.slot === slot) {
+          index = 0;
+        } else {
+          index = canonicalAttestedBlock.payloadStatus === PayloadStatus.FULL ? 1 : 0;
+        }
+      } else if (isForkPostElectra(fork)) {
+        index = 0;
+      } else {
+        if (committeeIndex === undefined) {
+          throw new ApiError(400, `Committee index must be provided for pre-electra fork=${fork}`);
+        }
+        index = committeeIndex;
+      }
 
       const targetSlot = computeStartSlotAtEpoch(attEpoch);
       const targetRoot =

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -999,7 +999,7 @@ export function getValidatorApi(
 
       let index: CommitteeIndex;
       if (isForkPostGloas(fork)) {
-        // In Gloas (ePBS), attestation.data.index signals payload status in fork-choice:
+        // After Gloas, attestation.data.index signals payload status in fork-choice:
         // 0 = EMPTY / not present, 1 = FULL / present.
         // Per spec, same-slot attestations must always use index = 0.
         const canonicalAttestedBlock = chain.forkChoice.getCanonicalBlockClosestLteSlot(slot);

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -999,15 +999,14 @@ export function getValidatorApi(
 
       let index: CommitteeIndex;
       if (isForkPostGloas(fork)) {
-        // After Gloas, attestation.data.index signals payload status in fork-choice:
-        // - 0 = EMPTY / not present, 1 = FULL / present
-        // - same-slot attestations must always use index = 0
         const canonicalBlock = chain.forkChoice.getCanonicalBlockByRoot(beaconBlockRoot);
         if (!canonicalBlock) {
           // This should never happen
           throw Error(`Block not found in fork choice slot=${slot}, root=${toRootHex(beaconBlockRoot)}`);
         }
-
+        // After Gloas, attestation.data.index signals payload status in fork-choice:
+        // - 0 = EMPTY / not present, 1 = FULL / present
+        // - same-slot attestations must always use index = 0
         if (canonicalBlock.slot === slot) {
           index = 0;
         } else {

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
-import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
+import {ExecutionStatus, PayloadStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {
   BUILDER_INDEX_SELF_BUILD,
   ForkName,

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1000,8 +1000,8 @@ export function getValidatorApi(
       let index: CommitteeIndex;
       if (isForkPostGloas(fork)) {
         // After Gloas, attestation.data.index signals payload status in fork-choice:
-        // 0 = EMPTY / not present, 1 = FULL / present.
-        // Per spec, same-slot attestations must always use index = 0.
+        // - 0 = EMPTY / not present, 1 = FULL / present
+        // - same-slot attestations must always use index = 0
         const canonicalAttestedBlock = chain.forkChoice.getCanonicalBlockClosestLteSlot(slot);
         const isMatchingCanonicalRoot =
           canonicalAttestedBlock !== null && canonicalAttestedBlock.blockRoot === toRootHex(beaconBlockRoot);

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1003,10 +1003,11 @@ export function getValidatorApi(
         // - 0 = EMPTY / not present, 1 = FULL / present
         // - same-slot attestations must always use index = 0
         const canonicalAttestedBlock = chain.forkChoice.getCanonicalBlockClosestLteSlot(slot);
-        const isMatchingCanonicalRoot =
-          canonicalAttestedBlock !== null && canonicalAttestedBlock.blockRoot === toRootHex(beaconBlockRoot);
-
-        if (!isMatchingCanonicalRoot || canonicalAttestedBlock.slot === slot) {
+        if (
+          !canonicalAttestedBlock ||
+          canonicalAttestedBlock.blockRoot !== toRootHex(beaconBlockRoot) ||
+          canonicalAttestedBlock.slot === slot
+        ) {
           index = 0;
         } else {
           index = canonicalAttestedBlock.payloadStatus === PayloadStatus.FULL ? 1 : 0;

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1211,6 +1211,21 @@ export class ForkChoice implements IForkChoice {
     };
   }
 
+  getCanonicalBlockByRoot(blockRoot: Root): ProtoBlock | null {
+    const blockRootHex = toRootHex(blockRoot);
+    if (blockRootHex === this.head.blockRoot) {
+      return this.head;
+    }
+
+    for (const block of this.protoArray.iterateAncestorNodes(this.head.blockRoot)) {
+      if (block.blockRoot === blockRootHex) {
+        return block;
+      }
+    }
+
+    return null;
+  }
+
   getCanonicalBlockAtSlot(slot: Slot): ProtoBlock | null {
     if (slot > this.head.slot) {
       return null;

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -265,6 +265,7 @@ export interface IForkChoice {
    * Returns both ancestor and non-ancestor blocks in a single traversal.
    */
   getAllAncestorAndNonAncestorBlocks(blockRoot: RootHex): {ancestors: ProtoBlock[]; nonAncestors: ProtoBlock[]};
+  getCanonicalBlockByRoot(blockRoot: Root): ProtoBlock | null;
   getCanonicalBlockAtSlot(slot: Slot): ProtoBlock | null;
   getCanonicalBlockClosestLteSlot(slot: Slot): ProtoBlock | null;
   /**

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -108,7 +108,7 @@ export class AttestationService {
         Array.from(dutiesByCommitteeIndex.entries()).map(([index, dutiesSameCommittee]) => {
           const attestationData: phase0.AttestationData = {
             ...attestationNoCommittee,
-            // Post-Gloas: preserve BN-provided index (payload status signal)
+            // After Gloas, preserve index returned by beacon node (payload status signal)
             index: isForkPostGloas(fork) ? attestationNoCommittee.index : isForkPostElectra(fork) ? 0 : index,
           };
           return this.produceAndPublishAggregates(fork, attestationData, index, dutiesSameCommittee);

--- a/packages/validator/src/services/attestation.ts
+++ b/packages/validator/src/services/attestation.ts
@@ -1,6 +1,6 @@
 import {ApiClient} from "@lodestar/api";
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, isForkPostElectra} from "@lodestar/params";
+import {ForkName, isForkPostElectra, isForkPostGloas} from "@lodestar/params";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {SignedAggregateAndProof, SingleAttestation, Slot, phase0, ssz} from "@lodestar/types";
 import {prettyBytes, sleep, toRootHex} from "@lodestar/utils";
@@ -108,7 +108,8 @@ export class AttestationService {
         Array.from(dutiesByCommitteeIndex.entries()).map(([index, dutiesSameCommittee]) => {
           const attestationData: phase0.AttestationData = {
             ...attestationNoCommittee,
-            index: isForkPostElectra(fork) ? 0 : index,
+            // Post-Gloas: preserve BN-provided index (payload status signal)
+            index: isForkPostGloas(fork) ? attestationNoCommittee.index : isForkPostElectra(fork) ? 0 : index,
           };
           return this.produceAndPublishAggregates(fork, attestationData, index, dutiesSameCommittee);
         })
@@ -145,7 +146,11 @@ export class AttestationService {
 
     await Promise.all(
       duties.map(async ({duty}) => {
-        const index = isForkPostElectra(fork) ? 0 : duty.committeeIndex;
+        const index = isForkPostGloas(fork)
+          ? attestationNoCommittee.index
+          : isForkPostElectra(fork)
+            ? 0
+            : duty.committeeIndex;
         const attestationData: phase0.AttestationData = {...attestationNoCommittee, index};
         const logCtxValidator = {slot, index, head: headRootHex, validatorIndex: duty.validatorIndex};
 

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -841,7 +841,7 @@ export class ValidatorStore {
       );
     }
     if (isPostGloas) {
-      // In Gloas, data.index signals payload status: 0 (EMPTY) or 1 (FULL)
+      // After Gloas, data.index signals payload status: 0 (EMPTY) or 1 (FULL)
       if (data.index !== 0 && data.index !== 1) {
         throw Error(`Invalid payload status index post-gloas during signing: data.index=${data.index}`);
       }

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -834,6 +834,7 @@ export class ValidatorStore {
     const forkSeq = this.config.getForkSeq(data.slot);
     const isPostElectra = forkSeq >= ForkSeq.electra;
     const isPostGloas = forkSeq >= ForkSeq.gloas;
+
     if (!isPostElectra && duty.committeeIndex !== data.index) {
       throw Error(
         `Inconsistent duties during signing: duty.committeeIndex ${duty.committeeIndex} != att.committeeIndex ${data.index}`
@@ -842,7 +843,7 @@ export class ValidatorStore {
     if (isPostGloas) {
       // In Gloas, data.index signals payload status: 0 (EMPTY) or 1 (FULL)
       if (data.index !== 0 && data.index !== 1) {
-        throw Error(`Invalid payload status index post-Gloas during signing: data.index=${data.index}`);
+        throw Error(`Invalid payload status index post-gloas during signing: data.index=${data.index}`);
       }
     } else if (isPostElectra && data.index !== 0) {
       throw Error(`Non-zero committee index post-electra during signing: att.committeeIndex ${data.index}`);

--- a/packages/validator/src/services/validatorStore.ts
+++ b/packages/validator/src/services/validatorStore.ts
@@ -831,13 +831,20 @@ export class ValidatorStore {
       throw Error(`Inconsistent duties during signing: duty.slot ${duty.slot} != att.slot ${data.slot}`);
     }
 
-    const isPostElectra = this.config.getForkSeq(data.slot) >= ForkSeq.electra;
+    const forkSeq = this.config.getForkSeq(data.slot);
+    const isPostElectra = forkSeq >= ForkSeq.electra;
+    const isPostGloas = forkSeq >= ForkSeq.gloas;
     if (!isPostElectra && duty.committeeIndex !== data.index) {
       throw Error(
         `Inconsistent duties during signing: duty.committeeIndex ${duty.committeeIndex} != att.committeeIndex ${data.index}`
       );
     }
-    if (isPostElectra && data.index !== 0) {
+    if (isPostGloas) {
+      // In Gloas, data.index signals payload status: 0 (EMPTY) or 1 (FULL)
+      if (data.index !== 0 && data.index !== 1) {
+        throw Error(`Invalid payload status index post-Gloas during signing: data.index=${data.index}`);
+      }
+    } else if (isPostElectra && data.index !== 0) {
       throw Error(`Non-zero committee index post-electra during signing: att.committeeIndex ${data.index}`);
     }
   }

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -58,7 +58,7 @@ describe("AttestationService", () => {
   });
 
   const electraConfig: Partial<ChainConfig> = {ELECTRA_FORK_EPOCH: 0};
-  const gloasConfig: Partial<ChainConfig> = {ELECTRA_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0};
+  const gloasConfig: Partial<ChainConfig> = {GLOAS_FORK_EPOCH: 0};
 
   const testContexts: [string, AttestationServiceOpts, Partial<ChainConfig>][] = [
     ["With default configuration", {}, {}],

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -57,8 +57,8 @@ describe("AttestationService", () => {
     vi.resetAllMocks();
   });
 
-  const electraConfig: Partial<ChainConfig> = {ELECTRA_FORK_EPOCH: 1};
-  const gloasConfig: Partial<ChainConfig> = {GLOAS_FORK_EPOCH: 0};
+  const electraConfig: Partial<ChainConfig> = {ELECTRA_FORK_EPOCH: 0};
+  const gloasConfig: Partial<ChainConfig> = {ELECTRA_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 0};
 
   const testContexts: [string, AttestationServiceOpts, Partial<ChainConfig>][] = [
     ["With default configuration", {}, {}],
@@ -72,8 +72,8 @@ describe("AttestationService", () => {
         const slot = 0;
         const clock = new ClockMock();
         const config = createChainForkConfig({...defaultConfig, ...chainConfig});
-        const isPostElectra = chainConfig.ELECTRA_FORK_EPOCH === 0;
-        const isPostGloas = chainConfig.GLOAS_FORK_EPOCH === 0;
+        const isPostElectra = config.getForkSeq(slot) >= ForkSeq.electra;
+        const isPostGloas = config.getForkSeq(slot) >= ForkSeq.gloas;
         const attestationService = new AttestationService(
           loggerVc,
           api,

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -3,7 +3,7 @@ import {SecretKey} from "@chainsafe/blst";
 import {toHexString} from "@chainsafe/ssz";
 import {ChainConfig, createChainForkConfig} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
-import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {AttestationService, AttestationServiceOpts} from "../../../src/services/attestation.js";
 import {AttDutyAndProof} from "../../../src/services/attestationDuties.js";
@@ -58,22 +58,22 @@ describe("AttestationService", () => {
   });
 
   const electraConfig: Partial<ChainConfig> = {ELECTRA_FORK_EPOCH: 1};
-  const gloasConfig: Partial<ChainConfig> = {ELECTRA_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 1};
+  const gloasConfig: Partial<ChainConfig> = {GLOAS_FORK_EPOCH: 0};
 
-  const testContexts: [string, AttestationServiceOpts, Partial<ChainConfig>, ForkName, number][] = [
-    ["With default configuration", {}, {}, ForkName.phase0, 0],
-    ["With default configuration post-electra", {}, electraConfig, ForkName.electra, SLOTS_PER_EPOCH],
-    ["With default configuration post-gloas", {}, gloasConfig, ForkName.gloas, SLOTS_PER_EPOCH],
+  const testContexts: [string, AttestationServiceOpts, Partial<ChainConfig>][] = [
+    ["With default configuration", {}, {}],
+    ["With default configuration post-electra", {}, electraConfig],
+    ["With default configuration post-gloas", {}, gloasConfig],
   ];
 
-  for (const [title, opts, chainConfig, expectedFork, testSlot] of testContexts) {
+  for (const [title, opts, chainConfig] of testContexts) {
     describe(title, () => {
       it("Should produce, sign, and publish an attestation + aggregate", async () => {
+        const slot = 0;
         const clock = new ClockMock();
         const config = createChainForkConfig({...defaultConfig, ...chainConfig});
-        expect(config.getForkName(testSlot)).toBe(expectedFork);
-        const isPostElectra = config.getForkName(testSlot) !== ForkName.phase0;
-        const isPostGloas = config.getForkName(testSlot) === ForkName.gloas;
+        const isPostElectra = chainConfig.ELECTRA_FORK_EPOCH === 0;
+        const isPostGloas = chainConfig.GLOAS_FORK_EPOCH === 0;
         const attestationService = new AttestationService(
           loggerVc,
           api,
@@ -90,6 +90,9 @@ describe("AttestationService", () => {
         const singleAttestation = isPostElectra
           ? ssz.electra.SingleAttestation.defaultValue()
           : ssz.phase0.Attestation.defaultValue();
+        if (isPostGloas) {
+          singleAttestation.data.index = 1;
+        }
         const aggregatedAttestation = isPostElectra
           ? ssz.electra.Attestation.defaultValue()
           : ssz.phase0.Attestation.defaultValue();
@@ -99,7 +102,7 @@ describe("AttestationService", () => {
         const duties: AttDutyAndProof[] = [
           {
             duty: {
-              slot: testSlot,
+              slot,
               committeeIndex: 6,
               committeeLength: 120,
               committeesAtSlot: 120,
@@ -110,11 +113,6 @@ describe("AttestationService", () => {
             selectionProof: ZERO_HASH,
           },
         ];
-        if (isPostGloas) {
-          singleAttestation.data.index = 1;
-        }
-        singleAttestation.data.slot = testSlot;
-        aggregatedAttestation.data.slot = testSlot;
 
         // Return empty replies to duties service
         api.beacon.postStateValidators.mockResolvedValue(
@@ -130,7 +128,7 @@ describe("AttestationService", () => {
         // Mock beacon's attestation and aggregates endpoints
         api.validator.produceAttestationData.mockResolvedValue(mockApiResponse({data: singleAttestation.data}));
         api.validator.getAggregatedAttestationV2.mockResolvedValue(
-          mockApiResponse({data: aggregatedAttestation, meta: {version: expectedFork}})
+          mockApiResponse({data: aggregatedAttestation, meta: {version: config.getForkName(slot)}})
         );
         api.beacon.submitPoolAttestationsV2.mockResolvedValue(mockApiResponse({}));
         api.validator.publishAggregateAndProofsV2.mockResolvedValue(mockApiResponse({}));
@@ -140,7 +138,7 @@ describe("AttestationService", () => {
         validatorStore.signAggregateAndProof.mockResolvedValue(aggregateAndProof);
 
         // Trigger clock onSlot for slot 0
-        await clock.tickSlotFns(testSlot, controller.signal);
+        await clock.tickSlotFns(slot, controller.signal);
 
         // Must submit the attestation received through produceAttestationData()
         expect(api.beacon.submitPoolAttestationsV2).toHaveBeenCalledOnce();
@@ -157,10 +155,11 @@ describe("AttestationService", () => {
           : isPostElectra
             ? 0
             : duties[0].duty.committeeIndex;
+
         expect(validatorStore.signAttestation).toHaveBeenCalledWith(
           duties[0].duty,
           expect.objectContaining({index: expectedIndex}),
-          Math.floor(testSlot / SLOTS_PER_EPOCH)
+          computeEpochAtSlot(slot)
         );
       });
     });

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -3,7 +3,7 @@ import {SecretKey} from "@chainsafe/blst";
 import {toHexString} from "@chainsafe/ssz";
 import {ChainConfig, createChainForkConfig} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
-import {ForkName} from "@lodestar/params";
+import {ForkName, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {AttestationService, AttestationServiceOpts} from "../../../src/services/attestation.js";
 import {AttDutyAndProof} from "../../../src/services/attestationDuties.js";
@@ -57,19 +57,23 @@ describe("AttestationService", () => {
     vi.resetAllMocks();
   });
 
-  const electraConfig: Partial<ChainConfig> = {ELECTRA_FORK_EPOCH: 0};
+  const electraConfig: Partial<ChainConfig> = {ELECTRA_FORK_EPOCH: 1};
+  const gloasConfig: Partial<ChainConfig> = {ELECTRA_FORK_EPOCH: 0, GLOAS_FORK_EPOCH: 1};
 
-  const testContexts: [string, AttestationServiceOpts, Partial<ChainConfig>][] = [
-    ["With default configuration", {}, {}],
-    ["With default configuration post-electra", {}, electraConfig],
+  const testContexts: [string, AttestationServiceOpts, Partial<ChainConfig>, ForkName, number][] = [
+    ["With default configuration", {}, {}, ForkName.phase0, 0],
+    ["With default configuration post-electra", {}, electraConfig, ForkName.electra, SLOTS_PER_EPOCH],
+    ["With default configuration post-gloas", {}, gloasConfig, ForkName.gloas, SLOTS_PER_EPOCH],
   ];
 
-  for (const [title, opts, chainConfig] of testContexts) {
+  for (const [title, opts, chainConfig, expectedFork, testSlot] of testContexts) {
     describe(title, () => {
       it("Should produce, sign, and publish an attestation + aggregate", async () => {
         const clock = new ClockMock();
         const config = createChainForkConfig({...defaultConfig, ...chainConfig});
-        const isPostElectra = chainConfig.ELECTRA_FORK_EPOCH === 0;
+        expect(config.getForkName(testSlot)).toBe(expectedFork);
+        const isPostElectra = config.getForkName(testSlot) !== ForkName.phase0;
+        const isPostGloas = config.getForkName(testSlot) === ForkName.gloas;
         const attestationService = new AttestationService(
           loggerVc,
           api,
@@ -95,8 +99,8 @@ describe("AttestationService", () => {
         const duties: AttDutyAndProof[] = [
           {
             duty: {
-              slot: 0,
-              committeeIndex: singleAttestation.data.index,
+              slot: testSlot,
+              committeeIndex: 6,
               committeeLength: 120,
               committeesAtSlot: 120,
               validatorCommitteeIndex: 1,
@@ -106,6 +110,11 @@ describe("AttestationService", () => {
             selectionProof: ZERO_HASH,
           },
         ];
+        if (isPostGloas) {
+          singleAttestation.data.index = 1;
+        }
+        singleAttestation.data.slot = testSlot;
+        aggregatedAttestation.data.slot = testSlot;
 
         // Return empty replies to duties service
         api.beacon.postStateValidators.mockResolvedValue(
@@ -121,7 +130,7 @@ describe("AttestationService", () => {
         // Mock beacon's attestation and aggregates endpoints
         api.validator.produceAttestationData.mockResolvedValue(mockApiResponse({data: singleAttestation.data}));
         api.validator.getAggregatedAttestationV2.mockResolvedValue(
-          mockApiResponse({data: aggregatedAttestation, meta: {version: ForkName.electra}})
+          mockApiResponse({data: aggregatedAttestation, meta: {version: expectedFork}})
         );
         api.beacon.submitPoolAttestationsV2.mockResolvedValue(mockApiResponse({}));
         api.validator.publishAggregateAndProofsV2.mockResolvedValue(mockApiResponse({}));
@@ -131,7 +140,7 @@ describe("AttestationService", () => {
         validatorStore.signAggregateAndProof.mockResolvedValue(aggregateAndProof);
 
         // Trigger clock onSlot for slot 0
-        await clock.tickSlotFns(0, controller.signal);
+        await clock.tickSlotFns(testSlot, controller.signal);
 
         // Must submit the attestation received through produceAttestationData()
         expect(api.beacon.submitPoolAttestationsV2).toHaveBeenCalledOnce();
@@ -142,6 +151,17 @@ describe("AttestationService", () => {
         expect(api.validator.publishAggregateAndProofsV2).toHaveBeenCalledWith({
           signedAggregateAndProofs: [aggregateAndProof],
         });
+
+        const expectedIndex = isPostGloas
+          ? singleAttestation.data.index
+          : isPostElectra
+            ? 0
+            : duties[0].duty.committeeIndex;
+        expect(validatorStore.signAttestation).toHaveBeenCalledWith(
+          duties[0].duty,
+          expect.objectContaining({index: expectedIndex}),
+          Math.floor(testSlot / SLOTS_PER_EPOCH)
+        );
       });
     });
   }

--- a/packages/validator/test/unit/services/attestation.test.ts
+++ b/packages/validator/test/unit/services/attestation.test.ts
@@ -3,6 +3,7 @@ import {SecretKey} from "@chainsafe/blst";
 import {toHexString} from "@chainsafe/ssz";
 import {ChainConfig, createChainForkConfig} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
+import {ForkSeq} from "@lodestar/params";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {AttestationService, AttestationServiceOpts} from "../../../src/services/attestation.js";


### PR DESCRIPTION
After Gloas, attestation.data.index signals payload status in fork-choice:
- 0 = EMPTY / not present, 1 = FULL / present
- same-slot attestations must always use index = 0