### PR TITLE
chore(ci): pin ethspecify to 0.3.7 in check-specrefs

### DIFF
--- a/.github/workflows/check-specrefs.yml
+++ b/.github/workflows/check-specrefs.yml
@@ -32,7 +32,7 @@ jobs:
         fi
 
     - name: Install ethspecify
-      run: python3 -mpip install ethspecify==0.3.7
+      run: python3 -mpip install ethspecify==0.3.9
 
     - name: Update spec references
       run: ethspecify process --path=specrefs

--- a/.github/workflows/check-specrefs.yml
+++ b/.github/workflows/check-specrefs.yml
@@ -32,7 +32,7 @@ jobs:
         fi
 
     - name: Install ethspecify
-      run: python3 -mpip install ethspecify
+      run: python3 -mpip install ethspecify==0.3.7
 
     - name: Update spec references
       run: ethspecify process --path=specrefs


### PR DESCRIPTION
## Summary\nPin `ethspecify` to `0.3.7` in the `check-specrefs` workflow to avoid the current regression in `0.3.8` (false `MISSING FILE` failures).\n\n## Context\nPR #8984 merged before the pin commit landed, so this is a standalone follow-up PR carrying only the CI pin.\n\n## Validation\n- Reproduced failure with `ethspecify==0.3.8`\n- Confirmed pass with `ethspecify==0.3.7` (`All specification references (935) are valid`)