### PR TITLE
fix: enhance epochIndex to track payloadPresent variants

### DIFF
--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -210,7 +210,12 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       return stateOrStateBytesData ?? null;
     }
     const {persistedKey, stateBytes} = stateOrStateBytesData;
-    const logMeta = {persistedKey: toHex(persistedKey)};
+    const logMeta = {
+      epoch: cp.epoch,
+      rootHex: cp.rootHex,
+      payloadPresent: cp.payloadPresent,
+      persistedKey: toHex(persistedKey),
+    };
     this.logger.debug("Reload: read state successful", logMeta);
     this.metrics?.cpStateCache.stateReloadSecFromSlot.observe(
       this.clock?.secFromSlot(this.clock?.currentSlot ?? 0) ?? 0
@@ -305,7 +310,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   /**
    * Similar to get() api without reloading from disk
    */
-  get(cpOrKey: CheckpointHexPayload | string): CachedBeaconStateAllForks | null {
+  get(cpOrKey: CheckpointHexPayload | CacheKey): CachedBeaconStateAllForks | null {
     this.metrics?.cpStateCache.lookups.inc();
     const cpKey = typeof cpOrKey === "string" ? cpOrKey : toCacheKey(cpOrKey);
     const cacheItem = this.cache.get(cpKey);
@@ -346,11 +351,16 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       this.logger.verbose("Added checkpoint state to memory but a persisted key existed", {
         epoch: cp.epoch,
         rootHex: cpHex.rootHex,
+        payloadPresent,
         persistedKey: toHex(persistedKey),
       });
     } else {
       this.cache.set(key, {type: CacheItemType.inMemory, state});
-      this.logger.verbose("Added checkpoint state to memory", {epoch: cp.epoch, rootHex: cpHex.rootHex});
+      this.logger.verbose("Added checkpoint state to memory", {
+        epoch: cp.epoch,
+        rootHex: cpHex.rootHex,
+        payloadPresent,
+      });
     }
     this.addToEpochIndex(cp.epoch, cpHex.rootHex, cpHex.payloadPresent);
     this.prunePersistedStates();
@@ -825,13 +835,21 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
           }
         }
         this.cache.delete(key);
+        this.logger.verbose("Pruned checkpoint state", {
+          epoch,
+          rootHex,
+          payloadPresent,
+          type: cacheItem ? (isPersistedCacheItem(cacheItem) ? "persisted" : "in-memory") : "missing",
+        });
       }
     }
     this.epochIndex.delete(epoch);
-    this.logger.verbose("Pruned checkpoint states for epoch", {
+    this.logger.verbose("Pruned all checkpoint states for epoch", {
       epoch,
       persistCount,
-      rootHexes: Array.from(rootHexMap.keys()).join(","),
+      items: Array.from(rootHexMap.entries())
+        .flatMap(([rootHex, variants]) => Array.from(variants).map((p) => `${rootHex}:${p}`))
+        .join(","),
     });
   }
 

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -645,6 +645,9 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     variants.delete(payloadPresent);
     if (variants.size === 0) {
       rootMap.delete(rootHex);
+      if (rootMap.size === 0) {
+        this.epochIndex.delete(epoch);
+      }
     }
   }
 

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -107,8 +107,8 @@ const PROCESS_CHECKPOINT_STATES_BPS = 6667;
  */
 export class PersistentCheckpointStateCache implements CheckpointStateCache {
   private readonly cache: MapTracker<CacheKey, CacheItem>;
-  /** Epoch -> Set<blockRoot> */
-  private readonly epochIndex = new MapDef<Epoch, Set<RootHex>>(() => new Set<string>());
+  /** Epoch -> Map<blockRoot, Set<payloadPresent>> */
+  private readonly epochIndex = new MapDef<Epoch, Map<RootHex, Set<boolean>>>(() => new Map());
   private readonly config: BeaconConfig;
   private readonly metrics: Metrics | null | undefined;
   private readonly logger: Logger;
@@ -251,7 +251,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       // only remove persisted state once we reload successfully
       const cpKey = toCacheKey(cp);
       this.cache.set(cpKey, {type: CacheItemType.inMemory, state: newCachedState, persistedKey});
-      this.epochIndex.getOrDefault(cp.epoch).add(cp.rootHex);
+      this.addToEpochIndex(cp.epoch, cp.rootHex, cp.payloadPresent);
       // don't prune from memory here, call it at the last 1/3 of slot 0 of an epoch
       return newCachedState;
     } catch (e) {
@@ -352,7 +352,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       this.cache.set(key, {type: CacheItemType.inMemory, state});
       this.logger.verbose("Added checkpoint state to memory", {epoch: cp.epoch, rootHex: cpHex.rootHex});
     }
-    this.epochIndex.getOrDefault(cp.epoch).add(cpHex.rootHex);
+    this.addToEpochIndex(cp.epoch, cpHex.rootHex, cpHex.payloadPresent);
     this.prunePersistedStates();
   }
 
