### PR TITLE
fix: only create QUIC clients for configured address families

### DIFF
--- a/packages/beacon-node/package.json
+++ b/packages/beacon-node/package.json
@@ -113,7 +113,7 @@
     "@chainsafe/discv5": "^12.0.1",
     "@chainsafe/enr": "^6.0.1",
     "@chainsafe/libp2p-noise": "^17.0.0",
-    "@chainsafe/libp2p-quic": "^2.0.0",
+    "@chainsafe/libp2p-quic": "^2.0.1",
     "@chainsafe/persistent-merkle-tree": "^1.2.1",
     "@chainsafe/prometheus-gc-stats": "^1.0.0",
     "@chainsafe/pubkey-index-map": "^3.0.0",

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -88,6 +88,7 @@ export async function createNodeJsLibp2p(
     );
   }
   if (networkOpts.quic) {
+    const hasIpv6Quic = localMultiaddrs.some((ma) => ma.includes("/ip6/") && ma.includes("/quic-v1"));
     transports.unshift(
       quic({
         handshakeTimeout: 5_000,
@@ -96,6 +97,7 @@ export async function createNodeJsLibp2p(
         maxConcurrentStreamLimit: 256,
         maxStreamData: 10_000_000,
         maxConnectionData: 15_000_000,
+        ipv6: hasIpv6Quic,
       })
     );
   }

--- a/packages/beacon-node/src/network/libp2p/index.ts
+++ b/packages/beacon-node/src/network/libp2p/index.ts
@@ -88,7 +88,9 @@ export async function createNodeJsLibp2p(
     );
   }
   if (networkOpts.quic) {
-    const hasIpv6Quic = localMultiaddrs.some((ma) => ma.includes("/ip6/") && ma.includes("/quic-v1"));
+    const quicMultiaddrs = localMultiaddrs.filter((ma) => ma.includes("/quic-v1"));
+    const hasIpv4Quic = quicMultiaddrs.some((ma) => ma.includes("/ip4/"));
+    const hasIpv6Quic = quicMultiaddrs.some((ma) => ma.includes("/ip6/"));
     transports.unshift(
       quic({
         handshakeTimeout: 5_000,
@@ -97,6 +99,7 @@ export async function createNodeJsLibp2p(
         maxConcurrentStreamLimit: 256,
         maxStreamData: 10_000_000,
         maxConnectionData: 15_000_000,
+        ipv4: hasIpv4Quic,
         ipv6: hasIpv6Quic,
       })
     );

--- a/packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts
+++ b/packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts
@@ -1,0 +1,71 @@
+import {generateKeyPair} from "@libp2p/crypto/keys";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+const createLibp2pMock = vi.fn(async () => ({}) as never);
+const quicMock = vi.fn((options?: Record<string, unknown>) => ({options}) as never);
+
+vi.mock("libp2p", async (importActual) => {
+  const mod = await importActual<typeof import("libp2p")>();
+
+  return {
+    ...mod,
+    createLibp2p: createLibp2pMock,
+  };
+});
+
+vi.mock("@chainsafe/libp2p-quic", async (importActual) => {
+  const mod = await importActual<typeof import("@chainsafe/libp2p-quic")>();
+
+  return {
+    ...mod,
+    quic: quicMock,
+  };
+});
+
+import {createNodeJsLibp2p} from "../../../../src/network/libp2p/index.js";
+
+describe("network / libp2p / createNodeJsLibp2p", () => {
+  beforeEach(() => {
+    createLibp2pMock.mockClear();
+    quicMock.mockClear();
+  });
+
+  it.each([
+    {
+      case: "ipv4 only",
+      localMultiaddrs: ["/ip4/0.0.0.0/udp/9001/quic-v1"],
+      expected: {ipv4: true, ipv6: false},
+    },
+    {
+      case: "ipv6 only",
+      localMultiaddrs: ["/ip6/::/udp/9001/quic-v1"],
+      expected: {ipv4: false, ipv6: true},
+    },
+    {
+      case: "dual stack",
+      localMultiaddrs: ["/ip4/0.0.0.0/udp/9001/quic-v1", "/ip6/::/udp/9001/quic-v1"],
+      expected: {ipv4: true, ipv6: true},
+    },
+  ])("should pass the right QUIC socket family flags for $case", async ({localMultiaddrs, expected}) => {
+    const privateKey = await generateKeyPair("secp256k1");
+
+    await createNodeJsLibp2p(
+      privateKey,
+      {
+        tcp: false,
+        quic: true,
+        localMultiaddrs,
+      },
+      {disablePeerDiscovery: true}
+    );
+
+    expect(quicMock).toHaveBeenCalledOnce();
+    expect(quicMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipv4: expected.ipv4,
+        ipv6: expected.ipv6,
+      })
+    );
+    expect(createLibp2pMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts
+++ b/packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts
@@ -1,12 +1,13 @@
 import {generateKeyPair} from "@libp2p/crypto/keys";
 import {beforeEach, describe, expect, it, vi} from "vitest";
 
-const createLibp2pMock = vi.fn(async () => ({}) as never);
-const quicMock = vi.fn((options?: Record<string, unknown>) => ({options}) as never);
+const {createLibp2pMock, quicMock} = vi.hoisted(() => ({
+  createLibp2pMock: vi.fn(async () => ({}) as never),
+  quicMock: vi.fn((options?: Record<string, unknown>) => ({options}) as never),
+}));
 
 vi.mock("libp2p", async (importActual) => {
   const mod = await importActual<typeof import("libp2p")>();
-
   return {
     ...mod,
     createLibp2p: createLibp2pMock,
@@ -15,7 +16,6 @@ vi.mock("libp2p", async (importActual) => {
 
 vi.mock("@chainsafe/libp2p-quic", async (importActual) => {
   const mod = await importActual<typeof import("@chainsafe/libp2p-quic")>();
-
   return {
     ...mod,
     quic: quicMock,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,8 +232,8 @@ importers:
         specifier: ^17.0.0
         version: 17.0.0
       '@chainsafe/libp2p-quic':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.0.1
+        version: 2.0.1
       '@chainsafe/persistent-merkle-tree':
         specifier: ^1.2.1
         version: 1.2.1
@@ -1446,54 +1446,54 @@ packages:
   '@chainsafe/libp2p-noise@17.0.0':
     resolution: {integrity: sha512-vwrmY2Y+L1xYhIDiEpl61KHxwrLCZoXzTpwhyk34u+3+6zCAZPL3GxH3i2cs+u5IYNoyLptORdH17RKFXy7upA==}
 
-  '@chainsafe/libp2p-quic-darwin-arm64@2.0.0':
-    resolution: {integrity: sha512-dY/LEALfn4qRUjY8i3+V5YcmPRzJdeiaE/6eoS92KZr6UoWdVuxUCUz24+3jTl9Ke+EqvqsjZxfIS08CuhWhRA==}
+  '@chainsafe/libp2p-quic-darwin-arm64@2.0.1':
+    resolution: {integrity: sha512-IdtYFNixSEhmAMl3oEGWd8S1G5u0Ucy++ML4JTr+fCR+eIaS5cqaTzZ82r3LAcjHPtB9bLbXhjYHprF93MXxaA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@chainsafe/libp2p-quic-darwin-x64@2.0.0':
-    resolution: {integrity: sha512-XOt+rxMUjJ7W+ainDVUJ76kkmFO/LZYjGI8D9ecVL4P1+SIfxc90awrjikGUDqlozvsk96vjNzvUO6Obw+ftXA==}
+  '@chainsafe/libp2p-quic-darwin-x64@2.0.1':
+    resolution: {integrity: sha512-04kRCyN7SNMw7Apr2xhYNzcs/P9gZ8PyXpE2xya3IYgEW9yfEGaRkQx2MqUA/XaLQ6XXxbxQVqXUUNalwYuKZw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@chainsafe/libp2p-quic-linux-arm64-gnu@2.0.0':
-    resolution: {integrity: sha512-TgRv12gyZMWm8G9RMi7j0Uwjmk272ikqXVvYkDICD5yS13vIkvxueVuvAOtFnkt7qO+pPh2hciPUkdfYeqVjuA==}
+  '@chainsafe/libp2p-quic-linux-arm64-gnu@2.0.1':
+    resolution: {integrity: sha512-QOEprwUHnLBpQajvsvDxUACdOMNWIkNH/aOEDmzrIUJLIuLpu7ZLltXD8M0eIGmuUzx91UJKvHjAAcd0JsKz+A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@chainsafe/libp2p-quic-linux-arm64-musl@2.0.0':
-    resolution: {integrity: sha512-cax7qIL8fGeN41ydH6yRXcYhbYZbSQOYXa9tSr5lLSDJE24JEOjy8BugeP618kXydNFEbbt3VmyjNc+8XrGd4g==}
+  '@chainsafe/libp2p-quic-linux-arm64-musl@2.0.1':
+    resolution: {integrity: sha512-vtIjDUM+ZasuPgQMZQg9tzGGVCv01Rrdb8G+7F7LqzKP3uuhqDnwBKsdcU0Hp8PoL2MKpD8GAyUFqZ8kC95+Mw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@chainsafe/libp2p-quic-linux-x64-gnu@2.0.0':
-    resolution: {integrity: sha512-LiiaS3lmebt4USDQAFQCM+t5n1wuMoGeEDmHco6moSmZ9FJhBaM4CryUS3bXey31tpxEyQIx3q6Ub8SOUyLJ/g==}
+  '@chainsafe/libp2p-quic-linux-x64-gnu@2.0.1':
+    resolution: {integrity: sha512-3DcKCGF1k071fJ2TyKM8SPMsFeGOVcFdfbYN0ZI7uvQN+zSq6jABvD9b1laMOfdXg6Kt/arjS5hlwJ6URf5/3g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@chainsafe/libp2p-quic-linux-x64-musl@2.0.0':
-    resolution: {integrity: sha512-G3SS24AoY/1xkAA9IvL7alq2fp4GJwp+YXM8lOaez3cTCZuhwq4CksQFjy11VzyKrNCs/D9H02l0Aat8UeQaBw==}
+  '@chainsafe/libp2p-quic-linux-x64-musl@2.0.1':
+    resolution: {integrity: sha512-smklgWlu7GutWUDjnvaIz51i4+3XBweIpczKVtiVJTSu/ZoeAVme5XUBPhYHctp7+nO+M5XGYC0jgCb6ytanbg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@chainsafe/libp2p-quic-win32-x64-msvc@2.0.0':
-    resolution: {integrity: sha512-IxLdu8uVcus/KmFTiXHX6xqZE51uazKRJSbEn/9r94UY+uA7AEAeu497Zug7LOfzg3j++vFwd/AOJRSbk4U9Lw==}
+  '@chainsafe/libp2p-quic-win32-x64-msvc@2.0.1':
+    resolution: {integrity: sha512-Zzez2uYoMdHmccLUkJFisTT9w+Hr6LlLtxurHmk9JswuOsT8EbDeHo7GHcLh629X3DHL9anRHuGMR79rqo8fuQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@chainsafe/libp2p-quic@2.0.0':
-    resolution: {integrity: sha512-RNxHNdo22XhS5DEFbT0fAaZFfrEmuIVRP5InqgMq8md6r0f61AATZdmYqAuNkcj6VSBareLlCAJ/iuhhNZYt7A==}
+  '@chainsafe/libp2p-quic@2.0.1':
+    resolution: {integrity: sha512-vXpS0MOC97z019X9Vxjr1pAPaKk97Jc4AC9G1IKnx3fhL+1utZOHeKf6MHd75QXcJgVyUDmL56LSLrUrcrN25g==}
     engines: {node: '>= 22'}
 
   '@chainsafe/netmask@2.0.0':
@@ -7886,28 +7886,28 @@ snapshots:
       uint8arrays: 5.1.0
       wherearewe: 2.0.1
 
-  '@chainsafe/libp2p-quic-darwin-arm64@2.0.0':
+  '@chainsafe/libp2p-quic-darwin-arm64@2.0.1':
     optional: true
 
-  '@chainsafe/libp2p-quic-darwin-x64@2.0.0':
+  '@chainsafe/libp2p-quic-darwin-x64@2.0.1':
     optional: true
 
-  '@chainsafe/libp2p-quic-linux-arm64-gnu@2.0.0':
+  '@chainsafe/libp2p-quic-linux-arm64-gnu@2.0.1':
     optional: true
 
-  '@chainsafe/libp2p-quic-linux-arm64-musl@2.0.0':
+  '@chainsafe/libp2p-quic-linux-arm64-musl@2.0.1':
     optional: true
 
-  '@chainsafe/libp2p-quic-linux-x64-gnu@2.0.0':
+  '@chainsafe/libp2p-quic-linux-x64-gnu@2.0.1':
     optional: true
 
-  '@chainsafe/libp2p-quic-linux-x64-musl@2.0.0':
+  '@chainsafe/libp2p-quic-linux-x64-musl@2.0.1':
     optional: true
 
-  '@chainsafe/libp2p-quic-win32-x64-msvc@2.0.0':
+  '@chainsafe/libp2p-quic-win32-x64-msvc@2.0.1':
     optional: true
 
-  '@chainsafe/libp2p-quic@2.0.0':
+  '@chainsafe/libp2p-quic@2.0.1':
     dependencies:
       '@libp2p/crypto': 5.1.13
       '@libp2p/interface': 3.1.0
@@ -7918,13 +7918,13 @@ snapshots:
       race-signal: 1.1.3
       uint8arraylist: 2.4.8
     optionalDependencies:
-      '@chainsafe/libp2p-quic-darwin-arm64': 2.0.0
-      '@chainsafe/libp2p-quic-darwin-x64': 2.0.0
-      '@chainsafe/libp2p-quic-linux-arm64-gnu': 2.0.0
-      '@chainsafe/libp2p-quic-linux-arm64-musl': 2.0.0
-      '@chainsafe/libp2p-quic-linux-x64-gnu': 2.0.0
-      '@chainsafe/libp2p-quic-linux-x64-musl': 2.0.0
-      '@chainsafe/libp2p-quic-win32-x64-msvc': 2.0.0
+      '@chainsafe/libp2p-quic-darwin-arm64': 2.0.1
+      '@chainsafe/libp2p-quic-darwin-x64': 2.0.1
+      '@chainsafe/libp2p-quic-linux-arm64-gnu': 2.0.1
+      '@chainsafe/libp2p-quic-linux-arm64-musl': 2.0.1
+      '@chainsafe/libp2p-quic-linux-x64-gnu': 2.0.1
+      '@chainsafe/libp2p-quic-linux-x64-musl': 2.0.1
+      '@chainsafe/libp2p-quic-win32-x64-msvc': 2.0.1
 
   '@chainsafe/netmask@2.0.0':
     dependencies:


### PR DESCRIPTION
## Problem

The QUIC transport unconditionally creates both IPv4 and IPv6 clients regardless of which address families are actually configured in `localMultiaddrs`. On systems with IPv6 disabled at the OS level, this crashes during startup.

## Fix

Pass `ipv4` and `ipv6` options to `@chainsafe/libp2p-quic` based on which address families are present in the configured QUIC listen addresses. This ensures only the needed clients are created.

Requires `@chainsafe/libp2p-quic` ≥ 2.0.1 (ChainSafe/js-libp2p-quic#56) which adds the `ipv4`/`ipv6` options with graceful try/catch fallback.

## Changes

- **`packages/beacon-node/src/network/libp2p/index.ts`**: Detect IPv4/IPv6 QUIC listen addresses and pass `ipv4`/`ipv6` flags to the QUIC transport constructor
- **`packages/beacon-node/test/unit/network/libp2p/createNodeJsLibp2p.test.ts`**: Unit tests covering IPv4-only, IPv6-only, and dual-stack configurations

🤖 Generated with AI assistance