### PR TITLE
feat: introduce nativeStateView feature flag

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
+++ b/packages/beacon-node/src/chain/archiveStore/archiveStore.ts
@@ -120,6 +120,7 @@ export class ArchiveStore {
         opts: {
           genesisTime: this.chain.clock.genesisTime,
           dbLocation: this.opts.dbName,
+          nativeStateView: this.opts.nativeStateView ?? false,
         },
         config: this.chain.config,
         metrics: this.metrics,

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
@@ -26,7 +26,7 @@ export async function getNearestState(
   }
 
   const stateBytes = stateBytesArr[0];
-  return createBeaconStateViewForHistoricalRegen(config, stateBytes, pubkeyCache);
+  return createBeaconStateViewForHistoricalRegen({useNative: false, config, stateBytes});
 }
 
 /**

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
@@ -3,7 +3,6 @@ import {
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
   IBeaconStateView,
-  type PubkeyCache,
   createBeaconStateViewForHistoricalRegen,
 } from "@lodestar/state-transition";
 import {byteArrayEquals} from "@lodestar/utils";
@@ -18,7 +17,7 @@ export async function getNearestState(
   slot: number,
   config: BeaconConfig,
   db: IBeaconDb,
-  pubkeyCache: PubkeyCache
+  nativeStateView: boolean
 ): Promise<IBeaconStateView> {
   const stateBytesArr = await db.stateArchive.binaries({limit: 1, lte: slot, reverse: true});
   if (!stateBytesArr.length) {
@@ -26,7 +25,9 @@ export async function getNearestState(
   }
 
   const stateBytes = stateBytesArr[0];
-  return createBeaconStateViewForHistoricalRegen({useNative: false, config, stateBytes});
+  return nativeStateView
+    ? createBeaconStateViewForHistoricalRegen({useNative: true, stateBytes})
+    : createBeaconStateViewForHistoricalRegen({useNative: false, config, stateBytes});
 }
 
 /**
@@ -36,13 +37,13 @@ export async function getHistoricalState(
   slot: number,
   config: BeaconConfig,
   db: IBeaconDb,
-  pubkeyCache: PubkeyCache,
+  nativeStateView: boolean,
   metrics?: HistoricalStateRegenMetrics
 ): Promise<Uint8Array> {
   const regenTimer = metrics?.regenTime.startTimer();
 
   const loadStateTimer = metrics?.loadStateTime.startTimer();
-  let state = await getNearestState(slot, config, db, pubkeyCache).catch((e) => {
+  let state = await getNearestState(slot, config, db, nativeStateView).catch((e) => {
     metrics?.regenErrorCount.inc({reason: RegenErrorType.loadState});
     throw e;
   });

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/historicalStateRegen.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/historicalStateRegen.ts
@@ -20,7 +20,7 @@ export class HistoricalStateRegen implements HistoricalStateWorkerApi {
   private readonly api: ModuleThread<HistoricalStateWorkerApi>;
   private readonly logger: LoggerNode;
 
-  constructor(modules: HistoricalStateRegenModules) {
+  private constructor(modules: HistoricalStateRegenModules) {
     this.api = modules.api;
     this.logger = modules.logger;
     modules.signal?.addEventListener("abort", () => this.close(), {once: true});
@@ -35,6 +35,7 @@ export class HistoricalStateRegen implements HistoricalStateWorkerApi {
       dbLocation: modules.opts.dbLocation,
       metricsEnabled: Boolean(modules.metrics),
       loggerOpts: modules.logger.toOpts(),
+      nativeStateView: modules.opts.nativeStateView,
     };
 
     const worker = new Worker(path.join(WORKER_DIR, "worker.js"), {

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/types.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/types.ts
@@ -7,6 +7,7 @@ export type HistoricalStateRegenInitModules = {
   opts: {
     genesisTime: number;
     dbLocation: string;
+    nativeStateView: boolean;
   };
   config: BeaconConfig;
   logger: LoggerNode;
@@ -26,6 +27,7 @@ export type HistoricalStateWorkerData = {
   dbLocation: string;
   metricsEnabled: boolean;
   loggerOpts: LoggerNodeOpts;
+  nativeStateView: boolean;
 };
 
 export type HistoricalStateWorkerApi = {

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
@@ -3,7 +3,6 @@ import {Transfer, expose} from "@chainsafe/threads/worker";
 import {chainConfigFromJson, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {getNodeLogger} from "@lodestar/logger/node";
-import {createPubkeyCache} from "@lodestar/state-transition";
 import {BeaconDb} from "../../../db/index.js";
 import {RegistryMetricCreator, collectNodeJSMetrics} from "../../../metrics/index.js";
 import {JobFnQueue} from "../../../util/queue/fnQueue.js";
@@ -52,9 +51,6 @@ const queue = new JobFnQueue(
   queueMetrics
 );
 
-// Reuse a single pubkey cache across all historical state regen calls in this worker
-const pubkeyCache = createPubkeyCache();
-
 const api: HistoricalStateWorkerApi = {
   async close() {
     abortController.abort();
@@ -66,7 +62,7 @@ const api: HistoricalStateWorkerApi = {
     historicalStateRegenMetrics?.regenRequestCount.inc();
 
     const stateBytes = await queue.push<Uint8Array>(() =>
-      getHistoricalState(slot, config, db, pubkeyCache, historicalStateRegenMetrics)
+      getHistoricalState(slot, config, db, workerData.nativeStateView, historicalStateRegenMetrics)
     );
     const result = Transfer(stateBytes, [stateBytes.buffer]) as unknown as Uint8Array;
 

--- a/packages/beacon-node/src/chain/archiveStore/interface.ts
+++ b/packages/beacon-node/src/chain/archiveStore/interface.ts
@@ -25,6 +25,7 @@ export type ArchiveStoreOpts = StatesArchiveOpts & {
   archiveDataEpochs?: number;
   pruneHistory?: boolean;
   serveHistoricalState?: boolean;
+  nativeStateView?: boolean;
 };
 
 export type ProposalStats = {

--- a/packages/beacon-node/src/chain/options.ts
+++ b/packages/beacon-node/src/chain/options.ts
@@ -47,6 +47,7 @@ export type IChainOptions = BlockProcessOpts &
     minSameMessageSignatureSetsToBatch: number;
     archiveDateEpochs?: number;
     nHistoricalStatesFileDataStore?: boolean;
+    nativeStateView?: boolean;
   };
 
 export type BlockProcessOpts = {
@@ -124,6 +125,7 @@ export const defaultChainOptions: IChainOptions = {
   //   - users can prune the persisted checkpoint state files manually to save disc space
   //   - it helps debug easier when network is unfinalized
   nHistoricalStatesFileDataStore: true,
+  nativeStateView: false,
   maxBlockStates: DEFAULT_MAX_BLOCK_STATES,
   maxCPStateEpochsInMemory: DEFAULT_MAX_CP_STATE_EPOCHS_IN_MEMORY,
   maxCPStateEpochsOnDisk: DEFAULT_MAX_CP_STATE_ON_DISK,

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -73,15 +73,16 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
   try {
     const {
       anchorState,
-      stateBytes: _anchorStateBytes,
+      stateBytes: anchorStateBytes,
       isFinalized,
       wsCheckpoint,
     } = await initBeaconState(args, beaconPaths.dataDir, config, db, logger);
     const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
     const pubkeyCache = createPubkeyCache();
     syncPubkeys(pubkeyCache, anchorState.validators.getAllReadonlyValues());
-    // Feature flag: use {useNative: true, stateBytes: anchorStateBytes} when Zig BeaconStateView is ready
-    const anchorStateView = createBeaconStateView({useNative: false, anchorState, config: beaconConfig, pubkeyCache});
+    const anchorStateView = args["chain.nativeStateView"]
+      ? createBeaconStateView({useNative: true, stateBytes: anchorStateBytes})
+      : createBeaconStateView({useNative: false, anchorState, config: beaconConfig, pubkeyCache});
 
     const node = await BeaconNode.init({
       opts: options,

--- a/packages/cli/src/cmds/beacon/handler.ts
+++ b/packages/cli/src/cmds/beacon/handler.ts
@@ -7,7 +7,7 @@ import {ChainForkConfig, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {LoggerNode, getNodeLogger} from "@lodestar/logger/node";
 import {ACTIVE_PRESET, PresetName} from "@lodestar/params";
-import {BeaconStateView, createCachedBeaconState, createPubkeyCache, syncPubkeys} from "@lodestar/state-transition";
+import {createBeaconStateView, createPubkeyCache, syncPubkeys} from "@lodestar/state-transition";
 import {ErrorAborted, bytesToInt, formatBytes} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
 import {BeaconNodeOptions, getBeaconConfigFromArgs} from "../../config/index.js";
@@ -71,24 +71,17 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
 
   // BeaconNode setup
   try {
-    const {anchorState, isFinalized, wsCheckpoint} = await initBeaconState(
-      args,
-      beaconPaths.dataDir,
-      config,
-      db,
-      logger
-    );
+    const {
+      anchorState,
+      stateBytes: _anchorStateBytes,
+      isFinalized,
+      wsCheckpoint,
+    } = await initBeaconState(args, beaconPaths.dataDir, config, db, logger);
     const beaconConfig = createBeaconConfig(config, anchorState.genesisValidatorsRoot);
     const pubkeyCache = createPubkeyCache();
     syncPubkeys(pubkeyCache, anchorState.validators.getAllReadonlyValues());
-    const cachedState = createCachedBeaconState(
-      anchorState,
-      {
-        config: beaconConfig,
-        pubkeyCache,
-      },
-      {skipSyncPubkeys: true}
-    );
+    // Feature flag: use {useNative: true, stateBytes: anchorStateBytes} when Zig BeaconStateView is ready
+    const anchorStateView = createBeaconStateView({useNative: false, anchorState, config: beaconConfig, pubkeyCache});
 
     const node = await BeaconNode.init({
       opts: options,
@@ -100,7 +93,7 @@ export async function beaconHandler(args: BeaconArgs & GlobalArgs): Promise<void
       privateKey,
       dataDir: beaconPaths.dataDir,
       peerStoreDir: beaconPaths.peerStoreDir,
-      anchorState: new BeaconStateView(cachedState),
+      anchorState: anchorStateView,
       isAnchorStateFinalized: isFinalized,
       wsCheckpoint,
     });

--- a/packages/cli/src/cmds/beacon/initBeaconState.ts
+++ b/packages/cli/src/cmds/beacon/initBeaconState.ts
@@ -40,7 +40,7 @@ async function initAndVerifyWeakSubjectivityState(
   isWsStateFinalized: boolean,
   wsCheckpoint: Checkpoint,
   opts: {forceCheckpointSync?: boolean; ignoreWeakSubjectivityCheck?: boolean} = {}
-): Promise<{anchorState: BeaconStateAllForks; wsCheckpoint: Checkpoint}> {
+): Promise<{anchorState: BeaconStateAllForks; stateBytes: Uint8Array; wsCheckpoint: Checkpoint}> {
   const dbState = dbStateBytes.state;
   const wsState = wsStateBytes.state;
   // Check if the store's state and wsState are compatible
@@ -82,7 +82,7 @@ async function initAndVerifyWeakSubjectivityState(
   }
 
   // Return the latest anchorState but still return original wsCheckpoint to validate in backfill
-  return {anchorState: anchorState.state, wsCheckpoint};
+  return {anchorState: anchorState.state, stateBytes: anchorState.stateBytes, wsCheckpoint};
 }
 
 /**
@@ -103,7 +103,12 @@ export async function initBeaconState(
   chainForkConfig: ChainForkConfig,
   db: IBeaconDb,
   logger: Logger
-): Promise<{anchorState: BeaconStateAllForks; isFinalized: boolean; wsCheckpoint?: Checkpoint}> {
+): Promise<{
+  anchorState: BeaconStateAllForks;
+  stateBytes: Uint8Array;
+  isFinalized: boolean;
+  wsCheckpoint?: Checkpoint;
+}> {
   if (args.forceCheckpointSync && !(args.checkpointState || args.checkpointSyncUrl || args.unsafeCheckpointState)) {
     throw new Error("Forced checkpoint sync without specifying a checkpointState or checkpointSyncUrl");
   }
@@ -166,7 +171,7 @@ export async function initBeaconState(
           stateRoot: toRootHex(lastDbState.hashTreeRoot()),
           isFinalized,
         });
-        return {anchorState: lastDbState, isFinalized};
+        return {anchorState: lastDbState, stateBytes, isFinalized};
       }
     }
   }
@@ -325,7 +330,7 @@ export async function initBeaconState(
       stateRoot,
       isFinalized,
     });
-    return {anchorState, isFinalized};
+    return {anchorState, stateBytes, isFinalized};
   }
 
   throw Error("Failed to initialize beacon state, please provide a genesis state file or use checkpoint sync");
@@ -344,7 +349,7 @@ async function readWSState(
   chainForkConfig: ChainForkConfig,
   db: IBeaconDb,
   logger: Logger
-): Promise<{anchorState: BeaconStateAllForks; wsCheckpoint?: Checkpoint}> {
+): Promise<{anchorState: BeaconStateAllForks; stateBytes: Uint8Array; wsCheckpoint?: Checkpoint}> {
   // weak subjectivity sync from a provided state file:
   // if a weak subjectivity checkpoint has been provided, it is used for additional verification
   // otherwise, the state itself is used for verification (not bad, because the trusted state has been explicitly provided)
@@ -380,7 +385,7 @@ async function fetchWSStateFromBeaconApi(
   chainForkConfig: ChainForkConfig,
   db: IBeaconDb,
   logger: Logger
-): Promise<{anchorState: BeaconStateAllForks; wsCheckpoint?: Checkpoint}> {
+): Promise<{anchorState: BeaconStateAllForks; stateBytes: Uint8Array; wsCheckpoint?: Checkpoint}> {
   // weak subjectivity sync from a state that needs to be fetched:
   // if a weak subjectivity checkpoint has been provided, it is used to inform which state to download and used for additional verification
   // otherwise, the 'finalized' state is downloaded and the state itself is used for verification (all trust delegated to the remote beacon node)

--- a/packages/cli/src/options/beaconNodeOptions/chain.ts
+++ b/packages/cli/src/options/beaconNodeOptions/chain.ts
@@ -31,6 +31,7 @@ export type ChainArgs = {
   "chain.archiveDataEpochs"?: number;
   "chain.archiveMode": ArchiveMode;
   "chain.nHistoricalStatesFileDataStore"?: boolean;
+  "chain.nativeStateView"?: boolean;
   "chain.maxBlockStates"?: number;
   "chain.maxCPStateEpochsInMemory"?: number;
   "chain.maxCPStateEpochsOnDisk"?: number;
@@ -71,6 +72,7 @@ export function parseArgs(args: ChainArgs): IBeaconNodeOptions["chain"] {
     archiveMode: args["chain.archiveMode"] ?? defaultOptions.chain.archiveMode,
     nHistoricalStatesFileDataStore:
       args["chain.nHistoricalStatesFileDataStore"] ?? defaultOptions.chain.nHistoricalStatesFileDataStore,
+    nativeStateView: args["chain.nativeStateView"] ?? defaultOptions.chain.nativeStateView,
     maxBlockStates: args["chain.maxBlockStates"] ?? defaultOptions.chain.maxBlockStates,
     maxCPStateEpochsInMemory: args["chain.maxCPStateEpochsInMemory"] ?? defaultOptions.chain.maxCPStateEpochsInMemory,
     maxCPStateEpochsOnDisk: args["chain.maxCPStateEpochsOnDisk"] ?? defaultOptions.chain.maxCPStateEpochsOnDisk,
@@ -277,6 +279,14 @@ Will double processing times. Use only for debugging purposes.",
     description: "Use fs to store checkpoint state for PersistentCheckpointStateCache or not",
     type: "boolean",
     default: defaultOptions.chain.nHistoricalStatesFileDataStore,
+    group: "chain",
+  },
+
+  "chain.nativeStateView": {
+    hidden: true,
+    description: "Use native (Zig) BeaconStateView instead of JS implementation",
+    type: "boolean",
+    default: defaultOptions.chain.nativeStateView,
     group: "chain",
   },
 

--- a/packages/cli/test/unit/options/beaconNodeOptions.test.ts
+++ b/packages/cli/test/unit/options/beaconNodeOptions.test.ts
@@ -139,6 +139,7 @@ describe("options / beaconNodeOptions", () => {
         archiveDataEpochs: 10000,
         archiveMode: ArchiveMode.Frequency,
         nHistoricalStatesFileDataStore: true,
+        nativeStateView: false,
         maxBlockStates: 100,
         maxCPStateEpochsInMemory: 100,
         maxCPStateEpochsOnDisk: 1000,

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -34,7 +34,6 @@ import {VoluntaryExitValidity, getVoluntaryExitValidity} from "../block/processV
 import {getExpectedWithdrawals} from "../block/processWithdrawals.js";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";
 import {EpochTransitionCacheOpts} from "../cache/epochTransitionCache.js";
-import {PubkeyCache} from "../cache/pubkeyCache.js";
 import {RewardCache} from "../cache/rewardCache.js";
 import {
   CachedBeaconStateAllForks,
@@ -48,7 +47,6 @@ import {
   isStateValidatorsNodesPopulated,
 } from "../cache/stateCache.js";
 import {SyncCommitteeCache} from "../cache/syncCommitteeCache.js";
-import {BeaconStateAllForks} from "../cache/types.js";
 import {computeUnrealizedCheckpoints} from "../epoch/computeUnrealizedCheckpoints.js";
 import {getFinalizedRootProof, getSyncCommitteesWitness} from "../lightClient/proofs.js";
 import {SyncCommitteeWitness} from "../lightClient/types.js";
@@ -65,7 +63,6 @@ import {isExecutionEnabled, isExecutionStateType, isMergeTransitionComplete} fro
 import {canBuilderCoverBid} from "../util/gloas.js";
 import {loadState} from "../util/loadState/loadState.js";
 import {getRandaoMix} from "../util/seed.js";
-import {getStateTypeFromBytes} from "../util/sszBytes.js";
 import {getLatestWeakSubjectivityCheckpointEpoch} from "../util/weakSubjectivity.js";
 import {IBeaconStateView} from "./interface.js";
 
@@ -785,43 +782,5 @@ export class BeaconStateView implements IBeaconStateView {
       opts
     );
     return new BeaconStateView(postPayloadState);
-  }
-}
-
-/**
- * Create BeaconStateView for historical state regen, this is called from a worker thread.
- */
-export function createBeaconStateViewForHistoricalRegen(
-  config: BeaconConfig,
-  stateBytes: Uint8Array,
-  pubkeyCache: PubkeyCache
-): IBeaconStateView {
-  const state = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);
-
-  syncPubkeyCache(state, pubkeyCache);
-  const cachedState = createCachedBeaconState(
-    state,
-    {
-      config,
-      pubkeyCache,
-    },
-    {
-      skipSyncPubkeys: true,
-    }
-  );
-
-  return new BeaconStateView(cachedState);
-}
-
-/**
- * Populate a PubkeyIndexMap with any new entries based on a BeaconState
- */
-function syncPubkeyCache(state: BeaconStateAllForks, pubkeyCache: PubkeyCache): void {
-  // Get the validators sub tree once for all the loop
-
-  const newCount = state.validators.length;
-  for (let i = pubkeyCache.size; i < newCount; i++) {
-    const pubkey = state.validators.getReadonly(i).pubkey;
-    pubkeyCache.set(i, pubkey);
   }
 }