@@ -365,7 +365,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       .sort((a, b) => b - a)
       .filter((e) => e <= maxEpoch);
     for (const epoch of epochs) {
-      if (this.epochIndex.get(epoch)?.has(rootHex)) {
+      if (this.epochIndex.get(epoch)?.get(rootHex)?.has(payloadPresent)) {
         const inMemoryClonedState = this.get({rootHex, epoch, payloadPresent});
         if (inMemoryClonedState) {
           return inMemoryClonedState;
@@ -392,7 +392,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
       .sort((a, b) => b - a)
       .filter((e) => e <= maxEpoch);
     for (const epoch of epochs) {
-      if (this.epochIndex.get(epoch)?.has(rootHex)) {
+      if (this.epochIndex.get(epoch)?.get(rootHex)?.has(payloadPresent)) {
         try {
           const state = await this.getOrReload({rootHex, epoch, payloadPresent});
           if (state) {
@@ -574,9 +574,8 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
         return firstState;
       }
 
-      for (const rootHex of this.epochIndex.get(epoch) || []) {
-        // Try both payloadPresent values when searching for seed state
-        for (const payloadPresent of [true, false]) {
+      for (const [rootHex, variants] of this.epochIndex.get(epoch) || []) {
+        for (const payloadPresent of variants) {
           const cpKey = toCacheKey({rootHex, epoch, payloadPresent});
           const cacheItem = this.cache.get(cpKey);
           if (cacheItem === undefined) {
@@ -616,6 +615,27 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
   clear(): void {
     this.cache.clear();
     this.epochIndex.clear();
+  }
+
+  private addToEpochIndex(epoch: Epoch, rootHex: RootHex, payloadPresent: boolean): void {
+    const rootMap = this.epochIndex.getOrDefault(epoch);
+    let variants = rootMap.get(rootHex);
+    if (variants === undefined) {
+      variants = new Set();
+      rootMap.set(rootHex, variants);
+    }
+    variants.add(payloadPresent);
+  }
+
+  private removeFromEpochIndex(epoch: Epoch, rootHex: RootHex, payloadPresent: boolean): void {
+    const rootMap = this.epochIndex.get(epoch);
+    if (rootMap === undefined) return;
+    const variants = rootMap.get(rootHex);
+    if (variants === undefined) return;
+    variants.delete(payloadPresent);
+    if (variants.size === 0) {
+      rootMap.delete(rootHex);
+    }
   }
 
   /** ONLY FOR DEBUGGING PURPOSES. For lodestar debug API */
@@ -696,7 +716,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     const prevEpochRoot = toRootHex(getBlockRootAtSlot(state, epochBoundarySlot - 1));
 
     // for each epoch, usually there are 2 rootHexes respective to the 2 checkpoint states: Previous Root Checkpoint State and Current Root Checkpoint State
-    const cpRootHexes = this.epochIndex.get(epoch) ?? [];
+    const cpRootHexMap = this.epochIndex.get(epoch) ?? new Map<RootHex, Set<boolean>>();
     const persistedRootHexes = new Set<RootHex>();
 
     // 1) if there is no CRCS, persist PRCS (block 0 of epoch is skipped). In this case prevEpochRoot === epochBoundaryHex
@@ -705,15 +725,14 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     persistedRootHexes.add(epochBoundaryHex);
 
     // 3) persist any states with unknown roots to this state
-    for (const rootHex of cpRootHexes) {
+    for (const rootHex of cpRootHexMap.keys()) {
       if (rootHex !== epochBoundaryHex && rootHex !== prevEpochRoot) {
         persistedRootHexes.add(rootHex);
       }
     }
 
-    for (const rootHex of cpRootHexes) {
-      // Process both payloadPresent variants for each rootHex
-      for (const payloadPresent of [true, false]) {
+    for (const [rootHex, variants] of cpRootHexMap) {
+      for (const payloadPresent of variants) {
         const cpKey = toCacheKey({epoch: epoch, rootHex, payloadPresent});
         const cacheItem = this.cache.get(cpKey);
 
@@ -774,7 +793,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
             } else {
               // delete the state from memory
               this.cache.delete(cpKey);
-              this.epochIndex.get(epoch)?.delete(rootHex);
+              this.removeFromEpochIndex(epoch, rootHex, payloadPresent);
             }
             this.metrics?.cpStateCache.statePruneFromMemoryCount.inc();
             this.logger.verbose("Pruned checkpoint state from memory", logMeta);
@@ -791,10 +810,9 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
    */
   private async deleteAllEpochItems(epoch: Epoch): Promise<void> {
     let persistCount = 0;
-    const rootHexes = this.epochIndex.get(epoch) || [];
-    for (const rootHex of rootHexes) {
-      // Delete both payloadPresent variants for each rootHex
-      for (const payloadPresent of [true, false]) {
+    const rootHexMap = this.epochIndex.get(epoch) || new Map<RootHex, Set<boolean>>();
+    for (const [rootHex, variants] of rootHexMap) {
+      for (const payloadPresent of variants) {
         const key = toCacheKey({rootHex, epoch, payloadPresent});
         const cacheItem = this.cache.get(key);
 
@@ -813,7 +831,7 @@ export class PersistentCheckpointStateCache implements CheckpointStateCache {
     this.logger.verbose("Pruned checkpoint states for epoch", {
       epoch,
       persistCount,
-      rootHexes: Array.from(rootHexes).join(","),
+      rootHexes: Array.from(rootHexMap.keys()).join(","),
     });
   }
 


### PR DESCRIPTION
## Summary

Follows up on #8868.

- Enhance `epochIndex` from `Map<Epoch, Set<RootHex>>` to `Map<Epoch, Map<RootHex, Set<boolean>>>` to track which `payloadPresent` variants exist per checkpoint
- Eliminate all 3 `for (const payloadPresent of [true, false])` brute-force loops in `findSeedStateToReload`, `processPastEpoch`, and `deleteAllEpochItems`
- Fix bug where `removeFromEpochIndex` would delete a rootHex entry even when the other payloadPresent variant still existed
- Improve logging to include `payloadPresent` in `add()`, `getOrReload()`, and `deleteAllEpochItems()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)