### PR TITLE
feat: add toValue() to IBeaconStateView, simplify debug API

### DIFF
--- a/packages/beacon-node/src/api/impl/debug/index.ts
+++ b/packages/beacon-node/src/api/impl/debug/index.ts
@@ -79,11 +79,7 @@ export function getDebugApi({
         data = state;
       } else {
         slot = state.slot;
-        const stateBytes = state.serialize();
-        data = context?.returnBytes
-          ? stateBytes
-          : // TODO: modify api definition too?
-            sszTypesFor(config.getForkName(slot)).BeaconState.deserialize(stateBytes);
+        data = context?.returnBytes ? state.serialize() : state.toValue();
       }
       return {
         data,

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -719,7 +719,7 @@ export class BeaconStateView implements IBeaconStateView {
   }
 
   toValue(): BeaconState {
-    return this.cachedState.toValue() as BeaconState;
+    return this.cachedState.toValue();
   }
 
   serialize(): Uint8Array {

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -4,6 +4,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq, SLOTS_PER_HISTORICAL_ROOT, isForkPostGloas} from "@lodestar/params";
 import {
   BeaconBlock,
+  BeaconState,
   BlindedBeaconBlock,
   BuilderIndex,
   Bytes32,
@@ -715,6 +716,10 @@ export class BeaconStateView implements IBeaconStateView {
     cachedState.balances.getAll();
 
     return new BeaconStateView(cachedState);
+  }
+
+  toValue(): BeaconState {
+    return this.cachedState.toValue() as BeaconState;
   }
 
   serialize(): Uint8Array {

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -2,6 +2,7 @@ import {CompactMultiProof} from "@chainsafe/persistent-merkle-tree";
 import {BitArray, ByteViews} from "@chainsafe/ssz";
 import {
   BeaconBlock,
+  BeaconState,
   BlindedBeaconBlock,
   BuilderIndex,
   Bytes32,
@@ -193,6 +194,7 @@ export interface IBeaconStateView {
 
   // Serialization
   loadOtherState(stateBytes: Uint8Array, seedValidatorsBytes?: Uint8Array): IBeaconStateView;
+  toValue(): BeaconState;
   serialize(): Uint8Array;
   serializedSize(): number;
   serializeToBytes(output: ByteViews, offset: number): number;


### PR DESCRIPTION
## Description

Add `toValue()` method to `IBeaconStateView` interface and implement it in `BeaconStateView` by delegating to the underlying `CachedBeaconState`.

This replaces the serialize→deserialize roundtrip in the debug API's `getStateV2` endpoint with a direct `toValue()` call, restoring the pre-refactor behavior.

### Changes
- **`IBeaconStateView`**: Added `toValue(): BeaconState` to the interface
- **`BeaconStateView`**: Implemented via `this.cachedState.toValue()`
- **Debug API `getStateV2`**: Simplified from `serialize() → sszTypesFor(...).deserialize()` to `state.toValue()`

### Context
Suggested in [PR #8857 review](https://github.com/ChainSafe/lodestar/pull/8857#discussion_r2966903793) and [requested by @nflaig](https://github.com/ChainSafe/lodestar/pull/8857#discussion_r2967596507).

> This PR was implemented with AI assistance (Claude).
