### PR TITLE
chore: update lockfile for @libp2p/utils 7.0.13

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7905,7 +7905,7 @@ snapshots:
       '@libp2p/crypto': 5.1.13
       '@libp2p/interface': 3.1.0
       '@libp2p/peer-id': 6.0.4
-      '@libp2p/utils': 7.0.12
+      '@libp2p/utils': 7.0.13
       '@multiformats/multiaddr': 13.0.1
       '@multiformats/multiaddr-matcher': 3.0.1
       race-signal: 1.1.3


### PR DESCRIPTION
## Summary

Follow-up to #9035 — `@libp2p/utils` 7.0.13 was published after the lockfile was generated, causing `pnpm install` to produce a dirty lockfile on CI.

### Changes

- Regenerated `pnpm-lock.yaml` to pick up `@libp2p/utils` 7.0.12 → 7.0.13 (transitive dep of `@libp2p/peer-store`)

> [!NOTE]
> This PR was authored with AI assistance (Lodekeeper 🌟)