### PR TITLE
feat: gloas range sync

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -224,7 +224,7 @@ export function getBeaconBlockApi({
           }
 
           try {
-            await verifyBlocksInEpoch.call(chain as BeaconChain, parentBlock, [blockForImport], {
+            await verifyBlocksInEpoch.call(chain as BeaconChain, parentBlock, [blockForImport], null, {
               ...opts,
               verifyOnly: true,
               skipVerifyBlockSignatures: true,

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -113,7 +113,7 @@ export function getLodestarApi({
       return {
         // biome-ignore lint/complexity/useLiteralKeys: The `blockProcessor` is a protected attribute
         data: (chain as BeaconChain)["blockProcessor"].jobQueue.getItems().map((item) => {
-          const [blockInputs, opts] = item.args;
+          const [blockInputs, _envelopes, opts] = item.args;
           return {
             blockSlots: blockInputs.map((blockInput) => blockInput.slot),
             jobOpts: opts,

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import {ChainForkConfig} from "@lodestar/config";
 import {KeyValue} from "@lodestar/db";
-import {IForkChoice} from "@lodestar/fork-choice";
+import {IForkChoice, PayloadStatus} from "@lodestar/fork-choice";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot} from "@lodestar/types";
@@ -67,13 +67,31 @@ export async function archiveBlocks(
   // NOTE: The finalized block will be exactly the first block of `epoch` or previous
   const finalizedPostDeneb = finalizedCheckpoint.epoch >= config.DENEB_FORK_EPOCH;
   const finalizedPostFulu = finalizedCheckpoint.epoch >= config.FULU_FORK_EPOCH;
+  const finalizedPostGloas = finalizedCheckpoint.epoch >= config.GLOAS_FORK_EPOCH;
 
-  const finalizedCanonicalBlockRoots: BlockRootSlot[] = finalizedCanonicalBlocks.map((block) => ({
-    slot: block.slot,
-    root: fromHex(block.blockRoot),
-  }));
+  const finalizedCanonicalBlockRoots: BlockRootSlot[] = [];
+  const finalizedCanonicalEnvelopeBlockRoots: BlockRootSlot[] = [];
+  for (const block of finalizedCanonicalBlocks) {
+    const rootAndSlot = {slot: block.slot, root: fromHex(block.blockRoot)};
+    const isPostGloasBlock = config.getForkSeq(block.slot) >= ForkSeq.gloas;
 
-  const logCtx = {currentEpoch, finalizedEpoch: finalizedCheckpoint.epoch, finalizedRoot: finalizedCheckpoint.rootHex};
+    if (isPostGloasBlock) {
+      finalizedCanonicalBlockRoots.push(rootAndSlot);
+      if (block.payloadStatus === PayloadStatus.FULL) {
+        finalizedCanonicalEnvelopeBlockRoots.push(rootAndSlot);
+      }
+    } else {
+      finalizedCanonicalBlockRoots.push(rootAndSlot);
+    }
+  }
+
+  const envelopeCount = finalizedCanonicalEnvelopeBlockRoots.length;
+  const logCtx = {
+    currentEpoch,
+    finalizedEpoch: finalizedCheckpoint.epoch,
+    finalizedRoot: finalizedCheckpoint.rootHex,
+    envelopeCount,
+  };
 
   if (finalizedCanonicalBlockRoots.length > 0) {
     await migrateBlocksFromHotToColdDb(db, finalizedCanonicalBlockRoots);
@@ -103,6 +121,14 @@ export async function archiveBlocks(
         currentEpoch
       );
       logger.verbose("Migrated dataColumnSidecars from hot DB to cold DB", {...logCtx, migratedEntries});
+    }
+
+    if (finalizedPostGloas && finalizedCanonicalEnvelopeBlockRoots.length > 0) {
+      const migratedEntries = await migrateExecutionPayloadEnvelopesFromHotToColdDb(
+        db,
+        finalizedCanonicalEnvelopeBlockRoots
+      );
+      logger.verbose("Migrated executionPayloadEnvelopes from hot DB to cold DB", {...logCtx, migratedEntries});
     }
   }
 
@@ -371,6 +397,36 @@ async function migrateDataColumnSidecarsFromHotToColdDb(
   }
 
   return migratedWrappedDataColumns;
+}
+
+async function migrateExecutionPayloadEnvelopesFromHotToColdDb(db: IBeaconDb, blocks: BlockRootSlot[]): Promise<number> {
+  let migratedEnvelopes = 0;
+  for (let i = 0; i < blocks.length; i += BLOCK_BATCH_SIZE) {
+    const toIdx = Math.min(i + BLOCK_BATCH_SIZE, blocks.length);
+    const canonicalBlocks = blocks.slice(i, toIdx);
+
+    if (canonicalBlocks.length === 0) break;
+
+    const canonicalEnvelopeEntries: KeyValue<Slot, Uint8Array>[] = await Promise.all(
+      canonicalBlocks.map(async (block) => {
+        const envelopeBytes = await db.executionPayloadEnvelope.getBinary(block.root);
+        if (!envelopeBytes) {
+          throw Error(`No executionPayloadEnvelope found for slot ${block.slot} root ${toRootHex(block.root)}`);
+        }
+
+        return {key: block.slot, value: envelopeBytes};
+      })
+    );
+
+    await Promise.all([
+      db.executionPayloadEnvelopeArchive.batchPutBinary(canonicalEnvelopeEntries),
+      db.executionPayloadEnvelope.batchDelete(canonicalBlocks.map((block) => block.root)),
+    ]);
+
+    migratedEnvelopes += canonicalEnvelopeEntries.length;
+  }
+
+  return migratedEnvelopes;
 }
 
 /**

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
 import {ChainForkConfig} from "@lodestar/config";
 import {KeyValue} from "@lodestar/db";
-import {IForkChoice, PayloadStatus} from "@lodestar/fork-choice";
+import {CheckpointWithPayload, IForkChoice, PayloadStatus} from "@lodestar/fork-choice";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
-import {Epoch, RootHex, Slot} from "@lodestar/types";
+import {Epoch, Slot} from "@lodestar/types";
 import {Logger, fromAsync, fromHex, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {IBeaconDb} from "../../../db/index.js";
 import {BlockArchiveBatchPutBinaryItem} from "../../../db/repositories/index.js";
@@ -19,7 +19,6 @@ const BLOCK_BATCH_SIZE = 256;
 const BLOB_SIDECAR_BATCH_SIZE = 32;
 
 type BlockRootSlot = {slot: Slot; root: Uint8Array};
-type CheckpointHex = {epoch: Epoch; rootHex: RootHex};
 
 /**
  * Persist orphaned block to disk
@@ -53,7 +52,7 @@ export async function archiveBlocks(
   forkChoice: IForkChoice,
   lightclientServer: LightClientServer | undefined,
   logger: Logger,
-  finalizedCheckpoint: CheckpointHex,
+  finalizedCheckpoint: CheckpointWithPayload,
   currentEpoch: Epoch,
   archiveDataEpochs?: number,
   persistOrphanedBlocks?: boolean,
@@ -62,7 +61,7 @@ export async function archiveBlocks(
   // Use fork choice to determine the blocks to archive and delete
   // getAllAncestorBlocks response includes the finalized block, so it's also moved to the cold db
   const {ancestors: finalizedCanonicalBlocks, nonAncestors: finalizedNonCanonicalBlocks} =
-    forkChoice.getAllAncestorAndNonAncestorBlocks(finalizedCheckpoint.rootHex);
+    forkChoice.getAllAncestorAndNonAncestorBlocks(finalizedCheckpoint.rootHex, finalizedCheckpoint.payloadStatus);
 
   // NOTE: The finalized block will be exactly the first block of `epoch` or previous
   const finalizedPostDeneb = finalizedCheckpoint.epoch >= config.DENEB_FORK_EPOCH;

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -399,7 +399,10 @@ async function migrateDataColumnSidecarsFromHotToColdDb(
   return migratedWrappedDataColumns;
 }
 
-async function migrateExecutionPayloadEnvelopesFromHotToColdDb(db: IBeaconDb, blocks: BlockRootSlot[]): Promise<number> {
+async function migrateExecutionPayloadEnvelopesFromHotToColdDb(
+  db: IBeaconDb,
+  blocks: BlockRootSlot[]
+): Promise<number> {
   let migratedEnvelopes = 0;
   for (let i = 0; i < blocks.length; i += BLOCK_BATCH_SIZE) {
     const toIdx = Math.min(i + BLOCK_BATCH_SIZE, blocks.length);

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -74,13 +74,9 @@ export async function archiveBlocks(
     const rootAndSlot = {slot: block.slot, root: fromHex(block.blockRoot)};
     const isPostGloasBlock = config.getForkSeq(block.slot) >= ForkSeq.gloas;
 
-    if (isPostGloasBlock) {
-      finalizedCanonicalBlockRoots.push(rootAndSlot);
-      if (block.payloadStatus === PayloadStatus.FULL) {
-        finalizedCanonicalEnvelopeBlockRoots.push(rootAndSlot);
-      }
-    } else {
-      finalizedCanonicalBlockRoots.push(rootAndSlot);
+    finalizedCanonicalBlockRoots.push(rootAndSlot);
+    if (isPostGloasBlock && block.payloadStatus === PayloadStatus.FULL) {
+      finalizedCanonicalEnvelopeBlockRoots.push(rootAndSlot);
     }
   }
 

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -69,8 +69,15 @@ export async function importBlock(
   fullyVerifiedBlock: FullyVerifiedBlock,
   opts: ImportBlockOpts
 ): Promise<void> {
-  const {blockInput, postState, parentBlockSlot, executionStatus, dataAvailabilityStatus, indexedAttestations} =
-    fullyVerifiedBlock;
+  const {
+    blockInput,
+    postState,
+    postEnvelopeState,
+    parentBlockSlot,
+    executionStatus,
+    dataAvailabilityStatus,
+    indexedAttestations,
+  } = fullyVerifiedBlock;
   const block = blockInput.getBlock();
   const source = blockInput.getBlockSource();
   const {slot: blockSlot} = block.message;
@@ -122,9 +129,21 @@ export async function importBlock(
   const payloadPresent = !isGloasBlock;
   // processState manages both block state and payload state variants together for memory/disk management
   this.regen.processState(blockRootHex, postState);
+  this.logger.verbose("Added block to forkchoice and block state cache", {slot: blockSlot, root: blockRootHex, stateRoot: toRootHex(postState.hashTreeRoot())});
+
+  if (postEnvelopeState !== null) {
+    this.regen.processPayloadState(postEnvelopeState);
+    this.forkChoice.onExecutionPayload(
+      blockRootHex,
+      toRootHex(postEnvelopeState.latestBlockHash),
+      // TODO GLOAS: this is not right but we don't need to track it as part of consensus spec, lighthouse also does not track it
+      0,
+      toRootHex(postEnvelopeState.hashTreeRoot())
+    );
+    this.logger.verbose("Added envelope state to block state cache", {slot: blockSlot, root: blockRootHex, stateRoot: toRootHex(postEnvelopeState.hashTreeRoot())});
+  }
 
   this.metrics?.importBlock.bySource.inc({source: source.source});
-  this.logger.verbose("Added block to forkchoice and state cache", {slot: blockSlot, root: blockRootHex});
 
   // Post-Gloas: immediately import pending envelope for this block if available.
   // This makes the block FULL right away, so child blocks won't need to wait

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -129,7 +129,11 @@ export async function importBlock(
   const payloadPresent = !isGloasBlock;
   // processState manages both block state and payload state variants together for memory/disk management
   this.regen.processState(blockRootHex, postState);
-  this.logger.verbose("Added block to forkchoice and block state cache", {slot: blockSlot, root: blockRootHex, stateRoot: toRootHex(postState.hashTreeRoot())});
+  this.logger.verbose("Added block to forkchoice and block state cache", {
+    slot: blockSlot,
+    root: blockRootHex,
+    stateRoot: toRootHex(postState.hashTreeRoot()),
+  });
 
   if (postEnvelopeState !== null) {
     this.regen.processPayloadState(postEnvelopeState);
@@ -140,7 +144,11 @@ export async function importBlock(
       0,
       toRootHex(postEnvelopeState.hashTreeRoot())
     );
-    this.logger.verbose("Added envelope state to block state cache", {slot: blockSlot, root: blockRootHex, stateRoot: toRootHex(postEnvelopeState.hashTreeRoot())});
+    this.logger.verbose("Added envelope state to block state cache", {
+      slot: blockSlot,
+      root: blockRootHex,
+      stateRoot: toRootHex(postEnvelopeState.hashTreeRoot()),
+    });
   }
 
   this.metrics?.importBlock.bySource.inc({source: source.source});

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -22,14 +22,17 @@ const QUEUE_MAX_LENGTH = 256;
  * BlockProcessor processes block jobs in a queued fashion, one after the other.
  */
 export class BlockProcessor {
-  readonly jobQueue: JobItemQueue<[IBlockInput[], ImportBlockOpts, Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null], void>;
+  readonly jobQueue: JobItemQueue<
+    [IBlockInput[], Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null, ImportBlockOpts],
+    void
+  >;
 
   constructor(chain: BeaconChain, metrics: Metrics | null, opts: BlockProcessOpts, signal: AbortSignal) {
     this.jobQueue = new JobItemQueue<
-      [IBlockInput[], ImportBlockOpts, Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null],
+      [IBlockInput[], Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null, ImportBlockOpts],
       void
     >(
-      (job, importOpts, envelopes) => {
+      (job, envelopes, importOpts) => {
         return processBlocks.call(chain, job, envelopes, {...opts, ...importOpts});
       },
       {maxLength: QUEUE_MAX_LENGTH, noYieldIfOneItem: true, signal},
@@ -39,10 +42,10 @@ export class BlockProcessor {
 
   async processBlocksJob(
     job: IBlockInput[],
-    opts: ImportBlockOpts = {},
-    envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null = null
+    envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null = null,
+    opts: ImportBlockOpts = {}
   ): Promise<void> {
-    await this.jobQueue.push(job, opts, envelopes);
+    await this.jobQueue.push(job, envelopes, opts);
   }
 }
 

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -74,7 +74,7 @@ export async function processBlocks(
   }
 
   try {
-    const {relevantBlocks, parentSlots, parentBlock} = verifyBlocksSanityChecks(this, blocks, opts);
+    const {relevantBlocks, parentSlots, parentBlock} = verifyBlocksSanityChecks(this, blocks, opts, envelopes);
 
     // No relevant blocks, skip verifyBlocksInEpoch()
     if (relevantBlocks.length === 0 || parentBlock === null) {
@@ -84,8 +84,14 @@ export async function processBlocks(
 
     // Fully verify a block to be imported immediately after. Does not produce any side-effects besides adding intermediate
     // states in the state cache through regen.
-    const {postStates, dataAvailabilityStatuses, proposerBalanceDeltas, segmentExecStatus, indexedAttestationsByBlock} =
-      await verifyBlocksInEpoch.call(this, parentBlock, relevantBlocks, envelopes, opts);
+    const {
+      postStates,
+      postEnvelopeStates,
+      dataAvailabilityStatuses,
+      proposerBalanceDeltas,
+      segmentExecStatus,
+      indexedAttestationsByBlock,
+    } = await verifyBlocksInEpoch.call(this, parentBlock, relevantBlocks, envelopes, opts);
 
     // If segmentExecStatus has lvhForkchoice then, the entire segment should be invalid
     // and we need to further propagate
@@ -101,6 +107,7 @@ export async function processBlocks(
       (block, i): FullyVerifiedBlock => ({
         blockInput: block,
         postState: postStates[i],
+        postEnvelopeState: postEnvelopeStates.get(block.slot) ?? null,
         parentBlockSlot: parentSlots[i],
         executionStatus: executionStatuses[i],
         // start supporting optimistic syncing/processing

--- a/packages/beacon-node/src/chain/blocks/index.ts
+++ b/packages/beacon-node/src/chain/blocks/index.ts
@@ -1,4 +1,4 @@
-import {SignedBeaconBlock} from "@lodestar/types";
+import {SignedBeaconBlock, Slot, gloas} from "@lodestar/types";
 import {isErrorAborted, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {nextEventLoop} from "../../util/eventLoop.js";
@@ -22,20 +22,27 @@ const QUEUE_MAX_LENGTH = 256;
  * BlockProcessor processes block jobs in a queued fashion, one after the other.
  */
 export class BlockProcessor {
-  readonly jobQueue: JobItemQueue<[IBlockInput[], ImportBlockOpts], void>;
+  readonly jobQueue: JobItemQueue<[IBlockInput[], ImportBlockOpts, Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null], void>;
 
   constructor(chain: BeaconChain, metrics: Metrics | null, opts: BlockProcessOpts, signal: AbortSignal) {
-    this.jobQueue = new JobItemQueue<[IBlockInput[], ImportBlockOpts], void>(
-      (job, importOpts) => {
-        return processBlocks.call(chain, job, {...opts, ...importOpts});
+    this.jobQueue = new JobItemQueue<
+      [IBlockInput[], ImportBlockOpts, Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null],
+      void
+    >(
+      (job, importOpts, envelopes) => {
+        return processBlocks.call(chain, job, envelopes, {...opts, ...importOpts});
       },
       {maxLength: QUEUE_MAX_LENGTH, noYieldIfOneItem: true, signal},
       metrics?.blockProcessorQueue ?? undefined
     );
   }
 
-  async processBlocksJob(job: IBlockInput[], opts: ImportBlockOpts = {}): Promise<void> {
-    await this.jobQueue.push(job, opts);
+  async processBlocksJob(
+    job: IBlockInput[],
+    opts: ImportBlockOpts = {},
+    envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null = null
+  ): Promise<void> {
+    await this.jobQueue.push(job, opts, envelopes);
   }
 }
 
@@ -52,6 +59,7 @@ export class BlockProcessor {
 export async function processBlocks(
   this: BeaconChain,
   blocks: IBlockInput[],
+  envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null,
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<void> {
   if (blocks.length === 0) {
@@ -74,7 +82,7 @@ export async function processBlocks(
     // Fully verify a block to be imported immediately after. Does not produce any side-effects besides adding intermediate
     // states in the state cache through regen.
     const {postStates, dataAvailabilityStatuses, proposerBalanceDeltas, segmentExecStatus, indexedAttestationsByBlock} =
-      await verifyBlocksInEpoch.call(this, parentBlock, relevantBlocks, opts);
+      await verifyBlocksInEpoch.call(this, parentBlock, relevantBlocks, envelopes, opts);
 
     // If segmentExecStatus has lvhForkchoice then, the entire segment should be invalid
     // and we need to further propagate

--- a/packages/beacon-node/src/chain/blocks/types.ts
+++ b/packages/beacon-node/src/chain/blocks/types.ts
@@ -1,7 +1,12 @@
 import type {ChainForkConfig} from "@lodestar/config";
 import {MaybeValidExecutionStatus} from "@lodestar/fork-choice";
 import {ForkSeq} from "@lodestar/params";
-import {CachedBeaconStateAllForks, DataAvailabilityStatus, computeEpochAtSlot} from "@lodestar/state-transition";
+import {
+  CachedBeaconStateAllForks,
+  CachedBeaconStateGloas,
+  DataAvailabilityStatus,
+  computeEpochAtSlot,
+} from "@lodestar/state-transition";
 import type {IndexedAttestation, Slot, fulu} from "@lodestar/types";
 import {IBlockInput} from "./blockInput/types.js";
 
@@ -86,6 +91,7 @@ export type ImportBlockOpts = {
 export type FullyVerifiedBlock = {
   blockInput: IBlockInput;
   postState: CachedBeaconStateAllForks;
+  postEnvelopeState: CachedBeaconStateGloas | null;
   parentBlockSlot: Slot;
   proposerBalanceDelta: number;
   /**

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -6,7 +6,7 @@ import {
   computeEpochAtSlot,
   isStateValidatorsNodesPopulated,
 } from "@lodestar/state-transition";
-import {IndexedAttestation, deneb, isGloasBeaconBlock} from "@lodestar/types";
+import {IndexedAttestation, Slot, deneb, gloas, isGloasBeaconBlock} from "@lodestar/types";
 import {sleep, toRootHex} from "@lodestar/utils";
 import type {BeaconChain} from "../chain.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
@@ -38,6 +38,7 @@ export async function verifyBlocksInEpoch(
   this: BeaconChain,
   parentBlock: ProtoBlock,
   blockInputs: IBlockInput[],
+  envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null,
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<{
   postStates: CachedBeaconStateAllForks[];
@@ -151,7 +152,15 @@ export async function verifyBlocksInEpoch(
     // Start execution payload verification first (async request to execution client)
     const verifyExecutionPayloadsPromise =
       opts.skipVerifyExecutionPayload !== true
-        ? verifyBlocksExecutionPayload(this, parentBlock, blockInputs, preState0, abortController.signal, opts)
+        ? verifyBlocksExecutionPayload(
+            this,
+            parentBlock,
+            blockInputs,
+            envelopes,
+            preState0,
+            abortController.signal,
+            opts
+          )
         : Promise.resolve({
             execAborted: null,
             executionStatuses: blocks.map((_blk) => ExecutionStatus.Syncing),
@@ -184,6 +193,7 @@ export async function verifyBlocksInEpoch(
       verifyBlocksStateTransitionOnly(
         preState0,
         blockInputs,
+        envelopes,
         // hack availability for state transition eval as availability is separately determined
         blocks.map(() => DataAvailabilityStatus.Available),
         this.logger,
@@ -202,6 +212,7 @@ export async function verifyBlocksInEpoch(
             this.metrics,
             preState0,
             blocks,
+            envelopes,
             indexedAttestationsByBlock,
             opts
           )

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -2,6 +2,7 @@ import {ExecutionStatus, PayloadStatus, ProtoBlock} from "@lodestar/fork-choice"
 import {ForkName, isForkPostFulu} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
+  CachedBeaconStateGloas,
   DataAvailabilityStatus,
   computeEpochAtSlot,
   isStateValidatorsNodesPopulated,
@@ -42,6 +43,7 @@ export async function verifyBlocksInEpoch(
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<{
   postStates: CachedBeaconStateAllForks[];
+  postEnvelopeStates: Map<Slot, CachedBeaconStateGloas | null>;
   proposerBalanceDeltas: number[];
   segmentExecStatus: SegmentExecStatus;
   dataAvailabilityStatuses: DataAvailabilityStatus[];
@@ -180,7 +182,7 @@ export async function verifyBlocksInEpoch(
     const [
       segmentExecStatus,
       {dataAvailabilityStatuses, availableTime},
-      {postStates, proposerBalanceDeltas, verifyStateTime},
+      {postStates, postEnvelopeStates, proposerBalanceDeltas, verifyStateTime},
       {verifySignaturesTime},
     ] = await Promise.all([
       verifyExecutionPayloadsPromise,
@@ -297,7 +299,14 @@ export async function verifyBlocksInEpoch(
       );
     }
 
-    return {postStates, dataAvailabilityStatuses, proposerBalanceDeltas, segmentExecStatus, indexedAttestationsByBlock};
+    return {
+      postStates,
+      postEnvelopeStates,
+      dataAvailabilityStatuses,
+      proposerBalanceDeltas,
+      segmentExecStatus,
+      indexedAttestationsByBlock,
+    };
   } finally {
     abortController.abort();
   }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -294,10 +294,7 @@ function getSegmentErrorResponse(
           : isGloasBeaconBlock(block.message)
             ? toRootHex(block.message.body.signedExecutionPayloadBid.message.blockHash)
             : null;
-      if (
-        executionBlockHash !== null &&
-        executionBlockHash === lvhResponse.latestValidExecHash
-      ) {
+      if (executionBlockHash !== null && executionBlockHash === lvhResponse.latestValidExecHash) {
         lvhFound = true;
         break;
       }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -7,18 +7,20 @@ import {
   MaybeValidExecutionStatus,
   ProtoBlock,
 } from "@lodestar/fork-choice";
-import {ForkSeq} from "@lodestar/params";
+import {ForkPostDeneb, ForkSeq} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   isExecutionBlockBodyType,
   isExecutionEnabled,
   isExecutionStateType,
 } from "@lodestar/state-transition";
-import {bellatrix, electra} from "@lodestar/types";
+import {SignedBeaconBlock, Slot, bellatrix, electra, gloas, isGloasBeaconBlock} from "@lodestar/types";
 import {ErrorAborted, Logger, toRootHex} from "@lodestar/utils";
 import {ExecutionPayloadStatus, IExecutionEngine} from "../../execution/engine/interface.js";
 import {Metrics} from "../../metrics/metrics.js";
+import {kzgCommitmentToVersionedHash} from "../../util/blobs.js";
 import {IClock} from "../../util/clock.js";
+import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
 import {BlockProcessOpts} from "../options.js";
 import {isBlockInputBlobs, isBlockInputColumns} from "./blockInput/blockInput.js";
@@ -63,6 +65,7 @@ export async function verifyBlocksExecutionPayload(
   chain: VerifyBlockExecutionPayloadModules,
   parentBlock: ProtoBlock,
   blockInputs: IBlockInput[],
+  envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null,
   preState0: CachedBeaconStateAllForks,
   signal: AbortSignal,
   opts: BlockProcessOpts & ImportBlockOpts
@@ -101,11 +104,16 @@ export async function verifyBlocksExecutionPayload(
     if (signal.aborted) {
       throw new ErrorAborted("verifyBlockExecutionPayloads");
     }
-    const verifyResponse = await verifyBlockExecutionPayload(chain, blockInput, preState0);
+    const verifyResponse = await verifyBlockExecutionPayload(
+      chain,
+      blockInput,
+      envelopes?.get(blockInput.slot) ?? null,
+      preState0
+    );
 
     // If execError has happened, then we need to extract the segmentExecStatus and return
     if (verifyResponse.execError !== null) {
-      return getSegmentErrorResponse({verifyResponse, blockIndex}, parentBlock, blockInputs);
+      return getSegmentErrorResponse({verifyResponse, blockIndex}, parentBlock, blockInputs, envelopes);
     }
 
     // If we are here then its because executionStatus is one of MaybeValidExecutionStatus
@@ -146,6 +154,7 @@ export async function verifyBlocksExecutionPayload(
 export async function verifyBlockExecutionPayload(
   chain: VerifyBlockExecutionPayloadModules,
   blockInput: IBlockInput,
+  signedEnvelope: gloas.SignedExecutionPayloadEnvelope | null,
   preState0: CachedBeaconStateAllForks
 ): Promise<VerifyBlockExecutionResponse> {
   const block = blockInput.getBlock();
@@ -154,11 +163,15 @@ export async function verifyBlockExecutionPayload(
   const executionEnabled =
     ForkSeq[fork] >= ForkSeq.gloas || (isExecutionStateType(preState0) && isExecutionEnabled(preState0, block.message));
 
+  const envelope = signedEnvelope?.message ?? null;
+
   /** Not null if execution payload is embedded in the block body (pre-Gloas post-merge blocks) */
   const executionPayloadEnabled =
     executionEnabled && isExecutionBlockBodyType(block.message.body) ? block.message.body.executionPayload : null;
+  const executionPayloadFromEnvelope = executionEnabled && envelope ? envelope.payload : null;
+  const executionPayload = executionPayloadEnabled ?? executionPayloadFromEnvelope;
 
-  if (!executionPayloadEnabled) {
+  if (!executionPayload) {
     if (executionEnabled) {
       // Post-Gloas bid-only blocks: execution payload is delivered separately via envelope.
       // Block is valid but payload status is pending until envelope arrives.
@@ -169,16 +182,26 @@ export async function verifyBlockExecutionPayload(
     return {executionStatus: ExecutionStatus.PreMerge, lvhResponse: undefined, execError: null};
   }
   const versionedHashes =
-    isBlockInputBlobs(blockInput) || isBlockInputColumns(blockInput) ? blockInput.getVersionedHashes() : undefined;
+    isBlockInputBlobs(blockInput) || isBlockInputColumns(blockInput)
+      ? blockInput.getVersionedHashes()
+      : isGloasBeaconBlock(block.message)
+        ? getBlobKzgCommitments(blockInput.forkName, block as SignedBeaconBlock<ForkPostDeneb>).map(
+            kzgCommitmentToVersionedHash
+          )
+        : undefined;
   const parentBlockRoot = ForkSeq[fork] >= ForkSeq.deneb ? block.message.parentRoot : undefined;
   const executionRequests =
-    ForkSeq[fork] >= ForkSeq.electra ? (block.message.body as electra.BeaconBlockBody).executionRequests : undefined;
+    ForkSeq[fork] >= ForkSeq.gloas
+      ? envelope?.executionRequests
+      : ForkSeq[fork] >= ForkSeq.electra
+        ? (block.message.body as electra.BeaconBlockBody).executionRequests
+        : undefined;
 
-  const logCtx = {slot: blockInput.slot, executionBlock: executionPayloadEnabled.blockNumber};
+  const logCtx = {slot: blockInput.slot, executionBlock: executionPayload.blockNumber};
   chain.logger.debug("Call engine api newPayload", logCtx);
   const execResult = await chain.executionEngine.notifyNewPayload(
     fork,
-    executionPayloadEnabled,
+    executionPayload,
     versionedHashes,
     parentBlockRoot,
     executionRequests
@@ -248,7 +271,8 @@ export async function verifyBlockExecutionPayload(
 function getSegmentErrorResponse(
   {verifyResponse, blockIndex}: {verifyResponse: VerifyExecutionErrorResponse; blockIndex: number},
   parentBlock: ProtoBlock,
-  blocks: IBlockInput[]
+  blocks: IBlockInput[],
+  envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null
 ): SegmentExecStatus {
   const {executionStatus, lvhResponse, execError} = verifyResponse;
   let invalidSegmentLVH: LVHInvalidResponse | undefined = undefined;
@@ -261,9 +285,18 @@ function getSegmentErrorResponse(
     let lvhFound = false;
     for (let mayBeLVHIndex = blockIndex - 1; mayBeLVHIndex >= 0; mayBeLVHIndex--) {
       const block = blocks[mayBeLVHIndex].getBlock();
+      const signedEnvelope = envelopes?.get(block.message.slot) ?? null;
+      const envelope = signedEnvelope?.message ?? null;
+      const executionBlockHash = isExecutionBlockBodyType(block.message.body)
+        ? toRootHex((block.message.body as bellatrix.BeaconBlockBody).executionPayload.blockHash)
+        : envelope
+          ? toRootHex(envelope.payload.blockHash)
+          : isGloasBeaconBlock(block.message)
+            ? toRootHex(block.message.body.signedExecutionPayloadBid.message.blockHash)
+            : null;
       if (
-        toRootHex((block.message.body as bellatrix.BeaconBlockBody).executionPayload.blockHash) ===
-        lvhResponse.latestValidExecHash
+        executionBlockHash !== null &&
+        executionBlockHash === lvhResponse.latestValidExecHash
       ) {
         lvhFound = true;
         break;

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSanityChecks.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSanityChecks.ts
@@ -2,7 +2,7 @@ import {ChainForkConfig} from "@lodestar/config";
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {RootHex, Slot, isGloasBeaconBlock} from "@lodestar/types";
-import {toRootHex} from "@lodestar/utils";
+import {Logger, toRootHex} from "@lodestar/utils";
 import {IClock} from "../../util/clock.js";
 import {BlockError, BlockErrorCode} from "../errors/index.js";
 import {IChainOptions} from "../options.js";
@@ -28,9 +28,11 @@ export function verifyBlocksSanityChecks(
     config: ChainForkConfig;
     opts: IChainOptions;
     blacklistedBlocks: Map<RootHex, Slot | null>;
+    logger?: Logger;
   },
   blocks: IBlockInput[],
-  opts: ImportBlockOpts
+  opts: ImportBlockOpts,
+  envelopes: Map<Slot, unknown> | null = null
 ): {
   relevantBlocks: IBlockInput[];
   parentSlots: Slot[];
@@ -39,6 +41,11 @@ export function verifyBlocksSanityChecks(
   if (blocks.length === 0) {
     throw Error("Empty partiallyVerifiedBlocks");
   }
+
+  chain.logger?.debug("verifyBlocksSanityChecks", {
+    blockCount: blocks.length,
+    envelopeCount: envelopes?.size ?? 0,
+  });
 
   const relevantBlocks: IBlockInput[] = [];
   const parentSlots: Slot[] = [];

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
@@ -1,6 +1,14 @@
+import {PublicKey} from "@chainsafe/blst";
 import {BeaconConfig} from "@lodestar/config";
-import {CachedBeaconStateAllForks, getBlockSignatureSets} from "@lodestar/state-transition";
-import {IndexedAttestation, SignedBeaconBlock} from "@lodestar/types";
+import {
+  CachedBeaconStateAllForks,
+  CachedBeaconStateGloas,
+  createSingleSignatureSetFromComponents,
+  getBlockSignatureSets,
+  getExecutionPayloadEnvelopeSigningRoot,
+} from "@lodestar/state-transition";
+import {BUILDER_INDEX_SELF_BUILD} from "@lodestar/params";
+import {IndexedAttestation, Slot, SignedBeaconBlock, gloas, isGloasBeaconBlock} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {nextEventLoop} from "../../util/eventLoop.js";
@@ -22,6 +30,7 @@ export async function verifyBlocksSignatures(
   metrics: Metrics | null,
   preState0: CachedBeaconStateAllForks,
   blocks: SignedBeaconBlock[],
+  envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null,
   indexedAttestationsByBlock: IndexedAttestation[][],
   opts: ImportBlockOpts
 ): Promise<{verifySignaturesTime: number}> {
@@ -34,17 +43,29 @@ export async function verifyBlocksSignatures(
   // NOTE: If in the future multiple blocks signatures are verified at once, all blocks must be in the same epoch
   // so the attester and proposer shufflings are correct.
   for (const [i, block] of blocks.entries()) {
+    let blockSignaturesPromise: Promise<boolean>;
+    if (opts.validSignatures) {
+      // Skip all block signature verification
+      blockSignaturesPromise = Promise.resolve(true);
+    } else {
+      // Verify signatures per block to track which block is invalid
+      blockSignaturesPromise = bls.verifySignatureSets(
+        getBlockSignatureSets(config, currentSyncCommitteeIndexed, block, indexedAttestationsByBlock[i], {
+          skipProposerSignature: opts.validProposerSignature,
+        })
+      );
+    }
+
+    const signedEnvelope = envelopes?.get(block.message.slot) ?? null;
+    const envelopeSignaturePromise =
+      signedEnvelope && isGloasBeaconBlock(block.message)
+        ? verifyExecutionPayloadEnvelopeSignature(bls, preState0 as CachedBeaconStateGloas, block, signedEnvelope)
+        : Promise.resolve(true);
+
     // Use [i] to make clear that the index has to be correct to blame the right block below on BlockError()
-    isValidPromises[i] = opts.validSignatures
-      ? // Skip all signature verification
-        Promise.resolve(true)
-      : //
-        // Verify signatures per block to track which block is invalid
-        bls.verifySignatureSets(
-          getBlockSignatureSets(config, currentSyncCommitteeIndexed, block, indexedAttestationsByBlock[i], {
-            skipProposerSignature: opts.validProposerSignature,
-          })
-        );
+    isValidPromises[i] = Promise.all([blockSignaturesPromise, envelopeSignaturePromise]).then(
+      ([blockSigsValid, envelopeSigValid]) => blockSigsValid && envelopeSigValid
+    );
 
     // getBlockSignatureSets() takes 45ms in benchmarks for 2022Q2 mainnet blocks (100 sigs). When syncing a 32 blocks
     // segments it will block the event loop for 1400 ms, which is too much. This call will allow the event loop to
@@ -77,6 +98,27 @@ export async function verifyBlocksSignatures(
   }
 
   return {verifySignaturesTime};
+}
+
+async function verifyExecutionPayloadEnvelopeSignature(
+  bls: IBlsVerifier,
+  state: CachedBeaconStateGloas,
+  block: SignedBeaconBlock,
+  signedEnvelope: gloas.SignedExecutionPayloadEnvelope
+): Promise<boolean> {
+  const envelope = signedEnvelope.message;
+  const pubkey =
+    envelope.builderIndex === BUILDER_INDEX_SELF_BUILD
+      ? state.epochCtx.index2pubkey[block.message.proposerIndex]
+      : PublicKey.fromBytes(state.builders.getReadonly(envelope.builderIndex).pubkey);
+  const publicKey = pubkey instanceof PublicKey ? pubkey : PublicKey.fromBytes(pubkey);
+  const signatureSet = createSingleSignatureSetFromComponents(
+    publicKey,
+    getExecutionPayloadEnvelopeSigningRoot(state.config, envelope),
+    signedEnvelope.signature
+  );
+
+  return bls.verifySignatureSets([signatureSet]);
 }
 
 type AllValidRes = {allValid: true} | {allValid: false; index: number};

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
@@ -1,5 +1,6 @@
 import {PublicKey} from "@chainsafe/blst";
 import {BeaconConfig} from "@lodestar/config";
+import {BUILDER_INDEX_SELF_BUILD} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   CachedBeaconStateGloas,
@@ -7,8 +8,7 @@ import {
   getBlockSignatureSets,
   getExecutionPayloadEnvelopeSigningRoot,
 } from "@lodestar/state-transition";
-import {BUILDER_INDEX_SELF_BUILD} from "@lodestar/params";
-import {IndexedAttestation, Slot, SignedBeaconBlock, gloas, isGloasBeaconBlock} from "@lodestar/types";
+import {IndexedAttestation, SignedBeaconBlock, Slot, gloas, isGloasBeaconBlock} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {nextEventLoop} from "../../util/eventLoop.js";

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -69,7 +69,8 @@ export async function verifyBlocksStateTransitionOnly(
 
     const signedEnvelope = envelopes?.get(block.message.slot) ?? null;
     if (signedEnvelope && isGloasBeaconBlock(block.message)) {
-      processExecutionPayloadEnvelope(postState as CachedBeaconStateGloas, signedEnvelope, true);
+      // Envelope signatures are verified in verifyBlocksSignatures(); avoid duplicate checks here.
+      processExecutionPayloadEnvelope(postState as CachedBeaconStateGloas, signedEnvelope, false);
     }
 
     const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -1,10 +1,13 @@
 import {
   CachedBeaconStateAllForks,
+  CachedBeaconStateGloas,
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
   StateHashTreeRootSource,
   stateTransition,
 } from "@lodestar/state-transition";
+import {processExecutionPayloadEnvelope} from "@lodestar/state-transition/block";
+import {Slot, gloas, isGloasBeaconBlock} from "@lodestar/types";
 import {ErrorAborted, Logger, byteArrayEquals} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
 import {nextEventLoop} from "../../util/eventLoop.js";
@@ -25,6 +28,7 @@ import {ImportBlockOpts} from "./types.js";
 export async function verifyBlocksStateTransitionOnly(
   preState0: CachedBeaconStateAllForks,
   blocks: IBlockInput[],
+  envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null,
   dataAvailabilityStatuses: DataAvailabilityStatus[],
   logger: Logger,
   metrics: Metrics | null,
@@ -62,6 +66,11 @@ export async function verifyBlocksStateTransitionOnly(
       },
       {metrics, validatorMonitor}
     );
+
+    const signedEnvelope = envelopes?.get(block.message.slot) ?? null;
+    if (signedEnvelope && isGloasBeaconBlock(block.message)) {
+      processExecutionPayloadEnvelope(postState as CachedBeaconStateGloas, signedEnvelope, true);
+    }
 
     const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
       source: StateHashTreeRootSource.blockTransition,

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -36,11 +36,13 @@ export async function verifyBlocksStateTransitionOnly(
   signal: AbortSignal,
   opts: BlockProcessOpts & ImportBlockOpts
 ): Promise<{
+  preStates: CachedBeaconStateAllForks[];
   postStates: CachedBeaconStateAllForks[];
   postEnvelopeStates: Map<Slot, CachedBeaconStateGloas | null>;
   proposerBalanceDeltas: number[];
   verifyStateTime: number;
 }> {
+  const preStates: CachedBeaconStateAllForks[] = [];
   const postStates: CachedBeaconStateAllForks[] = [];
   const postEnvelopeStates = new Map<Slot, CachedBeaconStateGloas | null>();
   const proposerBalanceDeltas: number[] = [];
@@ -49,8 +51,32 @@ export async function verifyBlocksStateTransitionOnly(
   for (let i = 0; i < blocks.length; i++) {
     const {validProposerSignature, validSignatures} = opts;
     const block = blocks[i].getBlock();
-    const preState =
-      i === 0 ? preState0 : (postEnvelopeStates.get(blocks[i - 1].getBlock().message.slot) ?? postStates[i - 1]);
+    let preState: CachedBeaconStateAllForks;
+    if (i === 0) {
+      preState = preState0;
+    } else {
+      const prevSlot = blocks[i - 1].getBlock().message.slot;
+      const prevPostEnvelopeState = postEnvelopeStates.get(prevSlot);
+      if (prevPostEnvelopeState && isGloasBeaconBlock(block.message)) {
+        // In ePBS, the proposer may build on the FULL path (saw previous envelope)
+        // or the EMPTY path (didn't see it). Check bid.parentBlockHash to determine:
+        // - If it matches the previous envelope's payload.blockHash → FULL path
+        // - Otherwise → EMPTY path (use block-only state)
+        const bid = block.message.body.signedExecutionPayloadBid.message;
+        const prevEnvelope = envelopes?.get(prevSlot);
+        if (prevEnvelope && byteArrayEquals(bid.parentBlockHash, prevEnvelope.message.payload.blockHash)) {
+          // FULL path: block builds on top of revealed payload
+          preState = prevPostEnvelopeState;
+        } else {
+          // EMPTY path: block was produced without seeing previous envelope
+          preState = postStates[i - 1];
+        }
+      } else {
+        // No envelope for previous block or pre-Gloas: use envelope state if available, else block state
+        preState = prevPostEnvelopeState ?? postStates[i - 1];
+      }
+    }
+    preStates[i] = preState;
     const dataAvailabilityStatus = dataAvailabilityStatuses[i];
 
     // STFN - per_slot_processing() + per_block_processing()
@@ -146,5 +172,5 @@ export async function verifyBlocksStateTransitionOnly(
     logger.debug("Verified block state transition", {slot, recvToValLatency, recvToValidation, validationTime});
   }
 
-  return {postStates, postEnvelopeStates, proposerBalanceDeltas, verifyStateTime};
+  return {preStates, postStates, postEnvelopeStates, proposerBalanceDeltas, verifyStateTime};
 }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -35,15 +35,21 @@ export async function verifyBlocksStateTransitionOnly(
   validatorMonitor: ValidatorMonitor | null,
   signal: AbortSignal,
   opts: BlockProcessOpts & ImportBlockOpts
-): Promise<{postStates: CachedBeaconStateAllForks[]; proposerBalanceDeltas: number[]; verifyStateTime: number}> {
+): Promise<{
+  postStates: CachedBeaconStateAllForks[];
+  postEnvelopeStates: Map<Slot, CachedBeaconStateGloas | null>;
+  proposerBalanceDeltas: number[];
+  verifyStateTime: number;
+}> {
   const postStates: CachedBeaconStateAllForks[] = [];
+  const postEnvelopeStates = new Map<Slot, CachedBeaconStateGloas | null>();
   const proposerBalanceDeltas: number[] = [];
   const recvToValLatency = Date.now() / 1000 - (opts.seenTimestampSec ?? Date.now() / 1000);
 
   for (let i = 0; i < blocks.length; i++) {
     const {validProposerSignature, validSignatures} = opts;
     const block = blocks[i].getBlock();
-    const preState = i === 0 ? preState0 : postStates[i - 1];
+    const preState = i === 0 ? preState0 : postEnvelopeStates.get(blocks[i - 1].getBlock().message.slot) ??  postStates[i - 1];
     const dataAvailabilityStatus = dataAvailabilityStatuses[i];
 
     // STFN - per_slot_processing() + per_block_processing()
@@ -67,27 +73,46 @@ export async function verifyBlocksStateTransitionOnly(
       {metrics, validatorMonitor}
     );
 
-    const signedEnvelope = envelopes?.get(block.message.slot) ?? null;
-    if (signedEnvelope && isGloasBeaconBlock(block.message)) {
-      // Envelope signatures are verified in verifyBlocksSignatures(); avoid duplicate checks here.
-      processExecutionPayloadEnvelope(postState as CachedBeaconStateGloas, signedEnvelope, false);
-    }
-
     const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
       source: StateHashTreeRootSource.blockTransition,
     });
-    const stateRoot = postState.hashTreeRoot();
+    const stateRootAfterStateTransition = postState.hashTreeRoot();
     hashTreeRootTimer?.();
 
-    // Check state root matches
-    if (!byteArrayEquals(block.message.stateRoot, stateRoot)) {
+    // Check state root from block right after stateTransition()
+    if (!byteArrayEquals(block.message.stateRoot, stateRootAfterStateTransition)) {
       throw new BlockError(block, {
         code: BlockErrorCode.INVALID_STATE_ROOT,
-        root: postState.hashTreeRoot(),
+        root: stateRootAfterStateTransition,
         expectedRoot: block.message.stateRoot,
         preState,
         postState,
       });
+    }
+
+    const signedEnvelope = envelopes?.get(block.message.slot) ?? null;
+    if (signedEnvelope && isGloasBeaconBlock(block.message)) {
+      const postEnvelopeState = postState.clone(true) as CachedBeaconStateGloas;
+      // Envelope signatures are verified in verifyBlocksSignatures(); avoid duplicate checks here.
+      processExecutionPayloadEnvelope(postEnvelopeState, signedEnvelope, false);
+
+      const envelopeHashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
+        source: StateHashTreeRootSource.envelopeTransition,
+      });
+      const stateRootAfterEnvelope = postEnvelopeState.hashTreeRoot();
+      envelopeHashTreeRootTimer?.();
+
+      // Check state root from signed envelope right after processExecutionPayloadEnvelope()
+      if (!byteArrayEquals(signedEnvelope.message.stateRoot, stateRootAfterEnvelope)) {
+        throw new BlockError(block, {
+          code: BlockErrorCode.INVALID_STATE_ROOT,
+          root: stateRootAfterEnvelope,
+          expectedRoot: signedEnvelope.message.stateRoot,
+          preState,
+          postState: postEnvelopeState,
+        });
+      }
+      postEnvelopeStates.set(block.message.slot, postEnvelopeState);
     }
 
     postStates[i] = postState;
@@ -120,5 +145,5 @@ export async function verifyBlocksStateTransitionOnly(
     logger.debug("Verified block state transition", {slot, recvToValLatency, recvToValidation, validationTime});
   }
 
-  return {postStates, proposerBalanceDeltas, verifyStateTime};
+  return {postStates, postEnvelopeStates, proposerBalanceDeltas, verifyStateTime};
 }

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksStateTransitionOnly.ts
@@ -49,7 +49,8 @@ export async function verifyBlocksStateTransitionOnly(
   for (let i = 0; i < blocks.length; i++) {
     const {validProposerSignature, validSignatures} = opts;
     const block = blocks[i].getBlock();
-    const preState = i === 0 ? preState0 : postEnvelopeStates.get(blocks[i - 1].getBlock().message.slot) ??  postStates[i - 1];
+    const preState =
+      i === 0 ? preState0 : (postEnvelopeStates.get(blocks[i - 1].getBlock().message.slot) ?? postStates[i - 1]);
     const dataAvailabilityStatus = dataAvailabilityStatuses[i];
 
     // STFN - per_slot_processing() + per_block_processing()

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1070,29 +1070,15 @@ export class BeaconChain implements IBeaconChain {
   }
 
   async processBlock(block: IBlockInput, opts?: ImportBlockOpts): Promise<void> {
-    return this.blockProcessor.processBlocksJob([block], opts);
+    return this.blockProcessor.processBlocksJob([block], null, opts);
   }
 
-  async processChainSegment(blocks: IBlockInput[], opts?: ImportBlockOpts): Promise<void>;
   async processChainSegment(
     blocks: IBlockInput[],
-    envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null,
-    opts?: ImportBlockOpts
-  ): Promise<void>;
-  async processChainSegment(
-    blocks: IBlockInput[],
-    envelopesOrOpts?: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null | ImportBlockOpts,
+    envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null = null,
     opts?: ImportBlockOpts
   ): Promise<void> {
-    const envelopes =
-      envelopesOrOpts instanceof Map || envelopesOrOpts === null
-        ? envelopesOrOpts
-        : null;
-    const importOpts =
-      envelopesOrOpts instanceof Map || envelopesOrOpts === null
-        ? opts
-        : envelopesOrOpts;
-    return this.blockProcessor.processBlocksJob(blocks, importOpts, envelopes);
+    return this.blockProcessor.processBlocksJob(blocks, envelopes, opts);
   }
 
   async importExecutionPayloadEnvelope(signedEnvelope: gloas.SignedExecutionPayloadEnvelope): Promise<void> {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -1073,8 +1073,26 @@ export class BeaconChain implements IBeaconChain {
     return this.blockProcessor.processBlocksJob([block], opts);
   }
 
-  async processChainSegment(blocks: IBlockInput[], opts?: ImportBlockOpts): Promise<void> {
-    return this.blockProcessor.processBlocksJob(blocks, opts);
+  async processChainSegment(blocks: IBlockInput[], opts?: ImportBlockOpts): Promise<void>;
+  async processChainSegment(
+    blocks: IBlockInput[],
+    envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null,
+    opts?: ImportBlockOpts
+  ): Promise<void>;
+  async processChainSegment(
+    blocks: IBlockInput[],
+    envelopesOrOpts?: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null | ImportBlockOpts,
+    opts?: ImportBlockOpts
+  ): Promise<void> {
+    const envelopes =
+      envelopesOrOpts instanceof Map || envelopesOrOpts === null
+        ? envelopesOrOpts
+        : null;
+    const importOpts =
+      envelopesOrOpts instanceof Map || envelopesOrOpts === null
+        ? opts
+        : envelopesOrOpts;
+    return this.blockProcessor.processBlocksJob(blocks, importOpts, envelopes);
   }
 
   async importExecutionPayloadEnvelope(signedEnvelope: gloas.SignedExecutionPayloadEnvelope): Promise<void> {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -884,6 +884,34 @@ export class BeaconChain implements IBeaconChain {
     return sidecarsFinalized;
   }
 
+  async getSerializedExecutionPayloadEnvelope(blockSlot: Slot, blockRootHex: string): Promise<Uint8Array | null> {
+    const envelopeInput = this.seenPayloadEnvelopeCache.get(blockRootHex);
+    if (envelopeInput?.hasEnvelope()) {
+      const envelope = envelopeInput.getEnvelope();
+      const serialized = this.serializedCache.get(envelope);
+      if (serialized) {
+        return serialized;
+      }
+      return ssz.gloas.SignedExecutionPayloadEnvelope.serialize(envelope);
+    }
+
+    const pendingEnvelope = this.pendingEnvelopes.get(blockRootHex);
+    if (pendingEnvelope) {
+      const serialized = this.serializedCache.get(pendingEnvelope);
+      if (serialized) {
+        return serialized;
+      }
+      return ssz.gloas.SignedExecutionPayloadEnvelope.serialize(pendingEnvelope);
+    }
+
+    const unfinalizedEnvelope = await this.db.executionPayloadEnvelope.getBinary(fromHex(blockRootHex));
+    if (unfinalizedEnvelope) {
+      return unfinalizedEnvelope;
+    }
+
+    return this.db.executionPayloadEnvelopeArchive.getBinary(blockSlot);
+  }
+
   async produceCommonBlockBody(blockAttributes: BlockAttributes): Promise<CommonBlockBody> {
     const {slot, parentBlock} = blockAttributes;
     const state = await this.regen.getBlockSlotState(

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -254,7 +254,6 @@ export interface IBeaconChain {
   /** Process a block until complete */
   processBlock(block: IBlockInput, opts?: ImportBlockOpts): Promise<void>;
   /** Process a chain of blocks until complete */
-  processChainSegment(blocks: IBlockInput[], opts?: ImportBlockOpts): Promise<void>;
   processChainSegment(
     blocks: IBlockInput[],
     envelopes?: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null,

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -255,6 +255,11 @@ export interface IBeaconChain {
   processBlock(block: IBlockInput, opts?: ImportBlockOpts): Promise<void>;
   /** Process a chain of blocks until complete */
   processChainSegment(blocks: IBlockInput[], opts?: ImportBlockOpts): Promise<void>;
+  processChainSegment(
+    blocks: IBlockInput[],
+    envelopes?: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null,
+    opts?: ImportBlockOpts
+  ): Promise<void>;
 
   /** Process a signed execution payload envelope (post-gloas) */
   importExecutionPayloadEnvelope(signedEnvelope: gloas.SignedExecutionPayloadEnvelope): Promise<void>;

--- a/packages/beacon-node/src/chain/interface.ts
+++ b/packages/beacon-node/src/chain/interface.ts
@@ -236,6 +236,7 @@ export interface IBeaconChain {
     blockRootHex: string,
     indices: number[]
   ): Promise<(Uint8Array | undefined)[]>;
+  getSerializedExecutionPayloadEnvelope(blockSlot: Slot, blockRootHex: string): Promise<Uint8Array | null>;
 
   produceCommonBlockBody(blockAttributes: BlockAttributes): Promise<CommonBlockBody>;
   produceBlock(blockAttributes: BlockAttributes & {commonBlockBodyPromise: Promise<CommonBlockBody>}): Promise<{

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -1,10 +1,12 @@
 import {routes} from "@lodestar/api";
 import {IForkChoice, PayloadStatus, ProtoBlock} from "@lodestar/fork-choice";
+import {SLOTS_PER_EPOCH} from "@lodestar/params";
 import {CachedBeaconStateAllForks, computeEpochAtSlot} from "@lodestar/state-transition";
 import {BeaconBlock, Epoch, RootHex, Slot, isGloasBeaconBlock, phase0} from "@lodestar/types";
 import {Logger, toRootHex} from "@lodestar/utils";
 import {Metrics} from "../../metrics/index.js";
 import {JobItemQueue} from "../../util/queue/index.js";
+import {getCheckpointFromState} from "../blocks/utils/checkpoint.ts";
 import {BlockStateCache, CheckpointHexPayload, CheckpointStateCache} from "../stateCache/types.js";
 import {RegenError, RegenErrorCode} from "./errors.js";
 import {
@@ -194,6 +196,9 @@ export class QueuedStateRegenerator implements IStateRegenerator {
   processPayloadState(payloadState: CachedBeaconStateAllForks): void {
     // Add payload state to block state cache (keyed by payload state root)
     this.blockStateCache.add(payloadState);
+    if (payloadState.slot % SLOTS_PER_EPOCH === 0) {
+      this.addCheckpointState(getCheckpointFromState(payloadState), payloadState, true);
+    }
   }
 
   // TODO GLOAS: This should also be called when importing execution payload after we implement it

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -10,7 +10,17 @@ import {
   getBlockHeaderProposerSignatureSetByHeaderSlot,
   getBlockHeaderProposerSignatureSetByParentStateSlot,
 } from "@lodestar/state-transition";
-import {DataColumnSidecar, DataColumnSidecars, Root, Slot, SubnetID, deneb, fulu, isGloasDataColumnSidecar, ssz} from "@lodestar/types";
+import {
+  DataColumnSidecar,
+  DataColumnSidecars,
+  Root,
+  Slot,
+  SubnetID,
+  deneb,
+  fulu,
+  isGloasDataColumnSidecar,
+  ssz,
+} from "@lodestar/types";
 import {byteArrayEquals, toRootHex, verifyMerkleBranch} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {kzg} from "../../util/kzg.js";
@@ -361,7 +371,10 @@ export async function validateBlockDataColumnSidecars(
       const slot = firstSidecarSignedBlockHeader.message.slot;
       const signature = firstSidecarSignedBlockHeader.signature;
       if (!chain.seenBlockInputCache.isVerifiedProposerSignature(slot, rootHex, signature)) {
-        const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(chain.config, firstSidecarSignedBlockHeader);
+        const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(
+          chain.config,
+          firstSidecarSignedBlockHeader
+        );
 
         if (
           !(await chain.bls.verifySignatureSets([signatureSet], {

--- a/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
+++ b/packages/beacon-node/src/chain/validation/dataColumnSidecar.ts
@@ -10,7 +10,7 @@ import {
   getBlockHeaderProposerSignatureSetByHeaderSlot,
   getBlockHeaderProposerSignatureSetByParentStateSlot,
 } from "@lodestar/state-transition";
-import {DataColumnSidecar, Root, Slot, SubnetID, fulu, ssz} from "@lodestar/types";
+import {DataColumnSidecar, DataColumnSidecars, Root, Slot, SubnetID, deneb, fulu, isGloasDataColumnSidecar, ssz} from "@lodestar/types";
 import {byteArrayEquals, toRootHex, verifyMerkleBranch} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
 import {kzg} from "../../util/kzg.js";
@@ -297,7 +297,8 @@ export async function validateBlockDataColumnSidecars(
   blockSlot: Slot,
   blockRoot: Root,
   blockBlobCount: number,
-  dataColumnSidecars: fulu.DataColumnSidecars
+  dataColumnSidecars: DataColumnSidecars,
+  blockKzgCommitments?: deneb.KZGCommitment[]
 ): Promise<void> {
   if (dataColumnSidecars.length === 0) {
     return;
@@ -314,44 +315,69 @@ export async function validateBlockDataColumnSidecars(
       "Block has no blob commitments but data column sidecars were provided"
     );
   }
-  // Hash the first sidecar block header and compare the rest via (cheaper) equality
-  const firstSidecarSignedBlockHeader = dataColumnSidecars[0].signedBlockHeader;
-  const firstSidecarBlockHeader = firstSidecarSignedBlockHeader.message;
-  const firstBlockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(firstSidecarBlockHeader);
-  if (!byteArrayEquals(blockRoot, firstBlockRoot)) {
-    throw new DataColumnSidecarValidationError(
-      {
-        code: DataColumnSidecarErrorCode.INCORRECT_BLOCK,
-        slot: blockSlot,
-        columnIndex: 0,
-        expected: toRootHex(blockRoot),
-        actual: toRootHex(firstBlockRoot),
-      },
-      "DataColumnSidecar doesn't match corresponding block"
-    );
+  const firstSidecar = dataColumnSidecars[0];
+  const isGloas = isGloasDataColumnSidecar(firstSidecar);
+
+  if (isGloas) {
+    if (firstSidecar.slot !== blockSlot || !byteArrayEquals(blockRoot, firstSidecar.beaconBlockRoot)) {
+      throw new DataColumnSidecarValidationError(
+        {
+          code: DataColumnSidecarErrorCode.INCORRECT_BLOCK,
+          slot: blockSlot,
+          columnIndex: 0,
+          expected: toRootHex(blockRoot),
+          actual: toRootHex(firstSidecar.beaconBlockRoot),
+        },
+        "DataColumnSidecar doesn't match corresponding block"
+      );
+    }
+  } else {
+    // Hash the first sidecar block header and compare the rest via (cheaper) equality
+    const firstSidecarSignedBlockHeader = firstSidecar.signedBlockHeader;
+    const firstSidecarBlockHeader = firstSidecarSignedBlockHeader.message;
+    const firstBlockRoot = ssz.phase0.BeaconBlockHeader.hashTreeRoot(firstSidecarBlockHeader);
+    if (!byteArrayEquals(blockRoot, firstBlockRoot)) {
+      throw new DataColumnSidecarValidationError(
+        {
+          code: DataColumnSidecarErrorCode.INCORRECT_BLOCK,
+          slot: blockSlot,
+          columnIndex: 0,
+          expected: toRootHex(blockRoot),
+          actual: toRootHex(firstBlockRoot),
+        },
+        "DataColumnSidecar doesn't match corresponding block"
+      );
+    }
   }
 
   if (chain !== null) {
-    const rootHex = toRootHex(blockRoot);
-    const slot = firstSidecarSignedBlockHeader.message.slot;
-    const signature = firstSidecarSignedBlockHeader.signature;
-    if (!chain.seenBlockInputCache.isVerifiedProposerSignature(slot, rootHex, signature)) {
-      const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(chain.config, firstSidecarSignedBlockHeader);
+    if (isGloas) {
+      // Post-gloas sidecars do not include signed block headers.
+      // Signature verification is handled via envelope/bid validation paths.
+      // Skip proposer signature verification here.
+    } else {
+      const firstSidecarSignedBlockHeader = firstSidecar.signedBlockHeader;
+      const rootHex = toRootHex(blockRoot);
+      const slot = firstSidecarSignedBlockHeader.message.slot;
+      const signature = firstSidecarSignedBlockHeader.signature;
+      if (!chain.seenBlockInputCache.isVerifiedProposerSignature(slot, rootHex, signature)) {
+        const signatureSet = getBlockHeaderProposerSignatureSetByHeaderSlot(chain.config, firstSidecarSignedBlockHeader);
 
-      if (
-        !(await chain.bls.verifySignatureSets([signatureSet], {
-          verifyOnMainThread: true,
-        }))
-      ) {
-        throw new DataColumnSidecarValidationError({
-          code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
-          blockRoot: rootHex,
-          slot: blockSlot,
-          index: dataColumnSidecars[0].index,
-        });
+        if (
+          !(await chain.bls.verifySignatureSets([signatureSet], {
+            verifyOnMainThread: true,
+          }))
+        ) {
+          throw new DataColumnSidecarValidationError({
+            code: DataColumnSidecarErrorCode.PROPOSAL_SIGNATURE_INVALID,
+            blockRoot: rootHex,
+            slot: blockSlot,
+            index: dataColumnSidecars[0].index,
+          });
+        }
+
+        chain.seenBlockInputCache.markVerifiedProposerSignature(slot, rootHex, signature);
       }
-
-      chain.seenBlockInputCache.markVerifiedProposerSignature(slot, rootHex, signature);
     }
   }
 
@@ -362,15 +388,12 @@ export async function validateBlockDataColumnSidecars(
   for (let i = 0; i < dataColumnSidecars.length; i++) {
     const columnSidecar = dataColumnSidecars[i];
 
-    if (
-      i !== 0 &&
-      !ssz.phase0.SignedBeaconBlockHeader.equals(firstSidecarSignedBlockHeader, columnSidecar.signedBlockHeader)
-    ) {
+    if (isGloasDataColumnSidecar(columnSidecar) !== isGloas) {
       throw new DataColumnSidecarValidationError({
         code: DataColumnSidecarErrorCode.INCORRECT_HEADER_ROOT,
         slot: blockSlot,
-        expected: toRootHex(blockRoot),
-        actual: toRootHex(ssz.phase0.BeaconBlockHeader.hashTreeRoot(columnSidecar.signedBlockHeader.message)),
+        expected: "uniform sidecar type",
+        actual: "mixed sidecar type",
       });
     }
 
@@ -395,16 +418,6 @@ export async function validateBlockDataColumnSidecars(
       });
     }
 
-    if (columnSidecar.column.length !== columnSidecar.kzgCommitments.length) {
-      throw new DataColumnSidecarValidationError({
-        code: DataColumnSidecarErrorCode.INCORRECT_KZG_COMMITMENTS_COUNT,
-        slot: blockSlot,
-        columnIndex: columnSidecar.index,
-        expected: columnSidecar.column.length,
-        actual: columnSidecar.kzgCommitments.length,
-      });
-    }
-
     if (columnSidecar.column.length !== columnSidecar.kzgProofs.length) {
       throw new DataColumnSidecarValidationError({
         code: DataColumnSidecarErrorCode.INCORRECT_KZG_PROOF_COUNT,
@@ -415,18 +428,64 @@ export async function validateBlockDataColumnSidecars(
       });
     }
 
-    if (!verifyDataColumnSidecarInclusionProof(columnSidecar)) {
-      throw new DataColumnSidecarValidationError(
-        {
-          code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID,
+    if (isGloasDataColumnSidecar(columnSidecar)) {
+      if (columnSidecar.slot !== blockSlot || !byteArrayEquals(columnSidecar.beaconBlockRoot, blockRoot)) {
+        throw new DataColumnSidecarValidationError({
+          code: DataColumnSidecarErrorCode.INCORRECT_BLOCK,
           slot: blockSlot,
           columnIndex: columnSidecar.index,
-        },
-        "DataColumnSidecar has invalid inclusion proof"
-      );
+          expected: toRootHex(blockRoot),
+          actual: toRootHex(columnSidecar.beaconBlockRoot),
+        });
+      }
+      if (!blockKzgCommitments || blockKzgCommitments.length !== blockBlobCount) {
+        throw new DataColumnSidecarValidationError({
+          code: DataColumnSidecarErrorCode.INCORRECT_KZG_COMMITMENTS_COUNT,
+          slot: blockSlot,
+          columnIndex: columnSidecar.index,
+          expected: blockBlobCount,
+          actual: blockKzgCommitments?.length ?? 0,
+        });
+      }
+      commitments.push(...blockKzgCommitments);
+    } else {
+      const firstSidecarSignedBlockHeader = (firstSidecar as fulu.DataColumnSidecar).signedBlockHeader;
+      if (
+        i !== 0 &&
+        !ssz.phase0.SignedBeaconBlockHeader.equals(firstSidecarSignedBlockHeader, columnSidecar.signedBlockHeader)
+      ) {
+        throw new DataColumnSidecarValidationError({
+          code: DataColumnSidecarErrorCode.INCORRECT_HEADER_ROOT,
+          slot: blockSlot,
+          expected: toRootHex(blockRoot),
+          actual: toRootHex(ssz.phase0.BeaconBlockHeader.hashTreeRoot(columnSidecar.signedBlockHeader.message)),
+        });
+      }
+
+      if (columnSidecar.column.length !== columnSidecar.kzgCommitments.length) {
+        throw new DataColumnSidecarValidationError({
+          code: DataColumnSidecarErrorCode.INCORRECT_KZG_COMMITMENTS_COUNT,
+          slot: blockSlot,
+          columnIndex: columnSidecar.index,
+          expected: columnSidecar.column.length,
+          actual: columnSidecar.kzgCommitments.length,
+        });
+      }
+
+      if (!verifyDataColumnSidecarInclusionProof(columnSidecar)) {
+        throw new DataColumnSidecarValidationError(
+          {
+            code: DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID,
+            slot: blockSlot,
+            columnIndex: columnSidecar.index,
+          },
+          "DataColumnSidecar has invalid inclusion proof"
+        );
+      }
+
+      commitments.push(...columnSidecar.kzgCommitments);
     }
 
-    commitments.push(...columnSidecar.kzgCommitments);
     cellIndices.push(...Array.from({length: columnSidecar.column.length}, () => columnSidecar.index));
     cells.push(...columnSidecar.column);
     proofs.push(...columnSidecar.kzgProofs);

--- a/packages/beacon-node/src/network/interface.ts
+++ b/packages/beacon-node/src/network/interface.ts
@@ -83,6 +83,10 @@ export interface INetwork extends INetworkCorePublic {
     peerId: PeerIdStr,
     request: fulu.DataColumnSidecarsByRangeRequest
   ): Promise<fulu.DataColumnSidecar[]>;
+  sendExecutionPayloadEnvelopesByRange(
+    peerId: PeerIdStr,
+    request: gloas.ExecutionPayloadEnvelopesByRangeRequest
+  ): Promise<gloas.SignedExecutionPayloadEnvelope[]>;
   sendDataColumnSidecarsByRoot(
     peerId: PeerIdStr,
     request: DataColumnSidecarsByRootRequest

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -647,7 +647,19 @@ export class Network implements INetwork {
     return collectMaxResponseTyped(
       this.sendReqRespRequest(peerId, ReqRespMethod.ExecutionPayloadEnvelopesByRoot, [Version.V1], request),
       request.length,
-      responseSszTypeByMethod[ReqRespMethod.ExecutionPayloadEnvelopesByRoot]
+      responseSszTypeByMethod[ReqRespMethod.ExecutionPayloadEnvelopesByRoot],
+      this.chain.serializedCache
+    );
+  }
+
+  async sendExecutionPayloadEnvelopesByRange(
+    peerId: PeerIdStr,
+    request: gloas.ExecutionPayloadEnvelopesByRangeRequest
+  ): Promise<gloas.SignedExecutionPayloadEnvelope[]> {
+    return collectMaxResponseTyped(
+      this.sendReqRespRequest(peerId, ReqRespMethod.ExecutionPayloadEnvelopesByRange, [Version.V1], request),
+      request.count,
+      responseSszTypeByMethod[ReqRespMethod.ExecutionPayloadEnvelopesByRange]
     );
   }
 

--- a/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
+++ b/packages/beacon-node/src/network/reqresp/ReqRespBeaconNode.ts
@@ -298,10 +298,16 @@ export class ReqRespBeaconNode extends ReqResp {
     }
 
     if (ForkSeq[fork] >= ForkSeq.gloas) {
-      protocolsAtFork.push([
-        protocols.ExecutionPayloadEnvelopesByRoot(fork, this.config),
-        this.getHandler(ReqRespMethod.ExecutionPayloadEnvelopesByRoot),
-      ]);
+      protocolsAtFork.push(
+        [
+          protocols.ExecutionPayloadEnvelopesByRoot(fork, this.config),
+          this.getHandler(ReqRespMethod.ExecutionPayloadEnvelopesByRoot),
+        ],
+        [
+          protocols.ExecutionPayloadEnvelopesByRange(fork, this.config),
+          this.getHandler(ReqRespMethod.ExecutionPayloadEnvelopesByRange),
+        ]
+      );
     }
 
     return protocolsAtFork;

--- a/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/beaconBlocksByRange.ts
@@ -47,9 +47,9 @@ export async function* onBeaconBlocksByRange(
 
   // Non-finalized range of blocks
   if (endSlot > finalizedSlot) {
-    const headRoot = chain.forkChoice.getHeadRoot();
+    const head = chain.forkChoice.getHead();
     // TODO DENEB: forkChoice should mantain an array of canonical blocks, and change only on reorg
-    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
+    const headChain = chain.forkChoice.getAllAncestorBlocks(head);
     // getAllAncestorBlocks response includes the head node, so it's the full chain.
 
     // Iterate head chain with ascending block numbers

--- a/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/blobSidecarsByRange.ts
@@ -34,9 +34,9 @@ export async function* onBlobSidecarsByRange(
 
   // Non-finalized range of blobs
   if (endSlot > finalizedSlot) {
-    const headRoot = chain.forkChoice.getHeadRoot();
+    const head = chain.forkChoice.getHead();
     // TODO DENEB: forkChoice should mantain an array of canonical blocks, and change only on reorg
-    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
+    const headChain = chain.forkChoice.getAllAncestorBlocks(head);
 
     // Iterate head chain with ascending block numbers
     for (let i = headChain.length - 1; i >= 0; i--) {

--- a/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/dataColumnSidecarsByRange.ts
@@ -78,8 +78,8 @@ export async function* onDataColumnSidecarsByRange(
 
   // Non-finalized range of columns
   if (endSlot > finalizedSlot) {
-    const headRoot = chain.forkChoice.getHeadRoot();
-    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
+    const head = chain.forkChoice.getHead();
+    const headChain = chain.forkChoice.getAllAncestorBlocks(head);
 
     // Iterate head chain with ascending block numbers
     for (let i = headChain.length - 1; i >= 0; i--) {

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
@@ -27,8 +27,8 @@ export async function* onExecutionPayloadEnvelopesByRange(
 
   // Non-finalized range: from chain cache
   if (endSlot > finalizedSlot) {
-    const headRoot = chain.forkChoice.getHeadRoot();
-    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
+    const head = chain.forkChoice.getHead();
+    const headChain = chain.forkChoice.getAllAncestorBlocks(head);
     for (let i = headChain.length - 1; i >= 0; i--) {
       const block = headChain[i];
       if (block.slot >= startSlot && block.slot < endSlot) {

--- a/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/executionPayloadEnvelopesByRange.ts
@@ -1,0 +1,64 @@
+import {ChainConfig} from "@lodestar/config";
+import {GENESIS_SLOT} from "@lodestar/params";
+import {RespStatus, ResponseError, ResponseOutgoing} from "@lodestar/reqresp";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {gloas} from "@lodestar/types";
+import {IBeaconChain} from "../../../chain/index.js";
+import {IBeaconDb} from "../../../db/index.js";
+
+export async function* onExecutionPayloadEnvelopesByRange(
+  request: gloas.ExecutionPayloadEnvelopesByRangeRequest,
+  chain: IBeaconChain,
+  db: IBeaconDb
+): AsyncIterable<ResponseOutgoing> {
+  const {startSlot, count} = validateEnvelopesByRangeRequest(chain.config, request);
+  const endSlot = startSlot + count;
+  const finalizedSlot = chain.forkChoice.getFinalizedBlock().slot;
+
+  // Finalized range: from archive (indexed by slot)
+  if (startSlot <= finalizedSlot) {
+    for (let slot = startSlot; slot < endSlot && slot <= finalizedSlot; slot++) {
+      const envelopeBytes = await db.executionPayloadEnvelopeArchive.getBinary(slot);
+      if (envelopeBytes) {
+        yield {data: envelopeBytes, boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(slot))};
+      }
+    }
+  }
+
+  // Non-finalized range: from chain cache
+  if (endSlot > finalizedSlot) {
+    const headRoot = chain.forkChoice.getHeadRoot();
+    const headChain = chain.forkChoice.getAllAncestorBlocks(headRoot);
+    for (let i = headChain.length - 1; i >= 0; i--) {
+      const block = headChain[i];
+      if (block.slot >= startSlot && block.slot < endSlot) {
+        const envelopeBytes = await chain.getSerializedExecutionPayloadEnvelope(block.slot, block.blockRoot);
+        if (envelopeBytes) {
+          yield {data: envelopeBytes, boundary: chain.config.getForkBoundaryAtEpoch(computeEpochAtSlot(block.slot))};
+        }
+      } else if (block.slot >= endSlot) {
+        break;
+      }
+    }
+  }
+}
+
+export function validateEnvelopesByRangeRequest(
+  config: ChainConfig,
+  request: gloas.ExecutionPayloadEnvelopesByRangeRequest
+): gloas.ExecutionPayloadEnvelopesByRangeRequest {
+  const {startSlot} = request;
+  let {count} = request;
+
+  if (count < 1) {
+    throw new ResponseError(RespStatus.INVALID_REQUEST, "count < 1");
+  }
+  if (startSlot < GENESIS_SLOT) {
+    throw new ResponseError(RespStatus.INVALID_REQUEST, "startSlot < genesis");
+  }
+  if (count > config.MAX_REQUEST_BLOCKS_DENEB) {
+    count = config.MAX_REQUEST_BLOCKS_DENEB;
+  }
+
+  return {startSlot, count};
+}

--- a/packages/beacon-node/src/network/reqresp/handlers/index.ts
+++ b/packages/beacon-node/src/network/reqresp/handlers/index.ts
@@ -15,6 +15,7 @@ import {onBlobSidecarsByRange} from "./blobSidecarsByRange.js";
 import {onBlobSidecarsByRoot} from "./blobSidecarsByRoot.js";
 import {onDataColumnSidecarsByRange} from "./dataColumnSidecarsByRange.js";
 import {onDataColumnSidecarsByRoot} from "./dataColumnSidecarsByRoot.js";
+import {onExecutionPayloadEnvelopesByRange} from "./executionPayloadEnvelopesByRange.js";
 import {onExecutionPayloadEnvelopesByRoot} from "./executionPayloadEnvelopesByRoot.js";
 import {onLightClientBootstrap} from "./lightClientBootstrap.js";
 import {onLightClientFinalityUpdate} from "./lightClientFinalityUpdate.js";
@@ -66,6 +67,10 @@ export function getReqRespHandlers({db, chain}: {db: IBeaconDb; chain: IBeaconCh
     [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: (req) => {
       const body = ExecutionPayloadEnvelopesByRootRequestType(chain.config).deserialize(req.data);
       return onExecutionPayloadEnvelopesByRoot(body, chain, db);
+    },
+    [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: (req) => {
+      const body = ssz.gloas.ExecutionPayloadEnvelopesByRangeRequest.deserialize(req.data);
+      return onExecutionPayloadEnvelopesByRange(body, chain, db);
     },
 
     [ReqRespMethod.LightClientBootstrap]: (req) => {

--- a/packages/beacon-node/src/network/reqresp/protocols.ts
+++ b/packages/beacon-node/src/network/reqresp/protocols.ts
@@ -100,6 +100,12 @@ export const ExecutionPayloadEnvelopesByRoot = toProtocol({
   contextBytesType: ContextBytesType.ForkDigest,
 });
 
+export const ExecutionPayloadEnvelopesByRange = toProtocol({
+  method: ReqRespMethod.ExecutionPayloadEnvelopesByRange,
+  version: Version.V1,
+  contextBytesType: ContextBytesType.ForkDigest,
+});
+
 export const LightClientBootstrap = toProtocol({
   method: ReqRespMethod.LightClientBootstrap,
   version: Version.V1,

--- a/packages/beacon-node/src/network/reqresp/rateLimit.ts
+++ b/packages/beacon-node/src/network/reqresp/rateLimit.ts
@@ -83,6 +83,16 @@ export const rateLimitQuotas: (fork: ForkName, config: BeaconConfig) => Record<R
       (req) => req.length
     ),
   },
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: {
+    // Rationale: similar to BeaconBlocksByRange — one envelope per block
+    byPeer: {quota: config.MAX_REQUEST_PAYLOADS, quotaTimeMs: 10_000},
+    getRequestCount: getRequestCountFn(
+      fork,
+      config,
+      ReqRespMethod.ExecutionPayloadEnvelopesByRange,
+      (req) => req.count
+    ),
+  },
   [ReqRespMethod.LightClientBootstrap]: {
     // As similar in the nature of `Status` protocol so we use the same rate limits.
     byPeer: {quota: 5, quotaTimeMs: 15_000},

--- a/packages/beacon-node/src/network/reqresp/score.ts
+++ b/packages/beacon-node/src/network/reqresp/score.ts
@@ -19,6 +19,12 @@ const multiStreamSelectErrorCodes = {
   protocolSelectionFailed: "protocol selection failed",
 };
 
+const reqRespRateLimitErrorMessages = [
+  RequestErrorCode.REQUEST_RATE_LIMITED,
+  RequestErrorCode.REQUEST_SELF_RATE_LIMITED,
+  RequestErrorCode.RESP_RATE_LIMITED,
+] as const;
+
 export function onOutgoingReqRespError(e: RequestError, method: ReqRespMethod): PeerAction | null {
   switch (e.type.code) {
     case RequestErrorCode.INVALID_REQUEST:
@@ -27,7 +33,9 @@ export function onOutgoingReqRespError(e: RequestError, method: ReqRespMethod): 
       return PeerAction.LowToleranceError;
 
     case RequestErrorCode.SERVER_ERROR:
-      return PeerAction.MidToleranceError;
+      return reqRespRateLimitErrorMessages.some((errMessage) => e.message.includes(errMessage))
+        ? null
+        : PeerAction.MidToleranceError;
     case RequestErrorCode.UNKNOWN_ERROR_STATUS:
       return PeerAction.HighToleranceError;
 
@@ -59,6 +67,7 @@ export function onOutgoingReqRespError(e: RequestError, method: ReqRespMethod): 
         return PeerAction.Fatal;
       case ReqRespMethod.Metadata:
       case ReqRespMethod.Status:
+      case ReqRespMethod.ExecutionPayloadEnvelopesByRange:
         return PeerAction.LowToleranceError;
       default:
         return null;

--- a/packages/beacon-node/src/network/reqresp/types.ts
+++ b/packages/beacon-node/src/network/reqresp/types.ts
@@ -1,6 +1,6 @@
 import {Type} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {ForkName, ForkPostAltair, isForkPostAltair} from "@lodestar/params";
+import {ForkName, ForkPostAltair, ForkPostFulu, isForkPostAltair, isForkPostFulu} from "@lodestar/params";
 import {Protocol, ProtocolHandler, ReqRespRequest} from "@lodestar/reqresp";
 import {
   LightClientBootstrap,
@@ -46,6 +46,7 @@ export enum ReqRespMethod {
   DataColumnSidecarsByRange = "data_column_sidecars_by_range",
   DataColumnSidecarsByRoot = "data_column_sidecars_by_root",
   ExecutionPayloadEnvelopesByRoot = "execution_payload_envelopes_by_root",
+  ExecutionPayloadEnvelopesByRange = "execution_payload_envelopes_by_range",
   LightClientBootstrap = "light_client_bootstrap",
   LightClientUpdatesByRange = "light_client_updates_by_range",
   LightClientFinalityUpdate = "light_client_finality_update",
@@ -65,6 +66,7 @@ export type RequestBodyByMethod = {
   [ReqRespMethod.DataColumnSidecarsByRange]: fulu.DataColumnSidecarsByRangeRequest;
   [ReqRespMethod.DataColumnSidecarsByRoot]: DataColumnSidecarsByRootRequest;
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: ExecutionPayloadEnvelopesByRootRequest;
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: gloas.ExecutionPayloadEnvelopesByRangeRequest;
   [ReqRespMethod.LightClientBootstrap]: Root;
   [ReqRespMethod.LightClientUpdatesByRange]: altair.LightClientUpdatesByRange;
   [ReqRespMethod.LightClientFinalityUpdate]: null;
@@ -84,6 +86,7 @@ type ResponseBodyByMethod = {
   [ReqRespMethod.DataColumnSidecarsByRange]: fulu.DataColumnSidecar;
   [ReqRespMethod.DataColumnSidecarsByRoot]: fulu.DataColumnSidecar;
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: gloas.SignedExecutionPayloadEnvelope;
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: gloas.SignedExecutionPayloadEnvelope;
 
   [ReqRespMethod.LightClientBootstrap]: LightClientBootstrap;
   [ReqRespMethod.LightClientUpdatesByRange]: LightClientUpdate;
@@ -112,6 +115,7 @@ export const requestSszTypeByMethod: (
   [ReqRespMethod.DataColumnSidecarsByRange]: ssz.fulu.DataColumnSidecarsByRangeRequest,
   [ReqRespMethod.DataColumnSidecarsByRoot]: DataColumnSidecarsByRootRequestType(config),
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: ExecutionPayloadEnvelopesByRootRequestType(config),
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: ssz.gloas.ExecutionPayloadEnvelopesByRangeRequest,
 
   [ReqRespMethod.LightClientBootstrap]: ssz.Root,
   [ReqRespMethod.LightClientUpdatesByRange]: ssz.altair.LightClientUpdatesByRange,
@@ -142,9 +146,12 @@ export const responseSszTypeByMethod: {[K in ReqRespMethod]: ResponseTypeGetter<
   [ReqRespMethod.LightClientBootstrap]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientBootstrap,
   [ReqRespMethod.LightClientUpdatesByRange]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientUpdate,
   [ReqRespMethod.LightClientFinalityUpdate]: (fork) => sszTypesFor(onlyPostAltairFork(fork)).LightClientFinalityUpdate,
-  [ReqRespMethod.DataColumnSidecarsByRange]: () => ssz.fulu.DataColumnSidecar,
-  [ReqRespMethod.DataColumnSidecarsByRoot]: () => ssz.fulu.DataColumnSidecar,
+  [ReqRespMethod.DataColumnSidecarsByRange]: (fork) =>
+    sszTypesFor(onlyPostFuluFork(fork)).DataColumnSidecar as Type<fulu.DataColumnSidecar>,
+  [ReqRespMethod.DataColumnSidecarsByRoot]: (fork) =>
+    sszTypesFor(onlyPostFuluFork(fork)).DataColumnSidecar as Type<fulu.DataColumnSidecar>,
   [ReqRespMethod.ExecutionPayloadEnvelopesByRoot]: () => ssz.gloas.SignedExecutionPayloadEnvelope,
+  [ReqRespMethod.ExecutionPayloadEnvelopesByRange]: () => ssz.gloas.SignedExecutionPayloadEnvelope,
   [ReqRespMethod.LightClientOptimisticUpdate]: (fork) =>
     sszTypesFor(onlyPostAltairFork(fork)).LightClientOptimisticUpdate,
 };
@@ -154,6 +161,13 @@ function onlyPostAltairFork(fork: ForkName): ForkPostAltair {
     return fork;
   }
   throw Error(`Not a post-altair fork ${fork}`);
+}
+
+function onlyPostFuluFork(fork: ForkName): ForkPostFulu {
+  if (isForkPostFulu(fork)) {
+    return fork;
+  }
+  throw Error(`Not a post-fulu fork ${fork}`);
 }
 
 export type RequestTypedContainer = {

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -1,6 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkName, isForkPostDeneb, isForkPostFulu} from "@lodestar/params";
-import {Epoch, RootHex, Slot, phase0} from "@lodestar/types";
+import {ForkName, isForkPostDeneb, isForkPostFulu, isForkPostGloas} from "@lodestar/params";
+import {Epoch, RootHex, Slot, gloas, phase0} from "@lodestar/types";
 import {LodestarError} from "@lodestar/utils";
 import {isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {IBlockInput} from "../../chain/blocks/blockInput/types.js";
@@ -46,19 +46,36 @@ export type Attempt = {
 export type AwaitingDownloadState = {
   status: BatchStatus.AwaitingDownload;
   blocks: IBlockInput[];
+  envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
 };
 
 export type DownloadSuccessState = {
   status: BatchStatus.AwaitingProcessing;
   blocks: IBlockInput[];
+  envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
 };
 
 export type BatchState =
   | AwaitingDownloadState
-  | {status: BatchStatus.Downloading; peer: PeerIdStr; blocks: IBlockInput[]}
+  | {
+      status: BatchStatus.Downloading;
+      peer: PeerIdStr;
+      blocks: IBlockInput[];
+      envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
+    }
   | DownloadSuccessState
-  | {status: BatchStatus.Processing; blocks: IBlockInput[]; attempt: Attempt}
-  | {status: BatchStatus.AwaitingValidation; blocks: IBlockInput[]; attempt: Attempt};
+  | {
+      status: BatchStatus.Processing;
+      blocks: IBlockInput[];
+      envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
+      attempt: Attempt;
+    }
+  | {
+      status: BatchStatus.AwaitingValidation;
+      blocks: IBlockInput[];
+      envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
+      attempt: Attempt;
+    };
 
 export type BatchMetadata = {
   startEpoch: Epoch;
@@ -85,7 +102,7 @@ export class Batch {
   /** Block, blob and column requests that are used to determine the best peer and are used in downloadByRange */
   requests: DownloadByRangeRequests;
   /** State of the batch. */
-  state: BatchState = {status: BatchStatus.AwaitingDownload, blocks: []};
+  state: BatchState = {status: BatchStatus.AwaitingDownload, blocks: [], envelopes: null};
   /** Peers that provided good data */
   goodPeers: PeerIdStr[] = [];
   /** The `Attempts` that have been made and failed to send us this batch. */
@@ -130,13 +147,25 @@ export class Batch {
         step: 1,
       };
       if (isForkPostFulu(this.forkName) && withinValidRequestWindow) {
-        return {
-          blocksRequest,
-          columnsRequest: {
+        const columnsRequest = {
+          startSlot: this.startSlot,
+          count: this.count,
+          columns: this.custodyConfig.sampledColumns,
+        };
+        if (isForkPostGloas(this.forkName)) {
+          const envelopesRequest: gloas.ExecutionPayloadEnvelopesByRangeRequest = {
             startSlot: this.startSlot,
             count: this.count,
-            columns: this.custodyConfig.sampledColumns,
-          },
+          };
+          return {
+            blocksRequest,
+            columnsRequest,
+            envelopesRequest,
+          };
+        }
+        return {
+          blocksRequest,
+          columnsRequest,
         };
       }
       if (isForkPostDeneb(this.forkName) && withinValidRequestWindow) {
@@ -207,6 +236,12 @@ export class Batch {
           startSlot: dataStartSlot,
           columns: Array.from(neededColumns),
         };
+        if (isForkPostGloas(this.forkName)) {
+          requests.envelopesRequest = {
+            count,
+            startSlot: dataStartSlot,
+          };
+        }
       } else if (isForkPostDeneb(this.forkName) && withinValidRequestWindow) {
         requests.blobsRequest = {
           count,
@@ -220,7 +255,8 @@ export class Batch {
   }
 
   /**
-   * Post-fulu we should only get columns that peer has advertised
+   * Post-fulu we should only get columns that peer has advertised.
+   * envelopesRequest is unchanged, all peers can serve envelopes.
    */
   getRequestsForPeer(peer: PeerSyncMeta): DownloadByRangeRequests {
     if (!isForkPostFulu(this.forkName)) {
@@ -263,6 +299,10 @@ export class Batch {
     return this.state.blocks;
   }
 
+  getEnvelopes(): Map<Slot, gloas.ExecutionPayloadEnvelope> | null {
+    return this.state.envelopes;
+  }
+
   /**
    * AwaitingDownload -> Downloading
    */
@@ -271,13 +311,17 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.AwaitingDownload));
     }
 
-    this.state = {status: BatchStatus.Downloading, peer, blocks: this.state.blocks};
+    this.state = {status: BatchStatus.Downloading, peer, blocks: this.state.blocks, envelopes: this.state.envelopes};
   }
 
   /**
    * Downloading -> AwaitingProcessing
    */
-  downloadingSuccess(peer: PeerIdStr, blocks: IBlockInput[]): DownloadSuccessState {
+  downloadingSuccess(
+    peer: PeerIdStr,
+    blocks: IBlockInput[],
+    envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null = null
+  ): DownloadSuccessState {
     if (this.state.status !== BatchStatus.Downloading) {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.Downloading));
     }
@@ -305,11 +349,13 @@ export class Batch {
         status: this.state.status,
       });
     }
+    const envelopesMap = envelopes ?? this.state.envelopes;
+
     if (allComplete) {
-      this.state = {status: BatchStatus.AwaitingProcessing, blocks};
+      this.state = {status: BatchStatus.AwaitingProcessing, blocks, envelopes: envelopesMap};
     } else {
       this.requests = this.getRequests(blocks);
-      this.state = {status: BatchStatus.AwaitingDownload, blocks};
+      this.state = {status: BatchStatus.AwaitingDownload, blocks, envelopes: envelopesMap};
     }
 
     return this.state as DownloadSuccessState;
@@ -328,7 +374,7 @@ export class Batch {
       throw new BatchError(this.errorType({code: BatchErrorCode.MAX_DOWNLOAD_ATTEMPTS}));
     }
 
-    this.state = {status: BatchStatus.AwaitingDownload, blocks: this.state.blocks};
+    this.state = {status: BatchStatus.AwaitingDownload, blocks: this.state.blocks, envelopes: this.state.envelopes};
   }
 
   /**
@@ -345,7 +391,7 @@ export class Batch {
     // that the data came from will be handled by the Attempt that goes for processing
     const peers = this.goodPeers;
     this.goodPeers = [];
-    this.state = {status: BatchStatus.Processing, blocks, attempt: {peers, hash}};
+    this.state = {status: BatchStatus.Processing, blocks, envelopes: this.state.envelopes, attempt: {peers, hash}};
     return blocks;
   }
 
@@ -357,7 +403,12 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.Processing));
     }
 
-    this.state = {status: BatchStatus.AwaitingValidation, blocks: this.state.blocks, attempt: this.state.attempt};
+    this.state = {
+      status: BatchStatus.AwaitingValidation,
+      blocks: this.state.blocks,
+      envelopes: this.state.envelopes,
+      attempt: this.state.attempt,
+    };
   }
 
   /**
@@ -408,7 +459,7 @@ export class Batch {
 
     // remove any downloaded blocks and re-attempt
     // TODO(fulu): need to remove the bad blocks from the SeenBlockInputCache
-    this.state = {status: BatchStatus.AwaitingDownload, blocks: []};
+    this.state = {status: BatchStatus.AwaitingDownload, blocks: [], envelopes: null};
   }
 
   private onProcessingError(attempt: Attempt): void {
@@ -419,7 +470,7 @@ export class Batch {
 
     // remove any downloaded blocks and re-attempt
     // TODO(fulu): need to remove the bad blocks from the SeenBlockInputCache
-    this.state = {status: BatchStatus.AwaitingDownload, blocks: []};
+    this.state = {status: BatchStatus.AwaitingDownload, blocks: [], envelopes: null};
   }
 
   /** Helper to construct typed BatchError. Stack traces are correct as the error is thrown above */

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -46,13 +46,13 @@ export type Attempt = {
 export type AwaitingDownloadState = {
   status: BatchStatus.AwaitingDownload;
   blocks: IBlockInput[];
-  envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
+  envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null;
 };
 
 export type DownloadSuccessState = {
   status: BatchStatus.AwaitingProcessing;
   blocks: IBlockInput[];
-  envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
+  envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null;
 };
 
 export type BatchState =
@@ -61,19 +61,19 @@ export type BatchState =
       status: BatchStatus.Downloading;
       peer: PeerIdStr;
       blocks: IBlockInput[];
-      envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
+      envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null;
     }
   | DownloadSuccessState
   | {
       status: BatchStatus.Processing;
       blocks: IBlockInput[];
-      envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
+      envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null;
       attempt: Attempt;
     }
   | {
       status: BatchStatus.AwaitingValidation;
       blocks: IBlockInput[];
-      envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
+      envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null;
       attempt: Attempt;
     };
 
@@ -299,7 +299,7 @@ export class Batch {
     return this.state.blocks;
   }
 
-  getEnvelopes(): Map<Slot, gloas.ExecutionPayloadEnvelope> | null {
+  getEnvelopes(): Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null {
     return this.state.envelopes;
   }
 
@@ -320,7 +320,7 @@ export class Batch {
   downloadingSuccess(
     peer: PeerIdStr,
     blocks: IBlockInput[],
-    envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null = null
+    envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null = null
   ): DownloadSuccessState {
     if (this.state.status !== BatchStatus.Downloading) {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.Downloading));
@@ -380,19 +380,20 @@ export class Batch {
   /**
    * AwaitingProcessing -> Processing
    */
-  startProcessing(): IBlockInput[] {
+  startProcessing(): {blocks: IBlockInput[]; envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null} {
     if (this.state.status !== BatchStatus.AwaitingProcessing) {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.AwaitingProcessing));
     }
 
     const blocks = this.state.blocks;
+    const envelopes = this.state.envelopes;
     const hash = hashBlocks(blocks, this.config); // tracks blocks to report peer on processing error
     // Reset goodPeers in case another download attempt needs to be made.  When Attempt is successful or not the peers
     // that the data came from will be handled by the Attempt that goes for processing
     const peers = this.goodPeers;
     this.goodPeers = [];
     this.state = {status: BatchStatus.Processing, blocks, envelopes: this.state.envelopes, attempt: {peers, hash}};
-    return blocks;
+    return {blocks, envelopes};
   }
 
   /**

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -146,47 +146,39 @@ export class Batch {
         count: this.count,
         step: 1,
       };
+      const requests: DownloadByRangeRequests = {blocksRequest};
+
+      // Post-Gloas envelopes are required for block processing, independent of DA retention window.
+      if (isForkPostGloas(this.forkName)) {
+        requests.envelopesRequest = {
+          startSlot: this.startSlot,
+          count: this.count,
+        };
+      }
+
       if (isForkPostFulu(this.forkName) && withinValidRequestWindow) {
-        const columnsRequest = {
+        requests.columnsRequest = {
           startSlot: this.startSlot,
           count: this.count,
           columns: this.custodyConfig.sampledColumns,
         };
-        if (isForkPostGloas(this.forkName)) {
-          const envelopesRequest: gloas.ExecutionPayloadEnvelopesByRangeRequest = {
-            startSlot: this.startSlot,
-            count: this.count,
-          };
-          return {
-            blocksRequest,
-            columnsRequest,
-            envelopesRequest,
-          };
-        }
-        return {
-          blocksRequest,
-          columnsRequest,
+      } else if (isForkPostDeneb(this.forkName) && withinValidRequestWindow) {
+        requests.blobsRequest = {
+          startSlot: this.startSlot,
+          count: this.count,
         };
       }
-      if (isForkPostDeneb(this.forkName) && withinValidRequestWindow) {
-        return {
-          blocksRequest,
-          blobsRequest: {
-            startSlot: this.startSlot,
-            count: this.count,
-          },
-        };
-      }
-      return {
-        blocksRequest,
-      };
+
+      return requests;
     }
 
     // subsequent request where part of the epoch has already been downloaded. Need to figure out what is the beginning
     // of the range where download needs to resume
     let blockStartSlot = this.startSlot;
     let dataStartSlot = this.startSlot;
+    let envelopeStartSlot = this.startSlot;
     const neededColumns = new Set<number>();
+    const envelopesBySlot = this.state.envelopes ?? new Map<Slot, gloas.SignedExecutionPayloadEnvelope>();
 
     // ensure blocks are in slot-wise order
     for (const blockInput of blocks) {
@@ -204,6 +196,10 @@ export class Batch {
       if (blockInput.hasBlock() && blockStartSlot === blockSlot) {
         blockStartSlot = blockSlot + 1;
       }
+      if (blockInput.hasBlock() && envelopeStartSlot === blockSlot && envelopesBySlot.has(blockSlot)) {
+        envelopeStartSlot = blockSlot + 1;
+      }
+
       if (!blockInput.hasAllData()) {
         if (isBlockInputColumns(blockInput)) {
           for (const index of blockInput.getMissingSampledColumnMeta().missing) {
@@ -227,6 +223,14 @@ export class Batch {
         step: 1,
       };
     }
+
+    if (isForkPostGloas(this.forkName) && envelopeStartSlot <= endSlot) {
+      requests.envelopesRequest = {
+        startSlot: envelopeStartSlot,
+        count: endSlot - envelopeStartSlot + 1,
+      };
+    }
+
     if (dataStartSlot <= endSlot) {
       // range of 40 - 63, startSlot will be inclusive but subtraction will exclusive so need to + 1
       const count = endSlot - dataStartSlot + 1;
@@ -236,12 +240,6 @@ export class Batch {
           startSlot: dataStartSlot,
           columns: Array.from(neededColumns),
         };
-        if (isForkPostGloas(this.forkName)) {
-          requests.envelopesRequest = {
-            count,
-            startSlot: dataStartSlot,
-          };
-        }
       } else if (isForkPostDeneb(this.forkName) && withinValidRequestWindow) {
         requests.blobsRequest = {
           count,
@@ -364,14 +362,16 @@ export class Batch {
   /**
    * Downloading -> AwaitingDownload
    */
-  downloadingError(peer: PeerIdStr): void {
+  downloadingError(peer: PeerIdStr, {countFailedAttempt = true}: {countFailedAttempt?: boolean} = {}): void {
     if (this.state.status !== BatchStatus.Downloading) {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.Downloading));
     }
 
-    this.failedDownloadAttempts.push(peer);
-    if (this.failedDownloadAttempts.length > MAX_BATCH_DOWNLOAD_ATTEMPTS) {
-      throw new BatchError(this.errorType({code: BatchErrorCode.MAX_DOWNLOAD_ATTEMPTS}));
+    if (countFailedAttempt) {
+      this.failedDownloadAttempts.push(peer);
+      if (this.failedDownloadAttempts.length > MAX_BATCH_DOWNLOAD_ATTEMPTS) {
+        throw new BatchError(this.errorType({code: BatchErrorCode.MAX_DOWNLOAD_ATTEMPTS}));
+      }
     }
 
     this.state = {status: BatchStatus.AwaitingDownload, blocks: this.state.blocks, envelopes: this.state.envelopes};

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -31,6 +31,10 @@ import {
   validateBatchesStatus,
 } from "./utils/index.js";
 
+const RATE_LIMITED_DOWNLOAD_RETRY_MS = 1_000;
+const PEER_QUARANTINE_MS = 2 * 60_000;
+const PEER_QUARANTINE_STRIKES = 2;
+
 export type SyncChainModules = {
   config: ChainForkConfig;
   clock: IClock;
@@ -137,6 +141,8 @@ export class SyncChain {
   /** Sorted map of batches undergoing some kind of processing. */
   private readonly batches = new Map<Epoch, Batch>();
   private readonly peerset = new Map<PeerIdStr, ChainTarget>();
+  private readonly peerQuarantineUntilByPeer = new Map<PeerIdStr, number>();
+  private readonly quarantineStrikeCountByPeer = new Map<PeerIdStr, number>();
 
   private readonly logger: Logger;
   private readonly config: ChainForkConfig;
@@ -232,6 +238,16 @@ export class SyncChain {
    * Add peer to the chain and request batches if active
    */
   addPeer(peer: PeerIdStr, target: ChainTarget): void {
+    const quarantineUntil = this.peerQuarantineUntilByPeer.get(peer);
+    if (quarantineUntil && quarantineUntil > Date.now()) {
+      return;
+    }
+
+    if (quarantineUntil) {
+      this.peerQuarantineUntilByPeer.delete(peer);
+    }
+
+    this.quarantineStrikeCountByPeer.delete(peer);
     this.peerset.set(peer, target);
     this.computeTarget();
     this.triggerBatchDownloader();
@@ -245,6 +261,20 @@ export class SyncChain {
     const deleted = this.peerset.delete(peerId);
     this.computeTarget();
     return deleted;
+  }
+
+  private quarantinePeer(peerId: PeerIdStr, reason: string): void {
+    const quarantineUntil = Date.now() + PEER_QUARANTINE_MS;
+    this.peerQuarantineUntilByPeer.set(peerId, quarantineUntil);
+    this.quarantineStrikeCountByPeer.delete(peerId);
+    this.removePeer(peerId);
+    this.logger.verbose("Quarantined peer for post-fork sync errors", {
+      id: this.logId,
+      peer: prettyPrintPeerIdStr(peerId),
+      reason,
+      quarantineMs: PEER_QUARANTINE_MS,
+      quarantineUntil,
+    });
   }
 
   /**
@@ -463,9 +493,13 @@ export class SyncChain {
    */
   private async sendBatch(batch: Batch, peer: PeerSyncMeta): Promise<void> {
     const previousEnvelopeCount = batch.getEnvelopes()?.size ?? 0;
+    let nextDownloadAttemptDelayMs = 0;
+
     this.logger.verbose("Downloading batch", {
       id: this.logId,
       ...batch.getMetadata(),
+      fork: batch.forkName,
+      hasEnvelopeRequest: batch.requests.envelopesRequest != null,
       peer: prettyPrintPeerIdStr(peer.peerId),
     });
     try {
@@ -475,8 +509,10 @@ export class SyncChain {
       const res = await wrapError(this.downloadByRange(peer, batch, this.syncType));
 
       if (res.err) {
+        const downloadErr = res.err as DownloadByRangeError;
+        const isTransientDownloadError = shouldTreatAsTransientDownloadError(downloadErr);
         // There's several known error cases where we want to take action on the peer
-        const errCode = (res.err as LodestarError<{code: string}>).type?.code;
+        const errCode = (downloadErr as LodestarError<{code: string}>).type?.code;
         this.metrics?.syncRange.downloadByRange.error.inc({client: peer.client, code: errCode ?? "UNKNOWN"});
         if (this.syncType === RangeSyncType.Finalized) {
           // For finalized sync, we are stricter with peers as there is no ambiguity about which chain we're syncing.
@@ -507,12 +543,50 @@ export class SyncChain {
           case DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID:
             this.reportPeer(peer.peerId, PeerAction.LowToleranceError, res.err.message);
         }
+
+        if (
+          errCode === DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE ||
+          errCode === DownloadByRangeErrorCode.MISSING_COLUMNS_RESPONSE ||
+          errCode === DownloadByRangeErrorCode.MISSING_BLOBS_RESPONSE
+        ) {
+          this.reportPeer(peer.peerId, PeerAction.LowToleranceError, res.err.message);
+        }
+
+        if (
+          errCode === DownloadByRangeErrorCode.REQ_RESP_ERROR &&
+          "reason" in downloadErr.type &&
+          shouldReportPeerOnReqRespErrorReason(downloadErr.type.reason)
+        ) {
+          this.reportPeer(peer.peerId, PeerAction.LowToleranceError, res.err.message);
+        }
+
+        if (shouldQuarantinePeerOnDownloadError(downloadErr)) {
+          const strikeCount = (this.quarantineStrikeCountByPeer.get(peer.peerId) ?? 0) + 1;
+          if (strikeCount >= PEER_QUARANTINE_STRIKES) {
+            this.quarantinePeer(peer.peerId, res.err.message);
+          } else {
+            this.quarantineStrikeCountByPeer.set(peer.peerId, strikeCount);
+            this.logger.verbose("Peer hit quarantine strike", {
+              id: this.logId,
+              peer: prettyPrintPeerIdStr(peer.peerId),
+              strikeCount,
+              requiredStrikes: PEER_QUARANTINE_STRIKES,
+              reason: res.err.message,
+            });
+          }
+        } else {
+          this.quarantineStrikeCountByPeer.delete(peer.peerId);
+        }
+
         this.logger.verbose(
           "Batch download error",
           {id: this.logId, ...batch.getMetadata(), peer: prettyPrintPeerIdStr(peer.peerId)},
           res.err
         );
-        batch.downloadingError(peer.peerId); // Throws after MAX_DOWNLOAD_ATTEMPTS
+        batch.downloadingError(peer.peerId, {countFailedAttempt: !isTransientDownloadError}); // Throws after MAX_DOWNLOAD_ATTEMPTS
+        if (isTransientDownloadError) {
+          nextDownloadAttemptDelayMs = RATE_LIMITED_DOWNLOAD_RETRY_MS;
+        }
       } else {
         this.logger.verbose("Batch download success", {
           id: this.logId,
@@ -520,6 +594,7 @@ export class SyncChain {
           peer: prettyPrintPeerIdStr(peer.peerId),
         });
         this.metrics?.syncRange.downloadByRange.success.inc();
+        this.quarantineStrikeCountByPeer.delete(peer.peerId);
         const {warnings, result} = res.result;
         const downloadSuccessOutput = batch.downloadingSuccess(peer.peerId, result.blocks, result.envelopes);
         const logMeta: Record<string, number> = {
@@ -583,8 +658,13 @@ export class SyncChain {
       this.batchProcessor.end(e as Error);
     }
 
-    // Preemptively request more blocks from peers whilst we process current blocks
-    this.triggerBatchDownloader();
+    // Preemptively request more blocks from peers whilst we process current blocks.
+    // For req/resp rate-limit errors, delay the retry to avoid a hot retry loop.
+    if (nextDownloadAttemptDelayMs > 0) {
+      setTimeout(() => this.triggerBatchDownloader(), nextDownloadAttemptDelayMs);
+    } else {
+      this.triggerBatchDownloader();
+    }
   }
 
   /**
@@ -714,6 +794,55 @@ export class SyncChain {
  * Enforces that a report peer action is defined for all BatchErrorCode exhaustively.
  * If peer should not be downscored, returns null.
  */
+function shouldTreatAsTransientDownloadError(err: DownloadByRangeError): boolean {
+  switch (err.type.code) {
+    case DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE:
+    case DownloadByRangeErrorCode.MISSING_COLUMNS_RESPONSE:
+    case DownloadByRangeErrorCode.MISSING_BLOBS_RESPONSE:
+      return true;
+
+    case DownloadByRangeErrorCode.REQ_RESP_ERROR: {
+      const reason = err.type.reason;
+      return (
+        reason.includes("REQUEST_ERROR_SELF_RATE_LIMITED") ||
+        reason.includes("REQUEST_ERROR_RATE_LIMITED") ||
+        reason.includes("RESPONSE_ERROR_RATE_LIMITED") ||
+        reason.includes("REQUEST_ERROR_DIAL_ERROR") ||
+        reason.includes("REQUEST_ERROR_INVALID_REQUEST") ||
+        reason.includes("Message was truncated")
+      );
+    }
+
+    default:
+      return false;
+  }
+}
+
+function shouldReportPeerOnReqRespErrorReason(reason: string): boolean {
+  return (
+    reason.includes("REQUEST_ERROR_DIAL_ERROR") ||
+    reason.includes("REQUEST_ERROR_INVALID_REQUEST") ||
+    reason.includes("Message was truncated")
+  );
+}
+
+function shouldQuarantinePeerOnDownloadError(err: DownloadByRangeError): boolean {
+  switch (err.type.code) {
+    case DownloadByRangeErrorCode.MISSING_COLUMNS_RESPONSE:
+      return true;
+
+    case DownloadByRangeErrorCode.REQ_RESP_ERROR:
+      return (
+        err.type.reason.includes("unexpected end of input") ||
+        err.type.reason.includes("REQUEST_ERROR_INVALID_REQUEST") ||
+        err.type.reason.includes("Message was truncated")
+      );
+
+    default:
+      return false;
+  }
+}
+
 export function shouldReportPeerOnBatchError(
   code: BatchErrorCode
 ): {action: PeerAction.LowToleranceError; reason: string} | null {

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {Epoch, Root, Slot} from "@lodestar/types";
+import {Epoch, Root, Slot, gloas} from "@lodestar/types";
 import {ErrorAborted, LodestarError, Logger, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {BlockInputErrorCode} from "../../chain/blocks/blockInput/errors.js";
@@ -44,7 +44,11 @@ export type SyncChainFns = {
    * Must return if ALL blocks are processed successfully
    * If SOME blocks are processed must throw BlockProcessorError()
    */
-  processChainSegment: (blocks: IBlockInput[], syncType: RangeSyncType) => Promise<void>;
+  processChainSegment: (
+    blocks: IBlockInput[],
+    envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null,
+    syncType: RangeSyncType
+  ) => Promise<void>;
   /** Must download blocks, and validate their range */
   downloadByRange: (
     peer: PeerSyncMeta,
@@ -578,10 +582,10 @@ export class SyncChain {
    * Sends `batch` to the processor. Note: batch may be empty
    */
   private async processBatch(batch: Batch): Promise<void> {
-    const blocks = batch.startProcessing();
+    const {blocks, envelopes} = batch.startProcessing();
 
     // wrapError ensures to never call both batch success() and batch error()
-    const res = await wrapError(this.processChainSegment(blocks, this.syncType));
+    const res = await wrapError(this.processChainSegment(blocks, envelopes, this.syncType));
 
     if (!res.err) {
       batch.processingSuccess();

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -1,6 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {Epoch, Root, Slot, gloas} from "@lodestar/types";
-import {ErrorAborted, LodestarError, Logger, toRootHex} from "@lodestar/utils";
+import {ErrorAborted, LodestarError, Logger, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
 import {BlockInputErrorCode} from "../../chain/blocks/blockInput/errors.js";
 import {IBlockInput} from "../../chain/blocks/blockInput/types.js";
@@ -462,6 +462,7 @@ export class SyncChain {
    * Requests the batch assigned to the given id from a given peer.
    */
   private async sendBatch(batch: Batch, peer: PeerSyncMeta): Promise<void> {
+    const previousEnvelopeCount = batch.getEnvelopes()?.size ?? 0;
     this.logger.verbose("Downloading batch", {
       id: this.logId,
       ...batch.getMetadata(),
@@ -524,6 +525,13 @@ export class SyncChain {
         const logMeta: Record<string, number> = {
           blockCount: downloadSuccessOutput.blocks.length,
         };
+        const envelopesMeta = getEnvelopeLogMeta(downloadSuccessOutput.envelopes, previousEnvelopeCount);
+        this.logger.debug("Batch envelopes after downloadingSuccess", {
+          id: this.logId,
+          epoch: batch.startEpoch,
+          peer: prettyPrintPeerIdStr(peer.peerId),
+          ...envelopesMeta,
+        });
 
         if (warnings && warnings.length > 0) {
           for (const warning of warnings) {
@@ -560,6 +568,7 @@ export class SyncChain {
           id: this.logId,
           epoch: batch.startEpoch,
           ...logMeta,
+          ...(envelopesMeta ?? {}),
           peer: prettyPrintPeerIdStr(peer.peerId),
         });
       }
@@ -583,6 +592,14 @@ export class SyncChain {
    */
   private async processBatch(batch: Batch): Promise<void> {
     const {blocks, envelopes} = batch.startProcessing();
+    const processLogMeta: Record<string, number> = {blockCount: blocks.length};
+    const envelopesMeta = getEnvelopeLogMeta(envelopes);
+    this.logger.debug("Processing batch", {
+      id: this.logId,
+      epoch: batch.startEpoch,
+      ...processLogMeta,
+      ...(envelopesMeta ?? {}),
+    });
 
     // wrapError ensures to never call both batch success() and batch error()
     const res = await wrapError(this.processChainSegment(blocks, envelopes, this.syncType));
@@ -715,4 +732,25 @@ export function shouldReportPeerOnBatchError(
     case BatchErrorCode.MAX_EXECUTION_ENGINE_ERROR_ATTEMPTS:
       return null;
   }
+}
+
+function getEnvelopeLogMeta(
+  envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null,
+  previousEnvelopeCount = 0
+): {envelopeCount: number; newEnvelopeCount: number; envelopeSlots: string | null} {
+  if (!envelopes || envelopes.size === 0) {
+    return {
+      envelopeCount: 0,
+      newEnvelopeCount: 0,
+      envelopeSlots: null,
+    };
+  }
+
+  const envelopeSlots = Array.from(envelopes.keys()).sort((a, b) => a - b);
+
+  return {
+    envelopeCount: envelopes.size,
+    newEnvelopeCount: Math.max(envelopes.size - previousEnvelopeCount, 0),
+    envelopeSlots: prettyPrintIndices(envelopeSlots),
+  };
 }

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -15,7 +15,7 @@ import {ItTrigger} from "../../util/itTrigger.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {WarnResult, wrapError} from "../../util/wrapError.js";
 import {BATCH_BUFFER_SIZE, EPOCHS_PER_BATCH, MAX_LOOK_AHEAD_EPOCHS} from "../constants.js";
-import {DownloadByRangeError, DownloadByRangeErrorCode} from "../utils/downloadByRange.js";
+import {DownloadByRangeError, DownloadByRangeErrorCode, DownloadByRangeResult} from "../utils/downloadByRange.js";
 import {RangeSyncType} from "../utils/remoteSyncType.js";
 import {Batch, BatchError, BatchErrorCode, BatchMetadata, BatchStatus} from "./batch.js";
 import {
@@ -50,7 +50,7 @@ export type SyncChainFns = {
     peer: PeerSyncMeta,
     batch: Batch,
     syncType: RangeSyncType
-  ) => Promise<WarnResult<IBlockInput[], DownloadByRangeError>>;
+  ) => Promise<WarnResult<DownloadByRangeResult, DownloadByRangeError>>;
   /** Report peer for negative actions. Decouples from the full network instance */
   reportPeer: (peer: PeerIdStr, action: PeerAction, actionName: string) => void;
   /** Gets current peer custodyColumns and earliestAvailableSlot */
@@ -516,7 +516,7 @@ export class SyncChain {
         });
         this.metrics?.syncRange.downloadByRange.success.inc();
         const {warnings, result} = res.result;
-        const downloadSuccessOutput = batch.downloadingSuccess(peer.peerId, result);
+        const downloadSuccessOutput = batch.downloadingSuccess(peer.peerId, result.blocks, result.envelopes);
         const logMeta: Record<string, number> = {
           blockCount: downloadSuccessOutput.blocks.length,
         };

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -172,7 +172,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
   }
 
   /** Convenience method for `SyncChain` */
-  private processChainSegment: SyncChainFns["processChainSegment"] = async (blocks, syncType) => {
+  private processChainSegment: SyncChainFns["processChainSegment"] = async (blocks, envelopes, syncType) => {
     // Not trusted, verify signatures
     const flags: ImportBlockOpts = {
       // Only skip importing attestations for finalized sync. For head sync attestation are valuable.
@@ -194,7 +194,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       // Should only be used for debugging or testing
       for (const block of blocks) await this.chain.processBlock(block, flags);
     } else {
-      await this.chain.processChainSegment(blocks, flags);
+      await this.chain.processChainSegment(blocks, envelopes, flags);
     }
   };
 

--- a/packages/beacon-node/src/sync/range/range.ts
+++ b/packages/beacon-node/src/sync/range/range.ts
@@ -200,6 +200,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
 
   private downloadByRange: SyncChainFns["downloadByRange"] = async (peer, batch) => {
     const batchBlocks = batch.getBlocks();
+    const batchEnvelops = batch.getEnvelopes();
     const {result, warnings} = await downloadByRange({
       config: this.config,
       network: this.network,
@@ -213,6 +214,7 @@ export class RangeSync extends (EventEmitter as {new (): RangeSyncEmitter}) {
       peerIdStr: peer.peerId,
       responses: result,
       batchBlocks,
+      batchEnvelops,
     });
     return {result: cached, warnings};
   };

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -322,7 +322,11 @@ export async function requestByRange({
     );
   }
 
-  await Promise.all(requests);
+  const results = await Promise.allSettled(requests);
+  const rejected = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
+  if (rejected) {
+    throw rejected.reason;
+  }
 
   return {
     blocks,
@@ -376,24 +380,24 @@ export async function validateResponses({
   }
 
   const dataRequest = blobsRequest ?? columnsRequest;
-  if (!dataRequest) {
-    return {result: validatedResponses, warnings};
-  }
+  let blocksForDataValidation: ValidatedBlock[] = [];
 
-  const blocksForDataValidation = getBlocksForDataValidation(
-    dataRequest,
-    batchBlocks,
-    validatedResponses.validatedBlocks?.length ? validatedResponses.validatedBlocks : undefined
-  );
-
-  if (!blocksForDataValidation.length) {
-    throw new DownloadByRangeError(
-      {
-        code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
-        ...requestsLogMeta({blobsRequest, columnsRequest, envelopesRequest}),
-      },
-      "No blocks in data request slot range to validate data response against"
+  if (dataRequest) {
+    blocksForDataValidation = getBlocksForDataValidation(
+      dataRequest,
+      batchBlocks,
+      validatedResponses.validatedBlocks?.length ? validatedResponses.validatedBlocks : undefined
     );
+
+    if (!blocksForDataValidation.length) {
+      throw new DownloadByRangeError(
+        {
+          code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
+          ...requestsLogMeta({blobsRequest, columnsRequest, envelopesRequest}),
+        },
+        "No blocks in data request slot range to validate data response against"
+      );
+    }
   }
 
   if (blobsRequest) {
@@ -434,10 +438,26 @@ export async function validateResponses({
     warnings = validatedColumnSidecarsResult.warnings;
   }
 
-  const validatedBlocks = validatedResponses.validatedBlocks;
-  if (signedEnvelopes?.length) {
-    validateEnvelopesByRangeResponse({envelopes: signedEnvelopes, validatedBlocks: validatedBlocks ?? []});
-    validatedResponses.validatedEnvelopes = signedEnvelopes;
+  if (envelopesRequest) {
+    const blocksForEnvelopeValidation = getBlocksForDataValidation(
+      envelopesRequest,
+      batchBlocks,
+      validatedResponses.validatedBlocks?.length ? validatedResponses.validatedBlocks : undefined
+    );
+
+    if (!blocksForEnvelopeValidation.length) {
+      throw new DownloadByRangeError(
+        {
+          code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
+          ...requestsLogMeta({blobsRequest, columnsRequest, envelopesRequest}),
+        },
+        "No blocks in envelope request slot range to validate envelope response against"
+      );
+    }
+
+    const envelopes = signedEnvelopes ?? [];
+    validateEnvelopesByRangeResponse({envelopes, validatedBlocks: blocksForEnvelopeValidation});
+    validatedResponses.validatedEnvelopes = envelopes;
   }
 
   return {result: validatedResponses, warnings};
@@ -559,6 +579,8 @@ export function validateEnvelopesByRangeResponse({
   validatedBlocks: ValidatedBlock[];
 }): void {
   const blockBySlot = new Map(validatedBlocks.map(({block, blockRoot}) => [block.message.slot, {block, blockRoot}]));
+  const seenEnvelopeSlots = new Set<Slot>();
+
   for (const signedEnvelope of envelopes) {
     const env = signedEnvelope.message;
     const entry = blockBySlot.get(env.slot);
@@ -577,7 +599,14 @@ export function validateEnvelopesByRangeResponse({
     if (!byteArrayEquals(env.payload.blockHash, bid.blockHash)) {
       throw new DownloadByRangeError({code: DownloadByRangeErrorCode.ENVELOPE_WRONG_BLOCK_HASH, slot: env.slot});
     }
+
+    seenEnvelopeSlots.add(env.slot);
   }
+
+  // Blocks without envelopes are allowed: the payload may have been orphaned (never
+  // revealed by the builder).  The state-transition EMPTY path handles this correctly
+  // and subsequent block state-root checks will catch any maliciously omitted envelopes.
+  // Do NOT penalise or quarantine the peer for this — it is a valid serving behaviour.
 }
 
 /**
@@ -972,6 +1001,7 @@ export enum DownloadByRangeErrorCode {
   MISMATCH_BLOCK_FORK = "DOWNLOAD_BY_RANGE_ERROR_MISMATCH_BLOCK_FORK",
   MISMATCH_BLOCK_INPUT_TYPE = "DOWNLOAD_BY_RANGE_ERROR_MISMATCH_BLOCK_INPUT_TYPE",
   ENVELOPE_NO_MATCHING_BLOCK = "DOWNLOAD_BY_RANGE_ERROR_ENVELOPE_NO_MATCHING_BLOCK",
+  ENVELOPE_MISSING_FOR_BLOCK = "DOWNLOAD_BY_RANGE_ERROR_ENVELOPE_MISSING_FOR_BLOCK",
   ENVELOPE_WRONG_BLOCK_ROOT = "DOWNLOAD_BY_RANGE_ERROR_ENVELOPE_WRONG_BLOCK_ROOT",
   ENVELOPE_WRONG_BUILDER_INDEX = "DOWNLOAD_BY_RANGE_ERROR_ENVELOPE_WRONG_BUILDER_INDEX",
   ENVELOPE_WRONG_BLOCK_HASH = "DOWNLOAD_BY_RANGE_ERROR_ENVELOPE_WRONG_BLOCK_HASH",
@@ -1074,6 +1104,7 @@ export type DownloadByRangeErrorType =
   | {
       code:
         | DownloadByRangeErrorCode.ENVELOPE_NO_MATCHING_BLOCK
+        | DownloadByRangeErrorCode.ENVELOPE_MISSING_FOR_BLOCK
         | DownloadByRangeErrorCode.ENVELOPE_WRONG_BLOCK_ROOT
         | DownloadByRangeErrorCode.ENVELOPE_WRONG_BUILDER_INDEX
         | DownloadByRangeErrorCode.ENVELOPE_WRONG_BLOCK_HASH;

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -1,6 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPostDeneb, ForkPostFulu, ForkPreFulu, isForkPostFulu} from "@lodestar/params";
-import {SignedBeaconBlock, Slot, deneb, fulu, phase0} from "@lodestar/types";
+import {DataColumnSidecars, SignedBeaconBlock, Slot, deneb, fulu, gloas, isGloasDataColumnSidecar, phase0} from "@lodestar/types";
 import {LodestarError, Logger, byteArrayEquals, fromHex, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {
   BlockInputSource,
@@ -21,12 +21,14 @@ export type DownloadByRangeRequests = {
   blocksRequest?: phase0.BeaconBlocksByRangeRequest;
   blobsRequest?: deneb.BlobSidecarsByRangeRequest;
   columnsRequest?: fulu.DataColumnSidecarsByRangeRequest;
+  envelopesRequest?: gloas.ExecutionPayloadEnvelopesByRangeRequest;
 };
 
 export type DownloadByRangeResponses = {
   blocks?: SignedBeaconBlock[];
   blobSidecars?: deneb.BlobSidecars;
-  columnSidecars?: fulu.DataColumnSidecars;
+  columnSidecars?: fulu.DataColumnSidecars | gloas.DataColumnSidecars;
+  signedEnvelopes?: gloas.SignedExecutionPayloadEnvelope[];
 };
 
 export type DownloadAndCacheByRangeProps = DownloadByRangeRequests & {
@@ -42,6 +44,7 @@ export type CacheByRangeResponsesProps = {
   peerIdStr: string;
   responses: ValidatedResponses;
   batchBlocks: IBlockInput[];
+  batchEnvelops: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
 };
 
 export type ValidatedBlock = {
@@ -56,13 +59,19 @@ export type ValidatedBlobSidecars = {
 
 export type ValidatedColumnSidecars = {
   blockRoot: Uint8Array;
-  columnSidecars: fulu.DataColumnSidecars;
+  columnSidecars: fulu.DataColumnSidecars | gloas.DataColumnSidecars;
 };
 
 export type ValidatedResponses = {
   validatedBlocks?: ValidatedBlock[];
   validatedBlobSidecars?: ValidatedBlobSidecars[];
   validatedColumnSidecars?: ValidatedColumnSidecars[];
+  validatedEnvelopes?: gloas.ExecutionPayloadEnvelope[];
+};
+
+export type DownloadByRangeResult = {
+  blocks: IBlockInput[];
+  envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
 };
 
 /**
@@ -73,7 +82,8 @@ export function cacheByRangeResponses({
   peerIdStr,
   responses,
   batchBlocks,
-}: CacheByRangeResponsesProps): IBlockInput[] {
+  batchEnvelops,
+}: CacheByRangeResponsesProps): DownloadByRangeResult {
   const source = BlockInputSource.byRange;
   const seenTimestampSec = Date.now() / 1000;
   const updatedBatchBlocks = new Map<Slot, IBlockInput>(batchBlocks.map((block) => [block.slot, block]));
@@ -148,7 +158,9 @@ export function cacheByRangeResponses({
   }
 
   for (const {blockRoot, columnSidecars} of responses.validatedColumnSidecars ?? []) {
-    const dataSlot = columnSidecars.at(0)?.signedBlockHeader.message.slot;
+    const firstColumn = columnSidecars.at(0);
+    const dataSlot =
+      firstColumn && "slot" in firstColumn ? firstColumn.slot : firstColumn?.signedBlockHeader.message.slot;
     if (dataSlot === undefined) {
       throw new Error(
         `Coding Error: empty columnSidecars returned for blockRoot=${toRootHex(blockRoot)} from validation functions`
@@ -162,6 +174,10 @@ export function cacheByRangeResponses({
     }
 
     if (!isBlockInputColumns(existing)) {
+      if (existing.type === DAType.PayloadBid) {
+        // Post-gloas columns are cross-validated separately; no column cache insertion for payload-bid block inputs.
+        continue;
+      }
       throw new DownloadByRangeError({
         code: DownloadByRangeErrorCode.MISMATCH_BLOCK_INPUT_TYPE,
         slot: existing.slot,
@@ -170,7 +186,10 @@ export function cacheByRangeResponses({
         actual: existing.type,
       });
     }
-    for (const columnSidecar of columnSidecars) {
+    if (columnSidecars.length > 0 && "slot" in columnSidecars[0]) {
+      continue;
+    }
+    for (const columnSidecar of columnSidecars as fulu.DataColumnSidecars) {
       // will throw if root hex does not match (meaning we are following the wrong chain)
       existing.addColumn(
         {
@@ -185,7 +204,16 @@ export function cacheByRangeResponses({
     }
   }
 
-  return Array.from(updatedBatchBlocks.values());
+  const envelopesBySlot = new Map<number, gloas.ExecutionPayloadEnvelope>();
+  for (const [slot, envelope] of batchEnvelops ?? []) {
+    envelopesBySlot.set(slot, envelope);
+  }
+  for (const envelope of responses.validatedEnvelopes ?? []) {
+    envelopesBySlot.set(envelope.slot, envelope);
+  }
+  const envelopes = envelopesBySlot.size > 0 ? envelopesBySlot : null;
+
+  return {blocks: Array.from(updatedBatchBlocks.values()), envelopes};
 }
 
 export async function downloadByRange({
@@ -196,6 +224,7 @@ export async function downloadByRange({
   blocksRequest,
   blobsRequest,
   columnsRequest,
+  envelopesRequest,
 }: DownloadAndCacheByRangeProps): Promise<WarnResult<ValidatedResponses, DownloadByRangeError>> {
   let response: DownloadByRangeResponses;
   try {
@@ -205,12 +234,13 @@ export async function downloadByRange({
       blocksRequest,
       blobsRequest,
       columnsRequest,
+      envelopesRequest,
     });
   } catch (err) {
     throw new DownloadByRangeError({
       code: DownloadByRangeErrorCode.REQ_RESP_ERROR,
       reason: (err as Error).message,
-      ...requestsLogMeta({blocksRequest, blobsRequest, columnsRequest}),
+      ...requestsLogMeta({blocksRequest, blobsRequest, columnsRequest, envelopesRequest}),
     });
   }
 
@@ -220,6 +250,7 @@ export async function downloadByRange({
     blocksRequest,
     blobsRequest,
     columnsRequest,
+    envelopesRequest,
     ...response,
   });
 
@@ -235,13 +266,15 @@ export async function requestByRange({
   blocksRequest,
   blobsRequest,
   columnsRequest,
+  envelopesRequest,
 }: DownloadByRangeRequests & {
   network: INetwork;
   peerIdStr: PeerIdStr;
 }): Promise<DownloadByRangeResponses> {
   let blocks: undefined | SignedBeaconBlock[];
   let blobSidecars: undefined | deneb.BlobSidecars;
-  let columnSidecars: undefined | fulu.DataColumnSidecars;
+  let columnSidecars: undefined | fulu.DataColumnSidecars | gloas.DataColumnSidecars;
+  let signedEnvelopes: undefined | gloas.SignedExecutionPayloadEnvelope[];
 
   const requests: Promise<unknown>[] = [];
 
@@ -269,12 +302,21 @@ export async function requestByRange({
     );
   }
 
+  if (envelopesRequest) {
+    requests.push(
+      network.sendExecutionPayloadEnvelopesByRange(peerIdStr, envelopesRequest).then((envelopes) => {
+        signedEnvelopes = envelopes;
+      })
+    );
+  }
+
   await Promise.all(requests);
 
   return {
     blocks,
     blobSidecars,
     columnSidecars,
+    signedEnvelopes,
   };
 }
 
@@ -287,9 +329,11 @@ export async function validateResponses({
   blocksRequest,
   blobsRequest,
   columnsRequest,
+  envelopesRequest,
   blocks,
   blobSidecars,
   columnSidecars,
+  signedEnvelopes,
 }: DownloadByRangeRequests &
   DownloadByRangeResponses & {
     config: ChainForkConfig;
@@ -302,7 +346,7 @@ export async function validateResponses({
     throw new DownloadByRangeError(
       {
         code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
-        ...requestsLogMeta({blobsRequest, columnsRequest}),
+        ...requestsLogMeta({blobsRequest, columnsRequest, envelopesRequest}),
       },
       "No blocks to validate data requests against"
     );
@@ -334,7 +378,7 @@ export async function validateResponses({
     throw new DownloadByRangeError(
       {
         code: DownloadByRangeErrorCode.MISSING_BLOCKS_RESPONSE,
-        ...requestsLogMeta({blobsRequest, columnsRequest}),
+        ...requestsLogMeta({blobsRequest, columnsRequest, envelopesRequest}),
       },
       "No blocks in data request slot range to validate data response against"
     );
@@ -345,16 +389,13 @@ export async function validateResponses({
       throw new DownloadByRangeError(
         {
           code: DownloadByRangeErrorCode.MISSING_BLOBS_RESPONSE,
-          ...requestsLogMeta({blobsRequest, columnsRequest}),
+          ...requestsLogMeta({blobsRequest, columnsRequest, envelopesRequest}),
         },
         "No blobSidecars to validate against blobsRequest"
       );
     }
 
-    validatedResponses.validatedBlobSidecars = await validateBlobsByRangeResponse(
-      blocksForDataValidation,
-      blobSidecars
-    );
+    validatedResponses.validatedBlobSidecars = await validateBlobsByRangeResponse(blocksForDataValidation, blobSidecars);
   }
 
   if (columnsRequest) {
@@ -362,7 +403,7 @@ export async function validateResponses({
       throw new DownloadByRangeError(
         {
           code: DownloadByRangeErrorCode.MISSING_COLUMNS_RESPONSE,
-          ...requestsLogMeta({blobsRequest, columnsRequest}),
+          ...requestsLogMeta({blobsRequest, columnsRequest, envelopesRequest}),
         },
         "No columnSidecars to check columnRequest against"
       );
@@ -376,6 +417,12 @@ export async function validateResponses({
     );
     validatedResponses.validatedColumnSidecars = validatedColumnSidecarsResult.result;
     warnings = validatedColumnSidecarsResult.warnings;
+  }
+
+  const validatedBlocks = validatedResponses.validatedBlocks;
+  if (signedEnvelopes?.length) {
+    validateEnvelopesByRangeResponse({envelopes: signedEnvelopes, validatedBlocks: validatedBlocks ?? []});
+    validatedResponses.validatedEnvelopes = signedEnvelopes.map((envelope) => envelope.message);
   }
 
   return {result: validatedResponses, warnings};
@@ -487,6 +534,35 @@ export function validateBlockByRangeResponse(
     result: response,
     warnings: null,
   };
+}
+
+export function validateEnvelopesByRangeResponse({
+  envelopes,
+  validatedBlocks,
+}: {
+  envelopes: gloas.SignedExecutionPayloadEnvelope[];
+  validatedBlocks: ValidatedBlock[];
+}): void {
+  const blockBySlot = new Map(validatedBlocks.map(({block, blockRoot}) => [block.message.slot, {block, blockRoot}]));
+  for (const signedEnvelope of envelopes) {
+    const env = signedEnvelope.message;
+    const entry = blockBySlot.get(env.slot);
+    if (!entry) {
+      throw new DownloadByRangeError({code: DownloadByRangeErrorCode.ENVELOPE_NO_MATCHING_BLOCK, slot: env.slot});
+    }
+    const {block, blockRoot} = entry;
+    const bid = (block.message.body as gloas.BeaconBlockBody).signedExecutionPayloadBid.message;
+
+    if (!byteArrayEquals(env.beaconBlockRoot, blockRoot)) {
+      throw new DownloadByRangeError({code: DownloadByRangeErrorCode.ENVELOPE_WRONG_BLOCK_ROOT, slot: env.slot});
+    }
+    if (env.builderIndex !== bid.builderIndex) {
+      throw new DownloadByRangeError({code: DownloadByRangeErrorCode.ENVELOPE_WRONG_BUILDER_INDEX, slot: env.slot});
+    }
+    if (!byteArrayEquals(env.payload.blockHash, bid.blockHash)) {
+      throw new DownloadByRangeError({code: DownloadByRangeErrorCode.ENVELOPE_WRONG_BLOCK_HASH, slot: env.slot});
+    }
+  }
 }
 
 /**
@@ -608,16 +684,16 @@ export async function validateColumnsByRangeResponse(
   config: ChainForkConfig,
   request: fulu.DataColumnSidecarsByRangeRequest,
   blocks: ValidatedBlock[],
-  columnSidecars: fulu.DataColumnSidecars
+  columnSidecars: DataColumnSidecars
 ): Promise<WarnResult<ValidatedColumnSidecars[], DownloadByRangeError>> {
   const warnings: DownloadByRangeError[] = [];
 
-  const seenColumns = new Map<Slot, Map<number, fulu.DataColumnSidecar>>();
+  const seenColumns = new Map<Slot, Map<number, fulu.DataColumnSidecar | gloas.DataColumnSidecar>>();
   let currentSlot = -1;
   let currentIndex = -1;
   // Check for duplicates and order
   for (const columnSidecar of columnSidecars) {
-    const slot = columnSidecar.signedBlockHeader.message.slot;
+    const slot = isGloasDataColumnSidecar(columnSidecar) ? columnSidecar.slot : columnSidecar.signedBlockHeader.message.slot;
     let seenSlotColumns = seenColumns.get(slot);
     if (!seenSlotColumns) {
       seenSlotColumns = new Map();
@@ -676,7 +752,7 @@ export async function validateColumnsByRangeResponse(
     const slot = block.message.slot;
     const rootHex = toRootHex(blockRoot);
     const forkName = config.getForkName(slot);
-    const columnSidecarsMap: Map<number, fulu.DataColumnSidecar> = seenColumns.get(slot) ?? new Map();
+    const columnSidecarsMap = seenColumns.get(slot) ?? new Map();
     const columnSidecars = Array.from(columnSidecarsMap.values()).sort((a, b) => a.index - b.index);
 
     let blobCount: number;
@@ -764,7 +840,8 @@ export async function validateColumnsByRangeResponse(
         slot,
         blockRoot,
         blobCount,
-        columnSidecars
+        columnSidecars,
+        getBlobKzgCommitments(forkName, block as SignedBeaconBlock<ForkPostFulu>)
       ).then(() => ({
         blockRoot,
         columnSidecars,
@@ -818,7 +895,7 @@ export function getBlocksForDataValidation(
   return dataRequestBlocks;
 }
 
-function requestsLogMeta({blocksRequest, blobsRequest, columnsRequest}: DownloadByRangeRequests) {
+function requestsLogMeta({blocksRequest, blobsRequest, columnsRequest, envelopesRequest}: DownloadByRangeRequests) {
   const logMeta: {
     blockStartSlot?: number;
     blockCount?: number;
@@ -826,6 +903,8 @@ function requestsLogMeta({blocksRequest, blobsRequest, columnsRequest}: Download
     blobCount?: number;
     columnStartSlot?: number;
     columnCount?: number;
+    envelopeStartSlot?: number;
+    envelopeCount?: number;
   } = {};
   if (blocksRequest) {
     logMeta.blockStartSlot = blocksRequest.startSlot;
@@ -838,6 +917,10 @@ function requestsLogMeta({blocksRequest, blobsRequest, columnsRequest}: Download
   if (columnsRequest) {
     logMeta.columnStartSlot = columnsRequest.startSlot;
     logMeta.columnCount = columnsRequest.count;
+  }
+  if (envelopesRequest) {
+    logMeta.envelopeStartSlot = envelopesRequest.startSlot;
+    logMeta.envelopeCount = envelopesRequest.count;
   }
   return logMeta;
 }
@@ -871,6 +954,10 @@ export enum DownloadByRangeErrorCode {
   /** Cached block input type mismatches new data */
   MISMATCH_BLOCK_FORK = "DOWNLOAD_BY_RANGE_ERROR_MISMATCH_BLOCK_FORK",
   MISMATCH_BLOCK_INPUT_TYPE = "DOWNLOAD_BY_RANGE_ERROR_MISMATCH_BLOCK_INPUT_TYPE",
+  ENVELOPE_NO_MATCHING_BLOCK = "DOWNLOAD_BY_RANGE_ERROR_ENVELOPE_NO_MATCHING_BLOCK",
+  ENVELOPE_WRONG_BLOCK_ROOT = "DOWNLOAD_BY_RANGE_ERROR_ENVELOPE_WRONG_BLOCK_ROOT",
+  ENVELOPE_WRONG_BUILDER_INDEX = "DOWNLOAD_BY_RANGE_ERROR_ENVELOPE_WRONG_BUILDER_INDEX",
+  ENVELOPE_WRONG_BLOCK_HASH = "DOWNLOAD_BY_RANGE_ERROR_ENVELOPE_WRONG_BLOCK_HASH",
 }
 
 export type DownloadByRangeErrorType =
@@ -885,6 +972,8 @@ export type DownloadByRangeErrorType =
       blobCount?: number;
       columnStartSlot?: number;
       columnCount?: number;
+      envelopeStartSlot?: number;
+      envelopeCount?: number;
     }
   | {
       code: DownloadByRangeErrorCode.OUT_OF_RANGE_BLOCKS;
@@ -907,6 +996,8 @@ export type DownloadByRangeErrorType =
       blobCount?: number;
       columnStartSlot?: number;
       columnCount?: number;
+      envelopeStartSlot?: number;
+      envelopeCount?: number;
       reason: string;
     }
   | {
@@ -962,6 +1053,14 @@ export type DownloadByRangeErrorType =
       blockRoot: string;
       expected: DAType;
       actual: DAType;
+    }
+  | {
+      code:
+        | DownloadByRangeErrorCode.ENVELOPE_NO_MATCHING_BLOCK
+        | DownloadByRangeErrorCode.ENVELOPE_WRONG_BLOCK_ROOT
+        | DownloadByRangeErrorCode.ENVELOPE_WRONG_BUILDER_INDEX
+        | DownloadByRangeErrorCode.ENVELOPE_WRONG_BLOCK_HASH;
+      slot: number;
     };
 
 export class DownloadByRangeError extends LodestarError<DownloadByRangeErrorType> {}

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -1,6 +1,15 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPostDeneb, ForkPostFulu, ForkPreFulu, isForkPostFulu} from "@lodestar/params";
-import {DataColumnSidecars, SignedBeaconBlock, Slot, deneb, fulu, gloas, isGloasDataColumnSidecar, phase0} from "@lodestar/types";
+import {
+  DataColumnSidecars,
+  SignedBeaconBlock,
+  Slot,
+  deneb,
+  fulu,
+  gloas,
+  isGloasDataColumnSidecar,
+  phase0,
+} from "@lodestar/types";
 import {LodestarError, Logger, byteArrayEquals, fromHex, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {
   BlockInputSource,
@@ -395,7 +404,10 @@ export async function validateResponses({
       );
     }
 
-    validatedResponses.validatedBlobSidecars = await validateBlobsByRangeResponse(blocksForDataValidation, blobSidecars);
+    validatedResponses.validatedBlobSidecars = await validateBlobsByRangeResponse(
+      blocksForDataValidation,
+      blobSidecars
+    );
   }
 
   if (columnsRequest) {
@@ -693,7 +705,9 @@ export async function validateColumnsByRangeResponse(
   let currentIndex = -1;
   // Check for duplicates and order
   for (const columnSidecar of columnSidecars) {
-    const slot = isGloasDataColumnSidecar(columnSidecar) ? columnSidecar.slot : columnSidecar.signedBlockHeader.message.slot;
+    const slot = isGloasDataColumnSidecar(columnSidecar)
+      ? columnSidecar.slot
+      : columnSidecar.signedBlockHeader.message.slot;
     let seenSlotColumns = seenColumns.get(slot);
     if (!seenSlotColumns) {
       seenSlotColumns = new Map();

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -168,8 +168,11 @@ export function cacheByRangeResponses({
 
   for (const {blockRoot, columnSidecars} of responses.validatedColumnSidecars ?? []) {
     const firstColumn = columnSidecars.at(0);
-    const dataSlot =
-      firstColumn && "slot" in firstColumn ? firstColumn.slot : firstColumn?.signedBlockHeader.message.slot;
+    const dataSlot = firstColumn
+      ? isGloasDataColumnSidecar(firstColumn)
+        ? firstColumn.slot
+        : firstColumn.signedBlockHeader.message.slot
+      : undefined;
     if (dataSlot === undefined) {
       throw new Error(
         `Coding Error: empty columnSidecars returned for blockRoot=${toRootHex(blockRoot)} from validation functions`
@@ -195,7 +198,7 @@ export function cacheByRangeResponses({
         actual: existing.type,
       });
     }
-    if (columnSidecars.length > 0 && "slot" in columnSidecars[0]) {
+    if (columnSidecars.length > 0 && isGloasDataColumnSidecar(columnSidecars[0])) {
       continue;
     }
     for (const columnSidecar of columnSidecars as fulu.DataColumnSidecars) {

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -44,7 +44,7 @@ export type CacheByRangeResponsesProps = {
   peerIdStr: string;
   responses: ValidatedResponses;
   batchBlocks: IBlockInput[];
-  batchEnvelops: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
+  batchEnvelops: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null;
 };
 
 export type ValidatedBlock = {
@@ -66,12 +66,12 @@ export type ValidatedResponses = {
   validatedBlocks?: ValidatedBlock[];
   validatedBlobSidecars?: ValidatedBlobSidecars[];
   validatedColumnSidecars?: ValidatedColumnSidecars[];
-  validatedEnvelopes?: gloas.ExecutionPayloadEnvelope[];
+  validatedEnvelopes?: gloas.SignedExecutionPayloadEnvelope[];
 };
 
 export type DownloadByRangeResult = {
   blocks: IBlockInput[];
-  envelopes: Map<Slot, gloas.ExecutionPayloadEnvelope> | null;
+  envelopes: Map<Slot, gloas.SignedExecutionPayloadEnvelope> | null;
 };
 
 /**
@@ -204,12 +204,12 @@ export function cacheByRangeResponses({
     }
   }
 
-  const envelopesBySlot = new Map<number, gloas.ExecutionPayloadEnvelope>();
+  const envelopesBySlot = new Map<Slot, gloas.SignedExecutionPayloadEnvelope>();
   for (const [slot, envelope] of batchEnvelops ?? []) {
     envelopesBySlot.set(slot, envelope);
   }
   for (const envelope of responses.validatedEnvelopes ?? []) {
-    envelopesBySlot.set(envelope.slot, envelope);
+    envelopesBySlot.set(envelope.message.slot, envelope);
   }
   const envelopes = envelopesBySlot.size > 0 ? envelopesBySlot : null;
 
@@ -422,7 +422,7 @@ export async function validateResponses({
   const validatedBlocks = validatedResponses.validatedBlocks;
   if (signedEnvelopes?.length) {
     validateEnvelopesByRangeResponse({envelopes: signedEnvelopes, validatedBlocks: validatedBlocks ?? []});
-    validatedResponses.validatedEnvelopes = signedEnvelopes.map((envelope) => envelope.message);
+    validatedResponses.validatedEnvelopes = signedEnvelopes;
   }
 
   return {result: validatedResponses, warnings};

--- a/packages/beacon-node/src/sync/utils/downloadByRoot.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRoot.ts
@@ -440,7 +440,14 @@ export async function fetchAndValidateColumns({
     );
   }
 
-  await validateBlockDataColumnSidecars(chain, slot, blockRoot, blobCount, columnSidecars);
+  await validateBlockDataColumnSidecars(
+    chain,
+    slot,
+    blockRoot,
+    blobCount,
+    columnSidecars,
+    getBlobKzgCommitments(forkName, block)
+  );
 
   return {result: columnSidecars, warnings: warnings.length > 0 ? warnings : null};
 }

--- a/packages/beacon-node/src/util/sszBytes.ts
+++ b/packages/beacon-node/src/util/sszBytes.ts
@@ -518,10 +518,13 @@ export function getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized(
   const slot = getSlotFromSignedBeaconBlockSerialized(blockBytes);
   if (slot === null) throw new Error("Can not parse the slot from block bytes");
 
-  if (config.getForkSeq(slot) < ForkSeq.deneb) return 0;
+  const forkSeq = config.getForkSeq(slot);
+  if (forkSeq < ForkSeq.deneb) return 0;
+  const commitmentSize = ssz.deneb.KZGCommitment.fixedSize;
+  const forkName = config.getForkName(slot);
+  const forkSsz = ssz[forkName as ForkPostDeneb];
 
-  const {SignedBeaconBlock, BeaconBlock, BeaconBlockBody, KZGCommitment} =
-    ssz[config.getForkName(slot) as ForkPostDeneb];
+  const {SignedBeaconBlock, BeaconBlock, BeaconBlockBody} = forkSsz;
 
   const view = new DataView(blockBytes.buffer, blockBytes.byteOffset, blockBytes.byteLength);
   const singedBlockFieldRanges = SignedBeaconBlock.getFieldRanges(view, 0, blockBytes.length);
@@ -537,12 +540,56 @@ export function getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized(
     messageRange.start + bodyRange.start,
     messageRange.end + bodyRange.end
   );
-  const kzgCommitmentsIndex = Object.keys(BeaconBlockBody.fields).indexOf("blobKzgCommitments");
-  const kzgCommitmentsRange = bodyFieldRanges[kzgCommitmentsIndex];
-  const commitmentSize = KZGCommitment.fixedSize;
+  let start: number;
+  let end: number;
 
-  const end = messageRange.end + bodyRange.end + kzgCommitmentsRange.end;
-  const start = messageRange.start + bodyRange.start + kzgCommitmentsRange.start;
+  if (forkSeq >= ForkSeq.gloas) {
+    const {SignedExecutionPayloadBid, ExecutionPayloadBid} = forkSsz as typeof ssz.gloas;
+    const signedExecutionPayloadBidIndex = Object.keys(BeaconBlockBody.fields).indexOf("signedExecutionPayloadBid");
+    if (signedExecutionPayloadBidIndex < 0) return 0;
+    const signedExecutionPayloadBidRange = bodyFieldRanges[signedExecutionPayloadBidIndex];
+    if (!signedExecutionPayloadBidRange) return 0;
+
+    const signedExecutionPayloadBidFieldRanges = SignedExecutionPayloadBid.getFieldRanges(
+      view,
+      messageRange.start + bodyRange.start + signedExecutionPayloadBidRange.start,
+      messageRange.end + bodyRange.end + signedExecutionPayloadBidRange.end
+    );
+    const bidMessageIndex = Object.keys(SignedExecutionPayloadBid.fields).indexOf("message");
+    if (bidMessageIndex < 0) return 0;
+    const bidMessageRange = signedExecutionPayloadBidFieldRanges[bidMessageIndex];
+    if (!bidMessageRange) return 0;
+
+    const executionPayloadBidFieldRanges = ExecutionPayloadBid.getFieldRanges(
+      view,
+      messageRange.start + bodyRange.start + signedExecutionPayloadBidRange.start + bidMessageRange.start,
+      messageRange.end + bodyRange.end + signedExecutionPayloadBidRange.end + bidMessageRange.end
+    );
+    const kzgCommitmentsIndex = Object.keys(ExecutionPayloadBid.fields).indexOf("blobKzgCommitments");
+    if (kzgCommitmentsIndex < 0) return 0;
+    const kzgCommitmentsRange = executionPayloadBidFieldRanges[kzgCommitmentsIndex];
+    if (!kzgCommitmentsRange) return 0;
+
+    end =
+      messageRange.end +
+      bodyRange.end +
+      signedExecutionPayloadBidRange.end +
+      bidMessageRange.end +
+      kzgCommitmentsRange.end;
+    start =
+      messageRange.start +
+      bodyRange.start +
+      signedExecutionPayloadBidRange.start +
+      bidMessageRange.start +
+      kzgCommitmentsRange.start;
+  } else {
+    const kzgCommitmentsIndex = Object.keys(BeaconBlockBody.fields).indexOf("blobKzgCommitments");
+    if (kzgCommitmentsIndex < 0) return 0;
+    const kzgCommitmentsRange = bodyFieldRanges[kzgCommitmentsIndex];
+    if (!kzgCommitmentsRange) return 0;
+    end = messageRange.end + bodyRange.end + kzgCommitmentsRange.end;
+    start = messageRange.start + bodyRange.start + kzgCommitmentsRange.start;
+  }
 
   return Math.round(((end > blockBytes.byteLength ? blockBytes.byteLength : end) - start) / commitmentSize);
 }

--- a/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
+++ b/packages/beacon-node/test/e2e/sync/finalizedSync.test.ts
@@ -12,13 +12,13 @@ import {connect, onPeerConnect} from "../../utils/network.js";
 import {getDevBeaconNode} from "../../utils/node/beacon.js";
 import {getAndInitDevValidators} from "../../utils/node/validator.js";
 
-describe("sync / finalized sync for fulu", () => {
+describe("sync / finalized sync for gloas", () => {
   // chain is finalized at slot 32, plus 4 slots for genesis delay => ~72s it should sync pretty fast
   vi.setConfig({testTimeout: 90_000});
 
   const validatorCount = 8;
   const ELECTRA_FORK_EPOCH = 0;
-  const FULU_FORK_EPOCH = 1;
+  const GLOAS_FORK_EPOCH = 1;
   const SLOT_DURATION_MS = 2000;
   const testParams: Partial<ChainConfig> = {
     SLOT_DURATION_MS,
@@ -27,7 +27,8 @@ describe("sync / finalized sync for fulu", () => {
     CAPELLA_FORK_EPOCH: ELECTRA_FORK_EPOCH,
     DENEB_FORK_EPOCH: ELECTRA_FORK_EPOCH,
     ELECTRA_FORK_EPOCH: ELECTRA_FORK_EPOCH,
-    FULU_FORK_EPOCH: FULU_FORK_EPOCH,
+    FULU_FORK_EPOCH: ELECTRA_FORK_EPOCH,
+    GLOAS_FORK_EPOCH: GLOAS_FORK_EPOCH,
     BLOB_SCHEDULE: [
       {
         EPOCH: 1,
@@ -40,7 +41,12 @@ describe("sync / finalized sync for fulu", () => {
   afterEach(async () => {
     while (afterEachCallbacks.length > 0) {
       const callback = afterEachCallbacks.pop();
-      if (callback) await callback();
+      if (!callback) continue;
+      try {
+        await callback();
+      } catch {
+        // ignore teardown errors in this e2e test to preserve the root assertion failure
+      }
     }
   });
 
@@ -96,7 +102,7 @@ describe("sync / finalized sync for fulu", () => {
         bn.chain.emitter,
         ChainEvent.forkChoiceFinalized,
         240000,
-        (finalized) => finalized.epoch >= FULU_FORK_EPOCH
+        (finalized) => finalized.epoch >= GLOAS_FORK_EPOCH
       ),
       waitForEvent<routes.events.EventData[routes.events.EventType.head]>(
         bn.chain.emitter,
@@ -106,7 +112,7 @@ describe("sync / finalized sync for fulu", () => {
         ({slot}) => slot === 32
       ),
     ]);
-    loggerNodeA.info("Node A emitted finalized checkpoint event for fulu");
+    loggerNodeA.info("Node A emitted finalized checkpoint event for gloas");
 
     const bn2 = await getDevBeaconNode({
       params: testParams,
@@ -139,7 +145,7 @@ describe("sync / finalized sync for fulu", () => {
 
     try {
       await waitForSynced;
-      loggerNodeB.info("Node B synced to Node A, received fulu head block", {slot: head.message.slot});
+      loggerNodeB.info("Node B synced to Node A, received gloas head block", {slot: head.message.slot});
     } catch (_e) {
       expect.fail("Failed to sync to other node in time");
     }

--- a/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
+++ b/packages/beacon-node/test/perf/chain/verifyImportBlocks.test.ts
@@ -127,7 +127,7 @@ describe.skip("verify+import blocks - range sync perf test", () => {
         });
       });
 
-      await chain.processChainSegment(blocksImport, {
+      await chain.processChainSegment(blocksImport, null, {
         // Only skip importing attestations for finalized sync. For head sync attestation are valuable.
         // Importing attestations also triggers a head update, see https://github.com/ChainSafe/lodestar/issues/3804
         // TODO: Review if this is okay, can we prevent some attacks by importing attestations?

--- a/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
+++ b/packages/beacon-node/test/unit/chain/archiveStore/blockArchiver.test.ts
@@ -2,6 +2,8 @@ import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {fromHexString, toHexString} from "@chainsafe/ssz";
 import {createChainForkConfig} from "@lodestar/config";
 import {config as defaultConfig} from "@lodestar/config/default";
+import {PayloadStatus} from "@lodestar/fork-choice";
+import {ZERO_HASH} from "@lodestar/params";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {archiveBlocks} from "../../../../src/chain/archiveStore/utils/archiveBlocks.js";
@@ -68,7 +70,7 @@ describe("block archiver task", () => {
       forkChoiceStub,
       lightclientServer,
       logger,
-      {epoch: 5, rootHex: ZERO_HASH_HEX},
+      {epoch: 5, rootHex: ZERO_HASH_HEX, root: ZERO_HASH, payloadStatus: PayloadStatus.EMPTY},
       currentEpoch
     );
 
@@ -141,7 +143,7 @@ describe("block archiver task", () => {
       forkChoiceStub,
       lightclientServer,
       logger,
-      {epoch: config.FULU_FORK_EPOCH + 1, rootHex: ZERO_HASH_HEX},
+      {epoch: config.FULU_FORK_EPOCH + 1, root: ZERO_HASH, rootHex: ZERO_HASH_HEX, payloadStatus: PayloadStatus.EMPTY},
       currentEpoch
     );
 

--- a/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
+++ b/packages/beacon-node/test/unit/chain/forkChoice/forkChoice.test.ts
@@ -200,19 +200,22 @@ describe("LodestarForkChoice", () => {
       forkChoice.onBlock(block20.message, state20, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
       forkChoice.onBlock(block24.message, state24, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
       forkChoice.onBlock(block28.message, state28, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
-      expect(forkChoice.getAllAncestorBlocks(hashBlock(block16.message))).toHaveLength(3);
-      expect(forkChoice.getAllAncestorBlocks(hashBlock(block24.message))).toHaveLength(5);
+      const block16Summary = forkChoice.getBlockHexDefaultStatus(hashBlock(block16.message));
+      const block24Summary = forkChoice.getBlockHexDefaultStatus(hashBlock(block24.message));
+      if (!block16Summary || !block24Summary) throw new Error("Expected block summaries to exist");
+      expect(forkChoice.getAllAncestorBlocks(block16Summary)).toHaveLength(3);
+      expect(forkChoice.getAllAncestorBlocks(block24Summary)).toHaveLength(5);
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block08.message))).not.toBeNull();
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block12.message))).not.toBeNull();
       expect(forkChoice.hasBlockHex(hashBlock(block08.message))).toBe(true);
       expect(forkChoice.hasBlockHex(hashBlock(block12.message))).toBe(true);
       forkChoice.onBlock(block32.message, state32, blockDelaySec, currentSlot, executionStatus, dataAvailabilityStatus);
       forkChoice.prune(hashBlock(block16.message));
-      expect(forkChoice.getAllAncestorBlocks(hashBlock(block16.message)).length).toBeWithMessage(
+      expect(forkChoice.getAllAncestorBlocks(block16Summary).length).toBeWithMessage(
         0,
         "getAllAncestorBlocks should not return finalized block"
       );
-      expect(forkChoice.getAllAncestorBlocks(hashBlock(block24.message))).toHaveLength(2);
+      expect(forkChoice.getAllAncestorBlocks(block24Summary)).toHaveLength(2);
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block08.message))).toBe(null);
       expect(forkChoice.getBlockHexDefaultStatus(hashBlock(block12.message))).toBe(null);
       expect(forkChoice.hasBlockHex(hashBlock(block08.message))).toBe(false);

--- a/packages/beacon-node/test/unit/network/reqresp/score.test.ts
+++ b/packages/beacon-node/test/unit/network/reqresp/score.test.ts
@@ -1,0 +1,27 @@
+import {describe, expect, it} from "vitest";
+import {RequestError, RequestErrorCode} from "@lodestar/reqresp";
+import {PeerAction} from "../../../../src/network/peers/score/index.js";
+import {onOutgoingReqRespError} from "../../../../src/network/reqresp/score.js";
+import {ReqRespMethod} from "../../../../src/network/reqresp/types.js";
+
+describe("network / reqresp / score", () => {
+  it("does not downscore peer on reqresp rate-limit server errors", () => {
+    const err = new RequestError({
+      code: RequestErrorCode.SERVER_ERROR,
+      errorMessage: RequestErrorCode.REQUEST_RATE_LIMITED,
+    });
+
+    const action = onOutgoingReqRespError(err, ReqRespMethod.BeaconBlocksByRange);
+    expect(action).toBeNull();
+  });
+
+  it("keeps downscoring on non-rate-limit server errors", () => {
+    const err = new RequestError({
+      code: RequestErrorCode.SERVER_ERROR,
+      errorMessage: "unexpected internal failure",
+    });
+
+    const action = onOutgoingReqRespError(err, ReqRespMethod.BeaconBlocksByRange);
+    expect(action).toBe(PeerAction.MidToleranceError);
+  });
+});

--- a/packages/beacon-node/test/unit/sync/range/batch.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/batch.test.ts
@@ -223,6 +223,21 @@ describe("sync / range / batch", async () => {
       });
     });
 
+    describe("ForkGloas", () => {
+      const startEpoch = config.GLOAS_FORK_EPOCH + 1;
+
+      it("should request envelopes even when data column requests are out of availability window", () => {
+        vi.spyOn(clock, "currentEpoch", "get").mockReturnValue(
+          startEpoch + config.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS + 1
+        );
+        const batch = new Batch(startEpoch, config, clock, custodyConfig);
+
+        expect(batch.requests.blocksRequest).toEqual({startSlot: batch.startSlot, count: batch.count, step: 1});
+        expect(batch.requests.columnsRequest).toBeUndefined();
+        expect(batch.requests.envelopesRequest).toEqual({startSlot: batch.startSlot, count: batch.count});
+      });
+    });
+
     it("should not request data pre-deneb", () => {
       const startEpoch = config.CAPELLA_FORK_EPOCH - 1;
       const batch = new Batch(startEpoch, config, clock, custodyConfig);
@@ -261,6 +276,17 @@ describe("sync / range / batch", async () => {
 
   describe("downloadingSuccess", () => {
     it("should handle blocks that are not in slot-wise order", () => {});
+  });
+
+  it("should not count failed download attempts when explicitly disabled", () => {
+    const startEpoch = 0;
+    const batch = new Batch(startEpoch, config, clock, custodyConfig);
+
+    batch.startDownloading(peer);
+    batch.downloadingError(peer, {countFailedAttempt: false});
+
+    expect(batch.state.status).toBe(BatchStatus.AwaitingDownload);
+    expect(batch.getFailedPeers()).toEqual([]);
   });
 
   it("Complete state flow", () => {

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -218,9 +218,9 @@ describe("sync / range / chain", () => {
 
 function logSyncChainFns(logger: Logger, fns: SyncChainFns): SyncChainFns {
   return {
-    processChainSegment(blocks, syncType) {
+    processChainSegment(blocks, envelopes, syncType) {
       logger.debug("mock processChainSegment", {blocks: blocks.map((b) => b.slot).join(",")});
-      return fns.processChainSegment(blocks, syncType);
+      return fns.processChainSegment(blocks, envelopes, syncType);
     },
     downloadByRange(peer, request, syncType) {
       logger.debug("mock downloadBeaconBlocksByRange", request.state.status);

--- a/packages/beacon-node/test/unit/sync/range/chain.test.ts
+++ b/packages/beacon-node/test/unit/sync/range/chain.test.ts
@@ -117,7 +117,7 @@ describe("sync / range / chain", () => {
             })
           );
         }
-        return {result: blocks, warnings: null};
+        return {result: {blocks, envelopes: null}, warnings: null};
       };
 
       const target: ChainTarget = {slot: computeStartSlotAtEpoch(targetEpoch), root: ZERO_HASH};
@@ -172,7 +172,7 @@ describe("sync / range / chain", () => {
           })
         );
       }
-      return {result: blocks, warnings: null};
+      return {result: {blocks, envelopes: null}, warnings: null};
     };
 
     const target: ChainTarget = {slot: computeStartSlotAtEpoch(targetEpoch), root: ZERO_HASH};

--- a/packages/beacon-node/test/unit/sync/utils/requestByRange.test.ts
+++ b/packages/beacon-node/test/unit/sync/utils/requestByRange.test.ts
@@ -1,0 +1,33 @@
+import {describe, expect, it, vi} from "vitest";
+import {phase0} from "@lodestar/types";
+import {INetwork} from "../../../../src/network/interface.js";
+import {requestByRange} from "../../../../src/sync/utils/downloadByRange.js";
+
+describe("requestByRange", () => {
+  it("waits for all in-flight requests to settle before rethrowing", async () => {
+    let blobRequestSettled = false;
+
+    const network = {
+      sendBeaconBlocksByRange: vi.fn().mockRejectedValue(new Error("boom")),
+      sendBlobSidecarsByRange: vi.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => {
+              blobRequestSettled = true;
+              resolve([]);
+            }, 25);
+          })
+      ),
+    } as unknown as INetwork;
+
+    const requestPromise = requestByRange({
+      network,
+      peerIdStr: "peer-id",
+      blocksRequest: {startSlot: 0, count: 1, step: 1} as phase0.BeaconBlocksByRangeRequest,
+      blobsRequest: {startSlot: 0, count: 1},
+    });
+
+    await expect(requestPromise).rejects.toThrow("boom");
+    expect(blobRequestSettled).toBe(true);
+  });
+});

--- a/packages/beacon-node/test/unit/util/sszBytes.test.ts
+++ b/packages/beacon-node/test/unit/util/sszBytes.test.ts
@@ -12,6 +12,7 @@ import {
   ValidatorIndex,
   deneb,
   electra,
+  gloas,
   isElectraSingleAttestation,
   phase0,
   ssz,
@@ -334,6 +335,7 @@ describe("getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized", () => {
     DENEB_FORK_EPOCH: 5,
     ELECTRA_FORK_EPOCH: 10,
     FULU_FORK_EPOCH: 15,
+    GLOAS_FORK_EPOCH: 20,
   });
 
   it("should return 0 blob count pre deneb", async () => {
@@ -366,6 +368,20 @@ describe("getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized", () => {
     const kzgCommitments = blobs.map((blob) => kzg.blobToKzgCommitment(blob));
     block.message.body.blobKzgCommitments = kzgCommitments;
     block.message.slot = slot;
+    const blockBytes = config.getForkTypes(slot).SignedBeaconBlock.serialize(block);
+
+    const blobsCount = getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized(config, blockBytes);
+
+    expect(blobsCount).toBe(blobs.length);
+  });
+
+  it("should return blob count post gloas from signed execution payload bid", async () => {
+    const slot = computeStartSlotAtEpoch(20);
+    const block = config.getForkTypes(slot).SignedBeaconBlock.defaultValue() as gloas.SignedBeaconBlock;
+    const blobs = [generateRandomBlob(), generateRandomBlob(), generateRandomBlob()];
+    const kzgCommitments = blobs.map((blob) => kzg.blobToKzgCommitment(blob));
+    block.message.slot = slot;
+    block.message.body.signedExecutionPayloadBid.message.blobKzgCommitments = kzgCommitments;
     const blockBytes = config.getForkTypes(slot).SignedBeaconBlock.serialize(block);
 
     const blobsCount = getBlobKzgCommitmentsCountFromSignedBeaconBlockSerialized(config, blockBytes);

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1210,8 +1210,8 @@ export class ForkChoice implements IForkChoice {
    * Returns all blocks backwards starting from a block root.
    * Return only the non-finalized blocks.
    */
-  getAllAncestorBlocks(blockRoot: RootHex): ProtoBlock[] {
-    const blocks = this.protoArray.getAllAncestorNodes(blockRoot);
+  getAllAncestorBlocks(block: ProtoBlock): ProtoBlock[] {
+    const blocks = this.protoArray.getAllAncestorNodes(block.blockRoot, block.payloadStatus);
     // the last node is the previous finalized one, it's there to check onBlock finalized checkpoint only.
     return blocks.slice(0, blocks.length - 1);
   }

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -1226,8 +1226,11 @@ export class ForkChoice implements IForkChoice {
   /**
    * Returns both ancestor and non-ancestor blocks in a single traversal.
    */
-  getAllAncestorAndNonAncestorBlocks(blockRoot: RootHex): {ancestors: ProtoBlock[]; nonAncestors: ProtoBlock[]} {
-    const {ancestors, nonAncestors} = this.protoArray.getAllAncestorAndNonAncestorNodes(blockRoot);
+  getAllAncestorAndNonAncestorBlocks(
+    blockRoot: RootHex,
+    payloadStatus: PayloadStatus
+  ): {ancestors: ProtoBlock[]; nonAncestors: ProtoBlock[]} {
+    const {ancestors, nonAncestors} = this.protoArray.getAllAncestorAndNonAncestorNodes(blockRoot, payloadStatus);
 
     return {
       // the last node is the previous finalized one, it's there to check onBlock finalized checkpoint only.

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -256,7 +256,7 @@ export interface IForkChoice {
    * Iterates backwards through ancestor block summaries, starting from a block root
    */
   iterateAncestorBlocks(blockRoot: RootHex): IterableIterator<ProtoBlock>;
-  getAllAncestorBlocks(blockRoot: RootHex): ProtoBlock[];
+  getAllAncestorBlocks(block: ProtoBlock): ProtoBlock[];
   /**
    * The same to iterateAncestorBlocks but this gets non-ancestor nodes instead of ancestor nodes.
    */

--- a/packages/fork-choice/src/forkChoice/interface.ts
+++ b/packages/fork-choice/src/forkChoice/interface.ts
@@ -264,7 +264,10 @@ export interface IForkChoice {
   /**
    * Returns both ancestor and non-ancestor blocks in a single traversal.
    */
-  getAllAncestorAndNonAncestorBlocks(blockRoot: RootHex): {ancestors: ProtoBlock[]; nonAncestors: ProtoBlock[]};
+  getAllAncestorAndNonAncestorBlocks(
+    blockRoot: RootHex,
+    payloadStatus: PayloadStatus
+  ): {ancestors: ProtoBlock[]; nonAncestors: ProtoBlock[]};
   getCanonicalBlockAtSlot(slot: Slot): ProtoBlock | null;
   getCanonicalBlockClosestLteSlot(slot: Slot): ProtoBlock | null;
   /**

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -1774,11 +1774,11 @@ export class ProtoArray {
    * For Gloas blocks: returns EMPTY/FULL variants (not PENDING) based on parent payload status
    * For pre-Gloas blocks: returns FULL variants
    */
-  getAllAncestorAndNonAncestorNodes(blockRoot: RootHex): {ancestors: ProtoNode[]; nonAncestors: ProtoNode[]} {
-    // Get canonical node: FULL for pre-Gloas, PENDING for Gloas
-    const defaultStatus = this.getDefaultVariant(blockRoot);
-    const startIndex =
-      defaultStatus !== undefined ? this.getNodeIndexByRootAndStatus(blockRoot, defaultStatus) : undefined;
+  getAllAncestorAndNonAncestorNodes(
+    blockRoot: RootHex,
+    payloadStatus: PayloadStatus
+  ): {ancestors: ProtoNode[]; nonAncestors: ProtoNode[]} {
+    const startIndex = this.getNodeIndexByRootAndStatus(blockRoot, payloadStatus);
     if (startIndex === undefined) {
       return {ancestors: [], nonAncestors: []};
     }

--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -1681,11 +1681,8 @@ export class ProtoArray {
    * For Gloas blocks: returns EMPTY/FULL variants (not PENDING) based on parent payload status
    * For pre-Gloas blocks: returns FULL variants
    */
-  getAllAncestorNodes(blockRoot: RootHex): ProtoNode[] {
-    // Get canonical node: FULL for pre-Gloas, PENDING for Gloas
-    const defaultStatus = this.getDefaultVariant(blockRoot);
-    const startIndex =
-      defaultStatus !== undefined ? this.getNodeIndexByRootAndStatus(blockRoot, defaultStatus) : undefined;
+  getAllAncestorNodes(blockRoot: RootHex, payloadStatus: PayloadStatus): ProtoNode[] {
+    const startIndex = this.getNodeIndexByRootAndStatus(blockRoot, payloadStatus);
     if (startIndex === undefined) {
       return [];
     }
@@ -1698,14 +1695,8 @@ export class ProtoArray {
       });
     }
 
-    // Include starting node if node is pre-gloas
-    // Reason why we exclude post-gloas is because node is always default variant (PENDING)
-    // which we want to exclude.
-    const nodes: ProtoNode[] = [];
-
-    if (!isGloasBlock(node)) {
-      nodes.push(node);
-    }
+    // Include starting node
+    const nodes: ProtoNode[] = [node];
 
     while (node.parent !== undefined) {
       const parentIndex = this.getParentNodeIndex(node);

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -182,7 +182,7 @@ describe("Forkchoice", () => {
     const canonicalBlockRoot = getBlockRoot(genesisSlot + 3);
     const canonicalAncestorBlocks = forkchoice.getAllAncestorBlocks(canonicalBlockRoot);
     const canonicalNonAncestorBlocks = forkchoice.getAllNonAncestorBlocks(canonicalBlockRoot);
-    const canonicalCombined = forkchoice.getAllAncestorAndNonAncestorBlocks(canonicalBlockRoot);
+    const canonicalCombined = forkchoice.getAllAncestorAndNonAncestorBlocks(canonicalBlockRoot, PayloadStatus.FULL);
 
     expect(canonicalCombined.ancestors).toEqual(canonicalAncestorBlocks);
     expect(canonicalCombined.nonAncestors).toEqual(canonicalNonAncestorBlocks);
@@ -191,7 +191,7 @@ describe("Forkchoice", () => {
     const forkBlockRoot = getBlockRoot(genesisSlot + 10);
     const forkAncestorBlocks = forkchoice.getAllAncestorBlocks(forkBlockRoot);
     const forkNonAncestorBlocks = forkchoice.getAllNonAncestorBlocks(forkBlockRoot);
-    const forkCombined = forkchoice.getAllAncestorAndNonAncestorBlocks(forkBlockRoot);
+    const forkCombined = forkchoice.getAllAncestorAndNonAncestorBlocks(forkBlockRoot, PayloadStatus.FULL);
 
     expect(forkCombined.ancestors).toEqual(forkAncestorBlocks);
     expect(forkCombined.nonAncestors).toEqual(forkNonAncestorBlocks);

--- a/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
+++ b/packages/fork-choice/test/unit/forkChoice/forkChoice.test.ts
@@ -152,7 +152,9 @@ describe("Forkchoice", () => {
     const block = getBlock(genesisSlot + 1);
     protoArr.onBlock(block, block.slot);
     const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
-    const summaries = forkchoice.getAllAncestorBlocks(getBlockRoot(genesisSlot + 1));
+    const canonicalBlock = forkchoice.getBlockHexDefaultStatus(getBlockRoot(genesisSlot + 1));
+    if (!canonicalBlock) throw new Error("Expected block to exist");
+    const summaries = forkchoice.getAllAncestorBlocks(canonicalBlock);
     // there are 2 blocks in protoArray but iterateAncestorBlocks should only return non-finalized blocks
     expect(summaries).toHaveLength(1);
     expect(summaries[0]).toEqual({
@@ -163,6 +165,18 @@ describe("Forkchoice", () => {
       weight: 0,
       payloadStatus: 2, // Pre-Gloas blocks always have PAYLOAD_STATUS_FULL
     });
+  });
+
+  it("getAllAncestorBlocks supports ProtoBlock input", () => {
+    const block = getBlock(genesisSlot + 1);
+    protoArr.onBlock(block, block.slot);
+    const forkchoice = new ForkChoice(config, fcStore, protoArr, validatorCount, null);
+    const head = forkchoice.getHead();
+
+    const summaries = forkchoice.getAllAncestorBlocks(head);
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].blockRoot).toBe(head.blockRoot);
   });
 
   it("getAllAncestorAndNonAncestorBlocks equals getAllAncestorBlocks + getAllNonAncestorBlocks", () => {
@@ -180,7 +194,9 @@ describe("Forkchoice", () => {
 
     // Test with a block from the canonical chain
     const canonicalBlockRoot = getBlockRoot(genesisSlot + 3);
-    const canonicalAncestorBlocks = forkchoice.getAllAncestorBlocks(canonicalBlockRoot);
+    const canonicalBlock = forkchoice.getBlockHexDefaultStatus(canonicalBlockRoot);
+    if (!canonicalBlock) throw new Error("Expected canonical block to exist");
+    const canonicalAncestorBlocks = forkchoice.getAllAncestorBlocks(canonicalBlock);
     const canonicalNonAncestorBlocks = forkchoice.getAllNonAncestorBlocks(canonicalBlockRoot);
     const canonicalCombined = forkchoice.getAllAncestorAndNonAncestorBlocks(canonicalBlockRoot, PayloadStatus.FULL);
 
@@ -189,7 +205,9 @@ describe("Forkchoice", () => {
 
     // Test with a block from the fork chain
     const forkBlockRoot = getBlockRoot(genesisSlot + 10);
-    const forkAncestorBlocks = forkchoice.getAllAncestorBlocks(forkBlockRoot);
+    const forkBlockSummary = forkchoice.getBlockHexDefaultStatus(forkBlockRoot);
+    if (!forkBlockSummary) throw new Error("Expected fork block to exist");
+    const forkAncestorBlocks = forkchoice.getAllAncestorBlocks(forkBlockSummary);
     const forkNonAncestorBlocks = forkchoice.getAllNonAncestorBlocks(forkBlockRoot);
     const forkCombined = forkchoice.getAllAncestorAndNonAncestorBlocks(forkBlockRoot, PayloadStatus.FULL);
 

--- a/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
+++ b/packages/fork-choice/test/unit/protoArray/protoArray.test.ts
@@ -4,6 +4,68 @@ import {RootHex} from "@lodestar/types";
 import {ExecutionStatus, PayloadStatus, ProtoArray} from "../../../src/index.js";
 
 describe("ProtoArray", () => {
+  it("getAllAncestorNodes includes the starting node", () => {
+    const genesisSlot = 0;
+    const genesisEpoch = 0;
+    const stateRoot = "0";
+    const finalizedRoot = "1";
+    const parentRoot = "1";
+    const childRoot = "2";
+    const fc = ProtoArray.initialize(
+      {
+        slot: genesisSlot,
+        stateRoot,
+        parentRoot,
+        blockRoot: finalizedRoot,
+        justifiedEpoch: genesisEpoch,
+        justifiedRoot: stateRoot,
+        finalizedEpoch: genesisEpoch,
+        finalizedRoot: stateRoot,
+        unrealizedJustifiedEpoch: genesisEpoch,
+        unrealizedJustifiedRoot: stateRoot,
+        unrealizedFinalizedEpoch: genesisEpoch,
+        unrealizedFinalizedRoot: stateRoot,
+        timeliness: false,
+        ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
+        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+        parentBlockHash: null,
+        payloadStatus: PayloadStatus.FULL,
+        builderIndex: null,
+        blockHashFromBid: null,
+      },
+      genesisSlot
+    );
+
+    fc.onBlock(
+      {
+        slot: genesisSlot + 1,
+        blockRoot: childRoot,
+        parentRoot: finalizedRoot,
+        stateRoot,
+        targetRoot: finalizedRoot,
+        justifiedEpoch: genesisEpoch,
+        justifiedRoot: stateRoot,
+        finalizedEpoch: genesisEpoch,
+        finalizedRoot: stateRoot,
+        unrealizedJustifiedEpoch: genesisEpoch,
+        unrealizedJustifiedRoot: stateRoot,
+        unrealizedFinalizedEpoch: genesisEpoch,
+        unrealizedFinalizedRoot: stateRoot,
+        timeliness: false,
+        ...{executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge},
+        dataAvailabilityStatus: DataAvailabilityStatus.PreData,
+        parentBlockHash: null,
+        payloadStatus: PayloadStatus.FULL,
+        builderIndex: null,
+        blockHashFromBid: null,
+      },
+      genesisSlot + 1
+    );
+
+    const ancestors = fc.getAllAncestorNodes(childRoot, PayloadStatus.FULL);
+    expect(ancestors.map((node) => node.blockRoot)).toEqual([childRoot, finalizedRoot]);
+  });
+
   it("finalized descendant", () => {
     const genesisSlot = 0;
     const genesisEpoch = 0;

--- a/packages/state-transition/src/stateTransition.ts
+++ b/packages/state-transition/src/stateTransition.ts
@@ -72,6 +72,7 @@ export enum StateCloneSource {
 export enum StateHashTreeRootSource {
   stateTransition = "state_transition",
   blockTransition = "block_transition",
+  envelopeTransition = "envelope_transition",
   prepareNextSlot = "prepare_next_slot",
   prepareNextEpoch = "prepare_next_epoch",
   regenState = "regen_state",

--- a/packages/types/src/gloas/sszTypes.ts
+++ b/packages/types/src/gloas/sszTypes.ts
@@ -166,6 +166,14 @@ export const SignedExecutionPayloadEnvelope = new ContainerType(
   {typeName: "SignedExecutionPayloadEnvelope", jsonCase: "eth2"}
 );
 
+export const ExecutionPayloadEnvelopesByRangeRequest = new ContainerType(
+  {
+    startSlot: Slot,
+    count: UintNum64,
+  },
+  {typeName: "ExecutionPayloadEnvelopesByRangeRequest", jsonCase: "eth2"}
+);
+
 export const BeaconBlockBody = new ContainerType(
   {
     randaoReveal: phase0Ssz.BeaconBlockBody.fields.randaoReveal,

--- a/packages/types/src/gloas/types.ts
+++ b/packages/types/src/gloas/types.ts
@@ -14,6 +14,7 @@ export type ExecutionPayloadBid = ValueOf<typeof ssz.ExecutionPayloadBid>;
 export type SignedExecutionPayloadBid = ValueOf<typeof ssz.SignedExecutionPayloadBid>;
 export type ExecutionPayloadEnvelope = ValueOf<typeof ssz.ExecutionPayloadEnvelope>;
 export type SignedExecutionPayloadEnvelope = ValueOf<typeof ssz.SignedExecutionPayloadEnvelope>;
+export type ExecutionPayloadEnvelopesByRangeRequest = ValueOf<typeof ssz.ExecutionPayloadEnvelopesByRangeRequest>;
 export type BeaconBlockBody = ValueOf<typeof ssz.BeaconBlockBody>;
 export type BeaconBlock = ValueOf<typeof ssz.BeaconBlock>;
 export type SignedBeaconBlock = ValueOf<typeof ssz.SignedBeaconBlock>;


### PR DESCRIPTION
All 15 commits from `te/epbs-devnet-0_syncing` (twoeths' 14 gloas range sync commits + #8995 sync hardening) merged into current `epbs-devnet-0` with conflicts resolved.

## Commits
- twoeths' 14 range sync commits
- `6d6b2de` — #8995 sync hardening (merged into syncing branch by nflaig)
- 1 merge resolution commit

## Conflicts resolved
- `ReqRespBeaconNode.ts`: kept syncing branch protocol order
- `executionPayloadEnvelopesByRange.ts` handler: kept twoeths' 3-arg version
- `types.ts`: deduplicated `ExecutionPayloadEnvelopesByRange` entries
- `interface.ts`: kept `payloadStatus` param + added `getCanonicalBlockByRoot`

## Also fixed
- Removed duplicate definitions in protocols.ts, handlers/index.ts, rateLimit.ts, sszTypes.ts, types.ts
- Updated handler call in index.ts + test to match 3-arg signature
- Lint clean

Build, types, and lint all pass locally.

Supersedes #9002, #9001, #9000, #8988.