### PR TITLE
refactor: clone state in processExecutionPayloadEnvelope

### DIFF
--- a/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
+++ b/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
@@ -61,7 +61,6 @@ export function computeNewStateRoot(
  * Compute the state root after processing an execution payload envelope.
  * Similar to `computeNewStateRoot` but for payload envelope processing.
  *
- * The `postBlockState` is mutated in place, callers must ensure it is not needed afterward.
  */
 export function computeEnvelopeStateRoot(
   metrics: Metrics | null,
@@ -74,13 +73,15 @@ export function computeEnvelopeStateRoot(
   };
 
   const processEnvelopeTimer = metrics?.blockPayload.executionPayloadEnvelopeProcessingTime.startTimer();
-  processExecutionPayloadEnvelope(postBlockState, signedEnvelope, false);
+  const postEnvelopeState = processExecutionPayloadEnvelope(postBlockState, signedEnvelope, false, {
+    dontTransferCache: true,
+  });
   processEnvelopeTimer?.();
 
   const hashTreeRootTimer = metrics?.stateHashTreeRootTime.startTimer({
     source: StateHashTreeRootSource.computeEnvelopeStateRoot,
   });
-  const stateRoot = postBlockState.hashTreeRoot();
+  const stateRoot = postEnvelopeState.hashTreeRoot();
   hashTreeRootTimer?.();
 
   return stateRoot;

--- a/packages/beacon-node/test/spec/presets/operations.test.ts
+++ b/packages/beacon-node/test/spec/presets/operations.test.ts
@@ -75,17 +75,16 @@ const operationFns: Record<string, BlockProcessFn<CachedBeaconStateAllForks>> = 
       signed_envelope: gloas.SignedExecutionPayloadEnvelope;
       execution: {execution_valid: boolean};
     }
-  ) => {
+  ): CachedBeaconStateAllForks | void => {
     const fork = state.config.getForkSeq(state.slot);
     if (fork >= ForkSeq.gloas) {
-      blockFns.processExecutionPayloadEnvelope(state as CachedBeaconStateGloas, testCase.signed_envelope, true);
-    } else {
-      blockFns.processExecutionPayload(fork, state as CachedBeaconStateBellatrix, testCase.body, {
-        executionPayloadStatus: testCase.execution.execution_valid
-          ? ExecutionPayloadStatus.valid
-          : ExecutionPayloadStatus.invalid,
-      });
+      return blockFns.processExecutionPayloadEnvelope(state as CachedBeaconStateGloas, testCase.signed_envelope, true);
     }
+    blockFns.processExecutionPayload(fork, state as CachedBeaconStateBellatrix, testCase.body, {
+      executionPayloadStatus: testCase.execution.execution_valid
+        ? ExecutionPayloadStatus.valid
+        : ExecutionPayloadStatus.invalid,
+    });
   },
 
   bls_to_execution_change: (state, testCase: {address_change: capella.SignedBLSToExecutionChange}) => {
@@ -120,7 +119,7 @@ const operationFns: Record<string, BlockProcessFn<CachedBeaconStateAllForks>> = 
   },
 };
 
