### PR TITLE
perf(types/electra): model Pending* electra types as ContainerNodeStructType

### DIFF
--- a/packages/state-transition/test/perf/epoch/processPendingDeposits.test.ts
+++ b/packages/state-transition/test/perf/epoch/processPendingDeposits.test.ts
@@ -1,0 +1,83 @@
+import {bench, describe} from "@chainsafe/benchmark";
+import {ContainerNodeStructType, ContainerType, ListCompositeType} from "@chainsafe/ssz";
+import {PENDING_DEPOSITS_LIMIT} from "@lodestar/params";
+import {ssz} from "@lodestar/types";
+
+// PERF: Cost is O(pendingDeposits.length). In the worst case (large deposit queue after a big network event),
+// this can be 50_000 items. Each item requires reading all 5 fields.
+//
+// Benchmarks ContainerType (current) vs ContainerNodeStructType (proposed) for field access performance.
+// ContainerNodeStructType stores items as plain JS objects, avoiding tree traversal on every field read.
+
+const NUM_DEPOSITS = 50_000;
+const CHUNK = 100;
+
+// Reuse the same field types as the existing PendingDeposit SSZ type
+const fields = ssz.electra.PendingDeposit.fields;
+
+const PendingDepositContainer = new ContainerType(fields, {typeName: "PendingDeposit", jsonCase: "eth2"});
+const PendingDepositNodeStruct = new ContainerNodeStructType(fields, {typeName: "PendingDeposit", jsonCase: "eth2"});
+
+const ListContainer = new ListCompositeType(PendingDepositContainer, PENDING_DEPOSITS_LIMIT);
+const ListNodeStruct = new ListCompositeType(PendingDepositNodeStruct, PENDING_DEPOSITS_LIMIT);
+
+function buildList(listType: typeof ListContainer): ReturnType<typeof ListContainer.defaultViewDU>;
+function buildList(listType: typeof ListNodeStruct): ReturnType<typeof ListNodeStruct.defaultViewDU>;
+function buildList(listType: typeof ListContainer | typeof ListNodeStruct) {
+  const view = listType.defaultViewDU();
+  const defaultDeposit = ssz.electra.PendingDeposit.defaultValue();
+  for (let i = 0; i < NUM_DEPOSITS; i++) {
+    if (listType === ListContainer) {
+      view.push(PendingDepositContainer.toViewDU(defaultDeposit));
+    } else {
+      view.push(PendingDepositNodeStruct.toViewDU(defaultDeposit));
+    }
+  }
+  view.commit();
+  return view;
+}
+
+describe.skip(`processPendingDeposits - iterate ${NUM_DEPOSITS} deposits, access all fields`, () => {
+  const containerListView = buildList(ListContainer);
+  const nodeStructListView = buildList(ListNodeStruct);
+
+  bench({
+    id: `ContainerType - getReadonlyByRange chunk=${CHUNK}`,
+    yieldEventLoopAfterEach: true,
+    fn: () => {
+      let sum = 0;
+      for (let i = 0; i < NUM_DEPOSITS; i += CHUNK) {
+        const deposits = containerListView.getReadonlyByRange(i, CHUNK);
+        for (const deposit of deposits) {
+          sum += deposit.amount + deposit.slot;
+          void deposit.pubkey;
+          void deposit.withdrawalCredentials;
+          void deposit.signature;
+        }
+      }
+      if (sum === Number.MIN_SAFE_INTEGER) {
+        throw new Error("unreachable");
+      }
+    },
+  });
+
+  bench({
+    id: `ContainerNodeStructType - getReadonlyByRange chunk=${CHUNK}`,
+    yieldEventLoopAfterEach: true,
+    fn: () => {
+      let sum = 0;
+      for (let i = 0; i < NUM_DEPOSITS; i += CHUNK) {
+        const deposits = nodeStructListView.getReadonlyByRange(i, CHUNK);
+        for (const deposit of deposits) {
+          sum += deposit.amount + deposit.slot;
+          void deposit.pubkey;
+          void deposit.withdrawalCredentials;
+          void deposit.signature;
+        }
+      }
+      if (sum === Number.MIN_SAFE_INTEGER) {
+        throw new Error("unreachable");
+      }
+    },
+  });
+});

--- a/packages/types/src/electra/sszTypes.ts
+++ b/packages/types/src/electra/sszTypes.ts
@@ -286,7 +286,7 @@ export const PendingDeposit = new ContainerNodeStructType(
 
 export const PendingDeposits = new ListCompositeType(PendingDeposit, PENDING_DEPOSITS_LIMIT);
 
-export const PendingPartialWithdrawal = new ContainerType(
+export const PendingPartialWithdrawal = new ContainerNodeStructType(
   {
     validatorIndex: ValidatorIndex,
     amount: Gwei,
@@ -300,7 +300,7 @@ export const PendingPartialWithdrawals = new ListCompositeType(
   PENDING_PARTIAL_WITHDRAWALS_LIMIT
 );
 
-export const PendingConsolidation = new ContainerType(
+export const PendingConsolidation = new ContainerNodeStructType(
   {
     sourceIndex: ValidatorIndex,
     targetIndex: ValidatorIndex,

--- a/packages/types/src/electra/sszTypes.ts
+++ b/packages/types/src/electra/sszTypes.ts
@@ -1,6 +1,7 @@
 import {
   BitListType,
   BitVectorType,
+  ContainerNodeStructType,
   ContainerType,
   ListBasicType,
   ListCompositeType,
@@ -270,7 +271,7 @@ export const SignedBuilderBid = new ContainerType(
   {typeName: "SignedBuilderBid", jsonCase: "eth2"}
 );
 
-export const PendingDeposit = new ContainerType(
+export const PendingDeposit = new ContainerNodeStructType(
   {
     pubkey: BLSPubkey,
     withdrawalCredentials: Bytes32,


### PR DESCRIPTION
**Motivation**

`processPendingDeposits`, `processPendingConsolidations`, and related epoch functions iterate over up to tens of thousands of `PendingDeposit`, `PendingPartialWithdrawal`, and `PendingConsolidation` items per epoch transition, reading all fields on each item. These were backed by `ContainerType`, which stores each item as a Merkle tree node — every field read requires tree traversal.

`ContainerNodeStructType` stores items as plain JS objects (structs), reducing field access to a direct property lookup. A benchmark with 50,000 items and chunked iteration (matching the real access pattern) shows a **~33x speedup**: 12.8 ops/s → 417 ops/s.

```
processPendingDeposits - iterate 50000 deposits, access all fields
    ✔ ContainerType - getReadonlyByRange chunk=100                        12.79264 ops/s    78.16995 ms/op        -         12 runs   1.47 s
    ✔ ContainerNodeStructType - getReadonlyByRange chunk=100              417.2092 ops/s    2.396879 ms/op        -         60 runs  0.968 s
```

**Description**

- Model `PendingDeposit`, `PendingPartialWithdrawal`, and `PendingConsolidation` in `packages/types/src/electra/sszTypes.ts` as `ContainerNodeStructType` instead of `ContainerType`
- Add benchmark `packages/state-transition/test/perf/epoch/processPendingDeposits.test.ts` comparing both types with 50,000 items; benchmark is skipped in CI

**AI Assistance Disclosure**

Used Claude Code to explore the codebase, identify candidates, and write the benchmark.