### PR TITLE
chore: enable forceJsExtensions in biome lint config

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -72,7 +72,7 @@
         "useImportExtensions": {
           "level": "error",
           "options": {
-            "forceJsExtensions": false
+            "forceJsExtensions": true
           }
         },
         "useParseIntRadix": {


### PR DESCRIPTION
## Description

Enable `forceJsExtensions: true` in the Biome `useImportExtensions` rule. This makes Biome flag `.ts` import extensions and enforce `.js`, preventing a recurring bug where AI-assisted code uses `.ts` instead of `.js` in relative imports.

### Context
Raised by @nflaig in [PR #8857 review](https://github.com/ChainSafe/lodestar/pull/8857#discussion_r2966970293) — a `.ts` import was introduced by the refactor. The existing rule had `forceJsExtensions: false` which only checks that an extension exists, not that it's `.js` specifically. Flipping to `true` catches this at lint time.

No code changes needed — the codebase already uses `.js` everywhere. Lint passes cleanly.

> This PR was implemented with AI assistance (Claude).
