### PR TITLE
refactor: inject pubkeyCache into createBeaconStateViewForHistoricalRegen

### DIFF
--- a/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
@@ -3,6 +3,7 @@ import {
   DataAvailabilityStatus,
   ExecutionPayloadStatus,
   IBeaconStateView,
+  type PubkeyCache,
   createBeaconStateViewForHistoricalRegen,
 } from "@lodestar/state-transition";
 import {byteArrayEquals} from "@lodestar/utils";
@@ -13,14 +14,19 @@ import {RegenErrorType} from "./types.js";
 /**
  * Get the nearest BeaconState at or before a slot
  */
-export async function getNearestState(slot: number, config: BeaconConfig, db: IBeaconDb): Promise<IBeaconStateView> {
+export async function getNearestState(
+  slot: number,
+  config: BeaconConfig,
+  db: IBeaconDb,
+  pubkeyCache?: PubkeyCache
+): Promise<IBeaconStateView> {
   const stateBytesArr = await db.stateArchive.binaries({limit: 1, lte: slot, reverse: true});
   if (!stateBytesArr.length) {
     throw new Error("No near state found in the database");
   }
 
   const stateBytes = stateBytesArr[0];
-  return createBeaconStateViewForHistoricalRegen(config, stateBytes);
+  return createBeaconStateViewForHistoricalRegen(config, stateBytes, pubkeyCache);
 }
 
 /**
@@ -30,12 +36,13 @@ export async function getHistoricalState(
   slot: number,
   config: BeaconConfig,
   db: IBeaconDb,
-  metrics?: HistoricalStateRegenMetrics
+  metrics?: HistoricalStateRegenMetrics,
+  pubkeyCache?: PubkeyCache
 ): Promise<Uint8Array> {
   const regenTimer = metrics?.regenTime.startTimer();
 
   const loadStateTimer = metrics?.loadStateTime.startTimer();
-  let state = await getNearestState(slot, config, db).catch((e) => {
+  let state = await getNearestState(slot, config, db, pubkeyCache).catch((e) => {
     metrics?.regenErrorCount.inc({reason: RegenErrorType.loadState});
     throw e;
   });

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/getHistoricalState.ts
@@ -18,7 +18,7 @@ export async function getNearestState(
   slot: number,
   config: BeaconConfig,
   db: IBeaconDb,
-  pubkeyCache?: PubkeyCache
+  pubkeyCache: PubkeyCache
 ): Promise<IBeaconStateView> {
   const stateBytesArr = await db.stateArchive.binaries({limit: 1, lte: slot, reverse: true});
   if (!stateBytesArr.length) {
@@ -36,8 +36,8 @@ export async function getHistoricalState(
   slot: number,
   config: BeaconConfig,
   db: IBeaconDb,
-  metrics?: HistoricalStateRegenMetrics,
-  pubkeyCache?: PubkeyCache
+  pubkeyCache: PubkeyCache,
+  metrics?: HistoricalStateRegenMetrics
 ): Promise<Uint8Array> {
   const regenTimer = metrics?.regenTime.startTimer();
 

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
@@ -3,6 +3,7 @@ import {Transfer, expose} from "@chainsafe/threads/worker";
 import {chainConfigFromJson, createBeaconConfig} from "@lodestar/config";
 import {LevelDbController} from "@lodestar/db/controller/level";
 import {getNodeLogger} from "@lodestar/logger/node";
+import {createPubkeyCache} from "@lodestar/state-transition";
 import {BeaconDb} from "../../../db/index.js";
 import {RegistryMetricCreator, collectNodeJSMetrics} from "../../../metrics/index.js";
 import {JobFnQueue} from "../../../util/queue/fnQueue.js";
@@ -51,6 +52,9 @@ const queue = new JobFnQueue(
   queueMetrics
 );
 
+// Reuse a single pubkey cache across all historical state regen calls in this worker
+const pubkeyCache = createPubkeyCache();
+
 const api: HistoricalStateWorkerApi = {
   async close() {
     abortController.abort();
@@ -62,7 +66,7 @@ const api: HistoricalStateWorkerApi = {
     historicalStateRegenMetrics?.regenRequestCount.inc();
 
     const stateBytes = await queue.push<Uint8Array>(() =>
-      getHistoricalState(slot, config, db, historicalStateRegenMetrics)
+      getHistoricalState(slot, config, db, historicalStateRegenMetrics, pubkeyCache)
     );
     const result = Transfer(stateBytes, [stateBytes.buffer]) as unknown as Uint8Array;
 

--- a/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
+++ b/packages/beacon-node/src/chain/archiveStore/historicalState/worker.ts
@@ -66,7 +66,7 @@ const api: HistoricalStateWorkerApi = {
     historicalStateRegenMetrics?.regenRequestCount.inc();
 
     const stateBytes = await queue.push<Uint8Array>(() =>
-      getHistoricalState(slot, config, db, historicalStateRegenMetrics, pubkeyCache)
+      getHistoricalState(slot, config, db, pubkeyCache, historicalStateRegenMetrics)
     );
     const result = Transfer(stateBytes, [stateBytes.buffer]) as unknown as Uint8Array;
 

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -788,16 +788,18 @@ export class BeaconStateView implements IBeaconStateView {
  */
 export function createBeaconStateViewForHistoricalRegen(
   config: BeaconConfig,
-  stateBytes: Uint8Array
+  stateBytes: Uint8Array,
+  pubkeyCache?: PubkeyCache
 ): IBeaconStateView {
+  const cache = pubkeyCache ?? createPubkeyCache();
   const state = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);
 
-  syncPubkeyCache(state, pubkeyCacheRegen);
+  syncPubkeyCache(state, cache);
   const cachedState = createCachedBeaconState(
     state,
     {
       config,
-      pubkeyCache: pubkeyCacheRegen,
+      pubkeyCache: cache,
     },
     {
       skipSyncPubkeys: true,
@@ -806,9 +808,6 @@ export function createBeaconStateViewForHistoricalRegen(
 
   return new BeaconStateView(cachedState);
 }
-
-// this is reused for all historical state regens in the worker.
-const pubkeyCacheRegen = createPubkeyCache();
 
 /**
  * Populate a PubkeyIndexMap with any new entries based on a BeaconState

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -33,7 +33,7 @@ import {VoluntaryExitValidity, getVoluntaryExitValidity} from "../block/processV
 import {getExpectedWithdrawals} from "../block/processWithdrawals.js";
 import {EffectiveBalanceIncrements} from "../cache/effectiveBalanceIncrements.js";
 import {EpochTransitionCacheOpts} from "../cache/epochTransitionCache.js";
-import {PubkeyCache, createPubkeyCache} from "../cache/pubkeyCache.js";
+import {PubkeyCache} from "../cache/pubkeyCache.js";
 import {RewardCache} from "../cache/rewardCache.js";
 import {
   CachedBeaconStateAllForks,
@@ -789,17 +789,16 @@ export class BeaconStateView implements IBeaconStateView {
 export function createBeaconStateViewForHistoricalRegen(
   config: BeaconConfig,
   stateBytes: Uint8Array,
-  pubkeyCache?: PubkeyCache
+  pubkeyCache: PubkeyCache
 ): IBeaconStateView {
-  const cache = pubkeyCache ?? createPubkeyCache();
   const state = getStateTypeFromBytes(config, stateBytes).deserializeToViewDU(stateBytes);
 
-  syncPubkeyCache(state, cache);
+  syncPubkeyCache(state, pubkeyCache);
   const cachedState = createCachedBeaconState(
     state,
     {
       config,
-      pubkeyCache: cache,
+      pubkeyCache,
     },
     {
       skipSyncPubkeys: true,


### PR DESCRIPTION
## Summary

Remove the module-global mutable singleton `pubkeyCacheRegen` from `beaconStateView.ts`. The pubkey cache is now created by the caller (`getHistoricalState`) and passed as a parameter.

### Why

The module-global singleton bakes in assumptions about execution context — it prevents parallel historical regen or alternate worker contexts from using their own cache instances. Making the dependency explicit is cleaner.

### Changes

| File | Change |
|------|--------|
| `beaconStateView.ts` | Accept optional `pubkeyCache` param, remove global singleton |
| `getHistoricalState.ts` | Create cache once, pass to `getNearestState` → `createBeaconStateViewForHistoricalRegen` |

Split from #9080 per review feedback.

Addresses https://github.com/ChainSafe/lodestar/pull/8857#discussion_r2967808767