### PR TITLE
fix: avoid redundant DB query in getGenesisBlockRoot

### DIFF
--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -198,17 +198,17 @@ export function getValidatorApi(
       // Close to genesis the genesis block may not be available in the DB
       if (state.slot < SLOTS_PER_HISTORICAL_ROOT) {
         genesisBlockRoot = state.blockRoots.get(0);
-      }
-
-      const blockRes = await chain.getCanonicalBlockAtSlot(GENESIS_SLOT);
-      if (blockRes) {
-        genesisBlockRoot = config
-          .getForkTypes(blockRes.block.message.slot)
-          .SignedBeaconBlock.hashTreeRoot(blockRes.block);
+      } else {
+        const blockRes = await chain.getCanonicalBlockAtSlot(GENESIS_SLOT);
+        if (blockRes) {
+          genesisBlockRoot = config
+            .getForkTypes(blockRes.block.message.slot)
+            .SignedBeaconBlock.hashTreeRoot(blockRes.block);
+        }
       }
     }
 
-    // If for some reason the genesisBlockRoot is not able don't prevent validators from
+    // If for some reason the genesisBlockRoot is not available don't prevent validators from
     // proposing or attesting. If the genesisBlockRoot is wrong, at worst it may trigger a re-fetch of the duties
     return genesisBlockRoot || ZERO_HASH;
   }

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -53,6 +53,7 @@ import {
 } from "@lodestar/types";
 import {
   TimeoutError,
+  byteArrayEquals,
   defer,
   formatWeiToEth,
   fromHex,
@@ -195,10 +196,18 @@ export function getValidatorApi(
   /** Compute and cache the genesis block root */
   async function getGenesisBlockRoot(state: CachedBeaconStateAllForks): Promise<Root> {
     if (!genesisBlockRoot) {
-      // Close to genesis the genesis block may not be available in the DB
+      // Close to genesis the genesis block root may already be in blockRoots
       if (state.slot < SLOTS_PER_HISTORICAL_ROOT) {
-        genesisBlockRoot = state.blockRoots.get(0);
-      } else {
+        const root = state.blockRoots.get(0);
+        // At slot 0 blockRoots may not be populated yet (all zeros), so only
+        // cache if non-zero to allow the DB fallback to run on the next call
+        if (!byteArrayEquals(root, ZERO_HASH)) {
+          genesisBlockRoot = root;
+        }
+      }
+
+      // Fall through to DB lookup if blockRoots didn't yield a valid root
+      if (!genesisBlockRoot) {
         const blockRes = await chain.getCanonicalBlockAtSlot(GENESIS_SLOT);
         if (blockRes) {
           genesisBlockRoot = config


### PR DESCRIPTION
## Problem

`getGenesisBlockRoot()` executes both the state lookup AND the DB lookup unconditionally. When `state.slot < SLOTS_PER_HISTORICAL_ROOT`, the genesis block root is available directly from `state.blockRoots.get(0)`, but the DB path still runs afterward — calling `getCanonicalBlockAtSlot(GENESIS_SLOT)` and computing `hashTreeRoot` just to overwrite the already-correct value.

## Fix

Add `else` so the DB fallback only runs when the state can't provide the root (`slot >= SLOTS_PER_HISTORICAL_ROOT`).

Also fixes typo `not able` → `not available`.