### PR TITLE
refactor: avoid falsy zero check in indexed attestation bounds validation

### DIFF
--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -74,7 +74,7 @@ export function isValidIndexedAttestationIndices(
     prev = index;
   }
 
-  // check if indices are out of bounds, `prev` value is the highest index (since it is sorted)
+  // check if indices are out of bounds, `prev` is the highest index since indices are sorted
   if (prev >= validatorsLen) {
     return false;
   }

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -74,7 +74,7 @@ export function isValidIndexedAttestationIndices(
     prev = index;
   }
 
-  // check if indices are out of bounds, by checking the highest index (since it is sorted)
+  // indices are sorted, so the final `prev` value is the highest index
   if (prev >= validatorsLen) {
     return false;
   }

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -74,7 +74,7 @@ export function isValidIndexedAttestationIndices(
     prev = index;
   }
 
-  // indices are sorted, so the final `prev` value is the highest index
+  // check if indices are out of bounds, `prev` value is the highest index (since it is sorted)
   if (prev >= validatorsLen) {
     return false;
   }

--- a/packages/state-transition/src/block/isValidIndexedAttestation.ts
+++ b/packages/state-transition/src/block/isValidIndexedAttestation.ts
@@ -75,8 +75,7 @@ export function isValidIndexedAttestationIndices(
   }
 
   // check if indices are out of bounds, by checking the highest index (since it is sorted)
-  const lastIndex = indices.at(-1);
-  if (lastIndex && lastIndex >= validatorsLen) {
+  if (prev >= validatorsLen) {
     return false;
   }
 

--- a/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
+++ b/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
@@ -29,6 +29,11 @@ describe("validate indexed attestation", () => {
       name: "should return invalid indexed attestation - indexes not sorted",
     },
     {
+      indices: [0, 0],
+      expectedValue: false,
+      name: "should return invalid indexed attestation - duplicate indexes",
+    },
+    {
       indices: [0, 1, 2, 3],
       expectedValue: true,
       name: "should return valid indexed attestation",

--- a/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
+++ b/packages/state-transition/test/unit/block/isValidIndexedAttestation.test.ts
@@ -33,6 +33,11 @@ describe("validate indexed attestation", () => {
       expectedValue: true,
       name: "should return valid indexed attestation",
     },
+    {
+      indices: [0],
+      expectedValue: true,
+      name: "should return valid indexed attestation - single index 0",
+    },
   ];
 
   it.each(testValues)("$name", ({indices, expectedValue}) => {


### PR DESCRIPTION
This doesn't fix a real bug, we are passing the test added already without any changes, so https://github.com/ChainSafe/lodestar/pull/9088 doesn't make sense. But we can simplify the code and avoid the extra `indices.at(-1)` since  `prev` is already the highest index.
