### PR TITLE
feat: add execution_payload_envelopes_by_range serving

### DIFF
--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -298,10 +298,16 @@ export class ReqRespBeaconNode extends ReqResp {
     }
 
     if (ForkSeq[fork] >= ForkSeq.gloas) {
-      protocolsAtFork.push([
-        protocols.ExecutionPayloadEnvelopesByRoot(fork, this.config),
-        this.getHandler(ReqRespMethod.ExecutionPayloadEnvelopesByRoot),
-      ]);
+      protocolsAtFork.push(
+        [
+          protocols.ExecutionPayloadEnvelopesByRange(fork, this.config),
+          this.getHandler(ReqRespMethod.ExecutionPayloadEnvelopesByRange),
+        ],
+        [
+          protocols.ExecutionPayloadEnvelopesByRoot(fork, this.config),
+          this.getHandler(ReqRespMethod.ExecutionPayloadEnvelopesByRoot),
+        ]
+      );
     }
 
     return protocolsAtFork;

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
@@ -1,0 +1,77 @@
+import {PeerId} from "@libp2p/interface";
+import {ResponseOutgoing} from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {phase0, ssz} from "@lodestar/types";
+import {fromHex} from "@lodestar/utils";
+import {IBeaconChain} from "../../../chain/index.js";
+import {IBeaconDb} from "../../../db/index.js";
+import {prettyPrintPeerId} from "../../util.ts";
+import {validateBeaconBlocksByRangeRequest} from "./beaconBlocksByRange.js";
+
+/**
+ * Serve signed execution payload envelopes over req/resp by range.
+ *
+ * Behavior is equivalent to BeaconBlocksByRange v2 but with envelope responses,
+ * matching spec for ExecutionPayloadEnvelopesByRange.
+ */
+export async function* onExecutionPayloadEnvelopesByRange(
+  request: phase0.BeaconBlocksByRangeRequest,
+  chain: IBeaconChain,
+  db: IBeaconDb,
+  peerId: PeerId,
+  peerClient: string
+): AsyncIterable<ResponseOutgoing> {
+  const {startSlot, count} = validateBeaconBlocksByRangeRequest(chain.config, request);
+  const endSlot = startSlot + count;
+
+  if (startSlot < chain.earliestAvailableSlot) {
+    chain.logger.verbose("Peer did not respect earliestAvailableSlot for ExecutionPayloadEnvelopesByRange", {
+      peer: prettyPrintPeerId(peerId),
+      client: peerClient,
+    });
+    return;
+  }
+
+  const finalizedSlot = chain.forkChoice.getFinalizedCheckpointSlot();
+
+  // Finalized range (archived by slot)
+  if (startSlot <= finalizedSlot) {
+    const finalizedEndSlot = Math.min(endSlot, finalizedSlot + 1);
+
+    for (let slot = startSlot; slot < finalizedEndSlot; slot++) {
+      const envelope = await db.executionPayloadEnvelopeArchive.get(slot);
+      if (!envelope) {
+        continue;
+      }
+
+      yield {
+        data: ssz.gloas.SignedExecutionPayloadEnvelope.serialize(envelope),
+        boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(slot)),
+      };
+    }
+  }
+
+  // Non-finalized range (canonical head chain by root)
+  if (endSlot > finalizedSlot) {
+    const headRoot = chain.forkChoice.getHeadRoot();
+    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
+
+    for (let i = headChain.length - 1; i >= 0; i--) {
+      const block = headChain[i];
+
+      if (block.slot >= startSlot && block.slot < endSlot) {
+        const envelope = await db.executionPayloadEnvelope.get(fromHex(block.blockRoot));
+        if (!envelope) {
+          continue;
+        }
+
+        yield {
+          data: ssz.gloas.SignedExecutionPayloadEnvelope.serialize(envelope),
+          boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(block.slot)),
+        };
+      } else if (block.slot >= endSlot) {
+        break;
+      }
+    }
+  }
+}

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
@@ -1,29 +1,28 @@
 import {PeerId} from "@libp2p/interface";
-import {ResponseOutgoing} from "@lodestar/reqresp";
+import {ChainConfig} from "@lodestar/config";
+import {GENESIS_SLOT} from "@lodestar/params";
+import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
 import {computeEpochAtSlot} from "@lodestar/state-transition";
-import {phase0, ssz} from "@lodestar/types";
+import {gloas, ssz} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../chain/index.js";
 import {IBeaconDb} from "../../../db/index.js";
 import {prettyPrintPeerId} from "../../util.ts";
