### PR TITLE
fix: make addPayloadEnvelope idempotent for API/gossip race #9071

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/blocks/index.ts
@@ -709,12 +709,16 @@ export function getBeaconBlockApi({
         throw new ApiError(404, `PayloadEnvelopeInput not found for block root ${blockRootHex}`);
       }
 
-      payloadInput.addPayloadEnvelope({
-        envelope: signedExecutionPayloadEnvelope,
-        source: PayloadEnvelopeInputSource.api,
-        seenTimestampSec,
-        peerIdStr: undefined,
-      });
+      try {
+        payloadInput.addPayloadEnvelope({
+          envelope: signedExecutionPayloadEnvelope,
+          source: PayloadEnvelopeInputSource.api,
+          seenTimestampSec,
+          peerIdStr: undefined,
+        });
+      } catch (e) {
+        throw new ApiError(400, `Invalid payload envelope: ${(e as Error).message}`);
+      }
 
       if (dataColumnSidecars.length > 0) {
         for (const columnSidecar of dataColumnSidecars) {

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/payloadEnvelopeInput.ts
@@ -1,6 +1,6 @@
 import {NUMBER_OF_COLUMNS} from "@lodestar/params";
 import {ColumnIndex, DataColumnSidecars, RootHex, Slot, ValidatorIndex, deneb, gloas} from "@lodestar/types";
-import {toRootHex, withTimeout} from "@lodestar/utils";
+import {toRootHex, withTimeout, Logger} from "@lodestar/utils";
 import {VersionedHashes} from "../../../execution/index.js";
 import {kzgCommitmentToVersionedHash} from "../../../util/blobs.js";
 import {AddPayloadEnvelopeProps, ColumnWithSource, CreateFromBlockProps, SourceMeta} from "./types.js";
@@ -62,6 +62,7 @@ export class PayloadEnvelopeInput {
   readonly proposerIndex: ValidatorIndex;
   readonly bid: gloas.ExecutionPayloadBid;
   readonly versionedHashes: VersionedHashes;
+  private readonly logger?: Logger;
 
   private columnsCache = new Map<ColumnIndex, ColumnWithSource>();
 
@@ -83,6 +84,7 @@ export class PayloadEnvelopeInput {
     sampledColumns: ColumnIndex[];
     custodyColumns: ColumnIndex[];
     timeCreatedSec: number;
+    logger?: Logger;
   }) {
     this.blockRootHex = props.blockRootHex;
     this.slot = props.slot;
@@ -92,12 +94,15 @@ export class PayloadEnvelopeInput {
     this.sampledColumns = props.sampledColumns;
     this.custodyColumns = props.custodyColumns;
     this.timeCreatedSec = props.timeCreatedSec;
+    
     this.payloadEnvelopeDataPromise = createPromise();
     this.columnsDataPromise = createPromise();
+    this.logger = props.logger;
 
     const noBlobs = props.bid.blobKzgCommitments.length === 0;
     const noSampledColumns = props.sampledColumns.length === 0;
     const hasAllData = noBlobs || noSampledColumns;
+    
 
     if (hasAllData) {
       this.state = {hasPayload: false, hasAllData: true, hasComputedAllData: true};
@@ -117,6 +122,7 @@ export class PayloadEnvelopeInput {
       sampledColumns: props.sampledColumns,
       custodyColumns: props.custodyColumns,
       timeCreatedSec: props.timeCreatedSec,
+      logger: props.logger,
     });
   }
 
@@ -136,42 +142,59 @@ export class PayloadEnvelopeInput {
     return this.bid.blobKzgCommitments;
   }
 
-  addPayloadEnvelope(props: AddPayloadEnvelopeProps): void {
-    if (this.state.hasPayload) {
-      throw new Error(`Payload envelope already set for block ${this.blockRootHex}`);
-    }
-    if (toRootHex(props.envelope.message.beaconBlockRoot) !== this.blockRootHex) {
+addPayloadEnvelope(props: AddPayloadEnvelopeProps): void {
+  const incomingRoot = toRootHex(props.envelope.message.beaconBlockRoot);
+
+  if (this.state.hasPayload) {
+    if (incomingRoot !== this.blockRootHex) {
       throw new Error("Payload envelope beacon_block_root mismatch");
     }
 
-    const source: SourceMeta = {
-      source: props.source,
-      seenTimestampSec: props.seenTimestampSec,
-      peerIdStr: props.peerIdStr,
-    };
-
-    if (this.state.hasAllData) {
-      // Complete state
-      this.state = {
-        hasPayload: true,
-        hasAllData: true,
-        hasComputedAllData: this.state.hasComputedAllData,
-        payloadEnvelope: props.envelope,
-        payloadEnvelopeSource: source,
-        timeCompleteSec: props.seenTimestampSec,
-      };
-      this.payloadEnvelopeDataPromise.resolve(props.envelope);
+    const existing = this.state.payloadEnvelope;
+    if (existing && existing.message.payload.blockHash !== props.envelope.message.payload.blockHash) {
+      this.logger?.warn?.(
+        `Conflicting payload envelope for block ${this.blockRootHex}`
+      );
     } else {
-      // Has payload, waiting for columns
-      this.state = {
-        hasPayload: true,
-        hasAllData: false,
-        hasComputedAllData: false,
-        payloadEnvelope: props.envelope,
-        payloadEnvelopeSource: source,
-      };
+      this.logger?.debug?.(
+        `Duplicate payload envelope ignored for block ${this.blockRootHex}`
+      );
     }
+
+    return;
   }
+
+  // ✅ Keep original validation
+  if (incomingRoot !== this.blockRootHex) {
+    throw new Error("Payload envelope beacon_block_root mismatch");
+  }
+
+  const source: SourceMeta = {
+    source: props.source,
+    seenTimestampSec: props.seenTimestampSec,
+    peerIdStr: props.peerIdStr,
+  };
+
+  if (this.state.hasAllData) {
+    this.state = {
+      hasPayload: true,
+      hasAllData: true,
+      hasComputedAllData: this.state.hasComputedAllData,
+      payloadEnvelope: props.envelope,
+      payloadEnvelopeSource: source,
+      timeCompleteSec: props.seenTimestampSec,
+    };
+    this.payloadEnvelopeDataPromise.resolve(props.envelope);
+  } else {
+    this.state = {
+      hasPayload: true,
+      hasAllData: false,
+      hasComputedAllData: false,
+      payloadEnvelope: props.envelope,
+      payloadEnvelopeSource: source,
+    };
+  }
+}
 
   addColumn(columnWithSource: ColumnWithSource): void {
     const {columnSidecar, seenTimestampSec} = columnWithSource;

--- a/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/types.ts
+++ b/packages/beacon-node/src/chain/blocks/payloadEnvelopeInput/types.ts
@@ -1,5 +1,6 @@
 import {ForkPostGloas} from "@lodestar/params";
 import {ColumnIndex, RootHex, SignedBeaconBlock, gloas} from "@lodestar/types";
+import {Logger} from "@lodestar/utils";
 
 export enum PayloadEnvelopeInputSource {
   gossip = "gossip",
@@ -26,6 +27,7 @@ export type CreateFromBlockProps = {
   sampledColumns: ColumnIndex[];
   custodyColumns: ColumnIndex[];
   timeCreatedSec: number;
+  logger?: Logger;
 };
 
 export type AddPayloadEnvelopeProps = SourceMeta & {

--- a/packages/beacon-node/test/unit/chain/blocks/payloadEnvelopeInput.test.ts
+++ b/packages/beacon-node/test/unit/chain/blocks/payloadEnvelopeInput.test.ts
@@ -1,0 +1,101 @@
+import {describe, it, expect} from "vitest";
+import {PayloadEnvelopeInput} from "../../../../src/chain/seenCache/index.js";
+import {PayloadEnvelopeInputSource} from "../../../../src/chain/blocks/payloadEnvelopeInput/types.js";
+
+const MOCK_ROOT_HEX = "0x" + "aa".repeat(32);
+const MOCK_BLOCK_HASH = "0x" + "bb".repeat(32);
+
+describe("PayloadEnvelopeInput - addPayloadEnvelope", () => {
+  function createMockBlock() {
+    return {
+      message: {
+        slot: 1,
+        proposerIndex: 1,
+        body: {
+          signedExecutionPayloadBid: {
+            message: {
+              blobKzgCommitments: [],
+              blockHash: "0xabc",
+              builderIndex: 1,
+            },
+          },
+        },
+      },
+    } as any;
+  }
+
+  function createMockEnvelope(blockHash = MOCK_BLOCK_HASH) {
+    return {
+      message: {
+        beaconBlockRoot: Buffer.from(MOCK_ROOT_HEX.slice(2), "hex"),
+        payload: {
+          blockHash,
+        },
+      },
+    } as any;
+  }
+
+  function createInput() {
+    return PayloadEnvelopeInput.createFromBlock({
+      blockRootHex: MOCK_ROOT_HEX,
+      block: createMockBlock(),
+      sampledColumns: [],
+      custodyColumns: [],
+      timeCreatedSec: 1,
+      logger: undefined,
+    });
+  }
+
+  it("should set payload on first call", () => {
+    const input = createInput();
+    const envelope = createMockEnvelope();
+
+    input.addPayloadEnvelope({
+      envelope,
+      source: PayloadEnvelopeInputSource.gossip,
+      seenTimestampSec: 1,
+    });
+
+    expect(input.hasPayloadEnvelope()).toBe(true);
+  });
+
+  it("should NOT throw on duplicate payload (race condition fix)", () => {
+    const input = createInput();
+    const envelope = createMockEnvelope();
+
+    input.addPayloadEnvelope({
+      envelope,
+      source: PayloadEnvelopeInputSource.gossip,
+      seenTimestampSec: 1,
+    });
+
+    expect(() =>
+      input.addPayloadEnvelope({
+        envelope,
+        source: PayloadEnvelopeInputSource.api,
+        seenTimestampSec: 2,
+      })
+    ).not.toThrow();
+  });
+
+  it("should NOT throw on conflicting payload", () => {
+    const input = createInput();
+
+    const envelope1 = createMockEnvelope(MOCK_BLOCK_HASH);
+    const envelope2 = createMockEnvelope("0x" + "cc".repeat(32));9
+
+    input.addPayloadEnvelope({
+      envelope: envelope1,
+      source: PayloadEnvelopeInputSource.gossip,
+      seenTimestampSec: 1,
+    });
+
+    expect(() =>
+      input.addPayloadEnvelope({
+        envelope: envelope2,
+        source: PayloadEnvelopeInputSource.api,
+        seenTimestampSec: 2,
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
**Motivation**

The API and gossip handlers can race in multi-node or DVT setups, causing PayloadEnvelopeInput.addPayloadEnvelope() to throw "Payload envelope already set", which leads to 500 errors for the validator client. This PR ensures that the method is idempotent, preventing failures when duplicate payloads arrive.

**Description**

1. Made addPayloadEnvelope() idempotent by returning early for duplicate payloads
2. Added logging to distinguish conflicting vs duplicate payloads
3. Wrapped API calls in try-catch to prevent 500 errors
4. Added comprehensive unit tests for race condition scenarios

**Changes**:

- payloadEnvelopeInput.ts – idempotency logic with early return for existing payloads
- index.ts – try-catch around addPayloadEnvelope() calls
- types.ts – logger support for proper logging
- payloadEnvelopeInput.test.ts – tests for duplicate and conflicting payloads

**Testing**:

- All tests pass ✅ (3/3)
- Covers duplicate payloads, conflicting payloads, and normal operation
- No regressions in broader test suite

**AI Assistance Disclosure**

 External Contributors: I have read the contributor guidelines and disclose that AI was used to help format and polish the PR description for clarity.