### PR TITLE
docs(reqresp): add upstream issue reference to createRespSignal

### DIFF
--- a/packages/reqresp/src/request/index.ts
+++ b/packages/reqresp/src/request/index.ts
@@ -38,6 +38,17 @@ function scheduleStreamAbortIfNotClosed(stream: Stream, timeoutMs: number): void
 
 type ClearableSignal = AbortSignal & {clear: () => void};
 
+/**
+ * Compose an abort signal from an optional parent signal and a timeout, with explicit cleanup.
+ *
+ * This replaces a plain `AbortSignal.any([signal, AbortSignal.timeout(timeoutMs)])` to work
+ * around a memory leak in Node.js where AbortSignal.any() retains references to all source
+ * signals for the lifetime of the longest-lived signal (the timeout). In a long-running
+ * req/resp workload this causes unbounded growth of the dependent-signal set.
+ *
+ * Upstream issue: https://github.com/nodejs/node/issues/54614
+ * Lodestar investigation: https://github.com/ChainSafe/lodestar/issues/8969
+ */
 function createRespSignal(signal: AbortSignal | undefined, timeoutMs: number): ClearableSignal {
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
   const signals = signal ? [signal, timeoutSignal] : [timeoutSignal];


### PR DESCRIPTION
## Summary

Add a JSDoc comment to `createRespSignal()` in `packages/reqresp/src/request/index.ts` documenting the upstream Node.js issue that motivates the manual `AbortController` composition pattern.

Follow-up to #9029 per [review feedback](https://github.com/ChainSafe/lodestar/pull/9029#discussion_r2931776412) — the code should document _why_ we avoid `AbortSignal.any()` and link to the upstream issue for future maintainers.

## References

- Upstream: https://github.com/nodejs/node/issues/54614 (`AbortSignal.any()` memory leak)
- Investigation: #8969
- Fix PR: #9029

## AI disclosure

This PR was authored with AI assistance (Lodekeeper 🌟).
