### PR TITLE
chore: clean up UnknownBlockSync

### DIFF
--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -489,10 +489,7 @@ export class BlockInputSync {
   private async fetchBlockInput(cacheItem: BlockInputSyncCacheItem): Promise<PendingBlockInput> {
     const rootHex = getBlockInputSyncCacheItemRootHex(cacheItem);
     const excludedPeers = new Set<PeerIdStr>();
-    const defaultPendingColumns =
-      this.config.getForkSeq(this.chain.clock.currentSlot) >= ForkSeq.fulu
-        ? new Set(this.network.custodyConfig.sampledColumns)
-        : null;
+    const defaultPendingColumns = new Set(this.network.custodyConfig.sampledColumns);
 
     const fetchStartSec = Date.now() / 1000;
     let slot = isPendingBlockInput(cacheItem) ? cacheItem.blockInput.slot : undefined;
@@ -506,14 +503,10 @@ export class BlockInputSync {
         isPendingBlockInput(cacheItem) && isBlockInputColumns(cacheItem.blockInput)
           ? new Set(cacheItem.blockInput.getMissingSampledColumnMeta().missing)
           : defaultPendingColumns;
-      // pendingDataColumns is null pre-fulu
       const peerMeta = this.peerBalancer.bestPeerForPendingColumns(pendingColumns, excludedPeers);
       if (peerMeta === null) {
         // no more peer with needed columns to try, throw error
-        let message = `Error fetching UnknownBlockRoot slot=${slot} root=${rootHex} after ${i}: cannot find peer`;
-        if (pendingColumns) {
-          message += ` with needed columns=${prettyPrintIndices(Array.from(pendingColumns))}`;
-        }
+        const message = `Error fetching UnknownBlockRoot slot=${slot} root=${rootHex} after ${i}: cannot find peer with needed columns=${prettyPrintIndices(Array.from(pendingColumns))}`;
         this.metrics?.blockInputSync.fetchTimeSec.observe(
           {result: FetchResult.FailureTriedAllPeers},
           Date.now() / 1000 - fetchStartSec
@@ -733,7 +726,7 @@ export class UnknownBlockPeerBalancer {
    * excludedPeers are the peers that we requested already so we don't want to try again
    * pendingColumns is empty for prefulu, or the 1st time we we download a block by root
    */
-  bestPeerForPendingColumns(pendingColumns: Set<number> | null, excludedPeers: Set<PeerIdStr>): PeerSyncMeta | null {
+  bestPeerForPendingColumns(pendingColumns: Set<number>, excludedPeers: Set<PeerIdStr>): PeerSyncMeta | null {
     const eligiblePeers = this.filterPeers(pendingColumns, excludedPeers);
     if (eligiblePeers.length === 0) {
       return null;
@@ -773,8 +766,7 @@ export class UnknownBlockPeerBalancer {
     return totalActiveRequests;
   }
 
-  // pendingDataColumns could be null for prefulu
-  private filterPeers(pendingDataColumns: Set<number> | null, excludedPeers: Set<PeerIdStr>): PeerIdStr[] {
+  private filterPeers(pendingDataColumns: Set<number>, excludedPeers: Set<PeerIdStr>): PeerIdStr[] {
     let maxColumnCount = 0;
     const considerPeers: {peerId: PeerIdStr; columnCount: number}[] = [];
     for (const [peerId, syncMeta] of this.peersMeta.entries()) {
@@ -789,13 +781,12 @@ export class UnknownBlockPeerBalancer {
         continue;
       }
 
-      if (pendingDataColumns === null || pendingDataColumns.size === 0) {
-        // prefulu, no pending columns
+      if (pendingDataColumns.size === 0) {
         considerPeers.push({peerId, columnCount: 0});
         continue;
       }
 
-      // postfulu, find peers that have custody columns that we need
+      // find peers that have custody columns that we need
       const {custodyColumns: peerColumns} = syncMeta;
       // check if the peer has all needed columns
       // get match

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -481,7 +481,7 @@ export class BlockInputSync {
    * From a set of shuffled peers:
    *   - fetch the block
    *   - from deneb, fetch all missing blobs
-   *   - from peerDAS, fetch sampled colmns
+   *   - from peerDAS, fetch sampled columns
    * TODO: this means we only have block root, and nothing else. Consider to reflect this in the function name
    * prefulu, will attempt a max of `MAX_ATTEMPTS_PER_BLOCK` on different peers, postfulu we may attempt more as defined in `getMaxDownloadAttempts()` function
    * Also verifies the received block root + returns the peer that provided the block for future downscoring.
@@ -650,7 +650,7 @@ export class BlockInputSync {
       // TODO(fulu): why is this commented out here?
       //
       //   this.knownBadBlocks.add(block.blockRootHex);
-      //   for (const peerIdStr of block.peerIdStrs) {
+      //   for (const peerIdStr of block.peerIdStrings) {
       //     // TODO: Refactor peerRpcScores to work with peerIdStr only
       //     this.network.reportPeer(peerIdStr, PeerAction.LowToleranceError, "BadBlockByRoot");
       //   }
@@ -729,7 +729,7 @@ export class UnknownBlockPeerBalancer {
   }
 
   /**
-   * called from fetchUnknownBlockRoot() where we only have block root and nothing else
+   * called from fetchBlockInput() where we only have block root and nothing else
    * excludedPeers are the peers that we requested already so we don't want to try again
    * pendingColumns is empty for prefulu, or the 1st time we we download a block by root
    */

--- a/packages/beacon-node/src/sync/unknownBlock.ts
+++ b/packages/beacon-node/src/sync/unknownBlock.ts
@@ -751,37 +751,6 @@ export class UnknownBlockPeerBalancer {
   }
 
   /**
-   * called from fetchUnavailableBlockInput() where we have either BlockInput or NullBlockInput
-   * excludedPeers are the peers that we requested already so we don't want to try again
-   */
-  bestPeerForBlockInput(blockInput: IBlockInput, excludedPeers: Set<PeerIdStr>): PeerSyncMeta | null {
-    const eligiblePeers: PeerIdStr[] = [];
-
-    if (isBlockInputColumns(blockInput)) {
-      const pendingDataColumns: Set<number> = new Set(blockInput.getMissingSampledColumnMeta().missing);
-      // there could be no pending column in case when block is still missing
-      eligiblePeers.push(...this.filterPeers(pendingDataColumns, excludedPeers));
-    } else {
-      // prefulu
-      eligiblePeers.push(...this.filterPeers(null, excludedPeers));
-    }
-
-    if (eligiblePeers.length === 0) {
-      return null;
-    }
-
-    const sortedEligiblePeers = sortBy(
-      shuffle(eligiblePeers),
-      // prefer peers with least active req
-      (peerId) => this.activeRequests.get(peerId) ?? 0
-    );
-
-    const bestPeerId = sortedEligiblePeers[0];
-    this.onRequest(bestPeerId);
-    return this.peersMeta.get(bestPeerId) ?? null;
-  }
-
-  /**
    * Consumers don't need to call this method directly, it is called internally by bestPeer*() methods
    * make this public for testing
    */

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -8,7 +8,7 @@ import {testLogger} from "@lodestar/logger/test-utils";
 import {ForkName} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {notNullish, sleep} from "@lodestar/utils";
-import {BlockInputColumns, BlockInputPreData} from "../../../src/chain/blocks/blockInput/blockInput.js";
+import {BlockInputPreData} from "../../../src/chain/blocks/blockInput/blockInput.js";
 import {BlockInputSource} from "../../../src/chain/blocks/blockInput/types.js";
 import {BlockError, BlockErrorCode} from "../../../src/chain/errors/blockError.js";
 import {ChainEvent, ChainEventEmitter, IBeaconChain} from "../../../src/chain/index.js";
@@ -22,7 +22,6 @@ import {CustodyConfig} from "../../../src/util/dataColumns.js";
 import {PeerIdStr} from "../../../src/util/peerId.js";
 import {ClockStopped} from "../../mocks/clock.js";
 import {MockedBeaconChain, getMockedBeaconChain} from "../../mocks/mockedBeaconChain.js";
-import {generateBlockWithColumnSidecars} from "../../utils/blocksAndData.js";
 import {getRandPeerIdStr, getRandPeerSyncMeta} from "../../utils/peer.js";
 
 describe("sync by UnknownBlockSync", {timeout: 20_000}, () => {
@@ -413,44 +412,6 @@ describe("UnknownBlockPeerBalancer", async () => {
     for (const [i, groups] of custodyGroups.entries()) {
       peers[i].custodyColumns = groups;
     }
-
-    const signedBlock = ssz.fulu.SignedBeaconBlock.defaultValue();
-    signedBlock.message.body.blobKzgCommitments = [ssz.fulu.KZGCommitment.defaultValue()];
-    const {block, rootHex, columnSidecars} = generateBlockWithColumnSidecars({forkName: ForkName.fulu});
-    const blockInput = BlockInputColumns.createFromBlock({
-      block: block,
-      blockRootHex: rootHex,
-      forkName: ForkName.fulu,
-      daOutOfRange: false,
-      source: BlockInputSource.gossip,
-      seenTimestampSec: Math.floor(Date.now() / 1000),
-      custodyColumns: custodyConfig.custodyColumns,
-      sampledColumns: custodyConfig.sampledColumns,
-    });
-
-    // test cases rely on first 2 columns being known, the rest unknown
-    for (const sidecar of columnSidecars.slice(0, 2)) {
-      blockInput.addColumn({
-        columnSidecar: sidecar,
-        blockRootHex: rootHex,
-        seenTimestampSec: Math.floor(Date.now() / 1000),
-        source: BlockInputSource.gossip,
-      });
-    }
-
-    it(`bestPeerForBlockInput - test case ${testCaseIndex}`, () => {
-      for (const [i, activeRequest] of activeRequests.entries()) {
-        for (let j = 0; j < activeRequest; j++) {
-          peerBalancer.onRequest(peers[i].peerId);
-        }
-      }
-      const peer = peerBalancer.bestPeerForBlockInput(blockInput, new Set(excludedPeers));
-      if (bestPeer) {
-        expect(peer).toEqual(bestPeer);
-      } else {
-        expect(peer).toBeNull();
-      }
-    });
 
     it(`bestPeerForPendingColumns - test case ${testCaseIndex}`, () => {
       for (const [i, activeRequest] of activeRequests.entries()) {

--- a/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
+++ b/packages/beacon-node/test/unit/sync/unknownBlock.test.ts
@@ -5,7 +5,6 @@ import {createChainForkConfig} from "@lodestar/config";
 import {config as minimalConfig} from "@lodestar/config/default";
 import {IForkChoice, ProtoBlock} from "@lodestar/fork-choice";
 import {testLogger} from "@lodestar/logger/test-utils";
-import {ForkName} from "@lodestar/params";
 import {ssz} from "@lodestar/types";
 import {notNullish, sleep} from "@lodestar/utils";
 import {BlockInputPreData} from "../../../src/chain/blocks/blockInput/blockInput.js";
@@ -354,7 +353,6 @@ describe("UnknownBlockSync", () => {
 });
 
 describe("UnknownBlockPeerBalancer", async () => {
-  const custodyConfig = {sampledColumns: [0, 1, 2, 3]} as CustodyConfig;
   const peer0 = await getRandPeerSyncMeta("peer-0");
   const peer1 = await getRandPeerSyncMeta("peer-1");
   const peer2 = await getRandPeerSyncMeta("peer-2");


### PR DESCRIPTION
**Motivation**

found during review #9034

- `bestPeerForBlockInput()` is not used anywhere after [PR-8200](https://github.com/ChainSafe/lodestar/pull/8200/changes#diff-593e2f511966ad9d8cb737688f30aadb67c896c68766d1b09a33cf1e251f7860L649)
- We have to handle `pendingColumns` as `Set<number> | null` for pre-fulu; we can simplify to `Set<number>` since fulu is the active fork already

**Description**

- Remove dead `bestPeerForBlockInput` method from `UnknownBlockPeerBalancer` and its test
- Fix stale comments referencing non-existent functions (`fetchUnknownBlockRoot`, `fetchUnavailableBlockInput`) and a wrong field name (`peerIdStrs` → `peerIdStrings`)
- Narrow `pendingColumns` type from `Set<number> | null` to `Set<number>` in `bestPeerForPendingColumns` and `filterPeers`, removing the pre-fulu null path

**AI Assistance Disclosure**

Used Claude Code to identify and implement this cleanup.