### PR TITLE
fix: avoid redundant DB query in getGenesisBlockRoot

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -195,17 +195,17 @@ export function getValidatorApi(
         genesisBlockRoot = state.computeAnchorCheckpoint().checkpoint.root;
       } else if (state.slot < SLOTS_PER_HISTORICAL_ROOT) {
         genesisBlockRoot = state.getBlockRootAtSlot(GENESIS_SLOT);
-      }
-
-      const blockRes = await chain.getCanonicalBlockAtSlot(GENESIS_SLOT);
-      if (blockRes) {
-        genesisBlockRoot = config
-          .getForkTypes(blockRes.block.message.slot)
-          .SignedBeaconBlock.hashTreeRoot(blockRes.block);
+      } else {
+        const blockRes = await chain.getCanonicalBlockAtSlot(GENESIS_SLOT);
+        if (blockRes) {
+          genesisBlockRoot = config
+            .getForkTypes(blockRes.block.message.slot)
+            .SignedBeaconBlock.hashTreeRoot(blockRes.block);
+        }
       }
     }
 
-    // If for some reason the genesisBlockRoot is not able don't prevent validators from
+    // If for some reason the genesisBlockRoot is not available don't prevent validators from
     // proposing or attesting. If the genesisBlockRoot is wrong, at worst it may trigger a re-fetch of the duties
     return genesisBlockRoot || ZERO_HASH;
   }


### PR DESCRIPTION
## Problem

`getGenesisBlockRoot()` executes both the state lookup AND the DB lookup unconditionally. When the genesis block root is already resolved from state, the DB path still runs — calling `getCanonicalBlockAtSlot(GENESIS_SLOT)` and computing `hashTreeRoot` just to overwrite the value already obtained.

Three state paths exist after `93371549bf`:
- **Slot 0**: `computeAnchorCheckpoint().checkpoint.root` — then DB overwrites ❌
- **Slots 1–8191**: `getBlockRootAtSlot(GENESIS_SLOT)` — then DB overwrites ❌
- **Slot ≥ 8192**: no state path (correct) — DB lookup needed ✅

## Fix

Wrap the DB path in `else` so it only runs when the state can't provide the root.

Also fixes typo `not able` → `not available` in the fallback comment.

## Note

Replaces #9082 which I incorrectly closed.