### PR TITLE
test: wire sync committee gossip validation spec tests

### DIFF
--- a/packages/beacon-node/test/spec/utils/gossipValidation.ts
+++ b/packages/beacon-node/test/spec/utils/gossipValidation.ts
@@ -131,11 +131,11 @@ class GossipTestClock extends EventEmitter implements IClock {
 interface MetaYaml {
   topic: GossipType;
   blocks?: {block: string; failed?: boolean}[];
-  finalized_checkpoint?: {epoch: number; root?: string; block?: string};
-  current_time_ms?: number;
+  finalized_checkpoint?: {epoch: bigint; root?: string; block?: string};
+  current_time_ms?: bigint;
   messages: {
-    offset_ms?: number;
-    subnet_id?: number;
+    offset_ms?: bigint;
+    subnet_id?: bigint;
     message: string;
     expected: "valid" | "ignore" | "reject";
     reason?: string;

--- a/packages/beacon-node/test/spec/utils/gossipValidation.ts
+++ b/packages/beacon-node/test/spec/utils/gossipValidation.ts
@@ -542,13 +542,6 @@ async function validateMessageForTopic(
         ssz.altair.SyncCommitteeMessage.deserialize(bytes)
       );
       await validateGossipSyncCommittee(chain, syncCommitteeMessage, Number(message.subnet_id ?? 0));
-      // Mirror gossip handler: mark as seen so duplicate detection works
-      chain.seenSyncCommitteeMessages.add(
-        syncCommitteeMessage.slot,
-        Number(message.subnet_id ?? 0),
-        syncCommitteeMessage.validatorIndex,
-        toRootHex(syncCommitteeMessage.beaconBlockRoot)
-      );
       break;
     }
 
@@ -557,10 +550,6 @@ async function validateMessageForTopic(
         ssz.altair.SignedContributionAndProof.deserialize(bytes)
       );
       await validateSyncCommitteeGossipContributionAndProof(chain, signedContributionAndProof);
-      // Mirror gossip handler: mark as seen so duplicate detection works
-      const contribution = signedContributionAndProof.message.contribution;
-      const trueBitCount = Array.from(contribution.aggregationBits).filter(Boolean).length;
-      chain.seenContributionAndProof.add(signedContributionAndProof.message, trueBitCount);
       break;
     }
 

--- a/packages/beacon-node/test/spec/utils/gossipValidation.ts
+++ b/packages/beacon-node/test/spec/utils/gossipValidation.ts
@@ -18,7 +18,7 @@ import {
   isExecutionStateType,
   syncPubkeys,
 } from "@lodestar/state-transition";
-import {RootHex, sszTypesFor} from "@lodestar/types";
+import {RootHex, ssz, sszTypesFor} from "@lodestar/types";
 import {fromHex, loadYaml, toHex, toRootHex} from "@lodestar/utils";
 import {BlockInputPreData, BlockInputSource} from "../../../src/chain/blocks/blockInput/index.js";
 import {AttestationImportOpt, BlobSidecarValidation} from "../../../src/chain/blocks/types.js";
@@ -30,6 +30,8 @@ import {GossipAttestation, validateGossipAttestationsSameAttData} from "../../..
 import {validateGossipAttesterSlashing} from "../../../src/chain/validation/attesterSlashing.js";
 import {validateGossipBlock} from "../../../src/chain/validation/block.js";
 import {validateGossipProposerSlashing} from "../../../src/chain/validation/proposerSlashing.js";
+import {validateGossipSyncCommittee} from "../../../src/chain/validation/syncCommittee.js";
+import {validateSyncCommitteeGossipContributionAndProof} from "../../../src/chain/validation/syncCommitteeContributionAndProof.js";
 import {validateGossipVoluntaryExit} from "../../../src/chain/validation/voluntaryExit.js";
 import {ZERO_HASH_HEX} from "../../../src/constants/constants.js";
 import {ExecutionEngineMockBackend} from "../../../src/execution/engine/mock.js";
@@ -147,6 +149,8 @@ const gossipTopicByHandler = {
   gossip_proposer_slashing: GossipType.proposer_slashing,
   gossip_attester_slashing: GossipType.attester_slashing,
   gossip_voluntary_exit: GossipType.voluntary_exit,
+  gossip_sync_committee_message: GossipType.sync_committee,
+  gossip_sync_committee_contribution_and_proof: GossipType.sync_committee_contribution_and_proof,
 } as const satisfies Record<string, GossipType>;
 
 export function isGossipValidationHandler(topicHandler: string): topicHandler is keyof typeof gossipTopicByHandler {
@@ -530,6 +534,33 @@ async function validateMessageForTopic(
       await validateGossipVoluntaryExit(chain, exit);
       // Mirror gossip handler: insert into opPool so duplicate detection works
       chain.opPool.insertVoluntaryExit(exit);
+      break;
+    }
+
+    case GossipType.sync_committee: {
+      const syncCommitteeMessage = rejectOnInvalidSerializedBytes(() =>
+        ssz.altair.SyncCommitteeMessage.deserialize(bytes)
+      );
+      await validateGossipSyncCommittee(chain, syncCommitteeMessage, Number(message.subnet_id ?? 0));
+      // Mirror gossip handler: mark as seen so duplicate detection works
+      chain.seenSyncCommitteeMessages.add(
+        syncCommitteeMessage.slot,
+        Number(message.subnet_id ?? 0),
+        syncCommitteeMessage.validatorIndex,
+        toRootHex(syncCommitteeMessage.beaconBlockRoot)
+      );
+      break;
+    }
+
+    case GossipType.sync_committee_contribution_and_proof: {
+      const signedContributionAndProof = rejectOnInvalidSerializedBytes(() =>
+        ssz.altair.SignedContributionAndProof.deserialize(bytes)
+      );
+      await validateSyncCommitteeGossipContributionAndProof(chain, signedContributionAndProof);
+      // Mirror gossip handler: mark as seen so duplicate detection works
+      const contribution = signedContributionAndProof.message.contribution;
+      const trueBitCount = Array.from(contribution.aggregationBits).filter(Boolean).length;
+      chain.seenContributionAndProof.add(signedContributionAndProof.message, trueBitCount);
       break;
     }
 


### PR DESCRIPTION
Add support for `gossip_sync_committee_message` and `gossip_sync_committee_contribution_and_proof` handlers in the networking spec test harness.

Ref: ethereum/consensus-specs#5033
