### PR TITLE
chore: create GitHub releases as draft to support immutable releases

### DIFF
--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Publish to npm registry
         run: pnpm run release:publish --dist-tag rc
 
-      - name: Publish release (undraft after successful npm publish)
+      - name: Publish release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit ${{ needs.tag.outputs.tag }} --draft=false

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -88,6 +88,12 @@ jobs:
           body_path: "CHANGELOG.md"
           name: Release ${{ needs.tag.outputs.tag }}
           prerelease: true
+          draft: true
+
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit ${{ needs.tag.outputs.tag }} --draft=false
 
       - name: Change and commit version
         # Write version before publishing so it's picked up by `lerna publish from-package`.

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -90,11 +90,6 @@ jobs:
           prerelease: true
           draft: true
 
-      - name: Publish release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit ${{ needs.tag.outputs.tag }} --draft=false
-
       - name: Change and commit version
         # Write version before publishing so it's picked up by `lerna publish from-package`.
         # It must also be committed to ensure a clean git tree, otherwise `lerna publish` errors.
@@ -113,6 +108,11 @@ jobs:
 
       - name: Publish to npm registry
         run: pnpm run release:publish --dist-tag rc
+
+      - name: Publish release (undraft after successful npm publish)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit ${{ needs.tag.outputs.tag }} --draft=false
 
       # In case of failure
       - name: Rollback on failure

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -96,13 +96,13 @@ jobs:
           prerelease: false
           draft: true
 
-      - name: Publish release
+      - name: Publish to npm registry (release)
+        run: pnpm run release:publish
+
+      - name: Publish release (undraft after successful npm publish)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit ${{ needs.tag.outputs.tag }} --draft=false
-
-      - name: Publish to npm registry (release)
-        run: pnpm run release:publish
 
       # In case of failure
       - name: Rollback on failure

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Publish to npm registry (release)
         run: pnpm run release:publish
 
-      - name: Publish release (undraft after successful npm publish)
+      - name: Publish release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit ${{ needs.tag.outputs.tag }} --draft=false

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -94,6 +94,12 @@ jobs:
           body_path: "CHANGELOG.md"
           name: Release ${{ needs.tag.outputs.tag }}
           prerelease: false
+          draft: true
+
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit ${{ needs.tag.outputs.tag }} --draft=false
 
       - name: Publish to npm registry (release)
         run: pnpm run release:publish


### PR DESCRIPTION
## What

Creates GitHub releases as draft first, uploads assets, then publishes (undrafts). Fixes the `Create Release` step failing on repos with immutable releases enabled.

## Why

Closes the RC publish failure: https://github.com/ChainSafe/lodestar/actions/runs/23205012815/job/67438769695

```
Error: Cannot upload asset lodestar-v1.41.0-rc.1-linux-arm64.tar.gz to an immutable release.
GitHub only allows asset uploads before a release is published...
```

GitHub's immutable releases feature fires `release.published` immediately for prereleases, making the release immutable before assets finish uploading. The fix: create as `draft: true`, upload assets, then `gh release edit --draft=false`.

## Changes

- **`publish-rc.yml`**: Add `draft: true` to release creation + publish step
- **`publish-stable.yml`**: Same fix for stable releases

The rollback step still works — it references `steps.create_release.outputs.id` which is set during draft creation.

> This PR was authored by Lodekeeper 🌟 with AI assistance.