### PR TITLE
feat: rate limit backoff sync

### DIFF
--- a/packages/beacon-node/src/network/reqresp/score.ts
+++ b/packages/beacon-node/src/network/reqresp/score.ts
@@ -64,6 +64,6 @@ export function onOutgoingReqRespError(e: RequestError, method: ReqRespMethod): 
     }
   }
 
-  // other errors like RequestErrorCode.RESP_RATE_LIMITED could come from ourself, not the peer so we should not penalize them
+  // other errors like RequestErrorCode.OUTGOING_REQUEST_SELF_RATE_LIMITED comes from us, not the peer so we should not penalize them
   return null;
 }

--- a/packages/beacon-node/src/sync/constants.ts
+++ b/packages/beacon-node/src/sync/constants.ts
@@ -69,3 +69,21 @@ export const MAX_CONCURRENT_REQUESTS = 2;
  * so having this constant too big is a waste of resources and peers may rate limit us.
  */
 export const MAX_LOOK_AHEAD_EPOCHS = 2;
+
+/**
+ * Maximum number of consecutive rate-limited download attempts per batch before giving up.
+ * Rate-limited attempts are tracked separately from regular download failures since they
+ * indicate the peer is healthy but throttling us — retrying with backoff is appropriate.
+ */
+export const MAX_RATE_LIMITED_RETRIES = 3;
+
+/**
+ * Initial delay in milliseconds before retrying a rate-limited batch download.
+ * Doubles on each consecutive rate-limited attempt up to {@link RATE_LIMITED_MAX_DELAY_MS}.
+ */
+export const RATE_LIMITED_INITIAL_DELAY_MS = 50;
+
+/**
+ * Maximum backoff delay in milliseconds for rate-limited batch retries.
+ */
+export const RATE_LIMITED_MAX_DELAY_MS = 200;

--- a/packages/beacon-node/src/sync/constants.ts
+++ b/packages/beacon-node/src/sync/constants.ts
@@ -5,10 +5,7 @@ export const PARALLEL_HEAD_CHAINS = 2;
 export const MIN_FINALIZED_CHAIN_VALIDATED_EPOCHS = 10;
 
 /** The number of times to retry a batch before it is considered failed. */
