### PR TITLE
fix: handle falsy zero in indexed attestation bounds check

### DIFF
--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -76,7 +76,7 @@ export function isValidIndexedAttestationIndices(
 
   // check if indices are out of bounds, by checking the highest index (since it is sorted)
   const lastIndex = indices.at(-1);
-  if (lastIndex && lastIndex >= validatorsLen) {
+  if (lastIndex !== undefined && lastIndex >= validatorsLen) {
     return false;
   }
 

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -75,8 +75,8 @@ export function isValidIndexedAttestationIndices(
   }
 
   // check if indices are out of bounds, by checking the highest index (since it is sorted)
-  const lastIndex = indices.at(-1);
-  if (lastIndex !== undefined && lastIndex >= validatorsLen) {
+  const lastIndex = indices[indices.length - 1];
+  if (lastIndex >= validatorsLen) {
     return false;
   }
 

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -74,8 +74,8 @@ export function isValidIndexedAttestationIndices(
     prev = index;
   }
 
-  // check if indices are out of bounds, by checking the highest index (since it is sorted)
-  const lastIndex = indices[indices.length - 1];
+  // indices is guaranteed non-empty at this point (length checked above)
+  const lastIndex = indices.at(-1) as number;
   if (lastIndex >= validatorsLen) {
     return false;
   }

--- a/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
+++ b/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
@@ -33,6 +33,11 @@ describe("validate indexed attestation", () => {
       expectedValue: true,
       name: "should return valid indexed attestation",
     },
+    {
+      indices: [0],
+      expectedValue: true,
+      name: "should return valid indexed attestation - single index 0",
+    },
   ];
 
   it.each(testValues)("$name", ({indices, expectedValue}) => {


### PR DESCRIPTION
  **Motivation**

  The bounds check for the highest attesting index uses a falsy check (`lastIndex && ...`) which skips validation when `lastIndex === 0` because `0` is falsy in JavaScript.

  **Description**

  `indices.at(-1)` returns `0` for `indices = [0]`, and `if (0 && ...)` short-circuits without evaluating `0 >= validatorsLen`. Changed to `lastIndex !== undefined`  which correctly handles all index values including 0.

  Added a regression test for the `indices = [0]` edge case.

  **AI Assistance Disclosure**

  - [x] External Contributors: I have read the [contributor guidelines](https://github.com/ChainSafe/lodestar/blob/unstable/CONTRIBUTING.md#ai-assistance-notice) and disclosed my usage of AI below.

  This bug was identified with the assistance of Claude Code during a security audit of Ethereum consensus clients. The fix and test were reviewed and validated manually.
