### PR TITLE
ci: add native module CPU portability check

### DIFF
--- a/.github/workflows/native-portability.yml
+++ b/.github/workflows/native-portability.yml
@@ -1,0 +1,42 @@
+name: Native portability
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "packages/*/package.json"
+      - "scripts/ci/check_native_portability.sh"
+  push:
+    branches: [unstable, stable]
+    paths:
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "packages/*/package.json"
+      - "scripts/ci/check_native_portability.sh"
+  workflow_dispatch:
+
+jobs:
+  check-native-portability:
+    name: Check native module portability
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c # v4
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install binutils
+        run: sudo apt-get install -y binutils
+
+      - name: Check native module CPU portability
+        run: bash scripts/ci/check_native_portability.sh

--- a/scripts/ci/check_native_portability.sh
+++ b/scripts/ci/check_native_portability.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# check_native_portability.sh
+#
+# Scans prebuilt native (.node) binaries for unconditional AVX/AVX2 usage.
+# Native modules that use AVX instructions MUST have CPUID-based runtime
+# dispatch to fall back on CPUs without AVX support (e.g. Intel Atom/Celeron).
+#
+# Catches issues like https://github.com/ChainSafe/lodestar/issues/9042
+# where a dependency was compiled with hard-coded -C target-feature=+avx2.
+
+set -euo pipefail
+
+EXIT_CODE=0
+
+echo "Checking native modules for CPU portability..."
+echo ""
+
+found=0
+while IFS= read -r node_file; do
+  found=1
+  # Relative path from node_modules for readable output
+  name=$(echo "$node_file" | sed 's|.*node_modules/||;s|/[^/]*\.node$||')
+
+  # Count AVX instructions (YMM register = 256-bit AVX)
+  ymm_count=$(objdump -d "$node_file" 2>/dev/null | grep -c "ymm" || true)
+
+  # Count CPUID calls (runtime CPU feature detection)
+  cpuid_count=$(objdump -d "$node_file" 2>/dev/null | grep -c "cpuid" || true)
+
+  if [ "$ymm_count" -gt 0 ] && [ "$cpuid_count" -eq 0 ]; then
+    echo "FAIL: $name"
+    echo "   $ymm_count AVX instructions, 0 CPUID dispatch calls"
+    echo "   Binary will crash with SIGILL on CPUs without AVX (e.g. Celeron N5105)"
+    EXIT_CODE=1
+  elif [ "$ymm_count" -gt 0 ]; then
+    echo "OK:   $name ($ymm_count AVX insns, $cpuid_count CPUID calls)"
+  else
+    echo "OK:   $name (no AVX)"
+  fi
+done < <(find node_modules -name "*.node" -path "*linux-x64*" ! -path "*/rollup/*" ! -path "*/swc/*" ! -path "*musl*" 2>/dev/null | sort)
+
+if [ "$found" -eq 0 ]; then
+  echo "No linux-x64 native modules found (skipped)."
+  exit 0
+fi
+
+echo ""
+if [ "$EXIT_CODE" -eq 0 ]; then
+  echo "All native modules have proper CPU feature detection"
+else
+  echo ""
+  echo "Some native modules use AVX without runtime CPU detection."
+  echo "These will crash with SIGILL (exit code 132) on CPUs without AVX support."
+  echo "See: https://github.com/ChainSafe/lodestar/issues/9042"
+fi
+
+exit $EXIT_CODE


### PR DESCRIPTION
## What

Adds a CI workflow that scans prebuilt native (`.node`) binaries for unconditional AVX/AVX2 instructions. Native modules using AVX **must** have CPUID-based runtime dispatch to avoid SIGILL crashes on CPUs without AVX support.

## Why

Closes #9042. A user running Lodestar v1.40.0 on a Celeron N5105 (no AVX) hit exit code 132 (SIGILL). Root cause: [`@vekexasia/bigint-buffer2@1.1.0`](https://github.com/vekexasia/bigint-swissknife/issues/6) is compiled with hard-coded `-C target-feature=+avx2,+bmi2`, producing 1292 AVX instructions with zero CPUID dispatch.

All other native modules in our tree (`blst`, `node-eth-kzg`, `hashtree`, `libp2p-quic`) have proper CPUID-based runtime detection.

## How it works

After `pnpm install`, the script:
1. Finds all `linux-x64` native `.node` files
2. Counts AVX instructions (YMM register references) via `objdump`
3. Counts CPUID calls (runtime CPU feature detection)
4. Fails if any module has AVX instructions but zero CPUID calls

Triggers on dependency changes (`package.json`, `pnpm-lock.yaml`) and on `workflow_dispatch`.

## Example output

```
✅ OK:   @chainsafe/blst-linux-x64-gnu (104 AVX insns, 9 CPUID calls)
✅ OK:   @chainsafe/hashtree-linux-x64-gnu (6067 AVX insns, 10 CPUID calls)
✅ OK:   @chainsafe/libp2p-quic-linux-x64-gnu (6755 AVX insns, 21 CPUID calls)
✅ OK:   @crate-crypto/node-eth-kzg-linux-x64-gnu (100 AVX insns, 11 CPUID calls)
❌ FAIL: @vekexasia/bigint-buffer2
   1292 AVX instructions, 0 CPUID dispatch calls
   Binary will crash with SIGILL on CPUs without AVX (e.g. Celeron N5105)
```

Upstream issue filed: https://github.com/vekexasia/bigint-swissknife/issues/6

---
> This PR was authored with AI assistance (Lodekeeper 🌟)