### PR TITLE
fix: add toValue() and latestBlockHeaderRoot() to IBeaconStateView

### DIFF
--- a/packages/beacon-node/src/api/impl/debug/index.ts
+++ b/packages/beacon-node/src/api/impl/debug/index.ts
@@ -79,11 +79,7 @@ export function getDebugApi({
         data = state;
       } else {
         slot = state.slot;
-        const stateBytes = state.serialize();
-        data = context?.returnBytes
-          ? stateBytes
-          : // TODO: modify api definition too?
-            sszTypesFor(config.getForkName(slot)).BeaconState.deserialize(stateBytes);
+        data = context?.returnBytes ? state.serialize() : state.toValue();
       }
       return {
         data,

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
@@ -3,7 +3,9 @@ import {
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
   IBeaconStateView,
+  type PubkeyCache,
   createBeaconStateViewForHistoricalRegen,
+  createPubkeyCache,
 } from "@lodestar/state-transition";
 import {byteArrayEquals} from "@lodestar/utils";
 import {IBeaconDb} from "../../../db/index.js";
@@ -13,14 +15,19 @@ import {RegenErrorType} from "./types.js";
 /**
  * Get the nearest BeaconState at or before a slot
  */
-export async function getNearestState(slot: number, config: BeaconConfig, db: IBeaconDb): Promise<IBeaconStateView> {
+export async function getNearestState(
+  slot: number,
+  config: BeaconConfig,
+  db: IBeaconDb,
+  pubkeyCache?: PubkeyCache
+): Promise<IBeaconStateView> {
   const stateBytesArr = await db.stateArchive.binaries({limit: 1, lte: slot, reverse: true});
   if (!stateBytesArr.length) {
     throw new Error("No near state found in the database");
   }
 
   const stateBytes = stateBytesArr[0];
-  return createBeaconStateViewForHistoricalRegen(config, stateBytes);
+  return createBeaconStateViewForHistoricalRegen(config, stateBytes, pubkeyCache);
 }
 
 /**
@@ -34,8 +41,11 @@ export async function getHistoricalState(
 ): Promise<Uint8Array> {
   const regenTimer = metrics?.regenTime.startTimer();
 
+  // Reuse a single pubkey cache for all state regens in this call
+  const pubkeyCache = createPubkeyCache();
+
   const loadStateTimer = metrics?.loadStateTime.startTimer();
-  let state = await getNearestState(slot, config, db).catch((e) => {
+  let state = await getNearestState(slot, config, db, pubkeyCache).catch((e) => {
     metrics?.regenErrorCount.inc({reason: RegenErrorType.loadState});
     throw e;
   });

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -632,9 +632,7 @@ export class BeaconChain implements IBeaconChain {
   ): Promise<{state: IBeaconStateView | Uint8Array; executionOptimistic: boolean; finalized: boolean} | null> {
     if (opts?.allowRegen) {
       const state = await this.regen.getState(stateRoot, RegenCaller.restApi);
-      const block = this.forkChoice.getBlockDefaultStatus(
-        ssz.phase0.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader)
-      );
+      const block = this.forkChoice.getBlockDefaultStatus(state.latestBlockHeaderRoot());
       const finalizedEpoch = this.forkChoice.getFinalizedCheckpoint().epoch;
       return {
         state,
@@ -650,9 +648,7 @@ export class BeaconChain implements IBeaconChain {
     // TODO: This is very inneficient for debug requests of serialized content, since it deserializes to serialize again
     const cachedStateCtx = this.regen.getStateSync(stateRoot);
     if (cachedStateCtx) {
-      const block = this.forkChoice.getBlockDefaultStatus(
-        ssz.phase0.BeaconBlockHeader.hashTreeRoot(cachedStateCtx.latestBlockHeader)
-      );
+      const block = this.forkChoice.getBlockDefaultStatus(cachedStateCtx.latestBlockHeaderRoot());
       const finalizedEpoch = this.forkChoice.getFinalizedCheckpoint().epoch;
       return {
         state: cachedStateCtx,
@@ -689,9 +685,7 @@ export class BeaconChain implements IBeaconChain {
     const checkpointHexPayload = fcCheckpointToHexPayload(checkpoint);
     const cachedStateCtx = this.regen.getCheckpointStateSync(checkpointHexPayload);
     if (cachedStateCtx) {
-      const block = this.forkChoice.getBlockDefaultStatus(
-        ssz.phase0.BeaconBlockHeader.hashTreeRoot(cachedStateCtx.latestBlockHeader)
-      );
+      const block = this.forkChoice.getBlockDefaultStatus(cachedStateCtx.latestBlockHeaderRoot());
       const finalizedEpoch = this.forkChoice.getFinalizedCheckpoint().epoch;
       return {
         state: cachedStateCtx,

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -797,16 +797,18 @@ export class BeaconStateView implements IBeaconStateView {
  */
 export function createBeaconStateViewForHistoricalRegen(
   config: BeaconConfig,
-  stateBytes: Uint8Array
+  stateBytes: Uint8Array,
+  pubkeyCache?: PubkeyCache
 ): IBeaconStateView {
+  const cache = pubkeyCache ?? createPubkeyCache();
   const state = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);
 
-  syncPubkeyCache(state, pubkeyCacheRegen);
+  syncPubkeyCache(state, cache);
   const cachedState = createCachedBeaconState(
     state,
     {
       config,
-      pubkeyCache: pubkeyCacheRegen,
+      pubkeyCache: cache,
     },
     {
       skipSyncPubkeys: true,
@@ -815,9 +817,6 @@ export function createBeaconStateViewForHistoricalRegen(
 
   return new BeaconStateView(cachedState);
 }
-
-// this is reused for all historical state regens in the worker.
-const pubkeyCacheRegen = createPubkeyCache();
 
 /**
  * Populate a PubkeyIndexMap with any new entries based on a BeaconState

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -4,6 +4,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq, SLOTS_PER_HISTORICAL_ROOT, isForkPostGloas} from "@lodestar/params";
 import {
   BeaconBlock,
+  BeaconState,
   BlindedBeaconBlock,
   BuilderIndex,
   Bytes32,
@@ -715,6 +716,14 @@ export class BeaconStateView implements IBeaconStateView {
     cachedState.balances.getAll();
 
     return new BeaconStateView(cachedState);
+  }
+
+  toValue(): BeaconState {
+    return this.cachedState.toValue() as BeaconState;
+  }
+
+  latestBlockHeaderRoot(): Uint8Array {
+    return this.cachedState.latestBlockHeader.hashTreeRoot();
   }
 
   serialize(): Uint8Array {

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -2,6 +2,7 @@ import {CompactMultiProof} from "@chainsafe/persistent-merkle-tree";
 import {BitArray, ByteViews} from "@chainsafe/ssz";
 import {
   BeaconBlock,
+  BeaconState,
   BlindedBeaconBlock,
   BuilderIndex,
   Bytes32,
@@ -192,6 +193,10 @@ export interface IBeaconStateView {
   isStateValidatorsNodesPopulated(): boolean;
 
   // Serialization
+  /** Returns the full state as a plain value object (fork-aware). */
+  toValue(): BeaconState;
+  /** Returns the hash tree root of latestBlockHeader. */
+  latestBlockHeaderRoot(): Uint8Array;
   loadOtherState(stateBytes: Uint8Array, seedValidatorsBytes?: Uint8Array): IBeaconStateView;
   serialize(): Uint8Array;
   serializedSize(): number;


### PR DESCRIPTION
## Summary

Adds two helper methods to `IBeaconStateView` to clean up call sites that were working around missing abstraction:

### `toValue(): BeaconState`

The debug API was doing `state.serialize()` → `sszTypesFor(fork).BeaconState.deserialize(stateBytes)` — a full encode/decode roundtrip just to get a value object. This replaces it with `state.toValue()` which delegates to the tree-backed `toValue()` directly.

**Before:**
```typescript
const stateBytes = state.serialize();
data = context?.returnBytes
  ? stateBytes
  : sszTypesFor(config.getForkName(slot)).BeaconState.deserialize(stateBytes);
```

**After:**
```typescript
data = context?.returnBytes ? state.serialize() : state.toValue();
```

### `latestBlockHeaderRoot(): Uint8Array`

Three call sites in `chain.ts` used `ssz.phase0.BeaconBlockHeader.hashTreeRoot(state.latestBlockHeader)` — reaching through the SSZ layer to compute a root from a value returned by the view. This encapsulates it so callers don't need to know about SSZ plumbing.

## Changes

| File | Change |
|------|--------|
| `stateView/interface.ts` | Add `toValue()` and `latestBlockHeaderRoot()` to interface |
| `stateView/beaconStateView.ts` | Implement both methods |
| `api/impl/debug/index.ts` | Use `state.toValue()` instead of serialize→deserialize |
| `chain/chain.ts` | Use `latestBlockHeaderRoot()` at 3 call sites |

Addresses https://github.com/ChainSafe/lodestar/pull/8857#discussion_r2967596507 and https://github.com/ChainSafe/lodestar/pull/8857#discussion_r2967723782