### PR TITLE
perf(fork-choice): hoist proposerBoostRoot out of applyScoreChanges loop

### DIFF
--- a/packages/fork-choice/src/protoArray/protoArray.ts
+++ b/packages/fork-choice/src/protoArray/protoArray.ts
@@ -391,6 +391,7 @@ export class ProtoArray {
     // We _must_ perform these functions separate from the weight-updating loop above to ensure
     // that we have a fully coherent set of weights before updating parent
     // best-child/descendant.
+    const proposerBoostRoot = proposerBoost?.root ?? null;
     for (let nodeIndex = this.nodes.length - 1; nodeIndex >= 0; nodeIndex--) {
       const node = this.nodes[nodeIndex];
       if (node === undefined) {
@@ -403,7 +404,7 @@ export class ProtoArray {
       // If the node has a parent, try to update its best-child and best-descendant.
       const parentIndex = node.parent;
       if (parentIndex !== undefined) {
-        this.maybeUpdateBestChildAndDescendant(parentIndex, nodeIndex, currentSlot, proposerBoost?.root ?? null);
+        this.maybeUpdateBestChildAndDescendant(parentIndex, nodeIndex, currentSlot, proposerBoostRoot);
       }
     }
     // Update the previous proposer boost


### PR DESCRIPTION
## Description

In `applyScoreChanges`, the expression `proposerBoost?.root ?? null` was being evaluated on every iteration of the second loop (which iterates over all proto-array nodes in reverse). Since `proposerBoost` does not change during the loop, this is a loop-invariant computation that can be hoisted out.

This is a micro-optimization but it applies to a hot path — `applyScoreChanges` runs on every attestation/block import and iterates over all fork-choice nodes.

### Changes

- Hoist `proposerBoost?.root ?? null` into a `const proposerBoostRoot` before the loop
- Pass the pre-computed value to `maybeUpdateBestChildAndDescendant`

> This PR was authored with AI assistance (GitHub Copilot).