### PR TITLE
feat: fork-aware IBeaconStateView type narrowing

### DIFF
--- a/packages/beacon-node/src/api/impl/beacon/pool/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/pool/index.ts
@@ -1,6 +1,7 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
 import {ForkPostElectra, ForkPreElectra, SYNC_COMMITTEE_SUBNET_SIZE, isForkPostElectra} from "@lodestar/params";
+import {isStatePostAltair} from "@lodestar/state-transition";
 import {Attestation, Epoch, SingleAttestation, isElectraAttestation, ssz, sszTypesFor} from "@lodestar/types";
 import {
   AttestationError,
@@ -249,6 +250,9 @@ export function getBeaconPoolApi({
 
       // TODO: Fetch states at signature slots
       const state = chain.getHeadState();
+      if (!isStatePostAltair(state)) {
+        throw new ApiError(400, "Sync committee pool is not supported before Altair");
+      }
 
       const failures: FailureList = [];
 

--- a/packages/beacon-node/src/api/impl/beacon/state/index.ts
+++ b/packages/beacon-node/src/api/impl/beacon/state/index.ts
@@ -1,17 +1,14 @@
 import {routes} from "@lodestar/api";
 import {ApplicationMethods} from "@lodestar/api/server";
-import {
-  EPOCHS_PER_HISTORICAL_VECTOR,
-  SLOTS_PER_EPOCH,
-  SYNC_COMMITTEE_SUBNET_SIZE,
-  isForkPostElectra,
-  isForkPostFulu,
-} from "@lodestar/params";
+import {EPOCHS_PER_HISTORICAL_VECTOR, SLOTS_PER_EPOCH, SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
 import {
   IBeaconStateView,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   getCurrentEpoch,
+  isStatePostAltair,
+  isStatePostElectra,
+  isStatePostFulu,
 } from "@lodestar/state-transition";
 import {ValidatorIndex, getValidatorStatus, ssz} from "@lodestar/types";
 import {ApiError} from "../../errors.js";
@@ -303,6 +300,9 @@ export function getBeaconStateApi({
       if (stateEpoch < config.ALTAIR_FORK_EPOCH) {
         throw new ApiError(400, "Requested state before ALTAIR_FORK_EPOCH");
       }
+      if (!isStatePostAltair(state)) {
+        throw new Error("Expected Altair state for sync committee lookup");
+      }
 
       const syncCommitteeCache = state.getIndexedSyncCommitteeAtEpoch(epoch ?? stateEpoch);
       const validatorIndices = new Array<ValidatorIndex>(...syncCommitteeCache.validatorIndices);
@@ -324,9 +324,9 @@ export function getBeaconStateApi({
 
     async getPendingDeposits({stateId}, context) {
       const {state, executionOptimistic, finalized} = await getState(stateId);
-      const fork = config.getForkName(state.slot);
+      const fork = state.forkName;
 
-      if (!isForkPostElectra(fork)) {
+      if (!isStatePostElectra(state)) {
         throw new ApiError(400, `Cannot retrieve pending deposits for pre-electra state fork=${fork}`);
       }
 
@@ -340,9 +340,9 @@ export function getBeaconStateApi({
 
     async getPendingPartialWithdrawals({stateId}, context) {
       const {state, executionOptimistic, finalized} = await getState(stateId);
-      const fork = config.getForkName(state.slot);
+      const fork = state.forkName;
 
-      if (!isForkPostElectra(fork)) {
+      if (!isStatePostElectra(state)) {
         throw new ApiError(400, `Cannot retrieve pending partial withdrawals for pre-electra state fork=${fork}`);
       }
 
@@ -358,9 +358,9 @@ export function getBeaconStateApi({
 
     async getPendingConsolidations({stateId}, context) {
       const {state, executionOptimistic, finalized} = await getState(stateId);
-      const fork = config.getForkName(state.slot);
+      const fork = state.forkName;
 
-      if (!isForkPostElectra(fork)) {
+      if (!isStatePostElectra(state)) {
         throw new ApiError(400, `Cannot retrieve pending consolidations for pre-electra state fork=${fork}`);
       }
 
@@ -376,9 +376,9 @@ export function getBeaconStateApi({
 
     async getProposerLookahead({stateId}, context) {
       const {state, executionOptimistic, finalized} = await getState(stateId);
-      const fork = config.getForkName(state.slot);
+      const fork = state.forkName;
 
-      if (!isForkPostFulu(fork)) {
+      if (!isStatePostFulu(state)) {
         throw new ApiError(400, `Cannot retrieve proposer lookahead for pre-fulu state fork=${fork}`);
       }
 

--- a/packages/beacon-node/src/api/impl/lodestar/index.ts
+++ b/packages/beacon-node/src/api/impl/lodestar/index.ts
@@ -3,6 +3,7 @@ import {ApplicationMethods} from "@lodestar/api/server";
 import {ChainForkConfig} from "@lodestar/config";
 import {Repository} from "@lodestar/db";
 import {ForkSeq, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {isStatePostCapella} from "@lodestar/state-transition";
 import {ssz} from "@lodestar/types";
 import {Checkpoint} from "@lodestar/types/phase0";
 import {fromHex, toHex, toRootHex} from "@lodestar/utils";
@@ -217,6 +218,9 @@ export function getLodestarApi({
       const fork = config.getForkName(stateView.slot);
       if (ForkSeq[fork] < ForkSeq.capella) {
         throw new Error("Historical summaries are not supported before Capella");
+      }
+      if (!isStatePostCapella(stateView)) {
+        throw new Error("Expected Capella state for historical summaries");
       }
 
       const {gindex} = ssz[fork].BeaconState.getPathInfo(["historicalSummaries"]);

--- a/packages/beacon-node/src/api/impl/validator/index.ts
+++ b/packages/beacon-node/src/api/impl/validator/index.ts
@@ -25,6 +25,7 @@ import {
   computeStartSlotAtEpoch,
   computeTimeAtSlot,
   getCurrentSlot,
+  isStatePostAltair,
   proposerShufflingDecisionRoot,
 } from "@lodestar/state-transition";
 import {
@@ -1282,6 +1283,9 @@ export function getValidatorApi(
       if (indices.length === 0) {
         throw new ApiError(400, "No validator to get attester duties");
       }
+      if (epoch < config.ALTAIR_FORK_EPOCH) {
+        throw new ApiError(400, "Sync committee duties are not supported before Altair");
+      }
 
       // May request for an epoch that's in the future
       await waitForNextClosestEpoch();
@@ -1291,6 +1295,9 @@ export function getValidatorApi(
       // Note: does not support requesting past duties
       const head = chain.forkChoice.getHead();
       const state = chain.getHeadState();
+      if (!isStatePostAltair(state)) {
+        throw new ApiError(400, "Sync committee duties are not available before Altair");
+      }
 
       // Check that all validatorIndex belong to the state before calling getCommitteeAssignments()
       const pubkeys = getPubkeysForIndices(state, indices);

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -24,6 +24,8 @@ import {
   computeStartSlotAtEpoch,
   computeTimeAtSlot,
   isStartSlotOfEpoch,
+  isStatePostAltair,
+  isStatePostBellatrix,
 } from "@lodestar/state-transition";
 import {
   Attestation,
@@ -370,11 +372,13 @@ export async function importBlock(
       // we want to import block asap so do this in the next event loop
       callInNextEventLoop(() => {
         try {
-          this.lightClientServer?.onImportBlockHead(
-            block.message as BeaconBlock<ForkPostAltair>,
-            postState,
-            parentBlockSlot
-          );
+          if (isStatePostAltair(postState)) {
+            this.lightClientServer?.onImportBlockHead(
+              block.message as BeaconBlock<ForkPostAltair>,
+              postState,
+              parentBlockSlot
+            );
+          }
         } catch (e) {
           this.logger.verbose("Error lightClientServer.onImportBlock", {slot: blockSlot}, e as Error);
         }
@@ -393,7 +397,7 @@ export async function importBlock(
   // and the block is weak and can potentially be reorged out.
   let shouldOverrideFcu = false;
 
-  if (blockSlot >= currentSlot && postState.isExecutionStateType) {
+  if (blockSlot >= currentSlot && isStatePostBellatrix(postState) && postState.isExecutionStateType) {
     let notOverrideFcuReason = NotReorgedReason.Unknown;
     const proposalSlot = blockSlot + 1;
     try {
@@ -580,7 +584,7 @@ export async function importBlock(
   this.metrics?.parentBlockDistance.observe(blockSlot - parentBlockSlot);
   this.metrics?.proposerBalanceDeltaAny.observe(fullyVerifiedBlock.proposerBalanceDelta);
   this.validatorMonitor?.registerImportedBlock(block.message, fullyVerifiedBlock);
-  if (this.config.getForkSeq(blockSlot) >= ForkSeq.altair) {
+  if (isStatePostAltair(fullyVerifiedBlock.postState)) {
     this.validatorMonitor?.registerSyncAggregateInBlock(
       blockEpoch,
       (block as altair.SignedBeaconBlock).message.body.syncAggregate,

--- a/packages/beacon-node/src/chain/blocks/importBlock.ts
+++ b/packages/beacon-node/src/chain/blocks/importBlock.ts
@@ -602,7 +602,7 @@ export async function importBlock(
   this.metrics?.parentBlockDistance.observe(blockSlot - parentBlockSlot);
   this.metrics?.proposerBalanceDeltaAny.observe(fullyVerifiedBlock.proposerBalanceDelta);
   this.validatorMonitor?.registerImportedBlock(block.message, fullyVerifiedBlock);
-  if (isStatePostAltair(fullyVerifiedBlock.postState)) {
+  if (isStatePostAltair(fullyVerifiedBlock.postBlockState)) {
     this.validatorMonitor?.registerSyncAggregateInBlock(
       blockEpoch,
       (block as altair.SignedBeaconBlock).message.body.syncAggregate,

--- a/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
+++ b/packages/beacon-node/src/chain/blocks/importExecutionPayload.ts
@@ -1,6 +1,6 @@
 import {routes} from "@lodestar/api";
 import {ForkName} from "@lodestar/params";
-import {getExecutionPayloadEnvelopeSignatureSet} from "@lodestar/state-transition";
+import {getExecutionPayloadEnvelopeSignatureSet, isStatePostGloas} from "@lodestar/state-transition";
 import {byteArrayEquals, fromHex, toRootHex} from "@lodestar/utils";
 import {ExecutionPayloadStatus} from "../../execution/index.js";
 import {isQueueErrorAborted} from "../../util/queue/index.js";
@@ -94,6 +94,12 @@ export async function importExecutionPayload(
     {dontTransferCache: true},
     RegenCaller.processBlock
   );
+  if (!isStatePostGloas(blockState)) {
+    throw new PayloadError({
+      code: PayloadErrorCode.STATE_TRANSITION_ERROR,
+      message: `Expected gloas+ block state for payload import, got fork=${blockState.forkName}`,
+    });
+  }
 
   // 4. Run verification steps in parallel
   // Note: No data availability check needed here - importExecutionPayload is only

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksExecutionPayloads.ts
@@ -8,7 +8,7 @@ import {
   ProtoBlock,
 } from "@lodestar/fork-choice";
 import {ForkSeq} from "@lodestar/params";
-import {IBeaconStateView, isExecutionBlockBodyType} from "@lodestar/state-transition";
+import {IBeaconStateView, isExecutionBlockBodyType, isStatePostBellatrix} from "@lodestar/state-transition";
 import {bellatrix, electra} from "@lodestar/types";
 import {ErrorAborted, Logger, toRootHex} from "@lodestar/utils";
 import {ExecutionPayloadStatus, IExecutionEngine} from "../../execution/engine/interface.js";
@@ -152,6 +152,7 @@ export async function verifyBlockExecutionPayload(
 
   /** Not null if execution is enabled */
   const executionPayloadEnabled =
+    isStatePostBellatrix(preState0) &&
     preState0.isExecutionStateType &&
     isExecutionBlockBodyType(block.message.body) &&
     preState0.isExecutionEnabled(block.message)

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
@@ -1,5 +1,10 @@
 import {BeaconConfig} from "@lodestar/config";
-import {IBeaconStateView, getBlockSignatureSets, isStatePostAltair} from "@lodestar/state-transition";
+import {
+  IBeaconStateView,
+  SyncCommitteeCacheEmpty,
+  getBlockSignatureSets,
+  isStatePostAltair,
+} from "@lodestar/state-transition";
 import {IndexedAttestation, SignedBeaconBlock} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
@@ -27,7 +32,9 @@ export async function verifyBlocksSignatures(
 ): Promise<{verifySignaturesTime: number}> {
   const isValidPromises: Promise<boolean>[] = [];
   const recvToValLatency = Date.now() / 1000 - (opts.seenTimestampSec ?? Date.now() / 1000);
-  const currentSyncCommitteeIndexed = isStatePostAltair(preState0) ? preState0.currentSyncCommitteeIndexed : null;
+  const currentSyncCommitteeIndexed = isStatePostAltair(preState0)
+    ? preState0.currentSyncCommitteeIndexed
+    : new SyncCommitteeCacheEmpty();
 
   // Verifies signatures after running state transition, so all SyncCommittee signed roots are known at this point.
   // We must ensure block.slot <= state.slot before running getAllBlockSignatureSets().

--- a/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
+++ b/packages/beacon-node/src/chain/blocks/verifyBlocksSignatures.ts
@@ -1,5 +1,5 @@
 import {BeaconConfig} from "@lodestar/config";
-import {IBeaconStateView, getBlockSignatureSets} from "@lodestar/state-transition";
+import {IBeaconStateView, getBlockSignatureSets, isStatePostAltair} from "@lodestar/state-transition";
 import {IndexedAttestation, SignedBeaconBlock} from "@lodestar/types";
 import {Logger} from "@lodestar/utils";
 import {Metrics} from "../../metrics/metrics.js";
@@ -27,7 +27,7 @@ export async function verifyBlocksSignatures(
 ): Promise<{verifySignaturesTime: number}> {
   const isValidPromises: Promise<boolean>[] = [];
   const recvToValLatency = Date.now() / 1000 - (opts.seenTimestampSec ?? Date.now() / 1000);
-  const currentSyncCommitteeIndexed = preState0.currentSyncCommitteeIndexed;
+  const currentSyncCommitteeIndexed = isStatePostAltair(preState0) ? preState0.currentSyncCommitteeIndexed : null;
 
   // Verifies signatures after running state transition, so all SyncCommittee signed roots are known at this point.
   // We must ensure block.slot <= state.slot before running getAllBlockSignatureSets().

--- a/packages/beacon-node/src/chain/chain.ts
+++ b/packages/beacon-node/src/chain/chain.ts
@@ -17,7 +17,6 @@ import {
   type ForkPostFulu,
   GENESIS_SLOT,
   SLOTS_PER_EPOCH,
-  isForkPostElectra,
   isForkPostGloas,
 } from "@lodestar/params";
 import {
@@ -29,6 +28,9 @@ import {
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
   getEffectiveBalancesFromStateBytes,
+  isStatePostAltair,
+  isStatePostElectra,
+  isStatePostGloas,
 } from "@lodestar/state-transition";
 import {
   BeaconBlock,
@@ -1019,6 +1021,9 @@ export class BeaconChain implements IBeaconChain {
         slot,
         stateRoot: ZERO_HASH,
       };
+      if (!isStatePostGloas(postState)) {
+        throw Error(`Expected gloas+ post-state for execution payload envelope, got fork=${postState.forkName}`);
+      }
       const envelopeStateRoot = computeEnvelopeStateRoot(this.metrics, postState, envelope);
       gloasResult.envelopeStateRoot = envelopeStateRoot;
     }
@@ -1347,9 +1352,7 @@ export class BeaconChain implements IBeaconChain {
     metrics.chain.blacklistedBlocks.set(this.blacklistedBlocks.size);
 
     const headState = this.getHeadState();
-    const fork = this.config.getForkName(headState.slot);
-
-    if (isForkPostElectra(fork)) {
+    if (isStatePostElectra(headState)) {
       metrics.pendingDeposits.set(headState.pendingDepositsCount);
       metrics.pendingPartialWithdrawals.set(headState.pendingPartialWithdrawalsCount);
       metrics.pendingConsolidations.set(headState.pendingConsolidationsCount);
@@ -1596,6 +1599,9 @@ export class BeaconChain implements IBeaconChain {
     }
 
     preState = preState.processSlots(block.slot); // Dial preState's slot to block.slot
+    if (!isStatePostAltair(preState)) {
+      throw new Error("Sync committee rewards are not supported before Altair");
+    }
 
     return preState.computeSyncCommitteeRewards(block, validatorIds ?? []);
   }

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -10,12 +10,14 @@ import {
   ForkChoiceOpts as RawForkChoiceOpts,
   getCheckpointPayloadStatus,
 } from "@lodestar/fork-choice";
-import {ForkSeq, ZERO_HASH_HEX} from "@lodestar/params";
+import {ZERO_HASH_HEX} from "@lodestar/params";
 import {
   DataAvailabilityStatus,
   IBeaconStateView,
   computeEpochAtSlot,
   computeStartSlotAtEpoch,
+  isStatePostBellatrix,
+  isStatePostGloas,
 } from "@lodestar/state-transition";
 import {Slot, ssz} from "@lodestar/types";
 import {Logger, toRootHex} from "@lodestar/utils";
@@ -107,6 +109,14 @@ export function initializeForkChoiceFromFinalizedState(
 
   // Determine finalized checkpoint payload status
   const finalizedPayloadStatus = getCheckpointPayloadStatus(config, state, finalizedCheckpoint.epoch);
+  const parentBlockHash = isForkPostGloas
+    ? (() => {
+        if (!isStatePostGloas(state)) {
+          throw new Error(`Expected gloas+ state for anchor checkpoint, got fork=${state.forkName}`);
+        }
+        return toRootHex(state.latestBlockHash);
+      })()
+    : null;
 
   return new forkchoiceConstructor(
     config,
@@ -142,19 +152,19 @@ export function initializeForkChoiceFromFinalizedState(
         unrealizedFinalizedEpoch: finalizedCheckpoint.epoch,
         unrealizedFinalizedRoot: toRootHex(finalizedCheckpoint.root),
 
-        ...(state.isExecutionStateType && state.isMergeTransitionComplete
+        ...(isStatePostBellatrix(state) && state.isExecutionStateType && state.isMergeTransitionComplete
           ? {
               executionPayloadBlockHash: toRootHex(state.latestBlockHash),
               // TODO GLOAS: executionPayloadNumber is not tracked in BeaconState post-gloas (EIP-7732 removed
               // latestExecutionPayloadHeader). Using 0 as unavailable fallback until a solution is found.
-              executionPayloadNumber: config.getForkSeq(state.slot) >= ForkSeq.gloas ? 0 : state.payloadBlockNumber,
+              executionPayloadNumber: isStatePostGloas(state) ? 0 : state.payloadBlockNumber,
               executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,
             }
           : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),
 
         dataAvailabilityStatus: DataAvailabilityStatus.PreData,
         payloadStatus: isForkPostGloas ? PayloadStatus.PENDING : PayloadStatus.FULL, // TODO GLOAS: Post-gloas how do we know if the checkpoint payload is FULL or EMPTY?
-        parentBlockHash: isForkPostGloas ? toRootHex(state.latestBlockHash) : null,
+        parentBlockHash,
       },
       currentSlot
     ),
@@ -204,6 +214,14 @@ export function initializeForkChoiceFromUnfinalizedState(
   // It checks state.execution_payload_availability to determine EMPTY vs FULL.
   const justifiedPayloadStatus = getCheckpointPayloadStatus(config, unfinalizedState, justifiedCheckpoint.epoch);
   const finalizedPayloadStatus = getCheckpointPayloadStatus(config, unfinalizedState, finalizedCheckpoint.epoch);
+  const parentBlockHash = isForkPostGloas
+    ? (() => {
+        if (!isStatePostGloas(unfinalizedState)) {
+          throw new Error(`Expected gloas+ state for unfinalized anchor, got fork=${unfinalizedState.forkName}`);
+        }
+        return toRootHex(unfinalizedState.latestBlockHash);
+      })()
+    : null;
 
   const store = new ForkChoiceStore(
     currentSlot,
@@ -237,20 +255,21 @@ export function initializeForkChoiceFromUnfinalizedState(
     unrealizedFinalizedEpoch: finalizedCheckpoint.epoch,
     unrealizedFinalizedRoot: toRootHex(finalizedCheckpoint.root),
 
-    ...(unfinalizedState.isExecutionStateType && unfinalizedState.isMergeTransitionComplete
+    ...(isStatePostBellatrix(unfinalizedState) &&
+    unfinalizedState.isExecutionStateType &&
+    unfinalizedState.isMergeTransitionComplete
       ? {
           executionPayloadBlockHash: toRootHex(unfinalizedState.latestBlockHash),
           // TODO GLOAS: executionPayloadNumber is not tracked in BeaconState post-gloas (EIP-7732 removed
           // latestExecutionPayloadHeader). Using 0 as unavailable fallback until a solution is found.
-          executionPayloadNumber:
-            config.getForkSeq(unfinalizedState.slot) >= ForkSeq.gloas ? 0 : unfinalizedState.payloadBlockNumber,
+          executionPayloadNumber: isStatePostGloas(unfinalizedState) ? 0 : unfinalizedState.payloadBlockNumber,
           executionStatus: blockHeader.slot === GENESIS_SLOT ? ExecutionStatus.Valid : ExecutionStatus.Syncing,
         }
       : {executionPayloadBlockHash: null, executionStatus: ExecutionStatus.PreMerge}),
 
     dataAvailabilityStatus: DataAvailabilityStatus.PreData,
     payloadStatus: isForkPostGloas ? PayloadStatus.PENDING : PayloadStatus.FULL, // TODO GLOAS: Post-gloas how do we know if the checkpoint payload is FULL or EMPTY?
-    parentBlockHash: isForkPostGloas ? toRootHex(unfinalizedState.latestBlockHash) : null,
+    parentBlockHash,
   };
 
   const parentSlot = blockHeader.slot - 1;

--- a/packages/beacon-node/src/chain/forkChoice/index.ts
+++ b/packages/beacon-node/src/chain/forkChoice/index.ts
@@ -109,14 +109,6 @@ export function initializeForkChoiceFromFinalizedState(
 
   // Determine finalized checkpoint payload status
   const finalizedPayloadStatus = getCheckpointPayloadStatus(config, state, finalizedCheckpoint.epoch);
-  const parentBlockHash = isForkPostGloas
-    ? (() => {
-        if (!isStatePostGloas(state)) {
-          throw new Error(`Expected gloas+ state for anchor checkpoint, got fork=${state.forkName}`);
-        }
-        return toRootHex(state.latestBlockHash);
-      })()
-    : null;
 
   return new forkchoiceConstructor(
     config,
@@ -164,7 +156,7 @@ export function initializeForkChoiceFromFinalizedState(
 
         dataAvailabilityStatus: DataAvailabilityStatus.PreData,
         payloadStatus: isForkPostGloas ? PayloadStatus.PENDING : PayloadStatus.FULL, // TODO GLOAS: Post-gloas how do we know if the checkpoint payload is FULL or EMPTY?
-        parentBlockHash,
+        parentBlockHash: isStatePostGloas(state) ? toRootHex(state.latestBlockHash) : null,
       },
       currentSlot
     ),
@@ -214,14 +206,6 @@ export function initializeForkChoiceFromUnfinalizedState(
   // It checks state.execution_payload_availability to determine EMPTY vs FULL.
   const justifiedPayloadStatus = getCheckpointPayloadStatus(config, unfinalizedState, justifiedCheckpoint.epoch);
   const finalizedPayloadStatus = getCheckpointPayloadStatus(config, unfinalizedState, finalizedCheckpoint.epoch);
-  const parentBlockHash = isForkPostGloas
-    ? (() => {
-        if (!isStatePostGloas(unfinalizedState)) {
-          throw new Error(`Expected gloas+ state for unfinalized anchor, got fork=${unfinalizedState.forkName}`);
-        }
-        return toRootHex(unfinalizedState.latestBlockHash);
-      })()
-    : null;
 
   const store = new ForkChoiceStore(
     currentSlot,
@@ -269,7 +253,7 @@ export function initializeForkChoiceFromUnfinalizedState(
 
     dataAvailabilityStatus: DataAvailabilityStatus.PreData,
     payloadStatus: isForkPostGloas ? PayloadStatus.PENDING : PayloadStatus.FULL, // TODO GLOAS: Post-gloas how do we know if the checkpoint payload is FULL or EMPTY?
-    parentBlockHash,
+    parentBlockHash: isStatePostGloas(unfinalizedState) ? toRootHex(unfinalizedState.latestBlockHash) : null,
   };
 
   const parentSlot = blockHeader.slot - 1;

--- a/packages/beacon-node/src/chain/lightClient/index.ts
+++ b/packages/beacon-node/src/chain/lightClient/index.ts
@@ -21,7 +21,7 @@ import {
   isForkPostElectra,
 } from "@lodestar/params";
 import {
-  IBeaconStateView,
+  type IBeaconStateViewAltair,
   computeStartSlotAtEpoch,
   computeSyncPeriodAtEpoch,
   computeSyncPeriodAtSlot,
@@ -260,7 +260,11 @@ export class LightClientServer {
    * - Persist state witness
    * - Use block's syncAggregate
    */
-  onImportBlockHead(block: BeaconBlock<ForkPostAltair>, postState: IBeaconStateView, parentBlockSlot: Slot): void {
+  onImportBlockHead(
+    block: BeaconBlock<ForkPostAltair>,
+    postState: IBeaconStateViewAltair,
+    parentBlockSlot: Slot
+  ): void {
     // TEMP: To disable this functionality for fork_choice spec tests.
     // Since the tests have deep-reorgs attested data is not available often printing lots of error logs.
     // While this function is only called for head blocks, best to disable.
@@ -396,7 +400,7 @@ export class LightClientServer {
 
   private async persistPostBlockImportData(
     block: BeaconBlock<ForkPostAltair>,
-    postState: IBeaconStateView,
+    postState: IBeaconStateViewAltair,
     parentBlockSlot: Slot
   ): Promise<void> {
     const blockSlot = block.slot;

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -355,14 +355,13 @@ export class AggregatedAttestationPool {
         // after all committees are processed, we have a list of sameAttDataCons
         for (const consolidation of sameAttDataCons) {
           // Score attestations by profitability to maximize proposer reward
-          const executionPayloadAvailability = isStatePostGloas(state) ? state.executionPayloadAvailability : null;
           const flags = getAttestationParticipationStatus(
             ForkSeq[fork],
             consolidation.attData,
             inclusionDistance,
             stateEpoch,
             rootCache,
-            executionPayloadAvailability
+            isStatePostGloas(state) ? state.executionPayloadAvailability : null
           );
 
           const weight =

--- a/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
+++ b/packages/beacon-node/src/chain/opPools/aggregatedAttestationPool.ts
@@ -26,6 +26,8 @@ import {
   computeSlotsSinceEpochStart,
   computeStartSlotAtEpoch,
   getAttestationParticipationStatus,
+  isStatePostAltair,
+  isStatePostGloas,
 } from "@lodestar/state-transition";
 import {Attestation, Epoch, RootHex, Slot, electra, isElectraAttestation, phase0, ssz} from "@lodestar/types";
 import {MapDef, assert, toRootHex} from "@lodestar/utils";
@@ -353,13 +355,14 @@ export class AggregatedAttestationPool {
         // after all committees are processed, we have a list of sameAttDataCons
         for (const consolidation of sameAttDataCons) {
           // Score attestations by profitability to maximize proposer reward
+          const executionPayloadAvailability = isStatePostGloas(state) ? state.executionPayloadAvailability : null;
           const flags = getAttestationParticipationStatus(
             ForkSeq[fork],
             consolidation.attData,
             inclusionDistance,
             stateEpoch,
             rootCache,
-            ForkSeq[fork] >= ForkSeq.gloas ? state.executionPayloadAvailability : null
+            executionPayloadAvailability
           );
 
           const weight =
@@ -741,6 +744,9 @@ export function getNotSeenValidatorsFn(
   const stateSlot = state.slot;
   if (config.getForkName(stateSlot) === ForkName.phase0) {
     throw new Error("getNotSeenValidatorsFn is not supported phase0 state");
+  }
+  if (!isStatePostAltair(state)) {
+    throw new Error("Expected Altair state for participation tracking");
   }
 
   // altair and future forks

--- a/packages/beacon-node/src/chain/prepareNextSlot.ts
+++ b/packages/beacon-node/src/chain/prepareNextSlot.ts
@@ -7,6 +7,7 @@ import {
   StateHashTreeRootSource,
   computeEpochAtSlot,
   computeTimeAtSlot,
+  isStatePostBellatrix,
 } from "@lodestar/state-transition";
 import {Slot} from "@lodestar/types";
 import {Logger, fromHex, isErrorAborted, sleep} from "@lodestar/utils";
@@ -159,6 +160,9 @@ export class PrepareNextSlotScheduler {
           const preparationTime =
             computeTimeAtSlot(this.config, prepareSlot, this.chain.genesisTime) - Date.now() / 1000;
           this.metrics?.blockPayload.payloadAdvancePrepTime.observe(preparationTime);
+          if (!isStatePostBellatrix(updatedPrepareState)) {
+            throw new Error("Expected Bellatrix state for payload preparation");
+          }
 
           const safeBlockHash = getSafeExecutionBlockHash(this.chain.forkChoice);
           const finalizedBlockHash =
@@ -181,6 +185,10 @@ export class PrepareNextSlotScheduler {
             proposerIndex,
             feeRecipient,
           });
+        }
+
+        if (!isStatePostBellatrix(updatedPrepareState)) {
+          throw new Error("Expected Bellatrix state for payload attributes");
         }
 
         this.computeStateHashTreeRoot(updatedPrepareState, isEpochTransition);

--- a/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
+++ b/packages/beacon-node/src/chain/produceBlock/computeNewStateRoot.ts
@@ -3,6 +3,7 @@ import {
   ExecutionPayloadStatus,
   G2_POINT_AT_INFINITY,
   IBeaconStateView,
+  IBeaconStateViewGloas,
   StateHashTreeRootSource,
 } from "@lodestar/state-transition";
 import {BeaconBlock, BlindedBeaconBlock, Gwei, Root, gloas} from "@lodestar/types";
@@ -60,7 +61,7 @@ export function computeNewStateRoot(
  */
 export function computeEnvelopeStateRoot(
   metrics: Metrics | null,
-  postBlockState: IBeaconStateView,
+  postBlockState: IBeaconStateViewGloas,
   envelope: gloas.ExecutionPayloadEnvelope
 ): Root {
   const signedEnvelope: gloas.SignedExecutionPayloadEnvelope = {

--- a/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
+++ b/packages/beacon-node/src/chain/produceBlock/produceBlockBody.ts
@@ -14,7 +14,15 @@ import {
   isForkPostBellatrix,
   isForkPostGloas,
 } from "@lodestar/params";
-import {G2_POINT_AT_INFINITY, IBeaconStateView, computeTimeAtSlot} from "@lodestar/state-transition";
+import {
+  G2_POINT_AT_INFINITY,
+  IBeaconStateView,
+  type IBeaconStateViewBellatrix,
+  computeTimeAtSlot,
+  isStatePostBellatrix,
+  isStatePostCapella,
+  isStatePostGloas,
+} from "@lodestar/state-transition";
 import {
   BLSPubkey,
   BLSSignature,
@@ -191,6 +199,10 @@ export async function produceBlockBody<T extends BlockType>(
   this.logger.verbose("Producing beacon block body", logMeta);
 
   if (isForkPostGloas(fork)) {
+    if (!isStatePostGloas(currentState)) {
+      throw new Error("Expected Gloas state for Gloas block production");
+    }
+
     // TODO GLOAS: support non self-building here, the block type differentiation between
     // full and blinded no longer makes sense in gloas, it might be a good idea to move
     // this into a completely separate function and have pre/post gloas more separated
@@ -297,6 +309,10 @@ export async function produceBlockBody<T extends BlockType>(
       shouldOverrideBuilder,
     });
   } else if (isForkPostBellatrix(fork)) {
+    if (!isStatePostBellatrix(currentState)) {
+      throw new Error("Expected Bellatrix state for execution block production");
+    }
+
     const safeBlockHash = getSafeExecutionBlockHash(this.forkChoice);
     const finalizedBlockHash = this.forkChoice.getFinalizedBlock().executionPayloadBlockHash ?? ZERO_HASH_HEX;
     const feeRecipient = requestedFeeRecipient ?? this.beaconProposerCache.getOrDefault(proposerIndex);
@@ -598,7 +614,7 @@ export async function prepareExecutionPayload(
   parentBlockRoot: Root,
   safeBlockHash: RootHex,
   finalizedBlockHash: RootHex,
-  state: IBeaconStateView,
+  state: IBeaconStateViewBellatrix,
   suggestedFeeRecipient: string
 ): Promise<{prepType: PayloadPreparationType; payloadId: PayloadId}> {
   const parentHash = state.latestBlockHash;
@@ -666,7 +682,7 @@ async function prepareExecutionPayloadHeader(
     config: ChainForkConfig;
   },
   fork: ForkPostBellatrix,
-  state: IBeaconStateView,
+  state: IBeaconStateViewBellatrix,
   proposerPubKey: BLSPubkey
 ): Promise<{
   header: ExecutionPayloadHeader;
@@ -693,7 +709,7 @@ export function getPayloadAttributesForSSE(
     prepareSlot,
     parentBlockRoot,
     feeRecipient,
-  }: {prepareState: IBeaconStateView; prepareSlot: Slot; parentBlockRoot: Root; feeRecipient: string}
+  }: {prepareState: IBeaconStateViewBellatrix; prepareSlot: Slot; parentBlockRoot: Root; feeRecipient: string}
 ): SSEPayloadAttributes {
   const parentHash = prepareState.latestBlockHash;
   const payloadAttributes = preparePayloadAttributes(fork, chain, {
@@ -736,7 +752,7 @@ function preparePayloadAttributes(
     parentBlockRoot,
     feeRecipient,
   }: {
-    prepareState: IBeaconStateView;
+    prepareState: IBeaconStateViewBellatrix;
     prepareSlot: Slot;
     parentBlockRoot: Root;
     feeRecipient: string;
@@ -751,6 +767,10 @@ function preparePayloadAttributes(
   };
 
   if (ForkSeq[fork] >= ForkSeq.capella) {
+    if (!isStatePostCapella(prepareState)) {
+      throw new Error("Expected Capella state for withdrawals");
+    }
+
     // withdrawals logic is now fork aware as it changes on electra fork post capella
     (payloadAttributes as capella.SSEPayloadAttributes["payloadAttributes"]).withdrawals =
       prepareState.getExpectedWithdrawals().expectedWithdrawals;

--- a/packages/beacon-node/src/chain/validation/block.ts
+++ b/packages/beacon-node/src/chain/validation/block.ts
@@ -6,6 +6,7 @@ import {
   computeTimeAtSlot,
   getBlockProposerSignatureSet,
   isExecutionBlockBodyType,
+  isStatePostBellatrix,
 } from "@lodestar/state-transition";
 import {SignedBeaconBlock, deneb, gloas, isGloasBeaconBlock} from "@lodestar/types";
 import {byteArrayEquals, sleep, toRootHex} from "@lodestar/utils";
@@ -174,7 +175,7 @@ export async function validateGossipBlock(
   if (isForkPostBellatrix(fork) && !isForkPostGloas(fork)) {
     if (!isExecutionBlockBodyType(block.body)) throw Error("Not execution block body type");
     const executionPayload = block.body.executionPayload;
-    if (blockState.isExecutionStateType && blockState.isExecutionEnabled(block)) {
+    if (isStatePostBellatrix(blockState) && blockState.isExecutionStateType && blockState.isExecutionEnabled(block)) {
       const expectedTimestamp = computeTimeAtSlot(config, blockSlot, chain.genesisTime);
       if (executionPayload.timestamp !== computeTimeAtSlot(config, blockSlot, chain.genesisTime)) {
         throw new BlockGossipError(GossipAction.REJECT, {

--- a/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadBid.ts
@@ -3,6 +3,7 @@ import {
   createSingleSignatureSetFromComponents,
   getExecutionPayloadBidSigningRoot,
   isActiveBuilder,
+  isStatePostGloas,
 } from "@lodestar/state-transition";
 import {gloas} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
@@ -32,6 +33,9 @@ async function validateExecutionPayloadBid(
   const parentBlockRootHex = toRootHex(bid.parentBlockRoot);
   const parentBlockHashHex = toRootHex(bid.parentBlockHash);
   const state = await chain.getHeadStateAtCurrentEpoch(RegenCaller.validateGossipExecutionPayloadBid);
+  if (!isStatePostGloas(state)) {
+    throw new Error(`Expected gloas+ state for execution payload bid validation, got fork=${state.forkName}`);
+  }
 
   // [IGNORE] `bid.slot` is the current slot or the next slot.
   const currentSlot = chain.clock.currentSlot;

--- a/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
+++ b/packages/beacon-node/src/chain/validation/executionPayloadEnvelope.ts
@@ -1,5 +1,9 @@
 import {PayloadStatus} from "@lodestar/fork-choice";
-import {computeStartSlotAtEpoch, getExecutionPayloadEnvelopeSignatureSet} from "@lodestar/state-transition";
+import {
+  computeStartSlotAtEpoch,
+  getExecutionPayloadEnvelopeSignatureSet,
+  isStatePostGloas,
+} from "@lodestar/state-transition";
 import {gloas} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {ExecutionPayloadEnvelopeError, ExecutionPayloadEnvelopeErrorCode, GossipAction} from "../errors/index.js";
@@ -113,6 +117,9 @@ async function validateExecutionPayloadEnvelope(
         slot: envelope.slot,
       });
     });
+  if (!isStatePostGloas(blockState)) {
+    throw new Error(`Expected gloas+ state for execution payload envelope validation, got fork=${blockState.forkName}`);
+  }
 
   const signatureSet = getExecutionPayloadEnvelopeSignatureSet(
     chain.config,

--- a/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
+++ b/packages/beacon-node/src/chain/validation/payloadAttestationMessage.ts
@@ -2,6 +2,7 @@ import {
   computeEpochAtSlot,
   createSingleSignatureSetFromComponents,
   getPayloadAttestationDataSigningRoot,
+  isStatePostGloas,
 } from "@lodestar/state-transition";
 import {RootHex, gloas, ssz} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
@@ -66,6 +67,9 @@ async function validatePayloadAttestationMessage(
   }
 
   const state = chain.getHeadState();
+  if (!isStatePostGloas(state)) {
+    throw new Error(`Expected gloas+ state for payload attestation validation, got fork=${state.forkName}`);
+  }
 
   // [REJECT] The message's block `data.beacon_block_root` passes validation.
   // TODO GLOAS: implement this. Technically if we cannot get proto block from fork choice,

--- a/packages/beacon-node/src/chain/validation/syncCommittee.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommittee.ts
@@ -1,5 +1,5 @@
 import {SYNC_COMMITTEE_SUBNET_COUNT, SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
-import {IBeaconStateView} from "@lodestar/state-transition";
+import {IBeaconStateView, isStatePostAltair} from "@lodestar/state-transition";
 import {SubnetID, altair} from "@lodestar/types";
 import {toRootHex} from "@lodestar/utils";
 import {GossipAction, SyncCommitteeError, SyncCommitteeErrorCode} from "../errors/index.js";
@@ -148,6 +148,10 @@ function getIndicesInSubcommittee(
   subnet: SubnetID,
   data: Pick<altair.SyncCommitteeMessage, "slot" | "validatorIndex">
 ): IndexInSubcommittee[] | null {
+  if (!isStatePostAltair(headState)) {
+    return null;
+  }
+
   const syncCommittee = headState.getIndexedSyncCommittee(data.slot);
   const indexesInCommittee = syncCommittee.validatorIndexMap.get(data.validatorIndex);
   if (indexesInCommittee === undefined) {

--- a/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
+++ b/packages/beacon-node/src/chain/validation/syncCommitteeContributionAndProof.ts
@@ -1,5 +1,5 @@
 import {SYNC_COMMITTEE_SUBNET_SIZE} from "@lodestar/params";
-import {IBeaconStateView, isSyncCommitteeAggregator} from "@lodestar/state-transition";
+import {IBeaconStateView, isStatePostAltair, isSyncCommitteeAggregator} from "@lodestar/state-transition";
 import {ValidatorIndex, altair} from "@lodestar/types";
 import {GossipAction, SyncCommitteeError, SyncCommitteeErrorCode} from "../errors/index.js";
 import {IBeaconChain} from "../interface.js";
@@ -107,6 +107,10 @@ function getContributionIndices(
   state: IBeaconStateView,
   contribution: altair.SyncCommitteeContribution
 ): ValidatorIndex[] {
+  if (!isStatePostAltair(state)) {
+    throw new Error("Expected Altair state for sync committee contribution");
+  }
+
   const startIndex = contribution.subcommitteeIndex * SYNC_COMMITTEE_SUBNET_SIZE;
 
   const syncCommittee = state.getIndexedSyncCommittee(contribution.slot);

--- a/packages/beacon-node/src/chain/validatorMonitor.ts
+++ b/packages/beacon-node/src/chain/validatorMonitor.ts
@@ -1,5 +1,5 @@
 import {ChainForkConfig} from "@lodestar/config";
-import {ForkSeq, MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@lodestar/params";
+import {MIN_ATTESTATION_INCLUSION_DELAY, SLOTS_PER_EPOCH} from "@lodestar/params";
 import {
   IBeaconStateView,
   ParticipationFlags,
@@ -7,6 +7,7 @@ import {
   computeStartSlotAtEpoch,
   computeTimeAtSlot,
   getCurrentSlot,
+  isStatePostAltair,
   parseAttesterFlags,
   parseParticipationFlags,
 } from "@lodestar/state-transition";
@@ -740,7 +741,7 @@ export function createValidatorMonitor(
 
       const rootCache = new RootHexCache(headState);
 
-      if (config.getForkSeq(headState.slot) >= ForkSeq.altair) {
+      if (isStatePostAltair(headState)) {
         const prevEpochStartSlot = computeStartSlotAtEpoch(prevEpoch);
         const prevEpochTargetRoot = toRootHex(headState.getBlockRootAtSlot(prevEpochStartSlot));
 

--- a/packages/beacon-node/src/node/nodejs.ts
+++ b/packages/beacon-node/src/node/nodejs.ts
@@ -6,7 +6,7 @@ import {BeaconApiMethods} from "@lodestar/api/beacon/server";
 import {BeaconConfig} from "@lodestar/config";
 import type {LoggerNode} from "@lodestar/logger/node";
 import {ZERO_HASH_HEX} from "@lodestar/params";
-import {IBeaconStateView, PubkeyCache} from "@lodestar/state-transition";
+import {IBeaconStateView, PubkeyCache, isStatePostBellatrix} from "@lodestar/state-transition";
 import {phase0} from "@lodestar/types";
 import {sleep, toRootHex} from "@lodestar/utils";
 import {ProcessShutdownCallback} from "@lodestar/validator";
@@ -221,7 +221,10 @@ export class BeaconNode {
 
     let executionEngineOpts = opts.executionEngine;
     if (opts.executionEngine.mode === "mock") {
-      const eth1BlockHash = anchorState.isExecutionStateType ? toRootHex(anchorState.latestBlockHash) : undefined;
+      const eth1BlockHash =
+        isStatePostBellatrix(anchorState) && anchorState.isExecutionStateType
+          ? toRootHex(anchorState.latestBlockHash)
+          : undefined;
       executionEngineOpts = {
         ...opts.executionEngine,
         genesisBlockHash: ZERO_HASH_HEX,

--- a/packages/beacon-node/src/node/notifier.ts
+++ b/packages/beacon-node/src/node/notifier.ts
@@ -1,7 +1,12 @@
 import {BeaconConfig} from "@lodestar/config";
 import {ExecutionStatus, ProtoBlock} from "@lodestar/fork-choice";
 import {EPOCHS_PER_SYNC_COMMITTEE_PERIOD, SLOTS_PER_EPOCH} from "@lodestar/params";
-import {IBeaconStateView, computeEpochAtSlot, computeStartSlotAtEpoch} from "@lodestar/state-transition";
+import {
+  IBeaconStateView,
+  computeEpochAtSlot,
+  computeStartSlotAtEpoch,
+  isStatePostBellatrix,
+} from "@lodestar/state-transition";
 import {Epoch} from "@lodestar/types";
 import {ErrorAborted, Logger, prettyBytes, prettyBytesShort, sleep} from "@lodestar/utils";
 import {IBeaconChain} from "../chain/index.js";
@@ -165,7 +170,7 @@ function getHeadExecutionInfo(
   const executionStatusStr = headInfo.executionStatus.toLowerCase();
 
   // Add execution status to notifier only if head is on/post bellatrix
-  if (headState.isExecutionStateType) {
+  if (isStatePostBellatrix(headState) && headState.isExecutionStateType) {
     if (headState.isMergeTransitionComplete) {
       const executionPayloadHashInfo =
         headInfo.executionStatus !== ExecutionStatus.PreMerge ? headInfo.executionPayloadBlockHash : "empty";

--- a/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
+++ b/packages/beacon-node/test/e2e/api/impl/lightclient/endpoint.test.ts
@@ -3,6 +3,7 @@ import {HttpHeader, getClient, routes} from "@lodestar/api";
 import {ChainConfig, createBeaconConfig} from "@lodestar/config";
 import {LogLevel, TestLoggerOpts, testLogger} from "@lodestar/logger/test-utils";
 import {ForkName} from "@lodestar/params";
+import {isStatePostAltair} from "@lodestar/state-transition";
 import {phase0, ssz} from "@lodestar/types";
 import {sleep} from "@lodestar/utils";
 import {Validator} from "@lodestar/validator";
@@ -131,6 +132,9 @@ describe.skipIf(process.env.CI)("lightclient api", () => {
     // The sync committee is computed using a weighted random shuffle, not simple alternation
     // Since the test starts at Electra, headState is always post-Altair and has currentSyncCommittee
     const headState = bn.chain.getHeadState();
+    if (!isStatePostAltair(headState)) {
+      throw new Error("Expected Altair state in lightclient test");
+    }
     const expectedRoot = ssz.altair.SyncCommittee.hashTreeRoot(headState.currentSyncCommittee);
 
     // single committee hash since we requested for the first period

--- a/packages/fork-choice/src/forkChoice/forkChoice.ts
+++ b/packages/fork-choice/src/forkChoice/forkChoice.ts
@@ -10,6 +10,8 @@ import {
   computeStartSlotAtEpoch,
   getAttesterSlashableIndices,
   isExecutionBlockBodyType,
+  isStatePostBellatrix,
+  isStatePostGloas,
 } from "@lodestar/state-transition";
 import {
   AttesterSlashing,
@@ -824,7 +826,10 @@ export class ForkChoice implements IForkChoice {
             executionStatus: this.getPostGloasExecStatus(executionStatus),
             dataAvailabilityStatus,
           }
-        : isExecutionBlockBodyType(block.body) && state.isExecutionStateType && state.isExecutionEnabled(block)
+        : isExecutionBlockBodyType(block.body) &&
+            isStatePostBellatrix(state) &&
+            state.isExecutionStateType &&
+            state.isExecutionEnabled(block)
           ? {
               executionPayloadBlockHash: toRootHex(block.body.executionPayload.blockHash),
               executionPayloadNumber: block.body.executionPayload.blockNumber,
@@ -1870,6 +1875,9 @@ export function getCheckpointPayloadStatus(
   // Pre-Gloas: always FULL
   if (fork < ForkSeq.gloas) {
     return PayloadStatus.FULL;
+  }
+  if (!isStatePostGloas(state)) {
+    throw new Error(`Expected gloas+ state for checkpoint payload status, got fork=${state.forkName}`);
   }
 
   // For Gloas, check state.execution_payload_availability

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -42,7 +42,24 @@ export {type BeaconStateTransitionMetrics, getMetrics} from "./metrics.js";
 export * from "./rewards/index.js";
 export * from "./signatureSets/index.js";
 export * from "./stateTransition.js";
-export * from "./stateView/index.js";
+export {BeaconStateView, createBeaconStateViewForHistoricalRegen} from "./stateView/beaconStateView.js";
+export {
+  type IBeaconStateView,
+  type IBeaconStateViewAltair,
+  type IBeaconStateViewBellatrix,
+  type IBeaconStateViewCapella,
+  type IBeaconStateViewDeneb,
+  type IBeaconStateViewElectra,
+  type IBeaconStateViewFulu,
+  type IBeaconStateViewGloas,
+  isStatePostAltair,
+  isStatePostBellatrix,
+  isStatePostCapella,
+  isStatePostDeneb,
+  isStatePostElectra,
+  isStatePostFulu,
+  isStatePostGloas,
+} from "./stateView/interface.js";
 export type {
   BeaconStateAllForks,
   BeaconStateAltair,

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -35,7 +35,7 @@ export {
   isStateValidatorsNodesPopulated,
   loadCachedBeaconState,
 } from "./cache/stateCache.js";
-export {type SyncCommitteeCache} from "./cache/syncCommitteeCache.js";
+export {type SyncCommitteeCache, SyncCommitteeCacheEmpty} from "./cache/syncCommitteeCache.js";
 export * from "./constants/index.js";
 export type {EpochTransitionStep} from "./epoch/index.js";
 export {type BeaconStateTransitionMetrics, getMetrics} from "./metrics.js";

--- a/packages/state-transition/src/index.ts
+++ b/packages/state-transition/src/index.ts
@@ -42,7 +42,7 @@ export {type BeaconStateTransitionMetrics, getMetrics} from "./metrics.js";
 export * from "./rewards/index.js";
 export * from "./signatureSets/index.js";
 export * from "./stateTransition.js";
-export {BeaconStateView, createBeaconStateViewForHistoricalRegen} from "./stateView/beaconStateView.js";
+export {BeaconStateView} from "./stateView/beaconStateView.js";
 export {
   type IBeaconStateView,
   type IBeaconStateViewAltair,
@@ -60,6 +60,7 @@ export {
   isStatePostFulu,
   isStatePostGloas,
 } from "./stateView/interface.js";
+export {createBeaconStateView, createBeaconStateViewForHistoricalRegen} from "./stateView/stateViewFactory.js";
 export type {
   BeaconStateAllForks,
   BeaconStateAltair,

--- a/packages/state-transition/src/signatureSets/executionPayloadEnvelope.ts
+++ b/packages/state-transition/src/signatureSets/executionPayloadEnvelope.ts
@@ -3,7 +3,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {BUILDER_INDEX_SELF_BUILD, DOMAIN_BEACON_BUILDER} from "@lodestar/params";
 import {ValidatorIndex, gloas, ssz} from "@lodestar/types";
 import {PubkeyCache} from "../cache/pubkeyCache.js";
-import {IBeaconStateView} from "../stateView/interface.js";
+import {IBeaconStateView, isStatePostGloas} from "../stateView/interface.js";
 import {computeSigningRoot} from "../util/index.js";
 import {type SingleSignatureSet, createSingleSignatureSetFromComponents} from "../util/signatureSets.js";
 
@@ -24,10 +24,16 @@ export function getExecutionPayloadEnvelopeSignatureSet(
   proposerIndex: ValidatorIndex
 ): SingleSignatureSet {
   const envelope = signedEnvelope.message;
-  const pubkey =
-    envelope.builderIndex === BUILDER_INDEX_SELF_BUILD
-      ? pubkeyCache.getOrThrow(proposerIndex)
-      : PublicKey.fromBytes(state.getBuilder(envelope.builderIndex).pubkey);
+  let pubkey: PublicKey;
+
+  if (envelope.builderIndex === BUILDER_INDEX_SELF_BUILD) {
+    pubkey = pubkeyCache.getOrThrow(proposerIndex);
+  } else {
+    if (!isStatePostGloas(state)) {
+      throw new Error(`Expected gloas+ state for execution payload envelope signature, got fork=${state.forkName}`);
+    }
+    pubkey = PublicKey.fromBytes(state.getBuilder(envelope.builderIndex).pubkey);
+  }
 
   return createSingleSignatureSetFromComponents(
     pubkey,

--- a/packages/state-transition/src/signatureSets/executionPayloadEnvelope.ts
+++ b/packages/state-transition/src/signatureSets/executionPayloadEnvelope.ts
@@ -23,15 +23,16 @@ export function getExecutionPayloadEnvelopeSignatureSet(
   signedEnvelope: gloas.SignedExecutionPayloadEnvelope,
   proposerIndex: ValidatorIndex
 ): SingleSignatureSet {
+  if (!isStatePostGloas(state)) {
+    throw new Error(`Expected gloas+ state for execution payload envelope signature, got fork=${state.forkName}`);
+  }
+
   const envelope = signedEnvelope.message;
   let pubkey: PublicKey;
 
   if (envelope.builderIndex === BUILDER_INDEX_SELF_BUILD) {
     pubkey = pubkeyCache.getOrThrow(proposerIndex);
   } else {
-    if (!isStatePostGloas(state)) {
-      throw new Error(`Expected gloas+ state for execution payload envelope signature, got fork=${state.forkName}`);
-    }
     pubkey = PublicKey.fromBytes(state.getBuilder(envelope.builderIndex).pubkey);
   }
 

--- a/packages/state-transition/src/signatureSets/executionPayloadEnvelope.ts
+++ b/packages/state-transition/src/signatureSets/executionPayloadEnvelope.ts
@@ -28,13 +28,10 @@ export function getExecutionPayloadEnvelopeSignatureSet(
   }
 
   const envelope = signedEnvelope.message;
-  let pubkey: PublicKey;
-
-  if (envelope.builderIndex === BUILDER_INDEX_SELF_BUILD) {
-    pubkey = pubkeyCache.getOrThrow(proposerIndex);
-  } else {
-    pubkey = PublicKey.fromBytes(state.getBuilder(envelope.builderIndex).pubkey);
-  }
+  const pubkey =
+    envelope.builderIndex === BUILDER_INDEX_SELF_BUILD
+      ? pubkeyCache.getOrThrow(proposerIndex)
+      : PublicKey.fromBytes(state.getBuilder(envelope.builderIndex).pubkey);
 
   return createSingleSignatureSetFromComponents(
     pubkey,

--- a/packages/state-transition/src/signatureSets/index.ts
+++ b/packages/state-transition/src/signatureSets/index.ts
@@ -30,7 +30,7 @@ export * from "./voluntaryExits.js";
  */
 export function getBlockSignatureSets(
   config: BeaconConfig,
-  currentSyncCommitteeIndexed: SyncCommitteeCache,
+  currentSyncCommitteeIndexed: SyncCommitteeCache | null,
   state: IBeaconStateView,
   signedBlock: SignedBeaconBlock,
   indexedAttestations: IndexedAttestation[],
@@ -56,6 +56,10 @@ export function getBlockSignatureSets(
 
   // Only after altair fork, validate tSyncCommitteeSignature
   if (fork >= ForkSeq.altair) {
+    if (currentSyncCommitteeIndexed === null) {
+      throw new Error("Altair block requires sync committee cache");
+    }
+
     const syncCommitteeSignatureSet = getSyncCommitteeSignatureSet(
       config,
       currentSyncCommitteeIndexed,

--- a/packages/state-transition/src/signatureSets/index.ts
+++ b/packages/state-transition/src/signatureSets/index.ts
@@ -30,7 +30,7 @@ export * from "./voluntaryExits.js";
  */
 export function getBlockSignatureSets(
   config: BeaconConfig,
-  currentSyncCommitteeIndexed: SyncCommitteeCache | null,
+  currentSyncCommitteeIndexed: SyncCommitteeCache,
   state: IBeaconStateView,
   signedBlock: SignedBeaconBlock,
   indexedAttestations: IndexedAttestation[],
@@ -56,10 +56,6 @@ export function getBlockSignatureSets(
 
   // Only after altair fork, validate tSyncCommitteeSignature
   if (fork >= ForkSeq.altair) {
-    if (currentSyncCommitteeIndexed === null) {
-      throw new Error("Altair block requires sync committee cache");
-    }
-
     const syncCommitteeSignatureSet = getSyncCommitteeSignatureSet(
       config,
       currentSyncCommitteeIndexed,

--- a/packages/state-transition/src/signatureSets/voluntaryExits.ts
+++ b/packages/state-transition/src/signatureSets/voluntaryExits.ts
@@ -3,7 +3,7 @@ import {BeaconConfig} from "@lodestar/config";
 import {ForkSeq} from "@lodestar/params";
 import {SignedBeaconBlock, Slot, phase0, ssz} from "@lodestar/types";
 import {PubkeyCache} from "../cache/pubkeyCache.js";
-import {IBeaconStateView} from "../stateView/interface.js";
+import {IBeaconStateView, IBeaconStateViewGloas, isStatePostGloas} from "../stateView/interface.js";
 import {
   ISignatureSet,
   SignatureSetType,
@@ -34,6 +34,9 @@ export function getVoluntaryExitSignatureSet(
   const fork = config.getForkSeq(state.slot);
 
   if (fork >= ForkSeq.gloas && isBuilderVoluntaryExit(signedVoluntaryExit)) {
+    if (!isStatePostGloas(state)) {
+      throw new Error(`Expected gloas+ state for builder voluntary exit signature, got fork=${state.forkName}`);
+    }
     return getBuilderVoluntaryExitSignatureSet(config, state, signedVoluntaryExit);
   }
 
@@ -68,7 +71,7 @@ export function getValidatorVoluntaryExitSignatureSet(
 
 export function getBuilderVoluntaryExitSignatureSet(
   config: BeaconConfig,
-  state: IBeaconStateView,
+  state: IBeaconStateViewGloas,
   signedVoluntaryExit: phase0.SignedVoluntaryExit
 ): ISignatureSet {
   const messageSlot = computeStartSlotAtEpoch(signedVoluntaryExit.message.epoch);

--- a/packages/state-transition/src/stateView/beaconStateView.ts
+++ b/packages/state-transition/src/stateView/beaconStateView.ts
@@ -1,7 +1,7 @@
 import {CompactMultiProof, ProofType, Tree, createProof} from "@chainsafe/persistent-merkle-tree";
 import {BitArray, ByteViews} from "@chainsafe/ssz";
 import {BeaconConfig} from "@lodestar/config";
-import {ForkSeq, SLOTS_PER_HISTORICAL_ROOT, isForkPostGloas} from "@lodestar/params";
+import {ForkName, ForkSeq, SLOTS_PER_HISTORICAL_ROOT, isForkPostGloas} from "@lodestar/params";
 import {
   BeaconBlock,
   BeaconState,
@@ -67,9 +67,9 @@ import {loadState} from "../util/loadState/loadState.js";
 import {getRandaoMix} from "../util/seed.js";
 import {getStateTypeFromBytes} from "../util/sszBytes.js";
 import {getLatestWeakSubjectivityCheckpointEpoch} from "../util/weakSubjectivity.js";
-import {IBeaconStateView} from "./interface.js";
+import {IBeaconStateView, IBeaconStateViewLatestFork} from "./interface.js";
 
-export class BeaconStateView implements IBeaconStateView {
+export class BeaconStateView implements IBeaconStateViewLatestFork {
   private readonly config: BeaconConfig;
   // Cached values extracted from the tree
   // phase0
@@ -101,6 +101,10 @@ export class BeaconStateView implements IBeaconStateView {
   }
 
   // phase0
+
+  get forkName(): ForkName {
+    return this.config.getForkName(this.cachedState.slot);
+  }
 
   get slot(): number {
     return this.cachedState.slot;

--- a/packages/state-transition/src/stateView/interface.ts
+++ b/packages/state-transition/src/stateView/interface.ts
@@ -1,6 +1,23 @@
 import {CompactMultiProof} from "@chainsafe/persistent-merkle-tree";
 import {BitArray, ByteViews} from "@chainsafe/ssz";
 import {
+  ForkName,
+  ForkPostAltair,
+  ForkPostBellatrix,
+  ForkPostCapella,
+  ForkPostDeneb,
+  ForkPostElectra,
+  ForkPostFulu,
+  ForkPostGloas,
+  isForkPostAltair,
+  isForkPostBellatrix,
+  isForkPostCapella,
+  isForkPostDeneb,
+  isForkPostElectra,
+  isForkPostFulu,
+  isForkPostGloas,
+} from "@lodestar/params";
+import {
   BeaconBlock,
   BeaconState,
   BlindedBeaconBlock,
@@ -41,6 +58,7 @@ export interface IBeaconStateView {
   // State access
 
   // phase0
+  forkName: ForkName;
   slot: Slot;
   fork: Fork;
   epoch: Epoch;
@@ -55,50 +73,6 @@ export interface IBeaconStateView {
   getBlockRootAtEpoch(epoch: Epoch): Root;
   getStateRootAtSlot(slot: Slot): Root;
   getRandaoMix(epoch: Epoch): Bytes32;
-
-  // altair
-  previousEpochParticipation: Uint8Array;
-  currentEpochParticipation: Uint8Array;
-  getPreviousEpochParticipation(validatorIndex: ValidatorIndex): number;
-  getCurrentEpochParticipation(validatorIndex: ValidatorIndex): number;
-
-  // bellatrix
-  latestExecutionPayloadHeader: ExecutionPayloadHeader;
-  /**
-   * Cross-fork accessor for the execution block hash of the most recently included payload.
-   * Pre-gloas: returns latestExecutionPayloadHeader.blockHash (bellatrix–fulu).
-   * Gloas+: returns the dedicated latestBlockHash state field (EIP-7732).
-   * Throws before bellatrix.
-   */
-  latestBlockHash: Bytes32;
-  /**
-   * The execution block number of the most recently included payload.
-   * Named payloadBlockNumber (not latestBlockNumber) to mirror ExecutionPayloadHeader.blockNumber pre-gloas.
-   * Only available from bellatrix through fulu — not tracked on BeaconState in gloas+ (EIP-7732).
-   * Throws before bellatrix and from gloas onwards.
-   */
-  payloadBlockNumber: number;
-
-  // capella
-  historicalSummaries: capella.HistoricalSummaries;
-
-  // electra
-  pendingDeposits: electra.PendingDeposits;
-  pendingDepositsCount: number;
-  pendingPartialWithdrawals: electra.PendingPartialWithdrawals;
-  pendingPartialWithdrawalsCount: number;
-  pendingConsolidations: electra.PendingConsolidations;
-  pendingConsolidationsCount: number;
-
-  // fulu
-  proposerLookahead: fulu.ProposerLookahead;
-
-  // gloas
-  executionPayloadAvailability: BitArray;
-  latestExecutionPayloadBid: ExecutionPayloadBid;
-  getBuilder(index: BuilderIndex): gloas.Builder;
-  canBuilderCoverBid(builderIndex: BuilderIndex, bidAmount: number): boolean;
-  getIndexInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number;
 
   // Shuffling and committees
   getShufflingAtEpoch(epoch: Epoch): EpochShuffling;
@@ -117,15 +91,6 @@ export interface IBeaconStateView {
   nextProposers: ValidatorIndex[];
   getBeaconProposer(slot: Slot): ValidatorIndex;
 
-  // Sync committees
-  currentSyncCommittee: altair.SyncCommittee;
-  nextSyncCommittee: altair.SyncCommittee;
-  currentSyncCommitteeIndexed: SyncCommitteeCache;
-  syncProposerReward: number;
-  getIndexedSyncCommitteeAtEpoch(epoch: Epoch): SyncCommitteeCache;
-  /** Get indexed sync committee with slot+1 offset for duty lookups */
-  getIndexedSyncCommittee(slot: Slot): SyncCommitteeCache;
-
   // Validators and balances
   effectiveBalanceIncrements: EffectiveBalanceIncrements;
   getEffectiveBalanceIncrementsZeroInactive(): EffectiveBalanceIncrements;
@@ -140,29 +105,10 @@ export interface IBeaconStateView {
   getAllValidators(): phase0.Validator[];
   getAllBalances(): number[];
 
-  // Merge
-  isExecutionStateType: boolean;
-  isMergeTransitionComplete: boolean;
-  // TODO this should go away (or rather only need block)
-  isExecutionEnabled(block: BeaconBlock | BlindedBeaconBlock): boolean;
-
-  // Block production
-  getExpectedWithdrawals(): {
-    expectedWithdrawals: capella.Withdrawal[];
-    processedBuilderWithdrawalsCount: number;
-    processedPartialWithdrawalsCount: number;
-    processedBuildersSweepCount: number;
-    processedValidatorSweepCount: number;
-  };
-
   // API
   proposerRewards: RewardCache;
   computeBlockRewards(block: BeaconBlock, proposerRewards?: RewardCache): Promise<rewards.BlockRewards>;
   computeAttestationsRewards(validatorIds?: (ValidatorIndex | string)[]): Promise<rewards.AttestationsRewards>;
-  computeSyncCommitteeRewards(
-    block: BeaconBlock,
-    validatorIds: (ValidatorIndex | string)[]
-  ): Promise<rewards.SyncCommitteeRewards>;
   getLatestWeakSubjectivityCheckpointEpoch(): Epoch;
 
   // Validation
@@ -174,7 +120,6 @@ export interface IBeaconStateView {
 
   // Proofs
   getFinalizedRootProof(): Uint8Array[];
-  getSyncCommitteesWitness(): SyncCommitteeWitness;
   getSingleProof(gindex: bigint): Uint8Array[];
   createMultiProof(descriptor: Uint8Array): CompactMultiProof;
 
@@ -215,8 +160,132 @@ export interface IBeaconStateView {
     epochTransitionCacheOpts?: EpochTransitionCacheOpts & {dontTransferCache?: boolean},
     modules?: StateTransitionModules
   ): IBeaconStateView;
+}
+
+/** Altair+ state fields — use isStatePostAltair() guard */
+export interface IBeaconStateViewAltair extends IBeaconStateView {
+  forkName: ForkPostAltair;
+  previousEpochParticipation: Uint8Array;
+  currentEpochParticipation: Uint8Array;
+  getPreviousEpochParticipation(validatorIndex: ValidatorIndex): number;
+  getCurrentEpochParticipation(validatorIndex: ValidatorIndex): number;
+  currentSyncCommittee: altair.SyncCommittee;
+  nextSyncCommittee: altair.SyncCommittee;
+  currentSyncCommitteeIndexed: SyncCommitteeCache;
+  syncProposerReward: number;
+  getIndexedSyncCommitteeAtEpoch(epoch: Epoch): SyncCommitteeCache;
+  /** Get indexed sync committee with slot+1 offset for duty lookups */
+  getIndexedSyncCommittee(slot: Slot): SyncCommitteeCache;
+  computeSyncCommitteeRewards(
+    block: BeaconBlock,
+    validatorIds: (ValidatorIndex | string)[]
+  ): Promise<rewards.SyncCommitteeRewards>;
+  getSyncCommitteesWitness(): SyncCommitteeWitness;
+}
+
+/** Bellatrix+ state fields — use isStatePostBellatrix() guard */
+export interface IBeaconStateViewBellatrix extends IBeaconStateViewAltair {
+  forkName: ForkPostBellatrix;
+  latestExecutionPayloadHeader: ExecutionPayloadHeader;
+  /**
+   * Cross-fork accessor for the execution block hash of the most recently included payload.
+   * Pre-gloas: returns latestExecutionPayloadHeader.blockHash (bellatrix–fulu).
+   * Gloas+: returns the dedicated latestBlockHash state field (EIP-7732).
+   * Throws before bellatrix.
+   */
+  latestBlockHash: Bytes32;
+  /**
+   * The execution block number of the most recently included payload.
+   * Named payloadBlockNumber (not latestBlockNumber) to mirror ExecutionPayloadHeader.blockNumber pre-gloas.
+   * Only available from bellatrix through fulu — not tracked on BeaconState in gloas+ (EIP-7732).
+   * Throws before bellatrix and from gloas onwards.
+   */
+  payloadBlockNumber: number;
+  isExecutionStateType: boolean;
+  isMergeTransitionComplete: boolean;
+  isExecutionEnabled(block: BeaconBlock | BlindedBeaconBlock): boolean;
+}
+
+/** Capella+ state fields — use isStatePostCapella() guard */
+export interface IBeaconStateViewCapella extends IBeaconStateViewBellatrix {
+  forkName: ForkPostCapella;
+  historicalSummaries: capella.HistoricalSummaries;
+  getExpectedWithdrawals(): {
+    expectedWithdrawals: capella.Withdrawal[];
+    processedBuilderWithdrawalsCount: number;
+    processedPartialWithdrawalsCount: number;
+    processedBuildersSweepCount: number;
+    processedValidatorSweepCount: number;
+  };
+}
+
+/** Deneb+ state — no new state-view fields; placeholder for fork completeness and isStatePostDeneb() narrowing */
+export interface IBeaconStateViewDeneb extends IBeaconStateViewCapella {
+  forkName: ForkPostDeneb;
+}
+
+/** Electra+ state fields — use isStatePostElectra() guard */
+export interface IBeaconStateViewElectra extends IBeaconStateViewDeneb {
+  forkName: ForkPostElectra;
+  pendingDeposits: electra.PendingDeposits;
+  pendingDepositsCount: number;
+  pendingPartialWithdrawals: electra.PendingPartialWithdrawals;
+  pendingPartialWithdrawalsCount: number;
+  pendingConsolidations: electra.PendingConsolidations;
+  pendingConsolidationsCount: number;
+}
+
+/** Fulu+ state fields — use isStatePostFulu() guard */
+export interface IBeaconStateViewFulu extends IBeaconStateViewElectra {
+  forkName: ForkPostFulu;
+  proposerLookahead: fulu.ProposerLookahead;
+}
+
+/** Gloas+ state fields — use isStatePostGloas() guard */
+export interface IBeaconStateViewGloas extends IBeaconStateViewFulu {
+  forkName: ForkPostGloas;
+  executionPayloadAvailability: BitArray;
+  latestExecutionPayloadBid: ExecutionPayloadBid;
+  getBuilder(index: BuilderIndex): gloas.Builder;
+  canBuilderCoverBid(builderIndex: BuilderIndex, bidAmount: number): boolean;
+  getIndexInPayloadTimelinessCommittee(validatorIndex: ValidatorIndex, slot: Slot): number;
   processExecutionPayloadEnvelope(
     signedEnvelope: gloas.SignedExecutionPayloadEnvelope,
     opts?: ProcessExecutionPayloadEnvelopeOpts
   ): IBeaconStateView;
+}
+
+/**
+ * Type constraint for the concrete BeaconStateView class.
+ * Requires all fields from the latest fork interface (IBeaconStateViewGloas) but keeps
+ * forkName as ForkName since the class wraps any fork's state.
+ * Sub-interfaces retain their narrowed forkName discriminants for caller-side type guards.
+ */
+export type IBeaconStateViewLatestFork = Omit<IBeaconStateViewGloas, "forkName"> & {forkName: ForkName};
+export function isStatePostAltair(state: IBeaconStateView): state is IBeaconStateViewAltair {
+  return isForkPostAltair(state.forkName);
+}
+
+export function isStatePostBellatrix(state: IBeaconStateView): state is IBeaconStateViewBellatrix {
+  return isForkPostBellatrix(state.forkName);
+}
+
+export function isStatePostCapella(state: IBeaconStateView): state is IBeaconStateViewCapella {
+  return isForkPostCapella(state.forkName);
+}
+
+export function isStatePostDeneb(state: IBeaconStateView): state is IBeaconStateViewDeneb {
+  return isForkPostDeneb(state.forkName);
+}
+
+export function isStatePostElectra(state: IBeaconStateView): state is IBeaconStateViewElectra {
+  return isForkPostElectra(state.forkName);
+}
+
+export function isStatePostFulu(state: IBeaconStateView): state is IBeaconStateViewFulu {
+  return isForkPostFulu(state.forkName);
+}
+
+export function isStatePostGloas(state: IBeaconStateView): state is IBeaconStateViewGloas {
+  return isForkPostGloas(state.forkName);
 }


### PR DESCRIPTION
Split `IBeaconStateView` into fork-specific capability interfaces (`IBeaconStateViewAltair` through `IBeaconStateViewGloas`) with type guard functions (`isStatePostAltair` through `isStatePostGloas`) for compile-time safety when accessing fork-specific fields.

**Key design:**
- Each fork interface adds only the fields introduced at that fork
- `forkName` discriminant narrows through the hierarchy (`ForkPostAltair`, `ForkPostGloas`, etc.)
- Type guards narrow the interface type AND forkName at call sites
- `IBeaconStateViewLatestFork = Omit<IBeaconStateViewGloas, 'forkName'> & {forkName: ForkName}` — compile-time enforcement that `BeaconStateView` implements all latest fork fields while keeping `forkName` as `ForkName` (any fork)

**What changed:**
- `packages/state-transition/src/stateView/interface.ts`: Split flat interface into linear fork chain + type guards + `IBeaconStateViewLatestFork`
- `packages/state-transition/src/stateView/beaconStateView.ts`: `implements IBeaconStateViewLatestFork`
- 30 downstream callers updated to use `isStatePostX()` guards before fork-specific field access

Rebased from #9085 (which targeted the now-merged `te/consume_beacon_state_view` branch).

🤖 Generated with AI assistance