### PR TITLE
chore: fix seen block input cache metrics

### DIFF
--- a/dashboards/lodestar_beacon_chain.json
+++ b/dashboards/lodestar_beacon_chain.json
@@ -330,7 +330,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(lodestar_seen_block_input_cache_duplicate_block_count[$rate_interval]) * 12",
+          "expr": "rate(lodestar_seen_block_input_cache_duplicate_block_total[$rate_interval]) * 12",
           "hide": false,
           "instant": false,
           "legendFormat": "duplicate_block_{{source}}",
@@ -343,7 +343,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(lodestar_seen_block_input_cache_duplicate_blob_count[$rate_interval]) * 12",
+          "expr": "rate(lodestar_seen_block_input_cache_duplicate_blob_total[$rate_interval]) * 12",
           "hide": false,
           "instant": false,
           "legendFormat": "duplicate_blob_{{source}}",
@@ -356,7 +356,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(lodestar_seen_block_input_cache_duplicate_column_count[$rate_interval]) * 12",
+          "expr": "rate(lodestar_seen_block_input_cache_duplicate_column_total[$rate_interval]) * 12",
           "hide": false,
           "instant": false,
           "legendFormat": "duplicate_columns_{{source}}",
@@ -369,7 +369,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(lodestar_seen_block_input_cache_items_created_by_block[$rate_interval]) * 12",
+          "expr": "rate(lodestar_seen_block_input_cache_items_created_by_block_total[$rate_interval]) * 12",
           "hide": false,
           "instant": false,
           "legendFormat": "created_by_block",
@@ -382,7 +382,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(lodestar_seen_block_input_cache_items_created_by_blob[$rate_interval]) * 12",
+          "expr": "rate(lodestar_seen_block_input_cache_items_created_by_blob_total[$rate_interval]) * 12",
           "hide": false,
           "instant": false,
           "legendFormat": "created_by_blob",
@@ -395,11 +395,24 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "lodestar_seen_block_input_cache_serialized_object_count",
+          "expr": "rate(lodestar_seen_block_input_cache_items_created_by_column_total[$rate_interval]) * 12",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "created_by_column",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "lodestar_seen_block_input_cache_serialized_object_refs",
           "instant": false,
           "legendFormat": "serialized_objects",
           "range": true,
-          "refId": "G"
+          "refId": "H"
         }
       ],
       "title": "Block Input",

--- a/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
+++ b/packages/beacon-node/src/chain/seenCache/seenGossipBlockInput.ts
@@ -134,7 +134,7 @@ export class SeenBlockInput {
     if (metrics) {
       metrics.seenCache.blockInput.blockInputCount.addCollect(() => {
         metrics.seenCache.blockInput.blockInputCount.set(this.blockInputs.size);
-        metrics.seenCache.blockInput.serializedObjectCount.set(
+        metrics.seenCache.blockInput.serializedObjectRefs.set(
           Array.from(this.blockInputs.values()).reduce(
             (count, blockInput) => count + blockInput.getSerializedCacheKeys().length,
             0
@@ -250,6 +250,7 @@ export class SeenBlockInput {
           peerIdStr,
         });
       }
+      this.metrics?.seenCache.blockInput.createdByBlock.inc();
       this.blockInputs.set(blockInput.blockRootHex, blockInput);
     }
 
@@ -349,7 +350,7 @@ export class SeenBlockInput {
         custodyColumns: this.custodyConfig.custodyColumns,
         sampledColumns: this.custodyConfig.sampledColumns,
       });
-      this.metrics?.seenCache.blockInput.createdByBlob.inc();
+      this.metrics?.seenCache.blockInput.createdByColumn.inc();
       this.blockInputs.set(blockRootHex, blockInput);
     }
 

--- a/packages/beacon-node/src/metrics/metrics/lodestar.ts
+++ b/packages/beacon-node/src/metrics/metrics/lodestar.ts
@@ -1461,32 +1461,36 @@ export function createLodestarMetrics(
           name: "lodestar_seen_block_input_cache_size",
           help: "Number of cached BlockInputs",
         }),
-        serializedObjectCount: register.gauge({
-          name: "lodestar_seen_block_input_cache_serialized_object_count",
-          help: "Number of serialized objects retained by cached BlockInputs",
+        serializedObjectRefs: register.gauge({
+          name: "lodestar_seen_block_input_cache_serialized_object_refs",
+          help: "Number of serialized-cache object refs retained by cached BlockInputs",
         }),
-        duplicateBlockCount: register.gauge<{source: BlockInputSource}>({
-          name: "lodestar_seen_block_input_cache_duplicate_block_count",
+        duplicateBlockCount: register.counter<{source: BlockInputSource}>({
+          name: "lodestar_seen_block_input_cache_duplicate_block_total",
           help: "Total number of duplicate blocks that pass validation and attempt to be cached but are known",
           labelNames: ["source"],
         }),
-        duplicateBlobCount: register.gauge<{source: BlockInputSource}>({
-          name: "lodestar_seen_block_input_cache_duplicate_blob_count",
+        duplicateBlobCount: register.counter<{source: BlockInputSource}>({
+          name: "lodestar_seen_block_input_cache_duplicate_blob_total",
           help: "Total number of duplicate blobs that pass validation and attempt to be cached but are known",
           labelNames: ["source"],
         }),
-        duplicateColumnCount: register.gauge<{source: BlockInputSource}>({
-          name: "lodestar_seen_block_input_cache_duplicate_column_count",
+        duplicateColumnCount: register.counter<{source: BlockInputSource}>({
+          name: "lodestar_seen_block_input_cache_duplicate_column_total",
           help: "Total number of duplicate columns that pass validation and attempt to be cached but are known",
           labelNames: ["source"],
         }),
-        createdByBlock: register.gauge({
-          name: "lodestar_seen_block_input_cache_items_created_by_block",
+        createdByBlock: register.counter({
+          name: "lodestar_seen_block_input_cache_items_created_by_block_total",
           help: "Number of BlockInputs created via a block being seen first",
         }),
-        createdByBlob: register.gauge({
-          name: "lodestar_seen_block_input_cache_items_created_by_blob",
+        createdByBlob: register.counter({
+          name: "lodestar_seen_block_input_cache_items_created_by_blob_total",
           help: "Number of BlockInputs created via a blob being seen first",
+        }),
+        createdByColumn: register.counter({
+          name: "lodestar_seen_block_input_cache_items_created_by_column_total",
+          help: "Number of BlockInputs created via a data column being seen first",
         }),
       },
     },


### PR DESCRIPTION
Fix `seenBlockInputCache` metrics to match actual behavior.
 - rename the serialized object metric so it reads as a gauge, not a counter
 - change duplicate / created metrics to counters with `_total`
 - fix cache creation accounting for block-first and column-first paths
 - update the Grafana dashboard queries accordingly