### PR TITLE
fix(epbs): set attestation index from FULL variant availability

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -1016,7 +1016,10 @@ export function getValidatorApi(
         // - 0 = EMPTY / not present, 1 = FULL / present
         // - same-slot attestations must always use index = 0
         if (canonicalBlock.slot !== slot) {
-          index = canonicalBlock.payloadStatus === PayloadStatus.FULL ? 1 : 0;
+          // Use FULL-variant availability for this beacon block root, not only the current
+          // canonical variant. The canonical view can temporarily prefer EMPTY for tiebreaking
+          // while the FULL sibling already exists and should be attested as payload-present.
+          index = chain.forkChoice.getBlock(beaconBlockRoot, PayloadStatus.FULL) !== null ? 1 : 0;
         } else {
           index = 0;
         }


### PR DESCRIPTION
## Summary
Fix Gloas attestation index derivation for non-same-slot attestations when the attested block already has a FULL variant in fork-choice.

Before this patch, `produceAttestationData` used only the current canonical variant's `payloadStatus` for `attestation.data.index`:
- `index=1` iff canonical variant was `FULL`
- otherwise `index=0`

In missed-slot scenarios, canonical variant selection can temporarily prefer a non-FULL sibling while the FULL sibling already exists for the same block root. This caused index=0 votes where index=1 was expected for payload-present attestations.

Now, for non-same-slot attestations, we derive `index` from FULL-variant availability on the attested block root:
- FULL variant exists -> `index=1`
- FULL variant absent -> `index=0`

Same-slot behavior remains unchanged (`index=0`).

## Change
- `packages/beacon-node/src/api/impl/validator/index.ts`
  - use `chain.forkChoice.getBlock(beaconBlockRoot, PayloadStatus.FULL) !== null` for non-same-slot index selection

## Verification
- `pnpm lint`
- `pnpm test:unit packages/beacon-node/test/unit/api/impl/validator/produceAttestationData.test.ts`

## Context / Repro notes
Observed on local Kurtosis Lodestar-only minimal devnet while forcing missed slots by stopping VCs:
- attestation index output for the same attested root could fall back to `0` even after FULL sibling availability, causing index=1 participation to be underrepresented in missed-slot windows.
