### PR TITLE
fix(epbs): checkpoint restart stability + finalized state API parity

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -58,7 +58,7 @@ export async function getStateResponseWithRegen(
         : stateId
       : null;
 
-  const res =
+  let res =
     typeof stateId === "string"
       ? await chain.getStateByStateRoot(stateId, {allowRegen: true})
       : typeof stateId === "number"
@@ -68,6 +68,12 @@ export async function getStateResponseWithRegen(
             ? await chain.getStateBySlot(stateId, {allowRegen: true})
             : await chain.getHistoricalStateBySlot(stateId)
         : await chain.getStateOrBytesByCheckpoint(checkpointStateId ?? stateId);
+
+  // Defensive fallback: if post-Gloas checkpoint normalization prefers EMPTY but that
+  // variant is unavailable, retry original checkpoint status before returning 404.
+  if (!res && checkpointStateId) {
+    res = await chain.getStateOrBytesByCheckpoint(stateId);
+  }
 
   if (!res) {
     throw new ApiError(404, `State not found for id '${inStateId}'`);

--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -1,7 +1,7 @@
 import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {routes} from "@lodestar/api";
-import {CheckpointWithPayload, IForkChoice} from "@lodestar/fork-choice";
-import {GENESIS_SLOT} from "@lodestar/params";
+import {CheckpointWithPayload, IForkChoice, PayloadStatus} from "@lodestar/fork-choice";
+import {ForkSeq, GENESIS_SLOT} from "@lodestar/params";
 import {BeaconStateAllForks, CachedBeaconStateAllForks} from "@lodestar/state-transition";
 import {BLSPubkey, Epoch, RootHex, Slot, ValidatorIndex, getValidatorStatus, phase0} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
@@ -47,6 +47,17 @@ export async function getStateResponseWithRegen(
 ): Promise<{state: CachedBeaconStateAllForks | Uint8Array; executionOptimistic: boolean; finalized: boolean}> {
   const stateId = resolveStateId(chain.forkChoice, inStateId);
 
+  // For checkpoint identifiers on post-Gloas forks, serve the consensus post-state (EMPTY path)
+  // rather than a post-envelope variant. This matches spec intent and Prysm checkpoint behavior.
+  const checkpointStateId =
+    typeof stateId !== "string" && typeof stateId !== "number"
+      ? inStateId === "finalized" || inStateId === "justified"
+        ? chain.config.getForkSeqAtEpoch(stateId.epoch) >= ForkSeq.gloas
+          ? {...stateId, payloadStatus: PayloadStatus.EMPTY}
+          : stateId
+        : stateId
+      : null;
+
   const res =
     typeof stateId === "string"
       ? await chain.getStateByStateRoot(stateId, {allowRegen: true})
@@ -56,7 +67,7 @@ export async function getStateResponseWithRegen(
           : stateId >= chain.forkChoice.getFinalizedBlock().slot
             ? await chain.getStateBySlot(stateId, {allowRegen: true})
             : await chain.getHistoricalStateBySlot(stateId)
-        : await chain.getStateOrBytesByCheckpoint(stateId);
+        : await chain.getStateOrBytesByCheckpoint(checkpointStateId ?? stateId);
 
   if (!res) {
     throw new ApiError(404, `State not found for id '${inStateId}'`);

--- a/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
+++ b/packages/beacon-node/src/chain/archiveStore/utils/archiveBlocks.ts
@@ -405,23 +405,32 @@ async function migrateExecutionPayloadEnvelopesFromHotToColdDb(
 
     if (canonicalBlocks.length === 0) break;
 
-    const canonicalEnvelopeEntries: KeyValue<Slot, Uint8Array>[] = await Promise.all(
+    const canonicalEnvelopeEntries = await Promise.all(
       canonicalBlocks.map(async (block) => {
         const envelopeBytes = await db.executionPayloadEnvelope.getBinary(block.root);
         if (!envelopeBytes) {
-          throw Error(`No executionPayloadEnvelope found for slot ${block.slot} root ${toRootHex(block.root)}`);
+          // Not every canonical Gloas block is guaranteed to have a revealed envelope.
+          // Skip missing envelopes (orphaned/unrevealed payload path) instead of failing
+          // finalized archival processing.
+          return null;
         }
 
-        return {key: block.slot, value: envelopeBytes};
+        return {slot: block.slot, root: block.root, value: envelopeBytes};
       })
     );
 
-    await Promise.all([
-      db.executionPayloadEnvelopeArchive.batchPutBinary(canonicalEnvelopeEntries),
-      db.executionPayloadEnvelope.batchDelete(canonicalBlocks.map((block) => block.root)),
-    ]);
+    const envelopesToArchive = canonicalEnvelopeEntries.filter((entry) => entry !== null);
 
-    migratedEnvelopes += canonicalEnvelopeEntries.length;
+    if (envelopesToArchive.length > 0) {
+      await Promise.all([
+        db.executionPayloadEnvelopeArchive.batchPutBinary(
+          envelopesToArchive.map((entry) => ({key: entry.slot, value: entry.value}))
+        ),
+        db.executionPayloadEnvelope.batchDelete(envelopesToArchive.map((entry) => entry.root)),
+      ]);
+    }
+
+    migratedEnvelopes += envelopesToArchive.length;
   }
 
   return migratedEnvelopes;

--- a/packages/beacon-node/src/chain/blocks/verifyBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlock.ts
@@ -93,6 +93,23 @@ export async function verifyBlocksInEpoch(
         const updatedParent = this.forkChoice.getBlockHex(parentRootHex, PayloadStatus.FULL);
         if (updatedParent) break;
 
+        const downloadedParentEnvelope = envelopes?.get(parentBlock.slot);
+        if (downloadedParentEnvelope && toRootHex(downloadedParentEnvelope.message.beaconBlockRoot) === parentRootHex) {
+          try {
+            await this.importExecutionPayloadEnvelope(downloadedParentEnvelope);
+            envelopes?.delete(parentBlock.slot);
+            this.logger.info("Imported downloaded parent envelope before block import", {
+              parentRoot: parentRootHex,
+              parentSlot: parentBlock.slot,
+              childSlot: block0.message.slot,
+              attempt,
+            });
+            break;
+          } catch (e) {
+            this.logger.debug("Failed importing downloaded parent envelope", {parentRoot: parentRootHex}, e as Error);
+          }
+        }
+
         const pendingEnvelope = this.pendingEnvelopes.get(parentRootHex);
         if (pendingEnvelope) {
           try {

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -39,6 +39,7 @@ import {
   computeSyncCommitteeRewards,
   getEffectiveBalanceIncrementsZeroInactive,
   getEffectiveBalancesFromStateBytes,
+  isParentBlockFull,
   processSlots,
 } from "@lodestar/state-transition";
 import {processExecutionPayloadEnvelope} from "@lodestar/state-transition/block";
@@ -384,11 +385,13 @@ export class BeaconChain implements IBeaconChain {
     const {checkpoint} = computeAnchorCheckpoint(config, anchorState);
     blockStateCache.add(anchorState);
     blockStateCache.setHeadState(anchorState);
-    // TODO: For Gloas, determine if anchor state is block state or payload state
+    // Determine payload status from anchor state for Gloas
     // Pre-Gloas: payloadPresent is always true (execution payload embedded in block)
-    // Post-Gloas: Could be either - depends on whether anchor was loaded with payload processing
-    // For now, assume true
-    checkpointStateCache.add(checkpoint, anchorState, true);
+    // Post-Gloas: check if envelope was applied using isParentBlockFull()
+    const anchorPayloadPresent = isForkPostGloas(config.getForkName(anchorState.slot))
+      ? isParentBlockFull(anchorState as CachedBeaconStateGloas)
+      : true;
+    checkpointStateCache.add(checkpoint, anchorState, anchorPayloadPresent);
 
     const forkChoice = initializeForkChoice(
       config,

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -10,7 +10,7 @@ import {
   ForkChoiceOpts as RawForkChoiceOpts,
   getCheckpointPayloadStatus,
 } from "@lodestar/fork-choice";
-import {ZERO_HASH_HEX} from "@lodestar/params";
+import {ForkSeq, ZERO_HASH_HEX} from "@lodestar/params";
 import {
   CachedBeaconStateAllForks,
   CachedBeaconStateGloas,
@@ -22,6 +22,7 @@ import {
   getEffectiveBalanceIncrementsZeroInactive,
   isExecutionStateType,
   isMergeTransitionComplete,
+  isParentBlockFull,
 } from "@lodestar/state-transition";
 import {Slot, ssz} from "@lodestar/types";
 import {Logger, toRootHex} from "@lodestar/utils";
@@ -106,7 +107,7 @@ export function initializeForkChoiceFromFinalizedState(
   // production code use ForkChoice constructor directly
   const forkchoiceConstructor = opts.forkchoiceConstructor ?? ForkChoice;
 
-  const isForkPostGloas = (state as CachedBeaconStateGloas).latestBlockHash !== undefined;
+  const isForkPostGloas = config.getForkSeq(state.slot) >= ForkSeq.gloas;
 
   // Determine justified checkpoint payload status
   const justifiedPayloadStatus = getCheckpointPayloadStatus(state, justifiedCheckpoint.epoch);
@@ -148,21 +149,33 @@ export function initializeForkChoiceFromFinalizedState(
         unrealizedFinalizedEpoch: finalizedCheckpoint.epoch,
         unrealizedFinalizedRoot: toRootHex(finalizedCheckpoint.root),
 
-        ...(isExecutionStateType(state) && isMergeTransitionComplete(state)
+        ...(isForkPostGloas
           ? {
-              executionPayloadBlockHash: toRootHex(state.latestExecutionPayloadHeader.blockHash),
-              executionPayloadNumber: state.latestExecutionPayloadHeader.blockNumber,
+              executionPayloadBlockHash: toRootHex((state as unknown as CachedBeaconStateGloas).latestBlockHash),
+              executionPayloadNumber: 0,
               executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,
             }
-          : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),
+          : isExecutionStateType(state) && isMergeTransitionComplete(state)
+            ? {
+                executionPayloadBlockHash: toRootHex(state.latestExecutionPayloadHeader.blockHash),
+                executionPayloadNumber: state.latestExecutionPayloadHeader.blockNumber,
+                executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,
+              }
+            : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),
 
         dataAvailabilityStatus: DataAvailabilityStatus.PreData,
-        payloadStatus: isForkPostGloas ? PayloadStatus.PENDING : PayloadStatus.FULL, // TODO GLOAS: Post-gloas how do we know if the checkpoint payload is FULL or EMPTY?
+        payloadStatus: isForkPostGloas
+          ? isParentBlockFull(state as CachedBeaconStateGloas)
+            ? PayloadStatus.FULL
+            : PayloadStatus.EMPTY
+          : PayloadStatus.FULL,
         builderIndex: isForkPostGloas ? (state as CachedBeaconStateGloas).latestExecutionPayloadBid.builderIndex : null,
         blockHashFromBid: isForkPostGloas
           ? toRootHex((state as CachedBeaconStateGloas).latestExecutionPayloadBid.blockHash)
           : null,
-        parentBlockHash: isForkPostGloas ? toRootHex((state as CachedBeaconStateGloas).latestBlockHash) : null,
+        parentBlockHash: isForkPostGloas
+          ? toRootHex((state as unknown as CachedBeaconStateGloas).latestBlockHash)
+          : null,
       },
       currentSlot
     ),
@@ -206,7 +219,7 @@ export function initializeForkChoiceFromUnfinalizedState(
   // this is not the justified state, but there is no other ways to get justified balances
   const justifiedBalances = getEffectiveBalanceIncrementsZeroInactive(unfinalizedState);
 
-  const isForkPostGloas = (unfinalizedState as CachedBeaconStateGloas).latestBlockHash !== undefined;
+  const isForkPostGloas = config.getForkSeq(unfinalizedState.slot) >= ForkSeq.gloas;
 
   // For unfinalized state, use getCheckpointPayloadStatus to determine the correct status.
   // It checks state.execution_payload_availability to determine EMPTY vs FULL.
@@ -245,23 +258,35 @@ export function initializeForkChoiceFromUnfinalizedState(
     unrealizedFinalizedEpoch: finalizedCheckpoint.epoch,
     unrealizedFinalizedRoot: toRootHex(finalizedCheckpoint.root),
 
-    ...(isExecutionStateType(unfinalizedState) && isMergeTransitionComplete(unfinalizedState)
+    ...(isForkPostGloas
       ? {
-          executionPayloadBlockHash: toRootHex(unfinalizedState.latestExecutionPayloadHeader.blockHash),
-          executionPayloadNumber: unfinalizedState.latestExecutionPayloadHeader.blockNumber,
+          executionPayloadBlockHash: toRootHex((unfinalizedState as unknown as CachedBeaconStateGloas).latestBlockHash),
+          executionPayloadNumber: 0,
           executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,
         }
-      : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),
+      : isExecutionStateType(unfinalizedState) && isMergeTransitionComplete(unfinalizedState)
+        ? {
+            executionPayloadBlockHash: toRootHex(unfinalizedState.latestExecutionPayloadHeader.blockHash),
+            executionPayloadNumber: unfinalizedState.latestExecutionPayloadHeader.blockNumber,
+            executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,
+          }
+        : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),
 
     dataAvailabilityStatus: DataAvailabilityStatus.PreData,
-    payloadStatus: isForkPostGloas ? PayloadStatus.PENDING : PayloadStatus.FULL, // TODO GLOAS: Post-gloas how do we know if the checkpoint payload is FULL or EMPTY?
+    payloadStatus: isForkPostGloas
+      ? isParentBlockFull(unfinalizedState as CachedBeaconStateGloas)
+        ? PayloadStatus.FULL
+        : PayloadStatus.EMPTY
+      : PayloadStatus.FULL,
     builderIndex: isForkPostGloas
       ? (unfinalizedState as CachedBeaconStateGloas).latestExecutionPayloadBid.builderIndex
       : null,
     blockHashFromBid: isForkPostGloas
       ? toRootHex((unfinalizedState as CachedBeaconStateGloas).latestExecutionPayloadBid.blockHash)
       : null,
-    parentBlockHash: isForkPostGloas ? toRootHex((unfinalizedState as CachedBeaconStateGloas).latestBlockHash) : null,
+    parentBlockHash: isForkPostGloas
+      ? toRootHex((unfinalizedState as unknown as CachedBeaconStateGloas).latestBlockHash)
+      : null,
   };
 
   const parentSlot = blockHeader.slot - 1;

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -151,7 +151,7 @@ export function initializeForkChoiceFromFinalizedState(
 
         ...(isForkPostGloas
           ? {
-              executionPayloadBlockHash: toRootHex((state as unknown as CachedBeaconStateGloas).latestBlockHash),
+              executionPayloadBlockHash: toRootHex((state as CachedBeaconStateGloas).latestBlockHash),
               executionPayloadNumber: 0,
               executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,
             }
@@ -173,9 +173,7 @@ export function initializeForkChoiceFromFinalizedState(
         blockHashFromBid: isForkPostGloas
           ? toRootHex((state as CachedBeaconStateGloas).latestExecutionPayloadBid.blockHash)
           : null,
-        parentBlockHash: isForkPostGloas
-          ? toRootHex((state as unknown as CachedBeaconStateGloas).latestBlockHash)
-          : null,
+        parentBlockHash: isForkPostGloas ? toRootHex((state as CachedBeaconStateGloas).latestBlockHash) : null,
       },
       currentSlot
     ),
@@ -260,7 +258,7 @@ export function initializeForkChoiceFromUnfinalizedState(
 
     ...(isForkPostGloas
       ? {
-          executionPayloadBlockHash: toRootHex((unfinalizedState as unknown as CachedBeaconStateGloas).latestBlockHash),
+          executionPayloadBlockHash: toRootHex((unfinalizedState as CachedBeaconStateGloas).latestBlockHash),
           executionPayloadNumber: 0,
           executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,
         }
@@ -284,9 +282,7 @@ export function initializeForkChoiceFromUnfinalizedState(
     blockHashFromBid: isForkPostGloas
       ? toRootHex((unfinalizedState as CachedBeaconStateGloas).latestExecutionPayloadBid.blockHash)
       : null,
-    parentBlockHash: isForkPostGloas
-      ? toRootHex((unfinalizedState as unknown as CachedBeaconStateGloas).latestBlockHash)
-      : null,
+    parentBlockHash: isForkPostGloas ? toRootHex((unfinalizedState as CachedBeaconStateGloas).latestBlockHash) : null,
   };
 
   const parentSlot = blockHeader.slot - 1;

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -169,8 +169,8 @@ export class QueuedStateRegenerator implements IStateRegenerator {
     // to avoid startup failures (`headState does not exist`).
     return (
       this.checkpointStateCache.getLatest(head.blockRoot, Infinity, preferredPayloadPresent) ||
-      this.checkpointStateCache.getLatest(head.blockRoot, Infinity, !preferredPayloadPresent) ||
-      this.blockStateCache.get(head.stateRoot)
+      this.blockStateCache.get(head.stateRoot) ||
+      this.checkpointStateCache.getLatest(head.blockRoot, Infinity, !preferredPayloadPresent)
     );
   }
 

--- a/packages/beacon-node/src/chain/regen/queued.ts
+++ b/packages/beacon-node/src/chain/regen/queued.ts
@@ -162,9 +162,14 @@ export class QueuedStateRegenerator implements IStateRegenerator {
   getClosestHeadState(head: ProtoBlock): CachedBeaconStateAllForks | null {
     // Convert PayloadStatus to payloadPresent boolean.
     // PENDING blocks are in fork-choice but lack an envelope — treat as non-FULL.
-    const payloadPresent = head.payloadStatus === PayloadStatus.FULL;
+    const preferredPayloadPresent = head.payloadStatus === PayloadStatus.FULL;
+
+    // In some restart edge cases, fork-choice may reference a head variant whose payload status
+    // differs from the variant persisted in checkpoint cache. Fall back to the opposite variant
+    // to avoid startup failures (`headState does not exist`).
     return (
-      this.checkpointStateCache.getLatest(head.blockRoot, Infinity, payloadPresent) ||
+      this.checkpointStateCache.getLatest(head.blockRoot, Infinity, preferredPayloadPresent) ||
+      this.checkpointStateCache.getLatest(head.blockRoot, Infinity, !preferredPayloadPresent) ||
       this.blockStateCache.get(head.stateRoot)
     );
   }

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -1,6 +1,8 @@
-import {describe, expect, it} from "vitest";
+import {describe, expect, it, vi} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
-import {getStateValidatorIndex} from "../../../../../../src/api/impl/beacon/state/utils.js";
+import {PayloadStatus} from "@lodestar/fork-choice";
+import {ForkSeq} from "@lodestar/params";
+import {getStateResponseWithRegen, getStateValidatorIndex} from "../../../../../../src/api/impl/beacon/state/utils.js";
 import {generateCachedAltairState} from "../../../../../utils/state.js";
 
 describe("beacon state api utils", () => {
@@ -56,5 +58,47 @@ describe("beacon state api utils", () => {
         expect.fail("validator index should be found - Uint8Array input");
       }
     });
+  });
+});
+
+describe("getStateResponseWithRegen", () => {
+  it("falls back to original checkpoint payload status if forced EMPTY lookup misses", async () => {
+    const finalizedCheckpoint = {
+      epoch: 123,
+      rootHex: "0xabc",
+      payloadStatus: PayloadStatus.FULL,
+      payloadPresent: true,
+    };
+
+    const expectedResponse = {
+      state: new Uint8Array([1, 2, 3]),
+      executionOptimistic: false,
+      finalized: true,
+    };
+
+    const chain = {
+      forkChoice: {
+        getFinalizedCheckpoint: vi.fn().mockReturnValue(finalizedCheckpoint),
+      },
+      config: {
+        getForkSeqAtEpoch: vi.fn().mockReturnValue(ForkSeq.gloas),
+      },
+      clock: {
+        currentSlot: 1000,
+      },
+      getStateByStateRoot: vi.fn(),
+      getStateBySlot: vi.fn(),
+      getHistoricalStateBySlot: vi.fn(),
+      getStateOrBytesByCheckpoint: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(expectedResponse),
+    } as never;
+
+    const response = await getStateResponseWithRegen(chain, "finalized");
+
+    expect(response).toBe(expectedResponse);
+    expect(chain.getStateOrBytesByCheckpoint).toHaveBeenNthCalledWith(1, {
+      ...finalizedCheckpoint,
+      payloadStatus: PayloadStatus.EMPTY,
+    });
+    expect(chain.getStateOrBytesByCheckpoint).toHaveBeenNthCalledWith(2, finalizedCheckpoint);
   });
 });

--- a/packages/beacon-node/test/unit/chain/regen/queued.closestHeadState.test.ts
+++ b/packages/beacon-node/test/unit/chain/regen/queued.closestHeadState.test.ts
@@ -1,0 +1,130 @@
+import {describe, expect, it, vi} from "vitest";
+import {PayloadStatus, type ProtoBlock} from "@lodestar/fork-choice";
+import {QueuedStateRegenerator} from "../../../../src/chain/regen/queued.js";
+
+function makeHead(payloadStatus: PayloadStatus): ProtoBlock {
+  return {
+    slot: 0,
+    blockRoot: "0x11",
+    parentRoot: "0x22",
+    stateRoot: "0x33",
+    targetRoot: "0x44",
+    justifiedEpoch: 0,
+    justifiedRoot: "0x55",
+    finalizedEpoch: 0,
+    finalizedRoot: "0x66",
+    unrealizedJustifiedEpoch: 0,
+    unrealizedJustifiedRoot: "0x77",
+    unrealizedFinalizedEpoch: 0,
+    unrealizedFinalizedRoot: "0x88",
+    timeliness: true,
+    payloadStatus,
+    builderIndex: null,
+    blockHashFromBid: null,
+    parentBlockHash: null,
+    executionPayloadBlockHash: null,
+    executionStatus: "PreMerge",
+    dataAvailabilityStatus: "PreData",
+  } as unknown as ProtoBlock;
+}
+
+describe("QueuedStateRegenerator - getClosestHeadState", () => {
+  it("prefers exact head state root cache hit over opposite payload variant fallback", () => {
+    const oppositeVariantState = {tag: "opposite"};
+    const exactHeadState = {tag: "exact-head"};
+
+    const checkpointStateCache = {
+      getLatest: vi.fn().mockReturnValueOnce(null).mockReturnValueOnce(oppositeVariantState),
+      get: vi.fn(),
+      getStateOrBytes: vi.fn(),
+      clear: vi.fn(),
+      dumpSummary: vi.fn().mockReturnValue([]),
+      prune: vi.fn(),
+      pruneFinalized: vi.fn(),
+      processState: vi.fn().mockResolvedValue(undefined),
+      add: vi.fn(),
+      updatePreComputedCheckpoint: vi.fn(),
+    };
+
+    const blockStateCache = {
+      get: vi.fn().mockReturnValue(exactHeadState),
+      clear: vi.fn(),
+      dumpSummary: vi.fn().mockReturnValue([]),
+      prune: vi.fn(),
+      deleteAllBeforeEpoch: vi.fn(),
+      add: vi.fn(),
+      setHeadState: vi.fn(),
+    };
+
+    const regenerator = new QueuedStateRegenerator({
+      signal: new AbortController().signal,
+      metrics: null,
+      logger: {debug: vi.fn(), warn: vi.fn(), error: vi.fn()},
+      forkChoice: {} as never,
+      blockStateCache: blockStateCache as never,
+      checkpointStateCache: checkpointStateCache as never,
+      db: {} as never,
+      seenBlockInputCache: {} as never,
+      config: {} as never,
+      emitter: {} as never,
+      validatorMonitor: null,
+    });
+
+    const head = makeHead(PayloadStatus.FULL);
+    const state = regenerator.getClosestHeadState(head);
+
+    expect(state).toBe(exactHeadState);
+    expect(checkpointStateCache.getLatest).toHaveBeenCalledTimes(1);
+    expect(checkpointStateCache.getLatest).toHaveBeenCalledWith(head.blockRoot, Infinity, true);
+    expect(blockStateCache.get).toHaveBeenCalledWith(head.stateRoot);
+  });
+
+  it("falls back to opposite payload variant only when exact head state is unavailable", () => {
+    const oppositeVariantState = {tag: "opposite"};
+
+    const checkpointStateCache = {
+      getLatest: vi.fn().mockReturnValueOnce(null).mockReturnValueOnce(oppositeVariantState),
+      get: vi.fn(),
+      getStateOrBytes: vi.fn(),
+      clear: vi.fn(),
+      dumpSummary: vi.fn().mockReturnValue([]),
+      prune: vi.fn(),
+      pruneFinalized: vi.fn(),
+      processState: vi.fn().mockResolvedValue(undefined),
+      add: vi.fn(),
+      updatePreComputedCheckpoint: vi.fn(),
+    };
+
+    const blockStateCache = {
+      get: vi.fn().mockReturnValue(null),
+      clear: vi.fn(),
+      dumpSummary: vi.fn().mockReturnValue([]),
+      prune: vi.fn(),
+      deleteAllBeforeEpoch: vi.fn(),
+      add: vi.fn(),
+      setHeadState: vi.fn(),
+    };
+
+    const regenerator = new QueuedStateRegenerator({
+      signal: new AbortController().signal,
+      metrics: null,
+      logger: {debug: vi.fn(), warn: vi.fn(), error: vi.fn()},
+      forkChoice: {} as never,
+      blockStateCache: blockStateCache as never,
+      checkpointStateCache: checkpointStateCache as never,
+      db: {} as never,
+      seenBlockInputCache: {} as never,
+      config: {} as never,
+      emitter: {} as never,
+      validatorMonitor: null,
+    });
+
+    const head = makeHead(PayloadStatus.FULL);
+    const state = regenerator.getClosestHeadState(head);
+
+    expect(state).toBe(oppositeVariantState);
+    expect(checkpointStateCache.getLatest).toHaveBeenNthCalledWith(1, head.blockRoot, Infinity, true);
+    expect(blockStateCache.get).toHaveBeenCalledWith(head.stateRoot);
+    expect(checkpointStateCache.getLatest).toHaveBeenNthCalledWith(2, head.blockRoot, Infinity, false);
+  });
+});


### PR DESCRIPTION
## Summary
This patch fixes EPBS checkpoint/restart behavior and finalized state serving semantics to match spec intent (consensus post-state) and Prysm checkpoint behavior.

### Fixes included
1. **Restart crash (`headState does not exist`) hardening**
   - Derive anchor checkpoint cache payload variant from state (`isParentBlockFull`) instead of hardcoded `true`
   - Derive Gloas fork-choice anchor `payloadStatus` as FULL/EMPTY from state instead of defaulting to PENDING
   - Add `getClosestHeadState()` fallback to opposite payload variant when preferred variant is missing

2. **Range sync prestate failure on first post-checkpoint block**
   - Import downloaded parent envelope before validating child blocks that require FULL parent path
   - This fixes recurring `BLOCK_ERROR_PRESTATE_MISSING / REGEN_ERROR_BLOCK_NOT_IN_FORKCHOICE` loops after checkpoint sync

3. **Finalized v2 state serving semantics**
   - For `finalized`/`justified` state IDs on post-Gloas forks, normalize to EMPTY checkpoint variant (consensus post-state)
   - Aligns with potuz guidance + Prysm checkpoint endpoint behavior

4. **Finalized archival robustness**
   - Envelope migration hot→cold now skips missing/unrevealed envelopes instead of hard failing finalized checkpoint processing

## Why
On EPBS devnet-0, restarting from a synced DB state could crash at startup and checkpoint sync could stall due parent-path mismatches. Also `/eth/v2/debug/beacon/states/finalized` could return a post-envelope variant (or 404) instead of the consensus post-state expected from checkpoint sync providers.

## Validation
Live-devnet validation on `epbs-devnet-0` with:
- `--checkpointSyncUrl https://checkpoint-sync.epbs-devnet-0.ethpandaops.io/`
- `--execution.engineMock`
- bootnodes from `config.epbs-devnet-0.ethpandaops.io`

### Observed
- ✅ Checkpoint sync reaches `Synced`
- ✅ Restart from DB state succeeds (no `headState does not exist` crash)
- ✅ Finalized state SSZ from local `/eth/v2/debug/beacon/states/finalized` matches checkpoint endpoint exactly (same SHA256)
- ✅ Finalized state is post-CL (`latest_block_hash == latest_execution_payload_bid.parent_block_hash`)

## Notes
- This PR intentionally follows the consensus post-state serving model for checkpoint IDs.
- Existing sync fix behavior for orphaned/unrevealed envelopes remains intact.