-export type BlockProcessFn<T extends CachedBeaconStateAllForks> = (state: T, testCase: any) => void;
+export type BlockProcessFn<T extends CachedBeaconStateAllForks> = (state: T, testCase: any) => T | void;
 
 export type OperationsTestCase = {
   meta?: {bls_setting?: bigint};
@@ -141,7 +140,12 @@ const operations: TestRunnerFn<OperationsTestCase, BeaconStateAllForks> = (fork,
       const epoch = (state.fork as phase0.Fork).epoch;
       const cachedState = createCachedBeaconStateTest(state, getConfig(fork, epoch));
 
-      operationFn(cachedState, testcase);
+      const postState = operationFn(cachedState, testcase);
+      // processExecutionPayloadEnvelope returns the postState, other operations mutate the state in-place and return void
+      if (postState !== undefined) {
+        postState.commit();
+        return postState;
+      }
       state.commit();
       return state;
     },

--- a/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
+++ b/packages/state-transition/src/block/processExecutionPayloadEnvelope.ts
@@ -13,12 +13,19 @@ import {processConsolidationRequest} from "./processConsolidationRequest.ts";
 import {processDepositRequest} from "./processDepositRequest.ts";
 import {processWithdrawalRequest} from "./processWithdrawalRequest.ts";
 
-// This function does not call execution engine to verify payload. Need to call it from other place
+export type ProcessExecutionPayloadEnvelopeOpts = {
+  dontTransferCache?: boolean;
+};
+
+// Unlike other block processing functions which mutate state in-place, this function
+// clones the state and returns the post-state, similar to stateTransition().
+// This function does not call execution engine to verify payload. Need to call it from other place.
 export function processExecutionPayloadEnvelope(
   state: CachedBeaconStateGloas,
   signedEnvelope: gloas.SignedExecutionPayloadEnvelope,
-  verify: boolean
-): void {
+  verify: boolean,
+  opts?: ProcessExecutionPayloadEnvelopeOpts
+): CachedBeaconStateGloas {
   const envelope = signedEnvelope.message;
   const payload = envelope.payload;
   const fork = state.config.getForkSeq(envelope.slot);
@@ -27,42 +34,49 @@ export function processExecutionPayloadEnvelope(
     throw Error(`Execution payload envelope has invalid signature builderIndex=${envelope.builderIndex}`);
   }
 
-  validateExecutionPayloadEnvelope(state, envelope);
+  // .clone() before mutating state, similar to stateTransition()
+  const postState = state.clone(opts?.dontTransferCache) as CachedBeaconStateGloas;
+
+  validateExecutionPayloadEnvelope(postState, envelope);
 
   const requests = envelope.executionRequests;
 
   for (const deposit of requests.deposits) {
-    processDepositRequest(fork, state, deposit);
+    processDepositRequest(fork, postState, deposit);
   }
 
   for (const withdrawal of requests.withdrawals) {
-    processWithdrawalRequest(fork, state, withdrawal);
+    processWithdrawalRequest(fork, postState, withdrawal);
   }
 
   for (const consolidation of requests.consolidations) {
-    processConsolidationRequest(state, consolidation);
+    processConsolidationRequest(postState, consolidation);
   }
 
   // Queue the builder payment
-  const paymentIndex = SLOTS_PER_EPOCH + (state.slot % SLOTS_PER_EPOCH);
-  const payment = state.builderPendingPayments.get(paymentIndex).clone();
+  const paymentIndex = SLOTS_PER_EPOCH + (postState.slot % SLOTS_PER_EPOCH);
+  const payment = postState.builderPendingPayments.get(paymentIndex).clone();
   const amount = payment.withdrawal.amount;
 
   if (amount > 0) {
-    state.builderPendingWithdrawals.push(payment.withdrawal);
+    postState.builderPendingWithdrawals.push(payment.withdrawal);
   }
 
-  state.builderPendingPayments.set(paymentIndex, ssz.gloas.BuilderPendingPayment.defaultViewDU());
+  postState.builderPendingPayments.set(paymentIndex, ssz.gloas.BuilderPendingPayment.defaultViewDU());
 
   // Cache the execution payload hash
-  state.executionPayloadAvailability.set(state.slot % SLOTS_PER_HISTORICAL_ROOT, true);
-  state.latestBlockHash = payload.blockHash;
+  postState.executionPayloadAvailability.set(postState.slot % SLOTS_PER_HISTORICAL_ROOT, true);
+  postState.latestBlockHash = payload.blockHash;
 
-  if (verify && !byteArrayEquals(envelope.stateRoot, state.hashTreeRoot())) {
+  postState.commit();
+
+  if (verify && !byteArrayEquals(envelope.stateRoot, postState.hashTreeRoot())) {
     throw new Error(
-      `Envelope's state root does not match state envelope=${toRootHex(envelope.stateRoot)} state=${toRootHex(state.hashTreeRoot())}`
+      `Envelope's state root does not match state envelope=${toRootHex(envelope.stateRoot)} state=${toRootHex(postState.hashTreeRoot())}`
     );
   }
+
+  return postState;
 }
 
 function validateExecutionPayloadEnvelope(


### PR DESCRIPTION
## Summary
- Refactor `processExecutionPayloadEnvelope` to clone the beacon state before mutating it and return the post-state, matching the pattern used by `stateTransition()`
- Add `dontTransferCache` option to control SSZ cache transfer behavior during clone
- Update `computeEnvelopeStateRoot` and spec test runner to use the returned post-state

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm check-types` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)