### PR TITLE
fix(epbs): serve block-state checkpoint variants

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/state/utils.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/utils.ts
@@ -1,8 +1,8 @@
 import {PubkeyIndexMap} from "@chainsafe/pubkey-index-map";
 import {routes} from "@lodestar/api";
-import {CheckpointWithPayload, IForkChoice} from "@lodestar/fork-choice";
-import {GENESIS_SLOT} from "@lodestar/params";
-import {BeaconStateAllForks, CachedBeaconStateAllForks} from "@lodestar/state-transition";
+import {CheckpointWithPayload, IForkChoice, PayloadStatus} from "@lodestar/fork-choice";
+import {GENESIS_SLOT, isForkPostGloas} from "@lodestar/params";
+import {BeaconStateAllForks, CachedBeaconStateAllForks, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {BLSPubkey, Epoch, RootHex, Slot, ValidatorIndex, getValidatorStatus, phase0} from "@lodestar/types";
 import {fromHex} from "@lodestar/utils";
 import {IBeaconChain} from "../../../../chain/index.js";
@@ -41,11 +41,28 @@ export function resolveStateId(
   return blockSlot;
 }
 
+function getCanonicalCheckpointStateId(
+  chain: IBeaconChain,
+  inStateId: routes.beacon.StateId,
+  stateId: RootHex | Slot | CheckpointWithPayload
+): RootHex | Slot | CheckpointWithPayload {
+  if (inStateId !== "finalized" || typeof stateId === "string" || typeof stateId === "number") {
+    return stateId;
+  }
+
+  const checkpointSlot = computeStartSlotAtEpoch(stateId.epoch);
+  if (!isForkPostGloas(chain.config.getForkName(checkpointSlot))) {
+    return stateId;
+  }
+
+  return {...stateId, payloadStatus: PayloadStatus.EMPTY};
+}
+
 export async function getStateResponseWithRegen(
   chain: IBeaconChain,
   inStateId: routes.beacon.StateId
 ): Promise<{state: CachedBeaconStateAllForks | Uint8Array; executionOptimistic: boolean; finalized: boolean}> {
-  const stateId = resolveStateId(chain.forkChoice, inStateId);
+  const stateId = getCanonicalCheckpointStateId(chain, inStateId, resolveStateId(chain.forkChoice, inStateId));
 
   const res =
     typeof stateId === "string"

--- a/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
+++ b/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
@@ -74,6 +74,7 @@ export class ArchiveStore {
 
     if (opts.archiveMode === ArchiveMode.Frequency) {
       this.statesArchiverStrategy = new FrequencyStateArchiveStrategy(
+        this.chain.config,
         this.chain.regen,
         this.db,
         this.logger,

--- a/packages/beacon-node/src/chain/archiveStore/strategies/frequencyStateArchiveStrategy.ts
+++ b/packages/beacon-node/src/chain/archiveStore/strategies/frequencyStateArchiveStrategy.ts
@@ -1,5 +1,6 @@
+import {BeaconConfig} from "@lodestar/config";
 import {CheckpointWithPayload} from "@lodestar/fork-choice";
-import {SLOTS_PER_EPOCH} from "@lodestar/params";
+import {SLOTS_PER_EPOCH, isForkPostGloas} from "@lodestar/params";
 import {computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
 import {Epoch, RootHex, Slot} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
@@ -34,6 +35,7 @@ export enum FrequencyStateArchiveStep {
  */
 export class FrequencyStateArchiveStrategy implements StateArchiveStrategy {
   constructor(
+    private readonly config: BeaconConfig,
     private readonly regen: IStateRegenerator,
     private readonly db: IBeaconDb,
     private readonly logger: Logger,
@@ -109,7 +111,11 @@ export class FrequencyStateArchiveStrategy implements StateArchiveStrategy {
     // starting from Mar 2024, the finalized state could be from disk or in memory
     let timer = metrics?.processFinalizedCheckpoint.frequencyStateArchive.startTimer();
     // Convert fork-choice checkpoint to beacon-node checkpoint with payloadPresent
-    const finalizedHexPayload = fcCheckpointToHexPayload(finalized);
+    const finalizedSlot = computeStartSlotAtEpoch(finalized.epoch);
+    const finalizedHexPayload = fcCheckpointToHexPayload(
+      finalized,
+      isForkPostGloas(this.config.getForkName(finalizedSlot)) ? false : undefined
+    );
     const finalizedStateOrBytes = await this.regen.getCheckpointStateOrBytes(finalizedHexPayload);
     timer?.({step: FrequencyStateArchiveStep.GetFinalizedState});
 

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -39,6 +39,7 @@ import {
   computeSyncCommitteeRewards,
   getEffectiveBalanceIncrementsZeroInactive,
   getEffectiveBalancesFromStateBytes,
+  isParentBlockFull,
   processSlots,
 } from "@lodestar/state-transition";
 import {processExecutionPayloadEnvelope} from "@lodestar/state-transition/block";
@@ -384,11 +385,10 @@ export class BeaconChain implements IBeaconChain {
     const {checkpoint} = computeAnchorCheckpoint(config, anchorState);
     blockStateCache.add(anchorState);
     blockStateCache.setHeadState(anchorState);
-    // TODO: For Gloas, determine if anchor state is block state or payload state
-    // Pre-Gloas: payloadPresent is always true (execution payload embedded in block)
-    // Post-Gloas: Could be either - depends on whether anchor was loaded with payload processing
-    // For now, assume true
-    checkpointStateCache.add(checkpoint, anchorState, true);
+    const anchorPayloadPresent = isForkPostGloas(config.getForkName(anchorState.slot))
+      ? isParentBlockFull(anchorState as CachedBeaconStateGloas)
+      : true;
+    checkpointStateCache.add(checkpoint, anchorState, anchorPayloadPresent);
 
     const forkChoice = initializeForkChoice(
       config,

--- a/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
+++ b/packages/beacon-node/src/chain/stateCache/persistentCheckpointsCache.ts
@@ -878,7 +878,18 @@ export function toCheckpointHexPayload(checkpoint: phase0.Checkpoint, payloadPre
  * Maps PayloadStatus enum to boolean payloadPresent.
  * @throws Error if checkpoint has PENDING payload status (ambiguous which variant to use)
  */
-export function fcCheckpointToHexPayload(checkpoint: CheckpointWithPayload): CheckpointHexPayload {
+export function fcCheckpointToHexPayload(
+  checkpoint: CheckpointWithPayload,
+  payloadPresentOverride?: boolean
+): CheckpointHexPayload {
+  if (payloadPresentOverride !== undefined) {
+    return {
+      epoch: checkpoint.epoch,
+      rootHex: checkpoint.rootHex,
+      payloadPresent: payloadPresentOverride,
+    };
+  }
+
   const PayloadStatus = {PENDING: 0, EMPTY: 1, FULL: 2} as const;
 
   if (checkpoint.payloadStatus === PayloadStatus.PENDING) {

--- a/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
+++ b/packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts
@@ -1,9 +1,40 @@
-import {describe, expect, it} from "vitest";
+import {describe, expect, it, vi} from "vitest";
 import {toHexString} from "@chainsafe/ssz";
-import {getStateValidatorIndex} from "../../../../../../src/api/impl/beacon/state/utils.js";
+import {PayloadStatus} from "@lodestar/fork-choice";
+import {getStateResponseWithRegen, getStateValidatorIndex} from "../../../../../../src/api/impl/beacon/state/utils.js";
 import {generateCachedAltairState} from "../../../../../utils/state.js";
 
 describe("beacon state api utils", () => {
+  describe("getStateResponseWithRegen", () => {
+    it("uses the block-state variant for post-Gloas finalized checkpoints", async () => {
+      const config = {getForkName: () => "gloas"};
+      const checkpoint = {
+        epoch: 3,
+        root: Buffer.alloc(32, 0x11),
+        rootHex: "0x" + Buffer.alloc(32, 0x11).toString("hex"),
+        payloadStatus: PayloadStatus.FULL,
+      };
+      const response = {state: new Uint8Array([1, 2, 3]), executionOptimistic: false, finalized: true};
+      const getStateOrBytesByCheckpoint = vi.fn().mockResolvedValue(response);
+
+      const chain = {
+        config,
+        forkChoice: {
+          getFinalizedCheckpoint: () => checkpoint,
+          getFinalizedBlock: () => ({slot: 0}),
+        },
+        getStateOrBytesByCheckpoint,
+        getStateByStateRoot: vi.fn(),
+        getStateBySlot: vi.fn(),
+        getHistoricalStateBySlot: vi.fn(),
+        clock: {currentSlot: 0},
+      };
+
+      await expect(getStateResponseWithRegen(chain as any, "finalized")).resolves.toEqual(response);
+      expect(getStateOrBytesByCheckpoint).toHaveBeenCalledWith({...checkpoint, payloadStatus: PayloadStatus.EMPTY});
+    });
+  });
+
   describe("getStateValidatorIndex", () => {
     const state = generateCachedAltairState();
     const pubkey2index = state.epochCtx.pubkey2index;

--- a/packages/beacon-node/test/unit/chain/archiveStore/stateArchiver.test.ts
+++ b/packages/beacon-node/test/unit/chain/archiveStore/stateArchiver.test.ts
@@ -1,8 +1,40 @@
-import {describe, expect, it} from "vitest";
+import {describe, expect, it, vi} from "vitest";
+import {PayloadStatus} from "@lodestar/fork-choice";
 import {computeStartSlotAtEpoch} from "@lodestar/state-transition";
-import {computeStateSlotsToDelete} from "../../../../src/chain/archiveStore/strategies/frequencyStateArchiveStrategy.js";
+import {ArchiveMode} from "../../../../src/chain/archiveStore/interface.js";
+import {
+  FrequencyStateArchiveStrategy,
+  computeStateSlotsToDelete,
+} from "../../../../src/chain/archiveStore/strategies/frequencyStateArchiveStrategy.js";
+import {testLogger} from "../../../utils/logger.js";
 
 describe("state archiver task", () => {
+  describe("archiveState", () => {
+    it("reloads the block-state variant for post-Gloas finalized checkpoints", async () => {
+      const config = {getForkName: () => "gloas"};
+      const regen = {getCheckpointStateOrBytes: vi.fn().mockResolvedValue(new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0]))};
+      const db = {stateArchive: {putBinary: vi.fn().mockResolvedValue(undefined)}};
+      const strategy = new FrequencyStateArchiveStrategy(config, regen as any, db as any, testLogger(), {
+        archiveMode: ArchiveMode.Frequency,
+        archiveStateEpochFrequency: 1,
+      });
+      const checkpoint = {
+        epoch: 2,
+        root: Buffer.alloc(32, 0x22),
+        rootHex: "0x" + Buffer.alloc(32, 0x22).toString("hex"),
+        payloadStatus: PayloadStatus.FULL,
+      };
+
+      await strategy.archiveState(checkpoint);
+
+      expect(regen.getCheckpointStateOrBytes).toHaveBeenCalledWith({
+        epoch: checkpoint.epoch,
+        rootHex: checkpoint.rootHex,
+        payloadPresent: false,
+      });
+    });
+  });
+
   describe("computeStateSlotsToDelete", () => {
     const testCases: {
       id: string;


### PR DESCRIPTION
## Summary
- serve the block-state variant for Gloas finalized checkpoint state requests instead of the post-envelope payload-state variant
- archive finalized Gloas checkpoints using the block-state variant so historical checkpoint sync stays canonical across restarts
- detect anchor checkpoint payload presence from the loaded state instead of hardcoding `payloadPresent=true`

## Why
Fork choice currently records finalized Gloas checkpoints as `payloadStatus=FULL`. That is fine for fork-choice semantics, but it leaked into checkpoint-state serving and archival:
- `/eth/v2/debug/beacon/states/finalized` and related checkpoint-state lookups could return a post-envelope state
- archived finalized checkpoint states could persist the post-envelope variant
- restart initialization could cache a loaded anchor state under the wrong payload-present key

That broke cross-client checkpoint sync because other clients expect the canonical block-state variant, not the state after envelope application.

## Testing
- `pnpm lint`
- `pnpm check-types`
- `pnpm vitest run packages/beacon-node/test/unit/api/impl/beacon/state/utils.test.ts packages/beacon-node/test/unit/chain/archiveStore/stateArchiver.test.ts`

## Notes
AI-assisted patch and review.
