### PR TITLE
fix: avoid redundant DB query in getGenesisBlockRoot

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -191,19 +191,19 @@ export function getValidatorApi(
   async function getGenesisBlockRoot(state: IBeaconStateView): Promise<Root> {
     if (!genesisBlockRoot) {
       // Close to genesis the genesis block may not be available in the DB
-      if (state.slot < SLOTS_PER_HISTORICAL_ROOT && state.slot > GENESIS_SLOT) {
+      if (state.slot > GENESIS_SLOT && state.slot < SLOTS_PER_HISTORICAL_ROOT) {
         genesisBlockRoot = state.getBlockRootAtSlot(GENESIS_SLOT);
-      }
-
-      const blockRes = await chain.getCanonicalBlockAtSlot(GENESIS_SLOT);
-      if (blockRes) {
-        genesisBlockRoot = config
-          .getForkTypes(blockRes.block.message.slot)
-          .SignedBeaconBlock.hashTreeRoot(blockRes.block);
+      } else {
+        const blockRes = await chain.getCanonicalBlockAtSlot(GENESIS_SLOT);
+        if (blockRes) {
+          genesisBlockRoot = config
+            .getForkTypes(blockRes.block.message.slot)
+            .SignedBeaconBlock.hashTreeRoot(blockRes.block);
+        }
       }
     }
 
-    // If for some reason the genesisBlockRoot is not able don't prevent validators from
+    // If for some reason the genesisBlockRoot is not available don't prevent validators from
     // proposing or attesting. If the genesisBlockRoot is wrong, at worst it may trigger a re-fetch of the duties
     return genesisBlockRoot || ZERO_HASH;
   }


### PR DESCRIPTION
## Problem

`getGenesisBlockRoot()` always executes both the state lookup AND the DB lookup unconditionally. When the genesis block root is available from state (slots 1 through `SLOTS_PER_HISTORICAL_ROOT - 1`), the DB query is redundant — it fetches the block, deserializes it, and computes `hashTreeRoot` just to overwrite the value already obtained from state.

## Fix

Add `else` so the DB path only runs when the state path can't provide the root:

- **Slots 1 to 8191**: get from `state.getBlockRootAtSlot(GENESIS_SLOT)` — no DB I/O
- **Slot 0 or slot ≥ 8192**: fall back to DB lookup via `getCanonicalBlockAtSlot`

Also reorders conditions to check the tighter guard first (`slot > GENESIS_SLOT`) and fixes a typo in the fallback comment.

## Why this matters

`getGenesisBlockRoot` is called during attester duty computation. The genesis block root is cached after the first call, but on the first call the DB query adds unnecessary latency when the state already has the answer.