-// export const MAX_BATCH_DOWNLOAD_ATTEMPTS = 5;
-// this constant is increased a lot for peerDAS because we may have many failed download due to rate limit not implemented yet
-// TODO: change it back to 5 when this issue is implemented https://github.com/ChainSafe/lodestar/issues/8033
-export const MAX_BATCH_DOWNLOAD_ATTEMPTS = 20;
+export const MAX_BATCH_DOWNLOAD_ATTEMPTS = 5;
 
 /**
  * Consider batch faulty after downloading and processing this number of times

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -266,7 +266,12 @@ export class Batch {
    * Gives a list of peers from which this batch has had a failed download or processing attempt.
    */
   getFailedPeers(): PeerIdStr[] {
-    return [...this.failedDownloadAttempts, ...this.failedProcessingAttempts.flatMap((a) => a.peers)];
+    return [
+      ...this.failedDownloadAttempts,
+      ...this.failedProcessingAttempts.flatMap((a) => a.peers),
+      // TODO: should this get counted here? Will penalize peers for outbound rate limits
+      // ...this.rateLimitedPeers.keys(),
+    ];
   }
 
   getMetadata(): BatchMetadata {

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -7,10 +7,17 @@ import {IBlockInput} from "../../chain/blocks/blockInput/types.js";
 import {isDaOutOfRange} from "../../chain/blocks/blockInput/utils.js";
 import {BlockError, BlockErrorCode} from "../../chain/errors/index.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
+import {prettyPrintPeerIdStr} from "../../network/util.js";
 import {IClock} from "../../util/clock.js";
 import {CustodyConfig} from "../../util/dataColumns.js";
 import {PeerIdStr} from "../../util/peerId.js";
-import {MAX_BATCH_DOWNLOAD_ATTEMPTS, MAX_BATCH_PROCESSING_ATTEMPTS} from "../constants.js";
+import {
+  MAX_BATCH_DOWNLOAD_ATTEMPTS,
+  MAX_BATCH_PROCESSING_ATTEMPTS,
+  MAX_RATE_LIMITED_RETRIES,
+  RATE_LIMITED_INITIAL_DELAY_MS,
+  RATE_LIMITED_MAX_DELAY_MS,
+} from "../constants.js";
 import {DownloadByRangeRequests} from "../utils/downloadByRange.js";
 import {getBatchSlotRange, hashBlocks} from "./utils/index.js";
 
@@ -22,6 +29,8 @@ export enum BatchStatus {
   AwaitingDownload = "AwaitingDownload",
   /** The batch is being downloaded. */
   Downloading = "Downloading",
+  /** The batch download was rate-limited and is waiting for cooldown before retrying. */
+  RateLimited = "RateLimited",
   /** The batch has been completely downloaded and is ready for processing. */
   AwaitingProcessing = "AwaitingProcessing",
   /** The batch is being processed. */
@@ -56,6 +65,7 @@ export type DownloadSuccessState = {
 export type BatchState =
   | AwaitingDownloadState
   | {status: BatchStatus.Downloading; peer: PeerIdStr; blocks: IBlockInput[]}
+  | {status: BatchStatus.RateLimited; blocks: IBlockInput[]}
   | DownloadSuccessState
   | {status: BatchStatus.Processing; blocks: IBlockInput[]; attempt: Attempt}
   | {status: BatchStatus.AwaitingValidation; blocks: IBlockInput[]; attempt: Attempt};
@@ -64,6 +74,8 @@ export type BatchMetadata = {
   startEpoch: Epoch;
   status: BatchStatus;
 };
+
+export type RateLimitMeta = {timeout: number; retries: number};
 
 /**
  * Batches are downloaded at the first block of the epoch.
@@ -94,6 +106,8 @@ export class Batch {
   readonly executionErrorAttempts: Attempt[] = [];
   /** The number of download retries this batch has undergone due to a failed request. */
   private readonly failedDownloadAttempts: PeerIdStr[] = [];
+  /** Peers that are rate-limited (inbound or outbound) during download attempts */
+  readonly rateLimitedPeers = new Map<PeerIdStr, RateLimitMeta>();
   private readonly config: ChainForkConfig;
   private readonly clock: IClock;
   private readonly custodyConfig: CustodyConfig;
@@ -329,6 +343,73 @@ export class Batch {
     }
 
     this.state = {status: BatchStatus.AwaitingDownload, blocks: this.state.blocks};
+  }
+
+  rateLimitDownload(): void {
+    if (this.state.status !== BatchStatus.AwaitingDownload) {
+      throw new BatchError(this.wrongStatusErrorType(BatchStatus.AwaitingDownload));
+    }
+
+    this.state = {status: BatchStatus.RateLimited, blocks: this.state.blocks};
+  }
+
+  rateLimitExpired(): void {
+    if (this.state.status !== BatchStatus.RateLimited) {
+      throw new BatchError(this.wrongStatusErrorType(BatchStatus.RateLimited));
+    }
+
+    this.state = {status: BatchStatus.AwaitingDownload, blocks: this.state.blocks};
+  }
+
+  /**
+   * Apply a cool down to the peer that rate-limit errored, either inbound or outbound, so that we
+   * do not retry that peer until cool down expires in the SyncChain.  Will return the delay to the
+   * caller and can piggy back on that to signal if the MAX_RATE_LIMIT_RETRIES has been exceeded.
+   * Should be a delay returned and if delay is 0 it means that the limit was hit and a download
+   * error occurred.
+   */
+  coolDownPeer(peer: PeerIdStr): number {
+    const rateLimit = this.rateLimitedPeers.get(peer) ?? {retries: 0, timeout: 0};
+
+    // check if timeout has already passed and reset as necessary
+    const now = Date.now();
+    if (rateLimit.timeout < now) {
+      rateLimit.retries = 0;
+      rateLimit.timeout = 0;
+    }
+
+    // TODO: should we apply and additional delay here so if the batch is picked up after the error
+    //       there is an enforced minimum wait (potentially the RATE_LIMITED_MAX_DELAY_MS).
+    if (rateLimit.retries >= MAX_RATE_LIMITED_RETRIES) {
+      return 0;
+    }
+
+    const delayMs = Math.min(RATE_LIMITED_INITIAL_DELAY_MS * 2 ** rateLimit.retries, RATE_LIMITED_MAX_DELAY_MS);
+    rateLimit.retries++;
+    rateLimit.timeout = now + delayMs;
+    this.rateLimitedPeers.set(peer, rateLimit);
+
+    return delayMs;
+  }
+
+  /**
+   * Returns the unix time for when the timeout expires.  If the timeout has passed delete the
+   * entry.  If there is not a rate-limit return epoch time of 0.
+   */
+  getPeerCoolTimeout(peer: PeerIdStr): number {
+    const rateLimit = this.rateLimitedPeers.get(peer);
+    if (!rateLimit) {
+      return 0;
+    }
+
+    // check if timeout has already passed and delete
+    const coolDownMs = rateLimit.timeout - Date.now();
+    if (coolDownMs < 1) {
+      this.rateLimitedPeers.delete(peer);
+      return 0;
+    }
+
+    return rateLimit.timeout;
   }
 
   /**

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -7,7 +7,6 @@ import {IBlockInput} from "../../chain/blocks/blockInput/types.js";
 import {isDaOutOfRange} from "../../chain/blocks/blockInput/utils.js";
 import {BlockError, BlockErrorCode} from "../../chain/errors/index.js";
 import {PeerSyncMeta} from "../../network/peers/peersData.js";
-import {prettyPrintPeerIdStr} from "../../network/util.js";
 import {IClock} from "../../util/clock.js";
 import {CustodyConfig} from "../../util/dataColumns.js";
 import {PeerIdStr} from "../../util/peerId.js";
@@ -106,7 +105,10 @@ export class Batch {
   readonly executionErrorAttempts: Attempt[] = [];
   /** The number of download retries this batch has undergone due to a failed request. */
   private readonly failedDownloadAttempts: PeerIdStr[] = [];
-  /** Peers that are rate-limited (inbound or outbound) during download attempts */
+  /**
+   * Peers that are rate-limited (inbound or outbound) during download attempts
+   * Note that this is unbounded and entries do not get deleted except with the batch itself
+   */
   readonly rateLimitedPeers = new Map<PeerIdStr, RateLimitMeta>();
   private readonly config: ChainForkConfig;
   private readonly clock: IClock;
@@ -409,8 +411,8 @@ export class Batch {
   }
 
   /**
-   * Returns the unix time for when the timeout expires.  If the timeout has passed delete the
-   * entry.  If there is not a rate-limit return epoch time of 0.
+   * Returns the unix time for when the timeout expires.  If the timeout has passed reset the
+   * timeout.  If there is not a rate-limit return epoch time of 0.
    */
   getPeerCoolDownTimeout(peer: PeerIdStr): number {
     const rateLimit = this.rateLimitedPeers.get(peer);

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -383,7 +383,7 @@ export class Batch {
   /**
    * Apply a cool down to the peer that rate-limit errored, either inbound or outbound, so that we
    * do not retry that peer until cool down expires in the SyncChain.  Will return the delay to the
-   * caller and can piggy back on that to signal if the MAX_RATE_LIMIT_RETRIES has been exceeded.
+   * caller and can piggy back on that to signal if the MAX_RATE_LIMITED_RETRIES has been exceeded.
    * Should be a delay returned and if delay is 0 it means that the limit was hit and a download
    * error occurred.
    */
@@ -396,9 +396,10 @@ export class Batch {
       rateLimit.timeout = 0;
     }
 
-    // TODO: should we apply and additional delay here so if the batch is picked up after the error
-    //       there is an enforced minimum wait (potentially the RATE_LIMITED_MAX_DELAY_MS).
+    // Apply max delay here so if the batch is picked up after a retry error there is an enforced
+    // minimum wait on the next download attempt
     if (rateLimit.count >= MAX_RATE_LIMITED_RETRIES) {
+      rateLimit.timeout = RATE_LIMITED_MAX_DELAY_MS;
       return 0;
     }
 
@@ -420,7 +421,7 @@ export class Batch {
       return 0;
     }
 
-    // check if timeout has already passed and delete
+    // check if timeout has already passed and reset timeout
     const coolDownMs = rateLimit.timeout - Date.now();
     if (coolDownMs < 1) {
       rateLimit.timeout = 0;

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -358,11 +358,12 @@ export class Batch {
     this.state = {status: BatchStatus.RateLimited, blocks: this.state.blocks};
   }
 
-  rateLimitExpired(): void {
+  rateLimitExpired(peer: PeerIdStr): void {
     if (this.state.status !== BatchStatus.RateLimited) {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.RateLimited));
     }
 
+    this.rateLimitedPeers.delete(peer);
     this.state = {status: BatchStatus.AwaitingDownload, blocks: this.state.blocks};
   }
 

--- a/packages/beacon-node/src/sync/range/batch.ts
+++ b/packages/beacon-node/src/sync/range/batch.ts
@@ -75,7 +75,7 @@ export type BatchMetadata = {
   status: BatchStatus;
 };
 
-export type RateLimitMeta = {timeout: number; retries: number};
+export type RateLimitMeta = {timeout: number; count: number};
 
 /**
  * Batches are downloaded at the first block of the epoch.
@@ -363,7 +363,18 @@ export class Batch {
       throw new BatchError(this.wrongStatusErrorType(BatchStatus.RateLimited));
     }
 
-    this.rateLimitedPeers.delete(peer);
+    const rateLimit = this.rateLimitedPeers.get(peer);
+    if (rateLimit) {
+      rateLimit.timeout = 0;
+    }
+    this.state = {status: BatchStatus.AwaitingDownload, blocks: this.state.blocks};
+  }
+
+  retryDownload(): void {
+    if (this.state.status !== BatchStatus.Downloading) {
+      throw new BatchError(this.wrongStatusErrorType(BatchStatus.Downloading));
+    }
+
     this.state = {status: BatchStatus.AwaitingDownload, blocks: this.state.blocks};
   }
 
@@ -375,23 +386,22 @@ export class Batch {
    * error occurred.
    */
   coolDownPeer(peer: PeerIdStr): number {
-    const rateLimit = this.rateLimitedPeers.get(peer) ?? {retries: 0, timeout: 0};
+    const rateLimit = this.rateLimitedPeers.get(peer) ?? {count: 0, timeout: 0};
 
     // check if timeout has already passed and reset as necessary
     const now = Date.now();
     if (rateLimit.timeout < now) {
-      rateLimit.retries = 0;
       rateLimit.timeout = 0;
     }
 
     // TODO: should we apply and additional delay here so if the batch is picked up after the error
     //       there is an enforced minimum wait (potentially the RATE_LIMITED_MAX_DELAY_MS).
-    if (rateLimit.retries >= MAX_RATE_LIMITED_RETRIES) {
+    if (rateLimit.count >= MAX_RATE_LIMITED_RETRIES) {
       return 0;
     }
 
-    const delayMs = Math.min(RATE_LIMITED_INITIAL_DELAY_MS * 2 ** rateLimit.retries, RATE_LIMITED_MAX_DELAY_MS);
-    rateLimit.retries++;
+    const delayMs = Math.min(RATE_LIMITED_INITIAL_DELAY_MS * 2 ** rateLimit.count, RATE_LIMITED_MAX_DELAY_MS);
+    rateLimit.count++;
     rateLimit.timeout = now + delayMs;
     this.rateLimitedPeers.set(peer, rateLimit);
 
@@ -402,7 +412,7 @@ export class Batch {
    * Returns the unix time for when the timeout expires.  If the timeout has passed delete the
    * entry.  If there is not a rate-limit return epoch time of 0.
    */
-  getPeerCoolTimeout(peer: PeerIdStr): number {
+  getPeerCoolDownTimeout(peer: PeerIdStr): number {
     const rateLimit = this.rateLimitedPeers.get(peer);
     if (!rateLimit) {
       return 0;
@@ -411,7 +421,7 @@ export class Batch {
     // check if timeout has already passed and delete
     const coolDownMs = rateLimit.timeout - Date.now();
     if (coolDownMs < 1) {
-      this.rateLimitedPeers.delete(peer);
+      rateLimit.timeout = 0;
       return 0;
     }
 

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -517,7 +517,7 @@ export class SyncChain {
             this.reportPeer(peer.peerId, PeerAction.LowToleranceError, res.err.message);
         }
         // Not sure if we should be penalizing here so going with high tolerance error penalty
-        if (errCode === RequestErrorCode.RESP_RATE_LIMITED) {
+        if (errCode === RequestErrorCode.RESPONSE_ERROR_RATE_LIMITED) {
           this.reportPeer(peer.peerId, PeerAction.HighToleranceError, res.err.message);
         }
 

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -1,4 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
+import {RequestErrorCode} from "@lodestar/reqresp";
 import {Epoch, Root, Slot} from "@lodestar/types";
 import {ErrorAborted, LodestarError, Logger, toRootHex} from "@lodestar/utils";
 import {isBlockInputBlobs, isBlockInputColumns} from "../../chain/blocks/blockInput/blockInput.js";
@@ -515,6 +516,10 @@ export class SyncChain {
           case DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID:
             this.reportPeer(peer.peerId, PeerAction.LowToleranceError, res.err.message);
         }
+        // Not sure if we should be penalizing here so going with high tolerance error penalty
+        if (errCode === RequestErrorCode.RESP_RATE_LIMITED) {
+          this.reportPeer(peer.peerId, PeerAction.HighToleranceError, res.err.message);
+        }
 
         const isRateLimited = isRateLimitRequestError(errCode);
         if (isRateLimited) {
@@ -529,6 +534,7 @@ export class SyncChain {
               coolDownMs,
             });
             // No batch downloadingError in this case. Allow to fall through and get picked up by another peer
+            batch.retryDownload();
           } else {
             this.logger.debug("Batch download rate limited, max retries exhausted", {
               id: this.logId,

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -603,12 +603,6 @@ export class SyncChain {
           peer: prettyPrintPeerIdStr(peer.peerId),
         });
       }
-
-      // Preemptively request more blocks from peers whilst we process current blocks
-      //
-      // TODO(fulu): why is this second call here.  should fall through to the one below the catch block. commenting
-      //      for now and will resolve during PR process
-      // this.triggerBatchDownloader();
     } catch (e) {
       // bubble the error up to the main async iterable loop
       this.batchProcessor.end(e as Error);

--- a/packages/beacon-node/src/sync/range/chain.ts
+++ b/packages/beacon-node/src/sync/range/chain.ts
@@ -15,7 +15,7 @@ import {ItTrigger} from "../../util/itTrigger.js";
 import {PeerIdStr} from "../../util/peerId.js";
 import {WarnResult, wrapError} from "../../util/wrapError.js";
 import {BATCH_BUFFER_SIZE, EPOCHS_PER_BATCH, MAX_LOOK_AHEAD_EPOCHS} from "../constants.js";
-import {DownloadByRangeError, DownloadByRangeErrorCode} from "../utils/downloadByRange.js";
+import {DownloadByRangeError, DownloadByRangeErrorCode, isRateLimitRequestError} from "../utils/downloadByRange.js";
 import {RangeSyncType} from "../utils/remoteSyncType.js";
 import {Batch, BatchError, BatchErrorCode, BatchMetadata, BatchStatus} from "./batch.js";
 import {
@@ -420,7 +420,11 @@ export class SyncChain {
     // Note: Don't count batches in the AwaitingValidation state, to prevent stalling sync
     // if the current processing window is contained in a long range of skip slots.
     const batchesInBuffer = batches.filter((batch) => {
-      return batch.state.status === BatchStatus.Downloading || batch.state.status === BatchStatus.AwaitingProcessing;
+      return (
+        batch.state.status === BatchStatus.RateLimited ||
+        batch.state.status === BatchStatus.Downloading ||
+        batch.state.status === BatchStatus.AwaitingProcessing
+      );
     });
     if (batchesInBuffer.length > BATCH_BUFFER_SIZE) {
       return null;
@@ -457,13 +461,22 @@ export class SyncChain {
   /**
    * Requests the batch assigned to the given id from a given peer.
    */
-  private async sendBatch(batch: Batch, peer: PeerSyncMeta): Promise<void> {
+  private async sendBatch(batch: Batch, peer: PeerSyncInfo): Promise<void> {
     this.logger.verbose("Downloading batch", {
       id: this.logId,
       ...batch.getMetadata(),
       peer: prettyPrintPeerIdStr(peer.peerId),
     });
     try {
+      if (peer.timeout !== undefined) {
+        batch.rateLimitDownload();
+
+        const coolDownMs = peer.timeout - Date.now();
+        await new Promise((res) => setTimeout(res, coolDownMs));
+
+        batch.rateLimitExpired(peer.peerId);
+      }
+
       batch.startDownloading(peer.peerId);
 
       // wrapError ensures to never call both batch success() and batch error()
@@ -502,12 +515,37 @@ export class SyncChain {
           case DataColumnSidecarErrorCode.INCLUSION_PROOF_INVALID:
             this.reportPeer(peer.peerId, PeerAction.LowToleranceError, res.err.message);
         }
-        this.logger.verbose(
-          "Batch download error",
-          {id: this.logId, ...batch.getMetadata(), peer: prettyPrintPeerIdStr(peer.peerId)},
-          res.err
-        );
-        batch.downloadingError(peer.peerId); // Throws after MAX_DOWNLOAD_ATTEMPTS
+
+        const isRateLimited = isRateLimitRequestError(errCode);
+        if (isRateLimited) {
+          const coolDownMs = batch.coolDownPeer(peer.peerId);
+          const rateLimitedPeers = `[ ${[...batch.rateLimitedPeers.keys()].map(prettyPrintPeerIdStr).join(", ")} ]`;
+          if (coolDownMs > 0) {
+            this.logger.debug("Batch download rate limited", {
+              id: this.logId,
+              ...batch.getMetadata(),
+              peer: prettyPrintPeerIdStr(peer.peerId),
+              rateLimitedPeers,
+              coolDownMs,
+            });
+            // No batch downloadingError in this case. Allow to fall through and get picked up by another peer
+          } else {
+            this.logger.debug("Batch download rate limited, max retries exhausted", {
+              id: this.logId,
+              ...batch.getMetadata(),
+              peer: prettyPrintPeerIdStr(peer.peerId),
+              rateLimitedPeers,
+            });
+            batch.downloadingError(peer.peerId); // Throws after MAX_DOWNLOAD_ATTEMPTS
+          }
+        } else {
+          this.logger.verbose(
+            "Batch download error",
+            {id: this.logId, ...batch.getMetadata(), peer: prettyPrintPeerIdStr(peer.peerId)},
+            res.err
+          );
+          batch.downloadingError(peer.peerId); // Throws after MAX_DOWNLOAD_ATTEMPTS
+        }
       } else {
         this.logger.verbose("Batch download success", {
           id: this.logId,

--- a/packages/beacon-node/src/sync/range/utils/batches.ts
+++ b/packages/beacon-node/src/sync/range/utils/batches.ts
@@ -7,7 +7,7 @@ import {Batch, BatchStatus} from "../batch.js";
 /**
  * Validates that the status and ordering of batches is valid
  * ```
- * [AwaitingValidation]* [Processing]? [AwaitingDownload,Downloading,AwaitingProcessing]*
+ * [AwaitingValidation]* [Processing]? [AwaitingDownload,Downloading,RateLimited,AwaitingProcessing]*
  * ```
  */
 export function validateBatchesStatus(batches: Batch[]): void {
@@ -29,6 +29,7 @@ export function validateBatchesStatus(batches: Batch[]): void {
 
       case BatchStatus.AwaitingDownload:
       case BatchStatus.Downloading:
+      case BatchStatus.RateLimited:
       case BatchStatus.AwaitingProcessing:
         preProcessing++;
         break;
@@ -56,6 +57,7 @@ export function getNextBatchToProcess(batches: Batch[]): Batch | null {
       // There MUST be no AwaitingProcessing state after AwaitingDownload, Downloading, Processing
       case BatchStatus.AwaitingDownload:
       case BatchStatus.Downloading:
+      case BatchStatus.RateLimited:
       case BatchStatus.Processing:
         return null;
     }

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -11,9 +11,14 @@ import {ChainTarget} from "./chainTarget.js";
 
 export type PeerSyncInfo = PeerSyncMeta & {
   target: ChainTarget;
+  timeout?: number;
 };
 
-type PeerInfoColumn = {syncInfo: PeerSyncInfo; columns: number; hasEarliestAvailableSlots: boolean};
+type PeerInfoColumn = {
+  syncInfo: PeerSyncInfo;
+  columns: number;
+  hasEarliestAvailableSlots: boolean;
+};
 
 /**
  * Balance and organize peers to perform requests with a SyncChain
@@ -54,8 +59,8 @@ export class ChainPeersBalancer {
    * Return the most suitable peer to retry
    * Sort peers by (1) no failed request (2) less active requests, then pick first
    */
-  bestPeerToRetryBatch(batch: Batch): PeerSyncMeta | undefined {
-    if (batch.state.status !== BatchStatus.AwaitingDownload) {
+  bestPeerToRetryBatch(batch: Batch): PeerSyncInfo | undefined {
+    if (batch.state.status !== BatchStatus.AwaitingDownload && batch.state.status !== BatchStatus.RateLimited) {
       return;
     }
     const {columnsRequest} = batch.requests;
@@ -88,7 +93,7 @@ export class ChainPeersBalancer {
    * Return peers with 0 or no active requests that has a higher target slot than this batch and has columns we need.
    */
   idlePeerForBatch(batch: Batch): PeerSyncInfo | undefined {
-    if (batch.state.status !== BatchStatus.AwaitingDownload) {
+    if (batch.state.status !== BatchStatus.AwaitingDownload && batch.state.status !== BatchStatus.RateLimited) {
       return;
     }
     const eligiblePeers = this.filterPeers(batch, this.custodyConfig.sampledColumns, true);
@@ -110,10 +115,16 @@ export class ChainPeersBalancer {
     return undefined;
   }
 
-  private filterPeers(batch: Batch, requestColumns: number[], noActiveRequest: boolean): PeerInfoColumn[] {
+  private filterPeers(
+    batch: Batch,
+    requestColumns: number[],
+    noActiveRequest: boolean,
+    allowRateLimited = false
+  ): PeerInfoColumn[] {
     const eligiblePeers: PeerInfoColumn[] = [];
+    let hasCoolingDownPeers = false;
 
-    if (batch.state.status !== BatchStatus.AwaitingDownload) {
+    if (batch.state.status !== BatchStatus.AwaitingDownload && batch.state.status !== BatchStatus.RateLimited) {
       return eligiblePeers;
     }
 
@@ -133,6 +144,17 @@ export class ChainPeersBalancer {
 
       if (target.slot < batch.startSlot) {
         continue;
+      }
+
+      let timeout: number | undefined;
+      const coolDownTimeout = batch.getPeerCoolDownTimeout(peer.peerId);
+      if (coolDownTimeout !== 0) {
+        if (!allowRateLimited) {
+          hasCoolingDownPeers = true;
+          continue;
+        }
+
+        timeout = coolDownTimeout;
       }
 
       if (isForkPostFulu(batch.forkName) && this.syncType === RangeSyncType.Head) {
@@ -172,13 +194,16 @@ export class ChainPeersBalancer {
 
       if (columns.length > 0) {
         eligiblePeers.push({
-          syncInfo: peer,
+          syncInfo: {...peer, timeout},
           columns: columns.length,
           hasEarliestAvailableSlots: earliestAvailableSlot != null,
         });
       }
     }
 
+    if (eligiblePeers.length === 0 && hasCoolingDownPeers && !allowRateLimited) {
+      return this.filterPeers(batch, requestColumns, noActiveRequest, true);
+    }
     return eligiblePeers;
   }
 }

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -60,7 +60,7 @@ export class ChainPeersBalancer {
    * Sort peers by (1) no failed request (2) less active requests, then pick first
    */
   bestPeerToRetryBatch(batch: Batch): PeerSyncInfo | undefined {
-    if (batch.state.status !== BatchStatus.AwaitingDownload && batch.state.status !== BatchStatus.RateLimited) {
+    if (batch.state.status !== BatchStatus.AwaitingDownload) {
       return;
     }
     const {columnsRequest} = batch.requests;
@@ -93,7 +93,7 @@ export class ChainPeersBalancer {
    * Return peers with 0 or no active requests that has a higher target slot than this batch and has columns we need.
    */
   idlePeerForBatch(batch: Batch): PeerSyncInfo | undefined {
-    if (batch.state.status !== BatchStatus.AwaitingDownload && batch.state.status !== BatchStatus.RateLimited) {
+    if (batch.state.status !== BatchStatus.AwaitingDownload) {
       return;
     }
     const eligiblePeers = this.filterPeers(batch, this.custodyConfig.sampledColumns, true);
@@ -123,10 +123,6 @@ export class ChainPeersBalancer {
   ): PeerInfoColumn[] {
     const eligiblePeers: PeerInfoColumn[] = [];
     let hasCoolingDownPeers = false;
-
-    if (batch.state.status !== BatchStatus.AwaitingDownload && batch.state.status !== BatchStatus.RateLimited) {
-      return eligiblePeers;
-    }
 
     for (const peer of this.peers) {
       const {earliestAvailableSlot, target, peerId} = peer;

--- a/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
+++ b/packages/beacon-node/src/sync/range/utils/peerBalancer.ts
@@ -171,7 +171,11 @@ export class ChainPeersBalancer {
 
       if (!isForkPostFulu(batch.forkName)) {
         // pre-fulu logic, we don't care columns and earliestAvailableSlot
-        eligiblePeers.push({syncInfo: peer, columns: 0, hasEarliestAvailableSlots: false});
+        eligiblePeers.push({
+          syncInfo: {...peer, timeout},
+          columns: 0,
+          hasEarliestAvailableSlots: false,
+        });
         continue;
       }
 

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -568,7 +568,7 @@ export class BlockInputSync {
           // should look into req_resp metrics in this case
           downloadByRootMetrics?.error.inc({code: "req_resp", client: peerClient});
           switch (e.type.code) {
-            case RequestErrorCode.REQUEST_RATE_LIMITED:
+            case RequestErrorCode.RESPONSE_ERROR_RATE_LIMITED:
             case RequestErrorCode.REQUEST_TIMEOUT:
               // do not exclude peer for these errors
               break;

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -855,9 +855,8 @@ function requestsLogMeta({blocksRequest, blobsRequest, columnsRequest}: Download
  */
 export function isRateLimitRequestError(code: string | undefined): boolean {
   return (
-    code === RequestErrorCode.REQUEST_RATE_LIMITED ||
-    code === RequestErrorCode.REQUEST_SELF_RATE_LIMITED ||
-    code === RequestErrorCode.RESP_RATE_LIMITED
+    code === RequestErrorCode.OUTGOING_REQUEST_SELF_RATE_LIMITED ||
+    code === RequestErrorCode.RESPONSE_ERROR_RATE_LIMITED
   );
 }
 

--- a/packages/beacon-node/src/sync/utils/downloadByRange.ts
+++ b/packages/beacon-node/src/sync/utils/downloadByRange.ts
@@ -1,5 +1,6 @@
 import {ChainForkConfig} from "@lodestar/config";
 import {ForkPostDeneb, ForkPostFulu, ForkPreFulu, isForkPostFulu} from "@lodestar/params";
+import {RequestErrorCode} from "@lodestar/reqresp";
 import {SignedBeaconBlock, Slot, deneb, fulu, phase0} from "@lodestar/types";
 import {LodestarError, Logger, byteArrayEquals, fromHex, prettyPrintIndices, toRootHex} from "@lodestar/utils";
 import {
@@ -207,6 +208,13 @@ export async function downloadByRange({
       columnsRequest,
     });
   } catch (err) {
+    const errCode = (err as LodestarError<{code: string}>).type?.code;
+    // Let rate-limit errors propagate with original reqresp code so chain.ts
+    // can detect them via isRateLimitRequestError without code remapping.
+    if (isRateLimitRequestError(errCode)) {
+      throw err;
+    }
+
     throw new DownloadByRangeError({
       code: DownloadByRangeErrorCode.REQ_RESP_ERROR,
       reason: (err as Error).message,
@@ -840,6 +848,17 @@ function requestsLogMeta({blocksRequest, blobsRequest, columnsRequest}: Download
     logMeta.columnCount = columnsRequest.count;
   }
   return logMeta;
+}
+
+/**
+ * Check whether a reqresp error code indicates the request was rate-limited.
+ */
+export function isRateLimitRequestError(code: string | undefined): boolean {
+  return (
+    code === RequestErrorCode.REQUEST_RATE_LIMITED ||
+    code === RequestErrorCode.REQUEST_SELF_RATE_LIMITED ||
+    code === RequestErrorCode.RESP_RATE_LIMITED
+  );
 }
 
 export enum DownloadByRangeErrorCode {

--- a/packages/reqresp/src/ReqResp.ts
+++ b/packages/reqresp/src/ReqResp.ts
@@ -4,7 +4,7 @@ import type {Libp2p} from "libp2p";
 import {Logger, MetricsRegisterExtra} from "@lodestar/utils";
 import {Metrics, getMetrics} from "./metrics.js";
 import {ReqRespRateLimiter} from "./rate_limiter/ReqRespRateLimiter.js";
-import {SelfRateLimiter} from "./rate_limiter/selfRateLimiter.js";
+import {SelfRateLimiter} from "./rate_limiter/selfRateLimiter.ts";
 import {RequestError, RequestErrorCode, SendRequestOpts, sendRequest} from "./request/index.js";
 import {handleRequest} from "./response/index.js";
 import {
@@ -176,8 +176,8 @@ export class ReqResp {
 
       if (!this.selfRateLimiter.allows(peerIdStr, protocolID, requestId)) {
         // we technically don't send request in this case but would be nice just to track this in the same `outgoingErrorReasons` metric
-        this.metrics?.outgoingErrorReasons.inc({reason: RequestErrorCode.REQUEST_SELF_RATE_LIMITED});
-        throw new RequestError({code: RequestErrorCode.REQUEST_SELF_RATE_LIMITED});
+        this.metrics?.outgoingErrorReasons.inc({reason: RequestErrorCode.OUTGOING_REQUEST_SELF_RATE_LIMITED});
+        throw new RequestError({code: RequestErrorCode.OUTGOING_REQUEST_SELF_RATE_LIMITED});
         // don't call this.onOutgoingRequestError() to penalize peer
       }
 

--- a/packages/reqresp/src/request/errors.ts
+++ b/packages/reqresp/src/request/errors.ts
@@ -26,11 +26,11 @@ export enum RequestErrorCode {
   /** Response transfer timeout exceeded */
   RESP_TIMEOUT = "REQUEST_ERROR_RESP_TIMEOUT",
   /** Request rate limited */
-  REQUEST_RATE_LIMITED = "REQUEST_ERROR_RATE_LIMITED",
+  INCOMING_REQUEST_RATE_LIMITED = "REQUEST_ERROR_RATE_LIMITED",
   /** Request self rate limited */
-  REQUEST_SELF_RATE_LIMITED = "REQUEST_ERROR_SELF_RATE_LIMITED",
+  OUTGOING_REQUEST_SELF_RATE_LIMITED = "REQUEST_ERROR_SELF_RATE_LIMITED",
   /** Response rate limited */
-  RESP_RATE_LIMITED = "RESPONSE_ERROR_RATE_LIMITED",
+  RESPONSE_ERROR_RATE_LIMITED = "RESPONSE_ERROR_RATE_LIMITED",
   /** For malformed SSZ (metadata) responses */
   SSZ_OVER_MAX_SIZE = "SSZ_SNAPPY_ERROR_OVER_SSZ_MAX_SIZE",
 }
@@ -47,9 +47,9 @@ type RequestErrorType =
   | {code: RequestErrorCode.REQUEST_ERROR; error: Error}
   | {code: RequestErrorCode.EMPTY_RESPONSE}
   | {code: RequestErrorCode.RESP_TIMEOUT}
-  | {code: RequestErrorCode.REQUEST_RATE_LIMITED}
-  | {code: RequestErrorCode.REQUEST_SELF_RATE_LIMITED}
-  | {code: RequestErrorCode.RESP_RATE_LIMITED}
+  | {code: RequestErrorCode.INCOMING_REQUEST_RATE_LIMITED}
+  | {code: RequestErrorCode.OUTGOING_REQUEST_SELF_RATE_LIMITED}
+  | {code: RequestErrorCode.RESPONSE_ERROR_RATE_LIMITED}
   | {code: RequestErrorCode.SSZ_OVER_MAX_SIZE};
 
 export const REQUEST_ERROR_CLASS_NAME = "RequestError";
@@ -78,7 +78,7 @@ export function responseStatusErrorToRequestError(e: ResponseError): RequestErro
   // refer to https://github.com/ChainSafe/lodestar/issues/8065#issuecomment-3157266196
   const errorMessageLowercase = errorMessage.toLowerCase();
   if (errorMessageLowercase.includes("rate limit")) {
-    return {code: RequestErrorCode.RESP_RATE_LIMITED};
+    return {code: RequestErrorCode.RESPONSE_ERROR_RATE_LIMITED};
   }
 
   // Grandine may return this without standard RespStatus, see https://github.com/ChainSafe/lodestar/issues/8110

--- a/packages/reqresp/src/response/index.ts
+++ b/packages/reqresp/src/response/index.ts
@@ -93,7 +93,7 @@ export async function handleRequest({
           const requestCount = protocol?.inboundRateLimits?.getRequestCount?.(requestBody) ?? 1;
 
           if (!rateLimiter.allows(peerId, protocolID, requestCount)) {
-            throw new RequestError({code: RequestErrorCode.REQUEST_RATE_LIMITED});
+            throw new RequestError({code: RequestErrorCode.INCOMING_REQUEST_RATE_LIMITED});
           }
 
           const requestChunk: ReqRespRequest = {

--- a/packages/reqresp/test/unit/rate_limiter/selfRateLimiter.test.ts
+++ b/packages/reqresp/test/unit/rate_limiter/selfRateLimiter.test.ts
@@ -3,7 +3,7 @@ import {
   CHECK_DISCONNECTED_PEERS_INTERVAL_MS,
   REQUEST_TIMEOUT_MS,
   SelfRateLimiter,
-} from "../../../src/rate_limiter/selfRateLimiter.js";
+} from "../../../src/rate_limiter/selfRateLimiter.ts";
 
 describe("SelfRateLimiter", () => {
   let selfRateLimiter: SelfRateLimiter;


### PR DESCRIPTION
**NOTE:** Leaving open in draft as a placeholder.  Need to investigate moving the rate limiting to the peer level so that its applicable across all req/resp.  This approach does not handle separate batches or chains requesting from a single peer and the peer sends a rate limit error back on one of the requests.  All others batches/chains will still attempt the request.  This is insufficient


Replaces #8924 

## Motivation

When peers respond with rate-limit errors during range sync, the retry logic immediately re-requests from the same peer, creating a death spiral:

Closes https://github.com/ChainSafe/lodestar/issues/8033