### PR TITLE
fix:  prune serialized cache by block input keys

### DIFF
--- a/dashboards/lodestar_beacon_chain.json
+++ b/dashboards/lodestar_beacon_chain.json
@@ -388,6 +388,18 @@
           "legendFormat": "created_by_blob",
           "range": true,
           "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "lodestar_seen_block_input_cache_serialized_object_count",
+          "instant": false,
+          "legendFormat": "serialized_objects",
+          "range": true,
+          "refId": "G"
         }
       ],
       "title": "Block Input",

--- a/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/blockInput.ts
@@ -105,6 +105,7 @@ abstract class AbstractBlockInput<F extends ForkName = ForkName, TData extends D
   }
 
   abstract addBlock(props: AddBlock<F>): void;
+  abstract getSerializedCacheKeys(): object[];
 
   hasBlock(): boolean {
     return this.state.hasBlock;
@@ -242,6 +243,10 @@ export class BlockInputPreData extends AbstractBlockInput<ForkPreDeneb, null> {
         "Cannot addBlock to BlockInputPreData"
       );
     }
+  }
+
+  getSerializedCacheKeys(): object[] {
+    return [this.state.block];
   }
 }
 
@@ -525,6 +530,20 @@ export class BlockInputBlobs extends AbstractBlockInput<ForkBlobsDA, deneb.BlobS
 
   getBlobs(): deneb.BlobSidecars {
     return this.getAllBlobsWithSource().map(({blobSidecar}) => blobSidecar);
+  }
+
+  getSerializedCacheKeys(): object[] {
+    const objects: object[] = [];
+
+    if (this.state.hasBlock) {
+      objects.push(this.state.block);
+    }
+
+    for (const {blobSidecar} of this.blobsCache.values()) {
+      objects.push(blobSidecar);
+    }
+
+    return objects;
   }
 }
 
@@ -906,6 +925,18 @@ export class BlockInputColumns extends AbstractBlockInput<ForkColumnsDA, fulu.Da
     }
     return Promise.resolve(this.getSampledColumns());
   }