--- a/packages/state-transition/src/stateView/index.ts
+++ b/packages/state-transition/src/stateView/index.ts
@@ -1,2 +1,3 @@
 export * from "./beaconStateView.js";
 export * from "./interface.js";
+export * from "./stateViewFactory.js";

--- a/packages/state-transition/src/stateView/stateViewFactory.ts
+++ b/packages/state-transition/src/stateView/stateViewFactory.ts
@@ -1,0 +1,78 @@
+import {BeaconConfig} from "@lodestar/config";
+import {PubkeyCache, createPubkeyCache} from "../cache/pubkeyCache.js";
+import {createCachedBeaconState} from "../cache/stateCache.js";
+import {BeaconStateAllForks} from "../cache/types.js";
+import {getStateTypeFromBytes} from "../util/sszBytes.js";
+import {BeaconStateView} from "./beaconStateView.js";
+import {IBeaconStateView} from "./interface.js";
+
+// ---- createBeaconStateView (startup path) ----
+
+type NodeJSOpts = {
+  useNative: false;
+  anchorState: BeaconStateAllForks;
+  config: BeaconConfig;
+  pubkeyCache: PubkeyCache;
+};
+
+type NativeOpts = {
+  useNative: true;
+  stateBytes: Uint8Array;
+};
+
+/**
+ * Create a BeaconStateView from a pre-deserialized state. Used at node startup.
+ *
+ * The caller is responsible for creating and populating `pubkeyCache` (it is also
+ * passed separately to BeaconNode.init, so it must live outside this factory).
+ *
+ * Set `useNative: true` to use the native (Zig) implementation once available.
+ */
+export function createBeaconStateView(opts: NodeJSOpts | NativeOpts): IBeaconStateView {
+  if (opts.useNative) {
+    throw new Error("Native (Zig) BeaconStateView not yet implemented");
+  }
+  const {anchorState, config, pubkeyCache} = opts;
+  const cachedState = createCachedBeaconState(anchorState, {config, pubkeyCache}, {skipSyncPubkeys: true});
+  return new BeaconStateView(cachedState);
+}
+
+// ---- createBeaconStateViewForHistoricalRegen (regen path) ----
+
+// Reused across all historical state regen calls in the worker thread
+const pubkeyCacheRegen = createPubkeyCache();
+
+function syncPubkeyCache(state: BeaconStateAllForks, pubkeyCache: PubkeyCache): void {
+  const newCount = state.validators.length;
+  for (let i = pubkeyCache.size; i < newCount; i++) {
+    const pubkey = state.validators.getReadonly(i).pubkey;
+    pubkeyCache.set(i, pubkey);
+  }
+}
+
+type RegenNodeJSOpts = {
+  useNative: false;
+  config: BeaconConfig;
+  stateBytes: Uint8Array;
+};
+
+type RegenNativeOpts = {
+  useNative: true;
+  stateBytes: Uint8Array;
+};
+
+/**
+ * Create a BeaconStateView from raw SSZ bytes. Used in the historical state regen worker thread.
+ *
+ * Set `useNative: true` to use the native (Zig) implementation once available.
+ */
+export function createBeaconStateViewForHistoricalRegen(opts: RegenNodeJSOpts | RegenNativeOpts): IBeaconStateView {
+  if (opts.useNative) {
+    throw new Error("Native (Zig) BeaconStateView not yet implemented");
+  }
+  const {config, stateBytes} = opts;
+  const state = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);
+  syncPubkeyCache(state, pubkeyCacheRegen);
+  const cachedState = createCachedBeaconState(state, {config, pubkeyCache: pubkeyCacheRegen}, {skipSyncPubkeys: true});
+  return new BeaconStateView(cachedState);
+}


### PR DESCRIPTION
**Motivation**

Introduce a `nativeStateView` feature flag to make it easy to switch to a native (Zig) `BeaconStateView` implementation in the future, without breaking existing functionality.

**Description**

This PR builds on the `BeaconStateView` abstraction from #8857 and introduces:

- **`StateViewFactory`** (`packages/state-transition/src/stateView/stateViewFactory.ts`): Factory functions (`createBeaconStateView`, `createBeaconStateViewForHistoricalRegen`) for constructing `IBeaconStateView` instances, supporting both the existing JS/`CachedBeaconState` path and a future native path.
- **`nativeStateView` feature flag** (`packages/beacon-node/src/chain/options.ts`): A chain option (default `false`) to toggle between the JS and native state view implementations at runtime. Exposed as `--chain.nativeStateView` CLI flag.

**AI Assistance Disclosure**

- [ ] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

<!-- This PR was developed with AI assistance (Claude Code). -->