### PR TITLE
fix(reqresp): clear composed response timeout signals

### DIFF
--- a/packages/reqresp/src/request/index.ts
+++ b/packages/reqresp/src/request/index.ts
@@ -36,6 +36,39 @@ function scheduleStreamAbortIfNotClosed(stream: Stream, timeoutMs: number): void
   stream.addEventListener("close", onClose, {once: true});
 }
 
+type ClearableSignal = AbortSignal & {clear: () => void};
+
+function createRespSignal(signal: AbortSignal | undefined, timeoutMs: number): ClearableSignal {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signals = signal ? [signal, timeoutSignal] : [timeoutSignal];
+  const controller = new AbortController();
+
+  const clear = (): void => {
+    for (const entry of signals) {
+      entry.removeEventListener("abort", onAbort);
+    }
+  };
+
+  const onAbort = (): void => {
+    const reason = signals.find((entry) => entry.aborted)?.reason;
+    controller.abort(reason);
+    clear();
+  };
+
+  for (const entry of signals) {
+    if (entry.aborted) {
+      onAbort();
+      break;
+    }
+    entry.addEventListener("abort", onAbort);
+  }
+
+  const respSignal = controller.signal as ClearableSignal;
+  respSignal.clear = clear;
+
+  return respSignal;
+}
+
 export interface SendRequestOpts {
   /** The maximum time for complete response transfer. */
   respTimeoutMs?: number;
@@ -154,9 +187,7 @@ export async function* sendRequest(
     }
 
     // RESP_TIMEOUT: Maximum time for complete response transfer
-    const respSignal = signal
-      ? AbortSignal.any([signal, AbortSignal.timeout(RESP_TIMEOUT)])
-      : AbortSignal.timeout(RESP_TIMEOUT);
+    const respSignal = createRespSignal(signal, RESP_TIMEOUT);
 
     let responseError: Error | null = null;
     let responseFullyConsumed = false;
@@ -199,6 +230,7 @@ export async function* sendRequest(
           }
         }
       }
+      respSignal.clear();
       metrics?.outgoingClosedStreams?.inc({method});
       logger.verbose("Req  stream closed", logCtx);
     }

--- a/packages/reqresp/src/request/index.ts
+++ b/packages/reqresp/src/request/index.ts
@@ -50,6 +50,9 @@ function createRespSignal(signal: AbortSignal | undefined, timeoutMs: number): C
   };
 
   const onAbort = (): void => {
+    if (controller.signal.aborted) {
+      return;
+    }
     const reason = signals.find((entry) => entry.aborted)?.reason;
     controller.abort(reason);
     clear();


### PR DESCRIPTION
## Summary

Open the Lodestar side of the memory-leak mitigation by clearing composed response-timeout signals in req/resp request handling.

This is the Lodestar-local follow-up for the network-thread leak investigation in #8969. It addresses the req/resp timeout-signal retention path by replacing the `AbortSignal.any(...)` composition with a clearable composed signal and explicitly clearing listeners once the response stream is done.

This PR is intentionally scoped to the req/resp fix only.
The separate residual gossipsub topic-retention issue is being tracked upstream in `ChainSafe/js-libp2p-gossipsub#543`, and we can pick that up once a new libp2p release lands.

## Change

- add `createRespSignal()` helper in `packages/reqresp/src/request/index.ts`
- compose request signal + timeout signal via an `AbortController`
- remove abort listeners explicitly via `respSignal.clear()` after the response closes

## Validation

- `pnpm build`
- `pnpm lint` *(warning-only: pre-existing unused biome suppression in `packages/light-client/test/unit/webEsmBundle.browser.test.ts`)*

## AI disclosure

This PR was authored with AI assistance (Lodekeeper 🌟).
