### PR TITLE
chore: replace BuildJet runners with GitHub runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   run:
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     # Skip for dependabot PRs, secrets are not made available and will fail
     # Don't run on forks. Forks don't have access to the S3 credentials and the workflow will fail
     if: |

--- a/.github/workflows/build-debug-node.yml
+++ b/.github/workflows/build-debug-node.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     name: Build Debug version of Node.js
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,9 +25,9 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: buildjet-4vcpu-ubuntu-2204
+            runner: ubuntu-22.04
           - arch: arm64
-            runner: buildjet-4vcpu-ubuntu-2204-arm
+            runner: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/kurtosis.yml
+++ b/.github/workflows/kurtosis.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     timeout-minutes: 60
     name: Build and run Kurtosis
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test-sim.yml
+++ b/.github/workflows/test-sim.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -36,7 +36,7 @@ jobs:
   sim-test-multifork:
     name: Multifork sim test
     needs: build
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -65,7 +65,7 @@ jobs:
   sim-test-endpoints:
     name: Endpoint sim tests
     needs: build
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -94,7 +94,7 @@ jobs:
   sim-test-eth-backup-provider:
     name: Eth backup provider sim tests
     needs: build
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -123,7 +123,7 @@ jobs:
   sim-test-mixed-clients:
     name: Mixed clients sim tests
     needs: build
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
       # <common-build> - Uses YAML anchors in the future
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -85,7 +85,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     needs: type-checks
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -123,7 +123,7 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     needs: build
     strategy:
       fail-fast: false
@@ -160,7 +160,7 @@ jobs:
 
   browser-tests:
     name: Browser Tests
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     needs: build
     strategy:
       fail-fast: false
@@ -183,7 +183,7 @@ jobs:
   spec-tests:
     name: Spec tests
     needs: build
-    runs-on: buildjet-4vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

Replace all BuildJet CI runners with GitHub-hosted runners.

### Changes

| Workflow | BuildJet Runner | GitHub Runner |
|---|---|---|
| benchmark | `buildjet-4vcpu-ubuntu-2204` | `ubuntu-22.04` |
| build-debug-node | `buildjet-4vcpu-ubuntu-2204` | `ubuntu-22.04` |
| codeql-analysis | `buildjet-4vcpu-ubuntu-2204` | `ubuntu-22.04` |
| docker (amd64) | `buildjet-4vcpu-ubuntu-2204` | `ubuntu-22.04` |
| docker (arm64) | `buildjet-4vcpu-ubuntu-2204-arm` | `ubuntu-22.04-arm` |
| kurtosis | `buildjet-4vcpu-ubuntu-2204` | `ubuntu-22.04` |
| test-sim | `buildjet-4vcpu-ubuntu-2204` | `ubuntu-22.04` |
| test | `buildjet-4vcpu-ubuntu-2204` | `ubuntu-22.04` |

7 files changed, 16 substitutions total.

> This PR was authored by Lodekeeper 🌟 with AI assistance.