+
+  getSerializedCacheKeys(): object[] {
+    const objects: object[] = [];
+
+    if (this.state.hasBlock) {
+      objects.push(this.state.block);
+    }
+
+    objects.push(...this.getAllColumns());
+
+    return objects;
+  }
 }
 
 type BlockInputNoDataState = {
@@ -966,5 +997,9 @@ export class BlockInputNoData extends AbstractBlockInput<ForkPostGloas, null> {
   getBlobKzgCommitments(): deneb.BlobKzgCommitments {
     return (this.state.block.message.body as gloas.BeaconBlockBody).signedExecutionPayloadBid.message
       .blobKzgCommitments;
+  }
+
+  getSerializedCacheKeys(): object[] {
+    return [this.state.block];
   }
 }

--- a/packages/beacon-node/src/chain/blocks/blockInput/types.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/types.ts
@@ -152,7 +152,7 @@ export interface IBlockInput<F extends ForkName = ForkName, TData extends DAData
   /** Only safe to call when `hasBlockAndAllData` is true */
   getTimeComplete(): number;
   /**
-   * Return object identities used as keys in `SerializedCache` that can be safely removed
+   * Return object references used as keys in `SerializedCache` that can be safely removed
    * once this block input lifecycle has completed.
    */
   getSerializedCacheKeys(): object[];

--- a/packages/beacon-node/src/chain/blocks/blockInput/types.ts
+++ b/packages/beacon-node/src/chain/blocks/blockInput/types.ts
@@ -151,6 +151,11 @@ export interface IBlockInput<F extends ForkName = ForkName, TData extends DAData
 
   /** Only safe to call when `hasBlockAndAllData` is true */
   getTimeComplete(): number;
+  /**
+   * Return object identities used as keys in `SerializedCache` that can be safely removed
+   * once this block input lifecycle has completed.
+   */
+  getSerializedCacheKeys(): object[];
 
   waitForBlock(timeout: number, signal?: AbortSignal): Promise<SignedBeaconBlock<F>>;
   waitForAllData(timeout: number, signal?: AbortSignal): Promise<TData>;

--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -132,7 +132,7 @@ export async function persistBlockInput(this: BeaconChain, blockInput: IBlockInp
     .finally(() => {
       this.seenBlockInputCache.prune(blockInput.blockRootHex);
       // Without forcefully clearing this cache, we would rely on WeakMap to evict memory which is not reliable.
-      // Clear here (after the DB write) so that writeBlockInputToDb can still use the cached serialized bytes.
+      // Delete after the DB write so that writeBlockInputToDb can still use the cached serialized bytes.
       this.serializedCache.delete(blockInput.getSerializedCacheKeys());
       this.logger.debug("Pruned block input", {
         slot: blockInput.slot,

--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -3,13 +3,7 @@ import {SignedBeaconBlock} from "@lodestar/types";
 import {fromHex, toRootHex} from "@lodestar/utils";
 import {getBlobKzgCommitments} from "../../util/dataColumns.js";
 import {BeaconChain} from "../chain.js";
-import {
-  IBlockInput,
-  IDataColumnsInput,
-  isBlockInputBlobs,
-  isBlockInputColumns,
-  isBlockInputNoData,
-} from "./blockInput/index.js";
+import {IBlockInput, IDataColumnsInput, isBlockInputBlobs, isBlockInputColumns} from "./blockInput/index.js";
 import {BLOB_AVAILABILITY_TIMEOUT} from "./verifyBlocksDataAvailability.js";
 
 /**
@@ -137,17 +131,7 @@ export async function persistBlockInput(this: BeaconChain, blockInput: IBlockInp
     })
     .finally(() => {
       this.seenBlockInputCache.prune(blockInput.blockRootHex);
-      // Without forcefully clearing this cache, we would rely on WeakMap to evict memory which is not reliable.
-      // Clear here (after the DB write) so that writeBlockInputToDb can still use the cached serialized bytes.
-      //
-      // For Gloas (BlockInputNoData), the execution payload and columns arrive separately after the beacon block.
-      // Do NOT clear the cache here — it must remain available for writeDataColumnsToDb when the payload arrives.
-      // The cache is cleared in the Gloas payload persistence path instead.
-      if (!isBlockInputNoData(blockInput)) {
-        // TODO: enhance this SerializedCache for Gloas because payload may not come
-        // see https://github.com/ChainSafe/lodestar/pull/8974#discussion_r2885598229
-        this.serializedCache.clear();
-      }
+      this.serializedCache.delete(blockInput.getSerializedCacheKeys());
       this.logger.debug("Pruned block input", {
         slot: blockInput.slot,
         root: blockInput.blockRootHex,

--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -131,9 +131,6 @@ export async function persistBlockInput(this: BeaconChain, blockInput: IBlockInp
     })
     .finally(() => {
       this.seenBlockInputCache.prune(blockInput.blockRootHex);
-      // Without forcefully clearing this cache, we would rely on WeakMap to evict memory which is not reliable.
-      // Delete after the DB write so that writeBlockInputToDb can still use the cached serialized bytes.
-      this.serializedCache.delete(blockInput.getSerializedCacheKeys());
       this.logger.debug("Pruned block input", {
         slot: blockInput.slot,
         root: blockInput.blockRootHex,

--- a/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
+++ b/packages/beacon-node/src/chain/blocks/writeBlockInputToDb.ts
@@ -131,6 +131,8 @@ export async function persistBlockInput(this: BeaconChain, blockInput: IBlockInp
     })
     .finally(() => {
       this.seenBlockInputCache.prune(blockInput.blockRootHex);
+      // Without forcefully clearing this cache, we would rely on WeakMap to evict memory which is not reliable.
+      // Clear here (after the DB write) so that writeBlockInputToDb can still use the cached serialized bytes.
       this.serializedCache.delete(blockInput.getSerializedCacheKeys());
       this.logger.debug("Pruned block input", {
         slot: blockInput.slot,

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -320,12 +320,14 @@ export class BeaconChain implements IBeaconChain {
 
     this.beaconProposerCache = new BeaconProposerCache(opts);
     this.checkpointBalancesCache = new CheckpointBalancesCache();
+    this.serializedCache = new SerializedCache();
     this.seenBlockInputCache = new SeenBlockInput({
       config,
       custodyConfig: this.custodyConfig,
       clock,
       chainEvents: emitter,
       signal,
+      serializedCache: this.serializedCache,
       metrics,
       logger,
     });
@@ -411,8 +413,6 @@ export class BeaconChain implements IBeaconChain {
     this.regen = regen;
     this.bls = bls;
     this.emitter = emitter;
-
-    this.serializedCache = new SerializedCache();
 
     this.getBlobsTracker = new GetBlobsTracker({
       logger,

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -440,6 +440,7 @@ export class SeenBlockInput {
   }
 
   private evictBlockInput(blockInput: IBlockInput): void {
+    // Without forcefully clearing this cache, we would rely on WeakMap to evict memory which is not reliable
     this.serializedCache.delete(blockInput.getSerializedCacheKeys());
     this.blockInputs.delete(blockInput.blockRootHex);
   }

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -17,6 +17,7 @@ import {Metrics} from "../../metrics/metrics.js";
 import {MAX_LOOK_AHEAD_EPOCHS} from "../../sync/constants.js";
 import {IClock} from "../../util/clock.js";
 import {CustodyConfig} from "../../util/dataColumns.js";
+import {SerializedCache} from "../../util/serializedCache.js";
 import {
   BlockInput,
   BlockInputBlobs,
@@ -55,6 +56,7 @@ export type SeenBlockInputCacheModules = {
   chainEvents: ChainEventEmitter;
   signal: AbortSignal;
   custodyConfig: CustodyConfig;
+  serializedCache: SerializedCache;
   metrics: Metrics | null;
   logger?: Logger;
 };
@@ -101,6 +103,7 @@ export class SeenBlockInput {
   private readonly clock: IClock;
   private readonly chainEvents: ChainEventEmitter;
   private readonly signal: AbortSignal;
+  private readonly serializedCache: SerializedCache;
   private readonly metrics: Metrics | null;
   private readonly logger?: Logger;
   private blockInputs = new Map<RootHex, IBlockInput>();
@@ -109,19 +112,35 @@ export class SeenBlockInput {
   // and the signature to ensure we only skip verification if both match
   private verifiedProposerSignatures = new Map<Slot, Map<RootHex, BLSSignature>>();
 
-  constructor({config, custodyConfig, clock, chainEvents, signal, metrics, logger}: SeenBlockInputCacheModules) {
+  constructor({
+    config,
+    custodyConfig,
+    clock,
+    chainEvents,
+    signal,
+    serializedCache,
+    metrics,
+    logger,
+  }: SeenBlockInputCacheModules) {
     this.config = config;
     this.custodyConfig = custodyConfig;
     this.clock = clock;
     this.chainEvents = chainEvents;
     this.signal = signal;
+    this.serializedCache = serializedCache;
     this.metrics = metrics;
     this.logger = logger;
 
     if (metrics) {
-      metrics.seenCache.blockInput.blockInputCount.addCollect(() =>
-        metrics.seenCache.blockInput.blockInputCount.set(this.blockInputs.size)
-      );
+      metrics.seenCache.blockInput.blockInputCount.addCollect(() => {
+        metrics.seenCache.blockInput.blockInputCount.set(this.blockInputs.size);
+        metrics.seenCache.blockInput.serializedObjectCount.set(
+          Array.from(this.blockInputs.values()).reduce(
+            (count, blockInput) => count + blockInput.getSerializedCacheKeys().length,
+            0
+          )
+        );
+      });
     }
 
     this.chainEvents.on(ChainEvent.forkChoiceFinalized, this.onFinalized);
@@ -142,7 +161,10 @@ export class SeenBlockInput {
    * Removes the single BlockInput from the cache
    */
   remove(rootHex: RootHex): void {
-    this.blockInputs.delete(rootHex);
+    const blockInput = this.blockInputs.get(rootHex);
+    if (blockInput) {
+      this.evictBlockInput(blockInput);
+    }
   }
 
   /**
@@ -154,7 +176,7 @@ export class SeenBlockInput {
     let deletedCount = 0;
     while (blockInput) {
       deletedCount++;
-      this.blockInputs.delete(blockInput.blockRootHex);
+      this.evictBlockInput(blockInput);
       blockInput = this.blockInputs.get(parentRootHex ?? "");
       parentRootHex = blockInput?.parentRootHex;
     }
@@ -165,10 +187,10 @@ export class SeenBlockInput {
   onFinalized = (checkpoint: CheckpointWithHex) => {
     let deletedCount = 0;
     const cutoffSlot = computeStartSlotAtEpoch(checkpoint.epoch);
-    for (const [rootHex, blockInput] of this.blockInputs) {
+    for (const [, blockInput] of this.blockInputs) {
       if (blockInput.slot < cutoffSlot) {
         deletedCount++;
-        this.blockInputs.delete(rootHex);
+        this.evictBlockInput(blockInput);
       }
     }
     this.logger?.debug(`BlockInputCache.onFinalized deleted ${deletedCount} cached BlockInputs`);
@@ -408,13 +430,18 @@ export class SeenBlockInput {
 
     if (itemsToDelete > 0) {
       const sorted = [...this.blockInputs.entries()].sort((a, b) => a[1].slot - b[1].slot);
-      for (const [rootHex] of sorted) {
-        this.blockInputs.delete(rootHex);
+      for (const [, blockInput] of sorted) {
+        this.evictBlockInput(blockInput);
         itemsToDelete--;
         if (itemsToDelete <= 0) return;
       }
     }
     pruneSetToMax(this.verifiedProposerSignatures, MAX_BLOCK_INPUT_CACHE_SIZE);
+  }
+
+  private evictBlockInput(blockInput: IBlockInput): void {
+    this.serializedCache.delete(blockInput.getSerializedCacheKeys());
+    this.blockInputs.delete(blockInput.blockRootHex);
   }
 }
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1461,6 +1461,10 @@ export function createLodestarMetrics(
           name: "lodestar_seen_block_input_cache_size",
           help: "Number of cached BlockInputs",
         }),
+        serializedObjectCount: register.gauge({
+          name: "lodestar_seen_block_input_cache_serialized_object_count",
+          help: "Number of serialized objects retained by cached BlockInputs",
+        }),
         duplicateBlockCount: register.gauge<{source: BlockInputSource}>({
           name: "lodestar_seen_block_input_cache_duplicate_block_count",
           help: "Total number of duplicate blocks that pass validation and attempt to be cached but are known",

--- a/packages/beacon-node/src/network/network.ts
+++ b/packages/beacon-node/src/network/network.ts
@@ -539,7 +539,8 @@ export class Network implements INetwork {
         this.config.getForkSeq(this.clock.currentSlot) >= ForkSeq.altair ? [Version.V2] : [Version.V2, Version.V1],
         request
       ),
-      request
+      request,
+      this.chain.serializedCache
     );
   }
 

--- a/packages/beacon-node/src/util/serializedCache.ts
+++ b/packages/beacon-node/src/util/serializedCache.ts
@@ -14,6 +14,11 @@ export class SerializedCache {
     this.map.set(obj, serialized);
   }
 
+  /**
+   * Delete cached serialized entries for the provided object identities.
+   * Must only be called after all DB writes that may read from this cache have completed,
+   * otherwise cached serialized bytes will be unavailable and data will be re-serialized unnecessarily.
+   */
   delete(objs: object[]): void {
     for (const obj of objs) {
       this.map.delete(obj);

--- a/packages/beacon-node/src/util/serializedCache.ts
+++ b/packages/beacon-node/src/util/serializedCache.ts
@@ -15,7 +15,7 @@ export class SerializedCache {
   }
 
   /**
-   * Delete cached serialized entries for the provided object identities.
+   * Delete cached serialized entries for the provided object references.
    * Must only be called after all DB writes that may read from this cache have completed,
    * otherwise cached serialized bytes will be unavailable and data will be re-serialized unnecessarily.
    */

--- a/packages/beacon-node/src/util/serializedCache.ts
+++ b/packages/beacon-node/src/util/serializedCache.ts
@@ -16,7 +16,7 @@ export class SerializedCache {
 
   /**
    * Delete cached serialized entries for the provided object references.
-   * Must only be called after all DB writes that may read from this cache have completed,
+   * Must only be called after all DB writes that read from this cache for these objects have completed,
    * otherwise cached serialized bytes will be unavailable and data will be re-serialized unnecessarily.
    */
   delete(objs: object[]): void {

--- a/packages/beacon-node/src/util/serializedCache.ts
+++ b/packages/beacon-node/src/util/serializedCache.ts
@@ -1,5 +1,7 @@
 /**
- * Cache serialized bytes keyed by object identity.
+ * A cache to store the serialized version of an object
+ *
+ * This is a thin wrapper around WeakMap
  */
 export class SerializedCache {
   private map: WeakMap<object, Uint8Array> = new WeakMap();

--- a/packages/beacon-node/src/util/serializedCache.ts
+++ b/packages/beacon-node/src/util/serializedCache.ts
@@ -1,10 +1,8 @@
 /**
- * A cache to store the serialized version of an object
- *
- * This is a thin wrapper around WeakMap
+ * Cache serialized bytes keyed by object identity.
  */
 export class SerializedCache {
-  map: WeakMap<object, Uint8Array> = new WeakMap();
+  private map: WeakMap<object, Uint8Array> = new WeakMap();
 
   get(obj: object): Uint8Array | undefined {
     return this.map.get(obj);
@@ -14,12 +12,9 @@ export class SerializedCache {
     this.map.set(obj, serialized);
   }
 
-  /**
-   * Replace the internal WeakMap to force GC of all cached entries.
-   * Must only be called after all DB writes that may read from this cache have completed,
-   * otherwise cached serialized bytes will be unavailable and data will be re-serialized unnecessarily.
-   */
-  clear(): void {
-    this.map = new WeakMap();
+  delete(objs: object[]): void {
+    for (const obj of objs) {
+      this.map.delete(obj);
+    }
   }
 }

--- a/packages/beacon-node/test/unit/chain/seenCache/seenBlockInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/seenCache/seenBlockInput.test.ts
@@ -17,6 +17,7 @@ import {SeenBlockInput} from "../../../../src/chain/seenCache/seenGossipBlockInp
 import {computeNodeIdFromPrivateKey} from "../../../../src/network/subnets/index.js";
 import {Clock} from "../../../../src/util/clock.js";
 import {CustodyConfig} from "../../../../src/util/dataColumns.js";
+import {SerializedCache} from "../../../../src/util/serializedCache.js";
 import {
   config,
   generateBlock,
@@ -29,6 +30,7 @@ describe("SeenBlockInputCache", async () => {
   let cache: SeenBlockInput;
   let abortController: AbortController;
   let chainEvents: ChainEventEmitter;
+  let serializedCache: SerializedCache;
 
   const privateKey = await generateKeyPair("secp256k1");
   const nodeId = computeNodeIdFromPrivateKey(privateKey);
@@ -38,6 +40,7 @@ describe("SeenBlockInputCache", async () => {
   beforeEach(() => {
     chainEvents = new ChainEventEmitter();
     abortController = new AbortController();
+    serializedCache = new SerializedCache();
     const signal = abortController.signal;
     const genesisTime = Math.floor(Date.now() / 1000);
     cache = new SeenBlockInput({
@@ -46,6 +49,7 @@ describe("SeenBlockInputCache", async () => {
       clock: new Clock({config, genesisTime, signal}),
       chainEvents,
       signal,
+      serializedCache,
       logger,
       metrics: null,
     });
@@ -121,6 +125,21 @@ describe("SeenBlockInputCache", async () => {
       expect(cache.get(rootHex)).toBeUndefined();
     });
 
+    it("should remove serialized cache entries for the evicted BlockInput", () => {
+      const {block, rootHex} = generateBlock({forkName: ForkName.capella});
+      cache.getByBlock({
+        block,
+        blockRootHex: rootHex,
+        source: BlockInputSource.gossip,
+        seenTimestampSec: Date.now() / 1000,
+      });
+      serializedCache.set(block, new Uint8Array([1]));
+
+      expect(serializedCache.get(block)).toBeDefined();
+      cache.remove(rootHex);
+      expect(serializedCache.get(block)).toBeUndefined();
+    });
+
     it("should not throw an error if BlockInput not in cache", () => {
       const {block, blockRoot, rootHex} = generateBlock({forkName: ForkName.capella});
       const blockInput = cache.getByBlock({
@@ -179,6 +198,34 @@ describe("SeenBlockInputCache", async () => {
       expect(cache.get(childRootHex)).toBeUndefined();
       expect(cache.get(parentRootHex)).toBeUndefined();
     });
+
+    it("should remove serialized cache entries for the pruned BlockInputs", () => {
+      const blocks = generateChainOfBlocks({forkName: ForkName.capella, count: 2});
+      const parentBlock = blocks[0].block;
+      const parentRootHex = blocks[0].rootHex;
+      const childBlock = blocks[1].block;
+      const childRootHex = blocks[1].rootHex;
+
+      cache.getByBlock({
+        block: parentBlock,
+        blockRootHex: parentRootHex,
+        source: BlockInputSource.gossip,
+        seenTimestampSec: Date.now() / 1000,
+      });
+      cache.getByBlock({
+        block: childBlock,
+        blockRootHex: childRootHex,
+        source: BlockInputSource.gossip,
+        seenTimestampSec: Date.now() / 1000,
+      });
+      serializedCache.set(parentBlock, new Uint8Array([1]));
+      serializedCache.set(childBlock, new Uint8Array([2]));
+
+      cache.prune(childRootHex);
+
+      expect(serializedCache.get(parentBlock)).toBeUndefined();
+      expect(serializedCache.get(childBlock)).toBeUndefined();
+    });
   });
 
   describe("onFinalized()", () => {
@@ -215,6 +262,9 @@ describe("SeenBlockInputCache", async () => {
     });
 
     it("should remove all BlockInputs in slots before the checkpoint", () => {
+      serializedCache.set(parentBlockInput.getBlock(), new Uint8Array([1]));
+      serializedCache.set(childBlockInput.getBlock(), new Uint8Array([2]));
+
       chainEvents.emit(ChainEvent.forkChoiceFinalized, {
         epoch: config.DENEB_FORK_EPOCH,
         root,
@@ -223,6 +273,8 @@ describe("SeenBlockInputCache", async () => {
       });
       expect(cache.get(childRootHex)).toBeUndefined();
       expect(cache.get(parentRootHex)).toBeUndefined();
+      expect(serializedCache.get(parentBlockInput.getBlock())).toBeUndefined();
+      expect(serializedCache.get(childBlockInput.getBlock())).toBeUndefined();
     });
 
     it("should not remove BlockInputs in slots after the checkpoint", () => {

--- a/packages/beacon-node/test/utils/blockInput.ts
+++ b/packages/beacon-node/test/utils/blockInput.ts
@@ -91,6 +91,10 @@ export class MockBlockInput implements IBlockInput {
     return this._timeCompleted ?? 0;
   }
 
+  getSerializedCacheKeys(): object[] {
+    return this._block ? [this._block] : [];
+  }
+
   waitForAllData(_timeout: number, _signal?: AbortSignal): Promise<DAData> {
     return Promise.resolve(null);
   }


### PR DESCRIPTION
- add `getSerializedCacheKeys()` to block input variants
- more closely couple `SerializedCache` and `SeenBlockInput`
- delete only relevant serialized cache object references after block input is written
- remove global `SerializedCache.clear()` usage to avoid premature cache eviction