### PR TITLE
feat: schedule Fulu fork for Chiado testnet

### DIFF
--- a/packages/config/src/chainConfig/networks/chiado.ts
+++ b/packages/config/src/chainConfig/networks/chiado.ts
@@ -42,7 +42,7 @@ export const chiadoChainConfig: ChainConfig = {
   ELECTRA_FORK_EPOCH: 948224, // Thu Mar 06 2025 09:43:40 GMT+0000
   // Fulu
   FULU_FORK_VERSION: b("0x0600006f"),
-  FULU_FORK_EPOCH: Infinity,
+  FULU_FORK_EPOCH: 1353216, // Mon Mar 16 2026 09:33:00 GMT+0000
   // Gloas
   GLOAS_FORK_VERSION: b("0x0700006f"),
   GLOAS_FORK_EPOCH: Infinity,


### PR DESCRIPTION
## Summary

Sets `FULU_FORK_EPOCH` for the Chiado testnet (Gnosis Chain testnet).

- **Epoch**: 1353216
- **Slot**: 21651456
- **Timestamp**: 1773653580
- **UTC**: Mon Mar 16 2026 09:33:00

Matches the activation scheduled by other clients:
- Lighthouse: sigp/lighthouse#8954
- Nethermind: v1.36.1
- Erigon: erigontech/erigon#19681