### PR TITLE
fix(fork-choice): make payloadStatus explicit in ancestor traversal APIs

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
+++ b/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
@@ -1,4 +1,4 @@
-import {CheckpointWithHex} from "@lodestar/fork-choice";
+import {CheckpointWithPayload} from "@lodestar/fork-choice";
 import {LoggerNode} from "@lodestar/logger/node";
 import {ForkSeq} from "@lodestar/params";
 import {Checkpoint} from "@lodestar/types/phase0";
@@ -44,7 +44,7 @@ export enum ArchiveStoreTask {
  */
 export class ArchiveStore {
   private archiveMode: ArchiveMode;
-  private jobQueue: JobItemQueue<[CheckpointWithHex], void>;
+  private jobQueue: JobItemQueue<[CheckpointWithPayload], void>;
 
   private archiveDataEpochs?: number;
   private readonly statesArchiverStrategy: StateArchiveStrategy;
@@ -67,7 +67,7 @@ export class ArchiveStore {
     this.archiveMode = opts.archiveMode;
     this.archiveDataEpochs = opts.archiveDataEpochs;
 
-    this.jobQueue = new JobItemQueue<[CheckpointWithHex], void>(this.processFinalizedCheckpoint, {
+    this.jobQueue = new JobItemQueue<[CheckpointWithPayload], void>(this.processFinalizedCheckpoint, {
       maxLength: PROCESS_FINALIZED_CHECKPOINT_QUEUE_LENGTH,
       signal,
     });
@@ -168,7 +168,7 @@ export class ArchiveStore {
   //-------------------------------------------------------------------------
   // Event handlers
   //-------------------------------------------------------------------------
-  private onFinalizedCheckpoint = (finalized: CheckpointWithHex): void => {
+  private onFinalizedCheckpoint = (finalized: CheckpointWithPayload): void => {
     this.jobQueue.push(finalized).catch((e) => {
       if (!isQueueErrorAborted(e)) {
         this.logger.error("Error queuing finalized checkpoint", {epoch: finalized.epoch}, e as Error);
@@ -189,7 +189,7 @@ export class ArchiveStore {
     });
   };
 
-  private processFinalizedCheckpoint = async (finalized: CheckpointWithHex): Promise<void> => {
+  private processFinalizedCheckpoint = async (finalized: CheckpointWithPayload): Promise<void> => {
     try {
       const finalizedEpoch = finalized.epoch;
       const finalizedFork = this.chain.config.getForkSeqAtEpoch(finalizedEpoch);

--- a/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
+++ b/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
@@ -1,4 +1,4 @@
-import {CheckpointWithPayload} from "@lodestar/fork-choice";
+import {CheckpointWithPayloadStatus} from "@lodestar/fork-choice";
 import {LoggerNode} from "@lodestar/logger/node";
 import {ForkSeq} from "@lodestar/params";
 import {Checkpoint} from "@lodestar/types/phase0";
@@ -44,7 +44,7 @@ export enum ArchiveStoreTask {
  */
 export class ArchiveStore {
   private archiveMode: ArchiveMode;
-  private jobQueue: JobItemQueue<[CheckpointWithPayload], void>;
+  private jobQueue: JobItemQueue<[CheckpointWithPayloadStatus], void>;
 
   private archiveDataEpochs?: number;
   private readonly statesArchiverStrategy: StateArchiveStrategy;
@@ -67,7 +67,7 @@ export class ArchiveStore {
     this.archiveMode = opts.archiveMode;
     this.archiveDataEpochs = opts.archiveDataEpochs;
 
-    this.jobQueue = new JobItemQueue<[CheckpointWithPayload], void>(this.processFinalizedCheckpoint, {
+    this.jobQueue = new JobItemQueue<[CheckpointWithPayloadStatus], void>(this.processFinalizedCheckpoint, {
       maxLength: PROCESS_FINALIZED_CHECKPOINT_QUEUE_LENGTH,
       signal,
     });
@@ -168,7 +168,7 @@ export class ArchiveStore {
   //-------------------------------------------------------------------------
   // Event handlers
   //-------------------------------------------------------------------------
-  private onFinalizedCheckpoint = (finalized: CheckpointWithPayload): void => {
+  private onFinalizedCheckpoint = (finalized: CheckpointWithPayloadStatus): void => {
     this.jobQueue.push(finalized).catch((e) => {
       if (!isQueueErrorAborted(e)) {
         this.logger.error("Error queuing finalized checkpoint", {epoch: finalized.epoch}, e as Error);
@@ -189,7 +189,7 @@ export class ArchiveStore {
     });
   };
 
-  private processFinalizedCheckpoint = async (finalized: CheckpointWithPayload): Promise<void> => {
+  private processFinalizedCheckpoint = async (finalized: CheckpointWithPayloadStatus): Promise<void> => {
     try {
       const finalizedEpoch = finalized.epoch;
       const finalizedFork = this.chain.config.getForkSeqAtEpoch(finalizedEpoch);

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import {ChainForkConfig} from "@lodestar/config";
 import {KeyValue} from "@lodestar/db";
-import {CheckpointWithPayload, IForkChoice} from "@lodestar/fork-choice";
+import {CheckpointWithPayloadStatus, IForkChoice} from "@lodestar/fork-choice";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, Slot} from "@lodestar/types";
@@ -52,7 +52,7 @@ export async function archiveBlocks(
   forkChoice: IForkChoice,
   lightclientServer: LightClientServer | undefined,
   logger: Logger,
-  finalizedCheckpoint: CheckpointWithPayload,
+  finalizedCheckpoint: CheckpointWithPayloadStatus,
   currentEpoch: Epoch,
   archiveDataEpochs?: number,
   persistOrphanedBlocks?: boolean,

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
 import {ChainForkConfig} from "@lodestar/config";
 import {KeyValue} from "@lodestar/db";
-import {IForkChoice} from "@lodestar/fork-choice";
+import {CheckpointWithPayload, IForkChoice} from "@lodestar/fork-choice";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
-import {Epoch, RootHex, Slot} from "@lodestar/types";
+import {Epoch, Slot} from "@lodestar/types";
 import {Logger, fromAsync, fromHex, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {IBeaconDb} from "../../../db/index.js";
 import {BlockArchiveBatchPutBinaryItem} from "../../../db/repositories/index.js";
@@ -19,7 +19,6 @@ const BLOCK_BATCH_SIZE = 256;
 const BLOB_SIDECAR_BATCH_SIZE = 32;
 
 type BlockRootSlot = {slot: Slot; root: Uint8Array};
-type CheckpointHex = {epoch: Epoch; rootHex: RootHex};
 
 /**
  * Persist orphaned block to disk
@@ -53,7 +52,7 @@ export async function archiveBlocks(
   forkChoice: IForkChoice,
   lightclientServer: LightClientServer | undefined,
   logger: Logger,
-  finalizedCheckpoint: CheckpointHex,
+  finalizedCheckpoint: CheckpointWithPayload,
   currentEpoch: Epoch,
   archiveDataEpochs?: number,
   persistOrphanedBlocks?: boolean,
@@ -62,7 +61,7 @@ export async function archiveBlocks(
   // Use fork choice to determine the blocks to archive and delete
   // getAllAncestorBlocks response includes the finalized block, so it's also moved to the cold db
   const {ancestors: finalizedCanonicalBlocks, nonAncestors: finalizedNonCanonicalBlocks} =
-    forkChoice.getAllAncestorAndNonAncestorBlocks(finalizedCheckpoint.rootHex);
+    forkChoice.getAllAncestorAndNonAncestorBlocks(finalizedCheckpoint.rootHex, finalizedCheckpoint.payloadStatus);
 
   // NOTE: The finalized block will be exactly the first block of `epoch` or previous
   const finalizedPostDeneb = finalizedCheckpoint.epoch >= config.DENEB_FORK_EPOCH;

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import {PrivateKey} from "@libp2p/interface";
 import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {CheckpointWithHex, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
+import {CheckpointWithHex, CheckpointWithPayload, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
 import {LoggerNode} from "@lodestar/logger/node";
 import {
   BUILDER_INDEX_SELF_BUILD,
@@ -1186,7 +1186,7 @@ export class BeaconChain implements IBeaconChain {
    * @param blockState state that declares justified checkpoint `checkpoint`
    */
   private justifiedBalancesGetter(
-    checkpoint: CheckpointWithHex,
+    checkpoint: CheckpointWithPayload,
     blockState: CachedBeaconStateAllForks
   ): EffectiveBalanceIncrements {
     this.metrics?.balancesCache.requests.inc();
@@ -1225,7 +1225,7 @@ export class BeaconChain implements IBeaconChain {
    * @param blockState state that declares justified checkpoint `checkpoint`
    */
   private closestJustifiedBalancesStateToCheckpoint(
-    checkpoint: CheckpointWithHex,
+    checkpoint: CheckpointWithPayload,
     blockState: CachedBeaconStateAllForks
   ): {state: CachedBeaconStateAllForks; stateId: string; shouldWarn: boolean} {
     const state = this.regen.getCheckpointStateSync(checkpoint);
@@ -1239,7 +1239,10 @@ export class BeaconChain implements IBeaconChain {
     }
 
     // Find a state in the same branch of checkpoint at same epoch. Balances should exactly the same
-    for (const descendantBlock of this.forkChoice.forwardIterateDescendants(checkpoint.rootHex)) {
+    for (const descendantBlock of this.forkChoice.forwardIterateDescendants(
+      checkpoint.rootHex,
+      checkpoint.payloadStatus
+    )) {
       if (computeEpochAtSlot(descendantBlock.slot) === checkpoint.epoch) {
         const descendantBlockState = this.regen.getStateSync(descendantBlock.stateRoot);
         if (descendantBlockState) {
@@ -1255,7 +1258,10 @@ export class BeaconChain implements IBeaconChain {
 
     // Find a state in the same branch of checkpoint at a latter epoch. Balances are not the same, but should be close
     // Note: must call .forwardIterateDescendants() again since nodes are not sorted
-    for (const descendantBlock of this.forkChoice.forwardIterateDescendants(checkpoint.rootHex)) {
+    for (const descendantBlock of this.forkChoice.forwardIterateDescendants(
+      checkpoint.rootHex,
+      checkpoint.payloadStatus
+    )) {
       if (computeEpochAtSlot(descendantBlock.slot) > checkpoint.epoch) {
         const descendantBlockState = this.regen.getStateSync(descendantBlock.stateRoot);
         if (descendantBlockState) {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -2,7 +2,13 @@ import path from "node:path";
 import {PrivateKey} from "@libp2p/interface";
 import {CompositeTypeAny, TreeView, Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {CheckpointWithHex, CheckpointWithPayload, IForkChoice, ProtoBlock, UpdateHeadOpt} from "@lodestar/fork-choice";
+import {
+  CheckpointWithHex,
+  CheckpointWithPayloadStatus,
+  IForkChoice,
+  ProtoBlock,
+  UpdateHeadOpt,
+} from "@lodestar/fork-choice";
 import {LoggerNode} from "@lodestar/logger/node";
 import {
   BUILDER_INDEX_SELF_BUILD,
@@ -1186,7 +1192,7 @@ export class BeaconChain implements IBeaconChain {
    * @param blockState state that declares justified checkpoint `checkpoint`
    */
   private justifiedBalancesGetter(
-    checkpoint: CheckpointWithPayload,
+    checkpoint: CheckpointWithPayloadStatus,
     blockState: CachedBeaconStateAllForks
   ): EffectiveBalanceIncrements {
     this.metrics?.balancesCache.requests.inc();
@@ -1225,7 +1231,7 @@ export class BeaconChain implements IBeaconChain {
    * @param blockState state that declares justified checkpoint `checkpoint`
    */
   private closestJustifiedBalancesStateToCheckpoint(
-    checkpoint: CheckpointWithPayload,
+    checkpoint: CheckpointWithPayloadStatus,
     blockState: CachedBeaconStateAllForks
   ): {state: CachedBeaconStateAllForks; stateId: string; shouldWarn: boolean} {
     const state = this.regen.getCheckpointStateSync(checkpoint);

--- a/packages/beacon-node/src/chain/emitter.ts
+++ b/packages/beacon-node/src/chain/emitter.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from "node:events";
 import {StrictEventEmitter} from "strict-event-emitter-types";
 import {routes} from "@lodestar/api";
-import {CheckpointWithPayload} from "@lodestar/fork-choice";
+import {CheckpointWithPayloadStatus} from "@lodestar/fork-choice";
 import {CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {DataColumnSidecars, RootHex, deneb, phase0} from "@lodestar/types";
 import {PeerIdStr} from "../util/peerId.js";
@@ -83,8 +83,8 @@ export type ChainEventData = {
 export type IChainEvents = ApiEvents & {
   [ChainEvent.checkpoint]: (checkpoint: phase0.Checkpoint, state: CachedBeaconStateAllForks) => void;
 
-  [ChainEvent.forkChoiceJustified]: (checkpoint: CheckpointWithPayload) => void;
-  [ChainEvent.forkChoiceFinalized]: (checkpoint: CheckpointWithPayload) => void;
+  [ChainEvent.forkChoiceJustified]: (checkpoint: CheckpointWithPayloadStatus) => void;
+  [ChainEvent.forkChoiceFinalized]: (checkpoint: CheckpointWithPayloadStatus) => void;
 
   [ChainEvent.updateTargetCustodyGroupCount]: (targetGroupCount: number) => void;
 

--- a/packages/beacon-node/src/chain/regen/regen.ts
+++ b/packages/beacon-node/src/chain/regen/regen.ts
@@ -158,7 +158,7 @@ export class StateRegenerator implements IStateRegeneratorInternal {
 
     const getSeedStateTimer = this.modules.metrics?.regenGetState.getSeedState.startTimer({caller});
     // iterateAncestorBlocks only returns ancestor blocks, not the block itself
-    for (const b of this.modules.forkChoice.iterateAncestorBlocks(block.blockRoot)) {
+    for (const b of this.modules.forkChoice.iterateAncestorBlocks(block.blockRoot, block.payloadStatus)) {
       state = this.modules.blockStateCache.get(b.stateRoot);
       if (state) {
         break;

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -47,9 +47,10 @@ export async function* onBeaconBlocksByRange(
 
   // Non-finalized range of blocks
   if (endSlot > finalizedSlot) {
-    const headRoot = chain.forkChoice.getHeadRoot();
+    const headBlock = chain.forkChoice.getHead();
+    const headRoot = headBlock.blockRoot;
     // TODO DENEB: forkChoice should mantain an array of canonical blocks, and change only on reorg
-    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
+    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot, headBlock.payloadStatus);
     // getAllAncestorBlocks response includes the head node, so it's the full chain.
 
     // Iterate head chain with ascending block numbers

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
@@ -34,9 +34,10 @@ export async function* onBlobSidecarsByRange(
 
   // Non-finalized range of blobs
   if (endSlot > finalizedSlot) {
-    const headRoot = chain.forkChoice.getHeadRoot();
+    const headBlock = chain.forkChoice.getHead();
+    const headRoot = headBlock.blockRoot;
     // TODO DENEB: forkChoice should mantain an array of canonical blocks, and change only on reorg
-    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
+    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot, headBlock.payloadStatus);
 
     // Iterate head chain with ascending block numbers
     for (let i = headChain.length - 1; i >= 0; i--) {

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
@@ -78,8 +78,9 @@ export async function* onDataColumnSidecarsByRange(
 
   // Non-finalized range of columns
   if (endSlot > finalizedSlot) {
-    const headRoot = chain.forkChoice.getHeadRoot();
-    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
+    const headBlock = chain.forkChoice.getHead();
+    const headRoot = headBlock.blockRoot;
+    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot, headBlock.payloadStatus);
 
     // Iterate head chain with ascending block numbers
     for (let i = headChain.length - 1; i >= 0; i--) {

--- a/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
+++ b/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
@@ -2,6 +2,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {createChainForkConfig} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
+import {PayloadStatus} from "@lodestar/fork-choice";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {archiveBlocks} from "../../../../src/chain/archiveStore/utils/archiveBlocks.js";
@@ -68,7 +69,7 @@ describe("block archiver task", () => {
       forkChoiceStub,
       lightclientServer,
       logger,
-      {epoch: 5, rootHex: ZERO_HASH_HEX},
+      {epoch: 5, root: fromHexString(ZERO_HASH_HEX), rootHex: ZERO_HASH_HEX, payloadStatus: PayloadStatus.FULL},
       currentEpoch
     );
 
@@ -141,7 +142,12 @@ describe("block archiver task", () => {
       forkChoiceStub,
       lightclientServer,
       logger,
-      {epoch: config.FULU_FORK_EPOCH + 1, rootHex: ZERO_HASH_HEX},
+      {
+        epoch: config.FULU_FORK_EPOCH + 1,
+        root: fromHexString(ZERO_HASH_HEX),
+        rootHex: ZERO_HASH_HEX,
+        payloadStatus: PayloadStatus.FULL,
+      },
       currentEpoch
     );
 

--- a/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -1,7 +1,7 @@
 import {beforeAll, beforeEach, describe, expect, it, vi} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
 import {config} from "@lodestar/config/default";
-import {CheckpointWithHex, ExecutionStatus, ForkChoice} from "@lodestar/fork-choice";
+import {CheckpointWithHex, ExecutionStatus, ForkChoice, PayloadStatus} from "@lodestar/fork-choice";
 import {FAR_FUTURE_EPOCH, MAX_EFFECTIVE_BALANCE} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
@@ -200,19 +200,19 @@ describe("LodestarForkChoice", () => {
       forkChoice.onBlock(block20.message, state20, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
       forkChoice.onBlock(block24.message, state24, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
       forkChoice.onBlock(block28.message, state28, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
-      expect(forkChoice.getAllAncestorBlocks(hashBlock(block16.message))).toHaveLength(3);
-      expect(forkChoice.getAllAncestorBlocks(hashBlock(block24.message))).toHaveLength(5);
+      expect(forkChoice.getAllAncestorBlocks(hashBlock(block16.message), PayloadStatus.FULL)).toHaveLength(3);
+      expect(forkChoice.getAllAncestorBlocks(hashBlock(block24.message), PayloadStatus.FULL)).toHaveLength(5);
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block08.message))).not.toBeNull();
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block12.message))).not.toBeNull();
       expect(forkChoice.hasBlockHex(hashBlock(block08.message))).toBe(true);
       expect(forkChoice.hasBlockHex(hashBlock(block12.message))).toBe(true);
       forkChoice.onBlock(block32.message, state32, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
       forkChoice.prune(hashBlock(block16.message));
-      expect(forkChoice.getAllAncestorBlocks(hashBlock(block16.message)).length).toBeWithMessage(
+      expect(forkChoice.getAllAncestorBlocks(hashBlock(block16.message), PayloadStatus.FULL).length).toBeWithMessage(
         0,
         "getAllAncestorBlocks should not return finalized block"
       );
-      expect(forkChoice.getAllAncestorBlocks(hashBlock(block24.message))).toHaveLength(2);
+      expect(forkChoice.getAllAncestorBlocks(hashBlock(block24.message), PayloadStatus.FULL)).toHaveLength(2);
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block08.message))).toBe(null);
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block12.message))).toBe(null);
       expect(forkChoice.hasBlockHex(hashBlock(block08.message))).toBe(false);
@@ -274,10 +274,11 @@ describe("LodestarForkChoice", () => {
         .forwarditerateAncestorBlocks()
         .filter(
           (summary) =>
-            summary.slot < childBlock.message.slot && !forkChoice.isDescendant(summary.blockRoot, childBlockRoot)
+            summary.slot < childBlock.message.slot &&
+            !forkChoice.isDescendant(summary.blockRoot, summary.payloadStatus, childBlockRoot, PayloadStatus.FULL)
         );
       // compare to getAllNonAncestorBlocks api
-      expect(forkChoice.getAllNonAncestorBlocks(childBlockRoot)).toEqual(nonCanonicalSummaries);
+      expect(forkChoice.getAllNonAncestorBlocks(childBlockRoot, PayloadStatus.FULL)).toEqual(nonCanonicalSummaries);
     });
 
     /**

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1225,7 +1225,7 @@ export class ForkChoice implements IForkChoice {
       return this.head;
     }
 
-    for (const block of this.protoArray.iterateAncestorNodes(this.head.blockRoot)) {
+    for (const block of this.protoArray.iterateAncestorNodes(this.head.blockRoot, this.head.payloadStatus)) {
       if (block.blockRoot === blockRootHex) {
         return block;
       }

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -54,7 +54,7 @@ import {
   NotReorgedReason,
   ShouldOverrideForkChoiceUpdateResult,
 } from "./interface.js";
-import {CheckpointWithPayload, IForkChoiceStore, JustifiedBalances, toCheckpointWithPayload} from "./store.js";
+import {CheckpointWithPayloadStatus, IForkChoiceStore, JustifiedBalances, toCheckpointWithPayload} from "./store.js";
 
 export type ForkChoiceOpts = {
   proposerBoost?: boolean;
@@ -557,11 +557,11 @@ export class ForkChoice implements IForkChoice {
     return this.protoArray.nodes;
   }
 
-  getFinalizedCheckpoint(): CheckpointWithPayload {
+  getFinalizedCheckpoint(): CheckpointWithPayloadStatus {
     return this.fcStore.finalizedCheckpoint;
   }
 
-  getJustifiedCheckpoint(): CheckpointWithPayload {
+  getJustifiedCheckpoint(): CheckpointWithPayloadStatus {
     return this.fcStore.justified.checkpoint;
   }
 
@@ -700,8 +700,8 @@ export class ForkChoice implements IForkChoice {
     // This is an optimization. It should reduce the amount of times we run
     // `process_justification_and_finalization` by approximately 1/3rd when the chain is
     // performing optimally.
-    let unrealizedJustifiedCheckpoint: CheckpointWithPayload;
-    let unrealizedFinalizedCheckpoint: CheckpointWithPayload;
+    let unrealizedJustifiedCheckpoint: CheckpointWithPayloadStatus;
+    let unrealizedFinalizedCheckpoint: CheckpointWithPayloadStatus;
     if (this.opts?.computeUnrealized) {
       if (
         parentBlock.unrealizedJustifiedEpoch === blockEpoch &&
@@ -1478,8 +1478,8 @@ export class ForkChoice implements IForkChoice {
    * Since this balances are already available the getter is just `() => balances`, without cache interaction
    */
   private updateCheckpoints(
-    justifiedCheckpoint: CheckpointWithPayload,
-    finalizedCheckpoint: CheckpointWithPayload,
+    justifiedCheckpoint: CheckpointWithPayloadStatus,
+    finalizedCheckpoint: CheckpointWithPayloadStatus,
     getJustifiedBalances: () => JustifiedBalances
   ): void {
     // Update justified checkpoint.
@@ -1499,8 +1499,8 @@ export class ForkChoice implements IForkChoice {
    * Update unrealized checkpoints in store if necessary
    */
   private updateUnrealizedCheckpoints(
-    unrealizedJustifiedCheckpoint: CheckpointWithPayload,
-    unrealizedFinalizedCheckpoint: CheckpointWithPayload,
+    unrealizedJustifiedCheckpoint: CheckpointWithPayloadStatus,
+    unrealizedFinalizedCheckpoint: CheckpointWithPayloadStatus,
     getJustifiedBalances: () => JustifiedBalances
   ): void {
     if (unrealizedJustifiedCheckpoint.epoch > this.fcStore.unrealizedJustified.checkpoint.epoch) {

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1133,8 +1133,13 @@ export class ForkChoice implements IForkChoice {
    * Always returns `false` if either input roots are unknown.
    * Still returns `true` if `ancestorRoot===descendantRoot` (and the roots are known)
    */
-  isDescendant(ancestorRoot: RootHex, descendantRoot: RootHex): boolean {
-    return this.protoArray.isDescendant(ancestorRoot, descendantRoot);
+  isDescendant(
+    ancestorRoot: RootHex,
+    ancestorPayloadStatus: PayloadStatus,
+    descendantRoot: RootHex,
+    descendantPayloadStatus: PayloadStatus
+  ): boolean {
+    return this.protoArray.isDescendant(ancestorRoot, ancestorPayloadStatus, descendantRoot, descendantPayloadStatus);
   }
 
   /**
@@ -1177,16 +1182,16 @@ export class ForkChoice implements IForkChoice {
    * Iterates backwards through block summaries, starting from a block root.
    * Return only the non-finalized blocks.
    */
-  iterateAncestorBlocks(blockRoot: RootHex): IterableIterator<ProtoBlock> {
-    return this.protoArray.iterateAncestorNodes(blockRoot);
+  iterateAncestorBlocks(blockRoot: RootHex, payloadStatus: PayloadStatus): IterableIterator<ProtoBlock> {
+    return this.protoArray.iterateAncestorNodes(blockRoot, payloadStatus);
   }
 
   /**
    * Returns all blocks backwards starting from a block root.
    * Return only the non-finalized blocks.
    */
-  getAllAncestorBlocks(blockRoot: RootHex): ProtoBlock[] {
-    const blocks = this.protoArray.getAllAncestorNodes(blockRoot);
+  getAllAncestorBlocks(blockRoot: RootHex, payloadStatus: PayloadStatus): ProtoBlock[] {
+    const blocks = this.protoArray.getAllAncestorNodes(blockRoot, payloadStatus);
     // the last node is the previous finalized one, it's there to check onBlock finalized checkpoint only.
     return blocks.slice(0, blocks.length - 1);
   }
@@ -1194,15 +1199,18 @@ export class ForkChoice implements IForkChoice {
   /**
    * The same to iterateAncestorBlocks but this gets non-ancestor nodes instead of ancestor nodes.
    */
-  getAllNonAncestorBlocks(blockRoot: RootHex): ProtoBlock[] {
-    return this.protoArray.getAllNonAncestorNodes(blockRoot);
+  getAllNonAncestorBlocks(blockRoot: RootHex, payloadStatus: PayloadStatus): ProtoBlock[] {
+    return this.protoArray.getAllNonAncestorNodes(blockRoot, payloadStatus);
   }
 
   /**
    * Returns both ancestor and non-ancestor blocks in a single traversal.
    */
-  getAllAncestorAndNonAncestorBlocks(blockRoot: RootHex): {ancestors: ProtoBlock[]; nonAncestors: ProtoBlock[]} {
-    const {ancestors, nonAncestors} = this.protoArray.getAllAncestorAndNonAncestorNodes(blockRoot);
+  getAllAncestorAndNonAncestorBlocks(
+    blockRoot: RootHex,
+    payloadStatus: PayloadStatus
+  ): {ancestors: ProtoBlock[]; nonAncestors: ProtoBlock[]} {
+    const {ancestors, nonAncestors} = this.protoArray.getAllAncestorAndNonAncestorNodes(blockRoot, payloadStatus);
 
     return {
       // the last node is the previous finalized one, it's there to check onBlock finalized checkpoint only.
@@ -1235,7 +1243,7 @@ export class ForkChoice implements IForkChoice {
       return this.head;
     }
 
-    for (const block of this.protoArray.iterateAncestorNodes(this.head.blockRoot)) {
+    for (const block of this.protoArray.iterateAncestorNodes(this.head.blockRoot, this.head.payloadStatus)) {
       if (block.slot === slot) {
         return block;
       }
@@ -1248,7 +1256,7 @@ export class ForkChoice implements IForkChoice {
       return this.head;
     }
 
-    for (const block of this.protoArray.iterateAncestorNodes(this.head.blockRoot)) {
+    for (const block of this.protoArray.iterateAncestorNodes(this.head.blockRoot, this.head.payloadStatus)) {
       if (slot >= block.slot) {
         return block;
       }
@@ -1261,23 +1269,15 @@ export class ForkChoice implements IForkChoice {
     return this.protoArray.nodes;
   }
 
-  // TODO GLOAS: this function is ambiguous, consumer should also provide payload, or it should accept a ProtoBlock instead
-  // also consumer may want PENDING or EMPTY only
-  *forwardIterateDescendants(blockRoot: RootHex): IterableIterator<ProtoBlock> {
+  *forwardIterateDescendants(blockRoot: RootHex, payloadStatus: PayloadStatus): IterableIterator<ProtoBlock> {
     const rootsInChain = new Set([blockRoot]);
-
-    const blockVariants = this.protoArray.indices.get(blockRoot);
-    if (blockVariants === undefined) {
+    const blockIndex = this.protoArray.getNodeIndexByRootAndStatus(blockRoot, payloadStatus);
+    if (blockIndex === undefined) {
       throw new ForkChoiceError({
         code: ForkChoiceErrorCode.MISSING_PROTO_ARRAY_BLOCK,
         root: blockRoot,
       });
     }
-
-    // Find the minimum index among all variants to start iteration
-    const blockIndex = Array.isArray(blockVariants)
-      ? Math.min(...blockVariants.filter((idx) => idx !== undefined))
-      : blockVariants;
 
     for (let i = blockIndex + 1; i < this.protoArray.nodes.length; i++) {
       const node = this.protoArray.nodes[i];

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -12,7 +12,7 @@ import {
   ProtoNode,
 } from "../protoArray/interface.js";
 import {UpdateAndGetHeadOpt} from "./forkChoice.js";
-import {CheckpointWithHex, CheckpointWithPayload} from "./store.js";
+import {CheckpointWithHex, CheckpointWithPayloadStatus} from "./store.js";
 
 export type CheckpointHex = {
   epoch: Epoch;
@@ -25,7 +25,7 @@ export type CheckpointsWithHex = {
 };
 
 export type CheckpointWithPayloadAndBalance = {
-  checkpoint: CheckpointWithPayload;
+  checkpoint: CheckpointWithPayloadStatus;
   balances: EffectiveBalanceIncrements;
 };
 
@@ -124,8 +124,8 @@ export interface IForkChoice {
    * Retrieve all nodes for the debug API.
    */
   getAllNodes(): ProtoNode[];
-  getFinalizedCheckpoint(): CheckpointWithPayload;
-  getJustifiedCheckpoint(): CheckpointWithPayload;
+  getFinalizedCheckpoint(): CheckpointWithPayloadStatus;
+  getJustifiedCheckpoint(): CheckpointWithPayloadStatus;
   /**
    * Add `block` to the fork choice DAG.
    *

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -246,7 +246,12 @@ export interface IForkChoice {
    * Always returns `false` if either input roots are unknown.
    * Still returns `true` if `ancestorRoot===descendantRoot` (and the roots are known)
    */
-  isDescendant(ancestorRoot: RootHex, descendantRoot: RootHex): boolean;
+  isDescendant(
+    ancestorRoot: RootHex,
+    ancestorPayloadStatus: PayloadStatus,
+    descendantRoot: RootHex,
+    descendantPayloadStatus: PayloadStatus
+  ): boolean;
   /**
    * Prune items up to a finalized root.
    */
@@ -255,16 +260,19 @@ export interface IForkChoice {
   /**
    * Iterates backwards through ancestor block summaries, starting from a block root
    */
-  iterateAncestorBlocks(blockRoot: RootHex): IterableIterator<ProtoBlock>;
-  getAllAncestorBlocks(blockRoot: RootHex): ProtoBlock[];
+  iterateAncestorBlocks(blockRoot: RootHex, payloadStatus: PayloadStatus): IterableIterator<ProtoBlock>;
+  getAllAncestorBlocks(blockRoot: RootHex, payloadStatus: PayloadStatus): ProtoBlock[];
   /**
    * The same to iterateAncestorBlocks but this gets non-ancestor nodes instead of ancestor nodes.
    */
-  getAllNonAncestorBlocks(blockRoot: RootHex): ProtoBlock[];
+  getAllNonAncestorBlocks(blockRoot: RootHex, payloadStatus: PayloadStatus): ProtoBlock[];
   /**
    * Returns both ancestor and non-ancestor blocks in a single traversal.
    */
-  getAllAncestorAndNonAncestorBlocks(blockRoot: RootHex): {ancestors: ProtoBlock[]; nonAncestors: ProtoBlock[]};
+  getAllAncestorAndNonAncestorBlocks(
+    blockRoot: RootHex,
+    payloadStatus: PayloadStatus
+  ): {ancestors: ProtoBlock[]; nonAncestors: ProtoBlock[]};
   getCanonicalBlockByRoot(blockRoot: Root): ProtoBlock | null;
   getCanonicalBlockAtSlot(slot: Slot): ProtoBlock | null;
   getCanonicalBlockClosestLteSlot(slot: Slot): ProtoBlock | null;
@@ -275,7 +283,7 @@ export interface IForkChoice {
   /**
    * Iterates forward descendants of blockRoot. Does not yield blockRoot itself
    */
-  forwardIterateDescendants(blockRoot: RootHex): IterableIterator<ProtoBlock>;
+  forwardIterateDescendants(blockRoot: RootHex, payloadStatus: PayloadStatus): IterableIterator<ProtoBlock>;
   getBlockSummariesByParentRoot(parentRoot: RootHex): ProtoBlock[];
   getBlockSummariesAtSlot(slot: Slot): ProtoBlock[];
   /** Returns the distance of common ancestor of nodes to the max of the newNode and the prevNode. */

--- a/packages/fork-choice/src/forkChoice/store.ts
+++ b/packages/fork-choice/src/forkChoice/store.ts
@@ -18,7 +18,7 @@ export type CheckpointWithHex = phase0.Checkpoint & {rootHex: RootHex};
  * Pre-Gloas: payloadStatus is always FULL (payload embedded in block)
  * Gloas: determined by state.execution_payload_availability
  */
-export type CheckpointWithPayload = CheckpointWithHex & {payloadStatus: PayloadStatus};
+export type CheckpointWithPayloadStatus = CheckpointWithHex & {payloadStatus: PayloadStatus};
 
 export type JustifiedBalances = EffectiveBalanceIncrements;
 
@@ -29,7 +29,7 @@ export type JustifiedBalances = EffectiveBalanceIncrements;
  * @param blockState state that declares justified checkpoint `checkpoint`
  */
 export type JustifiedBalancesGetter = (
-  checkpoint: CheckpointWithPayload,
+  checkpoint: CheckpointWithPayloadStatus,
   blockState: CachedBeaconStateAllForks
 ) => JustifiedBalances;
 
@@ -50,8 +50,8 @@ export interface IForkChoiceStore {
   get justified(): CheckpointWithPayloadAndTotalBalance;
   set justified(justified: CheckpointWithPayloadAndBalance);
   unrealizedJustified: CheckpointWithPayloadAndBalance;
-  finalizedCheckpoint: CheckpointWithPayload;
-  unrealizedFinalizedCheckpoint: CheckpointWithPayload;
+  finalizedCheckpoint: CheckpointWithPayloadStatus;
+  unrealizedFinalizedCheckpoint: CheckpointWithPayloadStatus;
   justifiedBalancesGetter: JustifiedBalancesGetter;
   equivocatingIndices: Set<ValidatorIndex>;
 }
@@ -62,8 +62,8 @@ export interface IForkChoiceStore {
 export class ForkChoiceStore implements IForkChoiceStore {
   private _justified: CheckpointWithPayloadAndTotalBalance;
   unrealizedJustified: CheckpointWithPayloadAndBalance;
-  private _finalizedCheckpoint: CheckpointWithPayload;
-  unrealizedFinalizedCheckpoint: CheckpointWithPayload;
+  private _finalizedCheckpoint: CheckpointWithPayloadStatus;
+  unrealizedFinalizedCheckpoint: CheckpointWithPayloadStatus;
   equivocatingIndices = new Set<ValidatorIndex>();
   justifiedBalancesGetter: JustifiedBalancesGetter;
   currentSlot: Slot;
@@ -87,8 +87,8 @@ export class ForkChoiceStore implements IForkChoiceStore {
      */
     finalizedPayloadStatus: PayloadStatus,
     private readonly events?: {
-      onJustified: (cp: CheckpointWithPayload) => void;
-      onFinalized: (cp: CheckpointWithPayload) => void;
+      onJustified: (cp: CheckpointWithPayloadStatus) => void;
+      onFinalized: (cp: CheckpointWithPayloadStatus) => void;
     }
   ) {
     this.justifiedBalancesGetter = justifiedBalancesGetter;
@@ -112,10 +112,10 @@ export class ForkChoiceStore implements IForkChoiceStore {
     this.events?.onJustified(justified.checkpoint);
   }
 
-  get finalizedCheckpoint(): CheckpointWithPayload {
+  get finalizedCheckpoint(): CheckpointWithPayloadStatus {
     return this._finalizedCheckpoint;
   }
-  set finalizedCheckpoint(checkpoint: CheckpointWithPayload) {
+  set finalizedCheckpoint(checkpoint: CheckpointWithPayloadStatus) {
     const cp = toCheckpointWithPayload(checkpoint, checkpoint.payloadStatus);
     this._finalizedCheckpoint = cp;
     this.events?.onFinalized(cp);
@@ -136,7 +136,7 @@ export function toCheckpointWithHex(checkpoint: phase0.Checkpoint): CheckpointWi
 export function toCheckpointWithPayload(
   checkpoint: phase0.Checkpoint,
   payloadStatus: PayloadStatus
-): CheckpointWithPayload {
+): CheckpointWithPayloadStatus {
   return {
     ...toCheckpointWithHex(checkpoint),
     payloadStatus,

--- a/packages/fork-choice/src/index.ts
+++ b/packages/fork-choice/src/index.ts
@@ -24,7 +24,7 @@ export {
 export * from "./forkChoice/safeBlocks.js";
 export {
   type CheckpointWithHex,
-  type CheckpointWithPayload,
+  type CheckpointWithPayloadStatus,
   ForkChoiceStore,
   type IForkChoiceStore,
   type JustifiedBalancesGetter,

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -1477,11 +1477,8 @@ export class ProtoArray {
    * For Gloas blocks: returns EMPTY/FULL variants (not PENDING) based on parent payload status
    * For pre-Gloas blocks: returns FULL variants
    */
-  *iterateAncestorNodes(blockRoot: RootHex): IterableIterator<ProtoNode> {
-    // Get canonical node: FULL for pre-Gloas, PENDING for Gloas
-    const defaultStatus = this.getDefaultVariant(blockRoot);
-    const startIndex =
-      defaultStatus !== undefined ? this.getNodeIndexByRootAndStatus(blockRoot, defaultStatus) : undefined;
+  *iterateAncestorNodes(blockRoot: RootHex, payloadStatus: PayloadStatus): IterableIterator<ProtoNode> {
+    const startIndex = this.getNodeIndexByRootAndStatus(blockRoot, payloadStatus);
     if (startIndex === undefined) {
       return;
     }
@@ -1520,11 +1517,8 @@ export class ProtoArray {
    * For Gloas blocks: returns EMPTY/FULL variants (not PENDING) based on parent payload status
    * For pre-Gloas blocks: returns FULL variants
    */
-  getAllAncestorNodes(blockRoot: RootHex): ProtoNode[] {
-    // Get canonical node: FULL for pre-Gloas, PENDING for Gloas
-    const defaultStatus = this.getDefaultVariant(blockRoot);
-    const startIndex =
-      defaultStatus !== undefined ? this.getNodeIndexByRootAndStatus(blockRoot, defaultStatus) : undefined;
+  getAllAncestorNodes(blockRoot: RootHex, payloadStatus: PayloadStatus): ProtoNode[] {
+    const startIndex = this.getNodeIndexByRootAndStatus(blockRoot, payloadStatus);
     if (startIndex === undefined) {
       return [];
     }
@@ -1537,12 +1531,10 @@ export class ProtoArray {
       });
     }
 
-    // Include starting node if node is pre-gloas
-    // Reason why we exclude post-gloas is because node is always default variant (PENDING)
-    // which we want to exclude.
+    // Exclude PENDING variant from returned ancestors.
     const nodes: ProtoNode[] = [];
 
-    if (!isGloasBlock(node)) {
+    if (node.payloadStatus !== PayloadStatus.PENDING) {
       nodes.push(node);
     }
 
@@ -1553,7 +1545,9 @@ export class ProtoArray {
       }
 
       node = this.nodes[parentIndex];
-      nodes.push(node);
+      if (node.payloadStatus !== PayloadStatus.PENDING) {
+        nodes.push(node);
+      }
     }
 
     return nodes;
@@ -1567,13 +1561,8 @@ export class ProtoArray {
    * For Gloas blocks: returns EMPTY/FULL variants (not PENDING) based on parent payload status
    * For pre-Gloas blocks: returns FULL variants
    */
-  getAllNonAncestorNodes(blockRoot: RootHex): ProtoNode[] {
-    // Get canonical node: FULL for pre-Gloas, PENDING for Gloas
-    const defaultStatus = this.getDefaultVariant(blockRoot);
-    if (defaultStatus === undefined) {
-      return [];
-    }
-    const startIndex = this.getNodeIndexByRootAndStatus(blockRoot, defaultStatus);
+  getAllNonAncestorNodes(blockRoot: RootHex, payloadStatus: PayloadStatus): ProtoNode[] {
+    const startIndex = this.getNodeIndexByRootAndStatus(blockRoot, payloadStatus);
     if (startIndex === undefined) {
       return [];
     }
@@ -1613,11 +1602,11 @@ export class ProtoArray {
    * For Gloas blocks: returns EMPTY/FULL variants (not PENDING) based on parent payload status
    * For pre-Gloas blocks: returns FULL variants
    */
-  getAllAncestorAndNonAncestorNodes(blockRoot: RootHex): {ancestors: ProtoNode[]; nonAncestors: ProtoNode[]} {
-    // Get canonical node: FULL for pre-Gloas, PENDING for Gloas
-    const defaultStatus = this.getDefaultVariant(blockRoot);
-    const startIndex =
-      defaultStatus !== undefined ? this.getNodeIndexByRootAndStatus(blockRoot, defaultStatus) : undefined;
+  getAllAncestorAndNonAncestorNodes(
+    blockRoot: RootHex,
+    payloadStatus: PayloadStatus
+  ): {ancestors: ProtoNode[]; nonAncestors: ProtoNode[]} {
+    const startIndex = this.getNodeIndexByRootAndStatus(blockRoot, payloadStatus);
     if (startIndex === undefined) {
       return {ancestors: [], nonAncestors: []};
     }
@@ -1735,26 +1724,28 @@ export class ProtoArray {
   /**
    * Returns `true` if the `descendantRoot` has an ancestor with `ancestorRoot`.
    * Always returns `false` if either input roots are unknown.
-   * Still returns `true` if `ancestorRoot` === `descendantRoot` (and the roots are known)
+   * Still returns `true` if `ancestorRoot` === `descendantRoot` and payload statuses match.
    */
-  isDescendant(ancestorRoot: RootHex, descendantRoot: RootHex): boolean {
-    // We use the default variant (PENDING for Gloas, FULL for pre-Gloas)
-    // We cannot use FULL/EMPTY variants for Gloas because they may not be canonical
-    const defaultStatus = this.getDefaultVariant(ancestorRoot);
-    const ancestorNode = defaultStatus !== undefined ? this.getNode(ancestorRoot, defaultStatus) : undefined;
+  isDescendant(
+    ancestorRoot: RootHex,
+    ancestorPayloadStatus: PayloadStatus,
+    descendantRoot: RootHex,
+    descendantPayloadStatus: PayloadStatus
+  ): boolean {
+    const ancestorNode = this.getNode(ancestorRoot, ancestorPayloadStatus);
     if (!ancestorNode) {
       return false;
     }
 
-    if (ancestorRoot === descendantRoot) {
+    if (ancestorRoot === descendantRoot && ancestorPayloadStatus === descendantPayloadStatus) {
       return true;
     }
 
-    for (const node of this.iterateAncestorNodes(descendantRoot)) {
+    for (const node of this.iterateAncestorNodes(descendantRoot, descendantPayloadStatus)) {
       if (node.slot < ancestorNode.slot) {
         return false;
       }
-      if (node.blockRoot === ancestorNode.blockRoot) {
+      if (node.blockRoot === ancestorNode.blockRoot && node.payloadStatus === ancestorNode.payloadStatus) {
         return true;
       }
     }

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -1545,9 +1545,7 @@ export class ProtoArray {
       }
 
       node = this.nodes[parentIndex];
-      if (node.payloadStatus !== PayloadStatus.PENDING) {
-        nodes.push(node);
-      }
+      nodes.push(node);
     }
 
     return nodes;

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -152,7 +152,7 @@ describe("Forkchoice", () => {
     const block = getBlock(genesisSlot + 1);
     protoArr.onBlock(block, block.slot, null);
     const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
-    const summaries = forkchoice.getAllAncestorBlocks(getBlockRoot(genesisSlot + 1));
+    const summaries = forkchoice.getAllAncestorBlocks(getBlockRoot(genesisSlot + 1), PayloadStatus.FULL);
     // there are 2 blocks in protoArray but iterateAncestorBlocks should only return non-finalized blocks
     expect(summaries).toHaveLength(1);
     expect(summaries[0]).toEqual({
@@ -180,18 +180,18 @@ describe("Forkchoice", () => {
 
     // Test with a block from the canonical chain
     const canonicalBlockRoot = getBlockRoot(genesisSlot + 3);
-    const canonicalAncestorBlocks = forkchoice.getAllAncestorBlocks(canonicalBlockRoot);
-    const canonicalNonAncestorBlocks = forkchoice.getAllNonAncestorBlocks(canonicalBlockRoot);
-    const canonicalCombined = forkchoice.getAllAncestorAndNonAncestorBlocks(canonicalBlockRoot);
+    const canonicalAncestorBlocks = forkchoice.getAllAncestorBlocks(canonicalBlockRoot, PayloadStatus.FULL);
+    const canonicalNonAncestorBlocks = forkchoice.getAllNonAncestorBlocks(canonicalBlockRoot, PayloadStatus.FULL);
+    const canonicalCombined = forkchoice.getAllAncestorAndNonAncestorBlocks(canonicalBlockRoot, PayloadStatus.FULL);
 
     expect(canonicalCombined.ancestors).toEqual(canonicalAncestorBlocks);
     expect(canonicalCombined.nonAncestors).toEqual(canonicalNonAncestorBlocks);
 
     // Test with a block from the fork chain
     const forkBlockRoot = getBlockRoot(genesisSlot + 10);
-    const forkAncestorBlocks = forkchoice.getAllAncestorBlocks(forkBlockRoot);
-    const forkNonAncestorBlocks = forkchoice.getAllNonAncestorBlocks(forkBlockRoot);
-    const forkCombined = forkchoice.getAllAncestorAndNonAncestorBlocks(forkBlockRoot);
+    const forkAncestorBlocks = forkchoice.getAllAncestorBlocks(forkBlockRoot, PayloadStatus.FULL);
+    const forkNonAncestorBlocks = forkchoice.getAllNonAncestorBlocks(forkBlockRoot, PayloadStatus.FULL);
+    const forkCombined = forkchoice.getAllAncestorAndNonAncestorBlocks(forkBlockRoot, PayloadStatus.FULL);
 
     expect(forkCombined.ancestors).toEqual(forkAncestorBlocks);
     expect(forkCombined.nonAncestors).toEqual(forkNonAncestorBlocks);

--- a/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
@@ -133,7 +133,7 @@ describe("ProtoArray", () => {
     ];
 
     for (const [ancestorRoot, descendantRoot, isDescendant] of assertions) {
-      expect(fc.isDescendant(ancestorRoot, descendantRoot)).toBeWithMessage(
+      expect(fc.isDescendant(ancestorRoot, PayloadStatus.FULL, descendantRoot, PayloadStatus.FULL)).toBeWithMessage(
         isDescendant,
         `${descendantRoot} must be ${isDescendant ? "descendant" : "not descendant"} of ${ancestorRoot}`
       );


### PR DESCRIPTION
## Motivation

The Gloas fork introduced block variants (FULL/EMPTY/PENDING) that share the same `blockRoot`. Previously, traversal methods in `ProtoArray`/`ForkChoice` used `getDefaultVariant()` internally to pick a canonical variant (PENDING for Gloas, FULL for pre-Gloas). This made callers unaware of which variant was being traversed and caused ambiguity when the caller already held a specific variant.

## Changes

**`packages/fork-choice`**

- `iterateAncestorBlocks`, `getAllAncestorBlocks`, `getAllNonAncestorBlocks`, `getAllAncestorAndNonAncestorBlocks`, `forwardIterateDescendants`, `isDescendant` — now require an explicit `payloadStatus` parameter instead of calling `getDefaultVariant()` internally
- `getAllAncestorNodes` / `getAllAncestorAndNonAncestorNodes` — PENDING variants are now explicitly filtered out from returned results (previously only pre-Gloas FULL nodes were excluded via `isGloasBlock()` check)
- `isDescendant` — self-equality now also requires matching `payloadStatus`, not just matching `blockRoot`
- Removed TODO comment on `forwardIterateDescendants` about payload ambiguity — resolved by explicit parameter

**`packages/beacon-node`**

- `CheckpointWithHex` replaced with `CheckpointWithPayload` (`CheckpointWithHex & {payloadStatus}`) in `ArchiveStore`, `archiveBlocks`, `regen`, and `chain.ts` where payload status is semantically relevant
- All call sites updated to pass explicit `payloadStatus` from the `ProtoBlock` they already hold

## Test plan

- [ ] `pnpm test:unit` in `packages/fork-choice` and `packages/beacon-node`
- [ ] `pnpm check-types`

> Note: AI-assisted (Claude Sonnet 4.6)

🤖 Generated with [Claude Code](https://claude.ai/code)