-import {validateBeaconBlocksByRangeRequest} from "./beaconBlocksByRange.js";
 
 /**
  * Serve signed execution payload envelopes over req/resp by range.
  *
- * Behavior is equivalent to BeaconBlocksByRange v2 but with envelope responses,
- * matching spec for ExecutionPayloadEnvelopesByRange.
+ * Spec: https://github.com/ethereum/consensus-specs/blob/master/specs/gloas/p2p-interface.md#executionpayloadenvelopesbyrange-v1
  */
 export async function* onExecutionPayloadEnvelopesByRange(
-  request: phase0.BeaconBlocksByRangeRequest,
+  request: gloas.ExecutionPayloadEnvelopesByRangeRequest,
   chain: IBeaconChain,
   db: IBeaconDb,
   peerId: PeerId,
   peerClient: string
 ): AsyncIterable<ResponseOutgoing> {
-  const {startSlot, count} = validateBeaconBlocksByRangeRequest(chain.config, request);
-  const step = request.step > 0 ? request.step : 1;
-  const endSlot = startSlot + count * step;
+  const {startSlot, count} = validateEnvelopesByRangeRequest(chain.config, request);
+  const endSlot = startSlot + count;
 
   if (startSlot < chain.earliestAvailableSlot) {
     chain.logger.verbose("Peer did not respect earliestAvailableSlot for ExecutionPayloadEnvelopesByRange", {
@@ -39,7 +38,7 @@ export async function* onExecutionPayloadEnvelopesByRange(
   if (startSlot <= finalizedSlot) {
     const finalizedEndSlot = Math.min(endSlot, finalizedSlot + 1);
 
-    for (let slot = startSlot; slot < finalizedEndSlot; slot += step) {
+    for (let slot = startSlot; slot < finalizedEndSlot; slot++) {
       const envelope = await db.executionPayloadEnvelopeArchive.get(slot);
       if (!envelope) {
         continue;
@@ -53,14 +52,13 @@ export async function* onExecutionPayloadEnvelopesByRange(
   }
 
   // Non-finalized range (canonical head chain by root)
+  // Note: getAllAncestorBlocks excludes the Gloas head (PENDING variant),
+  // so we must check the head separately via getBlockHexDefaultStatus.
   const nonFinalizedStartSlot = Math.max(startSlot, finalizedSlot + 1);
   if (endSlot > nonFinalizedStartSlot) {
     const seenRoots = new Set<string>();
 
-    const maybeYieldEnvelope = async function* (block: {slot: number; blockRoot: string}) {
-      if (block.slot < nonFinalizedStartSlot || block.slot >= endSlot || (block.slot - startSlot) % step !== 0) {
-        return;
-      }
+    const yieldEnvelope = async function* (block: {slot: number; blockRoot: string}) {
       if (seenRoots.has(block.blockRoot)) {
         return;
       }
@@ -76,12 +74,8 @@ export async function* onExecutionPayloadEnvelopesByRange(
       };
     };
 
+    // Iterate ancestors oldest-to-newest (ascending slot order)
     const headRoot = chain.forkChoice.getHeadRoot();
-    const headBlock = chain.forkChoice.getBlockHexDefaultStatus(headRoot);
-    if (headBlock) {
-      yield* maybeYieldEnvelope(headBlock);
-    }
-
     const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
     for (let i = headChain.length - 1; i >= 0; i--) {
       const block = headChain[i];
@@ -93,7 +87,33 @@ export async function* onExecutionPayloadEnvelopesByRange(
         break;
       }
 
-      yield* maybeYieldEnvelope(block);
+      yield* yieldEnvelope(block);
+    }
+
+    // Head block (may be excluded from ancestor list for Gloas PENDING variant)
+    const headBlock = chain.forkChoice.getBlockHexDefaultStatus(headRoot);
+    if (headBlock && headBlock.slot >= nonFinalizedStartSlot && headBlock.slot < endSlot) {
+      yield* yieldEnvelope(headBlock);
     }
   }
+}
+
+export function validateEnvelopesByRangeRequest(
+  config: ChainConfig,
+  request: gloas.ExecutionPayloadEnvelopesByRangeRequest
+): gloas.ExecutionPayloadEnvelopesByRangeRequest {
+  const {startSlot} = request;
+  let {count} = request;
+
+  if (count < 1) {
+    throw new ResponseError(RespStatus.INVALID_REQUEST, "count < 1");
+  }
+  if (startSlot < GENESIS_SLOT) {
+    throw new ResponseError(RespStatus.INVALID_REQUEST, "startSlot < genesis");
+  }
+  if (count > config.MAX_REQUEST_BLOCKS_DENEB) {
+    count = config.MAX_REQUEST_BLOCKS_DENEB;
+  }
+
+  return {startSlot, count};
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
@@ -22,7 +22,8 @@ export async function* onExecutionPayloadEnvelopesByRange(
   peerClient: string
 ): AsyncIterable<ResponseOutgoing> {
   const {startSlot, count} = validateBeaconBlocksByRangeRequest(chain.config, request);
-  const endSlot = startSlot + count;
+  const step = request.step > 0 ? request.step : 1;
+  const endSlot = startSlot + count * step;
 
   if (startSlot < chain.earliestAvailableSlot) {
     chain.logger.verbose("Peer did not respect earliestAvailableSlot for ExecutionPayloadEnvelopesByRange", {
@@ -38,7 +39,7 @@ export async function* onExecutionPayloadEnvelopesByRange(
   if (startSlot <= finalizedSlot) {
     const finalizedEndSlot = Math.min(endSlot, finalizedSlot + 1);
 
-    for (let slot = startSlot; slot < finalizedEndSlot; slot++) {
+    for (let slot = startSlot; slot < finalizedEndSlot; slot += step) {
       const envelope = await db.executionPayloadEnvelopeArchive.get(slot);
       if (!envelope) {
         continue;
@@ -52,26 +53,47 @@ export async function* onExecutionPayloadEnvelopesByRange(
   }
 
   // Non-finalized range (canonical head chain by root)
-  if (endSlot > finalizedSlot) {
-    const headRoot = chain.forkChoice.getHeadRoot();
-    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
+  const nonFinalizedStartSlot = Math.max(startSlot, finalizedSlot + 1);
+  if (endSlot > nonFinalizedStartSlot) {
+    const seenRoots = new Set<string>();
 
+    const maybeYieldEnvelope = async function* (block: {slot: number; blockRoot: string}) {
+      if (block.slot < nonFinalizedStartSlot || block.slot >= endSlot || (block.slot - startSlot) % step !== 0) {
+        return;
+      }
+      if (seenRoots.has(block.blockRoot)) {
+        return;
+      }
+      const envelope = await db.executionPayloadEnvelope.get(fromHex(block.blockRoot));
+      if (!envelope) {
+        return;
+      }
+
+      seenRoots.add(block.blockRoot);
+      yield {
+        data: ssz.gloas.SignedExecutionPayloadEnvelope.serialize(envelope),
+        boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(block.slot)),
+      };
+    };
+
+    const headRoot = chain.forkChoice.getHeadRoot();
+    const headBlock = chain.forkChoice.getBlockHexDefaultStatus(headRoot);
+    if (headBlock) {
+      yield* maybeYieldEnvelope(headBlock);
+    }
+
+    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
     for (let i = headChain.length - 1; i >= 0; i--) {
       const block = headChain[i];
 
-      if (block.slot >= startSlot && block.slot < endSlot) {
-        const envelope = await db.executionPayloadEnvelope.get(fromHex(block.blockRoot));
-        if (!envelope) {
-          continue;
-        }
-
-        yield {
-          data: ssz.gloas.SignedExecutionPayloadEnvelope.serialize(envelope),
-          boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(block.slot)),
-        };
-      } else if (block.slot >= endSlot) {
+      if (block.slot < nonFinalizedStartSlot) {
+        continue;
+      }
+      if (block.slot >= endSlot) {
         break;
       }
+
+      yield* maybeYieldEnvelope(block);
     }
   }
 }

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -65,7 +65,7 @@ export function getReqRespHandlers({db, chain}: {db: IBeaconDb; chain: IBeaconCh
       return onDataColumnSidecarsByRoot(body, chain, db, peerId, peerClient);
     },
     [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: (req, peerId, peerClient) => {
-      const body = ssz.phase0.BeaconBlocksByRangeRequest.deserialize(req.data);
+      const body = ssz.gloas.BeaconBlocksByRangeRequest.deserialize(req.data);
       return onExecutionPayloadEnvelopesByRange(body, chain, db, peerId, peerClient);
     },
     [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: (req) => {

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -15,6 +15,7 @@ import {onBlobSidecarsByRange} from "./blobSidecarsByRange.js";
 import {onBlobSidecarsByRoot} from "./blobSidecarsByRoot.js";
 import {onDataColumnSidecarsByRange} from "./dataColumnSidecarsByRange.js";
 import {onDataColumnSidecarsByRoot} from "./dataColumnSidecarsByRoot.js";
+import {onExecutionPayloadEnvelopesByRange} from "./executionPayloadEnvelopesByRange.js";
 import {onExecutionPayloadEnvelopesByRoot} from "./executionPayloadEnvelopesByRoot.js";
 import {onLightClientBootstrap} from "./lightClientBootstrap.js";
 import {onLightClientFinalityUpdate} from "./lightClientFinalityUpdate.js";
@@ -62,6 +63,10 @@ export function getReqRespHandlers({db, chain}: {db: IBeaconDb; chain: IBeaconCh
     [ReqRespMethod.DataColumnSidecarsByRoot]: (req, peerId, peerClient) => {
       const body = DataColumnSidecarsByRootRequestType(chain.config).deserialize(req.data);
       return onDataColumnSidecarsByRoot(body, chain, db, peerId, peerClient);
+    },
+    [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: (req, peerId, peerClient) => {
+      const body = ssz.phase0.BeaconBlocksByRangeRequest.deserialize(req.data);
+      return onExecutionPayloadEnvelopesByRange(body, chain, db, peerId, peerClient);
     },
     [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: (req) => {
       const body = ExecutionPayloadEnvelopesByRootRequestType(chain.config).deserialize(req.data);

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -65,7 +65,7 @@ export function getReqRespHandlers({db, chain}: {db: IBeaconDb; chain: IBeaconCh
       return onDataColumnSidecarsByRoot(body, chain, db, peerId, peerClient);
     },
     [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: (req, peerId, peerClient) => {
-      const body = ssz.gloas.BeaconBlocksByRangeRequest.deserialize(req.data);
+      const body = ssz.gloas.ExecutionPayloadEnvelopesByRangeRequest.deserialize(req.data);
       return onExecutionPayloadEnvelopesByRange(body, chain, db, peerId, peerClient);
     },
     [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: (req) => {

--- a/packages/beacon-node/src/network/reqresp/protocols.ts
+++ b/packages/beacon-node/src/network/reqresp/protocols.ts
@@ -94,6 +94,12 @@ export const DataColumnSidecarsByRoot = toProtocol({
   contextBytesType: ContextBytesType.ForkDigest,
 });
 
+export const ExecutionPayloadEnvelopesByRange = toProtocol({
+  method: ReqRespMethod.ExecutionPayloadEnvelopesByRange,
+  version: Version.V1,
+  contextBytesType: ContextBytesType.ForkDigest,
+});
+
 export const ExecutionPayloadEnvelopesByRoot = toProtocol({
   method: ReqRespMethod.ExecutionPayloadEnvelopesByRoot,
   version: Version.V1,

--- a/packages/beacon-node/src/network/reqresp/rateLimit.ts
+++ b/packages/beacon-node/src/network/reqresp/rateLimit.ts
@@ -73,6 +73,16 @@ export const rateLimitQuotas: (fork: ForkName, config: BeaconConfig) => Record<R
       req.reduce((total, item) => total + item.columns.length, 0)
     ),
   },
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: {
+    // Rationale: similar to BeaconBlocksByRange — one envelope per block in range
+    byPeer: {quota: config.MAX_REQUEST_BLOCKS_DENEB, quotaTimeMs: 10_000},
+    getRequestCount: getRequestCountFn(
+      fork,
+      config,
+      ReqRespMethod.ExecutionPayloadEnvelopesByRange,
+      (req) => req.count
+    ),
+  },
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: {
     // Rationale: similar to BeaconBlocksByRoot — one envelope per block
     byPeer: {quota: config.MAX_REQUEST_PAYLOADS, quotaTimeMs: 10_000},

--- a/packages/beacon-node/src/network/reqresp/rateLimit.ts
+++ b/packages/beacon-node/src/network/reqresp/rateLimit.ts
@@ -74,8 +74,8 @@ export const rateLimitQuotas: (fork: ForkName, config: BeaconConfig) => Record<R
     ),
   },
   [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: {
-    // Rationale: similar to BeaconBlocksByRange — one envelope per block in range
-    byPeer: {quota: config.MAX_REQUEST_BLOCKS_DENEB, quotaTimeMs: 10_000},
+    // Rationale: bounded by payload request limits
+    byPeer: {quota: config.MAX_REQUEST_PAYLOADS, quotaTimeMs: 10_000},
     getRequestCount: getRequestCountFn(
       fork,
       config,

--- a/packages/beacon-node/src/network/reqresp/score.ts
+++ b/packages/beacon-node/src/network/reqresp/score.ts
@@ -47,6 +47,7 @@ export function onOutgoingReqRespError(e: RequestError, method: ReqRespMethod): 
           return PeerAction.LowToleranceError;
         case ReqRespMethod.BeaconBlocksByRange:
         case ReqRespMethod.BeaconBlocksByRoot:
+        case ReqRespMethod.ExecutionPayloadEnvelopesByRange:
           return PeerAction.MidToleranceError;
         default:
           return null;

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -147,8 +147,8 @@ export const responseSszTypeByMethod: {[K in ReqRespMethod]: ResponseTypeGetter<
   [ReqRespMethod.LightClientBootstrap]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientBootstrap,
   [ReqRespMethod.LightClientUpdatesByRange]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientUpdate,
   [ReqRespMethod.LightClientFinalityUpdate]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientFinalityUpdate,
-  [ReqRespMethod.DataColumnSidecarsByRange]: (fork) => sszTypesFor(onlyPostFuluFork(fork)).DataColumnSidecar,
-  [ReqRespMethod.DataColumnSidecarsByRoot]: (fork) => sszTypesFor(onlyPostFuluFork(fork)).DataColumnSidecar,
+  [ReqRespMethod.DataColumnSidecarsByRange]: (fork) => sszTypesFor(onlyPostFuluFork(fork)).DataColumnSidecar as Type<fulu.DataColumnSidecar>,
+  [ReqRespMethod.DataColumnSidecarsByRoot]: (fork) => sszTypesFor(onlyPostFuluFork(fork)).DataColumnSidecar as Type<fulu.DataColumnSidecar>,
   [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: () => ssz.gloas.SignedExecutionPayloadEnvelope,
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: () => ssz.gloas.SignedExecutionPayloadEnvelope,
   [ReqRespMethod.LightClientOptimisticUpdate]: (fork) =>

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -1,6 +1,6 @@
 import {Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {ForkName, ForkPostAltair, isForkPostAltair} from "@lodestar/params";
+import {ForkName, ForkPostAltair, ForkPostFulu, isForkPostAltair, isForkPostFulu} from "@lodestar/params";
 import {Protocol, ProtocolHandler, ReqRespRequest} from "@lodestar/reqresp";
 import {
   LightClientBootstrap,
@@ -147,8 +147,8 @@ export const responseSszTypeByMethod: {[K in ReqRespMethod]: ResponseTypeGetter<
   [ReqRespMethod.LightClientBootstrap]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientBootstrap,
   [ReqRespMethod.LightClientUpdatesByRange]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientUpdate,
   [ReqRespMethod.LightClientFinalityUpdate]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientFinalityUpdate,
-  [ReqRespMethod.DataColumnSidecarsByRange]: () => ssz.fulu.DataColumnSidecar,
-  [ReqRespMethod.DataColumnSidecarsByRoot]: () => ssz.fulu.DataColumnSidecar,
+  [ReqRespMethod.DataColumnSidecarsByRange]: (fork) => sszTypesFor(onlyPostFuluFork(fork)).DataColumnSidecar,
+  [ReqRespMethod.DataColumnSidecarsByRoot]: (fork) => sszTypesFor(onlyPostFuluFork(fork)).DataColumnSidecar,
   [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: () => ssz.gloas.SignedExecutionPayloadEnvelope,
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: () => ssz.gloas.SignedExecutionPayloadEnvelope,
   [ReqRespMethod.LightClientOptimisticUpdate]: (fork) =>
@@ -160,6 +160,13 @@ function onlyPostAltairFork(fork: ForkName): ForkPostAltair {
     return fork;
   }
   throw Error(`Not a post-altair fork ${fork}`);
+}
+
+function onlyPostFuluFork(fork: ForkName): ForkPostFulu {
+  if (isForkPostFulu(fork)) {
+    return fork;
+  }
+  throw Error(`Not a post-fulu fork ${fork}`);
 }
 
 export type RequestTypedContainer = {

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -54,6 +54,7 @@ export enum ReqRespMethod {
 }
 
 // To typesafe events to network
+type ExecutionPayloadEnvelopesByRangeRequest = phase0.BeaconBlocksByRangeRequest;
 export type RequestBodyByMethod = {
   [ReqRespMethod.Status]: Status;
   [ReqRespMethod.Goodbye]: phase0.Goodbye;
@@ -65,7 +66,7 @@ export type RequestBodyByMethod = {
   [ReqRespMethod.BlobSidecarsByRoot]: BlobSidecarsByRootRequest;
   [ReqRespMethod.DataColumnSidecarsByRange]: fulu.DataColumnSidecarsByRangeRequest;
   [ReqRespMethod.DataColumnSidecarsByRoot]: DataColumnSidecarsByRootRequest;
-  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: phase0.BeaconBlocksByRangeRequest;
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: ExecutionPayloadEnvelopesByRangeRequest;
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: ExecutionPayloadEnvelopesByRootRequest;
   [ReqRespMethod.LightClientBootstrap]: Root;
   [ReqRespMethod.LightClientUpdatesByRange]: altair.LightClientUpdatesByRange;
@@ -114,7 +115,7 @@ export const requestSszTypeByMethod: (
   [ReqRespMethod.BlobSidecarsByRoot]: BlobSidecarsByRootRequestType(fork, config),
   [ReqRespMethod.DataColumnSidecarsByRange]: ssz.fulu.DataColumnSidecarsByRangeRequest,
   [ReqRespMethod.DataColumnSidecarsByRoot]: DataColumnSidecarsByRootRequestType(config),
-  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: ssz.phase0.BeaconBlocksByRangeRequest,
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: ssz.gloas.BeaconBlocksByRangeRequest,
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: ExecutionPayloadEnvelopesByRootRequestType(config),
 
   [ReqRespMethod.LightClientBootstrap]: ssz.Root,

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -45,6 +45,7 @@ export enum ReqRespMethod {
   BlobSidecarsByRoot = "blob_sidecars_by_root",
   DataColumnSidecarsByRange = "data_column_sidecars_by_range",
   DataColumnSidecarsByRoot = "data_column_sidecars_by_root",
+  ExecutionPayloadEnvelopesByRange = "execution_payload_envelopes_by_range",
   ExecutionPayloadEnvelopesByRoot = "execution_payload_envelopes_by_root",
   LightClientBootstrap = "light_client_bootstrap",
   LightClientUpdatesByRange = "light_client_updates_by_range",
@@ -64,6 +65,7 @@ export type RequestBodyByMethod = {
   [ReqRespMethod.BlobSidecarsByRoot]: BlobSidecarsByRootRequest;
   [ReqRespMethod.DataColumnSidecarsByRange]: fulu.DataColumnSidecarsByRangeRequest;
   [ReqRespMethod.DataColumnSidecarsByRoot]: DataColumnSidecarsByRootRequest;
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: phase0.BeaconBlocksByRangeRequest;
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: ExecutionPayloadEnvelopesByRootRequest;
   [ReqRespMethod.LightClientBootstrap]: Root;
   [ReqRespMethod.LightClientUpdatesByRange]: altair.LightClientUpdatesByRange;
@@ -83,6 +85,7 @@ type ResponseBodyByMethod = {
   [ReqRespMethod.BlobSidecarsByRoot]: deneb.BlobSidecar;
   [ReqRespMethod.DataColumnSidecarsByRange]: fulu.DataColumnSidecar;
   [ReqRespMethod.DataColumnSidecarsByRoot]: fulu.DataColumnSidecar;
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: gloas.SignedExecutionPayloadEnvelope;
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: gloas.SignedExecutionPayloadEnvelope;
 
   [ReqRespMethod.LightClientBootstrap]: LightClientBootstrap;
@@ -111,6 +114,7 @@ export const requestSszTypeByMethod: (
   [ReqRespMethod.BlobSidecarsByRoot]: BlobSidecarsByRootRequestType(fork, config),
   [ReqRespMethod.DataColumnSidecarsByRange]: ssz.fulu.DataColumnSidecarsByRangeRequest,
   [ReqRespMethod.DataColumnSidecarsByRoot]: DataColumnSidecarsByRootRequestType(config),
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: ssz.phase0.BeaconBlocksByRangeRequest,
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: ExecutionPayloadEnvelopesByRootRequestType(config),
 
   [ReqRespMethod.LightClientBootstrap]: ssz.Root,
@@ -144,6 +148,7 @@ export const responseSszTypeByMethod: {[K in ReqRespMethod]: ResponseTypeGetter<
   [ReqRespMethod.LightClientFinalityUpdate]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientFinalityUpdate,
   [ReqRespMethod.DataColumnSidecarsByRange]: () => ssz.fulu.DataColumnSidecar,
   [ReqRespMethod.DataColumnSidecarsByRoot]: () => ssz.fulu.DataColumnSidecar,
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: () => ssz.gloas.SignedExecutionPayloadEnvelope,
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: () => ssz.gloas.SignedExecutionPayloadEnvelope,
   [ReqRespMethod.LightClientOptimisticUpdate]: (fork) =>
     sszTypesFor(onlyPostAltairFork(fork)).LightClientOptimisticUpdate,

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -147,8 +147,10 @@ export const responseSszTypeByMethod: {[K in ReqRespMethod]: ResponseTypeGetter<
   [ReqRespMethod.LightClientBootstrap]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientBootstrap,
   [ReqRespMethod.LightClientUpdatesByRange]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientUpdate,
   [ReqRespMethod.LightClientFinalityUpdate]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientFinalityUpdate,
-  [ReqRespMethod.DataColumnSidecarsByRange]: (fork) => sszTypesFor(onlyPostFuluFork(fork)).DataColumnSidecar as Type<fulu.DataColumnSidecar>,
-  [ReqRespMethod.DataColumnSidecarsByRoot]: (fork) => sszTypesFor(onlyPostFuluFork(fork)).DataColumnSidecar as Type<fulu.DataColumnSidecar>,
+  [ReqRespMethod.DataColumnSidecarsByRange]: (fork) =>
+    sszTypesFor(onlyPostFuluFork(fork)).DataColumnSidecar as Type<fulu.DataColumnSidecar>,
+  [ReqRespMethod.DataColumnSidecarsByRoot]: (fork) =>
+    sszTypesFor(onlyPostFuluFork(fork)).DataColumnSidecar as Type<fulu.DataColumnSidecar>,
   [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: () => ssz.gloas.SignedExecutionPayloadEnvelope,
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: () => ssz.gloas.SignedExecutionPayloadEnvelope,
   [ReqRespMethod.LightClientOptimisticUpdate]: (fork) =>

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -54,7 +54,7 @@ export enum ReqRespMethod {
 }
 
 // To typesafe events to network
-type ExecutionPayloadEnvelopesByRangeRequest = phase0.BeaconBlocksByRangeRequest;
+
 export type RequestBodyByMethod = {
   [ReqRespMethod.Status]: Status;
   [ReqRespMethod.Goodbye]: phase0.Goodbye;
@@ -66,7 +66,7 @@ export type RequestBodyByMethod = {
   [ReqRespMethod.BlobSidecarsByRoot]: BlobSidecarsByRootRequest;
   [ReqRespMethod.DataColumnSidecarsByRange]: fulu.DataColumnSidecarsByRangeRequest;
   [ReqRespMethod.DataColumnSidecarsByRoot]: DataColumnSidecarsByRootRequest;
-  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: ExecutionPayloadEnvelopesByRangeRequest;
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: gloas.ExecutionPayloadEnvelopesByRangeRequest;
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: ExecutionPayloadEnvelopesByRootRequest;
   [ReqRespMethod.LightClientBootstrap]: Root;
   [ReqRespMethod.LightClientUpdatesByRange]: altair.LightClientUpdatesByRange;
@@ -115,7 +115,7 @@ export const requestSszTypeByMethod: (
   [ReqRespMethod.BlobSidecarsByRoot]: BlobSidecarsByRootRequestType(fork, config),
   [ReqRespMethod.DataColumnSidecarsByRange]: ssz.fulu.DataColumnSidecarsByRangeRequest,
   [ReqRespMethod.DataColumnSidecarsByRoot]: DataColumnSidecarsByRootRequestType(config),
-  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: ssz.gloas.BeaconBlocksByRangeRequest,
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: ssz.gloas.ExecutionPayloadEnvelopesByRangeRequest,
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: ExecutionPayloadEnvelopesByRootRequestType(config),
 
   [ReqRespMethod.LightClientBootstrap]: ssz.Root,

--- a/packages/beacon-node/test/unit/network/reqresp/executionPayloadEnvelopesByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/reqresp/executionPayloadEnvelopesByRange.test.ts
@@ -38,6 +38,7 @@ describe("beacon-node / network / reqresp / handlers / executionPayloadEnvelopes
       forkChoice: {
         getFinalizedCheckpointSlot: () => 64,
         getHeadRoot: () => "0xhead",
+        getBlockHexDefaultStatus: () => ({slot: 66, blockRoot: toRootHex(rootWithByte(66))}),
         getAllAncestorBlocks: () => [
           {slot: 66, blockRoot: toRootHex(rootWithByte(66))},
           {slot: 65, blockRoot: toRootHex(rootWithByte(65))},
@@ -80,6 +81,7 @@ describe("beacon-node / network / reqresp / handlers / executionPayloadEnvelopes
       forkChoice: {
         getFinalizedCheckpointSlot: () => 0,
         getHeadRoot: () => "0xhead",
+        getBlockHexDefaultStatus: () => undefined,
         getAllAncestorBlocks: () => [],
       },
     } as any;
@@ -100,5 +102,65 @@ describe("beacon-node / network / reqresp / handlers / executionPayloadEnvelopes
     expect(chain.logger.verbose).toHaveBeenCalledTimes(1);
     expect(db.executionPayloadEnvelopeArchive.get).not.toHaveBeenCalled();
     expect(db.executionPayloadEnvelope.get).not.toHaveBeenCalled();
+  });
+
+  it("respects step and includes head envelope when ancestor list excludes head", async () => {
+    const finalizedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    finalizedEnvelope.message.slot = 64;
+    finalizedEnvelope.message.beaconBlockRoot = rootWithByte(64);
+
+    const headEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    headEnvelope.message.slot = 66;
+    headEnvelope.message.beaconBlockRoot = rootWithByte(66);
+
+    const skippedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    skippedEnvelope.message.slot = 65;
+    skippedEnvelope.message.beaconBlockRoot = rootWithByte(65);
+
+    const archivedBySlot = new Map<number, typeof finalizedEnvelope>([[64, finalizedEnvelope]]);
+    const hotByRoot = new Map<string, typeof headEnvelope>([
+      [toRootHex(headEnvelope.message.beaconBlockRoot), headEnvelope],
+      [toRootHex(skippedEnvelope.message.beaconBlockRoot), skippedEnvelope],
+    ]);
+
+    const chain = {
+      earliestAvailableSlot: 1,
+      logger: {verbose: vi.fn()},
+      config: {
+        SLOTS_PER_EPOCH: 32,
+        MAX_REQUEST_BLOCKS: 1024,
+        MAX_REQUEST_BLOCKS_DENEB: 128,
+        getForkName: () => ForkName.gloas,
+        getForkBoundaryAtEpoch: (epoch: number) => ({fork: ForkName.gloas, epoch}),
+      },
+      forkChoice: {
+        getFinalizedCheckpointSlot: () => 64,
+        getHeadRoot: () => "0xhead",
+        // Simulate Gloas behavior where getAllAncestorBlocks() omits the current head node
+        getBlockHexDefaultStatus: () => ({slot: 66, blockRoot: toRootHex(rootWithByte(66))}),
+        getAllAncestorBlocks: () => [
+          {slot: 65, blockRoot: toRootHex(rootWithByte(65))},
+          {slot: 64, blockRoot: toRootHex(rootWithByte(64))},
+        ],
+      },
+    } as any;
+
+    const db = {
+      executionPayloadEnvelopeArchive: {
+        get: vi.fn(async (slot: number) => archivedBySlot.get(slot) ?? null),
+      },
+      executionPayloadEnvelope: {
+        get: vi.fn(async (root: Uint8Array) => hotByRoot.get(toRootHex(root)) ?? null),
+      },
+    } as any;
+
+    const request = {startSlot: 64, count: 2, step: 2};
+
+    const responses = [];
+    for await (const response of onExecutionPayloadEnvelopesByRange(request, chain, db, {} as any, "teku")) {
+      responses.push(ssz.gloas.SignedExecutionPayloadEnvelope.deserialize(response.data));
+    }
+
+    expect(responses.map((e) => e.message.slot)).toEqual([64, 66]);
   });
 });

--- a/packages/beacon-node/test/unit/network/reqresp/executionPayloadEnvelopesByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/reqresp/executionPayloadEnvelopesByRange.test.ts
@@ -1,0 +1,104 @@
+import {describe, expect, it, vi} from "vitest";
+import {ForkName} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
+import {toRootHex} from "@lodestar/utils";
+import {onExecutionPayloadEnvelopesByRange} from "../../../../src/network/reqresp/handlers/executionPayloadEnvelopesByRange.js";
+
+function rootWithByte(n: number): Uint8Array {
+  const root = new Uint8Array(32);
+  root[31] = n;
+  return root;
+}
+
+describe("beacon-node / network / reqresp / handlers / executionPayloadEnvelopesByRange", () => {
+  it("serves envelopes from finalized archive and non-finalized cache", async () => {
+    const finalizedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    finalizedEnvelope.message.slot = 64;
+    finalizedEnvelope.message.beaconBlockRoot = rootWithByte(64);
+
+    const hotEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    hotEnvelope.message.slot = 65;
+    hotEnvelope.message.beaconBlockRoot = rootWithByte(65);
+
+    const archivedBySlot = new Map<number, typeof finalizedEnvelope>([[64, finalizedEnvelope]]);
+    const hotByRoot = new Map<string, typeof hotEnvelope>([
+      [toRootHex(hotEnvelope.message.beaconBlockRoot), hotEnvelope],
+    ]);
+
+    const chain = {
+      earliestAvailableSlot: 1,
+      logger: {verbose: vi.fn()},
+      config: {
+        SLOTS_PER_EPOCH: 32,
+        MAX_REQUEST_BLOCKS: 1024,
+        MAX_REQUEST_BLOCKS_DENEB: 128,
+        getForkName: () => ForkName.gloas,
+        getForkBoundaryAtEpoch: (epoch: number) => ({fork: ForkName.gloas, epoch}),
+      },
+      forkChoice: {
+        getFinalizedCheckpointSlot: () => 64,
+        getHeadRoot: () => "0xhead",
+        getAllAncestorBlocks: () => [
+          {slot: 66, blockRoot: toRootHex(rootWithByte(66))},
+          {slot: 65, blockRoot: toRootHex(rootWithByte(65))},
+          {slot: 64, blockRoot: toRootHex(rootWithByte(64))},
+        ],
+      },
+    } as any;
+
+    const db = {
+      executionPayloadEnvelopeArchive: {
+        get: vi.fn(async (slot: number) => archivedBySlot.get(slot) ?? null),
+      },
+      executionPayloadEnvelope: {
+        get: vi.fn(async (root: Uint8Array) => hotByRoot.get(toRootHex(root)) ?? null),
+      },
+    } as any;
+
+    const request = {startSlot: 64, count: 2, step: 1};
+
+    const responses = [];
+    for await (const response of onExecutionPayloadEnvelopesByRange(request, chain, db, {} as any, "teku")) {
+      responses.push(ssz.gloas.SignedExecutionPayloadEnvelope.deserialize(response.data));
+    }
+
+    expect(responses).toHaveLength(2);
+    expect(responses.map((e) => e.message.slot)).toEqual([64, 65]);
+  });
+
+  it("returns nothing for requests below earliestAvailableSlot", async () => {
+    const chain = {
+      earliestAvailableSlot: 10,
+      logger: {verbose: vi.fn()},
+      config: {
+        SLOTS_PER_EPOCH: 32,
+        MAX_REQUEST_BLOCKS: 1024,
+        MAX_REQUEST_BLOCKS_DENEB: 128,
+        getForkName: () => ForkName.gloas,
+        getForkBoundaryAtEpoch: (epoch: number) => ({fork: ForkName.gloas, epoch}),
+      },
+      forkChoice: {
+        getFinalizedCheckpointSlot: () => 0,
+        getHeadRoot: () => "0xhead",
+        getAllAncestorBlocks: () => [],
+      },
+    } as any;
+
+    const db = {
+      executionPayloadEnvelopeArchive: {get: vi.fn()},
+      executionPayloadEnvelope: {get: vi.fn()},
+    } as any;
+
+    const request = {startSlot: 1, count: 1, step: 1};
+
+    const responses = [];
+    for await (const response of onExecutionPayloadEnvelopesByRange(request, chain, db, {} as any, "teku")) {
+      responses.push(response);
+    }
+
+    expect(responses).toHaveLength(0);
+    expect(chain.logger.verbose).toHaveBeenCalledTimes(1);
+    expect(db.executionPayloadEnvelopeArchive.get).not.toHaveBeenCalled();
+    expect(db.executionPayloadEnvelope.get).not.toHaveBeenCalled();
+  });
+});

--- a/packages/beacon-node/test/unit/network/reqresp/executionPayloadEnvelopesByRange.test.ts
+++ b/packages/beacon-node/test/unit/network/reqresp/executionPayloadEnvelopesByRange.test.ts
@@ -56,7 +56,7 @@ describe("beacon-node / network / reqresp / handlers / executionPayloadEnvelopes
       },
     } as any;
 
-    const request = {startSlot: 64, count: 2, step: 1};
+    const request = {startSlot: 64, count: 2};
 
     const responses = [];
     for await (const response of onExecutionPayloadEnvelopesByRange(request, chain, db, {} as any, "teku")) {
@@ -91,7 +91,7 @@ describe("beacon-node / network / reqresp / handlers / executionPayloadEnvelopes
       executionPayloadEnvelope: {get: vi.fn()},
     } as any;
 
-    const request = {startSlot: 1, count: 1, step: 1};
+    const request = {startSlot: 1, count: 1};
 
     const responses = [];
     for await (const response of onExecutionPayloadEnvelopesByRange(request, chain, db, {} as any, "teku")) {
@@ -104,7 +104,7 @@ describe("beacon-node / network / reqresp / handlers / executionPayloadEnvelopes
     expect(db.executionPayloadEnvelope.get).not.toHaveBeenCalled();
   });
 
-  it("respects step and includes head envelope when ancestor list excludes head", async () => {
+  it("includes head envelope when ancestor list excludes head", async () => {
     const finalizedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
     finalizedEnvelope.message.slot = 64;
     finalizedEnvelope.message.beaconBlockRoot = rootWithByte(64);
@@ -113,14 +113,14 @@ describe("beacon-node / network / reqresp / handlers / executionPayloadEnvelopes
     headEnvelope.message.slot = 66;
     headEnvelope.message.beaconBlockRoot = rootWithByte(66);
 
-    const skippedEnvelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
-    skippedEnvelope.message.slot = 65;
-    skippedEnvelope.message.beaconBlockRoot = rootWithByte(65);
+    const slot65Envelope = ssz.gloas.SignedExecutionPayloadEnvelope.defaultValue();
+    slot65Envelope.message.slot = 65;
+    slot65Envelope.message.beaconBlockRoot = rootWithByte(65);
 
     const archivedBySlot = new Map<number, typeof finalizedEnvelope>([[64, finalizedEnvelope]]);
     const hotByRoot = new Map<string, typeof headEnvelope>([
       [toRootHex(headEnvelope.message.beaconBlockRoot), headEnvelope],
-      [toRootHex(skippedEnvelope.message.beaconBlockRoot), skippedEnvelope],
+      [toRootHex(slot65Envelope.message.beaconBlockRoot), slot65Envelope],
     ]);
 
     const chain = {
@@ -136,7 +136,6 @@ describe("beacon-node / network / reqresp / handlers / executionPayloadEnvelopes
       forkChoice: {
         getFinalizedCheckpointSlot: () => 64,
         getHeadRoot: () => "0xhead",
-        // Simulate Gloas behavior where getAllAncestorBlocks() omits the current head node
         getBlockHexDefaultStatus: () => ({slot: 66, blockRoot: toRootHex(rootWithByte(66))}),
         getAllAncestorBlocks: () => [
           {slot: 65, blockRoot: toRootHex(rootWithByte(65))},
@@ -154,13 +153,13 @@ describe("beacon-node / network / reqresp / handlers / executionPayloadEnvelopes
       },
     } as any;
 
-    const request = {startSlot: 64, count: 2, step: 2};
+    const request = {startSlot: 64, count: 3};
 
     const responses = [];
     for await (const response of onExecutionPayloadEnvelopesByRange(request, chain, db, {} as any, "teku")) {
       responses.push(ssz.gloas.SignedExecutionPayloadEnvelope.deserialize(response.data));
     }
 
-    expect(responses.map((e) => e.message.slot)).toEqual([64, 66]);
+    expect(responses.map((e) => e.message.slot)).toEqual([64, 65, 66]);
   });
 });

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -282,3 +282,13 @@ export const DataColumnSidecar = new ContainerType(
 );
 
 export const DataColumnSidecars = new ListCompositeType(DataColumnSidecar, NUMBER_OF_COLUMNS);
+
+// Req/Resp types
+
+export const ExecutionPayloadEnvelopesByRangeRequest = new ContainerType(
+  {
+    startSlot: Slot,
+    count: UintNum64,
+  },
+  {typeName: "ExecutionPayloadEnvelopesByRangeRequest", jsonCase: "eth2"}
+);

--- a/packages/types/src/gloas/types.ts
+++ b/packages/types/src/gloas/types.ts
@@ -21,3 +21,5 @@ export type BeaconState = ValueOf<typeof ssz.BeaconState>;
 
 export type DataColumnSidecar = ValueOf<typeof ssz.DataColumnSidecar>;
 export type DataColumnSidecars = ValueOf<typeof ssz.DataColumnSidecars>;
+
+export type ExecutionPayloadEnvelopesByRangeRequest = ValueOf<typeof ssz.ExecutionPayloadEnvelopesByRangeRequest>;


### PR DESCRIPTION
## Summary
Adds serving-side req/resp support for Gloas `execution_payload_envelopes_by_range/1`, using the existing by-root implementation as reference.

Scope is intentionally **serve-only** (no consumer/download path changes).

## What changed
- Add new req/resp method: `execution_payload_envelopes_by_range`
- Register protocol in req/resp protocol set (Gloas boundary)
- Add handler wiring in `handlers/index.ts`
- Implement range handler:
  - finalized range -> `executionPayloadEnvelopeArchive` by slot
  - non-finalized range -> canonical head-chain roots -> `executionPayloadEnvelope`
  - enforces `earliestAvailableSlot` gate (same pattern as other by-range handlers)
  - emits fork boundary by slot epoch
- Add request/response SSZ mapping + method enum typing
- Add inbound rate-limit entry for by-range
- Add req/resp score handling for by-range timeout classification
- Add unit tests for serving behavior and earliestAvailableSlot gating

## Validation
- `pnpm lint` (repo)
- `pnpm vitest run --project unit test/unit/network/reqresp/executionPayloadEnvelopesByRange.test.ts`
- `pnpm check-types` (packages/beacon-node)

## Notes
- This PR does **not** implement consuming these by-range envelopes yet, per task scope.